### PR TITLE
Update API link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ More info: https://docs.gitea.io/en-us/install-from-source/
     ./gitea web
 
 NOTE: If you're interested in using our APIs, we have experimental
-support with [documentation](https://godoc.org/code.gitea.io/sdk/gitea).
+support with [documentation](https://try.gitea.io/api/swagger).
 
 ## Contributing
 


### PR DESCRIPTION
Link to API documentation is broken in the README (https://godoc.org/code.gitea.io/sdk/gitea). Add link to https://try.gitea.io/api/swagger instead