### PR TITLE
cmd/serv: initalize session settings properly

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -67,6 +67,7 @@ func checkLFSVersion() {
 func setup(logPath string) {
 	log.DelLogger("console")
 	setting.NewContext()
+	setting.NewServices() // cannot access session settings otherwise
 	checkLFSVersion()
 	log.NewGitLogger(filepath.Join(setting.LogRootPath, logPath))
 }


### PR DESCRIPTION
This should fix #5478 and with REQUIRE_SIGNIN_VIEW=true lfs auth errors

Without this, `ssh git@<domain> git-lfs-authenticate <repo> download` will not return user claim and will cause an authentication error. cmd/dump also uses this same pattern.

https://github.com/go-gitea/gitea/blob/e1fcd6b7427d1e7c43ac9dcb32462a8e6d77c905/cmd/dump.go#L62-L63

I'm not sure, but it also looks like it needs to be done here?
https://github.com/go-gitea/gitea/blob/e1fcd6b7427d1e7c43ac9dcb32462a8e6d77c905/cmd/cmd.go#L39-L48

