### PR TITLE
Add notice that LFS mirroring is not supported

### DIFF
--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -431,6 +431,7 @@ migrate.clone_local_path=oder Pfad auf dem lokalen Server
 migrate.permission_denied=Ihnen fehlen die Rechte zum Importieren lokaler Repositories.
 migrate.invalid_local_path=Der lokale Pfad ist ungültig, existiert nicht oder ist kein Ordner.
 migrate.failed=Fehler bei Migration: %v
+migrate.lfs_mirror_unsupported = Migrieren von LFS Objekten wird nicht unterstützt - verwenden Sie stattdessen 'git lfs fetch --all' und 'git lfs push --all'.
 
 mirror_from=Mirror von
 forked_from=geforkt von

--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -431,7 +431,6 @@ migrate.clone_local_path=oder Pfad auf dem lokalen Server
 migrate.permission_denied=Ihnen fehlen die Rechte zum Importieren lokaler Repositories.
 migrate.invalid_local_path=Der lokale Pfad ist ungültig, existiert nicht oder ist kein Ordner.
 migrate.failed=Fehler bei Migration: %v
-migrate.lfs_mirror_unsupported = Migrieren von LFS Objekten wird nicht unterstützt - verwenden Sie stattdessen 'git lfs fetch --all' und 'git lfs push --all'.
 
 mirror_from=Mirror von
 forked_from=geforkt von

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -442,6 +442,7 @@ migrate.clone_local_path = or local server path
 migrate.permission_denied = You are not allowed to import local repositories.
 migrate.invalid_local_path = Invalid local path, it does not exist or not a directory.
 migrate.failed = Migration failed: %v
+migrate.lfs_mirror_unsupported = Mirroring LFS objects is not supported - use 'git lfs fetch --all' and 'git lfs push --all' instead.
 
 mirror_from = mirror of
 forked_from = forked from

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -153,6 +153,7 @@ func Migrate(ctx *context.Context) {
 	ctx.Data["private"] = ctx.User.LastRepoVisibility
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["mirror"] = ctx.Query("mirror") == "1"
+	ctx.Data["LFSActive"] = setting.LFS.StartServer
 
 	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))
 	if ctx.Written() {

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -12,7 +12,10 @@
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
-						<span class="help">{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}</span>
+						<span class="help">
+						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{if .LFSActive}}<br/>{{.i18n.Tr "repo.migrate.lfs_mirror_unsupported"}}{{end}}
+						</span>
 					</div>
 					<div class="ui accordion optional field">
 						<div class="title {{if .Err_Auth}}text red active{{end}}">


### PR DESCRIPTION
As discussed in #849:

Mirroring LFS objects is no easy feat, so this PR adds a notice to the migration UI which tells the user that Gitea does not support it currently, hinting at ```git lfs``` functionality.