### PR TITLE
Realy don't cache apk index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Thomas Boerger <thomas@webhippie.de>
 
 EXPOSE 22 3000
 
-RUN apk -U --no-cache add \
+RUN apk --no-cache add \
     su-exec \
     ca-certificates \
     sqlite \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM multiarch/alpine:aarch64-v3.5
 
 EXPOSE 22 3000
 
-RUN apk -U --no-cache add \
+RUN apk --no-cache add \
     su-exec \
     ca-certificates \
     sqlite \

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -3,7 +3,7 @@ MAINTAINER Thomas Boerger <thomas@webhippie.de>
 
 EXPOSE 22 3000
 
-RUN apk -U --no-cache add \
+RUN apk --no-cache add \
     su-exec \
     ca-certificates \
     sqlite \


### PR DESCRIPTION
Actually the "-U --no-cache" effectively is treated as --no-cache
was never specified:

```
/ # apk -U --no-cache add sed
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
(1/1) Installing sed (4.2.2-r0)
Executing busybox-1.25.1-r0.trigger
OK: 4 MiB in 12 packages
/ # ls -la /var/cache/apk/
total 1004
drwxr-xr-x    1 root     root            70 May  8 11:08 .
drwxr-xr-x    1 root     root            29 Mar  3 11:20 ..
-rw-r--r--    1 root     root        732807 May  5 07:11 APKINDEX.c51f8f92.tar.gz
-rw-r--r--    1 root     root        293014 May  1 12:37 APKINDEX.d09172fd.tar.gz
```

So removing the "-U" fix this behavior.