### PR TITLE
fix update avatar

### DIFF
--- a/models/migrations/v20.go
+++ b/models/migrations/v20.go
@@ -34,6 +34,7 @@ func useNewNameAvatars(x *xorm.Engine) error {
 	}
 
 	type User struct {
+		ID              int64 `xorm:"pk autoincr"`
 		Avatar          string
 		UseCustomAvatar bool
 	}


### PR DESCRIPTION
will fix #1234. This PR will not recover the wrong updated the database, you have to update the database manually yourself if you upgrade from v1.0.x to v1.1.0 or v1.1.1. This will fix the avatar problem on upgrading from v1.0.x to v1.1.2.