### PR TITLE
Add missing envionment vars for DB with Docker

### DIFF
--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -105,6 +105,11 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
++      - DB_TYPE=mysql
++      - DB_HOST=db:3306
++      - DB_NAME=gitea
++      - DB_USER=gitea
++      - DB_PASSWD=gitea
     restart: always
     networks:
       - gitea
@@ -148,6 +153,11 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
++      - DB_TYPE=postgres
++      - DB_HOST=db:5432
++      - DB_NAME=gitea
++      - DB_USER=gitea
++      - DB_PASSWD=gitea
     restart: always
     networks:
       - gitea


### PR DESCRIPTION
Current docs demonstrate how to configure a database container but don't explicitly specify that you should add additional environment variables to the Gitea container to make it use the database. This just demonstrates the changes required.
