### PR TITLE
Fix code tab link when viewing tags

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -48,7 +48,7 @@
 	<div class="ui tabs container">
 		<div class="ui tabular stackable menu navbar">
 			{{if .Repository.UnitEnabled $.UnitTypeCode}}
-			<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}{{if (ne .BranchName .Repository.DefaultBranch)}}/src/branch/{{.BranchName}}{{end}}">
+			<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}{{if (ne .BranchName .Repository.DefaultBranch)}}/src/{{.BranchNameSubURL}}{{end}}">
 				<i class="octicon octicon-code"></i> {{.i18n.Tr "repo.code"}}
 			</a>
 			{{end}}


### PR DESCRIPTION
"Code" tab button in the repo view assumes that the current BranchName is always a branch. This fix replaces the hardcoded "branch/{{.BranchName}}" path with the proper "{{.BranchNameSubURL}}". 