### PR TITLE
Gogs merge: Add app sub url for color picker js lib inclusion

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -96,7 +96,7 @@
         </div>
     </div>
 </div>
-<script src="/js/bootstrap-colorpicker.min.js"></script>
+<script src="{{AppSubUrl}}/js/bootstrap-colorpicker.min.js"></script>
 <script>
     $(function(){
         $('.label-color-picker').colorpicker({


### PR DESCRIPTION
**Merge from https://github.com/gogits/gogs/pull/1256**

Currently, the js file doesn't take into account the possibility of a sub url being used (wich is my case :) wich prevents its inclusion.
(cherry picked from commit 5c63e1015d54098e56652f07d4ce2861e52e75f9)