### PR TITLE
Add links to branches on pull request

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -1428,6 +1428,54 @@ func (pr *PullRequest) GetWorkInProgressPrefix() string {
 	return ""
 }
 
+// GetRelBaseBranchLink gets the full relative URL to the base branch of the pull request
+// Will return a zero value if there is no base repo or branch for the pull request.
+func (pr *PullRequest) GetRelBaseBranchLink() string {
+	branchExists, err := pr.doesBranchExist(pr.BaseRepo, pr.BaseBranch)
+	if err != nil {
+		log.Error("GetRelBaseBranchLink: %v", err)
+		return ""
+	} else if !branchExists {
+		return ""
+	}
+
+	return pr.generateRelBranchLink(pr.BaseRepo, pr.BaseBranch)
+}
+
+// GetRelHeadBranchLink gets the full relative URL to the head branch of the pull request
+// Will return a zero value if there is no head repo or branch for the pull request.
+func (pr *PullRequest) GetRelHeadBranchLink() string {
+	branchExists, err := pr.doesBranchExist(pr.HeadRepo, pr.HeadBranch)
+	if err != nil {
+		log.Error("GetRelHeadBranchLink: %v", err)
+		return ""
+	} else if !branchExists {
+		return ""
+	}
+
+	return pr.generateRelBranchLink(pr.HeadRepo, pr.HeadBranch)
+}
+
+// doesBranchExist returns true if the branch exists, false otherwise.
+func (pr *PullRequest) doesBranchExist(repo *Repository, branchName string) (bool, error) {
+	if repo == nil {
+		return false, nil
+	}
+
+	gitRepo, err := git.OpenRepository(repo.RepoPath())
+	if err != nil {
+		return false, err
+	}
+
+	return gitRepo.IsBranchExist(branchName), nil
+}
+
+func (pr *PullRequest) generateRelBranchLink(repo *Repository, branchName string) string {
+	escapedBranchName := util.PathEscapeSegments(branchName)
+
+	return fmt.Sprintf("/%s/src/branch/%s", repo.FullName(), escapedBranchName)
+}
+
 // TestPullRequests checks and tests untested patches of pull requests.
 // TODO: test more pull requests at same time.
 func TestPullRequests() {

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -233,6 +233,13 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return float32(n) * 100 / float32(sum)
 		},
+		"Ternary": func(condition bool, truthyValue string, falsyValue string) string {
+			if condition {
+				return truthyValue
+			}
+
+			return falsyValue
+		},
 	}}
 }
 

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -948,8 +948,8 @@ pulls.no_results = No results found.
 pulls.nothing_to_compare = These branches are equal. There is no need to create a pull request.
 pulls.has_pull_request = `A pull request between these branches already exists: <a href="%[1]s/pulls/%[3]d">%[2]s#%[3]d</a>`
 pulls.create = Create Pull Request
-pulls.title_desc = wants to merge %[1]d commits from <code>%[2]s</code> into <code>%[3]s</code>
-pulls.merged_title_desc = merged %[1]d commits from <code>%[2]s</code> into <code>%[3]s</code> %[4]s
+pulls.title_desc = wants to merge %[1]d commits from %[2]s into %[3]s
+pulls.merged_title_desc = merged %[1]d commits from %[2]s into %[3]s %[4]s
 pulls.tab_conversation = Conversation
 pulls.tab_commits = Commits
 pulls.tab_files = Files Changed

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -25,13 +25,23 @@
 	{{end}}
 
 	{{if .Issue.IsPull}}
+		{{ $baseTargetLink := .Issue.PullRequest.GetRelBaseBranchLink }}
+		{{ $baseTargetLinkTag := printf "<a href=\"%s\">%s</a>" $baseTargetLink .BaseTarget }}
+		{{ $baseTargetNoLinkTag := printf "<code>%s</code>" .BaseTarget }}
+		{{ $baseTargetTag := Ternary (eq $baseTargetLink "") $baseTargetNoLinkTag $baseTargetLinkTag}}
+
+		{{ $headTargetLink := .Issue.PullRequest.GetRelHeadBranchLink }}
+		{{ $headTargetLinkTag := printf "<a href=\"%s\">%s</a>" $headTargetLink .HeadTarget }}
+		{{ $headTargetNoLinkTag := printf "<code>%s</code>" .HeadTarget }}
+		{{ $headTargetTag := Ternary (eq $headTargetLink "") $headTargetNoLinkTag $headTargetLinkTag}}
+
 		{{if .Issue.PullRequest.HasMerged}}
 			{{ $mergedStr:= TimeSinceUnix .Issue.PullRequest.MergedUnix $.Lang }}
 			<a {{if gt .Issue.PullRequest.Merger.ID 0}}href="{{.Issue.PullRequest.Merger.HomeLink}}"{{end}}>{{.Issue.PullRequest.Merger.GetDisplayName}}</a>
-			<span class="pull-desc">{{$.i18n.Tr "repo.pulls.merged_title_desc" .NumCommits .HeadTarget .BaseTarget $mergedStr | Str2html}}</span>
+			<span class="pull-desc">{{$.i18n.Tr "repo.pulls.merged_title_desc" .NumCommits $headTargetTag $baseTargetTag $mergedStr | Str2html}}</span>
 		{{else}}
 			<a {{if gt .Issue.Poster.ID 0}}href="{{.Issue.Poster.HomeLink}}"{{end}}>{{.Issue.Poster.GetDisplayName}}</a>
-			<span class="pull-desc">{{$.i18n.Tr "repo.pulls.title_desc" .NumCommits .HeadTarget .BaseTarget | Str2html}}</span>
+			<span class="pull-desc">{{$.i18n.Tr "repo.pulls.title_desc" .NumCommits $headTargetTag $baseTargetTag | Str2html}}</span>
 		{{end}}
 	{{else}}
 		{{ $createdStr:= TimeSinceUnix .Issue.CreatedUnix $.Lang }}


### PR DESCRIPTION
Modifies branch names on the pull request summary page are now links to the branch that is being merged into/from.

The `CONTRIBUTING.md` says that only English translations are maintained in this repo, but I still modified the markdown that was embedded in other translations. Please let me know if this was the wrong move.

**Screenshots:**
Merging from one repo's branch to another's:
![image](https://user-images.githubusercontent.com/977151/54889277-2e396200-4e7a-11e9-90e7-691c650cdecc.png)
Merging into the same repo:
![image](https://user-images.githubusercontent.com/977151/54889285-36919d00-4e7a-11e9-8232-581629a36f99.png)
Merging from a deleted repo:
![image](https://user-images.githubusercontent.com/977151/54889292-3beee780-4e7a-11e9-83b2-f2e3a9217fae.png)

Closes #5672

