### PR TITLE
Add support for X-Hub-Signature headers in webhooks 

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -252,6 +252,8 @@ var migrations = []Migration{
 	NewMigration("add repo_admin_change_team_access to user", addRepoAdminChangeTeamAccessColumnForUser),
 	// v98 -> v99
 	NewMigration("add original author name and id on migrated release", addOriginalAuthorOnMigratedReleases),
+	// v99 -> v100
+	NewMigration("rename signature column to support sha1 and sha256 webhook signatures", specifyWebhookSignatureType),
 }
 
 // Migrate database to current version

--- a/models/migrations/v99.go
+++ b/models/migrations/v99.go
@@ -15,11 +15,11 @@ func specifyWebhookSignatureType(x *xorm.Engine) error {
 
 	switch x.Dialect().DriverName() {
 	case "mysql":
-		_, err = x.Exec("ALTER TABLE `webhook` CHANGE COLUMN `signature` TO `signature_sha1`")
+		_, err = x.Exec("ALTER TABLE webhook CHANGE COLUMN signature signature_sha1 text")
 	case "postgres":
-		_, err = x.Exec("ALTER TABLE `webhook` RENAME COLUMN `signature` TO `signature_sha1`")
+		_, err = x.Exec("ALTER TABLE webhook RENAME COLUMN signature TO signature_sha1")
 	case "mssql":
-		_, err = x.Exec("sp_rename 'webhook.signature', 'signature_sha1', 'COLUMN'")
+		_, err = x.Exec("sp_rename @objname = 'webhook.signature', @newname = 'signature_sha1', @objtype = 'COLUMN'")
 	}
 
 	if err != nil {

--- a/models/migrations/v99.go
+++ b/models/migrations/v99.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-xorm/xorm"
+)
+
+func specifyWebhookSignatureType(x *xorm.Engine) error {
+	var err error
+
+	switch x.Dialect().DriverName() {
+	case "mysql":
+		_, err = x.Exec("ALTER TABLE `webhook` CHANGE COLUMN `signature` TO `signature_sha1`")
+	case "postgres":
+		_, err = x.Exec("ALTER TABLE `webhook` RENAME COLUMN `signature` TO `signature_sha1`")
+	case "mssql":
+		_, err = x.Exec("sp_rename 'webhook.signature', 'signature_sha1', 'COLUMN'")
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error renaming webhook signature column to signature_sha1: %v", err)
+	}
+
+	return nil
+}

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -574,7 +574,7 @@ type HookTask struct {
 	UUID            string
 	Type            HookTaskType
 	URL             string `xorm:"TEXT"`
-	SignatureSha1   string `xorm:"TEXT"`
+	Signature       string `xorm:"TEXT"`
 	SignatureSha256 string `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -575,7 +575,7 @@ type HookTask struct {
 	Type            HookTaskType
 	URL             string `xorm:"TEXT"`
 	Signature       string `xorm:"TEXT"`
-	SignatureSha256 string `xorm:"TEXT"`
+	SignatureSha1   string `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -107,22 +107,22 @@ const (
 
 // Webhook represents a web hook object.
 type Webhook struct {
-	ID           int64  `xorm:"pk autoincr"`
-	RepoID       int64  `xorm:"INDEX"`
-	OrgID        int64  `xorm:"INDEX"`
-	URL          string `xorm:"url TEXT"`
-	SignatureSha1    string `xorm:"TEXT"`
-	SignatureSha256  string `xorm:"TEXT"`
-	HTTPMethod   string `xorm:"http_method"`
-	ContentType  HookContentType
-	Secret       string `xorm:"TEXT"`
-	Events       string `xorm:"TEXT"`
-	*HookEvent   `xorm:"-"`
-	IsSSL        bool `xorm:"is_ssl"`
-	IsActive     bool `xorm:"INDEX"`
-	HookTaskType HookTaskType
-	Meta         string     `xorm:"TEXT"` // store hook-specific attributes
-	LastStatus   HookStatus // Last delivery status
+	ID              int64  `xorm:"pk autoincr"`
+	RepoID          int64  `xorm:"INDEX"`
+	OrgID           int64  `xorm:"INDEX"`
+	URL             string `xorm:"url TEXT"`
+	SignatureSha1   string `xorm:"TEXT"`
+	SignatureSha256 string `xorm:"TEXT"`
+	HTTPMethod      string `xorm:"http_method"`
+	ContentType     HookContentType
+	Secret          string `xorm:"TEXT"`
+	Events          string `xorm:"TEXT"`
+	*HookEvent      `xorm:"-"`
+	IsSSL           bool `xorm:"is_ssl"`
+	IsActive        bool `xorm:"INDEX"`
+	HookTaskType    HookTaskType
+	Meta            string     `xorm:"TEXT"` // store hook-specific attributes
+	LastStatus      HookStatus // Last delivery status
 
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
@@ -574,8 +574,8 @@ type HookTask struct {
 	UUID            string
 	Type            HookTaskType
 	URL             string `xorm:"TEXT"`
-	SignatureSha1       string `xorm:"TEXT"`
-	SignatureSha256     string `xorm:"TEXT"`
+	SignatureSha1   string `xorm:"TEXT"`
+	SignatureSha256 string `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`
@@ -772,17 +772,17 @@ func prepareWebhook(e Engine, w *Webhook, repo *Repository, event HookEventType,
 	}
 
 	if err = createHookTask(e, &HookTask{
-		RepoID:      repo.ID,
-		HookID:      w.ID,
-		Type:        w.HookTaskType,
-		URL:         w.URL,
+		RepoID:          repo.ID,
+		HookID:          w.ID,
+		Type:            w.HookTaskType,
+		URL:             w.URL,
 		SignatureSha1:   signatureSha1,
-		SignatureSha256:   signatureSha256,
-		Payloader:   payloader,
-		HTTPMethod:  w.HTTPMethod,
-		ContentType: w.ContentType,
-		EventType:   event,
-		IsSSL:       w.IsSSL,
+		SignatureSha256: signatureSha256,
+		Payloader:       payloader,
+		HTTPMethod:      w.HTTPMethod,
+		ContentType:     w.ContentType,
+		EventType:       event,
+		IsSSL:           w.IsSSL,
 	}); err != nil {
 		return fmt.Errorf("CreateHookTask: %v", err)
 	}


### PR DESCRIPTION
Send a new header X-Hub-Signature using the sha1 format

Renames existing Signature to Signature256 since we need to generate to HMACs from the same secret

Fix #7788