### PR TITLE
Fix pull request compare link

### DIFF
--- a/integrations/pull_compare_test.go
+++ b/integrations/pull_compare_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullCompare(t *testing.T) {
+	prepareTestEnv(t)
+
+	session := loginUser(t, "user2", "password")
+	req, err := http.NewRequest("GET", "/user2/repo1/pulls", nil)
+	assert.NoError(t, err)
+	resp := session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	htmlDoc, err := NewHtmlParser(resp.Body)
+	assert.NoError(t, err)
+	link, exists := htmlDoc.doc.Find(".navbar").Find(".ui.green.button").Attr("href")
+	assert.True(t, exists, "The template has changed")
+
+	req, err = http.NewRequest("GET", link, nil)
+	assert.NoError(t, err)
+	resp = session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/models/fixtures/repo_unit.yml
+++ b/models/fixtures/repo_unit.yml
@@ -17,6 +17,14 @@
 -
   id: 3
   repo_id: 1
+  type: 3
+  index: 0
+  config: "{}"
+  created_unix: 946684810
+
+-
+  id: 4
+  repo_id: 1
   type: 7
   index: 0
   config: "{}"

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,7 @@
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item">
-					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.Username}}:{{.BranchName}}">
+					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.SignedUser.Name}}:{{.BranchName}}">
 						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>


### PR DESCRIPTION
The link should be `parentOwner/parent/compare/master...childOwner:master` instead of `parentOwner/parent/compare/master...parentOwner:master`.

Without this fix, the owner of the child repo gets a 404 when they click on the compare-pull-request button on the parent repo's homepage.
