### PR TITLE
Fix wiki redirects

### DIFF
--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -350,7 +350,7 @@ func NewWikiPost(ctx *context.Context, form auth.NewWikiForm) {
 		return
 	}
 
-	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + models.WikiNameToFilename(wikiName))
+	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + models.WikiNameToSubURL(wikiName))
 }
 
 // EditWiki render wiki modify page
@@ -391,7 +391,7 @@ func EditWikiPost(ctx *context.Context, form auth.NewWikiForm) {
 		return
 	}
 
-	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + models.WikiNameToFilename(newWikiName))
+	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + models.WikiNameToSubURL(newWikiName))
 }
 
 // DeleteWikiPagePost delete wiki page


### PR DESCRIPTION
When creating or editing a wiki page, the redirect to the wiki page does not work because the file name is used instead of the page name.

This happens on our instance since upgrading to Gitea 1.4. If the PR is okay, I will also prepare a backport for 1.4.