### PR TITLE
Improve integration test helper functions

### DIFF
--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -5,7 +5,6 @@
 package integrations
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -25,9 +24,8 @@ func TestAPIListComments(t *testing.T) {
 	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
 
 	session := loginUser(t, repoOwner.Name)
-	requestUrl := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments",
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/%d/comments",
 		repoOwner.Name, repo.Name, issue.Index)
-	req := NewRequest(t, "GET", requestUrl)
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -5,7 +5,6 @@
 package integrations
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -22,8 +21,7 @@ func TestAPITeam(t *testing.T) {
 	user := models.AssertExistsAndLoadBean(t, &models.User{ID: teamUser.UID}).(*models.User)
 
 	session := loginUser(t, user.Name)
-	url := fmt.Sprintf("/api/v1/teams/%d", teamUser.TeamID)
-	req := NewRequest(t, "GET", url)
+	req := NewRequestf(t, "GET", "/api/v1/teams/%d", teamUser.TeamID)
 	resp := session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/change_default_branch_test.go
+++ b/integrations/change_default_branch_test.go
@@ -32,7 +32,6 @@ func TestChangeDefaultBranch(t *testing.T) {
 		"action": "default_branch",
 		"branch": "DefaultBranch",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
@@ -46,7 +45,6 @@ func TestChangeDefaultBranch(t *testing.T) {
 		"action": "default_branch",
 		"branch": "does_not_exist",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
 }

--- a/integrations/delete_user_test.go
+++ b/integrations/delete_user_test.go
@@ -26,7 +26,6 @@ func TestDeleteUser(t *testing.T) {
 	req = NewRequestWithValues(t, "POST", "/admin/users/8/delete", map[string]string{
 		"_csrf": doc.GetCSRF(),
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/editor_test.go
+++ b/integrations/editor_test.go
@@ -34,7 +34,6 @@ func TestCreateFile(t *testing.T) {
 		"content":       "Content",
 		"commit_choice": "direct",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 }
@@ -57,7 +56,6 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 		"branchName": "master",
 		"canPush":    "true",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 	// Check if master branch has been locked successfully
@@ -83,7 +81,6 @@ func TestCreateFileOnProtectedBranch(t *testing.T) {
 		"commit_choice": "direct",
 	})
 
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 	// Check body for error message
@@ -113,7 +110,6 @@ func testEditFile(t *testing.T, session *TestSession, user, repo, branch, filePa
 			"commit_choice": "direct",
 		},
 	)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
@@ -150,7 +146,6 @@ func testEditFileToNewBranch(t *testing.T, session *TestSession, user, repo, bra
 			"new_branch_name": targetBranch,
 		},
 	)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -173,7 +173,6 @@ func loginUserWithPassword(t testing.TB, userName, password string) *TestSession
 		"user_name": userName,
 		"password":  password,
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = MakeRequest(req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
@@ -218,18 +217,26 @@ func NewRequest(t testing.TB, method, urlStr string) *http.Request {
 	return NewRequestWithBody(t, method, urlStr, nil)
 }
 
+func NewRequestf(t testing.TB, method, urlFormat string, args ...interface{}) *http.Request {
+	return NewRequest(t, method, fmt.Sprintf(urlFormat, args...))
+}
+
 func NewRequestWithValues(t testing.TB, method, urlStr string, values map[string]string) *http.Request {
 	urlValues := url.Values{}
 	for key, value := range values {
 		urlValues[key] = []string{value}
 	}
-	return NewRequestWithBody(t, method, urlStr, bytes.NewBufferString(urlValues.Encode()))
+	req := NewRequestWithBody(t, method, urlStr, bytes.NewBufferString(urlValues.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	return req
 }
 
 func NewRequestWithJSON(t testing.TB, method, urlStr string, v interface{}) *http.Request {
 	jsonBytes, err := json.Marshal(v)
 	assert.NoError(t, err)
-	return NewRequestWithBody(t, method, urlStr, bytes.NewBuffer(jsonBytes))
+	req := NewRequestWithBody(t, method, urlStr, bytes.NewBuffer(jsonBytes))
+	req.Header.Add("Content-Type", "application/json")
+	return req
 }
 
 func NewRequestWithBody(t testing.TB, method, urlStr string, body io.Reader) *http.Request {

--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -90,7 +90,6 @@ func testNewIssue(t *testing.T, session *TestSession, user, repo, title string) 
 		"_csrf": htmlDoc.GetCSRF(),
 		"title": title,
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 	redirectedURL := resp.Headers["Location"]

--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -38,7 +38,6 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch strin
 		"_csrf": htmlDoc.GetCSRF(),
 		"title": "This is a pull title",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 

--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -25,7 +25,6 @@ func testPullMerge(t *testing.T, session *TestSession, user, repo, pullnum strin
 	req = NewRequestWithValues(t, "POST", link, map[string]string{
 		"_csrf": htmlDoc.GetCSRF(),
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 
@@ -44,7 +43,6 @@ func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum str
 	req = NewRequestWithValues(t, "POST", link, map[string]string{
 		"_csrf": htmlDoc.GetCSRF(),
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 

--- a/integrations/repo_commits_test.go
+++ b/integrations/repo_commits_test.go
@@ -56,7 +56,6 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 		},
 	)
 
-	req.Header.Add("Content-Type", "application/json")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusCreated, resp.HeaderCode)
 

--- a/integrations/repo_fork_test.go
+++ b/integrations/repo_fork_test.go
@@ -39,7 +39,6 @@ func testRepoFork(t *testing.T, session *TestSession) *TestResponse {
 		"uid":       "1",
 		"repo_name": "repo1",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 

--- a/integrations/repo_migrate_test.go
+++ b/integrations/repo_migrate_test.go
@@ -30,7 +30,6 @@ func testRepoMigrate(t testing.TB, session *TestSession, cloneAddr, repoName str
 		"repo_name":  repoName,
 	},
 	)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp = session.MakeRequest(t, req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 

--- a/integrations/signup_test.go
+++ b/integrations/signup_test.go
@@ -24,7 +24,6 @@ func TestSignup(t *testing.T) {
 		"password":  "examplePassword",
 		"retype":    "examplePassword",
 	})
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp := MakeRequest(req)
 	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
 


### PR DESCRIPTION
Set request headers in helper functions, and new helper for requests with string-formatted URLs.