### PR TITLE
Pull request conflict files detection

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -853,19 +853,26 @@ func (pr *PullRequest) testPatch(e Engine) (err error) {
 		for i := range patchConflicts {
 			if strings.Contains(stderr, patchConflicts[i]) {
 				log.Trace("PullRequest[%d].testPatch (apply): has conflict", pr.ID)
-				fmt.Println(stderr)
+				const prefix = "error: patch failed:"
 				pr.Status = PullRequestStatusConflict
-				if patchConflicts[i] == "error:" {
-					pr.ConflictedFiles = make([]string, 0, 5)
-					scanner := bufio.NewScanner(strings.NewReader(stderr))
-					for scanner.Scan() {
-						line := scanner.Text()
-						const prefix = "error: patch failed:"
-						if strings.HasPrefix(line, prefix) {
-							pr.ConflictedFiles = append(pr.ConflictedFiles, strings.TrimSpace(strings.Split(line[len(prefix):], ":")[0]))
-						}
+				pr.ConflictedFiles = make([]string, 0, 5)
+				scanner := bufio.NewScanner(strings.NewReader(stderr))
+				for scanner.Scan() {
+					line := scanner.Text()
+
+					if strings.HasPrefix(line, prefix) {
+						pr.ConflictedFiles = append(pr.ConflictedFiles, strings.TrimSpace(strings.Split(line[len(prefix):], ":")[0]))
+					}
+					// only list 10 conflicted files
+					if len(pr.ConflictedFiles) >= 10 {
+						break
 					}
 				}
+
+				if len(pr.ConflictedFiles) > 0 {
+					log.Trace("Found %d files conflicted: %v", len(pr.ConflictedFiles), pr.ConflictedFiles)
+				}
+
 				return nil
 			}
 		}
@@ -1388,7 +1395,7 @@ func (pr *PullRequest) checkAndUpdateStatus() {
 
 	// Make sure there is no waiting test to process before leaving the checking status.
 	if !pullRequestQueue.Exist(pr.ID) {
-		if err := pr.UpdateCols("status"); err != nil {
+		if err := pr.UpdateCols("status, conflicted_files"); err != nil {
 			log.Error(4, "Update[%d]: %v", pr.ID, err)
 		}
 	}
@@ -1407,6 +1414,11 @@ func (pr *PullRequest) IsWorkInProgress() bool {
 		}
 	}
 	return false
+}
+
+// IsFilesConflicted determine if the  Pull Request has files conflicted.
+func (pr *PullRequest) IsFilesConflicted() bool {
+	return len(pr.ConflictedFiles) > 0
 }
 
 // GetWorkInProgressPrefix returns the prefix used to mark the pull request as a work in progress.

--- a/models/pull.go
+++ b/models/pull.go
@@ -1416,7 +1416,7 @@ func (pr *PullRequest) IsWorkInProgress() bool {
 	return false
 }
 
-// IsFilesConflicted determine if the  Pull Request has files conflicted.
+// IsFilesConflicted determines if the  Pull Request has changes conflicting with the target branch.
 func (pr *PullRequest) IsFilesConflicted() bool {
 	return len(pr.ConflictedFiles) > 0
 }

--- a/models/pull.go
+++ b/models/pull.go
@@ -844,6 +844,7 @@ func (pr *PullRequest) testPatch(e Engine) (err error) {
 		args = append(args, "--ignore-whitespace")
 	}
 	args = append(args, patchPath)
+	pr.ConflictedFiles = []string{}
 
 	_, stderr, err = process.GetManager().ExecDirEnv(-1, "", fmt.Sprintf("testPatch (git apply --check): %d", pr.BaseRepo.ID),
 		[]string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()},

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -871,7 +871,7 @@ pulls.has_merged = The pull request has been merged.
 pulls.title_wip_desc = `<a href="#">Start the title with <strong>%s</strong></a> to prevent the pull request from being merged accidentally.`
 pulls.cannot_merge_work_in_progress = This pull request is marked as a work in progress. Remove the <strong>%s</strong> prefix from the title when it's ready
 pulls.data_broken = This pull request is broken due to missing fork information.
-pulls.files_conflicted = This pull request has some files conflicted with target branch.
+pulls.files_conflicted = This pull request has changes conflicting with the target branch.
 pulls.is_checking = "Merge conflict checking is in progress. Try again in few moments."
 pulls.blocked_by_approvals = "This Pull Request doesn't have enough approvals yet. %d of %d approvals granted."
 pulls.can_auto_merge_desc = This pull request can be merged automatically.

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -871,6 +871,7 @@ pulls.has_merged = The pull request has been merged.
 pulls.title_wip_desc = `<a href="#">Start the title with <strong>%s</strong></a> to prevent the pull request from being merged accidentally.`
 pulls.cannot_merge_work_in_progress = This pull request is marked as a work in progress. Remove the <strong>%s</strong> prefix from the title when it's ready
 pulls.data_broken = This pull request is broken due to missing fork information.
+pulls.files_conflicted = This pull request has some files conflicted with target branch.
 pulls.is_checking = "Merge conflict checking is in progress. Try again in few moments."
 pulls.blocked_by_approvals = "This Pull Request doesn't have enough approvals yet. %d of %d approvals granted."
 pulls.can_auto_merge_desc = This pull request can be merged automatically.

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -345,6 +345,11 @@ func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.PullReq
 		ctx.Data["WorkInProgressPrefix"] = pull.GetWorkInProgressPrefix()
 	}
 
+	if pull.IsFilesConflicted() {
+		ctx.Data["IsPullFilesConflicted"] = true
+		ctx.Data["ConflictedFiles"] = pull.ConflictedFiles
+	}
+
 	ctx.Data["NumCommits"] = prInfo.Commits.Len()
 	ctx.Data["NumFiles"] = prInfo.NumFiles
 	return prInfo

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -38,6 +38,7 @@
 	{{if .Issue.PullRequest.HasMerged}}purple
 	{{else if .Issue.IsClosed}}grey
 	{{else if .IsPullWorkInProgress}}grey
+	{{else if .IsFilesConflicted}}grey
 	{{else if .IsPullRequestBroken}}red
 	{{else if .IsBlockedByApprovals}}red
 	{{else if .Issue.PullRequest.IsChecking}}yellow
@@ -58,6 +59,14 @@
 			{{else if .Issue.IsClosed}}
 				<div class="item text grey">
 					{{$.i18n.Tr "repo.pulls.reopen_to_merge"}}
+				</div>
+			{{else if .IsPullFilesConflicted}}
+				<div class="item text grey">
+					<span class="octicon octicon-x"></span>
+					{{$.i18n.Tr "repo.pulls.files_conflicted"}}
+					{{range .ConflictedFiles}}
+						<div>{{.}}</div>
+					{{end}}
 				</div>
 			{{else if .IsPullRequestBroken}}
 				<div class="item text red">


### PR DESCRIPTION
This pull request will add a new column on table `pull_request` named `conflicted_files` that will store less than 10 conflicted file names which will be filled on `testPatch` method. Will fix #887 