### PR TITLE
Separate generate swagger + fix sed os specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,10 @@ generate-swagger:
 	@hash swagger > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/go-swagger/go-swagger/cmd/swagger; \
 	fi
-	swagger generate spec -o ./public/swagger.v1.json
-	sed -i "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ./public/swagger.v1.json
+	swagger generate spec -o ./public/swagger.v1.tmp
+	sed "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ./public/swagger.v1.tmp > ./public/swagger.v1.tmp2
+	sed "s;^          \".ref\": \"#/definitions/Repository\";          \"type\": \"object\";g" ./public/swagger.v1.tmp2 > ./public/swagger.v1.json
+	rm ./public/swagger.v1.tmp ./public/swagger.v1.tmp2
 
 .PHONY: errcheck
 errcheck:

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,15 @@ generate:
 	@hash go-bindata > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/jteeuwen/go-bindata/...; \
 	fi
+	go generate $(PACKAGES)
+
+.PHONY: generate-swagger
+generate-swagger:
 	@hash swagger > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/go-swagger/go-swagger/cmd/swagger; \
 	fi
-	go generate $(PACKAGES)
+	swagger generate spec -o ./public/swagger.v1.json
+	sed -i "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ./public/swagger.v1.json
 
 .PHONY: errcheck
 errcheck:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
 DIST := dist
 IMPORT := code.gitea.io/gitea
+
+SED_INPLACE := sed -i
+
+ifeq ($(OS), Windows_NT)
+	EXECUTABLE := gitea.exe
+else
+	EXECUTABLE := gitea
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		SED_INPLACE := sed -i ''
+	endif
+endif
+
 BINDATA := modules/{options,public,templates}/bindata.go
 STYLESHEETS := $(wildcard public/less/index.less public/less/_*.less)
 JAVASCRIPTS :=
@@ -66,11 +79,10 @@ generate-swagger:
 	@hash swagger > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go get -u github.com/go-swagger/go-swagger/cmd/swagger; \
 	fi
-	swagger generate spec -o ./public/swagger.v1.tmp
-	sed "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ./public/swagger.v1.tmp > ./public/swagger.v1.tmp2
-	sed "s;^          \".ref\": \"#/definitions/Repository\";          \"type\": \"object\";g" ./public/swagger.v1.tmp2 > ./public/swagger.v1.json
-	rm ./public/swagger.v1.tmp ./public/swagger.v1.tmp2
-
+	swagger generate spec -o ./public/swagger.v1.json
+	$(SED_INPLACE) "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ./public/swagger.v1.json
+	$(SED_INPLACE) "s;^          \".ref\": \"#/definitions/Repository\";          \"type\": \"object\";g" ./public/swagger.v1.json
+	
 .PHONY: errcheck
 errcheck:
 	@hash errcheck > /dev/null 2>&1; if [ $$? -ne 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ swagger-ui:
 	git clone --depth=10 -b v3.0.7 --single-branch https://github.com/swagger-api/swagger-ui.git /tmp/swagger-ui
 	mv /tmp/swagger-ui/dist public/assets/swagger-ui
 	rm -Rf /tmp/swagger-ui
-	sed -i "s;http://petstore.swagger.io/v2/swagger.json;../../swagger.v1.json;g" public/assets/swagger-ui/index.html
+	$(SED_INPLACE) "s;http://petstore.swagger.io/v2/swagger.json;../../swagger.v1.json;g" public/assets/swagger-ui/index.html
 
 .PHONY: assets
 assets: javascripts stylesheets

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//go:generate swagger generate spec -o ../../../public/swagger.v1.json
-//go:generate sed -i "s;\".ref\": \"#/definitions/GPGKey\";\"type\": \"object\";g" ../../../public/swagger.v1.json
-//go:generate sed -i "s;^          \".ref\": \"#/definitions/Repository\";          \"type\": \"object\";g" ../../../public/swagger.v1.json
-
 // Package v1 Gitea API.
 //
 // This provide API interface to communicate with this Gitea instance.


### PR DESCRIPTION
I suggest to remove generation of swagger file via `go generate` and make a separate make task.

Making it in go generate permit that any change in comments would update the docs but it add some overhead and seems to failed on CI build (maybe from change introduce in go-swagger ?). :-(

With this change, people redacting api docs would have to do `make generate-swagger` to rebuild the swagger.json file.

Related to : #1785 #1665