### PR TITLE
Fix ParsePatch function to work with quoted diff --git strings

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -550,7 +550,13 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 			beg := len(cmdDiffHead)
 			a := line[beg+2 : middle]
 			b := line[middle+3:]
+
 			if hasQuote {
+				// When /a and /b are surrounded by double quotes, we want to first
+				// make sure we keep everything the quotes and then strip out the leading /a /b
+				a = strings.Replace(line[beg:middle], "\"a/", "\"", -1)
+				b = strings.Replace(line[middle+1:], "\"b/", "\"", -1)
+
 				var err error
 				a, err = strconv.Unquote(a)
 				if err != nil {
@@ -637,6 +643,7 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 			}
 		}
 	}
+
 	return diff, nil
 }
 

--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -552,10 +552,9 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 			b := line[middle+3:]
 
 			if hasQuote {
-				// When /a and /b are surrounded by double quotes, we want to first
-				// make sure we keep everything the quotes and then strip out the leading /a /b
-				a = strings.Replace(line[beg:middle], "\"a/", "\"", -1)
-				b = strings.Replace(line[middle+1:], "\"b/", "\"", -1)
+				// Keep the entire string in double quotes for now
+				a = line[beg:middle]
+				b = line[middle+1:]
 
 				var err error
 				a, err = strconv.Unquote(a)
@@ -566,6 +565,10 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 				if err != nil {
 					return nil, fmt.Errorf("Unquote: %v", err)
 				}
+				// Now remove the /a /b
+				a = a[2:]
+				b = b[2:]
+
 			}
 
 			curFile = &DiffFile{

--- a/models/git_diff_test.go
+++ b/models/git_diff_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"code.gitea.io/gitea/modules/setting"
+
 	dmp "github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/assert"
 )
@@ -96,6 +98,42 @@ func ExampleCutDiffAroundLine() {
 + cut off
 + cut off`
 	result := CutDiffAroundLine(strings.NewReader(diff), 4, false, 3)
+	println(result)
+}
+
+func TestParsePatch(t *testing.T) {
+	var diff = `diff --git "a/README.md" "b/README.md"
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,6 @@
+ # gitea-github-migrator
++
++ Build Status
+- Latest Release
+ Docker Pulls
++ cut off
++ cut off`
+	result, err := ParsePatch(setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, strings.NewReader(diff))
+	if err != nil {
+		t.Errorf("ParsePatch failed: %s", err)
+	}
+	println(result)
+
+	var diff2 = `diff --git "a/A \\ B" "b/A \\ B"
+--- "a/A \\ B"
++++ "b/A \\ B"
+@@ -1,3 +1,6 @@
+ # gitea-github-migrator
++
++ Build Status
+- Latest Release
+ Docker Pulls
++ cut off
++ cut off`
+	result, err = ParsePatch(setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, strings.NewReader(diff2))
+	if err != nil {
+		t.Errorf("ParsePatch failed: %s", err)
+	}
 	println(result)
 }
 

--- a/models/git_diff_test.go
+++ b/models/git_diff_test.go
@@ -135,6 +135,23 @@ func TestParsePatch(t *testing.T) {
 		t.Errorf("ParsePatch failed: %s", err)
 	}
 	println(result)
+
+	var diff3 = `diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,6 @@
+ # gitea-github-migrator
++
++ Build Status
+- Latest Release
+ Docker Pulls
++ cut off
++ cut off`
+	result, err = ParsePatch(setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, strings.NewReader(diff3))
+	if err != nil {
+		t.Errorf("ParsePatch failed: %s", err)
+	}
+	println(result)
 }
 
 func setupDefaultDiff() *Diff {


### PR DESCRIPTION
This fixes the ParsePatch function to work when a diff puts the a/ b/ filenames inside double quotes. See #6309 for more details.

Added some new tests for this function as well.