### PR TITLE
Implement/Fix PR review webhooks

### DIFF
--- a/models/webhook_discord.go
+++ b/models/webhook_discord.go
@@ -413,7 +413,17 @@ func getDiscordPullRequestApprovalPayload(p *api.PullRequestPayload, meta *Disco
 
 		title = fmt.Sprintf("[%s] Pull request review %s: #%d %s", p.Repository.FullName, action, p.Index, p.PullRequest.Title)
 		text = p.PullRequest.Body
-		color = warnColor
+
+		switch event {
+		case HookEventPullRequestApproved:
+			color = successColor
+		case HookEventPullRequestRejected:
+			color = failedColor
+		case HookEventPullRequestComment:
+			fallthrough
+		default:
+			color = warnColor
+		}
 	}
 
 	return &DiscordPayload{

--- a/routers/repo/pull_review.go
+++ b/routers/repo/pull_review.go
@@ -157,7 +157,7 @@ func SubmitReview(ctx *context.Context, form auth.SubmitReviewForm) {
 			return
 		}
 		// No current review. Create a new one!
-		if review, err = models.CreateReview(models.CreateReviewOptions{
+		if review, err = pull_service.CreateReview(models.CreateReviewOptions{
 			Type:     reviewType,
 			Issue:    issue,
 			Reviewer: ctx.User,
@@ -169,7 +169,7 @@ func SubmitReview(ctx *context.Context, form auth.SubmitReviewForm) {
 	} else {
 		review.Content = form.Content
 		review.Type = reviewType
-		if err = models.UpdateReview(review); err != nil {
+		if err = pull_service.UpdateReview(review); err != nil {
 			ctx.ServerError("UpdateReview", err)
 			return
 		}


### PR DESCRIPTION
Resolves #8322

This PR also changes the embed color for Discord webhooks  
Red = rejected  
Green = approved  
Yellow = comment (this could be grey to match GitHub, but `warnColor` was the old default so it seemed to make about as much sense)