### PR TITLE
Fix TLS errors when using acme/autocert for local connections

### DIFF
--- a/modules/private/internal.go
+++ b/modules/private/internal.go
@@ -39,6 +39,7 @@ func decodeJSONError(resp *http.Response) *Response {
 func newInternalRequest(url, method string) *httplib.Request {
 	req := newRequest(url, method).SetTLSClientConfig(&tls.Config{
 		InsecureSkipVerify: true,
+		ServerName:         setting.Domain,
 	})
 	if setting.Protocol == setting.UnixSocket {
 		req.SetTransport(&http.Transport{


### PR DESCRIPTION
The upstream library `golang.org/x/crypto/acme/autocert`, a package that handles the Let's Encrypt certificate automation terminates incoming HTTP requests if the SNI (ServerName) field isn't in it's whitelist. For internal connection this domain is `localhost` which cannot be whitelisted for `autocert.Manager` to automatically try to handle certificates for.

This PR simply adds a `ServerName` setting to `TlsClientConfig` for connections made towards localhost, thus mitigating this issue, as the certificate requested from `autocert.Manager` indeed matches the domain in its whitelist.

This isn't an issue for non - Let's Encrypt setups either, and quite the opposite - in many cases should also be able to eliminate the need for `InsecureSkipVerify`.

Fixes: #5800 
