### PR TITLE
Fix SQL bug in models.PullRequests

### DIFF
--- a/integrations/api_pull_test.go
+++ b/integrations/api_pull_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	api "code.gitea.io/sdk/gitea"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIViewPulls(t *testing.T) {
+	prepareTestEnv(t)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
+	owner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, "user2")
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/pulls?state=all", owner.Name, repo.Name)
+	resp := session.MakeRequest(t, req)
+	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+
+	var pulls []*api.PullRequest
+	DecodeJSON(t, resp, &pulls)
+	expectedLen := models.GetCount(t, &models.Issue{RepoID: repo.ID}, models.Cond("is_pull = ?", true))
+	assert.Len(t, pulls, expectedLen)
+}

--- a/models/pull.go
+++ b/models/pull.go
@@ -688,8 +688,6 @@ func listPullRequestStatement(baseRepoID int64, opts *PullRequestsOptions) (*xor
 		sess.And("issue.is_closed=?", opts.State == "closed")
 	}
 
-	sortIssuesSession(sess, opts.SortType)
-
 	if labelIDs, err := base.StringsToInt64s(opts.Labels); err != nil {
 		return nil, err
 	} else if len(labelIDs) > 0 {
@@ -723,6 +721,7 @@ func PullRequests(baseRepoID int64, opts *PullRequestsOptions) ([]*PullRequest, 
 
 	prs := make([]*PullRequest, 0, ItemsPerPage)
 	findSession, err := listPullRequestStatement(baseRepoID, opts)
+	sortIssuesSession(findSession, opts.SortType)
 	if err != nil {
 		log.Error(4, "listPullRequestStatement", err)
 		return nil, maxResults, err


### PR DESCRIPTION
Fixes the `GET /repos/:owner/:repo/pulls` API endpoint, which previously gave a 500 on Postgres.

Postgres doesn't like `ORDER BY` clauses in `SELECT COUNT(*) ...` queries.

Also add an integration test.