### PR TITLE
When mirroring we should set the remote to mirror

### DIFF
--- a/models/repo_mirror.go
+++ b/models/repo_mirror.go
@@ -128,7 +128,7 @@ func (m *Mirror) SaveAddress(addr string) error {
 		return err
 	}
 
-	_, err = git.NewCommand("remote", "add", "origin", addr).RunInDir(repoPath)
+	_, err = git.NewCommand("remote", "add", "origin", "--mirror=fetch", addr).RunInDir(repoPath)
 	return err
 }
 


### PR DESCRIPTION
My fix in #6593 didn't set the mirrors to be mirrors for fetching, which appears to have broken mirroring.

When adding the remote we should --mirror=fetch to set the refs correctly.

Fix #6783 