### PR TITLE
full directory support for wiki

### DIFF
--- a/models/wiki.go
+++ b/models/wiki.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	reservedWikiNames = []string{"_pages", "_new", "_edit", "raw"}
+	reservedWikiNames = []string{"_pages", "_new", "_edit", "_delete", "raw"}
 	wikiWorkingPool   = sync.NewExclusivePool()
 )
 

--- a/modules/markup/markdown/markdown.go
+++ b/modules/markup/markdown/markdown.go
@@ -103,9 +103,6 @@ func (r *Renderer) ListItem(out *bytes.Buffer, text []byte, flags int) {
 // Image defines how images should be processed to produce corresponding HTML elements.
 func (r *Renderer) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
 	prefix := r.URLPrefix
-	if r.IsWiki {
-		prefix = util.URLJoin(prefix, "wiki", "raw")
-	}
 	prefix = strings.Replace(prefix, "/src/", "/media/", 1)
 	if len(link) > 0 && !markup.IsLink(link) {
 		lnk := string(link)

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1033,6 +1033,7 @@ wiki.default_commit_message = Write a note about this page update (optional).
 wiki.save_page = Save Page
 wiki.last_commit_info = %s edited this page %s
 wiki.edit_page_button = Edit
+wiki.abort_edit_page_button = Abort
 wiki.new_page_button = New Page
 wiki.file_revision = Page Revision
 wiki.wiki_page_revisions = Wiki Page Revisions

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -292,7 +292,7 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .markdown:not(code) .ui.list .list,.markdown:not(code) ol.ui.list ol,.markdown:not(code) ul.ui.list ul{padding-left:2em}
 .repository.wiki.revisions .ui.container>.ui.stackable.grid{flex-direction:row-reverse}
 .repository.wiki.revisions .ui.container>.ui.stackable.grid>.header{margin-top:0}
-.repository.wiki.revisions .ui.container>.ui.stackable.grid>.header .sub.header{padding-left:52px}
+.repository.wiki.revisions .ui.container>.ui.stackable.grid>.header .sub.header{padding-left:52px;word-break:break-word}
 .file-revisions-btn{display:block;float:left;margin-bottom:2px!important;padding:11px!important;margin-right:10px!important}
 .file-revisions-btn i{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .home .logo{max-width:220px}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -292,7 +292,7 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .markdown:not(code) .ui.list .list,.markdown:not(code) ol.ui.list ol,.markdown:not(code) ul.ui.list ul{padding-left:2em}
 .repository.wiki.revisions .ui.container>.ui.stackable.grid{flex-direction:row-reverse}
 .repository.wiki.revisions .ui.container>.ui.stackable.grid>.header{margin-top:0}
-.repository.wiki.revisions .ui.container>.ui.stackable.grid>.header .sub.header{padding-left:52px;word-break:break-word}
+.repository.wiki.revisions .ui.container>.ui.stackable.grid>.header .sub.header{padding-left:52px}
 .file-revisions-btn{display:block;float:left;margin-bottom:2px!important;padding:11px!important;margin-right:10px!important}
 .file-revisions-btn i{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .home .logo{max-width:220px}

--- a/routers/repo/wiki_test.go
+++ b/routers/repo/wiki_test.go
@@ -25,10 +25,13 @@ func wikiEntry(t *testing.T, repo *models.Repository, wikiName string) *git.Tree
 	assert.NoError(t, err)
 	commit, err := wikiRepo.GetBranchCommit("master")
 	assert.NoError(t, err)
-	entries, err := commit.ListEntries()
+	entries, err := commit.ListEntriesRecursive()
 	assert.NoError(t, err)
 	for _, entry := range entries {
 		if entry.Name() == models.WikiNameToFilename(wikiName) {
+			return entry
+		}
+		if entry.Name() == models.WikiNameToPathFilename(wikiName) {
 			return entry
 		}
 	}
@@ -78,7 +81,7 @@ func TestWiki(t *testing.T) {
 	Wiki(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assert.EqualValues(t, "Home", ctx.Data["Title"])
-	assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name"}, ctx.Data["Pages"])
+	assertPagesMetas(t, []string{"Home", "Page-With-Image", "Page-With-Spaced-Name"}, ctx.Data["Pages"])
 }
 
 func TestWikiPages(t *testing.T) {
@@ -88,7 +91,7 @@ func TestWikiPages(t *testing.T) {
 	test.LoadRepo(t, ctx, 1)
 	WikiPages(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
-	assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name"}, ctx.Data["Pages"])
+	assertPagesMetas(t, []string{"Home", "Page-With-Image", "Page-With-Spaced-Name"}, ctx.Data["Pages"])
 }
 
 func TestNewWiki(t *testing.T) {
@@ -179,7 +182,7 @@ func TestEditWikiPost(t *testing.T) {
 func TestDeleteWikiPagePost(t *testing.T) {
 	models.PrepareTestEnv(t)
 
-	ctx := test.MockContext(t, "user2/repo1/wiki/Home/delete")
+	ctx := test.MockContext(t, "user2/repo1/wiki/Home/_delete")
 	test.LoadUser(t, ctx, 2)
 	test.LoadRepo(t, ctx, 1)
 	DeleteWikiPagePost(ctx)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -809,6 +809,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Group("", func() {
 				m.Combo("/_new").Get(repo.NewWiki).
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.NewWikiPost)
+				m.Get("/:page/_new/", repo.NewWiki)
 				m.Combo("/:page/_edit").Get(repo.EditWiki).
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.EditWikiPost)
 				m.Post("/:page/_delete", repo.DeleteWikiPagePost)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -811,7 +811,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.NewWikiPost)
 				m.Combo("/:page/_edit").Get(repo.EditWiki).
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.EditWikiPost)
-				m.Post("/:page/delete", repo.DeleteWikiPagePost)
+				m.Post("/:page/_delete", repo.DeleteWikiPagePost)
 			}, context.RepoMustNotBeArchived(), reqSignIn, reqRepoWikiWriter)
 		}, repo.MustEnableWiki, context.RepoRef())
 

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -7,22 +7,27 @@
 			{{.i18n.Tr "repo.wiki.new_page"}}
 			{{if .PageIsWikiEdit}}
 				<div class="ui right">
-					<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+					<a class="ui green small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
 				</div>
 			{{end}}
 		</div>
+		{{if .PageIsWikiEdit}}
 		<form class="ui form" action="{{.Link}}" method="post">
+		{{else}}
+		<form class="ui form" action="{{.RepoLink}}/wiki/_new" method="post">
+		{{end}}
 			{{.CsrfTokenHtml}}
 			<div class="field {{if .Err_Title}}error{{end}}">
 				<input name="title" value="{{.title}}" autofocus required>
 			</div>
 			<div class="field">
-				<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/wiki" required>{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>
+				<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/wiki/raw/{{.PageURL}}/../" required>{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>
 			</div>
 			<div class="field">
 				<input name="message" placeholder="{{.i18n.Tr "repo.wiki.default_commit_message"}}">
 			</div>
 			<div class="text right">
+				<a class="ui small red button" href="{{.RepoLink}}/wiki/{{.PageURL}}">{{.i18n.Tr "repo.wiki.abort_edit_page_button"}}</a>
 				<button class="ui green button">
 					{{.i18n.Tr "repo.wiki.save_page"}}
 				</button>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -67,7 +67,7 @@
 					{{if and .CanWriteWiki (not .Repository.IsMirror)}}
 						<div class="ui right">
 							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
-							<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+							<a class="ui green small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
 							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/_delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
 						</div>
 					{{end}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -68,7 +68,7 @@
 						<div class="ui right">
 							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
 							<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
-							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
+							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/_delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
 						</div>
 					{{end}}
 				</div>


### PR DESCRIPTION
## directory support for wiki

previously this was part of #7225 - lets split it up

### This PR

* add support for **directories** inside wiki. Create/update/delete pages works well. If an old page is updated, the file will be moved to subdirectory.
  * allows to read files with nearly all letters, as it is possible to push all via wiki gitrepo
    * files can exists in old and new structure.
      * files are selected by link, so it is possible to access and view both
      * writing to one of them will delete both, and create new one in directory structure
      * delete will delete the selected file
   * **support images** relative to directory path
      * fix preview on preview rendering
   *  fix **500 error** if wiki contains pages with invalid uri encoding (e.g. filename: badescaping%%.md)
* ui fixes
  * add button 'Abort' to wiki `edit` and `new` page

fix #823

Signed-off-by: Michael Gnehr <michael@gnehr.de>