### PR TITLE
[HOTFIX] Fix Drone/Gitea webhook reference integration

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -385,7 +385,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 						Put(bind(api.AddCollaboratorOption{}), repo.AddCollaborator).
 						Delete(repo.DeleteCollaborator)
 				}, reqToken())
-				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
+				m.Get("/raw/*", context.RepoRefByType(context.RepoRefCommit), repo.GetRawFile)
 				m.Get("/archive/*", repo.GetArchive)
 				m.Combo("/forks").Get(repo.ListForks).
 					Post(reqToken(), bind(api.CreateForkOption{}), repo.CreateFork)


### PR DESCRIPTION
This PR fixes the broken webhook integration between Drone & Gitea due to 513375c429435ba60a667b219bdfb00e5b760b38. Essentially, the default `context.RepoRef()` has been set to use branch references instead of commit references, so Gitea was getting the wrong information.

This also fixes #2824.