### PR TITLE
Fix build with pam

### DIFF
--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -1,3 +1,5 @@
+// +build !pam
+
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Commit 9b0f4c0491c19a80ea8c37884aa848e28ec85110 added a "pam" build
tag but did not update the pam stub module with the corresponding !pam