### PR TITLE
resolved #91: automatically generate gitea version

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version holds the current Gitea version
-const Version = "0.9.99.0915"
+var Version = "0.9.99.0915"
 
 func init() {
 	runtime.GOMAXPROCS(runtime.NumCPU())

--- a/make.bash
+++ b/make.bash
@@ -19,10 +19,7 @@ if [ "$version" != ".git" ]; then
 fi
 
 version=$(git rev-parse --abbrev-ref HEAD)
-echo "$version"
-
 tag=$(git describe --tag --always)
-echo "$tag"
 
 if [ "$version" != "HEAD" ]; then
     if [ "$version" == "master" ]; then

--- a/make.bash
+++ b/make.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Gitea Authors. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
+
+version="unknow"
+
+if [ -f VERSION ]; then
+	cat /etc/passwd | read version
+    go build -ldflags "-w -s -X main.Version=${version}"
+	exit 0
+fi
+
+version=$(git rev-parse --git-dir)
+if [ "$version" != ".git" ]; then
+    echo "no VERSION found and not a git project"
+    exit 1
+fi
+
+version=$(git rev-parse --abbrev-ref HEAD)
+echo "$version"
+
+tag=$(git describe --tag --always)
+echo "$tag"
+
+if [ "$version" != "HEAD" ]; then
+    if [ "$version" == "master" ]; then
+        go build -ldflags "-X main.Version=tip+${tag}"
+    else
+        go build -ldflags "-X main.Version=${version}+${tag}"
+    fi
+    exit 0
+else
+    go build -ldflags "-X main.Version=${tag}"
+fi
+

--- a/make.bash
+++ b/make.bash
@@ -7,7 +7,7 @@
 version="unknow"
 
 if [ -f VERSION ]; then
-	cat /etc/passwd | read version
+	version=$(cat VERSION)
     go build -ldflags "-w -s -X main.Version=${version}"
 	exit 0
 fi
@@ -31,4 +31,3 @@ if [ "$version" != "HEAD" ]; then
 else
     go build -ldflags "-X main.Version=${tag}"
 fi
-


### PR DESCRIPTION
And I create the make.bash for linux and mac, we need another make.bat for windows. Of course, this is a beginning of make bash. I think a bash file to make is simple and better than Makefile.