### PR TITLE
Use AppSubUrl for more redirections (#8647)

### DIFF
--- a/modules/context/org.go
+++ b/modules/context/org.go
@@ -63,7 +63,7 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 
 	// Force redirection when username is actually a user.
 	if !org.IsOrganization() {
-		ctx.Redirect("/" + org.Name)
+		ctx.Redirect(setting.AppSubURL + "/" + org.Name)
 		return
 	}
 

--- a/routers/home.go
+++ b/routers/home.go
@@ -273,7 +273,7 @@ func ExploreOrganizations(ctx *context.Context) {
 // ExploreCode render explore code page
 func ExploreCode(ctx *context.Context) {
 	if !setting.Indexer.RepoIndexerEnabled {
-		ctx.Redirect("/explore", 302)
+		ctx.Redirect(setting.AppSubURL+"/explore", 302)
 		return
 	}
 

--- a/templates/user/auth/grant.tmpl
+++ b/templates/user/auth/grant.tmpl
@@ -16,7 +16,7 @@
 				<p>{{.i18n.Tr "auth.authroize_redirect_notice" .ApplicationRedirectDomainHTML | Str2html}}</p>
 			</div>
 			<div class="ui attached segment">
-				<form method="post" action="{{.AppSubUrl}}/login/oauth/grant">
+				<form method="post" action="{{AppSubUrl}}/login/oauth/grant">
 					{{.CsrfTokenHtml}}
 					<input type="hidden" name="client_id" value="{{.Application.ClientID}}">
 					<input type="hidden" name="state" value="{{.State}}">


### PR DESCRIPTION
Partial backport without changes to locale files.

Fix #8461 - fix misspelling of {{AppSubUrl}} and other misspelling in template
Fixes /explore and organisation redirection
