### PR TITLE
fix #1643 and improve integration test

### DIFF
--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -21,3 +21,12 @@ func TestAPIUserReposNotLogin(t *testing.T) {
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
+
+func TestAPISearchRepoNotLogin(t *testing.T) {
+	assert.NoError(t, models.LoadFixtures())
+
+	req, err := http.NewRequest("GET", "/api/v1/repos/search?q=Test", nil)
+	assert.NoError(t, err)
+	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -19,12 +19,3 @@ func TestViewRepo(t *testing.T) {
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
-
-func TestViewUser(t *testing.T) {
-	prepareTestEnv(t)
-
-	req, err := http.NewRequest("GET", "/user2", nil)
-	assert.NoError(t, err)
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
-}

--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -1,0 +1,21 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestViewUser(t *testing.T) {
+	prepareTestEnv(t)
+
+	req, err := http.NewRequest("GET", "/user2", nil)
+	assert.NoError(t, err)
+	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -55,6 +55,11 @@ func Search(ctx *context.APIContext) {
 		return
 	}
 
+	var userID int64
+	if ctx.IsSigned {
+		userID = ctx.User.ID
+	}
+
 	results := make([]*api.Repository, len(repos))
 	for i, repo := range repos {
 		if err = repo.GetOwner(); err != nil {
@@ -64,7 +69,7 @@ func Search(ctx *context.APIContext) {
 			})
 			return
 		}
-		accessMode, err := models.AccessLevel(ctx.User.ID, repo)
+		accessMode, err := models.AccessLevel(userID, repo)
 		if err != nil {
 			ctx.JSON(500, map[string]interface{}{
 				"ok":    false,


### PR DESCRIPTION
This will fix #1643 with integration test and will split `integration/view_test.go` into `integration/repo_test.go` and `integration/user_test.go`.