### PR TITLE
allow current user to reset their own password

### DIFF
--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -254,6 +254,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 
 	// ***** START: User *****
 	m.Group("/user", func() {
+		m.Get("/reset_password", user.ResetPasswd)
+		m.Post("/reset_password", user.ResetPasswdPost)
+	})
+	m.Group("/user", func() {
 		m.Get("/login", user.SignIn)
 		m.Post("/login", bindIgnErr(auth.SignInForm{}), user.SignInPost)
 		m.Group("", func() {
@@ -273,8 +277,6 @@ func RegisterRoutes(m *macaron.Macaron) {
 		}, openIDSignInEnabled)
 		m.Get("/sign_up", user.SignUp)
 		m.Post("/sign_up", bindIgnErr(auth.RegisterForm{}), user.SignUpPost)
-		m.Get("/reset_password", user.ResetPasswd)
-		m.Post("/reset_password", user.ResetPasswdPost)
 		m.Group("/oauth2", func() {
 			m.Get("/:provider", user.SignInOAuth)
 			m.Get("/:provider/callback", user.SignInOAuthCallback)


### PR DESCRIPTION
Re: https://github.com/go-gitea/gitea/issues/5008

The current logged-in user (which may have signed in via OAuth) is not able to reset their own password via email reset, because they cannot access the form.

* [x] Users can get to reset form logged in and logged out
* [x] Can attempt to reset password without being logged out
* [x] If password reset will be successful, user is logged out (and is redirected to login)

Beyond fixing the bug, these are some things I'd be open to adding now (but would prefer to wait until after this clears)

* [ ] show username / email of user
  * [ ] take some action if that's different from the current user?
* [ ] treat reset password form the same as register & sign in (remember me, retype password)
* [ ] invalidate the code once used
* [ ] set time to 15 minutes rather than 3 hours