### PR TITLE
Allow collaborators to view repo owned by private org

### DIFF
--- a/integrations/org_test.go
+++ b/integrations/org_test.go
@@ -92,6 +92,15 @@ func TestPrivateOrg(t *testing.T) {
 	req = NewRequest(t, "GET", "/privated_org/private_repo_on_private_org")
 	session.MakeRequest(t, req, http.StatusNotFound)
 
+	// non-org member who is collaborator on repo in private org
+	session = loginUser(t, "user4")
+	req = NewRequest(t, "GET", "/privated_org")
+	session.MakeRequest(t, req, http.StatusNotFound)
+	req = NewRequest(t, "GET", "/privated_org/public_repo_on_private_org") // colab of this repo
+	session.MakeRequest(t, req, http.StatusOK)
+	req = NewRequest(t, "GET", "/privated_org/private_repo_on_private_org")
+	session.MakeRequest(t, req, http.StatusNotFound)
+
 	// site admin
 	session = loginUser(t, "user1")
 	req = NewRequest(t, "GET", "/privated_org")

--- a/models/fixtures/collaboration.yml
+++ b/models/fixtures/collaboration.yml
@@ -9,3 +9,9 @@
   repo_id: 4
   user_id: 4
   mode: 2 # write
+
+-
+  id: 3
+  repo_id: 40
+  user_id: 4
+  mode: 2 # write


### PR DESCRIPTION
Handle case where an organization is private but a user who is not a member of the organization has been added as a collaborator of a repo within that org

Fixes #6962