### PR TITLE
Fix slice out of bounds error in mailer

### DIFF
--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -41,7 +42,7 @@ func NewMessageFrom(to []string, from, subject, body string) *Message {
 
 	plainBody, err := html2text.FromString(body)
 	if err != nil || setting.MailService.SendAsPlainText {
-		if strings.Contains(body[:100], "<html>") {
+		if strings.Contains(base.TruncateString(body, 100), "<html>"){
 			log.Warn("Mail contains HTML but configured to send as plain text.")
 		}
 		msg.SetBody("text/plain", plainBody)


### PR DESCRIPTION
Fix #2472 by using TruncateString() instead of just slicing and hoping for the best.