### PR TITLE
[WIP] Refactor: Replace RepoPath(string,string) with (*Repository).RepoPath()

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -81,7 +81,12 @@ func runHookPreReceive(c *cli.Context) error {
 	username := os.Getenv(models.EnvRepoUsername)
 	reponame := os.Getenv(models.EnvRepoName)
 	userIDStr := os.Getenv(models.EnvPusherID)
-	repoPath := models.MakeRepoPath(username, reponame)
+
+	repo, err := models.GetRepositoryByOwnerAndName(username, reponame)
+	if err != nil {
+		fail("repository %s/%s does not exist: %v", username, reponame, err)
+	}
+	repoPath := repo.RepoPath()
 
 	buf := bytes.NewBuffer(nil)
 	scanner := bufio.NewScanner(os.Stdin)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -81,7 +81,7 @@ func runHookPreReceive(c *cli.Context) error {
 	username := os.Getenv(models.EnvRepoUsername)
 	reponame := os.Getenv(models.EnvRepoName)
 	userIDStr := os.Getenv(models.EnvPusherID)
-	repoPath := models.RepoPath(username, reponame)
+	repoPath := models.MakeRepoPath(username, reponame)
 
 	buf := bytes.NewBuffer(nil)
 	scanner := bufio.NewScanner(os.Stdin)

--- a/models/migrations/v82.go
+++ b/models/migrations/v82.go
@@ -87,7 +87,7 @@ func fixReleaseSha1OnReleaseTable(x *xorm.Engine) error {
 					userCache[repo.OwnerID] = user
 				}
 
-				gitRepo, err = git.OpenRepository(models.RepoPath(user.Name, repo.Name))
+				gitRepo, err = git.OpenRepository(models.MakeRepoPath(user.Name, repo.Name))
 				if err != nil {
 					return err
 				}

--- a/models/pull.go
+++ b/models/pull.go
@@ -413,7 +413,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		go AddTestPullRequestTask(doer, pr.BaseRepo.ID, pr.BaseBranch, false)
 	}()
 
-	headRepoPath := RepoPath(pr.HeadUserName, pr.HeadRepo.Name)
+	headRepoPath := MakeRepoPath(pr.HeadUserName, pr.HeadRepo.Name)
 
 	// Clone base repo.
 	tmpBasePath := path.Join(LocalCopyPath(), "merge-"+com.ToStr(time.Now().Nanosecond())+".git")
@@ -1172,7 +1172,7 @@ func (pr *PullRequest) UpdatePatch() (err error) {
 
 	// Add a temporary remote.
 	tmpRemote := com.ToStr(time.Now().UnixNano())
-	if err = headGitRepo.AddRemote(tmpRemote, RepoPath(pr.BaseRepo.MustOwner().Name, pr.BaseRepo.Name), true); err != nil {
+	if err = headGitRepo.AddRemote(tmpRemote, MakeRepoPath(pr.BaseRepo.MustOwner().Name, pr.BaseRepo.Name), true); err != nil {
 		return fmt.Errorf("AddRemote: %v", err)
 	}
 	defer func() {

--- a/models/release_test.go
+++ b/models/release_test.go
@@ -17,7 +17,7 @@ func TestRelease_Create(t *testing.T) {
 
 	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
-	repoPath := RepoPath(user.Name, repo.Name)
+	repoPath := MakeRepoPath(user.Name, repo.Name)
 
 	gitRepo, err := git.OpenRepository(repoPath)
 	assert.NoError(t, err)
@@ -100,7 +100,7 @@ func TestRelease_MirrorDelete(t *testing.T) {
 
 	user := AssertExistsAndLoadBean(t, &User{ID: 2}).(*User)
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
-	repoPath := RepoPath(user.Name, repo.Name)
+	repoPath := MakeRepoPath(user.Name, repo.Name)
 	migrationOptions := MigrateRepoOptions{
 		Name:        "test_mirror",
 		Description: "Test mirror",

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -168,8 +168,8 @@ func TestTransferOwnership(t *testing.T) {
 	transferredRepo := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
 	assert.EqualValues(t, 2, transferredRepo.OwnerID)
 
-	assert.False(t, com.IsExist(RepoPath("user3", "repo3")))
-	assert.True(t, com.IsExist(RepoPath("user2", "repo3")))
+	assert.False(t, com.IsExist(MakeRepoPath("user3", "repo3")))
+	assert.True(t, com.IsExist(MakeRepoPath("user2", "repo3")))
 	AssertExistsAndLoadBean(t, &Action{
 		OpType:    ActionTransferRepo,
 		ActUserID: 2,

--- a/models/update.go
+++ b/models/update.go
@@ -191,7 +191,7 @@ func pushUpdate(opts PushUpdateOptions) (repo *Repository, err error) {
 		return nil, fmt.Errorf("Old and new revisions are both %s", git.EmptySHA)
 	}
 
-	repoPath := RepoPath(opts.RepoUserName, opts.RepoName)
+	repoPath := MakeRepoPath(opts.RepoUserName, opts.RepoName)
 
 	gitUpdate := exec.Command("git", "update-server-info")
 	gitUpdate.Dir = repoPath

--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -134,7 +134,7 @@ func ReferencesGitRepo() macaron.Handler {
 
 		// For API calls.
 		if ctx.Repo.GitRepo == nil {
-			repoPath := models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+			repoPath := models.MakeRepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 			gitRepo, err := git.OpenRepository(repoPath)
 			if err != nil {
 				ctx.Error(500, "RepoRef Invalid repo "+repoPath, err)

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -338,9 +338,9 @@ func RepoAssignment() macaron.Handler {
 			return
 		}
 
-		gitRepo, err := git.OpenRepository(models.RepoPath(userName, repoName))
+		gitRepo, err := git.OpenRepository(models.MakeRepoPath(userName, repoName))
 		if err != nil {
-			ctx.ServerError("RepoAssignment Invalid repo "+models.RepoPath(userName, repoName), err)
+			ctx.ServerError("RepoAssignment Invalid repo "+models.MakeRepoPath(userName, repoName), err)
 			return
 		}
 		ctx.Repo.GitRepo = gitRepo
@@ -557,7 +557,7 @@ func RepoRefByType(refType RepoRefType) macaron.Handler {
 
 		// For API calls.
 		if ctx.Repo.GitRepo == nil {
-			repoPath := models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+			repoPath := models.MakeRepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 			ctx.Repo.GitRepo, err = git.OpenRepository(repoPath)
 			if err != nil {
 				ctx.ServerError("RepoRef Invalid repo "+repoPath, err)

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -83,7 +83,7 @@ func GetArchive(ctx *context.APIContext) {
 	// responses:
 	//   200:
 	//     description: success
-	repoPath := models.RepoPath(ctx.Params(":username"), ctx.Params(":reponame"))
+	repoPath := models.MakeRepoPath(ctx.Params(":username"), ctx.Params(":reponame"))
 	gitRepo, err := git.OpenRepository(repoPath)
 	if err != nil {
 		ctx.Error(500, "OpenRepository", err)

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -659,7 +659,7 @@ func parseCompareInfo(ctx *context.APIContext, form api.CreatePullRequestOption)
 		headRepo = ctx.Repo.Repository
 		headGitRepo = ctx.Repo.GitRepo
 	} else {
-		headGitRepo, err = git.OpenRepository(models.RepoPath(headUser.Name, headRepo.Name))
+		headGitRepo, err = git.OpenRepository(models.MakeRepoPath(headUser.Name, headRepo.Name))
 		if err != nil {
 			ctx.Error(500, "OpenRepository", err)
 			return nil, nil, nil, nil, "", ""
@@ -683,7 +683,7 @@ func parseCompareInfo(ctx *context.APIContext, form api.CreatePullRequestOption)
 		return nil, nil, nil, nil, "", ""
 	}
 
-	prInfo, err := headGitRepo.GetPullRequestInfo(models.RepoPath(baseRepo.Owner.Name, baseRepo.Name), baseBranch, headBranch)
+	prInfo, err := headGitRepo.GetPullRequestInfo(models.MakeRepoPath(baseRepo.Owner.Name, baseRepo.Name), baseBranch, headBranch)
 	if err != nil {
 		ctx.Error(500, "GetPullRequestInfo", err)
 		return nil, nil, nil, nil, "", ""

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -209,7 +209,7 @@ func Diff(ctx *context.Context) {
 
 	ctx.Data["CommitStatus"] = models.CalcCommitStatus(statuses)
 
-	diff, err := models.GetDiffCommit(models.RepoPath(userName, repoName),
+	diff, err := models.GetDiffCommit(models.MakeRepoPath(userName, repoName),
 		commitID, setting.Git.MaxGitDiffLines,
 		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles)
 	if err != nil {
@@ -249,7 +249,7 @@ func Diff(ctx *context.Context) {
 // RawDiff dumps diff results of repository in given commit ID to io.Writer
 func RawDiff(ctx *context.Context) {
 	if err := models.GetRawDiff(
-		models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name),
+		models.MakeRepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name),
 		ctx.Params(":sha"),
 		models.RawDiffType(ctx.Params(":ext")),
 		ctx.Resp,
@@ -274,7 +274,7 @@ func CompareDiff(ctx *context.Context) {
 		return
 	}
 
-	diff, err := models.GetDiffRange(models.RepoPath(userName, repoName), beforeCommitID,
+	diff, err := models.GetDiffRange(models.MakeRepoPath(userName, repoName), beforeCommitID,
 		afterCommitID, setting.Git.MaxGitDiffLines,
 		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles)
 	if err != nil {

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -324,7 +324,7 @@ func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.PullReq
 		return nil
 	}
 
-	prInfo, err := headGitRepo.GetPullRequestInfo(models.RepoPath(repo.Owner.Name, repo.Name),
+	prInfo, err := headGitRepo.GetPullRequestInfo(models.MakeRepoPath(repo.Owner.Name, repo.Name),
 		pull.BaseBranch, pull.HeadBranch)
 	if err != nil {
 		if strings.Contains(err.Error(), "fatal: Not a valid object name") {
@@ -457,7 +457,7 @@ func ViewPullFiles(ctx *context.Context) {
 			return
 		}
 
-		headRepoPath := models.RepoPath(pull.HeadUserName, pull.HeadRepo.Name)
+		headRepoPath := models.MakeRepoPath(pull.HeadUserName, pull.HeadRepo.Name)
 
 		headGitRepo, err := git.OpenRepository(headRepoPath)
 		if err != nil {
@@ -690,7 +690,7 @@ func ParseCompareInfo(ctx *context.Context) (*models.User, *models.Repository, *
 		headGitRepo = ctx.Repo.GitRepo
 		ctx.Data["BaseName"] = headUser.Name
 	} else {
-		headGitRepo, err = git.OpenRepository(models.RepoPath(headUser.Name, headRepo.Name))
+		headGitRepo, err = git.OpenRepository(models.MakeRepoPath(headUser.Name, headRepo.Name))
 		ctx.Data["BaseName"] = baseRepo.OwnerName
 		if err != nil {
 			ctx.ServerError("OpenRepository", err)
@@ -722,7 +722,7 @@ func ParseCompareInfo(ctx *context.Context) (*models.User, *models.Repository, *
 	}
 	ctx.Data["HeadBranches"] = headBranches
 
-	prInfo, err := headGitRepo.GetPullRequestInfo(models.RepoPath(baseRepo.Owner.Name, baseRepo.Name), baseBranch, headBranch)
+	prInfo, err := headGitRepo.GetPullRequestInfo(models.MakeRepoPath(baseRepo.Owner.Name, baseRepo.Name), baseBranch, headBranch)
 	if err != nil {
 		ctx.ServerError("GetPullRequestInfo", err)
 		return nil, nil, nil, nil, "", ""
@@ -762,7 +762,7 @@ func PrepareCompareDiff(
 		return true
 	}
 
-	diff, err := models.GetDiffRange(models.RepoPath(headUser.Name, headRepo.Name),
+	diff, err := models.GetDiffRange(models.MakeRepoPath(headUser.Name, headRepo.Name),
 		prInfo.MergeBase, headCommitID, setting.Git.MaxGitDiffLines,
 		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles)
 	if err != nil {


### PR DESCRIPTION
For #6622 

The renaming part of the changeset is to make it easier to distinguish RepoPath(string,string) and (*Repository).RepoPath() when grepping as we incrementally replace them. 