### PR TITLE
Add repo mirror sync API endpoint

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -402,6 +402,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 						Patch(bind(api.EditReleaseOption{}), repo.EditRelease).
 						Delete(repo.DeleteRelease)
 				})
+				m.Post("/mirror-sync", repo.MirrorSync)
 				m.Get("/editorconfig/:filename", context.RepoRef(), repo.GetEditorconfig)
 				m.Group("/pulls", func() {
 					m.Combo("").Get(bind(api.ListPullRequestsOptions{}), repo.ListPullRequests).Post(reqRepoWriter(), bind(api.CreatePullRequestOption{}), repo.CreatePullRequest)

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -269,3 +269,15 @@ func Delete(ctx *context.APIContext) {
 	log.Trace("Repository deleted: %s/%s", owner.Name, repo.Name)
 	ctx.Status(204)
 }
+
+// MirrorSync adds a mirrored repository to the sync queue
+func MirrorSync(ctx *context.APIContext) {
+	repo := ctx.Repo.Repository
+
+	if !ctx.Repo.IsWriter() {
+		ctx.Error(403, "MirrorSync", "Must be owner")
+	}
+
+	go models.MirrorQueue.Add(repo.ID)
+	ctx.Status(202)
+}

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -275,7 +275,7 @@ func MirrorSync(ctx *context.APIContext) {
 	repo := ctx.Repo.Repository
 
 	if !ctx.Repo.IsWriter() {
-		ctx.Error(403, "MirrorSync", "Must be owner")
+		ctx.Error(403, "MirrorSync", "Must have write access")
 	}
 
 	go models.MirrorQueue.Add(repo.ID)

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -279,5 +279,5 @@ func MirrorSync(ctx *context.APIContext) {
 	}
 
 	go models.MirrorQueue.Add(repo.ID)
-	ctx.Status(202)
+	ctx.Status(200)
 }


### PR DESCRIPTION
First stab at the API, please bear with me :)
Add mirror sync endpoint to the Api adopted from Gogs. 
`/repos/:owner/:repo/mirror-sync`