### PR TITLE
Use url.PathEscape to escape the branchname

### DIFF
--- a/modules/private/branch.go
+++ b/modules/private/branch.go
@@ -7,6 +7,7 @@ package private
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/log"
@@ -16,7 +17,7 @@ import (
 // GetProtectedBranchBy get protected branch information
 func GetProtectedBranchBy(repoID int64, branchName string) (*models.ProtectedBranch, error) {
 	// Ask for running deliver hook and test pull request tasks.
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/branch/%d/%s", repoID, branchName)
+	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/branch/%d/%s", repoID, url.PathEscape(branchName))
 	log.GitLogger.Trace("GetProtectedBranchBy: %s", reqURL)
 
 	resp, err := newInternalRequest(reqURL, "GET").Response()

--- a/modules/private/internal.go
+++ b/modules/private/internal.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/httplib"
@@ -76,7 +77,7 @@ func CheckUnitUser(userID, repoID int64, isAdmin bool, unitType models.UnitType)
 
 // GetRepositoryByOwnerAndName returns the repository by given ownername and reponame.
 func GetRepositoryByOwnerAndName(ownerName, repoName string) (*models.Repository, error) {
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/repo/%s/%s", ownerName, repoName)
+	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/repo/%s/%s", url.PathEscape(ownerName), url.PathEscape(repoName))
 	log.GitLogger.Trace("GetRepositoryByOwnerAndName: %s", reqURL)
 
 	resp, err := newInternalRequest(reqURL, "GET").Response()


### PR DESCRIPTION
It is currently not possible to push a branch containing a `%` in it's name as it causes the internal protected branch checking api to return an error.

This code protects the branchname with `url.PathEscape`