### PR TITLE
Fix issue with broken inter-wiki links #3506

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -464,7 +464,11 @@ func shortLinkProcessorFull(ctx *postProcessCtx, node *html.Node, noLink bool) {
 	childNode.Parent = linkNode
 	absoluteLink := isLinkStr(link)
 	if !absoluteLink {
-		link = strings.Replace(link, " ", "+", -1)
+		if image {
+			link = strings.Replace(link, " ", "+", -1)
+		} else {
+			link = strings.Replace(link, " ", "-", -1)
+		}
 	}
 	urlPrefix := ctx.urlPrefix
 	if image {

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -81,11 +81,13 @@ func TestRender_ShortLinks(t *testing.T) {
 
 	rawtree := util.URLJoin(AppSubURL, "raw", "master")
 	url := util.URLJoin(tree, "Link")
-	otherURL := util.URLJoin(tree, "OtherLink")
+	otherURL := util.URLJoin(tree, "Other-Link")
 	imgurl := util.URLJoin(rawtree, "Link.jpg")
+	otherImgurl := util.URLJoin(rawtree, "Link+Other.jpg")
 	urlWiki := util.URLJoin(AppSubURL, "wiki", "Link")
-	otherURLWiki := util.URLJoin(AppSubURL, "wiki", "OtherLink")
+	otherURLWiki := util.URLJoin(AppSubURL, "wiki", "Other-Link")
 	imgurlWiki := util.URLJoin(AppSubURL, "wiki", "raw", "Link.jpg")
+	otherImgurlWiki := util.URLJoin(AppSubURL, "wiki", "raw", "Link+Other.jpg")
 	favicon := "http://google.com/favicon.ico"
 
 	test(
@@ -125,7 +127,11 @@ func TestRender_ShortLinks(t *testing.T) {
 		`<p><a href="`+imgurl+`" rel="nofollow"><img src="`+imgurl+`" title="Title" alt="AltName"/></a></p>`,
 		`<p><a href="`+imgurlWiki+`" rel="nofollow"><img src="`+imgurlWiki+`" title="Title" alt="AltName"/></a></p>`)
 	test(
-		"[[Link]] [[OtherLink]]",
-		`<p><a href="`+url+`" rel="nofollow">Link</a> <a href="`+otherURL+`" rel="nofollow">OtherLink</a></p>`,
-		`<p><a href="`+urlWiki+`" rel="nofollow">Link</a> <a href="`+otherURLWiki+`" rel="nofollow">OtherLink</a></p>`)
+		"[[Name|Link Other.jpg|alt=\"AltName\"|title='Title']]",
+		`<p><a href="`+otherImgurl+`" rel="nofollow"><img src="`+otherImgurl+`" title="Title" alt="AltName"/></a></p>`,
+		`<p><a href="`+otherImgurlWiki+`" rel="nofollow"><img src="`+otherImgurlWiki+`" title="Title" alt="AltName"/></a></p>`)
+	test(
+		"[[Link]] [[Other Link]]",
+		`<p><a href="`+url+`" rel="nofollow">Link</a> <a href="`+otherURL+`" rel="nofollow">Other Link</a></p>`,
+		`<p><a href="`+urlWiki+`" rel="nofollow">Link</a> <a href="`+otherURLWiki+`" rel="nofollow">Other Link</a></p>`)
 }


### PR DESCRIPTION
This fixes issue #3506, in which inter-wiki links automatically generated in the sidebar contained `+` signs instead of `-` signs and were therefore all broken.