### PR TITLE
Fix #8453 by making openssh listen on SSH_LISTEN_PORT not SSH_PORT

### DIFF
--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -26,6 +26,7 @@ fi
 
 if [ -d /etc/ssh ]; then
     SSH_PORT=${SSH_PORT:-"22"} \
+    SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"${SSH_PORT}"} \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -1,4 +1,4 @@
-Port ${SSH_PORT}
+Port ${SSH_LISTEN_PORT}
 Protocol 2
 
 AddressFamily any


### PR DESCRIPTION
#7829 made the docker support SSH_LISTEN_PORT for those who are using the internal SSH server but did not extend this functionality to the OpenSSHD.

Although we are/were planning to switch to the internal SSH by default - this currently leaves us in a bit of a conflicted state. This PR extends that functionality to the current default provider, OpenSSHD.

Fixes #8453 