### PR TITLE
Makefile: Use hash over which

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,21 +47,21 @@ vet:
 
 .PHONY: generate
 generate:
-	@which go-bindata > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+	@hash go-bindata > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/jteeuwen/go-bindata/...; \
 	fi
 	go generate $(PACKAGES)
 
 .PHONY: errcheck
 errcheck:
-	@which errcheck > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+	@hash errcheck > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/kisielk/errcheck; \
 	fi
 	errcheck $(PACKAGES)
 
 .PHONY: lint
 lint:
-	@which golint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+	@hash golint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/golang/lint/golint; \
 	fi
 	for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;
@@ -105,7 +105,7 @@ release-dirs:
 
 .PHONY: release-build
 release-build:
-	@which xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/karalabe/xgo; \
 	fi
 	xgo -dest $(DIST)/binaries -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -targets '$(TARGETS)' -out $(EXECUTABLE)-$(VERSION) .


### PR DESCRIPTION
`hash` is a much faster shell-builtin alternative to `which`. I checked and it's available even on minimal shells like busybox, so I think it's save to use.

As [suggested](https://github.com/go-gitea/gitea/pull/1068#issuecomment-282553114) by @tboerger.