### PR TITLE
Add LFS timeout issue to troubleshooting doc

### DIFF
--- a/docs/content/doc/help/troubleshooting.en-us.md
+++ b/docs/content/doc/help/troubleshooting.en-us.md
@@ -80,3 +80,17 @@ To migrate an repository *with* all tags you need to do two things
  ```
  gitea admin repo-sync-releases
  ```
+
+## LFS Issues
+
+For issues concerning LFS data upload
+
+```
+batch response: Authentication required: Authorization error: <GITEA_LFS_URL>/info/lfs/objects/batch                                                                                                              
+Check that you have proper access to the repository
+error: failed to push some refs to '<GIT_REPO_URL>'
+```
+Have you checked the value of `LFS_HTTP_AUTH_EXPIRY` in your `app.ini` file? By default your LFS token will expire after 20 minutes. If you have a slow connection or a large file (or both) it may not finish uploading within the time limit. 
+
+You may want to set this value to `60m` or `120m`.
+


### PR DESCRIPTION
I ran into an issue where the default value of `LFS_HTTP_AUTH_EXPIRY` was too low and my auth token kept expiring before my file was uploaded. I couldn't find any docs on this error message so I've added a short description to the Troubleshooting page.

I don't know if it's reasonable to increase the default value of this configuration variable to 60 minutes or 120 minutes so that poor souls with slow internet connections don't have this issue?