### PR TITLE
Expose db.SetMaxOpenConns and allow all dbs to set conn pool params (#8528)

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -277,10 +277,12 @@ LOG_SQL = true
 DB_RETRIES = 10
 ; Backoff time per DB retry (time.Duration)
 DB_RETRY_BACKOFF = 3s
-; Max idle database connections on connnection pool, default is 0
-MAX_IDLE_CONNS = 0
-; Database connection max life time, default is 3s
+; Max idle database connections on connnection pool, default is 2
+MAX_IDLE_CONNS = 2
+; Database connection max life time, default is 0 or 3s mysql (See #6804 & #7071 for reasoning)
 CONN_MAX_LIFETIME = 3s
+; Database maximum number of open connections, default is 0 meaning no maximum
+MAX_OPEN_CONNS = 0
 
 [indexer]
 ; Issue indexer type, currently support: bleve or db, default is bleve
@@ -823,6 +825,6 @@ TOKEN =
 QUEUE_TYPE = channel
 ; Task queue length, available only when `QUEUE_TYPE` is `channel`.
 QUEUE_LENGTH = 1000
-; Task queue connction string, available only when `QUEUE_TYPE` is `redis`. 
+; Task queue connection string, available only when `QUEUE_TYPE` is `redis`.
 ; If there is a password of redis, use `addrs=127.0.0.1:6379 password=123 db=0`.
 QUEUE_CONN_STR = "addrs=127.0.0.1:6379 db=0"

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -167,8 +167,12 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `LOG_SQL`: **true**: Log the executed SQL.
 - `DB_RETRIES`: **10**: How many ORM init / DB connect attempts allowed.
 - `DB_RETRY_BACKOFF`: **3s**: time.Duration to wait before trying another ORM init / DB connect attempt, if failure occured.
-- `MAX_IDLE_CONNS` **0**: Max idle database connections on connnection pool, default is 0
-- `CONN_MAX_LIFETIME` **3s**: Database connection max lifetime
+- `MAX_OPEN_CONNS` **0**: Database maximum open connections - default is 0, meaning there is no limit.
+- `MAX_IDLE_CONNS` **2**: Max idle database connections on connnection pool, default is 2 - this will be capped to `MAX_OPEN_CONNS`.
+- `CONN_MAX_LIFETIME` **0 or 3s**: Sets the maximum amount of time a DB connection may be reused - default is 0, meaning there is no limit (except on MySQL where it is 3s - see #6804 & #7071).
+  
+Please see #8540 & #8273 for further discussion of the appropriate values for `MAX_OPEN_CONNS`, `MAX_IDLE_CONNS` & `CONN_MAX_LIFETIME` and their
+relation to port exhaustion.
 
 ## Indexer (`indexer`)
 

--- a/models/models.go
+++ b/models/models.go
@@ -157,11 +157,9 @@ func SetEngine() (err error) {
 	// so use log file to instead print to stdout.
 	x.SetLogger(NewXORMLogger(setting.Database.LogSQL))
 	x.ShowSQL(setting.Database.LogSQL)
-	if setting.Database.UseMySQL {
-		x.SetMaxIdleConns(setting.Database.MaxIdleConns)
-		x.SetConnMaxLifetime(setting.Database.ConnMaxLifetime)
-	}
-
+	x.SetMaxOpenConns(setting.Database.MaxOpenConns)
+	x.SetMaxIdleConns(setting.Database.MaxIdleConns)
+	x.SetConnMaxLifetime(setting.Database.ConnMaxLifetime)
 	return nil
 }
 

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -42,12 +42,11 @@ var (
 		DBConnectRetries  int
 		DBConnectBackoff  time.Duration
 		MaxIdleConns      int
+		MaxOpenConns      int
 		ConnMaxLifetime   time.Duration
 		IterateBufferSize int
 	}{
-		Timeout:         500,
-		MaxIdleConns:    0,
-		ConnMaxLifetime: 3 * time.Second,
+		Timeout: 500,
 	}
 )
 
@@ -80,8 +79,13 @@ func InitDBConfig() {
 	Database.Charset = sec.Key("CHARSET").In("utf8", []string{"utf8", "utf8mb4"})
 	Database.Path = sec.Key("PATH").MustString(filepath.Join(AppDataPath, "gitea.db"))
 	Database.Timeout = sec.Key("SQLITE_TIMEOUT").MustInt(500)
-	Database.MaxIdleConns = sec.Key("MAX_IDLE_CONNS").MustInt(0)
-	Database.ConnMaxLifetime = sec.Key("CONN_MAX_LIFE_TIME").MustDuration(3 * time.Second)
+	Database.MaxIdleConns = sec.Key("MAX_IDLE_CONNS").MustInt(2)
+	if Database.UseMySQL {
+		Database.ConnMaxLifetime = sec.Key("CONN_MAX_LIFE_TIME").MustDuration(3 * time.Second)
+	} else {
+		Database.ConnMaxLifetime = sec.Key("CONN_MAX_LIFE_TIME").MustDuration(0)
+	}
+	Database.MaxOpenConns = sec.Key("MAX_OPEN_CONNS").MustInt(0)
 
 	Database.IterateBufferSize = sec.Key("ITERATE_BUFFER_SIZE").MustInt(50)
 	Database.LogSQL = sec.Key("LOG_SQL").MustBool(true)


### PR DESCRIPTION
Backport #8528

* Expose db.SetMaxOpenConns and allow other dbs to set their connection params
* Add note about port exhaustion

Co-Authored-By: guillep2k <18600385+guillep2k@users.noreply.github.com>
