### PR TITLE
Use monospace font in githook editor

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1166,6 +1166,9 @@ footer .ui.language .menu {
 .new.webhook .events.fields .column {
   padding-left: 40px;
 }
+.githook textarea {
+  font-family: monospace;
+}
 .repository {
   padding-top: 15px;
   padding-bottom: 80px;

--- a/public/less/_form.less
+++ b/public/less/_form.less
@@ -140,3 +140,9 @@
 		}
 	}
 }
+
+.githook {
+    textarea {
+        font-family: monospace;
+    }
+}


### PR DESCRIPTION
Before:

<img width="701" alt="screen shot 2017-06-13 at 00 34 07" src="https://user-images.githubusercontent.com/115237/27058249-6185f24a-4fd0-11e7-8aa5-b4415b0b07ec.png">

After:

<img width="831" alt="screen shot 2017-06-13 at 00 34 17" src="https://user-images.githubusercontent.com/115237/27058260-667c3a70-4fd0-11e7-82ca-65e8fc1df1f8.png">

Unfortunately, there was no fitting semantic ui rule, so I had to add a custom one.