### PR TITLE
Change two factor code entry box from text to number

### DIFF
--- a/templates/user/auth/twofa.tmpl
+++ b/templates/user/auth/twofa.tmpl
@@ -11,7 +11,7 @@
 					{{template "base/alert" .}}
 					<div class="required inline field">
 						<label for="passcode">{{.i18n.Tr "passcode"}}</label>
-						<input id="passcode" name="passcode" type="text" autocomplete="off" autofocus required>
+						<input id="passcode" name="passcode" type="number" autocomplete="off" autofocus required>
 					</div>
 
 					<div class="inline field">


### PR DESCRIPTION
This makes it only accept numbers, and is easier to use on a mobile device because only numbers will show on the onscreen keyboard.