### PR TITLE
Gogs merge: Prevent browsers from leaking referrer headers

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -6,6 +6,7 @@
 	<meta name="author" content="Gitea - Git service with a cup of tea" />
 	<meta name="description" content="Gitea (Git service with a cup of tea) a painless self-hosted Git Service written in Go" />
 	<meta name="keywords" content="go, git, self-hosted, gitea">
+	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />
 	{{if .GoGetImport}}
 	<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">

--- a/templates/base/head_old.tmpl
+++ b/templates/base/head_old.tmpl
@@ -8,6 +8,7 @@
         <meta name="author" content="Gitea - Git service with a cup of tea" />
 		<meta name="description" content="Gitea (Git service with a cup of tea) is a GitHub-like clone in the Go Programming Language" />
 		<meta name="keywords" content="go, git">
+		<meta name="referrer" content="no-referrer" />
 		<meta name="_csrf" content="{{.CsrfToken}}" />
 		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -6,6 +6,7 @@
         <meta name="author" content="Gitea - Git service with a cup of tea" />
         <meta name="description" content="Gitea (Git service with a cup of tea) a painless self-hosted Git Service written in Go" />
         <meta name="keywords" content="go, git, self-hosted, gitea">
+        <meta name="referrer" content="no-referrer" />
         <meta name="_csrf" content="{{.CsrfToken}}" />
         {{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 


### PR DESCRIPTION
**Merge from https://github.com/gogits/gogs/pull/1380**

(cherry picked from commit a6596f223175547952816351905c34ccf3e0b84f)