### PR TITLE
Fix doubled issue tab introduced in migration v16

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -136,6 +136,8 @@ var migrations = []Migration{
 	NewMigration("add tags to releases and sync existing repositories", releaseAddColumnIsTagAndSyncTags),
 	// v43 -> v44
 	NewMigration("fix protected branch can push value to false", fixProtectedBranchCanPushValue),
+	// v44 -> v45
+	NewMigration("remove UnitTypeIssue if UnitTypeExternalTracker exists", removeDuplicateIssueUnitType),
 }
 
 // Migrate database to current version

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -137,7 +137,7 @@ var migrations = []Migration{
 	// v43 -> v44
 	NewMigration("fix protected branch can push value to false", fixProtectedBranchCanPushValue),
 	// v44 -> v45
-	NewMigration("remove UnitTypeIssue if UnitTypeExternalTracker exists", removeDuplicateIssueUnitType),
+	NewMigration("remove duplicate unit types", removeDuplicateUnitTypes),
 }
 
 // Migrate database to current version

--- a/models/migrations/v44.go
+++ b/models/migrations/v44.go
@@ -24,13 +24,13 @@ func removeDuplicateUnitTypes(x *xorm.Engine) error {
 
 	// Enumerate all the unit types
 	const (
-		UnitTypeCode             = iota + 1 // 1 code
-		UnitTypeIssues                      // 2 issues
-		UnitTypePullRequests                // 3 PRs
-		UnitTypeReleases                    // 4 Releases
-		UnitTypeWiki                        // 5 Wiki
-		UnitTypeExternalWiki                // 6 ExternalWiki
-		UnitTypeExternalTracker             // 7 ExternalTracker
+		UnitTypeCode            = iota + 1 // 1 code
+		UnitTypeIssues                     // 2 issues
+		UnitTypePullRequests               // 3 PRs
+		UnitTypeReleases                   // 4 Releases
+		UnitTypeWiki                       // 5 Wiki
+		UnitTypeExternalWiki               // 6 ExternalWiki
+		UnitTypeExternalTracker            // 7 ExternalTracker
 	)
 
 	var externalIssueRepos []Repo

--- a/models/migrations/v44.go
+++ b/models/migrations/v44.go
@@ -17,11 +17,6 @@ func removeDuplicateUnitTypes(x *xorm.Engine) error {
 		Type   int
 	}
 
-	// Repo describes a repository
-	type Repo struct {
-		ID int64
-	}
-
 	// Enumerate all the unit types
 	const (
 		UnitTypeCode            = iota + 1 // 1 code
@@ -33,20 +28,14 @@ func removeDuplicateUnitTypes(x *xorm.Engine) error {
 		UnitTypeExternalTracker            // 7 ExternalTracker
 	)
 
-	var externalIssueRepos []Repo
-	err := x.Table("repository").Select("`repository`.id").
-		Join("INNER", "repo_unit", "`repo_unit`.repo_id = `repository`.id").
-		Where("`repo_unit`.type = ?", UnitTypeExternalTracker).
-		Find(&externalIssueRepos)
+	var externalIssueRepoUnits []RepoUnit
+	err := x.Where("type = ?", UnitTypeExternalTracker).Find(&externalIssueRepoUnits)
 	if err != nil {
 		return fmt.Errorf("Query repositories: %v", err)
 	}
 
-	var externalWikiRepos []Repo
-	err = x.Table("repository").Select("`repository`.id").
-		Join("INNER", "repo_unit", "`repo_unit`.repo_id = `repository`.id").
-		Where("`repo_unit`.type = ?", UnitTypeExternalWiki).
-		Find(&externalWikiRepos)
+	var externalWikiRepoUnits []RepoUnit
+	err = x.Where("type = ?", UnitTypeExternalWiki).Find(&externalWikiRepoUnits)
 	if err != nil {
 		return fmt.Errorf("Query repositories: %v", err)
 	}
@@ -58,18 +47,18 @@ func removeDuplicateUnitTypes(x *xorm.Engine) error {
 		return err
 	}
 
-	for _, repo := range externalIssueRepos {
+	for _, repoUnit := range externalIssueRepoUnits {
 		if _, err = sess.Delete(&RepoUnit{
-			RepoID: repo.ID,
+			RepoID: repoUnit.RepoID,
 			Type:   UnitTypeIssues,
 		}); err != nil {
 			return fmt.Errorf("Delete repo unit: %v", err)
 		}
 	}
 
-	for _, repo := range externalWikiRepos {
+	for _, repoUnit := range externalWikiRepoUnits {
 		if _, err = sess.Delete(&RepoUnit{
-			RepoID: repo.ID,
+			RepoID: repoUnit.RepoID,
 			Type:   UnitTypeWiki,
 		}); err != nil {
 			return fmt.Errorf("Delete repo unit: %v", err)

--- a/models/migrations/v44.go
+++ b/models/migrations/v44.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-xorm/xorm"
+)
+
+func removeDuplicateIssueUnitType(x *xorm.Engine) error {
+	// RepoUnit describes all units of a repository
+	type RepoUnit struct {
+		RepoID int64
+		Type   int
+	}
+
+	// Repo describes a repository
+	type Repo struct {
+		ID int64
+	}
+
+	// Enumerate all the unit types
+	const (
+		UnitTypeCode             = iota + 1 // 1 code
+		UnitTypeIssues                      // 2 issues
+		UnitTypePullRequests                // 3 PRs
+		UnitTypeReleases                    // 4 Releases
+		UnitTypeWiki                        // 5 Wiki
+		UnitTypeExternalWiki                // 6 ExternalWiki
+		UnitTypeExternalTracker             // 7 ExternalTracker
+	)
+
+	var repos []Repo
+	err := x.Table("repository").Select("`repository`.id").
+		Join("INNER", "repo_unit", "`repo_unit`.repo_id = `repository`.id").
+		Where("`repo_unit`.type = ?", UnitTypeExternalTracker).
+		Find(&repos)
+	if err != nil {
+		return fmt.Errorf("Query repositories: %v", err)
+	}
+
+	sess := x.NewSession()
+	defer sess.Close()
+
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	for _, repo := range repos {
+		if _, err = sess.Delete(&RepoUnit{
+			RepoID: repo.ID,
+			Type:   UnitTypeIssues,
+		}); err != nil {
+			return fmt.Errorf("Insert repo unit: %v", err)
+		}
+	}
+
+	return sess.Commit()
+}


### PR DESCRIPTION
Migration v16 creates UnitTypeIssue and UnitTypeExternalTracker for each repository with enabled external issue tracker as repo.EnableIssues is true even for external tracker.

And because both Unit Types exist the issue tab is shown twice.

The same behaviour is happening to UnitTypeWiki and UnitTypeExternalWiki, but because the tab is not changed in view it has no visual impact.

PR fixes both mistakes and removes UnitTypeIssue for repositories with UniTypeExternalTracker and removes UnitTypeWiki for repositories with UnitTypeExternalWiki.