### PR TITLE
Give all units to owner team

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -156,6 +156,7 @@ func CreateOrganization(org, owner *User) (err error) {
 		Name:       ownerTeamName,
 		Authorize:  AccessModeOwner,
 		NumMembers: 1,
+		UnitTypes:  allRepUnitTypes,
 	}
 	if _, err = sess.Insert(t); err != nil {
 		return fmt.Errorf("insert owner team: %v", err)


### PR DESCRIPTION
Fixes a bug where the owner team for a newly-created organization was not given any units. With my changes, the owner team is now given all units.

Fixes #1797.