### PR TITLE
Clarify scope of license notice on dashboard footer

### DIFF
--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -16,7 +16,7 @@
 					{{end}}
 				</div>
 			</div>
-			<a href="{{AppSubUrl}}/vendor/librejs.html" data-jslicense="1">JavaScript licenses</a>
+			<a href="{{AppSubUrl}}/vendor/librejs.html" data-jslicense="1">Licenses</a>
 			{{if .EnableSwagger}}<a href="{{AppSubUrl}}/api/swagger">API</a>{{end}}
 			<a target="_blank" rel="noopener noreferrer" href="https://gitea.io">{{.i18n.Tr "website"}}</a>
 			{{if (or .ShowFooterVersion .PageIsAdmin)}}<span class="version">{{GoVer}}</span>{{end}}


### PR DESCRIPTION
The license notice also includes fonts, icons, etc. It doesn't make sense to label it as "JavaScript licenses." Just calling it "Licenses" also leaves it open for other additions in the future. Bonus: The footer looks less cluttered.