### PR TITLE
Allow mime types to match based off of prefix

### DIFF
--- a/modules/upload/filetype.go
+++ b/modules/upload/filetype.go
@@ -34,9 +34,13 @@ func VerifyAllowedContentType(buf []byte, allowedTypes []string) error {
 	for _, t := range allowedTypes {
 		t := strings.Trim(t, " ")
 
-		if t == "*/*" || t == fileType ||
+		if t == fileType ||
+			// Allow wildcard */* to match all mime types
+			t == "*/*" ||
 			// Allow directives after type, like 'text/plain; charset=utf-8'
-			strings.HasPrefix(fileType, t+";") {
+			strings.HasPrefix(fileType, t+";") ||
+			// Allow a class whitelist, like 'image/*'
+			(strings.HasSuffix(t, "/*") && strings.HasPrefix(fileType, strings.TrimRight(t, "*"))) {
 			return nil
 		}
 	}


### PR DESCRIPTION
The old behavior prevented simple file types like "text/plain" from
being uploaded since browsers upload them with the charset as well (e.g.
`text/plain charset=utf-8`) without specifying all possible charsets.

Additionally, this allows for blanket includes like "text/" or "image/"
by class type.

There should be minimal risk introduced here as mime types are generally
hierarchical, but an alternative approach would be the equivalent of

```
if allowed.endsWith("*") && strings.HasPrefix(fileType,
    allowed.substr(0, allowed.length - 1) { ....
```