### PR TITLE
Fix out-of-transaction query in removeOrgUser (#4521)

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -454,7 +454,7 @@ func AddOrgUser(orgID, uid int64) error {
 func removeOrgUser(sess *xorm.Session, orgID, userID int64) error {
 	ou := new(OrgUser)
 
-	has, err := x.
+	has, err := sess.
 		Where("uid=?", userID).
 		And("org_id=?", orgID).
 		Get(ou)


### PR DESCRIPTION
Fix #4521 

This query checked if user is member of organization to prevent deletion twice, but it was done out of transaction, so if user was deleted inside transaction, changes were not visible before commit and user was deleted multiple times (made member counter decrease twice).