### PR TITLE
Make issue in commit graph "clickable"

### DIFF
--- a/templates/repo/graph.tmpl
+++ b/templates/repo/graph.tmpl
@@ -26,7 +26,7 @@
 		    <a href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.Rev}}">{{ .ShortRev}}</a>
 		  </code>
 		  <strong> {{.Branch}}</strong>
-		  <em>{{.Subject}}</em> by
+		  <em>{{RenderCommitMessage false .Subject $.RepoLink $.Repository.ComposeMetas}}</em> by
 		  <span class="author">
 		    {{.Author}}
 		  </span>


### PR DESCRIPTION
Create clickable links to internal/external issue tracker from commit graph UI.

Before/Turned off issue tracker:
![chrome_2017-03-27_17-22-21](https://cloud.githubusercontent.com/assets/12720041/24364416/0130c2a2-1313-11e7-8955-572cade49948.png)

After (turned on issue tracker):
![chrome_2017-03-27_17-21-43](https://cloud.githubusercontent.com/assets/12720041/24364423/068b75e4-1313-11e7-9581-0c80038d03e3.png)