### PR TITLE
Fix SSH2 conditional in key parsing code

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -107,7 +107,7 @@ func parseKeyString(content string) (string, error) {
 
 	var keyType, keyContent, keyComment string
 
-	if content[:len(ssh2keyStart)] == ssh2keyStart {
+	if strings.HasPrefix(content, ssh2keyStart) {
 		// Parse SSH2 file format.
 
 		// Transform all legal line endings to a single "\n".

--- a/models/ssh_key_test.go
+++ b/models/ssh_key_test.go
@@ -131,6 +131,19 @@ AAAAC3NzaC1lZDI1NTE5AAAAICV0MGX/W9IvLA4FXpIuUcdDcbj5KX4syHgsTy7soVgf
 		_, err := CheckPublicKeyString(test.content)
 		assert.NoError(t, err)
 	}
+
+	for _, invalidKeys := range []struct {
+		content string
+	}{
+		{"test"},
+		{"---- NOT A REAL KEY ----"},
+		{"bad\nkey"},
+		{"\t\t:)\t\r\n"},
+		{"\r\ntest \r\ngitea\r\n\r\n"},
+	} {
+		_, err := CheckPublicKeyString(invalidKeys.content)
+		assert.Error(t, err)
+	}
 }
 
 func Test_calcFingerprint(t *testing.T) {


### PR DESCRIPTION
Avoid out of bounds error by using strings.HasPrefix to check for starting SSH2 text rather than assuming user input has at least 31 characters.

Add tests for bad input as well.

Fixes #8800
