### PR TITLE
Add template repositories to comparison

### DIFF
--- a/docs/content/doc/features/comparison.en-us.md
+++ b/docs/content/doc/features/comparison.en-us.md
@@ -68,6 +68,7 @@ _Symbols used in table:_
 | Create new branches | ✓ | ✘ | ✓ | ✓ | ✓ | ✘ | ✘ |
 | Web code editor | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Commit graph | ✓ | ✘ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Template Repositories | [✓](https://github.com/go-gitea/gitea/pull/8768) | ✘ | ✓ | ✘ | ✓ | ✓ | ✘ |
 
 #### Issue Tracker
 


### PR DESCRIPTION
As title

GitHub has this feature
[Gogs](https://github.com/gogs/gogs/issues/3236) (best I could find)
[GitLab](https://docs.gitlab.com/ee/gitlab-basics/create-project.html#custom-project-templates-premium)
[BitBucket](https://marketplace.atlassian.com/apps/1213038/repository-templates-for-bitbucket?hosting=server&tab=overview)
RhodeCode: I couldn't find anything for it