### PR TITLE
Convert xorm literal queries to method calls

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -712,8 +712,7 @@ func convertDateToUnix(x *xorm.Engine) (err error) {
 		offset := 0
 		for {
 			beans := make([]*Bean, 0, 100)
-			if err = x.SQL(fmt.Sprintf("SELECT * FROM `%s` ORDER BY id ASC LIMIT 100 OFFSET %d",
-				table.name, offset)).Find(&beans); err != nil {
+			if err = x.Table(table.name).Asc("id").Limit(100, offset).Find(&beans); err != nil {
 				return fmt.Errorf("select beans [table: %s, offset: %d]: %v", table.name, offset, err)
 			}
 			log.Trace("Table [%s]: offset: %d, beans: %d", table.name, offset, len(beans))

--- a/models/migrations/v28.go
+++ b/models/migrations/v28.go
@@ -37,8 +37,7 @@ func addRepoSize(x *xorm.Engine) (err error) {
 	offset := 0
 	for {
 		repos := make([]*Repository, 0, 10)
-		if err = x.Sql(fmt.Sprintf("SELECT * FROM `repository` ORDER BY id ASC LIMIT 10 OFFSET %d", offset)).
-			Find(&repos); err != nil {
+		if err = x.Table("repository").Asc("id").Limit(10, offset).Find(&repos); err != nil {
 			return fmt.Errorf("select repos [offset: %d]: %v", offset, err)
 		}
 		log.Trace("Select [offset: %d, repos: %d]", offset, len(repos))


### PR DESCRIPTION
The literal queries contained the keyword `LIMIT`, which doesn't exist in MSSQL. When I tried migrating, the process failed upon their execution. This change fixed it.