### PR TITLE
Fixed asterisk based tasklist items #3295

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -60,8 +60,8 @@ var (
 	issueTasksDonePat *regexp.Regexp
 )
 
-const issueTasksRegexpStr = `(^\s*-\s\[[\sx]\]\s)|(\n\s*-\s\[[\sx]\]\s)`
-const issueTasksDoneRegexpStr = `(^\s*-\s\[[x]\]\s)|(\n\s*-\s\[[x]\]\s)`
+const issueTasksRegexpStr = `(^\s*[-*]\s\[[\sx]\]\s.)|(\n\s*[-*]\s\[[\sx]\]\s.)`
+const issueTasksDoneRegexpStr = `(^\s*[-*]\s\[[x]\]\s.)|(\n\s*[-*]\s\[[x]\]\s.)`
 
 func init() {
 	issueTasksPat = regexp.MustCompile(issueTasksRegexpStr)


### PR DESCRIPTION
Fixed the possibility to use asterisk in tasklists as described in #3295.

Also fixed the requirement for one character after the blank of `- [ ] `.