### PR TITLE
Fix SQL quoting

### DIFF
--- a/models/user_openid.go
+++ b/models/user_openid.go
@@ -93,7 +93,7 @@ func DeleteUserOpenID(openid *UserOpenID) (err error) {
 
 // ToggleUserOpenIDVisibility toggles visibility of an openid address of given user.
 func ToggleUserOpenIDVisibility(id int64) (err error) {
-	_, err = x.Exec("update user_open_id set show = not show where id = ?", id)
+	_, err = x.Exec("update `user_open_id` set `show` = not `show` where `id` = ?", id)
 	return err
 }
 


### PR DESCRIPTION
Backport of #5117.

`show` is keyword in MySQL and has to be quoted to reference a column name. Use grave accents (ASCII code 96) for quoting to match rest of the source code. It's non-standard SQL, but it's supported by SQLite and MySQL.