### PR TITLE
Fix regression in reverse proxy documentation

### DIFF
--- a/docs/content/doc/usage/reverse-proxies.en-us.md
+++ b/docs/content/doc/usage/reverse-proxies.en-us.md
@@ -71,11 +71,11 @@ In case you already have a site, and you want Gitea to share the domain name, yo
     <Proxy *>
          Order allow,deny
          Allow from all
-         AllowEncodedSlashes NoDecode
     </Proxy>
-
-    ProxyPass /git http://localhost:3000 nocanon # Note: no trailing slash after either /git or port
-    ProxyPassReverse /git http://localhost:3000 # Note: no trailing slash after either /git or port
+    AllowEncodedSlashes NoDecode
+    # Note: no trailing slash after either /git or port
+    ProxyPass /git http://localhost:3000 nocanon
+    ProxyPassReverse /git http://localhost:3000
 </VirtualHost>
 ```
 

--- a/docs/content/doc/usage/reverse-proxies.zh-cn.md
+++ b/docs/content/doc/usage/reverse-proxies.zh-cn.md
@@ -72,11 +72,11 @@ server {
     <Proxy *>
          Order allow,deny
          Allow from all
-         AllowEncodedSlashes NoDecode
     </Proxy>
-
-    ProxyPass /git http://localhost:3000 nocanon # Note: no trailing slash after either /git or port
-    ProxyPassReverse /git http://localhost:3000 # Note: no trailing slash after either /git or port
+    AllowEncodedSlashes NoDecode
+    # Note: no trailing slash after either /git or port
+    ProxyPass /git http://localhost:3000 nocanon
+    ProxyPassReverse /git http://localhost:3000
 </VirtualHost>
 ```
 


### PR DESCRIPTION
From Apache: ```AllowEncodedSlashes not allowed in <Proxy> context```

Move this out of \<Proxy\> block

Fixes #7632 

I've also moved the #comment to its own line so you can just copy and paste without syntax error