### PR TITLE
Add the ability to use multiple labels as filters

### DIFF
--- a/models/fixtures/issue_label.yml
+++ b/models/fixtures/issue_label.yml
@@ -12,8 +12,3 @@
   id: 3
   issue_id: 2
   label_id: 1
-
--
-  id: 4
-  issue_id: 1
-  label_id: 2

--- a/models/fixtures/issue_label.yml
+++ b/models/fixtures/issue_label.yml
@@ -12,3 +12,8 @@
   id: 3
   issue_id: 2
   label_id: 1
+
+-
+  id: 4
+  issue_id: 1
+  label_id: 2

--- a/models/issue.go
+++ b/models/issue.go
@@ -1144,7 +1144,7 @@ func (opts *IssuesOptions) setupSession(sess *xorm.Session) error {
 			sess.
 				Join("INNER", "issue_label", "issue.id = issue_label.issue_id").
 				In("issue_label.label_id", labelIDs)
-		} else if len(labelIDs) > 1{
+		} else if len(labelIDs) > 1 {
 			cond, args, _ := builder.ToSQL(builder.In("issue_label.label_id", labelIDs))
 			sess.
 				Where(fmt.Sprintf(`issue.id IN (

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -78,12 +78,12 @@ func (label *Label) CalOpenIssues() {
 	label.NumOpenIssues = label.NumIssues - label.NumClosedIssues
 }
 
-// CalQueryString calculates query string in issue/pulls list
-func (label *Label) CalQueryString(query []string) {
+// LoadSelectedLabelsAfterClick calculates the set of selected labels when a label is clicked
+func (label *Label) LoadSelectedLabelsAfterClick(currentSelectedLabels []string) {
 	var labelQuerySlice []string
 	labelSelected := false
 	labelID := fmt.Sprint(label.ID)
-	for _, s := range query {
+	for _, s := range currentSelectedLabels {
 		if s == labelID {
 			labelSelected = true
 		} else if s != "" {

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -60,6 +60,8 @@ type Label struct {
 	NumClosedIssues int
 	NumOpenIssues   int  `xorm:"-"`
 	IsChecked       bool `xorm:"-"`
+	QueryString     string
+	IsSelected      bool
 }
 
 // APIFormat converts a Label to the api.Label format
@@ -74,6 +76,25 @@ func (label *Label) APIFormat() *api.Label {
 // CalOpenIssues calculates the open issues of label.
 func (label *Label) CalOpenIssues() {
 	label.NumOpenIssues = label.NumIssues - label.NumClosedIssues
+}
+
+// CalQueryString calculates query string in issue/pulls list
+func (label *Label) CalQueryString(query []string) {
+	var labelQuerySlice []string
+	labelSelected := false
+	labelID := fmt.Sprint(label.ID)
+	for _, s := range query {
+		if s == labelID {
+			labelSelected = true
+		} else {
+			labelQuerySlice = append(labelQuerySlice, s)
+		}
+	}
+	if !labelSelected {
+		labelQuerySlice = append(labelQuerySlice, labelID)
+	}
+	label.IsSelected = labelSelected
+	label.QueryString = strings.Join(labelQuerySlice, ",")
 }
 
 // ForegroundColor calculates the text color for labels based

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -86,7 +86,7 @@ func (label *Label) CalQueryString(query []string) {
 	for _, s := range query {
 		if s == labelID {
 			labelSelected = true
-		} else {
+		} else if s != "" {
 			labelQuerySlice = append(labelQuerySlice, s)
 		}
 	}

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -193,11 +193,19 @@ func TestIssues(t *testing.T) {
 		},
 		{
 			IssuesOptions{
+				Labels:   "1",
+				Page:     1,
+				PageSize: 4,
+			},
+			[]int64{2, 1},
+		},
+		{
+			IssuesOptions{
 				Labels:   "1,2",
 				Page:     1,
 				PageSize: 4,
 			},
-			[]int64{5, 2, 1},
+			[]int64{1},
 		},
 	} {
 		issues, err := Issues(&test.Opts)

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -205,7 +205,7 @@ func TestIssues(t *testing.T) {
 				Page:     1,
 				PageSize: 4,
 			},
-			[]int64{1},
+			[]int64{1}, // issues with **both** label 1 and 2, only issue 1 matches
 		},
 	} {
 		issues, err := Issues(&test.Opts)

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -205,7 +205,7 @@ func TestIssues(t *testing.T) {
 				Page:     1,
 				PageSize: 4,
 			},
-			[]int64{1}, // issues with **both** label 1 and 2, only issue 1 matches
+			[]int64{}, // issues with **both** label 1 and 2, none of these issues matches, TODO: add more tests
 		},
 	} {
 		issues, err := Issues(&test.Opts)

--- a/routers/repo/issue_label.go
+++ b/routers/repo/issue_label.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"strings"
+
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/auth"
 	"code.gitea.io/gitea/modules/base"
@@ -63,6 +65,23 @@ func RetrieveLabels(ctx *context.Context) {
 	}
 	for _, l := range labels {
 		l.CalOpenIssues()
+	}
+	ctx.Data["Labels"] = labels
+	ctx.Data["NumLabels"] = len(labels)
+	ctx.Data["SortType"] = ctx.Query("sort")
+}
+
+// RetreveLabelsAndCalQueryString calculate query string when filtering issues/pulls
+func RetreveLabelsAndCalQueryString(ctx *context.Context) {
+	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Query("sort"))
+	if err != nil {
+		ctx.ServerError("RetreveLabelsAndCalQueryString.GetLabels", err)
+		return
+	}
+	selectLabelsSlice := strings.Split(ctx.Query("labels"), ",")
+	for _, l := range labels {
+		l.CalOpenIssues()
+		l.CalQueryString(selectLabelsSlice)
 	}
 	ctx.Data["Labels"] = labels
 	ctx.Data["NumLabels"] = len(labels)

--- a/routers/repo/issue_label.go
+++ b/routers/repo/issue_label.go
@@ -71,17 +71,17 @@ func RetrieveLabels(ctx *context.Context) {
 	ctx.Data["SortType"] = ctx.Query("sort")
 }
 
-// RetreveLabelsAndCalQueryString calculate query string when filtering issues/pulls
-func RetreveLabelsAndCalQueryString(ctx *context.Context) {
+// RetrieveLabelsAndLoadSelectedLabels calculate query string when filtering issues/pulls
+func RetrieveLabelsAndLoadSelectedLabels(ctx *context.Context) {
 	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Query("sort"))
 	if err != nil {
-		ctx.ServerError("RetreveLabelsAndCalQueryString.GetLabels", err)
+		ctx.ServerError("RetrieveLabelsAndLoadSelectedLabels.GetLabels", err)
 		return
 	}
-	selectLabelsSlice := strings.Split(ctx.Query("labels"), ",")
+	selectLabels := strings.Split(ctx.Query("labels"), ",")
 	for _, l := range labels {
 		l.CalOpenIssues()
-		l.CalQueryString(selectLabelsSlice)
+		l.LoadSelectedLabelsAfterClick(selectLabels)
 	}
 	ctx.Data["Labels"] = labels
 	ctx.Data["NumLabels"] = len(labels)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -585,7 +585,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 
 	m.Group("/:username/:reponame", func() {
 		m.Group("", func() {
-			m.Get("/^:type(issues|pulls)$", repo.RetreveLabelsAndCalQueryString, repo.Issues)
+			m.Get("/^:type(issues|pulls)$", repo.RetrieveLabelsAndLoadSelectedLabels, repo.Issues)
 			m.Get("/^:type(issues|pulls)$/:index", repo.ViewIssue)
 			m.Get("/labels/", context.CheckAnyUnit(models.UnitTypeIssues, models.UnitTypePullRequests), repo.RetrieveLabels, repo.Labels)
 			m.Get("/milestones", context.CheckAnyUnit(models.UnitTypeIssues, models.UnitTypePullRequests), repo.Milestones)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -585,7 +585,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 
 	m.Group("/:username/:reponame", func() {
 		m.Group("", func() {
-			m.Get("/^:type(issues|pulls)$", repo.RetrieveLabels, repo.Issues)
+			m.Get("/^:type(issues|pulls)$", repo.RetreveLabelsAndCalQueryString, repo.Issues)
 			m.Get("/^:type(issues|pulls)$/:index", repo.ViewIssue)
 			m.Get("/labels/", context.CheckAnyUnit(models.UnitTypeIssues, models.UnitTypePullRequests), repo.RetrieveLabels, repo.Labels)
 			m.Get("/milestones", context.CheckAnyUnit(models.UnitTypeIssues, models.UnitTypePullRequests), repo.Milestones)

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -42,7 +42,7 @@
 						<div class="menu">
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}"><span class="octicon {{if eq $.SelectLabels .ID}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name}}</a>
+								<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}"><span class="octicon {{if .IsSelected}}octicon-check{{end}}"></span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name}}</a>
 							{{end}}
 						</div>
 					</div>


### PR DESCRIPTION
Implements Issue #3430 

![multiplelabels](https://user-images.githubusercontent.com/5517838/35624310-9ba558f2-06c9-11e8-8b89-1fd16c3f73f8.png)

As in GitHub, when selecting multiple labels, only display those issues with all the labels selected.

I cannot figure out how to achieve this using the orm provided, so I write a subquery.

Then I use `Label.QueryString` and `Label.IsSelected` for the query string(issues?labels=xxx) and the tick before labels.