### PR TITLE
Fix missing-return bug

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -394,6 +394,7 @@ func RepoRef() macaron.Handler {
 					err = fmt.Errorf("No branches in non-bare repository %s",
 						ctx.Repo.GitRepo.Path)
 					ctx.Handle(500, "GetBranches", err)
+					return
 				}
 				refName = brs[0]
 			}


### PR DESCRIPTION
Prevent out-of-index error in `RepoRef()` handler.
