### PR TITLE
Fix repo links

### DIFF
--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -2,7 +2,7 @@
 	{{range .Repos}}
 		<div class="item">
 			<div class="ui header">
-				<a class="name" href="{{AppSubUrl}}/{{if .Owner}}{{.Owner.Name}}{{else if $.Org}}{{$.Org.Name}}{{else}}{{$.Owner.Name}}{{end}}/{{.Name}}">{{if or $.PageIsExplore $.PageIsProfileStarList }}{{if .Owner}}{{.Owner.Name}} / {{end}}{{end}}{{.Name}}</a>
+				<a class="name" href="{{.HTMLURL}}">{{if or $.PageIsExplore $.PageIsProfileStarList }}{{if .Owner}}{{.Owner.Name}} / {{end}}{{end}}{{.Name}}</a>
 				{{if .IsPrivate}}
 					<span class="text gold"><i class="octicon octicon-lock"></i></span>
 				{{else if .IsFork}}


### PR DESCRIPTION
Fixes incorrect links in the repository listing of a user profile, as described #3035.

This PR does *not* address the other points raised in #3035, e.g.
* whether it makes sense to have "Show more repos" link to a user's profile page
* whether it makes sense to initially show only a user's repos on their profile page, but include collaborative repos when searching on the profile page

Therefore, we probably should *not* close #3035 if/when this PR merged.