### PR TITLE
Move add to hook queue for created repo to outside xorm session.

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1401,8 +1401,7 @@ func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err
 		}
 	}
 
-	err = sess.Commit()
-	if err != nil {
+	if err = sess.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -1332,7 +1332,6 @@ func createRepository(e *xorm.Session, doer, u *User, repo *Repository) (err err
 		}); err != nil {
 			return fmt.Errorf("prepareWebhooks: %v", err)
 		}
-		go HookQueue.Add(repo.ID)
 	} else if err = repo.recalculateAccesses(e); err != nil {
 		// Organization automatically called this in addRepository method.
 		return fmt.Errorf("recalculateAccesses: %v", err)
@@ -1402,7 +1401,14 @@ func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err
 		}
 	}
 
-	return repo, sess.Commit()
+	err = sess.Commit()
+
+	// Add to hook queue for created repo after session commit.
+	if u.IsOrganization() {
+		go HookQueue.Add(repo.ID)
+	}
+
+	return repo, err
 }
 
 func countRepositories(userID int64, private bool) int64 {
@@ -2460,6 +2466,11 @@ func ForkRepository(doer, u *User, oldRepo *Repository, name, desc string) (_ *R
 		log.Error("PrepareWebhooks [repo_id: %d]: %v", oldRepo.ID, err)
 	} else {
 		go HookQueue.Add(oldRepo.ID)
+	}
+
+	// Add to hook queue for created repo after session commit.
+	if u.IsOrganization() {
+		go HookQueue.Add(repo.ID)
 	}
 
 	if err = repo.UpdateSize(); err != nil {

--- a/models/repo.go
+++ b/models/repo.go
@@ -1402,6 +1402,9 @@ func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err
 	}
 
 	err = sess.Commit()
+	if err != nil {
+		return nil, err
+	}
 
 	// Add to hook queue for created repo after session commit.
 	if u.IsOrganization() {


### PR DESCRIPTION
New try to solve issue #7404. Moving adding created repository to hook queue outside the xorm session. This code is therefore duplicated and moved up to functions ForkRepository and CreateRepository. This is necessary to ensure the hook is in the database when read by DeliveryHooks.