### PR TITLE
More integration tests for comment API

### DIFF
--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -5,6 +5,7 @@
 package integrations
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIListComments(t *testing.T) {
+func TestAPIListRepoComments(t *testing.T) {
+	prepareTestEnv(t)
+
+	comment := models.AssertExistsAndLoadBean(t, &models.Comment{},
+		models.Cond("type = ?", models.CommentTypeComment)).(*models.Comment)
+	issue := models.AssertExistsAndLoadBean(t, &models.Issue{ID: comment.IssueID}).(*models.Issue)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/comments",
+		repoOwner.Name, repo.Name)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+
+	var apiComments []*api.Comment
+	DecodeJSON(t, resp, &apiComments)
+	for _, apiComment := range apiComments {
+		c := &models.Comment{ID: apiComment.ID}
+		models.AssertExistsAndLoadBean(t, c,
+			models.Cond("type = ?", models.CommentTypeComment))
+		models.AssertExistsAndLoadBean(t, &models.Issue{ID: c.IssueID, RepoID: repo.ID})
+	}
+}
+
+func TestAPIListIssueComments(t *testing.T) {
 	prepareTestEnv(t)
 
 	comment := models.AssertExistsAndLoadBean(t, &models.Comment{},
@@ -33,4 +58,68 @@ func TestAPIListComments(t *testing.T) {
 	expectedCount := models.GetCount(t, &models.Comment{IssueID: issue.ID},
 		models.Cond("type = ?", models.CommentTypeComment))
 	assert.EqualValues(t, expectedCount, len(comments))
+}
+
+func TestAPICreateComment(t *testing.T) {
+	prepareTestEnv(t)
+	const commentBody = "Comment body"
+
+	issue := models.AssertExistsAndLoadBean(t, &models.Issue{}).(*models.Issue)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments",
+		repoOwner.Name, repo.Name, issue.Index)
+	req := NewRequestWithValues(t, "POST", urlStr, map[string]string{
+		"body": commentBody,
+	})
+	resp := session.MakeRequest(t, req, http.StatusCreated)
+
+	var updatedComment api.Comment
+	DecodeJSON(t, resp, &updatedComment)
+	assert.EqualValues(t, commentBody, updatedComment.Body)
+	models.AssertExistsAndLoadBean(t, &models.Comment{ID: updatedComment.ID, IssueID: issue.ID, Content: commentBody})
+}
+
+func TestAPIEditComment(t *testing.T) {
+	prepareTestEnv(t)
+	const newCommentBody = "This is the new comment body"
+
+	comment := models.AssertExistsAndLoadBean(t, &models.Comment{},
+		models.Cond("type = ?", models.CommentTypeComment)).(*models.Comment)
+	issue := models.AssertExistsAndLoadBean(t, &models.Issue{ID: comment.IssueID}).(*models.Issue)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments/%d",
+		repoOwner.Name, repo.Name, issue.Index, comment.ID)
+	req := NewRequestWithValues(t, "PATCH", urlStr, map[string]string{
+		"body": newCommentBody,
+	})
+	resp := session.MakeRequest(t, req, http.StatusOK)
+
+	var updatedComment api.Comment
+	DecodeJSON(t, resp, &updatedComment)
+	assert.EqualValues(t, comment.ID, updatedComment.ID)
+	assert.EqualValues(t, newCommentBody, updatedComment.Body)
+	models.AssertExistsAndLoadBean(t, &models.Comment{ID: comment.ID, IssueID: issue.ID, Content: newCommentBody})
+}
+
+func TestAPIDeleteComment(t *testing.T) {
+	prepareTestEnv(t)
+
+	comment := models.AssertExistsAndLoadBean(t, &models.Comment{},
+		models.Cond("type = ?", models.CommentTypeComment)).(*models.Comment)
+	issue := models.AssertExistsAndLoadBean(t, &models.Issue{ID: comment.IssueID}).(*models.Issue)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	req := NewRequestf(t, "DELETE", "/api/v1/repos/%s/%s/issues/%d/comments/%d",
+		repoOwner.Name, repo.Name, issue.Index, comment.ID)
+	session.MakeRequest(t, req, http.StatusNoContent)
+
+	models.AssertNotExistsBean(t, &models.Comment{ID: comment.ID})
 }


### PR DESCRIPTION
Add tests for following endpoints:
- `GET /api/v1/repos/:owner/:reponame/issues/comments`
- `POST /api/v1/repos/:owner/:reponame/issues/:index/comments`
- `PATCH /api/v1/repos/:owner/:reponame/issues/:index/comments/:id`
- `DELETE /api/v1/repos/:owner/:reponame/issues/:index/comments/:id`