### PR TITLE
Fix span wrapping all the things

### DIFF
--- a/public/js/libs/autolink.js
+++ b/public/js/libs/autolink.js
@@ -1,12 +1,15 @@
 jQuery.fn.autolink = function() {
-	return this.find('*').contents().filter(function () { return this.nodeType === 3; }).each(function() {
-		var re = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+:=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
-		$(this).each(function() {
-			$(this).replaceWith(
-				$("<span />").html(
-					this.nodeValue.replace(re, "<a href='$1'>$1</a>")
-				)
-			);
+	var re = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+:=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
+	return this.find('*').contents()
+		.filter(function () { return this.nodeType === 3; })
+		.each(function() {
+			$(this).each(function() {
+				if (re.test($(this).text()))
+					$(this).replaceWith(
+						$("<span />").html(
+							this.nodeValue.replace(re, "<a href='$1'>$1</a>")
+						)
+					);
+			});
 		});
-	});
 };


### PR DESCRIPTION
As it is in the title. Wrap in ```<span>``` only if text contains link to autolink. Fixes double sized table borders. Ready as it is. Fixes regression introduced in #186.