### PR TITLE
Fix incorrect MergeWhitelistTeamIDs check in CanUserMerge function (#4519)

### DIFF
--- a/models/branches.go
+++ b/models/branches.go
@@ -74,7 +74,7 @@ func (protectBranch *ProtectedBranch) CanUserMerge(userID int64) bool {
 		return true
 	}
 
-	if len(protectBranch.WhitelistTeamIDs) == 0 {
+	if len(protectBranch.MergeWhitelistTeamIDs) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
Fixes #4519

WhitelistTeamIDs was checked instead of MergeWhitelistTeamIDs in CanUserMerge (WhitelistTeamIDs is whitelist to push, not to merge).