### PR TITLE
Allow externalID to be UUID

### DIFF
--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -168,7 +168,7 @@ func FindExternalUsersByProvider(opts FindExternalUserOptions) ([]ExternalLoginU
 }
 
 // UpdateMigrationsByType updates all migrated repositories' posterid from gitServiceType to replace originalAuthorID to posterID
-func UpdateMigrationsByType(tp structs.GitServiceType, externalUserID, userID int64) error {
+func UpdateMigrationsByType(tp structs.GitServiceType, externalUserID string, userID int64) error {
 	if err := UpdateIssuesMigrationsByType(tp, externalUserID, userID); err != nil {
 		return err
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -1936,7 +1936,7 @@ func (issue *Issue) ResolveMentionsByVisibility(ctx DBContext, doer *User, menti
 }
 
 // UpdateIssuesMigrationsByType updates all migrated repositories' issues from gitServiceType to replace originalAuthorID to posterID
-func UpdateIssuesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID, posterID int64) error {
+func UpdateIssuesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID string, posterID int64) error {
 	_, err := x.Table("issue").
 		Where("repo_id IN (SELECT id FROM repository WHERE original_service_type = ?)", gitServiceType).
 		And("original_author_id = ?", originalAuthorID).

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1046,7 +1046,7 @@ func FetchCodeComments(issue *Issue, currentUser *User) (CodeComments, error) {
 }
 
 // UpdateCommentsMigrationsByType updates comments' migrations information via given git service type and original id and poster id
-func UpdateCommentsMigrationsByType(tp structs.GitServiceType, originalAuthorID, posterID int64) error {
+func UpdateCommentsMigrationsByType(tp structs.GitServiceType, originalAuthorID string, posterID int64) error {
 	_, err := x.Table("comment").
 		Where(builder.In("issue_id",
 			builder.Select("issue.id").

--- a/models/release.go
+++ b/models/release.go
@@ -369,7 +369,7 @@ func SyncReleasesWithTags(repo *Repository, gitRepo *git.Repository) error {
 }
 
 // UpdateReleasesMigrationsByType updates all migrated repositories' releases from gitServiceType to replace originalAuthorID to posterID
-func UpdateReleasesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID, posterID int64) error {
+func UpdateReleasesMigrationsByType(gitServiceType structs.GitServiceType, originalAuthorID string, posterID int64) error {
 	_, err := x.Table("release").
 		Where("repo_id IN (SELECT id FROM repository WHERE original_service_type = ?)", gitServiceType).
 		And("original_author_id = ?", originalAuthorID).

--- a/modules/migrations/update.go
+++ b/modules/migrations/update.go
@@ -5,8 +5,6 @@
 package migrations
 
 import (
-	"strconv"
-
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/structs"
@@ -40,11 +38,7 @@ func updateMigrationPosterIDByGitService(tp structs.GitServiceType) error {
 		}
 
 		for _, user := range users {
-			externalUserID, err := strconv.ParseInt(user.ExternalID, 10, 64)
-			if err != nil {
-				log.Warn("Parse externalUser %#v 's userID failed: %v", user, err)
-				continue
-			}
+			externalUserID := user.ExternalID
 			if err := models.UpdateMigrationsByType(tp, externalUserID, user.UserID); err != nil {
 				log.Error("UpdateMigrationsByType type %s external user id %v to local user id %v failed: %v", tp.Name(), user.ExternalID, user.UserID, err)
 			}

--- a/services/externalaccount/user.go
+++ b/services/externalaccount/user.go
@@ -5,7 +5,6 @@
 package externalaccount
 
 import (
-	"strconv"
 	"strings"
 
 	"code.gitea.io/gitea/models"
@@ -45,10 +44,7 @@ func LinkAccountToUser(user *models.User, gothUser goth.User) error {
 		return err
 	}
 
-	externalID, err := strconv.ParseInt(externalLoginUser.ExternalID, 10, 64)
-	if err != nil {
-		return err
-	}
+	externalID := externalLoginUser.ExternalID
 
 	var tp structs.GitServiceType
 	for _, s := range structs.SupportedFullGitService {


### PR DESCRIPTION
Fix a issue that introduced in https://github.com/go-gitea/gitea/pull/7751 which prevents using Keycloak as an OpenID provider.

The issue is caused by calling `strconv.ParseInt` on `ExternalID` since some provider uses UUID for JWT `sub` field, which generate the following error when trying to link external account:

```
2019/10/16 20:46:48 routers/user/auth.go:807:LinkAccountPostSignIn() [E] UserLinkAccount: strconv.ParseInt: parsing "a9ba181f-3b75-4c3a-a571-47f9d2cb6b5c": invalid syntax
```

I also suggest to change SQL type of `AccessToken`, `AccessTokenSecret`, and `RefreshToken` to  `TEXT` to store large string (Keycloak returns `AccessToken` and `RefreshToken` with more than 1000 characters, which throws errors when trying to insert into database)