### PR TITLE
Send mails as HTML as default. Setting for send as plain text.

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -290,8 +290,8 @@ FROM =
 ; Mailer user name and password
 USER =
 PASSWD =
-; Use text/html as alternative format of content
-ENABLE_HTML_ALTERNATIVE = false
+; Send mails as plain text
+SEND_AS_PLAIN_TEXT = false
 ; Enable sendmail (override SMTP)
 USE_SENDMAIL = false
 ; Specifiy an alternative sendmail binary

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -1,4 +1,5 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2017 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -15,11 +16,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jaytaylor/html2text"
-	"gopkg.in/gomail.v2"
-
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/jaytaylor/html2text"
+	"gopkg.in/gomail.v2"
 )
 
 // Message mail body and log info
@@ -29,8 +30,8 @@ type Message struct {
 }
 
 // NewMessageFrom creates new mail message object with custom From header.
-func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
-	log.Trace("NewMessageFrom (htmlBody):\n%s", htmlBody)
+func NewMessageFrom(to []string, from, subject, body string) *Message {
+	log.Trace("NewMessageFrom (body):\n%s", body)
 
 	msg := gomail.NewMessage()
 	msg.SetHeader("From", from)
@@ -38,15 +39,23 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 	msg.SetHeader("Subject", subject)
 	msg.SetDateHeader("Date", time.Now())
 
-	body, err := html2text.FromString(htmlBody)
+	var plainBody string
+	var err error
+	if strings.Contains(body[:100], "<html>") {
+		plainBody, err = html2text.FromString(body)
+	} else {
+		plainBody = body
+		err = nil
+	}
+
 	if err != nil {
 		log.Error(4, "html2text.FromString: %v", err)
-		msg.SetBody("text/html", htmlBody)
+		msg.SetBody("text/html", body)
+	} else if setting.MailService.SendAsPlainText {
+		msg.SetBody("text/plain", plainBody)
 	} else {
-		msg.SetBody("text/plain", body)
-		if setting.MailService.EnableHTMLAlternative {
-			msg.AddAlternative("text/html", htmlBody)
-		}
+		msg.SetBody("text/plain", plainBody)
+		msg.AddAlternative("text/html", body)
 	}
 
 	return &Message{

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -39,19 +39,11 @@ func NewMessageFrom(to []string, from, subject, body string) *Message {
 	msg.SetHeader("Subject", subject)
 	msg.SetDateHeader("Date", time.Now())
 
-	var plainBody string
-	var err error
-	if strings.Contains(body[:100], "<html>") {
-		plainBody, err = html2text.FromString(body)
-	} else {
-		plainBody = body
-		err = nil
-	}
-
-	if err != nil {
-		log.Error(4, "html2text.FromString: %v", err)
-		msg.SetBody("text/html", body)
-	} else if setting.MailService.SendAsPlainText {
+	plainBody, _ := html2text.FromString(body)
+	if setting.MailService.SendAsPlainText {
+		if strings.Contains(body[:100], "<html>") {
+			log.Warn("Mail contains HTML but configured to send as plain text.")
+		}
 		msg.SetBody("text/plain", plainBody)
 	} else {
 		msg.SetBody("text/plain", plainBody)

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -39,8 +39,8 @@ func NewMessageFrom(to []string, from, subject, body string) *Message {
 	msg.SetHeader("Subject", subject)
 	msg.SetDateHeader("Date", time.Now())
 
-	plainBody, _ := html2text.FromString(body)
-	if setting.MailService.SendAsPlainText {
+	plainBody, err := html2text.FromString(body)
+	if err != nil || setting.MailService.SendAsPlainText {
 		if strings.Contains(body[:100], "<html>") {
 			log.Warn("Mail contains HTML but configured to send as plain text.")
 		}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1306,6 +1306,7 @@ func newMailService() {
 
 	if sec.HasKey("ENABLE_HTML_ALTERNATIVE") {
 		log.Warn("ENABLE_HTML_ALTERNATIVE is deprecated, use SEND_AS_PLAIN_TEXT")
+		MailService.SendAsPlainText = !sec.Key("ENABLE_HTML_ALTERNATIVE").MustBool(false)
 	}
 
 	parsed, err := mail.ParseAddress(MailService.From)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1252,11 +1252,11 @@ func newSessionService() {
 // Mailer represents mail service.
 type Mailer struct {
 	// Mailer
-	QueueLength           int
-	Name                  string
-	From                  string
-	FromEmail             string
-	EnableHTMLAlternative bool
+	QueueLength     int
+	Name            string
+	From            string
+	FromEmail       string
+	SendAsPlainText bool
 
 	// SMTP sender
 	Host              string
@@ -1285,9 +1285,9 @@ func newMailService() {
 	}
 
 	MailService = &Mailer{
-		QueueLength: sec.Key("SEND_BUFFER_LEN").MustInt(100),
-		Name:        sec.Key("NAME").MustString(AppName),
-		EnableHTMLAlternative: sec.Key("ENABLE_HTML_ALTERNATIVE").MustBool(),
+		QueueLength:     sec.Key("SEND_BUFFER_LEN").MustInt(100),
+		Name:            sec.Key("NAME").MustString(AppName),
+		SendAsPlainText: sec.Key("SEND_AS_PLAIN_TEXT").MustBool(false),
 
 		Host:           sec.Key("HOST").String(),
 		User:           sec.Key("USER").String(),

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1304,6 +1304,10 @@ func newMailService() {
 	}
 	MailService.From = sec.Key("FROM").MustString(MailService.User)
 
+	if sec.HasKey("ENABLE_HTML_ALTERNATIVE") {
+		log.Warn("ENABLE_HTML_ALTERNATIVE is deprecated, use SEND_AS_PLAIN_TEXT")
+	}
+
 	parsed, err := mail.ParseAddress(MailService.From)
 	if err != nil {
 		log.Fatal(4, "Invalid mailer.FROM (%s): %v", MailService.From, err)


### PR DESCRIPTION
As the default mail templates are all HTML and look rather crappy if sent as plain text I think the default should be to send as HTML. HTML is added as mime/alternative so it's still possible to view as plain text.

I have added a new setting, SEND_AS_PLAIN_TEXT, to send as plain text as default instead. Old setting, ENABLE_HTML_ALTERNATIVE, is removed.

Fixes https://github.com/go-gitea/gitea/issues/1342