### PR TITLE
Fix latest docker image haven't include static files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 
 #Checkout version if set
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
- && make clean generate build
+ && make clean build
 
 FROM alpine:3.10
 LABEL maintainer="maintainers@gitea.io"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,4 +11,4 @@ docker:
 
 .PHONY: docker-build
 docker-build:
-	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" LDFLAGS="$(LDFLAGS)" webhippie/golang:edge make clean generate build
+	docker run -ti --rm -v $(CURDIR):/srv/app/src/code.gitea.io/gitea -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" LDFLAGS="$(LDFLAGS)" webhippie/golang:edge make clean build

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -106,7 +106,7 @@ To include assets, add the `bindata` tag:
 TAGS="bindata" make build
 ```
 
-WARNING: `generate` was dropped, `generate` may lost all the static files.
+WARNING: `generate` method is deprecated and using it may cause build to miss some static files.
 
 In the default release build of our continuous integration system, the build
 tags are: `TAGS="bindata sqlite sqlite_unlock_notify"`. The simplest

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -106,6 +106,8 @@ To include assets, add the `bindata` tag:
 TAGS="bindata" make build
 ```
 
+WARNING: `generate` was dropped, `generate` may lost all the static files.
+
 In the default release build of our continuous integration system, the build
 tags are: `TAGS="bindata sqlite sqlite_unlock_notify"`. The simplest
 recommended way to build from source is therefore:

--- a/docs/content/doc/installation/from-source.zh-cn.md
+++ b/docs/content/doc/installation/from-source.zh-cn.md
@@ -48,7 +48,7 @@ git checkout v{{< version >}}
 
 - `go` 1.11.0 或以上版本, 详见 [here](https://golang.org/dl/)
 - `node` 10.0.0 或以上版本，并且安装 `npm`, 详见 [here](https://nodejs.org/en/download/)
-- `make`, 详见 <a href='{{< relref "doc/advanced/make.en-us.md" >}}'>这里</a>
+- `make`, 详见 <a href='{{< relref "make.zh-cn.md" >}}'>这里</a>
 
 各种可用的 [make 任务](https://github.com/go-gitea/gitea/blob/master/Makefile)
 可以用来使编译过程更方便。

--- a/docs/content/doc/installation/from-source.zh-cn.md
+++ b/docs/content/doc/installation/from-source.zh-cn.md
@@ -44,30 +44,34 @@ git checkout v{{< version >}}
 
 ## 编译
 
-我们已经将所有的依赖项拷贝到本工程，我们提供了一些 [编译选项](https://github.com/go-gitea/gitea/blob/master/Makefile) 来让编译更简单。你可以按照你的需求来设置编译开关，可用编译选项如下：
+要从源代码进行编译，以下依赖程序必须事先安装好：
+
+- `go` 1.11.0 或以上版本, 详见 [here](https://golang.org/dl/)
+- `node` 10.0.0 或以上版本，并且安装 `npm`, 详见 [here](https://nodejs.org/en/download/)
+- `make`, 详见 <a href='{{< relref "doc/advanced/make.en-us.md" >}}'>这里</a>
+
+各种可用的 [make 任务](https://github.com/go-gitea/gitea/blob/master/Makefile)
+可以用来使编译过程更方便。
+
+按照您的编译需求，以下 tags 可以使用：
 
 * `bindata`: 这个编译选项将会把运行Gitea所需的所有外部资源都打包到可执行文件中，这样部署将非常简单因为除了可执行程序将不再需要任何其他文件。
 * `sqlite sqlite_unlock_notify`: 这个编译选项将启用SQLite3数据库的支持，建议只在少数人使用时使用这个模式。
 * `pam`: 这个编译选项将会启用 PAM (Linux Pluggable Authentication Modules) 认证，如果你使用这一认证模式的话需要开启这个选项。
 
-我们支持两种方式进行编译，Make 工具 和 Go 工具。不过我们推荐使用 Make工具，因为他将会给出更多的编译选项。
+使用 bindata 可以打包资源文件到二进制可以使开发和测试更容易，你可以根据自己的需求决定是否打包资源文件。
+要包含资源文件，请使用 `bindata` tag：
 
-**Note**: We recommend the Go version 1.6 or higher because we are using vendoring and we don't set the required env variable for 1.5 anywhere.
-
-* Make 工具
-
-这个编译方式要求你先安装Make工具，关于Make工具的安装你可以参考Make相关资料。同样如果要使用bindata选项，你可能需要先执行make generate：
-
-```
-TAGS="bindata" make generate build
+```bash
+TAGS="bindata" make build
 ```
 
-* Go 工具
+警告: `generate` 已经废弃，使用 `generate` 会导致资源文件打包失败。
 
-使用 Go 工具编译需要你至少安装了Go 1.5以上版本并且将 govendor 的支持打开。执行命令如下：
+默认的发布版本中的编译选项是： `TAGS="bindata sqlite sqlite_unlock_notify"`。以下为推荐的编译方式：
 
-```
-go build
+```bash
+TAGS="bindata sqlite sqlite_unlock_notify" make build
 ```
 
 ## 测试


### PR DESCRIPTION
Since the build process will start to build frontend files and then check if bindata has been generated. So if 

```
make generate build
```

will ignore all the static files.

This PR will rename all `make generate build` to `make build` to fix that.