### PR TITLE
Fix type mismatch of format string

### DIFF
--- a/integrations/benchmarks_test.go
+++ b/integrations/benchmarks_test.go
@@ -102,7 +102,7 @@ func BenchmarkRepoBranchCommit(b *testing.B) {
 				branchCount := len(branches)
 				b.ResetTimer() //We measure from here
 				for i := 0; i < b.N; i++ {
-					req := NewRequestf(b, "GET", "/%s/%s/commits/%s", owner.Name, repo.Name, branches[i%branchCount])
+					req := NewRequestf(b, "GET", "/%s/%s/commits/%s", owner.Name, repo.Name, branches[i%branchCount].Name)
 					session.MakeRequest(b, req, http.StatusOK)
 				}
 			})


### PR DESCRIPTION
The "%s" in the format string can not accept an unsupported type.
