### PR TITLE
Fix #1719

### DIFF
--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -913,6 +913,10 @@
           "type": "string",
           "x-go-name": "Description"
         },
+        "empty": {
+          "type": "boolean",
+          "x-go-name": "Empty"
+        },
         "fork": {
           "type": "boolean",
           "x-go-name": "Fork"
@@ -952,6 +956,10 @@
           "x-go-name": "Owner",
           "$ref": "#/definitions/User"
         },
+        "parent": {
+          "x-go-name": "Parent",
+          "$ref": "#/definitions/Repository"
+        },
         "permissions": {
           "x-go-name": "Permissions",
           "$ref": "#/definitions/Permission"
@@ -959,6 +967,11 @@
         "private": {
           "type": "boolean",
           "x-go-name": "Private"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Size"
         },
         "ssh_url": {
           "type": "string",
@@ -1116,6 +1129,9 @@
         "description": {
           "type": "string"
         },
+        "empty": {
+          "type": "boolean"
+        },
         "fork": {
           "type": "boolean"
         },
@@ -1144,9 +1160,14 @@
           "format": "int64"
         },
         "owner": {},
+        "parent": {},
         "permissions": {},
         "private": {
           "type": "boolean"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int64"
         },
         "ssh_url": {
           "type": "string"


### PR DESCRIPTION
re-generate swagger.json for changes introduced to repo format by : go-gitea/gitea#1687 go-gitea/go-sdk#58  go-gitea/gitea#1668 go-gitea/go-sdk#56

This will fix #1719. We could think of check if swagger need a re-generation in drone in a other PR.