### PR TITLE
backport:[1.9] - Run CORS handler first for /api routes (#7967)

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -74,7 +74,6 @@ import (
 	"code.gitea.io/gitea/routers/api/v1/user"
 
 	"github.com/go-macaron/binding"
-	"github.com/go-macaron/cors"
 	macaron "gopkg.in/macaron.v1"
 )
 
@@ -501,12 +500,6 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/swagger", misc.Swagger) //Render V1 by default
 	}
 
-	var handlers []macaron.Handler
-	if setting.EnableCORS {
-		handlers = append(handlers, cors.CORS(setting.CORSConfig))
-	}
-	handlers = append(handlers, securityHeaders(), context.APIContexter(), sudo())
-
 	m.Group("/v1", func() {
 		// Miscellaneous
 		if setting.API.EnableSwagger {
@@ -852,7 +845,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Group("/topics", func() {
 			m.Get("/search", repo.TopicSearch)
 		})
-	}, handlers...)
+	}, securityHeaders(), context.APIContexter(), sudo())
 }
 
 func securityHeaders() macaron.Handler {

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -38,6 +38,7 @@ import (
 	"github.com/go-macaron/binding"
 	"github.com/go-macaron/cache"
 	"github.com/go-macaron/captcha"
+	"github.com/go-macaron/cors"
 	"github.com/go-macaron/csrf"
 	"github.com/go-macaron/i18n"
 	"github.com/go-macaron/session"
@@ -947,9 +948,14 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/swagger.v1.json", templates.JSONRenderer(), routers.SwaggerV1Json)
 	}
 
+	var handlers []macaron.Handler
+	if setting.EnableCORS {
+		handlers = append(handlers, cors.CORS(setting.CORSConfig))
+	}
+	handlers = append(handlers, ignSignIn)
 	m.Group("/api", func() {
 		apiv1.RegisterRoutes(m)
-	}, ignSignIn)
+	}, handlers...)
 
 	m.Group("/api/internal", func() {
 		// package name internal is ideal but Golang is not allowed, so we use private as package name.


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>
