### PR TITLE
SQLite has a query timeout. Hopefully fixes most 'database locked' errors

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -166,6 +166,8 @@ PASSWD =
 SSL_MODE = disable
 ; For "sqlite3" and "tidb", use absolute path when you start as service
 PATH = data/gitea.db
+; For "sqlite3" only. Query timeout
+SQLITE_TIMEOUT = 500
 
 [indexer]
 ISSUE_INDEXER_PATH = indexers/issues.bleve

--- a/models/models.go
+++ b/models/models.go
@@ -66,7 +66,7 @@ var (
 	// DbCfg holds the database settings
 	DbCfg struct {
 		Type, Host, Name, User, Passwd, Path, SSLMode string
-		Timeout int
+		Timeout                                       int
 	}
 
 	// EnableSQLite3 use SQLite3

--- a/models/models.go
+++ b/models/models.go
@@ -66,6 +66,7 @@ var (
 	// DbCfg holds the database settings
 	DbCfg struct {
 		Type, Host, Name, User, Passwd, Path, SSLMode string
+		Timeout int
 	}
 
 	// EnableSQLite3 use SQLite3
@@ -151,6 +152,7 @@ func LoadConfigs() {
 	}
 	DbCfg.SSLMode = sec.Key("SSL_MODE").String()
 	DbCfg.Path = sec.Key("PATH").MustString("data/gitea.db")
+	DbCfg.Timeout = sec.Key("SQLITE_TIMEOUT").MustInt(500)
 
 	sec = setting.Cfg.Section("indexer")
 	setting.Indexer.IssuePath = sec.Key("ISSUE_INDEXER_PATH").MustString("indexers/issues.bleve")
@@ -220,7 +222,7 @@ func getEngine() (*xorm.Engine, error) {
 		if err := os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm); err != nil {
 			return nil, fmt.Errorf("Failed to create directories: %v", err)
 		}
-		connStr = "file:" + DbCfg.Path + "?cache=shared&mode=rwc"
+		connStr = fmt.Sprintf("file:%s?cache=shared&mode=rwc&_busy_timeout=%d", DbCfg.Path, DbCfg.Timeout)
 	case "tidb":
 		if !EnableTiDB {
 			return nil, errors.New("this binary version does not build support for TiDB")


### PR DESCRIPTION
This adds a wait timeout for when the database is locked. Hopefully this should fix the `database table is locked` errors.