### PR TITLE
fix topic name length on database

### DIFF
--- a/models/migrations/v68.go
+++ b/models/migrations/v68.go
@@ -25,7 +25,7 @@ func reformatAndRemoveIncorrectTopics(x *xorm.Engine) (err error) {
 
 	type Topic struct {
 		ID          int64
-		Name        string `xorm:"UNIQUE"`
+		Name        string `xorm:"UNIQUE VARCHAR(25)"`
 		RepoCount   int
 		CreatedUnix int64 `xorm:"INDEX created"`
 		UpdatedUnix int64 `xorm:"INDEX updated"`

--- a/models/topic.go
+++ b/models/topic.go
@@ -26,7 +26,7 @@ var topicPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 // Topic represents a topic of repositories
 type Topic struct {
 	ID          int64
-	Name        string `xorm:"UNIQUE"`
+	Name        string `xorm:"UNIQUE VARCHAR(25)"`
 	RepoCount   int
 	CreatedUnix util.TimeStamp `xorm:"INDEX created"`
 	UpdatedUnix util.TimeStamp `xorm:"INDEX updated"`


### PR DESCRIPTION
Since we have controlled topic name length is less than 25, so we should change the name column's length.This will fix #5491