### PR TITLE
Ignore static files statstics for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+conf/* linguist-vendored
+docker/* linguist-vendored
+options/* linguist-vendored
+public/* linguist-vendored
+scripts/* linguist-vendored
+templates/* linguist-vendored


### PR DESCRIPTION
Currently, github considers Gitea is a Javascript repository. See https://github.com/github/linguist#troubleshooting, this PR will ignore all the static files statistics.