### PR TITLE
Fix Slack webhook fork message

### DIFF
--- a/models/webhook_slack.go
+++ b/models/webhook_slack.go
@@ -120,8 +120,8 @@ func getSlackDeletePayload(p *api.DeletePayload, slack *SlackMeta) (*SlackPayloa
 
 // getSlackForkPayload composes Slack payload for forked by a repository.
 func getSlackForkPayload(p *api.ForkPayload, slack *SlackMeta) (*SlackPayload, error) {
-	baseLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.Name)
-	forkLink := SlackLinkFormatter(p.Forkee.HTMLURL, p.Forkee.FullName)
+	baseLink := SlackLinkFormatter(p.Forkee.HTMLURL, p.Forkee.FullName)
+	forkLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.FullName)
 	text := fmt.Sprintf("%s is forked to %s", baseLink, forkLink)
 	return &SlackPayload{
 		Channel:  slack.Channel,


### PR DESCRIPTION
The order of forkee and fork was mixed up. I checked the code for other webhooks, and only Slack webhook was affected, other webhooks were doing it right.

I also changed to use full repository names (like other webhooks do).

Before fix (`WGH/test` is the original, `WGH2/test` is the fork):
> [test](http://localhost:3000/WGH2/test) is forked to [WGH/test](http://localhost:3000/WGH/test)

After fix:
> [WGH/test](http://localhost:3000/WGH/test) is forked to [WGH2/test](http://localhost:3000/WGH2/test)
