### PR TITLE
Add X-Auto-Response-Suppress header to outgoing messages

### DIFF
--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -40,6 +40,7 @@ func NewMessageFrom(to []string, fromDisplayName, fromAddress, subject, body str
 	msg.SetHeader("To", to...)
 	msg.SetHeader("Subject", subject)
 	msg.SetDateHeader("Date", time.Now())
+	msg.SetHeader("X-Auto-Response-Suppress", "All")
 
 	plainBody, err := html2text.FromString(body)
 	if err != nil || setting.MailService.SendAsPlainText {


### PR DESCRIPTION
This is a header used to suggest mail servers not to respond to a message with an auto-responder:

 https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1

This header is also used by github and gitlab in outgoing messages.

Fixes #6484