### PR TITLE
Allow migrating installations with no local avatars

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -89,7 +89,7 @@ var migrations = []Migration{
 	// v19 -> v20
 	NewMigration("generate and migrate Git hooks", generateAndMigrateGitHooks),
 	// v20 -> v21
-	NewMigration("use new avtar path name for security reason", useNewNameAvatars),
+	NewMigration("use new avatar path name for security reason", useNewNameAvatars),
 }
 
 // Migrate database to current version

--- a/models/migrations/v20.go
+++ b/models/migrations/v20.go
@@ -21,6 +21,10 @@ import (
 func useNewNameAvatars(x *xorm.Engine) error {
 	d, err := os.Open(setting.AvatarUploadPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to do if AvatarUploadPath does not exist
+			return nil
+		}
 		return err
 	}
 	names, err := d.Readdirnames(0)


### PR DESCRIPTION
Fixes this error:

[...itea/routers/init.go:54 GlobalInit()] [E] Failed to initialize ORM engine: migrate: do migrate: open /var/www/git/data/avatars: no such file or directory