### PR TITLE
Prevent Commit Status and Message From Overflowing On Branch Page

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -632,7 +632,7 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .repository #commits-table thead .sha{width:140px}
 .repository #commits-table thead .shatd{text-align:center}
 .repository #commits-table td.sha .sha.label{margin:0}
-.repository #commits-table td.message{display:flex;padding-top:0;padding-bottom:0}
+.repository #commits-table td.message{text-overflow:unset}
 .repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n){background-color:rgba(0,0,0,.02)!important}
 .repository #commits-table td.sha .sha.label,.repository #repo-files-table .sha.label{border:1px solid #bbb}
 .repository #commits-table td.sha .sha.label .detail.icon,.repository #repo-files-table .sha.label .detail.icon{background:#fafafa;margin:-6px -10px -4px 0;padding:5px 3px 5px 6px;border-left:1px solid #bbb;border-top-left-radius:0;border-bottom-left-radius:0}
@@ -828,8 +828,8 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .stats-table .table-cell{display:table-cell}
 .stats-table .table-cell.tiny{height:.5em}
 tbody.commit-list{vertical-align:baseline}
-.commit-list .message-wrapper{overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 24px);display:inline-block;vertical-align:middle}
-.commit-list .message-wrapper .commit-status-link{display:inline-block;vertical-align:middle}
+.commit-list .message-wrapper{overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 50px);display:inline-block;vertical-align:middle}
+.commit-list .commit-status-link{display:inline-block;vertical-align:middle}
 .commit-body{white-space:pre-wrap}
 .git-notes.top{text-align:left}
 .git-notes .commit-body{margin:0}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -632,6 +632,7 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .repository #commits-table thead .sha{width:140px}
 .repository #commits-table thead .shatd{text-align:center}
 .repository #commits-table td.sha .sha.label{margin:0}
+.repository #commits-table td.message{display:flex;padding-top:0;padding-bottom:0}
 .repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n){background-color:rgba(0,0,0,.02)!important}
 .repository #commits-table td.sha .sha.label,.repository #repo-files-table .sha.label{border:1px solid #bbb}
 .repository #commits-table td.sha .sha.label .detail.icon,.repository #repo-files-table .sha.label .detail.icon{background:#fafafa;margin:-6px -10px -4px 0;padding:5px 3px 5px 6px;border-left:1px solid #bbb;border-top-left-radius:0;border-bottom-left-radius:0}

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -1265,6 +1265,12 @@
             margin: 0;
         }
 
+        td.message {
+            display: flex;
+            padding-top: 0;
+            padding-bottom: 0;
+        }
+
         &.ui.basic.striped.table tbody tr:nth-child(2n) {
             background-color: rgba(0, 0, 0, 0.02) !important;
         }

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -1266,9 +1266,7 @@
         }
 
         td.message {
-            display: flex;
-            padding-top: 0;
-            padding-bottom: 0;
+            text-overflow: unset;
         }
 
         &.ui.basic.striped.table tbody tr:nth-child(2n) {
@@ -2310,12 +2308,12 @@ tbody.commit-list {
 .commit-list .message-wrapper {
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: calc(100% - 24px);
+    max-width: calc(100% - 50px);
     display: inline-block;
     vertical-align: middle;
 }
 
-.commit-list .message-wrapper .commit-status-link {
+.commit-list .commit-status-link {
     display: inline-block;
     vertical-align: middle;
 }

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -70,14 +70,19 @@
 							</a>
 						</td>
 						<td class="message">
-							<span class="message-wrapper">
-								<span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary}}</span>
-								{{if IsMultilineCommitMessage .Message}}
-								<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
-								<pre class="commit-body" style="display: none;">{{RenderCommitBody .Message $.RepoLink $.Repository.ComposeMetas}}</pre>
-								{{end}}
+						<span class="message-wrapper-parent">
+                                <span class="message-wrapper">
+                                    <span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary}}</span>
+                                </span>
+                                {{if IsMultilineCommitMessage .Message}}
+                                <button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
+                                {{end}}
+                                {{template "repo/commit_status" .Status}}
+                                {{if IsMultilineCommitMessage .Message}}
+                                <pre class="commit-body" style="display: none;">{{RenderCommitBody .Message $.RepoLink $.Repository.ComposeMetas}}</pre>
+                                {{end}}
 							</span>
-							{{template "repo/commit_status" .Status}}
+
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
 					</tr>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -46,11 +46,11 @@
 					<tr>
 						<td class="author">
 							{{if .User}}
-							  {{if .User.FullName}}
+								{{if .User.FullName}}
 								<img class="ui avatar image" src="{{.User.RelAvatarLink}}" alt=""/>&nbsp;&nbsp;<a href="{{AppSubUrl}}/{{.User.Name}}">{{.User.FullName}}</a>
-							  {{else}}
+								{{else}}
 								<img class="ui avatar image" src="{{.User.RelAvatarLink}}" alt=""/>&nbsp;&nbsp;<a href="{{AppSubUrl}}/{{.User.Name}}">{{.Author.Name}}</a>
-							  {{end}}
+								{{end}}
 							{{else}}
 								<img class="ui avatar image" src="{{AvatarLink .Author.Email}}" alt=""/>&nbsp;&nbsp;{{.Author.Name}}
 							{{end}}
@@ -70,19 +70,16 @@
 							</a>
 						</td>
 						<td class="message">
-						<span class="message-wrapper-parent">
-                                <span class="message-wrapper">
-                                    <span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary}}</span>
-                                </span>
-                                {{if IsMultilineCommitMessage .Message}}
-                                <button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
-                                {{end}}
-                                {{template "repo/commit_status" .Status}}
-                                {{if IsMultilineCommitMessage .Message}}
-                                <pre class="commit-body" style="display: none;">{{RenderCommitBody .Message $.RepoLink $.Repository.ComposeMetas}}</pre>
-                                {{end}}
+							<span class="message-wrapper">
+									<span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary}}</span>
 							</span>
-
+							{{if IsMultilineCommitMessage .Message}}
+							<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
+							{{end}}
+							{{template "repo/commit_status" .Status}}
+							{{if IsMultilineCommitMessage .Message}}
+							<pre class="commit-body" style="display: none;">{{RenderCommitBody .Message $.RepoLink $.Repository.ComposeMetas}}</pre>
+							{{end}}
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
 					</tr>


### PR DESCRIPTION
It is possible for the commit ci status
on the branches page for a repository to
become an ellipsis due to overflowing.

This commit will fix that issue by
using flex.

---
It was possible that the commit message would
overflow hiding the expand commits button
and commit status. This change ensures that
the correct elements overflow without hiding
anything else.

This change also reverts using flex in the
commits list because it was causing issues
in Blink based browsers.

---

~~EDIT: There is also an issue with the expand commit message button overflowing as can be seen in both screenshots that this PR does not fix. I separated that into a different PR because it may require a JS change as well. I'll make the PR after this gets merged.~~ Change has been made in this PR with just template changes.

~~EDIT2: Give me a bit. It seems like Blink based browsers have their own unique issues.~~ Issues with Blink have been fixed.

## Before
![Screenshot from 2019-08-09 18-57-23](https://user-images.githubusercontent.com/47195730/62774600-be2c2100-ba94-11e9-9fc5-bbe44d6db16c.png)



## After
![Screenshot from 2019-08-09 18-59-02](https://user-images.githubusercontent.com/47195730/62774608-c6845c00-ba94-11e9-8986-0276539a52fa.png)

