### PR TITLE
Fix profile update for non-local users

### DIFF
--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -100,7 +100,7 @@ func (f *SignInForm) Validate(ctx *macaron.Context, errs binding.Errors) binding
 
 // UpdateProfileForm form for updating profile
 type UpdateProfileForm struct {
-	Name             string `binding:"Required;AlphaDashDot;MaxSize(35)"`
+	Name             string `binding:"AlphaDashDot;MaxSize(35)"`
 	FullName         string `binding:"MaxSize(100)"`
 	Email            string `binding:"Required;Email;MaxSize(254)"`
 	KeepEmailPrivate bool


### PR DESCRIPTION
Remove required field from `UpdateProfileForm` as there is check later not to update Name if it is empty. Fixes #2176