### PR TITLE
Consolidate boilerplate in integration tests

### DIFF
--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -23,7 +23,7 @@ func TestAPITeam(t *testing.T) {
 	team := models.AssertExistsAndLoadBean(t, &models.Team{ID: teamUser.TeamID}).(*models.Team)
 	user := models.AssertExistsAndLoadBean(t, &models.User{ID: teamUser.UID}).(*models.User)
 
-	session := loginUser(t, user.Name, "password")
+	session := loginUser(t, user.Name)
 	url := fmt.Sprintf("/api/v1/teams/%d", teamUser.TeamID)
 	req := NewRequest(t, "GET", url)
 	resp := session.MakeRequest(t, req)

--- a/integrations/change_default_branch_test.go
+++ b/integrations/change_default_branch_test.go
@@ -5,10 +5,8 @@
 package integrations
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"code.gitea.io/gitea/models"
@@ -21,21 +19,19 @@ func TestChangeDefaultBranch(t *testing.T) {
 	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
 	owner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
 
-	session := loginUser(t, owner.Name, "password")
+	session := loginUser(t, owner.Name)
 	branchesURL := fmt.Sprintf("/%s/%s/settings/branches", owner.Name, repo.Name)
 
 	req := NewRequest(t, "GET", branchesURL)
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc := NewHtmlParser(t, resp.Body)
 
-	req = NewRequestBody(t, "POST", branchesURL,
-		bytes.NewBufferString(url.Values{
-			"_csrf":  []string{doc.GetInputValueByName("_csrf")},
-			"action": []string{"default_branch"},
-			"branch": []string{"DefaultBranch"},
-		}.Encode()))
+	req = NewRequestWithValues(t, "POST", branchesURL, map[string]string{
+		"_csrf":  doc.GetCSRF(),
+		"action": "default_branch",
+		"branch": "DefaultBranch",
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
@@ -43,15 +39,13 @@ func TestChangeDefaultBranch(t *testing.T) {
 	req = NewRequest(t, "GET", branchesURL)
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
-	doc, err = NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc = NewHtmlParser(t, resp.Body)
 
-	req = NewRequestBody(t, "POST", branchesURL,
-		bytes.NewBufferString(url.Values{
-			"_csrf":  []string{doc.GetInputValueByName("_csrf")},
-			"action": []string{"default_branch"},
-			"branch": []string{"does_not_exist"},
-		}.Encode()))
+	req = NewRequestWithValues(t, "POST", branchesURL, map[string]string{
+		"_csrf":  doc.GetInputValueByName("_csrf"),
+		"action": "default_branch",
+		"branch": "does_not_exist",
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)

--- a/integrations/delete_user_test.go
+++ b/integrations/delete_user_test.go
@@ -5,9 +5,7 @@
 package integrations
 
 import (
-	"bytes"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"code.gitea.io/gitea/models"
@@ -18,18 +16,16 @@ import (
 func TestDeleteUser(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user1", "password")
+	session := loginUser(t, "user1")
 
 	req := NewRequest(t, "GET", "/admin/users/8")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
-	req = NewRequestBody(t, "POST", "/admin/users/8/delete",
-		bytes.NewBufferString(url.Values{
-			"_csrf": []string{doc.GetInputValueByName("_csrf")},
-		}.Encode()))
+	doc := NewHtmlParser(t, resp.Body)
+	req = NewRequestWithValues(t, "POST", "/admin/users/8/delete", map[string]string{
+		"_csrf": doc.GetCSRF(),
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)

--- a/integrations/editor_test.go
+++ b/integrations/editor_test.go
@@ -5,9 +5,7 @@
 package integrations
 
 import (
-	"bytes"
 	"net/http"
-	"net/url"
 	"path"
 	"testing"
 
@@ -17,28 +15,25 @@ import (
 func TestCreateFile(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 
 	// Request editor page
 	req := NewRequest(t, "GET", "/user2/repo1/_new/master/")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc := NewHtmlParser(t, resp.Body)
 	lastCommit := doc.GetInputValueByName("last_commit")
 	assert.NotEmpty(t, lastCommit)
 
 	// Save new file to master branch
-	req = NewRequestBody(t, "POST", "/user2/repo1/_new/master/",
-		bytes.NewBufferString(url.Values{
-			"_csrf":         []string{doc.GetInputValueByName("_csrf")},
-			"last_commit":   []string{lastCommit},
-			"tree_path":     []string{"test.txt"},
-			"content":       []string{"Content"},
-			"commit_choice": []string{"direct"},
-		}.Encode()),
-	)
+	req = NewRequestWithValues(t, "POST", "/user2/repo1/_new/master/", map[string]string{
+		"_csrf":         doc.GetCSRF(),
+		"last_commit":   lastCommit,
+		"tree_path":     "test.txt",
+		"content":       "Content",
+		"commit_choice": "direct",
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
@@ -47,25 +42,21 @@ func TestCreateFile(t *testing.T) {
 func TestCreateFileOnProtectedBranch(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 
 	// Open repository branch settings
 	req := NewRequest(t, "GET", "/user2/repo1/settings/branches")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc := NewHtmlParser(t, resp.Body)
 
 	// Change master branch to protected
-	req = NewRequestBody(t, "POST", "/user2/repo1/settings/branches?action=protected_branch",
-		bytes.NewBufferString(url.Values{
-			"_csrf":      []string{doc.GetInputValueByName("_csrf")},
-			"branchName": []string{"master"},
-			"canPush":    []string{"true"},
-		}.Encode()),
-	)
-	assert.NoError(t, err)
+	req = NewRequestWithValues(t, "POST", "/user2/repo1/settings/branches?action=protected_branch", map[string]string{
+		"_csrf":      doc.GetCSRF(),
+		"branchName": "master",
+		"canPush":    "true",
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
@@ -79,21 +70,19 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err = NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc = NewHtmlParser(t, resp.Body)
 	lastCommit := doc.GetInputValueByName("last_commit")
 	assert.NotEmpty(t, lastCommit)
 
 	// Save new file to master branch
-	req = NewRequestBody(t, "POST", "/user2/repo1/_new/master/",
-		bytes.NewBufferString(url.Values{
-			"_csrf":         []string{doc.GetInputValueByName("_csrf")},
-			"last_commit":   []string{lastCommit},
-			"tree_path":     []string{"test.txt"},
-			"content":       []string{"Content"},
-			"commit_choice": []string{"direct"},
-		}.Encode()),
-	)
+	req = NewRequestWithValues(t, "POST", "/user2/repo1/_new/master/", map[string]string{
+		"_csrf":         doc.GetCSRF(),
+		"last_commit":   lastCommit,
+		"tree_path":     "test.txt",
+		"content":       "Content",
+		"commit_choice": "direct",
+	})
+
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
@@ -110,20 +99,19 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	htmlDoc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	htmlDoc := NewHtmlParser(t, resp.Body)
 	lastCommit := htmlDoc.GetInputValueByName("last_commit")
 	assert.NotEmpty(t, lastCommit)
 
 	// Submit the edits
-	req = NewRequestBody(t, "POST", path.Join(user, repo, "_edit", branch, filePath),
-		bytes.NewBufferString(url.Values{
-			"_csrf":         []string{htmlDoc.GetInputValueByName("_csrf")},
-			"last_commit":   []string{lastCommit},
-			"tree_path":     []string{filePath},
-			"content":       []string{newContent},
-			"commit_choice": []string{"direct"},
-		}.Encode()),
+	req = NewRequestWithValues(t, "POST", path.Join(user, repo, "_edit", branch, filePath),
+		map[string]string{
+			"_csrf":         htmlDoc.GetCSRF(),
+			"last_commit":   lastCommit,
+			"tree_path":     filePath,
+			"content":       newContent,
+			"commit_choice": "direct",
+		},
 	)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
@@ -140,6 +128,6 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 
 func TestEditFile(t *testing.T) {
 	prepareTestEnv(t)
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 	testEditFile(t, session, "user2", "repo1", "master", "README.md")
 }

--- a/integrations/html_helper.go
+++ b/integrations/html_helper.go
@@ -6,21 +6,20 @@ package integrations
 
 import (
 	"bytes"
+	"testing"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
 )
 
 type HtmlDoc struct {
 	doc *goquery.Document
 }
 
-func NewHtmlParser(content []byte) (*HtmlDoc, error) {
+func NewHtmlParser(t *testing.T, content []byte) *HtmlDoc {
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(content))
-	if err != nil {
-		return nil, err
-	}
-
-	return &HtmlDoc{doc: doc}, nil
+	assert.NoError(t, err)
+	return &HtmlDoc{doc: doc}
 }
 
 func (doc *HtmlDoc) GetInputValueById(id string) string {
@@ -31,4 +30,8 @@ func (doc *HtmlDoc) GetInputValueById(id string) string {
 func (doc *HtmlDoc) GetInputValueByName(name string) string {
 	text, _ := doc.doc.Find("input[name=\"" + name + "\"]").Attr("value")
 	return text
+}
+
+func (doc *HtmlDoc) GetCSRF() string {
+	return doc.GetInputValueByName("_csrf")
 }

--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -45,13 +45,12 @@ func TestNoLoginViewIssuesSortByType(t *testing.T) {
 	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
 	repo.Owner = models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
 
-	session := loginUser(t, user.Name, "password")
+	session := loginUser(t, user.Name)
 	req := NewRequest(t, "GET", repo.RelLink()+"/issues?type=created_by")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	htmlDoc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	htmlDoc := NewHtmlParser(t, resp.Body)
 	issuesSelection := getIssuesSelection(htmlDoc)
 	expectedNumIssues := models.GetCount(t,
 		&models.Issue{RepoID: repo.ID, PosterID: user.ID},

--- a/integrations/pull_compare_test.go
+++ b/integrations/pull_compare_test.go
@@ -14,12 +14,11 @@ import (
 func TestPullCompare(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 	req := NewRequest(t, "GET", "/user2/repo1/pulls")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
-	htmlDoc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	htmlDoc := NewHtmlParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find(".navbar").Find(".ui.green.button").Attr("href")
 	assert.True(t, exists, "The template has changed")
 

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -14,7 +14,7 @@ import (
 func TestViewReleases(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 	req := NewRequest(t, "GET", "/user2/repo1/releases")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)

--- a/integrations/repo_commits_test.go
+++ b/integrations/repo_commits_test.go
@@ -5,10 +5,11 @@
 package integrations
 
 import (
-	"bytes"
 	"net/http"
 	"path"
 	"testing"
+
+	api "code.gitea.io/sdk/gitea"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,15 +17,14 @@ import (
 func TestRepoCommits(t *testing.T) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 
 	// Request repository commits page
 	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc := NewHtmlParser(t, resp.Body)
 	commitURL, exists := doc.doc.Find("#commits-table tbody tr td.sha a").Attr("href")
 	assert.True(t, exists)
 	assert.NotEmpty(t, commitURL)
@@ -33,23 +33,28 @@ func TestRepoCommits(t *testing.T) {
 func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 	prepareTestEnv(t)
 
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 
 	// Request repository commits page
 	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err := NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc := NewHtmlParser(t, resp.Body)
 	// Get first commit URL
 	commitURL, exists := doc.doc.Find("#commits-table tbody tr td.sha a").Attr("href")
 	assert.True(t, exists)
 	assert.NotEmpty(t, commitURL)
 
 	// Call API to add status for commit
-	req = NewRequestBody(t, "POST", "/api/v1/repos/user2/repo1/statuses/"+path.Base(commitURL),
-		bytes.NewBufferString("{\"state\":\""+state+"\", \"target_url\": \"http://test.ci/\", \"description\": \"\", \"context\": \"testci\"}"))
+	req = NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/statuses/"+path.Base(commitURL),
+		api.CreateStatusOption{
+			State:       api.StatusState(state),
+			TargetURL:   "http://test.ci/",
+			Description: "",
+			Context:     "testci",
+		},
+	)
 
 	req.Header.Add("Content-Type", "application/json")
 	resp = session.MakeRequest(t, req)
@@ -59,8 +64,7 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
-	doc, err = NewHtmlParser(resp.Body)
-	assert.NoError(t, err)
+	doc = NewHtmlParser(t, resp.Body)
 	// Check if commit status is displayed in message column
 	sel := doc.doc.Find("#commits-table tbody tr td.message i.commit-status")
 	assert.Equal(t, sel.Length(), 1)

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -22,7 +22,7 @@ func TestViewRepo(t *testing.T) {
 	resp = MakeRequest(req)
 	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
 
-	session := loginUser(t, "user1", "password")
+	session := loginUser(t, "user1")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
 }
@@ -31,7 +31,7 @@ func TestViewRepo2(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user3/repo3")
-	session := loginUser(t, "user2", "password")
+	session := loginUser(t, "user2")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
@@ -40,7 +40,7 @@ func TestViewRepo3(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user3/repo3")
-	session := loginUser(t, "user3", "password")
+	session := loginUser(t, "user3")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/signup_test.go
+++ b/integrations/signup_test.go
@@ -5,9 +5,7 @@
 package integrations
 
 import (
-	"bytes"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -20,14 +18,12 @@ func TestSignup(t *testing.T) {
 
 	setting.Service.EnableCaptcha = false
 
-	req := NewRequestBody(t, "POST", "/user/sign_up",
-		bytes.NewBufferString(url.Values{
-			"user_name": []string{"exampleUser"},
-			"email":     []string{"exampleUser@example.com"},
-			"password":  []string{"examplePassword"},
-			"retype":    []string{"examplePassword"},
-		}.Encode()),
-	)
+	req := NewRequestWithValues(t, "POST", "/user/sign_up", map[string]string{
+		"user_name": "exampleUser",
+		"email":     "exampleUser@example.com",
+		"password":  "examplePassword",
+		"retype":    "examplePassword",
+	})
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -1,3 +1,5 @@
+# NOTE: all users should have a password of "password"
+
 - # NOTE: this user (id=1) is the admin
   id: 1
   lower_name: user1


### PR DESCRIPTION
Move error-checking and other shared boilerplate to helper functions; makes tests less verbose.
