### PR TITLE
Fix metrics auth token detection

### DIFF
--- a/routers/metrics.go
+++ b/routers/metrics.go
@@ -17,7 +17,7 @@ func Metrics(ctx *context.Context) {
 		promhttp.Handler().ServeHTTP(ctx.Resp, ctx.Req.Request)
 		return
 	}
-	header := ctx.Header().Get("Authorization")
+	header := ctx.Req.Header.Get("Authorization")
 	if header == "" {
 		ctx.Error(401)
 		return


### PR DESCRIPTION
Metrics token authorization currently does not work with token and metrics enabled in config. There's always 401 response without any data. This fixes header detection.