### PR TITLE
Corrected wrong function name in error

### DIFF
--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -67,7 +67,7 @@ func Releases(ctx *context.Context) {
 
 	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, page, limit)
 	if err != nil {
-		ctx.Handle(500, "GetReleasesByRepoIDAndNames", err)
+		ctx.Handle(500, "GetReleasesByRepoID", err)
 		return
 	}
 


### PR DESCRIPTION
Did not find an issue regarding this, just noticed it as I was working on fixing paginaton on the Releases page. Should I create an issue as well for something this small?
