### PR TITLE
Attempt to fix release-master not including js/css

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -390,15 +390,9 @@ steps:
 
   - name: build
     pull: always
-    image: node:10 # this step is kept at the lowest version of node that we support
-    commands:
-      - make css
-      - make js
-
-  - name: static
-    pull: always
     image: techknowlogick/xgo:latest
     commands:
+      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
@@ -498,15 +492,9 @@ steps:
 
   - name: build
     pull: always
-    image: node:10 # this step is kept at the lowest version of node that we support
-    commands:
-      - make css
-      - make js
-
-  - name: static
-    pull: always
     image: techknowlogick/xgo:latest
     commands:
+      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ $(EXECUTABLE): $(GO_SOURCES)
 	GO111MODULE=on $(GO) build -mod=vendor $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: release
-release: generate release-dirs release-windows release-linux release-darwin release-copy release-compress release-check
+release: js css generate release-dirs release-windows release-linux release-darwin release-copy release-compress release-check
 
 .PHONY: release-dirs
 release-dirs:


### PR DESCRIPTION
My assumption currently is that drone pipeline steps may not share files so files generated in the previous 'build' tasks may have been discarded for the previous 'static' task.