### PR TITLE
Prevent html entity escaping on delete branch

### DIFF
--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -72,7 +72,7 @@
 		{{.i18n.Tr "repo.branch.delete_html"}} <span class="branch-name"></span>
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.branch.delete_desc"}}</p>
+		<p>{{.i18n.Tr "repo.branch.delete_desc" | Str2html}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -137,7 +137,7 @@
 		{{.i18n.Tr "repo.branch.delete" .HeadTarget }}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.branch.delete_desc"}}</p>
+		<p>{{.i18n.Tr "repo.branch.delete_desc" | Str2html}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>


### PR DESCRIPTION
Deletion confirmation message is escaping html tags.

![captura de tela de 2018-07-19 10-46-34](https://user-images.githubusercontent.com/1946348/42946638-bc509f7e-8b41-11e8-9bb9-6fcd7a54d87c.png)
