### PR TITLE
Fix broken table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@
 [![GoDoc](https://godoc.org/code.gitea.io/gitea?status.svg)](https://godoc.org/code.gitea.io/gitea)
 [![Release](https://github-release-version.herokuapp.com/github/go-gitea/gitea/release.svg?style=flat)](https://github.com/go-gitea/gitea/releases/latest)
 
-||||
-|:-------------:|:-------:|:-------:|
+| | | |
+|:---:|:---:|:---:|
 |![Dashboard](https://i.imgur.com/3iEQsux.jpg)|![Repository](https://i.imgur.com/glqFnj8.jpg)|![Commits History](https://i.imgur.com/ad1FEpi.jpg)|
 |![Profile](https://i.imgur.com/q81EcGa.jpg)|![Admin Dashboard](https://i.imgur.com/L2CQeN0.jpg)|![Diff](https://i.imgur.com/cNuvMum.jpg)|
 |![Issues](https://i.imgur.com/xCYRqaF.jpg)|![Releases](https://i.imgur.com/ILpRBCe.jpg)|![Organization](https://i.imgur.com/0BHnrcL.jpg)|
-||||
 
 ## Purpose
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -10,12 +10,11 @@
 [![GoDoc](https://godoc.org/code.gitea.io/gitea?status.svg)](https://godoc.org/code.gitea.io/gitea)
 [![Release](https://github-release-version.herokuapp.com/github/go-gitea/gitea/release.svg?style=flat)](https://github.com/go-gitea/gitea/releases/latest)
 
-||||
-|:-------------:|:-------:|:-------:|
+| | | |
+|:---:|:---:|:---:|
 |![Dashboard](https://i.imgur.com/3iEQsux.jpg)|![Repository](https://i.imgur.com/glqFnj8.jpg)|![Commits History](https://i.imgur.com/ad1FEpi.jpg)|
 |![Profile](https://i.imgur.com/q81EcGa.jpg)|![Admin Dashboard](https://i.imgur.com/L2CQeN0.jpg)|![Diff](https://i.imgur.com/cNuvMum.jpg)|
 |![Issues](https://i.imgur.com/xCYRqaF.jpg)|![Releases](https://i.imgur.com/ILpRBCe.jpg)|![Organization](https://i.imgur.com/0BHnrcL.jpg)|
-||||
 
 ## 目标
 


### PR DESCRIPTION
The table layout in the README is broken after Github's change of markdown renderer. This PR will fix that and display the screenshots in a 3x3 table.
Github markdown doesn't support tables without headers so there's an empty row at the top.
Looks ok in Gitea too, https://try.gitea.io/cez81/gitea/src/fix_readme_layout/README.md.

References:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1010#issuecomment-286917804