### PR TITLE
Log IP of failed ssh connection

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -135,9 +135,9 @@ func listen(config *ssh.ServerConfig, host string, port int) {
 			sConn, chans, reqs, err := ssh.NewServerConn(conn, config)
 			if err != nil {
 				if err == io.EOF {
-					log.Warn("SSH: Handshaking was terminated: %v", err)
+					log.Warn("SSH: Handshaking with %s was terminated: %v", conn.RemoteAddr(), err)
 				} else {
-					log.Error(3, "SSH: Error on handshaking: %v", err)
+					log.Error(3, "SSH: Error on handshaking with %s: %v", conn.RemoteAddr(), err)
 				}
 				return
 			}


### PR DESCRIPTION
Targets issue #5765

Log the IP address of a connecting remote machine in case of a SSH connection error for the built-in ssh server.