### PR TITLE
Fix installation page ssh domain unavilable

### DIFF
--- a/routers/install.go
+++ b/routers/install.go
@@ -40,7 +40,7 @@ func InstallInit(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("install.install")
 	ctx.Data["PageIsInstall"] = true
 
-	dbOpts := []string{"MySQL", "PostgreSQL","MSSQL"}
+	dbOpts := []string{"MySQL", "PostgreSQL", "MSSQL"}
 	if models.EnableSQLite3 {
 		dbOpts = append(dbOpts, "SQLite3")
 	}
@@ -254,7 +254,7 @@ func InstallPost(ctx *context.Context, form auth.InstallForm) {
 	cfg.Section("").Key("APP_NAME").SetValue(form.AppName)
 	cfg.Section("repository").Key("ROOT").SetValue(form.RepoRootPath)
 	cfg.Section("").Key("RUN_USER").SetValue(form.RunUser)
-	cfg.Section("server").Key("DOMAIN").SetValue(form.Domain)
+	cfg.Section("server").Key("SSH_DOMAIN").SetValue(form.Domain)
 	cfg.Section("server").Key("HTTP_PORT").SetValue(form.HTTPPort)
 	cfg.Section("server").Key("ROOT_URL").SetValue(form.AppURL)
 


### PR DESCRIPTION
On installation page, whatever you fill in the Domain(SSH), it will not fill into ssh clone URL. This will fix that and should be merged to release/v1.0 after merged. And this will also resolve #472 