### PR TITLE
Fixes #6659 - Swagger schemes selection default to page's protocol

### DIFF
--- a/templates/swagger/ui.tmpl
+++ b/templates/swagger/ui.tmpl
@@ -71,22 +71,33 @@
 <script>
 
 window.onload = function() {
-  // Build a system
-  const ui = SwaggerUIBundle({
-    url: "{{AppUrl}}swagger.{{.APIJSONVersion}}.json",
-    dom_id: '#swagger-ui',
-    deepLinking: true,
-    presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
-    ],
-    plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
-    ],
-    layout: "StandaloneLayout"
-  })
+  // Fetch the Swagger JSON specs
+  var url = "{{AppUrl}}swagger.{{.APIJSONVersion}}.json"
+  fetch(url)
+  .then(function(response) {
+    response.json()
+    .then(function(spec) {
+      // Make the page's protocol be at the top of the schemes list
+      var protocol = window.location.protocol.slice(0, -1)
+      spec.schemes.sort(function(x,y){ return x == protocol ? -1 : y == protocol ? 1 : 0 })
+      // Build the Swagger UI
+      const ui = SwaggerUIBundle({
+        spec: spec,
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
 
-  window.ui = ui
+      window.ui = ui
+    })
+  })
 }
 </script>
 </body>


### PR DESCRIPTION
Fixes #6659 

Makes it so the Schemes selection on the swagger page (e.g. http://localhost:3000/api/swagger) doesn't have to be set if the website uses https. Before would always just default to HTTP since it was the first item in the v1_json.tmpl file. Uses pure javascript to move the protocol of the page's url to the top of the list by getting the swagger json file first, manimpultes json.schemes, and then calls SwaggerUIBundle() with that JSON object rather than a URL.

Fix taken and modified from: https://gist.github.com/miguelmota/289643541cf55825f14d2ea66598bf64

Can see it work with https at https://bg.door43.org/api/swagger