### PR TITLE
Fix user profile activity feed

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -306,10 +306,10 @@ func TestGetFeeds(t *testing.T) {
 	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 
 	actions, err := GetFeeds(GetFeedsOptions{
-		RequestedUser: user,
+		RequestedUser:    user,
 		RequestingUserID: user.ID,
-		IncludePrivate: true,
-		OnlyPerformedBy: false,
+		IncludePrivate:   true,
+		OnlyPerformedBy:  false,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
@@ -317,10 +317,10 @@ func TestGetFeeds(t *testing.T) {
 	assert.EqualValues(t, user.ID, actions[0].UserID)
 
 	actions, err = GetFeeds(GetFeedsOptions{
-		RequestedUser: user,
+		RequestedUser:    user,
 		RequestingUserID: user.ID,
-		IncludePrivate: false,
-		OnlyPerformedBy: false,
+		IncludePrivate:   false,
+		OnlyPerformedBy:  false,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
@@ -333,10 +333,10 @@ func TestGetFeeds2(t *testing.T) {
 	userID := AssertExistsAndLoadBean(t, &OrgUser{OrgID: org.ID, IsOwner: true}).(*OrgUser).UID
 
 	actions, err := GetFeeds(GetFeedsOptions{
-		RequestedUser: org,
+		RequestedUser:    org,
 		RequestingUserID: userID,
-		IncludePrivate: true,
-		OnlyPerformedBy: false,
+		IncludePrivate:   true,
+		OnlyPerformedBy:  false,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
@@ -344,10 +344,10 @@ func TestGetFeeds2(t *testing.T) {
 	assert.EqualValues(t, org.ID, actions[0].UserID)
 
 	actions, err = GetFeeds(GetFeedsOptions{
-		RequestedUser: org,
+		RequestedUser:    org,
 		RequestingUserID: userID,
-		IncludePrivate: false,
-		OnlyPerformedBy: false,
+		IncludePrivate:   false,
+		OnlyPerformedBy:  false,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)

--- a/models/action_test.go
+++ b/models/action_test.go
@@ -305,13 +305,23 @@ func TestGetFeeds(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 
-	actions, err := GetFeeds(user, user.ID, 0, false)
+	actions, err := GetFeeds(GetFeedsOptions{
+		RequestedUser: user,
+		RequestingUserID: user.ID,
+		IncludePrivate: true,
+		OnlyPerformedBy: false,
+	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
-	assert.Equal(t, int64(1), actions[0].ID)
-	assert.Equal(t, user.ID, actions[0].UserID)
+	assert.EqualValues(t, 1, actions[0].ID)
+	assert.EqualValues(t, user.ID, actions[0].UserID)
 
-	actions, err = GetFeeds(user, user.ID, 0, true)
+	actions, err = GetFeeds(GetFeedsOptions{
+		RequestedUser: user,
+		RequestingUserID: user.ID,
+		IncludePrivate: false,
+		OnlyPerformedBy: false,
+	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
 }
@@ -319,15 +329,26 @@ func TestGetFeeds(t *testing.T) {
 func TestGetFeeds2(t *testing.T) {
 	// test with an organization user
 	assert.NoError(t, PrepareTestDatabase())
-	user := AssertExistsAndLoadBean(t, &User{ID: 3}).(*User)
+	org := AssertExistsAndLoadBean(t, &User{ID: 3}).(*User)
+	userID := AssertExistsAndLoadBean(t, &OrgUser{OrgID: org.ID, IsOwner: true}).(*OrgUser).UID
 
-	actions, err := GetFeeds(user, user.ID, 0, false)
+	actions, err := GetFeeds(GetFeedsOptions{
+		RequestedUser: org,
+		RequestingUserID: userID,
+		IncludePrivate: true,
+		OnlyPerformedBy: false,
+	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
-	assert.Equal(t, int64(2), actions[0].ID)
-	assert.Equal(t, user.ID, actions[0].UserID)
+	assert.EqualValues(t, 2, actions[0].ID)
+	assert.EqualValues(t, org.ID, actions[0].UserID)
 
-	actions, err = GetFeeds(user, user.ID, 0, true)
+	actions, err = GetFeeds(GetFeedsOptions{
+		RequestedUser: org,
+		RequestingUserID: userID,
+		IncludePrivate: false,
+		OnlyPerformedBy: false,
+	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
 }

--- a/models/fixtures/action.yml
+++ b/models/fixtures/action.yml
@@ -10,7 +10,7 @@
   id: 2
   user_id: 3
   op_type: 2 # rename repo
-  act_user_id: 3
+  act_user_id: 2
   repo_id: 3
   is_private: true
   content: oldRepoName

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -138,7 +138,7 @@ func Profile(ctx *context.Context) {
 	ctx.Data["Keyword"] = keyword
 	switch tab {
 	case "activity":
-		retrieveFeeds(ctx, ctxUser, -1, 0, !showPrivate)
+		retrieveFeeds(ctx, ctxUser, showPrivate, true)
 		if ctx.Written() {
 			return
 		}


### PR DESCRIPTION
Fixes #1202.

Causes the activity feed on a user's profile page to only be actions performed by that user. The activity feed on the dashboard is unchanged, and still shows relevant actions performed by other users.
