### PR TITLE
fixed bug #151 finally

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@
 package main // import "code.gitea.io/gitea"
 
 import (
-	"log"
 	"os"
 	"runtime"
 
@@ -38,5 +37,5 @@ func main() {
 		cmd.CmdAdmin,
 	}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
-	log.Fatal(app.Run(os.Args))
+	app.Run(os.Args)
 }


### PR DESCRIPTION
As #151 described, found `remote: 2016/11/12 10:27:43 <nil>`. So this is because command `serv` or `update` output some error to the standard output. but don't find any `fmt.Println` and finally, find the main.go. Spend me so many time.
