### PR TITLE
Support git.PATH entry in app.ini

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -668,6 +668,8 @@ SCHEDULE = @every 24h
 UPDATE_EXISTING = true
 
 [git]
+; The path of git executable. If empty, Gitea searches through the PATH environment.
+PATH =
 ; Disables highlight of added and removed changes
 DISABLE_DIFF_HIGHLIGHT = false
 ; Max number of lines allowed in a single file in diff view

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -408,7 +408,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 
 ## Git (`git`)
 
-- `PATH`: "": The path of git executable. If empty, Gitea searches through the PATH environment.
+- `PATH`: **""**: The path of git executable. If empty, Gitea searches through the PATH environment.
 - `MAX_GIT_DIFF_LINES`: **100**: Max number of lines allowed of a single file in diff view.
 - `MAX_GIT_DIFF_LINE_CHARACTERS`: **5000**: Max character count per line highlighted in diff view.
 - `MAX_GIT_DIFF_FILES`: **100**: Max number of files shown in diff view.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -408,6 +408,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 
 ## Git (`git`)
 
+- `PATH`: "": The path of git executable. If empty, Gitea searches through the PATH environment.
 - `MAX_GIT_DIFF_LINES`: **100**: Max number of lines allowed of a single file in diff view.
 - `MAX_GIT_DIFF_LINE_CHARACTERS`: **5000**: Max character count per line highlighted in diff view.
 - `MAX_GIT_DIFF_FILES`: **100**: Max number of files shown in diff view.

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -77,20 +77,27 @@ func BinVersion() (string, error) {
 	return gitVersion, nil
 }
 
-func init() {
+// SetExeutablecPath changes the path of git executable and checks the file permission and version.
+func SetExecutablePath(path string) error {
+	// If path is empty, we use the default value of GitExecutable "git" to search for the location of git.
+	if path != "" {
+		GitExecutable = path
+	}
 	absPath, err := exec.LookPath(GitExecutable)
 	if err != nil {
-		panic(fmt.Sprintf("Git not found: %v", err))
+		return fmt.Errorf("Git not found: %v", err)
 	}
 	GitExecutable = absPath
 
 	gitVersion, err := BinVersion()
 	if err != nil {
-		panic(fmt.Sprintf("Git version missing: %v", err))
+		return fmt.Errorf("Git version missing: %v", err)
 	}
 	if version.Compare(gitVersion, GitVersionRequired, "<") {
-		panic(fmt.Sprintf("Git version not supported. Requires version > %v", GitVersionRequired))
+		return fmt.Errorf("Git version not supported. Requires version > %v", GitVersionRequired)
 	}
+
+	return nil
 }
 
 // Init initializes git module

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -77,7 +77,7 @@ func BinVersion() (string, error) {
 	return gitVersion, nil
 }
 
-// SetExeutablecPath changes the path of git executable and checks the file permission and version.
+// SetExecutablePath changes the path of git executable and checks the file permission and version.
 func SetExecutablePath(path string) error {
 	// If path is empty, we use the default value of GitExecutable "git" to search for the location of git.
 	if path != "" {

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -16,6 +16,7 @@ import (
 var (
 	// Git settings
 	Git = struct {
+		Path                      string
 		DisableDiffHighlight      bool
 		MaxGitDiffLines           int
 		MaxGitDiffLineCharacters  int
@@ -58,6 +59,9 @@ var (
 func newGit() {
 	if err := Cfg.Section("git").MapTo(&Git); err != nil {
 		log.Fatal("Failed to map Git settings: %v", err)
+	}
+	if err := git.SetExecutablePath(Git.Path); err != nil {
+		log.Fatal("Failed to initialize Git settings", err)
 	}
 	git.DefaultCommandExecutionTimeout = time.Duration(Git.Timeout.Default) * time.Second
 


### PR DESCRIPTION
A user can specify the location of the git executable rather than relying on the PATH environment.