### PR TITLE
Fix missing AppSubUrl in few more templates (fixup)

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -34,7 +34,7 @@
 					<div class="ui fluid multiple search selection dropdown">
 						<input type="hidden" name="topics" value="{{range $i, $v := .Topics}}{{.Name}}{{if lt (Add $i 1) (len $.Topics)}},{{end}}{{end}}">
 						{{range .Topics}}
-						<a class="ui green basic label topic transition visible" data-value="{{.Name}}" style="display: inline-block !important;" href="/explore/repos?q={{.Name}}&topic=1">{{.Name}}<i class="delete icon"></i></a>
+						<a class="ui green basic label topic transition visible" data-value="{{.Name}}" style="display: inline-block !important;" href="{{AppSubUrl}}/explore/repos?q={{.Name}}&topic=1">{{.Name}}<i class="delete icon"></i></a>
 						{{end}}
 						<div class="text"></div>
 					</div>

--- a/templates/user/auth/u2f.tmpl
+++ b/templates/user/auth/u2f.tmpl
@@ -13,7 +13,7 @@
 			</div>
 			<div id="wait-for-key" class="ui attached segment"><div class="ui active indeterminate inline loader"></div> {{.i18n.Tr "u2f_press_button"}} </div>
 			<div class="ui attached segment">
-				<a href="/user/two_factor">{{.i18n.Tr "u2f_use_twofa"}}</a>
+				<a href="{{AppSubUrl}}/user/two_factor">{{.i18n.Tr "u2f_use_twofa"}}</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
In addition to PR #5020, searched all templates for href and src attributes with URLs that are not starting with variable (like {{AppSubUrl}} or {{.RepoLink}}) and found few more.

Fixed them, but old PR was merged so I made new PR.
Sorry for hurrying up and sending incomplete fix previous time.