### PR TITLE
Backport for "Fix incorrect MergeWhitelistTeamIDs check in CanUserMerge function" to v1.5 branch

### DIFF
--- a/models/branches.go
+++ b/models/branches.go
@@ -74,7 +74,7 @@ func (protectBranch *ProtectedBranch) CanUserMerge(userID int64) bool {
 		return true
 	}
 
-	if len(protectBranch.WhitelistTeamIDs) == 0 {
+	if len(protectBranch.MergeWhitelistTeamIDs) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
Backport for #4525