### PR TITLE
Reorder file actions

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -18,6 +18,7 @@
 				{{if not .ReadmeInList}}
 					<div class="ui right file-actions">
 						<div class="ui buttons">
+							<a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
 							{{if not .IsViewCommit}}
 								<a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
 							{{end}}
@@ -25,7 +26,6 @@
 								<a class="ui button" href="{{.RepoLink}}/blame/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.blame"}}</a>
 							{{end}}
 							<a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
-							<a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
 						</div>
 						{{if .Repository.CanEnableEditor}}
 							{{if .CanEditFile}}


### PR DESCRIPTION
Currently the ordering of the file actions in Gitea is different from the ordering of the same actions in GitHub.

To improve the usability, since they are the same actions, I am sending this PR to leave equal in the two tools, Gitea and GiHub.

Follow the images for comparison:

GitHub:
![github](https://user-images.githubusercontent.com/1946348/56506349-8e143e80-64f4-11e9-9e47-ffeb34b1a9b2.png)

Actual Gitea:
![gitea](https://user-images.githubusercontent.com/1946348/56506374-a1270e80-64f4-11e9-8ead-e64f017012e9.png)

New Gitea:
![giteaAfterPR](https://user-images.githubusercontent.com/1946348/56506383-aab07680-64f4-11e9-9150-ccd94070021e.png)
