### PR TITLE
Add integration test for repository migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,20 @@ test-mysql: integrations.test
 test-pgsql: integrations.test
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/pgsql.ini ./integrations.test
 
+
+.PHONY: bench-sqlite
+bench-sqlite: integrations.sqlite.test
+	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/sqlite.ini ./integrations.sqlite.test -test.bench .
+
+.PHONY: bench-mysql
+bench-mysql: integrations.test
+	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/mysql.ini ./integrations.test -test.bench .
+
+.PHONY: bench-pgsql
+bench-pgsql: integrations.test
+	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/pgsql.ini ./integrations.test -test.bench .
+
+
 .PHONY: integration-test-coverage
 integration-test-coverage: integrations.cover.test
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/mysql.ini ./integrations.cover.test -test.coverprofile=integration.coverage.out

--- a/integrations/repo_migrate_test.go
+++ b/integrations/repo_migrate_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testRepoMigrate(t testing.TB, session *TestSession, cloneAddr, repoName string) *TestResponse {
+	req := NewRequest(t, "GET", "/repo/migrate")
+	resp := session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+
+	link, exists := htmlDoc.doc.Find("form.ui.form").Attr("action")
+	assert.True(t, exists, "The template has changed")
+
+	uid, exists := htmlDoc.doc.Find("#uid").Attr("value")
+	assert.True(t, exists, "The template has changed")
+
+	req = NewRequestWithValues(t, "POST", link, map[string]string{
+		"_csrf":      htmlDoc.GetCSRF(),
+		"clone_addr": cloneAddr,
+		"uid":        uid,
+		"repo_name":  repoName,
+	},
+	)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp = session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+
+	return resp
+}
+
+func TestRepoMigrate(t *testing.T) {
+	prepareTestEnv(t)
+	session := loginUser(t, "user2")
+	testRepoMigrate(t, session, "https://github.com/go-gitea/git.git", "git")
+}
+
+func BenchmarkRepoMigrate(b *testing.B) {
+	samples := []struct {
+		url  string
+		name string
+	}{
+		{url: "https://github.com/go-gitea/gitea.git", name: "gitea"},
+		{url: "https://github.com/ethantkoenig/manyfiles.git", name: "manyfiles"},
+		{url: "https://github.com/moby/moby.git", name: "moby"},
+		{url: "https://github.com/golang/go.git", name: "go"},
+		{url: "https://github.com/torvalds/linux.git", name: "linux"},
+	}
+
+	prepareTestEnv(b)
+	session := loginUser(b, "user2")
+	b.ResetTimer()
+
+	for _, s := range samples {
+		b.Run(s.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				testRepoMigrate(b, session, s.url, s.name)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
~~A build flag 'extra' for guarding the test since it would take long time and consume too much bandwidth. It can be used as a building block for other tests.~~ 

P.S. It's changed per the suggestions by the reviewers.