### PR TITLE
Fix regression in #248

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -121,12 +121,30 @@ func (pr *PullRequest) LoadIssue() (err error) {
 // Required - Issue
 // Optional - Merger
 func (pr *PullRequest) APIFormat() *api.PullRequest {
-
+	var (
+		baseBranch *Branch
+		headBranch *Branch
+		baseCommit *git.Commit
+		headCommit *git.Commit
+		err        error
+	)
 	apiIssue := pr.Issue.APIFormat()
-	baseBranch, _ := pr.BaseRepo.GetBranch(pr.BaseBranch)
-	baseCommit, _ := baseBranch.GetCommit()
-	headBranch, _ := pr.HeadRepo.GetBranch(pr.HeadBranch)
-	headCommit, _ := headBranch.GetCommit()
+	if pr.BaseRepo == nil || pr.HeadRepo == nil {
+		log.Critical(log.CRITICAL, "Base/HeadRepo not set for PR!!!")
+		return nil
+	}
+	if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {
+		return nil
+	}
+	if baseCommit, err = baseBranch.GetCommit(); err != nil {
+		return nil
+	}
+	if headBranch, err = pr.HeadRepo.GetBranch(pr.HeadBranch); err != nil {
+		return nil
+	}
+	if headCommit, err = headBranch.GetCommit(); err != nil {
+		return nil
+	}
 	apiBaseBranchInfo := &api.PRBranchInfo{
 		Name:       pr.BaseBranch,
 		Ref:        pr.BaseBranch,
@@ -590,8 +608,12 @@ func GetPullRequestByIndex(repoID int64, index int64) (*PullRequest, error) {
 		return nil, ErrPullRequestNotExist{0, repoID, index, 0, "", ""}
 	}
 
-	pr.LoadAttributes()
-	pr.LoadIssue()
+	if err = pr.LoadAttributes(); err != nil {
+		return nil, err
+	}
+	if err = pr.LoadIssue(); err != nil {
+		return nil, err
+	}
 
 	return pr, nil
 }

--- a/models/pull.go
+++ b/models/pull.go
@@ -129,9 +129,19 @@ func (pr *PullRequest) APIFormat() *api.PullRequest {
 		err        error
 	)
 	apiIssue := pr.Issue.APIFormat()
-	if pr.BaseRepo == nil || pr.HeadRepo == nil {
-		log.Critical(log.CRITICAL, "Base/HeadRepo not set for PR!!!")
-		return nil
+	if pr.BaseRepo == nil {
+		pr.BaseRepo, err = GetRepositoryByID(pr.BaseRepoID)
+		if err != nil {
+			log.Error(log.ERROR, "BaseRepo not set for PR %d", pr.ID)
+			return nil
+		}
+	}
+	if pr.HeadRepo == nil {
+		pr.HeadRepo, err = GetRepositoryByID(pr.HeadRepoID)
+		if err != nil {
+			log.Error(log.ERROR, "HeadRepo not set for PR %d", pr.ID)
+			return nil
+		}
 	}
 	if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {
 		return nil

--- a/models/pull.go
+++ b/models/pull.go
@@ -132,14 +132,14 @@ func (pr *PullRequest) APIFormat() *api.PullRequest {
 	if pr.BaseRepo == nil {
 		pr.BaseRepo, err = GetRepositoryByID(pr.BaseRepoID)
 		if err != nil {
-			log.Error(log.ERROR, "BaseRepo not set for PR %d", pr.ID)
+			log.Error(log.ERROR, "GetRepositoryById[%d]: %v", pr.ID, err)
 			return nil
 		}
 	}
 	if pr.HeadRepo == nil {
 		pr.HeadRepo, err = GetRepositoryByID(pr.HeadRepoID)
 		if err != nil {
-			log.Error(log.ERROR, "HeadRepo not set for PR %d", pr.ID)
+			log.Error(log.ERROR, "GetRepositoryById[%d]: %v", pr.ID, err)
 			return nil
 		}
 	}


### PR DESCRIPTION
This fixes a regression in #248 where Closing a PR in the WebUI make gitea throw a panic.

Closes #344 

It fixes the problem, PRs can now be closed in WebUI, ~but it still spits out error-logs in the console...~ Doesn't do this anymore since I'm _actually_ populating the Head/BaseRepo now 😈 

```
Started POST /toor/foobar/issues/1/comments for [::1]
[D] Session ID: 6aa78f141f0be42a
[D] CSRF Token: EVvkiIBTdh2Js1LIMFOoBLjP84s6MTQ4MDkyNzI1MTYxMjU2ODk0Mw==
[T] Issue [1] status changed to closed: true
[T] DeliverHooks [repo_id: 1]
Completed /toor/foobar/issues/1/comments 302 Found in 36.378904ms

Started GET /toor/foobar/pulls/1 for [::1]
[D] Session ID: 6aa78f141f0be42a
[D] CSRF Token: EVvkiIBTdh2Js1LIMFOoBLjP84s6MTQ4MDkyNzI1MTYxMjU2ODk0Mw==
[D] Template: repo/issue/view
Completed /toor/foobar/pulls/1 200 OK in 57.302163ms
```