### PR TITLE
Remove extra slash from twitter card

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -144,7 +144,7 @@
 {{else}}
 	<meta property="og:title" content="{{AppName}}">
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="{{AppUrl}}/img/gitea-lg.png" />
+	<meta property="og:image" content="{{AppUrl}}img/gitea-lg.png" />
 	<meta property="og:url" content="{{AppUrl}}" />
 	<meta property="og:description" content="{{MetaDescription}}">
 {{end}}


### PR DESCRIPTION
on try.gitea.io the current looks like: `<meta property="og:image" content="https://try.gitea.io//img/gitea-lg.png" />`

This PR removes the extra slash from the `AppUrl`

cc: @ashimokawa 