### PR TITLE
Backport bugfixes #1220 and #1393 to v1.1

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -360,7 +360,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit) err
 
 			issue, err := GetIssueByRef(ref)
 			if err != nil {
-				if IsErrIssueNotExist(err) {
+				if IsErrIssueNotExist(err) || err == errMissingIssueNumber {
 					continue
 				}
 				return err

--- a/models/action.go
+++ b/models/action.go
@@ -398,7 +398,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit) err
 
 			issue, err := GetIssueByRef(ref)
 			if err != nil {
-				if IsErrIssueNotExist(err) {
+				if IsErrIssueNotExist(err) || err == errMissingIssueNumber {
 					continue
 				}
 				return err
@@ -438,7 +438,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit) err
 
 			issue, err := GetIssueByRef(ref)
 			if err != nil {
-				if IsErrIssueNotExist(err) {
+				if IsErrIssueNotExist(err) || err == errMissingIssueNumber {
 					continue
 				}
 				return err


### PR DESCRIPTION
As requested by @lunny, I am backporting bugfixes #1220 and #1393 to v1.1. They fix the message "Error: No issue number specified" when pushing (bug #1111).