### PR TITLE
Restore build as the default make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ else
 	endif
 endif
 
-include docker/Makefile
-
 .PHONY: all
 all: build
+
+include docker/Makefile
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Fixes a (presumably?) unintended side-effect of #1985. Right now, `make docker` is the default rule.

cc @sapk