### PR TITLE
Delete indexer DB entries when (re)creating index

### DIFF
--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -86,6 +86,12 @@ func populateRepoIndexerAsynchronously() error {
 		return nil
 	}
 
+	// if there is any existing repo indexer metadata in the DB, delete it
+	// since we are starting afresh.
+	if _, err := x.Where("1=1").Delete(new(RepoIndexerStatus)); err != nil {
+		return err
+	}
+
 	var maxRepoID int64
 	if _, err = x.Select("MAX(id)").Table("repository").Get(&maxRepoID); err != nil {
 		return err

--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -87,7 +87,8 @@ func populateRepoIndexerAsynchronously() error {
 	}
 
 	// if there is any existing repo indexer metadata in the DB, delete it
-	// since we are starting afresh.
+	// since we are starting afresh. Also, xorm requires deletes to have a
+	// condition, and we want to delete everything, thus 1=1.
 	if _, err := x.Where("1=1").Delete(new(RepoIndexerStatus)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, if you needed to recreate the repo indexer, you need to delete the indexer *and* manually clear the `repo_indexer_status` table in the DB. Now, you just need to delete the indexer.