### PR TITLE
Add InternalTokenURI to load/save InteralToken from an external file.

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -249,6 +249,10 @@ MIN_PASSWORD_LENGTH = 6
 IMPORT_LOCAL_PATHS = false
 ; Prevent all users (including admin) from creating custom git hooks
 DISABLE_GIT_HOOKS = false
+; Store INTERNAL_TOKEN in a separate file. Will be stored in this config if not set
+; formats allowed:
+; - file:/path/to/my/internal_token
+;INTERNAL_TOKEN_URI =
 
 [openid]
 ;

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1206,7 +1206,7 @@ func loadOrGenerateInternalToken(sec *ini.Section) string {
 			log.Fatal(4, "Failed to create '%s': %v", CustomConf, err)
 		}
 		if err := cfgSave.SaveTo(CustomConf); err != nil {
-			log.Fatal(4, "Error saving generated JWT Secret to custom config: %v", err)
+			log.Fatal(4, "Error saving generated INTERNAL_TOKEN to custom config: %v", err)
 		}
 	}
 	return token


### PR DESCRIPTION
- URI HAVE TO start with 'file:' or 'file://'. Possibility to add http/s3
  support in the future.
- On errors it WILL fail hard (in case of misconfiguration OR the storage not being available)
- The file WILL be read if it exists and the token extracted from it.
- The file WILL be created if it does not exist.

Closes #3246 