### PR TITLE
refactor: remove redundant slash.

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -583,9 +583,7 @@ please consider changing to GITEA_CUSTOM`)
 	sec := Cfg.Section("server")
 	AppName = Cfg.Section("").Key("APP_NAME").MustString("Gitea: Git with a cup of tea")
 	AppURL = sec.Key("ROOT_URL").MustString("http://localhost:3000/")
-	if AppURL[len(AppURL)-1] != '/' {
-		AppURL += "/"
-	}
+	AppURL = strings.TrimRight(AppURL, "/") + "/"
 
 	// Check if has app suburl.
 	url, err := url.Parse(AppURL)


### PR DESCRIPTION
before: `https://try.gitea.io/////`
after: `https://try.gitea.io/`