### PR TITLE
Fix bug conflict between SyncReleasesWithTags and InsertReleases

### DIFF
--- a/models/release_test.go
+++ b/models/release_test.go
@@ -102,12 +102,12 @@ func TestRelease_MirrorDelete(t *testing.T) {
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
 	repoPath := RepoPath(user.Name, repo.Name)
 	migrationOptions := MigrateRepoOptions{
-		Name:        "test_mirror",
-		Description: "Test mirror",
-		IsPrivate:   false,
-		IsMirror:    true,
-		RemoteAddr:  repoPath,
-		Wiki:        true,
+		Name:                 "test_mirror",
+		Description:          "Test mirror",
+		IsPrivate:            false,
+		IsMirror:             true,
+		RemoteAddr:           repoPath,
+		Wiki:                 true,
 		SyncReleasesWithTags: true,
 	}
 	mirror, err := MigrateRepository(user, user, migrationOptions)

--- a/models/release_test.go
+++ b/models/release_test.go
@@ -108,6 +108,7 @@ func TestRelease_MirrorDelete(t *testing.T) {
 		IsMirror:    true,
 		RemoteAddr:  repoPath,
 		Wiki:        true,
+		SyncReleasesWithTags: true,
 	}
 	mirror, err := MigrateRepository(user, user, migrationOptions)
 	assert.NoError(t, err)

--- a/models/repo.go
+++ b/models/repo.go
@@ -845,12 +845,13 @@ func (repo *Repository) CloneLink() (cl *CloneLink) {
 
 // MigrateRepoOptions contains the repository migrate options
 type MigrateRepoOptions struct {
-	Name        string
-	Description string
-	IsPrivate   bool
-	IsMirror    bool
-	RemoteAddr  string
-	Wiki        bool // include wiki repository
+	Name                 string
+	Description          string
+	IsPrivate            bool
+	IsMirror             bool
+	RemoteAddr           string
+	Wiki                 bool // include wiki repository
+	SyncReleasesWithTags bool // sync releases from tags
 }
 
 /*
@@ -942,7 +943,7 @@ func MigrateRepository(doer, u *User, opts MigrateRepoOptions) (*Repository, err
 		return repo, fmt.Errorf("git.IsEmpty: %v", err)
 	}
 
-	if !repo.IsEmpty {
+	if opts.SyncReleasesWithTags && !repo.IsEmpty {
 		// Try to get HEAD branch and set it as default branch.
 		headBranch, err := gitRepo.GetHEADBranch()
 		if err != nil {

--- a/modules/migrations/base/uploader.go
+++ b/modules/migrations/base/uploader.go
@@ -7,7 +7,7 @@ package base
 
 // Uploader uploads all the informations of one repository
 type Uploader interface {
-	CreateRepo(repo *Repository, includeWiki bool) error
+	CreateRepo(repo *Repository, opts MigrateOptions) error
 	CreateMilestones(milestones ...*Milestone) error
 	CreateReleases(releases ...*Release) error
 	CreateLabels(labels ...*Label) error

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -80,7 +80,7 @@ func migrateRepository(downloader base.Downloader, uploader base.Uploader, opts 
 		repo.Description = opts.Description
 	}
 	log.Trace("migrating git data")
-	if err := uploader.CreateRepo(repo, opts.Wiki); err != nil {
+	if err := uploader.CreateRepo(repo, opts); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This bug is caused by #7050. In that PR, we always insert releases batchly, but that releases maybe added when `SyncReleasesWithTags` which invoked after git repository created. It will make migrating releases failed.

This PR will move `SyncReleasesWithTags` from `clone` function to `CreateReleases` if `releases` migrating is enabled.