### PR TITLE
Fix rendering of external links

### DIFF
--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -75,7 +75,7 @@ func TestAPI_RenderGFM(t *testing.T) {
 <ul>
 <li><a href="` + AppSubURL + `wiki/Links" rel="nofollow">Links, Language bindings, Engine bindings</a></li>
 <li><a href="` + AppSubURL + `wiki/Tips" rel="nofollow">Tips</a></li>
-<li>Bezier widget (by <a href="` + AppURL + `r-lyeh" rel="nofollow">@r-lyeh</a>)<a href="https://github.com/ocornut/imgui/issues/786" rel="nofollow">#786</a></li>
+<li>Bezier widget (by <a href="` + AppURL + `r-lyeh" rel="nofollow">@r-lyeh</a>) https://github.com/ocornut/imgui/issues/786</li>
 </ul>
 `,
 		// wine-staging wiki home extract: special wiki syntax, images

--- a/routers/init.go
+++ b/routers/init.go
@@ -50,6 +50,7 @@ func GlobalInit() {
 
 	if setting.InstallLock {
 		highlight.NewContext()
+		markdown.InitMarkdown()
 		markdown.NewSanitizer()
 		if err := models.NewEngine(migrations.Migrate); err != nil {
 			log.Fatal(4, "Failed to initialize ORM engine: %v", err)


### PR DESCRIPTION
Fixes #2282 (both space-consuming bug and rendering-external-link-as-internal-issue bug).

Some minor points:
- Now we only match URLs of the form `{Setting.AppURL}/:owner/:repo/(issues|pulls)/:index`
- We previously appended ` <i class="icon comment"></i>` to the displayed text for links to comments. However, due to client-side JS, the icon was never rendered. Ideally, I think we should append ` (comment)` like Github does. However, adding this would require some extra refactoring (to support multiple languages), so I put it in a TODO