### PR TITLE
Remove duplicated if bodies

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+
 	// Needed for jpeg support
 	_ "image/jpeg"
 	"image/png"
@@ -377,12 +378,8 @@ func (u *User) GetFollowers(page int) ([]*User, error) {
 	users := make([]*User, 0, ItemsPerPage)
 	sess := x.
 		Limit(ItemsPerPage, (page-1)*ItemsPerPage).
-		Where("follow.follow_id=?", u.ID)
-	if setting.UsePostgreSQL {
-		sess = sess.Join("LEFT", "follow", "`user`.id=follow.user_id")
-	} else {
-		sess = sess.Join("LEFT", "follow", "`user`.id=follow.user_id")
-	}
+		Where("follow.follow_id=?", u.ID).
+		Join("LEFT", "follow", "`user`.id=follow.user_id")
 	return users, sess.Find(&users)
 }
 
@@ -396,12 +393,8 @@ func (u *User) GetFollowing(page int) ([]*User, error) {
 	users := make([]*User, 0, ItemsPerPage)
 	sess := x.
 		Limit(ItemsPerPage, (page-1)*ItemsPerPage).
-		Where("follow.user_id=?", u.ID)
-	if setting.UsePostgreSQL {
-		sess = sess.Join("LEFT", "follow", "`user`.id=follow.follow_id")
-	} else {
-		sess = sess.Join("LEFT", "follow", "`user`.id=follow.follow_id")
-	}
+		Where("follow.user_id=?", u.ID).
+		Join("LEFT", "follow", "`user`.id=follow.follow_id")
 	return users, sess.Find(&users)
 }
 


### PR DESCRIPTION
Found by go-critic `dupBranchBody` checker. 

Possibly a bug? Maybe we should use different queries for different databases?

Log
```
models/user.go:381:2 dupBranchBody both branches in if statement has same body
models/user.go:400:2 dupBranchBody both branches in if statement has same body
```