### PR TITLE
WIP: Duplicate Issue.Index stress test

### DIFF
--- a/integrations/issue_stress_test.go
+++ b/integrations/issue_stress_test.go
@@ -4,7 +4,6 @@
 
 // +build stress
 
-
 package integrations
 
 import (

--- a/integrations/issue_stress_test.go
+++ b/integrations/issue_stress_test.go
@@ -1,0 +1,20 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// +build stress
+
+
+package integrations
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models"
+)
+
+// TestStressCreateIssue do something
+func TestStressCreateIssue(t *testing.T) {
+	// TODO: refactor this to avoid including StressIssueNoDupIndex() in production
+	models.StressIssueNoDupIndex(t)
+}

--- a/integrations/issue_stress_test.go
+++ b/integrations/issue_stress_test.go
@@ -15,5 +15,6 @@ import (
 // TestStressCreateIssue do something
 func TestStressCreateIssue(t *testing.T) {
 	// TODO: refactor this to avoid including StressIssueNoDupIndex() in production
-	models.StressIssueNoDupIndex(t)
+	// func StressIssueNoDupIndex(t *testing.T, useTransactions bool, initialIssueFill int, maxTestDuration int, threadCount int) {
+	models.StressIssueNoDupIndex(t, true, 0, 0, 0)
 }

--- a/models/issue_stress.go
+++ b/models/issue_stress.go
@@ -17,13 +17,23 @@ import (
 )
 
 // StressIssueNoDupIndex Performs a stress test of the INSERT ... SELECT function of database for inserting issues
-func StressIssueNoDupIndex(t *testing.T) {
+func StressIssueNoDupIndex(t *testing.T, useTransactions bool, initialIssueFill int, maxTestDuration int, threadCount int) {
 	assert.NoError(t, PrepareTestDatabase())
 
-	const initialIssueFill = 1000 // issues inserted prior to stress test
-	const maxTestDuration = 60    // seconds
-	const threadCount = 8         // max simultaneous threads
-	const useTransactions = true  // true: wrap attempts with BEGIN TRANSACTION/COMMIT
+	// Defaults
+	const defInitialIssueFill = 1000 // issues inserted prior to stress test
+	const defMaxTestDuration = 60    // seconds
+	const defThreadCount = 8         // max simultaneous threads
+
+	if initialIssueFill == 0 {
+		initialIssueFill = defInitialIssueFill
+	}
+	if maxTestDuration == 0 {
+		maxTestDuration = defMaxTestDuration
+	}
+	if threadCount == 0 {
+		threadCount = defThreadCount
+	}
 
 	var err error
 	repo := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)

--- a/models/issue_stress.go
+++ b/models/issue_stress.go
@@ -53,7 +53,7 @@ func StressIssueNoDupIndex(t *testing.T, useTransactions bool, initialIssueFill 
 
 	fmt.Printf("TestIssueNoDupIndex(): %d rows created\n", initialIssueFill)
 
-	until := time.Now().Add(time.Second * maxTestDuration)
+	until := time.Now().Add(time.Second * time.Duration(maxTestDuration))
 
 	var hasErrors int32
 	var wg sync.WaitGroup

--- a/models/issue_stress.go
+++ b/models/issue_stress.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+// +build stress
+
 package models
 
 import (
@@ -14,8 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestIssueNoDupIndex Performs a stress test of the INSERT ... SELECT function of database for inserting issues
-func TestIssueNoDupIndex(t *testing.T) {
+// StressIssueNoDupIndex Performs a stress test of the INSERT ... SELECT function of database for inserting issues
+func StressIssueNoDupIndex(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 
 	const initialIssueFill = 1000 // issues inserted prior to stress test

--- a/models/issue_stress_test.go
+++ b/models/issue_stress_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIssueNoDupIndex Performs a stress test of the INSERT ... SELECT function of database for inserting issues
+func TestIssueNoDupIndex(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	const initialIssueFill = 1000 // issues inserted prior to stress test
+	const maxTestDuration = 60    // seconds
+	const threadCount = 8         // max simultaneous threads
+	const useTransactions = true  // true: wrap attempts with BEGIN TRANSACTION/COMMIT
+
+	var err error
+	repo := AssertExistsAndLoadBean(t, &Repository{ID: 3}).(*Repository)
+	doer := AssertExistsAndLoadBean(t, &User{ID: repo.OwnerID}).(*User)
+
+	// Pre-load
+	for i := 1; i < initialIssueFill; i++ {
+		issue := &Issue{
+			RepoID:   repo.ID,
+			PosterID: repo.OwnerID,
+			Index:    int64(i + 5000), // Avoid clashing with other tests
+			Title:    fmt.Sprintf("NoDup initial %d", i),
+		}
+		_, err = x.Insert(issue)
+		assert.NoError(t, err)
+	}
+
+	fmt.Printf("TestIssueNoDupIndex(): %d rows created\n", initialIssueFill)
+
+	until := time.Now().Add(time.Second * maxTestDuration)
+
+	var hasErrors int32
+	var wg sync.WaitGroup
+
+	f := func(thread int) {
+		defer wg.Done()
+		sess := x.NewSession()
+		defer sess.Close()
+		i := 1
+		for {
+			if time.Now().After(until) || atomic.LoadInt32(&hasErrors) != 0 {
+				return
+			}
+			issue := &Issue{
+				RepoID:         repo.ID,
+				PosterID:       repo.OwnerID,
+				Title:          fmt.Sprintf("NoDup stress %d, %d", thread, i),
+				OriginalAuthor: "TestIssueNoDupIndex()",
+				Priority:       thread, // For statistics
+			}
+			if useTransactions {
+				if err = sess.Begin(); err != nil {
+					break
+				}
+			}
+			if err = newIssue(sess, doer, NewIssueOptions{
+				Repo:  repo,
+				Issue: issue,
+			}); err != nil {
+				break
+			}
+			if useTransactions {
+				if err = sess.Commit(); err != nil {
+					break
+				}
+			}
+			i++
+		}
+		if useTransactions {
+			_ = sess.Rollback()
+		}
+		atomic.StoreInt32(&hasErrors, 1)
+		t.Logf("newIssue(): %+v", err)
+	}
+
+	for i := 1; i <= threadCount; i++ {
+		go f(i)
+		wg.Add(1)
+	}
+
+	fmt.Printf("TestIssueNoDupIndex(): %d threads created\n", threadCount)
+
+	wg.Wait()
+
+	for i := 1; i <= threadCount; i++ {
+		total, err := x.Table("issue").
+			Where("original_author = ?", "TestIssueNoDupIndex()").
+			And("priority = ?", i).
+			Count()
+		assert.NoError(t, err, "Failed counting generated issues count")
+		fmt.Printf("TestIssueNoDupIndex(): rows created in thread #%d: %d\n", i, total)
+	}
+
+	assert.Equal(t, int32(0), hasErrors, "Synchronization errors detected.")
+}


### PR DESCRIPTION
This is a stress test for the `models.newIssue()` function, which is expected to fail under big server loads. The problem is a _duplicate key_ error due to the way the function calculates the value for the `Index` column. See #7887 and #7898.

The test only compiles when the `stress` tag is specified because **it always fails** (as expected). EDIT: _except for SQLite with sqlite_unlock_notify_.

#### Note: I know the code needs refactoring. I'd like some help with that, as I couldn't figure out the proper way to do it.

The code is meant to be run under `integrations/` so one day, when the _duplicate key_ is resolved, the test can be run for every database in the CI (AFAIK the CI does not run tests in the `models` package for all databases; only for SQLite).

#### What the test does

First the test creates a relatively large number of rows in the `Issues` table (default=1000) to make the table grow by at least two blocks.

Then, the test spawns several goroutines (default=8) to simulate multiple users attempting to create issues on the server at the same time.

The goroutines keep calling `models.newIssue()` as quickly as they can, and stop when any of the following is true:

* A predetermined time has passed (default=60 seconds).
* It gets an error when attempting to insert.
* Any other goroutine gets an error.

So, the test should take at most ~60 seconds if successful, or less if it fails.

The reason the code attempts with 8 goroutines and not -say- 1000 is because it's not realistic to expect the database to have a connection pool that big. As long as the goroutines keep inserting continuously, this test is equivalent and gets the server to spend more time doing database stuff and less time doing process synchronization.
