### PR TITLE
Add .fa icon margin like .octicon

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -874,7 +874,7 @@ tbody.commit-list{vertical-align:baseline}
 .user.profile .ui.card .extra.content ul{margin:0;padding:0}
 .user.profile .ui.card .extra.content ul li{padding:10px;list-style:none}
 .user.profile .ui.card .extra.content ul li:not(:last-child){border-bottom:1px solid #eaeaea}
-.user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}
+.user.profile .ui.card .extra.content ul li .fa,.user.profile .ui.card .extra.content ul li .octicon{margin-left:1px;margin-right:5px}
 .user.profile .ui.card .extra.content ul li.follow .ui.button{width:100%}
 @media only screen and (max-width:768px){.user.profile .ui.card #profile-avatar{height:250px;overflow:hidden}
 .user.profile .ui.card #profile-avatar img{max-height:768px;max-width:768px}

--- a/public/less/_user.less
+++ b/public/less/_user.less
@@ -24,7 +24,7 @@
                             border-bottom: 1px solid #eaeaea;
                         }
 
-                        .octicon {
+                        .octicon, .fa {
                             margin-left: 1px;
                             margin-right: 5px;
                         }


### PR DESCRIPTION
A little margin is missing for fa icon like openid on this example.
This PR simply duplicate the rule applied on `.octicon` to `.fa`
 
## Before
![before](https://user-images.githubusercontent.com/4052400/59809982-6cbcac80-9303-11e9-9632-fb799bd9ea52.PNG)
## After
![after](https://user-images.githubusercontent.com/4052400/59809985-6e867000-9303-11e9-9943-87999b174652.PNG)
