### PR TITLE
Update drone to use drone 1 format

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: build
+name: testing
 
 platform:
   os: linux
@@ -308,6 +308,101 @@ steps:
         - push
         - tag
         - pull_request
+---
+kind: pipeline
+name: translations
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    exclude:
+      - pull_request
+
+steps:
+  - name: download
+    pull: always
+    image: jonasfranz/crowdin
+    settings:
+      download: true
+      export_dir: options/locale/
+      ignore_branch: true
+      project_identifier: gitea
+    environment:
+      CROWDIN_KEY:
+        from_secret: crowdin_key
+
+  - name: update
+    pull: default
+    image: alpine:3.10
+    commands:
+      - mv ./options/locale/locale_en-US.ini ./options/
+      - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
+      - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
+      - mv ./options/locale_en-US.ini ./options/locale/
+
+  - name: push
+    pull: always
+    image: appleboy/drone-git-push
+    settings:
+      author_email: "teabot@gitea.io"
+      author_name: GiteaBot
+      commit: true
+      commit_message: "[skip ci] Updated translations via Crowdin"
+      remote: "git@github.com:go-gitea/gitea.git"
+    environment:
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_push_ssh_key
+
+  - name: upload_translations
+    pull: always
+    image: jonasfranz/crowdin
+    settings:
+      files:
+        locale_en-US.ini: options/locale/locale_en-US.ini
+      ignore_branch: true
+      project_identifier: gitea
+    environment:
+      CROWDIN_KEY:
+        from_secret: crowdin_key
+
+---
+kind: pipeline
+name: release
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    exclude:
+      - pull_request
+
+depends_on:
+  - testing
+  - translations
+
+steps:
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
 
   - name: static
     pull: always
@@ -317,8 +412,6 @@ steps:
       - make release
     environment:
       TAGS: bindata sqlite sqlite_unlock_notify
-    depends_on:
-      - build
     when:
       event:
         - push
@@ -432,72 +525,6 @@ steps:
 
 ---
 kind: pipeline
-name: translations
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /go
-  path: src/code.gitea.io/gitea
-
-when:
-  branch:
-    - master
-  event:
-    exclude:
-      - pull_request
-
-steps:
-  - name: download
-    pull: always
-    image: jonasfranz/crowdin
-    settings:
-      download: true
-      export_dir: options/locale/
-      ignore_branch: true
-      project_identifier: gitea
-    environment:
-      CROWDIN_KEY:
-        from_secret: crowdin_key
-
-  - name: update
-    pull: default
-    image: alpine:3.10
-    commands:
-      - mv ./options/locale/locale_en-US.ini ./options/
-      - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
-      - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
-      - mv ./options/locale_en-US.ini ./options/locale/
-
-  - name: push
-    pull: always
-    image: appleboy/drone-git-push
-    settings:
-      author_email: "teabot@gitea.io"
-      author_name: GiteaBot
-      commit: true
-      commit_message: "[skip ci] Updated translations via Crowdin"
-      remote: "git@github.com:go-gitea/gitea.git"
-    environment:
-      GIT_PUSH_SSH_KEY:
-        from_secret: git_push_ssh_key
-
-  - name: upload_translations
-    pull: always
-    image: jonasfranz/crowdin
-    settings:
-      files:
-        locale_en-US.ini: options/locale/locale_en-US.ini
-      ignore_branch: true
-      project_identifier: gitea
-    environment:
-      CROWDIN_KEY:
-        from_secret: crowdin_key
-
----
-kind: pipeline
 name: docs
 
 platform:
@@ -548,12 +575,17 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
-  branch:
-    - master
   event:
-    - push
+    exclude:
+      - pull_request
 
 steps:
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
+
   - name: dryrun
     pull: always
     image: plugins/docker:18.09
@@ -626,6 +658,7 @@ depends_on:
   - build
   - docker
   - translations
+  - release
   - docs
 
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -321,7 +321,7 @@ workspace:
   base: /go
   path: src/code.gitea.io/gitea
 
-when:
+trigger:
   branch:
     - master
   event:
@@ -386,7 +386,7 @@ workspace:
   base: /go
   path: src/code.gitea.io/gitea
 
-when:
+trigger:
   branch:
     - master
   event:
@@ -534,7 +534,7 @@ workspace:
   base: /go
   path: src/code.gitea.io/gitea
 
-when:
+trigger:
   branch:
     - master
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -134,40 +134,6 @@ steps:
         - push
         - pull_request
 
-  - name: generate-coverage
-    pull: always
-    image: golang:1.12
-    commands:
-      - make coverage
-    environment:
-      TAGS: bindata
-    depends_on:
-      - unit-test
-    when:
-      branch:
-        - master
-      event:
-        - push
-        - pull_request
-
-  - name: coverage
-    pull: always
-    image: robertstettner/drone-codecov
-    settings:
-      files:
-        - coverage.all
-    environment:
-      CODECOV_TOKEN:
-        from_secret: codecov_token
-    depends_on:
-      - generate-coverage
-    when:
-      branch:
-        - master
-      event:
-        - push
-        - pull_request
-
   - name: release-test
     pull: always
     image: golang:1.12
@@ -307,6 +273,41 @@ steps:
       event:
         - push
         - tag
+        - pull_request
+
+  - name: generate-coverage
+    pull: always
+    image: golang:1.12
+    commands:
+      - make coverage
+    environment:
+      TAGS: bindata
+    depends_on:
+      - unit-test
+      - test-mysql
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - pull_request
+
+  - name: coverage
+    pull: always
+    image: robertstettner/drone-codecov
+    settings:
+      files:
+        - coverage.all
+    environment:
+      CODECOV_TOKEN:
+        from_secret: codecov_token
+    depends_on:
+      - generate-coverage
+    when:
+      branch:
+        - master
+      event:
+        - push
         - pull_request
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -375,154 +375,154 @@ steps:
       CROWDIN_KEY:
         from_secret: crowdin_key
 
----
-kind: pipeline
-name: release
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /go
-  path: src/code.gitea.io/gitea
-
-when:
-  branch:
-    - master
-  event:
-    exclude:
-      - pull_request
-
-depends_on:
-  - testing
-  - translations
-
-steps:
-  - name: fetch-tags
-    pull: default
-    image: docker:git
-    commands:
-      - git fetch --tags --force
-
-  - name: static
-    pull: always
-    image: techknowlogick/xgo:latest
-    commands:
-      - export PATH=$PATH:$GOPATH/bin
-      - make release
-    environment:
-      TAGS: bindata sqlite sqlite_unlock_notify
-    when:
-      event:
-        - push
-        - tag
-
-  - name: gpg-sign
-    pull: always
-    image: plugins/gpgsign:1
-    settings:
-      detach_sign: true
-      excludes:
-        - "dist/release/*.sha256"
-      files:
-        - "dist/release/*"
-    environment:
-      GPGSIGN_KEY:
-        from_secret: gpgsign_key
-      GPGSIGN_PASSPHRASE:
-        from_secret: gpgsign_passphrase
-    depends_on:
-      - static
-    when:
-      event:
-        - push
-        - tag
-
-  - name: tag-release
-    pull: always
-    image: plugins/s3:1
-    settings:
-      acl: public-read
-      bucket: releases
-      endpoint: https://storage.gitea.io
-      path_style: true
-      source: "dist/release/*"
-      strip_prefix: dist/release/
-      target: "/gitea/${DRONE_TAG##v}"
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-    depends_on:
-      - gpg-sign
-    when:
-      event:
-        - tag
-
-  - name: release-branch-release
-    pull: always
-    image: plugins/s3:1
-    settings:
-      acl: public-read
-      bucket: releases
-      endpoint: https://storage.gitea.io
-      path_style: true
-      source: "dist/release/*"
-      strip_prefix: dist/release/
-      target: "/gitea/${DRONE_BRANCH##release/v}"
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-    depends_on:
-      - gpg-sign
-    when:
-      branch:
-        - "release/*"
-      event:
-        - push
-
-  - name: release
-    pull: always
-    image: plugins/s3:1
-    settings:
-      acl: public-read
-      bucket: releases
-      endpoint: https://storage.gitea.io
-      path_style: true
-      source: "dist/release/*"
-      strip_prefix: dist/release/
-      target: /gitea/master
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-    depends_on:
-      - gpg-sign
-    when:
-      branch:
-        - master
-      event:
-        - push
-
-  - name: github
-    pull: always
-    image: plugins/github-release:1
-    settings:
-      files:
-        - "dist/release/*"
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    depends_on:
-      - gpg-sign
-    when:
-      event:
-        - tag
+#---
+#kind: pipeline
+#name: release
+#
+#platform:
+#  os: linux
+#  arch: amd64
+#
+#workspace:
+#  base: /go
+#  path: src/code.gitea.io/gitea
+#
+#when:
+#  branch:
+#    - master
+#  event:
+#    exclude:
+#      - pull_request
+#
+#depends_on:
+#  - testing
+#  - translations
+#
+#steps:
+#  - name: fetch-tags
+#    pull: default
+#    image: docker:git
+#    commands:
+#      - git fetch --tags --force
+#
+#  - name: static
+#    pull: always
+#    image: techknowlogick/xgo:latest
+#    commands:
+#      - export PATH=$PATH:$GOPATH/bin
+#      - make release
+#    environment:
+#      TAGS: bindata sqlite sqlite_unlock_notify
+#    when:
+#      event:
+#        - push
+#        - tag
+#
+#  - name: gpg-sign
+#    pull: always
+#    image: plugins/gpgsign:1
+#    settings:
+#      detach_sign: true
+#      excludes:
+#        - "dist/release/*.sha256"
+#      files:
+#        - "dist/release/*"
+#    environment:
+#      GPGSIGN_KEY:
+#        from_secret: gpgsign_key
+#      GPGSIGN_PASSPHRASE:
+#        from_secret: gpgsign_passphrase
+#    depends_on:
+#      - static
+#    when:
+#      event:
+#        - push
+#        - tag
+#
+#  - name: tag-release
+#    pull: always
+#    image: plugins/s3:1
+#    settings:
+#      acl: public-read
+#      bucket: releases
+#      endpoint: https://storage.gitea.io
+#      path_style: true
+#      source: "dist/release/*"
+#      strip_prefix: dist/release/
+#      target: "/gitea/${DRONE_TAG##v}"
+#    environment:
+#      AWS_ACCESS_KEY_ID:
+#        from_secret: aws_access_key_id
+#      AWS_SECRET_ACCESS_KEY:
+#        from_secret: aws_secret_access_key
+#    depends_on:
+#      - gpg-sign
+#    when:
+#      event:
+#        - tag
+#
+#  - name: release-branch-release
+#    pull: always
+#    image: plugins/s3:1
+#    settings:
+#      acl: public-read
+#      bucket: releases
+#      endpoint: https://storage.gitea.io
+#      path_style: true
+#      source: "dist/release/*"
+#      strip_prefix: dist/release/
+#      target: "/gitea/${DRONE_BRANCH##release/v}"
+#    environment:
+#      AWS_ACCESS_KEY_ID:
+#        from_secret: aws_access_key_id
+#      AWS_SECRET_ACCESS_KEY:
+#        from_secret: aws_secret_access_key
+#    depends_on:
+#      - gpg-sign
+#    when:
+#      branch:
+#        - "release/*"
+#      event:
+#        - push
+#
+#  - name: release
+#    pull: always
+#    image: plugins/s3:1
+#    settings:
+#      acl: public-read
+#      bucket: releases
+#      endpoint: https://storage.gitea.io
+#      path_style: true
+#      source: "dist/release/*"
+#      strip_prefix: dist/release/
+#      target: /gitea/master
+#    environment:
+#      AWS_ACCESS_KEY_ID:
+#        from_secret: aws_access_key_id
+#      AWS_SECRET_ACCESS_KEY:
+#        from_secret: aws_secret_access_key
+#    depends_on:
+#      - gpg-sign
+#    when:
+#      branch:
+#        - master
+#      event:
+#        - push
+#
+#  - name: github
+#    pull: always
+#    image: plugins/github-release:1
+#    settings:
+#      files:
+#        - "dist/release/*"
+#    environment:
+#      GITHUB_TOKEN:
+#        from_secret: github_token
+#    depends_on:
+#      - gpg-sign
+#    when:
+#      event:
+#        - tag
 
 ---
 kind: pipeline
@@ -659,7 +659,7 @@ depends_on:
   - build
   - docker
   - translations
-  - release
+#  - release
   - docs
 
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -375,154 +375,154 @@ steps:
       CROWDIN_KEY:
         from_secret: crowdin_key
 
-#---
-#kind: pipeline
-#name: release
-#
-#platform:
-#  os: linux
-#  arch: amd64
-#
-#workspace:
-#  base: /go
-#  path: src/code.gitea.io/gitea
-#
-#when:
-#  branch:
-#    - master
-#  event:
-#    exclude:
-#      - pull_request
-#
-#depends_on:
-#  - testing
-#  - translations
-#
-#steps:
-#  - name: fetch-tags
-#    pull: default
-#    image: docker:git
-#    commands:
-#      - git fetch --tags --force
-#
-#  - name: static
-#    pull: always
-#    image: techknowlogick/xgo:latest
-#    commands:
-#      - export PATH=$PATH:$GOPATH/bin
-#      - make release
-#    environment:
-#      TAGS: bindata sqlite sqlite_unlock_notify
-#    when:
-#      event:
-#        - push
-#        - tag
-#
-#  - name: gpg-sign
-#    pull: always
-#    image: plugins/gpgsign:1
-#    settings:
-#      detach_sign: true
-#      excludes:
-#        - "dist/release/*.sha256"
-#      files:
-#        - "dist/release/*"
-#    environment:
-#      GPGSIGN_KEY:
-#        from_secret: gpgsign_key
-#      GPGSIGN_PASSPHRASE:
-#        from_secret: gpgsign_passphrase
-#    depends_on:
-#      - static
-#    when:
-#      event:
-#        - push
-#        - tag
-#
-#  - name: tag-release
-#    pull: always
-#    image: plugins/s3:1
-#    settings:
-#      acl: public-read
-#      bucket: releases
-#      endpoint: https://storage.gitea.io
-#      path_style: true
-#      source: "dist/release/*"
-#      strip_prefix: dist/release/
-#      target: "/gitea/${DRONE_TAG##v}"
-#    environment:
-#      AWS_ACCESS_KEY_ID:
-#        from_secret: aws_access_key_id
-#      AWS_SECRET_ACCESS_KEY:
-#        from_secret: aws_secret_access_key
-#    depends_on:
-#      - gpg-sign
-#    when:
-#      event:
-#        - tag
-#
-#  - name: release-branch-release
-#    pull: always
-#    image: plugins/s3:1
-#    settings:
-#      acl: public-read
-#      bucket: releases
-#      endpoint: https://storage.gitea.io
-#      path_style: true
-#      source: "dist/release/*"
-#      strip_prefix: dist/release/
-#      target: "/gitea/${DRONE_BRANCH##release/v}"
-#    environment:
-#      AWS_ACCESS_KEY_ID:
-#        from_secret: aws_access_key_id
-#      AWS_SECRET_ACCESS_KEY:
-#        from_secret: aws_secret_access_key
-#    depends_on:
-#      - gpg-sign
-#    when:
-#      branch:
-#        - "release/*"
-#      event:
-#        - push
-#
-#  - name: release
-#    pull: always
-#    image: plugins/s3:1
-#    settings:
-#      acl: public-read
-#      bucket: releases
-#      endpoint: https://storage.gitea.io
-#      path_style: true
-#      source: "dist/release/*"
-#      strip_prefix: dist/release/
-#      target: /gitea/master
-#    environment:
-#      AWS_ACCESS_KEY_ID:
-#        from_secret: aws_access_key_id
-#      AWS_SECRET_ACCESS_KEY:
-#        from_secret: aws_secret_access_key
-#    depends_on:
-#      - gpg-sign
-#    when:
-#      branch:
-#        - master
-#      event:
-#        - push
-#
-#  - name: github
-#    pull: always
-#    image: plugins/github-release:1
-#    settings:
-#      files:
-#        - "dist/release/*"
-#    environment:
-#      GITHUB_TOKEN:
-#        from_secret: github_token
-#    depends_on:
-#      - gpg-sign
-#    when:
-#      event:
-#        - tag
+---
+kind: pipeline
+name: release
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    exclude:
+      - pull_request
+
+depends_on:
+  - testing
+  - translations
+
+steps:
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
+
+  - name: static
+    pull: always
+    image: techknowlogick/xgo:latest
+    commands:
+      - export PATH=$PATH:$GOPATH/bin
+      - make release
+    environment:
+      TAGS: bindata sqlite sqlite_unlock_notify
+    when:
+      event:
+        - push
+        - tag
+
+  - name: gpg-sign
+    pull: always
+    image: plugins/gpgsign:1
+    settings:
+      detach_sign: true
+      excludes:
+        - "dist/release/*.sha256"
+      files:
+        - "dist/release/*"
+    environment:
+      GPGSIGN_KEY:
+        from_secret: gpgsign_key
+      GPGSIGN_PASSPHRASE:
+        from_secret: gpgsign_passphrase
+    depends_on:
+      - static
+    when:
+      event:
+        - push
+        - tag
+
+  - name: tag-release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: "/gitea/${DRONE_TAG##v}"
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      event:
+        - tag
+
+  - name: release-branch-release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: "/gitea/${DRONE_BRANCH##release/v}"
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      branch:
+        - "release/*"
+      event:
+        - push
+
+  - name: release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: /gitea/master
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      branch:
+        - master
+      event:
+        - push
+
+  - name: github
+    pull: always
+    image: plugins/github-release:1
+    settings:
+      files:
+        - "dist/release/*"
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    depends_on:
+      - gpg-sign
+    when:
+      event:
+        - tag
 
 ---
 kind: pipeline
@@ -656,10 +656,10 @@ when:
     - failure
 
 depends_on:
-  - build
+  - testing
   - docker
   - translations
-#  - release
+  - release
   - docs
 
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -322,8 +322,6 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
-  branch:
-    - master
   event:
     exclude:
       - pull_request
@@ -388,8 +386,6 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
-  branch:
-    - master
   event:
     exclude:
       - pull_request
@@ -537,8 +533,6 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
-  branch:
-    - master
   event:
     exclude:
       - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,55 +21,6 @@ steps:
       exclude:
       - pull_request
 
-- name: download_translations
-  pull: always
-  image: jonasfranz/crowdin
-  settings:
-    download: true
-    export_dir: options/locale/
-    ignore_branch: true
-    project_identifier: gitea
-  environment:
-    CROWDIN_KEY:
-      from_secret: crowdin_key
-  when:
-    branch:
-    - master
-    event:
-    - push
-
-- name: update-translations
-  pull: default
-  image: alpine:3.10
-  commands:
-  - mv ./options/locale/locale_en-US.ini ./options/
-  - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
-  - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
-  - mv ./options/locale_en-US.ini ./options/locale/
-  when:
-    branch:
-    - master
-    event:
-    - push
-
-- name: git_push
-  pull: always
-  image: appleboy/drone-git-push
-  settings:
-    author_email: "teabot@gitea.io"
-    author_name: GiteaBot
-    commit: true
-    commit_message: "[skip ci] Updated translations via Crowdin"
-    remote: "git@github.com:go-gitea/gitea.git"
-  environment:
-    GIT_PUSH_SSH_KEY:
-      from_secret: git_push_ssh_key
-  when:
-    branch:
-    - master
-    event:
-    - push
-
 - name: pre-build
   pull: always
   image: webhippie/nodejs:latest
@@ -571,5 +522,55 @@ services:
     - push
     - tag
     - pull_request
+---
+kind: pipeline
+name: translations
 
-...
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    - push
+
+steps:
+- name: download
+  pull: always
+  image: jonasfranz/crowdin
+  settings:
+    download: true
+    export_dir: options/locale/
+    ignore_branch: true
+    project_identifier: gitea
+  environment:
+    CROWDIN_KEY:
+      from_secret: crowdin_key
+
+- name: update
+  pull: default
+  image: alpine:3.10
+  commands:
+    - mv ./options/locale/locale_en-US.ini ./options/
+    - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
+    - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
+    - mv ./options/locale_en-US.ini ./options/locale/
+
+- name: push
+  pull: always
+  image: appleboy/drone-git-push
+  settings:
+    author_email: "teabot@gitea.io"
+    author_name: GiteaBot
+    commit: true
+    commit_message: "[skip ci] Updated translations via Crowdin"
+    remote: "git@github.com:go-gitea/gitea.git"
+  environment:
+    GIT_PUSH_SSH_KEY:
+      from_secret: git_push_ssh_key

--- a/.drone.yml
+++ b/.drone.yml
@@ -308,6 +308,7 @@ steps:
         - push
         - tag
         - pull_request
+
 ---
 kind: pipeline
 name: translations

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,449 +1,575 @@
+---
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: amd64
+
 workspace:
   base: /go
   path: src/code.gitea.io/gitea
 
-pipeline:
-  fetch-tags:
-    image: docker:git
-    commands:
-      - git fetch --tags --force
-    when:
-      event:
-        exclude: [ pull_request ]
+steps:
+- name: fetch-tags
+  pull: default
+  image: docker:git
+  commands:
+  - git fetch --tags --force
+  when:
+    event:
+      exclude:
+      - pull_request
 
-  download_translations:
-    image: jonasfranz/crowdin
-    pull: true
-    secrets: [ crowdin_key ]
-    project_identifier: gitea
-    ignore_branch: true
+- name: download_translations
+  pull: always
+  image: jonasfranz/crowdin
+  settings:
     download: true
     export_dir: options/locale/
-    when:
-      event: [ push ]
-      branch: [ master ]
+    ignore_branch: true
+    project_identifier: gitea
+  environment:
+    CROWDIN_KEY:
+      from_secret: crowdin_key
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  update-translations:
-    image: alpine:3.10
-    commands:
-      - mv ./options/locale/locale_en-US.ini ./options/
-      - sed -i -e 's/="/=/g' -e 's/"$$//g' ./options/locale/*.ini
-      - sed -i -e 's/\\\\"/"/g' ./options/locale/*.ini
-      - mv ./options/locale_en-US.ini ./options/locale/
-    when:
-      event: [ push ]
-      branch: [ master ]
+- name: update-translations
+  pull: default
+  image: alpine:3.10
+  commands:
+  - mv ./options/locale/locale_en-US.ini ./options/
+  - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
+  - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
+  - mv ./options/locale_en-US.ini ./options/locale/
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  git_push:
-    image: appleboy/drone-git-push
-    pull: true
-    secrets: [ git_push_ssh_key ]
-    remote: git@github.com:go-gitea/gitea.git
-    force: false
+- name: git_push
+  pull: always
+  image: appleboy/drone-git-push
+  settings:
+    author_email: "teabot@gitea.io"
+    author_name: GiteaBot
     commit: true
     commit_message: "[skip ci] Updated translations via Crowdin"
-    author_name: GiteaBot
-    author_email: teabot@gitea.io
-    when:
-      event: [ push ]
-      branch: [ master ]
+    remote: "git@github.com:go-gitea/gitea.git"
+  environment:
+    GIT_PUSH_SSH_KEY:
+      from_secret: git_push_ssh_key
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  pre-build:
-    image: webhippie/nodejs:latest
-    pull: true
-    commands:
-      - make css
-      - make js
-    when:
-      event: [ push, tag, pull_request ]
+- name: pre-build
+  pull: always
+  image: webhippie/nodejs:latest
+  commands:
+  - make css
+  - make js
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  build-without-gcc:
-    image: golang:1.10 # this step is kept as the lowest version of golang that we support
-    pull: true
-    commands:
-      - go build -o gitea_no_gcc # test if build succeeds without the sqlite tag
-    when:
-      event: [ push, tag, pull_request ]
+- name: build-without-gcc
+  pull: always
+  image: golang:1.10
+  commands:
+  - go build -o gitea_no_gcc
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  build:
-    image: golang:1.12
-    pull: true
-    environment:
-      TAGS: bindata sqlite sqlite_unlock_notify
-    commands:
-      - make clean
-      - make generate
-      - make golangci-lint
-      - make revive
-      - make swagger-check
-      - make swagger-validate
-      - make test-vendor
-      - make build
-    when:
-      event: [ push, tag, pull_request ]
+- name: build
+  pull: always
+  image: golang:1.12
+  commands:
+  - make clean
+  - make generate
+  - make golangci-lint
+  - make revive
+  - make swagger-check
+  - make swagger-validate
+  - make test-vendor
+  - make build
+  environment:
+    TAGS: bindata sqlite sqlite_unlock_notify
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  unit-test:
-    image: golang:1.12
-    pull: true
+- name: unit-test
+  pull: always
+  image: golang:1.12
+  commands:
+  - make unit-test-coverage
+  settings:
     group: test
-    environment:
-      TAGS: bindata sqlite sqlite_unlock_notify
-    commands:
-      - make unit-test-coverage
-    when:
-      event: [ push, pull_request ]
-      branch: [ master ]
+  environment:
+    TAGS: bindata sqlite sqlite_unlock_notify
+  when:
+    branch:
+    - master
+    event:
+    - push
+    - pull_request
 
-  release-test:
-    image: golang:1.12
-    pull: true
+- name: release-test
+  pull: always
+  image: golang:1.12
+  commands:
+  - make test
+  settings:
     group: test
-    environment:
-      TAGS: bindata sqlite sqlite_unlock_notify
-    commands:
-      - make test
-    when:
-      event: [ push, pull_request ]
-      branch: [ release/* ]
+  environment:
+    TAGS: bindata sqlite sqlite_unlock_notify
+  when:
+    branch:
+    - "release/*"
+    event:
+    - push
+    - pull_request
 
-  tag-test:
-    image: golang:1.12
-    pull: true
+- name: tag-test
+  pull: always
+  image: golang:1.12
+  commands:
+  - make test
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-    commands:
-      - make test
-    when:
-      event: [ tag ]
+  environment:
+    TAGS: bindata
+  when:
+    event:
+    - tag
 
-  test-sqlite:
-    image: golang:1.12
-    pull: true
+- name: test-sqlite
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - timeout -s ABRT 20m make test-sqlite-migration
+  - timeout -s ABRT 20m make test-sqlite
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - timeout -s ABRT 20m make test-sqlite-migration
-      - timeout -s ABRT 20m make test-sqlite
-    when:
-      event: [ push, tag, pull_request ]
+  environment:
+    TAGS: bindata
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  test-mysql:
-    image: golang:1.12
-    pull: true
+- name: test-mysql
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - make test-mysql-migration
+  - make integration-test-coverage
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-      TEST_LDAP: "1"
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - make test-mysql-migration
-      - make integration-test-coverage
-    when:
-      event: [ push, pull_request ]
-      branch: [ master ]
+  environment:
+    TAGS: bindata
+    TEST_LDAP: 1
+  when:
+    branch:
+    - master
+    event:
+    - push
+    - pull_request
 
-  tag-test-mysql:
-    image: golang:1.12
-    pull: true
+- name: tag-test-mysql
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - timeout -s ABRT 20m make test-mysql-migration
+  - timeout -s ABRT 20m make test-mysql
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-      TEST_LDAP: "1"
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - timeout -s ABRT 20m make test-mysql-migration
-      - timeout -s ABRT 20m make test-mysql
-    when:
-      event: [ tag ]
+  environment:
+    TAGS: bindata
+    TEST_LDAP: 1
+  when:
+    event:
+    - tag
 
-  test-mysql8:
-    image: golang:1.12
-    pull: true
+- name: test-mysql8
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - timeout -s ABRT 20m make test-mysql8-migration
+  - timeout -s ABRT 20m make test-mysql8
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-      TEST_LDAP: "1"
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - timeout -s ABRT 20m make test-mysql8-migration
-      - timeout -s ABRT 20m make test-mysql8
-    when:
-      event: [ push, tag, pull_request ]
+  environment:
+    TAGS: bindata
+    TEST_LDAP: 1
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  test-pgsql:
-    image: golang:1.12
-    pull: true
+- name: test-pgsql
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - timeout -s ABRT 20m make test-pgsql-migration
+  - timeout -s ABRT 20m make test-pgsql
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-      TEST_LDAP: "1"
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - timeout -s ABRT 20m make test-pgsql-migration
-      - timeout -s ABRT 20m make test-pgsql
-    when:
-      event: [ push, tag, pull_request ]
+  environment:
+    TAGS: bindata
+    TEST_LDAP: 1
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  test-mssql:
-    image: golang:1.12
-    pull: true
+- name: test-mssql
+  pull: always
+  image: golang:1.12
+  commands:
+  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+  - apt-get install -y git-lfs
+  - make test-mssql-migration
+  - make test-mssql
+  settings:
     group: test
-    environment:
-      TAGS: bindata
-      TEST_LDAP: "1"
-    commands:
-      - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-      - apt-get install -y git-lfs
-      - make test-mssql-migration
-      - make test-mssql
-    when:
-      event: [ push, tag, pull_request ]
+  environment:
+    TAGS: bindata
+    TEST_LDAP: 1
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-#  bench-sqlite:
-#    image: golang:1.12
-#    pull: true
-#    group: bench
-#    commands:
-#      - make bench-sqlite
-#    when:
-#      event: [ tag ]
+- name: generate-coverage
+  pull: always
+  image: golang:1.12
+  commands:
+  - make coverage
+  environment:
+    TAGS: bindata
+  when:
+    branch:
+    - master
+    event:
+    - push
+    - pull_request
 
-#  bench-mysql:
-#    image: golang:1.12
-#    pull: true
-#    group: bench
-#    commands:
-#      - make bench-mysql
-#    when:
-#      event: [ tag ]
-
-#  bench-mssql:
-#    image: golang:1.12
-#    pull: true
-#    group: bench
-#    commands:
-#      - make bench-mssql
-#    when:
-#      event: [ tag ]
-
-#  bench-pgsql:
-#    image: golang:1.12
-#    pull: true
-#    group: bench
-#    commands:
-#      - make bench-pgsql
-#    when:
-#      event: [ tag ]
-
-  generate-coverage:
-    image: golang:1.12
-    pull: true
-    environment:
-      TAGS: bindata
-    commands:
-      - make coverage
-    when:
-      event: [ push, pull_request ]
-      branch: [ master ]
-
-  coverage:
-    image: robertstettner/drone-codecov
-    secrets: [ codecov_token ]
+- name: coverage
+  pull: default
+  image: robertstettner/drone-codecov
+  settings:
     files:
-      - coverage.all
-    when:
-      event: [ push, pull_request ]
-      branch: [ master ]
+    - coverage.all
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    branch:
+    - master
+    event:
+    - push
+    - pull_request
 
-  static:
-    image: techknowlogick/xgo:latest
-    pull: true
-    environment:
-      TAGS: bindata sqlite sqlite_unlock_notify
-    commands:
-      - export PATH=$PATH:$GOPATH/bin
-      - make release
-    when:
-      event: [ push, tag ]
+- name: static
+  pull: always
+  image: techknowlogick/xgo:latest
+  commands:
+  - export PATH=$PATH:$GOPATH/bin
+  - make release
+  environment:
+    TAGS: bindata sqlite sqlite_unlock_notify
+  when:
+    event:
+    - push
+    - tag
 
-  build-docs:
-    image: webhippie/hugo:latest
-    pull: true
-    commands:
-      - cd docs
-      - make trans-copy
-      - make clean
-      - make build
+- name: build-docs
+  pull: always
+  image: webhippie/hugo:latest
+  commands:
+  - cd docs
+  - make trans-copy
+  - make clean
+  - make build
 
-  publish-docs:
-    image: lucap/drone-netlify:latest
-    pull: true
-    secrets: [ netlify_token ]
-    site_id: d2260bae-7861-4c02-8646-8f6440b12672
+- name: publish-docs
+  pull: always
+  image: lucap/drone-netlify:latest
+  settings:
     path: docs/public/
-    when:
-      event: [ push ]
-      branch: [ master ]
+    site_id: d2260bae-7861-4c02-8646-8f6440b12672
+  environment:
+    NETLIFY_TOKEN:
+      from_secret: netlify_token
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  docker-dryrun:
-    image: plugins/docker:18.09
-    pull: true
-    repo: gitea/gitea
+- name: docker-dryrun
+  pull: always
+  image: plugins/docker:18.09
+  settings:
     cache_from: gitea/gitea
     dry_run: true
-    when:
-      event: [ pull_request ]
-
-  release-docker:
-    image: plugins/docker:18.09
-    pull: true
-    secrets: [ docker_username, docker_password ]
     repo: gitea/gitea
-    tags: [ '${DRONE_BRANCH##release/v}' ]
+  when:
+    event:
+    - pull_request
+
+- name: release-docker
+  pull: always
+  image: plugins/docker:18.09
+  settings:
     cache_from: gitea/gitea
-    when:
-      event: [ push ]
-      branch: [ release/* ]
-
-  docker:
-    image: plugins/docker:18.09
-    secrets: [ docker_username, docker_password ]
-    pull: true
     repo: gitea/gitea
+    tags:
+    - "${DRONE_BRANCH##release/v}"
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  when:
+    branch:
+    - "release/*"
+    event:
+    - push
+
+- name: docker
+  pull: always
+  image: plugins/docker:18.09
+  settings:
     cache_from: gitea/gitea
     default_tags: true
-    when:
-      event: [ push, tag ]
+    repo: gitea/gitea
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  when:
+    event:
+    - push
+    - tag
 
-  gpg-sign:
-    image: plugins/gpgsign:1
-    pull: true
-    secrets: [ gpgsign_key, gpgsign_passphrase ]
+- name: gpg-sign
+  pull: always
+  image: plugins/gpgsign:1
+  settings:
     detach_sign: true
-    files:
-      - dist/release/*
     excludes:
-      - dist/release/*.sha256
-    when:
-      event: [ push, tag ]
-
-  tag-release:
-    image: plugins/s3:1
-    pull: true
-    secrets: [ aws_access_key_id, aws_secret_access_key ]
-    bucket: releases
-    acl: public-read
-    endpoint: https://storage.gitea.io
-    path_style: true
-    strip_prefix: dist/release/
-    source: dist/release/*
-    target: /gitea/${DRONE_TAG##v}
-    when:
-      event: [ tag ]
-
-  release-branch-release:
-    image: plugins/s3:1
-    pull: true
-    secrets: [ aws_access_key_id, aws_secret_access_key ]
-    bucket: releases
-    acl: public-read
-    endpoint: https://storage.gitea.io
-    path_style: true
-    strip_prefix: dist/release/
-    source: dist/release/*
-    target: /gitea/${DRONE_BRANCH##release/v}
-    when:
-      event: [ push ]
-      branch: [ release/* ]
-
-  release:
-    image: plugins/s3:1
-    pull: true
-    secrets: [ aws_access_key_id, aws_secret_access_key ]
-    bucket: releases
-    acl: public-read
-    endpoint: https://storage.gitea.io
-    path_style: true
-    strip_prefix: dist/release/
-    source: dist/release/*
-    target: /gitea/master
-    when:
-      event: [ push ]
-      branch: [ master ]
-
-  github:
-    image: plugins/github-release:1
-    pull: true
-    secrets: [ github_token ]
+    - "dist/release/*.sha256"
     files:
-      - dist/release/*
-    when:
-      event: [ tag ]
+    - "dist/release/*"
+  environment:
+    GPGSIGN_KEY:
+      from_secret: gpgsign_key
+    GPGSIGN_PASSPHRASE:
+      from_secret: gpgsign_passphrase
+  when:
+    event:
+    - push
+    - tag
 
-  upload_translations:
-    image: jonasfranz/crowdin
-    pull: true
-    secrets: [ crowdin_key ]
-    project_identifier: gitea
-    ignore_branch: true
-    download: false
+- name: tag-release
+  pull: always
+  image: plugins/s3:1
+  settings:
+    acl: public-read
+    bucket: releases
+    endpoint: https://storage.gitea.io
+    path_style: true
+    source: "dist/release/*"
+    strip_prefix: dist/release/
+    target: "/gitea/${DRONE_TAG##v}"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  when:
+    event:
+    - tag
+
+- name: release-branch-release
+  pull: always
+  image: plugins/s3:1
+  settings:
+    acl: public-read
+    bucket: releases
+    endpoint: https://storage.gitea.io
+    path_style: true
+    source: "dist/release/*"
+    strip_prefix: dist/release/
+    target: "/gitea/${DRONE_BRANCH##release/v}"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  when:
+    branch:
+    - "release/*"
+    event:
+    - push
+
+- name: release
+  pull: always
+  image: plugins/s3:1
+  settings:
+    acl: public-read
+    bucket: releases
+    endpoint: https://storage.gitea.io
+    path_style: true
+    source: "dist/release/*"
+    strip_prefix: dist/release/
+    target: /gitea/master
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  when:
+    branch:
+    - master
+    event:
+    - push
+
+- name: github
+  pull: always
+  image: plugins/github-release:1
+  settings:
+    files:
+    - "dist/release/*"
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  when:
+    event:
+    - tag
+
+- name: upload_translations
+  pull: always
+  image: jonasfranz/crowdin
+  settings:
     files:
       locale_en-US.ini: options/locale/locale_en-US.ini
-    when:
-      event: [ push ]
-      branch: [ master ]
+    ignore_branch: true
+    project_identifier: gitea
+  environment:
+    CROWDIN_KEY:
+      from_secret: crowdin_key
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  discord:
-    image: appleboy/drone-discord:1.0.0
-    pull: true
-    secrets: [ discord_webhook_id, discord_webhook_token ]
-    when:
-      event: [ push, tag, pull_request ]
-      status: [ changed, failure ]
+- name: discord
+  pull: always
+  image: appleboy/drone-discord:1.0.0
+  environment:
+    DISCORD_WEBHOOK_ID:
+      from_secret: discord_webhook_id
+    DISCORD_WEBHOOK_TOKEN:
+      from_secret: discord_webhook_token
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
+    status:
+    - changed
+    - failure
 
 services:
-  mysql:
-    image: mysql:5.7
-    environment:
-      - MYSQL_DATABASE=test
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-    when:
-      event: [ push, tag, pull_request ]
+- name: mysql
+  pull: default
+  image: mysql:5.7
+  environment:
+    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_DATABASE: test
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  mysql8:
-    image: mysql:8.0
-    environment:
-      - MYSQL_DATABASE=test
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-      - MYSQL_DATABASE=testgitea
-    when:
-      event: [ push, tag, pull_request ]
+- name: mysql8
+  pull: default
+  image: mysql:8.0
+  environment:
+    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_DATABASE: testgitea
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  pgsql:
-    image: postgres:9.5
-    environment:
-      - POSTGRES_DB=test
-    when:
-      event: [ push, tag, pull_request ]
+- name: pgsql
+  pull: default
+  image: postgres:9.5
+  environment:
+    POSTGRES_DB: test
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  mssql:
-    image: microsoft/mssql-server-linux:latest
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=MwantsaSecurePassword1
-      - MSSQL_PID=Standard
-    when:
-      event: [ push, tag, pull_request ]
+- name: mssql
+  pull: default
+  image: microsoft/mssql-server-linux:latest
+  environment:
+    ACCEPT_EULA: Y
+    MSSQL_PID: Standard
+    SA_PASSWORD: MwantsaSecurePassword1
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
 
-  ldap:
-    image: gitea/test-openldap:latest
-    when:
-      event: [ push, tag, pull_request ]
+- name: ldap
+  pull: default
+  image: gitea/test-openldap:latest
+  when:
+    event:
+    - push
+    - tag
+    - pull_request
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -322,9 +322,10 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
+  branch:
+    - master
   event:
-    exclude:
-      - pull_request
+    - push
 
 steps:
   - name: download
@@ -386,9 +387,10 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
+  branch:
+    - master
   event:
-    exclude:
-      - pull_request
+    - push
 
 depends_on:
   - testing
@@ -533,9 +535,10 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
+  branch:
+    - master
   event:
-    exclude:
-      - pull_request
+    - push
 
 steps:
   - name: build-docs
@@ -568,11 +571,6 @@ platform:
 workspace:
   base: /go
   path: src/code.gitea.io/gitea
-
-when:
-  event:
-    exclude:
-      - pull_request
 
 steps:
   - name: fetch-tags
@@ -628,6 +626,8 @@ steps:
     depends_on:
       - dryrun
     when:
+      branch:
+        - master
       event:
         - push
         - tag
@@ -651,9 +651,9 @@ when:
 
 depends_on:
   - testing
-  - docker
   - translations
   - release
+  - docker
   - docs
 
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -74,10 +74,6 @@ steps:
     image: docker:git
     commands:
       - git fetch --tags --force
-    when:
-      event:
-        exclude:
-          - pull_request
 
   - name: pre-build
     pull: always
@@ -450,8 +446,6 @@ when:
   branch:
     - master
   event:
-    include:
-      - push
     exclude:
       - pull_request
 
@@ -518,8 +512,6 @@ when:
   branch:
     - master
   event:
-    include:
-      - push
     exclude:
       - pull_request
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -69,370 +69,370 @@ services:
         - pull_request
 
 steps:
-- name: fetch-tags
-  pull: default
-  image: docker:git
-  commands:
-  - git fetch --tags --force
-  when:
-    event:
-      exclude:
-      - pull_request
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
+    when:
+      event:
+        exclude:
+          - pull_request
 
-- name: pre-build
-  pull: always
-  image: webhippie/nodejs:latest
-  commands:
-  - make css
-  - make js
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: pre-build
+    pull: always
+    image: webhippie/nodejs:latest
+    commands:
+      - make css
+      - make js
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: build-without-gcc
-  pull: always
-  image: golang:1.10
-  commands:
-  - go build -o gitea_no_gcc
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: build-without-gcc
+    pull: always
+    image: golang:1.10
+    commands:
+      - go build -o gitea_no_gcc
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: build
-  pull: always
-  image: golang:1.12
-  commands:
-  - make clean
-  - make generate
-  - make golangci-lint
-  - make revive
-  - make swagger-check
-  - make swagger-validate
-  - make test-vendor
-  - make build
-  environment:
-    TAGS: bindata sqlite sqlite_unlock_notify
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: build
+    pull: always
+    image: golang:1.12
+    commands:
+      - make clean
+      - make generate
+      - make golangci-lint
+      - make revive
+      - make swagger-check
+      - make swagger-validate
+      - make test-vendor
+      - make build
+    environment:
+      TAGS: bindata sqlite sqlite_unlock_notify
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: unit-test
-  pull: always
-  image: golang:1.12
-  commands:
-  - make unit-test-coverage
-  environment:
-    TAGS: bindata sqlite sqlite_unlock_notify
-  depends_on:
-    - build
-  when:
-    branch:
-    - master
-    event:
-    - push
-    - pull_request
+  - name: unit-test
+    pull: always
+    image: golang:1.12
+    commands:
+      - make unit-test-coverage
+    environment:
+      TAGS: bindata sqlite sqlite_unlock_notify
+    depends_on:
+      - build
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - pull_request
 
-- name: generate-coverage
-  pull: always
-  image: golang:1.12
-  commands:
-    - make coverage
-  environment:
-    TAGS: bindata
-  depends_on:
-    - unit-test
-  when:
-    branch:
-      - master
-    event:
-      - push
-      - pull_request
+  - name: generate-coverage
+    pull: always
+    image: golang:1.12
+    commands:
+      - make coverage
+    environment:
+      TAGS: bindata
+    depends_on:
+      - unit-test
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - pull_request
 
-- name: coverage
-  pull: always
-  image: robertstettner/drone-codecov
-  settings:
-    files:
-      - coverage.all
-  environment:
-    CODECOV_TOKEN:
-      from_secret: codecov_token
-  depends_on:
-    - generate-coverage
-  when:
-    branch:
-      - master
-    event:
-      - push
-      - pull_request
+  - name: coverage
+    pull: always
+    image: robertstettner/drone-codecov
+    settings:
+      files:
+        - coverage.all
+    environment:
+      CODECOV_TOKEN:
+        from_secret: codecov_token
+    depends_on:
+      - generate-coverage
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - pull_request
 
-- name: release-test
-  pull: always
-  image: golang:1.12
-  commands:
-  - make test
-  environment:
-    TAGS: bindata sqlite sqlite_unlock_notify
-  depends_on:
-    - build
-  when:
-    branch:
-    - "release/*"
-    event:
-    - push
-    - pull_request
+  - name: release-test
+    pull: always
+    image: golang:1.12
+    commands:
+      - make test
+    environment:
+      TAGS: bindata sqlite sqlite_unlock_notify
+    depends_on:
+      - build
+    when:
+      branch:
+        - "release/*"
+      event:
+        - push
+        - pull_request
 
-- name: tag-test
-  pull: always
-  image: golang:1.12
-  commands:
-  - make test
-  environment:
-    TAGS: bindata
-  depends_on:
-    - build
-  when:
-    event:
-    - tag
+  - name: tag-test
+    pull: always
+    image: golang:1.12
+    commands:
+      - make test
+    environment:
+      TAGS: bindata
+    depends_on:
+      - build
+    when:
+      event:
+        - tag
 
-- name: test-sqlite
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - timeout -s ABRT 20m make test-sqlite-migration
-  - timeout -s ABRT 20m make test-sqlite
-  environment:
-    TAGS: bindata
-  depends_on:
-    - build
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: test-sqlite
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - timeout -s ABRT 20m make test-sqlite-migration
+      - timeout -s ABRT 20m make test-sqlite
+    environment:
+      TAGS: bindata
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: test-mysql
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - make test-mysql-migration
-  - make integration-test-coverage
-  environment:
-    TAGS: bindata
-    TEST_LDAP: 1
-  depends_on:
-    - build
-  when:
-    branch:
-    - master
-    event:
-    - push
-    - pull_request
+  - name: test-mysql
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - make test-mysql-migration
+      - make integration-test-coverage
+    environment:
+      TAGS: bindata
+      TEST_LDAP: 1
+    depends_on:
+      - build
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - pull_request
 
-- name: tag-test-mysql
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - timeout -s ABRT 20m make test-mysql-migration
-  - timeout -s ABRT 20m make test-mysql
-  environment:
-    TAGS: bindata
-    TEST_LDAP: 1
-  depends_on:
-    - build
-  when:
-    event:
-    - tag
+  - name: tag-test-mysql
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - timeout -s ABRT 20m make test-mysql-migration
+      - timeout -s ABRT 20m make test-mysql
+    environment:
+      TAGS: bindata
+      TEST_LDAP: 1
+    depends_on:
+      - build
+    when:
+      event:
+        - tag
 
-- name: test-mysql8
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - timeout -s ABRT 20m make test-mysql8-migration
-  - timeout -s ABRT 20m make test-mysql8
-  environment:
-    TAGS: bindata
-    TEST_LDAP: 1
-  depends_on:
-    - build
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: test-mysql8
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - timeout -s ABRT 20m make test-mysql8-migration
+      - timeout -s ABRT 20m make test-mysql8
+    environment:
+      TAGS: bindata
+      TEST_LDAP: 1
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: test-pgsql
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - timeout -s ABRT 20m make test-pgsql-migration
-  - timeout -s ABRT 20m make test-pgsql
-  environment:
-    TAGS: bindata
-    TEST_LDAP: 1
-  depends_on:
-    - build
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: test-pgsql
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - timeout -s ABRT 20m make test-pgsql-migration
+      - timeout -s ABRT 20m make test-pgsql
+    environment:
+      TAGS: bindata
+      TEST_LDAP: 1
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: test-mssql
-  pull: always
-  image: golang:1.12
-  commands:
-  - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
-  - apt-get install -y git-lfs
-  - make test-mssql-migration
-  - make test-mssql
-  environment:
-    TAGS: bindata
-    TEST_LDAP: 1
-  depends_on:
-    - build
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
+  - name: test-mssql
+    pull: always
+    image: golang:1.12
+    commands:
+      - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
+      - apt-get install -y git-lfs
+      - make test-mssql-migration
+      - make test-mssql
+    environment:
+      TAGS: bindata
+      TEST_LDAP: 1
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
-- name: static
-  pull: always
-  image: techknowlogick/xgo:latest
-  commands:
-  - export PATH=$PATH:$GOPATH/bin
-  - make release
-  environment:
-    TAGS: bindata sqlite sqlite_unlock_notify
-  depends_on:
-    - build
-  when:
-    event:
-    - push
-    - tag
+  - name: static
+    pull: always
+    image: techknowlogick/xgo:latest
+    commands:
+      - export PATH=$PATH:$GOPATH/bin
+      - make release
+    environment:
+      TAGS: bindata sqlite sqlite_unlock_notify
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
 
-- name: gpg-sign
-  pull: always
-  image: plugins/gpgsign:1
-  settings:
-    detach_sign: true
-    excludes:
-    - "dist/release/*.sha256"
-    files:
-    - "dist/release/*"
-  environment:
-    GPGSIGN_KEY:
-      from_secret: gpgsign_key
-    GPGSIGN_PASSPHRASE:
-      from_secret: gpgsign_passphrase
-  depends_on:
-    - static
-  when:
-    event:
-    - push
-    - tag
+  - name: gpg-sign
+    pull: always
+    image: plugins/gpgsign:1
+    settings:
+      detach_sign: true
+      excludes:
+        - "dist/release/*.sha256"
+      files:
+        - "dist/release/*"
+    environment:
+      GPGSIGN_KEY:
+        from_secret: gpgsign_key
+      GPGSIGN_PASSPHRASE:
+        from_secret: gpgsign_passphrase
+    depends_on:
+      - static
+    when:
+      event:
+        - push
+        - tag
 
-- name: tag-release
-  pull: always
-  image: plugins/s3:1
-  settings:
-    acl: public-read
-    bucket: releases
-    endpoint: https://storage.gitea.io
-    path_style: true
-    source: "dist/release/*"
-    strip_prefix: dist/release/
-    target: "/gitea/${DRONE_TAG##v}"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: aws_access_key_id
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: aws_secret_access_key
-  depends_on:
-    - gpg-sign
-  when:
-    event:
-    - tag
+  - name: tag-release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: "/gitea/${DRONE_TAG##v}"
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      event:
+        - tag
 
-- name: release-branch-release
-  pull: always
-  image: plugins/s3:1
-  settings:
-    acl: public-read
-    bucket: releases
-    endpoint: https://storage.gitea.io
-    path_style: true
-    source: "dist/release/*"
-    strip_prefix: dist/release/
-    target: "/gitea/${DRONE_BRANCH##release/v}"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: aws_access_key_id
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: aws_secret_access_key
-  depends_on:
-    - gpg-sign
-  when:
-    branch:
-    - "release/*"
-    event:
-    - push
+  - name: release-branch-release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: "/gitea/${DRONE_BRANCH##release/v}"
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      branch:
+        - "release/*"
+      event:
+        - push
 
-- name: release
-  pull: always
-  image: plugins/s3:1
-  settings:
-    acl: public-read
-    bucket: releases
-    endpoint: https://storage.gitea.io
-    path_style: true
-    source: "dist/release/*"
-    strip_prefix: dist/release/
-    target: /gitea/master
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: aws_access_key_id
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: aws_secret_access_key
-  depends_on:
-    - gpg-sign
-  when:
-    branch:
-    - master
-    event:
-    - push
+  - name: release
+    pull: always
+    image: plugins/s3:1
+    settings:
+      acl: public-read
+      bucket: releases
+      endpoint: https://storage.gitea.io
+      path_style: true
+      source: "dist/release/*"
+      strip_prefix: dist/release/
+      target: /gitea/master
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    depends_on:
+      - gpg-sign
+    when:
+      branch:
+        - master
+      event:
+        - push
 
-- name: github
-  pull: always
-  image: plugins/github-release:1
-  settings:
-    files:
-    - "dist/release/*"
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  depends_on:
-    - gpg-sign
-  when:
-    event:
-    - tag
+  - name: github
+    pull: always
+    image: plugins/github-release:1
+    settings:
+      files:
+        - "dist/release/*"
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    depends_on:
+      - gpg-sign
+    when:
+      event:
+        - tag
 
 ---
 kind: pipeline
@@ -453,51 +453,51 @@ when:
     - push
 
 steps:
-- name: download
-  pull: always
-  image: jonasfranz/crowdin
-  settings:
-    download: true
-    export_dir: options/locale/
-    ignore_branch: true
-    project_identifier: gitea
-  environment:
-    CROWDIN_KEY:
-      from_secret: crowdin_key
+  - name: download
+    pull: always
+    image: jonasfranz/crowdin
+    settings:
+      download: true
+      export_dir: options/locale/
+      ignore_branch: true
+      project_identifier: gitea
+    environment:
+      CROWDIN_KEY:
+        from_secret: crowdin_key
 
-- name: update
-  pull: default
-  image: alpine:3.10
-  commands:
-    - mv ./options/locale/locale_en-US.ini ./options/
-    - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
-    - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
-    - mv ./options/locale_en-US.ini ./options/locale/
+  - name: update
+    pull: default
+    image: alpine:3.10
+    commands:
+      - mv ./options/locale/locale_en-US.ini ./options/
+      - "sed -i -e 's/=\"/=/g' -e 's/\"$$//g' ./options/locale/*.ini"
+      - "sed -i -e 's/\\\\\\\\\"/\"/g' ./options/locale/*.ini"
+      - mv ./options/locale_en-US.ini ./options/locale/
 
-- name: push
-  pull: always
-  image: appleboy/drone-git-push
-  settings:
-    author_email: "teabot@gitea.io"
-    author_name: GiteaBot
-    commit: true
-    commit_message: "[skip ci] Updated translations via Crowdin"
-    remote: "git@github.com:go-gitea/gitea.git"
-  environment:
-    GIT_PUSH_SSH_KEY:
-      from_secret: git_push_ssh_key
+  - name: push
+    pull: always
+    image: appleboy/drone-git-push
+    settings:
+      author_email: "teabot@gitea.io"
+      author_name: GiteaBot
+      commit: true
+      commit_message: "[skip ci] Updated translations via Crowdin"
+      remote: "git@github.com:go-gitea/gitea.git"
+    environment:
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_push_ssh_key
 
-- name: upload_translations
-  pull: always
-  image: jonasfranz/crowdin
-  settings:
-    files:
-      locale_en-US.ini: options/locale/locale_en-US.ini
-    ignore_branch: true
-    project_identifier: gitea
-  environment:
-    CROWDIN_KEY:
-      from_secret: crowdin_key
+  - name: upload_translations
+    pull: always
+    image: jonasfranz/crowdin
+    settings:
+      files:
+        locale_en-US.ini: options/locale/locale_en-US.ini
+      ignore_branch: true
+      project_identifier: gitea
+    environment:
+      CROWDIN_KEY:
+        from_secret: crowdin_key
 
 ---
 kind: pipeline
@@ -518,24 +518,24 @@ when:
     - push
 
 steps:
-- name: build-docs
-  pull: always
-  image: webhippie/hugo:latest
-  commands:
-    - cd docs
-    - make trans-copy
-    - make clean
-    - make build
+  - name: build-docs
+    pull: always
+    image: webhippie/hugo:latest
+    commands:
+      - cd docs
+      - make trans-copy
+      - make clean
+      - make build
 
-- name: publish-docs
-  pull: always
-  image: lucap/drone-netlify:latest
-  settings:
-    path: docs/public/
-    site_id: d2260bae-7861-4c02-8646-8f6440b12672
-  environment:
-    NETLIFY_TOKEN:
-      from_secret: netlify_token
+  - name: publish-docs
+    pull: always
+    image: lucap/drone-netlify:latest
+    settings:
+      path: docs/public/
+      site_id: d2260bae-7861-4c02-8646-8f6440b12672
+    environment:
+      NETLIFY_TOKEN:
+        from_secret: netlify_token
 
 ---
 kind: pipeline
@@ -556,58 +556,58 @@ when:
     - push
 
 steps:
-- name: dryrun
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    dry_run: true
-    repo: gitea/gitea
-  depends_on:
-    - build
-  when:
-    event:
-      - pull_request
+  - name: dryrun
+    pull: always
+    image: plugins/docker:18.09
+    settings:
+      cache_from: gitea/gitea
+      dry_run: true
+      repo: gitea/gitea
+    depends_on:
+      - build
+    when:
+      event:
+        - pull_request
 
-- name: release
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    repo: gitea/gitea
-    tags:
-      - "${DRONE_BRANCH##release/v}"
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
-  depends_on:
-    - build
-  when:
-    branch:
-      - "release/*"
-    event:
-      - push
+  - name: release
+    pull: always
+    image: plugins/docker:18.09
+    settings:
+      cache_from: gitea/gitea
+      repo: gitea/gitea
+      tags:
+        - "${DRONE_BRANCH##release/v}"
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: docker_password
+      DOCKER_USERNAME:
+        from_secret: docker_username
+    depends_on:
+      - build
+    when:
+      branch:
+        - "release/*"
+      event:
+        - push
 
-- name: latest
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    default_tags: true
-    repo: gitea/gitea
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
-  depends_on:
-    - build
-  when:
-    event:
-      - push
-      - tag
+  - name: latest
+    pull: always
+    image: plugins/docker:18.09
+    settings:
+      cache_from: gitea/gitea
+      default_tags: true
+      repo: gitea/gitea
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: docker_password
+      DOCKER_USERNAME:
+        from_secret: docker_username
+    depends_on:
+      - build
+    when:
+      event:
+        - push
+        - tag
 
 ---
 kind: pipeline
@@ -637,11 +637,11 @@ depends_on:
   - docs
 
 steps:
-- name: discord
-  pull: always
-  image: appleboy/drone-discord:1.0.0
-  environment:
-    DISCORD_WEBHOOK_ID:
-      from_secret: discord_webhook_id
-    DISCORD_WEBHOOK_TOKEN:
-      from_secret: discord_webhook_token
+  - name: discord
+    pull: always
+    image: appleboy/drone-discord:1.0.0
+    environment:
+      DISCORD_WEBHOOK_ID:
+        from_secret: discord_webhook_id
+      DISCORD_WEBHOOK_TOKEN:
+        from_secret: discord_webhook_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -451,6 +451,8 @@ when:
     - master
   event:
     - push
+    exclude:
+      - pull_request
 
 steps:
   - name: download
@@ -516,6 +518,8 @@ when:
     - master
   event:
     - push
+    exclude:
+      - pull_request
 
 steps:
   - name: build-docs

--- a/.drone.yml
+++ b/.drone.yml
@@ -620,12 +620,8 @@ workspace:
   path: src/code.gitea.io/gitea
 
 when:
-  event:
-    - push
-    - tag
-    - pull_request
   status:
-    - changed
+    - success
     - failure
 
 depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: default
+name: build
 
 platform:
   os: linux
@@ -9,6 +9,64 @@ platform:
 workspace:
   base: /go
   path: src/code.gitea.io/gitea
+
+services:
+  - name: mysql
+    pull: default
+    image: mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_DATABASE: test
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
+
+  - name: mysql8
+    pull: default
+    image: mysql:8.0
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_DATABASE: testgitea
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
+
+  - name: pgsql
+    pull: default
+    image: postgres:9.5
+    environment:
+      POSTGRES_DB: test
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
+
+  - name: mssql
+    pull: default
+    image: microsoft/mssql-server-linux:latest
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_PID: Standard
+      SA_PASSWORD: MwantsaSecurePassword1
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
+
+  - name: ldap
+    pull: default
+    image: gitea/test-openldap:latest
+    when:
+      event:
+        - push
+        - tag
+        - pull_request
 
 steps:
 - name: fetch-tags
@@ -69,10 +127,10 @@ steps:
   image: golang:1.12
   commands:
   - make unit-test-coverage
-  settings:
-    group: test
   environment:
     TAGS: bindata sqlite sqlite_unlock_notify
+  depends_on:
+    - build
   when:
     branch:
     - master
@@ -80,15 +138,49 @@ steps:
     - push
     - pull_request
 
+- name: generate-coverage
+  pull: always
+  image: golang:1.12
+  commands:
+    - make coverage
+  environment:
+    TAGS: bindata
+  depends_on:
+    - unit-test
+  when:
+    branch:
+      - master
+    event:
+      - push
+      - pull_request
+
+- name: coverage
+  pull: always
+  image: robertstettner/drone-codecov
+  settings:
+    files:
+      - coverage.all
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  depends_on:
+    - generate-coverage
+  when:
+    branch:
+      - master
+    event:
+      - push
+      - pull_request
+
 - name: release-test
   pull: always
   image: golang:1.12
   commands:
   - make test
-  settings:
-    group: test
   environment:
     TAGS: bindata sqlite sqlite_unlock_notify
+  depends_on:
+    - build
   when:
     branch:
     - "release/*"
@@ -101,10 +193,10 @@ steps:
   image: golang:1.12
   commands:
   - make test
-  settings:
-    group: test
   environment:
     TAGS: bindata
+  depends_on:
+    - build
   when:
     event:
     - tag
@@ -117,10 +209,10 @@ steps:
   - apt-get install -y git-lfs
   - timeout -s ABRT 20m make test-sqlite-migration
   - timeout -s ABRT 20m make test-sqlite
-  settings:
-    group: test
   environment:
     TAGS: bindata
+  depends_on:
+    - build
   when:
     event:
     - push
@@ -135,11 +227,11 @@ steps:
   - apt-get install -y git-lfs
   - make test-mysql-migration
   - make integration-test-coverage
-  settings:
-    group: test
   environment:
     TAGS: bindata
     TEST_LDAP: 1
+  depends_on:
+    - build
   when:
     branch:
     - master
@@ -155,11 +247,11 @@ steps:
   - apt-get install -y git-lfs
   - timeout -s ABRT 20m make test-mysql-migration
   - timeout -s ABRT 20m make test-mysql
-  settings:
-    group: test
   environment:
     TAGS: bindata
     TEST_LDAP: 1
+  depends_on:
+    - build
   when:
     event:
     - tag
@@ -172,11 +264,11 @@ steps:
   - apt-get install -y git-lfs
   - timeout -s ABRT 20m make test-mysql8-migration
   - timeout -s ABRT 20m make test-mysql8
-  settings:
-    group: test
   environment:
     TAGS: bindata
     TEST_LDAP: 1
+  depends_on:
+    - build
   when:
     event:
     - push
@@ -191,11 +283,11 @@ steps:
   - apt-get install -y git-lfs
   - timeout -s ABRT 20m make test-pgsql-migration
   - timeout -s ABRT 20m make test-pgsql
-  settings:
-    group: test
   environment:
     TAGS: bindata
     TEST_LDAP: 1
+  depends_on:
+    - build
   when:
     event:
     - push
@@ -210,45 +302,15 @@ steps:
   - apt-get install -y git-lfs
   - make test-mssql-migration
   - make test-mssql
-  settings:
-    group: test
   environment:
     TAGS: bindata
     TEST_LDAP: 1
+  depends_on:
+    - build
   when:
     event:
     - push
     - tag
-    - pull_request
-
-- name: generate-coverage
-  pull: always
-  image: golang:1.12
-  commands:
-  - make coverage
-  environment:
-    TAGS: bindata
-  when:
-    branch:
-    - master
-    event:
-    - push
-    - pull_request
-
-- name: coverage
-  pull: default
-  image: robertstettner/drone-codecov
-  settings:
-    files:
-    - coverage.all
-  environment:
-    CODECOV_TOKEN:
-      from_secret: codecov_token
-  when:
-    branch:
-    - master
-    event:
-    - push
     - pull_request
 
 - name: static
@@ -259,77 +321,8 @@ steps:
   - make release
   environment:
     TAGS: bindata sqlite sqlite_unlock_notify
-  when:
-    event:
-    - push
-    - tag
-
-- name: build-docs
-  pull: always
-  image: webhippie/hugo:latest
-  commands:
-  - cd docs
-  - make trans-copy
-  - make clean
-  - make build
-
-- name: publish-docs
-  pull: always
-  image: lucap/drone-netlify:latest
-  settings:
-    path: docs/public/
-    site_id: d2260bae-7861-4c02-8646-8f6440b12672
-  environment:
-    NETLIFY_TOKEN:
-      from_secret: netlify_token
-  when:
-    branch:
-    - master
-    event:
-    - push
-
-- name: docker-dryrun
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    dry_run: true
-    repo: gitea/gitea
-  when:
-    event:
-    - pull_request
-
-- name: release-docker
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    repo: gitea/gitea
-    tags:
-    - "${DRONE_BRANCH##release/v}"
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
-  when:
-    branch:
-    - "release/*"
-    event:
-    - push
-
-- name: docker
-  pull: always
-  image: plugins/docker:18.09
-  settings:
-    cache_from: gitea/gitea
-    default_tags: true
-    repo: gitea/gitea
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
+  depends_on:
+    - build
   when:
     event:
     - push
@@ -349,6 +342,8 @@ steps:
       from_secret: gpgsign_key
     GPGSIGN_PASSPHRASE:
       from_secret: gpgsign_passphrase
+  depends_on:
+    - static
   when:
     event:
     - push
@@ -370,6 +365,8 @@ steps:
       from_secret: aws_access_key_id
     AWS_SECRET_ACCESS_KEY:
       from_secret: aws_secret_access_key
+  depends_on:
+    - gpg-sign
   when:
     event:
     - tag
@@ -390,6 +387,8 @@ steps:
       from_secret: aws_access_key_id
     AWS_SECRET_ACCESS_KEY:
       from_secret: aws_secret_access_key
+  depends_on:
+    - gpg-sign
   when:
     branch:
     - "release/*"
@@ -412,6 +411,8 @@ steps:
       from_secret: aws_access_key_id
     AWS_SECRET_ACCESS_KEY:
       from_secret: aws_secret_access_key
+  depends_on:
+    - gpg-sign
   when:
     branch:
     - master
@@ -427,101 +428,12 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
+  depends_on:
+    - gpg-sign
   when:
     event:
     - tag
 
-- name: upload_translations
-  pull: always
-  image: jonasfranz/crowdin
-  settings:
-    files:
-      locale_en-US.ini: options/locale/locale_en-US.ini
-    ignore_branch: true
-    project_identifier: gitea
-  environment:
-    CROWDIN_KEY:
-      from_secret: crowdin_key
-  when:
-    branch:
-    - master
-    event:
-    - push
-
-- name: discord
-  pull: always
-  image: appleboy/drone-discord:1.0.0
-  environment:
-    DISCORD_WEBHOOK_ID:
-      from_secret: discord_webhook_id
-    DISCORD_WEBHOOK_TOKEN:
-      from_secret: discord_webhook_token
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
-    status:
-    - changed
-    - failure
-
-services:
-- name: mysql
-  pull: default
-  image: mysql:5.7
-  environment:
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
-    MYSQL_DATABASE: test
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
-
-- name: mysql8
-  pull: default
-  image: mysql:8.0
-  environment:
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
-    MYSQL_DATABASE: testgitea
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
-
-- name: pgsql
-  pull: default
-  image: postgres:9.5
-  environment:
-    POSTGRES_DB: test
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
-
-- name: mssql
-  pull: default
-  image: microsoft/mssql-server-linux:latest
-  environment:
-    ACCEPT_EULA: Y
-    MSSQL_PID: Standard
-    SA_PASSWORD: MwantsaSecurePassword1
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
-
-- name: ldap
-  pull: default
-  image: gitea/test-openldap:latest
-  when:
-    event:
-    - push
-    - tag
-    - pull_request
 ---
 kind: pipeline
 name: translations
@@ -574,3 +486,162 @@ steps:
   environment:
     GIT_PUSH_SSH_KEY:
       from_secret: git_push_ssh_key
+
+- name: upload_translations
+  pull: always
+  image: jonasfranz/crowdin
+  settings:
+    files:
+      locale_en-US.ini: options/locale/locale_en-US.ini
+    ignore_branch: true
+    project_identifier: gitea
+  environment:
+    CROWDIN_KEY:
+      from_secret: crowdin_key
+
+---
+kind: pipeline
+name: docs
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    - push
+
+steps:
+- name: build-docs
+  pull: always
+  image: webhippie/hugo:latest
+  commands:
+    - cd docs
+    - make trans-copy
+    - make clean
+    - make build
+
+- name: publish-docs
+  pull: always
+  image: lucap/drone-netlify:latest
+  settings:
+    path: docs/public/
+    site_id: d2260bae-7861-4c02-8646-8f6440b12672
+  environment:
+    NETLIFY_TOKEN:
+      from_secret: netlify_token
+
+---
+kind: pipeline
+name: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  branch:
+    - master
+  event:
+    - push
+
+steps:
+- name: dryrun
+  pull: always
+  image: plugins/docker:18.09
+  settings:
+    cache_from: gitea/gitea
+    dry_run: true
+    repo: gitea/gitea
+  depends_on:
+    - build
+  when:
+    event:
+      - pull_request
+
+- name: release
+  pull: always
+  image: plugins/docker:18.09
+  settings:
+    cache_from: gitea/gitea
+    repo: gitea/gitea
+    tags:
+      - "${DRONE_BRANCH##release/v}"
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  depends_on:
+    - build
+  when:
+    branch:
+      - "release/*"
+    event:
+      - push
+
+- name: latest
+  pull: always
+  image: plugins/docker:18.09
+  settings:
+    cache_from: gitea/gitea
+    default_tags: true
+    repo: gitea/gitea
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  depends_on:
+    - build
+  when:
+    event:
+      - push
+      - tag
+
+---
+kind: pipeline
+name: notify
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+when:
+  event:
+    - push
+    - tag
+    - pull_request
+  status:
+    - changed
+    - failure
+
+depends_on:
+  - build
+  - docker
+  - translations
+  - docs
+
+steps:
+- name: discord
+  pull: always
+  image: appleboy/drone-discord:1.0.0
+  environment:
+    DISCORD_WEBHOOK_ID:
+      from_secret: discord_webhook_id
+    DISCORD_WEBHOOK_TOKEN:
+      from_secret: discord_webhook_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -450,7 +450,8 @@ when:
   branch:
     - master
   event:
-    - push
+    include:
+      - push
     exclude:
       - pull_request
 
@@ -517,7 +518,8 @@ when:
   branch:
     - master
   event:
-    - push
+    include:
+      - push
     exclude:
       - pull_request
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -563,8 +563,6 @@ steps:
       cache_from: gitea/gitea
       dry_run: true
       repo: gitea/gitea
-    depends_on:
-      - build
     when:
       event:
         - pull_request
@@ -583,7 +581,7 @@ steps:
       DOCKER_USERNAME:
         from_secret: docker_username
     depends_on:
-      - build
+      - dryrun
     when:
       branch:
         - "release/*"
@@ -603,7 +601,7 @@ steps:
       DOCKER_USERNAME:
         from_secret: docker_username
     depends_on:
-      - build
+      - dryrun
     when:
       event:
         - push


### PR DESCRIPTION
Successor of  #6602, fixes #6463

I've refactored the drone file to use the new syntax of drone 1, which brings several advanteges:
* multiple pipelines
* dependencies of steps -> paralle execution of tests

Multiple pipelines:
* `testing`: Runs all linters, unit and integration tests
* `translations`: Downloads the newest translations from crowdin and also pushes them back to the repo
* `release`: cross-compiles releases with xgo and publishes them
* `docs`: publishes the docs
* `docker`: builds and publishes the docker images
* `notify`: triggers the discord notify hook