### PR TITLE
Organziation webhook API endpoints

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -266,7 +266,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 				m.Group("/hooks", func() {
 					m.Combo("").Get(repo.ListHooks).
 						Post(bind(api.CreateHookOption{}), repo.CreateHook)
-					m.Combo("/:id").Patch(bind(api.EditHookOption{}), repo.EditHook).
+					m.Combo("/:id").Get(repo.GetHook).
+						Patch(bind(api.EditHookOption{}), repo.EditHook).
 						Delete(repo.DeleteHook)
 				})
 				m.Put("/collaborators/:collaborator", bind(api.AddCollaboratorOption{}), repo.AddCollaborator)
@@ -343,6 +344,13 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Group("/orgs/:orgname", func() {
 			m.Combo("").Get(org.Get).Patch(bind(api.EditOrgOption{}), org.Edit)
 			m.Combo("/teams").Get(org.ListTeams)
+			m.Group("/hooks", func() {
+				m.Combo("").Get(org.ListHooks).
+					Post(bind(api.CreateHookOption{}), org.CreateHook)
+				m.Combo("/:id").Get(org.GetHook).
+					Patch(bind(api.EditHookOption{}), org.EditHook).
+					Delete(org.DeleteHook)
+			})
 		}, orgAssignment(true))
 
 		m.Any("/*", func(ctx *context.Context) {

--- a/routers/api/v1/org/hook.go
+++ b/routers/api/v1/org/hook.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package org
+
+import (
+	api "code.gitea.io/sdk/gitea"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/routers/api/v1/convert"
+	"code.gitea.io/gitea/routers/api/v1/utils"
+)
+
+// ListHooks list an organziation's webhooks
+func ListHooks(ctx *context.APIContext) {
+	org := ctx.Org.Organization
+	orgHooks, err := models.GetWebhooksByOrgID(org.ID)
+	if err != nil {
+		ctx.Error(500, "GetWebhooksByOrgID", err)
+		return
+	}
+	hooks := make([]*api.Hook, len(orgHooks))
+	for i, hook := range orgHooks {
+		hooks[i] = convert.ToHook(org.HomeLink(), hook)
+	}
+	ctx.JSON(200, hooks)
+}
+
+// GetHook get an organization's hook by id
+func GetHook(ctx *context.APIContext) {
+	org := ctx.Org.Organization
+	hookID := ctx.ParamsInt64(":id")
+	hook, err := utils.GetOrgHook(ctx, org.ID, hookID)
+	if err != nil {
+		return
+	}
+	ctx.JSON(200, convert.ToHook(org.HomeLink(), hook))
+}
+
+// CreateHook create a hook for an organization
+func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
+	if !utils.CheckCreateHookOption(ctx, &form) {
+		return
+	}
+	utils.AddOrgHook(ctx, &form)
+}
+
+// EditHook modify a hook of a repository
+func EditHook(ctx *context.APIContext, form api.EditHookOption) {
+	hookID := ctx.ParamsInt64(":id")
+	utils.EditOrgHook(ctx, &form, hookID)
+}
+
+// DeleteHook delete a hook of an organization
+func DeleteHook(ctx *context.APIContext) {
+	org := ctx.Org.Organization
+	hookID := ctx.ParamsInt64(":id")
+	if err := models.DeleteWebhookByOrgID(org.ID, hookID); err != nil {
+		ctx.Error(500, "DeleteWebhookByOrgID", err)
+		return
+	}
+	ctx.Status(204)
+}

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -5,15 +5,12 @@
 package repo
 
 import (
-	"encoding/json"
-
-	"github.com/Unknwon/com"
-
 	api "code.gitea.io/sdk/gitea"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/routers/api/v1/convert"
+	"code.gitea.io/gitea/routers/api/v1/utils"
 )
 
 // ListHooks list all hooks of a repository
@@ -32,146 +29,31 @@ func ListHooks(ctx *context.APIContext) {
 	ctx.JSON(200, &apiHooks)
 }
 
+// GetHook get a repo's hook by id
+func GetHook(ctx *context.APIContext) {
+	repo := ctx.Repo
+	hookID := ctx.ParamsInt64(":id")
+	hook, err := utils.GetRepoHook(ctx, repo.Repository.ID, hookID)
+	if err != nil {
+		return
+	}
+	ctx.JSON(200, convert.ToHook(repo.RepoLink, hook))
+}
+
 // CreateHook create a hook for a repository
 // see https://github.com/gogits/go-gogs-client/wiki/Repositories#create-a-hook
 func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
-	if !models.IsValidHookTaskType(form.Type) {
-		ctx.Error(422, "", "Invalid hook type")
+	if !utils.CheckCreateHookOption(ctx, &form) {
 		return
 	}
-	for _, name := range []string{"url", "content_type"} {
-		if _, ok := form.Config[name]; !ok {
-			ctx.Error(422, "", "Missing config option: "+name)
-			return
-		}
-	}
-	if !models.IsValidHookContentType(form.Config["content_type"]) {
-		ctx.Error(422, "", "Invalid content type")
-		return
-	}
-
-	if len(form.Events) == 0 {
-		form.Events = []string{"push"}
-	}
-	w := &models.Webhook{
-		RepoID:      ctx.Repo.Repository.ID,
-		URL:         form.Config["url"],
-		ContentType: models.ToHookContentType(form.Config["content_type"]),
-		Secret:      form.Config["secret"],
-		HookEvent: &models.HookEvent{
-			ChooseEvents: true,
-			HookEvents: models.HookEvents{
-				Create:      com.IsSliceContainsStr(form.Events, string(models.HookEventCreate)),
-				Push:        com.IsSliceContainsStr(form.Events, string(models.HookEventPush)),
-				PullRequest: com.IsSliceContainsStr(form.Events, string(models.HookEventPullRequest)),
-			},
-		},
-		IsActive:     form.Active,
-		HookTaskType: models.ToHookTaskType(form.Type),
-	}
-	if w.HookTaskType == models.SLACK {
-		channel, ok := form.Config["channel"]
-		if !ok {
-			ctx.Error(422, "", "Missing config option: channel")
-			return
-		}
-		meta, err := json.Marshal(&models.SlackMeta{
-			Channel:  channel,
-			Username: form.Config["username"],
-			IconURL:  form.Config["icon_url"],
-			Color:    form.Config["color"],
-		})
-		if err != nil {
-			ctx.Error(500, "slack: JSON marshal failed", err)
-			return
-		}
-		w.Meta = string(meta)
-	}
-
-	if err := w.UpdateEvent(); err != nil {
-		ctx.Error(500, "UpdateEvent", err)
-		return
-	} else if err := models.CreateWebhook(w); err != nil {
-		ctx.Error(500, "CreateWebhook", err)
-		return
-	}
-
-	ctx.JSON(201, convert.ToHook(ctx.Repo.RepoLink, w))
+	utils.AddRepoHook(ctx, &form)
 }
 
 // EditHook modify a hook of a repository
 // see https://github.com/gogits/go-gogs-client/wiki/Repositories#edit-a-hook
 func EditHook(ctx *context.APIContext, form api.EditHookOption) {
 	hookID := ctx.ParamsInt64(":id")
-	w, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, hookID)
-	if err != nil {
-		if models.IsErrWebhookNotExist(err) {
-			ctx.Status(404)
-		} else {
-			ctx.Error(500, "GetWebhookByID", err)
-		}
-		return
-	}
-
-	if form.Config != nil {
-		if url, ok := form.Config["url"]; ok {
-			w.URL = url
-		}
-		if ct, ok := form.Config["content_type"]; ok {
-			if !models.IsValidHookContentType(ct) {
-				ctx.Error(422, "", "Invalid content type")
-				return
-			}
-			w.ContentType = models.ToHookContentType(ct)
-		}
-
-		if w.HookTaskType == models.SLACK {
-			if channel, ok := form.Config["channel"]; ok {
-				meta, err := json.Marshal(&models.SlackMeta{
-					Channel:  channel,
-					Username: form.Config["username"],
-					IconURL:  form.Config["icon_url"],
-					Color:    form.Config["color"],
-				})
-				if err != nil {
-					ctx.Error(500, "slack: JSON marshal failed", err)
-					return
-				}
-				w.Meta = string(meta)
-			}
-		}
-	}
-
-	// Update events
-	if len(form.Events) == 0 {
-		form.Events = []string{"push"}
-	}
-	w.PushOnly = false
-	w.SendEverything = false
-	w.ChooseEvents = true
-	w.Create = com.IsSliceContainsStr(form.Events, string(models.HookEventCreate))
-	w.Push = com.IsSliceContainsStr(form.Events, string(models.HookEventPush))
-	w.PullRequest = com.IsSliceContainsStr(form.Events, string(models.HookEventPullRequest))
-	if err = w.UpdateEvent(); err != nil {
-		ctx.Error(500, "UpdateEvent", err)
-		return
-	}
-
-	if form.Active != nil {
-		w.IsActive = *form.Active
-	}
-
-	if err := models.UpdateWebhook(w); err != nil {
-		ctx.Error(500, "UpdateWebhook", err)
-		return
-	}
-
-	updated, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, hookID)
-	if err != nil {
-		ctx.Error(500, "GetWebhookByRepoID", err)
-		return
-	}
-	ctx.JSON(200, convert.ToHook(ctx.Repo.RepoLink, updated))
+	utils.EditRepoHook(ctx, &form, hookID)
 }
 
 // DeleteHook delete a hook of a repository

--- a/routers/api/v1/utils/hook.go
+++ b/routers/api/v1/utils/hook.go
@@ -1,0 +1,227 @@
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package utils
+
+import (
+	api "code.gitea.io/sdk/gitea"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/routers/api/v1/convert"
+	"encoding/json"
+	"github.com/Unknwon/com"
+)
+
+// GetOrgHook get an organization's webhook. If there is an error, write to
+// `ctx` accordingly and return the error
+func GetOrgHook(ctx *context.APIContext, orgID, hookID int64) (*models.Webhook, error) {
+	w, err := models.GetWebhookByOrgID(orgID, hookID)
+	if err != nil {
+		if models.IsErrWebhookNotExist(err) {
+			ctx.Status(404)
+		} else {
+			ctx.Error(500, "GetWebhookByOrgID", err)
+		}
+		return nil, err
+	}
+	return w, nil
+}
+
+// GetRepoHook get a repo's webhook. If there is an error, write to `ctx`
+// accordingly and return the error
+func GetRepoHook(ctx *context.APIContext, repoID, hookID int64) (*models.Webhook, error) {
+	w, err := models.GetWebhookByRepoID(repoID, hookID)
+	if err != nil {
+		if models.IsErrWebhookNotExist(err) {
+			ctx.Status(404)
+		} else {
+			ctx.Error(500, "GetWebhookByID", err)
+		}
+		return nil, err
+	}
+	return w, nil
+}
+
+// CheckCreateHookOption check if a CreateHookOption form is valid. If invalid,
+// write the appropriate error to `ctx`. Return whether the form is valid
+func CheckCreateHookOption(ctx *context.APIContext, form *api.CreateHookOption) bool {
+	if !models.IsValidHookTaskType(form.Type) {
+		ctx.Error(422, "", "Invalid hook type")
+		return false
+	}
+	for _, name := range []string{"url", "content_type"} {
+		if _, ok := form.Config[name]; !ok {
+			ctx.Error(422, "", "Missing config option: "+name)
+			return false
+		}
+	}
+	if !models.IsValidHookContentType(form.Config["content_type"]) {
+		ctx.Error(422, "", "Invalid content type")
+		return false
+	}
+	return true
+}
+
+// AddOrgHook add a hook to an organization. Writes to `ctx` accordingly
+func AddOrgHook(ctx *context.APIContext, form *api.CreateHookOption) {
+	org := ctx.Org.Organization
+	hook, ok := addHook(ctx, form, org.ID, 0)
+	if ok {
+		ctx.JSON(200, convert.ToHook(org.HomeLink(), hook))
+	}
+}
+
+// AddRepoHook add a hook to a repo. Writes to `ctx` accordingly
+func AddRepoHook(ctx *context.APIContext, form *api.CreateHookOption) {
+	repo := ctx.Repo
+	hook, ok := addHook(ctx, form, 0, repo.Repository.ID)
+	if ok {
+		ctx.JSON(200, convert.ToHook(repo.RepoLink, hook))
+	}
+}
+
+// addHook add the hook specified by `form`, `orgID` and `repoID`. If there is
+// an error, write to `ctx` accordingly. Return (webhook, ok)
+func addHook(ctx *context.APIContext, form *api.CreateHookOption, orgID, repoID int64) (*models.Webhook, bool) {
+	if len(form.Events) == 0 {
+		form.Events = []string{"push"}
+	}
+	w := &models.Webhook{
+		OrgID:       orgID,
+		RepoID:      repoID,
+		URL:         form.Config["url"],
+		ContentType: models.ToHookContentType(form.Config["content_type"]),
+		Secret:      form.Config["secret"],
+		HookEvent: &models.HookEvent{
+			ChooseEvents: true,
+			HookEvents: models.HookEvents{
+				Create:      com.IsSliceContainsStr(form.Events, string(models.HookEventCreate)),
+				Push:        com.IsSliceContainsStr(form.Events, string(models.HookEventPush)),
+				PullRequest: com.IsSliceContainsStr(form.Events, string(models.HookEventPullRequest)),
+			},
+		},
+		IsActive:     form.Active,
+		HookTaskType: models.ToHookTaskType(form.Type),
+	}
+	if w.HookTaskType == models.SLACK {
+		channel, ok := form.Config["channel"]
+		if !ok {
+			ctx.Error(422, "", "Missing config option: channel")
+			return nil, false
+		}
+		meta, err := json.Marshal(&models.SlackMeta{
+			Channel:  channel,
+			Username: form.Config["username"],
+			IconURL:  form.Config["icon_url"],
+			Color:    form.Config["color"],
+		})
+		if err != nil {
+			ctx.Error(500, "slack: JSON marshal failed", err)
+			return nil, false
+		}
+		w.Meta = string(meta)
+	}
+
+	if err := w.UpdateEvent(); err != nil {
+		ctx.Error(500, "UpdateEvent", err)
+		return nil, false
+	} else if err := models.CreateWebhook(w); err != nil {
+		ctx.Error(500, "CreateWebhook", err)
+		return nil, false
+	}
+	return w, true
+}
+
+// EditOrgHook edit webhook `w` according to `form`. Writes to `ctx` accordingly
+func EditOrgHook(ctx *context.APIContext, form *api.EditHookOption, hookID int64) {
+	org := ctx.Org.Organization
+	hook, err := GetOrgHook(ctx, org.ID, hookID)
+	if err != nil {
+		return
+	}
+	if !editHook(ctx, form, hook) {
+		return
+	}
+	updated, err := GetOrgHook(ctx, org.ID, hookID)
+	if err != nil {
+		return
+	}
+	ctx.JSON(200, convert.ToHook(org.HomeLink(), updated))
+}
+
+// EditRepoHook edit webhook `w` according to `form`. Writes to `ctx` accordingly
+func EditRepoHook(ctx *context.APIContext, form *api.EditHookOption, hookID int64) {
+	repo := ctx.Repo
+	hook, err := GetRepoHook(ctx, repo.Repository.ID, hookID)
+	if err != nil {
+		return
+	}
+	if !editHook(ctx, form, hook) {
+		return
+	}
+	updated, err := GetRepoHook(ctx, repo.Repository.ID, hookID)
+	if err != nil {
+		return
+	}
+	ctx.JSON(200, convert.ToHook(repo.RepoLink, updated))
+}
+
+// editHook edit the webhook `w` according to `form`. If an error occurs, write
+// to `ctx` accordingly and return the error. Return whether successful
+func editHook(ctx *context.APIContext, form *api.EditHookOption, w *models.Webhook) bool {
+	if form.Config != nil {
+		if url, ok := form.Config["url"]; ok {
+			w.URL = url
+		}
+		if ct, ok := form.Config["content_type"]; ok {
+			if !models.IsValidHookContentType(ct) {
+				ctx.Error(422, "", "Invalid content type")
+				return false
+			}
+			w.ContentType = models.ToHookContentType(ct)
+		}
+
+		if w.HookTaskType == models.SLACK {
+			if channel, ok := form.Config["channel"]; ok {
+				meta, err := json.Marshal(&models.SlackMeta{
+					Channel:  channel,
+					Username: form.Config["username"],
+					IconURL:  form.Config["icon_url"],
+					Color:    form.Config["color"],
+				})
+				if err != nil {
+					ctx.Error(500, "slack: JSON marshal failed", err)
+					return false
+				}
+				w.Meta = string(meta)
+			}
+		}
+	}
+
+	// Update events
+	if len(form.Events) == 0 {
+		form.Events = []string{"push"}
+	}
+	w.PushOnly = false
+	w.SendEverything = false
+	w.ChooseEvents = true
+	w.Create = com.IsSliceContainsStr(form.Events, string(models.HookEventCreate))
+	w.Push = com.IsSliceContainsStr(form.Events, string(models.HookEventPush))
+	w.PullRequest = com.IsSliceContainsStr(form.Events, string(models.HookEventPullRequest))
+	if err := w.UpdateEvent(); err != nil {
+		ctx.Error(500, "UpdateEvent", err)
+		return false
+	}
+
+	if form.Active != nil {
+		w.IsActive = *form.Active
+	}
+
+	if err := models.UpdateWebhook(w); err != nil {
+		ctx.Error(500, "UpdateWebhook", err)
+		return false
+	}
+	return true
+}

--- a/vendor/code.gitea.io/sdk/gitea/hook.go
+++ b/vendor/code.gitea.io/sdk/gitea/hook.go
@@ -30,10 +30,28 @@ type Hook struct {
 	Created time.Time         `json:"created_at"`
 }
 
+// ListOrgHooks list all the hooks of one organization
+func (c *Client) ListOrgHooks(org string) ([]*Hook, error) {
+	hooks := make([]*Hook, 0, 10)
+	return hooks, c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s/hooks", org), nil, nil, &hooks)
+}
+
 // ListRepoHooks list all the hooks of one repository
 func (c *Client) ListRepoHooks(user, repo string) ([]*Hook, error) {
 	hooks := make([]*Hook, 0, 10)
 	return hooks, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/hooks", user, repo), nil, nil, &hooks)
+}
+
+// GetOrgHook get a hook of an organization
+func (c *Client) GetOrgHook(org string, id int64) (*Hook, error) {
+	h := new(Hook)
+	return h, c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), nil, nil, h)
+}
+
+// GetRepoHook get a hook of a repository
+func (c *Client) GetRepoHook(user, repo string, id int64) (*Hook, error) {
+	h := new(Hook)
+	return h, c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), nil, nil, h)
 }
 
 // CreateHookOption options when create a hook
@@ -44,7 +62,17 @@ type CreateHookOption struct {
 	Active bool              `json:"active"`
 }
 
-// CreateRepoHook create one hook with options
+// CreateOrgHook create one hook for an organization, with options
+func (c *Client) CreateOrgHook(org string, opt CreateHookOption) (*Hook, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	h := new(Hook)
+	return h, c.getParsedResponse("POST", fmt.Sprintf("/orgs/%s/hooks", org), jsonHeader, bytes.NewReader(body), h)
+}
+
+// CreateRepoHook create one hook for a repository, with options
 func (c *Client) CreateRepoHook(user, repo string, opt CreateHookOption) (*Hook, error) {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -61,7 +89,17 @@ type EditHookOption struct {
 	Active *bool             `json:"active"`
 }
 
-// EditRepoHook modify one hook with hook id and options
+// EditOrgHook modify one hook of an organization, with hook id and options
+func (c *Client) EditOrgHook(org string, id int64, opt EditHookOption) error {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return err
+	}
+	_, err = c.getResponse("PATCH", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), jsonHeader, bytes.NewReader(body))
+	return err
+}
+
+// EditRepoHook modify one hook of a repository, with hook id and options
 func (c *Client) EditRepoHook(user, repo string, id int64, opt EditHookOption) error {
 	body, err := json.Marshal(&opt)
 	if err != nil {
@@ -71,7 +109,14 @@ func (c *Client) EditRepoHook(user, repo string, id int64, opt EditHookOption) e
 	return err
 }
 
-// DeleteRepoHook delete one hook with hook id
+// DeleteOrgHook delete one hook from an organization, with hook id
+func (c *Client) DeleteOrgHook(org string, id int64) error {
+	_, err := c.getResponse("DELETE", fmt.Sprintf("/org/%s/hooks/%d", org, id), nil, nil)
+	return err
+}
+
+
+// DeleteRepoHook delete one hook from a repository, with hook id
 func (c *Client) DeleteRepoHook(user, repo string, id int64) error {
 	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), nil, nil)
 	return err

--- a/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
@@ -10,6 +10,29 @@ import (
 	"fmt"
 )
 
+// ListCollaborators list a repository's collaborators
+func (c *Client) ListCollaborators(user, repo string) ([]*User, error) {
+	collaborators := make([]*User, 0, 10)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/collaborators", user, repo),
+		nil, nil, &collaborators)
+	return collaborators, err
+}
+
+// IsCollaborator check if a user is a collaborator of a repository
+func (c *Client) IsCollaborator(user, repo, collaborator string) (bool, error) {
+	status, err := c.getStatusCode("GET",
+		fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator),
+		nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if status == 204 {
+		return true, nil
+	}
+	return false, nil
+}
+
 // AddCollaboratorOption options when add some user as a collaborator of a repository
 type AddCollaboratorOption struct {
 	Permission *string `json:"permission"`
@@ -22,5 +45,13 @@ func (c *Client) AddCollaborator(user, repo, collaborator string, opt AddCollabo
 		return err
 	}
 	_, err = c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator), nil, bytes.NewReader(body))
+	return err
+}
+
+// DeleteCollaborator remove a collaborator from a repository
+func (c *Client) DeleteCollaborator(user, repo, collaborator string) error {
+	_, err := c.getResponse("DELETE",
+		fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator),
+		nil, nil)
 	return err
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2016-12-22T08:49:21Z"
 		},
 		{
-			"checksumSHA1": "KZEYDYPzVc12f0770V++kIHhfa0=",
+			"checksumSHA1": "dnGaLR7sd9D5YpQZP4QUGZiEq+c=",
 			"path": "code.gitea.io/sdk/gitea",
-			"revision": "76837c0ea4b9b9a011e7bb04d79e3d20caf1a45c",
-			"revisionTime": "2016-12-15T16:13:48Z"
+			"revision": "d628d07f7377c2c10df5e0292370b21d9ac689eb",
+			"revisionTime": "2016-12-24T02:50:46Z"
 		},
 		{
 			"checksumSHA1": "IyfS7Rbl6OgR83QR7TOfKdDCq+M=",


### PR DESCRIPTION
Adds the following API endpoints:
- `GET repos/:owner/:reponame/hooks/:id`: Get a single repo webhook
- `GET orgs/:orgname/hooks`: Get an organization's webhooks
- `GET orgs/:orgname/hooks/:id`: Get a single organization webhook
- `POST orgs/:orgname/hooks`: Create an organization webhook
- `PATCH orgs/:orgname/hooks/:id`: Update an organization webhook
- `DELETE orgs/:orgname/hooks/:id`: Delete an organization webhook

All these endpoints exists in the Github API (see [orgs](https://developer.github.com/v3/orgs/hooks/), [repos](https://developer.github.com/v3/repos/hooks/))

I've added `routers/api/v1/utils/hook.go`, which contains functionality that is shared between repo webhook and organization webhook endpoints.