### PR TITLE
Fix documentation on Oauth2.Enable flag

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -698,7 +698,7 @@ DEFAULT_MAX_BLOB_SIZE = 10485760
 
 [oauth2]
 ; Enables OAuth2 provider
-ENABLED = true
+ENABLE = true
 ; Lifetime of an OAuth2 access token in seconds
 ACCESS_TOKEN_EXPIRATION_TIME=3600
 ; Lifetime of an OAuth2 access token in hours

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -419,7 +419,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 
 ## OAuth2 (`oauth2`)
 
-- `ENABLED`: **true**: Enables OAuth2 provider.
+- `ENABLE`: **true**: Enables OAuth2 provider.
 - `ACCESS_TOKEN_EXPIRATION_TIME`: **3600**: Lifetime of an OAuth2 access token in seconds
 - `REFRESH_TOKEN_EXPIRATION_TIME`: **730**: Lifetime of an OAuth2 access token in hours
 - `INVALIDATE_REFRESH_TOKEN`: **false**: Check if refresh token got already used


### PR DESCRIPTION
The docs list this as ENABLED, but in the source code it's
ENABLE, meaning following the docs leads to confusion.