### PR TITLE
Allow setting wiki writeable for all users on an instance

### DIFF
--- a/models/repo_permission.go
+++ b/models/repo_permission.go
@@ -48,6 +48,16 @@ func (p *Permission) UnitAccessMode(unitType UnitType) AccessMode {
 	return p.UnitsMode[unitType]
 }
 
+// AllowWriteAll returns true if a all users are on the gitea instance have write access to the unit
+func (p *Permission) AllowWriteAll(unitType UnitType) bool {
+	for _, u := range p.Units {
+		if u.Type == unitType {
+			return u.AllowWriteAll
+		}
+	}
+	return false
+}
+
 // CanAccess returns true if user has mode access to the unit of the repository
 func (p *Permission) CanAccess(mode AccessMode, unitType UnitType) bool {
 	return p.UnitAccessMode(unitType) >= mode
@@ -254,6 +264,9 @@ func getUserRepoPermission(e Engine, repo *Repository, user *User) (perm Permiss
 		if !found && !repo.IsPrivate && !user.IsRestricted {
 			if _, ok := perm.UnitsMode[u.Type]; !ok {
 				perm.UnitsMode[u.Type] = AccessModeRead
+				if u.AllowWriteAll == true {
+					perm.UnitsMode[u.Type] = AccessModeWrite
+				}
 			}
 		}
 	}

--- a/models/repo_unit.go
+++ b/models/repo_unit.go
@@ -16,11 +16,12 @@ import (
 
 // RepoUnit describes all units of a repository
 type RepoUnit struct {
-	ID          int64
-	RepoID      int64              `xorm:"INDEX(s)"`
-	Type        UnitType           `xorm:"INDEX(s)"`
-	Config      convert.Conversion `xorm:"TEXT"`
-	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
+	ID            int64
+	RepoID        int64    `xorm:"INDEX(s)"`
+	Type          UnitType `xorm:"INDEX(s)"`
+	AllowWriteAll bool
+	Config        convert.Conversion `xorm:"TEXT"`
+	CreatedUnix   timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
 
 // UnitConfig describes common unit config

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1658,6 +1658,7 @@ settings.advanced_settings = Advanced Settings
 settings.wiki_desc = Enable Repository Wiki
 settings.use_internal_wiki = Use Built-In Wiki
 settings.use_external_wiki = Use External Wiki
+settings.allow_wiki_edit_all = Allow Wiki editing by all users
 settings.external_wiki_url = External Wiki URL
 settings.external_wiki_url_error = The external wiki URL is not a valid URL.
 settings.external_wiki_url_desc = Visitors are redirected to the external wiki URL when clicking the wiki tab.

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -347,9 +347,10 @@ func SettingsPost(ctx *context.Context) {
 			deleteUnitTypes = append(deleteUnitTypes, models.UnitTypeWiki)
 		} else if form.EnableWiki && !form.EnableExternalWiki && !models.UnitTypeWiki.UnitGlobalDisabled() {
 			units = append(units, models.RepoUnit{
-				RepoID: repo.ID,
-				Type:   models.UnitTypeWiki,
-				Config: new(models.UnitConfig),
+				RepoID:        repo.ID,
+				Type:          models.UnitTypeWiki,
+				Config:        new(models.UnitConfig), // TODO: introduce a WikiConfig
+				AllowWriteAll: form.AllowWikiEditAll,
 			})
 			deleteUnitTypes = append(deleteUnitTypes, models.UnitTypeExternalWiki)
 		} else {

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -133,6 +133,7 @@ type RepoSettingForm struct {
 
 	// Advanced settings
 	EnableWiki                            bool
+	AllowWikiEditAll                      bool
 	EnableExternalWiki                    bool
 	ExternalWikiURL                       string
 	EnableIssues                          bool

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -259,17 +259,27 @@
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" data-context="#internal_wiki_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_internal_wiki"}}</label>
 						</div>
 					</div>
+					{{if .Repository.Owner.IsOrganization}}
+					<div class="field {{if (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}disabled{{end}}" id="internal_wiki_box">
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="allow_wiki_edit_all" type="checkbox" {{if .Permission.AllowWriteAll $.UnitTypeWiki}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.settings.allow_wiki_edit_all"}}</label>
+							</div>
+						</div>
+					</div>
+					{{end}}
 					<div class="field">
 						{{if .UnitTypeExternalWiki.UnitGlobalDisabled}}
 						<div class="ui radio checkbox poping up disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.UnitEnabled $.UnitTypeExternalWiki}}checked{{end}}/>
+							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" data-context="#internal_wiki_box" {{if .Repository.UnitEnabled $.UnitTypeExternalWiki}}checked{{end}}/>
 							<label>{{.i18n.Tr "repo.settings.use_external_wiki"}}</label>
 						</div>
 					</div>


### PR DESCRIPTION
This change allows to set wikis of an organization wiki to writable for all user of an instance.
This setting is also available on github (even default?).

Internally the setting is available to all Units but currently only used for wiki.

This PR is heavily inspired by #5833 by @lunny, and will conflict with his. Thanks and sorry :sweat_smile: 