### PR TITLE
Close resources left by go-git after request is finished

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -47,6 +47,15 @@ type Context struct {
 	Org  *Organization
 }
 
+// Close Releases resources used by this context, like file descriptors
+func (ctx *Context) Close() {
+	if ctx.Repo != nil && ctx.Repo.GitRepo != nil {
+		if err := ctx.Repo.GitRepo.Close(); err != nil {
+			log.Warn("Unable to clean up repository resources %s", err.Error())
+		}
+	}
+}
+
 // IsUserSiteAdmin returns true if current user is a site admin
 func (ctx *Context) IsUserSiteAdmin() bool {
 	return ctx.IsSigned && ctx.User.IsAdmin
@@ -341,5 +350,14 @@ func Contexter() macaron.Handler {
 		ctx.Data["EnableOpenIDSignIn"] = setting.Service.EnableOpenIDSignIn
 
 		c.Map(ctx)
+	}
+}
+
+// Cleanup Cleans up used resources like open file descriptors at the end of the request
+func Cleanup() macaron.Handler {
+	return func(ctx *Context) {
+		defer ctx.Close()
+
+		ctx.Next()
 	}
 }

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -122,6 +122,11 @@ func OpenRepository(repoPath string) (*Repository, error) {
 	}, nil
 }
 
+// Close Release file descriptors that are left open for performance reasons
+func (repo *Repository) Close() error {
+	return repo.gogitStorage.Close()
+}
+
 // GoGitRepo gets the go-git repo representation
 func (repo *Repository) GoGitRepo() *gogit.Repository {
 	return repo.gogitRepo

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -226,6 +226,8 @@ func NewMacaron() *macaron.Macaron {
 	// OK we are now set-up enough to allow us to create a nicer recovery than
 	// the default macaron recovery
 	m.Use(context.Recovery())
+
+	m.Use(context.Cleanup())
 	m.SetAutoHead(true)
 	return m
 }


### PR DESCRIPTION
*Rebase of #8915 onto `master`*

In #7947 I figured out that go-git leaves handles to the pack files open. These are eventually garbage collected, but this isn't very deterministic. 

What I did:
- Close any open repository handles after each request via a common middleware so it is on one place instead of littered throughout the source code. (*There might still be a possible race condition here if many concurrent page views are happening on the repository and a transfer ownership or rename is attempted*)
- Close the repository before ownership transfer or rename which are the operations that touch the directory.
- Log if closing the repository fails, apparently go-git can return an error.
- Tested on Windows based on the testcase in #7947 as I'm a Windows user.

I believe this should be quite easy to merge and addresses all issues when it comes to resources left open by requests.
