### PR TITLE
add ability to run webhooks more often

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -87,8 +87,8 @@ ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
 DISABLE_MINIMUM_KEY_SIZE_CHECK = false
 
 [webhook]
-; Cron task interval in minutes
-TASK_INTERVAL = 1
+; Cron task interval
+TASK_INTERVAL = 1m
 ; Deliver timeout in seconds
 DELIVER_TIMEOUT = 5
 ; Allow insecure certification
@@ -106,12 +106,12 @@ SUBJECT = %(APP_NAME)s
 ; Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used.
 HOST =
 ; Do not verify the certificate of the server. Only use this for self-signed certificates
-SKIP_VERIFY = 
+SKIP_VERIFY =
 ; Use client certificate
 USE_CERTIFICATE = false
 CERT_FILE = custom/mailer/cert.pem
 KEY_FILE = custom/mailer/key.pem
-; Mail from address, RFC 5322. This can be just an email address, or the "Name" <email@example.com> format 
+; Mail from address, RFC 5322. This can be just an email address, or the "Name" <email@example.com> format
 FROM =
 ; Mailer user name and password
 USER =
@@ -276,7 +276,7 @@ CONN =
 MAX_GIT_DIFF_LINES = 10000
 ; Arguments for command 'git gc', e.g.: "--aggressive --auto"
 ; see more on http://git-scm.com/docs/git-gc/1.7.5
-GC_ARGS = 
+GC_ARGS =
 
 ; Git health check.
 [git.fsck]
@@ -285,7 +285,7 @@ ENABLE = true
 INTERVAL = 24
 ; Arguments for command 'git fsck', e.g.: "--unreachable --tags"
 ; see more on http://git-scm.com/docs/git-fsck/1.7.5
-ARGS = 
+ARGS =
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL

--- a/modules/cron/manager.go
+++ b/modules/cron/manager.go
@@ -15,7 +15,7 @@ var c = New()
 
 func NewCronContext() {
 	c.AddFunc("Update mirrors", "@every 1h", models.MirrorUpdate)
-	c.AddFunc("Deliver hooks", fmt.Sprintf("@every %dm", setting.Webhook.TaskInterval), models.DeliverHooks)
+	c.AddFunc("Deliver hooks", fmt.Sprintf("@every %ds", setting.Webhook.TaskInterval), models.DeliverHooks)
 	if setting.Git.Fsck.Enable {
 		c.AddFunc("Repository health check", fmt.Sprintf("@every %dh", setting.Git.Fsck.Interval), models.GitFsck)
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -546,7 +546,11 @@ func newNotifyMailService() {
 
 func newWebhookService() {
 	sec := Cfg.Section("webhook")
-	Webhook.TaskInterval = sec.Key("TASK_INTERVAL").MustInt(1)
+	td, err := time.ParseDuration(sec.Key("TASK_INTERVAL").String())
+	if err != nil {
+		td, _ = time.ParseDuration("60s")
+	}
+	Webhook.TaskInterval = int(td.Seconds())
 	Webhook.DeliverTimeout = sec.Key("DELIVER_TIMEOUT").MustInt(5)
 	Webhook.SkipTLSVerify = sec.Key("SKIP_TLS_VERIFY").MustBool()
 }


### PR DESCRIPTION
run webhook once a minute is very slowly in some cases, use generic time.Duration parsing to able to use go format for interval.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>