### PR TITLE
Fix bug when repo remained bare if multiple branches pushed in single push

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -537,12 +537,14 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 	}
 
 	refName := git.RefEndName(opts.RefFullName)
-	if repo.IsBare && refName != repo.DefaultBranch {
+
+	// Change default branch and bare status only if pushed ref is non-empty branch.
+	if repo.IsBare && opts.NewCommitID != git.EmptySHA && strings.HasPrefix(opts.RefFullName, git.BranchPrefix) {
 		repo.DefaultBranch = refName
+		repo.IsBare = false
 	}
 
 	// Change repository bare status and update last updated time.
-	repo.IsBare = repo.IsBare && opts.Commits.Len <= 0
 	if err = UpdateRepository(repo, false); err != nil {
 		return fmt.Errorf("UpdateRepository: %v", err)
 	}


### PR DESCRIPTION
Fixes #4919

Also closes #3704 (now it's impossible to un-bare repo with tag push)

Bug happened because CommitsBefore method was intended to use in webhooks only, but it was used to determine if pushed branch is not empty (has at least one commit). But in PR https://github.com/go-gitea/git/pull/88 it was changed to ignore commits that have multiple branches (to avoid pushing the same commits twice if other branch is created).

Now i just check this conditions to un-bare repo and set default branch to first pushed branch:
(1) repo is bare
(2) new branch is non-empty (idk if it's possible to push empty branch to bare repo, but extra cautions won't harm)
(3) branch is branch, not tag (which also affects default branch change and makes #3704 impossible too)
