### PR TITLE
WIP: By-repository mutex to create issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/willf/bitset v0.0.0-20180426185212-8ce1146b8621 // indirect
 	github.com/yohcop/openid-go v0.0.0-20160914080427-2c050d2dae53
+	go.chromium.org/luci v0.0.0-20190816194131-4b600c9efb12
 	go.etcd.io/bbolt v1.3.2 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/yohcop/openid-go v0.0.0-20160914080427-2c050d2dae53 h1:HsIQ6yAjfjQ3Ix
 github.com/yohcop/openid-go v0.0.0-20160914080427-2c050d2dae53/go.mod h1:f6elajwZV+xceiaqgRL090YzLEDGSbqr3poGL3ZgXYo=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
+go.chromium.org/luci v0.0.0-20190816194131-4b600c9efb12 h1:mY6O4bEXDOKJNhqkv17p5Pxjk3hM9RoRPeMc2CJWM2A=
+go.chromium.org/luci v0.0.0-20190816194131-4b600c9efb12/go.mod h1:MIQewVTLvOvc0UioV0JNqTNO/RspKFS0XEeoKrOxsdM=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=

--- a/models/issue.go
+++ b/models/issue.go
@@ -68,13 +68,6 @@ type Issue struct {
 	IsLocked bool `xorm:"NOT NULL DEFAULT false"`
 }
 
-/*
-type repoMutexEntry struct {
-	Mutex    sync.Mutex
-	Waiters  int
-}
-*/
-
 var (
 	issueTasksPat     *regexp.Regexp
 	issueTasksDonePat *regexp.Regexp

--- a/vendor/go.chromium.org/luci/AUTHORS
+++ b/vendor/go.chromium.org/luci/AUTHORS
@@ -1,0 +1,14 @@
+# This is the official list of LUCI authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as one of
+#     Organization's name <fnmatch pattern>
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+# See CONTRIBUTORS for the meaning of multiple email addresses.
+
+# Please keep the list sorted.
+
+Cloudera <*@cloudera.com>
+Google Inc. <*@google.com>

--- a/vendor/go.chromium.org/luci/CONTRIBUTORS
+++ b/vendor/go.chromium.org/luci/CONTRIBUTORS
@@ -1,0 +1,51 @@
+# This is the official list of people who can contribute
+# (and typically have contributed) code to the LUCI project.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# Names should be added to this file only after verifying that
+# the individual or the individual's organization has agreed to
+# the appropriate Contributor License Agreement, found here:
+#
+#     http://code.google.com/legal/individual-cla-v1.0.html
+#     http://code.google.com/legal/corporate-cla-v1.0.html
+#
+# The agreement for individuals can be filled out on the web.
+#
+# When adding J Random Contributor's name to this file,
+# either J's name or J's organization's name should be
+# added to the AUTHORS file, depending on whether the
+# individual or corporate CLA was used.
+
+# Names should be added to this file like so:
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+#
+# An entry with multiple email addresses specifies that the
+# first address should be used in the submit logs and
+# that the other addresses should be recognized as the
+# same person when interacting with Gerrit.
+
+# Please keep the list sorted.
+
+Andrew Wang <andrew.wang@cloudera.com>
+Andrii Shyshkalov <tandrii@chromium.org>
+Dan Jacques <dnj@chromium.org>
+Dave Sansome <dsansome@chromium.org>
+Eric Boren <borenet@chromium.org>
+Erik Staab <estaab@chromium.org>
+Marc-Antoine Ruel <maruel@chromium.org>
+Mike Stipicevic <stip@chromium.org>
+Nodir Turakulov <nodir@chromium.org>
+Paweł Hajdan <phajdan.jr@chromium.org>
+Philippe Gervais <pgervais@chromium.org>
+Robert Iannucci <iannucci@chromium.org>
+Roberto Carrillo <robertocn@chromium.org>
+Roger Tawa <rogerta@chromium.org>
+Ryan Tseng <hinoka@chromium.org>
+Sergey Berezin <sergeyberezin@chromium.org>
+Stephen Martinis <martiniss@chromium.org>
+Todd Lipcon <todd@cloudera.com>
+Vadim Shtayura <vadimsh@chromium.org>
+Yoshisato Yanagisawa <yyanagisawa@chromium.org>

--- a/vendor/go.chromium.org/luci/LICENSE
+++ b/vendor/go.chromium.org/luci/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014 The LUCI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.chromium.org/luci/common/sync/mutexpool/pool.go
+++ b/vendor/go.chromium.org/luci/common/sync/mutexpool/pool.go
@@ -1,0 +1,96 @@
+// Copyright 2017 The LUCI Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mutexpool implements P, a pool of keyed mutexes. These mutexes are
+// created on-demand and deleted when no longer referenced, so the pool's
+// maximum size is a function of the maximum number of concurrent mutexes
+// held at any given time.
+//
+// Package mutexpool is useful when coordinating access to resources that are
+// not managed by the accessor such as remote resource accesses.
+package mutexpool
+
+import (
+	"fmt"
+	"sync"
+)
+
+// P is a pool of keyed mutexes. The zero value is a valid empty pool.
+//
+// A user can grab an arbitrary Mutex's lock by calling WithMutex with a key.
+// If something else currently holds that Mutex's lock, WithMutex will block
+// until it can claim the lock. When a key is no longer in use, it will be
+// removed from P.
+type P struct {
+	mutexesLock sync.Mutex
+	mutexes     map[interface{}]*mutexEntry
+}
+
+func (pc *P) getConfigLock(key interface{}) *mutexEntry {
+	// Does the lock already exist?
+	pc.mutexesLock.Lock()
+	defer pc.mutexesLock.Unlock()
+
+	if me := pc.mutexes[key]; me != nil {
+		me.count++
+		if me.count == 0 {
+			panic(fmt.Errorf("mutex reference counter overflow"))
+		}
+		return me
+	}
+
+	if pc.mutexes == nil {
+		pc.mutexes = make(map[interface{}]*mutexEntry)
+	}
+	me := &mutexEntry{
+		count: 1, // Start with one ref.
+	}
+	pc.mutexes[key] = me
+	return me
+}
+
+func (pc *P) decRef(me *mutexEntry, key interface{}) {
+	pc.mutexesLock.Lock()
+	defer pc.mutexesLock.Unlock()
+
+	me.count--
+	if me.count == 0 {
+		delete(pc.mutexes, key)
+	}
+}
+
+// WithMutex locks the Mutex matching the specified key and executes fn while
+// holding its lock.
+//
+// If a mutex for key doesn't exist, one will be created, and will be
+// automatically cleaned up when no longer referenced.
+func (pc *P) WithMutex(key interface{}, fn func()) {
+	// Get a lock for this config key, and increment its reference.
+	me := pc.getConfigLock(key)
+	defer pc.decRef(me, key)
+
+	// Hold this lock's mutex and call "fn".
+	me.Lock()
+	defer me.Unlock()
+
+	fn()
+}
+
+type mutexEntry struct {
+	sync.Mutex
+
+	// count is the number of references to this mutexEntry. It is protected
+	// by P's lock.
+	count uint64
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -333,6 +333,8 @@ github.com/willf/bitset
 github.com/xanzy/ssh-agent
 # github.com/yohcop/openid-go v0.0.0-20160914080427-2c050d2dae53
 github.com/yohcop/openid-go
+# go.chromium.org/luci v0.0.0-20190816194131-4b600c9efb12
+go.chromium.org/luci/common/sync/mutexpool
 # golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 golang.org/x/crypto/acme/autocert
 golang.org/x/crypto/argon2


### PR DESCRIPTION
This should fix a possible race condition in `models/issue.go` (#7887) ***if*** we deem it necessary to fix; I'm not sure it's much of an issue, however.

The idea is to put a lock between `select max(index)` and `insert into issue (index, ....)`, so there's no chance that two simultaneous requests attempt to insert the same index for two separate issues.

To make sure it doesn't hurt insert performance, I've used per-repository mutexes with a library I've found at [go.chromium.org/luci/common/sync/mutexpool](go.chromium.org/luci/common/sync/mutexpool); so there's no lock if two inserts go for different repositories.

As I've said, it's probably not worth fixing; but I figured I'd try anyway. The pattern might be useful for other parts of the code.

One more thing: I couldn't figure out a good way of unit testing this modification. I've been looking around but didn't find anything convincing. Suggestions are welcomed.