### PR TITLE
Add label names as filter in issue search api

### DIFF
--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -203,13 +203,25 @@ func GetLabelInRepoByName(repoID int64, labelName string) (*Label, error) {
 	return getLabelInRepoByName(x, repoID, labelName)
 }
 
+// GetLabelsInRepoByNames returns a list of labels by names in a given
+// repository.
+// it silently ignores label IDs that do not belong to the repository.
+func GetLabelsInRepoByNames(repoID int64, labelNames []string) ([]*Label, error) {
+	labels := make([]*Label, 0, len(labelNames))
+	return labels, x.
+		Where("repo_id = ?", repoID).
+		In("name", labelNames).
+		Asc("name").
+		Find(&labels)
+}
+
 // GetLabelInRepoByID returns a label by ID in given repository.
 func GetLabelInRepoByID(repoID, labelID int64) (*Label, error) {
 	return getLabelInRepoByID(x, repoID, labelID)
 }
 
 // GetLabelsInRepoByIDs returns a list of labels by IDs in given repository,
-// it silently ignores label IDs that are not belong to the repository.
+// it silently ignores label IDs that do not belong to the repository.
 func GetLabelsInRepoByIDs(repoID int64, labelIDs []int64) ([]*Label, error) {
 	labels := make([]*Label, 0, len(labelIDs))
 	return labels, x.

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -205,7 +205,7 @@ func GetLabelInRepoByName(repoID int64, labelName string) (*Label, error) {
 
 // GetLabelsInRepoByNames returns a list of labels by names in a given
 // repository.
-// it silently ignores label IDs that do not belong to the repository.
+// it silently ignores label names that do not belong to the repository.
 func GetLabelsInRepoByNames(repoID int64, labelNames []string) ([]*Label, error) {
 	labels := make([]*Label, 0, len(labelNames))
 	return labels, x.

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -203,16 +203,17 @@ func GetLabelInRepoByName(repoID int64, labelName string) (*Label, error) {
 	return getLabelInRepoByName(x, repoID, labelName)
 }
 
-// GetLabelsInRepoByNames returns a list of labels by names in a given
+// GetLabelIDsInRepoByNames returns a list of labelIDs by names in a given
 // repository.
 // it silently ignores label names that do not belong to the repository.
-func GetLabelsInRepoByNames(repoID int64, labelNames []string) ([]*Label, error) {
-	labels := make([]*Label, 0, len(labelNames))
-	return labels, x.
+func GetLabelIDsInRepoByNames(repoID int64, labelNames []string) ([]int64, error) {
+	labelIDs := make([]int64, 0, len(labelNames))
+	return labelIDs, x.Table("label").
 		Where("repo_id = ?", repoID).
 		In("name", labelNames).
 		Asc("name").
-		Find(&labels)
+		Cols("id").
+		Find(&labelIDs)
 }
 
 // GetLabelInRepoByID returns a label by ID in given repository.

--- a/models/issue_label_test.go
+++ b/models/issue_label_test.go
@@ -81,6 +81,29 @@ func TestGetLabelInRepoByName(t *testing.T) {
 	assert.True(t, IsErrLabelNotExist(err))
 }
 
+func TestGetLabelInRepoByNames(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	labels, err := GetLabelsInRepoByNames(1, []string{"label1", "label2"})
+	assert.NoError(t, err)
+
+	assert.Len(t, labels, 2)
+
+	assert.Equal(t, "label1", labels[0].Name)
+	assert.Equal(t, "label2", labels[1].Name)
+}
+
+func TestGetLabelInRepoByNamesDiscardsNonExistentLabels(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+	// label3 doesn't exists.. See labels.yml
+	labels, err := GetLabelsInRepoByNames(1, []string{"label1", "label2", "label3"})
+	assert.NoError(t, err)
+
+	assert.Len(t, labels, 2)
+
+	assert.Equal(t, "label1", labels[0].Name)
+	assert.Equal(t, "label2", labels[1].Name)
+}
+
 func TestGetLabelInRepoByID(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	label, err := GetLabelInRepoByID(1, 1)

--- a/models/issue_label_test.go
+++ b/models/issue_label_test.go
@@ -83,25 +83,26 @@ func TestGetLabelInRepoByName(t *testing.T) {
 
 func TestGetLabelInRepoByNames(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
-	labels, err := GetLabelsInRepoByNames(1, []string{"label1", "label2"})
+	labelIDs, err := GetLabelIDsInRepoByNames(1, []string{"label1", "label2"})
 	assert.NoError(t, err)
 
-	assert.Len(t, labels, 2)
+	assert.Len(t, labelIDs, 2)
 
-	assert.Equal(t, "label1", labels[0].Name)
-	assert.Equal(t, "label2", labels[1].Name)
+	assert.Equal(t, int64(1), labelIDs[0])
+	assert.Equal(t, int64(2), labelIDs[1])
 }
 
 func TestGetLabelInRepoByNamesDiscardsNonExistentLabels(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	// label3 doesn't exists.. See labels.yml
-	labels, err := GetLabelsInRepoByNames(1, []string{"label1", "label2", "label3"})
+	labelIDs, err := GetLabelIDsInRepoByNames(1, []string{"label1", "label2", "label3"})
 	assert.NoError(t, err)
 
-	assert.Len(t, labels, 2)
+	assert.Len(t, labelIDs, 2)
 
-	assert.Equal(t, "label1", labels[0].Name)
-	assert.Equal(t, "label2", labels[1].Name)
+	assert.Equal(t, int64(1), labelIDs[0])
+	assert.Equal(t, int64(2), labelIDs[1])
+	assert.NoError(t, err)
 }
 
 func TestGetLabelInRepoByID(t *testing.T) {

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -85,7 +85,7 @@ func ListIssues(ctx *context.APIContext) {
 		var err error
 		labelIDs, err = models.GetLabelIDsInRepoByNames(ctx.Repo.Repository.ID, splitted)
 		if err != nil {
-			ctx.Error(500, "GetLabelsInRepoByNames", err)
+			ctx.Error(500, "GetLabelIDsInRepoByNames", err)
 			return
 		}
 	}

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -75,35 +75,31 @@ func ListIssues(ctx *context.APIContext) {
 		keyword = ""
 	}
 	var issueIDs []int64
-	var labelsID []int64
+	var labelIDs []int64
 	var err error
 	if len(keyword) > 0 {
 		issueIDs, err = indexer.SearchIssuesByKeyword(ctx.Repo.Repository.ID, keyword)
 	}
 
 	if splitted := strings.Split(ctx.Query("labels"), ","); len(splitted) > 0 {
-		labels, err := models.GetLabelsInRepoByNames(ctx.Repo.Repository.ID, splitted)
+		var err error
+		labelIDs, err = models.GetLabelIDsInRepoByNames(ctx.Repo.Repository.ID, splitted)
 		if err != nil {
 			ctx.Error(500, "GetLabelsInRepoByNames", err)
 			return
-		}
-
-		labelsID = make([]int64, 0, len(labels))
-		for i := range labels {
-			labelsID = append(labelsID, labels[i].ID)
 		}
 	}
 
 	// Only fetch the issues if we either don't have a keyword or the search returned issues
 	// This would otherwise return all issues if no issues were found by the search.
-	if len(keyword) == 0 || len(issueIDs) > 0 || len(labelsID) > 0 {
+	if len(keyword) == 0 || len(issueIDs) > 0 || len(labelIDs) > 0 {
 		issues, err = models.Issues(&models.IssuesOptions{
 			RepoIDs:  []int64{ctx.Repo.Repository.ID},
 			Page:     ctx.QueryInt("page"),
 			PageSize: setting.UI.IssuePagingNum,
 			IsClosed: isClosed,
 			IssueIDs: issueIDs,
-			LabelIDs: labelsID,
+			LabelIDs: labelIDs,
 		})
 	}
 

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -82,7 +82,6 @@ func ListIssues(ctx *context.APIContext) {
 	}
 
 	if splitted := strings.Split(ctx.Query("labels"), ","); len(splitted) > 0 {
-		var err error
 		labelIDs, err = models.GetLabelIDsInRepoByNames(ctx.Repo.Repository.ID, splitted)
 		if err != nil {
 			ctx.Error(500, "GetLabelIDsInRepoByNames", err)

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -45,7 +45,7 @@ func ListIssues(ctx *context.APIContext) {
 	//   type: string
 	// - name: labels
 	//   in: query
-	//   description: comma seperated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded
+	//   description: comma separated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded
 	//   type: string
 	// - name: page
 	//   in: query

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -21,7 +21,7 @@
     },
     "version": "1.1.1"
   },
-  "basePath": "/api/v1",
+  "basePath": "{{AppSubUrl}}/api/v1",
   "paths": {
     "/admin/orgs": {
       "get": {
@@ -2061,7 +2061,7 @@
           },
           {
             "type": "string",
-            "description": "comma seperated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded",
+            "description": "comma separated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded",
             "name": "labels",
             "in": "query"
           },

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -21,7 +21,7 @@
     },
     "version": "1.1.1"
   },
-  "basePath": "{{AppSubUrl}}/api/v1",
+  "basePath": "/api/v1",
   "paths": {
     "/admin/orgs": {
       "get": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -2060,6 +2060,12 @@
             "in": "query"
           },
           {
+            "type": "string",
+            "description": "comma seperated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded",
+            "name": "labels",
+            "in": "query"
+          },
+          {
             "type": "integer",
             "description": "page number of requested issues",
             "name": "page",


### PR DESCRIPTION
I am working on some sort of Gitea integration that needs to comment on a list of issues
with a certain label. I don't want to manually keep track of the label ID for each repository 
I am running the service against. 


Sample request:

```
http://localhost:3000/api/v1/repos/damn/KKKKK/issues?labels=bug,duplicate
```
