### PR TITLE
skip application/octet-stream in gzip module

### DIFF
--- a/modules/gzip/gzip.go
+++ b/modules/gzip/gzip.go
@@ -114,7 +114,6 @@ func Middleware(options ...Options) macaron.Handler {
 
 		// If the client is asking for a specific range of bytes - don't compress
 		if rangeHdr := ctx.Req.Header.Get(rangeHeader); rangeHdr != "" {
-
 			match := regex.FindStringSubmatch(rangeHdr)
 			if match != nil && len(match) > 1 {
 				return
@@ -320,6 +319,9 @@ func compressedContentType(contentType string) bool {
 	case "application/x-gzip":
 		return true
 	case "application/gzip":
+		return true
+	// assume all octet-stream data is already compressed to avoid double compression from LFS
+	case "application/octet-stream":
 		return true
 	default:
 		return false

--- a/modules/gzip/gzip_test.go
+++ b/modules/gzip/gzip_test.go
@@ -80,7 +80,7 @@ func TestMiddlewareSmall(t *testing.T) {
 func TestMiddlewareLarge(t *testing.T) {
 	b := make([]byte, MinSize+1)
 	for i := range b {
-		b[i] = letters[i % len(letters)]
+		b[i] = letters[i%len(letters)]
 	}
 	m, sampleResponse := setup(b)
 
@@ -93,7 +93,7 @@ func TestMiddlewareLarge(t *testing.T) {
 func TestMiddlewareGzip(t *testing.T) {
 	b := make([]byte, MinSize*10)
 	for i := range b {
-		b[i] = letters[i % len(letters)]
+		b[i] = letters[i%len(letters)]
 	}
 	outputBuffer := bytes.NewBuffer([]byte{})
 	gzippWriter := gzipp.NewWriter(outputBuffer)
@@ -113,7 +113,7 @@ func TestMiddlewareGzip(t *testing.T) {
 func TestMiddlewareZip(t *testing.T) {
 	b := make([]byte, MinSize*10)
 	for i := range b {
-		b[i] = letters[i % len(letters)]
+		b[i] = letters[i%len(letters)]
 	}
 	outputBuffer := bytes.NewBuffer([]byte{})
 	zipWriter := zip.NewWriter(outputBuffer)

--- a/modules/gzip/gzip_test.go
+++ b/modules/gzip/gzip_test.go
@@ -17,6 +17,8 @@ import (
 	macaron "gopkg.in/macaron.v1"
 )
 
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 func setup(sampleResponse []byte) (*macaron.Macaron, *[]byte) {
 	m := macaron.New()
 	m.Use(Middleware())
@@ -78,7 +80,7 @@ func TestMiddlewareSmall(t *testing.T) {
 func TestMiddlewareLarge(t *testing.T) {
 	b := make([]byte, MinSize+1)
 	for i := range b {
-		b[i] = byte(i % 256)
+		b[i] = letters[i % len(letters)]
 	}
 	m, sampleResponse := setup(b)
 
@@ -91,7 +93,7 @@ func TestMiddlewareLarge(t *testing.T) {
 func TestMiddlewareGzip(t *testing.T) {
 	b := make([]byte, MinSize*10)
 	for i := range b {
-		b[i] = byte(i % 256)
+		b[i] = letters[i % len(letters)]
 	}
 	outputBuffer := bytes.NewBuffer([]byte{})
 	gzippWriter := gzipp.NewWriter(outputBuffer)
@@ -111,7 +113,7 @@ func TestMiddlewareGzip(t *testing.T) {
 func TestMiddlewareZip(t *testing.T) {
 	b := make([]byte, MinSize*10)
 	for i := range b {
-		b[i] = byte(i % 256)
+		b[i] = letters[i % len(letters)]
 	}
 	outputBuffer := bytes.NewBuffer([]byte{})
 	zipWriter := zip.NewWriter(outputBuffer)


### PR DESCRIPTION
We want to skip application/octet-stream in the gzip module due to the
possiblity of having already compressed data in a repository or LFS
object store. This avoids problems with double compression and
decompression issues from tar.gz files stored in git-lfs.