### PR TITLE
Backport: Fix an issue with some pages throwing 'not defined' js exceptions (#7450)

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -11,7 +11,9 @@ var csrf;
 var suburl;
 
 // Disable Dropzone auto-discover because it's manually initialized
-Dropzone.autoDiscover = false;
+if (typeof(Dropzone) !== "undefined") {
+    Dropzone.autoDiscover = false;
+}
 
 // Polyfill for IE9+ support (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
 if (!Array.from) {


### PR DESCRIPTION
Backport of #7450 

Fix an issue introduced by cc8e7dd355c9c625b895a1b633a3a7fa5016f718