### PR TITLE
Don't force a password change for the admin user when creating an account via cli

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -322,14 +322,14 @@ func runCreateUser(c *cli.Context) error {
 	// always default to true
 	var changePassword = true
 
-	if c.IsSet("must-change-password") {
-		changePassword = c.Bool("must-change-password")
-	}
-
 	// If this is the first user being created.
 	// Take it as the admin and don't force a password update.
 	if n := models.CountUsers(); n == 0 {
 		changePassword = false
+	}
+
+	if c.IsSet("must-change-password") {
+		changePassword = c.Bool("must-change-password")
 	}
 
 	if err := models.CreateUser(&models.User{

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -326,6 +326,12 @@ func runCreateUser(c *cli.Context) error {
 		changePassword = c.Bool("must-change-password")
 	}
 
+	// If this is the first user being created.
+	// Take it as the admin and don't force a password update.
+	if n := models.CountUsers(); n == 0 {
+		changePassword = false
+	}
+
 	if err := models.CreateUser(&models.User{
 		Name:               c.String("name"),
 		Email:              c.String("email"),


### PR DESCRIPTION
This resolves https://github.com/go-gitea/gitea/issues/5376#issuecomment-441135845 .

If the account being created is the initial admin account, skip requesting a password change.
 