### PR TITLE
Use named const instead of a raw string

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+
 	// Needed for jpeg support
 	_ "image/jpeg"
 	"image/png"
@@ -1387,7 +1388,7 @@ func SearchUsers(opts *SearchUserOptions) (users []*User, _ int64, _ error) {
 		opts.Page = 1
 	}
 	if len(opts.OrderBy) == 0 {
-		opts.OrderBy = "name ASC"
+		opts.OrderBy = SearchOrderByAlphabetically
 	}
 
 	users = make([]*User, 0, opts.PageSize)


### PR DESCRIPTION
Found by go-critic.

Log:
```
models/user.go:1390:18 namedConst use SearchOrderByAlphabetically instead of "name ASC"
```