### PR TITLE
Trigger sync webhooks on UI commit

### DIFF
--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -297,23 +297,29 @@ func (repo *Repository) DeleteRepoFile(doer *User, opts DeleteRepoFileOptions) (
 	}
 
 	// Simulate push event.
-	pushCommits := &PushCommits{
-		Len:     1,
-		Commits: []*PushCommit{CommitToPushCommit(commit)},
-	}
-	if err := CommitRepoAction(CommitRepoActionOptions{
-		PusherName:  doer.Name,
-		RepoOwnerID: repo.MustOwner().ID,
-		RepoName:    repo.Name,
-		RefFullName: git.BranchPrefix + opts.NewBranch,
-		OldCommitID: opts.LastCommitID,
-		NewCommitID: commit.ID.String(),
-		Commits:     pushCommits,
-	}); err != nil {
-		log.Error(4, "CommitRepoAction: %v", err)
-		return nil
+	oldCommitID := opts.LastCommitID
+	if opts.NewBranch != opts.OldBranch {
+		oldCommitID = git.EmptySHA
 	}
 
+	if err = repo.GetOwner(); err != nil {
+		return fmt.Errorf("GetOwner: %v", err)
+	}
+	err = PushUpdate(
+		opts.NewBranch,
+		PushUpdateOptions{
+			PusherID:     doer.ID,
+			PusherName:   doer.Name,
+			RepoUserName: repo.Owner.Name,
+			RepoName:     repo.Name,
+			RefFullName:  git.BranchPrefix + opts.NewBranch,
+			OldCommitID:  oldCommitID,
+			NewCommitID:  commit.ID.String(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("PushUpdate: %v", err)
+	}
 	return nil
 }
 
@@ -536,21 +542,28 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 	}
 
 	// Simulate push event.
-	pushCommits := &PushCommits{
-		Len:     1,
-		Commits: []*PushCommit{CommitToPushCommit(commit)},
+	oldCommitID := opts.LastCommitID
+	if opts.NewBranch != opts.OldBranch {
+		oldCommitID = git.EmptySHA
 	}
-	if err := CommitRepoAction(CommitRepoActionOptions{
-		PusherName:  doer.Name,
-		RepoOwnerID: repo.MustOwner().ID,
-		RepoName:    repo.Name,
-		RefFullName: git.BranchPrefix + opts.NewBranch,
-		OldCommitID: opts.LastCommitID,
-		NewCommitID: commit.ID.String(),
-		Commits:     pushCommits,
-	}); err != nil {
-		log.Error(4, "CommitRepoAction: %v", err)
-		return nil
+
+	if err = repo.GetOwner(); err != nil {
+		return fmt.Errorf("GetOwner: %v", err)
+	}
+	err = PushUpdate(
+		opts.NewBranch,
+		PushUpdateOptions{
+			PusherID:     doer.ID,
+			PusherName:   doer.Name,
+			RepoUserName: repo.Owner.Name,
+			RepoName:     repo.Name,
+			RefFullName:  git.BranchPrefix + opts.NewBranch,
+			OldCommitID:  oldCommitID,
+			NewCommitID:  commit.ID.String(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("PushUpdate: %v", err)
 	}
 
 	return DeleteUploads(uploads...)

--- a/routers/private/push_update.go
+++ b/routers/private/push_update.go
@@ -32,15 +32,7 @@ func PushUpdate(ctx *macaron.Context) {
 		return
 	}
 
-	repo, err := models.PushUpdate(opt)
-	if err != nil {
-		ctx.JSON(500, map[string]interface{}{
-			"err": err.Error(),
-		})
-		return
-	}
-
-	pusher, err := models.GetUserByID(opt.PusherID)
+	err := models.PushUpdate(branch, opt)
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
 			ctx.Error(404)
@@ -51,10 +43,5 @@ func PushUpdate(ctx *macaron.Context) {
 		}
 		return
 	}
-
-	log.Trace("TriggerTask '%s/%s' by %s", repo.Name, branch, pusher.Name)
-
-	go models.HookQueue.Add(repo.ID)
-	go models.AddTestPullRequestTask(pusher, repo.ID, branch, true)
 	ctx.Status(202)
 }


### PR DESCRIPTION
Fixes #2295.

Ensure that `AddTestPullRequestTask(..)` called during a UI commit. For normally-pushed commits, `AddTestPullRequestTask(..)` is called by the `post-receive` webhook, but the webhook does not run* for UI commits.

(*It technically runs, but immediately quits because `$SSH_ORIGINAL_COMMAND` is not set)