### PR TITLE
Fix 7303 - remove unnessesary buttons on archived repos

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1866,6 +1866,7 @@ push_tag = pushed tag <a href="%s/src/tag/%s">%[2]s</a> to <a href="%[1]s">%[3]s
 delete_tag = deleted tag %[2]s from <a href="%[1]s">%[3]s</a>
 delete_branch = deleted branch %[2]s from <a href="%[1]s">%[3]s</a>
 compare_commits = Compare %d commits
+compare_commits_general = Compare commits
 mirror_sync_push = synced commits to <a href="%[1]s/src/%[2]s">%[3]s</a> at <a href="%[1]s">%[4]s</a> from mirror
 mirror_sync_create = synced new reference <a href="%s/src/%s">%[2]s</a> to <a href="%[1]s">%[3]s</a> from mirror
 mirror_sync_delete = synced and deleted reference <code>%[2]s</code> at <a href="%[1]s">%[3]s</a> from mirror

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -56,9 +56,11 @@
         		{{.i18n.Tr "repo.pulls.has_pull_request" $.RepoLink $.RepoRelPath .PullRequest.Index | Safe}}
         	</div>
         {{else}}
+        	{{if not .Repository.IsArchived}}
         	<div class="ui info message show-form-container">
         		<button class="ui button green show-form">{{.i18n.Tr "repo.pulls.new"}}</button>
         	</div>
+        	{{end}}
         	<div class="pullrequest-form" style="display: none">
         		{{template "repo/issue/new_form" .}}
         	</div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -17,6 +17,12 @@
 						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | EscapePound}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{.Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | EscapePound}}{{end}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 					{{end}}
 				</div>
+			{{else}}
+				{{if not .PageIsIssueList}}
+					<div class="column right aligned">
+						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | EscapePound}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{.Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | EscapePound}}{{end}}">{{$.i18n.Tr "action.compare_commits_general"}}</a>
+					</div>
+				{{end}}
 			{{end}}
 		</div>
 		<div class="ui divider"></div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -132,6 +132,7 @@
 			this one correctly, but not the other one. */}}
 			<div class="nine wide right aligned right floated column">
 				<div class="ui secondary filter stackable menu">
+					{{if not .Repository.IsArchived}}
 					<!-- Action Button -->
 					{{if .IsShowClosed}}
 						<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.i18n.Tr "repo.issues.action_open"}}</div>
@@ -188,6 +189,7 @@
 							{{end}}
 						</div>
 					</div>
+					{{end}}
 				</div>
 			</div>
 		</div>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -70,7 +70,7 @@
 				{{ template "repo/issue/view_content/pull". }}
 			{{end}}
 			{{if .IsSigned}}
-				{{ if or .IsRepoAdmin .IsRepoIssuesWriter (or (not .Issue.IsLocked)) }}
+				{{ if and (or .IsRepoAdmin .IsRepoIssuesWriter (or (not .Issue.IsLocked))) (not .Repository.IsArchived) }}
 				<div class="comment form">
 					<a class="avatar" href="{{.SignedUser.HomeLink}}">
 						<img src="{{.SignedUser.RelAvatarLink}}">
@@ -111,6 +111,7 @@
 				</div>
 			{{else}}
 				{{if .IsSigned}}
+					{{if .Repository.IsArchived}}
 					<div class="comment form">
 						<a class="avatar" href="{{.SignedUser.HomeLink}}">
 							<img src="{{.SignedUser.RelAvatarLink}}">
@@ -139,6 +140,7 @@
 							</form>
 						</div>
 					</div>
+					{{end}}
 				{{else}}
 					<div class="ui warning message">
 						{{.i18n.Tr "repo.issues.sign_in_require_desc" .SignInLink | Safe}}

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -336,7 +336,7 @@
 				{{end}}
 			</div>
 
-			{{ if .IsRepoAdmin }}
+			{{ if and .IsRepoAdmin (not .Repository.IsArchived) }}
 			<div class="ui divider"></div>
 			<div class="ui watching">
 				<div>


### PR DESCRIPTION
remove disabled* ui elements on **archived repositories** + enable compare button

`* by router`

#### full list of changes

- archived repo - remove 
  - open/close button on issue list
  - assigne person on issue list
  - comment field on issue view
  - lock/unlock issue conversation button from sidebar on issue view
  - `new pull request` button from compare view
- archived repo - add 
  - 'compare commits' button to pull request (as the route is still working, and there is no need for it to be hidden)

fix #7303

### Images
|Commit 1|Commit 2|
|--|--|
| ![grafik](https://user-images.githubusercontent.com/24939127/60377167-9917ad80-9a14-11e9-98a8-a365b95597d9.png) | ![grafik](https://user-images.githubusercontent.com/24939127/60377221-1f33f400-9a15-11e9-8d7e-45997a2175c5.png) |   |
|**Commit 3**| |
| ![grafik](https://user-images.githubusercontent.com/24939127/60377278-9f5a5980-9a15-11e9-94b5-7be9f10ffe9f.png) | ![grafik](https://user-images.githubusercontent.com/24939127/60377333-1ee82880-9a16-11e9-8aaf-69c261ae23a2.png)  |