### PR TITLE
To support Active Directory authentication

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1294,6 +1294,7 @@ auths.domain = Domain
 auths.host = Host
 auths.port = Port
 auths.bind_dn = Bind DN
+auths.bind_dn_helper=You can use '%s' as placeholder for username, e.g. DOM\%s
 auths.bind_password = Bind Password
 auths.bind_password_helper = Warning: This password is stored in plain text. It is highly recommended to use read-only account.
 auths.user_base = User Search Base

--- a/options/locale/locale_fr-FR.ini
+++ b/options/locale/locale_fr-FR.ini
@@ -1289,6 +1289,7 @@ auths.domain=Domaine
 auths.host=Hôte
 auths.port=Port
 auths.bind_dn=Bind DN
+auths.bind_dn_helper=Vous pouvez utiliser '%s' comme substitut pour le nom d'utilisateur
 auths.bind_password=Bind mot de passe
 auths.bind_password_helper=Attention: Le mot de passe est stocké en clair. Il est fortement recommandé d'utiliser un compte en lecture seule.
 auths.user_base=Utilisateur Search Base
@@ -1550,4 +1551,3 @@ error.failed_retrieval_gpg_keys=Impossible de récupérer la clé liée au compt
 [units]
 error.no_unit_allowed_repo=Vous n'avez accès à aucune fonctionnalité sur ce dépôt
 error.unit_not_allowed=Vous n'avez pas la permission d'accéder à cette fonctionnalité
-

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -44,11 +44,12 @@
 						<label for="port">{{.i18n.Tr "admin.auths.port"}}</label>
 						<input id="port" name="port" value="{{$cfg.Port}}"  placeholder="e.g. 636" required>
 					</div>
+					<div class="field">
+						<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
+						<input id="bind_dn" name="bind_dn" value="{{$cfg.BindDN}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
+						<p class="help text blue">{{.i18n.Tr "admin.auths.bind_dn_helper"}}</p>
+					</div>
 					{{if .Source.IsLDAP}}
-						<div class="field">
-							<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
-							<input id="bind_dn" name="bind_dn" value="{{$cfg.BindDN}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
-						</div>
 						<input class="fake" type="password">
 						<div class="field">
 							<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>

--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -20,9 +20,10 @@
 		<label for="port">{{.i18n.Tr "admin.auths.port"}}</label>
 		<input id="port" name="port" value="{{.port}}"  placeholder="e.g. 636">
 	</div>
-	<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
+	<div class="ldap dldap field {{if not (or (eq .type 2) (eq .type 5))}}hide{{end}}">
 		<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
 		<input id="bind_dn" name="bind_dn" value="{{.bind_dn}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
+		<p class="help text blue">{{.i18n.Tr "admin.auths.bind_dn_helper"}}</p>
 	</div>
 	<input class="fake" type="password">
 	<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">


### PR DESCRIPTION
These are the changes needed to allow authentication with Active Directory using LDAP Simple Authentication.

In Active Directory the user DN doesn't usually contain the user ID. Most look like this ` cn:Jane Doe, cn=users, dc=domain, dc=org`.  When using the simple bind LDAP, we would have to use the User full name as their login if we want to also use the same DN to search for the user info in AD. Therefore separating the value we use to bind to LDAP and the one we use for searching solve allows us to authenticate with AD.

![scr1](https://user-images.githubusercontent.com/348391/33224999-dbb9e186-d13d-11e7-95eb-2de2d71d83a1.png)

we can use the userPrincipalName to bind with Active Directory and a UserDN to search. Also, as the User DN we use to search for the user doesn't have the user ID, using fmt.sprintf is failing.