### PR TITLE
Add length check for the return string

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -508,7 +508,7 @@ func (pr *PullRequest) getMergeCommit() (*git.Commit, error) {
 		[]string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()},
 		"git", "rev-list", "--ancestry-path", "--merges", "--reverse", cmd)
 
-	if err != nil {
+	if err != nil || len(mergeCommit) != 40 {
 		return nil, fmt.Errorf("git rev-list --ancestry-path --merges --reverse: %v %v", stderr, err)
 	}
 

--- a/models/pull.go
+++ b/models/pull.go
@@ -508,7 +508,7 @@ func (pr *PullRequest) getMergeCommit() (*git.Commit, error) {
 		[]string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()},
 		"git", "rev-list", "--ancestry-path", "--merges", "--reverse", cmd)
 	if err == nil && len(mergeCommit) != 40 {
-		err = fmt.Errorf("git rev-list --ancestry-path --merges --reverse: unexpected length of output (got:%d bytes)", len(mergeCommit))
+		err = fmt.Errorf("unexpected length of output (got:%d bytes) '%s'", len(mergeCommit), mergeCommit)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("git rev-list --ancestry-path --merges --reverse: %v %v", stderr, err)

--- a/models/pull.go
+++ b/models/pull.go
@@ -507,8 +507,10 @@ func (pr *PullRequest) getMergeCommit() (*git.Commit, error) {
 	mergeCommit, stderr, err := process.GetManager().ExecDirEnv(-1, "", fmt.Sprintf("isMerged (git rev-list --ancestry-path --merges --reverse): %d", pr.BaseRepo.ID),
 		[]string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()},
 		"git", "rev-list", "--ancestry-path", "--merges", "--reverse", cmd)
-
-	if err != nil || len(mergeCommit) != 40 {
+	if err == nil && len(mergeCommit) != 40 {
+		err = fmt.Errorf("git rev-list --ancestry-path --merges --reverse: unexpected length of output (got:%d bytes)", len(mergeCommit))
+	}
+	if err != nil {
 		return nil, fmt.Errorf("git rev-list --ancestry-path --merges --reverse: %v %v", stderr, err)
 	}
 


### PR DESCRIPTION
Without the check, it could lead to out-of-bound panic if the return string is shorter than expected.