### PR TITLE
Make sure to catch the right error so it is displayed on the UI

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -732,7 +732,7 @@ func AddDeployKey(repoID int64, name, content string, readOnly bool) (*DeployKey
 
 	key, err := addDeployKey(sess, pkey.ID, repoID, name, pkey.Fingerprint, accessMode)
 	if err != nil {
-		return nil, fmt.Errorf("addDeployKey: %v", err)
+		return nil, err
 	}
 
 	return key, sess.Commit()

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -586,7 +586,7 @@ func DeployKeysPost(ctx *context.Context, form auth.AddKeyForm) {
 	if err != nil {
 		ctx.Data["HasError"] = true
 		switch {
-		case models.IsErrKeyAlreadyExist(err):
+		case models.IsErrDeployKeyAlreadyExist(err):
 			ctx.Data["Err_Content"] = true
 			ctx.RenderWithErr(ctx.Tr("repo.settings.key_been_used"), tplDeployKeys, &form)
 		case models.IsErrKeyNameAlreadyUsed(err):


### PR DESCRIPTION
- Using `fmt.Errorf("addDeployKey: %v", err)` ___changes the error type___ and thus an error page is thrown since it doesn't match all expected cases...
- Also caught the right error ( `ErrDeployKeyAlreadyExist` ) instead of a regular ssh key error


<img width="1920" alt="screen shot 2018-09-16 at 10 24 04" src="https://user-images.githubusercontent.com/12677701/45594926-fa492580-b99a-11e8-9fb5-fa36db1fa45b.png">
