### PR TITLE
fix lost text color on button on set as primary email

### DIFF
--- a/templates/user/settings/email.tmpl
+++ b/templates/user/settings/email.tmpl
@@ -25,7 +25,7 @@
 												{{$.CsrfTokenHtml}}
 												<input name="_method" type="hidden" value="PRIMARY">
 												<input name="id" type="hidden" value="{{.ID}}">
-												<button class="ui green tiny button">{{$.i18n.Tr "settings.primary_email"}}</button>
+												<button class="ui blue tiny button">{{$.i18n.Tr "settings.primary_email"}}</button>
 											</form>
 										</div>
 									{{end}}


### PR DESCRIPTION
This will change the button color to blue to fix #1521. After the screenshot:
![untitled](https://cloud.githubusercontent.com/assets/81045/25473892/c9aff55a-2b63-11e7-82e4-12bb265b65ad.png)
