### PR TITLE
Keep file permissions during database migration

### DIFF
--- a/docker/usr/bin/entrypoint
+++ b/docker/usr/bin/entrypoint
@@ -32,7 +32,6 @@ done
 
 if [ -f /data/gitea/conf/app.ini ]; then
     echo "Found app.ini config file, migrating database"
-    chmod 644 /data/gitea/conf/app.ini
     chown -R ${USER_UID}:${USER_GID} /data/git /data/gitea
     su - ${USER} -c gitea migrate -c /data/gitea/conf/app.ini
 fi


### PR DESCRIPTION
PR #5290 added auto-migration to the docker entrypoint. It introduced a small security issue, by changing the file permissions of the `app.ini` to `644` (read permissions for all users). The the `app.ini` contains multiple credentials (smtp, database).

Either the user should be reponsible for appropriate file permissions, or the file permissions should be changed so that only the user can read this file (`600`).

This PR removes the file permission change, so the user is responsible for that. I can change it to setting secure permissions if requested.