### PR TITLE
Change order that PostProcess Processors are run (#6445)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -152,15 +152,15 @@ func (p *postProcessError) Error() string {
 type processor func(ctx *postProcessCtx, node *html.Node)
 
 var defaultProcessors = []processor{
-	mentionProcessor,
-	shortLinkProcessor,
 	fullIssuePatternProcessor,
+	fullSha1PatternProcessor,
+	shortLinkProcessor,
+	linkProcessor,
+	mentionProcessor,
 	issueIndexPatternProcessor,
 	crossReferenceIssueIndexPatternProcessor,
-	fullSha1PatternProcessor,
 	sha1CurrentPatternProcessor,
 	emailAddressProcessor,
-	linkProcessor,
 }
 
 type postProcessCtx struct {
@@ -194,14 +194,14 @@ func PostProcess(
 }
 
 var commitMessageProcessors = []processor{
-	mentionProcessor,
 	fullIssuePatternProcessor,
+	fullSha1PatternProcessor,
+	linkProcessor,
+	mentionProcessor,
 	issueIndexPatternProcessor,
 	crossReferenceIssueIndexPatternProcessor,
-	fullSha1PatternProcessor,
 	sha1CurrentPatternProcessor,
 	emailAddressProcessor,
-	linkProcessor,
 }
 
 // RenderCommitMessage will use the same logic as PostProcess, but will disable

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -113,6 +113,12 @@ func TestRender_links(t *testing.T) {
 	test(
 		"https://foo_bar.example.com/",
 		`<p><a href="https://foo_bar.example.com/" rel="nofollow">https://foo_bar.example.com/</a></p>`)
+	test(
+		"https://stackoverflow.com/questions/2896191/what-is-go-used-fore",
+		`<p><a href="https://stackoverflow.com/questions/2896191/what-is-go-used-fore" rel="nofollow">https://stackoverflow.com/questions/2896191/what-is-go-used-fore</a></p>`)
+	test(
+		"https://username:password@gitea.com",
+		`<p><a href="https://username:password@gitea.com" rel="nofollow">https://username:password@gitea.com</a></p>`)
 
 	// Test that should *not* be turned into URL
 	test(


### PR DESCRIPTION
Make sure Processors that work on full links are run first so that
something matching another pattern doesn't alter a link before we get to
it, for example:

 https://stackoverflow.com/questions/2896191/what-is-go-used-fore

Fixes #4813

This is backport to release/v1.8