### PR TITLE
Fix bug on migrating milestone from github

### DIFF
--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -112,7 +112,7 @@ func (g *GiteaLocalUploader) CreateMilestones(milestones ...*base.Milestone) err
 			RepoID:       g.repo.ID,
 			Name:         milestone.Title,
 			Content:      milestone.Description,
-			IsClosed:     milestone.State == "close",
+			IsClosed:     milestone.State == "closed",
 			DeadlineUnix: deadline,
 		}
 		if ms.IsClosed && milestone.Closed != nil {


### PR DESCRIPTION
According https://developer.github.com/v3/issues/milestones/ , the milestone state should be `open` or `closed` but not `close`.