### PR TITLE
Fix trimming of markup section names

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1155,7 +1155,7 @@ func NewContext() {
 
 	extensionReg := regexp.MustCompile(`\.\w`)
 	for _, sec := range Cfg.Section("markup").ChildSections() {
-		name := strings.TrimLeft(sec.Name(), "markup.")
+		name := strings.TrimPrefix(sec.Name(), "markup.")
 		if name == "" {
 			log.Warn("name is empty, markup " + sec.Name() + "ignored")
 			continue


### PR DESCRIPTION
This small fix corrects the trimming of markup section names in the settings parser.

Previously, `TrimLeft(sec.Name(), "markup.")` was used, which [trims all characters contained in the second string](https://godoc.org/strings#TrimLeft).

So, for example, the section name `markup.moo` was incorrectly trimmed to `oo`.

The correct function for this is [`TrimPrefix`](https://godoc.org/strings#TrimPrefix) which uses the second string as, well, a prefix. Now, for example, `markup.moo` gets correctly trimmed to `moo`.

(I noticed this when trying to overwrite markdown parsing with a app.ini section `markup.markdown`.
Wiki pages are currently hardcoded to use `markdown` markup type. The function `Wiki` in routers/repo/wiki.go complains as wiki pages are `.md` files which returned `down` as markup type instead of the expected `markdown`.)

Signed-off-by: Nicolas Lenz <nicolas@eisfunke.com>