### PR TITLE
API Endpoints for forks

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -276,6 +276,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 				})
 				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
 				m.Get("/archive/*", repo.GetArchive)
+				m.Combo("/forks").Get(repo.ListForks).
+					Post(bind(api.CreateForkOption{}), repo.CreateFork)
 				m.Group("/branches", func() {
 					m.Get("", repo.ListBranches)
 					m.Get("/:branchname", repo.GetBranch)

--- a/routers/api/v1/repo/fork.go
+++ b/routers/api/v1/repo/fork.go
@@ -1,0 +1,61 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repo
+
+import (
+	api "code.gitea.io/sdk/gitea"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/context"
+)
+
+// ListForks list a repository's forks
+func ListForks(ctx *context.APIContext) {
+	forks, err := ctx.Repo.Repository.GetForks()
+	if err != nil {
+		ctx.Error(500, "GetForks", err)
+		return
+	}
+	apiForks := make([]*api.Repository, len(forks))
+	for i, fork := range forks {
+		access, err := models.AccessLevel(ctx.User, fork)
+		if err != nil {
+			ctx.Error(500, "AccessLevel", err)
+			return
+		}
+		apiForks[i] = fork.APIFormat(access)
+	}
+	ctx.JSON(200, apiForks)
+}
+
+// CreateFork create a fork of a repo
+func CreateFork(ctx *context.APIContext, form api.CreateForkOption) {
+	repo := ctx.Repo.Repository
+	var forker *models.User // user/org that will own the fork
+	if form.Organization == nil {
+		forker = ctx.User
+	} else {
+		org, err := models.GetOrgByName(*form.Organization)
+		if err != nil {
+			if err == models.ErrOrgNotExist {
+				ctx.Error(422, "", err)
+			} else {
+				ctx.Error(500, "GetOrgByName", err)
+			}
+			return
+		}
+		if !org.IsOrgMember(ctx.User.ID) {
+			ctx.Status(403)
+			return
+		}
+		forker = org
+	}
+	fork, err := models.ForkRepository(forker, repo, repo.Name, repo.Description)
+	if err != nil {
+		ctx.Error(500, "ForkRepository", err)
+		return
+	}
+	ctx.JSON(202, fork.APIFormat(models.AccessModeOwner))
+}

--- a/vendor/code.gitea.io/sdk/gitea/fork.go
+++ b/vendor/code.gitea.io/sdk/gitea/fork.go
@@ -1,0 +1,38 @@
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// ListForks list a repository's forks
+func (c *Client) ListForks(user, repo string) ([]*Repository, error) {
+	forks := make([]*Repository, 10)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/forks", user, repo),
+		nil, nil, &forks)
+	return forks, err
+}
+
+// CreateForkOption options for creating a fork
+type CreateForkOption struct {
+	Organization *string `json:"organization"`
+}
+
+// CreateFork create a fork of a repository
+func (c *Client) CreateFork(user, repo string, form CreateForkOption) (*Repository, error) {
+	body, err := json.Marshal(form)
+	if err != nil {
+		return nil, err
+	}
+	fork := new(Repository)
+	err = c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/forks", user, repo),
+		jsonHeader, bytes.NewReader(body), &fork)
+	return fork, err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2016-12-28T14:57:51Z"
 		},
 		{
-			"checksumSHA1": "dnGaLR7sd9D5YpQZP4QUGZiEq+c=",
+			"checksumSHA1": "5J8ejjEp2moLyK1pD++Jzof8DFs=",
 			"path": "code.gitea.io/sdk/gitea",
-			"revision": "d628d07f7377c2c10df5e0292370b21d9ac689eb",
-			"revisionTime": "2016-12-24T02:50:46Z"
+			"revision": "c0e081342a4b99d90371081b888765b91f05546f",
+			"revisionTime": "2016-12-29T09:40:42Z"
 		},
 		{
 			"checksumSHA1": "IyfS7Rbl6OgR83QR7TOfKdDCq+M=",


### PR DESCRIPTION
Adds the following endpoints:
- `GET /repos/:user/:repo/forks`: List a repository's fork
- `POST /repos/:user/:repo/forks`: Fork a repository

See also https://github.com/go-gitea/go-sdk/pull/30