### PR TITLE
consistent IsOverdue field name capitalization

### DIFF
--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -24,7 +24,7 @@ type Milestone struct {
 	NumClosedIssues int
 	NumOpenIssues   int  `xorm:"-"`
 	Completeness    int  // Percentage(1-100).
-	IsOverDue       bool `xorm:"-"`
+	IsOverdue       bool `xorm:"-"`
 
 	DeadlineString string `xorm:"-"`
 	DeadlineUnix   util.TimeStamp
@@ -52,7 +52,7 @@ func (m *Milestone) AfterLoad() {
 
 	m.DeadlineString = m.DeadlineUnix.Format("2006-01-02")
 	if util.TimeStampNow() >= m.DeadlineUnix {
-		m.IsOverDue = true
+		m.IsOverdue = true
 	}
 }
 


### PR DESCRIPTION
Milestone.IsOverDue vs Issue.IsOverdue: the former was causing the milestone list page template to fail to render if any milestones have a due date assigned.

See https://try.gitea.io/teepark/pqinterval/milestones as an example (as of 2018/05/06).

Signed-off-by: Travis J Parker <travis.parker@gmail.com>