### PR TITLE
Support for custom html meta 

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -74,6 +74,11 @@ ORG_PAGING_NUM = 50
 ; Number of repos that are showed in one page
 REPO_PAGING_NUM = 15
 
+[ui.meta]
+AUTHOR = Gitea - Git with a cup of tea
+DESCRIPTION = Gitea: Git with a cup of tea
+KEYWORDS = go,git,self-hosted,gitea
+
 [markdown]
 ; Enable hard line break extension
 ENABLE_HARD_LINE_BREAK = false

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -76,7 +76,7 @@ REPO_PAGING_NUM = 15
 
 [ui.meta]
 AUTHOR = Gitea - Git with a cup of tea
-DESCRIPTION = Gitea: Git with a cup of tea
+DESCRIPTION = Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go
 KEYWORDS = go,git,self-hosted,gitea
 
 [markdown]

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -226,6 +226,11 @@ var (
 		User struct {
 			RepoPagingNum int
 		} `ini:"ui.user"`
+		Meta struct {
+			Author      string
+			Description string
+			Keywords    string
+		} `ini:"ui.meta"`
 	}{
 		ExplorePagingNum:   20,
 		IssuePagingNum:     10,
@@ -247,6 +252,15 @@ var (
 			RepoPagingNum int
 		}{
 			RepoPagingNum: 15,
+		},
+		Meta: struct {
+			Author      string
+			Description string
+			Keywords    string
+		}{
+			Author:      "Gitea - Git with a cup of tea",
+			Description: "",
+			Keywords:    "go,git,self-hosted,gitea",
 		},
 	}
 
@@ -897,6 +911,7 @@ please consider changing to GITEA_CUSTOM`)
 	ShowFooterTemplateLoadTime = Cfg.Section("other").Key("SHOW_FOOTER_TEMPLATE_LOAD_TIME").MustBool(true)
 
 	UI.ShowUserEmail = Cfg.Section("ui").Key("SHOW_USER_EMAIL").MustBool(true)
+	UI.Meta.Description = Cfg.Section("ui.meta").Key("DESCRIPTION").MustString(AppName)
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -259,7 +259,7 @@ var (
 			Keywords    string
 		}{
 			Author:      "Gitea - Git with a cup of tea",
-			Description: "",
+			Description: "Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go",
 			Keywords:    "go,git,self-hosted,gitea",
 		},
 	}
@@ -911,7 +911,6 @@ please consider changing to GITEA_CUSTOM`)
 	ShowFooterTemplateLoadTime = Cfg.Section("other").Key("SHOW_FOOTER_TEMPLATE_LOAD_TIME").MustBool(true)
 
 	UI.ShowUserEmail = Cfg.Section("ui").Key("SHOW_USER_EMAIL").MustBool(true)
-	UI.Meta.Description = Cfg.Section("ui.meta").Key("DESCRIPTION").MustString(AppName)
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -110,6 +110,15 @@ func NewFuncMap() []template.FuncMap {
 		"ThemeColorMetaTag": func() string {
 			return setting.UI.ThemeColorMetaTag
 		},
+		"MetaAuthor": func() string {
+			return setting.UI.Meta.Author
+		},
+		"MetaDescription": func() string {
+			return setting.UI.Meta.Description
+		},
+		"MetaKeywords": func() string {
+			return setting.UI.Meta.Keywords
+		},
 		"FilenameIsImage": func(filename string) bool {
 			mimeType := mime.TypeByExtension(filepath.Ext(filename))
 			return strings.HasPrefix(mimeType, "image/")

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -5,9 +5,9 @@
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<title>{{if .Title}}{{.Title}} - {{end}}{{AppName}}</title>
 	<meta name="theme-color" content="{{ThemeColorMetaTag}}">
-	<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}Gitea - Git with a cup of tea{{end}}" />
-	<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go{{end}}" />
-	<meta name="keywords" content="go, git, self-hosted, gitea">
+	<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}{{MetaAuthor}}{{end}}" />
+	<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}{{MetaDescription}}{{end}}" />
+	<meta name="keywords" content="{{MetaKeywords}}">
 	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />
 	<meta name="_suburl" content="{{AppSubUrl}}" />
@@ -68,7 +68,7 @@
 	<meta property="og:type" content="website" />
 	<meta property="og:image" content="{{AppSubUrl}}/img/gitea-lg.png" />
 	<meta property="og:url" content="{{AppUrl}}" />
-	<meta property="og:description" content="Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go">
+	<meta property="og:description" content="{{MetaDescription}}">
 {{end}}
 </head>
 <body>


### PR DESCRIPTION
Fix for #1204

Custom HTML meta tags can be defined in app.ini

```
[ui.meta]
AUTHOR = Gitea - Git with a cup of tea
DESCRIPTION = Gitea: Git with a cup of tea
KEYWORDS = go,git,self-hosted,gitea
```