### PR TITLE
Yet another attempt to fix the intermittent failure of gpg git test

### DIFF
--- a/integrations/git_helper_for_declarative_test.go
+++ b/integrations/git_helper_for_declarative_test.go
@@ -91,6 +91,7 @@ func onGiteaRun(t *testing.T, callback func(*testing.T, *url.URL), prepare ...bo
 	assert.NoError(t, err)
 	listener, err := net.Listen("tcp", u.Host)
 	assert.NoError(t, err)
+	u.Host = listener.Addr().String()
 
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)

--- a/integrations/gpg_git_test.go
+++ b/integrations/gpg_git_test.go
@@ -170,7 +170,8 @@ func TestGPGGit(t *testing.T) {
 
 		t.Run("AlwaysSign-Initial-CRUD-Never", func(t *testing.T) {
 			defer PrintCurrentTest(t)()
-			testCtx := NewAPITestContext(t, username, "initial-always")
+			testCtx := NewAPITestContext(t, username, "initial-always-never")
+			t.Run("CreateRepository", doAPICreateRepository(testCtx, false))
 			t.Run("CreateCRUDFile-Never", crudActionCreateFile(
 				t, testCtx, user, "master", "never", "unsigned-never.txt", func(t *testing.T, response api.FileResponse) {
 					assert.False(t, response.Verification.Verified)
@@ -180,10 +181,10 @@ func TestGPGGit(t *testing.T) {
 	setting.Repository.Signing.CRUDActions = []string{"parentsigned"}
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
 		u.Path = baseAPITestContext.GitPath()
-
 		t.Run("AlwaysSign-Initial-CRUD-ParentSigned-On-Always", func(t *testing.T) {
 			defer PrintCurrentTest(t)()
-			testCtx := NewAPITestContext(t, username, "initial-always")
+			testCtx := NewAPITestContext(t, username, "initial-always-parent")
+			t.Run("CreateRepository", doAPICreateRepository(testCtx, false))
 			t.Run("CreateCRUDFile-ParentSigned", crudActionCreateFile(
 				t, testCtx, user, "master", "parentsigned", "signed-parent.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
@@ -197,7 +198,8 @@ func TestGPGGit(t *testing.T) {
 
 		t.Run("AlwaysSign-Initial-CRUD-Always", func(t *testing.T) {
 			defer PrintCurrentTest(t)()
-			testCtx := NewAPITestContext(t, username, "initial-always")
+			testCtx := NewAPITestContext(t, username, "initial-always-always")
+			t.Run("CreateRepository", doAPICreateRepository(testCtx, false))
 			t.Run("CreateCRUDFile-Always", crudActionCreateFile(
 				t, testCtx, user, "master", "always", "signed-always.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)

--- a/integrations/gpg_git_test.go
+++ b/integrations/gpg_git_test.go
@@ -125,11 +125,19 @@ func TestGPGGit(t *testing.T) {
 			t.Run("CreateCRUDFile-Always", crudActionCreateFile(
 				t, testCtx, user, "master", "always", "signed-always.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
+					if !response.Verification.Verified {
+						t.FailNow()
+						return
+					}
 					assert.Equal(t, "gitea@fake.local", response.Verification.Signer.Email)
 				}))
 			t.Run("CreateCRUDFile-ParentSigned-always", crudActionCreateFile(
 				t, testCtx, user, "parentsigned", "parentsigned-always", "signed-parent2.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
+					if !response.Verification.Verified {
+						t.FailNow()
+						return
+					}
 					assert.Equal(t, "gitea@fake.local", response.Verification.Signer.Email)
 				}))
 		})
@@ -144,6 +152,10 @@ func TestGPGGit(t *testing.T) {
 			t.Run("CreateCRUDFile-Always-ParentSigned", crudActionCreateFile(
 				t, testCtx, user, "always", "always-parentsigned", "signed-always-parentsigned.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
+					if !response.Verification.Verified {
+						t.FailNow()
+						return
+					}
 					assert.Equal(t, "gitea@fake.local", response.Verification.Signer.Email)
 				}))
 		})
@@ -160,6 +172,10 @@ func TestGPGGit(t *testing.T) {
 				assert.NotNil(t, branch.Commit)
 				assert.NotNil(t, branch.Commit.Verification)
 				assert.True(t, branch.Commit.Verification.Verified)
+				if !branch.Commit.Verification.Verified {
+					t.FailNow()
+					return
+				}
 				assert.Equal(t, "gitea@fake.local", branch.Commit.Verification.Signer.Email)
 			}))
 		})
@@ -188,6 +204,10 @@ func TestGPGGit(t *testing.T) {
 			t.Run("CreateCRUDFile-ParentSigned", crudActionCreateFile(
 				t, testCtx, user, "master", "parentsigned", "signed-parent.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
+					if !response.Verification.Verified {
+						t.FailNow()
+						return
+					}
 					assert.Equal(t, "gitea@fake.local", response.Verification.Signer.Email)
 				}))
 		})
@@ -203,6 +223,10 @@ func TestGPGGit(t *testing.T) {
 			t.Run("CreateCRUDFile-Always", crudActionCreateFile(
 				t, testCtx, user, "master", "always", "signed-always.txt", func(t *testing.T, response api.FileResponse) {
 					assert.True(t, response.Verification.Verified)
+					if !response.Verification.Verified {
+						t.FailNow()
+						return
+					}
 					assert.Equal(t, "gitea@fake.local", response.Verification.Signer.Email)
 				}))
 
@@ -289,7 +313,7 @@ func crudActionCreateFile(t *testing.T, ctx APITestContext, user *models.User, f
 				Email: user.Email,
 			},
 		},
-		Content: base64.StdEncoding.EncodeToString([]byte("This is new text")),
+		Content: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("This is new text for %s", path))),
 	}, callback...)
 }
 

--- a/integrations/gpg_git_test.go
+++ b/integrations/gpg_git_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGPGGit(t *testing.T) {
+	prepareTestEnv(t)
 	username := "user2"
 
 	// OK Set a new GPG home


### PR DESCRIPTION
I think I've finally fixed the intermittent failure in gpg git test - The issue appears to be that occasionally the wrong/shutting-down fake server. 

The fix appears to be in the `integrations/git_helper_for_declarative_test.go` where adding:

```go
u.Host = listener.Addr().String()
```

Ensures that if there is more than one listener open the host will be updated for this.

I have run this PR on my local machine 30 times without reproducing the previous error.