### PR TITLE
Change EncodePasswd to HashPassword

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -111,7 +111,7 @@ func runChangePassword(c *cli.Context) error {
 	if user.Salt, err = models.GetUserSalt(); err != nil {
 		return fmt.Errorf("%v", err)
 	}
-	user.EncodePasswd()
+	user.HashPassword()
 	if err := models.UpdateUserCols(user, "passwd", "salt"); err != nil {
 		return fmt.Errorf("%v", err)
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -388,8 +388,8 @@ func (u *User) NewGitSig() *git.Signature {
 	}
 }
 
-// EncodePasswd encodes password to safe format.
-func (u *User) EncodePasswd() {
+// HashPassword hashes a password using PBKDF.
+func (u *User) HashPassword() {
 	newPasswd := pbkdf2.Key([]byte(u.Passwd), []byte(u.Salt), 10000, 50, sha256.New)
 	u.Passwd = fmt.Sprintf("%x", newPasswd)
 }
@@ -397,7 +397,7 @@ func (u *User) EncodePasswd() {
 // ValidatePassword checks if given password matches the one belongs to the user.
 func (u *User) ValidatePassword(passwd string) bool {
 	newUser := &User{Passwd: passwd, Salt: u.Salt}
-	newUser.EncodePasswd()
+	newUser.HashPassword()
 	return subtle.ConstantTimeCompare([]byte(u.Passwd), []byte(newUser.Passwd)) == 1
 }
 
@@ -711,7 +711,7 @@ func CreateUser(u *User) (err error) {
 	if u.Salt, err = GetUserSalt(); err != nil {
 		return err
 	}
-	u.EncodePasswd()
+	u.HashPassword()
 	u.AllowCreateOrganization = setting.Service.DefaultAllowCreateOrganization
 	u.MaxRepoCreation = -1
 

--- a/routers/admin/users.go
+++ b/routers/admin/users.go
@@ -200,7 +200,7 @@ func EditUserPost(ctx *context.Context, form auth.AdminEditUserForm) {
 			ctx.Handle(500, "UpdateUser", err)
 			return
 		}
-		u.EncodePasswd()
+		u.HashPassword()
 	}
 
 	u.LoginName = form.LoginName

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -132,7 +132,7 @@ func EditUser(ctx *context.APIContext, form api.EditUserOption) {
 			ctx.Error(500, "UpdateUser", err)
 			return
 		}
-		u.EncodePasswd()
+		u.HashPassword()
 	}
 
 	u.LoginName = form.LoginName

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -994,7 +994,7 @@ func ResetPasswdPost(ctx *context.Context) {
 			ctx.Handle(500, "UpdateUser", err)
 			return
 		}
-		u.EncodePasswd()
+		u.HashPassword()
 		if err := models.UpdateUserCols(u, "passwd", "rands", "salt"); err != nil {
 			ctx.Handle(500, "UpdateUser", err)
 			return

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -235,7 +235,7 @@ func SettingsSecurityPost(ctx *context.Context, form auth.ChangePasswordForm) {
 			ctx.Handle(500, "UpdateUser", err)
 			return
 		}
-		ctx.User.EncodePasswd()
+		ctx.User.HashPassword()
 		if err := models.UpdateUserCols(ctx.User, "salt", "passwd"); err != nil {
 			ctx.Handle(500, "UpdateUser", err)
 			return


### PR DESCRIPTION
Gogs used the function "EncodePasswd" - when really the function in question __hashes__ the data, and does not encode it.

Encoding and encrypting imply that there is a way to decode or decrypt. A hashing function, instead, is by definition impossible to reverse if not by brute force - which is the case of PBKDF2, and any password-hashing function that should be used in modern applications.
  