### PR TITLE
Display commit status on landing page of repo

### DIFF
--- a/models/status.go
+++ b/models/status.go
@@ -126,6 +126,26 @@ func (status *CommitStatus) APIFormat() *api.Status {
 	return apiStatus
 }
 
+// CalcCommitStatus returns commit status state via some status
+func CalcCommitStatus(statuses []*CommitStatus) *CommitStatus {
+	var lastStatus *CommitStatus
+	var state CommitStatusState
+	for _, status := range statuses {
+		if status.State.IsWorseThan(state) {
+			state = status.State
+			lastStatus = status
+		}
+	}
+	if lastStatus == nil {
+		if len(statuses) > 0 {
+			lastStatus = statuses[len(statuses)-1]
+		} else {
+			lastStatus = &CommitStatus{}
+		}
+	}
+	return lastStatus
+}
+
 // GetCommitStatuses returns all statuses for a given commit.
 func GetCommitStatuses(repo *Repository, sha string, page int) ([]*CommitStatus, error) {
 	statuses := make([]*CommitStatus, 0, 10)
@@ -255,8 +275,7 @@ func NewCommitStatus(repo *Repository, creator *User, sha string, status *Commit
 
 // SignCommitWithStatuses represents a commit with validation of signature and status state.
 type SignCommitWithStatuses struct {
-	Statuses []*CommitStatus
-	State    CommitStatusState
+	Status *CommitStatus
 	*SignCommit
 }
 
@@ -265,25 +284,18 @@ func ParseCommitsWithStatus(oldCommits *list.List, repo *Repository) *list.List 
 	var (
 		newCommits = list.New()
 		e          = oldCommits.Front()
-		err        error
 	)
 
 	for e != nil {
 		c := e.Value.(SignCommit)
 		commit := SignCommitWithStatuses{
 			SignCommit: &c,
-			State:      "",
-			Statuses:   make([]*CommitStatus, 0),
 		}
-		commit.Statuses, err = GetLatestCommitStatus(repo, commit.ID.String(), 0)
+		statuses, err := GetLatestCommitStatus(repo, commit.ID.String(), 0)
 		if err != nil {
 			log.Error(3, "GetLatestCommitStatus: %v", err)
 		} else {
-			for _, status := range commit.Statuses {
-				if status.State.IsWorseThan(commit.State) {
-					commit.State = status.State
-				}
-			}
+			commit.Status = CalcCommitStatus(statuses)
 		}
 
 		newCommits.PushBack(commit)

--- a/models/status.go
+++ b/models/status.go
@@ -126,7 +126,7 @@ func (status *CommitStatus) APIFormat() *api.Status {
 	return apiStatus
 }
 
-// CalcCommitStatus returns commit status state via some status
+// CalcCommitStatus returns commit status state via some status, the commit statues should order by id desc
 func CalcCommitStatus(statuses []*CommitStatus) *CommitStatus {
 	var lastStatus *CommitStatus
 	var state CommitStatusState
@@ -138,7 +138,7 @@ func CalcCommitStatus(statuses []*CommitStatus) *CommitStatus {
 	}
 	if lastStatus == nil {
 		if len(statuses) > 0 {
-			lastStatus = statuses[len(statuses)-1]
+			lastStatus = statuses[0]
 		} else {
 			lastStatus = &CommitStatus{}
 		}

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -13,7 +13,9 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+
 	"github.com/Unknwon/paginater"
 )
 
@@ -208,6 +210,14 @@ func Diff(ctx *context.Context) {
 	if len(commitID) != 40 {
 		commitID = commit.ID.String()
 	}
+
+	statuses, err := models.GetLatestCommitStatus(ctx.Repo.Repository, ctx.Repo.Commit.ID.String(), 0)
+	if err != nil {
+		log.Error(3, "GetLatestCommitStatus: %v", err)
+	}
+
+	ctx.Data["CommitStatus"] = models.CalcCommitStatus(statuses)
+
 	diff, err := models.GetDiffCommit(models.RepoPath(userName, repoName),
 		commitID, setting.Git.MaxGitDiffLines,
 		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -120,21 +120,13 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 	ctx.Data["LatestCommit"] = latestCommit
 	ctx.Data["LatestCommitVerification"] = models.ParseCommitWithSignature(latestCommit)
 	ctx.Data["LatestCommitUser"] = models.ValidateCommitWithEmail(latestCommit)
-	commit := models.SignCommitWithStatuses{
-		State:    "",
-		Statuses: make([]*models.CommitStatus, 0),
-	}
-	commit.Statuses, err = models.GetLatestCommitStatus(ctx.Repo.Repository, ctx.Repo.Commit.ID.String(), 0)
+
+	statuses, err := models.GetLatestCommitStatus(ctx.Repo.Repository, ctx.Repo.Commit.ID.String(), 0)
 	if err != nil {
 		log.Error(3, "GetLatestCommitStatus: %v", err)
-	} else {
-		for _, status := range commit.Statuses {
-			if status.State.IsWorseThan(commit.State) {
-				commit.State = status.State
-			}
-		}
 	}
-	ctx.Data["LatestCommitStatus"] = commit.State
+
+	ctx.Data["LatestCommitStatus"] = models.CalcCommitStatus(statuses)
 
 	// Check permission to add or upload new file.
 	if ctx.Repo.IsWriter() && ctx.Repo.IsViewBranch {

--- a/templates/repo/commit_status.tmpl
+++ b/templates/repo/commit_status.tmpl
@@ -1,0 +1,15 @@
+{{if eq .State "pending"}}
+    <a href="{{.TargetURL}}" target=_blank><i class="commit-status circle icon yellow"></i></a>
+{{end}}
+{{if eq .State "success"}}
+    <a href="{{.TargetURL}}" target=_blank><i class="commit-status check icon green"></i></a>
+{{end}}
+{{if eq .State "error"}}
+    <a href="{{.TargetURL}}" target=_blank><i class="commit-status warning icon red"></i></a>
+{{end}}
+{{if eq .State "failure"}}
+    <a href="{{.TargetURL}}" target=_blank><i class="commit-status remove icon red"></i></a>
+{{end}}
+{{if eq .State "warning"}}
+    <a href="{{.TargetURL}}" target=_blank><i class="commit-status warning sign icon yellow"></i></a>
+{{end}}

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -61,21 +61,7 @@
 						</td>
 						<td class="message collapsing">
 							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}">{{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
-							{{if eq .State "pending"}}
-							<i class="commit-status circle icon yellow"></i>
-							{{end}}
-							{{if eq .State "success"}}
-							<i class="commit-status check icon green"></i>
-							{{end}}
-							{{if eq .State "error"}}
-							<i class="commit-status warning icon red"></i>
-							{{end}}
-							{{if eq .State "failure"}}
-							<i class="commit-status remove icon red"></i>
-							{{end}}
-							{{if eq .State "warning"}}
-							<i class="commit-status warning sign icon yellow"></i>
-							{{end}}
+							{{template "repo/commit_status" .Status}}
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
 					</tr>

--- a/templates/repo/diff/page.tmpl
+++ b/templates/repo/diff/page.tmpl
@@ -9,7 +9,7 @@
 				<a class="ui floated right blue tiny button" href="{{EscapePound .SourcePath}}">
 					{{.i18n.Tr "repo.diff.browse_source"}}
 				</a>
-				{{RenderCommitMessage true .Commit.Message $.RepoLink $.Repository.ComposeMetas}}
+				<h3>{{RenderCommitMessage false .Commit.Message $.RepoLink $.Repository.ComposeMetas}}{{template "repo/commit_status" .CommitStatus}}</h3>
 			</div>
 			<div class="ui attached info segment {{if .Commit.Signature}} isSigned {{if .Verification.Verified }} isVerified {{end}}{{end}}">
 				{{if .Author}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -26,6 +26,23 @@
 						{{end}}
 				</a>
 				<span class="grey has-emoji">{{RenderCommitMessage false .LatestCommit.Summary .RepoLink $.Repository.ComposeMetas}}</span>
+				{{if .LatestCommitStatus}}
+					{{if eq .LatestCommitStatus "pending"}}
+						<i class="commit-status circle icon yellow"></i>
+					{{end}}
+					{{if eq .LatestCommitStatus "success"}}
+						<i class="commit-status check icon green"></i>
+					{{end}}
+					{{if eq .LatestCommitStatus "error"}}
+						<i class="commit-status warning icon red"></i>
+					{{end}}
+					{{if eq .LatestCommitStatus "failure"}}
+						<i class="commit-status remove icon red"></i>
+					{{end}}
+					{{if eq .LatestCommitStatus "warning"}}
+						<i class="commit-status warning sign icon yellow"></i>
+					{{end}}
+				{{end}}
 			</th>
 			<th class="nine wide">
 			</th>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -25,24 +25,8 @@
 							</div>
 						{{end}}
 				</a>
-				<span class="grey has-emoji">{{RenderCommitMessage false .LatestCommit.Summary .RepoLink $.Repository.ComposeMetas}}</span>
-				{{if .LatestCommitStatus}}
-					{{if eq .LatestCommitStatus "pending"}}
-						<i class="commit-status circle icon yellow"></i>
-					{{end}}
-					{{if eq .LatestCommitStatus "success"}}
-						<i class="commit-status check icon green"></i>
-					{{end}}
-					{{if eq .LatestCommitStatus "error"}}
-						<i class="commit-status warning icon red"></i>
-					{{end}}
-					{{if eq .LatestCommitStatus "failure"}}
-						<i class="commit-status remove icon red"></i>
-					{{end}}
-					{{if eq .LatestCommitStatus "warning"}}
-						<i class="commit-status warning sign icon yellow"></i>
-					{{end}}
-				{{end}}
+				<span class="grey has-emoji">{{RenderCommitMessage false .LatestCommit.Summary .RepoLink $.Repository.ComposeMetas}}
+				{{template "repo/commit_status" .LatestCommitStatus}}</span>
 			</th>
 			<th class="nine wide">
 			</th>


### PR DESCRIPTION
This will implement a part of #996 and so #1029.

The modification of the ui will be like this:
![image](https://cloud.githubusercontent.com/assets/832617/26371155/2ef36532-3ffa-11e7-8ba9-a0e0b34b5398.png)

Status is now displayed.