### PR TITLE
Fix file header overflow in file and blame views

### DIFF
--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -2,11 +2,11 @@
 
 	<h4 class="ui top attached header" id="repo-read-file">
 		<div class="ui stackable grid">
-			<div class="ten wide column">
+			<div class="eight wide column">
                 <i class="file text outline icon ui left"></i>
                 <strong>{{.FileName}}</strong> <span class="text grey normal">{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
 			</div>
-			<div class="six wide right aligned column">
+			<div class="eight wide right aligned column">
                 <div class="ui right file-actions">
                     <div class="ui buttons">
                         {{if not .IsViewCommit}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -1,7 +1,7 @@
 <div class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
 	<h4 class="ui top attached header" id="{{if .ReadmeExist}}repo-readme{{else}}repo-read-file{{end}}">
 		<div class="ui stackable grid">
-			<div class="ten wide column">
+			<div class="eight wide column">
 				{{if .ReadmeExist}}
 					<i class="book icon ui left"></i>
 					{{if .ReadmeInList}}
@@ -14,7 +14,7 @@
 					<strong>{{.FileName}}</strong> <span class="text grey normal">{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
 				{{end}}
 			</div>
-			<div class="six wide right aligned column">
+			<div class="eight wide right aligned column">
 				{{if not .ReadmeInList}}
 					<div class="ui right file-actions">
 						<div class="ui buttons">


### PR DESCRIPTION
Under certain circumstances, the header buttons would overflow to a second line because the column holding the buttons was sized to small, increased that.

#### Before
<img width="697" alt="Screenshot 2019-07-22 at 14 07 04" src="https://user-images.githubusercontent.com/115237/61631327-5dc27480-ac8a-11e9-9325-9ad22ccfa501.png">

#### After
<img width="706" alt="Screenshot 2019-07-22 at 14 06 53" src="https://user-images.githubusercontent.com/115237/61631339-6450ec00-ac8a-11e9-988f-69a08486a0e4.png">
