### PR TITLE
[docker] drop the bits argument when generating an ed25519 key

### DIFF
--- a/docker/etc/s6/openssh/setup
+++ b/docker/etc/s6/openssh/setup
@@ -6,7 +6,7 @@ fi
 
 if [ ! -f /data/ssh/ssh_host_ed25519_key ]; then
     echo "Generating /data/ssh/ssh_host_ed25519_key..."
-    ssh-keygen -t ed25519 -b 4096 -f /data/ssh/ssh_host_ed25519_key -N "" > /dev/null
+    ssh-keygen -t ed25519 -f /data/ssh/ssh_host_ed25519_key -N "" > /dev/null
 fi
 
 if [ ! -f /data/ssh/ssh_host_rsa_key ]; then


### PR DESCRIPTION
From the man page of ssh-keygen [1]:
```
Ed25519 keys have a fixed length and the -b flag will be ignored.
```

The actual private key size for Ed25519 is 256 bits [1] which does not match with the currently specified 4096 bits anyways.

[1] https://man.openbsd.org/ssh-keygen#b
[2] https://tools.ietf.org/html/rfc8032#section-5.1.5