### PR TITLE
Fix FCGI (over TCP) support

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -701,7 +701,12 @@ func runWeb(ctx *cli.Context) error {
 	case setting.HTTPS:
 		err = runHTTPS(listenAddr, setting.CertFile, setting.KeyFile, context2.ClearHandler(m))
 	case setting.FCGI:
-		err = fcgi.Serve(nil, context2.ClearHandler(m))
+		listener, err := net.Listen("tcp", listenAddr)
+		if err != nil {
+			log.Fatal(4, "Failed to bind %s", listenAddr, err)
+		}
+		defer listener.Close()
+		err = fcgi.Serve(listener, context2.ClearHandler(m))
 	case setting.UnixSocket:
 		if err := os.Remove(listenAddr); err != nil && !os.IsNotExist(err) {
 			log.Fatal(4, "Failed to remove unix socket directory %s: %v", listenAddr, err)


### PR DESCRIPTION
Although basic FCGI support is present since 2014 (gogits/gogs#601), it's not usable.
This commit adds support for serving via FCGI protocol over tcp socket.
The socket address:port is derived from HTTP_ADDR and HTTP_PORT configuration settings.
Tested on OpenBSD-current with OpenBSD's httpd.