### PR TITLE
Fix TestSearchRepo by waiting till indexing is done

### DIFF
--- a/integrations/repo_search_test.go
+++ b/integrations/repo_search_test.go
@@ -39,14 +39,18 @@ func TestSearchRepo(t *testing.T) {
 	log.Printf("Waiting for indexing\n")
 
 	i := 0
-	for {
-		if repo.IndexerStatus != nil && len(repo.IndexerStatus.CommitSha) != 0 && i <= 60 {
+	for i < 60 {
+		if repo.IndexerStatus != nil && len(repo.IndexerStatus.CommitSha) != 0 {
 			break
 		}
 		time.Sleep(1 * time.Second)
 		i++
 	}
-	log.Printf("Indexing took: %d s\n", i)
+	if i < 60 {
+		log.Printf("Indexing took: %ds\n", i)
+	} else {
+		log.Printf("Waited the limit: %ds for indexing, continuing\n", i)
+	}
 
 	req := NewRequestf(t, "GET", "/user2/repo1/search?q=Description&page=1")
 	resp := MakeRequest(t, req, http.StatusOK)

--- a/integrations/repo_search_test.go
+++ b/integrations/repo_search_test.go
@@ -40,7 +40,7 @@ func TestSearchRepo(t *testing.T) {
 
 	i := 0
 	for {
-		if repo.IndexerStatus != nil && len(repo.IndexerStatus.CommitSha) != 0 && i <= 60 {
+		if (repo.IndexerStatus != nil && len(repo.IndexerStatus.CommitSha) != 0) || i > 60 {
 			break
 		}
 		time.Sleep(1 * time.Second)

--- a/integrations/repo_search_test.go
+++ b/integrations/repo_search_test.go
@@ -5,8 +5,12 @@
 package integrations
 
 import (
+	"log"
 	"net/http"
 	"testing"
+	"time"
+
+	"code.gitea.io/gitea/models"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
@@ -26,6 +30,23 @@ func resultFilenames(t testing.TB, doc *HTMLDoc) []string {
 
 func TestSearchRepo(t *testing.T) {
 	prepareTestEnv(t)
+
+	repo, err := models.GetRepositoryByOwnerAndName("user2", "repo1")
+	assert.NoError(t, err)
+
+	models.UpdateRepoIndexer(repo)
+
+	log.Printf("Waiting for indexing\n")
+
+	i := 0
+	for {
+		if repo.IndexerStatus != nil && len(repo.IndexerStatus.CommitSha) != 0 && i <= 60 {
+			break
+		}
+		time.Sleep(1 * time.Second)
+		i++
+	}
+	log.Printf("Indexing took: %d s\n", i)
 
 	req := NewRequestf(t, "GET", "/user2/repo1/search?q=Description&page=1")
 	resp := MakeRequest(t, req, http.StatusOK)


### PR DESCRIPTION
Fixes #6977 by force waiting till the repository has finished updating the index.