### PR TITLE
Remove the required class from optional ssh port in installation page

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -99,7 +99,7 @@
 						<input id="domain" name="domain" value="{{.domain}}" placeholder="e.g. try.gitea.io" required>
 						<span class="help">{{.i18n.Tr "install.domain_helper"}}</span>
 					</div>
-					<div class="inline required field">
+					<div class="inline field">
 						<label for="ssh_port">{{.i18n.Tr "install.ssh_port"}}</label>
 						<input id="ssh_port" name="ssh_port" value="{{.ssh_port}}">
 						<span class="help">{{.i18n.Tr "install.ssh_port_helper"}}</span>


### PR DESCRIPTION
the ssh port is optional during the installation process. The translations even mention that it is optional and can be blank. Right now it has the `required` class which creates the red `*` behind the
field caption - used for required fields. If you leave it blank, the SSH option is disabled (not touched by this PR)

