### PR TITLE
docs change gitea version to 1.10.1

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -18,7 +18,7 @@ params:
   description: Git with a cup of tea
   author: The Gitea Authors
   website: https://docs.gitea.io
-  version: 1.10.0
+  version: 1.10.1
 
 outputs:
   home:


### PR DESCRIPTION
update it so docs.gitea.io has new version

@lunny does docs.gitea.io follow master or release branch?