### PR TITLE
Hotfix: Add time manually adds time in nanoseconds

### DIFF
--- a/routers/repo/issue_timetrack.go
+++ b/routers/repo/issue_timetrack.go
@@ -41,7 +41,7 @@ func AddTimeManually(c *context.Context, form auth.AddTimeManuallyForm) {
 		return
 	}
 
-	if _, err := models.AddTime(c.User, issue, int64(total)); err != nil {
+	if _, err := models.AddTime(c.User, issue, int64(total.Seconds())); err != nil {
 		c.Handle(http.StatusInternalServerError, "AddTime", err)
 		return
 	}


### PR DESCRIPTION
The add time manually form adds the time as nanoseconds but it should be seconds.
This issue is reported by @gsantner (#2211 (comment)).

For more information please have a look at @gsantner comment: #2211 (comment)