### PR TITLE
Make sure .git/info is created before generating .git/info/sparse-che…

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -447,7 +447,11 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		return fmt.Errorf("getDiffTree: %v", err)
 	}
 
-	sparseCheckoutListPath := filepath.Join(tmpBasePath, ".git", "info", "sparse-checkout")
+	infoPath := filepath.Join(tmpBasePath, ".git", "info")
+	if err := os.MkdirAll(infoPath, 0600); err != nil {
+		return fmt.Errorf("creating directory failed [%s]: %v", infoPath, err)
+	}
+	sparseCheckoutListPath := filepath.Join(infoPath, "sparse-checkout")
 	if err := ioutil.WriteFile(sparseCheckoutListPath, []byte(sparseCheckoutList), 0600); err != nil {
 		return fmt.Errorf("Writing sparse-checkout file to %s: %v", sparseCheckoutListPath, err)
 	}

--- a/models/pull.go
+++ b/models/pull.go
@@ -448,7 +448,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 	}
 
 	infoPath := filepath.Join(tmpBasePath, ".git", "info")
-	if err := os.MkdirAll(infoPath, 0600); err != nil {
+	if err := os.MkdirAll(infoPath, 0700); err != nil {
 		return fmt.Errorf("creating directory failed [%s]: %v", infoPath, err)
 	}
 	sparseCheckoutListPath := filepath.Join(infoPath, "sparse-checkout")


### PR DESCRIPTION
Under certain circumstances, `.git/info` might not exist.
Create it before generating `.git/info/sparse-checkout`.

Fixes #5824 