### PR TITLE
Fix extra columns from `label` table

### DIFF
--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -68,10 +68,10 @@ type Label struct {
 	Color           string `xorm:"VARCHAR(7)"`
 	NumIssues       int
 	NumClosedIssues int
-	NumOpenIssues   int  `xorm:"-"`
-	IsChecked       bool `xorm:"-"`
-	QueryString     string
-	IsSelected      bool
+	NumOpenIssues   int    `xorm:"-"`
+	IsChecked       bool   `xorm:"-"`
+	QueryString     string `xorm:"-"`
+	IsSelected      bool   `xorm:"-"`
 }
 
 // APIFormat converts a Label to the api.Label format

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -262,6 +262,8 @@ var migrations = []Migration{
 	NewMigration("update migration repositories' service type", dropColumnHeadUserNameOnPullRequest),
 	// v103 -> v104
 	NewMigration("Add WhitelistDeployKeys to protected branch", addWhitelistDeployKeysToBranches),
+	// v104 -> v105
+	NewMigration("remove unnecessary columns from label", removeLabelUneededCols),
 }
 
 // Migrate database to current version

--- a/models/migrations/v104.go
+++ b/models/migrations/v104.go
@@ -9,6 +9,16 @@ import (
 )
 
 func removeLabelUneededCols(x *xorm.Engine) error {
+
+	// Make sure the columns exist before dropping them
+	type Label struct {
+		QueryString string
+		IsSelected  bool
+	}
+	if err := x.Sync2(new(Label)); err != nil {
+		return err
+	}
+
 	sess := x.NewSession()
 	defer sess.Close()
 	if err := sess.Begin(); err != nil {

--- a/models/migrations/v104.go
+++ b/models/migrations/v104.go
@@ -20,8 +20,5 @@ func removeLabelUneededCols(x *xorm.Engine) error {
 	if err := dropTableColumns(sess, "label", "is_selected"); err != nil {
 		return err
 	}
-	if err := sess.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return sess.Commit()
 }

--- a/models/migrations/v104.go
+++ b/models/migrations/v104.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"xorm.io/xorm"
+)
+
+func removeLabelUneededCols(x *xorm.Engine) error {
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+	if err := dropTableColumns(sess, "label", "query_string"); err != nil {
+		return err
+	}
+	if err := dropTableColumns(sess, "label", "is_selected"); err != nil {
+		return err
+	}
+	if err := sess.Commit(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Some fields were inadvertently introduced in the database in #5786. This PR removes the mapping, but does not remove the already created columns from existing databases.