### PR TITLE
Fix Issues/PR List "in your repository" view

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -178,7 +178,7 @@ func Issues(ctx *context.Context) {
 	)
 
 	if ctxUser.IsOrganization() {
-		viewType = "all"
+		viewType = "your_repositories"
 	} else {
 		viewType = ctx.Query("type")
 		switch viewType {
@@ -188,9 +188,9 @@ func Issues(ctx *context.Context) {
 			filterMode = models.FilterModeCreate
 		case "mentioned":
 			filterMode = models.FilterModeMention
-		case "all": // filterMode already set to All
+		case "your_repositories": // filterMode already set to All
 		default:
-			viewType = "all"
+			viewType = "your_repositories"
 		}
 	}
 


### PR DESCRIPTION
This PR correctly sets the `viewType` so that "in your repositories" is active when applicable.  
Ignore the incorrect counts in the above screenshot, that's being taken care of in another PR.

`viewType` doesn't drive any logic other than the template, so no queries are affected.
![Screenshot from 2019-12-02 21-47-29](https://user-images.githubusercontent.com/42128690/70019006-84a08980-154d-11ea-80ec-f467d68860f5.png)
![Screenshot from 2019-12-02 21-47-45](https://user-images.githubusercontent.com/42128690/70019008-84a08980-154d-11ea-9b90-11851b66abde.png)

