### PR TITLE
remove sqlite tag when integration test with mysql/postgres and recreate database when init integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ test-vendor:
 	govendor status || exit 1
 
 .PHONY: test-sqlite
-test-sqlite: integrations.test
+test-sqlite:
+	go test -c code.gitea.io/gitea/integrations -tags 'sqlite'
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/sqlite.ini ./integrations.test
 
 .PHONY: test-mysql
@@ -108,7 +109,7 @@ test-pgsql: integrations.test
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/pgsql.ini ./integrations.test
 
 integrations.test: $(SOURCES)
-	go test -c code.gitea.io/gitea/integrations -tags 'sqlite'
+	go test -c code.gitea.io/gitea/integrations
 
 .PHONY: check
 check: test

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -79,7 +79,7 @@ func initIntegrationTest() {
 		if err != nil {
 			log.Fatalf("sql.Open: %v", err)
 		}
-		if _, err = db.Exec("DROP DATABASE testgitea"); err != nil {
+		if _, err = db.Exec("DROP DATABASE IF EXISTS testgitea"); err != nil {
 			log.Fatalf("db.drop db: %v", err)
 		}
 		if _, err = db.Exec("CREATE DATABASE IF NOT EXISTS testgitea"); err != nil {

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -79,6 +79,9 @@ func initIntegrationTest() {
 		if err != nil {
 			log.Fatalf("sql.Open: %v", err)
 		}
+		if _, err = db.Exec("DROP DATABASE testgitea"); err != nil {
+			log.Fatalf("db.drop db: %v", err)
+		}
 		if _, err = db.Exec("CREATE DATABASE IF NOT EXISTS testgitea"); err != nil {
 			log.Fatalf("db.Exec: %v", err)
 		}
@@ -96,10 +99,13 @@ func initIntegrationTest() {
 		}
 		defer rows.Close()
 
-		if !rows.Next() {
-			if _, err = db.Exec("CREATE DATABASE testgitea"); err != nil {
-				log.Fatalf("db.Exec: %v", err)
+		if rows.Next() {
+			if _, err = db.Exec("DROP DATABASE testgitea"); err != nil {
+				log.Fatalf("db.drop db: %v", err)
 			}
+		}
+		if _, err = db.Exec("CREATE DATABASE testgitea"); err != nil {
+			log.Fatalf("db.Exec: %v", err)
 		}
 	}
 	routers.GlobalInit()


### PR DESCRIPTION
As title. This will spend less time when run `test-mysql` and `test-pgsql` since there is no CGO build.