### PR TITLE
Fix 'Diff stats' scroll error

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -1,5 +1,5 @@
 {{if .DiffNotAvailable}}
-	<div class="diff-detail-box diff-box ui sticky">
+	<div class="diff-detail-box diff-box ui">
 		<div>
 			<div class="ui right">
 				{{if .PageIsPullFiles}}
@@ -16,7 +16,7 @@
 	</div>
 	<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
 {{else}}
-	<div class="diff-detail-box diff-box ui sticky">
+	<div class="diff-detail-box diff-box ui">
 		<div>
 			<i class="fa fa-retweet"></i>
 			{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -1,6 +1,6 @@
 {{if .DiffNotAvailable}}
 	<div class="diff-detail-box diff-box ui">
-		<div>
+		<div class=“diff-header sticky”>
 			<div class="ui right">
 				{{if .PageIsPullFiles}}
 					{{template "repo/diff/whitespace_dropdown" .}}
@@ -17,7 +17,7 @@
 	<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
 {{else}}
 	<div class="diff-detail-box diff-box ui">
-		<div>
+		<div class=“diff-header sticky”>
 			<i class="fa fa-retweet"></i>
 			{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
 			<div class="ui right">


### PR DESCRIPTION
When the 'Show diff stats' window is open, if the diff stats container is longer than the viewport, the sticky element does not scroll and hides the diff files in the background, although they continue to scroll. 

Removed sticky class.

Fixes #5532