### PR TITLE
Don't warn users about *every* dirty form

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1663,8 +1663,11 @@ function selectRange($list, $select, $from) {
 }
 
 $(function () {
-    if ($('.user.signin').length > 0) return;
-    $('form').areYouSure();
+    // Warn users that try to leave a page after entering data into a form.
+    // Except on sign-in pages, and for forms marked as 'ignore-dirty'.
+    if ($('.user.signin').length === 0) {
+      $('form:not(.ignore-dirty)').areYouSure();
+    }
 
     // Parse SSH Key
     $("#ssh-key-content").on('change paste keyup',function(){

--- a/templates/admin/base/search.tmpl
+++ b/templates/admin/base/search.tmpl
@@ -17,7 +17,7 @@
 		</div>
 	</div>
 </div>
-<form class="ui form"  style="max-width: 90%">
+<form class="ui form ignore-dirty"  style="max-width: 90%">
 	<div class="ui fluid action input">
 	  <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
 	  <button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -185,7 +185,7 @@
 					{{end}}
 					<dt>{{.i18n.Tr "admin.config.mailer_user"}}</dt>
 					<dd>{{if .Mailer.User}}{{.Mailer.User}}{{else}}(empty){{end}}</dd><br>
-					<form class="ui form" action="{{AppSubUrl}}/admin/config/test_mail" method="post">
+					<form class="ui form ignore-dirty" action="{{AppSubUrl}}/admin/config/test_mail" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="inline field ui left">
 							<div class="ui input">

--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -2,7 +2,7 @@
 <div class="explore users">
 	{{template "explore/navbar" .}}
 	<div class="ui container">
-		<form class="ui form" style="max-width: 100%">
+		<form class="ui form ignore-dirty" style="max-width: 100%">
             <div class="ui fluid action input">
                 <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
                 <input type="hidden" name="tab" value="{{$.TabName}}">

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -15,7 +15,7 @@
 		</div>
 	</div>
 </div>
-<form class="ui form" style="max-width: 90%">
+<form class="ui form ignore-dirty" style="max-width: 90%">
 	<div class="ui fluid action input">
 	  <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
 	  <input type="hidden" name="tab" value="{{$.TabName}}">

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -13,7 +13,7 @@
 					<div class="ui red message">
 						<p class="text left"><i class="octicon octicon-alert"></i> {{.i18n.Tr "org.settings.delete_prompt" | Str2html}}</p>
 					</div>
-					<form class="ui form" id="delete-form" action="{{.Link}}" method="post">
+					<form class="ui form ignore-dirty" id="delete-form" action="{{.Link}}" method="post">
 						{{.CsrfTokenHtml}}
 						<input class="fake" type="password">
 						<div class="inline required field {{if .Err_Password}}error{{end}}">

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -5,7 +5,7 @@
 		</div>
 		<div class="ten wide right aligned column">
 			{{if .PageIsCommits}}
-				<form action="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/search">
+				<form class="ignore-dirty" action="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/search">
 					<div class="ui tiny search input">
 						<input name="q" placeholder="{{.i18n.Tr "repo.commits.search"}}" value="{{.Keyword}}" autofocus>
 					</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,7 @@
 			</div>
 			{{if .RepoSearchEnabled}}
 				<div class="ui repo-search">
-					<form class="ui form" action="{{.RepoLink}}/search" method="get">
+					<form class="ui form ignore-dirty" action="{{.RepoLink}}/search" method="get">
 						<div class="field">
 							<div class="ui action input">
 								<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "repo.search.search_repo"}}">

--- a/templates/repo/issue/search.tmpl
+++ b/templates/repo/issue/search.tmpl
@@ -1,4 +1,4 @@
-<form class="ui form">
+<form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
 		<input type="hidden" name="type" value="{{$.ViewType}}"/>
 		<input type="hidden" name="state" value="{{$.State}}"/>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -3,7 +3,7 @@
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui repo-search">
-			<form class="ui form" method="get">
+			<form class="ui form ignore-dirty" method="get">
 				<div class="ui fluid action input">
 					<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "repo.search.search_repo"}}">
 					<button class="ui button" type="submit">

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -2,7 +2,7 @@
 <div class="user activate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
-			<form class="ui form" action="{{AppSubUrl}}/user/activate" method="post">
+			<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/activate" method="post">
 				{{.CsrfTokenHtml}}
 				<h2 class="ui top attached header">
 					{{.i18n.Tr "auth.active_your_account"}}

--- a/templates/user/auth/forgot_passwd.tmpl
+++ b/templates/user/auth/forgot_passwd.tmpl
@@ -2,7 +2,7 @@
 <div class="user forgot password">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
-			<form class="ui form" action="{{.Link}}" method="post">
+			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h2 class="ui top attached header">
 					{{.i18n.Tr "auth.forgot_password_title"}}

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -2,7 +2,7 @@
 <div class="user reset password">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
-			<form class="ui form" action="{{.Link}}" method="post">
+			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<input name="code" type="hidden" value="{{.Code}}">
 				<h2 class="ui top attached header">

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -38,7 +38,7 @@
 				{{.i18n.Tr "settings.generate_new_token"}}
 			</h4>
 			<div class="ui attached segment">
-				<form class="ui form" action="{{.Link}}" method="post">
+				<form class="ui form ignore-dirty" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<p>{{.i18n.Tr "settings.new_token_desc"}}</p>
 					<div class="field {{if .Err_Name}}error{{end}}">

--- a/templates/user/settings/delete.tmpl
+++ b/templates/user/settings/delete.tmpl
@@ -10,7 +10,7 @@
 			<div class="ui red message">
 				<p class="text left"><i class="octicon octicon-alert"></i> {{.i18n.Tr "settings.delete_prompt" | Str2html}}</p>
 			</div>
-			<form class="ui form" id="delete-form" action="{{.Link}}" method="post">
+			<form class="ui form ignore-dirty" id="delete-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<input class="fake" type="password">
 				<div class="required field {{if .Err_Password}}error{{end}}">


### PR DESCRIPTION
The choice regarding which forms should or should not trigger a warning
is subjective. I tried to be consistent and not warn about forms that:
 - run an action, rather than edit data: search, send an email.
 - delete data: a warning about losing data would be confusing

Note that forms on sign-in pages were already ignored (using a selector,
rather than an explicit class on the form element).

Fixes #3698.

*Note: I did not yet manage to build gitea (due to some problem with golang), so I have not been able to test this change properly*