### PR TITLE
Disable swagger validation while it is not fixed in upstream

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -75,7 +75,7 @@ pipeline:
       - make lint
       - make fmt-check
       - make swagger-check
-      - make swagger-validate
+#      - make swagger-validate
       - make misspell-check
       - make test-vendor
       - make build


### PR DESCRIPTION
While go-swagger/go-swagger#1614 is not fully fixed