### PR TITLE
Change default sort order

### DIFF
--- a/routers/home.go
+++ b/routers/home.go
@@ -88,8 +88,8 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		err     error
 		orderBy models.SearchOrderBy
 	)
+	
 	ctx.Data["SortType"] = ctx.Query("sort")
-
 	switch ctx.Query("sort") {
 	case "newest":
 		orderBy = models.SearchOrderByNewest
@@ -108,6 +108,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	case "size":
 		orderBy = models.SearchOrderBySize
 	default:
+		ctx.Data["SortType"] = "recentupdate"
 		orderBy = models.SearchOrderByRecentUpdated
 	}
 
@@ -190,6 +191,8 @@ func RenderUserSearch(ctx *context.Context, opts *UserSearchOptions) {
 
 	ctx.Data["SortType"] = ctx.Query("sort")
 	switch ctx.Query("sort") {
+	case "newest":
+		orderBy = "id DESC"
 	case "oldest":
 		orderBy = "id ASC"
 	case "recentupdate":
@@ -201,7 +204,8 @@ func RenderUserSearch(ctx *context.Context, opts *UserSearchOptions) {
 	case "alphabetically":
 		orderBy = "name ASC"
 	default:
-		orderBy = "id DESC"
+		ctx.Data["SortType"] = "alphabetically"
+		orderBy = "name ASC"
 	}
 
 	keyword := strings.Trim(ctx.Query("q"), " ")

--- a/routers/home.go
+++ b/routers/home.go
@@ -199,7 +199,7 @@ func RenderUserSearch(ctx *context.Context, opts *UserSearchOptions) {
 	case "alphabetically":
 		orderBy = "name ASC"
 	default:
-		orderBy = "id DESC"
+		orderBy = "updated_unix DESC"
 	}
 
 	keyword := strings.Trim(ctx.Query("q"), " ")

--- a/routers/home.go
+++ b/routers/home.go
@@ -91,6 +91,8 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	ctx.Data["SortType"] = ctx.Query("sort")
 
 	switch ctx.Query("sort") {
+	case "newest":
+		orderBy = models.SearchOrderByNewest
 	case "oldest":
 		orderBy = models.SearchOrderByOldest
 	case "recentupdate":

--- a/routers/home.go
+++ b/routers/home.go
@@ -106,7 +106,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	case "size":
 		orderBy = models.SearchOrderBySize
 	default:
-		orderBy = models.SearchOrderByNewest
+		orderBy = models.SearchOrderByRecentUpdated
 	}
 
 	keyword := strings.Trim(ctx.Query("q"), " ")

--- a/routers/home.go
+++ b/routers/home.go
@@ -88,7 +88,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		err     error
 		orderBy models.SearchOrderBy
 	)
-	
+
 	ctx.Data["SortType"] = ctx.Query("sort")
 	switch ctx.Query("sort") {
 	case "newest":

--- a/routers/home.go
+++ b/routers/home.go
@@ -199,7 +199,7 @@ func RenderUserSearch(ctx *context.Context, opts *UserSearchOptions) {
 	case "alphabetically":
 		orderBy = "name ASC"
 	default:
-		orderBy = "updated_unix DESC"
+		orderBy = "id DESC"
 	}
 
 	keyword := strings.Trim(ctx.Query("q"), " ")

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -126,12 +126,7 @@ func Profile(ctx *context.Context) {
 		orderBy = models.SearchOrderByAlphabetically
 	default:
 		ctx.Data["SortType"] = "recentupdate"
-		orderBy = models.SearchOrderByNewest
-	}
-
-	// set default sort value if sort is empty.
-	if ctx.Query("sort") == "" {
-		ctx.Data["SortType"] = "recentupdate"
+		orderBy = models.SearchOrderByRecentUpdated
 	}
 
 	keyword := strings.Trim(ctx.Query("q"), " ")

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -10,7 +10,7 @@
 			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
 			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
 			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if or (eq .SortType "recentupdate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
 			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 		</div>
 	</div>

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -6,11 +6,11 @@
 			<i class="dropdown icon"></i>
 		</span>
 		<div class="menu">
-			<a class="{{if or (eq .SortType "newest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
+			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
 			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
 			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
 			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if or (eq .SortType "recentupdate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
 			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}&tab={{$.TabName}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 		</div>
 	</div>


### PR DESCRIPTION
Change default sort key to `updated_unix` from `created_unix`
(repositories order on explore page)

it was suggested on (#2442)

Closes #2442