### PR TITLE
Use POSIX complaint ! operator in find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BINDATA := modules/{options,public,templates}/bindata.go
 STYLESHEETS := $(wildcard public/less/index.less public/less/_*.less)
 JAVASCRIPTS :=
 DOCKER_TAG := gitea/gitea:latest
-GOFILES := $(shell find . -name "*.go" -type f -not -path "./vendor/*" -not -path "*/bindata.go")
+GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*" ! -path "*/bindata.go")
 GOFMT ?= gofmt -s
 
 GOFLAGS := -i -v

--- a/vendor/code.gitea.io/git/Makefile
+++ b/vendor/code.gitea.io/git/Makefile
@@ -18,7 +18,7 @@ generate:
 
 .PHONY: fmt
 fmt:
-	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark/*" | xargs gofmt -s -w
+	find . -name "*.go" -type f ! -path "./vendor/*" ! -path "./benchmark/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:

--- a/vendor/code.gitea.io/git/Makefile
+++ b/vendor/code.gitea.io/git/Makefile
@@ -18,7 +18,7 @@ generate:
 
 .PHONY: fmt
 fmt:
-	find . -name "*.go" -type f ! -path "./vendor/*" ! -path "./benchmark/*" | xargs gofmt -s -w
+	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
-not is a GNU extension and not all find(8) implementations
support it. It's just an alias for ! which is POSIX compliant.

Now gitea compiles on NetBSD at least.