### PR TITLE
WIP: Support hsts

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -787,3 +787,13 @@ IS_INPUT_FILE = false
 ENABLED = false
 ; If you want to add authorization, specify a token here
 TOKEN =
+
+[hsts]
+; Enables hsts. True or false, default is false.
+ENABLED = false
+; Max age of the time, default is 365 days.
+MAX_AGE = 8760h
+; require sub domains use hsts
+INCLUDE_SUB_DOMAINS = false
+; send preload 
+SEND_PRELOAD_DIRECTIVE = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -501,6 +501,13 @@ Two special environment variables are passed to the render command:
 - `GITEA_PREFIX_SRC`, which contains the current URL prefix in the `src` path tree. To be used as prefix for links.
 - `GITEA_PREFIX_RAW`, which contains the current URL prefix in the `raw` path tree. To be used as prefix for image paths.
 
+## HSTS (`hsts`)
+
+- ENABLED: **false** Enables hsts. True or false, default is false.
+- MAX_AGE: **8760h** Max age of the time, default is 365 days.
+- INCLUDE_SUB_DOMAINS: **false** require sub domains use hsts, default is false.
+- SEND_PRELOAD_DIRECTIVE: **false** send preload, default is false.
+
 ## Other (`other`)
 
 - `SHOW_FOOTER_BRANDING`: **false**: Show Gitea branding in the footer.

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -237,7 +237,12 @@ IS_INPUT_FILE = false
 - RENDER_COMMAND: 工具的命令行命令及参数。
 - IS_INPUT_FILE: 输入方式是最后一个参数为文件路径还是从标准输入读取。
 
+## HSTS (`hsts`)
 
+- ENABLED: **false** 是否启用 HSTS。默认为否。
+- MAX_AGE: **8760h** 最大时间，默认是 365 天。
+- INCLUDE_SUB_DOMAINS: **false** 是否包含子域名，默认为否。
+- SEND_PRELOAD_DIRECTIVE: **false** 是否预加载，默认为否。
 
 ## Other (`other`)
 

--- a/modules/setting/hsts.go
+++ b/modules/setting/hsts.go
@@ -23,7 +23,6 @@ var HSTS = struct {
 
 func configHSTS() {
 	sec := Cfg.Section("hsts")
-	// Check mailer setting.
 	if !sec.Key("ENABLED").MustBool() {
 		return
 	}

--- a/modules/setting/hsts.go
+++ b/modules/setting/hsts.go
@@ -14,10 +14,12 @@ const (
 var HSTS = struct {
 	Enabled              bool
 	MaxAge               time.Duration
+	IncludeSubDomains    bool
 	SendPreloadDirective bool
 }{
 	Enabled:              false,
 	MaxAge:               defaultMaxAge,
+	IncludeSubDomains:    false,
 	SendPreloadDirective: false,
 }
 
@@ -29,5 +31,6 @@ func configHSTS() {
 
 	HSTS.Enabled = true
 	HSTS.MaxAge = sec.Key("MAX_AGE").MustDuration(defaultMaxAge)
+	HSTS.IncludeSubDomains = sec.Key("INCLUDE_SUB_DOMAINS").MustBool()
 	HSTS.SendPreloadDirective = sec.Key("SEND_PRELOAD_DIRECTIVE").MustBool()
 }

--- a/modules/setting/hsts.go
+++ b/modules/setting/hsts.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package setting
+
+import "time"
+
+const (
+	defaultMaxAge = time.Hour * 24 * 365
+)
+
+// HSTS is the configuration of HSTS
+var HSTS = struct {
+	Enabled              bool
+	MaxAge               time.Duration
+	SendPreloadDirective bool
+}{
+	Enabled:              false,
+	MaxAge:               defaultMaxAge,
+	SendPreloadDirective: false,
+}
+
+func configHSTS() {
+	sec := Cfg.Section("hsts")
+	// Check mailer setting.
+	if !sec.Key("ENABLED").MustBool() {
+		return
+	}
+
+	HSTS.Enabled = true
+	HSTS.MaxAge = sec.Key("MAX_AGE").MustDuration(defaultMaxAge)
+	HSTS.SendPreloadDirective = sec.Key("SEND_PRELOAD_DIRECTIVE").MustBool()
+}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -910,6 +910,7 @@ func NewContext() {
 
 	newCron()
 	newGit()
+	configHSTS()
 
 	sec = Cfg.Section("mirror")
 	Mirror.MinInterval = sec.Key("MIN_INTERVAL").MustDuration(10 * time.Minute)

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"text/template"
 	"time"
 
@@ -102,6 +103,16 @@ func RouterHandler(level log.Level) func(ctx *macaron.Context) {
 	}
 }
 
+func createHeaderValueNew(maxAge time.Duration, sendPreloadDirective bool) string {
+	buf := bytes.NewBufferString("max-age=")
+	buf.WriteString(strconv.Itoa(int(maxAge.Seconds())))
+	buf.WriteString("; includeSubDomains")
+	if sendPreloadDirective {
+		buf.WriteString("; preload")
+	}
+	return buf.String()
+}
+
 // NewMacaron initializes Macaron instance.
 func NewMacaron() *macaron.Macaron {
 	gob.Register(&u2f.Challenge{})
@@ -130,6 +141,13 @@ func NewMacaron() *macaron.Macaron {
 	}
 	if setting.Protocol == setting.FCGI {
 		m.SetURLPrefix(setting.AppSubURL)
+	}
+	if setting.HSTS.Enabled {
+		m.Use(func() macaron.Handler {
+			return func(ctx *macaron.Context) {
+				ctx.Resp.Header().Set("Strict-Transport-Security", createHeaderValueNew(setting.HSTS.MaxAge, setting.HSTS.SendPreloadDirective))
+			}
+		})
 	}
 	m.Use(public.Custom(
 		&public.Options{

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -103,10 +103,12 @@ func RouterHandler(level log.Level) func(ctx *macaron.Context) {
 	}
 }
 
-func createHeaderValueNew(maxAge time.Duration, sendPreloadDirective bool) string {
+func createHeaderValueNew(maxAge time.Duration, includeSubDomains, sendPreloadDirective bool) string {
 	buf := bytes.NewBufferString("max-age=")
 	buf.WriteString(strconv.Itoa(int(maxAge.Seconds())))
-	buf.WriteString("; includeSubDomains")
+	if includeSubDomains {
+		buf.WriteString("; includeSubDomains")
+	}
 	if sendPreloadDirective {
 		buf.WriteString("; preload")
 	}
@@ -145,7 +147,8 @@ func NewMacaron() *macaron.Macaron {
 	if setting.HSTS.Enabled {
 		m.Use(func() macaron.Handler {
 			return func(ctx *macaron.Context) {
-				ctx.Resp.Header().Set("Strict-Transport-Security", createHeaderValueNew(setting.HSTS.MaxAge, setting.HSTS.SendPreloadDirective))
+				ctx.Resp.Header().Set("Strict-Transport-Security",
+					createHeaderValueNew(setting.HSTS.MaxAge, setting.HSTS.IncludeSubDomains, setting.HSTS.SendPreloadDirective))
 			}
 		})
 	}


### PR DESCRIPTION
As title. Since a gitea service may behind a reverse proxy, we don't know if it's a HTTPS request or a HTTP one. So users could enable it if he knows the service will always use HTTPS.

@techknowlogick Just remember you have implemented the middleware after I wrote the PR. :(

should fix #3788