### PR TITLE
Update heatmap fixtures to restore tests

### DIFF
--- a/integrations/api_user_heatmap_test.go
+++ b/integrations/api_user_heatmap_test.go
@@ -26,7 +26,7 @@ func TestUserHeatmap(t *testing.T) {
 	var heatmap []*models.UserHeatmapData
 	DecodeJSON(t, resp, &heatmap)
 	var dummyheatmap []*models.UserHeatmapData
-	dummyheatmap = append(dummyheatmap, &models.UserHeatmapData{Timestamp: 1540080000, Contributions: 1})
+	dummyheatmap = append(dummyheatmap, &models.UserHeatmapData{Timestamp: 1571616000, Contributions: 1})
 
 	assert.Equal(t, dummyheatmap, heatmap)
 }

--- a/models/fixtures/action.yml
+++ b/models/fixtures/action.yml
@@ -5,7 +5,7 @@
   act_user_id: 2
   repo_id: 2
   is_private: true
-  created_unix: 1540139562
+  created_unix: 1571686356
 
 -
   id: 2

--- a/models/user_heatmap_test.go
+++ b/models/user_heatmap_test.go
@@ -17,7 +17,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		CountResult int
 		JSONResult  string
 	}{
-		{2, 1, `[{"timestamp":1540080000,"contributions":1}]`},
+		{2, 1, `[{"timestamp":1571616000,"contributions":1}]`},
 		{3, 0, `[]`},
 	}
 	// Prepare

--- a/models/user_heatmap_test.go
+++ b/models/user_heatmap_test.go
@@ -41,7 +41,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		// Get the heatmap and compare
 		heatmap, err := GetUserHeatmapDataByUser(user)
 		assert.NoError(t, err)
-		assert.Equal(t, len(actions), len(heatmap))
+		assert.Equal(t, len(actions), len(heatmap), "invalid action count: did the test data became too old?")
 		assert.Equal(t, tc.CountResult, len(heatmap))
 
 		//Test JSON rendering


### PR DESCRIPTION
The heatmap fixtures have now gone over a year old meaning that our heatmap tests are now broken.

This PR updates the fixtures and sets the default values. 

We need to refactor these fixtures to prevent this in future.