### PR TITLE
Take back control of hooks

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -5,12 +5,8 @@
 package cmd
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 
 	"code.gitea.io/gitea/models"
 
@@ -64,21 +60,6 @@ func runHookPreReceive(c *cli.Context) error {
 		fail("Hook pre-receive init failed", fmt.Sprintf("setup: %v", err))
 	}
 
-	buf := bytes.NewBuffer(nil)
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		buf.Write(scanner.Bytes())
-		buf.WriteByte('\n')
-	}
-
-	customHooksPath := os.Getenv(envRepoCustomHooksPath)
-	hookCmd := exec.Command(filepath.Join(customHooksPath, "pre-receive"))
-	hookCmd.Stdout = os.Stdout
-	hookCmd.Stdin = buf
-	hookCmd.Stderr = os.Stderr
-	if err := hookCmd.Run(); err != nil {
-		fail("Internal error", "Fail to execute custom pre-receive hook: %v", err)
-	}
 	return nil
 }
 
@@ -108,14 +89,6 @@ func runHookUpdate(c *cli.Context) error {
 		fail("Internal error", "Fail to add update task '%s': %v", uuid, err)
 	}
 
-	customHooksPath := os.Getenv(envRepoCustomHooksPath)
-	hookCmd := exec.Command(filepath.Join(customHooksPath, "update"), args...)
-	hookCmd.Stdout = os.Stdout
-	hookCmd.Stdin = os.Stdin
-	hookCmd.Stderr = os.Stderr
-	if err := hookCmd.Run(); err != nil {
-		fail("Internal error", "Fail to execute custom pre-receive hook: %v", err)
-	}
 	return nil
 }
 
@@ -128,13 +101,5 @@ func runHookPostReceive(c *cli.Context) error {
 		fail("Hook post-receive init failed", fmt.Sprintf("setup: %v", err))
 	}
 
-	customHooksPath := os.Getenv(envRepoCustomHooksPath)
-	hookCmd := exec.Command(filepath.Join(customHooksPath, "post-receive"))
-	hookCmd.Stdout = os.Stdout
-	hookCmd.Stdin = os.Stdin
-	hookCmd.Stderr = os.Stderr
-	if err := hookCmd.Run(); err != nil {
-		fail("Internal error", "Fail to execute custom post-receive hook: %v", err)
-	}
 	return nil
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1,0 +1,140 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"code.gitea.io/gitea/models"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	CmdHook = cli.Command{
+		Name:        "hook",
+		Usage:       "Delegate commands to corresponding Git hooks",
+		Description: "All sub-commands should only be called by Git",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "config, c",
+				Value: "custom/conf/app.ini",
+				Usage: "Custom configuration file path",
+			},
+		},
+		Subcommands: []cli.Command{
+			subcmdHookPreReceive,
+			subcmdHookUpadte,
+			subcmdHookPostReceive,
+		},
+	}
+
+	subcmdHookPreReceive = cli.Command{
+		Name:        "pre-receive",
+		Usage:       "Delegate pre-receive Git hook",
+		Description: "This command should only be called by Git",
+		Action:      runHookPreReceive,
+	}
+	subcmdHookUpadte = cli.Command{
+		Name:        "update",
+		Usage:       "Delegate update Git hook",
+		Description: "This command should only be called by Git",
+		Action:      runHookUpdate,
+	}
+	subcmdHookPostReceive = cli.Command{
+		Name:        "post-receive",
+		Usage:       "Delegate post-receive Git hook",
+		Description: "This command should only be called by Git",
+		Action:      runHookPostReceive,
+	}
+)
+
+func runHookPreReceive(c *cli.Context) error {
+	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
+		return nil
+	}
+	if err := setup("hooks/pre-receive.log"); err != nil {
+		fail("Hook pre-receive init failed", fmt.Sprintf("setup: %v", err))
+	}
+
+	buf := bytes.NewBuffer(nil)
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		buf.Write(scanner.Bytes())
+		buf.WriteByte('\n')
+	}
+
+	customHooksPath := os.Getenv(envRepoCustomHooksPath)
+	hookCmd := exec.Command(filepath.Join(customHooksPath, "pre-receive"))
+	hookCmd.Stdout = os.Stdout
+	hookCmd.Stdin = buf
+	hookCmd.Stderr = os.Stderr
+	if err := hookCmd.Run(); err != nil {
+		fail("Internal error", "Fail to execute custom pre-receive hook: %v", err)
+	}
+	return nil
+}
+
+func runHookUpdate(c *cli.Context) error {
+	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
+		return nil
+	}
+
+	if err := setup("hooks/pre-receive.log"); err != nil {
+		fail("Hook update init failed", fmt.Sprintf("setup: %v", err))
+	}
+
+	args := c.Args()
+	if len(args) != 3 {
+		fail("Arguments received are not equal to three", "Arguments received are not equal to three")
+	} else if len(args[0]) == 0 {
+		fail("First argument 'refName' is empty", "First argument 'refName' is empty")
+	}
+
+	uuid := os.Getenv(envUpdateTaskUUID)
+	if err := models.AddUpdateTask(&models.UpdateTask{
+		UUID:        uuid,
+		RefName:     args[0],
+		OldCommitID: args[1],
+		NewCommitID: args[2],
+	}); err != nil {
+		fail("Internal error", "Fail to add update task '%s': %v", uuid, err)
+	}
+
+	customHooksPath := os.Getenv(envRepoCustomHooksPath)
+	hookCmd := exec.Command(filepath.Join(customHooksPath, "update"), args...)
+	hookCmd.Stdout = os.Stdout
+	hookCmd.Stdin = os.Stdin
+	hookCmd.Stderr = os.Stderr
+	if err := hookCmd.Run(); err != nil {
+		fail("Internal error", "Fail to execute custom pre-receive hook: %v", err)
+	}
+	return nil
+}
+
+func runHookPostReceive(c *cli.Context) error {
+	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
+		return nil
+	}
+
+	if err := setup("hooks/pre-receive.log"); err != nil {
+		fail("Hook post-receive init failed", fmt.Sprintf("setup: %v", err))
+	}
+
+	customHooksPath := os.Getenv(envRepoCustomHooksPath)
+	hookCmd := exec.Command(filepath.Join(customHooksPath, "post-receive"))
+	hookCmd.Stdout = os.Stdout
+	hookCmd.Stdin = os.Stdin
+	hookCmd.Stderr = os.Stderr
+	if err := hookCmd.Run(); err != nil {
+		fail("Internal error", "Fail to execute custom post-receive hook: %v", err)
+	}
+	return nil
+}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -18,7 +18,7 @@ var (
 	CmdHook = cli.Command{
 		Name:        "hook",
 		Usage:       "Delegate commands to corresponding Git hooks",
-		Description: "All sub-commands should only be called by Git",
+		Description: "This should only be called by Git",
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "config, c",

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2017 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"code.gitea.io/gitea/models"
-
 	"github.com/urfave/cli"
+
+	"code.gitea.io/gitea/models"
 )
 
 var (
@@ -68,7 +68,7 @@ func runHookUpdate(c *cli.Context) error {
 		return nil
 	}
 
-	if err := setup("hooks/pre-receive.log"); err != nil {
+	if err := setup("hooks/update.log"); err != nil {
 		fail("Hook update init failed", fmt.Sprintf("setup: %v", err))
 	}
 
@@ -97,7 +97,7 @@ func runHookPostReceive(c *cli.Context) error {
 		return nil
 	}
 
-	if err := setup("hooks/pre-receive.log"); err != nil {
+	if err := setup("hooks/post-receive.log"); err != nil {
 		fail("Hook post-receive init failed", fmt.Sprintf("setup: %v", err))
 	}
 

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	// CmdHook represents the available hooks sub-command.
 	CmdHook = cli.Command{
 		Name:        "hook",
 		Usage:       "Delegate commands to corresponding Git hooks",

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
-
 	"code.gitea.io/gitea/models"
+
+	"github.com/urfave/cli"
 )
 
 var (

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -28,10 +28,12 @@ import (
 )
 
 const (
-	accessDenied           = "Repository does not exist or you do not have access"
-	lfsAuthenticateVerb    = "git-lfs-authenticate"
-	envUpdateTaskUUID      = "GITEA_UUID"
-	envRepoCustomHooksPath = "REPO_CUSTOM_HOOKS_PATH"
+	accessDenied                = "Repository does not exist or you do not have access"
+	lfsAuthenticateVerb         = "git-lfs-authenticate"
+	envUpdateTaskUUID           = "GITEA_UUID"
+	envRepoUpdateHooksPath      = "GITEA_REPO_UPDATE_HOOKS_PATH"
+	envRepoPreReceiveHooksPath  = "GITEA_REPO_PRERECEIVE_HOOKS_PATH"
+	envRepoPostReceiveHooksPath = "GITEA_REPO_POSTRECEIVE_HOOKS_PATH"
 )
 
 // CmdServ represents the available serv sub-command.
@@ -333,7 +335,9 @@ func runServ(c *cli.Context) error {
 	os.Setenv(envUpdateTaskUUID, uuid)
 	// Keep the old env variable name for backward compability
 	os.Setenv("uuid", uuid)
-	os.Setenv(envRepoCustomHooksPath, filepath.Join(repo.RepoPath(), "custom_hooks"))
+	os.Setenv(envRepoUpdateHooksPath, filepath.Join(repo.RepoPath(), "hooks", "update.d"))
+	os.Setenv(envRepoPreReceiveHooksPath, filepath.Join(repo.RepoPath(), "hooks", "pre-receive.d"))
+	os.Setenv(envRepoPostReceiveHooksPath, filepath.Join(repo.RepoPath(), "hooks", "post-receive.d"))
 
 	// Special handle for Windows.
 	if setting.IsWindows {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	app.Commands = []cli.Command{
 		cmd.CmdWeb,
 		cmd.CmdServ,
-		cmd.CmdUpdate,
+		cmd.CmdHook,
 		cmd.CmdDump,
 		cmd.CmdCert,
 		cmd.CmdAdmin,

--- a/models/action.go
+++ b/models/action.go
@@ -506,7 +506,7 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 		}
 
 		if err = UpdateIssuesCommit(pusher, repo, opts.Commits.Commits); err != nil {
-			log.Error(4, "updateIssuesCommit: %v", err)
+			log.Error(4, "UpdateIssuesCommit: %v", err)
 		}
 	}
 

--- a/models/action.go
+++ b/models/action.go
@@ -506,7 +506,7 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 		}
 
 		if err = UpdateIssuesCommit(pusher, repo, opts.Commits.Commits); err != nil {
-			log.Error(4, "UpdateIssuesCommit: %v", err)
+			log.Error(4, "updateIssuesCommit: %v", err)
 		}
 	}
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -86,6 +86,8 @@ var migrations = []Migration{
 	NewMigration("set protect branches updated with created", setProtectedBranchUpdatedWithCreated),
 	// v18 -> v19
 	NewMigration("add external login user", addExternalLoginUser),
+	// v19 -> v20
+	NewMigration("generate and migrate Git hooks", generateAndMigrateGitHooks),
 }
 
 // Migrate database to current version

--- a/models/migrations/v18.go
+++ b/models/migrations/v18.go
@@ -13,8 +13,8 @@ import (
 // ExternalLoginUser makes the connecting between some existing user and additional external login sources
 type ExternalLoginUser struct {
 	ExternalID    string `xorm:"NOT NULL"`
-	UserID        int64 `xorm:"NOT NULL"`
-	LoginSourceID int64 `xorm:"NOT NULL"`
+	UserID        int64  `xorm:"NOT NULL"`
+	LoginSourceID int64  `xorm:"NOT NULL"`
 }
 
 func addExternalLoginUser(x *xorm.Engine) error {

--- a/models/migrations/v19.go
+++ b/models/migrations/v19.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"code.gitea.io/gitea/modules/setting"
+
 	"github.com/Unknwon/com"
 	"github.com/go-xorm/xorm"
-
-	"code.gitea.io/gitea/modules/setting"
 )
 
 func generateAndMigrateGitHooks(x *xorm.Engine) (err error) {

--- a/models/migrations/v19.go
+++ b/models/migrations/v19.go
@@ -31,9 +31,9 @@ func generateAndMigrateGitHooks(x *xorm.Engine) (err error) {
 	var (
 		hookNames = []string{"pre-receive", "update", "post-receive"}
 		hookTpls  = []string{
-			"cd ./pre-receive.d\nfor i in `ls`; do\n    sh $i\ndone",
-			"cd ./update.d\nfor i in `ls`; do\n    sh $i $1 $2 $3\ndone",
-			"cd ./post-receive.d\nfor i in `ls`; do\n    sh $i\ndone",
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/pre-receive.d\"`; do\n    sh \"$SHELL_FOLDER/pre-receive.d/$i\"\ndone", setting.ScriptType),
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/update.d\"`; do\n    sh \"$SHELL_FOLDER/update.d/$i\" $1 $2 $3\ndone", setting.ScriptType),
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/post-receive.d\"`; do\n    sh \"$SHELL_FOLDER/post-receive.d/$i\"\ndone", setting.ScriptType),
 		}
 		giteaHookTpls = []string{
 			fmt.Sprintf("#!/usr/bin/env %s\n\"%s\" hook --config='%s' pre-receive\n", setting.ScriptType, setting.AppPath, setting.CustomConf),

--- a/models/migrations/v19.go
+++ b/models/migrations/v19.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Unknwon/com"
+	"github.com/go-xorm/xorm"
+
+	"code.gitea.io/gitea/modules/setting"
+)
+
+func generateAndMigrateGitHooks(x *xorm.Engine) (err error) {
+	type Repository struct {
+		ID      int64
+		OwnerID int64
+		Name    string
+	}
+	type User struct {
+		ID   int64
+		Name string
+	}
+	var (
+		hookNames = []string{"pre-receive", "update", "post-receive"}
+		hookTpls  = []string{
+			fmt.Sprintf("#!/usr/bin/env %s\n\"%s\" hook --config='%s' pre-receive\n", setting.ScriptType, setting.AppPath, setting.CustomConf),
+			fmt.Sprintf("#!/usr/bin/env %s\n\"%s\" hook --config='%s' update $1 $2 $3\n", setting.ScriptType, setting.AppPath, setting.CustomConf),
+			fmt.Sprintf("#!/usr/bin/env %s\n\"%s\" hook --config='%s' post-receive\n", setting.ScriptType, setting.AppPath, setting.CustomConf),
+		}
+	)
+
+	return x.Where("id > 0").Iterate(new(Repository),
+		func(idx int, bean interface{}) error {
+			repo := bean.(*Repository)
+			user := new(User)
+			has, err := x.Where("id = ?", repo.OwnerID).Get(user)
+			if err != nil {
+				return fmt.Errorf("query owner of repository [repo_id: %d, owner_id: %d]: %v", repo.ID, repo.OwnerID, err)
+			} else if !has {
+				return nil
+			}
+
+			repoPath := filepath.Join(setting.RepoRootPath, strings.ToLower(user.Name), strings.ToLower(repo.Name)) + ".git"
+			hookDir := filepath.Join(repoPath, "hooks")
+			customHookDir := filepath.Join(repoPath, "custom_hooks")
+
+			for i, hookName := range hookNames {
+				oldHookPath := filepath.Join(hookDir, hookName)
+				newHookPath := filepath.Join(customHookDir, hookName)
+
+				// Gogs didn't allow user to set custom update hook thus no migration for it.
+				// In case user runs this migration multiple times, and custom hook exists,
+				// we assume it's been migrated already.
+				if hookName != "update" && com.IsFile(oldHookPath) && !com.IsExist(newHookPath) {
+					os.MkdirAll(customHookDir, os.ModePerm)
+					if err = os.Rename(oldHookPath, newHookPath); err != nil {
+						return fmt.Errorf("move hook file to custom directory '%s' -> '%s': %v", oldHookPath, newHookPath, err)
+					}
+				}
+
+				if err = ioutil.WriteFile(oldHookPath, []byte(hookTpls[i]), 0777); err != nil {
+					return fmt.Errorf("write hook file '%s': %v", oldHookPath, err)
+				}
+			}
+			return nil
+		})
+}

--- a/models/repo.go
+++ b/models/repo.go
@@ -836,9 +836,9 @@ func createDelegateHooks(repoPath string) (err error) {
 	var (
 		hookNames = []string{"pre-receive", "update", "post-receive"}
 		hookTpls  = []string{
-			"cd ./pre-receive.d\nfor i in `ls`; do\n    sh $i\ndone",
-			"cd ./update.d\nfor i in `ls`; do\n    sh $i $1 $2 $3\ndone",
-			"cd ./post-receive.d\nfor i in `ls`; do\n    sh $i\ndone",
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/pre-receive.d\"`; do\n    sh \"$SHELL_FOLDER/pre-receive.d/$i\"\ndone", setting.ScriptType),
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/update.d\"`; do\n    sh \"$SHELL_FOLDER/update.d/$i\" $1 $2 $3\ndone", setting.ScriptType),
+			fmt.Sprintf("#!/usr/bin/env %s\nORI_DIR=`pwd`\nSHELL_FOLDER=$(cd \"$(dirname \"$0\")\";pwd)\ncd \"$ORI_DIR\"\nfor i in `ls \"$SHELL_FOLDER/post-receive.d\"`; do\n    sh \"$SHELL_FOLDER/post-receive.d/$i\"\ndone", setting.ScriptType),
 		}
 		giteaHookTpls = []string{
 			fmt.Sprintf("#!/usr/bin/env %s\n\"%s\" hook --config='%s' pre-receive\n", setting.ScriptType, setting.AppPath, setting.CustomConf),
@@ -2049,7 +2049,7 @@ func SyncRepositoryHooks() error {
 	return x.Where("id > 0").Iterate(new(Repository),
 		func(idx int, bean interface{}) error {
 			if err := createDelegateHooks(bean.(*Repository).RepoPath()); err != nil {
-				return err
+				return fmt.Errorf("SyncRepositoryHook: %v", err)
 			}
 			return nil
 		})

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -69,8 +69,8 @@ func (repo *Repository) InitWiki() error {
 
 	if err := git.InitRepository(repo.WikiPath(), true); err != nil {
 		return fmt.Errorf("InitRepository: %v", err)
-	} else if err = createUpdateHook(repo.WikiPath()); err != nil {
-		return fmt.Errorf("createUpdateHook: %v", err)
+	} else if err = createDelegateHooks(repo.WikiPath()); err != nil {
+		return fmt.Errorf("createDelegateHooks: %v", err)
 	}
 	return nil
 }

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1003,8 +1003,8 @@ dashboard.git_gc_repos = Do garbage collection on repositories
 dashboard.git_gc_repos_success = All repositories have done garbage collection successfully.
 dashboard.resync_all_sshkeys = Rewrite '.ssh/authorized_keys' file (caution: non-Gitea keys will be lost)
 dashboard.resync_all_sshkeys_success = All public keys have been rewritten successfully.
-dashboard.resync_all_update_hooks = Rewrite all update hook of repositories (needed when custom config path is changed)
-dashboard.resync_all_update_hooks_success = All repositories' update hook have been rewritten successfully.
+dashboard.resync_all_hooks = Resync pre-receive, update and post-receive hooks of all repositories.
+dashboard.resync_all_hooks_success = All repositories' pre-receive, update and post-receive hooks have been resynced successfully.
 dashboard.reinit_missing_repos = Reinitialize all repository records that lost Git files
 dashboard.reinit_missing_repos_success = All repository records that lost Git files have been reinitialized successfully.
 

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -152,8 +152,8 @@ func Dashboard(ctx *context.Context) {
 			success = ctx.Tr("admin.dashboard.resync_all_sshkeys_success")
 			err = models.RewriteAllPublicKeys()
 		case syncRepositoryUpdateHook:
-			success = ctx.Tr("admin.dashboard.resync_all_update_hooks_success")
-			err = models.RewriteRepositoryUpdateHook()
+			success = ctx.Tr("admin.dashboard.resync_all_hooks_success")
+			err = models.SyncRepositoryHooks()
 		case reinitMissingRepository:
 			success = ctx.Tr("admin.dashboard.reinit_missing_repos_success")
 			err = models.ReinitMissingRepositories()

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -40,7 +40,7 @@
 								<td><i class="fa fa-caret-square-o-right"></i> <a href="{{AppSubUrl}}/admin?op=5">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
 							</tr>
 							<tr>
-								<td>{{.i18n.Tr "admin.dashboard.resync_all_update_hooks"}}</td>
+								<td>{{.i18n.Tr "admin.dashboard.resync_all_hooks"}}</td>
 								<td><i class="fa fa-caret-square-o-right"></i> <a href="{{AppSubUrl}}/admin?op=6">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
 							</tr>
 							<tr>

--- a/vendor/code.gitea.io/git/hook.go
+++ b/vendor/code.gitea.io/git/hook.go
@@ -14,12 +14,16 @@ import (
 	"github.com/Unknwon/com"
 )
 
-// hookNames is a list of Git server hooks' name that are supported.
-var hookNames = []string{
-	"pre-receive",
-	// "update",
-	"post-receive",
-}
+var (
+	// Direcotry of hook file. Can be changed to "custom_hooks" for very purpose.
+	HookDir = "hooks"
+	// HookNames is a list of Git server hooks' name that are supported.
+	HookNames = []string{
+		"pre-receive",
+		"update",
+		"post-receive",
+	}
+)
 
 var (
 	// ErrNotValidHook error when a git hook is not valid
@@ -28,7 +32,7 @@ var (
 
 // IsValidHookName returns true if given name is a valid Git hook.
 func IsValidHookName(name string) bool {
-	for _, hn := range hookNames {
+	for _, hn := range HookNames {
 		if hn == name {
 			return true
 		}
@@ -52,7 +56,7 @@ func GetHook(repoPath, name string) (*Hook, error) {
 	}
 	h := &Hook{
 		name: name,
-		path: path.Join(repoPath, "hooks", name),
+		path: path.Join(repoPath, HookDir, name),
 	}
 	if isFile(h.path) {
 		data, err := ioutil.ReadFile(h.path)
@@ -76,7 +80,7 @@ func (h *Hook) Name() string {
 	return h.name
 }
 
-// Update updates hook settings.
+// Update updates content hook file.
 func (h *Hook) Update() error {
 	if len(strings.TrimSpace(h.Content)) == 0 {
 		if isExist(h.path) {
@@ -93,8 +97,8 @@ func ListHooks(repoPath string) (_ []*Hook, err error) {
 		return nil, errors.New("hooks path does not exist")
 	}
 
-	hooks := make([]*Hook, len(hookNames))
-	for i, name := range hookNames {
+	hooks := make([]*Hook, len(HookNames))
+	for i, name := range HookNames {
 		hooks[i], err = GetHook(repoPath, name)
 		if err != nil {
 			return nil, err

--- a/vendor/code.gitea.io/git/repo_blame.go
+++ b/vendor/code.gitea.io/git/repo_blame.go
@@ -1,0 +1,10 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+// FileBlame return the Blame object of file
+func (repo *Repository) FileBlame(revision, path, file string) ([]byte, error) {
+	return NewCommand("blame", "--root", file).RunInDirBytes(path)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "km1AOUs34DCwgXT55fh6PrkPdiU=",
+			"checksumSHA1": "nt2y/SNJe3Rl0tzdaEyGQfCc4L4=",
 			"path": "code.gitea.io/git",
-			"revision": "dd951bf625ebf5c16ef403f681aaec6c34324bca",
-			"revisionTime": "2017-02-05T02:50:57Z"
+			"revision": "b4c06a53d0f619e84a99eb042184663d4ad8a32b",
+			"revisionTime": "2017-02-22T02:52:05Z"
 		},
 		{
 			"checksumSHA1": "BKj0haFTDebzdC2nACpoGzp3s8A=",


### PR DESCRIPTION
This PR depends on go-gitea/git#34. On this PR, we changed the hooks directory structure. 

Now we put all the server-side hooks(pre-receive, update, post-receive) on `hooks/pre-receive.d/`, `hooks/update.d/` and `hooks/post-receive.d/`. 
Gitea's hook will be at `hooks/pre-receive.d/gitea`, `hooks/update.d/gitea` and `hooks/post-receive.d/gitea`.
And the old user hooks will be at `hooks/pre-receive.d/pre-receive` and `hooks/post-receive.d/post-receive`. Of course, we will support multiple hooks on the UI sometime, it's will be easy if this PR is merged.