### PR TITLE
Use api.TrackedTime in API

### DIFF
--- a/models/issue_tracked_time.go
+++ b/models/issue_tracked_time.go
@@ -7,6 +7,8 @@ package models
 import (
 	"time"
 
+	api "code.gitea.io/sdk/gitea"
+
 	"github.com/go-xorm/builder"
 )
 
@@ -23,6 +25,17 @@ type TrackedTime struct {
 // AfterLoad is invoked from XORM after setting the values of all fields of this object.
 func (t *TrackedTime) AfterLoad() {
 	t.Created = time.Unix(t.CreatedUnix, 0).Local()
+}
+
+// APIFormat converts TrackedTime to API format
+func (t *TrackedTime) APIFormat() *api.TrackedTime {
+	return &api.TrackedTime{
+		ID:      t.ID,
+		IssueID: t.IssueID,
+		UserID:  t.UserID,
+		Time:    t.Time,
+		Created: t.Created,
+	}
 }
 
 // FindTrackedTimesOptions represent the filters for tracked times. If an ID is 0 it will be ignored.

--- a/routers/api/v1/convert/convert.go
+++ b/routers/api/v1/convert/convert.go
@@ -190,14 +190,3 @@ func ToTeam(team *models.Team) *api.Team {
 		Permission:  team.Authorize.String(),
 	}
 }
-
-// ToTrackedTime convert models.TrackedTime to api.TrackedTime
-func ToTrackedTime(trackedTime *models.TrackedTime) *api.TrackedTime {
-	return &api.TrackedTime{
-		ID:      trackedTime.ID,
-		IssueID: trackedTime.IssueID,
-		UserID:  trackedTime.UserID,
-		Time:    trackedTime.Time,
-		Created: trackedTime.Created,
-	}
-}

--- a/routers/api/v1/convert/convert.go
+++ b/routers/api/v1/convert/convert.go
@@ -190,3 +190,14 @@ func ToTeam(team *models.Team) *api.Team {
 		Permission:  team.Authorize.String(),
 	}
 }
+
+// ToTrackedTime convert models.TrackedTime to api.TrackedTime
+func ToTrackedTime(trackedTime *models.TrackedTime) *api.TrackedTime {
+	return &api.TrackedTime{
+		ID:      trackedTime.ID,
+		IssueID: trackedTime.IssueID,
+		UserID:  trackedTime.UserID,
+		Time:    trackedTime.Time,
+		Created: trackedTime.Created,
+	}
+}

--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -10,7 +10,7 @@ import (
 	api "code.gitea.io/sdk/gitea"
 )
 
-func convertTrackedTimes(trackedTimes []*models.TrackedTime) []*api.TrackedTime {
+func trackedTimesToAPIFormat(trackedTimes []*models.TrackedTime) []*api.TrackedTime {
 	apiTrackedTimes := make([]*api.TrackedTime, len(trackedTimes))
 	for i, trackedTime := range trackedTimes {
 		apiTrackedTimes[i] = trackedTime.APIFormat()
@@ -48,7 +48,7 @@ func ListTrackedTimes(ctx *context.APIContext) {
 		ctx.Error(500, "GetTrackedTimesByIssue", err)
 		return
 	}
-	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	apiTrackedTimes := trackedTimesToAPIFormat(trackedTimes)
 	ctx.JSON(200, &apiTrackedTimes)
 }
 
@@ -127,7 +127,7 @@ func ListTrackedTimesByUser(ctx *context.APIContext) {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
 		return
 	}
-	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	apiTrackedTimes := trackedTimesToAPIFormat(trackedTimes)
 	ctx.JSON(200, &apiTrackedTimes)
 }
 
@@ -152,7 +152,7 @@ func ListTrackedTimesByRepository(ctx *context.APIContext) {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
 		return
 	}
-	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	apiTrackedTimes := trackedTimesToAPIFormat(trackedTimes)
 	ctx.JSON(200, &apiTrackedTimes)
 }
 
@@ -171,6 +171,6 @@ func ListMyTrackedTimes(ctx *context.APIContext) {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
 		return
 	}
-	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	apiTrackedTimes := trackedTimesToAPIFormat(trackedTimes)
 	ctx.JSON(200, &apiTrackedTimes)
 }

--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -7,8 +7,17 @@ package repo
 import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/routers/api/v1/convert"
 	api "code.gitea.io/sdk/gitea"
 )
+
+func convertTrackedTimes(trackedTimes []*models.TrackedTime) []*api.TrackedTime {
+	apiTrackedTimes := make([]*api.TrackedTime, len(trackedTimes))
+	for i, trackedTime := range trackedTimes {
+		apiTrackedTimes[i] = convert.ToTrackedTime(trackedTime)
+	}
+	return apiTrackedTimes
+}
 
 // ListTrackedTimes list all the tracked times of an issue
 func ListTrackedTimes(ctx *context.APIContext) {
@@ -35,11 +44,13 @@ func ListTrackedTimes(ctx *context.APIContext) {
 		return
 	}
 
-	if trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{IssueID: issue.ID}); err != nil {
+	trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{IssueID: issue.ID})
+	if err != nil {
 		ctx.Error(500, "GetTrackedTimesByIssue", err)
-	} else {
-		ctx.JSON(200, &trackedTimes)
+		return
 	}
+	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	ctx.JSON(200, &apiTrackedTimes)
 }
 
 // AddTime adds time manual to the given issue
@@ -73,13 +84,12 @@ func AddTime(ctx *context.APIContext, form api.AddTimeOption) {
 		ctx.Status(403)
 		return
 	}
-	var tt *models.TrackedTime
-	if tt, err = models.AddTime(ctx.User, issue, form.Time); err != nil {
+	trackedTime, err := models.AddTime(ctx.User, issue, form.Time)
+	if err != nil {
 		ctx.Error(500, "AddTime", err)
 		return
 	}
-	ctx.JSON(200, tt)
-
+	ctx.JSON(200, convert.ToTrackedTime(trackedTime))
 }
 
 // ListTrackedTimesByUser  lists all tracked times of the user
@@ -111,11 +121,15 @@ func ListTrackedTimesByUser(ctx *context.APIContext) {
 		ctx.Status(404)
 		return
 	}
-	if trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{UserID: user.ID, RepositoryID: ctx.Repo.Repository.ID}); err != nil {
+	trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{
+		UserID:       user.ID,
+		RepositoryID: ctx.Repo.Repository.ID})
+	if err != nil {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
-	} else {
-		ctx.JSON(200, &trackedTimes)
+		return
 	}
+	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	ctx.JSON(200, &apiTrackedTimes)
 }
 
 // ListTrackedTimesByRepository lists all tracked times of the user
@@ -133,11 +147,14 @@ func ListTrackedTimesByRepository(ctx *context.APIContext) {
 		ctx.JSON(400, struct{ Message string }{Message: "time tracking disabled"})
 		return
 	}
-	if trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{RepositoryID: ctx.Repo.Repository.ID}); err != nil {
+	trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{
+		RepositoryID: ctx.Repo.Repository.ID})
+	if err != nil {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
-	} else {
-		ctx.JSON(200, &trackedTimes)
+		return
 	}
+	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	ctx.JSON(200, &apiTrackedTimes)
 }
 
 // ListMyTrackedTimes lists all tracked times of the current user
@@ -150,9 +167,11 @@ func ListMyTrackedTimes(ctx *context.APIContext) {
 	//     Responses:
 	//       200: TrackedTimes
 	//       500: error
-	if trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{UserID: ctx.User.ID}); err != nil {
+	trackedTimes, err := models.GetTrackedTimes(models.FindTrackedTimesOptions{UserID: ctx.User.ID})
+	if err != nil {
 		ctx.Error(500, "GetTrackedTimesByUser", err)
-	} else {
-		ctx.JSON(200, &trackedTimes)
+		return
 	}
+	apiTrackedTimes := convertTrackedTimes(trackedTimes)
+	ctx.JSON(200, &apiTrackedTimes)
 }

--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -7,14 +7,13 @@ package repo
 import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/routers/api/v1/convert"
 	api "code.gitea.io/sdk/gitea"
 )
 
 func convertTrackedTimes(trackedTimes []*models.TrackedTime) []*api.TrackedTime {
 	apiTrackedTimes := make([]*api.TrackedTime, len(trackedTimes))
 	for i, trackedTime := range trackedTimes {
-		apiTrackedTimes[i] = convert.ToTrackedTime(trackedTime)
+		apiTrackedTimes[i] = trackedTime.APIFormat()
 	}
 	return apiTrackedTimes
 }
@@ -89,7 +88,7 @@ func AddTime(ctx *context.APIContext, form api.AddTimeOption) {
 		ctx.Error(500, "AddTime", err)
 		return
 	}
-	ctx.JSON(200, convert.ToTrackedTime(trackedTime))
+	ctx.JSON(200, trackedTime.APIFormat())
 }
 
 // ListTrackedTimesByUser  lists all tracked times of the user


### PR DESCRIPTION
Use `api.TrackedTime` instead of `models.TrackedTime` in responses from time-tracking API endpoints.

cc @JonasFranzDEV