### PR TITLE
gitea own dark codemirror theme

### DIFF
--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -230,6 +230,7 @@ a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb
 .CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:0}
 .CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
 .CodeMirror .CodeMirror-gutters{background-color:#2b2b2b}
+.CodeMirror .CodeMirror-selected,.CodeMirror ::-moz-selection,.CodeMirror ::selection{background:#42402f!important}
 .CodeMirror.cm-s-default .cm-property,.CodeMirror.cm-s-paper .cm-property{color:#a0cc75}
 .CodeMirror.cm-s-default .cm-header,.CodeMirror.cm-s-paper .cm-header{color:#9daccc}
 .CodeMirror.cm-s-default .cm-quote,.CodeMirror.cm-s-paper .cm-quote{color:#090}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -169,7 +169,6 @@ input{background:#2e323e}
 .ui.bottom.attached.message{background-color:#2c662d;color:#87ab63}
 .ui.bottom.attached.message .pull-right{color:#87ab63}
 .ui.info.message{background-color:#2c3b4a;color:#9ebcc5}
-.CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
 .ui .warning.header{background-color:#5d3a22!important;border-color:#794f31}
 .ui.red.message{background-color:rgba(80,23,17,.6);color:#f9cbcb;box-shadow:0 0 0 1px rgba(121,71,66,.5) inset,0 0 0 0 transparent}
 .ui.red.button,.ui.red.buttons .button{background-color:#7d3434}
@@ -219,8 +218,6 @@ a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb
 .ui.modal>.content{background:#383c4a}
 .editor-toolbar{background-color:#404552}
 .editor-toolbar a{color:#87ab63!important}
-.CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:0}
-.CodeMirror-gutters{background-color:#2b2b2b}
 .repository .diff-detail-box{background-color:#383c4a}
 .repository .diff-detail-box .detail-files{background-color:inherit}
 .comment-code-cloud .ui.attached.tabular.menu{background:none transparent;border:0}
@@ -230,3 +227,27 @@ a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667;color:#dbdbdb
 .ui.comments .comment .metadata{color:#808084}
 .ui.comments .comment .text{color:#9e9e9e}
 .heatmap-color-0{background-color:#2d303b}
+.CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:0}
+.CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
+.CodeMirror .CodeMirror-gutters{background-color:#2b2b2b}
+.CodeMirror.cm-s-default .cm-property,.CodeMirror.cm-s-paper .cm-property{color:#a0cc75}
+.CodeMirror.cm-s-default .cm-header,.CodeMirror.cm-s-paper .cm-header{color:#9daccc}
+.CodeMirror.cm-s-default .cm-quote,.CodeMirror.cm-s-paper .cm-quote{color:#090}
+.CodeMirror.cm-s-default .cm-keyword,.CodeMirror.cm-s-paper .cm-keyword{color:#cc8a61}
+.CodeMirror.cm-s-default .cm-atom,.CodeMirror.cm-s-paper .cm-atom{color:#ef5e77}
+.CodeMirror.cm-s-default .cm-number,.CodeMirror.cm-s-paper .cm-number{color:#ff5656}
+.CodeMirror.cm-s-default .cm-def,.CodeMirror.cm-s-paper .cm-def{color:#e4e4e4}
+.CodeMirror.cm-s-default .cm-variable-2,.CodeMirror.cm-s-paper .cm-variable-2{color:#00bdbf}
+.CodeMirror.cm-s-default .cm-variable-3,.CodeMirror.cm-s-paper .cm-variable-3{color:#085}
+.CodeMirror.cm-s-default .cm-comment,.CodeMirror.cm-s-paper .cm-comment{color:#8e9ab3}
+.CodeMirror.cm-s-default .cm-string,.CodeMirror.cm-s-paper .cm-string{color:#a77272}
+.CodeMirror.cm-s-default .cm-string-2,.CodeMirror.cm-s-paper .cm-string-2{color:#f50}
+.CodeMirror.cm-s-default .cm-meta,.CodeMirror.cm-s-default .cm-qualifier,.CodeMirror.cm-s-paper .cm-meta,.CodeMirror.cm-s-paper .cm-qualifier{color:#ffb176}
+.CodeMirror.cm-s-default .cm-builtin,.CodeMirror.cm-s-paper .cm-builtin{color:#b7c951}
+.CodeMirror.cm-s-default .cm-bracket,.CodeMirror.cm-s-paper .cm-bracket{color:#997}
+.CodeMirror.cm-s-default .cm-tag,.CodeMirror.cm-s-paper .cm-tag{color:#f1d273}
+.CodeMirror.cm-s-default .cm-attribute,.CodeMirror.cm-s-paper .cm-attribute{color:#bfcc70}
+.CodeMirror.cm-s-default .cm-hr,.CodeMirror.cm-s-paper .cm-hr{color:#999}
+.CodeMirror.cm-s-default .cm-url,.CodeMirror.cm-s-paper .cm-url{color:#c5cfd0}
+.CodeMirror.cm-s-default .cm-link,.CodeMirror.cm-s-paper .cm-link{color:#d8c792}
+.CodeMirror.cm-s-default .cm-error,.CodeMirror.cm-s-paper .cm-error{color:#dbdbeb}

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -857,10 +857,6 @@ input {
     color: #9ebcc5;
 }
 
-.CodeMirror div.CodeMirror-cursor {
-    border-left: 1px solid #9e9e9e;
-}
-
 .ui .warning.header {
     background-color: #5d3a22 !important;
     border-color: #794f31;
@@ -1134,16 +1130,6 @@ a.ui.labels .label:hover {
     }
 }
 
-.CodeMirror {
-    color: #9daccc;
-    background-color: #2b2b2b;
-    border-top: 0;
-}
-
-.CodeMirror-gutters {
-    background-color: #2b2b2b;
-}
-
 .repository .diff-detail-box {
     background-color: #383c4a;
 
@@ -1183,4 +1169,109 @@ a.ui.labels .label:hover {
 
 .heatmap-color-0 {
     background-color: #2d303b;
+}
+
+/* code mirror dark theme */
+
+.CodeMirror {
+    color: #9daccc;
+    background-color: #2b2b2b;
+    border-top: 0;
+
+    div.CodeMirror-cursor {
+        border-left: 1px solid #9e9e9e;
+    }
+
+    .CodeMirror-gutters {
+        background-color: #2b2b2b;
+    }
+
+    &.cm-s-default,
+    &.cm-s-paper {
+        .cm-property {
+            color: #a0cc75;
+        }
+
+        .cm-header {
+            color: #9daccc;
+        }
+
+        .cm-quote {
+            color: #009900;
+        }
+
+        .cm-keyword {
+            color: #cc8a61;
+        }
+
+        .cm-atom {
+            color: #ef5e77;
+        }
+
+        .cm-number {
+            color: #ff5656;
+        }
+
+        .cm-def {
+            color: #e4e4e4;
+        }
+
+        .cm-variable-2 {
+            color: #00bdbf;
+        }
+
+        .cm-variable-3 {
+            color: #008855;
+        }
+
+        .cm-comment {
+            color: #8e9ab3;
+        }
+
+        .cm-string {
+            color: #a77272;
+        }
+
+        .cm-string-2 {
+            color: #ff5500;
+        }
+
+        .cm-meta,
+        .cm-qualifier {
+            color: #ffb176;
+        }
+
+        .cm-builtin {
+            color: #b7c951;
+        }
+
+        .cm-bracket {
+            color: #999977;
+        }
+
+        .cm-tag {
+            color: #f1d273;
+        }
+
+        .cm-attribute {
+            color: #bfcc70;
+        }
+
+        .cm-hr {
+            color: #999999;
+        }
+
+        .cm-url {
+            color: #c5cfd0;
+        }
+
+        .cm-link {
+            color: #d8c792;
+        }
+
+        .cm-error {
+            /* color: #ff6e00; */
+            color: #dbdbeb;
+        }
+    }
 }

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -1186,6 +1186,12 @@ a.ui.labels .label:hover {
         background-color: #2b2b2b;
     }
 
+    ::selection,
+    ::-moz-selection,
+    .CodeMirror-selected {
+        background: #42402f !important;
+    }
+
     &.cm-s-default,
     &.cm-s-paper {
         .cm-property {


### PR DESCRIPTION
fix #6573 (Editor in dark mode can't be seen)

feel free to modify the colors

## old

![grafik](https://user-images.githubusercontent.com/24939127/59817458-45c0a380-9320-11e9-9410-12328ed7d91b.png)

## examples - this PR

### md (wiki editor)

![grafik](https://user-images.githubusercontent.com/24939127/60310640-221ae000-9954-11e9-9f42-2eb123a9eae9.png)

### css

![grafik](https://user-images.githubusercontent.com/24939127/60310656-34951980-9954-11e9-8ac3-6a6f08153f28.png)

### js

![grafik](https://user-images.githubusercontent.com/24939127/60310708-57bfc900-9954-11e9-821f-1131a4bf764a.png)

## selection

![grafik](https://user-images.githubusercontent.com/24939127/60311520-df5b0700-9957-11e9-862c-a25aa581d7e7.png)

