### PR TITLE
gpg/bugfix: Use .ExpiredUnix.IsZero to display green color of forever valid gpg key

### DIFF
--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -16,7 +16,7 @@
 						{{$.i18n.Tr "settings.delete_key"}}
 					</button>
 				</div>
-				<i class="mega-octicon octicon-key {{if or (eq .ExpiredUnix 0) ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
+				<i class="mega-octicon octicon-key {{if or (.ExpiredUnix.IsZero) ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
 				<div class="content">
 					{{range .Emails}}<strong>{{.Email}} </strong>{{end}}
 					<div class="print meta">

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -16,7 +16,7 @@
 						{{$.i18n.Tr "settings.delete_key"}}
 					</button>
 				</div>
-				<i class="mega-octicon octicon-key {{if or (.ExpiredUnix.IsZero) ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
+				<i class="mega-octicon octicon-key {{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
 				<div class="content">
 					{{range .Emails}}<strong>{{.Email}} </strong>{{end}}
 					<div class="print meta">


### PR DESCRIPTION
We need to convert to time object to check if key is valid forever. 
Similar to test later: https://github.com/go-gitea/gitea/pull/7846/files#diff-b39af036c147da90df23fbbd6b50e41fL29

Before: 
![image](https://user-images.githubusercontent.com/4052400/62984850-08b2f200-be35-11e9-9f5f-09377a77fdc2.png)

After:
![image](https://user-images.githubusercontent.com/4052400/62984912-444dbc00-be35-11e9-9540-732250794941.png)

Related : #3153