### PR TITLE
When git version >= 2.18, git command could run with git wire protocol version 2 param if enabled

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -671,6 +671,8 @@ MAX_GIT_DIFF_FILES = 100
 ; Arguments for command 'git gc', e.g. "--aggressive --auto"
 ; see more on http://git-scm.com/docs/git-gc/
 GC_ARGS =
+; If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
+EnableAutoGitWireProtocol = true
 
 ; Operation timeout in seconds
 [git.timeout]

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -396,6 +396,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 - `MAX_GIT_DIFF_LINE_CHARACTERS`: **5000**: Max character count per line highlighted in diff view.
 - `MAX_GIT_DIFF_FILES`: **100**: Max number of files shown in diff view.
 - `GC_ARGS`: **\<empty\>**: Arguments for command `git gc`, e.g. `--aggressive --auto`. See more on http://git-scm.com/docs/git-gc/
+- `ENABLE_AUTO_GIT_WIRE_PROTOCOL`: **true**: If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
 
 ## Git - Timeout settings (`git.timeout`)
 - `DEFAUlT`: **360**: Git operations default timeout seconds.

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -210,6 +210,7 @@ menu:
 - `CLONE`: **300**: 内部仓库间克隆的超时时间，单位秒
 - `PULL`: **300**: 内部仓库间拉取的超时时间，单位秒
 - `GC`: **60**: git仓库GC的超时时间，单位秒
+- `ENABLE_AUTO_GIT_WIRE_PROTOCOL`: **true**: 是否根据 Git Wire Protocol协议支持情况自动切换版本，当 git 版本在 2.18 及以上时会自动切换到版本2。为 `false` 则不切换。
 
 ## API (`api`)
 

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -16,12 +16,13 @@ import (
 var (
 	// Git settings
 	Git = struct {
-		DisableDiffHighlight     bool
-		MaxGitDiffLines          int
-		MaxGitDiffLineCharacters int
-		MaxGitDiffFiles          int
-		GCArgs                   []string `delim:" "`
-		Timeout                  struct {
+		DisableDiffHighlight      bool
+		MaxGitDiffLines           int
+		MaxGitDiffLineCharacters  int
+		MaxGitDiffFiles           int
+		GCArgs                    []string `delim:" "`
+		EnableAutoGitWireProtocol bool
+		Timeout                   struct {
 			Default int
 			Migrate int
 			Mirror  int
@@ -30,11 +31,12 @@ var (
 			GC      int `ini:"GC"`
 		} `ini:"git.timeout"`
 	}{
-		DisableDiffHighlight:     false,
-		MaxGitDiffLines:          1000,
-		MaxGitDiffLineCharacters: 5000,
-		MaxGitDiffFiles:          100,
-		GCArgs:                   []string{},
+		DisableDiffHighlight:      false,
+		MaxGitDiffLines:           1000,
+		MaxGitDiffLineCharacters:  5000,
+		MaxGitDiffFiles:           100,
+		GCArgs:                    []string{},
+		EnableAutoGitWireProtocol: true,
 		Timeout: struct {
 			Default int
 			Migrate int
@@ -64,10 +66,19 @@ func newGit() {
 		log.Fatal("Error retrieving git version: %v", err)
 	}
 
-	log.Info("Git Version: %s", binVersion)
-
 	if version.Compare(binVersion, "2.9", ">=") {
 		// Explicitly disable credential helper, otherwise Git credentials might leak
 		git.GlobalCommandArgs = append(git.GlobalCommandArgs, "-c", "credential.helper=")
 	}
+
+	var format = "Git Version: %s"
+	var args = []interface{}{binVersion}
+	// Since git wire protocol has been released from git v2.18
+	if Git.EnableAutoGitWireProtocol && version.Compare(binVersion, "2.18", ">=") {
+		git.GlobalCommandArgs = append(git.GlobalCommandArgs, "-c", "protocol.version=2")
+		format += ", Wire Protocol %s Enabled"
+		args = append(args, "Version 2") // for focus color
+	}
+
+	log.Info(format, args...)
 }


### PR DESCRIPTION
This PR will accelerate many git operations with remotes, especial migrations and mirrors.