### PR TITLE
Backport: Fix trimming of markup section names

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1112,7 +1112,7 @@ func NewContext() {
 
 	extensionReg := regexp.MustCompile(`\.\w`)
 	for _, sec := range Cfg.Section("markup").ChildSections() {
-		name := strings.TrimLeft(sec.Name(), "markup.")
+		name := strings.TrimPrefix(sec.Name(), "markup.")
 		if name == "" {
 			log.Warn("name is empty, markup " + sec.Name() + "ignored")
 			continue


### PR DESCRIPTION
Backport of #4863 (I hope I did this right)