### PR TITLE
deps: Upgrade gopkg.in/editorconfig/editorconfig-core-go.v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20150924051756-4e86f4367175 // indirect
 	gopkg.in/bufio.v1 v1.0.0-20140618132640-567b2bfa514e // indirect
-	gopkg.in/editorconfig/editorconfig-core-go.v1 v1.2.0
+	gopkg.in/editorconfig/editorconfig-core-go.v1 v1.3.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/ini.v1 v1.42.0
 	gopkg.in/ldap.v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ gopkg.in/bufio.v1 v1.0.0-20140618132640-567b2bfa514e/go.mod h1:xsQCaysVCudhrYTfz
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/editorconfig/editorconfig-core-go.v1 v1.2.0 h1:CO465/foR4+bY1xNYjZEl6l8By1g/iMsImoruxfEt84=
-gopkg.in/editorconfig/editorconfig-core-go.v1 v1.2.0/go.mod h1:s2mQFI9McjArkyCwyEwU//+luQENTnD/Lfb/7Sj3/kQ=
+gopkg.in/editorconfig/editorconfig-core-go.v1 v1.3.0 h1:oxOEwvhxLMpWpN+0pb2r9TWrM0DCFBHxbuIlS27tmFg=
+gopkg.in/editorconfig/editorconfig-core-go.v1 v1.3.0/go.mod h1:s2mQFI9McjArkyCwyEwU//+luQENTnD/Lfb/7Sj3/kQ=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.editorconfig
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 
 [*.go]
 indent_style = tab
-indent_size = 4
+indent_size = 8

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.gitignore
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.test
 *.prof
 
+# EditorConfig
+
+/editorconfig

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.gitmodules
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core-test"]
+	path = core-test
+	url = https://github.com/editorconfig/editorconfig-core-test.git

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.travis.yml
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: go
+sudo: false
+go:
+  - '1.8'
+  - '1.9'
+  - '1.10'
+go_import_path: gopkg.in/editorconfig/editorconfig-core-go.v1
+
+install:
+  - make installdeps
+
+script:
+  - make test

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/Makefile
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/Makefile
@@ -1,0 +1,25 @@
+PROJECT_ROOT_DIR := $(CURDIR)
+SRC := editorconfig.go cmd/editorconfig/main.go
+
+.PHONY: bin test test-go test-core submodule installdeps
+
+test: test-go test-core
+
+submodule:
+	git submodule update --init
+
+installdeps:
+	go get -t ./...
+
+editorconfig: $(SRC)
+	go build ./cmd/editorconfig
+
+test-go:
+	go test -v
+
+test-core: editorconfig
+	cd $(PROJECT_ROOT_DIR)/core-test && \
+		cmake -DEDITORCONFIG_CMD="$(PROJECT_ROOT_DIR)/editorconfig" .
+# Temporarily disable core-test
+	# cd $(PROJECT_ROOT_DIR)/core-test && \
+	# 	ctest --output-on-failure .

--- a/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/README.md
+++ b/vendor/gopkg.in/editorconfig/editorconfig-core-go.v1/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/editorconfig/editorconfig-core-go.svg?branch=master)](https://travis-ci.org/editorconfig/editorconfig-core-go)
 [![GoDoc](https://godoc.org/gopkg.in/editorconfig/editorconfig-core-go.v1?status.svg)](https://godoc.org/gopkg.in/editorconfig/editorconfig-core-go.v1)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/editorconfig/editorconfig-core-go.v1)](https://goreportcard.com/report/gopkg.in/editorconfig/editorconfig-core-go.v1)
 
@@ -15,7 +16,7 @@ We recommend the use of [gopkg.in][gopkg] for this package:
 go get -u gopkg.in/editorconfig/editorconfig-core-go.v1
 ```
 
-Import by the same path. Tha package name you will use to access it is
+Import by the same path. The package name you will use to access it is
 `editorconfig`.
 
 ```go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -414,7 +414,7 @@ gopkg.in/alexcesaro/quotedprintable.v3
 gopkg.in/asn1-ber.v1
 # gopkg.in/bufio.v1 v1.0.0-20140618132640-567b2bfa514e
 gopkg.in/bufio.v1
-# gopkg.in/editorconfig/editorconfig-core-go.v1 v1.2.0
+# gopkg.in/editorconfig/editorconfig-core-go.v1 v1.3.0
 gopkg.in/editorconfig/editorconfig-core-go.v1
 # gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 gopkg.in/gomail.v2


### PR DESCRIPTION
Upgrade gopkg.in/editorconfig/editorconfig-core-go.v1 from 1.2.0 to 1.3.0

This is for having some [improvements](https://github.com/editorconfig/editorconfig-core-go/compare/v1.2.0...v1.3.0) but also to re-validate the test-vendor in CI. (by not vendoring in the first commit)