### PR TITLE
Have "make" create the executable in root dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ install: $(wildcard *.go)
 	go install -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)'
 
 .PHONY: build
-build: $(BIN)/$(EXECUTABLE)
+build: $(EXECUTABLE)
 
-$(BIN)/$(EXECUTABLE): $(wildcard *.go)
+$(EXECUTABLE): $(wildcard *.go)
 	go build -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: release


### PR DESCRIPTION
Same as "go build".
Makes it functional by default as it'd then find template/ and public/
by default w/out setting GITEA_WORK_DIR