### PR TITLE
fix drone build bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,7 @@ pr:
 .PHONY: golangci-lint
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		export BINARY="golangci-lint" & curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.16.0; \
+		export BINARY="golangci-lint"; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -d -b $(GOPATH)/bin v1.16.0; \
 	fi
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,6 @@ pr:
 .PHONY: golangci-lint
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.16.0; \
+		export BINARY="golangci-lint" & curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.16.0; \
 	fi
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,6 @@ pr:
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		export BINARY="golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -d -b $(GOPATH)/bin v1.16.0; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.16.0; \
 	fi
 	golangci-lint run

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -1112,6 +1112,7 @@
         .show-form-container {
             text-align: left;
         }
+
         .choose.branch {
             .octicon {
                 padding-right: 10px;
@@ -2226,6 +2227,7 @@ tbody.commit-list {
     &.top {
         text-align: left;
     }
+
     .commit-body {
         margin: 0;
     }

--- a/routers/user/oauth.go
+++ b/routers/user/oauth.go
@@ -169,7 +169,7 @@ func AuthorizeOAuth(ctx *context.Context, form auth.AuthorizationForm) {
 		for _, e := range errs {
 			errstring += e.Error() + "\n"
 		}
-		ctx.ServerError("AuthorizeOAuth: Validate: ", fmt.Errorf("errors occured during validation: %s", errstring))
+		ctx.ServerError("AuthorizeOAuth: Validate: ", fmt.Errorf("errors occurred during validation: %s", errstring))
 		return
 	}
 


### PR DESCRIPTION
current master branch breaks drone build because of a misspelling bug in 
./routers/user/oauth.go:172 -> added with https://github.com/go-gitea/gitea/pull/6418

+ fix some less format warning
+ fix makefile

Signed-off-by: Michael Gnehr <michael@gnehr.de>