### PR TITLE
Allow committing / adding empty files using the web ui (#8420)

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -557,7 +557,7 @@ func (f *NewWikiForm) Validate(ctx *macaron.Context, errs binding.Errors) bindin
 // EditRepoFileForm form for changing repository file
 type EditRepoFileForm struct {
 	TreePath      string `binding:"Required;MaxSize(500)"`
-	Content       string `binding:"Required"`
+	Content       string
 	CommitSummary string `binding:"MaxSize(100)"`
 	CommitMessage string
 	CommitChoice  string `binding:"Required;MaxSize(50)"`

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -726,6 +726,8 @@ editor.file_editing_no_longer_exists = The file being edited, '%s', no longer ex
 editor.file_deleting_no_longer_exists = The file being deleted, '%s', no longer exists in this repository.
 editor.file_changed_while_editing = The file contents have changed since you started editing. <a target="_blank" rel="noopener noreferrer" href="%s">Click here</a> to see them or <strong>Commit Changes again</strong> to overwrite them.
 editor.file_already_exists = A file named '%s' already exists in this repository.
+editor.commit_empty_file_header = Commit an empty file
+editor.commit_empty_file_text = The file you're about commit is empty. Proceed?
 editor.no_changes_to_show = There are no changes to show.
 editor.fail_to_update_file = Failed to update/create file '%s' with error: %v
 editor.add_subdir = Add a directory…

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -262,7 +262,7 @@ function initRepoStatusChecker() {
                             location.reload();
                             return
                         }
-            
+
                         setTimeout(function () {
                             initRepoStatusChecker()
                         }, 2000);
@@ -1571,6 +1571,18 @@ function initEditor() {
             codeMirrorEditor.setOption("tabSize", editorconfig.tab_width || 4);
         });
     }).trigger('keyup');
+
+    $('#commit-button').click(function (event) {
+        // A modal which asks if an empty file should be committed
+        if ($editArea.val().length === 0) {
+            $('#edit-empty-content-modal').modal({
+                onApprove: function () {
+                    $('.edit.form').submit();
+                }
+            }).modal('show');
+            event.preventDefault();
+        }
+    });
 }
 
 function initOrganization() {

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -52,5 +52,27 @@
 			{{template "repo/editor/commit_form" .}}
 		</form>
 	</div>
+
+
+	<div class="ui small basic modal" id="edit-empty-content-modal">
+		<div class="ui icon header">
+			<i class="file icon"></i>
+            {{.i18n.Tr "repo.editor.commit_empty_file_header"}}
+		</div>
+		<div class="center content">
+			<p>{{.i18n.Tr "repo.editor.commit_empty_file_text"}}</p>
+		</div>
+		<div class="actions">
+			<div class="ui red basic cancel inverted button">
+				<i class="remove icon"></i>
+                {{.i18n.Tr "repo.editor.cancel"}}
+			</div>
+			<div class="ui green basic ok inverted button">
+				<i class="save icon"></i>
+                {{.i18n.Tr "repo.editor.commit_changes"}}
+			</div>
+		</div>
+	</div>
+
 </div>
 {{template "base/footer" .}}

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -39,8 +39,7 @@
 						data-url="{{.Repository.APIURL}}/markdown"
 						data-context="{{.RepoLink}}"
 						data-markdown-file-exts="{{.MarkdownFileExts}}"
-						data-line-wrap-extensions="{{.LineWrapExtensions}}"
-						required>
+						data-line-wrap-extensions="{{.LineWrapExtensions}}">
 {{.FileContent}}</textarea>
 				</div>
 				<div class="ui bottom attached tab segment markdown" data-tab="preview">


### PR DESCRIPTION
Hey,
this commit tries to fix the issue #8420.

**The Problem**
It wasn't possible to commit empty files using the online editor. There was also no error when the content of the file was empty, it just did not work.

Empty files are needed to force Git to clone empty folders, for example `.gitkeep`.

**My solution**
I removed the required tag for the `edit_area` and now it's possible to commit empty files.