### PR TITLE
security: some organization endpoints can be accessed without authorization

### DIFF
--- a/integrations/api_repo_test.go
+++ b/integrations/api_repo_test.go
@@ -241,7 +241,16 @@ func TestAPIOrgRepos(t *testing.T) {
 		}
 		t.Run(testName, func(t *testing.T) {
 			req := NewRequestf(t, "GET", "/api/v1/orgs/%s/repos?token="+token, sourceOrg.Name)
-			resp := session.MakeRequest(t, req, http.StatusOK)
+
+			var status int
+
+			if token == "" {
+				status = http.StatusUnauthorized
+			} else {
+				status = http.StatusOK
+			}
+
+			resp := session.MakeRequest(t, req, status)
 
 			var apiRepos []*api.Repository
 			DecodeJSON(t, resp, &apiRepos)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -620,12 +620,12 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/users/:username/orgs", org.ListUserOrgs)
 		m.Post("/orgs", reqToken(), bind(api.CreateOrgOption{}), org.Create)
 		m.Group("/orgs/:orgname", func() {
-			m.Get("/repos", user.ListOrgRepos)
+			m.Get("/repos", reqToken(), reqOrgMembership(), user.ListOrgRepos)
 			m.Combo("").Get(org.Get).
 				Patch(reqToken(), reqOrgOwnership(), bind(api.EditOrgOption{}), org.Edit)
 			m.Group("/members", func() {
-				m.Get("", org.ListMembers)
-				m.Combo("/:username").Get(org.IsMember).
+				m.Get("", reqToken(), reqOrgMembership(), org.ListMembers)
+				m.Combo("/:username").Get(reqToken(), reqOrgMembership(), org.IsMember).
 					Delete(reqToken(), reqOrgOwnership(), org.DeleteMember)
 			})
 			m.Group("/public_members", func() {


### PR DESCRIPTION
Fixes #5603 

I didn't add `reqToken` for the `/api/v1/orgs/{org}` endpoint as the returned information
 is minimal and there is no notion of a public or private organization in Gitea.