### PR TITLE
Improve org error handling

### DIFF
--- a/models/error.go
+++ b/models/error.go
@@ -448,6 +448,22 @@ func (err ErrAccessTokenEmpty) Error() string {
 // \_______  /__|  \___  (____  /___|  /__/_____ \(____  /__| |__|\____/|___|  /
 //         \/     /_____/     \/     \/         \/     \/                    \/
 
+// ErrOrgNotExist represents a "OrgNotExist" kind of error.
+type ErrOrgNotExist struct {
+	ID   int64
+	Name string
+}
+
+// IsErrOrgNotExist checks if an error is a ErrOrgNotExist.
+func IsErrOrgNotExist(err error) bool {
+	_, ok := err.(ErrOrgNotExist)
+	return ok
+}
+
+func (err ErrOrgNotExist) Error() string {
+	return fmt.Sprintf("org does not exist [id: %d, name: %s]", err.ID, err.Name)
+}
+
 // ErrLastOrgOwner represents a "LastOrgOwner" kind of error.
 type ErrLastOrgOwner struct {
 	UID int64

--- a/models/org.go
+++ b/models/org.go
@@ -16,8 +16,6 @@ import (
 )
 
 var (
-	// ErrOrgNotExist organization does not exist
-	ErrOrgNotExist = errors.New("Organization does not exist")
 	// ErrTeamNotExist team does not exist
 	ErrTeamNotExist = errors.New("Team does not exist")
 )
@@ -180,7 +178,7 @@ func CreateOrganization(org, owner *User) (err error) {
 // GetOrgByName returns organization by given name.
 func GetOrgByName(name string) (*User, error) {
 	if len(name) == 0 {
-		return nil, ErrOrgNotExist
+		return nil, ErrOrgNotExist{0, name}
 	}
 	u := &User{
 		LowerName: strings.ToLower(name),
@@ -190,7 +188,7 @@ func GetOrgByName(name string) (*User, error) {
 	if err != nil {
 		return nil, err
 	} else if !has {
-		return nil, ErrOrgNotExist
+		return nil, ErrOrgNotExist{0, name}
 	}
 	return u, nil
 }

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -230,7 +230,7 @@ func NewTeam(t *Team) (err error) {
 	if err != nil {
 		return err
 	} else if !has {
-		return ErrOrgNotExist
+		return ErrOrgNotExist{t.OrgID, ""}
 	}
 
 	t.LowerName = strings.ToLower(t.Name)

--- a/models/org_test.go
+++ b/models/org_test.go
@@ -222,10 +222,10 @@ func TestGetOrgByName(t *testing.T) {
 	assert.Equal(t, "user3", org.Name)
 
 	org, err = GetOrgByName("user2") // user2 is an individual
-	assert.Equal(t, ErrOrgNotExist, err)
+	assert.True(t, IsErrOrgNotExist(err))
 
 	org, err = GetOrgByName("") // corner case
-	assert.Equal(t, ErrOrgNotExist, err)
+	assert.True(t, IsErrOrgNotExist(err))
 }
 
 func TestCountOrganizations(t *testing.T) {

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -208,9 +208,9 @@ func orgAssignment(args ...bool) macaron.Handler {
 
 		var err error
 		if assignOrg {
-			ctx.Org.Organization, err = models.GetUserByName(ctx.Params(":orgname"))
+			ctx.Org.Organization, err = models.GetOrgByName(ctx.Params(":orgname"))
 			if err != nil {
-				if models.IsErrUserNotExist(err) {
+				if models.IsErrOrgNotExist(err) {
 					ctx.Status(404)
 				} else {
 					ctx.Error(500, "GetUserByName", err)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -213,7 +213,7 @@ func orgAssignment(args ...bool) macaron.Handler {
 				if models.IsErrOrgNotExist(err) {
 					ctx.Status(404)
 				} else {
-					ctx.Error(500, "GetUserByName", err)
+					ctx.Error(500, "GetOrgByName", err)
 				}
 				return
 			}

--- a/routers/api/v1/repo/fork.go
+++ b/routers/api/v1/repo/fork.go
@@ -59,7 +59,7 @@ func CreateFork(ctx *context.APIContext, form api.CreateForkOption) {
 	} else {
 		org, err := models.GetOrgByName(*form.Organization)
 		if err != nil {
-			if err == models.ErrOrgNotExist {
+			if models.IsErrOrgNotExist(err) {
 				ctx.Error(422, "", err)
 			} else {
 				ctx.Error(500, "GetOrgByName", err)

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -156,7 +156,7 @@ func CreateOrgRepo(ctx *context.APIContext, opt api.CreateRepoOption) {
 
 	org, err := models.GetOrgByName(ctx.Params(":org"))
 	if err != nil {
-		if models.IsErrUserNotExist(err) {
+		if models.IsErrOrgNotExist(err) {
 			ctx.Error(422, "", err)
 		} else {
 			ctx.Error(500, "GetOrgByName", err)


### PR DESCRIPTION
And enforcement that :orgname is a org by using GetOrgByName inplace of GetUserByName and specific error check (GetOrgByName return ErrOrgNotExist not IsErrUserNotExist ) like it was done in CreateOrgRepo. 
Before this PR we could use username as orgname.

This could also be done for enforcement of team in a other PR.

~~~Note: I have quickly done this change via the web editor. It need to be tested but should be good.~~~