### PR TITLE
Enhance healthcheck for database connectivity

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -335,7 +335,10 @@ func GetStatistic() (stats Statistic) {
 
 // Ping tests if database is alive
 func Ping() error {
-	return x.Ping()
+	if x != nil {
+		return x.Ping()
+	}
+	return errors.New("database not configured")
 }
 
 // DumpDatabase dumps all data from database according the special database SQL syntax to file system.


### PR DESCRIPTION
Modify the call to ping the database to fail gracefully if the database has not yet been configured by the end user, such as after a clean install. This allows /healthcheck to return a 200 with a modified status message instead of causing a PANIC.

---

I ran into this issue when trying to install Gitea on Kubernetes in Google Cloud Platform. The root path `/` returns a 302 redirect to `/install`, but GCP Health Checks treat anything that's not a 200 as a "unhealthy" status. I also saw that Macaron provides a `/healthcheck` endpoint and that y'all were pinging the database when hitting it, but this causes a PANIC if the database has not yet been configured. This PR guards against that and returns 200 with a different error message:

> * Database connection: database not configured
