### PR TITLE
Reject duplicate access token name

### DIFF
--- a/models/token.go
+++ b/models/token.go
@@ -77,6 +77,13 @@ func GetAccessTokenBySHA(token string) (*AccessToken, error) {
 	return nil, ErrAccessTokenNotExist{token}
 }
 
+// AccessTokenByNameExists checks if a token name has been used already
+// by a user.
+func AccessTokenByNameExists(token *AccessToken) bool {
+	exists, _ := x.Get(token)
+	return exists
+}
+
 // ListAccessTokens returns a list of access tokens belongs to given user.
 func ListAccessTokens(uid int64) ([]*AccessToken, error) {
 	tokens := make([]*AccessToken, 0, 5)

--- a/models/token_test.go
+++ b/models/token_test.go
@@ -27,6 +27,36 @@ func TestNewAccessToken(t *testing.T) {
 	assert.Error(t, NewAccessToken(invalidToken))
 }
 
+func TestAccessTokenByNameExists(t *testing.T) {
+
+	name := "Token Gitea"
+
+	assert.NoError(t, PrepareTestDatabase())
+	token := &AccessToken{
+		UID:  3,
+		Name: name,
+	}
+
+	// Check to make sure it doesn't exists already
+	assert.False(t, AccessTokenByNameExists(token))
+
+	// Save it to the database
+	assert.NoError(t, NewAccessToken(token))
+	AssertExistsAndLoadBean(t, token)
+
+	// This token must be found by name in the DB now
+	assert.True(t, AccessTokenByNameExists(token))
+
+	user4Token := &AccessToken{
+		UID:  4,
+		Name: name,
+	}
+
+	// Name matches but different user ID, this shouldn't exists in the
+	// database
+	assert.False(t, AccessTokenByNameExists(user4Token))
+}
+
 func TestGetAccessTokenBySHA(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	token, err := GetAccessTokenBySHA("d2c6c1ba3890b309189a8e618c72a162e4efbf36")

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -479,6 +479,7 @@ new_token_desc = Applications using a token have full access to your account.
 token_name = Token Name
 generate_token = Generate Token
 generate_token_success = Your new token has been generated. Copy it now as it will not be shown again.
+generate_token_name_duplicate = <strong>%s</strong> has been used as an application name already. Please use a new one.
 delete_token = Delete
 access_token_deletion = Delete Access Token
 access_token_deletion_desc = Deleting a token will revoke access to your account for applications using it. Continue?

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -6,6 +6,9 @@
 package user
 
 import (
+	"errors"
+	"net/http"
+
 	api "code.gitea.io/gitea/modules/structs"
 
 	"code.gitea.io/gitea/models"
@@ -82,6 +85,12 @@ func CreateAccessToken(ctx *context.APIContext, form api.CreateAccessTokenOption
 	if t.Name == "drone" {
 		t.Name = "drone-legacy-use-oauth2-instead"
 	}
+
+	if models.AccessTokenByNameExists(t) {
+		ctx.Error(http.StatusBadRequest, "AccessTokenByNameExists", errors.New("access token name has been used already"))
+		return
+	}
+
 	if err := models.NewAccessToken(t); err != nil {
 		ctx.Error(500, "NewAccessToken", err)
 		return

--- a/routers/user/setting/applications.go
+++ b/routers/user/setting/applications.go
@@ -43,6 +43,13 @@ func ApplicationsPost(ctx *context.Context, form auth.NewAccessTokenForm) {
 		UID:  ctx.User.ID,
 		Name: form.Name,
 	}
+
+	if models.AccessTokenByNameExists(t) {
+		ctx.Flash.Error(ctx.Tr("settings.generate_token_name_duplicate", t.Name))
+		ctx.Redirect(setting.AppSubURL + "/user/settings/applications")
+		return
+	}
+
 	if err := models.NewAccessToken(t); err != nil {
 		ctx.ServerError("NewAccessToken", err)
 		return


### PR DESCRIPTION
I have run into cases where I have multiple tokens with the same name and 
it becomes hard to find out which one is no longer being used, so it can be deleted

