### PR TITLE
Add ENABLE_PPROF to app.ini and start pprof if true on localhost:6060

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/fcgi"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // Used for debugging if enabled and a web server is running
 	"os"
 	"path"
 	"strings"

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/fcgi"
+	_ "net/http/pprof"
 	"os"
 	"path"
 	"strings"
@@ -643,6 +644,12 @@ func runWeb(ctx *cli.Context) error {
 
 	if setting.LFS.StartServer {
 		log.Info("LFS server enabled")
+	}
+
+	if setting.EnablePprof {
+		go func() {
+			log.Info("%v", http.ListenAndServe("localhost:6060", nil))
+		}()
 	}
 
 	var err error

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/go-macaron/cache/redis"
 	"github.com/go-macaron/session"
 	_ "github.com/go-macaron/session/redis" // redis plugin for store session
-	"gopkg.in/ini.v1"
+	ini "gopkg.in/ini.v1"
 	"strk.kbt.io/projects/go/libravatar"
 )
 
@@ -79,6 +79,7 @@ var (
 	EnableGzip           bool
 	LandingPageURL       LandingPage
 	UnixSocketPermission uint32
+	EnablePprof          bool
 
 	SSH = struct {
 		Disabled            bool           `ini:"DISABLE_SSH"`
@@ -591,6 +592,7 @@ please consider changing to GITEA_CUSTOM`)
 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(workDir)
 	AppDataPath = sec.Key("APP_DATA_PATH").MustString("data")
 	EnableGzip = sec.Key("ENABLE_GZIP").MustBool()
+	EnablePprof = sec.Key("ENABLE_PPROF").MustBool(false)
 
 	switch sec.Key("LANDING_PAGE").MustString("home") {
 	case "explore":


### PR DESCRIPTION
For #753 I want a simple way for people to enable pprof so they can debug with our help, or on their own, growing memory consumption or CPU usage.

For that I added `ENABLE_PPROF` to the `app.ini`.

```
[server]
ROOT_URL         = http://localhost:3000/
...
ENABLE_PPROF     = true
```

If set to true gitea will start pprof on localhost:6060 with the `gitea web` command.

https://blog.golang.org/profiling-go-programs
https://golang.org/pkg/net/http/pprof/