### PR TITLE
export pusher name ENV variable #316

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -256,7 +256,11 @@ func runServ(c *cli.Context) error {
 		}
 	}
 
+	os.Setenv("GITEA_PUSHER_NAME", user.Name)
+
 	uuid := gouuid.NewV4().String()
+	os.Setenv("GITEA_UUID", uuid)
+	// Keep the old env variable name for backward compability
 	os.Setenv("uuid", uuid)
 
 	// Special handle for Windows.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,7 +49,7 @@ func runUpdate(c *cli.Context) error {
 	}
 
 	task := models.UpdateTask{
-		UUID:        os.Getenv("uuid"),
+		UUID:        os.Getenv("GITEA_UUID"),
 		RefName:     args[0],
 		OldCommitID: args[1],
 		NewCommitID: args[2],


### PR DESCRIPTION
This change will export the name of the pusher as an environment variable in order to use it in custom hooks.