### PR TITLE
drone/mssql: use golang 1.11

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -177,7 +177,7 @@ pipeline:
       event: [ push, tag, pull_request ]
 
   test-mssql:
-    image: golang:1.10
+    image: golang:1.11
     pull: true
     group: test
     environment:


### PR DESCRIPTION
Seems that mssql tests were stuck in golang:1.10.
Others tests use golang:1.11