### PR TITLE
Fix deleted milestone bug

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -231,9 +231,7 @@ func (c *Comment) LoadMilestone() error {
 		has, err := x.ID(c.OldMilestoneID).Get(oldMilestone)
 		if err != nil {
 			return err
-		} else if !has {
-			c.OldMilestone = NewGhostMilestone()
-		} else {
+		} else if has {
 			c.OldMilestone = &oldMilestone
 		}
 	}
@@ -243,9 +241,7 @@ func (c *Comment) LoadMilestone() error {
 		has, err := x.ID(c.MilestoneID).Get(&milestone)
 		if err != nil {
 			return err
-		} else if !has {
-			c.Milestone = NewGhostMilestone()
-		} else {
+		} else if has {
 			c.Milestone = &milestone
 		}
 	}

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -228,15 +228,14 @@ func (c *Comment) LoadLabel() error {
 func (c *Comment) LoadMilestone() error {
 	if c.OldMilestoneID > 0 {
 		var oldMilestone Milestone
-		has, err := x.ID(c.OldMilestoneID).Get(&oldMilestone)
+		has, err := x.ID(c.OldMilestoneID).Get(oldMilestone)
 		if err != nil {
 			return err
 		} else if !has {
-			return ErrMilestoneNotExist{
-				ID: c.OldMilestoneID,
-			}
+			c.OldMilestone = NewGhostMilestone()
+		} else {
+			c.OldMilestone = &oldMilestone
 		}
-		c.OldMilestone = &oldMilestone
 	}
 
 	if c.MilestoneID > 0 {
@@ -245,11 +244,10 @@ func (c *Comment) LoadMilestone() error {
 		if err != nil {
 			return err
 		} else if !has {
-			return ErrMilestoneNotExist{
-				ID: c.MilestoneID,
-			}
+			c.Milestone = NewGhostMilestone()
+		} else {
+			c.Milestone = &milestone
 		}
-		c.Milestone = &milestone
 	}
 	return nil
 }

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -228,7 +228,7 @@ func (c *Comment) LoadLabel() error {
 func (c *Comment) LoadMilestone() error {
 	if c.OldMilestoneID > 0 {
 		var oldMilestone Milestone
-		has, err := x.ID(c.OldMilestoneID).Get(oldMilestone)
+		has, err := x.ID(c.OldMilestoneID).Get(&oldMilestone)
 		if err != nil {
 			return err
 		} else if has {

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -119,6 +119,14 @@ func NewMilestone(m *Milestone) (err error) {
 	return sess.Commit()
 }
 
+// NewGhostMilestone a fake milestone to hold the place of a deleted milestone
+func NewGhostMilestone() *Milestone {
+	return &Milestone{
+		ID:   -1,
+		Name: "Deleted",
+	}
+}
+
 func getMilestoneByRepoID(e Engine, repoID, id int64) (*Milestone, error) {
 	m := &Milestone{
 		ID:     id,

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -119,14 +119,6 @@ func NewMilestone(m *Milestone) (err error) {
 	return sess.Commit()
 }
 
-// NewGhostMilestone a fake milestone to hold the place of a deleted milestone
-func NewGhostMilestone() *Milestone {
-	return &Milestone{
-		ID:   -1,
-		Name: "Deleted",
-	}
-}
-
 func getMilestoneByRepoID(e Engine, repoID, id int64) (*Milestone, error) {
 	m := &Milestone{
 		ID:     id,

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -612,6 +612,7 @@ issues.remove_label_at = `removed the <div class="ui label" style="color: %s; ba
 issues.add_milestone_at = `added this to the <b>%s</b> milestone %s`
 issues.change_milestone_at = `modified the milestone from <b>%s</b> to <b>%s</b> %s`
 issues.remove_milestone_at = `removed this from the <b>%s</b> milestone %s`
+issues.deleted_milestone = `(deleted)`
 issues.self_assign_at = `self-assigned this %s`
 issues.add_assignee_at = `was assigned by <b>%s</b> %s`
 issues.remove_assignee_at = `removed their assignment %s`

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -625,6 +625,16 @@ func ViewIssue(ctx *context.Context) {
 				ctx.Handle(500, "LoadMilestone", err)
 				return
 			}
+			ghostMilestone := &models.Milestone{
+				ID:   -1,
+				Name: ctx.Tr("repo.issues.deleted_milestone"),
+			}
+			if comment.OldMilestoneID > 0 && comment.OldMilestone == nil {
+				comment.OldMilestone = ghostMilestone
+			}
+			if comment.MilestoneID > 0 && comment.Milestone == nil {
+				comment.Milestone = ghostMilestone
+			}
 		} else if comment.Type == models.CommentTypeAssignees {
 			if err = comment.LoadAssignees(); err != nil {
 				ctx.Handle(500, "LoadAssignees", err)


### PR DESCRIPTION
Fixes a bug where viewing an issue from a deleted milestone resulted in a 500 (because comments from that issue would still refer to the deleted milestone, which gitea would then try to load).

~When deleting a milestone, delete all comments referencing that milestone.~
Introduce "ghost" milestones (similar to "ghost" users) to fix the problem.
