### PR TITLE
Fix nil-dereference bug

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -219,7 +219,11 @@ func RepoAssignment(args ...bool) macaron.Handler {
 		if ctx.IsSigned && ctx.User.IsAdmin {
 			ctx.Repo.AccessMode = models.AccessModeOwner
 		} else {
-			mode, err := models.AccessLevel(ctx.User.ID, repo)
+			var userID int64
+			if ctx.User != nil {
+				userID = ctx.User.ID
+			}
+			mode, err := models.AccessLevel(userID, repo)
 			if err != nil {
 				ctx.Handle(500, "AccessLevel", err)
 				return


### PR DESCRIPTION
Fix bug introduced by #1247 where viewing a repository while not signed in a user causes a 500 (due to a nil pointer deference).
