### PR TITLE
Use vendors when go generate

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,9 +63,9 @@ steps:
 
   - name: build-without-gcc
     pull: always
-    image: golang:1.10 # this step is kept as the lowest version of golang that we support
+    image: golang:1.11 # this step is kept as the lowest version of golang that we support
     commands:
-      - go build -o gitea_no_gcc # test if build succeeds without the sqlite tag
+      - go build -mod=vendor -o gitea_no_gcc # test if build succeeds without the sqlite tag
 
   - name: build
     pull: always

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,6 +64,8 @@ steps:
   - name: build-without-gcc
     pull: always
     image: golang:1.11 # this step is kept as the lowest version of golang that we support
+    environment:
+      GO111MODULE: on
     commands:
       - go build -mod=vendor -o gitea_no_gcc # test if build succeeds without the sqlite tag
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ vet:
 
 .PHONY: generate
 generate:
-	GO111MODULE=on $(GO) generate $(PACKAGES)
+	GO111MODULE=on $(GO) generate -mod=vendor $(PACKAGES)
 
 .PHONY: generate-swagger
 generate-swagger:

--- a/docs/content/doc/advanced/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/advanced/hacking-on-gitea.en-us.md
@@ -32,7 +32,7 @@ necessary. To be able to use these you must have the `"$GOPATH"/bin` directory
 on the executable path. If you don't add the go bin directory to the
 executable path you will have to manage this yourself.
 
-**Note 2**: Go version 1.9 or higher is required; however, it is important
+**Note 2**: Go version 1.11 or higher is required; however, it is important
 to note that our continuous integration will check that the formatting of the
 source code is not changed by `gofmt` using `make fmt-check`. Unfortunately,
 the results of `gofmt` can differ by the version of `go`. It is therefore

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -27,7 +27,7 @@ necessary. To be able to use these, you must have the `"$GOPATH/bin"` directory
 on the executable path. If you don't add the go bin directory to the
 executable path, you will have to manage this yourself.
 
-**Note 2**: Go version 1.9 or higher is required. However, it is recommended to
+**Note 2**: Go version 1.11 or higher is required. However, it is recommended to
 obtain the same version as our continuous integration, see the advice given in
 <a href='{{< relref "doc/advanced/hacking-on-gitea.en-us.md" >}}'>Hacking on
 Gitea</a>


### PR DESCRIPTION
Since we have store all the dependencies on vendor, I think we should also use them when run `go generate`. This will speed up `make generate` process and reduce failure possible when CI runs.