### PR TITLE
Fix repo-transfer-and-team-repo-count bug

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1503,20 +1503,6 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) error 
 
 	// Remove old team-repository relations.
 	if owner.IsOrganization() {
-		if err = owner.getTeams(sess); err != nil {
-			return fmt.Errorf("getTeams: %v", err)
-		}
-		for _, t := range owner.Teams {
-			if !t.hasRepository(sess, repo.ID) {
-				continue
-			}
-
-			t.NumRepos--
-			if _, err := sess.ID(t.ID).Cols("num_repos").Update(t); err != nil {
-				return fmt.Errorf("decrease team repository count '%d': %v", t.ID, err)
-			}
-		}
-
 		if err = owner.removeOrgRepo(sess, repo.ID); err != nil {
 			return fmt.Errorf("removeOrgRepo: %v", err)
 		}

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -153,3 +153,26 @@ func TestRepoLocalCopyPath(t *testing.T) {
 	setting.Repository.Local.LocalCopyPath = tempPath
 	assert.Equal(t, expected, repo.LocalCopyPath())
 }
+
+func TestTransferOwnership(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	doer := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
+	repo.Owner = AssertExistsAndLoadBean(t, &User{ID: repo.OwnerID}).(*User)
+	assert.NoError(t, TransferOwnership(doer, "user2", repo))
+
+	transferredRepo := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
+	assert.EqualValues(t, 2, transferredRepo.OwnerID)
+
+	assert.False(t, com.IsExist(RepoPath("user3", "repo3")))
+	assert.True(t, com.IsExist(RepoPath("user2", "repo3")))
+	AssertExistsAndLoadBean(t, &Action{
+		OpType:    ActionTransferRepo,
+		ActUserID: 2,
+		RepoID:    3,
+		Content:   "user3/repo3",
+	})
+
+	CheckConsistencyFor(t, &Repository{}, &User{}, &Team{})
+}


### PR DESCRIPTION
Remove code in `TransferOwnership` which decrements teams' number of repos, since that is already done by the `removeOrgRepo(..)` method. Also adds a unit test for a `TransferOwnership`.