### PR TITLE
Updated drone config to use the "next" git plugin 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 clone:
   git:
-    image: plugins/git:1
+    image: plugins/git:next
     depth: 50
     tags: true
 

--- a/models/user.go
+++ b/models/user.go
@@ -90,7 +90,7 @@ type User struct {
 	OwnedOrgs        []*User       `xorm:"-"`
 	Orgs             []*User       `xorm:"-"`
 	Repos            []*Repository `xorm:"-"`
-	Location            string
+	Location         string
 	Website          string
 	Rands            string `xorm:"VARCHAR(10)"`
 	Salt             string `xorm:"VARCHAR(10)"`

--- a/models/user.go
+++ b/models/user.go
@@ -90,7 +90,7 @@ type User struct {
 	OwnedOrgs        []*User       `xorm:"-"`
 	Orgs             []*User       `xorm:"-"`
 	Repos            []*Repository `xorm:"-"`
-	Location         string
+	Location            string
 	Website          string
 	Rands            string `xorm:"VARCHAR(10)"`
 	Salt             string `xorm:"VARCHAR(10)"`


### PR DESCRIPTION
This pr tries to fix a drone behavior where drone wouldn't pick up the latest commit while saying it does so. This resulted in the build failing, even if everything was ok in the latest commit.

According to @tboerger, this is an issue with Github which wont get fixed, so I'm trying the `next` branch of the git plugin, so I'll try that with this pr. If it doesn't work, I'll close it.