### PR TITLE
Webhook Logs show proper HTTP Method, and allow change HTTP method in form

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -760,6 +760,9 @@ func (t *HookTask) deliver() {
 
 	var req *httplib.Request
 	switch t.HTTPMethod {
+	case "":
+		log.Info("HTTP Method for webhook %d empty, setting to POST as default", t.ID)
+		fallthrough
 	case http.MethodPost:
 		req = httplib.Post(t.URL)
 		switch t.ContentType {

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -755,17 +755,12 @@ func prepareWebhooks(e Engine, repo *Repository, event HookEventType, p api.Payl
 
 func (t *HookTask) deliver() {
 	t.IsDelivered = true
-	t.RequestInfo = &HookRequest{
-		Headers: map[string]string{},
-	}
-	t.ResponseInfo = &HookResponse{
-		Headers: map[string]string{},
-	}
 
 	timeout := time.Duration(setting.Webhook.DeliverTimeout) * time.Second
 
 	var req *httplib.Request
-	if t.HTTPMethod == http.MethodPost {
+	switch t.HTTPMethod {
+	case http.MethodPost:
 		req = httplib.Post(t.URL)
 		switch t.ContentType {
 		case ContentTypeJSON:
@@ -773,10 +768,10 @@ func (t *HookTask) deliver() {
 		case ContentTypeForm:
 			req.Param("payload", t.PayloadContent)
 		}
-	} else if t.HTTPMethod == http.MethodGet {
+	case http.MethodGet:
 		req = httplib.Get(t.URL).Param("payload", t.PayloadContent)
-	} else {
-		t.ResponseInfo.Body = fmt.Sprintf("Invalid http method: %v", t.HTTPMethod)
+	default:
+		log.Error("Invalid http method for webhook: [%d] %v", t.ID, t.HTTPMethod)
 		return
 	}
 
@@ -792,8 +787,15 @@ func (t *HookTask) deliver() {
 		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: setting.Webhook.SkipTLSVerify})
 
 	// Record delivery information.
+	t.RequestInfo = &HookRequest{
+		Headers: map[string]string{},
+	}
 	for k, vals := range req.Headers() {
 		t.RequestInfo.Headers[k] = strings.Join(vals, ",")
+	}
+
+	t.ResponseInfo = &HookResponse{
+		Headers: map[string]string{},
 	}
 
 	defer func() {

--- a/routers/api/v1/utils/hook.go
+++ b/routers/api/v1/utils/hook.go
@@ -98,6 +98,7 @@ func addHook(ctx *context.APIContext, form *api.CreateHookOption, orgID, repoID 
 		URL:         form.Config["url"],
 		ContentType: models.ToHookContentType(form.Config["content_type"]),
 		Secret:      form.Config["secret"],
+		HTTPMethod:  "POST",
 		HookEvent: &models.HookEvent{
 			ChooseEvents: true,
 			HookEvents: models.HookEvents{

--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -564,6 +564,7 @@ func WebHooksEditPost(ctx *context.Context, form auth.NewWebhookForm) {
 	w.Secret = form.Secret
 	w.HookEvent = ParseHookEvent(form.WebhookForm)
 	w.IsActive = form.Active
+	w.HTTPMethod = form.HTTPMethod
 	if err := w.UpdateEvent(); err != nil {
 		ctx.ServerError("UpdateEvent", err)
 		return

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -45,7 +45,7 @@
 							{{if .RequestInfo}}
 								<h5>{{$.i18n.Tr "repo.settings.webhook.headers"}}</h5>
 								<pre class="raw"><strong>Request URL:</strong> {{.URL}}
-<strong>Request method:</strong> POST
+<strong>Request method:</strong> {{if .HTTPMethod}}{{.HTTPMethod}}{{else}}POST{{end}}
 {{ range $key, $val := .RequestInfo.Headers }}<strong>{{$key}}:</strong> {{$val}}
 {{end}}</pre>
 								<h5>{{$.i18n.Tr "repo.settings.webhook.payload"}}</h5>


### PR DESCRIPTION
Fix #6951

Note: this doesn't solve issues some users were having with webhooks not sending.