### PR TITLE
Revert "API should follow RequireSignInView (#8654)"

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -845,7 +845,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Group("/topics", func() {
 			m.Get("/search", repo.TopicSearch)
 		})
-	}, securityHeaders(), reqTokenBySetting(), context.APIContexter(), sudo())
+	}, securityHeaders(), context.APIContexter(), sudo())
 }
 
 func securityHeaders() macaron.Handler {
@@ -856,11 +856,4 @@ func securityHeaders() macaron.Handler {
 			w.Header().Set("x-content-type-options", "nosniff")
 		})
 	}
-}
-
-func reqTokenBySetting() macaron.Handler {
-	if setting.Service.RequireSignInView {
-		return reqToken()
-	}
-	return func(ctx *macaron.Context) {}
 }


### PR DESCRIPTION
Reverts go-gitea/gitea#8661

In fact, It has been checked on `ignSignIn`.