### PR TITLE
Serve audio files using HTML5 audio tag

### DIFF
--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -576,6 +576,11 @@ func IsVideoFile(data []byte) bool {
 	return strings.Index(http.DetectContentType(data), "video/") != -1
 }
 
+// IsAudioFile detects if data is an video format
+func IsAudioFile(data []byte) bool {
+	return strings.Index(http.DetectContentType(data), "audio/") != -1
+}
+
 // EntryIcon returns the octicon class for displaying files/directories
 func EntryIcon(entry *git.TreeEntry) string {
 	switch {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -592,6 +592,7 @@ file_view_raw = View Raw
 file_permalink = Permalink
 file_too_large = The file is too large to be shown.
 video_not_supported_in_browser = Your browser does not support the HTML5 'video' tag.
+audio_not_supported_in_browser = Your browser does not support the HTML5 'audio' tag.
 stored_lfs = Stored with Git LFS
 commit_graph = Commit Graph
 

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -264,6 +264,8 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 		ctx.Data["IsPDFFile"] = true
 	case base.IsVideoFile(buf):
 		ctx.Data["IsVideoFile"] = true
+	case base.IsAudioFile(buf):
+		ctx.Data["IsAudioFile"] = true
 	case base.IsImageFile(buf):
 		ctx.Data["IsImageFile"] = true
 	}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -55,6 +55,11 @@
 						<video controls src="{{EscapePound $.RawFileLink}}">
 							<strong>{{.i18n.Tr "repo.video_not_supported_in_browser"}}</strong>
 						</video>
+						<img src="{{EscapePound $.RawFileLink}}">
+					{{else if .IsAudioFile}}
+						<audio controls src="{{EscapePound $.RawFileLink}}">
+							<strong>{{.i18n.Tr "repo.audio_not_supported_in_browser"}}</strong>
+						</audio>
 					{{else if .IsPDFFile}}
 						<iframe width="100%" height="600px" src="{{AppSubUrl}}/vendor/plugins/pdfjs/web/viewer.html?file={{EscapePound $.RawFileLink}}"></iframe>
 					{{else}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -55,7 +55,6 @@
 						<video controls src="{{EscapePound $.RawFileLink}}">
 							<strong>{{.i18n.Tr "repo.video_not_supported_in_browser"}}</strong>
 						</video>
-						<img src="{{EscapePound $.RawFileLink}}">
 					{{else if .IsAudioFile}}
 						<audio controls src="{{EscapePound $.RawFileLink}}">
 							<strong>{{.i18n.Tr "repo.audio_not_supported_in_browser"}}</strong>


### PR DESCRIPTION
Similar to how Gitea shows video files using HTML this enables audio files.

Closes https://github.com/go-gitea/gitea/issues/5206

Ref: https://github.com/go-gitea/gitea/pull/418