### PR TITLE
UI: Fix header menu misalignment

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -56,14 +56,14 @@
 				</span>
 				<div class="menu">
 					<a class="item" href="{{AppSubUrl}}/repo/create">
-						<i class="fitted octicon octicon-plus"></i> {{.i18n.Tr "new_repo"}}
+						<i class="octicon octicon-plus"></i> {{.i18n.Tr "new_repo"}}
 					</a>
 					<a class="item" href="{{AppSubUrl}}/repo/migrate">
-						<i class="fitted octicon octicon-repo-clone"></i> {{.i18n.Tr "new_migrate"}}
+						<i class="octicon octicon-repo-clone"></i> {{.i18n.Tr "new_migrate"}}
 					</a>
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
-						<i class="fitted octicon octicon-organization"></i> {{.i18n.Tr "new_org"}}
+						<i class="octicon octicon-organization"></i> {{.i18n.Tr "new_org"}}
 					</a>
 					{{end}}
 				</div><!-- end content create new menu -->


### PR DESCRIPTION
The icons in the '+' menu were misaligned, fixed it by using the same icon classes as on the user menu.

#### Before
<img width="198" alt="screenshot 2019-02-08 at 08 33 34" src="https://user-images.githubusercontent.com/115237/52464750-5d229f80-2b7c-11e9-964e-9ed66504b34a.png">

#### After
<img width="211" alt="screenshot 2019-02-08 at 08 33 22" src="https://user-images.githubusercontent.com/115237/52464759-627fea00-2b7c-11e9-8754-c391075b394b.png">
