### PR TITLE
drone/release-version: remove translations deps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -455,7 +455,6 @@ trigger:
 
 depends_on:
   - testing
-  - translations
 
 steps:
   - name: fetch-tags


### PR DESCRIPTION
This change drone to not make release-version depends on translations step since translations is only triggered by push on master and release-version on tag (that can occur on release branches)
