### PR TITLE
Add notice to docs for migrating from more recent versions of Gogs

### DIFF
--- a/docs/content/doc/upgrade/from-gogs.en-us.md
+++ b/docs/content/doc/upgrade/from-gogs.en-us.md
@@ -74,6 +74,11 @@ After successful migration from `gogs` to `gitea 1.0.x`, it is possible to upgra
 Simply download the file matching the destination platform from the [downloads page](https://dl.gitea.io/gitea)
 and replace the binary.
 
+## Upgrading from a more recent version of Gogs
+
+Upgrading from a more recent version of Gogs is also possible, but requires a bit more work. 
+See [#4286](https://github.com/go-gitea/gitea/issues/4286).
+
 ## Troubleshooting
 
 * If errors are encountered relating to custom templates in the `gitea/custom/templates`


### PR DESCRIPTION
This PR adds a reference to #4286 to the migration docs.

(We should extract the info from the issue and put them directly in the docs, but just putting a reference to the issue is fine for now - helps finding it quickly)