### PR TITLE
add your_repositories to types

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -111,7 +111,7 @@ func Issues(ctx *context.Context) {
 
 	viewType := ctx.Query("type")
 	sortType := ctx.Query("sort")
-	types := []string{"all", "assigned", "created_by", "mentioned"}
+	types := []string{"all", "your_repositories", "assigned", "created_by", "mentioned"}
 	if !com.IsSliceContainsStr(types, viewType) {
 		viewType = "all"
 	}


### PR DESCRIPTION
hello!

This is to fix a small issue I noticed on the Issues and Pull Request dashboards.

When selecting "In your repositories", the selection doesn't get highlighted.

From the templates this seems to be based on the `.viewType`, however when `type=your_repositories`, `.viewType` is set to "all".

This means the css class isn't applied because the issues template contains:
```html
<a class="{{if eq .ViewType "your_repositories"}}ui basic blue button{{end}} item" ...
```
[issues.tmpl:8](https://github.com/go-gitea/gitea/blob/master/templates/user/dashboard/issues.tmpl#L8)

In the below gif I have added the `.viewType` to the page:

![no_highlight_your_repos](https://user-images.githubusercontent.com/13941027/37671649-18c84168-2c64-11e8-952f-dcff4037626f.gif)
