### PR TITLE
Fix invalid reference in feeds template

### DIFF
--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNoLoginViewIssues(t *testing.T) {
+	prepareTestEnv(t)
+
+	req, err := http.NewRequest("GET", "/user2/repo1/issues", nil)
+	assert.NoError(t, err)
+	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}
+
 func TestNoLoginViewIssue(t *testing.T) {
 	prepareTestEnv(t)
 

--- a/models/action.go
+++ b/models/action.go
@@ -142,6 +142,11 @@ func (a *Action) ShortActUserName() string {
 	return base.EllipsisString(a.GetActUserName(), 20)
 }
 
+func (a *Action) GetActAvatar() string {
+	a.loadActUser()
+	return a.ActUser.AvatarLink()
+}
+
 // GetRepoUserName returns the name of the action repository owner.
 func (a *Action) GetRepoUserName() string {
 	a.loadRepo()

--- a/models/action.go
+++ b/models/action.go
@@ -142,6 +142,7 @@ func (a *Action) ShortActUserName() string {
 	return base.EllipsisString(a.GetActUserName(), 20)
 }
 
+// GetActAvatar the action's user's avatar link
 func (a *Action) GetActAvatar() string {
 	a.loadActUser()
 	return a.ActUser.AvatarLink()

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -1,7 +1,7 @@
 {{range .Feeds}}
 	<div class="news">
 		<div class="ui left">
-			<img class="ui avatar image" src="{{.ActAvatar}}" alt="">
+			<img class="ui avatar image" src="{{.GetActAvatar}}" alt="">
 		</div>
 		<div class="ui grid">
 			<div class="ui fifteen wide column">


### PR DESCRIPTION
Fixes the following error on the dashboard page: (oversight on my part from #1779)

```
template: user/dashboard/feeds:4:39: executing "user/dashboard/feeds" at <.ActAvatar>: can't evaluate field ActAvatar in type *models.Action
```

see https://github.com/go-gitea/gitea/pull/1812#issuecomment-304227078
