### PR TITLE
Handle insecure and ports in go get

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -258,8 +258,10 @@ func Contexter() macaron.Handler {
 			}
 			prefix := setting.AppURL + path.Join(url.PathEscape(ownerName), url.PathEscape(repoName), "src", "branch", util.PathEscapeSegments(branchName))
 
+			appURL, _ := url.Parse(setting.AppURL)
+
 			insecure := ""
-			if setting.Protocol == setting.HTTP {
+			if appURL.Scheme == string(setting.HTTP) {
 				insecure = "--insecure "
 			}
 			c.Header().Set("Content-Type", "text/html")

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -257,6 +257,11 @@ func Contexter() macaron.Handler {
 				branchName = repo.DefaultBranch
 			}
 			prefix := setting.AppURL + path.Join(url.PathEscape(ownerName), url.PathEscape(repoName), "src", "branch", util.PathEscapeSegments(branchName))
+
+			insecure := ""
+			if setting.Protocol == setting.HTTP {
+				insecure = "--insecure "
+			}
 			c.Header().Set("Content-Type", "text/html")
 			c.WriteHeader(http.StatusOK)
 			c.Write([]byte(com.Expand(`<!doctype html>
@@ -266,7 +271,7 @@ func Contexter() macaron.Handler {
 		<meta name="go-source" content="{GoGetImport} _ {GoDocDirectory} {GoDocFile}">
 	</head>
 	<body>
-		go get {GoGetImport}
+		go get {Insecure}{GoGetImport}
 	</body>
 </html>
 `, map[string]string{
@@ -274,6 +279,7 @@ func Contexter() macaron.Handler {
 				"CloneLink":      models.ComposeHTTPSCloneURL(ownerName, repoName),
 				"GoDocDirectory": prefix + "{/dir}",
 				"GoDocFile":      prefix + "{/dir}/{file}#L{line}",
+				"Insecure":       insecure,
 			})))
 			return
 		}

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -188,7 +188,11 @@ func RetrieveBaseRepo(ctx *Context, repo *models.Repository) {
 
 // ComposeGoGetImport returns go-get-import meta content.
 func ComposeGoGetImport(owner, repo string) string {
-	return path.Join(setting.Domain, setting.AppSubURL, url.PathEscape(owner), url.PathEscape(repo))
+	host := setting.Domain
+	if (setting.Protocol == setting.HTTP && setting.HTTPPort != "80") || (setting.Protocol == setting.HTTPS && setting.HTTPPort != "443") {
+		host += ":" + setting.HTTPPort
+	}
+	return path.Join(host, setting.AppSubURL, url.PathEscape(owner), url.PathEscape(repo))
 }
 
 // EarlyResponseForGoGetMeta responses appropriate go-get meta with status 200

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -188,11 +188,10 @@ func RetrieveBaseRepo(ctx *Context, repo *models.Repository) {
 
 // ComposeGoGetImport returns go-get-import meta content.
 func ComposeGoGetImport(owner, repo string) string {
-	host := setting.Domain
-	if (setting.Protocol == setting.HTTP && setting.HTTPPort != "80") || (setting.Protocol == setting.HTTPS && setting.HTTPPort != "443") {
-		host += ":" + setting.HTTPPort
-	}
-	return path.Join(host, setting.AppSubURL, url.PathEscape(owner), url.PathEscape(repo))
+	/// setting.AppUrl is guaranteed to be parse as url
+	appURL, _ := url.Parse(setting.AppURL)
+
+	return path.Join(appURL.Host, setting.AppSubURL, url.PathEscape(owner), url.PathEscape(repo))
 }
 
 // EarlyResponseForGoGetMeta responses appropriate go-get meta with status 200

--- a/modules/util/url.go
+++ b/modules/util/url.go
@@ -52,11 +52,8 @@ func IsExternalURL(rawURL string) bool {
 	if err != nil {
 		return true
 	}
-	host := setting.Domain
-	if (setting.Protocol == setting.HTTP && setting.HTTPPort != "80") || (setting.Protocol == setting.HTTPS && setting.HTTPPort != "443") {
-		host += ":" + setting.HTTPPort
-	}
-	if len(parsed.Host) != 0 && strings.Replace(parsed.Host, "www.", "", 1) != strings.Replace(host, "www.", "", 1) {
+	appURL, _ := url.Parse(setting.AppURL)
+	if len(parsed.Host) != 0 && strings.Replace(parsed.Host, "www.", "", 1) != strings.Replace(appURL.Host, "www.", "", 1) {
 		return true
 	}
 	return false

--- a/modules/util/url.go
+++ b/modules/util/url.go
@@ -52,7 +52,11 @@ func IsExternalURL(rawURL string) bool {
 	if err != nil {
 		return true
 	}
-	if len(parsed.Host) != 0 && strings.Replace(parsed.Host, "www.", "", 1) != strings.Replace(setting.Domain, "www.", "", 1) {
+	host := setting.Domain
+	if (setting.Protocol == setting.HTTP && setting.HTTPPort != "80") || (setting.Protocol == setting.HTTPS && setting.HTTPPort != "443") {
+		host += ":" + setting.HTTPPort
+	}
+	if len(parsed.Host) != 0 && strings.Replace(parsed.Host, "www.", "", 1) != strings.Replace(host, "www.", "", 1) {
 		return true
 	}
 	return false

--- a/modules/util/util_test.go
+++ b/modules/util/util_test.go
@@ -46,7 +46,7 @@ func TestURLJoin(t *testing.T) {
 }
 
 func TestIsExternalURL(t *testing.T) {
-	setting.Domain = "try.gitea.io"
+	setting.AppURL = "https://try.gitea.io"
 	type test struct {
 		Expected bool
 		RawURL   string


### PR DESCRIPTION
If a gitea running on non-standard port is listed as the location for a go mod file, go will fail to get it as the port is not listed and for HTTP the --insecure flag is not set. This PR applies these changes.

Fixes #6985 

Also fixes a similar unreported bug in url.IsExternalURL on non-standard ports.