### PR TITLE
fix broken caused by boltdb in mips/mipsle

### DIFF
--- a/vendor/github.com/boltdb/bolt/bolt_mips.go
+++ b/vendor/github.com/boltdb/bolt/bolt_mips.go
@@ -1,0 +1,11 @@
+// +build mips
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x40000000 // 1GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// brokenUnaligned Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_mipsle.go
+++ b/vendor/github.com/boltdb/bolt/bolt_mipsle.go
@@ -1,0 +1,11 @@
+// +build mipsle
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x40000000 // 1GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// brokenUnaligned Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false


### PR DESCRIPTION
This fix boltdb build error on linux/mips and linux/mipsle, 
inspired by https://github.com/boltdb/bolt/pull/663