### PR TITLE
Reserve the "explore" user/org name

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -630,7 +630,7 @@ func NewGhostUser() *User {
 }
 
 var (
-	reservedUsernames    = []string{"assets", "css", "img", "js", "less", "plugins", "debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
+	reservedUsernames    = []string{"assets", "css", "explore", "img", "js", "less", "plugins", "debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
 	reservedUserPatterns = []string{"*.keys"}
 )
 


### PR DESCRIPTION
Found abuse on https://try.gitea.io/explore/repos where
an "explore" user has "repos" and "users" repositories,
at the time of writing...