### PR TITLE
Unit tests for models/wiki

### DIFF
--- a/models/setup_for_test.go
+++ b/models/setup_for_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"testing"
 
+	"code.gitea.io/gitea/modules/setting"
+
 	"github.com/go-xorm/core"
 	"github.com/go-xorm/xorm"
 	_ "github.com/mattn/go-sqlite3" // for the test engine
@@ -23,6 +25,14 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Error creating test engine: %v\n", err)
 		os.Exit(1)
 	}
+
+	setting.AppURL = "https://try.gitea.io/"
+	setting.RunUser = "runuser"
+	setting.SSH.Port = 3000
+	setting.SSH.Domain = "try.gitea.io"
+	setting.RepoRootPath = "/repos"
+	setting.AppDataPath = "/appdata"
+
 	os.Exit(m.Run())
 }
 

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -41,7 +41,7 @@ func ToWikiPageName(urlString string) string {
 }
 
 // WikiCloneLink returns clone URLs of repository wiki.
-func (repo *Repository) WikiCloneLink() (cl *CloneLink) {
+func (repo *Repository) WikiCloneLink() *CloneLink {
 	return repo.cloneLink(true)
 }
 

--- a/models/wiki_test.go
+++ b/models/wiki_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToWikiPageURL(t *testing.T) {
+	assert.Equal(t, "wiki-name", ToWikiPageURL("wiki-name"))
+	assert.Equal(t, "wiki-name-with-many-spaces", ToWikiPageURL("wiki name with many spaces"))
+}
+
+func TestToWikiPageName(t *testing.T) {
+	assert.Equal(t, "wiki name", ToWikiPageName("wiki name"))
+	assert.Equal(t, "wiki name", ToWikiPageName("wiki-name"))
+	assert.Equal(t, "wiki name", ToWikiPageName("wiki\tname"))
+	assert.Equal(t, "wiki name", ToWikiPageName("./.././wiki/name"))
+}
+
+func TestRepository_WikiCloneLink(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
+	cloneLink := repo.WikiCloneLink()
+	assert.Equal(t, "ssh://runuser@try.gitea.io:3000/user2/repo1.wiki.git", cloneLink.SSH)
+	assert.Equal(t, "https://try.gitea.io/user2/repo1.wiki.git", cloneLink.HTTPS)
+}
+
+func TestWikiPath(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	assert.Equal(t, "/repos/user2/repo1.wiki.git", WikiPath("user2", "repo1"))
+}
+
+func TestRepository_WikiPath(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
+	assert.Equal(t, "/repos/user2/repo1.wiki.git", repo.WikiPath())
+}
+
+// TODO TestRepository_HasWiki
+
+// TODO TestRepository_InitWiki
+
+func TestRepository_LocalWikiPath(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
+	assert.Equal(t, "/appdata/tmp/local-wiki/1", repo.LocalWikiPath())
+}
+
+// TODO TestRepository_UpdateLocalWiki
+
+// TODO ... (all remaining untested functions)


### PR DESCRIPTION
Unfornuately, many of the functions in `models/wiki.go` rely on git and the file-system, so they can't be tested until we find a good approach for testing functions with git/file-system dependencies.
