### PR TITLE
Always build, even when it's up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ install: $(wildcard *.go)
 .PHONY: build
 build: $(EXECUTABLE)
 
+.PHONY: $(EXECUTABLE)
 $(EXECUTABLE): $(wildcard *.go)
 	go build -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 


### PR DESCRIPTION
Currently `make build` was to be preceded with `make clean` otherwise it won't build. This is because of how make works internally so AFAIK nothing can be done about that 😒 

This PR "fixes" it by ignoring the fact that it's built and always builds