### PR TITLE
Cleanup log messaging

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -82,7 +82,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 	case *ecdsa.PrivateKey:
 		b, err := x509.MarshalECPrivateKey(k)
 		if err != nil {
-			log.Fatalf("Unable to marshal ECDSA private key: %v\n", err)
+			log.Fatalf("Unable to marshal ECDSA private key: %v", err)
 		}
 		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
 	default:
@@ -112,7 +112,7 @@ func runCert(ctx *cli.Context) error {
 		log.Fatalf("Unrecognized elliptic curve: %q", ctx.String("ecdsa-curve"))
 	}
 	if err != nil {
-		log.Fatalf("Failed to generate private key: %s", err)
+		log.Fatalf("Failed to generate private key: %v", err)
 	}
 
 	var notBefore time.Time
@@ -121,7 +121,7 @@ func runCert(ctx *cli.Context) error {
 	} else {
 		notBefore, err = time.Parse("Jan 2 15:04:05 2006", ctx.String("start-date"))
 		if err != nil {
-			log.Fatalf("Failed to parse creation date: %s", err)
+			log.Fatalf("Failed to parse creation date: %v", err)
 		}
 	}
 
@@ -130,7 +130,7 @@ func runCert(ctx *cli.Context) error {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		log.Fatalf("Failed to generate serial number: %s", err)
+		log.Fatalf("Failed to generate serial number: %v", err)
 	}
 
 	template := x509.Certificate{
@@ -163,12 +163,12 @@ func runCert(ctx *cli.Context) error {
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		log.Fatalf("Failed to create certificate: %s", err)
+		log.Fatalf("Failed to create certificate: %v", err)
 	}
 
 	certOut, err := os.Create("cert.pem")
 	if err != nil {
-		log.Fatalf("Failed to open cert.pem for writing: %s", err)
+		log.Fatalf("Failed to open cert.pem for writing: %v", err)
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	certOut.Close()
@@ -176,7 +176,7 @@ func runCert(ctx *cli.Context) error {
 
 	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		log.Fatalf("Failed to open key.pem for writing: %v\n", err)
+		log.Fatalf("Failed to open key.pem for writing: %v", err)
 	}
 	pem.Encode(keyOut, pemBlockForKey(priv))
 	keyOut.Close()

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -68,7 +68,7 @@ func runDump(ctx *cli.Context) error {
 	}
 	TmpWorkDir, err := ioutil.TempDir(tmpDir, "gitea-dump-")
 	if err != nil {
-		log.Fatalf("Fail to create tmp work directory: %v", err)
+		log.Fatalf("Failed to create tmp work directory: %v", err)
 	}
 	log.Printf("Creating tmp work dir: %s", TmpWorkDir)
 
@@ -78,7 +78,7 @@ func runDump(ctx *cli.Context) error {
 	log.Printf("Dumping local repositories...%s", setting.RepoRootPath)
 	zip.Verbose = ctx.Bool("verbose")
 	if err := zip.PackTo(setting.RepoRootPath, reposDump, true); err != nil {
-		log.Fatalf("Fail to dump local repositories: %v", err)
+		log.Fatalf("Failed to dump local repositories: %v", err)
 	}
 
 	targetDBType := ctx.String("database")
@@ -89,26 +89,26 @@ func runDump(ctx *cli.Context) error {
 	}
 
 	if err := models.DumpDatabase(dbDump, targetDBType); err != nil {
-		log.Fatalf("Fail to dump database: %v", err)
+		log.Fatalf("Failed to dump database: %v", err)
 	}
 
 	fileName := fmt.Sprintf("gitea-dump-%d.zip", time.Now().Unix())
 	log.Printf("Packing dump files...")
 	z, err := zip.Create(fileName)
 	if err != nil {
-		log.Fatalf("Fail to create %s: %v", fileName, err)
+		log.Fatalf("Failed to create %s: %v", fileName, err)
 	}
 
 	if err := z.AddFile("gitea-repo.zip", reposDump); err != nil {
-		log.Fatalf("Fail to include gitea-repo.zip: %v", err)
+		log.Fatalf("Failed to include gitea-repo.zip: %v", err)
 	}
 	if err := z.AddFile("gitea-db.sql", dbDump); err != nil {
-		log.Fatalf("Fail to include gitea-db.sql: %v", err)
+		log.Fatalf("Failed to include gitea-db.sql: %v", err)
 	}
 	customDir, err := os.Stat(setting.CustomPath)
 	if err == nil && customDir.IsDir() {
 		if err := z.AddDir("custom", setting.CustomPath); err != nil {
-			log.Fatalf("Fail to include custom: %v", err)
+			log.Fatalf("Failed to include custom: %v", err)
 		}
 	} else {
 		log.Printf("Custom dir %s doesn't exist, skipped", setting.CustomPath)
@@ -124,16 +124,16 @@ func runDump(ctx *cli.Context) error {
 	}
 
 	if err := zipAddDirectoryExclude(z, "data", setting.AppDataPath, sessionAbsPath); err != nil {
-		log.Fatalf("Fail to include data directory: %v", err)
+		log.Fatalf("Failed to include data directory: %v", err)
 	}
 
 	if err := z.AddDir("log", setting.LogRootPath); err != nil {
-		log.Fatalf("Fail to include log: %v", err)
+		log.Fatalf("Failed to include log: %v", err)
 	}
 	// FIXME: SSH key file.
 	if err = z.Close(); err != nil {
 		_ = os.Remove(fileName)
-		log.Fatalf("Fail to save %s: %v", fileName, err)
+		log.Fatalf("Failed to save %s: %v", fileName, err)
 	}
 
 	if err := os.Chmod(fileName, 0600); err != nil {
@@ -143,7 +143,7 @@ func runDump(ctx *cli.Context) error {
 	log.Printf("Removing tmp work dir: %s", TmpWorkDir)
 
 	if err := os.RemoveAll(TmpWorkDir); err != nil {
-		log.Fatalf("Fail to remove %s: %v", TmpWorkDir, err)
+		log.Fatalf("Failed to remove %s: %v", TmpWorkDir, err)
 	}
 	log.Printf("Finish dumping in file %s", fileName)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -56,7 +56,7 @@ func setup(logPath string) {
 	if setting.UseSQLite3 || setting.UseTiDB {
 		workDir, _ := setting.WorkDir()
 		if err := os.Chdir(workDir); err != nil {
-			log.GitLogger.Fatal(4, "Fail to change directory %s: %v", workDir, err)
+			log.GitLogger.Fatal(4, "Failed to change directory %s: %v", workDir, err)
 		}
 	}
 
@@ -134,10 +134,10 @@ func handleUpdateTask(uuid string, user, repoUser *models.User, reponame string,
 	if err == nil {
 		resp.Body.Close()
 		if resp.StatusCode/100 != 2 {
-			log.GitLogger.Error(2, "Fail to trigger task: not 2xx response code")
+			log.GitLogger.Error(2, "Failed to trigger task: not 2xx response code")
 		}
 	} else {
-		log.GitLogger.Error(2, "Fail to trigger task: %v", err)
+		log.GitLogger.Error(2, "Failed to trigger task: %v", err)
 	}
 }
 
@@ -273,7 +273,7 @@ func runServ(c *cli.Context) error {
 
 			mode, err := models.AccessLevel(user, repo)
 			if err != nil {
-				fail("Internal error", "Fail to check access: %v", err)
+				fail("Internal error", "Failed to check access: %v", err)
 			} else if mode < requestedMode {
 				clientMessage := accessDenied
 				if mode >= models.AccessModeRead {

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -114,7 +114,7 @@ func newMacaron() *macaron.Macaron {
 	localeNames, err := options.Dir("locale")
 
 	if err != nil {
-		log.Fatal(4, "Fail to list locale files: %v", err)
+		log.Fatal(4, "Failed to list locale files: %v", err)
 	}
 
 	localFiles := make(map[string][]byte)
@@ -655,7 +655,7 @@ func runWeb(ctx *cli.Context) error {
 		err = fcgi.Serve(nil, m)
 	case setting.UnixSocket:
 		if err := os.Remove(listenAddr); err != nil {
-			log.Fatal(4, "Fail to remove unix socket directory %s: %v", listenAddr, err)
+			log.Fatal(4, "Failed to remove unix socket directory %s: %v", listenAddr, err)
 		}
 		var listener *net.UnixListener
 		listener, err = net.ListenUnix("unix", &net.UnixAddr{Name: listenAddr, Net: "unix"})
@@ -674,7 +674,7 @@ func runWeb(ctx *cli.Context) error {
 	}
 
 	if err != nil {
-		log.Fatal(4, "Fail to start server: %v", err)
+		log.Fatal(4, "Failed to start server: %v", err)
 	}
 
 	return nil

--- a/cmd/web_graceful.go
+++ b/cmd/web_graceful.go
@@ -8,9 +8,9 @@ package cmd
 
 import (
 	"crypto/tls"
-	"log"
 	"net/http"
 
+	"code.gitea.io/gitea/modules/log"
 	"github.com/facebookgo/grace/gracehttp"
 )
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Fatal(4, "Fail to run app with %s: %v", os.Args, err)
+		log.Fatal(4, "Failed to run app with %s: %v", os.Args, err)
 	}
 
 }

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -328,7 +328,7 @@ func attachmentRefactor(x *xorm.Engine) error {
 
 		dumpPath := path.Join(setting.LogRootPath, "attachment_path.dump")
 		ioutil.WriteFile(dumpPath, buf.Bytes(), 0666)
-		fmt.Println("Fail to rename some attachments, old and new paths are saved into:", dumpPath)
+		log.Info("Failed to rename some attachments, old and new paths are saved into: %s", dumpPath)
 	}()
 	for _, attach := range attachments {
 		if err = os.MkdirAll(path.Dir(attach.NewPath), os.ModePerm); err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -205,7 +205,7 @@ func getEngine() (*xorm.Engine, error) {
 			return nil, errors.New("this binary version does not build support for SQLite3")
 		}
 		if err := os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm); err != nil {
-			return nil, fmt.Errorf("Fail to create directories: %v", err)
+			return nil, fmt.Errorf("Failed to create directories: %v", err)
 		}
 		connStr = "file:" + DbCfg.Path + "?cache=shared&mode=rwc"
 	case "tidb":
@@ -213,7 +213,7 @@ func getEngine() (*xorm.Engine, error) {
 			return nil, errors.New("this binary version does not build support for TiDB")
 		}
 		if err := os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm); err != nil {
-			return nil, fmt.Errorf("Fail to create directories: %v", err)
+			return nil, fmt.Errorf("Failed to create directories: %v", err)
 		}
 		connStr = "goleveldb://" + DbCfg.Path
 	default:
@@ -237,7 +237,7 @@ func NewTestEngine(x *xorm.Engine) (err error) {
 func SetEngine() (err error) {
 	x, err = getEngine()
 	if err != nil {
-		return fmt.Errorf("Fail to connect to database: %v", err)
+		return fmt.Errorf("Failed to connect to database: %v", err)
 	}
 
 	x.SetMapper(core.GonicMapper{})
@@ -247,12 +247,12 @@ func SetEngine() (err error) {
 	logPath := path.Join(setting.LogRootPath, "xorm.log")
 
 	if err := os.MkdirAll(path.Dir(logPath), os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", logPath, err)
+		return fmt.Errorf("Failed to create dir %s: %v", logPath, err)
 	}
 
 	f, err := os.Create(logPath)
 	if err != nil {
-		return fmt.Errorf("Fail to create xorm.log: %v", err)
+		return fmt.Errorf("Failed to create xorm.log: %v", err)
 	}
 	x.SetLogger(xorm.NewSimpleLogger(f))
 	x.ShowSQL(true)

--- a/models/org.go
+++ b/models/org.go
@@ -272,13 +272,13 @@ func deleteOrg(e *xorm.Session, u *User) error {
 	path := UserPath(u.Name)
 
 	if err := os.RemoveAll(path); err != nil {
-		return fmt.Errorf("Fail to RemoveAll %s: %v", path, err)
+		return fmt.Errorf("Failed to RemoveAll %s: %v", path, err)
 	}
 
 	avatarPath := u.CustomAvatarPath()
 	if com.IsExist(avatarPath) {
 		if err := os.Remove(avatarPath); err != nil {
-			return fmt.Errorf("Fail to remove %s: %v", avatarPath, err)
+			return fmt.Errorf("Failed to remove %s: %v", avatarPath, err)
 		}
 	}
 

--- a/models/pull.go
+++ b/models/pull.go
@@ -275,7 +275,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository) (err error
 	tmpBasePath := path.Join(setting.AppDataPath, "tmp/repos", com.ToStr(time.Now().Nanosecond())+".git")
 
 	if err := os.MkdirAll(path.Dir(tmpBasePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", tmpBasePath, err)
+		return fmt.Errorf("Failed to create dir %s: %v", tmpBasePath, err)
 	}
 
 	defer os.RemoveAll(path.Dir(tmpBasePath))

--- a/models/repo.go
+++ b/models/repo.go
@@ -83,13 +83,13 @@ func LoadRepoConfig() {
 	for i, t := range types {
 		files, err := options.Dir(t)
 		if err != nil {
-			log.Fatal(4, "Fail to get %s files: %v", t, err)
+			log.Fatal(4, "Failed to get %s files: %v", t, err)
 		}
 		customPath := path.Join(setting.CustomPath, "options", t)
 		if com.IsDir(customPath) {
 			customFiles, err := com.StatDir(customPath)
 			if err != nil {
-				log.Fatal(4, "Fail to get custom %s files: %v", t, err)
+				log.Fatal(4, "Failed to get custom %s files: %v", t, err)
 			}
 
 			for _, f := range customFiles {
@@ -131,13 +131,13 @@ func NewRepoContext() {
 
 	// Check Git installation.
 	if _, err := exec.LookPath("git"); err != nil {
-		log.Fatal(4, "Fail to test 'git' command: %v (forgotten install?)", err)
+		log.Fatal(4, "Failed to test 'git' command: %v (forgotten install?)", err)
 	}
 
 	// Check Git version.
 	gitVer, err := git.BinVersion()
 	if err != nil {
-		log.Fatal(4, "Fail to get Git version: %v", err)
+		log.Fatal(4, "Failed to get Git version: %v", err)
 	}
 
 	log.Info("Git Version: %s", gitVer)
@@ -151,11 +151,11 @@ func NewRepoContext() {
 			// ExitError indicates this config is not set
 			if _, ok := err.(*exec.ExitError); ok || strings.TrimSpace(stdout) == "" {
 				if _, stderr, gerr := process.GetManager().Exec("NewRepoContext(set "+configKey+")", "git", "config", "--global", configKey, defaultValue); gerr != nil {
-					log.Fatal(4, "Fail to set git %s(%s): %s", configKey, gerr, stderr)
+					log.Fatal(4, "Failed to set git %s(%s): %s", configKey, gerr, stderr)
 				}
 				log.Info("Git config %s set to %s", configKey, defaultValue)
 			} else {
-				log.Fatal(4, "Fail to get git %s(%s): %s", configKey, err, stderr)
+				log.Fatal(4, "Failed to get git %s(%s): %s", configKey, err, stderr)
 			}
 		}
 	}
@@ -163,7 +163,7 @@ func NewRepoContext() {
 	// Set git some configurations.
 	if _, stderr, err := process.GetManager().Exec("NewRepoContext(git config --global core.quotepath false)",
 		"git", "config", "--global", "core.quotepath", "false"); err != nil {
-		log.Fatal(4, "Fail to execute 'git config --global core.quotepath false': %s", stderr)
+		log.Fatal(4, "Failed to execute 'git config --global core.quotepath false': %s", stderr)
 	}
 
 	RemoveAllWithNotice("Clean up repository temporary data", filepath.Join(setting.AppDataPath, "tmp"))
@@ -566,7 +566,7 @@ func (repo *Repository) SavePatch(index int64, patch []byte) error {
 	dir := filepath.Dir(patchPath)
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", dir, err)
+		return fmt.Errorf("Failed to create dir %s: %v", dir, err)
 	}
 
 	if err = ioutil.WriteFile(patchPath, patch, 0644); err != nil {
@@ -679,7 +679,7 @@ func MigrateRepository(u *User, opts MigrateRepoOptions) (*Repository, error) {
 	migrateTimeout := time.Duration(setting.Git.Timeout.Migrate) * time.Second
 
 	if err := os.RemoveAll(repoPath); err != nil {
-		return repo, fmt.Errorf("Fail to remove %s: %v", repoPath, err)
+		return repo, fmt.Errorf("Failed to remove %s: %v", repoPath, err)
 	}
 
 	if err = git.Clone(opts.RemoteAddr, repoPath, git.CloneRepoOptions{
@@ -693,7 +693,7 @@ func MigrateRepository(u *User, opts MigrateRepoOptions) (*Repository, error) {
 	wikiRemotePath := wikiRemoteURL(opts.RemoteAddr)
 	if len(wikiRemotePath) > 0 {
 		if err := os.RemoveAll(wikiPath); err != nil {
-			return repo, fmt.Errorf("Fail to remove %s: %v", wikiPath, err)
+			return repo, fmt.Errorf("Failed to remove %s: %v", wikiPath, err)
 		}
 
 		if err = git.Clone(wikiRemotePath, wikiPath, git.CloneRepoOptions{
@@ -704,7 +704,7 @@ func MigrateRepository(u *User, opts MigrateRepoOptions) (*Repository, error) {
 		}); err != nil {
 			log.Warn("Clone wiki: %v", err)
 			if err := os.RemoveAll(wikiPath); err != nil {
-				return repo, fmt.Errorf("Fail to remove %s: %v", wikiPath, err)
+				return repo, fmt.Errorf("Failed to remove %s: %v", wikiPath, err)
 			}
 		}
 	}
@@ -938,7 +938,7 @@ func initRepository(e Engine, repoPath string, u *User, repo *Repository, opts C
 	if opts.AutoInit {
 
 		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
-			return fmt.Errorf("Fail to create dir %s: %v", tmpDir, err)
+			return fmt.Errorf("Failed to create dir %s: %v", tmpDir, err)
 		}
 
 		defer os.RemoveAll(tmpDir)
@@ -1243,7 +1243,7 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) error 
 	dir := UserPath(newOwner.Name)
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", dir, err)
+		return fmt.Errorf("Failed to create dir %s: %v", dir, err)
 	}
 
 	if err = os.Rename(RepoPath(owner.Name, repo.Name), RepoPath(newOwner.Name, repo.Name)); err != nil {
@@ -1818,7 +1818,7 @@ func GitFsck() {
 				repo := bean.(*Repository)
 				repoPath := repo.RepoPath()
 				if err := git.Fsck(repoPath, setting.Cron.RepoHealthCheck.Timeout, setting.Cron.RepoHealthCheck.Args...); err != nil {
-					desc := fmt.Sprintf("Fail to health check repository (%s): %v", repoPath, err)
+					desc := fmt.Sprintf("Failed to health check repository (%s): %v", repoPath, err)
 					log.Warn(desc)
 					if err = CreateRepositoryNotice(desc); err != nil {
 						log.Error(4, "CreateRepositoryNotice: %v", err)

--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -107,7 +107,7 @@ func (repo *Repository) UpdateRepoFile(doer *User, opts UpdateRepoFileOptions) (
 	dir := path.Dir(filePath)
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", dir, err)
+		return fmt.Errorf("Failed to create dir %s: %v", dir, err)
 	}
 
 	// If it's meant to be a new file, make sure it doesn't exist.
@@ -192,7 +192,7 @@ func (repo *Repository) GetDiffPreview(branch, treePath, content string) (diff *
 	dir := filepath.Dir(filePath)
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("Fail to create dir %s: %v", dir, err)
+		return nil, fmt.Errorf("Failed to create dir %s: %v", dir, err)
 	}
 
 	if err = ioutil.WriteFile(filePath, []byte(content), 0666); err != nil {
@@ -486,7 +486,7 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 	dirPath := path.Join(localPath, opts.TreePath)
 
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", dirPath, err)
+		return fmt.Errorf("Failed to create dir %s: %v", dirPath, err)
 	}
 
 	// Copy uploaded files into repository.

--- a/models/repo_mirror.go
+++ b/models/repo_mirror.go
@@ -140,7 +140,7 @@ func (m *Mirror) runSync() bool {
 	if _, stderr, err := process.GetManager().ExecDir(
 		timeout, repoPath, fmt.Sprintf("Mirror.runSync: %s", repoPath),
 		"git", gitArgs...); err != nil {
-		desc := fmt.Sprintf("Fail to update mirror repository '%s': %s", repoPath, stderr)
+		desc := fmt.Sprintf("Failed to update mirror repository '%s': %s", repoPath, stderr)
 		log.Error(4, desc)
 		if err = CreateRepositoryNotice(desc); err != nil {
 			log.Error(4, "CreateRepositoryNotice: %v", err)
@@ -151,7 +151,7 @@ func (m *Mirror) runSync() bool {
 		if _, stderr, err := process.GetManager().ExecDir(
 			timeout, wikiPath, fmt.Sprintf("Mirror.runSync: %s", wikiPath),
 			"git", "remote", "update", "--prune"); err != nil {
-			desc := fmt.Sprintf("Fail to update mirror wiki repository '%s': %s", wikiPath, stderr)
+			desc := fmt.Sprintf("Failed to update mirror wiki repository '%s': %s", wikiPath, stderr)
 			log.Error(4, desc)
 			if err = CreateRepositoryNotice(desc); err != nil {
 				log.Error(4, "CreateRepositoryNotice: %v", err)

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -376,7 +376,7 @@ func addKey(e Engine, key *PublicKey) (err error) {
 	dir := path.Dir(tmpPath)
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", dir, err)
+		return fmt.Errorf("Failed to create dir %s: %v", dir, err)
 	}
 
 	if err = ioutil.WriteFile(tmpPath, []byte(key.Content), 0644); err != nil {

--- a/models/update.go
+++ b/models/update.go
@@ -102,7 +102,7 @@ func PushUpdate(opts PushUpdateOptions) (err error) {
 	gitUpdate := exec.Command("git", "update-server-info")
 	gitUpdate.Dir = repoPath
 	if err = gitUpdate.Run(); err != nil {
-		return fmt.Errorf("Fail to call 'git update-server-info': %v", err)
+		return fmt.Errorf("Failed to call 'git update-server-info': %v", err)
 	}
 
 	if isDelRef {

--- a/models/user.go
+++ b/models/user.go
@@ -414,7 +414,7 @@ func (u *User) UploadAvatar(data []byte) error {
 	}
 
 	if err := os.MkdirAll(setting.AvatarUploadPath, os.ModePerm); err != nil {
-		return fmt.Errorf("Fail to create dir %s: %v", setting.AvatarUploadPath, err)
+		return fmt.Errorf("Failed to create dir %s: %v", setting.AvatarUploadPath, err)
 	}
 
 	fw, err := os.Create(u.CustomAvatarPath())
@@ -435,7 +435,7 @@ func (u *User) DeleteAvatar() error {
 	log.Trace("DeleteAvatar[%d]: %s", u.ID, u.CustomAvatarPath())
 
 	if err := os.Remove(u.CustomAvatarPath()); err != nil {
-		return fmt.Errorf("Fail to remove %s: %v", u.CustomAvatarPath(), err)
+		return fmt.Errorf("Failed to remove %s: %v", u.CustomAvatarPath(), err)
 	}
 
 	u.UseCustomAvatar = false
@@ -918,13 +918,13 @@ func deleteUser(e *xorm.Session, u *User) error {
 	path := UserPath(u.Name)
 
 	if err := os.RemoveAll(path); err != nil {
-		return fmt.Errorf("Fail to RemoveAll %s: %v", path, err)
+		return fmt.Errorf("Failed to RemoveAll %s: %v", path, err)
 	}
 
 	avatarPath := u.CustomAvatarPath()
 	if com.IsExist(avatarPath) {
 		if err := os.Remove(avatarPath); err != nil {
-			return fmt.Errorf("Fail to remove %s: %v", avatarPath, err)
+			return fmt.Errorf("Failed to remove %s: %v", avatarPath, err)
 		}
 	}
 

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -133,7 +133,7 @@ func (repo *Repository) updateWikiPage(doer *User, oldWikiPath, wikiPath, conten
 		file := path.Join(localPath, oldWikiPath+".md")
 
 		if err := os.Remove(file); err != nil {
-			return fmt.Errorf("Fail to remove %s: %v", file, err)
+			return fmt.Errorf("Failed to remove %s: %v", file, err)
 		}
 	}
 
@@ -192,7 +192,7 @@ func (repo *Repository) DeleteWikiPage(doer *User, wikiPath string) (err error) 
 	filename := path.Join(localPath, wikiPath+".md")
 
 	if err := os.Remove(filename); err != nil {
-		return fmt.Errorf("Fail to remove %s: %v", filename, err)
+		return fmt.Errorf("Failed to remove %s: %v", filename, err)
 	}
 
 	title := ToWikiPageName(wikiPath)

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -110,7 +110,7 @@ func GetRandomBytesAsBase64(n int) string {
 	_, err := io.ReadFull(rand.Reader, bytes)
 
 	if err != nil {
-		log.Fatal(4, "Error reading random bytes: %s", err)
+		log.Fatal(4, "Error reading random bytes: %v", err)
 	}
 
 	return base64.RawURLEncoding.EncodeToString(bytes)

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -151,7 +151,7 @@ func (w *FileLogWriter) initFd() error {
 	fd := w.mw.fd
 	finfo, err := fd.Stat()
 	if err != nil {
-		return fmt.Errorf("get stat: %s", err)
+		return fmt.Errorf("get stat: %v", err)
 	}
 	w.maxsizeCursize = int(finfo.Size())
 	w.dailyOpenDate = time.Now().Day()
@@ -194,12 +194,12 @@ func (w *FileLogWriter) DoRotate() error {
 		// close fd before rename
 		// Rename the file to its newfound home
 		if err = os.Rename(w.Filename, fname); err != nil {
-			return fmt.Errorf("Rotate: %s", err)
+			return fmt.Errorf("Rotate: %v", err)
 		}
 
 		// re-start logger
 		if err = w.StartLogger(); err != nil {
-			return fmt.Errorf("Rotate StartLogger: %s", err)
+			return fmt.Errorf("Rotate StartLogger: %v", err)
 		}
 
 		go w.deleteOldLog()
@@ -221,7 +221,7 @@ func (w *FileLogWriter) deleteOldLog() {
 			if strings.HasPrefix(filepath.Base(path), filepath.Base(w.Filename)) {
 
 				if err := os.Remove(path); err != nil {
-					returnErr = fmt.Errorf("Fail to remove %s: %v", path, err)
+					returnErr = fmt.Errorf("Failed to remove %s: %v", path, err)
 				}
 			}
 		}

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -35,7 +35,7 @@ func NewLogger(bufLen int64, mode, config string) {
 		loggers = append(loggers, logger)
 	}
 	if err := logger.SetLogger(mode, config); err != nil {
-		Fatal(2, "Fail to set logger (%s): %v", mode, err)
+		Fatal(2, "Failed to set logger (%s): %v", mode, err)
 	}
 }
 
@@ -56,7 +56,7 @@ func NewGitLogger(logPath string) {
 	path := path.Dir(logPath)
 
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
-		Fatal(4, "Fail to create dir %s: %v", path, err)
+		Fatal(4, "Failed to create dir %s: %v", path, err)
 	}
 
 	GitLogger = newLogger(0)

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -241,7 +241,7 @@ func processMailQueue() {
 		case msg := <-mailQueue:
 			log.Trace("New e-mail sending request %s: %s", msg.GetHeader("To"), msg.Info)
 			if err := gomail.Send(Sender, msg.Message); err != nil {
-				log.Error(3, "Fail to send emails %s: %s - %v", msg.GetHeader("To"), msg.Info, err)
+				log.Error(3, "Failed to send emails %s: %s - %v", msg.GetHeader("To"), msg.Info, err)
 			} else {
 				log.Trace("E-mails sent %s: %s", msg.GetHeader("To"), msg.Info)
 			}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -431,7 +431,7 @@ func init() {
 
 	var err error
 	if AppPath, err = execPath(); err != nil {
-		log.Fatal(4, "fail to get app path: %v\n", err)
+		log.Fatal(4, "Failed to get app path: %v", err)
 	}
 
 	// Note: we don't use path.Dir here because it does not handle case
@@ -483,16 +483,16 @@ func IsRunUserMatchCurrentUser(runUser string) (string, bool) {
 func createPIDFile(pidPath string) {
 	currentPid := os.Getpid()
 	if err := os.MkdirAll(filepath.Dir(pidPath), os.ModePerm); err != nil {
-		log.Fatal(4, "Can't create PID folder on %s", err)
+		log.Fatal(4, "Failed to create PID folder: %v", err)
 	}
 
 	file, err := os.Create(pidPath)
 	if err != nil {
-		log.Fatal(4, "Can't create PID file: %v", err)
+		log.Fatal(4, "Failed to create PID file: %v", err)
 	}
 	defer file.Close()
 	if _, err := file.WriteString(strconv.FormatInt(int64(currentPid), 10)); err != nil {
-		log.Fatal(4, "Can'write PID information on %s", err)
+		log.Fatal(4, "Failed to write PID information: %v", err)
 	}
 }
 
@@ -501,13 +501,13 @@ func createPIDFile(pidPath string) {
 func NewContext() {
 	workDir, err := WorkDir()
 	if err != nil {
-		log.Fatal(4, "Fail to get work directory: %v", err)
+		log.Fatal(4, "Failed to get work directory: %v", err)
 	}
 
 	Cfg = ini.Empty()
 
 	if err != nil {
-		log.Fatal(4, "Fail to parse 'app.ini': %v", err)
+		log.Fatal(4, "Failed to parse 'app.ini': %v", err)
 	}
 
 	CustomPath = os.Getenv("GITEA_CUSTOM")
@@ -533,7 +533,7 @@ please consider changing to GITEA_CUSTOM`)
 
 	if com.IsFile(CustomConf) {
 		if err = Cfg.Append(CustomConf); err != nil {
-			log.Fatal(4, "Fail to load custom conf '%s': %v", CustomConf, err)
+			log.Fatal(4, "Failed to load custom conf '%s': %v", CustomConf, err)
 		}
 	} else {
 		log.Warn("Custom config '%s' not found, ignore this if you're running first time", CustomConf)
@@ -542,7 +542,7 @@ please consider changing to GITEA_CUSTOM`)
 
 	homeDir, err := com.HomeDir()
 	if err != nil {
-		log.Fatal(4, "Fail to get home directory: %v", err)
+		log.Fatal(4, "Failed to get home directory: %v", err)
 	}
 	homeDir = strings.Replace(homeDir, "\\", "/", -1)
 
@@ -578,7 +578,7 @@ please consider changing to GITEA_CUSTOM`)
 		UnixSocketPermissionRaw := sec.Key("UNIX_SOCKET_PERMISSION").MustString("666")
 		UnixSocketPermissionParsed, err := strconv.ParseUint(UnixSocketPermissionRaw, 8, 32)
 		if err != nil || UnixSocketPermissionParsed > 0777 {
-			log.Fatal(4, "Fail to parse unixSocketPermission: %s", UnixSocketPermissionRaw)
+			log.Fatal(4, "Failed to parse unixSocketPermission: %s", UnixSocketPermissionRaw)
 		}
 		UnixSocketPermission = uint32(UnixSocketPermissionParsed)
 	}
@@ -602,7 +602,7 @@ please consider changing to GITEA_CUSTOM`)
 	SSH.RootPath = path.Join(homeDir, ".ssh")
 	SSH.KeyTestPath = os.TempDir()
 	if err = Cfg.Section("server").MapTo(&SSH); err != nil {
-		log.Fatal(4, "Fail to map SSH settings: %v", err)
+		log.Fatal(4, "Failed to map SSH settings: %v", err)
 	}
 
 	SSH.KeygenPath = sec.Key("SSH_KEYGEN_PATH").MustString("ssh-keygen")
@@ -616,9 +616,9 @@ please consider changing to GITEA_CUSTOM`)
 
 	if !SSH.Disabled && !SSH.StartBuiltinServer {
 		if err := os.MkdirAll(SSH.RootPath, 0700); err != nil {
-			log.Fatal(4, "Fail to create '%s': %v", SSH.RootPath, err)
+			log.Fatal(4, "Failed to create '%s': %v", SSH.RootPath, err)
 		} else if err = os.MkdirAll(SSH.KeyTestPath, 0644); err != nil {
-			log.Fatal(4, "Fail to create '%s': %v", SSH.KeyTestPath, err)
+			log.Fatal(4, "Failed to create '%s': %v", SSH.KeyTestPath, err)
 		}
 	}
 
@@ -632,13 +632,13 @@ please consider changing to GITEA_CUSTOM`)
 	}
 
 	if err = Cfg.Section("server").MapTo(&LFS); err != nil {
-		log.Fatal(4, "Fail to map LFS settings: %v", err)
+		log.Fatal(4, "Failed to map LFS settings: %v", err)
 	}
 
 	if LFS.StartServer {
 
 		if err := os.MkdirAll(LFS.ContentPath, 0700); err != nil {
-			log.Fatal(4, "Fail to create '%s': %v", LFS.ContentPath, err)
+			log.Fatal(4, "Failed to create '%s': %v", LFS.ContentPath, err)
 		}
 
 		LFS.JWTSecretBytes = make([]byte, 32)
@@ -650,7 +650,7 @@ please consider changing to GITEA_CUSTOM`)
 			_, err := io.ReadFull(rand.Reader, LFS.JWTSecretBytes)
 
 			if err != nil {
-				log.Fatal(4, "Error reading random bytes: %s", err)
+				log.Fatal(4, "Error reading random bytes: %v", err)
 			}
 
 			LFS.JWTSecretBase64 = base64.RawURLEncoding.EncodeToString(LFS.JWTSecretBytes)
@@ -660,14 +660,14 @@ please consider changing to GITEA_CUSTOM`)
 			if com.IsFile(CustomConf) {
 				// Keeps custom settings if there is already something.
 				if err := cfg.Append(CustomConf); err != nil {
-					log.Error(4, "Fail to load custom conf '%s': %v", CustomConf, err)
+					log.Error(4, "Failed to load custom conf '%s': %v", CustomConf, err)
 				}
 			}
 
 			cfg.Section("server").Key("LFS_JWT_SECRET").SetValue(LFS.JWTSecretBase64)
 
 			if err := os.MkdirAll(filepath.Dir(CustomConf), os.ModePerm); err != nil {
-				log.Fatal(4, "Fail to create '%s': %v", CustomConf, err)
+				log.Fatal(4, "Failed to create '%s': %v", CustomConf, err)
 			}
 			if err := cfg.SaveTo(CustomConf); err != nil {
 				log.Fatal(4, "Error saving generated JWT Secret to custom config: %v", err)
@@ -680,22 +680,22 @@ please consider changing to GITEA_CUSTOM`)
 
 		binVersion, err := git.BinVersion()
 		if err != nil {
-			log.Fatal(4, "Error retrieving git version: %s", err)
+			log.Fatal(4, "Error retrieving git version: %v", err)
 		}
 
 		splitVersion := strings.SplitN(binVersion, ".", 3)
 
 		majorVersion, err := strconv.ParseUint(splitVersion[0], 10, 64)
 		if err != nil {
-			log.Fatal(4, "Error parsing git major version: %s", err)
+			log.Fatal(4, "Error parsing git major version: %v", err)
 		}
 		minorVersion, err := strconv.ParseUint(splitVersion[1], 10, 64)
 		if err != nil {
-			log.Fatal(4, "Error parsing git minor version: %s", err)
+			log.Fatal(4, "Error parsing git minor version: %v", err)
 		}
 		revisionVersion, err := strconv.ParseUint(splitVersion[2], 10, 64)
 		if err != nil {
-			log.Fatal(4, "Error parsing git revision version: %s", err)
+			log.Fatal(4, "Error parsing git revision version: %v", err)
 		}
 
 		if !((majorVersion > 2) || (majorVersion == 2 && minorVersion > 1) ||
@@ -771,11 +771,11 @@ please consider changing to GITEA_CUSTOM`)
 	}
 	ScriptType = sec.Key("SCRIPT_TYPE").MustString("bash")
 	if err = Cfg.Section("repository").MapTo(&Repository); err != nil {
-		log.Fatal(4, "Fail to map Repository settings: %v", err)
+		log.Fatal(4, "Failed to map Repository settings: %v", err)
 	} else if err = Cfg.Section("repository.editor").MapTo(&Repository.Editor); err != nil {
-		log.Fatal(4, "Fail to map Repository.Editor settings: %v", err)
+		log.Fatal(4, "Failed to map Repository.Editor settings: %v", err)
 	} else if err = Cfg.Section("repository.upload").MapTo(&Repository.Upload); err != nil {
-		log.Fatal(4, "Fail to map Repository.Upload settings: %v", err)
+		log.Fatal(4, "Failed to map Repository.Upload settings: %v", err)
 	}
 
 	if !filepath.IsAbs(Repository.Upload.TempPath) {
@@ -823,17 +823,17 @@ please consider changing to GITEA_CUSTOM`)
 	}
 
 	if err = Cfg.Section("ui").MapTo(&UI); err != nil {
-		log.Fatal(4, "Fail to map UI settings: %v", err)
+		log.Fatal(4, "Failed to map UI settings: %v", err)
 	} else if err = Cfg.Section("markdown").MapTo(&Markdown); err != nil {
-		log.Fatal(4, "Fail to map Markdown settings: %v", err)
+		log.Fatal(4, "Failed to map Markdown settings: %v", err)
 	} else if err = Cfg.Section("cron").MapTo(&Cron); err != nil {
-		log.Fatal(4, "Fail to map Cron settings: %v", err)
+		log.Fatal(4, "Failed to map Cron settings: %v", err)
 	} else if err = Cfg.Section("git").MapTo(&Git); err != nil {
-		log.Fatal(4, "Fail to map Git settings: %v", err)
+		log.Fatal(4, "Failed to map Git settings: %v", err)
 	} else if err = Cfg.Section("mirror").MapTo(&Mirror); err != nil {
-		log.Fatal(4, "Fail to map Mirror settings: %v", err)
+		log.Fatal(4, "Failed to map Mirror settings: %v", err)
 	} else if err = Cfg.Section("api").MapTo(&API); err != nil {
-		log.Fatal(4, "Fail to map API settings: %v", err)
+		log.Fatal(4, "Failed to map API settings: %v", err)
 	}
 
 	if Mirror.DefaultInterval <= 0 {

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -5,7 +5,6 @@
 package ssh
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -117,7 +116,7 @@ func handleServerConn(keyID string, chans <-chan ssh.NewChannel) {
 func listen(config *ssh.ServerConfig, host string, port int) {
 	listener, err := net.Listen("tcp", host+":"+com.ToStr(port))
 	if err != nil {
-		log.Fatal(4, "Fail to start SSH server: %v", err)
+		log.Fatal(4, "Failed to start SSH server: %v", err)
 	}
 	for {
 		// Once a ServerConfig has been configured, connections can be accepted.
@@ -169,23 +168,23 @@ func Listen(host string, port int) {
 		filePath := filepath.Dir(keyPath)
 
 		if err := os.MkdirAll(filePath, os.ModePerm); err != nil {
-			log.Error(4, "Fail to create dir %s: %v", filePath, err)
+			log.Error(4, "Failed to create dir %s: %v", filePath, err)
 		}
 
 		_, stderr, err := com.ExecCmd("ssh-keygen", "-f", keyPath, "-t", "rsa", "-N", "")
 		if err != nil {
-			panic(fmt.Sprintf("Fail to generate private key: %v - %s", err, stderr))
+			log.Fatal(4, "Failed to generate private key: %v - %s", err, stderr)
 		}
 		log.Trace("SSH: New private key is generateed: %s", keyPath)
 	}
 
 	privateBytes, err := ioutil.ReadFile(keyPath)
 	if err != nil {
-		panic("SSH: Fail to load private key")
+		log.Fatal(4, "SSH: Failed to load private key")
 	}
 	private, err := ssh.ParsePrivateKey(privateBytes)
 	if err != nil {
-		panic("SSH: Fail to parse private key")
+		log.Fatal(4, "SSH: Failed to parse private key")
 	}
 	config.AddHostKey(private)
 

--- a/routers/init.go
+++ b/routers/init.go
@@ -51,7 +51,7 @@ func GlobalInit() {
 		highlight.NewContext()
 		markdown.BuildSanitizer()
 		if err := models.NewEngine(); err != nil {
-			log.Fatal(4, "Fail to initialize ORM engine: %v", err)
+			log.Fatal(4, "Failed to initialize ORM engine: %v", err)
 		}
 		models.HasEngine = true
 

--- a/routers/install.go
+++ b/routers/install.go
@@ -242,7 +242,7 @@ func InstallPost(ctx *context.Context, form auth.InstallForm) {
 	if com.IsFile(setting.CustomConf) {
 		// Keeps custom settings if there is already something.
 		if err = cfg.Append(setting.CustomConf); err != nil {
-			log.Error(4, "Fail to load custom conf '%s': %v", setting.CustomConf, err)
+			log.Error(4, "Failed to load custom conf '%s': %v", setting.CustomConf, err)
 		}
 	}
 	cfg.Section("database").Key("DB_TYPE").SetValue(models.DbCfg.Type)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -6,10 +6,12 @@ package repo
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	gotemplate "html/template"
 	"io/ioutil"
 	"path"
+	"strconv"
 	"strings"
 
 	"code.gitea.io/git"
@@ -22,9 +24,7 @@ import (
 	"code.gitea.io/gitea/modules/markdown"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
-	"encoding/base64"
 	"github.com/Unknwon/paginater"
-	"strconv"
 )
 
 const (
@@ -193,7 +193,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			var fileContent string
 			if content, err := templates.ToUTF8WithErr(buf); err != nil {
 				if err != nil {
-					log.Error(4, "ToUTF8WithErr: %s", err)
+					log.Error(4, "ToUTF8WithErr: %v", err)
 				}
 				fileContent = string(buf)
 			} else {


### PR DESCRIPTION
This change corrects a few logging issues:

 * Standardized formatting errors with '%v'.
 * Standardized failure warning word usage.
 * Corrected an instance of using the standard log library when
   the gitea log library should be used instead.

This targets issue https://github.com/go-gitea/gitea/issues/775
