### PR TITLE
Implements generator cli for secrets

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,83 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+
+	"code.gitea.io/gitea/modules/generate"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	// CmdGenerate represents the available generate sub-command.
+	CmdGenerate = cli.Command{
+		Name:  "generate",
+		Usage: "Command line interface for running generators",
+		Subcommands: []cli.Command{
+			subcmdSecret,
+		},
+	}
+
+	subcmdSecret = cli.Command{
+		Name:  "secret",
+		Usage: "Generate a secret token",
+		Subcommands: []cli.Command{
+			microcmdGenerateInternalToken,
+			microcmdGenerateLfsJwtSecret,
+			microcmdGenerateSecretKey,
+		},
+	}
+
+	microcmdGenerateInternalToken = cli.Command{
+		Name:   "INTERNAL_TOKEN",
+		Usage:  "Generate a new INTERNAL_TOKEN",
+		Action: runGenerateInternalToken,
+	}
+
+	microcmdGenerateLfsJwtSecret = cli.Command{
+		Name:   "LFS_JWT_SECRET",
+		Usage:  "Generate a new LFS_JWT_SECRET",
+		Action: runGenerateLfsJwtSecret,
+	}
+
+	microcmdGenerateSecretKey = cli.Command{
+		Name:   "SECRET_KEY",
+		Usage:  "Generate a new SECRET_KEY",
+		Action: runGenerateSecretKey,
+	}
+)
+
+func runGenerateInternalToken(c *cli.Context) error {
+	internalToken, err := generate.NewInternalToken()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", internalToken)
+	return nil
+}
+
+func runGenerateLfsJwtSecret(c *cli.Context) error {
+	JWTSecretBase64, err := generate.NewLfsJwtSecret()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", JWTSecretBase64)
+	return nil
+}
+
+func runGenerateSecretKey(c *cli.Context) error {
+	secretKey, err := generate.NewSecretKey()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", secretKey)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ arguments - which can alternatively be run by running the subcommand web.`
 		cmd.CmdDump,
 		cmd.CmdCert,
 		cmd.CmdAdmin,
+		cmd.CmdGenerate,
 	}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Action = cmd.CmdWeb.Action

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -20,7 +20,7 @@ import (
 	gouuid "github.com/satori/go.uuid"
 	"gopkg.in/ini.v1"
 
-	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
@@ -539,10 +539,10 @@ func generateOrgRandsAndSalt(x *xorm.Engine) (err error) {
 	}
 
 	for _, org := range orgs {
-		if org.Rands, err = base.GetRandomString(10); err != nil {
+		if org.Rands, err = generate.GetRandomString(10); err != nil {
 			return err
 		}
-		if org.Salt, err = base.GetRandomString(10); err != nil {
+		if org.Salt, err = generate.GetRandomString(10); err != nil {
 			return err
 		}
 		if _, err = sess.Id(org.ID).Update(org); err != nil {

--- a/models/twofactor.go
+++ b/models/twofactor.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/pquerna/otp/totp"
 
-	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 )
@@ -33,7 +33,7 @@ type TwoFactor struct {
 
 // GenerateScratchToken recreates the scratch token the user is using.
 func (t *TwoFactor) GenerateScratchToken() error {
-	token, err := base.GetRandomString(8)
+	token, err := generate.GetRandomString(8)
 	if err != nil {
 		return err
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -34,6 +34,7 @@ import (
 
 	"code.gitea.io/gitea/modules/avatar"
 	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
@@ -638,7 +639,7 @@ func IsUserExist(uid int64, name string) (bool, error) {
 
 // GetUserSalt returns a random user salt token.
 func GetUserSalt() (string, error) {
-	return base.GetRandomString(10)
+	return generate.GetRandomString(10)
 }
 
 // NewGhostUser creates and returns a fake user for someone has deleted his/her account.

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -14,7 +14,6 @@ import (
 	"html/template"
 	"io"
 	"math"
-	"math/big"
 	"net/http"
 	"net/url"
 	"path"
@@ -88,25 +87,6 @@ func BasicAuthEncode(username, password string) string {
 	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 }
 
-// GetRandomString generate random string by specify chars.
-func GetRandomString(n int) (string, error) {
-	const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-
-	buffer := make([]byte, n)
-	max := big.NewInt(int64(len(alphanum)))
-
-	for i := 0; i < n; i++ {
-		index, err := randomInt(max)
-		if err != nil {
-			return "", err
-		}
-
-		buffer[i] = alphanum[index]
-	}
-
-	return string(buffer), nil
-}
-
 // GetRandomBytesAsBase64 generates a random base64 string from n bytes
 func GetRandomBytesAsBase64(n int) string {
 	bytes := make([]byte, 32)
@@ -117,15 +97,6 @@ func GetRandomBytesAsBase64(n int) string {
 	}
 
 	return base64.RawURLEncoding.EncodeToString(bytes)
-}
-
-func randomInt(max *big.Int) (int, error) {
-	rand, err := rand.Int(rand.Reader, max)
-	if err != nil {
-		return 0, err
-	}
-
-	return int(rand.Int64()), nil
 }
 
 // VerifyTimeLimitCode verify time limit code

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -107,12 +107,6 @@ func TestBasicAuthEncode(t *testing.T) {
 	assert.Equal(t, "Zm9vOmJhcg==", BasicAuthEncode("foo", "bar"))
 }
 
-func TestGetRandomString(t *testing.T) {
-	randomString, err := GetRandomString(4)
-	assert.NoError(t, err)
-	assert.Len(t, randomString, 4)
-}
-
 // TODO: Test PBKDF2()
 // TODO: Test VerifyTimeLimitCode()
 // TODO: Test CreateTimeLimitCode()

--- a/modules/generate/generate.go
+++ b/modules/generate/generate.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package generate
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"math/big"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// GetRandomString generate random string by specify chars.
+func GetRandomString(n int) (string, error) {
+	const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	buffer := make([]byte, n)
+	max := big.NewInt(int64(len(alphanum)))
+
+	for i := 0; i < n; i++ {
+		index, err := randomInt(max)
+		if err != nil {
+			return "", err
+		}
+
+		buffer[i] = alphanum[index]
+	}
+
+	return string(buffer), nil
+}
+
+// NewInternalToken generate a new value intended to be used by INTERNAL_TOKEN.
+func NewInternalToken() (string, error) {
+	secretBytes := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, secretBytes)
+	if err != nil {
+		return "", err
+	}
+
+	secretKey := base64.RawURLEncoding.EncodeToString(secretBytes)
+
+	now := time.Now()
+
+	var internalToken string
+	internalToken, err = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"nbf": now.Unix(),
+	}).SignedString([]byte(secretKey))
+	if err != nil {
+		return "", err
+	}
+
+	return internalToken, nil
+}
+
+// NewLfsJwtSecret generate a new value intended to be used by LFS_JWT_SECRET.
+func NewLfsJwtSecret() (string, error) {
+	JWTSecretBytes := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, JWTSecretBytes)
+	if err != nil {
+		return "", err
+	}
+
+	JWTSecretBase64 := base64.RawURLEncoding.EncodeToString(JWTSecretBytes)
+	return JWTSecretBase64, nil
+}
+
+// NewSecretKey generate a new value intended to be used by SECRET_KEY.
+func NewSecretKey() (string, error) {
+	secretKey, err := GetRandomString(64)
+	if err != nil {
+		return "", err
+	}
+
+	return secretKey, nil
+}
+
+func randomInt(max *big.Int) (int, error) {
+	rand, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(rand.Int64()), nil
+}

--- a/modules/generate/generate_test.go
+++ b/modules/generate/generate_test.go
@@ -1,0 +1,20 @@
+package generate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	retVal := m.Run()
+
+	os.Exit(retVal)
+}
+
+func TestGetRandomString(t *testing.T) {
+	randomString, err := GetRandomString(4)
+	assert.NoError(t, err)
+	assert.Len(t, randomString, 4)
+}

--- a/routers/user/auth_openid.go
+++ b/routers/user/auth_openid.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/modules/auth/openid"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -348,7 +349,7 @@ func RegisterOpenIDPost(ctx *context.Context, cpt *captcha.Captcha, form auth.Si
 	if len < 256 {
 		len = 256
 	}
-	password, err := base.GetRandomString(len)
+	password, err := generate.GetRandomString(len)
 	if err != nil {
 		ctx.RenderWithErr(err.Error(), tplSignUpOID, form)
 		return


### PR DESCRIPTION
Adds CLI subcommands for generating secrets.

This was inspired by a simmilar command available in Ruby on Rails: `rails secret` which generates a new value for `SECRET_KEY_BASE`, used to encrypt cookies.

To use this you execute the following commands:
```bash 
./gitea generate secret INTERNAL_TOKEN
# eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE1MTg5Njk4Njd9.X7-Qt89vFqLD1iS1UtAdGuVwvI7pz9n5EdqDuaHRNlI
./gitea generate secret LFS_JWT_SECRET
# SVxQQXbDGDqicXJoy9ygiHQKg6A79lTIuWoh_KfzPTI
./gitea generate secret SECRET_KEY
# FOQ5XMfOHo2GUc0FcnPJzf7MCvfUbqqkhkK1fJjXCx8UT1jYAxE2bIigI392j40x
```

I also modified the length of `SECRET_KEY` from `10` to `64` since it felt kind of short comapred to the rest.

The main use case for this would be an automated setup which has `app.ini` as a template and the values for `INTERNAL_TOKEN`, `LFS_JWT_SECRET`, and `SECRET_KEY` would be generated by the CLI commands, then added to the template. This would ensure no secrets would need to be hardcoded, and since they are generated by the same functions used in the `/install` endpoint, they will be consistent. 

Here is an example of such automated setup I developed this for (just to give you an idea of how I intend this to be used):

An ansible role that generates the ini file:
```yaml
- name: Generate postgres password
  shell: 'cat /dev/urandom | tr -dc "a-zA-Z0-9" | fold -w ${1:-32} | head -n 1'
  register: new_postgres_password

- name: Generate internal token
  shell: 'docker run --rm {{ project_name }}_web /work/gitea generate secret INTERNAL_TOKEN | tail -n 1'
  register: new_internal_token

- name: Generate LFS JWT secret
  shell: 'docker run --rm {{ project_name }}_web /work/gitea generate secret LFS_JWT_SECRET | tail -n 1'
  register: new_lfs_jwt_secret

- name: Generate secret key
  shell: 'docker run --rm {{ project_name }}_web /work/gitea generate secret SECRET_KEY | tail -n 1'
  register: new_secret_key

- name: Create the app.ini file from the template
  template:
    src: '{{ project_repo }}/secrets/templates/app.ini.j2'
    dest: '{{ project_repo }}/secrets/app.ini'
  vars:
    postgres_password: '{{ new_postgres_password.stdout }}'
    internal_token: '{{ new_internal_token.stdout }}'
    lfs_jwt_secret: '{{ new_lfs_jwt_secret.stdout }}'
    secret_key: '{{ new_secret_key.stdout }}'
```

And the ini file template:
```ini
APP_NAME = Gitea: Git with a cup of tea
RUN_USER = git
RUN_MODE = prod

[security]
INTERNAL_TOKEN = {{ internal_token }}
INSTALL_LOCK   = true
SECRET_KEY     = {{ secret_key }}

[database]
DB_TYPE  = postgres
HOST     = postgres:5432
NAME     = gitea
USER     = postgres
PASSWD   = {{ postgres_password }}
SSL_MODE = disable
PATH     = /work/data/gitea.db

[repository]
ROOT          = /work/repos
FORCE_PRIVATE = true

[server]
SSH_DOMAIN       = gitea.local
DOMAIN           = gitea.local
HTTP_PORT        = 3000
ROOT_URL         = http://gitea.local:3000/
DISABLE_SSH      = false
SSH_PORT         = 22
START_SSH_SERVER = true
LFS_START_SERVER = true
LFS_CONTENT_PATH = /work/data/lfs
LFS_JWT_SECRET   = {{ lfs_jwt_secret }}
OFFLINE_MODE     = true

[mailer]
ENABLED = false

[markdown]
ENABLE_HARD_LINE_BREAK = true

[service]
REGISTER_EMAIL_CONFIRM            = false
ENABLE_NOTIFY_MAIL                = false
DISABLE_REGISTRATION              = true
ENABLE_CAPTCHA                    = false
REQUIRE_SIGNIN_VIEW               = true
DEFAULT_KEEP_EMAIL_PRIVATE        = true
DEFAULT_ALLOW_CREATE_ORGANIZATION = false
DEFAULT_ENABLE_TIMETRACKING       = false
NO_REPLY_ADDRESS                  = noreply.gitea.local

[picture]
DISABLE_GRAVATAR        = true
ENABLE_FEDERATED_AVATAR = false

[openid]
ENABLE_OPENID_SIGNIN = false
ENABLE_OPENID_SIGNUP = false

[session]
PROVIDER = file

[log]
MODE      = console,file
LEVEL     = Info
ROOT_PATH = /work/log
```

About the implementation:
- I extracted the generation logic into it's own package and reuse the same functions as part of the `generate` CLI subcommand and as part of the install setup.
- Existing functionality is the same, except for the length of `SECRET_KEY` which I feel it's better to be longer.
- This is the first (non trivial) golang code I've ever written so please let me know if I've made any mistakes.
- I am not sure how to write tests for all this yet.
 