### PR TITLE
update default value of `--must-change-password` cli flag

### DIFF
--- a/docs/content/doc/usage/command-line.md
+++ b/docs/content/doc/usage/command-line.md
@@ -57,7 +57,7 @@ Admin operations:
             - `--admin`: If provided, this makes the user an admin. Optional.
             - `--config path`: Gitea configuration file path. Optional. (default: custom/conf/app.ini).
             - `--must-change-password`: If provided, the created user will be required to choose a newer password after
-	    the initial login. Optional. (default: false).
+	    the initial login. Optional. (default: true).
             - ``--random-password``: If provided, a randomly generated password will be used as the password of
 	    the created user. The value of `--password` will be discarded. Optional.
             - `--random-password-length`: If provided, it will be used to configure the length of the randomly


### PR DESCRIPTION
Fixes the confusion caused at https://github.com/go-gitea/gitea/issues/6005