### PR TITLE
fix #1189, commit messages containing a pipe

### DIFF
--- a/models/graph.go
+++ b/models/graph.go
@@ -78,8 +78,8 @@ func graphItemFromString(s string, r *git.Repository) (GraphItem, error) {
 		return GraphItem{}, fmt.Errorf("Failed parsing grap line:%s. Expect 1 or two fields", s)
 	}
 
-	rows := strings.Split(data, "|")
-	if len(rows) != 8 {
+	rows := strings.SplitN(data, "|", 8)
+	if len(rows) < 8 {
 		return GraphItem{}, fmt.Errorf("Failed parsing grap line:%s - Should containt 8 datafields", s)
 	}
 


### PR DESCRIPTION
this patch makes `graphItemFromString` split only the first 8 elements, leaving commit messages with pipes in it untouched.