### PR TITLE
Fix an issue with some pages throwing 'not defined' js exceptions

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -11,7 +11,9 @@ var csrf;
 var suburl;
 
 // Disable Dropzone auto-discover because it's manually initialized
-Dropzone.autoDiscover = false;
+if (typeof(Dropzone) !== "undefined") {
+    Dropzone.autoDiscover = false;
+}
 
 // Polyfill for IE9+ support (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
 if (!Array.from) {


### PR DESCRIPTION
Fix an issue introduced by 831288cc916d5301beaa0adc1d912d6748a4cdaa

On some pages, there is no `Dropzone` object causing an exception and because the file is in strict mode, stopping the whole script.

You can see this on <https://try.gitea.io> in the console. Also, when signed in, clicking your own profile picture does not bring up the dropdown menu.

EDIT: I'm not sure why the CI build is failing?
EDIT2: Oh okay, JS style. Maybe we should make that more clear in the `CONTRIBUTING.md`?