### PR TITLE
Backport #7846: Use .ExpiredUnix.IsZero to display green color of forever valid gpg key

### DIFF
--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -16,7 +16,7 @@
 						{{$.i18n.Tr "settings.delete_key"}}
 					</button>
 				</div>
-				<i class="mega-octicon octicon-key {{if or (eq .ExpiredUnix 0) ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
+				<i class="mega-octicon octicon-key {{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}"></i>
 				<div class="content">
 					{{range .Emails}}<strong>{{.Email}} </strong>{{end}}
 					<div class="print meta">


### PR DESCRIPTION
Backport #7846