### PR TITLE
support custom file name in `gitea dump` command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"code.gitea.io/gitea/models"
@@ -34,6 +35,11 @@ It can be used for backup and capture Gitea server image to send to maintainer`,
 			Name:  "config, c",
 			Value: "custom/conf/app.ini",
 			Usage: "Custom configuration file path",
+		},
+		cli.StringFlag{
+			Name:  "file, f",
+			Value: "gitea-dump-%d.zip",
+			Usage: "Name of the dump file which will be created.",
 		},
 		cli.BoolFlag{
 			Name:  "verbose, v",
@@ -85,7 +91,7 @@ func runDump(ctx *cli.Context) error {
 
 	dbDump := path.Join(tmpWorkDir, "gitea-db.sql")
 
-	fileName := fmt.Sprintf("gitea-dump-%d.zip", time.Now().Unix())
+	fileName := getDumpFileName(ctx)
 	log.Printf("Packing dump files...")
 	z, err := zip.Create(fileName)
 	if err != nil {
@@ -162,6 +168,16 @@ func runDump(ctx *cli.Context) error {
 	log.Printf("Finish dumping in file %s", fileName)
 
 	return nil
+}
+
+func getDumpFileName(ctx *cli.Context) string {
+	fmtString := ctx.String("file")
+
+	if strings.Count(fmtString, "%d") > 0 {
+		fmtString = fmt.Sprintf(fmtString, time.Now().Unix())
+	}
+
+	return fmtString
 }
 
 // zipAddDirectoryExclude zips absPath to specified zipPath inside z excluding excludeAbsPath

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"code.gitea.io/gitea/models"
@@ -38,7 +37,7 @@ It can be used for backup and capture Gitea server image to send to maintainer`,
 		},
 		cli.StringFlag{
 			Name:  "file, f",
-			Value: "gitea-dump-%d.zip",
+			Value: fmt.Sprintf("gitea-dump-%d.zip", time.Now().Unix()),
 			Usage: "Name of the dump file which will be created.",
 		},
 		cli.BoolFlag{
@@ -91,7 +90,7 @@ func runDump(ctx *cli.Context) error {
 
 	dbDump := path.Join(tmpWorkDir, "gitea-db.sql")
 
-	fileName := getDumpFileName(ctx)
+	fileName := ctx.String("file")
 	log.Printf("Packing dump files...")
 	z, err := zip.Create(fileName)
 	if err != nil {
@@ -168,16 +167,6 @@ func runDump(ctx *cli.Context) error {
 	log.Printf("Finish dumping in file %s", fileName)
 
 	return nil
-}
-
-func getDumpFileName(ctx *cli.Context) string {
-	fmtString := ctx.String("file")
-
-	if strings.Count(fmtString, "%d") > 0 {
-		fmtString = fmt.Sprintf(fmtString, time.Now().Unix())
-	}
-
-	return fmtString
 }
 
 // zipAddDirectoryExclude zips absPath to specified zipPath inside z excluding excludeAbsPath

--- a/docs/content/doc/usage/command-line.md
+++ b/docs/content/doc/usage/command-line.md
@@ -148,6 +148,7 @@ in the current directory.
 
 - Options:
     - `--config path`, `-c path`: Gitea configuration file path. Optional. (default: custom/conf/app.ini).
+    - `--file name`, `-f name`: Name of the dump file with will be created. Optional. (default: gitea-dump-[timestamp].zip).
     - `--tempdir path`, `-t path`: Path to the temporary directory used. Optional. (default: /tmp).
     - `--skip-repository`, `-R`: Skip the repository dumping. Optional.
     - `--database`, `-d`: Specify the database SQL syntax. Optional.


### PR DESCRIPTION
## what

with this patch you can submit a custom nam for the backup file created by `gitea dump`.

    gitea dump -f gitea-backup.zip

## why

without this patch, when writing a backup script which stores my gitea dump off-site, i have to do some weird gymnastics to get the file `gitea dump` writes to disk because it generates a random file name with the current unix timestamp. like `dump_file=$(ls -t|head -1)` while being sure to be in an empty directory.

with this patch, i can just choose the file's name myself and move on encrypting and uploading it.

## compatibility

this change should not affect anybody as the new parameter is optional and has a default value which does not change the known behavior of the binary.