### PR TITLE
Add pre-build step for nodejs stuff

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,14 @@ clone:
     tags: true
 
 pipeline:
+  pre-build:
+    image: webhippie/nodejs:latest
+    pull: true
+    commands:
+      - npm install
+      - make stylesheets-check
+    when:
+      event: [ push, tag, pull_request ]
   build:
     image: webhippie/golang:edge
     pull: true
@@ -16,14 +24,11 @@ pipeline:
       TAGS: bindata sqlite
       GOPATH: /srv/app
     commands:
-      - apk -U add nodejs nodejs-npm
-      - npm install
       - make clean
       - make generate
       - make vet
       - make lint
       - make fmt-check
-      - make stylesheets-check
       - make misspell-check
       - make test-vendor
       - make build


### PR DESCRIPTION
As title. Based (=contains) on #2580 (need to be merged first, then I'll rebase this one). Only `.drone.yml` file contains related changes.

Instead of installing node on each PR, use image with nodejs and run nodejs stuff there.

@tboerger Please take a look.