### PR TITLE
Allow custom public files

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -88,6 +88,11 @@ func newMacaron() *macaron.Macaron {
 	if setting.Protocol == setting.FCGI {
 		m.SetURLPrefix(setting.AppSubURL)
 	}
+	m.Use(public.Custom(
+		&public.Options{
+			SkipLogging: setting.DisableRouterLog,
+		},
+	))
 	m.Use(public.Static(
 		&public.Options{
 			Directory:   path.Join(setting.StaticRootPath, "public"),

--- a/models/attachment.go
+++ b/models/attachment.go
@@ -31,7 +31,6 @@ type Attachment struct {
 	CreatedUnix int64
 }
 
-
 // BeforeInsert is invoked from XORM before inserting an object of this type.
 func (a *Attachment) BeforeInsert() {
 	a.CreatedUnix = time.Now().Unix()

--- a/models/issue.go
+++ b/models/issue.go
@@ -953,9 +953,9 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 
 	switch opts.IsPull {
 	case util.OptionalBoolTrue:
-		sess.And("issue.is_pull=?",true)
+		sess.And("issue.is_pull=?", true)
 	case util.OptionalBoolFalse:
-		sess.And("issue.is_pull=?",false)
+		sess.And("issue.is_pull=?", false)
 	}
 
 	sortIssuesSession(sess, opts.SortType)
@@ -1780,4 +1780,3 @@ func DeleteMilestoneByRepoID(repoID, id int64) error {
 	}
 	return sess.Commit()
 }
-

--- a/models/pull.go
+++ b/models/pull.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"code.gitea.io/git"
+	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
@@ -21,7 +22,6 @@ import (
 	api "code.gitea.io/sdk/gitea"
 	"github.com/Unknwon/com"
 	"github.com/go-xorm/xorm"
-	"code.gitea.io/gitea/modules/base"
 )
 
 var pullRequestQueue = sync.NewUniqueQueue(setting.Repository.PullRequestQueueLength)

--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -4,6 +4,13 @@
 
 package public
 
+import (
+	"path"
+
+	"code.gitea.io/gitea/modules/setting"
+	"gopkg.in/macaron.v1"
+)
+
 //go:generate go-bindata -tags "bindata" -ignore "\\.go|\\.less" -pkg "public" -o "bindata.go" ../../public/...
 //go:generate go fmt bindata.go
 //go:generate sed -i.bak s/..\/..\/public\/// bindata.go
@@ -13,4 +20,14 @@ package public
 type Options struct {
 	Directory   string
 	SkipLogging bool
+}
+
+// Custom implements the macaron static handler for serving custom assets.
+func Custom(opts *Options) macaron.Handler {
+	return macaron.Static(
+		path.Join(setting.CustomPath, "public"),
+		macaron.StaticOptions{
+			SkipLogging: opts.SkipLogging,
+		},
+	)
 }

--- a/routers/init.go
+++ b/routers/init.go
@@ -12,13 +12,13 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/cron"
 	"code.gitea.io/gitea/modules/highlight"
+	"code.gitea.io/gitea/modules/indexer"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/mailer"
 	"code.gitea.io/gitea/modules/markdown"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/ssh"
 	macaron "gopkg.in/macaron.v1"
-	"code.gitea.io/gitea/modules/indexer"
 )
 
 func checkRunMode() {

--- a/routers/repo/attachment.go
+++ b/routers/repo/attachment.go
@@ -70,4 +70,3 @@ func UploadAttachment(ctx *context.Context) {
 		"uuid": attach.UUID,
 	})
 }
-

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -169,7 +169,7 @@ func NewRelease(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.release.new_release")
 	ctx.Data["PageIsReleaseList"] = true
 	ctx.Data["tag_target"] = ctx.Repo.Repository.DefaultBranch
-	renderAttachmentSettings(ctx);
+	renderAttachmentSettings(ctx)
 	ctx.HTML(200, tplReleaseNew)
 }
 
@@ -250,7 +250,7 @@ func EditRelease(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.release.edit_release")
 	ctx.Data["PageIsReleaseList"] = true
 	ctx.Data["PageIsEditRelease"] = true
-	renderAttachmentSettings(ctx);
+	renderAttachmentSettings(ctx)
 
 	tagName := ctx.Params("*")
 	rel, err := models.GetRelease(ctx.Repo.Repository.ID, tagName)


### PR DESCRIPTION
This allows serving custom public files again, just place files into `custom/public/` and they will be available to the builtin server.

Fixes #758