### PR TITLE
Add MSSQL to issues template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,6 +11,7 @@
 - Database (use `[x]`):
   - [ ] PostgreSQL
   - [ ] MySQL
+  - [ ] MSSQL
   - [ ] SQLite
 - Can you reproduce the bug at https://try.gitea.io:
   - [ ] Yes (provide example URL)


### PR DESCRIPTION
Simple update for the issues template used by the source Gitea repo here on Github to add MSSQL to the list of databases since it is now supported in 1.1.0
