### PR TITLE
Show last commit status in pull request lists

### DIFF
--- a/integrations/pull_status_test.go
+++ b/integrations/pull_status_test.go
@@ -1,0 +1,93 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+package integrations
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	api "code.gitea.io/sdk/gitea"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullCreate_CommitStatus(t *testing.T) {
+	prepareTestEnv(t)
+	session := loginUser(t, "user1")
+	testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
+	testEditFileToNewBranch(t, session, "user1", "repo1", "master", "status1", "README.md", "status1")
+
+	url := path.Join("user1", "repo1", "compare", "master...status1")
+	req := NewRequestWithValues(t, "POST", url,
+		map[string]string{
+			"_csrf": GetCSRF(t, session, url),
+			"title": "pull request from status1",
+		},
+	)
+	session.MakeRequest(t, req, http.StatusFound)
+
+	req = NewRequest(t, "GET", "/user1/repo1/pulls")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	doc := NewHTMLParser(t, resp.Body)
+
+	// Request repository commits page
+	req = NewRequest(t, "GET", "/user1/repo1/pulls/1/commits")
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	doc = NewHTMLParser(t, resp.Body)
+
+	// Get first commit URL
+	commitURL, exists := doc.doc.Find("#commits-table tbody tr td.sha a").Last().Attr("href")
+	assert.True(t, exists)
+	assert.NotEmpty(t, commitURL)
+
+	commitID := path.Base(commitURL)
+
+	statusList := []models.CommitStatusState{
+		models.CommitStatusPending,
+		models.CommitStatusError,
+		models.CommitStatusFailure,
+		models.CommitStatusWarning,
+		models.CommitStatusSuccess,
+	}
+
+	statesIcons := map[models.CommitStatusState]string{
+		models.CommitStatusPending: "circle icon yellow",
+		models.CommitStatusSuccess: "check icon green",
+		models.CommitStatusError:   "warning icon red",
+		models.CommitStatusFailure: "remove icon red",
+		models.CommitStatusWarning: "warning sign icon yellow",
+	}
+
+	// Update commit status, and check if icon is updated as well
+	for _, status := range statusList {
+
+		// Call API to add status for commit
+		token := getTokenForLoggedInUser(t, session)
+		req = NewRequestWithJSON(t, "POST", fmt.Sprintf("/api/v1/repos/user1/repo1/statuses/%s?token=%s", commitID, token),
+			api.CreateStatusOption{
+				State:       api.StatusState(status),
+				TargetURL:   "http://test.ci/",
+				Description: "",
+				Context:     "testci",
+			},
+		)
+		session.MakeRequest(t, req, http.StatusCreated)
+
+		req = NewRequestf(t, "GET", "/user1/repo1/pulls/1/commits")
+		resp = session.MakeRequest(t, req, http.StatusOK)
+		doc = NewHTMLParser(t, resp.Body)
+
+		commitURL, exists = doc.doc.Find("#commits-table tbody tr td.sha a").Last().Attr("href")
+		assert.True(t, exists)
+		assert.NotEmpty(t, commitURL)
+		assert.EqualValues(t, commitID, path.Base(commitURL))
+
+		cls, ok := doc.doc.Find("#commits-table tbody tr td.message i.commit-status").Last().Attr("class")
+		assert.True(t, ok)
+		assert.EqualValues(t, "commit-status "+statesIcons[status], cls)
+	}
+}

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -214,6 +214,8 @@ func issues(ctx *context.Context, milestoneID int64, isPullOption util.OptionalB
 		}
 	}
 
+	var commitStatus = make(map[int64]*models.CommitStatus, len(issues))
+
 	// Get posters.
 	for i := range issues {
 		// Check read status
@@ -223,8 +225,18 @@ func issues(ctx *context.Context, milestoneID int64, isPullOption util.OptionalB
 			ctx.ServerError("GetIsRead", err)
 			return
 		}
+
+		if isPullOption == util.OptionalBoolTrue {
+			commitStatus[issues[i].PullRequest.ID], err = issues[i].PullRequest.GetLastCommitStatus()
+			if err != nil {
+				ctx.ServerError("GetLastCommitStatus", err)
+				return
+			}
+		}
 	}
+
 	ctx.Data["Issues"] = issues
+	ctx.Data["CommitStatus"] = commitStatus
 
 	// Get assignees.
 	ctx.Data["Assignees"], err = repo.GetAssignees()

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -319,8 +319,17 @@ func Issues(ctx *context.Context) {
 		return
 	}
 
+	var commitStatus = make(map[int64]*models.CommitStatus, len(issues))
 	for _, issue := range issues {
 		issue.Repo = showReposMap[issue.RepoID]
+
+		if isPullList {
+			commitStatus[issue.PullRequest.ID], err = issue.PullRequest.GetLastCommitStatus()
+			if err != nil {
+				ctx.ServerError("GetLastCommitStatus", err)
+				return
+			}
+		}
 	}
 
 	issueStats, err := models.GetUserIssueStats(models.UserIssueStatsOptions{
@@ -344,6 +353,7 @@ func Issues(ctx *context.Context) {
 	}
 
 	ctx.Data["Issues"] = issues
+	ctx.Data["CommitStatus"] = commitStatus
 	ctx.Data["Repos"] = showRepos
 	ctx.Data["Counts"] = counts
 	ctx.Data["Page"] = paginater.New(total, setting.UI.IssuePagingNum, page, 5)

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -203,6 +203,12 @@
 					<div class="ui {{if .IsRead}}black{{else}}green{{end}} label">#{{.Index}}</div>
 					<a class="title has-emoji" href="{{$.Link}}/{{.Index}}">{{.Title}}</a>
 
+                    {{if .IsPull }}
+                        {{if (index $.CommitStatus .ID)}}
+                            {{template "repo/commit_status" (index $.CommitStatus .ID)}}
+						{{end}}
+					{{end}}
+
 					{{if .Ref}}
 						<a class="ui label" href="{{$.RepoLink}}/src/branch/{{.Ref}}">{{.Ref}}</a>
 					{{end}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -66,6 +66,12 @@
 							<div class="ui label">{{if not $.RepoID}}{{.Repo.FullName}}{{end}}#{{.Index}}</div>
 							<a class="title has-emoji" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Title}}</a>
 
+                            {{if .IsPull }}
+                                {{if (index $.CommitStatus .ID)}}
+                                    {{template "repo/commit_status" (index $.CommitStatus .ID)}}
+                                {{end}}
+                            {{end}}
+
 							{{with .Labels}}
 								{{/* If we have any labels, we should show them
 								with a 2.5 line height, this way they don't look


### PR DESCRIPTION
Show last commit status for pull requests in lists.
Addresses part of issue #996 (Better CI Integration).

Takes a sligthly different approach than PR #2519 (Add commit status on repo and user pull request  lists) to minimize the changes needed to implement the feature.

Screenshots:
![Screenshot_2019-03-28 Gitea Git with a cup of tea](https://user-images.githubusercontent.com/1116218/55152027-d0459c80-514f-11e9-97b4-042db22fdab3.png)
![Screenshot_2019-03-28 test](https://user-images.githubusercontent.com/1116218/55152033-d3d92380-514f-11e9-8f0b-ebe2ac0b0f62.png)
