### PR TITLE
Remove links from topics in edit mode 

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -34,7 +34,7 @@
 					<div class="ui fluid multiple search selection dropdown">
 						<input type="hidden" name="topics" value="{{range $i, $v := .Topics}}{{.Name}}{{if lt (Add $i 1) (len $.Topics)}},{{end}}{{end}}">
 						{{range .Topics}}
-						<a class="ui green basic label topic transition visible" data-value="{{.Name}}" style="display: inline-block !important;" href="{{AppSubUrl}}/explore/repos?q={{.Name}}&topic=1">{{.Name}}<i class="delete icon"></i></a>
+						<div class="ui green basic label topic transition visible" data-value="{{.Name}}" style="display: inline-block !important; cursor: default;">{{.Name}}<i class="delete icon"></i></div>
 						{{end}}
 						<div class="text"></div>
 					</div>


### PR DESCRIPTION
Fixes #4992

Now topic labels are not clickable in edit mode (previously they redirected to search page even when clicking close button next to them, now they don't)