### PR TITLE
When redirecting clean the path to avoid redirecting to //www.othersite.com (#5669) (Backport v1.6)

### DIFF
--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -117,7 +117,7 @@ func (opts *Options) handle(ctx *macaron.Context, log *log.Logger, opt *Options)
 	if fi.IsDir() {
 		// Redirect if missing trailing slash.
 		if !strings.HasSuffix(ctx.Req.URL.Path, "/") {
-			http.Redirect(ctx.Resp, ctx.Req.Request, ctx.Req.URL.Path+"/", http.StatusFound)
+			http.Redirect(ctx.Resp, ctx.Req.Request, path.Clean(ctx.Req.URL.Path+"/"), http.StatusFound)
 			return true
 		}
 


### PR DESCRIPTION
Backport of #5669 to v1.6

Out of the box it is possible to get gitea to redirect to other servers:

```bash
$ curl -i --path-as-is http://localhost:3000//www.google.com/..
HTTP/1.1 302 Found
Content-Type: text/html; charset=utf-8
Location: //www.google.com/../
Date: Tue, 08 Jan 2019 21:53:05 GMT
Content-Length: 43

<a href="//www.google.com/../">Found</a>.
```

This PR cleans the path, prior to sending a` http.Redirect`.

Fix #5627

With thanks from @0x5c 

Fix #5627

Signed-off-by: Andrew Thornton <art27@cantab.net>