### PR TITLE
Fix drone docker target

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -253,8 +253,18 @@ pipeline:
     repo: gitea/gitea
     default_tags: true
     when:
-      event: [ push, tag ]
+      event: [ push ]
+      branch: [ master ]
 
+  docker:
+    image: plugins/docker:17.12
+    secrets: [ docker_username, docker_password ]
+    pull: true
+    repo: gitea/gitea
+    default_tags: true
+    when:
+      event: [ tag ]
+      
   gpg-sign:
     image: plugins/gpgsign:1
     pull: true


### PR DESCRIPTION
Only publish push to master, release branch and tag across all branches.

This will prevent push to some branch to create docker :tag with the name of the branch.
