### PR TITLE
Improve OGP

### DIFF
--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -242,6 +242,10 @@ func checkPullInfo(ctx *context.Context) *models.Issue {
 		ctx.ServerError("LoadPoster", err)
 		return nil
 	}
+	if err := issue.LoadRepo(); err != nil {
+		ctx.ServerError("LoadRepo", err)
+		return nil
+	}
 	ctx.Data["Title"] = fmt.Sprintf("#%d - %s", issue.Index, issue.Title)
 	ctx.Data["Issue"] = issue
 

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -131,16 +131,25 @@
 	<meta property="og:type" content="profile" />
 	<meta property="og:image" content="{{.Owner.AvatarLink}}" />
 	<meta property="og:url" content="{{.Owner.HTMLURL}}" />
-	<meta property="og:site_name" content="{{AppName}}" />
+	{{if .Owner.Description}}
+		<meta property="og:description" content="{{.Owner.Description}}">
+	{{end}}
 {{else if .Repository}}
-	<meta property="og:title" content="{{.Repository.Name}}" />
+	{{if .Issue}}
+		<meta property="og:title" content="{{.Issue.Title}}" />
+		<meta property="og:url" content="{{.Issue.HTMLURL}}" />
+		{{if .Issue.Content}}
+			<meta property="og:description" content="{{.Issue.Content}}" />
+		{{end}}
+	{{else}}
+		<meta property="og:title" content="{{.Repository.Name}}" />
+		<meta property="og:url" content="{{.Repository.HTMLURL}}" />
+		{{if .Repository.Description}}
+			<meta property="og:description" content="{{.Repository.Description}}" />
+		{{end}}
+	{{end}}
 	<meta property="og:type" content="object" />
 	<meta property="og:image" content="{{.Repository.Owner.AvatarLink}}" />
-	<meta property="og:url" content="{{.Repository.HTMLURL}}" />
-	{{if .Repository.Description}}
-	<meta property="og:description" content="{{.Repository.Description}}" />
-	{{end}}
-	<meta property="og:site_name" content="{{AppName}}" />
 {{else}}
 	<meta property="og:title" content="{{AppName}}">
 	<meta property="og:type" content="website" />
@@ -148,6 +157,7 @@
 	<meta property="og:url" content="{{AppUrl}}" />
 	<meta property="og:description" content="{{MetaDescription}}">
 {{end}}
+<meta property="og:site_name" content="{{AppName}}" />
 {{if .IsSigned }}
 	{{ if ne .SignedUser.Theme "gitea" }}
 		<link rel="stylesheet" href="{{StaticUrlPrefix}}/css/theme-{{.SignedUser.Theme}}.css">


### PR DESCRIPTION
These will be more noticeable once we move to gitea.com completely and paste issues/pulls in our chat service (currently Discord).  
Currently our [OGP](https://ogp.me/) "rich presence" offers limited information.  
  
Before example PR gitea.com vs github.com  
![gitea-ogp-3](https://user-images.githubusercontent.com/42128690/67333471-375ce100-f4e6-11e9-860b-fe52626da804.png)

After
![gitea-ogp-4](https://user-images.githubusercontent.com/42128690/67901072-d790b680-fb33-11e9-8c11-b175de1fab1f.png)
