### PR TITLE
Update display of reactions to issues and comments

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -789,11 +789,12 @@ i.icon.centerlock{top:1.5em}
 .repository .segment.reactions.dropdown .menu>.header,.repository .select-reaction.dropdown .menu>.header{margin:.75rem 0 .5rem}
 .repository .segment.reactions.dropdown .menu>.item,.repository .select-reaction.dropdown .menu>.item{float:left;padding:.5rem .5rem!important}
 .repository .segment.reactions.dropdown .menu>.item img.emoji,.repository .select-reaction.dropdown .menu>.item img.emoji{margin-right:0}
-.repository .segment.reactions{padding:.3em 1em}
-.repository .segment.reactions .ui.label{padding:.4em}
-.repository .segment.reactions .ui.label.disabled{cursor:default}
+.repository .segment.reactions{padding:0;display:flex}
+.repository .segment.reactions .ui.label{padding:.4em;padding-right:1em;padding-left:1em;border:0;border-right:1px solid;border-radius:0;margin:0;font-size:14px;border-color:inherit!important}
+.repository .segment.reactions .ui.label.disabled{cursor:default;opacity:.5}
 .repository .segment.reactions .ui.label>img{height:1.5em!important}
-.repository .segment.reactions .select-reaction{float:none}
+.repository .segment.reactions .ui.label.basic.blue{background-color:#f1f8ff!important;border-color:inherit!important}
+.repository .segment.reactions .select-reaction{float:left;padding:.5em;padding-left:1em}
 .repository .segment.reactions .select-reaction:not(.active) a{display:none}
 .repository .segment.reactions:hover .select-reaction a{display:block}
 .repository .ui.fluid.action.input .ui.search.action.input{flex:auto}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1910,13 +1910,23 @@
     }
 
     .segment.reactions {
-        padding: 0.3em 1em;
+        padding: 0;
+        display: flex;
 
         .ui.label {
             padding: 0.4em;
+            padding-right: 1em;
+            padding-left: 1em;
+            border: 0;
+            border-right: 1px solid;
+            border-radius: 0;
+            margin: 0;
+            font-size: 14px;
+            border-color: inherit !important;
 
             &.disabled {
                 cursor: default;
+                opacity: 0.5;
             }
 
             > img {
@@ -1924,8 +1934,15 @@
             }
         }
 
+        .ui.label.basic.blue {
+            background-color: #f1f8ff !important;
+            border-color: inherit !important;
+        }
+
         .select-reaction {
-            float: none;
+            float: left;
+            padding: 0.5em;
+            padding-left: 1em;
 
             &:not(.active) a {
                 display: none;


### PR DESCRIPTION
Modify display of reactions to issues to remove spaces and make them feel more apart of the reactions bar rather than separate items within.

Mainly motivated by not liking the little boxes inside a bigger box look and wanting to use the space a bit more efficiently. Obviously 'inspired' from what Github does here:

Old:
<img width="864" alt="Screen Shot 2019-11-15 at 3 09 37 PM" src="https://user-images.githubusercontent.com/1669571/68974329-7a953180-07be-11ea-9fa4-ca8031d8e888.png"> 

New:
<img width="856" alt="Screen Shot 2019-11-15 at 3 09 43 PM" src="https://user-images.githubusercontent.com/1669571/68974349-87198a00-07be-11ea-8b0d-ef582f03ea79.png">
<img width="855" alt="Screen Shot 2019-11-15 at 3 10 35 PM" src="https://user-images.githubusercontent.com/1669571/68974479-d8297e00-07be-11ea-949f-a4dfd9cbbf98.png">

New not logged in:

<img width="858" alt="Screen Shot 2019-11-15 at 3 10 14 PM" src="https://user-images.githubusercontent.com/1669571/68974420-bb8d4600-07be-11ea-9407-1df98649cc68.png">

Certainly open to suggestions, modifications, or rejection if everybody likes the current way. 