### PR TITLE
cmd/serv: actually exit after fatal errors

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -73,7 +73,6 @@ func fail(userMessage, logMessage string, args ...interface{}) {
 		if !setting.ProdMode {
 			fmt.Fprintf(os.Stderr, logMessage+"\n", args...)
 		}
-		return
 	}
 
 	os.Exit(1)


### PR DESCRIPTION
Regression in 356854fc5f8d7d1a7e4d68c9e00929e9ce8aa867, where
a log.Fatal call was removed. log.Fatal calls os.Exit(1) as intended,
but without it the fail() function returns normally and execution
continues past the fatal error, causing a panic.

This is visible as a go panic log and stack trace returned to the SSH
client, which is not only ugly, it leaks server and build system
information.

Fix by removing the stray return statement so that the fail() function
always calls os.Exit(1).

Backport: 2186a99c768cf4511d9fbed0781d94d892199873
Fixes: https://github.com/go-gitea/gitea/issues/7457
Signed-off-by: Allen Wild <allenwild93@gmail.com>

Please check the following: