### PR TITLE
Load Issue attributes for API call

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -142,7 +142,7 @@ func GetIssue(ctx *context.APIContext) {
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/Issue"
-	issue, err := models.GetIssueByIndex(ctx.Repo.Repository.ID, ctx.ParamsInt64(":index"))
+	issue, err := models.GetIssueWithAttrsByIndex(ctx.Repo.Repository.ID, ctx.ParamsInt64(":index"))
 	if err != nil {
 		if models.IsErrIssueNotExist(err) {
 			ctx.Status(404)


### PR DESCRIPTION
Fixes #6056 

Issues were being loaded raw instead of with attributes. Changed the API to use the func that loads attributes.

![issue api milestone](https://user-images.githubusercontent.com/42128690/53030220-06488000-3430-11e9-9ae4-26086ce67a4e.png)
