### PR TITLE
Pagination on releases page

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -248,9 +248,9 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 func GetReleaseCountByRepoID(repoID int64, isOwner bool) (total int64, err error) {
 	if isOwner {
 		return x.Where("repo_id = ?", repoID).Count(&Release{})
-	} else {
-		return x.Where("repo_id = ? AND is_prerelease = 0 AND is_draft = 0", repoID).Count(&Release{})
 	}
+
+	return x.Where("repo_id = ? AND is_prerelease = 0 AND is_draft = 0", repoID).Count(&Release{})
 }
 
 // GetReleasesByRepoIDAndNames returns a list of releases of repository according repoID and tagNames.

--- a/models/release.go
+++ b/models/release.go
@@ -233,7 +233,7 @@ func GetReleaseByID(id int64) (*Release, error) {
 }
 
 // GetReleasesByRepoID returns a list of releases of repository.
-func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err error) {
+func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, count int64, err error) {
 	if page <= 0 {
 		page = 1
 	}
@@ -241,7 +241,12 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 		Desc("created_unix").
 		Limit(pageSize, (page-1)*pageSize).
 		Find(&rels, Release{RepoID: repoID})
-	return rels, err
+	if err != nil {
+		return rels, 0, err
+	}
+	count, err = x.Where("repo_id = ?", repoID).Count(new(Release))
+
+	return rels, count, err
 }
 
 // GetReleasesByRepoIDAndNames returns a list of releases of repository according repoID and tagNames.

--- a/models/release.go
+++ b/models/release.go
@@ -241,7 +241,6 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 		Desc("created_unix").
 		Limit(pageSize, (page-1)*pageSize).
 		Find(&rels, Release{RepoID: repoID})
-
 	return rels, err
 }
 

--- a/models/release.go
+++ b/models/release.go
@@ -249,7 +249,7 @@ func GetReleaseCountByRepoID(repoID int64, isOwner bool) (total int64, err error
 	if isOwner {
 		return x.Where("repo_id = ?", repoID).Count(&Release{})
 	} else {
-		return x.Where("repo_id = ? AND is_prerelease = 0", repoID).Count(&Release{})
+		return x.Where("repo_id = ? AND is_prerelease = 0 AND is_draft = 0", repoID).Count(&Release{})
 	}
 }
 

--- a/models/release.go
+++ b/models/release.go
@@ -244,6 +244,7 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 	return rels, err
 }
 
+// GetReleaseCountByRepoID returns the count of releases of repository
 func GetReleaseCountByRepoID(repoID int64) (total int64, err error) {
 	count, err := x.Where("repo_id = ?", repoID).Count(&Release{})
 

--- a/models/release.go
+++ b/models/release.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/sdk/gitea"
+	"github.com/go-xorm/builder"
 	"github.com/go-xorm/xorm"
 )
 
@@ -246,11 +247,15 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 
 // GetReleaseCountByRepoID returns the count of releases of repository
 func GetReleaseCountByRepoID(repoID int64, isOwner bool) (total int64, err error) {
+	var cond = builder.NewCond()
+	cond = cond.And(builder.Eq{"repo_id": repoID})
+
 	if isOwner {
-		return x.Where("repo_id = ?", repoID).Count(&Release{})
+		return x.Where(cond).Count(&Release{})
 	}
 
-	return x.Where("repo_id = ? AND is_prerelease = 0 AND is_draft = 0", repoID).Count(&Release{})
+	cond = cond.And(builder.Eq{"is_draft": 0})
+	return x.Where(cond).Count(&Release{})
 }
 
 // GetReleasesByRepoIDAndNames returns a list of releases of repository according repoID and tagNames.

--- a/models/release.go
+++ b/models/release.go
@@ -233,7 +233,7 @@ func GetReleaseByID(id int64) (*Release, error) {
 }
 
 // GetReleasesByRepoID returns a list of releases of repository.
-func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, count int64, err error) {
+func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err error) {
 	if page <= 0 {
 		page = 1
 	}
@@ -241,12 +241,14 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, cou
 		Desc("created_unix").
 		Limit(pageSize, (page-1)*pageSize).
 		Find(&rels, Release{RepoID: repoID})
-	if err != nil {
-		return rels, 0, err
-	}
-	count, err = x.Where("repo_id = ?", repoID).Count(new(Release))
 
-	return rels, count, err
+	return rels, err
+}
+
+func GetReleaseCountByRepoID(repoID int64) (total int64, err error) {
+	count, err := x.Where("repo_id = ?", repoID).Count(&Release{})
+
+	return count, err
 }
 
 // GetReleasesByRepoIDAndNames returns a list of releases of repository according repoID and tagNames.

--- a/models/release.go
+++ b/models/release.go
@@ -246,15 +246,15 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 }
 
 // GetReleaseCountByRepoID returns the count of releases of repository
-func GetReleaseCountByRepoID(repoID int64, isOwner bool) (total int64, err error) {
+func GetReleaseCountByRepoID(repoID int64, includeDrafts bool) (int64, error) {
 	var cond = builder.NewCond()
 	cond = cond.And(builder.Eq{"repo_id": repoID})
 
-	if isOwner {
+	if includeDrafts {
 		return x.Where(cond).Count(&Release{})
 	}
 
-	cond = cond.And(builder.Eq{"is_draft": 0})
+	cond = cond.And(builder.Eq{"is_draft": false})
 	return x.Where(cond).Count(&Release{})
 }
 

--- a/models/release.go
+++ b/models/release.go
@@ -245,10 +245,12 @@ func GetReleasesByRepoID(repoID int64, page, pageSize int) (rels []*Release, err
 }
 
 // GetReleaseCountByRepoID returns the count of releases of repository
-func GetReleaseCountByRepoID(repoID int64) (total int64, err error) {
-	count, err := x.Where("repo_id = ?", repoID).Count(&Release{})
-
-	return count, err
+func GetReleaseCountByRepoID(repoID int64, isOwner bool) (total int64, err error) {
+	if isOwner {
+		return x.Where("repo_id = ?", repoID).Count(&Release{})
+	} else {
+		return x.Where("repo_id = ? AND is_prerelease = 0", repoID).Count(&Release{})
+	}
 }
 
 // GetReleasesByRepoIDAndNames returns a list of releases of repository according repoID and tagNames.

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -34,7 +34,7 @@ func GetRelease(ctx *context.APIContext) {
 
 // ListReleases list a repository's releases
 func ListReleases(ctx *context.APIContext) {
-	releases, _, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, 1, 2147483647)
+	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, 1, 2147483647)
 	if err != nil {
 		ctx.Error(500, "GetReleasesByRepoID", err)
 		return

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -34,7 +34,7 @@ func GetRelease(ctx *context.APIContext) {
 
 // ListReleases list a repository's releases
 func ListReleases(ctx *context.APIContext) {
-	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, 1, 2147483647)
+	releases, _, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, 1, 2147483647)
 	if err != nil {
 		ctx.Error(500, "GetReleasesByRepoID", err)
 		return

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -65,9 +65,15 @@ func Releases(ctx *context.Context) {
 		limit = 10
 	}
 
-	releases, count, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
+	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
 	if err != nil {
 		ctx.Handle(500, "GetReleasesByRepoIDAndNames", err)
+		return
+	}
+
+	count, err := models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID)
+	if err != nil {
+		ctx.Handle(500, "GetReleaseCountByRepoIDAndNames", err)
 		return
 	}
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -67,7 +67,7 @@ func Releases(ctx *context.Context) {
 
 	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
 	if err != nil {
-		ctx.Handle(500, "GetReleasesByRepoIDAndNames", err)
+		ctx.Handle(500, "GetReleasesByRepoID", err)
 		return
 	}
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -71,7 +71,7 @@ func Releases(ctx *context.Context) {
 		return
 	}
 
-	count, err := models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID)
+	count, err := models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, ctx.Repo.IsOwner())
 	if err != nil {
 		ctx.Handle(500, "GetReleaseCountByRepoID", err)
 		return
@@ -91,7 +91,7 @@ func Releases(ctx *context.Context) {
 	}
 	var ok bool
 
-	releasesToDisplay := make([]*models.Release, 0, len(releases))
+	releasesToDisplay := make([]*models.Release, 0, count)
 	for _, r := range releases {
 		if r.IsDraft && !ctx.Repo.IsOwner() {
 			continue

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -73,7 +73,7 @@ func Releases(ctx *context.Context) {
 
 	count, err := models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID)
 	if err != nil {
-		ctx.Handle(500, "GetReleaseCountByRepoIDAndNames", err)
+		ctx.Handle(500, "GetReleaseCountByRepoID", err)
 		return
 	}
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -65,7 +65,7 @@ func Releases(ctx *context.Context) {
 		limit = 10
 	}
 
-	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
+	releases, count, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
 	if err != nil {
 		ctx.Handle(500, "GetReleasesByRepoIDAndNames", err)
 		return
@@ -110,7 +110,7 @@ func Releases(ctx *context.Context) {
 		releasesToDisplay = append(releasesToDisplay, r)
 	}
 
-	pager := paginater.New(len(releasesToDisplay), limit, page, 5)
+	pager := paginater.New(int(count), limit, page, 5)
 	ctx.Data["Page"] = pager
 	ctx.Data["Releases"] = releasesToDisplay
 	ctx.HTML(200, tplReleases)

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -91,7 +91,7 @@ func Releases(ctx *context.Context) {
 	}
 	var ok bool
 
-	releasesToDisplay := make([]*models.Release, 0, count)
+	releasesToDisplay := make([]*models.Release, 0, len(releases))
 	for _, r := range releases {
 		if r.IsDraft && !ctx.Repo.IsOwner() {
 			continue


### PR DESCRIPTION
Reason for why the pagination did not work, was because the paginater was never given a higher count than the amount of releases to display (which is max 10)
Added `GetReleaseCountByRepoID` function to get count of releases so pagination will work on releases page.
Count also checks if user is owner, so if there are many prereleases and/or drafts the page count should not be off.

Tested by being logged in as owner, and not logged in.

Fixes https://github.com/go-gitea/gitea/issues/1863