### PR TITLE
Backport: Fix missing release title in webhook (#4783)

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -88,6 +88,7 @@ func (r *Release) APIFormat() *api.Release {
 		ID:           r.ID,
 		TagName:      r.TagName,
 		Target:       r.Target,
+		Title:        r.Title,
 		Note:         r.Note,
 		URL:          r.APIURL(),
 		TarURL:       r.TarURL(),


### PR DESCRIPTION
Backport #4796