### PR TITLE
Hotfix for review actions and notifications (1.10.0)

### DIFF
--- a/models/review.go
+++ b/models/review.go
@@ -135,6 +135,7 @@ func (r *Review) publish(e *xorm.Engine) error {
 						Repo:    review.Issue.Repo,
 						Type:    comm.Type,
 						Content: comm.Content,
+						Review:  r,
 					}, comm); err != nil {
 						log.Warn("sendCreateCommentAction: %v", err)
 					}

--- a/routers/repo/pull_review.go
+++ b/routers/repo/pull_review.go
@@ -174,6 +174,12 @@ func SubmitReview(ctx *context.Context, form auth.SubmitReviewForm) {
 			return
 		}
 	}
+
+	// Hotfix 1.10.0: make sure the review exists before creating the head comment
+	if err = review.Publish(); err != nil {
+		ctx.ServerError("Publish", err)
+		return
+	}
 	comm, err := models.CreateComment(&models.CreateCommentOptions{
 		Type:     models.CommentTypeReview,
 		Doer:     ctx.User,
@@ -184,10 +190,6 @@ func SubmitReview(ctx *context.Context, form auth.SubmitReviewForm) {
 	})
 	if err != nil || comm == nil {
 		ctx.ServerError("CreateComment", err)
-		return
-	}
-	if err = review.Publish(); err != nil {
-		ctx.ServerError("Publish", err)
 		return
 	}
 


### PR DESCRIPTION
This PR resolves some issues regarding review notifications. Since 1.11.0 is too far apart from 1.10.0, I made a hotfix for this.

Fixes:

* A mail is sent whenever a review is created; previously some cases would not send a mail (specifically when using SQLite3).
* Review headers for multi-step reviews did not create an entry in the Dashboard.