### PR TITLE
Fix upgrade failed after ever rollback

### DIFF
--- a/models/migrations/v16.go
+++ b/models/migrations/v16.go
@@ -59,6 +59,12 @@ func addUnitsToTables(x *xorm.Engine) error {
 	}
 
 	var repoUnit RepoUnit
+	if exist, err := sess.IsTableExist(&repoUnit); err != nil {
+		return fmt.Errorf("IsExist RepoUnit: %v", err)
+	} else if exist {
+		return nil
+	}
+
 	if err := sess.CreateTable(&repoUnit); err != nil {
 		return fmt.Errorf("CreateTable RepoUnit: %v", err)
 	}

--- a/models/migrations/v19.go
+++ b/models/migrations/v19.go
@@ -60,8 +60,14 @@ func generateAndMigrateGitHooks(x *xorm.Engine) (err error) {
 				oldHookPath := filepath.Join(hookDir, hookName)
 				newHookPath := filepath.Join(hookDir, hookName+".d", "gitea")
 
-				if err = os.MkdirAll(filepath.Join(hookDir, hookName+".d"), os.ModePerm); err != nil {
-					return fmt.Errorf("create hooks dir '%s': %v", filepath.Join(hookDir, hookName+".d"), err)
+				customHooksDir := filepath.Join(hookDir, hookName+".d")
+				// if it's exist, that means you have upgraded ever
+				if com.IsExist(customHooksDir) {
+					continue
+				}
+
+				if err = os.MkdirAll(customHooksDir, os.ModePerm); err != nil {
+					return fmt.Errorf("create hooks dir '%s': %v", customHooksDir, err)
 				}
 
 				// WARNING: Old server-side hooks will be moved to sub directory with the same name

--- a/models/migrations/v20.go
+++ b/models/migrations/v20.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/go-xorm/xorm"
@@ -40,7 +41,8 @@ func useNewNameAvatars(x *xorm.Engine) error {
 	for _, name := range names {
 		userID, err := strconv.ParseInt(name, 10, 64)
 		if err != nil {
-			return err
+			log.Warnf("ignore avatar %s rename: %v", name, err)
+			continue
 		}
 
 		var user User

--- a/models/migrations/v20.go
+++ b/models/migrations/v20.go
@@ -41,7 +41,7 @@ func useNewNameAvatars(x *xorm.Engine) error {
 	for _, name := range names {
 		userID, err := strconv.ParseInt(name, 10, 64)
 		if err != nil {
-			log.Warnf("ignore avatar %s rename: %v", name, err)
+			log.Warn("ignore avatar %s rename: %v", name, err)
 			continue
 		}
 


### PR DESCRIPTION
After upgrade to a gitea new version and then downgrade an old version, then if you upgrade again, you will encounter some migrations issues. This PR will check more conditions on migrations and ignore this situation to let upgrade smoothly.