### PR TITLE
Update strk.kbt.io/projects/go/libravatar to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	gopkg.in/stretchr/testify.v1 v1.2.2 // indirect
 	gopkg.in/testfixtures.v2 v2.5.0
 	mvdan.cc/xurls/v2 v2.0.0
-	strk.kbt.io/projects/go/libravatar v0.0.0-20160628055650-5eed7bff870a
+	strk.kbt.io/projects/go/libravatar v0.0.0-20191008002943-06d1c002b251
 	xorm.io/builder v0.3.6
 	xorm.io/core v0.7.2
 )

--- a/go.sum
+++ b/go.sum
@@ -815,8 +815,8 @@ honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 mvdan.cc/xurls/v2 v2.0.0 h1:r1zSOSNS/kqtpmATyMMMvaZ4/djsesbYz5kr0+qMRWc=
 mvdan.cc/xurls/v2 v2.0.0/go.mod h1:2/webFPYOXN9jp/lzuj0zuAVlF+9g4KPFJANH1oJhRU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
-strk.kbt.io/projects/go/libravatar v0.0.0-20160628055650-5eed7bff870a h1:8q33ShxKXRwQ7JVd1ZnhIU3hZhwwn0Le+4fTeAackuM=
-strk.kbt.io/projects/go/libravatar v0.0.0-20160628055650-5eed7bff870a/go.mod h1:FJGmPh3vz9jSos1L/F91iAgnC/aejc0wIIrF2ZwJxdY=
+strk.kbt.io/projects/go/libravatar v0.0.0-20191008002943-06d1c002b251 h1:mUcz5b3FJbP5Cvdq7Khzn6J9OCUQJaBwgBkCR+MOwSs=
+strk.kbt.io/projects/go/libravatar v0.0.0-20191008002943-06d1c002b251/go.mod h1:FJGmPh3vz9jSos1L/F91iAgnC/aejc0wIIrF2ZwJxdY=
 xorm.io/builder v0.3.6 h1:ha28mQ2M+TFx96Hxo+iq6tQgnkC9IZkM6D8w9sKHHF8=
 xorm.io/builder v0.3.6/go.mod h1:LEFAPISnRzG+zxaxj2vPicRwz67BdhFreKg8yv8/TgU=
 xorm.io/core v0.7.2-0.20190928055935-90aeac8d08eb h1:msX3zG3BPl8Ti+LDzP33/9K7BzO/WqFXk610K1kYKfo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -612,7 +612,7 @@ gopkg.in/warnings.v0
 gopkg.in/yaml.v2
 # mvdan.cc/xurls/v2 v2.0.0
 mvdan.cc/xurls/v2
-# strk.kbt.io/projects/go/libravatar v0.0.0-20160628055650-5eed7bff870a
+# strk.kbt.io/projects/go/libravatar v0.0.0-20191008002943-06d1c002b251
 strk.kbt.io/projects/go/libravatar
 # xorm.io/builder v0.3.6
 xorm.io/builder

--- a/vendor/strk.kbt.io/projects/go/libravatar/Makefile
+++ b/vendor/strk.kbt.io/projects/go/libravatar/Makefile
@@ -1,0 +1,12 @@
+PACKAGES ?= $(shell go list ./...)
+
+.PHONY: check
+check: lint
+	go test
+
+.PHONY: lint
+lint:
+	@which golint > /dev/null; if [ $$? -ne 0 ]; then \
+		go get -u github.com/golang/lint/golint; \
+	fi
+	@for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;

--- a/vendor/strk.kbt.io/projects/go/libravatar/README.md
+++ b/vendor/strk.kbt.io/projects/go/libravatar/README.md
@@ -1,12 +1,14 @@
 Simple [golang](https://www.golang.org) library for serving
 [federated avatars](https://www.libravatar.org)
 
+[![trunk](https://goreportcard.com/badge/strk.kbt.io/projects/go/libravatar)]
+(https://goreportcard.com/report/strk.kbt.io/projects/go/libravatar)
+
 # Use
 
 ```sh
 go get strk.kbt.io/projects/go/libravatar
-cd $GOPATH/src/strk.kbt.io/projects/go/libravatar
-go doc
+go doc strk.kbt.io/projects/go/libravatar
 ```
 
 # Contribute


### PR DESCRIPTION
Closes #7860

This version [adds a mutex](https://gitlab.com/strk/go-libravatar/merge_requests/1) to serialize access to the gravatar cache.