### PR TITLE
Render SHA1 links as code blocks

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -327,22 +327,39 @@ func (ctx *postProcessCtx) textNode(node *html.Node) {
 }
 
 func createLink(href, content string) *html.Node {
-	textNode := &html.Node{
+	a := &html.Node{
+		Type: html.ElementNode,
+		Data: atom.A.String(),
+		Attr: []html.Attribute{{Key: "href", Val: href}},
+	}
+	text := &html.Node{
 		Type: html.TextNode,
 		Data: content,
 	}
-	linkNode := &html.Node{
-		FirstChild: textNode,
-		LastChild:  textNode,
-		Type:       html.ElementNode,
-		Data:       "a",
-		DataAtom:   atom.A,
-		Attr: []html.Attribute{
-			{Key: "href", Val: href},
-		},
+
+	a.AppendChild(text)
+	return a
+}
+
+func createCodeLink(href, content string) *html.Node {
+	a := &html.Node{
+		Type: html.ElementNode,
+		Data: atom.A.String(),
+		Attr: []html.Attribute{{Key: "href", Val: href}},
 	}
-	textNode.Parent = linkNode
-	return linkNode
+	text := &html.Node{
+		Type: html.TextNode,
+		Data: content,
+	}
+
+	code := &html.Node{
+		Type: html.ElementNode,
+		Data: atom.Code.String(),
+	}
+
+	code.AppendChild(text)
+	a.AppendChild(code)
+	return a
 }
 
 // replaceContent takes a text node, and in its content it replaces a section of
@@ -633,7 +650,7 @@ func fullSha1PatternProcessor(ctx *postProcessCtx, node *html.Node) {
 		text += " (" + hash + ")"
 	}
 
-	replaceContent(node, start, end, createLink(urlFull, text))
+	replaceContent(node, start, end, createCodeLink(urlFull, text))
 }
 
 // sha1CurrentPatternProcessor renders SHA1 strings to corresponding links that
@@ -651,7 +668,7 @@ func sha1CurrentPatternProcessor(ctx *postProcessCtx, node *html.Node) {
 	// Although unlikely, deadbeef and 1234567 are valid short forms of SHA1 hash
 	// as used by git and github for linking and thus we have to do similar.
 	replaceContent(node, m[2], m[3],
-		createLink(util.URLJoin(ctx.urlPrefix, "commit", hash), base.ShortSha(hash)))
+		createCodeLink(util.URLJoin(ctx.urlPrefix, "commit", hash), base.ShortSha(hash)))
 }
 
 // emailAddressProcessor replaces raw email addresses with a mailto: link.

--- a/modules/markup/html_internal_test.go
+++ b/modules/markup/html_internal_test.go
@@ -195,13 +195,13 @@ func TestRender_AutoLink(t *testing.T) {
 
 	// render valid commit URLs
 	tmp := util.URLJoin(AppSubURL, "commit", "d8a994ef243349f321568f9e36d5c3f444b99cae")
-	test(tmp, "<a href=\""+tmp+"\">d8a994ef24</a>")
+	test(tmp, "<a href=\""+tmp+"\"><code>d8a994ef24</code></a>")
 	tmp += "#diff-2"
-	test(tmp, "<a href=\""+tmp+"\">d8a994ef24 (diff-2)</a>")
+	test(tmp, "<a href=\""+tmp+"\"><code>d8a994ef24 (diff-2)</code></a>")
 
 	// render other commit URLs
 	tmp = "https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2"
-	test(tmp, "<a href=\""+tmp+"\">d8a994ef24 (diff-2)</a>")
+	test(tmp, "<a href=\""+tmp+"\"><code>d8a994ef24 (diff-2)</code></a>")
 }
 
 func TestRender_FullIssueURLs(t *testing.T) {

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -30,12 +30,12 @@ func TestRender_Commits(t *testing.T) {
 	var subtree = util.URLJoin(commit, "src")
 	var tree = strings.Replace(subtree, "/commit/", "/tree/", -1)
 
-	test(sha, `<p><a href="`+commit+`" rel="nofollow">b6dd6210ea</a></p>`)
-	test(sha[:7], `<p><a href="`+commit[:len(commit)-(40-7)]+`" rel="nofollow">b6dd621</a></p>`)
-	test(sha[:39], `<p><a href="`+commit[:len(commit)-(40-39)]+`" rel="nofollow">b6dd6210ea</a></p>`)
-	test(commit, `<p><a href="`+commit+`" rel="nofollow">b6dd6210ea</a></p>`)
-	test(tree, `<p><a href="`+tree+`" rel="nofollow">b6dd6210ea/src</a></p>`)
-	test("commit "+sha, `<p>commit <a href="`+commit+`" rel="nofollow">b6dd6210ea</a></p>`)
+	test(sha, `<p><a href="`+commit+`" rel="nofollow"><code>b6dd6210ea</code></a></p>`)
+	test(sha[:7], `<p><a href="`+commit[:len(commit)-(40-7)]+`" rel="nofollow"><code>b6dd621</code></a></p>`)
+	test(sha[:39], `<p><a href="`+commit[:len(commit)-(40-39)]+`" rel="nofollow"><code>b6dd6210ea</code></a></p>`)
+	test(commit, `<p><a href="`+commit+`" rel="nofollow"><code>b6dd6210ea</code></a></p>`)
+	test(tree, `<p><a href="`+tree+`" rel="nofollow"><code>b6dd6210ea/src</code></a></p>`)
+	test("commit "+sha, `<p>commit <a href="`+commit+`" rel="nofollow"><code>b6dd6210ea</code></a></p>`)
 	test("/home/gitea/"+sha, "<p>/home/gitea/"+sha+"</p>")
 
 }


### PR DESCRIPTION
This changes the rendering of SHA1 hashes to render with `<code>` blocks, matching GitHub's behaviour. I added a new `createCodeLink` function and simplified `createLink` a bit.

#### Before
<img width="197" alt="Screenshot 2019-04-08 at 21 27 17" src="https://user-images.githubusercontent.com/115237/55751143-4813a100-5a45-11e9-85ea-5732eb62aabf.png">

#### After
<img width="215" alt="Screenshot 2019-04-08 at 21 27 25" src="https://user-images.githubusercontent.com/115237/55751152-4d70eb80-5a45-11e9-84c5-281a46301ea1.png">
