### PR TITLE
Load label ID in NewLabels

### DIFF
--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -96,10 +96,29 @@ func (label *Label) ForegroundColor() template.CSS {
 	return template.CSS("#000")
 }
 
-// NewLabels creates new label(s) for a repository.
-func NewLabels(labels ...*Label) error {
-	_, err := x.Insert(labels)
+func newLabel(e Engine, label *Label) error {
+	_, err := e.Insert(label)
 	return err
+}
+
+// NewLabel creates a new label for a repository
+func NewLabel(label *Label) error {
+	return newLabel(x, label)
+}
+
+// NewLabels creates new labels for a repository.
+func NewLabels(labels ...*Label) error {
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+	for _, label := range labels {
+		if err := newLabel(sess, label); err != nil {
+			return err
+		}
+	}
+	return sess.Commit()
 }
 
 // getLabelInRepoByName returns a label by Name in given repository.

--- a/models/issue_label_test.go
+++ b/models/issue_label_test.go
@@ -52,7 +52,7 @@ func TestNewLabels(t *testing.T) {
 	}
 	assert.NoError(t, NewLabels(labels...))
 	for _, label := range labels {
-		AssertExistsAndLoadBean(t, label)
+		AssertExistsAndLoadBean(t, label, Cond("id = ?", label.ID))
 	}
 	CheckConsistencyFor(t, &Label{}, &Repository{})
 }

--- a/routers/api/v1/repo/label.go
+++ b/routers/api/v1/repo/label.go
@@ -64,7 +64,7 @@ func CreateLabel(ctx *context.APIContext, form api.CreateLabelOption) {
 		Color:  form.Color,
 		RepoID: ctx.Repo.Repository.ID,
 	}
-	if err := models.NewLabels(label); err != nil {
+	if err := models.NewLabel(label); err != nil {
 		ctx.Error(500, "NewLabel", err)
 		return
 	}

--- a/routers/repo/issue_label.go
+++ b/routers/repo/issue_label.go
@@ -89,7 +89,7 @@ func NewLabel(ctx *context.Context, form auth.CreateLabelForm) {
 		Name:   form.Title,
 		Color:  form.Color,
 	}
-	if err := models.NewLabels(l); err != nil {
+	if err := models.NewLabel(l); err != nil {
 		ctx.Handle(500, "NewLabel", err)
 		return
 	}


### PR DESCRIPTION
Fix bug in `NewLabels(..)` where the `ID` field for the labels were not populated. This caused a problem in the `POST /repos/:user/:repo/labels` API endpoint, where the response label would have an `"id"` attribute of 0.

Also update the unit test to check that `ID` has been populated.