### PR TITLE
Make distinction between DisplayName and Username in email templates

### DIFF
--- a/models/mail.go
+++ b/models/mail.go
@@ -48,7 +48,7 @@ func SendTestMail(email string) error {
 func SendUserMail(c *macaron.Context, u *User, tpl base.TplName, code, subject, info string) {
 	data := map[string]interface{}{
 		"DisplayName":       u.DisplayName(),
-		"Username":          u.DisplayUsername(),
+		"Username":          u.Name,
 		"ActiveCodeLives":   base.MinutesToFriendly(setting.Service.ActiveCodeLives, c.Locale.Language()),
 		"ResetPwdCodeLives": base.MinutesToFriendly(setting.Service.ResetPwdCodeLives, c.Locale.Language()),
 		"Code":              code,
@@ -80,7 +80,8 @@ func SendResetPasswordMail(c *macaron.Context, u *User) {
 // SendActivateEmailMail sends confirmation email to confirm new email address
 func SendActivateEmailMail(c *macaron.Context, u *User, email *EmailAddress) {
 	data := map[string]interface{}{
-		"Username":        u.DisplayName(),
+		"DisplayName":     u.DisplayName(),
+		"Username":        u.Name,
 		"ActiveCodeLives": base.MinutesToFriendly(setting.Service.ActiveCodeLives, c.Locale.Language()),
 		"Code":            u.GenerateEmailActivateCode(email.Email),
 		"Email":           email.Email,
@@ -102,7 +103,8 @@ func SendActivateEmailMail(c *macaron.Context, u *User, email *EmailAddress) {
 // SendRegisterNotifyMail triggers a notify e-mail by admin created a account.
 func SendRegisterNotifyMail(c *macaron.Context, u *User) {
 	data := map[string]interface{}{
-		"Username": u.DisplayName(),
+		"DisplayName": u.DisplayName(),
+		"Username":    u.Name,
 	}
 
 	var content bytes.Buffer

--- a/models/mail.go
+++ b/models/mail.go
@@ -48,7 +48,6 @@ func SendTestMail(email string) error {
 func SendUserMail(c *macaron.Context, u *User, tpl base.TplName, code, subject, info string) {
 	data := map[string]interface{}{
 		"DisplayName":       u.DisplayName(),
-		"Username":          u.Name,
 		"ActiveCodeLives":   base.MinutesToFriendly(setting.Service.ActiveCodeLives, c.Locale.Language()),
 		"ResetPwdCodeLives": base.MinutesToFriendly(setting.Service.ResetPwdCodeLives, c.Locale.Language()),
 		"Code":              code,
@@ -81,7 +80,6 @@ func SendResetPasswordMail(c *macaron.Context, u *User) {
 func SendActivateEmailMail(c *macaron.Context, u *User, email *EmailAddress) {
 	data := map[string]interface{}{
 		"DisplayName":     u.DisplayName(),
-		"Username":        u.Name,
 		"ActiveCodeLives": base.MinutesToFriendly(setting.Service.ActiveCodeLives, c.Locale.Language()),
 		"Code":            u.GenerateEmailActivateCode(email.Email),
 		"Email":           email.Email,

--- a/models/mail.go
+++ b/models/mail.go
@@ -47,7 +47,8 @@ func SendTestMail(email string) error {
 // SendUserMail sends a mail to the user
 func SendUserMail(c *macaron.Context, u *User, tpl base.TplName, code, subject, info string) {
 	data := map[string]interface{}{
-		"Username":          u.DisplayName(),
+		"DisplayName":       u.DisplayName(),
+		"Username":          u.DisplayUsername(),
 		"ActiveCodeLives":   base.MinutesToFriendly(setting.Service.ActiveCodeLives, c.Locale.Language()),
 		"ResetPwdCodeLives": base.MinutesToFriendly(setting.Service.ResetPwdCodeLives, c.Locale.Language()),
 		"Code":              code,

--- a/models/user.go
+++ b/models/user.go
@@ -650,11 +650,6 @@ func (u *User) DisplayName() string {
 	return u.Name
 }
 
-// DisplayUsername returns username
-func (u *User) DisplayUsername() string {
-	return u.Name
-}
-
 func gitSafeName(name string) string {
 	return strings.TrimSpace(strings.NewReplacer("\n", "", "<", "", ">", "").Replace(name))
 }

--- a/models/user.go
+++ b/models/user.go
@@ -650,6 +650,11 @@ func (u *User) DisplayName() string {
 	return u.Name
 }
 
+// DisplayUsername returns username
+func (u *User) DisplayUsername() string {
+	return u.Name
+}
+
 func gitSafeName(name string) string {
 	return strings.TrimSpace(strings.NewReplacer("\n", "", "<", "", ">", "").Replace(name))
 }

--- a/templates/mail/auth/activate.tmpl
+++ b/templates/mail/auth/activate.tmpl
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>{{.Username}}, please activate your account</title>
+	<title>{{.DisplayName}}, please activate your account</title>
 </head>
 
 <body>
-	<p>Hi <b>{{.Username}}</b>, thanks for registering at {{AppName}}!</p>
+	<p>Hi <b>{{.DisplayName}}</b>, thanks for registering at {{AppName}}!</p>
 	<p>Please click the following link to activate your account within <b>{{.ActiveCodeLives}}</b>:</p>
 	<p><a href="{{AppUrl}}user/activate?code={{.Code}}">{{AppUrl}}user/activate?code={{.Code}}</a></p>
 	<p>Not working? Try copying and pasting it to your browser.</p>

--- a/templates/mail/auth/activate_email.tmpl
+++ b/templates/mail/auth/activate_email.tmpl
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>{{.Username}}, please verify your e-mail address</title>
+	<title>{{.DisplayName}}, please verify your e-mail address</title>
 </head>
 
 <body>
-	<p>Hi <b>{{.Username}}</b>,</p>
+	<p>Hi <b>{{.DisplayName}}</b>,</p>
 	<p>Please click the following link to verify your email address within <b>{{.ActiveCodeLives}}</b>:</p>
 	<p><a href="{{AppUrl}}user/activate_email?code={{.Code}}&email={{.Email}}">{{AppUrl}}user/activate_email?code={{.Code}}&email={{.Email}}</a></p>
 	<p>Not working? Try copying and pasting it to your browser.</p>

--- a/templates/mail/auth/register_notify.tmpl
+++ b/templates/mail/auth/register_notify.tmpl
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>{{.Username}}, welcome to {{AppName}}</title>
+	<title>{{.DisplayName}}, welcome to {{AppName}}</title>
 </head>
 
 <body>
-	<p>Hi <b>{{.Username}}</b>, this is your registration confirmation email for {{AppName}}!</p>
+	<p>Hi <b>{{.DisplayName}}</b>, this is your registration confirmation email for {{AppName}}!</p>
 	<p>You can now login via username: {{.Username}}.</p>
 	<p><a href="{{AppUrl}}user/login">{{AppUrl}}user/login</a></p>
 	<p>If this account has been created for you, please <a href="{{AppUrl}}user/forgot_password">reset your password</a> first.</p>

--- a/templates/mail/auth/reset_passwd.tmpl
+++ b/templates/mail/auth/reset_passwd.tmpl
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>{{.Username}}, you have requested to reset your password</title>
+	<title>{{.DisplayName}}, you have requested to reset your password</title>
 </head>
 
 <body>
-	<p>Hi <b>{{.Username}}</b>,</p>
+	<p>Hi <b>{{.DisplayName}}</b>,</p>
 	<p>Please click the following link to reset your password within <b>{{.ResetPwdCodeLives}}</b>:</p>
 	<p><a href="{{AppUrl}}user/reset_password?code={{.Code}}">{{AppUrl}}user/reset_password?code={{.Code}}</a></p>
 	<p>Not working? Try copying and pasting it to your browser.</p>


### PR DESCRIPTION
Store the actual username in the variable named Username and store the separate DisplayName in another variable. This allows us to access the actual username when we need, which currently fails if a user has set a full name.

Fixes #6161