### PR TITLE
Fix consistency check

### DIFF
--- a/models/fixtures/issue.yml
+++ b/models/fixtures/issue.yml
@@ -8,7 +8,7 @@
   content: content1
   is_closed: false
   is_pull: false
-  num_comments: 1
+  num_comments: 0
   created_unix: 946684800
   updated_unix: 978307200
 

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -4,7 +4,7 @@
   lower_name: repo1
   name: repo1
   is_private: false
-  num_issues: 4
+  num_issues: 2
   num_closed_issues: 1
   num_pulls: 2
   num_closed_pulls: 0

--- a/models/issue_label_test.go
+++ b/models/issue_label_test.go
@@ -54,6 +54,7 @@ func TestNewLabels(t *testing.T) {
 	for _, label := range labels {
 		AssertExistsAndLoadBean(t, label)
 	}
+	CheckConsistencyFor(t, &Label{}, &Repository{})
 }
 
 func TestGetLabelByID(t *testing.T) {
@@ -138,6 +139,7 @@ func TestUpdateLabel(t *testing.T) {
 	assert.NoError(t, UpdateLabel(label))
 	newLabel := AssertExistsAndLoadBean(t, &Label{ID: 1}).(*Label)
 	assert.Equal(t, *label, *newLabel)
+	CheckConsistencyFor(t, &Label{}, &Repository{})
 }
 
 func TestDeleteLabel(t *testing.T) {
@@ -150,6 +152,7 @@ func TestDeleteLabel(t *testing.T) {
 	AssertNotExistsBean(t, &Label{ID: label.ID, RepoID: label.RepoID})
 
 	assert.NoError(t, DeleteLabel(NonexistentID, NonexistentID))
+	CheckConsistencyFor(t, &Label{}, &Repository{})
 }
 
 func TestHasIssueLabel(t *testing.T) {
@@ -180,6 +183,7 @@ func TestNewIssueLabel(t *testing.T) {
 
 	// re-add existing IssueLabel
 	assert.NoError(t, NewIssueLabel(issue, label, doer))
+	CheckConsistencyFor(t, &Issue{}, &Label{})
 }
 
 func TestNewIssueLabels(t *testing.T) {
@@ -208,6 +212,8 @@ func TestNewIssueLabels(t *testing.T) {
 
 	// corner case: test empty slice
 	assert.NoError(t, NewIssueLabels(issue, []*Label{}, doer))
+
+	CheckConsistencyFor(t, &Issue{}, &Label{})
 }
 
 func TestDeleteIssueLabel(t *testing.T) {
@@ -241,4 +247,6 @@ func TestDeleteIssueLabel(t *testing.T) {
 	testSuccess(1, 1, 2)
 	testSuccess(2, 5, 2)
 	testSuccess(1, 1, 2) // delete non-existent IssueLabel
+
+	CheckConsistencyFor(t, &Issue{}, &Label{})
 }


### PR DESCRIPTION
The `repo.NumIssues` is the number of non-pull-request issues, whereas I had previously thought it was the total number of pull-request-or-non-pull-request issues.

Also a similar fix for `repo.NumComments` too, and more thorough consistency testing.
