### PR TITLE
Use single line per selector & don't strip license comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,8 +388,8 @@ generate-stylesheets:
 		exit 1; \
 	fi;
 	$(eval BROWSERS := "> 1%, last 2 firefox versions, last 2 safari versions, ie 11")
-	npx lessc --clean-css public/less/index.less public/css/index.css
-	$(foreach file, $(filter-out public/less/themes/_base.less, $(wildcard public/less/themes/*)),npx lessc --clean-css public/less/themes/$(notdir $(file)) > public/css/theme-$(notdir $(call strip-suffix,$(file))).css;)
+	npx lessc --clean-css="--s0 -b" public/less/index.less public/css/index.css
+	$(foreach file, $(filter-out public/less/themes/_base.less, $(wildcard public/less/themes/*)),npx lessc --clean-css="--s0 -b" public/less/themes/$(notdir $(file)) > public/css/theme-$(notdir $(call strip-suffix,$(file))).css;)
 	$(foreach file, $(wildcard public/css/*),npx postcss --use autoprefixer --autoprefixer.browsers $(BROWSERS) -o $(file) $(file);)
 
 .PHONY: swagger-ui

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1,1 +1,978 @@
-.tribute-container{box-shadow:0 1px 3px 1px #c7c7c7}.tribute-container ul{background:#fff}.tribute-container li{padding:8px 12px;border-bottom:1px solid #dcdcdc}.tribute-container li img{display:inline-block;vertical-align:middle;width:28px;height:28px;margin-right:5px}.tribute-container li span.fullname{font-weight:400;font-size:.8rem;margin-left:3px}.tribute-container li.highlight,.tribute-container li:hover{background:#2185D0;color:#fff}.emoji{width:1.5em;height:1.5em;display:inline-block;background-size:contain}.ui.label .emoji{height:1.2em!important}@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-regular.eot);src:url(../vendor/assets/lato-fonts/lato-regular.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-regular.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-regular.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-regular.ttf) format('truetype');font-weight:400;font-style:normal}@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-italic.eot);src:url(../vendor/assets/lato-fonts/lato-italic.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-italic.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-italic.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-italic.ttf) format('truetype');font-weight:400;font-style:italic}@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-bold.eot);src:url(../vendor/assets/lato-fonts/lato-bold.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-bold.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-bold.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-bold.ttf) format('truetype');font-weight:700;font-style:normal}@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-bolditalic.eot);src:url(../vendor/assets/lato-fonts/lato-bolditalic.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-bolditalic.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-bolditalic.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-bolditalic.ttf) format('truetype');font-weight:700;font-style:italic}@font-face{font-family:'Yu Gothic';src:local('Yu Gothic Medium');font-weight:400}@font-face{font-family:'Yu Gothic';src:local('Yu Gothic Bold');font-weight:700}textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}.markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}h1,h2,h3,h4,h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}.home .hero h1,.home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}.ui.accordion .title:not(.ui),.ui.button,.ui.card>.content>.header.ui.card>.content>.header,.ui.category.search>.results .category>.name,.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=file],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url],.ui.header,.ui.input input,.ui.input>input,.ui.items>.item>.content>.header,.ui.language>.menu>.item,.ui.list .list>.item .header,.ui.list>.item .header,.ui.menu,.ui.message .header,.ui.modal>.header,.ui.popup>.header,.ui.search>.results .result .title,.ui.search>.results>.message .header,.ui.statistic>.label,.ui.statistic>.value,.ui.statistics .statistic>.label,.ui.statistics .statistic>.value,.ui.steps .step .title,.ui.text.container,body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}body{background-color:#fff;overflow-y:auto;-webkit-font-smoothing:antialiased;display:flex;flex-direction:column}:lang(ja) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}:lang(ja) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}:lang(ja) h1,:lang(ja) h2,:lang(ja) h3,:lang(ja) h4,:lang(ja) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}:lang(ja) .home .hero h1,:lang(ja) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}.ui.language>.menu>.item:lang(ja),:lang(ja) .ui.accordion .title:not(.ui),:lang(ja) .ui.button,:lang(ja) .ui.card>.content>.header.ui.card>.content>.header,:lang(ja) .ui.category.search>.results .category>.name,:lang(ja) .ui.form input:not([type]),:lang(ja) .ui.form input[type=date],:lang(ja) .ui.form input[type=datetime-local],:lang(ja) .ui.form input[type=email],:lang(ja) .ui.form input[type=file],:lang(ja) .ui.form input[type=number],:lang(ja) .ui.form input[type=password],:lang(ja) .ui.form input[type=search],:lang(ja) .ui.form input[type=tel],:lang(ja) .ui.form input[type=text],:lang(ja) .ui.form input[type=time],:lang(ja) .ui.form input[type=url],:lang(ja) .ui.header,:lang(ja) .ui.input input,:lang(ja) .ui.input>input,:lang(ja) .ui.items>.item>.content>.header,:lang(ja) .ui.list .list>.item .header,:lang(ja) .ui.list>.item .header,:lang(ja) .ui.menu,:lang(ja) .ui.message .header,:lang(ja) .ui.modal>.header,:lang(ja) .ui.popup>.header,:lang(ja) .ui.search>.results .result .title,:lang(ja) .ui.search>.results>.message .header,:lang(ja) .ui.statistic>.label,:lang(ja) .ui.statistic>.value,:lang(ja) .ui.statistics .statistic>.label,:lang(ja) .ui.statistics .statistic>.value,:lang(ja) .ui.steps .step .title,:lang(ja) .ui.text.container,:lang(ja) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}:lang(zh-CN) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}:lang(zh-CN) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}:lang(zh-CN) h1,:lang(zh-CN) h2,:lang(zh-CN) h3,:lang(zh-CN) h4,:lang(zh-CN) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}:lang(zh-CN) .home .hero h1,:lang(zh-CN) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}.ui.language>.menu>.item:lang(zh-CN),:lang(zh-CN) .ui.accordion .title:not(.ui),:lang(zh-CN) .ui.button,:lang(zh-CN) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-CN) .ui.category.search>.results .category>.name,:lang(zh-CN) .ui.form input:not([type]),:lang(zh-CN) .ui.form input[type=date],:lang(zh-CN) .ui.form input[type=datetime-local],:lang(zh-CN) .ui.form input[type=email],:lang(zh-CN) .ui.form input[type=file],:lang(zh-CN) .ui.form input[type=number],:lang(zh-CN) .ui.form input[type=password],:lang(zh-CN) .ui.form input[type=search],:lang(zh-CN) .ui.form input[type=tel],:lang(zh-CN) .ui.form input[type=text],:lang(zh-CN) .ui.form input[type=time],:lang(zh-CN) .ui.form input[type=url],:lang(zh-CN) .ui.header,:lang(zh-CN) .ui.input input,:lang(zh-CN) .ui.input>input,:lang(zh-CN) .ui.items>.item>.content>.header,:lang(zh-CN) .ui.list .list>.item .header,:lang(zh-CN) .ui.list>.item .header,:lang(zh-CN) .ui.menu,:lang(zh-CN) .ui.message .header,:lang(zh-CN) .ui.modal>.header,:lang(zh-CN) .ui.popup>.header,:lang(zh-CN) .ui.search>.results .result .title,:lang(zh-CN) .ui.search>.results>.message .header,:lang(zh-CN) .ui.statistic>.label,:lang(zh-CN) .ui.statistic>.value,:lang(zh-CN) .ui.statistics .statistic>.label,:lang(zh-CN) .ui.statistics .statistic>.value,:lang(zh-CN) .ui.steps .step .title,:lang(zh-CN) .ui.text.container,:lang(zh-CN) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}:lang(zh-TW) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}:lang(zh-TW) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}:lang(zh-TW) h1,:lang(zh-TW) h2,:lang(zh-TW) h3,:lang(zh-TW) h4,:lang(zh-TW) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}:lang(zh-TW) .home .hero h1,:lang(zh-TW) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}.ui.language>.menu>.item:lang(zh-TW),:lang(zh-TW) .ui.accordion .title:not(.ui),:lang(zh-TW) .ui.button,:lang(zh-TW) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-TW) .ui.category.search>.results .category>.name,:lang(zh-TW) .ui.form input:not([type]),:lang(zh-TW) .ui.form input[type=date],:lang(zh-TW) .ui.form input[type=datetime-local],:lang(zh-TW) .ui.form input[type=email],:lang(zh-TW) .ui.form input[type=file],:lang(zh-TW) .ui.form input[type=number],:lang(zh-TW) .ui.form input[type=password],:lang(zh-TW) .ui.form input[type=search],:lang(zh-TW) .ui.form input[type=tel],:lang(zh-TW) .ui.form input[type=text],:lang(zh-TW) .ui.form input[type=time],:lang(zh-TW) .ui.form input[type=url],:lang(zh-TW) .ui.header,:lang(zh-TW) .ui.input input,:lang(zh-TW) .ui.input>input,:lang(zh-TW) .ui.items>.item>.content>.header,:lang(zh-TW) .ui.list .list>.item .header,:lang(zh-TW) .ui.list>.item .header,:lang(zh-TW) .ui.menu,:lang(zh-TW) .ui.message .header,:lang(zh-TW) .ui.modal>.header,:lang(zh-TW) .ui.popup>.header,:lang(zh-TW) .ui.search>.results .result .title,:lang(zh-TW) .ui.search>.results>.message .header,:lang(zh-TW) .ui.statistic>.label,:lang(zh-TW) .ui.statistic>.value,:lang(zh-TW) .ui.statistics .statistic>.label,:lang(zh-TW) .ui.statistics .statistic>.value,:lang(zh-TW) .ui.steps .step .title,:lang(zh-TW) .ui.text.container,:lang(zh-TW) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}:lang(zh-HK) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}:lang(zh-HK) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}:lang(zh-HK) h1,:lang(zh-HK) h2,:lang(zh-HK) h3,:lang(zh-HK) h4,:lang(zh-HK) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}:lang(zh-HK) .home .hero h1,:lang(zh-HK) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}.ui.language>.menu>.item:lang(zh-HK),:lang(zh-HK) .ui.accordion .title:not(.ui),:lang(zh-HK) .ui.button,:lang(zh-HK) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-HK) .ui.category.search>.results .category>.name,:lang(zh-HK) .ui.form input:not([type]),:lang(zh-HK) .ui.form input[type=date],:lang(zh-HK) .ui.form input[type=datetime-local],:lang(zh-HK) .ui.form input[type=email],:lang(zh-HK) .ui.form input[type=file],:lang(zh-HK) .ui.form input[type=number],:lang(zh-HK) .ui.form input[type=password],:lang(zh-HK) .ui.form input[type=search],:lang(zh-HK) .ui.form input[type=tel],:lang(zh-HK) .ui.form input[type=text],:lang(zh-HK) .ui.form input[type=time],:lang(zh-HK) .ui.form input[type=url],:lang(zh-HK) .ui.header,:lang(zh-HK) .ui.input input,:lang(zh-HK) .ui.input>input,:lang(zh-HK) .ui.items>.item>.content>.header,:lang(zh-HK) .ui.list .list>.item .header,:lang(zh-HK) .ui.list>.item .header,:lang(zh-HK) .ui.menu,:lang(zh-HK) .ui.message .header,:lang(zh-HK) .ui.modal>.header,:lang(zh-HK) .ui.popup>.header,:lang(zh-HK) .ui.search>.results .result .title,:lang(zh-HK) .ui.search>.results>.message .header,:lang(zh-HK) .ui.statistic>.label,:lang(zh-HK) .ui.statistic>.value,:lang(zh-HK) .ui.statistics .statistic>.label,:lang(zh-HK) .ui.statistics .statistic>.value,:lang(zh-HK) .ui.steps .step .title,:lang(zh-HK) .ui.text.container,:lang(zh-HK) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}:lang(ko) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}:lang(ko) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}:lang(ko) h1,:lang(ko) h2,:lang(ko) h3,:lang(ko) h4,:lang(ko) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}:lang(ko) .home .hero h1,:lang(ko) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}.ui.language>.menu>.item:lang(ko),:lang(ko) .ui.accordion .title:not(.ui),:lang(ko) .ui.button,:lang(ko) .ui.card>.content>.header.ui.card>.content>.header,:lang(ko) .ui.category.search>.results .category>.name,:lang(ko) .ui.form input:not([type]),:lang(ko) .ui.form input[type=date],:lang(ko) .ui.form input[type=datetime-local],:lang(ko) .ui.form input[type=email],:lang(ko) .ui.form input[type=file],:lang(ko) .ui.form input[type=number],:lang(ko) .ui.form input[type=password],:lang(ko) .ui.form input[type=search],:lang(ko) .ui.form input[type=tel],:lang(ko) .ui.form input[type=text],:lang(ko) .ui.form input[type=time],:lang(ko) .ui.form input[type=url],:lang(ko) .ui.header,:lang(ko) .ui.input input,:lang(ko) .ui.input>input,:lang(ko) .ui.items>.item>.content>.header,:lang(ko) .ui.list .list>.item .header,:lang(ko) .ui.list>.item .header,:lang(ko) .ui.menu,:lang(ko) .ui.message .header,:lang(ko) .ui.modal>.header,:lang(ko) .ui.popup>.header,:lang(ko) .ui.search>.results .result .title,:lang(ko) .ui.search>.results>.message .header,:lang(ko) .ui.statistic>.label,:lang(ko) .ui.statistic>.value,:lang(ko) .ui.statistics .statistic>.label,:lang(ko) .ui.statistics .statistic>.value,:lang(ko) .ui.steps .step .title,:lang(ko) .ui.text.container,:lang(ko) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}img{border-radius:3px}table{border-collapse:collapse}a{cursor:pointer}.rounded{border-radius:.28571429rem!important}code,pre{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}code.raw,pre.raw{padding:7px 12px;margin:10px 0;background-color:#f8f8f8;border:1px solid #ddd;border-radius:3px;font-size:13px;line-height:1.5;overflow:auto}code.wrap,pre.wrap{white-space:pre-wrap;word-break:break-all;overflow-wrap:break-word;word-wrap:break-word}.dont-break-out{overflow-wrap:break-word;word-wrap:break-word;word-break:break-all;-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto}.full.height{flex-grow:1;padding-bottom:80px}.following.bar{z-index:900;left:0;margin:0!important}.following.bar.light{background-color:#fff;border-bottom:1px solid #DDD;box-shadow:0 2px 3px rgba(0,0,0,.04)}.following.bar .column .menu{margin-top:0}.following.bar .top.menu a.item.brand{padding-left:0}.following.bar .brand .ui.mini.image{width:30px}.following.bar .top.menu .dropdown.item.active,.following.bar .top.menu .dropdown.item:hover,.following.bar .top.menu a.item:hover{background-color:transparent}.following.bar .top.menu a.item:hover{color:rgba(0,0,0,.45)}.following.bar .top.menu .menu{z-index:900}.following.bar .octicon{margin-right:.75em}.following.bar .octicon.fitted{margin-right:0}.following.bar .searchbox{background-color:#f4f4f4!important}.following.bar .searchbox:focus{background-color:#e9e9e9!important}.following.bar .text .octicon{width:16px;text-align:center}.following.bar #navbar{width:100vw;min-height:52px;padding:0 .5rem}.following.bar #navbar .brand{margin:0}@media only screen and (max-width:767px){.following.bar #navbar:not(.shown)>:not(:first-child){display:none}}.right.stackable.menu{margin-left:auto;display:flex;align-items:inherit;flex-direction:inherit}.ui.left{float:left}.ui.right{float:right}.ui.button,.ui.menu .item{-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto}.ui.container.fluid.padded{padding:0 10px 0 10px}.ui.form .ui.button{font-weight:400}.ui.floating.label{z-index:10}.ui.transparent.label{background-color:transparent}.ui.menu,.ui.segment,.ui.vertical.menu{box-shadow:none}.ui .menu:not(.vertical) .item>.button.compact{padding:.58928571em 1.125em}.ui .menu:not(.vertical) .item>.button.small{font-size:.92857143rem}.ui.menu .ui.dropdown.item .menu .item{margin-right:auto}.ui.dropdown .menu>.item>.floating.label{z-index:11}.ui.dropdown .menu .menu>.item>.floating.label{z-index:21}.ui .text.red{color:#d95c5c!important}.ui .text.red a{color:#d95c5c!important}.ui .text.red a:hover{color:#E67777!important}.ui .text.blue{color:#428bca!important}.ui .text.blue a{color:#15c!important}.ui .text.blue a:hover{color:#428bca!important}.ui .text.black{color:#444}.ui .text.black:hover{color:#000}.ui .text.grey{color:#767676!important}.ui .text.grey a{color:#444!important}.ui .text.grey a:hover{color:#000!important}.ui .text.light.grey{color:#888!important}.ui .text.green{color:#6cc644!important}.ui .text.purple{color:#6e5494!important}.ui .text.yellow{color:#FBBD08!important}.ui .text.gold{color:#a1882b!important}.ui .text.left{text-align:left!important}.ui .text.right{text-align:right!important}.ui .text.small{font-size:.75em}.ui .text.normal{font-weight:400}.ui .text.bold{font-weight:700}.ui .text.italic{font-style:italic}.ui .text.truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block}.ui .text.thin{font-weight:400}.ui .text.middle{vertical-align:middle}.ui .message{text-align:center}.ui.bottom.attached.message{font-weight:700;text-align:left;color:#000}.ui.bottom.attached.message .pull-right{color:#000}.ui.bottom.attached.message .pull-right>span,.ui.bottom.attached.message>span{color:#21ba45}.ui .header>i+.content{padding-left:.75rem;vertical-align:middle}.ui .warning.header{background-color:#F9EDBE!important;border-color:#F0C36D}.ui .warning.segment{border-color:#F0C36D}.ui .info.segment{border:1px solid #c5d5dd}.ui .info.segment.top{background-color:#e6f1f6!important}.ui .info.segment.top h3,.ui .info.segment.top h4{margin-top:0}.ui .info.segment.top h3:last-child{margin-top:4px}.ui .info.segment.top>:last-child{margin-bottom:0}.ui .normal.header{font-weight:400}.ui .avatar.image{border-radius:3px}.ui .form .fake{display:none!important}.ui .form .sub.field{margin-left:25px}.ui .sha.label{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;font-size:13px;padding:6px 10px 4px 10px;font-weight:400;margin:0 6px}.ui.status.buttons .octicon{margin-right:4px}.ui.inline.delete-button{padding:8px 15px;font-weight:400}.ui .background.red{background-color:#d95c5c!important}.ui .background.blue{background-color:#428bca!important}.ui .background.black{background-color:#444}.ui .background.grey{background-color:#767676!important}.ui .background.light.grey{background-color:#888!important}.ui .background.green{background-color:#6cc644!important}.ui .background.purple{background-color:#6e5494!important}.ui .background.yellow{background-color:#FBBD08!important}.ui .background.gold{background-color:#a1882b!important}.ui .branch-tag-choice{line-height:20px}@media only screen and (max-width:767px){.ui.pagination.menu .item.navigation span.navigation_label,.ui.pagination.menu .item:not(.active):not(.navigation){display:none}}.file-comment{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.87)}.ui.floating.dropdown .overflow.menu .scrolling.menu.items{border-radius:0!important;box-shadow:none!important;border-bottom:1px solid rgba(34,36,38,.15)}.user-menu>.item{width:100%;border-radius:0!important}.scrolling.menu .item.selected{font-weight:700!important}footer{background-color:#fff;border-top:1px solid #d6d6d6;width:100%;flex-basis:40px;color:#888}footer .container{width:100vw!important;padding:0 .5rem}footer .container .fa{width:16px;text-align:center;color:#428bca}footer .container .links>*{border-left:1px solid #d6d6d6;padding-left:8px;margin-left:5px}footer .container .links>:first-child{border-left:none}footer .ui.language .menu{max-height:500px;overflow-y:auto;margin-bottom:7px}footer .ui.left,footer .ui.right{line-height:40px}.hide{display:none}.hide.show-outdated{display:none!important}.hide.hide-outdated{display:none!important}.center{text-align:center}.img-1{width:2px!important;height:2px!important}.img-2{width:4px!important;height:4px!important}.img-3{width:6px!important;height:6px!important}.img-4{width:8px!important;height:8px!important}.img-5{width:10px!important;height:10px!important}.img-6{width:12px!important;height:12px!important}.img-7{width:14px!important;height:14px!important}.img-8{width:16px!important;height:16px!important}.img-9{width:18px!important;height:18px!important}.img-10{width:20px!important;height:20px!important}.img-11{width:22px!important;height:22px!important}.img-12{width:24px!important;height:24px!important}.img-13{width:26px!important;height:26px!important}.img-14{width:28px!important;height:28px!important}.img-15{width:30px!important;height:30px!important}.img-16{width:32px!important;height:32px!important}@media only screen and (min-width:768px){.mobile-only,.ui.button.mobile-only{display:none}.sr-mobile-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}}@media only screen and (max-width:767px){.not-mobile{display:none}}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}.sr-only-focusable:active,.sr-only-focusable:focus{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto}@media only screen and (max-width:991px) and (min-width:768px){.ui.container{width:95%}}.hljs{background:inherit!important;padding:0!important}.ui.menu.new-menu{justify-content:center!important;padding-top:15px!important;margin-top:-15px!important;margin-bottom:15px!important;background-color:#FAFAFA!important;border-width:1px!important}@media only screen and (max-width:1200px){.ui.menu.new-menu{overflow-x:auto!important;justify-content:left!important;padding-bottom:5px}.ui.menu.new-menu::-webkit-scrollbar{height:8px;display:none}.ui.menu.new-menu:hover::-webkit-scrollbar{display:block}.ui.menu.new-menu::-webkit-scrollbar-track{background:rgba(0,0,0,.01)}.ui.menu.new-menu::-webkit-scrollbar-thumb{background:rgba(0,0,0,.2)}.ui.menu.new-menu:after{position:absolute;margin-top:-15px;display:block;background-image:linear-gradient(to right,rgba(255,255,255,0),#fff 100%);content:' ';right:0;height:53px;z-index:1000;width:60px;clear:none;visibility:visible}.ui.menu.new-menu a.item:last-child{padding-right:30px!important}}[v-cloak]{display:none!important}.repos-search{padding-bottom:0!important}.repos-filter{margin-top:0!important;border-bottom-width:0!important;margin-bottom:2px!important}#user-heatmap{width:107%;text-align:center}#user-heatmap svg:not(:root){overflow:inherit;padding:0!important}@media only screen and (max-width:1200px){#user-heatmap{display:none}}.heatmap-color-0{background-color:#f4f4f4}.heatmap-color-1{background-color:#d7e5db}.heatmap-color-2{background-color:#adc7ab}.heatmap-color-3{background-color:#83a87b}.heatmap-color-4{background-color:#598a4b}.heatmap-color-5{background-color:#2f6b1b}.archived-icon{color:#b3b3b3!important}.oauth2-authorize-application-box{margin-top:3em!important}.ui.tabular.menu .item{color:rgba(0,0,0,.5)}.ui.tabular.menu .item:hover{color:rgba(0,0,0,.8)}.ui.tabular.menu .item.active{color:rgba(0,0,0,.9)}.markdown:not(code){overflow:hidden;font-size:16px;line-height:1.6!important;word-wrap:break-word}.markdown:not(code).ui.segment{padding:3em}.markdown:not(code).file-view{padding:2em 2em 2em!important}.markdown:not(code)>:first-child{margin-top:0!important}.markdown:not(code)>:last-child{margin-bottom:0!important}.markdown:not(code) a:not([href]){color:inherit;text-decoration:none}.markdown:not(code) .absent{color:#c00}.markdown:not(code) .anchor{position:absolute;top:0;left:0;display:block;padding-right:6px;padding-left:30px;margin-left:-30px}.markdown:not(code) .anchor:focus{outline:0}.markdown:not(code) h1,.markdown:not(code) h2,.markdown:not(code) h3,.markdown:not(code) h4,.markdown:not(code) h5,.markdown:not(code) h6{position:relative;margin-top:1em;margin-bottom:16px;font-weight:700;line-height:1.4}.markdown:not(code) h1:first-of-type,.markdown:not(code) h2:first-of-type,.markdown:not(code) h3:first-of-type,.markdown:not(code) h4:first-of-type,.markdown:not(code) h5:first-of-type,.markdown:not(code) h6:first-of-type{margin-top:0!important}.markdown:not(code) h1 .octicon-link,.markdown:not(code) h2 .octicon-link,.markdown:not(code) h3 .octicon-link,.markdown:not(code) h4 .octicon-link,.markdown:not(code) h5 .octicon-link,.markdown:not(code) h6 .octicon-link{display:none;color:#000;vertical-align:middle}.markdown:not(code) h1:hover .anchor,.markdown:not(code) h2:hover .anchor,.markdown:not(code) h3:hover .anchor,.markdown:not(code) h4:hover .anchor,.markdown:not(code) h5:hover .anchor,.markdown:not(code) h6:hover .anchor{padding-left:8px;margin-left:-30px;text-decoration:none}.markdown:not(code) h1:hover .anchor .octicon-link,.markdown:not(code) h2:hover .anchor .octicon-link,.markdown:not(code) h3:hover .anchor .octicon-link,.markdown:not(code) h4:hover .anchor .octicon-link,.markdown:not(code) h5:hover .anchor .octicon-link,.markdown:not(code) h6:hover .anchor .octicon-link{display:inline-block}.markdown:not(code) h1 code,.markdown:not(code) h1 tt,.markdown:not(code) h2 code,.markdown:not(code) h2 tt,.markdown:not(code) h3 code,.markdown:not(code) h3 tt,.markdown:not(code) h4 code,.markdown:not(code) h4 tt,.markdown:not(code) h5 code,.markdown:not(code) h5 tt,.markdown:not(code) h6 code,.markdown:not(code) h6 tt{font-size:inherit}.markdown:not(code) h1{padding-bottom:.3em;font-size:2.25em;line-height:1.2;border-bottom:1px solid #eee}.markdown:not(code) h1 .anchor{line-height:1}.markdown:not(code) h2{padding-bottom:.3em;font-size:1.75em;line-height:1.225;border-bottom:1px solid #eee}.markdown:not(code) h2 .anchor{line-height:1}.markdown:not(code) h3{font-size:1.5em;line-height:1.43}.markdown:not(code) h3 .anchor{line-height:1.2}.markdown:not(code) h4{font-size:1.25em}.markdown:not(code) h4 .anchor{line-height:1.2}.markdown:not(code) h5{font-size:1em}.markdown:not(code) h5 .anchor{line-height:1.1}.markdown:not(code) h6{font-size:1em;color:#777}.markdown:not(code) h6 .anchor{line-height:1.1}.markdown:not(code) blockquote,.markdown:not(code) dl,.markdown:not(code) ol,.markdown:not(code) p,.markdown:not(code) pre,.markdown:not(code) table,.markdown:not(code) ul{margin-top:0;margin-bottom:16px}.markdown:not(code) blockquote{margin-left:0}.markdown:not(code) hr{height:4px;padding:0;margin:16px 0;background-color:#e7e7e7;border:0 none}.markdown:not(code) ol,.markdown:not(code) ul{padding-left:2em}.markdown:not(code) ol.no-list,.markdown:not(code) ul.no-list{padding:0;list-style-type:none}.markdown:not(code) ol ol,.markdown:not(code) ol ul,.markdown:not(code) ul ol,.markdown:not(code) ul ul{margin-top:0;margin-bottom:0}.markdown:not(code) ol ol,.markdown:not(code) ul ol{list-style-type:lower-roman}.markdown:not(code) li>p{margin-top:0}.markdown:not(code) dl{padding:0}.markdown:not(code) dl dt{padding:0;margin-top:16px;font-size:1em;font-style:italic;font-weight:700}.markdown:not(code) dl dd{padding:0 16px;margin-bottom:16px}.markdown:not(code) blockquote{padding:0 15px;color:#777;border-left:4px solid #ddd}.markdown:not(code) blockquote>:first-child{margin-top:0}.markdown:not(code) blockquote>:last-child{margin-bottom:0}.markdown:not(code) table{width:auto;overflow:auto;word-break:normal;word-break:keep-all;display:block}.markdown:not(code) table th{font-weight:700}.markdown:not(code) table td,.markdown:not(code) table th{padding:6px 13px!important;border:1px solid #ddd!important}.markdown:not(code) table tr{background-color:#fff;border-top:1px solid #ccc}.markdown:not(code) table tr:nth-child(2n){background-color:#f8f8f8}.markdown:not(code) img{max-width:100%;box-sizing:border-box}.markdown:not(code) .emoji{max-width:none}.markdown:not(code) span.frame{display:block;overflow:hidden}.markdown:not(code) span.frame>span{display:block;float:left;width:auto;padding:7px;margin:13px 0 0;overflow:hidden;border:1px solid #ddd}.markdown:not(code) span.frame span img{display:block;float:left}.markdown:not(code) span.frame span span{display:block;padding:5px 0 0;clear:both;color:#333}.markdown:not(code) span.align-center{display:block;overflow:hidden;clear:both}.markdown:not(code) span.align-center>span{display:block;margin:13px auto 0;overflow:hidden;text-align:center}.markdown:not(code) span.align-center span img{margin:0 auto;text-align:center}.markdown:not(code) span.align-right{display:block;overflow:hidden;clear:both}.markdown:not(code) span.align-right>span{display:block;margin:13px 0 0;overflow:hidden;text-align:right}.markdown:not(code) span.align-right span img{margin:0;text-align:right}.markdown:not(code) span.float-left{display:block;float:left;margin-right:13px;overflow:hidden}.markdown:not(code) span.float-left span{margin:13px 0 0}.markdown:not(code) span.float-right{display:block;float:right;margin-left:13px;overflow:hidden}.markdown:not(code) span.float-right>span{display:block;margin:13px auto 0;overflow:hidden;text-align:right}.markdown:not(code) code,.markdown:not(code) tt{padding:.2em 0;margin:0;font-size:85%;background-color:rgba(0,0,0,.04);border-radius:3px}.markdown:not(code) code:after,.markdown:not(code) code:before,.markdown:not(code) tt:after,.markdown:not(code) tt:before{letter-spacing:-.2em;content:"\00a0"}.markdown:not(code) code br,.markdown:not(code) tt br{display:none}.markdown:not(code) del code{text-decoration:inherit}.markdown:not(code) pre>code{padding:0;margin:0;font-size:100%;word-break:normal;white-space:pre;background:0 0;border:0}.markdown:not(code) .highlight{margin-bottom:16px}.markdown:not(code) .highlight pre,.markdown:not(code) pre{padding:16px;overflow:auto;font-size:85%;line-height:1.45;background-color:#f7f7f7;border-radius:3px}.markdown:not(code) .highlight pre{margin-bottom:0;word-break:normal}.markdown:not(code) pre{word-wrap:normal}.markdown:not(code) pre code,.markdown:not(code) pre tt{display:inline;max-width:initial;padding:0;margin:0;overflow:initial;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}.markdown:not(code) pre code:after,.markdown:not(code) pre code:before,.markdown:not(code) pre tt:after,.markdown:not(code) pre tt:before{content:normal}.markdown:not(code) kbd{display:inline-block;padding:3px 5px;font-size:11px;line-height:10px;color:#555;vertical-align:middle;background-color:#fcfcfc;border:solid 1px #ccc;border-bottom-color:#bbb;border-radius:3px;box-shadow:inset 0 -1px 0 #bbb}.markdown:not(code) input[type=checkbox]{vertical-align:middle!important}.markdown:not(code) .csv-data td,.markdown:not(code) .csv-data th{padding:5px;overflow:hidden;font-size:12px;line-height:1;text-align:left;white-space:nowrap}.markdown:not(code) .csv-data .blob-num{padding:10px 8px 9px;text-align:right;background:#fff;border:0}.markdown:not(code) .csv-data tr{border-top:0}.markdown:not(code) .csv-data th{font-weight:700;background:#f8f8f8;border-top:0}.markdown:not(code) .ui.list .list,.markdown:not(code) ol.ui.list ol,.markdown:not(code) ul.ui.list ul{padding-left:2em}.home .logo{max-width:220px}@media only screen and (max-width:767px){.home .hero h1{font-size:3.5em}.home .hero h2{font-size:2em}}@media only screen and (min-width:768px){.home .hero h1{font-size:5.5em}.home .hero h2{font-size:3em}}.home .hero .octicon{color:#5aa509;font-size:40px;width:50px}.home .hero.header{font-size:20px}.home p.large{font-size:16px}.home .stackable{padding-top:30px}.home a{color:#5aa509}.signup{padding-top:15px}@media only screen and (max-width:880px){footer .ui.container .left,footer .ui.container .right{display:block;text-align:center;float:none}}.install{padding-top:45px}.install form label{text-align:right;width:320px!important}.install form input{width:35%!important}.install form .field{text-align:left}.install form .field .help{margin-left:335px!important}.install form .field.optional .title{margin-left:38%}.install .ui .checkbox{margin-left:40%!important}.install .ui .checkbox label{width:auto!important}.form .help{color:#999;padding-top:.6em;padding-bottom:.6em;display:inline-block}.ui.attached.header{background:#f0f0f0}.ui.attached.header .right{margin-top:-5px}.ui.attached.header .right .button{padding:8px 10px;font-weight:400}#create-page-form form{margin:auto}#create-page-form form .ui.message{text-align:center}@media only screen and (min-width:768px){#create-page-form form{width:800px!important}#create-page-form form .header{padding-left:280px!important}#create-page-form form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}#create-page-form form .help{margin-left:265px!important}#create-page-form form .optional .title{margin-left:250px!important}#create-page-form form input,#create-page-form form textarea{width:50%!important}}@media only screen and (max-width:767px){#create-page-form form .optional .title{margin-left:15px}#create-page-form form .inline.field>label{display:block}}.signin .oauth2 div{display:inline-block}.signin .oauth2 div p{margin:10px 5px 0 0;float:left}.signin .oauth2 a{margin-right:3px}.signin .oauth2 a:last-child{margin-right:0}.signin .oauth2 img{width:32px;height:32px}.signin .oauth2 img.openidConnect{width:auto}@media only screen and (min-width:768px){.g-recaptcha{margin:0 auto!important;width:304px;padding-left:30px}}@media screen and (max-height:575px){#rc-imageselect,.g-recaptcha{transform:scale(.77);transform-origin:0 0}}.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{margin:auto}.user.activate form .ui.message,.user.forgot.password form .ui.message,.user.reset.password form .ui.message,.user.signin form .ui.message,.user.signup form .ui.message{text-align:center}@media only screen and (min-width:768px){.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{width:800px!important}.user.activate form .header,.user.forgot.password form .header,.user.reset.password form .header,.user.signin form .header,.user.signup form .header{padding-left:280px!important}.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}.user.activate form .help,.user.forgot.password form .help,.user.reset.password form .help,.user.signin form .help,.user.signup form .help{margin-left:265px!important}.user.activate form .optional .title,.user.forgot.password form .optional .title,.user.reset.password form .optional .title,.user.signin form .optional .title,.user.signup form .optional .title{margin-left:250px!important}.user.activate form input,.user.activate form textarea,.user.forgot.password form input,.user.forgot.password form textarea,.user.reset.password form input,.user.reset.password form textarea,.user.signin form input,.user.signin form textarea,.user.signup form input,.user.signup form textarea{width:50%!important}}@media only screen and (max-width:767px){.user.activate form .optional .title,.user.forgot.password form .optional .title,.user.reset.password form .optional .title,.user.signin form .optional .title,.user.signup form .optional .title{margin-left:15px}.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{display:block}}.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{width:700px!important}.user.activate form .header,.user.forgot.password form .header,.user.reset.password form .header,.user.signin form .header,.user.signup form .header{padding-left:0!important;text-align:center}.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{width:200px}@media only screen and (max-width:768px){.user.activate form .inline.field>label,.user.activate form input,.user.forgot.password form .inline.field>label,.user.forgot.password form input,.user.reset.password form .inline.field>label,.user.reset.password form input,.user.signin form .inline.field>label,.user.signin form input,.user.signup form .inline.field>label,.user.signup form input{width:100%!important}}.repository.new.fork form,.repository.new.migrate form,.repository.new.repo form{margin:auto}.repository.new.fork form .ui.message,.repository.new.migrate form .ui.message,.repository.new.repo form .ui.message{text-align:center}@media only screen and (min-width:768px){.repository.new.fork form,.repository.new.migrate form,.repository.new.repo form{width:800px!important}.repository.new.fork form .header,.repository.new.migrate form .header,.repository.new.repo form .header{padding-left:280px!important}.repository.new.fork form .inline.field>label,.repository.new.migrate form .inline.field>label,.repository.new.repo form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}.repository.new.fork form .help,.repository.new.migrate form .help,.repository.new.repo form .help{margin-left:265px!important}.repository.new.fork form .optional .title,.repository.new.migrate form .optional .title,.repository.new.repo form .optional .title{margin-left:250px!important}.repository.new.fork form input,.repository.new.fork form textarea,.repository.new.migrate form input,.repository.new.migrate form textarea,.repository.new.repo form input,.repository.new.repo form textarea{width:50%!important}}@media only screen and (max-width:767px){.repository.new.fork form .optional .title,.repository.new.migrate form .optional .title,.repository.new.repo form .optional .title{margin-left:15px}.repository.new.fork form .inline.field>label,.repository.new.migrate form .inline.field>label,.repository.new.repo form .inline.field>label{display:block}}.repository.new.fork form .dropdown .dropdown.icon,.repository.new.migrate form .dropdown .dropdown.icon,.repository.new.repo form .dropdown .dropdown.icon{margin-top:-7px!important;padding-bottom:5px}.repository.new.fork form .dropdown .text,.repository.new.migrate form .dropdown .text,.repository.new.repo form .dropdown .text{margin-right:0!important}.repository.new.fork form .dropdown .text i,.repository.new.migrate form .dropdown .text i,.repository.new.repo form .dropdown .text i{margin-right:0!important}.repository.new.fork form .header,.repository.new.migrate form .header,.repository.new.repo form .header{padding-left:0!important;text-align:center}@media only screen and (max-width:768px){.repository.new.fork form .selection.dropdown,.repository.new.fork form input,.repository.new.fork form label,.repository.new.migrate form .selection.dropdown,.repository.new.migrate form input,.repository.new.migrate form label,.repository.new.repo form .selection.dropdown,.repository.new.repo form input,.repository.new.repo form label{width:100%!important}.repository.new.fork form .field a,.repository.new.fork form .field button,.repository.new.migrate form .field a,.repository.new.migrate form .field button,.repository.new.repo form .field a,.repository.new.repo form .field button{margin-bottom:1em;width:100%}}@media only screen and (min-width:768px){.repository.new.repo .ui.form #auto-init{margin-left:265px!important}}.repository.new.repo .ui.form .selection.dropdown:not(.owner){width:50%!important}@media only screen and (max-width:768px){.repository.new.repo .ui.form .selection.dropdown:not(.owner){width:100%!important}}.new.webhook form .help{margin-left:25px}.new.webhook .events.fields .column{padding-left:40px}.githook textarea{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}@media only screen and (max-width:768px){.new.org .ui.form .field a,.new.org .ui.form .field button{margin-bottom:1em;width:100%}.new.org .ui.form .field input{width:100%!important}}.repository{padding-top:15px}.repository .repo-header .ui.compact.menu{margin-left:1rem}.repository .repo-header .ui.header{margin-top:0}.repository .repo-header .mega-octicon{width:30px;font-size:30px}.repository .repo-header .ui.huge.breadcrumb{font-weight:400;font-size:1.5rem}.repository .repo-header .fork-flag{margin-left:36px;margin-top:3px;display:block;font-size:12px;white-space:nowrap}.repository .repo-header .octicon.octicon-repo-forked{margin-top:-1px;font-size:15px}.repository .repo-header .button{margin-top:2px;margin-bottom:2px}.repository .tabs .navbar{justify-content:initial}.repository .navbar{display:flex;justify-content:space-between}.repository .navbar .ui.label{margin-left:7px;padding:3px 5px}.repository .owner.dropdown{min-width:40%!important}.repository #file-buttons{margin-left:auto!important;font-weight:400}.repository #file-buttons .ui.button{padding:8px 10px;font-weight:400}.repository .metas .menu{max-height:300px;overflow-x:auto}.repository .metas .ui.list .hide{display:none!important}.repository .metas .ui.list .item{padding:0}.repository .metas .ui.list .label.color{padding:0 8px;margin-right:5px}.repository .metas .ui.list a{margin:2px 0}.repository .metas .ui.list a .text{color:#444}.repository .metas .ui.list a .text:hover{color:#000}.repository .metas #deadlineForm input{width:12.8rem;border-radius:4px 0 0 4px;border-right:0;white-space:nowrap}.repository .header-wrapper{background-color:#FAFAFA;margin-top:-15px;padding-top:15px}.repository .header-wrapper .ui.tabs.divider{border-bottom:none}.repository .header-wrapper .ui.tabular .octicon{margin-right:5px}.repository .filter.menu .label.color{border-radius:3px;margin-left:15px;padding:0 8px}.repository .filter.menu .octicon{float:left;margin:5px -7px 0 -5px;width:16px}.repository .filter.menu.labels .octicon{margin:-2px -7px 0 -5px}.repository .filter.menu .text{margin-left:.9em}.repository .filter.menu .menu{max-height:300px;overflow-x:auto;right:0!important;left:auto!important}.repository .filter.menu .dropdown.item{margin:1px;padding-right:0}.repository .select-label .item{max-width:250px;overflow:hidden;text-overflow:ellipsis}.repository .select-label .desc{padding-left:16px}.repository .ui.tabs.container{margin-top:14px;margin-bottom:0}.repository .ui.tabs.container .ui.menu{border-bottom:none}.repository .ui.tabs.divider{margin-top:0;margin-bottom:20px}.repository #clone-panel{width:350px}@media only screen and (max-width:768px){.repository #clone-panel{width:100%}}.repository #clone-panel input{border-radius:0;padding:5px 10px;width:50%}.repository #clone-panel .clone.button{font-size:13px;padding:0 5px}.repository #clone-panel .clone.button:first-child{border-radius:.28571429rem 0 0 .28571429rem}.repository #clone-panel .icon.button{padding:0 10px}.repository #clone-panel .dropdown .menu{right:0!important;left:auto!important}.repository.file.list .repo-description{display:flex;justify-content:space-between;align-items:center}.repository.file.list #repo-desc{font-size:1.2em}.repository.file.list .choose.reference .header .icon{font-size:1.4em}.repository.file.list .repo-path .divider,.repository.file.list .repo-path .section{display:inline}.repository.file.list #file-buttons{font-weight:400}.repository.file.list #file-buttons .ui.button{padding:8px 10px;font-weight:400}@media only screen and (max-width:768px){.repository.file.list #file-buttons .ui.tiny.blue.buttons{width:100%}}.repository.file.list #repo-files-table thead th{padding-top:8px;padding-bottom:5px;font-weight:400}.repository.file.list #repo-files-table thead .ui.avatar{margin-bottom:5px}.repository.file.list #repo-files-table tbody .octicon{margin-left:3px;margin-right:5px;color:#777}.repository.file.list #repo-files-table tbody .octicon.octicon-mail-reply{margin-right:10px}.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule,.repository.file.list #repo-files-table tbody .octicon.octicon-file-symlink-directory{color:#1e70bf}.repository.file.list #repo-files-table td{padding-top:8px;padding-bottom:8px;overflow:initial}.repository.file.list #repo-files-table td.name{max-width:150px}.repository.file.list #repo-files-table td.message{max-width:400px}.repository.file.list #repo-files-table td.age{width:120px}.repository.file.list #repo-files-table td .truncate{display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis;vertical-align:top;white-space:nowrap}.repository.file.list #repo-files-table td.message .isSigned{cursor:default}.repository.file.list #repo-files-table tr:hover{background-color:#ffE}.repository.file.list #repo-files-table .jumpable-path{color:#888}.repository.file.list .non-diff-file-content .header .icon{font-size:1em}.repository.file.list .non-diff-file-content .header .file-actions{margin-top:0;margin-bottom:-5px;padding-left:20px}.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon{display:inline-block;padding:5px;margin-left:5px;line-height:1;color:#767676;vertical-align:middle;background:0 0;border:0;outline:0}.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon:hover{color:#4078c0}.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon-danger:hover{color:#bd2c00}.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon.disabled{color:#bbb;cursor:default}.repository.file.list .non-diff-file-content .header .file-actions #delete-file-form{display:inline-block}.repository.file.list .non-diff-file-content .view-raw{padding:5px}.repository.file.list .non-diff-file-content .view-raw *{max-width:100%}.repository.file.list .non-diff-file-content .view-raw img{padding:5px 5px 0 5px}.repository.file.list .non-diff-file-content .plain-text{padding:1em 2em 1em 2em}.repository.file.list .non-diff-file-content pre{overflow:auto}.repository.file.list .non-diff-file-content .code-view *{font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}.repository.file.list .non-diff-file-content .code-view table{width:100%}.repository.file.list .non-diff-file-content .code-view .lines-num{vertical-align:top;text-align:right;color:#999;background:#f5f5f5;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.repository.file.list .non-diff-file-content .code-view .lines-num span{line-height:20px;padding:0 10px;cursor:pointer;display:block}.repository.file.list .non-diff-file-content .code-view .lines-code,.repository.file.list .non-diff-file-content .code-view .lines-num{padding:0}.repository.file.list .non-diff-file-content .code-view .lines-code .hljs,.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-code pre,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs,.repository.file.list .non-diff-file-content .code-view .lines-num ol,.repository.file.list .non-diff-file-content .code-view .lines-num pre{background-color:#fff;margin:0;padding:0!important}.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-code ol li,.repository.file.list .non-diff-file-content .code-view .lines-code pre li,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-num ol li,.repository.file.list .non-diff-file-content .code-view .lines-num pre li{display:block;width:100%}.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-code ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-code pre li.active,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-num ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-num pre li.active{background:#ffd}.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-code ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-code pre li:before,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-num ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-num pre li:before{content:' '}.repository.file.list .non-diff-file-content .code-view .lines-commit{vertical-align:top;color:#999;padding:0;background:#f5f5f5;width:1%;-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none}.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info{width:350px;max-width:350px;display:block;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;padding:0 0 0 10px}.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data{display:flex;font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial}.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-message{flex-grow:2;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;line-height:20px}.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-avatar,.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-time{flex-shrink:0}.repository.file.list .non-diff-file-content .code-view .lines-commit .ui.avatar.image{height:18px;width:18px}.repository.file.list .non-diff-file-content .code-view .lines-code .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-commit .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-num .bottom-line{border-bottom:1px solid #eaecef}.repository.file.list .non-diff-file-content .code-view .active{background:#ffd}.repository.file.list .sidebar{padding-left:0}.repository.file.list .sidebar .octicon{width:16px}.repository.file.editor .treepath{width:100%}.repository.file.editor .treepath input{vertical-align:middle;box-shadow:rgba(0,0,0,.0745098) 0 1px 2px inset;width:inherit;padding:7px 8px;margin-right:5px}.repository.file.editor .tabular.menu .octicon{margin-right:5px}.repository.file.editor .commit-form-wrapper{padding-left:64px}.repository.file.editor .commit-form-wrapper .commit-avatar{float:left;margin-left:-64px;width:3em;height:auto}.repository.file.editor .commit-form-wrapper .commit-form{position:relative;padding:15px;margin-bottom:10px;border:1px solid #ddd;border-radius:3px}.repository.file.editor .commit-form-wrapper .commit-form:after,.repository.file.editor .commit-form-wrapper .commit-form:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.repository.file.editor .commit-form-wrapper .commit-form:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}.repository.file.editor .commit-form-wrapper .commit-form:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}.repository.file.editor .commit-form-wrapper .commit-form:after{border-right-color:#fff}.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .branch-name{display:inline-block;padding:3px 6px;font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.65);background-color:rgba(209,227,237,.45);border-radius:3px}.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .new-branch-name-input{position:relative;margin-left:25px}.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .new-branch-name-input input{width:240px!important;padding-left:26px!important}.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .octicon-git-branch{position:absolute;top:9px;left:10px;color:#b0c4ce}.repository.options #interval{width:100px!important;min-width:100px}.repository.options .danger .item{padding:20px 15px}.repository.options .danger .ui.divider{margin:0}.repository.new.issue .comment.form .comment .avatar{width:3em}.repository.new.issue .comment.form .content{margin-left:4em}.repository.new.issue .comment.form .content:after,.repository.new.issue .comment.form .content:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.repository.new.issue .comment.form .content:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}.repository.new.issue .comment.form .content:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}.repository.new.issue .comment.form .content:after{border-right-color:#fff}.repository.new.issue .comment.form .content .markdown{font-size:14px}.repository.new.issue .comment.form .metas{min-width:220px}.repository.new.issue .comment.form .metas .filter.menu{max-height:300px;overflow-x:auto}.repository.view.issue .title{padding-bottom:0!important}.repository.view.issue .title h1{font-weight:300;font-size:2.3rem;margin-bottom:5px}.repository.view.issue .title h1 .ui.input{font-size:.5em;vertical-align:top;width:50%;min-width:600px}.repository.view.issue .title h1 .ui.input input{font-size:1.5em;padding:6px 10px}.repository.view.issue .title .index{font-weight:300;color:#aaa;letter-spacing:-1px}.repository.view.issue .title .label{margin-right:10px}.repository.view.issue .title .edit-zone{margin-top:10px}.repository.view.issue .pull-desc code{color:#0166E6}.repository.view.issue .pull.tabular.menu{margin-bottom:10px}.repository.view.issue .pull.tabular.menu .octicon{margin-right:5px}.repository.view.issue .pull.tab.segment{border:none;padding:10px 0 0;box-shadow:none;background-color:inherit}.repository.view.issue .pull .merge.box .avatar{margin-left:10px;margin-top:10px}.repository.view.issue .pull .review-item .avatar,.repository.view.issue .pull .review-item .type-icon{float:none;display:inline-block;text-align:center;vertical-align:middle}.repository.view.issue .pull .review-item .avatar .octicon,.repository.view.issue .pull .review-item .type-icon .octicon{width:23px;font-size:23px;margin-top:.45em}.repository.view.issue .pull .review-item .text{margin:.3em 0 .5em .5em}.repository.view.issue .pull .review-item .type-icon{float:right;margin-right:1em}.repository.view.issue .pull .review-item .divider{margin:.5rem 0}.repository.view.issue .pull .review-item .review-content{padding:1em 0 1em 3.8em}.repository.view.issue .comment-list:before{display:block;content:"";position:absolute;margin-top:12px;margin-bottom:14px;top:0;bottom:0;left:96px;width:2px;background-color:#f3f3f3;z-index:-1}.repository.view.issue .comment-list .comment .avatar{width:3em}.repository.view.issue .comment-list .comment .tag{color:#767676;margin-top:3px;padding:2px 5px;font-size:12px;border:1px solid rgba(0,0,0,.1);border-radius:3px}.repository.view.issue .comment-list .comment .actions .item{float:left}.repository.view.issue .comment-list .comment .actions .item.tag{margin-right:5px}.repository.view.issue .comment-list .comment .actions .item.action{margin-top:6px;margin-left:10px}.repository.view.issue .comment-list .comment .content{margin-left:4em}.repository.view.issue .comment-list .comment .content>.header{font-weight:400;padding:auto 15px;position:relative;color:#767676;background-color:#f7f7f7;border-bottom:1px solid #eee;border-top-left-radius:3px;border-top-right-radius:3px}.repository.view.issue .comment-list .comment .content>.header:after,.repository.view.issue .comment-list .comment .content>.header:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.repository.view.issue .comment-list .comment .content>.header:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}.repository.view.issue .comment-list .comment .content>.header:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}.repository.view.issue .comment-list .comment .content>.header .text{max-width:78%;padding-top:10px;padding-bottom:10px}.repository.view.issue .comment-list .comment .content .markdown{font-size:14px}.repository.view.issue .comment-list .comment .content .no-content{color:#767676;font-style:italic}.repository.view.issue .comment-list .comment .content>.bottom.segment{background:#f3f4f5}.repository.view.issue .comment-list .comment .content>.bottom.segment .ui.images::after{clear:both;content:' ';display:block}.repository.view.issue .comment-list .comment .content>.bottom.segment a{display:block;float:left;margin:5px;padding:5px;height:150px;border:solid 1px #eee;border-radius:3px;max-width:150px;background-color:#fff}.repository.view.issue .comment-list .comment .content>.bottom.segment a:before{content:' ';display:inline-block;height:100%;vertical-align:middle}.repository.view.issue .comment-list .comment .content>.bottom.segment .ui.image{max-height:100%;width:auto;margin:0;vertical-align:middle}.repository.view.issue .comment-list .comment .content>.bottom.segment span.ui.image{font-size:128px;color:#000}.repository.view.issue .comment-list .comment .content>.bottom.segment span.ui.image:hover{color:#000}.repository.view.issue .comment-list .comment .ui.form .field:first-child{clear:none}.repository.view.issue .comment-list .comment .ui.form .tab.segment{border:none;padding:10px 0 0}.repository.view.issue .comment-list .comment .ui.form textarea{height:200px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}.repository.view.issue .comment-list .comment .edit.buttons{margin-top:10px}.repository.view.issue .comment-list .event{position:relative;margin:15px 0 15px 79px;padding-left:25px}.repository.view.issue .comment-list .event .octicon{width:30px;float:left;text-align:center}.repository.view.issue .comment-list .event .octicon.octicon-circle-slash{margin-top:5px;margin-left:-34.5px;font-size:20px;color:#bd2c00}.repository.view.issue .comment-list .event .octicon.octicon-primitive-dot{margin-left:-28.5px;margin-right:-1px;font-size:30px;color:#6cc644}.repository.view.issue .comment-list .event .octicon.octicon-bookmark{margin-top:3px;margin-left:-31px;margin-right:-1px;font-size:25px}.repository.view.issue .comment-list .event .octicon.octicon-comment{margin-top:4px;margin-left:-35px;font-size:24px}.repository.view.issue .comment-list .event .octicon.octicon-eye{margin-top:3px;margin-left:-35px;margin-right:0;font-size:22px}.repository.view.issue .comment-list .event .octicon.octicon-x{margin-left:-33px;font-size:25px}.repository.view.issue .comment-list .event .detail{font-size:.9rem;margin-top:5px;margin-left:35px}.repository.view.issue .comment-list .event .detail .octicon.octicon-git-commit{margin-top:2px}.repository.view.issue .ui.segment.metas{margin-top:-3px}.repository.view.issue .ui.participants img{margin-top:5px;margin-right:5px}.repository.view.issue .ui.depending .item.is-closed .title{text-decoration:line-through}.repository .comment.form .ui.comments{margin-top:-12px;max-width:100%}.repository .comment.form .content .field:first-child{clear:none}.repository .comment.form .content .form:after,.repository .comment.form .content .form:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.repository .comment.form .content .form:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}.repository .comment.form .content .form:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}.repository .comment.form .content .form:after{border-right-color:#fff}.repository .comment.form .content .tab.segment{border:none;padding:10px 0 0}.repository .comment.form .content textarea{height:200px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}.repository .label.list{list-style:none;padding-top:15px}.repository .label.list .item{padding-top:10px;padding-bottom:10px;border-bottom:1px dashed #AAA}.repository .label.list .item a{font-size:15px;padding-top:5px;padding-right:10px;color:#666}.repository .label.list .item a:hover{color:#000}.repository .label.list .item a.open-issues{margin-right:30px}.repository .label.list .item .ui.label{font-size:1em}.repository .milestone.list{list-style:none;padding-top:15px}.repository .milestone.list>.item{padding-top:10px;padding-bottom:10px;border-bottom:1px dashed #AAA}.repository .milestone.list>.item>a{padding-top:5px;padding-right:10px;color:#000}.repository .milestone.list>.item>a:hover{color:#4078c0}.repository .milestone.list>.item .ui.progress{width:40%;padding:0;border:0;margin:0}.repository .milestone.list>.item .ui.progress .bar{height:20px}.repository .milestone.list>.item .meta{color:#999;padding-top:5px}.repository .milestone.list>.item .meta .issue-stats .octicon{padding-left:5px}.repository .milestone.list>.item .meta .overdue{color:red}.repository .milestone.list>.item .operate{margin-top:-15px}.repository .milestone.list>.item .operate>a{font-size:15px;padding-top:5px;padding-right:10px;color:#666}.repository .milestone.list>.item .operate>a:hover{color:#000}.repository .milestone.list>.item .content{padding-top:10px}.repository.new.milestone textarea{height:200px}.repository.new.milestone #deadline{width:150px}.repository.compare.pull .choose.branch .octicon{padding-right:10px}.repository.compare.pull .comment.form .content:after,.repository.compare.pull .comment.form .content:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.repository.compare.pull .comment.form .content:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}.repository.compare.pull .comment.form .content:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}.repository.compare.pull .comment.form .content:after{border-right-color:#fff}.repository .filter.dropdown .menu{margin-top:1px!important}.repository.branches .commit-divergence .bar-group{position:relative;float:left;padding-bottom:6px;width:90px}.repository.branches .commit-divergence .bar-group:last-child{border-left:1px solid #b4b4b4}.repository.branches .commit-divergence .count{margin:0 3px}.repository.branches .commit-divergence .count.count-ahead{text-align:left}.repository.branches .commit-divergence .count.count-behind{text-align:right}.repository.branches .commit-divergence .bar{height:4px;position:absolute;background-color:#d4d4d5}.repository.branches .commit-divergence .bar.bar-behind{right:0}.repository.branches .commit-divergence .bar.bar-ahead{left:0}.repository.commits .header .search input{font-weight:400;padding:5px 10px}.repository #commits-table thead th:first-of-type{padding-left:15px}.repository #commits-table thead .sha{width:140px}.repository #commits-table thead .shatd{text-align:center}.repository #commits-table td.sha .sha.label{margin:0}.repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n){background-color:rgba(0,0,0,.02)!important}.repository #commits-table td.sha .sha.label.isSigned,.repository #repo-files-table .sha.label.isSigned{border:1px solid #BBB}.repository #commits-table td.sha .sha.label.isSigned .detail.icon,.repository #repo-files-table .sha.label.isSigned .detail.icon{background:#FAFAFA;margin:-6px -10px -4px 0;padding:5px 3px 5px 6px;border-left:1px solid #BBB;border-top-left-radius:0;border-bottom-left-radius:0}.repository #commits-table td.sha .sha.label.isSigned.isVerified,.repository #repo-files-table .sha.label.isSigned.isVerified{border:1px solid #21BA45;background:rgba(33,186,69,.1)}.repository #commits-table td.sha .sha.label.isSigned.isVerified .detail.icon,.repository #repo-files-table .sha.label.isSigned.isVerified .detail.icon{border-left:1px solid rgba(33,186,69,.5)}.repository .diff-detail-box{padding:7px 0;background:#fff;line-height:30px}.repository .diff-detail-box>div:after{clear:both;content:"";display:block}.repository .diff-detail-box ol{clear:both;padding-left:0;margin-top:5px;margin-bottom:28px}.repository .diff-detail-box ol li{list-style:none;padding-bottom:4px;margin-bottom:4px;border-bottom:1px dashed #DDD;padding-left:6px}.repository .diff-detail-box span.status{display:inline-block;width:12px;height:12px;margin-right:8px;vertical-align:middle}.repository .diff-detail-box span.status.modify{background-color:#f0db88}.repository .diff-detail-box span.status.add{background-color:#b4e2b4}.repository .diff-detail-box span.status.del{background-color:#e9aeae}.repository .diff-detail-box span.status.rename{background-color:#dad8ff}.repository .diff-detail-box .detail-files{background:#fff;margin:0}.repository .diff-box .header{display:flex;align-items:center}.repository .diff-box .header .count{margin-right:12px;font-size:13px;flex:0 0 auto}.repository .diff-box .header .count .bar{background-color:#bd2c00;height:12px;width:40px;display:inline-block;margin:2px 4px 0 4px;vertical-align:text-top}.repository .diff-box .header .count .bar .add{background-color:#55a532;height:12px}.repository .diff-box .header .file{flex:1;color:#888;word-break:break-all}.repository .diff-box .header .button{margin:-5px 0 -5px 12px;padding:8px 10px;flex:0 0 auto}.repository .diff-file-box .header{background-color:#f7f7f7}.repository .diff-file-box .file-body.file-code .lines-num{text-align:right;color:#A7A7A7;background:#fafafa;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:top}.repository .diff-file-box .file-body.file-code .lines-num span.fold{display:block;text-align:center}.repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #DDD}.repository .diff-file-box .code-diff{font-size:12px}.repository .diff-file-box .code-diff td{padding:0 0 0 10px;border-top:none}.repository .diff-file-box .code-diff pre{margin:0}.repository .diff-file-box .code-diff .lines-num{border-color:#d4d4d5;border-right-width:1px;border-right-style:solid;padding:0 5px}.repository .diff-file-box .code-diff tbody tr td.halfwidth{width:49%}.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#F0F0F0!important;border-color:#D2CECE!important;padding-top:8px;padding-bottom:8px}.repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#f99}.repository .diff-file-box .code-diff tbody tr .added-code{background-color:#9f9}.repository .diff-file-box .code-diff-unified tbody tr.del-code td{background-color:#ffe0e0!important;border-color:#f1c0c0!important}.repository .diff-file-box .code-diff-unified tbody tr.add-code td{background-color:#d6fcd6!important;border-color:#c1e9c1!important}.repository .diff-file-box .code-diff-split table,.repository .diff-file-box .code-diff-split tbody{width:100%}.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(4){background-color:#fafafa}.repository .diff-file-box .code-diff-split tbody tr td.del-code,.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(2){background-color:#ffe0e0!important;border-color:#f1c0c0!important}.repository .diff-file-box .code-diff-split tbody tr td.add-code,.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(4){background-color:#d6fcd6!important;border-color:#c1e9c1!important}.repository .diff-file-box .code-diff-split tbody tr td:nth-child(3){border-left-width:1px;border-left-style:solid}.repository .diff-file-box.file-content{clear:right}.repository .diff-file-box.file-content img{max-width:100%;padding:5px 5px 0 5px}.repository .code-view{overflow:auto;overflow-x:auto;overflow-y:hidden}.repository .repo-search-result{padding-top:10px;padding-bottom:10px}.repository .repo-search-result .lines-num a{color:inherit}.repository.quickstart .guide .item{padding:1em}.repository.quickstart .guide .item small{font-weight:400}.repository.quickstart .guide .clone.button:first-child{border-radius:.28571429rem 0 0 .28571429rem}.repository.quickstart .guide .ui.action.small.input{width:100%}.repository.quickstart .guide #repo-clone-url{border-radius:0;padding:5px 10px;font-size:1.2em}.repository.release #release-list{border-top:1px solid #DDD;margin-top:20px;padding-top:15px}.repository.release #release-list>li{list-style:none}.repository.release #release-list>li .detail,.repository.release #release-list>li .meta{padding-top:30px;padding-bottom:40px}.repository.release #release-list>li .meta{text-align:right;position:relative}.repository.release #release-list>li .meta .tag:not(.icon){display:block;margin-top:15px}.repository.release #release-list>li .meta .commit{display:block;margin-top:10px}.repository.release #release-list>li .detail{border-left:1px solid #DDD}.repository.release #release-list>li .detail .author img{margin-bottom:-3px}.repository.release #release-list>li .detail .download{margin-top:20px}.repository.release #release-list>li .detail .download>a .octicon{margin-left:5px;margin-right:5px}.repository.release #release-list>li .detail .download .list{padding-left:0;border-top:1px solid #eee}.repository.release #release-list>li .detail .download .list li{list-style:none;display:block;padding-top:8px;padding-bottom:8px;border-bottom:1px solid #eee}.repository.release #release-list>li .detail .dot{width:9px;height:9px;background-color:#ccc;z-index:999;position:absolute;display:block;left:-5px;top:40px;border-radius:6px;border:1px solid #FFF}.repository.new.release .target{min-width:500px}.repository.new.release .target #tag-name{margin-top:-4px}.repository.new.release .target .at{margin-left:-5px;margin-right:5px}.repository.new.release .target .dropdown.icon{margin:0;padding-top:3px}.repository.new.release .target .selection.dropdown{padding-top:10px;padding-bottom:10px}.repository.new.release .prerelease.field{margin-bottom:0}@media only screen and (max-width:438px){.repository.new.release .field button,.repository.new.release .field input{width:100%}}@media only screen and (max-width:768px){.repository.new.release .field button{margin-bottom:1em}}.repository.forks .list{margin-top:0}.repository.forks .list .item{padding-top:10px;padding-bottom:10px;border-bottom:1px solid #DDD}.repository.forks .list .item .ui.avatar{float:left;margin-right:5px}.repository.forks .list .item .link{padding-top:5px}.repository.wiki.start .ui.segment{padding-top:70px;padding-bottom:100px}.repository.wiki.start .ui.segment .mega-octicon{font-size:48px}.repository.wiki.new .CodeMirror .CodeMirror-code{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}.repository.wiki.new .CodeMirror .CodeMirror-code .cm-comment{background:inherit}.repository.wiki.new .editor-preview{background-color:#fff}.repository.wiki.view .choose.page{margin-top:-5px}.repository.wiki.view .ui.sub.header{text-transform:none}.repository.wiki.view>.markdown{padding:15px 30px}.repository.wiki.view>.markdown h1:first-of-type,.repository.wiki.view>.markdown h2:first-of-type,.repository.wiki.view>.markdown h3:first-of-type,.repository.wiki.view>.markdown h4:first-of-type,.repository.wiki.view>.markdown h5:first-of-type,.repository.wiki.view>.markdown h6:first-of-type{margin-top:0}@media only screen and (max-width:767px){.repository.wiki .dividing.header .stackable.grid .button{margin-top:2px;margin-bottom:2px}}.repository.settings.collaboration .collaborator.list{padding:0}.repository.settings.collaboration .collaborator.list>.item{margin:0;line-height:2em}.repository.settings.collaboration .collaborator.list>.item:not(:last-child){border-bottom:1px solid #DDD}.repository.settings.collaboration #repo-collab-form #search-user-box .results{left:7px}.repository.settings.collaboration #repo-collab-form .ui.button{margin-left:5px;margin-top:-3px}.repository.settings.branches .protected-branches .selection.dropdown{width:300px}.repository.settings.branches .protected-branches .item{border:1px solid #eaeaea;padding:10px 15px}.repository.settings.branches .protected-branches .item:not(:last-child){border-bottom:0}.repository.settings.branches .branch-protection .help{margin-left:26px;padding-top:0}.repository.settings.branches .branch-protection .fields{margin-left:20px;display:block}.repository.settings.branches .branch-protection .whitelist{margin-left:26px}.repository.settings.branches .branch-protection .whitelist .dropdown img{display:inline-block}.repository.settings.webhook .events .column{padding-bottom:0}.repository.settings.webhook .events .help{font-size:13px;margin-left:26px;padding-top:0}.repository .ui.attached.isSigned.isVerified:not(.positive){border-left:1px solid #A3C293;border-right:1px solid #A3C293}.repository .ui.attached.isSigned.isVerified.top:not(.positive){border-top:1px solid #A3C293}.repository .ui.attached.isSigned.isVerified:not(.positive):last-child{border-bottom:1px solid #A3C293}.repository .ui.segment.sub-menu{padding:7px;line-height:0}.repository .ui.segment.sub-menu .list{width:100%;display:flex}.repository .ui.segment.sub-menu .list .item{width:100%;border-radius:3px}.repository .ui.segment.sub-menu .list .item a{color:#000}.repository .ui.segment.sub-menu .list .item a:hover{color:#666}.repository .ui.segment.sub-menu .list .item.active{background:rgba(0,0,0,.05)}.repository .segment.reactions.dropdown .menu,.repository .select-reaction.dropdown .menu{right:0!important;left:auto!important}.repository .segment.reactions.dropdown .menu>.header,.repository .select-reaction.dropdown .menu>.header{margin:.75rem 0 .5rem}.repository .segment.reactions.dropdown .menu>.item,.repository .select-reaction.dropdown .menu>.item{float:left;padding:.5rem .5rem!important}.repository .segment.reactions.dropdown .menu>.item img.emoji,.repository .select-reaction.dropdown .menu>.item img.emoji{margin-right:0}.repository .segment.reactions{padding:.3em 1em}.repository .segment.reactions .ui.label{padding:.4em}.repository .segment.reactions .ui.label.disabled{cursor:default}.repository .segment.reactions .ui.label>img{height:1.5em!important}.repository .segment.reactions .select-reaction{float:none}.repository .segment.reactions .select-reaction:not(.active) a{display:none}.repository .segment.reactions:hover .select-reaction a{display:block}.user-cards .list{padding:0}.user-cards .list .item{list-style:none;width:32%;margin:10px 10px 10px 0;padding-bottom:14px;float:left}.user-cards .list .item .avatar{width:48px;height:48px;float:left;display:block;margin-right:10px}.user-cards .list .item .name{margin-top:0;margin-bottom:0;font-weight:400}.user-cards .list .item .meta{margin-top:5px}#search-repo-box .results .result .image,#search-user-box .results .result .image{float:left;margin-right:8px;width:2em;height:2em}#search-repo-box .results .result .content,#search-user-box .results .result .content{margin:6px 0}#issue-filters.hide{display:none}#issue-actions{margin-top:-1rem!important}#issue-actions.hide{display:none}.ui.checkbox.issue-checkbox{vertical-align:middle}.issue.list{list-style:none}.issue.list>.item{padding-top:15px;padding-bottom:10px;border-bottom:1px dashed #AAA}.issue.list>.item .title{color:#444;font-size:15px;font-weight:700;margin:0 6px}.issue.list>.item .title:hover{color:#000}.issue.list>.item .comment{padding-right:10px;color:#666}.issue.list>.item .desc{padding-top:5px;color:#999}.issue.list>.item .desc .checklist{padding-left:5px}.issue.list>.item .desc .checklist .progress-bar{margin-left:2px;width:80px;height:6px;display:inline-block;background-color:#eee;overflow:hidden;border-radius:3px;vertical-align:2px!important}.issue.list>.item .desc .checklist .progress-bar .progress{background-color:#ccc;display:block;height:100%}.issue.list>.item .desc a.milestone{padding-left:5px;color:#999!important}.issue.list>.item .desc a.milestone:hover{color:#000!important}.issue.list>.item .desc .assignee{margin-top:-5px;margin-right:5px}.issue.list>.item .desc .overdue{color:red}.page.buttons{padding-top:15px}.ui.form .dropzone{width:100%;margin-bottom:10px;border:2px dashed #0087F7;box-shadow:none!important}.ui.form .dropzone .dz-error-message{top:140px}.settings .content{margin-top:2px}.settings .content .segment,.settings .content>.header{box-shadow:0 1px 2px 0 rgba(34,36,38,.15)}.settings .list>.item .green{color:#21BA45}.settings .list>.item:not(:first-child){border-top:1px solid #eaeaea;padding:1rem;margin:15px -1rem -1rem -1rem}.settings .list>.item>.mega-octicon{display:table-cell}.settings .list>.item>.mega-octicon+.content{display:table-cell;padding:0 0 0 .5em;vertical-align:top}.settings .list>.item .info{margin-top:10px}.settings .list>.item .info .tab.segment{border:none;padding:10px 0 0}.settings .list.key .meta{padding-top:5px;color:#666}.settings .list.email>.item:not(:first-child){min-height:60px}.settings .list.collaborator>.item{padding:0}.ui.vertical.menu .header.item{font-size:1.1em;background:#f0f0f0}.edit-label.modal .form .column,.new-label.segment .form .column{padding-right:0}.edit-label.modal .form .buttons,.new-label.segment .form .buttons{margin-left:auto;padding-top:15px}.edit-label.modal .form .color.picker.column,.new-label.segment .form .color.picker.column{width:auto}.edit-label.modal .form .color.picker.column .color-picker,.new-label.segment .form .color.picker.column .color-picker{height:35px;width:auto;padding-left:30px}.edit-label.modal .form .minicolors-swatch.minicolors-sprite,.new-label.segment .form .minicolors-swatch.minicolors-sprite{top:10px;left:10px;width:15px;height:15px}.edit-label.modal .form .precolors,.new-label.segment .form .precolors{padding-left:0;padding-right:0;margin:3px 10px auto 10px;width:120px}.edit-label.modal .form .precolors .color,.new-label.segment .form .precolors .color{float:left;width:15px;height:15px}#avatar-arrow:after,#avatar-arrow:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}#avatar-arrow:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}#avatar-arrow:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}#delete-repo-modal .ui.message,#transfer-repo-modal .ui.message{width:100%!important}.tab-size-1{-moz-tab-size:1!important;-o-tab-size:1!important;tab-size:1!important}.tab-size-2{-moz-tab-size:2!important;-o-tab-size:2!important;tab-size:2!important}.tab-size-3{-moz-tab-size:3!important;-o-tab-size:3!important;tab-size:3!important}.tab-size-4{-moz-tab-size:4!important;-o-tab-size:4!important;tab-size:4!important}.tab-size-5{-moz-tab-size:5!important;-o-tab-size:5!important;tab-size:5!important}.tab-size-6{-moz-tab-size:6!important;-o-tab-size:6!important;tab-size:6!important}.tab-size-7{-moz-tab-size:7!important;-o-tab-size:7!important;tab-size:7!important}.tab-size-8{-moz-tab-size:8!important;-o-tab-size:8!important;tab-size:8!important}.tab-size-9{-moz-tab-size:9!important;-o-tab-size:9!important;tab-size:9!important}.tab-size-10{-moz-tab-size:10!important;-o-tab-size:10!important;tab-size:10!important}.tab-size-11{-moz-tab-size:11!important;-o-tab-size:11!important;tab-size:11!important}.tab-size-12{-moz-tab-size:12!important;-o-tab-size:12!important;tab-size:12!important}.tab-size-13{-moz-tab-size:13!important;-o-tab-size:13!important;tab-size:13!important}.tab-size-14{-moz-tab-size:14!important;-o-tab-size:14!important;tab-size:14!important}.tab-size-15{-moz-tab-size:15!important;-o-tab-size:15!important;tab-size:15!important}.tab-size-16{-moz-tab-size:16!important;-o-tab-size:16!important;tab-size:16!important}.stats-table{display:table;width:100%}.stats-table .table-cell{display:table-cell}.stats-table .table-cell.tiny{height:.5em}tbody.commit-list{vertical-align:baseline}.commit-body{white-space:pre-wrap}@media only screen and (max-width:767px){.ui.stackable.menu.mobile--margin-between-items>.item{margin-top:5px;margin-bottom:5px}.ui.stackable.menu.mobile--no-negative-margins{margin-left:0;margin-right:0}}#topic_edit{margin-top:5px}#repo-topics{margin-top:5px}.repo-topic{cursor:pointer}#new-dependency-drop-list.ui.selection.dropdown{min-width:0;width:100%;border-radius:4px 0 0 4px;border-right:0;white-space:nowrap}#new-dependency-drop-list .text{width:100%;overflow:hidden}#manage_topic{font-size:12px}.label+#manage_topic{margin-left:5px}.repo-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap}.repo-header .repo-buttons{display:flex;align-items:center}.repo-buttons .disabled-repo-button .label{opacity:.5}.repo-buttons .disabled-repo-button a.button{opacity:.5;cursor:not-allowed}.repo-buttons .disabled-repo-button a.button:hover{background:0 0!important;color:rgba(0,0,0,.6)!important;box-shadow:0 0 0 1px rgba(34,36,38,.15) inset!important}.repo-buttons .ui.labeled.button>.label{border-left:none!important;margin:0!important}.CodeMirror{font:14px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}.CodeMirror.cm-s-default{border-radius:3px;padding:0!important}.CodeMirror .cm-comment{background:inherit!important}.repository.file.editor .tab[data-tab=write]{padding:0!important}.repository.file.editor .tab[data-tab=write] .editor-toolbar{border:none!important}.repository.file.editor .tab[data-tab=write] .CodeMirror{border-left:none;border-right:none;border-bottom:none}.organization{padding-top:15px}.organization .head .ui.header .text{vertical-align:middle;font-size:1.6rem;margin-left:15px}.organization .head .ui.header .ui.right{margin-top:5px}.organization.new.org form{margin:auto}.organization.new.org form .ui.message{text-align:center}@media only screen and (min-width:768px){.organization.new.org form{width:800px!important}.organization.new.org form .header{padding-left:280px!important}.organization.new.org form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}.organization.new.org form .help{margin-left:265px!important}.organization.new.org form .optional .title{margin-left:250px!important}.organization.new.org form input,.organization.new.org form textarea{width:50%!important}}@media only screen and (max-width:767px){.organization.new.org form .optional .title{margin-left:15px}.organization.new.org form .inline.field>label{display:block}}.organization.new.org form .header{padding-left:0!important;text-align:center}.organization.options input{min-width:300px}.organization.profile #org-avatar{width:100px;height:100px;margin-right:15px}.organization.profile #org-info .ui.header{font-size:36px;margin-bottom:0}.organization.profile #org-info .desc{font-size:16px;margin-bottom:10px}.organization.profile #org-info .meta .item{display:inline-block;margin-right:10px}.organization.profile #org-info .meta .item .icon{margin-right:5px}.organization.profile .ui.top.header .ui.right{margin-top:0}.organization.profile .teams .item{padding:10px 15px}.organization.profile .members .ui.avatar,.organization.teams .members .ui.avatar{width:48px;height:48px;margin-right:5px}.organization.invite #invite-box{margin:50px auto auto;width:500px!important}.organization.invite #invite-box #search-user-box input{margin-left:0;width:300px}.organization.invite #invite-box .ui.button{margin-left:5px;margin-top:-3px}.organization.members .list .item{margin-left:0;margin-right:0;border-bottom:1px solid #eee}.organization.members .list .item .ui.avatar{width:48px;height:48px}.organization.members .list .item .meta{line-height:24px}.organization.teams .detail .item{padding:10px 15px}.organization.teams .detail .item:not(:last-child){border-bottom:1px solid #eee}.organization.teams .members .item,.organization.teams .repositories .item{padding:10px 20px;line-height:32px}.organization.teams .members .item:not(:last-child),.organization.teams .repositories .item:not(:last-child){border-bottom:1px solid #DDD}.organization.teams .members .item .button,.organization.teams .repositories .item .button{padding:9px 10px}.organization.teams #add-member-form input,.organization.teams #add-repo-form input{margin-left:0}.organization.teams #add-member-form .ui.button,.organization.teams #add-repo-form .ui.button{margin-left:5px;margin-top:-3px}.user:not(.icon){padding-top:15px}.user.profile .ui.card .username{display:block}.user.profile .ui.card .extra.content{padding:0}.user.profile .ui.card .extra.content ul{margin:0;padding:0}.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none}.user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}.user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}.user.profile .ui.card .extra.content ul li.follow .ui.button{width:100%}@media only screen and (max-width:768px){.user.profile .ui.card #profile-avatar{height:250px;overflow:hidden}.user.profile .ui.card #profile-avatar img{max-height:768px;max-width:768px}}@media only screen and (max-width:768px){.user.profile .ui.card{width:100%}}.user.profile .ui.repository.list{margin-top:25px}.user.profile #loading-heatmap{margin-bottom:1em}.user.followers .header.name{font-size:20px;line-height:24px;vertical-align:middle}.user.followers .follow .ui.button{padding:8px 15px}.user.notification .octicon{float:left;font-size:2em}.user.notification .content{float:left;margin-left:7px}.user.notification table form{display:inline-block}.user.notification table button{padding:3px 3px 3px 5px}.user.notification table tr{cursor:pointer}.user.notification .octicon.green{color:#21ba45}.user.notification .octicon.red{color:#d01919}.user.notification .octicon.purple{color:#a333c8}.user.notification .octicon.blue{color:#2185d0}.user.link-account:not(.icon){padding-top:15px;padding-bottom:5px}.user.settings .iconFloat{float:left}.dashboard{padding-top:15px}.dashboard.feeds .context.user.menu,.dashboard.issues .context.user.menu{z-index:101;min-width:200px}.dashboard.feeds .context.user.menu .ui.header,.dashboard.issues .context.user.menu .ui.header{font-size:1rem;text-transform:none}.dashboard.feeds .filter.menu .item,.dashboard.issues .filter.menu .item{text-align:left}.dashboard.feeds .filter.menu .item .text,.dashboard.issues .filter.menu .item .text{height:16px;vertical-align:middle}.dashboard.feeds .filter.menu .item .text.truncate,.dashboard.issues .filter.menu .item .text.truncate{width:85%}.dashboard.feeds .filter.menu .item .floating.label,.dashboard.issues .filter.menu .item .floating.label{top:7px;left:90%;width:15%}@media only screen and (max-width:768px){.dashboard.feeds .filter.menu .item .floating.label,.dashboard.issues .filter.menu .item .floating.label{top:10px;left:auto;width:auto;right:13px}}.dashboard.feeds .filter.menu .jump.item,.dashboard.issues .filter.menu .jump.item{margin:1px;padding-right:0}.dashboard.feeds .filter.menu .menu,.dashboard.issues .filter.menu .menu{max-height:300px;overflow-x:auto;right:0!important;left:auto!important}@media only screen and (max-width:768px){.dashboard.feeds .filter.menu,.dashboard.issues .filter.menu{width:100%}}.dashboard.feeds .right.stackable.menu>.item.active,.dashboard.issues .right.stackable.menu>.item.active{color:#d9453d}.dashboard .dashboard-repos{margin:0 1px}.dashboard .dashboard-navbar{width:100vw;padding:0 .5rem}.feeds .news>.ui.grid{margin-left:auto;margin-right:auto}.feeds .news .ui.avatar{margin-top:13px}.feeds .news .time-since{font-size:13px}.feeds .news .issue.title{width:80%}.feeds .news .push.news .content ul{font-size:13px;list-style:none;padding-left:10px}.feeds .news .push.news .content ul img{margin-bottom:-2px}.feeds .news .push.news .content ul .text.truncate{width:80%;margin-bottom:-5px}.feeds .news .commit-id{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}.feeds .news code{padding:1px;font-size:85%;background-color:rgba(0,0,0,.04);border-radius:3px;word-break:break-all}.feeds .list .header .ui.label{margin-top:-4px;padding:4px 5px;font-weight:400}.feeds .list .header .plus.icon{margin-top:5px}.feeds .list ul{list-style:none;margin:0;padding-left:0}.feeds .list ul li:not(:last-child){border-bottom:1px solid #EAEAEA}.feeds .list ul li.private{background-color:#fcf8e9}.feeds .list ul li a{padding:6px 1.2em;display:block}.feeds .list ul li a .octicon{color:#888}.feeds .list ul li a .octicon.rear{font-size:15px}.feeds .list ul li a .star-num{font-size:12px}.feeds .list .repo-owner-name-list .item-name{max-width:70%;margin-bottom:-4px}.feeds .list #collaborative-repo-list .owner-and-repo{max-width:80%;margin-bottom:-5px}.feeds .list #collaborative-repo-list .owner-name{max-width:120px;margin-bottom:-5px}.admin{padding-top:15px}.admin .table.segment{padding:0;font-size:13px}.admin .table.segment:not(.striped){padding-top:5px}.admin .table.segment:not(.striped) thead th:last-child{padding-right:5px!important}.admin .table.segment th{padding-top:5px;padding-bottom:5px}.admin .table.segment:not(.select) td:first-of-type,.admin .table.segment:not(.select) th:first-of-type{padding-left:15px!important}.admin .ui.header,.admin .ui.segment{box-shadow:0 1px 2px 0 rgba(34,36,38,.15)}.admin.user .email{max-width:200px}.admin dl.admin-dl-horizontal{padding:20px;margin:0}.admin dl.admin-dl-horizontal dd{margin-left:275px}.admin dl.admin-dl-horizontal dt{font-weight:bolder;float:left;width:285px;clear:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.admin.config #test-mail-btn{margin-left:5px}.explore{padding-top:15px}.explore .navbar{justify-content:center;padding-top:15px!important;margin-top:-15px!important;margin-bottom:15px!important;background-color:#FAFAFA!important;border-width:1px!important}.explore .navbar .octicon{width:16px;text-align:center;margin-right:5px}.ui.repository.list .item{padding-bottom:25px}.ui.repository.list .item:not(:first-child){border-top:1px solid #eee;padding-top:25px}.ui.repository.list .item .ui.header{font-size:1.5rem;padding-bottom:10px}.ui.repository.list .item .ui.header .name{word-break:break-all}.ui.repository.list .item .ui.header .metas{color:#888;font-size:14px;font-weight:400}.ui.repository.list .item .ui.header .metas span:not(:last-child){margin-right:5px}.ui.repository.list .item .time{font-size:12px;color:grey}.ui.repository.list .item .ui.tags{margin-bottom:1em}.ui.repository.branches .time{font-size:12px;color:grey}.ui.user.list .item{padding-bottom:25px}.ui.user.list .item:not(:first-child){border-top:1px solid #eee;padding-top:25px}.ui.user.list .item .ui.avatar.image{width:40px;height:40px}.ui.user.list .item .description{margin-top:5px}.ui.user.list .item .description .octicon:not(:first-child){margin-left:5px}.ui.user.list .item .description a{color:#333}.ui.user.list .item .description a:hover{text-decoration:underline}.ui.button.add-code-comment{font-size:14px;height:16px;padding:2px 0 0;position:relative;width:16px;z-index:5;float:left;margin:-2px -10px -2px -20px;opacity:0;transition:transform .1s ease-in-out;transform:scale(1,1)}.ui.button.add-code-comment:hover{transform:scale(1.2,1.2)}.focus-lines-new .ui.button.add-code-comment.add-code-comment-right,.focus-lines-old .ui.button.add-code-comment.add-code-comment-left{opacity:1}.comment-code-cloud{padding:4px;position:relative;border:1px solid #f1f1f1;margin:13px 10px 5px auto}.comment-code-cloud:before{content:" ";width:0;height:0;border-left:13px solid transparent;border-right:13px solid transparent;border-bottom:13px solid #f1f1f1;left:20px;position:absolute;top:-13px}.comment-code-cloud .attached.tab{border:none;padding:0;margin:0}.comment-code-cloud .attached.tab.markdown{padding:1em;min-height:168px}.comment-code-cloud .attached.header{padding:.1rem 1rem}.comment-code-cloud .right.menu.options .item{padding:.85714286em .442857em;cursor:pointer}.comment-code-cloud .ui.form textarea{border:0}.comment-code-cloud .ui.attached.tabular.menu{background:#f7f7f7;border:1px solid #d4d4d5;padding-top:5px;padding-left:5px;margin-top:0}.comment-code-cloud .footer{border-top:1px solid #f1f1f1;margin-top:10px}.comment-code-cloud .footer .markdown-info{display:inline-block;margin:5px 0;font-size:12px;color:rgba(0,0,0,.6)}.comment-code-cloud .footer .ui.right.floated{padding-top:6px}.comment-code-cloud .footer:after{clear:both;content:"";display:block}.comment-code-cloud button.comment-form-reply{margin:.5em .5em .5em 4.5em}.comment-code-cloud form.comment-form-reply{margin:0 0 0 4em}.file-comment{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.87)}
+.tribute-container{box-shadow:0 1px 3px 1px #c7c7c7}
+.tribute-container ul{background:#fff}
+.tribute-container li{padding:8px 12px;border-bottom:1px solid #dcdcdc}
+.tribute-container li img{display:inline-block;vertical-align:middle;width:28px;height:28px;margin-right:5px}
+.tribute-container li span.fullname{font-weight:400;font-size:.8rem;margin-left:3px}
+.tribute-container li.highlight,.tribute-container li:hover{background:#2185D0;color:#fff}
+.emoji{width:1.5em;height:1.5em;display:inline-block;background-size:contain}
+.ui.label .emoji{height:1.2em!important}
+@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-regular.eot);src:url(../vendor/assets/lato-fonts/lato-regular.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-regular.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-regular.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-regular.ttf) format('truetype');font-weight:400;font-style:normal}
+@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-italic.eot);src:url(../vendor/assets/lato-fonts/lato-italic.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-italic.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-italic.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-italic.ttf) format('truetype');font-weight:400;font-style:italic}
+@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-bold.eot);src:url(../vendor/assets/lato-fonts/lato-bold.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-bold.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-bold.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-bold.ttf) format('truetype');font-weight:700;font-style:normal}
+@font-face{font-family:Lato;src:url(../vendor/assets/lato-fonts/lato-bolditalic.eot);src:url(../vendor/assets/lato-fonts/lato-bolditalic.eot?#iefix) format('embedded-opentype'),url(../vendor/assets/lato-fonts/lato-bolditalic.woff2) format('woff2'),url(../vendor/assets/lato-fonts/lato-bolditalic.woff) format('woff'),url(../vendor/assets/lato-fonts/lato-bolditalic.ttf) format('truetype');font-weight:700;font-style:italic}
+@font-face{font-family:'Yu Gothic';src:local('Yu Gothic Medium');font-weight:400}
+@font-face{font-family:'Yu Gothic';src:local('Yu Gothic Bold');font-weight:700}
+textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+.markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+h1,h2,h3,h4,h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+.home .hero h1,.home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+.ui.accordion .title:not(.ui),.ui.button,.ui.card>.content>.header.ui.card>.content>.header,.ui.category.search>.results .category>.name,.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=file],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url],.ui.header,.ui.input input,.ui.input>input,.ui.items>.item>.content>.header,.ui.language>.menu>.item,.ui.list .list>.item .header,.ui.list>.item .header,.ui.menu,.ui.message .header,.ui.modal>.header,.ui.popup>.header,.ui.search>.results .result .title,.ui.search>.results>.message .header,.ui.statistic>.label,.ui.statistic>.value,.ui.statistics .statistic>.label,.ui.statistics .statistic>.value,.ui.steps .step .title,.ui.text.container,body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+body{background-color:#fff;overflow-y:auto;-webkit-font-smoothing:antialiased;display:flex;flex-direction:column}
+:lang(ja) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}
+:lang(ja) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}
+:lang(ja) h1,:lang(ja) h2,:lang(ja) h3,:lang(ja) h4,:lang(ja) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}
+:lang(ja) .home .hero h1,:lang(ja) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}
+.ui.language>.menu>.item:lang(ja),:lang(ja) .ui.accordion .title:not(.ui),:lang(ja) .ui.button,:lang(ja) .ui.card>.content>.header.ui.card>.content>.header,:lang(ja) .ui.category.search>.results .category>.name,:lang(ja) .ui.form input:not([type]),:lang(ja) .ui.form input[type=date],:lang(ja) .ui.form input[type=datetime-local],:lang(ja) .ui.form input[type=email],:lang(ja) .ui.form input[type=file],:lang(ja) .ui.form input[type=number],:lang(ja) .ui.form input[type=password],:lang(ja) .ui.form input[type=search],:lang(ja) .ui.form input[type=tel],:lang(ja) .ui.form input[type=text],:lang(ja) .ui.form input[type=time],:lang(ja) .ui.form input[type=url],:lang(ja) .ui.header,:lang(ja) .ui.input input,:lang(ja) .ui.input>input,:lang(ja) .ui.items>.item>.content>.header,:lang(ja) .ui.list .list>.item .header,:lang(ja) .ui.list>.item .header,:lang(ja) .ui.menu,:lang(ja) .ui.message .header,:lang(ja) .ui.modal>.header,:lang(ja) .ui.popup>.header,:lang(ja) .ui.search>.results .result .title,:lang(ja) .ui.search>.results>.message .header,:lang(ja) .ui.statistic>.label,:lang(ja) .ui.statistic>.value,:lang(ja) .ui.statistics .statistic>.label,:lang(ja) .ui.statistics .statistic>.value,:lang(ja) .ui.steps .step .title,:lang(ja) .ui.text.container,:lang(ja) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Hiragino Kaku Gothic ProN','Yu Gothic','Source Han Sans JP','Noto Sans CJK JP','Droid Sans Japanese',Meiryo,'MS PGothic',sans-serif}
+:lang(zh-CN) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}
+:lang(zh-CN) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}
+:lang(zh-CN) h1,:lang(zh-CN) h2,:lang(zh-CN) h3,:lang(zh-CN) h4,:lang(zh-CN) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}
+:lang(zh-CN) .home .hero h1,:lang(zh-CN) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}
+.ui.language>.menu>.item:lang(zh-CN),:lang(zh-CN) .ui.accordion .title:not(.ui),:lang(zh-CN) .ui.button,:lang(zh-CN) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-CN) .ui.category.search>.results .category>.name,:lang(zh-CN) .ui.form input:not([type]),:lang(zh-CN) .ui.form input[type=date],:lang(zh-CN) .ui.form input[type=datetime-local],:lang(zh-CN) .ui.form input[type=email],:lang(zh-CN) .ui.form input[type=file],:lang(zh-CN) .ui.form input[type=number],:lang(zh-CN) .ui.form input[type=password],:lang(zh-CN) .ui.form input[type=search],:lang(zh-CN) .ui.form input[type=tel],:lang(zh-CN) .ui.form input[type=text],:lang(zh-CN) .ui.form input[type=time],:lang(zh-CN) .ui.form input[type=url],:lang(zh-CN) .ui.header,:lang(zh-CN) .ui.input input,:lang(zh-CN) .ui.input>input,:lang(zh-CN) .ui.items>.item>.content>.header,:lang(zh-CN) .ui.list .list>.item .header,:lang(zh-CN) .ui.list>.item .header,:lang(zh-CN) .ui.menu,:lang(zh-CN) .ui.message .header,:lang(zh-CN) .ui.modal>.header,:lang(zh-CN) .ui.popup>.header,:lang(zh-CN) .ui.search>.results .result .title,:lang(zh-CN) .ui.search>.results>.message .header,:lang(zh-CN) .ui.statistic>.label,:lang(zh-CN) .ui.statistic>.value,:lang(zh-CN) .ui.statistics .statistic>.label,:lang(zh-CN) .ui.statistics .statistic>.value,:lang(zh-CN) .ui.steps .step .title,:lang(zh-CN) .ui.text.container,:lang(zh-CN) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Source Han Sans CN','Source Han Sans SC','Noto Sans CJK SC','Microsoft YaHei','Heiti SC',SimHei,sans-serif}
+:lang(zh-TW) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}
+:lang(zh-TW) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}
+:lang(zh-TW) h1,:lang(zh-TW) h2,:lang(zh-TW) h3,:lang(zh-TW) h4,:lang(zh-TW) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}
+:lang(zh-TW) .home .hero h1,:lang(zh-TW) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}
+.ui.language>.menu>.item:lang(zh-TW),:lang(zh-TW) .ui.accordion .title:not(.ui),:lang(zh-TW) .ui.button,:lang(zh-TW) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-TW) .ui.category.search>.results .category>.name,:lang(zh-TW) .ui.form input:not([type]),:lang(zh-TW) .ui.form input[type=date],:lang(zh-TW) .ui.form input[type=datetime-local],:lang(zh-TW) .ui.form input[type=email],:lang(zh-TW) .ui.form input[type=file],:lang(zh-TW) .ui.form input[type=number],:lang(zh-TW) .ui.form input[type=password],:lang(zh-TW) .ui.form input[type=search],:lang(zh-TW) .ui.form input[type=tel],:lang(zh-TW) .ui.form input[type=text],:lang(zh-TW) .ui.form input[type=time],:lang(zh-TW) .ui.form input[type=url],:lang(zh-TW) .ui.header,:lang(zh-TW) .ui.input input,:lang(zh-TW) .ui.input>input,:lang(zh-TW) .ui.items>.item>.content>.header,:lang(zh-TW) .ui.list .list>.item .header,:lang(zh-TW) .ui.list>.item .header,:lang(zh-TW) .ui.menu,:lang(zh-TW) .ui.message .header,:lang(zh-TW) .ui.modal>.header,:lang(zh-TW) .ui.popup>.header,:lang(zh-TW) .ui.search>.results .result .title,:lang(zh-TW) .ui.search>.results>.message .header,:lang(zh-TW) .ui.statistic>.label,:lang(zh-TW) .ui.statistic>.value,:lang(zh-TW) .ui.statistics .statistic>.label,:lang(zh-TW) .ui.statistics .statistic>.value,:lang(zh-TW) .ui.steps .step .title,:lang(zh-TW) .ui.text.container,:lang(zh-TW) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang TC','Hiragino Sans TC','Source Han Sans TW','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU,sans-serif}
+:lang(zh-HK) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}
+:lang(zh-HK) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}
+:lang(zh-HK) h1,:lang(zh-HK) h2,:lang(zh-HK) h3,:lang(zh-HK) h4,:lang(zh-HK) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}
+:lang(zh-HK) .home .hero h1,:lang(zh-HK) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}
+.ui.language>.menu>.item:lang(zh-HK),:lang(zh-HK) .ui.accordion .title:not(.ui),:lang(zh-HK) .ui.button,:lang(zh-HK) .ui.card>.content>.header.ui.card>.content>.header,:lang(zh-HK) .ui.category.search>.results .category>.name,:lang(zh-HK) .ui.form input:not([type]),:lang(zh-HK) .ui.form input[type=date],:lang(zh-HK) .ui.form input[type=datetime-local],:lang(zh-HK) .ui.form input[type=email],:lang(zh-HK) .ui.form input[type=file],:lang(zh-HK) .ui.form input[type=number],:lang(zh-HK) .ui.form input[type=password],:lang(zh-HK) .ui.form input[type=search],:lang(zh-HK) .ui.form input[type=tel],:lang(zh-HK) .ui.form input[type=text],:lang(zh-HK) .ui.form input[type=time],:lang(zh-HK) .ui.form input[type=url],:lang(zh-HK) .ui.header,:lang(zh-HK) .ui.input input,:lang(zh-HK) .ui.input>input,:lang(zh-HK) .ui.items>.item>.content>.header,:lang(zh-HK) .ui.list .list>.item .header,:lang(zh-HK) .ui.list>.item .header,:lang(zh-HK) .ui.menu,:lang(zh-HK) .ui.message .header,:lang(zh-HK) .ui.modal>.header,:lang(zh-HK) .ui.popup>.header,:lang(zh-HK) .ui.search>.results .result .title,:lang(zh-HK) .ui.search>.results>.message .header,:lang(zh-HK) .ui.statistic>.label,:lang(zh-HK) .ui.statistic>.value,:lang(zh-HK) .ui.statistics .statistic>.label,:lang(zh-HK) .ui.statistics .statistic>.value,:lang(zh-HK) .ui.steps .step .title,:lang(zh-HK) .ui.text.container,:lang(zh-HK) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'PingFang HK','Hiragino Sans TC','Source Han Sans HK','Source Han Sans TC','Noto Sans CJK TC','Microsoft JhengHei','Heiti TC',PMingLiU_HKSCS,PMingLiU,sans-serif}
+:lang(ko) textarea{font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}
+:lang(ko) .markdown:not(code){font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}
+:lang(ko) h1,:lang(ko) h2,:lang(ko) h3,:lang(ko) h4,:lang(ko) h5{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}
+:lang(ko) .home .hero h1,:lang(ko) .home .hero h2{font-family:'PT Sans Narrow',Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}
+.ui.language>.menu>.item:lang(ko),:lang(ko) .ui.accordion .title:not(.ui),:lang(ko) .ui.button,:lang(ko) .ui.card>.content>.header.ui.card>.content>.header,:lang(ko) .ui.category.search>.results .category>.name,:lang(ko) .ui.form input:not([type]),:lang(ko) .ui.form input[type=date],:lang(ko) .ui.form input[type=datetime-local],:lang(ko) .ui.form input[type=email],:lang(ko) .ui.form input[type=file],:lang(ko) .ui.form input[type=number],:lang(ko) .ui.form input[type=password],:lang(ko) .ui.form input[type=search],:lang(ko) .ui.form input[type=tel],:lang(ko) .ui.form input[type=text],:lang(ko) .ui.form input[type=time],:lang(ko) .ui.form input[type=url],:lang(ko) .ui.header,:lang(ko) .ui.input input,:lang(ko) .ui.input>input,:lang(ko) .ui.items>.item>.content>.header,:lang(ko) .ui.list .list>.item .header,:lang(ko) .ui.list>.item .header,:lang(ko) .ui.menu,:lang(ko) .ui.message .header,:lang(ko) .ui.modal>.header,:lang(ko) .ui.popup>.header,:lang(ko) .ui.search>.results .result .title,:lang(ko) .ui.search>.results>.message .header,:lang(ko) .ui.statistic>.label,:lang(ko) .ui.statistic>.value,:lang(ko) .ui.statistics .statistic>.label,:lang(ko) .ui.statistics .statistic>.value,:lang(ko) .ui.steps .step .title,:lang(ko) .ui.text.container,:lang(ko) body{font-family:Lato,-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo',NanumBarunGothic,'Malgun Gothic',Gulim,Dotum,'Nanum Gothic','Source Han Sans KR','Noto Sans CJK KR',sans-serif}
+img{border-radius:3px}
+table{border-collapse:collapse}
+a{cursor:pointer}
+.rounded{border-radius:.28571429rem!important}
+code,pre{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+code.raw,pre.raw{padding:7px 12px;margin:10px 0;background-color:#f8f8f8;border:1px solid #ddd;border-radius:3px;font-size:13px;line-height:1.5;overflow:auto}
+code.wrap,pre.wrap{white-space:pre-wrap;word-break:break-all;overflow-wrap:break-word;word-wrap:break-word}
+.dont-break-out{overflow-wrap:break-word;word-wrap:break-word;word-break:break-all;-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto}
+.full.height{flex-grow:1;padding-bottom:80px}
+.following.bar{z-index:900;left:0;margin:0!important}
+.following.bar.light{background-color:#fff;border-bottom:1px solid #DDD;box-shadow:0 2px 3px rgba(0,0,0,.04)}
+.following.bar .column .menu{margin-top:0}
+.following.bar .top.menu a.item.brand{padding-left:0}
+.following.bar .brand .ui.mini.image{width:30px}
+.following.bar .top.menu .dropdown.item.active,.following.bar .top.menu .dropdown.item:hover,.following.bar .top.menu a.item:hover{background-color:transparent}
+.following.bar .top.menu a.item:hover{color:rgba(0,0,0,.45)}
+.following.bar .top.menu .menu{z-index:900}
+.following.bar .octicon{margin-right:.75em}
+.following.bar .octicon.fitted{margin-right:0}
+.following.bar .searchbox{background-color:#f4f4f4!important}
+.following.bar .searchbox:focus{background-color:#e9e9e9!important}
+.following.bar .text .octicon{width:16px;text-align:center}
+.following.bar #navbar{width:100vw;min-height:52px;padding:0 .5rem}
+.following.bar #navbar .brand{margin:0}
+@media only screen and (max-width:767px){.following.bar #navbar:not(.shown)>:not(:first-child){display:none}
+}
+.right.stackable.menu{margin-left:auto;display:flex;align-items:inherit;flex-direction:inherit}
+.ui.left{float:left}
+.ui.right{float:right}
+.ui.button,.ui.menu .item{-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto}
+.ui.container.fluid.padded{padding:0 10px 0 10px}
+.ui.form .ui.button{font-weight:400}
+.ui.floating.label{z-index:10}
+.ui.transparent.label{background-color:transparent}
+.ui.menu,.ui.segment,.ui.vertical.menu{box-shadow:none}
+.ui .menu:not(.vertical) .item>.button.compact{padding:.58928571em 1.125em}
+.ui .menu:not(.vertical) .item>.button.small{font-size:.92857143rem}
+.ui.menu .ui.dropdown.item .menu .item{margin-right:auto}
+.ui.dropdown .menu>.item>.floating.label{z-index:11}
+.ui.dropdown .menu .menu>.item>.floating.label{z-index:21}
+.ui .text.red{color:#d95c5c!important}
+.ui .text.red a{color:#d95c5c!important}
+.ui .text.red a:hover{color:#E67777!important}
+.ui .text.blue{color:#428bca!important}
+.ui .text.blue a{color:#15c!important}
+.ui .text.blue a:hover{color:#428bca!important}
+.ui .text.black{color:#444}
+.ui .text.black:hover{color:#000}
+.ui .text.grey{color:#767676!important}
+.ui .text.grey a{color:#444!important}
+.ui .text.grey a:hover{color:#000!important}
+.ui .text.light.grey{color:#888!important}
+.ui .text.green{color:#6cc644!important}
+.ui .text.purple{color:#6e5494!important}
+.ui .text.yellow{color:#FBBD08!important}
+.ui .text.gold{color:#a1882b!important}
+.ui .text.left{text-align:left!important}
+.ui .text.right{text-align:right!important}
+.ui .text.small{font-size:.75em}
+.ui .text.normal{font-weight:400}
+.ui .text.bold{font-weight:700}
+.ui .text.italic{font-style:italic}
+.ui .text.truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block}
+.ui .text.thin{font-weight:400}
+.ui .text.middle{vertical-align:middle}
+.ui .message{text-align:center}
+.ui.bottom.attached.message{font-weight:700;text-align:left;color:#000}
+.ui.bottom.attached.message .pull-right{color:#000}
+.ui.bottom.attached.message .pull-right>span,.ui.bottom.attached.message>span{color:#21ba45}
+.ui .header>i+.content{padding-left:.75rem;vertical-align:middle}
+.ui .warning.header{background-color:#F9EDBE!important;border-color:#F0C36D}
+.ui .warning.segment{border-color:#F0C36D}
+.ui .info.segment{border:1px solid #c5d5dd}
+.ui .info.segment.top{background-color:#e6f1f6!important}
+.ui .info.segment.top h3,.ui .info.segment.top h4{margin-top:0}
+.ui .info.segment.top h3:last-child{margin-top:4px}
+.ui .info.segment.top>:last-child{margin-bottom:0}
+.ui .normal.header{font-weight:400}
+.ui .avatar.image{border-radius:3px}
+.ui .form .fake{display:none!important}
+.ui .form .sub.field{margin-left:25px}
+.ui .sha.label{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;font-size:13px;padding:6px 10px 4px 10px;font-weight:400;margin:0 6px}
+.ui.status.buttons .octicon{margin-right:4px}
+.ui.inline.delete-button{padding:8px 15px;font-weight:400}
+.ui .background.red{background-color:#d95c5c!important}
+.ui .background.blue{background-color:#428bca!important}
+.ui .background.black{background-color:#444}
+.ui .background.grey{background-color:#767676!important}
+.ui .background.light.grey{background-color:#888!important}
+.ui .background.green{background-color:#6cc644!important}
+.ui .background.purple{background-color:#6e5494!important}
+.ui .background.yellow{background-color:#FBBD08!important}
+.ui .background.gold{background-color:#a1882b!important}
+.ui .branch-tag-choice{line-height:20px}
+@media only screen and (max-width:767px){.ui.pagination.menu .item.navigation span.navigation_label,.ui.pagination.menu .item:not(.active):not(.navigation){display:none}
+}
+.file-comment{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.87)}
+.ui.floating.dropdown .overflow.menu .scrolling.menu.items{border-radius:0!important;box-shadow:none!important;border-bottom:1px solid rgba(34,36,38,.15)}
+.user-menu>.item{width:100%;border-radius:0!important}
+.scrolling.menu .item.selected{font-weight:700!important}
+footer{background-color:#fff;border-top:1px solid #d6d6d6;width:100%;flex-basis:40px;color:#888}
+footer .container{width:100vw!important;padding:0 .5rem}
+footer .container .fa{width:16px;text-align:center;color:#428bca}
+footer .container .links>*{border-left:1px solid #d6d6d6;padding-left:8px;margin-left:5px}
+footer .container .links>:first-child{border-left:none}
+footer .ui.language .menu{max-height:500px;overflow-y:auto;margin-bottom:7px}
+footer .ui.left,footer .ui.right{line-height:40px}
+.hide{display:none}
+.hide.show-outdated{display:none!important}
+.hide.hide-outdated{display:none!important}
+.center{text-align:center}
+.img-1{width:2px!important;height:2px!important}
+.img-2{width:4px!important;height:4px!important}
+.img-3{width:6px!important;height:6px!important}
+.img-4{width:8px!important;height:8px!important}
+.img-5{width:10px!important;height:10px!important}
+.img-6{width:12px!important;height:12px!important}
+.img-7{width:14px!important;height:14px!important}
+.img-8{width:16px!important;height:16px!important}
+.img-9{width:18px!important;height:18px!important}
+.img-10{width:20px!important;height:20px!important}
+.img-11{width:22px!important;height:22px!important}
+.img-12{width:24px!important;height:24px!important}
+.img-13{width:26px!important;height:26px!important}
+.img-14{width:28px!important;height:28px!important}
+.img-15{width:30px!important;height:30px!important}
+.img-16{width:32px!important;height:32px!important}
+@media only screen and (min-width:768px){.mobile-only,.ui.button.mobile-only{display:none}
+.sr-mobile-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
+}
+@media only screen and (max-width:767px){.not-mobile{display:none}
+}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
+.sr-only-focusable:active,.sr-only-focusable:focus{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto}
+@media only screen and (max-width:991px) and (min-width:768px){.ui.container{width:95%}
+}
+.hljs{background:inherit!important;padding:0!important}
+.ui.menu.new-menu{justify-content:center!important;padding-top:15px!important;margin-top:-15px!important;margin-bottom:15px!important;background-color:#FAFAFA!important;border-width:1px!important}
+@media only screen and (max-width:1200px){.ui.menu.new-menu{overflow-x:auto!important;justify-content:left!important;padding-bottom:5px}
+.ui.menu.new-menu::-webkit-scrollbar{height:8px;display:none}
+.ui.menu.new-menu:hover::-webkit-scrollbar{display:block}
+.ui.menu.new-menu::-webkit-scrollbar-track{background:rgba(0,0,0,.01)}
+.ui.menu.new-menu::-webkit-scrollbar-thumb{background:rgba(0,0,0,.2)}
+.ui.menu.new-menu:after{position:absolute;margin-top:-15px;display:block;background-image:linear-gradient(to right,rgba(255,255,255,0),#fff 100%);content:' ';right:0;height:53px;z-index:1000;width:60px;clear:none;visibility:visible}
+.ui.menu.new-menu a.item:last-child{padding-right:30px!important}
+}
+[v-cloak]{display:none!important}
+.repos-search{padding-bottom:0!important}
+.repos-filter{margin-top:0!important;border-bottom-width:0!important;margin-bottom:2px!important}
+#user-heatmap{width:107%;text-align:center}
+#user-heatmap svg:not(:root){overflow:inherit;padding:0!important}
+@media only screen and (max-width:1200px){#user-heatmap{display:none}
+}
+.heatmap-color-0{background-color:#f4f4f4}
+.heatmap-color-1{background-color:#d7e5db}
+.heatmap-color-2{background-color:#adc7ab}
+.heatmap-color-3{background-color:#83a87b}
+.heatmap-color-4{background-color:#598a4b}
+.heatmap-color-5{background-color:#2f6b1b}
+.archived-icon{color:#b3b3b3!important}
+.oauth2-authorize-application-box{margin-top:3em!important}
+.ui.tabular.menu .item{color:rgba(0,0,0,.5)}
+.ui.tabular.menu .item:hover{color:rgba(0,0,0,.8)}
+.ui.tabular.menu .item.active{color:rgba(0,0,0,.9)}
+.markdown:not(code){overflow:hidden;font-size:16px;line-height:1.6!important;word-wrap:break-word}
+.markdown:not(code).ui.segment{padding:3em}
+.markdown:not(code).file-view{padding:2em 2em 2em!important}
+.markdown:not(code)>:first-child{margin-top:0!important}
+.markdown:not(code)>:last-child{margin-bottom:0!important}
+.markdown:not(code) a:not([href]){color:inherit;text-decoration:none}
+.markdown:not(code) .absent{color:#c00}
+.markdown:not(code) .anchor{position:absolute;top:0;left:0;display:block;padding-right:6px;padding-left:30px;margin-left:-30px}
+.markdown:not(code) .anchor:focus{outline:0}
+.markdown:not(code) h1,.markdown:not(code) h2,.markdown:not(code) h3,.markdown:not(code) h4,.markdown:not(code) h5,.markdown:not(code) h6{position:relative;margin-top:1em;margin-bottom:16px;font-weight:700;line-height:1.4}
+.markdown:not(code) h1:first-of-type,.markdown:not(code) h2:first-of-type,.markdown:not(code) h3:first-of-type,.markdown:not(code) h4:first-of-type,.markdown:not(code) h5:first-of-type,.markdown:not(code) h6:first-of-type{margin-top:0!important}
+.markdown:not(code) h1 .octicon-link,.markdown:not(code) h2 .octicon-link,.markdown:not(code) h3 .octicon-link,.markdown:not(code) h4 .octicon-link,.markdown:not(code) h5 .octicon-link,.markdown:not(code) h6 .octicon-link{display:none;color:#000;vertical-align:middle}
+.markdown:not(code) h1:hover .anchor,.markdown:not(code) h2:hover .anchor,.markdown:not(code) h3:hover .anchor,.markdown:not(code) h4:hover .anchor,.markdown:not(code) h5:hover .anchor,.markdown:not(code) h6:hover .anchor{padding-left:8px;margin-left:-30px;text-decoration:none}
+.markdown:not(code) h1:hover .anchor .octicon-link,.markdown:not(code) h2:hover .anchor .octicon-link,.markdown:not(code) h3:hover .anchor .octicon-link,.markdown:not(code) h4:hover .anchor .octicon-link,.markdown:not(code) h5:hover .anchor .octicon-link,.markdown:not(code) h6:hover .anchor .octicon-link{display:inline-block}
+.markdown:not(code) h1 code,.markdown:not(code) h1 tt,.markdown:not(code) h2 code,.markdown:not(code) h2 tt,.markdown:not(code) h3 code,.markdown:not(code) h3 tt,.markdown:not(code) h4 code,.markdown:not(code) h4 tt,.markdown:not(code) h5 code,.markdown:not(code) h5 tt,.markdown:not(code) h6 code,.markdown:not(code) h6 tt{font-size:inherit}
+.markdown:not(code) h1{padding-bottom:.3em;font-size:2.25em;line-height:1.2;border-bottom:1px solid #eee}
+.markdown:not(code) h1 .anchor{line-height:1}
+.markdown:not(code) h2{padding-bottom:.3em;font-size:1.75em;line-height:1.225;border-bottom:1px solid #eee}
+.markdown:not(code) h2 .anchor{line-height:1}
+.markdown:not(code) h3{font-size:1.5em;line-height:1.43}
+.markdown:not(code) h3 .anchor{line-height:1.2}
+.markdown:not(code) h4{font-size:1.25em}
+.markdown:not(code) h4 .anchor{line-height:1.2}
+.markdown:not(code) h5{font-size:1em}
+.markdown:not(code) h5 .anchor{line-height:1.1}
+.markdown:not(code) h6{font-size:1em;color:#777}
+.markdown:not(code) h6 .anchor{line-height:1.1}
+.markdown:not(code) blockquote,.markdown:not(code) dl,.markdown:not(code) ol,.markdown:not(code) p,.markdown:not(code) pre,.markdown:not(code) table,.markdown:not(code) ul{margin-top:0;margin-bottom:16px}
+.markdown:not(code) blockquote{margin-left:0}
+.markdown:not(code) hr{height:4px;padding:0;margin:16px 0;background-color:#e7e7e7;border:0 none}
+.markdown:not(code) ol,.markdown:not(code) ul{padding-left:2em}
+.markdown:not(code) ol.no-list,.markdown:not(code) ul.no-list{padding:0;list-style-type:none}
+.markdown:not(code) ol ol,.markdown:not(code) ol ul,.markdown:not(code) ul ol,.markdown:not(code) ul ul{margin-top:0;margin-bottom:0}
+.markdown:not(code) ol ol,.markdown:not(code) ul ol{list-style-type:lower-roman}
+.markdown:not(code) li>p{margin-top:0}
+.markdown:not(code) dl{padding:0}
+.markdown:not(code) dl dt{padding:0;margin-top:16px;font-size:1em;font-style:italic;font-weight:700}
+.markdown:not(code) dl dd{padding:0 16px;margin-bottom:16px}
+.markdown:not(code) blockquote{padding:0 15px;color:#777;border-left:4px solid #ddd}
+.markdown:not(code) blockquote>:first-child{margin-top:0}
+.markdown:not(code) blockquote>:last-child{margin-bottom:0}
+.markdown:not(code) table{width:auto;overflow:auto;word-break:normal;word-break:keep-all;display:block}
+.markdown:not(code) table th{font-weight:700}
+.markdown:not(code) table td,.markdown:not(code) table th{padding:6px 13px!important;border:1px solid #ddd!important}
+.markdown:not(code) table tr{background-color:#fff;border-top:1px solid #ccc}
+.markdown:not(code) table tr:nth-child(2n){background-color:#f8f8f8}
+.markdown:not(code) img{max-width:100%;box-sizing:border-box}
+.markdown:not(code) .emoji{max-width:none}
+.markdown:not(code) span.frame{display:block;overflow:hidden}
+.markdown:not(code) span.frame>span{display:block;float:left;width:auto;padding:7px;margin:13px 0 0;overflow:hidden;border:1px solid #ddd}
+.markdown:not(code) span.frame span img{display:block;float:left}
+.markdown:not(code) span.frame span span{display:block;padding:5px 0 0;clear:both;color:#333}
+.markdown:not(code) span.align-center{display:block;overflow:hidden;clear:both}
+.markdown:not(code) span.align-center>span{display:block;margin:13px auto 0;overflow:hidden;text-align:center}
+.markdown:not(code) span.align-center span img{margin:0 auto;text-align:center}
+.markdown:not(code) span.align-right{display:block;overflow:hidden;clear:both}
+.markdown:not(code) span.align-right>span{display:block;margin:13px 0 0;overflow:hidden;text-align:right}
+.markdown:not(code) span.align-right span img{margin:0;text-align:right}
+.markdown:not(code) span.float-left{display:block;float:left;margin-right:13px;overflow:hidden}
+.markdown:not(code) span.float-left span{margin:13px 0 0}
+.markdown:not(code) span.float-right{display:block;float:right;margin-left:13px;overflow:hidden}
+.markdown:not(code) span.float-right>span{display:block;margin:13px auto 0;overflow:hidden;text-align:right}
+.markdown:not(code) code,.markdown:not(code) tt{padding:.2em 0;margin:0;font-size:85%;background-color:rgba(0,0,0,.04);border-radius:3px}
+.markdown:not(code) code:after,.markdown:not(code) code:before,.markdown:not(code) tt:after,.markdown:not(code) tt:before{letter-spacing:-.2em;content:"\00a0"}
+.markdown:not(code) code br,.markdown:not(code) tt br{display:none}
+.markdown:not(code) del code{text-decoration:inherit}
+.markdown:not(code) pre>code{padding:0;margin:0;font-size:100%;word-break:normal;white-space:pre;background:0 0;border:0}
+.markdown:not(code) .highlight{margin-bottom:16px}
+.markdown:not(code) .highlight pre,.markdown:not(code) pre{padding:16px;overflow:auto;font-size:85%;line-height:1.45;background-color:#f7f7f7;border-radius:3px}
+.markdown:not(code) .highlight pre{margin-bottom:0;word-break:normal}
+.markdown:not(code) pre{word-wrap:normal}
+.markdown:not(code) pre code,.markdown:not(code) pre tt{display:inline;max-width:initial;padding:0;margin:0;overflow:initial;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}
+.markdown:not(code) pre code:after,.markdown:not(code) pre code:before,.markdown:not(code) pre tt:after,.markdown:not(code) pre tt:before{content:normal}
+.markdown:not(code) kbd{display:inline-block;padding:3px 5px;font-size:11px;line-height:10px;color:#555;vertical-align:middle;background-color:#fcfcfc;border:solid 1px #ccc;border-bottom-color:#bbb;border-radius:3px;box-shadow:inset 0 -1px 0 #bbb}
+.markdown:not(code) input[type=checkbox]{vertical-align:middle!important}
+.markdown:not(code) .csv-data td,.markdown:not(code) .csv-data th{padding:5px;overflow:hidden;font-size:12px;line-height:1;text-align:left;white-space:nowrap}
+.markdown:not(code) .csv-data .blob-num{padding:10px 8px 9px;text-align:right;background:#fff;border:0}
+.markdown:not(code) .csv-data tr{border-top:0}
+.markdown:not(code) .csv-data th{font-weight:700;background:#f8f8f8;border-top:0}
+.markdown:not(code) .ui.list .list,.markdown:not(code) ol.ui.list ol,.markdown:not(code) ul.ui.list ul{padding-left:2em}
+.home .logo{max-width:220px}
+@media only screen and (max-width:767px){.home .hero h1{font-size:3.5em}
+.home .hero h2{font-size:2em}
+}
+@media only screen and (min-width:768px){.home .hero h1{font-size:5.5em}
+.home .hero h2{font-size:3em}
+}
+.home .hero .octicon{color:#5aa509;font-size:40px;width:50px}
+.home .hero.header{font-size:20px}
+.home p.large{font-size:16px}
+.home .stackable{padding-top:30px}
+.home a{color:#5aa509}
+.signup{padding-top:15px}
+@media only screen and (max-width:880px){footer .ui.container .left,footer .ui.container .right{display:block;text-align:center;float:none}
+}
+.install{padding-top:45px}
+.install form label{text-align:right;width:320px!important}
+.install form input{width:35%!important}
+.install form .field{text-align:left}
+.install form .field .help{margin-left:335px!important}
+.install form .field.optional .title{margin-left:38%}
+.install .ui .checkbox{margin-left:40%!important}
+.install .ui .checkbox label{width:auto!important}
+.form .help{color:#999;padding-top:.6em;padding-bottom:.6em;display:inline-block}
+.ui.attached.header{background:#f0f0f0}
+.ui.attached.header .right{margin-top:-5px}
+.ui.attached.header .right .button{padding:8px 10px;font-weight:400}
+#create-page-form form{margin:auto}
+#create-page-form form .ui.message{text-align:center}
+@media only screen and (min-width:768px){#create-page-form form{width:800px!important}
+#create-page-form form .header{padding-left:280px!important}
+#create-page-form form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}
+#create-page-form form .help{margin-left:265px!important}
+#create-page-form form .optional .title{margin-left:250px!important}
+#create-page-form form input,#create-page-form form textarea{width:50%!important}
+}
+@media only screen and (max-width:767px){#create-page-form form .optional .title{margin-left:15px}
+#create-page-form form .inline.field>label{display:block}
+}
+.signin .oauth2 div{display:inline-block}
+.signin .oauth2 div p{margin:10px 5px 0 0;float:left}
+.signin .oauth2 a{margin-right:3px}
+.signin .oauth2 a:last-child{margin-right:0}
+.signin .oauth2 img{width:32px;height:32px}
+.signin .oauth2 img.openidConnect{width:auto}
+@media only screen and (min-width:768px){.g-recaptcha{margin:0 auto!important;width:304px;padding-left:30px}
+}
+@media screen and (max-height:575px){#rc-imageselect,.g-recaptcha{transform:scale(.77);transform-origin:0 0}
+}
+.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{margin:auto}
+.user.activate form .ui.message,.user.forgot.password form .ui.message,.user.reset.password form .ui.message,.user.signin form .ui.message,.user.signup form .ui.message{text-align:center}
+@media only screen and (min-width:768px){.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{width:800px!important}
+.user.activate form .header,.user.forgot.password form .header,.user.reset.password form .header,.user.signin form .header,.user.signup form .header{padding-left:280px!important}
+.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}
+.user.activate form .help,.user.forgot.password form .help,.user.reset.password form .help,.user.signin form .help,.user.signup form .help{margin-left:265px!important}
+.user.activate form .optional .title,.user.forgot.password form .optional .title,.user.reset.password form .optional .title,.user.signin form .optional .title,.user.signup form .optional .title{margin-left:250px!important}
+.user.activate form input,.user.activate form textarea,.user.forgot.password form input,.user.forgot.password form textarea,.user.reset.password form input,.user.reset.password form textarea,.user.signin form input,.user.signin form textarea,.user.signup form input,.user.signup form textarea{width:50%!important}
+}
+@media only screen and (max-width:767px){.user.activate form .optional .title,.user.forgot.password form .optional .title,.user.reset.password form .optional .title,.user.signin form .optional .title,.user.signup form .optional .title{margin-left:15px}
+.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{display:block}
+}
+.user.activate form,.user.forgot.password form,.user.reset.password form,.user.signin form,.user.signup form{width:700px!important}
+.user.activate form .header,.user.forgot.password form .header,.user.reset.password form .header,.user.signin form .header,.user.signup form .header{padding-left:0!important;text-align:center}
+.user.activate form .inline.field>label,.user.forgot.password form .inline.field>label,.user.reset.password form .inline.field>label,.user.signin form .inline.field>label,.user.signup form .inline.field>label{width:200px}
+@media only screen and (max-width:768px){.user.activate form .inline.field>label,.user.activate form input,.user.forgot.password form .inline.field>label,.user.forgot.password form input,.user.reset.password form .inline.field>label,.user.reset.password form input,.user.signin form .inline.field>label,.user.signin form input,.user.signup form .inline.field>label,.user.signup form input{width:100%!important}
+}
+.repository.new.fork form,.repository.new.migrate form,.repository.new.repo form{margin:auto}
+.repository.new.fork form .ui.message,.repository.new.migrate form .ui.message,.repository.new.repo form .ui.message{text-align:center}
+@media only screen and (min-width:768px){.repository.new.fork form,.repository.new.migrate form,.repository.new.repo form{width:800px!important}
+.repository.new.fork form .header,.repository.new.migrate form .header,.repository.new.repo form .header{padding-left:280px!important}
+.repository.new.fork form .inline.field>label,.repository.new.migrate form .inline.field>label,.repository.new.repo form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}
+.repository.new.fork form .help,.repository.new.migrate form .help,.repository.new.repo form .help{margin-left:265px!important}
+.repository.new.fork form .optional .title,.repository.new.migrate form .optional .title,.repository.new.repo form .optional .title{margin-left:250px!important}
+.repository.new.fork form input,.repository.new.fork form textarea,.repository.new.migrate form input,.repository.new.migrate form textarea,.repository.new.repo form input,.repository.new.repo form textarea{width:50%!important}
+}
+@media only screen and (max-width:767px){.repository.new.fork form .optional .title,.repository.new.migrate form .optional .title,.repository.new.repo form .optional .title{margin-left:15px}
+.repository.new.fork form .inline.field>label,.repository.new.migrate form .inline.field>label,.repository.new.repo form .inline.field>label{display:block}
+}
+.repository.new.fork form .dropdown .dropdown.icon,.repository.new.migrate form .dropdown .dropdown.icon,.repository.new.repo form .dropdown .dropdown.icon{margin-top:-7px!important;padding-bottom:5px}
+.repository.new.fork form .dropdown .text,.repository.new.migrate form .dropdown .text,.repository.new.repo form .dropdown .text{margin-right:0!important}
+.repository.new.fork form .dropdown .text i,.repository.new.migrate form .dropdown .text i,.repository.new.repo form .dropdown .text i{margin-right:0!important}
+.repository.new.fork form .header,.repository.new.migrate form .header,.repository.new.repo form .header{padding-left:0!important;text-align:center}
+@media only screen and (max-width:768px){.repository.new.fork form .selection.dropdown,.repository.new.fork form input,.repository.new.fork form label,.repository.new.migrate form .selection.dropdown,.repository.new.migrate form input,.repository.new.migrate form label,.repository.new.repo form .selection.dropdown,.repository.new.repo form input,.repository.new.repo form label{width:100%!important}
+.repository.new.fork form .field a,.repository.new.fork form .field button,.repository.new.migrate form .field a,.repository.new.migrate form .field button,.repository.new.repo form .field a,.repository.new.repo form .field button{margin-bottom:1em;width:100%}
+}
+@media only screen and (min-width:768px){.repository.new.repo .ui.form #auto-init{margin-left:265px!important}
+}
+.repository.new.repo .ui.form .selection.dropdown:not(.owner){width:50%!important}
+@media only screen and (max-width:768px){.repository.new.repo .ui.form .selection.dropdown:not(.owner){width:100%!important}
+}
+.new.webhook form .help{margin-left:25px}
+.new.webhook .events.fields .column{padding-left:40px}
+.githook textarea{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+@media only screen and (max-width:768px){.new.org .ui.form .field a,.new.org .ui.form .field button{margin-bottom:1em;width:100%}
+.new.org .ui.form .field input{width:100%!important}
+}
+.repository{padding-top:15px}
+.repository .repo-header .ui.compact.menu{margin-left:1rem}
+.repository .repo-header .ui.header{margin-top:0}
+.repository .repo-header .mega-octicon{width:30px;font-size:30px}
+.repository .repo-header .ui.huge.breadcrumb{font-weight:400;font-size:1.5rem}
+.repository .repo-header .fork-flag{margin-left:36px;margin-top:3px;display:block;font-size:12px;white-space:nowrap}
+.repository .repo-header .octicon.octicon-repo-forked{margin-top:-1px;font-size:15px}
+.repository .repo-header .button{margin-top:2px;margin-bottom:2px}
+.repository .tabs .navbar{justify-content:initial}
+.repository .navbar{display:flex;justify-content:space-between}
+.repository .navbar .ui.label{margin-left:7px;padding:3px 5px}
+.repository .owner.dropdown{min-width:40%!important}
+.repository #file-buttons{margin-left:auto!important;font-weight:400}
+.repository #file-buttons .ui.button{padding:8px 10px;font-weight:400}
+.repository .metas .menu{max-height:300px;overflow-x:auto}
+.repository .metas .ui.list .hide{display:none!important}
+.repository .metas .ui.list .item{padding:0}
+.repository .metas .ui.list .label.color{padding:0 8px;margin-right:5px}
+.repository .metas .ui.list a{margin:2px 0}
+.repository .metas .ui.list a .text{color:#444}
+.repository .metas .ui.list a .text:hover{color:#000}
+.repository .metas #deadlineForm input{width:12.8rem;border-radius:4px 0 0 4px;border-right:0;white-space:nowrap}
+.repository .header-wrapper{background-color:#FAFAFA;margin-top:-15px;padding-top:15px}
+.repository .header-wrapper .ui.tabs.divider{border-bottom:none}
+.repository .header-wrapper .ui.tabular .octicon{margin-right:5px}
+.repository .filter.menu .label.color{border-radius:3px;margin-left:15px;padding:0 8px}
+.repository .filter.menu .octicon{float:left;margin:5px -7px 0 -5px;width:16px}
+.repository .filter.menu.labels .octicon{margin:-2px -7px 0 -5px}
+.repository .filter.menu .text{margin-left:.9em}
+.repository .filter.menu .menu{max-height:300px;overflow-x:auto;right:0!important;left:auto!important}
+.repository .filter.menu .dropdown.item{margin:1px;padding-right:0}
+.repository .select-label .item{max-width:250px;overflow:hidden;text-overflow:ellipsis}
+.repository .select-label .desc{padding-left:16px}
+.repository .ui.tabs.container{margin-top:14px;margin-bottom:0}
+.repository .ui.tabs.container .ui.menu{border-bottom:none}
+.repository .ui.tabs.divider{margin-top:0;margin-bottom:20px}
+.repository #clone-panel{width:350px}
+@media only screen and (max-width:768px){.repository #clone-panel{width:100%}
+}
+.repository #clone-panel input{border-radius:0;padding:5px 10px;width:50%}
+.repository #clone-panel .clone.button{font-size:13px;padding:0 5px}
+.repository #clone-panel .clone.button:first-child{border-radius:.28571429rem 0 0 .28571429rem}
+.repository #clone-panel .icon.button{padding:0 10px}
+.repository #clone-panel .dropdown .menu{right:0!important;left:auto!important}
+.repository.file.list .repo-description{display:flex;justify-content:space-between;align-items:center}
+.repository.file.list #repo-desc{font-size:1.2em}
+.repository.file.list .choose.reference .header .icon{font-size:1.4em}
+.repository.file.list .repo-path .divider,.repository.file.list .repo-path .section{display:inline}
+.repository.file.list #file-buttons{font-weight:400}
+.repository.file.list #file-buttons .ui.button{padding:8px 10px;font-weight:400}
+@media only screen and (max-width:768px){.repository.file.list #file-buttons .ui.tiny.blue.buttons{width:100%}
+}
+.repository.file.list #repo-files-table thead th{padding-top:8px;padding-bottom:5px;font-weight:400}
+.repository.file.list #repo-files-table thead .ui.avatar{margin-bottom:5px}
+.repository.file.list #repo-files-table tbody .octicon{margin-left:3px;margin-right:5px;color:#777}
+.repository.file.list #repo-files-table tbody .octicon.octicon-mail-reply{margin-right:10px}
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule,.repository.file.list #repo-files-table tbody .octicon.octicon-file-symlink-directory{color:#1e70bf}
+.repository.file.list #repo-files-table td{padding-top:8px;padding-bottom:8px;overflow:initial}
+.repository.file.list #repo-files-table td.name{max-width:150px}
+.repository.file.list #repo-files-table td.message{max-width:400px}
+.repository.file.list #repo-files-table td.age{width:120px}
+.repository.file.list #repo-files-table td .truncate{display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis;vertical-align:top;white-space:nowrap}
+.repository.file.list #repo-files-table td.message .isSigned{cursor:default}
+.repository.file.list #repo-files-table tr:hover{background-color:#ffE}
+.repository.file.list #repo-files-table .jumpable-path{color:#888}
+.repository.file.list .non-diff-file-content .header .icon{font-size:1em}
+.repository.file.list .non-diff-file-content .header .file-actions{margin-top:0;margin-bottom:-5px;padding-left:20px}
+.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon{display:inline-block;padding:5px;margin-left:5px;line-height:1;color:#767676;vertical-align:middle;background:0 0;border:0;outline:0}
+.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon:hover{color:#4078c0}
+.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon-danger:hover{color:#bd2c00}
+.repository.file.list .non-diff-file-content .header .file-actions .btn-octicon.disabled{color:#bbb;cursor:default}
+.repository.file.list .non-diff-file-content .header .file-actions #delete-file-form{display:inline-block}
+.repository.file.list .non-diff-file-content .view-raw{padding:5px}
+.repository.file.list .non-diff-file-content .view-raw *{max-width:100%}
+.repository.file.list .non-diff-file-content .view-raw img{padding:5px 5px 0 5px}
+.repository.file.list .non-diff-file-content .plain-text{padding:1em 2em 1em 2em}
+.repository.file.list .non-diff-file-content pre{overflow:auto}
+.repository.file.list .non-diff-file-content .code-view *{font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}
+.repository.file.list .non-diff-file-content .code-view table{width:100%}
+.repository.file.list .non-diff-file-content .code-view .lines-num{vertical-align:top;text-align:right;color:#999;background:#f5f5f5;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+.repository.file.list .non-diff-file-content .code-view .lines-num span{line-height:20px;padding:0 10px;cursor:pointer;display:block}
+.repository.file.list .non-diff-file-content .code-view .lines-code,.repository.file.list .non-diff-file-content .code-view .lines-num{padding:0}
+.repository.file.list .non-diff-file-content .code-view .lines-code .hljs,.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-code pre,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs,.repository.file.list .non-diff-file-content .code-view .lines-num ol,.repository.file.list .non-diff-file-content .code-view .lines-num pre{background-color:#fff;margin:0;padding:0!important}
+.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-code ol li,.repository.file.list .non-diff-file-content .code-view .lines-code pre li,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-num ol li,.repository.file.list .non-diff-file-content .code-view .lines-num pre li{display:block;width:100%}
+.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-code ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-code pre li.active,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-num ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-num pre li.active{background:#ffd}
+.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-code ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-code pre li:before,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-num ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-num pre li:before{content:' '}
+.repository.file.list .non-diff-file-content .code-view .lines-commit{vertical-align:top;color:#999;padding:0;background:#f5f5f5;width:1%;-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none}
+.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info{width:350px;max-width:350px;display:block;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;padding:0 0 0 10px}
+.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data{display:flex;font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial}
+.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-message{flex-grow:2;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;line-height:20px}
+.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-avatar,.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-time{flex-shrink:0}
+.repository.file.list .non-diff-file-content .code-view .lines-commit .ui.avatar.image{height:18px;width:18px}
+.repository.file.list .non-diff-file-content .code-view .lines-code .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-commit .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-num .bottom-line{border-bottom:1px solid #eaecef}
+.repository.file.list .non-diff-file-content .code-view .active{background:#ffd}
+.repository.file.list .sidebar{padding-left:0}
+.repository.file.list .sidebar .octicon{width:16px}
+.repository.file.editor .treepath{width:100%}
+.repository.file.editor .treepath input{vertical-align:middle;box-shadow:rgba(0,0,0,.0745098) 0 1px 2px inset;width:inherit;padding:7px 8px;margin-right:5px}
+.repository.file.editor .tabular.menu .octicon{margin-right:5px}
+.repository.file.editor .commit-form-wrapper{padding-left:64px}
+.repository.file.editor .commit-form-wrapper .commit-avatar{float:left;margin-left:-64px;width:3em;height:auto}
+.repository.file.editor .commit-form-wrapper .commit-form{position:relative;padding:15px;margin-bottom:10px;border:1px solid #ddd;border-radius:3px}
+.repository.file.editor .commit-form-wrapper .commit-form:after,.repository.file.editor .commit-form-wrapper .commit-form:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+.repository.file.editor .commit-form-wrapper .commit-form:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+.repository.file.editor .commit-form-wrapper .commit-form:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+.repository.file.editor .commit-form-wrapper .commit-form:after{border-right-color:#fff}
+.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .branch-name{display:inline-block;padding:3px 6px;font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.65);background-color:rgba(209,227,237,.45);border-radius:3px}
+.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .new-branch-name-input{position:relative;margin-left:25px}
+.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .new-branch-name-input input{width:240px!important;padding-left:26px!important}
+.repository.file.editor .commit-form-wrapper .commit-form .quick-pull-choice .octicon-git-branch{position:absolute;top:9px;left:10px;color:#b0c4ce}
+.repository.options #interval{width:100px!important;min-width:100px}
+.repository.options .danger .item{padding:20px 15px}
+.repository.options .danger .ui.divider{margin:0}
+.repository.new.issue .comment.form .comment .avatar{width:3em}
+.repository.new.issue .comment.form .content{margin-left:4em}
+.repository.new.issue .comment.form .content:after,.repository.new.issue .comment.form .content:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+.repository.new.issue .comment.form .content:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+.repository.new.issue .comment.form .content:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+.repository.new.issue .comment.form .content:after{border-right-color:#fff}
+.repository.new.issue .comment.form .content .markdown{font-size:14px}
+.repository.new.issue .comment.form .metas{min-width:220px}
+.repository.new.issue .comment.form .metas .filter.menu{max-height:300px;overflow-x:auto}
+.repository.view.issue .title{padding-bottom:0!important}
+.repository.view.issue .title h1{font-weight:300;font-size:2.3rem;margin-bottom:5px}
+.repository.view.issue .title h1 .ui.input{font-size:.5em;vertical-align:top;width:50%;min-width:600px}
+.repository.view.issue .title h1 .ui.input input{font-size:1.5em;padding:6px 10px}
+.repository.view.issue .title .index{font-weight:300;color:#aaa;letter-spacing:-1px}
+.repository.view.issue .title .label{margin-right:10px}
+.repository.view.issue .title .edit-zone{margin-top:10px}
+.repository.view.issue .pull-desc code{color:#0166E6}
+.repository.view.issue .pull.tabular.menu{margin-bottom:10px}
+.repository.view.issue .pull.tabular.menu .octicon{margin-right:5px}
+.repository.view.issue .pull.tab.segment{border:none;padding:10px 0 0;box-shadow:none;background-color:inherit}
+.repository.view.issue .pull .merge.box .avatar{margin-left:10px;margin-top:10px}
+.repository.view.issue .pull .review-item .avatar,.repository.view.issue .pull .review-item .type-icon{float:none;display:inline-block;text-align:center;vertical-align:middle}
+.repository.view.issue .pull .review-item .avatar .octicon,.repository.view.issue .pull .review-item .type-icon .octicon{width:23px;font-size:23px;margin-top:.45em}
+.repository.view.issue .pull .review-item .text{margin:.3em 0 .5em .5em}
+.repository.view.issue .pull .review-item .type-icon{float:right;margin-right:1em}
+.repository.view.issue .pull .review-item .divider{margin:.5rem 0}
+.repository.view.issue .pull .review-item .review-content{padding:1em 0 1em 3.8em}
+.repository.view.issue .comment-list:before{display:block;content:"";position:absolute;margin-top:12px;margin-bottom:14px;top:0;bottom:0;left:96px;width:2px;background-color:#f3f3f3;z-index:-1}
+.repository.view.issue .comment-list .comment .avatar{width:3em}
+.repository.view.issue .comment-list .comment .tag{color:#767676;margin-top:3px;padding:2px 5px;font-size:12px;border:1px solid rgba(0,0,0,.1);border-radius:3px}
+.repository.view.issue .comment-list .comment .actions .item{float:left}
+.repository.view.issue .comment-list .comment .actions .item.tag{margin-right:5px}
+.repository.view.issue .comment-list .comment .actions .item.action{margin-top:6px;margin-left:10px}
+.repository.view.issue .comment-list .comment .content{margin-left:4em}
+.repository.view.issue .comment-list .comment .content>.header{font-weight:400;padding:auto 15px;position:relative;color:#767676;background-color:#f7f7f7;border-bottom:1px solid #eee;border-top-left-radius:3px;border-top-right-radius:3px}
+.repository.view.issue .comment-list .comment .content>.header:after,.repository.view.issue .comment-list .comment .content>.header:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+.repository.view.issue .comment-list .comment .content>.header:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+.repository.view.issue .comment-list .comment .content>.header:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+.repository.view.issue .comment-list .comment .content>.header .text{max-width:78%;padding-top:10px;padding-bottom:10px}
+.repository.view.issue .comment-list .comment .content .markdown{font-size:14px}
+.repository.view.issue .comment-list .comment .content .no-content{color:#767676;font-style:italic}
+.repository.view.issue .comment-list .comment .content>.bottom.segment{background:#f3f4f5}
+.repository.view.issue .comment-list .comment .content>.bottom.segment .ui.images::after{clear:both;content:' ';display:block}
+.repository.view.issue .comment-list .comment .content>.bottom.segment a{display:block;float:left;margin:5px;padding:5px;height:150px;border:solid 1px #eee;border-radius:3px;max-width:150px;background-color:#fff}
+.repository.view.issue .comment-list .comment .content>.bottom.segment a:before{content:' ';display:inline-block;height:100%;vertical-align:middle}
+.repository.view.issue .comment-list .comment .content>.bottom.segment .ui.image{max-height:100%;width:auto;margin:0;vertical-align:middle}
+.repository.view.issue .comment-list .comment .content>.bottom.segment span.ui.image{font-size:128px;color:#000}
+.repository.view.issue .comment-list .comment .content>.bottom.segment span.ui.image:hover{color:#000}
+.repository.view.issue .comment-list .comment .ui.form .field:first-child{clear:none}
+.repository.view.issue .comment-list .comment .ui.form .tab.segment{border:none;padding:10px 0 0}
+.repository.view.issue .comment-list .comment .ui.form textarea{height:200px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+.repository.view.issue .comment-list .comment .edit.buttons{margin-top:10px}
+.repository.view.issue .comment-list .event{position:relative;margin:15px 0 15px 79px;padding-left:25px}
+.repository.view.issue .comment-list .event .octicon{width:30px;float:left;text-align:center}
+.repository.view.issue .comment-list .event .octicon.octicon-circle-slash{margin-top:5px;margin-left:-34.5px;font-size:20px;color:#bd2c00}
+.repository.view.issue .comment-list .event .octicon.octicon-primitive-dot{margin-left:-28.5px;margin-right:-1px;font-size:30px;color:#6cc644}
+.repository.view.issue .comment-list .event .octicon.octicon-bookmark{margin-top:3px;margin-left:-31px;margin-right:-1px;font-size:25px}
+.repository.view.issue .comment-list .event .octicon.octicon-comment{margin-top:4px;margin-left:-35px;font-size:24px}
+.repository.view.issue .comment-list .event .octicon.octicon-eye{margin-top:3px;margin-left:-35px;margin-right:0;font-size:22px}
+.repository.view.issue .comment-list .event .octicon.octicon-x{margin-left:-33px;font-size:25px}
+.repository.view.issue .comment-list .event .detail{font-size:.9rem;margin-top:5px;margin-left:35px}
+.repository.view.issue .comment-list .event .detail .octicon.octicon-git-commit{margin-top:2px}
+.repository.view.issue .ui.segment.metas{margin-top:-3px}
+.repository.view.issue .ui.participants img{margin-top:5px;margin-right:5px}
+.repository.view.issue .ui.depending .item.is-closed .title{text-decoration:line-through}
+.repository .comment.form .ui.comments{margin-top:-12px;max-width:100%}
+.repository .comment.form .content .field:first-child{clear:none}
+.repository .comment.form .content .form:after,.repository .comment.form .content .form:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+.repository .comment.form .content .form:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+.repository .comment.form .content .form:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+.repository .comment.form .content .form:after{border-right-color:#fff}
+.repository .comment.form .content .tab.segment{border:none;padding:10px 0 0}
+.repository .comment.form .content textarea{height:200px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+.repository .label.list{list-style:none;padding-top:15px}
+.repository .label.list .item{padding-top:10px;padding-bottom:10px;border-bottom:1px dashed #AAA}
+.repository .label.list .item a{font-size:15px;padding-top:5px;padding-right:10px;color:#666}
+.repository .label.list .item a:hover{color:#000}
+.repository .label.list .item a.open-issues{margin-right:30px}
+.repository .label.list .item .ui.label{font-size:1em}
+.repository .milestone.list{list-style:none;padding-top:15px}
+.repository .milestone.list>.item{padding-top:10px;padding-bottom:10px;border-bottom:1px dashed #AAA}
+.repository .milestone.list>.item>a{padding-top:5px;padding-right:10px;color:#000}
+.repository .milestone.list>.item>a:hover{color:#4078c0}
+.repository .milestone.list>.item .ui.progress{width:40%;padding:0;border:0;margin:0}
+.repository .milestone.list>.item .ui.progress .bar{height:20px}
+.repository .milestone.list>.item .meta{color:#999;padding-top:5px}
+.repository .milestone.list>.item .meta .issue-stats .octicon{padding-left:5px}
+.repository .milestone.list>.item .meta .overdue{color:red}
+.repository .milestone.list>.item .operate{margin-top:-15px}
+.repository .milestone.list>.item .operate>a{font-size:15px;padding-top:5px;padding-right:10px;color:#666}
+.repository .milestone.list>.item .operate>a:hover{color:#000}
+.repository .milestone.list>.item .content{padding-top:10px}
+.repository.new.milestone textarea{height:200px}
+.repository.new.milestone #deadline{width:150px}
+.repository.compare.pull .choose.branch .octicon{padding-right:10px}
+.repository.compare.pull .comment.form .content:after,.repository.compare.pull .comment.form .content:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+.repository.compare.pull .comment.form .content:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+.repository.compare.pull .comment.form .content:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+.repository.compare.pull .comment.form .content:after{border-right-color:#fff}
+.repository .filter.dropdown .menu{margin-top:1px!important}
+.repository.branches .commit-divergence .bar-group{position:relative;float:left;padding-bottom:6px;width:90px}
+.repository.branches .commit-divergence .bar-group:last-child{border-left:1px solid #b4b4b4}
+.repository.branches .commit-divergence .count{margin:0 3px}
+.repository.branches .commit-divergence .count.count-ahead{text-align:left}
+.repository.branches .commit-divergence .count.count-behind{text-align:right}
+.repository.branches .commit-divergence .bar{height:4px;position:absolute;background-color:#d4d4d5}
+.repository.branches .commit-divergence .bar.bar-behind{right:0}
+.repository.branches .commit-divergence .bar.bar-ahead{left:0}
+.repository.commits .header .search input{font-weight:400;padding:5px 10px}
+.repository #commits-table thead th:first-of-type{padding-left:15px}
+.repository #commits-table thead .sha{width:140px}
+.repository #commits-table thead .shatd{text-align:center}
+.repository #commits-table td.sha .sha.label{margin:0}
+.repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n){background-color:rgba(0,0,0,.02)!important}
+.repository #commits-table td.sha .sha.label.isSigned,.repository #repo-files-table .sha.label.isSigned{border:1px solid #BBB}
+.repository #commits-table td.sha .sha.label.isSigned .detail.icon,.repository #repo-files-table .sha.label.isSigned .detail.icon{background:#FAFAFA;margin:-6px -10px -4px 0;padding:5px 3px 5px 6px;border-left:1px solid #BBB;border-top-left-radius:0;border-bottom-left-radius:0}
+.repository #commits-table td.sha .sha.label.isSigned.isVerified,.repository #repo-files-table .sha.label.isSigned.isVerified{border:1px solid #21BA45;background:rgba(33,186,69,.1)}
+.repository #commits-table td.sha .sha.label.isSigned.isVerified .detail.icon,.repository #repo-files-table .sha.label.isSigned.isVerified .detail.icon{border-left:1px solid rgba(33,186,69,.5)}
+.repository .diff-detail-box{padding:7px 0;background:#fff;line-height:30px}
+.repository .diff-detail-box>div:after{clear:both;content:"";display:block}
+.repository .diff-detail-box ol{clear:both;padding-left:0;margin-top:5px;margin-bottom:28px}
+.repository .diff-detail-box ol li{list-style:none;padding-bottom:4px;margin-bottom:4px;border-bottom:1px dashed #DDD;padding-left:6px}
+.repository .diff-detail-box span.status{display:inline-block;width:12px;height:12px;margin-right:8px;vertical-align:middle}
+.repository .diff-detail-box span.status.modify{background-color:#f0db88}
+.repository .diff-detail-box span.status.add{background-color:#b4e2b4}
+.repository .diff-detail-box span.status.del{background-color:#e9aeae}
+.repository .diff-detail-box span.status.rename{background-color:#dad8ff}
+.repository .diff-detail-box .detail-files{background:#fff;margin:0}
+.repository .diff-box .header{display:flex;align-items:center}
+.repository .diff-box .header .count{margin-right:12px;font-size:13px;flex:0 0 auto}
+.repository .diff-box .header .count .bar{background-color:#bd2c00;height:12px;width:40px;display:inline-block;margin:2px 4px 0 4px;vertical-align:text-top}
+.repository .diff-box .header .count .bar .add{background-color:#55a532;height:12px}
+.repository .diff-box .header .file{flex:1;color:#888;word-break:break-all}
+.repository .diff-box .header .button{margin:-5px 0 -5px 12px;padding:8px 10px;flex:0 0 auto}
+.repository .diff-file-box .header{background-color:#f7f7f7}
+.repository .diff-file-box .file-body.file-code .lines-num{text-align:right;color:#A7A7A7;background:#fafafa;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:top}
+.repository .diff-file-box .file-body.file-code .lines-num span.fold{display:block;text-align:center}
+.repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #DDD}
+.repository .diff-file-box .code-diff{font-size:12px}
+.repository .diff-file-box .code-diff td{padding:0 0 0 10px;border-top:none}
+.repository .diff-file-box .code-diff pre{margin:0}
+.repository .diff-file-box .code-diff .lines-num{border-color:#d4d4d5;border-right-width:1px;border-right-style:solid;padding:0 5px}
+.repository .diff-file-box .code-diff tbody tr td.halfwidth{width:49%}
+.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#F0F0F0!important;border-color:#D2CECE!important;padding-top:8px;padding-bottom:8px}
+.repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#f99}
+.repository .diff-file-box .code-diff tbody tr .added-code{background-color:#9f9}
+.repository .diff-file-box .code-diff-unified tbody tr.del-code td{background-color:#ffe0e0!important;border-color:#f1c0c0!important}
+.repository .diff-file-box .code-diff-unified tbody tr.add-code td{background-color:#d6fcd6!important;border-color:#c1e9c1!important}
+.repository .diff-file-box .code-diff-split table,.repository .diff-file-box .code-diff-split tbody{width:100%}
+.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(4){background-color:#fafafa}
+.repository .diff-file-box .code-diff-split tbody tr td.del-code,.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(2){background-color:#ffe0e0!important;border-color:#f1c0c0!important}
+.repository .diff-file-box .code-diff-split tbody tr td.add-code,.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(4){background-color:#d6fcd6!important;border-color:#c1e9c1!important}
+.repository .diff-file-box .code-diff-split tbody tr td:nth-child(3){border-left-width:1px;border-left-style:solid}
+.repository .diff-file-box.file-content{clear:right}
+.repository .diff-file-box.file-content img{max-width:100%;padding:5px 5px 0 5px}
+.repository .code-view{overflow:auto;overflow-x:auto;overflow-y:hidden}
+.repository .repo-search-result{padding-top:10px;padding-bottom:10px}
+.repository .repo-search-result .lines-num a{color:inherit}
+.repository.quickstart .guide .item{padding:1em}
+.repository.quickstart .guide .item small{font-weight:400}
+.repository.quickstart .guide .clone.button:first-child{border-radius:.28571429rem 0 0 .28571429rem}
+.repository.quickstart .guide .ui.action.small.input{width:100%}
+.repository.quickstart .guide #repo-clone-url{border-radius:0;padding:5px 10px;font-size:1.2em}
+.repository.release #release-list{border-top:1px solid #DDD;margin-top:20px;padding-top:15px}
+.repository.release #release-list>li{list-style:none}
+.repository.release #release-list>li .detail,.repository.release #release-list>li .meta{padding-top:30px;padding-bottom:40px}
+.repository.release #release-list>li .meta{text-align:right;position:relative}
+.repository.release #release-list>li .meta .tag:not(.icon){display:block;margin-top:15px}
+.repository.release #release-list>li .meta .commit{display:block;margin-top:10px}
+.repository.release #release-list>li .detail{border-left:1px solid #DDD}
+.repository.release #release-list>li .detail .author img{margin-bottom:-3px}
+.repository.release #release-list>li .detail .download{margin-top:20px}
+.repository.release #release-list>li .detail .download>a .octicon{margin-left:5px;margin-right:5px}
+.repository.release #release-list>li .detail .download .list{padding-left:0;border-top:1px solid #eee}
+.repository.release #release-list>li .detail .download .list li{list-style:none;display:block;padding-top:8px;padding-bottom:8px;border-bottom:1px solid #eee}
+.repository.release #release-list>li .detail .dot{width:9px;height:9px;background-color:#ccc;z-index:999;position:absolute;display:block;left:-5px;top:40px;border-radius:6px;border:1px solid #FFF}
+.repository.new.release .target{min-width:500px}
+.repository.new.release .target #tag-name{margin-top:-4px}
+.repository.new.release .target .at{margin-left:-5px;margin-right:5px}
+.repository.new.release .target .dropdown.icon{margin:0;padding-top:3px}
+.repository.new.release .target .selection.dropdown{padding-top:10px;padding-bottom:10px}
+.repository.new.release .prerelease.field{margin-bottom:0}
+@media only screen and (max-width:438px){.repository.new.release .field button,.repository.new.release .field input{width:100%}
+}
+@media only screen and (max-width:768px){.repository.new.release .field button{margin-bottom:1em}
+}
+.repository.forks .list{margin-top:0}
+.repository.forks .list .item{padding-top:10px;padding-bottom:10px;border-bottom:1px solid #DDD}
+.repository.forks .list .item .ui.avatar{float:left;margin-right:5px}
+.repository.forks .list .item .link{padding-top:5px}
+.repository.wiki.start .ui.segment{padding-top:70px;padding-bottom:100px}
+.repository.wiki.start .ui.segment .mega-octicon{font-size:48px}
+.repository.wiki.new .CodeMirror .CodeMirror-code{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+.repository.wiki.new .CodeMirror .CodeMirror-code .cm-comment{background:inherit}
+.repository.wiki.new .editor-preview{background-color:#fff}
+.repository.wiki.view .choose.page{margin-top:-5px}
+.repository.wiki.view .ui.sub.header{text-transform:none}
+.repository.wiki.view>.markdown{padding:15px 30px}
+.repository.wiki.view>.markdown h1:first-of-type,.repository.wiki.view>.markdown h2:first-of-type,.repository.wiki.view>.markdown h3:first-of-type,.repository.wiki.view>.markdown h4:first-of-type,.repository.wiki.view>.markdown h5:first-of-type,.repository.wiki.view>.markdown h6:first-of-type{margin-top:0}
+@media only screen and (max-width:767px){.repository.wiki .dividing.header .stackable.grid .button{margin-top:2px;margin-bottom:2px}
+}
+.repository.settings.collaboration .collaborator.list{padding:0}
+.repository.settings.collaboration .collaborator.list>.item{margin:0;line-height:2em}
+.repository.settings.collaboration .collaborator.list>.item:not(:last-child){border-bottom:1px solid #DDD}
+.repository.settings.collaboration #repo-collab-form #search-user-box .results{left:7px}
+.repository.settings.collaboration #repo-collab-form .ui.button{margin-left:5px;margin-top:-3px}
+.repository.settings.branches .protected-branches .selection.dropdown{width:300px}
+.repository.settings.branches .protected-branches .item{border:1px solid #eaeaea;padding:10px 15px}
+.repository.settings.branches .protected-branches .item:not(:last-child){border-bottom:0}
+.repository.settings.branches .branch-protection .help{margin-left:26px;padding-top:0}
+.repository.settings.branches .branch-protection .fields{margin-left:20px;display:block}
+.repository.settings.branches .branch-protection .whitelist{margin-left:26px}
+.repository.settings.branches .branch-protection .whitelist .dropdown img{display:inline-block}
+.repository.settings.webhook .events .column{padding-bottom:0}
+.repository.settings.webhook .events .help{font-size:13px;margin-left:26px;padding-top:0}
+.repository .ui.attached.isSigned.isVerified:not(.positive){border-left:1px solid #A3C293;border-right:1px solid #A3C293}
+.repository .ui.attached.isSigned.isVerified.top:not(.positive){border-top:1px solid #A3C293}
+.repository .ui.attached.isSigned.isVerified:not(.positive):last-child{border-bottom:1px solid #A3C293}
+.repository .ui.segment.sub-menu{padding:7px;line-height:0}
+.repository .ui.segment.sub-menu .list{width:100%;display:flex}
+.repository .ui.segment.sub-menu .list .item{width:100%;border-radius:3px}
+.repository .ui.segment.sub-menu .list .item a{color:#000}
+.repository .ui.segment.sub-menu .list .item a:hover{color:#666}
+.repository .ui.segment.sub-menu .list .item.active{background:rgba(0,0,0,.05)}
+.repository .segment.reactions.dropdown .menu,.repository .select-reaction.dropdown .menu{right:0!important;left:auto!important}
+.repository .segment.reactions.dropdown .menu>.header,.repository .select-reaction.dropdown .menu>.header{margin:.75rem 0 .5rem}
+.repository .segment.reactions.dropdown .menu>.item,.repository .select-reaction.dropdown .menu>.item{float:left;padding:.5rem .5rem!important}
+.repository .segment.reactions.dropdown .menu>.item img.emoji,.repository .select-reaction.dropdown .menu>.item img.emoji{margin-right:0}
+.repository .segment.reactions{padding:.3em 1em}
+.repository .segment.reactions .ui.label{padding:.4em}
+.repository .segment.reactions .ui.label.disabled{cursor:default}
+.repository .segment.reactions .ui.label>img{height:1.5em!important}
+.repository .segment.reactions .select-reaction{float:none}
+.repository .segment.reactions .select-reaction:not(.active) a{display:none}
+.repository .segment.reactions:hover .select-reaction a{display:block}
+.user-cards .list{padding:0}
+.user-cards .list .item{list-style:none;width:32%;margin:10px 10px 10px 0;padding-bottom:14px;float:left}
+.user-cards .list .item .avatar{width:48px;height:48px;float:left;display:block;margin-right:10px}
+.user-cards .list .item .name{margin-top:0;margin-bottom:0;font-weight:400}
+.user-cards .list .item .meta{margin-top:5px}
+#search-repo-box .results .result .image,#search-user-box .results .result .image{float:left;margin-right:8px;width:2em;height:2em}
+#search-repo-box .results .result .content,#search-user-box .results .result .content{margin:6px 0}
+#issue-filters.hide{display:none}
+#issue-actions{margin-top:-1rem!important}
+#issue-actions.hide{display:none}
+.ui.checkbox.issue-checkbox{vertical-align:middle}
+.issue.list{list-style:none}
+.issue.list>.item{padding-top:15px;padding-bottom:10px;border-bottom:1px dashed #AAA}
+.issue.list>.item .title{color:#444;font-size:15px;font-weight:700;margin:0 6px}
+.issue.list>.item .title:hover{color:#000}
+.issue.list>.item .comment{padding-right:10px;color:#666}
+.issue.list>.item .desc{padding-top:5px;color:#999}
+.issue.list>.item .desc .checklist{padding-left:5px}
+.issue.list>.item .desc .checklist .progress-bar{margin-left:2px;width:80px;height:6px;display:inline-block;background-color:#eee;overflow:hidden;border-radius:3px;vertical-align:2px!important}
+.issue.list>.item .desc .checklist .progress-bar .progress{background-color:#ccc;display:block;height:100%}
+.issue.list>.item .desc a.milestone{padding-left:5px;color:#999!important}
+.issue.list>.item .desc a.milestone:hover{color:#000!important}
+.issue.list>.item .desc .assignee{margin-top:-5px;margin-right:5px}
+.issue.list>.item .desc .overdue{color:red}
+.page.buttons{padding-top:15px}
+.ui.form .dropzone{width:100%;margin-bottom:10px;border:2px dashed #0087F7;box-shadow:none!important}
+.ui.form .dropzone .dz-error-message{top:140px}
+.settings .content{margin-top:2px}
+.settings .content .segment,.settings .content>.header{box-shadow:0 1px 2px 0 rgba(34,36,38,.15)}
+.settings .list>.item .green{color:#21BA45}
+.settings .list>.item:not(:first-child){border-top:1px solid #eaeaea;padding:1rem;margin:15px -1rem -1rem -1rem}
+.settings .list>.item>.mega-octicon{display:table-cell}
+.settings .list>.item>.mega-octicon+.content{display:table-cell;padding:0 0 0 .5em;vertical-align:top}
+.settings .list>.item .info{margin-top:10px}
+.settings .list>.item .info .tab.segment{border:none;padding:10px 0 0}
+.settings .list.key .meta{padding-top:5px;color:#666}
+.settings .list.email>.item:not(:first-child){min-height:60px}
+.settings .list.collaborator>.item{padding:0}
+.ui.vertical.menu .header.item{font-size:1.1em;background:#f0f0f0}
+.edit-label.modal .form .column,.new-label.segment .form .column{padding-right:0}
+.edit-label.modal .form .buttons,.new-label.segment .form .buttons{margin-left:auto;padding-top:15px}
+.edit-label.modal .form .color.picker.column,.new-label.segment .form .color.picker.column{width:auto}
+.edit-label.modal .form .color.picker.column .color-picker,.new-label.segment .form .color.picker.column .color-picker{height:35px;width:auto;padding-left:30px}
+.edit-label.modal .form .minicolors-swatch.minicolors-sprite,.new-label.segment .form .minicolors-swatch.minicolors-sprite{top:10px;left:10px;width:15px;height:15px}
+.edit-label.modal .form .precolors,.new-label.segment .form .precolors{padding-left:0;padding-right:0;margin:3px 10px auto 10px;width:120px}
+.edit-label.modal .form .precolors .color,.new-label.segment .form .precolors .color{float:left;width:15px;height:15px}
+#avatar-arrow:after,#avatar-arrow:before{right:100%;top:20px;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}
+#avatar-arrow:before{border-right-color:#D4D4D5;border-width:9px;margin-top:-9px}
+#avatar-arrow:after{border-right-color:#f7f7f7;border-width:8px;margin-top:-8px}
+#delete-repo-modal .ui.message,#transfer-repo-modal .ui.message{width:100%!important}
+.tab-size-1{-moz-tab-size:1!important;-o-tab-size:1!important;tab-size:1!important}
+.tab-size-2{-moz-tab-size:2!important;-o-tab-size:2!important;tab-size:2!important}
+.tab-size-3{-moz-tab-size:3!important;-o-tab-size:3!important;tab-size:3!important}
+.tab-size-4{-moz-tab-size:4!important;-o-tab-size:4!important;tab-size:4!important}
+.tab-size-5{-moz-tab-size:5!important;-o-tab-size:5!important;tab-size:5!important}
+.tab-size-6{-moz-tab-size:6!important;-o-tab-size:6!important;tab-size:6!important}
+.tab-size-7{-moz-tab-size:7!important;-o-tab-size:7!important;tab-size:7!important}
+.tab-size-8{-moz-tab-size:8!important;-o-tab-size:8!important;tab-size:8!important}
+.tab-size-9{-moz-tab-size:9!important;-o-tab-size:9!important;tab-size:9!important}
+.tab-size-10{-moz-tab-size:10!important;-o-tab-size:10!important;tab-size:10!important}
+.tab-size-11{-moz-tab-size:11!important;-o-tab-size:11!important;tab-size:11!important}
+.tab-size-12{-moz-tab-size:12!important;-o-tab-size:12!important;tab-size:12!important}
+.tab-size-13{-moz-tab-size:13!important;-o-tab-size:13!important;tab-size:13!important}
+.tab-size-14{-moz-tab-size:14!important;-o-tab-size:14!important;tab-size:14!important}
+.tab-size-15{-moz-tab-size:15!important;-o-tab-size:15!important;tab-size:15!important}
+.tab-size-16{-moz-tab-size:16!important;-o-tab-size:16!important;tab-size:16!important}
+.stats-table{display:table;width:100%}
+.stats-table .table-cell{display:table-cell}
+.stats-table .table-cell.tiny{height:.5em}
+tbody.commit-list{vertical-align:baseline}
+.commit-body{white-space:pre-wrap}
+@media only screen and (max-width:767px){.ui.stackable.menu.mobile--margin-between-items>.item{margin-top:5px;margin-bottom:5px}
+.ui.stackable.menu.mobile--no-negative-margins{margin-left:0;margin-right:0}
+}
+#topic_edit{margin-top:5px}
+#repo-topics{margin-top:5px}
+.repo-topic{cursor:pointer}
+#new-dependency-drop-list.ui.selection.dropdown{min-width:0;width:100%;border-radius:4px 0 0 4px;border-right:0;white-space:nowrap}
+#new-dependency-drop-list .text{width:100%;overflow:hidden}
+#manage_topic{font-size:12px}
+.label+#manage_topic{margin-left:5px}
+.repo-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap}
+.repo-header .repo-buttons{display:flex;align-items:center}
+.repo-buttons .disabled-repo-button .label{opacity:.5}
+.repo-buttons .disabled-repo-button a.button{opacity:.5;cursor:not-allowed}
+.repo-buttons .disabled-repo-button a.button:hover{background:0 0!important;color:rgba(0,0,0,.6)!important;box-shadow:0 0 0 1px rgba(34,36,38,.15) inset!important}
+.repo-buttons .ui.labeled.button>.label{border-left:none!important;margin:0!important}
+.CodeMirror{font:14px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+.CodeMirror.cm-s-default{border-radius:3px;padding:0!important}
+.CodeMirror .cm-comment{background:inherit!important}
+.repository.file.editor .tab[data-tab=write]{padding:0!important}
+.repository.file.editor .tab[data-tab=write] .editor-toolbar{border:none!important}
+.repository.file.editor .tab[data-tab=write] .CodeMirror{border-left:none;border-right:none;border-bottom:none}
+.organization{padding-top:15px}
+.organization .head .ui.header .text{vertical-align:middle;font-size:1.6rem;margin-left:15px}
+.organization .head .ui.header .ui.right{margin-top:5px}
+.organization.new.org form{margin:auto}
+.organization.new.org form .ui.message{text-align:center}
+@media only screen and (min-width:768px){.organization.new.org form{width:800px!important}
+.organization.new.org form .header{padding-left:280px!important}
+.organization.new.org form .inline.field>label{text-align:right;width:250px!important;word-wrap:break-word}
+.organization.new.org form .help{margin-left:265px!important}
+.organization.new.org form .optional .title{margin-left:250px!important}
+.organization.new.org form input,.organization.new.org form textarea{width:50%!important}
+}
+@media only screen and (max-width:767px){.organization.new.org form .optional .title{margin-left:15px}
+.organization.new.org form .inline.field>label{display:block}
+}
+.organization.new.org form .header{padding-left:0!important;text-align:center}
+.organization.options input{min-width:300px}
+.organization.profile #org-avatar{width:100px;height:100px;margin-right:15px}
+.organization.profile #org-info .ui.header{font-size:36px;margin-bottom:0}
+.organization.profile #org-info .desc{font-size:16px;margin-bottom:10px}
+.organization.profile #org-info .meta .item{display:inline-block;margin-right:10px}
+.organization.profile #org-info .meta .item .icon{margin-right:5px}
+.organization.profile .ui.top.header .ui.right{margin-top:0}
+.organization.profile .teams .item{padding:10px 15px}
+.organization.profile .members .ui.avatar,.organization.teams .members .ui.avatar{width:48px;height:48px;margin-right:5px}
+.organization.invite #invite-box{margin:50px auto auto;width:500px!important}
+.organization.invite #invite-box #search-user-box input{margin-left:0;width:300px}
+.organization.invite #invite-box .ui.button{margin-left:5px;margin-top:-3px}
+.organization.members .list .item{margin-left:0;margin-right:0;border-bottom:1px solid #eee}
+.organization.members .list .item .ui.avatar{width:48px;height:48px}
+.organization.members .list .item .meta{line-height:24px}
+.organization.teams .detail .item{padding:10px 15px}
+.organization.teams .detail .item:not(:last-child){border-bottom:1px solid #eee}
+.organization.teams .members .item,.organization.teams .repositories .item{padding:10px 20px;line-height:32px}
+.organization.teams .members .item:not(:last-child),.organization.teams .repositories .item:not(:last-child){border-bottom:1px solid #DDD}
+.organization.teams .members .item .button,.organization.teams .repositories .item .button{padding:9px 10px}
+.organization.teams #add-member-form input,.organization.teams #add-repo-form input{margin-left:0}
+.organization.teams #add-member-form .ui.button,.organization.teams #add-repo-form .ui.button{margin-left:5px;margin-top:-3px}
+.user:not(.icon){padding-top:15px}
+.user.profile .ui.card .username{display:block}
+.user.profile .ui.card .extra.content{padding:0}
+.user.profile .ui.card .extra.content ul{margin:0;padding:0}
+.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none}
+.user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}
+.user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}
+.user.profile .ui.card .extra.content ul li.follow .ui.button{width:100%}
+@media only screen and (max-width:768px){.user.profile .ui.card #profile-avatar{height:250px;overflow:hidden}
+.user.profile .ui.card #profile-avatar img{max-height:768px;max-width:768px}
+}
+@media only screen and (max-width:768px){.user.profile .ui.card{width:100%}
+}
+.user.profile .ui.repository.list{margin-top:25px}
+.user.profile #loading-heatmap{margin-bottom:1em}
+.user.followers .header.name{font-size:20px;line-height:24px;vertical-align:middle}
+.user.followers .follow .ui.button{padding:8px 15px}
+.user.notification .octicon{float:left;font-size:2em}
+.user.notification .content{float:left;margin-left:7px}
+.user.notification table form{display:inline-block}
+.user.notification table button{padding:3px 3px 3px 5px}
+.user.notification table tr{cursor:pointer}
+.user.notification .octicon.green{color:#21ba45}
+.user.notification .octicon.red{color:#d01919}
+.user.notification .octicon.purple{color:#a333c8}
+.user.notification .octicon.blue{color:#2185d0}
+.user.link-account:not(.icon){padding-top:15px;padding-bottom:5px}
+.user.settings .iconFloat{float:left}
+.dashboard{padding-top:15px}
+.dashboard.feeds .context.user.menu,.dashboard.issues .context.user.menu{z-index:101;min-width:200px}
+.dashboard.feeds .context.user.menu .ui.header,.dashboard.issues .context.user.menu .ui.header{font-size:1rem;text-transform:none}
+.dashboard.feeds .filter.menu .item,.dashboard.issues .filter.menu .item{text-align:left}
+.dashboard.feeds .filter.menu .item .text,.dashboard.issues .filter.menu .item .text{height:16px;vertical-align:middle}
+.dashboard.feeds .filter.menu .item .text.truncate,.dashboard.issues .filter.menu .item .text.truncate{width:85%}
+.dashboard.feeds .filter.menu .item .floating.label,.dashboard.issues .filter.menu .item .floating.label{top:7px;left:90%;width:15%}
+@media only screen and (max-width:768px){.dashboard.feeds .filter.menu .item .floating.label,.dashboard.issues .filter.menu .item .floating.label{top:10px;left:auto;width:auto;right:13px}
+}
+.dashboard.feeds .filter.menu .jump.item,.dashboard.issues .filter.menu .jump.item{margin:1px;padding-right:0}
+.dashboard.feeds .filter.menu .menu,.dashboard.issues .filter.menu .menu{max-height:300px;overflow-x:auto;right:0!important;left:auto!important}
+@media only screen and (max-width:768px){.dashboard.feeds .filter.menu,.dashboard.issues .filter.menu{width:100%}
+}
+.dashboard.feeds .right.stackable.menu>.item.active,.dashboard.issues .right.stackable.menu>.item.active{color:#d9453d}
+.dashboard .dashboard-repos{margin:0 1px}
+.dashboard .dashboard-navbar{width:100vw;padding:0 .5rem}
+.feeds .news>.ui.grid{margin-left:auto;margin-right:auto}
+.feeds .news .ui.avatar{margin-top:13px}
+.feeds .news .time-since{font-size:13px}
+.feeds .news .issue.title{width:80%}
+.feeds .news .push.news .content ul{font-size:13px;list-style:none;padding-left:10px}
+.feeds .news .push.news .content ul img{margin-bottom:-2px}
+.feeds .news .push.news .content ul .text.truncate{width:80%;margin-bottom:-5px}
+.feeds .news .commit-id{font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
+.feeds .news code{padding:1px;font-size:85%;background-color:rgba(0,0,0,.04);border-radius:3px;word-break:break-all}
+.feeds .list .header .ui.label{margin-top:-4px;padding:4px 5px;font-weight:400}
+.feeds .list .header .plus.icon{margin-top:5px}
+.feeds .list ul{list-style:none;margin:0;padding-left:0}
+.feeds .list ul li:not(:last-child){border-bottom:1px solid #EAEAEA}
+.feeds .list ul li.private{background-color:#fcf8e9}
+.feeds .list ul li a{padding:6px 1.2em;display:block}
+.feeds .list ul li a .octicon{color:#888}
+.feeds .list ul li a .octicon.rear{font-size:15px}
+.feeds .list ul li a .star-num{font-size:12px}
+.feeds .list .repo-owner-name-list .item-name{max-width:70%;margin-bottom:-4px}
+.feeds .list #collaborative-repo-list .owner-and-repo{max-width:80%;margin-bottom:-5px}
+.feeds .list #collaborative-repo-list .owner-name{max-width:120px;margin-bottom:-5px}
+.admin{padding-top:15px}
+.admin .table.segment{padding:0;font-size:13px}
+.admin .table.segment:not(.striped){padding-top:5px}
+.admin .table.segment:not(.striped) thead th:last-child{padding-right:5px!important}
+.admin .table.segment th{padding-top:5px;padding-bottom:5px}
+.admin .table.segment:not(.select) td:first-of-type,.admin .table.segment:not(.select) th:first-of-type{padding-left:15px!important}
+.admin .ui.header,.admin .ui.segment{box-shadow:0 1px 2px 0 rgba(34,36,38,.15)}
+.admin.user .email{max-width:200px}
+.admin dl.admin-dl-horizontal{padding:20px;margin:0}
+.admin dl.admin-dl-horizontal dd{margin-left:275px}
+.admin dl.admin-dl-horizontal dt{font-weight:bolder;float:left;width:285px;clear:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.admin.config #test-mail-btn{margin-left:5px}
+.explore{padding-top:15px}
+.explore .navbar{justify-content:center;padding-top:15px!important;margin-top:-15px!important;margin-bottom:15px!important;background-color:#FAFAFA!important;border-width:1px!important}
+.explore .navbar .octicon{width:16px;text-align:center;margin-right:5px}
+.ui.repository.list .item{padding-bottom:25px}
+.ui.repository.list .item:not(:first-child){border-top:1px solid #eee;padding-top:25px}
+.ui.repository.list .item .ui.header{font-size:1.5rem;padding-bottom:10px}
+.ui.repository.list .item .ui.header .name{word-break:break-all}
+.ui.repository.list .item .ui.header .metas{color:#888;font-size:14px;font-weight:400}
+.ui.repository.list .item .ui.header .metas span:not(:last-child){margin-right:5px}
+.ui.repository.list .item .time{font-size:12px;color:grey}
+.ui.repository.list .item .ui.tags{margin-bottom:1em}
+.ui.repository.branches .time{font-size:12px;color:grey}
+.ui.user.list .item{padding-bottom:25px}
+.ui.user.list .item:not(:first-child){border-top:1px solid #eee;padding-top:25px}
+.ui.user.list .item .ui.avatar.image{width:40px;height:40px}
+.ui.user.list .item .description{margin-top:5px}
+.ui.user.list .item .description .octicon:not(:first-child){margin-left:5px}
+.ui.user.list .item .description a{color:#333}
+.ui.user.list .item .description a:hover{text-decoration:underline}
+.ui.button.add-code-comment{font-size:14px;height:16px;padding:2px 0 0;position:relative;width:16px;z-index:5;float:left;margin:-2px -10px -2px -20px;opacity:0;transition:transform .1s ease-in-out;transform:scale(1,1)}
+.ui.button.add-code-comment:hover{transform:scale(1.2,1.2)}
+.focus-lines-new .ui.button.add-code-comment.add-code-comment-right,.focus-lines-old .ui.button.add-code-comment.add-code-comment-left{opacity:1}
+.comment-code-cloud{padding:4px;position:relative;border:1px solid #f1f1f1;margin:13px 10px 5px auto}
+.comment-code-cloud:before{content:" ";width:0;height:0;border-left:13px solid transparent;border-right:13px solid transparent;border-bottom:13px solid #f1f1f1;left:20px;position:absolute;top:-13px}
+.comment-code-cloud .attached.tab{border:none;padding:0;margin:0}
+.comment-code-cloud .attached.tab.markdown{padding:1em;min-height:168px}
+.comment-code-cloud .attached.header{padding:.1rem 1rem}
+.comment-code-cloud .right.menu.options .item{padding:.85714286em .442857em;cursor:pointer}
+.comment-code-cloud .ui.form textarea{border:0}
+.comment-code-cloud .ui.attached.tabular.menu{background:#f7f7f7;border:1px solid #d4d4d5;padding-top:5px;padding-left:5px;margin-top:0}
+.comment-code-cloud .footer{border-top:1px solid #f1f1f1;margin-top:10px}
+.comment-code-cloud .footer .markdown-info{display:inline-block;margin:5px 0;font-size:12px;color:rgba(0,0,0,.6)}
+.comment-code-cloud .footer .ui.right.floated{padding-top:6px}
+.comment-code-cloud .footer:after{clear:both;content:"";display:block}
+.comment-code-cloud button.comment-form-reply{margin:.5em .5em .5em 4.5em}
+.comment-code-cloud form.comment-form-reply{margin:0 0 0 4em}
+.file-comment{font:12px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;color:rgba(0,0,0,.87)}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -1,1 +1,240 @@
-.hljs{display:block;overflow-x:auto;padding:.5em;color:#bababa}.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-num{background-color:#2b2b2b!important}.hljs-emphasis,.hljs-strong{color:#a8a8a2}.hljs-bullet,.hljs-link,.hljs-literal,.hljs-number,.hljs-quote,.hljs-regexp{color:#6896ba}.hljs-code,.hljs-selector-class{color:#a6e22e}.hljs-emphasis{font-style:italic}.hljs-attribute,.hljs-keyword,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-variable{color:#cb7832}.hljs-params{color:#b9b9b9}.hljs-string{color:#6a8759}.hljs-addition,.hljs-built_in,.hljs-builtin-name,.hljs-selector-attr,.hljs-selector-id,.hljs-selector-pseudo,.hljs-subst,.hljs-symbol,.hljs-template-tag,.hljs-template-variable,.hljs-type{color:#e0c46c}.hljs-comment,.hljs-deletion,.hljs-meta{color:#7f7f7f}.repository .ui.segment.sub-menu .list .item a{color:#dbdbdb}.ui.horizontal.segments>.segment{background-color:#383c4a}body{background:#383c4a;color:#9e9e9e}a{color:#87ab63}a:hover{color:#a0cc75}.ui.card>.extra a:not(.ui):hover,.ui.cards>.card>.extra a:not(.ui):hover{color:#a0cc75}.ui.breadcrumb a:hover{color:#a0cc75}.ui.breadcrumb a{color:#87ab63}.repository .metas .ui.list a .text{color:#87ab63}.repository .metas .ui.list a .text:hover{color:#a0cc75}.repository .label.list .item a{color:#87ab63}.repository .label.list .item a:hover{color:#a0cc75}.repository .milestone.list>.item>a{color:#87ab63}.repository .milestone.list>.item>a:hover{color:#a0cc75}.repository.release #release-list{border-top:1px solid #4c505c}.repository .milestone.list>.item .operate>a{color:#87ab63}.repository .milestone.list>.item .operate>a:hover{color:#a0cc75}.ui.green.progress .bar{background-color:#684}.ui.progress.success .bar{background-color:#7b9e57!important}.following.bar.light{background:#2e323e}.ui.secondary.menu .active.item{color:#dbdbdb}.ui.secondary.menu .item{color:#9e9e9e}.following.bar .top.menu a.item:hover{color:#fff}.repository.view.issue .comment-list .comment .content>.bottom.segment a{border:solid 1px #353945;background-color:#353945}.following.bar.light{border-bottom:1px solid #313131}.ui.attached.header{background:#404552;border:1px solid #404552;color:#dbdbdb}.ui.attached.table{border:1px solid #304251;background:#304251}.feeds .list ul li:not(:last-child){border-bottom:1px solid #333640}.feeds .list ul li.private{background:#353945;border:1px solid #333640}.ui.secondary.menu .dropdown.item:hover,.ui.secondary.menu .link.item:hover,.ui.secondary.menu a.item:hover{color:#fff}.ui.menu .ui.dropdown .menu>.item{background:#2c303a!important;color:#9e9e9e!important}.ui.secondary.menu .dropdown.item>.menu,.ui.text.menu .dropdown.item>.menu{border:1px solid #434444}footer{background:#2e323e;border-top:1px solid #313131}.ui.menu .dropdown.item .menu{background:#2c303a}.ui.menu .ui.dropdown .menu>.item:hover,.ui.menu .ui.dropdown .menu>.selected.item{color:#fff!important}.ui.dropdown .menu>.header{color:#dbdbdb}.ui.red.label,.ui.red.labels .label{background-color:#7d3434!important;border-color:#8a2121!important}.ui.menu{background:#404552;border:1px solid #353945}.ui.menu .active.item:hover,.ui.vertical.menu .active.item:hover{color:#dbdbdb;background:#4B5162}.ui.link.menu .item:hover,.ui.menu .dropdown.item:hover,.ui.menu .link.item:hover,.ui.menu a.item:hover{color:#dbdbdb;background:#454b5a}.ui.menu .active.item{background:#4B5162;color:#dbdbdb}.ui.input input{background:#404552;border:2px solid #353945;color:#dbdbdb}.ui.input input:focus,.ui.input.focus input{background:#404552;border:2px solid #353945;color:#dbdbdb}.ui.accordion .title:not(.ui){color:#dbdbdb}.ui.label{color:#dbdbdb;background-color:#404552}.issue.list>.item .title{color:#87ab63}.issue.list>.item .title:hover{color:#a0cc75}.issue.list>.item{border-bottom:1px dashed #475767}.ui.basic.green.label,.ui.green.label,.ui.green.labels .label{background-color:#2d693b!important;border-color:#2d693b!important}.ui.basic.green.labels a.label:hover,a.ui.basic.green.label:hover{background-color:#16ab39!important;border-color:#16ab39!important;color:#fff!important}.issue.list>.item .comment{color:#129c92}.ui.basic.button,.ui.basic.buttons .button{color:#797979!important}.ui.basic.red.active.button,.ui.basic.red.buttons .active.button{box-shadow:0 0 0 1px #c75252 inset!important;color:#c75252!important}.ui.basic.button:focus,.ui.basic.button:hover,.ui.basic.buttons .button:focus,.ui.basic.buttons .button:hover{background:0 0!important;color:#dbdbdb!important}.ui.menu .item{background:#404552;color:#9e9e9e}.ui.menu .item.disabled,.ui.menu .item.disabled:hover{color:#626773}.ui.pagination.menu .active.item{color:#dbdbdb;background-color:#87ab63}.repository .header-wrapper{background-color:#2a2e3a}.ui.tabular.menu .active.item{background:#383c4a;color:#dbdbdb;border-left:1px solid transparent;border-right:1px solid transparent;border-top:none}.ui.tabular.menu .item{color:#9e9e9e}.ui.tabular.menu .item:hover{color:#dbdbdb}.ui.breadcrumb .divider,.ui.header{color:#9e9e9e}.ui.blue.label,.ui.blue.labels .label{background-color:#26577b!important;border-color:#26577b!important}.ui.menu .item>.label{background:#565454}.ui.blue.button,.ui.blue.buttons .button{background-color:#87ab63}.ui.blue.button:hover,.ui.blue.buttons .button:hover{background-color:#a0cc75}.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url]{background:#404552;border:2px solid #353945}.ui.form input:not([type]):focus,.ui.form input[type=date]:focus,.ui.form input[type=datetime-local]:focus,.ui.form input[type=email]:focus,.ui.form input[type=number]:focus,.ui.form input[type=password]:focus,.ui.form input[type=search]:focus,.ui.form input[type=tel]:focus,.ui.form input[type=text]:focus,.ui.form input[type=time]:focus,.ui.form input[type=url]:focus{background:#404552;border:2px solid #4b505f;color:#dbdbdb}.ui.action.input:not([class*="left action"]) input:focus{border-right-color:#4b505f!important}.ui.green.button,.ui.green.buttons .button{background-color:#87ab63}.ui.green.button:hover,.ui.green.buttons .button:hover{background-color:#a0cc75}.ui.button{background:#383c4a;border:1px solid #4c505c;color:#dbdbdb}.ui.labeled.button:not([class*="left labeled"])>.label,.ui[class*="left labeled"].button>.button{background:#404552;border:1px solid #4c505c;color:#87ab63}.ui.button:hover{background-color:#404552;color:#dbdbdb}.ui.table thead th{background:#404552;color:#dbdbdb}.repository.file.list #repo-files-table tr:hover{background-color:#393d4a}.ui.table{color:#a5a5a5!important;border:1px solid #4c505c;background:#353945}.ui.table tbody tr{border-bottom:1px solid #333640;background:#2a2e3a}.ui .text.grey{color:#808084!important}.ui.attached.table.segment{background:#353945;color:#dbdbdb!important}.markdown:not(code) h2{border-bottom:1px solid #304251}.hljs,.hljs-keyword,.hljs-selector-tag,.hljs-subst{color:#9daccc}.markdown:not(code) .highlight pre,.markdown:not(code) pre{background-color:#2a2e3a;border:1px solid #404552}.markdown:not(code) table tr:nth-child(2n){background-color:#474d61}.ui.dropdown .menu{background:#2c303a}.ui.dropdown .menu>.message:not(.ui){color:#636363}.ui.input{color:#dbdbdb}.overflow.menu .items .item{color:#9d9d9d}.overflow.menu .items .item:hover{color:#dbdbdb}.ui.segment{background:#353945;color:#9e9e9e!important;border:1px solid #404552}.ui.active.button:active,.ui.button:active,.ui.button:focus{background-color:#2e3e4e;color:#dbdbdb}.ui.dropdown .menu .selected.item,.ui.dropdown.selected{color:#dbdbdb}.ui.dropdown .menu>.item:hover{color:#dbdbdb}.ui.dropdown .menu>.item{color:#9e9e9e}.ui.attached.segment{border:1px solid #404552}.repository.view.issue .comment-list .comment .content>.bottom.segment{background:#353945}.repository.view.issue .comment-list .comment .content .header{color:#dbdbdb;background-color:#404552;border-bottom:1px solid #353944}.ui .text.grey a{color:#b3b3b3!important}.ui.comments .comment .actions a{color:#dbdbdb}.repository.view.issue .comment-list .comment .content .header:after{border-right-color:#404552}.repository.new.issue .comment.form .content:after{border-right-color:#353945}.repository.view.issue .comment-list .comment .content .header:before{border-right-color:#404552}.repository.new.issue .comment.form .content:before{border-right-color:#353945}.repository.view.issue .comment-list:before{background-color:#313c47}.repository .comment.form .content .form:after{border-right-color:#313c47}.repository .comment.form .content .form:before{border-right-color:#313c47}.ui .text.grey a{color:#dbdbdb!important}.ui .text.grey a:hover{color:#dbdbdb!important}.ui.basic.green.active.button,.ui.basic.green.buttons .active.button{color:#13ae38!important}.ui.form textarea,.ui.form textarea:focus{background:#1a2632;border:1px solid #313c47;color:#dbdbdb}.ui.form textarea:focus{border:1px solid #456580}.ui .info.segment.top{background-color:#404552!important}.repository .diff-file-box .code-diff-unified tbody tr.del-code td{background-color:#3c2626!important;border-color:#634343!important}.repository .diff-file-box .code-diff-unified tbody tr.add-code td{background-color:#283e2d!important;border-color:#314a37!important}.repository .diff-file-box .code-diff tbody tr .added-code{background-color:#3a523a}.repository .diff-file-box .code-diff .lines-num{border-right:1px solid #2d2d2d}.repository .diff-file-box .file-body.file-code .lines-num{color:#9e9e9e;background:#2e323e}.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{border-color:#2d2d2d!important}.repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #2d2d2d}.hljs-section,.hljs-selector-id,.hljs-title{color:#986c88}.hljs-doctag,.hljs-string{color:#949494}.repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#5f3737}.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#292727!important}.ui.vertical.menu .active.item{background:#4B5162}.ui.vertical.menu .item{background:#353945}.ui.vertical.menu .header.item{background:#404552}.ui.vertical.menu{background:#353945;border:1px solid #333640}.ui.repository.list .item:not(:first-child){border-top:1px solid #4c505c}.ui .text.blue{color:#87ab63!important}.ui.selection.active.dropdown,.ui.selection.active.dropdown .menu{border-color:#4e5361;box-shadow:0 2px 3px 0 rgba(34,36,38,.15)}.ui.selection.active.dropdown:hover,.ui.selection.active.dropdown:hover .menu{border-color:#4e5361;box-shadow:0 2px 3px 0 rgba(34,36,38,.15)}.ui.selection.dropdown{background:#404552;border:1px solid #404552;color:#9e9e9e}.ui.menu .ui.dropdown .menu>.active.item{color:#dbdbdb!important}.ui.tabular.menu{border-bottom:1px solid #313c47}.ui.card,.ui.cards>.card{background:#353945;box-shadow:0 1px 3px 0 #4c505c,0 0 0 1px #4c505c}.ui.card>.content>.header,.ui.cards>.card>.content>.header{color:#dbdbdb}.ui.card>.extra a:not(.ui),.ui.cards>.card>.extra a:not(.ui){color:#87ab63}.ui .text.black{color:#9e9e9e}.ui .text.black:hover{color:#dbdbdb}.ui.secondary.segment{background:#353945}.ui.secondary.pointing.menu .active.item{border-color:#87ab63;color:#dbdbdb;background:#404552}.ui.user.list .item:not(:first-child){border-top:1px solid #4c505c}.ui.secondary.pointing.menu .active.item:hover{border-color:#af8b4c;color:#dbdbdb;background:#4b5162}.ui.secondary.pointing.menu .dropdown.item:hover,.ui.secondary.pointing.menu .link.item:hover,.ui.secondary.pointing.menu a.item:hover{color:#dbdbdb}.ui.checkbox label,.ui.checkbox+label,.ui.form .field>label{color:#9e9e9e}.ui.form .inline.field>label,.ui.form .inline.field>p,.ui.form .inline.fields .field>label,.ui.form .inline.fields .field>p,.ui.form .inline.fields>label{color:#9e9e9e}.user.settings .email.list .item:not(:first-child){border-top:1px solid #3f4451}.explore .navbar{background-color:#2a2e3a!important}.ui.menu.new-menu{background-color:#2a2e3a!important}@media only screen and (max-width:1200px){.ui.menu.new-menu:after{background-image:linear-gradient(to right,rgba(42,46,42,0),#2a2e2a 100%)}}input{background:#2e323e}.ui.secondary.pointing.menu .active.item{border:none;background:#383c4a}.settings .key.list .item:not(:first-child){border-top:1px solid #404552}.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url]{color:#9e9e9e}.ui.attached.info.message,.ui.info.message{box-shadow:0 0 0 1px #4b5e71 inset,0 0 0 0 transparent}.ui.bottom.attached.message{background-color:#2c662d;color:#87ab63}.ui.bottom.attached.message .pull-right{color:#87ab63}.ui.info.message{background-color:#2c3b4a;color:#9ebcc5}.CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}.ui .warning.header{background-color:#5d3a22!important;border-color:#794f31}.ui.red.message{background-color:rgba(80,23,17,.6);color:#f9cbcb;box-shadow:0 0 0 1px rgba(121,71,66,.5) inset,0 0 0 0 transparent}.ui.red.button,.ui.red.buttons .button{background-color:#7d3434}.ui.red.button:hover,.ui.red.buttons .button:hover{background-color:#984646}.ui.checkbox label:hover,.ui.checkbox+label:hover{color:#dbdbdb!important}.ui.checkbox input:checked~.box:after,.ui.checkbox input:checked~label:after{color:#7f98ad}.ui.checkbox input:checked~.box:before,.ui.checkbox input:checked~label:before{background:#304251}.ui.checkbox .box:hover::before,.ui.checkbox label:hover::before{background:#304251}.ui.checkbox .box:before,.ui.checkbox label:before{background:#304251;border:1px solid #304251}.ui.checkbox .box:active::before,.ui.checkbox label:active::before{background:#304251;border-color:rgba(34,36,38,.35)}.ui.checkbox input:checked~.box:before,.ui.checkbox input:checked~label:before{border-color:#304251;background:#304251}.ui.checkbox input:focus~.box:before,.ui.checkbox input:focus~label:before{border-color:#304251;background:#304251}.ui.checkbox input:checked:focus~.box:before,.ui.checkbox input:checked:focus~label:before,.ui.checkbox input:not([type=radio]):indeterminate:focus~.box:before,.ui.checkbox input:not([type=radio]):indeterminate:focus~label:before{border-color:#304251;background:#304251}.ui.checkbox input:checked~.box:after,.ui.checkbox input:checked~label:after{opacity:1;color:#7f98ad}.ui.checkbox input:checked:focus~.box:after,.ui.checkbox input:checked:focus~label:after,.ui.checkbox input:not([type=radio]):indeterminate:focus~.box:after,.ui.checkbox input:not([type=radio]):indeterminate:focus~label:after{color:#7f98ad}.ui.checkbox input:focus~.box:after,.ui.checkbox input:focus~label,.ui.checkbox input:focus~label:after{color:#9a9a9a}.ui.selection.dropdown:hover{border:1px solid #456580}.ui.selection.dropdown .menu>.item{border-top:1px solid #313c47}.ui.selection.visible.dropdown>.text:not(.default){color:#9e9e9e}.ui.negative.message{background-color:rgba(80,23,17,.6);color:#f9cbcb;box-shadow:0 0 0 1px rgba(121,71,66,.5) inset,0 0 0 0 transparent}.hljs-attribute,.hljs-name,.hljs-tag{color:#ef5e77}.user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #4c505c}.ui.form textarea,.ui.form textarea:focus{background:#404552;border:2px solid #353945}.hljs-literal,.hljs-number,.hljs-tag .hljs-attr,.hljs-template-variable,.hljs-variable{color:#bd84bf}.hljs-doctag,.hljs-string{color:#8ab398}.ui.form .dropzone{border:2px dashed #4c505c}.ui.basic.red.button,.ui.basic.red.buttons .button{box-shadow:0 0 0 1px #a04141 inset!important;color:#a04141!important}.ui.list .list>.item .header,.ui.list>.item .header{color:#dedede}.ui.list .list>.item .description,.ui.list>.item .description{color:#9e9e9e}.ui.user.list .item .description a{color:#668cb1}.repository.file.list #file-content .code-view .lines-num{background:#2e323e}.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule{color:#7c9b5e}.ui.blue.button:focus,.ui.blue.buttons .button:focus{background-color:#87ab63}.ui.basic.blue.button:hover,.ui.basic.blue.buttons .button:hover{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}.ui.basic.blue.button:focus,.ui.basic.blue.buttons .button:focus{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}.repository.file.list #file-content .code-view .lines-code .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb}.repository .label.list .item{border-bottom:1px dashed #4c505c}.repository.file.list #file-content .code-view .lines-num{background:#2e323e}.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule{color:#7c9b5e}.ui.basic.blue.button,.ui.basic.blue.buttons .button{box-shadow:0 0 0 1px #a27558 inset!important;color:#a27558!important}.repository.file.list #file-content .code-view .lines-code .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb}.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(4){background-color:#2a2e3a}.repository .diff-file-box .code-diff-split tbody tr td.add-code,.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(4){background-color:#283e2d!important;border-color:#314a37!important}.repository .diff-file-box .code-diff-split tbody tr td.del-code,.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(2){background-color:#3c2626!important;border-color:#634343!important}.ui.blue.button:focus,.ui.blue.buttons .button:focus{background-color:#a27558}.ui.blue.button:active,.ui.blue.buttons .button:active{background-color:#a27558}#git-graph-container li a{color:#c79575}#git-graph-container li .author{color:#c79575}.ui.header .sub.header{color:#9e9e9e}.ui.dividing.header{border-bottom:1px solid #4c505c}.ui.modal>.header{background:#404552;color:#dbdbdb}.ui.modal>.actions{background:#404552;border-top:1px solid #404552}.ui.modal>.content{background:#383c4a}.ui.basic.blue.button,.ui.basic.blue.buttons .button{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}.editor-toolbar{background-color:#404552}.editor-toolbar a{color:#87ab63!important}.CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:none}.CodeMirror-gutters{background-color:#2b2b2b}.repository .diff-detail-box{background-color:#383c4a}.repository .diff-detail-box .detail-files{background-color:inherit}.comment-code-cloud .ui.attached.tabular.menu{background:none transparent;border:none}.comment-code-cloud .footer .markdown-info{color:inherit}.file-comment{color:#888}.ui.comments .comment .author{color:#dbdbdb}.ui.comments .comment .metadata{color:#808084}.ui.comments .comment .text{color:#9e9e9e}.heatmap-color-0{background-color:#2d303b}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#bababa}
+.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-num{background-color:#2b2b2b!important}
+.hljs-emphasis,.hljs-strong{color:#a8a8a2}
+.hljs-bullet,.hljs-link,.hljs-literal,.hljs-number,.hljs-quote,.hljs-regexp{color:#6896ba}
+.hljs-code,.hljs-selector-class{color:#a6e22e}
+.hljs-emphasis{font-style:italic}
+.hljs-attribute,.hljs-keyword,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-variable{color:#cb7832}
+.hljs-params{color:#b9b9b9}
+.hljs-string{color:#6a8759}
+.hljs-addition,.hljs-built_in,.hljs-builtin-name,.hljs-selector-attr,.hljs-selector-id,.hljs-selector-pseudo,.hljs-subst,.hljs-symbol,.hljs-template-tag,.hljs-template-variable,.hljs-type{color:#e0c46c}
+.hljs-comment,.hljs-deletion,.hljs-meta{color:#7f7f7f}
+.repository .ui.segment.sub-menu .list .item a{color:#dbdbdb}
+.ui.horizontal.segments>.segment{background-color:#383c4a}
+body{background:#383c4a;color:#9e9e9e}
+a{color:#87ab63}
+a:hover{color:#a0cc75}
+.ui.card>.extra a:not(.ui):hover,.ui.cards>.card>.extra a:not(.ui):hover{color:#a0cc75}
+.ui.breadcrumb a:hover{color:#a0cc75}
+.ui.breadcrumb a{color:#87ab63}
+.repository .metas .ui.list a .text{color:#87ab63}
+.repository .metas .ui.list a .text:hover{color:#a0cc75}
+.repository .label.list .item a{color:#87ab63}
+.repository .label.list .item a:hover{color:#a0cc75}
+.repository .milestone.list>.item>a{color:#87ab63}
+.repository .milestone.list>.item>a:hover{color:#a0cc75}
+.repository.release #release-list{border-top:1px solid #4c505c}
+.repository .milestone.list>.item .operate>a{color:#87ab63}
+.repository .milestone.list>.item .operate>a:hover{color:#a0cc75}
+.ui.green.progress .bar{background-color:#684}
+.ui.progress.success .bar{background-color:#7b9e57!important}
+.following.bar.light{background:#2e323e}
+.ui.secondary.menu .active.item{color:#dbdbdb}
+.ui.secondary.menu .item{color:#9e9e9e}
+.following.bar .top.menu a.item:hover{color:#fff}
+.repository.view.issue .comment-list .comment .content>.bottom.segment a{border:solid 1px #353945;background-color:#353945}
+.following.bar.light{border-bottom:1px solid #313131}
+.ui.attached.header{background:#404552;border:1px solid #404552;color:#dbdbdb}
+.ui.attached.table{border:1px solid #304251;background:#304251}
+.feeds .list ul li:not(:last-child){border-bottom:1px solid #333640}
+.feeds .list ul li.private{background:#353945;border:1px solid #333640}
+.ui.secondary.menu .dropdown.item:hover,.ui.secondary.menu .link.item:hover,.ui.secondary.menu a.item:hover{color:#fff}
+.ui.menu .ui.dropdown .menu>.item{background:#2c303a!important;color:#9e9e9e!important}
+.ui.secondary.menu .dropdown.item>.menu,.ui.text.menu .dropdown.item>.menu{border:1px solid #434444}
+footer{background:#2e323e;border-top:1px solid #313131}
+.ui.menu .dropdown.item .menu{background:#2c303a}
+.ui.menu .ui.dropdown .menu>.item:hover,.ui.menu .ui.dropdown .menu>.selected.item{color:#fff!important}
+.ui.dropdown .menu>.header{color:#dbdbdb}
+.ui.red.label,.ui.red.labels .label{background-color:#7d3434!important;border-color:#8a2121!important}
+.ui.menu{background:#404552;border:1px solid #353945}
+.ui.menu .active.item:hover,.ui.vertical.menu .active.item:hover{color:#dbdbdb;background:#4B5162}
+.ui.link.menu .item:hover,.ui.menu .dropdown.item:hover,.ui.menu .link.item:hover,.ui.menu a.item:hover{color:#dbdbdb;background:#454b5a}
+.ui.menu .active.item{background:#4B5162;color:#dbdbdb}
+.ui.input input{background:#404552;border:2px solid #353945;color:#dbdbdb}
+.ui.input input:focus,.ui.input.focus input{background:#404552;border:2px solid #353945;color:#dbdbdb}
+.ui.accordion .title:not(.ui){color:#dbdbdb}
+.ui.label{color:#dbdbdb;background-color:#404552}
+.issue.list>.item .title{color:#87ab63}
+.issue.list>.item .title:hover{color:#a0cc75}
+.issue.list>.item{border-bottom:1px dashed #475767}
+.ui.basic.green.label,.ui.green.label,.ui.green.labels .label{background-color:#2d693b!important;border-color:#2d693b!important}
+.ui.basic.green.labels a.label:hover,a.ui.basic.green.label:hover{background-color:#16ab39!important;border-color:#16ab39!important;color:#fff!important}
+.issue.list>.item .comment{color:#129c92}
+.ui.basic.button,.ui.basic.buttons .button{color:#797979!important}
+.ui.basic.red.active.button,.ui.basic.red.buttons .active.button{box-shadow:0 0 0 1px #c75252 inset!important;color:#c75252!important}
+.ui.basic.button:focus,.ui.basic.button:hover,.ui.basic.buttons .button:focus,.ui.basic.buttons .button:hover{background:0 0!important;color:#dbdbdb!important}
+.ui.menu .item{background:#404552;color:#9e9e9e}
+.ui.menu .item.disabled,.ui.menu .item.disabled:hover{color:#626773}
+.ui.pagination.menu .active.item{color:#dbdbdb;background-color:#87ab63}
+.repository .header-wrapper{background-color:#2a2e3a}
+.ui.tabular.menu .active.item{background:#383c4a;color:#dbdbdb;border-left:1px solid transparent;border-right:1px solid transparent;border-top:none}
+.ui.tabular.menu .item{color:#9e9e9e}
+.ui.tabular.menu .item:hover{color:#dbdbdb}
+.ui.breadcrumb .divider,.ui.header{color:#9e9e9e}
+.ui.blue.label,.ui.blue.labels .label{background-color:#26577b!important;border-color:#26577b!important}
+.ui.menu .item>.label{background:#565454}
+.ui.blue.button,.ui.blue.buttons .button{background-color:#87ab63}
+.ui.blue.button:hover,.ui.blue.buttons .button:hover{background-color:#a0cc75}
+.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url]{background:#404552;border:2px solid #353945}
+.ui.form input:not([type]):focus,.ui.form input[type=date]:focus,.ui.form input[type=datetime-local]:focus,.ui.form input[type=email]:focus,.ui.form input[type=number]:focus,.ui.form input[type=password]:focus,.ui.form input[type=search]:focus,.ui.form input[type=tel]:focus,.ui.form input[type=text]:focus,.ui.form input[type=time]:focus,.ui.form input[type=url]:focus{background:#404552;border:2px solid #4b505f;color:#dbdbdb}
+.ui.action.input:not([class*="left action"]) input:focus{border-right-color:#4b505f!important}
+.ui.green.button,.ui.green.buttons .button{background-color:#87ab63}
+.ui.green.button:hover,.ui.green.buttons .button:hover{background-color:#a0cc75}
+.ui.button{background:#383c4a;border:1px solid #4c505c;color:#dbdbdb}
+.ui.labeled.button:not([class*="left labeled"])>.label,.ui[class*="left labeled"].button>.button{background:#404552;border:1px solid #4c505c;color:#87ab63}
+.ui.button:hover{background-color:#404552;color:#dbdbdb}
+.ui.table thead th{background:#404552;color:#dbdbdb}
+.repository.file.list #repo-files-table tr:hover{background-color:#393d4a}
+.ui.table{color:#a5a5a5!important;border:1px solid #4c505c;background:#353945}
+.ui.table tbody tr{border-bottom:1px solid #333640;background:#2a2e3a}
+.ui .text.grey{color:#808084!important}
+.ui.attached.table.segment{background:#353945;color:#dbdbdb!important}
+.markdown:not(code) h2{border-bottom:1px solid #304251}
+.hljs,.hljs-keyword,.hljs-selector-tag,.hljs-subst{color:#9daccc}
+.markdown:not(code) .highlight pre,.markdown:not(code) pre{background-color:#2a2e3a;border:1px solid #404552}
+.markdown:not(code) table tr:nth-child(2n){background-color:#474d61}
+.ui.dropdown .menu{background:#2c303a}
+.ui.dropdown .menu>.message:not(.ui){color:#636363}
+.ui.input{color:#dbdbdb}
+.overflow.menu .items .item{color:#9d9d9d}
+.overflow.menu .items .item:hover{color:#dbdbdb}
+.ui.segment{background:#353945;color:#9e9e9e!important;border:1px solid #404552}
+.ui.active.button:active,.ui.button:active,.ui.button:focus{background-color:#2e3e4e;color:#dbdbdb}
+.ui.dropdown .menu .selected.item,.ui.dropdown.selected{color:#dbdbdb}
+.ui.dropdown .menu>.item:hover{color:#dbdbdb}
+.ui.dropdown .menu>.item{color:#9e9e9e}
+.ui.attached.segment{border:1px solid #404552}
+.repository.view.issue .comment-list .comment .content>.bottom.segment{background:#353945}
+.repository.view.issue .comment-list .comment .content .header{color:#dbdbdb;background-color:#404552;border-bottom:1px solid #353944}
+.ui .text.grey a{color:#b3b3b3!important}
+.ui.comments .comment .actions a{color:#dbdbdb}
+.repository.view.issue .comment-list .comment .content .header:after{border-right-color:#404552}
+.repository.new.issue .comment.form .content:after{border-right-color:#353945}
+.repository.view.issue .comment-list .comment .content .header:before{border-right-color:#404552}
+.repository.new.issue .comment.form .content:before{border-right-color:#353945}
+.repository.view.issue .comment-list:before{background-color:#313c47}
+.repository .comment.form .content .form:after{border-right-color:#313c47}
+.repository .comment.form .content .form:before{border-right-color:#313c47}
+.ui .text.grey a{color:#dbdbdb!important}
+.ui .text.grey a:hover{color:#dbdbdb!important}
+.ui.basic.green.active.button,.ui.basic.green.buttons .active.button{color:#13ae38!important}
+.ui.form textarea,.ui.form textarea:focus{background:#1a2632;border:1px solid #313c47;color:#dbdbdb}
+.ui.form textarea:focus{border:1px solid #456580}
+.ui .info.segment.top{background-color:#404552!important}
+.repository .diff-file-box .code-diff-unified tbody tr.del-code td{background-color:#3c2626!important;border-color:#634343!important}
+.repository .diff-file-box .code-diff-unified tbody tr.add-code td{background-color:#283e2d!important;border-color:#314a37!important}
+.repository .diff-file-box .code-diff tbody tr .added-code{background-color:#3a523a}
+.repository .diff-file-box .code-diff .lines-num{border-right:1px solid #2d2d2d}
+.repository .diff-file-box .file-body.file-code .lines-num{color:#9e9e9e;background:#2e323e}
+.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{border-color:#2d2d2d!important}
+.repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #2d2d2d}
+.hljs-section,.hljs-selector-id,.hljs-title{color:#986c88}
+.hljs-doctag,.hljs-string{color:#949494}
+.repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#5f3737}
+.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#292727!important}
+.ui.vertical.menu .active.item{background:#4B5162}
+.ui.vertical.menu .item{background:#353945}
+.ui.vertical.menu .header.item{background:#404552}
+.ui.vertical.menu{background:#353945;border:1px solid #333640}
+.ui.repository.list .item:not(:first-child){border-top:1px solid #4c505c}
+.ui .text.blue{color:#87ab63!important}
+.ui.selection.active.dropdown,.ui.selection.active.dropdown .menu{border-color:#4e5361;box-shadow:0 2px 3px 0 rgba(34,36,38,.15)}
+.ui.selection.active.dropdown:hover,.ui.selection.active.dropdown:hover .menu{border-color:#4e5361;box-shadow:0 2px 3px 0 rgba(34,36,38,.15)}
+.ui.selection.dropdown{background:#404552;border:1px solid #404552;color:#9e9e9e}
+.ui.menu .ui.dropdown .menu>.active.item{color:#dbdbdb!important}
+.ui.tabular.menu{border-bottom:1px solid #313c47}
+.ui.card,.ui.cards>.card{background:#353945;box-shadow:0 1px 3px 0 #4c505c,0 0 0 1px #4c505c}
+.ui.card>.content>.header,.ui.cards>.card>.content>.header{color:#dbdbdb}
+.ui.card>.extra a:not(.ui),.ui.cards>.card>.extra a:not(.ui){color:#87ab63}
+.ui .text.black{color:#9e9e9e}
+.ui .text.black:hover{color:#dbdbdb}
+.ui.secondary.segment{background:#353945}
+.ui.secondary.pointing.menu .active.item{border-color:#87ab63;color:#dbdbdb;background:#404552}
+.ui.user.list .item:not(:first-child){border-top:1px solid #4c505c}
+.ui.secondary.pointing.menu .active.item:hover{border-color:#af8b4c;color:#dbdbdb;background:#4b5162}
+.ui.secondary.pointing.menu .dropdown.item:hover,.ui.secondary.pointing.menu .link.item:hover,.ui.secondary.pointing.menu a.item:hover{color:#dbdbdb}
+.ui.checkbox label,.ui.checkbox+label,.ui.form .field>label{color:#9e9e9e}
+.ui.form .inline.field>label,.ui.form .inline.field>p,.ui.form .inline.fields .field>label,.ui.form .inline.fields .field>p,.ui.form .inline.fields>label{color:#9e9e9e}
+.user.settings .email.list .item:not(:first-child){border-top:1px solid #3f4451}
+.explore .navbar{background-color:#2a2e3a!important}
+.ui.menu.new-menu{background-color:#2a2e3a!important}
+@media only screen and (max-width:1200px){.ui.menu.new-menu:after{background-image:linear-gradient(to right,rgba(42,46,42,0),#2a2e2a 100%)}
+}
+input{background:#2e323e}
+.ui.secondary.pointing.menu .active.item{border:none;background:#383c4a}
+.settings .key.list .item:not(:first-child){border-top:1px solid #404552}
+.ui.form input:not([type]),.ui.form input[type=date],.ui.form input[type=datetime-local],.ui.form input[type=email],.ui.form input[type=number],.ui.form input[type=password],.ui.form input[type=search],.ui.form input[type=tel],.ui.form input[type=text],.ui.form input[type=time],.ui.form input[type=url]{color:#9e9e9e}
+.ui.attached.info.message,.ui.info.message{box-shadow:0 0 0 1px #4b5e71 inset,0 0 0 0 transparent}
+.ui.bottom.attached.message{background-color:#2c662d;color:#87ab63}
+.ui.bottom.attached.message .pull-right{color:#87ab63}
+.ui.info.message{background-color:#2c3b4a;color:#9ebcc5}
+.CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
+.ui .warning.header{background-color:#5d3a22!important;border-color:#794f31}
+.ui.red.message{background-color:rgba(80,23,17,.6);color:#f9cbcb;box-shadow:0 0 0 1px rgba(121,71,66,.5) inset,0 0 0 0 transparent}
+.ui.red.button,.ui.red.buttons .button{background-color:#7d3434}
+.ui.red.button:hover,.ui.red.buttons .button:hover{background-color:#984646}
+.ui.checkbox label:hover,.ui.checkbox+label:hover{color:#dbdbdb!important}
+.ui.checkbox input:checked~.box:after,.ui.checkbox input:checked~label:after{color:#7f98ad}
+.ui.checkbox input:checked~.box:before,.ui.checkbox input:checked~label:before{background:#304251}
+.ui.checkbox .box:hover::before,.ui.checkbox label:hover::before{background:#304251}
+.ui.checkbox .box:before,.ui.checkbox label:before{background:#304251;border:1px solid #304251}
+.ui.checkbox .box:active::before,.ui.checkbox label:active::before{background:#304251;border-color:rgba(34,36,38,.35)}
+.ui.checkbox input:checked~.box:before,.ui.checkbox input:checked~label:before{border-color:#304251;background:#304251}
+.ui.checkbox input:focus~.box:before,.ui.checkbox input:focus~label:before{border-color:#304251;background:#304251}
+.ui.checkbox input:checked:focus~.box:before,.ui.checkbox input:checked:focus~label:before,.ui.checkbox input:not([type=radio]):indeterminate:focus~.box:before,.ui.checkbox input:not([type=radio]):indeterminate:focus~label:before{border-color:#304251;background:#304251}
+.ui.checkbox input:checked~.box:after,.ui.checkbox input:checked~label:after{opacity:1;color:#7f98ad}
+.ui.checkbox input:checked:focus~.box:after,.ui.checkbox input:checked:focus~label:after,.ui.checkbox input:not([type=radio]):indeterminate:focus~.box:after,.ui.checkbox input:not([type=radio]):indeterminate:focus~label:after{color:#7f98ad}
+.ui.checkbox input:focus~.box:after,.ui.checkbox input:focus~label,.ui.checkbox input:focus~label:after{color:#9a9a9a}
+.ui.selection.dropdown:hover{border:1px solid #456580}
+.ui.selection.dropdown .menu>.item{border-top:1px solid #313c47}
+.ui.selection.visible.dropdown>.text:not(.default){color:#9e9e9e}
+.ui.negative.message{background-color:rgba(80,23,17,.6);color:#f9cbcb;box-shadow:0 0 0 1px rgba(121,71,66,.5) inset,0 0 0 0 transparent}
+.hljs-attribute,.hljs-name,.hljs-tag{color:#ef5e77}
+.user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #4c505c}
+.ui.form textarea,.ui.form textarea:focus{background:#404552;border:2px solid #353945}
+.hljs-literal,.hljs-number,.hljs-tag .hljs-attr,.hljs-template-variable,.hljs-variable{color:#bd84bf}
+.hljs-doctag,.hljs-string{color:#8ab398}
+.ui.form .dropzone{border:2px dashed #4c505c}
+.ui.basic.red.button,.ui.basic.red.buttons .button{box-shadow:0 0 0 1px #a04141 inset!important;color:#a04141!important}
+.ui.list .list>.item .header,.ui.list>.item .header{color:#dedede}
+.ui.list .list>.item .description,.ui.list>.item .description{color:#9e9e9e}
+.ui.user.list .item .description a{color:#668cb1}
+.repository.file.list #file-content .code-view .lines-num{background:#2e323e}
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule{color:#7c9b5e}
+.ui.blue.button:focus,.ui.blue.buttons .button:focus{background-color:#87ab63}
+.ui.basic.blue.button:hover,.ui.basic.blue.buttons .button:hover{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
+.ui.basic.blue.button:focus,.ui.basic.blue.buttons .button:focus{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
+.repository.file.list #file-content .code-view .lines-code .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}
+a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb}
+.repository .label.list .item{border-bottom:1px dashed #4c505c}
+.repository.file.list #file-content .code-view .lines-num{background:#2e323e}
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule{color:#7c9b5e}
+.ui.basic.blue.button,.ui.basic.blue.buttons .button{box-shadow:0 0 0 1px #a27558 inset!important;color:#a27558!important}
+.repository.file.list #file-content .code-view .lines-code .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}
+a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb}
+.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(4){background-color:#2a2e3a}
+.repository .diff-file-box .code-diff-split tbody tr td.add-code,.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(4){background-color:#283e2d!important;border-color:#314a37!important}
+.repository .diff-file-box .code-diff-split tbody tr td.del-code,.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(2){background-color:#3c2626!important;border-color:#634343!important}
+.ui.blue.button:focus,.ui.blue.buttons .button:focus{background-color:#a27558}
+.ui.blue.button:active,.ui.blue.buttons .button:active{background-color:#a27558}
+#git-graph-container li a{color:#c79575}
+#git-graph-container li .author{color:#c79575}
+.ui.header .sub.header{color:#9e9e9e}
+.ui.dividing.header{border-bottom:1px solid #4c505c}
+.ui.modal>.header{background:#404552;color:#dbdbdb}
+.ui.modal>.actions{background:#404552;border-top:1px solid #404552}
+.ui.modal>.content{background:#383c4a}
+.ui.basic.blue.button,.ui.basic.blue.buttons .button{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
+.editor-toolbar{background-color:#404552}
+.editor-toolbar a{color:#87ab63!important}
+.CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:none}
+.CodeMirror-gutters{background-color:#2b2b2b}
+.repository .diff-detail-box{background-color:#383c4a}
+.repository .diff-detail-box .detail-files{background-color:inherit}
+.comment-code-cloud .ui.attached.tabular.menu{background:none transparent;border:none}
+.comment-code-cloud .footer .markdown-info{color:inherit}
+.file-comment{color:#888}
+.ui.comments .comment .author{color:#dbdbdb}
+.ui.comments .comment .metadata{color:#808084}
+.ui.comments .comment .text{color:#9e9e9e}
+.heatmap-color-0{background-color:#2d303b}


### PR DESCRIPTION
**Why?**
Every PR touching css needs a rebase after a single change in an merged PR. Single line will only conflict if the same line/area is modified. Less Builds, less conflicts

Also i added -s0 option. No comments with `?*!` will be removed (used for licenses).

I also would like the source map option, but isn't in code like all other options.

**Doku**
https://github.com/jakubpawlowicz/clean-css/tree/v3.0.1#how-to-use-clean-css-cli