### PR TITLE
Fix panic: template: repo/issue/list:210: unexpected "=" in operand

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -953,6 +953,25 @@ func (issue *Issue) GetTasksDone() int {
 	return len(issueTasksDonePat.FindAllStringIndex(issue.Content, -1))
 }
 
+// GetLastEventTimestamp returns the last user visible event timestamp, either the creation of this issue or the close.
+func (issue *Issue) GetLastEventTimestamp() util.TimeStamp {
+	if issue.IsClosed {
+		return issue.ClosedUnix
+	}
+	return issue.CreatedUnix
+}
+
+// GetLastEventLabel returns the localization label for the current issue.
+func (issue *Issue) GetLastEventLabel() string {
+	if issue.IsClosed {
+		if issue.IsPull && issue.PullRequest.HasMerged {
+			return "repo.pulls.merged_by"
+		}
+		return "repo.issues.closed_by"
+	}
+	return "repo.issues.opened_by"
+}
+
 // NewIssueOptions represents the options of a new issue.
 type NewIssueOptions struct {
 	Repo        *Repository

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -181,7 +181,6 @@
 
 		<div class="issue list">
 			{{range .Issues}}
-				{{ $timeStr:= TimeSinceUnix .CreatedUnix $.Lang }}
 				<li class="item">
 					<div class="ui checkbox issue-checkbox">
 						<input type="checkbox" data-issue-id={{.ID}}></input>
@@ -205,22 +204,8 @@
 					{{end}}
 
 					<p class="desc">
-						{{ $textToTranslate := "repo.issues.opened_by" }}
-						{{ if not .IsClosed }}
-							{{ $timeStr = TimeSinceUnix .CreatedUnix $.Lang }}
-						{{ else if and .IsClosed .IsPull  }}
-							{{ $timeStr = TimeSinceUnix .ClosedUnix $.Lang }}
-							{{ if .PullRequest.HasMerged }}
-								{{ $textToTranslate = "repo.pulls.merged_by"}}
-							{{ else }}
-								{{ $textToTranslate = "repo.issues.closed_by"}}
-							{{ end }}
-						{{ else }}
-							{{ $timeStr = TimeSinceUnix .ClosedUnix $.Lang }}
-							{{ $textToTranslate = "repo.issues.closed_by"}}
-						{{ end }}
-
-						{{$.i18n.Tr $textToTranslate $timeStr .Poster.HomeLink .Poster.Name | Safe}}
+						{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.Lang }}
+						{{$.i18n.Tr .GetLastEventLabel $timeStr .Poster.HomeLink .Poster.Name | Safe}}
 
 						{{$tasks := .GetTasks}}
 						{{if gt $tasks 0}}


### PR DESCRIPTION
It seems, that a recent change introduced invalid template content, which resulted in a startup failure:

```

 AppPath: /opt/gitea/gitea
 AppWorkPath: /var/lib/gitea
 Custom path: /var/lib/gitea/custom
 Log path: /var/log/gitea
 panic: template: repo/issue/list:210: unexpected "=" in operand
 goroutine 1 [running]:
 html/template.Must(0x0, 0x192b4a0, 0xc420d1a070, 0x0)
         /var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go-1.10.3/src/html/template/template.go:372 +0x54
 code.gitea.io/gitea/vendor/gopkg.in/macaron%2ev1.compile(0x17d26f2, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42000c120, 0x2, 0x2, ...)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/gopkg.in/macaron.v1/render.go:292 +0x21d
 code.gitea.io/gitea/vendor/gopkg.in/macaron%2ev1.(*TemplateSet).Set(0xc4207e6630, 0x17cc1cb, 0x7, 0xc4207e4000, 0x0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/gopkg.in/macaron.v1/render.go:318 +0x61
 code.gitea.io/gitea/vendor/gopkg.in/macaron%2ev1.renderHandler(0x17d26f2, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42000c120, 0x2, 0x2, ...)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/gopkg.in/macaron.v1/render.go:385 +0x12d
 code.gitea.io/gitea/vendor/gopkg.in/macaron%2ev1.Renderer(0xc4208d5240, 0x1, 0x1, 0xc42000c100, 0x0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/gopkg.in/macaron.v1/render.go:422 +0x165
 code.gitea.io/gitea/modules/templates.HTMLRenderer(0xc42002ed80, 0x16218a0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/modules/templates/static.go:117 +0x155
 code.gitea.io/gitea/routers/routes.NewMacaron(0xc420231680)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/routers/routes/routes.go:107 +0x2fe
 code.gitea.io/gitea/cmd.runWeb(0xc420231680, 0x0, 0x0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/cmd/web.go:125 +0xb2
 code.gitea.io/gitea/vendor/github.com/urfave/cli.HandleAction(0x15aeb40, 0x1848c20, 0xc420231680, 0xc42014d200, 0x0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/app.go:471 +0xad
 code.gitea.io/gitea/vendor/github.com/urfave/cli.Command.Run(0x17c6b46, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x17f092c, 0x16, 0x0, ...)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/command.go:191 +0xa0e
 code.gitea.io/gitea/vendor/github.com/urfave/cli.(*App).Run(0xc4205801a0, 0xc4200be040, 0x4, 0x4, 0x0, 0x0)
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/app.go:241 +0x5b8
 main.main()
         /var/lib/jenkins/workspace/build_gitea/src/code.gitea.io/gitea/main.go:57 +0x495

```