### PR TITLE
Update migrated repositories' issues/comments/prs poster id if user has a github external user saved

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -690,6 +690,11 @@ SCHEDULE = @every 24h
 ;   or only create new users if UPDATE_EXISTING is set to false
 UPDATE_EXISTING = true
 
+; Update migrated repositories' issues and comments' posterid, it will always be started at start.
+[cron.update_migration_post_id]
+; Interval as a duration between each synchronization (default every 10m)
+SCHEDULE = @every 10m
+
 [git]
 ; The path of git executable. If empty, Gitea searches through the PATH environment.
 PATH =

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -690,10 +690,10 @@ SCHEDULE = @every 24h
 ;   or only create new users if UPDATE_EXISTING is set to false
 UPDATE_EXISTING = true
 
-; Update migrated repositories' issues and comments' posterid, it will always be started at start.
+; Update migrated repositories' issues and comments' posterid, it will always attempt synchronization when the instance starts.
 [cron.update_migration_post_id]
-; Interval as a duration between each synchronization (default every 10m)
-SCHEDULE = @every 10m
+; Interval as a duration between each synchronization. (default every 24h)
+SCHEDULE = @every 24h
 
 [git]
 ; The path of git executable. If empty, Gitea searches through the PATH environment.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -419,6 +419,10 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 - `RUN_AT_START`: **true**: Run repository statistics check at start time.
 - `SCHEDULE`: **@every 24h**: Cron syntax for scheduling repository statistics check.
 
+### Cron - Update Migration Poster ID (`cron.update_migration_post_id`)
+
+- `SCHEDULE`: **@every 10m** : Interval as a duration between each synchronization, it will always be started at start.
+
 ## Git (`git`)
 
 - `PATH`: **""**: The path of git executable. If empty, Gitea searches through the PATH environment.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -421,7 +421,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 
 ### Cron - Update Migration Poster ID (`cron.update_migration_post_id`)
 
-- `SCHEDULE`: **@every 10m** : Interval as a duration between each synchronization, it will always be started at start.
+- `SCHEDULE`: **@every 24h** : Interval as a duration between each synchronization, it will always attempt synchronization when the instance starts.
 
 ## Git (`git`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -200,7 +200,7 @@ menu:
 
 ### Cron - Update Migration Poster ID (`cron.update_migration_post_id`)
 
-- `SCHEDULE`: **@every 24h** : 每次统计的间隔时间。此任务总是在启动时自动进行。
+- `SCHEDULE`: **@every 24h** : 每次同步的间隔时间。此任务总是在启动时自动进行。
 
 ## Git (`git`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -200,7 +200,7 @@ menu:
 
 ### Cron - Update Migration Poster ID (`cron.update_migration_post_id`)
 
-- `SCHEDULE`: **@every 10m** : 每次统计的间隔时间。此任务总是在启动时自动进行。
+- `SCHEDULE`: **@every 24h** : 每次统计的间隔时间。此任务总是在启动时自动进行。
 
 ## Git (`git`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -196,7 +196,11 @@ menu:
 ### Cron - Repository Statistics Check (`cron.check_repo_stats`)
 
 - `RUN_AT_START`: 是否启动时自动运行仓库统计。
-- `SCHEDULE`: 藏亏统计时的Cron 语法，比如：`@every 24h`.
+- `SCHEDULE`: 仓库统计时的Cron 语法，比如：`@every 24h`.
+
+### Cron - Update Migration Poster ID (`cron.update_migration_post_id`)
+
+- `SCHEDULE`: **@every 10m** : 每次统计的间隔时间。此任务总是在启动时自动进行。
 
 ## Git (`git`)
 

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/structs"
+
 	"github.com/markbates/goth"
 	"xorm.io/builder"
 )

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -157,7 +157,10 @@ func (opts FindExternalUserOptions) toConds() builder.Cond {
 // FindExternalUsersByProvider represents external users via provider
 func FindExternalUsersByProvider(opts FindExternalUserOptions) ([]ExternalLoginUser, error) {
 	var users []ExternalLoginUser
-	err := x.Where(opts.toConds()).Limit(opts.Limit, opts.Start).Find(&users)
+	err := x.Where(opts.toConds()).
+		Limit(opts.Limit, opts.Start).
+		Asc("id").
+		Find(&users)
 	if err != nil {
 		return nil, err
 	}

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -18,7 +18,7 @@ type ExternalLoginUser struct {
 	ExternalID        string                 `xorm:"pk NOT NULL"`
 	UserID            int64                  `xorm:"INDEX NOT NULL"`
 	LoginSourceID     int64                  `xorm:"pk NOT NULL"`
-	RawData           map[string]interface{} `xorm:"TEXT"`
+	RawData           map[string]interface{} `xorm:"TEXT JSON"`
 	Provider          string                 `xorm:"index VARCHAR(25)"`
 	Email             string
 	Name              string

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -162,6 +162,7 @@ func UpdateExternalUser(user *User, gothUser goth.User) error {
 	return err
 }
 
+// FindExternalUserOptions represents an options to find external users
 type FindExternalUserOptions struct {
 	Provider string
 	Limit    int

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -14,11 +14,11 @@ import (
 
 // ExternalLoginUser makes the connecting between some existing user and additional external login sources
 type ExternalLoginUser struct {
-	ExternalID        string                 `xorm:"VARCHAR(50) pk NOT NULL"`
+	ExternalID        string                 `xorm:"pk NOT NULL"`
 	UserID            int64                  `xorm:"INDEX NOT NULL"`
 	LoginSourceID     int64                  `xorm:"pk NOT NULL"`
 	RawData           map[string]interface{} `xorm:"TEXT"`
-	Provider          string                 `xorm:"index"`
+	Provider          string                 `xorm:"index VARCHAR(25)"`
 	Email             string
 	Name              string
 	FirstName         string

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -169,5 +169,9 @@ func UpdateMigrationsByType(tp structs.GitServiceType, externalUserID, userID in
 		return err
 	}
 
-	return UpdateCommentsMigrationsByType(tp, externalUserID, userID)
+	if err := UpdateCommentsMigrationsByType(tp, externalUserID, userID); err != nil {
+		return err
+	}
+
+	return UpdateReleasesMigrationsByType(tp, externalUserID, userID)
 }

--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -4,13 +4,32 @@
 
 package models
 
-import "github.com/markbates/goth"
+import (
+	"time"
+
+	"github.com/markbates/goth"
+)
 
 // ExternalLoginUser makes the connecting between some existing user and additional external login sources
 type ExternalLoginUser struct {
-	ExternalID    string `xorm:"pk NOT NULL"`
-	UserID        int64  `xorm:"INDEX NOT NULL"`
-	LoginSourceID int64  `xorm:"pk NOT NULL"`
+	ExternalID        string `xorm:"pk NOT NULL"`
+	UserID            int64  `xorm:"INDEX NOT NULL"`
+	LoginSourceID     int64  `xorm:"pk NOT NULL"`
+	RawData           map[string]interface{}
+	Provider          string `xorm:"index"`
+	Email             string
+	Name              string
+	FirstName         string
+	LastName          string
+	NickName          string
+	Description       string
+	ExternalUserID    string `xorm:"VARCHAR(50) index"`
+	AvatarURL         string
+	Location          string
+	AccessToken       string
+	AccessTokenSecret string
+	RefreshToken      string
+	ExpiresAt         time.Time
 }
 
 // GetExternalLogin checks if a externalID in loginSourceID scope already exists
@@ -71,4 +90,15 @@ func RemoveAccountLink(user *User, loginSourceID int64) (int64, error) {
 func removeAllAccountLinks(e Engine, user *User) error {
 	_, err := e.Delete(&ExternalLoginUser{UserID: user.ID})
 	return err
+}
+
+// GetUserIDByExternalUserID get user id according to provider and userID
+func GetUserIDByExternalUserID(provider string, userID string) (int64, error) {
+	var id int64
+	_, err := x.Select("user_id").Where("provider=?", provider).
+		And("external_user_id=?", userID).Get(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -32,7 +32,7 @@ type Issue struct {
 	PosterID         int64       `xorm:"INDEX"`
 	Poster           *User       `xorm:"-"`
 	OriginalAuthor   string
-	OriginalAuthorID int64
+	OriginalAuthorID int64      `xorm:"index"`
 	Title            string     `xorm:"name"`
 	Content          string     `xorm:"TEXT"`
 	RenderedContent  string     `xorm:"-"`
@@ -1946,4 +1946,15 @@ func (issue *Issue) ResolveMentionsByVisibility(ctx DBContext, doer *User, menti
 	}
 
 	return
+}
+
+// UpdateIssuesMigrations updates issues' migrations information
+func UpdateIssuesMigrations(repoID, originalAuthorID, posterID int64) error {
+	_, err := x.Table("issue").
+		Where("repo_id = ?", repoID).
+		And("original_author_id = ?", originalAuthorID).
+		Update(map[string]interface{}{
+			"poster_id": posterID,
+		})
+	return err
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -1954,7 +1954,9 @@ func UpdateIssuesMigrations(repoID, originalAuthorID, posterID int64) error {
 		Where("repo_id = ?", repoID).
 		And("original_author_id = ?", originalAuthorID).
 		Update(map[string]interface{}{
-			"poster_id": posterID,
+			"poster_id":          posterID,
+			"original_author":    "",
+			"original_author_id": 0,
 		})
 	return err
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
@@ -1948,10 +1949,10 @@ func (issue *Issue) ResolveMentionsByVisibility(ctx DBContext, doer *User, menti
 	return
 }
 
-// UpdateIssuesMigrations updates issues' migrations information
-func UpdateIssuesMigrations(repoID, originalAuthorID, posterID int64) error {
+// UpdateIssuesMigrationsByType updates all migrated repositories' issues from gitServiceType to replace originalAuthorID to posterID
+func UpdateIssuesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID, posterID int64) error {
 	_, err := x.Table("issue").
-		Where("repo_id = ?", repoID).
+		Where("repo_id IN (SELECT id FROM repository WHERE original_service_type = ?)", gitServiceType).
 		And("original_author_id = ?", originalAuthorID).
 		Update(map[string]interface{}{
 			"poster_id":          posterID,

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1029,7 +1029,9 @@ func UpdateCommentsMigrations(repoID, originalAuthorID, posterID int64) error {
 		Where("issue_id IN (SELECT id FROM issue WHERE repo_id = ?)", repoID).
 		And("original_author_id = ?", originalAuthorID).
 		Update(map[string]interface{}{
-			"poster_id": posterID,
+			"poster_id":          posterID,
+			"original_author":    "",
+			"original_author_id": 0,
 		})
 	return err
 }

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1023,7 +1023,7 @@ func FetchCodeComments(issue *Issue, currentUser *User) (CodeComments, error) {
 	return fetchCodeComments(x, issue, currentUser)
 }
 
-// UpdateIssuesMigrations updates issues' migrations information
+// UpdateCommentsMigrations updates comments' migrations information
 func UpdateCommentsMigrations(repoID, originalAuthorID, posterID int64) error {
 	_, err := x.Table("comment").
 		Where("issue_id IN (SELECT id FROM issue WHERE repo_id = ?)", repoID).

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1022,3 +1022,14 @@ func fetchCodeCommentsByReview(e Engine, issue *Issue, currentUser *User, review
 func FetchCodeComments(issue *Issue, currentUser *User) (CodeComments, error) {
 	return fetchCodeComments(x, issue, currentUser)
 }
+
+// UpdateIssuesMigrations updates issues' migrations information
+func UpdateCommentsMigrations(repoID, originalAuthorID, posterID int64) error {
+	_, err := x.Table("comment").
+		Where("issue_id IN (SELECT id FROM issue WHERE repo_id = ?)", repoID).
+		And("original_author_id = ?", originalAuthorID).
+		Update(map[string]interface{}{
+			"poster_id": posterID,
+		})
+	return err
+}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -254,6 +254,8 @@ var migrations = []Migration{
 	NewMigration("add original author name and id on migrated release", addOriginalAuthorOnMigratedReleases),
 	// v99 -> v100
 	NewMigration("add task table and status column for repository table", addTaskTable),
+	// v100 -> v101
+	NewMigration("update migration repositories' service type", updateMigrationServiceTypes),
 }
 
 // Migrate database to current version

--- a/models/migrations/v100.go
+++ b/models/migrations/v100.go
@@ -63,7 +63,7 @@ func updateMigrationServiceTypes(x *xorm.Engine) error {
 		ExternalID        string                 `xorm:"pk NOT NULL"`
 		UserID            int64                  `xorm:"INDEX NOT NULL"`
 		LoginSourceID     int64                  `xorm:"pk NOT NULL"`
-		RawData           map[string]interface{} `xorm:"TEXT"`
+		RawData           map[string]interface{} `xorm:"TEXT JSON"`
 		Provider          string                 `xorm:"index VARCHAR(25)"`
 		Email             string
 		Name              string

--- a/models/migrations/v100.go
+++ b/models/migrations/v100.go
@@ -30,7 +30,7 @@ func updateMigrationServiceTypes(x *xorm.Engine) error {
 		for _, res := range results {
 			u := strings.ToLower(res.OriginalURL)
 			var serviceType = structs.PlainGitService
-			if strings.HasPrefix(u, "https://github.com") || strings.HasPrefix(u, "https://github.com") {
+			if strings.HasPrefix(u, "https://github.com") || strings.HasPrefix(u, "http://github.com") {
 				serviceType = structs.GithubService
 			}
 			_, err = x.Exec("UPDATE repository SET original_service_type = ? WHERE id = ?", serviceType, res.ID)

--- a/models/migrations/v100.go
+++ b/models/migrations/v100.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"strings"
+
+	"code.gitea.io/gitea/modules/structs"
+
+	"github.com/go-xorm/xorm"
+)
+
+func updateMigrationServiceTypes(x *xorm.Engine) error {
+	for {
+		sql := "SELECT id, original_url FROM WHERE original_url <> '' LIMIT 50 ORDER BY id"
+		var results = make([]struct {
+			ID          int64
+			OriginalURL string
+		}, 0, 50)
+		err := x.SQL(sql).Find(results)
+		if err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			return nil
+		}
+
+		for _, res := range results {
+			u := strings.ToLower(res.OriginalURL)
+			var serviceType = structs.PlainGitService
+			if strings.HasPrefix(u, "https://github.com") || strings.HasPrefix(u, "https://github.com") {
+				serviceType = structs.GithubService
+			}
+			_, err = x.Exec("UPDATE repository SET original_service_type = ? WHERE id = ?", serviceType, res.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/models/migrations/v100.go
+++ b/models/migrations/v100.go
@@ -7,8 +7,6 @@ package migrations
 import (
 	"strings"
 
-	"code.gitea.io/gitea/modules/structs"
-
 	"github.com/go-xorm/xorm"
 )
 
@@ -27,11 +25,14 @@ func updateMigrationServiceTypes(x *xorm.Engine) error {
 			return nil
 		}
 
+		const PlainGitService = 1 // 1 plain git service
+		const GithubService = 2   // 2 github.com
+
 		for _, res := range results {
 			u := strings.ToLower(res.OriginalURL)
-			var serviceType = structs.PlainGitService
+			var serviceType = PlainGitService
 			if strings.HasPrefix(u, "https://github.com") || strings.HasPrefix(u, "http://github.com") {
-				serviceType = structs.GithubService
+				serviceType = GithubService
 			}
 			_, err = x.Exec("UPDATE repository SET original_service_type = ? WHERE id = ?", serviceType, res.ID)
 			if err != nil {

--- a/models/migrations/v99.go
+++ b/models/migrations/v99.go
@@ -26,8 +26,29 @@ func addTaskTable(x *xorm.Engine) error {
 		Created        timeutil.TimeStamp `xorm:"created"`
 	}
 
+<<<<<<< HEAD
 	type Repository struct {
 		Status int `xorm:"NOT NULL DEFAULT 0"`
+=======
+	type ExternalLoginUser struct {
+		ExternalID        string                 `xorm:"pk NOT NULL"`
+		UserID            int64                  `xorm:"INDEX NOT NULL"`
+		LoginSourceID     int64                  `xorm:"pk NOT NULL"`
+		RawData           map[string]interface{} `xorm:"TEXT"`
+		Provider          string                 `xorm:"index VARCHAR(25)"`
+		Email             string
+		Name              string
+		FirstName         string
+		LastName          string
+		NickName          string
+		Description       string
+		AvatarURL         string
+		Location          string
+		AccessToken       string
+		AccessTokenSecret string
+		RefreshToken      string
+		ExpiresAt         time.Time
+>>>>>>> improve code
 	}
 
 	return x.Sync2(new(Task), new(Repository))

--- a/models/migrations/v99.go
+++ b/models/migrations/v99.go
@@ -26,29 +26,8 @@ func addTaskTable(x *xorm.Engine) error {
 		Created        timeutil.TimeStamp `xorm:"created"`
 	}
 
-<<<<<<< HEAD
 	type Repository struct {
 		Status int `xorm:"NOT NULL DEFAULT 0"`
-=======
-	type ExternalLoginUser struct {
-		ExternalID        string                 `xorm:"pk NOT NULL"`
-		UserID            int64                  `xorm:"INDEX NOT NULL"`
-		LoginSourceID     int64                  `xorm:"pk NOT NULL"`
-		RawData           map[string]interface{} `xorm:"TEXT"`
-		Provider          string                 `xorm:"index VARCHAR(25)"`
-		Email             string
-		Name              string
-		FirstName         string
-		LastName          string
-		NickName          string
-		Description       string
-		AvatarURL         string
-		Location          string
-		AccessToken       string
-		AccessTokenSecret string
-		RefreshToken      string
-		ExpiresAt         time.Time
->>>>>>> improve code
 	}
 
 	return x.Sync2(new(Task), new(Repository))

--- a/models/release.go
+++ b/models/release.go
@@ -12,6 +12,7 @@ import (
 
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
 
@@ -368,7 +369,7 @@ func SyncReleasesWithTags(repo *Repository, gitRepo *git.Repository) error {
 }
 
 // UpdateReleasesMigrationsByType updates all migrated repositories' releases from gitServiceType to replace originalAuthorID to posterID
-func UpdateReleasesMigrationsByType(gitServiceType GitServiceType, originalAuthorID, posterID int64) error {
+func UpdateReleasesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID, posterID int64) error {
 	_, err := x.Table("release").
 		Where("repo_id IN (SELECT id FROM repository WHERE original_service_type = ?)", gitServiceType).
 		And("original_author_id = ?", originalAuthorID).

--- a/models/release.go
+++ b/models/release.go
@@ -366,3 +366,16 @@ func SyncReleasesWithTags(repo *Repository, gitRepo *git.Repository) error {
 	}
 	return nil
 }
+
+// UpdateReleasesMigrationsByType updates all migrated repositories' releases from gitServiceType to replace originalAuthorID to posterID
+func UpdateReleasesMigrationsByType(gitServiceType GitServiceType, originalAuthorID, posterID int64) error {
+	_, err := x.Table("release").
+		Where("repo_id IN (SELECT id FROM repository WHERE original_service_type = ?)", gitServiceType).
+		And("original_author_id = ?", originalAuthorID).
+		Update(map[string]interface{}{
+			"publisher_id":       posterID,
+			"original_author":    "",
+			"original_author_id": 0,
+		})
+	return err
+}

--- a/models/repo.go
+++ b/models/repo.go
@@ -2782,14 +2782,3 @@ func (repo *Repository) GetOriginalURLHostname() string {
 
 	return u.Host
 }
-
-// FindMigratedRepositoryIDs find all migrated
-func FindMigratedRepositoryIDs(tp structs.GitServiceType, limit, start int) ([]int64, error) {
-	var ids []int64
-	err := x.Select("id").
-		Where("original_service_type = ?", tp).
-		Limit(limit, start).
-		Table("repository").
-		Find(&ids)
-	return ids, err
-}

--- a/models/repo.go
+++ b/models/repo.go
@@ -32,6 +32,7 @@ import (
 	"code.gitea.io/gitea/modules/options"
 	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/sync"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -137,16 +138,17 @@ const (
 
 // Repository represents a git repository.
 type Repository struct {
-	ID            int64  `xorm:"pk autoincr"`
-	OwnerID       int64  `xorm:"UNIQUE(s) index"`
-	OwnerName     string `xorm:"-"`
-	Owner         *User  `xorm:"-"`
-	LowerName     string `xorm:"UNIQUE(s) INDEX NOT NULL"`
-	Name          string `xorm:"INDEX NOT NULL"`
-	Description   string `xorm:"TEXT"`
-	Website       string `xorm:"VARCHAR(2048)"`
-	OriginalURL   string `xorm:"VARCHAR(2048)"`
-	DefaultBranch string
+	ID                  int64                  `xorm:"pk autoincr"`
+	OwnerID             int64                  `xorm:"UNIQUE(s) index"`
+	OwnerName           string                 `xorm:"-"`
+	Owner               *User                  `xorm:"-"`
+	LowerName           string                 `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	Name                string                 `xorm:"INDEX NOT NULL"`
+	Description         string                 `xorm:"TEXT"`
+	Website             string                 `xorm:"VARCHAR(2048)"`
+	OriginalServiceType structs.GitServiceType `xorm:"index"`
+	OriginalURL         string                 `xorm:"VARCHAR(2048)"`
+	DefaultBranch       string
 
 	NumWatches          int
 	NumStars            int
@@ -2779,4 +2781,11 @@ func (repo *Repository) GetOriginalURLHostname() string {
 	}
 
 	return u.Host
+}
+
+// FindMigratedRepositoryIDs find all migrated
+func FindMigratedRepositoryIDs(tp structs.GitServiceType) ([]int64, error) {
+	var ids []int64
+	err := x.Select("id").Where("original_service_type = ?", tp).Table("repository").Find(&ids)
+	return ids, err
 }

--- a/models/repo.go
+++ b/models/repo.go
@@ -2784,8 +2784,12 @@ func (repo *Repository) GetOriginalURLHostname() string {
 }
 
 // FindMigratedRepositoryIDs find all migrated
-func FindMigratedRepositoryIDs(tp structs.GitServiceType) ([]int64, error) {
+func FindMigratedRepositoryIDs(tp structs.GitServiceType, limit, start int) ([]int64, error) {
 	var ids []int64
-	err := x.Select("id").Where("original_service_type = ?", tp).Table("repository").Find(&ids)
+	err := x.Select("id").
+		Where("original_service_type = ?", tp).
+		Limit(limit, start).
+		Table("repository").
+		Find(&ids)
 	return ids, err
 }

--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -5,6 +5,8 @@
 
 package base
 
+import "code.gitea.io/gitea/modules/structs"
+
 // Downloader downloads the site repo informations
 type Downloader interface {
 	GetRepoInfo() (*Repository, error)
@@ -21,4 +23,5 @@ type Downloader interface {
 type DownloaderFactory interface {
 	Match(opts MigrateOptions) (bool, error)
 	New(opts MigrateOptions) (Downloader, error)
+	GitServiceType() structs.GitServiceType
 }

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -43,6 +43,7 @@ type GiteaLocalUploader struct {
 	issues      sync.Map
 	gitRepo     *git.Repository
 	prHeadCache map[string]struct{}
+	userMap     map[int64]int64 // external user id mapping to user id
 }
 
 // NewGiteaLocalUploader creates an gitea Uploader via gitea API v1
@@ -109,13 +110,15 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, opts base.Migrate
 	}
 
 	r, err = models.MigrateRepositoryGitData(g.doer, owner, r, structs.MigrateRepoOption{
-		RepoName:    g.repoName,
-		Description: repo.Description,
-		Mirror:      repo.IsMirror,
-		CloneAddr:   remoteAddr,
-		Private:     repo.IsPrivate,
-		Wiki:        opts.Wiki,
-		Releases:    opts.Releases, // if didn't get releases, then sync them from tags
+		RepoName:       g.repoName,
+		Description:    repo.Description,
+		OriginalURL:    repo.OriginalURL,
+		GitServiceType: opts.GitServiceType,
+		Mirror:         repo.IsMirror,
+		CloneAddr:      remoteAddr,
+		Private:        repo.IsPrivate,
+		Wiki:           opts.Wiki,
+		Releases:       opts.Releases, // if didn't get releases, then sync them from tags
 	})
 
 	g.repo = r
@@ -284,20 +287,38 @@ func (g *GiteaLocalUploader) CreateIssues(issues ...*base.Issue) error {
 		}
 
 		var is = models.Issue{
-			RepoID:           g.repo.ID,
-			Repo:             g.repo,
-			Index:            issue.Number,
-			PosterID:         g.doer.ID,
-			OriginalAuthor:   issue.PosterName,
-			OriginalAuthorID: issue.PosterID,
-			Title:            issue.Title,
-			Content:          issue.Content,
-			IsClosed:         issue.State == "closed",
-			IsLocked:         issue.IsLocked,
-			MilestoneID:      milestoneID,
-			Labels:           labels,
-			CreatedUnix:      timeutil.TimeStamp(issue.Created.Unix()),
+			RepoID:      g.repo.ID,
+			Repo:        g.repo,
+			Index:       issue.Number,
+			Title:       issue.Title,
+			Content:     issue.Content,
+			IsClosed:    issue.State == "closed",
+			IsLocked:    issue.IsLocked,
+			MilestoneID: milestoneID,
+			Labels:      labels,
+			CreatedUnix: timeutil.TimeStamp(issue.Created.Unix()),
 		}
+
+		userid, ok := g.userMap[issue.PosterID]
+		if !ok {
+			var err error
+			userid, err = models.GetUserIDByExternalUserID("github", fmt.Sprintf("%v", issue.PosterID))
+			if err != nil {
+				log.Error("GetUserIDByExternalUserID: %v", err)
+			}
+			if userid > 0 {
+				g.userMap[issue.PosterID] = userid
+			}
+		}
+
+		if userid > 0 {
+			is.PosterID = userid
+		} else {
+			is.PosterID = g.doer.ID
+			is.OriginalAuthor = issue.PosterName
+			is.OriginalAuthorID = issue.PosterID
+		}
+
 		if issue.Closed != nil {
 			is.ClosedUnix = timeutil.TimeStamp(issue.Closed.Unix())
 		}
@@ -331,15 +352,34 @@ func (g *GiteaLocalUploader) CreateComments(comments ...*base.Comment) error {
 			issueID = issueIDStr.(int64)
 		}
 
-		cms = append(cms, &models.Comment{
-			IssueID:          issueID,
-			Type:             models.CommentTypeComment,
-			PosterID:         g.doer.ID,
-			OriginalAuthor:   comment.PosterName,
-			OriginalAuthorID: comment.PosterID,
-			Content:          comment.Content,
-			CreatedUnix:      timeutil.TimeStamp(comment.Created.Unix()),
-		})
+		userid, ok := g.userMap[comment.PosterID]
+		if !ok {
+			var err error
+			userid, err = models.GetUserIDByExternalUserID("github", fmt.Sprintf("%v", comment.PosterID))
+			if err != nil {
+				log.Error("GetUserIDByExternalUserID: %v", err)
+			}
+			if userid > 0 {
+				g.userMap[comment.PosterID] = userid
+			}
+		}
+
+		cm := models.Comment{
+			IssueID:     issueID,
+			Type:        models.CommentTypeComment,
+			Content:     comment.Content,
+			CreatedUnix: timeutil.TimeStamp(comment.Created.Unix()),
+		}
+
+		if userid > 0 {
+			cm.PosterID = userid
+		} else {
+			cm.PosterID = g.doer.ID
+			cm.OriginalAuthor = comment.PosterName
+			cm.OriginalAuthorID = comment.PosterID
+		}
+
+		cms = append(cms, &cm)
 
 		// TODO: Reactions
 	}
@@ -460,6 +500,40 @@ func (g *GiteaLocalUploader) newPullRequest(pr *base.PullRequest) (*models.PullR
 		head = pr.Head.Ref
 	}
 
+	var issue = models.Issue{
+		RepoID:      g.repo.ID,
+		Repo:        g.repo,
+		Title:       pr.Title,
+		Index:       pr.Number,
+		Content:     pr.Content,
+		MilestoneID: milestoneID,
+		IsPull:      true,
+		IsClosed:    pr.State == "closed",
+		IsLocked:    pr.IsLocked,
+		Labels:      labels,
+		CreatedUnix: timeutil.TimeStamp(pr.Created.Unix()),
+	}
+
+	userid, ok := g.userMap[pr.PosterID]
+	if !ok {
+		var err error
+		userid, err = models.GetUserIDByExternalUserID("github", fmt.Sprintf("%v", pr.PosterID))
+		if err != nil {
+			log.Error("GetUserIDByExternalUserID: %v", err)
+		}
+		if userid > 0 {
+			g.userMap[pr.PosterID] = userid
+		}
+	}
+
+	if userid > 0 {
+		issue.PosterID = userid
+	} else {
+		issue.PosterID = g.doer.ID
+		issue.OriginalAuthor = pr.PosterName
+		issue.OriginalAuthorID = pr.PosterID
+	}
+
 	var pullRequest = models.PullRequest{
 		HeadRepoID:   g.repo.ID,
 		HeadBranch:   head,
@@ -470,22 +544,7 @@ func (g *GiteaLocalUploader) newPullRequest(pr *base.PullRequest) (*models.PullR
 		Index:        pr.Number,
 		HasMerged:    pr.Merged,
 
-		Issue: &models.Issue{
-			RepoID:           g.repo.ID,
-			Repo:             g.repo,
-			Title:            pr.Title,
-			Index:            pr.Number,
-			PosterID:         g.doer.ID,
-			OriginalAuthor:   pr.PosterName,
-			OriginalAuthorID: pr.PosterID,
-			Content:          pr.Content,
-			MilestoneID:      milestoneID,
-			IsPull:           true,
-			IsClosed:         pr.State == "closed",
-			IsLocked:         pr.IsLocked,
-			Labels:           labels,
-			CreatedUnix:      timeutil.TimeStamp(pr.Created.Unix()),
-		},
+		Issue: &issue,
 	}
 
 	if pullRequest.Issue.IsClosed && pr.Closed != nil {

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -14,6 +14,7 @@ import (
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations/base"
+	"code.gitea.io/gitea/modules/structs"
 
 	"github.com/google/go-github/v24/github"
 	"golang.org/x/oauth2"
@@ -56,6 +57,11 @@ func (f *GithubDownloaderV3Factory) New(opts base.MigrateOptions) (base.Download
 	log.Trace("Create github downloader: %s/%s", oldOwner, oldName)
 
 	return NewGithubDownloaderV3(opts.AuthUsername, opts.AuthPassword, oldOwner, oldName), nil
+}
+
+// GitServiceType returns the type of git service
+func (f *GithubDownloaderV3Factory) GitServiceType() structs.GitServiceType {
+	return structs.GithubService
 }
 
 // GithubDownloaderV3 implements a Downloader interface to get repository informations

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -40,7 +40,7 @@ func (f *GithubDownloaderV3Factory) Match(opts base.MigrateOptions) (bool, error
 		return false, err
 	}
 
-	return u.Host == "github.com" && opts.AuthUsername != "", nil
+	return strings.EqualFold(u.Host, "github.com") && opts.AuthUsername != "", nil
 }
 
 // New returns a Downloader related to this factory according MigrateOptions

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -58,10 +58,8 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 		opts.GitServiceType = structs.PlainGitService
 		downloader = NewPlainGitDownloader(ownerName, opts.RepoName, opts.CloneAddr)
 		log.Trace("Will migrate from git: %s", opts.CloneAddr)
-	} else {
-		if opts.GitServiceType == structs.NotMigrated {
-			opts.GitServiceType = theFactory.GitServiceType()
-		}
+	} else if opts.GitServiceType == structs.NotMigrated {
+		opts.GitServiceType = theFactory.GitServiceType()
 	}
 
 	uploader.gitServiceType = opts.GitServiceType

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations/base"
+	"code.gitea.io/gitea/modules/structs"
 )
 
 // MigrateOptions is equal to base.MigrateOptions
@@ -30,6 +31,7 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 	var (
 		downloader base.Downloader
 		uploader   = NewGiteaLocalUploader(doer, ownerName, opts.RepoName)
+		theFactory base.DownloaderFactory
 	)
 
 	for _, factory := range factories {
@@ -40,6 +42,7 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 			if err != nil {
 				return nil, err
 			}
+			theFactory = factory
 			break
 		}
 	}
@@ -52,10 +55,16 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 		opts.Comments = false
 		opts.Issues = false
 		opts.PullRequests = false
+		opts.GitServiceType = structs.PlainGitService
 		downloader = NewPlainGitDownloader(ownerName, opts.RepoName, opts.CloneAddr)
 		log.Trace("Will migrate from git: %s", opts.CloneAddr)
+	} else {
+		if opts.GitServiceType == structs.NotMigrated {
+			opts.GitServiceType = theFactory.GitServiceType()
+		}
 	}
 
+	uploader.gitServiceType = opts.GitServiceType
 	if err := migrateRepository(downloader, uploader, opts); err != nil {
 		if err1 := uploader.Rollback(); err1 != nil {
 			log.Error("rollback failed: %v", err1)

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -13,9 +13,5 @@ func UpdateGithubMigrations(repoID, githubUserID, userID int64) error {
 		return err
 	}
 
-	if err := models.UpdateCommentsMigrations(repoID, githubUserID, userID); err != nil {
-		return err
-	}
-
-	return nil
+	return models.UpdateCommentsMigrations(repoID, githubUserID, userID)
 }

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import "code.gitea.io/gitea/models"
+
+// UpdateGithubMigrations will update posterid on issues/comments/prs when github user
+// login or when migrating
+func UpdateGithubMigrations(repoID, githubUserID, userID int64) error {
+	if err := models.UpdateIssuesMigrations(repoID, githubUserID, userID); err != nil {
+		return err
+	}
+
+	if err := models.UpdateCommentsMigrations(repoID, githubUserID, userID); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -46,7 +46,7 @@ func updateMigrationPosterIDByGitService(tp structs.GitServiceType) error {
 				continue
 			}
 			if err := models.UpdateMigrationsByType(tp, externalUserID, user.UserID); err != nil {
-				log.Error("UpdateMigrationsByType type %v, github user id %v, user id %v failed: %v", tp, user.ExternalID, user.UserID, err)
+				log.Error("UpdateMigrationsByType type %s external user id %v to local user id %v failed: %v", tp.Name(), user.ExternalID, user.UserID, err)
 			}
 		}
 

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -4,14 +4,78 @@
 
 package migrations
 
-import "code.gitea.io/gitea/models"
+import (
+	"strconv"
 
-// UpdateGithubMigrations will update posterid on issues/comments/prs when github user
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/structs"
+)
+
+// UpdateRepoMigrations will update posterid on issues/comments/prs when external login user
 // login or when migrating
-func UpdateGithubMigrations(repoID, githubUserID, userID int64) error {
-	if err := models.UpdateIssuesMigrations(repoID, githubUserID, userID); err != nil {
+func UpdateRepoMigrations(repoID, externalUserID, userID int64) error {
+	if err := models.UpdateIssuesMigrations(repoID, externalUserID, userID); err != nil {
 		return err
 	}
 
-	return models.UpdateCommentsMigrations(repoID, githubUserID, userID)
+	return models.UpdateCommentsMigrations(repoID, externalUserID, userID)
+}
+
+// UpdateMigrationPosterID updates all migrated repositories' issues and comments posterID
+func UpdateMigrationPosterID() {
+	if err := updateMigrationPosterIDByGitService(structs.GithubService); err != nil {
+		log.Error("updateMigrationPosterIDByGitService failed: %v", err)
+	}
+}
+
+func updateMigrationPosterIDByGitService(tp structs.GitServiceType) error {
+	provider := tp.Name()
+	if len(provider) == 0 {
+		return nil
+	}
+
+	var repoStart int
+	const batchSize = 100
+	for {
+		ids, err := models.FindMigratedRepositoryIDs(tp, batchSize, repoStart)
+		if err != nil {
+			return err
+		}
+
+		var start int
+		for {
+			users, err := models.FindExternalUsersByProvider(models.FindExternalUserOptions{
+				Provider: provider,
+				Start:    start,
+				Limit:    batchSize,
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, user := range users {
+				externalUserID, err := strconv.ParseInt(user.ExternalID, 10, 64)
+				if err != nil {
+					log.Warn("Parse externalUser %#v 's userID failed: %v", user, err)
+					continue
+				}
+				for _, id := range ids {
+					if err = UpdateRepoMigrations(id, externalUserID, user.UserID); err != nil {
+						log.Error("UpdateRepoMigrations repo %v, github user id %v, user id %v failed: %v", id, user.ExternalID, user.UserID, err)
+					}
+				}
+			}
+
+			if len(users) < batchSize {
+				break
+			}
+			start += len(users)
+		}
+
+		if len(ids) < batchSize {
+			return nil
+		}
+		repoStart += len(ids)
+	}
 }

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -14,8 +14,10 @@ import (
 
 // UpdateMigrationPosterID updates all migrated repositories' issues and comments posterID
 func UpdateMigrationPosterID() {
-	if err := updateMigrationPosterIDByGitService(structs.GithubService); err != nil {
-		log.Error("updateMigrationPosterIDByGitService failed: %v", err)
+	for _, gitService := range structs.SupportedFullGitService {
+		if err := updateMigrationPosterIDByGitService(gitService); err != nil {
+			log.Error("updateMigrationPosterIDByGitService failed: %v", err)
+		}
 	}
 }
 

--- a/modules/setting/cron.go
+++ b/modules/setting/cron.go
@@ -120,7 +120,7 @@ var (
 		UpdateMigrationPosterID: struct {
 			Schedule string
 		}{
-			Schedule: "@every 10m",
+			Schedule: "@every 24h",
 		},
 	}
 )

--- a/modules/setting/cron.go
+++ b/modules/setting/cron.go
@@ -49,6 +49,9 @@ var (
 			Schedule   string
 			OlderThan  time.Duration
 		} `ini:"cron.deleted_branches_cleanup"`
+		UpdateMigrationPosterID struct {
+			Schedule string
+		} `ini:"cron.update_migration_poster_id"`
 	}{
 		UpdateMirror: struct {
 			Enabled    bool
@@ -113,6 +116,11 @@ var (
 			RunAtStart: true,
 			Schedule:   "@every 24h",
 			OlderThan:  24 * time.Hour,
+		},
+		UpdateMigrationPosterID: struct {
+			Schedule string
+		}{
+			Schedule: "@every 10m",
 		},
 	}
 )

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -176,6 +176,8 @@ func (gt GitServiceType) Name() string {
 		return "gitea"
 	case GitlabService:
 		return "gitlab"
+	case GogsService:
+		return "gogs"
 	}
 	return ""
 }

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -153,15 +153,17 @@ type EditRepoOption struct {
 	Archived *bool `json:"archived,omitempty"`
 }
 
-// GitServiceType
+// GitServiceType represents a git service
 type GitServiceType int
 
+// enumerate all GitServiceType
 const (
-	PlainGitService GitServiceType = iota // 0 plain git service
-	GithubService                         // 1 github.com
-	GiteaService                          // 2 gitea service
-	GitlabService                         // 3 gitlab service
-	GogsService                           // 4 gogs service
+	NotMigrated     GitServiceType = iota // 0 not migrated from external sites
+	PlainGitService                       // 1 plain git service
+	GithubService                         // 2 github.com
+	GiteaService                          // 3 gitea service
+	GitlabService                         // 4 gitlab service
+	GogsService                           // 5 gogs service
 )
 
 // MigrateRepoOption options for migrating a repository from an external service

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -183,7 +183,7 @@ func (gt GitServiceType) Name() string {
 }
 
 var (
-	// all git services supported to migrate issues/labels/prs and etc.
+	// SupportedFullGitService represents all git services supported to migrate issues/labels/prs and etc.
 	// TODO: add to this list after new git service added
 	SupportedFullGitService = []GitServiceType{
 		GithubService,

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -153,6 +153,17 @@ type EditRepoOption struct {
 	Archived *bool `json:"archived,omitempty"`
 }
 
+// GitServiceType
+type GitServiceType int
+
+const (
+	PlainGitService GitServiceType = iota // 0 plain git service
+	GithubService                         // 1 github.com
+	GiteaService                          // 2 gitea service
+	GitlabService                         // 3 gitlab service
+	GogsService                           // 4 gogs service
+)
+
 // MigrateRepoOption options for migrating a repository from an external service
 type MigrateRepoOption struct {
 	// required: true
@@ -166,6 +177,8 @@ type MigrateRepoOption struct {
 	Mirror          bool   `json:"mirror"`
 	Private         bool   `json:"private"`
 	Description     string `json:"description"`
+	OriginalURL     string
+	GitServiceType  GitServiceType
 	Wiki            bool
 	Issues          bool
 	Milestones      bool

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -166,6 +166,20 @@ const (
 	GogsService                           // 5 gogs service
 )
 
+// Name represents the service type's name
+// WARNNING: the name have to be equal to that on goth's library
+func (gt GitServiceType) Name() string {
+	switch gt {
+	case GithubService:
+		return "github"
+	case GiteaService:
+		return "gitea"
+	case GitlabService:
+		return "gitlab"
+	}
+	return ""
+}
+
 // MigrateRepoOption options for migrating a repository from an external service
 type MigrateRepoOption struct {
 	// required: true

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -180,6 +180,14 @@ func (gt GitServiceType) Name() string {
 	return ""
 }
 
+var (
+	// all git services supported to migrate issues/labels/prs and etc.
+	// TODO: add to this list after new git service added
+	SupportedFullGitService = []GitServiceType{
+		GithubService,
+	}
+)
+
 // MigrateRepoOption options for migrating a repository from an external service
 type MigrateRepoOption struct {
 	// required: true

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -8,6 +8,7 @@ package repo
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"code.gitea.io/gitea/models"
@@ -399,8 +400,8 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 	}
 
 	var gitServiceType = structs.PlainGitService
-	// TODO: this should be chosen by UI when from a customerize git service domain
-	if strings.HasPrefix(remoteAddr, "https://github.com") || strings.HasPrefix(remoteAddr, "http://github.com") {
+	u, err := url.Parse(remoteAddr)
+	if err == nil && strings.EqualFold(u.Host, "github.com") {
 		gitServiceType = structs.GithubService
 	}
 

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -17,6 +17,7 @@ import (
 	"code.gitea.io/gitea/modules/migrations"
 	"code.gitea.io/gitea/modules/notification"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/validation"
@@ -397,21 +398,28 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 		return
 	}
 
+	var gitServiceType = structs.PlainGitService
+	// TODO: this should be chosen by UI when from a customerize git service domain
+	if strings.HasPrefix(remoteAddr, "https://github.com") || strings.HasPrefix(remoteAddr, "http://github.com") {
+		gitServiceType = structs.GithubService
+	}
+
 	var opts = migrations.MigrateOptions{
-		CloneAddr:    remoteAddr,
-		RepoName:     form.RepoName,
-		Description:  form.Description,
-		Private:      form.Private || setting.Repository.ForcePrivate,
-		Mirror:       form.Mirror,
-		AuthUsername: form.AuthUsername,
-		AuthPassword: form.AuthPassword,
-		Wiki:         form.Wiki,
-		Issues:       form.Issues,
-		Milestones:   form.Milestones,
-		Labels:       form.Labels,
-		Comments:     true,
-		PullRequests: form.PullRequests,
-		Releases:     form.Releases,
+		CloneAddr:      remoteAddr,
+		RepoName:       form.RepoName,
+		Description:    form.Description,
+		Private:        form.Private || setting.Repository.ForcePrivate,
+		Mirror:         form.Mirror,
+		AuthUsername:   form.AuthUsername,
+		AuthPassword:   form.AuthPassword,
+		Wiki:           form.Wiki,
+		Issues:         form.Issues,
+		Milestones:     form.Milestones,
+		Labels:         form.Labels,
+		Comments:       true,
+		PullRequests:   form.PullRequests,
+		Releases:       form.Releases,
+		GitServiceType: gitServiceType,
 	}
 	if opts.Mirror {
 		opts.Issues = false

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -18,7 +18,6 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/log"
-	"code.gitea.io/gitea/modules/migrations"
 	"code.gitea.io/gitea/modules/recaptcha"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
@@ -604,51 +603,57 @@ func handleOAuth2SignIn(u *models.User, gothUser goth.User, ctx *context.Context
 	// Instead, redirect them to the 2FA authentication page.
 	_, err = models.GetTwoFactorByUID(u.ID)
 	if err != nil {
-		if models.IsErrTwoFactorNotEnrolled(err) {
-			err = ctx.Session.Set("uid", u.ID)
+		if !models.IsErrTwoFactorNotEnrolled(err) {
+			ctx.ServerError("UserSignIn", err)
+			return
+		}
+
+		err = ctx.Session.Set("uid", u.ID)
+		if err != nil {
+			log.Error(fmt.Sprintf("Error setting session: %v", err))
+		}
+		err = ctx.Session.Set("uname", u.Name)
+		if err != nil {
+			log.Error(fmt.Sprintf("Error setting session: %v", err))
+		}
+
+		// Clear whatever CSRF has right now, force to generate a new one
+		ctx.SetCookie(setting.CSRFCookieName, "", -1, setting.AppSubURL, setting.SessionConfig.Domain, setting.SessionConfig.Secure, true)
+
+		// Register last login
+		u.SetLastLogin()
+		if err := models.UpdateUserCols(u, "last_login_unix"); err != nil {
+			ctx.ServerError("UpdateUserCols", err)
+			return
+		}
+
+		// update user's migrated comments and issues original id
+		if gothUser.Provider == "github" {
+			ids, err := models.FindMigratedRepositoryIDs(structs.GithubService)
 			if err != nil {
-				log.Error(fmt.Sprintf("Error setting session: %v", err))
-			}
-			err = ctx.Session.Set("uname", u.Name)
-			if err != nil {
-				log.Error(fmt.Sprintf("Error setting session: %v", err))
-			}
-
-			// Clear whatever CSRF has right now, force to generate a new one
-			ctx.SetCookie(setting.CSRFCookieName, "", -1, setting.AppSubURL, setting.SessionConfig.Domain, setting.SessionConfig.Secure, true)
-
-			// Register last login
-			u.SetLastLogin()
-			if err := models.UpdateUserCols(u, "last_login_unix"); err != nil {
-				ctx.ServerError("UpdateUserCols", err)
-				return
-			}
-
-			if redirectTo := ctx.GetCookie("redirect_to"); len(redirectTo) > 0 {
-				ctx.SetCookie("redirect_to", "", -1, setting.AppSubURL, "", setting.SessionConfig.Secure, true)
-				ctx.RedirectToFirst(redirectTo)
-				return
-			}
-
-			// update user's migrated comments and issues original id
-			if gothUser.Provider == "github" {
-				ids, err := models.FindMigratedRepositoryIDs(structs.GithubService)
-				if err != nil {
-					log.Error("FindMigratedRepositoryIDs failed: %v", err)
-				} else {
-					for _, id := range ids {
-						userID, _ := strconv.ParseInt(gothUser.UserID, 10, 64)
-						if err = migrations.UpdateGithubMigrations(id, userID, u.ID); err != nil {
-							log.Error("UpdateGithubMigrations repo %v, github user id %v, user id %v failed: %v", id, gothUser.UserID, u.ID, err)
-						}
+				log.Error("FindMigratedRepositoryIDs failed: %v", err)
+			} else {
+				for _, id := range ids {
+					userID, _ := strconv.ParseInt(gothUser.UserID, 10, 64)
+					if err = migrations.UpdateGithubMigrations(id, userID, u.ID); err != nil {
+						log.Error("UpdateGithubMigrations repo %v, github user id %v, user id %v failed: %v", id, gothUser.UserID, u.ID, err)
 					}
 				}
 			}
-
-			ctx.Redirect(setting.AppSubURL + "/")
-		} else {
-			ctx.ServerError("UserSignIn", err)
 		}
+
+		// update external user information
+		if err := models.UpdateExternalUser(u, gothUser); err != nil {
+			log.Error("UpdateExternalUser failed: %v", err)
+		}
+
+		if redirectTo := ctx.GetCookie("redirect_to"); len(redirectTo) > 0 {
+			ctx.SetCookie("redirect_to", "", -1, setting.AppSubURL, "", setting.SessionConfig.Secure, true)
+			ctx.RedirectToFirst(redirectTo)
+			return
+		}
+
+		ctx.Redirect(setting.AppSubURL + "/")
 		return
 	}
 
@@ -693,7 +698,7 @@ func oAuth2UserLoginCallback(loginSource *models.LoginSource, request *http.Requ
 	}
 
 	if hasUser {
-		return user, goth.User{}, nil
+		return user, gothUser, nil
 	}
 
 	// search in external linked users
@@ -707,7 +712,7 @@ func oAuth2UserLoginCallback(loginSource *models.LoginSource, request *http.Requ
 	}
 	if hasUser {
 		user, err = models.GetUserByID(externalLoginUser.UserID)
-		return user, goth.User{}, err
+		return user, gothUser, err
 	}
 
 	// no user found to login
@@ -807,16 +812,18 @@ func LinkAccountPostSignIn(ctx *context.Context, signInForm auth.SignInForm) {
 	// Instead, redirect them to the 2FA authentication page.
 	_, err = models.GetTwoFactorByUID(u.ID)
 	if err != nil {
-		if models.IsErrTwoFactorNotEnrolled(err) {
-			err = models.LinkAccountToUser(u, gothUser.(goth.User))
-			if err != nil {
-				ctx.ServerError("UserLinkAccount", err)
-			} else {
-				handleSignIn(ctx, u, signInForm.Remember)
-			}
-		} else {
+		if !models.IsErrTwoFactorNotEnrolled(err) {
 			ctx.ServerError("UserLinkAccount", err)
+			return
 		}
+
+		err = models.LinkAccountToUser(u, gothUser.(goth.User))
+		if err != nil {
+			ctx.ServerError("UserLinkAccount", err)
+			return
+		}
+
+		handleSignIn(ctx, u, signInForm.Remember)
 		return
 	}
 
@@ -963,6 +970,11 @@ func LinkAccountPostRegister(ctx *context.Context, cpt *captcha.Captcha, form au
 			ctx.ServerError("UpdateUser", err)
 			return
 		}
+	}
+
+	// update external user information
+	if err := models.UpdateExternalUser(u, gothUser.(goth.User)); err != nil {
+		log.Error("UpdateExternalUser failed: %v", err)
 	}
 
 	// Send confirmation email

--- a/services/externalaccount/user.go
+++ b/services/externalaccount/user.go
@@ -1,3 +1,7 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package externalaccount
 
 import (

--- a/services/externalaccount/user.go
+++ b/services/externalaccount/user.go
@@ -1,0 +1,62 @@
+package externalaccount
+
+import (
+	"strconv"
+	"strings"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/structs"
+
+	"github.com/markbates/goth"
+)
+
+// LinkAccountToUser link the gothUser to the user
+func LinkAccountToUser(user *models.User, gothUser goth.User) error {
+	loginSource, err := models.GetActiveOAuth2LoginSourceByName(gothUser.Provider)
+	if err != nil {
+		return err
+	}
+
+	externalLoginUser := &models.ExternalLoginUser{
+		ExternalID:        gothUser.UserID,
+		UserID:            user.ID,
+		LoginSourceID:     loginSource.ID,
+		RawData:           gothUser.RawData,
+		Provider:          gothUser.Provider,
+		Email:             gothUser.Email,
+		Name:              gothUser.Name,
+		FirstName:         gothUser.FirstName,
+		LastName:          gothUser.LastName,
+		NickName:          gothUser.NickName,
+		Description:       gothUser.Description,
+		AvatarURL:         gothUser.AvatarURL,
+		Location:          gothUser.Location,
+		AccessToken:       gothUser.AccessToken,
+		AccessTokenSecret: gothUser.AccessTokenSecret,
+		RefreshToken:      gothUser.RefreshToken,
+		ExpiresAt:         gothUser.ExpiresAt,
+	}
+
+	if err := models.LinkExternalToUser(user, externalLoginUser); err != nil {
+		return err
+	}
+
+	externalID, err := strconv.ParseInt(externalLoginUser.ExternalID, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	var tp structs.GitServiceType
+	for _, s := range structs.SupportedFullGitService {
+		if strings.EqualFold(s.Name(), gothUser.Provider) {
+			tp = s
+			break
+		}
+	}
+
+	if tp.Name() != "" {
+		return models.UpdateMigrationsByType(tp, externalID, user.ID)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR will replace all migrated user info on issues/comments/prs to local user id after user has binded his github account.

Will fix  #7410.

- [x] When migrating a repository from github and he has also binding a github account, then we can assign his issues/pull requests/comments/releases to the local user id instead of a place holder name.

- [x] For those people who binding github account after the migration, we can check that on the background. This will be executed on cron and default `@ervery 24h`.

- [x] When a github user binds his user, all previous migrated issues/pull requests/comments/releases' posterid will be updated.