### PR TITLE
faq: mention EMAIL_DOMAIN_WHITELIST on allowing email domains

### DIFF
--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -133,8 +133,11 @@ There are multiple things you can combine to prevent spammers.
 2. Setting `ENABLE_CAPTCHA` to `true` in your `app.ini` and properly configuring `RECAPTCHA_SECRET` and `RECAPTCHA_SITEKEY`
 3. Settings `DISABLE_REGISTRATION` to `true` and creating new users via the [CLI]({{< relref "doc/usage/command-line.en-us.md" >}}), [API]({{< relref "doc/advanced/api-usage.en-us.md" >}}), or Gitea's Admin UI  
 
-### Only allow/block certain email domains
-You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`. If using OpenID, you can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` in your `app.ini`
+### Only allow certain email domains
+You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`.
+
+## Only allow/block certain OpenID providers
+You can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` under `[openid]` in your `app.ini`
 **NOTE:** whitelisted takes precedence, so if it is non-blank then blacklisted is ignored
 
 ### Issue only users

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -137,7 +137,7 @@ There are multiple things you can combine to prevent spammers.
 ### Only allow certain email domains
 You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`
 
-## Only allow/block certain OpenID providers
+### Only allow/block certain OpenID providers
 You can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` under `[openid]` in your `app.ini`
 **NOTE:** whitelisted takes precedence, so if it is non-blank then blacklisted is ignored
 

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -28,7 +28,8 @@ Also see [Support Options]({{< relref "doc/help/seek-help.en-us.md" >}})
 * [What is Swagger?](#what-is-swagger)
 * [Adjusting your server for public/private use](#adjusting-your-server-for-public-private-use)
   * [Preventing spammers](#preventing-spammers)
-  * [Only allow/block certain email domains](#only-allow-block-certain-email-domains)
+  * [Only allow certain email domains](#only-allow-certain-email-domains)
+  * [Only allow/block certain OpenID providers](#only-allow-block-certain-openid-providers)
   * [Issue only users](#issue-only-users)
   * [Enable Fail2ban](#enable-fail2ban)
 * [Adding custom themes](#how-to-add-use-custom-themes)
@@ -134,7 +135,7 @@ There are multiple things you can combine to prevent spammers.
 3. Settings `DISABLE_REGISTRATION` to `true` and creating new users via the [CLI]({{< relref "doc/usage/command-line.en-us.md" >}}), [API]({{< relref "doc/advanced/api-usage.en-us.md" >}}), or Gitea's Admin UI  
 
 ### Only allow certain email domains
-You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`.
+You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`
 
 ## Only allow/block certain OpenID providers
 You can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` under `[openid]` in your `app.ini`

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -138,7 +138,7 @@ There are multiple things you can combine to prevent spammers.
 You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`
 
 ### Only allow/block certain OpenID providers
-You can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` under `[openid]` in your `app.ini`
+You can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` under `[openid]` in your `app.ini`  
 **NOTE:** whitelisted takes precedence, so if it is non-blank then blacklisted is ignored
 
 ### Issue only users

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -134,7 +134,7 @@ There are multiple things you can combine to prevent spammers.
 3. Settings `DISABLE_REGISTRATION` to `true` and creating new users via the [CLI]({{< relref "doc/usage/command-line.en-us.md" >}}), [API]({{< relref "doc/advanced/api-usage.en-us.md" >}}), or Gitea's Admin UI  
 
 ### Only allow/block certain email domains
-If using OpenID, you can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` in your `app.ini`  
+You can configure `EMAIL_DOMAIN_WHITELIST` in your app.ini under `[service]`. If using OpenID, you can configure `WHITELISTED_URIS` or `BLACKLISTED_URIS` in your `app.ini`
 **NOTE:** whitelisted takes precedence, so if it is non-blank then blacklisted is ignored
 
 ### Issue only users


### PR DESCRIPTION
I wanted to only allow two domains related to two specific organisations and followed the FAQ and was confused until reading `app.ini` more closely and finding out that the FAQ was wrong.

Questions that aren't yet clear to me:

* Why does this section talk about email domains, while it documented only OpenID? Should I move it to a separate section?
* I didn't see any blacklist in `app.ini`, should I remove `/block`?