### PR TITLE
Set TMPDIR enviroment variable for dump command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -74,6 +74,11 @@ func runDump(ctx *cli.Context) error {
 	}
 	log.Printf("Creating tmp work dir: %s", TmpWorkDir)
 
+	// work-around #1103
+	if os.Getenv("TMPDIR") == "" {
+		os.Setenv("TMPDIR", TmpWorkDir)
+	}
+
 	reposDump := path.Join(TmpWorkDir, "gitea-repo.zip")
 	dbDump := path.Join(TmpWorkDir, "gitea-db.sql")
 


### PR DESCRIPTION
Work-around for cae/zip-library using /tmp directory (which could be inaccesible or to small). 

Fixes #1103 and #1878 

Ref: https://golang.org/src/os/file_unix.go?s=7617:7638#L255
https://github.com/Unknwon/cae/blob/master/zip/write.go#L169