### PR TITLE
Do not show empty collaborators segment

### DIFF
--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -7,6 +7,7 @@
 		<h4 class="ui top attached header">
 			{{.i18n.Tr "repo.settings.collaboration"}}
 		</h4>
+		{{if .Collaborators}}
 		<div class="ui attached segment collaborator list">
 			{{range .Collaborators}}
 				<div class="item ui grid">
@@ -36,6 +37,7 @@
 				</div>
 			{{end}}
 		</div>
+		{{end}}
 		<div class="ui bottom attached segment">
 			<form class="ui form" id="repo-collab-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}


### PR DESCRIPTION
When there is no collaborator:
Before:
![chrome_2017-04-22_12-22-36](https://cloud.githubusercontent.com/assets/12720041/25303593/db17aa88-2756-11e7-9cc0-dbb8a3fe959d.png)

After:
![image](https://cloud.githubusercontent.com/assets/12720041/25303616/3571c306-2757-11e7-9de2-e2fd3e24fa88.png)

1+ collaborator - remains same:
![chrome_2017-04-22_12-22-01](https://cloud.githubusercontent.com/assets/12720041/25303604/053a27be-2757-11e7-953d-ab3266c5680b.png)

