### PR TITLE
Replace openssh with openssh-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk --no-cache add \
     gettext \
     git \
     linux-pam \
-    openssh \
+    openssh-server \
     s6 \
     sqlite \
     su-exec \


### PR DESCRIPTION
We don't need openssh-client.
It will allow to save around 3.2 megabytes from the final image. 
I have tested cloning and pushing the change to the repository and everything functioned correctly.