### PR TITLE
Do only show teams access for organization repositories on collaboration setting page

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -395,6 +395,7 @@ func RepoAssignment() macaron.Handler {
 		ctx.Data["Owner"] = ctx.Repo.Repository.Owner
 		ctx.Data["IsRepositoryOwner"] = ctx.Repo.IsOwner()
 		ctx.Data["IsRepositoryAdmin"] = ctx.Repo.IsAdmin()
+		ctx.Data["RepoOwnerIsOrganization"] = repo.Owner.IsOrganization()
 		ctx.Data["CanWriteCode"] = ctx.Repo.CanWrite(models.UnitTypeCode)
 		ctx.Data["CanWriteIssues"] = ctx.Repo.CanWrite(models.UnitTypeIssues)
 		ctx.Data["CanWritePulls"] = ctx.Repo.CanWrite(models.UnitTypePullRequests)

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -52,6 +52,7 @@
 			</form>
 		</div>
 
+		{{if .RepoOwnerIsOrganization}}
 		<h4 class="ui top attached header">
 			Teams
 		</h4>
@@ -108,6 +109,7 @@
 				</div>
 			{{end}}
 		</div>
+		{{end}}
 	</div>
 </div>
 


### PR DESCRIPTION
There is a case I had missed in #8045 and only realized after it was merged (a bug if you want). 

Only organizations have teams and not users, so user repositories shall not have the team box on the collaboration setting page (it always looks like the screenshot below). This PR fixes so only organization repos has the team box.

### Screenshot
![image](https://user-images.githubusercontent.com/161914/65467494-d3e98000-de61-11e9-8f3e-830d99111f95.png)


Signed-off-by: David Svantesson <davidsvantesson@gmail.com>
