### PR TITLE
Set input and button elements default font size to css

### DIFF
--- a/public/ng/css/ui.css
+++ b/public/ng/css/ui.css
@@ -16,6 +16,7 @@ textarea,
 select,
 option,
 button {
+  font-size: 13px;
   font-family: Helvetica, "Microsoft Yahei", Arial, sans-serif;
 }
 article,

--- a/public/ng/less/ui/reset.less
+++ b/public/ng/less/ui/reset.less
@@ -23,6 +23,7 @@ textarea,
 select,
 option,
 button {
+  font-size: @baseFontSize+1;
   font-family: Helvetica, "Microsoft Yahei", Arial, sans-serif;
 }
 


### PR DESCRIPTION
Set input and button elements default font size to css.
Just html element is not enough for input and button.