### PR TITLE
Fix API status code for hook creation

### DIFF
--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1527,7 +1527,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "201": {
             "$ref": "#/responses/Hook"
           }
         }

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -107,7 +107,7 @@ func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
 	//   schema:
 	//     "$ref": "#/definitions/CreateHookOption"
 	// responses:
-	//   "200":
+	//   "201":
 	//     "$ref": "#/responses/Hook"
 	if !utils.CheckCreateHookOption(ctx, &form) {
 		return

--- a/routers/api/v1/utils/hook.go
+++ b/routers/api/v1/utils/hook.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/routers/api/v1/convert"
 	"encoding/json"
 	"github.com/Unknwon/com"
+	"net/http"
 )
 
 // GetOrgHook get an organization's webhook. If there is an error, write to
@@ -69,7 +70,7 @@ func AddOrgHook(ctx *context.APIContext, form *api.CreateHookOption) {
 	org := ctx.Org.Organization
 	hook, ok := addHook(ctx, form, org.ID, 0)
 	if ok {
-		ctx.JSON(201, convert.ToHook(org.HomeLink(), hook))
+		ctx.JSON(http.StatusCreated, convert.ToHook(org.HomeLink(), hook))
 	}
 }
 
@@ -78,7 +79,7 @@ func AddRepoHook(ctx *context.APIContext, form *api.CreateHookOption) {
 	repo := ctx.Repo
 	hook, ok := addHook(ctx, form, 0, repo.Repository.ID)
 	if ok {
-		ctx.JSON(201, convert.ToHook(repo.RepoLink, hook))
+		ctx.JSON(http.StatusCreated, convert.ToHook(repo.RepoLink, hook))
 	}
 }
 

--- a/routers/api/v1/utils/hook.go
+++ b/routers/api/v1/utils/hook.go
@@ -69,7 +69,7 @@ func AddOrgHook(ctx *context.APIContext, form *api.CreateHookOption) {
 	org := ctx.Org.Organization
 	hook, ok := addHook(ctx, form, org.ID, 0)
 	if ok {
-		ctx.JSON(200, convert.ToHook(org.HomeLink(), hook))
+		ctx.JSON(201, convert.ToHook(org.HomeLink(), hook))
 	}
 }
 
@@ -78,7 +78,7 @@ func AddRepoHook(ctx *context.APIContext, form *api.CreateHookOption) {
 	repo := ctx.Repo
 	hook, ok := addHook(ctx, form, 0, repo.Repository.ID)
 	if ok {
-		ctx.JSON(200, convert.ToHook(repo.RepoLink, hook))
+		ctx.JSON(201, convert.ToHook(repo.RepoLink, hook))
 	}
 }
 


### PR DESCRIPTION
Return 201, instead of 200, when creating a hook via the API; this is in compliance with the Github API, and more generally the semantics of HTTP status codes. Affects the following routes:
- `POST /:owner/:repo/hooks`
- `POST /orgs/:org/hooks`