### PR TITLE
remove duplicated webhook trigger

### DIFF
--- a/modules/pull/merge.go
+++ b/modules/pull/merge.go
@@ -49,7 +49,6 @@ func Merge(pr *models.PullRequest, doer *models.User, baseGitRepo *git.Repositor
 	}
 
 	defer func() {
-		go models.HookQueue.Add(pr.BaseRepo.ID)
 		go models.AddTestPullRequestTask(doer, pr.BaseRepo.ID, pr.BaseBranch, false)
 	}()
 


### PR DESCRIPTION
Fix duplicated webhook trigger when edit file on web. There is already a trigger on https://github.com/go-gitea/gitea/pull/7511/files#diff-3118802184bbc1301bbf65e551886506R320