### PR TITLE
Page parameter for repo search API

### DIFF
--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -849,13 +849,19 @@
           },
           {
             "type": "integer",
-            "description": "if provided, will return only repos owned by the user with the given id",
+            "description": "search only for repos that the user with the given id owns or contributes to",
             "name": "uid",
             "in": "query"
           },
           {
             "type": "integer",
-            "description": "maximum number of repos to return",
+            "description": "page number of results to return (1-based)",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "page size of results, maximum page size is 50",
             "name": "limit",
             "in": "query"
           },
@@ -867,7 +873,7 @@
           },
           {
             "type": "boolean",
-            "description": "only search for repositories owned by the authenticated user",
+            "description": "if `uid` is given, search only for repos that the user owns",
             "name": "exclusive",
             "in": "query"
           }

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -34,11 +34,15 @@ func Search(ctx *context.APIContext) {
 	//   type: string
 	// - name: uid
 	//   in: query
-	//   description: if provided, will return only repos owned by the user with the given id
+	//   description: search only for repos that the user with the given id owns or contributes to
+	//   type: integer
+	// - name: page
+	//   in: query
+	//   description: page number of results to return (1-based)
 	//   type: integer
 	// - name: limit
 	//   in: query
-	//   description: maximum number of repos to return
+	//   description: page size of results, maximum page size is 50
 	//   type: integer
 	// - name: mode
 	//   in: query
@@ -47,7 +51,7 @@ func Search(ctx *context.APIContext) {
 	//   type: string
 	// - name: exclusive
 	//   in: query
-	//   description: only search for repositories owned by the authenticated user
+	//   description: if `uid` is given, search only for repos that the user owns
 	//   type: boolean
 	// responses:
 	//   "200":
@@ -57,6 +61,7 @@ func Search(ctx *context.APIContext) {
 	opts := &models.SearchRepoOptions{
 		Keyword:     strings.Trim(ctx.Query("q"), " "),
 		OwnerID:     ctx.QueryInt64("uid"),
+		Page:        ctx.QueryInt("page"),
 		PageSize:    convert.ToCorrectPageSize(ctx.QueryInt("limit")),
 		Collaborate: util.OptionalBoolNone,
 	}


### PR DESCRIPTION
Right now, there is no way to get more than the first 50 repos from the `/repos/search` API endpoint.

Also makes some tweaks to the endpoint's swagger docs.
