### PR TITLE
Fix empty ssh key importing in ldap

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -1501,9 +1501,12 @@ func synchronizeLdapSSHPublicKeys(usr *User, s *LoginSource, SSHPublicKeys []str
 	// Get Public Keys from LDAP and skip duplicate keys
 	var ldapKeys []string
 	for _, v := range SSHPublicKeys {
-		ldapKey := strings.Join(strings.Split(v, " ")[:2], " ")
-		if !util.ExistsInSlice(ldapKey, ldapKeys) {
-			ldapKeys = append(ldapKeys, ldapKey)
+		sshKeySplit := strings.Split(v, " ")
+		if len(sshKeySplit) > 1 {
+			ldapKey := strings.Join(sshKeySplit[:2], " ")
+			if !util.ExistsInSlice(ldapKey, ldapKeys) {
+				ldapKeys = append(ldapKeys, ldapKey)
+			}
 		}
 	}
 


### PR DESCRIPTION
The current implementation assumes that any LDAP will either return a valid SSH public key or none at all. It appears that some LDAPs will simply return "" which will cause an out of bounds in our code. 

This code protects the importation of public keys by checking that these can be split in to a space separated string (presumably key type and key content - checked later). If the string provided cannot do this it is ignored.

Many thanks to @silverwind for their excellent bug report.

Fix #5975