### PR TITLE
Fix intermittent GPG Git test failure

### DIFF
--- a/integrations/git_helper_for_declarative_test.go
+++ b/integrations/git_helper_for_declarative_test.go
@@ -79,8 +79,10 @@ func allowLFSFilters() []string {
 	return globalArgs
 }
 
-func onGiteaRun(t *testing.T, callback func(*testing.T, *url.URL)) {
-	prepareTestEnv(t, 1)
+func onGiteaRun(t *testing.T, callback func(*testing.T, *url.URL), prepare ...bool) {
+	if len(prepare) == 0 || prepare[0] {
+		prepareTestEnv(t, 1)
+	}
 	s := http.Server{
 		Handler: mac,
 	}


### PR DESCRIPTION
This PR fixes an intermittent failure with the GPG Git Test whereby it would fail due to a race condition secondary to changing settings whilst the test server is running.