### PR TITLE
Always run fmt check in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,7 @@ pipeline:
       - make generate
       - make vet
       - make lint
+      - make fmt-check
       - make stylesheets-check
       - make misspell-check
       - make test-vendor

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ fmt-check:
 	fi;
 
 .PHONY: test
-test: fmt-check
+test:
 	$(GO) test $(PACKAGES)
 
 .PHONY: coverage


### PR DESCRIPTION
Previously, `make fmt-check` would only run as a dependency of `make test`, which only runs on tag events. See also #2544.

I also removed `fmt-check` as a dependency of `test`, because I don't see why the two should be related. Let me know if I'm missing something.