### PR TITLE
fix: only count users own actions for heatmap contributions

### DIFF
--- a/models/user_heatmap.go
+++ b/models/user_heatmap.go
@@ -32,9 +32,15 @@ func GetUserHeatmapDataByUser(user *User) ([]*UserHeatmapData, error) {
 		groupByName = groupBy
 	}
 
-	// For invidividual users only their own contributions count
-	// For organisations contributions by every user in owned repos count
-	var isOrganization = user.Type == UserTypeOrganization
+	var isOrganization string
+	switch user.Type {
+	case UserTypeIndividual:
+		// For invidividual users only their own contributions count
+		isOrganization = "1 = 0"
+	case UserTypeOrganization:
+		// For organisations contributions by every user in owned repos count
+		isOrganization = "1 = 1" // mssql does not support boolean literal for expressions
+	}
 
 	err := x.Select(groupBy+" AS timestamp, count(user_id) as contributions").
 		Table("action").

--- a/models/user_heatmap.go
+++ b/models/user_heatmap.go
@@ -36,16 +36,16 @@ func GetUserHeatmapDataByUser(user *User) ([]*UserHeatmapData, error) {
 	switch user.Type {
 	case UserTypeIndividual:
 		// For invidividual users only their own contributions count
-		isOrganization = "1 = 0"
+		isOrganization = "0"
 	case UserTypeOrganization:
 		// For organisations contributions by every user in owned repos count
-		isOrganization = "1 = 1" // mssql does not support boolean literal for expressions
+		isOrganization = "1" // mssql does not support boolean literal for expressions
 	}
 
 	err := x.Select(groupBy+" AS timestamp, count(user_id) as contributions").
 		Table("action").
 		Where("user_id = ?", user.ID).
-		And("(? OR act_user_id = ?)", isOrganization, user.ID).
+		And("(1 = ? OR act_user_id = ?)", isOrganization, user.ID).
 		And("created_unix > ?", (util.TimeStampNow() - 31536000)).
 		GroupBy(groupByName).
 		OrderBy("timestamp").

--- a/models/user_heatmap.go
+++ b/models/user_heatmap.go
@@ -35,6 +35,7 @@ func GetUserHeatmapDataByUser(user *User) ([]*UserHeatmapData, error) {
 	err := x.Select(groupBy+" AS timestamp, count(user_id) as contributions").
 		Table("action").
 		Where("user_id = ?", user.ID).
+		And("act_user_id = ?", user.ID).
 		And("created_unix > ?", (util.TimeStampNow() - 31536000)).
 		GroupBy(groupByName).
 		OrderBy("timestamp").

--- a/models/user_heatmap.go
+++ b/models/user_heatmap.go
@@ -32,10 +32,14 @@ func GetUserHeatmapDataByUser(user *User) ([]*UserHeatmapData, error) {
 		groupByName = groupBy
 	}
 
+	// For invidividual users only their own contributions count
+	// For organisations contributions by every user in owned repos count
+	var isOrganization = user.Type == UserTypeOrganization
+
 	err := x.Select(groupBy+" AS timestamp, count(user_id) as contributions").
 		Table("action").
 		Where("user_id = ?", user.ID).
-		And("act_user_id = ?", user.ID).
+		And("(? OR act_user_id = ?)", isOrganization, user.ID).
 		And("created_unix > ?", (util.TimeStampNow() - 31536000)).
 		GroupBy(groupByName).
 		OrderBy("timestamp").


### PR DESCRIPTION
## Problem / Current Behaviour

The current query used to count contributions includes notifications sent to watchers of the repository.

Imagine following setup:

* Two users with ids `0` and `1`
* User `0` has a repository with id `0`
* User `1` watches the repository
* User `0` creates a new issue "Test" (or any other action) in the repo
* The `action` table now contains following entries:
    ```
    sqlite> SELECT * FROM action ORDER BY id DESC LIMIT 10;
    id          user_id     op_type     act_user_id  act_user_name  repo_id     repo_user_name  repo_name   ref_name    is_private  content     created_unix  comment_id  is_deleted
    ----------  ----------  ----------  -----------  -------------  ----------  --------------  ----------  ----------  ----------  ----------  ------------  ----------  ----------
    19766       0           6           0                           0                                                  0           43|Test     1546719456    0           0
    19765       1           6           0                           0                                                  0           43|Test     1546719456    0           0
    ```

The current query only checks that the `user_id` matches, this means that the issue created by user `0` will show up as 1 contribution for both users.

## Proposed Fix

By also checking for `act_user_id` we can assure that only actions that the user did himself are counted as a contribution.

We can not drop the check for `user_id`, assuming the scenario from above, the one issue created would show up as 2 (1 + number of watchers) contributions for the user who created the issue.

## Drawback

**Edit**: Resolved by only adding the condition if the user is not an organization.

~~The organization's heatmap will now only contain meta-actions like `ActionCreateRepo`, previously all contributions made by users in this repository were also counted, resulting in a nice summary heatmap for all activity.~~