### PR TITLE
Remove hardcoded paths to fix randomly failing tests

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -138,6 +138,7 @@ func prepareTestEnv(t testing.TB) {
 	assert.NoError(t, models.LoadFixtures())
 	assert.NoError(t, os.RemoveAll(setting.RepoRootPath))
 	assert.NoError(t, os.RemoveAll(models.LocalCopyPath()))
+	assert.NoError(t, os.RemoveAll(models.LocalWikiPath()))
 
 	assert.NoError(t, com.CopyDir(path.Join(filepath.Dir(setting.AppPath), "integrations/gitea-repositories-meta"),
 		setting.RepoRootPath))

--- a/integrations/mysql.ini.tmpl
+++ b/integrations/mysql.ini.tmpl
@@ -20,6 +20,7 @@ ROOT = integrations/gitea-integration-mysql/gitea-repositories
 
 [repository.local]
 LOCAL_COPY_PATH = tmp/local-repo-mysql
+LOCAL_WIKI_PATH = tmp/local-wiki-mysql
 
 [server]
 SSH_DOMAIN       = localhost

--- a/integrations/pgsql.ini.tmpl
+++ b/integrations/pgsql.ini.tmpl
@@ -20,6 +20,7 @@ ROOT = integrations/gitea-integration-pgsql/gitea-repositories
 
 [repository.local]
 LOCAL_COPY_PATH = tmp/local-repo-pgsql
+LOCAL_WIKI_PATH = tmp/local-wiki-pgsql
 
 [server]
 SSH_DOMAIN       = localhost

--- a/integrations/sqlite.ini
+++ b/integrations/sqlite.ini
@@ -15,6 +15,7 @@ ROOT = integrations/gitea-integration-sqlite/gitea-repositories
 
 [repository.local]
 LOCAL_COPY_PATH = tmp/local-repo-sqlite
+LOCAL_WIKI_PATH = tmp/local-wiki-sqlite
 
 [server]
 SSH_DOMAIN       = localhost
@@ -23,6 +24,7 @@ ROOT_URL         = http://localhost:3003/
 DISABLE_SSH      = false
 SSH_PORT         = 22
 LFS_START_SERVER = true
+LFS_CONTENT_PATH = data/lfs-sqlite
 OFFLINE_MODE     = false
 LFS_JWT_SECRET   = Tv_MjmZuHqpIY6GFl12ebgkRAMt4RlWt0v4EHKSXO0w
 

--- a/models/pull.go
+++ b/models/pull.go
@@ -299,7 +299,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 	}
 
 	// Clone base repo.
-	tmpBasePath := path.Join(setting.Repository.Local.LocalCopyPath, "merge-"+com.ToStr(time.Now().Nanosecond())+".git")
+	tmpBasePath := path.Join(LocalCopyPath(), "merge-"+com.ToStr(time.Now().Nanosecond())+".git")
 
 	if err := os.MkdirAll(path.Dir(tmpBasePath), os.ModePerm); err != nil {
 		return fmt.Errorf("Failed to create dir %s: %v", tmpBasePath, err)

--- a/models/pull.go
+++ b/models/pull.go
@@ -299,7 +299,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 	}
 
 	// Clone base repo.
-	tmpBasePath := path.Join(setting.AppDataPath, "tmp/repos", com.ToStr(time.Now().Nanosecond())+".git")
+	tmpBasePath := path.Join(setting.Repository.Local.LocalCopyPath, "merge-"+com.ToStr(time.Now().Nanosecond())+".git")
 
 	if err := os.MkdirAll(path.Dir(tmpBasePath), os.ModePerm); err != nil {
 		return fmt.Errorf("Failed to create dir %s: %v", tmpBasePath, err)

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -90,9 +90,17 @@ func (repo *Repository) InitWiki() error {
 	return nil
 }
 
+// LocalWikiPath returns the local wiki repository copy path.
+func LocalWikiPath() string {
+	if filepath.IsAbs(setting.Repository.Local.LocalWikiPath) {
+		return setting.Repository.Local.LocalWikiPath
+	}
+	return path.Join(setting.AppDataPath, setting.Repository.Local.LocalWikiPath)
+}
+
 // LocalWikiPath returns the path to the local wiki repository (?).
 func (repo *Repository) LocalWikiPath() string {
-	return path.Join(setting.AppDataPath, "tmp/local-wiki", com.ToStr(repo.ID))
+	return path.Join(LocalWikiPath(), com.ToStr(repo.ID))
 }
 
 // UpdateLocalWiki makes sure the local copy of repository wiki is up-to-date.

--- a/models/wiki_test.go
+++ b/models/wiki_test.go
@@ -145,7 +145,7 @@ func TestRepository_InitWiki(t *testing.T) {
 func TestRepository_LocalWikiPath(t *testing.T) {
 	PrepareTestEnv(t)
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
-	expected := filepath.Join(setting.AppDataPath, "tmp/local-wiki/1")
+	expected := filepath.Join(setting.AppDataPath, setting.Repository.Local.LocalWikiPath, "1")
 	assert.Equal(t, expected, repo.LocalWikiPath())
 }
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -215,6 +215,7 @@ var (
 		// Repository local settings
 		Local struct {
 			LocalCopyPath string
+			LocalWikiPath string
 		} `ini:"-"`
 	}{
 		AnsiCharset:            "",
@@ -254,8 +255,10 @@ var (
 		// Repository local settings
 		Local: struct {
 			LocalCopyPath string
+			LocalWikiPath string
 		}{
 			LocalCopyPath: "tmp/local-repo",
+			LocalWikiPath: "tmp/local-wiki",
 		},
 	}
 	RepoRootPath string


### PR DESCRIPTION
* Adds option for `LOCAL_WIKI_PATH` so that it would not be hardcoded
* Reuse local repository path when merging

