### PR TITLE
Implement basic file uploads to wiki

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -483,6 +483,17 @@ func (f *NewWikiForm) Validate(ctx *macaron.Context, errs binding.Errors) bindin
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
 
+// UploadWikiFileForm form for uploading wiki file
+type UploadWikiFileForm struct {
+	Message string
+	Files   []string
+}
+
+// Validate validates the fields
+func (f *UploadWikiFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
+	return validate(errs, ctx.Data, f, ctx.Locale)
+}
+
 // ___________    .___.__  __
 // \_   _____/  __| _/|__|/  |_
 //  |    __)_  / __ | |  \   __\

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -938,6 +938,7 @@ wiki.last_commit_info = %s edited this page %s
 wiki.edit_page_button = Edit
 wiki.new_page_button = New Page
 wiki.delete_page_button = Delete Page
+wiki.upload_files_button = Upload Files
 wiki.delete_page_notice_1 = Deleting the wiki page '%s' cannot be undone. Continue?
 wiki.page_already_exists = A wiki page with the same name already exists.
 wiki.reserved_page = The wiki page name '%s' is reserved.

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -697,6 +697,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.NewWikiPost)
 				m.Combo("/:page/_edit").Get(repo.EditWiki).
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.EditWikiPost)
+				m.Combo("/_upload").Get(repo.UploadWikiFile).
+					Post(bindIgnErr(auth.UploadWikiFileForm{}), repo.UploadWikiFilePost)
 				m.Post("/:page/delete", repo.DeleteWikiPagePost)
 			}, context.RepoMustNotBeArchived(), reqSignIn, reqRepoWikiWriter)
 		}, repo.MustEnableWiki, context.RepoRef())

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -7,6 +7,7 @@
 			{{if and .CanWriteWiki (not .IsRepositoryMirror)}}
 			<div class="ui right">
 				<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+				<a class="ui blue small button" href="{{.RepoLink}}/wiki/_upload">{{.i18n.Tr "repo.wiki.upload_files_button"}}</a>
 			</div>
 			{{end}}
 		</div>

--- a/templates/repo/wiki/upload.tmpl
+++ b/templates/repo/wiki/upload.tmpl
@@ -1,0 +1,23 @@
+{{template "base/head" .}}
+<div class="repository file editor upload">
+	{{template "repo/header" .}}
+	<div class="ui container">
+		{{template "base/alert" .}}
+		<form class="ui comment form" method="post">
+			{{.CsrfTokenHtml}}
+			<div class="field">
+				<div class="files"></div>
+				<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{.RepoLink}}/upload-file" data-remove-url="{{.RepoLink}}/upload-remove" data-csrf="{{.CsrfToken}}" data-accepts="{{.UploadAllowedTypes}}" data-max-file="{{.UploadMaxFiles}}" data-max-size="{{.UploadMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
+			</div>
+            <div class="field">
+				<input name="message" placeholder="{{.i18n.Tr "repo.wiki.default_commit_message"}}">
+			</div>
+			<div class="text right">
+				<button class="ui green button">
+					{{.i18n.Tr "repo.wiki.upload_files_button"}}
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -68,6 +68,7 @@
 							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
 							<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
 							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
+							<a class="ui blue small button" href="{{.RepoLink}}/wiki/_upload">{{.i18n.Tr "repo.wiki.upload_files_button"}}</a>
 						</div>
 					{{end}}
 				</div>


### PR DESCRIPTION
Closes #574

Signed-off-by: Gabriel Silva Simões <simoes.sgabriel@gmail.com>

This allows uploading files to the root of the wiki repo. It doesn't add any deleting feature, but I suppose if a user needs that feature, he/she should be cloning the wiki repo and managing the files there (which is the only way to do that on Github),