### PR TITLE
Update Github Migration Test

### DIFF
--- a/modules/migrations/github_test.go
+++ b/modules/migrations/github_test.go
@@ -248,8 +248,8 @@ func TestGitHubDownloadRepo(t *testing.T) {
 				},
 			},
 			Reactions: &base.Reactions{
-				TotalCount: 9,
-				PlusOne:    8,
+				TotalCount: 10,
+				PlusOne:    9,
 				MinusOne:   0,
 				Laugh:      0,
 				Confused:   0,


### PR DESCRIPTION
Small fix for test on 1.9 since #8938 can't be easily back ported to this branch.
