### PR TITLE
Remove duplicated sanitize

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -38,7 +38,7 @@
 	<div class="ui attached table segment">
 		<div class="file-view {{if .IsMarkup}}markdown{{else if .IsRenderedHTML}}plain-text{{else if .IsTextFile}}code-view{{end}} has-emoji">
 			{{if .IsMarkup}}
-				{{if .FileContent}}{{.FileContent | Str2html}}{{end}}
+				{{if .FileContent}}{{.FileContent | Safe}}{{end}}
 			{{else if .IsRenderedHTML}}
 				<pre>{{if .FileContent}}{{.FileContent | Str2html}}{{end}}</pre>
 			{{else if not .IsTextFile}}


### PR DESCRIPTION
All markup content has been sanitize via https://github.com/go-gitea/gitea/blob/master/modules/markup/markup.go#L73, and `Str2html` is also call the same sanitize method. so remove the one on the template.