### PR TITLE
Fix integration tests

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -136,6 +136,7 @@ func initIntegrationTest() {
 func prepareTestEnv(t testing.TB) {
 	assert.NoError(t, models.LoadFixtures())
 	assert.NoError(t, os.RemoveAll(setting.RepoRootPath))
+	assert.NoError(t, os.RemoveAll(models.LocalCopyPath()))
 
 	assert.NoError(t, com.CopyDir(path.Join(filepath.Dir(setting.AppPath), "integrations/gitea-repositories-meta"),
 		setting.RepoRootPath))

--- a/models/repo.go
+++ b/models/repo.go
@@ -757,12 +757,17 @@ func (repo *Repository) DescriptionHTML() template.HTML {
 	return template.HTML(descPattern.ReplaceAllStringFunc(markup.Sanitize(repo.Description), sanitize))
 }
 
-// LocalCopyPath returns the local repository copy path
-func (repo *Repository) LocalCopyPath() string {
+// LocalCopyPath returns the local repository copy path.
+func LocalCopyPath() string {
 	if filepath.IsAbs(setting.Repository.Local.LocalCopyPath) {
-		return path.Join(setting.Repository.Local.LocalCopyPath, com.ToStr(repo.ID))
+		return setting.Repository.Local.LocalCopyPath
 	}
-	return path.Join(setting.AppDataPath, setting.Repository.Local.LocalCopyPath, com.ToStr(repo.ID))
+	return path.Join(setting.AppDataPath, setting.Repository.Local.LocalCopyPath)
+}
+
+// LocalCopyPath returns the local repository copy path for the given repo.
+func (repo *Repository) LocalCopyPath() string {
+	return path.Join(LocalCopyPath(), com.ToStr(repo.ID))
 }
 
 // UpdateLocalCopyBranch pulls latest changes of given branch from repoPath to localPath.


### PR DESCRIPTION
Delete the local repo copy path between integration tests. If we do not do this, the local copy of a repo created in one test will persist in later tests, which can cause tests to break (see https://drone.gitea.io/go-gitea/gitea/2502/9, which failed because of a leftover local copy of a repo created in `git_test.go`)