### PR TITLE
Attach to release

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -309,7 +309,7 @@ func runWeb(ctx *cli.Context) error {
 				return
 			}
 		})
-		m.Post("/attachments", repo.UploadIssueAttachment)
+		m.Post("/attachments", repo.UploadAttachment)
 	}, ignSignIn)
 
 	m.Group("/:username", func() {

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -309,7 +309,7 @@ func runWeb(ctx *cli.Context) error {
 				return
 			}
 		})
-		m.Post("/issues/attachments", repo.UploadIssueAttachment)
+		m.Post("/attachments", repo.UploadIssueAttachment)
 	}, ignSignIn)
 
 	m.Group("/:username", func() {
@@ -463,13 +463,11 @@ func runWeb(ctx *cli.Context) error {
 			m.Get("/:id/:action", repo.ChangeMilestonStatus)
 			m.Post("/delete", repo.DeleteMilestone)
 		}, reqRepoWriter, context.RepoRef())
-
 		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)
 			m.Post("/delete", repo.DeleteRelease)
 		}, reqRepoWriter, context.RepoRef())
-
 		m.Group("/releases", func() {
 			m.Get("/edit/*", repo.EditRelease)
 			m.Post("/edit/*", bindIgnErr(auth.EditReleaseForm{}), repo.EditReleasePost)

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -289,7 +289,7 @@ ENABLE = true
 ; Path for attachments. Defaults to `data/attachments`
 PATH = data/attachments
 ; One or more allowed types, e.g. image/jpeg|image/png
-ALLOWED_TYPES = image/jpeg|image/png
+ALLOWED_TYPES = image/jpeg|image/png|application/zip|application/gzip
 ; Max size of each file. Defaults to 32MB
 MAX_SIZE = 4
 ; Max number of files per upload. Defaults to 10

--- a/models/release.go
+++ b/models/release.go
@@ -184,11 +184,10 @@ func CreateRelease(gitRepo *git.Repository, rel *Release, attachmentUUIDs []stri
 	}
 	rel.LowerTagName = strings.ToLower(rel.TagName)
 
-	var issueID int64
-	issueID, err = x.InsertOne(rel)
+	_, err = x.InsertOne(rel)
 
 	for i := range attachments {
-		attachments[i].ReleaseID = issueID
+		attachments[i].ReleaseID = rel.ID
 		// No assign value could be 0, so ignore AllCols().
 		if _, err = x.Id(attachments[i].ID).Update(attachments[i]); err != nil {
 			return fmt.Errorf("update attachment [%d]: %v", attachments[i].ID, err)
@@ -246,6 +245,64 @@ func GetReleasesByRepoIDAndNames(repoID int64, tagNames []string) (rels []*Relea
 		In("tag_name", tagNames).
 		Find(&rels, Release{RepoID: repoID})
 	return rels, err
+}
+
+type releaseMetaSearch struct {
+	ID [] int64
+	Rel [] *Release
+}
+func (s releaseMetaSearch) Len() int {
+	return len(s.ID)
+}
+func (s releaseMetaSearch) Swap(i, j int) {
+	s.ID[i], s.ID[j] = s.ID[j], s.ID[i]
+	s.Rel[i], s.Rel[j] = s.Rel[j], s.Rel[i]
+}
+func (s releaseMetaSearch) Less(i, j int) bool {
+	return s.ID[i] < s.ID[j]
+}
+
+// GetReleaseAttachments retrieves the attachments for releases
+func GetReleaseAttachments(rels ... *Release) (err error){
+	if len(rels) == 0 {
+		return
+	}
+
+	// To keep this efficient as possible sort all releases by id, 
+	//    select attachments by release id,
+	//    then merge join them
+
+	// Sort
+	var sortedRels = releaseMetaSearch{ID: make([]int64, len(rels)), Rel: make([]*Release, len(rels))}
+	var attachments [] *Attachment
+	for index, element := range rels {
+		element.Attachments = []*Attachment{}
+		sortedRels.ID[index] = element.ID
+		sortedRels.Rel[index] = element
+	}
+	sort.Sort(sortedRels)
+
+	// Select attachments
+	err = x.
+		Asc("release_id").
+		In("release_id", sortedRels.ID).
+		Find(&attachments, Attachment{})
+
+	if err != nil {
+		return err
+	}
+
+	// merge join
+	var currentIndex = 0
+	for _, attachment := range attachments {
+		for sortedRels.ID[currentIndex] < attachment.ReleaseID {
+			currentIndex++
+		}
+		sortedRels.Rel[currentIndex].Attachments = append(sortedRels.Rel[currentIndex].Attachments, attachment)
+	}
+
+	return
+
 }
 
 type releaseSorter struct {

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -267,6 +267,7 @@ type NewReleaseForm struct {
 	Content    string
 	Draft      string
 	Prerelease bool
+	Files   []string
 }
 
 // Validate valideates the fields

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -281,6 +281,7 @@ type EditReleaseForm struct {
 	Content    string `form:"content"`
 	Draft      string `form:"draft"`
 	Prerelease bool   `form:"prerelease"`
+	Files   []string
 }
 
 // Validate valideates the fields

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -720,7 +720,7 @@ please consider changing to GITEA_CUSTOM`)
 	if !filepath.IsAbs(AttachmentPath) {
 		AttachmentPath = path.Join(workDir, AttachmentPath)
 	}
-	AttachmentAllowedTypes = strings.Replace(sec.Key("ALLOWED_TYPES").MustString("image/jpeg,image/png"), "|", ",", -1)
+	AttachmentAllowedTypes = strings.Replace(sec.Key("ALLOWED_TYPES").MustString("image/jpeg,image/png,application/zip,application/gzip"), "|", ",", -1)
 	AttachmentMaxSize = sec.Key("MAX_SIZE").MustInt64(4)
 	AttachmentMaxFiles = sec.Key("MAX_FILES").MustInt(5)
 	AttachmentEnabled = sec.Key("ENABLE").MustBool(true)

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -99,7 +99,7 @@ func CreateRelease(ctx *context.APIContext, form api.CreateReleaseOption) {
 		IsPrerelease: form.IsPrerelease,
 		CreatedUnix:  commit.Author.When.Unix(),
 	}
-	if err := models.CreateRelease(ctx.Repo.GitRepo, rel); err != nil {
+	if err := models.CreateRelease(ctx.Repo.GitRepo, rel, nil); err != nil {
 		if models.IsErrReleaseAlreadyExist(err) {
 			ctx.Status(409)
 		} else {

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -145,7 +145,7 @@ func EditRelease(ctx *context.APIContext, form api.EditReleaseOption) {
 	if form.IsPrerelease != nil {
 		rel.IsPrerelease = *form.IsPrerelease
 	}
-	if err := models.UpdateRelease(ctx.Repo.GitRepo, rel); err != nil {
+	if err := models.UpdateRelease(ctx.Repo.GitRepo, rel, nil); err != nil {
 		ctx.Error(500, "UpdateRelease", err)
 		return
 	}

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -477,8 +477,8 @@ func NewIssuePost(ctx *context.Context, form auth.CreateIssueForm) {
 	ctx.Redirect(ctx.Repo.RepoLink + "/issues/" + com.ToStr(issue.Index))
 }
 
-// UploadIssueAttachment response for uploading issue's attachment
-func UploadIssueAttachment(ctx *context.Context) {
+// UploadAttachment response for uploading issue's attachment
+func UploadAttachment(ctx *context.Context) {
 	if !setting.AttachmentEnabled {
 		ctx.Error(404, "attachment is not enabled")
 		return

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -100,6 +100,12 @@ func Releases(ctx *context.Context) {
 		return
 	}
 
+	err = models.GetReleaseAttachments(releases...)
+	if err != nil {
+		ctx.Handle(500, "GetReleaseAttachments", err)
+		return
+	}
+
 	// Temproray cache commits count of used branches to speed up.
 	countCache := make(map[string]int64)
 	var cacheUsers = make(map[int64]*models.User)

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -300,11 +300,16 @@ func EditReleasePost(ctx *context.Context, form auth.EditReleaseForm) {
 		return
 	}
 
+	var attachmentUUIDs []string
+	if setting.AttachmentEnabled {
+		attachmentUUIDs = form.Files
+	}
+
 	rel.Title = form.Title
 	rel.Note = form.Content
 	rel.IsDraft = len(form.Draft) > 0
 	rel.IsPrerelease = form.Prerelease
-	if err = models.UpdateRelease(ctx.Repo.GitRepo, rel); err != nil {
+	if err = models.UpdateRelease(ctx.Repo.GitRepo, rel, attachmentUUIDs); err != nil {
 		ctx.Handle(500, "UpdateRelease", err)
 		return
 	}

--- a/templates/repo/issue/comment_tab.tmpl
+++ b/templates/repo/issue/comment_tab.tmpl
@@ -13,5 +13,5 @@
 </div>
 {{if .IsAttachmentEnabled}}
 	<div class="files"></div>
-	<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{AppSubUrl}}/issues/attachments" data-accepts="{{.AttachmentAllowedTypes}}" data-max-file="{{.AttachmentMaxFiles}}" data-max-size="{{.AttachmentMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
+	<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{AppSubUrl}}/attachments" data-accepts="{{.AttachmentAllowedTypes}}" data-max-file="{{.AttachmentMaxFiles}}" data-max-size="{{.AttachmentMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
 {{end}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -59,6 +59,15 @@
 									<li>
 										<a href="{{$.RepoLink}}/archive/{{.TagName}}.tar.gz"><i class="octicon octicon-file-zip"></i> {{$.i18n.Tr "repo.release.source_code"}} (TAR.GZ)</a>
 									</li>
+									{{if .Attachments}}
+									{{range .Attachments}}
+									<li>
+										<a target="_blank" rel="noopener" href="{{AppSubUrl}}/attachments/{{.UUID}}">
+											<span class="ui image octicon octicon-desktop-download" title='{{.Name}}'></span> {{.Name}}
+										</a>
+									</li>
+									{{end}}
+									{{end}}
 								</ul>
 							</div>
 						{{else}}

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -48,6 +48,10 @@
 					<label>{{.i18n.Tr "repo.release.content"}}</label>
 					<textarea name="content">{{.content}}</textarea>
 				</div>
+				{{if .IsAttachmentEnabled}}
+					<div class="files"></div>
+					<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{AppSubUrl}}/attachments" data-accepts="{{.AttachmentAllowedTypes}}" data-max-file="{{.AttachmentMaxFiles}}" data-max-size="{{.AttachmentMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
+				{{end}}
 			</div>
 			<div class="ui container">
 				<div class="ui divider"></div>


### PR DESCRIPTION
Implemented attaching files to a release as requested in  #282

There is already a field in the Attachment table which is unused not used called ReleaseID.  This allows an attachment to be associated with a release.  This PR:

- Adds an upload box for users to upload attachments when creating / editing a release.
- Associates uploaded attachments with releases using the existing ReleaseID field 
- Adds attachments as download links on the release page below source zip and tar links
- Moves attachments POST URL from `/issues/attachments` to `/attachments` (the GET url was already `/attachments`)
- Changes default upload file types to include zip and gzip files as these are the most likely files to attach to a release
