### PR TITLE
chore: simplify docker build process.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -238,7 +238,7 @@ pipeline:
       branch: [ master ]
 
   docker:
-    image: plugins/docker:17.05
+    image: plugins/docker:17.12
     pull: true
     secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
@@ -248,7 +248,7 @@ pipeline:
       branch: [ release/* ]
 
   docker:
-    image: plugins/docker:17.05
+    image: plugins/docker:17.12
     pull: true
     repo: gitea/gitea
     default_tags: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -242,15 +242,6 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
-    tags: [ '${DRONE_TAG##v}' ]
-    when:
-      event: [ tag ]
-
-  docker:
-    image: plugins/docker:17.05
-    pull: true
-    secrets: [ docker_username, docker_password ]
-    repo: gitea/gitea
     tags: [ '${DRONE_BRANCH##release/v}' ]
     when:
       event: [ push ]
@@ -259,12 +250,10 @@ pipeline:
   docker:
     image: plugins/docker:17.05
     pull: true
-    secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
-    tags: [ 'latest' ]
+    default_tags: true
     when:
-      event: [ push ]
-      branch: [ master ]
+      event: [ push, tag ]
 
   release:
     image: plugins/s3:1


### PR DESCRIPTION
> * git tag v1.9.2 will publish docker tags 1, 1.9 and 1.9.2
> * git tag v1.9.2-alpha.1 will publish docker tag 1.9.2-alpha.1

See the folllowings:

```diff
pipeline:
  publish_latest:
    image: plugins/docker
    repo: octocat/hello-world
-   tags: latest
+   default_tags: true
    when:
-     event: push
+     event: [ push, tag ]

- publish_release:
-   image: plugins/docker
-   repo: octocat/hello-world
-   tags: $DRONE_TAG
-   when:
-     event: tag
```

ref: https://discourse.drone.io/t/new-default-tags-parameter-for-docker-plugin/995

cc @lunny @tboerger 