### PR TITLE
Fix HTTP headers for issue attachment download

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -336,11 +336,7 @@ func runWeb(ctx *cli.Context) error {
 			}
 			defer fr.Close()
 
-			ctx.Header().Set("Cache-Control", "public,max-age=86400")
-			ctx.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, attach.Name))
-			// Fix #312. Attachments with , in their name are not handled correctly by Google Chrome.
-			// We must put the name in " manually.
-			if err = repo.ServeData(ctx, "\""+attach.Name+"\"", fr); err != nil {
+			if err = repo.ServeData(ctx, attach.Name, fr); err != nil {
 				ctx.Handle(500, "ServeData", err)
 				return
 			}

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -7,6 +7,7 @@ package repo
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"code.gitea.io/git"
 
@@ -23,6 +24,9 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	}
 
 	ctx.Resp.Header().Set("Cache-Control", "public,max-age=86400")
+
+	// Google Chrome dislike commas in filenames, so let's change it to a space
+	name = strings.Replace(name, ",", " ", -1)
 
 	if base.IsTextFile(buf) || ctx.QueryBool("render") {
 		ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -5,8 +5,8 @@
 package repo
 
 import (
+	"fmt"
 	"io"
-	"path"
 
 	"code.gitea.io/git"
 
@@ -22,14 +22,16 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 		buf = buf[:n]
 	}
 
-	if !base.IsTextFile(buf) {
-		if !base.IsImageFile(buf) {
-			ctx.Resp.Header().Set("Content-Disposition", "attachment; filename=\""+path.Base(ctx.Repo.TreePath)+"\"")
-			ctx.Resp.Header().Set("Content-Transfer-Encoding", "binary")
-		}
-	} else if !ctx.QueryBool("render") {
+	ctx.Resp.Header().Set("Cache-Control", "public,max-age=86400")
+
+	if base.IsTextFile(buf) || ctx.QueryBool("render") {
 		ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	} else if base.IsImageFile(buf) || base.IsPDFFile(buf) {
+		ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, name))
+	} else {
+		ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
 	}
+
 	ctx.Resp.Write(buf)
 	_, err := io.Copy(ctx.Resp, reader)
 	return err


### PR DESCRIPTION
This fixes:

- Download filename was wrong for files other than images. Example: It was `download` instead of `file.pdf`
- PDF was downloading instead of showing on browser