### PR TITLE
Fix removing backslash before quotes in translations

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ pipeline:
     commands:
       - mv ./options/locale/locale_en-US.ini ./options/
       - sed -i -e 's/="/=/g' -e 's/"$$//g' ./options/locale/*.ini
-      - sed -i -e 's/\\"/"/g' ./options/locale/*.ini
+      - sed -i -e 's/\\\\"/"/g' ./options/locale/*.ini
       - mv ./options/locale_en-US.ini ./options/locale/
     when:
       event: [ push ]


### PR DESCRIPTION
Current translations commited by drone are still broken. This should fix that.