### PR TITLE
MS Teams webhook misses commit messages (backport v1.9)

### DIFF
--- a/models/webhook_msteams.go
+++ b/models/webhook_msteams.go
@@ -236,6 +236,7 @@ func getMSTeamsPushPayload(p *api.PushPayload) (*MSTeamsPayload, error) {
 				ActivityTitle:    p.Sender.FullName,
 				ActivitySubtitle: p.Sender.UserName,
 				ActivityImage:    p.Sender.AvatarURL,
+				Text:             text,
 				Facts: []MSTeamsFact{
 					{
 						Name:  "Repository:",


### PR DESCRIPTION
The current webhook just shows the amount of commits, but misses the actual commit description. While the code is actually there to include the description, it is just not included.

(this has been already been merged into master - see issue #8209)

Signed-off-by: Bjoern Petri <bjoern.petri@sundevil.de>