### PR TITLE
Fixes #7475 - Settings pages giving UnitType error message

### DIFF
--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -667,7 +667,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		}, func(ctx *context.Context) {
 			ctx.Data["PageIsSettings"] = true
 		})
-	}, reqSignIn, context.RepoAssignment(), reqRepoAdmin, context.UnitTypes(), context.RepoRef())
+	}, reqSignIn, context.RepoAssignment(), context.UnitTypes(), reqRepoAdmin, context.RepoRef())
 
 	m.Get("/:username/:reponame/action/:action", reqSignIn, context.RepoAssignment(), context.UnitTypes(), repo.Action)
 


### PR DESCRIPTION
Fixes #7475 

If you go to a settings page that you do not have access to, would get a weird template error that UnitTypeCode is not the proper type.

This was due to the UnitTypes not being set in the context before it the permission requirement fails, resulting in a 404 page. The 404 page still needs the UnitTypes for display.
