### PR TITLE
Allow link verification for services like Mastodon

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -31,7 +31,7 @@
 							{{if .Owner.Website}}
 								<li>
 									<i class="octicon octicon-link"></i>
-									<a target="_blank" rel="noopener noreferrer" href="{{.Owner.Website}}">{{.Owner.Website}}</a>
+									<a target="_blank" rel="noopener noreferrer me" href="{{.Owner.Website}}">{{.Owner.Website}}</a>
 								</li>
 							{{end}}
 							{{range .OpenIDs}}


### PR DESCRIPTION
This pull request will enable Mastodon users to verify their Gitea profiles on their profile pages. It's just a small, but handy modification to the user template file.