### PR TITLE
Don't show non-comments in comments API

### DIFF
--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -1,0 +1,39 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	api "code.gitea.io/sdk/gitea"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIListComments(t *testing.T) {
+	prepareTestEnv(t)
+
+	comment := models.AssertExistsAndLoadBean(t, &models.Comment{},
+		models.Cond("type = ?", models.CommentTypeComment)).(*models.Comment)
+	issue := models.AssertExistsAndLoadBean(t, &models.Issue{ID: comment.IssueID}).(*models.Issue)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	requestUrl := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments",
+		repoOwner.Name, repo.Name, issue.Index)
+	req := NewRequest(t, "GET", requestUrl)
+	resp := session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+
+	var comments []*api.Comment
+	DecodeJSON(t, resp, &comments)
+	expectedCount := models.GetCount(t, &models.Comment{IssueID: issue.ID},
+		models.Cond("type = ?", models.CommentTypeComment))
+	assert.EqualValues(t, expectedCount, len(comments))
+}

--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -5,8 +5,6 @@
 package integrations
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,8 +28,7 @@ func TestAPITeam(t *testing.T) {
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
 	var apiTeam api.Team
-	decoder := json.NewDecoder(bytes.NewBuffer(resp.Body))
-	assert.NoError(t, decoder.Decode(&apiTeam))
+	DecodeJSON(t, resp, &apiTeam)
 	assert.EqualValues(t, team.ID, apiTeam.ID)
 	assert.Equal(t, team.Name, apiTeam.Name)
 }

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -252,3 +252,8 @@ func MakeRequest(req *http.Request) *TestResponse {
 		Headers:    respWriter.Headers,
 	}
 }
+
+func DecodeJSON(t testing.TB, resp *TestResponse, v interface{}) {
+	decoder := json.NewDecoder(bytes.NewBuffer(resp.Body))
+	assert.NoError(t, decoder.Decode(v))
+}

--- a/integrations/version_test.go
+++ b/integrations/version_test.go
@@ -5,8 +5,6 @@
 package integrations
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -22,11 +20,9 @@ func TestVersion(t *testing.T) {
 	setting.AppVer = "1.1.0+dev"
 	req := NewRequest(t, "GET", "/api/v1/version")
 	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 
 	var version gitea.ServerVersion
-	decoder := json.NewDecoder(bytes.NewBuffer(resp.Body))
-	assert.NoError(t, decoder.Decode(&version))
-
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	DecodeJSON(t, resp, &version)
 	assert.Equal(t, setting.AppVer, string(version.Version))
 }

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -572,6 +572,7 @@ func getCommentsByIssueIDSince(e Engine, issueID, since int64) ([]*Comment, erro
 	comments := make([]*Comment, 0, 10)
 	sess := e.
 		Where("issue_id = ?", issueID).
+		Where("type = ?", CommentTypeComment).
 		Asc("created_unix")
 	if since > 0 {
 		sess.And("updated_unix >= ?", since)
@@ -582,6 +583,7 @@ func getCommentsByIssueIDSince(e Engine, issueID, since int64) ([]*Comment, erro
 func getCommentsByRepoIDSince(e Engine, repoID, since int64) ([]*Comment, error) {
 	comments := make([]*Comment, 0, 10)
 	sess := e.Where("issue.repo_id = ?", repoID).
+		Where("comment.type = ?", CommentTypeComment).
 		Join("INNER", "issue", "issue.id = comment.issue_id").
 		Asc("comment.created_unix")
 	if since > 0 {


### PR DESCRIPTION
Fix the `GET /repos/:owner/:repo/issues/:index/comments` and `GET /repos/:owner/:repo/issues/comments` API endpoints to only return actual comments, and not "non-comment" comments (e.g. addition/removal of label)

Also add integration test.