### PR TITLE
Update code.gitea.io/git

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"code.gitea.io/git"
@@ -368,8 +369,15 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 			a := line[beg+2 : middle]
 			b := line[middle+3:]
 			if hasQuote {
-				a = string(git.UnescapeChars([]byte(a[1 : len(a)-1])))
-				b = string(git.UnescapeChars([]byte(b[1 : len(b)-1])))
+				var err error
+				a, err = strconv.Unquote(a)
+				if err != nil {
+					return nil, fmt.Errorf("Unquote: %v", err)
+				}
+				b, err = strconv.Unquote(b)
+				if err != nil {
+					return nil, fmt.Errorf("Unquote: %v", err)
+				}
 			}
 
 			curFile = &DiffFile{

--- a/vendor/code.gitea.io/git/parse.go
+++ b/vendor/code.gitea.io/git/parse.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// ParseTreeEntries parses the output of a `git ls-tree` command.
+func ParseTreeEntries(data []byte) ([]*TreeEntry, error) {
+	return parseTreeEntries(data, nil)
+}
+
+func parseTreeEntries(data []byte, ptree *Tree) ([]*TreeEntry, error) {
+	entries := make([]*TreeEntry, 0, 10)
+	for pos := 0; pos < len(data); {
+		// expect line to be of the form "<mode> <type> <sha>\t<filename>"
+		entry := new(TreeEntry)
+		entry.ptree = ptree
+		if pos+6 > len(data) {
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
+		}
+		switch string(data[pos : pos+6]) {
+		case "100644":
+			entry.mode = EntryModeBlob
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "100644 blob "
+		case "100755":
+			entry.mode = EntryModeExec
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "100755 blob "
+		case "120000":
+			entry.mode = EntryModeSymlink
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "120000 blob "
+		case "160000":
+			entry.mode = EntryModeCommit
+			entry.Type = ObjectCommit
+			pos += 14 // skip over "160000 object "
+		case "040000":
+			entry.mode = EntryModeTree
+			entry.Type = ObjectTree
+			pos += 12 // skip over "040000 tree "
+		default:
+			return nil, fmt.Errorf("unknown type: %v", string(data[pos:pos+6]))
+		}
+
+		if pos+40 > len(data) {
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
+		}
+		id, err := NewIDFromString(string(data[pos : pos+40]))
+		if err != nil {
+			return nil, fmt.Errorf("Invalid ls-tree output: %v", err)
+		}
+		entry.ID = id
+		pos += 41 // skip over sha and trailing space
+
+		end := pos + bytes.IndexByte(data[pos:], '\n')
+		if end < pos {
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
+		}
+
+		// In case entry name is surrounded by double quotes(it happens only in git-shell).
+		if data[pos] == '"' {
+			entry.name, err = strconv.Unquote(string(data[pos:end]))
+			if err != nil {
+				return nil, fmt.Errorf("Invalid ls-tree output: %v", err)
+			}
+		} else {
+			entry.name = string(data[pos:end])
+		}
+
+		pos = end + 1
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test appengine",
 	"package": [
 		{
-			"checksumSHA1": "Gz+a5Qo4PCiB/Gf2f02v8HEAxDM=",
+			"checksumSHA1": "j6YyQxuOYRs94MVEamvnbE6ZtD0=",
 			"path": "code.gitea.io/git",
-			"revision": "6798d0f202cdc7187c00a467b586a4bdee27e8c9",
-			"revisionTime": "2018-01-14T14:37:32Z"
+			"revision": "827f97aaaa6a4ab5c31b1b799c56687a8cf6aade",
+			"revisionTime": "2018-02-10T03:05:43Z"
 		},
 		{
 			"checksumSHA1": "Qtq0kW+BnpYMOriaoCjMa86WGG8=",


### PR DESCRIPTION
Includes https://github.com/go-gitea/git/pull/110. Also updates repo indexer code to use newly-added `ParseTreeEntries(..)` function.