### PR TITLE
Make short link pattern greedy

### DIFF
--- a/modules/markdown/markdown.go
+++ b/modules/markdown/markdown.go
@@ -64,7 +64,7 @@ var (
 	Sha1CurrentPattern = regexp.MustCompile(`(?:^|\s|\()([0-9a-f]{7,40})\b`)
 
 	// ShortLinkPattern matches short but difficult to parse [[name|link|arg=test]] syntax
-	ShortLinkPattern = regexp.MustCompile(`(\[\[.*\]\]\w*)`)
+	ShortLinkPattern = regexp.MustCompile(`(\[\[.*?\]\]\w*)`)
 
 	// AnySHA1Pattern allows to split url containing SHA into parts
 	AnySHA1Pattern = regexp.MustCompile(`(http\S*)://(\S+)/(\S+)/(\S+)/(\S+)/([0-9a-f]{40})(?:/?([^#\s]+)?(?:#(\S+))?)?`)

--- a/modules/markdown/markdown_test.go
+++ b/modules/markdown/markdown_test.go
@@ -260,8 +260,10 @@ func TestRender_ShortLinks(t *testing.T) {
 
 	rawtree := URLJoin(AppSubURL, "raw", "master")
 	url := URLJoin(tree, "Link")
+	otherUrl := URLJoin(tree, "OtherLink")
 	imgurl := URLJoin(rawtree, "Link.jpg")
 	urlWiki := URLJoin(AppSubURL, "wiki", "Link")
+	otherUrlWiki := URLJoin(AppSubURL, "wiki", "OtherLink")
 	imgurlWiki := URLJoin(AppSubURL, "wiki", "raw", "Link.jpg")
 	favicon := "http://google.com/favicon.ico"
 
@@ -301,6 +303,10 @@ func TestRender_ShortLinks(t *testing.T) {
 		"[[Name|Link.jpg|alt=\"AltName\"|title='Title']]",
 		`<p><a href="`+imgurl+`" rel="nofollow"><img src="`+imgurl+`" alt="AltName" title="Title"/></a></p>`,
 		`<p><a href="`+imgurlWiki+`" rel="nofollow"><img src="`+imgurlWiki+`" alt="AltName" title="Title"/></a></p>`)
+	test(
+		"[[Link]] [[OtherLink]]",
+		`<p><a href="`+url+`" rel="nofollow">Link</a> <a href="`+otherUrl+`" rel="nofollow">OtherLink</a></p>`,
+		`<p><a href="`+urlWiki+`" rel="nofollow">Link</a> <a href="`+otherUrlWiki+`" rel="nofollow">OtherLink</a></p>`)
 }
 
 func TestRender_Commits(t *testing.T) {


### PR DESCRIPTION
Multiple links on the same line are currently not recognized correctly.

To reproduce, simply write something like this: `[[link1]] [[link2]]`