### PR TITLE
Fix random avatar begin regenerated on every page refresh

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -296,9 +296,6 @@ func (u *User) GenerateRandomAvatar() error {
 	if err != nil {
 		return fmt.Errorf("RandomImage: %v", err)
 	}
-	// NOTICE for random avatar, it still uses id as avatar name, but custom avatar use md5
-	// since random image is not a user's photo, there is no security for enumable
-	u.Avatar = fmt.Sprintf("%d", u.ID)
 	if err = os.MkdirAll(filepath.Dir(u.CustomAvatarPath()), os.ModePerm); err != nil {
 		return fmt.Errorf("MkdirAll: %v", err)
 	}


### PR DESCRIPTION
See this line: https://github.com/go-gitea/gitea/blob/848293671b5d9c31ce3eb9ad8a1f130edd0ee7c5/models/user.go#L335

This line was always returning true because `u.CustomAvatarPath()` uses a email hash to generate the avatar path, but it was actually generated and served by the user ID.

Using hash on all cases is more consistent and fixes the issue.
