### PR TITLE
Fix missing branch in release bug

### DIFF
--- a/modules/test/context_tests.go
+++ b/modules/test/context_tests.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	"code.gitea.io/git"
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
 
@@ -49,6 +50,15 @@ func LoadRepo(t *testing.T, ctx *context.Context, repoID int64) {
 // LoadUser load a user into a test context.
 func LoadUser(t *testing.T, ctx *context.Context, userID int64) {
 	ctx.User = models.AssertExistsAndLoadBean(t, &models.User{ID: userID}).(*models.User)
+}
+
+// LoadGitRepo load a git repo into a test context. Requires that ctx.Repo has
+// already been populated.
+func LoadGitRepo(t *testing.T, ctx *context.Context) {
+	assert.NoError(t, ctx.Repo.Repository.GetOwner())
+	var err error
+	ctx.Repo.GitRepo, err = git.OpenRepository(ctx.Repo.Repository.RepoPath())
+	assert.NoError(t, err)
 }
 
 type mockLocale struct{}

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -191,6 +191,7 @@ func NewReleasePost(ctx *context.Context, form auth.NewReleaseForm) {
 
 		rel.Title = form.Title
 		rel.Note = form.Content
+		rel.Target = form.Target
 		rel.IsDraft = len(form.Draft) > 0
 		rel.IsPrerelease = form.Prerelease
 		rel.PublisherID = ctx.User.ID

--- a/routers/repo/release_test.go
+++ b/routers/repo/release_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repo
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/auth"
+	"code.gitea.io/gitea/modules/test"
+)
+
+func TestNewReleasePost(t *testing.T) {
+	for _, testCase := range []struct {
+		RepoID  int64
+		UserID  int64
+		TagName string
+		Form    auth.NewReleaseForm
+	}{
+		{
+			RepoID:  1,
+			UserID:  2,
+			TagName: "v1.1", // pre-existing tag
+			Form: auth.NewReleaseForm{
+				TagName: "newtag",
+				Target:  "master",
+				Title:   "title",
+				Content: "content",
+			},
+		},
+		{
+			RepoID:  1,
+			UserID:  2,
+			TagName: "newtag",
+			Form: auth.NewReleaseForm{
+				TagName: "newtag",
+				Target:  "master",
+				Title:   "title",
+				Content: "content",
+			},
+		},
+	} {
+		models.PrepareTestEnv(t)
+
+		ctx := test.MockContext(t, "user2/repo1/releases/new")
+		test.LoadUser(t, ctx, 2)
+		test.LoadRepo(t, ctx, 1)
+		test.LoadGitRepo(t, ctx)
+		NewReleasePost(ctx, testCase.Form)
+		models.AssertExistsAndLoadBean(t, &models.Release{
+			RepoID:      1,
+			PublisherID: 2,
+			TagName:     testCase.Form.TagName,
+			Target:      testCase.Form.Target,
+			Title:       testCase.Form.Title,
+			Note:        testCase.Form.Content,
+		}, models.Cond("is_draft=?", len(testCase.Form.Draft) > 0))
+	}
+}


### PR DESCRIPTION
Fixes #3066. Previously, the `target` of a release would not be set if the tag already existed.