### PR TITLE
Update link on user’s profile avatar to avatar settings

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -5,7 +5,7 @@
 			<div class="ui five wide column">
 				<div class="ui card">
 					{{if eq .SignedUserName .Owner.Name}}
-						<a class="image poping up" href="{{AppSubUrl}}/user/settings" id="profile-avatar" data-content="{{.i18n.Tr "user.change_avatar"}}" data-variation="inverted tiny" data-position="bottom center">
+						<a class="image poping up" href="{{AppSubUrl}}/user/settings/avatar" id="profile-avatar" data-content="{{.i18n.Tr "user.change_avatar"}}" data-variation="inverted tiny" data-position="bottom center">
 							<img src="{{.Owner.RelAvatarLink}}?s=290" title="{{.Owner.Name}}"/>
 						</a>
 					{{else}}


### PR DESCRIPTION
When click on the avatar on my profile page I expect to get to the avatar settings.

I get linked to `/user/settings` and not to the expected `/user/settings/avatar` where I can acuatally update my avatar.