### PR TITLE
Add Google Analytics config option

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -94,6 +94,9 @@ var (
 	AppDataPath    string
 	AppWorkPath    string
 
+	// User settings
+	GoogleAnalyticsID string
+
 	// Server settings
 	Protocol             Scheme
 	Domain               string
@@ -724,6 +727,7 @@ func NewContext() {
 
 	sec := Cfg.Section("server")
 	AppName = Cfg.Section("").Key("APP_NAME").MustString("Gitea: Git with a cup of tea")
+	GoogleAnalyticsID = Cfg.Section("").Key("GOOGLE_ANALYTICS_ID").String()
 
 	Protocol = HTTP
 	if sec.Key("PROTOCOL").String() == "https" {

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -61,6 +61,9 @@ func NewFuncMap() []template.FuncMap {
 		"DisableGravatar": func() bool {
 			return setting.DisableGravatar
 		},
+		"GoogleAnalyticsID": func() string {
+			return setting.GoogleAnalyticsID
+		},
 		"ShowFooterTemplateLoadTime": func() bool {
 			return setting.ShowFooterTemplateLoadTime
 		},

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -105,6 +105,17 @@
 
 	<script src="{{AppSubUrl}}/vendor/plugins/cssrelpreload/loadCSS.min.js"></script>
 	<script src="{{AppSubUrl}}/vendor/plugins/cssrelpreload/cssrelpreload.min.js"></script>
+{{if .GoogleAnalyticsID}}
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{.GoogleAnalyticsID}}"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', '{{GoogleAnalyticsID}}');
+	</script>
+{{end}}
 {{if .PageIsUserProfile}}
 	<meta property="og:title" content="{{.Owner.Name}}" />
 	<meta property="og:type" content="profile" />


### PR DESCRIPTION
Adds the option `GOOGLE_ANALYTICS_ID` which puts the GA script tag into the `head.tmpl` so that a person can see metrics about their projects.

This would be of value to branded projects, such as Gitea itself (once moved to Gitea).

The ability to track analytics is something I personally see as a core benefit to having a personal git platform.