### PR TITLE
Ensure repo is loaded in mailer (Completely fix #5891)

### DIFF
--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -88,6 +88,10 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 		names = append(names, participants[i].Name)
 	}
 
+	if err := issue.loadRepo(e); err != nil {
+		return err
+	}
+
 	for _, to := range tos {
 		SendIssueCommentMail(issue, doer, content, comment, []string{to})
 	}


### PR DESCRIPTION
Although it appears that the master branch is currently protected against the nil dereference bug referred to in #5891 - looking closer at the functions this calls these expect that the repo is loaded in the issue, which may not be available. 

This fix ensures that the repo is loaded before calling these methods meaning that any future changes will be protected against a nil dereference. (We should probably also "MustRepo" in those downstream functions - however, injudicious use could cause deadlocks.)

Signed-off-by: Andrew Thornton <art27@cantab.net>
