### PR TITLE
Use hash version if current branch tag differs from latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,13 @@ GOFMT ?= gofmt -s
 GOFLAGS := -i -v
 EXTRA_GOFLAGS ?=
 
-LDFLAGS := -X "main.Version=$(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')" -X "main.Tags=$(TAGS)"
+ifeq ($(shell git describe --abbrev=0),$(shell git tag | tail -1))
+	VERSION := $(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')
+else
+	VERSION := $(shell git rev-parse --short HEAD)
+endif
+
+LDFLAGS := -X "main.Version=$(VERSION)" -X "main.Tags=$(TAGS)"
 
 PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations,$(shell $(GO) list ./... | grep -v /vendor/))
 SOURCES ?= $(shell find . -name "*.go" -type f)


### PR DESCRIPTION
Attempt to resolve https://github.com/go-gitea/gitea/issues/3194.

My idea is that if a releaser is on a release branch, their latest tag on the current branch (identified by `git describe`) will be the same as the latest tag of all branches (identified by `git tag`). If this is the case, use the `v0.0.0+123-hash` version scheme. In all other situations, only use `hash` for the version. 