### PR TITLE
fix public will not be reused as public key after deleting as deploy key (#5671)

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -826,6 +826,11 @@ func DeleteDeployKey(doer *User, id int64) error {
 		if err = deletePublicKeys(sess, key.KeyID); err != nil {
 			return err
 		}
+
+		// after deleted the public keys, should rewrite the public keys file
+		if err = rewriteAllPublicKeys(sess); err != nil {
+			return err
+		}
 	}
 
 	return sess.Commit()


### PR DESCRIPTION
backport from #5671 