### PR TITLE
Use the rev-parsed sha1 commit id

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -9,11 +9,11 @@ import (
 	"path"
 
 	"github.com/Unknwon/paginater"
+	"github.com/go-gitea/git"
 	"github.com/go-gitea/gitea/models"
 	"github.com/go-gitea/gitea/modules/base"
 	"github.com/go-gitea/gitea/modules/context"
 	"github.com/go-gitea/gitea/modules/setting"
-	"github.com/go-gitea/git"
 )
 
 const (
@@ -158,7 +158,9 @@ func Diff(ctx *context.Context) {
 		}
 		return
 	}
-
+	if len(commitID) != 40 {
+		commitID = commit.ID.String()
+	}
 	diff, err := models.GetDiffCommit(models.RepoPath(userName, repoName),
 		commitID, setting.Git.MaxGitDiffLines,
 		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles)


### PR DESCRIPTION
Use the rev-parsed sha1 commit id in urls to repo files,
instead of the abbreved version.

Now, the urls to the repo-files contains the abbreviated version of the commits sha1sum, resulting in a 404, due to a lacking implementation of the route `/:user/:repo/src/:sha/`.