### PR TITLE
Site admin could create repos even MAX_CREATION_LIMIT=0

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1411,8 +1411,10 @@ func createRepository(e *xorm.Session, doer, u *User, repo *Repository) (err err
 
 // CreateRepository creates a repository for the user/organization u.
 func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err error) {
-	if !u.CanCreateRepo() {
-		return nil, ErrReachLimitOfRepo{u.MaxRepoCreation}
+	if !doer.IsAdmin {
+		if !u.CanCreateRepo() {
+			return nil, ErrReachLimitOfRepo{u.MaxRepoCreation}
+		}
 	}
 
 	repo := &Repository{

--- a/models/repo.go
+++ b/models/repo.go
@@ -1411,10 +1411,8 @@ func createRepository(e *xorm.Session, doer, u *User, repo *Repository) (err err
 
 // CreateRepository creates a repository for the user/organization u.
 func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err error) {
-	if !doer.IsAdmin {
-		if !u.CanCreateRepo() {
-			return nil, ErrReachLimitOfRepo{u.MaxRepoCreation}
-		}
+	if !doer.IsAdmin && !u.CanCreateRepo() {
+		return nil, ErrReachLimitOfRepo{u.MaxRepoCreation}
 	}
 
 	repo := &Repository{


### PR DESCRIPTION
When MAX_CREATION_LIMIT=0, site admin could create repos on any account but not organization, it will result in 500. This PR will fix that issue. That means, site admin could create repos on any account or  organization even 
MAX_CREATION_LIMIT=0