### PR TITLE
Fix legacy URL redirects

### DIFF
--- a/integrations/links_test.go
+++ b/integrations/links_test.go
@@ -46,8 +46,10 @@ func TestRedirectsNoLogin(t *testing.T) {
 	prepareTestEnv(t)
 
 	var redirects = map[string]string{
-		"/user2/repo1/commits/master": "/user2/repo1/commits/branch/master",
-		"/user2/repo1/src/master":     "/user2/repo1/src/branch/master",
+		"/user2/repo1/commits/master":                "/user2/repo1/commits/branch/master",
+		"/user2/repo1/src/master":                    "/user2/repo1/src/branch/master",
+		"/user2/repo1/src/master/file.txt":           "/user2/repo1/src/branch/master/file.txt",
+		"/user2/repo1/src/master/directory/file.txt": "/user2/repo1/src/branch/master/directory/file.txt",
 	}
 	for link, redirectLink := range redirects {
 		req := NewRequest(t, "GET", link)

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -618,7 +618,11 @@ func RepoRefByType(refType RepoRefType) macaron.Handler {
 
 			if refType == RepoRefLegacy {
 				// redirect from old URL scheme to new URL scheme
-				ctx.Redirect(path.Join(setting.AppSubURL, strings.TrimSuffix(ctx.Req.URL.String(), ctx.Params("*")), ctx.Repo.BranchNameSubURL()))
+				ctx.Redirect(path.Join(
+					setting.AppSubURL,
+					strings.TrimSuffix(ctx.Req.URL.String(), ctx.Params("*")),
+					ctx.Repo.BranchNameSubURL(),
+					ctx.Repo.TreePath))
 				return
 			}
 		}


### PR DESCRIPTION
Fix legacy URL redirects, which previously ignored the path component of the URL. Also adds tests.

For example, `/user/repo/src/master/file.txt` previously redirected to `/user/repo/src/branch/master`, but now redirects to `/user/repo/src/branch/master/file.txt`.