### PR TITLE
Respect email privacy option in user search via API

### DIFF
--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -60,7 +60,7 @@ func Search(ctx *context.APIContext) {
 			AvatarURL: users[i].AvatarLink(),
 			FullName:  markup.Sanitize(users[i].FullName),
 		}
-		if ctx.IsSigned {
+		if ctx.IsSigned && !users[i].KeepEmailPrivate {
 			results[i].Email = users[i].Email
 		}
 	}

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -60,7 +60,7 @@ func Search(ctx *context.APIContext) {
 			AvatarURL: users[i].AvatarLink(),
 			FullName:  markup.Sanitize(users[i].FullName),
 		}
-		if ctx.IsSigned && !users[i].KeepEmailPrivate {
+		if ctx.IsSigned && (!users[i].KeepEmailPrivate || ctx.User.IsAdmin) {
 			results[i].Email = users[i].Email
 		}
 	}


### PR DESCRIPTION
Fixes #4502 ... 


~~~I was also thinking of something along the line of the code below where you use __****__ instead of leaving it as an empty string~~~