### PR TITLE
Fix #6813: Allow git.GetTree to take both commit and tree names

### DIFF
--- a/modules/git/repo_tree.go
+++ b/modules/git/repo_tree.go
@@ -36,10 +36,10 @@ func (repo *Repository) GetTree(idStr string) (*Tree, error) {
 		return nil, err
 	}
 	commitObject, err := repo.gogitRepo.CommitObject(plumbing.Hash(id))
-	if err != nil {
-		return nil, err
+	if err == nil {
+		id = SHA1(commitObject.TreeHash)
 	}
-	treeObject, err := repo.getTree(SHA1(commitObject.TreeHash))
+	treeObject, err := repo.getTree(id)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/repo_tree.go
+++ b/modules/git/repo_tree.go
@@ -35,6 +35,7 @@ func (repo *Repository) GetTree(idStr string) (*Tree, error) {
 	if err != nil {
 		return nil, err
 	}
+	resolvedID := id
 	commitObject, err := repo.gogitRepo.CommitObject(plumbing.Hash(id))
 	if err == nil {
 		id = SHA1(commitObject.TreeHash)
@@ -43,6 +44,6 @@ func (repo *Repository) GetTree(idStr string) (*Tree, error) {
 	if err != nil {
 		return nil, err
 	}
-	treeObject.CommitID = id
+	treeObject.ResolvedID = resolvedID
 	return treeObject, nil
 }

--- a/modules/git/tree.go
+++ b/modules/git/tree.go
@@ -15,9 +15,9 @@ import (
 
 // Tree represents a flat directory listing.
 type Tree struct {
-	ID       SHA1
-	CommitID SHA1
-	repo     *Repository
+	ID         SHA1
+	ResolvedID SHA1
+	repo       *Repository
 
 	gogitTree *object.Tree
 

--- a/modules/git/tree.go
+++ b/modules/git/tree.go
@@ -106,7 +106,7 @@ func (t *Tree) ListEntriesRecursive() (Entries, error) {
 	seen := map[plumbing.Hash]bool{}
 	walker := object.NewTreeWalker(t.gogitTree, true, seen)
 	for {
-		_, entry, err := walker.Next()
+		fullName, entry, err := walker.Next()
 		if err == io.EOF {
 			break
 		}
@@ -121,6 +121,7 @@ func (t *Tree) ListEntriesRecursive() (Entries, error) {
 			ID:             entry.Hash,
 			gogitTreeEntry: &entry,
 			ptree:          t,
+			fullName:       fullName,
 		}
 		entries = append(entries, convertedEntry)
 	}

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -40,12 +40,16 @@ type TreeEntry struct {
 	gogitTreeEntry *object.TreeEntry
 	ptree          *Tree
 
-	size  int64
-	sized bool
+	size     int64
+	sized    bool
+	fullName string
 }
 
 // Name returns the name of the entry
 func (te *TreeEntry) Name() string {
+	if te.fullName != "" {
+		return te.fullName
+	}
 	return te.gogitTreeEntry.Name
 }
 

--- a/modules/repofiles/tree.go
+++ b/modules/repofiles/tree.go
@@ -23,7 +23,7 @@ func GetTreeBySHA(repo *models.Repository, sha string, page, perPage int, recurs
 		}
 	}
 	tree := new(api.GitTreeResponse)
-	tree.SHA = gitTree.CommitID.String()
+	tree.SHA = gitTree.ResolvedID.String()
 	tree.URL = repo.APIURL() + "/git/trees/" + tree.SHA
 	var entries git.Entries
 	if recursive {


### PR DESCRIPTION
Fixes two separate bugs reported in #6813:
- Allow git.GetTree to take both commit and tree names; this matches GitHub behavior on the Trees API
- Return full paths on entries listed through Tree.ListEntriesRecursive. Technically this is abuse of the API but I am just doing a hot-fix here. A proper fix would be to move the recursive enumeration to different layer and add unit tests for it.
