### PR TITLE
Fix for #1013 - Tweak docker target to work by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ $(EXECUTABLE): $(SOURCES)
 
 .PHONY: docker
 docker:
-	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="$(TAGS)" webhippie/golang:edge make clean generate build
+	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" webhippie/golang:edge make clean generate build
 	docker build -t gitea/gitea:latest .
 
 .PHONY: release


### PR DESCRIPTION
Fix for #1013: adds "bindata" to tags by default, as without this the
resulting docker image won't start, as it doesn't contain locale files.
Verified to work even if you specify TAGS="bindata" such that it appears
twice.