### PR TITLE
Remove ambiguity in GetUserRepositories SQL

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -557,15 +557,29 @@ func (org *User) GetUserRepositories(userID int64, page, pageSize int) ([]*Repos
 	if page <= 0 {
 		page = 1
 	}
+
 	repos := make([]*Repository, 0, pageSize)
 
-	if err := x.Select("`repository`.*").
+	if err := x.
+		Select("`repository`.id").
 		Join("INNER", "team_repo", "`team_repo`.repo_id=`repository`.id").
 		Where(cond).
-		GroupBy("`repository`.id").
+		GroupBy("`repository`.id,`repository`.updated_unix").
 		OrderBy("updated_unix DESC").
 		Limit(pageSize, (page-1)*pageSize).
 		Find(&repos); err != nil {
+		return nil, 0, fmt.Errorf("get repository ids: %v", err)
+	}
+
+	repoIDs := make([]int64,pageSize)
+	for i := range repos {
+		repoIDs[i] = repos[i].ID
+	}
+
+	if err := x.
+		Select("`repository`.*").
+		Where(builder.In("`repository`.id",repoIDs)).
+		Find(&repos); err!=nil {
 		return nil, 0, fmt.Errorf("get repositories: %v", err)
 	}
 


### PR DESCRIPTION
This includes all columns of the repository table in the group by clause
Certain databases will attempt to infer the other columns eg.
https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html

As some databases supported by xorm don't have the ability to do this
we include every column in the group by clause, this should work the
same assumining repository.id is unique.

This pull request will fix issues viewing the organisation page with #383.