### PR TITLE
Mention the possibility of resetting the password for new accounts

### DIFF
--- a/templates/mail/auth/register_notify.tmpl
+++ b/templates/mail/auth/register_notify.tmpl
@@ -9,6 +9,7 @@
 	<p>Hi <b>{{.Username}}</b>, this is your registration confirmation email for {{AppName}}!</p>
 	<p>You can now login via username: {{.Username}}.</p>
 	<p><a href="{{AppUrl}}user/login">{{AppUrl}}user/login</a></p>
+	<p>If this account has been created for you, please <a href="{{AppUrl}}user/forgot_password">reset your password</a> first.</p>
 	<p>© <a target="_blank" rel="noopener" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>
 </html>


### PR DESCRIPTION
This solves the problem of administrators creating accounts for users that then do not know their initial password (without the administrator sending it to them via some other channel).

Our Gitea instance is private and I typically create accounts for our users. They then get the registration e-mail (without a password) but then frequently ask me how to log in and what their password is.

The phrasing is obviously just a proposal.