### PR TITLE
Fixed dutch typo "Gebruikersacount"

### DIFF
--- a/options/locale/locale_nl-NL.ini
+++ b/options/locale/locale_nl-NL.ini
@@ -1034,7 +1034,7 @@ teams.add_nonexistent_repo=De opslagplaats die u probeert toe te voegen bestaat 
 
 [admin]
 dashboard=Overzicht
-users=Gebruikersacount
+users=Gebruikersaccount
 organizations=Organisaties
 repositories=Repositories
 authentication=Authenticatie bronnen


### PR DESCRIPTION
Changed Gebruikersa**c**ount to Gebruikersa**cc**ount.  
While browsing my gitea server i found this small typo.  
When putting Gebruikersacount into translate (https://translate.google.nl/#view=home&op=translate&sl=nl&tl=en&text=Gebruikersacount) it will suggest the same change made here.