### PR TITLE
Change "show more repos" to simply extend the repo list

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -22,7 +22,6 @@
 					:search-limit="searchLimit"
 					:suburl="suburl"
 					:uid="uid"
-					:more-repos-link="'{{.ContextUser.HomeLink}}'"
 					{{if not .ContextUser.IsOrganization}}
 					:organizations="[
 						{{range .ContextUser.Orgs}}
@@ -94,7 +93,7 @@
 										</a>
 									</li>
 									<li v-if="showMoreReposLink">
-										<a :href="moreReposLink">{{.i18n.Tr "home.show_more_repos"}}</a>
+										<a @click="searchMoreRepos">{{.i18n.Tr "home.show_more_repos"}}</a>
 									</li>
 								</ul>
 							</div>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2736,10 +2736,6 @@ function initVueComponents() {
       organizationsTotalCount: {
         type: Number,
         default: 0
-      },
-      moreReposLink: {
-        type: String,
-        default: ''
       }
     },
 
@@ -2751,6 +2747,7 @@ function initVueComponents() {
         reposFilter: 'all',
         searchQuery: '',
         isLoading: false,
+        page: 1,
         repoTypes: {
           all: {
             count: 0,
@@ -2783,7 +2780,7 @@ function initVueComponents() {
       searchURL() {
         return `${this.suburl}/api/v1/repos/search?sort=updated&order=desc&uid=${this.uid}&q=${this.searchQuery
         }&limit=${this.searchLimit}&mode=${this.repoTypes[this.reposFilter].searchMode
-        }${this.reposFilter !== 'all' ? '&exclusive=1' : ''}`;
+        }${this.reposFilter !== 'all' ? '&exclusive=1' : ''}&page=${this.page}`;
       },
       repoTypeCount() {
         return this.repoTypes[this.reposFilter].count;
@@ -2808,6 +2805,7 @@ function initVueComponents() {
         this.reposFilter = filter;
         this.repos = [];
         this.repoTypes[filter].count = 0;
+        this.page = 1;
         this.searchRepos(filter);
       },
 
@@ -2837,7 +2835,11 @@ function initVueComponents() {
 
         $.getJSON(searchedURL, (result, _textStatus, request) => {
           if (searchedURL === self.searchURL) {
-            self.repos = result.data;
+            if (self.page > 1) {
+              result.data.forEach(repo => self.repos.push(repo));
+            } else {
+              self.repos = result.data;
+            }
             const count = request.getResponseHeader('X-Total-Count');
             if (searchedQuery === '' && searchedMode === '') {
               self.reposTotalCount = count;
@@ -2849,6 +2851,11 @@ function initVueComponents() {
             self.isLoading = false;
           }
         });
+      },
+
+      searchMoreRepos() {
+        this.page += 1;
+        this.searchRepos(this.reposFilter);
       },
 
       repoClass(repo) {


### PR DESCRIPTION
Gitea's index page features a repository list, which by default only shows at most 15 repos. If there are more, a "show more repos" link is displayed at the bottom.

Previously this was a link to the user's profile, but that is not helpful, as not all repos (e.g. those owned by organizations) are shown there.
