### PR TITLE
Commitless repos should be bare

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -517,7 +517,7 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 	}
 
 	// Change repository bare status and update last updated time.
-	repo.IsBare = false
+	repo.IsBare = repo.IsBare && opts.Commits.Len <= 0
 	if err = UpdateRepository(repo, false); err != nil {
 		return fmt.Errorf("UpdateRepository: %v", err)
 	}

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -392,6 +392,10 @@ func RepoRef() macaron.Handler {
 				if err != nil {
 					ctx.Handle(500, "GetBranches", err)
 					return
+				} else if len(brs) == 0 {
+					err = fmt.Errorf("No branches in non-bare repository %s",
+						ctx.Repo.GitRepo.Path)
+					ctx.Handle(500, "GetBranches", err)
 				}
 				refName = brs[0]
 			}


### PR DESCRIPTION
Only mark a repo as bare if commits are pushed to it, as opposed to if only tags are pushed. Fixes https://github.com/go-gitea/gitea/issues/1706

Also add a sanity check to `RepoRef()` to avoid potential index-out-of-range error. As far as I can understand, every non-bare repo should have at least one branch, so `ctx.Repo.GitRepo.GetBranches()` should never actually return an empty slice, but unchecked indices make me nervous.