### PR TITLE
Fix double borders on edit page (#1152)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1406,6 +1406,17 @@ footer .ui.language .menu {
 .repository.file.editor .commit-form-wrapper {
   padding-left: 64px;
 }
+.repository.file.editor .tab[data-tab="write"] {
+    padding: 0 !important;
+}
+.repository.file.editor .tab[data-tab="write"] .editor-toolbar {
+    border: none !important;
+}
+.repository.file.editor .tab[data-tab="write"] .CodeMirror {
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+}
 .repository.file.editor .commit-form-wrapper .commit-avatar {
   float: left;
   margin-left: -64px;

--- a/public/less/_editor.less
+++ b/public/less/_editor.less
@@ -8,3 +8,14 @@
 		background: inherit !important;
 	}
 }
+.repository.file.editor .tab[data-tab="write"] {
+    padding: 0 !important;
+}
+.repository.file.editor .tab[data-tab="write"] .editor-toolbar {
+    border: none !important;
+}
+.repository.file.editor .tab[data-tab="write"] .CodeMirror {
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+}


### PR DESCRIPTION
There is unnecessary double borders around the editors on the edit file view. This applies to both the markdown and the plain text editor. This also makes the editor more consistent with GitHub and the rest of the Gitea UI.

## Screenshots
|Before my CSS|After my CSS|
|-|-|
|![Before my CSS](https://cloud.githubusercontent.com/assets/13909717/23731039/29b40998-0439-11e7-8bea-b1f3c00a7aac.png)|![After my CSS](https://cloud.githubusercontent.com/assets/13909717/23731038/29b23fdc-0439-11e7-8cce-fa5614f34013.png)|