### PR TITLE
Properly escape release attachment URL (#6512)

### DIFF
--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -77,7 +77,7 @@
 									{{if .Attachments}}
 										{{range $attachment := .Attachments}}
 										<li>
-											<a target="_blank" rel="noopener noreferrer" href="{{$.RepoLink}}/releases/download/{{$release.TagName}}/{{$attachment.Name}}">
+											<a target="_blank" rel="noopener noreferrer" href="{{$.RepoLink}}/releases/download/{{$release.TagName | PathEscape}}/{{$attachment.Name | PathEscape}}">
 												<strong><span class="ui image octicon octicon-package" title='{{$attachment.Name}}'></span> {{$attachment.Name}}</strong>
 												<span class="ui text grey right">{{$attachment.Size | FileSize}}</span>
 											</a>


### PR DESCRIPTION
Make sure file attachments on a release get a properly escaped URL when
linking.

Fixes #6506

This is backport to release/v1.8