### PR TITLE
Remove feature `global code search` from GitLab CE

### DIFF
--- a/docs/content/doc/features/comparison.en-us.md
+++ b/docs/content/doc/features/comparison.en-us.md
@@ -56,7 +56,7 @@ _Symbols used in table:_
 |---------|-------|------|-----------|-----------|-----------|-----------|--------------|
 | Repository topics | ✓ | ✘ | ✓ | ✓ | ✓ | ✘ | ✘ |
 | Repository code search | ✓ | ✘ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Global code search | ✓ | ✘ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Global code search | ✓ | ✘ | ✓ | ✘ | ✓ | ✓ | ✓ |
 | Git LFS 2.0 | ✓ | ✘ | ✓ | ✓ | ✓ | ⁄ | ✓ |
 | Group Milestones | ✘ | ✘ | ✘ | ✓ | ✓ | ✘ | ✘ |
 | Granular user roles (Code, Issues, Wiki etc) | ✓ | ✘ | ✘ | ✓ | ✓ | ✘ | ✘ |


### PR DESCRIPTION
Just recently we realized that it's not possible to enable [`Global Search`](https://docs.gitlab.com/ee/user/search/advanced_global_search.html) for a GitLab CE.

Their [admin docs](https://docs.gitlab.com/ee/integration/elasticsearch.html#version-requirements) actually also says so. That's why I think it should be mark like that in your comparison page :)