### PR TITLE
Reword the reinit_missing_repos message to be clear about what it does

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1005,8 +1005,8 @@ dashboard.resync_all_sshkeys = Rewrite '.ssh/authorized_keys' file (caution: non
 dashboard.resync_all_sshkeys_success = All public keys have been rewritten successfully.
 dashboard.resync_all_hooks = Resync pre-receive, update and post-receive hooks of all repositories.
 dashboard.resync_all_hooks_success = All repositories' pre-receive, update and post-receive hooks have been resynced successfully.
-dashboard.reinit_missing_repos = Reinitialize all repository records that lost Git files
-dashboard.reinit_missing_repos_success = All repository records that lost Git files have been reinitialized successfully.
+dashboard.reinit_missing_repos = Reinitialize all lost Git repositories for which records exist
+dashboard.reinit_missing_repos_success = All lost Git repositories for which records existed have been reinitialized successfully.
 
 dashboard.server_uptime = Server Uptime
 dashboard.current_goroutine = Current Goroutines


### PR DESCRIPTION
I was confused by current wording, which seemed to imply that
*records* would be initialized, while instead the function initializes
the *git repositories* instead, where missing but referenced.