### PR TITLE
add missing copyright header

### DIFF
--- a/models/migrations/v16.go
+++ b/models/migrations/v16.go
@@ -1,3 +1,7 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package migrations
 
 import (


### PR DESCRIPTION
In PR #742 this file is added without a copyright header.
Appeared in review of #679 

This will only add the copyright header