### PR TITLE
Backport v1.6: fix: use correct value for "MSpan Structures Obtained" #4742 (#5706)

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -100,7 +100,7 @@
 				<dt>{{.i18n.Tr "admin.dashboard.mspan_structures_usage"}}</dt>
 				<dd>{{.SysStatus.MSpanInuse}}</dd>
 				<dt>{{.i18n.Tr "admin.dashboard.mspan_structures_obtained"}}</dt>
-				<dd>{{.SysStatus.HeapSys}}</dd>
+				<dd>{{.SysStatus.MSpanSys}}</dd>
 				<dt>{{.i18n.Tr "admin.dashboard.mcache_structures_usage"}}</dt>
 				<dd>{{.SysStatus.MCacheInuse}}</dd>
 				<dt>{{.i18n.Tr "admin.dashboard.mcache_structures_obtained"}}</dt>


### PR DESCRIPTION
Backport PR #5706 to `release/v1.6`