### PR TITLE
Fix failure on creating pull request with assignees (#4419)

### DIFF
--- a/models/issue_assignees.go
+++ b/models/issue_assignees.go
@@ -162,6 +162,10 @@ func (issue *Issue) changeAssignee(sess *xorm.Session, doer *User, assigneeID in
 	mode, _ := accessLevel(sess, doer.ID, issue.Repo)
 	if issue.IsPull {
 		if err = issue.loadPullRequest(sess); err != nil {
+			// If pull request is not yet created - don't fail here, skip webhooks
+			if IsErrPullRequestNotExist(err) {
+				return nil
+			}
 			return fmt.Errorf("loadPullRequest: %v", err)
 		}
 		issue.PullRequest.Issue = issue


### PR DESCRIPTION
Fixes #4419

If pull request is in the middle of creation, it's impossible to call '```pull_request```' webhook with action '```assign```' in changeAssignee function. Now it's just skipped.

I don't know if this extra webhooks should be called after pull request is created, because '```pull_request```' webhook with action '```opened```' is called anyway and it already contains ```assignees``` section. For now additional ```assign``` webhooks are just skipped.