### PR TITLE
Ensure LF on checkouts and in editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
+end_of_line = lf
 
 [*.go]
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto eol=lf
 conf/* linguist-vendored
 docker/* linguist-vendored
 options/* linguist-vendored


### PR DESCRIPTION
This will ensure our repo is always checked out with LF line endings which should help Windows users who have line ending normalization enabled.

Additionally, added the LF preference to .editorconfig.