### PR TITLE
Only run coverage on merges/pushes to master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,8 +73,10 @@ pipeline:
   coverage:
     image: plugins/coverage
     server: https://coverage.gitea.io
+    commands:
+      - make test-coverage
     when:
-      event: [ push, tag, pull_request ]
+      event: [ push, tag ]
 
   docker:
     image: plugins/docker

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ integrations: build
 
 .PHONY: test
 test:
+	go test $(PACKAGES)
+
+.PHONY: test-coverage
+test-coverage:
 	for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
 
 .PHONY: test-vendor


### PR DESCRIPTION
Our CI builds are really slow (routinely over 40 minutes), and running the unit tests takes a large portion of the CI duration.

From running locally, it seems that running tests without coverage reports is much faster (~6x) than running with coverage reports (partly because they can be run in parallel, partly because shared code only needs to be compiled once). We don't really need coverage reports for commits/changes that aren't part of master, so only run a coverage report when changes are pushed/merged to master.

Changes the `make test` to only runs test (no coverage report), and adds the `make test-coverage` rule for generating a coverage report.

__NOTE__: needs signature for changes to `drone.yml`