### PR TITLE
Use sqlite3 database as default for Docker image

### DIFF
--- a/docker/etc/templates/app.ini
+++ b/docker/etc/templates/app.ini
@@ -8,7 +8,7 @@ TEMP_PATH = /data/gitea/uploads
 APP_DATA_PATH = /data/gitea
 
 [database]
-HOST = mysql:3306
+DB_TYPE = sqlite3
 PATH = /data/gitea/gitea.db
 
 [session]


### PR DESCRIPTION
The `app.ini` template file in the Docker image is currently using `mysql` as default database engine. However, it's not practical as default. Because, 

1. It require more setup to run `gitea`, such as:
    * run a `mysql` instance inside docker, which has to be named as `mysql`, 
    * prepare a database called `gitea`, 
    * and the password of the `mysql`'s `root` user has to be empty.
2. People, who are going to use `mysql` as the database, are more likely provide their own `app.ini` file, to specify the server address, mysql IP/name, reasonable user & password, etc.

So, my suggestion is that replacing the `mysql` with `sqlite3` as default. So, anyone who just want to simply run the `gitea` image to get an idea, can just run the image without providing a customized `app.ini` file or preparing a MySQL server.

Signed-off-by: Tao Wang <twang2218@gmail.com>
