### PR TITLE
Use a better default MAX_GIT_DIFF_LINE_CHARACTERS

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -406,7 +406,7 @@ DISABLE_DIFF_HIGHLIGHT = false
 ; Max number of lines allowed of a single file in diff view
 MAX_GIT_DIFF_LINES = 1000
 ; Max number of characters of a line allowed in diff view
-MAX_GIT_DIFF_LINE_CHARACTERS = 500
+MAX_GIT_DIFF_LINE_CHARACTERS = 5000
 ; Max number of files shown in diff view
 MAX_GIT_DIFF_FILES = 100
 ; Arguments for command 'git gc', e.g. "--aggressive --auto"


### PR DESCRIPTION
Tests indicate that line length alone does not make browsers slow, so increase the default threshold after which diffs get surpressed for line length from 500 to a more reasonable 5000 characters.

Fixes: https://github.com/go-gitea/gitea/issues/1826