### PR TITLE
Improve the performance of tree listing

### DIFF
--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -67,7 +67,6 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 		return
 	}
 
-	entries.Sort()
 	entries = entries[start : start+count]
 
 	ctx.Data["Files"], err = entries.GetCommitsInfo(ctx.Repo.Commit, ctx.Repo.TreePath)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -52,7 +52,7 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 	count := ctx.QueryInt("count")
 
 	// Check invalid values
-	if (start == 0 && count == 0) || start+count < start || start+count > len(entries) {
+	if (start == 0 && count == 0) || count < 0 || start+count > len(entries) {
 		start = 0
 		count = len(entries)
 	}

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -41,32 +41,14 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 		return
 	}
 
-	query := ctx.Req.URL.Query()
-
-	var start, count int = 0, 100
-
-	if _start, ok := query["start"]; ok && len(_start) == 1 {
-		start, err = strconv.Atoi(_start[0])
-		if err != nil {
-			ctx.Handle(500, "QueryString", err)
-			return
-		}
-	}
-
-	if _count, ok := query["count"]; ok && len(_count) == 1 {
-		count, err = strconv.Atoi(_count[0])
-		if err != nil {
-			ctx.Handle(500, "QueryString", err)
-			return
-		}
-	}
-
 	entries, err := tree.ListEntries()
 	if err != nil {
 		ctx.Handle(500, "ListEntries", err)
 		return
 	}
 
+	start := ctx.QueryInt("start")
+	count := ctx.QueryInt("count")
 	entries = entries[start : start+count]
 
 	ctx.Data["Files"], err = entries.GetCommitsInfo(ctx.Repo.Commit, ctx.Repo.TreePath)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -6,14 +6,13 @@ package repo
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	gotemplate "html/template"
 	"io/ioutil"
 	"path"
-	"strings"
-
-	"encoding/base64"
 	"strconv"
+	"strings"
 
 	"code.gitea.io/git"
 	"code.gitea.io/gitea/models"

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -49,6 +49,12 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 
 	start := ctx.QueryInt("start")
 	count := ctx.QueryInt("count")
+
+	// Check invalid values
+	if start < 0 || count < 0 || start+count > len(entries) {
+		start = 0
+		count = len(entries)
+	}
 	entries = entries[start : start+count]
 
 	ctx.Data["Files"], err = entries.GetCommitsInfo(ctx.Repo.Commit, ctx.Repo.TreePath)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -47,6 +47,8 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 		return
 	}
 
+	entries.Sort()
+
 	start := ctx.QueryInt("start")
 	count := ctx.QueryInt("count")
 

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -51,7 +51,7 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 	count := ctx.QueryInt("count")
 
 	// Check invalid values
-	if start < 0 || count < 0 || start+count > len(entries) {
+	if (start == 0 && count == 0) || start+count < start || start+count > len(entries) {
 		start = 0
 		count = len(entries)
 	}


### PR DESCRIPTION
Add two query strings `start` and `count` for the home page of repository.  If the values are omitted or invalid they are set to 0 and the total number of rows respectively.
   
For #502 