### PR TITLE
Ensure issue.Poster is loaded in mailIssueCommentToParticipants

### DIFF
--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -39,11 +39,11 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 
 	// In case the issue poster is not watching the repository and is active,
 	// even if we have duplicated in watchers, can be safely filtered out.
-	poster, err := getUserByID(e, issue.PosterID)
+	err = issue.loadPoster(e)
 	if err != nil {
 		return fmt.Errorf("GetUserByID [%d]: %v", issue.PosterID, err)
 	}
-	if issue.PosterID != doer.ID && poster.IsActive && !poster.ProhibitLogin {
+	if issue.PosterID != doer.ID && issue.Poster.IsActive && !issue.Poster.ProhibitLogin {
 		participants = append(participants, issue.Poster)
 	}
 


### PR DESCRIPTION
Previous code could potentially dereference nil - this PR ensures
that the poster is loaded before dereferencing it.

Fixes issue reported on Discord by drewG 

Signed-off-by: Andrew Thornton <art27@cantab.net>
