### PR TITLE
Bug fixes for webhook API

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -258,8 +258,10 @@ func deleteWebhook(bean *Webhook) (err error) {
 		return err
 	}
 
-	if _, err = sess.Delete(bean); err != nil {
+	if count, err := sess.Delete(bean); err != nil {
 		return err
+	} else if count == 0 {
+		return ErrWebhookNotExist{ID: bean.ID}
 	} else if _, err = sess.Delete(&HookTask{HookID: bean.ID}); err != nil {
 		return err
 	}

--- a/routers/api/v1/org/hook.go
+++ b/routers/api/v1/org/hook.go
@@ -58,7 +58,11 @@ func DeleteHook(ctx *context.APIContext) {
 	org := ctx.Org.Organization
 	hookID := ctx.ParamsInt64(":id")
 	if err := models.DeleteWebhookByOrgID(org.ID, hookID); err != nil {
-		ctx.Error(500, "DeleteWebhookByOrgID", err)
+		if models.IsErrWebhookNotExist(err) {
+			ctx.Status(404)
+		} else {
+			ctx.Error(500, "DeleteWebhookByOrgID", err)
+		}
 		return
 	}
 	ctx.Status(204)

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -59,9 +59,12 @@ func EditHook(ctx *context.APIContext, form api.EditHookOption) {
 // DeleteHook delete a hook of a repository
 func DeleteHook(ctx *context.APIContext) {
 	if err := models.DeleteWebhookByRepoID(ctx.Repo.Repository.ID, ctx.ParamsInt64(":id")); err != nil {
-		ctx.Error(500, "DeleteWebhookByRepoID", err)
+		if models.IsErrWebhookNotExist(err) {
+			ctx.Status(404)
+		} else {
+			ctx.Error(500, "DeleteWebhookByRepoID", err)
+		}
 		return
 	}
-
 	ctx.Status(204)
 }


### PR DESCRIPTION
Require organization membership/ownership for API operations involving an organization's webhooks. 404 if a user tries to delete a non-existent webhook.