### PR TITLE
Create repository on organisation by default on its dashboard (#6026)

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -44,12 +44,14 @@
 						<div v-show="tab === 'repos'" class="ui tab active list dashboard-repos">
 							<h4 class="ui top attached header">
 								{{.i18n.Tr "home.my_repos"}} <span class="ui grey label">${reposTotalCount}</span>
+								{{if or (not .ContextUser.IsOrganization) .IsOrganizationOwner}}
 								<div class="ui right">
-									<a class="poping up" :href="suburl + '/repo/create'" data-content="{{.i18n.Tr "new_repo"}}" data-variation="tiny inverted" data-position="left center">
+									<a class="poping up" :href="suburl + '/repo/create{{if .ContextUser.IsOrganization}}?org={{.ContextUser.ID}}{{end}}'" data-content="{{.i18n.Tr "new_repo"}}" data-variation="tiny inverted" data-position="left center">
 										<i class="plus icon"></i>
 										<span class="sr-only">{{.i18n.Tr "new_repo"}}</span>
 									</a>
 								</div>
+								{{end}}
 							</h4>
 							<div class="ui attached secondary segment repos-search">
 								<div class="ui fluid icon input" :class="{loading: isLoading}">


### PR DESCRIPTION
Backport #6026 

* Create repository on organisation by default on its dashboard
* Only show owners the add new repositories to an organisation button.

Fix #3253

Signed-off-by: Andrew Thornton <art27@cantab.net>