### PR TITLE
Makefile: install on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ install: $(wildcard *.go)
 build: $(EXECUTABLE)
 
 $(EXECUTABLE): $(SOURCES)
-	go build -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
+	go build -i -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
Makefile: install on build

This install Go packages on building for caching and faster builds