### PR TITLE
Fix key usage time update if the key is used in parallel for multiple operations

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -496,15 +496,20 @@ func UpdatePublicKey(key *PublicKey) error {
 // UpdatePublicKeyUpdated updates public key use time.
 func UpdatePublicKeyUpdated(id int64) error {
 	now := time.Now()
-	cnt, err := x.ID(id).Cols("updated_unix").Update(&PublicKey{
+	// Check if key exists before update as affected rows count is unreliable
+	//    and will return 0 affected rows if two updates are made at the same time
+	if cnt, err := x.ID(id).Count(&PublicKey{}); err != nil {
+		return err
+	} else if cnt != 1 {
+		return ErrKeyNotExist{id}
+	}
+
+	_, err := x.ID(id).Cols("updated_unix").Update(&PublicKey{
 		Updated:     now,
 		UpdatedUnix: now.Unix(),
 	})
 	if err != nil {
 		return err
-	}
-	if cnt != 1 {
-		return ErrKeyNotExist{id}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #2060

In case of MySQL update will return 0 affected rows if values has not changed and is not reliable to check record existence.
