### PR TITLE
allow binding gitea to privileged port, gated behind environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apk --no-cache add \
     s6 \
     sqlite \
     su-exec \
-    tzdata
+    tzdata \
+    libcap
 
 RUN addgroup \
     -S -g 1000 \

--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -44,3 +44,4 @@ if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${U
 if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi
 if ! [[ $(ls -ld /data/git   | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/git;   fi
 chmod 0755 /data/gitea /app/gitea /data/git
+if [[ "${ALLOW_PRIVILEGED_PORT}" = 1 ]]; then setcap 'cap_net_bind_service=+ep' /app/gitea/gitea; fi

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -259,6 +259,7 @@ You can configure some of Gitea's settings via environment variables:
 * `REQUIRE_SIGNIN_VIEW`: **false**: Enable this to force users to log in to view any page.
 * `USER_UID`: **1000**: The UID (Unix user ID) of the user that runs Gitea within the container. Match this to the UID of the owner of the `/data` volume if using host volumes (this is not necessary with named volumes).
 * `USER_GID`: **1000**: The GID (Unix group ID) of the user that runs Gitea within the container. Match this to the GID of the owner of the `/data` volume if using host volumes (this is not necessary with named volumes).
+* `ALLOW_PRIVILEGED_PORT`: **0**: Set to 1 to allow the gitea service to run on a port < 1024.
 
 # Customization
 


### PR DESCRIPTION
This is in reference to some issues documented in #1190 and hopefully a more acceptable method of accomplishing what #2183 was trying to do.

This allows the gitea service to run on a privileged port if the container is run with the environment variable `ALLOW_PRIVILEGED_PORT` is set to 1.

This means the security of the image is unchanged for users who do not run the container with this environment variable, but it gives those who choose to the ability to run gitea on a privileged port.

This is important in our environment because we run docker with a custom network plugin and with docker's iptables integration disabled.