### PR TITLE
backport of #7385 - add missing template variable on organisation settings

### DIFF
--- a/routers/org/setting.go
+++ b/routers/org/setting.go
@@ -39,6 +39,7 @@ func Settings(ctx *context.Context) {
 func SettingsPost(ctx *context.Context, form auth.UpdateOrgSettingForm) {
 	ctx.Data["Title"] = ctx.Tr("org.settings")
 	ctx.Data["PageIsSettingsOptions"] = true
+	ctx.Data["CurrentVisibility"] = structs.VisibleType(ctx.Org.Organization.Visibility)
 
 	if ctx.HasError() {
 		ctx.HTML(200, tplSettingsOptions)


### PR DESCRIPTION
As the error produce 500 server error, if someone tries too save to long values on organisation settings
-> backported this to 1.9

see #7385
affects #6755

Signed-off-by: Michael Gnehr <michael@gnehr.de>