### PR TITLE
rhel7 has a git version with four digits (1.8.3.1)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -762,7 +762,7 @@ func NewContext() {
 			log.Fatal(4, "Error retrieving git version: %v", err)
 		}
 
-		splitVersion := strings.SplitN(binVersion, ".", 3)
+		splitVersion := strings.SplitN(binVersion, ".", 4)
 
 		majorVersion, err := strconv.ParseUint(splitVersion[0], 10, 64)
 		if err != nil {


### PR DESCRIPTION
rhel7 has a git version with four digits. Checking for git version > 2.X (large file support) fails