### PR TITLE
Ensure default gpg settings not nil and found commits have reference to repo

### DIFF
--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -682,7 +682,9 @@ func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
 	defaultGPGSettings, err := c.GetRepositoryDefaultPublicGPGKey(false)
 	if err != nil {
 		log.Error("Error getting default public gpg key: %v", err)
-	} else if defaultGPGSettings != nil && defaultGPGSettings.Sign {
+	} else if defaultGPGSettings == nil {
+		log.Warn("Unable to get defaultGPGSettings for unattached commit: %s", c.ID.String())
+	} else if defaultGPGSettings.Sign {
 		if commitVerification := verifyWithGPGSettings(defaultGPGSettings, sig, c.Signature.Payload, committer, keyID); commitVerification != nil {
 			if commitVerification.Reason == BadSignature {
 				defaultReason = BadSignature

--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -682,7 +682,7 @@ func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
 	defaultGPGSettings, err := c.GetRepositoryDefaultPublicGPGKey(false)
 	if err != nil {
 		log.Error("Error getting default public gpg key: %v", err)
-	} else if defaultGPGSettings.Sign {
+	} else if defaultGPGSettings != nil && defaultGPGSettings.Sign {
 		if commitVerification := verifyWithGPGSettings(defaultGPGSettings, sig, c.Signature.Payload, committer, keyID); commitVerification != nil {
 			if commitVerification.Reason == BadSignature {
 				defaultReason = BadSignature

--- a/modules/git/commit_info.go
+++ b/modules/git/commit_info.go
@@ -72,6 +72,7 @@ func (tes Entries) GetCommitsInfo(commit *Commit, treePath string, cache LastCom
 		treeCommit = commit
 	} else if rev, ok := revs[""]; ok {
 		treeCommit = convertCommit(rev)
+		treeCommit.repo = commit.repo
 	}
 	return commitsInfo, treeCommit, nil
 }


### PR DESCRIPTION
There is a mistake in ParseCommitWithSignature which assumes that if (*git.Commit).GetRepositoryDefaultPublicGPGKey returns nil in the error component that it will always return DefaultGPGSettings. This is not the case and the value should be checked for nil.

This however, revealed a bug in `GetCommitsInfo` whereby a "found" parent commit does not gain a reference to the repository that it is in - this is also fixed.

Fixes #8603 