### PR TITLE
Fixes #7564 - Malformed URLs in API git/commits response

### DIFF
--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -92,7 +92,7 @@ func GetSingleCommit(ctx *context.APIContext) {
 			URL: setting.AppURL + ctx.Link[1:],
 			SHA: commit.ID.String(),
 		},
-		HTMLURL: ctx.Repo.Repository.HTMLURL() + "/commits/" + commit.ID.String(),
+		HTMLURL: ctx.Repo.Repository.HTMLURL() + "/commit/" + commit.ID.String(),
 		RepoCommit: &api.RepoCommit{
 			URL: setting.AppURL + ctx.Link[1:],
 			Author: &api.CommitUser{
@@ -111,7 +111,7 @@ func GetSingleCommit(ctx *context.APIContext) {
 			},
 			Message: commit.Message(),
 			Tree: &api.CommitMeta{
-				URL: ctx.Repo.Repository.APIURL() + "/trees/" + commit.ID.String(),
+				URL: ctx.Repo.Repository.APIURL() + "/git/trees/" + commit.ID.String(),
 				SHA: commit.ID.String(),
 			},
 		},


### PR DESCRIPTION
Fixes #7564: Correction to two different URLs in the /git/commits response, the tree url and the HTML url. Probably should be backported to 1.9