### PR TITLE
Fix Slack webhook fork message (1.9 release backport)

### DIFF
--- a/models/webhook_slack.go
+++ b/models/webhook_slack.go
@@ -120,8 +120,8 @@ func getSlackDeletePayload(p *api.DeletePayload, slack *SlackMeta) (*SlackPayloa
 
 // getSlackForkPayload composes Slack payload for forked by a repository.
 func getSlackForkPayload(p *api.ForkPayload, slack *SlackMeta) (*SlackPayload, error) {
-	baseLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.Name)
-	forkLink := SlackLinkFormatter(p.Forkee.HTMLURL, p.Forkee.FullName)
+	baseLink := SlackLinkFormatter(p.Forkee.HTMLURL, p.Forkee.FullName)
+	forkLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.FullName)
 	text := fmt.Sprintf("%s is forked to %s", baseLink, forkLink)
 	return &SlackPayload{
 		Channel:  slack.Channel,


### PR DESCRIPTION
As requested in https://github.com/go-gitea/gitea/pull/7774#issuecomment-518880265