### PR TITLE
Use consistent title case for language names

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -541,7 +541,7 @@ MAX_RESPONSE_ITEMS = 50
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어
+NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Русский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomi,Türkçe,Čeština,Српски,Svenska,한국어
 
 ; Used for datetimepicker
 [i18n.datelang]

--- a/modules/setting/defaults.go
+++ b/modules/setting/defaults.go
@@ -6,5 +6,5 @@ import (
 
 var (
 	defaultLangs     = strings.Split("en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR", ",")
-	defaultLangNames = strings.Split("English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어", ",")
+	defaultLangNames = strings.Split("English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Русский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomi,Türkçe,Čeština,Српски,Svenska,한국어", ",")
 )


### PR DESCRIPTION
Updated the default language names so they are consistently title cased.

<img width="205" alt="screen shot 2017-12-07 at 16 56 38" src="https://user-images.githubusercontent.com/115237/33724426-b0985406-db6f-11e7-973d-5159a7fa4bf2.png">
