### PR TITLE
Fix null pointer dereference in ParseCommitWithSignature

### DIFF
--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -360,7 +360,7 @@ func verifySign(s *packet.Signature, h hash.Hash, k *GPGKey) error {
 
 // ParseCommitWithSignature check if signature is good against keystore.
 func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
-	if c.Signature != nil {
+	if c.Signature != nil && c.Committer != nil {
 		//Parsing signature
 		sig, err := extractSignature(c.Signature.Signature)
 		if err != nil { //Skipping failed to extract sign


### PR DESCRIPTION
Fixes #4961

Explanation: tag commits do not have 'author' and 'committer', they have 'tagger' field (which is treated as 'author' in vendor/code.gitea.io/git/repo_commit.go:68) and committer is simply nil.

But ParseCommitWithSignature thinked if signature is set - then committer is set too. So now it just skips checking signature if no committer is set.

Probably repo_commit.go from vendor git module should set 'tagger' to both 'author' and 'committer' fields, I have no idea what behaviour is correct (addressed here: go-gitea/git#129 )

Or maybe ParseCommitWithSignature should check signature against both Author and Committer and return true if any one of them is correct.

Now I just check against null pointer to solve panic issue.