### PR TITLE
Missed defer prepareTestEnv

### DIFF
--- a/integrations/benchmarks_test.go
+++ b/integrations/benchmarks_test.go
@@ -25,7 +25,7 @@ func BenchmarkRepo(b *testing.B) {
 		{url: "https://github.com/golang/go.git", name: "go", skipShort: true},
 		{url: "https://github.com/torvalds/linux.git", name: "linux", skipShort: true},
 	}
-	prepareTestEnv(b)
+	defer prepareTestEnv(b)()
 	session := loginUser(b, "user2")
 	b.ResetTimer()
 
@@ -75,7 +75,7 @@ func StringWithCharset(length int, charset string) string {
 
 func BenchmarkRepoBranchCommit(b *testing.B) {
 	samples := []int64{1, 3, 15, 16}
-	prepareTestEnv(b)
+	defer prepareTestEnv(b)()
 	b.ResetTimer()
 
 	for _, repoID := range samples {

--- a/integrations/git_helper_for_declarative_test.go
+++ b/integrations/git_helper_for_declarative_test.go
@@ -78,7 +78,7 @@ func allowLFSFilters() []string {
 
 func onGiteaRun(t *testing.T, callback func(*testing.T, *url.URL), prepare ...bool) {
 	if len(prepare) == 0 || prepare[0] {
-		prepareTestEnv(t, 1)
+		defer prepareTestEnv(t, 1)()
 	}
 	s := http.Server{
 		Handler: mac,

--- a/integrations/gpg_git_test.go
+++ b/integrations/gpg_git_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestGPGGit(t *testing.T) {
-	prepareTestEnv(t)
+	defer prepareTestEnv(t)()
 	username := "user2"
 
 	// OK Set a new GPG home


### PR DESCRIPTION
It appears that a few defers were missed from the calls to `integrations.prepareTestEnv(...)` causing testlogger to reveal races during testing.

This PR fixes these.