### PR TITLE
Correct formatting of bullet list

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -17,6 +17,7 @@ menu:
 
 Gitea supports custom file renderings (i.e., Jupyter notebooks, asciidoc, etc.) through external binaries, 
 it is just a matter of:
+
 * installing external binaries
 * add some configuration to your `app.ini` file
 * restart your Gitea instance


### PR DESCRIPTION
Just a missing blank line; apparently that's what's missing to render that page correctly.

This is [what's online](https://docs.gitea.io/en-us/external-renderers/) right now:

![image](https://user-images.githubusercontent.com/18600385/62673324-6b5b4800-b974-11e9-860e-930c44fd5b1e.png)


This is the expected rendering:


![image](https://user-images.githubusercontent.com/18600385/62673365-8f1e8e00-b974-11e9-9730-b9ef8f647d61.png)
