### PR TITLE
Backport: Strict name matching for Repository.GetTagID()

### DIFF
--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -157,11 +157,14 @@ func (repo *Repository) GetTagID(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fields := strings.Fields(stdout)
-	if len(fields) != 2 {
-		return "", ErrNotExist{ID: name}
+	// Make sure exact match is used: "v1" != "release/v1"
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == "refs/tags/"+name {
+			return fields[0], nil
+		}
 	}
-	return fields[0], nil
+	return "", ErrNotExist{ID: name}
 }
 
 // GetTag returns a Git tag by given name.

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -62,6 +62,16 @@ func TestRepository_GetTag(t *testing.T) {
 	assert.NotEqual(t, aTagID, aTag.Object.String())
 	assert.EqualValues(t, aTagCommitID, aTag.Object.String())
 	assert.EqualValues(t, "tag", aTag.Type)
+
+	rTagCommitID := "8006ff9adbf0cb94da7dad9e537e53817f9fa5c0"
+	rTagName := "release/" + lTagName
+	bareRepo1.CreateTag(rTagName, rTagCommitID)
+	rTagID, err := bareRepo1.GetTagID(rTagName)
+	assert.NoError(t, err)
+	assert.EqualValues(t, rTagCommitID, rTagID)
+	oTagID, err := bareRepo1.GetTagID(lTagName)
+	assert.NoError(t, err)
+	assert.EqualValues(t, lTagCommitID, oTagID)
 }
 
 func TestRepository_GetAnnotatedTag(t *testing.T) {


### PR DESCRIPTION
Fixes #7985
Backport for #8074 
