### PR TITLE
Add config option and shortcode for Gitea version in documentation

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -18,6 +18,7 @@ params:
   description: Git with a cup of tea
   author: The Gitea Authors
   website: https://docs.gitea.io
+  version: 1.9.2
 
 menu:
   page:

--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -21,7 +21,7 @@ the destination platform from the [downloads page](https://dl.gitea.io/gitea/), 
 the URL and replace the URL within the commands below:
 
 ```sh
-wget -O gitea https://dl.gitea.io/gitea/1.8.3/gitea-1.8.3-linux-amd64
+wget -O gitea https://dl.gitea.io/gitea/{{< version >}}/gitea-{{< version >}}-linux-amd64
 chmod +x gitea
 ```
 
@@ -30,7 +30,7 @@ Gitea signs all binaries with a [GPG key](https://pgp.mit.edu/pks/lookup?op=vind
 
 ```sh
 gpg --keyserver pgp.mit.edu --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
-gpg --verify gitea-1.8.3-linux-amd64.asc gitea-1.8.3-linux-amd64
+gpg --verify gitea-{{< version >}}-linux-amd64.asc gitea-{{< version >}}-linux-amd64
 ```
 
 ## Test

--- a/docs/content/doc/installation/from-binary.fr-fr.md
+++ b/docs/content/doc/installation/from-binary.fr-fr.md
@@ -18,7 +18,7 @@ menu:
 Tous les binaires sont livrés avec le support de SQLite, MySQL et PostgreSQL, et sont construits avec les ressources incorporées. Gardez à l'esprit que cela peut être différent pour les versions antérieures. L'installation basée sur nos binaires est assez simple, il suffit de choisir le fichier correspondant à votre plateforme à partir de la [page de téléchargement](https://dl.gitea.io/gitea). Copiez l'URL et remplacer l'URL dans les commandes suivantes par la nouvelle:
 
 ```
-wget -O gitea https://dl.gitea.io/gitea/1.3.2/gitea-1.3.2-linux-amd64
+wget -O gitea https://dl.gitea.io/gitea/{{< version >}}/gitea-{{< version >}}-linux-amd64
 chmod +x gitea
 ```
 

--- a/docs/content/doc/installation/from-binary.zh-cn.md
+++ b/docs/content/doc/installation/from-binary.zh-cn.md
@@ -18,7 +18,7 @@ menu:
 所有下载均包括 SQLite, MySQL 和 PostgreSQL 的支持，同时所有资源均已嵌入到可执行程序中，这一点和老版本有所不同。 基于二进制的安装非常简单，只要从 [下载页面](https://dl.gitea.io/gitea) 选择对应平台，拷贝下载URL，执行以下命令即可（以Linux为例）：
 
 ```
-wget -O gitea https://dl.gitea.io/gitea/1.3.2/gitea-1.3.2-linux-amd64
+wget -O gitea https://dl.gitea.io/gitea/{{< version >}}/gitea-{{< version >}}-linux-amd64
 chmod +x gitea
 ```
 

--- a/docs/content/doc/installation/from-binary.zh-tw.md
+++ b/docs/content/doc/installation/from-binary.zh-tw.md
@@ -18,7 +18,7 @@ menu:
 所有的執行檔皆支援 SQLite, MySQL and PostgreSQL，且所有檔案都已經包在執行檔內，這一點跟之前的版本有所不同。關於執行檔的安裝方式非常簡單，只要從[下載頁面](https://dl.gitea.io/gitea)選擇相對應平台，複製下載連結，使用底下指令就可以完成了:
 
 ```
-wget -O gitea https://dl.gitea.io/gitea/1.3.2/gitea-1.3.2-linux-amd64
+wget -O gitea https://dl.gitea.io/gitea/{{< version >}}/gitea-{{< version >}}-linux-amd64
 chmod +x gitea
 ```
 

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -53,7 +53,7 @@ To work with tagged releases, the following commands can be used:
 
 ```bash
 git branch -a
-git checkout v1.0
+git checkout v{{< version >}}
 ```
 
 To validate a Pull Request, first enable the new branch (`xyz` is the PR id;
@@ -63,14 +63,14 @@ for example `2663` for [#2663](https://github.com/go-gitea/gitea/pull/2663)):
 git fetch origin pull/xyz/head:pr-xyz
 ```
 
-To build Gitea from source at a specific tagged release (like v1.0.0), list the
+To build Gitea from source at a specific tagged release (like v{{< version >}}), list the
 available tags and check out the specific tag.
 
 List available tags with the following.
 
 ```bash
 git tag -l
-git checkout v1.0.0  # or git checkout pr-xyz
+git checkout v{{< version >}}  # or git checkout pr-xyz
 ```
 
 ## Build

--- a/docs/content/doc/installation/from-source.fr-fr.md
+++ b/docs/content/doc/installation/from-source.fr-fr.md
@@ -35,7 +35,7 @@ Si vous souhaitez compiler la dernière version stable, utilisez les étiquettes
 
 ```
 git branch -a
-git checkout v1.0
+git checkout v{{< version >}}
 ```
 
 Si vous souhaitez valider une demande d'ajout (_Pull request_), vous devez activer cette branche en premier : 
@@ -44,11 +44,11 @@ Si vous souhaitez valider une demande d'ajout (_Pull request_), vous devez activ
 git fetch origin pull/xyz/head:pr-xyz  # xyz is PR value
 ```
 
-Enfin, vous pouvez directement utiliser les versions étiquettées (ex : `v1.0.0`). Pour utiliser les étiquettes, vous devez lister les étiquettes disponibles et choisir une étiquette spécifique avec les commandes suivantes :
+Enfin, vous pouvez directement utiliser les versions étiquettées (ex : `v{{< version >}}`). Pour utiliser les étiquettes, vous devez lister les étiquettes disponibles et choisir une étiquette spécifique avec les commandes suivantes :
 
 ```
 git tag -l
-git checkout v1.0.0
+git checkout v{{< version >}}
 git checkout pr-xyz
 ```
 

--- a/docs/content/doc/installation/from-source.zh-cn.md
+++ b/docs/content/doc/installation/from-source.zh-cn.md
@@ -32,14 +32,14 @@ cd $GOPATH/src/code.gitea.io/gitea
 
 ```
 git branch -a
-git checkout v1.0
+git checkout v{{< version >}}
 ```
 
-最后，你也可以直接使用标签版本如 `v1.0.0`。你可以执行以下命令列出可用的版本并选择某个版本签出：
+最后，你也可以直接使用标签版本如 `v{{< version >}}`。你可以执行以下命令列出可用的版本并选择某个版本签出：
 
 ```
 git tag -l
-git checkout v1.0.0
+git checkout v{{< version >}}
 ```
 
 ## 编译

--- a/docs/content/doc/installation/from-source.zh-tw.md
+++ b/docs/content/doc/installation/from-source.zh-tw.md
@@ -32,14 +32,14 @@ cd $GOPATH/src/code.gitea.io/gitea
 
 ```
 git branch -a
-git checkout v1.0
+git checkout v{{< version >}}
 ```
 
-最後您也可以直接編譯最新的標籤版本像是 `v1.0.0`，假如您想要從原始碼編譯，這方法是最合適的，在編譯標籤版本前，您需要列出當下所有標籤，並且直接切換到標籤版本，請使用底下指令：:
+最後您也可以直接編譯最新的標籤版本像是 `v{{< version >}}`，假如您想要從原始碼編譯，這方法是最合適的，在編譯標籤版本前，您需要列出當下所有標籤，並且直接切換到標籤版本，請使用底下指令：:
 
 ```
 git tag -l
-git checkout v1.0.0
+git checkout v{{< version >}}
 ```
 
 ## 編譯

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -31,7 +31,7 @@ Create a directory like `gitea` and paste the following content into a file name
 Note that the volume should be owned by the user/group with the UID/GID specified in the config file.
 If you don't give the volume correct permissions, the container may not start.
 Also be aware that the tag `:latest` will install the current development version.
-For a stable release you can use `:1` or specify a certain release like `:1.5.1`.
+For a stable release you can use `:1` or specify a certain release like `:{{< version >}}`.
 
 ```yaml
 version: "2"

--- a/docs/layouts/shortcodes/version.html
+++ b/docs/layouts/shortcodes/version.html
@@ -1,0 +1,1 @@
+{{ .Site.Params.version }}


### PR DESCRIPTION
This PR would replace #7937, which gave me this idea.

Now the Gitea version would be stored in the Hugo config, and a shortcode would print it wherever it's used.  
There would only be one place to update the Gitea version for documentation.

I may have gotten a little overzealous in my swapping.  
The original idea was for the installing from binary page(s), but I made a few extra changes where I thought it wouldn't hurt to mention the "latest" version in examples.

