### PR TITLE
Theme arc-green: reverse heatmap colors

### DIFF
--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -249,11 +249,11 @@ a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667!important;col
 .xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td,.xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar th{border-color:#4c505c;background-color:#2a2e39}
 .xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td.xdsoft_disabled,.xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td.xdsoft_other_month{opacity:.8;background:#a0cc75;color:#000}
 .heatmap-color-0{background-color:#2d303b}
-.heatmap-color-1{background-color:#3f4943}
-.heatmap-color-2{background-color:#51614b}
-.heatmap-color-3{background-color:#637a53}
-.heatmap-color-4{background-color:#75925b}
-.heatmap-color-5{background-color:#87ab63}
+.heatmap-color-1{background-color:#444f47}
+.heatmap-color-2{background-color:#5b6e52}
+.heatmap-color-3{background-color:#728e5e}
+.heatmap-color-4{background-color:#89ad69}
+.heatmap-color-5{background-color:#a0cc75}
 .CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:0}
 .CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
 .CodeMirror .CodeMirror-gutters{background-color:#2b2b2b}

--- a/public/css/theme-arc-green.css
+++ b/public/css/theme-arc-green.css
@@ -249,6 +249,11 @@ a.ui.label:hover,a.ui.labels .label:hover{background-color:#505667!important;col
 .xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td,.xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar th{border-color:#4c505c;background-color:#2a2e39}
 .xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td.xdsoft_disabled,.xdsoft_datetimepicker .xdsoft_datepicker .xdsoft_calendar td.xdsoft_other_month{opacity:.8;background:#a0cc75;color:#000}
 .heatmap-color-0{background-color:#2d303b}
+.heatmap-color-1{background-color:#3f4943}
+.heatmap-color-2{background-color:#51614b}
+.heatmap-color-3{background-color:#637a53}
+.heatmap-color-4{background-color:#75925b}
+.heatmap-color-5{background-color:#87ab63}
 .CodeMirror{color:#9daccc;background-color:#2b2b2b;border-top:0}
 .CodeMirror div.CodeMirror-cursor{border-left:1px solid #9e9e9e}
 .CodeMirror .CodeMirror-gutters{background-color:#2b2b2b}

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -1296,7 +1296,7 @@ a.ui.labels .label:hover {
 
 .heatmap(@heat) {
     @heatmap-cold: #2d303b;
-    @heatmap-hot: #87ab63;
+    @heatmap-hot: #a0cc75;
     background-color: mix(@heatmap-hot, @heatmap-cold, @heat);
 }
 

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -1298,6 +1298,26 @@ a.ui.labels .label:hover {
     background-color: #2d303b;
 }
 
+.heatmap-color-1 {
+    background-color: #025900;
+}
+
+.heatmap-color-2 {
+    background-color: #609926;
+}
+
+.heatmap-color-3 {
+    background-color: #66c74b;
+}
+
+.heatmap-color-4 {
+    background-color: #9fdb81;
+}
+
+.heatmap-color-5 {
+    background-color: #d8efbf;
+}
+
 /* code mirror dark theme */
 
 .CodeMirror {

--- a/public/less/themes/arc-green.less
+++ b/public/less/themes/arc-green.less
@@ -1294,28 +1294,34 @@ a.ui.labels .label:hover {
     }
 }
 
+.heatmap(@heat) {
+    @heatmap-cold: #2d303b;
+    @heatmap-hot: #87ab63;
+    background-color: mix(@heatmap-hot, @heatmap-cold, @heat);
+}
+
 .heatmap-color-0 {
-    background-color: #2d303b;
+    .heatmap(0%);
 }
 
 .heatmap-color-1 {
-    background-color: #025900;
+    .heatmap(20%);
 }
 
 .heatmap-color-2 {
-    background-color: #609926;
+    .heatmap(40%);
 }
 
 .heatmap-color-3 {
-    background-color: #66c74b;
+    .heatmap(60%);
 }
 
 .heatmap-color-4 {
-    background-color: #9fdb81;
+    .heatmap(80%);
 }
 
 .heatmap-color-5 {
-    background-color: #d8efbf;
+    .heatmap(100%);
 }
 
 /* code mirror dark theme */


### PR DESCRIPTION
This uses the same colors as the updated palette in the base theme.

See #8709 and #5864, in particular [my comment showing the problem](https://github.com/go-gitea/gitea/issues/5864#issuecomment-462334171)