### PR TITLE
Fix 500 when change user setting email to an exist email

### DIFF
--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -105,6 +105,11 @@ func SettingsPost(ctx *context.Context, form auth.UpdateProfileForm) {
 	ctx.User.Website = form.Website
 	ctx.User.Location = form.Location
 	if err := models.UpdateUser(ctx.User); err != nil {
+		if _, ok := err.(models.ErrEmailAlreadyUsed); ok {
+			ctx.Flash.Error(ctx.Tr("form.email_been_used"))
+			ctx.Redirect(setting.AppSubURL + "/user/settings")
+			return
+		}
 		ctx.Handle(500, "UpdateUser", err)
 		return
 	}


### PR DESCRIPTION
This PR fix a 500 when you change your email to an exist email address.

before

![untitled](https://cloud.githubusercontent.com/assets/81045/23296028/4234aa48-faae-11e6-883f-cf62d0d2d94a.png)

after 

![untitled2](https://cloud.githubusercontent.com/assets/81045/23296037/4b510414-faae-11e6-9eab-84d2a9c4cdc3.png)
