### PR TITLE
Close resources left by go-git after request is finished

### DIFF
--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -107,6 +107,11 @@ func OpenRepository(repoPath string) (*Repository, error) {
 	}, nil
 }
 
+// Close Release file descriptors that are left open for performance reasons
+func (repo *Repository) Close() error {
+	return repo.gogitStorage.Close()
+}
+
 // IsEmpty Check if repository is empty.
 func (repo *Repository) IsEmpty() (bool, error) {
 	var errbuf strings.Builder

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -69,6 +69,13 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 		// Check if repository name has been changed.
 		if repo.LowerName != strings.ToLower(newRepoName) {
 			isNameChanged = true
+
+			// Close any file descriptors, primarily for Windows which refuses to move directories with open descriptors
+			if err := ctx.Repo.GitRepo.Close(); err != nil {
+				ctx.ServerError("ChangeRepositoryName", err)
+				return
+			}
+
 			if err := models.ChangeRepositoryName(ctx.Repo.Owner, repo.Name, newRepoName); err != nil {
 				ctx.Data["Err_RepoName"] = true
 				switch {
@@ -367,6 +374,12 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 			return
 		} else if !isExist {
 			ctx.RenderWithErr(ctx.Tr("form.enterred_invalid_owner_name"), tplSettingsOptions, nil)
+			return
+		}
+
+		// Close any file descriptors, primarily for Windows which refuses to move directories with open descriptors
+		if err := ctx.Repo.GitRepo.Close(); err != nil {
+			ctx.ServerError("ChangeRepositoryName", err)
 			return
 		}
 

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -220,6 +220,8 @@ func NewMacaron() *macaron.Macaron {
 	// OK we are now set-up enough to allow us to create a nicer recovery than
 	// the default macaron recovery
 	m.Use(context.Recovery())
+
+	m.Use(context.Cleanup())
 	m.SetAutoHead(true)
 	return m
 }


### PR DESCRIPTION
*I believe this a bugfix so I based this on the branch for hopefully a release in 1.9.6. It is a relatively small change but does prevent some resource leaks from happening. If this is not desired I'Il rebase on another branch.*

In #7947 I figured out that go-git leaves handles to the pack files open. These are eventually garbage collected, but this isn't very deterministic. 

What I did:
- Close any open repository handles after each request via a common middleware so it is on one place instead of littered throughout the source code. (*There might still be a possible race condition here if many concurrent page views are happening on the repository and a transfer ownership or rename is attempted*)
- Close the repository before ownership transfer or rename which are the operations that touch the directory.
- Log if closing the repository fails, apparently go-git can return an error.
- Tested on Windows based on the testcase in #7947 as I'm a Windows user.
