### PR TITLE
WiP/Proposal - Login: Try to work around the compatibility with AD's UPN

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -407,6 +407,14 @@ func LoginViaLDAP(user *User, login, password string, source *LoginSource, autoR
 	if len(sr.Username) == 0 {
 		sr.Username = login
 	}
+
+	// Active Directory also accepts authentication with userPrincipalName (UPN).
+	// UPNs end by @yourdomain.tld, thus similar to mail. However using it directly
+	// may break different things such as repository URLs, hence we rewrite it.
+	if binding.EmailPattern.MatchString(sr.Username) {
+		sr.Username = strings.Replace(sr.Username, "@", "_at_", -1)
+	}
+
 	// Validate username make sure it satisfies requirement.
 	if binding.AlphaDashDotPattern.MatchString(sr.Username) {
 		return nil, fmt.Errorf("Invalid pattern for attribute 'username' [%s]: must be valid alpha or numeric or dash(-_) or dot characters", sr.Username)


### PR DESCRIPTION
The user name becomes part of the repository path and does break the clone URLs for HTTP but if we rewrite the user name before that we might find a workaround that allows not breaking gitea and make the use of the UPN acceptable with gitea.