### PR TITLE
Allow custom SSH user in UI for built-in SSH server (#2617)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -114,7 +114,7 @@ DISABLE_SSH = false
 ; Whether use builtin SSH server or not.
 START_SSH_SERVER = false
 ; Username to use for builtin SSH server. If blank, then it is the value of RUN_USER.
-BUILTIN_SSH_USER =
+BUILTIN_SSH_SERVER_USER =
 ; Domain name to be exposed in clone URL
 SSH_DOMAIN = %(DOMAIN)s
 ; Network interface builtin SSH server listens on

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -113,6 +113,8 @@ LOCAL_ROOT_URL = %(PROTOCOL)s://%(HTTP_ADDR)s:%(HTTP_PORT)s/
 DISABLE_SSH = false
 ; Whether use builtin SSH server or not.
 START_SSH_SERVER = false
+; Username to use for builtin SSH server. If blank, then it is the value of RUN_USER.
+BUILTIN_SSH_USER =
 ; Domain name to be exposed in clone URL
 SSH_DOMAIN = %(DOMAIN)s
 ; Network interface builtin SSH server listens on

--- a/models/repo.go
+++ b/models/repo.go
@@ -806,14 +806,19 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 		repoName += ".wiki"
 	}
 
+	sshUser := setting.RunUser
+	if setting.SSH.StartBuiltinServer {
+		sshUser = setting.SSH.BuiltinServerUser
+	}
+
 	repo.Owner = repo.MustOwner()
 	cl := new(CloneLink)
 	if setting.SSH.Port != 22 {
-		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoName)
+		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", sshUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoName)
 	} else if setting.Repository.UseCompatSSHURI {
-		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", sshUser, setting.SSH.Domain, repo.Owner.Name, repoName)
 	} else {
-		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", sshUser, setting.SSH.Domain, repo.Owner.Name, repoName)
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
 	return cl

--- a/models/repo.go
+++ b/models/repo.go
@@ -808,7 +808,7 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 
 	sshUser := setting.RunUser
 	if setting.SSH.StartBuiltinServer {
-		sshUser = setting.SSH.BuiltinSSHServerUser
+		sshUser = setting.SSH.BuiltinServerUser
 	}
 
 	repo.Owner = repo.MustOwner()

--- a/models/repo.go
+++ b/models/repo.go
@@ -808,7 +808,7 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 
 	sshUser := setting.RunUser
 	if setting.SSH.StartBuiltinServer {
-		sshUser = setting.SSH.BuiltinServerUser
+		sshUser = setting.SSH.BuiltinSSHServerUser
 	}
 
 	repo.Owner = repo.MustOwner()

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -90,7 +90,7 @@ var (
 	SSH = struct {
 		Disabled             bool           `ini:"DISABLE_SSH"`
 		StartBuiltinServer   bool           `ini:"START_SSH_SERVER"`
-		BuiltinServerUser    string         `ini:"BUILTIN_SSH_USER"`
+		BuiltinSSHServerUser string         `ini:"BUILTIN_SSH_SERVER_USER"`
 		Domain               string         `ini:"SSH_DOMAIN"`
 		Port                 int            `ini:"SSH_PORT"`
 		ListenHost           string         `ini:"SSH_LISTEN_HOST"`
@@ -105,7 +105,6 @@ var (
 	}{
 		Disabled:           false,
 		StartBuiltinServer: false,
-		BuiltinServerUser:  "",
 		Domain:             "",
 		Port:               22,
 		KeygenPath:         "ssh-keygen",
@@ -722,7 +721,7 @@ func NewContext() {
 		SSH.StartBuiltinServer = false
 	}
 
-	SSH.BuiltinServerUser = sec.Key("BUILTIN_SSH_USER").MustString("")
+	SSH.BuiltinSSHServerUser = sec.Key("BUILTIN_SSH_USER").MustString("")
 
 	if !SSH.Disabled && !SSH.StartBuiltinServer {
 		if err := os.MkdirAll(SSH.RootPath, 0700); err != nil {
@@ -919,8 +918,8 @@ func NewContext() {
 		}
 	}
 
-	if SSH.BuiltinServerUser == "" {
-		SSH.BuiltinServerUser = RunUser
+	if SSH.BuiltinSSHServerUser == "" {
+		SSH.BuiltinSSHServerUser = RunUser
 	}
 
 	// Determine and create root git repository path.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -721,7 +721,7 @@ func NewContext() {
 	if SSH.Disabled {
 		SSH.StartBuiltinServer = false
 	}
-	
+
 	SSH.BuiltinServerUser = sec.Key("BUILTIN_SSH_USER").MustString("")
 
 	if !SSH.Disabled && !SSH.StartBuiltinServer {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -721,8 +721,6 @@ func NewContext() {
 		SSH.StartBuiltinServer = false
 	}
 
-	SSH.BuiltinSSHServerUser = sec.Key("BUILTIN_SSH_USER").MustString("")
-
 	if !SSH.Disabled && !SSH.StartBuiltinServer {
 		if err := os.MkdirAll(SSH.RootPath, 0700); err != nil {
 			log.Fatal(4, "Failed to create '%s': %v", SSH.RootPath, err)
@@ -918,9 +916,7 @@ func NewContext() {
 		}
 	}
 
-	if SSH.BuiltinSSHServerUser == "" {
-		SSH.BuiltinSSHServerUser = RunUser
-	}
+	SSH.BuiltinSSHServerUser = Cfg.Section("server").Key("BUILTIN_SSH_USER").MustString(RunUser)
 
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -90,7 +90,7 @@ var (
 	SSH = struct {
 		Disabled             bool           `ini:"DISABLE_SSH"`
 		StartBuiltinServer   bool           `ini:"START_SSH_SERVER"`
-		BuiltinSSHServerUser string         `ini:"BUILTIN_SSH_SERVER_USER"`
+		BuiltinServerUser    string         `ini:"BUILTIN_SSH_SERVER_USER"`
 		Domain               string         `ini:"SSH_DOMAIN"`
 		Port                 int            `ini:"SSH_PORT"`
 		ListenHost           string         `ini:"SSH_LISTEN_HOST"`
@@ -916,7 +916,7 @@ func NewContext() {
 		}
 	}
 
-	SSH.BuiltinSSHServerUser = Cfg.Section("server").Key("BUILTIN_SSH_USER").MustString(RunUser)
+	SSH.BuiltinServerUser = Cfg.Section("server").Key("BUILTIN_SSH_SERVER_USER").MustString(RunUser)
 
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -90,6 +90,7 @@ var (
 	SSH = struct {
 		Disabled             bool           `ini:"DISABLE_SSH"`
 		StartBuiltinServer   bool           `ini:"START_SSH_SERVER"`
+		BuiltinServerUser    string         `ini:"BUILTIN_SSH_USER"`
 		Domain               string         `ini:"SSH_DOMAIN"`
 		Port                 int            `ini:"SSH_PORT"`
 		ListenHost           string         `ini:"SSH_LISTEN_HOST"`
@@ -104,6 +105,7 @@ var (
 	}{
 		Disabled:           false,
 		StartBuiltinServer: false,
+		BuiltinServerUser:  "",
 		Domain:             "",
 		Port:               22,
 		KeygenPath:         "ssh-keygen",
@@ -914,6 +916,8 @@ func NewContext() {
 			log.Fatal(4, "Expect user '%s' but current user is: %s", RunUser, currentUser)
 		}
 	}
+
+	SSH.BuiltinServerUser = sec.Key("BUILTIN_SSH_USER").MustString(RunUser)
 
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -721,6 +721,8 @@ func NewContext() {
 	if SSH.Disabled {
 		SSH.StartBuiltinServer = false
 	}
+	
+	SSH.BuiltinServerUser = sec.Key("BUILTIN_SSH_USER").MustString("")
 
 	if !SSH.Disabled && !SSH.StartBuiltinServer {
 		if err := os.MkdirAll(SSH.RootPath, 0700); err != nil {
@@ -917,7 +919,9 @@ func NewContext() {
 		}
 	}
 
-	SSH.BuiltinServerUser = sec.Key("BUILTIN_SSH_USER").MustString(RunUser)
+	if SSH.BuiltinServerUser == "" {
+		SSH.BuiltinServerUser = RunUser
+	}
 
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")


### PR DESCRIPTION
This allows a custom username to be set for the built-in SSH server.

It adds the config option `BUILTIN_SSH_USER` in the `[server]` section. If this option is missing or empty, it defaults to the `RUN_USER` (which was the default before), and it it is present and the built-in SSH server is enabled, then it uses the custom user for the built-in SSH server.

This does not introduce any compatibility issues with old versions.

I have tested this feature.

See issue #2617 
