### PR TITLE
Change all DB default false to 0 because some DB backends do not support "false"

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -73,7 +73,7 @@ type Action struct {
 	RepoUserName string
 	RepoName     string
 	RefName      string
-	IsPrivate    bool      `xorm:"NOT NULL DEFAULT false"`
+	IsPrivate    bool      `xorm:"NOT NULL DEFAULT 0"`
 	Content      string    `xorm:"TEXT"`
 	Created      time.Time `xorm:"created"`
 }

--- a/models/login.go
+++ b/models/login.go
@@ -94,9 +94,9 @@ type LoginSource struct {
 	Id                int64
 	Type              LoginType
 	Name              string          `xorm:"UNIQUE"`
-	IsActived         bool            `xorm:"NOT NULL DEFAULT false"`
+	IsActived         bool            `xorm:"NOT NULL DEFAULT 0"`
 	Cfg               core.Conversion `xorm:"TEXT"`
-	AllowAutoRegister bool            `xorm:"NOT NULL DEFAULT false"`
+	AllowAutoRegister bool            `xorm:"NOT NULL DEFAULT 0"`
 	Created           time.Time       `xorm:"CREATED"`
 	Updated           time.Time       `xorm:"UPDATED"`
 }

--- a/models/release.go
+++ b/models/release.go
@@ -32,7 +32,7 @@ type Release struct {
 	NumCommits       int
 	NumCommitsBehind int    `xorm:"-"`
 	Note             string `xorm:"TEXT"`
-	IsDraft          bool   `xorm:"NOT NULL DEFAULT false"`
+	IsDraft          bool   `xorm:"NOT NULL DEFAULT 0"`
 	IsPrerelease     bool
 	Created          time.Time `xorm:"CREATED"`
 }

--- a/models/repo.go
+++ b/models/repo.go
@@ -158,11 +158,11 @@ type Repository struct {
 	IsMirror bool
 	*Mirror  `xorm:"-"`
 
-	IsFork   bool `xorm:"NOT NULL DEFAULT false"`
+	IsFork   bool `xorm:"NOT NULL DEFAULT 0"`
 	ForkId   int64
 	ForkRepo *Repository `xorm:"-"`
 
-	IsWiki       bool        `xorm:"NOT NULL DEFAULT false"`
+	IsWiki       bool        `xorm:"NOT NULL DEFAULT 0"`
 	WikiRepoId   int64       `xorm:"NOT NULL DEFAULT 0"`
 	WikiRepo     *Repository `xorm:"-"`
 


### PR DESCRIPTION
Some DB backends do not support "false", such as sqlite, mssql.
So use 0 instead, which should work with mysql, pgsql, sqlite, mssql.

Otherwise, when the user upgrades to a newer version of gogs, the DB will be filled with "false" in new columns as default, which is not supported in sqlite and cause problems after DB upgrade.
