### PR TITLE
Dockerfile for aarch64 (#1128)

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,43 @@
+FROM aarch64/alpine:3.5
+
+EXPOSE 22 3000
+
+RUN apk update && \
+  apk add \
+    su-exec \
+    ca-certificates \
+    sqlite \
+    bash \
+    git \
+    linux-pam \
+    s6 \
+    curl \
+    openssh \
+    tzdata && \
+  rm -rf \
+    /var/cache/apk/* && \
+  addgroup \
+    -S -g 1000 \
+    git && \
+  adduser \
+    -S -H -D \
+    -h /data/git \
+    -s /bin/bash \
+    -u 1000 \
+    -G git \
+    git && \
+  echo "git:$(date +%s | sha256sum | base64 | head -c 32)" | chpasswd
+
+ENV USER git
+ENV GITEA_CUSTOM /data/gitea
+
+COPY docker /
+COPY gitea /app/gitea/gitea
+
+ENV GODEBUG=netdns=go
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/bin/s6-svscan", "/etc/s6"]
+


### PR DESCRIPTION
As requested by @vielmetti, this is pretty much the same as the existing Dockerfile for rpi.
The Dockerfile is already being built [here](https://hub.docker.com/r/atzoum/aarch64-gitea/) using [this Jenkinsfile](https://github.com/atzoum/docker-aarch64/blob/master/aarch64-gitea/Jenkinsfile) and tested on both odroid64 and pine64 boards.