### PR TITLE
Fix bug caused by #788

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -109,7 +109,9 @@ function initCommentForm() {
     }
 
     $('.select-label').dropdown('setting', 'onHide', function(){
-        location.reload();
+        if (hasLabelUpdateAction) {
+            location.reload();
+        }
     });
 
     $labelMenu.find('.item:not(.no-select)').click(function () {


### PR DESCRIPTION
When create a new issue and set labels, it should not reload the page after the label menus hidden.