### PR TITLE
Fix comment API paths

### DIFF
--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -93,8 +93,8 @@ func TestAPIEditComment(t *testing.T) {
 	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
 
 	session := loginUser(t, repoOwner.Name)
-	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments/%d",
-		repoOwner.Name, repo.Name, issue.Index, comment.ID)
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/comments/%d",
+		repoOwner.Name, repo.Name, comment.ID)
 	req := NewRequestWithValues(t, "PATCH", urlStr, map[string]string{
 		"body": newCommentBody,
 	})
@@ -117,8 +117,8 @@ func TestAPIDeleteComment(t *testing.T) {
 	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
 
 	session := loginUser(t, repoOwner.Name)
-	req := NewRequestf(t, "DELETE", "/api/v1/repos/%s/%s/issues/%d/comments/%d",
-		repoOwner.Name, repo.Name, issue.Index, comment.ID)
+	req := NewRequestf(t, "DELETE", "/api/v1/repos/%s/%s/issues/comments/%d",
+		repoOwner.Name, repo.Name, comment.ID)
 	session.MakeRequest(t, req, http.StatusNoContent)
 
 	models.AssertNotExistsBean(t, &models.Comment{ID: comment.ID})

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1225,91 +1225,6 @@
         }
       }
     },
-    "/repos/{owner}/{repo}/comments/{id}": {
-      "delete": {
-        "tags": [
-          "issue"
-        ],
-        "summary": "Delete a comment",
-        "operationId": "issueDeleteComment",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "owner of the repo",
-            "name": "owner",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of the repo",
-            "name": "repo",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "integer",
-            "description": "id of comment to delete",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/responses/empty"
-          }
-        }
-      },
-      "patch": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "issue"
-        ],
-        "summary": "Edit a comment",
-        "operationId": "issueEditComment",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "owner of the repo",
-            "name": "owner",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of the repo",
-            "name": "repo",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "integer",
-            "description": "id of the comment to edit",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/EditIssueCommentOption"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/Comment"
-          }
-        }
-      }
-    },
     "/repos/{owner}/{repo}/commits/{ref}/statuses": {
       "get": {
         "produces": [
@@ -1965,6 +1880,91 @@
         }
       }
     },
+    "/repos/{owner}/{repo}/issues/comments/{id}": {
+      "delete": {
+        "tags": [
+          "issue"
+        ],
+        "summary": "Delete a comment",
+        "operationId": "issueDeleteComment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "id of comment to delete",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/responses/empty"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "issue"
+        ],
+        "summary": "Edit a comment",
+        "operationId": "issueEditComment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "id of the comment to edit",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EditIssueCommentOption"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Comment"
+          }
+        }
+      }
+    },
     "/repos/{owner}/{repo}/issues/{id}": {
       "get": {
         "produces": [
@@ -2098,6 +2098,107 @@
         ],
         "responses": {
           "201": {
+            "$ref": "#/responses/Comment"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{index}/comments/{id}": {
+      "delete": {
+        "tags": [
+          "issue"
+        ],
+        "summary": "Delete a comment",
+        "operationId": "issueDeleteCommentDeprecated",
+        "deprecated": true,
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "this parameter is ignored",
+            "name": "index",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "id of comment to delete",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/responses/empty"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "issue"
+        ],
+        "summary": "Edit a comment",
+        "operationId": "issueEditCommentDeprecated",
+        "deprecated": true,
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "this parameter is ignored",
+            "name": "index",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "id of the comment to edit",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EditIssueCommentOption"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
             "$ref": "#/responses/Comment"
           }
         }

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -406,7 +406,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 					m.Group("/comments", func() {
 						m.Get("", repo.ListRepoIssueComments)
 						m.Combo("/:id", reqToken()).
-							Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment)
+							Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment).
+							Delete(repo.DeleteIssueComment)
 					})
 					m.Group("/:index", func() {
 						m.Combo("").Get(repo.GetIssue).
@@ -415,8 +416,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 						m.Group("/comments", func() {
 							m.Combo("").Get(repo.ListIssueComments).
 								Post(reqToken(), bind(api.CreateIssueCommentOption{}), repo.CreateIssueComment)
-							m.Combo("/:id", reqToken()).Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment).
-								Delete(repo.DeleteIssueComment)
+							m.Combo("/:id", reqToken()).Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueCommentDeprecated).
+								Delete(repo.DeleteIssueCommentDeprecated)
 						})
 
 						m.Group("/labels", func() {

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -168,7 +168,7 @@ func CreateIssueComment(ctx *context.APIContext, form api.CreateIssueCommentOpti
 
 // EditIssueComment modify a comment of an issue
 func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) {
-	// swagger:operation PATCH /repos/{owner}/{repo}/comments/{id} issue issueEditComment
+	// swagger:operation PATCH /repos/{owner}/{repo}/issues/comments/{id} issue issueEditComment
 	// ---
 	// summary: Edit a comment
 	// consumes:
@@ -198,6 +198,51 @@ func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) 
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/Comment"
+	editIssueComment(ctx, form)
+}
+
+// EditIssueCommentDeprecated modify a comment of an issue
+func EditIssueCommentDeprecated(ctx *context.APIContext, form api.EditIssueCommentOption) {
+	// swagger:operation PATCH /repos/{owner}/{repo}/issues/{index}/comments/{id} issue issueEditCommentDeprecated
+	// ---
+	// summary: Edit a comment
+	// deprecated: true
+	// consumes:
+	// - application/json
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: index
+	//   in: path
+	//   description: this parameter is ignored
+	//   type: integer
+	//   required: true
+	// - name: id
+	//   in: path
+	//   description: id of the comment to edit
+	//   type: integer
+	//   required: true
+	// - name: body
+	//   in: body
+	//   schema:
+	//     "$ref": "#/definitions/EditIssueCommentOption"
+	// responses:
+	//   "200":
+	//     "$ref": "#/responses/Comment"
+	editIssueComment(ctx, form)
+}
+
+func editIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) {
 	comment, err := models.GetCommentByID(ctx.ParamsInt64(":id"))
 	if err != nil {
 		if models.IsErrCommentNotExist(err) {
@@ -226,7 +271,7 @@ func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) 
 
 // DeleteIssueComment delete a comment from an issue
 func DeleteIssueComment(ctx *context.APIContext) {
-	// swagger:operation DELETE /repos/{owner}/{repo}/comments/{id} issue issueDeleteComment
+	// swagger:operation DELETE /repos/{owner}/{repo}/issues/comments/{id} issue issueDeleteComment
 	// ---
 	// summary: Delete a comment
 	// parameters:
@@ -248,6 +293,43 @@ func DeleteIssueComment(ctx *context.APIContext) {
 	// responses:
 	//   "204":
 	//     "$ref": "#/responses/empty"
+	deleteIssueComment(ctx)
+}
+
+// DeleteIssueCommentDeprecated delete a comment from an issue
+func DeleteIssueCommentDeprecated(ctx *context.APIContext) {
+	// swagger:operation DELETE /repos/{owner}/{repo}/issues/{index}/comments/{id} issue issueDeleteCommentDeprecated
+	// ---
+	// summary: Delete a comment
+	// deprecated: true
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: index
+	//   in: path
+	//   description: this parameter is ignored
+	//   type: integer
+	//   required: true
+	// - name: id
+	//   in: path
+	//   description: id of comment to delete
+	//   type: integer
+	//   required: true
+	// responses:
+	//   "204":
+	//     "$ref": "#/responses/empty"
+	deleteIssueComment(ctx)
+}
+
+func deleteIssueComment(ctx *context.APIContext) {
 	comment, err := models.GetCommentByID(ctx.ParamsInt64(":id"))
 	if err != nil {
 		if models.IsErrCommentNotExist(err) {


### PR DESCRIPTION
Corrects the following comment API routes
- `PATCH /:owner/:repo/issues/:index/comments/:id` -> `PATCH /:owner/:repo/issues/comments/:id`
- `DELETE /:owner/:repo/issues/:index/comments/:id` -> `DELETE /:owner/:repo/issues/comments/:id`

The previous routes ignored the `:index` parameter, and were in conflict with [the Github API](https://developer.github.com/v3/issues/comments/). The previous route are marked as deprecated, but have not been removed.