### PR TITLE
Fix update avatar via email

### DIFF
--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -129,7 +129,7 @@ func UpdateAvatarSetting(ctx *context.Context, form auth.AvatarForm, ctxUser *mo
 		ctxUser.AvatarEmail = form.Gravatar
 	}
 
-	if form.Avatar != nil {
+	if form.Avatar != nil && form.Avatar.Filename != "" {
 		fr, err := form.Avatar.Open()
 		if err != nil {
 			return fmt.Errorf("Avatar.Open: %v", err)


### PR DESCRIPTION
Minor fix:

When attempting to update an avatar via email address it will produce an error stating that the image is invalid when no image has been provided.