### PR TITLE
Use unique name for docs docker build step in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -189,7 +189,7 @@ pipeline:
       - make clean
       - make build
 
-  docker:
+  docker_docs:
     image: plugins/docker:17.05
     pull: true
     secrets: [ docker_username, docker_password ]
@@ -201,7 +201,7 @@ pipeline:
       event: [ push ]
       branch: [ release/* ]
 
-  docker:
+  docker_docs:
     image: plugins/docker:17.05
     pull: true
     secrets: [ docker_username, docker_password ]


### PR DESCRIPTION
Otherwise drone may combine (or hide) the logs for the docs image
