### PR TITLE
Add GOFLAGS and EXTRA_GOFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ BINDATA := modules/{options,public,templates}/bindata.go
 STYLESHEETS := $(wildcard public/less/index.less public/less/_*.less)
 JAVASCRIPTS :=
 
+GOFLAGS := -i -v
+EXTRA_GOFLAGS ?=
+
 LDFLAGS := -X "main.Version=$(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')" -X "main.Tags=$(TAGS)"
 
 PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations,$(shell go list ./... | grep -v /vendor/))
@@ -93,7 +96,7 @@ install: $(wildcard *.go)
 build: $(EXECUTABLE)
 
 $(EXECUTABLE): $(SOURCES)
-	go build -i -v -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
+	go build $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
With these flags (modelling after CFLAGS and EXTRA_CFLAGS), we can enable race detector by setting environment variables.

E.g. `EXTRA_GOFLAGS=-race make` or `make EXTRA_GOFLAGS=-race`

For #1430 