### PR TITLE
Backport #5537 Remove a double slash in the HTTPS redirect with Let's Encrypt

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -102,7 +102,10 @@ func runLetsEncryptFallbackHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Use HTTPS", http.StatusBadRequest)
 		return
 	}
-	target := setting.AppURL + r.URL.RequestURI()
+	// Remove the trailing slash at the end of setting.AppURL, the request
+	// URI always contains a leading slash, which would result in a double
+	// slash
+	target := strings.TrimRight(setting.AppURL, "/") + r.URL.RequestURI()
 	http.Redirect(w, r, target, http.StatusFound)
 }
 


### PR DESCRIPTION
Before:

$ curl 0.0.0.0:3001
<a href="https://gitea.example.com:3000//">Found</a>.

After:

$ curl 0.0.0.0:3001
<a href="https://gitea.example.com:3000/">Found</a>.

Fixes #5536

Cherry-pick from the master branch