### PR TITLE
Remove redudant issue LoadAttributes() calls

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -984,12 +984,7 @@ func GetIssueByRef(ref string) (*Issue, error) {
 		return nil, err
 	}
 
-	issue, err := GetIssueByIndex(repo.ID, index)
-	if err != nil {
-		return nil, err
-	}
-
-	return issue, issue.LoadAttributes()
+	return GetIssueByIndex(repo.ID, index)
 }
 
 // GetRawIssueByIndex returns raw issue without loading attributes by index in a repository.

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -39,12 +39,6 @@ func ListIssues(ctx *context.APIContext) {
 		return
 	}
 
-	err = models.IssueList(issues).LoadAttributes()
-	if err != nil {
-		ctx.Error(500, "LoadAttributes", err)
-		return
-	}
-
 	apiIssues := make([]*api.Issue, len(issues))
 	for i := range issues {
 		apiIssues[i] = issues[i].APIFormat()


### PR DESCRIPTION
This should reduce duplicated `LoadAttributes()` calls. Functions `models.Issues` and `models.GetIssueByIndex` are already doing it. This should speed up Gitea a little bit when working with issues.