### PR TITLE
Refactor spelling of JavaScript licenses in footer

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -22,7 +22,7 @@
 						{{end}}
 					</div>
 				</div>
-				<a href="{{AppSubUrl}}/vendor/librejs.html" data-jslicense="1">Javascript licenses</a>
+				<a href="{{AppSubUrl}}/vendor/librejs.html" data-jslicense="1">JavaScript licenses</a>
 				<a href="{{AppSubUrl}}/api/swagger">API</a>
 				<a target="_blank" rel="noopener" href="https://gitea.io">{{.i18n.Tr "website"}}</a>
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}<span class="version">{{GoVer}}</span>{{end}}


### PR DESCRIPTION
Spell JavaScript licenses in footer with an uppercase 'S'

Reference: [Mozilla](https://developer.mozilla.org/en-US/docs/Web/JavaScript)