### PR TITLE
GPG key email verification no longer case sensitive (#2661)

### DIFF
--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -402,7 +402,7 @@ func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
 			//Pre-check (& optimization) that emails attached to key can be attached to the commiter email and can validate
 			canValidate := false
 			for _, e := range k.Emails {
-				if e.IsActivated && e.Email == c.Committer.Email {
+				if e.IsActivated && strings.ToLower(e.Email) == strings.ToLower(c.Committer.Email) {
 					canValidate = true
 					break
 				}

--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -401,8 +401,9 @@ func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
 		for _, k := range keys {
 			//Pre-check (& optimization) that emails attached to key can be attached to the commiter email and can validate
 			canValidate := false
+			lowerCommiterEmail := strings.ToLower(c.Committer.Email)
 			for _, e := range k.Emails {
-				if e.IsActivated && strings.ToLower(e.Email) == strings.ToLower(c.Committer.Email) {
+				if e.IsActivated && strings.ToLower(e.Email) == lowerCommiterEmail {
 					canValidate = true
 					break
 				}


### PR DESCRIPTION
surround every mail in https://github.com/go-gitea/gitea/blob/master/models/gpg_key.go#L405
with strings.ToLower(email) 

Fixes #2661