### PR TITLE
Switch to full markdown renderer for issue notification mails

### DIFF
--- a/models/mail.go
+++ b/models/mail.go
@@ -150,7 +150,7 @@ func composeTplData(subject, body, link string) map[string]interface{} {
 
 func composeIssueMessage(issue *Issue, doer *User, tplName base.TplName, tos []string, info string) *mailer.Message {
 	subject := issue.mailSubject()
-	body := string(markdown.RenderSpecialLink([]byte(issue.Content), issue.Repo.HTMLURL(), issue.Repo.ComposeMetas()))
+	body := markdown.RenderString(issue.Content, issue.Repo.HTMLURL(), issue.Repo.ComposeMetas())
 	data := composeTplData(subject, body, issue.HTMLURL())
 	data["Doer"] = doer
 


### PR DESCRIPTION
Notification mails for issues included the content of the issue in a non-rendered format. Especially when code blocks or markdown formatting was used in the issue content, this lead to unreadable garbage in the notification mails (#768).

This PR fully renders markdown in issue content before putting it in the email body.