### PR TITLE
 refactoring access token from sha1 to sha1+JWT, with plan for backward compatibility

### DIFF
--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -188,10 +188,10 @@ type NewAccessTokenForm struct {
 	Name string `binding:"Required;MaxSize(255)"`
 	MatchOwner []string `binding:"OmitEmpty"`
 	MatchRepo []string `binding:"OmitEmpty"`
-	RegexMatchBranch []string `binding:"OmitEmpty"`
-	RegexMatchRoute []string `binding:"OmitEmpty"`
+	WildcardMatchBranch []string `binding:"OmitEmpty"`
+	WildcardMatchRoute []string `binding:"OmitEmpty"`
 	MatchMethod []string `binding:"OmitEmpty"`
-	Expires int64 `binding:"OmitEmpty"`
+	ExpiresAt int64 `binding:"OmitEmpty"`
 }
 
 // Validate valideates the fields

--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -186,6 +186,12 @@ func (f *AddKeyForm) Validate(ctx *macaron.Context, errs binding.Errors) binding
 // NewAccessTokenForm form for creating access token
 type NewAccessTokenForm struct {
 	Name string `binding:"Required;MaxSize(255)"`
+	MatchOwner []string `binding:"OmitEmpty"`
+	MatchRepo []string `binding:"OmitEmpty"`
+	RegexMatchBranch []string `binding:"OmitEmpty"`
+	RegexMatchRoute []string `binding:"OmitEmpty"`
+	MatchMethod []string `binding:"OmitEmpty"`
+	Expires int64 `binding:"OmitEmpty"`
 }
 
 // Validate valideates the fields

--- a/vendor/github.com/go-macaron/csrf/xsrf.go
+++ b/vendor/github.com/go-macaron/csrf/xsrf.go
@@ -50,7 +50,7 @@ func generateTokenAtTime(key, userID, actionID string, now time.Time) string {
 	h := hmac.New(sha1.New, []byte(key))
 	fmt.Fprintf(h, "%s:%s:%d", clean(userID), clean(actionID), now.UnixNano())
 	tok := fmt.Sprintf("%s:%d", h.Sum(nil), now.UnixNano())
-	return base64.URLEncoding.EncodeToString([]byte(tok))
+	return base64.RawURLEncoding.EncodeToString([]byte(tok))
 }
 
 // Valid returns true if token is a valid, unexpired token returned by Generate.
@@ -61,7 +61,7 @@ func ValidToken(token, key, userID, actionID string) bool {
 // validTokenAtTime is like Valid, but it uses now to check if the token is expired.
 func validTokenAtTime(token, key, userID, actionID string, now time.Time) bool {
 	// Decode the token.
-	data, err := base64.URLEncoding.DecodeString(token)
+	data, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
 		return false
 	}

--- a/vendor/github.com/go-macaron/csrf/xsrf.go
+++ b/vendor/github.com/go-macaron/csrf/xsrf.go
@@ -50,7 +50,7 @@ func generateTokenAtTime(key, userID, actionID string, now time.Time) string {
 	h := hmac.New(sha1.New, []byte(key))
 	fmt.Fprintf(h, "%s:%s:%d", clean(userID), clean(actionID), now.UnixNano())
 	tok := fmt.Sprintf("%s:%d", h.Sum(nil), now.UnixNano())
-	return base64.RawURLEncoding.EncodeToString([]byte(tok))
+	return base64.URLEncoding.EncodeToString([]byte(tok))
 }
 
 // Valid returns true if token is a valid, unexpired token returned by Generate.
@@ -61,7 +61,7 @@ func ValidToken(token, key, userID, actionID string) bool {
 // validTokenAtTime is like Valid, but it uses now to check if the token is expired.
 func validTokenAtTime(token, key, userID, actionID string, now time.Time) bool {
 	// Decode the token.
-	data, err := base64.RawURLEncoding.DecodeString(token)
+	data, err := base64.URLEncoding.DecodeString(token)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This is a proposal of the parameters of custom access grants/claims in new JWT access token. This is the first step to start the discussion and PR process.

AccessToken generated can include JWT as content, and sha1 hash of the content for backward compatibility. during transition period, the api/ui can accept old and new sha1, and JWT at the same time. Admin can enforce the use of JWT after the transition period. 

Only the token name, claims and sha1 hash will be stored in DB. The meta data is to describe the issued token, but can not be used to authenticate after transition period. 

Admin can optionally enable checking the stored sha1 after validating the token with  server secret, for extra peace of mind. or turn it off for performance.