### PR TITLE
When creating repo with at least one default file, make sure default branch is set to master

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -589,15 +589,18 @@ func initRepository(e Engine, repoPath string, u *User, repo *Repository, initRe
 		delete(fileName, "license")
 	}
 
+	// Re-fetch the repository from database before updating it (else it would
+	// override changes that were done earlier with sql)
+	if repo, err = getRepositoryById(e, repo.ID); err != nil {
+		return err
+	}
 	if len(fileName) == 0 {
-		// Re-fetch the repository from database before updating it (else it would
-		// override changes that were done earlier with sql)
-		if repo, err = getRepositoryById(e, repo.ID); err != nil {
-			return err
-		}
 		repo.IsBare = true
-		repo.DefaultBranch = "master"
-		return updateRepository(e, repo, false)
+	}
+	repo.DefaultBranch = "master"
+	err = updateRepository(e, repo, false)
+	if err != nil || len(fileName) == 0 {
+		return err
 	}
 
 	// Apply changes and commit.


### PR DESCRIPTION
When creating repo with at least one default file, make sure default branch is set to master