### PR TITLE
Docs: Backup&Restore: fixed rendering + minor fixes

### DIFF
--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -20,10 +20,10 @@ file can be unpacked and used to restore an instance.
 
 ## Backup Command (`dump`)
 
-Switch to the user running gitea: `su git`. Run `./gitea dump -c /path/to/app.ini` in the gitea installation
+Switch to the user running Gitea: `su git`. Run `./gitea dump -c /path/to/app.ini` in the Gitea installation
 directory. There should be some output similar to the following:
 
-```
+```none
 2016/12/27 22:32:09 Creating tmp work dir: /tmp/gitea-dump-417443001
 2016/12/27 22:32:09 Dumping local repositories.../home/git/gitea-repositories
 2016/12/27 22:32:22 Dumping database...
@@ -35,7 +35,7 @@ directory. There should be some output similar to the following:
 Inside the `gitea-dump-1482906742.zip` file, will be the following:
 
 * `app.ini` - Optional copy of configuration file if originally stored outside of the default `custom/` directory
-* `custom` - All config or customerize files in `custom/`.
+* `custom` - All config or customization files in `custom/`.
 * `data` - Data directory in <GITEA_WORK_DIR>, except sessions if you are using file session. This directory includes `attachments`, `avatars`, `lfs`, `indexers`, sqlite file if you are using sqlite.
 * `gitea-db.sql` - SQL dump of database
 * `gitea-repo.zip` - Complete copy of the repository directory.
@@ -45,15 +45,18 @@ Intermediate backup files are created in a temporary directory specified either 
 `--tempdir` command-line parameter or the `TMPDIR` environment variable.
 
 ### Using Docker (`dump`)
+
 There are a few caveats for using the `dump` command with Docker.
 
 The command has to be executed with the `RUN_USER = <OS_USERNAME>` specified in `gitea/conf/app.ini`; and, for the zipping of the backup folder to occur without permission error the command `docker exec` must be executed inside of the `--tempdir`.
 
 Example:
 
-```docker exec -u <OS_USERNAME> -it -w <--tempdir> $(docker ps -qf "name=<NAME_OF_DOCKER_CONTAINER>") bash -c '/app/gitea/gitea dump -c </path/to/app.ini>'```
+```none
+docker exec -u <OS_USERNAME> -it -w <--tempdir> $(docker ps -qf "name=<NAME_OF_DOCKER_CONTAINER>") bash -c '/app/gitea/gitea dump -c </path/to/app.ini>'
+```
 
-*Note: `--tempdir` refers to the temporary directory of the docker enviroment used by gitea; if you have not specified a custom `--tempdir`, then gitea uses `/tmp` or the `TMPDIR` enviromental variable of the docker container. For `--tempdir` adjust your `docker exec` command options accordingly.
+*Note: `--tempdir` refers to the temporary directory of the docker environment used by Gitea; if you have not specified a custom `--tempdir`, then Gitea uses `/tmp` or the `TMPDIR` environment variable of the docker container. For `--tempdir` adjust your `docker exec` command options accordingly.
 
 The result should be a file, stored in the `--tempdir` specified, along the lines of: `gitea-dump-1482906742.zip`
 
@@ -63,7 +66,8 @@ There is currently no support for a recovery command. It is a manual process tha
 involves moving files to their correct locations and restoring a database dump.
 
 Example:
-```
+
+```none
 apt-get install gitea
 unzip gitea-dump-1482906742.zip
 cd gitea-dump-1482906742


### PR DESCRIPTION
This fixes a major issue with the rendering of the page, where a code block would cause the rest of the code blocks of the page to be inverted. Also fixed are some markdown syntax issues, and general spelling issues.

Screenshot of the current rendering:
![image](https://user-images.githubusercontent.com/5877043/55861908-5d6ff480-5b45-11e9-861e-5d7e6913155c.png)