### PR TITLE
Use different directories for session files in integration tests

### DIFF
--- a/integrations/mysql.ini.tmpl
+++ b/integrations/mysql.ini.tmpl
@@ -49,6 +49,7 @@ ENABLE_FEDERATED_AVATAR = false
 
 [session]
 PROVIDER = file
+PROVIDER_CONFIG = data/sessions-mysql
 
 [log]
 MODE      = console,file

--- a/integrations/pgsql.ini.tmpl
+++ b/integrations/pgsql.ini.tmpl
@@ -49,6 +49,7 @@ ENABLE_FEDERATED_AVATAR = false
 
 [session]
 PROVIDER = file
+PROVIDER_CONFIG = data/sessions-pgsql
 
 [log]
 MODE = console,file


### PR DESCRIPTION
Could be one of reasons why mysql&pgsql integration tests fail randomly as both are run in parallel 