### PR TITLE
Fix missing translations when updating username.

### DIFF
--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -92,7 +92,7 @@ func TestRenameReservedUsername(t *testing.T) {
 		htmlDoc := NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),
-			i18n.Tr("en", "user.newName_reserved"),
+			i18n.Tr("en", "form.name_reserved", reservedUsername),
 		)
 
 		models.AssertNotExistsBean(t, &models.User{Name: reservedUsername})

--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -92,7 +92,7 @@ func TestRenameReservedUsername(t *testing.T) {
 		htmlDoc := NewHTMLParser(t, resp.Body)
 		assert.Contains(t,
 			htmlDoc.doc.Find(".ui.negative.message").Text(),
-			i18n.Tr("en", "form.name_reserved", reservedUsername),
+			i18n.Tr("en", "user.form.name_reserved", reservedUsername),
 		)
 
 		models.AssertNotExistsBean(t, &models.User{Name: reservedUsername})

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -61,16 +61,16 @@ func handleUsernameChange(ctx *context.Context, newName string) {
 		if err := models.ChangeUserName(ctx.User, newName); err != nil {
 			switch {
 			case models.IsErrUserAlreadyExist(err):
-				ctx.Flash.Error(ctx.Tr("newName_been_taken"))
+				ctx.Flash.Error(ctx.Tr("form.username_been_taken"))
 				ctx.Redirect(setting.AppSubURL + "/user/settings")
 			case models.IsErrEmailAlreadyUsed(err):
 				ctx.Flash.Error(ctx.Tr("form.email_been_used"))
 				ctx.Redirect(setting.AppSubURL + "/user/settings")
 			case models.IsErrNameReserved(err):
-				ctx.Flash.Error(ctx.Tr("user.newName_reserved"))
+				ctx.Flash.Error(ctx.Tr("user.form.name_reserved", newName))
 				ctx.Redirect(setting.AppSubURL + "/user/settings")
 			case models.IsErrNamePatternNotAllowed(err):
-				ctx.Flash.Error(ctx.Tr("user.newName_pattern_not_allowed"))
+				ctx.Flash.Error(ctx.Tr("user.form.name_pattern_not_allowed", newName))
 				ctx.Redirect(setting.AppSubURL + "/user/settings")
 			default:
 				ctx.ServerError("ChangeUserName", err)


### PR DESCRIPTION
Gitea tries to display non-existing translation strings after failing to update a username on the 'Your Settings' page. This PR (hopefully) fixes three error cases. I'm no Go expert and I can't test this, but I think it should work.