### PR TITLE
reserve .well-known username

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -783,6 +783,7 @@ var (
 		"robots.txt",
 		".",
 		"..",
+		".well-known",
 	}
 	reservedUserPatterns = []string{"*.keys", "*.gpg"}
 )


### PR DESCRIPTION
This PR is meant to prevent a scenario where a user creates an account ".well-known" and then a repo with an auth key filename, so that for example https://codeberg.org/.well_known/authkey-for-whatever.txt becomes valid. The "authkey-for-whatever.txt" can then have the required data inside its description.

It actually happened to us. But we do not know yet weather it was successful. (**EDIT**: it was)

Generally it is hard to fix such attacks, what if a service just wants a file in the rood directory called 3435345345342523534.html, then a user account with a description would suffice. 

It also depends if the remote accepts files with a lot of html or if they expect data to be plain text starting in line 1.