### PR TITLE
Fix LFS not returning correct content length when requesting a range …

### DIFF
--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -152,7 +152,7 @@ func getContentHandler(ctx *context.Context) {
 		return
 	}
 
-	ctx.Resp.Header().Set("Content-Length", strconv.FormatInt(meta.Size, 10))
+	ctx.Resp.Header().Set("Content-Length", strconv.FormatInt(meta.Size-fromByte, 10))
 	ctx.Resp.Header().Set("Content-Type", "application/octet-stream")
 
 	filename := ctx.Params("filename")


### PR DESCRIPTION
…of bytes

This intends to fix issue #2112 