### PR TITLE
Fix Let's Encrypt handler

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -80,7 +80,13 @@ func runLetsEncrypt(listenAddr, domain, directory, email string, m http.Handler)
 		Cache:      autocert.DirCache(directory),
 		Email:      email,
 	}
-	go http.ListenAndServe(listenAddr+":"+setting.PortToRedirect, certManager.HTTPHandler(http.HandlerFunc(runLetsEncryptFallbackHandler))) // all traffic coming into HTTP will be redirect to HTTPS automatically (LE HTTP-01 validatio happens here)
+	go func() {
+		log.Info("Running Let's Encrypt handler on %s", setting.HTTPAddr+":"+setting.PortToRedirect)
+		var err = http.ListenAndServe(setting.HTTPAddr+":"+setting.PortToRedirect, certManager.HTTPHandler(http.HandlerFunc(runLetsEncryptFallbackHandler))) // all traffic coming into HTTP will be redirect to HTTPS automatically (LE HTTP-01 validatio happens here)
+		if err != nil {
+			log.Fatal(4, "Failed to start the Let's Encrypt handler on port %s: %v", setting.PortToRedirect, err)
+		}
+	}()
 	server := &http.Server{
 		Addr:    listenAddr,
 		Handler: m,

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -82,7 +82,7 @@ func runLetsEncrypt(listenAddr, domain, directory, email string, m http.Handler)
 	}
 	go func() {
 		log.Info("Running Let's Encrypt handler on %s", setting.HTTPAddr+":"+setting.PortToRedirect)
-		var err = http.ListenAndServe(setting.HTTPAddr+":"+setting.PortToRedirect, certManager.HTTPHandler(http.HandlerFunc(runLetsEncryptFallbackHandler))) // all traffic coming into HTTP will be redirect to HTTPS automatically (LE HTTP-01 validatio happens here)
+		var err = http.ListenAndServe(setting.HTTPAddr+":"+setting.PortToRedirect, certManager.HTTPHandler(http.HandlerFunc(runLetsEncryptFallbackHandler))) // all traffic coming into HTTP will be redirect to HTTPS automatically (LE HTTP-01 validation happens here)
 		if err != nil {
 			log.Fatal(4, "Failed to start the Let's Encrypt handler on port %s: %v", setting.PortToRedirect, err)
 		}


### PR DESCRIPTION
The issue was that the listen address was wrong (it looked like `.0.0.0:443:80`).

Also handle errors in the HTTP server go routine, return a fatal error when something goes wrong.

Thanks to @gbl08ma for finding the actual bug

Here is an example of the error handling:

    2018/12/11 14:23:07 [....io/gitea/cmd/web.go:87 func1()] [E] Failed to
    start the Let's Encrypt handler on port 30: listen tcp 0.0.0.0:30: bind:
    permission denied

Closes #5280

Edit: This is my first Go pull request so I am open to suggestions about the error handling