### PR TITLE
add simple descriptions for file API responses

### DIFF
--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1028,7 +1028,9 @@
           }
         ],
         "responses": {
-          "200": {}
+          "200": {
+            "description": "success"
+          }
         }
       }
     },
@@ -1338,7 +1340,9 @@
           }
         ],
         "responses": {
-          "200": {}
+          "200": {
+            "description": "success"
+          }
         }
       }
     },
@@ -3261,7 +3265,9 @@
           }
         ],
         "responses": {
-          "200": {}
+          "200": {
+            "description": "success"
+          }
         }
       }
     },

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -36,7 +36,8 @@ func GetRawFile(ctx *context.APIContext) {
 	//   type: string
 	//   required: true
 	// responses:
-	//       200:
+	//   200:
+	//     description: success
 	if !ctx.Repo.HasAccess() {
 		ctx.Status(404)
 		return
@@ -85,7 +86,8 @@ func GetArchive(ctx *context.APIContext) {
 	//   type: string
 	//   required: true
 	// responses:
-	//       200:
+	//   200:
+	//     description: success
 	repoPath := models.RepoPath(ctx.Params(":username"), ctx.Params(":reponame"))
 	gitRepo, err := git.OpenRepository(repoPath)
 	if err != nil {
@@ -121,7 +123,8 @@ func GetEditorconfig(ctx *context.APIContext) {
 	//   type: string
 	//   required: true
 	// responses:
-	//       200:
+	//   200:
+	//     description: success
 	ec, err := ctx.Repo.GetEditorconfig()
 	if err != nil {
 		if git.IsErrNotExist(err) {


### PR DESCRIPTION
* Partial fix for #4010

Swagger needs a description field in each swagger:operation response.  Adding
minimal text for now on the way to getting swagger validate to pass.  Many
standard swagger client libraries will not work with gitea until validate
passes, so prioritizing that over better descriptions for now.

Signed-off-by: Steve Traugott <stevegt@t7a.org>
