### PR TITLE
Increase the retry limit to 20 times and the interval to 200ms

### DIFF
--- a/models/test_fixtures.go
+++ b/models/test_fixtures.go
@@ -5,6 +5,9 @@
 package models
 
 import (
+	"fmt"
+	"time"
+
 	"gopkg.in/testfixtures.v2"
 )
 
@@ -21,12 +24,16 @@ func InitFixtures(helper testfixtures.Helper, dir string) (err error) {
 func LoadFixtures() error {
 	var err error
 	// Database transaction conflicts could occur and result in ROLLBACK
-	// As a simple workaround, we just retry 5 times.
-	for i := 0; i < 5; i++ {
+	// As a simple workaround, we just retry 20 times.
+	for i := 0; i < 20; i++ {
 		err = fixtures.Load()
 		if err == nil {
 			break
 		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if err != nil {
+		fmt.Printf("LoadFixtures failed after retries: %v\n", err)
 	}
 	return err
 }


### PR DESCRIPTION
The original settings have less tolerance and would fail in some environments.

Fixes the test failure in https://github.com/go-gitea/gitea/pull/5133 
