### PR TITLE
Fix #7736: remove `-i` flag from GOFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BINDATA := modules/{options,public,templates}/bindata.go
 GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*" ! -path "*/bindata.go")
 GOFMT ?= gofmt -s
 
-GOFLAGS := -i -v
+GOFLAGS := -v
 EXTRA_GOFLAGS ?=
 
 MAKE_VERSION := $(shell make -v | head -n 1)


### PR DESCRIPTION
Fix #7736: this flag is not needed for Go versions >=1.10 and creates problems
while building. see https://github.com/golang/go/issues/27285#issuecomment-424382413
