### PR TITLE
Add an option to allow redirect of http port 80 to https.

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -52,7 +52,7 @@ and it takes care of all the other things for you`,
 }
 
 func runHTTPRedirector() {
-	source := setting.HTTPAddr + ":80"
+	source := fmt.Sprintf("%s:%s", setting.HTTPAddr, setting.PortToRedirect)
 	dest := strings.TrimSuffix(setting.AppURL, "/")
 	log.Info("Redirecting: %s to %s", source, dest)
 
@@ -67,7 +67,7 @@ func runHTTPRedirector() {
 	var err = runHTTP(source, context2.ClearHandler(handler))
 
 	if err != nil {
-		log.Fatal(4, "Failed to start port 80 redirector: %v", err)
+		log.Fatal(4, "Failed to start port redirection: %v", err)
 	}
 }
 
@@ -144,7 +144,7 @@ func runWeb(ctx *cli.Context) error {
 	case setting.HTTP:
 		err = runHTTP(listenAddr, context2.ClearHandler(m))
 	case setting.HTTPS:
-		if setting.RedirectPort80 {
+		if setting.RedirectOtherPort {
 			go runHTTPRedirector()
 		}
 		err = runHTTPS(listenAddr, setting.CertFile, setting.KeyFile, context2.ClearHandler(m))

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -107,9 +107,12 @@ ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
 ; Listen address. Either a IPv4/IPv6 address or the path to a unix socket.
 HTTP_ADDR = 0.0.0.0
 HTTP_PORT = 3000
-; If true, and PROTOCOL is set to https, http requests on port 80 will be
-; redirected to ROOT_URL. Default is false.
-REDIRECT_PORT_80 = false
+; If REDIRECT_OTHER_PORT is true, and PROTOCOL is set to https an http server
+; will be started on PORT_TO_REDIRECT and redirect request to the main
+; ROOT_URL.  Defaults are false for REDIRECT_OTHER_PORT and 80 for
+; PORT_TO_REDIRECT.
+REDIRECT_OTHER_PORT = false
+PORT_TO_REDIRECT = 80
 ; Permission for unix socket
 UNIX_SOCKET_PERMISSION = 666
 ; Local (DMZ) URL for Gitea workers (such as SSH update) accessing web service.

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -107,6 +107,9 @@ ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
 ; Listen address. Either a IPv4/IPv6 address or the path to a unix socket.
 HTTP_ADDR = 0.0.0.0
 HTTP_PORT = 3000
+; If true, and PROTOCOL is set to https, http requests on port 80 will be
+; redirected to ROOT_URL. Default is false.
+REDIRECT_PORT_80 = false
 ; Permission for unix socket
 UNIX_SOCKET_PERMISSION = 666
 ; Local (DMZ) URL for Gitea workers (such as SSH update) accessing web service.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -89,7 +89,8 @@ var (
 	HTTPAddr             string
 	HTTPPort             string
 	LocalURL             string
-	RedirectPort80       bool
+	RedirectOtherPort    bool
+	PortToRedirect       string
 	OfflineMode          bool
 	DisableRouterLog     bool
 	CertFile             string
@@ -733,7 +734,8 @@ func NewContext() {
 		defaultLocalURL += ":" + HTTPPort + "/"
 	}
 	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(defaultLocalURL)
-	RedirectPort80 = sec.Key("REDIRECT_PORT_80").MustBool(false)
+	RedirectOtherPort = sec.Key("REDIRECT_OTHER_PORT").MustBool(false)
+	PortToRedirect = sec.Key("PORT_TO_REDIRECT").MustString("80")
 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(AppWorkPath)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -89,6 +89,7 @@ var (
 	HTTPAddr             string
 	HTTPPort             string
 	LocalURL             string
+	RedirectPort80       bool
 	OfflineMode          bool
 	DisableRouterLog     bool
 	CertFile             string
@@ -732,6 +733,7 @@ func NewContext() {
 		defaultLocalURL += ":" + HTTPPort + "/"
 	}
 	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(defaultLocalURL)
+	RedirectPort80 = sec.Key("REDIRECT_PORT_80").MustBool(false)
 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(AppWorkPath)


### PR DESCRIPTION
This is an "opt in" option (default is to not redirect).  It will only redirect
if protocol is https and the new REDIRECT_PORT_80 option is set to true.

Signed-off-by: Mike Fellows <mike.fellows@shaw.ca>

This will resolve https://github.com/go-gitea/gitea/issues/1720