### PR TITLE
Refactor vue delimeters to use es6 template delimeters

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1649,7 +1649,7 @@ function initDashboardSearch() {
     }
 
     new Vue({
-        delimiters: ['<%', '%>'],
+        delimiters: ['${', '}'],
         el: el,
 
         data: {

--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -33,9 +33,9 @@
 							<li v-for="repo in repos" :class="{'private': repo.private}">
 								<a :href="'{{AppSubUrl}}/' + repo.full_name">
 									<i :class="repoClass(repo)"></i>
-									<strong class="text truncate item-name"><% repo.full_name %></strong>
+									<strong class="text truncate item-name">${ repo.full_name }</strong>
 									<span class="ui right text light grey">
-										<% repo.stars_count %> <i class="octicon octicon-star rear"></i>
+										${ repo.stars_count } <i class="octicon octicon-star rear"></i>
 									</span>
 								</a>
 							</li>


### PR DESCRIPTION
Current delimiters are not editor friendly, change to use ES6 template delimiters while there is not too much VueJS code 