### PR TITLE
Fix migration from pre-v15 to 1.2.0

### DIFF
--- a/models/migrations/v15.go
+++ b/models/migrations/v15.go
@@ -12,6 +12,7 @@ import (
 
 // UserV15 describes the added field for User
 type UserV15 struct {
+	KeepEmailPrivate        bool
 	AllowCreateOrganization bool
 }
 


### PR DESCRIPTION
Otherwise when upgrading from either gogs or pre migration v15 it will fail in later steps when selecting from users table with error that `user` table does not have column `keep_email_private`

Fixes #2206 and #2437