### PR TITLE
IsBranchExist: return false if provided name is empty (#8485)

### DIFF
--- a/modules/git/repo_branch.go
+++ b/modules/git/repo_branch.go
@@ -28,8 +28,14 @@ func IsBranchExist(repoPath, name string) bool {
 
 // IsBranchExist returns true if given branch exists in current repository.
 func (repo *Repository) IsBranchExist(name string) bool {
-	_, err := repo.gogitRepo.Reference(plumbing.ReferenceName(BranchPrefix+name), true)
-	return err == nil
+	if name == "" {
+		return false
+	}
+	reference, err := repo.gogitRepo.Reference(plumbing.ReferenceName(BranchPrefix+name), true)
+	if err != nil {
+		return false
+	}
+	return reference.Type() != plumbing.InvalidReference
 }
 
 // Branch represents a Git branch.


### PR DESCRIPTION
Backport #8485 

* IsBranchExist: return false if provided name is empty

* Ensure that the reference returned is actually of a valid type
