### PR TITLE
Enable matching host file permissions when using docker container.

### DIFF
--- a/docker/etc/cont-init.d/10-adduser
+++ b/docker/etc/cont-init.d/10-adduser
@@ -1,0 +1,15 @@
+#!/usr/bin/with-contenv bash
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+groupmod -o -g "$PGID" git
+usermod -o -u "$PUID" git
+
+echo "
+-------------------------------------
+User uid:    $(id -u git)
+User gid:    $(id -g git)
+-------------------------------------
+"
+chown git:git /data


### PR DESCRIPTION
Enable gitea docker to use permissions matching a host user.
I stole this approach from linuxserver.io images.  The standard
docker `--user` option doesn't work with s6 based images.

**NOTE:**  Someone _using_ these settings that weren't using them before
will want to `chmod -R` their data/ and db/ directories on the host.
But merely upgrading to this image will not force this.

Example mods to your docker-compose.yml

gitea service

    environment:
      - "PUID=1026"
      - "GUID=100"

maria db service

    user: "1026:100"
