### PR TITLE
Escape repo search query

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/html/charset"
 	"golang.org/x/text/transform"
 	"gopkg.in/editorconfig/editorconfig-core-go.v1"
+	"html"
 )
 
 // NewFuncMap returns functions for injecting to templates
@@ -179,6 +180,7 @@ func NewFuncMap() []template.FuncMap {
 			return dict, nil
 		},
 		"Printf": fmt.Sprintf,
+		"Escape": Escape,
 	}}
 }
 
@@ -195,6 +197,11 @@ func SafeJS(raw string) template.JS {
 // Str2html render Markdown text to HTML
 func Str2html(raw string) template.HTML {
 	return template.HTML(markup.Sanitize(raw))
+}
+
+// Escape escapes a HTML string
+func Escape(raw string) string {
+	return html.EscapeString(raw)
 }
 
 // List traversings the list

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -14,7 +14,7 @@
 		</div>
 		{{if .Keyword}}
 			<h3>
-				{{.i18n.Tr "repo.search.results" .Keyword .RepoLink .RepoName | Str2html}}
+				{{.i18n.Tr "repo.search.results" (.Keyword|Escape) .RepoLink .RepoName | Str2html }}
 			</h3>
 			<div class="repository search">
 				{{range $result := .SearchResults}}


### PR DESCRIPTION
Fixes #3485 by escaping the search term.

Needs perhaps a backport to 1.3 and 1.4.