### PR TITLE
Add search mode option to /api/repo/search

### DIFF
--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -119,10 +119,18 @@ func TestAPISearchRepo(t *testing.T) {
 			nil:   {count: 1},
 			user:  {count: 1},
 			user4: {count: 2, includesPrivate: true}}},
+		{name: "RepositoriesAccessibleAndRelatedToUser4/SearchModeFork/Exclusive", requestURL: fmt.Sprintf("/api/v1/repos/search?uid=%d&mode=%s&exclusive=1", user4.ID, "fork"), expectedResults: expectedResults{
+			nil:   {count: 1},
+			user:  {count: 1},
+			user4: {count: 2, includesPrivate: true}}},
 		{name: "RepositoriesAccessibleAndRelatedToUser4/SearchModeMirror", requestURL: fmt.Sprintf("/api/v1/repos/search?uid=%d&mode=%s", user4.ID, "mirror"), expectedResults: expectedResults{
 			nil:   {count: 2},
 			user:  {count: 2},
 			user4: {count: 4, includesPrivate: true}}},
+		{name: "RepositoriesAccessibleAndRelatedToUser4/SearchModeMirror/Exclusive", requestURL: fmt.Sprintf("/api/v1/repos/search?uid=%d&mode=%s&exclusive=1", user4.ID, "mirror"), expectedResults: expectedResults{
+			nil:   {count: 1},
+			user:  {count: 1},
+			user4: {count: 2, includesPrivate: true}}},
 		{name: "RepositoriesAccessibleAndRelatedToUser4/SearchModeCollaborative", requestURL: fmt.Sprintf("/api/v1/repos/search?uid=%d&mode=%s", user4.ID, "collaborative"), expectedResults: expectedResults{
 			nil:   {count: 0},
 			user:  {count: 0},

--- a/models/fixtures/access.yml
+++ b/models/fixtures/access.yml
@@ -66,24 +66,12 @@
 
 -
   id: 12
-  user_id: 19
-  repo_id: 23
-  mode: 4 # owner
-  
--
-  id: 13
-  user_id: 19
-  repo_id: 24
-  mode: 4 # owner
-
--
-  id: 14
-  user_id: 19
+  user_id: 20
   repo_id: 27
   mode: 4 # owner
   
 -
-  id: 15
-  user_id: 19
+  id: 13
+  user_id: 20
   repo_id: 28
   mode: 4 # owner

--- a/models/fixtures/access.yml
+++ b/models/fixtures/access.yml
@@ -63,3 +63,27 @@
   user_id: 18
   repo_id: 21
   mode: 2 # write
+
+-
+  id: 12
+  user_id: 19
+  repo_id: 23
+  mode: 4 # owner
+  
+-
+  id: 13
+  user_id: 19
+  repo_id: 24
+  mode: 4 # owner
+
+-
+  id: 14
+  user_id: 19
+  repo_id: 27
+  mode: 4 # owner
+  
+-
+  id: 15
+  user_id: 19
+  repo_id: 28
+  mode: 4 # owner

--- a/models/fixtures/org_user.yml
+++ b/models/fixtures/org_user.yml
@@ -45,3 +45,11 @@
   is_public: false
   is_owner: true
   num_teams: 1
+
+-
+  id: 7
+  uid: 20
+  org_id: 19
+  is_public: true
+  is_owner: true
+  num_teams: 1

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -201,6 +201,7 @@
   num_closed_pulls: 0
   num_watches: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 18
@@ -213,6 +214,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 19
@@ -225,6 +227,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 20
@@ -237,6 +240,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 21
@@ -249,6 +253,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 22
@@ -261,6 +266,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 23
@@ -273,6 +279,7 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
 
 -
   id: 24
@@ -285,3 +292,90 @@
   num_pulls: 0
   num_closed_pulls: 0
   is_mirror: false
+  is_fork: false
+
+-
+  id: 25
+  owner_id: 20
+  lower_name: big_test_public_mirror_5
+  name: big_test_public_mirror_5
+  is_private: false
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  num_watches: 0
+  is_mirror: true
+  is_fork: false
+
+-
+  id: 26
+  owner_id: 20
+  lower_name: big_test_private_mirror_5
+  name: big_test_private_mirror_5
+  is_private: true
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  num_watches: 0
+  is_mirror: true
+  is_fork: false
+
+-
+  id: 27
+  owner_id: 19
+  lower_name: big_test_public_mirror_6
+  name: big_test_public_mirror_6
+  is_private: false
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  num_watches: 0
+  is_mirror: true
+  num_forks: 1
+  is_fork: false
+
+-
+  id: 28
+  owner_id: 19
+  lower_name: big_test_private_mirror_6
+  name: big_test_private_mirror_6
+  is_private: true
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  num_watches: 0
+  is_mirror: true
+  num_forks: 1
+  is_fork: false
+  
+-
+  id: 29
+  fork_id: 27
+  owner_id: 20
+  lower_name: big_test_public_fork_7
+  name: big_test_public_fork_7
+  is_private: false
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  is_mirror: false
+  is_fork: true
+  
+-
+  id: 30
+  fork_id: 28
+  owner_id: 20
+  lower_name: big_test_private_fork_7
+  name: big_test_private_fork_7
+  is_private: true
+  num_issues: 0
+  num_closed_issues: 0
+  num_pulls: 0
+  num_closed_pulls: 0
+  is_mirror: false
+  is_fork: true

--- a/models/fixtures/team.yml
+++ b/models/fixtures/team.yml
@@ -37,6 +37,7 @@
   num_repos: 0
   num_members: 1
   unit_types: '[1,2,3,4,5,6,7]'
+
 -
   id: 5
   org_id: 17
@@ -45,4 +46,14 @@
   authorize: 4 # owner
   num_repos: 2
   num_members: 2
+  unit_types: '[1,2,3,4,5,6,7]'
+
+-
+  id: 6
+  org_id: 19
+  lower_name: owners
+  name: Owners
+  authorize: 4 # owner
+  num_repos: 2
+  num_members: 1
   unit_types: '[1,2,3,4,5,6,7]'

--- a/models/fixtures/team_repo.yml
+++ b/models/fixtures/team_repo.yml
@@ -27,3 +27,15 @@
   org_id: 17
   team_id: 5
   repo_id: 24
+
+-
+  id: 6
+  org_id: 19
+  team_id: 6
+  repo_id: 27
+  
+-
+  id: 7
+  org_id: 19
+  team_id: 6
+  repo_id: 28

--- a/models/fixtures/team_user.yml
+++ b/models/fixtures/team_user.yml
@@ -39,3 +39,9 @@
   org_id: 17
   team_id: 5
   uid: 18
+
+-
+  id: 8
+  org_id: 19
+  team_id: 6
+  uid: 20

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -290,7 +290,7 @@
   full_name: User 19
   email: user19@example.com
   passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
-  type: 1 # individual
+  type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
   avatar: avatar19

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -282,3 +282,35 @@
   avatar_email: user18@example.com
   num_repos: 0
   is_active: true
+
+-
+  id: 19
+  lower_name: user19
+  name: user19
+  full_name: User 19
+  email: user19@example.com
+  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  type: 1 # individual
+  salt: ZogKvWdyEx
+  is_admin: false
+  avatar: avatar19
+  avatar_email: user19@example.com
+  num_repos: 2
+  is_active: true
+  num_members: 1
+  num_teams: 1
+
+-
+  id: 20
+  lower_name: user20
+  name: user20
+  full_name: User 20
+  email: user20@example.com
+  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  type: 0 # individual
+  salt: ZogKvWdyEx
+  is_admin: false
+  avatar: avatar20
+  avatar_email: user20@example.com
+  num_repos: 4
+  is_active: true

--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -28,10 +28,11 @@ func populateIssueIndexer() error {
 	batch := indexer.IssueIndexerBatch()
 	for page := 1; ; page++ {
 		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
-			Page:     page,
-			PageSize: 10,
-			OrderBy:  SearchOrderByID,
-			Private:  true,
+			Page:        page,
+			PageSize:    10,
+			OrderBy:     SearchOrderByID,
+			Private:     true,
+			Collaborate: util.OptionalBoolFalse,
 		})
 		if err != nil {
 			return fmt.Errorf("Repositories: %v", err)

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -182,21 +182,12 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (RepositoryList, int64, err
 		cond = cond.And(builder.Like{"lower_name", strings.ToLower(opts.Keyword)})
 	}
 
-	var forkCond builder.Cond
-	var mirrorCond builder.Cond
-
 	if opts.Fork != util.OptionalBoolNone {
-		forkCond = builder.Eq{"is_fork": opts.Fork == util.OptionalBoolTrue}
+		cond = cond.And(builder.Eq{"is_fork": opts.Fork == util.OptionalBoolTrue})
 	}
 
 	if opts.Mirror != util.OptionalBoolNone {
-		mirrorCond = builder.Eq{"is_mirror": opts.Mirror == util.OptionalBoolTrue}
-	}
-
-	if opts.Fork == util.OptionalBoolTrue && opts.Mirror == util.OptionalBoolTrue {
-		cond = cond.And(builder.Or(forkCond, mirrorCond))
-	} else {
-		cond = cond.And(forkCond, mirrorCond)
+		cond = cond.And(builder.Eq{"is_mirror": opts.Mirror == util.OptionalBoolTrue})
 	}
 
 	if len(opts.OrderBy) == 0 {

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -120,11 +120,16 @@ type SearchRepoOptions struct {
 type SearchMode string
 
 const (
-	SearchModeAny           SearchMode = ""              // SearchModeAny any mode (default)
-	SearchModeFork                     = "FORK"          // SearchModeFork fork mode
-	SearchModeMirror                   = "MIRROR"        // SearchModeMirror mirror mode
-	SearchModeSource                   = "SOURCE"        // SearchModeSource source mode
-	SearchModeCollaborative            = "COLLABORATIVE" // SearchModeCollaborative collaborative mode
+	// SearchModeAny any mode (default)
+	SearchModeAny SearchMode = ""
+	// SearchModeFork fork mode
+	SearchModeFork = "FORK"
+	// SearchModeMirror mirror mode
+	SearchModeMirror = "MIRROR"
+	// SearchModeSource source mode
+	SearchModeSource = "SOURCE"
+	// SearchModeCollaborative collaborative mode
+	SearchModeCollaborative = "COLLABORATIVE"
 )
 
 //SearchOrderBy is used to sort the result

--- a/models/repo_list_test.go
+++ b/models/repo_list_test.go
@@ -5,8 +5,9 @@
 package models
 
 import (
-	"fmt"
 	"testing"
+
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,9 +17,10 @@ func TestSearchRepositoryByName(t *testing.T) {
 
 	// test search public repository on explore page
 	repos, count, err := SearchRepositoryByName(&SearchRepoOptions{
-		Keyword:  "repo_12",
-		Page:     1,
-		PageSize: 10,
+		Keyword:     "repo_12",
+		Page:        1,
+		PageSize:    10,
+		Collaborate: util.OptionalBoolFalse,
 	})
 
 	assert.NoError(t, err)
@@ -28,9 +30,10 @@ func TestSearchRepositoryByName(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 
 	repos, count, err = SearchRepositoryByName(&SearchRepoOptions{
-		Keyword:  "test_repo",
-		Page:     1,
-		PageSize: 10,
+		Keyword:     "test_repo",
+		Page:        1,
+		PageSize:    10,
+		Collaborate: util.OptionalBoolFalse,
 	})
 
 	assert.NoError(t, err)
@@ -39,10 +42,11 @@ func TestSearchRepositoryByName(t *testing.T) {
 
 	// test search private repository on explore page
 	repos, count, err = SearchRepositoryByName(&SearchRepoOptions{
-		Keyword:  "repo_13",
-		Page:     1,
-		PageSize: 10,
-		Private:  true,
+		Keyword:     "repo_13",
+		Page:        1,
+		PageSize:    10,
+		Private:     true,
+		Collaborate: util.OptionalBoolFalse,
 	})
 
 	assert.NoError(t, err)
@@ -52,10 +56,11 @@ func TestSearchRepositoryByName(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 
 	repos, count, err = SearchRepositoryByName(&SearchRepoOptions{
-		Keyword:  "test_repo",
-		Page:     1,
-		PageSize: 10,
-		Private:  true,
+		Keyword:     "test_repo",
+		Page:        1,
+		PageSize:    10,
+		Private:     true,
+		Collaborate: util.OptionalBoolFalse,
 	})
 
 	assert.NoError(t, err)
@@ -69,181 +74,151 @@ func TestSearchRepositoryByName(t *testing.T) {
 	assert.Empty(t, repos)
 	assert.Equal(t, int64(0), count)
 
-	// excepted count by repo type
-	type ec map[SearchMode]int
-
-	helperEC := ec{SearchModeAny: 14, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 4, SearchModeCollaborative: 10}
-	helperECZero := ec{SearchModeAny: 0, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}
-
 	testCases := []struct {
 		name  string
 		opts  *SearchRepoOptions
-		count ec
+		count int
 	}{
 		{name: "PublicRepositoriesByName",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10},
-			count: ec{SearchModeAny: 7, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 5}},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10, Collaborate: util.OptionalBoolFalse},
+			count: 7},
 		{name: "PublicAndPrivateRepositoriesByName",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "PublicAndPrivateRepositoriesByNameWithPagesizeLimitFirstPage",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 5, Private: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 5, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "PublicAndPrivateRepositoriesByNameWithPagesizeLimitSecondPage",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 2, PageSize: 5, Private: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 2, PageSize: 5, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "PublicAndPrivateRepositoriesByNameWithPagesizeLimitThirdPage",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 3, PageSize: 5, Private: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 3, PageSize: 5, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "PublicAndPrivateRepositoriesByNameWithPagesizeLimitFourthPage",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 3, PageSize: 5, Private: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 3, PageSize: 5, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "PublicRepositoriesOfUser",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15},
-			count: ec{SearchModeAny: 2, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Collaborate: util.OptionalBoolFalse},
+			count: 2},
 		{name: "PublicRepositoriesOfUser2",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18},
-			count: helperECZero},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Collaborate: util.OptionalBoolFalse},
+			count: 0},
 		{name: "PublicRepositoriesOfUser3",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20},
-			count: ec{SearchModeAny: 2, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 1, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Collaborate: util.OptionalBoolFalse},
+			count: 2},
 		{name: "PublicAndPrivateRepositoriesOfUser",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 4},
 		{name: "PublicAndPrivateRepositoriesOfUser2",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Private: true},
-			count: helperECZero},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 0},
 		{name: "PublicAndPrivateRepositoriesOfUser3",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Private: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 0, SearchModeFork: 2, SearchModeMirror: 2, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 4},
 		{name: "PublicRepositoriesOfUserIncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Collaborate: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 2}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15},
+			count: 4},
 		{name: "PublicRepositoriesOfUser2IncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Collaborate: true},
-			count: ec{SearchModeAny: 1, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 1}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18},
+			count: 1},
 		{name: "PublicRepositoriesOfUser3IncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Collaborate: true},
-			count: ec{SearchModeAny: 3, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 2, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20},
+			count: 3},
 		{name: "PublicAndPrivateRepositoriesOfUserIncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true},
-			count: ec{SearchModeAny: 8, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 4}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true},
+			count: 8},
 		{name: "PublicAndPrivateRepositoriesOfUser2IncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Private: true, Collaborate: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 4}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Private: true},
+			count: 4},
 		{name: "PublicAndPrivateRepositoriesOfUser3IncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Private: true, Collaborate: true},
-			count: ec{SearchModeAny: 6, SearchModeSource: 0, SearchModeFork: 2, SearchModeMirror: 4, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Private: true},
+			count: 6},
 		{name: "PublicRepositoriesOfOrganization",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17},
-			count: ec{SearchModeAny: 1, SearchModeSource: 1, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, Collaborate: util.OptionalBoolFalse},
+			count: 1},
 		{name: "PublicAndPrivateRepositoriesOfOrganization",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, Private: true},
-			count: ec{SearchModeAny: 2, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, Private: true, Collaborate: util.OptionalBoolFalse},
+			count: 2},
 		{name: "AllPublic/PublicRepositoriesByName",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10, AllPublic: true},
-			count: ec{SearchModeAny: 7, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 5}},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10, AllPublic: true, Collaborate: util.OptionalBoolFalse},
+			count: 7},
 		{name: "AllPublic/PublicAndPrivateRepositoriesByName",
-			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true, AllPublic: true},
-			count: helperEC},
+			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true, AllPublic: true, Collaborate: util.OptionalBoolFalse},
+			count: 14},
 		{name: "AllPublic/PublicRepositoriesOfUserIncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 15, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 9}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, AllPublic: true},
+			count: 15},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborative",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 19, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 11}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, AllPublic: true},
+			count: 19},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborativeByName",
-			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 13, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 7}},
+			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 15, Private: true, AllPublic: true},
+			count: 13},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUser2IncludingCollaborativeByName",
-			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 18, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 11, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 9}},
+			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 18, Private: true, AllPublic: true},
+			count: 11},
 		{name: "AllPublic/PublicRepositoriesOfOrganization",
-			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, AllPublic: true},
-			count: ec{SearchModeAny: 15, SearchModeSource: 1, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 10}},
+			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, AllPublic: true, Collaborate: util.OptionalBoolFalse},
+			count: 15},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			for searchMode, expectedCount := range testCase.count {
-				testName := "SearchModeAny"
-				testCase.opts.SearchMode = searchMode
-				if len(searchMode) > 0 {
-					testName = fmt.Sprintf("SearchMode%s", searchMode)
-				}
+			repos, count, err := SearchRepositoryByName(testCase.opts)
 
-				page := testCase.opts.Page
-				if page <= 0 {
-					page = 1
-				}
+			assert.NoError(t, err)
+			assert.Equal(t, int64(testCase.count), count)
 
-				t.Run(testName, func(t *testing.T) {
-					repos, count, err := SearchRepositoryByName(testCase.opts)
+			page := testCase.opts.Page
+			if page <= 0 {
+				page = 1
+			}
+			var expectedLen = testCase.opts.PageSize
+			if testCase.opts.PageSize*page > testCase.count+testCase.opts.PageSize {
+				expectedLen = 0
+			} else if testCase.opts.PageSize*page > testCase.count {
+				expectedLen = testCase.count % testCase.opts.PageSize
+			}
+			if assert.Len(t, repos, expectedLen) {
+				for _, repo := range repos {
+					assert.NotEmpty(t, repo.Name)
 
-					assert.NoError(t, err)
-					assert.Equal(t, int64(expectedCount), count)
+					if len(testCase.opts.Keyword) > 0 {
+						assert.Contains(t, repo.Name, testCase.opts.Keyword)
+					}
 
-					var expectedLen int
-					if testCase.opts.PageSize*page > expectedCount+testCase.opts.PageSize {
-						expectedLen = 0
-					} else if testCase.opts.PageSize*page > expectedCount {
-						expectedLen = expectedCount % testCase.opts.PageSize
+					if !testCase.opts.Private {
+						assert.False(t, repo.IsPrivate)
+					}
+
+					if testCase.opts.Fork == util.OptionalBoolTrue && testCase.opts.Mirror == util.OptionalBoolTrue {
+						assert.True(t, repo.IsFork || repo.IsMirror)
 					} else {
-						expectedLen = testCase.opts.PageSize
-					}
-					if assert.Len(t, repos, expectedLen) {
-						var tester func(t *testing.T, ownerID int64, repo *Repository)
-
-						switch searchMode {
-						case SearchModeSource:
-							tester = SearchModeSourceTester
-						case SearchModeFork:
-							tester = SearchModeForkTester
-						case SearchModeMirror:
-							tester = SearchModeMirrorTester
-						case SearchModeCollaborative:
-							tester = SearchModeCollaborativeTester
+						switch testCase.opts.Fork {
+						case util.OptionalBoolFalse:
+							assert.False(t, repo.IsFork)
+						case util.OptionalBoolTrue:
+							assert.True(t, repo.IsFork)
 						}
 
-						for _, repo := range repos {
-							assert.NotEmpty(t, repo.Name)
-
-							if len(testCase.opts.Keyword) > 0 {
-								assert.Contains(t, repo.Name, testCase.opts.Keyword)
-							}
-
-							if !testCase.opts.Private {
-								assert.False(t, repo.IsPrivate)
-							}
-
-							if tester != nil {
-								tester(t, testCase.opts.OwnerID, repo)
-							}
+						switch testCase.opts.Mirror {
+						case util.OptionalBoolFalse:
+							assert.False(t, repo.IsMirror)
+						case util.OptionalBoolTrue:
+							assert.True(t, repo.IsMirror)
 						}
 					}
-				})
+
+					if testCase.opts.OwnerID > 0 && !testCase.opts.AllPublic {
+						switch testCase.opts.Collaborate {
+						case util.OptionalBoolFalse:
+							assert.Equal(t, testCase.opts.OwnerID, repo.Owner.ID)
+						case util.OptionalBoolTrue:
+							assert.NotEqual(t, testCase.opts.OwnerID, repo.Owner.ID)
+						}
+					}
+				}
 			}
 		})
 	}
-}
-
-func SearchModeSourceTester(t *testing.T, ownerID int64, repo *Repository) {
-	assert.False(t, repo.IsFork)
-	assert.False(t, repo.IsMirror)
-	assert.Equal(t, ownerID, repo.Owner.ID)
-}
-
-func SearchModeForkTester(t *testing.T, ownerID int64, repo *Repository) {
-	assert.True(t, repo.IsFork)
-	assert.False(t, repo.IsMirror)
-	assert.Equal(t, ownerID, repo.Owner.ID)
-}
-
-func SearchModeMirrorTester(t *testing.T, ownerID int64, repo *Repository) {
-	assert.True(t, repo.IsMirror)
-}
-
-func SearchModeCollaborativeTester(t *testing.T, ownerID int64, repo *Repository) {
-	assert.False(t, repo.IsMirror)
-	assert.NotEqual(t, ownerID, repo.Owner.ID)
 }

--- a/models/repo_list_test.go
+++ b/models/repo_list_test.go
@@ -68,7 +68,7 @@ func TestSearchRepositoryByName(t *testing.T) {
 	assert.Len(t, repos, 3)
 
 	// Test non existing owner
-	repos, count, err = SearchRepositoryByName(&SearchRepoOptions{OwnerID: int64(99999)})
+	repos, count, err = SearchRepositoryByName(&SearchRepoOptions{OwnerID: NonexistentID})
 
 	assert.NoError(t, err)
 	assert.Empty(t, repos)

--- a/models/repo_list_test.go
+++ b/models/repo_list_test.go
@@ -106,7 +106,7 @@ func TestSearchRepositoryByName(t *testing.T) {
 			count: helperECZero},
 		{name: "PublicRepositoriesOfUser3",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20},
-			count: ec{SearchModeAny: 4, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 1, SearchModeCollaborative: 0}},
+			count: ec{SearchModeAny: 2, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 1, SearchModeCollaborative: 0}},
 		{name: "PublicAndPrivateRepositoriesOfUser",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true},
 			count: ec{SearchModeAny: 4, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
@@ -124,16 +124,16 @@ func TestSearchRepositoryByName(t *testing.T) {
 			count: ec{SearchModeAny: 1, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 1}},
 		{name: "PublicRepositoriesOfUser3IncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Collaborate: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 2, SearchModeCollaborative: 1}},
+			count: ec{SearchModeAny: 3, SearchModeSource: 0, SearchModeFork: 1, SearchModeMirror: 2, SearchModeCollaborative: 0}},
 		{name: "PublicAndPrivateRepositoriesOfUserIncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true},
 			count: ec{SearchModeAny: 8, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 4}},
 		{name: "PublicAndPrivateRepositoriesOfUser2IncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 18, Private: true, Collaborate: true},
-			count: ec{SearchModeAny: 4, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 2}},
+			count: ec{SearchModeAny: 4, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 4}},
 		{name: "PublicAndPrivateRepositoriesOfUser3IncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 20, Private: true, Collaborate: true},
-			count: ec{SearchModeAny: 6, SearchModeSource: 0, SearchModeFork: 2, SearchModeMirror: 2, SearchModeCollaborative: 2}},
+			count: ec{SearchModeAny: 6, SearchModeSource: 0, SearchModeFork: 2, SearchModeMirror: 4, SearchModeCollaborative: 0}},
 		{name: "PublicRepositoriesOfOrganization",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17},
 			count: ec{SearchModeAny: 1, SearchModeSource: 1, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
@@ -142,25 +142,25 @@ func TestSearchRepositoryByName(t *testing.T) {
 			count: ec{SearchModeAny: 2, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
 		{name: "AllPublic/PublicRepositoriesByName",
 			opts:  &SearchRepoOptions{Keyword: "big_test_", PageSize: 10, AllPublic: true},
-			count: ec{SearchModeAny: 7, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 0, SearchModeCollaborative: 0}},
+			count: ec{SearchModeAny: 7, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 5}},
 		{name: "AllPublic/PublicAndPrivateRepositoriesByName",
 			opts:  &SearchRepoOptions{Keyword: "big_test_", Page: 1, PageSize: 10, Private: true, AllPublic: true},
 			count: helperEC},
 		{name: "AllPublic/PublicRepositoriesOfUserIncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 15, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 9}},
+			count: ec{SearchModeAny: 15, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 9}},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborative",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 19, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 3, SearchModeCollaborative: 12}},
+			count: ec{SearchModeAny: 19, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 11}},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUserIncludingCollaborativeByName",
 			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 15, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 14, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 3, SearchModeCollaborative: 7}},
+			count: ec{SearchModeAny: 13, SearchModeSource: 4, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 7}},
 		{name: "AllPublic/PublicAndPrivateRepositoriesOfUser2IncludingCollaborativeByName",
 			opts:  &SearchRepoOptions{Keyword: "test", Page: 1, PageSize: 10, OwnerID: 18, Private: true, Collaborate: true, AllPublic: true},
-			count: ec{SearchModeAny: 9, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 5}},
+			count: ec{SearchModeAny: 11, SearchModeSource: 0, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 9}},
 		{name: "AllPublic/PublicRepositoriesOfOrganization",
 			opts:  &SearchRepoOptions{Page: 1, PageSize: 10, OwnerID: 17, AllPublic: true},
-			count: ec{SearchModeAny: 15, SearchModeSource: 2, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 11}},
+			count: ec{SearchModeAny: 15, SearchModeSource: 1, SearchModeFork: 0, SearchModeMirror: 2, SearchModeCollaborative: 10}},
 	}
 
 	for _, testCase := range testCases {
@@ -172,6 +172,11 @@ func TestSearchRepositoryByName(t *testing.T) {
 					testName = fmt.Sprintf("SearchMode%s", searchMode)
 				}
 
+				page := testCase.opts.Page
+				if page <= 0 {
+					page = 1
+				}
+
 				t.Run(testName, func(t *testing.T) {
 					repos, count, err := SearchRepositoryByName(testCase.opts)
 
@@ -179,9 +184,9 @@ func TestSearchRepositoryByName(t *testing.T) {
 					assert.Equal(t, int64(expectedCount), count)
 
 					var expectedLen int
-					if testCase.opts.PageSize*testCase.opts.Page > expectedCount+testCase.opts.PageSize {
+					if testCase.opts.PageSize*page > expectedCount+testCase.opts.PageSize {
 						expectedLen = 0
-					} else if testCase.opts.PageSize*testCase.opts.Page > expectedCount {
+					} else if testCase.opts.PageSize*page > expectedCount {
 						expectedLen = expectedCount % testCase.opts.PageSize
 					} else {
 						expectedLen = testCase.opts.PageSize

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -63,7 +63,10 @@ func TestSearchUsers(t *testing.T) {
 	testOrgSuccess(&SearchUserOptions{OrderBy: "id ASC", Page: 2, PageSize: 2},
 		[]int64{7, 17})
 
-	testOrgSuccess(&SearchUserOptions{Page: 3, PageSize: 2},
+	testOrgSuccess(&SearchUserOptions{OrderBy: "id ASC", Page: 3, PageSize: 2},
+		[]int64{19})
+
+	testOrgSuccess(&SearchUserOptions{Page: 4, PageSize: 2},
 		[]int64{})
 
 	// test users
@@ -73,13 +76,13 @@ func TestSearchUsers(t *testing.T) {
 	}
 
 	testUserSuccess(&SearchUserOptions{OrderBy: "id ASC", Page: 1},
-		[]int64{1, 2, 4, 5, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18})
+		[]int64{1, 2, 4, 5, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20})
 
 	testUserSuccess(&SearchUserOptions{Page: 1, IsActive: util.OptionalBoolFalse},
 		[]int64{9})
 
 	testUserSuccess(&SearchUserOptions{OrderBy: "id ASC", Page: 1, IsActive: util.OptionalBoolTrue},
-		[]int64{1, 2, 4, 5, 8, 10, 11, 12, 13, 14, 15, 16, 18})
+		[]int64{1, 2, 4, 5, 8, 10, 11, 12, 13, 14, 15, 16, 18, 20})
 
 	testUserSuccess(&SearchUserOptions{Keyword: "user1", OrderBy: "id ASC", Page: 1, IsActive: util.OptionalBoolTrue},
 		[]int64{1, 10, 11, 12, 13, 14, 15, 16, 18})

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1102,7 +1102,7 @@
             "type": "integer",
             "format": "int64",
             "x-go-name": "OwnerID",
-            "description": "Owner in we search search",
+            "description": "Repository owner to search",
             "name": "uid",
             "in": "query"
           },
@@ -1118,13 +1118,16 @@
             "type": "string",
             "x-go-name": "SearchMode",
             "description": "Type of repository to search, related to owner",
-            "name": "type",
+            "name": "mode",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
             "$ref": "#/responses/SearchResults"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
           },
           "500": {
             "$ref": "#/responses/SearchError"

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1113,6 +1113,13 @@
             "description": "Limit of result\n\nmaximum: setting.ExplorePagingNum",
             "name": "limit",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "SearchMode",
+            "description": "Type of repository to search, related to owner",
+            "name": "type",
+            "in": "query"
           }
         ],
         "responses": {

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1120,6 +1120,13 @@
             "description": "Type of repository to search, related to owner",
             "name": "mode",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "x-go-name": "OwnerExclusive",
+            "description": "Search only owners repositories\nHas effect only if owner is provided and mode is not \"collaborative\"",
+            "name": "exclusive",
+            "in": "query"
           }
         ],
         "responses": {

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -29,10 +29,25 @@ func Search(ctx *context.APIContext) {
 	//       200: SearchResults
 	//       500: SearchError
 
+	var searchMode models.SearchMode
+	switch ctx.Query("mode") {
+	case "fork":
+		searchMode = models.SearchModeFork
+	case "mirror":
+		searchMode = models.SearchModeMirror
+	case "source":
+		searchMode = models.SearchModeSource
+	case "collaborative":
+		searchMode = models.SearchModeCollaborative
+	default:
+		searchMode = models.SearchModeAny
+	}
+
 	opts := &models.SearchRepoOptions{
-		Keyword:  strings.Trim(ctx.Query("q"), " "),
-		OwnerID:  ctx.QueryInt64("uid"),
-		PageSize: convert.ToCorrectPageSize(ctx.QueryInt("limit")),
+		Keyword:    strings.Trim(ctx.Query("q"), " "),
+		OwnerID:    ctx.QueryInt64("uid"),
+		PageSize:   convert.ToCorrectPageSize(ctx.QueryInt("limit")),
+		SearchMode: searchMode,
 	}
 
 	if opts.OwnerID > 0 {

--- a/routers/home.go
+++ b/routers/home.go
@@ -108,14 +108,13 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	keyword := strings.Trim(ctx.Query("q"), " ")
 
 	repos, count, err = models.SearchRepositoryByName(&models.SearchRepoOptions{
-		Page:        page,
-		PageSize:    opts.PageSize,
-		OrderBy:     orderBy,
-		Private:     opts.Private,
-		Keyword:     keyword,
-		OwnerID:     opts.OwnerID,
-		Collaborate: true,
-		AllPublic:   true,
+		Page:      page,
+		PageSize:  opts.PageSize,
+		OrderBy:   orderBy,
+		Private:   opts.Private,
+		Keyword:   keyword,
+		OwnerID:   opts.OwnerID,
+		AllPublic: true,
 	})
 	if err != nil {
 		ctx.Handle(500, "SearchRepositoryByName", err)

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -15,6 +15,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/repo"
 )
 
@@ -157,13 +158,14 @@ func Profile(ctx *context.Context) {
 			}
 		} else {
 			repos, count, err = models.SearchRepositoryByName(&models.SearchRepoOptions{
-				Keyword:  keyword,
-				OwnerID:  ctxUser.ID,
-				OrderBy:  orderBy,
-				Private:  showPrivate,
-				Page:     page,
-				PageSize: setting.UI.User.RepoPagingNum,
-				Starred:  true,
+				Keyword:     keyword,
+				OwnerID:     ctxUser.ID,
+				OrderBy:     orderBy,
+				Private:     showPrivate,
+				Page:        page,
+				PageSize:    setting.UI.User.RepoPagingNum,
+				Starred:     true,
+				Collaborate: util.OptionalBoolFalse,
 			})
 			if err != nil {
 				ctx.Handle(500, "SearchRepositoryByName", err)
@@ -199,14 +201,13 @@ func Profile(ctx *context.Context) {
 			ctx.Data["Total"] = total
 		} else {
 			repos, count, err = models.SearchRepositoryByName(&models.SearchRepoOptions{
-				Keyword:     keyword,
-				OwnerID:     ctxUser.ID,
-				OrderBy:     orderBy,
-				Private:     showPrivate,
-				Page:        page,
-				IsProfile:   true,
-				PageSize:    setting.UI.User.RepoPagingNum,
-				Collaborate: true,
+				Keyword:   keyword,
+				OwnerID:   ctxUser.ID,
+				OrderBy:   orderBy,
+				Private:   showPrivate,
+				Page:      page,
+				IsProfile: true,
+				PageSize:  setting.UI.User.RepoPagingNum,
 			})
 			if err != nil {
 				ctx.Handle(500, "SearchRepositoryByName", err)


### PR DESCRIPTION
Replacement of #2326 (can't be reopen). Implements #2321.
- Adds option to search repositories through api in particular mode (`all` = default, `source`, `fork`, `mirror` and `collaborative`) with same rules as in dashboard. Every repository type / search mode is related to provided owner ID.
- Adds new validation error to search repositories api
- Adds/improve unit and integration tests
  - New organization user (2 repositories: 1 private mirror and 1 public mirror)
  - New user (4 repositories: 1 private mirror, 1 private fork, 1 public mirror and 1 public fork), used as owner of new organization
  - new accessibility checks in integration test to improve security
- Adds new options to `SearchRepositoryByName`
  - Search olny/except `fork`/`mirror` repositories or both
  - Search only `collaborative` repositories
  - Change behaviour to include `collaborative` repositories by default (every call to function was fixed to behave same as before change)


Files related to changed behaviour ~(`3 files changed, 71 insertions(+), 8 deletions(-)`)~:
- `models/repo_list.go`
- `routers/api/v1/repo/repo.go`
- `public/swagger.v1.json`
- some one line changed files due to `collaborative` option change

Other changed files ~(+353, -55 lines)~ are only for tests.


This change is esential for implementing #2312 (this PR will reopen #2343)