### PR TITLE
Use whole button (commit graph) as link

### DIFF
--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -5,14 +5,12 @@
 	  <div class="ui secondary menu">
 	    {{template "repo/branch_dropdown" .}}
 	    <div class="fitted item">
-	      <div class="ui basic small button">
-		<a href="{{.RepoLink}}/graph">
+		<a href="{{.RepoLink}}/graph" class="ui basic small button">
 		  <span class="text">
 		    <i class="octicon octicon-git-branch"></i>
 		  </span>
 		  {{.i18n.Tr "repo.commit_graph"}}
 		</a>
-	      </div>
 	    </div>
 	  </div>
 	  {{template "repo/commits_table" .}}


### PR DESCRIPTION
Update html template to use whole button as link, not only text inside button.

Before:
![explorer_2017-03-27_14-08-23](https://cloud.githubusercontent.com/assets/12720041/24355847/ce0f5926-12f7-11e7-959a-3b4219f82964.png)

After:
![explorer_2017-03-27_14-09-46](https://cloud.githubusercontent.com/assets/12720041/24355852/d242daf4-12f7-11e7-98b3-854bf9ee9e73.png)

