### PR TITLE
Cache session cookies in tests

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -158,8 +158,15 @@ func (s *TestSession) MakeRequest(t testing.TB, req *http.Request, expectedStatu
 
 const userPassword = "password"
 
+var loginSessionCache = make(map[string]*TestSession, 10)
+
 func loginUser(t testing.TB, userName string) *TestSession {
-	return loginUserWithPassword(t, userName, userPassword)
+	if session, ok := loginSessionCache[userName]; ok {
+		return session
+	}
+	session := loginUserWithPassword(t, userName, userPassword)
+	loginSessionCache[userName] = session
+	return session
 }
 
 func loginUserWithPassword(t testing.TB, userName, password string) *TestSession {


### PR DESCRIPTION
Cache session cookies in integration tests to avoid repeatedly logging in. Makes tests a little faster (`make test-mysql` goes from 34 to 30 seconds on my laptop)
