### PR TITLE
Add primary key and index to external login user table

### DIFF
--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -8,9 +8,9 @@ import "github.com/markbates/goth"
 
 // ExternalLoginUser makes the connecting between some existing user and additional external login sources
 type ExternalLoginUser struct {
-	ExternalID    string `xorm:"NOT NULL"`
-	UserID        int64  `xorm:"NOT NULL"`
-	LoginSourceID int64  `xorm:"NOT NULL"`
+	ExternalID    string `xorm:"pk NOT NULL"`
+	UserID        int64  `xorm:"INDEX NOT NULL"`
+	LoginSourceID int64  `xorm:"pk NOT NULL"`
 }
 
 // GetExternalLogin checks if a externalID in loginSourceID scope already exists

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -108,6 +108,8 @@ var migrations = []Migration{
 	NewMigration("add field for repo size", addRepoSize),
 	// v29 -> v30
 	NewMigration("add commit status table", addCommitStatus),
+	// v30 -> 31
+	NewMigration("add primary key to external login user", addExternalLoginUserPK),
 }
 
 // Migrate database to current version

--- a/models/migrations/v30.go
+++ b/models/migrations/v30.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-xorm/xorm"
+)
+
+func addExternalLoginUserPK(x *xorm.Engine) error {
+	// ExternalLoginUser see models/external_login_user.go
+	type ExternalLoginUser struct {
+		ExternalID    string `xorm:"pk NOT NULL"`
+		UserID        int64  `xorm:"INDEX NOT NULL"`
+		LoginSourceID int64  `xorm:"pk NOT NULL"`
+	}
+
+	extlogins := make([]*ExternalLoginUser, 0, 6)
+	if err := x.Find(&extlogins); err != nil {
+		return fmt.Errorf("Find: %v", err)
+	}
+
+	if err := x.DropTables(new(ExternalLoginUser)); err != nil {
+		return fmt.Errorf("DropTables: %v", err)
+	}
+
+	if err := x.Sync2(new(ExternalLoginUser)); err != nil {
+		return fmt.Errorf("Sync2: %v", err)
+	}
+
+	if _, err := x.Insert(extlogins); err != nil {
+		return fmt.Errorf("Insert: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #1655

I don't know if that's the best way for migration, it would be better to add primary key as SQL commands not recreating table, let me know what you think.