### PR TITLE
Clarify indexer MAX_FILE_SIZE setting

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -128,7 +128,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `REPO_INDEXER_ENABLED`: **false**: Enables code search (uses a lot of disk space).
 - `REPO_INDEXER_PATH`: **indexers/repos.bleve**: Index file used for code search.
 - `UPDATE_BUFFER_LEN`: **20**: Buffer length of index request.
-- `MAX_FILE_SIZE`: **1048576**: Maximum size in bytes of each index files.
+- `MAX_FILE_SIZE`: **1048576**: Maximum size in bytes of files to be indexed.
 
 ## Security (`security`)
 


### PR DESCRIPTION
MAX_FILE_SIZE is the maximum file size for a file to be indexed. It's not the max file size for the index file itself.

https://github.com/go-gitea/gitea/issues/3457