### PR TITLE
Fix typo in doc fail2ban-setup.md

### DIFF
--- a/docs/content/doc/usage/fail2ban-setup.md
+++ b/docs/content/doc/usage/fail2ban-setup.md
@@ -13,7 +13,7 @@ menu:
     identifier: "fail2ban-setup"
 ---
 
-# Fail2ban setup to block users after failed login attemts
+# Fail2ban setup to block users after failed login attempts
 
 **Remember that fail2ban is powerful and can cause lots of issues if you do it incorrectly, so make 
 sure to test this before relying on it so you don't lock yourself out.**


### PR DESCRIPTION
This fixes a 1 character typo in fail2ban-setup.md