### PR TITLE
Fixes indexed repos keeping outdated indexes when files grow too large

### DIFF
--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -199,7 +199,7 @@ func addUpdate(update fileUpdate, repo *Repository, batch rupture.FlushingBatch)
 	if size, err := strconv.Atoi(strings.TrimSpace(stdout)); err != nil {
 		return fmt.Errorf("Misformatted git cat-file output: %v", err)
 	} else if int64(size) > setting.Indexer.MaxIndexerFileSize {
-		return nil
+		return addDelete(update.Filename, repo, batch)
 	}
 
 	fileContents, err := git.NewCommand("cat-file", "blob", update.BlobSha).


### PR DESCRIPTION
> @guillep2k I agree that change would fix it. Why don't you add another quick PR for that?
> 
> _Originally posted by @zeripath in https://github.com/go-gitea/gitea/pull/7711#issuecomment-517500634_

For indexed repos, when a commited file grows larger than [indexer] MAX_FILE_SIZE, its index is no longer updated, but remain "frozen" and produce outdated results. Chaining the action with addDelete() should remove any lingering indexes the file might have.

This code will not fix indexes already outdated (not until a new commit is performed on it).