### PR TITLE
Absolute path for setting.CustomConf

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -595,6 +595,8 @@ func NewContext() {
 
 	if len(CustomConf) == 0 {
 		CustomConf = CustomPath + "/conf/app.ini"
+	} else if !filepath.IsAbs(CustomConf) {
+		CustomConf = filepath.Join(workDir, CustomConf)
 	}
 
 	if com.IsFile(CustomConf) {


### PR DESCRIPTION
Ensure that `setting.CustomConf` is an absolute path, so that the commands in `.ssh/authorized_keys` do not contain relative paths.
