### PR TITLE
Prevent removal of non-empty emoji panel following selection of duplicate

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -306,7 +306,7 @@ function initReactionSelector(parent) {
             if (resp && (resp.html || resp.empty)) {
                 const content = $(vm).closest('.content');
                 let react = content.find('.segment.reactions');
-                if (react.length > 0) {
+                if (!resp.empty && react.length > 0) {
                     react.remove();
                 }
                 if (!resp.empty) {


### PR DESCRIPTION
If you try to add a duplicate reaction emoji to a comment on the issues page the whole emoji panel will be removed.