### PR TITLE
drone/docker: prepare multi-arch release + provide arm64 image (#7571)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -558,7 +558,7 @@ steps:
 
 ---
 kind: pipeline
-name: docker
+name: docker-linux-amd64
 
 platform:
   os: linux
@@ -594,6 +594,7 @@ steps:
     settings:
       dry_run: true
       repo: gitea/gitea
+      tags: linux-amd64
     when:
       event:
         - pull_request
@@ -603,6 +604,7 @@ steps:
     image: plugins/docker:linux-amd64
     settings:
       auto_tag: true
+      auto_tag_suffix: linux-amd64
       repo: gitea/gitea
       password:
         from_secret: docker_password
@@ -612,6 +614,97 @@ steps:
       event:
         exclude:
         - pull_request
+
+
+
+---
+kind: pipeline
+name: docker-linux-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+depends_on:
+  - testing
+
+trigger:
+  ref:
+  - refs/heads/master
+  - "refs/tags/**"
+  - "refs/pull/**"
+
+steps:
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
+    when:
+      event:
+        exclude:
+          - pull_request
+
+  - name: dryrun
+    pull: always
+    image: plugins/docker:linux-arm64
+    settings:
+      dry_run: true
+      repo: gitea/gitea
+      tags: linux-arm64
+    when:
+      event:
+        - pull_request
+
+  - name: publish
+    pull: always
+    image: plugins/docker:linux-arm64
+    settings:
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      repo: gitea/gitea
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        exclude:
+        - pull_request
+
+---
+kind: pipeline
+name: docker-manifest
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: manifest
+    pull: always
+    image: plugins/manifest
+    settings:
+      auto_tag: true
+      ignore_missing: true
+      spec: docker/manifest.tmpl
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+
+trigger:
+  ref:
+  - refs/heads/master
+  - "refs/tags/**"
+
+depends_on:
+  - docker-linux-amd64
+  - docker-linux-arm64
 
 ---
 kind: pipeline
@@ -635,7 +728,9 @@ depends_on:
   - translations
   - release-version
   - release-master
-  - docker
+  - docker-linux-amd64
+  - docker-linux-arm64
+  - docker-manifest
   - docs
 
 steps:

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,0 +1,19 @@
+image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8


### PR DESCRIPTION
Backport #7571 and fix #7880

This PR wasn't backported since it wasn't a fix but it seems needed.
I prepare this PR to let you see if we need to backport it.