### PR TITLE
Recover panic in orgmode.Render if bad orgfile (#4982) (#5903)

### DIFF
--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -5,6 +5,7 @@
 package markup
 
 import (
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/markdown"
 
@@ -31,7 +32,13 @@ func (Parser) Extensions() []string {
 }
 
 // Render renders orgmode rawbytes to HTML
-func Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
+func Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) (result []byte) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Error(4, "Panic in orgmode.Render: %v Just returning the rawBytes", err)
+			result = rawBytes
+		}
+	}()
 	htmlFlags := blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_SKIP_STYLE
 	htmlFlags |= blackfriday.HTML_OMIT_CONTENTS
@@ -40,9 +47,8 @@ func Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki b
 		URLPrefix: urlPrefix,
 		IsWiki:    isWiki,
 	}
-
-	result := goorgeous.Org(rawBytes, renderer)
-	return result
+	result = goorgeous.Org(rawBytes, renderer)
+	return
 }
 
 // RenderString reners orgmode string to HTML string


### PR DESCRIPTION
Backport #5903 to v1.7

This PR protects against the panic referred to in chaseadmsio/goorgeous#82
by recovering from the panic and just returning the raw bytes if
there is an error.

Signed-off-by: Andrew Thornton <art27@cantab.net>