### PR TITLE
Remove visitLinksForShortLinks features

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -171,11 +171,6 @@ type postProcessCtx struct {
 
 	// processors used by this context.
 	procs []processor
-
-	// if set to true, when an <a> is found, instead of just returning during
-	// visitNode, it will recursively visit the node exclusively running
-	// shortLinkProcessorFull with true.
-	visitLinksForShortLinks bool
 }
 
 // PostProcess does the final required transformations to the passed raw HTML
@@ -191,11 +186,10 @@ func PostProcess(
 ) ([]byte, error) {
 	// create the context from the parameters
 	ctx := &postProcessCtx{
-		metas:                   metas,
-		urlPrefix:               urlPrefix,
-		isWikiMarkdown:          isWikiMarkdown,
-		procs:                   defaultProcessors,
-		visitLinksForShortLinks: true,
+		metas:          metas,
+		urlPrefix:      urlPrefix,
+		isWikiMarkdown: isWikiMarkdown,
+		procs:          defaultProcessors,
 	}
 	return ctx.postProcess(rawHTML)
 }
@@ -285,9 +279,6 @@ func (ctx *postProcessCtx) visitNode(node *html.Node) {
 		ctx.textNode(node)
 	case html.ElementNode:
 		if node.Data == "a" || node.Data == "code" || node.Data == "pre" {
-			if node.Data == "a" && ctx.visitLinksForShortLinks {
-				ctx.visitNodeForShortLinks(node)
-			}
 			return
 		}
 		for n := node.FirstChild; n != nil; n = n.NextSibling {
@@ -302,7 +293,7 @@ func (ctx *postProcessCtx) visitNodeForShortLinks(node *html.Node) {
 	case html.TextNode:
 		shortLinkProcessorFull(ctx, node, true)
 	case html.ElementNode:
-		if node.Data == "code" || node.Data == "pre" {
+		if node.Data == "code" || node.Data == "pre" || node.Data == "a" {
 			return
 		}
 		for n := node.FirstChild; n != nil; n = n.NextSibling {

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -222,4 +222,8 @@ func TestRender_ShortLinks(t *testing.T) {
 		"[[some/path/Link #.jpg]]",
 		`<p><a href="`+notencodedImgurl+`" rel="nofollow"><img src="`+notencodedImgurl+`"/></a></p>`,
 		`<p><a href="`+notencodedImgurlWiki+`" rel="nofollow"><img src="`+notencodedImgurlWiki+`"/></a></p>`)
+	test(
+		"<p><a href=\"https://example.org\">[[foobar]]</a></p>",
+		`<p><a href="https://example.org" rel="nofollow">[[foobar]]</a></p>`,
+		`<p><a href="https://example.org" rel="nofollow">[[foobar]]</a></p>`)
 }


### PR DESCRIPTION
The visitLinksForShortLinks feature would look inside of an \<a\> tag and run shortLinkProcessorFull on any text, which attempts to create links out of potential 'short links' like [[test]] [[link|example]] etc... This makes no sense becaused you can't have nested links within an existing \<a\> tag. Specifically, the html5 standard says \<a\> tags can't include interactive content if they contain the href attribute:

 http://w3c.github.io/html/single-page.html#the-a-element

And also defines an <a> element with a href attribute as interactive:

 http://w3c.github.io/html/single-page.html#interactive-content

Therefore you can't really put a link inside of another link as this would try. In practice none of this should work anyway since browsers won't render it, it would probably be broken if they tried, and it is causing a bug (#4946). No current tests rely on this behavior either that I can see. 

This removes the feature and also explicitly excludes the current visitNodeForShortLinks from looking in \<a\> tags.

-----
Open to feedback if anybody knows of a legitimate use for this, but it appears to have been added as part of a much larger commit ( https://github.com/go-gitea/gitea/commit/535445c32ee730988033728b3b91c4d6f456e08c) without specific explanation as to the use case behind this. Thanks!