### PR TITLE
Fix can_push value to false in protected_branch

### DIFF
--- a/models/branches.go
+++ b/models/branches.go
@@ -26,6 +26,7 @@ type ProtectedBranch struct {
 	ID               int64  `xorm:"pk autoincr"`
 	RepoID           int64  `xorm:"UNIQUE(s)"`
 	BranchName       string `xorm:"UNIQUE(s)"`
+	CanPush          bool   `xorm:"NOT NULL DEFAULT false"`
 	EnableWhitelist  bool
 	WhitelistUserIDs []int64   `xorm:"JSON TEXT"`
 	WhitelistTeamIDs []int64   `xorm:"JSON TEXT"`

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -134,6 +134,8 @@ var migrations = []Migration{
 	NewMigration("add default value to user prohibit_login", addDefaultValueToUserProhibitLogin),
 	// v42 -> v43
 	NewMigration("add tags to releases and sync existing repositories", releaseAddColumnIsTagAndSyncTags),
+	// v43 -> v44
+	NewMigration("fix protected branch can push value to false", fixProtectedBranchCanPushValue),
 }
 
 // Migrate database to current version

--- a/models/migrations/v43.go
+++ b/models/migrations/v43.go
@@ -1,0 +1,18 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"code.gitea.io/gitea/models"
+
+	"github.com/go-xorm/xorm"
+)
+
+func fixProtectedBranchCanPushValue(x *xorm.Engine) error {
+	_, err := x.Cols("can_push").Update(&models.ProtectedBranch{
+		CanPush: false,
+	})
+	return err
+}


### PR DESCRIPTION
Needed for #2556 and for future option to be able to specify that branch can be pushed to always but are protected only from deletion