### PR TITLE
Fix incorrect 'Erase Wiki Data' string identifier.

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -399,7 +399,7 @@
 	{{if .Repository.UnitEnabled $.UnitTypeWiki}}
 	<div class="ui small modal" id="delete-wiki-modal">
 		<div class="header">
-			{{.i18n.Tr "repo.settings.wiki-delete"}}
+			{{.i18n.Tr "repo.settings.wiki_delete"}}
 		</div>
 		<div class="content">
 			<div class="ui warning message text left">


### PR DESCRIPTION
The modal dialog to confirm erasure of repository wiki data doesn't use a valid string identifier. I couldn't find any unit tests depending on this, so hopefully it's an easy pull.