### PR TITLE
update ng/css/gogs.css for the new repo icon

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -866,7 +866,7 @@ ol.linenums {
   border-top-right-radius: .3em;
 }
 #dashboard-new-repo .octicon {
-  font-size: 2em;
+  font-size: 1.5rem;
 }
 #dashboard-new-repo-menu {
   top: 33px;


### PR DESCRIPTION
bringing over PR 1287 from [gogits/gogs](https://github.com/gogits/gogs/pull/1287)

For visual comparison:

Before
![Before adjustment](http://i.imgur.com/3PoQtzm.png)

After
![After adjustment](http://i.imgur.com/kX63BNi.png)