### PR TITLE
Prevent nil dereference in mailIssueCommentToParticipants (#5891, #5895)

### DIFF
--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -39,11 +39,11 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 
 	// In case the issue poster is not watching the repository and is active,
 	// even if we have duplicated in watchers, can be safely filtered out.
-	poster, err := getUserByID(e, issue.PosterID)
+	err = issue.loadPoster(e)
 	if err != nil {
 		return fmt.Errorf("GetUserByID [%d]: %v", issue.PosterID, err)
 	}
-	if issue.PosterID != doer.ID && poster.IsActive && !poster.ProhibitLogin {
+	if issue.PosterID != doer.ID && issue.Poster.IsActive && !issue.Poster.ProhibitLogin {
 		participants = append(participants, issue.Poster)
 	}
 

--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -88,6 +88,10 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 		names = append(names, participants[i].Name)
 	}
 
+	if err := issue.loadRepo(e); err != nil {
+		return err
+	}
+
 	for _, to := range tos {
 		SendIssueCommentMail(issue, doer, content, comment, []string{to})
 	}


### PR DESCRIPTION
The previous code could potentially dereference nil - this PR ensures
that the poster and the repo are loaded before dereferencing them.

#5891

Signed-off-by: Andrew Thornton <art27@cantab.net>