### PR TITLE
Go uses ident size 8 with tabs. Nothing else.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ trim_trailing_whitespace = true
 
 [*.go]
 indent_style = tab
-indent_size = 4
+indent_size = 8
 
 [*.tmpl]
 indent_style = tab


### PR DESCRIPTION
We are using _gofmt_ to format our code. This will emit tabs.
The standard is tabs which is 8 spaces and not 4.