### PR TITLE
webhook tag sha fix (#286)

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -565,8 +565,10 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 		}
 
 	case ActionPushTag: // Create
+		shaSum := git.OpenRepository(repo.RepoPath()).GetTagCommitID(refName)
 		return PrepareWebhooks(repo, HookEventCreate, &api.CreatePayload{
 			Ref:     refName,
+			Sha:     shaSum,
 			RefType: "tag",
 			Repo:    apiRepo,
 			Sender:  apiPusher,

--- a/models/issue.go
+++ b/models/issue.go
@@ -173,9 +173,9 @@ func (issue *Issue) HTMLURL() string {
 // State returns string representation of issue status.
 func (issue *Issue) State() api.StateType {
 	if issue.IsClosed {
-		return api.STATE_CLOSED
+		return api.StateClosed
 	}
-	return api.STATE_OPEN
+	return api.StateOpen
 }
 
 // APIFormat assumes some fields assigned with values:
@@ -483,7 +483,7 @@ func (issue *Issue) ChangeStatus(doer *User, repo *Repository, isClosed bool) (e
 		if isClosed {
 			apiPullRequest.Action = api.HookIssueClosed
 		} else {
-			apiPullRequest.Action = api.HookIssueReopened
+			apiPullRequest.Action = api.HookIssueReOpened
 		}
 		err = PrepareWebhooks(repo, HookEventPullRequest, apiPullRequest)
 	}
@@ -1409,9 +1409,9 @@ func (m *Milestone) AfterSet(colName string, _ xorm.Cell) {
 // State returns string representation of milestone status.
 func (m *Milestone) State() api.StateType {
 	if m.IsClosed {
-		return api.STATE_CLOSED
+		return api.StateClosed
 	}
-	return api.STATE_OPEN
+	return api.StateOpen
 }
 
 // APIFormat returns this Milestone in API format.

--- a/models/pull.go
+++ b/models/pull.go
@@ -139,7 +139,7 @@ func (pr *PullRequest) APIFormat() *api.PullRequest {
 
 	if pr.Status != PullRequestStatusChecking {
 		mergeable := pr.Status != PullRequestStatusConflict
-		apiPullRequest.Mergeable = &mergeable
+		apiPullRequest.Mergeable = mergeable
 	}
 	if pr.HasMerged {
 		apiPullRequest.Merged = &pr.Merged

--- a/models/user.go
+++ b/models/user.go
@@ -174,7 +174,7 @@ func (u *User) APIFormat() *api.User {
 		UserName:  u.Name,
 		FullName:  u.FullName,
 		Email:     u.Email,
-		AvatarUrl: u.AvatarLink(),
+		AvatarURL: u.AvatarLink(),
 	}
 }
 

--- a/models/webhook_slack.go
+++ b/models/webhook_slack.go
@@ -157,7 +157,7 @@ func getSlackPullRequestPayload(p *api.PullRequestPayload, slack *SlackMeta) (*S
 		} else {
 			text = fmt.Sprintf("[%s] Pull request closed: %s by %s", p.Repository.FullName, titleLink, senderLink)
 		}
-	case api.HookIssueReopened:
+	case api.HookIssueReOpened:
 		text = fmt.Sprintf("[%s] Pull request re-opened: %s by %s", p.Repository.FullName, titleLink, senderLink)
 	case api.HookIssueEdited:
 		text = fmt.Sprintf("[%s] Pull request edited: %s by %s", p.Repository.FullName, titleLink, senderLink)

--- a/routers/api/v1/convert/convert.go
+++ b/routers/api/v1/convert/convert.go
@@ -115,7 +115,7 @@ func ToDeployKey(apiLink string, key *models.DeployKey) *api.DeployKey {
 func ToOrganization(org *models.User) *api.Organization {
 	return &api.Organization{
 		ID:          org.ID,
-		AvatarUrl:   org.AvatarLink(),
+		AvatarURL:   org.AvatarLink(),
 		UserName:    org.Name,
 		FullName:    org.FullName,
 		Description: org.Description,

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -165,7 +165,7 @@ func EditIssue(ctx *context.APIContext, form api.EditIssueOption) {
 		return
 	}
 	if form.State != nil {
-		if err = issue.ChangeStatus(ctx.User, ctx.Repo.Repository, api.STATE_CLOSED == api.StateType(*form.State)); err != nil {
+		if err = issue.ChangeStatus(ctx.User, ctx.Repo.Repository, api.StateClosed == api.StateType(*form.State)); err != nil {
 			ctx.Error(500, "ChangeStatus", err)
 			return
 		}

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -38,7 +38,7 @@ func Search(ctx *context.APIContext) {
 		results[i] = &api.User{
 			ID:        users[i].ID,
 			UserName:  users[i].Name,
-			AvatarUrl: users[i].AvatarLink(),
+			AvatarURL: users[i].AvatarLink(),
 			FullName:  users[i].FullName,
 		}
 		if ctx.IsSigned {

--- a/vendor/code.gitea.io/sdk/gitea/admin_org.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_org.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 )
 
+// AdminCreateOrg create an organization
 func (c *Client) AdminCreateOrg(user string, opt CreateOrgOption) (*Organization, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/admin_repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_repo.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 )
 
+// AdminCreateRepo create a repo
 func (c *Client) AdminCreateRepo(user string, opt CreateRepoOption) (*Repository, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/admin_user.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_user.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 )
 
+// CreateUserOption create user options
 type CreateUserOption struct {
 	SourceID   int64  `json:"source_id"`
 	LoginName  string `json:"login_name"`
@@ -20,6 +21,7 @@ type CreateUserOption struct {
 	SendNotify bool   `json:"send_notify"`
 }
 
+// AdminCreateUser create a user
 func (c *Client) AdminCreateUser(opt CreateUserOption) (*User, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -29,6 +31,7 @@ func (c *Client) AdminCreateUser(opt CreateUserOption) (*User, error) {
 	return user, c.getParsedResponse("POST", "/admin/users", jsonHeader, bytes.NewReader(body), user)
 }
 
+// EditUserOption edit user options
 type EditUserOption struct {
 	SourceID         int64  `json:"source_id"`
 	LoginName        string `json:"login_name"`
@@ -44,6 +47,7 @@ type EditUserOption struct {
 	MaxRepoCreation  *int   `json:"max_repo_creation"`
 }
 
+// AdminEditUser modify user informations
 func (c *Client) AdminEditUser(user string, opt EditUserOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -53,11 +57,13 @@ func (c *Client) AdminEditUser(user string, opt EditUserOption) error {
 	return err
 }
 
+// AdminDeleteUser delete one user according name
 func (c *Client) AdminDeleteUser(user string) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/admin/users/%s", user), nil, nil)
 	return err
 }
 
+// AdminCreateUserPublicKey create one user with options
 func (c *Client) AdminCreateUserPublicKey(user string, opt CreateKeyOption) (*PublicKey, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/doc.go
+++ b/vendor/code.gitea.io/sdk/gitea/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea // import "code.gitea.io/sdk/gitea"

--- a/vendor/code.gitea.io/sdk/gitea/gitea.go
+++ b/vendor/code.gitea.io/sdk/gitea/gitea.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 )
 
+// Version return the library version
 func Version() string {
 	return "0.12.3"
 }
@@ -87,4 +88,14 @@ func (c *Client) getParsedResponse(method, path string, header http.Header, body
 		return err
 	}
 	return json.Unmarshal(data, obj)
+}
+
+func (c *Client) getStatusCode(method, path string, header http.Header, body io.Reader) (int, error) {
+	resp, err := c.doRequest(method, path, header, body)
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode, nil
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue.go
@@ -11,18 +11,23 @@ import (
 	"time"
 )
 
+// StateType issue state type
 type StateType string
 
 const (
-	STATE_OPEN   StateType = "open"
-	STATE_CLOSED StateType = "closed"
+	// StateOpen pr is opend
+	StateOpen StateType = "open"
+	// StateClosed pr is closed
+	StateClosed StateType = "closed"
 )
 
+// PullRequestMeta PR info if an issue is a PR
 type PullRequestMeta struct {
 	HasMerged bool       `json:"merged"`
 	Merged    *time.Time `json:"merged_at"`
 }
 
+// Issue an issue to a repository
 type Issue struct {
 	ID        int64      `json:"id"`
 	Index     int64      `json:"number"`
@@ -40,20 +45,37 @@ type Issue struct {
 	PullRequest *PullRequestMeta `json:"pull_request"`
 }
 
+// ListIssueOption list issue options
 type ListIssueOption struct {
-	Page int
+	Page  int
+	State string
 }
 
+// ListIssues returns all issues assigned the authenticated user
+func (c *Client) ListIssues(opt ListIssueOption) ([]*Issue, error) {
+	issues := make([]*Issue, 0, 10)
+	return issues, c.getParsedResponse("GET", fmt.Sprintf("/issues?page=%d", opt.Page), nil, nil, &issues)
+}
+
+// ListUserIssues returns all issues assigned to the authenticated user
+func (c *Client) ListUserIssues(opt ListIssueOption) ([]*Issue, error) {
+	issues := make([]*Issue, 0, 10)
+	return issues, c.getParsedResponse("GET", fmt.Sprintf("/user/issues?page=%d", opt.Page), nil, nil, &issues)
+}
+
+// ListRepoIssues returns all issues for a given repository
 func (c *Client) ListRepoIssues(owner, repo string, opt ListIssueOption) ([]*Issue, error) {
 	issues := make([]*Issue, 0, 10)
 	return issues, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/issues?page=%d", owner, repo, opt.Page), nil, nil, &issues)
 }
 
+// GetIssue returns a single issue for a given repository
 func (c *Client) GetIssue(owner, repo string, index int64) (*Issue, error) {
 	issue := new(Issue)
 	return issue, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, index), nil, nil, issue)
 }
 
+// CreateIssueOption options to create one issue
 type CreateIssueOption struct {
 	Title     string  `json:"title" binding:"Required"`
 	Body      string  `json:"body"`
@@ -63,6 +85,7 @@ type CreateIssueOption struct {
 	Closed    bool    `json:"closed"`
 }
 
+// CreateIssue create a new issue for a given repository
 func (c *Client) CreateIssue(owner, repo string, opt CreateIssueOption) (*Issue, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -73,6 +96,7 @@ func (c *Client) CreateIssue(owner, repo string, opt CreateIssueOption) (*Issue,
 		jsonHeader, bytes.NewReader(body), issue)
 }
 
+// EditIssueOption edit issue options
 type EditIssueOption struct {
 	Title     string  `json:"title"`
 	Body      *string `json:"body"`
@@ -81,6 +105,7 @@ type EditIssueOption struct {
 	State     *string `json:"state"`
 }
 
+// EditIssue modify an existing issue for a given repository
 func (c *Client) EditIssue(owner, repo string, index int64, opt EditIssueOption) (*Issue, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/issue_comment.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_comment.go
@@ -13,17 +13,26 @@ import (
 
 // Comment represents a comment in commit and issue page.
 type Comment struct {
-	ID      int64     `json:"id"`
-	Poster  *User     `json:"user"`
-	Body    string    `json:"body"`
-	Created time.Time `json:"created_at"`
-	Updated time.Time `json:"updated_at"`
+	ID       int64     `json:"id"`
+	HTMLURL  string    `json:"html_url"`
+	PRURL    string    `json:"pull_request_url"`
+	IssueURL string    `json:"issue_url"`
+	Poster   *User     `json:"user"`
+	Body     string    `json:"body"`
+	Created  time.Time `json:"created_at"`
+	Updated  time.Time `json:"updated_at"`
 }
 
 // ListIssueComments list comments on an issue.
 func (c *Client) ListIssueComments(owner, repo string, index int64) ([]*Comment, error) {
 	comments := make([]*Comment, 0, 10)
 	return comments, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, index), nil, nil, &comments)
+}
+
+// ListRepoIssueComments list comments for a given repo.
+func (c *Client) ListRepoIssueComments(owner, repo string) ([]*Comment, error) {
+	comments := make([]*Comment, 0, 10)
+	return comments, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/issues/comments", owner, repo), nil, nil, &comments)
 }
 
 // CreateIssueCommentOption is option when creating an issue comment.
@@ -54,4 +63,10 @@ func (c *Client) EditIssueComment(owner, repo string, index, commentID int64, op
 	}
 	comment := new(Comment)
 	return comment, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/:%s/:%s/issues/%d/comments/%d", owner, repo, index, commentID), jsonHeader, bytes.NewReader(body), comment)
+}
+
+// DeleteIssueComment deletes an issue comment.
+func (c *Client) DeleteIssueComment(owner, repo string, index, commentID int64) error {
+	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/comments/%d", owner, repo, index, commentID), nil, nil)
+	return err
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue_label.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_label.go
@@ -10,27 +10,34 @@ import (
 	"fmt"
 )
 
+// Label a label to an issue or a pr
 type Label struct {
 	ID    int64  `json:"id"`
 	Name  string `json:"name"`
 	Color string `json:"color"`
+	URL   string `json:"url"`
 }
 
+// ListRepoLabels list lables of one reppsitory
 func (c *Client) ListRepoLabels(owner, repo string) ([]*Label, error) {
 	labels := make([]*Label, 0, 10)
 	return labels, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels", owner, repo), nil, nil, &labels)
 }
 
+// GetRepoLabel get one label of repository by repo it
+// TODO: maybe we need get a label by name
 func (c *Client) GetRepoLabel(owner, repo string, id int64) (*Label, error) {
 	label := new(Label)
 	return label, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil, label)
 }
 
+// CreateLabelOption create options when one label of repository
 type CreateLabelOption struct {
 	Name  string `json:"name" binding:"Required"`
 	Color string `json:"color" binding:"Required;Size(7)"`
 }
 
+// CreateLabel create one label of repository
 func (c *Client) CreateLabel(owner, repo string, opt CreateLabelOption) (*Label, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -41,11 +48,13 @@ func (c *Client) CreateLabel(owner, repo string, opt CreateLabelOption) (*Label,
 		jsonHeader, bytes.NewReader(body), label)
 }
 
+// EditLabelOption edit label options
 type EditLabelOption struct {
 	Name  *string `json:"name"`
 	Color *string `json:"color"`
 }
 
+// EditLabel modify one label with options
 func (c *Client) EditLabel(owner, repo string, id int64, opt EditLabelOption) (*Label, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -55,43 +64,52 @@ func (c *Client) EditLabel(owner, repo string, id int64, opt EditLabelOption) (*
 	return label, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), jsonHeader, bytes.NewReader(body), label)
 }
 
+// DeleteLabel delete one label of repository by id
+// TODO: maybe we need delete by name
 func (c *Client) DeleteLabel(owner, repo string, id int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil)
 	return err
 }
 
+// IssueLabelsOption list one issue's labels options
 type IssueLabelsOption struct {
 	Labels []int64 `json:"labels"`
 }
 
+// GetIssueLabels get labels of one issue via issue id
 func (c *Client) GetIssueLabels(owner, repo string, index int64) ([]*Label, error) {
 	labels := make([]*Label, 0, 5)
 	return labels, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), nil, nil, &labels)
 }
 
+// AddIssueLabels add one or more labels to one issue
 func (c *Client) AddIssueLabels(owner, repo string, index int64, opt IssueLabelsOption) ([]*Label, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
 		return nil, err
 	}
-	labels := make([]*Label, 0)
+	var labels []*Label
 	return labels, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), jsonHeader, bytes.NewReader(body), &labels)
 }
 
+// ReplaceIssueLabels replace old labels of issue with new labels
 func (c *Client) ReplaceIssueLabels(owner, repo string, index int64, opt IssueLabelsOption) ([]*Label, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
 		return nil, err
 	}
-	labels := make([]*Label, 0)
+	var labels []*Label
 	return labels, c.getParsedResponse("PUT", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), jsonHeader, bytes.NewReader(body), &labels)
 }
 
+// DeleteIssueLabel delete one label of one issue by issue id and label id
+// TODO: maybe we need delete by label name and issue id
 func (c *Client) DeleteIssueLabel(owner, repo string, index, label int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%d", owner, repo, index, label), nil, nil)
 	return err
 }
 
+// ClearIssueLabels delete all the labels of one issue.
 func (c *Client) ClearIssueLabels(owner, repo string, index int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/issue_milestone.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_milestone.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// Milestone milestone is a collection of issues on one repository
 type Milestone struct {
 	ID           int64      `json:"id"`
 	Title        string     `json:"title"`
@@ -22,22 +23,26 @@ type Milestone struct {
 	Deadline     *time.Time `json:"due_on"`
 }
 
+// ListRepoMilestones list all the milestones of one repository
 func (c *Client) ListRepoMilestones(owner, repo string) ([]*Milestone, error) {
 	milestones := make([]*Milestone, 0, 10)
 	return milestones, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/milestones", owner, repo), nil, nil, &milestones)
 }
 
+// GetMilestone get one milestone by repo name and milestone id
 func (c *Client) GetMilestone(owner, repo string, id int64) (*Milestone, error) {
 	milestone := new(Milestone)
 	return milestone, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/milestones/%d", owner, repo, id), nil, nil, milestone)
 }
 
+// CreateMilestoneOption options when creating milestone
 type CreateMilestoneOption struct {
 	Title       string     `json:"title"`
 	Description string     `json:"description"`
 	Deadline    *time.Time `json:"due_on"`
 }
 
+// CreateMilestone create one milestone with options
 func (c *Client) CreateMilestone(owner, repo string, opt CreateMilestoneOption) (*Milestone, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -47,6 +52,7 @@ func (c *Client) CreateMilestone(owner, repo string, opt CreateMilestoneOption) 
 	return milestone, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/milestones", owner, repo), jsonHeader, bytes.NewReader(body), milestone)
 }
 
+// EditMilestoneOption options when modify milestone
 type EditMilestoneOption struct {
 	Title       string     `json:"title"`
 	Description *string    `json:"description"`
@@ -54,6 +60,7 @@ type EditMilestoneOption struct {
 	Deadline    *time.Time `json:"due_on"`
 }
 
+// EditMilestone modify milestone with options
 func (c *Client) EditMilestone(owner, repo string, id int64, opt EditMilestoneOption) (*Milestone, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -63,6 +70,7 @@ func (c *Client) EditMilestone(owner, repo string, id int64, opt EditMilestoneOp
 	return milestone, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/milestones/%d", owner, repo, id), jsonHeader, bytes.NewReader(body), milestone)
 }
 
+// DeleteMilestone delete one milestone by milestone id
 func (c *Client) DeleteMilestone(owner, repo string, id int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/milestones/%d", owner, repo, id), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/miscellaneous.go
+++ b/vendor/code.gitea.io/sdk/gitea/miscellaneous.go
@@ -4,6 +4,7 @@
 
 package gitea
 
+// MarkdownOption markdown options
 type MarkdownOption struct {
 	Text    string
 	Mode    string

--- a/vendor/code.gitea.io/sdk/gitea/org.go
+++ b/vendor/code.gitea.io/sdk/gitea/org.go
@@ -10,31 +10,36 @@ import (
 	"fmt"
 )
 
+// Organization a group of some repositories, users and teams
 type Organization struct {
 	ID          int64  `json:"id"`
 	UserName    string `json:"username"`
 	FullName    string `json:"full_name"`
-	AvatarUrl   string `json:"avatar_url"`
+	AvatarURL   string `json:"avatar_url"`
 	Description string `json:"description"`
 	Website     string `json:"website"`
 	Location    string `json:"location"`
 }
 
+// ListMyOrgs list all of current user's organizations
 func (c *Client) ListMyOrgs() ([]*Organization, error) {
 	orgs := make([]*Organization, 0, 5)
 	return orgs, c.getParsedResponse("GET", "/user/orgs", nil, nil, &orgs)
 }
 
+// ListUserOrgs list all of some user's organizations
 func (c *Client) ListUserOrgs(user string) ([]*Organization, error) {
 	orgs := make([]*Organization, 0, 5)
 	return orgs, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/orgs", user), nil, nil, &orgs)
 }
 
+// GetOrg get one organization by name
 func (c *Client) GetOrg(orgname string) (*Organization, error) {
 	org := new(Organization)
 	return org, c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s", orgname), nil, nil, org)
 }
 
+// CreateOrgOption create one organization options
 type CreateOrgOption struct {
 	UserName    string `json:"username" binding:"Required"`
 	FullName    string `json:"full_name"`
@@ -43,6 +48,7 @@ type CreateOrgOption struct {
 	Location    string `json:"location"`
 }
 
+// EditOrgOption edit one organization options
 type EditOrgOption struct {
 	FullName    string `json:"full_name"`
 	Description string `json:"description"`
@@ -50,6 +56,7 @@ type EditOrgOption struct {
 	Location    string `json:"location"`
 }
 
+// EditOrg modify one organization via options
 func (c *Client) EditOrg(orgname string, opt EditOrgOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/org_member.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_member.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 )
 
+// AddOrgMembershipOption add user to organization options
 type AddOrgMembershipOption struct {
 	Role string `json:"role" binding:"Required"`
 }
 
+// AddOrgMembership add some one to an organization's member
 func (c *Client) AddOrgMembership(org, user string, opt AddOrgMembershipOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/org_team.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_team.go
@@ -4,6 +4,7 @@
 
 package gitea
 
+// Team is a sub virtual organization of one Organization
 type Team struct {
 	ID          int64  `json:"id"`
 	Name        string `json:"name"`
@@ -11,6 +12,7 @@ type Team struct {
 	Permission  string `json:"permission"`
 }
 
+// CreateTeamOption options when create team
 type CreateTeamOption struct {
 	Name        string `json:"name" binding:"Required;AlphaDashDot;MaxSize(30)"`
 	Description string `json:"description" binding:"MaxSize(255)"`

--- a/vendor/code.gitea.io/sdk/gitea/pull.go
+++ b/vendor/code.gitea.io/sdk/gitea/pull.go
@@ -5,12 +5,14 @@
 package gitea
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
-// PullRequest represents a pull reqesut API object.
+// PullRequest represents a pull request API object.
 type PullRequest struct {
-	// Copied from issue.go
 	ID        int64      `json:"id"`
 	Index     int64      `json:"number"`
 	Poster    *User      `json:"user"`
@@ -22,16 +24,109 @@ type PullRequest struct {
 	State     StateType  `json:"state"`
 	Comments  int        `json:"comments"`
 
-	HeadBranch string      `json:"head_branch"`
-	HeadRepo   *Repository `json:"head_repo"`
-	BaseBranch string      `json:"base_branch"`
-	BaseRepo   *Repository `json:"base_repo"`
+	HTMLURL  string `json:"html_url"`
+	DiffURL  string `json:"diff_url"`
+	PatchURL string `json:"patch_url"`
 
-	HTMLURL string `json:"html_url"`
-
-	Mergeable      *bool      `json:"mergeable"`
+	Mergeable      bool       `json:"mergeable"`
 	HasMerged      bool       `json:"merged"`
 	Merged         *time.Time `json:"merged_at"`
 	MergedCommitID *string    `json:"merge_commit_sha"`
 	MergedBy       *User      `json:"merged_by"`
+
+	Base      *PRBranchInfo `json:"base"`
+	Head      *PRBranchInfo `json:"head"`
+	MergeBase string        `json:"merge_base"`
+}
+
+// PRBranchInfo base branch info when send a PR
+type PRBranchInfo struct {
+	Name       string      `json:"label"`
+	Ref        string      `json:"ref"`
+	Sha        string      `json:"sha"`
+	RepoID     int64       `json:"repo_id"`
+	Repository *Repository `json:"repo"`
+}
+
+// ListPullRequestsOptions options when list PRs
+type ListPullRequestsOptions struct {
+	Page  int    `json:"page"`
+	State string `json:"state"`
+}
+
+// ListRepoPullRequests list PRs of one repository
+func (c *Client) ListRepoPullRequests(owner, repo string, opt ListPullRequestsOptions) ([]*PullRequest, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	prs := make([]*PullRequest, 0, 10)
+	return prs, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/pulls", owner, repo), jsonHeader, bytes.NewReader(body), &prs)
+}
+
+// GetPullRequest get information of one PR
+func (c *Client) GetPullRequest(owner, repo string, index int64) (*PullRequest, error) {
+	pr := new(PullRequest)
+	return pr, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, index), nil, nil, pr)
+}
+
+// CreatePullRequestOption options when creating a pull request
+type CreatePullRequestOption struct {
+	Head      string  `json:"head" binding:"Required"`
+	Base      string  `json:"base" binding:"Required"`
+	Title     string  `json:"title" binding:"Required"`
+	Body      string  `json:"body"`
+	Assignee  string  `json:"assignee"`
+	Milestone int64   `json:"milestone"`
+	Labels    []int64 `json:"labels"`
+}
+
+// CreatePullRequest create pull request with options
+func (c *Client) CreatePullRequest(owner, repo string, opt CreatePullRequestOption) (*PullRequest, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	pr := new(PullRequest)
+	return pr, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/pulls", owner, repo),
+		jsonHeader, bytes.NewReader(body), pr)
+}
+
+// EditPullRequestOption options when modify pull request
+type EditPullRequestOption struct {
+	Title     string  `json:"title"`
+	Body      string  `json:"body"`
+	Assignee  string  `json:"assignee"`
+	Milestone int64   `json:"milestone"`
+	Labels    []int64 `json:"labels"`
+	State     *string `json:"state"`
+}
+
+// EditPullRequest modify pull request with PR id and options
+func (c *Client) EditPullRequest(owner, repo string, index int64, opt EditPullRequestOption) (*PullRequest, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	pr := new(PullRequest)
+	return pr, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), pr)
+}
+
+// MergePullRequest merge a PR to repository by PR id
+func (c *Client) MergePullRequest(owner, repo string, index int64) error {
+	_, err := c.getResponse("POST", fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, index), nil, nil)
+	return err
+}
+
+// IsPullRequestMerged test if one PR is merged to one repository
+func (c *Client) IsPullRequestMerged(owner, repo string, index int64) (bool, error) {
+	statusCode, err := c.getStatusCode("GET", fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, index), nil, nil)
+
+	if err != nil {
+		return false, err
+	}
+
+	return statusCode == 204, nil
+
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo.go
@@ -47,16 +47,19 @@ func (c *Client) ListMyRepos() ([]*Repository, error) {
 	return repos, c.getParsedResponse("GET", "/user/repos", nil, nil, &repos)
 }
 
+// ListUserRepos list all repositories of one user by user's name
 func (c *Client) ListUserRepos(user string) ([]*Repository, error) {
 	repos := make([]*Repository, 0, 10)
 	return repos, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/repos", user), nil, nil, &repos)
 }
 
+// ListOrgRepos list all repositories of one organization by organization's name
 func (c *Client) ListOrgRepos(org string) ([]*Repository, error) {
 	repos := make([]*Repository, 0, 10)
 	return repos, c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s/repos", org), nil, nil, &repos)
 }
 
+// CreateRepoOption options when creating repository
 type CreateRepoOption struct {
 	Name        string `json:"name" binding:"Required;AlphaDashDot;MaxSize(100)"`
 	Description string `json:"description" binding:"MaxSize(255)"`
@@ -99,6 +102,7 @@ func (c *Client) DeleteRepo(owner, repo string) error {
 	return err
 }
 
+// MigrateRepoOption options when migrate repository from an external place
 type MigrateRepoOption struct {
 	CloneAddr    string `json:"clone_addr" binding:"Required"`
 	AuthUsername string `json:"auth_username"`

--- a/vendor/code.gitea.io/sdk/gitea/repo_branch.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_branch.go
@@ -14,11 +14,13 @@ type Branch struct {
 	Commit *PayloadCommit `json:"commit"`
 }
 
+// ListRepoBranches list all the branches of one repository
 func (c *Client) ListRepoBranches(user, repo string) ([]*Branch, error) {
 	branches := make([]*Branch, 0, 10)
 	return branches, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/branches", user, repo), nil, nil, &branches)
 }
 
+// GetRepoBranch get one branch's information of one repository
 func (c *Client) GetRepoBranch(user, repo, branch string) (*Branch, error) {
 	b := new(Branch)
 	return b, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/branches/%s", user, repo, branch), nil, nil, &b)

--- a/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 )
 
+// AddCollaboratorOption options when add some user as a collaborator of a repository
 type AddCollaboratorOption struct {
 	Permission *string `json:"permission"`
 }
 
+// AddCollaborator add some user as a collaborator of a repository
 func (c *Client) AddCollaborator(user, repo, collaborator string, opt AddCollaboratorOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/repo_hook.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_hook.go
@@ -14,9 +14,11 @@ import (
 )
 
 var (
+	// ErrInvalidReceiveHook FIXME
 	ErrInvalidReceiveHook = errors.New("Invalid JSON payload received over webhook")
 )
 
+// Hook a hook is a web hook when one repository changed
 type Hook struct {
 	ID      int64             `json:"id"`
 	Type    string            `json:"type"`
@@ -28,11 +30,13 @@ type Hook struct {
 	Created time.Time         `json:"created_at"`
 }
 
+// ListRepoHooks list all the hooks of one repository
 func (c *Client) ListRepoHooks(user, repo string) ([]*Hook, error) {
 	hooks := make([]*Hook, 0, 10)
 	return hooks, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/hooks", user, repo), nil, nil, &hooks)
 }
 
+// CreateHookOption options when create a hook
 type CreateHookOption struct {
 	Type   string            `json:"type" binding:"Required"`
 	Config map[string]string `json:"config" binding:"Required"`
@@ -40,6 +44,7 @@ type CreateHookOption struct {
 	Active bool              `json:"active"`
 }
 
+// CreateRepoHook create one hook with options
 func (c *Client) CreateRepoHook(user, repo string, opt CreateHookOption) (*Hook, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -49,12 +54,14 @@ func (c *Client) CreateRepoHook(user, repo string, opt CreateHookOption) (*Hook,
 	return h, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/hooks", user, repo), jsonHeader, bytes.NewReader(body), h)
 }
 
+// EditHookOption options when modify one hook
 type EditHookOption struct {
 	Config map[string]string `json:"config"`
 	Events []string          `json:"events"`
 	Active *bool             `json:"active"`
 }
 
+// EditRepoHook modify one hook with hook id and options
 func (c *Client) EditRepoHook(user, repo string, id int64, opt EditHookOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -64,23 +71,26 @@ func (c *Client) EditRepoHook(user, repo string, id int64, opt EditHookOption) e
 	return err
 }
 
+// DeleteRepoHook delete one hook with hook id
 func (c *Client) DeleteRepoHook(user, repo string, id int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), nil, nil)
 	return err
 }
 
+// Payloader payload is some part of one hook
 type Payloader interface {
 	SetSecret(string)
 	JSONPayload() ([]byte, error)
 }
 
+// PayloadUser FIXME
 type PayloadUser struct {
 	Name     string `json:"name"`
 	Email    string `json:"email"`
 	UserName string `json:"username"`
 }
 
-// FIXME: consider use same format as API when commits API are added.
+// PayloadCommit FIXME: consider use same format as API when commits API are added.
 type PayloadCommit struct {
 	ID        string       `json:"id"`
 	Message   string       `json:"message"`
@@ -103,18 +113,22 @@ var (
 //  \______  /|__|    \___  >____  /__|  \___  >
 //         \/             \/     \/          \/
 
+// CreatePayload FIXME
 type CreatePayload struct {
 	Secret  string      `json:"secret"`
+	Sha     string      `json:"sha"`
 	Ref     string      `json:"ref"`
 	RefType string      `json:"ref_type"`
 	Repo    *Repository `json:"repository"`
 	Sender  *User       `json:"sender"`
 }
 
+// SetSecret FIXME
 func (p *CreatePayload) SetSecret(secret string) {
 	p.Secret = secret
 }
 
+// JSONPayload return payload information
 func (p *CreatePayload) JSONPayload() ([]byte, error) {
 	return json.MarshalIndent(p, "", "  ")
 }
@@ -159,10 +173,12 @@ type PushPayload struct {
 	Sender     *User            `json:"sender"`
 }
 
+// SetSecret FIXME
 func (p *PushPayload) SetSecret(secret string) {
 	p.Secret = secret
 }
 
+// JSONPayload FIXME
 func (p *PushPayload) JSONPayload() ([]byte, error) {
 	return json.MarshalIndent(p, "", "  ")
 }
@@ -195,24 +211,36 @@ func (p *PushPayload) Branch() string {
 // |___/____  >____  >____/  \___  >
 //          \/     \/            \/
 
+// HookIssueAction FIXME
 type HookIssueAction string
 
 const (
-	HookIssueOpened        HookIssueAction = "opened"
-	HookIssueClosed        HookIssueAction = "closed"
-	HookIssueReopened      HookIssueAction = "reopened"
-	HookIssueEdited        HookIssueAction = "edited"
-	HookIssueAssigned      HookIssueAction = "assigned"
-	HookIssueUnassigned    HookIssueAction = "unassigned"
+	// HookIssueOpened opened
+	HookIssueOpened HookIssueAction = "opened"
+	// HookIssueClosed closed
+	HookIssueClosed HookIssueAction = "closed"
+	// HookIssueReOpened reopened
+	HookIssueReOpened HookIssueAction = "reopened"
+	// HookIssueEdited edited
+	HookIssueEdited HookIssueAction = "edited"
+	// HookIssueAssigned assigned
+	HookIssueAssigned HookIssueAction = "assigned"
+	// HookIssueUnassigned unassigned
+	HookIssueUnassigned HookIssueAction = "unassigned"
+	// HookIssueLabelUpdated label_updated
 	HookIssueLabelUpdated HookIssueAction = "label_updated"
+	// HookIssueLabelCleared label_cleared
 	HookIssueLabelCleared HookIssueAction = "label_cleared"
-	HookIssueSynchronized  HookIssueAction = "synchronized"
+	// HookIssueSynchronized synchronized
+	HookIssueSynchronized HookIssueAction = "synchronized"
 )
 
+// ChangesFromPayload FIXME
 type ChangesFromPayload struct {
 	From string `json:"from"`
 }
 
+// ChangesPayload FIXME
 type ChangesPayload struct {
 	Title *ChangesFromPayload `json:"title,omitempty"`
 	Body  *ChangesFromPayload `json:"body,omitempty"`
@@ -236,10 +264,12 @@ type PullRequestPayload struct {
 	Sender      *User           `json:"sender"`
 }
 
+// SetSecret FIXME
 func (p *PullRequestPayload) SetSecret(secret string) {
 	p.Secret = secret
 }
 
+// JSONPayload FIXME
 func (p *PullRequestPayload) JSONPayload() ([]byte, error) {
 	return json.MarshalIndent(p, "", "  ")
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_key.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// DeployKey a deploy key
 type DeployKey struct {
 	ID       int64     `json:"id"`
 	Key      string    `json:"key"`
@@ -20,21 +21,25 @@ type DeployKey struct {
 	ReadOnly bool      `json:"read_only"`
 }
 
+// ListDeployKeys list all the deploy keys of one repository
 func (c *Client) ListDeployKeys(user, repo string) ([]*DeployKey, error) {
 	keys := make([]*DeployKey, 0, 10)
 	return keys, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/keys", user, repo), nil, nil, &keys)
 }
 
+// GetDeployKey get one deploy key with key id
 func (c *Client) GetDeployKey(user, repo string, keyID int64) (*DeployKey, error) {
 	key := new(DeployKey)
 	return key, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/keys/%d", user, repo, keyID), nil, nil, &key)
 }
 
+// CreateKeyOption options when create deploy key
 type CreateKeyOption struct {
 	Title string `json:"title" binding:"Required"`
 	Key   string `json:"key" binding:"Required"`
 }
 
+// CreateDeployKey options when create one deploy key
 func (c *Client) CreateDeployKey(user, repo string, opt CreateKeyOption) (*DeployKey, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -44,6 +49,7 @@ func (c *Client) CreateDeployKey(user, repo string, opt CreateKeyOption) (*Deplo
 	return key, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/keys", user, repo), jsonHeader, bytes.NewReader(body), key)
 }
 
+// DeleteDeployKey delete deploy key with key id
 func (c *Client) DeleteDeployKey(owner, repo string, keyID int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/keys/%d", owner, repo, keyID), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/user.go
+++ b/vendor/code.gitea.io/sdk/gitea/user.go
@@ -11,12 +11,13 @@ import (
 // User represents a API user.
 type User struct {
 	ID        int64  `json:"id"`
-	UserName  string `json:"username"`
+	UserName  string `json:"login"`
 	FullName  string `json:"full_name"`
 	Email     string `json:"email"`
-	AvatarUrl string `json:"avatar_url"`
+	AvatarURL string `json:"avatar_url"`
 }
 
+// GetUserInfo get user info by user's name
 func (c *Client) GetUserInfo(user string) (*User, error) {
 	u := new(User)
 	err := c.getParsedResponse("GET", fmt.Sprintf("/users/%s", user), nil, nil, u)

--- a/vendor/code.gitea.io/sdk/gitea/user_app.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_app.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 )
 
+// BasicAuthEncode generate base64 of basic auth head
 func BasicAuthEncode(user, pass string) string {
 	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
 }
@@ -22,16 +23,19 @@ type AccessToken struct {
 	Sha1 string `json:"sha1"`
 }
 
+// ListAccessTokens lista all the access tokens of user
 func (c *Client) ListAccessTokens(user, pass string) ([]*AccessToken, error) {
 	tokens := make([]*AccessToken, 0, 10)
 	return tokens, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/tokens", user),
 		http.Header{"Authorization": []string{"Basic " + BasicAuthEncode(user, pass)}}, nil, &tokens)
 }
 
+// CreateAccessTokenOption options when create access token
 type CreateAccessTokenOption struct {
 	Name string `json:"name" binding:"Required"`
 }
 
+// CreateAccessToken create one access token with options
 func (c *Client) CreateAccessToken(user, pass string, opt CreateAccessTokenOption) (*AccessToken, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/user_email.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_email.go
@@ -9,21 +9,25 @@ import (
 	"encoding/json"
 )
 
+// Email en email information of user
 type Email struct {
 	Email    string `json:"email"`
 	Verified bool   `json:"verified"`
 	Primary  bool   `json:"primary"`
 }
 
+// ListEmails all the email addresses of user
 func (c *Client) ListEmails() ([]*Email, error) {
 	emails := make([]*Email, 0, 3)
 	return emails, c.getParsedResponse("GET", "/user/emails", nil, nil, &emails)
 }
 
+// CreateEmailOption options when create an email
 type CreateEmailOption struct {
 	Emails []string `json:"emails"`
 }
 
+// AddEmail add one email to current user with options
 func (c *Client) AddEmail(opt CreateEmailOption) ([]*Email, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -33,6 +37,7 @@ func (c *Client) AddEmail(opt CreateEmailOption) ([]*Email, error) {
 	return emails, c.getParsedResponse("POST", "/user/emails", jsonHeader, bytes.NewReader(body), emails)
 }
 
+// DeleteEmail delete one email of current users'
 func (c *Client) DeleteEmail(opt CreateEmailOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {

--- a/vendor/code.gitea.io/sdk/gitea/user_follow.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_follow.go
@@ -6,41 +6,49 @@ package gitea
 
 import "fmt"
 
+// ListMyFollowers list all the followers of current user
 func (c *Client) ListMyFollowers(page int) ([]*User, error) {
 	users := make([]*User, 0, 10)
 	return users, c.getParsedResponse("GET", fmt.Sprintf("/user/followers?page=%d", page), nil, nil, &users)
 }
 
+// ListFollowers list all the followers of one user
 func (c *Client) ListFollowers(user string, page int) ([]*User, error) {
 	users := make([]*User, 0, 10)
 	return users, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/followers?page=%d", user, page), nil, nil, &users)
 }
 
+// ListMyFollowing list all the users current user followed
 func (c *Client) ListMyFollowing(page int) ([]*User, error) {
 	users := make([]*User, 0, 10)
 	return users, c.getParsedResponse("GET", fmt.Sprintf("/user/following?page=%d", page), nil, nil, &users)
 }
 
+// ListFollowing list all the users the user followed
 func (c *Client) ListFollowing(user string, page int) ([]*User, error) {
 	users := make([]*User, 0, 10)
 	return users, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/following?page=%d", user, page), nil, nil, &users)
 }
 
+// IsFollowing if current user followed the target
 func (c *Client) IsFollowing(target string) bool {
 	_, err := c.getResponse("GET", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return err == nil
 }
 
+// IsUserFollowing if the user followed the target
 func (c *Client) IsUserFollowing(user, target string) bool {
 	_, err := c.getResponse("GET", fmt.Sprintf("/users/%s/following/%s", user, target), nil, nil)
 	return err == nil
 }
 
+// Follow set current user follow the target
 func (c *Client) Follow(target string) error {
 	_, err := c.getResponse("PUT", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return err
 }
 
+// Unfollow set current user unfollow the target
 func (c *Client) Unfollow(target string) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/user_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_key.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// PublicKey publickey is a user key to push code to repository
 type PublicKey struct {
 	ID      int64     `json:"id"`
 	Key     string    `json:"key"`
@@ -19,21 +20,25 @@ type PublicKey struct {
 	Created time.Time `json:"created_at,omitempty"`
 }
 
+// ListPublicKeys list all the public keys of the user
 func (c *Client) ListPublicKeys(user string) ([]*PublicKey, error) {
 	keys := make([]*PublicKey, 0, 10)
 	return keys, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/keys", user), nil, nil, &keys)
 }
 
+// ListMyPublicKeys list all the public keys of current user
 func (c *Client) ListMyPublicKeys() ([]*PublicKey, error) {
 	keys := make([]*PublicKey, 0, 10)
 	return keys, c.getParsedResponse("GET", "/user/keys", nil, nil, &keys)
 }
 
+// GetPublicKey get current user's public key by key id
 func (c *Client) GetPublicKey(keyID int64) (*PublicKey, error) {
 	key := new(PublicKey)
 	return key, c.getParsedResponse("GET", fmt.Sprintf("/user/keys/%d", keyID), nil, nil, &key)
 }
 
+// CreatePublicKey create public key with options
 func (c *Client) CreatePublicKey(opt CreateKeyOption) (*PublicKey, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -43,6 +48,7 @@ func (c *Client) CreatePublicKey(opt CreateKeyOption) (*PublicKey, error) {
 	return key, c.getParsedResponse("POST", "/user/keys", jsonHeader, bytes.NewReader(body), key)
 }
 
+// DeletePublicKey delete public key with key id
 func (c *Client) DeletePublicKey(keyID int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/user/keys/%d", keyID), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/utils.go
+++ b/vendor/code.gitea.io/sdk/gitea/utils.go
@@ -10,14 +10,17 @@ import (
 
 var jsonHeader = http.Header{"content-type": []string{"application/json"}}
 
+// Bool return address of bool value
 func Bool(v bool) *bool {
 	return &v
 }
 
+// String return address of string value
 func String(v string) *string {
 	return &v
 }
 
+// Int64 return address of int64 value
 func Int64(v int64) *int64 {
 	return &v
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2016-11-13T14:20:52Z"
 		},
 		{
-			"checksumSHA1": "/uhZZppDeb3Rbp3h8C0ALR3hdrA=",
+			"checksumSHA1": "x5jr5+UwaMg861XyFWIoNzYmmMM=",
 			"path": "code.gitea.io/sdk/gitea",
-			"revision": "0a0a04ccf7a5e6b93d9a5507701635330cf4579c",
-			"revisionTime": "2016-11-07T15:06:50Z"
+			"revision": "140df7f34c05d0d7e5b03c2b4a7d38690b3a5152",
+			"revisionTime": "2016-11-29T07:37:12Z"
 		},
 		{
 			"checksumSHA1": "IyfS7Rbl6OgR83QR7TOfKdDCq+M=",


### PR DESCRIPTION
Fixes #286 
Depends on go-gitea/go-sdk#21 ~(**Don't merge** before I've vendored it!)~

Tag-hooks are pretty useless without specifying which shasum the new tag points at, this PR fixes that :)

Question: ~Should we also send the Shasum for "create branch"-events? (need to add another line in that case ^.^ )~ Yes