### PR TITLE
Fix #9151 - smtp logger configuration sendTos should be an array (#9154)

### DIFF
--- a/modules/setting/log.go
+++ b/modules/setting/log.go
@@ -128,7 +128,11 @@ func generateLogConfig(sec *ini.Section, name string, defaults defaultLogOptions
 		logConfig["username"] = sec.Key("USER").MustString("example@example.com")
 		logConfig["password"] = sec.Key("PASSWD").MustString("******")
 		logConfig["host"] = sec.Key("HOST").MustString("127.0.0.1:25")
-		logConfig["sendTos"] = sec.Key("RECEIVERS").MustString("[]")
+		sendTos := strings.Split(sec.Key("RECEIVERS").MustString(""), ",")
+		for i, address := range sendTos {
+			sendTos[i] = strings.TrimSpace(address)
+		}
+		logConfig["sendTos"] = sendTos
 		logConfig["subject"] = sec.Key("SUBJECT").MustString("Diagnostic message from Gitea")
 	}
 


### PR DESCRIPTION
* Fix #9151 - sendTos should be an array

* trimspace from the addresses
