### PR TITLE
Log failed authentications as warning message.

### DIFF
--- a/docs/content/doc/usage/fail2ban-setup.md
+++ b/docs/content/doc/usage/fail2ban-setup.md
@@ -23,7 +23,7 @@ Gitea returns an HTTP 200 for bad logins in the web logs, but if you have loggin
 on a bad authentication:
 
 ```log
-2018/04/26 18:15:54 [I] Failed authentication attempt for user from xxx.xxx.xxx.xxx
+2019/03/12 12:14:04 [W] Failed authentication attempt for user from xxx.xxx.xxx.xxx
 ```
 
 So we set our filter in `/etc/fail2ban/filter.d/gitea.conf`:

--- a/modules/context/auth.go
+++ b/modules/context/auth.go
@@ -38,7 +38,7 @@ func Toggle(options *ToggleOptions) macaron.Handler {
 				ctx.HTML(200, "user/auth/activate")
 				return
 			} else if !ctx.User.IsActive || ctx.User.ProhibitLogin {
-				log.Info("Failed authentication attempt for %s from %s", ctx.User.Name, ctx.RemoteAddr())
+				log.Warn("Failed authentication attempt for %s from %s", ctx.User.Name, ctx.RemoteAddr())
 				ctx.Data["Title"] = ctx.Tr("auth.prohibit_login")
 				ctx.HTML(200, "user/auth/prohibit_login")
 				return

--- a/routers/home.go
+++ b/routers/home.go
@@ -42,7 +42,7 @@ func Home(ctx *context.Context) {
 			ctx.Data["Title"] = ctx.Tr("auth.active_your_account")
 			ctx.HTML(200, user.TplActivate)
 		} else if !ctx.User.IsActive || ctx.User.ProhibitLogin {
-			log.Info("Failed authentication attempt for %s from %s", ctx.User.Name, ctx.RemoteAddr())
+			log.Warn("Failed authentication attempt for %s from %s", ctx.User.Name, ctx.RemoteAddr())
 			ctx.Data["Title"] = ctx.Tr("auth.prohibit_login")
 			ctx.HTML(200, "user/auth/prohibit_login")
 		} else if ctx.User.MustChangePassword {

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -157,12 +157,12 @@ func SignInPost(ctx *context.Context, form auth.SignInForm) {
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
 			ctx.RenderWithErr(ctx.Tr("form.username_password_incorrect"), tplSignIn, &form)
-			log.Info("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
+			log.Warn("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
 		} else if models.IsErrEmailAlreadyUsed(err) {
 			ctx.RenderWithErr(ctx.Tr("form.email_been_used"), tplSignIn, &form)
-			log.Info("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
+			log.Warn("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
 		} else if models.IsErrUserProhibitLogin(err) {
-			log.Info("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
+			log.Warn("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
 			ctx.Data["Title"] = ctx.Tr("auth.prohibit_login")
 			ctx.HTML(200, "user/auth/prohibit_login")
 		} else if models.IsErrUserInactive(err) {
@@ -170,7 +170,7 @@ func SignInPost(ctx *context.Context, form auth.SignInForm) {
 				ctx.Data["Title"] = ctx.Tr("auth.active_your_account")
 				ctx.HTML(200, TplActivate)
 			} else {
-				log.Info("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
+				log.Warn("Failed authentication attempt for %s from %s", form.UserName, ctx.RemoteAddr())
 				ctx.Data["Title"] = ctx.Tr("auth.prohibit_login")
 				ctx.HTML(200, "user/auth/prohibit_login")
 			}


### PR DESCRIPTION

`fail2ban` will not work, if the gitea loglevel is set to `Warn`, since failed authentications are log as info.

Suggestion: Log failed authentications as warning.

