### PR TITLE
update index.css

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -124,7 +124,7 @@ a{cursor:pointer}
 .ui .info.segment.top{background-color:#e6f1f6!important}
 .ui .info.segment.top h3,.ui .info.segment.top h4{margin-top:0}
 .ui .info.segment.top h3:last-child{margin-top:4px}
-.ui .info.segment.top>:last-child{margin-bottom:0}
+.ui .info.segment.top>:last-child{margin-bottom:0;overflow:auto;}
 .ui .normal.header{font-weight:400}
 .ui .avatar.image{border-radius:3px}
 .ui .form .fake{display:none!important}


### PR DESCRIPTION
edit overflow of ui.info.segment.top:last-child so the commit description won't overflow when too long

example:
![](https://i.imgur.com/4fsmLI2.png)

i don't know why the change on line 1082 happened, hope that doesn't matter

