### PR TITLE
fix hide auth source options

### DIFF
--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -35,7 +35,7 @@
 				{{ template "admin/auth/source/smtp" . }}
 
 				<!-- PAM -->
-				<div class="pam required field {{if not (eq .type 4)}}hide{{end}}">
+				<div class="pam required field">
 					<label for="pam_service_name">{{.i18n.Tr "admin.auths.pam_service_name"}}</label>
 					<input id="pam_service_name" name="pam_service_name" value="{{.pam_service_name}}" />
 				</div>

--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -1,4 +1,4 @@
-<div class="ldap dldap field {{if not (or (eq .type 2) (eq .type 5))}}hide{{end}}">
+<div class="ldap dldap field">
 	<div class="inline required field {{if .Err_SecurityProtocol}}error{{end}}">
 		<label>{{.i18n.Tr "admin.auths.security_protocol"}}</label>
 		<div class="ui selection security-protocol dropdown">

--- a/templates/admin/auth/source/oauth.tmpl
+++ b/templates/admin/auth/source/oauth.tmpl
@@ -1,4 +1,4 @@
-<div class="oauth2 field {{if not (eq .type 6)}}hide{{end}}">
+<div class="oauth2 field">
 	<div class="inline required field">
 		<label>{{.i18n.Tr "admin.auths.oauth2_provider"}}</label>
 		<div class="ui selection type dropdown">

--- a/templates/admin/auth/source/smtp.tmpl
+++ b/templates/admin/auth/source/smtp.tmpl
@@ -1,4 +1,4 @@
-<div class="smtp field {{if not (eq .type 3)}}hide{{end}}">
+<div class="smtp field">
 	<div class="inline required field">
 		<label>{{.i18n.Tr "admin.auths.smtp_auth"}}</label>
 		<div class="ui selection type dropdown">


### PR DESCRIPTION
I found the I can't see the options when adding new auth source.
After checking the code, I've found the options are hidden, and jQuery show() will not remove the `hide` css class.
so I fix it.