### PR TITLE
Only show "New Pull Request" button if repo allows pulls

### DIFF
--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -39,6 +39,7 @@ func Branches(ctx *context.Context) {
 	ctx.Data["Title"] = "Branches"
 	ctx.Data["IsRepoToolbarBranches"] = true
 	ctx.Data["DefaultBranch"] = ctx.Repo.Repository.DefaultBranch
+	ctx.Data["AllowsPulls"] = ctx.Repo.Repository.AllowsPulls()
 	ctx.Data["IsWriter"] = ctx.Repo.CanWrite(models.UnitTypeCode)
 	ctx.Data["IsMirror"] = ctx.Repo.Repository.IsMirror
 	ctx.Data["PageIsViewCode"] = true

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -63,7 +63,7 @@
 									</td>
 									<td class="right aligned">
 										{{if not .LatestPullRequest}}
-											{{if not .IsDeleted}}
+											{{if and (not .IsDeleted) $.AllowsPulls}}
 											<a href="{{$.RepoLink}}/compare/{{$.DefaultBranch | EscapePound}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | EscapePound}}">
 												<button id="new-pull-request" class="ui compact basic button">{{$.i18n.Tr "repo.pulls.compare_changes"}}</button>
 											</a>


### PR DESCRIPTION
The "New Pull Request" button is shown in the branches page even when the repository does not allow pull requests. If you click on it, it will simply lead to a 404 page. 

This change will make it so that the "New Pull Request" button is only available if the repository allows pull requests.

![Screenshot from 2019-07-12 00-33-57](https://user-images.githubusercontent.com/47195730/61068586-e96e1280-a3f9-11e9-9da3-13df41621e40.png)
