### PR TITLE
Backport: Prevent .code-view from overriding font on icon fonts (#8614)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -239,7 +239,7 @@ footer .ui.left,footer .ui.right{line-height:40px}
 .lines-commit .ui.avatar.image{height:18px;width:18px}
 .lines-code .bottom-line,.lines-commit .bottom-line,.lines-num .bottom-line{border-bottom:1px solid #eaecef}
 .code-view{overflow:auto;overflow-x:auto;overflow-y:hidden}
-.code-view *{font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}
+.code-view :not(.fa):not(.octicon):not(.icon){font-size:12px;font-family:'SF Mono',Consolas,Menlo,'Liberation Mono',Monaco,'Lucida Console',monospace;line-height:20px}
 .code-view table{width:100%}
 .code-view .active{background:#fff866}
 .markdown:not(code){overflow:hidden;font-size:16px;line-height:1.6!important;word-wrap:break-word}

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -1047,7 +1047,7 @@ footer {
     overflow-x: auto;
     overflow-y: hidden;
 
-    * {
+    *:not(.fa):not(.octicon):not(.icon) {
         font-size: 12px;
         font-family: @monospaced-fonts, monospace;
         line-height: 20px;


### PR DESCRIPTION
Backport of #8614