### PR TITLE
Make repo private to not interfere with other tests

### DIFF
--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -182,7 +182,7 @@
   owner_id: 2
   lower_name: repo16
   name: repo16
-  is_private: false
+  is_private: true
   num_issues: 0
   num_closed_issues: 0
   num_pulls: 0


### PR DESCRIPTION
Since dev of #2266 some tests were added. Change made in PR #2266 add a repo fixture that interfere with thoses tests. 

To fix that, I made the repo fixture private.
