### PR TITLE
Make default branch name link to default branch

### DIFF
--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -18,7 +18,7 @@
 								{{if .IsProtected}}
 									<i class="octicon octicon-shield"></i>
 								{{end}}
-								{{$.DefaultBranch}}
+								<a href="{{$.RepoLink}}/src/branch/{{$.DefaultBranch | EscapePound}}">{{$.DefaultBranch}}</a>
 								<p class="info"><i class="octicon octicon-git-commit"></i><a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
 							{{end}}
 						{{end}}


### PR DESCRIPTION
The default branch's name on the branches page
for a repo was previously simply text and did
not link anywhere.

The name is now a link to the default branch
just like the non-default branch names.