### PR TITLE
make avatar radio buttons read-only

### DIFF
--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -68,7 +68,7 @@
 				{{.CsrfTokenHtml}}
 				{{if not DisableGravatar}}
 				<div class="inline field">
-					<div class="ui radio checkbox">
+					<div class="ui read-only radio checkbox">
 						<input name="source" value="lookup" type="radio" {{if not .SignedUser.UseCustomAvatar}}checked{{end}}>
 						<label>{{.i18n.Tr "settings.lookup_avatar_by_mail"}}</label>
 					</div>
@@ -80,7 +80,7 @@
 				{{end}}
 
 				<div class="inline field">
-					<div class="ui radio checkbox">
+					<div class="ui read-only radio checkbox">
 						<input name="source" value="local" type="radio" {{if .SignedUser.UseCustomAvatar}}checked{{end}}>
 						<label>{{.i18n.Tr "settings.enable_custom_avatar"}}</label>
 					</div>


### PR DESCRIPTION
This PR makes the radio buttons for the profile avatar setting read only as they are useless anyway and confuse the user (me included).

To upload an avatar image you just have to provide an image in the file input and submit. Radio button changes on it's own.
But now it gets confusing. If I want to undo that change to use my gravatar image again I am dempted to click on the radio button to look up an image by my email and click "Update Avatar".
However this doesn't work as expected. Instead a user has to click "Delete Avatar".

To prevent that misunderstanding the radio buttons should be read-only.