### PR TITLE
Add option to skip health check for some repositories

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -498,6 +498,8 @@ TIMEOUT = 60s
 ; Arguments for command 'git fsck', e.g. "--unreachable --tags"
 ; see more on http://git-scm.com/docs/git-fsck/1.7.5
 ARGS =
+; A list of repos which shouldn't be health-checked, e.g. "user1/repo1 user2/repo2"
+SKIP_REPOS =
 
 ; Check repository statistics
 [cron.check_repo_stats]

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -258,6 +258,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `SCHEDULE`: **every 24h**: Cron syntax for scheduling repository health check.
 - `TIMEOUT`: **60s**: Time duration syntax for health check execution timeout.
 - `ARGS`: **\<empty\>**: Arguments for command `git fsck`, e.g. `--unreachable --tags`.
+- `SKIP_REPOS`: **\<empty\>**: A list of repos which shouldn't be health-checked, e.g. `user1/repo1 user2/repo2`
 
 ### Cron - Repository Statistics Check (`cron.check_repo_stats`)
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -2171,6 +2171,14 @@ func GitFsck() {
 		Iterate(new(Repository),
 			func(idx int, bean interface{}) error {
 				repo := bean.(*Repository)
+				repoFullName := repo.FullName()
+				for _, skipName := range setting.Cron.RepoHealthCheck.SkipRepos {
+					if repoFullName == skipName {
+						desc := fmt.Sprintf("Skipping health check for repository %s", repoFullName)
+						log.Trace(desc)
+						return nil
+					}
+				}
 				repoPath := repo.RepoPath()
 				if err := git.Fsck(repoPath, setting.Cron.RepoHealthCheck.Timeout, setting.Cron.RepoHealthCheck.Args...); err != nil {
 					desc := fmt.Sprintf("Failed to health check repository (%s): %v", repoPath, err)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -378,6 +378,7 @@ var (
 			Schedule   string
 			Timeout    time.Duration
 			Args       []string `delim:" "`
+			SkipRepos  []string `delim:" "`
 		} `ini:"cron.repo_health_check"`
 		CheckRepoStats struct {
 			Enabled    bool
@@ -418,6 +419,7 @@ var (
 			Schedule   string
 			Timeout    time.Duration
 			Args       []string `delim:" "`
+			SkipRepos  []string `delim:" "`
 		}{
 			Enabled:    true,
 			RunAtStart: false,


### PR DESCRIPTION
Some large git repos (e.g. the Linux Kernel) take an excessively long
time to fsck, and the resulting failure messages pollute the Gitea
system notices with noise.

Add the field SKIP_REPOS to the [cron.repo_health_check] section of
app.ini which is a list of repos for which to skip the health check.

Implements: https://github.com/go-gitea/gitea/issues/1712
Signed-off-by: Allen Wild <allenwild93@gmail.com>