### PR TITLE
Fix go vet faults

### DIFF
--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -28,9 +28,9 @@ func createContext(req *http.Request) (*macaron.Context, *httptest.ResponseRecor
 	resp := httptest.NewRecorder()
 	c := &macaron.Context{
 		Injector: inject.New(),
-		Req:      macaron.Request{req},
+		Req:      macaron.Request{Request: req},
 		Resp:     macaron.NewResponseWriter(resp),
-		Render:   &macaron.DummyRender{resp},
+		Render:   &macaron.DummyRender{ResponseWriter: resp},
 		Data:     make(map[string]interface{}),
 	}
 	c.Map(c)

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -22,7 +22,10 @@ func ListAccessTokens(ctx *context.APIContext) {
 
 	apiTokens := make([]*api.AccessToken, len(tokens))
 	for i := range tokens {
-		apiTokens[i] = &api.AccessToken{tokens[i].Name, tokens[i].Sha1}
+		apiTokens[i] = &api.AccessToken{
+			Name: tokens[i].Name,
+			Sha1: tokens[i].Sha1,
+		}
 	}
 	ctx.JSON(200, &apiTokens)
 }
@@ -38,5 +41,8 @@ func CreateAccessToken(ctx *context.APIContext, form api.CreateAccessTokenOption
 		ctx.Error(500, "NewAccessToken", err)
 		return
 	}
-	ctx.JSON(201, &api.AccessToken{t.Name, t.Sha1})
+	ctx.JSON(201, &api.AccessToken{
+		Name: t.Name,
+		Sha1: t.Sha1,
+	})
 }


### PR DESCRIPTION
Fixes a few `composite literal uses unkeyed fields` errors that occurred when I ran `make vet` locally; for some reason, `make vet` has still been passing in CI builds. 