### PR TITLE
[Backport 1.9] Enable switching to a different source branch when PR already exists

### DIFF
--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -292,6 +292,13 @@ func CompareDiff(ctx *context.Context) {
 	}
 
 	if ctx.Data["PageIsComparePull"] == true {
+		headBranches, err := headGitRepo.GetBranches()
+		if err != nil {
+			ctx.ServerError("GetBranches", err)
+			return
+		}
+		ctx.Data["HeadBranches"] = headBranches
+
 		pr, err := models.GetUnmergedPullRequest(headRepo.ID, ctx.Repo.Repository.ID, headBranch, baseBranch)
 		if err != nil {
 			if !models.IsErrPullRequestNotExist(err) {
@@ -312,13 +319,6 @@ func CompareDiff(ctx *context.Context) {
 				return
 			}
 		}
-
-		headBranches, err := headGitRepo.GetBranches()
-		if err != nil {
-			ctx.ServerError("GetBranches", err)
-			return
-		}
-		ctx.Data["HeadBranches"] = headBranches
 	}
 	beforeCommitID := ctx.Data["BeforeCommitID"].(string)
 	afterCommitID := ctx.Data["AfterCommitID"].(string)


### PR DESCRIPTION
Backport of bugfix in #7819 for 1.9