### PR TITLE
[Docker] Allow Container to bind < 1024 ports 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk --no-cache add \
     s6 \
     sqlite \
     su-exec \
+    libcap \
     tzdata
 
 RUN addgroup \

--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -52,3 +52,6 @@ if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${U
 if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi
 if ! [[ $(ls -ld /data/git   | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/git;   fi
 chmod 0755 /data/gitea /app/gitea /data/git
+
+# Allow to bind < 1024 ports without being root
+setcap 'cap_net_bind_service=+ep' /app/gitea/gitea


### PR DESCRIPTION
Since the installation / setup of Gitea in Docker allows any port number to be bound to Gitea, there is a problem when issuing < 1024 ports number (like 80 or 443). This is because the `/app/gitea/gitea` binary is not executed as `root`.

To allow the binary to bind these ports, it must run as `root`. To avoid this, we use the command `setcap` (part of the `libcap` library) to allow the binary to **only** bound these ports while keeping it running as non-`root`.

The only problem I see with this is that `libcap` weights 45MB~. I tried using libcap at building time (in last stages) but the binary coudln't get proper permissions, so I resorted to this.

![image](https://user-images.githubusercontent.com/5141911/64212480-79b75980-ce77-11e9-818a-b69b51edb9a6.png)
