### PR TITLE
Refactor duplicated order-by code

### DIFF
--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -28,11 +28,10 @@ func populateIssueIndexer() error {
 	batch := indexer.IssueIndexerBatch()
 	for page := 1; ; page++ {
 		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
-			Page:        page,
-			PageSize:    10,
-			OrderBy:     SearchOrderByID,
-			Private:     true,
-			Collaborate: util.OptionalBoolFalse,
+			Page:     page,
+			PageSize: 10,
+			OrderBy:  RepoOrderByID,
+			Private:  true,
 		})
 		if err != nil {
 			return fmt.Errorf("Repositories: %v", err)

--- a/models/repo.go
+++ b/models/repo.go
@@ -1946,14 +1946,10 @@ func GetRepositoryByID(id int64) (*Repository, error) {
 }
 
 // GetUserRepositories returns a list of repositories of given user.
-func GetUserRepositories(userID int64, private bool, page, pageSize int, orderBy string) ([]*Repository, error) {
-	if len(orderBy) == 0 {
-		orderBy = "updated_unix DESC"
-	}
-
+func GetUserRepositories(userID int64, private bool, page, pageSize int, orderBy RepoOrderByType) ([]*Repository, error) {
 	sess := x.
 		Where("owner_id = ?", userID).
-		OrderBy(orderBy)
+		OrderBy(orderBy.SQL())
 	if !private {
 		sess.And("is_private=?", false)
 	}

--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -82,7 +82,7 @@ func populateRepoIndexer() error {
 		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
 			Page:     page,
 			PageSize: 10,
-			OrderBy:  SearchOrderByID,
+			OrderBy:  RepoOrderByID,
 			Private:  true,
 		})
 		if err != nil {

--- a/models/star.go
+++ b/models/star.go
@@ -71,14 +71,11 @@ func (repo *Repository) GetStargazers(page int) ([]*User, error) {
 }
 
 // GetStarredRepos returns the repos the user starred.
-func (u *User) GetStarredRepos(private bool, page, pageSize int, orderBy string) (repos RepositoryList, err error) {
-	if len(orderBy) == 0 {
-		orderBy = "updated_unix DESC"
-	}
+func (u *User) GetStarredRepos(private bool, page, pageSize int, orderBy RepoOrderByType) (repos RepositoryList, err error) {
 	sess := x.
 		Join("INNER", "star", "star.repo_id = repository.id").
 		Where("star.uid = ?", u.ID).
-		OrderBy(orderBy)
+		OrderBy(orderBy.SQL())
 
 	if !private {
 		sess = sess.And("is_private = ?", false)

--- a/models/star_test.go
+++ b/models/star_test.go
@@ -54,13 +54,13 @@ func TestUser_GetStarredRepos(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
 	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
-	starred, err := user.GetStarredRepos(false, 1, 10, "")
+	starred, err := user.GetStarredRepos(false, 1, 10, RepoOrderByRecentUpdated)
 	assert.NoError(t, err)
 	if assert.Len(t, starred, 1) {
 		assert.Equal(t, int64(4), starred[0].ID)
 	}
 
-	starred, err = user.GetStarredRepos(true, 1, 10, "")
+	starred, err = user.GetStarredRepos(true, 1, 10, RepoOrderByRecentUpdated)
 	assert.NoError(t, err)
 	if assert.Len(t, starred, 2) {
 		assert.Equal(t, int64(2), starred[0].ID)
@@ -73,11 +73,11 @@ func TestUser_GetStarredRepos2(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
 	user := AssertExistsAndLoadBean(t, &User{ID: 1}).(*User)
-	starred, err := user.GetStarredRepos(false, 1, 10, "")
+	starred, err := user.GetStarredRepos(false, 1, 10, RepoOrderByRecentUpdated)
 	assert.NoError(t, err)
 	assert.Len(t, starred, 0)
 
-	starred, err = user.GetStarredRepos(true, 1, 10, "")
+	starred, err = user.GetStarredRepos(true, 1, 10, RepoOrderByRecentUpdated)
 	assert.NoError(t, err)
 	assert.Len(t, starred, 0)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -508,7 +508,7 @@ func (u *User) GetOrganizationCount() (int64, error) {
 
 // GetRepositories returns repositories that user owns, including private repositories.
 func (u *User) GetRepositories(page, pageSize int) (err error) {
-	u.Repos, err = GetUserRepositories(u.ID, true, page, pageSize, "")
+	u.Repos, err = GetUserRepositories(u.ID, true, page, pageSize, RepoOrderByRecentUpdated)
 	return err
 }
 

--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -13,7 +13,7 @@ import (
 // listUserRepos - List the repositories owned by the given user.
 func listUserRepos(ctx *context.APIContext, u *models.User) {
 	showPrivateRepos := ctx.IsSigned && (ctx.User.ID == u.ID || ctx.User.IsAdmin)
-	repos, err := models.GetUserRepositories(u.ID, showPrivateRepos, 1, u.NumRepos, "")
+	repos, err := models.GetUserRepositories(u.ID, showPrivateRepos, 1, u.NumRepos, models.RepoOrderByRecentUpdated)
 	if err != nil {
 		ctx.Error(500, "GetUserRepositories", err)
 		return
@@ -67,7 +67,7 @@ func ListMyRepos(ctx *context.APIContext) {
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/RepositoryList"
-	ownRepos, err := models.GetUserRepositories(ctx.User.ID, true, 1, ctx.User.NumRepos, "")
+	ownRepos, err := models.GetUserRepositories(ctx.User.ID, true, 1, ctx.User.NumRepos, models.RepoOrderByRecentUpdated)
 	if err != nil {
 		ctx.Error(500, "GetUserRepositories", err)
 		return

--- a/routers/home.go
+++ b/routers/home.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/user"
+	"code.gitea.io/gitea/routers/utils"
 
 	"github.com/Unknwon/paginater"
 )
@@ -75,42 +76,15 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		page = 1
 	}
 
-	var (
-		repos   []*models.Repository
-		count   int64
-		err     error
-		orderBy models.SearchOrderBy
-	)
-
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
-	case "newest":
-		orderBy = models.SearchOrderByNewest
-	case "oldest":
-		orderBy = models.SearchOrderByOldest
-	case "recentupdate":
-		orderBy = models.SearchOrderByRecentUpdated
-	case "leastupdate":
-		orderBy = models.SearchOrderByLeastUpdated
-	case "reversealphabetically":
-		orderBy = models.SearchOrderByAlphabeticallyReverse
-	case "alphabetically":
-		orderBy = models.SearchOrderByAlphabetically
-	case "reversesize":
-		orderBy = models.SearchOrderBySizeReverse
-	case "size":
-		orderBy = models.SearchOrderBySize
-	default:
-		ctx.Data["SortType"] = "recentupdate"
-		orderBy = models.SearchOrderByRecentUpdated
-	}
+	orderByType := utils.ParseRepoOrderByType(ctx.Query("sort"))
+	ctx.Data["SortType"] = utils.ToQueryString(orderByType)
 
 	keyword := strings.Trim(ctx.Query("q"), " ")
 
-	repos, count, err = models.SearchRepositoryByName(&models.SearchRepoOptions{
+	repos, count, err := models.SearchRepositoryByName(&models.SearchRepoOptions{
 		Page:      page,
 		PageSize:  opts.PageSize,
-		OrderBy:   orderBy,
+		OrderBy:   orderByType,
 		Private:   opts.Private,
 		Keyword:   keyword,
 		OwnerID:   opts.OwnerID,

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -391,7 +391,7 @@ func showOrgProfile(ctx *context.Context) {
 		ctx.Data["Repos"] = repos
 	} else {
 		showPrivate := ctx.IsSigned && ctx.User.IsAdmin
-		repos, err = models.GetUserRepositories(org.ID, showPrivate, page, setting.UI.User.RepoPagingNum, "")
+		repos, err = models.GetUserRepositories(org.ID, showPrivate, page, setting.UI.User.RepoPagingNum, models.RepoOrderByRecentUpdated)
 		if err != nil {
 			ctx.Handle(500, "GetRepositories", err)
 			return

--- a/routers/utils/utils.go
+++ b/routers/utils/utils.go
@@ -6,6 +6,9 @@ package utils
 
 import (
 	"strings"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/log"
 )
 
 // RemoveUsernameParameterSuffix returns the username parameter without the (fullname) suffix - leaving just the username
@@ -14,4 +17,58 @@ func RemoveUsernameParameterSuffix(name string) string {
 		name = name[:index]
 	}
 	return name
+}
+
+// ParseRepoOrderByType returns the OrderByType represented by the given string.
+func ParseRepoOrderByType(s string) models.RepoOrderByType {
+	switch s {
+	case "alphabetically":
+		return models.RepoOrderByAlphabetically
+	case "reversealphabetically":
+		return models.RepoOrderByAlphabeticallyReverse
+	case "leastupdate":
+		return models.RepoOrderByLeastUpdated
+	case "recentupdate":
+		return models.RepoOrderByRecentUpdated
+	case "newest":
+		return models.RepoOrderByNewest
+	case "oldest":
+		return models.RepoOrderByOldest
+	case "size":
+		return models.RepoOrderBySize
+	case "reversesize":
+		return models.RepoOrderBySizeReverse
+	case "id":
+		return models.RepoOrderByID
+	default:
+		return models.RepoOrderByRecentUpdated
+	}
+}
+
+// ToQueryString returns the string equivalent of the given RepoOrderByType, for
+// use in URL queries and HTML templates.
+func ToQueryString(s models.RepoOrderByType) string {
+	switch s {
+	case models.RepoOrderByAlphabetically:
+		return "alphabetically"
+	case models.RepoOrderByAlphabeticallyReverse:
+		return "reversealphabetically"
+	case models.RepoOrderByLeastUpdated:
+		return "leastupdate"
+	case models.RepoOrderByRecentUpdated:
+		return "recentupdate"
+	case models.RepoOrderByNewest:
+		return "newest"
+	case models.RepoOrderByOldest:
+		return "oldest"
+	case models.RepoOrderBySize:
+		return "size"
+	case models.RepoOrderBySizeReverse:
+		return "reversesize"
+	case models.RepoOrderByID:
+		return "id"
+	default:
+		log.Error(4, "Unrecognized models.RepoOrderBy: %v", s)
+		return ""
+	}
 }

--- a/routers/utils/utils_test.go
+++ b/routers/utils/utils_test.go
@@ -7,6 +7,8 @@ package utils
 import (
 	"testing"
 
+	"code.gitea.io/gitea/models"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,4 +16,25 @@ func TestRemoveUsernameParameterSuffix(t *testing.T) {
 	assert.Equal(t, "foobar", RemoveUsernameParameterSuffix("foobar (Foo Bar)"))
 	assert.Equal(t, "foobar", RemoveUsernameParameterSuffix("foobar"))
 	assert.Equal(t, "", RemoveUsernameParameterSuffix(""))
+}
+
+var allRepoOrderByTypes = []models.RepoOrderByType{
+	models.RepoOrderByAlphabetically,
+	models.RepoOrderByAlphabeticallyReverse,
+	models.RepoOrderByLeastUpdated,
+	models.RepoOrderByRecentUpdated,
+	models.RepoOrderByOldest,
+	models.RepoOrderByNewest,
+	models.RepoOrderByID,
+}
+
+func TestParseOrderByType(t *testing.T) {
+	for _, orderByType := range allRepoOrderByTypes {
+		s := ToQueryString(orderByType)
+		assert.EqualValues(t, orderByType, ParseRepoOrderByType(s))
+	}
+	assert.EqualValues(t, models.RepoOrderByRecentUpdated,
+		ParseRepoOrderByType(""))
+	assert.EqualValues(t, models.RepoOrderByRecentUpdated,
+		ParseRepoOrderByType("I don't match anything!"))
 }


### PR DESCRIPTION
Refactor duplicated code for parsing query parameters for search ordering. Also adds unit tests.

This will pay off if/when we add more search pages (e.g. searching for an organization's repos)