### PR TITLE
Fix notifications tabs according to semantic-ui docs

### DIFF
--- a/templates/user/notification/notification.tmpl
+++ b/templates/user/notification/notification.tmpl
@@ -5,18 +5,14 @@
 		<h1 class="ui dividing header">{{.i18n.Tr "notification.notifications"}}</h1>
 
 		<div class="ui top attached tabular menu">
-			<a href="{{AppSubUrl}}/notifications?q=unread">
-				<div class="{{if eq .Status 1}}active{{end}} item">
-					{{.i18n.Tr "notification.unread"}}
-					{{if .NotificationUnreadCount}}
-						<div class="ui label">{{.NotificationUnreadCount}}</div>
-					{{end}}
-				</div>
+			<a href="{{AppSubUrl}}/notifications?q=unread" class="{{if eq .Status 1}}active{{end}} item">
+				{{.i18n.Tr "notification.unread"}}
+				{{if .NotificationUnreadCount}}
+					<div class="ui label">{{.NotificationUnreadCount}}</div>
+				{{end}}
 			</a>
-			<a href="{{AppSubUrl}}/notifications?q=read">
-				<div class="{{if eq .Status 2}}active{{end}} item">
-					{{.i18n.Tr "notification.read"}}
-				</div>
+			<a href="{{AppSubUrl}}/notifications?q=read" class="{{if eq .Status 2}}active{{end}} item">
+				{{.i18n.Tr "notification.read"}}
 			</a>
 		</div>
 		<div class="ui bottom attached active tab segment">


### PR DESCRIPTION
This removes the line under the active tab, which should not be there. This also makes this comply with the documentation: https://semantic-ui.com/collections/menu.html

![notificationstabs](https://user-images.githubusercontent.com/13909717/31696055-942a4308-b37c-11e7-96ad-142b4751ba71.gif)
