### PR TITLE
Change Collaborators List to include permissions

### DIFF
--- a/models/repo_collaboration.go
+++ b/models/repo_collaboration.go
@@ -6,6 +6,8 @@ package models
 
 import (
 	"fmt"
+
+	api "code.gitea.io/sdk/gitea"
 )
 
 // Collaboration represent the relation between an individual and a repository.
@@ -76,6 +78,25 @@ func (repo *Repository) getCollaborations(e Engine) ([]*Collaboration, error) {
 type Collaborator struct {
 	*User
 	Collaboration *Collaboration
+}
+
+// APIFormat converts a Collaborator to api.Collaborator
+func (c *Collaborator) APIFormat() *api.Collaborator {
+	mode := c.Collaboration.Mode
+	permission := &api.Permission{
+		Admin: mode >= AccessModeAdmin,
+		Push:  mode >= AccessModeWrite,
+		Pull:  mode >= AccessModeRead,
+	}
+	return &api.Collaborator{
+		ID:          c.ID,
+		UserName:    c.Name,
+		FullName:    c.FullName,
+		Email:       c.getEmail(),
+		AvatarURL:   c.AvatarLink(),
+		Language:    c.Language,
+		Permissions: permission,
+	}
 }
 
 func (repo *Repository) getCollaborators(e Engine) ([]*Collaborator, error) {

--- a/routers/api/v1/repo/collaborators.go
+++ b/routers/api/v1/repo/collaborators.go
@@ -33,7 +33,7 @@ func ListCollaborators(ctx *context.APIContext) {
 	//   required: true
 	// responses:
 	//   "200":
-	//     "$ref": "#/responses/UserList"
+	//     "$ref": "#/responses/CollaboratorList"
 	if !ctx.Repo.IsWriter() {
 		ctx.Error(403, "", "User does not have push access")
 		return
@@ -43,7 +43,7 @@ func ListCollaborators(ctx *context.APIContext) {
 		ctx.Error(500, "ListCollaborators", err)
 		return
 	}
-	users := make([]*api.User, len(collaborators))
+	users := make([]*api.Collaborator, len(collaborators))
 	for i, collaborator := range collaborators {
 		users[i] = collaborator.APIFormat()
 	}

--- a/routers/api/v1/swagger/repo.go
+++ b/routers/api/v1/swagger/repo.go
@@ -78,6 +78,13 @@ type swaggerResponseReleaseList struct {
 	Body []api.Release `json:"body"`
 }
 
+// Permission
+// swagger:response Permission
+type swaggerResponsePermission struct {
+	// in:body
+	Body api.Permission `json:"body"`
+}
+
 // PullRequest
 // swagger:response PullRequest
 type swaggerResponsePullRequest struct {

--- a/routers/api/v1/swagger/repo.go
+++ b/routers/api/v1/swagger/repo.go
@@ -22,6 +22,20 @@ type swaggerResponseRepositoryList struct {
 	Body []api.Repository `json:"body"`
 }
 
+// Collaborator
+// swagger:response Collaborator
+type swaggerResponseCollaborator struct {
+	// in:body
+	Body api.Collaborator `json:"body"`
+}
+
+// CollaboratorList
+// swagger:response CollaboratorList
+type swaggerResponseCollaboratorList struct {
+	// in:body
+	Body []api.Collaborator `json:"body"`
+}
+
 // Branch
 // swagger:response Branch
 type swaggerResponseBranch struct {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1281,8 +1281,8 @@
           }
         ],
         "responses": {
-          "204": {
-            "$ref": "#/responses/empty"
+          "200": {
+            "$ref": "#/responses/Permission"
           },
           "404": {
             "$ref": "#/responses/empty"
@@ -8117,6 +8117,12 @@
         "items": {
           "$ref": "#/definitions/Organization"
         }
+      }
+    },
+    "Permission": {
+      "description": "Permission",
+      "schema": {
+        "$ref": "#/definitions/Permission"
       }
     },
     "PublicKey": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1242,7 +1242,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/UserList"
+            "$ref": "#/responses/CollaboratorList"
           }
         }
       }
@@ -5855,6 +5855,47 @@
       },
       "x-go-package": "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
     },
+    "Collaborator": {
+      "description": "Collaborator represents a collaborator",
+      "type": "object",
+      "properties": {
+        "avatar_url": {
+          "description": "URL to the user's avatar",
+          "type": "string",
+          "x-go-name": "AvatarURL"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "x-go-name": "Email"
+        },
+        "full_name": {
+          "description": "the user's full name",
+          "type": "string",
+          "x-go-name": "FullName"
+        },
+        "id": {
+          "description": "the user's id",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ID"
+        },
+        "language": {
+          "description": "User locale",
+          "type": "string",
+          "x-go-name": "Language"
+        },
+        "login": {
+          "description": "the user's username",
+          "type": "string",
+          "x-go-name": "UserName"
+        },
+        "permissions": {
+          "$ref": "#/definitions/Permission"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    },
     "Comment": {
       "description": "Comment represents a comment on a commit or issue",
       "type": "object",
@@ -7919,6 +7960,21 @@
         "type": "array",
         "items": {
           "$ref": "#/definitions/Branch"
+        }
+      }
+    },
+    "Collaborator": {
+      "description": "Collaborator",
+      "schema": {
+        "$ref": "#/definitions/Collaborator"
+      }
+    },
+    "CollaboratorList": {
+      "description": "CollaboratorList",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Collaborator"
         }
       }
     },

--- a/vendor/code.gitea.io/sdk/gitea/repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo.go
@@ -48,6 +48,25 @@ type Repository struct {
 	Permissions *Permission `json:"permissions,omitempty"`
 }
 
+// Collaborator represents a collaborator
+// swagger:model
+type Collaborator struct {
+	// the user's id
+	ID int64 `json:"id"`
+	// the user's username
+	UserName string `json:"login"`
+	// the user's full name
+	FullName string `json:"full_name"`
+	// swagger:strfmt email
+	Email string `json:"email"`
+	// URL to the user's avatar
+	AvatarURL string `json:"avatar_url"`
+	// User locale
+	Language string `json:"language"`
+	// Permissions
+	Permissions *Permission `json:"permissions,omitempty"`
+}
+
 // ListMyRepos lists all repositories for the authenticated user that has access to.
 func (c *Client) ListMyRepos() ([]*Repository, error) {
 	repos := make([]*Repository, 0, 10)

--- a/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
@@ -20,17 +20,12 @@ func (c *Client) ListCollaborators(user, repo string) ([]*Collaborator, error) {
 }
 
 // IsCollaborator check if a user is a collaborator of a repository
-func (c *Client) IsCollaborator(user, repo, collaborator string) (bool, error) {
-	status, err := c.getStatusCode("GET",
+func (c *Client) IsCollaborator(user, repo, collaborator string) (*Permission, error) {
+	var permission *Permission
+	err := c.getParsedResponse("GET",
 		fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator),
-		nil, nil)
-	if err != nil {
-		return false, err
-	}
-	if status == 204 {
-		return true, nil
-	}
-	return false, nil
+		nil, nil, &permission)
+	return permission, err
 }
 
 // AddCollaboratorOption options when adding a user as a collaborator of a repository

--- a/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
@@ -11,8 +11,8 @@ import (
 )
 
 // ListCollaborators list a repository's collaborators
-func (c *Client) ListCollaborators(user, repo string) ([]*User, error) {
-	collaborators := make([]*User, 0, 10)
+func (c *Client) ListCollaborators(user, repo string) ([]*Collaborator, error) {
+	collaborators := make([]*Collaborator, 0, 10)
 	err := c.getParsedResponse("GET",
 		fmt.Sprintf("/repos/%s/%s/collaborators", user, repo),
 		nil, nil, &collaborators)


### PR DESCRIPTION
This pull request adjusts the api for /api/v1/repos/:owner/:reponame/collaborators to return the permissions for each collaborator, making this api a bit more useful. 