### PR TITLE
Disable 'May Import Local Repository' when is disabled by setting (Is…

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -165,6 +165,9 @@ func NewFuncMap() []template.FuncMap {
 		"DisableGitHooks": func() bool {
 			return setting.DisableGitHooks
 		},
+		"DisableImportLocal": func() bool {
+			return !setting.ImportLocalPaths
+		},
 		"TrN": TrN,
 		"Dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -92,7 +92,7 @@
 				<div class="inline field">
 					<div class="ui checkbox">
 						<label><strong>{{.i18n.Tr "admin.users.allow_import_local"}}</strong></label>
-						<input name="allow_import_local" type="checkbox" {{if .User.CanImportLocal}}checked{{end}}>
+						<input name="allow_import_local" type="checkbox" {{if .User.CanImportLocal}}checked{{end}} {{if DisableImportLocal}}disabled{{end}}>
 					</div>
 				</div>
 				{{if not .DisableRegularOrgCreation}}


### PR DESCRIPTION
Modify the layout of /admin/users/{user} when the setting IMPORT_LOCAL_PATHS is missing or equal a false (Issue #4779):

Setting:
```
[security]
...
IMPORT_LOCAL_PATHS = false
DISABLE_GIT_HOOKS = true 
```

As is:
![image](https://user-images.githubusercontent.com/25525316/44553918-6b484500-a72f-11e8-8602-86a4b991d7ad.png)

To be:
![image](https://user-images.githubusercontent.com/25525316/44554045-c4b07400-a72f-11e8-8a76-86c4af0e64fb.png)

