### PR TITLE
Remove the default console logger when it is not set in the configuration

### DIFF
--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -46,7 +46,7 @@ func DelLogger(mode string) error {
 			return l.DelLogger(mode)
 		}
 	}
-	panic("log: unknown adapter \"" + mode + "\" (forgotten register?)")
+	panic(`log: unknown adapter "` + mode + `" (forgotten register?)`)
 }
 
 // NewGitLogger create a logger for git

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -39,6 +39,7 @@ func NewLogger(bufLen int64, mode, config string) {
 	}
 }
 
+// DelLogger removes loggers that are for the given mode
 func DelLogger(mode string) error {
 	for _, l := range loggers {
 		if l.adapter == mode {

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -42,11 +42,12 @@ func NewLogger(bufLen int64, mode, config string) {
 // DelLogger removes loggers that are for the given mode
 func DelLogger(mode string) error {
 	for _, l := range loggers {
-		if l.adapter == mode {
+		if _, ok := l.outputs[mode]; ok {
 			return l.DelLogger(mode)
 		}
 	}
-	panic(`log: unknown adapter "` + mode + `" (forgotten register?)`)
+	Trace("Log adapter %s not found, no need to delete", mode)
+	return nil
 }
 
 // NewGitLogger create a logger for git

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -39,6 +39,15 @@ func NewLogger(bufLen int64, mode, config string) {
 	}
 }
 
+func DelLogger(mode string) error {
+	for _, l := range loggers {
+		if l.adapter == mode {
+			return l.DelLogger(mode)
+		}
+	}
+	panic("log: unknown adapter \"" + mode + "\" (forgotten register?)")
+}
+
 // NewGitLogger create a logger for git
 // FIXME: use same log level as other loggers.
 func NewGitLogger(logPath string) {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -867,6 +867,16 @@ func newLogService() {
 	LogModes = strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
 	LogConfigs = make([]string, len(LogModes))
 
+	useConsole := false;
+	for _, mode := range LogModes {
+		if "console" == mode {
+			useConsole = true;
+		}
+	}
+	if (!useConsole) {
+		log.DelLogger("console");
+	}
+
 	for i, mode := range LogModes {
 		mode = strings.TrimSpace(mode)
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -867,14 +867,14 @@ func newLogService() {
 	LogModes = strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
 	LogConfigs = make([]string, len(LogModes))
 
-	useConsole := false;
+	useConsole := false
 	for _, mode := range LogModes {
-		if "console" == mode {
-			useConsole = true;
+		if mode == "console"  {
+			useConsole = true
 		}
 	}
 	if (!useConsole) {
-		log.DelLogger("console");
+		log.DelLogger("console")
 	}
 
 	for i, mode := range LogModes {


### PR DESCRIPTION
Fix for issue #581 
Removes the default console logger when it is not set in the configuration

Mark: this is my first Go programming experience so please be gentle ;)