### PR TITLE
Fix pull merge 500 error caused by git-fetch breaking behaviors

### DIFF
--- a/modules/pull/merge.go
+++ b/modules/pull/merge.go
@@ -101,7 +101,7 @@ func Merge(pr *models.PullRequest, doer *models.User, baseGitRepo *git.Repositor
 	}
 
 	// Fetch head branch
-	if err := git.NewCommand("fetch", remoteRepoName, pr.HeadBranch).RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
+	if err := git.NewCommand("fetch", remoteRepoName, fmt.Sprintf("%s:refs/remotes/%s/%s", pr.HeadBranch, remoteRepoName, pr.HeadBranch)).RunInDirPipeline(tmpBasePath, nil, &errbuf); err != nil {
 		return fmt.Errorf("git fetch [%s -> %s]: %s", headRepoPath, tmpBasePath, errbuf.String())
 	}
 


### PR DESCRIPTION
Fixes #8133 

The git version before 1.8.4 would not update remote refs automatically.
That causes the following git-diff-tree command to get 'bad revision' errors.
Use refspec for git-fetch explicitly to avoid the problem.