### PR TITLE
check if signups are allowed during SignUpPost

### DIFF
--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -923,7 +923,7 @@ func SignUpPost(ctx *context.Context, cpt *captcha.Captcha, form auth.RegisterFo
 	ctx.Data["RecaptchaSitekey"] = setting.Service.RecaptchaSitekey
 
 	//Permission denied if DisableRegistration or AllowOnlyExternalRegistration options are true
-	if !setting.Service.ShowRegistrationButton {
+	if setting.Service.DisableRegistration || setting.Service.AllowOnlyExternalRegistration {
 		ctx.Error(403)
 		return
 	}


### PR DESCRIPTION
Previously you could hide the sign up page with the following
configs:

```ini
[service]
SHOW_REGISTRATION_BUTTON          = false
```

This would remove the sign up button from the navbar, but the user could still access the page with a direct link. During the http post action, the go action checked if the key `SHOW_REGISTRATION_BUTTON` was set to true. If not, the user received a 403.

You can use this scenario for a semi-hidden sign up page that is only accessible through a direct link.

I've changed the check in this PR to check if the sign up is allowed or not. The user can access the sign up page (if it's enabled) and sign up even if the value of `SHOW_REGISTRATION_BUTTON` is `false`, the user can sign up.

Another solution could be:
- unify `SHOW_REGISTRATION_BUTTON ` with `DISABLE_REGISTRATION ` to
only show the registration page if it's enabled, but that would dis-
allow the mentioned scenario

fixes: https://github.com/go-gitea/gitea/issues/5183
