### PR TITLE
Add SQL execution on log and indexes on table repository and comment

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -99,10 +99,10 @@ const (
 
 // Comment represents a comment in commit and issue page.
 type Comment struct {
-	ID               int64 `xorm:"pk autoincr"`
-	Type             CommentType
-	PosterID         int64 `xorm:"INDEX"`
-	Poster           *User `xorm:"-"`
+	ID               int64       `xorm:"pk autoincr"`
+	Type             CommentType `xorm:"index"`
+	PosterID         int64       `xorm:"INDEX"`
+	Poster           *User       `xorm:"-"`
 	OriginalAuthor   string
 	OriginalAuthorID int64
 	IssueID          int64  `xorm:"INDEX"`
@@ -143,7 +143,7 @@ type Comment struct {
 	ShowTag CommentTag `xorm:"-"`
 
 	Review      *Review `xorm:"-"`
-	ReviewID    int64
+	ReviewID    int64   `xorm:"index"`
 	Invalidated bool
 }
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -236,6 +236,8 @@ var migrations = []Migration{
 	NewMigration("add original author/url migration info to issues, comments, and repo ", addOriginalMigrationInfo),
 	// v90 -> v91
 	NewMigration("change length of some repository columns", changeSomeColumnsLengthOfRepo),
+	// v91 -> v92
+	NewMigration("add index on owner_id of repository and type, review_id of comment", addIndexOnRepositoryAndComment),
 }
 
 // Migrate database to current version

--- a/models/migrations/v91.go
+++ b/models/migrations/v91.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import "github.com/go-xorm/xorm"
+
+func addIndexOnRepositoryAndComment(x *xorm.Engine) error {
+	type Repository struct {
+		ID      int64 `xorm:"pk autoincr"`
+		OwnerID int64 `xorm:"index"`
+	}
+
+	if err := x.Sync2(new(Repository)); err != nil {
+		return err
+	}
+
+	type Comment struct {
+		ID       int64 `xorm:"pk autoincr"`
+		Type     int   `xorm:"index"`
+		ReviewID int64 `xorm:"index"`
+	}
+
+	return x.Sync2(new(Comment))
+}

--- a/models/models.go
+++ b/models/models.go
@@ -262,6 +262,7 @@ func NewTestEngine(x *xorm.Engine) (err error) {
 		return fmt.Errorf("Connect to database: %v", err)
 	}
 
+	x.ShowExecTime(true)
 	x.SetMapper(core.GonicMapper{})
 	x.SetLogger(NewXORMLogger(!setting.ProdMode))
 	x.ShowSQL(!setting.ProdMode)
@@ -275,6 +276,7 @@ func SetEngine() (err error) {
 		return fmt.Errorf("Failed to connect to database: %v", err)
 	}
 
+	x.ShowExecTime(true)
 	x.SetMapper(core.GonicMapper{})
 	// WARNING: for serv command, MUST remove the output to os.stdout,
 	// so use log file to instead print to stdout.

--- a/models/repo.go
+++ b/models/repo.go
@@ -129,7 +129,7 @@ func NewRepoContext() {
 // Repository represents a git repository.
 type Repository struct {
 	ID            int64  `xorm:"pk autoincr"`
-	OwnerID       int64  `xorm:"UNIQUE(s)"`
+	OwnerID       int64  `xorm:"UNIQUE(s) index"`
 	OwnerName     string `xorm:"-"`
 	Owner         *User  `xorm:"-"`
 	LowerName     string `xorm:"UNIQUE(s) INDEX NOT NULL"`


### PR DESCRIPTION
This PR will always enable SQL execution on xorm logger.
And it will add indexes on column owner_id of repository and type, review_id of comment.