### PR TITLE
Restrict modules/graceful to non-windows build and shim IsChild

### DIFF
--- a/modules/graceful/cleanup.go
+++ b/modules/graceful/cleanup.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/graceful_windows.go
+++ b/modules/graceful/graceful_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+// This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
+
+package graceful
+
+// This file contains shims for windows builds
+const IsChild = false

--- a/modules/graceful/net.go
+++ b/modules/graceful/net.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/restart.go
+++ b/modules/graceful/restart.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/server.go
+++ b/modules/graceful/server.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/server_hooks.go
+++ b/modules/graceful/server_hooks.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/server_http.go
+++ b/modules/graceful/server_http.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/modules/graceful/server_signals.go
+++ b/modules/graceful/server_signals.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Unfortunately the graceful module cannot build on windows but is a build dependency due to the use of the IsChild marker for gracefully handling index reload.

This PR will fix our release build by protecting windows builds from seeing the unix based code in modules/graceful and shimming IsChild.

We still need to create a PR to handle windows reloads gracefully - if at all possible.

Fixes #8544 