### PR TITLE
Fix race condition in ReplaceSanitizer

### DIFF
--- a/modules/markup/sanitizer.go
+++ b/modules/markup/sanitizer.go
@@ -34,7 +34,6 @@ func NewSanitizer() {
 
 // ReplaceSanitizer replaces the current sanitizer to account for changes in settings
 func ReplaceSanitizer() {
-	sanitizer = &Sanitizer{}
 	sanitizer.policy = bluemonday.UGCPolicy()
 	// We only want to allow HighlightJS specific classes for code blocks
 	sanitizer.policy.AllowAttrs("class").Matching(regexp.MustCompile(`^language-\w+$`)).OnElements("code")


### PR DESCRIPTION
Recreating the sanitizer in ReplaceSanitizer causes a race condition because it recreates the sync.Once.

This PR removes this recreation - removing the random race condition affecting testing.