### PR TITLE
Remove unneeded database loads

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -185,10 +185,8 @@ func RepoAssignment(args ...bool) macaron.Handler {
 				ctx.Handle(500, "GetRepositoryByName", err)
 			}
 			return
-		} else if err = repo.GetOwner(); err != nil {
-			ctx.Handle(500, "GetOwner", err)
-			return
 		}
+		repo.Owner = owner
 
 		// Admin has super access.
 		if ctx.IsSigned && ctx.User.IsAdmin {

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -57,10 +57,8 @@ func repoAssignment() macaron.Handler {
 				ctx.Error(500, "GetRepositoryByName", err)
 			}
 			return
-		} else if err = repo.GetOwner(); err != nil {
-			ctx.Error(500, "GetOwner", err)
-			return
 		}
+		repo.Owner = owner
 
 		if ctx.IsSigned && ctx.User.IsAdmin {
 			ctx.Repo.AccessMode = models.AccessModeOwner


### PR DESCRIPTION
Remove unnecessary calls to `repo.GetOwner()` in context handlers.