### PR TITLE
Fix release API URL generation

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -65,7 +65,7 @@ func (r *Release) LoadAttributes() error {
 
 // APIURL the api url for a release. release must have attributes loaded
 func (r *Release) APIURL() string {
-	return fmt.Sprintf("%sapi/v1/%s/releases/%d",
+	return fmt.Sprintf("%sapi/v1/repos/%s/releases/%d",
 		setting.AppURL, r.Repo.FullName(), r.ID)
 }
 


### PR DESCRIPTION
When I configure the repository to send a release webhook, the URL key is generated without repos/ resulting in a wrong API URL. Example:

Actual:
```json
{
    "url": "https://try.gitea.io/api/v1/danielflira/test123/releases/3281557"
}
```

Fixed:
```json
{
    "url": "http://localhost:3000/api/v1/repos/danielflira/test123/releases/1"
}
```