### PR TITLE
Gogs merge: "Port is blocked" issue

### DIFF
--- a/packager/debian/postinst
+++ b/packager/debian/postinst
@@ -18,8 +18,6 @@ case "$1" in
     chown ${APP_USER}.${APP_GROUP} $(dirname ${APP_CONFIG})
     [ -f ${APP_CONFIG} ] || ${CLI} run cp conf/app.ini ${APP_CONFIG}
     ${CLI} config:set USER=${APP_USER}
-    PORT=$(${CLI} config:get PORT || echo "6000")
-    sed -i "s|HTTP_PORT = 3000|HTTP_PORT = ${PORT}|" ${APP_CONFIG}
     sed -i "s|RUN_USER = git|RUN_USER = ${APP_USER}|" ${APP_CONFIG}
     sed -i "s|RUN_MODE = dev|RUN_MODE = prod|" ${APP_CONFIG}
 


### PR DESCRIPTION
**Merge from https://github.com/gogits/gogs/pull/1277**

Fixed an issue where the post intall file for Debian enforced port 6000
which should have been port 3000 because it renders the software virtually unusable
because it's a blocked port in Firefox, Chrome and alikes.

For further reference see:
http://www-archive.mozilla.org/projects/netlib/PortBanning.html

(cherry picked from commit 27fe9cfcba095ea42fb97764b869616d2079cdc1)