### PR TITLE
API: support '/orgs/:org/repos'

### DIFF
--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -67,8 +67,8 @@ func TestAPIViewRepo(t *testing.T) {
 func TestAPIOrgRepos(t *testing.T) {
 	prepareTestEnv(t)
 
-	req := NewRequest(t, "GET", "/api/v1/orgs/org1/repos")
-	session := loginUser(t, "user1")
+	req := NewRequest(t, "GET", "/api/v1/orgs/user3/repos")
+	session := loginUser(t, "user2")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -5,7 +5,6 @@
 package integrations
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -80,11 +79,8 @@ func TestAPIOrgRepos(t *testing.T) {
 	DecodeJSON(t, resp, &apiRepos)
 	expectedLen := models.GetCount(t, models.Repository{OwnerID: sourceOrg.ID},
 		models.Cond("is_private = ?", false))
-	fmt.Println(expectedLen)   // 0
-	fmt.Println(len(apiRepos)) // 1
 	assert.Len(t, apiRepos, expectedLen)
 	for _, repo := range apiRepos {
-		fmt.Printf("%+v\n", repo)
 		assert.False(t, repo.Private)
 	}
 }

--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -71,4 +71,8 @@ func TestAPIOrgRepos(t *testing.T) {
 	session := loginUser(t, "user2")
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+
+	var repos []*api.Repository
+	DecodeJSON(t, resp, &repos)
+	assert.Len(t, repos, 1) // User3 has 1 public repo.
 }

--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -64,10 +64,11 @@ func TestAPIViewRepo(t *testing.T) {
 	assert.EqualValues(t, "repo1", repo.Name)
 }
 
-func TestAPIOrgReposNotLogin(t *testing.T) {
-	assert.NoError(t, models.LoadFixtures())
+func TestAPIOrgRepos(t *testing.T) {
+	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/api/v1/orgs/org1/repos")
-	resp := MakeRequest(req)
+	session := loginUser(t, "user1")
+	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -63,3 +63,11 @@ func TestAPIViewRepo(t *testing.T) {
 	assert.EqualValues(t, 1, repo.ID)
 	assert.EqualValues(t, "repo1", repo.Name)
 }
+
+func TestAPIOrgReposNotLogin(t *testing.T) {
+	assert.NoError(t, models.LoadFixtures())
+
+	req := NewRequest(t, "GET", "/api/v1/orgs/org1/repos")
+	resp := MakeRequest(req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+}

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -187,6 +187,22 @@
         }
       }
     },
+    "/orgs/{org}/repos": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "orgListRepos",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/RepositoryList"
+          },
+          "500": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/repos/search": {
       "get": {
         "produces": [

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -465,6 +465,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 				m.Combo("/:username").Get(org.IsMember).
 					Delete(reqToken(), reqOrgOwnership(), org.DeleteMember)
 			})
+			m.Group("/repos", func() {
+				m.Get("", user.ListOrgRepos)
+			})
 			m.Group("/public_members", func() {
 				m.Get("", org.ListPublicMembers)
 				m.Combo("/:username").Get(org.IsPublicMember).

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -458,15 +458,13 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/user/orgs", reqToken(), org.ListMyOrgs)
 		m.Get("/users/:username/orgs", org.ListUserOrgs)
 		m.Group("/orgs/:orgname", func() {
+			m.Get("/repos", user.ListOrgRepos)
 			m.Combo("").Get(org.Get).
 				Patch(reqToken(), reqOrgOwnership(), bind(api.EditOrgOption{}), org.Edit)
 			m.Group("/members", func() {
 				m.Get("", org.ListMembers)
 				m.Combo("/:username").Get(org.IsMember).
 					Delete(reqToken(), reqOrgOwnership(), org.DeleteMember)
-			})
-			m.Group("/repos", func() {
-				m.Get("", user.ListOrgRepos)
 			})
 			m.Group("/public_members", func() {
 				m.Get("", org.ListPublicMembers)

--- a/routers/api/v1/user/key.go
+++ b/routers/api/v1/user/key.go
@@ -33,11 +33,6 @@ func GetUserByParams(ctx *context.APIContext) *models.User {
 	return GetUserByParamsName(ctx, ":username")
 }
 
-// GetOrgByParams returns org whose name is presented in URL parameter.
-func GetOrgByParams(ctx *context.APIContext) *models.User {
-	return GetUserByParamsName(ctx, ":org")
-}
-
 func composePublicKeysAPILink() string {
 	return setting.AppURL + "api/v1/user/keys/"
 }

--- a/routers/api/v1/user/key.go
+++ b/routers/api/v1/user/key.go
@@ -33,6 +33,11 @@ func GetUserByParams(ctx *context.APIContext) *models.User {
 	return GetUserByParamsName(ctx, ":username")
 }
 
+// GetOrgByParams returns org whose name is presented in URL parameter.
+func GetOrgByParams(ctx *context.APIContext) *models.User {
+	return GetUserByParamsName(ctx, ":org")
+}
+
 func composePublicKeysAPILink() string {
 	return setting.AppURL + "api/v1/user/keys/"
 }

--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -96,9 +96,5 @@ func ListOrgRepos(ctx *context.APIContext) {
 	//       200: RepositoryList
 	//       500: error
 
-	org := GetOrgByParams(ctx)
-	if ctx.Written() {
-		return
-	}
-	listUserRepos(ctx, org)
+	listUserRepos(ctx, ctx.Org)
 }

--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -96,5 +96,5 @@ func ListOrgRepos(ctx *context.APIContext) {
 	//       200: RepositoryList
 	//       500: error
 
-	listUserRepos(ctx, ctx.Org)
+	listUserRepos(ctx, ctx.Org.Organization)
 }

--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -1,3 +1,7 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package user
 
 import (
@@ -79,4 +83,22 @@ func ListMyRepos(ctx *context.APIContext) {
 		i++
 	}
 	ctx.JSON(200, &apiRepos)
+}
+
+// ListOrgRepos - list the repositories of an organization.
+func ListOrgRepos(ctx *context.APIContext) {
+	// swagger:route GET /orgs/{org}/repos orgListRepos
+	//
+	//     Produces:
+	//     - application/json
+	//
+	//     Responses:
+	//       200: RepositoryList
+	//       500: error
+
+	org := GetOrgByParams(ctx)
+	if ctx.Written() {
+		return
+	}
+	listUserRepos(ctx, org)
 }


### PR DESCRIPTION
This is in favor of #1691 in order to fix #494. 

Sorry for opening a new PR, but this new approach seems to address all of the concerns brought up in #494. I also added an integration test, but was unsure of how to create a test organization in the integrations directory. If this PR is approved of over #494 I'll close that one and we can focus on this one. Otherwise I'll go back to fixing that one and close this one. 