### PR TITLE
Speed up conflict checking in pull request creation

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -432,7 +432,7 @@ func (pr *PullRequest) testPatch() (err error) {
 
 	pr.Status = PullRequestStatusChecking
 
-	indexTmpPath := filepath.Join(os.TempDir(), "-gitea-"+pr.BaseRepo.Name+"-"+strconv.Itoa(time.Now().Nanosecond()))
+	indexTmpPath := filepath.Join(os.TempDir(), "gitea-"+pr.BaseRepo.Name+"-"+strconv.Itoa(time.Now().Nanosecond()))
 	defer os.Remove(indexTmpPath)
 
 	var stderr string

--- a/models/pull.go
+++ b/models/pull.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -428,17 +430,22 @@ func (pr *PullRequest) testPatch() (err error) {
 
 	log.Trace("PullRequest[%d].testPatch (patchPath): %s", pr.ID, patchPath)
 
-	// Delete old temp local copy before we create a new temp local copy
-	RemoveAllWithNotice("Deleting old local copy", pr.BaseRepo.LocalCopyPath())
+	pr.Status = PullRequestStatusChecking
 
-	if err := pr.BaseRepo.UpdateLocalCopyBranch(pr.BaseBranch); err != nil {
-		return fmt.Errorf("UpdateLocalCopy: %v", err)
+	indexTmpPath := filepath.Join(os.TempDir(), "-gitea-"+pr.BaseRepo.Name+"-"+strconv.Itoa(time.Now().Nanosecond()))
+	defer os.Remove(indexTmpPath)
+
+	var stderr string
+	_, stderr, err = process.ExecDirEnv(-1, "", fmt.Sprintf("testPatch (git read-tree): %d", pr.BaseRepo.ID),
+		[]string{"GIT_DIR=" + pr.BaseRepo.RepoPath()},
+		"git", "read-tree", "--index-output", indexTmpPath, pr.BaseBranch)
+	if err != nil {
+		return fmt.Errorf("git read-tree --index-output=%s %s: %v - %s", indexTmpPath, pr.BaseBranch, err, stderr)
 	}
 
-	pr.Status = PullRequestStatusChecking
-	_, stderr, err := process.ExecDir(-1, pr.BaseRepo.LocalCopyPath(),
-		fmt.Sprintf("testPatch (git apply --check): %d", pr.BaseRepo.ID),
-		"git", "apply", "--check", patchPath)
+	_, stderr, err = process.ExecDirEnv(-1, "", fmt.Sprintf("testPatch (git apply --check): %d", pr.BaseRepo.ID),
+		[]string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()},
+		"git", "apply", "--check", "--cached", patchPath)
 	if err != nil {
 		for i := range patchConflicts {
 			if strings.Contains(stderr, patchConflicts[i]) {

--- a/models/pull.go
+++ b/models/pull.go
@@ -437,8 +437,8 @@ func (pr *PullRequest) testPatch() (err error) {
 
 	var stderr string
 	_, stderr, err = process.ExecDirEnv(-1, "", fmt.Sprintf("testPatch (git read-tree): %d", pr.BaseRepo.ID),
-		[]string{"GIT_DIR=" + pr.BaseRepo.RepoPath()},
-		"git", "read-tree", "--index-output", indexTmpPath, pr.BaseBranch)
+		[]string{"GIT_DIR=" + pr.BaseRepo.RepoPath(), "GIT_INDEX_FILE=" + indexTmpPath},
+		"git", "read-tree", pr.BaseBranch)
 	if err != nil {
 		return fmt.Errorf("git read-tree --index-output=%s %s: %v - %s", indexTmpPath, pr.BaseBranch, err, stderr)
 	}


### PR DESCRIPTION
In order to check conflicts of a PR, we set up a working tree by cloning the base branch, which is quite time-consuming and would hang the web response when the repository is huge.
Instead, this PR uses `git read-tree` and `git apply --check --cached` to check conflicts, where only the index file is required to be created.

For #258