### PR TITLE
Fix order of comments

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -611,6 +611,7 @@ func findComments(e Engine, opts FindCommentsOptions) ([]*Comment, error) {
 	}
 	return comments, sess.
 		Asc("comment.created_unix").
+		Asc("comment.id").
 		Find(&comments)
 }
 


### PR DESCRIPTION
Simple change. If comments have same `created_unix` time, use `id` for ordering.

Before:
![image](https://user-images.githubusercontent.com/12720041/32358009-2e624f70-c042-11e7-9b97-4742b4040093.png)

After:
![chrome_2017-11-03_02-49-43](https://user-images.githubusercontent.com/12720041/32358025-5c9e92cc-c042-11e7-93bd-f75438a6ebe3.png)
