### PR TITLE
Fix version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ JAVASCRIPTS :=
 GOFLAGS := -i -v
 EXTRA_GOFLAGS ?=
 
-VERSION := $(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')
-
-LDFLAGS := -X "main.Version=$(VERSION)" -X "main.Tags=$(TAGS)"
+LDFLAGS := -X "main.Version=$(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')" -X "main.Tags=$(TAGS)"
 
 PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations,$(shell go list ./... | grep -v /vendor/))
 SOURCES ?= $(shell find . -name "*.go" -type f)


### PR DESCRIPTION
This reverts commit 410af6971b87ac5dc7ac198f538d8383c1f47a1f.

Without this drone will fill up `dl.gitea.io/gitea/master` with old builds, and `gitea-master-[os]-[arch]` isn't the lastest master... _not_ what we want to do