### PR TITLE
Include git-hook regeneration in restore documentation

### DIFF
--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -80,8 +80,8 @@ mysql -u$USER -p$PASS $DATABASE <gitea-db.sql
 service gitea restart
 ```
 
-If a restoration is done to migrate from one installation method to a another (eg. binary -> Docker), repository git-hooks should be regenerated.
+Repository git-hooks should be regenerated if installation method is changed (eg. binary -> Docker), or if Gitea is installed to a different directory than the previous installation.
 
-With Gitea running, execute: `gitea admin regenerate hooks`
+With Gitea running, execute: `./gitea admin regenerate hooks`
 
-This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation.
+This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation. If these paths are not updated, repository `push` actions may fail.

--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -84,4 +84,4 @@ Repository git-hooks should be regenerated if installation method is changed (eg
 
 With Gitea running, and from the directory Gitea's binary is located, execute: `./gitea admin regenerate hooks`
 
-This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation. If these paths are not updated, repository `push` actions may fail.
+This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation. If these paths are not updated, repository `push` actions will fail.

--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -79,3 +79,9 @@ mysql -u$USER -p$PASS $DATABASE <gitea-db.sql
 # or  sqlite3 $DATABASE_PATH <gitea-db.sql
 service gitea restart
 ```
+
+If a restoration is done to migrate from one installation method to a another (eg. binary -> Docker), repository git-hooks should be regenerated.
+
+With Gitea running, execute: `gitea admin regenerate hooks`
+
+This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation.

--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -82,6 +82,6 @@ service gitea restart
 
 Repository git-hooks should be regenerated if installation method is changed (eg. binary -> Docker), or if Gitea is installed to a different directory than the previous installation.
 
-With Gitea running, execute: `./gitea admin regenerate hooks`
+With Gitea running, and from the directory Gitea's binary is located, execute: `./gitea admin regenerate hooks`
 
 This ensures that application and configuration file paths in repository git-hooks are consistent and applicable to the current installation. If these paths are not updated, repository `push` actions may fail.


### PR DESCRIPTION
This PR is to include the git-hook regeneration command to the `restore` section of the `Backup and Restore` guide.

When migrating to a different installation method (eg. binary -> Docker), there is currently no mention of needing to regenerate git-hooks, causing `push` actions to fail on the new installation.