### PR TITLE
Minor improvements on commit graph UI

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -503,6 +503,7 @@ file_permalink = Permalink
 file_too_large = This file is too large to be shown
 video_not_supported_in_browser = Your browser doesn't support HTML5 video tag.
 stored_lfs = Stored with Git LFS
+commit_graph = Commit graph
 
 editor.new_file = New file
 editor.upload_file = Upload file

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -5,12 +5,12 @@
 	  <div class="ui secondary menu">
 	    {{template "repo/branch_dropdown" .}}
 	    <div class="fitted item">
-	      <div class="ui breadcrumb">
+	      <div class="ui basic small button">
 		<a href="{{.RepoLink}}/graph">
 		  <span class="text">
 		    <i class="octicon octicon-git-branch"></i>
 		  </span>
-		  commit graph
+		  {{.i18n.Tr "repo.commit_graph"}}
 		</a>
 	      </div>
 	    </div>

--- a/templates/repo/graph.tmpl
+++ b/templates/repo/graph.tmpl
@@ -5,6 +5,7 @@
 
 
 	  <div id="git-graph-container" class="ui segment">
+		  <h1>{{.i18n.Tr "repo.commit_graph"}}</h1>
 	    <div id="rel-container">
 	      <canvas id="graph-canvas">
 		<ul id="graph-raw-list">


### PR DESCRIPTION
Link to Commit Graph:
- [Before](https://cloud.githubusercontent.com/assets/7011819/24275264/065292b4-100d-11e7-901f-4638fd4938a9.png)
- [After](https://cloud.githubusercontent.com/assets/7011819/24275268/0e06ba1c-100d-11e7-9c9a-e85adcd866b7.png)

Commit Graph page:
- [Before](https://cloud.githubusercontent.com/assets/7011819/24275284/21e61528-100d-11e7-90da-7bcf340d822a.png)
- [After](https://cloud.githubusercontent.com/assets/7011819/24275287/2673cc70-100d-11e7-86fd-df8fe3b861ba.png)

