### PR TITLE
Do not allow inactive users to access repositories using private keys

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -231,7 +231,7 @@ func runServ(c *cli.Context) error {
 			}
 
 			if !user.IsActive || user.ProhibitLogin {
-				fail("Your account is not active or has been disabled by Adminstrator",
+				fail("Your account is not active or has been disabled by Administrator",
 					"User %s is disabled and have no access to repository %s",
 					user.Name, repoPath)
 			}

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -230,8 +230,8 @@ func runServ(c *cli.Context) error {
 				fail("internal error", "Failed to get user by key ID(%d): %v", keyID, err)
 			}
 
-			if !user.IsActive {
-				fail("Your account is not active",
+			if !user.IsActive || user.ProhibitLogin {
+				fail("Your account is not active or has been disabled by Adminstrator",
 					"User %s is disabled and have no access to repository %s",
 					user.Name, repoPath)
 			}

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -230,6 +230,12 @@ func runServ(c *cli.Context) error {
 				fail("internal error", "Failed to get user by key ID(%d): %v", keyID, err)
 			}
 
+			if !user.IsActive {
+				fail("Your account is not active",
+					"User %s is disabled and have no access to repository %s",
+					user.Name, repoPath)
+			}
+
 			mode, err := models.AccessLevel(user.ID, repo)
 			if err != nil {
 				fail("Internal error", "Failed to check access: %v", err)


### PR DESCRIPTION
Currently when disabling user he can still access repository using his private key when cloning/pushing using SSH