### PR TITLE
Remove empty lines on issues/pulls page

### DIFF
--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -86,8 +86,8 @@
 					{{range .Issues}}
 
 						{{ $timeStr:= TimeSinceUnix .CreatedUnix $.Lang }}
+						{{if .Repo}}
 						<li class="item">
-							{{if .Repo}}
 							<div class="ui label">{{.Repo.FullName}}#{{.Index}}</div>
 							<a class="title has-emoji" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Title}}</a>
 


### PR DESCRIPTION
This does not fix the underlying issue of not showing (seemingly) random issues/PRs, but it does fix the positioning of the if-check.  
The check starts inside the `<li>` but ends outside the closing `</li>`
https://github.com/go-gitea/gitea/blob/51432ebb9c6f59c618ff34147f4b644c8bfb52f5/templates/user/dashboard/issues.tmpl#L89-L90
https://github.com/go-gitea/gitea/blob/51432ebb9c6f59c618ff34147f4b644c8bfb52f5/templates/user/dashboard/issues.tmpl#L155-L156

![lines](https://user-images.githubusercontent.com/42128690/70002502-d3d2c400-1525-11ea-873c-d7a1c23a700e.png)
