### PR TITLE
Make the space for repo actions wider on repo header

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -2,7 +2,7 @@
 {{with .Repository}}
 	<div class="ui container">
 		<div class="ui stackable grid header-grid">
-			<div class="ten wide column">
+			<div class="eight wide column">
 				<div class="ui huge breadcrumb">
 					<i class="mega-octicon octicon-{{if .IsPrivate}}lock{{else if .IsMirror}}repo-clone{{else if .IsFork}}repo-forked{{else}}repo{{end}}"></i>
 					<a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a>
@@ -13,7 +13,7 @@
 				</div>
 			</div>
 
-			<div class="ui six wide right aligned column">
+			<div class="ui eight wide right aligned column">
 				<div class="ui compact labeled button" tabindex="0">
 					<a class="ui compact button" href="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}">
 						<i class="icon fa-eye{{if not $.IsWatchingRepo}}-slash{{end}}"></i>{{if $.IsWatchingRepo}}{{$.i18n.Tr "repo.unwatch"}}{{else}}{{$.i18n.Tr "repo.watch"}}{{end}}


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/4681308/34641180-62de588e-f300-11e7-9823-9b3373faef5f.png)


After: 
![image](https://user-images.githubusercontent.com/4681308/34641177-556c3a72-f300-11e7-8e5b-97d75ee8d39e.png)
