### PR TITLE
Fix issue updated_unix bug

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -580,6 +580,7 @@ func (issue *Issue) ReadBy(userID int64) error {
 }
 
 func updateIssueCols(e Engine, issue *Issue, cols ...string) error {
+	cols = append(cols, "updated_unix")
 	if _, err := e.Id(issue.ID).Cols(cols...).Update(issue); err != nil {
 		return err
 	}

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -399,7 +399,11 @@ func createComment(e *xorm.Session, opts *CreateCommentOptions) (_ *Comment, err
 		if err != nil {
 			return nil, err
 		}
+	}
 
+	// update the issue's updated_unix column
+	if err = updateIssueCols(e, opts.Issue); err != nil {
+		return nil, err
 	}
 
 	// Notify watchers for whatever action comes in, ignore if no action type.

--- a/models/issue_comment_test.go
+++ b/models/issue_comment_test.go
@@ -1,0 +1,41 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateComment(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	issue := AssertExistsAndLoadBean(t, &Issue{}).(*Issue)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: issue.RepoID}).(*Repository)
+	doer := AssertExistsAndLoadBean(t, &User{ID: repo.OwnerID}).(*User)
+
+	now := time.Now().Unix()
+	comment, err := CreateComment(&CreateCommentOptions{
+		Type:    CommentTypeComment,
+		Doer:    doer,
+		Repo:    repo,
+		Issue:   issue,
+		Content: "Hello",
+	})
+	assert.NoError(t, err)
+	then := time.Now().Unix()
+
+	assert.EqualValues(t, CommentTypeComment, comment.Type)
+	assert.EqualValues(t, "Hello", comment.Content)
+	assert.EqualValues(t, issue.ID, comment.IssueID)
+	assert.EqualValues(t, doer.ID, comment.PosterID)
+	AssertInt64InRange(t, now, then, comment.CreatedUnix)
+	AssertExistsAndLoadBean(t, comment) // assert actually added to DB
+
+	updatedIssue := AssertExistsAndLoadBean(t, &Issue{ID: issue.ID}).(*Issue)
+	AssertInt64InRange(t, now, then, updatedIssue.UpdatedUnix)
+}

--- a/models/unit_tests.go
+++ b/models/unit_tests.go
@@ -92,3 +92,9 @@ func AssertSuccessfulInsert(t *testing.T, beans ...interface{}) {
 func AssertCount(t *testing.T, bean interface{}, expected interface{}) {
 	assert.EqualValues(t, expected, GetCount(t, bean))
 }
+
+// AssertInt64InRange assert value is in range [low, high]
+func AssertInt64InRange(t *testing.T, low, high, value int64) {
+	assert.True(t, value >= low && value <= high,
+		"Expected value in range [%d, %d], found %d", low, high, value)
+}


### PR DESCRIPTION
Fixes #1938.

The `Issue.UpdatedUnix` column is set in the `BeforeUpdate()` method. However, that write had no effect on the `updated_unix` column when `updateIssueCols(..)` was called, unless `"updated_unix"` was explicitly listed as a column to update.

This PR:
- fixes `updateIssueCols(..)` to always update `updated_unix`.
- updates `createComment()` to update an issue's `updated_unix` column when a comment is added.
- includes relevant unit tests