### PR TITLE
App restarts to quickly if it fails to start.

### DIFF
--- a/contrib/systemd/gitea.service
+++ b/contrib/systemd/gitea.service
@@ -14,6 +14,7 @@ After=network.target
 ###
 #LimitMEMLOCK=infinity
 #LimitNOFILE=65535
+RestartSec=2s
 Type=simple
 User=git
 Group=git


### PR DESCRIPTION
Systemd has a default restart time of 100ms. This does not allow enough time if the app fails to start.