### PR TITLE
keep blame view buttons sequence consistent with normal view when view a file

### DIFF
--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -9,12 +9,12 @@
 			<div class="eight wide right aligned column">
                 <div class="ui right file-actions">
                     <div class="ui buttons">
+                        <a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
                         {{if not .IsViewCommit}}
                             <a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
                         {{end}}
                         <a class="ui button" href="{{.RepoLink}}/src/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.normal_view"}}</a>
                         <a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
-                        <a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
                     </div>
                     {{if .Repository.CanEnableEditor}}
                         {{if .CanEditFile}}


### PR DESCRIPTION
Before:

Normal View:
![image](https://user-images.githubusercontent.com/81045/63820116-abfa2000-c97a-11e9-901f-84f93d03cd0e.png)

Blame View:
![image](https://user-images.githubusercontent.com/81045/63820185-e5cb2680-c97a-11e9-94fc-59a9874d3dfc.png)

After:

Normal View:
![image](https://user-images.githubusercontent.com/81045/63820116-abfa2000-c97a-11e9-901f-84f93d03cd0e.png)

Blame View:
![image](https://user-images.githubusercontent.com/81045/63820099-9684f600-c97a-11e9-8ad7-589310890bb3.png)
