### PR TITLE
Refactor duplicated code in repo handlers

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -174,13 +174,54 @@ func RedirectToRepo(ctx *Context, redirectRepoID int64) {
 	ctx.Redirect(redirectPath)
 }
 
-// RepoIDAssignment returns an macaron handler which assigns the repo to the context.
+func repoAssignment(ctx *Context, repo *models.Repository) {
+	// Admin has super access.
+	if ctx.IsSigned && ctx.User.IsAdmin {
+		ctx.Repo.AccessMode = models.AccessModeOwner
+	} else {
+		var userID int64
+		if ctx.User != nil {
+			userID = ctx.User.ID
+		}
+		mode, err := models.AccessLevel(userID, repo)
+		if err != nil {
+			ctx.Handle(500, "AccessLevel", err)
+			return
+		}
+		ctx.Repo.AccessMode = mode
+	}
+
+	// Check access.
+	if ctx.Repo.AccessMode == models.AccessModeNone {
+		if ctx.Query("go-get") == "1" {
+			EarlyResponseForGoGetMeta(ctx)
+			return
+		}
+		ctx.Error(404, "no access right")
+		return
+	}
+	ctx.Data["HasAccess"] = true
+
+	if repo.IsMirror {
+		var err error
+		ctx.Repo.Mirror, err = models.GetMirrorByRepoID(repo.ID)
+		if err != nil {
+			ctx.Handle(500, "GetMirror", err)
+			return
+		}
+		ctx.Data["MirrorEnablePrune"] = ctx.Repo.Mirror.EnablePrune
+		ctx.Data["MirrorInterval"] = ctx.Repo.Mirror.Interval
+		ctx.Data["Mirror"] = ctx.Repo.Mirror
+	}
+
+	ctx.Repo.Repository = repo
+	ctx.Data["RepoName"] = ctx.Repo.Repository.Name
+	ctx.Data["IsBareRepo"] = ctx.Repo.Repository.IsBare
+}
+
+// RepoIDAssignment returns a macaron handler which assigns the repo to the context.
 func RepoIDAssignment() macaron.Handler {
 	return func(ctx *Context) {
-		var (
-			err error
-		)
-
 		repoID := ctx.ParamsInt64(":repoid")
 
 		// Get repository.
@@ -198,48 +239,7 @@ func RepoIDAssignment() macaron.Handler {
 			ctx.Handle(500, "GetOwner", err)
 			return
 		}
-
-		// Admin has super access.
-		if ctx.IsSigned && ctx.User.IsAdmin {
-			ctx.Repo.AccessMode = models.AccessModeOwner
-		} else {
-			var userID int64
-			if ctx.User != nil {
-				userID = ctx.User.ID
-			}
-			mode, err := models.AccessLevel(userID, repo)
-			if err != nil {
-				ctx.Handle(500, "AccessLevel", err)
-				return
-			}
-			ctx.Repo.AccessMode = mode
-		}
-
-		// Check access.
-		if ctx.Repo.AccessMode == models.AccessModeNone {
-			if ctx.Query("go-get") == "1" {
-				EarlyResponseForGoGetMeta(ctx)
-				return
-			}
-			ctx.Handle(404, "no access right", err)
-			return
-		}
-		ctx.Data["HasAccess"] = true
-
-		if repo.IsMirror {
-			ctx.Repo.Mirror, err = models.GetMirrorByRepoID(repo.ID)
-			if err != nil {
-				ctx.Handle(500, "GetMirror", err)
-				return
-			}
-			ctx.Data["MirrorEnablePrune"] = ctx.Repo.Mirror.EnablePrune
-			ctx.Data["MirrorInterval"] = ctx.Repo.Mirror.Interval
-			ctx.Data["Mirror"] = ctx.Repo.Mirror
-		}
-
-		ctx.Repo.Repository = repo
-		ctx.Data["RepoName"] = ctx.Repo.Repository.Name
-		ctx.Data["IsBareRepo"] = ctx.Repo.Repository.IsBare
+		repoAssignment(ctx, repo)
 	}
 }
 
@@ -298,47 +298,10 @@ func RepoAssignment() macaron.Handler {
 		}
 		repo.Owner = owner
 
-		// Admin has super access.
-		if ctx.IsSigned && ctx.User.IsAdmin {
-			ctx.Repo.AccessMode = models.AccessModeOwner
-		} else {
-			var userID int64
-			if ctx.User != nil {
-				userID = ctx.User.ID
-			}
-			mode, err := models.AccessLevel(userID, repo)
-			if err != nil {
-				ctx.Handle(500, "AccessLevel", err)
-				return
-			}
-			ctx.Repo.AccessMode = mode
-		}
-
-		// Check access.
-		if ctx.Repo.AccessMode == models.AccessModeNone {
-			if ctx.Query("go-get") == "1" {
-				EarlyResponseForGoGetMeta(ctx)
-				return
-			}
-			ctx.Handle(404, "no access right", err)
+		repoAssignment(ctx, repo)
+		if ctx.Written() {
 			return
 		}
-		ctx.Data["HasAccess"] = true
-
-		if repo.IsMirror {
-			ctx.Repo.Mirror, err = models.GetMirrorByRepoID(repo.ID)
-			if err != nil {
-				ctx.Handle(500, "GetMirror", err)
-				return
-			}
-			ctx.Data["MirrorEnablePrune"] = ctx.Repo.Mirror.EnablePrune
-			ctx.Data["MirrorInterval"] = ctx.Repo.Mirror.Interval
-			ctx.Data["Mirror"] = ctx.Repo.Mirror
-		}
-
-		ctx.Repo.Repository = repo
-		ctx.Data["RepoName"] = ctx.Repo.Repository.Name
-		ctx.Data["IsBareRepo"] = ctx.Repo.Repository.IsBare
 
 		gitRepo, err := git.OpenRepository(models.RepoPath(userName, repoName))
 		if err != nil {

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -197,7 +197,7 @@ func repoAssignment(ctx *Context, repo *models.Repository) {
 			EarlyResponseForGoGetMeta(ctx)
 			return
 		}
-		ctx.Error(404, "no access right")
+		ctx.Handle(404, "no access right", nil)
 		return
 	}
 	ctx.Data["HasAccess"] = true


### PR DESCRIPTION
Move duplicated code in `RepoIDAssignment` and `RepoAssignment` handlers to a helper function. Also removed an unused var and fix a typo
