### PR TITLE
Fix default for allowing new organization creation for new users (#7017)

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -832,10 +832,9 @@ func CreateUser(u *User) (err error) {
 		return err
 	}
 	u.HashPassword(u.Passwd)
-	u.AllowCreateOrganization = setting.Service.DefaultAllowCreateOrganization
+	u.AllowCreateOrganization = setting.Service.DefaultAllowCreateOrganization && !setting.Admin.DisableRegularOrgCreation
 	u.MaxRepoCreation = -1
 	u.Theme = setting.UI.DefaultTheme
-	u.AllowCreateOrganization = !setting.Admin.DisableRegularOrgCreation
 
 	if _, err = sess.Insert(u); err != nil {
 		return err

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -261,6 +261,8 @@ func TestCreateUser_Issue5882(t *testing.T) {
 		{&User{Name: "GiteaBot2", Email: "GiteaBot2@gitea.io", Passwd: passwd, MustChangePassword: false}, true},
 	}
 
+	setting.Service.DefaultAllowCreateOrganization = true
+
 	for _, v := range tt {
 		setting.Admin.DisableRegularOrgCreation = v.disableOrgCreation
 


### PR DESCRIPTION
This is a backport of #7017 as requested by @lafriks.