### PR TITLE
Display URLs in integration test logs

### DIFF
--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -16,8 +16,7 @@ import (
 func TestAPIUserReposNotLogin(t *testing.T) {
 	assert.NoError(t, models.LoadFixtures())
 
-	req, err := http.NewRequest("GET", "/api/v1/users/user2/repos", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/api/v1/users/user2/repos")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
@@ -25,8 +24,7 @@ func TestAPIUserReposNotLogin(t *testing.T) {
 func TestAPISearchRepoNotLogin(t *testing.T) {
 	assert.NoError(t, models.LoadFixtures())
 
-	req, err := http.NewRequest("GET", "/api/v1/repos/search?q=Test", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/api/v1/repos/search?q=Test")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -25,8 +25,7 @@ func TestAPITeam(t *testing.T) {
 
 	session := loginUser(t, user.Name, "password")
 	url := fmt.Sprintf("/api/v1/teams/%d", teamUser.TeamID)
-	req, err := http.NewRequest("GET", url, nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", url)
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/delete_user_test.go
+++ b/integrations/delete_user_test.go
@@ -20,18 +20,16 @@ func TestDeleteUser(t *testing.T) {
 
 	session := loginUser(t, "user1", "password")
 
-	req, err := http.NewRequest("GET", "/admin/users/8", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/admin/users/8")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
 	doc, err := NewHtmlParser(resp.Body)
 	assert.NoError(t, err)
-	req, err = http.NewRequest("POST", "/admin/users/8/delete",
+	req = NewRequestBody(t, "POST", "/admin/users/8/delete",
 		bytes.NewBufferString(url.Values{
 			"_csrf": []string{doc.GetInputValueByName("_csrf")},
 		}.Encode()))
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)

--- a/integrations/editor_test.go
+++ b/integrations/editor_test.go
@@ -20,8 +20,7 @@ func TestCreateFile(t *testing.T) {
 	session := loginUser(t, "user2", "password")
 
 	// Request editor page
-	req, err := http.NewRequest("GET", "/user2/repo1/_new/master/", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/_new/master/")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -31,7 +30,7 @@ func TestCreateFile(t *testing.T) {
 	assert.NotEmpty(t, lastCommit)
 
 	// Save new file to master branch
-	req, err = http.NewRequest("POST", "/user2/repo1/_new/master/",
+	req = NewRequestBody(t, "POST", "/user2/repo1/_new/master/",
 		bytes.NewBufferString(url.Values{
 			"_csrf":         []string{doc.GetInputValueByName("_csrf")},
 			"last_commit":   []string{lastCommit},
@@ -40,7 +39,6 @@ func TestCreateFile(t *testing.T) {
 			"commit_choice": []string{"direct"},
 		}.Encode()),
 	)
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
@@ -52,8 +50,7 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 	session := loginUser(t, "user2", "password")
 
 	// Open repository branch settings
-	req, err := http.NewRequest("GET", "/user2/repo1/settings/branches", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/settings/branches")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -61,7 +58,7 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Change master branch to protected
-	req, err = http.NewRequest("POST", "/user2/repo1/settings/branches?action=protected_branch",
+	req = NewRequestBody(t, "POST", "/user2/repo1/settings/branches?action=protected_branch",
 		bytes.NewBufferString(url.Values{
 			"_csrf":      []string{doc.GetInputValueByName("_csrf")},
 			"branchName": []string{"master"},
@@ -78,8 +75,7 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 	assert.EqualValues(t, flashCookie.Value, "success%3Dmaster%2BLocked%2Bsuccessfully")
 
 	// Request editor page
-	req, err = http.NewRequest("GET", "/user2/repo1/_new/master/", nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", "/user2/repo1/_new/master/")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -89,7 +85,7 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 	assert.NotEmpty(t, lastCommit)
 
 	// Save new file to master branch
-	req, err = http.NewRequest("POST", "/user2/repo1/_new/master/",
+	req = NewRequestBody(t, "POST", "/user2/repo1/_new/master/",
 		bytes.NewBufferString(url.Values{
 			"_csrf":         []string{doc.GetInputValueByName("_csrf")},
 			"last_commit":   []string{lastCommit},
@@ -98,7 +94,6 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 			"commit_choice": []string{"direct"},
 		}.Encode()),
 	)
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
@@ -111,8 +106,7 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 	newContent := "Hello, World (Edited)\n"
 
 	// Get to the 'edit this file' page
-	req, err := http.NewRequest("GET", path.Join(user, repo, "_edit", branch, filePath), nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", path.Join(user, repo, "_edit", branch, filePath))
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -122,7 +116,7 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 	assert.NotEmpty(t, lastCommit)
 
 	// Submit the edits
-	req, err = http.NewRequest("POST", path.Join(user, repo, "_edit", branch, filePath),
+	req = NewRequestBody(t, "POST", path.Join(user, repo, "_edit", branch, filePath),
 		bytes.NewBufferString(url.Values{
 			"_csrf":         []string{htmlDoc.GetInputValueByName("_csrf")},
 			"last_commit":   []string{lastCommit},
@@ -131,14 +125,12 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 			"commit_choice": []string{"direct"},
 		}.Encode()),
 	)
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
 	// Verify the change
-	req, err = http.NewRequest("GET", path.Join(user, repo, "raw", branch, filePath), nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", path.Join(user, repo, "raw", branch, filePath))
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 	assert.EqualValues(t, newContent, string(resp.Body))

--- a/integrations/internal_test.go
+++ b/integrations/internal_test.go
@@ -19,11 +19,10 @@ import (
 
 func assertProtectedBranch(t *testing.T, repoID int64, branchName string, isErr, canPush bool) {
 	reqURL := fmt.Sprintf("/api/internal/branch/%d/%s", repoID, url.QueryEscape(branchName))
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req := NewRequest(t, "GET", reqURL)
 	t.Log(reqURL)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", setting.InternalToken))
 
-	assert.NoError(t, err)
 	resp := MakeRequest(req)
 	if isErr {
 		assert.EqualValues(t, 500, resp.HeaderCode)

--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -14,8 +14,7 @@ import (
 func TestNoLoginViewIssues(t *testing.T) {
 	prepareTestEnv(t)
 
-	req, err := http.NewRequest("GET", "/user2/repo1/issues", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/issues")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
@@ -23,8 +22,7 @@ func TestNoLoginViewIssues(t *testing.T) {
 func TestNoLoginViewIssue(t *testing.T) {
 	prepareTestEnv(t)
 
-	req, err := http.NewRequest("GET", "/user2/repo1/issues/1", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/issues/1")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/pull_compare_test.go
+++ b/integrations/pull_compare_test.go
@@ -15,8 +15,7 @@ func TestPullCompare(t *testing.T) {
 	prepareTestEnv(t)
 
 	session := loginUser(t, "user2", "password")
-	req, err := http.NewRequest("GET", "/user2/repo1/pulls", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/pulls")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 	htmlDoc, err := NewHtmlParser(resp.Body)
@@ -24,8 +23,7 @@ func TestPullCompare(t *testing.T) {
 	link, exists := htmlDoc.doc.Find(".navbar").Find(".ui.green.button").Attr("href")
 	assert.True(t, exists, "The template has changed")
 
-	req, err = http.NewRequest("GET", link, nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", link)
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -15,8 +15,7 @@ func TestViewReleases(t *testing.T) {
 	prepareTestEnv(t)
 
 	session := loginUser(t, "user2", "password")
-	req, err := http.NewRequest("GET", "/user2/repo1/releases", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/releases")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/repo_commits_test.go
+++ b/integrations/repo_commits_test.go
@@ -19,8 +19,7 @@ func TestRepoCommits(t *testing.T) {
 	session := loginUser(t, "user2", "password")
 
 	// Request repository commits page
-	req, err := http.NewRequest("GET", "/user2/repo1/commits/master", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -37,8 +36,7 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 	session := loginUser(t, "user2", "password")
 
 	// Request repository commits page
-	req, err := http.NewRequest("GET", "/user2/repo1/commits/master", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -50,16 +48,14 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 	assert.NotEmpty(t, commitURL)
 
 	// Call API to add status for commit
-	req, err = http.NewRequest("POST", "/api/v1/repos/user2/repo1/statuses/"+path.Base(commitURL),
+	req = NewRequestBody(t, "POST", "/api/v1/repos/user2/repo1/statuses/"+path.Base(commitURL),
 		bytes.NewBufferString("{\"state\":\""+state+"\", \"target_url\": \"http://test.ci/\", \"description\": \"\", \"context\": \"testci\"}"))
 
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/json")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusCreated, resp.HeaderCode)
 
-	req, err = http.NewRequest("GET", "/user2/repo1/commits/master", nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", "/user2/repo1/commits/master")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/repo_fork_test.go
+++ b/integrations/repo_fork_test.go
@@ -15,14 +15,12 @@ import (
 
 func testRepoFork(t *testing.T, session *TestSession) {
 	// Step0: check the existence of the to-fork repo
-	req, err := http.NewRequest("GET", "/user1/repo1", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user1/repo1")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
 
 	// Step1: go to the main page of repo
-	req, err = http.NewRequest("GET", "/user2/repo1", nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", "/user2/repo1")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -31,8 +29,7 @@ func testRepoFork(t *testing.T, session *TestSession) {
 	assert.NoError(t, err)
 	link, exists := htmlDoc.doc.Find("a.ui.button[href^=\"/repo/fork/\"]").Attr("href")
 	assert.True(t, exists, "The template has changed")
-	req, err = http.NewRequest("GET", link, nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", link)
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
@@ -41,21 +38,19 @@ func testRepoFork(t *testing.T, session *TestSession) {
 	assert.NoError(t, err)
 	link, exists = htmlDoc.doc.Find("form.ui.form[action^=\"/repo/fork/\"]").Attr("action")
 	assert.True(t, exists, "The template has changed")
-	req, err = http.NewRequest("POST", link,
+	req = NewRequestBody(t, "POST", link,
 		bytes.NewBufferString(url.Values{
 			"_csrf":     []string{htmlDoc.GetInputValueByName("_csrf")},
 			"uid":       []string{"1"},
 			"repo_name": []string{"repo1"},
 		}.Encode()),
 	)
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
 	// Step4: check the existence of the forked repo
-	req, err = http.NewRequest("GET", "/user1/repo1", nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", "/user1/repo1")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -14,8 +14,7 @@ import (
 func TestViewRepo(t *testing.T) {
 	prepareTestEnv(t)
 
-	req, err := http.NewRequest("GET", "/user2/repo1", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2/repo1")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/signup_test.go
+++ b/integrations/signup_test.go
@@ -20,7 +20,7 @@ func TestSignup(t *testing.T) {
 
 	setting.Service.EnableCaptcha = false
 
-	req, err := http.NewRequest("POST", "/user/sign_up",
+	req := NewRequestBody(t, "POST", "/user/sign_up",
 		bytes.NewBufferString(url.Values{
 			"user_name": []string{"exampleUser"},
 			"email":     []string{"exampleUser@example.com"},
@@ -28,14 +28,12 @@ func TestSignup(t *testing.T) {
 			"retype":    []string{"examplePassword"},
 		}.Encode()),
 	)
-	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
 	// should be able to view new user's page
-	req, err = http.NewRequest("GET", "/exampleUser", nil)
-	assert.NoError(t, err)
+	req = NewRequest(t, "GET", "/exampleUser")
 	resp = MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -14,8 +14,7 @@ import (
 func TestViewUser(t *testing.T) {
 	prepareTestEnv(t)
 
-	req, err := http.NewRequest("GET", "/user2", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/user2")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/version_test.go
+++ b/integrations/version_test.go
@@ -20,8 +20,7 @@ func TestVersion(t *testing.T) {
 	prepareTestEnv(t)
 
 	setting.AppVer = "1.1.0+dev"
-	req, err := http.NewRequest("GET", "/api/v1/version", nil)
-	assert.NoError(t, err)
+	req := NewRequest(t, "GET", "/api/v1/version")
 	resp := MakeRequest(req)
 
 	var version gitea.ServerVersion


### PR DESCRIPTION
Before:
```
[Macaron] 2017-06-09 15:56:01: Started POST  for 
[Macaron] 2017-06-09 15:56:01: Completed  302 Found in 43.305422ms
```

After:
```
[Macaron] 2017-06-09 15:56:01: Started POST /user/login for 
[Macaron] 2017-06-09 15:56:01: Completed /user/login 302 Found in 43.305422ms
```

Will help in debugging, such as figuring out what caused https://drone.gitea.io/go-gitea/gitea/3457 to fail