### PR TITLE
fix url in discord webhook

### DIFF
--- a/models/webhook_discord.go
+++ b/models/webhook_discord.go
@@ -213,6 +213,7 @@ func getDiscordPushPayload(p *api.PushPayload, meta *DiscordMeta) (*DiscordPaylo
 func getDiscordIssuesPayload(p *api.IssuePayload, meta *DiscordMeta) (*DiscordPayload, error) {
 	var text, title string
 	var color int
+	url := fmt.Sprintf("%s/issues/%d", p.Repository.HTMLURL, p.Issue.Index)
 	switch p.Action {
 	case api.HookIssueOpened:
 		title = fmt.Sprintf("[%s] Issue opened: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
@@ -268,7 +269,7 @@ func getDiscordIssuesPayload(p *api.IssuePayload, meta *DiscordMeta) (*DiscordPa
 			{
 				Title:       title,
 				Description: text,
-				URL:         p.Issue.URL,
+				URL:         url,
 				Color:       color,
 				Author: DiscordEmbedAuthor{
 					Name:    p.Sender.UserName,


### PR DESCRIPTION
opening issues generates a webhook to discord that contains
a url to the gitea api. the message title in discord is therefore
referencing to the api instead of the issue itself.

already on *release/v1.5* sorry for that (see https://github.com/go-gitea/gitea/pull/4951)