### PR TITLE
No highlighting for .txt files

### DIFF
--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -63,7 +63,9 @@ var (
 	}
 
 	// Extensions that are not same as highlight classes.
-	highlightMapping = map[string]string{}
+	highlightMapping = map[string]string{
+		".txt": "nohighlight",
+	}
 )
 
 // NewContext loads highlight map


### PR DESCRIPTION
Before (https://try.gitea.io/ethantkoenig/sandbox/src/master/text.txt):

![image](https://user-images.githubusercontent.com/8990880/26988043-d6cdd5d4-4d1b-11e7-9047-be75966ca4fe.png)

After:

![image](https://user-images.githubusercontent.com/8990880/26988099-fed930dc-4d1b-11e7-9f55-e709e4c50f0e.png)


