### PR TITLE
Graceful: Cancel Process on monitor pages & HammerTime

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -197,6 +197,7 @@ func runWeb(ctx *cli.Context) error {
 	log.Info("HTTP Listener: %s Closed", listenAddr)
 	graceful.Manager.WaitForServers()
 	graceful.Manager.WaitForTerminate()
+	log.Info("PID: %d Gitea Web Finished", os.Getpid())
 	log.Close()
 	return nil
 }

--- a/models/repo.go
+++ b/models/repo.go
@@ -30,7 +30,6 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/options"
-	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
@@ -1202,11 +1201,11 @@ func initRepoCommit(tmpPath string, u *User) (err error) {
 		"GIT_COMMITTER_DATE="+commitTimeStr,
 	)
 
-	var stderr string
-	if _, stderr, err = process.GetManager().ExecDir(-1,
-		tmpPath, fmt.Sprintf("initRepoCommit (git add): %s", tmpPath),
-		git.GitExecutable, "add", "--all"); err != nil {
-		return fmt.Errorf("git add: %s", stderr)
+	if stdout, err := git.NewCommand("add", "--all").
+		SetDescription(fmt.Sprintf("initRepoCommit (git add): %s", tmpPath)).
+		RunInDir(tmpPath); err != nil {
+		log.Error("git add --all failed: Stdout: %s\nError: %v", stdout, err)
+		return fmt.Errorf("git add --all: %v", err)
 	}
 
 	binVersion, err := git.BinVersion()
@@ -1228,18 +1227,20 @@ func initRepoCommit(tmpPath string, u *User) (err error) {
 		}
 	}
 
-	if _, stderr, err = process.GetManager().ExecDirEnv(-1,
-		tmpPath, fmt.Sprintf("initRepoCommit (git commit): %s", tmpPath),
-		env,
-		git.GitExecutable, args...); err != nil {
-		return fmt.Errorf("git commit: %s", stderr)
+	if stdout, err := git.NewCommand(args...).
+		SetDescription(fmt.Sprintf("initRepoCommit (git commit): %s", tmpPath)).
+		RunInDirWithEnv(tmpPath, env); err != nil {
+		log.Error("Failed to commit: %v: Stdout: %s\nError: %v", args, stdout, err)
+		return fmt.Errorf("git commit: %v", err)
 	}
 
-	if _, stderr, err = process.GetManager().ExecDir(-1,
-		tmpPath, fmt.Sprintf("initRepoCommit (git push): %s", tmpPath),
-		git.GitExecutable, "push", "origin", "master"); err != nil {
-		return fmt.Errorf("git push: %s", stderr)
+	if stdout, err := git.NewCommand("push", "origin", "master").
+		SetDescription(fmt.Sprintf("initRepoCommit (git push): %s", tmpPath)).
+		RunInDir(tmpPath); err != nil {
+		log.Error("Failed to push back to master: Stdout: %s\nError: %v", stdout, err)
+		return fmt.Errorf("git push: %v", err)
 	}
+
 	return nil
 }
 
@@ -1297,14 +1298,11 @@ func prepareRepoCommit(e Engine, repo *Repository, tmpDir, repoPath string, opts
 	)
 
 	// Clone to temporary path and do the init commit.
-	_, stderr, err := process.GetManager().ExecDirEnv(
-		-1, "",
-		fmt.Sprintf("initRepository(git clone): %s", repoPath),
-		env,
-		git.GitExecutable, "clone", repoPath, tmpDir,
-	)
-	if err != nil {
-		return fmt.Errorf("git clone: %v - %s", err, stderr)
+	if stdout, err := git.NewCommand("clone", repoPath, tmpDir).
+		SetDescription(fmt.Sprintf("initRepository (git clone): %s to %s", repoPath, tmpDir)).
+		RunInDirWithEnv("", env); err != nil {
+		log.Error("Failed to clone from %v into %s: stdout: %s\nError: %v", repo, tmpDir, stdout, err)
+		return fmt.Errorf("git clone: %v", err)
 	}
 
 	// README
@@ -1584,11 +1582,11 @@ func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err
 			}
 		}
 
-		_, stderr, err := process.GetManager().ExecDir(-1,
-			repoPath, fmt.Sprintf("CreateRepository(git update-server-info): %s", repoPath),
-			git.GitExecutable, "update-server-info")
-		if err != nil {
-			return nil, errors.New("CreateRepository(git update-server-info): " + stderr)
+		if stdout, err := git.NewCommand("update-server-info").
+			SetDescription(fmt.Sprintf("CreateRepository(git update-server-info): %s", repoPath)).
+			RunInDir(repoPath); err != nil {
+			log.Error("CreateRepitory(git update-server-info) in %v: Stdout: %s\nError: %v", repo, stdout, err)
+			return nil, fmt.Errorf("CreateRepository(git update-server-info): %v", err)
 		}
 	}
 
@@ -2422,12 +2420,13 @@ func GitGcRepos() error {
 				if err := repo.GetOwner(); err != nil {
 					return err
 				}
-				_, stderr, err := process.GetManager().ExecDir(
-					time.Duration(setting.Git.Timeout.GC)*time.Second,
-					RepoPath(repo.Owner.Name, repo.Name), "Repository garbage collection",
-					git.GitExecutable, args...)
-				if err != nil {
-					return fmt.Errorf("%v: %v", err, stderr)
+				if stdout, err := git.NewCommand(args...).
+					SetDescription(fmt.Sprintf("Repository Garbage Collection: %s", repo.FullName())).
+					RunInDirTimeout(
+						time.Duration(setting.Git.Timeout.GC)*time.Second,
+						RepoPath(repo.Owner.Name, repo.Name)); err != nil {
+					log.Error("Repository garbage collection failed for %v. Stdout: %s\nError: %v", repo, stdout, err)
+					return fmt.Errorf("Repository garbage collection failed: Error: %v", err)
 				}
 				return nil
 			})
@@ -2647,18 +2646,19 @@ func ForkRepository(doer, owner *User, oldRepo *Repository, name, desc string) (
 	}
 
 	repoPath := RepoPath(owner.Name, repo.Name)
-	_, stderr, err := process.GetManager().ExecTimeout(10*time.Minute,
-		fmt.Sprintf("ForkRepository(git clone): %s/%s", owner.Name, repo.Name),
-		git.GitExecutable, "clone", "--bare", oldRepo.repoPath(sess), repoPath)
-	if err != nil {
-		return nil, fmt.Errorf("git clone: %v", stderr)
+	if stdout, err := git.NewCommand(
+		"clone", "--bare", oldRepo.repoPath(sess), repoPath).
+		SetDescription(fmt.Sprintf("ForkRepository(git clone): %s to %s", oldRepo.FullName(), repo.FullName())).
+		RunInDirTimeout(10*time.Minute, ""); err != nil {
+		log.Error("Fork Repository (git clone) Failed for %v (from %v):\nStdout: %s\nError: %v", repo, oldRepo, stdout, err)
+		return nil, fmt.Errorf("git clone: %v", err)
 	}
 
-	_, stderr, err = process.GetManager().ExecDir(-1,
-		repoPath, fmt.Sprintf("ForkRepository(git update-server-info): %s", repoPath),
-		git.GitExecutable, "update-server-info")
-	if err != nil {
-		return nil, fmt.Errorf("git update-server-info: %v", stderr)
+	if stdout, err := git.NewCommand("update-server-info").
+		SetDescription(fmt.Sprintf("ForkRepository(git update-server-info): %s", repo.FullName())).
+		RunInDir(repoPath); err != nil {
+		log.Error("Fork Repository (git update-server-info) failed for %v:\nStdout: %s\nError: %v", repo, stdout, err)
+		return nil, fmt.Errorf("git update-server-info: %v", err)
 	}
 
 	if err = createDelegateHooks(repoPath); err != nil {

--- a/modules/git/blame.go
+++ b/modules/git/blame.go
@@ -97,7 +97,9 @@ func CreateBlameReader(repoPath, commitID, file string) (*BlameReader, error) {
 }
 
 func createBlameReader(dir string, command ...string) (*BlameReader, error) {
-	cmd := exec.Command(command[0], command[1:]...)
+	// FIXME: graceful: This should have a timeout
+	// FIXME: graceful: This should create its own subcontext
+	cmd := exec.CommandContext(DefaultContext, command[0], command[1:]...)
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr
 

--- a/modules/git/blame.go
+++ b/modules/git/blame.go
@@ -117,7 +117,7 @@ func createBlameReader(dir string, command ...string) (*BlameReader, error) {
 		return nil, fmt.Errorf("Start: %v", err)
 	}
 
-	pid := process.GetManager().Add(fmt.Sprintf("GetBlame [repo_path: %s]", dir), cmd, cancel)
+	pid := process.GetManager().Add(fmt.Sprintf("GetBlame [repo_path: %s]", dir), cancel)
 
 	scanner := bufio.NewScanner(stdout)
 

--- a/modules/git/blame.go
+++ b/modules/git/blame.go
@@ -6,6 +6,7 @@ package git
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +29,7 @@ type BlameReader struct {
 	output  io.ReadCloser
 	scanner *bufio.Scanner
 	lastSha *string
+	cancel  context.CancelFunc
 }
 
 var shaLineRegex = regexp.MustCompile("^([a-z0-9]{40})")
@@ -76,7 +78,8 @@ func (r *BlameReader) NextPart() (*BlamePart, error) {
 
 // Close BlameReader - don't run NextPart after invoking that
 func (r *BlameReader) Close() error {
-	process.GetManager().Remove(r.pid)
+	defer process.GetManager().Remove(r.pid)
+	defer r.cancel()
 
 	if err := r.cmd.Wait(); err != nil {
 		return fmt.Errorf("Wait: %v", err)
@@ -98,21 +101,23 @@ func CreateBlameReader(repoPath, commitID, file string) (*BlameReader, error) {
 
 func createBlameReader(dir string, command ...string) (*BlameReader, error) {
 	// FIXME: graceful: This should have a timeout
-	// FIXME: graceful: This should create its own subcontext
-	cmd := exec.CommandContext(DefaultContext, command[0], command[1:]...)
+	ctx, cancel := context.WithCancel(DefaultContext)
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		defer cancel()
 		return nil, fmt.Errorf("StdoutPipe: %v", err)
 	}
 
 	if err = cmd.Start(); err != nil {
+		defer cancel()
 		return nil, fmt.Errorf("Start: %v", err)
 	}
 
-	pid := process.GetManager().Add(fmt.Sprintf("GetBlame [repo_path: %s]", dir), cmd)
+	pid := process.GetManager().Add(fmt.Sprintf("GetBlame [repo_path: %s]", dir), cmd, cancel)
 
 	scanner := bufio.NewScanner(stdout)
 
@@ -122,5 +127,6 @@ func createBlameReader(dir string, command ...string) (*BlameReader, error) {
 		stdout,
 		scanner,
 		nil,
+		cancel,
 	}, nil
 }

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -131,7 +131,7 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 	if desc == "" {
 		desc = fmt.Sprintf("%s %s %s [repo_path: %s]", GitExecutable, c.name, strings.Join(c.args, " "), dir)
 	}
-	pid := process.GetManager().Add(desc, cmd, cancel)
+	pid := process.GetManager().Add(desc, cancel)
 	defer process.GetManager().Remove(pid)
 
 	if fn != nil {

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -131,7 +131,7 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 	if desc == "" {
 		desc = fmt.Sprintf("%s %s %s [repo_path: %s]", GitExecutable, c.name, strings.Join(c.args, " "), dir)
 	}
-	pid := process.GetManager().Add(desc, cmd)
+	pid := process.GetManager().Add(desc, cmd, cancel)
 	defer process.GetManager().Remove(pid)
 
 	if fn != nil {

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -58,8 +58,9 @@ func NewCommand(args ...string) *Command {
 // NewCommandNoGlobals creates and returns a new Git Command based on given command and arguments only with the specify args and don't care global command args
 func NewCommandNoGlobals(args ...string) *Command {
 	return &Command{
-		name: GitExecutable,
-		args: args,
+		name:          GitExecutable,
+		args:          args,
+		parentContext: DefaultContext,
 	}
 }
 

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -6,6 +6,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -34,6 +35,9 @@ var (
 	// GitExecutable is the command name of git
 	// Could be updated to an absolute path while initialization
 	GitExecutable = "git"
+
+	// DefaultContext is the default context to run git commands in
+	DefaultContext = context.Background()
 
 	gitVersion string
 )

--- a/modules/graceful/context.go
+++ b/modules/graceful/context.go
@@ -1,0 +1,90 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package graceful
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Errors for context.Err()
+var (
+	ErrShutdown  = fmt.Errorf("Graceful Manager called Shutdown")
+	ErrHammer    = fmt.Errorf("Graceful Manager called Hammer")
+	ErrTerminate = fmt.Errorf("Graceful Manager called Terminate")
+)
+
+// ChannelContext is a context that wraps a channel and error as a context
+type ChannelContext struct {
+	done <-chan struct{}
+	err  error
+}
+
+// NewChannelContext creates a ChannelContext from a channel and error
+func NewChannelContext(done <-chan struct{}, err error) *ChannelContext {
+	return &ChannelContext{
+		done: done,
+		err:  err,
+	}
+}
+
+// Deadline returns the time when work done on behalf of this context
+// should be canceled. There is no Deadline for a ChannelContext
+func (ctx *ChannelContext) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+// Done returns the channel provided at the creation of this context.
+// When closed, work done on behalf of this context should be canceled.
+func (ctx *ChannelContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+// Err returns nil, if Done is not closed. If Done is closed,
+// Err returns the error provided at the creation of this context
+func (ctx *ChannelContext) Err() error {
+	select {
+	case <-ctx.done:
+		return ctx.err
+	default:
+		return nil
+	}
+}
+
+// Value returns nil for all calls as no values are or can be associated with this context
+func (ctx *ChannelContext) Value(key interface{}) interface{} {
+	return nil
+}
+
+// ShutdownContext returns a context.Context that is Done at shutdown
+// Callers using this context should ensure that they are registered as a running server
+// in order that they are waited for.
+func (g *gracefulManager) ShutdownContext() context.Context {
+	return &ChannelContext{
+		done: g.IsShutdown(),
+		err:  ErrShutdown,
+	}
+}
+
+// HammerContext returns a context.Context that is Done at hammer
+// Callers using this context should ensure that they are registered as a running server
+// in order that they are waited for.
+func (g *gracefulManager) HammerContext() context.Context {
+	return &ChannelContext{
+		done: g.IsHammer(),
+		err:  ErrHammer,
+	}
+}
+
+// TerminateContext returns a context.Context that is Done at terminate
+// Callers using this context should ensure that they are registered as a terminating server
+// in order that they are waited for.
+func (g *gracefulManager) TerminateContext() context.Context {
+	return &ChannelContext{
+		done: g.IsTerminate(),
+		err:  ErrTerminate,
+	}
+}

--- a/modules/graceful/manager.go
+++ b/modules/graceful/manager.go
@@ -50,7 +50,7 @@ type CallbackWithContext func(ctx context.Context, callback func())
 // RunnableWithShutdownFns is a runnable with functions to run at shutdown and terminate
 // After the callback to atShutdown is called and is complete, the main function must return.
 // Similarly the callback function provided to atTerminate must return once termination is complete.
-// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till till their respective signals
+// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till their respective signals
 // - users must therefore be careful to only call these as necessary.
 // If run is not expected to run indefinitely RunWithShutdownChan is likely to be more appropriate.
 type RunnableWithShutdownFns func(atShutdown, atTerminate func(context.Context, func()))
@@ -58,7 +58,7 @@ type RunnableWithShutdownFns func(atShutdown, atTerminate func(context.Context, 
 // RunWithShutdownFns takes a function that has both atShutdown and atTerminate callbacks
 // After the callback to atShutdown is called and is complete, the main function must return.
 // Similarly the callback function provided to atTerminate must return once termination is complete.
-// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till till their respective signals
+// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till their respective signals
 // - users must therefore be careful to only call these as necessary.
 // If run is not expected to run indefinitely RunWithShutdownChan is likely to be more appropriate.
 func (g *gracefulManager) RunWithShutdownFns(run RunnableWithShutdownFns) {

--- a/modules/graceful/manager.go
+++ b/modules/graceful/manager.go
@@ -5,6 +5,7 @@
 package graceful
 
 import (
+	"context"
 	"time"
 
 	"code.gitea.io/gitea/modules/log"
@@ -34,9 +35,106 @@ const numberOfServersToCreate = 3
 var Manager *gracefulManager
 
 func init() {
-	Manager = newGracefulManager()
+	Manager = newGracefulManager(context.Background())
 }
 
+// CallbackWithContext is combined runnable and context to watch to see if the caller has finished
+type CallbackWithContext func(ctx context.Context, callback func())
+
+// RunnableWithShutdownFns is a runnable with functions to run at shutdown and terminate
+// After the callback to atShutdown is called and is complete, the main function must return.
+// Similarly the callback function provided to atTerminate must return once termination is complete.
+// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till till their respective signals
+// - users must therefore be careful to only call these as necessary.
+// If run is not expected to run indefinitely RunWithShutdownChan is likely to be more appropriate.
+type RunnableWithShutdownFns func(atShutdown, atTerminate func(context.Context, func()))
+
+// RunWithShutdownFns takes a function that has both atShutdown and atTerminate callbacks
+// After the callback to atShutdown is called and is complete, the main function must return.
+// Similarly the callback function provided to atTerminate must return once termination is complete.
+// Please note that use of the atShutdown and atTerminate callbacks will create go-routines that will wait till till their respective signals
+// - users must therefore be careful to only call these as necessary.
+// If run is not expected to run indefinitely RunWithShutdownChan is likely to be more appropriate.
+func (g *gracefulManager) RunWithShutdownFns(run RunnableWithShutdownFns) {
+	g.runningServerWaitGroup.Add(1)
+	defer g.runningServerWaitGroup.Done()
+	run(func(ctx context.Context, atShutdown func()) {
+		go func() {
+			select {
+			case <-g.IsShutdown():
+				atShutdown()
+			case <-ctx.Done():
+				return
+			}
+		}()
+	}, func(ctx context.Context, atTerminate func()) {
+		g.RunAtTerminate(ctx, atTerminate)
+	})
+}
+
+// RunnableWithShutdownChan is a runnable with functions to run at shutdown and terminate.
+// After the atShutdown channel is closed, the main function must return once shutdown is complete.
+// (Optionally IsHammer may be waited for instead however, this should be avoided if possible.)
+// The callback function provided to atTerminate must return once termination is complete.
+// Please note that use of the atTerminate function will create a go-routine that will wait till terminate - users must therefore be careful to only call this as necessary.
+type RunnableWithShutdownChan func(atShutdown <-chan struct{}, atTerminate CallbackWithContext)
+
+// RunWithShutdownChan takes a function that has channel to watch for shutdown and atTerminate callbacks
+// After the atShutdown channel is closed, the main function must return once shutdown is complete.
+// (Optionally IsHammer may be waited for instead however, this should be avoided if possible.)
+// The callback function provided to atTerminate must return once termination is complete.
+// Please note that use of the atTerminate function will create a go-routine that will wait till terminate - users must therefore be careful to only call this as necessary.
+func (g *gracefulManager) RunWithShutdownChan(run RunnableWithShutdownChan) {
+	g.runningServerWaitGroup.Add(1)
+	defer g.runningServerWaitGroup.Done()
+	run(g.IsShutdown(), func(ctx context.Context, atTerminate func()) {
+		g.RunAtTerminate(ctx, atTerminate)
+	})
+}
+
+// RunWithShutdownContext takes a function that has a context to watch for shutdown.
+// After the provided context is Done(), the main function must return once shutdown is complete.
+// (Optionally the HammerContext may be obtained and waited for however, this should be avoided if possible.)
+func (g *gracefulManager) RunWithShutdownContext(run func(context.Context)) {
+	g.runningServerWaitGroup.Add(1)
+	defer g.runningServerWaitGroup.Done()
+	run(g.ShutdownContext())
+}
+
+// RunAtTerminate adds to the terminate wait group and creates a go-routine to run the provided function at termination
+func (g *gracefulManager) RunAtTerminate(ctx context.Context, terminate func()) {
+	g.terminateWaitGroup.Add(1)
+	go func() {
+		select {
+		case <-g.IsTerminate():
+			terminate()
+		case <-ctx.Done():
+		}
+		g.terminateWaitGroup.Done()
+	}()
+}
+
+// RunAtShutdown creates a go-routine to run the provided function at shutdown
+func (g *gracefulManager) RunAtShutdown(ctx context.Context, shutdown func()) {
+	go func() {
+		select {
+		case <-g.IsShutdown():
+			shutdown()
+		case <-ctx.Done():
+		}
+	}()
+}
+
+// RunAtHammer creates a go-routine to run the provided function at shutdown
+func (g *gracefulManager) RunAtHammer(ctx context.Context, hammer func()) {
+	go func() {
+		select {
+		case <-g.IsHammer():
+			hammer()
+		case <-ctx.Done():
+		}
+	}()
+}
 func (g *gracefulManager) doShutdown() {
 	if !g.setStateTransition(stateRunning, stateShuttingDown) {
 		return

--- a/modules/graceful/manager.go
+++ b/modules/graceful/manager.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"time"
 
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
@@ -36,6 +38,10 @@ var Manager *gracefulManager
 
 func init() {
 	Manager = newGracefulManager(context.Background())
+	// Set the git default context to the HammerContext
+	git.DefaultContext = Manager.HammerContext()
+	// Set the process default context to the HammerContext
+	process.DefaultContext = Manager.HammerContext()
 }
 
 // CallbackWithContext is combined runnable and context to watch to see if the caller has finished

--- a/modules/graceful/manager.go
+++ b/modules/graceful/manager.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/git"
-	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
 )
 
@@ -154,6 +154,8 @@ func (g *gracefulManager) doShutdown() {
 	}
 	go func() {
 		g.WaitForServers()
+		// Mop up any remaining unclosed events.
+		g.doHammerTime(0)
 		<-time.After(1 * time.Second)
 		g.doTerminate()
 	}()

--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -24,6 +24,9 @@ var (
 	// ErrExecTimeout represent a timeout error
 	ErrExecTimeout = errors.New("Process execution timeout")
 	manager        *Manager
+
+	// DefaultContext is the default context to run processing commands in
+	DefaultContext = context.Background()
 )
 
 // Process represents a working process inherit from Gogs.
@@ -110,7 +113,7 @@ func (pm *Manager) ExecDirEnvStdIn(timeout time.Duration, dir, desc string, env 
 	stdOut := new(bytes.Buffer)
 	stdErr := new(bytes.Buffer)
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(DefaultContext, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, cmdName, args...)

--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -35,7 +35,6 @@ type Process struct {
 	PID         int64 // Process ID, not system one.
 	Description string
 	Start       time.Time
-	Cmd         *exec.Cmd
 	Cancel      context.CancelFunc
 }
 
@@ -58,14 +57,13 @@ func GetManager() *Manager {
 }
 
 // Add a process to the ProcessManager and returns its PID.
-func (pm *Manager) Add(description string, cmd *exec.Cmd, cancel context.CancelFunc) int64 {
+func (pm *Manager) Add(description string, cancel context.CancelFunc) int64 {
 	pm.mutex.Lock()
 	pid := pm.counter + 1
 	pm.processes[pid] = &Process{
 		PID:         pid,
 		Description: description,
 		Start:       time.Now(),
-		Cmd:         cmd,
 		Cancel:      cancel,
 	}
 	pm.counter = pid
@@ -154,7 +152,7 @@ func (pm *Manager) ExecDirEnvStdIn(timeout time.Duration, dir, desc string, env 
 		return "", "", err
 	}
 
-	pid := pm.Add(desc, cmd, cancel)
+	pid := pm.Add(desc, cancel)
 	err := cmd.Wait()
 	pm.Remove(pid)
 

--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -156,6 +156,9 @@ func (pm *Manager) ExecDirEnvStdIn(timeout time.Duration, dir, desc string, env 
 func (pm *Manager) Kill(pid int64) error {
 	if proc, exists := pm.Processes[pid]; exists {
 		pm.mutex.Lock()
+		if proc.Cancel != nil {
+			proc.Cancel()
+		}
 		if proc.Cmd != nil &&
 			proc.Cmd.Process != nil &&
 			proc.Cmd.ProcessState != nil &&

--- a/modules/process/manager_test.go
+++ b/modules/process/manager_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -12,10 +11,10 @@ import (
 func TestManager_Add(t *testing.T) {
 	pm := Manager{processes: make(map[int64]*Process)}
 
-	pid := pm.Add("foo", exec.Command("foo"), nil)
+	pid := pm.Add("foo", nil)
 	assert.Equal(t, int64(1), pid, "expected to get pid 1 got %d", pid)
 
-	pid = pm.Add("bar", exec.Command("bar"), nil)
+	pid = pm.Add("bar", nil)
 	assert.Equal(t, int64(2), pid, "expected to get pid 2 got %d", pid)
 }
 
@@ -23,7 +22,7 @@ func TestManager_Cancel(t *testing.T) {
 	pm := Manager{processes: make(map[int64]*Process)}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	pid := pm.Add("foo", exec.Command("foo"), cancel)
+	pid := pm.Add("foo", cancel)
 
 	pm.Cancel(pid)
 
@@ -37,10 +36,10 @@ func TestManager_Cancel(t *testing.T) {
 func TestManager_Remove(t *testing.T) {
 	pm := Manager{processes: make(map[int64]*Process)}
 
-	pid1 := pm.Add("foo", exec.Command("foo"), nil)
+	pid1 := pm.Add("foo", nil)
 	assert.Equal(t, int64(1), pid1, "expected to get pid 1 got %d", pid1)
 
-	pid2 := pm.Add("bar", exec.Command("bar"), nil)
+	pid2 := pm.Add("bar", nil)
 	assert.Equal(t, int64(2), pid2, "expected to get pid 2 got %d", pid2)
 
 	pm.Remove(pid2)

--- a/modules/process/manager_test.go
+++ b/modules/process/manager_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestManager_Add(t *testing.T) {
-	pm := Manager{Processes: make(map[int64]*Process)}
+	pm := Manager{processes: make(map[int64]*Process)}
 
 	pid := pm.Add("foo", exec.Command("foo"), nil)
 	assert.Equal(t, int64(1), pid, "expected to get pid 1 got %d", pid)
@@ -20,7 +20,7 @@ func TestManager_Add(t *testing.T) {
 }
 
 func TestManager_Cancel(t *testing.T) {
-	pm := Manager{Processes: make(map[int64]*Process)}
+	pm := Manager{processes: make(map[int64]*Process)}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	pid := pm.Add("foo", exec.Command("foo"), cancel)
@@ -35,7 +35,7 @@ func TestManager_Cancel(t *testing.T) {
 }
 
 func TestManager_Remove(t *testing.T) {
-	pm := Manager{Processes: make(map[int64]*Process)}
+	pm := Manager{processes: make(map[int64]*Process)}
 
 	pid1 := pm.Add("foo", exec.Command("foo"), nil)
 	assert.Equal(t, int64(1), pid1, "expected to get pid 1 got %d", pid1)
@@ -45,7 +45,7 @@ func TestManager_Remove(t *testing.T) {
 
 	pm.Remove(pid2)
 
-	_, exists := pm.Processes[pid2]
+	_, exists := pm.processes[pid2]
 	assert.False(t, exists, "PID %d is in the list but shouldn't", pid2)
 }
 

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1999,6 +1999,9 @@ monitor.process = Running Processes
 monitor.desc = Description
 monitor.start = Start Time
 monitor.execute_time = Execution Time
+monitor.process.cancel = Cancel process
+monitor.process.cancel_desc =  Cancelling a process may cause data loss
+monitor.process.cancel_notices =  Cancel: <strong>%s</strong>?
 
 notices.system_notice_list = System Notices
 notices.view_detail_header = View Notice Details

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -356,3 +356,12 @@ func Monitor(ctx *context.Context) {
 	ctx.Data["Entries"] = cron.ListTasks()
 	ctx.HTML(200, tplMonitor)
 }
+
+// MonitorCancel cancels a process
+func MonitorCancel(ctx *context.Context) {
+	pid := ctx.ParamsInt64("pid")
+	process.GetManager().Cancel(pid)
+	ctx.JSON(200, map[string]interface{}{
+		"redirect": ctx.Repo.RepoLink + "/admin/monitor",
+	})
+}

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -352,7 +352,7 @@ func Monitor(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("admin.monitor")
 	ctx.Data["PageIsAdmin"] = true
 	ctx.Data["PageIsAdminMonitor"] = true
-	ctx.Data["Processes"] = process.GetManager().Processes
+	ctx.Data["Processes"] = process.GetManager().Processes()
 	ctx.Data["Entries"] = cron.ListTasks()
 	ctx.HTML(200, tplMonitor)
 }

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -478,7 +478,7 @@ func serviceRPC(h serviceHandler, service string) {
 	cmd.Stdin = reqBody
 	cmd.Stderr = &stderr
 
-	pid := process.GetManager().Add(fmt.Sprintf("%s %s %s [repo_path: %s]", git.GitExecutable, service, "--stateless-rpc", h.dir), cmd, cancel)
+	pid := process.GetManager().Add(fmt.Sprintf("%s %s %s [repo_path: %s]", git.GitExecutable, service, "--stateless-rpc", h.dir), cancel)
 	defer process.GetManager().Remove(pid)
 
 	if err := cmd.Run(); err != nil {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -8,6 +8,7 @@ package repo
 import (
 	"bytes"
 	"compress/gzip"
+	gocontext "context"
 	"fmt"
 	"net/http"
 	"os"
@@ -465,8 +466,10 @@ func serviceRPC(h serviceHandler, service string) {
 	h.environ = append(h.environ, "SSH_ORIGINAL_COMMAND="+service)
 
 	// FIXME: graceful: Is the defaultContext appropriate here or should it be the requests context?
+	ctx, cancel := gocontext.WithCancel(git.DefaultContext)
+	defer cancel()
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(git.DefaultContext, git.GitExecutable, service, "--stateless-rpc", h.dir)
+	cmd := exec.CommandContext(ctx, git.GitExecutable, service, "--stateless-rpc", h.dir)
 	cmd.Dir = h.dir
 	if service == "receive-pack" {
 		cmd.Env = append(os.Environ(), h.environ...)
@@ -475,7 +478,7 @@ func serviceRPC(h serviceHandler, service string) {
 	cmd.Stdin = reqBody
 	cmd.Stderr = &stderr
 
-	pid := process.GetManager().Add(fmt.Sprintf("%s %s %s [repo_path: %s]", git.GitExecutable, service, "--stateless-rpc", h.dir), cmd)
+	pid := process.GetManager().Add(fmt.Sprintf("%s %s %s [repo_path: %s]", git.GitExecutable, service, "--stateless-rpc", h.dir), cmd, cancel)
 	defer process.GetManager().Remove(pid)
 
 	if err := cmd.Run(); err != nil {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -465,7 +465,6 @@ func serviceRPC(h serviceHandler, service string) {
 	// set this for allow pre-receive and post-receive execute
 	h.environ = append(h.environ, "SSH_ORIGINAL_COMMAND="+service)
 
-	// FIXME: graceful: Is the defaultContext appropriate here or should it be the requests context?
 	ctx, cancel := gocontext.WithCancel(git.DefaultContext)
 	defer cancel()
 	var stderr bytes.Buffer

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -422,6 +422,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/config", admin.Config)
 		m.Post("/config/test_mail", admin.SendTestMail)
 		m.Get("/monitor", admin.Monitor)
+		m.Post("/monitor/cancel/:pid", admin.MonitorCancel)
 
 		m.Group("/users", func() {
 			m.Get("", admin.Users)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -859,7 +859,7 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 		return nil, fmt.Errorf("Start: %v", err)
 	}
 
-	pid := process.GetManager().Add(fmt.Sprintf("GetDiffRange [repo_path: %s]", repoPath), cmd, cancel)
+	pid := process.GetManager().Add(fmt.Sprintf("GetDiffRange [repo_path: %s]", repoPath), cancel)
 	defer process.GetManager().Remove(pid)
 
 	diff, err := ParsePatch(maxLines, maxLineCharacters, maxFiles, stdout)
@@ -947,7 +947,7 @@ func GetRawDiffForFile(repoPath, startCommit, endCommit string, diffType RawDiff
 	cmd.Dir = repoPath
 	cmd.Stdout = writer
 	cmd.Stderr = stderr
-	pid := process.GetManager().Add(fmt.Sprintf("GetRawDiffForFile: [repo_path: %s]", repoPath), cmd, cancel)
+	pid := process.GetManager().Add(fmt.Sprintf("GetRawDiffForFile: [repo_path: %s]", repoPath), cancel)
 	defer process.GetManager().Remove(pid)
 
 	if err = cmd.Run(); err != nil {

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -8,6 +8,7 @@ package gitdiff
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"html"
 	"html/template"
@@ -826,9 +827,11 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 	}
 
 	// FIXME: graceful: These commands should likely have a timeout
+	ctx, cancel := context.WithCancel(git.DefaultContext)
+	defer cancel()
 	var cmd *exec.Cmd
 	if len(beforeCommitID) == 0 && commit.ParentCount() == 0 {
-		cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, "show", afterCommitID)
+		cmd = exec.CommandContext(ctx, git.GitExecutable, "show", afterCommitID)
 	} else {
 		actualBeforeCommitID := beforeCommitID
 		if len(actualBeforeCommitID) == 0 {
@@ -841,7 +844,7 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 		}
 		diffArgs = append(diffArgs, actualBeforeCommitID)
 		diffArgs = append(diffArgs, afterCommitID)
-		cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, diffArgs...)
+		cmd = exec.CommandContext(ctx, git.GitExecutable, diffArgs...)
 		beforeCommitID = actualBeforeCommitID
 	}
 	cmd.Dir = repoPath
@@ -856,7 +859,7 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 		return nil, fmt.Errorf("Start: %v", err)
 	}
 
-	pid := process.GetManager().Add(fmt.Sprintf("GetDiffRange [repo_path: %s]", repoPath), cmd)
+	pid := process.GetManager().Add(fmt.Sprintf("GetDiffRange [repo_path: %s]", repoPath), cmd, cancel)
 	defer process.GetManager().Remove(pid)
 
 	diff, err := ParsePatch(maxLines, maxLineCharacters, maxFiles, stdout)
@@ -910,27 +913,30 @@ func GetRawDiffForFile(repoPath, startCommit, endCommit string, diffType RawDiff
 		fileArgs = append(fileArgs, "--", file)
 	}
 	// FIXME: graceful: These commands should have a timeout
+	ctx, cancel := context.WithCancel(git.DefaultContext)
+	defer cancel()
+
 	var cmd *exec.Cmd
 	switch diffType {
 	case RawDiffNormal:
 		if len(startCommit) != 0 {
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"diff", "-M", startCommit, endCommit}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"diff", "-M", startCommit, endCommit}, fileArgs...)...)
 		} else if commit.ParentCount() == 0 {
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"show", endCommit}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"show", endCommit}, fileArgs...)...)
 		} else {
 			c, _ := commit.Parent(0)
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"diff", "-M", c.ID.String(), endCommit}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"diff", "-M", c.ID.String(), endCommit}, fileArgs...)...)
 		}
 	case RawDiffPatch:
 		if len(startCommit) != 0 {
 			query := fmt.Sprintf("%s...%s", endCommit, startCommit)
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", "--root", query}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", "--root", query}, fileArgs...)...)
 		} else if commit.ParentCount() == 0 {
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", "--root", endCommit}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", "--root", endCommit}, fileArgs...)...)
 		} else {
 			c, _ := commit.Parent(0)
 			query := fmt.Sprintf("%s...%s", endCommit, c.ID.String())
-			cmd = exec.CommandContext(git.DefaultContext, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", query}, fileArgs...)...)
+			cmd = exec.CommandContext(ctx, git.GitExecutable, append([]string{"format-patch", "--no-signature", "--stdout", query}, fileArgs...)...)
 		}
 	default:
 		return fmt.Errorf("invalid diffType: %s", diffType)
@@ -941,7 +947,7 @@ func GetRawDiffForFile(repoPath, startCommit, endCommit string, diffType RawDiff
 	cmd.Dir = repoPath
 	cmd.Stdout = writer
 	cmd.Stderr = stderr
-	pid := process.GetManager().Add(fmt.Sprintf("GetRawDiffForFile: [repo_path: %s]", repoPath), cmd)
+	pid := process.GetManager().Add(fmt.Sprintf("GetRawDiffForFile: [repo_path: %s]", repoPath), cmd, cancel)
 	defer process.GetManager().Remove(pid)
 
 	if err = cmd.Run(); err != nil {

--- a/services/mirror/mirror.go
+++ b/services/mirror/mirror.go
@@ -15,7 +15,6 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/notification"
-	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/sync"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -172,25 +171,36 @@ func runSync(m *models.Mirror) ([]*mirrorSyncResult, bool) {
 		gitArgs = append(gitArgs, "--prune")
 	}
 
-	_, stderr, err := process.GetManager().ExecDir(
-		timeout, repoPath, fmt.Sprintf("Mirror.runSync: %s", repoPath),
-		git.GitExecutable, gitArgs...)
-	if err != nil {
+	stdoutBuilder := strings.Builder{}
+	stderrBuilder := strings.Builder{}
+	if err := git.NewCommand(gitArgs...).
+		SetDescription(fmt.Sprintf("Mirror.runSync: %s", m.Repo.FullName())).
+		RunInDirTimeoutPipeline(timeout, repoPath, &stdoutBuilder, &stderrBuilder); err != nil {
+		stdout := stdoutBuilder.String()
+		stderr := stderrBuilder.String()
 		// sanitize the output, since it may contain the remote address, which may
 		// contain a password
-		message, err := sanitizeOutput(stderr, repoPath)
-		if err != nil {
-			log.Error("sanitizeOutput: %v", err)
+		stderrMessage, sanitizeErr := sanitizeOutput(stderr, repoPath)
+		if sanitizeErr != nil {
+			log.Error("sanitizeOutput failed on stderr: %v", sanitizeErr)
+			log.Error("Failed to update mirror repository %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdout, stderr, err)
 			return nil, false
 		}
-		desc := fmt.Sprintf("Failed to update mirror repository '%s': %s", repoPath, message)
-		log.Error(desc)
+		stdoutMessage, err := sanitizeOutput(stdout, repoPath)
+		if err != nil {
+			log.Error("sanitizeOutput failed: %v", sanitizeErr)
+			log.Error("Failed to update mirror repository %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdout, stderrMessage, err)
+			return nil, false
+		}
+
+		log.Error("Failed to update mirror repository %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdoutMessage, stderrMessage, err)
+		desc := fmt.Sprintf("Failed to update mirror repository '%s': %s", repoPath, stderrMessage)
 		if err = models.CreateRepositoryNotice(desc); err != nil {
 			log.Error("CreateRepositoryNotice: %v", err)
 		}
 		return nil, false
 	}
-	output := stderr
+	output := stderrBuilder.String()
 
 	gitRepo, err := git.OpenRepository(repoPath)
 	if err != nil {
@@ -208,18 +218,30 @@ func runSync(m *models.Mirror) ([]*mirrorSyncResult, bool) {
 	}
 
 	if m.Repo.HasWiki() {
-		if _, stderr, err := process.GetManager().ExecDir(
-			timeout, wikiPath, fmt.Sprintf("Mirror.runSync: %s", wikiPath),
-			git.GitExecutable, "remote", "update", "--prune"); err != nil {
+		stderrBuilder.Reset()
+		stdoutBuilder.Reset()
+		if err := git.NewCommand("remote", "update", "--prune").
+			SetDescription(fmt.Sprintf("Mirror.runSync Wiki: %s ", m.Repo.FullName())).
+			RunInDirTimeoutPipeline(timeout, wikiPath, &stdoutBuilder, &stderrBuilder); err != nil {
+			stdout := stdoutBuilder.String()
+			stderr := stderrBuilder.String()
 			// sanitize the output, since it may contain the remote address, which may
 			// contain a password
-			message, err := sanitizeOutput(stderr, wikiPath)
-			if err != nil {
-				log.Error("sanitizeOutput: %v", err)
+			stderrMessage, sanitizeErr := sanitizeOutput(stderr, repoPath)
+			if sanitizeErr != nil {
+				log.Error("sanitizeOutput failed on stderr: %v", sanitizeErr)
+				log.Error("Failed to update mirror repository wiki %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdout, stderr, err)
 				return nil, false
 			}
-			desc := fmt.Sprintf("Failed to update mirror wiki repository '%s': %s", wikiPath, message)
-			log.Error(desc)
+			stdoutMessage, err := sanitizeOutput(stdout, repoPath)
+			if err != nil {
+				log.Error("sanitizeOutput failed: %v", sanitizeErr)
+				log.Error("Failed to update mirror repository wiki %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdout, stderrMessage, err)
+				return nil, false
+			}
+
+			log.Error("Failed to update mirror repository wiki %v:\nStdout: %s\nStderr: %s\nErr: %v", m.Repo, stdoutMessage, stderrMessage, err)
+			desc := fmt.Sprintf("Failed to update mirror repository wiki '%s': %s", wikiPath, stderrMessage)
 			if err = models.CreateRepositoryNotice(desc); err != nil {
 				log.Error("CreateRepositoryNotice: %v", err)
 			}

--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -42,6 +42,7 @@
 						<th>{{.i18n.Tr "admin.monitor.desc"}}</th>
 						<th>{{.i18n.Tr "admin.monitor.start"}}</th>
 						<th>{{.i18n.Tr "admin.monitor.execute_time"}}</th>
+						<th></th>
 					</tr>
 				</thead>
 				<tbody>
@@ -51,11 +52,23 @@
 							<td>{{.Description}}</td>
 							<td>{{DateFmtLong .Start}}</td>
 							<td>{{TimeSince .Start $.Lang}}</td>
+							<td><a class="delete-button" href="" data-url="{{$.Link}}/cancel/{{.PID}}" data-id="{{.PID}}" data-name="{{.Description}}"><i class="close icon text red"></i></a></td>
 						</tr>
 					{{end}}
 				</tbody>
 			</table>
 		</div>
 	</div>
+</div>
+<div class="ui small basic delete modal">
+	<div class="ui icon header">
+		<i class="close icon"></i>
+		{{.i18n.Tr "admin.monitor.process.cancel"}}
+	</div>
+	<div class="content">
+		<p>{{$.i18n.Tr "admin.monitor.process.cancel_notices" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.i18n.Tr "admin.monitor.process.cancel_desc"}}</p>
+	</div>
+	{{template "base/delete_modal_actions" .}}
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
This PR is a breakout from the #8874.

It adds a few callbacks to the graceful manager, a default context to Git and Process processes and the ability to cancel processes from the monitor page.