### PR TITLE
Fix 500 when getting user as unauthenticated user (#8653)

### DIFF
--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -104,7 +104,7 @@ func GetInfo(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.JSON(200, convert.ToUser(u, ctx.IsSigned, ctx.User.ID == u.ID || ctx.User.IsAdmin))
+	ctx.JSON(200, convert.ToUser(u, ctx.IsSigned, ctx.User != nil && (ctx.User.ID == u.ID || ctx.User.IsAdmin)))
 }
 
 // GetAuthenticatedUser get current user's information


### PR DESCRIPTION
When doing GET /api/v1/users/{user} as an unauthenticated user,
gitea throws a 500 because it's trying to dereference elements
from the context user. It wants to do this to see whether to
show the primary email and will do that if the logged in user
is admin or the user in question. However, if ctx.User is nil,
go gets really unhappy.