### PR TITLE
Fixing MSSQL timestamp type

### DIFF
--- a/models/user_heatmap.go
+++ b/models/user_heatmap.go
@@ -28,7 +28,7 @@ func GetUserHeatmapDataByUser(user *User) ([]*UserHeatmapData, error) {
 	case setting.UsePostgreSQL:
 		groupBy = "extract(epoch from date_trunc('day', to_timestamp(created_unix)))"
 	case setting.UseMSSQL:
-		groupBy = "dateadd(DAY,0, datediff(day,0, dateadd(s, created_unix, '19700101')))"
+		groupBy = "datediff(SECOND, '19700101', dateadd(DAY, 0, datediff(day, 0, dateadd(s, created_unix, '19700101'))))"
 		groupByName = groupBy
 	}
 


### PR DESCRIPTION
MSSQL is using the wrong type here which results in a strconv.ParseInt: parsing "2018-12-07T00:00:00Z": invalid syntax error.
The added datediff(SECOND, '19700101', x) results in the unix timestamp to be returned.

This should fix #5328.