### PR TITLE
Require token before checking membership/ownership

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -453,19 +453,19 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/users/:username/orgs", org.ListUserOrgs)
 		m.Group("/orgs/:orgname", func() {
 			m.Combo("").Get(org.Get).
-				Patch(reqOrgOwnership(), bind(api.EditOrgOption{}), org.Edit)
+				Patch(reqToken(), reqOrgOwnership(), bind(api.EditOrgOption{}), org.Edit)
 			m.Group("/members", func() {
 				m.Get("", org.ListMembers)
 				m.Combo("/:username").Get(org.IsMember).
-					Delete(reqOrgOwnership(), org.DeleteMember)
+					Delete(reqToken(), reqOrgOwnership(), org.DeleteMember)
 			})
 			m.Group("/public_members", func() {
 				m.Get("", org.ListPublicMembers)
 				m.Combo("/:username").Get(org.IsPublicMember).
-					Put(reqOrgMembership(), org.PublicizeMember).
-					Delete(reqOrgMembership(), org.ConcealMember)
+					Put(reqToken(), reqOrgMembership(), org.PublicizeMember).
+					Delete(reqToken(), reqOrgMembership(), org.ConcealMember)
 			})
-			m.Combo("/teams", reqOrgMembership()).Get(org.ListTeams).
+			m.Combo("/teams", reqToken(), reqOrgMembership()).Get(org.ListTeams).
 				Post(bind(api.CreateTeamOption{}), org.CreateTeam)
 			m.Group("/hooks", func() {
 				m.Combo("").Get(org.ListHooks).
@@ -473,7 +473,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 				m.Combo("/:id").Get(org.GetHook).
 					Patch(reqOrgOwnership(), bind(api.EditHookOption{}), org.EditHook).
 					Delete(reqOrgOwnership(), org.DeleteHook)
-			}, reqOrgMembership())
+			}, reqToken(), reqOrgMembership())
 		}, orgAssignment(true))
 		m.Group("/teams/:teamid", func() {
 			m.Combo("").Get(org.GetTeam).
@@ -491,7 +491,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 					Put(org.AddTeamRepository).
 					Delete(org.RemoveTeamRepository)
 			})
-		}, orgAssignment(false, true), reqOrgMembership())
+		}, orgAssignment(false, true), reqToken(), reqOrgMembership())
 
 		m.Any("/*", func(ctx *context.Context) {
 			ctx.Error(404)


### PR DESCRIPTION
Call the `reqToken()` handler before calling the `reqOrgMembership()` or `reqOrgOwnership()` handlers. Failing to do so results in a 500 for unauthenticated users (see error from #1899)
