### PR TITLE
docs(comparison): correct GitLab CE multiple assignees for issues

### DIFF
--- a/docs/content/doc/features/comparison.en-us.md
+++ b/docs/content/doc/features/comparison.en-us.md
@@ -77,7 +77,7 @@ _Symbols used in table:_
 | Issue templates | ✓ | ✓ | ✓ | ✓ | ✓ | ✘ | ✘ |
 | Labels | ✓ | ✓ | ✓ | ✓ | ✓ | ✘ | ✘ |
 | Time tracking | ✓ | ✘ | ✓ | ✓ | ✓ | ✘ | ✘ |
-| Multiple assignees for issues | ✓ | ✘ | ✓ | ✓ | ✓ | ✘ | ✘ |
+| Multiple assignees for issues | ✓ | ✘ | ✓ | ✘ | ✓ | ✘ | ✘ |
 | Related issues | ✘ | ✘ | ⁄ | ✘ | ✓ | ✘ | ✘ |
 | Confidential issues | ✘ | ✘ | ✘ | ✓ | ✓ | ✘ | ✘ |
 | Comment reactions | ✓ | ✘ | ✓ | ✓ | ✓ | ✘ | ✘ |


### PR DESCRIPTION
GitLab CE doesn't support multiple assignees for issues.  
That's an enterprise feature.  See: https://docs.gitlab.com/ee/user/project/issues/multiple_assignees_for_issues.html