### PR TITLE
Support secure cookie for csrf-token

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -254,9 +254,10 @@
   revision = "8aa5919789ab301e865595eb4b1114d6b9847deb"
 
 [[projects]]
+  branch = "master"
   name = "github.com/go-macaron/csrf"
   packages = ["."]
-  revision = "6a9a7df172cc1fcd81e4585f44b09200b6087cc0"
+  revision = "503617c6b37257a55dff6293ec28556506c3a9a8"
 
 [[projects]]
   branch = "master"

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -119,6 +119,7 @@ func NewMacaron() *macaron.Macaron {
 		Secret:     setting.SecretKey,
 		Cookie:     setting.CSRFCookieName,
 		SetCookie:  true,
+		Secure:     setting.SessionConfig.Secure,
 		Header:     "X-Csrf-Token",
 		CookiePath: setting.AppSubURL,
 	}))


### PR DESCRIPTION
Fixes #1734

Currently SetCookie for csrf has secure hardcodded to false.
This passes security argument to cookie creation and set it by COOKIE_SECURE config var.