### PR TITLE
Fix gofmt error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 .PHONY: fmt
 fmt:
-	go fmt $(PACKAGES)
+	find . -name "*.go" -type f -not -path "./vendor/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:

--- a/models/git_diff_test.go
+++ b/models/git_diff_test.go
@@ -20,16 +20,16 @@ func assertLineEqual(t *testing.T, d1 *DiffLine, d2 *DiffLine) {
 
 func TestDiffToHTML(t *testing.T) {
 	assertEqual(t, "+foo <span class=\"added-code\">bar</span> biz", diffToHTML([]dmp.Diff{
-		dmp.Diff{dmp.DiffEqual, "foo "},
-		dmp.Diff{dmp.DiffInsert, "bar"},
-		dmp.Diff{dmp.DiffDelete, " baz"},
-		dmp.Diff{dmp.DiffEqual, " biz"},
+		{dmp.DiffEqual, "foo "},
+		{dmp.DiffInsert, "bar"},
+		{dmp.DiffDelete, " baz"},
+		{dmp.DiffEqual, " biz"},
 	}, DiffLineAdd))
 
 	assertEqual(t, "-foo <span class=\"removed-code\">bar</span> biz", diffToHTML([]dmp.Diff{
-		dmp.Diff{dmp.DiffEqual, "foo "},
-		dmp.Diff{dmp.DiffDelete, "bar"},
-		dmp.Diff{dmp.DiffInsert, " baz"},
-		dmp.Diff{dmp.DiffEqual, " biz"},
+		{dmp.DiffEqual, "foo "},
+		{dmp.DiffDelete, "bar"},
+		{dmp.DiffInsert, " baz"},
+		{dmp.DiffEqual, " biz"},
 	}, DiffLineDel))
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -1194,8 +1194,8 @@ func GetIssueStats(opts *IssueStatsOptions) *IssueStats {
 
 		if opts.MentionedID > 0 {
 			sess.Join("INNER", "issue_user", "issue.id = issue_user.issue_id").
-			And("issue_user.uid = ?", opts.MentionedID).
-			And("issue_user.is_mentioned = ?", true)
+				And("issue_user.uid = ?", opts.MentionedID).
+				And("issue_user.is_mentioned = ?", true)
 		}
 
 		return sess

--- a/models/models.go
+++ b/models/models.go
@@ -130,15 +130,15 @@ func parsePostgreSQLHostPort(info string) (string, string) {
 
 func parseMSSQLHostPort(info string) (string, string) {
 	host, port := "127.0.0.1", "1433"
-		if strings.Contains(info, ":") {
-			host = strings.Split(info, ":")[0]
-				port = strings.Split(info, ":")[1]
-		} else if strings.Contains(info, ",") {
-			host = strings.Split(info, ",")[0]
-				port = strings.TrimSpace(strings.Split(info, ",")[1])
-		} else if len(info) > 0 {
-			host = info
-		}
+	if strings.Contains(info, ":") {
+		host = strings.Split(info, ":")[0]
+		port = strings.Split(info, ":")[1]
+	} else if strings.Contains(info, ",") {
+		host = strings.Split(info, ",")[0]
+		port = strings.TrimSpace(strings.Split(info, ",")[1])
+	} else if len(info) > 0 {
+		host = info
+	}
 	return host, port
 }
 

--- a/modules/lfs/content_store.go
+++ b/modules/lfs/content_store.go
@@ -90,5 +90,5 @@ func transformKey(key string) string {
 		return key
 	}
 
-	return filepath.Join(key[0:2], key[2:4], key[4:len(key)])
+	return filepath.Join(key[0:2], key[2:4], key[4:])
 }

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -220,12 +220,12 @@ func (s *sendmailSender) Send(from string, to []string, msg io.WriterTo) error {
 		return err
 	}
 
-	_,err = msg.WriteTo(pipe)
+	_, err = msg.WriteTo(pipe)
 
 	// we MUST close the pipe or sendmail will hang waiting for more of the message
 	// Also we should wait on our sendmail command even if something fails
 	closeError = pipe.Close()
-	waitError =  cmd.Wait()
+	waitError = cmd.Wait()
 	if err != nil {
 		return err
 	} else if closeError != nil {
@@ -262,7 +262,6 @@ func NewContext() {
 	if setting.MailService == nil || mailQueue != nil {
 		return
 	}
-
 
 	if setting.MailService.UseSendmail {
 		Sender = &sendmailSender{}

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -94,7 +94,7 @@ func HTTP(ctx *context.Context) {
 				ctx.HandleText(401, "reverse proxy login error, got error while running GetUserByName")
 				return
 			}
-		}else{
+		} else {
 			authHead := ctx.Req.Header.Get("Authorization")
 			if len(authHead) == 0 {
 				ctx.Resp.Header().Set("WWW-Authenticate", "Basic realm=\".\"")

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -131,10 +131,10 @@ func Issues(ctx *context.Context) {
 	}
 
 	var (
-		assigneeID = ctx.QueryInt64("assignee")
-		posterID     int64
-		mentionedID  int64
-		forceEmpty   bool
+		assigneeID  = ctx.QueryInt64("assignee")
+		posterID    int64
+		mentionedID int64
+		forceEmpty  bool
 	)
 	switch viewType {
 	case "assigned":


### PR DESCRIPTION
Gofmt error message from report card: https://goreportcard.com/report/code.gitea.io/gitea#gofmt and we need to replace `go fmt` with `gofmt` command since `go fmt` doesn's support `simplify` command.

cc @lunny @tboerger 