### PR TITLE
Remove hard line break Markdown flag as default

### DIFF
--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -198,7 +198,7 @@ func RenderRawMarkdown(body []byte, urlPrefix string) []byte {
 	extensions |= blackfriday.EXTENSION_FENCED_CODE
 	extensions |= blackfriday.EXTENSION_AUTOLINK
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
-	extensions |= blackfriday.EXTENSION_HARD_LINE_BREAK
+	// extensions |= blackfriday.EXTENSION_HARD_LINE_BREAK
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
 	extensions |= blackfriday.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK
 


### PR DESCRIPTION
This extension will compile this:

```markdown
A very long
line
```

into this

```html
<p>A very long<br />
line</p>
```

instead of this:

```html
<p>A very long
line</p>
```

Many people try to keep their markdown files under 80 columns to keep them human-readable but that doesn't mean they want to preserve this layout in HTML.

All Markdown renderers I know (including blackfriday-tool itself, markdown, kramdown, pandoc, markdown_py and the implementations used in similar services such as GitHub) disable this feature by default and the fact that Gogs/Gitea has it enabled is quite unexpected, I suggest it is disabled by default.