### PR TITLE
Fix 500 when edit hook

### DIFF
--- a/modules/git/hook.go
+++ b/modules/git/hook.go
@@ -90,6 +90,11 @@ func (h *Hook) Update() error {
 		h.IsActive = false
 		return nil
 	}
+	d := filepath.Dir(h.path)
+	if err := os.MkdirAll(d, os.ModePerm); err != nil {
+		return err
+	}
+
 	err := ioutil.WriteFile(h.path, []byte(strings.Replace(h.Content, "\r", "", -1)), os.ModePerm)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix #3696 . A mirror repository will not create gitea hooks directory `hooks`.  This PR will check and create that if not exist.