### PR TITLE
.editorconfig: do not specify line ending

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
That is annoying on Windows, since the editor will change the file if you just open it. Git will checking as LF anyway.