### PR TITLE
Delete Public SSH Key tmp file after calculating fingerprint

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -377,7 +377,6 @@ func calcFingerprint(publicKeyContent string) (string, error) {
 		return "", err
 	}
 	defer os.Remove(tmpPath)
-	
 	stdout, stderr, err := process.GetManager().Exec("AddPublicKey", "ssh-keygen", "-lf", tmpPath)
 	if err != nil {
 		return "", fmt.Errorf("'ssh-keygen -lf %s' failed with error '%s': %s", tmpPath, err, stderr)

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -376,13 +376,14 @@ func calcFingerprint(publicKeyContent string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer os.Remove(tmpPath)
+	
 	stdout, stderr, err := process.GetManager().Exec("AddPublicKey", "ssh-keygen", "-lf", tmpPath)
 	if err != nil {
 		return "", fmt.Errorf("'ssh-keygen -lf %s' failed with error '%s': %s", tmpPath, err, stderr)
 	} else if len(stdout) < 2 {
 		return "", errors.New("not enough output for calculating fingerprint: " + stdout)
 	}
-	os.Remove(tmpPath)
 	return strings.Split(stdout, " ")[1], nil
 }
 

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -382,7 +382,7 @@ func calcFingerprint(publicKeyContent string) (string, error) {
 	} else if len(stdout) < 2 {
 		return "", errors.New("not enough output for calculating fingerprint: " + stdout)
 	}
-	defer os.Remove(tmpPath)
+	os.Remove(tmpPath)
 	return strings.Split(stdout, " ")[1], nil
 }
 

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -373,6 +373,7 @@ func checkKeyFingerprint(e Engine, fingerprint string) error {
 func calcFingerprint(publicKeyContent string) (string, error) {
 	// Calculate fingerprint.
 	tmpPath, err := writeTmpKeyFile(publicKeyContent)
+	defer os.Remove(tmpPath)
 	if err != nil {
 		return "", err
 	}

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -373,7 +373,6 @@ func checkKeyFingerprint(e Engine, fingerprint string) error {
 func calcFingerprint(publicKeyContent string) (string, error) {
 	// Calculate fingerprint.
 	tmpPath, err := writeTmpKeyFile(publicKeyContent)
-	defer os.Remove(tmpPath)
 	if err != nil {
 		return "", err
 	}
@@ -383,6 +382,7 @@ func calcFingerprint(publicKeyContent string) (string, error) {
 	} else if len(stdout) < 2 {
 		return "", errors.New("not enough output for calculating fingerprint: " + stdout)
 	}
+	defer os.Remove(tmpPath)
 	return strings.Split(stdout, " ")[1], nil
 }
 


### PR DESCRIPTION
When using LDAP User Synchronization (#1478) with LDAP Public SSH Keys synchronization (#1844), the public key fingerprint calculation might be running with a quite high frequency.

As the tmp-files for calculating public key fingerprint is not deleted, the system could end up with lots of public tmp files causing inode issue and running out of disk space.

This PR addresses this issue by cleaning up the tmp file after the fingerprint has been calculated.