### PR TITLE
Update U2F Section of app.ini.sample

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -662,11 +662,12 @@ sv-SE = sv
 ko-KR = ko
 
 [U2F]
+; NOTE: THE DEFAULT VALUES HERE WILL NEED TO BE CHANGED
 ; Two Factor authentication with security keys
 ; https://developers.yubico.com/U2F/App_ID.html
-APP_ID = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
-; Comma seperated list of truisted facets
-TRUSTED_FACETS = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
+;APP_ID = http://localhost:3000/
+; Comma seperated list of trusted facets
+;TRUSTED_FACETS = http://localhost:3000/
 
 ; Extension mapping to highlight class
 ; e.g. .toml=ini


### PR DESCRIPTION
Currently when users copy the default values over to their `app.ini`, Gitea crashes on startup due to a panic from the upstream ini module.  
Perhaps in the future the module will support referencing keys from other non-default sections, but currently it does not.  
  
I commented them out and added a note that users will need to modify them to get them working. I don't particularly love all-caps notes...but without them it blended into the rest of the comments. Let me know if you prefer changes to the wording (or not all caps).  
I thought of leaving the values as `%(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/` and just commenting them out, however I didn't want to imply that those values would work.  
Instead I changed them to what the default values would resolve to, `http://localhost:3000/`

Affected Issues: #4260 #4692 #5394 #5406 #5526
Resolves #4692 
Resolves #5982
