### PR TITLE
Fix fmt errors

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -171,11 +171,12 @@ func RedirectToRepo(ctx *Context, redirectRepoID int64) {
 	)
 	ctx.Redirect(redirectPath)
 }
+
 // RepoIDAssignment returns an macaron handler which assigns the repo to the context.
 func RepoIDAssignment() macaron.Handler {
 	return func(ctx *Context) {
 		var (
-			err   error
+			err error
 		)
 
 		repoID := ctx.ParamsInt64(":repoid")


### PR DESCRIPTION
With the recent changes to `.drone.yml`, we should double check that `make fmt-check` (or something that has it as a dependency) always runs in CI.