### PR TITLE
Makefile: Properly clean and generate bindata.go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	endif
 endif
 
-BINDATA := modules/{options,public,templates}/bindata.go
+BINDATA := modules/options/bindata.go modules/public/bindata.go modules/templates/bindata.go
 GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*" ! -path "*/bindata.go")
 GOFMT ?= gofmt -s
 
@@ -42,7 +42,7 @@ endif
 LDFLAGS := $(LDFLAGS) -X "main.MakeVersion=$(MAKE_VERSION)" -X "main.Version=$(GITEA_VERSION)" -X "main.Tags=$(TAGS)"
 
 PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations/migration-test,$(filter-out code.gitea.io/gitea/integrations,$(shell GO111MODULE=on $(GO) list -mod=vendor ./... | grep -v /vendor/)))
-SOURCES ?= $(shell find . -name "*.go" -type f)
+SOURCES ?= $(shell find . -name "*.go" -type f) $(BINDATA)
 
 TAGS ?=
 
@@ -100,6 +100,7 @@ vet:
 .PHONY: generate
 generate:
 	GO111MODULE=on $(GO) generate -mod=vendor $(PACKAGES)
+$(BINDATA): generate
 
 .PHONY: generate-swagger
 generate-swagger:


### PR DESCRIPTION
Running something like "make clean generate build -j4 && ./gitea web"
on my system would build gitea with deleted files.

This is really weird, but a result of a race condition:
- 'make clean' wouldn't delete bindata.go as it used bad globbing
- 'build' and 'generate' would run in parallel, 'generate' taking longer
- 'build' would pack in older bindata.go files before 'generate' finished
- 'generate' would finish and output new bindata.go files

So in effect this happened:
- I built gitea from source for the first time
- I modified a file and built gitea which showed no change
- I deleted the file and built gitea which now showed the modified file
- I added the file back and built gitea which now couldn't find the file