### PR TITLE
Fix 500 when repo has invalid .editorconfig

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -179,12 +179,10 @@ func Diff(ctx *context.Context) {
 		}
 	}
 
-	ec, err := ctx.Repo.GetEditorconfig()
-	if err != nil && !git.IsErrNotExist(err) {
-		ctx.Handle(500, "ErrGettingEditorconfig", err)
+	setEditorconfigIfExists(ctx)
+	if ctx.Written() {
 		return
 	}
-	ctx.Data["Editorconfig"] = ec
 
 	ctx.Data["CommitID"] = commitID
 	ctx.Data["IsSplitStyle"] = ctx.Query("style") == "split"

--- a/routers/repo/middlewares.go
+++ b/routers/repo/middlewares.go
@@ -1,0 +1,23 @@
+package repo
+
+import (
+	"fmt"
+
+	"github.com/go-gitea/gitea/models"
+	"github.com/go-gitea/gitea/modules/context"
+	"github.com/gogits/git-module"
+)
+
+func setEditorconfigIfExists(ctx *context.Context) {
+	ec, err := ctx.Repo.GetEditorconfig()
+
+	if err != nil && !git.IsErrNotExist(err) {
+		description := fmt.Sprintf("Error while getting .editorconfig file: %v", err)
+		if err := models.CreateRepositoryNotice(description); err != nil {
+			ctx.Handle(500, "ErrCreatingReporitoryNotice", err)
+		}
+		return
+	}
+
+	ctx.Data["Editorconfig"] = ec
+}

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -368,12 +368,10 @@ func ViewPullFiles(ctx *context.Context) {
 		return
 	}
 
-	ec, err := ctx.Repo.GetEditorconfig()
-	if err != nil && !git.IsErrNotExist(err) {
-		ctx.Handle(500, "ErrGettingEditorconfig", err)
+	setEditorconfigIfExists(ctx)
+	if ctx.Written() {
 		return
 	}
-	ctx.Data["Editorconfig"] = ec
 
 	headTarget := path.Join(pull.HeadUserName, pull.HeadRepo.Name)
 	ctx.Data["IsSplitStyle"] = ctx.Query("style") == "split"
@@ -627,12 +625,10 @@ func CompareAndPullRequest(ctx *context.Context) {
 		}
 	}
 
-	ec, err := ctx.Repo.GetEditorconfig()
-	if err != nil && !git.IsErrNotExist(err) {
-		ctx.Handle(500, "ErrGettingEditorconfig", err)
+	setEditorconfigIfExists(ctx)
+	if ctx.Written() {
 		return
 	}
-	ctx.Data["Editorconfig"] = ec
 
 	ctx.HTML(200, COMPARE_PULL)
 }

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -245,12 +245,10 @@ func Home(ctx *context.Context) {
 		return
 	}
 
-	ec, err := ctx.Repo.GetEditorconfig()
-	if err != nil && !git.IsErrNotExist(err) {
-		ctx.Handle(500, "Repo.GetEditorconfig", err)
+	setEditorconfigIfExists(ctx)
+	if ctx.Written() {
 		return
 	}
-	ctx.Data["Editorconfig"] = ec
 
 	var treeNames []string
 	paths := make([]string, 0, 5)


### PR DESCRIPTION
Creating a notice instead

Fixes gogits/gogs#3643