### PR TITLE
Batch updates for issues

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -467,16 +467,15 @@ func runWeb(ctx *cli.Context) error {
 				Post(bindIgnErr(auth.CreateIssueForm{}), repo.NewIssuePost)
 
 			m.Group("/:index", func() {
-				m.Post("/label", repo.UpdateIssueLabel)
-				m.Post("/milestone", repo.UpdateIssueMilestone)
-				m.Post("/assignee", repo.UpdateIssueAssignee)
-			}, reqRepoWriter)
-
-			m.Group("/:index", func() {
 				m.Post("/title", repo.UpdateIssueTitle)
 				m.Post("/content", repo.UpdateIssueContent)
 				m.Combo("/comments").Post(bindIgnErr(auth.CreateCommentForm{}), repo.NewComment)
 			})
+
+			m.Post("/labels", repo.UpdateIssueLabel, reqRepoWriter)
+			m.Post("/milestone", repo.UpdateIssueMilestone, reqRepoWriter)
+			m.Post("/assignee", repo.UpdateIssueAssignee, reqRepoWriter)
+			m.Post("/status", repo.UpdateIssueStatus, reqRepoWriter)
 		})
 		m.Group("/comments/:id", func() {
 			m.Post("", repo.UpdateCommentContent)

--- a/models/issue.go
+++ b/models/issue.go
@@ -1011,6 +1011,16 @@ func GetIssueByID(id int64) (*Issue, error) {
 	return getIssueByID(x, id)
 }
 
+func getIssuesByIDs(e Engine, issueIDs []int64) ([]*Issue, error) {
+	issues := make([]*Issue, 0, 10)
+	return issues, e.In("id", issueIDs).Find(&issues)
+}
+
+// GetIssuesByIDs return issues with the given IDs.
+func GetIssuesByIDs(issueIDs []int64) ([]*Issue, error) {
+	return getIssuesByIDs(x, issueIDs)
+}
+
 // IssuesOptions represents options of an issue.
 type IssuesOptions struct {
 	RepoID      int64

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -42,3 +42,19 @@ func TestIssueAPIURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://try.gitea.io/api/v1/repos/user2/repo1/issues/1", issue.APIURL())
 }
+
+func TestGetIssuesByIDs(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	testSuccess := func(expectedIssueIDs []int64, nonExistentIssueIDs []int64) {
+		issues, err := GetIssuesByIDs(append(expectedIssueIDs, nonExistentIssueIDs...))
+		assert.NoError(t, err)
+		actualIssueIDs := make([]int64, len(issues))
+		for i, issue := range issues {
+			actualIssueIDs[i] = issue.ID
+		}
+		assert.Equal(t, expectedIssueIDs, actualIssueIDs)
+
+	}
+	testSuccess([]int64{1, 2, 3}, []int64{})
+	testSuccess([]int64{1, 2, 3}, []int64{NonexistentID})
+}

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -583,6 +583,13 @@ issues.filter_sort.recentupdate = Recently updated
 issues.filter_sort.leastupdate = Least recently updated
 issues.filter_sort.mostcomment = Most commented
 issues.filter_sort.leastcomment = Least commented
+issues.action_open = Open
+issues.action_close = Close
+issues.action_label = Label
+issues.action_milestone = Milestone
+issues.action_milestone_no_select = No milestone
+issues.action_assignee = Assignee
+issues.action_assignee_no_select = No assignee
 issues.opened_by = opened %[1]s by <a href="%[2]s">%[3]s</a>
 issues.opened_by_fake = opened %[1]s by %[2]s
 issues.previous = Previous

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2307,6 +2307,9 @@ footer .ui.language .menu {
   margin-top: -5px;
   margin-right: 5px;
 }
+.issue-actions {
+    display: none;
+}
 .page.buttons {
   padding-top: 15px;
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2270,6 +2270,9 @@ footer .ui.language .menu {
 #search-user-box .results .item img {
   margin-right: 8px;
 }
+.issue-actions {
+  display: none;
+}
 .issue.list {
   list-style: none;
   padding-top: 15px;
@@ -2306,9 +2309,6 @@ footer .ui.language .menu {
 .issue.list > .item .desc .assignee {
   margin-top: -5px;
   margin-right: 5px;
-}
-.issue-actions {
-    display: none;
 }
 .page.buttons {
   padding-top: 15px;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -1261,6 +1261,10 @@
 	}
 }
 
+.issue-actions {
+    display: none;
+}
+
 .issue.list {
 	list-style: none;
 	padding-top: 15px;

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -14,86 +14,147 @@
 			</div>
 		</div>
 		<div class="ui divider"></div>
-		<div class="ui tiny basic status buttons">
-			<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-				<i class="octicon octicon-issue-opened"></i>
-				{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
-			</a>
-			<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-				<i class="octicon octicon-issue-closed"></i>
-				{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
-			</a>
+		<div class="issue-filters">
+			<div class="ui tiny basic status buttons">
+				<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
+					<i class="octicon octicon-issue-opened"></i>
+					{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
+				</a>
+				<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
+					<i class="octicon octicon-issue-closed"></i>
+					{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
+				</a>
+			</div>
+			<div class="ui right floated secondary filter menu">
+				<!-- Label -->
+				<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.filter_label"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
+						{{range .Labels}}
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}"><span class="octicon {{if eq $.SelectLabels .ID}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | Sanitize}}</a>
+						{{end}}
+					</div>
+				</div>
+
+				<!-- Milestone -->
+				<div class="ui {{if not .Milestones}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.filter_milestone"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_milestone_no_select"}}</a>
+						{{range .Milestones}}
+							<a class="{{if eq $.MilestoneID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.ID}}&assignee={{$.AssigneeID}}">{{.Name | Sanitize}}</a>
+						{{end}}
+					</div>
+				</div>
+
+				<!-- Assignee -->
+				<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.filter_assignee"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}">{{.i18n.Tr "repo.issues.filter_assginee_no_select"}}</a>
+						{{range .Assignees}}
+							<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{.ID}}"><img src="{{.RelAvatarLink}}"> {{.Name}}</a>
+						{{end}}
+					</div>
+				</div>
+
+				<!-- Type -->
+				<div class="ui dropdown type jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.filter_type"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.all_issues"}}</a>
+						<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
+						<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
+						<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
+					</div>
+				</div>
+
+				<!-- Sort -->
+				<div class="ui dropdown type jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.filter_sort"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
+						<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
+						<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+						<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+						<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.mostcomment"}}</a>
+						<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastcomment"}}</a>
+					</div>
+				</div>
+			</div>
 		</div>
-		<div class="ui right floated secondary filter menu">
-			<!-- Label -->
-			<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item">
-				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_label"}}
-					<i class="dropdown icon"></i>
-				</span>
-				<div class="menu">
-					<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
-					{{range .Labels}}
-						<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}"><span class="octicon {{if eq $.SelectLabels .ID}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | Sanitize}}</a>
-					{{end}}
-				</div>
+		<div class="issue-actions">
+			<div class="ui basic status buttons">
+				<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.Link}}/status">{{.i18n.Tr "repo.issues.action_open"}}</div>
+				<div class="ui red active basic button issue-action" data-action="close" data-url="{{$.Link}}/status">{{.i18n.Tr "repo.issues.action_close"}}</div>
 			</div>
 
-			<!-- Milestone -->
-			<div class="ui {{if not .Milestones}}disabled{{end}} dropdown jump item">
-				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_milestone"}}
-					<i class="dropdown icon"></i>
-				</span>
-				<div class="menu">
-					<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_milestone_no_select"}}</a>
-					{{range .Milestones}}
-						<a class="{{if eq $.MilestoneID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.ID}}&assignee={{$.AssigneeID}}">{{.Name | Sanitize}}</a>
-					{{end}}
+			<div class="ui secondary filter menu floated right">
+				<!-- Labels -->
+				<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.action_label"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						{{range .Labels}}
+							<div class="item issue-action" data-action="toggle" data-element-id="{{.ID}}" data-url="{{$.Link}}/labels">
+								<span class="octicon {{if eq $.SelectLabels .ID}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | Sanitize}}
+							</div>
+						{{end}}
+					</div>
 				</div>
-			</div>
 
-			<!-- Assignee -->
-			<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
-				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_assignee"}}
-					<i class="dropdown icon"></i>
-				</span>
-				<div class="menu">
-					<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}">{{.i18n.Tr "repo.issues.filter_assginee_no_select"}}</a>
-					{{range .Assignees}}
-						<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{.ID}}"><img src="{{.RelAvatarLink}}"> {{.Name}}</a>
-					{{end}}
+				<!-- Milestone -->
+				<div class="ui {{if not .Milestones}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.action_milestone"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/milestone">
+						  {{.i18n.Tr "repo.issues.action_milestone_no_select"}}
+						</div>
+						{{range .Milestones}}
+							<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.Link}}/milestone">
+								{{.Name | Sanitize}}
+							</div>
+						{{end}}
+					</div>
 				</div>
-			</div>
 
-			<!-- Type -->
-			<div class="ui dropdown type jump item">
-				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_type"}}
-					<i class="dropdown icon"></i>
-				</span>
-				<div class="menu">
-					<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.all_issues"}}</a>
-					<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
-					<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
-					<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
-				</div>
-			</div>
-
-			<!-- Sort -->
-			<div class="ui dropdown type jump item">
-				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_sort"}}
-					<i class="dropdown icon"></i>
-				</span>
-				<div class="menu">
-					<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-					<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-					<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-					<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
-					<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.mostcomment"}}</a>
-					<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastcomment"}}</a>
+				<!-- Assignee -->
+				<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
+					<span class="text">
+						{{.i18n.Tr "repo.issues.action_assignee"}}
+						<i class="dropdown icon"></i>
+					</span>
+					<div class="menu">
+						<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/assignee">
+							{{.i18n.Tr "repo.issues.action_assignee_no_select"}}
+						</div>
+						{{range .Assignees}}
+							<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.Link}}/assignee">
+								<img src="{{.RelAvatarLink}}"> {{.Name}}
+							</div>
+						{{end}}
+					</div>
 				</div>
 			</div>
 		</div>
@@ -102,6 +163,9 @@
 			{{range .Issues}}
 				{{ $timeStr:= TimeSince .Created $.Lang }}
 				<li class="item">
+					<div class="ui checkbox issue-checkbox">
+						<input type="checkbox" data-issue-id={{.ID}}></input>
+					</div>
 					<div class="ui {{if .IsRead}}black{{else}}green{{end}} label">#{{.Index}}</div>
 					<a class="title has-emoji" href="{{$.Link}}/{{.Index}}">{{.Title}}</a>
 

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -311,7 +311,7 @@
 					<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 					<span class="octicon octicon-gear"></span>
 				</span>
-				<div class="filter menu" data-action="update" data-update-url="{{$.RepoLink}}/issues/{{$.Issue.Index}}/label">
+				<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
 					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 					{{range .Labels}}
 						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon {{if .IsChecked}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name}}</a>
@@ -335,7 +335,7 @@
 					<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
 					<span class="octicon octicon-gear"></span>
 				</span>
-				<div class="menu" data-action="update" data-update-url="{{$.RepoLink}}/issues/{{$.Issue.Index}}/milestone">
+				<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/milestone">
 					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_milestone"}}</div>
 					{{if .OpenMilestones}}
 						<div class="divider"></div>
@@ -376,7 +376,7 @@
 					<strong>{{.i18n.Tr "repo.issues.new.assignee"}}</strong>
 					<span class="octicon octicon-gear"></span>
 				</span>
-				<div class="menu" data-action="update" data-update-url="{{$.RepoLink}}/issues/{{$.Issue.Index}}/assignee">
+				<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/assignee">
 					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignee"}}</div>
 					{{range .Assignees}}
 						<div class="item" data-id="{{.ID}}" data-href="{{$.RepoLink}}/issues?assignee={{.ID}}" data-avatar="{{.RelAvatarLink}}"><img src="{{.RelAvatarLink}}"> {{.Name}}</div>


### PR DESCRIPTION
#868

Updates the 
- `:reponame/issues/:index/label`
- `:reponame/issues/:index/milestone`
- `:reponame/issues/:index/assignee`

endpoints to allow for multiple issues.

Also adds a front-end for opening/closing/assigning/labelling/milestoning multiple issues at once.

![Screenshot](https://cloud.githubusercontent.com/assets/8990880/22994330/8e8eec6c-f394-11e6-93e3-c167c6829c2b.png)

I am by no means a front-end expert, so any feedback is welcome :smile: