### PR TITLE
[WIP] Fix SQLite 'database table is locked' problem

### DIFF
--- a/vendor/github.com/mattn/go-sqlite3/callback.c
+++ b/vendor/github.com/mattn/go-sqlite3/callback.c
@@ -1,0 +1,5 @@
+void _unlock_notify_callback(void *arg, int argc)
+{
+  extern void unlock_notify_callback(void *, int);
+  unlock_notify_callback(arg, argc);
+}

--- a/vendor/github.com/mattn/go-sqlite3/sqlite3.go
+++ b/vendor/github.com/mattn/go-sqlite3/sqlite3.go
@@ -127,7 +127,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -740,10 +739,8 @@ func (c *SQLiteConn) prepare(ctx context.Context, query string) (driver.Stmt, er
 		}
 	}
 	if rv != C.SQLITE_OK {
-		fmt.Fprintf(os.Stderr, "prepare:%v\n", c.lastError())
 		return nil, c.lastError()
 	}
-
 	var t string
 	if tail != nil && *tail != '\000' {
 		t = strings.TrimSpace(C.GoString(tail))
@@ -916,10 +913,8 @@ func (s *SQLiteStmt) exec(ctx context.Context, args []namedValue) (driver.Result
 	}(s.c.db)
 
 	var rowid, changes C.longlong
-
 	rv := C._sqlite3_step(s.s, &rowid, &changes)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
-		fmt.Fprintf(os.Stderr, "exec:%v\n", s.c.lastError())
 		err := s.c.lastError()
 		C.sqlite3_reset(s.s)
 		C.sqlite3_clear_bindings(s.s)


### PR DESCRIPTION
Fixes #2040 

CAVEAT: the PR hasn't fixed the issue yet.

According to the documentation, the upper layer has to handle the `SQLITE_LCOKED` status code reported by the underlying `sqlite_unlock_notify` API as well. The proper approach to fix it in upper layers still needs investigation but the basic mechanism described in the following link has been implemented in the PR. 

If this can eventually fix the issue, I will propose the PR to upstream.

Reference: https://sqlite.org/unlock_notify.html.
