### PR TITLE
Fix global search result CSS, misc CSS tweaks

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -215,6 +215,23 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .inline-grouped-list{display:inline-block;vertical-align:top}
 .inline-grouped-list>.ui{display:block;margin-top:5px;margin-bottom:10px}
 .inline-grouped-list>.ui:first-child{margin-top:1px}
+.lines-num{vertical-align:top;text-align:right!important;color:#999;background:#f5f5f5;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+.lines-num span{line-height:20px!important;padding:0 10px;cursor:pointer;display:block}
+.lines-code,.lines-num{padding:0!important}
+.lines-code .hljs,.lines-code ol,.lines-code pre,.lines-num .hljs,.lines-num ol,.lines-num pre{background-color:#fff;margin:0;padding:0!important}
+.lines-code .hljs li,.lines-code ol li,.lines-code pre li,.lines-num .hljs li,.lines-num ol li,.lines-num pre li{display:block;width:100%}
+.lines-code .hljs li:before,.lines-code ol li:before,.lines-code pre li:before,.lines-num .hljs li:before,.lines-num ol li:before,.lines-num pre li:before{content:' '}
+.lines-commit{vertical-align:top;color:#999;padding:0!important;background:#f5f5f5;width:1%;-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none}
+.lines-commit .blame-info{width:350px;max-width:350px;display:block;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;padding:0 0 0 10px}
+.lines-commit .blame-info .blame-data{display:flex;font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial}
+.lines-commit .blame-info .blame-data .blame-message{flex-grow:2;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;line-height:20px}
+.lines-commit .blame-info .blame-data .blame-avatar,.lines-commit .blame-info .blame-data .blame-time{flex-shrink:0}
+.lines-commit .ui.avatar.image{height:18px;width:18px}
+.lines-code .bottom-line,.lines-commit .bottom-line,.lines-num .bottom-line{border-bottom:1px solid #eaecef}
+.code-view{overflow:auto;overflow-x:auto;overflow-y:hidden}
+.code-view *{font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}
+.code-view table{width:100%}
+.code-view .active{background:#fff866}
 .markdown:not(code){overflow:hidden;font-size:16px;line-height:1.6!important;word-wrap:break-word}
 .markdown:not(code).ui.segment{padding:3em}
 .markdown:not(code).file-view{padding:2em 2em 2em!important}
@@ -473,23 +490,6 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .repository.file.list .non-diff-file-content .plain-text{padding:1em 2em 1em 2em}
 .repository.file.list .non-diff-file-content .plain-text pre{word-break:break-word;white-space:pre-wrap}
 .repository.file.list .non-diff-file-content pre{overflow:auto}
-.repository.file.list .non-diff-file-content .code-view *{font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}
-.repository.file.list .non-diff-file-content .code-view table{width:100%}
-.repository.file.list .non-diff-file-content .code-view .lines-num{vertical-align:top;text-align:right;color:#999;background:#f5f5f5;width:1%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-.repository.file.list .non-diff-file-content .code-view .lines-num span{line-height:20px;padding:0 10px;cursor:pointer;display:block}
-.repository.file.list .non-diff-file-content .code-view .lines-code,.repository.file.list .non-diff-file-content .code-view .lines-num{padding:0}
-.repository.file.list .non-diff-file-content .code-view .lines-code .hljs,.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-code pre,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs,.repository.file.list .non-diff-file-content .code-view .lines-num ol,.repository.file.list .non-diff-file-content .code-view .lines-num pre{background-color:#fff;margin:0;padding:0!important}
-.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-code ol li,.repository.file.list .non-diff-file-content .code-view .lines-code pre li,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li,.repository.file.list .non-diff-file-content .code-view .lines-num ol li,.repository.file.list .non-diff-file-content .code-view .lines-num pre li{display:block;width:100%}
-.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-code ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-code pre li.active,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li.active,.repository.file.list .non-diff-file-content .code-view .lines-num ol li.active,.repository.file.list .non-diff-file-content .code-view .lines-num pre li.active{background:#ffd}
-.repository.file.list .non-diff-file-content .code-view .lines-code .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-code ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-code pre li:before,.repository.file.list .non-diff-file-content .code-view .lines-num .hljs li:before,.repository.file.list .non-diff-file-content .code-view .lines-num ol li:before,.repository.file.list .non-diff-file-content .code-view .lines-num pre li:before{content:' '}
-.repository.file.list .non-diff-file-content .code-view .lines-commit{vertical-align:top;color:#999;padding:0;background:#f5f5f5;width:1%;-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none}
-.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info{width:350px;max-width:350px;display:block;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;padding:0 0 0 10px}
-.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data{display:flex;font-family:-apple-system,BlinkMacSystemFont,system-ui,'Segoe UI',Roboto,Helvetica,Arial}
-.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-message{flex-grow:2;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;line-height:20px}
-.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-avatar,.repository.file.list .non-diff-file-content .code-view .lines-commit .blame-info .blame-data .blame-time{flex-shrink:0}
-.repository.file.list .non-diff-file-content .code-view .lines-commit .ui.avatar.image{height:18px;width:18px}
-.repository.file.list .non-diff-file-content .code-view .lines-code .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-commit .bottom-line,.repository.file.list .non-diff-file-content .code-view .lines-num .bottom-line{border-bottom:1px solid #eaecef}
-.repository.file.list .non-diff-file-content .code-view .active{background:#ffd}
 .repository.file.list .sidebar{padding-left:0}
 .repository.file.list .sidebar .octicon{width:16px}
 .repository.file.editor .treepath{width:100%}
@@ -659,10 +659,9 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .repository .diff-file-box .file-body.file-code .lines-num span.fold{display:block;text-align:center}
 .repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #ddd}
 .repository .diff-file-box .code-diff{font-size:12px}
-.repository .diff-file-box .code-diff td{padding:0 0 0 10px;border-top:0}
-.repository .diff-file-box .code-diff .lines-num{border-color:#d4d4d5;border-right-width:1px;border-right-style:solid;padding:0 5px}
+.repository .diff-file-box .code-diff td{padding:0 0 0 10px!important;border-top:0}
+.repository .diff-file-box .code-diff .lines-num{border-color:#d4d4d5;border-right-width:1px;border-right-style:solid;padding:0 5px!important}
 .repository .diff-file-box .code-diff tbody tr td.halfwidth{width:49%}
-.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#f0f0f0!important;border-color:#d3cfcf!important;padding-top:8px;padding-bottom:8px}
 .repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#f99}
 .repository .diff-file-box .code-diff tbody tr .added-code{background-color:#9f9}
 .repository .diff-file-box .code-diff tbody tr [data-line-num]::before{content:attr(data-line-num);text-align:right}
@@ -677,7 +676,6 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .repository .diff-file-box .code-diff-split tbody tr td:nth-child(4){border-left-width:1px;border-left-style:solid}
 .repository .diff-file-box.file-content{clear:right}
 .repository .diff-file-box.file-content img{max-width:100%;padding:5px 5px 0 5px}
-.repository .code-view{overflow:auto;overflow-x:auto;overflow-y:hidden}
 .repository .repo-search-result{padding-top:10px;padding-bottom:10px}
 .repository .repo-search-result .lines-num a{color:inherit}
 .repository.quickstart .guide .item{padding:1em}
@@ -848,6 +846,7 @@ tbody.commit-list{vertical-align:baseline}
 .repo-buttons .disabled-repo-button a.button{opacity:.5;cursor:not-allowed}
 .repo-buttons .disabled-repo-button a.button:hover{background:0 0!important;color:rgba(0,0,0,.6)!important;box-shadow:0 0 0 1px rgba(34,36,38,.15) inset!important}
 .repo-buttons .ui.labeled.button>.label{border-left:0!important;margin:0!important}
+.tag-code,.tag-code td{background-color:#f0f0f0!important;border-color:#d3cfcf!important;padding-top:8px;padding-bottom:8px}
 .CodeMirror{font:14px 'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace}
 .CodeMirror.cm-s-default{border-radius:3px;padding:0!important}
 .CodeMirror .cm-comment{background:inherit!important}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -1,5 +1,4 @@
 .hljs{display:block;overflow-x:auto;padding:.5em;color:#bababa}
-.repository.file.list .non-diff-file-content .code-view .lines-code ol,.repository.file.list .non-diff-file-content .code-view .lines-num{background-color:#2b2b2b!important}
 .hljs-emphasis,.hljs-strong{color:#a8a8a2}
 .hljs-bullet,.hljs-link,.hljs-literal,.hljs-number,.hljs-quote,.hljs-regexp{color:#6896ba}
 .hljs-code,.hljs-selector-class{color:#a6e22e}
@@ -90,8 +89,8 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .ui.button:hover{background-color:#404552;color:#dbdbdb}
 .ui.table thead th{background:#404552;color:#dbdbdb}
 .repository.file.list #repo-files-table tr:hover{background-color:#393d4a}
-.ui.table{color:#a5a5a5!important;border:1px solid #4c505c;background:#353945}
-.ui.table tbody tr{border-bottom:1px solid #333640;background:#2a2e3a}
+.ui.table{color:#a5a5a5!important;border-color:#4c505c;background:#353945}
+.ui.table tbody tr{border-color:#333640;background:#2a2e3a}
 .ui .text.grey{color:#808084!important}
 .ui.attached.table.segment{background:#353945;color:#dbdbdb!important}
 .markdown:not(code) h2{border-bottom:1px solid #304251}
@@ -137,13 +136,10 @@ footer{background:#2e323e;border-top:1px solid #313131}
 .repository .diff-file-box .code-diff-unified tbody tr.del-code td{background-color:#3c2626!important;border-color:#634343!important}
 .repository .diff-file-box .code-diff-unified tbody tr.add-code td{background-color:#283e2d!important;border-color:#314a37!important}
 .repository .diff-file-box .code-diff tbody tr .added-code{background-color:#3a523a}
-.repository .diff-file-box .code-diff .lines-num{border-right:1px solid #2d2d2d}
-.repository .diff-file-box .file-body.file-code .lines-num{color:#9e9e9e;background:#2e323e}
-.repository .diff-file-box .file-body.file-code .lines-num-old{border-right:1px solid #2d2d2d}
 .hljs-section,.hljs-selector-id,.hljs-title{color:#986c88}
 .hljs-doctag,.hljs-string{color:#8ab398}
 .repository .diff-file-box .code-diff tbody tr .removed-code{background-color:#5f3737}
-.repository .diff-file-box .code-diff tbody tr td.tag-code,.repository .diff-file-box .code-diff tbody tr.tag-code td{background-color:#292727!important}
+.tag-code,.tag-code td{background:#242637!important;border-color:transparent!important}
 .ui.vertical.menu .active.item{background:#4b5162}
 .ui.vertical.menu .item{background:#353945}
 .ui.vertical.menu .header.item{background:#404552}
@@ -205,18 +201,20 @@ input{background:#2e323e}
 .ui.list .list>.item .header,.ui.list>.item .header{color:#dedede}
 .ui.list .list>.item .description,.ui.list>.item .description{color:#9e9e9e}
 .ui.user.list .item .description a{color:#668cb1}
-.repository.file.list #file-content .code-view .lines-num{background:#2e323e}
 .repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule{color:#7c9b5e}
 .ui.blue.button:focus,.ui.blue.buttons .button:focus{background-color:#a27558}
 .ui.basic.blue.button:hover,.ui.basic.blue.buttons .button:hover{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
 .ui.basic.blue.button:focus,.ui.basic.blue.buttons .button:focus{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
-.repository.file.list #file-content .code-view .lines-code .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}
+.lines-commit{background:#2e323e!important}
+.bottom-line{border-color:#4e525e!important}
+.lines-num{background:#2e323e!important;color:#9e9e9e!important;border-color:#2d2d2d!important}
+.lines-code .hljs,.lines-code ol,.lines-code pre,.lines-num .hljs,.lines-num ol,.lines-num pre{background-color:#2a2e3a!important}
+.code-view .active{background:#554a00}
 a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667!important;color:#dbdbdb!important}
 .repository #commits-table td.sha .sha.label,.repository #repo-files-table .sha.label{border-color:#888}
 .repository #commits-table td.sha .sha.label.isSigned .detail.icon,.repository #repo-files-table .sha.label.isSigned .detail.icon{background:0 0;border-left-color:#888}
 .repository .label.list .item{border-bottom:1px dashed #4c505c}
 .ui.basic.blue.button,.ui.basic.blue.buttons .button{box-shadow:0 0 0 1px #87ab63 inset!important;color:#87ab63!important}
-.repository.file.list #file-content .code-view .hljs,.repository.file.list #file-content .code-view .lines-code ol,.repository.file.list #file-content .code-view .lines-code pre,.repository.file.list #file-content .code-view .lines-num .hljs,.repository.file.list #file-content .code-view .lines-num ol,.repository.file.list #file-content .code-view .lines-num pre{background-color:#2a2e3a}
 .repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(3),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(4),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(5),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(6){background-color:#2a2e3a}
 .repository .diff-file-box .code-diff-split tbody tr td.add-code,.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(4),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(5),.repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(6){background-color:#283e2d!important;border-color:#314a37!important}
 .repository .diff-file-box .code-diff-split tbody tr td.del-code,.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(1),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(2),.repository .diff-file-box .code-diff-split tbody tr.del-code td:nth-child(3){background-color:#3c2626!important;border-color:#634343!important}

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -910,3 +910,112 @@ footer {
         }
     }
 }
+
+.lines-num {
+    vertical-align: top;
+    text-align: right !important;
+    color: #999999;
+    background: #f5f5f5;
+    width: 1%;
+    user-select: none;
+
+    span {
+        line-height: 20px !important;
+        padding: 0 10px;
+        cursor: pointer;
+        display: block;
+    }
+}
+
+.lines-num,
+.lines-code {
+    padding: 0 !important;
+
+    pre,
+    ol,
+    .hljs {
+        background-color: white;
+        margin: 0;
+        padding: 0 !important;
+
+        li {
+            display: block;
+            width: 100%;
+
+            &:before {
+                content: ' ';
+            }
+        }
+    }
+}
+
+.lines-commit {
+    vertical-align: top;
+    color: #999999;
+    padding: 0 !important;
+    background: #f5f5f5;
+    width: 1%;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
+
+    .blame-info {
+        width: 350px;
+        max-width: 350px;
+        display: block;
+        user-select: none;
+        padding: 0 0 0 10px;
+
+        .blame-data {
+            display: flex;
+            font-family: @default-fonts;
+
+            .blame-message {
+                flex-grow: 2;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                line-height: 20px;
+            }
+
+            .blame-time,
+            .blame-avatar {
+                flex-shrink: 0;
+            }
+        }
+    }
+
+    .ui.avatar.image {
+        height: 18px;
+        width: 18px;
+    }
+}
+
+.lines-num,
+.lines-code,
+.lines-commit {
+    .bottom-line {
+        border-bottom: 1px solid #eaecef;
+    }
+}
+
+.code-view {
+    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    * {
+        font-size: 12px;
+        font-family: @monospaced-fonts, monospace;
+        line-height: 20px;
+    }
+
+    table {
+        width: 100%;
+    }
+
+    .active {
+        background: #fff866;
+    }
+}

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -403,115 +403,6 @@
             pre {
                 overflow: auto;
             }
-
-            .code-view {
-                * {
-                    font-size: 12px;
-                    font-family: @monospaced-fonts, monospace;
-                    line-height: 20px;
-                }
-
-                table {
-                    width: 100%;
-                }
-
-                .lines-num {
-                    vertical-align: top;
-                    text-align: right;
-                    color: #999999;
-                    background: #f5f5f5;
-                    width: 1%;
-                    user-select: none;
-
-                    span {
-                        line-height: 20px;
-                        padding: 0 10px;
-                        cursor: pointer;
-                        display: block;
-                    }
-                }
-
-                .lines-num,
-                .lines-code {
-                    padding: 0;
-
-                    pre,
-                    ol,
-                    .hljs {
-                        background-color: white;
-                        margin: 0;
-                        padding: 0 !important;
-
-                        li {
-                            display: block;
-                            width: 100%;
-
-                            &.active {
-                                background: #ffffdd;
-                            }
-
-                            &:before {
-                                content: ' ';
-                            }
-                        }
-                    }
-                }
-
-                .lines-commit {
-                    vertical-align: top;
-                    color: #999999;
-                    padding: 0;
-                    background: #f5f5f5;
-                    width: 1%;
-                    -moz-user-select: none;
-                    -ms-user-select: none;
-                    -webkit-user-select: none;
-                    user-select: none;
-
-                    .blame-info {
-                        width: 350px;
-                        max-width: 350px;
-                        display: block;
-                        user-select: none;
-                        padding: 0 0 0 10px;
-
-                        .blame-data {
-                            display: flex;
-                            font-family: @default-fonts;
-
-                            .blame-message {
-                                flex-grow: 2;
-                                overflow: hidden;
-                                white-space: nowrap;
-                                text-overflow: ellipsis;
-                                line-height: 20px;
-                            }
-
-                            .blame-time,
-                            .blame-avatar {
-                                flex-shrink: 0;
-                            }
-                        }
-                    }
-
-                    .ui.avatar.image {
-                        height: 18px;
-                        width: 18px;
-                    }
-                }
-
-                .lines-num,
-                .lines-code,
-                .lines-commit {
-                    .bottom-line {
-                        border-bottom: 1px solid #eaecef;
-                    }
-                }
-
-                .active {
-                    background: #ffffdd;
-                }
-            }
         }
 
         .sidebar {
@@ -1420,7 +1311,7 @@
             font-size: 12px;
 
             td {
-                padding: 0 0 0 10px;
+                padding: 0 0 0 10px !important;
                 border-top: 0;
             }
 
@@ -1428,7 +1319,7 @@
                 border-color: #d4d4d5;
                 border-right-width: 1px;
                 border-right-style: solid;
-                padding: 0 5px;
+                padding: 0 5px !important;
             }
 
             tbody {
@@ -1437,23 +1328,6 @@
                         // halfwidth is used in split view - and in that case, 1% of each
                         width: 49%;
                     }
-
-                    &.tag-code td,
-                    td.tag-code {
-                        background-color: #f0f0f0 !important;
-                        border-color: #d3cfcf !important;
-                        padding-top: 8px;
-                        padding-bottom: 8px;
-                        // td.selected-line, td.selected-line pre {
-                        //     background-color: #ffffdd !important;
-                        // }
-                    }
-
-                    // &.same-code {
-                    //     td.selected-line, td.selected-line pre {
-                    //         background-color: #ffffdd !important;
-                    //     }
-                    // }
 
                     .removed-code {
                         background-color: #ff9999;
@@ -1545,12 +1419,6 @@
 
             clear: right;
         }
-    }
-
-    .code-view {
-        overflow: auto;
-        overflow-x: auto;
-        overflow-y: hidden;
     }
 
     .repo-search-result {
@@ -2407,4 +2275,12 @@ tbody.commit-list {
 .repo-buttons .ui.labeled.button > .label {
     border-left: 0 !important;
     margin: 0 !important;
+}
+
+.tag-code,
+.tag-code td {
+    background-color: #f0f0f0 !important;
+    border-color: #d3cfcf !important;
+    padding-top: 8px;
+    padding-bottom: 8px;
 }

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -7,11 +7,6 @@
     color: #bababa;
 }
 
-.repository.file.list .non-diff-file-content .code-view .lines-num,
-.repository.file.list .non-diff-file-content .code-view .lines-code ol {
-    background-color: #2b2b2b !important;
-}
-
 .hljs-strong,
 .hljs-emphasis {
     color: #a8a8a2;
@@ -498,12 +493,12 @@ a.ui.basic.green.label:hover {
 
 .ui.table {
     color: #a5a5a5 !important;
-    border: 1px solid #4c505c;
+    border-color: #4c505c;
     background: #353945;
 }
 
 .ui.table tbody tr {
-    border-bottom: 1px solid #333640;
+    border-color: #333640;
     background: #2a2e3a;
 }
 
@@ -714,19 +709,6 @@ a.ui.basic.green.label:hover {
     background-color: #3a523a;
 }
 
-.repository .diff-file-box .code-diff .lines-num {
-    border-right: 1px solid #2d2d2d;
-}
-
-.repository .diff-file-box .file-body.file-code .lines-num {
-    color: #9e9e9e;
-    background: #2e323e;
-}
-
-.repository .diff-file-box .file-body.file-code .lines-num-old {
-    border-right: 1px solid #2d2d2d;
-}
-
 .hljs-title,
 .hljs-section,
 .hljs-selector-id {
@@ -742,9 +724,10 @@ a.ui.basic.green.label:hover {
     background-color: #5f3737;
 }
 
-.repository .diff-file-box .code-diff tbody tr.tag-code td,
-.repository .diff-file-box .code-diff tbody tr td.tag-code {
-    background-color: #292727 !important;
+.tag-code,
+.tag-code td {
+    background: #242637 !important;
+    border-color: transparent !important;
 }
 
 .ui.vertical.menu .active.item {
@@ -1054,10 +1037,6 @@ input {
     color: #668cb1;
 }
 
-.repository.file.list #file-content .code-view .lines-num {
-    background: #2e323e;
-}
-
 .repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,
 .repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule {
     color: #7c9b5e;
@@ -1080,13 +1059,31 @@ input {
     color: #87ab63 !important;
 }
 
-.repository.file.list #file-content .code-view .lines-num pre,
-.repository.file.list #file-content .code-view .lines-code pre,
-.repository.file.list #file-content .code-view .lines-num ol,
-.repository.file.list #file-content .code-view .lines-code ol,
-.repository.file.list #file-content .code-view .lines-num .hljs,
-.repository.file.list #file-content .code-view .lines-code .hljs {
-    background-color: #2a2e3a;
+.lines-commit {
+    background: #2e323e !important;
+}
+
+.bottom-line {
+    border-color: #4e525e !important;
+}
+
+.lines-num {
+    background: #2e323e !important;
+    color: #9e9e9e !important;
+    border-color: #2d2d2d !important;
+}
+
+.lines-num pre,
+.lines-code pre,
+.lines-num ol,
+.lines-code ol,
+.lines-num .hljs,
+.lines-code .hljs {
+    background-color: #2a2e3a !important;
+}
+
+.code-view .active {
+    background: #554a00;
 }
 
 a.ui.label:hover,
@@ -1114,17 +1111,6 @@ a.ui.labels .label:hover {
 .ui.basic.blue.buttons .button {
     box-shadow: 0 0 0 1px #87ab63 inset !important;
     color: #87ab63 !important;
-}
-
-.repository.file.list #file-content .code-view {
-    .lines-num pre,
-    .lines-code pre,
-    .lines-num ol,
-    .lines-code ol,
-    .lines-num .hljs,
-    .hljs {
-        background-color: #2a2e3a;
-    }
 }
 
 .repository .diff-file-box .code-diff-split tbody tr.add-code td:nth-child(1),


### PR DESCRIPTION
- Fixes double line-numbers and padding in Explore > Code > Search
- Moved code-view specific CSS out of their parents to share those styles better.
- Fix misc issues discovered in code,diff and blame view, especially for the dark theme.
- Made yellow highlight in code more apparent

##### Before

<img width="408" src="https://user-images.githubusercontent.com/115237/62662596-df95eb80-b974-11e9-8c9d-56f001acdd68.png">

###### After

<img width="350" src="https://user-images.githubusercontent.com/115237/62662503-98a7f600-b974-11e9-87b2-849b3ccb010f.png">

###### After (dark)

<img width="381" src="https://user-images.githubusercontent.com/115237/62662500-947bd880-b974-11e9-8ccc-66873a67ca73.png">
