### PR TITLE
swagger: add 'required: true' for params in URL

### DIFF
--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -5005,7 +5005,8 @@
             "type": "string",
             "description": "username of user",
             "name": "username",
-            "in": "path"
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {
@@ -5279,7 +5280,8 @@
             "type": "string",
             "description": "username of the user",
             "name": "username",
-            "in": "path"
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {

--- a/routers/api/v1/org/org.go
+++ b/routers/api/v1/org/org.go
@@ -51,6 +51,7 @@ func ListUserOrgs(ctx *context.APIContext) {
 	//   in: path
 	//   description: username of user
 	//   type: string
+	//   required: true
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/OrganizationList"

--- a/routers/api/v1/user/watch.go
+++ b/routers/api/v1/user/watch.go
@@ -43,6 +43,7 @@ func GetWatchedRepos(ctx *context.APIContext) {
 	//   type: string
 	//   in: path
 	//   description: username of the user
+	//   required: true
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/RepositoryList"


### PR DESCRIPTION
* Partial fix for #4010

Swagger validation needs 'required: true' for parameters that are in
the URL path.

Signed-off-by: Steve Traugott <stevegt@t7a.org>