### PR TITLE
Add gitea/issues link to 500 page

### DIFF
--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -5,5 +5,6 @@
 	<br>
 	{{if .ErrorMsg}}<p>An error has occurred : {{.ErrorMsg}}</p>{{end}}
 	{{if .ShowFooterVersion}}<p>Application Version: {{AppVer}}</p>{{end}}
+	{{if .IsAdmin}}<p>If you are sure this is Gitea bug, please search for issue on <a href="https://github.com/go-gitea/gitea/issues">GitHub</a> and open new issue if necessary.</p>{{end}}
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
There was link to Gitea issues on 404 page, which was removed in #4639 PR.

I think 500 error page is suitable for that link, because 500 error  usually is Gitea error itself.

But limited this link to admins only because only admin could provide logs, not regular user.