### PR TITLE
Avoid including "num_issues" and "num_closed_issues" multiple times

### DIFF
--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -308,7 +308,8 @@ func updateLabel(e Engine, l *Label) error {
 					"issue.is_closed":      true,
 				}),
 		).
-		AllCols().Update(l)
+		Cols("repo_id", "name", "description", "color", "query_string", "is_selected").
+		Update(l)
 	return err
 }
 


### PR DESCRIPTION
Only update columns that have not been specified already in the query.

Fixes issue #8336.

 