### PR TITLE
Fix 404 for external tracking issues

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -965,6 +965,10 @@ func DeleteComment(ctx *context.Context) {
 
 // Milestones render milestones page
 func Milestones(ctx *context.Context) {
+	MustEnableIssues(ctx)
+	if ctx.Written() {
+		return
+	}
 	ctx.Data["Title"] = ctx.Tr("repo.milestones")
 	ctx.Data["PageIsIssueList"] = true
 	ctx.Data["PageIsMilestones"] = true

--- a/routers/repo/issue_label.go
+++ b/routers/repo/issue_label.go
@@ -18,6 +18,10 @@ const (
 
 // Labels render issue's labels page
 func Labels(ctx *context.Context) {
+	MustEnableIssues(ctx)
+	if ctx.Written() {
+		return
+	}
 	ctx.Data["Title"] = ctx.Tr("repo.labels")
 	ctx.Data["PageIsIssueList"] = true
 	ctx.Data["PageIsLabels"] = true

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -557,7 +557,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Get("/^:type(issues|pulls)$/:index", repo.ViewIssue)
 			m.Get("/labels/", repo.RetrieveLabels, repo.Labels)
 			m.Get("/milestones", repo.Milestones)
-		}, context.RepoRef(), context.CheckUnit(models.UnitTypeIssues))
+		}, context.RepoRef())
 
 		// m.Get("/branches", repo.Branches)
 		m.Post("/branches/:name/delete", reqSignIn, reqRepoWriter, repo.MustBeNotBare, repo.DeleteBranchPost)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -472,17 +472,17 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Post("/milestone", repo.UpdateIssueMilestone, reqRepoWriter)
 			m.Post("/assignee", repo.UpdateIssueAssignee, reqRepoWriter)
 			m.Post("/status", repo.UpdateIssueStatus, reqRepoWriter)
-		})
+		}, context.CheckUnit(models.UnitTypeIssues))
 		m.Group("/comments/:id", func() {
 			m.Post("", repo.UpdateCommentContent)
 			m.Post("/delete", repo.DeleteComment)
-		})
+		}, context.CheckUnit(models.UnitTypeIssues))
 		m.Group("/labels", func() {
 			m.Post("/new", bindIgnErr(auth.CreateLabelForm{}), repo.NewLabel)
 			m.Post("/edit", bindIgnErr(auth.CreateLabelForm{}), repo.UpdateLabel)
 			m.Post("/delete", repo.DeleteLabel)
 			m.Post("/initialize", bindIgnErr(auth.InitializeLabelsForm{}), repo.InitializeLabels)
-		}, reqRepoWriter, context.RepoRef())
+		}, reqRepoWriter, context.RepoRef(), context.CheckUnit(models.UnitTypeIssues))
 		m.Group("/milestones", func() {
 			m.Combo("/new").Get(repo.NewMilestone).
 				Post(bindIgnErr(auth.CreateMilestoneForm{}), repo.NewMilestonePost)
@@ -490,7 +490,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Post("/:id/edit", bindIgnErr(auth.CreateMilestoneForm{}), repo.EditMilestonePost)
 			m.Get("/:id/:action", repo.ChangeMilestonStatus)
 			m.Post("/delete", repo.DeleteMilestone)
-		}, reqRepoWriter, context.RepoRef())
+		}, reqRepoWriter, context.RepoRef(), context.CheckUnit(models.UnitTypeIssues))
+
 
 		m.Combo("/compare/*", repo.MustAllowPulls, repo.SetEditorconfigIfExists).
 			Get(repo.CompareAndPullRequest).
@@ -522,7 +523,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 				return
 			}
 		})
-	}, reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.LoadRepoUnits(), context.CheckUnit(models.UnitTypeIssues))
+	}, reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.LoadRepoUnits())
 
 	// Releases
 	m.Group("/:username/:reponame", func() {


### PR DESCRIPTION
Fixes #1847. Also causes `/:owner/:repo/labels` to `/:owner/:repo/milestones` to redirect to the external issue tracking URL (which was previously not the case).
