### PR TITLE
Fix bug in Issue.GetIsRead

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -193,7 +193,8 @@ func (issue *Issue) GetIsRead(userID int64) error {
 	if has, err := x.Get(issueUser); err != nil {
 		return err
 	} else if !has {
-		return ErrUserNotExist{UID: userID}
+		issue.IsRead = false
+		return nil
 	}
 	issue.IsRead = issueUser.IsRead
 	return nil


### PR DESCRIPTION
Fixes bug where a user would get a 500 if they tried to view the issues for a repo with issues they'd never viewed before.
