### PR TITLE
Implement creating non-bare repositories

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -12,6 +12,8 @@ SCRIPT_TYPE = bash
 ANSI_CHARSET =
 ; Force every new repository to be private
 FORCE_PRIVATE = false
+; Force every new repository to be bare
+FORCE_BARE = false
 ; Global maximum creation limit of repository per user, -1 means no limit
 MAX_CREATION_LIMIT = -1
 ; Mirror sync queue length, increase if mirror syncing starts hanging

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -69,7 +69,7 @@ func (repo *Repository) InitWiki() error {
 
 	if err := git.InitRepository(repo.WikiPath(), true); err != nil {
 		return fmt.Errorf("InitRepository: %v", err)
-	} else if err = createUpdateHook(repo.WikiPath()); err != nil {
+	} else if err = createUpdateHook(repo.WikiPath(), true); err != nil {
 		return fmt.Errorf("createUpdateHook: %v", err)
 	}
 	return nil

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -28,6 +28,7 @@ type CreateRepoForm struct {
 	Private     bool
 	Description string `binding:"MaxSize(255)"`
 	AutoInit    bool
+	Bare        bool   `binding:"Default(true)"`
 	Gitignores  string
 	License     string
 	Readme      string

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -305,7 +305,14 @@ func RepoAssignment(args ...bool) macaron.Handler {
 		ctx.Data["TagName"] = ctx.Repo.TagName
 		brs, err := ctx.Repo.GitRepo.GetBranches()
 		if err != nil {
-			ctx.Handle(500, "GetBranches", err)
+			if ctx.Repo.Repository.IsBare {
+				ctx.Handle(500, "GetBranches", err)
+			} else {
+				// it is an empty, non-bare repository - display the help screen for initializing
+				ctx.Data["BranchName"] = ""
+				ctx.Data["IsBareRepo"] = true
+				ctx.HTML(200, "repo/bare")
+			}
 			return
 		}
 		ctx.Data["Branches"] = brs

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -149,6 +149,7 @@ var (
 	Repository = struct {
 		AnsiCharset            string
 		ForcePrivate           bool
+		ForceBare              bool
 		MaxCreationLimit       int
 		MirrorQueueLength      int
 		PullRequestQueueLength int
@@ -172,6 +173,7 @@ var (
 	}{
 		AnsiCharset:            "",
 		ForcePrivate:           false,
+		ForceBare:              false,
 		MaxCreationLimit:       -1,
 		MirrorQueueLength:      1000,
 		PullRequestQueueLength: 1000,

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -393,6 +393,9 @@ visibility = Visibility
 visiblity_helper = This repository is <span class="ui red text">Private</span>
 visiblity_helper_forced = Site admin has forced all new repositories to be <span class="ui red text">Private</span>
 visiblity_fork_helper = (Change of this value will affect all forks)
+storage = Storage
+storage_helper = This repository is <span class="ui red text">Bare</span>
+storage_helper_forced = Site admin has forced all new repositories to be <span class="ui red text">Bare</span>
 clone_helper = Need help cloning? Visit <a target="_blank" rel="noopener" href="%s">Help</a>!
 fork_repo = Fork Repository
 fork_from = Fork From

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -75,7 +75,9 @@ func Create(ctx *context.Context) {
 	ctx.Data["Readmes"] = models.Readmes
 	ctx.Data["readme"] = "Default"
 	ctx.Data["private"] = ctx.User.LastRepoVisibility
+	ctx.Data["bare"] = true
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["IsForcedBare"] = setting.Repository.ForceBare
 
 	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))
 	if ctx.Written() {
@@ -131,6 +133,7 @@ func CreatePost(ctx *context.Context, form auth.CreateRepoForm) {
 		Readme:      form.Readme,
 		IsPrivate:   form.Private || setting.Repository.ForcePrivate,
 		AutoInit:    form.AutoInit,
+		IsBare:      form.Bare || setting.Repository.ForceBare,
 	})
 	if err == nil {
 		log.Trace("Repository created [%d]: %s/%s", repo.ID, ctxUser.Name, repo.Name)
@@ -152,6 +155,8 @@ func Migrate(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("new_migrate")
 	ctx.Data["private"] = ctx.User.LastRepoVisibility
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["bare"] = true
+	ctx.Data["IsForcedBare"] = setting.Repository.ForceBare
 	ctx.Data["mirror"] = ctx.Query("mirror") == "1"
 
 	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -50,6 +50,18 @@
 							{{end}}
 						</div>
 					</div>
+					<div class="inline field">
+						<label>{{.i18n.Tr "repo.storage"}}</label>
+						<div class="ui checkbox">
+							{{if .IsForcedBare}}
+								<input name="bare" type="checkbox" checked readonly>
+								<label>{{.i18n.Tr "repo.storage_helper_forced" | Safe}}</label>
+							{{else}}
+								<input name="bare" type="checkbox" {{if .bare}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.storage_helper" | Safe}}</label>
+							{{end}}
+						</div>
+					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
 						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>


### PR DESCRIPTION
Useful for hosting repositories where local access by scripts is needed.

For this, it is needed a checkbox in the initialization screen - a flag, which disables this totally.
The isBare flag is needed to push down to various places - for example the createUpdateHook assumed that the direct git directory was passed in. In the readme/licence/gitignore generation, with non-bare repository, it is possible to directly manipulate the content.