### PR TITLE
Avoid bad database state after failed migration

### DIFF
--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -68,10 +68,10 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, includeWiki bool)
 		IsPrivate:   repo.IsPrivate,
 		Wiki:        includeWiki,
 	})
+	g.repo = r
 	if err != nil {
 		return err
 	}
-	g.repo = r
 	g.gitRepo, err = git.OpenRepository(r.RepoPath())
 	return err
 }


### PR DESCRIPTION
Ensure `g.repo` is not nil after a failed migration, this allows the cleanup [here](https://github.com/rfwatson/gitea/blob/0c73755e039fbc62d000af79cf563ce29c136f41/modules/migrations/gitea.go#L397) to be triggered as expected.

Fixes #7039 