### PR TITLE
Do not hard-code PostgreSQL credentials in tester file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -164,6 +164,10 @@ pipeline:
     pull: true
     group: test
     environment:
+      PGHOST: pgsql
+      PGPORT: '5432'
+      PGUSER: postgres
+      PGPASSWORD: postgres
       TAGS: bindata
       GOPATH: /srv/app
     commands:

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,6 @@ TEST_MYSQL_HOST ?= mysql:3306
 TEST_MYSQL_DBNAME ?= testgitea
 TEST_MYSQL_USERNAME ?= root
 TEST_MYSQL_PASSWORD ?=
-TEST_PGSQL_HOST ?= pgsql:5432
-TEST_PGSQL_DBNAME ?= testgitea
-TEST_PGSQL_USERNAME ?= postgres
-TEST_PGSQL_PASSWORD ?= postgres
 
 ifeq ($(OS), Windows_NT)
 	EXECUTABLE := gitea.exe
@@ -67,7 +63,7 @@ clean:
 		integrations*.test \
 		integrations/gitea-integration-pgsql/ integrations/gitea-integration-mysql/ integrations/gitea-integration-sqlite/ \
 		integrations/indexers-mysql/ integrations/indexers-pgsql integrations/indexers-sqlite \
-		integrations/mysql.ini integrations/pgsql.ini
+		integrations/mysql.ini
 
 .PHONY: fmt
 fmt:
@@ -167,11 +163,6 @@ generate-ini:
 		-e 's|{{TEST_MYSQL_USERNAME}}|${TEST_MYSQL_USERNAME}|g' \
 		-e 's|{{TEST_MYSQL_PASSWORD}}|${TEST_MYSQL_PASSWORD}|g' \
 			integrations/mysql.ini.tmpl > integrations/mysql.ini
-	sed -e 's|{{TEST_PGSQL_HOST}}|${TEST_PGSQL_HOST}|g' \
-		-e 's|{{TEST_PGSQL_DBNAME}}|${TEST_PGSQL_DBNAME}|g' \
-		-e 's|{{TEST_PGSQL_USERNAME}}|${TEST_PGSQL_USERNAME}|g' \
-		-e 's|{{TEST_PGSQL_PASSWORD}}|${TEST_PGSQL_PASSWORD}|g' \
-			integrations/pgsql.ini.tmpl > integrations/pgsql.ini
 
 .PHONY: test-mysql
 test-mysql: integrations.test generate-ini

--- a/integrations/pgsql.ini
+++ b/integrations/pgsql.ini
@@ -3,12 +3,8 @@ RUN_MODE = prod
 
 [database]
 DB_TYPE  = postgres
-HOST     = {{TEST_PGSQL_HOST}}
-NAME     = {{TEST_PGSQL_DBNAME}}
-USER     = {{TEST_PGSQL_USERNAME}}
-PASSWD   = {{TEST_PGSQL_PASSWORD}}
+NAME     = testgitea
 SSL_MODE = disable
-PATH     = data/gitea.db
 
 [indexer]
 ISSUE_INDEXER_PATH = integrations/indexers-pgsql/issues.bleve


### PR DESCRIPTION
This allows running tests against non-default installs

NOTE: I suppose the change in .drone.yml will require signing it
      again, which I cannot do. Can you help @lunny $bkcsoft $appleboy ?