### PR TITLE
ensure that the `closed_at` is set for closed issues

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -329,6 +329,10 @@ func (issue *Issue) APIFormat() *api.Issue {
 		Updated:  issue.UpdatedUnix.AsTime(),
 	}
 
+	if issue.ClosedUnix != 0 {
+		apiIssue.Closed = issue.ClosedUnix.AsTimePtr()
+	}
+
 	if issue.Milestone != nil {
 		apiIssue.Milestone = issue.Milestone.APIFormat()
 	}


### PR DESCRIPTION
right now the `closed_at` field for json responses is not filled during the `APIIssue` creation for api responses.

For a closed issue you get a result like:
_(truncated json)_
```json
"state":"open","comments":0,"created_at":"2018-11-29T16:39:24+01:00",
"updated_at":"2018-11-30T10:49:19+01:00","closed_at":null,
"due_date":null,"pull_request":null}
```
which has no information about the closing date. (which exists in the db and ui)
With this PR the result changes to this:

_(truncated json)_
```json
"assignee":null,"assignees":null,
"state":"closed",
"comments":0,"created_at":"2018-11-29T16:43:05+01:00",
"updated_at":"2018-12-02T19:17:05+01:00",
"closed_at":"2018-12-02T19:17:05+01:00",
"due_date":null,"pull_request":null}
```
It includes now the correct `closed_at` date for closed issues.

fixes: https://github.com/go-gitea/gitea/issues/5446
