### PR TITLE
Gogs merge: Don't set mime type to text/plain

### DIFF
--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -28,7 +28,6 @@ func ServeBlob(ctx *middleware.Context, blob *git.Blob) error {
 
 	_, isTextFile := base.IsTextFile(buf)
 	_, isImageFile := base.IsImageFile(buf)
-	ctx.Resp.Header().Set("Content-Type", "text/plain")
 	if !isTextFile && !isImageFile {
 		ctx.Resp.Header().Set("Content-Disposition", "attachment; filename="+path.Base(ctx.Repo.TreeName))
 		ctx.Resp.Header().Set("Content-Transfer-Encoding", "binary")


### PR DESCRIPTION
**Merge from https://github.com/gogits/gogs/pull/1249**

This will break serving e.g. raw images,

html, etc

According to http://golang.org/pkg/net/http/#DetectContentType
"If the Header does not contain a Content-Type line, Write adds
a Content-Type set to the result of passing the initial 512 bytes
of written data to DetectContentType."

(cherry picked from commit 423b1c69be7828c331a47467b66217d190e916b9)