### PR TITLE
Remove the default console logger when it is not set in the configuration

### DIFF
--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -39,6 +39,17 @@ func NewLogger(bufLen int64, mode, config string) {
 	}
 }
 
+// DelLogger removes loggers that are for the given mode
+func DelLogger(mode string) error {
+	for _, l := range loggers {
+		if _, ok := l.outputs[mode]; ok {
+			return l.DelLogger(mode)
+		}
+	}
+	Trace("Log adapter %s not found, no need to delete", mode)
+	return nil
+}
+
 // NewGitLogger create a logger for git
 // FIXME: use same log level as other loggers.
 func NewGitLogger(logPath string) {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -765,6 +765,16 @@ func newLogService() {
 	LogModes = strings.Split(Cfg.Section("log").Key("MODE").MustString("console"), ",")
 	LogConfigs = make([]string, len(LogModes))
 
+	useConsole := false
+	for _, mode := range LogModes {
+		if mode == "console"  {
+			useConsole = true
+		}
+	}
+	if (!useConsole) {
+		log.DelLogger("console")
+	}
+
 	for i, mode := range LogModes {
 		mode = strings.TrimSpace(mode)
 


### PR DESCRIPTION
backport from #602 

* Remove the default console logger when it is not set in the configuration

* Added comment to new function (lint failure)

* update based on PR comments (code style)

* code style fix (thanks bkcsoft)

* check if logger exists based on the l.outputs (like in l.DelLogger) instead of adapter, otherwise panic when reinstalling gitea (since the output adapter still exist, without outputs)
