### PR TITLE
Ordering organizations and users by name

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -65,14 +65,12 @@ func (org *User) GetMembers() error {
 		return err
 	}
 
-	org.Members = make([]*User, len(ous))
+	var ids = make([]int64, len(ous))
 	for i, ou := range ous {
-		org.Members[i], err = GetUserByID(ou.Uid)
-		if err != nil {
-			return err
-		}
+		ids[i] = ou.Uid
 	}
-	return nil
+	org.Members, err = GetUsersByIDs(ids)
+	return err
 }
 
 // AddMember adds new member to organization.
@@ -190,7 +188,7 @@ func CountOrganizations() int64 {
 // Organizations returns number of organizations in given page.
 func Organizations(page, pageSize int) ([]*User, error) {
 	orgs := make([]*User, 0, pageSize)
-	return orgs, x.Limit(pageSize, (page-1)*pageSize).Where("type=1").Asc("id").Find(&orgs)
+	return orgs, x.Limit(pageSize, (page-1)*pageSize).Where("type=1").Asc("name").Find(&orgs)
 }
 
 // DeleteOrganization completely and permanently deletes everything of organization.
@@ -260,8 +258,11 @@ func getOrgsByUserID(sess *xorm.Session, userID int64, showAll bool) ([]*User, e
 	if !showAll {
 		sess.And("`org_user`.is_public=?", true)
 	}
-	return orgs, sess.And("`org_user`.uid=?", userID).
-		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").Find(&orgs)
+	return orgs, sess.
+		And("`org_user`.uid=?", userID).
+		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").
+		Asc("`user`.name").
+		Find(&orgs)
 }
 
 // GetOrgsByUserID returns a list of organizations that the given user ID
@@ -278,8 +279,12 @@ func GetOrgsByUserIDDesc(userID int64, desc string, showAll bool) ([]*User, erro
 
 func getOwnedOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
 	orgs := make([]*User, 0, 10)
-	return orgs, sess.Where("`org_user`.uid=?", userID).And("`org_user`.is_owner=?", true).
-		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").Find(&orgs)
+	return orgs, sess.
+		Where("`org_user`.uid=?", userID).
+		And("`org_user`.is_owner=?", true).
+		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").
+		Asc("`user`.name").
+		Find(&orgs)
 }
 
 // GetOwnedOrgsByUserID returns a list of organizations are owned by given user ID.
@@ -298,12 +303,16 @@ func GetOwnedOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
 // GetOrgUsersByUserID returns all organization-user relations by user ID.
 func GetOrgUsersByUserID(uid int64, all bool) ([]*OrgUser, error) {
 	ous := make([]*OrgUser, 0, 10)
-	sess := x.Where("uid=?", uid)
+	sess := x.
+		Join("LEFT", "user", `"org_user".org_id="user".id`).
+		Where(`"org_user".uid=?`, uid)
 	if !all {
 		// Only show public organizations
 		sess.And("is_public=?", true)
 	}
-	err := sess.Find(&ous)
+	err := sess.
+		Asc("`user`.name").
+		Find(&ous)
 	return ous, err
 }
 
@@ -450,10 +459,14 @@ func RemoveOrgRepo(orgID, repoID int64) error {
 
 func (org *User) getUserTeams(e Engine, userID int64, cols ...string) ([]*Team, error) {
 	teams := make([]*Team, 0, org.NumTeams)
-	return teams, e.Where("team_user.org_id = ?", org.ID).
-		And("team_user.uid = ?", userID).
-		Join("INNER", "team_user", "team_user.team_id = team.id").
-		Cols(cols...).Find(&teams)
+	return teams, e.
+		Where("`team_user`.org_id = ?", org.ID).
+		Join("INNER", "team_user", "`team_user`.team_id = team.id").
+		Join("INNER", "user", "`user`.id=team_user.uid").
+		And("`team_user`.uid = ?", userID).
+		Asc("`user`.name").
+		Cols(cols...).
+	    Find(&teams)
 }
 
 // GetUserTeamIDs returns of all team IDs of the organization that user is memeber of.

--- a/models/user.go
+++ b/models/user.go
@@ -578,7 +578,7 @@ func CountUsers() int64 {
 // Users returns number of users in given page.
 func Users(page, pageSize int) ([]*User, error) {
 	users := make([]*User, 0, pageSize)
-	return users, x.Limit(pageSize, (page-1)*pageSize).Where("type=0").Asc("id").Find(&users)
+	return users, x.Limit(pageSize, (page-1)*pageSize).Where("type=0").Asc("name").Find(&users)
 }
 
 // get user by erify code
@@ -921,6 +921,13 @@ func GetUserEmailsByNames(names []string) []string {
 		mails = append(mails, u.Email)
 	}
 	return mails
+}
+
+// GetUsersByIDs returns all resolved users from a list of Ids.
+func GetUsersByIDs(ids []int64) ([]*User, error) {
+	ous := make([]*User, 0, len(ids))
+	err := x.In("id", ids).Asc("name").Find(&ous)
+	return ous, err
 }
 
 // GetUserIDsByNames returns a slice of ids corresponds to names.

--- a/routers/admin/repos.go
+++ b/routers/admin/repos.go
@@ -27,7 +27,7 @@ func Repos(ctx *context.Context) {
 		Ranger:   models.Repositories,
 		Private:  true,
 		PageSize: setting.UI.Admin.RepoPagingNum,
-		OrderBy:  "id ASC",
+		OrderBy:  "owner_id ASC, name ASC, id ASC",
 		TplName:  REPOS,
 	})
 }

--- a/routers/home.go
+++ b/routers/home.go
@@ -176,7 +176,7 @@ func ExploreUsers(ctx *context.Context) {
 		Counter:  models.CountUsers,
 		Ranger:   models.Users,
 		PageSize: setting.UI.ExplorePagingNum,
-		OrderBy:  "updated_unix DESC",
+		OrderBy:  "name ASC",
 		TplName:  EXPLORE_USERS,
 	})
 }
@@ -191,7 +191,7 @@ func ExploreOrganizations(ctx *context.Context) {
 		Counter:  models.CountOrganizations,
 		Ranger:   models.Organizations,
 		PageSize: setting.UI.ExplorePagingNum,
-		OrderBy:  "updated_unix DESC",
+		OrderBy:  "name ASC",
 		TplName:  EXPLORE_ORGANIZATIONS,
 	})
 }


### PR DESCRIPTION
Relative to the issue #3845 and #49, this Pull Request add modifications to ordering by name Organizations and User Accounts.

It's more user friendly and make search more easy when organizations and user accounts are ordered by name rather than last update datetime.

I added new function `GetUsersByIDs` to decrease the number of SQL queries by using IN predicate rather than just running 1 SQL query per users.

**Note:** @lunny  @DblK I have re-created PR because rebase operation do something strange and the previous PR.