### PR TITLE
Doc added instructions for Git LFS support

### DIFF
--- a/docs/content/doc/usage/git-lfs-support.md
+++ b/docs/content/doc/usage/git-lfs-support.md
@@ -1,0 +1,26 @@
+---
+date: "2019-10-06T08:00:00+05:00"
+title: "Usage: Git LFS setup"
+slug: "git-lfs-setup"
+weight: 12
+toc: true
+draft: false
+menu:
+  sidebar:
+    parent: "usage"
+    name: "Git LFS setup"
+    weight: 12
+    identifier: "git-lfs-setup"
+---
+
+# Git Large File Storage setup
+
+To use Gitea's built-in LFS support, you must update the `app.ini` file:
+
+```ini
+[server]
+; Enables git-lfs support. true or false, default is false.
+LFS_START_SERVER = true
+; Where your lfs files reside, default is data/lfs.
+LFS_CONTENT_PATH = /home/gitea/data/lfs
+```


### PR DESCRIPTION
Under Docs Usage menu, added an article on how to enable Git LFS support. It's actually easy, but it took me a long time to figure out when I first installed gitea.