### PR TITLE
Fix images in Wiki repo not showing in Gitea Wiki (#4690)

### DIFF
--- a/models/wiki.go
+++ b/models/wiki.go
@@ -42,6 +42,12 @@ func WikiNameToFilename(name string) string {
 	return url.QueryEscape(name) + ".md"
 }
 
+// WikiNameToFilename converts a wiki name to its corresponding raw filename.
+func WikiNameToFilenameRaw(name string) string {
+	name = strings.Replace(name, " ", "-", -1)
+	return url.QueryEscape(name) 
+}
+
 // WikiFilenameToName converts a wiki filename to its corresponding page name.
 func WikiFilenameToName(filename string) (string, error) {
 	if !strings.HasSuffix(filename, ".md") {

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -294,7 +294,7 @@ func WikiRaw(ctx *context.Context) {
 	if strings.HasSuffix(providedPath, ".md") {
 		providedPath = providedPath[:len(providedPath)-3]
 	}
-	wikiPath := models.WikiNameToFilename(providedPath)
+	wikiPath := models.WikiNameToFilenameRaw(providedPath)
 	var entry *git.TreeEntry
 	if commit != nil {
 		entry, err = findEntryForFile(commit, wikiPath)


### PR DESCRIPTION
wikiRaw method in routers calls WikiNameToFilename which unconditionally adds ".md" to the path.
As a result, findEntryForFile will fail finding the corresponding git blob.
I added WikiNameToFilenameRaw to the model used in wikiRaw which omits any additions to the filename.

Signed-off-by: Matthias Wientapper <m.wientapper@gmx.de>
