### PR TITLE
Rename HookQueue to hookQueue

### DIFF
--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -62,8 +62,6 @@ func (m *webhookNotifier) NotifyIssueClearLabels(doer *models.User, issue *model
 	}
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.RepoID)
 	}
 }
 
@@ -78,8 +76,6 @@ func (m *webhookNotifier) NotifyForkRepository(doer *models.User, oldRepo, repo 
 		Sender: doer.APIFormat(),
 	}); err != nil {
 		log.Error("PrepareWebhooks [repo_id: %d]: %v", oldRepo.ID, err)
-	} else {
-		go webhook_module.HookQueue.Add(oldRepo.ID)
 	}
 
 	u := repo.MustOwner()
@@ -93,8 +89,6 @@ func (m *webhookNotifier) NotifyForkRepository(doer *models.User, oldRepo, repo 
 			Sender:       doer.APIFormat(),
 		}); err != nil {
 			log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
-		} else {
-			go webhook_module.HookQueue.Add(repo.ID)
 		}
 	}
 }
@@ -109,8 +103,6 @@ func (m *webhookNotifier) NotifyCreateRepository(doer *models.User, u *models.Us
 			Sender:       doer.APIFormat(),
 		}); err != nil {
 			log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
-		} else {
-			go webhook_module.HookQueue.Add(repo.ID)
 		}
 	}
 }
@@ -127,7 +119,6 @@ func (m *webhookNotifier) NotifyDeleteRepository(doer *models.User, repo *models
 		}); err != nil {
 			log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
 		}
-		go webhook_module.HookQueue.Add(repo.ID)
 	}
 }
 
@@ -175,8 +166,6 @@ func (m *webhookNotifier) NotifyIssueChangeAssignee(doer *models.User, issue *mo
 			return
 		}
 	}
-
-	go webhook_module.HookQueue.Add(issue.RepoID)
 }
 
 func (m *webhookNotifier) NotifyIssueChangeTitle(doer *models.User, issue *models.Issue, oldTitle string) {
@@ -217,8 +206,6 @@ func (m *webhookNotifier) NotifyIssueChangeTitle(doer *models.User, issue *model
 
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.RepoID)
 	}
 }
 
@@ -259,8 +246,6 @@ func (m *webhookNotifier) NotifyIssueChangeStatus(doer *models.User, issue *mode
 	}
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v, is_closed: %v]: %v", issue.IsPull, isClosed, err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.Repo.ID)
 	}
 }
 
@@ -274,8 +259,6 @@ func (m *webhookNotifier) NotifyNewIssue(issue *models.Issue) {
 		Sender:     issue.Poster.APIFormat(),
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.RepoID)
 	}
 }
 
@@ -312,8 +295,6 @@ func (m *webhookNotifier) NotifyIssueChangeContent(doer *models.User, issue *mod
 	}
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.RepoID)
 	}
 }
 
@@ -347,8 +328,6 @@ func (m *webhookNotifier) NotifyUpdateComment(doer *models.User, c *models.Comme
 		IsPull:     c.Issue.IsPull,
 	}); err != nil {
 		log.Error("PrepareWebhooks [comment_id: %d]: %v", c.ID, err)
-	} else {
-		go webhook_module.HookQueue.Add(c.Issue.Repo.ID)
 	}
 }
 
@@ -364,8 +343,6 @@ func (m *webhookNotifier) NotifyCreateIssueComment(doer *models.User, repo *mode
 		IsPull:     issue.IsPull,
 	}); err != nil {
 		log.Error("PrepareWebhooks [comment_id: %d]: %v", comment.ID, err)
-	} else {
-		go webhook_module.HookQueue.Add(repo.ID)
 	}
 }
 
@@ -395,8 +372,6 @@ func (m *webhookNotifier) NotifyDeleteComment(doer *models.User, comment *models
 		IsPull:     comment.Issue.IsPull,
 	}); err != nil {
 		log.Error("PrepareWebhooks [comment_id: %d]: %v", comment.ID, err)
-	} else {
-		go webhook_module.HookQueue.Add(comment.Issue.Repo.ID)
 	}
 }
 
@@ -442,7 +417,5 @@ func (m *webhookNotifier) NotifyIssueChangeLabels(doer *models.User, issue *mode
 	}
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
-	} else {
-		go webhook_module.HookQueue.Add(issue.RepoID)
 	}
 }

--- a/modules/repofiles/action.go
+++ b/modules/repofiles/action.go
@@ -112,10 +112,6 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 		return fmt.Errorf("NotifyWatchers: %v", err)
 	}
 
-	defer func() {
-		go webhook.HookQueue.Add(repo.ID)
-	}()
-
 	apiPusher := pusher.APIFormat()
 	apiRepo := repo.APIFormat(models.AccessModeNone)
 

--- a/modules/webhook/deliver.go
+++ b/modules/webhook/deliver.go
@@ -159,9 +159,9 @@ func DeliverHooks() {
 	}
 
 	// Start listening on new hook requests.
-	for repoIDStr := range HookQueue.Queue() {
+	for repoIDStr := range hookQueue.Queue() {
 		log.Trace("DeliverHooks [repo_id: %v]", repoIDStr)
-		HookQueue.Remove(repoIDStr)
+		hookQueue.Remove(repoIDStr)
 
 		repoID, err := com.StrTo(repoIDStr).Int64()
 		if err != nil {

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -137,7 +137,7 @@ func TestHook(ctx *context.APIContext) {
 		ctx.Error(500, "PrepareWebhook: ", err)
 		return
 	}
-	go webhook.HookQueue.Add(ctx.Repo.Repository.ID)
+
 	ctx.Status(204)
 }
 

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -23,7 +23,6 @@ import (
 	"code.gitea.io/gitea/modules/notification"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
-	"code.gitea.io/gitea/modules/webhook"
 	"code.gitea.io/gitea/services/gitdiff"
 	pull_service "code.gitea.io/gitea/services/pull"
 	repo_service "code.gitea.io/gitea/services/repository"
@@ -824,7 +823,6 @@ func TriggerTask(ctx *context.Context) {
 
 	log.Trace("TriggerTask '%s/%s' by %s", repo.Name, branch, pusher.Name)
 
-	go webhook.HookQueue.Add(repo.ID)
 	go pull_service.AddTestPullRequestTask(pusher, repo.ID, branch, true)
 	ctx.Status(202)
 }

--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -869,7 +869,6 @@ func TestWebhook(ctx *context.Context) {
 		ctx.Flash.Error("PrepareWebhook: " + err.Error())
 		ctx.Status(500)
 	} else {
-		go webhook.HookQueue.Add(ctx.Repo.Repository.ID)
 		ctx.Flash.Info(ctx.Tr("repo.settings.webhook.test_delivery_success"))
 		ctx.Status(200)
 	}

--- a/services/milestone/milestone.go
+++ b/services/milestone/milestone.go
@@ -53,8 +53,6 @@ func ChangeMilestoneAssign(issue *models.Issue, doer *models.User, oldMilestoneI
 	}
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
-	} else {
-		go webhook.HookQueue.Add(issue.RepoID)
 	}
 	return nil
 }

--- a/services/mirror/sync.go
+++ b/services/mirror/sync.go
@@ -28,10 +28,6 @@ func syncAction(opType models.ActionType, repo *models.Repository, refName strin
 		return fmt.Errorf("notifyWatchers: %v", err)
 	}
 
-	defer func() {
-		go webhook.HookQueue.Add(repo.ID)
-	}()
-
 	return nil
 }
 

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -369,8 +369,6 @@ func Merge(pr *models.PullRequest, doer *models.User, baseGitRepo *git.Repositor
 		Sender:      doer.APIFormat(),
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
-	} else {
-		go webhook.HookQueue.Add(pr.Issue.Repo.ID)
 	}
 
 	return nil

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -50,8 +50,6 @@ func NewPullRequest(repo *models.Repository, pull *models.Issue, labelIDs []int6
 		Sender:      pull.Poster.APIFormat(),
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
-	} else {
-		go webhook.HookQueue.Add(repo.ID)
 	}
 
 	return nil
@@ -125,7 +123,6 @@ func AddTestPullRequestTask(doer *models.User, repoID int64, branch string, isSy
 					log.Error("PrepareWebhooks [pull_id: %v]: %v", pr.ID, err)
 					continue
 				}
-				go webhook.HookQueue.Add(pr.Issue.Repo.ID)
 			}
 		}
 

--- a/services/pull/review.go
+++ b/services/pull/review.go
@@ -69,7 +69,6 @@ func reviewHook(review *models.Review) error {
 	}); err != nil {
 		return err
 	}
-	go webhook.HookQueue.Add(review.Issue.Repo.ID)
 
 	return nil
 }

--- a/services/pull/review.go
+++ b/services/pull/review.go
@@ -56,7 +56,7 @@ func reviewHook(review *models.Review) error {
 	if err != nil {
 		return err
 	}
-	if err := webhook.PrepareWebhooks(review.Issue.Repo, reviewHookType, &api.PullRequestPayload{
+	return webhook.PrepareWebhooks(review.Issue.Repo, reviewHookType, &api.PullRequestPayload{
 		Action:      api.HookIssueSynchronized,
 		Index:       review.Issue.Index,
 		PullRequest: pr.APIFormat(),
@@ -66,9 +66,5 @@ func reviewHook(review *models.Review) error {
 			Type:    string(reviewHookType),
 			Content: review.Content,
 		},
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }

--- a/services/release/release.go
+++ b/services/release/release.go
@@ -92,8 +92,6 @@ func CreateRelease(gitRepo *git.Repository, rel *models.Release, attachmentUUIDs
 				Sender:     rel.Publisher.APIFormat(),
 			}); err != nil {
 				log.Error("PrepareWebhooks: %v", err)
-			} else {
-				go webhook.HookQueue.Add(rel.Repo.ID)
 			}
 		}
 	}
@@ -129,8 +127,6 @@ func UpdateRelease(doer *models.User, gitRepo *git.Repository, rel *models.Relea
 		Sender:     doer.APIFormat(),
 	}); err1 != nil {
 		log.Error("PrepareWebhooks: %v", err)
-	} else {
-		go webhook.HookQueue.Add(rel.Repo.ID)
 	}
 
 	return err
@@ -195,8 +191,6 @@ func DeleteReleaseByID(id int64, doer *models.User, delTag bool) error {
 		Sender:     doer.APIFormat(),
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
-	} else {
-		go webhook.HookQueue.Add(rel.Repo.ID)
 	}
 
 	return nil


### PR DESCRIPTION
This PR renamed `HookQueue` to `hookQueue` so that external package will not visit it. And after this, webhook invokes will become just `PrepareWebhooks` or `PrepareWebhook`. `go webhook_module.HookQueue.Add` is unnecessary.