### PR TITLE
Backport: fix repo_index_status lingering when deleting a repository

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1791,6 +1791,7 @@ func DeleteRepository(doer *User, uid, repoID int64) error {
 		&HookTask{RepoID: repoID},
 		&Notification{RepoID: repoID},
 		&CommitStatus{RepoID: repoID},
+		&RepoIndexerStatus{RepoID: repoID},
 	); err != nil {
 		return fmt.Errorf("deleteBeans: %v", err)
 	}


### PR DESCRIPTION
Backport of #7734, which is fix for #7703.