### PR TITLE
Make non-existent repos require login to clone

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -109,7 +109,7 @@ func HTTP(ctx *context.Context) {
 				if authUser != nil && owner.ID == authUser.ID || owner.IsUserPartOfOrg(authUser.ID) {
 					ctx.NotFoundOrServerError("GetRepositoryByName", models.IsErrRepoRedirectNotExist, err)
 				} else {
-					ctx.NotFound("GetRepositoryByName", err)
+					ctx.NotFound("GetRepositoryByName", nil)
 				}
 			}
 		} else {
@@ -140,8 +140,7 @@ func HTTP(ctx *context.Context) {
 
 		perm, err := models.GetUserRepoPermission(repo, authUser)
 		if err != nil {
-			ctx.NotFound("GetRepositoryName", nil)
-			log.ErrorWithSkip(2, "%s: %v", err)
+			ctx.NotFound("GetRepositoryName", err)
 			return
 		}
 

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -127,9 +127,9 @@ func HTTP(ctx *context.Context) {
 	// Only public pull don't need auth.
 	isPublicPull := !repo.IsPrivate && isPull
 	var (
-		askAuth      = !isPublicPull || setting.Service.RequireSignInView
-		authUser     *models.User
-		environ      []string
+		askAuth  = !isPublicPull || setting.Service.RequireSignInView
+		authUser *models.User
+		environ  []string
 	)
 
 	// check access
@@ -181,11 +181,11 @@ func HTTP(ctx *context.Context) {
 	})(ctx.Resp, ctx.Req.Request)
 }
 
-func checkAuth (ctx *context.Context) (authUser *models.User) {
+func checkAuth(ctx *context.Context) (authUser *models.User) {
 	var (
 		authUsername string
-		authPasswd string
-		err error
+		authPasswd   string
+		err          error
 	)
 
 	authUsername = ctx.Req.Header.Get(setting.ReverseProxyAuthUser)
@@ -202,7 +202,7 @@ func checkAuth (ctx *context.Context) (authUser *models.User) {
 			ctx.Error(http.StatusUnauthorized)
 			return
 		}
-authUsername = ctx.Req.Header.Get(setting.ReverseProxyAuthUser)
+		authUsername = ctx.Req.Header.Get(setting.ReverseProxyAuthUser)
 		if setting.Service.EnableReverseProxyAuth && len(authUsername) > 0 {
 			authUser, err = models.GetUserByName(authUsername)
 			if err != nil {


### PR DESCRIPTION
Previously, it was possible to check if a private
repository exists by attempting to clone the repo.

This change will make it so that non-existent repos
will also require a login and will only tell the user
whether the truly doesn't if they would know about a
private repository with that name.

This will only really be effective while Gitea is in prod mode. Otherwise, errors that reveal exactly why the user could not clone may be sent to the user.

EDIT: I'll see if I can add some tests.