### PR TITLE
Unit tests and remove unused functions in models/notification

### DIFF
--- a/models/fixtures/notification.yml
+++ b/models/fixtures/notification.yml
@@ -1,0 +1,21 @@
+-
+  id: 1
+  user_id: 1
+  repo_id: 1
+  status: 1 # unread
+  source: 1 # issue
+  updated_by: 2
+  issue_id: 1
+  created_unix: 946684800
+  updated_unix: 946684800
+
+-
+  id: 2
+  user_id: 2
+  repo_id: 1
+  status: 2 # read
+  source: 1 # issue
+  updated_by: 1
+  issue_id: 2
+  created_unix: 946684800
+  updated_unix: 946684800

--- a/models/fixtures/watch.yml
+++ b/models/fixtures/watch.yml
@@ -1,0 +1,9 @@
+-
+  id: 1
+  user_id: 1
+  repo_id: 1
+
+-
+  id: 2
+  user_id: 4
+  repo_id: 1

--- a/models/notification.go
+++ b/models/notification.go
@@ -227,16 +227,6 @@ func (n *Notification) GetIssue() (*Issue, error) {
 	return n.Issue, err
 }
 
-// GetNotificationReadCount returns the notification read count for user
-func GetNotificationReadCount(user *User) (int64, error) {
-	return GetNotificationCount(user, NotificationStatusRead)
-}
-
-// GetNotificationUnreadCount returns the notification unread count for user
-func GetNotificationUnreadCount(user *User) (int64, error) {
-	return GetNotificationCount(user, NotificationStatusUnread)
-}
-
 // GetNotificationCount returns the notification count for user
 func GetNotificationCount(user *User, status NotificationStatus) (int64, error) {
 	return getNotificationCount(x, user, status)

--- a/models/notification_test.go
+++ b/models/notification_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateOrUpdateIssueNotifications(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	issue := AssertExistsAndLoadBean(t, &Issue{ID: 1}).(*Issue)
+
+	assert.NoError(t, CreateOrUpdateIssueNotifications(issue, 2))
+
+	notf := AssertExistsAndLoadBean(t, &Notification{UserID: 1, IssueID: issue.ID}).(*Notification)
+	assert.Equal(t, NotificationStatusUnread, notf.Status)
+	notf = AssertExistsAndLoadBean(t, &Notification{UserID: 4, IssueID: issue.ID}).(*Notification)
+	assert.Equal(t, NotificationStatusUnread, notf.Status)
+}
+
+func TestNotificationsForUser(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	statuses := []NotificationStatus{NotificationStatusRead, NotificationStatusUnread}
+	notfs, err := NotificationsForUser(user, statuses, 1, 10)
+	assert.NoError(t, err)
+	assert.Len(t, notfs, 1)
+	assert.EqualValues(t, 2, notfs[0].ID)
+	assert.EqualValues(t, user.ID, notfs[0].UserID)
+}
+
+func TestNotification_GetRepo(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	notf := AssertExistsAndLoadBean(t, &Notification{RepoID: 1}).(*Notification)
+	repo, err := notf.GetRepo()
+	assert.NoError(t, err)
+	assert.Equal(t, repo, notf.Repository)
+	assert.EqualValues(t, notf.RepoID, repo.ID)
+}
+
+func TestNotification_GetIssue(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	notf := AssertExistsAndLoadBean(t, &Notification{RepoID: 1}).(*Notification)
+	issue, err := notf.GetIssue()
+	assert.NoError(t, err)
+	assert.Equal(t, issue, notf.Issue)
+	assert.EqualValues(t, notf.IssueID, issue.ID)
+}
+
+func TestGetNotificationCount(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	cnt, err := GetNotificationCount(user, NotificationStatusUnread)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt)
+
+	cnt, err = GetNotificationCount(user, NotificationStatusRead)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, cnt)
+}
+
+func TestSetNotificationStatus(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	notf := AssertExistsAndLoadBean(t,
+		&Notification{UserID: user.ID, Status: NotificationStatusRead}).(*Notification)
+	assert.NoError(t, SetNotificationStatus(notf.ID, user, NotificationStatusPinned))
+	AssertExistsAndLoadBean(t,
+		&Notification{ID: notf.ID, Status: NotificationStatusPinned})
+
+	assert.Error(t, SetNotificationStatus(1, user, NotificationStatusRead))
+	assert.Error(t, SetNotificationStatus(NonexistentID, user, NotificationStatusRead))
+}

--- a/routers/user/notification.go
+++ b/routers/user/notification.go
@@ -28,7 +28,7 @@ func GetNotificationCount(c *context.Context) {
 		return
 	}
 
-	count, err := models.GetNotificationUnreadCount(c.User)
+	count, err := models.GetNotificationCount(c.User, models.NotificationStatusRead)
 	if err != nil {
 		c.Handle(500, "GetNotificationCount", err)
 		return

--- a/routers/user/notification.go
+++ b/routers/user/notification.go
@@ -28,7 +28,7 @@ func GetNotificationCount(c *context.Context) {
 		return
 	}
 
-	count, err := models.GetNotificationCount(c.User, models.NotificationStatusRead)
+	count, err := models.GetNotificationCount(c.User, models.NotificationStatusUnread)
 	if err != nil {
 		c.Handle(500, "GetNotificationCount", err)
 		return


### PR DESCRIPTION
I removed the `GetNotificationReadCount(..)` and `GetNotificationUnreadCount(..)` functions for the following reasons:
1. They were both just special cases of the more general `GetNotificationCount(..)` function.
2. They were used sparingly (a total of once)
3. IMO, having multiple ways to call a public functions like `GetNotificationCount(..)` (i.e. directly, or indirectly via `GetNotificationXYZCount(..)`) makes code more verbose and harder to test.

If anyone feels strongly that they should stay, I'll listen.
