### PR TITLE
More tweaks to repo top panel

### DIFF
--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -19,7 +19,7 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch strin
 
 	// Click the little green button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
-	link, exists := htmlDoc.doc.Find("button.ui.green.small.button").Parent().Attr("href")
+	link, exists := htmlDoc.doc.Find("button.ui.green.tiny.compact.button").Parent().Attr("href")
 	assert.True(t, exists, "The template has changed")
 	if branch != "master" {
 		link = strings.Replace(link, ":master", ":"+branch, 1)

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1290,7 +1290,6 @@ footer .ui.language .menu {
   margin-bottom: 20px;
 }
 .repository #clone-panel {
-  margin-top: -8px;
   margin-left: 5px;
   width: 350px;
 }
@@ -1317,6 +1316,10 @@ footer .ui.language .menu {
 }
 .repository.file.list .choose.reference .header .icon {
   font-size: 1.4em;
+}
+.repository.file.list .repo-path .section,
+.repository.file.list .repo-path .divider {
+  display: inline;
 }
 .repository.file.list #file-buttons {
   font-weight: normal;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -133,7 +133,6 @@
 	}
 
 	#clone-panel {
-		margin-top: -8px;
 		margin-left: 5px;
 		width: 350px;
 
@@ -167,6 +166,13 @@
 				font-size: 1.4em;
 			}
 		}
+
+		.repo-path {
+			.section, .divider {
+				display: inline;
+			}
+		}
+
 		#file-buttons {
 			font-weight: normal;
 			.ui.button {

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -1,6 +1,6 @@
 <div class="fitted item choose reference">
 	<div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
-			<div class="ui basic small button">
+			<div class="ui basic compact tiny button">
 			<span class="text">
 				<i class="octicon octicon-git-branch"></i>
 				{{if .IsViewBranch}}{{.i18n.Tr "repo.branch"}}{{else}}{{.i18n.Tr "repo.tree"}}{{end}}:

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -9,29 +9,18 @@
 		</p>
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
+			{{if ne .BranchName .BaseRepo.DefaultBranch}}
 				<div class="fitted item">
 					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if .SignedUser.HasForkedRepo .BaseRepo.ID }}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
-						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
+						<button class="ui green tiny compact button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>
 			{{end}}
+			{{end}}
 			{{template "repo/branch_dropdown" .}}
-			<div class="fitted item">
-				<span class="ui breadcrumb">
-					<a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>
-					{{ $n := len .TreeNames}}
-					{{ $l := Subtract $n 1}}
-					{{range $i, $v := .TreeNames}}
-						<span class="divider"> / </span>
-						{{if eq $i $l}}
-							<span class="active section">{{EllipsisString $v 30}}</span>
-						{{else}}
-							{{ $p := index $.Paths $i}}
-							<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>
-						{{end}}
-					{{end}}
-				</span>
-			</div>
+			{{ $n := len .TreeNames}}
+			{{ $l := Subtract $n 1}}
+			<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
 			<div class="right fitted item">
 				{{if .Repository.CanEnableEditor}}
 					<div id="file-buttons" class="ui tiny blue buttons">
@@ -48,9 +37,9 @@
 					</div>
 				{{end}}
 
-				<!-- Only show colne panel in repository home page -->
+				<!-- Only show clone panel in repository home page -->
 				{{if eq $n 0}}
-					<div class="ui action small input" id="clone-panel">
+					<div class="ui action tiny input" id="clone-panel">
 						{{if not $.DisableHTTP}}
 							<button class="ui basic clone button" id="repo-clone-https" data-link="{{.CloneLink.HTTPS}}">
 								{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -16,7 +16,9 @@
 				</div>
 			{{end}}
 			{{template "repo/branch_dropdown" .}}
-			<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>{{ $n := len .TreeNames}}{{ $l := Subtract $n 1}}{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
+			{{ $n := len .TreeNames}}
+			{{ $l := Subtract $n 1}}
+			<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
 			<div class="right fitted item">
 				{{if .Repository.CanEnableEditor}}
 					<div id="file-buttons" class="ui tiny blue buttons">

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -9,13 +9,11 @@
 		</p>
 		<div class="ui secondary menu">
 			{{if .PullRequestCtx.Allowed}}
-			{{if ne .BranchName .BaseRepo.DefaultBranch}}
 				<div class="fitted item">
 					<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch}}...{{if .SignedUser.HasForkedRepo .BaseRepo.ID }}{{.SignedUser.Name}}:{{end}}{{.BranchName}}">
 						<button class="ui green tiny compact button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>
-			{{end}}
 			{{end}}
 			{{template "repo/branch_dropdown" .}}
 			{{ $n := len .TreeNames}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -16,9 +16,7 @@
 				</div>
 			{{end}}
 			{{template "repo/branch_dropdown" .}}
-			{{ $n := len .TreeNames}}
-			{{ $l := Subtract $n 1}}
-			<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
+			<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchName}}">{{EllipsisString .Repository.Name 30}}</a>{{ $n := len .TreeNames}}{{ $l := Subtract $n 1}}{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
 			<div class="right fitted item">
 				{{if .Repository.CanEnableEditor}}
 					<div id="file-buttons" class="ui tiny blue buttons">


### PR DESCRIPTION
This includes various tweaks to the repo top panel.

- Unify the button and clone panel size in the panel and center them better vertically.
- ~~Hide the green compare button when the comparison would compare same branches, e.g. `master..master`~~
- Remove whitespace around the path so a path is copied as-is and without extra spaces between segments. This results in less readability in the template, but it's necessary. In the long run, minfiying HTML would be a better solution to avoid creation of empty text nodes.

#### Before

<img width="1143" src="https://user-images.githubusercontent.com/115237/29001908-f3efd2c8-7a95-11e7-8f0b-37c04d9301d3.png">

#### After

<img width="1147" src="https://user-images.githubusercontent.com/115237/29001911-109b2a94-7a96-11e7-85f2-727ab8121d65.png">
