### PR TITLE
fix install submit crash caused by xorm log

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -239,9 +239,8 @@ func NewTestEngine(x *xorm.Engine) (err error) {
 		return fmt.Errorf("Connect to database: %v", err)
 	}
 
-	setting.NewXORMLogService(false)
-
 	x.SetMapper(core.GonicMapper{})
+	x.SetLogger(log.XORMLogger)
 	return x.StoreEngine("InnoDB").Sync2(tables...)
 }
 


### PR DESCRIPTION
When starting a fresh installation, it crashed after you submit your installation config in the UI. This will fix that.