### PR TITLE
Bug fix for edit-hook API endpoint

### DIFF
--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -102,7 +102,8 @@ func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
 // EditHook modify a hook of a repository
 // see https://github.com/gogits/go-gogs-client/wiki/Repositories#edit-a-hook
 func EditHook(ctx *context.APIContext, form api.EditHookOption) {
-	w, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, ctx.ParamsInt64(":id"))
+	hookID := ctx.ParamsInt64(":id")
+	w, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, hookID)
 	if err != nil {
 		if models.IsErrWebhookNotExist(err) {
 			ctx.Status(404)
@@ -165,7 +166,12 @@ func EditHook(ctx *context.APIContext, form api.EditHookOption) {
 		return
 	}
 
-	ctx.JSON(200, convert.ToHook(ctx.Repo.RepoLink, w))
+	updated, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, hookID)
+	if err != nil {
+		ctx.Error(500, "GetWebhookByRepoID", err)
+		return
+	}
+	ctx.JSON(200, convert.ToHook(ctx.Repo.RepoLink, updated))
 }
 
 // DeleteHook delete a hook of a repository


### PR DESCRIPTION
This fixes a bug in the `PATCH /repos/:ownername/:reponame/hooks/:id` API endpoint. Previously the response contained old information about the webhook; for instance, if a webhook had a url of `urlA`, and I made a request to update the url to `urlB`, the returned JSON object previously would have a `"url"` field of `urlA`, not `urlB`. 

Now the response contains the updated information (e.g. `urlB`).

I wasn't able to figure out a way to fix this without doing another call to `models.GetWebhookByRepoID`; if you find a way to avoid the second call, please let me know!