### PR TITLE
Fix nil context user for template repositories

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -204,7 +204,13 @@ func RetrieveTemplateRepo(ctx *Context, repo *models.Repository) {
 		return
 	}
 
-	if !repo.TemplateRepo.CheckUnitUser(ctx.User.ID, ctx.User.IsAdmin, models.UnitTypeCode) {
+	perm, err := models.GetUserRepoPermission(repo.TemplateRepo, ctx.User)
+	if err != nil {
+		ctx.ServerError("GetUserRepoPermission", err)
+		return
+	}
+
+	if !perm.CanRead(models.UnitTypeCode) {
 		repo.TemplateID = 0
 	}
 }


### PR DESCRIPTION
Currently when visiting a generated repository, the context attempts to check permissions of the context user.

If the user is nil, the user sees a 500. This PR uses a different function in the models repository that handles nil Users.

Thanks to @kolaente for discovering this bug.  🕵 