### PR TITLE
Convert tabs to spaces in .less files

### DIFF
--- a/public/less/_admin.less
+++ b/public/less/_admin.less
@@ -1,66 +1,66 @@
 .admin {
-	padding-top: 15px;
-	padding-bottom: @footer-margin * 2;
+    padding-top: 15px;
+    padding-bottom: @footer-margin * 2;
 
-	.table.segment {
-		padding: 0;
-		font-size: 13px;
+    .table.segment {
+        padding: 0;
+        font-size: 13px;
 
-		&:not(.striped) {
-			padding-top: 5px;
+        &:not(.striped) {
+            padding-top: 5px;
 
-			thead {
-				th:last-child {
-					padding-right: 5px !important;
-				}
-			}
-		}
+            thead {
+                th:last-child {
+                    padding-right: 5px !important;
+                }
+            }
+        }
 
-		th {
-			padding-top: 5px;
-			padding-bottom: 5px;
-		}
+        th {
+            padding-top: 5px;
+            padding-bottom: 5px;
+        }
 
-		&:not(.select) {
-			th, td {
-				&:first-of-type {
-					padding-left: 15px !important;
-				}
-			}
-		}
-	}
-	.ui.header,
-	.ui.segment {
-		box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
-	}
+        &:not(.select) {
+            th, td {
+                &:first-of-type {
+                    padding-left: 15px !important;
+                }
+            }
+        }
+    }
+    .ui.header,
+    .ui.segment {
+        box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
+    }
 
-	&.user {
-		.email {
-			max-width: 200px;
-		}
-	}
+    &.user {
+        .email {
+            max-width: 200px;
+        }
+    }
 
-	dl.admin-dl-horizontal {
-		padding: 20px;
-		margin: 0;
+    dl.admin-dl-horizontal {
+        padding: 20px;
+        margin: 0;
 
-		dd {
-			margin-left: 275px;
-		}
-		dt {
-			font-weight: bolder;
-			float: left;
-			width: 285px;
-			clear: left;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-		}
-	}
+        dd {
+            margin-left: 275px;
+        }
+        dt {
+            font-weight: bolder;
+            float: left;
+            width: 285px;
+            clear: left;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
 
-	&.config {
-		#test-mail-btn {
-			margin-left: 5px;
-		}
-	}
+    &.config {
+        #test-mail-btn {
+            margin-left: 5px;
+        }
+    }
 }

--- a/public/less/_dashboard.less
+++ b/public/less/_dashboard.less
@@ -1,158 +1,158 @@
 .dashboard {
-	padding-top: 15px;
-	padding-bottom: @footer-margin * 2;
+    padding-top: 15px;
+    padding-bottom: @footer-margin * 2;
 
-	&.feeds,
-	&.issues {
-		.context.user.menu {
-			z-index: 101;
-			min-width: 200px;
-			.ui.header {
-				font-size: 1rem;
-				text-transform: none;
-			}
-		}
-		.filter.menu {
-			.item {
-				text-align: left;
-				.text {
-					height: 16px;
-					vertical-align: middle;
-					&.truncate {
-						width: 85%;
-					}
-				}
-				.floating.label {
-					top: 7px;
-					left: 90%;
-					width: 15%;
-				}
-			}
+    &.feeds,
+    &.issues {
+        .context.user.menu {
+            z-index: 101;
+            min-width: 200px;
+            .ui.header {
+                font-size: 1rem;
+                text-transform: none;
+            }
+        }
+        .filter.menu {
+            .item {
+                text-align: left;
+                .text {
+                    height: 16px;
+                    vertical-align: middle;
+                    &.truncate {
+                        width: 85%;
+                    }
+                }
+                .floating.label {
+                    top: 7px;
+                    left: 90%;
+                    width: 15%;
+                }
+            }
 
-			// Sort
-			.jump.item {
-				margin: 1px;
-				padding-right: 0;
-			}
-			.menu {
-				max-height: 300px;
-				overflow-x: auto;
-				right: 0!important;
-				left: auto!important;
-			}
-		}
-		.ui.right .head.menu {
-			margin-top: -5px;
-			.item.active {
-				color: #d9453d;
-			}
-		}
-	}
+            // Sort
+            .jump.item {
+                margin: 1px;
+                padding-right: 0;
+            }
+            .menu {
+                max-height: 300px;
+                overflow-x: auto;
+                right: 0!important;
+                left: auto!important;
+            }
+        }
+        .ui.right .head.menu {
+            margin-top: -5px;
+            .item.active {
+                color: #d9453d;
+            }
+        }
+    }
 }
 
 &.feeds {
-	.news {
-		> .ui.grid {
-			margin-left: auto;
-			margin-right: auto;
-		}
-		.ui.avatar {
-			margin-top: 13px;
-		}
-		p {
-			line-height: 1em;
-		}
-		.time-since {
-			font-size: 13px;
-		}
-		.issue.title {
-			width: 80%;
-		}
-		.push.news .content ul {
-			font-size: 13px;
-			list-style: none;
-			padding-left: 10px;
+    .news {
+        > .ui.grid {
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .ui.avatar {
+            margin-top: 13px;
+        }
+        p {
+            line-height: 1em;
+        }
+        .time-since {
+            font-size: 13px;
+        }
+        .issue.title {
+            width: 80%;
+        }
+        .push.news .content ul {
+            font-size: 13px;
+            list-style: none;
+            padding-left: 10px;
 
-			img {
-				margin-bottom: -2px;
-			}
-			.text.truncate {
-				width: 80%;
-				margin-bottom: -5px;
-			}
-		}
-		.commit-id {
-			font-family: Consolas, monospace;
-		}
-		code {
-			padding: 1px;
-			font-size: 85%;
-			background-color: rgba(0, 0, 0, 0.04);
-			border-radius: 3px;
-			word-break: break-all;
-		}
-	}
+            img {
+                margin-bottom: -2px;
+            }
+            .text.truncate {
+                width: 80%;
+                margin-bottom: -5px;
+            }
+        }
+        .commit-id {
+            font-family: Consolas, monospace;
+        }
+        code {
+            padding: 1px;
+            font-size: 85%;
+            background-color: rgba(0, 0, 0, 0.04);
+            border-radius: 3px;
+            word-break: break-all;
+        }
+    }
 
-	.list {
-		.header {
-			.ui.label {
-				margin-top: -4px;
-				padding: 4px 5px;
-				font-weight: normal;
-			}
+    .list {
+        .header {
+            .ui.label {
+                margin-top: -4px;
+                padding: 4px 5px;
+                font-weight: normal;
+            }
 
-			.plus.icon {
-				margin-top: 5px;
-			}
-		}
-		ul {
-			list-style: none;
-			margin: 0;
-			padding-left: 0;
+            .plus.icon {
+                margin-top: 5px;
+            }
+        }
+        ul {
+            list-style: none;
+            margin: 0;
+            padding-left: 0;
 
-			li {
-				&:not(:last-child) {
-					border-bottom: 1px solid #EAEAEA;
-				}
+            li {
+                &:not(:last-child) {
+                    border-bottom: 1px solid #EAEAEA;
+                }
 
-				&.private {
-					background-color: #fcf8e9;
-				}
+                &.private {
+                    background-color: #fcf8e9;
+                }
 
-				a {
-					padding: 6px 1.2em;
-					display: block;
+                a {
+                    padding: 6px 1.2em;
+                    display: block;
 
-					.octicon {
-						color: #888;
+                    .octicon {
+                        color: #888;
 
-						&.rear {
-					    font-size: 15px;
-						}
-					}
-					.star-num {
-						font-size: 12px;
-					}
-				}
-			}
-		}
+                        &.rear {
+                        font-size: 15px;
+                        }
+                    }
+                    .star-num {
+                        font-size: 12px;
+                    }
+                }
+            }
+        }
 
-		.repo-owner-name-list {
-			.item-name {
-				max-width: 70%;
-		    margin-bottom: -4px;
-			}
-		}
+        .repo-owner-name-list {
+            .item-name {
+                max-width: 70%;
+            margin-bottom: -4px;
+            }
+        }
 
-		#collaborative-repo-list {
-			.owner-and-repo {
-				max-width: 80%;
-		    margin-bottom: -5px;
-			}
-			.owner-name {
-				max-width: 120px;
-		    margin-bottom: -5px;
-			}
-		}
-	}
+        #collaborative-repo-list {
+            .owner-and-repo {
+                max-width: 80%;
+            margin-bottom: -5px;
+            }
+            .owner-name {
+                max-width: 120px;
+            margin-bottom: -5px;
+            }
+        }
+    }
 }

--- a/public/less/_editor.less
+++ b/public/less/_editor.less
@@ -1,12 +1,12 @@
 .CodeMirror {
-	font: 14px Consolas, "Liberation Mono", Menlo, Courier, monospace;
-	&.cm-s-default {
-		  border-radius: 3px;
-		  padding: 0 !important;
-	}
-	.cm-comment {
-		background: inherit !important;
-	}
+    font: 14px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    &.cm-s-default {
+          border-radius: 3px;
+          padding: 0 !important;
+    }
+    .cm-comment {
+        background: inherit !important;
+    }
 }
 .repository.file.editor .tab[data-tab="write"] {
     padding: 0 !important;

--- a/public/less/_emojify.less
+++ b/public/less/_emojify.less
@@ -1,6 +1,6 @@
 .emoji {
-	width: 1.5em;
-	height: 1.5em;
-	display: inline-block;
-	background-size: contain;
+    width: 1.5em;
+    height: 1.5em;
+    display: inline-block;
+    background-size: contain;
 }

--- a/public/less/_explore.less
+++ b/public/less/_explore.less
@@ -1,8 +1,8 @@
 .explore {
-	padding-top: 15px;
-	padding-bottom: @footer-margin * 2;
+    padding-top: 15px;
+    padding-bottom: @footer-margin * 2;
 
-	.navbar {
+    .navbar {
         justify-content: center;
         padding-top: 15px !important;
         margin-top: -15px !important;
@@ -10,80 +10,80 @@
         background-color: #FAFAFA !important;
         border-width: 1px !important;
 
-		.octicon {
-			width: 16px;
-			text-align: center;
-		}
-	}
+        .octicon {
+            width: 16px;
+            text-align: center;
+        }
+    }
 }
 
 .ui.repository.list {
-	.item {
-		padding-bottom: 25px;
+    .item {
+        padding-bottom: 25px;
 
-		&:not(:first-child) {
-			border-top: 1px solid #eee;
-			padding-top: 25px;
-		}
+        &:not(:first-child) {
+            border-top: 1px solid #eee;
+            padding-top: 25px;
+        }
 
-		.ui.header {
-			font-size: 1.5rem;
-			padding-bottom: 10px;
+        .ui.header {
+            font-size: 1.5rem;
+            padding-bottom: 10px;
 
-			.name {
-				word-break: break-all;
-			}
+            .name {
+                word-break: break-all;
+            }
 
-			.metas {
-				color: #888;
-				font-size: 14px;
-				font-weight: normal;
-				span:not(:last-child) {
-					margin-right: 5px;
-				}
-			}
-		}
-		.time {
-			font-size: 12px;
-			color: #808080;
-		}
-	}
+            .metas {
+                color: #888;
+                font-size: 14px;
+                font-weight: normal;
+                span:not(:last-child) {
+                    margin-right: 5px;
+                }
+            }
+        }
+        .time {
+            font-size: 12px;
+            color: #808080;
+        }
+    }
 }
 
 .ui.repository.branches  {
-	.time{
-		font-size: 12px;
-		color: #808080;
-	}
+    .time{
+        font-size: 12px;
+        color: #808080;
+    }
 }
 
 .ui.user.list {
-	.item {
-		padding-bottom: 25px;
+    .item {
+        padding-bottom: 25px;
 
-		&:not(:first-child) {
-			border-top: 1px solid #eee;
-			padding-top: 25px;
-		}
+        &:not(:first-child) {
+            border-top: 1px solid #eee;
+            padding-top: 25px;
+        }
 
-		.ui.avatar.image {
-			width: 40px;
-			height: 40px;
-		}
+        .ui.avatar.image {
+            width: 40px;
+            height: 40px;
+        }
 
-		.description {
-			margin-top: 5px;
+        .description {
+            margin-top: 5px;
 
-			.octicon:not(:first-child) {
-				margin-left: 5px;
-			}
+            .octicon:not(:first-child) {
+                margin-left: 5px;
+            }
 
-			a {
-				color: #333;
-				&:hover {
-					text-decoration: underline;
-				}
-			}
-		}
-	}
+            a {
+                color: #333;
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
 }

--- a/public/less/_form.less
+++ b/public/less/_form.less
@@ -1,144 +1,144 @@
 .form {
-	.help {
-		color: #999999;
-		padding-top: .6em;
-		padding-bottom: .6em;
-		display: inline-block;
-	}
+    .help {
+        color: #999999;
+        padding-top: .6em;
+        padding-bottom: .6em;
+        display: inline-block;
+    }
 }
 .ui.attached.header {
-	background: #f0f0f0;
-	.right {
-		margin-top: -5px;
-		.button {
-			padding: 8px 10px;
-			font-weight: normal;
-		}
-	}
+    background: #f0f0f0;
+    .right {
+        margin-top: -5px;
+        .button {
+            padding: 8px 10px;
+            font-weight: normal;
+        }
+    }
 }
 
 @create-page-form-input-padding: 250px !important;
 #create-page-form {
-	form {
-		margin: auto;
-		width: 800px!important;
-		.ui.message {
-			text-align: center;
-		}
-		.header {
-			padding-left: @create-page-form-input-padding+30px;
-		}
-		.inline.field > label {
-			text-align: right;
-			width: @create-page-form-input-padding;
-			word-wrap: break-word;
-		}
-		.help {
-			margin-left: @create-page-form-input-padding+15px;
-		}
-		.optional .title {
-			margin-left: @create-page-form-input-padding;
-		}
-		input,
-		textarea {
-			width: 50%!important;
-		}
-	}
+    form {
+        margin: auto;
+        width: 800px!important;
+        .ui.message {
+            text-align: center;
+        }
+        .header {
+            padding-left: @create-page-form-input-padding+30px;
+        }
+        .inline.field > label {
+            text-align: right;
+            width: @create-page-form-input-padding;
+            word-wrap: break-word;
+        }
+        .help {
+            margin-left: @create-page-form-input-padding+15px;
+        }
+        .optional .title {
+            margin-left: @create-page-form-input-padding;
+        }
+        input,
+        textarea {
+            width: 50%!important;
+        }
+    }
 }
 
 .signin {
-	.oauth2{
-		div {
-		  display: inline-block;
-			p {
-			  margin: 10px 5px 0 0;
-			  float: left;
-			}
-		}
-		a {
-		  margin-right: 3px;
-			&:last-child {
-			  margin-right: 0px;
-			}
-		}
-		img {
-		  width: 32px;
-		  height: 32px;
-		  &.openidConnect {
-			width: auto;
-		  }
-		}
-	}
+    .oauth2{
+        div {
+          display: inline-block;
+            p {
+              margin: 10px 5px 0 0;
+              float: left;
+            }
+        }
+        a {
+          margin-right: 3px;
+            &:last-child {
+              margin-right: 0px;
+            }
+        }
+        img {
+          width: 32px;
+          height: 32px;
+          &.openidConnect {
+            width: auto;
+          }
+        }
+    }
 }
 .user.activate,
 .user.forgot.password,
 .user.reset.password,
 .user.signin,
 .user.signup {
-	@input-padding: 200px!important;
-	#create-page-form;
-	form {
-		width: 700px!important;
-		.header {
-			padding-left: 0 !important;
-			text-align: center;
-		}
-		.inline.field > label {
-			width: @input-padding;
-		}
-	}
+    @input-padding: 200px!important;
+    #create-page-form;
+    form {
+        width: 700px!important;
+        .header {
+            padding-left: 0 !important;
+            text-align: center;
+        }
+        .inline.field > label {
+            width: @input-padding;
+        }
+    }
 }
 
 .repository {
-	&.new.repo,
-	&.new.migrate,
-	&.new.fork {
-		#create-page-form;
-		form {
-			.dropdown {
-				.dropdown.icon {
-					margin-top: -7px!important;
-				}
-				.text {
-					margin-right: 0!important;
-					i {
-						margin-right: 0!important;
-					}
-				}
-			}
-			.header {
-				padding-left: 0 !important;
-				text-align: center;
-			}
-		}
-	}
+    &.new.repo,
+    &.new.migrate,
+    &.new.fork {
+        #create-page-form;
+        form {
+            .dropdown {
+                .dropdown.icon {
+                    margin-top: -7px!important;
+                }
+                .text {
+                    margin-right: 0!important;
+                    i {
+                        margin-right: 0!important;
+                    }
+                }
+            }
+            .header {
+                padding-left: 0 !important;
+                text-align: center;
+            }
+        }
+    }
 
-	&.new.repo {
-		.ui.form {
-			.selection.dropdown:not(.owner) {
-				width: 50%!important;
-			}
-			#auto-init {
-				margin-left: @create-page-form-input-padding+15px;
-			}
-		}
-	}
+    &.new.repo {
+        .ui.form {
+            .selection.dropdown:not(.owner) {
+                width: 50%!important;
+            }
+            #auto-init {
+                margin-left: @create-page-form-input-padding+15px;
+            }
+        }
+    }
 }
 
 .new.webhook {
-	form {
-		.help {
-			margin-left: 25px;
-		}
-	}
+    form {
+        .help {
+            margin-left: 25px;
+        }
+    }
 }
 
 .new.webhook {
-	.events.fields {
-		.column {
-			padding-left: 40px;
-		}
-	}
+    .events.fields {
+        .column {
+            padding-left: 40px;
+        }
+    }
 }
 
 .githook {

--- a/public/less/_home.less
+++ b/public/less/_home.less
@@ -1,39 +1,39 @@
 .home {
-	padding-bottom: @footer-margin * 2;
-	.logo {
-		max-width: 220px;
-	}
-	.hero {
-		h1, h2 {
-			font-family: 'PT Sans Narrow', sans-serif, 'Microsoft YaHei';
-		}
-		h1 {
-			font-size: 5.5em;
-		}
-		h2 {
-			font-size: 3em;
-		}
-		.octicon {
-			color: #5aa509;
-			font-size: 40px;
-			width: 50px;
-		}
-		&.header {
-			font-size: 20px;
-		}
-	}
-	p.large {
-		font-size: 16px
-	}
-	.stackable {
-		padding-top: 30px;
-	}
-	a {
-		color: #5aa509;
-	}
+    padding-bottom: @footer-margin * 2;
+    .logo {
+        max-width: 220px;
+    }
+    .hero {
+        h1, h2 {
+            font-family: 'PT Sans Narrow', sans-serif, 'Microsoft YaHei';
+        }
+        h1 {
+            font-size: 5.5em;
+        }
+        h2 {
+            font-size: 3em;
+        }
+        .octicon {
+            color: #5aa509;
+            font-size: 40px;
+            width: 50px;
+        }
+        &.header {
+            font-size: 20px;
+        }
+    }
+    p.large {
+        font-size: 16px
+    }
+    .stackable {
+        padding-top: 30px;
+    }
+    a {
+        color: #5aa509;
+    }
 }
 
 .signup {
-	padding-top: 15px;
-	padding-bottom: @footer-margin * 2;
+    padding-top: 15px;
+    padding-bottom: @footer-margin * 2;
 }

--- a/public/less/_install.less
+++ b/public/less/_install.less
@@ -1,31 +1,31 @@
 .install {
-	padding-top: 45px;
-	padding-bottom: @footer-margin * 2;
-	form {
-		@input-padding: 320px !important;
-		label {
-			text-align: right;
-			width: @input-padding;
-		}
-		input {
-			width: 35% !important;
-		}
-		.field {
-			text-align: left;
-			.help {
-				margin-left: @input-padding+15px;
-			}
-			&.optional .title {
-				margin-left: 38%;
-			}
-		}
-	}
-	.ui {
-		.checkbox {
-			margin-left: 40% !important;
-			label {
-				width: auto !important;
-			}
-		}
-	}
+    padding-top: 45px;
+    padding-bottom: @footer-margin * 2;
+    form {
+        @input-padding: 320px !important;
+        label {
+            text-align: right;
+            width: @input-padding;
+        }
+        input {
+            width: 35% !important;
+        }
+        .field {
+            text-align: left;
+            .help {
+                margin-left: @input-padding+15px;
+            }
+            &.optional .title {
+                margin-left: 38%;
+            }
+        }
+    }
+    .ui {
+        .checkbox {
+            margin-left: 40% !important;
+            label {
+                width: auto !important;
+            }
+        }
+    }
 }

--- a/public/less/_markdown.less
+++ b/public/less/_markdown.less
@@ -1,492 +1,492 @@
 .markdown:not(code) {
-	overflow: hidden;
-	font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
-	font-size: 16px;
-	line-height: 1.6 !important;
-	word-wrap: break-word;
-
-	&.file-view {
-		padding: 2em 2em 2em !important;
-	}
-
-	>*:first-child {
-		margin-top: 0 !important;
-	}
-
-	>*:last-child {
-		margin-bottom: 0 !important;
-	}
-
-	a:not([href]) {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	.absent {
-		color: #c00;
-	}
-
-	.anchor {
-		position: absolute;
-		top: 0;
-		left: 0;
-		display: block;
-		padding-right: 6px;
-		padding-left: 30px;
-		margin-left: -30px;
-	}
-
-	.anchor:focus {
-		outline: none;
-	}
-
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		position: relative;
-		margin-top: 1em;
-		margin-bottom: 16px;
-		font-weight: bold;
-		line-height: 1.4;
-
-		&:first-of-type {
-			margin-top: 0 !important;
-		}
-	}
-
-	h1 .octicon-link,
-	h2 .octicon-link,
-	h3 .octicon-link,
-	h4 .octicon-link,
-	h5 .octicon-link,
-	h6 .octicon-link {
-		display:none;
-		color:#000;
-		vertical-align:middle;
-	}
-
-	h1:hover .anchor,
-	h2:hover .anchor,
-	h3:hover .anchor,
-	h4:hover .anchor,
-	h5:hover .anchor,
-	h6:hover .anchor {
-		padding-left:8px;
-		margin-left:-30px;
-		text-decoration:none;
-	}
-
-	h1:hover .anchor .octicon-link,
-	h2:hover .anchor .octicon-link,
-	h3:hover .anchor .octicon-link,
-	h4:hover .anchor .octicon-link,
-	h5:hover .anchor .octicon-link,
-	h6:hover .anchor .octicon-link {
-		display:inline-block;
-	}
-
-	h1 tt,
-	h1 code,
-	h2 tt,
-	h2 code,
-	h3 tt,
-	h3 code,
-	h4 tt,
-	h4 code,
-	h5 tt,
-	h5 code,
-	h6 tt,
-	h6 code {
-		font-size:inherit;
-	}
-
-	h1 {
-		padding-bottom:0.3em;
-		font-size:2.25em;
-		line-height:1.2;
-		border-bottom:1px solid #eee;
-	}
-
-	h1 .anchor {
-		line-height:1;
-	}
-
-	h2 {
-		padding-bottom:0.3em;
-		font-size:1.75em;
-		line-height:1.225;
-		border-bottom:1px solid #eee;
-	}
-
-	h2 .anchor {
-		line-height:1;
-	}
-
-	h3 {
-		font-size:1.5em;
-		line-height:1.43;
-	}
-
-	h3 .anchor {
-		line-height:1.2;
-	}
-
-	h4 {
-		font-size:1.25em;
-	}
-
-	h4 .anchor {
-		line-height:1.2;
-	}
-
-	h5 {
-		font-size:1em;
-	}
-
-	h5 .anchor {
-		line-height:1.1;
-	}
-
-	h6 {
-		font-size:1em;color:#777;
-	}
-
-	h6 .anchor {
-		line-height:1.1;
-	}
-
-	p,
-	blockquote,
-	ul,
-	ol,
-	dl,
-	table,
-	pre {
-		margin-top: 0;
-		margin-bottom: 16px;
-	}
-	blockquote {
-		margin-left: 0;
-	}
-
-	hr {
-		height:4px;
-		padding:0;
-		margin:16px 0;
-		background-color:#e7e7e7;
-		border:0 none;
-	}
-
-	ul,
-	ol {
-		padding-left:2em;
-	}
-
-	ul.no-list,
-	ol.no-list {
-		padding:0;
-		list-style-type:none;
-	}
-
-	ul ul,
-	ul ol,
-	ol ol,
-	ol ul {
-		margin-top:0;
-		margin-bottom:0;
-	}
-
-	ol ol,
-	ul ol {
-		list-style-type: lower-roman;
-	}
-
-	li>p {
-		margin-top:0;
-	}
-
-	dl {
-		padding:0;
-	}
-
-	dl dt {
-		padding:0;
-		margin-top:16px;
-		font-size:1em;
-		font-style:italic;
-		font-weight:bold;
-	}
-
-	dl dd {
-		padding:0 16px;
-		margin-bottom:16px;
-	}
-
-	blockquote {
-		padding:0 15px;
-		color:#777;
-		border-left:4px solid #ddd;
-	}
-
-	blockquote>:first-child {
-		margin-top:0;
-	}
-
-	blockquote>:last-child {
-		margin-bottom:0;
-	}
-
-	table {
-		width:auto;
-		overflow:auto;
-		word-break:normal;
-		word-break:keep-all;
-	}
-
-	table th {
-		font-weight:bold;
-	}
-
-	table th,
-	table td {
-		padding: 6px 13px !important;
-		border: 1px solid #ddd !important;
-	}
-
-	table tr {
-		background-color:#fff;
-		border-top:1px solid #ccc;
-	}
-
-	table tr:nth-child(2n) {
-		background-color:#f8f8f8;
-	}
-
-	img {
-		max-width:100%;
-		box-sizing:border-box;
-	}
-
-	.emoji {
-		max-width:none;
-	}
-
-	span.frame {
-		display:block;
-		overflow:hidden;
-	}
-
-	span.frame>span {
-		display:block;
-		float:left;
-		width:auto;
-		padding:7px;
-		margin:13px 0 0;
-		overflow:hidden;
-		border:1px solid #ddd;
-	}
-
-	span.frame span img {
-		display:block;
-		float:left;
-	}
-
-	span.frame span span {
-		display:block;
-		padding:5px 0 0;
-		clear:both;
-		color:#333;
-	}
-
-	span.align-center {
-		display:block;
-		overflow:hidden;
-		clear:both;
-	}
-
-	span.align-center>span {
-		display:block;
-		margin:13px auto 0;
-		overflow:hidden;
-		text-align:center;
-	}
-
-	span.align-center span img {
-		margin:0 auto;
-		text-align:center;
-	}
-
-	span.align-right {
-		display:block;
-		overflow:hidden;
-		clear:both;
-	}
-
-	span.align-right>span {
-		display:block;
-		margin:13px 0 0;
-		overflow:hidden;
-		text-align:right;
-	}
-
-	span.align-right span img {
-		margin:0;
-		text-align:right;
-	}
-
-	span.float-left {
-		display:block;
-		float:left;
-		margin-right:13px;
-		overflow:hidden;
-	}
-
-	span.float-left span {
-		margin:13px 0 0;
-	}
-
-	span.float-right {
-		display:block;
-		float:right;
-		margin-left:13px;
-		overflow:hidden;
-	}
-
-	span.float-right>span {
-		display:block;
-		margin:13px auto 0;
-		overflow:hidden;
-		text-align:right;
-	}
-
-	code,
-	tt {
-		padding:0;
-		padding-top:0.2em;
-		padding-bottom:0.2em;
-		margin:0;
-		font-size:85%;
-		background-color:rgba(0,0,0,0.04);
-		border-radius:3px;
-	}
-
-	code:before,
-	code:after,
-	tt:before,
-	tt:after {
-		letter-spacing:-0.2em;
-		content:"\00a0";
-	}
-
-	code br,
-	tt br {
-		display:none;
-	}
-
-	del code {
-		text-decoration:inherit;
-	}
-
-	pre>code {
-		padding:0;
-		margin:0;
-		font-size:100%;
-		word-break:normal;
-		white-space:pre;
-		background:transparent;
-		border:0;
-	}
-
-	.highlight {
-		margin-bottom:16px;
-	}
-
-	.highlight pre,
-	pre {
-		padding:16px;
-		overflow:auto;
-		font-size:85%;
-		line-height:1.45;
-		background-color:#f7f7f7;
-		border-radius:3px;
-	}
-
-	.highlight pre {
-		margin-bottom:0;
-		word-break:normal;
-	}
-
-	pre {
-		word-wrap:normal;
-	}
-
-	pre code,
-	pre tt {
-		display:inline;
-		max-width:initial;
-		padding:0;
-		margin:0;
-		overflow:initial;
-		line-height:inherit;
-		word-wrap:normal;
-		background-color:transparent;
-		border:0;
-	}
-
-	pre code:before,
-	pre code:after,
-	pre tt:before,
-	pre tt:after {
-		content:normal;
-	}
-
-	kbd {
-		display:inline-block;
-		padding:3px 5px;
-		font-size:11px;
-		line-height:10px;
-		color:#555;
-		vertical-align:middle;
-		background-color:#fcfcfc;
-		border:solid 1px #ccc;
-		border-bottom-color:#bbb;
-		border-radius:3px;
-		box-shadow:inset 0 -1px 0 #bbb;
-	}
-
-	input[type="checkbox"] {
-		vertical-align: middle !important;
-	}
-
-	.csv-data td,
-	.csv-data th {
-		padding:5px;
-		overflow:hidden;
-		font-size:12px;
-		line-height:1;
-		text-align:left;
-		white-space:nowrap;
-	}
-
-	.csv-data .blob-num {
-		padding:10px 8px 9px;
-		text-align:right;
-		background:#fff;border:0;
-	}
-
-	.csv-data tr {
-		border-top:0;
-	}
-
-	.csv-data th {
-		font-weight:bold;
-		background:#f8f8f8;border-top:0;
-	}
-
-	.ui.list .list, ol.ui.list ol, ul.ui.list ul {
-		padding-left: 2em;
-	}
+    overflow: hidden;
+    font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
+    font-size: 16px;
+    line-height: 1.6 !important;
+    word-wrap: break-word;
+
+    &.file-view {
+        padding: 2em 2em 2em !important;
+    }
+
+    >*:first-child {
+        margin-top: 0 !important;
+    }
+
+    >*:last-child {
+        margin-bottom: 0 !important;
+    }
+
+    a:not([href]) {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .absent {
+        color: #c00;
+    }
+
+    .anchor {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: block;
+        padding-right: 6px;
+        padding-left: 30px;
+        margin-left: -30px;
+    }
+
+    .anchor:focus {
+        outline: none;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        position: relative;
+        margin-top: 1em;
+        margin-bottom: 16px;
+        font-weight: bold;
+        line-height: 1.4;
+
+        &:first-of-type {
+            margin-top: 0 !important;
+        }
+    }
+
+    h1 .octicon-link,
+    h2 .octicon-link,
+    h3 .octicon-link,
+    h4 .octicon-link,
+    h5 .octicon-link,
+    h6 .octicon-link {
+        display:none;
+        color:#000;
+        vertical-align:middle;
+    }
+
+    h1:hover .anchor,
+    h2:hover .anchor,
+    h3:hover .anchor,
+    h4:hover .anchor,
+    h5:hover .anchor,
+    h6:hover .anchor {
+        padding-left:8px;
+        margin-left:-30px;
+        text-decoration:none;
+    }
+
+    h1:hover .anchor .octicon-link,
+    h2:hover .anchor .octicon-link,
+    h3:hover .anchor .octicon-link,
+    h4:hover .anchor .octicon-link,
+    h5:hover .anchor .octicon-link,
+    h6:hover .anchor .octicon-link {
+        display:inline-block;
+    }
+
+    h1 tt,
+    h1 code,
+    h2 tt,
+    h2 code,
+    h3 tt,
+    h3 code,
+    h4 tt,
+    h4 code,
+    h5 tt,
+    h5 code,
+    h6 tt,
+    h6 code {
+        font-size:inherit;
+    }
+
+    h1 {
+        padding-bottom:0.3em;
+        font-size:2.25em;
+        line-height:1.2;
+        border-bottom:1px solid #eee;
+    }
+
+    h1 .anchor {
+        line-height:1;
+    }
+
+    h2 {
+        padding-bottom:0.3em;
+        font-size:1.75em;
+        line-height:1.225;
+        border-bottom:1px solid #eee;
+    }
+
+    h2 .anchor {
+        line-height:1;
+    }
+
+    h3 {
+        font-size:1.5em;
+        line-height:1.43;
+    }
+
+    h3 .anchor {
+        line-height:1.2;
+    }
+
+    h4 {
+        font-size:1.25em;
+    }
+
+    h4 .anchor {
+        line-height:1.2;
+    }
+
+    h5 {
+        font-size:1em;
+    }
+
+    h5 .anchor {
+        line-height:1.1;
+    }
+
+    h6 {
+        font-size:1em;color:#777;
+    }
+
+    h6 .anchor {
+        line-height:1.1;
+    }
+
+    p,
+    blockquote,
+    ul,
+    ol,
+    dl,
+    table,
+    pre {
+        margin-top: 0;
+        margin-bottom: 16px;
+    }
+    blockquote {
+        margin-left: 0;
+    }
+
+    hr {
+        height:4px;
+        padding:0;
+        margin:16px 0;
+        background-color:#e7e7e7;
+        border:0 none;
+    }
+
+    ul,
+    ol {
+        padding-left:2em;
+    }
+
+    ul.no-list,
+    ol.no-list {
+        padding:0;
+        list-style-type:none;
+    }
+
+    ul ul,
+    ul ol,
+    ol ol,
+    ol ul {
+        margin-top:0;
+        margin-bottom:0;
+    }
+
+    ol ol,
+    ul ol {
+        list-style-type: lower-roman;
+    }
+
+    li>p {
+        margin-top:0;
+    }
+
+    dl {
+        padding:0;
+    }
+
+    dl dt {
+        padding:0;
+        margin-top:16px;
+        font-size:1em;
+        font-style:italic;
+        font-weight:bold;
+    }
+
+    dl dd {
+        padding:0 16px;
+        margin-bottom:16px;
+    }
+
+    blockquote {
+        padding:0 15px;
+        color:#777;
+        border-left:4px solid #ddd;
+    }
+
+    blockquote>:first-child {
+        margin-top:0;
+    }
+
+    blockquote>:last-child {
+        margin-bottom:0;
+    }
+
+    table {
+        width:auto;
+        overflow:auto;
+        word-break:normal;
+        word-break:keep-all;
+    }
+
+    table th {
+        font-weight:bold;
+    }
+
+    table th,
+    table td {
+        padding: 6px 13px !important;
+        border: 1px solid #ddd !important;
+    }
+
+    table tr {
+        background-color:#fff;
+        border-top:1px solid #ccc;
+    }
+
+    table tr:nth-child(2n) {
+        background-color:#f8f8f8;
+    }
+
+    img {
+        max-width:100%;
+        box-sizing:border-box;
+    }
+
+    .emoji {
+        max-width:none;
+    }
+
+    span.frame {
+        display:block;
+        overflow:hidden;
+    }
+
+    span.frame>span {
+        display:block;
+        float:left;
+        width:auto;
+        padding:7px;
+        margin:13px 0 0;
+        overflow:hidden;
+        border:1px solid #ddd;
+    }
+
+    span.frame span img {
+        display:block;
+        float:left;
+    }
+
+    span.frame span span {
+        display:block;
+        padding:5px 0 0;
+        clear:both;
+        color:#333;
+    }
+
+    span.align-center {
+        display:block;
+        overflow:hidden;
+        clear:both;
+    }
+
+    span.align-center>span {
+        display:block;
+        margin:13px auto 0;
+        overflow:hidden;
+        text-align:center;
+    }
+
+    span.align-center span img {
+        margin:0 auto;
+        text-align:center;
+    }
+
+    span.align-right {
+        display:block;
+        overflow:hidden;
+        clear:both;
+    }
+
+    span.align-right>span {
+        display:block;
+        margin:13px 0 0;
+        overflow:hidden;
+        text-align:right;
+    }
+
+    span.align-right span img {
+        margin:0;
+        text-align:right;
+    }
+
+    span.float-left {
+        display:block;
+        float:left;
+        margin-right:13px;
+        overflow:hidden;
+    }
+
+    span.float-left span {
+        margin:13px 0 0;
+    }
+
+    span.float-right {
+        display:block;
+        float:right;
+        margin-left:13px;
+        overflow:hidden;
+    }
+
+    span.float-right>span {
+        display:block;
+        margin:13px auto 0;
+        overflow:hidden;
+        text-align:right;
+    }
+
+    code,
+    tt {
+        padding:0;
+        padding-top:0.2em;
+        padding-bottom:0.2em;
+        margin:0;
+        font-size:85%;
+        background-color:rgba(0,0,0,0.04);
+        border-radius:3px;
+    }
+
+    code:before,
+    code:after,
+    tt:before,
+    tt:after {
+        letter-spacing:-0.2em;
+        content:"\00a0";
+    }
+
+    code br,
+    tt br {
+        display:none;
+    }
+
+    del code {
+        text-decoration:inherit;
+    }
+
+    pre>code {
+        padding:0;
+        margin:0;
+        font-size:100%;
+        word-break:normal;
+        white-space:pre;
+        background:transparent;
+        border:0;
+    }
+
+    .highlight {
+        margin-bottom:16px;
+    }
+
+    .highlight pre,
+    pre {
+        padding:16px;
+        overflow:auto;
+        font-size:85%;
+        line-height:1.45;
+        background-color:#f7f7f7;
+        border-radius:3px;
+    }
+
+    .highlight pre {
+        margin-bottom:0;
+        word-break:normal;
+    }
+
+    pre {
+        word-wrap:normal;
+    }
+
+    pre code,
+    pre tt {
+        display:inline;
+        max-width:initial;
+        padding:0;
+        margin:0;
+        overflow:initial;
+        line-height:inherit;
+        word-wrap:normal;
+        background-color:transparent;
+        border:0;
+    }
+
+    pre code:before,
+    pre code:after,
+    pre tt:before,
+    pre tt:after {
+        content:normal;
+    }
+
+    kbd {
+        display:inline-block;
+        padding:3px 5px;
+        font-size:11px;
+        line-height:10px;
+        color:#555;
+        vertical-align:middle;
+        background-color:#fcfcfc;
+        border:solid 1px #ccc;
+        border-bottom-color:#bbb;
+        border-radius:3px;
+        box-shadow:inset 0 -1px 0 #bbb;
+    }
+
+    input[type="checkbox"] {
+        vertical-align: middle !important;
+    }
+
+    .csv-data td,
+    .csv-data th {
+        padding:5px;
+        overflow:hidden;
+        font-size:12px;
+        line-height:1;
+        text-align:left;
+        white-space:nowrap;
+    }
+
+    .csv-data .blob-num {
+        padding:10px 8px 9px;
+        text-align:right;
+        background:#fff;border:0;
+    }
+
+    .csv-data tr {
+        border-top:0;
+    }
+
+    .csv-data th {
+        font-weight:bold;
+        background:#f8f8f8;border-top:0;
+    }
+
+    .ui.list .list, ol.ui.list ol, ul.ui.list ul {
+        padding-left: 2em;
+    }
 }

--- a/public/less/_organization.less
+++ b/public/less/_organization.less
@@ -1,162 +1,162 @@
 .organization {
-	padding-top: 15px;
-	padding-bottom: @footer-margin * 2;
+    padding-top: 15px;
+    padding-bottom: @footer-margin * 2;
 
-	.head {
-		.ui.header {
-			.text {
-				vertical-align: middle;
-				font-size: 1.6rem;
-				margin-left: 15px;
-			}
-			.ui.right {
-				margin-top: 5px;
-			}
-		}
-	}
+    .head {
+        .ui.header {
+            .text {
+                vertical-align: middle;
+                font-size: 1.6rem;
+                margin-left: 15px;
+            }
+            .ui.right {
+                margin-top: 5px;
+            }
+        }
+    }
 
-	&.new.org {
-		#create-page-form;
-		form {
-			.header {
-				padding-left: 0 !important;
-				text-align: center;
-			}
-		}
-	}
+    &.new.org {
+        #create-page-form;
+        form {
+            .header {
+                padding-left: 0 !important;
+                text-align: center;
+            }
+        }
+    }
 
-	&.options {
-		input {
-			min-width: 300px;
-		}
-	}
+    &.options {
+        input {
+            min-width: 300px;
+        }
+    }
 
-	&.profile {
-		#org-avatar {
-			width: 100px;
-			height: 100px;
-			margin-right: 15px;
-		}
+    &.profile {
+        #org-avatar {
+            width: 100px;
+            height: 100px;
+            margin-right: 15px;
+        }
 
-		#org-info {
-			.ui.header {
-				font-size: 36px;
-				margin-bottom: 0;
-			}
-			.desc {
-				font-size: 16px;
-				margin-bottom: 10px;
-			}
-			.meta {
-				.item {
-					display: inline-block;
-					margin-right: 10px;
+        #org-info {
+            .ui.header {
+                font-size: 36px;
+                margin-bottom: 0;
+            }
+            .desc {
+                font-size: 16px;
+                margin-bottom: 10px;
+            }
+            .meta {
+                .item {
+                    display: inline-block;
+                    margin-right: 10px;
 
-					.icon {
-						margin-right: 5px;
-					}
-				}
-			}
-		}
+                    .icon {
+                        margin-right: 5px;
+                    }
+                }
+            }
+        }
 
-		.ui.top.header {
-			.ui.right {
-				margin-top: 0;
-			}
-		}
+        .ui.top.header {
+            .ui.right {
+                margin-top: 0;
+            }
+        }
 
-		.teams {
-			.item {
-				padding: 10px 15px;
-			}
-		}
-	}
+        .teams {
+            .item {
+                padding: 10px 15px;
+            }
+        }
+    }
 
-	&.teams,
-	&.profile {
-		.members {
-			.ui.avatar {
-				width: 48px;
-				height: 48px;
-				margin-right: 5px;
-			}
-		}
-	}
+    &.teams,
+    &.profile {
+        .members {
+            .ui.avatar {
+                width: 48px;
+                height: 48px;
+                margin-right: 5px;
+            }
+        }
+    }
 
-	&.invite {
-		#invite-box {
-			margin: auto;
-			margin-top: 50px;
-			width: 500px !important;
+    &.invite {
+        #invite-box {
+            margin: auto;
+            margin-top: 50px;
+            width: 500px !important;
 
-			#search-user-box {
-				input {
-					margin-left: 0;
-					width: 300px;
-				}
-			}
-			.ui.button {
-				margin-left: 5px;
-				margin-top: -3px;
-			}
-		}
-	}
+            #search-user-box {
+                input {
+                    margin-left: 0;
+                    width: 300px;
+                }
+            }
+            .ui.button {
+                margin-left: 5px;
+                margin-top: -3px;
+            }
+        }
+    }
 
-	&.members {
-		.list {
-			.item {
-				margin-left: 0;
-				margin-right: 0;
-				border-bottom: 1px solid #eee;
+    &.members {
+        .list {
+            .item {
+                margin-left: 0;
+                margin-right: 0;
+                border-bottom: 1px solid #eee;
 
-				.ui.avatar {
-					width: 48px;
-					height: 48px;
-				}
-				.meta {
-					line-height: 24px;
-				}
-			}
-		}
-	}
+                .ui.avatar {
+                    width: 48px;
+                    height: 48px;
+                }
+                .meta {
+                    line-height: 24px;
+                }
+            }
+        }
+    }
 
-	&.teams {
-		.detail {
-			.item {
-				padding: 10px 15px;
+    &.teams {
+        .detail {
+            .item {
+                padding: 10px 15px;
 
-				&:not(:last-child) {
-					border-bottom: 1px solid #eee;
-				}
-			}
-		}
+                &:not(:last-child) {
+                    border-bottom: 1px solid #eee;
+                }
+            }
+        }
 
-		.repositories,
-		.members {
-			.item {
-				padding: 10px 20px;
-				line-height: 32px;
+        .repositories,
+        .members {
+            .item {
+                padding: 10px 20px;
+                line-height: 32px;
 
-				&:not(:last-child) {
-					border-bottom: 1px solid #DDD;
-				}
+                &:not(:last-child) {
+                    border-bottom: 1px solid #DDD;
+                }
 
-				.button {
-					padding: 9px 10px;
-				}
-			}
-		}
+                .button {
+                    padding: 9px 10px;
+                }
+            }
+        }
 
-		#add-repo-form,
-		#add-member-form {
-			input {
-				margin-left: 0;
-			}
+        #add-repo-form,
+        #add-member-form {
+            input {
+                margin-left: 0;
+            }
 
-			.ui.button {
-				margin-left: 5px;
-				margin-top: -3px;
-			}
-		}
-	}
+            .ui.button {
+                margin-left: 5px;
+                margin-top: -3px;
+            }
+        }
+    }
 }

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -1354,257 +1354,257 @@
 // End of .repository
 
 &.user-cards {
-	.list {
-		padding: 0;
+    .list {
+        padding: 0;
 
-		.item {
-			list-style: none;
-			width: 32%;
-			margin: 10px 10px 10px 0;
-			padding-bottom: 14px;
-			float: left;
+        .item {
+            list-style: none;
+            width: 32%;
+            margin: 10px 10px 10px 0;
+            padding-bottom: 14px;
+            float: left;
 
-			.avatar {
-				width: 48px;
-				height: 48px;
-				float: left;
-				display: block;
-				margin-right: 10px;
-			}
-			.name {
-				margin-top: 0;
-				margin-bottom: 0;
-				font-weight: normal;
-			}
-			.meta {
-				margin-top: 5px;
-			}
-		}
-	}
+            .avatar {
+                width: 48px;
+                height: 48px;
+                float: left;
+                display: block;
+                margin-right: 10px;
+            }
+            .name {
+                margin-top: 0;
+                margin-bottom: 0;
+                font-weight: normal;
+            }
+            .meta {
+                margin-top: 5px;
+            }
+        }
+    }
 }
 
 #search-repo-box,
 #search-user-box {
-	.results {
-		.result {
-			.image {
-				float: left;
-				margin-right: 8px;
-				width: 2em;
-				height: 2em;
-			}
-			.content {
-				margin: 6px 0;
-			}
-		}
-	}
+    .results {
+        .result {
+            .image {
+                float: left;
+                margin-right: 8px;
+                width: 2em;
+                height: 2em;
+            }
+            .content {
+                margin: 6px 0;
+            }
+        }
+    }
 }
 
 .issue-actions {
-		display: none;
+        display: none;
 }
 
 .issue.list {
-	list-style: none;
-	padding-top: 15px;
-	>.item {
-		padding-top: 15px;
-		padding-bottom: 10px;
-		border-bottom: 1px dashed #AAA;
-		.title {
-			color: #444;
-			font-size: 15px;
-			font-weight: bold;
-			margin: 0 6px;
-			&:hover {
-				color: #000;
-			}
-		}
-		.comment {
-			padding-right: 10px;
-			color: #666;
-		}
-		.desc {
-			padding-top: 5px;
-			color: #999;
-			a.milestone {
-				padding-left: 5px;
-				color: #999!important;
-				&:hover {
-					color: #000!important;
-				}
-			}
-			.assignee {
-				margin-top: -5px;
-				margin-right: 5px;
-			}
-		}
-	}
+    list-style: none;
+    padding-top: 15px;
+    >.item {
+        padding-top: 15px;
+        padding-bottom: 10px;
+        border-bottom: 1px dashed #AAA;
+        .title {
+            color: #444;
+            font-size: 15px;
+            font-weight: bold;
+            margin: 0 6px;
+            &:hover {
+                color: #000;
+            }
+        }
+        .comment {
+            padding-right: 10px;
+            color: #666;
+        }
+        .desc {
+            padding-top: 5px;
+            color: #999;
+            a.milestone {
+                padding-left: 5px;
+                color: #999!important;
+                &:hover {
+                    color: #000!important;
+                }
+            }
+            .assignee {
+                margin-top: -5px;
+                margin-right: 5px;
+            }
+        }
+    }
 }
 
 .page.buttons {
-	padding-top: 15px;
+    padding-top: 15px;
 }
 
 .ui.form {
-	.dropzone {
-		width: 100%;
-		margin-bottom: 10px;
-		border: 2px dashed #0087F7;
-		box-shadow: none!important;
-		.dz-error-message {
-			top: 140px;
-		}
-	}
+    .dropzone {
+        width: 100%;
+        margin-bottom: 10px;
+        border: 2px dashed #0087F7;
+        box-shadow: none!important;
+        .dz-error-message {
+            top: 140px;
+        }
+    }
 }
 
 .settings {
-	.content {
-		margin-top: 2px;
-		>.header,
-		.segment {
-			box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
-		}
-	}
-	.list {
-		> .item {
-			.green {
-				color: #21BA45 !important;
-			}
-			&:not(:first-child) {
-				border-top: 1px solid #eaeaea;
-				padding:1rem;
-				margin: 15px -1rem -1rem -1rem;
-			}
-			> .mega-octicon {
-				display: table-cell;
-			}
-			> .mega-octicon + .content {
-				display: table-cell;
-				padding: 0 0 0 .5em;
-				vertical-align: top;
-			}
-			.info {
-				margin-top: 10px;
-				.tab.segment {
-					border: none;
-					padding: 10px 0 0;
-				}
-			}
-		}
-		&.key{
-			.meta {
-				padding-top: 5px;
-				color: #666;
-			}
-		}
-		&.email {
-			> .item:not(:first-child) {
-				min-height: 60px;
-			}
-		}
-		&.collaborator {
-			> .item {
-				padding: 0;
-			}
-		}
-	}
+    .content {
+        margin-top: 2px;
+        >.header,
+        .segment {
+            box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
+        }
+    }
+    .list {
+        > .item {
+            .green {
+                color: #21BA45 !important;
+            }
+            &:not(:first-child) {
+                border-top: 1px solid #eaeaea;
+                padding:1rem;
+                margin: 15px -1rem -1rem -1rem;
+            }
+            > .mega-octicon {
+                display: table-cell;
+            }
+            > .mega-octicon + .content {
+                display: table-cell;
+                padding: 0 0 0 .5em;
+                vertical-align: top;
+            }
+            .info {
+                margin-top: 10px;
+                .tab.segment {
+                    border: none;
+                    padding: 10px 0 0;
+                }
+            }
+        }
+        &.key{
+            .meta {
+                padding-top: 5px;
+                color: #666;
+            }
+        }
+        &.email {
+            > .item:not(:first-child) {
+                min-height: 60px;
+            }
+        }
+        &.collaborator {
+            > .item {
+                padding: 0;
+            }
+        }
+    }
 }
 
 .ui.vertical.menu {
-	.header.item {
-		font-size: 1.1em;
-		background: #f0f0f0;
-	}
+    .header.item {
+        font-size: 1.1em;
+        background: #f0f0f0;
+    }
 }
 
 .edit-label.modal,
 .new-label.segment {
-	.form {
-		.column {
-			padding-right: 0;
-		}
-		.buttons {
-			margin-left: auto;
-			padding-top: 15px;
-		}
-		.color.picker.column {
-			width: auto;
-			.color-picker {
-				height: 35px;
-				width: auto;
-				padding-left: 30px;
-			}
-		}
-		.minicolors-swatch.minicolors-sprite {
-			top: 10px;
-			left: 10px;
-			width: 15px;
-			height: 15px;
-		}
-		.precolors {
-			padding-left: 0;
-			padding-right: 0;
-			margin: 3px 10px auto 10px;
-			width: 120px;
-			.color {
-				float: left;
-				width: 15px;
-				height: 15px;
-			}
-		}
-	}
+    .form {
+        .column {
+            padding-right: 0;
+        }
+        .buttons {
+            margin-left: auto;
+            padding-top: 15px;
+        }
+        .color.picker.column {
+            width: auto;
+            .color-picker {
+                height: 35px;
+                width: auto;
+                padding-left: 30px;
+            }
+        }
+        .minicolors-swatch.minicolors-sprite {
+            top: 10px;
+            left: 10px;
+            width: 15px;
+            height: 15px;
+        }
+        .precolors {
+            padding-left: 0;
+            padding-right: 0;
+            margin: 3px 10px auto 10px;
+            width: 120px;
+            .color {
+                float: left;
+                width: 15px;
+                height: 15px;
+            }
+        }
+    }
 }
 
 #avatar-arrow {
-	&:before, &:after {
-		right: 100%;
-		top: 20px;
-		border: solid transparent;
-		content: " ";
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-	}
-	&:before {
-		border-right-color: #D4D4D5;
-		border-width: 9px;
-		margin-top: -9px;
-	}
-	&:after {
-		border-right-color: #f7f7f7;
-		border-width: 8px;
-		margin-top: -8px;
-	}
+    &:before, &:after {
+        right: 100%;
+        top: 20px;
+        border: solid transparent;
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        pointer-events: none;
+    }
+    &:before {
+        border-right-color: #D4D4D5;
+        border-width: 9px;
+        margin-top: -9px;
+    }
+    &:after {
+        border-right-color: #f7f7f7;
+        border-width: 8px;
+        margin-top: -8px;
+    }
 }
 
 #transfer-repo-modal,
 #delete-repo-modal {
-	.ui.message {
-		width: 100%!important;
-	}
+    .ui.message {
+        width: 100%!important;
+    }
 }
 
 // generate .tab-size-{i} from 1 to 16
 .generate-tab-size(16);
 .generate-tab-size(@n, @i: 1) when (@i =< @n) {
-	.tab-size-@{i} {
-		tab-size: @i !important;
-		-moz-tab-size: @i !important;
-	}
-	.generate-tab-size(@n, (@i + 1));
+    .tab-size-@{i} {
+        tab-size: @i !important;
+        -moz-tab-size: @i !important;
+    }
+    .generate-tab-size(@n, (@i + 1));
 }
 
 .stats-table {
-	display: table;
-	width: 100%;
-	.table-cell {
-		display: table-cell;
-		&.tiny {
-			height: .5em;
-		}
-	}
+    display: table;
+    width: 100%;
+    .table-cell {
+        display: table-cell;
+        &.tiny {
+            height: .5em;
+        }
+    }
 }
 
 tbody.commit-list {
@@ -1612,5 +1612,5 @@ tbody.commit-list {
 }
 
 .commit-body {
-	white-space: pre-wrap;
+    white-space: pre-wrap;
 }

--- a/public/less/_user.less
+++ b/public/less/_user.less
@@ -1,62 +1,62 @@
 .user {
-	&:not(.icon) {
-		padding-top: 15px;
-		padding-bottom: @footer-margin * 2;
-	}
+    &:not(.icon) {
+        padding-top: 15px;
+        padding-bottom: @footer-margin * 2;
+    }
 
-	&.profile {
-		.ui.card {
-			.username {
-				display: block;
-			}
-			.extra.content {
-				padding: 0;
+    &.profile {
+        .ui.card {
+            .username {
+                display: block;
+            }
+            .extra.content {
+                padding: 0;
 
-				ul {
-					margin: 0;
-					padding: 0;
+                ul {
+                    margin: 0;
+                    padding: 0;
 
-					li {
-						padding: 10px;
-						list-style: none;
+                    li {
+                        padding: 10px;
+                        list-style: none;
 
-						&:not(:last-child) {
-							border-bottom: 1px solid #eaeaea;
-						}
+                        &:not(:last-child) {
+                            border-bottom: 1px solid #eaeaea;
+                        }
 
-						.octicon {
-							margin-left: 1px;
-							margin-right: 5px;
-						}
+                        .octicon {
+                            margin-left: 1px;
+                            margin-right: 5px;
+                        }
 
-						&.follow {
-							.ui.button {
-								width: 100%;
-							}
-						}
-					}
-				}
-			}
-		}
+                        &.follow {
+                            .ui.button {
+                                width: 100%;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		.ui.repository.list {
-			margin-top: 25px;
-		}
-	}
+        .ui.repository.list {
+            margin-top: 25px;
+        }
+    }
 
-	&.followers {
-		.header.name {
-			font-size: 20px;
-			line-height: 24px;
-			vertical-align: middle;
-		}
+    &.followers {
+        .header.name {
+            font-size: 20px;
+            line-height: 24px;
+            vertical-align: middle;
+        }
 
-		.follow {
-			.ui.button {
-				padding: 8px 15px;
-			}
-		}
-	}
+        .follow {
+            .ui.button {
+                padding: 8px 15px;
+            }
+        }
+    }
 
     &.notification {
         .octicon {


### PR DESCRIPTION
Out of the 3469 lines of code in the `.less` files, 2004 were indented with spaces while 1465 were indented with tabs. I converted all tab indendation to 4 spaces as specified in [`.editorconfig`](https://github.com/go-gitea/gitea/blob/35cc5b0402d46d672e02bbe1ad15d1460077e8f4/.editorconfig#L18-L20) using this command:

````
find . ! -type d -exec bash -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;
````

If we want to use tabs in these files, I'd be open to that too, but it should be consistent and in `.editorconfig`.