### PR TITLE
Fix config paths which do not respect GITEA_WORK_DIR

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -146,10 +146,14 @@ func LoadConfigs() {
 		DbCfg.Passwd = sec.Key("PASSWD").String()
 	}
 	DbCfg.SSLMode = sec.Key("SSL_MODE").String()
-	DbCfg.Path = sec.Key("PATH").MustString("data/gitea.db")
+	workDir, err := setting.WorkDir()
+	if err != nil {
+		log.Fatal(4, "Failed to get work directory: %v", err)
+	}
+	DbCfg.Path = sec.Key("PATH").MustString(path.Join(workDir, "data", "gitea.db"))
 
 	sec = setting.Cfg.Section("indexer")
-	setting.Indexer.IssuePath = sec.Key("ISSUE_INDEXER_PATH").MustString("indexers/issues.bleve")
+	setting.Indexer.IssuePath = sec.Key("ISSUE_INDEXER_PATH").MustString(path.Join(workDir, "indexers", "issues.bleve"))
 	setting.Indexer.UpdateQueueLength = sec.Key("UPDATE_BUFFER_LEN").MustInt(20)
 }
 


### PR DESCRIPTION
data/sessions, data/gitea.db, indexers/ used relative path to AppPath
when the others use directories under GITEA_WORK_DIR.

Specially case: sessions file, when PROVIDER_CONFIG is not specified,
will use that path that macaron framework uses (it is data/sessions). This
change set GITEA_WORK_DIR/data/sessions as default
dir instead.