### PR TITLE
Download files to their original filename

### DIFF
--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -7,6 +7,7 @@ package repo
 import (
 	"fmt"
 	"io"
+	"path"
 	"strings"
 
 	"code.gitea.io/git"
@@ -24,6 +25,7 @@ func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	}
 
 	ctx.Resp.Header().Set("Cache-Control", "public,max-age=86400")
+	name = path.Base(name)
 
 	// Google Chrome dislike commas in filenames, so let's change it to a space
 	name = strings.Replace(name, ",", " ", -1)


### PR DESCRIPTION
This removes the path from download filenames, so `dir/file.txt` now downloads to `file.txt` instead of `dir-file.txt` (browsers replace slashes with dashes).