### PR TITLE
Replace calls to xorm UseBool with Where

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -677,7 +677,7 @@ func UserSignIn(username, password string) (*User, error) {
 	}
 
 	sources := make([]*LoginSource, 0, 5)
-	if err = x.UseBool().Find(&sources, &LoginSource{IsActived: true}); err != nil {
+	if err = x.Where("is_actived = ?", true).Find(&sources); err != nil {
 		return nil, err
 	}
 

--- a/models/oauth2.go
+++ b/models/oauth2.go
@@ -56,7 +56,7 @@ var OAuth2DefaultCustomURLMappings = map[string]*oauth2.CustomURLMapping{
 // GetActiveOAuth2ProviderLoginSources returns all actived LoginOAuth2 sources
 func GetActiveOAuth2ProviderLoginSources() ([]*LoginSource, error) {
 	sources := make([]*LoginSource, 0, 1)
-	if err := x.UseBool().Find(&sources, &LoginSource{IsActived: true, Type: LoginOAuth2}); err != nil {
+	if err := x.Where("is_actived = ? and type = ?", true, LoginOAuth2).Find(&sources); err != nil {
 		return nil, err
 	}
 	return sources, nil
@@ -64,13 +64,8 @@ func GetActiveOAuth2ProviderLoginSources() ([]*LoginSource, error) {
 
 // GetActiveOAuth2LoginSourceByName returns a OAuth2 LoginSource based on the given name
 func GetActiveOAuth2LoginSourceByName(name string) (*LoginSource, error) {
-	loginSource := &LoginSource{
-		Name:      name,
-		Type:      LoginOAuth2,
-		IsActived: true,
-	}
-
-	has, err := x.UseBool().Get(loginSource)
+	loginSource := new(LoginSource)
+	has, err := x.Where("name = ? and type = ? and is_actived = ?", name, LoginOAuth2, true).Get(loginSource)
 	if !has || err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Filter with `Where` instead of by struct values with `UseBool`. 

Since new boolean fields can be added to a struct at any time in the future, filtering by struct with `UseBool()` is dangerous, as it considers as part of the filter all bools in the struct. 

Coders shouldnt have to think about the impact new fields have on existing database queries.