### PR TITLE
Optimize and fix autolink function (#1442)

### DIFF
--- a/public/js/libs/autolink.js
+++ b/public/js/libs/autolink.js
@@ -15,7 +15,7 @@
                 if(node.nodeType === 3) {
                     textNodes.push(node);
                 } else {
-                    all = all.concat(textNodesUnder(node));
+                    textNodes = textNodes.concat(textNodesUnder(node));
                 }
             }
         }

--- a/public/js/libs/autolink.js
+++ b/public/js/libs/autolink.js
@@ -1,15 +1,45 @@
-jQuery.fn.autolink = function() {
-	var re = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+:=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
-	return this.find('*').contents()
-		.filter(function () { return this.nodeType === 3; })
-		.each(function() {
-			$(this).each(function() {
-				if (re.test($(this).text()))
-					$(this).replaceWith(
-						$("<span />").html(
-							this.nodeValue.replace(re, "<a href='$1'>$1</a>")
-						)
-					);
-			});
-		});
-};
+(function () {
+    var re = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+:=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
+    function textNodesUnder(node) {
+        var textNodes = [];
+        if(typeof document.createTreeWalker === 'function') {
+            // Efficient TreeWalker
+            var currentNode, walker;
+            walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null, false);
+            while(currentNode = walker.nextNode()) {
+                textNodes.push(currentNode);
+            }
+        } else {
+            // Less efficient recursive function
+            for(node = node.firstChild; node; node = node.nextSibling) {
+                if(node.nodeType === 3) {
+                    textNodes.push(node);
+                } else {
+                    all = all.concat(textNodesUnder(node));
+                }
+            }
+        }
+        return textNodes;
+    }
+
+    function processNode(node) {
+        re.lastIndex = 0;
+        var results = re.exec(node.textContent);
+        if(results !== null) {
+            if($(node).parents().filter('pre>code').length === 0) {
+                $(node).replaceWith(
+                    $('<span />').html(
+                        node.nodeValue.replace(re, '<a href="$1">$1</a>')
+                    )
+                );
+            }
+        }
+    }
+
+    jQuery.fn.autolink = function () {
+        this.each(function () {
+            textNodesUnder(this).forEach(processNode);
+        });
+        return this;
+    };
+})();


### PR DESCRIPTION
This PR fixes the markdown rendering issues with code-blocks containing URLs (#1442). The culprit was the `autolink` function, which conflicted with highlight.js. I've excluded code-block URLs from being auto-linked to fix this issue.

Besides being broken the `autolink` function was also crazy inefficient. I've improved the efficiency by making use of the browser-native `createTreeWalker` function. If this function is not available (IE8 and below) I make use of a recursive function (which is still more efficient than the previous implementation).