### PR TITLE
Rename .gogs to .gitea and comply with github template guidelines (#568)

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -50,8 +50,11 @@ var (
 	// IssueTemplateCandidates issue templates
 	IssueTemplateCandidates = []string{
 		"ISSUE_TEMPLATE.md",
-		".gogs/ISSUE_TEMPLATE.md",
+		"issue_template.md",
+		".gitea/ISSUE_TEMPLATE.md",
+		".gitea/issue_template.md",
 		".github/ISSUE_TEMPLATE.md",
+		".github/issue_template.md",
 	}
 )
 

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -31,9 +31,12 @@ const (
 
 var (
 	pullRequestTemplateCandidates = []string{
-		"PULL_REQUEST.md",
-		".gogs/PULL_REQUEST.md",
-		".github/PULL_REQUEST.md",
+		"PULL_REQUEST_TEMPLATE.md",
+		"pull_request_template.md",
+		".gitea/PULL_REQUEST_TEMPLATE.md",
+		".gitea/pull_request_template.md",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		".github/pull_request_template.md",
 	}
 )
 


### PR DESCRIPTION
#568 proposed support for issue / pull templates in .gitea folder with a fallback .github folder, this was already existing but I've renamed .gogs to .gitea.

Also renamed the template file for pull requests to `PULL_REQUEST_TEMPLATE.md` since that's how it's named at [Github](https://github.com/blog/2111-issue-and-pull-request-templates) as well.

Closes #568 