### PR TITLE
tests: add attachement tests integration

### DIFF
--- a/integrations/attachement_test.go
+++ b/integrations/attachement_test.go
@@ -1,0 +1,88 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/modules/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func generateImg() bytes.Buffer {
+	// Generate image
+	myImage := image.NewRGBA(image.Rect(0, 0, 32, 32))
+	var buff bytes.Buffer
+	png.Encode(&buff, myImage)
+	return buff
+}
+
+func createAttachment(t *testing.T, session *TestSession, repoURL, filename string, buff bytes.Buffer, expectedStatus int) string {
+	body := &bytes.Buffer{}
+
+	//Setup multi-part
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	assert.NoError(t, err)
+	_, err = io.Copy(part, &buff)
+	assert.NoError(t, err)
+	err = writer.Close()
+	assert.NoError(t, err)
+
+	csrf := GetCSRF(t, session, repoURL)
+
+	req := NewRequestWithBody(t, "POST", "/attachments", body)
+	req.Header.Add("X-Csrf-Token", csrf)
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	resp := session.MakeRequest(t, req, expectedStatus)
+
+	if expectedStatus != http.StatusOK {
+		return ""
+	}
+	var obj map[string]string
+	DecodeJSON(t, resp, &obj)
+	return obj["uuid"]
+}
+
+func TestCreateAnonymeAttachement(t *testing.T) {
+	prepareTestEnv(t)
+	session := emptyTestSession(t)
+	createAttachment(t, session, "user2/repo1", "image.png", generateImg(), http.StatusFound)
+}
+
+func TestCreateIssueAttachement(t *testing.T) {
+	prepareTestEnv(t)
+	const repoURL = "user2/repo1"
+	session := loginUser(t, "user2")
+	uuid := createAttachment(t, session, repoURL, "image.png", generateImg(), http.StatusOK)
+
+	req := NewRequest(t, "GET", repoURL+"/issues/new")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+
+	link, exists := htmlDoc.doc.Find("form").Attr("action")
+	assert.True(t, exists, "The template has changed")
+
+	postData := map[string]string{
+		"_csrf":    htmlDoc.GetCSRF(),
+		"title":    "New Issue With Attachement",
+		"content":  "some content",
+		"files[0]": uuid,
+	}
+
+	req = NewRequestWithValues(t, "POST", link, postData)
+	resp = session.MakeRequest(t, req, http.StatusFound)
+	test.RedirectURL(resp) // check that redirect URL exists
+
+	//Validate that attachement is available
+	req = NewRequest(t, "GET", "/attachments/"+uuid)
+	session.MakeRequest(t, req, http.StatusOK)
+}

--- a/integrations/attachement_test.go
+++ b/integrations/attachement_test.go
@@ -52,7 +52,7 @@ func createAttachment(t *testing.T, session *TestSession, repoURL, filename stri
 	return obj["uuid"]
 }
 
-func TestCreateAnonymeAttachement(t *testing.T) {
+func TestCreateAnonymousAttachment(t *testing.T) {
 	prepareTestEnv(t)
 	session := emptyTestSession(t)
 	createAttachment(t, session, "user2/repo1", "image.png", generateImg(), http.StatusFound)

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -78,7 +78,7 @@ func TestCreateRelease(t *testing.T) {
 	session := loginUser(t, "user2")
 	createNewRelease(t, session, "/user2/repo1", "v0.0.1", "v0.0.1", false, false)
 
-	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.stable"), 1)
+	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.stable"), 2)
 }
 
 func TestCreateReleasePreRelease(t *testing.T) {
@@ -87,7 +87,7 @@ func TestCreateReleasePreRelease(t *testing.T) {
 	session := loginUser(t, "user2")
 	createNewRelease(t, session, "/user2/repo1", "v0.0.1", "v0.0.1", true, false)
 
-	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.prerelease"), 1)
+	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.prerelease"), 2)
 }
 
 func TestCreateReleaseDraft(t *testing.T) {
@@ -96,7 +96,7 @@ func TestCreateReleaseDraft(t *testing.T) {
 	session := loginUser(t, "user2")
 	createNewRelease(t, session, "/user2/repo1", "v0.0.1", "v0.0.1", false, true)
 
-	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.draft"), 1)
+	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", i18n.Tr("en", "repo.release.draft"), 2)
 }
 
 func TestCreateReleasePaging(t *testing.T) {

--- a/models/fixtures/attachment.yml
+++ b/models/fixtures/attachment.yml
@@ -69,3 +69,18 @@
   name: attach1
   download_count: 0
   created_unix: 946684800
+
+-
+  id: 9
+  uuid: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a19
+  release_id: 1
+  name: attach1
+  download_count: 0
+  created_unix: 946684800
+
+-
+  id: 10
+  uuid: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20
+  name: attach1
+  download_count: 0
+  created_unix: 946684800 

--- a/models/fixtures/release.yml
+++ b/models/fixtures/release.yml
@@ -1,1 +1,14 @@
-[] # empty
+-
+  id: 1
+  repo_id: 1
+  publisher_id: 2
+  tag_name: "v1.1"
+  lower_tag_name: "v1.1"
+  target: "master"
+  title: "testing-release"
+  sha1: "65f1bf27bc3bf70f64657658635e66094edbcb4d"
+  num_commits: 10
+  is_draft: false
+  is_prerelease: false
+  is_tag: false
+  created_unix: 946684800


### PR DESCRIPTION
Extracted from #7956, to make them work before changing (rebasing) anything.

I haven't very much time lately to do a rebase of the PR in one-shoot. I think this could be already merged as it add more test on current code and it will ease the review later when I rebase the PR with fix.