### PR TITLE
Enable emoji for wiki view

### DIFF
--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -73,7 +73,7 @@
 			</div>
 		{{end}}
 		<div class="ui {{if .sidebarPresent}}grid equal width{{end}}" style="margin-top: 1rem;">
-			<div class="ui {{if .sidebarPresent}}eleven wide column{{end}} segment markdown">
+			<div class="ui {{if .sidebarPresent}}eleven wide column{{end}} segment markdown has-emoji">
 				{{.content | Str2html}}
 			</div>
 			{{if .sidebarPresent}}


### PR DESCRIPTION
Enable emoji for wiki page content. It is enabled in the edit preview so the view should match.