### PR TITLE
Remove unused comment actions

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -721,12 +721,9 @@ func (issue *Issue) ChangeTitle(doer *User, oldTitle string) (err error) {
 		OldTitle: oldTitle,
 		NewTitle: issue.Title,
 	}
-	comment, err := createCommentWithNoAction(sess, opts)
+	_, err = createCommentWithNoAction(sess, opts)
 	if err != nil {
 		return fmt.Errorf("createComment: %v", err)
-	}
-	if err = sendCreateCommentAction(sess, opts, comment); err != nil {
-		return err
 	}
 	if err = issue.addCrossReferences(sess, doer, true); err != nil {
 		return err
@@ -753,11 +750,8 @@ func AddDeletePRBranchComment(doer *User, repo *Repository, issueID int64, branc
 		Issue:     issue,
 		CommitSHA: branchName,
 	}
-	comment, err := createCommentWithNoAction(sess, opts)
+	_, err = createCommentWithNoAction(sess, opts)
 	if err != nil {
-		return err
-	}
-	if err = sendCreateCommentAction(sess, opts, comment); err != nil {
 		return err
 	}
 
@@ -899,12 +893,8 @@ func newIssue(e *xorm.Session, doer *User, opts NewIssueOptions) (err error) {
 			OldMilestoneID: 0,
 			MilestoneID:    opts.Issue.MilestoneID,
 		}
-		comment, err := createCommentWithNoAction(e, opts)
+		_, err = createCommentWithNoAction(e, opts)
 		if err != nil {
-			return err
-		}
-
-		if err = sendCreateCommentAction(e, opts, comment); err != nil {
 			return err
 		}
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -721,8 +721,7 @@ func (issue *Issue) ChangeTitle(doer *User, oldTitle string) (err error) {
 		OldTitle: oldTitle,
 		NewTitle: issue.Title,
 	}
-	_, err = createCommentWithNoAction(sess, opts)
-	if err != nil {
+	if _, err = createCommentWithNoAction(sess, opts); err != nil {
 		return fmt.Errorf("createComment: %v", err)
 	}
 	if err = issue.addCrossReferences(sess, doer, true); err != nil {
@@ -750,8 +749,7 @@ func AddDeletePRBranchComment(doer *User, repo *Repository, issueID int64, branc
 		Issue:     issue,
 		CommitSHA: branchName,
 	}
-	_, err = createCommentWithNoAction(sess, opts)
-	if err != nil {
+	if _, err = createCommentWithNoAction(sess, opts); err != nil {
 		return err
 	}
 
@@ -893,8 +891,7 @@ func newIssue(e *xorm.Session, doer *User, opts NewIssueOptions) (err error) {
 			OldMilestoneID: 0,
 			MilestoneID:    opts.Issue.MilestoneID,
 		}
-		_, err = createCommentWithNoAction(e, opts)
-		if err != nil {
+		if _, err = createCommentWithNoAction(e, opts); err != nil {
 			return err
 		}
 	}

--- a/models/issue_assignees.go
+++ b/models/issue_assignees.go
@@ -144,9 +144,6 @@ func (issue *Issue) toggleAssignee(sess *xorm.Session, doer *User, assigneeID in
 	if err != nil {
 		return false, nil, fmt.Errorf("createComment: %v", err)
 	}
-	if err = sendCreateCommentAction(sess, opts, comment); err != nil {
-		return false, nil, err
-	}
 
 	// if pull request is in the middle of creation - don't call webhook
 	if isCreate {

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -678,7 +678,7 @@ func createDeadlineComment(e *xorm.Session, doer *User, issue *Issue, newDeadlin
 	if err != nil {
 		return nil, err
 	}
-	return comment, sendCreateCommentAction(e, opts, comment)
+	return comment, nil
 }
 
 // Creates issue dependency comment
@@ -699,12 +699,9 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		Issue:            issue,
 		DependentIssueID: dependentIssue.ID,
 	}
-	comment, err := createCommentWithNoAction(e, opts)
+	_, err = createCommentWithNoAction(e, opts)
 	if err != nil {
 		return
-	}
-	if err = sendCreateCommentAction(e, opts, comment); err != nil {
-		return err
 	}
 
 	opts = &CreateCommentOptions{
@@ -714,12 +711,9 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		Issue:            dependentIssue,
 		DependentIssueID: issue.ID,
 	}
-	comment, err = createCommentWithNoAction(e, opts)
+	_, err = createCommentWithNoAction(e, opts)
 	if err != nil {
 		return
-	}
-	if err = sendCreateCommentAction(e, opts, comment); err != nil {
-		return err
 	}
 
 	return

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -699,8 +699,7 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		Issue:            issue,
 		DependentIssueID: dependentIssue.ID,
 	}
-	_, err = createCommentWithNoAction(e, opts)
-	if err != nil {
+	if _, err = createCommentWithNoAction(e, opts); err != nil {
 		return
 	}
 
@@ -712,10 +711,6 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		DependentIssueID: issue.ID,
 	}
 	_, err = createCommentWithNoAction(e, opts)
-	if err != nil {
-		return
-	}
-
 	return
 }
 

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -414,8 +414,7 @@ func newIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (err
 		Label:   label,
 		Content: "1",
 	}
-	_, err = createCommentWithNoAction(e, opts)
-	if err != nil {
+	if _, err = createCommentWithNoAction(e, opts); err != nil {
 		return err
 	}
 
@@ -491,8 +490,7 @@ func deleteIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (
 		Issue: issue,
 		Label: label,
 	}
-	_, err = createCommentWithNoAction(e, opts)
-	if err != nil {
+	if _, err = createCommentWithNoAction(e, opts); err != nil {
 		return err
 	}
 

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -414,11 +414,8 @@ func newIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (err
 		Label:   label,
 		Content: "1",
 	}
-	comment, err := createCommentWithNoAction(e, opts)
+	_, err = createCommentWithNoAction(e, opts)
 	if err != nil {
-		return err
-	}
-	if err = sendCreateCommentAction(e, opts, comment); err != nil {
 		return err
 	}
 
@@ -494,11 +491,8 @@ func deleteIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (
 		Issue: issue,
 		Label: label,
 	}
-	comment, err := createCommentWithNoAction(e, opts)
+	_, err = createCommentWithNoAction(e, opts)
 	if err != nil {
-		return err
-	}
-	if err = sendCreateCommentAction(e, opts, comment); err != nil {
 		return err
 	}
 

--- a/models/issue_lock.go
+++ b/models/issue_lock.go
@@ -52,8 +52,7 @@ func updateIssueLock(opts *IssueLockOptions, lock bool) error {
 		Type:    commentType,
 		Content: opts.Reason,
 	}
-	_, err := createCommentWithNoAction(sess, opt)
-	if err != nil {
+	if _, err := createCommentWithNoAction(sess, opt); err != nil {
 		return err
 	}
 

--- a/models/issue_lock.go
+++ b/models/issue_lock.go
@@ -52,12 +52,8 @@ func updateIssueLock(opts *IssueLockOptions, lock bool) error {
 		Type:    commentType,
 		Content: opts.Reason,
 	}
-	comment, err := createCommentWithNoAction(sess, opt)
+	_, err := createCommentWithNoAction(sess, opt)
 	if err != nil {
-		return err
-	}
-
-	if err = sendCreateCommentAction(sess, opt, comment); err != nil {
 		return err
 	}
 

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -394,8 +394,7 @@ func changeMilestoneAssign(e *xorm.Session, doer *User, issue *Issue, oldMilesto
 			OldMilestoneID: oldMilestoneID,
 			MilestoneID:    issue.MilestoneID,
 		}
-		_, err := createCommentWithNoAction(e, opts)
-		if err != nil {
+		if _, err := createCommentWithNoAction(e, opts); err != nil {
 			return err
 		}
 	}

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -394,12 +394,8 @@ func changeMilestoneAssign(e *xorm.Session, doer *User, issue *Issue, oldMilesto
 			OldMilestoneID: oldMilestoneID,
 			MilestoneID:    issue.MilestoneID,
 		}
-		comment, err := createCommentWithNoAction(e, opts)
+		_, err := createCommentWithNoAction(e, opts)
 		if err != nil {
-			return err
-		}
-
-		if err := sendCreateCommentAction(e, opts, comment); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Since `sendCreateCommentAction` will only handle `CommentTypeCode`, `CommentTypeComment`, `CommentTypeReopen` and `CommentTypeClose`, so many invokes could be removed.