### PR TITLE
Regression: Include "executable" files in the index, as they are not necessarily …

### DIFF
--- a/models/repo_indexer.go
+++ b/models/repo_indexer.go
@@ -232,7 +232,7 @@ func addDelete(filename string, repo *Repository, batch rupture.FlushingBatch) e
 }
 
 func isIndexable(entry *git.TreeEntry) bool {
-	return entry.IsRegular()
+	return entry.IsRegular() || entry.IsExecutable()
 }
 
 // parseGitLsTreeOutput parses the output of a `git ls-tree -r --full-name` command

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -108,6 +108,11 @@ func (te *TreeEntry) IsRegular() bool {
 	return te.gogitTreeEntry.Mode == filemode.Regular
 }
 
+// IsExecutable if the entry is an executable file (not necessarily binary)
+func (te *TreeEntry) IsExecutable() bool {
+	return te.gogitTreeEntry.Mode == filemode.Executable
+}
+
 // Blob returns the blob object the entry
 func (te *TreeEntry) Blob() *Blob {
 	encodedObj, err := te.ptree.repo.gogitRepo.Storer.EncodedObject(plumbing.AnyObject, te.gogitTreeEntry.Hash)


### PR DESCRIPTION
Fix regression introduced in #7717 where files tagged as "Executable" were excluded from the list of indexables. It turns out that "Executable" is not a reliable classification, as many source files are marked as such (e.g. migrated from CVS, Windows).