### PR TITLE
Populate URL field of API commits

### DIFF
--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -13,6 +13,7 @@ import (
 	. "code.gitea.io/gitea/modules/markup"
 	_ "code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,12 +38,12 @@ var alphanumericMetas = map[string]string{
 
 // numericLink an HTML to a numeric-style issue
 func numericIssueLink(baseURL string, index int) string {
-	return link(URLJoin(baseURL, strconv.Itoa(index)), fmt.Sprintf("#%d", index))
+	return link(util.URLJoin(baseURL, strconv.Itoa(index)), fmt.Sprintf("#%d", index))
 }
 
 // alphanumLink an HTML link to an alphanumeric-style issue
 func alphanumIssueLink(baseURL string, name string) string {
-	return link(URLJoin(baseURL, name), name)
+	return link(util.URLJoin(baseURL, name), name)
 }
 
 // urlContentsLink an HTML link whose contents is the target URL
@@ -61,31 +62,6 @@ func testRenderIssueIndexPattern(t *testing.T, input, expected string, opts Rend
 	}
 	actual := string(RenderIssueIndexPattern([]byte(input), opts))
 	assert.Equal(t, expected, actual)
-}
-
-func TestURLJoin(t *testing.T) {
-	type test struct {
-		Expected string
-		Base     string
-		Elements []string
-	}
-	newTest := func(expected, base string, elements ...string) test {
-		return test{Expected: expected, Base: base, Elements: elements}
-	}
-	for _, test := range []test{
-		newTest("https://try.gitea.io/a/b/c",
-			"https://try.gitea.io", "a/b", "c"),
-		newTest("https://try.gitea.io/a/b/c",
-			"https://try.gitea.io/", "/a/b/", "/c/"),
-		newTest("https://try.gitea.io/a/c",
-			"https://try.gitea.io/", "/a/./b/", "../c/"),
-		newTest("a/b/c",
-			"a", "b/c/"),
-		newTest("a/b/d",
-			"a/", "b/c/", "/../d/"),
-	} {
-		assert.Equal(t, test.Expected, URLJoin(test.Base, test.Elements...))
-	}
 }
 
 func TestRender_IssueIndexPattern(t *testing.T) {
@@ -123,7 +99,7 @@ func TestRender_IssueIndexPattern2(t *testing.T) {
 	test := func(s, expectedFmt string, indices ...int) {
 		links := make([]interface{}, len(indices))
 		for i, index := range indices {
-			links[i] = numericIssueLink(URLJoin(setting.AppSubURL, "issues"), index)
+			links[i] = numericIssueLink(util.URLJoin(setting.AppSubURL, "issues"), index)
 		}
 		expectedNil := fmt.Sprintf(expectedFmt, links...)
 		testRenderIssueIndexPattern(t, s, expectedNil, RenderIssueIndexPatternOptions{})
@@ -228,8 +204,8 @@ func TestRender_AutoLink(t *testing.T) {
 	}
 
 	// render valid issue URLs
-	test(URLJoin(setting.AppSubURL, "issues", "3333"),
-		numericIssueLink(URLJoin(setting.AppSubURL, "issues"), 3333))
+	test(util.URLJoin(setting.AppSubURL, "issues", "3333"),
+		numericIssueLink(util.URLJoin(setting.AppSubURL, "issues"), 3333))
 
 	// render external issue URLs
 	for _, externalURL := range []string{
@@ -240,7 +216,7 @@ func TestRender_AutoLink(t *testing.T) {
 	}
 
 	// render valid commit URLs
-	tmp := URLJoin(AppSubURL, "commit", "d8a994ef243349f321568f9e36d5c3f444b99cae")
+	tmp := util.URLJoin(AppSubURL, "commit", "d8a994ef243349f321568f9e36d5c3f444b99cae")
 	test(tmp, "<a href=\""+tmp+"\">d8a994ef24</a>")
 	tmp += "#diff-2"
 	test(tmp, "<a href=\""+tmp+"\">d8a994ef24 (diff-2)</a>")
@@ -260,8 +236,8 @@ func TestRender_Commits(t *testing.T) {
 	}
 
 	var sha = "b6dd6210eaebc915fd5be5579c58cce4da2e2579"
-	var commit = URLJoin(AppSubURL, "commit", sha)
-	var subtree = URLJoin(commit, "src")
+	var commit = util.URLJoin(AppSubURL, "commit", sha)
+	var subtree = util.URLJoin(commit, "src")
 	var tree = strings.Replace(subtree, "/commit/", "/tree/", -1)
 	var src = strings.Replace(subtree, "/commit/", "/src/", -1)
 
@@ -284,10 +260,10 @@ func TestRender_CrossReferences(t *testing.T) {
 
 	test(
 		"gogits/gogs#12345",
-		`<p><a href="`+URLJoin(AppURL, "gogits", "gogs", "issues", "12345")+`" rel="nofollow">gogits/gogs#12345</a></p>`)
+		`<p><a href="`+util.URLJoin(AppURL, "gogits", "gogs", "issues", "12345")+`" rel="nofollow">gogits/gogs#12345</a></p>`)
 	test(
 		"go-gitea/gitea#12345",
-		`<p><a href="`+URLJoin(AppURL, "go-gitea", "gitea", "issues", "12345")+`" rel="nofollow">go-gitea/gitea#12345</a></p>`)
+		`<p><a href="`+util.URLJoin(AppURL, "go-gitea", "gitea", "issues", "12345")+`" rel="nofollow">go-gitea/gitea#12345</a></p>`)
 }
 
 func TestRender_FullIssueURLs(t *testing.T) {
@@ -482,7 +458,7 @@ func TestMisc_IsSameDomain(t *testing.T) {
 	setting.AppSubURL = AppSubURL
 
 	var sha = "b6dd6210eaebc915fd5be5579c58cce4da2e2579"
-	var commit = URLJoin(AppSubURL, "commit", sha)
+	var commit = util.URLJoin(AppSubURL, "commit", sha)
 
 	assert.True(t, IsSameDomain(commit))
 	assert.False(t, IsSameDomain("http://google.com/ncr"))

--- a/modules/markup/markdown/markdown.go
+++ b/modules/markup/markdown/markdown.go
@@ -10,6 +10,7 @@ import (
 
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/russross/blackfriday"
 )
@@ -27,9 +28,9 @@ func (r *Renderer) Link(out *bytes.Buffer, link []byte, title []byte, content []
 		if link[0] != '#' {
 			lnk := string(link)
 			if r.IsWiki {
-				lnk = markup.URLJoin("wiki", lnk)
+				lnk = util.URLJoin("wiki", lnk)
 			}
-			mLink := markup.URLJoin(r.URLPrefix, lnk)
+			mLink := util.URLJoin(r.URLPrefix, lnk)
 			link = []byte(mLink)
 		}
 	}
@@ -97,7 +98,7 @@ var (
 func (r *Renderer) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
 	prefix := r.URLPrefix
 	if r.IsWiki {
-		prefix = markup.URLJoin(prefix, "wiki", "src")
+		prefix = util.URLJoin(prefix, "wiki", "src")
 	}
 	prefix = strings.Replace(prefix, "/src/", "/raw/", 1)
 	if len(link) > 0 {
@@ -110,7 +111,7 @@ func (r *Renderer) Image(out *bytes.Buffer, link []byte, title []byte, alt []byt
 			}
 		} else {
 			lnk := string(link)
-			lnk = markup.URLJoin(prefix, lnk)
+			lnk = util.URLJoin(prefix, lnk)
 			lnk = strings.Replace(lnk, " ", "+", -1)
 			link = []byte(lnk)
 		}

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/modules/markup"
 	. "code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,8 +34,8 @@ func TestRender_StandardLinks(t *testing.T) {
 	googleRendered := `<p><a href="https://google.com/" rel="nofollow">https://google.com/</a></p>`
 	test("<https://google.com/>", googleRendered, googleRendered)
 
-	lnk := markup.URLJoin(AppSubURL, "WikiPage")
-	lnkWiki := markup.URLJoin(AppSubURL, "wiki", "WikiPage")
+	lnk := util.URLJoin(AppSubURL, "WikiPage")
+	lnkWiki := util.URLJoin(AppSubURL, "wiki", "WikiPage")
 	test("[WikiPage](WikiPage)",
 		`<p><a href="`+lnk+`" rel="nofollow">WikiPage</a></p>`,
 		`<p><a href="`+lnkWiki+`" rel="nofollow">WikiPage</a></p>`)
@@ -43,7 +44,7 @@ func TestRender_StandardLinks(t *testing.T) {
 func TestRender_ShortLinks(t *testing.T) {
 	setting.AppURL = AppURL
 	setting.AppSubURL = AppSubURL
-	tree := markup.URLJoin(AppSubURL, "src", "master")
+	tree := util.URLJoin(AppSubURL, "src", "master")
 
 	test := func(input, expected, expectedWiki string) {
 		buffer := RenderString(input, tree, nil)
@@ -52,13 +53,13 @@ func TestRender_ShortLinks(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(expectedWiki), strings.TrimSpace(string(buffer)))
 	}
 
-	rawtree := markup.URLJoin(AppSubURL, "raw", "master")
-	url := markup.URLJoin(tree, "Link")
-	otherUrl := markup.URLJoin(tree, "OtherLink")
-	imgurl := markup.URLJoin(rawtree, "Link.jpg")
-	urlWiki := markup.URLJoin(AppSubURL, "wiki", "Link")
-	otherUrlWiki := markup.URLJoin(AppSubURL, "wiki", "OtherLink")
-	imgurlWiki := markup.URLJoin(AppSubURL, "wiki", "raw", "Link.jpg")
+	rawtree := util.URLJoin(AppSubURL, "raw", "master")
+	url := util.URLJoin(tree, "Link")
+	otherUrl := util.URLJoin(tree, "OtherLink")
+	imgurl := util.URLJoin(rawtree, "Link.jpg")
+	urlWiki := util.URLJoin(AppSubURL, "wiki", "Link")
+	otherUrlWiki := util.URLJoin(AppSubURL, "wiki", "OtherLink")
+	imgurlWiki := util.URLJoin(AppSubURL, "wiki", "raw", "Link.jpg")
 	favicon := "http://google.com/favicon.ico"
 
 	test(
@@ -136,7 +137,7 @@ func TestRender_Images(t *testing.T) {
 
 	url := "../../.images/src/02/train.jpg"
 	title := "Train"
-	result := markup.URLJoin(AppSubURL, url)
+	result := util.URLJoin(AppSubURL, url)
 
 	test(
 		"!["+title+"]("+url+")",
@@ -259,7 +260,7 @@ Here are some links to the most important topics. You can find the full list of 
 }
 
 func TestTotal_RenderWiki(t *testing.T) {
-	answers := testAnswers(markup.URLJoin(AppSubURL, "wiki/"), markup.URLJoin(AppSubURL, "wiki", "raw/"))
+	answers := testAnswers(util.URLJoin(AppSubURL, "wiki/"), util.URLJoin(AppSubURL, "wiki", "raw/"))
 
 	for i := 0; i < len(sameCases); i++ {
 		line := RenderWiki([]byte(sameCases[i]), AppSubURL, nil)
@@ -286,10 +287,10 @@ func TestTotal_RenderWiki(t *testing.T) {
 }
 
 func TestTotal_RenderString(t *testing.T) {
-	answers := testAnswers(markup.URLJoin(AppSubURL, "src", "master/"), markup.URLJoin(AppSubURL, "raw", "master/"))
+	answers := testAnswers(util.URLJoin(AppSubURL, "src", "master/"), util.URLJoin(AppSubURL, "raw", "master/"))
 
 	for i := 0; i < len(sameCases); i++ {
-		line := RenderString(sameCases[i], markup.URLJoin(AppSubURL, "src", "master/"), nil)
+		line := RenderString(sameCases[i], util.URLJoin(AppSubURL, "src", "master/"), nil)
 		assert.Equal(t, answers[i], line)
 	}
 

--- a/modules/markup/orgmode/orgmode_test.go
+++ b/modules/markup/orgmode/orgmode_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +30,7 @@ func TestRender_StandardLinks(t *testing.T) {
 	googleRendered := `<p><a href="https://google.com/" title="https://google.com/">https://google.com/</a></p>`
 	test("[[https://google.com/]]", googleRendered)
 
-	lnk := markup.URLJoin(AppSubURL, "WikiPage")
+	lnk := util.URLJoin(AppSubURL, "WikiPage")
 	test("[[WikiPage][WikiPage]]",
 		`<p><a href="`+lnk+`" title="WikiPage">WikiPage</a></p>`)
 }
@@ -46,7 +46,7 @@ func TestRender_Images(t *testing.T) {
 
 	url := "../../.images/src/02/train.jpg"
 	title := "Train"
-	result := markup.URLJoin(AppSubURL, url)
+	result := util.URLJoin(AppSubURL, url)
 
 	test(
 		"[[file:"+url+"]["+title+"]]",

--- a/modules/util/util.go
+++ b/modules/util/util.go
@@ -4,6 +4,13 @@
 
 package util
 
+import (
+	"net/url"
+	"path"
+
+	"code.gitea.io/gitea/modules/log"
+)
+
 // OptionalBool a boolean that can be "null"
 type OptionalBool byte
 
@@ -45,6 +52,20 @@ func Max(a, b int) int {
 		return b
 	}
 	return a
+}
+
+// URLJoin joins url components, like path.Join, but preserving contents
+func URLJoin(base string, elems ...string) string {
+	u, err := url.Parse(base)
+	if err != nil {
+		log.Error(4, "URLJoin: Invalid base URL %s", base)
+		return ""
+	}
+	joinArgs := make([]string, 0, len(elems)+1)
+	joinArgs = append(joinArgs, u.Path)
+	joinArgs = append(joinArgs, elems...)
+	u.Path = path.Join(joinArgs...)
+	return u.String()
 }
 
 // Min min of two ints

--- a/modules/util/util_test.go
+++ b/modules/util/util_test.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestURLJoin(t *testing.T) {
+	type test struct {
+		Expected string
+		Base     string
+		Elements []string
+	}
+	newTest := func(expected, base string, elements ...string) test {
+		return test{Expected: expected, Base: base, Elements: elements}
+	}
+	for _, test := range []test{
+		newTest("https://try.gitea.io/a/b/c",
+			"https://try.gitea.io", "a/b", "c"),
+		newTest("https://try.gitea.io/a/b/c",
+			"https://try.gitea.io/", "/a/b/", "/c/"),
+		newTest("https://try.gitea.io/a/c",
+			"https://try.gitea.io/", "/a/./b/", "../c/"),
+		newTest("a/b/c",
+			"a", "b/c/"),
+		newTest("a/b/d",
+			"a/", "b/c/", "/../d/"),
+	} {
+		assert.Equal(t, test.Expected, URLJoin(test.Base, test.Elements...))
+	}
+}

--- a/routers/api/v1/misc/markdown.go
+++ b/routers/api/v1/misc/markdown.go
@@ -8,9 +8,9 @@ import (
 	api "code.gitea.io/sdk/gitea"
 
 	"code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // Markdown render markdown document to HTML
@@ -45,7 +45,7 @@ func Markdown(ctx *context.APIContext, form api.MarkdownOption) {
 	switch form.Mode {
 	case "gfm":
 		md := []byte(form.Text)
-		context := markup.URLJoin(setting.AppURL, form.Context)
+		context := util.URLJoin(setting.AppURL, form.Context)
 		if form.Wiki {
 			ctx.Write([]byte(markdown.RenderWiki(md, context, nil)))
 		} else {

--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	api "code.gitea.io/sdk/gitea"
 
 	"github.com/go-macaron/inject"
@@ -53,7 +53,7 @@ func TestAPI_RenderGFM(t *testing.T) {
 		Context: Repo,
 		Wiki:    true,
 	}
-	requrl, _ := url.Parse(markup.URLJoin(AppURL, "api", "v1", "markdown"))
+	requrl, _ := url.Parse(util.URLJoin(AppURL, "api", "v1", "markdown"))
 	req := &http.Request{
 		Method: "POST",
 		URL:    requrl,
@@ -147,7 +147,7 @@ func TestAPI_RenderSimple(t *testing.T) {
 		Text:    "",
 		Context: Repo,
 	}
-	requrl, _ := url.Parse(markup.URLJoin(AppURL, "api", "v1", "markdown"))
+	requrl, _ := url.Parse(util.URLJoin(AppURL, "api", "v1", "markdown"))
 	req := &http.Request{
 		Method: "POST",
 		URL:    requrl,
@@ -166,7 +166,7 @@ func TestAPI_RenderSimple(t *testing.T) {
 func TestAPI_RenderRaw(t *testing.T) {
 	setting.AppURL = AppURL
 
-	requrl, _ := url.Parse(markup.URLJoin(AppURL, "api", "v1", "markdown"))
+	requrl, _ := url.Parse(util.URLJoin(AppURL, "api", "v1", "markdown"))
 	req := &http.Request{
 		Method: "POST",
 		URL:    requrl,

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -61,7 +61,7 @@ func GetBranch(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.JSON(200, convert.ToBranch(branch, c))
+	ctx.JSON(200, convert.ToBranch(ctx.Repo.Repository, branch, c))
 }
 
 // ListBranches list all the branches of a repository
@@ -98,7 +98,7 @@ func ListBranches(ctx *context.APIContext) {
 			ctx.Error(500, "GetCommit", err)
 			return
 		}
-		apiBranches[i] = convert.ToBranch(branches[i], c)
+		apiBranches[i] = convert.ToBranch(ctx.Repo.Repository, branches[i], c)
 	}
 
 	ctx.JSON(200, &apiBranches)


### PR DESCRIPTION
Also moves `URLJoin` to `modules/util` so that everyone can use it.