### PR TITLE
Add badge and link to the Matrix room

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 # Gitea - Git with a cup of tea
 
 [![Build Status](https://drone.gitea.io/api/badges/go-gitea/gitea/status.svg)](https://drone.gitea.io/go-gitea/gitea)
-[![Join the chat at https://img.shields.io/discord/322538954119184384.svg](https://img.shields.io/discord/322538954119184384.svg)](https://discord.gg/NsatcWJ)
+[![Join the Discord chat at https://discord.gg/NsatcWJ](https://img.shields.io/discord/322538954119184384.svg)](https://discord.gg/NsatcWJ)
+[![Join the Matrix chat at https://matrix.to/#/#gitea:matrix.org](https://img.shields.io/badge/matrix-%23gitea%3Amatrix.org-7bc9a4.svg)](https://matrix.to/#/#gitea:matrix.org)
 [![](https://images.microbadger.com/badges/image/gitea/gitea.svg)](https://microbadger.com/images/gitea/gitea "Get your own image badge on microbadger.com")
 [![Coverage Status](https://coverage.gitea.io/badges/go-gitea/gitea/coverage.svg)](https://coverage.gitea.io/go-gitea/gitea)
 [![Go Report Card](https://goreportcard.com/badge/code.gitea.io/gitea)](https://goreportcard.com/report/code.gitea.io/gitea)
@@ -28,7 +29,7 @@ The goal of this project is to make the easiest, fastest, and most painless way 
 
 ## Docs
 
-For more information and instructions about how to install Gitea please look at our [documentation](https://docs.gitea.io/en-us/). If you cannot find some specific information, then head over to our [Discord](https://discord.gg/NsatcWJ) server to chat with us or use the [forum](https://discourse.gitea.io/).
+For more information and instructions about how to install Gitea please look at our [documentation](https://docs.gitea.io/en-us/). If you cannot find some specific information, then head over to our [Discord server](https://discord.gg/NsatcWJ) or [Matrix room](https://matrix.to/#/#gitea:matrix.org) to chat with us or use the [forum](https://discourse.gitea.io/).
 
 ## Contributing
 


### PR DESCRIPTION
This PR adds a badge and link for the Gitea Matrix room.
This allows people to choose how they can join the chat, as the Matrix room is bridged to Discord.
