### PR TITLE
Improve the way how branches are deleted

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -588,7 +588,6 @@ pulls.cannot_auto_merge_desc = This pull request can't be merged automatically b
 pulls.cannot_auto_merge_helper = Please merge manually in order to resolve the conflicts.
 pulls.merge_pull_request = Merge Pull Request
 pulls.open_unmerged_pull_exists = `You can't perform reopen operation because there is already an open pull request (#%d) from same repository with same merge information and is waiting for merging.`
-pulls.delete_branch = Delete Branch
 
 milestones.new = New Milestone
 milestones.open_tab = %d Open
@@ -811,6 +810,14 @@ release.deletion_success = Release has been deleted successfully!
 release.tag_name_already_exist = Release with this tag name already exists.
 release.tag_name_invalid = Tag name is not valid.
 release.downloads = Downloads
+
+branch.delete = Delete Branch %s
+branch.delete_desc = Once you delete a branch, there is no going back. Please be certain.
+branch.delete_notices_1 = - This operation <strong>CANNOT</strong> be undone.
+branch.delete_notices_2 = - This operation will permanently delete everything of branch %s.
+branch.deletion_success = %s has been deleted successfully!
+branch.deletion_failed = Failed to delete branch %s.
+branch.delete_branch_has_new_commits =  %s cannot be deleted because it has new commits after mergence.
 
 [org]
 org_name_holder = Organization Name

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -166,10 +166,7 @@
 								{{if .IsPullBranchDeletable}}
 									<div class="ui divider"></div>
 									<div>
-										<form class="ui form" action="{{.DeleteBranchLink}}" method="post">
-											{{.CsrfTokenHtml}}
-											<button class="ui red button">{{$.i18n.Tr "repo.pulls.delete_branch"}}</button>
-										</form>
+										<a class="delete-button ui red button" href="" data-url="{{.DeleteBranchLink}}">{{$.i18n.Tr "repo.branch.delete" .HeadTarget}}</a>
 									</div>
 								{{end}}
 							{{else if .Issue.IsClosed}}
@@ -379,4 +376,17 @@
 
 <div class="hide" id="no-content">
 	<span class="no-content">{{.i18n.Tr "repo.issues.no_content"}}</span>
+</div>
+
+<div class="ui small basic delete modal">
+	<div class="ui icon header">
+		<i class="trash icon"></i>
+		{{.i18n.Tr "repo.branch.delete" .HeadTarget | Safe}}
+	</div>
+	<div class="content">
+		<p>{{.i18n.Tr "repo.branch.delete_desc" | Safe}}</p>
+		{{.i18n.Tr "repo.branch.delete_notices_1" | Safe}}<br>
+		{{.i18n.Tr "repo.branch.delete_notices_2" .HeadTarget | Safe}}<br>
+	</div>
+	{{template "base/delete_modal_actions" .}}
 </div>


### PR DESCRIPTION
Delete branch from HeadRepo instead of BaseRepo
Prevent the deletion of a master branch
Show a yes/no overlay when you press the delete branch button