### PR TITLE
Include more variables on admin/config page

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1629,6 +1629,7 @@ config.app_name = Site Title
 config.app_ver = Gitea Version
 config.app_url = Gitea Base URL
 config.custom_conf = Configuration File Path
+config.custom_file_root_path = "Custom File Root Path"
 config.domain = SSH Server Domain
 config.offline_mode = Local Mode
 config.disable_router_log = Disable Router Log

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -6,6 +6,7 @@ package admin
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -211,6 +212,7 @@ func Config(ctx *context.Context) {
 	ctx.Data["RunMode"] = strings.Title(macaron.Env)
 	ctx.Data["GitVersion"] = setting.Git.Version
 	ctx.Data["RepoRootPath"] = setting.RepoRootPath
+	ctx.Data["CustomRootPath"] = setting.CustomPath
 	ctx.Data["StaticRootPath"] = setting.StaticRootPath
 	ctx.Data["LogRootPath"] = setting.LogRootPath
 	ctx.Data["ScriptType"] = setting.ScriptType
@@ -239,6 +241,20 @@ func Config(ctx *context.Context) {
 	ctx.Data["EnableFederatedAvatar"] = setting.EnableFederatedAvatar
 
 	ctx.Data["Git"] = setting.Git
+
+	type envVar struct {
+		Name, Value string
+	}
+
+	envVars := map[string]*envVar{}
+	if len(os.Getenv("GITEA_WORK_DIR")) > 0 {
+		envVars["GITEA_WORK_DIR"] = &envVar{"GITEA_WORK_DIR", os.Getenv("GITEA_WORK_DIR")}
+	}
+	if len(os.Getenv("GITEA_CUSTOM")) > 0 {
+		envVars["GITEA_CUSTOM"] = &envVar{"GITEA_CUSTOM", os.Getenv("GITEA_CUSTOM")}
+	}
+
+	ctx.Data["EnvVars"] = envVars
 
 	type logger struct {
 		Mode, Config string

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -41,12 +41,23 @@
 				<dd>{{.RepoRootPath}}</dd>
 				<dt>{{.i18n.Tr "admin.config.static_file_root_path"}}</dt>
 				<dd>{{.StaticRootPath}}</dd>
+				<dt>{{.i18n.Tr "admin.config.custom_file_root_path"}}</dt>
+				<dd>{{.CustomRootPath}}</dd>
 				<dt>{{.i18n.Tr "admin.config.log_file_root_path"}}</dt>
 				<dd>{{.LogRootPath}}</dd>
 				<dt>{{.i18n.Tr "admin.config.script_type"}}</dt>
 				<dd>{{.ScriptType}}</dd>
 				<dt>{{.i18n.Tr "admin.config.reverse_auth_user"}}</dt>
 				<dd>{{.ReverseProxyAuthUser}}</dd>
+
+				{{if .EnvVars }}
+				<div class="ui divider"></div>
+				{{range .EnvVars}}
+				<dt>{{.Name}}</dt>
+				<dd>{{.Value}}</dd>
+				{{end}}
+				{{end}}
+
 			</dl>
 		</div>
 


### PR DESCRIPTION
Include the current CustomPath location in the admin section and also
display GITEA_WORK_DIR and/or GITEA_CUSTOM env var if they are set.

Right now there is no easy way to see this information, and if you try
and help most users they won't be able to tell you anything about these
values -- just that their custom template isn't working, files aren't in
the right place, etc... Now you can see all paths and if they were set
by ENV or not.

Before:
<img width="653" alt="Screen Shot 2019-03-19 at 4 36 20 PM" src="https://user-images.githubusercontent.com/1669571/54641131-c5ac4880-4a67-11e9-97ea-7cca8dfbf3b8.png">

After:
<img width="609" alt="Screen Shot 2019-03-19 at 4 43 34 PM" src="https://user-images.githubusercontent.com/1669571/54641130-c5ac4880-4a67-11e9-97c3-6c278e9b3172.png">

