### PR TITLE
Escape branch name in dropdown menu

### DIFF
--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -47,9 +47,9 @@
 						</div>
 						<div class="text small">
 							{{if .IsViewBranch}}
-								{{.i18n.Tr "repo.branch.create_from" .BranchName | Safe}}
+								{{.i18n.Tr "repo.branch.create_from" .BranchName}}
 							{{else}}
-								{{.i18n.Tr "repo.branch.create_from" (ShortSha .BranchName) | Safe}}
+								{{.i18n.Tr "repo.branch.create_from" (ShortSha .BranchName)}}
 							{{end}}
 						</div>
 					</a>


### PR DESCRIPTION
Fix XSS part of #3681 by removing `safe` from `BranchName` in the dropdown menu.

Requires backport to 1.4.