### PR TITLE
Delete repo redirects on repo deletion

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1650,6 +1650,7 @@ func DeleteRepository(uid, repoID int64) error {
 		&Collaboration{RepoID: repoID},
 		&PullRequest{BaseRepoID: repoID},
 		&RepoUnit{RepoID: repoID},
+		&RepoRedirect{RedirectRepoID: repoID},
 	); err != nil {
 		return fmt.Errorf("deleteBeans: %v", err)
 	}


### PR DESCRIPTION
Delete entries from `repo_redirect` table when a repo is deleted.

To the best of my knowledge, failing to delete stale repo redirects doesn't currently cause any bugs, but there's no reason not to delete them.