### PR TITLE
File path tweaks in UI

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -120,6 +120,13 @@ code.wrap {
 .ui.right {
   float: right;
 }
+.ui.button,
+.ui.menu .item {
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+  -webkit-user-select: auto;
+  user-select: auto;
+}
 .ui.container.fluid.padded {
   padding: 0 10px 0 10px;
 }

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -122,6 +122,13 @@ pre, code {
 		float: right;
 	}
 
+	&.button, &.menu .item {
+		-moz-user-select: auto;
+		-ms-user-select: auto;
+		-webkit-user-select: auto;
+		user-select: auto;
+	}
+
 	&.container {
 		&.fluid {
 			&.padded {

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -17,20 +17,20 @@
 			{{end}}
 			{{template "repo/branch_dropdown" .}}
 			<div class="fitted item">
-				<div class="ui breadcrumb">
-					<a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 25}}</a>
+				<span class="ui breadcrumb">
+					<a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>
 					{{ $n := len .TreeNames}}
 					{{ $l := Subtract $n 1}}
 					{{range $i, $v := .TreeNames}}
-						<div class="divider"> / </div>
+						<span class="divider"> / </span>
 						{{if eq $i $l}}
-							<span class="active section">{{EllipsisString $v 15}}</span>
+							<span class="active section">{{EllipsisString $v 30}}</span>
 						{{else}}
 							{{ $p := index $.Paths $i}}
-							<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 15}}</a></span>
+							<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>
 						{{end}}
 					{{end}}
-				</div>
+				</span>
 			</div>
 			<div class="right fitted item">
 				{{if .Repository.CanEnableEditor}}


### PR DESCRIPTION
- Adjust file path to wrap at 30 chars instead of 25/15.
- Allow text selection of path. No idea why Semantic UI blocks selection on those, so I overrode it.
- Turn a few `<div>`s into `<span>`s so that copied text from the path does not include newlines.

### Before

<img width="826" src="https://user-images.githubusercontent.com/115237/28996206-a4d53e3e-79fb-11e7-89be-43cd9d1d3ec5.png">

### After

<img width="826" src="https://user-images.githubusercontent.com/115237/28996207-adacf470-79fb-11e7-9cdd-6ad2d9f26e72.png">
