### PR TITLE
Update hacking-on-gitea.en-us.md - misspelled command

### DIFF
--- a/docs/content/doc/advanced/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/advanced/hacking-on-gitea.en-us.md
@@ -178,7 +178,7 @@ make generate-swagger
 You should validate your generated Swagger file and spell-check it with:
 
 ```bash
-make swagger-validate mispell-check
+make swagger-validate misspell-check
 ```
 
 You should commit the changed swagger JSON file. The continous integration


### PR DESCRIPTION
Ironically, misspell-check is misspelled in command to validate swagger.