### PR TITLE
serve video files using the HTML5 video tag

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -431,6 +431,7 @@ file_history = History
 file_view_raw = View Raw
 file_permalink = Permalink
 file_too_large = This file is too large to be shown
+video_not_supported_in_browser = Your browser doesn't support HTML5 video tag.
 
 editor.new_file = New file
 editor.upload_file = Upload file

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -494,3 +494,7 @@ func IsImageFile(data []byte) bool {
 func IsPDFFile(data []byte) bool {
 	return strings.Index(http.DetectContentType(data), "application/pdf") != -1
 }
+
+func IsVideoFile(data []byte) bool {
+	return strings.Index(http.DetectContentType(data), "video/") != -1
+}

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -495,6 +495,7 @@ func IsPDFFile(data []byte) bool {
 	return strings.Index(http.DetectContentType(data), "application/pdf") != -1
 }
 
+// IsVideoFile detectes if data is an video format
 func IsVideoFile(data []byte) bool {
 	return strings.Index(http.DetectContentType(data), "video/") != -1
 }

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -198,6 +198,8 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 
 	case base.IsPDFFile(buf):
 		ctx.Data["IsPDFFile"] = true
+	case base.IsVideoFile(buf):
+		ctx.Data["IsVideoFile"] = true
 	case base.IsImageFile(buf):
 		ctx.Data["IsImageFile"] = true
 	}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -43,6 +43,10 @@
 				<div class="view-raw ui center">
 					{{if .IsImageFile}}
 						<img src="{{EscapePound $.RawFileLink}}">
+					{{else if .IsVideoFile}}
+						<video controls src="{{EscapePound $.RawFileLink}}">
+							<strong>{{.i18n.Tr "repo.video_not_supported_in_browser"}}</strong>
+						</video>
 					{{else if .IsPDFFile}}
 						<iframe width="100%" height="600px" src="{{AppSubUrl}}/plugins/pdfjs-1.4.20/web/viewer.html?file={{EscapePound $.RawFileLink}}"></iframe>
 					{{else}}


### PR DESCRIPTION
This pull requests adds support for video files using the HTML5 video tag. This allows viewing videos files directly in the webinterface - essentially the same way PDF files are supported.

Video files are not ideal to be managed using git, but may be stored in repositories as part of a projects documentation. This is the case in a project I am currently working on, and it helps a lot being able to preview these files directly in gitea instead of having to download and to open them in a video player. With video support in most of the current browsers (http://caniuse.com/#search=video) this seems like a helpful feature to be implemented in gitea.

I originally submited this PR to gogs (gogits/gogs#3967), in the discussion there @lunny asked me to also create this pull request to gitea. 