### PR TITLE
Fallback to $USER and $USERNAME if user.Current fails

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -24,6 +23,7 @@ import (
 	"github.com/go-gitea/gitea/modules/bindata"
 	"github.com/go-gitea/gitea/modules/log"
 	// "github.com/go-gitea/gitea/modules/ssh"
+	"github.com/go-gitea/gitea/modules/user"
 )
 
 type Scheme string
@@ -285,14 +285,13 @@ func NewConfigContext() {
 	}[Cfg.Section("time").Key("FORMAT").MustString("RFC1123")]
 
 	RunUser = Cfg.Section("").Key("RUN_USER").String()
-	curUser, err := user.Current()
+	curUser := user.CurrentUsername()
 	// Does not check run user when the install lock is off.
-	if InstallLock && (err != nil || RunUser != curUser.Username) {
-		curUsername := "unknown"
-		if curUser != nil {
-			curUsername = curUser.Username
+	if InstallLock && RunUser != curUser {
+		if len(curUser) == 0 {
+			curUser = "unknown"
 		}
-		log.Fatal(4, "Expect user(%s) but current user is: %s", RunUser, curUsername)
+		log.Fatal(4, "Expect user(%s) but current user is: %s.", RunUser, curUser)
 	}
 
 	// Determine and create root git repository path.

--- a/modules/user/user.go
+++ b/modules/user/user.go
@@ -1,0 +1,24 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+	"os"
+	"os/user"
+)
+
+func CurrentUsername() string {
+	curUser, err := user.Current()
+	if err == nil {
+		return curUser.Username
+	}
+
+	curUserName := os.Getenv("USER")
+	if len(curUserName) > 0 {
+		return curUserName
+	}
+
+	return os.Getenv("USERNAME")
+}

--- a/routers/install.go
+++ b/routers/install.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"github.com/go-gitea/gitea/modules/middleware"
 	"github.com/go-gitea/gitea/modules/setting"
 	"github.com/go-gitea/gitea/modules/social"
+	"github.com/go-gitea/gitea/modules/user"
 )
 
 const (
@@ -102,10 +102,7 @@ func Install(ctx *middleware.Context) {
 	// Note(unknwon): it's hard for Windows users change a running user,
 	// 	so just use current one if config says default.
 	if setting.IsWindows && setting.RunUser == "git" {
-		curUser, err := user.Current()
-		if err == nil {
-			form.RunUser = curUser.Username
-		}
+		form.RunUser = user.CurrentUsername()
 	} else {
 		form.RunUser = setting.RunUser
 	}
@@ -167,14 +164,10 @@ func InstallPost(ctx *middleware.Context, form auth.InstallForm) {
 	}
 
 	// Check run user.
-	curUser, err := user.Current()
-	if err != nil || form.RunUser != curUser.Username {
-		curUsername := "unknown"
-		if curUser != nil {
-			curUsername = curUser.Username
-		}
+	curUser := user.CurrentUsername()
+	if form.RunUser != curUser {
 		ctx.Data["Err_RunUser"] = true
-		ctx.RenderWithErr(ctx.Tr("install.run_user_not_match", form.RunUser, curUsername), INSTALL, &form)
+		ctx.RenderWithErr(ctx.Tr("install.run_user_not_match", form.RunUser, curUser), INSTALL, &form)
 		return
 	}
 


### PR DESCRIPTION
Commit 261810070fc668ed250620a5c6be05b21d69c56c started to use
user.Current instead of the env vars. However on some system this
fails ("user: Current not implemented on linux/amd64").
Factor out a small module that first tries user.Current and then
falls back to the old env vars.