### PR TITLE
Add external markup render support

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/markup/external"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/routers"
 	"code.gitea.io/gitea/routers/routes"
@@ -58,6 +59,8 @@ func runWeb(ctx *cli.Context) error {
 	}
 
 	routers.GlobalInit()
+
+	external.RegisterParsers()
 
 	m := routes.NewMacaron()
 	routes.RegisterRoutes(m)

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -573,3 +573,12 @@ SHOW_FOOTER_BRANDING = false
 SHOW_FOOTER_VERSION = true
 ; Show time of template execution in the footer
 SHOW_FOOTER_TEMPLATE_LOAD_TIME = true
+
+[markup.asciidoc]
+ENABLED = true
+; List of file extensions that should be rendered by an external command
+FILE_EXTENSIONS = .adoc,.asciidoc
+; External command to render all matching extensions
+RENDER_COMMAND = "asciidoc -o -"
+; Input is not a standard input but a file
+IS_INPUT_FILE = true

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -575,10 +575,10 @@ SHOW_FOOTER_VERSION = true
 SHOW_FOOTER_TEMPLATE_LOAD_TIME = true
 
 [markup.asciidoc]
-ENABLED = true
+ENABLED = false
 ; List of file extensions that should be rendered by an external command
 FILE_EXTENSIONS = .adoc,.asciidoc
 ; External command to render all matching extensions
-RENDER_COMMAND = "asciidoc -o -"
+RENDER_COMMAND = "asciidoc --out-file=- -"
 ; Input is not a standard input but a file
-IS_INPUT_FILE = true
+IS_INPUT_FILE = false

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -52,7 +52,7 @@ func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]stri
 	)
 
 	if p.IsInputFile {
-		// write to templ file
+		// write to temp file
 		f, err := ioutil.TempFile("", "gitea_input")
 		if err != nil {
 			log.Error(4, "%s create temp file when rendering %s failed: %v", p.Name(), p.Command, err)

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -19,16 +19,16 @@ import (
 
 // RegisterParsers registers all supported third part parsers according settings
 func RegisterParsers() {
-	for _, render := range setting.ExternalMarkupRenders {
-		if render.Enabled && render.Command != "" && len(render.FileExtensions) > 0 {
-			markup.RegisterParser(&Parser{render})
+	for _, parser := range setting.ExternalMarkupParsers {
+		if parser.Enabled && parser.Command != "" && len(parser.FileExtensions) > 0 {
+			markup.RegisterParser(&Parser{parser})
 		}
 	}
 }
 
 // Parser implements markup.Parser for external tools
 type Parser struct {
-	setting.MarkupRender
+	setting.MarkupParser
 }
 
 // Name returns the external tool name

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -1,0 +1,88 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package external
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/markup"
+	"code.gitea.io/gitea/modules/setting"
+
+	gouuid "github.com/satori/go.uuid"
+)
+
+// RegisterParsers registers all supported third part parsers according settings
+func RegisterParsers() {
+	for _, render := range setting.ExternalMarkupRenders {
+		if render.Enabled && render.Command != "" && len(render.FileExtensions) > 0 {
+			markup.RegisterParser(&Parser{render})
+		}
+	}
+}
+
+// Parser implements markup.Parser for orgmode
+type Parser struct {
+	setting.MarkupRender
+}
+
+// Name implements markup.Parser
+func (p *Parser) Name() string {
+	return p.MarkupName
+}
+
+// Extensions implements markup.Parser
+func (p *Parser) Extensions() []string {
+	return p.FileExtensions
+}
+
+// Render implements markup.Parser
+func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
+	var (
+		bs       []byte
+		buf      = bytes.NewBuffer(bs)
+		rd       = bytes.NewReader(rawBytes)
+		commands = strings.Fields(p.Command)
+		command  = commands[0]
+		args     []string
+	)
+
+	if len(commands) > 1 {
+		args = commands[1:]
+	}
+	if p.IsInputFile {
+		// write to templ file
+		fPath := filepath.Join(os.TempDir(), gouuid.NewV4().String())
+		f, err := os.Create(fPath)
+		if err != nil {
+			log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+			return []byte("")
+		}
+
+		_, err = io.Copy(f, rd)
+		f.Close()
+		if err != nil {
+			log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+			return []byte("")
+		}
+		args = append(args, fPath)
+	}
+
+	cmd := exec.Command(command, args...)
+	if !p.IsInputFile {
+		cmd.Stdin = rd
+	}
+	cmd.Stdout = buf
+	if err := cmd.Run(); err != nil {
+		log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+		return []byte("")
+	}
+	return buf.Bytes()
+}

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -61,12 +61,18 @@ func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]stri
 			log.Error(4, "%s create temp file when rendering %s failed: %v", p.Name(), p.Command, err)
 			return []byte("")
 		}
+		defer os.Remove(fPath)
 
 		_, err = io.Copy(f, rd)
-		f.Close()
-		os.Remove(fPath)
 		if err != nil {
+			f.Close()
 			log.Error(4, "%s write data to temp file when rendering %s failed: %v", p.Name(), p.Command, err)
+			return []byte("")
+		}
+
+		err = f.Close()
+		if err != nil {
+			log.Error(4, "%s close temp file when rendering %s failed: %v", p.Name(), p.Command, err)
 			return []byte("")
 		}
 		args = append(args, fPath)

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -28,22 +28,22 @@ func RegisterParsers() {
 	}
 }
 
-// Parser implements markup.Parser for orgmode
+// Parser implements markup.Parser for external tools
 type Parser struct {
 	setting.MarkupRender
 }
 
-// Name implements markup.Parser
+// Name returns the external tool name
 func (p *Parser) Name() string {
 	return p.MarkupName
 }
 
-// Extensions implements markup.Parser
+// Extensions returns the supported extensions of the tool
 func (p *Parser) Extensions() []string {
 	return p.FileExtensions
 }
 
-// Render implements markup.Parser
+// Render renders the data of the document to HTML via the external tool.
 func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
 	var (
 		bs       []byte
@@ -64,6 +64,7 @@ func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]stri
 
 		_, err = io.Copy(f, rd)
 		f.Close()
+		os.Remove(fPath)
 		if err != nil {
 			log.Error(4, "%s write data to temp file when rendering %s failed: %v", p.Name(), p.Command, err)
 			return []byte("")

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -45,15 +45,12 @@ func (p *Parser) Extensions() []string {
 
 // Render implements markup.Parser
 func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
-	var (
-		bs       []byte
-		buf      = bytes.NewBuffer(bs)
-		rd       = bytes.NewReader(rawBytes)
-		commands = strings.Fields(p.Command)
-		command  = commands[0]
-		args     []string
-	)
-
+	var bs []byte
+	var buf = bytes.NewBuffer(bs)
+	var rd = bytes.NewReader(rawBytes)
+	commands := strings.Fields(p.Command)
+	var command = commands[0]
+	var args []string
 	if len(commands) > 1 {
 		args = commands[1:]
 	}

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -78,7 +78,7 @@ func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]stri
 	}
 	cmd.Stdout = buf
 	if err := cmd.Run(); err != nil {
-		log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+		log.Error(4, "%s render run command %s %v failed: %v", p.Name(), commands[0], args, err)
 		return []byte("")
 	}
 	return buf.Bytes()

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -45,34 +45,33 @@ func (p *Parser) Extensions() []string {
 
 // Render implements markup.Parser
 func (p *Parser) Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
-	var bs []byte
-	var buf = bytes.NewBuffer(bs)
-	var rd = bytes.NewReader(rawBytes)
-	commands := strings.Fields(p.Command)
-	var command = commands[0]
-	var args []string
-	if len(commands) > 1 {
-		args = commands[1:]
-	}
+	var (
+		bs       []byte
+		buf      = bytes.NewBuffer(bs)
+		rd       = bytes.NewReader(rawBytes)
+		commands = strings.Fields(p.Command)
+		args     = commands[1:]
+	)
+
 	if p.IsInputFile {
 		// write to templ file
 		fPath := filepath.Join(os.TempDir(), gouuid.NewV4().String())
 		f, err := os.Create(fPath)
 		if err != nil {
-			log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+			log.Error(4, "%s create temp file when rendering %s failed: %v", p.Name(), p.Command, err)
 			return []byte("")
 		}
 
 		_, err = io.Copy(f, rd)
 		f.Close()
 		if err != nil {
-			log.Error(4, "%s render run command %s failed: %v", p.Name(), p.Command, err)
+			log.Error(4, "%s write data to temp file when rendering %s failed: %v", p.Name(), p.Command, err)
 			return []byte("")
 		}
 		args = append(args, fPath)
 	}
 
-	cmd := exec.Command(command, args...)
+	cmd := exec.Command(commands[0], args...)
 	if !p.IsInputFile {
 		cmd.Stdin = rd
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -60,7 +60,7 @@ const (
 	LandingPageExplore LandingPage = "/explore"
 )
 
-// MarkupParser defines the external parser configed on ini
+// MarkupParser defines the external parser configured in ini
 type MarkupParser struct {
 	Enabled        bool
 	MarkupName     string

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -60,8 +60,8 @@ const (
 	LandingPageExplore LandingPage = "/explore"
 )
 
-// MarkupRender defines the external render configed on ini
-type MarkupRender struct {
+// MarkupParser defines the external parser configed on ini
+type MarkupParser struct {
 	Enabled        bool
 	MarkupName     string
 	Command        string
@@ -525,7 +525,7 @@ var (
 	InternalToken     string // internal access token
 	IterateBufferSize int
 
-	ExternalMarkupRenders []MarkupRender
+	ExternalMarkupParsers []MarkupParser
 )
 
 // DateLang transforms standard language locale name to corresponding value in datetime plugin.
@@ -1114,7 +1114,7 @@ func NewContext() {
 			continue
 		}
 
-		ExternalMarkupRenders = append(ExternalMarkupRenders, MarkupRender{
+		ExternalMarkupParsers = append(ExternalMarkupParsers, MarkupParser{
 			Enabled:        sec.Key("ENABLED").MustBool(false),
 			MarkupName:     name,
 			FileExtensions: exts,

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1089,7 +1089,7 @@ func NewContext() {
 	for _, sec := range Cfg.Section("markup").ChildSections() {
 		name := strings.TrimLeft(sec.Name(), "markup.")
 		if name == "" {
-			log.Warn(sec.Name() + " name is empty, ignored")
+			log.Warn("name is empty, markup " + sec.Name() + "ignored")
 			continue
 		}
 
@@ -1097,20 +1097,20 @@ func NewContext() {
 		var exts = make([]string, 0, len(extensions))
 		for _, extension := range extensions {
 			if !extensionReg.MatchString(extension) {
-				log.Warn(sec.Name() + " FILE_EXTENSIONS " + extension + " is invalid, ignored")
+				log.Warn(sec.Name() + " file extension " + extension + " is invalid. Extension ignored")
 			} else {
 				exts = append(exts, extension)
 			}
 		}
 
 		if len(exts) == 0 {
-			log.Warn(sec.Name() + " FILE_EXTENSIONS is empty, ignored")
+			log.Warn(sec.Name() + " file extension is empty, markup " + name + " ignored")
 			continue
 		}
 
 		command := sec.Key("RENDER_COMMAND").MustString("")
 		if command == "" {
-			log.Warn(sec.Name() + " RENDER_COMMAND is empty, ignored")
+			log.Warn(" RENDER_COMMAND is empty, markup " + name + " ignored")
 			continue
 		}
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -60,6 +60,15 @@ const (
 	LandingPageExplore LandingPage = "/explore"
 )
 
+// MarkupRender defines the external render configed on ini
+type MarkupRender struct {
+	Enabled        bool
+	MarkupName     string
+	Command        string
+	FileExtensions []string
+	IsInputFile    bool
+}
+
 // settings
 var (
 	// AppVer settings
@@ -515,6 +524,8 @@ var (
 	HasRobotsTxt      bool
 	InternalToken     string // internal access token
 	IterateBufferSize int
+
+	ExternalMarkupRenders []MarkupRender
 )
 
 // DateLang transforms standard language locale name to corresponding value in datetime plugin.
@@ -1073,6 +1084,16 @@ func NewContext() {
 	UI.ShowUserEmail = Cfg.Section("ui").Key("SHOW_USER_EMAIL").MustBool(true)
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
+
+	for _, sec := range Cfg.Section("markup").ChildSections() {
+		ExternalMarkupRenders = append(ExternalMarkupRenders, MarkupRender{
+			Enabled:        sec.Key("ENABLED").MustBool(false),
+			MarkupName:     strings.TrimLeft(sec.Name(), "markup."),
+			FileExtensions: sec.Key("FILE_EXTENSIONS").Strings(","),
+			Command:        sec.Key("RENDER_COMMAND").MustString(""),
+			IsInputFile:    sec.Key("IS_INPUT_FILE").MustBool(false),
+		})
+	}
 }
 
 // Service settings
@@ -1133,7 +1154,6 @@ func newService() {
 			Service.OpenIDBlacklist[i] = regexp.MustCompilePOSIX(p)
 		}
 	}
-
 }
 
 var logLevels = map[string]string{


### PR DESCRIPTION
Will close #374.

Usage:
Add the below to your `custom/conf/app.ini` file. You can add one or more sections. The section name should `markup.xxxxx`, which you can name it as you like. Follow the below config items then restart your `gitea`, it's done. For example:

On MacOS, 
```
brew install asciidoc
```
Then add below config to your `custom/conf/app.ini` file and restart. Migration `https://github.com/maxandersen/gdoc2adoc.git` and then view the `.adoc` file.

```ini
[markup.asciidoc]
ENABLED = true
; List of file extensions that should be rendered by an external command
FILE_EXTENSIONS = .adoc,.asciidoc
; External command to render all matching extensions
RENDER_COMMAND = "asciidoc --out-file=- -"
; Input is not a standard input but a file
IS_INPUT_FILE = false
```