### PR TITLE
Let not-logged-in users view releases

### DIFF
--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -19,3 +19,11 @@ func TestViewReleases(t *testing.T) {
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }
+
+func TestViewReleasesNoLogin(t *testing.T) {
+	prepareTestEnv(t)
+
+	req := NewRequest(t, "GET", "/user2/repo1/releases")
+	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -79,7 +79,10 @@ func Releases(ctx *context.Context) {
 
 	// Temporary cache commits count of used branches to speed up.
 	countCache := make(map[string]int64)
-	cacheUsers := map[int64]*models.User{ctx.User.ID: ctx.User}
+	cacheUsers := make(map[int64]*models.User)
+	if ctx.User != nil {
+		cacheUsers[ctx.User.ID] = ctx.User
+	}
 	var ok bool
 
 	releasesToDisplay := make([]*models.Release, 0, len(releases))

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -529,14 +529,16 @@ func RegisterRoutes(m *macaron.Macaron) {
 	m.Group("/:username/:reponame", func() {
 		m.Group("/releases", func() {
 			m.Get("/", repo.MustBeNotBare, repo.Releases)
+		}, repo.MustBeNotBare, context.RepoRef())
+		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)
 			m.Post("/delete", repo.DeleteRelease)
-		}, repo.MustBeNotBare, reqRepoWriter, context.RepoRef())
+		}, reqSignIn, repo.MustBeNotBare, reqRepoWriter, context.RepoRef())
 		m.Group("/releases", func() {
 			m.Get("/edit/*", repo.EditRelease)
 			m.Post("/edit/*", bindIgnErr(auth.EditReleaseForm{}), repo.EditReleasePost)
-		}, repo.MustBeNotBare, reqRepoWriter, func(ctx *context.Context) {
+		}, reqSignIn, repo.MustBeNotBare, reqRepoWriter, func(ctx *context.Context) {
 			var err error
 			ctx.Repo.Commit, err = ctx.Repo.GitRepo.GetBranchCommit(ctx.Repo.Repository.DefaultBranch)
 			if err != nil {
@@ -550,7 +552,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			}
 			ctx.Data["CommitsCount"] = ctx.Repo.CommitsCount
 		})
-	}, reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.LoadRepoUnits(), context.CheckUnit(models.UnitTypeReleases))
+	}, context.RepoAssignment(), context.UnitTypes(), context.LoadRepoUnits(), context.CheckUnit(models.UnitTypeReleases))
 
 	m.Group("/:username/:reponame", func() {
 		m.Group("", func() {


### PR DESCRIPTION
Allow non-logged-in users, and non-writers, to view releases of public repos.
