### PR TITLE
Fix error preventing profile settings update without selecting a language first

### DIFF
--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -43,7 +43,7 @@
 					<div class="field">
 						<label for="language">{{.i18n.Tr "settings.language"}}</label>
 						<div class="ui language selection dropdown" id="language">
-							<input name="language" type="hidden">
+							<input name="language" type="hidden" value="{{.SignedUser.Language}}">
 							<i class="dropdown icon"></i>
 							<div class="text">{{range .AllLangs}}{{if eq $.SignedUser.Language .Lang}}{{.Name}}{{end}}{{end}}</div>
 							<div class="menu">


### PR DESCRIPTION
Currently it is not possible to save the profile in the settings without opening/selecting a language from the dropdown due to the missing value in the hidden input field.

At the moment an error is shown: `Language must be size 5.`

This PR sets the users language on this field.