### PR TITLE
Hide given credentials for migrated repos.

### DIFF
--- a/models/task.go
+++ b/models/task.go
@@ -196,7 +196,7 @@ func CreateMigrateTask(doer, u *User, opts base.MigrateOptions) (*Task, error) {
 	repo, err := CreateRepository(doer, u, CreateRepoOptions{
 		Name:        opts.RepoName,
 		Description: opts.Description,
-		OriginalURL: opts.CloneAddr,
+		OriginalURL: opts.OriginalURL,
 		IsPrivate:   opts.Private,
 		IsMirror:    opts.Mirror,
 		Status:      RepositoryBeingMigrated,

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -326,6 +326,7 @@ func MigratePost(ctx *context.Context, form auth.MigrateRepoForm) {
 	}
 
 	var opts = migrations.MigrateOptions{
+		OriginalURL:  form.CloneAddr,
 		CloneAddr:    remoteAddr,
 		RepoName:     form.RepoName,
 		Description:  form.Description,


### PR DESCRIPTION
The given migration credentials were previously stored in the DB and viewable on all migrated issues, due to the modified 'remoteAddr' being passed along as the 'OriginalURL'.

This fixes that by passing the unmodified 'CloneAddr' given in the form through to be used in 'CreateRepository'. 

Branched off from [PR#9084](https://github.com/go-gitea/gitea/pull/9084). 