### PR TITLE
fix: Add secret to all webhook's payload where it has been missing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,11 +11,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5e7f14543006a44047fb1d0df16da08b2ebc2428f1fd53bd8af26a2b34928b11"
+  digest = "1:bf4f822f636b99ac7d4f8fa5210a7439bacaf8d1f15d5783956bdd5dd2069bdc"
   name = "code.gitea.io/sdk"
   packages = ["gitea"]
   pruneopts = "NUT"
-  revision = "021567c9c12fe289b8980c34e81e6684434dd082"
+  revision = "11c860c8e49a23be26e6d6c6a039a46ad2ae1d27"
 
 [[projects]]
   digest = "1:3fcef06a1a6561955c94af6c7757a6fa37605eb653f0d06ab960e5bb80092195"

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -6198,6 +6198,10 @@
           "format": "date-time",
           "x-go-name": "Created"
         },
+        "fingerprint": {
+          "type": "string",
+          "x-go-name": "Fingerprint"
+        },
         "id": {
           "type": "integer",
           "format": "int64",
@@ -6207,9 +6211,17 @@
           "type": "string",
           "x-go-name": "Key"
         },
+        "key_id": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "KeyID"
+        },
         "read_only": {
           "type": "boolean",
           "x-go-name": "ReadOnly"
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository"
         },
         "title": {
           "type": "string",
@@ -7092,6 +7104,14 @@
           "type": "string",
           "x-go-name": "Key"
         },
+        "key_type": {
+          "type": "string",
+          "x-go-name": "KeyType"
+        },
+        "read_only": {
+          "type": "boolean",
+          "x-go-name": "ReadOnly"
+        },
         "title": {
           "type": "string",
           "x-go-name": "Title"
@@ -7099,6 +7119,9 @@
         "url": {
           "type": "string",
           "x-go-name": "URL"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
         }
       },
       "x-go-package": "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
@@ -7313,6 +7336,10 @@
       "description": "Repository represents a repository",
       "type": "object",
       "properties": {
+        "archived": {
+          "type": "boolean",
+          "x-go-name": "Archived"
+        },
         "clone_url": {
           "type": "string",
           "x-go-name": "CloneURL"

--- a/vendor/code.gitea.io/sdk/gitea/admin_user.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_user.go
@@ -42,17 +42,17 @@ type EditUserOption struct {
 	FullName  string `json:"full_name" binding:"MaxSize(100)"`
 	// required: true
 	// swagger:strfmt email
-	Email            string `json:"email" binding:"Required;Email;MaxSize(254)"`
-	Password         string `json:"password" binding:"MaxSize(255)"`
-	Website          string `json:"website" binding:"MaxSize(50)"`
-	Location         string `json:"location" binding:"MaxSize(50)"`
-	Active           *bool  `json:"active"`
-	Admin            *bool  `json:"admin"`
-	AllowGitHook     *bool  `json:"allow_git_hook"`
-	AllowImportLocal *bool  `json:"allow_import_local"`
-	MaxRepoCreation  *int   `json:"max_repo_creation"`
-	ProhibitLogin    *bool  `json:"prohibit_login"`
-	AllowCreateOrganization *bool `json:"allow_create_organization"`
+	Email                   string `json:"email" binding:"Required;Email;MaxSize(254)"`
+	Password                string `json:"password" binding:"MaxSize(255)"`
+	Website                 string `json:"website" binding:"MaxSize(50)"`
+	Location                string `json:"location" binding:"MaxSize(50)"`
+	Active                  *bool  `json:"active"`
+	Admin                   *bool  `json:"admin"`
+	AllowGitHook            *bool  `json:"allow_git_hook"`
+	AllowImportLocal        *bool  `json:"allow_import_local"`
+	MaxRepoCreation         *int   `json:"max_repo_creation"`
+	ProhibitLogin           *bool  `json:"prohibit_login"`
+	AllowCreateOrganization *bool  `json:"allow_create_organization"`
 }
 
 // AdminEditUser modify user informations

--- a/vendor/code.gitea.io/sdk/gitea/hook.go
+++ b/vendor/code.gitea.io/sdk/gitea/hook.go
@@ -199,7 +199,7 @@ type CreatePayload struct {
 	Sender  *User       `json:"sender"`
 }
 
-// SetSecret FIXME
+// SetSecret modifies the secret of the CreatePayload
 func (p *CreatePayload) SetSecret(secret string) {
 	p.Secret = secret
 }
@@ -246,6 +246,7 @@ const (
 
 // DeletePayload represents delete payload
 type DeletePayload struct {
+	Secret     string      `json:"secret"`
 	Ref        string      `json:"ref"`
 	RefType    string      `json:"ref_type"`
 	PusherType PusherType  `json:"pusher_type"`
@@ -253,8 +254,9 @@ type DeletePayload struct {
 	Sender     *User       `json:"sender"`
 }
 
-// SetSecret implements Payload
+// SetSecret modifies the secret of the DeletePayload
 func (p *DeletePayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload implements Payload
@@ -271,13 +273,15 @@ func (p *DeletePayload) JSONPayload() ([]byte, error) {
 
 // ForkPayload represents fork payload
 type ForkPayload struct {
+	Secret string      `json:"secret"`
 	Forkee *Repository `json:"forkee"`
 	Repo   *Repository `json:"repository"`
 	Sender *User       `json:"sender"`
 }
 
-// SetSecret implements Payload
+// SetSecret modifies the secret of the ForkPayload
 func (p *ForkPayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload implements Payload
@@ -297,6 +301,7 @@ const (
 
 // IssueCommentPayload represents a payload information of issue comment event.
 type IssueCommentPayload struct {
+	Secret     string                 `json:"secret"`
 	Action     HookIssueCommentAction `json:"action"`
 	Issue      *Issue                 `json:"issue"`
 	Comment    *Comment               `json:"comment"`
@@ -305,8 +310,9 @@ type IssueCommentPayload struct {
 	Sender     *User                  `json:"sender"`
 }
 
-// SetSecret implements Payload
+// SetSecret modifies the secret of the IssueCommentPayload
 func (p *IssueCommentPayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload implements Payload
@@ -333,14 +339,16 @@ const (
 
 // ReleasePayload represents a payload information of release event.
 type ReleasePayload struct {
+	Secret     string            `json:"secret"`
 	Action     HookReleaseAction `json:"action"`
 	Release    *Release          `json:"release"`
 	Repository *Repository       `json:"repository"`
 	Sender     *User             `json:"sender"`
 }
 
-// SetSecret implements Payload
+// SetSecret modifies the secret of the ReleasePayload
 func (p *ReleasePayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload implements Payload
@@ -368,7 +376,7 @@ type PushPayload struct {
 	Sender     *User            `json:"sender"`
 }
 
-// SetSecret FIXME
+// SetSecret modifies the secret of the PushPayload
 func (p *PushPayload) SetSecret(secret string) {
 	p.Secret = secret
 }
@@ -520,7 +528,7 @@ type RepositoryPayload struct {
 	Sender       *User          `json:"sender"`
 }
 
-// SetSecret set the payload's secret
+// SetSecret modifies the secret of the RepositoryPayload
 func (p *RepositoryPayload) SetSecret(secret string) {
 	p.Secret = secret
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue.go
@@ -152,3 +152,9 @@ type IssueDeadline struct {
 	// swagger:strfmt date-time
 	Deadline *time.Time `json:"due_date"`
 }
+
+// EditPriorityOption options for updating priority
+type EditPriorityOption struct {
+	// required:true
+	Priority int `json:"priority"`
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo.go
@@ -40,6 +40,7 @@ type Repository struct {
 	Watchers      int         `json:"watchers_count"`
 	OpenIssues    int         `json:"open_issues_count"`
 	DefaultBranch string      `json:"default_branch"`
+	Archived      bool        `json:"archived"`
 	// swagger:strfmt date-time
 	Created time.Time `json:"created_at"`
 	// swagger:strfmt date-time

--- a/vendor/code.gitea.io/sdk/gitea/repo_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_key.go
@@ -13,13 +13,16 @@ import (
 
 // DeployKey a deploy key
 type DeployKey struct {
-	ID    int64  `json:"id"`
-	Key   string `json:"key"`
-	URL   string `json:"url"`
-	Title string `json:"title"`
+	ID          int64  `json:"id"`
+	KeyID       int64  `json:"key_id"`
+	Key         string `json:"key"`
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Fingerprint string `json:"fingerprint"`
 	// swagger:strfmt date-time
-	Created  time.Time `json:"created_at"`
-	ReadOnly bool      `json:"read_only"`
+	Created    time.Time   `json:"created_at"`
+	ReadOnly   bool        `json:"read_only"`
+	Repository *Repository `json:"repository,omitempty"`
 }
 
 // ListDeployKeys list all the deploy keys of one repository

--- a/vendor/code.gitea.io/sdk/gitea/user_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_key.go
@@ -19,7 +19,10 @@ type PublicKey struct {
 	Title       string `json:"title,omitempty"`
 	Fingerprint string `json:"fingerprint,omitempty"`
 	// swagger:strfmt date-time
-	Created time.Time `json:"created_at,omitempty"`
+	Created  time.Time `json:"created_at,omitempty"`
+	Owner    *User     `json:"user,omitempty"`
+	ReadOnly bool      `json:"read_only,omitempty"`
+	KeyType  string    `json:"key_type,omitempty"`
 }
 
 // ListPublicKeys list all the public keys of the user


### PR DESCRIPTION
* Updated dependency manager via `dep ensure -update code.gitea.io/sdk`
* Gopkg.toml was not changed as sdk version is set to "master"
* affects webhooks for: Delete, Fork, IssueComment, Release
* also contains changes from go-gitea/go-sdk#125 and hence a swagger update

Signed-off-by: Berengar W. Lehr <Berengar.Lehr@kompetenztest.de>
Resolves: #4732, #5173