### PR TITLE
Use unique temp dirs in unit tests

### DIFF
--- a/models/unit_tests.go
+++ b/models/unit_tests.go
@@ -63,10 +63,10 @@ func MainTest(m *testing.M, pathToGiteaRoot string) {
 	}
 
 	exitStatus := m.Run()
-	if err = os.RemoveAll(setting.RepoRootPath); err != nil {
+	if err = removeAllWithRetry(setting.RepoRootPath); err != nil {
 		fatalTestError("os.RemoveAll: %v\n", err)
 	}
-	if err = os.RemoveAll(setting.AppDataPath); err != nil {
+	if err = removeAllWithRetry(setting.AppDataPath); err != nil {
 		fatalTestError("os.RemoveAll: %v\n", err)
 	}
 	os.Exit(exitStatus)

--- a/models/unit_tests.go
+++ b/models/unit_tests.go
@@ -6,6 +6,8 @@ package models
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +20,6 @@ import (
 	"github.com/go-xorm/xorm"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/testfixtures.v2"
-	"net/url"
 )
 
 // NonexistentID an ID that will never exist
@@ -42,8 +43,16 @@ func MainTest(m *testing.M, pathToGiteaRoot string) {
 	setting.RunUser = "runuser"
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
-	setting.RepoRootPath = filepath.Join(os.TempDir(), "repos")
-	setting.AppDataPath = filepath.Join(os.TempDir(), "appdata")
+	setting.RepoRootPath, err = ioutil.TempDir(os.TempDir(), "repos")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TempDir: %v\n", err)
+		os.Exit(1)
+	}
+	setting.AppDataPath, err = ioutil.TempDir(os.TempDir(), "appdata")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TempDir: %v\n", err)
+		os.Exit(1)
+	}
 	setting.AppWorkPath = pathToGiteaRoot
 	setting.StaticRootPath = pathToGiteaRoot
 	setting.GravatarSourceURL, err = url.Parse("https://secure.gravatar.com/avatar/")


### PR DESCRIPTION
Using a fixed directory causes problems if you run tests in parallel.

Using a fixed directory may have also caused tests to be flaky (e.g. https://drone.gitea.io/go-gitea/gitea/3530/8).