### PR TITLE
Have the default 'all' rule just build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
 endif
 
 .PHONY: all
-all: clean test build
+all: build
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Clean and test are saner being seperate targets