### PR TITLE
Remove repo unit index

### DIFF
--- a/models/fixtures/repo_unit.yml
+++ b/models/fixtures/repo_unit.yml
@@ -2,7 +2,6 @@
   id: 1
   repo_id: 1
   type: 1
-  index: 0
   config: "{}"
   created_unix: 946684810
 
@@ -10,7 +9,6 @@
   id: 2
   repo_id: 1
   type: 2
-  index: 1
   config: "{\"EnableTimetracker\":true,\"AllowOnlyContributorsToTrackTime\":true}"
   created_unix: 946684810
 
@@ -18,7 +16,6 @@
   id: 3
   repo_id: 1
   type: 3
-  index: 2
   config: "{}"
   created_unix: 946684810
 
@@ -26,7 +23,6 @@
   id: 4
   repo_id: 1
   type: 4
-  index: 3
   config: "{}"
   created_unix: 946684810
 
@@ -34,7 +30,6 @@
   id: 5
   repo_id: 1
   type: 5
-  index: 4
   config: "{}"
   created_unix: 946684810
 
@@ -42,7 +37,6 @@
   id: 6
   repo_id: 3
   type: 1
-  index: 0
   config: "{}"
   created_unix: 946684810
 
@@ -50,7 +44,6 @@
   id: 7
   repo_id: 3
   type: 2
-  index: 1
   config: "{\"EnableTimetracker\":false,\"AllowOnlyContributorsToTrackTime\":false}"
   created_unix: 946684810
 
@@ -58,7 +51,6 @@
   id: 8
   repo_id: 3
   type: 3
-  index: 2
   config: "{}"
   created_unix: 946684810
 
@@ -66,7 +58,6 @@
   id: 9
   repo_id: 3
   type: 4
-  index: 3
   config: "{}"
   created_unix: 946684810
 
@@ -74,6 +65,5 @@
   id: 10
   repo_id: 3
   type: 5
-  index: 4
   config: "{}"
   created_unix: 946684810

--- a/models/fixtures/repo_unit.yml
+++ b/models/fixtures/repo_unit.yml
@@ -1,7 +1,6 @@
 -
   id: 1
   repo_id: 1
-  type: 1
   type: 4
   config: "{}"
   created_unix: 946684810

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -138,6 +138,8 @@ var migrations = []Migration{
 	NewMigration("fix protected branch can push value to false", fixProtectedBranchCanPushValue),
 	// v44 -> v45
 	NewMigration("remove duplicate unit types", removeDuplicateUnitTypes),
+	// v45 -> v46
+	NewMigration("remove index column from repo_unit table", removeIndexColumnFromRepoUnitTable),
 }
 
 // Migrate database to current version

--- a/models/migrations/v45.go
+++ b/models/migrations/v45.go
@@ -1,0 +1,18 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-xorm/xorm"
+)
+
+func removeIndexColumnFromRepoUnitTable(x *xorm.Engine) (err error) {
+	if _, err := x.Exec("ALTER TABLE repo_unit DROP COLUMN index"); err != nil {
+		return fmt.Errorf("DROP COLUMN index: %v", err)
+	}
+	return nil
+}

--- a/models/migrations/v45.go
+++ b/models/migrations/v45.go
@@ -7,12 +7,22 @@ package migrations
 import (
 	"fmt"
 
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
 	"github.com/go-xorm/xorm"
 )
 
 func removeIndexColumnFromRepoUnitTable(x *xorm.Engine) (err error) {
-	if _, err := x.Exec("ALTER TABLE repo_unit DROP COLUMN index"); err != nil {
-		return fmt.Errorf("DROP COLUMN index: %v", err)
+	switch {
+	case setting.UseSQLite3:
+		log.Warn("Unable to drop columns in SQLite")
+	case setting.UseMySQL, setting.UsePostgreSQL, setting.UseMSSQL, setting.UseTiDB:
+		if _, err := x.Exec("ALTER TABLE repo_unit DROP COLUMN index"); err != nil {
+			return fmt.Errorf("DROP COLUMN index: %v", err)
+		}
+	default:
+		log.Fatal(4, "Unrecognized DB")
 	}
+
 	return nil
 }

--- a/models/repo.go
+++ b/models/repo.go
@@ -1252,19 +1252,17 @@ func createRepository(e *xorm.Session, doer, u *User, repo *Repository) (err err
 
 	// insert units for repo
 	var units = make([]RepoUnit, 0, len(defaultRepoUnits))
-	for i, tp := range defaultRepoUnits {
+	for _, tp := range defaultRepoUnits {
 		if tp == UnitTypeIssues {
 			units = append(units, RepoUnit{
 				RepoID: repo.ID,
 				Type:   tp,
-				Index:  i,
 				Config: &IssuesConfig{EnableTimetracker: setting.Service.DefaultEnableTimetracking, AllowOnlyContributorsToTrackTime: setting.Service.DefaultAllowOnlyContributorsToTrackTime},
 			})
 		} else {
 			units = append(units, RepoUnit{
 				RepoID: repo.ID,
 				Type:   tp,
-				Index:  i,
 			})
 		}
 

--- a/models/repo_unit.go
+++ b/models/repo_unit.go
@@ -16,9 +16,8 @@ import (
 // RepoUnit describes all units of a repository
 type RepoUnit struct {
 	ID          int64
-	RepoID      int64    `xorm:"INDEX(s)"`
-	Type        UnitType `xorm:"INDEX(s)"`
-	Index       int
+	RepoID      int64           `xorm:"INDEX(s)"`
+	Type        UnitType        `xorm:"INDEX(s)"`
 	Config      core.Conversion `xorm:"TEXT"`
 	CreatedUnix int64           `xorm:"INDEX CREATED"`
 	Created     time.Time       `xorm:"-"`

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -149,7 +149,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 			units = append(units, models.RepoUnit{
 				RepoID: repo.ID,
 				Type:   tp,
-				Index:  int(tp),
 				Config: new(models.UnitConfig),
 			})
 		}
@@ -165,7 +164,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 				units = append(units, models.RepoUnit{
 					RepoID: repo.ID,
 					Type:   models.UnitTypeExternalWiki,
-					Index:  int(models.UnitTypeExternalWiki),
 					Config: &models.ExternalWikiConfig{
 						ExternalWikiURL: form.ExternalWikiURL,
 					},
@@ -174,7 +172,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 				units = append(units, models.RepoUnit{
 					RepoID: repo.ID,
 					Type:   models.UnitTypeWiki,
-					Index:  int(models.UnitTypeWiki),
 					Config: new(models.UnitConfig),
 				})
 			}
@@ -190,7 +187,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 				units = append(units, models.RepoUnit{
 					RepoID: repo.ID,
 					Type:   models.UnitTypeExternalTracker,
-					Index:  int(models.UnitTypeExternalTracker),
 					Config: &models.ExternalTrackerConfig{
 						ExternalTrackerURL:    form.ExternalTrackerURL,
 						ExternalTrackerFormat: form.TrackerURLFormat,
@@ -201,7 +197,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 				units = append(units, models.RepoUnit{
 					RepoID: repo.ID,
 					Type:   models.UnitTypeIssues,
-					Index:  int(models.UnitTypeIssues),
 					Config: &models.IssuesConfig{
 						EnableTimetracker:                form.EnableTimetracker,
 						AllowOnlyContributorsToTrackTime: form.AllowOnlyContributorsToTrackTime,
@@ -214,7 +209,6 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 			units = append(units, models.RepoUnit{
 				RepoID: repo.ID,
 				Type:   models.UnitTypePullRequests,
-				Index:  int(models.UnitTypePullRequests),
 				Config: new(models.UnitConfig),
 			})
 		}


### PR DESCRIPTION
~Fix `Index` values in `RepoUnit`.~~#2601 has to be merged first.~

~Edit: #2601 or #2603 can fix problems with accessing repo pages with this changes.~

Removes unused `RepoUnit.Index`