### PR TITLE
Use a web worker for syntax highlighting, drop IE11 support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@ extends:
   - eslint:recommended
 
 parserOptions:
-  ecmaVersion: 2015
+  ecmaVersion: 2017
 
 env:
   browser: true
@@ -25,3 +25,4 @@ rules:
   no-unused-vars: [error, {args: all, argsIgnorePattern: ^_, varsIgnorePattern: ^_, ignoreRestSiblings: true}]
   prefer-const: [2, {destructuring: all}]
   no-var: [2]
+  no-empty: [2, {allowEmptyCatch: true}]

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -45,7 +45,6 @@ var (
 		".ini":   {},
 		".json":  {},
 		".java":  {},
-		".js":    {},
 		".less":  {},
 		".lua":   {},
 		".php":   {},
@@ -68,6 +67,11 @@ var (
 		".escript": "erlang",
 		".ex":      "elixir",
 		".exs":     "elixir",
+		".js":      "javascript",
+		".jsx":     "javascript",
+		".mjs":     "javascript",
+		".ts":      "typescript",
+		".tsx":     "typescript",
 	}
 )
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "> 1%",
     "last 2 firefox versions",
     "last 2 safari versions",
-    "ie 11"
+    "not ie 11"
   ]
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1989,12 +1989,12 @@ function highlight(nodes) {
 
         for (const [index, result] of Object.entries(results)) {
             const node = nodes[index];
+            node.classList.add("hljs");
 
             // highlight.js in a web worker does not accept HTML strings so we have to pass .textContent to it
             // and replicate what the golang templating does by re-adding these ol > li wrappings where necessary.
             if (node.querySelector("ol.linenums")) {
                 const lines = result.split(/\r?\n/).map((line, i) => `<li class="L${i + 1}" rel="L${i + 1}">${line}</li>`);
-                node.classList.add("hljs");
                 node.innerHTML = `<ol class="linenums">${lines.join("")}<ol>`;
             } else {
                 node.innerHTML = result;

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1988,11 +1988,18 @@ function highlight(nodes) {
         window.highlightWorker.removeEventListener("message", listener);
 
         for (const [index, result] of Object.entries(results)) {
+            const node = nodes[index];
+
             // highlight.js in a web worker does not accept HTML strings so we have to pass .textContent to it
-            // and replicate what the golang templating does by re-adding these ol > li wrappings.
-            const lines = result.split(/\r?\n/).map((line, i) => `<li class="L${i + 1}" rel="L${i + 1}">${line}</li>`);
-            nodes[index].classList.add("hljs");
-            nodes[index].innerHTML = `<ol class="linenums">${lines.join("")}<ol>`;
+            // and replicate what the golang templating does by re-adding these ol > li wrappings where necessary.
+            if (node.querySelector("ol.linenums")) {
+                const lines = result.split(/\r?\n/).map((line, i) => `<li class="L${i + 1}" rel="L${i + 1}">${line}</li>`);
+                node.classList.add("hljs");
+                node.innerHTML = `<ol class="linenums">${lines.join("")}<ol>`;
+            } else {
+                node.innerHTML = result;
+            }
+
         }
     }
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1937,7 +1937,7 @@ function u2fRegisterRequest() {
 
 function createWorker(fn, ...args) {
     const argsString = args.map(arg => JSON.stringify(arg)).join(", ");
-    const url = URL.createObjectURL(new Blob([`(${fn})(${argsString})`], {type: 'application/javascript'})),
+    const url = URL.createObjectURL(new Blob([`(${fn})(${argsString})`], {type: "application/javascript"})),
     worker = new Worker(url);
     URL.revokeObjectURL(url);
     return worker;

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1992,7 +1992,7 @@ function highlight(nodes) {
             node.classList.add("hljs");
 
             // highlight.js in a web worker does not accept HTML strings so we have to pass .textContent to it
-            // and replicate what the golang templating does by re-adding these ol > li wrappings where necessary.
+            // and then do line-per-line replacement to preserve the original HTML structured from the template.
             const wrappedNodes = node.querySelectorAll("ol.linenums li");
             if (wrappedNodes && wrappedNodes.length) {
                 const lines = result.split(/\r?\n/);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1995,11 +1995,12 @@ function highlight(nodes) {
             // and then do line-per-line replacement to preserve the original HTML structured from the template.
             const wrappedNodes = node.querySelectorAll("ol.linenums li");
             if (wrappedNodes && wrappedNodes.length) {
-                const lines = result.split(/\r?\n/);
+                const lines = result.split(/\r?\n/).map((line, i) => {
+                    const active = wrappedNodes[i].classList.contains("active") ? " active" : "";
+                    return `<li class="L${i + 1}${active}" rel="L${i + 1}">${line}</li>`;
+                });
 
-                for (const [index, node] of Object.entries(wrappedNodes)) {
-                    node.innerHTML = lines[index];
-                }
+                node.innerHTML = `<ol class="linenums">${lines.join("")}<ol>`;
             } else {
                 node.innerHTML = result;
             }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1993,9 +1993,13 @@ function highlight(nodes) {
 
             // highlight.js in a web worker does not accept HTML strings so we have to pass .textContent to it
             // and replicate what the golang templating does by re-adding these ol > li wrappings where necessary.
-            if (node.querySelector("ol.linenums")) {
-                const lines = result.split(/\r?\n/).map((line, i) => `<li class="L${i + 1}" rel="L${i + 1}">${line}</li>`);
-                node.innerHTML = `<ol class="linenums">${lines.join("")}<ol>`;
+            const wrappedNodes = node.querySelectorAll("ol.linenums li");
+            if (wrappedNodes) {
+                const lines = result.split(/\r?\n/);
+
+                for (const [index, node] of Object.entries(wrappedNodes)) {
+                    node.innerHTML = lines[index];
+                }
             } else {
                 node.innerHTML = result;
             }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1994,7 +1994,7 @@ function highlight(nodes) {
             // highlight.js in a web worker does not accept HTML strings so we have to pass .textContent to it
             // and replicate what the golang templating does by re-adding these ol > li wrappings where necessary.
             const wrappedNodes = node.querySelectorAll("ol.linenums li");
-            if (wrappedNodes) {
+            if (wrappedNodes && wrappedNodes.length) {
                 const lines = result.split(/\r?\n/);
 
                 for (const [index, node] of Object.entries(wrappedNodes)) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1937,8 +1937,8 @@ function u2fRegisterRequest() {
 
 function createWorker(fn, ...args) {
     const argsString = args.map(arg => JSON.stringify(arg)).join(", ");
-    const url = URL.createObjectURL(new Blob([`(${fn})(${argsString})`], {type: "application/javascript"})),
-    worker = new Worker(url);
+    const url = URL.createObjectURL(new Blob([`(${fn})(${argsString})`], {type: "application/javascript"}));
+    const worker = new Worker(url);
     URL.revokeObjectURL(url);
     return worker;
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1953,7 +1953,7 @@ function createHighlightWorker() {
     // convert relative URL to absolute for importScripts to accept it
     let url;
     try {
-        url = new URL(window.config.hljsUrl, location.origin).href;
+        url = new URL(window.config.hljsUrl, window.location.origin).href;
     } catch (err) {}
     if (!url) return;
 

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -15,6 +15,9 @@
 	<script src="{{AppSubUrl}}/vendor/plugins/jquery/jquery.min.js?v=3.4.1"></script>
 	<script src="{{AppSubUrl}}/vendor/plugins/jquery-migrate/jquery-migrate.min.js?v=3.0.1"></script>
 	<script src="{{AppSubUrl}}/vendor/plugins/jquery.areyousure/jquery.are-you-sure.js"></script>
+	<script>
+		window.config = {};
+	</script>
 {{if .RequireSimpleMDE}}
 	<script src="{{AppSubUrl}}/vendor/plugins/simplemde/simplemde.min.js"></script>
 	<script src="{{AppSubUrl}}/vendor/plugins/codemirror/addon/mode/loadmode.js"></script>
@@ -31,7 +34,9 @@
 
 <!-- Third-party libraries -->
 {{if .RequireHighlightJS}}
-	<script src="{{AppSubUrl}}/vendor/plugins/highlight/highlight.pack.js"></script>
+	<script>
+		window.config.hljsUrl = "{{AppSubUrl}}/vendor/plugins/highlight/highlight.pack.js";
+	</script>
 {{end}}
 {{if .RequireMinicolors}}
 	<script src="{{AppSubUrl}}/vendor/plugins/jquery.minicolors/jquery.minicolors.min.js"></script>


### PR DESCRIPTION
Syntax highlighting is now done in a separate thread which should help performance on large files.

The web worker is initialized from a function which is not something IE11 supports and which would force us to create a separate .js file for the worker code.

For the reason above, I think it's a good opportunity to end IE11 support with this commit, so it should be landed in the next minor release version.

The code uses various ES2017 features. It should work in all evergreen browsers.

Fixes: https://github.com/go-gitea/gitea/issues/6147