### PR TITLE
Add CommonName to the self signed certificate

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -114,6 +114,7 @@ func runCert(ctx *cli.Context) {
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			Organization: []string{"Acme Co"},
+			CommonName: "Gitea",
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,


### PR DESCRIPTION
Without a CN the self signed certificate is considered
invalid by chrome.
You can check with: openssl x509 -in cert.pem -subject -noout


See https://github.com/gogits/gogs/issues/1231 for the corresponding bug reported on gogs issue tracker