### PR TITLE
fix: remove `str2html` from org full name

### DIFF
--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -9,7 +9,7 @@
 				<div class="item">
 				  <img class="ui avatar image" src="{{.RelAvatarLink}}">
 				  <div class="content">
-					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}</span>
+					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName | Str2html}}</span>
 					<div class="description">
 							{{if .Location}}
 								<i class="octicon octicon-location"></i> {{.Location}}

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -9,7 +9,7 @@
 				<div class="item">
 				  <img class="ui avatar image" src="{{.RelAvatarLink}}">
 				  <div class="content">
-					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName | Str2html}}</span>
+					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}</span>
 					<div class="description">
 							{{if .Location}}
 								<i class="octicon octicon-location"></i> {{.Location}}

--- a/templates/org/header.tmpl
+++ b/templates/org/header.tmpl
@@ -4,7 +4,7 @@
 			<div class="column">
 				<div class="ui header">
 					<img class="ui image" src="{{.RelAvatarLink}}?s=100">
-					<span class="text thin grey"><a href="{{.HomeLink}}">{{.DisplayName | Str2html}}</a></span>
+					<span class="text thin grey"><a href="{{.HomeLink}}">{{.DisplayName}}</a></span>
 
 					<div class="ui right">
 						<div class="ui menu">

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -6,7 +6,7 @@
 				<img class="ui left" id="org-avatar" src="{{.Org.RelAvatarLink}}?s=140"/>
 				<div id="org-info">
 					<div class="ui header">
-						{{.Org.DisplayName | Str2html}}
+						{{.Org.DisplayName}}
 						{{if .IsOrganizationOwner}}<a class="text grey" href="{{.OrgLink}}/settings"><span class="octicon octicon-gear"></span></a>{{end}}
 					</div>
 					{{if .Org.Description}}<p class="desc">{{.Org.Description}}</p>{{end}}

--- a/templates/org/member/invite.tmpl
+++ b/templates/org/member/invite.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		<div id="invite-box">
 			{{template "base/alert" .}}
-			<h2>{{.i18n.Tr "org.members.invite_desc" .Org.DisplayName | Str2html}}</h2>
+			<h2>{{.i18n.Tr "org.members.invite_desc" .Org.DisplayName}}</h2>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="inline field ui left">

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -18,7 +18,7 @@
 						</div>
 						<div class="field {{if .Err_FullName}}error{{end}}">
 							<label for="full_name">{{.i18n.Tr "org.org_full_name_holder"}}</label>
-							<input id="full_name" name="full_name" value="{{.Org.FullName | Str2html}}">
+							<input id="full_name" name="full_name" value="{{.Org.FullName}}">
 						</div>
 						<div class="field {{if .Err_Description}}error{{end}}">
 							<label for="description">{{$.i18n.Tr "org.org_desc"}}</label>

--- a/templates/org/team/members.tmpl
+++ b/templates/org/team/members.tmpl
@@ -17,7 +17,7 @@
 							{{end}}
 							<a href="{{.HomeLink}}">
 								<img class="ui avatar image" src="{{.RelAvatarLink}}">
-								{{.DisplayName | Str2html}}
+								{{.DisplayName}}
 							</a>
 						</div>
 					{{end}}


### PR DESCRIPTION
We need to remove `str2html` from org full name.

![screen shot 2017-03-25 at 9 26 16 pm](https://cloud.githubusercontent.com/assets/21979/24322574/cb936fb8-11a1-11e7-8158-fad9e07de3b3.png)




