### PR TITLE
Avoid ambiguity of branch/directory names for the git-diff-tree command

### DIFF
--- a/modules/pull/merge.go
+++ b/modules/pull/merge.go
@@ -299,8 +299,7 @@ func getDiffTree(repoPath, baseBranch, headBranch string) (string, error) {
 	getDiffTreeFromBranch := func(repoPath, baseBranch, headBranch string) (string, error) {
 		var outbuf, errbuf strings.Builder
 		// Compute the diff-tree for sparse-checkout
-		// The branch argument must be enclosed with double-quotes ("") in case it contains slashes (e.g "feature/test")
-		if err := git.NewCommand("diff-tree", "--no-commit-id", "--name-only", "-r", "--root", baseBranch, headBranch).RunInDirPipeline(repoPath, &outbuf, &errbuf); err != nil {
+		if err := git.NewCommand("diff-tree", "--no-commit-id", "--name-only", "-r", "--root", baseBranch, headBranch, "--").RunInDirPipeline(repoPath, &outbuf, &errbuf); err != nil {
 			return "", fmt.Errorf("git diff-tree [%s base:%s head:%s]: %s", repoPath, baseBranch, headBranch, errbuf.String())
 		}
 		return outbuf.String(), nil


### PR DESCRIPTION
Fixes #8029 

When there is a directory at the top with the name clashed with the branch name,
the git diff-tree command will not be able to figure out the ambiguity.

Also, remove an outdated comment.