### PR TITLE
Integration PR for #6541

### DIFF
--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -95,8 +95,8 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 		}
 
 		visibilityChanged := repo.IsPrivate != form.Private
-		// when ForcePrivate enabled, you could change public repo to private, but could not change private to public
-		if visibilityChanged && setting.Repository.ForcePrivate && !form.Private {
+		// when ForcePrivate enabled, you could change public repo to private, but only admin users can change private to public
+		if visibilityChanged && setting.Repository.ForcePrivate && !form.Private && !ctx.User.IsAdmin {
 			ctx.ServerError("Force Private enabled", errors.New("cannot change private repository to public"))
 			return
 		}

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -19,7 +19,11 @@
 					<div class="inline field">
 						<label>{{.i18n.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
+							{{if .IsAdmin}}
+							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}>
+							{{else}}
 							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if and $.ForcePrivate .Repository.IsPrivate}} readonly{{end}}>
+							{{end}}
 							<label>{{.i18n.Tr "repo.visibility_helper" | Safe}} {{if .Repository.NumForks}}<span class="text red">{{.i18n.Tr "repo.visibility_fork_helper"}}</span>{{end}}</label>
 						</div>
 					</div>


### PR DESCRIPTION
Allow admin users to set a repositories visibility to public, even if FORCE_PRIVATE is to true (#6541)

Signed-off-by: Matthias Beckert <beckert.matthias@googlemail.com>
