### PR TITLE
Add pagination to release-page 

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -138,8 +138,11 @@ func GetReleaseByID(id int64) (*Release, error) {
 }
 
 // GetReleasesByRepoID returns a list of releases of repository.
-func GetReleasesByRepoID(repoID int64) (rels []*Release, err error) {
-	err = x.Desc("created_unix").Find(&rels, Release{RepoID: repoID})
+func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err error) {
+	if page <= 0 {
+		page = 1
+	}
+	err = x.Desc("created_unix").Limit(pageSize, (page-1)*pageSize).Find(&rels, Release{RepoID: repoID})
 	return rels, err
 }
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -7,6 +7,7 @@ package repo
 import (
 	"fmt"
 
+	"github.com/Unknwon/paginater"
 	"github.com/gogits/gogs/models"
 	"github.com/gogits/gogs/modules/auth"
 	"github.com/gogits/gogs/modules/base"
@@ -58,7 +59,11 @@ func Releases(ctx *context.Context) {
 		return
 	}
 
-	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID)
+	page := ctx.QueryInt("page")
+	if page <= 1 {
+		page = 1
+	}
+	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, 10)
 	if err != nil {
 		ctx.Handle(500, "GetReleasesByRepoID", err)
 		return
@@ -141,6 +146,8 @@ func Releases(ctx *context.Context) {
 		r.Note = markdown.RenderString(r.Note, ctx.Repo.RepoLink, ctx.Repo.Repository.ComposeMetas())
 		tags = append(tags, r)
 	}
+	pager := paginater.New(ctx.Repo.Repository.NumTags, 10, page, 5)
+	ctx.Data["Page"] = pager
 	models.SortReleases(tags)
 	ctx.Data["Releases"] = tags
 	ctx.HTML(200, RELEASES)

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -75,6 +75,7 @@
 				</li>
 			{{end}}
 		</ul>
+		{{template "admin/base/page" .}}
 	</div>
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
This fixes #2164

Hard-coded to 10 releases per page which is what GitHub does as well :)