### PR TITLE
ignore ca warning

### DIFF
--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/usr/sbin/update-ca-certificates
+/usr/sbin/update-ca-certificates 2>/dev/null || true
 
 if [ ! -d /data/git/.ssh ]; then
     mkdir -p /data/git/.ssh


### PR DESCRIPTION
followed https://github.com/gliderlabs/docker-alpine/issues/30 and fix #3865 and also recover try.gitea.io