### PR TITLE
Use /dev/urandom to create random password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN addgroup \
     -u 1000 \
     -G git \
     git && \
-  echo "git:$(date +%s | sha256sum | base64 | head -c 32)" | chpasswd
+  echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
 ENV GITEA_CUSTOM /data/gitea

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,7 @@ RUN addgroup \
     -u 1000 \
     -G git \
     git && \
-  echo "git:$(date +%s | sha256sum | base64 | head -c 32)" | chpasswd
+  echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
 ENV GITEA_CUSTOM /data/gitea

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -24,7 +24,7 @@ RUN addgroup \
     -u 1000 \
     -G git \
     git && \
-  echo "git:$(date +%s | sha256sum | base64 | head -c 32)" | chpasswd
+  echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
 ENV GITEA_CUSTOM /data/gitea


### PR DESCRIPTION
Previous solution used "date +%s" to generate a random password. Since drone logs the timestamp when that command is executed, the generated password wasn't random at all.