### PR TITLE
Prevent lfs process filter from running

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -59,7 +59,7 @@ func checkLFSVersion() {
 			println("LFS server support needs at least Git v2.1.2, disabled")
 		} else {
 			git.GlobalCommandArgs = append(git.GlobalCommandArgs, "-c", "filter.lfs.required=",
-				"-c", "filter.lfs.smudge=", "-c", "filter.lfs.clean=")
+				"-c", "filter.lfs.smudge=", "-c", "filter.lfs.clean=", "-c", "filter.lfs.process=")
 		}
 	}
 }

--- a/models/pull.go
+++ b/models/pull.go
@@ -485,6 +485,20 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		return fmt.Errorf("git config [core.sparsecheckout -> true]: %v", errbuf.String())
 	}
 
+	// Stop LFS from running its filters
+	if err := git.NewCommand("config", "--local", "filter.lfs.clean", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
+		return fmt.Errorf("git config [filter.lfs.clean -> \"\"]: %v", errbuf.String())
+	}
+	if err := git.NewCommand("config", "--local", "filter.lfs.smudge", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
+		return fmt.Errorf("git config [filter.lfs.smudge -> \"\"]: %v", errbuf.String())
+	}
+	if err := git.NewCommand("config", "--local", "filter.lfs.process", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
+		return fmt.Errorf("git config [filter.lfs.process -> \"\"]: %v", errbuf.String())
+	}
+	if err := git.NewCommand("config", "--local", "filter.lfs.required", "false").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
+		return fmt.Errorf("git config [filter.lfs.required -> false]: %v", errbuf.String())
+	}
+
 	// Read base branch index
 	if err := git.NewCommand("read-tree", "HEAD").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
 		return fmt.Errorf("git read-tree HEAD: %s", errbuf.String())

--- a/models/pull.go
+++ b/models/pull.go
@@ -485,20 +485,6 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		return fmt.Errorf("git config [core.sparsecheckout -> true]: %v", errbuf.String())
 	}
 
-	// Stop LFS from running its filters
-	if err := git.NewCommand("config", "--local", "filter.lfs.clean", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
-		return fmt.Errorf("git config [filter.lfs.clean -> \"\"]: %v", errbuf.String())
-	}
-	if err := git.NewCommand("config", "--local", "filter.lfs.smudge", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
-		return fmt.Errorf("git config [filter.lfs.smudge -> \"\"]: %v", errbuf.String())
-	}
-	if err := git.NewCommand("config", "--local", "filter.lfs.process", "").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
-		return fmt.Errorf("git config [filter.lfs.process -> \"\"]: %v", errbuf.String())
-	}
-	if err := git.NewCommand("config", "--local", "filter.lfs.required", "false").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
-		return fmt.Errorf("git config [filter.lfs.required -> false]: %v", errbuf.String())
-	}
-
 	// Read base branch index
 	if err := git.NewCommand("read-tree", "HEAD").RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
 		return fmt.Errorf("git read-tree HEAD: %s", errbuf.String())

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -472,7 +472,7 @@ func CheckLFSVersion() {
 			log.Error("LFS server support needs at least Git v2.1.2")
 		} else {
 			git.GlobalCommandArgs = append(git.GlobalCommandArgs, "-c", "filter.lfs.required=",
-				"-c", "filter.lfs.smudge=", "-c", "filter.lfs.clean=")
+				"-c", "filter.lfs.smudge=", "-c", "filter.lfs.clean=", "-c", "filter.lfs.process=")
 		}
 	}
 }


### PR DESCRIPTION
This PR sets the lfs process filter to empty preventing them from running during merge.

Fixes #732
