### PR TITLE
fixes #8725: change footer from `© Gitea` to `Powered by Gitea`

### DIFF
--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -1,7 +1,7 @@
 <footer>
 	<div class="ui container">
 		<div class="ui left">
-			© Gitea {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
+			Powered by Gitea {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
 		</div>
 		<div class="ui right links">
 			{{if .ShowFooterBranding}}


### PR DESCRIPTION
I like [this proposal](https://github.com/go-gitea/gitea/issues/8725#issue-513583217) so I thought I just could make a PR for it.
I'm just not sure whether it should stay static or moved into the locale data.