### PR TITLE
Only show SSH clone URL if signed in (#2169)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -126,7 +126,7 @@ SSH_KEY_TEST_PATH =
 SSH_KEYGEN_PATH = ssh-keygen
 ; Enable SSH Authorized Key Backup when rewriting all keys, default is true
 SSH_BACKUP_AUTHORIZED_KEYS = true
-; Enable exposure of SSH clone URL to anonymous visitors, default is true
+; Enable exposure of SSH clone URL to anonymous visitors, default is false
 SSH_EXPOSE_ANONYMOUS = false
 ; Indicate whether to check minimum key size with corresponding type
 MINIMUM_KEY_SIZE_CHECK = false

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -126,6 +126,8 @@ SSH_KEY_TEST_PATH =
 SSH_KEYGEN_PATH = ssh-keygen
 ; Enable SSH Authorized Key Backup when rewriting all keys, default is true
 SSH_BACKUP_AUTHORIZED_KEYS = true
+; Enable exposure of SSH clone URL to anonymous visitors, default is true
+SSH_EXPOSE_ANONYMOUS = true
 ; Indicate whether to check minimum key size with corresponding type
 MINIMUM_KEY_SIZE_CHECK = false
 ; Disable CDN even in "prod" mode
@@ -154,7 +156,7 @@ LFS_START_SERVER = false
 ; Where your lfs files put on, default is data/lfs.
 LFS_CONTENT_PATH = data/lfs
 ; LFS authentication secret, changed this to yourself.
-LFS_JWT_SECRET   = 
+LFS_JWT_SECRET   =
 
 ; Define allowed algorithms and their minimum key length (use -1 to disable a type)
 [ssh.minimum_key_sizes]

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -127,7 +127,7 @@ SSH_KEYGEN_PATH = ssh-keygen
 ; Enable SSH Authorized Key Backup when rewriting all keys, default is true
 SSH_BACKUP_AUTHORIZED_KEYS = true
 ; Enable exposure of SSH clone URL to anonymous visitors, default is true
-SSH_EXPOSE_ANONYMOUS = true
+SSH_EXPOSE_ANONYMOUS = false
 ; Indicate whether to check minimum key size with corresponding type
 MINIMUM_KEY_SIZE_CHECK = false
 ; Disable CDN even in "prod" mode
@@ -156,7 +156,7 @@ LFS_START_SERVER = false
 ; Where your lfs files put on, default is data/lfs.
 LFS_CONTENT_PATH = data/lfs
 ; LFS authentication secret, changed this to yourself.
-LFS_JWT_SECRET   =
+LFS_JWT_SECRET   = 
 
 ; Define allowed algorithms and their minimum key length (use -1 to disable a type)
 [ssh.minimum_key_sizes]

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -5,8 +5,13 @@
 package integrations
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestViewRepo(t *testing.T) {
@@ -36,4 +41,36 @@ func TestViewRepo3(t *testing.T) {
 	req := NewRequest(t, "GET", "/user3/repo3")
 	session := loginUser(t, "user3")
 	session.MakeRequest(t, req, http.StatusOK)
+}
+
+func TestViewRepo1CloneLinkAnonymous(t *testing.T) {
+	prepareTestEnv(t)
+
+	req := NewRequest(t, "GET", "/user2/repo1")
+	resp := MakeRequest(t, req, http.StatusOK)
+
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	link, exists := htmlDoc.doc.Find("#repo-clone-https").Attr("data-link")
+	assert.True(t, exists, "The template has changed")
+	assert.Equal(t, setting.AppURL+"user2/repo1.git", link)
+	_, exists = htmlDoc.doc.Find("#repo-clone-ssh").Attr("data-link")
+	assert.False(t, exists)
+}
+
+func TestViewRepo1CloneLinkAuthorized(t *testing.T) {
+	prepareTestEnv(t)
+
+	session := loginUser(t, "user2")
+
+	req := NewRequest(t, "GET", "/user2/repo1")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	link, exists := htmlDoc.doc.Find("#repo-clone-https").Attr("data-link")
+	assert.True(t, exists, "The template has changed")
+	assert.Equal(t, setting.AppURL+"user2/repo1.git", link)
+	link, exists = htmlDoc.doc.Find("#repo-clone-ssh").Attr("data-link")
+	assert.True(t, exists, "The template has changed")
+	sshURL := fmt.Sprintf("%s@%s:user2/repo1.git", setting.RunUser, setting.SSH.Domain)
+	assert.Equal(t, sshURL, link)
 }

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -285,6 +285,7 @@ func RepoAssignment() macaron.Handler {
 		ctx.Data["IsRepositoryWriter"] = ctx.Repo.IsWriter()
 
 		ctx.Data["DisableSSH"] = setting.SSH.Disabled
+		ctx.Data["ExposeAnonSSH"] = setting.SSH.ExposeAnonymous
 		ctx.Data["DisableHTTP"] = setting.Repository.DisableHTTPGit
 		ctx.Data["CloneLink"] = repo.CloneLink()
 		ctx.Data["WikiCloneLink"] = repo.WikiCloneLink()

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -99,12 +99,14 @@ var (
 		AuthorizedKeysBackup bool           `ini:"SSH_AUTHORIZED_KEYS_BACKUP"`
 		MinimumKeySizeCheck  bool           `ini:"-"`
 		MinimumKeySizes      map[string]int `ini:"-"`
+		ExposeAnonymous      bool           `ini:"SSH_EXPOSE_ANONYMOUS"`
 	}{
 		Disabled:           false,
 		StartBuiltinServer: false,
 		Domain:             "",
 		Port:               22,
 		KeygenPath:         "ssh-keygen",
+		ExposeAnonymous:    true,
 	}
 
 	LFS struct {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -106,7 +106,6 @@ var (
 		Domain:             "",
 		Port:               22,
 		KeygenPath:         "ssh-keygen",
-		ExposeAnonymous:    true,
 	}
 
 	LFS struct {
@@ -709,6 +708,7 @@ func NewContext() {
 		}
 	}
 	SSH.AuthorizedKeysBackup = sec.Key("SSH_AUTHORIZED_KEYS_BACKUP").MustBool(true)
+	SSH.ExposeAnonymous = sec.Key("SSH_EXPOSE_ANONYMOUS").MustBool(false)
 
 	if err = Cfg.Section("server").MapTo(&LFS); err != nil {
 		log.Fatal(4, "Failed to map LFS settings: %v", err)

--- a/templates/repo/bare.tmpl
+++ b/templates/repo/bare.tmpl
@@ -18,19 +18,21 @@
 										{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}
 									</button>
 								{{end}}
-								{{if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
+								{{if not $.DisableSSH}}
 									<button class="ui basic clone button" id="repo-clone-ssh" data-link="{{.CloneLink.SSH}}">
 										SSH
 									</button>
 								{{end}}
 								{{if not $.DisableHTTP}}
 									<input id="repo-clone-url" value="{{$.CloneLink.HTTPS}}" readonly>
-								{{else if or $.IsSigned $.ExposeAnonSSH}}
+								{{else}}
 									<input id="repo-clone-url" value="{{$.CloneLink.SSH}}" readonly>
 								{{end}}
-								<button class="ui basic button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-									<i class="octicon octicon-clippy"></i>
-								</button>
+								{{if not (and $.DisableHTTP $.DisableSSH)}}
+									<button class="ui basic button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
+										<i class="octicon octicon-clippy"></i>
+									</button>
+								{{end}}
 							</div>
 						</div>
 						<div class="ui divider"></div>

--- a/templates/repo/bare.tmpl
+++ b/templates/repo/bare.tmpl
@@ -18,14 +18,14 @@
 										{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}
 									</button>
 								{{end}}
-								{{if not $.DisableSSH}}
+								{{if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 									<button class="ui basic clone button" id="repo-clone-ssh" data-link="{{.CloneLink.SSH}}">
 										SSH
 									</button>
 								{{end}}
 								{{if not $.DisableHTTP}}
 									<input id="repo-clone-url" value="{{$.CloneLink.HTTPS}}" readonly>
-								{{else}}
+								{{else if or $.IsSigned $.ExposeAnonSSH}}
 									<input id="repo-clone-url" value="{{$.CloneLink.SSH}}" readonly>
 								{{end}}
 								<button class="ui basic button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -56,14 +56,14 @@
 								{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}
 							</button>
 						{{end}}
-						{{if not $.DisableSSH}}
+						{{if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 							<button class="ui basic clone button" id="repo-clone-ssh" data-link="{{.CloneLink.SSH}}">
 								SSH
 							</button>
 						{{end}}
 						{{if not $.DisableHTTP}}
 							<input id="repo-clone-url" value="{{$.CloneLink.HTTPS}}" readonly>
-						{{else}}
+						{{else if or $.IsSigned $.ExposeAnonSSH}}
 							<input id="repo-clone-url" value="{{$.CloneLink.SSH}}" readonly>
 						{{end}}
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -63,12 +63,14 @@
 						{{end}}
 						{{if not $.DisableHTTP}}
 							<input id="repo-clone-url" value="{{$.CloneLink.HTTPS}}" readonly>
-						{{else if or $.IsSigned $.ExposeAnonSSH}}
+						{{else if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 							<input id="repo-clone-url" value="{{$.CloneLink.SSH}}" readonly>
 						{{end}}
-						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-							<i class="octicon octicon-clippy"></i>
-						</button>
+						{{if or ((not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)))}}
+							<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
+								<i class="octicon octicon-clippy"></i>
+							</button>
+						{{end}}
 						<div class="ui basic jump dropdown icon button poping up" data-content="{{.i18n.Tr "repo.download_archive"}}" data-variation="tiny inverted" data-position="top right">
 							<i class="download icon"></i>
 							<div class="menu">

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -35,14 +35,14 @@
 							{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}
 						</button>
 					{{end}}
-					{{if not $.DisableSSH}}
+					{{if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 						<button class="ui basic clone button" id="repo-clone-ssh" data-link="{{.WikiCloneLink.SSH}}">
 							SSH
 						</button>
 					{{end}}
 					{{if not $.DisableHTTP}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.HTTPS}}" readonly>
-					{{else}}
+					{{else if or $.IsSigned $.ExposeAnonSSH}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.SSH}}" readonly>
 					{{end}}
 					<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -42,12 +42,14 @@
 					{{end}}
 					{{if not $.DisableHTTP}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.HTTPS}}" readonly>
-					{{else if or $.IsSigned $.ExposeAnonSSH}}
+					{{else if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.SSH}}" readonly>
 					{{end}}
-					<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-						<i class="octicon octicon-clippy"></i>
-					</button>
+					{{if or ((not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)))}}
+						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
+							<i class="octicon octicon-clippy"></i>
+						</button>
+					{{end}}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This PR targets issue #2169

For cloning via SSH a user needs to provide a public key. If this is the case, this user has an account or is added by a member. Anonymous visitors hence do not need to see the SSH URL.

~~This is a hard-coded soliton (as voted by @lafriks), equivalent to GitHub's behavior. If a configurable solution is desired instead, I got another diofferent branch (stklcode/gitea@d7cbf5d72e15a7411ec1648037fd94872e5ed2a3) ready.~~

This solution introduces a config flag `SSH_EXPOSE_ANONYMOUS` (default `false`) to hide by default and opt-in to the old behavior.