### PR TITLE
Don't print SQL in unit tests

### DIFF
--- a/models/unit_tests.go
+++ b/models/unit_tests.go
@@ -32,6 +32,10 @@ func CreateTestEngine(fixturesDir string) error {
 	if err = x.StoreEngine("InnoDB").Sync2(tables...); err != nil {
 		return err
 	}
+	switch os.Getenv("GITEA_UNIT_TESTS_VERBOSE") {
+	case "true", "1":
+		x.ShowSQL(true)
+	}
 
 	return InitFixtures(&testfixtures.SQLite{}, fixturesDir)
 }

--- a/models/unit_tests.go
+++ b/models/unit_tests.go
@@ -32,7 +32,6 @@ func CreateTestEngine(fixturesDir string) error {
 	if err = x.StoreEngine("InnoDB").Sync2(tables...); err != nil {
 		return err
 	}
-	x.ShowSQL(true)
 
 	return InitFixtures(&testfixtures.SQLite{}, fixturesDir)
 }


### PR DESCRIPTION
Currently, all SQL commands, from all tests, are printed to stdout (or maybe stderr?) when a unit test fails. This is too much output (thousands of lines) to be helpful as the default; you have to scroll through a bunch of unrelated output just to see which test failed.

Now, output will only be printed if the environment variable `$GITEA_UNIT_TESTS_VERBOSE` is set to true.