### PR TITLE
Fixes #794 by moving emoji tag to the correct span

### DIFF
--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -41,9 +41,9 @@
 							{{end}}
 						</td>
 
-						<td class="message collapsing has-emoji">
+						<td class="message collapsing">
 							<a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
-							<span {{if gt .ParentCount 1}}class="grey text"{{end}}>{{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
+							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}">{{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
 					</tr>


### PR DESCRIPTION
Signed-off-by: Stephen Brown <steve@evolvedlight.co.uk>

This is a simple CSS fix for #794. Tested locally and works.