### PR TITLE
Less verbose integration tests

### DIFF
--- a/integrations/api_branch_test.go
+++ b/integrations/api_branch_test.go
@@ -18,7 +18,7 @@ func testAPIGetBranch(t *testing.T, branchName string, exists bool) {
 
 	session := loginUser(t, "user2")
 	req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/branches/%s", branchName)
-	resp := session.MakeRequest(t, req)
+	resp := session.MakeRequest(t, req, NoExpectedStatus)
 	if !exists {
 		assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
 		return

--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -26,8 +26,7 @@ func TestAPIListComments(t *testing.T) {
 	session := loginUser(t, repoOwner.Name)
 	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/%d/comments",
 		repoOwner.Name, repo.Name, issue.Index)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	var comments []*api.Comment
 	DecodeJSON(t, resp, &comments)

--- a/integrations/api_issue_label_test.go
+++ b/integrations/api_issue_label_test.go
@@ -29,8 +29,7 @@ func TestAPIAddIssueLabels(t *testing.T) {
 		Labels: []int64{label.ID},
 	})
 	session := loginUser(t, owner.Name)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	var apiLabels []*api.Label
 	DecodeJSON(t, resp, &apiLabels)
 	assert.Len(t, apiLabels, models.GetCount(t, &models.IssueLabel{IssueID: issue.ID}))
@@ -52,8 +51,7 @@ func TestAPIReplaceIssueLabels(t *testing.T) {
 		Labels: []int64{label.ID},
 	})
 	session := loginUser(t, owner.Name)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	var apiLabels []*api.Label
 	DecodeJSON(t, resp, &apiLabels)
 	assert.Len(t, apiLabels, 1)

--- a/integrations/api_issue_test.go
+++ b/integrations/api_issue_test.go
@@ -24,8 +24,7 @@ func TestAPIListIssues(t *testing.T) {
 	session := loginUser(t, owner.Name)
 	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues?state=all",
 		owner.Name, repo.Name)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	var apiIssues []*api.Issue
 	DecodeJSON(t, resp, &apiIssues)
 	assert.Len(t, apiIssues, models.GetCount(t, &models.Issue{RepoID: repo.ID}))
@@ -49,8 +48,7 @@ func TestAPICreateIssue(t *testing.T) {
 		Title:    title,
 		Assignee: owner.Name,
 	})
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusCreated, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusCreated)
 	var apiIssue api.Issue
 	DecodeJSON(t, resp, &apiIssue)
 	assert.Equal(t, apiIssue.Body, body)

--- a/integrations/api_pull_test.go
+++ b/integrations/api_pull_test.go
@@ -21,8 +21,7 @@ func TestAPIViewPulls(t *testing.T) {
 
 	session := loginUser(t, "user2")
 	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/pulls?state=all", owner.Name, repo.Name)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	var pulls []*api.PullRequest
 	DecodeJSON(t, resp, &pulls)

--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -7,22 +7,18 @@ package integrations
 import (
 	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIUserReposNotLogin(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/api/v1/users/user2/repos")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func TestAPISearchRepoNotLogin(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/api/v1/repos/search?q=Test")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }

--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -22,8 +22,7 @@ func TestAPITeam(t *testing.T) {
 
 	session := loginUser(t, user.Name)
 	req := NewRequestf(t, "GET", "/api/v1/teams/%d", teamUser.TeamID)
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	var apiTeam api.Team
 	DecodeJSON(t, resp, &apiTeam)

--- a/integrations/delete_user_test.go
+++ b/integrations/delete_user_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDeleteUser(t *testing.T) {
@@ -18,16 +16,11 @@ func TestDeleteUser(t *testing.T) {
 
 	session := loginUser(t, "user1")
 
-	req := NewRequest(t, "GET", "/admin/users/8")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
-
-	doc := NewHTMLParser(t, resp.Body)
-	req = NewRequestWithValues(t, "POST", "/admin/users/8/delete", map[string]string{
-		"_csrf": doc.GetCSRF(),
+	csrf := GetCSRF(t, session, "/admin/users/8")
+	req := NewRequestWithValues(t, "POST", "/admin/users/8/delete", map[string]string{
+		"_csrf": csrf,
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	session.MakeRequest(t, req, http.StatusOK)
 
 	models.AssertNotExistsBean(t, &models.User{ID: 8})
 	models.CheckConsistencyFor(t, &models.User{})

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -140,13 +140,13 @@ func (s *TestSession) GetCookie(name string) *http.Cookie {
 	return nil
 }
 
-func (s *TestSession) MakeRequest(t testing.TB, req *http.Request) *TestResponse {
+func (s *TestSession) MakeRequest(t testing.TB, req *http.Request, expectedStatus int) *TestResponse {
 	baseURL, err := url.Parse(setting.AppURL)
 	assert.NoError(t, err)
 	for _, c := range s.jar.Cookies(baseURL) {
 		req.AddCookie(c)
 	}
-	resp := MakeRequest(req)
+	resp := MakeRequest(t, req, expectedStatus)
 
 	ch := http.Header{}
 	ch.Add("Cookie", strings.Join(resp.Headers["Set-Cookie"], ";"))
@@ -164,8 +164,7 @@ func loginUser(t testing.TB, userName string) *TestSession {
 
 func loginUserWithPassword(t testing.TB, userName, password string) *TestSession {
 	req := NewRequest(t, "GET", "/user/login")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := MakeRequest(t, req, http.StatusOK)
 
 	doc := NewHTMLParser(t, resp.Body)
 	req = NewRequestWithValues(t, "POST", "/user/login", map[string]string{
@@ -173,8 +172,7 @@ func loginUserWithPassword(t testing.TB, userName, password string) *TestSession
 		"user_name": userName,
 		"password":  password,
 	})
-	resp = MakeRequest(req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = MakeRequest(t, req, http.StatusFound)
 
 	ch := http.Header{}
 	ch.Add("Cookie", strings.Join(resp.Headers["Set-Cookie"], ";"))
@@ -246,13 +244,18 @@ func NewRequestWithBody(t testing.TB, method, urlStr string, body io.Reader) *ht
 	return request
 }
 
-func MakeRequest(req *http.Request) *TestResponse {
+const NoExpectedStatus = -1
+
+func MakeRequest(t testing.TB, req *http.Request, expectedStatus int) *TestResponse {
 	buffer := bytes.NewBuffer(nil)
 	respWriter := &TestResponseWriter{
 		Writer:  buffer,
 		Headers: make(map[string][]string),
 	}
 	mac.ServeHTTP(respWriter, req)
+	if expectedStatus != NoExpectedStatus {
+		assert.EqualValues(t, expectedStatus, respWriter.HeaderCode)
+	}
 	return &TestResponse{
 		HeaderCode: respWriter.HeaderCode,
 		Body:       buffer.Bytes(),
@@ -263,4 +266,11 @@ func MakeRequest(req *http.Request) *TestResponse {
 func DecodeJSON(t testing.TB, resp *TestResponse, v interface{}) {
 	decoder := json.NewDecoder(bytes.NewBuffer(resp.Body))
 	assert.NoError(t, decoder.Decode(v))
+}
+
+func GetCSRF(t testing.TB, session *TestSession, urlStr string) string {
+	req := NewRequest(t, "GET", urlStr)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	doc := NewHTMLParser(t, resp.Body)
+	return doc.GetCSRF()
 }

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -274,3 +274,9 @@ func GetCSRF(t testing.TB, session *TestSession, urlStr string) string {
 	doc := NewHTMLParser(t, resp.Body)
 	return doc.GetCSRF()
 }
+
+func RedirectURL(t testing.TB, resp *TestResponse) string {
+	urlSlice := resp.Headers["Location"]
+	assert.NotEmpty(t, urlSlice, "No redirect URL founds")
+	return urlSlice[0]
+}

--- a/integrations/internal_test.go
+++ b/integrations/internal_test.go
@@ -23,9 +23,9 @@ func assertProtectedBranch(t *testing.T, repoID int64, branchName string, isErr,
 	t.Log(reqURL)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", setting.InternalToken))
 
-	resp := MakeRequest(req)
+	resp := MakeRequest(t, req, NoExpectedStatus)
 	if isErr {
-		assert.EqualValues(t, 500, resp.HeaderCode)
+		assert.EqualValues(t, http.StatusInternalServerError, resp.HeaderCode)
 	} else {
 		assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 		var branch models.ProtectedBranch

--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -35,8 +35,7 @@ func TestNoLoginViewIssues(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user2/repo1/issues")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func TestNoLoginViewIssuesSortByType(t *testing.T) {
@@ -48,8 +47,7 @@ func TestNoLoginViewIssuesSortByType(t *testing.T) {
 
 	session := loginUser(t, user.Name)
 	req := NewRequest(t, "GET", repo.RelLink()+"/issues?type=created_by")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	issuesSelection := getIssuesSelection(htmlDoc)
@@ -73,15 +71,13 @@ func TestNoLoginViewIssue(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user2/repo1/issues/1")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func testNewIssue(t *testing.T, session *TestSession, user, repo, title string) {
 
 	req := NewRequest(t, "GET", path.Join(user, repo, "issues", "new"))
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find("form.ui.form").Attr("action")
@@ -90,14 +86,12 @@ func testNewIssue(t *testing.T, session *TestSession, user, repo, title string) 
 		"_csrf": htmlDoc.GetCSRF(),
 		"title": title,
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 	redirectedURL := resp.Headers["Location"]
 	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
 
 	req = NewRequest(t, "GET", redirectedURL[0])
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 }
 
 func TestNewIssue(t *testing.T) {

--- a/integrations/issue_test.go
+++ b/integrations/issue_test.go
@@ -87,10 +87,8 @@ func testNewIssue(t *testing.T, session *TestSession, user, repo, title string) 
 		"title": title,
 	})
 	resp = session.MakeRequest(t, req, http.StatusFound)
-	redirectedURL := resp.Headers["Location"]
-	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
 
-	req = NewRequest(t, "GET", redirectedURL[0])
+	req = NewRequest(t, "GET", RedirectURL(t, resp))
 	resp = session.MakeRequest(t, req, http.StatusOK)
 }
 

--- a/integrations/pull_compare_test.go
+++ b/integrations/pull_compare_test.go
@@ -16,13 +16,12 @@ func TestPullCompare(t *testing.T) {
 
 	session := loginUser(t, "user2")
 	req := NewRequest(t, "GET", "/user2/repo1/pulls")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find(".navbar").Find(".ui.green.button").Attr("href")
 	assert.True(t, exists, "The template has changed")
 
 	req = NewRequest(t, "GET", link)
-	resp = session.MakeRequest(t, req)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
 }

--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -15,8 +15,7 @@ import (
 
 func testPullCreate(t *testing.T, session *TestSession, user, repo, branch string) *TestResponse {
 	req := NewRequest(t, "GET", path.Join(user, repo))
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	// Click the little green button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
@@ -27,8 +26,7 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch strin
 	}
 
 	req = NewRequest(t, "GET", link)
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	// Submit the form for creating the pull
 	htmlDoc = NewHTMLParser(t, resp.Body)
@@ -38,8 +36,7 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch strin
 		"_csrf": htmlDoc.GetCSRF(),
 		"title": "This is a pull title",
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	//TODO check the redirected URL
 

--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -15,8 +15,7 @@ import (
 
 func testPullMerge(t *testing.T, session *TestSession, user, repo, pullnum string) *TestResponse {
 	req := NewRequest(t, "GET", path.Join(user, repo, "pulls", pullnum))
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	// Click the little green button to craete a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
@@ -25,16 +24,14 @@ func testPullMerge(t *testing.T, session *TestSession, user, repo, pullnum strin
 	req = NewRequestWithValues(t, "POST", link, map[string]string{
 		"_csrf": htmlDoc.GetCSRF(),
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	return resp
 }
 
 func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum string) *TestResponse {
 	req := NewRequest(t, "GET", path.Join(user, repo, "pulls", pullnum))
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	// Click the little green button to craete a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
@@ -43,8 +40,7 @@ func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum str
 	req = NewRequestWithValues(t, "POST", link, map[string]string{
 		"_csrf": htmlDoc.GetCSRF(),
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	return resp
 }
@@ -92,8 +88,7 @@ func TestPullCleanUpAfterMerge(t *testing.T) {
 
 	// Check branch deletion result
 	req := NewRequest(t, "GET", respJSON.Redirect)
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	resultMsg := htmlDoc.doc.Find(".ui.message>p").Text()

--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -52,10 +52,8 @@ func TestPullMerge(t *testing.T) {
 	testEditFile(t, session, "user1", "repo1", "master", "README.md")
 
 	resp := testPullCreate(t, session, "user1", "repo1", "master")
-	redirectedURL := resp.Headers["Location"]
-	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
 
-	elem := strings.Split(redirectedURL[0], "/")
+	elem := strings.Split(RedirectURL(t, resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
 	testPullMerge(t, session, elem[1], elem[2], elem[4])
 }
@@ -67,10 +65,8 @@ func TestPullCleanUpAfterMerge(t *testing.T) {
 	testEditFileToNewBranch(t, session, "user1", "repo1", "master", "feature/test", "README.md")
 
 	resp := testPullCreate(t, session, "user1", "repo1", "feature/test")
-	redirectedURL := resp.Headers["Location"]
-	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
 
-	elem := strings.Split(redirectedURL[0], "/")
+	elem := strings.Split(RedirectURL(t, resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
 	testPullMerge(t, session, elem[1], elem[2], elem[4])
 

--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -17,7 +17,7 @@ func testPullMerge(t *testing.T, session *TestSession, user, repo, pullnum strin
 	req := NewRequest(t, "GET", path.Join(user, repo, "pulls", pullnum))
 	resp := session.MakeRequest(t, req, http.StatusOK)
 
-	// Click the little green button to craete a pull
+	// Click the little green button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find("form.ui.form>button.ui.green.button").Parent().Attr("action")
 	assert.True(t, exists, "The template has changed")
@@ -33,7 +33,7 @@ func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum str
 	req := NewRequest(t, "GET", path.Join(user, repo, "pulls", pullnum))
 	resp := session.MakeRequest(t, req, http.StatusOK)
 
-	// Click the little green button to craete a pull
+	// Click the little green button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find(".comments .merge .delete-button").Attr("data-url")
 	assert.True(t, exists, "The template has changed")

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -15,8 +15,7 @@ import (
 
 func createNewRelease(t *testing.T, session *TestSession, repoURL, tag, title string, preRelease, draft bool) {
 	req := NewRequest(t, "GET", repoURL+"/releases/new")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 
 	link, exists := htmlDoc.doc.Find("form").Attr("action")
@@ -37,8 +36,7 @@ func createNewRelease(t *testing.T, session *TestSession, repoURL, tag, title st
 	}
 	req = NewRequestWithValues(t, "POST", link, postData)
 
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	redirectedURL := resp.Headers["Location"]
 	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
@@ -46,8 +44,7 @@ func createNewRelease(t *testing.T, session *TestSession, repoURL, tag, title st
 
 func checkLatestReleaseAndCount(t *testing.T, session *TestSession, repoURL, version, label string, count int) {
 	req := NewRequest(t, "GET", repoURL+"/releases")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	labelText := htmlDoc.doc.Find("#release-list > li .meta .label").First().Text()
@@ -64,16 +61,14 @@ func TestViewReleases(t *testing.T) {
 
 	session := loginUser(t, "user2")
 	req := NewRequest(t, "GET", "/user2/repo1/releases")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	session.MakeRequest(t, req, http.StatusOK)
 }
 
 func TestViewReleasesNoLogin(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user2/repo1/releases")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func TestCreateRelease(t *testing.T) {

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -38,8 +38,7 @@ func createNewRelease(t *testing.T, session *TestSession, repoURL, tag, title st
 
 	resp = session.MakeRequest(t, req, http.StatusFound)
 
-	redirectedURL := resp.Headers["Location"]
-	assert.NotEmpty(t, redirectedURL, "Redirected URL is not found")
+	RedirectURL(t, resp) // check that redirect URL exists
 }
 
 func checkLatestReleaseAndCount(t *testing.T, session *TestSession, repoURL, version, label string, count int) {

--- a/integrations/repo_commits_test.go
+++ b/integrations/repo_commits_test.go
@@ -21,8 +21,7 @@ func TestRepoCommits(t *testing.T) {
 
 	// Request repository commits page
 	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	doc := NewHTMLParser(t, resp.Body)
 	commitURL, exists := doc.doc.Find("#commits-table tbody tr td.sha a").Attr("href")
@@ -37,8 +36,7 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 
 	// Request repository commits page
 	req := NewRequest(t, "GET", "/user2/repo1/commits/master")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	doc := NewHTMLParser(t, resp.Body)
 	// Get first commit URL
@@ -56,12 +54,10 @@ func doTestRepoCommitWithStatus(t *testing.T, state string, classes ...string) {
 		},
 	)
 
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusCreated, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusCreated)
 
 	req = NewRequest(t, "GET", "/user2/repo1/commits/master")
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	doc = NewHTMLParser(t, resp.Body)
 	// Check if commit status is displayed in message column

--- a/integrations/repo_fork_test.go
+++ b/integrations/repo_fork_test.go
@@ -14,21 +14,18 @@ import (
 func testRepoFork(t *testing.T, session *TestSession) *TestResponse {
 	// Step0: check the existence of the to-fork repo
 	req := NewRequest(t, "GET", "/user1/repo1")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusNotFound)
 
 	// Step1: go to the main page of repo
 	req = NewRequest(t, "GET", "/user2/repo1")
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	// Step2: click the fork button
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	link, exists := htmlDoc.doc.Find("a.ui.button[href^=\"/repo/fork/\"]").Attr("href")
 	assert.True(t, exists, "The template has changed")
 	req = NewRequest(t, "GET", link)
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	// Step3: fill the form of the forking
 	htmlDoc = NewHTMLParser(t, resp.Body)
@@ -39,13 +36,11 @@ func testRepoFork(t *testing.T, session *TestSession) *TestResponse {
 		"uid":       "1",
 		"repo_name": "repo1",
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	// Step4: check the existence of the forked repo
 	req = NewRequest(t, "GET", "/user1/repo1")
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	return resp
 }

--- a/integrations/repo_migrate_test.go
+++ b/integrations/repo_migrate_test.go
@@ -13,8 +13,7 @@ import (
 
 func testRepoMigrate(t testing.TB, session *TestSession, cloneAddr, repoName string) *TestResponse {
 	req := NewRequest(t, "GET", "/repo/migrate")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 
 	link, exists := htmlDoc.doc.Find("form.ui.form").Attr("action")
@@ -30,8 +29,7 @@ func testRepoMigrate(t testing.TB, session *TestSession, cloneAddr, repoName str
 		"repo_name":  repoName,
 	},
 	)
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	return resp
 }

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -7,24 +7,19 @@ package integrations
 import (
 	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestViewRepo(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user2/repo1")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 
 	req = NewRequest(t, "GET", "/user3/repo3")
-	resp = MakeRequest(req)
-	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusNotFound)
 
 	session := loginUser(t, "user1")
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusNotFound, resp.HeaderCode)
+	session.MakeRequest(t, req, http.StatusNotFound)
 }
 
 func TestViewRepo2(t *testing.T) {
@@ -32,8 +27,7 @@ func TestViewRepo2(t *testing.T) {
 
 	req := NewRequest(t, "GET", "/user3/repo3")
 	session := loginUser(t, "user2")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	session.MakeRequest(t, req, http.StatusOK)
 }
 
 func TestViewRepo3(t *testing.T) {
@@ -41,6 +35,5 @@ func TestViewRepo3(t *testing.T) {
 
 	req := NewRequest(t, "GET", "/user3/repo3")
 	session := loginUser(t, "user3")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	session.MakeRequest(t, req, http.StatusOK)
 }

--- a/integrations/signup_test.go
+++ b/integrations/signup_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSignup(t *testing.T) {
@@ -24,11 +22,9 @@ func TestSignup(t *testing.T) {
 		"password":  "examplePassword",
 		"retype":    "examplePassword",
 	})
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusFound)
 
 	// should be able to view new user's page
 	req = NewRequest(t, "GET", "/exampleUser")
-	resp = MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }

--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -25,17 +25,12 @@ func TestRenameUsername(t *testing.T) {
 	prepareTestEnv(t)
 
 	session := loginUser(t, "user2")
-
-	req := NewRequest(t, "GET", "/user/settings")
-	resp := session.MakeRequest(t, req, http.StatusOK)
-
-	htmlDoc := NewHTMLParser(t, resp.Body)
-	req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
-		"_csrf": htmlDoc.GetCSRF(),
+	req := NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
+		"_csrf": GetCSRF(t, session, "/user/settings"),
 		"name":  "newUsername",
 		"email": "user2@example.com",
 	})
-	resp = session.MakeRequest(t, req, http.StatusFound)
+	session.MakeRequest(t, req, http.StatusFound)
 
 	models.AssertExistsAndLoadBean(t, &models.User{Name: "newUsername"})
 	models.AssertNotExistsBean(t, &models.User{Name: "user2"})
@@ -55,17 +50,14 @@ func TestRenameInvalidUsername(t *testing.T) {
 	session := loginUser(t, "user2")
 	for _, invalidUsername := range invalidUsernames {
 		t.Logf("Testing username %s", invalidUsername)
-		req := NewRequest(t, "GET", "/user/settings")
-		resp := session.MakeRequest(t, req, http.StatusOK)
 
-		htmlDoc := NewHTMLParser(t, resp.Body)
-		req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
-			"_csrf": htmlDoc.GetCSRF(),
+		req := NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
+			"_csrf": GetCSRF(t, session, "/user/settings"),
 			"name":  invalidUsername,
 			"email": "user2@example.com",
 		})
-		resp = session.MakeRequest(t, req, http.StatusOK)
-		htmlDoc = NewHTMLParser(t, resp.Body)
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		htmlDoc := NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),
 			i18n.Tr("en", "form.alpha_dash_dot_error"),
@@ -87,20 +79,16 @@ func TestRenameReservedUsername(t *testing.T) {
 	session := loginUser(t, "user2")
 	for _, reservedUsername := range reservedUsernames {
 		t.Logf("Testing username %s", reservedUsername)
-		req := NewRequest(t, "GET", "/user/settings")
-		resp := session.MakeRequest(t, req, http.StatusOK)
-
-		htmlDoc := NewHTMLParser(t, resp.Body)
-		req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
-			"_csrf": htmlDoc.GetCSRF(),
+		req := NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
+			"_csrf": GetCSRF(t, session, "/user/settings"),
 			"name":  reservedUsername,
 			"email": "user2@example.com",
 		})
-		resp = session.MakeRequest(t, req, http.StatusFound)
+		resp := session.MakeRequest(t, req, http.StatusFound)
 
-		req = NewRequest(t, "GET", "/user/settings")
+		req = NewRequest(t, "GET", RedirectURL(t, resp))
 		resp = session.MakeRequest(t, req, http.StatusOK)
-		htmlDoc = NewHTMLParser(t, resp.Body)
+		htmlDoc := NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),
 			i18n.Tr("en", "user.newName_reserved"),

--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -18,8 +18,7 @@ func TestViewUser(t *testing.T) {
 	prepareTestEnv(t)
 
 	req := NewRequest(t, "GET", "/user2")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func TestRenameUsername(t *testing.T) {
@@ -28,8 +27,7 @@ func TestRenameUsername(t *testing.T) {
 	session := loginUser(t, "user2")
 
 	req := NewRequest(t, "GET", "/user/settings")
-	resp := session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
@@ -37,8 +35,7 @@ func TestRenameUsername(t *testing.T) {
 		"name":  "newUsername",
 		"email": "user2@example.com",
 	})
-	resp = session.MakeRequest(t, req)
-	assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+	resp = session.MakeRequest(t, req, http.StatusFound)
 
 	models.AssertExistsAndLoadBean(t, &models.User{Name: "newUsername"})
 	models.AssertNotExistsBean(t, &models.User{Name: "user2"})
@@ -59,8 +56,7 @@ func TestRenameInvalidUsername(t *testing.T) {
 	for _, invalidUsername := range invalidUsernames {
 		t.Logf("Testing username %s", invalidUsername)
 		req := NewRequest(t, "GET", "/user/settings")
-		resp := session.MakeRequest(t, req)
-		assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+		resp := session.MakeRequest(t, req, http.StatusOK)
 
 		htmlDoc := NewHTMLParser(t, resp.Body)
 		req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
@@ -68,8 +64,7 @@ func TestRenameInvalidUsername(t *testing.T) {
 			"name":  invalidUsername,
 			"email": "user2@example.com",
 		})
-		resp = session.MakeRequest(t, req)
-		assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+		resp = session.MakeRequest(t, req, http.StatusOK)
 		htmlDoc = NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),
@@ -93,8 +88,7 @@ func TestRenameReservedUsername(t *testing.T) {
 	for _, reservedUsername := range reservedUsernames {
 		t.Logf("Testing username %s", reservedUsername)
 		req := NewRequest(t, "GET", "/user/settings")
-		resp := session.MakeRequest(t, req)
-		assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+		resp := session.MakeRequest(t, req, http.StatusOK)
 
 		htmlDoc := NewHTMLParser(t, resp.Body)
 		req = NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
@@ -102,12 +96,10 @@ func TestRenameReservedUsername(t *testing.T) {
 			"name":  reservedUsername,
 			"email": "user2@example.com",
 		})
-		resp = session.MakeRequest(t, req)
-		assert.EqualValues(t, http.StatusFound, resp.HeaderCode)
+		resp = session.MakeRequest(t, req, http.StatusFound)
 
 		req = NewRequest(t, "GET", "/user/settings")
-		resp = session.MakeRequest(t, req)
-		assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+		resp = session.MakeRequest(t, req, http.StatusOK)
 		htmlDoc = NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),

--- a/integrations/version_test.go
+++ b/integrations/version_test.go
@@ -19,8 +19,7 @@ func TestVersion(t *testing.T) {
 
 	setting.AppVer = "1.1.0+dev"
 	req := NewRequest(t, "GET", "/api/v1/version")
-	resp := MakeRequest(req)
-	assert.EqualValues(t, http.StatusOK, resp.HeaderCode)
+	resp := MakeRequest(t, req, http.StatusOK)
 
 	var version gitea.ServerVersion
 	DecodeJSON(t, resp, &version)


### PR DESCRIPTION
Changes to make integration tests less verbose
- Add expected status code argument to `MakeRequest(..)`, which saves a lot of `assert.EqualValues(t, http.StatusXYZ, resp.HeaderCode)` lines
- Helper function to get CSRF token (`GetCSRF(..)`)
- Helper function for getting redirect URL (`RedirectURL(..)`)