### PR TITLE
Backport #5830 : Include Go toolchain to --version

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ package main // import "code.gitea.io/gitea"
 
 import (
 	"os"
-	"strings"
 	"runtime"
+	"strings"
 
 	"code.gitea.io/gitea/cmd"
 	"code.gitea.io/gitea/modules/log"

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ package main // import "code.gitea.io/gitea"
 import (
 	"os"
 	"strings"
+	"runtime"
 
 	"code.gitea.io/gitea/cmd"
 	"code.gitea.io/gitea/modules/log"
@@ -61,8 +62,8 @@ arguments - which can alternatively be run by running the subcommand web.`
 
 func formatBuiltWith(Tags string) string {
 	if len(Tags) == 0 {
-		return ""
+		return " built with " + runtime.Version()
 	}
 
-	return " built with: " + strings.Replace(Tags, " ", ", ", -1)
+	return " built with " + runtime.Version() + " : " + strings.Replace(Tags, " ", ", ", -1)
 }


### PR DESCRIPTION
I backport the PR #5830 to rebuild with latest golang version to prevent [CVE-2019-6486](https://nvd.nist.gov/vuln/detail/CVE-2019-6486).
This will permit to know if a binary is potentially vulnerable. 
We should provide a newer binary after this.