### PR TITLE
Add support for using "libravatar" as the GravatarSource

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -544,6 +544,8 @@ please consider changing to GITEA_CUSTOM`)
 		GravatarSource = "http://gravatar.duoshuo.com/avatar/"
 	case "gravatar":
 		GravatarSource = "https://secure.gravatar.com/avatar/"
+	case "libravatar":
+		GravatarSource = "https://seccdn.libravatar.org/avatar/"
 	default:
 		GravatarSource = source
 	}


### PR DESCRIPTION
Just to make it easier for administrator to configure libre avatar,
as it is done for "duoshuo" and "gravatar"

NOTE: I'd actually make it the default, but will keep that for
a separate PR to reduce eventual conflicts