### PR TITLE
added setting MaxGitCommits

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -590,6 +590,9 @@ MAX_GIT_DIFF_FILES = 100
 ; Arguments for command 'git gc', e.g. "--aggressive --auto"
 ; see more on http://git-scm.com/docs/git-gc/
 GC_ARGS =
+; Max number of commits which are fetched and shown
+; Set this to improve performance on large repositories
+MAX_GIT_COMMITS = 0
 
 ; Operation timeout in seconds
 [git.timeout]

--- a/models/release.go
+++ b/models/release.go
@@ -137,7 +137,7 @@ func createTag(gitRepo *git.Repository, rel *Release) error {
 
 		rel.Sha1 = commit.ID.String()
 		rel.CreatedUnix = util.TimeStamp(commit.Author.When.Unix())
-		rel.NumCommits, err = commit.CommitsCount()
+		rel.NumCommits, err = commit.CommitsCount(setting.Git.MaxGitCommits)
 		if err != nil {
 			return fmt.Errorf("CommitsCount: %v", err)
 		}

--- a/models/update.go
+++ b/models/update.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/git"
 	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 )
 
@@ -142,7 +143,7 @@ func pushUpdateAddTag(repo *Repository, gitRepo *git.Repository, tagName string)
 		createdAt = sig.When
 	}
 
-	commitsCount, err := commit.CommitsCount()
+	commitsCount, err := commit.CommitsCount(setting.Git.MaxGitCommits)
 	if err != nil {
 		return fmt.Errorf("CommitsCount: %v", err)
 	}

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -100,7 +100,7 @@ func (r *Repository) GetCommitsCount() (int64, error) {
 		contextName = r.CommitID
 	}
 	return cache.GetInt64(r.Repository.GetCommitsCountCacheKey(contextName, r.IsViewBranch || r.IsViewTag), func() (int64, error) {
-		return r.Commit.CommitsCount()
+		return r.Commit.CommitsCount(setting.Git.MaxGitCommits)
 	})
 }
 
@@ -370,6 +370,7 @@ func RepoAssignment() macaron.Handler {
 			ctx.Data["IsStaringRepo"] = models.IsStaring(ctx.User.ID, repo.ID)
 		}
 
+		ctx.Data["MaxGitCommits"] = setting.Git.MaxGitCommits
 		// repo is bare and display enable
 		if ctx.Repo.Repository.IsBare {
 			ctx.Data["BranchName"] = ctx.Repo.Repository.DefaultBranch

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -512,6 +512,7 @@ var (
 		MaxGitDiffLines          int
 		MaxGitDiffLineCharacters int
 		MaxGitDiffFiles          int
+		MaxGitCommits            int
 		GCArgs                   []string `delim:" "`
 		Timeout                  struct {
 			Migrate int
@@ -525,6 +526,7 @@ var (
 		MaxGitDiffLines:          1000,
 		MaxGitDiffLineCharacters: 5000,
 		MaxGitDiffFiles:          100,
+		MaxGitCommits:            0,
 		GCArgs:                   []string{},
 		Timeout: struct {
 			Migrate int

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -146,7 +146,7 @@ func FileHistory(ctx *context.Context) {
 	}
 
 	branchName := ctx.Repo.BranchName
-	commitsCount, err := ctx.Repo.GitRepo.FileCommitsCount(branchName, fileName)
+	commitsCount, err := ctx.Repo.GitRepo.FileCommitsCount(branchName, fileName, setting.Git.MaxGitCommits)
 	if err != nil {
 		ctx.ServerError("FileCommitsCount", err)
 		return

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -39,7 +39,7 @@ func calReleaseNumCommitsBehind(repoCtx *context.Repository, release *models.Rel
 			if err != nil {
 				return fmt.Errorf("GetBranchCommit: %v", err)
 			}
-			countCache[release.Target], err = commit.CommitsCount()
+			countCache[release.Target], err = commit.CommitsCount(setting.Git.MaxGitCommits)
 			if err != nil {
 				return fmt.Errorf("CommitsCount: %v", err)
 			}

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -2,7 +2,7 @@
 	<div class="ui two horizontal center link list">
 		{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsBareRepo)}}
 			<div class="item{{if .PageIsCommits}} active{{end}}">
-				<a href="{{.RepoLink}}/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}"><i class="octicon octicon-history"></i> <b>{{.CommitsCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
+				<a href="{{.RepoLink}}/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}"><i class="octicon octicon-history"></i> <b>{{.CommitsCount}}{{if eq .CommitsCount .MaxGitCommits}}+{{end}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
 			</div>
 		{{end}}
 		{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsBareRepo) }}

--- a/vendor/code.gitea.io/git/commit.go
+++ b/vendor/code.gitea.io/git/commit.go
@@ -161,9 +161,12 @@ func CommitChanges(repoPath string, opts CommitChangesOptions) error {
 	return err
 }
 
-func commitsCount(repoPath, revision, relpath string) (int64, error) {
+func commitsCount(repoPath, revision, relpath string, max int) (int64, error) {
 	var cmd *Command
 	cmd = NewCommand("rev-list", "--count")
+	if max > 0 {
+		cmd.AddArguments("--max-count", strconv.Itoa(max))
+	}
 	cmd.AddArguments(revision)
 	if len(relpath) > 0 {
 		cmd.AddArguments("--", relpath)
@@ -178,13 +181,13 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 }
 
 // CommitsCount returns number of total commits of until given revision.
-func CommitsCount(repoPath, revision string) (int64, error) {
-	return commitsCount(repoPath, revision, "")
+func CommitsCount(repoPath, revision string, max int) (int64, error) {
+	return commitsCount(repoPath, revision, "", max)
 }
 
 // CommitsCount returns number of total commits of until current revision.
-func (c *Commit) CommitsCount() (int64, error) {
-	return CommitsCount(c.repo.Path, c.ID.String())
+func (c *Commit) CommitsCount(max int) (int64, error) {
+	return CommitsCount(c.repo.Path, c.ID.String(), max)
 }
 
 // CommitsByRange returns the specific page commits before current revision, every page's number default by CommitsRangeSize

--- a/vendor/code.gitea.io/git/repo_commit.go
+++ b/vendor/code.gitea.io/git/repo_commit.go
@@ -235,8 +235,8 @@ func (repo *Repository) getFilesChanged(id1 string, id2 string) ([]string, error
 }
 
 // FileCommitsCount return the number of files at a revison
-func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
-	return commitsCount(repo.Path, revision, file)
+func (repo *Repository) FileCommitsCount(revision, file string, max int) (int64, error) {
+	return commitsCount(repo.Path, revision, file, max)
 }
 
 // CommitsByFileAndRange return the commits accroding revison file and the page
@@ -281,8 +281,8 @@ func (repo *Repository) CommitsBetweenIDs(last, before string) (*list.List, erro
 }
 
 // CommitsCountBetween return numbers of commits between two commits
-func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
-	return commitsCount(repo.Path, start+"..."+end, "")
+func (repo *Repository) CommitsCountBetween(start, end string, max int) (int64, error) {
+	return commitsCount(repo.Path, start+"..."+end, "", max)
 }
 
 // commitsBefore the limit is depth, not total number of returned commits.


### PR DESCRIPTION
added setting MaxGitCommits to improve performance on large repositories e.g. linux-git (targets embedded platforms) to limit the git commit count with --max-count