### PR TITLE
make commit messages link to the commit diff

### DIFF
--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -32,7 +32,7 @@
                     {{end}}
                 </td>
                 <td class="sha"><a rel="nofollow" class="label label-green" href="{{AppSubUrl}}/{{$username}}/{{$reponame}}/commit/{{.Id}} ">{{SubStr .Id.String 0 10}} </a></td>
-                <td class="message"><span class="text-truncate">{{RenderCommitMessage .Summary $.RepoLink}}</span></td>
+                <td class="message"><span class="text-truncate"><a rel="nofollow" href="{{AppSubUrl}}/{{$username}}/{{$reponame}}/commit/{{.Id}} ">{{.Summary}}</a></span></td>
                 <td class="date">{{TimeSince .Author.When $.Lang}}</td>
             </tr>
             {{end}}


### PR DESCRIPTION
Fix #19 
This is what it looks like: 
![screen shot 2015-06-07 at 09 44 40](https://cloud.githubusercontent.com/assets/6280095/8037366/a218fc06-0dfd-11e5-8e87-ef673822c950.png)
