### PR TITLE
Add search by index to issues api

### DIFF
--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -6,6 +6,7 @@ package models
 
 import (
 	"fmt"
+	"strconv"
 
 	"code.gitea.io/gitea/modules/indexer"
 	"code.gitea.io/gitea/modules/log"
@@ -88,10 +89,11 @@ func (issue *Issue) update() indexer.IssueIndexerUpdate {
 	return indexer.IssueIndexerUpdate{
 		IssueID: issue.ID,
 		Data: &indexer.IssueIndexerData{
-			RepoID:   issue.RepoID,
-			Title:    issue.Title,
-			Content:  issue.Content,
-			Comments: comments,
+			RepoID:     issue.RepoID,
+			Title:      issue.Title,
+			Content:    issue.Content,
+			Comments:   comments,
+			IssueIndex: strconv.FormatInt(issue.Index, 10),
 		},
 	}
 }

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -136,6 +136,8 @@ var migrations = []Migration{
 	NewMigration("add tags to releases and sync existing repositories", releaseAddColumnIsTagAndSyncTags),
 	// v43 -> v44
 	NewMigration("fix protected branch can push value to false", fixProtectedBranchCanPushValue),
+	// v44 -> v45
+	NewMigration("add index field to bleve issue index", regenerateIssueIndexer),
 }
 
 // Migrate database to current version

--- a/models/migrations/v44.go
+++ b/models/migrations/v44.go
@@ -16,9 +16,8 @@ func regenerateIssueIndexer(x *xorm.Engine) error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 
 	return os.RemoveAll(setting.Indexer.IssuePath)

--- a/models/migrations/v44.go
+++ b/models/migrations/v44.go
@@ -1,0 +1,25 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+
+	"code.gitea.io/gitea/modules/setting"
+	"github.com/go-xorm/xorm"
+)
+
+func regenerateIssueIndexer(x *xorm.Engine) error {
+	_, err := os.Stat(setting.Indexer.IssuePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	return os.RemoveAll(setting.Indexer.IssuePath)
+}

--- a/modules/indexer/indexer.go
+++ b/modules/indexer/indexer.go
@@ -44,6 +44,12 @@ func newMatchPhraseQuery(matchPhrase, field, analyzer string) *query.MatchPhrase
 	return q
 }
 
+func newPrefixQuery(matchPhrase, field string) *query.PrefixQuery {
+	q := bleve.NewPrefixQuery(matchPhrase)
+	q.FieldVal = field
+	return q
+}
+
 const unicodeNormalizeName = "unicodeNormalize"
 
 func addUnicodeNormalizeTokenFilter(m *mapping.IndexMappingImpl) error {

--- a/modules/indexer/issue.go
+++ b/modules/indexer/issue.go
@@ -107,6 +107,23 @@ func IssueIndexerBatch() *Batch {
 	}
 }
 
+func searchIssues(req *bleve.SearchRequest) ([]int64, error) {
+	result, err := issueIndexer.Search(req)
+	if err != nil {
+		return nil, err
+	}
+
+	issueIDs := make([]int64, len(result.Hits))
+	for i, hit := range result.Hits {
+		issueIDs[i], err = idOfIndexerID(hit.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return issueIDs, nil
+}
+
 // SearchIssuesByKeyword searches for issues by given conditions.
 // Returns the matching issue IDs
 func SearchIssuesByKeyword(repoID int64, keyword string) ([]int64, error) {
@@ -119,19 +136,7 @@ func SearchIssuesByKeyword(repoID int64, keyword string) ([]int64, error) {
 		))
 	search := bleve.NewSearchRequestOptions(indexerQuery, 2147483647, 0, false)
 
-	result, err := issueIndexer.Search(search)
-	if err != nil {
-		return nil, err
-	}
-
-	issueIDs := make([]int64, len(result.Hits))
-	for i, hit := range result.Hits {
-		issueIDs[i], err = idOfIndexerID(hit.ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return issueIDs, nil
+	return searchIssues(search)
 }
 
 // SearchIssuesByIndex searches for issues by given conditions.
@@ -142,17 +147,5 @@ func SearchIssuesByIndex(repoID, issueIndex int64) ([]int64, error) {
 		newPrefixQuery(strconv.FormatInt(issueIndex, 10), "IssueIndex"))
 	search := bleve.NewSearchRequestOptions(indexerQuery, 2147483647, 0, false)
 
-	result, err := issueIndexer.Search(search)
-	if err != nil {
-		return nil, err
-	}
-
-	issueIDs := make([]int64, len(result.Hits))
-	for i, hit := range result.Hits {
-		issueIDs[i], err = idOfIndexerID(hit.ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return issueIDs, nil
+	return searchIssues(search)
 }

--- a/modules/indexer/issue.go
+++ b/modules/indexer/issue.go
@@ -6,6 +6,7 @@ package indexer
 
 import (
 	"os"
+	"strconv"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -22,10 +23,11 @@ var issueIndexer bleve.Index
 
 // IssueIndexerData data stored in the issue indexer
 type IssueIndexerData struct {
-	RepoID   int64
-	Title    string
-	Content  string
-	Comments []string
+	RepoID     int64
+	Title      string
+	Content    string
+	Comments   []string
+	IssueIndex string
 }
 
 // IssueIndexerUpdate an update to the issue indexer
@@ -76,6 +78,7 @@ func createIssueIndexer() error {
 	docMapping.AddFieldMappingsAt("Title", textFieldMapping)
 	docMapping.AddFieldMappingsAt("Content", textFieldMapping)
 	docMapping.AddFieldMappingsAt("Comments", textFieldMapping)
+	docMapping.AddFieldMappingsAt("IssueIndex", textFieldMapping)
 
 	if err := addUnicodeNormalizeTokenFilter(mapping); err != nil {
 		return err
@@ -114,6 +117,29 @@ func SearchIssuesByKeyword(repoID int64, keyword string) ([]int64, error) {
 			newMatchPhraseQuery(keyword, "Content", issueIndexerAnalyzer),
 			newMatchPhraseQuery(keyword, "Comments", issueIndexerAnalyzer),
 		))
+	search := bleve.NewSearchRequestOptions(indexerQuery, 2147483647, 0, false)
+
+	result, err := issueIndexer.Search(search)
+	if err != nil {
+		return nil, err
+	}
+
+	issueIDs := make([]int64, len(result.Hits))
+	for i, hit := range result.Hits {
+		issueIDs[i], err = idOfIndexerID(hit.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return issueIDs, nil
+}
+
+// SearchIssuesByIndex searches for issues by given conditions.
+// Returns the matching issue IDs
+func SearchIssuesByIndex(repoID, issueIndex int64) ([]int64, error) {
+	indexerQuery := bleve.NewConjunctionQuery(
+		numericEqualityQuery(repoID, "RepoID"),
+		newPrefixQuery(strconv.FormatInt(issueIndex, 10), "IssueIndex"))
 	search := bleve.NewSearchRequestOptions(indexerQuery, 2147483647, 0, false)
 
 	result, err := issueIndexer.Search(search)


### PR DESCRIPTION
This PR adds issue index field to bleve for indexing and adds option to search issues by index (search by prefix - eg. `Issue{Index: 1234}` will match `?index=1`, `12`, `123` or `1234`).