### PR TITLE
webhook: set Content-Type for application/x-www-form-urlencoded

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -833,6 +833,8 @@ func (t *HookTask) deliver() error {
 
 				return err
 			}
+
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}
 	case http.MethodGet:
 		u, err := url.Parse(t.URL)


### PR DESCRIPTION
This header is missing since switching http client from GiteaServer (`code.gitea.io/gitea/modules/httplib`) to Go-http-client/1.1 (`net.http`).

The header [was added by default](https://github.com/go-gitea/gitea/blob/release/v1.8/modules/httplib/httplib.go#L301) by the former, but this is no longer true with `net.http`, so it needs to be done explicitly.

Ref: https://github.com/go-gitea/gitea/issues/7700
