### PR TITLE
Explicitly disable Git credential helper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ebd587087cf937b6d3db7dde843a557d157fd68820a9d3d0157a8d8f4011ad29"
+  digest = "1:ab875622908a804a327a95a1701002b150806a3c5406df51ec231eac16d3a1ca"
   name = "code.gitea.io/git"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "578ad8f1259b0d660d19b05a011596f8fd3fea37"
+  revision = "389d3c803e12a30dffcbb54a15c2242521bc4333"
 
 [[projects]]
   branch = "master"

--- a/vendor/code.gitea.io/git/command.go
+++ b/vendor/code.gitea.io/git/command.go
@@ -37,9 +37,12 @@ func (c *Command) String() string {
 
 // NewCommand creates and returns a new Git Command based on given command and arguments.
 func NewCommand(args ...string) *Command {
+	// Make an explicit copy of GlobalCommandArgs, otherwise append might overwrite it
+	cargs := make([]string, len(GlobalCommandArgs))
+	copy(cargs, GlobalCommandArgs)
 	return &Command{
 		name: "git",
-		args: append(GlobalCommandArgs, args...),
+		args: append(cargs, args...),
 	}
 }
 

--- a/vendor/code.gitea.io/git/repo_tree.go
+++ b/vendor/code.gitea.io/git/repo_tree.go
@@ -18,6 +18,15 @@ func (repo *Repository) getTree(id SHA1) (*Tree, error) {
 
 // GetTree find the tree object in the repository.
 func (repo *Repository) GetTree(idStr string) (*Tree, error) {
+	if len(idStr) != 40 {
+		res, err := NewCommand("rev-parse", idStr).RunInDir(repo.Path)
+		if err != nil {
+			return nil, err;
+		}
+		if len(res) > 0 {
+			idStr = res[:len(res)-1]
+		}
+	}
 	id, err := NewIDFromString(idStr)
 	if err != nil {
 		return nil, err

--- a/vendor/code.gitea.io/git/tree.go
+++ b/vendor/code.gitea.io/git/tree.go
@@ -70,3 +70,17 @@ func (t *Tree) ListEntries() (Entries, error) {
 	t.entries, err = parseTreeEntries(stdout, t)
 	return t.entries, err
 }
+
+// ListEntriesRecursive returns all entries of current tree recursively including all subtrees
+func (t *Tree) ListEntriesRecursive() (Entries, error) {
+	if t.entriesParsed {
+		return t.entries, nil
+	}
+	stdout, err := NewCommand("ls-tree", "-t", "-r", t.ID.String()).RunInDirBytes(t.repo.Path)
+
+	if err != nil {
+		return nil, err
+	}
+	t.entries, err = parseTreeEntries(stdout, t)
+	return t.entries, err
+}

--- a/vendor/code.gitea.io/git/tree_entry.go
+++ b/vendor/code.gitea.io/git/tree_entry.go
@@ -18,15 +18,15 @@ type EntryMode int
 // one of these.
 const (
 	// EntryModeBlob
-	EntryModeBlob EntryMode = 0100644
+	EntryModeBlob EntryMode = 0x0100644
 	// EntryModeExec
-	EntryModeExec EntryMode = 0100755
+	EntryModeExec EntryMode = 0x0100755
 	// EntryModeSymlink
-	EntryModeSymlink EntryMode = 0120000
+	EntryModeSymlink EntryMode = 0x0120000
 	// EntryModeCommit
-	EntryModeCommit EntryMode = 0160000
+	EntryModeCommit EntryMode = 0x0160000
 	// EntryModeTree
-	EntryModeTree EntryMode = 0040000
+	EntryModeTree EntryMode = 0x0040000
 )
 
 // TreeEntry the leaf in the git tree
@@ -48,6 +48,11 @@ type TreeEntry struct {
 // Name returns the name of the entry
 func (te *TreeEntry) Name() string {
 	return te.name
+}
+
+// Mode returns the mode of the entry
+func (te *TreeEntry) Mode() EntryMode {
+	return te.mode
 }
 
 // Size returns the size of the entry


### PR DESCRIPTION
If the user running Gitea has configured a credential helper, Git credentials might leak out of Gitea.

There are two problems with credential helpers when combined with Gitea:

1. Credentials entered by a user when doing a migration or setting up a mirror will end up in the credential store. In the worst case, this is the plain text file ~/.git-credentials.
2. Credentials in the credential store will be used for migrations and mirrors by all users. For example, if user A sets up a mirror, their credentials will be stored. If user B later sets up a mirror from the same host and does not enter any credentials, user A's credentials will be used.

This PR prepends -c credential.helper= to all Git commands to clear the list of helpers. This requires at least Git version 2.9, as previous versions will try to load an empty helper instead. For more details, see https://github.com/git/git/commit/24321375cda79f141be72d1a842e930df6f41725

(Related to #3966)