### PR TITLE
Improve govendor testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ SOURCES ?= $(shell find . -name "*.go" -type f)
 
 TAGS ?=
 
+TMPDIR := $(shell mktemp -d)
+
 ifneq ($(DRONE_TAG),)
 	VERSION ?= $(subst v,,$(DRONE_TAG))
 else
@@ -84,12 +86,12 @@ test-vendor:
 	@hash govendor > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/kardianos/govendor; \
 	fi
-	govendor list +unused | tee '$(TMPDIR)/wc-gitea-unused'
-	[ $(cat '$(TMPDIR)/wc-gitea-unused' | wc -l) -eq 0 ] || echo "Warning: /!\ Some vendor are not used /!\"
-	
-	govendor list +outside | tee '$(TMPDIR)/wc-gitea-outside'
-	[ $(cat '$(TMPDIR)/wc-gitea-outside' | wc -l) -eq 0 ] || exit 1
-	
+	govendor list +unused | tee "$(TMPDIR)/wc-gitea-unused"
+	[ $$(cat "$(TMPDIR)/wc-gitea-unused" | wc -l) -eq 0 ] || echo "Warning: /!\\ Some vendor are not used /!\\"
+
+	govendor list +outside | tee "$(TMPDIR)/wc-gitea-outside"
+	[ $$(cat "$(TMPDIR)/wc-gitea-outside" | wc -l) -eq 0 ] || exit 1
+
 	govendor status || exit 1
 
 .PHONY: test-sqlite

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ test-vendor:
 	@hash govendor > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/kardianos/govendor; \
 	fi
-	govendor status +outside +unused  || exit 1
+	govendor list +outside +unused  || exit 1
+	govendor status || exit 1
 
 .PHONY: test-sqlite
 test-sqlite: integrations.test integrations/gitea-integration

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ test-vendor:
 	@hash govendor > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/kardianos/govendor; \
 	fi
-	govendor list +unused | tee /tmp/wc-gitea-unused
-	[ $(cat /tmp/wc-gitea-unused | wc -l) -eq 0 ] || echo "Warning: /!\ Some vendor are not used /!\"
+	govendor list +unused | tee '$(TMPDIR)/wc-gitea-unused'
+	[ $(cat '$(TMPDIR)/wc-gitea-unused' | wc -l) -eq 0 ] || echo "Warning: /!\ Some vendor are not used /!\"
 	
-	govendor list +outside | tee /tmp/wc-gitea-outside
-	[ $(cat /tmp/wc-gitea-outside | wc -l) -eq 0 ] || exit 1
+	govendor list +outside | tee '$(TMPDIR)/wc-gitea-outside'
+	[ $(cat '$(TMPDIR)/wc-gitea-outside' | wc -l) -eq 0 ] || exit 1
 	
 	govendor status || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,12 @@ test-vendor:
 	@hash govendor > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/kardianos/govendor; \
 	fi
-	govendor list +outside +unused  || exit 1
+	govendor list +unused | tee /tmp/wc-gitea-unused
+	[ $(cat /tmp/wc-gitea-unused | wc -l) -eq 0 ] || echo "Warning: /!\ Some vendor are not used /!\"
+	
+	govendor list +outside | tee /tmp/wc-gitea-outside
+	[ $(cat /tmp/wc-gitea-outside | wc -l) -eq 0 ] || exit 1
+	
 	govendor status || exit 1
 
 .PHONY: test-sqlite

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test",
+	"ignore": "test appengine",
 	"package": [
 		{
 			"checksumSHA1": "vPnpECwoEpT/TTJn8CINm2cxV8s=",


### PR DESCRIPTION
Use `govendor list +outside +unused` for finding missing or unused deps and `govendor status` for catching modified vendor.


Ref : #1620