### PR TITLE
Add possibility to record branch information in an issue

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -49,6 +49,7 @@ type Issue struct {
 	IsPull          bool         `xorm:"INDEX"` // Indicates whether is a pull request or not.
 	PullRequest     *PullRequest `xorm:"-"`
 	NumComments     int
+	Ref             string
 
 	Deadline     time.Time `xorm:"-"`
 	DeadlineUnix int64     `xorm:"INDEX"`

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -194,6 +194,7 @@ func (f *NewSlackHookForm) Validate(ctx *macaron.Context, errs binding.Errors) b
 type CreateIssueForm struct {
 	Title       string `binding:"Required;MaxSize(255)"`
 	LabelIDs    string `form:"label_ids"`
+	Ref         string `form:"ref"`
 	MilestoneID int64
 	AssigneeID  int64
 	Content     string

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -612,6 +612,7 @@ issues.new.closed_milestone = Closed Milestones
 issues.new.assignee = Assignee
 issues.new.clear_assignee = Clear assignee
 issues.new.no_assignee = No assignee
+issues.no_ref = No Branch/Tag Specified
 issues.create = Create Issue
 issues.new_label = New Label
 issues.new_label_placeholder = Label name...

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -86,6 +86,22 @@ function initEditForm() {
     initEditDiffTab($('.edit.form'));
 }
 
+function initBranchSelector() {
+    var $selectBranch = $('.ui.select-branch')
+    var $branchMenu = $selectBranch.find('.reference-list-menu');
+    $branchMenu.find('.item:not(.no-select)').click(function () {
+        var selectedValue = $(this).data('id');
+        $($(this).data('id-selector')).val(selectedValue);
+        $selectBranch.find('.ui .branch-name').text(selectedValue);
+    });
+    $selectBranch.find('.reference.column').click(function () {
+        $selectBranch.find('.scrolling.reference-list-menu').css('display', 'none');
+        $selectBranch.find('.reference .text').removeClass('black');
+        $($(this).data('target')).css('display', 'block');
+        $(this).find('.text').addClass('black');
+        return false;
+    });
+}
 
 function updateIssuesMeta(url, action, issueIds, elementId, afterSuccess) {
     $.ajax({
@@ -106,6 +122,7 @@ function initCommentForm() {
         return
     }
 
+    initBranchSelector();
     initCommentPreviewTab($('.comment.form'));
 
     // Labels

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -292,6 +292,13 @@ func RetrieveRepoMetas(ctx *context.Context, repo *models.Repository) []*models.
 		return nil
 	}
 
+	brs, err := ctx.Repo.GitRepo.GetBranches()
+	if err != nil {
+		ctx.Handle(500, "GetBranches", err)
+		return nil
+	}
+	ctx.Data["Branches"] = brs
+
 	return labels
 }
 
@@ -418,6 +425,7 @@ func NewIssuePost(ctx *context.Context, form auth.CreateIssueForm) {
 	ctx.Data["PageIsIssueList"] = true
 	ctx.Data["RequireHighlightJS"] = true
 	ctx.Data["RequireSimpleMDE"] = true
+	ctx.Data["ReadOnly"] = false
 	renderAttachmentSettings(ctx)
 
 	var (
@@ -447,6 +455,7 @@ func NewIssuePost(ctx *context.Context, form auth.CreateIssueForm) {
 		MilestoneID: milestoneID,
 		AssigneeID:  assigneeID,
 		Content:     form.Content,
+		Ref:         form.Ref,
 	}
 	if err := models.NewIssue(repo, issue, labelIDs, attachments); err != nil {
 		ctx.Handle(500, "NewIssue", err)
@@ -668,6 +677,7 @@ func ViewIssue(ctx *context.Context) {
 	ctx.Data["Participants"] = participants
 	ctx.Data["NumParticipants"] = len(participants)
 	ctx.Data["Issue"] = issue
+	ctx.Data["ReadOnly"] = true
 	ctx.Data["IsIssueOwner"] = ctx.Repo.IsWriter() || (ctx.IsSigned && issue.IsPoster(ctx.User.ID))
 	ctx.Data["SignInLink"] = setting.AppSubURL + "/user/login?redirect_to=" + ctx.Data["Link"].(string)
 	ctx.HTML(200, tplIssueView)

--- a/templates/repo/issue/branch_selector_field.tmpl
+++ b/templates/repo/issue/branch_selector_field.tmpl
@@ -1,0 +1,41 @@
+<input id="ref_selector" name="ref" type="hidden" value="{{.Issue.Ref}}">
+<div class="ui {{if .ReadOnly}}disabled{{end}} floating filter select-branch dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
+	<div class="ui basic small button">
+		<span class="text branch-name">{{if .Issue.Ref}}{{.Issue.Ref}}{{else}}{{.i18n.Tr "repo.issues.no_ref"}}{{end}}</span>
+		<i class="dropdown icon"></i>
+	</div>
+	<div class="menu">
+		<div class="ui icon search input">
+			<i class="filter icon"></i>
+			<input name="search" placeholder="{{.i18n.Tr "repo.filter_branch_and_tag"}}...">
+		</div>
+		<div class="header">
+			<div class="ui grid">
+				<div class="two column row">
+					<a class="reference column" href="#" data-target="#branch-list">
+						<span class="text black">
+							<i class="octicon octicon-git-branch"></i> {{.i18n.Tr "repo.branches"}}
+						</span>
+					</a>
+					<a class="reference column" href="#" data-target="#tag-list">
+						<span class="text">
+							<i class="reference tags icon"></i> {{.i18n.Tr "repo.tags"}}
+						</span>
+					</a>
+				</div>
+			</div>
+		</div>
+		<div id="branch-list" class="scrolling menu reference-list-menu">
+		{{range .Branches}}
+			<div class="item" data-id="{{.}}" data-id-selector="#ref_selector">{{.}}</div>
+		{{end}}
+		</div>
+		<div id="tag-list" class="scrolling menu reference-list-menu" style="display: none">
+		{{range .Tags}}
+			<div class="item" data-id="{{.}}" data-id-selector="#ref_selector">{{.}}</div>
+		{{end}}
+		</div>
+	</div>
+</div>
+
+<div class="ui divider"></div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -171,6 +171,9 @@
 					<div class="ui {{if .IsRead}}black{{else}}green{{end}} label">#{{.Index}}</div>
 					<a class="title has-emoji" href="{{$.Link}}/{{.Index}}">{{.Title}}</a>
 
+					{{if .Ref}}
+						<a class="ui label" href="{{$.RepoLink}}/src/{{.Ref}}">{{.Ref}}</a>
+					{{end}}
 					{{range .Labels}}
 						<a class="ui label" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{.ID}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" style="color: {{.ForegroundColor}}; background-color: {{.Color}}">{{.Name | Sanitize}}</a>
 					{{end}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -32,6 +32,8 @@
 
 	<div class="four wide column">
 		<div class="ui segment metas">
+			{{template "repo/issue/branch_selector_field" .}}
+
 			<input id="label_ids" name="label_ids" type="hidden" value="{{.label_ids}}">
 			<div class="ui {{if not .Labels}}disabled{{end}} floating jump select-label dropdown">
 				<span class="text">

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -1,5 +1,7 @@
 <div class="four wide column">
 	<div class="ui segment metas">
+		{{template "repo/issue/branch_selector_field" .}}
+
 		<div class="ui {{if not .IsRepositoryWriter}}disabled{{end}} floating jump select-label dropdown">
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>


### PR DESCRIPTION
This patch add a new field to the 'issue' entity, named 'branch' with the necessary UI to specify which branch this issue is referring. 
 Searching, filtering and editing is not yet implemented, so the branch can only specified when creating the issue
