### PR TITLE
Fix bug that tries to load mistyped templates

### DIFF
--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -44,7 +44,7 @@
 					</table>
 				</div>
 
-				{{template "base/paginage" .}}
+				{{template "base/paginate" .}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -75,7 +75,7 @@
 				</li>
 			{{end}}
 		</ul>
-		{{template "base/paginage" .}}
+		{{template "base/paginate" .}}
 	</div>
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
Trying to view some pages in the admin area I found this bug.