### PR TITLE
Revert "Make modules/structs as a separate go mod"

### DIFF
--- a/modules/structs/attachment.go
+++ b/modules/structs/attachment.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 package structs // import "code.gitea.io/gitea/modules/structs"
-
 import (
 	"time"
 )

--- a/modules/structs/go.mod
+++ b/modules/structs/go.mod
@@ -1,3 +1,0 @@
-module code.gitea.io/gitea/modules/structs
-
-go 1.12


### PR DESCRIPTION
Reverts go-gitea/gitea#7127

I think I'm wrong making a sub folder as a separate go mod will make PR merging difficult.