### PR TITLE
Silence console logger in gitea serv  (#5887)

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -70,6 +70,7 @@ func checkLFSVersion() {
 }
 
 func setup(logPath string) {
+	log.DelLogger("console")
 	setting.NewContext()
 	checkLFSVersion()
 	log.NewGitLogger(filepath.Join(setting.LogRootPath, logPath))


### PR DESCRIPTION
By default, if `setting.NewContext()` prints out any warning logs, these are printed to the stdout breaking `git receive-pack` etc. meaning that even if there is a warning because of a minor problem in your app.ini but gitea starts despite this - you **CANNOT** push or pull over SSH.

This PR disables the console logger whilst in `serv.go`

Backport #5887 to fix #5866 

Signed-off-by: Andrew Thornton <art27@cantab.net>