### PR TITLE
Fix #6655 - Don't EscapePound .Link as it is already escaped

### DIFF
--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -1,4 +1,4 @@
-<form class="ui comment form stackable grid" action="{{EscapePound .Link}}" method="post">
+<form class="ui comment form stackable grid" action="{{.Link}}" method="post">
 	{{.CsrfTokenHtml}}
 	{{if .Flash}}
 		<div class="sixteen wide column">


### PR DESCRIPTION
Fixes #6655 

Signed-off-by: Andrew Thornton <art27@cantab.net>
