### PR TITLE
Important: wrong PR merge commit ID saved

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -328,7 +328,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository) (err error
 		return fmt.Errorf("git push: %s", stderr)
 	}
 
-	pr.MergedCommitID, err = headGitRepo.GetBranchCommitID(pr.BaseBranch)
+	pr.MergedCommitID, err = baseGitRepo.GetBranchCommitID(pr.BaseBranch)
 	if err != nil {
 		return fmt.Errorf("GetBranchCommit: %v", err)
 	}


### PR DESCRIPTION
When merging PR changes that were made from forked repository last commit ID is taken from fork not base repository but for target branch, so it will point to wrong commit ID