### PR TITLE
Support CRLF when splitting code lines for display

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1435,7 +1435,7 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view .lines-code ol li,
 .repository.file.list #file-content .code-view .lines-num .hljs li,
 .repository.file.list #file-content .code-view .lines-code .hljs li {
-  display: inline-block;
+  display: block;
   width: 100%;
 }
 .repository.file.list #file-content .code-view .lines-num pre li.active,

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -296,7 +296,7 @@
 						margin: 0;
 						padding: 0 !important;
 						li {
-							display: inline-block;
+							display: block;
 							width: 100%;
 							&.active {
 								background: #ffffdd;

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -213,11 +213,13 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			var output bytes.Buffer
 			var terminator string
 
-			// test for bare linefeeds in case of mixed terminators
-			lf, _ := regexp.MatchString("[^\r]\n", str)
-
-			if strings.Index(fileContent, "\r\n") != -1 && !lf {
-				terminator = "\r\n"
+			if strings.Index(fileContent, "\r\n") != -1 {
+				lf, _ := regexp.MatchString("[^\r]\n", fileContent)
+				if lf {
+					terminator = "\n"
+				} else {
+					terminator = "\r\n"
+				}
 			} else {
 				terminator = "\n"
 			}
@@ -230,7 +232,6 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 				}
 				output.WriteString(fmt.Sprintf(`<li class="L%d" rel="L%d">%s</li>`, index+1, index+1, line))
 			}
-
 			ctx.Data["FileContent"] = gotemplate.HTML(output.String())
 
 			output.Reset()

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -11,7 +11,6 @@ import (
 	gotemplate "html/template"
 	"io/ioutil"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -211,24 +210,11 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			}
 
 			var output bytes.Buffer
-			var terminator string
-
-			if strings.Index(fileContent, "\r\n") != -1 {
-				lf, _ := regexp.MatchString(`[^\r]\n`, fileContent)
-				if lf {
-					terminator = "\n"
-				} else {
-					terminator = "\r\n"
-				}
-			} else {
-				terminator = "\n"
-			}
-			lines := regexp.MustCompile(`\r?\n`).Split(fileContent, -1)
-
+			lines := strings.Split(fileContent, "\n")
 			for index, line := range lines {
 				line = gotemplate.HTMLEscapeString(line)
 				if index != len(lines)-1 {
-					line += terminator
+					line += "\n"
 				}
 				output.WriteString(fmt.Sprintf(`<li class="L%d" rel="L%d">%s</li>`, index+1, index+1, line))
 			}

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -214,7 +214,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			var terminator string
 
 			if strings.Index(fileContent, "\r\n") != -1 {
-				lf, _ := regexp.MatchString("[^\r]\n", fileContent)
+				lf, _ := regexp.MatchString(`[^\r]\n`, fileContent)
 				if lf {
 					terminator = "\n"
 				} else {
@@ -223,7 +223,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			} else {
 				terminator = "\n"
 			}
-			lines := strings.Split(fileContent, terminator)
+			lines := regexp.MustCompile(`\r?\n`).Split(fileContent, -1)
 
 			for index, line := range lines {
 				line = gotemplate.HTMLEscapeString(line)

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -227,7 +227,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 
 			for index, line := range lines {
 				line = gotemplate.HTMLEscapeString(line)
-				if index != len(lines) - 1 {
+				if index != len(lines)-1 {
 					line += terminator
 				}
 				output.WriteString(fmt.Sprintf(`<li class="L%d" rel="L%d">%s</li>`, index+1, index+1, line))


### PR DESCRIPTION
This removes the whitspace between `<li>` elements and adds them to the tag content, where it was originally removed. `display:block` because with the previous `display:inline-block` it would all end up on one line.

Fixes: https://github.com/go-gitea/gitea/issues/1857