### PR TITLE
Dark theme markdown fixes

### DIFF
--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -92,7 +92,10 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .markdown:not(code) h2{border-bottom:1px solid #304251}
 .hljs,.hljs-keyword,.hljs-selector-tag,.hljs-subst{color:#9daccc}
 .markdown:not(code) .highlight pre,.markdown:not(code) pre{background-color:#2a2e3a;border:1px solid #404552}
-.markdown:not(code) table tr:nth-child(2n){background-color:#474d61}
+.markdown:not(code) table tr:nth-child(2n){background-color:#2a2e39}
+.markdown:not(code) table tr:nth-child(2n-1){background-color:#383b44}
+.markdown:not(code) table thead tr:nth-child(2n-1){background-color:#464c5d!important}
+.markdown:not(code) table td,.markdown:not(code) table th{border-color:#4c505c!important}
 .ui.dropdown .menu{background:#2c303a}
 .ui.dropdown .menu>.message:not(.ui){color:#636363}
 .ui.input{color:#dbdbdb}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -97,7 +97,7 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .markdown:not(code) table thead tr:nth-child(2n-1){background-color:#464c5d!important}
 .markdown:not(code) table td,.markdown:not(code) table th{border-color:#4c505c!important}
 .repository.file.editor.edit,.repository.wiki.new .CodeMirror{border-right:1px solid rgba(187,187,187,.6);border-left:1px solid rgba(187,187,187,.6);border-bottom:1px solid rgba(187,187,187,.6)}
-.repository.file.editor.edit .editor-preview,.repository.wiki.new .CodeMirror .editor-preview{background:#353945;scrollbar-color:#2a2a2a #fff}
+.repository.file.editor.edit .editor-preview,.repository.wiki.new .CodeMirror .editor-preview{background:#353945}
 .repository.file.editor.edit .editor-preview .markdown:not(code).ui.segment,.repository.wiki.new .CodeMirror .editor-preview .markdown:not(code).ui.segment{border-width:0}
 .ui.dropdown .menu{background:#2c303a}
 .ui.dropdown .menu>.message:not(.ui){color:#636363}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -97,8 +97,8 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .markdown:not(code) table thead tr:nth-child(2n-1){background-color:#464c5d!important}
 .markdown:not(code) table td,.markdown:not(code) table th{border-color:#4c505c!important}
 .repository.file.editor.edit,.repository.wiki.new .CodeMirror{border-right:1px solid rgba(187,187,187,.6);border-left:1px solid rgba(187,187,187,.6);border-bottom:1px solid rgba(187,187,187,.6)}
-.repository.file.editor.edit .editor-preview,.repository.wiki.new .CodeMirror .editor-preview{background:#353945}
-.repository.file.editor.edit .editor-preview .markdown:not(code).ui.segment,.repository.wiki.new .CodeMirror .editor-preview .markdown:not(code).ui.segment{border-width:0}
+.repository.file.editor.edit .editor-preview,.repository.file.editor.edit .editor-preview-side,.repository.wiki.new .CodeMirror .editor-preview,.repository.wiki.new .CodeMirror .editor-preview-side{background:#353945}
+.repository.file.editor.edit .editor-preview .markdown:not(code).ui.segment,.repository.file.editor.edit .editor-preview-side .markdown:not(code).ui.segment,.repository.wiki.new .CodeMirror .editor-preview .markdown:not(code).ui.segment,.repository.wiki.new .CodeMirror .editor-preview-side .markdown:not(code).ui.segment{border-width:0}
 .ui.dropdown .menu{background:#2c303a}
 .ui.dropdown .menu>.message:not(.ui){color:#636363}
 .ui.input{color:#dbdbdb}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -96,6 +96,9 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .markdown:not(code) table tr:nth-child(2n-1){background-color:#383b44}
 .markdown:not(code) table thead tr:nth-child(2n-1){background-color:#464c5d!important}
 .markdown:not(code) table td,.markdown:not(code) table th{border-color:#4c505c!important}
+.repository.file.editor.edit,.repository.wiki.new .CodeMirror{border-right:1px solid rgba(187,187,187,.6);border-left:1px solid rgba(187,187,187,.6);border-bottom:1px solid rgba(187,187,187,.6)}
+.repository.file.editor.edit .editor-preview,.repository.wiki.new .CodeMirror .editor-preview{background:#353945;scrollbar-color:#2a2a2a #fff}
+.repository.file.editor.edit .editor-preview .markdown:not(code).ui.segment,.repository.wiki.new .CodeMirror .editor-preview .markdown:not(code).ui.segment{border-width:0}
 .ui.dropdown .menu{background:#2c303a}
 .ui.dropdown .menu>.message:not(.ui){color:#636363}
 .ui.input{color:#dbdbdb}

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1144,7 +1144,7 @@ function initWikiForm() {
                             "text": plainText
                         },
                         function (data) {
-                            preview.innerHTML = '<div class="markdown">' + data + '</div>';
+                            preview.innerHTML = '<div class="markdown ui segment">' + data + '</div>';
                             emojify.run($('.editor-preview')[0]);
                         }
                     );
@@ -1224,7 +1224,7 @@ function setSimpleMDE($editArea) {
                         "text": plainText
                     },
                     function (data) {
-                        preview.innerHTML = '<div class="markdown">' + data + '</div>';
+                        preview.innerHTML = '<div class="markdown ui segment">' + data + '</div>';
                         emojify.run($('.editor-preview')[0]);
                     }
                 );

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -525,7 +525,6 @@ a.ui.basic.green.label:hover {
 
     .editor-preview {
         background: #353945;
-        scrollbar-color: #2a2a2a white;
 
         .markdown:not(code).ui.segment {
             border-width: 0;

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -517,6 +517,22 @@ a.ui.basic.green.label:hover {
     border-color: #4c505c !important;
 }
 
+.repository.file.editor.edit,
+.repository.wiki.new .CodeMirror {
+    border-right: 1px solid rgba(187,187,187, 0.6);
+    border-left: 1px solid rgba(187,187,187, 0.6);
+    border-bottom: 1px solid rgba(187,187,187, 0.6);
+
+    .editor-preview {
+        background: #353945;
+        scrollbar-color: #2a2a2a white;
+
+        .markdown:not(code).ui.segment {
+            border-width: 0;
+        }
+    }
+}
+
 .ui.dropdown .menu {
     background: #2c303a;
 }

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -501,7 +501,20 @@ a.ui.basic.green.label:hover {
 }
 
 .markdown:not(code) table tr:nth-child(2n) {
-    background-color: #474d61;
+    background-color: #2a2e39;
+}
+
+.markdown:not(code) table tr:nth-child(2n-1) {
+    background-color: #383b44;
+}
+
+.markdown:not(code) table thead tr:nth-child(2n-1) {
+    background-color: #464c5d !important;
+}
+
+.markdown:not(code) table td,
+.markdown:not(code) table th {
+    border-color: #4c505c !important;
 }
 
 .ui.dropdown .menu {

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -523,7 +523,8 @@ a.ui.basic.green.label:hover {
     border-left: 1px solid rgba(187,187,187, 0.6);
     border-bottom: 1px solid rgba(187,187,187, 0.6);
 
-    .editor-preview {
+    .editor-preview,
+    .editor-preview-side {
         background: #353945;
 
         .markdown:not(code).ui.segment {


### PR DESCRIPTION
* fixes tables in dark theme
* fix simpleMDE preview in dark theme

## Images

|                                                | OLD          | NEW        |
|:------------------------------------- |:-------------:|:-------------:|
| Tables in Markdown <br> Commit 1              | ![grafik](https://user-images.githubusercontent.com/24939127/59816583-f462e500-931c-11e9-9920-c4c5981d8a1f.png)  | ![grafik](https://user-images.githubusercontent.com/24939127/59816603-06dd1e80-931d-11e9-851b-0421ca46b9c8.png)  |
| Markdown editor wiki + repo  <br> Commit 2  | ![grafik](https://user-images.githubusercontent.com/24939127/59816831-dba6ff00-931d-11e9-8447-0d9c27642005.png)  | ![grafik](https://user-images.githubusercontent.com/24939127/59816781-b31f0500-931d-11e9-9cbd-bcf70d851a5c.png) |


Signed-off-by: Michael Gnehr <michael@gnehr.de>