### PR TITLE
Add INTERNAL_TOKEN to integration .ini file

### DIFF
--- a/integrations/pgsql.ini
+++ b/integrations/pgsql.ini
@@ -55,3 +55,4 @@ LEVEL = Debug
 [security]
 INSTALL_LOCK = true
 SECRET_KEY   = 9pCviYTWSb
+INTERNAL_TOKEN = test


### PR DESCRIPTION
Avoids override of source file upon running `make test-pgsql`

Long story: settings.NewContext *adds* an INTERNAL_TOKEN if none
is found; the other ini files under integration/ all have an
INTERNAL_TOKEN