### PR TITLE
Add 'repo-sync-releases` admin command

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -8,7 +8,9 @@ package cmd
 import (
 	"fmt"
 
+	"code.gitea.io/git"
 	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/urfave/cli"
@@ -24,6 +26,7 @@ to make automatic initialization process more smoothly`,
 		Subcommands: []cli.Command{
 			subcmdCreateUser,
 			subcmdChangePassword,
+			subcmdRepoSyncReleases,
 		},
 	}
 
@@ -75,6 +78,12 @@ to make automatic initialization process more smoothly`,
 				Usage: "New password to set for user",
 			},
 		},
+	}
+
+	subcmdRepoSyncReleases = cli.Command{
+		Name:   "repo-sync-releases",
+		Usage:  "Synchronize repository releases with tags",
+		Action: runRepoSyncReleases,
 	}
 )
 
@@ -143,5 +152,71 @@ func runCreateUser(c *cli.Context) error {
 	}
 
 	fmt.Printf("New user '%s' has been successfully created!\n", c.String("name"))
+	return nil
+}
+
+func runRepoSyncReleases(c *cli.Context) error {
+
+	setting.NewContext()
+	models.LoadConfigs()
+
+	setting.NewXORMLogService(false)
+	if err := models.SetEngine(); err != nil {
+		return fmt.Errorf("models.SetEngine: %v", err)
+	}
+
+	log.Trace("Synchronizing repository releases (this may take a while)")
+	for page := 1; ; page++ {
+		repos, count, err := models.SearchRepositoryByName(&models.SearchRepoOptions{
+			Page:     page,
+			PageSize: models.RepositoryListDefaultPageSize,
+			Private:  true,
+		})
+		if err != nil {
+			log.Fatal(4, "SearchRepositoryByName: %v", err)
+			return err
+		}
+		if len(repos) == 0 {
+			break
+		}
+		log.Trace("Processing next %d repos of %d", len(repos), count)
+		for _, repo := range repos {
+			log.Trace("Synchronizing repo %s with path %s", repo.FullName(), repo.RepoPath())
+			gitRepo, err := git.OpenRepository(repo.RepoPath())
+			if err != nil {
+				log.Warn("OpenRepository: %v", err)
+				continue
+			}
+
+			oldnum, err := models.GetReleaseCountByRepoID(repo.ID,
+				models.FindReleasesOptions{
+					IncludeDrafts: false,
+					IncludeTags:   true,
+				})
+			if err != nil {
+				log.Warn(" GetReleaseCountByRepoID: %v", err)
+			}
+			log.Trace(" currentNumReleases is %d, running SyncReleasesWithTags", oldnum)
+
+			if err = models.SyncReleasesWithTags(repo, gitRepo); err != nil {
+				log.Warn(" SyncReleasesWithTags: %v", err)
+				continue
+			}
+
+			count, err = models.GetReleaseCountByRepoID(repo.ID,
+				models.FindReleasesOptions{
+					IncludeDrafts: false,
+					IncludeTags:   true,
+				})
+			if err != nil {
+				log.Warn(" GetReleaseCountByRepoID: %v", err)
+				continue
+			}
+
+			log.Trace(" repo %s releases synchronized to tags: from %d to %d",
+				repo.FullName(), oldnum, count)
+		}
+	}
+
 	return nil
 }

--- a/models/issue_indexer.go
+++ b/models/issue_indexer.go
@@ -29,7 +29,7 @@ func populateIssueIndexer() error {
 	for page := 1; ; page++ {
 		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
 			Page:        page,
-			PageSize:    10,
+			PageSize:    RepositoryListDefaultPageSize,
 			OrderBy:     SearchOrderByID,
 			Private:     true,
 			Collaborate: util.OptionalBoolFalse,

--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -81,7 +81,7 @@ func populateRepoIndexer() error {
 	for page := 1; ; page++ {
 		repos, _, err := SearchRepositoryByName(&SearchRepoOptions{
 			Page:     page,
-			PageSize: 10,
+			PageSize: RepositoryListDefaultPageSize,
 			OrderBy:  SearchOrderByID,
 			Private:  true,
 		})

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -13,6 +13,13 @@ import (
 	"github.com/go-xorm/builder"
 )
 
+// RepositoryListDefaultPageSize is the default number of repositories
+// to load in memory when running administrative tasks on all (or almost
+// all) of them.
+// The number should be low enough to avoid filling up all RAM with
+// repository data...
+const RepositoryListDefaultPageSize = 64
+
 // RepositoryList contains a list of repositories
 type RepositoryList []*Repository
 


### PR DESCRIPTION
This is a backport of what just landed in master (1.4.0 branch).
Being a new feature it doesn't really belong to 1.3 branch, but
there's currently no way to restore from a failed upgrade without
this new command, so anyone who upgraded from Gogs to Gitea 1.3 might
get stuck until 1.4.0 is out, which may take some time.

Or, we quickly release 1.4.0 for this new feature (I'd be in favor of
this too)