### PR TITLE
Error message for integration test

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -268,7 +268,8 @@ func MakeRequest(t testing.TB, req *http.Request, expectedStatus int) *TestRespo
 	}
 	mac.ServeHTTP(respWriter, req)
 	if expectedStatus != NoExpectedStatus {
-		assert.EqualValues(t, expectedStatus, respWriter.HeaderCode)
+		assert.EqualValues(t, expectedStatus, respWriter.HeaderCode,
+			"Request URL: %s", req.URL.String())
 	}
 	return &TestResponse{
 		HeaderCode: respWriter.HeaderCode,


### PR DESCRIPTION
When a test that makes multiple requests fails, it's not always clear which request had the unexpected status code. This will hopefully make it a little easier to debug failing tests.
