### PR TITLE
Updated documentation

### DIFF
--- a/docs/content/doc/features/webhooks.en-us.md
+++ b/docs/content/doc/features/webhooks.en-us.md
@@ -17,7 +17,15 @@ menu:
 
 Gitea supports web hooks for repository events. This can be found in the settings
 page `/:username/:reponame/settings/hooks`. All event pushes are POST requests.
-The two methods currently supported are Gitea and Slack.
+The methods currently supported are:
+
+- Gitea
+- Gogs
+- Slack
+- Discord
+- Dingtalk
+- Telegram
+- Microsoft Teams
 
 ### Event information
 
@@ -104,3 +112,64 @@ X-Gitea-Event: push
   }
 }
 ```
+
+### Example
+
+This is an example of how to use webhooks to run a php script upon push requests to the repository.
+In your repository Settings, under Webhooks, Setup a Gitea webhook as follows:
+
+- Target URL: http://mydomain.com/webhook.php
+- HTTP Method: POST
+- POST Content Type: application/json
+- Secret: 123
+- Trigger On: Push Events
+- Active: Checked
+
+Now on your server create the php file webhook.php
+
+```
+<?php
+
+$secret_key = '123';
+
+// check for POST request
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    error_log('FAILED - not POST - '. $_SERVER['REQUEST_METHOD']);
+    exit();
+}
+
+// get content type
+$content_type = isset($_SERVER['CONTENT_TYPE']) ? strtolower(trim($_SERVER['CONTENT_TYPE'])) : '';
+
+if ($content_type != 'application/json') {
+    error_log('FAILED - not application/json - '. $content_type);
+    exit();
+}
+
+// get payload
+$payload = trim(file_get_contents("php://input"));
+
+if (empty($payload)) {
+    error_log('FAILED - no payload');
+    exit();
+}
+
+// convert json to array
+$decoded = json_decode($payload, true);
+
+// check for json decode errors
+if (json_last_error() !== JSON_ERROR_NONE) {
+    error_log('FAILED - json decode - '. json_last_error());
+    exit();
+}
+
+// check authorization
+if ($decoded['secret'] != $secret_key) {
+    error_log('FAILED - not authorized - '. $decoded['secret']);
+    exit();
+}
+
+// success, do something
+```
+
+There is a Test Delivery button in the webhook settings that allows to test the configuration as well as a list of the most Recent Deliveries.

--- a/docs/content/doc/usage/https-support.md
+++ b/docs/content/doc/usage/https-support.md
@@ -27,8 +27,8 @@ To use Gitea's built-in HTTPS support, you must change your `app.ini` file:
 PROTOCOL  = https
 ROOT_URL  = https://git.example.com:3000/
 HTTP_PORT = 3000
-CERT_FILE = cert.pem
-KEY_FILE  = key.pem
+CERT_FILE = /etc/gitea/cert.pem
+KEY_FILE  = /etc/gitea/key.pem
 ```
 
 To learn more about the config values, please checkout the [Config Cheat Sheet](../config-cheat-sheet#server).


### PR DESCRIPTION
I have noticed that gitea fails to load the certificate when relative path is used.
This happens at least when running it as a service as described in the documentation.

I also updated the webhook documentation to include the full list of supported hooks as well as an example on how to use webhooks.