### PR TITLE
branch: Trigger update when deleting branch via UI.

### DIFF
--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -126,7 +126,19 @@ func deleteBranch(ctx *context.Context, branchName string) error {
 		return err
 	}
 
-	// Don't return error here
+	// Don't return error below this
+	if err := models.PushUpdate(branchName, models.PushUpdateOptions{
+		RefFullName:  git.BranchPrefix + branchName,
+		OldCommitID:  commit.ID.String(),
+		NewCommitID:  git.EmptySHA,
+		PusherID:     ctx.User.ID,
+		PusherName:   ctx.User.Name,
+		RepoUserName: ctx.Repo.Owner.Name,
+		RepoName:     ctx.Repo.Repository.Name,
+	}); err != nil {
+		log.Error(4, "Update: %v", err)
+	}
+
 	if err := ctx.Repo.Repository.AddDeletedBranch(branchName, commit.ID.String(), ctx.User.ID); err != nil {
 		log.Warn("AddDeletedBranch: %v", err)
 	}


### PR DESCRIPTION
I also tried the approach to delete the branch by executing `git push --delete origin <banch_name>` in local copy of repository but it didn't trigger the `post-receive` hook. I tried debugging and everything seems fine yet a push via local copy doesn't trigger update. Can anyone shed some light on this?

Fixes: #5309.