### PR TITLE
Fix double-generation of scratch token (#6832)

### DIFF
--- a/models/twofactor.go
+++ b/models/twofactor.go
@@ -129,11 +129,7 @@ func aesDecrypt(key, text []byte) ([]byte, error) {
 
 // NewTwoFactor creates a new two-factor authentication token.
 func NewTwoFactor(t *TwoFactor) error {
-	_, err := t.GenerateScratchToken()
-	if err != nil {
-		return err
-	}
-	_, err = x.Insert(t)
+	_, err := x.Insert(t)
 	return err
 }
 


### PR DESCRIPTION
Removed scratch token regeneration in NewTwoFactor, as it's generated anyway before calling this function.

This fixes bug (#6832) when scratch token was generated twice during 2FA setup and first-generated scratch token was not working (due to instantly being overwritten).