### PR TITLE
Use temporary file to avoid out-of-memory when receiving big chunks.

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -364,14 +364,22 @@ func serviceRPC(h serviceHandler, service string) {
 	}
 
 	if h.cfg.OnSucceed != nil {
-		input, err = ioutil.ReadAll(reqBody)
+		tmpfile, err := ioutil.TempFile("", "gogs")
 		if err != nil {
-			log.GitLogger.Error(2, "fail to read request body: %v", err)
+			log.GitLogger.Error(2, "fail to create temporary file: %v", err)
+			h.w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer os.Remove(tmpfile.Name())
+
+		_, err = io.Copy(tmpfile, reqBody)
+		if err != nil {
+			log.GitLogger.Error(2, "fail to save request body: %v", err)
 			h.w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
-		br = bytes.NewReader(input)
+		br = tmpfile
 	} else {
 		br = reqBody
 	}

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -371,6 +371,7 @@ func serviceRPC(h serviceHandler, service string) {
 			return
 		}
 		defer os.Remove(tmpfile.Name())
+		defer tmpfile.Close()
 
 		_, err = io.Copy(tmpfile, reqBody)
 		if err != nil {


### PR DESCRIPTION
Not perfect but I think it's a reasonable solution.
For small request bodies, I suppose performance wouldn't be an issue.
For large ones, this seems to be a necessary evil.

Fixes #218 