### PR TITLE
Translate home template to Czech

### DIFF
--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -312,6 +312,43 @@
 				</p>
 			</div>
 		</div>
+	{{else if eq .Lang "cs-CZ"}}
+		<div class="ui stackable middle very relaxed page grid">
+			<div class="eight wide center column">
+				<h1 class="hero ui icon header">
+					<i class="octicon octicon-flame"></i> Jednoduchá na instalaci
+				</h1>
+				<p class="large">
+					Jednoduše <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/install-from-binary/">spusťte binárku</a> pro vaší platformu. Je také k dispozici pro <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> nebo <a target="_blank" rel="noopener noreferrer" href="https://github.com/alvaroaleman/ansible-gitea/blob/master/Vagrantfile">Vagrant</a>, nebo ji získejte z <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/install-from-package/">balíčku</a>.
+				</p>
+			</div>
+			<div class="eight wide center column">
+				<h1 class="hero ui icon header">
+					<i class="octicon octicon-device-desktop"></i> Multiplatformní
+				</h1>
+				<p class="large">
+					Gitea běží všude, kde <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> může kompilovat: Windows, macOS, Linux, ARM, atd. Vyberte si ten, který milujete!
+				</p>
+			</div>
+		</div>
+		<div class="ui stackable middle very relaxed page grid">
+			<div class="eight wide center column">
+				<h1 class="hero ui icon header">
+					<i class="octicon octicon-rocket"></i> Lehká
+				</h1>
+				<p class="large">
+					Gitea má minimální požadavky a může běžet na Raspberry Pi. Šetřete energii vašeho stroje!
+				</p>
+			</div>
+			<div class="eight wide center column">
+				<h1 class="hero ui icon header">
+					<i class="octicon octicon-code"></i> Open Source
+				</h1>
+				<p class="large">
+					Vše je na <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/">GitHubu</a>! Připojte se tím, že přispějete a uděláte tento projekt ještě lepší. Nestyďte se být přispěvatel!
+				</p>
+			</div>
+		</div>
 	{{else}}
 		<div class="ui stackable middle very relaxed page grid">
 			<div class="eight wide center column">


### PR DESCRIPTION
Translating of homepage is not possible via crowdin so here is proposed translation in Czech.

Wouldn't it be better to replace all texts with `{{.i18n.Tr "home.something"}}` and allow translation via crowdin?
