### PR TITLE
Fix /verify LFS handler expecting wrong content-type

### DIFF
--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	contentMediaType = "application/vnd.git-lfs"
-	metaMediaType    = contentMediaType + "+json"
+	metaMediaType = "application/vnd.git-lfs+json"
 )
 
 // RequestVars contain variables from the HTTP request. Variables from routing, json body decoding, and
@@ -101,11 +100,10 @@ func ObjectOidHandler(ctx *context.Context) {
 			getMetaHandler(ctx)
 			return
 		}
-		if ContentMatcher(ctx.Req) || len(ctx.Params("filename")) > 0 {
-			getContentHandler(ctx)
-			return
-		}
-	} else if ctx.Req.Method == "PUT" && ContentMatcher(ctx.Req) {
+
+		getContentHandler(ctx)
+		return
+	} else if ctx.Req.Method == "PUT" {
 		PutHandler(ctx)
 		return
 	}
@@ -348,7 +346,7 @@ func VerifyHandler(ctx *context.Context) {
 		return
 	}
 
-	if !ContentMatcher(ctx.Req) {
+	if !MetaMatcher(ctx.Req) {
 		writeStatus(ctx, 400)
 		return
 	}
@@ -385,7 +383,6 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 	}
 
 	header := make(map[string]string)
-	header["Accept"] = contentMediaType
 
 	if rv.Authorization == "" {
 		//https://github.com/github/git-lfs/issues/1088
@@ -408,14 +405,6 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 	}
 
 	return rep
-}
-
-// ContentMatcher provides a mux.MatcherFunc that only allows requests that contain
-// an Accept header with the contentMediaType
-func ContentMatcher(r macaron.Request) bool {
-	mediaParts := strings.Split(r.Header.Get("Accept"), ";")
-	mt := mediaParts[0]
-	return mt == contentMediaType
 }
 
 // MetaMatcher provides a mux.MatcherFunc that only allows requests that contain


### PR DESCRIPTION
According to [spec](https://github.com/git-lfs/git-lfs/blob/master/docs/api/basic-transfers.md#verification),
/verify requests must have "Accept: application/vnd.git-lfs+json"

Previous code worked just because native `git-lfs` implementation *replaced* Accept header that is required by
spec with value given by Gitea ("application/vnd.git-lfs"), however this

1. Doesn't apply to other clients, at least `git-lfs-java` *appends* headers instead of replacing them
2. Forces client to violate spec and send unexpected Accept header