### PR TITLE
Fix: `http: multiple response.WriteHeader calls`

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -381,7 +381,6 @@ func serviceRPC(h serviceHandler, service string) {
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		log.GitLogger.Error(2, "fail to serve RPC(%s): %v - %v", service, err, stderr)
-		h.w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 }


### PR DESCRIPTION
We can't change the http status code here, because the response has been written.

Also, this causes a HTTP `500` access log by Macaron, but the actual code sent to the client is `200`.

This issue can be reproduced with `git clone --depth=1 <http clone url>` on any repositories.