### PR TITLE
Fix Git LFS object/repo link storage in database and small refactoring

### DIFF
--- a/models/lfs.go
+++ b/models/lfs.go
@@ -70,12 +70,12 @@ func NewLFSMetaObject(m *LFSMetaObject) (*LFSMetaObject, error) {
 // GetLFSMetaObjectByOid selects a LFSMetaObject entry from database by its OID.
 // It may return ErrLFSObjectNotExist or a database error. If the error is nil,
 // the returned pointer is a valid LFSMetaObject.
-func GetLFSMetaObjectByOid(oid string) (*LFSMetaObject, error) {
+func (repo *Repository) GetLFSMetaObjectByOid(oid string) (*LFSMetaObject, error) {
 	if len(oid) == 0 {
 		return nil, ErrLFSObjectNotExist
 	}
 
-	m := &LFSMetaObject{Oid: oid}
+	m := &LFSMetaObject{Oid: oid, RepositoryID: repo.ID}
 	has, err := x.Get(m)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func GetLFSMetaObjectByOid(oid string) (*LFSMetaObject, error) {
 
 // RemoveLFSMetaObjectByOid removes a LFSMetaObject entry from database by its OID.
 // It may return ErrLFSObjectNotExist or a database error.
-func RemoveLFSMetaObjectByOid(oid string) error {
+func (repo *Repository) RemoveLFSMetaObjectByOid(oid string) error {
 	if len(oid) == 0 {
 		return ErrLFSObjectNotExist
 	}
@@ -98,8 +98,7 @@ func RemoveLFSMetaObjectByOid(oid string) error {
 		return err
 	}
 
-	m := &LFSMetaObject{Oid: oid}
-
+	m := &LFSMetaObject{Oid: oid, RepositoryID: repo.ID}
 	if _, err := sess.Delete(m); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently if same file is stored in multiple repositories only link between first LFS object and repository id is saved in gitea database this way if user has access to only other repositories it is not possible for him to fetch such files. This PR fixes that all LFS object and repository links are stored correctly.

Also if deleting first repository (that only has link between LFS object and repo saved) file from disk will be removed even if that is also used in other repositories so this can lead to serious data loss.

Fixes only partly #2796 - new links will be saved correctly. For previously uploaded LFS objects there needs to be created migration but that can be done in other PR.