### PR TITLE
fixes pull request hanging when it contains normal and LFS files

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -287,7 +287,6 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 					curFile.IsBin = true
 					curFile.IsLFSFile = true
 					curSection.Lines = nil
-					break
 				}
 			}
 		}


### PR DESCRIPTION
…FS file pointers


I found an issue where branch that has a mix of ordinary and LFS-backed files, this basically means that the diff (returned by command "git diff -M old_branch new_branch") never finishes.

There's a branch in the ParsePatch function that checks if the file currently patched is an LFS backed one, and then it breaks out of the loop - this somehow causes the bufio.NewReader(reader) to never finish...

To reproduce:

   * create a repo
   * put some files into it
   * create a branch
   * make some changes, and ensure some of the changes include putting new LFS objects and ideally changing a non-lfs to an LFS file. - basically you need to ensure that the 'git diff' between the branch and master has the 'oid: ' section of an LFS file pointer.
   * create a new PR, select the branch - it should hang, you will also see a 'git diff -M old new'