### PR TITLE
EnableUnit() -> UnitEnabled()

### DIFF
--- a/models/org_team.go
+++ b/models/org_team.go
@@ -192,8 +192,8 @@ func (t *Team) RemoveRepository(repoID int64) error {
 	return sess.Commit()
 }
 
-// EnableUnit returns if the team enables unit type t
-func (t *Team) EnableUnit(tp UnitType) bool {
+// UnitEnabled returns if the team has the given unit type enabled
+func (t *Team) UnitEnabled(tp UnitType) bool {
 	if len(t.UnitTypes) == 0 {
 		return true
 	}

--- a/models/repo.go
+++ b/models/repo.go
@@ -398,8 +398,8 @@ func (repo *Repository) getUnitsByUserID(e Engine, userID int64, isAdmin bool) (
 	return nil
 }
 
-// EnableUnit if this repository enabled some unit
-func (repo *Repository) EnableUnit(tp UnitType) bool {
+// UnitEnabled if this repository has the given unit enabled
+func (repo *Repository) UnitEnabled(tp UnitType) bool {
 	repo.getUnits(x)
 	for _, unit := range repo.Units {
 		if unit.Type == tp {
@@ -658,7 +658,7 @@ func (repo *Repository) CanEnablePulls() bool {
 
 // AllowsPulls returns true if repository meets the requirements of accepting pulls and has them enabled.
 func (repo *Repository) AllowsPulls() bool {
-	return repo.CanEnablePulls() && repo.EnableUnit(UnitTypePullRequests)
+	return repo.CanEnablePulls() && repo.UnitEnabled(UnitTypePullRequests)
 }
 
 // CanEnableEditor returns true if repository meets the requirements of web editor.

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -523,14 +523,7 @@ func LoadRepoUnits() macaron.Handler {
 // CheckUnit will check whether
 func CheckUnit(unitType models.UnitType) macaron.Handler {
 	return func(ctx *Context) {
-		var find bool
-		for _, unit := range ctx.Repo.Repository.Units {
-			if unit.Type == unitType {
-				find = true
-				break
-			}
-		}
-		if !find {
+		if !ctx.Repo.Repository.UnitEnabled(unitType) {
 			ctx.Handle(404, "CheckUnit", fmt.Errorf("%s: %v", ctx.Tr("units.error.unit_not_allowed"), unitType))
 		}
 	}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -235,7 +235,7 @@ func orgAssignment(args ...bool) macaron.Handler {
 }
 
 func mustEnableIssues(ctx *context.APIContext) {
-	if !ctx.Repo.Repository.EnableUnit(models.UnitTypeIssues) {
+	if !ctx.Repo.Repository.UnitEnabled(models.UnitTypeIssues) {
 		ctx.Status(404)
 		return
 	}

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -59,8 +59,8 @@ var (
 
 // MustEnableIssues check if repository enable internal issues
 func MustEnableIssues(ctx *context.Context) {
-	if !ctx.Repo.Repository.EnableUnit(models.UnitTypeIssues) &&
-		!ctx.Repo.Repository.EnableUnit(models.UnitTypeExternalTracker) {
+	if !ctx.Repo.Repository.UnitEnabled(models.UnitTypeIssues) &&
+		!ctx.Repo.Repository.UnitEnabled(models.UnitTypeExternalTracker) {
 		ctx.Handle(404, "MustEnableIssues", nil)
 		return
 	}

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -31,8 +31,8 @@ const (
 
 // MustEnableWiki check if wiki is enabled, if external then redirect
 func MustEnableWiki(ctx *context.Context) {
-	if !ctx.Repo.Repository.EnableUnit(models.UnitTypeWiki) &&
-		!ctx.Repo.Repository.EnableUnit(models.UnitTypeExternalWiki) {
+	if !ctx.Repo.Repository.UnitEnabled(models.UnitTypeWiki) &&
+		!ctx.Repo.Repository.UnitEnabled(models.UnitTypeExternalWiki) {
 		ctx.Handle(404, "MustEnableWiki", nil)
 		return
 	}

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -57,7 +57,7 @@
 							{{range $t, $unit := $.Units}}
 							<div class="field">
 								<div class="ui toggle checkbox">
-									<input type="checkbox" class="hidden" name="units" value="{{$unit.Type}}"{{if $.Team.EnableUnit $unit.Type}} checked{{end}}>
+									<input type="checkbox" class="hidden" name="units" value="{{$unit.Type}}"{{if $.Team.UnitEnabled $unit.Type}} checked{{end}}>
 									<label>{{$.i18n.Tr $unit.NameKey}}</label>
 									<span class="help">{{$.i18n.Tr $unit.DescKey}}</span>
 								</div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -49,19 +49,19 @@
 {{if not .IsDiffCompare}}
 	<div class="ui tabs container">
 		<div class="ui tabular stackable menu navbar">
-			{{if .Repository.EnableUnit $.UnitTypeCode}}
+			{{if .Repository.UnitEnabled $.UnitTypeCode}}
 			<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}">
 				<i class="octicon octicon-code"></i> {{.i18n.Tr "repo.code"}}
 			</a>
 			{{end}}
 
-			{{if .Repository.EnableUnit $.UnitTypeIssues}}
+			{{if .Repository.UnitEnabled $.UnitTypeIssues}}
 				<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
 					<i class="octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
 				</a>
 			{{end}}
 
-			{{if .Repository.EnableUnit $.UnitTypeExternalTracker}}
+			{{if .Repository.UnitEnabled $.UnitTypeExternalTracker}}
 				<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
 					<i class="octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} </span>
 				</a>
@@ -73,19 +73,19 @@
 				</a>
 			{{end}}
 
-			{{if and (.Repository.EnableUnit $.UnitTypeCode) (not .IsBareRepo)}}
+			{{if and (.Repository.UnitEnabled $.UnitTypeCode) (not .IsBareRepo)}}
 			<a class="{{if (or (.PageIsCommits) (.PageIsDiff))}}active{{end}} item" href="{{.RepoLink}}/commits/{{EscapePound .BranchName}}">
 				<i class="octicon octicon-history"></i> {{.i18n.Tr "repo.commits"}} <span class="ui {{if not .CommitsCount}}gray{{else}}blue{{end}} small label">{{.CommitsCount}}</span>
 			</a>
 			{{end}}
 
-			{{if and (.Repository.EnableUnit $.UnitTypeReleases) (not .IsBareRepo) }}
+			{{if and (.Repository.UnitEnabled $.UnitTypeReleases) (not .IsBareRepo) }}
 			<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
 				<i class="octicon octicon-tag"></i> {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .Repository.NumTags}}gray{{else}}blue{{end}} small label">{{.Repository.NumTags}}</span>
 			</a>
 			{{end}}
 
-			{{if or (.Repository.EnableUnit $.UnitTypeWiki) (.Repository.EnableUnit $.UnitTypeExternalWiki)}}
+			{{if or (.Repository.UnitEnabled $.UnitTypeWiki) (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}
 				<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki">
 					<i class="octicon octicon-book"></i> {{.i18n.Tr "repo.wiki"}}
 				</a>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -93,7 +93,7 @@
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="advanced">
 
-				{{$isWikiEnabled := or (.Repository.EnableUnit $.UnitTypeWiki) (.Repository.EnableUnit $.UnitTypeExternalWiki)}}
+				{{$isWikiEnabled := or (.Repository.UnitEnabled $.UnitTypeWiki) (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}
 				<div class="inline field">
 					<label>{{.i18n.Tr "repo.wiki"}}</label>
 					<div class="ui checkbox">
@@ -104,17 +104,17 @@
 				<div class="field {{if not $isWikiEnabled}}disabled{{end}}" id="wiki_box">
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.EnableUnit $.UnitTypeExternalWiki)}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_internal_wiki"}}</label>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.EnableUnit $.UnitTypeExternalWiki}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.UnitEnabled $.UnitTypeExternalWiki}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_external_wiki"}}</label>
 						</div>
 					</div>
-					<div class="field {{if not (.Repository.EnableUnit $.UnitTypeExternalWiki)}}disabled{{end}}" id="external_wiki_box">
+					<div class="field {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}disabled{{end}}" id="external_wiki_box">
 						<label for="external_wiki_url">{{.i18n.Tr "repo.settings.external_wiki_url"}}</label>
 						<input id="external_wiki_url" name="external_wiki_url" type="url" value="{{(.Repository.MustGetUnit $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}">
 						<p class="help">{{.i18n.Tr "repo.settings.external_wiki_url_desc"}}</p>
@@ -123,7 +123,7 @@
 
 				<div class="ui divider"></div>
 
-				{{$isIssuesEnabled := or (.Repository.EnableUnit $.UnitTypeIssues) (.Repository.EnableUnit $.UnitTypeExternalTracker)}}
+				{{$isIssuesEnabled := or (.Repository.UnitEnabled $.UnitTypeIssues) (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}
 				<div class="inline field">
 					<label>{{.i18n.Tr "repo.issues"}}</label>
 					<div class="ui checkbox">
@@ -134,17 +134,17 @@
 				<div class="field {{if not $isIssuesEnabled}}disabled{{end}}" id="issue_box">
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="false" data-target="#external_issue_box" {{if not (.Repository.EnableUnit $.UnitTypeExternalTracker)}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="false" data-target="#external_issue_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_internal_issue_tracker"}}</label>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="true" data-target="#external_issue_box" {{if .Repository.EnableUnit $.UnitTypeExternalTracker}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="true" data-target="#external_issue_box" {{if .Repository.UnitEnabled $.UnitTypeExternalTracker}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_external_issue_tracker"}}</label>
 						</div>
 					</div>
-					<div class="field {{if not (.Repository.EnableUnit $.UnitTypeExternalTracker)}}disabled{{end}}" id="external_issue_box">
+					<div class="field {{if not (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}disabled{{end}}" id="external_issue_box">
 						<div class="field">
 							<label for="external_tracker_url">{{.i18n.Tr "repo.settings.external_tracker_url"}}</label>
 							<input id="external_tracker_url" name="external_tracker_url" type="url" value="{{(.Repository.MustGetUnit $.UnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerURL}}">
@@ -181,7 +181,7 @@
 					<div class="inline field">
 						<label>{{.i18n.Tr "repo.pulls"}}</label>
 						<div class="ui checkbox">
-							<input name="enable_pulls" type="checkbox" {{if .Repository.EnableUnit $.UnitTypePullRequests}}checked{{end}}>
+							<input name="enable_pulls" type="checkbox" {{if .Repository.UnitEnabled $.UnitTypePullRequests}}checked{{end}}>
 							<label>{{.i18n.Tr "repo.settings.pulls_desc"}}</label>
 						</div>
 					</div>
@@ -222,7 +222,7 @@
 				</div>
 			</div>
 
-			{{if .Repository.EnableUnit $.UnitTypeWiki}}
+			{{if .Repository.UnitEnabled $.UnitTypeWiki}}
 				<div class="ui divider"></div>
 
 				<div class="item">
@@ -354,7 +354,7 @@
 		</div>
 	</div>
 
-	{{if .Repository.EnableUnit $.UnitTypeWiki}}
+	{{if .Repository.UnitEnabled $.UnitTypeWiki}}
 	<div class="ui small modal" id="delete-wiki-modal">
 		<div class="header">
 			{{.i18n.Tr "repo.settings.wiki-delete"}}


### PR DESCRIPTION
Renames the `Repository.EnableUnit(..)` and `Team.EnableUnit(..)` methods (which check if a unit is enabled) to `UnitEnabled(..)`. The original names seems misleading, since `EnableUnit(..)` sounds like a method that enables a unit, not one that checks if a unit is enabled.

Calls the method in more places to remove boilerplate.
