### PR TITLE
Fix dropdown menu position when explore repos

### DIFF
--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -1,6 +1,6 @@
 <div class="ui right floated secondary filter menu">
 <!-- Sort -->
-	<div class="ui dropdown type jump item">
+	<div class="ui right dropdown type jump item">
 		<span class="text">
 			{{.i18n.Tr "repo.issues.filter_sort"}}
 			<i class="dropdown icon"></i>


### PR DESCRIPTION
This will fix the dropdown position when explore the repos.

### Before
<img width="200" alt="before" src="https://user-images.githubusercontent.com/113989/32217757-8f63d21e-be5b-11e7-8874-216ec7fc46dc.png">

### After
<img width="200" style="width: 100%" alt="after" src="https://user-images.githubusercontent.com/113989/32217756-8f259d82-be5b-11e7-81fa-028e1365f4a1.png">