### PR TITLE
Fix home page template regression

### DIFF
--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -7,7 +7,7 @@
 			</div>
 			<div class="hero">
 				<h1 class="ui icon header title">
-					{{.i18n.Tr "app_name"}}
+					{{AppName}}
 				</h1>
 				<h2>{{.i18n.Tr "app_desc"}}</h2>
 			</div>


### PR DESCRIPTION
Commit 7bb4d610e5cca7ad514e377d2b36254a4cfee5b9 tries to take the app_name from the locale, however, it is a user defined setting. This causes the app name to simply display as `app_name` instead of the correct value.

templates/helper.go automatically injects the AppName variable into every template, so we can safely use that instead.

Right now, the home page looks like this: https://i.imgur.com/aZKaotf.png