### PR TITLE
Add X-GitHub-* headers 

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -538,6 +538,8 @@ func (t *HookTask) deliver() {
 	req := httplib.Post(t.URL).SetTimeout(timeout, timeout).
 		Header("X-Gogs-Delivery", t.UUID).
 		Header("X-Gogs-Event", string(t.EventType)).
+		Header("X-GitHub-Delivery", t.UUID).
+		Header("X-GitHub-Event", string(t.EventType)).
 		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: setting.Webhook.SkipTLSVerify})
 
 	switch t.ContentType {


### PR DESCRIPTION
clubhouse.io has "GitHub integration", Gitea webhooks payload is almost identical to GitHub's one, but they require X-GitHub-* headers to work. By adding this aliases Gitea can be used with clubhouse.io without any problems
