### PR TITLE
docs: Fix a broken relref link

### DIFF
--- a/docs/content/doc/advanced/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/advanced/hacking-on-gitea.en-us.md
@@ -209,7 +209,7 @@ OpenAPI 3 documentation.
 When creating new configuration options, it is not enough to add them to the
 `modules/setting` files. You should add information to `custom/conf/app.ini`
 and to the
-<a href='{{ relref "doc/advanced/config-cheat-sheet.en-us.md"}}'>configuration cheat sheet</a>
+<a href='{{< relref "doc/advanced/config-cheat-sheet.en-us.md" >}}'>configuration cheat sheet</a>
 found in `docs/content/doc/advanced/config-cheat-sheet.en-us.md`
 
 ### Changing the logo


### PR DESCRIPTION
A little PR to fix a broken link on current doc : https://docs.gitea.io/en-us/hacking-on-gitea/#creating-new-configuration-options

I based myself on a link that work on the same page : https://github.com/go-gitea/gitea/blame/master/docs/content/doc/advanced/hacking-on-gitea.en-us.md#L94