### PR TITLE
Fix Uninitialized variable in ParsePatch

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -238,7 +238,7 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 	var (
 		diff = &Diff{Files: make([]*DiffFile, 0)}
 
-		curFile    *DiffFile
+		curFile    = &DiffFile{}
 		curSection = &DiffSection{
 			Lines: make([]*DiffLine, 0, 10),
 		}


### PR DESCRIPTION
Fix a bug reported on Discord.

```
top of stack trace:

    [Macaron] PANIC: runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:489 (0x428a6a)
    /usr/local/go/src/runtime/panic.go:63 (0x427c0c)
    /usr/local/go/src/runtime/signal_windows.go:161 (0x43a624)
    /srv/app/src/code.gitea.io/gitea/models/git_diff.go:350 (0xb5eb8f)
    /srv/app/src/code.gitea.io/gitea/models/git_diff.go:495 (0xb609b9)
    /srv/app/src/code.gitea.io/gitea/models/git_diff.go:564 (0xb614e1)
    /srv/app/src/code.gitea.io/gitea/routers/repo/commit.go:213 (0xca6979)
```
Bug in https://github.com/go-gitea/gitea/blob/release/v1.3/models/git_diff.go#L341 because https://github.com/go-gitea/gitea/blob/release/v1.3/models/git_diff.go#L241 is never initialized.