### PR TITLE
add sorting to database query of repo_units

### DIFF
--- a/models/fixtures/repo_unit.yml
+++ b/models/fixtures/repo_unit.yml
@@ -1,13 +1,29 @@
 -
   id: 1
   repo_id: 1
+  type: 4
+  index: 3
+  config: "{}"
+  created_unix: 946684810
+
+-
+  id: 2
+  repo_id: 1
+  type: 5
+  index: 4
+  config: "{}"
+  created_unix: 946684810
+
+-
+  id: 3
+  repo_id: 1
   type: 1
   index: 0
   config: "{}"
   created_unix: 946684810
 
 -
-  id: 2
+  id: 4
   repo_id: 1
   type: 2
   index: 1
@@ -15,26 +31,10 @@
   created_unix: 946684810
 
 -
-  id: 3
+  id: 5
   repo_id: 1
   type: 3
   index: 2
-  config: "{}"
-  created_unix: 946684810
-
--
-  id: 4
-  repo_id: 1
-  type: 4
-  index: 3
-  config: "{}"
-  created_unix: 946684810
-
--
-  id: 5
-  repo_id: 1
-  type: 5
-  index: 4
   config: "{}"
   created_unix: 946684810
 

--- a/models/repo_unit.go
+++ b/models/repo_unit.go
@@ -150,9 +150,9 @@ func (r *RepoUnit) ExternalTrackerConfig() *ExternalTrackerConfig {
 }
 
 func getUnitsByRepoID(e Engine, repoID int64) (units []*RepoUnit, err error) {
-	return units, e.Where("repo_id = ?", repoID).Asc("type").Find(&units)
+	return units, e.Where("repo_id = ?", repoID).Asc("index").Find(&units)
 }
 
 func getUnitsByRepoIDAndIDs(e Engine, repoID int64, types []UnitType) (units []*RepoUnit, err error) {
-	return units, e.Where("repo_id = ?", repoID).In("`type`", types).Asc("type").Find(&units)
+	return units, e.Where("repo_id = ?", repoID).In("`type`", types).Asc("index").Find(&units)
 }

--- a/models/repo_unit.go
+++ b/models/repo_unit.go
@@ -150,9 +150,9 @@ func (r *RepoUnit) ExternalTrackerConfig() *ExternalTrackerConfig {
 }
 
 func getUnitsByRepoID(e Engine, repoID int64) (units []*RepoUnit, err error) {
-	return units, e.Where("repo_id = ?", repoID).Find(&units)
+	return units, e.Where("repo_id = ?", repoID).Asc("type").Find(&units)
 }
 
 func getUnitsByRepoIDAndIDs(e Engine, repoID int64, types []UnitType) (units []*RepoUnit, err error) {
-	return units, e.Where("repo_id = ?", repoID).In("`type`", types).Find(&units)
+	return units, e.Where("repo_id = ?", repoID).In("`type`", types).Asc("type").Find(&units)
 }


### PR DESCRIPTION
If sorting is wrong and UnitTypeCode is not the first one, a user can't visit to the `Code` Tab even with required permissions.

Furthermore fixes wrong redirect to leftmost accessible tab in repo view.