### PR TITLE
Fixed issue 1003, bad link to documentation on CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document explains how to contribute changes to the Gitea project. It assumes you have followed the [installation instructions](https://github.com/go-gitea/docs/tree/master/en-US/installation). Sensitive security-related issues should be reported to [security@gitea.io](mailto:security@gitea.io).
+This document explains how to contribute changes to the Gitea project. It assumes you have followed the [installation instructions](https://docs.gitea.io/en-us/). Sensitive security-related issues should be reported to [security@gitea.io](mailto:security@gitea.io).
 
 ## Bug reports
 


### PR DESCRIPTION
Fixes issue 1003, broken link to installation documentation on the CONTRIBUTING.md page.

Signed-off-by: P.B. <puffybsd@yahoo.com>