### PR TITLE
[RFC] Update issues via pull requests

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -807,7 +807,7 @@ func MergePullRequestAction(doer *User, repo *Repository, pull *Issue, commits *
 	}
 
 	if err := UpdateIssuesComment(doer, repo, pull, nil, true); err != nil {
-		log.Error(4, "UpdateIssuesCommit: %v", err)
+		log.Error(4, "UpdateIssuesComment: %v", err)
 	}
 
 	if err := notifyWatchers(x, &Action{
@@ -832,7 +832,7 @@ func NewPullRequestAction(doer *User, repo *Repository, pull *Issue, commits *Pu
 	}
 
 	if err := UpdateIssuesComment(doer, repo, pull, nil, false); err != nil {
-		log.Error(4, "UpdateIssuesCommit: %v", err)
+		log.Error(4, "UpdateIssuesComment: %v", err)
 	}
 
 	if err := NotifyWatchers(&Action{

--- a/models/action.go
+++ b/models/action.go
@@ -810,6 +810,10 @@ func MergePullRequestAction(doer *User, repo *Repository, pull *Issue, commits *
 		log.Error(4, "UpdateIssuesCommit: %v", err)
 	}
 
+	if err := UpdateIssuesComment(doer, repo, pull, nil, true); err != nil {
+		log.Error(4, "UpdateIssuesCommit: %v", err)
+	}
+
 	if err := notifyWatchers(x, &Action{
 		ActUserID: doer.ID,
 		ActUser:   doer,
@@ -828,6 +832,10 @@ func MergePullRequestAction(doer *User, repo *Repository, pull *Issue, commits *
 // NewPullRequestAction adds new action for creating a new pull request.
 func NewPullRequestAction(doer *User, repo *Repository, pull *Issue, commits *PushCommits) error {
 	if err := UpdateIssuesCommit(doer, repo, commits.Commits, false); err != nil {
+		log.Error(4, "UpdateIssuesCommit: %v", err)
+	}
+
+	if err := UpdateIssuesComment(doer, repo, pull, nil, false); err != nil {
 		log.Error(4, "UpdateIssuesCommit: %v", err)
 	}
 
@@ -853,6 +861,30 @@ func CommitPullRequestAction(doer *User, repo *Repository, commits *PushCommits)
 	if err := UpdateIssuesCommit(doer, repo, commits.Commits, false); err != nil {
 		log.Error(4, "UpdateIssuesCommit: %v", err)
 	}
+
+	// no action added
+
+	return nil
+}
+
+// CreateOrUpdateCommentAction adds new action when creating or updating a comment.
+func CreateOrUpdateCommentAction(doer *User, repo *Repository, issue *Issue, comment *Comment) error {
+	if err := UpdateIssuesComment(doer, repo, issue, comment, false); err != nil {
+		log.Error(4, "UpdateIssuesComment: %v", err)
+	}
+
+	// no action added
+
+	return nil
+}
+
+// CreateOrUpdateIssueAction adds new action when creating a new issue or pull request.
+func CreateOrUpdateIssueAction(doer *User, repo *Repository, issue *Issue) error {
+	if err := UpdateIssuesComment(doer, repo, issue, nil, false); err != nil {
+		log.Error(4, "UpdateIssuesComment: %v", err)
+	}
+
+	// no action added
 
 	return nil
 }

--- a/models/action.go
+++ b/models/action.go
@@ -565,7 +565,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit, com
 			}
 
 			if (mask & KeywordsFoundReference) == KeywordsFoundReference {
-				message := fmt.Sprintf(`<a href="%s/commit/%s">%s</a>`, repo.Link(), c.Sha1, c.Message)
+				message := fmt.Sprintf("%d %s", repo.ID, c.Sha1)
 				if err = CreateCommitRefComment(doer, repo, issue, message, c.Sha1); err != nil {
 					return err
 				}

--- a/models/action.go
+++ b/models/action.go
@@ -505,7 +505,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit, com
 
 			if (mask & KeywordsFoundReference) == KeywordsFoundReference {
 				message := fmt.Sprintf(`<a href="%s/commit/%s">%s</a>`, repo.Link(), c.Sha1, c.Message)
-				if err = CreateRefComment(doer, repo, issue, message, c.Sha1); err != nil {
+				if err = CreateCommitRefComment(doer, repo, issue, message, c.Sha1); err != nil {
 					return err
 				}
 			}

--- a/models/action.go
+++ b/models/action.go
@@ -787,8 +787,8 @@ func NewPullRequestAction(doer *User, repo *Repository, pull *Issue, commits *Pu
 	return nil
 }
 
-// UpdatePullRequestAction adds new action for updating or merging a pull request.
-func UpdatePullRequestAction(doer *User, repo *Repository, pull *Issue, commits *PushCommits) error {
+// CommitPullRequestAction adds new action for pushed commits tracked by a pull request.
+func CommitPullRequestAction(doer *User, repo *Repository, commits *PushCommits) error {
 	if err := UpdateIssuesCommit(doer, repo, commits.Commits, false); err != nil {
 		log.Error(4, "UpdateIssuesCommit: %v", err)
 	}

--- a/models/action.go
+++ b/models/action.go
@@ -86,15 +86,15 @@ func assembleKeywordsPattern(words []string) string {
 func init() {
 	// populate with details to find keywords for reference, reopen, close
 	issueKeywordsToFind = []*IssueKeywordsToFind{
-		&IssueKeywordsToFind{
+		{
 			Pattern:           regexp.MustCompile(issueRefRegexpStr),
 			KeywordsFoundMask: KeywordsFoundReference,
 		},
-		&IssueKeywordsToFind{
+		{
 			Pattern:           regexp.MustCompile(assembleKeywordsPattern(issueReopenKeywords)),
 			KeywordsFoundMask: KeywordsFoundReopen,
 		},
-		&IssueKeywordsToFind{
+		{
 			Pattern:           regexp.MustCompile(assembleKeywordsPattern(issueCloseKeywords)),
 			KeywordsFoundMask: KeywordsFoundClose,
 		},
@@ -512,13 +512,13 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit, com
 
 			if commitsAreMerged {
 				// take no action if both KeywordsFoundClose and KeywordsFoundOpen are set
-				if (mask & (KeywordsFoundReopen|KeywordsFoundClose)) == KeywordsFoundClose {
+				if (mask & (KeywordsFoundReopen | KeywordsFoundClose)) == KeywordsFoundClose {
 					if issue.RepoID == repo.ID && !issue.IsClosed {
 						if err = issue.ChangeStatus(doer, repo, true); err != nil {
 							return err
 						}
 					}
-				} else if (mask & (KeywordsFoundReopen|KeywordsFoundClose)) == KeywordsFoundReopen {
+				} else if (mask & (KeywordsFoundReopen | KeywordsFoundClose)) == KeywordsFoundReopen {
 					if issue.RepoID == repo.ID && issue.IsClosed {
 						if err = issue.ChangeStatus(doer, repo, false); err != nil {
 							return err

--- a/models/action.go
+++ b/models/action.go
@@ -800,10 +800,12 @@ func TransferRepoAction(doer, oldOwner *User, repo *Repository) error {
 	return transferRepoAction(x, doer, oldOwner, repo)
 }
 
-// MergePullRequestAction adds new action for merging pull request.
+// MergePullRequestAction adds new action for merging pull request (including manually merged pull requests).
 func MergePullRequestAction(doer *User, repo *Repository, pull *Issue, commits *PushCommits) error {
-	if err := UpdateIssuesCommit(doer, repo, commits.Commits, true); err != nil {
-		log.Error(4, "UpdateIssuesCommit: %v", err)
+	if commits != nil {
+		if err := UpdateIssuesCommit(doer, repo, commits.Commits, true); err != nil {
+			log.Error(4, "UpdateIssuesCommit: %v", err)
+		}
 	}
 
 	if err := UpdateIssuesComment(doer, repo, pull, nil, true); err != nil {

--- a/models/action_test.go
+++ b/models/action_test.go
@@ -227,7 +227,7 @@ func TestUpdateIssuesCommit(t *testing.T) {
 
 	AssertNotExistsBean(t, commentBean)
 	AssertNotExistsBean(t, &Issue{RepoID: repo.ID, Index: 2}, "is_closed=1")
-	assert.NoError(t, UpdateIssuesCommit(user, repo, pushCommits))
+	assert.NoError(t, UpdateIssuesCommit(user, repo, pushCommits, true))
 	AssertExistsAndLoadBean(t, commentBean)
 	AssertExistsAndLoadBean(t, issueBean, "is_closed=1")
 	CheckConsistencyFor(t, &Action{})

--- a/models/action_test.go
+++ b/models/action_test.go
@@ -379,6 +379,7 @@ func TestMergePullRequestAction(t *testing.T) {
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1, OwnerID: user.ID}).(*Repository)
 	repo.Owner = user
 	issue := AssertExistsAndLoadBean(t, &Issue{ID: 3, RepoID: repo.ID}).(*Issue)
+	commits := &PushCommits{0, make([]*PushCommit, 0), "", nil}
 
 	actionBean := &Action{
 		OpType:    ActionMergePullRequest,
@@ -389,7 +390,7 @@ func TestMergePullRequestAction(t *testing.T) {
 		IsPrivate: repo.IsPrivate,
 	}
 	AssertNotExistsBean(t, actionBean)
-	assert.NoError(t, MergePullRequestAction(user, repo, issue))
+	assert.NoError(t, MergePullRequestAction(user, repo, issue, commits))
 	AssertExistsAndLoadBean(t, actionBean)
 	CheckConsistencyFor(t, &Action{})
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -829,6 +829,10 @@ func (issue *Issue) ChangeTitle(doer *User, title string) (err error) {
 		go HookQueue.Add(issue.RepoID)
 	}
 
+	if err = CreateOrUpdateIssueAction(doer, issue.Repo, issue); err != nil {
+		return fmt.Errorf("CreateOrUpdateIssueAction: %v", err)
+	}
+
 	return nil
 }
 
@@ -892,6 +896,10 @@ func (issue *Issue) ChangeContent(doer *User, content string) (err error) {
 		log.Error(4, "PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
 	} else {
 		go HookQueue.Add(issue.RepoID)
+	}
+
+	if err = CreateOrUpdateIssueAction(doer, issue.Repo, issue); err != nil {
+		return fmt.Errorf("CreateOrUpdateIssueAction: %v", err)
 	}
 
 	return nil
@@ -1067,6 +1075,10 @@ func NewIssue(repo *Repository, issue *Issue, labelIDs []int64, assigneeIDs []in
 	}
 
 	UpdateIssueIndexer(issue.ID)
+
+	if err = CreateOrUpdateIssueAction(issue.Poster, issue.Repo, issue); err != nil {
+		return fmt.Errorf("CreateOrUpdateIssueAction: %v", err)
+	}
 
 	if err = NotifyWatchers(&Action{
 		ActUserID: issue.Poster.ID,

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -129,11 +129,11 @@ type Comment struct {
 	UpdatedUnix util.TimeStamp `xorm:"INDEX updated"`
 
 	// Reference issue in commit message, comments, issues, or pull requests
-	RefExists  bool
-	RefIssue   *Issue
-	RefComment *Comment
-	RefMessage string
-	RefURL     string
+	RefExists  bool     `xorm:"-"`
+	RefIssue   *Issue   `xorm:"-"`
+	RefComment *Comment `xorm:"-"`
+	RefMessage string   `xorm:"-"`
+	RefURL     string   `xorm:"-"`
 	// the commit SHA for commit refs otherwise a SHA of a unique reference identifier
 	CommitSHA string `xorm:"VARCHAR(40)"`
 

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -778,6 +778,10 @@ func CreateComment(opts *CreateCommentOptions) (comment *Comment, err error) {
 
 	if opts.Type == CommentTypeComment {
 		UpdateIssueIndexer(opts.Issue.ID)
+
+		if err = CreateOrUpdateCommentAction(comment.Poster, opts.Repo, opts.Issue, comment); err != nil {
+			return nil, err
+		}
 	}
 	return comment, nil
 }
@@ -1002,6 +1006,15 @@ func UpdateComment(doer *User, c *Comment, oldContent string) error {
 		return err
 	} else if c.Type == CommentTypeComment {
 		UpdateIssueIndexer(c.IssueID)
+
+		issue, err := GetIssueByID(c.IssueID)
+		if err != nil {
+			return err
+		}
+
+		if err = CreateOrUpdateCommentAction(c.Poster, issue.Repo, issue, c); err != nil {
+			return err
+		}
 	}
 
 	if err := c.LoadIssue(); err != nil {

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -273,7 +273,7 @@ func (c *Comment) EventTag() string {
 // LoadReference if comment.Type is CommentType{Issue,Commit,Comment,Pull}Ref, then load RefIssue, RefComment
 func (c *Comment) LoadReference() error {
 	if c.Type == CommentTypeIssueRef || c.Type == CommentTypePullRef {
-		issueID := int64(0)
+		var issueID int64
 		n, err := fmt.Sscanf(c.Content, "%d", &issueID)
 		if err != nil {
 			return err
@@ -309,7 +309,7 @@ func (c *Comment) LoadReference() error {
 			// this is a new style commit ref
 			contentParts := strings.SplitN(c.Content, " ", 2)
 			if len(contentParts) == 2 {
-				repoID := int64(0)
+				var repoID int64
 				n, err := fmt.Sscanf(contentParts[0], "%d", &repoID)
 				if err != nil {
 					return err
@@ -338,7 +338,7 @@ func (c *Comment) LoadReference() error {
 			}
 		}
 	} else if c.Type == CommentTypeCommentRef {
-		commentID := int64(0)
+		var commentID int64
 		n, err := fmt.Sscanf(c.Content, "%d", &commentID)
 		if err != nil {
 			return err

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1127,7 +1127,6 @@ func UpdateComment(doer *User, c *Comment, oldContent string) error {
 	}
 
 	mode, _ := AccessLevel(doer, c.Issue.Repo)
-
 	issue, err := GetIssueByID(c.IssueID)
 	if err != nil {
 		return err

--- a/models/issue_comment_test.go
+++ b/models/issue_comment_test.go
@@ -14,9 +14,27 @@ import (
 func TestCreateComment(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	issue := AssertExistsAndLoadBean(t, &Issue{}).(*Issue)
-	repo := AssertExistsAndLoadBean(t, &Repository{ID: issue.RepoID}).(*Repository)
-	doer := AssertExistsAndLoadBean(t, &User{ID: repo.OwnerID}).(*User)
+	doer := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
+	repo.Owner = doer
+
+	issue := AssertExistsAndLoadBean(t, &Issue{RepoID: repo.ID, Index: 1}).(*Issue)
+	refIssue := AssertExistsAndLoadBean(t, &Issue{RepoID: repo.ID, Index: 2}).(*Issue)
+
+	commentBean := []*Comment{
+		{
+			Type:     CommentTypeCommentRef,
+			PosterID: doer.ID,
+			IssueID:  issue.ID,
+		},
+		{
+			Type:     CommentTypeCommentRef,
+			PosterID: doer.ID,
+			IssueID:  refIssue.ID,
+		},
+	}
+	AssertNotExistsBean(t, commentBean[0])
+	AssertNotExistsBean(t, commentBean[1])
 
 	now := time.Now().Unix()
 	comment, err := CreateComment(&CreateCommentOptions{
@@ -24,20 +42,28 @@ func TestCreateComment(t *testing.T) {
 		Doer:    doer,
 		Repo:    repo,
 		Issue:   issue,
-		Content: "Hello",
+		Content: "Hello, this comment references issue #2",
 	})
 	assert.NoError(t, err)
 	then := time.Now().Unix()
 
 	assert.EqualValues(t, CommentTypeComment, comment.Type)
-	assert.EqualValues(t, "Hello", comment.Content)
+	assert.EqualValues(t, "Hello, this comment references issue #2", comment.Content)
 	assert.EqualValues(t, issue.ID, comment.IssueID)
 	assert.EqualValues(t, doer.ID, comment.PosterID)
 	AssertInt64InRange(t, now, then, int64(comment.CreatedUnix))
 	AssertExistsAndLoadBean(t, comment) // assert actually added to DB
+	AssertNotExistsBean(t, commentBean[0])
+	AssertExistsAndLoadBean(t, commentBean[1])
 
 	updatedIssue := AssertExistsAndLoadBean(t, &Issue{ID: issue.ID}).(*Issue)
 	AssertInt64InRange(t, now, then, int64(updatedIssue.UpdatedUnix))
+
+	err = commentBean[1].LoadReference()
+	assert.NoError(t, err)
+	if assert.NotNil(t, commentBean[1].RefIssue) {
+		assert.EqualValues(t, issue.ID, commentBean[1].RefIssue.ID)
+	}
 }
 
 func TestFetchCodeComments(t *testing.T) {

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -202,6 +202,8 @@ var migrations = []Migration{
 	NewMigration("add must_change_password column for users table", addMustChangePassword),
 	// v74 -> v75
 	NewMigration("add approval whitelists to protected branches", addApprovalWhitelistsToProtectedBranches),
+	// v75 -> v76
+	NewMigration("reformat old-style reference comments, add new-style reference comments", reformatAndAddReferenceComments),
 }
 
 // Migrate database to current version

--- a/models/migrations/v75.go
+++ b/models/migrations/v75.go
@@ -1,0 +1,280 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"container/list"
+	"fmt"
+	"strings"
+
+	"code.gitea.io/git"
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/util"
+	"github.com/go-xorm/xorm"
+)
+
+func reformatAndAddReferenceComments(x *xorm.Engine) error {
+	const batchSize = 100
+
+	sess := x.NewSession()
+	defer sess.Close()
+
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	var maxCommentID int64
+
+	// create an repo lookup to map the repo's full name to the repository object
+	var repos []*models.Repository
+	repoLookup := make(map[string]*models.Repository)
+	if err := x.Find(&repos); err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		repoLookup[repo.FullName()] = repo
+	}
+
+	// create an issue updated lookup to save the current UpdateUnix values since UpdatedUnix gets updated as we migrate
+	var issues []*models.Issue
+	issueUpdatedLookup := make(map[int64]util.TimeStamp)
+	if err := x.Find(&issues); err != nil {
+		return err
+	}
+	for _, issue := range issues {
+		issueUpdatedLookup[issue.ID] = issue.UpdatedUnix
+	}
+
+	// convert or remove old-style commit reference comments
+	for refCommentStart := 0; ; refCommentStart += batchSize {
+		refComments := make([]*models.Comment, 0, batchSize)
+		if err := x.Where("comment.type = ?", models.CommentTypeCommitRef).Limit(batchSize, refCommentStart).Find(&refComments); err != nil {
+			return err
+		}
+		if len(refComments) == 0 {
+			break
+		}
+
+		for _, refComment := range refComments {
+			if err := refComment.LoadReference(); err != nil {
+				// if load failed, parse the content into a repo link and a commit SHA...
+				if strings.HasPrefix(refComment.Content, `<a href="`) && strings.HasSuffix(refComment.Content, `</a>`) {
+					content := strings.TrimSuffix(strings.TrimPrefix(refComment.Content, `<a href="`), `</a>`)
+					contentParts := strings.SplitN(content, `">`, 2)
+					if len(contentParts) == 2 {
+						linkParts := strings.SplitN(contentParts[0], `/commit/`, 2)
+						if len(linkParts) == 2 && len(linkParts[1]) == 40 {
+							repoLinkParts := strings.Split(linkParts[0], "/")
+							commitSha1 := linkParts[1]
+							// ...then check if the repo/commit exist...
+							if len(repoLinkParts) >= 2 {
+								repoFullName := strings.Join(repoLinkParts[len(repoLinkParts)-2:], "/")
+								refRepo := repoLookup[repoFullName]
+								if refRepo != nil {
+									gitRepo, err := git.OpenRepository(refRepo.RepoPath())
+									if err == nil {
+										refCommit, err := gitRepo.GetCommit(commitSha1)
+										if err == nil {
+											// ...and update the ref comment to the new-style
+											refComment.Content = fmt.Sprintf("%d %s", refRepo.ID, refCommit.ID.String())
+											refComment.CommitSHA = base.EncodeSha1(refComment.Content)
+
+											if _, err := x.ID(refComment.ID).AllCols().Update(refComment); err == nil {
+												// continue if successful in order to skip over the delete below
+												continue
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+				// delete the comment if unable to convert it
+				if _, err := x.Delete(refComment); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// for every issue and every comment, try to process the title+contents as ref only, no open/close action
+	for issueStart := 0; ; issueStart += batchSize {
+		issues = make([]*models.Issue, 0, batchSize)
+		if err := x.Limit(batchSize, issueStart).Find(&issues); err != nil {
+			return err
+		}
+		if len(issues) == 0 {
+			break
+		}
+
+		if err := models.IssueList(issues).LoadAttributes(); err != nil {
+			continue
+		}
+
+		for _, issue := range issues {
+			if _, err := x.Table("comment").Select("coalesce(max(comment.id), 0)").Get(&maxCommentID); err != nil {
+				return err
+			}
+
+			if err := models.UpdateIssuesComment(issue.Poster, issue.Repo, issue, nil, false); err != nil {
+				continue
+			}
+
+			// try to handle the commit messages if this is a pull request
+			for once := true; once && issue.IsPull; once = false {
+				var (
+					err         error
+					pr          *models.PullRequest
+					baseBranch  *models.Branch
+					headBranch  *models.Branch
+					baseCommit  *git.Commit
+					headCommit  *git.Commit
+					baseGitRepo *git.Repository
+				)
+
+				if pr, err = issue.GetPullRequest(); err != nil {
+					continue
+				}
+
+				if err = pr.GetBaseRepo(); err != nil {
+					continue
+				}
+
+				if err = pr.GetHeadRepo(); err != nil {
+					continue
+				}
+
+				if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {
+					continue
+				}
+				if baseCommit, err = baseBranch.GetCommit(); err != nil {
+					continue
+				}
+				if headBranch, err = pr.HeadRepo.GetBranch(pr.HeadBranch); err != nil {
+					continue
+				}
+				if headCommit, err = headBranch.GetCommit(); err != nil {
+					continue
+				}
+				if baseGitRepo, err = git.OpenRepository(pr.BaseRepo.RepoPath()); err != nil {
+					continue
+				}
+
+				mergeBase, err := baseGitRepo.GetMergeBase(baseCommit.ID.String(), headCommit.ID.String())
+				if err != nil {
+					continue
+				}
+
+				l, err := baseGitRepo.CommitsBetweenIDs(headCommit.ID.String(), mergeBase)
+				if err != nil {
+					continue
+				}
+
+				commits := models.ListToPushCommits(l)
+				if err := models.UpdateIssuesCommit(issue.Poster, pr.BaseRepo, commits.Commits, false); err != nil {
+					continue
+				}
+			}
+
+			if _, err := x.Exec("UPDATE `comment` SET `created_unix` = ?, `updated_unix` = ? WHERE `id` > ?", issueUpdatedLookup[issue.ID], issueUpdatedLookup[issue.ID], maxCommentID); err != nil {
+				return err
+			}
+
+			// try to handle all comments on this issue
+			for commentStart := 0; ; commentStart += batchSize {
+				comments := make([]*models.Comment, 0, batchSize)
+				if err := x.Limit(batchSize, commentStart).Find(&comments); err != nil {
+					return err
+				}
+				if len(comments) == 0 {
+					break
+				}
+
+				for _, comment := range comments {
+					if comment.Type != models.CommentTypeComment && comment.Type != models.CommentTypeCode && comment.Type != models.CommentTypeReview {
+						continue
+					}
+
+					if _, err := x.Table("comment").Select("coalesce(max(comment.id), 0)").Get(&maxCommentID); err != nil {
+						return err
+					}
+
+					if err := comment.LoadIssue(); err != nil {
+						continue
+					}
+
+					if err := models.UpdateIssuesComment(comment.Poster, issue.Repo, issue, comment, false); err != nil {
+						continue
+					}
+
+					if _, err := x.Exec("UPDATE `comment` SET `created_unix` = ?, `updated_unix` = ? WHERE `id` > ?", comment.UpdatedUnix, comment.UpdatedUnix, maxCommentID); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// for every repo, try to process the commits an all branches for issue references
+	for _, repo := range repoLookup {
+		if _, err := x.Table("comment").Select("coalesce(max(comment.id), 0)").Get(&maxCommentID); err != nil {
+			return err
+		}
+
+		var (
+			err           error
+			gitRepo       *git.Repository
+			branches      []*models.Branch
+			defaultBranch *models.Branch
+			defaultCommit *git.Commit
+		)
+
+		if gitRepo, err = git.OpenRepository(repo.RepoPath()); err != nil {
+			continue
+		}
+
+		if defaultBranch, err = repo.GetBranch(repo.DefaultBranch); err != nil {
+			continue
+		}
+		if defaultCommit, err = defaultBranch.GetCommit(); err != nil {
+			continue
+		}
+
+		if branches, err = repo.GetBranches(); err != nil {
+			continue
+		}
+
+		for _, branch := range branches {
+			var branchCommit *git.Commit
+			if branchCommit, err = branch.GetCommit(); err != nil {
+				continue
+			}
+
+			var l *list.List
+			if branch.Name == repo.DefaultBranch {
+				l, err = branchCommit.CommitsBefore()
+			} else {
+				l, err = gitRepo.CommitsBetweenIDs(branchCommit.ID.String(), defaultCommit.ID.String())
+			}
+			if err != nil {
+				continue
+			}
+
+			commits := models.ListToPushCommits(l)
+			if err := models.UpdateIssuesCommit(repo.MustOwner(), repo, commits.Commits, false); err != nil {
+				continue
+			}
+		}
+
+		if _, err := x.Exec("UPDATE `comment` SET `created_unix` = ?, `updated_unix` = ? WHERE `id` > ?", repo.UpdatedUnix, repo.UpdatedUnix, maxCommentID); err != nil {
+			return err
+		}
+	}
+
+	return sess.Commit()
+}

--- a/models/pull.go
+++ b/models/pull.go
@@ -782,6 +782,10 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 		return fmt.Errorf("Commit: %v", err)
 	}
 
+	if err := pr.PushToBaseRepo(); err != nil {
+		return fmt.Errorf("PushToBaseRepo: %v", err)
+	}
+
 	UpdateIssueIndexer(pull.ID)
 
 	pr.Issue = pull

--- a/models/pull.go
+++ b/models/pull.go
@@ -815,7 +815,12 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 		return fmt.Errorf("OpenRepository: %v", err)
 	}
 
-	l, err := baseGitRepo.CommitsBetweenIDs(headCommit.ID.String(), baseCommit.ID.String())
+	mergeBase, err := baseGitRepo.GetMergeBase(baseCommit.ID.String(), headCommit.ID.String())
+	if err != nil {
+		return fmt.Errorf("GetMergeBase: %v", err)
+	}
+
+	l, err := baseGitRepo.CommitsBetweenIDs(headCommit.ID.String(), mergeBase)
 	if err != nil {
 		return fmt.Errorf("CommitsBetweenIDs: %v", err)
 	}

--- a/models/pull.go
+++ b/models/pull.go
@@ -800,26 +800,24 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 		baseGitRepo *git.Repository
 	)
 	if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {
-		return nil
+		return fmt.Errorf("GetBranch: %v", err)
 	}
 	if baseCommit, err = baseBranch.GetCommit(); err != nil {
-		return nil
+		return fmt.Errorf("GetCommit: %v", err)
 	}
 	if headBranch, err = pr.HeadRepo.GetBranch(pr.HeadBranch); err != nil {
-		return nil
+		return fmt.Errorf("GetBranch: %v", err)
 	}
 	if headCommit, err = headBranch.GetCommit(); err != nil {
-		return nil
+		return fmt.Errorf("GetCommit: %v", err)
 	}
 	if baseGitRepo, err = git.OpenRepository(pr.BaseRepo.RepoPath()); err != nil {
-		log.Error(4, "OpenRepository", err)
-		return nil
+		return fmt.Errorf("OpenRepository: %v", err)
 	}
 
 	l, err := baseGitRepo.CommitsBetweenIDs(headCommit.ID.String(), baseCommit.ID.String())
 	if err != nil {
-		log.Error(4, "CommitsBetweenIDs: %v", err)
-		return nil
+		return fmt.Errorf("CommitsBetweenIDs: %v", err)
 	}
 
 	commits := ListToPushCommits(l)

--- a/models/pull.go
+++ b/models/pull.go
@@ -588,6 +588,11 @@ func (pr *PullRequest) manuallyMerged() bool {
 			return false
 		}
 		log.Info("manuallyMerged[%d]: Marked as manually merged into %s/%s by commit id: %s", pr.ID, pr.BaseRepo.Name, pr.BaseBranch, commit.ID.String())
+
+		if err = MergePullRequestAction(pr.Merger, pr.Issue.Repo, pr.Issue, nil); err != nil {
+			log.Error(4, "MergePullRequestAction [%d]: %v", pr.ID, err)
+		}
+
 		return true
 	}
 	return false

--- a/models/pull.go
+++ b/models/pull.go
@@ -784,10 +784,10 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 	mode, _ := AccessLevel(pull.Poster, repo)
 
 	var (
-		baseBranch *Branch
-		headBranch *Branch
-		baseCommit *git.Commit
-		headCommit *git.Commit
+		baseBranch  *Branch
+		headBranch  *Branch
+		baseCommit  *git.Commit
+		headCommit  *git.Commit
 		baseGitRepo *git.Repository
 	)
 	if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {

--- a/models/update.go
+++ b/models/update.go
@@ -299,10 +299,10 @@ func pushUpdate(branch string, opts PushUpdateOptions) (repo *Repository, err er
 			}
 
 			var (
-				baseBranch *Branch
-				headBranch *Branch
-				baseCommit *git.Commit
-				headCommit *git.Commit
+				baseBranch  *Branch
+				headBranch  *Branch
+				baseCommit  *git.Commit
+				headCommit  *git.Commit
 				headGitRepo *git.Repository
 			)
 			if baseBranch, err = pr.BaseRepo.GetBranch(pr.BaseBranch); err != nil {

--- a/models/update.go
+++ b/models/update.go
@@ -328,7 +328,13 @@ func pushUpdate(branch string, opts PushUpdateOptions) (repo *Repository, err er
 				continue
 			}
 
-			l, err := headGitRepo.CommitsBetweenIDs(headCommit.ID.String(), baseCommit.ID.String())
+			mergeBase, err := headGitRepo.GetMergeBase(baseCommit.ID.String(), headCommit.ID.String())
+			if err != nil {
+				log.Error(4, "GetMergeBase: %v", err)
+				continue
+			}
+
+			l, err := headGitRepo.CommitsBetweenIDs(headCommit.ID.String(), mergeBase)
 			if err != nil {
 				log.Error(4, "CommitsBetweenIDs: %v", err)
 				continue

--- a/models/update.go
+++ b/models/update.go
@@ -335,8 +335,8 @@ func pushUpdate(branch string, opts PushUpdateOptions) (repo *Repository, err er
 			}
 
 			commits := ListToPushCommits(l)
-			if err = UpdatePullRequestAction(pusher, pr.BaseRepo, pr.Issue, commits); err != nil {
-				log.Error(4, "UpdatePullRequestAction [%d]: %v", pr.ID, err)
+			if err = CommitPullRequestAction(pusher, pr.BaseRepo, commits); err != nil {
+				log.Error(4, "CommitPullRequestAction [%d]: %v", pr.ID, err)
 				continue
 			}
 		}

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -740,6 +740,8 @@ issues.issue_ref_at = `referenced this issue from an issue <a id="%[1]s" href="#
 issues.commit_ref_at = `referenced this issue from a commit <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.comment_ref_at = `referenced this issue from a comment <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.pull_ref_at = `referenced this issue from a pull request <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.review_ref_at = `referenced this issue from a review of a pull request <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.code_ref_at = `referenced this issue from a comment on a pull request diff <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.poster = Poster
 issues.collaborator = Collaborator
 issues.owner = Owner

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -736,7 +736,10 @@ issues.reopen_comment_issue = Comment and Reopen
 issues.create_comment = Comment
 issues.closed_at = `closed <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.reopened_at = `reopened <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.issue_ref_at = `referenced this issue from an issue <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.commit_ref_at = `referenced this issue from a commit <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.comment_ref_at = `referenced this issue from a comment <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.pull_ref_at = `referenced this issue from a pull request <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.poster = Poster
 issues.collaborator = Collaborator
 issues.owner = Owner

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -294,9 +294,6 @@ func CreatePullRequest(ctx *context.APIContext, form api.CreatePullRequestOption
 		}
 		ctx.Error(500, "NewPullRequest", err)
 		return
-	} else if err := pr.PushToBaseRepo(); err != nil {
-		ctx.Error(500, "PushToBaseRepo", err)
-		return
 	}
 
 	notification.NotifyNewPullRequest(pr)

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -725,6 +725,10 @@ func ViewIssue(ctx *context.Context) {
 			if !isAdded && !issue.IsPoster(comment.Poster.ID) {
 				participants = append(participants, comment.Poster)
 			}
+		} else if comment.Type == models.CommentTypeIssueRef || comment.Type == models.CommentTypeCommitRef || comment.Type == models.CommentTypeCommentRef || comment.Type == models.CommentTypePullRef {
+			if err = comment.LoadReference(); err != nil {
+				continue
+			}
 		} else if comment.Type == models.CommentTypeLabel {
 			if err = comment.LoadLabel(); err != nil {
 				ctx.ServerError("LoadLabel", err)

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -725,7 +725,12 @@ func ViewIssue(ctx *context.Context) {
 			if !isAdded && !issue.IsPoster(comment.Poster.ID) {
 				participants = append(participants, comment.Poster)
 			}
-		} else if comment.Type == models.CommentTypeIssueRef || comment.Type == models.CommentTypeCommitRef || comment.Type == models.CommentTypeCommentRef || comment.Type == models.CommentTypePullRef {
+		} else if comment.Type == models.CommentTypeIssueRef ||
+			comment.Type == models.CommentTypeCommitRef ||
+			comment.Type == models.CommentTypeCommentRef ||
+			comment.Type == models.CommentTypePullRef ||
+			comment.Type == models.CommentTypeReviewRef ||
+			comment.Type == models.CommentTypeCodeRef {
 			if err = comment.LoadReference(); err != nil {
 				continue
 			}

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -894,9 +894,6 @@ func CompareAndPullRequestPost(ctx *context.Context, form auth.CreateIssueForm) 
 		}
 		ctx.ServerError("NewPullRequest", err)
 		return
-	} else if err := pullRequest.PushToBaseRepo(); err != nil {
-		ctx.ServerError("PushToBaseRepo", err)
-		return
 	}
 
 	notification.NotifyNewPullRequest(pullRequest)

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -104,7 +104,7 @@
 
 			<div class="detail">
 				<span class="octicon octicon-git-commit"></span>
-				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefMessage | Escape}}</span> ({{ShortSha .CommitSHA}})</a></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefCommitMessage | Escape}}</span> ({{.RefCommitShortSHA | Escape}})</a></span>
 			</div>
 		</div>
 	{{else if and (eq .Type 5) .RefExists}}
@@ -282,7 +282,7 @@
 	     	</span>
 	     	<div class="detail">
 		    	<span class="octicon octicon-plus"></span>
-			 	<span class="text grey"><a href="{{$.RepoLink}}/issues/{{.DependentIssue.Index}}">#{{.DependentIssue.Index}} {{.DependentIssue.Title}}</a></span>
+				<span class="text grey"><a href="{{$.RepoLink}}/issues/{{.DependentIssue.Index}}"><span class="title has-emoji">{{.DependentIssue.Title | Escape}}</span> (#{{.DependentIssue.Index}})</a></span>
 		 	</div>
      	</div>
 	{{else if eq .Type 20}}
@@ -296,7 +296,7 @@
 	     	</span>
 	     	<div class="detail">
 		     	<span class="text grey octicon octicon-trashcan"></span>
-			 	<span class="text grey"><a href="{{$.RepoLink}}/issues/{{.DependentIssue.Index}}">#{{.DependentIssue.Index}} {{.DependentIssue.Title}}</a></span>
+				<span class="text grey"><a href="{{$.RepoLink}}/issues/{{.DependentIssue.Index}}"><span class="title has-emoji">{{.DependentIssue.Title | Escape}}</span> (#{{.DependentIssue.Index}})</a></span>
 	     	</div>
      	</div>
 	{{else if eq .Type 22}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -133,6 +133,32 @@
 				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
 			</div>
 		</div>
+	{{else if and (eq .Type 23) .RefExists}}
+		<div class="event">
+			<span class="octicon octicon-bookmark"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.review_ref_at" .EventTag $createdStr | Safe}}</span>
+
+			<div class="detail">
+				<span class="octicon octicon-comment-discussion"></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
+			</div>
+		</div>
+	{{else if and (eq .Type 24) .RefExists}}
+		<div class="event">
+			<span class="octicon octicon-bookmark"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.code_ref_at" .EventTag $createdStr | Safe}}</span>
+
+			<div class="detail">
+				<span class="octicon octicon-comment-discussion"></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
+			</div>
+		</div>
 	{{else if eq .Type 7}}
 		{{if .Label}}
 			<div class="event">

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -81,7 +81,20 @@
 			</a>
 			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.closed_at" .EventTag $createdStr | Safe}}</span>
 		</div>
-	{{else if eq .Type 4}}
+	{{else if and (eq .Type 3) .RefExists}}
+		<div class="event">
+			<span class="octicon octicon-bookmark"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.issue_ref_at" .EventTag $createdStr | Safe}}</span>
+
+			<div class="detail">
+				<span class="octicon octicon-issue-opened"></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
+			</div>
+		</div>
+	{{else if and (eq .Type 4) .RefExists}}
 		<div class="event">
 			<span class="octicon octicon-bookmark"></span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
@@ -91,7 +104,33 @@
 
 			<div class="detail">
 				<span class="octicon octicon-git-commit"></span>
-				<span class="text grey">{{.Content | Str2html}}</span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefMessage | Escape}}</span> ({{ShortSha .CommitSHA}})</a></span>
+			</div>
+		</div>
+	{{else if and (eq .Type 5) .RefExists}}
+		<div class="event">
+			<span class="octicon octicon-bookmark"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.comment_ref_at" .EventTag $createdStr | Safe}}</span>
+
+			<div class="detail">
+				<span class="octicon octicon-comment-discussion"></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
+			</div>
+		</div>
+	{{else if and (eq .Type 6) .RefExists}}
+		<div class="event">
+			<span class="octicon octicon-bookmark"></span>
+			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
+				<img src="{{.Poster.RelAvatarLink}}">
+			</a>
+			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a> {{$.i18n.Tr "repo.issues.pull_ref_at" .EventTag $createdStr | Safe}}</span>
+
+			<div class="detail">
+				<span class="octicon octicon-git-pull-request"></span>
+				<span class="text grey"><a href="{{.RefURL}}"><span class="title has-emoji">{{.RefIssue.Title | Escape}}</span> (#{{.RefIssue.Index}})</a></span>
 			</div>
 		</div>
 	{{else if eq .Type 7}}


### PR DESCRIPTION
Various improvements on how issues are referenced, opened, or closed by pull requests.  Steps to accomplish:

  - [x] factor out reference, open, and close detection code
  - [x] enable commits in a PR creation or update on the tracked branch to reference issues
  - [x] enable PR and issue title or message to reference issues
  - [x] enable PR and issue comments to reference issues
  - [x] enable a PR's commits to open/close issues when PR is merged (#2735)
  - [x] enable a PR's title or message to open/close issues when PR is merged (#2735)
  - [x] add testing of updates to issues via PR
  - [x] enable a manually merged PR to open/close issues
  - [x] enable code comments to reference issues
  - [x] enable review comment to reference issues
  - [x] add migration to update content of existing references and retroactively create issue references
