### PR TITLE
Handle display of GPG key without end date

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -377,6 +377,7 @@ ssh_key_deletion_success = SSH key has been deleted successfully!
 gpg_key_deletion_success = GPG key has been deleted successfully!
 add_on = Added on
 valid_until = Valid until
+never = never
 last_used = Last used on
 no_activity = No recent activity
 key_state_desc = This key is used in last 7 days

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -16,7 +16,7 @@
               {{$.i18n.Tr "settings.delete_key"}}
             </button>
           </div>
-          <i class="mega-octicon octicon-key {{if .Expired.After $.PageStartTime}}green{{end}}"></i>
+          <i class="mega-octicon octicon-key {{if or .Expired.IsZero (.Expired.After $.PageStartTime)}}green{{end}}"></i>
           <div class="content">
             {{range .Emails}}<strong>{{.Email}} </strong>{{end}}
             <div class="print meta">
@@ -26,7 +26,7 @@
             <div class="activity meta">
                 <i>{{$.i18n.Tr "settings.add_on"}} <span>{{DateFmtShort .Added}}</span></i>
                  -
-                <i>{{$.i18n.Tr "settings.valid_until"}} <span>{{DateFmtShort .Expired}}</span></i>
+                <i>{{$.i18n.Tr "settings.valid_until"}} <span>{{if not .Expired.IsZero }}{{DateFmtShort .Expired}}{{else}}{{$.i18n.Tr "settings.never"}}{{end}}</span></i>
             </div>
           </div>
       </div>


### PR DESCRIPTION
All is in the title.

Reported by @Fastidious in a comment on @8371f94d06cefbd65392af3b5c0f1fd1057429f7 
(related issue #1626 )


Before : 
![after](https://cloud.githubusercontent.com/assets/8352292/25484734/32cbd774-2b29-11e7-8a69-5ebfc60268f3.png)

After : 
![after](https://cloud.githubusercontent.com/assets/4052400/25495838/06a61abe-2b7f-11e7-8b56-33c34a46246f.png)

