### PR TITLE
Fix mirror repository webhooks

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -896,6 +896,11 @@ func mirrorSyncAction(e Engine, opType ActionType, repo *Repository, refName str
 	}); err != nil {
 		return fmt.Errorf("notifyWatchers: %v", err)
 	}
+
+	defer func() {
+		go HookQueue.Add(repo.ID)
+	}()
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #5441 

I found that mirror syncs will properly create hook tasks, however, the hook queue that gitea is monitoring is never updated/notified of the hook task for the repo and thus the hook task is never fulfilled.  If you restart the gitea server, the goroutine first fulfills the current task list and then blocks on the hook queue.  This is why any mirror action webhooks are sent on restart and why any new hook tasks created by mirror actions do not get fulfilled automatically.

Signed-off-by: Drew Kowalski drewkowalski93@gmail.com
