### PR TITLE
Use raw status codes when calling ctx.Handle

### DIFF
--- a/routers/repo/issue_stopwatch.go
+++ b/routers/repo/issue_stopwatch.go
@@ -18,12 +18,12 @@ func IssueStopwatch(c *context.Context) {
 		return
 	}
 	if !c.Repo.CanUseTimetracker(issue, c.User) {
-		c.Handle(http.StatusNotFound, "CanUseTimetracker", nil)
+		c.Handle(404, "CanUseTimetracker", nil)
 		return
 	}
 
 	if err := models.CreateOrStopIssueStopwatch(c.User, issue); err != nil {
-		c.Handle(http.StatusInternalServerError, "CreateOrStopIssueStopwatch", err)
+		c.Handle(500, "CreateOrStopIssueStopwatch", err)
 		return
 	}
 
@@ -38,12 +38,12 @@ func CancelStopwatch(c *context.Context) {
 		return
 	}
 	if !c.Repo.CanUseTimetracker(issue, c.User) {
-		c.Handle(http.StatusNotFound, "CanUseTimetracker", nil)
+		c.Handle(404, "CanUseTimetracker", nil)
 		return
 	}
 
 	if err := models.CancelStopwatch(c.User, issue); err != nil {
-		c.Handle(http.StatusInternalServerError, "CancelStopwatch", err)
+		c.Handle(500, "CancelStopwatch", err)
 		return
 	}
 

--- a/routers/repo/issue_timetrack.go
+++ b/routers/repo/issue_timetrack.go
@@ -20,7 +20,7 @@ func AddTimeManually(c *context.Context, form auth.AddTimeManuallyForm) {
 		return
 	}
 	if !c.Repo.CanUseTimetracker(issue, c.User) {
-		c.Handle(http.StatusNotFound, "CanUseTimetracker", nil)
+		c.Handle(404, "CanUseTimetracker", nil)
 		return
 	}
 	url := issue.HTMLURL()
@@ -40,7 +40,7 @@ func AddTimeManually(c *context.Context, form auth.AddTimeManuallyForm) {
 	}
 
 	if _, err := models.AddTime(c.User, issue, int64(total.Seconds())); err != nil {
-		c.Handle(http.StatusInternalServerError, "AddTime", err)
+		c.Handle(500, "AddTime", err)
 		return
 	}
 

--- a/routers/repo/issue_watch.go
+++ b/routers/repo/issue_watch.go
@@ -17,7 +17,7 @@ import (
 func IssueWatch(c *context.Context) {
 	watch, err := strconv.ParseBool(c.Req.PostForm.Get("watch"))
 	if err != nil {
-		c.Handle(http.StatusInternalServerError, "watch is not bool", err)
+		c.Handle(500, "watch is not bool", err)
 		return
 	}
 
@@ -27,7 +27,7 @@ func IssueWatch(c *context.Context) {
 	}
 
 	if err := models.CreateOrUpdateIssueWatch(c.User.ID, issue.ID, watch); err != nil {
-		c.Handle(http.StatusInternalServerError, "CreateOrUpdateIssueWatch", err)
+		c.Handle(500, "CreateOrUpdateIssueWatch", err)
 		return
 	}
 


### PR DESCRIPTION
Almost every instance of Context.Handle uses a raw HTTP status code - either 404 or 500. For consistency, I replaced the few instances where http.Status* was still used.