### PR TITLE
Remove IsOwner, NumTeams from OrgUser

### DIFF
--- a/models/action_test.go
+++ b/models/action_test.go
@@ -425,7 +425,7 @@ func TestGetFeeds2(t *testing.T) {
 	// test with an organization user
 	assert.NoError(t, PrepareTestDatabase())
 	org := AssertExistsAndLoadBean(t, &User{ID: 3}).(*User)
-	userID := AssertExistsAndLoadBean(t, &OrgUser{OrgID: org.ID, IsOwner: true}).(*OrgUser).UID
+	const userID = 2 // user2 is an owner of the organization
 
 	actions, err := GetFeeds(GetFeedsOptions{
 		RequestedUser:    org,

--- a/models/fixtures/org_user.yml
+++ b/models/fixtures/org_user.yml
@@ -3,53 +3,39 @@
   uid: 2
   org_id: 3
   is_public: true
-  is_owner: true
-  num_teams: 1
 
 -
   id: 2
   uid: 4
   org_id: 3
   is_public: false
-  is_owner: false
-  num_teams: 0
 
 -
   id: 3
   uid: 5
   org_id: 6
   is_public: true
-  is_owner: true
-  num_teams: 1
 
 -
   id: 4
   uid: 5
   org_id: 7
   is_public: false
-  is_owner: true
-  num_teams: 1
 
 -
   id: 5
   uid: 15
   org_id: 17
   is_public: true
-  is_owner: true
-  num_teams: 1
 
 -
   id: 6
   uid: 18
   org_id: 17
   is_public: false
-  is_owner: true
-  num_teams: 1
 
 -
   id: 7
   uid: 20
   org_id: 19
   is_public: true
-  is_owner: true
-  num_teams: 1

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -164,6 +164,8 @@ var migrations = []Migration{
 	NewMigration("add pull request options", addPullRequestOptions),
 	// v55 -> v56
 	NewMigration("add writable deploy keys", addModeToDeploKeys),
+	// v56 -> v57
+	NewMigration("remove is_owner, num_teams columns from org_user", removeIsOwnerColumnFromOrgUser),
 }
 
 // Migrate database to current version

--- a/models/migrations/v56.go
+++ b/models/migrations/v56.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/go-xorm/xorm"
+)
+
+func removeIsOwnerColumnFromOrgUser(x *xorm.Engine) (err error) {
+	switch {
+	case setting.UseSQLite3:
+		log.Warn("Unable to drop columns in SQLite")
+	case setting.UseMySQL, setting.UseTiDB, setting.UsePostgreSQL:
+		if _, err := x.Exec("ALTER TABLE org_user DROP COLUMN is_owner, DROP COLUMN num_teams"); err != nil {
+			return fmt.Errorf("DROP COLUMN org_user.is_owner, org_user.num_teams: %v", err)
+		}
+	case setting.UseMSSQL:
+		if _, err := x.Exec("ALTER TABLE org_user DROP COLUMN is_owner, num_teams"); err != nil {
+			return fmt.Errorf("DROP COLUMN org_user.is_owner, org_user.num_teams: %v", err)
+		}
+	default:
+		log.Fatal(4, "Unrecognized DB")
+	}
+
+	return nil
+}

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -518,22 +518,6 @@ func AddTeamMember(team *Team, userID int64) error {
 		}
 	}
 
-	// We make sure it exists before.
-	ou := new(OrgUser)
-	if _, err := sess.
-		Where("uid = ?", userID).
-		And("org_id = ?", team.OrgID).
-		Get(ou); err != nil {
-		return err
-	}
-	ou.NumTeams++
-	if team.IsOwnerTeam() {
-		ou.IsOwner = true
-	}
-	if _, err := sess.ID(ou.ID).Cols("num_teams, is_owner").Update(ou); err != nil {
-		return err
-	}
-
 	return sess.Commit()
 }
 
@@ -574,25 +558,6 @@ func removeTeamMember(e Engine, team *Team, userID int64) error {
 		}
 	}
 
-	// This must exist.
-	ou := new(OrgUser)
-	_, err = e.
-		Where("uid = ?", userID).
-		And("org_id = ?", team.OrgID).
-		Get(ou)
-	if err != nil {
-		return err
-	}
-	ou.NumTeams--
-	if team.IsOwnerTeam() {
-		ou.IsOwner = false
-	}
-	if _, err = e.
-		ID(ou.ID).
-		Cols("num_teams").
-		Update(ou); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/models/org_test.go
+++ b/models/org_test.go
@@ -368,16 +368,12 @@ func TestGetOrgUsersByUserID(t *testing.T) {
 			ID:       orgUsers[0].ID,
 			OrgID:    6,
 			UID:      5,
-			IsOwner:  true,
-			IsPublic: true,
-			NumTeams: 1}, *orgUsers[0])
+			IsPublic: true}, *orgUsers[0])
 		assert.Equal(t, OrgUser{
 			ID:       orgUsers[1].ID,
 			OrgID:    7,
 			UID:      5,
-			IsOwner:  true,
-			IsPublic: false,
-			NumTeams: 1}, *orgUsers[1])
+			IsPublic: false}, *orgUsers[1])
 	}
 
 	publicOrgUsers, err := GetOrgUsersByUserID(5, false)
@@ -400,16 +396,12 @@ func TestGetOrgUsersByOrgID(t *testing.T) {
 			ID:       orgUsers[0].ID,
 			OrgID:    3,
 			UID:      2,
-			IsOwner:  true,
-			IsPublic: true,
-			NumTeams: 1}, *orgUsers[0])
+			IsPublic: true}, *orgUsers[0])
 		assert.Equal(t, OrgUser{
 			ID:       orgUsers[1].ID,
 			OrgID:    3,
 			UID:      4,
-			IsOwner:  false,
-			IsPublic: false,
-			NumTeams: 0}, *orgUsers[1])
+			IsPublic: false}, *orgUsers[1])
 	}
 
 	orgUsers, err = GetOrgUsersByOrgID(NonexistentID)


### PR DESCRIPTION
Remove the `IsOwner` and `NumTeams` from the `OrgUser` structs (and remove the corresponding columns from the `org_user` table).

- The `IsOwner` is outdated, since all org members must belong to at least one team (see https://github.com/go-gitea/gitea/pull/3164#issuecomment-350946035)
- The `NumTeams` field is never used, and is not properly updated when a team is deleted.