### PR TITLE
Disable custom Git Hooks globally via configuration file

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -206,6 +206,8 @@ REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
 MIN_PASSWORD_LENGTH = 6
 ; True when users are allowed to import local server paths
 IMPORT_LOCAL_PATHS = false
+; Disable all (including admin) users to create custom git-hooks
+DISABLE_GIT_HOOKS = false
 
 [openid]
 ;

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -206,7 +206,7 @@ REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
 MIN_PASSWORD_LENGTH = 6
 ; True when users are allowed to import local server paths
 IMPORT_LOCAL_PATHS = false
-; Disable all (including admin) users to create custom git-hooks
+; Prevent all users (including admin) from creating custom git hooks
 DISABLE_GIT_HOOKS = false
 
 [openid]

--- a/models/user.go
+++ b/models/user.go
@@ -237,7 +237,7 @@ func (u *User) CanCreateOrganization() bool {
 
 // CanEditGitHook returns true if user can edit Git hooks.
 func (u *User) CanEditGitHook() bool {
-	return u.IsAdmin || u.AllowGitHook
+	return !setting.DisableGitHooks && (u.IsAdmin || u.AllowGitHook)
 }
 
 // CanImportLocal returns true if user can migrate repository by local path.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -124,6 +124,7 @@ var (
 	ReverseProxyAuthUser string
 	MinPasswordLength    int
 	ImportLocalPaths     bool
+	DisableGitHooks      bool
 
 	// Database settings
 	UseSQLite3    bool
@@ -817,6 +818,7 @@ func NewContext() {
 	ReverseProxyAuthUser = sec.Key("REVERSE_PROXY_AUTHENTICATION_USER").MustString("X-WEBAUTH-USER")
 	MinPasswordLength = sec.Key("MIN_PASSWORD_LENGTH").MustInt(6)
 	ImportLocalPaths = sec.Key("IMPORT_LOCAL_PATHS").MustBool(false)
+	DisableGitHooks = sec.Key("DISABLE_GIT_HOOKS").MustBool(false)
 	InternalToken = sec.Key("INTERNAL_TOKEN").String()
 	if len(InternalToken) == 0 {
 		secretBytes := make([]byte, 32)

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -155,6 +155,9 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return out.String()
 		},
+		"DisableGitHooks": func() bool {
+			return setting.DisableGitHooks
+		},
 	}}
 }
 

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -86,7 +86,7 @@
 				<div class="inline field">
 					<div class="ui checkbox">
 						<label><strong>{{.i18n.Tr "admin.users.allow_git_hook"}}</strong></label>
-						<input name="allow_git_hook" type="checkbox" {{if .User.CanEditGitHook}}checked{{end}}>
+						<input name="allow_git_hook" type="checkbox" {{if .User.CanEditGitHook}}checked{{end}} {{if DisableGitHooks}}disabled{{end}}>
 					</div>
 				</div>
 				<div class="inline field">


### PR DESCRIPTION
Fixes #2449 by allowing the disabling of custom git hooks via configuration file
