### PR TITLE
Hacky fix for alignment of the create-organization dialog

### DIFF
--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -16,7 +16,7 @@
 					</div>
 
 					<div class="inline field {{if .Err_OrgVisibility}}error{{end}}">
-						<label for="visibility">{{.i18n.Tr "org.settings.visibility"}}</label>
+						<span class="inline required field"><label for="visibility">{{.i18n.Tr "org.settings.visibility"}}</label></span>
 						<div class="ui radio checkbox">
 							<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
 							<label>{{.i18n.Tr "org.settings.visibility.public"}}</label>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -15,28 +15,27 @@
 						<span class="help">{{.i18n.Tr "org.org_name_helper"}}</span>
 					</div>
 
-					<div class="inline required field {{if .Err_OrgVisibility}}error{{end}}">
+					<div class="inline field {{if .Err_OrgVisibility}}error{{end}}">
 						<label for="visibility">{{.i18n.Tr "org.settings.visibility"}}</label>
-						<div class="field">
-							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.public"}}</label>
-							</div>
-						</div>
-						<div class="field">
-							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.limited"}}</label>
-							</div>
-						</div>
-						<div class="field">
-							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.private"}}</label>
-							</div>
+						<div class="ui radio checkbox">
+							<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
+							<label>{{.i18n.Tr "org.settings.visibility.public"}}</label>
 						</div>
 					</div>
-
+					<div class="inline field {{if .Err_OrgVisibility}}error{{end}}">
+						<label>&nbsp;</label>
+						<div class="ui radio checkbox">
+							<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
+							<label>{{.i18n.Tr "org.settings.visibility.limited"}}</label>
+						</div>
+					</div>
+					<div class="inline field {{if .Err_OrgVisibility}}error{{end}}">
+						<label>&nbsp;</label>
+						<div class="ui radio checkbox">
+							<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
+							<label>{{.i18n.Tr "org.settings.visibility.private"}}</label>
+						</div>
+					</div>
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">


### PR DESCRIPTION
This PR suggests a somewhat hacky fix for the bug in #6376.

The issue is that semantic UI doesn't really provide an inline grouped radiobox format.

This PR hacks its way around this by creating empty labels to force semantic to display the radio boxes under each other.

![Screenshot from 2019-03-28 01-34-46](https://user-images.githubusercontent.com/1824502/55123252-b7aa9780-50f9-11e9-9e59-4b835334cb1c.png)
