### PR TITLE
Fixes repo branch endpoint summary

### DIFF
--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -16,7 +16,7 @@ import (
 func GetBranch(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/branches/{branch} repository repoGetBranch
 	// ---
-	// summary: List a repository's branches
+	// summary: Retrieve a specific branch from a repository
 	// produces:
 	// - application/json
 	// parameters:

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1157,7 +1157,7 @@
         "tags": [
           "repository"
         ],
-        "summary": "List a repository's branches",
+        "summary": "Retrieve a specific branch from a repository",
         "operationId": "repoGetBranch",
         "parameters": [
           {


### PR DESCRIPTION
in browser saw `/repos/{owner}/{repo}/branches/{branch} List a repository's branches`
fixed

![image](https://user-images.githubusercontent.com/2605791/45251660-b5d9dc00-b341-11e8-9042-a2cd9326fe1d.png)

Fixes https://github.com/go-gitea/gitea/issues/4892