### PR TITLE
Rename RepoCreationNum -> MaxCreationLimit

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -211,8 +211,8 @@ func (u *User) HasForkedRepo(repoID int64) bool {
 	return has
 }
 
-// RepoCreationNum returns the number of repositories created by the user
-func (u *User) RepoCreationNum() int {
+// MaxCreationLimit returns the number of repositories a user is allowed to create
+func (u *User) MaxCreationLimit() int {
 	if u.MaxRepoCreation <= -1 {
 		return setting.Repository.MaxCreationLimit
 	}

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -89,7 +89,7 @@ func Create(ctx *context.Context) {
 func handleCreateError(ctx *context.Context, owner *models.User, err error, name string, tpl base.TplName, form interface{}) {
 	switch {
 	case models.IsErrReachLimitOfRepo(err):
-		ctx.RenderWithErr(ctx.Tr("repo.form.reach_limit_of_creation", owner.RepoCreationNum()), tpl, form)
+		ctx.RenderWithErr(ctx.Tr("repo.form.reach_limit_of_creation", owner.MaxCreationLimit()), tpl, form)
 	case models.IsErrRepoAlreadyExist(err):
 		ctx.Data["Err_RepoName"] = true
 		ctx.RenderWithErr(ctx.Tr("form.repo_name_been_taken"), tpl, form)


### PR DESCRIPTION
Old name sounds more like it will return number of created repositories when in fact it returns the number of repositories the user is allowed to create.