### PR TITLE
Move input fields to add members to a team and repos to a team

### DIFF
--- a/templates/org/team/members.tmpl
+++ b/templates/org/team/members.tmpl
@@ -7,7 +7,23 @@
 			{{template "org/team/sidebar" .}}
 			<div class="ui ten wide column">
 				{{template "org/team/navbar" .}}
-				<div class="ui attached table segment members">
+				{{if .IsOrganizationOwner}}
+					<div class="ui attached segment">
+						<form class="ui form" id="add-member-form" action="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/add" method="post">
+							{{.CsrfTokenHtml}}
+							<input type="hidden" name="uid" value="{{.SignedUser.ID}}">
+							<div class="inline field ui left">
+								<div id="search-user-box" class="ui search">
+									<div class="ui input">
+										<input class="prompt" name="uname" placeholder="{{.i18n.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" required>
+									</div>
+								</div>
+							</div>
+							<button class="ui green button">{{.i18n.Tr "org.teams.add_team_member"}}</button>
+						</form>
+					</div>
+				{{end}}
+				<div class="ui bottom attached table segment members">
 					{{range .Team.Members}}
 						<div class="item">
 							{{if $.IsOrganizationOwner}}
@@ -24,22 +40,6 @@
 						</div>
 					{{end}}
 				</div>
-				{{if .IsOrganizationOwner}}
-					<div class="ui bottom attached segment">
-						<form class="ui form" id="add-member-form" action="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/add" method="post">
-							{{.CsrfTokenHtml}}
-							<input type="hidden" name="uid" value="{{.SignedUser.ID}}">
-							<div class="inline field ui left">
-								<div id="search-user-box" class="ui search">
-									<div class="ui input">
-										<input class="prompt" name="uname" placeholder="{{.i18n.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" required>
-									</div>
-								</div>
-							</div>
-							<button class="ui green button">{{.i18n.Tr "org.teams.add_team_member"}}</button>
-						</form>
-					</div>
-				{{end}}
 			</div>
 		</div>
 	</div>

--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -7,8 +7,23 @@
 			{{template "org/team/sidebar" .}}
 			<div class="ui ten wide column">
 				{{template "org/team/navbar" .}}
-				<div class="ui attached table segment repositories">
-					{{$canAddRemove := and $.IsOrganizationOwner (not (eq $.Team.LowerName "owners"))}}
+				{{$canAddRemove := and $.IsOrganizationOwner (not (eq $.Team.LowerName "owners"))}}
+				{{if $canAddRemove}}
+					<div class="ui attached segment">
+						<form class="ui form" id="add-repo-form" action="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/repo/add" method="post">
+							{{.CsrfTokenHtml}}
+							<div class="inline field ui left">
+								<div id="search-repo-box" data-uid="{{.Org.ID}}" class="ui search">
+									<div class="ui input">
+										<input class="prompt" name="repo_name" placeholder="{{.i18n.Tr "org.teams.search_repo_placeholder"}}" autocomplete="off" required>
+									</div>
+								</div>
+							</div>
+							<button class="ui green button">{{.i18n.Tr "org.teams.add_team_repository"}}</button>
+						</form>
+					</div>
+				{{end}}
+				<div class="ui bottom attached table segment repositories">
 					{{range .Team.Repos}}
 						<div class="item">
 							{{if $canAddRemove}}
@@ -25,21 +40,6 @@
 						</div>
 					{{end}}
 				</div>
-				{{if $canAddRemove}}
-					<div class="ui bottom attached segment">
-						<form class="ui form" id="add-repo-form" action="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/repo/add" method="post">
-							{{.CsrfTokenHtml}}
-							<div class="inline field ui left">
-								<div id="search-repo-box" data-uid="{{.Org.ID}}" class="ui search">
-									<div class="ui input">
-										<input class="prompt" name="repo_name" placeholder="{{.i18n.Tr "org.teams.search_repo_placeholder"}}" autocomplete="off" required>
-									</div>
-								</div>
-							</div>
-							<button class="ui green button">{{.i18n.Tr "org.teams.add_team_repository"}}</button>
-						</form>
-					</div>
-				{{end}}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Move input fields to the top so no scrolling is needed to add new members / repos to a team.

Currently if a team has many members and you want to add a new member you have to scroll a lot. Now the input fields are moved to the top of the list so adding users and repos to a team is easier.