### PR TITLE
auto-create repository on push

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -49,6 +49,8 @@ ALLOWED_TYPES =
 FILE_MAX_SIZE = 3
 ; Max number of files per upload. Defaults to 5
 MAX_FILES = 5
+; Create repository on upload if it doesn't exists
+AUTO_CREATE = false
 
 [ui]
 ; Number of repositories that are showed in one explore page

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -176,6 +176,7 @@ var (
 			AllowedTypes []string `delim:"|"`
 			FileMaxSize  int64
 			MaxFiles     int
+			AutoCreate   bool
 		} `ini:"-"`
 
 		// Repository local settings
@@ -208,12 +209,14 @@ var (
 			AllowedTypes []string `delim:"|"`
 			FileMaxSize  int64
 			MaxFiles     int
+			AutoCreate   bool
 		}{
 			Enabled:      true,
 			TempPath:     "data/tmp/uploads",
 			AllowedTypes: []string{},
 			FileMaxSize:  3,
 			MaxFiles:     5,
+			AutoCreate:   false,
 		},
 
 		// Repository local settings

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -95,6 +95,13 @@ func HTTP(ctx *context.Context) {
 	}
 
 	repo, err := models.GetRepositoryByName(repoUser.ID, reponame)
+	if models.IsErrRepoNotExist(err) && setting.Repository.Upload.AutoCreate {
+
+		// if 'CreateRepository' fails, the error are handled in the next 'if err != nil' block
+		repo, err = models.CreateRepository(repoUser, repoUser, models.CreateRepoOptions{
+			Name: reponame,
+		})
+	}
 	if err != nil {
 		if models.IsErrRepoNotExist(err) {
 			ctx.Handle(http.StatusNotFound, "GetRepositoryByName", nil)


### PR DESCRIPTION
if the repository doesn't exists at push time,
and the setting 'Repository.Upload.AutoCreate' is 'true'
(default is 'false') create the repository with the given name.

Signed-off-by: Jürgen Keck <jhyphenkeck@gmail.com>
