### PR TITLE
Remove unnecessary updates to issue indexer

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -582,7 +582,7 @@ func updateIssueCols(e Engine, issue *Issue, cols ...string) error {
 	if _, err := e.ID(issue.ID).Cols(cols...).Update(issue); err != nil {
 		return err
 	}
-	UpdateIssueIndexer(issue.ID)
+	UpdateIssueIndexerCols(issue.ID, cols...)
 	return nil
 }
 

--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -102,6 +102,26 @@ func (issue *Issue) update() indexer.IssueIndexerUpdate {
 	}
 }
 
+// updateNeededCols whether a change to the specified columns requires updating
+// the issue indexer
+func updateNeededCols(cols []string) bool {
+	for _, col := range cols {
+		switch col {
+		case "name", "content":
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateIssueIndexerCols update an issue in the issue indexer, given changes
+// to the specified columns
+func UpdateIssueIndexerCols(issueID int64, cols ...string) {
+	if updateNeededCols(cols) {
+		UpdateIssueIndexer(issueID)
+	}
+}
+
 // UpdateIssueIndexer add/update an issue to the issue indexer
 func UpdateIssueIndexer(issueID int64) {
 	select {

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -282,7 +282,7 @@ func changeMilestoneAssign(e *xorm.Session, doer *User, issue *Issue, oldMilesto
 		}
 	}
 
-	return updateIssue(e, issue)
+	return updateIssueCols(e, issue, "milestone_id")
 }
 
 // ChangeMilestoneAssign changes assignment of milestone for issue.


### PR DESCRIPTION
Do not update the issue indexer when an update to an issue does not affect the fields that are actually stored in the indexer.