### PR TITLE
Replace deprecated Id method with ID

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -76,7 +76,7 @@ func TestRenameRepoAction(t *testing.T) {
 	assert.NoError(t, RenameRepoAction(user, oldRepoName, repo))
 	AssertExistsAndLoadBean(t, actionBean)
 
-	_, err := x.Id(repo.ID).Cols("name", "lower_name").Update(repo)
+	_, err := x.ID(repo.ID).Cols("name", "lower_name").Update(repo)
 	assert.NoError(t, err)
 	CheckConsistencyFor(t, &Action{})
 }
@@ -337,7 +337,7 @@ func TestTransferRepoAction(t *testing.T) {
 	assert.NoError(t, TransferRepoAction(user2, user2, repo))
 	AssertExistsAndLoadBean(t, actionBean)
 
-	_, err := x.Id(repo.ID).Cols("owner_id").Update(repo)
+	_, err := x.ID(repo.ID).Cols("owner_id").Update(repo)
 	assert.NoError(t, err)
 	CheckConsistencyFor(t, &Action{})
 }

--- a/models/admin.go
+++ b/models/admin.go
@@ -93,7 +93,7 @@ func Notices(page, pageSize int) ([]*Notice, error) {
 
 // DeleteNotice deletes a system notice by given ID.
 func DeleteNotice(id int64) error {
-	_, err := x.Id(id).Delete(new(Notice))
+	_, err := x.ID(id).Delete(new(Notice))
 	return err
 }
 

--- a/models/branches.go
+++ b/models/branches.go
@@ -142,7 +142,7 @@ func UpdateProtectBranch(repo *Repository, protectBranch *ProtectedBranch, white
 		return nil
 	}
 
-	if _, err = x.Id(protectBranch.ID).AllCols().Update(protectBranch); err != nil {
+	if _, err = x.ID(protectBranch.ID).AllCols().Update(protectBranch); err != nil {
 		return fmt.Errorf("Update: %v", err)
 	}
 

--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -73,7 +73,7 @@ func ListGPGKeys(uid int64) ([]*GPGKey, error) {
 // GetGPGKeyByID returns public key by given ID.
 func GetGPGKeyByID(keyID int64) (*GPGKey, error) {
 	key := new(GPGKey)
-	has, err := x.Id(keyID).Get(key)
+	has, err := x.ID(keyID).Get(key)
 	if err != nil {
 		return nil, err
 	} else if !has {

--- a/models/issue.go
+++ b/models/issue.go
@@ -570,7 +570,7 @@ func (issue *Issue) ReadBy(userID int64) error {
 }
 
 func updateIssueCols(e Engine, issue *Issue, cols ...string) error {
-	if _, err := e.Id(issue.ID).Cols(cols...).Update(issue); err != nil {
+	if _, err := e.ID(issue.ID).Cols(cols...).Update(issue); err != nil {
 		return err
 	}
 	UpdateIssueIndexer(issue.ID)
@@ -911,7 +911,7 @@ func newIssue(e *xorm.Session, doer *User, opts NewIssueOptions) (err error) {
 
 		for i := 0; i < len(attachments); i++ {
 			attachments[i].IssueID = opts.Issue.ID
-			if _, err = e.Id(attachments[i].ID).Update(attachments[i]); err != nil {
+			if _, err = e.ID(attachments[i].ID).Update(attachments[i]); err != nil {
 				return fmt.Errorf("update attachment [id: %d]: %v", attachments[i].ID, err)
 			}
 		}
@@ -1008,7 +1008,7 @@ func GetIssueByIndex(repoID, index int64) (*Issue, error) {
 
 func getIssueByID(e Engine, id int64) (*Issue, error) {
 	issue := new(Issue)
-	has, err := e.Id(id).Get(issue)
+	has, err := e.ID(id).Get(issue)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -1435,7 +1435,7 @@ func GetRepoIssueStats(repoID, uid int64, filterMode int, isPull bool) (numOpen 
 }
 
 func updateIssue(e Engine, issue *Issue) error {
-	_, err := e.Id(issue.ID).AllCols().Update(issue)
+	_, err := e.ID(issue.ID).AllCols().Update(issue)
 	if err != nil {
 		return err
 	}

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -356,7 +356,7 @@ func createComment(e *xorm.Session, opts *CreateCommentOptions) (_ *Comment, err
 			attachments[i].IssueID = opts.Issue.ID
 			attachments[i].CommentID = comment.ID
 			// No assign value could be 0, so ignore AllCols().
-			if _, err = e.Id(attachments[i].ID).Update(attachments[i]); err != nil {
+			if _, err = e.ID(attachments[i].ID).Update(attachments[i]); err != nil {
 				return nil, fmt.Errorf("update attachment [%d]: %v", attachments[i].ID, err)
 			}
 		}
@@ -569,7 +569,7 @@ func CreateRefComment(doer *User, repo *Repository, issue *Issue, content, commi
 // GetCommentByID returns the comment by given ID.
 func GetCommentByID(id int64) (*Comment, error) {
 	c := new(Comment)
-	has, err := x.Id(id).Get(c)
+	has, err := x.ID(id).Get(c)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -647,7 +647,7 @@ func GetCommentsByRepoIDSince(repoID, since int64) ([]*Comment, error) {
 
 // UpdateComment updates information of comment.
 func UpdateComment(c *Comment) error {
-	if _, err := x.Id(c.ID).AllCols().Update(c); err != nil {
+	if _, err := x.ID(c.ID).AllCols().Update(c); err != nil {
 		return err
 	} else if c.Type == CommentTypeComment {
 		UpdateIssueIndexer(c.IssueID)

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -222,7 +222,7 @@ func GetLabelsByIssueID(issueID int64) ([]*Label, error) {
 }
 
 func updateLabel(e Engine, l *Label) error {
-	_, err := e.Id(l.ID).AllCols().Update(l)
+	_, err := e.ID(l.ID).AllCols().Update(l)
 	return err
 }
 
@@ -247,7 +247,7 @@ func DeleteLabel(repoID, labelID int64) error {
 		return err
 	}
 
-	if _, err = sess.Id(labelID).Delete(new(Label)); err != nil {
+	if _, err = sess.ID(labelID).Delete(new(Label)); err != nil {
 		return err
 	} else if _, err = sess.
 		Where("label_id = ?", labelID).

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -165,7 +165,7 @@ func GetMilestones(repoID int64, page int, isClosed bool, sortType string) ([]*M
 }
 
 func updateMilestone(e Engine, m *Milestone) error {
-	_, err := e.Id(m.ID).AllCols().Update(m)
+	_, err := e.ID(m.ID).AllCols().Update(m)
 	return err
 }
 
@@ -221,7 +221,7 @@ func ChangeMilestoneStatus(m *Milestone, isClosed bool) (err error) {
 
 	repo.NumMilestones = int(countRepoMilestones(sess, repo.ID))
 	repo.NumClosedMilestones = int(countRepoClosedMilestones(sess, repo.ID))
-	if _, err = sess.Id(repo.ID).Cols("num_milestones, num_closed_milestones").Update(repo); err != nil {
+	if _, err = sess.ID(repo.ID).Cols("num_milestones, num_closed_milestones").Update(repo); err != nil {
 		return err
 	}
 	return sess.Commit()
@@ -329,13 +329,13 @@ func DeleteMilestoneByRepoID(repoID, id int64) error {
 		return err
 	}
 
-	if _, err = sess.Id(m.ID).Delete(new(Milestone)); err != nil {
+	if _, err = sess.ID(m.ID).Delete(new(Milestone)); err != nil {
 		return err
 	}
 
 	repo.NumMilestones = int(countRepoMilestones(sess, repo.ID))
 	repo.NumClosedMilestones = int(countRepoClosedMilestones(sess, repo.ID))
-	if _, err = sess.Id(repo.ID).Cols("num_milestones, num_closed_milestones").Update(repo); err != nil {
+	if _, err = sess.ID(repo.ID).Cols("num_milestones, num_closed_milestones").Update(repo); err != nil {
 		return err
 	}
 

--- a/models/issue_user.go
+++ b/models/issue_user.go
@@ -101,7 +101,7 @@ func UpdateIssueUsersByMentions(e Engine, issueID int64, uids []int64) error {
 
 		iu.IsMentioned = true
 		if has {
-			_, err = e.Id(iu.ID).Cols("is_mentioned").Update(iu)
+			_, err = e.ID(iu.ID).Cols("is_mentioned").Update(iu)
 		} else {
 			_, err = e.Insert(iu)
 		}

--- a/models/issue_watch.go
+++ b/models/issue_watch.go
@@ -62,7 +62,7 @@ func CreateOrUpdateIssueWatch(userID, issueID int64, isWatching bool) error {
 	} else {
 		iw.IsWatching = isWatching
 
-		if _, err := x.Id(iw.ID).Cols("is_watching", "updated_unix").Update(iw); err != nil {
+		if _, err := x.ID(iw.ID).Cols("is_watching", "updated_unix").Update(iw); err != nil {
 			return err
 		}
 	}

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -308,7 +308,7 @@ func LoginSources() ([]*LoginSource, error) {
 // GetLoginSourceByID returns login source by given ID.
 func GetLoginSourceByID(id int64) (*LoginSource, error) {
 	source := new(LoginSource)
-	has, err := x.Id(id).Get(source)
+	has, err := x.ID(id).Get(source)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -328,7 +328,7 @@ func UpdateSource(source *LoginSource) error {
 		}
 	}
 
-	_, err := x.Id(source.ID).AllCols().Update(source)
+	_, err := x.ID(source.ID).AllCols().Update(source)
 	if err == nil && source.IsOAuth2() && source.IsActived {
 		oAuth2Config := source.OAuth2()
 		err = oauth2.RegisterProvider(source.Name, oAuth2Config.Provider, oAuth2Config.ClientID, oAuth2Config.ClientSecret, oAuth2Config.OpenIDConnectAutoDiscoveryURL, oAuth2Config.CustomURLMapping)
@@ -336,7 +336,7 @@ func UpdateSource(source *LoginSource) error {
 
 		if err != nil {
 			// restore original values since we cannot update the provider it self
-			x.Id(source.ID).AllCols().Update(originalLoginSource)
+			x.ID(source.ID).AllCols().Update(originalLoginSource)
 		}
 	}
 	return err
@@ -362,7 +362,7 @@ func DeleteSource(source *LoginSource) error {
 		oauth2.RemoveProvider(source.Name)
 	}
 
-	_, err = x.Id(source.ID).Delete(new(LoginSource))
+	_, err = x.ID(source.ID).Delete(new(LoginSource))
 	return err
 }
 
@@ -647,7 +647,7 @@ func UserSignIn(username, password string) (*User, error) {
 
 		default:
 			var source LoginSource
-			hasSource, err := x.Id(user.LoginSource).Get(&source)
+			hasSource, err := x.ID(user.LoginSource).Get(&source)
 			if err != nil {
 				return nil, err
 			} else if !hasSource {

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -173,7 +173,7 @@ Please try to upgrade to a lower version (>= v0.6.0) first, then upgrade to curr
 	if int(v-minDBVersion) > len(migrations) {
 		// User downgraded Gitea.
 		currentVersion.Version = int64(len(migrations) + minDBVersion)
-		_, err = x.Id(1).Update(currentVersion)
+		_, err = x.ID(1).Update(currentVersion)
 		return err
 	}
 	for i, m := range migrations[v-minDBVersion:] {
@@ -182,7 +182,7 @@ Please try to upgrade to a lower version (>= v0.6.0) first, then upgrade to curr
 			return fmt.Errorf("do migrate: %v", err)
 		}
 		currentVersion.Version = v + int64(i) + 1
-		if _, err = x.Id(1).Update(currentVersion); err != nil {
+		if _, err = x.ID(1).Update(currentVersion); err != nil {
 			return err
 		}
 	}

--- a/models/migrations/v28.go
+++ b/models/migrations/v28.go
@@ -67,7 +67,7 @@ func addRepoSize(x *xorm.Engine) (err error) {
 			}
 
 			repo.Size = countObject.Size + countObject.SizePack
-			if _, err = x.Id(repo.ID).Cols("size").Update(repo); err != nil {
+			if _, err = x.ID(repo.ID).Cols("size").Update(repo); err != nil {
 				return fmt.Errorf("update size: %v", err)
 			}
 		}

--- a/models/migrations/v38.go
+++ b/models/migrations/v38.go
@@ -33,7 +33,7 @@ func removeCommitsUnitType(x *xorm.Engine) (err error) {
 				}
 			}
 			team.UnitTypes = ut
-			if _, err := x.Id(team.ID).Cols("unit_types").Update(team); err != nil {
+			if _, err := x.ID(team.ID).Cols("unit_types").Update(team); err != nil {
 				return err
 			}
 		}

--- a/models/migrations/v39.go
+++ b/models/migrations/v39.go
@@ -56,7 +56,7 @@ func addTimetracking(x *xorm.Engine) error {
 			changes = true
 		}
 		if changes {
-			if _, err := x.Id(unit.ID).Cols("config").Update(unit); err != nil {
+			if _, err := x.ID(unit.ID).Cols("config").Update(unit); err != nil {
 				return err
 			}
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -37,7 +37,7 @@ type Engine interface {
 	Exec(string, ...interface{}) (sql.Result, error)
 	Find(interface{}, ...interface{}) error
 	Get(interface{}) (bool, error)
-	Id(interface{}) *xorm.Session
+	ID(interface{}) *xorm.Session
 	In(string, ...interface{}) *xorm.Session
 	Incr(column string, arg ...interface{}) *xorm.Session
 	Insert(...interface{}) (int64, error)

--- a/models/notification.go
+++ b/models/notification.go
@@ -195,7 +195,7 @@ func updateIssueNotification(e Engine, userID, issueID, updatedByID int64) error
 	notification.Status = NotificationStatusUnread
 	notification.UpdatedBy = updatedByID
 
-	_, err = e.Id(notification.ID).Update(notification)
+	_, err = e.ID(notification.ID).Update(notification)
 	return err
 }
 
@@ -274,7 +274,7 @@ func setNotificationStatusReadIfUnread(e Engine, userID, issueID int64) error {
 
 	notification.Status = NotificationStatusRead
 
-	_, err = e.Id(notification.ID).Update(notification)
+	_, err = e.ID(notification.ID).Update(notification)
 	return err
 }
 
@@ -291,7 +291,7 @@ func SetNotificationStatus(notificationID int64, user *User, status Notification
 
 	notification.Status = status
 
-	_, err = x.Id(notificationID).Update(notification)
+	_, err = x.ID(notificationID).Update(notification)
 	return err
 }
 

--- a/models/org.go
+++ b/models/org.go
@@ -259,7 +259,7 @@ func deleteOrg(e *xorm.Session, u *User) error {
 		return fmt.Errorf("deleteBeans: %v", err)
 	}
 
-	if _, err = e.Id(u.ID).Delete(new(User)); err != nil {
+	if _, err = e.ID(u.ID).Delete(new(User)); err != nil {
 		return fmt.Errorf("Delete: %v", err)
 	}
 
@@ -412,7 +412,7 @@ func ChangeOrgUserStatus(orgID, uid int64, public bool) error {
 	}
 
 	ou.IsPublic = public
-	_, err = x.Id(ou.ID).Cols("is_public").Update(ou)
+	_, err = x.ID(ou.ID).Cols("is_public").Update(ou)
 	return err
 }
 
@@ -480,7 +480,7 @@ func RemoveOrgUser(orgID, userID int64) error {
 		return err
 	}
 
-	if _, err := sess.Id(ou.ID).Delete(ou); err != nil {
+	if _, err := sess.ID(ou.ID).Delete(ou); err != nil {
 		return err
 	} else if _, err = sess.Exec("UPDATE `user` SET num_members=num_members-1 WHERE id=?", orgID); err != nil {
 		return err

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -96,7 +96,7 @@ func (t *Team) addRepository(e Engine, repo *Repository) (err error) {
 	}
 
 	t.NumRepos++
-	if _, err = e.Id(t.ID).Cols("num_repos").Update(t); err != nil {
+	if _, err = e.ID(t.ID).Cols("num_repos").Update(t); err != nil {
 		return fmt.Errorf("update team: %v", err)
 	}
 
@@ -142,7 +142,7 @@ func (t *Team) removeRepository(e Engine, repo *Repository, recalculate bool) (e
 	}
 
 	t.NumRepos--
-	if _, err = e.Id(t.ID).Cols("num_repos").Update(t); err != nil {
+	if _, err = e.ID(t.ID).Cols("num_repos").Update(t); err != nil {
 		return err
 	}
 
@@ -231,7 +231,7 @@ func NewTeam(t *Team) (err error) {
 		return err
 	}
 
-	has, err := x.Id(t.OrgID).Get(new(User))
+	has, err := x.ID(t.OrgID).Get(new(User))
 	if err != nil {
 		return err
 	} else if !has {
@@ -289,7 +289,7 @@ func GetTeam(orgID int64, name string) (*Team, error) {
 
 func getTeamByID(e Engine, teamID int64) (*Team, error) {
 	t := new(Team)
-	has, err := e.Id(teamID).Get(t)
+	has, err := e.ID(teamID).Get(t)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -331,7 +331,7 @@ func UpdateTeam(t *Team, authChanged bool) (err error) {
 		return ErrTeamAlreadyExist{t.OrgID, t.LowerName}
 	}
 
-	if _, err = sess.Id(t.ID).AllCols().Update(t); err != nil {
+	if _, err = sess.ID(t.ID).AllCols().Update(t); err != nil {
 		return fmt.Errorf("update: %v", err)
 	}
 
@@ -387,7 +387,7 @@ func DeleteTeam(t *Team) error {
 	}
 
 	// Delete team.
-	if _, err := sess.Id(t.ID).Delete(new(Team)); err != nil {
+	if _, err := sess.ID(t.ID).Delete(new(Team)); err != nil {
 		return err
 	}
 	// Update organization number of teams.
@@ -498,7 +498,7 @@ func AddTeamMember(team *Team, userID int64) error {
 		TeamID: team.ID,
 	}); err != nil {
 		return err
-	} else if _, err := sess.Id(team.ID).Update(team); err != nil {
+	} else if _, err := sess.ID(team.ID).Update(team); err != nil {
 		return err
 	}
 
@@ -521,7 +521,7 @@ func AddTeamMember(team *Team, userID int64) error {
 	if team.IsOwnerTeam() {
 		ou.IsOwner = true
 	}
-	if _, err := sess.Id(ou.ID).Cols("num_teams, is_owner").Update(ou); err != nil {
+	if _, err := sess.ID(ou.ID).Cols("num_teams, is_owner").Update(ou); err != nil {
 		return err
 	}
 
@@ -551,7 +551,7 @@ func removeTeamMember(e Engine, team *Team, userID int64) error {
 	}); err != nil {
 		return err
 	} else if _, err = e.
-		Id(team.ID).
+		ID(team.ID).
 		Cols("num_members").
 		Update(team); err != nil {
 		return err
@@ -578,7 +578,7 @@ func removeTeamMember(e Engine, team *Team, userID int64) error {
 		ou.IsOwner = false
 	}
 	if _, err = e.
-		Id(ou.ID).
+		ID(ou.ID).
 		Cols("num_teams").
 		Update(ou); err != nil {
 		return err

--- a/models/pull.go
+++ b/models/pull.go
@@ -422,7 +422,7 @@ func (pr *PullRequest) setMerged() (err error) {
 	if err = pr.Issue.changeStatus(sess, pr.Merger, pr.Issue.Repo, true); err != nil {
 		return fmt.Errorf("Issue.changeStatus: %v", err)
 	}
-	if _, err = sess.Id(pr.ID).Cols("has_merged").Update(pr); err != nil {
+	if _, err = sess.ID(pr.ID).Cols("has_merged").Update(pr); err != nil {
 		return fmt.Errorf("update pull request: %v", err)
 	}
 
@@ -795,7 +795,7 @@ func GetPullRequestByIndex(repoID int64, index int64) (*PullRequest, error) {
 
 func getPullRequestByID(e Engine, id int64) (*PullRequest, error) {
 	pr := new(PullRequest)
-	has, err := e.Id(id).Get(pr)
+	has, err := e.ID(id).Get(pr)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -829,13 +829,13 @@ func GetPullRequestByIssueID(issueID int64) (*PullRequest, error) {
 
 // Update updates all fields of pull request.
 func (pr *PullRequest) Update() error {
-	_, err := x.Id(pr.ID).AllCols().Update(pr)
+	_, err := x.ID(pr.ID).AllCols().Update(pr)
 	return err
 }
 
 // UpdateCols updates specific fields of pull request.
 func (pr *PullRequest) UpdateCols(cols ...string) error {
-	_, err := x.Id(pr.ID).Cols(cols...).Update(pr)
+	_, err := x.ID(pr.ID).Cols(cols...).Update(pr)
 	return err
 }
 

--- a/models/release.go
+++ b/models/release.go
@@ -170,7 +170,7 @@ func addReleaseAttachments(releaseID int64, attachmentUUIDs []string) (err error
 	for i := range attachments {
 		attachments[i].ReleaseID = releaseID
 		// No assign value could be 0, so ignore AllCols().
-		if _, err = x.Id(attachments[i].ID).Update(attachments[i]); err != nil {
+		if _, err = x.ID(attachments[i].ID).Update(attachments[i]); err != nil {
 			return fmt.Errorf("update attachment [%d]: %v", attachments[i].ID, err)
 		}
 	}
@@ -220,7 +220,7 @@ func GetRelease(repoID int64, tagName string) (*Release, error) {
 func GetReleaseByID(id int64) (*Release, error) {
 	rel := new(Release)
 	has, err := x.
-		Id(id).
+		ID(id).
 		Get(rel)
 	if err != nil {
 		return nil, err
@@ -365,7 +365,7 @@ func UpdateRelease(gitRepo *git.Repository, rel *Release, attachmentUUIDs []stri
 	}
 	rel.LowerTagName = strings.ToLower(rel.TagName)
 
-	_, err = x.Id(rel.ID).AllCols().Update(rel)
+	_, err = x.ID(rel.ID).AllCols().Update(rel)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func DeleteReleaseByID(id int64, u *User, delTag bool) error {
 			return fmt.Errorf("git tag -d: %v - %s", err, stderr)
 		}
 
-		if _, err = x.Id(rel.ID).Delete(new(Release)); err != nil {
+		if _, err = x.ID(rel.ID).Delete(new(Release)); err != nil {
 			return fmt.Errorf("Delete: %v", err)
 		}
 	} else {
@@ -412,7 +412,7 @@ func DeleteReleaseByID(id int64, u *User, delTag bool) error {
 		rel.Title = ""
 		rel.Note = ""
 
-		if _, err = x.Id(rel.ID).AllCols().Update(rel); err != nil {
+		if _, err = x.ID(rel.ID).AllCols().Update(rel); err != nil {
 			return fmt.Errorf("Update: %v", err)
 		}
 	}

--- a/models/repo.go
+++ b/models/repo.go
@@ -620,7 +620,7 @@ func (repo *Repository) updateSize(e Engine) error {
 	}
 
 	repo.Size = repoInfoSize.Size + repoInfoSize.SizePack
-	_, err = e.Id(repo.ID).Cols("size").Update(repo)
+	_, err = e.ID(repo.ID).Cols("size").Update(repo)
 	return err
 }
 
@@ -1417,7 +1417,7 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) error 
 	repo.Owner = newOwner
 
 	// Update repository.
-	if _, err := sess.Id(repo.ID).Update(repo); err != nil {
+	if _, err := sess.ID(repo.ID).Update(repo); err != nil {
 		return fmt.Errorf("update owner: %v", err)
 	}
 
@@ -1449,7 +1449,7 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) error 
 			}
 
 			t.NumRepos--
-			if _, err := sess.Id(t.ID).Cols("num_repos").Update(t); err != nil {
+			if _, err := sess.ID(t.ID).Cols("num_repos").Update(t); err != nil {
 				return fmt.Errorf("decrease team repository count '%d': %v", t.ID, err)
 			}
 		}
@@ -1568,7 +1568,7 @@ func updateRepository(e Engine, repo *Repository, visibilityChanged bool) (err e
 		repo.Website = repo.Website[:255]
 	}
 
-	if _, err = e.Id(repo.ID).AllCols().Update(repo); err != nil {
+	if _, err = e.ID(repo.ID).AllCols().Update(repo); err != nil {
 		return fmt.Errorf("update: %v", err)
 	}
 
@@ -1687,7 +1687,7 @@ func DeleteRepository(doer *User, uid, repoID int64) error {
 		return ErrRepoNotExist{repoID, uid, ""}
 	}
 
-	if cnt, err := sess.Id(repoID).Delete(&Repository{}); err != nil {
+	if cnt, err := sess.ID(repoID).Delete(&Repository{}); err != nil {
 		return err
 	} else if cnt != 1 {
 		return ErrRepoNotExist{repoID, uid, ""}
@@ -1868,7 +1868,7 @@ func GetRepositoryByName(ownerID int64, name string) (*Repository, error) {
 
 func getRepositoryByID(e Engine, id int64) (*Repository, error) {
 	repo := new(Repository)
-	has, err := e.Id(id).Get(repo)
+	has, err := e.ID(id).Get(repo)
 	if err != nil {
 		return nil, err
 	} else if !has {

--- a/models/repo_mirror.go
+++ b/models/repo_mirror.go
@@ -199,7 +199,7 @@ func GetMirrorByRepoID(repoID int64) (*Mirror, error) {
 }
 
 func updateMirror(e Engine, m *Mirror) error {
-	_, err := e.Id(m.ID).AllCols().Update(m)
+	_, err := e.ID(m.ID).AllCols().Update(m)
 	return err
 }
 

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -722,7 +722,7 @@ func AddDeployKey(repoID int64, name, content string) (*DeployKey, error) {
 // GetDeployKeyByID returns deploy key by given ID.
 func GetDeployKeyByID(id int64) (*DeployKey, error) {
 	key := new(DeployKey)
-	has, err := x.Id(id).Get(key)
+	has, err := x.ID(id).Get(key)
 	if err != nil {
 		return nil, err
 	} else if !has {
@@ -748,7 +748,7 @@ func GetDeployKeyByRepo(keyID, repoID int64) (*DeployKey, error) {
 
 // UpdateDeployKey updates deploy key information.
 func UpdateDeployKey(key *DeployKey) error {
-	_, err := x.Id(key.ID).AllCols().Update(key)
+	_, err := x.ID(key.ID).AllCols().Update(key)
 	return err
 }
 
@@ -782,7 +782,7 @@ func DeleteDeployKey(doer *User, id int64) error {
 		return err
 	}
 
-	if _, err = sess.Id(key.ID).Delete(new(DeployKey)); err != nil {
+	if _, err = sess.ID(key.ID).Delete(new(DeployKey)); err != nil {
 		return fmt.Errorf("delete deploy key [%d]: %v", key.ID, err)
 	}
 

--- a/models/token.go
+++ b/models/token.go
@@ -68,13 +68,13 @@ func ListAccessTokens(uid int64) ([]*AccessToken, error) {
 
 // UpdateAccessToken updates information of access token.
 func UpdateAccessToken(t *AccessToken) error {
-	_, err := x.Id(t.ID).AllCols().Update(t)
+	_, err := x.ID(t.ID).AllCols().Update(t)
 	return err
 }
 
 // DeleteAccessTokenByID deletes access token by given ID.
 func DeleteAccessTokenByID(id, userID int64) error {
-	cnt, err := x.Id(id).Delete(&AccessToken{
+	cnt, err := x.ID(id).Delete(&AccessToken{
 		UID: userID,
 	})
 	if err != nil {

--- a/models/twofactor.go
+++ b/models/twofactor.go
@@ -95,7 +95,7 @@ func NewTwoFactor(t *TwoFactor) error {
 
 // UpdateTwoFactor updates a two-factor authentication token.
 func UpdateTwoFactor(t *TwoFactor) error {
-	_, err := x.Id(t.ID).AllCols().Update(t)
+	_, err := x.ID(t.ID).AllCols().Update(t)
 	return err
 }
 
@@ -114,7 +114,7 @@ func GetTwoFactorByUID(uid int64) (*TwoFactor, error) {
 
 // DeleteTwoFactorByID deletes two-factor authentication token by given ID.
 func DeleteTwoFactorByID(id, userID int64) error {
-	cnt, err := x.Id(id).Delete(&TwoFactor{
+	cnt, err := x.ID(id).Delete(&TwoFactor{
 		UID: userID,
 	})
 	if err != nil {

--- a/models/update.go
+++ b/models/update.go
@@ -90,14 +90,14 @@ func pushUpdateDeleteTag(repo *Repository, gitRepo *git.Repository, tagName stri
 		return fmt.Errorf("GetRelease: %v", err)
 	}
 	if rel.IsTag {
-		if _, err = x.Id(rel.ID).Delete(new(Release)); err != nil {
+		if _, err = x.ID(rel.ID).Delete(new(Release)); err != nil {
 			return fmt.Errorf("Delete: %v", err)
 		}
 	} else {
 		rel.IsDraft = true
 		rel.NumCommits = 0
 		rel.Sha1 = ""
-		if _, err = x.Id(rel.ID).AllCols().Update(rel); err != nil {
+		if _, err = x.ID(rel.ID).AllCols().Update(rel); err != nil {
 			return fmt.Errorf("Update: %v", err)
 		}
 	}
@@ -161,7 +161,7 @@ func pushUpdateAddTag(repo *Repository, gitRepo *git.Repository, tagName string)
 		if rel.IsTag && author != nil {
 			rel.PublisherID = author.ID
 		}
-		if _, err = x.Id(rel.ID).AllCols().Update(rel); err != nil {
+		if _, err = x.ID(rel.ID).AllCols().Update(rel); err != nil {
 			return fmt.Errorf("Update: %v", err)
 		}
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -302,7 +302,7 @@ func (u *User) generateRandomAvatar(e Engine) error {
 	}
 	defer fw.Close()
 
-	if _, err := e.Id(u.ID).Cols("avatar").Update(u); err != nil {
+	if _, err := e.ID(u.ID).Cols("avatar").Update(u); err != nil {
 		return err
 	}
 
@@ -459,7 +459,7 @@ func (u *User) DeleteAvatar() error {
 
 	u.UseCustomAvatar = false
 	u.Avatar = ""
-	if _, err := x.Id(u.ID).Cols("avatar, use_custom_avatar").Update(u); err != nil {
+	if _, err := x.ID(u.ID).Cols("avatar, use_custom_avatar").Update(u); err != nil {
 		return fmt.Errorf("UpdateUser: %v", err)
 	}
 	return nil
@@ -862,7 +862,7 @@ func updateUser(e Engine, u *User) error {
 	u.Website = base.TruncateString(u.Website, 255)
 	u.Description = base.TruncateString(u.Description, 255)
 
-	_, err := e.Id(u.ID).AllCols().Update(u)
+	_, err := e.ID(u.ID).AllCols().Update(u)
 	return err
 }
 
@@ -893,7 +893,7 @@ func updateUserCols(e Engine, u *User, cols ...string) error {
 	u.Website = base.TruncateString(u.Website, 255)
 	u.Description = base.TruncateString(u.Description, 255)
 
-	_, err := e.Id(u.ID).Cols(cols...).Update(u)
+	_, err := e.ID(u.ID).Cols(cols...).Update(u)
 	return err
 }
 
@@ -1019,7 +1019,7 @@ func deleteUser(e *xorm.Session, u *User) error {
 	}
 	// ***** END: ExternalLoginUser *****
 
-	if _, err = e.Id(u.ID).Delete(new(User)); err != nil {
+	if _, err = e.ID(u.ID).Delete(new(User)); err != nil {
 		return fmt.Errorf("Delete: %v", err)
 	}
 
@@ -1112,7 +1112,7 @@ func GetUserByKeyID(keyID int64) (*User, error) {
 
 func getUserByID(e Engine, id int64) (*User, error) {
 	u := new(User)
-	has, err := e.Id(id).Get(u)
+	has, err := e.ID(id).Get(u)
 	if err != nil {
 		return nil, err
 	} else if !has {

--- a/models/user_mail.go
+++ b/models/user_mail.go
@@ -153,7 +153,7 @@ func DeleteEmailAddress(email *EmailAddress) (err error) {
 		UID: email.UID,
 	}
 	if email.ID > 0 {
-		deleted, err = x.Id(email.ID).Delete(&address)
+		deleted, err = x.ID(email.ID).Delete(&address)
 	} else {
 		deleted, err = x.
 			Where("email=?", email.Email).
@@ -222,7 +222,7 @@ func MakeEmailPrimary(email *EmailAddress) error {
 	}
 
 	user.Email = email.Email
-	if _, err = sess.Id(user.ID).Cols("email").Update(user); err != nil {
+	if _, err = sess.ID(user.ID).Cols("email").Update(user); err != nil {
 		return err
 	}
 

--- a/models/user_openid.go
+++ b/models/user_openid.go
@@ -76,7 +76,7 @@ func DeleteUserOpenID(openid *UserOpenID) (err error) {
 		UID: openid.UID,
 	}
 	if openid.ID > 0 {
-		deleted, err = x.Id(openid.ID).Delete(&address)
+		deleted, err = x.ID(openid.ID).Delete(&address)
 	} else {
 		deleted, err = x.
 			Where("openid=?", openid.URI).

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -270,7 +270,7 @@ func GetWebhooksByOrgID(orgID int64) (ws []*Webhook, err error) {
 
 // UpdateWebhook updates information of webhook.
 func UpdateWebhook(w *Webhook) error {
-	_, err := x.Id(w.ID).AllCols().Update(w)
+	_, err := x.ID(w.ID).AllCols().Update(w)
 	return err
 }
 
@@ -477,7 +477,7 @@ func createHookTask(e Engine, t *HookTask) error {
 
 // UpdateHookTask updates information of hook task.
 func UpdateHookTask(t *HookTask) error {
-	_, err := x.Id(t.ID).AllCols().Update(t)
+	_, err := x.ID(t.ID).AllCols().Update(t)
 	return err
 }
 


### PR DESCRIPTION
Replace deprecated xorm method `.Id(..)` with `.ID(..)`. See https://godoc.org/github.com/go-xorm/xorm#Engine.Id, https://godoc.org/github.com/go-xorm/xorm#Session.Id
