### PR TITLE
Prevent FOUC by briefly hiding the document body

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -72,6 +72,13 @@
 {{end}}
 </head>
 <body>
+	<script>
+		// Prevent FOUC by briefly hiding the body
+		document.body.style.display = 'none';
+		document.addEventListener('DOMContentLoaded', function() {
+			document.body.style.display = '';
+		});
+	</script>
 	<div class="full height">
 		<noscript>Please enable JavaScript in your browser!</noscript>
 


### PR DESCRIPTION
## Issue
Gitea currently has a pretty nasty [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content), especially visible in Firefox:

![](https://cloud.githubusercontent.com/assets/115237/24269644/5d6857fa-1012-11e7-94d8-1bcb59135b60.gif)

## Solution

By briefly hiding the `<body>` and showing it once DOM content is loaded, we can efficiently prevent FOUC without side effects (the site keeps working without JS enabled).