### PR TITLE
Update legacy branch and tag URLs in dashboard to new format

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1649,7 +1649,7 @@ notices.delete_success = The system notices have been deleted.
 [action]
 create_repo = created repository <a href="%s">%s</a>
 rename_repo = renamed repository from <code>%[1]s</code> to <a href="%[2]s">%[3]s</a>
-commit_repo = pushed to <a href="%[1]s/src/%[2]s">%[3]s</a> at <a href="%[1]s">%[4]s</a>
+commit_repo = pushed to <a href="%[1]s/src/branch/%[2]s">%[3]s</a> at <a href="%[1]s">%[4]s</a>
 create_issue = `opened issue <a href="%s/issues/%s">%s#%[2]s</a>`
 close_issue = `closed issue <a href="%s/issues/%s">%s#%[2]s</a>`
 reopen_issue = `reopened issue <a href="%s/issues/%s">%s#%[2]s</a>`
@@ -1659,7 +1659,7 @@ reopen_pull_request = `reopened pull request <a href="%s/pulls/%s">%s#%[2]s</a>`
 comment_issue = `commented on issue <a href="%s/issues/%s">%s#%[2]s</a>`
 merge_pull_request = `merged pull request <a href="%s/pulls/%s">%s#%[2]s</a>`
 transfer_repo = transferred repository <code>%s</code> to <a href="%s">%s</a>
-push_tag = pushed tag <a href="%s/src/%s">%[2]s</a> to <a href="%[1]s">%[3]s</a>
+push_tag = pushed tag <a href="%s/src/tag/%s">%[2]s</a> to <a href="%[1]s">%[3]s</a>
 delete_tag = deleted tag %[2]s from <a href="%[1]s">%[3]s</a>
 delete_branch = deleted branch %[2]s from <a href="%[1]s">%[3]s</a>
 compare_commits = Compare %d commits


### PR DESCRIPTION
I personally dislike storing dashboard URLs in language file, but to keep compatibility I did not changed much.

Previously, "{user} pushed to {branch}" and "{user} pushed tag" events were leading to {repo}/src/{branchname} and {repo}/src/{tagname} which are marked as legacy and kept for backward compatibility. Updated them to {repo}/src/branch/{branchname} and {repo}/src/tag/{tagname} where they are redirecting to.