### PR TITLE
Only allow token authentication with 2FA enabled

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -195,6 +195,7 @@ func HTTP(ctx *context.Context) {
 				_, err = models.GetTwoFactorByUID(authUser.ID)
 
 				if err == nil {
+					// TODO: This response should be changed to "invalid credentials" for security reasons once the expectation behind it (creating an app token to authenticate) is properly documented
 					ctx.HandleText(http.StatusUnauthorized, "Users with two-factor authentication enabled cannot perform HTTP/HTTPS operations via plain username and password. Please create and use a personal access token on the user settings page")
 					return
 				} else if !models.IsErrTwoFactorNotEnrolled(err) {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -174,7 +174,7 @@ func HTTP(ctx *context.Context) {
 				token, err := models.GetAccessTokenBySHA(authPasswd)
 				if err != nil {
 					if models.IsErrAccessTokenNotExist(err) || models.IsErrAccessTokenEmpty(err) {
-						ctx.HandleText(http.StatusUnauthorized, "invalid token")
+						ctx.HandleText(http.StatusUnauthorized, "invalid credentials")
 					} else {
 						ctx.Handle(http.StatusInternalServerError, "GetAccessTokenBySha", err)
 					}

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -159,7 +159,6 @@ func HTTP(ctx *context.Context) {
 			}
 
 			if authUser == nil {
-				log.GitLogger.Info("Inside if")
 				// Assume password is a token.
 				token, err := models.GetAccessTokenBySHA(authPasswd)
 				if err != nil {


### PR DESCRIPTION
Fixes #1394 

Previously, when a user had 2FA enabled they were still able to authenticate via HTTP(S) using their regular username and password. This PR makes token authentication mandatory for accounts with 2FA enabled.