### PR TITLE
Fix column droping for MySQL that need a new session for the new transaction

### DIFF
--- a/models/migrations/v64.go
+++ b/models/migrations/v64.go
@@ -124,6 +124,11 @@ func addMultipleAssignees(x *xorm.Engine) error {
 	if err := sess.Commit(); err != nil {
 		return err
 	}
+
+	sess.Close()
+	sess = x.NewSession()
+	defer sess.Close()
+
 	if err := sess.Begin(); err != nil {
 		return err
 	}

--- a/models/migrations/v69.go
+++ b/models/migrations/v69.go
@@ -77,6 +77,11 @@ func moveTeamUnitsToTeamUnitTable(x *xorm.Engine) error {
 	if err := sess.Commit(); err != nil {
 		return err
 	}
+
+	sess.Close()
+	sess = x.NewSession()
+	defer sess.Close()
+
 	if err := sess.Begin(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Finally Fixes #4360

Through PR #4440 an issue within migration scripts was introduced if running gitea with MySQL as Database.
This PR completely closes the database session and reopenes a new one to circumvent this issue. There may be a more performant solution. However, as this is only done once this solution should be sufficient.
