### PR TITLE
[WIP] Added custom css file. Fixes #688

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,0 +1,4 @@
+/* To use custom css, add a file in GITEA_CUSTOM/public/css/custom.css 
+ * in your gitea installation. 
+ * GITEA_CUSTOM is folder-with-gitea-executable/custom/ by default 
+ */

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -32,6 +32,7 @@
 	<!-- Stylesheet -->
 	<link rel="stylesheet" href="{{AppSubUrl}}/css/semantic-2.2.1.min.css">
 	<link rel="stylesheet" href="{{AppSubUrl}}/css/index.css?v={{MD5 AppVer}}">
+	<link rel="stylesheet" href="{{AppSubUrl}}/css/custom.css?v={{MD5 AppVer}}">
 
 {{if .RequireHighlightJS}}
 	<link rel="stylesheet" href="{{AppSubUrl}}/plugins/highlight-9.6.0/github.css">


### PR DESCRIPTION
I have added a line to the gitea css file which imports custom.css. It is blank by default (so there are not any 404s), but because of #782, it can be overridden, therefore allowing custom css which can survive updates.