### PR TITLE
Change repo search to use exact match for topic search.

### DIFF
--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -248,7 +248,11 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (RepositoryList, int64, err
 		// separate keyword
 		var subQueryCond = builder.NewCond()
 		for _, v := range strings.Split(opts.Keyword, ",") {
-			subQueryCond = subQueryCond.Or(builder.Like{"topic.name", strings.ToLower(v)})
+			if opts.TopicOnly {
+				subQueryCond = subQueryCond.Or(builder.Eq{"topic.name": strings.ToLower(v)})
+			} else {
+				subQueryCond = subQueryCond.Or(builder.Like{"topic.name", strings.ToLower(v)})
+			}
 		}
 		subQuery := builder.Select("repo_topic.repo_id").From("repo_topic").
 			Join("INNER", "topic", "topic.id = repo_topic.topic_id").


### PR DESCRIPTION
Suggested (short term) solution for #7922. When clicking on a topic, you want to see repos with that exact topic, and not topics that only partly contain the search word.

Before PR:
_https://try.gitea.io/explore/repos?q=it&topic=1_ will show repositories with topics _it_, _git_ and _gitea_.
After PR:
It will only give repositories that have the topic _it_.

In case of general searches (i.e. not "Topic only" search), the PR does not change the behavior. Motivations for not including general searches in change:

- Incremental searches (using ajax) should narrow down when you type more letters.
- When writing something to search for in free text you might not be as exact in what you want e.g. git or gitea (compared to clicking a topic)