### PR TITLE
add quotation around ports in docker-compose.yml

### DIFF
--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -39,8 +39,8 @@ services:
     volumes:
       - ./gitea:/data
     ports:
-      - 3000:3000
-      - 222:22
+      - "3000:3000"
+      - "222:22"
 ```
 
 ## Custom port
@@ -63,10 +63,10 @@ services:
     volumes:
       - ./gitea:/data
     ports:
--      - 3000:3000
--      - 222:22
-+      - 8080:3000
-+      - 2221:22
+-      - "3000:3000"
+-      - "222:22"
++      - "8080:3000"
++      - "2221:22"
 ```
 
 ## MySQL database
@@ -89,8 +89,8 @@ services:
     volumes:
       - ./gitea:/data
      ports:
-       - 3000:3000
-       - 222:22
+       - "3000:3000"
+       - "222:22"
 +    depends_on:
 +      - db
 +
@@ -128,8 +128,8 @@ services:
     volumes:
       - ./gitea:/data
      ports:
-       - 3000:3000
-       - 222:22
+       - "3000:3000"
+       - "222:22"
 +    depends_on:
 +      - db
 +
@@ -171,8 +171,8 @@ services:
 -      - ./gitea:/data
 +      - gitea:/data
     ports:
-      - 3000:3000
-      - 222:22
+      - "3000:3000"
+      - "222:22"
 ```
 
 If you are using MySQL or PostgreSQL it's up to you to create named volumes for these containers as well.


### PR DESCRIPTION
Without quotation around ports in docker-compose.yml, an error will occur when `docker-compose up`:

```
Creating network "test_gitea" with the default driver                                                                                            
Creating volume "test_gitea" with local driver                                                                                                   
Creating test_server_1 ...                                                                                                                       
Creating test_server_1 ... error
                                                                                                                                                 
ERROR: for test_server_1  Cannot create container for service server: b'invalid port specification: "601342"'

ERROR: for server  Cannot create container for service server: b'invalid port specification: "601342"'
ERROR: Encountered errors while bringing up the project.
```

According to yaml's specification, `:` is a special mark, which denotes map, so quotation is necessary to avoid ambiguity.