### PR TITLE
Include custom configuration file in dump

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -125,6 +125,14 @@ func runDump(ctx *cli.Context) error {
 	if err := z.AddFile("gitea-db.sql", dbDump); err != nil {
 		log.Fatalf("Failed to include gitea-db.sql: %v", err)
 	}
+
+	if len(setting.CustomConf) > 0 {
+		log.Printf("Adding custom configuration file from %s", setting.CustomConf)
+		if err := z.AddFile("app.ini", setting.CustomConf); err != nil {
+			log.Fatalf("Failed to include specified app.ini: %v", err)
+		}
+	}
+
 	customDir, err := os.Stat(setting.CustomPath)
 	if err == nil && customDir.IsDir() {
 		if err := z.AddDir("custom", setting.CustomPath); err != nil {

--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -34,6 +34,7 @@ directory. There should be some output similar to the following:
 
 Inside the `gitea-dump-1482906742.zip` file, will be the following:
 
+* `app.ini` - Optional copy of configuration file if originally stored outside of the default `custom/` directory
 * `custom` - All config or customerize files in `custom/`.
 * `data` - Data directory in <GITEA_WORK_DIR>, except sessions if you are using file session. This directory includes `attachments`, `avatars`, `lfs`, `indexers`, sqlite file if you are using sqlite.
 * `gitea-db.sql` - SQL dump of database
@@ -53,7 +54,7 @@ Example:
 apt-get install gitea
 unzip gitea-dump-1482906742.zip
 cd gitea-dump-1482906742
-mv custom/conf/app.ini /etc/gitea/conf/app.ini
+mv custom/conf/app.ini /etc/gitea/conf/app.ini # or mv app.ini /etc/gitea/conf/app.ini
 unzip gitea-repo.zip
 mv gitea-repo/* /var/lib/gitea/repositories/
 chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea/repositories/


### PR DESCRIPTION
When running the dump command, include the specific configuration file
provided as part of the backup. Currently we only zip up custom/ and this
misses the config file if it is somewhere else, like /etc/gitea/app.ini

Fixes #6034