### PR TITLE
WIP: Reimplement dump and implment restore command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -1,5 +1,5 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
-// Copyright 2017 The Gitea Authors. All rights reserved.
+// Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -67,7 +67,7 @@ func runRestore(ctx *cli.Context) error {
 	srcPath := os.Args[2]
 
 	zip.Verbose = ctx.Bool("verbose")
-	log.Printf("Extracting %s to tmp work dir", srcPath)
+	log.Printf("Extracting %s to %s", srcPath, tmpWorkDir)
 	err = zip.ExtractTo(srcPath, tmpWorkDir)
 	if err != nil {
 		log.Fatalf("Failed to extract %s to tmp work directory: %v", srcPath, err)
@@ -101,7 +101,12 @@ func runRestore(ctx *cli.Context) error {
 		log.Fatalf("Failed to SetEngine: %v", err)
 	}
 
-	log.Printf("Restoring repo dir %s ...", setting.RepoRootPath)
+	err = models.SyncDBStructs()
+	if err != nil {
+		log.Fatalf("Failed to SyncDBStructs: %v", err)
+	}
+
+	log.Printf("Restoring repo dir to %s ...", setting.RepoRootPath)
 	repoPath := filepath.Join(tmpWorkDir, "repositories")
 	err = os.RemoveAll(setting.RepoRootPath)
 	if err != nil {
@@ -113,7 +118,7 @@ func runRestore(ctx *cli.Context) error {
 		log.Fatalf("Failed to move %s to %s: %v", repoPath, setting.RepoRootPath, err)
 	}
 
-	log.Printf("Restoring custom dir %s ...", setting.CustomPath)
+	log.Printf("Restoring custom dir to %s ...", setting.CustomPath)
 	customPath := filepath.Join(tmpWorkDir, "custom")
 	err = os.RemoveAll(setting.CustomPath)
 	if err != nil {
@@ -125,7 +130,7 @@ func runRestore(ctx *cli.Context) error {
 		log.Fatalf("Failed to move %s to %s: %v", customPath, setting.CustomPath, err)
 	}
 
-	log.Printf("Restoring data dir %s ...", setting.AppDataPath)
+	log.Printf("Restoring data dir to %s ...", setting.AppDataPath)
 	dataPath := filepath.Join(tmpWorkDir, "data")
 	err = os.RemoveAll(setting.AppDataPath)
 	if err != nil {
@@ -137,8 +142,8 @@ func runRestore(ctx *cli.Context) error {
 		log.Fatalf("Failed to move %s to %s: %v", dataPath, setting.AppDataPath, err)
 	}
 
-	log.Printf("Restoring database from ...")
 	dbPath := filepath.Join(tmpWorkDir, "database")
+	log.Printf("Restoring database from %s ...", dbPath)
 	err = models.RestoreDatabaseFixtures(dbPath)
 	if err != nil {
 		log.Fatalf("Failed to restore database dir %s: %v", dbPath, err)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,0 +1,148 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/Unknwon/cae/zip"
+	"github.com/Unknwon/com"
+	"github.com/urfave/cli"
+)
+
+// CmdRestore represents the available restore sub-command.
+var CmdRestore = cli.Command{
+	Name:  "restore",
+	Usage: "Restore Gitea files and database",
+	Description: `Restore will restore all data from zip file which dumped from gitea. It will use 
+the custom config in this dump zip file, this operation will remove all the dest database and repositories.`,
+	Action: runRestore,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config, c",
+			Value: "custom/conf/app.ini",
+			Usage: "Custom configuration file path, if empty will use dumped config file",
+		},
+		cli.BoolFlag{
+			Name:  "verbose, v",
+			Usage: "Show process details",
+		},
+		cli.StringFlag{
+			Name:  "tempdir, t",
+			Value: os.TempDir(),
+			Usage: "Temporary dir path",
+		},
+	},
+}
+
+func runRestore(ctx *cli.Context) error {
+	if len(os.Args) < 3 {
+		return errors.New("need zip file path")
+	}
+
+	tmpDir := ctx.String("tempdir")
+	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+		log.Fatalf("Path does not exist: %s", tmpDir)
+	}
+	tmpWorkDir, err := ioutil.TempDir(tmpDir, "gitea-dump-")
+	if err != nil {
+		log.Fatalf("Failed to create tmp work directory: %v", err)
+	}
+	log.Printf("Creating tmp work dir: %s", tmpWorkDir)
+
+	// work-around #1103
+	if os.Getenv("TMPDIR") == "" {
+		os.Setenv("TMPDIR", tmpWorkDir)
+	}
+
+	srcPath := os.Args[2]
+
+	zip.Verbose = ctx.Bool("verbose")
+	log.Printf("Extracting %s to tmp work dir", srcPath)
+	err = zip.ExtractTo(srcPath, tmpWorkDir)
+	if err != nil {
+		log.Fatalf("Failed to extract %s to tmp work directory: %v", srcPath, err)
+	}
+
+	verData, err := ioutil.ReadFile(filepath.Join(tmpWorkDir, "VERSION"))
+	if err != nil {
+		log.Fatalf("Failed to extract %s to tmp work directory: %v", srcPath, err)
+	}
+
+	if setting.AppVer != string(verData) {
+		log.Fatalf("Expected gitea version to restore is %s, but get %s", string(verData), setting.AppVer)
+	}
+
+	if ctx.IsSet("config") {
+		setting.CustomConf = ctx.String("config")
+	} else {
+		setting.CustomConf = filepath.Join(tmpWorkDir, "custom", "conf", "app.ini")
+	}
+	if !com.IsExist(setting.CustomConf) {
+		log.Fatalf("Failed to load ini config file from %s", setting.CustomConf)
+	}
+
+	setting.NewContext()
+	//setting.CustomPath = filepath.Join(tmpWorkDir, "custom")
+	setting.NewXORMLogService(false)
+	models.LoadConfigs()
+
+	err = models.SetEngine()
+	if err != nil {
+		log.Fatalf("Failed to SetEngine: %v", err)
+	}
+
+	log.Printf("Restoring repo dir %s ...", setting.RepoRootPath)
+	repoPath := filepath.Join(tmpWorkDir, "repositories")
+	err = os.RemoveAll(setting.RepoRootPath)
+	if err != nil {
+		log.Fatalf("Failed to Remove repo root path %s: %v", setting.RepoRootPath, err)
+	}
+
+	err = os.Rename(repoPath, setting.RepoRootPath)
+	if err != nil {
+		log.Fatalf("Failed to move %s to %s: %v", repoPath, setting.RepoRootPath, err)
+	}
+
+	log.Printf("Restoring custom dir %s ...", setting.CustomPath)
+	customPath := filepath.Join(tmpWorkDir, "custom")
+	err = os.RemoveAll(setting.CustomPath)
+	if err != nil {
+		log.Fatalf("Failed to Remove repo root path %s: %v", setting.CustomPath, err)
+	}
+
+	err = os.Rename(customPath, setting.CustomPath)
+	if err != nil {
+		log.Fatalf("Failed to move %s to %s: %v", customPath, setting.CustomPath, err)
+	}
+
+	log.Printf("Restoring data dir %s ...", setting.AppDataPath)
+	dataPath := filepath.Join(tmpWorkDir, "data")
+	err = os.RemoveAll(setting.AppDataPath)
+	if err != nil {
+		log.Fatalf("Failed to Remove data root path %s: %v", setting.AppDataPath, err)
+	}
+
+	err = os.Rename(dataPath, setting.AppDataPath)
+	if err != nil {
+		log.Fatalf("Failed to move %s to %s: %v", dataPath, setting.AppDataPath, err)
+	}
+
+	log.Printf("Restoring database from ...")
+	dbPath := filepath.Join(tmpWorkDir, "database")
+	err = models.RestoreDatabaseFixtures(dbPath)
+	if err != nil {
+		log.Fatalf("Failed to restore database dir %s: %v", dbPath, err)
+	}
+
+	return nil
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -53,7 +53,7 @@ func runRestore(ctx *cli.Context) error {
 	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
 		log.Fatalf("Path does not exist: %s", tmpDir)
 	}
-	tmpWorkDir, err := ioutil.TempDir(tmpDir, "gitea-dump-")
+	tmpWorkDir, err := ioutil.TempDir(tmpDir, "gitea-restore-")
 	if err != nil {
 		log.Fatalf("Failed to create tmp work directory: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ arguments - which can alternatively be run by running the subcommand web.`
 		cmd.CmdServ,
 		cmd.CmdHook,
 		cmd.CmdDump,
+		cmd.CmdRestore,
 		cmd.CmdCert,
 		cmd.CmdAdmin,
 		cmd.CmdGenerate,

--- a/models/models.go
+++ b/models/models.go
@@ -439,7 +439,7 @@ func restoreTableFixtures(bean interface{}, dirPath string) error {
 	}
 
 	var columns = make([]string, 0, len(records[0]))
-	for k, _ := range records[0] {
+	for k := range records[0] {
 		columns = append(columns, k)
 	}
 	sort.Strings(columns)


### PR DESCRIPTION
This PR would like to replace #1637. It reimplemented `dump` command and old dump file will not be used anymore. And also added a restore command that could restore dumped zip file to some machine. You have to use the same version Gitea with `dump` when `restore`.

The dump databases will be stored as `<table_name>.yml` in one directory. This format is expected to be compatible with Gitea's test fixtures. So that it's easy to export test data from a real system.

Currently it's blocked because yaml package didn't support Gonic name mapping, so I have forked yml package to https://github.com/go-gitea/yaml. Before that package supports that feature, this PR is not really work.