### PR TITLE
Discord is the official channel - update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Build Status](https://drone.gitea.io/api/badges/go-gitea/gitea/status.svg)](https://drone.gitea.io/go-gitea/gitea)
 [![Join the Discord chat at https://discord.gg/NsatcWJ](https://img.shields.io/discord/322538954119184384.svg)](https://discord.gg/NsatcWJ)
-[![Join the Matrix chat at https://matrix.to/#/#gitea:matrix.org](https://img.shields.io/badge/matrix-%23gitea%3Amatrix.org-7bc9a4.svg)](https://matrix.to/#/#gitea:matrix.org)
 [![](https://images.microbadger.com/badges/image/gitea/gitea.svg)](https://microbadger.com/images/gitea/gitea "Get your own image badge on microbadger.com")
 [![codecov](https://codecov.io/gh/go-gitea/gitea/branch/master/graph/badge.svg)](https://codecov.io/gh/go-gitea/gitea)
 [![Go Report Card](https://goreportcard.com/badge/code.gitea.io/gitea)](https://goreportcard.com/report/code.gitea.io/gitea)


### PR DESCRIPTION
Matrix (and IRC) bridge drop too many messages which frustrate new user.
Let's only promote the official communication tool.

Sidenote: I understand the arguments against discord being the official place (not open source, etc.., but as of right now we are also use GH which isn't opensource either), I'd prefer something like Mattermost. However at this point this PR is to reduce the number of new users going to the wrong place and getting frustrated they aren't getting help.