### PR TITLE
Remove UsePrivilegeSeparation from the Docker sshd_config, see #2876

### DIFF
--- a/docker/etc/ssh/sshd_config
+++ b/docker/etc/ssh/sshd_config
@@ -29,4 +29,3 @@ AllowUsers git
 
 Banner none
 Subsystem sftp /usr/lib/ssh/sftp-server
-UsePrivilegeSeparation no


### PR DESCRIPTION
This removes the `UsePrivilegeSeparation` line from `sshd_config`, which is deprecated and causes this warning in the logs for every single ssh connection:
```
Aug 15 18:28:57 sshd[1200]: rexec line 32: Deprecated option UsePrivilegeSeparation
```

This should resolve #2876