### PR TITLE
add mssql to app.ini db config comment

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -147,7 +147,7 @@ RSA     = 2048
 DSA     = 1024
 
 [database]
-; Either "mysql", "postgres" or "sqlite3", it's your choice
+; Either "mysql", "postgres", "mssql" or "sqlite3", it's your choice
 DB_TYPE = mysql
 HOST = 127.0.0.1:3306
 NAME = gitea


### PR DESCRIPTION
Simple change to add "mssql" into the possible options in the database comment section in app.ini.
