### PR TITLE
Improve status table implementation

### DIFF
--- a/modules/sync/status_pool.go
+++ b/modules/sync/status_pool.go
@@ -27,23 +27,21 @@ func NewStatusTable() *StatusTable {
 // Start sets value of given name to true in the pool.
 func (p *StatusTable) Start(name string) {
 	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	p.pool[name] = true
+	p.lock.Unlock()
 }
 
 // Stop sets value of given name to false in the pool.
 func (p *StatusTable) Stop(name string) {
 	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	p.pool[name] = false
+	p.lock.Unlock()
 }
 
 // IsRunning checks if value of given name is set to true in the pool.
 func (p *StatusTable) IsRunning(name string) bool {
 	p.lock.RLock()
-	defer p.lock.RUnlock()
-
-	return p.pool[name]
+	res := p.pool[name]
+	p.lock.RUnlock()
+	return res
 }

--- a/modules/sync/status_pool.go
+++ b/modules/sync/status_pool.go
@@ -14,34 +14,34 @@ import (
 // in different goroutines.
 type StatusTable struct {
 	lock sync.RWMutex
-	pool map[string]bool
+	pool map[string]struct{}
 }
 
 // NewStatusTable initializes and returns a new StatusTable object.
 func NewStatusTable() *StatusTable {
 	return &StatusTable{
-		pool: make(map[string]bool),
+		pool: make(map[string]struct{}),
 	}
 }
 
 // Start sets value of given name to true in the pool.
 func (p *StatusTable) Start(name string) {
 	p.lock.Lock()
-	p.pool[name] = true
+	p.pool[name] = struct{}{}
 	p.lock.Unlock()
 }
 
 // Stop sets value of given name to false in the pool.
 func (p *StatusTable) Stop(name string) {
 	p.lock.Lock()
-	p.pool[name] = false
+	delete(p.pool, name)
 	p.lock.Unlock()
 }
 
 // IsRunning checks if value of given name is set to true in the pool.
 func (p *StatusTable) IsRunning(name string) bool {
 	p.lock.RLock()
-	res := p.pool[name]
+	_, ok := p.pool[name]
 	p.lock.RUnlock()
-	return res
+	return ok
 }

--- a/modules/sync/status_pool_test.go
+++ b/modules/sync/status_pool_test.go
@@ -1,0 +1,19 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StatusTable(t *testing.T) {
+	table := NewStatusTable()
+
+	assert.False(t, table.IsRunning("xyz"))
+
+	table.Start("xyz")
+	assert.True(t, table.IsRunning("xyz"))
+
+	table.Stop("xyz")
+	assert.False(t, table.IsRunning("xyz"))
+}

--- a/modules/sync/unique_queue.go
+++ b/modules/sync/unique_queue.go
@@ -51,7 +51,7 @@ func (q *UniqueQueue) AddFunc(id interface{}, fn func()) {
 
 	idStr := com.ToStr(id)
 	q.table.lock.Lock()
-	q.table.pool[idStr] = true
+	q.table.pool[idStr] = struct{}{}
 	if fn != nil {
 		fn()
 	}


### PR DESCRIPTION
This pull request improves the status table implementation in a few ways:

* Removes `defer` calls. Using `defer` to cover reading or modifying a map is superfluous.
* Change underlying data structure from `map[string]bool` to a `map[string]struct{}`, which is more appropriate as this is essentially a thread-safe set.
* Adds testing.