### PR TITLE
Fix PR template error

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -332,13 +332,11 @@ func RepoAssignment() macaron.Handler {
 		if ctx.Repo.IsWriter() || (ctx.IsSigned && ctx.User.HasForkedRepo(ctx.Repo.Repository.ID)) {
 			// Pull request is allowed if this is a fork repository
 			// and base repository accepts pull requests.
-			if repo.BaseRepo != nil {
-				if repo.BaseRepo.AllowsPulls() {
-					ctx.Data["BaseRepo"] = repo.BaseRepo
-					ctx.Repo.PullRequest.BaseRepo = repo.BaseRepo
-					ctx.Repo.PullRequest.Allowed = true
-					ctx.Repo.PullRequest.HeadInfo = ctx.Repo.Owner.Name + ":" + ctx.Repo.BranchName
-				}
+			if repo.BaseRepo != nil && repo.BaseRepo.AllowsPulls() {
+				ctx.Data["BaseRepo"] = repo.BaseRepo
+				ctx.Repo.PullRequest.BaseRepo = repo.BaseRepo
+				ctx.Repo.PullRequest.Allowed = true
+				ctx.Repo.PullRequest.HeadInfo = ctx.Repo.Owner.Name + ":" + ctx.Repo.BranchName
 			} else {
 				// Or, this is repository accepts pull requests between branches.
 				if repo.AllowsPulls() {


### PR DESCRIPTION
Fixes #1542. Ensures that `PullRequestCtx.BaseRepo` is populated when a fork's parent does not accept pull requests (since the fork should support intra-repo pull requests).

To reproduce the bug that this fixes, do the following:
1. Create a mirror repo (call it `repo1`)
2. Create a fork of `repo1` (call it `repo2`)
3. Create a fork of `repo2` (call it `repo3`)
4. Visit `/:username/repo2/pulls`, and you should get the error described in #1542.

If you follow the above steps with my changes, you should get no such error.