### PR TITLE
Fix homepage docs link broken

### DIFF
--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -20,7 +20,7 @@
 					<i class="octicon octicon-flame"></i> Einfach zu installieren
 				</h1>
 				<p class="large">
-					Starte einfach <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">die Anwendung</a> für deine Plattform. Gitea gibt es auch für <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">Installationspaket</a>.
+					Starte einfach <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">die Anwendung</a> für deine Plattform. Gitea gibt es auch für <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">Installationspaket</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -57,7 +57,7 @@
 					<i class="octicon octicon-flame"></i> 易安装
 				</h1>
 				<p class="large">
-					您除了可以根据操作系统平台通过 <a target="_blank" rel="noopener" href="https://docs.gitea.io/zh-cn/%E4%BB%8E%E4%BA%8C%E8%BF%9B%E5%88%B6%E5%AE%89%E8%A3%85/">二进制运行</a>，还可以通过 <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> 或 <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">包管理</a> 安装。
+					您除了可以根据操作系统平台通过 <a target="_blank" rel="noopener" href="https://docs.gitea.io/zh-cn/install-from-binary/">二进制运行</a>，还可以通过 <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> 或 <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" rel="noopener" href="https://docs.gitea.io/zh-cn/install-from-package/">包管理</a> 安装。
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -94,10 +94,10 @@
 					<i class="octicon octicon-flame"></i> Facile à installer
 				</h1>
 				<p class="large">
-				    Il suffit de <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">lancer l'exécutable</a> correspondant à votre système.
+				    Il suffit de <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">lancer l'exécutable</a> correspondant à votre système.
                     Ou d'utiliser Gitea avec <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou
                     <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>
-                    ou en l'installant depuis un <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">package</a>.
+                    ou en l'installant depuis un <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">package</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -134,7 +134,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplemente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">arranca el binario</a> para tu plataforma. O usa Gitea con <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> o <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">paquete</a>.
+					Simplemente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">arranca el binario</a> para tu plataforma. O usa Gitea con <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> o <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">paquete</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -171,7 +171,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplesmente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gitea com o <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">pacote</a>.
+					Simplesmente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gitea com o <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">pacote</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -208,7 +208,7 @@
 					<i class="octicon octicon-flame"></i> Простой в установке
 				</h1>
 				<p class="large">
-					Просто <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gitea с <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> или <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">пакет</a>.
+					Просто <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gitea с <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> или <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">пакет</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -245,7 +245,7 @@
 					<i class="octicon octicon-flame"></i> Easy to install
 				</h1>
 				<p class="large">
-					Simply <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">run the binary</a> for your platform. Or ship Gitea with <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> or <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">packaged</a>.
+					Simply <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-binary/">run the binary</a> for your platform. Or ship Gitea with <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> or <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/install-from-package/">packaged</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -20,7 +20,7 @@
 					<i class="octicon octicon-flame"></i> Einfach zu installieren
 				</h1>
 				<p class="large">
-					Starte einfach <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">die Anwendung</a> für deine Plattform. Gitea gibt es auch für <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">Installationspaket</a>.
+					Starte einfach <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">die Anwendung</a> für deine Plattform. Gitea gibt es auch für <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">Installationspaket</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -57,7 +57,7 @@
 					<i class="octicon octicon-flame"></i> 易安装
 				</h1>
 				<p class="large">
-					您除了可以根据操作系统平台通过 <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">二进制运行</a>，还可以通过 <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> 或 <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">包管理</a> 安装。
+					您除了可以根据操作系统平台通过 <a target="_blank" rel="noopener" href="https://docs.gitea.io/zh-cn/%E4%BB%8E%E4%BA%8C%E8%BF%9B%E5%88%B6%E5%AE%89%E8%A3%85/">二进制运行</a>，还可以通过 <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> 或 <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">包管理</a> 安装。
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -94,10 +94,10 @@
 					<i class="octicon octicon-flame"></i> Facile à installer
 				</h1>
 				<p class="large">
-				    Il suffit de <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">lancer l'exécutable</a> correspondant à votre système.
+				    Il suffit de <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">lancer l'exécutable</a> correspondant à votre système.
                     Ou d'utiliser Gitea avec <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou
                     <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>
-                    ou en l'installant depuis un <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">package</a>.
+                    ou en l'installant depuis un <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">package</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -134,7 +134,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplemente <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">arranca el binario</a> para tu plataforma. O usa Gitea con <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> o <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">paquete</a>.
+					Simplemente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">arranca el binario</a> para tu plataforma. O usa Gitea con <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> o <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">paquete</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -171,7 +171,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplesmente <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gitea com o <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">pacote</a>.
+					Simplesmente <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gitea com o <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">pacote</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -208,7 +208,7 @@
 					<i class="octicon octicon-flame"></i> Простой в установке
 				</h1>
 				<p class="large">
-					Просто <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gitea с <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> или <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">пакет</a>.
+					Просто <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gitea с <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> или <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">пакет</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -245,7 +245,7 @@
 					<i class="octicon octicon-flame"></i> Easy to install
 				</h1>
 				<p class="large">
-					Simply <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_binary.html">run the binary</a> for your platform. Or ship Gitea with <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> or <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" rel="noopener" href="https://docs.gitea.io/installation/install_from_packages.html">packaged</a>.
+					Simply <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-binary/">run the binary</a> for your platform. Or ship Gitea with <a target="_blank" rel="noopener" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> or <a target="_blank" rel="noopener" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" rel="noopener" href="https://docs.gitea.io/en-us/installation-from-package/">packaged</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">


### PR DESCRIPTION
And we have no installation-from-package page on docs.gitea.io, we should add one empty at the moment. I will send another PR to do that.