### PR TITLE
Fix leave team 404

### DIFF
--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -108,6 +108,8 @@ func TeamsAction(ctx *context.Context) {
 	switch page {
 	case "team":
 		ctx.Redirect(ctx.Org.OrgLink + "/teams/" + ctx.Org.Team.LowerName)
+	case "home":
+		ctx.Redirect(ctx.Org.Organization.HomeLink())
 	default:
 		ctx.Redirect(ctx.Org.OrgLink + "/teams")
 	}

--- a/templates/org/team/sidebar.tmpl
+++ b/templates/org/team/sidebar.tmpl
@@ -3,7 +3,7 @@
 		<strong>{{.Team.Name}}</strong>
 		<div class="ui right">
 			{{if .Team.IsMember $.SignedUser.ID}}
-				<a class="ui red tiny button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/action/leave?uid={{$.SignedUser.ID}}&page=team">{{$.i18n.Tr "org.teams.leave"}}</a>
+				<a class="ui red tiny button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/action/leave?uid={{$.SignedUser.ID}}&page=home">{{$.i18n.Tr "org.teams.leave"}}</a>
 			{{else if .IsOrganizationOwner}}
 				<a class="ui blue tiny button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/action/join?uid={{$.SignedUser.ID}}&page=team">{{$.i18n.Tr "org.teams.join"}}</a>
 			{{end}}


### PR DESCRIPTION
When leave team, you will be redirect to the original team page. It's a wrong logic and you will receive a 404 page. You should be redirected to organization page since you are still a member of organization.