### PR TITLE
raw should not be a reserved keyword

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -773,7 +773,6 @@ var (
 		"org",
 		"plugins",
 		"pulls",
-		"raw",
 		"repo",
 		"stars",
 		"template",


### PR DESCRIPTION
Hi there,

We happen to have a user whose login is "raw", and it's a reserved keyword in Gitea,
I made a quick patch to remove it from the list.

I don't see a reason for it being disallowed, gitea works perfectly fine...

(I"m positive that many other reserved keywords also don't *have* to be disallowed)

Thanks