### PR TITLE
fix language list

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -586,7 +586,7 @@ MAX_RESPONSE_ITEMS = 50
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어
+NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Pусский,Українська,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomi,Türkçe,Čeština,Cрпски,Svenska,한국어
 
 ; Used for datetimepicker
 [i18n.datelang]

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -299,7 +299,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 ## i18n (`i18n`)
 
 - `LANGS`: **en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR**: List of locales shown in language selector
-- `NAMES`: **English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어**: Visible names corresponding to the locales
+- `NAMES`: **English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Pусский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomi,Türkçe,Čeština,Cрпски,Svenska,한국어**: Visible names corresponding to the locales
 
 ### i18n - Datepicker Language (`i18n.datelang`)
 Maps locales to the languages used by the datepicker plugin

--- a/modules/setting/defaults.go
+++ b/modules/setting/defaults.go
@@ -6,5 +6,5 @@ import (
 
 var (
 	defaultLangs     = strings.Split("en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR", ",")
-	defaultLangNames = strings.Split("English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어", ",")
+	defaultLangNames = strings.Split("English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Pусский,Українська,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomi,Türkçe,Čeština,Cрпски,Svenska,한국어", ",")
 )


### PR DESCRIPTION
When picking up a language from the list (bottom page) the languages' name where not standardized.
Some started with caps, others didn't, but that's now starting all with a caps !

![image](https://user-images.githubusercontent.com/10053686/42925779-93c270e4-8b2f-11e8-965c-104341b47b6f.png)
