### PR TITLE
Fix typo in configuration

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -146,7 +146,7 @@ START_SSH_SERVER = false
 BUILTIN_SSH_SERVER_USER =
 ; Domain name to be exposed in clone URL
 SSH_DOMAIN = %(DOMAIN)s
-; THe network interface the builtin SSH server should listen on
+; The network interface the builtin SSH server should listen on
 SSH_LISTEN_HOST =
 ; Port number to be exposed in clone URL
 SSH_PORT = 22


### PR DESCRIPTION
This just fixes a typo in one of the comments in the sample configuration file.