### PR TITLE
Only allow local login if password is non-empty

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -644,7 +644,7 @@ func UserSignIn(username, password string) (*User, error) {
 	if hasUser {
 		switch user.LoginType {
 		case LoginNoType, LoginPlain, LoginOAuth2:
-			if user.ValidatePassword(password) {
+			if user.IsPasswordSet() && user.ValidatePassword(password) {
 				return user, nil
 			}
 

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -582,7 +582,7 @@ func parseToken(authorization string) (*models.User, *models.Repository, string,
 		if err != nil {
 			return nil, nil, "basic", err
 		}
-		if !u.ValidatePassword(password) {
+		if !u.IsPasswordSet() || !u.ValidatePassword(password) {
 			return nil, nil, "basic", fmt.Errorf("Basic auth failed")
 		}
 		return u, nil, "basic", nil


### PR DESCRIPTION
Prohibit local login if password is empty. This protects oauth2 users created by
an admin with an empty password and with must_change_password set to false.

With thanks to @petercolberg 