### PR TITLE
fix Dropzone.js integration

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -10,6 +10,9 @@ function htmlEncode(text) {
 var csrf;
 var suburl;
 
+// Disable Dropzone auto-discover because it's manually initialized
+Dropzone.autoDiscover = false;
+
 // Polyfill for IE9+ support (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
 if (!Array.from) {
     Array.from = (function () {
@@ -2005,13 +2008,11 @@ $(document).ready(function () {
     }
 
     // Dropzone
-    var $dropzone = $('#dropzone');
+    const $dropzone = $('#dropzone');
     if ($dropzone.length > 0) {
-        // Disable auto discover for all elements:
-        Dropzone.autoDiscover = false;
+        const filenameDict = {};
 
-        var filenameDict = {};
-        $dropzone.dropzone({
+        new Dropzone("#dropzone", {
             url: $dropzone.data('upload-url'),
             headers: {"X-Csrf-Token": csrf},
             maxFiles: $dropzone.data('max-file'),
@@ -2039,7 +2040,7 @@ $(document).ready(function () {
                         });
                     }
                 })
-            }
+            },
         });
     }
 


### PR DESCRIPTION
The recent jQuery update seems to have broke Dropzone.js as seen on any issue like https://try.gitea.io/silverwind/symlink-test/issues/1 where file uploads are broken and Dropzone.js logs these errors into the browser console:

````
Error: No URL provided. dropzone.js:439:15
Error: Dropzone already attached. dropzone.js:426:15
````

Fixed it by moving the jQuery-based Dropzone.js initialization to pure Javascript. I didn't investigate in depth, but I think Dropzone.js ships it's own version of jQuery which conflicts with the one we provide and broke it in turn.