### PR TITLE
Fix escaping changed title in comments

### DIFF
--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -56,7 +56,7 @@ func TestPullMerge(t *testing.T) {
 	testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 	testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
 
-	resp := testPullCreate(t, session, "user1", "repo1", "master")
+	resp := testPullCreate(t, session, "user1", "repo1", "master", "This is a pull title")
 
 	elem := strings.Split(test.RedirectURL(resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
@@ -69,7 +69,7 @@ func TestPullRebase(t *testing.T) {
 	testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 	testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
 
-	resp := testPullCreate(t, session, "user1", "repo1", "master")
+	resp := testPullCreate(t, session, "user1", "repo1", "master", "This is a pull title")
 
 	elem := strings.Split(test.RedirectURL(resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
@@ -83,7 +83,7 @@ func TestPullSquash(t *testing.T) {
 	testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
 	testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited!)\n")
 
-	resp := testPullCreate(t, session, "user1", "repo1", "master")
+	resp := testPullCreate(t, session, "user1", "repo1", "master", "This is a pull title")
 
 	elem := strings.Split(test.RedirectURL(resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
@@ -96,7 +96,7 @@ func TestPullCleanUpAfterMerge(t *testing.T) {
 	testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 	testEditFileToNewBranch(t, session, "user1", "repo1", "master", "feature/test", "README.md", "Hello, World (Edited)\n")
 
-	resp := testPullCreate(t, session, "user1", "repo1", "feature/test")
+	resp := testPullCreate(t, session, "user1", "repo1", "feature/test", "This is a pull title")
 
 	elem := strings.Split(test.RedirectURL(resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])

--- a/integrations/repo_activity_test.go
+++ b/integrations/repo_activity_test.go
@@ -22,16 +22,16 @@ func TestRepoActivity(t *testing.T) {
 	// Create PRs (1 merged & 2 proposed)
 	testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 	testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
-	resp := testPullCreate(t, session, "user1", "repo1", "master")
+	resp := testPullCreate(t, session, "user1", "repo1", "master", "This is a pull title")
 	elem := strings.Split(test.RedirectURL(resp), "/")
 	assert.EqualValues(t, "pulls", elem[3])
 	testPullMerge(t, session, elem[1], elem[2], elem[4], models.MergeStyleMerge)
 
 	testEditFileToNewBranch(t, session, "user1", "repo1", "master", "feat/better_readme", "README.md", "Hello, World (Edited Again)\n")
-	testPullCreate(t, session, "user1", "repo1", "feat/better_readme")
+	testPullCreate(t, session, "user1", "repo1", "feat/better_readme", "This is a pull title")
 
 	testEditFileToNewBranch(t, session, "user1", "repo1", "master", "feat/much_better_readme", "README.md", "Hello, World (Edited More)\n")
-	testPullCreate(t, session, "user1", "repo1", "feat/much_better_readme")
+	testPullCreate(t, session, "user1", "repo1", "feat/much_better_readme", "This is a pull title")
 
 	// Create issues (3 new issues)
 	testNewIssue(t, session, "user2", "repo1", "Issue 1", "Description 1")

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -103,7 +103,7 @@
 					<img src="{{.Poster.RelAvatarLink}}">
 				</a>
 				<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
-				{{if .Content}}{{$.i18n.Tr "repo.issues.add_label_at" .Label.ForegroundColor .Label.Color .Label.Name $createdStr | Safe}}{{else}}{{$.i18n.Tr "repo.issues.remove_label_at" .Label.ForegroundColor .Label.Color .Label.Name $createdStr | Safe}}{{end}}</span>
+				{{if .Content}}{{$.i18n.Tr "repo.issues.add_label_at" .Label.ForegroundColor .Label.Color (.Label.Name|Escape) $createdStr | Safe}}{{else}}{{$.i18n.Tr "repo.issues.remove_label_at" .Label.ForegroundColor .Label.Color (.Label.Name|Escape) $createdStr | Safe}}{{end}}</span>
 			</div>
 		{{end}}
 	{{else if eq .Type 8}}
@@ -113,7 +113,7 @@
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
 			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
-			{{if gt .OldMilestoneID 0}}{{if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.change_milestone_at" .OldMilestone.Name .Milestone.Name $createdStr | Safe}}{{else}}{{$.i18n.Tr "repo.issues.remove_milestone_at" .OldMilestone.Name $createdStr | Safe}}{{end}}{{else if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.add_milestone_at" .Milestone.Name $createdStr | Safe}}{{end}}</span>
+			{{if gt .OldMilestoneID 0}}{{if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.change_milestone_at" (.OldMilestone.Name|Escape) (.Milestone.Name|Escape) $createdStr | Safe}}{{else}}{{$.i18n.Tr "repo.issues.remove_milestone_at" (.OldMilestone.Name|Escape) $createdStr | Safe}}{{end}}{{else if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.add_milestone_at" (.Milestone.Name|Escape) $createdStr | Safe}}{{end}}</span>
 		</div>
 	{{else if eq .Type 9}}
 		<div class="event">
@@ -131,23 +131,23 @@
 	{{else if eq .Type 10}}
 		<div class="event">
 			<span class="octicon octicon-primitive-dot"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
+			{{$.i18n.Tr "repo.issues.change_title_at" (.OldTitle|Escape) (.NewTitle|Escape) $createdStr | Safe}}
+			</span>
 		</div>
-		<a class="ui avatar image" href="{{.Poster.HomeLink}}">
-			<img src="{{.Poster.RelAvatarLink}}">
-		</a>
-		<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
-		{{$.i18n.Tr "repo.issues.change_title_at" .OldTitle .NewTitle $createdStr | Safe}}
-		</span>
 	{{else if eq .Type 11}}
 		<div class="event">
 			<span class="octicon octicon-primitive-dot"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
+			{{$.i18n.Tr "repo.issues.delete_branch_at" .CommitSHA $createdStr | Safe}}
+			</span>
 		</div>
-		<a class="ui avatar image" href="{{.Poster.HomeLink}}">
-			<img src="{{.Poster.RelAvatarLink}}">
-		</a>
-		<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
-		{{$.i18n.Tr "repo.issues.delete_branch_at" .CommitSHA $createdStr | Safe}}
-		</span>
     {{else if eq .Type 12}}
 		<div class="event">
 			<span class="octicon octicon-primitive-dot"></span>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -104,7 +104,7 @@
 		{{.i18n.Tr "repo.wiki.delete_page_button"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.wiki.delete_page_notice_1" $title | Safe}}</p>
+		<p>{{.i18n.Tr "repo.wiki.delete_page_notice_1" ($title|Escape) | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>


### PR DESCRIPTION
Fixes #3510 
Also adds escaping to label and milestone names in comments