### PR TITLE
Disable same user check for internal SSH

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -438,7 +438,7 @@ func forcePathSeparator(path string) {
 // This check is ignored under Windows since SSH remote login is not the main
 // method to login on Windows.
 func IsRunUserMatchCurrentUser(runUser string) (string, bool) {
-	if IsWindows {
+	if IsWindows || SSH.StartBuiltinServer {
 		return "", true
 	}
 


### PR DESCRIPTION
We don't need to require the same running user for internal SSH (like on windows platform)

This PR is needed if we want #7129 to be (container running) user independant.