### PR TITLE
Update gitea/sdk vendor

### DIFF
--- a/vendor/code.gitea.io/sdk/gitea/org_team.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_team.go
@@ -18,3 +18,10 @@ type CreateTeamOption struct {
 	Description string `json:"description" binding:"MaxSize(255)"`
 	Permission  string `json:"permission"`
 }
+
+// EditTeamOption options when edit team
+type EditTeamOption struct {
+	Name        string `json:"name" binding:"Required;AlphaDashDot;MaxSize(30)"`
+	Description string `json:"description" binding:"MaxSize(255)"`
+	Permission  string `json:"permission"`
+}

--- a/vendor/code.gitea.io/sdk/gitea/user.go
+++ b/vendor/code.gitea.io/sdk/gitea/user.go
@@ -5,6 +5,7 @@
 package gitea
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -15,6 +16,16 @@ type User struct {
 	FullName  string `json:"full_name"`
 	Email     string `json:"email"`
 	AvatarURL string `json:"avatar_url"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for User, adding field(s) for backward compatibility
+func (u User) MarshalJSON() ([]byte, error) {
+	// Re-declaring User to avoid recursion
+	type shadow User
+	return json.Marshal(struct {
+		shadow
+		CompatUserName string `json:"username"`
+	}{shadow(u), u.UserName})
 }
 
 // GetUserInfo get user info by user's name

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2016-11-13T14:20:52Z"
 		},
 		{
-			"checksumSHA1": "x5jr5+UwaMg861XyFWIoNzYmmMM=",
+			"checksumSHA1": "KZEYDYPzVc12f0770V++kIHhfa0=",
 			"path": "code.gitea.io/sdk/gitea",
-			"revision": "140df7f34c05d0d7e5b03c2b4a7d38690b3a5152",
-			"revisionTime": "2016-11-29T07:37:12Z"
+			"revision": "76837c0ea4b9b9a011e7bb04d79e3d20caf1a45c",
+			"revisionTime": "2016-12-15T16:13:48Z"
 		},
 		{
 			"checksumSHA1": "IyfS7Rbl6OgR83QR7TOfKdDCq+M=",


### PR DESCRIPTION
For bringing in the API backward compatibility fix https://github.com/go-gitea/go-sdk/pull/28.

As a side-effect it will include https://github.com/go-gitea/go-sdk/pull/25 (ping @ethantkoenig).