### PR TITLE
Send issue closure email with correct user - fixes #7124

### DIFF
--- a/models/issue_mail.go
+++ b/models/issue_mail.go
@@ -118,11 +118,11 @@ func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, content 
 
 // MailParticipants sends new issue thread created emails to repository watchers
 // and mentioned people.
-func (issue *Issue) MailParticipants(opType ActionType) (err error) {
-	return issue.mailParticipants(x, opType)
+func (issue *Issue) MailParticipants(doer *User, opType ActionType) (err error) {
+	return issue.mailParticipants(x, doer, opType)
 }
 
-func (issue *Issue) mailParticipants(e Engine, opType ActionType) (err error) {
+func (issue *Issue) mailParticipants(e Engine, doer *User, opType ActionType) (err error) {
 	mentions := markup.FindAllMentions(issue.Content)
 	if err = UpdateIssueMentions(e, issue.ID, mentions); err != nil {
 		return fmt.Errorf("UpdateIssueMentions [%d]: %v", issue.ID, err)
@@ -136,7 +136,7 @@ func (issue *Issue) mailParticipants(e Engine, opType ActionType) (err error) {
 		content = fmt.Sprintf("Reopened #%d", issue.Index)
 	}
 
-	if err = mailIssueCommentToParticipants(e, issue, issue.Poster, content, nil, mentions); err != nil {
+	if err = mailIssueCommentToParticipants(e, issue, doer, content, nil, mentions); err != nil {
 		log.Error("mailIssueCommentToParticipants: %v", err)
 	}
 

--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -42,7 +42,7 @@ func (m *mailNotifier) NotifyCreateIssueComment(doer *models.User, repo *models.
 }
 
 func (m *mailNotifier) NotifyNewIssue(issue *models.Issue) {
-	if err := issue.MailParticipants(models.ActionCreateIssue); err != nil {
+	if err := issue.MailParticipants(issue.Poster, models.ActionCreateIssue); err != nil {
 		log.Error("MailParticipants: %v", err)
 	}
 }
@@ -63,13 +63,13 @@ func (m *mailNotifier) NotifyIssueChangeStatus(doer *models.User, issue *models.
 		}
 	}
 
-	if err := issue.MailParticipants(actionType); err != nil {
+	if err := issue.MailParticipants(doer, actionType); err != nil {
 		log.Error("MailParticipants: %v", err)
 	}
 }
 
 func (m *mailNotifier) NotifyNewPullRequest(pr *models.PullRequest) {
-	if err := pr.Issue.MailParticipants(models.ActionCreatePullRequest); err != nil {
+	if err := pr.Issue.MailParticipants(pr.Issue.Poster, models.ActionCreatePullRequest); err != nil {
 		log.Error("MailParticipants: %v", err)
 	}
 }


### PR DESCRIPTION
Lightly tested.

For anyone testing: Because of https://github.com/go-gitea/gitea/issues/5977, the closure must be done with a non-empty comment for it to send a mail.