### PR TITLE
Fix issue #1730 - Now all actions are modified

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -674,3 +674,17 @@ func GetFeeds(ctxUser *User, actorID, offset int64, isProfile bool) ([]*Action, 
 	err := sess.Find(&actions)
 	return actions, err
 }
+
+// ChangeUsernameInAction changes the name of act_user_name & repo_user_name
+func ChangeUsernameInAction(id int64, newUserName string) error {
+	ac := Action{
+		RepoUserName: newUserName,
+		ActUserName:  newUserName,
+	}
+	_, err := x.
+		Cols("act_user_name", "repo_user_name").
+		Where("act_user_id = ?", id).
+		Update(ac)
+	log.Info("%v", err)
+	return err
+}

--- a/models/user.go
+++ b/models/user.go
@@ -824,6 +824,10 @@ func ChangeUserName(u *User, newUserName string) (err error) {
 		return fmt.Errorf("ChangeUsernameInPullRequests: %v", err)
 	}
 
+	if err = ChangeUsernameInAction(u.ID, newUserName); err != nil {
+		return fmt.Errorf("ChangeUsernameInAction: %v", err)
+	}
+
 	// Delete all local copies of repository wiki that user owns.
 	if err = x.
 		Where("owner_id=?", u.ID).


### PR DESCRIPTION
Action in Dashboard are renamed when the user is renamed. This fix #1730.