### PR TITLE
Make basic functionality work without JavaScript

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -20,6 +20,7 @@ notifications = Notifications
 create_new = Create...
 user_profile_and_more = User profile and more
 signed_in_as = Signed in as
+enable_javascript = This website works better with JavaScript
 
 username = Username
 email = Email

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -76,6 +76,12 @@
 	<!-- Stylesheet -->
 	<link rel="stylesheet" href="{{AppSubUrl}}/vendor/plugins/semantic/semantic.min.css">
 	<link rel="stylesheet" href="{{AppSubUrl}}/css/index.css?v={{MD5 AppVer}}">
+	<noscript>
+		<style>
+			.dropdown:hover > .menu { display: block; }
+			.ui.secondary.menu .dropdown.item > .menu { margin-top: 0; }
+		</style>
+	</noscript>
 
 {{if .RequireHighlightJS}}
 	<link rel="stylesheet" href="{{AppSubUrl}}/vendor/plugins/highlight/github.css">
@@ -118,7 +124,7 @@
 </head>
 <body>
 	<div class="full height">
-		<noscript>Please enable JavaScript in your browser!</noscript>
+		<noscript>{{.i18n.Tr "enable_javascript"}}</noscript>
 
 		{{if not .PageIsInstall}}
 			<div class="following bar light">


### PR DESCRIPTION
Targeting https://github.com/go-gitea/gitea/issues/2538 to make the basic functionality of the website work better when JavaScript is disabled. The dropdowns of branches still don't work without JavaScript (the dropdown works, but the names of the branches don't appear), but this pull request makes the other dropdowns work just fine by using CSS and the `<noscript>` tag (unless I'm missing something).