### PR TITLE
Remove icons from explore navbar

### DIFF
--- a/templates/explore/navbar.tmpl
+++ b/templates/explore/navbar.tmpl
@@ -1,11 +1,11 @@
 <div class="ui secondary pointing tabular top attached borderless menu navbar">
 	<a class="{{if .PageIsExploreRepositories}}active{{end}} item" href="{{AppSubUrl}}/explore/repos">
-		<span class="octicon octicon-repo"></span> {{.i18n.Tr "explore.repos"}}
+		{{.i18n.Tr "explore.repos"}}
 	</a>
 	<a class="{{if .PageIsExploreUsers}}active{{end}} item" href="{{AppSubUrl}}/explore/users">
-		<span class="octicon octicon-person"></span> {{.i18n.Tr "explore.users"}}
+		{{.i18n.Tr "explore.users"}}
 	</a>
 	<a class="{{if .PageIsExploreOrganizations}}active{{end}} item" href="{{AppSubUrl}}/explore/organizations">
-		<span class="octicon octicon-organization"></span> {{.i18n.Tr "explore.organizations"}}
+		{{.i18n.Tr "explore.organizations"}}
 	</a>
 </div>


### PR DESCRIPTION
This is a matter of opinion. Feel free to reject it.

I think the UI is cleaner and more consistent without the icons on the explore navber. This PR removes them.

| Old | New |
| --- | --- |
| ![with-icons](https://user-images.githubusercontent.com/13909717/27512550-158ecd8a-5912-11e7-98ff-69e6959be28a.png) | ![without-icons](https://user-images.githubusercontent.com/13909717/27512551-158eead6-5912-11e7-87a3-719ea9a81066.png) |
