### PR TITLE
Fix #6960 - LFS OID urls uses unusual content-type header

### DIFF
--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -345,11 +345,6 @@ func VerifyHandler(ctx *context.Context) {
 		return
 	}
 
-	if !MetaMatcher(ctx.Req) {
-		writeStatus(ctx, 400)
-		return
-	}
-
 	rv := unpack(ctx)
 
 	meta, _ := getAuthenticatedRepoAndMeta(ctx, rv, true)
@@ -400,8 +395,12 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 
 	if upload && !download {
 		// Force client side verify action while gitea lacks proper server side verification
-		header["Accept"] = metaMediaType
-		rep.Actions["verify"] = &link{Href: rv.VerifyLink(), Header: header}
+		verifyHeader := make(map[string]string)
+		for k, v := range header {
+			verifyHeader[k] = v
+		}
+		verifyHeader["Accept"] = metaMediaType
+		rep.Actions["verify"] = &link{Href: rv.VerifyLink(), Header: verifyHeader}
 	}
 
 	return rep

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	contentMediaType = "application/vnd.git-lfs"
-	metaMediaType    = contentMediaType + "+json"
+	metaMediaType = "application/vnd.git-lfs+json"
 )
 
 // RequestVars contain variables from the HTTP request. Variables from routing, json body decoding, and
@@ -385,7 +384,6 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 	}
 
 	header := make(map[string]string)
-	header["Accept"] = contentMediaType
 
 	if rv.Authorization == "" {
 		//https://github.com/github/git-lfs/issues/1088
@@ -415,7 +413,7 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 func ContentMatcher(r macaron.Request) bool {
 	mediaParts := strings.Split(r.Header.Get("Accept"), ";")
 	mt := mediaParts[0]
-	return mt == contentMediaType
+	return mt != metaMediaType
 }
 
 // MetaMatcher provides a mux.MatcherFunc that only allows requests that contain

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -100,10 +100,8 @@ func ObjectOidHandler(ctx *context.Context) {
 			getMetaHandler(ctx)
 			return
 		}
-		if ContentMatcher(ctx.Req) || len(ctx.Params("filename")) > 0 {
-			getContentHandler(ctx)
-			return
-		}
+		getContentHandler(ctx)
+		return
 	} else if ctx.Req.Method == "PUT" && ContentMatcher(ctx.Req) {
 		PutHandler(ctx)
 		return
@@ -347,7 +345,7 @@ func VerifyHandler(ctx *context.Context) {
 		return
 	}
 
-	if !ContentMatcher(ctx.Req) {
+	if !MetaMatcher(ctx.Req) {
 		writeStatus(ctx, 400)
 		return
 	}
@@ -402,6 +400,7 @@ func Represent(rv *RequestVars, meta *models.LFSMetaObject, download, upload boo
 
 	if upload && !download {
 		// Force client side verify action while gitea lacks proper server side verification
+		header["Accept"] = metaMediaType
 		rep.Actions["verify"] = &link{Href: rv.VerifyLink(), Header: header}
 	}
 


### PR DESCRIPTION
This PR drops the unusual content-type requirement of "application/vnd.git-lfs" for repo.git/info/lfs/:oid, and just relies on the content-type not being "application/vnd.git-lfs+json". 

Fixes #6960

Of interest, I have been unable to find a definite use for the meta version of this url.