### PR TITLE
Removing disqus from docs site

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -2,7 +2,6 @@ baseurl: https://docs.gitea.io/
 languageCode: en-us
 title: Docs
 theme: gitea
-disqusShortname: gitea
 
 defaultContentLanguage: en-us
 defaultContentLanguageInSubdir: true


### PR DESCRIPTION
Gitea now has a forum which is probably a better venue for these types of conversations