### PR TITLE
Added ALWAYS_RENDER_RAW_FILES option to the repository section

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -23,6 +23,9 @@ PULL_REQUEST_QUEUE_LENGTH = 1000
 PREFERRED_LICENSES = Apache License 2.0,MIT License
 ; Disable ability to interact with repositories by HTTP protocol
 DISABLE_HTTP_GIT = false
+; Force correct content-type on raw files. 
+; This can be a security issue if improperly used because it allows html from a repo to run on the same domain as gitea.
+ALWAYS_RENDER_RAW_FILES = false
 
 [repository.editor]
 ; List of file extensions that should have line wraps in the CodeMirror editor

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -156,6 +156,7 @@ var (
 		PullRequestQueueLength int
 		PreferredLicenses      []string
 		DisableHTTPGit         bool
+		AlwaysRenderRawFiles   bool
 
 		// Repository editor settings
 		Editor struct {
@@ -179,6 +180,7 @@ var (
 		PullRequestQueueLength: 1000,
 		PreferredLicenses:      []string{"Apache License 2.0,MIT License"},
 		DisableHTTPGit:         false,
+		AlwaysRenderRawFiles:   false,
 
 		// Repository editor settings
 		Editor: struct {
@@ -824,6 +826,8 @@ please consider changing to GITEA_CUSTOM`)
 	if !filepath.IsAbs(Repository.Upload.TempPath) {
 		Repository.Upload.TempPath = path.Join(workDir, Repository.Upload.TempPath)
 	}
+	
+	Repository.AlwaysRenderRawFiles = sec.Key("ALWAYS_RENDER_RAW_FILES").MustBool()
 
 	sec = Cfg.Section("picture")
 	AvatarUploadPath = sec.Key("AVATAR_UPLOAD_PATH").MustString(path.Join(AppDataPath, "avatars"))

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -44,7 +44,6 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	return err
 }
 
-
 // ServeBlob download a git.Blob
 func ServeBlob(ctx *context.Context, blob *git.Blob) error {
 	dataRc, err := blob.Data()

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"path/filepath"
+	"mime"
 
 	"code.gitea.io/git"
 
@@ -31,6 +33,10 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 
 	if setting.Repository.AlwaysRenderRawFiles {
 		ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, name))
+		mimetype := mime.TypeByExtension(filepath.Ext(name))
+		if mimetype != "" {
+			ctx.Resp.Header().Set("Content-Type", mimetype)
+		}
 	} else if base.IsTextFile(buf) || ctx.QueryBool("render") {
 		ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	} else if base.IsImageFile(buf) || base.IsPDFFile(buf) {

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/git"
 
 	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/context"
 )
 
@@ -28,7 +29,9 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	// Google Chrome dislike commas in filenames, so let's change it to a space
 	name = strings.Replace(name, ",", " ", -1)
 
-	if base.IsTextFile(buf) || ctx.QueryBool("render") {
+	if setting.Repository.AlwaysRenderRawFiles {
+		ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, name))
+	} else if base.IsTextFile(buf) || ctx.QueryBool("render") {
 		ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	} else if base.IsImageFile(buf) || base.IsPDFFile(buf) {
 		ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, name))
@@ -40,6 +43,7 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	_, err := io.Copy(ctx.Resp, reader)
 	return err
 }
+
 
 // ServeBlob download a git.Blob
 func ServeBlob(ctx *context.Context, blob *git.Blob) error {


### PR DESCRIPTION
Used for serving raw files with the right content type, instead of text/plain. Fixes (#683). 

This option is disabled by default as it could be a potential security risk because the html in raw mode would render on the same domain as gitea.
