### PR TITLE
UI: Better support for long repo names

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -2,7 +2,7 @@
 {{with .Repository}}
 	<div class="ui container">
 		<div class="ui stackable grid header-grid">
-			<div class="seven wide column">
+			<div class="nine wide column">
 				<div class="ui huge breadcrumb">
 					<i class="mega-octicon octicon-{{if .IsPrivate}}lock{{else if .IsMirror}}repo-clone{{else if .IsFork}}repo-forked{{else}}repo{{end}}"></i>
 					<a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a>
@@ -14,7 +14,7 @@
 				</div>
 			</div>
 
-			<div class="ui nine wide right aligned column">
+			<div class="ui seven wide right aligned column">
 				<div class="ui compact labeled button" tabindex="0">
 					<a class="ui compact button" href="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}">
 						<i class="icon fa-eye{{if not $.IsWatchingRepo}}-slash{{end}}"></i>{{if $.IsWatchingRepo}}{{$.i18n.Tr "repo.unwatch"}}{{else}}{{$.i18n.Tr "repo.watch"}}{{end}}

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -4,7 +4,7 @@
 			<img class="ui avatar image" src="{{.GetActAvatar}}" alt="">
 		</div>
 		<div class="ui grid">
-			<div class="ui thirteen wide column">
+			<div class="ui fourteen wide column">
 				<div class="{{if or (eq .GetOpType 5) (eq .GetOpType 18)}}push news{{end}}">
 					<p>
 						<a href="{{AppSubUrl}}/{{.GetActUserName}}" title="{{.GetActFullName}}">{{.ShortActUserName}}</a>
@@ -87,7 +87,7 @@
 					<p class="text italic light grey">{{TimeSince .GetCreate $.i18n.Lang}}</p>
 				</div>
 			</div>
-			<div class="ui three wide right aligned column">
+			<div class="ui two wide right aligned column">
 				<i class="text grey mega-octicon octicon-{{ActionIcon .GetOpType}}"></i>
 			</div>
 		</div>


### PR DESCRIPTION
Small template tweak to allow more of the repo name to show without wrapping.

#### Before
<img width="1070" alt="screenshot 2019-02-02 at 07 53 07" src="https://user-images.githubusercontent.com/115237/52161063-b2b00580-26bf-11e9-827d-cfb419149280.png">

#### After
<img width="1069" alt="screenshot 2019-02-02 at 07 52 59" src="https://user-images.githubusercontent.com/115237/52161064-b93e7d00-26bf-11e9-8376-e7e76a4e83e8.png">