### PR TITLE
Added URL mapping for Release attachments like on github.com

### DIFF
--- a/models/attachment.go
+++ b/models/attachment.go
@@ -114,7 +114,7 @@ func getAttachmentByUUID(e Engine, uuid string) (*Attachment, error) {
 	attach := &Attachment{UUID: uuid}
 	has, err := e.Get(attach)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	} else if !has {
 		return nil, ErrAttachmentNotExist{0, uuid}
 	}

--- a/models/attachment.go
+++ b/models/attachment.go
@@ -157,11 +157,7 @@ func GetAttachmentsByCommentID(commentID int64) ([]*Attachment, error) {
 	return attachments, x.Where("comment_id=?", commentID).Find(&attachments)
 }
 
-/*	Author : github.com/gdeverlant
-	getAttachmentByReleaseIDFileName return a file based on the the following infos:
-	- releaseID
-	- fileName
-*/
+// getAttachmentByReleaseIDFileName return a file based on the the following infos:
 func getAttachmentByReleaseIDFileName(e Engine, releaseID int64, fileName string) (*Attachment, error) {
 	attach := &Attachment{ReleaseID: releaseID, Name: fileName}
 	has, err := e.Get(attach)

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -268,17 +268,14 @@ func Action(ctx *context.Context) {
 	ctx.Redirect(redirectTo)
 }
 
-//	RedirectDownload return a file based on the the following infos:
+// RedirectDownload return a file based on the the following infos:
 func RedirectDownload(ctx *context.Context) {
 	var (
 		vTag     = ctx.Params("vTag")
 		fileName = ctx.Params("fileName")
 	)
-	var tagNames []string
-	tagNames = append(tagNames, vTag)
-
+	tagNames := []string{vTag}
 	curRepo := ctx.Repo.Repository
-
 	releases, err := models.GetReleasesByRepoIDAndNames(curRepo.ID, tagNames)
 	if err != nil {
 		ctx.Handle(500, "RedirectDownload -> Release not found", err)

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -268,7 +268,7 @@ func Action(ctx *context.Context) {
 	ctx.Redirect(redirectTo)
 }
 
-// RedirectDownload return a file based on the the following infos:
+// RedirectDownload return a file based on the following infos:
 func RedirectDownload(ctx *context.Context) {
 	var (
 		vTag     = ctx.Params("vTag")
@@ -278,7 +278,11 @@ func RedirectDownload(ctx *context.Context) {
 	curRepo := ctx.Repo.Repository
 	releases, err := models.GetReleasesByRepoIDAndNames(curRepo.ID, tagNames)
 	if err != nil {
-		ctx.Handle(500, "RedirectDownload -> Release not found", err)
+		if models.IsErrAttachmentNotExist(err) {
+			ctx.Error(404)
+			return
+		}
+		ctx.Handle(500, "RedirectDownload: Failed to get attachment", err)
 		return
 	}
 	if len(releases) == 1 {

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -288,7 +288,9 @@ func RedirectDownload(ctx *context.Context) {
 			ctx.Handle(404, "RedirectDownload -> Attachment not found", err)
 			return
 		}
-		ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
+		if att != nil {
+			ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
+		}
 	}
 	ctx.Handle(404, "RedirectDownload -> Attachment not found", err)
 }

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -278,7 +278,7 @@ func RedirectDownload(ctx *context.Context) {
 	curRepo := ctx.Repo.Repository
 	releases, err := models.GetReleasesByRepoIDAndNames(curRepo.ID, tagNames)
 	if err != nil {
-		ctx.Handle(404, "RedirectDownload -> Release not found", err)
+		ctx.Handle(500, "RedirectDownload -> Release not found", err)
 		return
 	}
 
@@ -291,6 +291,8 @@ func RedirectDownload(ctx *context.Context) {
 		}
 		ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
 	}
+
+	ctx.Handle(404, "RedirectDownload -> Attachment not found", err)
 }
 
 // Download download an archive of a repository

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -274,13 +274,6 @@ func RedirectDownload(ctx *context.Context) {
 		vTag     = ctx.Params("vTag")
 		fileName = ctx.Params("fileName")
 	)
-	if len(vTag) > 0 {
-		fmt.Println("Value of vTag %v", vTag)
-	}
-	if len(fileName) > 0 {
-		fmt.Println("Value of fileName %v", fileName)
-	}
-
 	var tagNames []string
 	tagNames = append(tagNames, vTag)
 

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -281,7 +281,6 @@ func RedirectDownload(ctx *context.Context) {
 		ctx.Handle(500, "RedirectDownload -> Release not found", err)
 		return
 	}
-
 	if len(releases) == 1 {
 		release := releases[0]
 		att, err := models.GetAttachmentByReleaseIDFileName(release.ID, fileName)
@@ -291,7 +290,6 @@ func RedirectDownload(ctx *context.Context) {
 		}
 		ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
 	}
-
 	ctx.Handle(404, "RedirectDownload -> Attachment not found", err)
 }
 

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -268,6 +268,41 @@ func Action(ctx *context.Context) {
 	ctx.Redirect(redirectTo)
 }
 
+//	RedirectDownload return a file based on the the following infos:
+func RedirectDownload(ctx *context.Context) {
+	var (
+		vTag     = ctx.Params("vTag")
+		fileName = ctx.Params("fileName")
+	)
+	if len(vTag) > 0 {
+		fmt.Println("Value of vTag %v", vTag)
+	}
+	if len(fileName) > 0 {
+		fmt.Println("Value of fileName %v", fileName)
+	}
+
+	var tagNames []string
+	tagNames = append(tagNames, vTag)
+
+	curRepo := ctx.Repo.Repository
+
+	releases, err := models.GetReleasesByRepoIDAndNames(curRepo.ID, tagNames)
+	if err != nil {
+		ctx.Handle(500, "RedirectDownload -> Release not found", err)
+		return
+	}
+
+	if len(releases) == 1 {
+		release := releases[0]
+		att, err := models.GetAttachmentByReleaseIDFileName(release.ID, fileName)
+		if err != nil {
+			ctx.Handle(500, "RedirectDownload -> Attachment not found", err)
+			return
+		}
+		ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
+	}
+}
+
 // Download download an archive of a repository
 func Download(ctx *context.Context) {
 	var (

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -278,7 +278,7 @@ func RedirectDownload(ctx *context.Context) {
 	curRepo := ctx.Repo.Repository
 	releases, err := models.GetReleasesByRepoIDAndNames(curRepo.ID, tagNames)
 	if err != nil {
-		ctx.Handle(500, "RedirectDownload -> Release not found", err)
+		ctx.Handle(404, "RedirectDownload -> Release not found", err)
 		return
 	}
 
@@ -286,7 +286,7 @@ func RedirectDownload(ctx *context.Context) {
 		release := releases[0]
 		att, err := models.GetAttachmentByReleaseIDFileName(release.ID, fileName)
 		if err != nil {
-			ctx.Handle(500, "RedirectDownload -> Attachment not found", err)
+			ctx.Handle(404, "RedirectDownload -> Attachment not found", err)
 			return
 		}
 		ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -486,6 +486,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Get("/:id/:action", repo.ChangeMilestonStatus)
 			m.Post("/delete", repo.DeleteMilestone)
 		}, reqRepoWriter, context.RepoRef())
+		// New redirection from fake url
+		m.Group("/releases", func() {
+			m.Get("/download/:vTag/:fileName", repo.RedirectDownload)
+		}, repo.MustBeNotBare, reqRepoWriter, context.RepoRef())
 		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -488,8 +488,6 @@ func RegisterRoutes(m *macaron.Macaron) {
 		}, reqRepoWriter, context.RepoRef())
 		m.Group("/releases", func() {
 			m.Get("/download/:vTag/:fileName", repo.RedirectDownload)
-		}, repo.MustBeNotBare, reqRepoWriter, context.RepoRef())
-		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)
 			m.Post("/delete", repo.DeleteRelease)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -486,7 +486,6 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Get("/:id/:action", repo.ChangeMilestonStatus)
 			m.Post("/delete", repo.DeleteMilestone)
 		}, reqRepoWriter, context.RepoRef())
-		// New redirection from fake url
 		m.Group("/releases", func() {
 			m.Get("/download/:vTag/:fileName", repo.RedirectDownload)
 		}, repo.MustBeNotBare, reqRepoWriter, context.RepoRef())

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -53,14 +53,13 @@
 							<div class="download">
 								<h2>{{$.i18n.Tr "repo.release.downloads"}}</h2>
 								<ul class="list">
-									{{$tagname := .TagName}}
 									{{if .Attachments}}
 										{{range $attachment := .Attachments}}
 										<li>
 											<!-- {{AppSubUrl}}/attachments/{{$attachment.UUID}} -->
-											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}">
+											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$.TagName}}/{{$attachment.Name}}">
 												<span class="ui image octicon octicon-desktop-download" title='{{$attachment.Name}}'></span> {{$attachment.Name}} 
-												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>
+												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$.TagName}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>
 											</a>
 										</li>
 										{{end}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -53,21 +53,25 @@
 							<div class="download">
 								<h2>{{$.i18n.Tr "repo.release.downloads"}}</h2>
 								<ul class="list">
+									{{$tagname := .TagName}}
+									{{if .Attachments}}
+										{{range $attachment := .Attachments}}
+										<li>
+											<!-- {{AppSubUrl}}/attachments/{{$attachment.UUID}} -->
+											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}">
+												<span class="ui image octicon octicon-desktop-download" title='{{$attachment.Name}}'></span> {{$attachment.Name}} 
+												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>
+											</a>
+										</li>
+										{{end}}
+									{{end}}
 									<li>
 										<a href="{{$.RepoLink}}/archive/{{.TagName}}.zip" rel="nofollow"><i class="octicon octicon-file-zip"></i> {{$.i18n.Tr "repo.release.source_code"}} (ZIP)</a>
 									</li>
 									<li>
 										<a href="{{$.RepoLink}}/archive/{{.TagName}}.tar.gz"><i class="octicon octicon-file-zip"></i> {{$.i18n.Tr "repo.release.source_code"}} (TAR.GZ)</a>
 									</li>
-									{{if .Attachments}}
-									{{range .Attachments}}
-									<li>
-										<a target="_blank" rel="noopener" href="{{AppSubUrl}}/attachments/{{.UUID}}">
-											<span class="ui image octicon octicon-desktop-download" title='{{.Name}}'></span> {{.Name}}
-										</a>
-									</li>
-									{{end}}
-									{{end}}
+									
 								</ul>
 							</div>
 						{{else}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -57,7 +57,6 @@
 									{{if .Attachments}}
 										{{range $attachment := .Attachments}}
 										<li>
-											<!-- {{AppSubUrl}}/attachments/{{$attachment.UUID}} -->
 											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}">
 												<span class="ui image octicon octicon-desktop-download" title='{{$attachment.Name}}'></span> {{$attachment.Name}} 
 												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -53,13 +53,14 @@
 							<div class="download">
 								<h2>{{$.i18n.Tr "repo.release.downloads"}}</h2>
 								<ul class="list">
+									{{$tagname := .TagName}}
 									{{if .Attachments}}
 										{{range $attachment := .Attachments}}
 										<li>
 											<!-- {{AppSubUrl}}/attachments/{{$attachment.UUID}} -->
-											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$.TagName}}/{{$attachment.Name}}">
+											<a target="_blank" rel="noopener" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}">
 												<span class="ui image octicon octicon-desktop-download" title='{{$attachment.Name}}'></span> {{$attachment.Name}} 
-												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$.TagName}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>
+												<a target="_blank" href="{{$.RepoLink}}/releases/download/{{$tagname}}/{{$attachment.Name}}" class="ui right"><span class="ui image octicon octicon-file-binary" title='{{$attachment.Name}}'></span>{{$attachment.FileSize}}</a>
 											</a>
 										</li>
 										{{end}}


### PR DESCRIPTION
Implement a Git Hub style URL mapping for the attachment files in Release.

See screenshot : ![screenshot](https://cloud.githubusercontent.com/assets/26530975/25880055/6628ae2e-3535-11e7-994e-332d82d034e5.png)