### PR TITLE
Evaluate emojis in commit messages in list view

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -81,8 +81,8 @@
 						</span>
 					</td>
 				{{end}}
-				<td class="message has-emoji">
-					<span class="truncate">
+				<td class="message">
+					<span class="truncate has-emoji">
 						<a href="{{$.RepoLink}}/commit/{{$commit.ID}}" title="{{$commit.Summary}}">{{$commit.Summary}}</a>
 					</span>
 				</td>


### PR DESCRIPTION
Emojis in commit messages were not evaluated correctly in list view anymore:
![emoji-bug](https://user-images.githubusercontent.com/7293310/63224405-0f8a8d80-c1c4-11e9-891a-0d39e60a1acc.png)

It should look like:
![emoji-list-fixed](https://user-images.githubusercontent.com/7293310/63224406-0f8a8d80-c1c4-11e9-86d0-d58595b83e16.png)
