### PR TITLE
Support n as a line highlight prefix

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1602,9 +1602,9 @@ function initCodeView() {
                 $("html, body").scrollTop($first.offset().top - 200);
                 return;
             }
-            m = window.location.hash.match(/^#(L\d+)$/);
+            m = window.location.hash.match(/^#(L|n)(\d+)$/);
             if (m) {
-                $first = $list.filter('.' + m[1]);
+                $first = $list.filter('.L' + m[2]);
                 selectRange($list, $first);
                 $("html, body").scrollTop($first.offset().top - 200);
             }


### PR DESCRIPTION
We're working on rolling out gitea as a replacement for a fairly
large cgit installation. Part of this involves a metric ton of
mod_rewrite rules so that links people have out in the wild will
still work. Unfortunately, cgit uses #n1 in the url to indicate
a single line highlight, which doesn't get passed to the server
and therefore can't be rewritten.

We've got a local workaround by shoving a script block into a
custom header template, but thought it might be nicer to upstream
a simple patch to support #n as a prefix for single line highlights.
(luckily for simplicity, cgit does not support ranges)

Signed-off-by: Monty Taylor <mordred@inaugust.com>