### PR TITLE
Fix ref parsing in commit messages

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"path"
 	"strings"
 	"testing"
@@ -152,6 +153,35 @@ func TestPushCommits_AvatarLink(t *testing.T) {
 	assert.Equal(t,
 		"https://secure.gravatar.com/avatar/19ade630b94e1e0535b3df7387434154?d=identicon",
 		pushCommits.AvatarLink("nonexistent@example.com"))
+}
+
+func Test_getIssueFromRef(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
+	for _, test := range []struct {
+		Ref             string
+		ExpectedIssueID int64
+	}{
+		{"#2", 2},
+		{"reopen #2", 2},
+		{"user2/repo2#1", 4},
+		{"fixes user2/repo2#1", 4},
+	} {
+		issue, err := getIssueFromRef(repo, test.Ref)
+		assert.NoError(t, err)
+		if assert.NotNil(t, issue) {
+			assert.EqualValues(t, test.ExpectedIssueID, issue.ID)
+		}
+	}
+
+	for _, badRef := range []string{
+		"doesnotexist/doesnotexist#1",
+		fmt.Sprintf("#%d", NonexistentID),
+	} {
+		issue, err := getIssueFromRef(repo, badRef)
+		assert.NoError(t, err)
+		assert.Nil(t, issue)
+	}
 }
 
 func TestUpdateIssuesCommit(t *testing.T) {

--- a/models/issue.go
+++ b/models/issue.go
@@ -5,7 +5,6 @@
 package models
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -20,11 +19,6 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
-)
-
-var (
-	errMissingIssueNumber = errors.New("No issue number specified")
-	errInvalidIssueNumber = errors.New("Invalid issue number")
 )
 
 // Issue represents an issue or pull request of repository.
@@ -959,32 +953,6 @@ func NewIssue(repo *Repository, issue *Issue, labelIDs []int64, uuids []string) 
 	}
 
 	return nil
-}
-
-// GetIssueByRef returns an Issue specified by a GFM reference.
-// See https://help.github.com/articles/writing-on-github#references for more information on the syntax.
-func GetIssueByRef(ref string) (*Issue, error) {
-	n := strings.IndexByte(ref, '#')
-	if n == -1 {
-		return nil, errMissingIssueNumber
-	}
-
-	index, err := com.StrTo(ref[n+1:]).Int64()
-	if err != nil {
-		return nil, errInvalidIssueNumber
-	}
-
-	i := strings.IndexByte(ref[:n], '/')
-	if i < 2 {
-		return nil, ErrInvalidReference
-	}
-
-	repo, err := GetRepositoryByOwnerAndName(ref[:i], ref[i+1:n])
-	if err != nil {
-		return nil, err
-	}
-
-	return GetIssueByIndex(repo.ID, index)
 }
 
 // GetRawIssueByIndex returns raw issue without loading attributes by index in a repository.


### PR DESCRIPTION
Fix bug where commit messages containing `/#` would cause an error, and the rest of the commit message would not be parsed for issue references. This is because `GetIndexByRef` would return `ErrInvalidReference` when it encountered `/#`.

This PR also
* Improves the regexps for issue refs to avoid superfluous matches (`issueReferenceKeywordsPat` previously matched every word!)
* Refactor common code so that it can be reused
* Adds unit tests for commit message parsing