### PR TITLE
Gracefully handle bare repositories on API operations.

### DIFF
--- a/models/repo_branch.go
+++ b/models/repo_branch.go
@@ -39,7 +39,7 @@ func GetBranchesByPath(path string) ([]*Branch, error) {
 // GetBranch returns a branch by it's name
 func (repo *Repository) GetBranch(branch string) (*Branch, error) {
 	if !git.IsBranchExist(repo.RepoPath(), branch) {
-		return nil, &ErrBranchNotExist{branch}
+		return nil, ErrBranchNotExist{branch}
 	}
 	return &Branch{
 		Path: repo.RepoPath(),

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -7,6 +7,7 @@ package repo
 import (
 	api "code.gitea.io/sdk/gitea"
 
+	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/routers/api/v1/convert"
 )
@@ -16,7 +17,11 @@ import (
 func GetBranch(ctx *context.APIContext) {
 	branch, err := ctx.Repo.Repository.GetBranch(ctx.Params(":branchname"))
 	if err != nil {
-		ctx.Error(500, "GetBranch", err)
+		if models.IsErrBranchNotExist(err) {
+			ctx.Error(404, "GetBranch", err)
+		} else {
+			ctx.Error(500, "GetBranch", err)
+		}
 		return
 	}
 

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -20,6 +20,11 @@ func GetRawFile(ctx *context.APIContext) {
 		return
 	}
 
+	if ctx.Repo.Repository.IsBare {
+		ctx.Status(404)
+		return
+	}
+
 	blob, err := ctx.Repo.Commit.GetBlobByPath(ctx.Repo.TreePath)
 	if err != nil {
 		if git.IsErrNotExist(err) {


### PR DESCRIPTION
This pull request places safety checks in front of API operations against potential bare repositories. Previously those operations resulted in internal server errors as a consequence of non zero exit codes by the git module or thrown exceptions.

This is based upon the now merged PR go-gitea/git#39 to the git module which was vendored to the gitea master branch in #1824.

This change was also already partly applied to gogs in gogits/gogs#3996.