### PR TITLE
Make compare button URL aware if current repo is a fork (#2162)

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,7 @@
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item">
-					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if .Repository.IsFork}}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
+					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if or .Repository.IsFork (.SignedUser.HasForkedRepo .BaseRepo.ID )}}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
 						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,11 +10,7 @@
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item">
-					{{if .Repository.IsFork}}
-						<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.SignedUser.Name}}:{{.BranchName}}">
-					{{else}}
-						<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.BranchName}}">
-					{{end}}
+					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if .Repository.IsFork}}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
 						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,7 @@
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item">
-					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if or .Repository.IsFork (.SignedUser.HasForkedRepo .BaseRepo.ID )}}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
+					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if .SignedUser.HasForkedRepo .BaseRepo.ID }}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
 						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,11 @@
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item">
-					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.SignedUser.Name}}:{{.BranchName}}">
+					{{if .Repository.IsFork}}
+						<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.SignedUser.Name}}:{{.BranchName}}">
+					{{else}}
+						<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{.BranchName}}">
+					{{end}}
 						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>


### PR DESCRIPTION
The following merge request fixes the issue addressed in #2162. 

Long story short: The change prevents 404 when the template tries to compare non-existing branch by assuming that every repo is a fork (i.e. by providing `username:branchname` every time).

Since it was possible to determine if the repository is a fork from within the template, I've added a check in the `home` template. I'm not aware of any side effects of this solution.