### PR TITLE
Do not display the raw OpenID error in the UI #5705 (Backport v1.7)

### DIFF
--- a/routers/user/auth_openid.go
+++ b/routers/user/auth_openid.go
@@ -115,7 +115,8 @@ func SignInOpenIDPost(ctx *context.Context, form auth.SignInOpenIDForm) {
 	redirectTo := setting.AppURL + "user/login/openid"
 	url, err := openid.RedirectURL(id, redirectTo, setting.AppURL)
 	if err != nil {
-		ctx.RenderWithErr(err.Error(), tplSignInOpenID, &form)
+		log.Error(1, "Error in OpenID redirect URL: %s, %v", redirectTo, err.Error())
+		ctx.RenderWithErr(fmt.Sprintf("Unable to find OpenID provider in %s", redirectTo), tplSignInOpenID, &form)
 		return
 	}
 


### PR DESCRIPTION
If there are no `WHITELIST_URIS` or `BLACKLIST_URIS` set in the openid
section of the app.ini, it is possible that gitea can leak sensitive
information about the local network through the error provided by the
UI. This PR hides the error information and logs it.

Fix #4973

Signed-off-by: Andrew Thornton <art27@cantab.net>