### PR TITLE
Handle redirects for git clone commands

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -223,6 +223,9 @@ func RedirectToRepo(ctx *Context, redirectRepoID int64) {
 		fmt.Sprintf("%s/%s", repo.MustOwnerName(), repo.Name),
 		1,
 	)
+	if ctx.Req.URL.RawQuery != "" {
+		redirectPath += "?" + ctx.Req.URL.RawQuery
+	}
 	ctx.Redirect(redirectPath)
 }
 


### PR DESCRIPTION
Handle redirects in git clone commands

Add support for repo_redirect objects in the git smart http handler so that when a user clones a repo that has been moved or renamed, they are redirected to the new location.

This requires that the query string be included in the redirect as well, so that is added.
