### PR TITLE
Docker multiarch manifest + cross build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -241,7 +241,7 @@ pipeline:
       branch: [ master ]
 
   docker:
-    image: golang:1.10
+    image: golang:1.11
     pull: true
     commands:
       - GOARCH=amd64 QEMU_ARCH=amd64 make docker-generate-arch-dockerfile docker-download-qemu-binary

--- a/.drone.yml
+++ b/.drone.yml
@@ -245,7 +245,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
-    tag: '${DRONE_BRANCH##release/v}-linux-amd64'
+    tag: '${DRONE_BRANCH##release/v}-${DRONE_ARCH/\//-}'
     when:
       event: [ push ]
       branch: [ release/* ]
@@ -255,7 +255,7 @@ pipeline:
     secrets: [ docker_username, docker_password ]
     pull: true
     repo: gitea/gitea
-    tag: latest-linux-amd64
+    tag: 'latest-${DRONE_ARCH/\//-}'
     when:
       event: [ push, tag ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -241,28 +241,108 @@ pipeline:
       branch: [ master ]
 
   docker:
+    image: golang:1.10
+    pull: true
+    commands:
+      - GOARCH=amd64 QEMU_ARCH=amd64 make docker-generate-arch-dockerfile docker-download-qemu-binary
+      - GOARCH=arm QEMU_ARCH=arm make docker-generate-arch-dockerfile docker-download-qemu-binary
+      - GOARCH=arm64 QEMU_ARCH=aarch64 make docker-generate-arch-dockerfile docker-download-qemu-binary
+    when:
+      event: [ push, tag ]
+
+  docker:
+    image: multiarch/qemu-user-static:register
+    pull: true
+    privileged: true
+    when:
+      event: [ push, tag ]
+      
+  docker:
     image: plugins/docker:17.12
     pull: true
     secrets: [ docker_username, docker_password ]
+    group: docker
     repo: gitea/gitea
-    tag: '${DRONE_BRANCH##release/v}-${DRONE_ARCH/\//-}'
+    tag: '${DRONE_BRANCH##release/v}-linux-amd64'
+    build_args:
+      - TARGET=amd64
+    dockerfile: docker/Dockerfile.amd64
     when:
       event: [ push ]
       branch: [ release/* ]
 
   docker:
     image: plugins/docker:17.12
-    secrets: [ docker_username, docker_password ]
     pull: true
+    secrets: [ docker_username, docker_password ]
+    group: docker
     repo: gitea/gitea
-    tag: 'latest-${DRONE_ARCH/\//-}'
+    tag: '${DRONE_BRANCH##release/v}-linux-arm'
+    build_args:
+      - TARGET=arm32v6
+    dockerfile: docker/Dockerfile.arm
+    when:
+      event: [ push ]
+      branch: [ release/* ]
+
+  docker:
+    image: plugins/docker:17.12
+    pull: true
+    secrets: [ docker_username, docker_password ]
+    group: docker
+    repo: gitea/gitea
+    tag: '${DRONE_BRANCH##release/v}-linux-arm64'
+    build_args:
+      - TARGET=arm64v8
+    dockerfile: docker/Dockerfile.aarch64
+    when:
+      event: [ push ]
+      branch: [ release/* ]
+
+  docker:
+    image: plugins/docker:17.12
+    pull: true
+    secrets: [ docker_username, docker_password ]
+    group: docker
+    repo: gitea/gitea
+    tag: 'latest-linux-amd64'
+    build_args:
+      - TARGET=amd64
+    dockerfile: docker/Dockerfile.amd64
+    when:
+      event: [ push, tag ]
+
+  docker:
+    image: plugins/docker:17.12
+    pull: true
+    secrets: [ docker_username, docker_password ]
+    group: docker
+    repo: gitea/gitea
+    tag: 'latest-linux-arm'
+    build_args:
+      - TARGET=arm32v6
+    dockerfile: docker/Dockerfile.arm
+    when:
+      event: [ push, tag ]
+
+  docker:
+    image: plugins/docker:17.12
+    pull: true
+    secrets: [ docker_username, docker_password ]
+    group: docker
+    repo: gitea/gitea
+    tag: 'latest-linux-arm64'
+    build_args:
+      - TARGET=arm64v8
+    dockerfile: docker/Dockerfile.aarch64
     when:
       event: [ push, tag ]
 
   docker:
     image: plugins/manifest
+    pull: true
     secrets: [ docker_username, docker_password ]
-    platforms: linux/amd64
+    platforms: [ linux/amd64, linux/arm, linux/arm64 ]
     template: 'gitea/gitea:${DRONE_BRANCH##release/v}-OS-ARCH'
     target: 'gitea/gitea:${DRONE_BRANCH##release/v}'
     when:
@@ -271,8 +351,9 @@ pipeline:
 
   docker:
     image: plugins/manifest
+    pull: true
     secrets: [ docker_username, docker_password ]
-    platforms: linux/amd64
+    platforms: [ linux/amd64, linux/arm, linux/arm64 ]
     template: gitea/gitea:latest-OS-ARCH
     target: gitea/gitea:latest
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -263,7 +263,7 @@ pipeline:
     image: plugins/manifest
     secrets: [ docker_username, docker_password ]
     platforms: linux/amd64
-    template: 'gitea/gitea:${DRONE_BRANCH##release/v}-ARCH'
+    template: 'gitea/gitea:${DRONE_BRANCH##release/v}-OS-ARCH'
     target: 'gitea/gitea:${DRONE_BRANCH##release/v}'
     when:
       event: [ push ]
@@ -273,7 +273,7 @@ pipeline:
     image: plugins/manifest
     secrets: [ docker_username, docker_password ]
     platforms: linux/amd64
-    template: gitea/gitea:latest-ARCH
+    template: gitea/gitea:latest-OS-ARCH
     target: gitea/gitea:latest
     when:
       event: [ push, tag ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -245,7 +245,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
-    tags: [ '${DRONE_BRANCH##release/v}' ]
+    tag: '${DRONE_BRANCH##release/v}-linux-amd64'
     when:
       event: [ push ]
       branch: [ release/* ]
@@ -255,7 +255,26 @@ pipeline:
     secrets: [ docker_username, docker_password ]
     pull: true
     repo: gitea/gitea
-    default_tags: true
+    tag: latest-linux-amd64
+    when:
+      event: [ push, tag ]
+
+  docker:
+    image: plugins/manifest
+    secrets: [ docker_username, docker_password ]
+    platforms: linux/amd64
+    template: 'gitea/gitea:${DRONE_BRANCH##release/v}-ARCH'
+    target: 'gitea/gitea:${DRONE_BRANCH##release/v}'
+    when:
+      event: [ push ]
+      branch: [ release/* ]
+
+  docker:
+    image: plugins/manifest
+    secrets: [ docker_username, docker_password ]
+    platforms: linux/amd64
+    template: gitea/gitea:latest-ARCH
+    target: gitea/gitea:latest
     when:
       event: [ push, tag ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ coverage.all
 /integrations/mssql.ini
 /node_modules
 
+# Docker (cross build)
+/docker/Dockerfile.*
+/docker/qemu-*-static
 
 # Snapcraft
 snap/.snapcraft/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 
 #Checkout version if set
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
- && go env \
  && make clean generate build
 
 ###################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ARG target=library
 #Build stage
 FROM $target/golang:1.11-alpine3.8 AS build-env
 
-#QEMU phase
-
 ARG GOARCH
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ all: build
 include docker/Makefile
 
 .PHONY: clean
-clean:
+clean: docker-setup-clean
 	$(GO) clean -i ./...
 	rm -rf $(EXECUTABLE) $(DIST) $(BINDATA) \
 		integrations*.test \

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,11 @@ release-linux:
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GO) get -u github.com/karalabe/xgo; \
 	fi
+ifneq ($(XGOARCH),)
+	xgo -dest $(DIST)/binaries -tags 'netgo $(TAGS)' -ldflags '-linkmode external -extldflags "-static" $(LDFLAGS)' -targets "linux/${XGOARCH}" -out gitea-$(VERSION) .
+else
 	xgo -dest $(DIST)/binaries -tags 'netgo $(TAGS)' -ldflags '-linkmode external -extldflags "-static" $(LDFLAGS)' -targets 'linux/*' -out gitea-$(VERSION) .
+endif
 ifeq ($(CI),drone)
 	mv /build/* $(DIST)/binaries
 endif

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,8 +2,8 @@
 
 DOCKER_IMAGE ?= gitea/gitea
 DOCKER_TAG ?= latest
-DOCKER_REF := $(DOCKER_IMAGE):$(DOCKER_TAG)
-
+DOCKER_PLATFORM ?= $(shell docker version -f {{.Server.Os}}-{{.Server.Arch}} 2>/dev/null || echo 'undefined')
+DOCKER_REF ?= $(DOCKER_IMAGE):$(DOCKER_TAG)-$(DOCKER_PLATFORM)
 
 .PHONY: docker
 docker:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,9 @@
 #Makefile related to docker
 
+GOHOSTARCH := $(shell go env GOHOSTARCH)
 QEMU_VERSION ?= v2.12.0
 QEMU_ARCH ?= amd64
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 TARGET ?= library
 
 DOCKER_IMAGE ?= gitea/gitea
@@ -24,24 +25,27 @@ docker-build:
 	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" webhippie/golang:edge make clean generate build
 
 .PHONY: docker-cross
-docker-cross : docker-setup-qemu
-	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
+docker-cross : clean generate docker-setup-qemu
+#	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
+	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) --build-arg TAGS="" -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
 #exemple TARGET=arm64v8 GOARCH=arm64 QEMU_ARCH=aarch64 make docker-cross
 #exemple TARGET=amd64 GOARCH=amd64 QEMU_ARCH=amd64 make docker-cross
 #exemple TARGET=arm32v6 GOARCH=arm QEMU_ARCH=arm make docker-cross
+#TODO make generate fail with qemu (qemu: Unsupported syscall: 0) so we run as deps in host env
+#TODO seems to core dump when build with sqlite (maybe related to cgo) look at xgo to find a solution
 
 .PHONY: docker-setup-qemu
 docker-setup-qemu:
-	@if [ "$(QEMU_ARCH)" != "amd64" ]; then \
+	@if [ "$(QEMU_ARCH)" != ${GOHOSTARCH} ]; then \
 	  echo "Loading qemu libs for multi-arch support."; \
 	  (cd docker && curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz); \
 	  docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
 		sed "s/^#QEMU phase/COPY docker\/qemu-${QEMU_ARCH}-static* \/usr\/bin\//g" Dockerfile > docker/Dockerfile.${QEMU_ARCH}; \
+		sed -i "s/make clean generate build/make build/g" docker/Dockerfile.${QEMU_ARCH}; \
 	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \
 	fi;
 
 .PHONY: docker-setup-clean
 docker-setup-clean:
-	rm docker/qemu-*-static
-	rm docker/Dockerfile.*
-#TODO add to make clean
+	rm -f docker/qemu-*-static
+	rm -f docker/Dockerfile.*

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,14 +25,11 @@ docker-build:
 	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" webhippie/golang:edge make clean generate build
 
 .PHONY: docker-cross
-docker-cross : clean generate docker-setup-qemu
-#	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
-	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) --build-arg TAGS="" -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
+docker-cross : docker-setup-qemu
+	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
 #exemple TARGET=arm64v8 GOARCH=arm64 QEMU_ARCH=aarch64 make docker-cross
 #exemple TARGET=amd64 GOARCH=amd64 QEMU_ARCH=amd64 make docker-cross
 #exemple TARGET=arm32v6 GOARCH=arm QEMU_ARCH=arm make docker-cross
-#TODO make generate fail with qemu (qemu: Unsupported syscall: 0) so we run as deps in host env
-#TODO seems to core dump when build with sqlite (maybe related to cgo) look at xgo to find a solution
 
 .PHONY: docker-setup-qemu
 docker-setup-qemu:
@@ -40,8 +37,11 @@ docker-setup-qemu:
 	  echo "Loading qemu libs for multi-arch support."; \
 	  (cd docker && curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz); \
 	  docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
+		echo "Generate dockerfile for specific arch."; \
 		sed "s/^#QEMU phase/COPY docker\/qemu-${QEMU_ARCH}-static* \/usr\/bin\//g" Dockerfile > docker/Dockerfile.${QEMU_ARCH}; \
-		sed -i "s/make clean generate build/make build/g" docker/Dockerfile.${QEMU_ARCH}; \
+		sed -i 's/^FROM $$target\/golang:1.10-alpine3.7 AS build-env/FROM karalabe\/xgo-latest AS build-env/g' docker/Dockerfile.${QEMU_ARCH}; \
+		sed -i 's/^RUN apk --no-cache add build-base git/RUN GOARCH=$$GOHOSTARCH go get -u github.com\/jteeuwen\/go-bindata\/.../g' docker/Dockerfile.${QEMU_ARCH}; \
+		sed -i 's/make clean generate build/PATH=$$PATH:\$$GOPATH\/bin\/ XGOARCH="${GOARCH}" make clean generate release-linux \&\& mv \/build\/gitea-* .\/gitea/g' docker/Dockerfile.${QEMU_ARCH}; \
 	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \
 	fi;
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 #Makefile related to docker
 
-QEMU_VERSION ?= v2.11.0
+QEMU_VERSION ?= v2.12.0
 QEMU_ARCH ?= amd64
 GOARCH ?= amd64
 TARGET ?= library
@@ -30,7 +30,6 @@ docker-cross : docker-setup-qemu
 #exemple TARGET=amd64 GOARCH=amd64 QEMU_ARCH=amd64 make docker-cross
 #exemple TARGET=arm32v6 GOARCH=arm QEMU_ARCH=arm make docker-cross
 
-TARGET: arm32v6
 .PHONY: docker-setup-qemu
 docker-setup-qemu:
 	@if [ "$(QEMU_ARCH)" != "amd64" ]; then \
@@ -41,4 +40,8 @@ docker-setup-qemu:
 	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \
 	fi;
 
-#sed -i "s/make clean generate build/make build --always-make/g" docker/Dockerfile.${QEMU_ARCH}; \
+.PHONY: docker-setup-clean
+docker-setup-clean:
+	rm docker/qemu-*-static
+	rm docker/Dockerfile.*
+#TODO add to make clean

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -36,7 +36,7 @@ docker-generate-arch-dockerfile:
 	@if [ "$(QEMU_ARCH)" != ${GOHOSTARCH} ]; then \
 		echo "Generate dockerfile for specific arch."; \
 		sed "s/^#QEMU phase/COPY docker\/qemu-${QEMU_ARCH}-static* \/usr\/bin\//g" Dockerfile > docker/Dockerfile.${QEMU_ARCH}; \
-		sed -i 's/^FROM $$target\/golang:1.10-alpine3.7 AS build-env/FROM karalabe\/xgo-latest AS build-env/g' docker/Dockerfile.${QEMU_ARCH}; \
+		sed -i 's/^FROM $$target\/golang:1.11-alpine3.8 AS build-env/FROM karalabe\/xgo-latest AS build-env/g' docker/Dockerfile.${QEMU_ARCH}; \
 		sed -i 's/^RUN apk --no-cache add build-base git/RUN GOARCH=$$GOHOSTARCH go get -u github.com\/jteeuwen\/go-bindata\/.../g' docker/Dockerfile.${QEMU_ARCH}; \
 		sed -i 's/make clean generate build/PATH=$$PATH:\$$GOPATH\/bin\/ XGOARCH="${GOARCH}" make clean generate release-linux \&\& mv \/build\/gitea-* .\/gitea/g' docker/Dockerfile.${QEMU_ARCH}; \
 	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,18 +31,30 @@ docker-cross : docker-setup-qemu
 #exemple TARGET=amd64 GOARCH=amd64 QEMU_ARCH=amd64 make docker-cross
 #exemple TARGET=arm32v6 GOARCH=arm QEMU_ARCH=arm make docker-cross
 
-.PHONY: docker-setup-qemu
-docker-setup-qemu:
+.PHONY: docker-generate-arch-dockerfile
+docker-generate-arch-dockerfile:
 	@if [ "$(QEMU_ARCH)" != ${GOHOSTARCH} ]; then \
-	  echo "Loading qemu libs for multi-arch support."; \
-	  (cd docker && curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz); \
-	  docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
 		echo "Generate dockerfile for specific arch."; \
 		sed "s/^#QEMU phase/COPY docker\/qemu-${QEMU_ARCH}-static* \/usr\/bin\//g" Dockerfile > docker/Dockerfile.${QEMU_ARCH}; \
 		sed -i 's/^FROM $$target\/golang:1.10-alpine3.7 AS build-env/FROM karalabe\/xgo-latest AS build-env/g' docker/Dockerfile.${QEMU_ARCH}; \
 		sed -i 's/^RUN apk --no-cache add build-base git/RUN GOARCH=$$GOHOSTARCH go get -u github.com\/jteeuwen\/go-bindata\/.../g' docker/Dockerfile.${QEMU_ARCH}; \
 		sed -i 's/make clean generate build/PATH=$$PATH:\$$GOPATH\/bin\/ XGOARCH="${GOARCH}" make clean generate release-linux \&\& mv \/build\/gitea-* .\/gitea/g' docker/Dockerfile.${QEMU_ARCH}; \
 	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \
+	fi;
+
+
+.PHONY: docker-download-qemu-binary
+docker-download-qemu-binary:
+	@if [ "$(QEMU_ARCH)" != ${GOHOSTARCH} ]; then \
+	  echo "Downloading qemu binary for multi-arch support."; \
+	  (cd docker && curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz); \
+	fi;
+
+.PHONY: docker-setup-qemu
+docker-setup-qemu: docker-generate-arch-dockerfile docker-download-qemu-binary
+	@if [ "$(QEMU_ARCH)" != ${GOHOSTARCH} ]; then \
+	  echo "Loading qemu libs for multi-arch support."; \
+	  docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
 	fi;
 
 .PHONY: docker-setup-clean

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,17 @@
 #Makefile related to docker
 
+QEMU_VERSION ?= v2.11.0
+QEMU_ARCH ?= amd64
+GOARCH ?= amd64
+TARGET ?= library
+
 DOCKER_IMAGE ?= gitea/gitea
 DOCKER_TAG ?= latest
-DOCKER_PLATFORM ?= $(shell docker version -f {{.Server.Os}}-{{.Server.Arch}} 2>/dev/null || echo 'undefined')
+ifneq ($(TARGET), library)
+  DOCKER_PLATFORM ?= linux-$(GOARCH)
+else
+  DOCKER_PLATFORM ?= $(shell docker version -f {{.Server.Os}}-{{.Server.Arch}} 2>/dev/null || echo 'undefined')
+endif
 DOCKER_REF ?= $(DOCKER_IMAGE):$(DOCKER_TAG)-$(DOCKER_PLATFORM)
 
 .PHONY: docker
@@ -13,3 +22,23 @@ docker:
 .PHONY: docker-build
 docker-build:
 	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" webhippie/golang:edge make clean generate build
+
+.PHONY: docker-cross
+docker-cross : docker-setup-qemu
+	docker build --build-arg target=$(TARGET) --build-arg GOARCH=$(GOARCH) -f docker/Dockerfile.$(QEMU_ARCH) -t $(DOCKER_REF) .
+#exemple TARGET=arm64v8 GOARCH=arm64 QEMU_ARCH=aarch64 make docker-cross
+#exemple TARGET=amd64 GOARCH=amd64 QEMU_ARCH=amd64 make docker-cross
+#exemple TARGET=arm32v6 GOARCH=arm QEMU_ARCH=arm make docker-cross
+
+TARGET: arm32v6
+.PHONY: docker-setup-qemu
+docker-setup-qemu:
+	@if [ "$(QEMU_ARCH)" != "amd64" ]; then \
+	  echo "Loading qemu libs for multi-arch support."; \
+	  (cd docker && curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz); \
+	  docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
+		sed "s/^#QEMU phase/COPY docker\/qemu-${QEMU_ARCH}-static* \/usr\/bin\//g" Dockerfile > docker/Dockerfile.${QEMU_ARCH}; \
+	else cp Dockerfile docker/Dockerfile.${QEMU_ARCH}; \
+	fi;
+
+#sed -i "s/make clean generate build/make build --always-make/g" docker/Dockerfile.${QEMU_ARCH}; \


### PR DESCRIPTION
This PR will change the name of the image build and published to the format $version-$os-$arch of the running builder so for now only $version-linux-amd64.
This PR also add a manifest upload for the tag of previous format $version that will provide a multi-arch manifest/image. (only for currently linux/amd64) 

This lay down some structure to be able to provide multi-arch image so that a `docker run gitea/gitea` could work on any platform.

~To add a platform we will only need a build on this platform and add it to the list of platform supported to the manifest [here](https://github.com/go-gitea/gitea/compare/master...sapk-fork:docker-multiarch?expand=1#diff-3216dfff0ed3e301453e6799e8c367e2R269)~