### PR TITLE
[PR Contrib] Add way to force checkout

### DIFF
--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"code.gitea.io/gitea/modules/markup/external"
@@ -162,6 +163,12 @@ func main() {
 		return
 	}
 
+	// To force checkout (e.g. Windows complains about unclean work tree) set env variable FORCE=true
+	force, err := strconv.ParseBool(os.Getenv("FORCE"))
+	if err != nil {
+		force = false
+	}
+
 	//Otherwise checkout PR
 	if len(os.Args) != 2 {
 		log.Fatal("Need only one arg: the PR number")
@@ -221,7 +228,7 @@ func main() {
 	log.Printf("Checkout PR #%s in %s\n", pr, branch)
 	err = tree.Checkout(&git.CheckoutOptions{
 		Branch: branchRef,
-		//Force:  runtime.GOOS == "windows",
+		Force:  force,
 	})
 	if err != nil {
 		log.Fatalf("Failed to checkout %s : %v", branch, err)


### PR DESCRIPTION
Temp fix for Windows.  

I believe @sapk mentioned it in his original PR, but on Windows there are complaints of a dirty worktree when running the contrib. However on Linux (and Mac?) machines the issue doesn't exist.

The only way to make it work is to add the `Force` option to the checkout, however having it on by default sounds dangerous in case there are uncommitted changes the dev *wants* to keep.

This PR just adds a way to run the `Force` without editing the code.  

`FORCE=true go run contrib/pr/checkout.go 0000` or `FORCE=true PR=0000 make pr`
