### PR TITLE
Sleep induced slowness

### DIFF
--- a/vendor/code.gitea.io/git/tree_entry.go
+++ b/vendor/code.gitea.io/git/tree_entry.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type EntryMode int
@@ -157,7 +156,6 @@ func (tes Entries) GetCommitsInfo(commit *Commit, treePath string) ([][]interfac
 
 		if tes[i].Type != OBJECT_COMMIT {
 			go func(i int) {
-				time.Sleep(200 * time.Millisecond)
 				cinfo := commitInfo{entryName: tes[i].Name()}
 				c, err := commit.GetCommitByPath(filepath.Join(treePath, tes[i].Name()))
 				if err != nil {


### PR DESCRIPTION
This pull request remove usage of _sleep_ function who slow down git repos browsing (Issue #18).

Moved from https://github.com/gogits/git-module/pull/24