### PR TITLE
Documentation: Clarity for HTTPS setups

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -122,9 +122,8 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `LFS_CONTENT_PATH`: **./data/lfs**: Where to store LFS files.
 - `LFS_JWT_SECRET`: **\<empty\>**: LFS authentication secret, change this a unique string.
 - `LFS_HTTP_AUTH_EXPIRY`: **20m**: LFS authentication validity period in time.Duration, pushes taking longer than this may fail.
-- `REDIRECT_OTHER_PORT`: **false**: If true and `PROTOCOL` is https, redirects http requests
-   on another (https) port.
-- `PORT_TO_REDIRECT`: **80**: Port used when `REDIRECT_OTHER_PORT` is true.
+- `REDIRECT_OTHER_PORT`: **false**: If true and `PROTOCOL` is https, allows redirecting http requests on `PORT_TO_REDIRECT` to the https port Gitea listens on.
+- `PORT_TO_REDIRECT`: **80**: Port for the http redirection service to listen on. Used when `REDIRECT_OTHER_PORT` is true.
 - `ENABLE_LETSENCRYPT`: **false**: If enabled you must set `DOMAIN` to valid internet facing domain (ensure DNS is set and port 80 is accessible by letsencrypt validation server).
    By using Lets Encrypt **you must consent** to their [terms of service](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf).
 - `LETSENCRYPT_ACCEPTTOS`: **false**: This is an explicit check that you accept the terms of service for Let's Encrypt.

--- a/docs/content/doc/usage/https-support.md
+++ b/docs/content/doc/usage/https-support.md
@@ -30,7 +30,21 @@ HTTP_PORT = 3000
 CERT_FILE = cert.pem
 KEY_FILE = key.pem
 ```
+
 To learn more about the config values, please checkout the [Config Cheat Sheet](../config-cheat-sheet#server).
+
+### Setting-up HTTP redirection
+
+The Gitea server is only able to listen to one port; to redirect HTTP requests to the HTTPS port, you will need to enable the HTTP redirection service:
+
+```ini
+[server]
+REDIRECT_OTHER_PORT = true
+; Port the redirection service should listen on
+PORT_TO_REDIRECT = 3080
+```
+
+If you are using Docker, make sure that this port is configured in your `docker-compose.yml` file.
 
 ## Using Let's Encrypt
 


### PR DESCRIPTION
[https-setup]
- Made it clearer that HTTP redirection is possible
[config-cheat-sheet]
- Clarified the behaviour of the redirection-related config keys