### PR TITLE
Fix the v78 migration script

### DIFF
--- a/models/migrations/v78.go
+++ b/models/migrations/v78.go
@@ -21,6 +21,7 @@ func renameRepoIsBareToIsEmpty(x *xorm.Engine) error {
 		IsEmpty bool `xorm:"INDEX"`
 	}
 
+	// First remove the index
 	sess := x.NewSession()
 	defer sess.Close()
 	if err := sess.Begin(); err != nil {
@@ -35,6 +36,17 @@ func renameRepoIsBareToIsEmpty(x *xorm.Engine) error {
 	}
 	if err != nil {
 		return fmt.Errorf("Drop index failed: %v", err)
+	}
+
+	if err = sess.Commit(); err != nil {
+		return err
+	}
+
+	// Then reset the values
+	sess = x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
 	}
 
 	if err := sess.Sync2(new(Repository)); err != nil {


### PR DESCRIPTION
Unfortunately the last fix didn't completely fix the migration to v79 of the db
due to bug with schema locking during sess.Sync2. This should fix this issue.

Fix #5759, #5779

Signed-off-by: Andrew Thornton <art27@cantab.net>