### PR TITLE
Remove fixed FIXME

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -404,7 +404,6 @@ var patchConflicts = []string{
 }
 
 // testPatch checks if patch can be merged to base repository without conflict.
-// FIXME: make a mechanism to clean up stable local copies.
 func (pr *PullRequest) testPatch() (err error) {
 	if pr.BaseRepo == nil {
 		pr.BaseRepo, err = GetRepositoryByID(pr.BaseRepoID)


### PR DESCRIPTION
This was fixed by #368 = cbcb4361d5fa554b707b28055aed33629a34d60c
I think the original author of the comment meant "clean up stale local copies".