### PR TITLE
Move default highlight.js highlighting into a web worker

### DIFF
--- a/public/js/highlight-worker.js
+++ b/public/js/highlight-worker.js
@@ -2,6 +2,6 @@
 // See: https://highlightjs.org/usage/
 onmessage = function(event) {
     importScripts('/vendor/plugins/highlight/highlight.pack.js');
-    var result = self.hljs.highlightAuto(event.data);
-    postMessage(result.value);
+    var result = self.hljs.highlightAuto(event.data.text);
+    postMessage({index: event.data.index, html: result.value});
 };

--- a/public/js/highlight-worker.js
+++ b/public/js/highlight-worker.js
@@ -1,7 +1,10 @@
 // A very simple web worker for highlight.js
 // See: https://highlightjs.org/usage/
+'use strict';
+
+importScripts('/vendor/plugins/highlight/highlight.pack.js');
+
 onmessage = function(event) {
-    importScripts('/vendor/plugins/highlight/highlight.pack.js');
     var result = self.hljs.highlightAuto(event.data.text);
     postMessage({index: event.data.index, html: result.value});
 };

--- a/public/js/highlight.js
+++ b/public/js/highlight.js
@@ -1,0 +1,7 @@
+// A very simple web worker for highlight.js
+// See: https://highlightjs.org/usage/
+onmessage = function(event) {
+    importScripts('/vendor/plugins/highlight/highlight.pack.js');
+    var result = self.hljs.highlightAuto(event.data);
+    postMessage(result.value);
+}

--- a/public/js/highlight.js
+++ b/public/js/highlight.js
@@ -4,4 +4,4 @@ onmessage = function(event) {
     importScripts('/vendor/plugins/highlight/highlight.pack.js');
     var result = self.hljs.highlightAuto(event.data);
     postMessage(result.value);
-}
+};

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1430,12 +1430,13 @@ $(document).ready(function () {
 
     // Highlight JS
     if (typeof hljs != 'undefined') {
-        $('pre code').each(function (index, element) {
-            var worker = new Worker('/js/highlight-worker.js');
-            worker.onmessage = function(event) {
-                $(element).html(event.data);
-            }
-            worker.postMessage($(element).text());
+        var codeElements = $('pre code');
+        var worker = new Worker('/js/highlight-worker.js');
+        worker.onmessage = function(event) {
+            $(codeElements[event.data.index]).html(event.data.html);
+        }
+        $(codeElements).each(function (index, element) {
+            worker.postMessage({index: index, text: $(element).text()});
         });
     }
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1430,7 +1430,13 @@ $(document).ready(function () {
 
     // Highlight JS
     if (typeof hljs != 'undefined') {
-        hljs.initHighlightingOnLoad();
+        $('pre code').each(function (index, element) {
+            var worker = new Worker('/js/highlight-worker.js');
+            worker.onmessage = function(event) {
+                $(element).html(event.data);
+            }
+            worker.postMessage($(element).text());
+        });
     }
 
     // Dropzone


### PR DESCRIPTION
Hi, 

We noticed that pages served by gitea locked up when viewing large files, which I tracked down to (mainly) the syntax highlighting javascript. Highlight.js have [an example on their docs](https://highlightjs.org/usage/) of moving the actual highlighting to a web worker so that it doesn't block the rest of the page, and this seems to be a big improvement for us so I thought I'd see whether it would be interesting to you.

There are a couple of other places where you use highlight js, but they're for specific situations (preview panes etc) where I wasn't so sure this would be desirable. I'd be happy to extend it to those too if needs be.

Thanks!



