### PR TITLE
Prevent long email addresses from spilling out of the user profile infobox

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -873,6 +873,7 @@ tbody.commit-list{vertical-align:baseline}
 .user.profile .ui.card .extra.content{padding:0}
 .user.profile .ui.card .extra.content ul{margin:0;padding:0}
 .user.profile .ui.card .extra.content ul li{padding:10px;list-style:none;overflow:scroll;display:flex}
+.user.profile .ui.card .extra.content ul li .user-orgs{flex-grow:1}
 .user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}
 .user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}
 .user.profile .ui.card .extra.content ul li.follow .ui.button{width:100%}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -872,7 +872,7 @@ tbody.commit-list{vertical-align:baseline}
 .user.profile .ui.card .username{display:block}
 .user.profile .ui.card .extra.content{padding:0}
 .user.profile .ui.card .extra.content ul{margin:0;padding:0}
-.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none}
+.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none;overflow:scroll;display:flex}
 .user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}
 .user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}
 .user.profile .ui.card .extra.content ul li.follow .ui.button{width:100%}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -872,7 +872,7 @@ tbody.commit-list{vertical-align:baseline}
 .user.profile .ui.card .username{display:block}
 .user.profile .ui.card .extra.content{padding:0}
 .user.profile .ui.card .extra.content ul{margin:0;padding:0}
-.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none;overflow:scroll;display:flex}
+.user.profile .ui.card .extra.content ul li{padding:10px;list-style:none;overflow:auto;display:flex}
 .user.profile .ui.card .extra.content ul li .user-orgs{flex-grow:1}
 .user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}
 .user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}

--- a/public/less/_user.less
+++ b/public/less/_user.less
@@ -20,7 +20,7 @@
                         padding: 10px;
                         list-style: none;
 
-                        overflow: scroll; // prevent contents from spilling over
+                        overflow: auto; // prevent contents from spilling over
                         display: flex; // force horizontal layout
                         .user-orgs {
                             flex-grow: 1;

--- a/public/less/_user.less
+++ b/public/less/_user.less
@@ -20,6 +20,9 @@
                         padding: 10px;
                         list-style: none;
 
+                        overflow: scroll; // prevent contents from spilling over
+                        display: flex; // lay out contents horizontally
+
                         &:not(:last-child) {
                             border-bottom: 1px solid #eaeaea;
                         }

--- a/public/less/_user.less
+++ b/public/less/_user.less
@@ -21,7 +21,10 @@
                         list-style: none;
 
                         overflow: scroll; // prevent contents from spilling over
-                        display: flex; // lay out contents horizontally
+                        display: flex; // force horizontal layout
+                        .user-orgs {
+                            flex-grow: 1;
+                        }
 
                         &:not(:last-child) {
                             border-bottom: 1px solid #eaeaea;


### PR DESCRIPTION
On the web interface's user profile page, if you have a very long email it spills out of the infobox into the repositories section.

![Problem](https://user-images.githubusercontent.com/43831298/59803296-98776c80-92da-11e9-969b-2d593b8c7de9.png)

_(I use the Arc Green theme in the screenshots, but it happens on both included themes.)_

A slight tweak to the CSS neatly solves the problem:
```
.user.profile .ui.card .extra.content ul li {
	overflow: scroll;
	display: flex;
}
```

![Proposed solution](https://user-images.githubusercontent.com/43831298/59803482-19366880-92db-11e9-84a1-7fdfb42a00b9.png)

This scrolls to view the entire address, as you would expect.

If `display: flex;` is not included, it simply degrades to having the mail icon above the address, as it is now.