### PR TITLE
Fix unused Engine bugs

### DIFF
--- a/models/attachment.go
+++ b/models/attachment.go
@@ -89,7 +89,7 @@ func NewAttachment(name string, buf []byte, file multipart.File) (_ *Attachment,
 
 func getAttachmentByUUID(e Engine, uuid string) (*Attachment, error) {
 	attach := &Attachment{UUID: uuid}
-	has, err := x.Get(attach)
+	has, err := e.Get(attach)
 	if err != nil {
 		return nil, err
 	} else if !has {

--- a/models/repo.go
+++ b/models/repo.go
@@ -1810,15 +1810,15 @@ func GetRecentUpdatedRepositories(opts *SearchRepoOptions) (repos RepositoryList
 }
 
 func getRepositoryCount(e Engine, u *User) (int64, error) {
-	return x.Count(&Repository{OwnerID: u.ID})
+	return e.Count(&Repository{OwnerID: u.ID})
 }
 
 func getPublicRepositoryCount(e Engine, u *User) (int64, error) {
-	return x.Where("is_private = ?", false).Count(&Repository{OwnerID: u.ID})
+	return e.Where("is_private = ?", false).Count(&Repository{OwnerID: u.ID})
 }
 
 func getPrivateRepositoryCount(e Engine, u *User) (int64, error) {
-	return x.Where("is_private = ?", true).Count(&Repository{OwnerID: u.ID})
+	return e.Where("is_private = ?", true).Count(&Repository{OwnerID: u.ID})
 }
 
 // GetRepositoryCount returns the total number of repositories of user.


### PR DESCRIPTION
Fix bugs where private functions that take an `Engine` argument had previously ignored their argument, and used `x` instead.
