### PR TITLE
Correct flash after sending password reset email

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -222,7 +222,9 @@ WHITELISTED_URIS =
 BLACKLISTED_URIS =
 
 [service]
+; Time limit to confirm account/email registration (in multiples of 60 minutes)
 ACTIVE_CODE_LIVE_MINUTES = 180
+; Time limit to confirm forgot password reset process (in multiples of 60 minutes)
 RESET_PASSWD_CODE_LIVE_MINUTES = 180
 ; User need to confirm e-mail for registration
 REGISTER_EMAIL_CONFIRM = false

--- a/models/mail.go
+++ b/models/mail.go
@@ -65,7 +65,7 @@ func SendUserMail(c *macaron.Context, u *User, tpl base.TplName, code, subject, 
 	mailer.SendAsync(msg)
 }
 
-// SendActivateAccountMail sends an activation mail to the user
+// SendActivateAccountMail sends an activation mail to the user (new user registration)
 func SendActivateAccountMail(c *macaron.Context, u *User) {
 	SendUserMail(c, u, mailAuthActivate, u.GenerateActivateCode(), c.Tr("mail.activate_account"), "activate account")
 }
@@ -75,7 +75,7 @@ func SendResetPasswordMail(c *macaron.Context, u *User) {
 	SendUserMail(c, u, mailAuthResetPassword, u.GenerateActivateCode(), c.Tr("mail.reset_password"), "reset password")
 }
 
-// SendActivateEmailMail sends confirmation email.
+// SendActivateEmailMail sends confirmation email to confirm new email address
 func SendActivateEmailMail(c *macaron.Context, u *User, email *EmailAddress) {
 	data := map[string]interface{}{
 		"Username":        u.DisplayName(),

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -171,6 +171,7 @@ forgot_password_title= Forgot Password
 forgot_password = Forgot password?
 sign_up_now = Need an account? Sign up now.
 confirmation_mail_sent_prompt = A new confirmation email has been sent to <b>%s</b>. Please check your inbox within the next %d hours to complete the registration process.
+reset_password_mail_sent_prompt = A confirmation email has been sent to <b>%s</b>. Please check your inbox within the next %d hours to complete the password reset process.
 active_your_account = Activate Your Account
 prohibit_login = Login Prohibited
 prohibit_login_desc = Your account is prohibited to login, please contact the site administrator.

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -913,7 +913,7 @@ func ForgotPasswdPost(ctx *context.Context) {
 	u, err := models.GetUserByEmail(email)
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
-			ctx.Data["Hours"] = setting.Service.ActiveCodeLives / 60
+			ctx.Data["Hours"] = setting.Service.ResetPwdCodeLives / 60
 			ctx.Data["IsResetSent"] = true
 			ctx.HTML(200, tplForgotPassword)
 			return
@@ -940,7 +940,7 @@ func ForgotPasswdPost(ctx *context.Context) {
 		log.Error(4, "Set cache(MailResendLimit) fail: %v", err)
 	}
 
-	ctx.Data["Hours"] = setting.Service.ActiveCodeLives / 60
+	ctx.Data["Hours"] = setting.Service.ResetPwdCodeLives / 60
 	ctx.Data["IsResetSent"] = true
 	ctx.HTML(200, tplForgotPassword)
 }

--- a/templates/user/auth/forgot_passwd.tmpl
+++ b/templates/user/auth/forgot_passwd.tmpl
@@ -10,7 +10,7 @@
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					{{if .IsResetSent}}
-						<p>{{.i18n.Tr "auth.confirmation_mail_sent_prompt" .Email .Hours | Str2html}}</p>
+						<p>{{.i18n.Tr "auth.reset_password_mail_sent_prompt" .Email .Hours | Str2html}}</p>
 					{{else if .IsResetRequest}}
 						<div class="required inline field {{if .Err_Email}}error{{end}}">
 							<label for="email">{{.i18n.Tr "email"}}</label>


### PR DESCRIPTION
Adds a new text shown after sending password reset email. The previous reused same text as sending account confirmation mail including the wrong time limit.
Also improve documentation for related email functions.

Closes #1715 
