### PR TITLE
Display draft releases

### DIFF
--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -1,0 +1,22 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestViewReleases(t *testing.T) {
+	prepareTestEnv(t)
+
+	session := loginUser(t, "user2", "password")
+	req, err := http.NewRequest("GET", "/user2/repo1/releases", nil)
+	assert.NoError(t, err)
+	resp := session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/models/fixtures/repo_unit.yml
+++ b/models/fixtures/repo_unit.yml
@@ -25,6 +25,14 @@
 -
   id: 4
   repo_id: 1
+  type: 5
+  index: 0
+  config: "{}"
+  created_unix: 946684810
+
+-
+  id: 5
+  repo_id: 1
   type: 7
   index: 0
   config: "{}"

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -5,10 +5,8 @@
 package repo
 
 import (
-	"errors"
 	"fmt"
 
-	"code.gitea.io/git"
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/auth"
 	"code.gitea.io/gitea/modules/base"
@@ -67,35 +65,7 @@ func Releases(ctx *context.Context) {
 		limit = 10
 	}
 
-	rawTags, err := ctx.Repo.GitRepo.GetTagInfos(git.TagOption{})
-	if err != nil {
-		ctx.Handle(500, "GetTags", err)
-		return
-	}
-
-	if len(rawTags) == 0 {
-		ctx.HTML(200, tplReleases)
-		return
-	}
-
-	if len(rawTags) <= (page-1)*limit {
-		ctx.Handle(500, "Releases", errors.New("no more pages"))
-		return
-	}
-
-	var tags []*git.Tag
-	if page*limit > len(rawTags) {
-		tags = rawTags[(page-1)*limit:]
-	} else {
-		tags = rawTags[(page-1)*limit : page*limit]
-	}
-
-	var tagNames []string
-	for _, t := range tags {
-		tagNames = append(tagNames, t.Name)
-	}
-
-	releases, err := models.GetReleasesByRepoIDAndNames(ctx.Repo.Repository.ID, tagNames)
+	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
 	if err != nil {
 		ctx.Handle(500, "GetReleasesByRepoIDAndNames", err)
 		return
@@ -107,61 +77,39 @@ func Releases(ctx *context.Context) {
 		return
 	}
 
-	// Temproray cache commits count of used branches to speed up.
+	// Temporary cache commits count of used branches to speed up.
 	countCache := make(map[string]int64)
 	var cacheUsers = make(map[int64]*models.User)
 	var ok bool
-	releaseTags := make([]*models.Release, len(tags))
-	for i, rawTag := range tags {
-		for _, r := range releases {
-			if r.IsDraft && !ctx.Repo.IsOwner() {
-				continue
-			}
-			if r.TagName == rawTag.Name {
-				if r.Publisher, ok = cacheUsers[r.PublisherID]; !ok {
-					r.Publisher, err = models.GetUserByID(r.PublisherID)
-					if err != nil {
-						if models.IsErrUserNotExist(err) {
-							r.Publisher = models.NewGhostUser()
-						} else {
-							ctx.Handle(500, "GetUserByID", err)
-							return
-						}
-					}
-					cacheUsers[r.PublisherID] = r.Publisher
-				}
 
-				if err := calReleaseNumCommitsBehind(ctx.Repo, r, countCache); err != nil {
-					ctx.Handle(500, "calReleaseNumCommitsBehind", err)
+	releasesToDisplay := make([]*models.Release, 0, len(releases))
+	for _, r := range releases {
+		if r.IsDraft && !ctx.Repo.IsOwner() {
+			continue
+		}
+		if r.Publisher, ok = cacheUsers[r.PublisherID]; !ok {
+			r.Publisher, err = models.GetUserByID(r.PublisherID)
+			if err != nil {
+				if models.IsErrUserNotExist(err) {
+					r.Publisher = models.NewGhostUser()
+				} else {
+					ctx.Handle(500, "GetUserByID", err)
 					return
 				}
-
-				r.Note = markdown.RenderString(r.Note, ctx.Repo.RepoLink, ctx.Repo.Repository.ComposeMetas())
-				releaseTags[i] = r
-				break
 			}
+			cacheUsers[r.PublisherID] = r.Publisher
 		}
-
-		if releaseTags[i] == nil {
-			releaseTags[i] = &models.Release{
-				Title:   rawTag.Name,
-				TagName: rawTag.Name,
-				Sha1:    rawTag.Object.String(),
-				Note:    rawTag.Message,
-			}
-
-			releaseTags[i].NumCommits, err = git.CommitsCount(ctx.Repo.GitRepo.Path, rawTag.Object.String())
-			if err != nil {
-				ctx.Handle(500, "CommitsCount", err)
-				return
-			}
-			releaseTags[i].NumCommitsBehind = ctx.Repo.CommitsCount - releaseTags[i].NumCommits
+		if err := calReleaseNumCommitsBehind(ctx.Repo, r, countCache); err != nil {
+			ctx.Handle(500, "calReleaseNumCommitsBehind", err)
+			return
 		}
+		r.Note = markdown.RenderString(r.Note, ctx.Repo.RepoLink, ctx.Repo.Repository.ComposeMetas())
+		releasesToDisplay = append(releasesToDisplay, r)
 	}
 
-	pager := paginater.New(len(rawTags), limit, page, 5)
+	pager := paginater.New(len(releases), limit, page, 5)
 	ctx.Data["Page"] = pager
-	ctx.Data["Releases"] = releaseTags
+	ctx.Data["Releases"] = releasesToDisplay
 	ctx.HTML(200, tplReleases)
 }
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -79,7 +79,7 @@ func Releases(ctx *context.Context) {
 
 	// Temporary cache commits count of used branches to speed up.
 	countCache := make(map[string]int64)
-	var cacheUsers = make(map[int64]*models.User)
+	cacheUsers := map[int64]*models.User{ctx.User.ID: ctx.User}
 	var ok bool
 
 	releasesToDisplay := make([]*models.Release, 0, len(releases))


### PR DESCRIPTION
Fixes #1387. Previously, we only displayed releases whose tag name actually existed in the repository, which is why drafts did not show up.
