### PR TITLE
Clean up ref name rules

### DIFF
--- a/integrations/repo_branch_test.go
+++ b/integrations/repo_branch_test.go
@@ -58,7 +58,7 @@ func TestCreateBranch(t *testing.T) {
 			OldRefSubURL:   "branch/master",
 			NewBranch:      "feature=test1",
 			ExpectedStatus: http.StatusFound,
-			FlashMessage:   i18n.Tr("en", "form.NewBranchName") + i18n.Tr("en", "form.git_ref_name_error"),
+			FlashMessage:   i18n.Tr("en", "repo.branch.create_success", "feature=test1"),
 		},
 		{
 			OldRefSubURL:   "branch/master",

--- a/modules/validation/binding.go
+++ b/modules/validation/binding.go
@@ -19,7 +19,9 @@ const (
 
 var (
 	// GitRefNamePattern is regular expression with unallowed characters in git reference name
-	GitRefNamePattern = regexp.MustCompile("[^\\d\\w-_\\./]")
+	// They cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 DEL), space, tilde ~, caret ^, or colon : anywhere.
+	// They cannot have question-mark ?, asterisk *, or open bracket [ anywhere
+	GitRefNamePattern = regexp.MustCompile(`[\000-\037\177 \\~^:?*[]+`)
 )
 
 // AddBindingRules adds additional binding rules
@@ -44,7 +46,8 @@ func addGitRefNameBindingRule() {
 			// Additional rules as described at https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
 			if strings.HasPrefix(str, "/") || strings.HasSuffix(str, "/") ||
 				strings.HasSuffix(str, ".") || strings.Contains(str, "..") ||
-				strings.Contains(str, "//") {
+				strings.Contains(str, "//") || strings.Contains(str, "@{") ||
+				str == "@" {
 				errs.Add([]string{name}, ErrGitRefName, "GitRefName")
 				return false, errs
 			}

--- a/modules/validation/refname_test.go
+++ b/modules/validation/refname_test.go
@@ -26,6 +26,13 @@ var gitRefNameValidationTestCases = []validationTestCase{
 		expectedErrors: binding.Errors{},
 	},
 	{
+		description: "Reference name has allowed special characters",
+		data: TestForm{
+			BranchName: "debian/1%1.6.0-2",
+		},
+		expectedErrors: binding.Errors{},
+	},
+	{
 		description: "Reference name contains backslash",
 		data: TestForm{
 			BranchName: "feature\\test",
@@ -120,6 +127,123 @@ var gitRefNameValidationTestCases = []validationTestCase{
 		description: "Reference name contains multiple consecutive slashes",
 		data: TestForm{
 			BranchName: "te//st",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name is single @",
+		data: TestForm{
+			BranchName: "@",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has @{",
+		data: TestForm{
+			BranchName: "branch@{",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character ~",
+		data: TestForm{
+			BranchName: "~debian/1%1.6.0-2",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character *",
+		data: TestForm{
+			BranchName: "*debian/1%1.6.0-2",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character ?",
+		data: TestForm{
+			BranchName: "?debian/1%1.6.0-2",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character ^",
+		data: TestForm{
+			BranchName: "^debian/1%1.6.0-2",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character :",
+		data: TestForm{
+			BranchName: "debian:jessie",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character (whitespace)",
+		data: TestForm{
+			BranchName: "debian jessie",
+		},
+		expectedErrors: binding.Errors{
+			binding.Error{
+				FieldNames:     []string{"BranchName"},
+				Classification: ErrGitRefName,
+				Message:        "GitRefName",
+			},
+		},
+	},
+	{
+		description: "Reference name has unallowed special character [",
+		data: TestForm{
+			BranchName: "debian[jessie",
 		},
 		expectedErrors: binding.Errors{
 			binding.Error{

--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/util"
 )
 
 const (
@@ -250,5 +251,5 @@ func CreateBranch(ctx *context.Context, form auth.NewBranchForm) {
 	}
 
 	ctx.Flash.Success(ctx.Tr("repo.branch.create_success", form.NewBranchName))
-	ctx.Redirect(ctx.Repo.RepoLink + "/src/branch/" + form.NewBranchName)
+	ctx.Redirect(ctx.Repo.RepoLink + "/src/branch/" + util.PathEscapeSegments(form.NewBranchName))
 }


### PR DESCRIPTION
Clean up checks on reference names to better conform to the guideline
here: https://git-scm.com/docs/git-check-ref-format

This fixes half of #6321

To see example of current problem, just try and create a branch or tag with a valid name containing allowed special characters like ```test+me```. It will incorrectly say ```TagName must be a well-formed Git reference name```

I've tried to add several extra tests as well since if a bad name gets by this check it can later through a less friendly 500 error if we try to create a branch with a bad name