### PR TITLE
Add default SSH_LISTEN_PORT config value (#603)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -578,6 +578,7 @@ please consider changing to GITEA_CUSTOM`)
 
 	SSH.KeygenPath = sec.Key("SSH_KEYGEN_PATH").MustString("ssh-keygen")
 	SSH.Port = sec.Key("SSH_PORT").MustInt(22)
+	SSH.ListenPort = sec.Key("SSH_LISTEN_PORT").MustInt(SSH.Port)
 
 	// When disable SSH, start builtin server value is ignored.
 	if SSH.Disabled {


### PR DESCRIPTION
Sets default `SSH_LISTEN_PORT` to `SSH_PORT` as suggested in #603 and defined in `conf/app.ini`.

Comes with go-gitea/docs#60