### PR TITLE
User Dashboard Fix

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -117,7 +117,7 @@
                                     <strong class="repo">{{.Name}}</strong>
                                 </span>
                                 <span class="right repo-star">
-                                    <i class="octicon octicon-sync"></i>{{.Interval}}H
+                                    <i class="octicon octicon-sync"></i>{{.Mirror.Interval}}H
                                 </span>
                             </a>
                         </li>


### PR DESCRIPTION
The user dashboard is broken. It shows the following error:
```
template: user/dashboard/dashboard:120:74: executing "user/dashboard/dashboard" at <.Interval>: Interval is not a field of struct type *models.Repository
```
This PR solves it. If you check the PR just changes `.Interval` to `.Mirror.Interval` in the template.

What surprises me is that in gogs, and probably in previous gitea versions, just `.Interval` works fine. So I don't know if there is a different way to solve this issue. Though it makes sense to use `.Mirror.Interval`