### PR TITLE
Better settings for unit tests

### DIFF
--- a/models/setup_for_test.go
+++ b/models/setup_for_test.go
@@ -30,8 +30,8 @@ func TestMain(m *testing.M) {
 	setting.RunUser = "runuser"
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
-	setting.RepoRootPath = "/repos"
-	setting.AppDataPath = "/appdata"
+	setting.RepoRootPath = "/tmp/repos"
+	setting.AppDataPath = "/tmp/appdata"
 
 	os.Exit(m.Run())
 }

--- a/models/wiki_test.go
+++ b/models/wiki_test.go
@@ -5,7 +5,10 @@
 package models
 
 import (
+	"path/filepath"
 	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,13 +36,15 @@ func TestRepository_WikiCloneLink(t *testing.T) {
 
 func TestWikiPath(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
-	assert.Equal(t, "/repos/user2/repo1.wiki.git", WikiPath("user2", "repo1"))
+	expected := filepath.Join(setting.RepoRootPath, "user2/repo1.wiki.git")
+	assert.Equal(t, expected, WikiPath("user2", "repo1"))
 }
 
 func TestRepository_WikiPath(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
-	assert.Equal(t, "/repos/user2/repo1.wiki.git", repo.WikiPath())
+	expected := filepath.Join(setting.RepoRootPath, "user2/repo1.wiki.git")
+	assert.Equal(t, expected, repo.WikiPath())
 }
 
 // TODO TestRepository_HasWiki
@@ -49,7 +54,8 @@ func TestRepository_WikiPath(t *testing.T) {
 func TestRepository_LocalWikiPath(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
-	assert.Equal(t, "/appdata/tmp/local-wiki/1", repo.LocalWikiPath())
+	expected := filepath.Join(setting.AppDataPath, "tmp/local-wiki/1")
+	assert.Equal(t, expected, repo.LocalWikiPath())
 }
 
 // TODO TestRepository_UpdateLocalWiki


### PR DESCRIPTION
Update default values of `setting.RepoRootPath`, `setting.AppDataPath` to be subdirectories of `/tmp/`.
