### PR TITLE
Fix empty checkout bug

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -774,17 +774,17 @@ func UpdateLocalCopyBranch(repoPath, localPath, branch string) error {
 			return fmt.Errorf("git clone %s: %v", branch, err)
 		}
 	} else {
-		if err := git.Checkout(localPath, git.CheckoutOptions{
-			Branch: branch,
-		}); err != nil {
-			return fmt.Errorf("git checkout %s: %v", branch, err)
-		}
-
 		_, err := git.NewCommand("fetch", "origin").RunInDir(localPath)
 		if err != nil {
 			return fmt.Errorf("git fetch origin: %v", err)
 		}
 		if len(branch) > 0 {
+			if err := git.Checkout(localPath, git.CheckoutOptions{
+				Branch: branch,
+			}); err != nil {
+				return fmt.Errorf("git checkout %s: %v", branch, err)
+			}
+
 			if err := git.ResetHEAD(localPath, true, "origin/"+branch); err != nil {
 				return fmt.Errorf("git reset --hard origin/%s: %v", branch, err)
 			}


### PR DESCRIPTION
With newer versions of git, checking out an empty pathspec results in an error.

See https://github.com/go-gitea/gitea/blob/36a94da8dab112f47ee1774f2ae9a8fd7ca21a1c/models/repo_indexer.go#L170