### PR TITLE
Set console to debug for integration tests

### DIFF
--- a/integrations/mysql.ini
+++ b/integrations/mysql.ini
@@ -6,7 +6,7 @@ DB_TYPE  = mysql
 HOST     = 127.0.0.1:3306
 NAME     = testgitea
 USER     = root
-PASSWD   = 
+PASSWD   =
 SSL_MODE = disable
 PATH     = data/gitea.db
 
@@ -47,7 +47,7 @@ MODE      = console,file
 ROOT_PATH = mysql-log
 
 [log.console]
-LEVEL = Debug
+LEVEL = Warn
 
 [log.file]
 LEVEL = Debug

--- a/integrations/pgsql.ini
+++ b/integrations/pgsql.ini
@@ -47,10 +47,10 @@ MODE = console,file
 ROOT_PATH = pgsql-log
 
 [log.console]
-LEVEL = Debug
+LEVEL = Warn
 
 [log.file]
-LEVEL     = Debug
+LEVEL = Debug
 
 [security]
 INSTALL_LOCK = true

--- a/integrations/sqlite.ini
+++ b/integrations/sqlite.ini
@@ -44,13 +44,13 @@ PROVIDER = file
 
 [log]
 MODE = console,file
+ROOT_PATH = sqlite-log
 
 [log.console]
-LEVEL = Debug
+LEVEL = Warn
 
 [log.file]
-LEVEL     = Debug
-ROOT_PATH = log
+LEVEL = Debug
 
 [security]
 INSTALL_LOCK   = true


### PR DESCRIPTION
Way too verbose otherwise (every SQL query gets printed to stdout, see https://drone.gitea.io/go-gitea/gitea/3557)
