### PR TITLE
Fix #4060 by showing second line of commit

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -323,7 +323,7 @@ func RenderCommitBody(msg, urlPrefix string, metas map[string]string) template.H
 
 // IsMultilineCommitMessage checks to see if a commit message contains multiple lines.
 func IsMultilineCommitMessage(msg string) bool {
-	return strings.Count(strings.TrimSpace(msg), "\n") > 1
+	return strings.Count(strings.TrimSpace(msg), "\n") >= 1
 }
 
 // Actioner describes an action


### PR DESCRIPTION
Fix #4060 

`strings.TrimSpace` actually removes the `\n` at the end of the commit message. Because of that the comparison must be changed.