### PR TITLE
Sync MaxGitDiffLineCharacters with conf/app.ini

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -438,7 +438,7 @@ var (
 	}{
 		DisableDiffHighlight:     false,
 		MaxGitDiffLines:          1000,
-		MaxGitDiffLineCharacters: 500,
+		MaxGitDiffLineCharacters: 5000,
 		MaxGitDiffFiles:          100,
 		GCArgs:                   []string{},
 		Timeout: struct {


### PR DESCRIPTION
`MAX_GIT_DIFF_LINE_CHARACTERS` was updated in #1845 but the corresponding default value of `MaxGitDiffLineCharacters` was not changed. This can lead to inconsistencies.

Specifically, with my `bindata` build, Gitea used the default of 500 instead of 5000 because `MAX_GIT_DIFF_LINE_CHARACTERS` is not set in my `custom/conf/app.ini`.

I found the bug with version 1.2 but it should also apply to master.