### PR TITLE
Fix: remove duplicated signed commit icons

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -13,56 +13,55 @@
 				{{range $r}}
 					<tr>
 						<td class="author">
-						    {{$userName := .Author.Name}}
+							{{$userName := .Author.Name}}
 							{{if .User}}
 								{{if .User.FullName}}
-								    {{$userName = .User.FullName}}
+									{{$userName = .User.FullName}}
 								{{end}}
-							    <img class="ui avatar image" src="{{.User.RelAvatarLink}}" alt=""/>&nbsp;&nbsp;<a href="{{AppSubUrl}}/{{.User.Name}}">{{$userName}}</a>
+								<img class="ui avatar image" src="{{.User.RelAvatarLink}}" alt=""/>&nbsp;&nbsp;<a href="{{AppSubUrl}}/{{.User.Name}}">{{$userName}}</a>
 							{{else}}
 								<img class="ui avatar image" src="{{AvatarLink .Author.Email}}" alt=""/>&nbsp;&nbsp;{{$userName}}
 							{{end}}
 						</td>
 						<td class="sha">
-						    {{$class := "ui sha label"}}
-						    {{if .Signature}}
-						        {{$class = (printf "%s%s" $class " isSigned")}}
-                                {{if .Verification.Verified}}
-                                    {{$class = (printf "%s%s" $class " isVerified")}}
-                                {{else if .Verification.Warning}}
-                                    {{$class = (printf "%s%s" $class " isWarning")}}
-                                {{end}}
-						    {{end}}
-						    {{if $.Reponame}}
-							    <a href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}" rel="nofollow" class="{{$class}}">
-						    {{else}}
-							    <span class="{{$class}}">
-						    {{end}}
+							{{$class := "ui sha label"}}
+							{{if .Signature}}
+								{{$class = (printf "%s%s" $class " isSigned")}}
+								{{if .Verification.Verified}}
+									{{$class = (printf "%s%s" $class " isVerified")}}
+								{{else if .Verification.Warning}}
+									{{$class = (printf "%s%s" $class " isWarning")}}
+								{{end}}
+							{{end}}
+							{{if $.Reponame}}
+								<a href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}" rel="nofollow" class="{{$class}}">
+							{{else}}
+								<span class="{{$class}}">
+							{{end}}
 								{{ShortSha .ID.String}}
 								{{if .Signature}}
 									<div class="ui detail icon button">
 										{{if .Verification.Verified}}
-											<i title="{{.Verification.Reason}}" class="lock green icon"></i>
 											{{if ne .Verification.SigningUser.ID 0}}
-                                            	<i title="{{.Verification.Reason}}" class="lock green icon"></i>
-                                            {{else}}
-                                            	<i title="{{.Verification.Reason}}" class="icons">
-                                            		<i class="green lock icon"></i>
-                                            		<i class="tiny inverted cog icon centerlock"></i>
-                                            	</i>
-                                            {{end}}
+												<i title="{{.Verification.Reason}}" class="lock green icon"></i>
+											{{else}}
+												<i title="{{.Verification.Reason}}" class="icons">
+													<i class="green lock icon"></i>
+													<i class="tiny inverted cog icon centerlock"></i>
+												</i>
+											{{end}}
 										{{else if .Verification.Warning}}
-                                        	<i title="{{$.i18n.Tr .Verification.Reason}}" class="red unlock icon"></i>
-                                        {{else}}
+											<i title="{{$.i18n.Tr .Verification.Reason}}" class="red unlock icon"></i>
+										{{else}}
 											<i title="{{$.i18n.Tr .Verification.Reason}}" class="unlock icon"></i>
 										{{end}}
 									</div>
 								{{end}}
-						    {{if $.Reponame}}
-							    </a>
-						    {{else}}
-							    </span>
-						    {{end}}
+							{{if $.Reponame}}
+								</a>
+							{{else}}
+								</span>
+							{{end}}
 						</td>
 						<td class="message">
 							<span class="message-wrapper">
@@ -73,7 +72,7 @@
 							<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
 							{{end}}
 							{{if eq (CommitType .) "SignCommitWithStatuses"}}
-							    {{template "repo/commit_status" .Status}}
+								{{template "repo/commit_status" .Status}}
 							{{end}}
 							{{if IsMultilineCommitMessage .Message}}
 							<pre class="commit-body" style="display: none;">{{RenderCommitBody .Message $.RepoLink $.Repository.ComposeMetas}}</pre>


### PR DESCRIPTION
A recent update make the commits list to show two signed icons instead of one which I believe is a bug introduced in #7907. This makes the commits list weird and the column overflow and ellipsis for some browsers.

In #7907, the section

https://github.com/go-gitea/gitea/pull/7907/files#diff-7a50b55ffb3c01e4e467c74b23e0863bL63-L76

is changed to

https://github.com/go-gitea/gitea/pull/7907/files#diff-f7f8b7239c9e2d6f3afb0ca784ecc1bbR44-R58

Could @saitho help verify this fix?