### PR TITLE
Add git-LFS to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk --no-cache add \
     curl \
     gettext \
     git \
+    git-lfs \
     linux-pam \
     openssh \
     s6 \


### PR DESCRIPTION
This patch install the git-lfs in the docker image.

Fix #4756