### PR TITLE
Fix bug when users have serval teams with different units on different repositories

### DIFF
--- a/models/org_team.go
+++ b/models/org_team.go
@@ -525,6 +525,16 @@ func getUserTeams(e Engine, orgID, userID int64) (teams []*Team, err error) {
 		Find(&teams)
 }
 
+func getUserRepoTeams(e Engine, orgID, userID, repoID int64) (teams []*Team, err error) {
+	return teams, e.
+		Join("INNER", "team_user", "team_user.team_id = team.id").
+		Join("INNER", "team_repo", "team_repo.team_id = team.id").
+		Where("team.org_id = ?", orgID).
+		And("team_user.uid=?", userID).
+		And("team_repo.repo_id=?", repoID).
+		Find(&teams)
+}
+
 // GetUserTeams returns all teams that user belongs to in given organization.
 func GetUserTeams(orgID, userID int64) ([]*Team, error) {
 	return getUserTeams(x, orgID, userID)

--- a/models/repo.go
+++ b/models/repo.go
@@ -364,7 +364,7 @@ func (repo *Repository) getUnitsByUserID(e Engine, userID int64, isAdmin bool) (
 		return nil
 	}
 
-	teams, err := getUserTeams(e, repo.OwnerID, userID)
+	teams, err := getUserRepoTeams(e, repo.OwnerID, userID, repo.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When a user are on two teams on the same organization and get units will get non-current repository teams and units. This pull request will add a filter so that a repository get units only the repository's teams, not all the teams of the user.