### PR TITLE
Remove href on first/last link when on first/last page

### DIFF
--- a/templates/base/paginate.tmpl
+++ b/templates/base/paginate.tmpl
@@ -2,7 +2,7 @@
 	{{if gt .TotalPages 1}}
 		<div class="center page buttons">
 			<div class="ui borderless pagination menu">
-				<a class="{{if .IsFirst}}disabled{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&tab={{$.TabName}}"><i class="angle double left icon"></i> {{$.i18n.Tr "admin.first_page"}}</a>
+				<a class="{{if .IsFirst}}disabled{{end}} item" {{if not .IsFirst}}href="{{$.Link}}?q={{$.Keyword}}&tab={{$.TabName}}"{{end}}><i class="angle double left icon"></i> {{$.i18n.Tr "admin.first_page"}}</a>
 				<a class="{{if not .HasPrevious}}disabled{{end}} item" {{if .HasPrevious}}href="{{$.Link}}?page={{.Previous}}&q={{$.Keyword}}&tab={{$.TabName}}"{{end}}>
 					<i class="left arrow icon"></i> {{$.i18n.Tr "repo.issues.previous"}}
 				</a>
@@ -16,7 +16,7 @@
 				<a class="{{if not .HasNext}}disabled{{end}} item" {{if .HasNext}}href="{{$.Link}}?page={{.Next}}&q={{$.Keyword}}&tab={{$.TabName}}"{{end}}>
 					{{$.i18n.Tr "repo.issues.next"}}&nbsp;<i class="icon right arrow"></i>
 				</a>
-				<a class="{{if .IsLast}}disabled{{end}} item" href="{{$.Link}}?page={{.TotalPages}}&q={{$.Keyword}}&tab={{$.TabName}}">{{$.i18n.Tr "admin.last_page"}}&nbsp;<i class="angle double right icon"></i></a>
+				<a class="{{if .IsLast}}disabled{{end}} item" {{if not .IsLast}}href="{{$.Link}}?page={{.TotalPages}}&q={{$.Keyword}}&tab={{$.TabName}}"{{end}}>{{$.i18n.Tr "admin.last_page"}}&nbsp;<i class="angle double right icon"></i></a>
 			</div>
 		</div>
 	{{end}}


### PR DESCRIPTION
When you are on the first page of explore, the "First" link in pagination appears as disabled but it still has a `href` and so is clickable. Same thing for the "Last" link on the last page.
This PR aims to only have the `href` when the links are "enabled".
