### PR TITLE
Improve notification

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -270,6 +270,8 @@ var migrations = []Migration{
 	NewMigration("add column `mode` to table watch", addModeColumnToWatch),
 	// v107 -> v108
 	NewMigration("Add template options to repository", addTemplateToRepo),
+	// v108 -> v109
+	NewMigration("Add comment_id on table notification", addCommentIDOnNotification),
 }
 
 // Migrate database to current version

--- a/models/migrations/v108.go
+++ b/models/migrations/v108.go
@@ -1,0 +1,18 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"xorm.io/xorm"
+)
+
+func addCommentIDOnNotification(x *xorm.Engine) error {
+	type Notification struct {
+		ID        int64 `xorm:"pk autoincr"`
+		CommentID int64
+	}
+
+	return x.Sync2(new(Notification))
+}

--- a/models/notification.go
+++ b/models/notification.go
@@ -190,12 +190,16 @@ func updateIssueNotification(e Engine, userID, issueID, commentID, updatedByID i
 		return err
 	}
 
-	notification.Status = NotificationStatusUnread
-	notification.UpdatedBy = updatedByID
-	notification.CommentID = commentID
+	// NOTICE: Only update when the before notification on this issue is read, otherwise you may miss some notifications
+	if notification.Status == NotificationStatusRead {
+		notification.Status = NotificationStatusUnread
+		notification.UpdatedBy = updatedByID
+		notification.CommentID = commentID
+		_, err = e.ID(notification.ID).Cols("status, update_by, comment_id").Update(notification)
+		return err
+	}
 
-	_, err = e.ID(notification.ID).Cols("status, update_by, comment_id").Update(notification)
-	return err
+	return nil
 }
 
 func getIssueNotification(e Engine, userID, issueID int64) (*Notification, error) {

--- a/models/notification.go
+++ b/models/notification.go
@@ -204,8 +204,6 @@ func updateIssueNotification(e Engine, userID, issueID, commentID, updatedByID i
 
 	_, err = e.ID(notification.ID).Cols(cols...).Update(notification)
 	return err
-
-	return nil
 }
 
 func getIssueNotification(e Engine, userID, issueID int64) (*Notification, error) {

--- a/models/notification.go
+++ b/models/notification.go
@@ -408,7 +408,7 @@ func (nl NotificationList) getPendingCommentIDs() []int64 {
 	return keysInt64(ids)
 }
 
-// LoadComments loads issues from database
+// LoadComments loads comments from database
 func (nl NotificationList) LoadComments() error {
 	if len(nl) == 0 {
 		return nil

--- a/models/notification.go
+++ b/models/notification.go
@@ -266,6 +266,7 @@ func (n *Notification) HTMLURL() string {
 	return n.Issue.HTMLURL()
 }
 
+// NotificationList contains a list of notifications
 type NotificationList []*Notification
 
 func (nl NotificationList) getRepoIDs() []int64 {

--- a/models/notification_test.go
+++ b/models/notification_test.go
@@ -14,7 +14,7 @@ func TestCreateOrUpdateIssueNotifications(t *testing.T) {
 	assert.NoError(t, PrepareTestDatabase())
 	issue := AssertExistsAndLoadBean(t, &Issue{ID: 1}).(*Issue)
 
-	assert.NoError(t, CreateOrUpdateIssueNotifications(issue, 2))
+	assert.NoError(t, CreateOrUpdateIssueNotifications(issue.ID, 0, 2))
 
 	// User 9 is inactive, thus notifications for user 1 and 4 are created
 	notf := AssertExistsAndLoadBean(t, &Notification{UserID: 1, IssueID: issue.ID}).(*Notification)

--- a/routers/user/notification.go
+++ b/routers/user/notification.go
@@ -68,10 +68,16 @@ func Notifications(c *context.Context) {
 		return
 	}
 
-	if err := notifications.LoadRepos(); err != nil {
+	repos, err := notifications.LoadRepos()
+	if err != nil {
 		c.ServerError("LoadRepos", err)
 		return
 	}
+	if err := repos.LoadAttributes(); err != nil {
+		c.ServerError("LoadAttributes", err)
+		return
+	}
+
 	if err := notifications.LoadIssues(); err != nil {
 		c.ServerError("LoadIssues", err)
 		return

--- a/routers/user/notification.go
+++ b/routers/user/notification.go
@@ -68,6 +68,19 @@ func Notifications(c *context.Context) {
 		return
 	}
 
+	if err := notifications.LoadRepos(); err != nil {
+		c.ServerError("LoadRepos", err)
+		return
+	}
+	if err := notifications.LoadIssues(); err != nil {
+		c.ServerError("LoadIssues", err)
+		return
+	}
+	if err := notifications.LoadComments(); err != nil {
+		c.ServerError("LoadComments", err)
+		return
+	}
+
 	total, err := models.GetNotificationCount(c.User, status)
 	if err != nil {
 		c.ServerError("ErrGetNotificationCount", err)

--- a/templates/user/notification/notification.tmpl
+++ b/templates/user/notification/notification.tmpl
@@ -34,11 +34,11 @@
 				<table class="ui unstackable striped very compact small selectable table">
 					<tbody>
 						{{range $notification := .Notifications}}
-							{{$issue := $notification.GetIssue}}
-							{{$repo := $notification.GetRepo}}
+							{{$issue := $notification.Issue}}
+							{{$repo := $notification.Repository}}
 							{{$repoOwner := $repo.MustOwner}}
 
-							<tr data-href="{{AppSubUrl}}/{{$repoOwner.Name}}/{{$repo.Name}}/issues/{{$issue.Index}}">
+							<tr data-href="{{$notification.HTMLURL}}">
 								<td class="collapsing">
 									{{if eq $notification.Status 3}}
 										<i class="blue octicon octicon-pin"></i>
@@ -61,7 +61,7 @@
 									{{end}}
 								</td>
 								<td class="eleven wide">
-									<a class="item" href="{{AppSubUrl}}/{{$repoOwner.Name}}/{{$repo.Name}}/issues/{{$issue.Index}}">
+									<a class="item" href="{{$notification.HTMLURL}}">
 										#{{$issue.Index}} - {{$issue.Title}}
 									</a>
 								</td>


### PR DESCRIPTION
- [x] Add comment link on notification. Now the notification will be linked to the oldest comment of the issue you haven't read.
- [x] Improve the performance on notification. Batch loading repositories, issues, comments, owners.
- [x] Fix data race on notification queue. Only push issueID, commentID to the notification queue so that avoid multiple go routines load units on repository.
