### PR TITLE
[docker] Separate various /data/gitea

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN addgroup \
   echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
+ENV GITEA_CUSTOM /data/gitea
 # See docker/etc/s6/gitea/default_env file for configurable env variable
 
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,6 @@ RUN addgroup \
   echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
-#Should later be move to /data/gitea/custom
-ENV GITEA_CUSTOM /data/gitea 
-#Should later maybe be move to /data/gitea (goal use is to use the default path relative to AppWorkPath for new folder)
-ENV RUN_DIR /app/gitea
-#Should stay to /data/gitea
-ENV DATA_PATH /data/gitea
 
 VOLUME ["/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,12 @@ RUN addgroup \
   echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
-ENV GITEA_CUSTOM /data/gitea
+#Should later be move to /data/gitea/custom
+ENV GITEA_CUSTOM /data/gitea 
+#Should later maybe be move to /data/gitea (goal use is to use the default path relative to AppWorkPath for new folder)
+ENV RUN_DIR /app/gitea
+#Should stay to /data/gitea
+ENV DATA_PATH /data/gitea
 
 VOLUME ["/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN addgroup \
   echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
 
 ENV USER git
+# See docker/etc/s6/gitea/default_env file for configurable env variable
 
 VOLUME ["/data"]
 

--- a/docker/etc/profile.d/gitea.sh
+++ b/docker/etc/profile.d/gitea.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-export GITEA_CUSTOM=/data/gitea

--- a/docker/etc/s6/gitea/default_env
+++ b/docker/etc/s6/gitea/default_env
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Define the environment variables
+export DATA_PATH=${DATA_PATH:-"/data/gitea"}
+export GITEA_CUSTOM=${GITEA_CUSTOM:-"/data/gitea"}
+export RUN_DIR=${RUN_DIR:-"/app/gitea"}
+
+export APP_NAME=${APP_NAME:-"Gitea: Git with a cup of tea"}
+export RUN_MODE=${RUN_MODE:-"dev"}
+export SSH_DOMAIN=${SSH_DOMAIN:-"localhost"}
+export HTTP_PORT=${HTTP_PORT:-"3000"}
+export ROOT_URL=${ROOT_URL:-""}
+export DISABLE_SSH=${DISABLE_SSH:-"false"}
+export SSH_PORT=${SSH_PORT:-"22"}
+export DB_TYPE=${DB_TYPE:-"sqlite3"}
+export DB_HOST=${DB_HOST:-"localhost:3306"}
+export DB_NAME=${DB_NAME:-"gitea"}
+export DB_USER=${DB_USER:-"root"}
+export DB_PASSWD=${DB_PASSWD:-""}
+export INSTALL_LOCK=${INSTALL_LOCK:-"false"}
+export DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-"false"}
+export REQUIRE_SIGNIN_VIEW=${REQUIRE_SIGNIN_VIEW:-"false"}
+export SECRET_KEY=${SECRET_KEY:-""}

--- a/docker/etc/s6/gitea/default_env
+++ b/docker/etc/s6/gitea/default_env
@@ -5,6 +5,13 @@ export DATA_PATH=${DATA_PATH:-"/data/gitea"}
 export GITEA_CUSTOM=${GITEA_CUSTOM:-"/data/gitea"}
 export RUN_DIR=${RUN_DIR:-"/app/gitea"}
 
+
+# Set INSTALL_LOCK to true only if SECRET_KEY is not empty and
+# INSTALL_LOCK is empty
+if [ -n "$SECRET_KEY" ] && [ -z "$INSTALL_LOCK" ]; then
+    INSTALL_LOCK=true
+fi
+
 export APP_NAME=${APP_NAME:-"Gitea: Git with a cup of tea"}
 export RUN_MODE=${RUN_MODE:-"dev"}
 export SSH_DOMAIN=${SSH_DOMAIN:-"localhost"}

--- a/docker/etc/s6/gitea/run
+++ b/docker/etc/s6/gitea/run
@@ -1,4 +1,5 @@
 #!/bin/bash
+[[ -f ./default_env ]] && source ./default_env
 [[ -f ./setup ]] && source ./setup
 
 pushd "${RUN_DIR}" > /dev/null

--- a/docker/etc/s6/gitea/run
+++ b/docker/etc/s6/gitea/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 [[ -f ./setup ]] && source ./setup
 
-pushd /app/gitea > /dev/null
+pushd "${RUN_DIR}" > /dev/null
     exec su-exec $USER /app/gitea/gitea web
 popd

--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -20,23 +20,6 @@ if [ ! -f "${GITEA_CUSTOM}/conf/app.ini" ]; then
     fi
 
     # Substitude the environment variables in the template
-    APP_NAME=${APP_NAME:-"Gitea: Git with a cup of tea"} \
-    RUN_MODE=${RUN_MODE:-"dev"} \
-    DATA_PATH=${DATA_PATH:-"/data/gitea"} \
-    SSH_DOMAIN=${SSH_DOMAIN:-"localhost"} \
-    HTTP_PORT=${HTTP_PORT:-"3000"} \
-    ROOT_URL=${ROOT_URL:-""} \
-    DISABLE_SSH=${DISABLE_SSH:-"false"} \
-    SSH_PORT=${SSH_PORT:-"22"} \
-    DB_TYPE=${DB_TYPE:-"sqlite3"} \
-    DB_HOST=${DB_HOST:-"localhost:3306"} \
-    DB_NAME=${DB_NAME:-"gitea"} \
-    DB_USER=${DB_USER:-"root"} \
-    DB_PASSWD=${DB_PASSWD:-""} \
-    INSTALL_LOCK=${INSTALL_LOCK:-"false"} \
-    DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-"false"} \
-    REQUIRE_SIGNIN_VIEW=${REQUIRE_SIGNIN_VIEW:-"false"} \
-    SECRET_KEY=${SECRET_KEY:-""} \
     envsubst < /etc/templates/app.ini > "${GITEA_CUSTOM}/conf/app.ini"
 fi
 

--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -13,12 +13,6 @@ fi
 if [ ! -f "${GITEA_CUSTOM}/conf/app.ini" ]; then
     mkdir -p "${GITEA_CUSTOM}/conf"
 
-    # Set INSTALL_LOCK to true only if SECRET_KEY is not empty and
-    # INSTALL_LOCK is empty
-    if [ -n "$SECRET_KEY" ] && [ -z "$INSTALL_LOCK" ]; then
-        INSTALL_LOCK=true
-    fi
-
     # Substitude the environment variables in the template
     envsubst < /etc/templates/app.ini > "${GITEA_CUSTOM}/conf/app.ini"
 fi

--- a/docker/etc/s6/gitea/setup
+++ b/docker/etc/s6/gitea/setup
@@ -6,12 +6,12 @@ if [ ! -d /data/git/.ssh ]; then
 fi
 
 if [ ! -f /data/git/.ssh/environment ]; then
-    echo "GITEA_CUSTOM=/data/gitea" >| /data/git/.ssh/environment
+    echo "GITEA_CUSTOM=${GITEA_CUSTOM}" >| /data/git/.ssh/environment
     chmod 600 /data/git/.ssh/environment
 fi
 
-if [ ! -f /data/gitea/conf/app.ini ]; then
-    mkdir -p /data/gitea/conf
+if [ ! -f "${GITEA_CUSTOM}/conf/app.ini" ]; then
+    mkdir -p "${GITEA_CUSTOM}/conf"
 
     # Set INSTALL_LOCK to true only if SECRET_KEY is not empty and
     # INSTALL_LOCK is empty
@@ -22,6 +22,7 @@ if [ ! -f /data/gitea/conf/app.ini ]; then
     # Substitude the environment variables in the template
     APP_NAME=${APP_NAME:-"Gitea: Git with a cup of tea"} \
     RUN_MODE=${RUN_MODE:-"dev"} \
+    DATA_PATH=${DATA_PATH:-"/data/gitea"} \
     SSH_DOMAIN=${SSH_DOMAIN:-"localhost"} \
     HTTP_PORT=${HTTP_PORT:-"3000"} \
     ROOT_URL=${ROOT_URL:-""} \
@@ -36,11 +37,12 @@ if [ ! -f /data/gitea/conf/app.ini ]; then
     DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-"false"} \
     REQUIRE_SIGNIN_VIEW=${REQUIRE_SIGNIN_VIEW:-"false"} \
     SECRET_KEY=${SECRET_KEY:-""} \
-    envsubst < /etc/templates/app.ini > /data/gitea/conf/app.ini
+    envsubst < /etc/templates/app.ini > "${GITEA_CUSTOM}/conf/app.ini"
 fi
 
 # only chown if current owner is not already the gitea ${USER}. No recursive check to save time
-if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/gitea; fi
-if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi
+if ! [[ $(ls -ld "${GITEA_CUSTOM}" | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git "${GITEA_CUSTOM}"; fi
+if ! [[ $(ls -ld "${DATA_PATH}" | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git "${DATA_PATH}"; fi
+if ! [[ $(ls -ld "${RUN_DIR}"  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git "${RUN_DIR}";  fi
 if ! [[ $(ls -ld /data/git   | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/git;   fi
-chmod 0755 /data/gitea /app/gitea /data/git
+chmod 0755 "${GITEA_CUSTOM}" "${DATA_PATH}" "${RUN_DIR}" /data/git

--- a/docker/etc/templates/app.ini
+++ b/docker/etc/templates/app.ini
@@ -5,13 +5,13 @@ RUN_MODE = $RUN_MODE
 ROOT = /data/git/repositories
 
 [repository.local]
-LOCAL_COPY_PATH = /data/gitea/tmp/local-repo
+LOCAL_COPY_PATH = $DATA_PATH/tmp/local-repo
 
 [repository.upload]
-TEMP_PATH = /data/gitea/uploads
+TEMP_PATH = $DATA_PATH/uploads
 
 [server]
-APP_DATA_PATH = /data/gitea
+APP_DATA_PATH = $DATA_PATH
 SSH_DOMAIN       = $SSH_DOMAIN
 HTTP_PORT        = $HTTP_PORT
 ROOT_URL         = $ROOT_URL
@@ -20,7 +20,7 @@ SSH_PORT         = $SSH_PORT
 LFS_CONTENT_PATH = /data/git/lfs
 
 [database]
-PATH = /data/gitea/gitea.db
+PATH = $DATA_PATH/gitea.db
 DB_TYPE = $DB_TYPE
 HOST    = $DB_HOST
 NAME    = $DB_NAME
@@ -28,19 +28,19 @@ USER    = $DB_USER
 PASSWD  = $DB_PASSWD
 
 [indexer]
-ISSUE_INDEXER_PATH = /data/gitea/indexers/issues.bleve
+ISSUE_INDEXER_PATH = $DATA_PATH/indexers/issues.bleve
 
 [session]
-PROVIDER_CONFIG = /data/gitea/sessions
+PROVIDER_CONFIG = $DATA_PATH/sessions
 
 [picture]
-AVATAR_UPLOAD_PATH = /data/gitea/avatars
+AVATAR_UPLOAD_PATH = $DATA_PATH/avatars
 
 [attachment]
-PATH = /data/gitea/attachments
+PATH = $DATA_PATH/attachments
 
 [log]
-ROOT_PATH = /data/gitea/log
+ROOT_PATH = $DATA_PATH/log
 
 [security]
 INSTALL_LOCK = $INSTALL_LOCK

--- a/docker/usr/bin/entrypoint
+++ b/docker/usr/bin/entrypoint
@@ -26,7 +26,7 @@ if [ -n "${USER_UID}" ] && [ "${USER_UID}" != "`id -u ${USER}`" ]; then
     sed -i -e "s/^${USER}:\([^:]*\):[0-9]*:\([0-9]*\)/${USER}:\1:${USER_UID}:\2/" /etc/passwd
 fi
 
-for FOLDER in /data/gitea/conf /data/gitea/log /data/git /data/ssh; do
+for FOLDER in "${GITEA_CUSTOM}/conf" "${DATA_PATH}/log" /data/git /data/ssh; do
     mkdir -p ${FOLDER}
 done
 


### PR DESCRIPTION
This PR change nothing to the current used docker paths.
The goal is to distinguish paths (AppWorkPath, AppDataPath, CustomPath) that could be confusing based on default path of gitea. 
It permit to detail what `/data/gitea` path we are using at each use.

Later we could revert to a more default path based on gitea.
Ex: GITEA_CUSTOM = WorkDir + "/custom"
But permitting to continue to use old paths by simply overriding the env variable.

And move the config of env variable in a dedicate file.