### PR TITLE
[Backport] Properly fix displaying virtual session provider in admin panel (#9137)

### DIFF
--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -270,7 +270,7 @@
 				<dt>{{.i18n.Tr "admin.config.session_provider"}}</dt>
 				<dd>{{.SessionConfig.Provider}}</dd>
 				<dt>{{.i18n.Tr "admin.config.provider_config"}}</dt>
-				<dd><pre>{{if .SessionConfig.ProviderConfig}}{{.SessionConfig.ProviderConfig  | JsonPrettyPrint}}{{else}}-{{end}}</pre></dd>
+				<dd><code>{{if .SessionConfig.ProviderConfig}}{{.SessionConfig.ProviderConfig}}{{else}}-{{end}}</code></dd>
 				<dt>{{.i18n.Tr "admin.config.cookie_name"}}</dt>
 				<dd>{{.SessionConfig.CookieName}}</dd>
 				<dt>{{.i18n.Tr "admin.config.gc_interval_time"}}</dt>


### PR DESCRIPTION
Backports #9137

* Properly fix #7127

Although #7300 properly shadows the password from the virtual session
provider, the template displaying the provider config still presumed
that the config was JSON.

This PR updates the template and properly hides the Virtual Session
provider.

Fixes #7147