### PR TITLE
Remove all CommitStatus when a repo is deleted

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1787,6 +1787,7 @@ func DeleteRepository(doer *User, uid, repoID int64) error {
 		&Webhook{RepoID: repoID},
 		&HookTask{RepoID: repoID},
 		&Notification{RepoID: repoID},
+		&CommitStatus{RepoID: repoID},
 	); err != nil {
 		return fmt.Errorf("deleteBeans: %v", err)
 	}


### PR DESCRIPTION
Added the CommitStatus struct to the list of beans that get cleaned up when a repository is deleted.
Resolves #5926

Signed-off-by: jolheiser <john.olheiser@gmail.com>

