### PR TITLE
Add UseCompatSSHURI setting

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -23,6 +23,8 @@ PULL_REQUEST_QUEUE_LENGTH = 1000
 PREFERRED_LICENSES = Apache License 2.0,MIT License
 ; Disable ability to interact with repositories by HTTP protocol
 DISABLE_HTTP_GIT = false
+; Force ssh:// clone url instead of scp-style uri when default SSH port is used
+USE_COMPAT_SSH_URI = false
 
 [repository.editor]
 ; List of file extensions that should have line wraps in the CodeMirror editor

--- a/models/repo.go
+++ b/models/repo.go
@@ -1,4 +1,5 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2017 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -792,7 +793,11 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 	if setting.SSH.Port != 22 {
 		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoName)
 	} else {
-		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		if setting.Repository.UseCompatSSHURI {
+			cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		} else {
+			cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		}
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
 	return cl

--- a/models/repo.go
+++ b/models/repo.go
@@ -792,12 +792,10 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 	cl := new(CloneLink)
 	if setting.SSH.Port != 22 {
 		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoName)
+	} else if setting.Repository.UseCompatSSHURI {
+		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
 	} else {
-		if setting.Repository.UseCompatSSHURI {
-			cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
-		} else {
-			cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
-		}
+		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
 	return cl

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -161,6 +161,7 @@ var (
 		PullRequestQueueLength int
 		PreferredLicenses      []string
 		DisableHTTPGit         bool
+		UseCompatSSHURI        bool
 
 		// Repository editor settings
 		Editor struct {
@@ -189,6 +190,7 @@ var (
 		PullRequestQueueLength: 1000,
 		PreferredLicenses:      []string{"Apache License 2.0,MIT License"},
 		DisableHTTPGit:         false,
+		UseCompatSSHURI:        false,
 
 		// Repository editor settings
 		Editor: struct {
@@ -903,6 +905,7 @@ func NewContext() {
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")
 	Repository.DisableHTTPGit = sec.Key("DISABLE_HTTP_GIT").MustBool()
+	Repository.UseCompatSSHURI = sec.Key("USE_COMPAT_SSH_URI").MustBool()
 	Repository.MaxCreationLimit = sec.Key("MAX_CREATION_LIMIT").MustInt(-1)
 	RepoRootPath = sec.Key("ROOT").MustString(path.Join(homeDir, "gitea-repositories"))
 	forcePathSeparator(RepoRootPath)


### PR DESCRIPTION
This adds the Repository.UseCompatSSHURI boolean setting.
It forces the clone URL box of a repo to always show `ssh://user@server/path` URL instead of the scp-style URI `user@server:path` when the default SSH port 22 is used.

I tried to keep it as simple as possible and the changes minimal.
Feedback appreciated.
