### PR TITLE
Escape the commit message on issues update and title in telegram hook

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -8,6 +8,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"path"
 	"regexp"
 	"strconv"
@@ -580,7 +581,7 @@ func UpdateIssuesCommit(doer *User, repo *Repository, commits []*PushCommit, bra
 			}
 			refMarked[issue.ID] = true
 
-			message := fmt.Sprintf(`<a href="%s/commit/%s">%s</a>`, repo.Link(), c.Sha1, c.Message)
+			message := fmt.Sprintf(`<a href="%s/commit/%s">%s</a>`, repo.Link(), c.Sha1, html.EscapeString(c.Message))
 			if err = CreateRefComment(doer, refRepo, issue, message, c.Sha1); err != nil {
 				return err
 			}

--- a/models/webhook_telegram.go
+++ b/models/webhook_telegram.go
@@ -7,6 +7,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"strings"
 
 	"code.gitea.io/gitea/modules/git"
@@ -169,7 +170,7 @@ func getTelegramIssuesPayload(p *api.IssuePayload) (*TelegramPayload, error) {
 
 func getTelegramIssueCommentPayload(p *api.IssueCommentPayload) (*TelegramPayload, error) {
 	url := fmt.Sprintf("%s/issues/%d#%s", p.Repository.HTMLURL, p.Issue.Index, CommentHashTag(p.Comment.ID))
-	title := fmt.Sprintf(`<a href="%s">#%d %s</a>`, url, p.Issue.Index, p.Issue.Title)
+	title := fmt.Sprintf(`<a href="%s">#%d %s</a>`, url, p.Issue.Index, html.EscapeString(p.Issue.Title))
 	var text string
 	switch p.Action {
 	case api.HookIssueCommentCreated:


### PR DESCRIPTION
The commit message was not properly being escaped when being referenced in an issue, neither was the issue title escaped in the telegram webhook.

Fortunately the commit message was passed through a sanitiser but it is still possible to corrupt the  page structure. 