### PR TITLE
Remove repository mirrors from "collaborative" list

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1768,7 +1768,7 @@ function initVueComponents(){
                     case 'mirrors':
                         return repo.mirror;
                     case 'collaborative':
-                        return repo.owner.id != this.uid;
+                        return repo.owner.id != this.uid && !repo.mirror;
                     default:
                         return true;
                 }


### PR DESCRIPTION
Don't show "mirrors" on repository list when "collaborative" filter is applied.