### PR TITLE
Allow more than 255 characters for tokens in external_login_user table

### DIFF
--- a/models/external_login_user.go
+++ b/models/external_login_user.go
@@ -28,9 +28,9 @@ type ExternalLoginUser struct {
 	Description       string
 	AvatarURL         string
 	Location          string
-	AccessToken       string
-	AccessTokenSecret string
-	RefreshToken      string
+	AccessToken       string `xorm:"TEXT"`
+	AccessTokenSecret string `xorm:"TEXT"`
+	RefreshToken      string `xorm:"TEXT"`
 	ExpiresAt         time.Time
 }
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -256,6 +256,8 @@ var migrations = []Migration{
 	NewMigration("add task table and status column for repository table", addTaskTable),
 	// v100 -> v101
 	NewMigration("update migration repositories' service type", updateMigrationServiceTypes),
+	// v101 -> v102
+	NewMigration("change length of some external login users columns", changeSomeColumnsLengthOfExternalLoginUser),
 }
 
 // Migrate database to current version

--- a/models/migrations/v101.go
+++ b/models/migrations/v101.go
@@ -1,0 +1,19 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"xorm.io/xorm"
+)
+
+func changeSomeColumnsLengthOfExternalLoginUser(x *xorm.Engine) error {
+	type ExternalLoginUser struct {
+		AccessToken       string `xorm:"TEXT"`
+		AccessTokenSecret string `xorm:"TEXT"`
+		RefreshToken      string `xorm:"TEXT"`
+	}
+
+	return x.Sync2(new(ExternalLoginUser))
+}


### PR DESCRIPTION
As discussed in https://github.com/go-gitea/gitea/pull/8551, some OpenID provider like keycloak send back large JWT body that won't fit into `VARCHAR(255)`, and Gitea is not going to query by those fields, so make them `TEXT` for large JWT body.