### PR TITLE
Less boilerplate in models/ unit tests

### DIFF
--- a/models/access_test.go
+++ b/models/access_test.go
@@ -6,6 +6,7 @@ package models
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,10 +20,10 @@ var accessModes = []AccessMode{
 func TestAccessLevel(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user1 := &User{ID: 2}; AssertExistsAndLoadBean(t, user1)
-	user2 := &User{ID: 4}; AssertExistsAndLoadBean(t, user2)
-	repo1 := &Repository{OwnerID: 2, IsPrivate: false}; AssertExistsAndLoadBean(t, repo1)
-	repo2 := &Repository{OwnerID: 3, IsPrivate: true}; AssertExistsAndLoadBean(t, repo2)
+	user1 := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	user2 := AssertExistsAndLoadBean(t, &User{ID: 4}).(*User)
+	repo1 := AssertExistsAndLoadBean(t, &Repository{OwnerID: 2, IsPrivate: false}).(*Repository)
+	repo2 := AssertExistsAndLoadBean(t, &Repository{OwnerID: 3, IsPrivate: true}).(*Repository)
 
 	level, err := AccessLevel(user1, repo1)
 	assert.NoError(t, err)
@@ -44,10 +45,10 @@ func TestAccessLevel(t *testing.T) {
 func TestHasAccess(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user1 := &User{ID: 2}; AssertExistsAndLoadBean(t, user1)
-	user2 := &User{ID: 4}; AssertExistsAndLoadBean(t, user2)
-	repo1 := &Repository{OwnerID: 2, IsPrivate: false}; AssertExistsAndLoadBean(t, repo1)
-	repo2 := &Repository{OwnerID: 3, IsPrivate: true}; AssertExistsAndLoadBean(t, repo2)
+	user1 := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	user2 := AssertExistsAndLoadBean(t, &User{ID: 4}).(*User)
+	repo1 := AssertExistsAndLoadBean(t, &Repository{OwnerID: 2, IsPrivate: false}).(*Repository)
+	repo2 := AssertExistsAndLoadBean(t, &Repository{OwnerID: 3, IsPrivate: true}).(*Repository)
 
 	for _, accessMode := range accessModes {
 		has, err := HasAccess(user1, repo1, accessMode)
@@ -71,9 +72,7 @@ func TestHasAccess(t *testing.T) {
 func TestUser_GetRepositoryAccesses(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user1 := &User{ID: 1}; AssertExistsAndLoadBean(t, user1)
-	user2 := &User{ID: 2}; AssertExistsAndLoadBean(t, user2)
-
+	user1 := AssertExistsAndLoadBean(t, &User{ID: 1}).(*User)
 	accesses, err := user1.GetRepositoryAccesses()
 	assert.NoError(t, err)
 	assert.Len(t, accesses, 0)
@@ -82,23 +81,21 @@ func TestUser_GetRepositoryAccesses(t *testing.T) {
 func TestUser_GetAccessibleRepositories(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user1 := &User{ID: 1}; AssertExistsAndLoadBean(t, user1)
-	user2 := &User{ID: 2}; AssertExistsAndLoadBean(t, user2)
-
+	user1 := AssertExistsAndLoadBean(t, &User{ID: 1}).(*User)
 	repos, err := user1.GetAccessibleRepositories(0)
 	assert.NoError(t, err)
 	assert.Len(t, repos, 0)
 
+	user2 := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 	repos, err = user2.GetAccessibleRepositories(0)
 	assert.NoError(t, err)
 	assert.Len(t, repos, 1)
 }
 
-
 func TestRepository_RecalculateAccesses(t *testing.T) {
 	// test with organization repo
 	assert.NoError(t, PrepareTestDatabase())
-	repo1 := &Repository{ID: 3}; AssertExistsAndLoadBean(t, repo1)
+	repo1 := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
 	assert.NoError(t, repo1.GetOwner())
 
 	sess := x.NewSession()
@@ -119,7 +116,7 @@ func TestRepository_RecalculateAccesses(t *testing.T) {
 func TestRepository_RecalculateAccesses2(t *testing.T) {
 	// test with non-organization repo
 	assert.NoError(t, PrepareTestDatabase())
-	repo1 := &Repository{ID: 4}; AssertExistsAndLoadBean(t, repo1)
+	repo1 := AssertExistsAndLoadBean(t, &Repository{ID: 4}).(*Repository)
 	assert.NoError(t, repo1.GetOwner())
 
 	sess := x.NewSession()

--- a/models/action_test.go
+++ b/models/action_test.go
@@ -29,10 +29,8 @@ func TestAction_GetRepoLink(t *testing.T) {
 func TestNewRepoAction(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
-	repo := &Repository{OwnerID: user.ID}
-	AssertExistsAndLoadBean(t, repo)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{OwnerID: user.ID}).(*Repository)
 	repo.Owner = user
 
 	actionBean := &Action{
@@ -53,10 +51,8 @@ func TestNewRepoAction(t *testing.T) {
 func TestRenameRepoAction(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
-	repo := &Repository{OwnerID: user.ID}
-	AssertExistsAndLoadBean(t, repo)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{OwnerID: user.ID}).(*Repository)
 	repo.Owner = user
 
 	oldRepoName := repo.Name
@@ -179,10 +175,8 @@ func TestUpdateIssuesCommit(t *testing.T) {
 		},
 	}
 
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
-	repo := &Repository{ID: 1}
-	AssertExistsAndLoadBean(t, repo)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
 	repo.Owner = user
 
 	commentBean := &Comment{
@@ -203,10 +197,8 @@ func TestUpdateIssuesCommit(t *testing.T) {
 func TestCommitRepoAction(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
-	repo := &Repository{ID: 2, OwnerID: user.ID}
-	AssertExistsAndLoadBean(t, repo)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 2, OwnerID: user.ID}).(*Repository)
 	repo.Owner = user
 
 	pushCommits := NewPushCommits()
@@ -255,12 +247,9 @@ func TestCommitRepoAction(t *testing.T) {
 func TestTransferRepoAction(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	user2 := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user2)
-	user4 := &User{ID: 4}
-	AssertExistsAndLoadBean(t, user4)
-	repo := &Repository{ID: 1, OwnerID: user2.ID}
-	AssertExistsAndLoadBean(t, repo)
+	user2 := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	user4 := AssertExistsAndLoadBean(t, &User{ID: 4}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1, OwnerID: user2.ID}).(*Repository)
 
 	repo.OwnerID = user4.ID
 	repo.Owner = user4
@@ -281,13 +270,10 @@ func TestTransferRepoAction(t *testing.T) {
 
 func TestMergePullRequestAction(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
-	repo := &Repository{ID: 1, OwnerID: user.ID}
-	AssertExistsAndLoadBean(t, repo)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1, OwnerID: user.ID}).(*Repository)
 	repo.Owner = user
-	issue := &Issue{ID: 3, RepoID: repo.ID}
-	AssertExistsAndLoadBean(t, issue)
+	issue := AssertExistsAndLoadBean(t, &Issue{ID: 3, RepoID: repo.ID}).(*Issue)
 
 	actionBean := &Action{
 		OpType:       ActionMergePullRequest,
@@ -306,8 +292,7 @@ func TestMergePullRequestAction(t *testing.T) {
 func TestGetFeeds(t *testing.T) {
 	// test with an individual user
 	assert.NoError(t, PrepareTestDatabase())
-	user := &User{ID: 2}
-	AssertExistsAndLoadBean(t, user)
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 
 	actions, err := GetFeeds(user, user.ID, 0, false)
 	assert.NoError(t, err)
@@ -323,8 +308,7 @@ func TestGetFeeds(t *testing.T) {
 func TestGetFeeds2(t *testing.T) {
 	// test with an organization user
 	assert.NoError(t, PrepareTestDatabase())
-	user := &User{ID: 3}
-	AssertExistsAndLoadBean(t, user)
+	user := AssertExistsAndLoadBean(t, &User{ID: 3}).(*User)
 
 	actions, err := GetFeeds(user, user.ID, 0, false)
 	assert.NoError(t, err)

--- a/models/setup_for_test.go
+++ b/models/setup_for_test.go
@@ -59,10 +59,11 @@ func loadBeanIfExists(bean interface{}, conditions ...interface{}) (bool, error)
 
 // AssertExistsAndLoadBean assert that a bean exists and load it from the test
 // database
-func AssertExistsAndLoadBean(t *testing.T, bean interface{}, conditions ...interface{}) {
+func AssertExistsAndLoadBean(t *testing.T, bean interface{}, conditions ...interface{}) interface{} {
 	exists, err := loadBeanIfExists(bean, conditions...)
 	assert.NoError(t, err)
 	assert.True(t, exists)
+	return bean
 }
 
 // AssertNotExistsBean assert that a bean does not exist in the test database

--- a/models/token_test.go
+++ b/models/token_test.go
@@ -17,13 +17,7 @@ func TestNewAccessToken(t *testing.T) {
 		Name: "Token C",
 	}
 	assert.NoError(t, NewAccessToken(token))
-	sess := x.NewSession()
-	defer sess.Close()
-	has, err := sess.Get(*token)
-	assert.NoError(t, err)
-	assert.True(t, has)
-	assert.Equal(t, int64(3), token.UID)
-	assert.Equal(t, "Token C", token.Name)
+	AssertExistsAndLoadBean(t, token)
 
 	invalidToken := &AccessToken{
 		ID:   token.ID, // duplicate
@@ -78,13 +72,7 @@ func TestUpdateAccessToken(t *testing.T) {
 	token.Name = "Token Z"
 
 	assert.NoError(t, UpdateAccessToken(token))
-
-	sess := x.NewSession()
-	defer sess.Close()
-	has, err := sess.Get(token)
-	assert.NoError(t, err)
-	assert.True(t, has)
-	assert.Equal(t, token.Name, "Token Z")
+	AssertExistsAndLoadBean(t, token)
 }
 
 func TestDeleteAccessTokenByID(t *testing.T) {
@@ -95,11 +83,7 @@ func TestDeleteAccessTokenByID(t *testing.T) {
 	assert.Equal(t, int64(1), token.UID)
 
 	assert.NoError(t, DeleteAccessTokenByID(token.ID, 1))
-	sess := x.NewSession()
-	defer sess.Close()
-	has, err := sess.Get(token)
-	assert.NoError(t, err)
-	assert.False(t, has)
+	AssertNotExistsBean(t, token)
 
 	err = DeleteAccessTokenByID(100, 100)
 	assert.Error(t, err)

--- a/models/update_test.go
+++ b/models/update_test.go
@@ -23,13 +23,7 @@ func TestAddUpdateTask(t *testing.T) {
 		NewCommitID: "newCommitId4",
 	}
 	assert.NoError(t, AddUpdateTask(task))
-
-	sess := x.NewSession()
-	defer sess.Close()
-	has, err := sess.Get(task)
-	assert.NoError(t, err)
-	assert.True(t, has)
-	assert.Equal(t, "uuid4", task.UUID)
+	AssertExistsAndLoadBean(t, task)
 }
 
 func TestGetUpdateTaskByUUID(t *testing.T) {
@@ -49,11 +43,7 @@ func TestGetUpdateTaskByUUID(t *testing.T) {
 func TestDeleteUpdateTaskByUUID(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	assert.NoError(t, DeleteUpdateTaskByUUID("uuid1"))
-	sess := x.NewSession()
-	defer sess.Close()
-	has, err := sess.Get(&UpdateTask{UUID: "uuid1"})
-	assert.NoError(t, err)
-	assert.False(t, has)
+	AssertNotExistsBean(t, &UpdateTask{UUID: "uuid1"})
 
 	assert.NoError(t, DeleteUpdateTaskByUUID("invalid"))
 }


### PR DESCRIPTION
Change signature of `AssertExistsAndLoadBean` so that test fixtures can be loaded in a single line of code. Also add calls to `AssertExistsAndLoadBean` and `AssertNotExistsBean` to eliminate duplicated logic.


