### PR TITLE
Locale for button Edit on protected branch

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1097,6 +1097,7 @@ settings.protected_branch_deletion_desc = Disabling branch protection allows use
 settings.default_branch_desc = Select a default repository branch for pull requests and code commits:
 settings.choose_branch = Choose a branch…
 settings.no_protected_branch = There are no protected branches.
+settings.edit_protected_branch = Edit
 
 diff.browse_source = Browse Source
 diff.parent = parent

--- a/templates/repo/settings/branches.tmpl
+++ b/templates/repo/settings/branches.tmpl
@@ -62,7 +62,7 @@
 							{{range .ProtectedBranches}}
 								<tr>
 									<td><div class="ui basic label blue">{{.BranchName}}</div></td>
-									<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName}}">Edit</a></td>
+									<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName}}">{{.i18n.Tr "repo.settings.edit_protected_branch"}}</a></td>
 								</tr>
 							{{else}}
 								<tr class="center aligned"><td>{{.i18n.Tr "repo.settings.no_protected_branch"}}</td></tr>

--- a/templates/repo/settings/branches.tmpl
+++ b/templates/repo/settings/branches.tmpl
@@ -62,7 +62,7 @@
 							{{range .ProtectedBranches}}
 								<tr>
 									<td><div class="ui basic label blue">{{.BranchName}}</div></td>
-									<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName}}">{{.i18n.Tr "repo.settings.edit_protected_branch"}}</a></td>
+									<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName}}">{{$.i18n.Tr "repo.settings.edit_protected_branch"}}</a></td>
 								</tr>
 							{{else}}
 								<tr class="center aligned"><td>{{.i18n.Tr "repo.settings.no_protected_branch"}}</td></tr>


### PR DESCRIPTION
The button "Edit" on "Repo > Settings > Branches > Branch Protection" not have locale defined.

I added the locale for button Edit on protected branch.