### PR TITLE
Fix placeholders in german translation string

### DIFF
--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -869,7 +869,7 @@ issues.action_assignee=Zuständig
 issues.action_assignee_no_select=Niemand zuständig
 issues.opened_by=%[1]s von <a href="%[2]s">%[3]s</a> geöffnet
 pulls.merged_by=<a href="%[2]s">%[3]s</a> hat %[1]s zusammengeführt
-pulls.merged_by_fake=%[1] von %[2] zusammengeführt
+pulls.merged_by_fake=%[1]s von %[2]s zusammengeführt
 issues.closed_by=<a href="%[2]s">%[3]s</a> hat %[1]s geschlossen
 issues.opened_by_fake=geöffnet %[1]s von %[2]s
 issues.closed_by_fake=geschlossen %[1]s von %[2]s


### PR DESCRIPTION
It caused somthing like this being displayed before:

"%! (template.HTML=vor 1 Monat)von %! (string=testuser)zusammengeführt"
