### PR TITLE
Don't link wiki revision to commit

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -65,8 +65,12 @@
 						</td>
 						<td class="message">
 							<span class="message-wrapper">
+							{{if $.PageIsWiki}}
+								<span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary}}</span>
+							{{else }}
 								{{ $commitLink:= printf "%s/%s/%s/commit/%s" AppSubUrl $.Username $.Reponame .ID }}
 								<span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{RenderCommitMessageLinkSubject .Message $.RepoLink $commitLink $.Repository.ComposeMetas}}</span>
+							{{end}}
 							</span>
 							{{if IsMultilineCommitMessage .Message}}
 							<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>


### PR DESCRIPTION
In #7907 a change was made to use the same template for repo and wiki
commit lists. However, there is no code or logic for showing the diff of a wiki commit so it just produces broken links like:

```
http://localhost:3000/mrsdizzie/%!s(%3Cnil%3E)/commit/5e72eeb00896d3853ab22a01950a50119b249567
```

See: https://try.gitea.io/mrsdizzie/linktesting/wiki/Home/_revision for example

This just removes the link for now until that feature is implemented