### PR TITLE
Force-push to base repo's ref/pull/#/head

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -1005,7 +1005,7 @@ func (pr *PullRequest) PushToBaseRepo() (err error) {
 	if err = git.Push(headRepoPath, git.PushOptions{
 		Remote: tmpRemoteName,
 		Branch: fmt.Sprintf("%s:%s", pr.HeadBranch, headFile),
-		Force: true,
+		Force:  true,
 	}); err != nil {
 		return fmt.Errorf("Push: %v", err)
 	}

--- a/models/pull.go
+++ b/models/pull.go
@@ -1005,6 +1005,7 @@ func (pr *PullRequest) PushToBaseRepo() (err error) {
 	if err = git.Push(headRepoPath, git.PushOptions{
 		Remote: tmpRemoteName,
 		Branch: fmt.Sprintf("%s:%s", pr.HeadBranch, headFile),
+		Force: true,
 	}); err != nil {
 		return fmt.Errorf("Push: %v", err)
 	}


### PR DESCRIPTION
Fixes force-pushing to pull request branches, otherwise failing with:

[...gitea/models/pull.go:1022 AddTestPullRequestTask()] [E] PushToBaseRepo: Push: exit status 1 - To /path/to/gitea-repositories/org/repo.git
 ! [rejected]        issue-fix -> refs/pull/20/head (non-fast-forward)