### PR TITLE
Fix HighlightJS not working on compare diff page

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -292,5 +292,6 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["SourcePath"] = setting.AppSubURL + "/" + path.Join(userName, repoName, "src", afterCommitID)
 	ctx.Data["BeforeSourcePath"] = setting.AppSubURL + "/" + path.Join(userName, repoName, "src", beforeCommitID)
 	ctx.Data["RawPath"] = setting.AppSubURL + "/" + path.Join(userName, repoName, "raw", afterCommitID)
+	ctx.Data["RequireHighlightJS"] = true
 	ctx.HTML(200, tplDiff)
 }


### PR DESCRIPTION
It's this page: https://try.gitea.io/gitea/gitea/compare/2e7ccecfe6f3d52b1dd5277a0eaf7a628164c8ac...9847b38518fe19e0c764e92c51875443b3741e79

You see a link to it when one push something:

![andreynering painel gitea](https://cloud.githubusercontent.com/assets/7011819/22865051/5d24ca96-f143-11e6-8bae-ea538cc96257.png)
