### PR TITLE
only chown directories during docker setup if necessary. Fix #4425

### DIFF
--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -39,5 +39,8 @@ if [ ! -f /data/gitea/conf/app.ini ]; then
     envsubst < /etc/templates/app.ini > /data/gitea/conf/app.ini
 fi
 
-chown -R ${USER}:git /data/gitea /app/gitea /data/git
+# only chown if current owner is not already the gitea ${USER}. No recursive check to save time
+if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/gitea; fi
+if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi
+if ! [[ $(ls -ld /data/git   | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/git;   fi
 chmod 0755 /data/gitea /app/gitea /data/git


### PR DESCRIPTION
This PR fixes issue #4425 .
Instead of blindly running `chown` during setup, we check that the directory is not already owned by the correct user. Currently the check is non-recursive for speed (only checks the ownership of top-level directory).
