### PR TITLE
Docs: Added Docker fail2ban configuration.

### DIFF
--- a/docs/content/doc/usage/fail2ban-setup.md
+++ b/docs/content/doc/usage/fail2ban-setup.md
@@ -26,7 +26,7 @@ on a bad authentication:
 2018/04/26 18:15:54 [I] Failed authentication attempt for user from xxx.xxx.xxx.xxx
 ```
 
-So we set our filter in `/etc/fail2ban/filter.d/gitea.conf`:
+Add our filter in `/etc/fail2ban/filter.d/gitea.conf`:
 
 ```ini
 # gitea.conf
@@ -35,12 +35,11 @@ failregex =  .*Failed authentication attempt for .* from <HOST>
 ignoreregex =
 ```
 
-And configure it in `/etc/fail2ban/jail.d/jail.local`:
+Add our jail in `/etc/fail2ban/jail.d/gitea.conf`:
 
 ```ini
 [gitea]
 enabled = true
-port = http,https
 filter = gitea
 logpath = /home/git/gitea/log/gitea.log
 maxretry = 10
@@ -48,6 +47,23 @@ findtime = 3600
 bantime = 900
 action = iptables-allports
 ```
+
+If you're using Docker, you'll also need to add an additional jail to handle the **FORWARD** 
+chain in **iptables**. Configure it in `/etc/fail2ban/jail.d/gitea-docker.conf`:
+
+```ini
+[gitea-docker]
+enabled = true
+filter = gitea
+logpath = /home/git/gitea/log/gitea.log
+maxretry = 10
+findtime = 3600
+bantime = 900
+action = iptables-allports[chain="FORWARD"]
+```
+
+Then simply run `service fail2ban restart` to apply your changes. You can check to see if 
+fail2ban has accepted your configuration using `service fail2ban status`.
 
 Make sure and read up on fail2ban and configure it to your needs, this bans someone 
 for **15 minutes** (from all ports) when they fail authentication 10 times in an hour.


### PR DESCRIPTION
* Added Docker compatible fail2ban configuration. 
* Small changes for consitency and clarity.
* Removed redundant `ports` which does nothing when using the `iptables-allports` action.
* Added documentation on how to apply your configuration and check that it's valid.