### PR TITLE
LFS: Return 404 for unimplemented endpoints

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -638,6 +638,9 @@ func runWeb(ctx *cli.Context) error {
 				m.Get("/objects/:oid/:filename", lfs.ObjectOidHandler)
 				m.Any("/objects/:oid", lfs.ObjectOidHandler)
 				m.Post("/objects", lfs.PostHandler)
+				m.Any("/*", func(ctx *context.Context) {
+					ctx.Handle(404, "", nil)
+				})
 			}, ignSignInAndCsrf)
 			m.Any("/*", ignSignInAndCsrf, repo.HTTP)
 			m.Head("/tasks/trigger", repo.TriggerTask)


### PR DESCRIPTION
Without this change a 401 is returned for unspecified endpoints, making the LFS client ask for HTTP credentials. This behaviour was introduced with the new locking API:

https://github.com/git-lfs/git-lfs/blob/master/docs/api/locking.md

git-lfs trace before and after patch:

```
trace git-lfs: ssh: fabian@localhost git-lfs-authenticate test/test.git upload
trace git-lfs: HTTP: POST http://localhost:3000/test/test.git/info/lfs/locks/verify
trace git-lfs: HTTP: 401
trace git-lfs: setting repository access to basic
```

```
trace git-lfs: ssh: fabian@localhost git-lfs-authenticate test/test.git upload
trace git-lfs: HTTP: POST http://localhost:3000/test/test.git/info/lfs/locks/verify
trace git-lfs: HTTP: 404
Remote "origin" does not support the LFS locking API. Consider disabling it with:
$ git config 'lfs.https://localhost/test/test.git/info/lfs.locksverify' false
```