### PR TITLE
Gogs merge: fix .keys route

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -153,6 +153,7 @@ func ShowSSHKeys(ctx *middleware.Context, uid int64) {
 	var buf bytes.Buffer
 	for i := range keys {
 		buf.WriteString(keys[i].OmitEmail())
+		buf.WriteString("\n")
 	}
 	ctx.RenderData(200, buf.Bytes())
 }


### PR DESCRIPTION
**Merge from https://github.com/gogits/gogs/pull/1317**

This change fixes the output from /{{ username }}.keys so that it can work in
a ~/.ssh/authorized_keys file

(cherry picked from commit 73698d292a2c60cbe947efc2f62c05d8ffd88277)