### PR TITLE
fix password variable shadowing

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -301,7 +301,8 @@ func runCreateUser(c *cli.Context) error {
 	if c.IsSet("password") {
 		password = c.String("password")
 	} else if c.IsSet("random-password") {
-		password, err := generate.GetRandomString(c.Int("random-password-length"))
+		var err error
+		password, err = generate.GetRandomString(c.Int("random-password-length"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
My bad. While the password is randomly generated, it doesn't actually get stored in 
the original `password` variable as it is declared in a new scope with `:=`.

So an empty string will always be the password anytime `-random-password-length` is used