### PR TITLE
Make Xorm log configurable

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -74,6 +74,8 @@ func runCreateUser(c *cli.Context) error {
 
 	setting.NewContext()
 	models.LoadConfigs()
+
+	setting.NewXORMLogService(false)
 	if err := models.SetEngine(); err != nil {
 		return fmt.Errorf("models.SetEngine: %v", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -50,7 +50,6 @@ var CmdServ = cli.Command{
 func setup(logPath string) error {
 	setting.NewContext()
 	log.NewGitLogger(filepath.Join(setting.LogRootPath, logPath))
-
 	models.LoadConfigs()
 
 	if setting.UseSQLite3 || setting.UseTiDB {
@@ -60,6 +59,7 @@ func setup(logPath string) error {
 		}
 	}
 
+	setting.NewXORMLogService(true)
 	return models.SetEngine()
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/denisenkom/go-mssqldb"
 
 	"code.gitea.io/gitea/models/migrations"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
 
@@ -226,6 +227,7 @@ func getEngine() (*xorm.Engine, error) {
 	default:
 		return nil, fmt.Errorf("Unknown database type: %s", DbCfg.Type)
 	}
+
 	return xorm.NewEngine(DbCfg.Type, connStr)
 }
 
@@ -248,20 +250,9 @@ func SetEngine() (err error) {
 	}
 
 	x.SetMapper(core.GonicMapper{})
-
 	// WARNING: for serv command, MUST remove the output to os.stdout,
 	// so use log file to instead print to stdout.
-	logPath := path.Join(setting.LogRootPath, "xorm.log")
-
-	if err := os.MkdirAll(path.Dir(logPath), os.ModePerm); err != nil {
-		return fmt.Errorf("Failed to create dir %s: %v", logPath, err)
-	}
-
-	f, err := os.Create(logPath)
-	if err != nil {
-		return fmt.Errorf("Failed to create xorm.log: %v", err)
-	}
-	x.SetLogger(xorm.NewSimpleLogger(f))
+	x.SetLogger(log.XORMLogger)
 	x.ShowSQL(true)
 	return nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -238,6 +238,8 @@ func NewTestEngine(x *xorm.Engine) (err error) {
 		return fmt.Errorf("Connect to database: %v", err)
 	}
 
+	setting.NewXORMLogService(false)
+
 	x.SetMapper(core.GonicMapper{})
 	return x.StoreEngine("InnoDB").Sync2(tables...)
 }

--- a/modules/log/xorm.go
+++ b/modules/log/xorm.go
@@ -1,3 +1,7 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package log
 
 import (

--- a/modules/log/xorm.go
+++ b/modules/log/xorm.go
@@ -1,0 +1,113 @@
+package log
+
+import (
+	"fmt"
+
+	"github.com/go-xorm/core"
+)
+
+// XORMLogBridge a logger bridge from Logger to xorm
+type XORMLogBridge struct {
+	logger  *Logger
+	showSQL bool
+	level   core.LogLevel
+}
+
+var (
+	// XORMLogger the logger for xorm
+	XORMLogger *XORMLogBridge
+)
+
+// NewXORMLogger generate logger for xorm FIXME: configable
+func NewXORMLogger(bufferlen int64, mode, config string) {
+	logger := newLogger(bufferlen)
+	logger.SetLogger(mode, config)
+	XORMLogger = &XORMLogBridge{
+		logger:  logger,
+		showSQL: true,
+	}
+}
+
+// Debug show debug log
+func (l *XORMLogBridge) Debug(v ...interface{}) {
+	if l.level >= core.LOG_DEBUG {
+		msg := fmt.Sprint(v...)
+		l.logger.writerMsg(0, DEBUG, "[D]"+msg)
+	}
+}
+
+// Debugf show debug log
+func (l *XORMLogBridge) Debugf(format string, v ...interface{}) {
+	if l.level >= core.LOG_DEBUG {
+		l.logger.Debug(format, v...)
+	}
+}
+
+// Error show error log
+func (l *XORMLogBridge) Error(v ...interface{}) {
+	if l.level >= core.LOG_ERR {
+		msg := fmt.Sprint(v...)
+		l.logger.writerMsg(0, ERROR, "[E]"+msg)
+	}
+}
+
+// Errorf show error log
+func (l *XORMLogBridge) Errorf(format string, v ...interface{}) {
+	if l.level >= core.LOG_ERR {
+		l.logger.Error(0, format, v...)
+	}
+}
+
+// Info show information level log
+func (l *XORMLogBridge) Info(v ...interface{}) {
+	if l.level >= core.LOG_INFO {
+		msg := fmt.Sprint(v...)
+		l.logger.writerMsg(0, INFO, "[I]"+msg)
+	}
+}
+
+// Infof show information level log
+func (l *XORMLogBridge) Infof(format string, v ...interface{}) {
+	if l.level >= core.LOG_INFO {
+		l.logger.Info(format, v...)
+	}
+}
+
+// Warn show warnning log
+func (l *XORMLogBridge) Warn(v ...interface{}) {
+	if l.level >= core.LOG_WARNING {
+		msg := fmt.Sprint(v...)
+		l.logger.writerMsg(0, WARN, "[W] "+msg)
+	}
+}
+
+// Warnf show warnning log
+func (l *XORMLogBridge) Warnf(format string, v ...interface{}) {
+	if l.level >= core.LOG_WARNING {
+		l.logger.Warn(format, v...)
+	}
+}
+
+// Level get logger level
+func (l *XORMLogBridge) Level() core.LogLevel {
+	return l.level
+}
+
+// SetLevel set logger level
+func (l *XORMLogBridge) SetLevel(level core.LogLevel) {
+	l.level = level
+}
+
+// ShowSQL set if record SQL
+func (l *XORMLogBridge) ShowSQL(show ...bool) {
+	if len(show) > 0 {
+		l.showSQL = show[0]
+	} else {
+		l.showSQL = true
+	}
+}
+
+// IsShowSQL if record SQL
+func (l *XORMLogBridge) IsShowSQL() bool {
+	return l.showSQL
+}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/go-macaron/cache/redis"
 	"github.com/go-macaron/session"
 	_ "github.com/go-macaron/session/redis" // redis plugin for store session
+	"github.com/go-xorm/core"
 	ini "gopkg.in/ini.v1"
 	"strk.kbt.io/projects/go/libravatar"
 )
@@ -1014,6 +1015,85 @@ func newLogService() {
 	}
 }
 
+func NewXORMLogService(disableConsole bool) {
+	logModes := strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
+	var logConfigs string
+	for _, mode := range logModes {
+		if disableConsole && mode == "console" {
+			continue
+		}
+		mode = strings.TrimSpace(mode)
+		sec, err := Cfg.GetSection("log." + mode)
+		if err != nil {
+			log.Fatal(4, "Unknown log mode: %s", mode)
+		}
+
+		validLevels := []string{"Trace", "Debug", "Info", "Warn", "Error", "Critical"}
+		// Log level.
+		levelName := Cfg.Section("log."+mode).Key("LEVEL").In(
+			Cfg.Section("log").Key("LEVEL").In("Trace", validLevels),
+			validLevels)
+		level, ok := logLevels[levelName]
+		if !ok {
+			log.Fatal(4, "Unknown log level: %s", levelName)
+		}
+
+		// Generate log configuration.
+		switch mode {
+		case "console":
+			logConfigs = fmt.Sprintf(`{"level":%s}`, level)
+		case "file":
+			logPath := sec.Key("FILE_NAME").MustString(path.Join(LogRootPath, "xorm.log"))
+			if err = os.MkdirAll(path.Dir(logPath), os.ModePerm); err != nil {
+				panic(err.Error())
+			}
+			logPath = filepath.Join(filepath.Dir(logPath), "xorm.log")
+
+			logConfigs = fmt.Sprintf(
+				`{"level":%s,"filename":"%s","rotate":%v,"maxlines":%d,"maxsize":%d,"daily":%v,"maxdays":%d}`, level,
+				logPath,
+				sec.Key("LOG_ROTATE").MustBool(true),
+				sec.Key("MAX_LINES").MustInt(1000000),
+				1<<uint(sec.Key("MAX_SIZE_SHIFT").MustInt(28)),
+				sec.Key("DAILY_ROTATE").MustBool(true),
+				sec.Key("MAX_DAYS").MustInt(7))
+		case "conn":
+			logConfigs = fmt.Sprintf(`{"level":%s,"reconnectOnMsg":%v,"reconnect":%v,"net":"%s","addr":"%s"}`, level,
+				sec.Key("RECONNECT_ON_MSG").MustBool(),
+				sec.Key("RECONNECT").MustBool(),
+				sec.Key("PROTOCOL").In("tcp", []string{"tcp", "unix", "udp"}),
+				sec.Key("ADDR").MustString(":7020"))
+		case "smtp":
+			logConfigs = fmt.Sprintf(`{"level":%s,"username":"%s","password":"%s","host":"%s","sendTos":"%s","subject":"%s"}`, level,
+				sec.Key("USER").MustString("example@example.com"),
+				sec.Key("PASSWD").MustString("******"),
+				sec.Key("HOST").MustString("127.0.0.1:25"),
+				sec.Key("RECEIVERS").MustString("[]"),
+				sec.Key("SUBJECT").MustString("Diagnostic message from serve"))
+		case "database":
+			logConfigs = fmt.Sprintf(`{"level":%s,"driver":"%s","conn":"%s"}`, level,
+				sec.Key("DRIVER").String(),
+				sec.Key("CONN").String())
+		}
+
+		log.NewXORMLogger(Cfg.Section("log").Key("BUFFER_LEN").MustInt64(10000), mode, logConfigs)
+		log.Info("XORM Log Mode: %s(%s)", strings.Title(mode), levelName)
+
+		var lvl core.LogLevel
+		switch levelName {
+		case "Trace", "Debug":
+			lvl = core.LOG_DEBUG
+		case "Info":
+			lvl = core.LOG_INFO
+		case "Warn":
+			lvl = core.LOG_WARNING
+		case "Error", "Critical":
+			lvl = core.LOG_ERR
+		}
+		log.XORMLogger.SetLevel(lvl)
+	}
+}
+
 func newCacheService() {
 	CacheAdapter = Cfg.Section("cache").Key("ADAPTER").In("memory", []string{"memory", "redis", "memcache"})
 	switch CacheAdapter {
@@ -1140,6 +1220,7 @@ func newWebhookService() {
 func NewServices() {
 	newService()
 	newLogService()
+	NewXORMLogService(false)
 	newCacheService()
 	newSessionService()
 	newMailService()

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1015,6 +1015,7 @@ func newLogService() {
 	}
 }
 
+// NewXORMLogService initializes xorm logger service
 func NewXORMLogService(disableConsole bool) {
 	logModes := strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
 	var logConfigs string

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -945,18 +945,18 @@ func newLogService() {
 	LogConfigs = make([]string, len(LogModes))
 
 	useConsole := false
-	for _, mode := range LogModes {
-		if mode == "console" {
+	for i := 0; i < len(LogModes); i++ {
+		LogModes[i] = strings.TrimSpace(LogModes[i])
+		if LogModes[i] == "console" {
 			useConsole = true
 		}
 	}
+
 	if !useConsole {
 		log.DelLogger("console")
 	}
 
 	for i, mode := range LogModes {
-		mode = strings.TrimSpace(mode)
-
 		sec, err := Cfg.GetSection("log." + mode)
 
 		if err != nil {
@@ -1020,10 +1020,11 @@ func NewXORMLogService(disableConsole bool) {
 	logModes := strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
 	var logConfigs string
 	for _, mode := range logModes {
+		mode = strings.TrimSpace(mode)
+
 		if disableConsole && mode == "console" {
 			continue
 		}
-		mode = strings.TrimSpace(mode)
 		sec, err := Cfg.GetSection("log." + mode)
 		if err != nil {
 			log.Fatal(4, "Unknown log mode: %s", mode)


### PR DESCRIPTION
Before xorm's log will be stored `xorm.log`, now it will use the same configuration as `gogs.log`, except the file name from `gogs.log` to `xorm.log`. So that, user could set it to be rotated to avoid disk usage.