### PR TITLE
Remove unused fixme on dump command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -130,7 +130,7 @@ func runDump(ctx *cli.Context) error {
 	if err := z.AddDir("log", setting.LogRootPath); err != nil {
 		log.Fatalf("Failed to include log: %v", err)
 	}
-	// FIXME: SSH key file.
+
 	if err = z.Close(); err != nil {
 		_ = os.Remove(fileName)
 		log.Fatalf("Failed to save %s: %v", fileName, err)


### PR DESCRIPTION
Since all public keys are also stored in database and database will be dumped to file. Then it's no need to copy the public keys file from `.ssh/`. So let's remove this wrong `FIXME` comment.