### PR TITLE
[API] add release_counter to Repo API

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -369,6 +369,7 @@ func (repo *Repository) innerAPIFormat(e Engine, mode AccessMode, isParent bool)
 		Watchers:                  repo.NumWatches,
 		OpenIssues:                repo.NumOpenIssues,
 		OpenPulls:                 repo.NumOpenPulls,
+		Releases:                  repo.NumReleases,
 		DefaultBranch:             repo.DefaultBranch,
 		Created:                   repo.CreatedUnix.AsTime(),
 		Updated:                   repo.UpdatedUnix.AsTime(),

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -68,6 +68,7 @@ type Repository struct {
 	Watchers      int         `json:"watchers_count"`
 	OpenIssues    int         `json:"open_issues_count"`
 	OpenPulls     int         `json:"open_pr_counter"`
+	Releases      int         `json:"release_counter"`
 	DefaultBranch string      `json:"default_branch"`
 	Archived      bool        `json:"archived"`
 	// swagger:strfmt date-time

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -10351,6 +10351,11 @@
           "type": "boolean",
           "x-go-name": "Private"
         },
+        "release_counter": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Releases"
+        },
         "size": {
           "type": "integer",
           "format": "int64",


### PR DESCRIPTION
add `release_counter` to `GET /repos/{owner}/{repo}` responce

@lunny https://github.com/go-gitea/gitea/pull/9202#issuecomment-559820035: done ;)