### PR TITLE
Fixed missing end tag for organization link

### DIFF
--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -27,6 +27,7 @@
 	</a>
 	<a class="{{if .PageIsSettingsOrganization}}active{{end}} item" href="{{AppSubUrl}}/user/settings/organization">
 		{{.i18n.Tr "settings.organization"}}
+	</a>
 	<a class="{{if .PageIsSettingsRepos}}active{{end}} item" href="{{AppSubUrl}}/user/settings/repos">
 		{{.i18n.Tr "settings.repos"}}
 	</a>


### PR DESCRIPTION
This pull request is for a simple bug fix.
