### PR TITLE
Gogs merge: settings/password: no minimal required characters for OldPassword

### DIFF
--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -108,7 +108,7 @@ func (f *AddEmailForm) Validate(ctx *macaron.Context, errs binding.Errors) bindi
 }
 
 type ChangePasswordForm struct {
-	OldPassword string `form:"old_password" binding:"Required;MinSize(6);MaxSize(255)"`
+	OldPassword string `form:"old_password" binding:"Required;MinSize(1);MaxSize(255)"`
 	Password    string `form:"password" binding:"Required;MinSize(6);MaxSize(255)"`
 	Retype      string `form:"retype"`
 }


### PR DESCRIPTION
If users are added to gogs due a reverse proxy automatically, their password is
set to their initial username. If their username is shorter than 6 characters,
they can never set a password. But since this password is required for some
operations (e.g. repository deletion), they could not use all features of gogs
until now.

(cherry picked from commit b36134194cf8304ba553c2623447ea60586cd5e2)