### PR TITLE
Add raw blob endpoint

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -479,6 +479,8 @@ const (
 	RepoRefTag
 	// RepoRefCommit commit
 	RepoRefCommit
+	// RepoRefObject object
+	RepoRefBlob
 )
 
 // RepoRef handles repository reference names when the ref name is not
@@ -514,6 +516,9 @@ func getRefName(ctx *Context, pathType RepoRefType) string {
 		if refName := getRefName(ctx, RepoRefCommit); len(refName) > 0 {
 			return refName
 		}
+		if refName := getRefName(ctx, RepoRefBlob); len(refName) > 0 {
+			return refName
+		}
 		ctx.Repo.TreePath = path
 		return ctx.Repo.Repository.DefaultBranch
 	case RepoRefBranch:
@@ -526,6 +531,8 @@ func getRefName(ctx *Context, pathType RepoRefType) string {
 			ctx.Repo.TreePath = strings.Join(parts[1:], "/")
 			return parts[0]
 		}
+	case RepoRefBlob:
+		return getRefNameFromPath(ctx, path, ctx.Repo.GitRepo.IsBlobExist)
 	default:
 		log.Error(4, "Unrecognized path type: %v", path)
 	}

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -69,3 +69,19 @@ func SingleDownload(ctx *context.Context) {
 		ctx.ServerError("ServeBlob", err)
 	}
 }
+
+// DownloadById download a file by sha1 ID
+func DownloadByID(ctx *context.Context) {
+	blob, err := ctx.Repo.GitRepo.GetBlob(ctx.Params["sha"])
+	if err != nil {
+		if git.IsErrNotExist(err) {
+			ctx.NotFound("GetBlob", nil)
+		} else {
+			ctx.ServerError("GetBlob", err)
+		}
+		return
+	}
+	if err = ServeBlob(ctx, blob); err != nil {
+		ctx.ServerError("ServeBlob", err)
+	}
+}

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -678,6 +678,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Get("/branch/*", context.RepoRefByType(context.RepoRefBranch), repo.SingleDownload)
 			m.Get("/tag/*", context.RepoRefByType(context.RepoRefTag), repo.SingleDownload)
 			m.Get("/commit/*", context.RepoRefByType(context.RepoRefCommit), repo.SingleDownload)
+			m.Get("/blob/:sha", context.RepoRefByType(context.RepoRefBlob), repo.DownloadByID)
 			// "/*" route is deprecated, and kept for backward compatibility
 			m.Get("/*", context.RepoRefByType(context.RepoRefLegacy), repo.SingleDownload)
 		}, repo.MustBeNotBare, context.CheckUnit(models.UnitTypeCode))


### PR DESCRIPTION
This should make it possible to download raw blobs directly from `/:repo/:username/raw/blob/:sha1` URLs.

Fixes #4048.

(Also: depends on go-gitea/git#121)