### PR TITLE
Fix lax comparison in validation tests

### DIFF
--- a/modules/validation/binding_test.go
+++ b/modules/validation/binding_test.go
@@ -5,7 +5,6 @@
 package validation
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +36,12 @@ func performValidationTest(t *testing.T, testCase validationTestCase) {
 	m := macaron.Classic()
 
 	m.Post(testRoute, binding.Validate(testCase.data), func(actual binding.Errors) {
-		assert.Equal(t, fmt.Sprintf("%+v", testCase.expectedErrors), fmt.Sprintf("%+v", actual))
+		// see https://github.com/stretchr/testify/issues/435
+		if actual == nil {
+			actual = binding.Errors{}
+		}
+
+		assert.Equal(t, testCase.expectedErrors, actual)
 	})
 
 	req, err := http.NewRequest("POST", testRoute, nil)


### PR DESCRIPTION
If you add `t.Logf("%+v %+v", actual, testCase.expectedErrors)` to
the test code, you'll notice that only Errors' Messages are being
compared:

    --- PASS: Test_ValidURLValidation/Invalid_schema (0.00s)
    binding_test.go:43: [Url] [Url]

`FieldNames` and `Classification` are ignored in comparison.

Moreover, an `Errors` slice with a single `Error` with empty message
is formatted as `[]` (the same as empty slice), which is also
error-prone. I discovered this when working on #7791 when one test which
was not supposed to pass did pass. https://play.golang.org/p/qC4wVLrm4NG

This commit changes the test to do the comparison properly.