### PR TITLE
Fix sqlite deadlock when assigning to a PR (#5640) (Backport to v1.7)

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1402,7 +1402,7 @@ func UpdateIssueMentions(e Engine, issueID int64, mentions []string) error {
 		}
 
 		memberIDs := make([]int64, 0, user.NumMembers)
-		orgUsers, err := GetOrgUsersByOrgID(user.ID)
+		orgUsers, err := getOrgUsersByOrgID(e, user.ID)
 		if err != nil {
 			return fmt.Errorf("GetOrgUsersByOrgID [%d]: %v", user.ID, err)
 		}

--- a/models/issue_assignees.go
+++ b/models/issue_assignees.go
@@ -44,7 +44,11 @@ func (issue *Issue) loadAssignees(e Engine) (err error) {
 
 // GetAssigneesByIssue returns everyone assigned to that issue
 func GetAssigneesByIssue(issue *Issue) (assignees []*User, err error) {
-	err = issue.loadAssignees(x)
+	return getAssigneesByIssue(x, issue)
+}
+
+func getAssigneesByIssue(e Engine, issue *Issue) (assignees []*User, err error) {
+	err = issue.loadAssignees(e)
 	if err != nil {
 		return assignees, err
 	}
@@ -173,7 +177,7 @@ func (issue *Issue) changeAssignee(sess *xorm.Session, doer *User, assigneeID in
 		issue.PullRequest.Issue = issue
 		apiPullRequest := &api.PullRequestPayload{
 			Index:       issue.Index,
-			PullRequest: issue.PullRequest.APIFormat(),
+			PullRequest: issue.PullRequest.apiFormat(sess),
 			Repository:  issue.Repo.innerAPIFormat(sess, mode, false),
 			Sender:      doer.APIFormat(),
 		}

--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -48,7 +48,7 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 	}
 
 	// Assignees must receive any communications
-	assignees, err := GetAssigneesByIssue(issue)
+	assignees, err := getAssigneesByIssue(e, issue)
 	if err != nil {
 		return err
 	}

--- a/models/issue_user.go
+++ b/models/issue_user.go
@@ -54,7 +54,7 @@ func newIssueUsers(e Engine, repo *Repository, issue *Issue) error {
 func updateIssueAssignee(e *xorm.Session, issue *Issue, assigneeID int64) (removed bool, err error) {
 
 	// Check if the user exists
-	assignee, err := GetUserByID(assigneeID)
+	assignee, err := getUserByID(e, assigneeID)
 	if err != nil {
 		return false, err
 	}

--- a/models/org.go
+++ b/models/org.go
@@ -393,8 +393,12 @@ func GetOrgUsersByUserID(uid int64, all bool) ([]*OrgUser, error) {
 
 // GetOrgUsersByOrgID returns all organization-user relations by organization ID.
 func GetOrgUsersByOrgID(orgID int64) ([]*OrgUser, error) {
+	return getOrgUsersByOrgID(x, orgID)
+}
+
+func getOrgUsersByOrgID(e Engine, orgID int64) ([]*OrgUser, error) {
 	ous := make([]*OrgUser, 0, 10)
-	err := x.
+	err := e.
 		Where("org_id=?", orgID).
 		Find(&ous)
 	return ous, err

--- a/models/repo_watch.go
+++ b/models/repo_watch.go
@@ -113,15 +113,15 @@ func notifyWatchers(e Engine, act *Action) error {
 
 		switch act.OpType {
 		case ActionCommitRepo, ActionPushTag, ActionDeleteTag, ActionDeleteBranch:
-			if !act.Repo.CheckUnitUser(act.UserID, false, UnitTypeCode) {
+			if !act.Repo.checkUnitUser(e, act.UserID, false, UnitTypeCode) {
 				continue
 			}
 		case ActionCreateIssue, ActionCommentIssue, ActionCloseIssue, ActionReopenIssue:
-			if !act.Repo.CheckUnitUser(act.UserID, false, UnitTypeIssues) {
+			if !act.Repo.checkUnitUser(e, act.UserID, false, UnitTypeIssues) {
 				continue
 			}
 		case ActionCreatePullRequest, ActionMergePullRequest, ActionClosePullRequest, ActionReopenPullRequest:
-			if !act.Repo.CheckUnitUser(act.UserID, false, UnitTypePullRequests) {
+			if !act.Repo.checkUnitUser(e, act.UserID, false, UnitTypePullRequests) {
 				continue
 			}
 		}


### PR DESCRIPTION
When assigning a user to a PR there was a call to issue.PullRequest.APIFormat() which causes an deadlock in sqlite due to the internal use of the xorm engine. This PR changes this to issue.PullRequest.apiFormat(sess) passing in the current session and thus avoiding the deadlock.

Fix #5639
