### PR TITLE
use --follow on file history to show log across renames

### DIFF
--- a/vendor/code.gitea.io/git/repo_commit.go
+++ b/vendor/code.gitea.io/git/repo_commit.go
@@ -188,7 +188,7 @@ func (repo *Repository) GetCommitByPath(relpath string) (*Commit, error) {
 var CommitsRangeSize = 50
 
 func (repo *Repository) commitsByRange(id SHA1, page int) (*list.List, error) {
-	stdout, err := NewCommand("log", id.String(), "--skip="+strconv.Itoa((page-1)*CommitsRangeSize),
+	stdout, err := NewCommand("log", id.String(), "--follow", "--skip="+strconv.Itoa((page-1)*CommitsRangeSize),
 		"--max-count="+strconv.Itoa(CommitsRangeSize), prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
 
 // CommitsByFileAndRange return the commits accroding revison file and the page
 func (repo *Repository) CommitsByFileAndRange(revision, file string, page int) (*list.List, error) {
-	stdout, err := NewCommand("log", revision, "--skip="+strconv.Itoa((page-1)*50),
+	stdout, err := NewCommand("log", revision, "--follow", "--skip="+strconv.Itoa((page-1)*50),
 		"--max-count="+strconv.Itoa(CommitsRangeSize), prettyLogFormat, "--", file).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
when viewing a file's history, e.g. `https://git.myserver.example/myuser/myrepo/commits/master/subdir/file`, the log does not follow file renames. This patch should change that.
