### PR TITLE
Set heatmap color range configurable

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -85,6 +85,8 @@ MAX_DISPLAY_FILE_SIZE = 8388608
 SHOW_USER_EMAIL = true
 ; Set the default theme for the Gitea install
 DEFAULT_THEME = gitea
+; Set the color range to use for heatmap (default to `['#f4f4f4', '#459928']` but can use `['#2d303b', '#80bb46']` with the theme `arc-green`)
+HEATMAP_COLOR_RANGE = `['#f4f4f4', '#459928']`
 
 [ui.admin]
 ; Number of users that are displayed on one page

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -300,6 +300,7 @@ var (
 		MaxDisplayFileSize  int64
 		ShowUserEmail       bool
 		DefaultTheme        string
+		HeatmapColorRange   string
 
 		Admin struct {
 			UserPagingNum   int
@@ -326,6 +327,7 @@ var (
 		ThemeColorMetaTag:   `#6cc644`,
 		MaxDisplayFileSize:  8388608,
 		DefaultTheme:        `gitea`,
+		HeatmapColorRange:   `['#f4f4f4', '#459928']`,
 		Admin: struct {
 			UserPagingNum   int
 			RepoPagingNum   int

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -193,6 +193,9 @@ func NewFuncMap() []template.FuncMap {
 		"DefaultTheme": func() string {
 			return setting.UI.DefaultTheme
 		},
+		"HeatmapColorRange": func() string {
+			return setting.UI.HeatmapColorRange
+		},
 		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values) == 0 {
 				return nil, errors.New("invalid dict call")

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -65,7 +65,7 @@
 			var heatmap = calendarHeatmap()
 				.data(chartData)
 				.selector('#user-heatmap')
-				.colorRange(['#f4f4f4', '#459928'])
+				.colorRange({{SafeJS HeatmapColorRange}})
 				.tooltipEnabled(true);
 			heatmap();
 		});


### PR DESCRIPTION
Should fix #5164 by allowing the customization of the color range along theming

Suggestion to use with arc-green theme : `['#2d303b', '#80bb46']` 
![image](https://user-images.githubusercontent.com/4052400/47437494-0057d080-d7a9-11e8-9f16-5c4697b606bd.png)
