### PR TITLE
Fix create menu item widths

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -81,7 +81,7 @@ a{cursor:pointer}
 .ui.menu,.ui.segment,.ui.vertical.menu{box-shadow:none}
 .ui .menu:not(.vertical) .item>.button.compact{padding:.58928571em 1.125em}
 .ui .menu:not(.vertical) .item>.button.small{font-size:.92857143rem}
-.ui.menu .ui.dropdown.item .menu .item{margin-right:auto}
+.ui.menu .ui.dropdown.item .menu .item{width:100%}
 .ui.dropdown .menu>.item>.floating.label{z-index:11}
 .ui.dropdown .menu .menu>.item>.floating.label{z-index:21}
 .ui .text.red{color:#d95c5c!important}

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -339,7 +339,7 @@ code,
     }
 
     &.menu .ui.dropdown.item .menu .item {
-        margin-right: auto;
+        width: 100%;
     }
 
     &.dropdown .menu > .item > .floating.label {


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/7098

Before (background added to showcase item areas):
<img width="251" alt="Screenshot 2019-08-01 at 21 01 20" src="https://user-images.githubusercontent.com/115237/62320125-c5a16800-b49f-11e9-9178-e7485abfc533.png">

After:
<img width="257" alt="Screenshot 2019-08-01 at 21 01 29" src="https://user-images.githubusercontent.com/115237/62320126-c5a16800-b49f-11e9-8d58-f5bb32998866.png">
