### PR TITLE
Prevent double-close of issues

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -706,7 +706,7 @@ func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed bool) (er
 	}
 
 	// Nothing should be performed if current status is same as target status
-	if issue.IsClosed == isClosed || currentIssue.IsClosed == isClosed {
+	if currentIssue.IsClosed == isClosed {
 		return nil
 	}
 

--- a/models/issue.go
+++ b/models/issue.go
@@ -699,8 +699,14 @@ func UpdateIssueCols(issue *Issue, cols ...string) error {
 }
 
 func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed bool) (err error) {
+	// Reload the issue
+	currentIssue, err := getIssueByID(e, issue.ID)
+	if err != nil {
+		return err
+	}
+
 	// Nothing should be performed if current status is same as target status
-	if issue.IsClosed == isClosed {
+	if issue.IsClosed == isClosed || currentIssue.IsClosed == isClosed {
 		return nil
 	}
 


### PR DESCRIPTION
It's currently possible to end double-closing issues thus leading to a negative number of pulls remaining to be closed. This PR reloads the issue from the database within the transaction and checks that it isn't already closed in the database.