### PR TITLE
Only create branches for opened pull requestes when migrating from github

### DIFF
--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -383,7 +383,7 @@ func (g *GiteaLocalUploader) newPullRequest(pr *base.PullRequest) (*models.PullR
 	}
 
 	var head = "unknown repository"
-	if pr.IsForkPullRequest() {
+	if pr.IsForkPullRequest() && pr.State != "closed" {
 		if pr.Head.OwnerName != "" {
 			remote := pr.Head.OwnerName
 			_, ok := g.prHeadCache[remote]


### PR DESCRIPTION
This will not create branches for merged or closed pull request when migrating from github. 

For a big repository with many pull request merged or closed, it will reduce many time.