### PR TITLE
Fix empty wiki

### DIFF
--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -111,6 +111,9 @@ func wikiContentsByName(ctx *context.Context, commit *git.Commit, wikiName strin
 func renderWikiPage(ctx *context.Context, isViewPage bool) (*git.Repository, *git.TreeEntry) {
 	wikiRepo, commit, err := findWikiRepoCommit(ctx)
 	if err != nil {
+		if !git.IsErrNotExist(err) {
+			ctx.ServerError("GetBranchCommit", err)
+		}
 		return nil, nil
 	}
 

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -74,7 +74,6 @@ func findWikiRepoCommit(ctx *context.Context) (*git.Repository, *git.Commit, err
 
 	commit, err := wikiRepo.GetBranchCommit("master")
 	if err != nil {
-		ctx.ServerError("GetBranchCommit", err)
 		return wikiRepo, nil, err
 	}
 	return wikiRepo, commit, nil


### PR DESCRIPTION
When `git push` an empty wiki repo, the wiki page will be 500. This PR fix that issue.