### PR TITLE
Make /users/{username}/repos list private repos the current user has access to

### DIFF
--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -52,7 +52,7 @@ func ListUserRepos(ctx *context.APIContext) {
 	if ctx.Written() {
 		return
 	}
-	private := ctx.IsSigned && (ctx.User.ID == user.ID || ctx.User.IsAdmin)
+	private := ctx.IsSigned
 	listUserRepos(ctx, user, private)
 }
 


### PR DESCRIPTION
This PR is puposed to fix https://github.com/go-gitea/gitea/issues/8619
Please have a look at it for further description.
Some notes towards the PR: I never programmed go before and have no language knowledge
but as far as I can see receives the function listUserRepos private repositories only if the bool private is true. So to fix my Issue I removed the too strong condition in ListUserRepos. This allows non admin users(not owning the repo) to also retrieve the private repositories with read permission.

IMO this should not any have other impacts besides fixing the issue because of the santy checks made in line 28. This condition might also be reduced to just checking for read permission but I have no further framework and api knowledge so I did not touch those lines.

I did not had time to test it yet.
