### PR TITLE
API /admin/users/{username}  missing parameter

### DIFF
--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -154,6 +154,9 @@ func EditUser(ctx *context.APIContext, form api.EditUserOption) {
 	if form.MaxRepoCreation != nil {
 		u.MaxRepoCreation = *form.MaxRepoCreation
 	}
+	if form.AllowCreateOrganization != nil {
+		u.AllowCreateOrganization = *form.AllowCreateOrganization
+	}
 
 	if err := models.UpdateUser(u); err != nil {
 		if models.IsErrEmailAlreadyUsed(err) {

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -157,6 +157,9 @@ func EditUser(ctx *context.APIContext, form api.EditUserOption) {
 	if form.AllowCreateOrganization != nil {
 		u.AllowCreateOrganization = *form.AllowCreateOrganization
 	}
+	if form.ProhibitLogin != nil {
+		u.ProhibitLogin = *form.ProhibitLogin
+	}
 
 	if err := models.UpdateUser(u); err != nil {
 		if models.IsErrEmailAlreadyUsed(err) {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -6534,6 +6534,10 @@
           "type": "string",
           "x-go-name": "Password"
         },
+        "prohibit_login": {
+          "type": "boolean",
+          "x-go-name": "ProhibitLogin"
+        },
         "source_id": {
           "type": "integer",
           "format": "int64",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -6504,6 +6504,10 @@
           "type": "boolean",
           "x-go-name": "AllowImportLocal"
         },
+        "allow_create_organization": {
+          "type": "boolean",
+          "x-go-name": "AllowCreateOrganization"
+        },
         "email": {
           "type": "string",
           "format": "email",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -6496,6 +6496,10 @@
           "type": "boolean",
           "x-go-name": "Admin"
         },
+        "allow_create_organization": {
+          "type": "boolean",
+          "x-go-name": "AllowCreateOrganization"
+        },
         "allow_git_hook": {
           "type": "boolean",
           "x-go-name": "AllowGitHook"
@@ -6503,10 +6507,6 @@
         "allow_import_local": {
           "type": "boolean",
           "x-go-name": "AllowImportLocal"
-        },
-        "allow_create_organization": {
-          "type": "boolean",
-          "x-go-name": "AllowCreateOrganization"
         },
         "email": {
           "type": "string",

--- a/vendor/code.gitea.io/sdk/gitea/admin_user.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_user.go
@@ -51,6 +51,7 @@ type EditUserOption struct {
 	AllowGitHook     *bool  `json:"allow_git_hook"`
 	AllowImportLocal *bool  `json:"allow_import_local"`
 	MaxRepoCreation  *int   `json:"max_repo_creation"`
+	ProhibitLogin    *bool  `json:"prohibit_login"`
 	AllowCreateOrganization *bool `json:"allow_create_organization"`
 }
 

--- a/vendor/code.gitea.io/sdk/gitea/admin_user.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_user.go
@@ -51,6 +51,7 @@ type EditUserOption struct {
 	AllowGitHook     *bool  `json:"allow_git_hook"`
 	AllowImportLocal *bool  `json:"allow_import_local"`
 	MaxRepoCreation  *int   `json:"max_repo_creation"`
+	AllowCreateOrganization *bool `json:"allow_create_organization"`
 }
 
 // AdminEditUser modify user informations


### PR DESCRIPTION
This PR modify the logic of the api [/admin/users/{username}](https://try.gitea.io/api/swagger#/admin/adminEditUser) as descripted in the issue #4765 

Add two field in the structure EditUserOption and  allow to modify the values for **Disable Sign-In** and
**May Create Organization**
![image](https://user-images.githubusercontent.com/25525316/44454473-f1fc0580-a5fb-11e8-9c5a-17a0174ddc27.png)

The new two field in the swagger editor
![image](https://user-images.githubusercontent.com/25525316/44527711-f0a80700-a6e7-11e8-8510-c278fda2860f.png)

