### PR TITLE
feat: add download count field and unit testing for attachment.

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -350,6 +350,11 @@ func runWeb(ctx *cli.Context) error {
 			}
 			defer fr.Close()
 
+			if err := attach.IncreaseDownloadCount(); err != nil {
+				ctx.Handle(500, "Update", err)
+				return
+			}
+
 			if err = repo.ServeData(ctx, attach.Name, fr); err != nil {
 				ctx.Handle(500, "ServeData", err)
 				return

--- a/models/attachment.go
+++ b/models/attachment.go
@@ -50,7 +50,7 @@ func (a *Attachment) IncreaseDownloadCount() error {
 	sess := x.NewSession()
 	defer sessionRelease(sess)
 
-	// Update repository count.
+	// Update download count.
 	if _, err := sess.Exec("UPDATE `attachment` SET download_count=download_count+1 WHERE id=?", a.ID); err != nil {
 		return fmt.Errorf("increase attachment count: %v", err)
 	}

--- a/models/attachment.go
+++ b/models/attachment.go
@@ -20,15 +20,15 @@ import (
 
 // Attachment represent a attachment of issue/comment/release.
 type Attachment struct {
-	ID        int64  `xorm:"pk autoincr"`
-	UUID      string `xorm:"uuid UNIQUE"`
-	IssueID   int64  `xorm:"INDEX"`
-	CommentID int64
-	ReleaseID int64 `xorm:"INDEX"`
-	Name      string
-
-	Created     time.Time `xorm:"-"`
-	CreatedUnix int64
+	ID            int64  `xorm:"pk autoincr"`
+	UUID          string `xorm:"uuid UNIQUE"`
+	IssueID       int64  `xorm:"INDEX"`
+	CommentID     int64
+	ReleaseID     int64 `xorm:"INDEX"`
+	Name          string
+	DownloadCount int64
+	Created       time.Time `xorm:"-"`
+	CreatedUnix   int64
 }
 
 // BeforeInsert is invoked from XORM before inserting an object of this type.
@@ -43,6 +43,19 @@ func (a *Attachment) AfterSet(colName string, _ xorm.Cell) {
 	case "created_unix":
 		a.Created = time.Unix(a.CreatedUnix, 0).Local()
 	}
+}
+
+// IncreaseDownloadCount is update download count + 1
+func (a *Attachment) IncreaseDownloadCount() error {
+	sess := x.NewSession()
+	defer sessionRelease(sess)
+
+	// Update repository count.
+	if _, err := sess.Exec("UPDATE `attachment` SET download_count=download_count+1 WHERE id=?", a.ID); err != nil {
+		return fmt.Errorf("increase attachment count: %v", err)
+	}
+
+	return nil
 }
 
 // AttachmentLocalPath returns where attachment is stored in local file

--- a/models/attachment.go
+++ b/models/attachment.go
@@ -23,10 +23,10 @@ type Attachment struct {
 	ID            int64  `xorm:"pk autoincr"`
 	UUID          string `xorm:"uuid UNIQUE"`
 	IssueID       int64  `xorm:"INDEX"`
+	ReleaseID     int64  `xorm:"INDEX"`
 	CommentID     int64
-	ReleaseID     int64 `xorm:"INDEX"`
 	Name          string
-	DownloadCount int64
+	DownloadCount int64     `xorm:"DEFAULT 0"`
 	Created       time.Time `xorm:"-"`
 	CreatedUnix   int64
 }

--- a/models/attachment_test.go
+++ b/models/attachment_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncreaseDownloadCount(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	attachment, err := GetAttachmentByUUID("1234567890")
+	assert.NoError(t, err)
+
+	// increase download count
+	err = attachment.IncreaseDownloadCount()
+	assert.NoError(t, err)
+
+	attachment, err = GetAttachmentByUUID("1234567890")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), attachment.DownloadCount)
+}
+
+func TestGetByCommentOrIssueID(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	// count of attachments from issue ID
+	attachments, err := GetAttachmentsByIssueID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(attachments))
+
+	attachments, err = GetAttachmentsByCommentID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(attachments))
+}
+
+func TestDeleteAttachments(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	count, err := DeleteAttachmentsByIssue(4, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	count, err = DeleteAttachmentsByComment(2, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	err = DeleteAttachment(&Attachment{ID: 8}, false)
+	assert.NoError(t, err)
+
+	attachment, err := GetAttachmentByUUID("test-12345")
+	assert.NoError(t, err)
+	assert.Nil(t, attachment)
+}

--- a/models/attachment_test.go
+++ b/models/attachment_test.go
@@ -53,6 +53,7 @@ func TestDeleteAttachments(t *testing.T) {
 	assert.NoError(t, err)
 
 	attachment, err := GetAttachmentByUUID("test-12345")
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.True(t, IsErrAttachmentNotExist(err))
 	assert.Nil(t, attachment)
 }

--- a/models/attachment_test.go
+++ b/models/attachment_test.go
@@ -15,6 +15,7 @@ func TestIncreaseDownloadCount(t *testing.T) {
 
 	attachment, err := GetAttachmentByUUID("1234567890")
 	assert.NoError(t, err)
+	assert.Equal(t, int64(0), attachment.DownloadCount)
 
 	// increase download count
 	err = attachment.IncreaseDownloadCount()

--- a/models/fixtures/attachment.yml
+++ b/models/fixtures/attachment.yml
@@ -1,0 +1,71 @@
+-
+  id: 1
+  uuid: 1234567890
+  issue_id: 1
+  comment_id: 0
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 2
+  uuid: 1122334455
+  issue_id: 1
+  comment_id: 0
+  name: attach2
+  download_count: 1
+  created_unix: 946684800
+
+-
+  id: 3
+  uuid: comment-id-1
+  issue_id: 2
+  comment_id: 1
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 4
+  uuid: comment-id-2
+  issue_id: 3
+  comment_id: 1
+  name: attach2
+  download_count: 1
+  created_unix: 946684800
+
+-
+  id: 5
+  uuid: comment-id-3
+  issue_id: 4
+  comment_id: 0
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 6
+  uuid: comment-id-4
+  issue_id: 5
+  comment_id: 2
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 7
+  uuid: comment-id-5
+  issue_id: 5
+  comment_id: 2
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 8
+  uuid: test-12345
+  issue_id: 6
+  comment_id: 0
+  name: attach1
+  download_count: 0
+  created_unix: 946684800


### PR DESCRIPTION
* Add download count field in `attachment` table. See [GitHub API](https://developer.github.com/v3/repos/releases/#get-a-single-release-asset)
* Add unit testing.