### PR TITLE
2939 multiline commit message

### DIFF
--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -60,7 +60,7 @@
 							</a>
 						</td>
 						<td class="message collapsing">
-							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}">{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
+							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title={{.Message}}>!!!{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
 							{{template "repo/commit_status" .Status}}
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -60,7 +60,7 @@
 							</a>
 						</td>
 						<td class="message collapsing">
-							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title={{.Message}}>!!!{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
+							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title={{.Message}}>{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
 							{{template "repo/commit_status" .Status}}
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -60,7 +60,7 @@
 							</a>
 						</td>
 						<td class="message collapsing">
-							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title={{.Message}}>{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
+							<span class="has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Message}}">{{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
 							{{template "repo/commit_status" .Status}}
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>

--- a/templates/repo/diff/page.tmpl
+++ b/templates/repo/diff/page.tmpl
@@ -9,7 +9,7 @@
 				<a class="ui floated right blue tiny button" href="{{EscapePound .SourcePath}}">
 					{{.i18n.Tr "repo.diff.browse_source"}}
 				</a>
-				<h3>{{RenderCommitMessage .Commit.Message $.RepoLink $.Repository.ComposeMetas}}{{template "repo/commit_status" .CommitStatus}}</h3>
+				<h3 title="{{.Commit.Message}}">{{RenderCommitMessage .Commit.Message $.RepoLink $.Repository.ComposeMetas}}{{template "repo/commit_status" .CommitStatus}}</h3>
 			</div>
 			<div class="ui attached info segment {{if .Commit.Signature}} isSigned {{if .Verification.Verified }} isVerified {{end}}{{end}}">
 				{{if .Author}}


### PR DESCRIPTION
View of multiline commit messages as tooltips. 
Fixes #2939 