### PR TITLE
fix debian init script

### DIFF
--- a/scripts/init/debian/gogs
+++ b/scripts/init/debian/gogs
@@ -49,10 +49,12 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
-			--exec $DAEMON -- $DAEMON_ARGS --test > /dev/null \\
+			--test --chdir $WORKINGDIR --chuid $USER \\
+			--exec $DAEMON -- $DAEMON_ARGS > /dev/null \\
 			|| return 1"
 	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
-			--background --exec /bin/su -- - $USER -c \"cd \\\"$WORKINGDIR\\\" && $DAEMON -- $DAEMON_ARGS\" \\
+			--background --chdir $WORKINGDIR --chuid $USER \\
+			--exec $DAEMON -- $DAEMON_ARGS \\
 			|| return 2"
 }
 


### PR DESCRIPTION
My git user has it's shell set to /bin/false, which makes su -c impossible, also a flag was misplaced and this fixes that the test run is executed as root. (#1025)

Disclaimer: I'm not an experienced Debian nor System-V init user, maybe someone could review this commit before it gets merged.

(This is the same as [this gogs PR][1])

[1]: https://github.com/gogits/gogs/pull/1274