### PR TITLE
sendmail: correct option to set envelope-sender

### DIFF
--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -208,7 +208,7 @@ func (s *sendmailSender) Send(from string, to []string, msg io.WriterTo) error {
 	var closeError error
 	var waitError error
 
-	args := []string{"-F", from, "-i"}
+	args := []string{"-f", from, "-i"}
 	args = append(args, setting.MailService.SendmailArgs...)
 	args = append(args, to...)
 	log.Trace("Sending with: %s %v", setting.MailService.SendmailPath, args)


### PR DESCRIPTION
mailer doesn't set the correct options while calling sendmail. if
``mailer.FROM`` is set to ``"Gitea Webservice" <user@example.com>``
sendmail is called like this

``Sending with: sendmail [-F user@example.com -i alice@example.com]``

and doesn't set the envelope-sender. the option ``-F string`` set the
sender full name and is used only with messages that has no ``From``
message header.

set the envelope sender address with ``-f sender`` (lowercase ``f``)
works for me (fedora 27, x86_64, postfix-3.2.4, go1.9.1, gitea-1.3.0)