### PR TITLE
fix: Remove call to set GOMAXPROCS

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,9 @@ package main // import "code.gitea.io/gitea"
 
 import (
 	"os"
-	"runtime"
-
-	"code.gitea.io/gitea/modules/log"
 
 	"code.gitea.io/gitea/cmd"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"github.com/urfave/cli"
 )
@@ -21,7 +19,6 @@ import (
 var Version = "1.1.0+dev"
 
 func init() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	setting.AppVer = Version
 }
 


### PR DESCRIPTION
These changes come from https://github.com/gogits/gogs/pull/4010

> For Go 1.5, we propose to change the default to the number of CPUs available.

ref: https://docs.google.com/document/d/1At2Ls5_fhJQ59kDK2DFVhFu3g5mATSXqqV5QrxinasI/edit