### PR TITLE
Prevent conflicting TOTP accounts by adding AppURL to issuer parameter

### DIFF
--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -583,7 +583,7 @@ func twofaGenerateSecretAndQr(ctx *context.Context) bool {
 	if otpKey == nil {
 		err = nil // clear the error, in case the URL was invalid
 		otpKey, err = totp.Generate(totp.GenerateOpts{
-			Issuer:      setting.AppName,
+			Issuer:      setting.AppName + " (" + strings.TrimRight(setting.AppURL, "/") + ")",
 			AccountName: ctx.User.Name,
 		})
 		if err != nil {


### PR DESCRIPTION
Targets #2332 

Added AppURL without trailing slash to issuer parameter in TOTP QR Code generation.