### PR TITLE
Fix dep for actual goth version used in dep lock file

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@ ignored = ["google.golang.org/appengine*"]
 
 [[constraint]]
   name = "github.com/markbates/goth"
-  version = "1.45.5"
+  version = "1.46.1"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Fixes #5077 

Fixes just Gopkg.toml as lock file already has this version.