### PR TITLE
Make SHOW_USER_EMAIL also apply to profiles

### DIFF
--- a/integrations/setting_test.go
+++ b/integrations/setting_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingShowUserEmailExplore(t *testing.T) {
+	prepareTestEnv(t)
+
+	showUserEmail := setting.UI.ShowUserEmail
+	setting.UI.ShowUserEmail = true
+
+	session := loginUser(t, "user2")
+	req := NewRequest(t, "GET", "/explore/users")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	assert.Contains(t,
+		htmlDoc.doc.Find(".ui.user.list").Text(),
+		"user2@example.com",
+	)
+
+	setting.UI.ShowUserEmail = false
+
+	req = NewRequest(t, "GET", "/explore/users")
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc = NewHTMLParser(t, resp.Body)
+	assert.NotContains(t,
+		htmlDoc.doc.Find(".ui.user.list").Text(),
+		"user2@example.com",
+	)
+
+	setting.UI.ShowUserEmail = showUserEmail
+}
+
+func TestSettingShowUserEmailProfile(t *testing.T) {
+	prepareTestEnv(t)
+
+	showUserEmail := setting.UI.ShowUserEmail
+	setting.UI.ShowUserEmail = true
+
+	session := loginUser(t, "user2")
+	req := NewRequest(t, "GET", "/user2")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	assert.Contains(t,
+		htmlDoc.doc.Find(".user.profile").Text(),
+		"user2@example.com",
+	)
+
+	setting.UI.ShowUserEmail = false
+
+	req = NewRequest(t, "GET", "/user2")
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc = NewHTMLParser(t, resp.Body)
+	assert.NotContains(t,
+		htmlDoc.doc.Find(".user.profile").Text(),
+		"user2@example.com",
+	)
+
+	setting.UI.ShowUserEmail = showUserEmail
+}

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -219,6 +219,8 @@ func Profile(ctx *context.Context) {
 		}
 	}
 
+	ctx.Data["ShowUserEmail"] = setting.UI.ShowUserEmail
+
 	ctx.HTML(200, tplProfile)
 }
 

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -22,7 +22,7 @@
 							{{if .Owner.Location}}
 								<li><i class="octicon octicon-location"></i> {{.Owner.Location}}</li>
 							{{end}}
-							{{if or (and $.ShowUserEmail .Owner.Email .IsSigned) (and .Owner.Email .IsSigned (not .Owner.KeepEmailPrivate))}}
+							{{if and $.ShowUserEmail .Owner.Email .IsSigned (not .Owner.KeepEmailPrivate)}}
 								<li>
 									<i class="octicon octicon-mail"></i>
 									<a href="mailto:{{.Owner.Email}}" rel="nofollow">{{.Owner.Email}}</a>


### PR DESCRIPTION
The e-mail address is currently only hidden from the explore page.