### PR TITLE
Missing signed commit display translations

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -581,6 +581,8 @@ commits.message = Message
 commits.date = Date
 commits.older = Older
 commits.newer = Newer
+commits.signed_by = Signed by
+commits.gpg_key_id = GPG key ID
 
 ext_issues = Ext Issues
 ext_issues.desc = Ext Issues link to an external issue management page

--- a/templates/repo/diff/page.tmpl
+++ b/templates/repo/diff/page.tmpl
@@ -45,9 +45,9 @@
 				{{if .Verification.Verified }}
 					<div class="ui bottom attached positive message" style="text-align: initial;color: black;">
 					  <i class="green lock icon"></i>
-						<span style="color: #2C662D;">Signed by :</span>
+						<span style="color: #2C662D;">{{.i18n.Tr "repo.commits.signed_by"}}:</span>
 						<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Commit.Committer.Name}}</strong></a> <{{.Commit.Committer.Email}}>
-						<span class="pull-right"><span style="color: #2C662D;">GPG key ID:</span> {{.Verification.SigningKey.KeyID}}</span>
+						<span class="pull-right"><span style="color: #2C662D;">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> {{.Verification.SigningKey.KeyID}}</span>
 					</div>
 				{{else}}
 					<div class="ui bottom attached message" style="text-align: initial;color: black;">


### PR DESCRIPTION
Untranslated strings when displaying signed commit info