### PR TITLE
Backport #5650: fix commit page showing status for current default branch (#5649)

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -201,7 +201,7 @@ func Diff(ctx *context.Context) {
 		commitID = commit.ID.String()
 	}
 
-	statuses, err := models.GetLatestCommitStatus(ctx.Repo.Repository, ctx.Repo.Commit.ID.String(), 0)
+	statuses, err := models.GetLatestCommitStatus(ctx.Repo.Repository, commitID, 0)
 	if err != nil {
 		log.Error(3, "GetLatestCommitStatus: %v", err)
 	}


### PR DESCRIPTION
Backport PR #5650 to `release/v1.7`