### PR TITLE
 Add  Gitea Extension for Visual Studio  to   third party tools list 

### DIFF
--- a/docs/content/doc/advanced/third-party-tools.en-us.md
+++ b/docs/content/doc/advanced/third-party-tools.en-us.md
@@ -31,3 +31,6 @@ menu:
 
 ### Mobile
 [GitNex for Android](https://gitlab.com/mmarif4u/gitnex)
+
+###  Editor Extensions
+ - [Gitea Extension for Visual Studio](https://github.com/maikebing/Gitea.VisualStudio)   Download from   [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=MysticBoy.GiteaExtensionforVisualStudio)


### PR DESCRIPTION
Add  Gitea Extension for Visual Studio  To  third-party-tools.en-us.md
