### PR TITLE
Make /users/search return a UserList

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1459,7 +1459,7 @@ function searchUsers() {
             url: suburl + '/api/v1/users/search?q={query}',
             onResponse: function(response) {
                 var items = [];
-                $.each(response.data, function (i, item) {
+                $.each(response, function (i, item) {
                     var title = item.login;
                     if (item.full_name && item.full_name.length > 0) {
                         title += ' (' + item.full_name + ')';

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -45,10 +45,7 @@ func Search(ctx *context.APIContext) {
 
 	users, _, err := models.SearchUsers(opts)
 	if err != nil {
-		ctx.JSON(500, map[string]interface{}{
-			"ok":    false,
-			"error": err.Error(),
-		})
+		ctx.Error(500, "UserSearch", err)
 		return
 	}
 
@@ -65,10 +62,7 @@ func Search(ctx *context.APIContext) {
 		}
 	}
 
-	ctx.JSON(200, map[string]interface{}{
-		"ok":   true,
-		"data": results,
-	})
+	ctx.JSON(200, results)
 }
 
 // GetInfo get user's information


### PR DESCRIPTION
As per issue #4841 . The current implementation of the `/users/search` API does not return a UserList but rather an object similar to the SearchResults object returned by `/repos/search`. This pull request fixes this code to return a UserList as per the API description and the SDK.

The issue is that this API has been wrong for at least 10 months - therefore tools may have grown up using the incorrect API. I will also create a pull requests for the opposite solution...

