### PR TITLE
Disable benchmarking during tag events on DroneIO

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -211,41 +211,41 @@ pipeline:
     when:
       event: [ push, tag, pull_request ]
 
-  bench-sqlite:
-    image: golang:1.12
-    pull: true
-    group: bench
-    commands:
-      - make bench-sqlite
-    when:
-      event: [ tag ]
+#  bench-sqlite:
+#    image: golang:1.12
+#    pull: true
+#    group: bench
+#    commands:
+#      - make bench-sqlite
+#    when:
+#      event: [ tag ]
 
-  bench-mysql:
-    image: golang:1.12
-    pull: true
-    group: bench
-    commands:
-      - make bench-mysql
-    when:
-      event: [ tag ]
+#  bench-mysql:
+#    image: golang:1.12
+#    pull: true
+#    group: bench
+#    commands:
+#      - make bench-mysql
+#    when:
+#      event: [ tag ]
 
-  bench-mssql:
-    image: golang:1.12
-    pull: true
-    group: bench
-    commands:
-      - make bench-mssql
-    when:
-      event: [ tag ]
+#  bench-mssql:
+#    image: golang:1.12
+#    pull: true
+#    group: bench
+#    commands:
+#      - make bench-mssql
+#    when:
+#      event: [ tag ]
 
-  bench-pgsql:
-    image: golang:1.12
-    pull: true
-    group: bench
-    commands:
-      - make bench-pgsql
-    when:
-      event: [ tag ]
+#  bench-pgsql:
+#    image: golang:1.12
+#    pull: true
+#    group: bench
+#    commands:
+#      - make bench-pgsql
+#    when:
+#      event: [ tag ]
 
   generate-coverage:
     image: golang:1.12


### PR DESCRIPTION
As title, will need to be backported to release/v1.8

(When this gets backported 1.8.0-rc1 can be retagged)