### PR TITLE
Correct tooltip message blocked by dependencies

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -293,9 +293,9 @@
 
 				{{if .BlockedByDependencies}}
 					<span class="text" data-tooltip="{{if .Issue.IsPull}}
-						{{.i18n.Tr "repo.issues.dependency.issue_closing_blockedby"}}
-					{{else}}
 						{{.i18n.Tr "repo.issues.dependency.pr_closing_blockedby"}}
+					{{else}}
+						{{.i18n.Tr "repo.issues.dependency.issue_closing_blockedby"}}
 					{{end}}" data-inverted="">
 					<strong>{{.i18n.Tr "repo.issues.dependency.blocked_by_short"}}</strong>
 					</span>


### PR DESCRIPTION

Currently `gitea/templates/repo/issue/view_content/sidebar.tmpl ` [#L295-L299](https://github.com/go-gitea/gitea/blob/master/templates/repo/issue/view_content/sidebar.tmpl#L295-L299) has the translated tooltip message for pull requests and issues mixed.

This pull request introduces a commit which corrects this, and shouldn't break anything.