### PR TITLE
Use git plumbing for upload rather than porcelain

### DIFF
--- a/models/repo_branch.go
+++ b/models/repo_branch.go
@@ -14,6 +14,46 @@ import (
 	"github.com/Unknwon/com"
 )
 
+// discardLocalRepoBranchChanges discards local commits/changes of
+// given branch to make sure it is even to remote branch.
+func discardLocalRepoBranchChanges(localPath, branch string) error {
+	if !com.IsExist(localPath) {
+		return nil
+	}
+	// No need to check if nothing in the repository.
+	if !git.IsBranchExist(localPath, branch) {
+		return nil
+	}
+
+	refName := "origin/" + branch
+	if err := git.ResetHEAD(localPath, true, refName); err != nil {
+		return fmt.Errorf("git reset --hard %s: %v", refName, err)
+	}
+	return nil
+}
+
+// DiscardLocalRepoBranchChanges discards the local repository branch changes
+func (repo *Repository) DiscardLocalRepoBranchChanges(branch string) error {
+	return discardLocalRepoBranchChanges(repo.LocalCopyPath(), branch)
+}
+
+// checkoutNewBranch checks out to a new branch from the a branch name.
+func checkoutNewBranch(repoPath, localPath, oldBranch, newBranch string) error {
+	if err := git.Checkout(localPath, git.CheckoutOptions{
+		Timeout:   time.Duration(setting.Git.Timeout.Pull) * time.Second,
+		Branch:    newBranch,
+		OldBranch: oldBranch,
+	}); err != nil {
+		return fmt.Errorf("git checkout -b %s %s: %v", newBranch, oldBranch, err)
+	}
+	return nil
+}
+
+// CheckoutNewBranch checks out a new branch
+func (repo *Repository) CheckoutNewBranch(oldBranch, newBranch string) error {
+	return checkoutNewBranch(repo.RepoPath(), repo.LocalCopyPath(), oldBranch, newBranch)
+}
+
 // Branch holds the branch information
 type Branch struct {
 	Path string

--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -32,46 +32,6 @@ import (
 // /_______  /\____ | |__||__|    \___  /   |__|____/\___  >
 //         \/      \/                 \/                 \/
 
-// discardLocalRepoBranchChanges discards local commits/changes of
-// given branch to make sure it is even to remote branch.
-func discardLocalRepoBranchChanges(localPath, branch string) error {
-	if !com.IsExist(localPath) {
-		return nil
-	}
-	// No need to check if nothing in the repository.
-	if !git.IsBranchExist(localPath, branch) {
-		return nil
-	}
-
-	refName := "origin/" + branch
-	if err := git.ResetHEAD(localPath, true, refName); err != nil {
-		return fmt.Errorf("git reset --hard %s: %v", refName, err)
-	}
-	return nil
-}
-
-// DiscardLocalRepoBranchChanges discards the local repository branch changes
-func (repo *Repository) DiscardLocalRepoBranchChanges(branch string) error {
-	return discardLocalRepoBranchChanges(repo.LocalCopyPath(), branch)
-}
-
-// checkoutNewBranch checks out to a new branch from the a branch name.
-func checkoutNewBranch(repoPath, localPath, oldBranch, newBranch string) error {
-	if err := git.Checkout(localPath, git.CheckoutOptions{
-		Timeout:   time.Duration(setting.Git.Timeout.Pull) * time.Second,
-		Branch:    newBranch,
-		OldBranch: oldBranch,
-	}); err != nil {
-		return fmt.Errorf("git checkout -b %s %s: %v", newBranch, oldBranch, err)
-	}
-	return nil
-}
-
-// CheckoutNewBranch checks out a new branch
-func (repo *Repository) CheckoutNewBranch(oldBranch, newBranch string) error {
-	return checkoutNewBranch(repo.RepoPath(), repo.LocalCopyPath(), oldBranch, newBranch)
-}
-
 // UpdateRepoFileOptions holds the repository file update options
 type UpdateRepoFileOptions struct {
 	LastCommitID string

--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -305,7 +305,7 @@ func (repo *Repository) UpdateRepoFile(doer *User, opts UpdateRepoFileOptions) (
 	}
 
 	// Add the object to the index
-	if err := repo.addObjectToIndex(tmpBasePath, "100666", objectHash, opts.NewTreeName); err != nil {
+	if err := repo.addObjectToIndex(tmpBasePath, "100644", objectHash, opts.NewTreeName); err != nil {
 		return err
 	}
 
@@ -418,7 +418,7 @@ func (repo *Repository) GetDiffPreview(branch, treePath, content string) (diff *
 	}
 
 	// Add the object to the index
-	if err := repo.addObjectToIndex(tmpBasePath, "100666", objectHash, treePath); err != nil {
+	if err := repo.addObjectToIndex(tmpBasePath, "100644", objectHash, treePath); err != nil {
 		return nil, fmt.Errorf("GetDiffPreview: %v", err)
 	}
 
@@ -704,7 +704,7 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 		}
 
 		// Add the object to the index
-		if err := repo.addObjectToIndex(tmpBasePath, "100666", objectHash, path.Join(opts.TreePath, upload.Name)); err != nil {
+		if err := repo.addObjectToIndex(tmpBasePath, "100644", objectHash, path.Join(opts.TreePath, upload.Name)); err != nil {
 			return err
 		}
 	}

--- a/routers/repo/editor.go
+++ b/routers/repo/editor.go
@@ -62,6 +62,16 @@ func editFile(ctx *context.Context, isNewFile bool) {
 	ctx.Data["RequireSimpleMDE"] = true
 	canCommit := renderCommitRights(ctx)
 
+	treePath := cleanUploadFileName(ctx.Repo.TreePath)
+	if treePath != ctx.Repo.TreePath {
+		if isNewFile {
+			ctx.Redirect(path.Join(ctx.Repo.RepoLink, "_new", ctx.Repo.BranchName, treePath))
+		} else {
+			ctx.Redirect(path.Join(ctx.Repo.RepoLink, "_edit", ctx.Repo.BranchName, treePath))
+		}
+		return
+	}
+
 	treeNames, treePaths := getParentTreeFields(ctx.Repo.TreePath)
 
 	if !isNewFile {
@@ -155,7 +165,7 @@ func editFilePost(ctx *context.Context, form auth.EditRepoFileForm, isNewFile bo
 
 	oldBranchName := ctx.Repo.BranchName
 	branchName := oldBranchName
-	oldTreePath := ctx.Repo.TreePath
+	oldTreePath := cleanUploadFileName(ctx.Repo.TreePath)
 	lastCommit := form.LastCommit
 	form.LastCommit = ctx.Repo.Commit.ID.String()
 
@@ -328,7 +338,11 @@ func NewFilePost(ctx *context.Context, form auth.EditRepoFileForm) {
 
 // DiffPreviewPost render preview diff page
 func DiffPreviewPost(ctx *context.Context, form auth.EditPreviewDiffForm) {
-	treePath := ctx.Repo.TreePath
+	treePath := cleanUploadFileName(ctx.Repo.TreePath)
+	if len(treePath) == 0 {
+		ctx.Error(500, "file name to diff is invalid")
+		return
+	}
 
 	entry, err := ctx.Repo.Commit.GetTreeEntryByPath(treePath)
 	if err != nil {
@@ -358,7 +372,14 @@ func DiffPreviewPost(ctx *context.Context, form auth.EditPreviewDiffForm) {
 func DeleteFile(ctx *context.Context) {
 	ctx.Data["PageIsDelete"] = true
 	ctx.Data["BranchLink"] = ctx.Repo.RepoLink + "/src/" + ctx.Repo.BranchNameSubURL()
-	ctx.Data["TreePath"] = ctx.Repo.TreePath
+	treePath := cleanUploadFileName(ctx.Repo.TreePath)
+
+	if treePath != ctx.Repo.TreePath {
+		ctx.Redirect(path.Join(ctx.Repo.RepoLink, "_delete", ctx.Repo.BranchName, treePath))
+		return
+	}
+
+	ctx.Data["TreePath"] = treePath
 	canCommit := renderCommitRights(ctx)
 
 	ctx.Data["commit_summary"] = ""
@@ -453,6 +474,12 @@ func UploadFile(ctx *context.Context) {
 	ctx.Data["PageIsUpload"] = true
 	renderUploadSettings(ctx)
 	canCommit := renderCommitRights(ctx)
+	treePath := cleanUploadFileName(ctx.Repo.TreePath)
+	if treePath != ctx.Repo.TreePath {
+		ctx.Redirect(path.Join(ctx.Repo.RepoLink, "_upload", ctx.Repo.BranchName, treePath))
+		return
+	}
+	ctx.Repo.TreePath = treePath
 
 	treeNames, treePaths := getParentTreeFields(ctx.Repo.TreePath)
 	if len(treeNames) == 0 {

--- a/routers/repo/editor.go
+++ b/routers/repo/editor.go
@@ -576,12 +576,13 @@ func UploadFilePost(ctx *context.Context, form auth.UploadRepoFileForm) {
 }
 
 func cleanUploadFileName(name string) string {
-	name = strings.TrimLeft(name, "./\\")
-	name = strings.Replace(name, "../", "", -1)
-	name = strings.Replace(name, "..\\", "", -1)
-	name = strings.TrimPrefix(path.Clean(name), ".git/")
-	if name == ".git" {
-		return ""
+	// Rebase the filename
+	name = strings.Trim(path.Clean("/"+name), " /")
+	// Git disallows any filenames to have a .git directory in them.
+	for _, part := range strings.Split(name, "/") {
+		if strings.ToLower(part) == ".git" {
+			return ""
+		}
 	}
 	return name
 }

--- a/routers/repo/editor_test.go
+++ b/routers/repo/editor_test.go
@@ -15,14 +15,15 @@ func TestCleanUploadName(t *testing.T) {
 	models.PrepareTestEnv(t)
 
 	var kases = map[string]string{
-		".git/refs/master": "git/refs/master",
+		".git/refs/master": "",
 		"/root/abc":        "root/abc",
 		"./../../abc":      "abc",
-		"a/../.git":        "a/.git",
-		"a/../../../abc":   "a/abc",
+		"a/../.git":        "",
+		"a/../../../abc":   "abc",
 		"../../../acd":     "acd",
-		"../../.git/abc":   "git/abc",
-		"..\\..\\.git/abc": "git/abc",
+		"../../.git/abc":   "",
+		"..\\..\\.git/abc": "..\\..\\.git/abc",
+		"abc/../def":       "def",
 	}
 	for k, v := range kases {
 		assert.EqualValues(t, v, cleanUploadFileName(k))


### PR DESCRIPTION
When uploading files using the GUI, Gitea currently does:

a) A full clone - Including the whole object DB
b) A full branch checkout - every file
c) Copies the uploaded file to this cloned repository
d) Add/stages the changes
e) Commits
f) Pushes to the real repository
g) Cleans up the cloned repository - deleting the whole object db and checkout.

This is extremely inefficient.

This PR takes a different approach and, instead of using the git porcelain commands (git add and the like), uses the plumbing commands to (hopefully) significantly speed up this process. See my comments in #601 (https://github.com/go-gitea/gitea/issues/601#issuecomment-450194075).

Currently my approach is to use the git-cli commands which can/could be migrated to go-git commands later.

Will fix #5600. 