### PR TITLE
Improve SHA1 link detection

### DIFF
--- a/modules/markup/html_internal_test.go
+++ b/modules/markup/html_internal_test.go
@@ -273,12 +273,12 @@ func TestRegExp_anySHA1Pattern(t *testing.T) {
 	testCases := map[string][]string{
 		"https://github.com/jquery/jquery/blob/a644101ed04d0beacea864ce805e0c4f86ba1cd1/test/unit/event.js#L2703": {
 			"a644101ed04d0beacea864ce805e0c4f86ba1cd1",
-			"test/unit/event.js",
-			"L2703",
+			"/test/unit/event.js",
+			"#L2703",
 		},
 		"https://github.com/jquery/jquery/blob/a644101ed04d0beacea864ce805e0c4f86ba1cd1/test/unit/event.js": {
 			"a644101ed04d0beacea864ce805e0c4f86ba1cd1",
-			"test/unit/event.js",
+			"/test/unit/event.js",
 			"",
 		},
 		"https://github.com/jquery/jquery/commit/0705be475092aede1eddae01319ec931fb9c65fc": {
@@ -288,13 +288,13 @@ func TestRegExp_anySHA1Pattern(t *testing.T) {
 		},
 		"https://github.com/jquery/jquery/tree/0705be475092aede1eddae01319ec931fb9c65fc/src": {
 			"0705be475092aede1eddae01319ec931fb9c65fc",
-			"src",
+			"/src",
 			"",
 		},
 		"https://try.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2": {
 			"d8a994ef243349f321568f9e36d5c3f444b99cae",
 			"",
-			"diff-2",
+			"#diff-2",
 		},
 	}
 


### PR DESCRIPTION
This improves the SHA1 link detection to not pick up extraneous non-whitespace characters at the end of the URL. The '.' is a special case handled in code itself because of missing regexp lookahead support.

Regex test cases: https://regex101.com/r/xUMlqh/3/

#### Before
<img width="264" alt="Screenshot 2019-04-06 at 01 09 57" src="https://user-images.githubusercontent.com/115237/55660902-e7982000-5808-11e9-9a89-6efd05419065.png">


#### After
<img width="267" alt="Screenshot 2019-04-06 at 01 10 04" src="https://user-images.githubusercontent.com/115237/55660905-ed8e0100-5808-11e9-8157-a32bd2529ae7.png">

