### PR TITLE
Use identicon image for default gravatar.

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -146,11 +146,11 @@ func TestPushCommits_AvatarLink(t *testing.T) {
 	pushCommits.Len = len(pushCommits.Commits)
 
 	assert.Equal(t,
-		"https://secure.gravatar.com/avatar/ab53a2911ddf9b4817ac01ddcd3d975f",
+		"https://secure.gravatar.com/avatar/ab53a2911ddf9b4817ac01ddcd3d975f?d=identicon",
 		pushCommits.AvatarLink("user2@example.com"))
 
 	assert.Equal(t,
-		"https://secure.gravatar.com/avatar/19ade630b94e1e0535b3df7387434154",
+		"https://secure.gravatar.com/avatar/19ade630b94e1e0535b3df7387434154?d=identicon",
 		pushCommits.AvatarLink("nonexistent@example.com"))
 }
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -211,7 +211,7 @@ func AvatarLink(email string) string {
 	}
 
 	if !setting.DisableGravatar {
-		return setting.GravatarSource + HashEmail(email)
+		return setting.GravatarSource + HashEmail(email) + "?d=identicon"
 	}
 
 	return DefaultAvatarLink()

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -135,7 +135,7 @@ func TestAvatarLink(t *testing.T) {
 
 	setting.DisableGravatar = false
 	assert.Equal(t,
-		"353cbad9b58e69c96154ad99f92bedc7",
+		"353cbad9b58e69c96154ad99f92bedc7?d=identicon",
 		AvatarLink("gitea@example.com"),
 	)
 }


### PR DESCRIPTION
Use geometric pattern image as default gravatar. It is easier to distinguish different people.

Before:
![](https://i.imgur.com/KA6785K.png)

After:
![](https://i.imgur.com/ZtU4Crh.png)