### PR TITLE
WIP: Allow slashes in repository names

### DIFF
--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -607,9 +607,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 	}, reqSignIn)
 
 	// ***** Release Attachment Download without Signin
-	m.Get("/:username/:reponame/releases/download/:vTag/:fileName", ignSignIn, context.RepoAssignment(), repo.MustBeNotEmpty, repo.RedirectDownload)
+	m.Get("/:username/:reponame+/releases/download/:vTag/:fileName", ignSignIn, context.RepoAssignment(), repo.MustBeNotEmpty, repo.RedirectDownload)
 
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Group("/settings", func() {
 			m.Combo("").Get(repo.Settings).
 				Post(bindIgnErr(auth.RepoSettingForm{}), repo.SettingsPost)
@@ -663,9 +663,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 		})
 	}, reqSignIn, context.RepoAssignment(), reqRepoAdmin, context.UnitTypes(), context.RepoRef())
 
-	m.Get("/:username/:reponame/action/:action", reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.RepoMustNotBeArchived(), repo.Action)
+	m.Get("/:username/:reponame+/action/:action", reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.RepoMustNotBeArchived(), repo.Action)
 
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Group("/issues", func() {
 			m.Combo("/new").Get(context.RepoRef(), repo.NewIssue).
 				Post(bindIgnErr(auth.CreateIssueForm{}), repo.NewIssuePost)
@@ -757,7 +757,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 	}, reqSignIn, context.RepoAssignment(), context.UnitTypes())
 
 	// Releases
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Group("/releases", func() {
 			m.Get("/", repo.MustBeNotEmpty, repo.Releases)
 		}, repo.MustBeNotEmpty, context.RepoRef())
@@ -785,11 +785,11 @@ func RegisterRoutes(m *macaron.Macaron) {
 		})
 	}, ignSignIn, context.RepoAssignment(), context.UnitTypes(), reqRepoReleaseReader)
 
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Post("/topics", repo.TopicsPost)
 	}, context.RepoAssignment(), context.RepoMustNotBeArchived(), reqRepoAdmin)
 
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Group("", func() {
 			m.Get("/^:type(issues|pulls)$", repo.Issues)
 			m.Get("/^:type(issues|pulls)$/:index", repo.ViewIssue)
@@ -899,19 +899,19 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/compare/:before([a-z0-9]{40})\\.\\.\\.:after([a-z0-9]{40})", repo.SetEditorconfigIfExists,
 			repo.SetDiffViewStyle, repo.MustBeNotEmpty, reqRepoCodeReader, repo.CompareDiff)
 	}, ignSignIn, context.RepoAssignment(), context.UnitTypes())
-	m.Group("/:username/:reponame", func() {
+	m.Group("/:username/:reponame+", func() {
 		m.Get("/stars", repo.Stars)
 		m.Get("/watchers", repo.Watchers)
 		m.Get("/search", reqRepoCodeReader, repo.Search)
 	}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
 	m.Group("/:username", func() {
-		m.Group("/:reponame", func() {
+		m.Group("/:reponame+", func() {
 			m.Get("", repo.SetEditorconfigIfExists, repo.Home)
 			m.Get("\\.git$", repo.SetEditorconfigIfExists, repo.Home)
 		}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
-		m.Group("/:reponame", func() {
+		m.Group("/:reponame+", func() {
 			m.Group("\\.git/info/lfs", func() {
 				m.Post("/objects/batch", lfs.BatchHandler)
 				m.Get("/objects/:oid/:filename", lfs.ObjectOidHandler)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -607,9 +607,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 	}, reqSignIn)
 
 	// ***** Release Attachment Download without Signin
-	m.Get("/:username/:reponame+/releases/download/:vTag/:fileName", ignSignIn, context.RepoAssignment(), repo.MustBeNotEmpty, repo.RedirectDownload)
+	m.Get("/:username/:reponame+/+/releases/download/:vTag/:fileName", ignSignIn, context.RepoAssignment(), repo.MustBeNotEmpty, repo.RedirectDownload)
 
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Group("/settings", func() {
 			m.Combo("").Get(repo.Settings).
 				Post(bindIgnErr(auth.RepoSettingForm{}), repo.SettingsPost)
@@ -663,9 +663,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 		})
 	}, reqSignIn, context.RepoAssignment(), reqRepoAdmin, context.UnitTypes(), context.RepoRef())
 
-	m.Get("/:username/:reponame+/action/:action", reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.RepoMustNotBeArchived(), repo.Action)
+	m.Get("/:username/:reponame+/+/action/:action", reqSignIn, context.RepoAssignment(), context.UnitTypes(), context.RepoMustNotBeArchived(), repo.Action)
 
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Group("/issues", func() {
 			m.Combo("/new").Get(context.RepoRef(), repo.NewIssue).
 				Post(bindIgnErr(auth.CreateIssueForm{}), repo.NewIssuePost)
@@ -757,7 +757,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 	}, reqSignIn, context.RepoAssignment(), context.UnitTypes())
 
 	// Releases
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Group("/releases", func() {
 			m.Get("/", repo.MustBeNotEmpty, repo.Releases)
 		}, repo.MustBeNotEmpty, context.RepoRef())
@@ -785,11 +785,11 @@ func RegisterRoutes(m *macaron.Macaron) {
 		})
 	}, ignSignIn, context.RepoAssignment(), context.UnitTypes(), reqRepoReleaseReader)
 
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Post("/topics", repo.TopicsPost)
 	}, context.RepoAssignment(), context.RepoMustNotBeArchived(), reqRepoAdmin)
 
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Group("", func() {
 			m.Get("/^:type(issues|pulls)$", repo.Issues)
 			m.Get("/^:type(issues|pulls)$/:index", repo.ViewIssue)
@@ -899,19 +899,19 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/compare/:before([a-z0-9]{40})\\.\\.\\.:after([a-z0-9]{40})", repo.SetEditorconfigIfExists,
 			repo.SetDiffViewStyle, repo.MustBeNotEmpty, reqRepoCodeReader, repo.CompareDiff)
 	}, ignSignIn, context.RepoAssignment(), context.UnitTypes())
-	m.Group("/:username/:reponame+", func() {
+	m.Group("/:username/:reponame+/+", func() {
 		m.Get("/stars", repo.Stars)
 		m.Get("/watchers", repo.Watchers)
 		m.Get("/search", reqRepoCodeReader, repo.Search)
 	}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
 	m.Group("/:username", func() {
-		m.Group("/:reponame+", func() {
+		m.Group("/:reponame+/+", func() {
 			m.Get("", repo.SetEditorconfigIfExists, repo.Home)
 			m.Get("\\.git$", repo.SetEditorconfigIfExists, repo.Home)
 		}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
-		m.Group("/:reponame+", func() {
+		m.Group("/:reponame+/+", func() {
 			m.Group("\\.git/info/lfs", func() {
 				m.Post("/objects/batch", lfs.BatchHandler)
 				m.Get("/objects/:oid/:filename", lfs.ObjectOidHandler)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -906,12 +906,12 @@ func RegisterRoutes(m *macaron.Macaron) {
 	}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
 	m.Group("/:username", func() {
-		m.Group("/:reponame+/+", func() {
+		m.Group("/:reponame+", func() {
 			m.Get("", repo.SetEditorconfigIfExists, repo.Home)
 			m.Get("\\.git$", repo.SetEditorconfigIfExists, repo.Home)
 		}, ignSignIn, context.RepoAssignment(), context.RepoRef(), context.UnitTypes())
 
-		m.Group("/:reponame+/+", func() {
+		m.Group("/:reponame+", func() {
 			m.Group("\\.git/info/lfs", func() {
 				m.Post("/objects/batch", lfs.BatchHandler)
 				m.Get("/objects/:oid/:filename", lfs.ObjectOidHandler)

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -10,20 +10,20 @@
                 <div class="ui right file-actions">
                     <div class="ui buttons">
                         {{if not .IsViewCommit}}
-                            <a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
+                            <a class="ui button" href="{{.RepoLink}}/+/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
                         {{end}}
-                        <a class="ui button" href="{{.RepoLink}}/src/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.normal_view"}}</a>
-                        <a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
+                        <a class="ui button" href="{{.RepoLink}}/+/src/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.normal_view"}}</a>
+                        <a class="ui button" href="{{.RepoLink}}/+/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
                         <a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
                     </div>
                     {{if .Repository.CanEnableEditor}}
                         {{if .CanEditFile}}
-                            <a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-pencil btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
+                            <a href="{{.RepoLink}}/+/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-pencil btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
                         {{else}}
                             <i class="octicon octicon-pencil btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i>
                         {{end}}
                         {{if .CanDeleteFile}}
-                            <a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-trashcan btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
+                            <a href="{{.RepoLink}}/+/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-trashcan btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
                         {{else}}
                             <i class="octicon octicon-trashcan btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i>
                         {{end}}

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -53,7 +53,7 @@
 							{{end}}
 						</div>
 					</a>
-					<form ref="newBranchForm" action="{{.RepoLink}}/branches/_new/{{EscapePound .BranchNameSubURL}}" method="post">
+					<form ref="newBranchForm" action="{{.RepoLink}}/+/branches/_new/{{EscapePound .BranchNameSubURL}}" method="post">
 						{{.CsrfTokenHtml}}
 						<input type="hidden" name="new_branch_name" v-model="searchTerm">
 					</form>

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -6,7 +6,7 @@
 		<div class="ui secondary stackable menu mobile--margin-between-items">
 		{{template "repo/branch_dropdown" .}}
 			<div class="fitted item">
-				<a href="{{.RepoLink}}/graph" class="ui basic small compact button">
+				<a href="{{.RepoLink}}/+/graph" class="ui basic small compact button">
 					<span class="text">
 						<i class="octicon octicon-git-branch"></i>
 					</span>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -9,7 +9,7 @@
 		</div>
 		<div class="six wide right aligned column">
 			{{if .PageIsCommits}}
-				<form class="ignore-dirty" action="{{.RepoLink}}/commits/{{.BranchNameSubURL | EscapePound}}/search">
+				<form class="ignore-dirty" action="{{.RepoLink}}/+/commits/{{.BranchNameSubURL | EscapePound}}/search">
 					<div class="ui tiny search input">
 						<input name="q" placeholder="{{.i18n.Tr "repo.commits.search"}}" value="{{.Keyword}}" autofocus>
 					</div>

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -30,8 +30,8 @@
 				<div class="ui top attached tabular menu" data-write="write" data-preview="preview" data-diff="diff">
 					<a class="active item" data-tab="write"><i class="octicon octicon-code"></i> {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
 					{{if not .IsNewFile}}
-					<a class="item" data-tab="preview" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL | EscapePound}}" data-preview-file-modes="{{.PreviewableFileModes}}"><i class="octicon octicon-eye"></i> {{.i18n.Tr "preview"}}</a>
-					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | EscapePound}}/{{.TreePath | EscapePound}}" data-context="{{.BranchLink}}"><i class="octicon octicon-diff"></i> {{.i18n.Tr "repo.editor.preview_changes"}}</a>
+					<a class="item" data-tab="preview" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/+/src/{{.BranchNameSubURL | EscapePound}}" data-preview-file-modes="{{.PreviewableFileModes}}"><i class="octicon octicon-eye"></i> {{.i18n.Tr "preview"}}</a>
+					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/+/_preview/{{.BranchName | EscapePound}}/{{.TreePath | EscapePound}}" data-context="{{.BranchLink}}"><i class="octicon octicon-diff"></i> {{.i18n.Tr "repo.editor.preview_changes"}}</a>
 					{{end}}
 				</div>
 				<div class="ui bottom attached active tab segment" data-tab="write">

--- a/templates/repo/editor/upload.tmpl
+++ b/templates/repo/editor/upload.tmpl
@@ -27,7 +27,7 @@
 			</div>
 			<div class="field">
 				<div class="files"></div>
-				<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{.RepoLink}}/upload-file" data-remove-url="{{.RepoLink}}/upload-remove" data-csrf="{{.CsrfToken}}" data-accepts="{{.UploadAllowedTypes}}" data-max-file="{{.UploadMaxFiles}}" data-max-size="{{.UploadMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
+				<div class="ui basic button dropzone" id="dropzone" data-upload-url="{{.RepoLink}}/+/upload-file" data-remove-url="{{.RepoLink}}/+/upload-remove" data-csrf="{{.CsrfToken}}" data-accepts="{{.UploadAllowedTypes}}" data-max-file="{{.UploadMaxFiles}}" data-max-size="{{.UploadMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
 			</div>
 			{{template "repo/editor/commit_form" .}}
 		</form>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -52,7 +52,7 @@
 			{{end}}
 
 			{{if .Permission.CanRead $.UnitTypeIssues}}
-				<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
+				<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/+/issues">
 					<i class="octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
 				</a>
 			{{end}}
@@ -64,25 +64,25 @@
 			{{end}}
 
 			{{if and .Repository.CanEnablePulls (.Permission.CanRead $.UnitTypePullRequests)}}
-				<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
+				<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/+/pulls">
 					<i class="octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
 				</a>
 			{{end}}
 
 			{{if and (.Permission.CanRead $.UnitTypeReleases) (not .IsEmptyRepo) }}
-			<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
+			<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/+/releases">
 				<i class="octicon octicon-tag"></i> {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .Repository.NumReleases}}gray{{else}}blue{{end}} small label">{{.Repository.NumReleases}}</span>
 			</a>
 			{{end}}
 
 			{{if or (.Permission.CanRead $.UnitTypeWiki) (.Permission.CanRead $.UnitTypeExternalWiki)}}
-				<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki" {{if (.Permission.CanRead $.UnitTypeExternalWiki)}} target="_blank" rel="noopener noreferrer" {{end}}>
+				<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/+/wiki" {{if (.Permission.CanRead $.UnitTypeExternalWiki)}} target="_blank" rel="noopener noreferrer" {{end}}>
 					<i class="octicon octicon-book"></i> {{.i18n.Tr "repo.wiki"}}
 				</a>
 			{{end}}
 
 			{{if and (.Permission.CanReadAny $.UnitTypePullRequests $.UnitTypeIssues $.UnitTypeReleases) (not .IsEmptyRepo)}}
-				<a class="{{if .PageIsActivity}}active{{end}} item" href="{{.RepoLink}}/activity">
+				<a class="{{if .PageIsActivity}}active{{end}} item" href="{{.RepoLink}}/+/activity">
 					<i class="octicon octicon-pulse"></i> {{.i18n.Tr "repo.activity"}}
 				</a>
 			{{end}}
@@ -91,7 +91,7 @@
 
 			{{if .Permission.IsAdmin}}
 				<div class="right menu">
-					<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
+					<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/+/settings">
 						<i class="octicon octicon-tools"></i> {{.i18n.Tr "repo.settings"}}
 					</a>
 				</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -10,7 +10,7 @@
 			</div>
 			{{if .RepoSearchEnabled}}
 				<div class="ui repo-search">
-					<form class="ui form ignore-dirty" action="{{.RepoLink}}/search" method="get">
+					<form class="ui form ignore-dirty" action="{{.RepoLink}}/+/search" method="get">
 						<div class="field">
 							<div class="ui action input">
 								<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "repo.search.search_repo"}}">
@@ -42,7 +42,7 @@
 			</div>
 			<div class="two wide column">
 				<a class="ui button primary" href="javascript:;" id="save_topic"
-				data-link="{{.RepoLink}}/topics">{{.i18n.Tr "repo.topic.done"}}</a>
+				data-link="{{.RepoLink}}/+/topics">{{.i18n.Tr "repo.topic.done"}}</a>
 			</div>
 		</div>
 		{{end}}
@@ -70,24 +70,24 @@
 					</div>
 				{{end}}
 			{{else}}
-				<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/src/{{EscapePound .BranchNameSubURL}}" title="{{.Repository.Name}}">{{EllipsisString .Repository.Name 30}}</a>{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section" title="{{$v}}">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}" title="{{$v}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
+				<div class="fitted item"><span class="ui breadcrumb repo-path"><a class="section" href="{{.RepoLink}}/+/src/{{EscapePound .BranchNameSubURL}}" title="{{.Repository.Name}}">{{EllipsisString .Repository.Name 30}}</a>{{range $i, $v := .TreeNames}}<span class="divider">/</span>{{if eq $i $l}}<span class="active section" title="{{$v}}">{{EllipsisString $v 30}}</span>{{else}}{{ $p := index $.Paths $i}}<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $p}}" title="{{$v}}">{{EllipsisString $v 30}}</a></span>{{end}}{{end}}</span></div>
 			{{end}}
 			<div class="right fitted item" id="file-buttons">
 				<div class="ui tiny blue buttons">
 					{{if .Repository.CanEnableEditor}}
 						{{if .CanAddFile}}
-							<a href="{{.RepoLink}}/_new/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}" class="ui button">
+							<a href="{{.RepoLink}}/+/_new/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}" class="ui button">
 								{{.i18n.Tr "repo.editor.new_file"}}
 							</a>
 						{{end}}
 						{{if .CanUploadFile}}
-							<a href="{{.RepoLink}}/_upload/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}" class="ui button">
+							<a href="{{.RepoLink}}/+/_upload/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}" class="ui button">
 								{{.i18n.Tr "repo.editor.upload_file"}}
 							</a>
 						{{end}}
 					{{end}}
 					{{if and (ne $n 0) (not .IsViewFile) (not .IsBlame) }}
-						<a href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}" class="ui button">
+						<a href="{{.RepoLink}}/+/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}" class="ui button">
 							{{.i18n.Tr "repo.file_history"}}
 						</a>
 					{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -12,7 +12,7 @@
 			{{if not .Repository.IsArchived}}
 				<div class="column right aligned">
 					{{if .PageIsIssueList}}
-						<a class="ui green button" href="{{.RepoLink}}/issues/new">{{.i18n.Tr "repo.issues.new"}}</a>
+						<a class="ui green button" href="{{.RepoLink}}/+/issues/new">{{.i18n.Tr "repo.issues.new"}}</a>
 					{{else}}
 						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | EscapePound}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{.Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | EscapePound}}{{end}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 					{{end}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -12,9 +12,9 @@
 			{{if not .Repository.IsArchived}}
 				<div class="column right aligned">
 					{{if or .CanWriteIssues .CanWritePulls}}
-					<a class="ui grey button" href="{{.RepoLink}}/milestones/{{.MilestoneID}}/edit">{{.i18n.Tr "repo.milestones.edit"}}</a>
+					<a class="ui grey button" href="{{.RepoLink}}/+/milestones/{{.MilestoneID}}/edit">{{.i18n.Tr "repo.milestones.edit"}}</a>
 					{{end}}
-					<a class="ui green button" href="{{.RepoLink}}/issues/new?milestone={{.MilestoneID}}">{{.i18n.Tr "repo.issues.new"}}</a>
+					<a class="ui green button" href="{{.RepoLink}}/+/issues/new?milestone={{.MilestoneID}}">{{.i18n.Tr "repo.issues.new"}}</a>
 				</div>
 			{{end}}
 		</div>

--- a/templates/repo/issue/milestone_new.tmpl
+++ b/templates/repo/issue/milestone_new.tmpl
@@ -49,7 +49,7 @@
 				<div class="ui divider"></div>
 				<div class="ui right">
 					{{if .PageIsEditMilestone}}
-						<a class="ui blue basic button" href="{{.RepoLink}}/milestones">
+						<a class="ui blue basic button" href="{{.RepoLink}}/+/milestones">
 							{{.i18n.Tr "repo.milestones.cancel"}}
 						</a>
 						<button class="ui green button">

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -13,11 +13,11 @@
 		<div class="ui divider"></div>
 		{{template "base/alert" .}}
 		<div class="ui tiny basic buttons">
-			<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.RepoLink}}/milestones?state=open">
+			<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.RepoLink}}/+/milestones?state=open">
 				<i class="octicon octicon-milestone"></i>
 				{{.i18n.Tr "repo.milestones.open_tab" .OpenCount}}
 			</a>
-			<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.RepoLink}}/milestones?state=closed">
+			<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.RepoLink}}/+/milestones?state=closed">
 				<i class="octicon octicon-milestone"></i>
 				{{.i18n.Tr "repo.milestones.close_tab" .ClosedCount}}
 			</a>

--- a/templates/repo/issue/navbar.tmpl
+++ b/templates/repo/issue/navbar.tmpl
@@ -1,4 +1,4 @@
 <div class="ui compact left small menu">
-	<a class="{{if .PageIsLabels}}active{{end}} item" href="{{.RepoLink}}/labels">{{.i18n.Tr "repo.labels"}}</a>
-	<a class="{{if .PageIsMilestones}}active{{end}} item" href="{{.RepoLink}}/milestones">{{.i18n.Tr "repo.milestones"}}</a>
+	<a class="{{if .PageIsLabels}}active{{end}} item" href="{{.RepoLink}}/+/labels">{{.i18n.Tr "repo.labels"}}</a>
+	<a class="{{if .PageIsMilestones}}active{{end}} item" href="{{.RepoLink}}/+/milestones">{{.i18n.Tr "repo.milestones"}}</a>
 </div>

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -93,7 +93,7 @@
 				<span class="no-select item {{if .Milestone}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_milestone"}}</span>
 				<div class="selected">
 					{{if .Milestone}}
-						<a class="item" href="{{.RepoLink}}/issues?milestone={{.Milestone.ID}}"> {{.Milestone.Name}}</a>
+						<a class="item" href="{{.RepoLink}}/+/issues?milestone={{.Milestone.ID}}"> {{.Milestone.Name}}</a>
 					{{end}}
 				</div>
 			</div>
@@ -146,7 +146,7 @@
 				<span class="no-select item {{if .Assignee}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_assignees"}}</span>
 				<div class="selected">
 					{{if .Assignee}}
-						<a class="item" href="{{.RepoLink}}/issues?assignee={{.Assignee.ID}}"><img class="ui avatar image" src="{{.Assignee.RelAvatarLink}}"> {{.Assignee.Name}}</a>
+						<a class="item" href="{{.RepoLink}}/+/issues?assignee={{.Assignee.ID}}"><img class="ui avatar image" src="{{.Assignee.RelAvatarLink}}"> {{.Assignee.Name}}</a>
 					{{end}}
 				</div>
 			</div>-->

--- a/templates/repo/issue/view.tmpl
+++ b/templates/repo/issue/view.tmpl
@@ -9,9 +9,9 @@
 			{{if not .Repository.IsArchived}}
 				<div class="column right aligned">
 					{{if .PageIsIssueList}}
-						<a class="ui green button" href="{{.RepoLink}}/issues/new">{{.i18n.Tr "repo.issues.new"}}</a>
+						<a class="ui green button" href="{{.RepoLink}}/+/issues/new">{{.i18n.Tr "repo.issues.new"}}</a>
 					{{else}}
-						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/+/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 					{{end}}
 				</div>
 			{{end}}

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -60,7 +60,7 @@
 			<span class="no-select item {{if .Issue.Milestone}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_milestone"}}</span>
 			<div class="selected">
 				{{if .Issue.Milestone}}
-					<a class="item" href="{{.RepoLink}}/issues?milestone={{.Issue.Milestone.ID}}"> {{.Issue.Milestone.Name}}</a>
+					<a class="item" href="{{.RepoLink}}/+/issues?milestone={{.Issue.Milestone.ID}}"> {{.Issue.Milestone.Name}}</a>
 				{{end}}
 			</div>
 		</div>

--- a/templates/repo/pulls/commits.tmpl
+++ b/templates/repo/pulls/commits.tmpl
@@ -5,7 +5,7 @@
 		<div class="navbar">
 			{{template "repo/issue/navbar" .}}
 			<div class="ui right">
-				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/+/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 			</div>
 		</div>
 		<div class="ui divider"></div>

--- a/templates/repo/pulls/files.tmpl
+++ b/templates/repo/pulls/files.tmpl
@@ -5,7 +5,7 @@
 		<div class="navbar">
 			{{template "repo/issue/navbar" .}}
 			<div class="ui right">
-				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/+/compare/{{.BranchName | EscapePound}}...{{.PullRequestCtx.HeadInfo | EscapePound}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 			</div>
 		</div>
 		<div class="ui divider"></div>

--- a/templates/repo/pulls/tab_menu.tmpl
+++ b/templates/repo/pulls/tab_menu.tmpl
@@ -1,15 +1,15 @@
 <div class="ui top attached pull tabular stackable menu">
-	<a class="item {{if .PageIsPullConversation}}active{{end}}" href="{{.RepoLink}}/pulls/{{.Issue.Index}}">
+	<a class="item {{if .PageIsPullConversation}}active{{end}}" href="{{.RepoLink}}/+/pulls/{{.Issue.Index}}">
 		<span class="octicon octicon-comment-discussion"></span>
 		{{$.i18n.Tr "repo.pulls.tab_conversation"}}
 		<span class="ui {{if not .Issue.NumComments}}gray{{else}}blue{{end}} small label">{{.Issue.NumComments}}</span>
 	</a>
-	<a class="item {{if .PageIsPullCommits}}active{{end}}" {{if .NumCommits}}href="{{.RepoLink}}/pulls/{{.Issue.Index}}/commits"{{end}}>
+	<a class="item {{if .PageIsPullCommits}}active{{end}}" {{if .NumCommits}}href="{{.RepoLink}}/+/pulls/{{.Issue.Index}}/commits"{{end}}>
 		<span class="octicon octicon-git-commit"></span>
 		{{$.i18n.Tr "repo.pulls.tab_commits"}}
 		<span class="ui {{if not .NumCommits}}gray{{else}}blue{{end}} small label">{{if .NumCommits}}{{.NumCommits}}{{else}}N/A{{end}}</span>
 	</a>
-	<a class="item {{if .PageIsPullFiles}}active{{end}}" {{if .NumFiles}}href="{{.RepoLink}}/pulls/{{.Issue.Index}}/files"{{end}}>
+	<a class="item {{if .PageIsPullFiles}}active{{end}}" {{if .NumFiles}}href="{{.RepoLink}}/+/pulls/{{.Issue.Index}}/files"{{end}}>
 		<span class="octicon octicon-diff"></span>
 		{{$.i18n.Tr "repo.pulls.tab_files"}}
 		<span class="ui {{if not .NumFiles}}gray{{else}}blue{{end}} small label">{{if .NumFiles}}{{.NumFiles}}{{else}}N/A{{end}}</span>

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -65,7 +65,7 @@
 					<span class="help">{{.i18n.Tr "repo.release.prerelease_helper"}}</span>
 					<div class="field">
 						{{if .PageIsEditRelease}}
-							<a class="ui blue basic button" href="{{.RepoLink}}/releases">
+							<a class="ui blue basic button" href="{{.RepoLink}}/+/releases">
 								{{.i18n.Tr "repo.release.cancel"}}
 							</a>
 							{{if .IsDraft}}

--- a/templates/repo/settings/nav.tmpl
+++ b/templates/repo/settings/nav.tmpl
@@ -2,14 +2,14 @@
 	<p class="panel-header"><strong>{{.i18n.Tr "repo.settings"}}</strong></p>
 	<div class="panel-body">
 		<ul class="menu menu-vertical switching-list grid-1-5 left">
-			<li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="{{.RepoLink}}/settings">{{.i18n.Tr "repo.settings.options"}}</a></li>
-			<li {{if .PageIsSettingsCollaboration}}class="current"{{end}}><a href="{{.RepoLink}}/settings/collaboration">{{.i18n.Tr "repo.settings.collaboration"}}</a></li>
-			<li {{if .PageIsSettingsBranches}}class="current"{{end}}><a href="{{.RepoLink}}/settings/branches">{{.i18n.Tr "repo.settings.branches"}}</a></li>
-			<li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks">{{.i18n.Tr "repo.settings.hooks"}}</a></li>
+			<li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings">{{.i18n.Tr "repo.settings.options"}}</a></li>
+			<li {{if .PageIsSettingsCollaboration}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings/collaboration">{{.i18n.Tr "repo.settings.collaboration"}}</a></li>
+			<li {{if .PageIsSettingsBranches}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings/branches">{{.i18n.Tr "repo.settings.branches"}}</a></li>
+			<li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings/hooks">{{.i18n.Tr "repo.settings.hooks"}}</a></li>
 			{{if or .SignedUser.AllowGitHook .SignedUser.IsAdmin}}
-				<li {{if .PageIsSettingsGitHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks/git">{{.i18n.Tr "repo.settings.githooks"}}</a></li>
+				<li {{if .PageIsSettingsGitHooks}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings/hooks/git">{{.i18n.Tr "repo.settings.githooks"}}</a></li>
 			{{end}}
-			<li {{if .PageIsSettingsKeys}}class="current"{{end}}><a href="{{.RepoLink}}/settings/keys">{{.i18n.Tr "repo.settings.deploy_keys"}}</a></li>
+			<li {{if .PageIsSettingsKeys}}class="current"{{end}}><a href="{{.RepoLink}}/+/settings/keys">{{.i18n.Tr "repo.settings.deploy_keys"}}</a></li>
 		</ul>
 	</div>
 </div>

--- a/templates/repo/settings/navbar.tmpl
+++ b/templates/repo/settings/navbar.tmpl
@@ -1,24 +1,24 @@
 <div class="ui secondary pointing tabular top attached borderless menu stackable new-menu navbar">
-	<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.RepoLink}}/settings">
+	<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.RepoLink}}/+/settings">
 		{{.i18n.Tr "repo.settings.options"}}
 	</a>
-	<a class="{{if .PageIsSettingsCollaboration}}active{{end}} item" href="{{.RepoLink}}/settings/collaboration">
+	<a class="{{if .PageIsSettingsCollaboration}}active{{end}} item" href="{{.RepoLink}}/+/settings/collaboration">
 		{{.i18n.Tr "repo.settings.collaboration"}}
 	</a>
 	{{if not .Repository.IsEmpty}}
-		<a class="{{if .PageIsSettingsBranches}}active{{end}} item" href="{{.RepoLink}}/settings/branches">
+		<a class="{{if .PageIsSettingsBranches}}active{{end}} item" href="{{.RepoLink}}/+/settings/branches">
 			{{.i18n.Tr "repo.settings.branches"}}
 		</a>
 	{{end}}
-	<a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.RepoLink}}/settings/hooks">
+	<a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.RepoLink}}/+/settings/hooks">
 		{{.i18n.Tr "repo.settings.hooks"}}
 	</a>
 	{{if .SignedUser.CanEditGitHook}}
-		<a class="{{if .PageIsSettingsGitHooks}}active{{end}} item" href="{{.RepoLink}}/settings/hooks/git">
+		<a class="{{if .PageIsSettingsGitHooks}}active{{end}} item" href="{{.RepoLink}}/+/settings/hooks/git">
 			{{.i18n.Tr "repo.settings.githooks"}}
 		</a>
 	{{end}}
-	<a class="{{if .PageIsSettingsKeys}}active{{end}} item" href="{{.RepoLink}}/settings/keys">
+	<a class="{{if .PageIsSettingsKeys}}active{{end}} item" href="{{.RepoLink}}/+/settings/keys">
 		{{.i18n.Tr "repo.settings.deploy_keys"}}
 	</a>
 </div>

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -2,12 +2,12 @@
 	<div class="ui two horizontal center link list">
 		{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo)}}
 			<div class="item{{if .PageIsCommits}} active{{end}}">
-				<a class="ui" href="{{.RepoLink}}/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}"><i class="octicon octicon-history"></i> <b>{{.CommitsCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
+				<a class="ui" href="{{.RepoLink}}/+/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}"><i class="octicon octicon-history"></i> <b>{{.CommitsCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
 			</div>
 		{{end}}
 		{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo) }}
 			<div class="item{{if .PageIsBranches}} active{{end}}">
-				<a class="ui" href="{{.RepoLink}}/branches/"><i class="octicon octicon-git-branch"></i> <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
+				<a class="ui" href="{{.RepoLink}}/+/branches/"><i class="octicon octicon-git-branch"></i> <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
 			</div>
 		{{end}}
 	</div>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -20,21 +20,21 @@
 						<div class="ui buttons">
 							<a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
 							{{if not .IsViewCommit}}
-								<a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
+								<a class="ui button" href="{{.RepoLink}}/+/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
 							{{end}}
 							{{if .IsTextFile}}
-								<a class="ui button" href="{{.RepoLink}}/blame/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.blame"}}</a>
+								<a class="ui button" href="{{.RepoLink}}/+/blame/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.blame"}}</a>
 							{{end}}
-							<a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
+							<a class="ui button" href="{{.RepoLink}}/+/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
 						</div>
 						{{if .Repository.CanEnableEditor}}
 							{{if .CanEditFile}}
-								<a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-pencil btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
+								<a href="{{.RepoLink}}/+/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-pencil btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
 							{{else}}
 								<i class="octicon octicon-pencil btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i>
 							{{end}}
 							{{if .CanDeleteFile}}
-								<a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-trashcan btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
+								<a href="{{.RepoLink}}/+/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><i class="octicon octicon-trashcan btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i></a>
 							{{else}}
 								<i class="octicon octicon-trashcan btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted"></i>
 							{{end}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -15,7 +15,7 @@
 						<strong>{{.LatestCommit.Author.Name}}</strong>
 					{{end}}
 				{{end}}
-				<a rel="nofollow" class="ui sha label {{if .LatestCommit.Signature}} isSigned {{if .LatestCommitVerification.Verified }} isVerified {{end}}{{end}}" href="{{.RepoLink}}/commit/{{.LatestCommit.ID}}">
+				<a rel="nofollow" class="ui sha label {{if .LatestCommit.Signature}} isSigned {{if .LatestCommitVerification.Verified }} isVerified {{end}}{{end}}" href="{{.RepoLink}}/+/commit/{{.LatestCommit.ID}}">
 						{{ShortSha .LatestCommit.ID.String}}
 						{{if .LatestCommit.Signature}}
 							<div class="ui detail icon button">

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -7,7 +7,7 @@
 			{{.i18n.Tr "repo.wiki.new_page"}}
 			{{if .PageIsWikiEdit}}
 				<div class="ui right">
-					<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+					<a class="ui green small button" href="{{.RepoLink}}/+/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -17,7 +17,7 @@
 				<input name="title" value="{{.title}}" autofocus required>
 			</div>
 			<div class="field">
-				<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/wiki" required>{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>
+				<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/+/wiki" required>{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>
 			</div>
 			<div class="field">
 				<input name="message" placeholder="{{.i18n.Tr "repo.wiki.default_commit_message"}}">

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -6,7 +6,7 @@
 			{{.i18n.Tr "repo.wiki.pages"}}
 			{{if and .CanWriteWiki (not .IsRepositoryMirror)}}
 			<div class="ui right">
-				<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+				<a class="ui green small button" href="{{.RepoLink}}/+/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
 			</div>
 			{{end}}
 		</div>

--- a/templates/repo/wiki/start.tmpl
+++ b/templates/repo/wiki/start.tmpl
@@ -7,7 +7,7 @@
 			<h2>{{.i18n.Tr "repo.wiki.welcome"}}</h2>
 			<p>{{.i18n.Tr "repo.wiki.welcome_desc"}}</p>
 			{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-				<a class="ui green button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.create_first_page"}}</a>
+				<a class="ui green button" href="{{.RepoLink}}/+/wiki/_new">{{.i18n.Tr "repo.wiki.create_first_page"}}</a>
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -65,9 +65,9 @@
 				<div class="eight wide right aligned column">
 					{{if and .CanWriteWiki (not .Repository.IsMirror)}}
 						<div class="ui right">
-							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
-							<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
-							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
+							<a class="ui small button" href="{{.RepoLink}}/+/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
+							<a class="ui green small button" href="{{.RepoLink}}/+/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/+/wiki/{{.PageURL}}/delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
 						</div>
 					{{end}}
 				</div>

--- a/vendor/gopkg.in/macaron.v1/tree.go
+++ b/vendor/gopkg.in/macaron.v1/tree.go
@@ -69,6 +69,9 @@ func getNextWildcard(pattern string) (wildcard, _ string) {
 		case isSpecialRegexp(pattern, ":string", pos):
 			pattern = strings.Replace(pattern, ":string", "([\\w]+)", 1)
 		default:
+			if strings.HasSuffix(wildcard, "+") {
+				return wildcard, strings.Replace(pattern, wildcard, `(.+)/+/`, 1)
+			}
 			return wildcard, strings.Replace(pattern, wildcard, `(.+)`, 1)
 		}
 	}
@@ -251,14 +254,6 @@ func (t *Tree) addNextSegment(pattern string, handle Handle) *Leaf {
 	i := strings.Index(pattern, "/")
 	if i == -1 {
 		return t.addLeaf(pattern, handle)
-	}
-	// If the segment ends with "/+/", it has to be included into the pattern.
-	if strings.HasPrefix(pattern[i+1:], "+/") {
-		// [0] = '/''
-		// [1] = '+'
-		// [2] = '/'
-		// [3] = start of next pattern
-		i += 3
 	}
 	return t.addSubtree(pattern[:i], pattern[i+1:], handle)
 }

--- a/vendor/gopkg.in/macaron.v1/tree.go
+++ b/vendor/gopkg.in/macaron.v1/tree.go
@@ -252,6 +252,14 @@ func (t *Tree) addNextSegment(pattern string, handle Handle) *Leaf {
 	if i == -1 {
 		return t.addLeaf(pattern, handle)
 	}
+	// If the segment ends with "/+/", it has to be included into the pattern.
+	if strings.HasPrefix(pattern[i+1:], "+/") {
+		// [0] = '/''
+		// [1] = '+'
+		// [2] = '/'
+		// [3] = start of next pattern
+		i += 3
+	}
 	return t.addSubtree(pattern[:i], pattern[i+1:], handle)
 }
 


### PR DESCRIPTION
For #3840

What it does:
1. Add a new type of route pattern  `:name+`, where `+` means this path segment can contain slahes.
2. Make the URL router recognize the 'path separator `/+/`. 
E.g. http://localhost:3000/org/test-repo/+/issues
The choice of the path separator is inspired by Gitiles 
E.g., https://fuchsia.googlesource.com/third_party/github.com/golang/appengine/+/refs/heads/master
3. Update the routes at `routes/routes/routes.go` and all templates containing `{{.RepoLink}}`

For now, `:name+` has no difference than `:name`. It will be implemented later on.

TODO
1. Update routes for APIs. Might need a v2.
2. Update repository name validator.
3. Add & update tests.