### PR TITLE
Fix IE unsupported javascript construction in branch dropdown

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1886,14 +1886,14 @@ function initFilterBranchTagDropdown(selector) {
                     }
                     return null;
                 },
-                getSelectedIndexInFiltered() {
+                getSelectedIndexInFiltered: function() {
                     for (var i = 0, j = this.filteredItems.length; i < j; ++i) {
                         if (this.filteredItems[i].selected)
                             return i;
                     }
                     return -1;
                 },
-                scrollToActive() {
+                scrollToActive: function() {
                     var el = this.$refs['listItem' + this.active];
                     if (!el || el.length === 0) {
                         return;


### PR DESCRIPTION
Bug can be reproduced only in Internet Explorer where on page load there is JS syntax error