### PR TITLE
Link OAuth2 account to 2FA enabled account (fix #1050)

### DIFF
--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -219,6 +219,16 @@ func TwoFactorPost(ctx *context.Context, form auth.TwoFactorAuthForm) {
 			return
 		}
 
+		if ctx.Session.Get("linkAccount") != nil {
+			gothUser := ctx.Session.Get("linkAccountGothUser")
+			if gothUser == nil {
+				ctx.Handle(500, "UserSignIn", errors.New("not in LinkAccount session"))
+				return
+			}
+
+			models.LinkAccountToUser(u, gothUser.(goth.User))
+		}
+
 		handleSignIn(ctx, u, remember)
 		return
 	}


### PR DESCRIPTION
fixes #1050 where linking an account to a 2fa enabled account failed because we forgot to really link the account when 2fa is completed