### PR TITLE
Always put OAuth user info in the ExternalLoginUser table

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -173,7 +173,7 @@ func TestPushCommits_AvatarLink(t *testing.T) {
 	pushCommits.Len = len(pushCommits.Commits)
 
 	assert.Equal(t,
-		"https://secure.gravatar.com/avatar/ab53a2911ddf9b4817ac01ddcd3d975f?d=identicon",
+		"/suburl//explore/avatars/user2/-1",
 		pushCommits.AvatarLink("user2@example.com"))
 
 	assert.Equal(t,

--- a/models/user.go
+++ b/models/user.go
@@ -242,11 +242,6 @@ func (u *User) IsLocal() bool {
 	return u.LoginType <= LoginPlain
 }
 
-// IsOAuth2 returns true if user login type is LoginOAuth2.
-func (u *User) IsOAuth2() bool {
-	return u.LoginType == LoginOAuth2
-}
-
 // HasForkedRepo checks if user has already forked a repository with given ID.
 func (u *User) HasForkedRepo(repoID int64) bool {
 	_, has := HasForkedRepo(u.ID, repoID)

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -7,7 +7,7 @@
 			{{.i18n.Tr "settings.password"}}
 		</h4>
 		<div class="ui attached segment">
-			{{if or (.SignedUser.IsLocal) (.SignedUser.IsOAuth2)}}
+			{{if (.SignedUser.IsLocal) }}
 			<form class="ui form" action="{{AppSubUrl}}/user/settings/account" method="post">
 				{{.CsrfTokenHtml}}
 				{{if .SignedUser.IsPasswordSet}}


### PR DESCRIPTION
Never set OAuth in User.LoginSource, which keeps referring to
the username/password interpretation. Fixes #1124

\cc @willemvd, @morrildl, @lunny, @bkcsoft

I think this should be done before 1.1.0