### PR TITLE
Add commands to generate apache/nginx config files

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,145 @@
+// Copyright 2015 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"os"
+	"bufio"
+	"log"
+	"strings"
+	"text/template"
+	"github.com/codegangsta/cli"
+
+	"github.com/gogits/gogs/modules/setting"
+)
+
+var CmdGenerate = cli.Command{
+	Name:  "generate",
+	Usage: "Generate web server configuration files",
+	Description: `Generate configuration files to use a web server as a proxy for Gogs.`,
+	Flags: []cli.Flag{
+		cli.StringFlag{"config, c", "custom/conf/app.ini", "Custom configuration file path", ""},
+	},
+	Subcommands: []cli.Command{
+		{
+			Name: "apache",
+			Usage: "generate Apache configuration file",
+			Action: runApache,
+			Flags: []cli.Flag{
+				cli.StringFlag{"subpath", "", "Use a sub-path", ""},
+			},
+		},
+		{
+			Name: "nginx",
+			Usage: "generate nginx configuration file",
+			Action: runNginx,
+			Flags: []cli.Flag{
+				cli.StringFlag{"subpath", "", "Use a sub-path", ""},
+			},
+		},
+	},
+}
+
+type ServerType int
+
+const (
+	APACHE ServerType = iota
+	NGINX
+)
+
+const ApacheConfTemplate =
+`<VirtualHost *:80>
+    ServerName {{.Domain}}
+
+    <Proxy *>
+        Order allow,deny
+        Allow from all
+    </Proxy>
+
+    ProxyPreserveHost On
+    ProxyRequests off
+    <Location {{.Subpath}}>
+        ProxyPass        http://{{.Addr}}:{{.Port}}/
+        ProxyPassReverse http://{{.Addr}}:{{.Port}}/
+    </Location>
+</VirtualHost>`
+
+const NginxConfTemplate =
+`server {
+    listen 80;
+    server_name {{.Domain}};
+
+    location {{.Subpath}} {
+        proxy_pass http://{{.Addr}}:{{.Port}};
+    }
+}`
+
+var ServerTemplates = map[ServerType]string{
+	APACHE: ApacheConfTemplate,
+	NGINX: NginxConfTemplate,
+}
+
+const outFile = "gitea.conf"
+
+func runApache(ctx *cli.Context) {
+	genConfigFile(ctx, APACHE)
+}
+
+func runNginx(ctx *cli.Context) {
+	genConfigFile(ctx, NGINX)
+}
+
+func genConfigFile(ctx *cli.Context, st ServerType) {
+	if ctx.IsSet("config") {
+		setting.CustomConf = ctx.String("config")
+	}
+	setting.NewConfigContext()
+
+	tmpl, err := template.New("conf").Parse(ServerTemplates[st])
+	if err != nil {
+		log.Fatalf("Failed to create configuration template: %s", err)
+	}
+
+	confOut, err := os.Create(outFile)
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %s", outFile, err)
+	}
+
+	w := bufio.NewWriter(confOut)
+
+	type Params struct {
+		Domain string
+		Addr string
+		Port string
+		Subpath string
+	}
+
+	params := Params{
+		Domain: setting.Domain,
+		Addr: "127.0.0.1",
+		Port: setting.HttpPort,
+		Subpath: "/",
+	}
+
+	if setting.HttpAddr != "0.0.0.0" {
+		params.Addr = setting.HttpAddr
+	}
+
+	if ctx.IsSet("subpath") {
+		params.Subpath = ctx.String("subpath")
+		if (!strings.HasPrefix(params.Subpath, "/")) {
+			params.Subpath = "/" + params.Subpath
+		}
+	}
+
+	err = tmpl.Execute(w, params)
+	if err != nil {
+		log.Fatalf("Failed to write configuration to %s: %s", outFile, err)
+	}
+
+	w.Flush()
+	confOut.Close()
+	log.Printf("Written %s", outFile)
+}

--- a/gogs.go
+++ b/gogs.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/codegangsta/cli"
 
-	"github.com/gogits/gogs/cmd"
+	"github.com/go-gitea/gitea/cmd"
 	"github.com/gogits/gogs/modules/setting"
 )
 
@@ -35,6 +35,7 @@ func main() {
 		cmd.CmdUpdate,
 		cmd.CmdDump,
 		cmd.CmdCert,
+		cmd.CmdGenerate,
 	}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)


### PR DESCRIPTION
These commits add two commands that let you generate working config files for apache and nginx extracting information from the gogs/gitea configuration file.

These are the same patches that were sent to gogs. The corresponding gogs PR had some discussion, so I'll summarize here quickly why I think they are useful

* We will be able to have a very quick and clean "getting started" documentation that will only say to use the command to generate a working config file instead of having a lot of outdated wiki pages with different solutions
* The commands extract the port, domain etc from the ini file, so they are a useful tool to change things in just one place and script the rest
* In the future it would be really nice IMHO to show these configurations in the admin page, ready to cut&paste


Users are NOT forced to use these commands and the doc should state that these commands should be used to create a minimal config file for those of us (like me) who do not know apache/nginx by heart and just want to get things up and running quickly. Experts sysadmins are still free to tweak or create the config files as they prefer.


