### PR TITLE
Enabling and disabling the commit button to prevent empty commits (web editor)

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1572,7 +1572,21 @@ function initEditor() {
         });
     }).trigger('keyup');
 
-    $('#commit-button').click(function (event) {
+    // Using events from https://github.com/codedance/jquery.AreYouSure#advanced-usage
+    // to enable or disable the commit button
+    const $commitButton = $('#commit-button');
+    const $editForm = $('.ui.edit.form');
+
+    // Disabling the button at the start
+    $commitButton.prop('disabled', true);
+    $editForm.on('dirty.areYouSure', function() {
+        $commitButton.prop('disabled', false);
+    });
+    $editForm.on('clean.areYouSure', function() {
+        $commitButton.prop('disabled', true);
+    });
+
+    $commitButton.click(function (event) {
         // A modal which asks if an empty file should be committed
         if ($editArea.val().length === 0) {
             $('#edit-empty-content-modal').modal({

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1576,14 +1576,20 @@ function initEditor() {
     // to enable or disable the commit button
     const $commitButton = $('#commit-button');
     const $editForm = $('.ui.edit.form');
+    const dirtyFileClass = 'dirty-file';
 
     // Disabling the button at the start
     $commitButton.prop('disabled', true);
-    $editForm.on('dirty.areYouSure', function() {
-        $commitButton.prop('disabled', false);
-    });
-    $editForm.on('clean.areYouSure', function() {
-        $commitButton.prop('disabled', true);
+
+    // Registering a custom listener for the file path and the file content
+    $editForm.areYouSure({
+        slient: true,
+        dirtyClass: dirtyFileClass,
+        fieldSelector: ':input:not(.commit-form-wrapper :input)',
+        change: function () {
+            const dirty = $(this).hasClass(dirtyFileClass);
+            $commitButton.prop('disabled', !dirty);
+        }
     });
 
     $commitButton.click(function (event) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1583,7 +1583,7 @@ function initEditor() {
 
     // Registering a custom listener for the file path and the file content
     $editForm.areYouSure({
-        slient: true,
+        silent: true,
         dirtyClass: dirtyFileClass,
         fieldSelector: ':input:not(.commit-form-wrapper :input)',
         change: function () {


### PR DESCRIPTION
Hey,
here's my follow-up pull request for #8420. 

~It's possible to create an empty commit (no changes) via the web editor. I added a modal which warns the user about this. Here's a screenshot of the modal:~

![Screenshot_2019-10-19 yay](https://user-images.githubusercontent.com/8070210/67147283-d2aa4800-f293-11e9-9430-421cdcbb1bf0.png)

~I compare the content and the file path when the green 'Commit' button is clicked. The initial values are saved for the comparison in an additional `data-initial` field.~
