### PR TITLE
Show private organization for admin, fix #6111

### DIFF
--- a/routers/admin/orgs.go
+++ b/routers/admin/orgs.go
@@ -25,5 +25,6 @@ func Organizations(ctx *context.Context) {
 	routers.RenderUserSearch(ctx, &models.SearchUserOptions{
 		Type:     models.UserTypeOrganization,
 		PageSize: setting.UI.Admin.OrgPagingNum,
+		Private:  true,
 	}, tplOrgs)
 }


### PR DESCRIPTION
Currently admin can't see the private organization on $gitea/admin/orgs, however it is visible on the explore page
