### PR TITLE
Fix typos in models/ and modules/

### DIFF
--- a/models/branches.go
+++ b/models/branches.go
@@ -57,7 +57,7 @@ func GetProtectedBranchBy(repoID int64, BranchName string) (*ProtectedBranch, er
 	return rel, nil
 }
 
-// GetProtectedBranches get all protected btanches
+// GetProtectedBranches get all protected branches
 func (repo *Repository) GetProtectedBranches() ([]*ProtectedBranch, error) {
 	protectedBranches := make([]*ProtectedBranch, 0)
 	return protectedBranches, x.Find(&protectedBranches, &ProtectedBranch{RepoID: repo.ID})

--- a/models/issue.go
+++ b/models/issue.go
@@ -733,7 +733,7 @@ func (issue *Issue) ChangeContent(doer *User, content string) (err error) {
 	return nil
 }
 
-// ChangeAssignee changes the Asssignee field of this issue.
+// ChangeAssignee changes the Assignee field of this issue.
 func (issue *Issue) ChangeAssignee(doer *User, assigneeID int64) (err error) {
 	var oldAssigneeID = issue.AssigneeID
 	issue.AssigneeID = assigneeID

--- a/models/issue_list.go
+++ b/models/issue_list.go
@@ -59,10 +59,10 @@ func (issues IssueList) loadPosters(e Engine) error {
 		return nil
 	}
 
-	postgerIDs := issues.getPosterIDs()
-	posterMaps := make(map[int64]*User, len(postgerIDs))
+	posterIDs := issues.getPosterIDs()
+	posterMaps := make(map[int64]*User, len(posterIDs))
 	err := e.
-		In("id", postgerIDs).
+		In("id", posterIDs).
 		Find(&posterMaps)
 	if err != nil {
 		return err

--- a/models/migrations/v14.go
+++ b/models/migrations/v14.go
@@ -28,7 +28,7 @@ type UserV14 struct {
 	DiffViewStyle string `xorm:"NOT NULL DEFAULT ''"`
 }
 
-// TableName will be invoked by XORM to customrize the table name
+// TableName will be invoked by XORM to customize the table name
 func (*UserV14) TableName() string {
 	return "user"
 }

--- a/models/org_team_test.go
+++ b/models/org_team_test.go
@@ -117,15 +117,15 @@ func TestTeam_HasRepository(t *testing.T) {
 func TestTeam_AddRepository(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	testSucess := func(teamID, repoID int64) {
+	testSuccess := func(teamID, repoID int64) {
 		team := AssertExistsAndLoadBean(t, &Team{ID: teamID}).(*Team)
 		repo := AssertExistsAndLoadBean(t, &Repository{ID: repoID}).(*Repository)
 		assert.NoError(t, team.AddRepository(repo))
 		AssertExistsAndLoadBean(t, &TeamRepo{TeamID: teamID, RepoID: repoID})
 		CheckConsistencyFor(t, &Team{ID: teamID}, &Repository{ID: repoID})
 	}
-	testSucess(2, 3)
-	testSucess(2, 5)
+	testSuccess(2, 3)
+	testSuccess(2, 5)
 
 	team := AssertExistsAndLoadBean(t, &Team{ID: 1}).(*Team)
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)

--- a/models/release.go
+++ b/models/release.go
@@ -73,7 +73,7 @@ func (r *Release) loadAttributes(e Engine) error {
 	return nil
 }
 
-// LoadAttributes load repo and publisher attributes for a realease
+// LoadAttributes load repo and publisher attributes for a release
 func (r *Release) LoadAttributes() error {
 	return r.loadAttributes(x)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -541,7 +541,7 @@ func (u *User) GetOrgRepositoryIDs() ([]int64, error) {
 		GroupBy("repository.id").Find(&ids)
 }
 
-// GetAccessRepoIDs returns all repsitories IDs where user's or user is a team member orgnizations
+// GetAccessRepoIDs returns all repositories IDs where user's or user is a team member organizations
 func (u *User) GetAccessRepoIDs() ([]int64, error) {
 	ids, err := u.GetRepositoryIDs()
 	if err != nil {
@@ -596,7 +596,7 @@ func (u *User) ShortName(length int) string {
 	return base.EllipsisString(u.Name, length)
 }
 
-// IsMailable checks if a user is elegible
+// IsMailable checks if a user is eligible
 // to receive emails.
 func (u *User) IsMailable() bool {
 	return u.IsActive
@@ -615,7 +615,7 @@ func IsUserExist(uid int64, name string) (bool, error) {
 		Get(&User{LowerName: strings.ToLower(name)})
 }
 
-// GetUserSalt returns a ramdom user salt token.
+// GetUserSalt returns a random user salt token.
 func GetUserSalt() (string, error) {
 	return base.GetRandomString(10)
 }

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -475,11 +475,11 @@ func PrepareWebhooks(repo *Repository, event HookEventType, p api.Payloader) err
 	// check if repo belongs to org and append additional webhooks
 	if repo.MustOwner().IsOrganization() {
 		// get hooks for org
-		orgws, err := GetActiveWebhooksByOrgID(repo.OwnerID)
+		orgHooks, err := GetActiveWebhooksByOrgID(repo.OwnerID)
 		if err != nil {
 			return fmt.Errorf("GetActiveWebhooksByOrgID: %v", err)
 		}
-		ws = append(ws, orgws...)
+		ws = append(ws, orgHooks...)
 	}
 
 	if len(ws) == 0 {

--- a/modules/auth/org.go
+++ b/modules/auth/org.go
@@ -21,7 +21,7 @@ type CreateOrgForm struct {
 	OrgName string `binding:"Required;AlphaDashDot;MaxSize(35)" locale:"org.org_name_holder"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateOrgForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -36,7 +36,7 @@ type UpdateOrgSettingForm struct {
 	MaxRepoCreation int
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *UpdateOrgSettingForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -55,7 +55,7 @@ type CreateTeamForm struct {
 	Permission  string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateTeamForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -33,7 +33,7 @@ type CreateRepoForm struct {
 	Readme      string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateRepoForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -50,7 +50,7 @@ type MigrateRepoForm struct {
 	Description  string `json:"description" binding:"MaxSize(255)"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *MigrateRepoForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -105,7 +105,7 @@ type RepoSettingForm struct {
 	EnablePulls           bool
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *RepoSettingForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -149,7 +149,7 @@ type NewWebhookForm struct {
 	WebhookForm
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *NewWebhookForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -164,7 +164,7 @@ type NewSlackHookForm struct {
 	WebhookForm
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *NewSlackHookForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -186,7 +186,7 @@ type CreateIssueForm struct {
 	Files       []string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateIssueForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -198,7 +198,7 @@ type CreateCommentForm struct {
 	Files   []string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateCommentForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -217,7 +217,7 @@ type CreateMilestoneForm struct {
 	Deadline string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateMilestoneForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -236,7 +236,7 @@ type CreateLabelForm struct {
 	Color string `binding:"Required;Size(7)" locale:"repo.issues.label_color"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *CreateLabelForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -246,7 +246,7 @@ type InitializeLabelsForm struct {
 	TemplateName string `binding:"Required"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *InitializeLabelsForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -269,7 +269,7 @@ type NewReleaseForm struct {
 	Files      []string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *NewReleaseForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -283,7 +283,7 @@ type EditReleaseForm struct {
 	Files      []string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *EditReleaseForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -303,7 +303,7 @@ type NewWikiForm struct {
 	Message  string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 // FIXME: use code generation to generate this method.
 func (f *NewWikiForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
@@ -327,7 +327,7 @@ type EditRepoFileForm struct {
 	LastCommit    string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *EditRepoFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -337,7 +337,7 @@ type EditPreviewDiffForm struct {
 	Content string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *EditPreviewDiffForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -360,7 +360,7 @@ type UploadRepoFileForm struct {
 	Files         []string
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *UploadRepoFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -370,7 +370,7 @@ type RemoveUploadFileForm struct {
 	File string `binding:"Required;MaxSize(50)"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *RemoveUploadFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -390,7 +390,7 @@ type DeleteRepoFileForm struct {
 	NewBranchName string `binding:"AlphaDashDot;MaxSize(100)"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *DeleteRepoFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }

--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -53,7 +53,7 @@ type InstallForm struct {
 	AdminEmail         string `binding:"OmitEmpty;MinSize(3);MaxSize(254);Include(@)" locale:"install.admin_email"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *InstallForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -107,7 +107,7 @@ type UpdateProfileForm struct {
 	Location         string `binding:"MaxSize(50)"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *UpdateProfileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -126,7 +126,7 @@ type AvatarForm struct {
 	Federavatar bool
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *AvatarForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -136,7 +136,7 @@ type AddEmailForm struct {
 	Email string `binding:"Required;Email;MaxSize(254)"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *AddEmailForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -148,7 +148,7 @@ type ChangePasswordForm struct {
 	Retype      string `form:"retype"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *ChangePasswordForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -159,7 +159,7 @@ type AddSSHKeyForm struct {
 	Content string `binding:"Required"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *AddSSHKeyForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
@@ -179,7 +179,7 @@ type TwoFactorAuthForm struct {
 	Passcode string `binding:"Required"`
 }
 
-// Validate valideates the fields
+// Validate validates the fields
 func (f *TwoFactorAuthForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }

--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -43,7 +43,7 @@ func (ctx *APIContext) Error(status int, title string, obj interface{}) {
 	})
 }
 
-// SetLinkHeader sets pagination link header by given totol number and page size.
+// SetLinkHeader sets pagination link header by given total number and page size.
 func (ctx *APIContext) SetLinkHeader(total, pageSize int) {
 	page := paginater.New(total, pageSize, ctx.QueryInt("page"), 0)
 	links := make([]string, 0, 4)

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -164,7 +164,7 @@ func Contexter() macaron.Handler {
 
 		ctx.Data["PageStartTime"] = time.Now()
 
-		// Get user from session if logined.
+		// Get user from session if logged in.
 		ctx.User, ctx.IsBasicAuth = auth.SignedInUser(ctx.Context, ctx.Session)
 
 		if ctx.User != nil {

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -27,7 +27,7 @@ type PullRequest struct {
 	HeadInfo string // [<user>:]<branch>
 }
 
-// Repository contains informations to operate a repository
+// Repository contains information to operate a repository
 type Repository struct {
 	AccessMode   models.AccessMode
 	IsWatching   bool
@@ -330,7 +330,7 @@ func RepoAssignment(args ...bool) macaron.Handler {
 			}
 		}
 
-		// People who have push access or have fored repository can propose a new pull request.
+		// People who have push access or have forked repository can propose a new pull request.
 		if ctx.Repo.IsWriter() || (ctx.IsSigned && ctx.User.HasForkedRepo(ctx.Repo.Repository.ID)) {
 			// Pull request is allowed if this is a fork repository
 			// and base repository accepts pull requests.

--- a/modules/httplib/httplib.go
+++ b/modules/httplib/httplib.go
@@ -438,7 +438,7 @@ func (r *Request) ToXML(v interface{}) error {
 	return err
 }
 
-// Response executes request client gets response mannually.
+// Response executes request client gets response manually.
 func (r *Request) Response() (*http.Response, error) {
 	return r.getResponse()
 }

--- a/modules/lfs/content_store.go
+++ b/modules/lfs/content_store.go
@@ -20,7 +20,7 @@ type ContentStore struct {
 	BasePath string
 }
 
-// Get takes a Meta object and retreives the content from the store, returning
+// Get takes a Meta object and retrieves the content from the store, returning
 // it as an io.Reader. If fromByte > 0, the reader starts from that byte
 func (s *ContentStore) Get(meta *models.LFSMetaObject, fromByte int64) (io.ReadCloser, error) {
 	path := filepath.Join(s.BasePath, transformKey(meta.Oid))

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -50,7 +50,7 @@ type BatchResponse struct {
 	Objects  []*Representation `json:"objects"`
 }
 
-// Representation is object medata as seen by clients of the lfs server.
+// Representation is object metadata as seen by clients of the lfs server.
 type Representation struct {
 	Oid     string           `json:"oid"`
 	Size    int64            `json:"size"`

--- a/modules/log/conn.go
+++ b/modules/log/conn.go
@@ -42,7 +42,7 @@ func (cw *ConnWriter) WriteMsg(msg string, skip, level int) error {
 	if cw.Level > level {
 		return nil
 	}
-	if cw.neddedConnectOnMsg() {
+	if cw.neededConnectOnMsg() {
 		if err := cw.connect(); err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func (cw *ConnWriter) connect() error {
 	return nil
 }
 
-func (cw *ConnWriter) neddedConnectOnMsg() bool {
+func (cw *ConnWriter) neededConnectOnMsg() bool {
 	if cw.Reconnect {
 		cw.Reconnect = false
 		return true

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -84,7 +84,7 @@ func Info(format string, v ...interface{}) {
 	}
 }
 
-// Warn records warnning log
+// Warn records warning log
 func Warn(format string, v ...interface{}) {
 	for _, logger := range loggers {
 		logger.Warn(format, v...)
@@ -275,7 +275,7 @@ func (l *Logger) StartLogger() {
 	}
 }
 
-// Flush flushs all chan data.
+// Flush flushes all chan data.
 func (l *Logger) Flush() {
 	for _, l := range l.outputs {
 		l.Flush()
@@ -321,7 +321,7 @@ func (l *Logger) Info(format string, v ...interface{}) {
 	l.writerMsg(0, INFO, msg)
 }
 
-// Warn records warnning log
+// Warn records warning log
 func (l *Logger) Warn(format string, v ...interface{}) {
 	msg := fmt.Sprintf("[W] "+format, v...)
 	l.writerMsg(0, WARN, msg)

--- a/modules/log/xorm.go
+++ b/modules/log/xorm.go
@@ -101,7 +101,7 @@ func (l *XORMLogBridge) Infof(format string, v ...interface{}) {
 	}
 }
 
-// Warn show warnning log
+// Warn show warning log
 func (l *XORMLogBridge) Warn(v ...interface{}) {
 	if l.level <= core.LOG_WARNING {
 		msg := fmt.Sprint(v...)

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -146,7 +146,7 @@ func (s *smtpSender) Send(from string, to []string, msg io.WriterTo) error {
 		}
 	}
 
-	// If not using SMTPS, alway use STARTTLS if available
+	// If not using SMTPS, always use STARTTLS if available
 	hasStartTLS, _ := client.Extension("STARTTLS")
 	if !isSecureConn && hasStartTLS {
 		if err = client.StartTLS(tlsconfig); err != nil {

--- a/modules/options/dynamic.go
+++ b/modules/options/dynamic.go
@@ -76,7 +76,7 @@ func License(name string) ([]byte, error) {
 	return fileFromDir(path.Join("license", name))
 }
 
-// Labels eads the content of a specific labels from static or custom path.
+// Labels reads the content of a specific labels from static or custom path.
 func Labels(name string) ([]byte, error) {
 	return fileFromDir(path.Join("label", name))
 }

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -72,7 +72,7 @@ func License(name string) ([]byte, error) {
 	return fileFromDir(path.Join("license", name))
 }
 
-// Labels eads the content of a specific labels from static or custom path.
+// Labels reads the content of a specific labels from static or custom path.
 func Labels(name string) ([]byte, error) {
 	return fileFromDir(path.Join("label", name))
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -249,7 +249,7 @@ var (
 		},
 	}
 
-	// Markdown sttings
+	// Markdown settings
 	Markdown = struct {
 		EnableHardLineBreak bool
 		CustomURLSchemes    []string `ini:"CUSTOM_URL_SCHEMES"`
@@ -420,7 +420,7 @@ var (
 	Names     []string
 	dateLangs map[string]string
 
-	// Highlight settings are loaded in modules/template/hightlight.go
+	// Highlight settings are loaded in modules/template/highlight.go
 
 	// Other settings
 	ShowFooterBranding         bool

--- a/modules/sync/exclusive_pool.go
+++ b/modules/sync/exclusive_pool.go
@@ -39,7 +39,7 @@ func NewExclusivePool() *ExclusivePool {
 }
 
 // CheckIn checks in an instance to the pool and hangs while instance
-// with same indentity is using the lock.
+// with same identity is using the lock.
 func (p *ExclusivePool) CheckIn(identity string) {
 	p.lock.Lock()
 

--- a/modules/sync/unique_queue.go
+++ b/modules/sync/unique_queue.go
@@ -36,7 +36,7 @@ func (q *UniqueQueue) Queue() <-chan string {
 	return q.queue
 }
 
-// Exist returns true if there is an instance with given indentity
+// Exist returns true if there is an instance with given identity
 // exists in the queue.
 func (q *UniqueQueue) Exist(id interface{}) bool {
 	return q.table.IsRunning(com.ToStr(id))


### PR DESCRIPTION
One I want to double check:

`neddedConnectOnMsg()` should be `neededConnectOnMsg()` (i.e. `nedded` is not an intentional abbrevation of something), correct?