### PR TITLE
Fix for #1037: Corrected process ID placeholder to PID from Pid

### DIFF
--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -49,7 +49,7 @@
 						<tbody>
 							{{range .Processes}}
 								<tr>
-									<td>{{.Pid}}</td>
+									<td>{{.PID}}</td>
 									<td>{{.Description}}</td>
 									<td>{{DateFmtLong .Start}}</td>
 									<td>{{TimeSince .Start $.Lang}}</td>


### PR DESCRIPTION
Changed the process ID placeholder to PID from Pid

![admin_monitor_pid](https://cloud.githubusercontent.com/assets/9416498/23321968/1b06e272-fae2-11e6-968c-e5c2d3162380.png)
