### PR TITLE
Fix illogical setting defaults re. SSH_PORT and SSH_LISTEN_PORT

### DIFF
--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -30,8 +30,8 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
     HTTP_PORT=${HTTP_PORT:-"3000"} \
     ROOT_URL=${ROOT_URL:-""} \
     DISABLE_SSH=${DISABLE_SSH:-"false"} \
-    SSH_PORT=${SSH_PORT:-"22"} \
-    SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"${SSH_PORT}"} \
+    SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"22"} \
+    SSH_PORT=${SSH_PORT:-"${SSH_LISTEN_PORT}"} \
     LFS_START_SERVER=${LFS_START_SERVER:-"false"} \
     DB_TYPE=${DB_TYPE:-"sqlite3"} \
     DB_HOST=${DB_HOST:-"localhost:3306"} \

--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -25,8 +25,8 @@ if [ ! -f /data/ssh/ssh_host_ecdsa_key ]; then
 fi
 
 if [ -d /etc/ssh ]; then
-    SSH_PORT=${SSH_PORT:-"22"} \
-    SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"${SSH_PORT}"} \
+    SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"22"} \
+    SSH_PORT=${SSH_PORT:-"${SSH_LISTEN_PORT}"} \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -161,9 +161,9 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `DISABLE_SSH`: **false**: Disable SSH feature when it's not available.
 - `START_SSH_SERVER`: **false**: When enabled, use the built-in SSH server.
 - `SSH_DOMAIN`: **%(DOMAIN)s**: Domain name of this server, used for displayed clone URL.
-- `SSH_PORT`: **22**: SSH port displayed in clone URL.
 - `SSH_LISTEN_HOST`: **0.0.0.0**: Listen address for the built-in SSH server.
-- `SSH_LISTEN_PORT`: **%(SSH\_PORT)s**: Port for the built-in SSH server.
+- `SSH_LISTEN_PORT`: **22**: Port for the built-in SSH server.
+- `SSH_PORT`: **%(SSH\_LISTEN\_PORT)s**: SSH port displayed in clone URL.
 - `OFFLINE_MODE`: **false**: Disables use of CDN for static files and Gravatar for profile pictures.
 - `DISABLE_ROUTER_LOG`: **false**: Mute printing of the router log.
 - `CERT_FILE`: **custom/https/cert.pem**: Cert file path used for HTTPS.

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -59,7 +59,8 @@ menu:
 - `HTTP_PORT`: HTTP 监听端口。
 - `DISABLE_SSH`: 是否禁用SSH。
 - `START_SSH_SERVER`: 是否启用内部SSH服务器。
-- `SSH_PORT`: SSH端口，默认为 `22`。
+- `SSH_LISTEN_PORT`: SSH端口，默认为 `22`。
+- `SSH_PORT`: 克隆URL中显示的SSH端口，默认为 `SSH_LISTEN_PORT`。
 - `OFFLINE_MODE`: 针对静态和头像文件禁用 CDN。
 - `DISABLE_ROUTER_LOG`: 关闭日志中的路由日志。
 - `CERT_FILE`: 启用HTTPS的证书文件。

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -244,8 +244,8 @@ You can configure some of Gitea's settings via environment variables:
 * `APP_NAME`: **"Gitea: Git with a cup of tea"**: Application name, used in the page title.
 * `RUN_MODE`: **dev**: For performance and other purposes, change this to `prod` when deployed to a production environment.
 * `SSH_DOMAIN`: **localhost**: Domain name of this server, used for the displayed clone URL in Gitea's UI.
-* `SSH_PORT`: **22**: SSH port displayed in clone URL.
-* `SSH_LISTEN_PORT`: **%(SSH\_PORT)s**: Port for the built-in SSH server.
+* `SSH_LISTEN_PORT`: **22**: Port for the built-in SSH server.
+* `SSH_PORT`: **%(SSH\_LISTEN\_PORT)s**: SSH port displayed in clone URL.
 * `DISABLE_SSH`: **false**: Disable SSH feature when it's not available.
 * `HTTP_PORT`: **3000**: HTTP listen port.
 * `ROOT_URL`: **""**: Overwrite the automatically generated public URL. This is useful if the internal and the external URL don't match (e.g. in Docker).

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -654,8 +654,8 @@ func NewContext() {
 	}
 
 	SSH.KeygenPath = sec.Key("SSH_KEYGEN_PATH").MustString("ssh-keygen")
-	SSH.Port = sec.Key("SSH_PORT").MustInt(22)
-	SSH.ListenPort = sec.Key("SSH_LISTEN_PORT").MustInt(SSH.Port)
+	SSH.ListenPort = sec.Key("SSH_LISTEN_PORT").MustInt(22)
+	SSH.Port = sec.Key("SSH_PORT").MustInt(SSH.ListenPort)
 
 	// When disable SSH, start builtin server value is ignored.
 	if SSH.Disabled {


### PR DESCRIPTION
Fix issue whereby setting SSH_PORT, for the purpose of constructing a superficial git-clone URL, would implicitly also set SSH_LISTEN_PORT that the SSH service binds to, if the latter is not explicitly configured.

Manifestation
-----------
SSH_PORT=2222
Would cause Gitea to also modify SSH_LISTEN_PORT and start up SSH on port 2222.

Work around would be to simultaneously force service port binding back to 22:
SSH_PORT=2222
SSH_LISTEN_PORT=22

So, the actual service binding SSH_LISTEN_PORT is being defaulted to SSH_PORT that's used for 'external decoration.' It should really be the other way around.

Rationale
--------
Documentation states that:
* SSH_LISTEN_PORT: Port for the built-in SSH server.
* SSH_PORT: SSH port displayed in clone URL

Therefore, it stands to reason to expect that:
* SSH_LISTEN_PORT should default to 22, unless explicitly overriden, and with no other implicit defaults.
* SSH_PORT should be allowed to be freely set to any value as seen fit, depending on infrastructure/platform (be it Docker or otherwise) without implications on underlying service configuration. Though, it is sensible to default to the SSH_LISTEN_PORT above.

Additional Info
-------------
Documentation files are updated accordingly.

This may be considered a corrective fix to prior merged PR issues #8453 and #8477.


