### PR TITLE
Ensure Request Body Readers are closed in LFS server

### DIFF
--- a/modules/lfs/locks.go
+++ b/modules/lfs/locks.go
@@ -155,7 +155,9 @@ func PostLockHandler(ctx *context.Context) {
 	}
 
 	var req api.LFSLockRequest
-	dec := json.NewDecoder(ctx.Req.Body().ReadCloser())
+	bodyReader := ctx.Req.Body().ReadCloser()
+	defer bodyReader.Close()
+	dec := json.NewDecoder(bodyReader)
 	if err := dec.Decode(&req); err != nil {
 		writeStatus(ctx, 400)
 		return
@@ -269,7 +271,9 @@ func UnLockHandler(ctx *context.Context) {
 	}
 
 	var req api.LFSLockDeleteRequest
-	dec := json.NewDecoder(ctx.Req.Body().ReadCloser())
+	bodyReader := ctx.Req.Body().ReadCloser()
+	defer bodyReader.Close()
+	dec := json.NewDecoder(bodyReader)
 	if err := dec.Decode(&req); err != nil {
 		writeStatus(ctx, 400)
 		return

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -327,7 +327,9 @@ func PutHandler(ctx *context.Context) {
 	}
 
 	contentStore := &ContentStore{BasePath: setting.LFS.ContentPath}
-	if err := contentStore.Put(meta, ctx.Req.Body().ReadCloser()); err != nil {
+	bodyReader := ctx.Req.Body().ReadCloser()
+	defer bodyReader.Close()
+	if err := contentStore.Put(meta, bodyReader); err != nil {
 		ctx.Resp.WriteHeader(500)
 		fmt.Fprintf(ctx.Resp, `{"message":"%s"}`, err)
 		if err = repository.RemoveLFSMetaObjectByOid(rv.Oid); err != nil {
@@ -434,7 +436,9 @@ func unpack(ctx *context.Context) *RequestVars {
 
 	if r.Method == "POST" { // Maybe also check if +json
 		var p RequestVars
-		dec := json.NewDecoder(r.Body().ReadCloser())
+		bodyReader := r.Body().ReadCloser()
+		defer bodyReader.Close()
+		dec := json.NewDecoder(bodyReader)
 		err := dec.Decode(&p)
 		if err != nil {
 			return rv
@@ -453,7 +457,9 @@ func unpackbatch(ctx *context.Context) *BatchVars {
 	r := ctx.Req
 	var bv BatchVars
 
-	dec := json.NewDecoder(r.Body().ReadCloser())
+	bodyReader := r.Body().ReadCloser()
+	defer bodyReader.Close()
+	dec := json.NewDecoder(bodyReader)
 	err := dec.Decode(&bv)
 	if err != nil {
 		return &bv


### PR DESCRIPTION
There are multiple places in the LFS server code where Request Body ReadClosers are created however, these are not closed at the end of their use. This could lead to multiple hanging unclosed requests. 

This PR ensures that these ReadClosers are closed.

Fix #8273