### PR TITLE
Fix unclosed session bug

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1078,8 +1078,8 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 		sess = x.Limit(setting.UI.IssuePagingNum, start)
 	} else {
 		sess = x.NewSession()
-		defer sess.Close()
 	}
+	defer sess.Close()
 
 	if len(opts.IssueIDs) > 0 {
 		sess.In("issue.id", opts.IssueIDs)


### PR DESCRIPTION
Make sure `defer sess.Close()` always gets hit.
