### PR TITLE
Enable tls-alpn-01: Use certmanager provided TLSConfig for LetsEncrypt

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -82,11 +81,9 @@ func runLetsEncrypt(listenAddr, domain, directory, email string, m http.Handler)
 		}
 	}()
 	server := &http.Server{
-		Addr:    listenAddr,
-		Handler: m,
-		TLSConfig: &tls.Config{
-			GetCertificate: certManager.GetCertificate,
-		},
+		Addr:      listenAddr,
+		Handler:   m,
+		TLSConfig: certManager.TLSConfig(),
 	}
 	return server.ListenAndServeTLS("", "")
 }


### PR DESCRIPTION
If we use the certmanager provided TLSConfig for LetsEncrypt we get tls-alpn-01 for free allowing people to deploy gitea without http access. 