### PR TITLE
Added webkit-font-smoothing

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -8,6 +8,7 @@ body {
   font-family: "Helvetica Neue", "Microsoft YaHei", Arial, Helvetica, sans-serif !important;
   background-color: #fff;
   overflow-y: scroll;
+  -webkit-font-smoothing: antialiased;
 }
 img {
   border-radius: 3px;


### PR DESCRIPTION
Hey there, Here I'm adding `-webkit-font-smoothing` to the `body` CSS tag to make fonts look nicer on Mac.

Before:
![screen shot 2016-12-26 at 22 11 08](https://cloud.githubusercontent.com/assets/425200/21487054/677fb2f4-cbb8-11e6-965c-015c2d32fd22.png)

After
![screen shot 2016-12-26 at 22 11 21](https://cloud.githubusercontent.com/assets/425200/21487055/6a069d94-cbb8-11e6-9f87-35df8b4e30df.png)
