### PR TITLE
API endpoint for subscribers

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -2106,13 +2106,10 @@ func GetWatchers(repoID int64) ([]*Watch, error) {
 // GetWatchers returns range of users watching given repository.
 func (repo *Repository) GetWatchers(page int) ([]*User, error) {
 	users := make([]*User, 0, ItemsPerPage)
-	sess := x.
-		Limit(ItemsPerPage, (page-1)*ItemsPerPage).
-		Where("watch.repo_id=?", repo.ID)
-	if setting.UsePostgreSQL {
-		sess = sess.Join("LEFT", "watch", `"user".id=watch.user_id`)
-	} else {
-		sess = sess.Join("LEFT", "watch", "user.id=watch.user_id")
+	sess := x.Where("watch.repo_id=?", repo.ID).
+		Join("LEFT", "watch", "`user`.id=`watch`.user_id")
+	if page > 0 {
+		sess = sess.Limit(ItemsPerPage, (page-1)*ItemsPerPage)
 	}
 	return users, sess.Find(&users)
 }

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -327,6 +327,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 						Delete(reqRepoWriter(), repo.DeleteMilestone)
 				})
 				m.Get("/stargazers", repo.ListStargazers)
+				m.Get("/subscribers", repo.ListSubscribers)
 				m.Group("/subscription", func() {
 					m.Get("", user.IsWatching)
 					m.Put("", user.Watch)

--- a/routers/api/v1/repo/subscriber.go
+++ b/routers/api/v1/repo/subscriber.go
@@ -1,0 +1,25 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repo
+
+import (
+	api "code.gitea.io/sdk/gitea"
+
+	"code.gitea.io/gitea/modules/context"
+)
+
+// ListSubscribers list a repo's subscribers (i.e. watchers)
+func ListSubscribers(ctx *context.APIContext) {
+	subscribers, err := ctx.Repo.Repository.GetWatchers(0)
+	if err != nil {
+		ctx.Error(500, "GetWatchers", err)
+		return
+	}
+	users := make([]*api.User, len(subscribers))
+	for i, subscriber := range subscribers {
+		users[i] = subscriber.APIFormat()
+	}
+	ctx.JSON(200, users)
+}


### PR DESCRIPTION
Add the following endpoint:
- `GET /repos/:owner/:reponame/subscribers`: list a repo's subscribers/watchers