### PR TITLE
Migrate temp_repo.go to use git.NewCommand 

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -67,6 +67,13 @@ func (c *Command) RunInDirTimeoutEnvPipeline(env []string, timeout time.Duration
 // RunInDirTimeoutEnvFullPipeline executes the command in given directory with given timeout,
 // it pipes stdout and stderr to given io.Writer and passes in an io.Reader as stdin.
 func (c *Command) RunInDirTimeoutEnvFullPipeline(env []string, timeout time.Duration, dir string, stdout, stderr io.Writer, stdin io.Reader) error {
+	return c.RunInDirTimeoutEnvFullPipelineFunc(env, timeout, dir, stdout, stderr, stdin, nil)
+}
+
+// RunInDirTimeoutEnvFullPipelineFunc executes the command in given directory with given timeout,
+// it pipes stdout and stderr to given io.Writer and passes in an io.Reader as stdin. Between cmd.Start and cmd.Wait the passed in function is run.
+func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.Duration, dir string, stdout, stderr io.Writer, stdin io.Reader, fn func(context.Context, context.CancelFunc)) error {
+
 	if timeout == -1 {
 		timeout = DefaultCommandExecutionTimeout
 	}
@@ -97,6 +104,10 @@ func (c *Command) RunInDirTimeoutEnvFullPipeline(env []string, timeout time.Dura
 
 	pid := process.GetManager().Add(fmt.Sprintf("%s %s %s [repo_path: %s]", GitExecutable, c.name, strings.Join(c.args, " "), dir), cmd)
 	defer process.GetManager().Remove(pid)
+
+	if fn != nil {
+		fn(ctx, cancel)
+	}
 
 	if err := cmd.Wait(); err != nil {
 		return err

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -254,6 +254,10 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 		log.Error("Unable to open stdout pipe: %v", err)
 		return nil, fmt.Errorf("Unable to open stdout pipe: %v", err)
 	}
+	defer func() {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+	} ()
 	stderr := new(bytes.Buffer)
 	var diff *gitdiff.Diff
 	var finalErr error
@@ -277,7 +281,6 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 		return nil, fmt.Errorf("Unable to run diff-index pipeline in temporary repo %s. Error: %v\nStderr: %s",
 			t.repo.FullName(), err, stderr)
 	}
-	_ = stdoutWriter.Close()
 
 	return diff, nil
 }

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -257,7 +257,7 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 	defer func() {
 		_ = stdoutReader.Close()
 		_ = stdoutWriter.Close()
-	} ()
+	}()
 	stderr := new(bytes.Buffer)
 	var diff *gitdiff.Diff
 	var finalErr error

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -267,7 +267,6 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 				cancel()
 			}
 			_ = stdoutReader.Close()
-			return
 		}); err != nil {
 		if finalErr != nil {
 			log.Error("Unable to ParsePatch in temporary repo %s (%s). Error: %v", t.repo.FullName(), t.basePath, finalErr)


### PR DESCRIPTION
This PR migrates temp_repo.go to use git.NewCommand instead creating processes by itself - this fixes the problem underlying PR #8905.

There are other places that run git outside of the controlled locale defined in #8548 but temp_repo.go is the only cause of failure of local testing in cases where English is not the default - implying that error messages from those other commands are not interpreted.

Replaces #8905 