### PR TITLE
[backport]word-break the WebHook url to prevent a ui-break

### DIFF
--- a/templates/repo/settings/webhook/list.tmpl
+++ b/templates/repo/settings/webhook/list.tmpl
@@ -38,7 +38,7 @@
 				{{else}}
 					<span class="text grey"><i class="octicon octicon-primitive-dot"></i></span>
 				{{end}}
-				<a href="{{$.BaseLink}}/settings/hooks/{{.ID}}">{{.URL}}</a>
+				<a class="dont-break-out" href="{{$.BaseLink}}/settings/hooks/{{.ID}}">{{.URL}}</a>
 				<div class="ui right">
 					<span class="text blue"><a href="{{$.BaseLink}}/settings/hooks/{{.ID}}"><i class="fa fa-pencil"></i></a></span>
 					<span class="text red"><a class="delete-button" data-url="{{$.Link}}/delete" data-id="{{.ID}}"><i class="fa fa-times"></i></a></span>


### PR DESCRIPTION
the requested backport for https://github.com/go-gitea/gitea/pull/5432

right now, the url is displayed with an anchor tag with no classes. If
the url is really really long, the url will break out of the containing
div and (depending on the url length) the browser shows the horizontal
scrollbar.
This pr makes use of the already existing css class `dont-break-out`
which gives all the anchor the necessary properties to prevent the
break.
Another solution could be to introduce some classes like
`text text-break-word`, but that would duplicate the `dont-break-out`
class just for text elements that use the `text` class.

fixes: https://github.com/go-gitea/gitea/issues/5416
