### PR TITLE
Ensure that GitRepo is set on Empty repositories

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -414,8 +414,8 @@ func RepoAssignment() macaron.Handler {
 			}
 		}
 
-		// repo is empty and display enable
-		if ctx.Repo.Repository.IsEmpty || ctx.Repo.Repository.IsBeingCreated() {
+		// Disable everything when the repo is being created
+		if ctx.Repo.Repository.IsBeingCreated() {
 			ctx.Data["BranchName"] = ctx.Repo.Repository.DefaultBranch
 			return
 		}
@@ -426,6 +426,12 @@ func RepoAssignment() macaron.Handler {
 			return
 		}
 		ctx.Repo.GitRepo = gitRepo
+
+		// Stop at this point when the repo is empty.
+		if ctx.Repo.Repository.IsEmpty {
+			ctx.Data["BranchName"] = ctx.Repo.Repository.DefaultBranch
+			return
+		}
 
 		tags, err := ctx.Repo.GitRepo.GetTags()
 		if err != nil {


### PR DESCRIPTION
Both issues/new and settings/hooks/git expect `ctx.Repo.GitRepo` to be set.
This PR changes the context code to open the GitRepo.

(We may want to check further what we need to disable/read in Empty repositories and whether we can allow more functionality by default on empty repositories.)

Fixes #8538 