### PR TITLE
Update Swagger API to match the return of /users/search

### DIFF
--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -33,7 +33,16 @@ func Search(ctx *context.APIContext) {
 	//   type: integer
 	// responses:
 	//   "200":
-	//     "$ref": "#/responses/UserList"
+	//     description: "SearchResults of a successful search"
+	//     schema:
+	//       type: object
+	//       properties:
+	//         ok:
+	//           type: boolean
+	//         data:
+	//           type: array
+	//           items:
+	//             "$ref": "#/definitions/User"
 	opts := &models.SearchUserOptions{
 		Keyword:  strings.Trim(ctx.Query("q"), " "),
 		Type:     models.UserTypeIndividual,

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -5212,7 +5212,21 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/UserList"
+            "description": "SearchResults of a successful search",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/User"
+                  }
+                },
+                "ok": {
+                  "type": "boolean"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
As per issue #4841 . The current implementation of the /users/search API does not return a UserList but rather an object similar to the SearchResults object returned by /repos/search. This pull request fixes swagger API so that it actually describes the reality of what is returned.  

This pull-request requires https://github.com/go-gitea/go-sdk/pull/119

The issue is that this API has been wrong for at least 10 months - therefore tools may have grown up using the incorrect API even though the SDK is incorrect. I have also created a pull request for the opposite solution #4846 - which if pulled would mean this request was unnecessary.