### PR TITLE
Fix benchmarktests

### DIFF
--- a/models/graph_test.go
+++ b/models/graph_test.go
@@ -17,25 +17,29 @@ func BenchmarkGetCommitGraph(b *testing.B) {
 		b.Error("Could not open repository")
 	}
 
-	graph, err := GetCommitGraph(currentRepo)
-	if err != nil {
-		b.Error("Could get commit graph")
-	}
+	for i := 0; i < b.N; i++ {
+		graph, err := GetCommitGraph(currentRepo)
+		if err != nil {
+			b.Error("Could get commit graph")
+		}
 
-	if len(graph) < 100 {
-		b.Error("Should get 100 log lines.")
+		if len(graph) < 100 {
+			b.Error("Should get 100 log lines.")
+		}
 	}
 }
 
 func BenchmarkParseCommitString(b *testing.B) {
 	testString := "* DATA:||4e61bacab44e9b4730e44a6615d04098dd3a8eaf|2016-12-20 21:10:41 +0100|Kjell Kvinge|kjell@kvinge.biz|4e61bac|Add route for graph"
 
-	graphItem, err := graphItemFromString(testString, nil)
-	if err != nil {
-		b.Error("could not parse teststring")
-	}
+	for i := 0; i < b.N; i++ {
+		graphItem, err := graphItemFromString(testString, nil)
+		if err != nil {
+			b.Error("could not parse teststring")
+		}
 
-	if graphItem.Author != "Kjell Kvinge" {
-		b.Error("Did not get expected data")
+		if graphItem.Author != "Kjell Kvinge" {
+			b.Error("Did not get expected data")
+		}
 	}
 }


### PR DESCRIPTION
Hi. In #428 I was asked to create benchmark tests for the new feature (timeline).

I have now been made aware that these benchmark test make no sense. I'm sorry about that.

This PR fixes the tests. Note: the performance impact of that PR (#428) is quite a bit.

On my laptop, I get:

```
$go test -v  -bench Commit -run Commit

PASS
BenchmarkGetCommitGraph-4   	      20	  72745337 ns/op
BenchmarkParseCommitString-4	 1000000	      2614 ns/op
ok  	code.gitea.io/gitea/models	4.229s
```
