### PR TITLE
Make switch more clear

### DIFF
--- a/models/review.go
+++ b/models/review.go
@@ -38,12 +38,11 @@ func (rt ReviewType) Icon() string {
 		return "eye"
 	case ReviewTypeReject:
 		return "x"
+	case ReviewTypeComment, ReviewTypeUnknown:
+		return "comment"
 	default:
-	case ReviewTypeComment:
-	case ReviewTypeUnknown:
 		return "comment"
 	}
-	return "comment"
 }
 
 // Review represents collection of code comments giving feedback for a PR


### PR DESCRIPTION
Found by go-critic `defaultCaseOrder` checker

Log:
```
models/review.go:41:2 defaultCaseOrder consider to make `default` case as first or as last case
```