### PR TITLE
Remove go version from build tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,3 @@
-// +build go1.4
-
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/models/models_tidb.go
+++ b/models/models_tidb.go
@@ -1,4 +1,4 @@
-// +build tidb go1.4.2
+// +build tidb
 
 // Copyright 2015 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style


### PR DESCRIPTION
We don't use go 1.4 anymore.