### PR TITLE
[API] Load issue attributes when editing an issue

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -294,6 +294,7 @@ func EditIssue(ctx *context.APIContext, form api.EditIssueOption) {
 	err = issue.LoadAttributes()
 	if err != nil {
 		ctx.Error(500, "LoadAttributes", err)
+		return
 	}
 
 	if !issue.IsPoster(ctx.User.ID) && !ctx.Repo.CanWrite(models.UnitTypeIssues) {

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -291,6 +291,11 @@ func EditIssue(ctx *context.APIContext, form api.EditIssueOption) {
 	}
 	issue.Repo = ctx.Repo.Repository
 
+	err = issue.LoadAttributes()
+	if err != nil {
+		ctx.Error(500, "LoadAttributes", err)
+	}
+
 	if !issue.IsPoster(ctx.User.ID) && !ctx.Repo.CanWrite(models.UnitTypeIssues) {
 		ctx.Status(403)
 		return


### PR DESCRIPTION
Fixes #6721

Previously assignees on the issue were nil since they weren't loaded, which messed up any ranging that happened when comparing.