### PR TITLE
fix xorm NewSession uncorrected usages

### DIFF
--- a/models/access_test.go
+++ b/models/access_test.go
@@ -98,16 +98,12 @@ func TestRepository_RecalculateAccesses(t *testing.T) {
 	repo1 := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
 	assert.NoError(t, repo1.GetOwner())
 
-	sess := x.NewSession()
-	defer sess.Close()
-	_, err := sess.Delete(&Collaboration{UserID: 2, RepoID: 3})
+	_, err := x.Delete(&Collaboration{UserID: 2, RepoID: 3})
 	assert.NoError(t, err)
-
 	assert.NoError(t, repo1.RecalculateAccesses())
 
-	sess = x.NewSession()
 	access := &Access{UserID: 2, RepoID: 3}
-	has, err := sess.Get(access)
+	has, err := x.Get(access)
 	assert.NoError(t, err)
 	assert.True(t, has)
 	assert.Equal(t, AccessModeWrite, access.Mode)
@@ -119,15 +115,11 @@ func TestRepository_RecalculateAccesses2(t *testing.T) {
 	repo1 := AssertExistsAndLoadBean(t, &Repository{ID: 4}).(*Repository)
 	assert.NoError(t, repo1.GetOwner())
 
-	sess := x.NewSession()
-	defer sess.Close()
-	_, err := sess.Delete(&Collaboration{UserID: 4, RepoID: 4})
+	_, err := x.Delete(&Collaboration{UserID: 4, RepoID: 4})
 	assert.NoError(t, err)
-
 	assert.NoError(t, repo1.RecalculateAccesses())
 
-	sess = x.NewSession()
-	has, err := sess.Get(&Access{UserID: 4, RepoID: 4})
+	has, err := x.Get(&Access{UserID: 4, RepoID: 4})
 	assert.NoError(t, err)
 	assert.False(t, has)
 }

--- a/models/org.go
+++ b/models/org.go
@@ -345,13 +345,15 @@ func getOrgsByUserID(sess *xorm.Session, userID int64, showAll bool) ([]*User, e
 // GetOrgsByUserID returns a list of organizations that the given user ID
 // has joined.
 func GetOrgsByUserID(userID int64, showAll bool) ([]*User, error) {
-	return getOrgsByUserID(x.NewSession(), userID, showAll)
+	sess := x.NewSession()
+	defer sess.Close()
+	return getOrgsByUserID(sess, userID, showAll)
 }
 
 // GetOrgsByUserIDDesc returns a list of organizations that the given user ID
 // has joined, ordered descending by the given condition.
 func GetOrgsByUserIDDesc(userID int64, desc string, showAll bool) ([]*User, error) {
-	return getOrgsByUserID(x.NewSession().Desc(desc), userID, showAll)
+	return getOrgsByUserID(x.Desc(desc), userID, showAll)
 }
 
 func getOwnedOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
@@ -367,14 +369,14 @@ func getOwnedOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
 // GetOwnedOrgsByUserID returns a list of organizations are owned by given user ID.
 func GetOwnedOrgsByUserID(userID int64) ([]*User, error) {
 	sess := x.NewSession()
+	defer sess.Close()
 	return getOwnedOrgsByUserID(sess, userID)
 }
 
 // GetOwnedOrgsByUserIDDesc returns a list of organizations are owned by
 // given user ID, ordered descending by the given condition.
 func GetOwnedOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
-	sess := x.NewSession()
-	return getOwnedOrgsByUserID(sess.Desc(desc), userID)
+	return getOwnedOrgsByUserID(x.Desc(desc), userID)
 }
 
 // GetOrgUsersByUserID returns all organization-user relations by user ID.

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -309,7 +309,7 @@ func UpdateTeam(t *Team, authChanged bool) (err error) {
 	}
 
 	t.LowerName = strings.ToLower(t.Name)
-	has, err := x.
+	has, err := sess.
 		Where("org_id=?", t.OrgID).
 		And("lower_name=?", t.LowerName).
 		And("id!=?", t.ID).

--- a/models/pull_test.go
+++ b/models/pull_test.go
@@ -225,11 +225,9 @@ func TestChangeUsernameInPullRequests(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	const newUsername = "newusername"
 	assert.NoError(t, ChangeUsernameInPullRequests("user1", newUsername))
-	sess := x.NewSession()
-	defer sess.Close()
 
 	prs := make([]*PullRequest, 0, 10)
-	assert.NoError(t, sess.Where("head_user_name = ?", newUsername).Find(&prs))
+	assert.NoError(t, x.Where("head_user_name = ?", newUsername).Find(&prs))
 	assert.Len(t, prs, 2)
 	for _, pr := range prs {
 		assert.Equal(t, newUsername, pr.HeadUserName)

--- a/models/star.go
+++ b/models/star.go
@@ -14,7 +14,6 @@ type Star struct {
 // StarRepo or unstar repository.
 func StarRepo(userID, repoID int64, star bool) error {
 	sess := x.NewSession()
-
 	defer sess.Close()
 
 	if err := sess.Begin(); err != nil {


### PR DESCRIPTION
If `x.NewSession()` be called, `sess.Close()` must be called after that.