### PR TITLE
[WIP] Add team option to automatically add new organization repos

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -53,6 +53,10 @@ func (org *User) GetOwnerTeam() (*Team, error) {
 	return org.getOwnerTeam(x)
 }
 
+func (org *User) getTeamsWithAutoAddRepos(e Engine) ([]*Team, error) {
+	return getTeamsWithAutoAddRepos(e, org.ID)
+}
+
 func (org *User) getTeams(e Engine) error {
 	return e.
 		Where("org_id=?", org.ID).

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -21,17 +21,18 @@ const ownerTeamName = "Owners"
 
 // Team represents a organization team.
 type Team struct {
-	ID          int64 `xorm:"pk autoincr"`
-	OrgID       int64 `xorm:"INDEX"`
-	LowerName   string
-	Name        string
-	Description string
-	Authorize   AccessMode
-	Repos       []*Repository `xorm:"-"`
-	Members     []*User       `xorm:"-"`
-	NumRepos    int
-	NumMembers  int
-	Units       []*TeamUnit `xorm:"-"`
+	ID             int64 `xorm:"pk autoincr"`
+	OrgID          int64 `xorm:"INDEX"`
+	LowerName      string
+	Name           string
+	Description    string
+	Authorize      AccessMode
+	AutoAddNewRepo bool
+	Repos          []*Repository `xorm:"-"`
+	Members        []*User       `xorm:"-"`
+	NumRepos       int
+	NumMembers     int
+	Units          []*TeamUnit `xorm:"-"`
 }
 
 // ColorFormat provides a basic color format for a Team
@@ -355,6 +356,13 @@ func getTeam(e Engine, orgID int64, name string) (*Team, error) {
 		return nil, ErrTeamNotExist
 	}
 	return t, nil
+}
+
+func getTeamsWithAutoAddRepos(e Engine, orgID int64) ([]*Team, error) {
+	teams := make([]*Team, 0, 5)
+	sess := e.Where("org_id = ?", orgID).
+		And("auto_add_new_repo = ?", true)
+	return teams, sess.Find(&teams)
 }
 
 // GetTeam returns team by given team name and organization.

--- a/modules/auth/org.go
+++ b/modules/auth/org.go
@@ -56,10 +56,11 @@ func (f *UpdateOrgSettingForm) Validate(ctx *macaron.Context, errs binding.Error
 
 // CreateTeamForm form for creating team
 type CreateTeamForm struct {
-	TeamName    string `binding:"Required;AlphaDashDot;MaxSize(30)"`
-	Description string `binding:"MaxSize(255)"`
-	Permission  string
-	Units       []models.UnitType
+	TeamName     string `binding:"Required;AlphaDashDot;MaxSize(30)"`
+	Description  string `binding:"MaxSize(255)"`
+	Permission   string
+	AutoAddRepos bool
+	Units        []models.UnitType
 }
 
 // Validate validates the fields

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1485,6 +1485,8 @@ members.invite_now = Invite Now
 
 teams.join = Join
 teams.leave = Leave
+teams.auto_add_repo = Automatically add new repositories
+teams.auto_add_repo_helper = Team will automatically get access to newly created or transferred repositories in organization.
 teams.read_access = Read Access
 teams.read_access_helper = Members can view and clone team repositories.
 teams.write_access = Write Access

--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -182,10 +182,11 @@ func NewTeamPost(ctx *context.Context, form auth.CreateTeamForm) {
 	ctx.Data["Units"] = models.Units
 
 	t := &models.Team{
-		OrgID:       ctx.Org.Organization.ID,
-		Name:        form.TeamName,
-		Description: form.Description,
-		Authorize:   models.ParseAccessMode(form.Permission),
+		OrgID:          ctx.Org.Organization.ID,
+		Name:           form.TeamName,
+		Description:    form.Description,
+		Authorize:      models.ParseAccessMode(form.Permission),
+		AutoAddNewRepo: form.AutoAddRepos,
 	}
 
 	if t.Authorize < models.AccessModeOwner {
@@ -273,6 +274,7 @@ func EditTeamPost(ctx *context.Context, form auth.CreateTeamForm) {
 		auth := models.ParseAccessMode(form.Permission)
 
 		t.Name = form.TeamName
+		t.AutoAddNewRepo = form.AutoAddRepos
 		if t.Authorize != auth {
 			isAuthChanged = true
 			t.Authorize = auth

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -29,7 +29,7 @@
 							<br>
 							<div class="field">
 								<div class="ui checkbox">
-									<input type="radio" name="auto_add_repos" {{if .Team.AutoAddNewRepo}}checked{{end}}>
+									<input type="checkbox" name="auto_add_repos" {{if .Team.AutoAddNewRepo}}checked{{end}}>
 									<label>Automatically add team to new repositories</label>
 									<span class="help">Will automatically grant team access to newly created repositories.</span>
 								</div> 

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -30,8 +30,8 @@
 							<div class="field">
 								<div class="ui checkbox">
 									<input type="checkbox" name="auto_add_repos" {{if .Team.AutoAddNewRepo}}checked{{end}}>
-									<label>Automatically add team to new repositories</label>
-									<span class="help">Will automatically grant team access to newly created repositories.</span>
+									<label>{{.i18n.Tr "org.teams.auto_add_repo"}}</label>
+									<span class="help">{{.i18n.Tr "org.teams.auto_add_repo_helper"}}</span>
 								</div> 
 							</div>
 							<div class="field">

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -28,6 +28,13 @@
 							<label>{{.i18n.Tr "org.team_permission_desc"}}</label>
 							<br>
 							<div class="field">
+								<div class="ui checkbox">
+									<input type="radio" name="auto_add_repos" {{if .Team.AutoAddNewRepo}}checked{{end}}>
+									<label>Automatically add team to new repositories</label>
+									<span class="help">Will automatically grant team access to newly created repositories.</span>
+								</div> 
+							</div>
+							<div class="field">
 								<div class="ui radio checkbox">
 									<input type="radio" name="permission" value="read" {{if or .PageIsOrgTeamsNew (eq .Team.Authorize 1)}}checked{{end}}>
 									<label>{{.i18n.Tr "org.teams.read_access"}}</label>


### PR DESCRIPTION
This PR will add a team setting that allows to automatically add new (or transferred) repositories to a team. It only affects when a new repo is created in organization (including migrated or transferred) by adding the repository to the team's access. 

### Screenshot
![image](https://user-images.githubusercontent.com/161914/64076556-98c2b980-ccc6-11e9-80d5-55ae6f88d5f8.png)


Left todo for this PR:
- [ ] Make proper translation strings
- [ ] Update API
- [ ] Create database migration
- [ ] Add tests
