### PR TITLE
fix: Accept web-command cli flags if web-command is commited

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ arguments - which can alternatively be run by running the subcommand web.`
 		cmd.CmdAdmin,
 		cmd.CmdGenerate,
 	}
-	app.Flags = append(app.Flags, []cli.Flag{}...)
+	app.Flags = append(app.Flags, cmd.CmdWeb.Flags...)
 	app.Action = cmd.CmdWeb.Action
 	err := app.Run(os.Args)
 	if err != nil {


### PR DESCRIPTION
* Added flags of default cmd CmdWeb to app-wide flags
* If command *is* specified app-wide flags are ignored

Backport of #5200
Signed-off-by: Berengar W. Lehr <Berengar.Lehr@kompetenztest.de>