### PR TITLE
Fix race in integration testlogger

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -81,6 +81,8 @@ func TestMain(m *testing.M) {
 	}
 	exitCode := m.Run()
 
+	writerCloser.t = nil
+
 	if err = os.RemoveAll(setting.Indexer.IssuePath); err != nil {
 		fmt.Printf("os.RemoveAll: %v\n", err)
 		os.Exit(1)

--- a/integrations/testlogger.go
+++ b/integrations/testlogger.go
@@ -33,6 +33,27 @@ func (w *testLoggerWriterCloser) Write(p []byte) (int, error) {
 		if len(p) > 0 && p[len(p)-1] == '\n' {
 			p = p[:len(p)-1]
 		}
+
+		defer func() {
+			err := recover()
+			if err == nil {
+				return
+			}
+			var errString string
+			errErr, ok := err.(error)
+			if ok {
+				errString = errErr.Error()
+			} else {
+				errString, ok = err.(string)
+			}
+			if !ok {
+				panic(err)
+			}
+			if !strings.HasPrefix(errString, "Log in goroutine after ") {
+				panic(err)
+			}
+		}()
+
 		w.t.Log(string(p))
 		return len(p), nil
 	}


### PR DESCRIPTION
Unfortunately go testing will panic if you try to log after test has finished - this can cause a race in the integration test on drone. As we don't care about these logs - we should just catch the panic and just ignore it. 