### PR TITLE
Giving 'gitea' capability to listen on port below 1024 as non-root user in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apk --no-cache add \
     s6 \
     curl \
     openssh \
-    tzdata
+    tzdata \
+    libcap
 RUN addgroup \
     -S -g 1000 \
     git && \
@@ -37,3 +38,5 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 
 COPY docker /
 COPY gitea /app/gitea/gitea
+RUN chmod a+x /app/gitea/gitea \
+  && setcap cap_net_bind_service=+ep /app/gitea/gitea

--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -15,5 +15,5 @@ if [ ! -f /data/gitea/conf/app.ini ]; then
     cp /etc/templates/app.ini /data/gitea/conf/app.ini
 fi
 
-chown -R git:git /data/gitea /app/gitea /data/git
-chmod 0755 /data/gitea /app/gitea /data/git
+chown -R git:git /data/gitea /data/git
+chmod 0755 /data/gitea /data/git


### PR DESCRIPTION
Usually, the program started by a non-root user will not capable listen on a port below 1024. The restriction can be lift by given specific program CAP_NET_BIND_SERVICE capability, see 'man 7 capabilities'.

This commit added the CAP_NET_BIND_SERVICE capability to `/app/gitea/gitea` program in the docker, so the `gitea` service can listen at port below 1024, even it's running as a non-root user `git`.

It also removed `chown` and `chmod` on `/app/gitea/` directory, which is not necessary and will cause problem of `setcap` command.