### PR TITLE
Fix FIXME and remove superfluous queries in models/org

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -113,15 +113,20 @@ func Dashboard(ctx *context.Context) {
 	var err error
 	var repos, mirrors []*models.Repository
 	if ctxUser.IsOrganization() {
-		repos, _, err = ctxUser.GetUserRepositories(ctx.User.ID, 1, setting.UI.User.RepoPagingNum)
+		env, err := ctxUser.AccessibleReposEnv(ctx.User.ID)
 		if err != nil {
-			ctx.Handle(500, "GetUserRepositories", err)
+			ctx.Handle(500, "AccessibleReposEnv", err)
+			return
+		}
+		repos, err = env.Repos(1, setting.UI.User.RepoPagingNum)
+		if err != nil {
+			ctx.Handle(500, "env.Repos", err)
 			return
 		}
 
-		mirrors, err = ctxUser.GetUserMirrorRepositories(ctx.User.ID)
+		mirrors, err = env.MirrorRepos()
 		if err != nil {
-			ctx.Handle(500, "GetUserMirrorRepositories", err)
+			ctx.Handle(500, "env.MirrorRepos", err)
 			return
 		}
 	} else {
@@ -204,7 +209,12 @@ func Issues(ctx *context.Context) {
 	var err error
 	var repos []*models.Repository
 	if ctxUser.IsOrganization() {
-		repos, _, err = ctxUser.GetUserRepositories(ctx.User.ID, 1, ctxUser.NumRepos)
+		env, err := ctxUser.AccessibleReposEnv(ctx.User.ID)
+		if err != nil {
+			ctx.Handle(500, "AccessibleReposEnv", err)
+			return
+		}
+		repos, err = env.Repos(1, ctxUser.NumRepos)
 		if err != nil {
 			ctx.Handle(500, "GetRepositories", err)
 			return
@@ -352,9 +362,19 @@ func showOrgProfile(ctx *context.Context) {
 		err   error
 	)
 	if ctx.IsSigned && !ctx.User.IsAdmin {
-		repos, count, err = org.GetUserRepositories(ctx.User.ID, page, setting.UI.User.RepoPagingNum)
+		env, err := org.AccessibleReposEnv(ctx.User.ID)
 		if err != nil {
-			ctx.Handle(500, "GetUserRepositories", err)
+			ctx.Handle(500, "AccessibleReposEnv", err)
+			return
+		}
+		repos, err = env.Repos(page, setting.UI.User.RepoPagingNum)
+		if err != nil {
+			ctx.Handle(500, "env.Repos", err)
+			return
+		}
+		count, err = env.CountRepos()
+		if err != nil {
+			ctx.Handle(500, "env.CountRepos", err)
 			return
 		}
 		ctx.Data["Repos"] = repos


### PR DESCRIPTION
I realize this is long, but I want to give some context for my changes. Please bear with me, or jump to the TL;DR at the bottom if you're impatient.

This PR addresses the following `FIXME` in `models/org.go, line 474-475` (an identical `FIXME` is also in `models/action.go, line 661`):

```
// FIXME: only need to get IDs here, not all fields of repository.
repos, _, err := org.GetUserRepositories(user.ID, 1, org.NumRepos)
```

`org.GetUserRepositories(uid, ..)` first computes the necessary repoIDs, then loads the repos with those repoIDs, then finally computes a count (the second return value, which is ignored above). It would therefore make sense to create a separate function for computing the repoIDs (say `org.GetUserRepositoryIDs(uid, ..)`) that both `org.GetUserRepositories(..)` and `models/org.go, 474-475` can use.

There's more: of the several places where `org.GetUserRepositories(..)` is called, the count is ignored in all but one place (`routers/user/home.go, line 355`). So most of the time when `org.GetUserRepositories(..)` is called, the count is calculated (which involves a join), and then the count is immediately thrown away. I therefore decided to not have `org.GetUserRepositories(..)` compute the count, but instead move that logic to another function (say `org.GetAccessibleReposCount(uid)`) to avoid wasting work. `routers/user/home.go, line 355` would then make two calls: one to `org.GetUserRepositories(..)` and another to `org.GetAccessibleRepoCount(..)`.

This seems promising, but there's one problem with this approach: both computing the repoIDs (in `org.GetUserRepositoryIDs(..)`, and by extension `org.GetUserRepositories(..)`) and computing the count (`org.GetAccessibleRepoCount(..)`) require determining which teams the specified user belongs to. In `routers/user/home.go, line 355`, where I actually care about the count, I will need to compute the teams that a user belongs to twice (once for `org.GetUserRepositories()`, another time for `org.GetAccessibleRepoCount()`). The same problem occurs in places where both `org.GetUserRepositories()` and `org.GetUserMirrorRepositories()`) are called, (e.g. `routers/user/home.go, line 116`).


Taking a step back, there are three functions
* `org.GetUserRepositoryIDs(uid, ..)` 
* `org.GetAccessibleRepositoryCount(uid)`
* `org.GetUserMirrorRepositories(uid)`

all of which require the same preprocessing, and we would like to avoid doing the preprocessing more than once if we call these functions multiple times with the same `uid`. The solution that occurred to me was to move these functions to a `AccessibleRepoEnvironment` interface. The implementation of the interface, `accessibleRepoEnv`, would store the results of the preprocessing (i.e. the teamIDs a particular user belongs to), and each function/method would just use those results instead of (re)computing them.

Under my changes, to call these functions/method, one can do the following
```
env, err := org.AccessibleRepoEnv(userID) // preprocessing done here
// check err
count, err := env.CountRepos() // org and uid not provided, they're specific to env
// check err
repos := env.Repos()
// check err
...
```
and no work will be wasted or duplicated :smiley:. The interface, or at least the idea behind, could also be used in other parts of the codebase.

**TL;DR:** I got rid of useless/duplicated queries by moving some functions to an interface.

I'm open to suggestions (particularly for naming) and would be happy to hear any feedback on this.
