### PR TITLE
Fix bug on modifying sshd username

### DIFF
--- a/docker/usr/bin/entrypoint
+++ b/docker/usr/bin/entrypoint
@@ -4,7 +4,7 @@ if [ "${USER}" != "git" ]; then
     # rename user
     sed -i -e "s/^git\:/${USER}\:/g" /etc/passwd
     # switch sshd config to different user
-    sed -i -e "s/AllowUsers git/AllowUsers ${USER}/g" /etc/ssh/sshd_config
+    sed -i -e "s/AllowUsers git$/AllowUsers ${USER}/g" /etc/ssh/sshd_config
 fi
 
 ## Change GID for USER?


### PR DESCRIPTION
Should fix #5623 

Since the regex isn't matching the end-of-line, when using a user whose username starts with "git" it will perform an invalid replace (gitea -> giteaea, git-suffix -> git-suffix-suffix).

Matching against EOL should resolve this issue.