### PR TITLE
Remove redudant functions and code

### DIFF
--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -27,9 +27,11 @@ func InitIssueIndexer() {
 func populateIssueIndexer() error {
 	batch := indexer.IssueIndexerBatch()
 	for page := 1; ; page++ {
-		repos, _, err := Repositories(&SearchRepoOptions{
+		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
 			Page:     page,
 			PageSize: 10,
+			OrderBy:  SearchOrderByID,
+			Private:  true,
 		})
 		if err != nil {
 			return fmt.Errorf("Repositories: %v", err)

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -129,8 +129,8 @@ const (
 	SearchOrderByNewest                              = "created_unix DESC"
 	SearchOrderBySize                                = "size ASC"
 	SearchOrderBySizeReverse                         = "size DESC"
-	SearchOrderByID                                  = "ID ASC"
-	SearchOrderByIDReverse                           = "ID DESC"
+	SearchOrderByID                                  = "id ASC"
+	SearchOrderByIDReverse                           = "id DESC"
 )
 
 // SearchRepositoryByName takes keyword and part of repository name to search,

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -181,7 +181,7 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (repos RepositoryList, coun
 	}
 
 	if opts.OwnerID > 0 && opts.AllPublic {
-		cond = builder.Or(cond, builder.Eq{"is_private": false})
+		cond = cond.Or(builder.Eq{"is_private": false})
 	}
 
 	opts.Keyword = strings.ToLower(opts.Keyword)

--- a/models/repo_list_test.go
+++ b/models/repo_list_test.go
@@ -98,6 +98,24 @@ func TestSearchRepositoryByName(t *testing.T) {
 		{name: "PublicAndPrivateRepositoriesOfOrganization",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, Private: true},
 			count: 2},
+		{name: "AllPublic/PublicRepositoriesByName",
+			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10, AllPublic: true},
+			count: 4},
+		{name: "AllPublic/PublicAndPrivateRepositoriesByName",
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true, AllPublic: true},
+			count: 8},
+		{name: "AllPublic/PublicRepositoriesOfUserIncludingCollaborative",
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Collaborate: true, AllPublic: true},
+			count: 12},
+		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborative",
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
+			count: 16},
+		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborativeByName",
+			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
+			count: 10},
+		{name: "AllPublic/PublicRepositoriesOfOrganization",
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, AllPublic: true},
+			count: 12},
 	}
 
 	for _, testCase := range testCases {
@@ -126,7 +144,7 @@ func TestSearchRepositoryByName(t *testing.T) {
 				}
 
 				// FIXME: Can't check, need to fix current behaviour (see previous FIXME comments in test cases)
-				/*if testCase.opts.OwnerID > 0 && !testCase.opts.Collaborate {
+				/*if testCase.opts.OwnerID > 0 && !testCase.opts.Collaborate && !AllPublic {
 					assert.Equal(t, testCase.opts.OwnerID, repo.Owner.ID)
 				}*/
 

--- a/routers/admin/repos.go
+++ b/routers/admin/repos.go
@@ -24,7 +24,6 @@ func Repos(ctx *context.Context) {
 	ctx.Data["PageIsAdminRepositories"] = true
 
 	routers.RenderRepoSearch(ctx, &routers.RepoSearchOptions{
-		Ranger:   models.Repositories,
 		Private:  true,
 		PageSize: setting.UI.Admin.RepoPagingNum,
 		TplName:  tplRepos,

--- a/routers/home.go
+++ b/routers/home.go
@@ -60,7 +60,6 @@ func Swagger(ctx *context.Context) {
 
 // RepoSearchOptions when calling search repositories
 type RepoSearchOptions struct {
-	Searcher *models.User
 	Private  bool
 	PageSize int
 	TplName  base.TplName


### PR DESCRIPTION
Remove useless functions/code. Fixes multiple bugs and remove duplicated code, like:

- Corrects ordering of repositories on admin page
- Corrects results when searching (explore page) - now you can get 2 different results when searching with/without keyword because two different functions are used and implementation is not same for both. But results with non empty keyword should always contains subset of full search (empty keyword) results.
- `models.Repositories()` ignores privacy settings in search but uses it for `count` (even it's always true as it is used only in 1 place with fixed privacy settings). This function can be replaced by `models.SearchRepositoryByName()` as it does exactly same thing.
- `models.GetRecentUpdatedRepositories()` doesn't make sense, as it is used only if query parameter `q` is empty and can return results with different ordering (not "recent updated"). `models.SearchRepositoryByName()` should do same thing.

Bonus: less code to maintain, less space for bugs :)

Extracted from #2371 and further improved.