### PR TITLE
Add state param to milestone listing API

### DIFF
--- a/models/fixtures/milestone.yml
+++ b/models/fixtures/milestone.yml
@@ -13,3 +13,11 @@
   content: content2
   is_closed: false
   num_issues: 0
+
+-
+  id: 3
+  repo_id: 1
+  name: milestone3
+  content: content3
+  is_closed: true
+  num_issues: 0

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -9,6 +9,7 @@
   num_pulls: 2
   num_closed_pulls: 0
   num_milestones: 2
+  num_closed_milestones: 1
   num_watches: 3
 
 -

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -8,7 +8,7 @@
   num_closed_issues: 1
   num_pulls: 2
   num_closed_pulls: 0
-  num_milestones: 2
+  num_milestones: 3
   num_closed_milestones: 1
   num_watches: 3
 

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -190,9 +190,19 @@ func (milestones MilestoneList) getMilestoneIDs() []int64 {
 }
 
 // GetMilestonesByRepoID returns all opened milestones of a repository.
-func GetMilestonesByRepoID(repoID int64) (MilestoneList, error) {
+func GetMilestonesByRepoID(repoID int64, state api.StateType) (MilestoneList, error) {
+
+	// defaults to false
+	// always show opened milestones unless api.StateClosed is passed as a
+	// parameter
+	var isClosed bool
+
+	if state == api.StateClosed {
+		isClosed = true
+	}
+
 	miles := make([]*Milestone, 0, 10)
-	return miles, x.Where("repo_id = ? AND is_closed = ?", repoID, false).
+	return miles, x.Where("repo_id = ? AND is_closed = ?", repoID, isClosed).
 		Asc("deadline_unix").Asc("id").Find(&miles)
 }
 

--- a/models/issue_milestone_test.go
+++ b/models/issue_milestone_test.go
@@ -74,10 +74,20 @@ func TestGetMilestonesByRepoID(t *testing.T) {
 		milestones, err := GetMilestonesByRepoID(repo.ID, state)
 		assert.NoError(t, err)
 
-		var n = repo.NumOpenMilestones
+		var n int
 
-		if state == api.StateClosed {
+		switch state {
+		case api.StateClosed:
 			n = repo.NumClosedMilestones
+
+		case api.StateAll:
+			n = repo.NumMilestones
+
+		case api.StateOpen:
+			fallthrough
+
+		default:
+			n = repo.NumOpenMilestones
 		}
 
 		assert.Len(t, milestones, n)
@@ -86,11 +96,14 @@ func TestGetMilestonesByRepoID(t *testing.T) {
 		}
 	}
 	test(1, api.StateOpen)
+	test(1, api.StateAll)
 	test(1, api.StateClosed)
 	test(2, api.StateOpen)
+	test(2, api.StateAll)
 	test(2, api.StateClosed)
 	test(3, api.StateOpen)
 	test(3, api.StateClosed)
+	test(3, api.StateAll)
 
 	milestones, err := GetMilestonesByRepoID(NonexistentID, api.StateOpen)
 	assert.NoError(t, err)

--- a/models/issue_milestone_test.go
+++ b/models/issue_milestone_test.go
@@ -69,20 +69,30 @@ func TestGetMilestoneByRepoID(t *testing.T) {
 
 func TestGetMilestonesByRepoID(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
-	test := func(repoID int64) {
+	test := func(repoID int64, state api.StateType) {
 		repo := AssertExistsAndLoadBean(t, &Repository{ID: repoID}).(*Repository)
-		milestones, err := GetMilestonesByRepoID(repo.ID)
+		milestones, err := GetMilestonesByRepoID(repo.ID, state)
 		assert.NoError(t, err)
-		assert.Len(t, milestones, repo.NumMilestones)
+
+		var n = repo.NumMilestones
+
+		if state == api.StateClosed {
+			n = repo.NumClosedMilestones
+		}
+
+		assert.Len(t, milestones, n)
 		for _, milestone := range milestones {
 			assert.EqualValues(t, repoID, milestone.RepoID)
 		}
 	}
-	test(1)
-	test(2)
-	test(3)
+	test(1, api.StateOpen)
+	test(1, api.StateClosed)
+	test(2, api.StateOpen)
+	test(2, api.StateClosed)
+	test(3, api.StateOpen)
+	test(3, api.StateClosed)
 
-	milestones, err := GetMilestonesByRepoID(NonexistentID)
+	milestones, err := GetMilestonesByRepoID(NonexistentID, api.StateOpen)
 	assert.NoError(t, err)
 	assert.Len(t, milestones, 0)
 }

--- a/models/issue_milestone_test.go
+++ b/models/issue_milestone_test.go
@@ -74,7 +74,7 @@ func TestGetMilestonesByRepoID(t *testing.T) {
 		milestones, err := GetMilestonesByRepoID(repo.ID, state)
 		assert.NoError(t, err)
 
-		var n = repo.NumMilestones
+		var n = repo.NumOpenMilestones
 
 		if state == api.StateClosed {
 			n = repo.NumClosedMilestones

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -16,6 +16,8 @@ const (
 	StateOpen StateType = "open"
 	// StateClosed pr is closed
 	StateClosed StateType = "closed"
+	// StateAll is all
+	StateAll StateType = "all"
 )
 
 // PullRequestMeta PR info if an issue is a PR

--- a/routers/api/v1/repo/milestone.go
+++ b/routers/api/v1/repo/milestone.go
@@ -34,7 +34,7 @@ func ListMilestones(ctx *context.APIContext) {
 	//   required: true
 	// - name: state
 	//   in: query
-	//   description: Milestone state, Show only opened or closed milestones. Defaults to "open"
+	//   description: Milestone state, Recognised values are open, close and all. Defaults to "open"
 	//   type: string
 	// responses:
 	//   "200":

--- a/routers/api/v1/repo/milestone.go
+++ b/routers/api/v1/repo/milestone.go
@@ -14,7 +14,7 @@ import (
 	api "code.gitea.io/gitea/modules/structs"
 )
 
-// ListMilestones list all the opened milestones for a repository
+// ListMilestones list milestones for a repository
 func ListMilestones(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/milestones issue issueGetMilestonesList
 	// ---
@@ -32,10 +32,14 @@ func ListMilestones(ctx *context.APIContext) {
 	//   description: name of the repo
 	//   type: string
 	//   required: true
+	// - name: state
+	//   in: query
+	//   description: Milestone state, Show only opened or closed milestones. Defaults to "open"
+	//   type: string
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/MilestoneList"
-	milestones, err := models.GetMilestonesByRepoID(ctx.Repo.Repository.ID)
+	milestones, err := models.GetMilestonesByRepoID(ctx.Repo.Repository.ID, api.StateType(ctx.Query("state")))
 	if err != nil {
 		ctx.Error(500, "GetMilestonesByRepoID", err)
 		return

--- a/routers/api/v1/repo/milestone.go
+++ b/routers/api/v1/repo/milestone.go
@@ -34,7 +34,7 @@ func ListMilestones(ctx *context.APIContext) {
 	//   required: true
 	// - name: state
 	//   in: query
-	//   description: Milestone state, Recognised values are open, close and all. Defaults to "open"
+	//   description: Milestone state, Recognised values are open, closed and all. Defaults to "open"
 	//   type: string
 	// responses:
 	//   "200":

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -24,6 +24,7 @@ import (
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/notification"
 	"code.gitea.io/gitea/modules/setting"
+	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
 	"github.com/Unknwon/com"
@@ -305,7 +306,7 @@ func Issues(ctx *context.Context) {
 
 	var err error
 	// Get milestones.
-	ctx.Data["Milestones"], err = models.GetMilestonesByRepoID(ctx.Repo.Repository.ID)
+	ctx.Data["Milestones"], err = models.GetMilestonesByRepoID(ctx.Repo.Repository.ID, api.StateType(ctx.Query("state")))
 	if err != nil {
 		ctx.ServerError("GetAllRepoMilestones", err)
 		return

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3892,6 +3892,12 @@
             "name": "repo",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Milestone state, Show only opened or closed milestones. Defaults to \"open\"",
+            "name": "state",
+            "in": "query"
           }
         ],
         "responses": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3895,7 +3895,7 @@
           },
           {
             "type": "string",
-            "description": "Milestone state, Recognised values are open, close and all. Defaults to \"open\"",
+            "description": "Milestone state, Recognised values are open, closed and all. Defaults to \"open\"",
             "name": "state",
             "in": "query"
           }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3895,7 +3895,7 @@
           },
           {
             "type": "string",
-            "description": "Milestone state, Show only opened or closed milestones. Defaults to \"open\"",
+            "description": "Milestone state, Recognised values are open, close and all. Defaults to \"open\"",
             "name": "state",
             "in": "query"
           }


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/6384

This PR adds a `state` query param to the milestone listing API such as https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository 