### PR TITLE
Enable switching to a different source branch when PR already exists

### DIFF
--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -292,6 +292,13 @@ func CompareDiff(ctx *context.Context) {
 	}
 
 	if ctx.Data["PageIsComparePull"] == true {
+		headBranches, err := headGitRepo.GetBranches()
+		if err != nil {
+			ctx.ServerError("GetBranches", err)
+			return
+		}
+		ctx.Data["HeadBranches"] = headBranches
+
 		pr, err := models.GetUnmergedPullRequest(headRepo.ID, ctx.Repo.Repository.ID, headBranch, baseBranch)
 		if err != nil {
 			if !models.IsErrPullRequestNotExist(err) {
@@ -312,13 +319,6 @@ func CompareDiff(ctx *context.Context) {
 				return
 			}
 		}
-
-		headBranches, err := headGitRepo.GetBranches()
-		if err != nil {
-			ctx.ServerError("GetBranches", err)
-			return
-		}
-		ctx.Data["HeadBranches"] = headBranches
 	}
 	beforeCommitID := ctx.Data["BeforeCommitID"].(string)
 	afterCommitID := ctx.Data["AfterCommitID"].(string)


### PR DESCRIPTION
When comparing two branches where a pull request already exists, the user currently can not select a different source branch due to a missing headBranch list.

Example on try.gitea.io: https://try.gitea.io/saitho/test2/compare/master...conflict