### PR TITLE
Fixes #6881 - API users search fix

### DIFF
--- a/integrations/api_admin_test.go
+++ b/integrations/api_admin_test.go
@@ -129,3 +129,18 @@ func TestAPIListUsers(t *testing.T) {
 	numberOfUsers := models.GetCount(t, &models.User{}, "type = 0")
 	assert.Equal(t, numberOfUsers, len(users))
 }
+
+func TestAPIListUsersNotLoggedIn(t *testing.T) {
+	prepareTestEnv(t)
+	req := NewRequest(t, "GET", "/api/v1/admin/users")
+	MakeRequest(t, req, http.StatusUnauthorized)
+}
+
+func TestAPIListUsersNonAdmin(t *testing.T) {
+	prepareTestEnv(t)
+	nonAdminUsername := "user2"
+	session := loginUser(t, nonAdminUsername)
+	token := getTokenForLoggedInUser(t, session)
+	req := NewRequestf(t, "GET", "/api/v1/admin/users?token=%s", token)
+	session.MakeRequest(t, req, http.StatusForbidden)
+}

--- a/integrations/api_user_search_test.go
+++ b/integrations/api_user_search_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.package models
+
+package integrations
+
+import (
+	"net/http"
+	"testing"
+
+	api "code.gitea.io/sdk/gitea"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SearchResults struct {
+	OK   bool        `json:"ok"`
+	Data []*api.User `json:"data"`
+}
+
+func TestAPIUserSearchLoggedIn(t *testing.T) {
+	prepareTestEnv(t)
+	adminUsername := "user1"
+	session := loginUser(t, adminUsername)
+	token := getTokenForLoggedInUser(t, session)
+	query := "user2"
+	req := NewRequestf(t, "GET", "/api/v1/users/search?token=%s&q=%s", token, query)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+
+	var results SearchResults
+	DecodeJSON(t, resp, &results)
+	assert.NotEmpty(t, results.Data)
+	for _, user := range results.Data {
+		assert.Contains(t, user.UserName, query)
+		assert.NotEmpty(t, user.Email)
+	}
+}
+
+func TestAPIUserSearchNotLoggedIn(t *testing.T) {
+	prepareTestEnv(t)
+	query := "user2"
+	req := NewRequestf(t, "GET", "/api/v1/users/search?q=%s", query)
+	resp := MakeRequest(t, req, http.StatusOK)
+
+	var results SearchResults
+	DecodeJSON(t, resp, &results)
+	assert.NotEmpty(t, results.Data)
+	for _, user := range results.Data {
+		assert.Contains(t, user.UserName, query)
+		assert.Empty(t, user.Email)
+	}
+}

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -326,7 +326,7 @@ func GetAllUsers(ctx *context.APIContext) {
 
 	results := make([]*api.User, len(users))
 	for i := range users {
-		results[i] = convert.ToUser(users[i], ctx.IsSigned, ctx.User.IsAdmin)
+		results[i] = convert.ToUser(users[i], ctx.IsSigned, ctx.User != nil && ctx.User.IsAdmin)
 	}
 
 	ctx.JSON(200, &results)

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -67,7 +67,7 @@ func Search(ctx *context.APIContext) {
 
 	results := make([]*api.User, len(users))
 	for i := range users {
-		results[i] = convert.ToUser(users[i], ctx.IsSigned, ctx.User.IsAdmin)
+		results[i] = convert.ToUser(users[i], ctx.IsSigned, ctx.User != nil && ctx.User.IsAdmin)
 	}
 
 	ctx.JSON(200, map[string]interface{}{


### PR DESCRIPTION
Fixes #6881 

Fixes the user search if not using auth. No login/user should be needed for user search. Adds integration tests to make sure logged in, logged in as admin, and not logged in all work, where the former shows emails unless queried user has made their email private, the 2nd shows all emails, latter shows no emails.

Also set in admin API.

Test using the swagger page.