### PR TITLE
Turn time tracking off by default

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -298,7 +298,7 @@ DEFAULT_KEEP_EMAIL_PRIVATE = false
 DEFAULT_ALLOW_CREATE_ORGANIZATION = true
 ; Default value for EnableTimetracking
 ; Repositories will use timetracking by default depending on this setting
-DEFAULT_ENABLE_TIMETRACKING = true
+DEFAULT_ENABLE_TIMETRACKING = false
 ; Default value for AllowOnlyContributorsToTrackTime
 ; Only users with write permissions could track time if this is true
 DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME = true

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1185,7 +1185,7 @@ func newService() {
 	Service.EnableCaptcha = sec.Key("ENABLE_CAPTCHA").MustBool()
 	Service.DefaultKeepEmailPrivate = sec.Key("DEFAULT_KEEP_EMAIL_PRIVATE").MustBool()
 	Service.DefaultAllowCreateOrganization = sec.Key("DEFAULT_ALLOW_CREATE_ORGANIZATION").MustBool(true)
-	Service.DefaultEnableTimetracking = sec.Key("DEFAULT_ENABLE_TIMETRACKING").MustBool(false)
+	Service.DefaultEnableTimetracking = sec.Key("DEFAULT_ENABLE_TIMETRACKING").MustBool(!InstallLock)
 	Service.DefaultAllowOnlyContributorsToTrackTime = sec.Key("DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME").MustBool(true)
 	Service.NoReplyAddress = sec.Key("NO_REPLY_ADDRESS").MustString("noreply.example.org")
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1185,7 +1185,7 @@ func newService() {
 	Service.EnableCaptcha = sec.Key("ENABLE_CAPTCHA").MustBool()
 	Service.DefaultKeepEmailPrivate = sec.Key("DEFAULT_KEEP_EMAIL_PRIVATE").MustBool()
 	Service.DefaultAllowCreateOrganization = sec.Key("DEFAULT_ALLOW_CREATE_ORGANIZATION").MustBool(true)
-	Service.DefaultEnableTimetracking = sec.Key("DEFAULT_ENABLE_TIMETRACKING").MustBool(true)
+	Service.DefaultEnableTimetracking = sec.Key("DEFAULT_ENABLE_TIMETRACKING").MustBool(false)
 	Service.DefaultAllowOnlyContributorsToTrackTime = sec.Key("DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME").MustBool(true)
 	Service.NoReplyAddress = sec.Key("NO_REPLY_ADDRESS").MustString("noreply.example.org")
 


### PR DESCRIPTION
Timetracking is a new feature, so it should be off by default if
we want to apply such rule consisntently (OpenID was set to OFF
by default for the same reason)