### PR TITLE
Use type switch

### DIFF
--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -441,41 +441,41 @@ func Subtract(left interface{}, right interface{}) interface{} {
 	var rleft, rright int64
 	var fleft, fright float64
 	var isInt = true
-	switch left.(type) {
+	switch left := left.(type) {
 	case int:
-		rleft = int64(left.(int))
+		rleft = int64(left)
 	case int8:
-		rleft = int64(left.(int8))
+		rleft = int64(left)
 	case int16:
-		rleft = int64(left.(int16))
+		rleft = int64(left)
 	case int32:
-		rleft = int64(left.(int32))
+		rleft = int64(left)
 	case int64:
-		rleft = left.(int64)
+		rleft = left
 	case float32:
-		fleft = float64(left.(float32))
+		fleft = float64(left)
 		isInt = false
 	case float64:
-		fleft = left.(float64)
+		fleft = left
 		isInt = false
 	}
 
-	switch right.(type) {
+	switch right := right.(type) {
 	case int:
-		rright = int64(right.(int))
+		rright = int64(right)
 	case int8:
-		rright = int64(right.(int8))
+		rright = int64(right)
 	case int16:
-		rright = int64(right.(int16))
+		rright = int64(right)
 	case int32:
-		rright = int64(right.(int32))
+		rright = int64(right)
 	case int64:
-		rright = right.(int64)
+		rright = right
 	case float32:
-		fright = float64(right.(float32))
+		fright = float64(right)
 		isInt = false
 	case float64:
-		fright = right.(float64)
+		fright = right
 		isInt = false
 	}
 

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -299,21 +299,21 @@ func TestFileSize(t *testing.T) {
 
 func TestSubtract(t *testing.T) {
 	toFloat64 := func(n interface{}) float64 {
-		switch n.(type) {
+		switch n := n.(type) {
 		case int:
-			return float64(n.(int))
+			return float64(n)
 		case int8:
-			return float64(n.(int8))
+			return float64(n)
 		case int16:
-			return float64(n.(int16))
+			return float64(n)
 		case int32:
-			return float64(n.(int32))
+			return float64(n)
 		case int64:
-			return float64(n.(int64))
+			return float64(n)
 		case float32:
-			return float64(n.(float32))
+			return float64(n)
 		case float64:
-			return n.(float64)
+			return n
 		default:
 			return 0.0
 		}


### PR DESCRIPTION
Found by go-critic typeSwitchVar checker

Log
```
modules/base/tool.go:444:2 typeSwitchVar case 0 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 1 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 2 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 3 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 4 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 5 can benefit from type switch with assignment
modules/base/tool.go:444:2 typeSwitchVar case 6 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 0 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 1 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 2 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 3 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 4 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 5 can benefit from type switch with assignment
modules/base/tool.go:463:2 typeSwitchVar case 6 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 0 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 1 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 2 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 3 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 4 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 5 can benefit from type switch with assignment
modules/base/tool_test.go:302:3 typeSwitchVar case 6 can benefit from type switch with assignment
```