### PR TITLE
markup: microoptimise for many short filenames in directory

### DIFF
--- a/modules/markup/markup.go
+++ b/modules/markup/markup.go
@@ -71,11 +71,14 @@ func ReadmeFileType(name string) (string, bool) {
 // IsReadmeFile reports whether name looks like a README file
 // based on its name.
 func IsReadmeFile(name string) bool {
-	name = strings.ToLower(name)
 	if len(name) < 6 {
 		return false
-	} else if len(name) == 6 {
+	}
+
+	name = strings.ToLower(name)
+	if len(name) == 6 {
 		return name == "readme"
 	}
 	return name[:7] == "readme."
 }
+

--- a/modules/markup/markup_test.go
+++ b/modules/markup/markup_test.go
@@ -25,6 +25,7 @@ func TestMisc_IsReadmeFile(t *testing.T) {
 		"abcdefg",
 		"abcdefghijklmnopqrstuvwxyz",
 		"test.md.test",
+		"readmf",
 	}
 
 	for _, testCase := range trueTestCases {


### PR DESCRIPTION
Move strings.ToLower() after the early-return length check. This is a safe operation in all cases and should slightly improve directory listing performance when a directory contains many thousands of files with short filenames.