### PR TITLE
Orgs: fix org page title when full name is not defined

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -377,7 +377,7 @@ func showOrgProfile(ctx *context.Context) {
 	}
 
 	org := ctx.Org.Organization
-	ctx.Data["Title"] = org.FullName
+	ctx.Data["Title"] = org.DisplayName()
 
 	page := ctx.QueryInt("page")
 	if page <= 0 {


### PR DESCRIPTION
This falls back to a organization's name when the full name is not defined, so the page title at https://try.gitea.io/my-cool-organization will become

````
my-cool-organization - Gitea: Git with a cup of tea
````
instead of the current
````
Gitea: Git with a cup of tea
````

The same functionality is already in place for user profile pages.