### PR TITLE
Enable content trust when building image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,4 +8,4 @@ DOCKER_REF := $(DOCKER_IMAGE):$(DOCKER_TAG)
 .PHONY: docker
 docker:
 	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" webhippie/golang:edge make clean generate build
-	docker build -t $(DOCKER_REF) .
+	docker build --disable-content-trust=false -t $(DOCKER_REF) .


### PR DESCRIPTION
Enable base image verification at docker build phase.