### PR TITLE
Update hard-coded version to 1.4.0-dev

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version holds the current Gitea version
-var Version = "1.3.0-dev"
+var Version = "1.4.0-dev"
 
 // Tags holds the build tags used
 var Tags = ""


### PR DESCRIPTION
Now that 1.3.0 is out the new target is 1.4.0

(See #2390 for more context if needed)