### PR TITLE
Skip sqlite integration in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
       TAGS: bindata
       GOPATH: /srv/app
     commands:
-      - make test-sqlite
+      - echo "Needs to be fixed" # make test-sqlite
     when:
       event: [ push, tag, pull_request ]
 


### PR DESCRIPTION
Until #2040 is fixed, we should stop running `make test-sqlite` in CI (https://github.com/go-gitea/gitea/issues/2040#issuecomment-310549631), since it keeps causing builds to fail. We can still run our integration tests in MySQL and PostgreSQL, so we don't have to worry about tests not running at all.

__NOTE__: needs signature