### PR TITLE
Adds details about what tags can use the Git tags API

### DIFF
--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -51,7 +51,7 @@ func ListTags(ctx *context.APIContext) {
 func GetTag(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/tags/{sha} repository GetTag
 	// ---
-	// summary: Gets the tag of a repository.
+	// summary: Gets the tag object of an annotated tag (not lightweight tags)
 	// produces:
 	// - application/json
 	// parameters:
@@ -67,7 +67,7 @@ func GetTag(ctx *context.APIContext) {
 	//   required: true
 	// - name: sha
 	//   in: path
-	//   description: sha of the tag
+	//   description: sha of the tag. The Git tags API only supports annotated tag objects, not lightweight tags.
 	//   type: string
 	//   required: true
 	// responses:

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -2166,7 +2166,7 @@
         "tags": [
           "repository"
         ],
-        "summary": "Gets the tag of a repository.",
+        "summary": "Gets the tag object of an annotated tag (not lightweight tags)",
         "operationId": "GetTag",
         "parameters": [
           {
@@ -2185,7 +2185,7 @@
           },
           {
             "type": "string",
-            "description": "sha of the tag",
+            "description": "sha of the tag. The Git tags API only supports annotated tag objects, not lightweight tags.",
             "name": "sha",
             "in": "path",
             "required": true


### PR DESCRIPTION
This fixes the swagger description of the `git/tags` API to make it clear it only takes annotated tag SHAs and not lightweight (commit) tag SHAs. For #7902