### PR TITLE
Improve issue/comment api by enabling migration functionalities

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,11 @@
   revision = "31f4b8e8c805438ac6d8914b38accb1d8aaf695e"
 
 [[projects]]
-  branch = "master"
+  branch = "migration"
   name = "code.gitea.io/sdk"
   packages = ["gitea"]
-  revision = "b2308e3f700875a3642a78bd3f6e5db8ef6f974d"
+  revision = "c01e6df2e1cdb53403f6542e5d2248ace831f3ec"
+  source = "github.com/JonasFranzDEV/go-sdk"
 
 [[projects]]
   name = "github.com/PuerkitoBio/goquery"
@@ -873,6 +874,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "036b8c882671cf8d2c5e2fdbe53b1bdfbd39f7ebd7765bd50276c7c4ecf16687"
+  inputs-digest = "6e57d03c2ae6e7ee38ab336d3a8c2171b21f10f2b3f58ce7d19904cc725a2a06"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,7 +11,8 @@ ignored = ["google.golang.org/appengine*"]
   name = "code.gitea.io/git"
 
 [[constraint]]
-  branch = "master"
+  branch = "migration"
+  source = "github.com/JonasFranzDEV/go-sdk"
   name = "code.gitea.io/sdk"
 
 [[constraint]]

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -83,8 +83,9 @@ const (
 type Comment struct {
 	ID              int64 `xorm:"pk autoincr"`
 	Type            CommentType
-	PosterID        int64  `xorm:"INDEX"`
-	Poster          *User  `xorm:"-"`
+	PosterID        int64 `xorm:"INDEX"`
+	Poster          *User `xorm:"-"`
+	GhostName       string
 	IssueID         int64  `xorm:"INDEX"`
 	Issue           *Issue `xorm:"-"`
 	LabelID         int64
@@ -104,7 +105,7 @@ type Comment struct {
 	Content         string `xorm:"TEXT"`
 	RenderedContent string `xorm:"-"`
 
-	CreatedUnix util.TimeStamp `xorm:"INDEX created"`
+	CreatedUnix util.TimeStamp `xorm:"INDEX"`
 	UpdatedUnix util.TimeStamp `xorm:"INDEX updated"`
 
 	// Reference issue in commit message
@@ -126,6 +127,13 @@ func (c *Comment) LoadIssue() (err error) {
 	return
 }
 
+// BeforeInsert is invoked before XORM inserts this
+func (c *Comment) BeforeInsert() {
+	if c.CreatedUnix == util.TimeStamp(0) {
+		c.CreatedUnix = util.TimeStampNow()
+	}
+}
+
 // AfterLoad is invoked from XORM after setting the values of all fields of this object.
 func (c *Comment) AfterLoad(session *xorm.Session) {
 	var err error
@@ -139,6 +147,10 @@ func (c *Comment) AfterLoad(session *xorm.Session) {
 		if IsErrUserNotExist(err) {
 			c.PosterID = -1
 			c.Poster = NewGhostUser()
+			if len(c.GhostName) > 0 {
+				c.Poster.Name = c.GhostName
+				c.Poster.LowerName = strings.ToLower(c.GhostName)
+			}
 		} else {
 			log.Error(3, "getUserByID[%d]: %v", c.ID, err)
 		}
@@ -344,6 +356,10 @@ func createComment(e *xorm.Session, opts *CreateCommentOptions) (_ *Comment, err
 		Content:         opts.Content,
 		OldTitle:        opts.OldTitle,
 		NewTitle:        opts.NewTitle,
+		CreatedUnix:     opts.CreatedAt,
+	}
+	if opts.Doer.ID == -1 {
+		comment.GhostName = opts.Doer.Name
 	}
 	if _, err = e.Insert(comment); err != nil {
 		return nil, err
@@ -564,6 +580,7 @@ type CreateCommentOptions struct {
 	LineNum         int64
 	Content         string
 	Attachments     []string // UUIDs of attachments
+	CreatedAt       util.TimeStamp
 }
 
 // CreateComment creates comment of issue or commit.
@@ -590,7 +607,7 @@ func CreateComment(opts *CreateCommentOptions) (comment *Comment, err error) {
 }
 
 // CreateIssueComment creates a plain issue comment.
-func CreateIssueComment(doer *User, repo *Repository, issue *Issue, content string, attachments []string) (*Comment, error) {
+func CreateIssueComment(doer *User, repo *Repository, issue *Issue, content string, attachments []string, createdAt util.TimeStamp) (*Comment, error) {
 	comment, err := CreateComment(&CreateCommentOptions{
 		Type:        CommentTypeComment,
 		Doer:        doer,
@@ -598,6 +615,7 @@ func CreateIssueComment(doer *User, repo *Repository, issue *Issue, content stri
 		Issue:       issue,
 		Content:     content,
 		Attachments: attachments,
+		CreatedAt:   createdAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("CreateComment: %v", err)

--- a/models/issue_list.go
+++ b/models/issue_list.go
@@ -4,7 +4,10 @@
 
 package models
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // IssueList defines a list of issues
 type IssueList []*Issue
@@ -70,6 +73,11 @@ func (issues IssueList) loadPosters(e Engine) error {
 
 	for _, issue := range issues {
 		if issue.PosterID <= 0 {
+			if issue.GhostName != "" {
+				issue.Poster = NewGhostUser()
+				issue.Poster.Name = issue.GhostName
+				issue.Poster.LowerName = strings.ToLower(issue.GhostName)
+			}
 			continue
 		}
 		var ok bool

--- a/public/swagger.v1.json
+++ b/public/swagger.v1.json
@@ -1687,6 +1687,12 @@
             "required": true
           },
           {
+            "type": "boolean",
+            "description": "suppresses notifications and webhooks if true. Requires repo admin permissions.",
+            "name": "suppress_notifications",
+            "in": "query"
+          },
+          {
             "name": "body",
             "in": "body",
             "schema": {
@@ -1697,6 +1703,9 @@
         "responses": {
           "201": {
             "$ref": "#/responses/Issue"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
           }
         }
       }
@@ -1993,10 +2002,16 @@
             "required": true
           },
           {
+            "type": "boolean",
+            "description": "suppresses notifications and webhooks if true. Requires repo admin permissions.",
+            "name": "suppress_notifications",
+            "in": "query"
+          },
+          {
             "name": "body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/CreateIssueOption"
+              "$ref": "#/definitions/CreateIssueCommentOption"
             }
           }
         ],
@@ -5567,6 +5582,17 @@
         "body": {
           "type": "string",
           "x-go-name": "Body"
+        },
+        "created_at": {
+          "description": "Created will be used as creation date. This is used for migration. Requires admin permissions.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Created"
+        },
+        "ghost_name": {
+          "description": "GhostName will be used if poster is not existing on Gitea. Requires admin permissions.",
+          "type": "string",
+          "x-go-name": "GhostName"
         }
       },
       "x-go-package": "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
@@ -5598,10 +5624,27 @@
           "type": "boolean",
           "x-go-name": "Closed"
         },
+        "created_at": {
+          "description": "Created will be used as creation date. This is used for migration. Requires admin permissions.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Created"
+        },
         "due_date": {
           "type": "string",
           "format": "date-time",
           "x-go-name": "Deadline"
+        },
+        "ghost_name": {
+          "description": "GhostName is used if user is not existing on the gitea instance. Requires admin permissions.",
+          "type": "string",
+          "x-go-name": "GhostName"
+        },
+        "index": {
+          "description": "Index is former index of the issue. If the index is already taken, an error will be returned. Requires admin permission. Use it only for migrations.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Index"
         },
         "labels": {
           "description": "list of label ids",

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -5,10 +5,12 @@
 package repo
 
 import (
+	"strings"
 	"time"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/util"
 
 	api "code.gitea.io/sdk/gitea"
 )
@@ -144,10 +146,15 @@ func CreateIssueComment(ctx *context.APIContext, form api.CreateIssueCommentOpti
 	//   description: index of the issue
 	//   type: integer
 	//   required: true
+	// - name: suppress_notifications
+	//   in: query
+	//   type: boolean
+	//   description: suppresses notifications and webhooks if true. Requires repo admin permissions.
+	//   required: false
 	// - name: body
 	//   in: body
 	//   schema:
-	//     "$ref": "#/definitions/CreateIssueOption"
+	//     "$ref": "#/definitions/CreateIssueCommentOption"
 	// responses:
 	//   "201":
 	//     "$ref": "#/responses/Comment"
@@ -156,11 +163,37 @@ func CreateIssueComment(ctx *context.APIContext, form api.CreateIssueCommentOpti
 		ctx.Error(500, "GetIssueByIndex", err)
 		return
 	}
-
-	comment, err := models.CreateIssueComment(ctx.User, ctx.Repo.Repository, issue, form.Body, nil)
-	if err != nil {
-		ctx.Error(500, "CreateIssueComment", err)
-		return
+	var comment *models.Comment
+	doer := ctx.User
+	createdUnix := util.TimeStamp(0)
+	if ctx.User.IsAdmin && len(form.GhostName) > 0 {
+		doer = &models.User{
+			ID:        -1,
+			Name:      form.GhostName,
+			LowerName: strings.ToLower(form.GhostName),
+		}
+		if !form.Created.IsZero() {
+			createdUnix = util.TimeStamp(form.Created.Unix())
+		}
+	}
+	if ctx.QueryBool("suppress_notifications") && ctx.User.IsAdminOfRepo(ctx.Repo.Repository) {
+		comment, err = models.CreateComment(&models.CreateCommentOptions{
+			Type:      models.CommentTypeComment,
+			Doer:      doer,
+			Repo:      ctx.Repo.Repository,
+			Issue:     issue,
+			Content:   form.Body,
+			CreatedAt: createdUnix,
+		})
+		if err != nil {
+			ctx.Error(500, "CreateComment", err)
+		}
+	} else {
+		comment, err = models.CreateIssueComment(doer, ctx.Repo.Repository, issue, form.Body, nil, createdUnix)
+		if err != nil {
+			ctx.Error(500, "CreateIssueComment", err)
+			return
+		}
 	}
 
 	ctx.JSON(201, comment.APIFormat())

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -1059,7 +1059,7 @@ func NewComment(ctx *context.Context, form auth.CreateCommentForm) {
 		return
 	}
 
-	comment, err := models.CreateIssueComment(ctx.User, ctx.Repo.Repository, issue, form.Content, attachments)
+	comment, err := models.CreateIssueComment(ctx.User, ctx.Repo.Repository, issue, form.Content, attachments, util.TimeStamp(0))
 	if err != nil {
 		ctx.ServerError("CreateIssueComment", err)
 		return

--- a/vendor/code.gitea.io/sdk/gitea/issue.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue.go
@@ -103,6 +103,14 @@ type CreateIssueOption struct {
 	// list of label ids
 	Labels []int64 `json:"labels"`
 	Closed bool    `json:"closed"`
+	// GhostName is used if user is not existing on the gitea instance. Requires admin permissions.
+	GhostName string `json:"ghost_name" binding:"AlphaDashDot;MaxSize(35)"`
+	// Index is former index of the issue. If the index is already taken, an error will be returned. Requires admin permission. Use it only for migrations.
+	Index int64 `json:"index"`
+	// Created will be used as creation date. This is used for migration. Requires admin permissions.
+	// swagger:strfmt date-time
+	Created               time.Time `json:"created_at"`
+	SuppressNotifications bool      `json:"-"`
 }
 
 // CreateIssue create a new issue for a given repository
@@ -112,7 +120,7 @@ func (c *Client) CreateIssue(owner, repo string, opt CreateIssueOption) (*Issue,
 		return nil, err
 	}
 	issue := new(Issue)
-	return issue, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/issues", owner, repo),
+	return issue, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/issues?surpress_notifications=%t", owner, repo, opt.SuppressNotifications),
 		jsonHeader, bytes.NewReader(body), issue)
 }
 


### PR DESCRIPTION
This PR improves the issue/comment api by adding some new fields which should be used for migration:

* `CreatedAt`: (issue & comment): Let the user creates comments/issues dated at the past. Requires admin permissions.
* `Index` (issue): Let the user define the custom issue index. This should be used for migration to not destroy relationships. Requires admin permissions.
* `GhostName` (issue & comments): Define the name of the ghost user for comments of authors that do not exist at the gitea instance. Requires admin permissions.
* `suppress_notifications`: (issue & comments): Do not send notifications/emails to users if this is set. Requires **repo** admin permissions.

Blocked by go-gitea/go-sdk#108
