### PR TITLE
refactor(models/attachement): use getAttachmentsByUUIDs

### DIFF
--- a/models/attachment.go
+++ b/models/attachment.go
@@ -133,6 +133,11 @@ func getAttachmentByUUID(e Engine, uuid string) (*Attachment, error) {
 	return attach, nil
 }
 
+// GetAttachmentsByUUIDs returns attachment by given UUID list.
+func GetAttachmentsByUUIDs(uuids []string) ([]*Attachment, error) {
+	return getAttachmentsByUUIDs(x, uuids)
+}
+
 func getAttachmentsByUUIDs(e Engine, uuids []string) ([]*Attachment, error) {
 	if len(uuids) == 0 {
 		return []*Attachment{}, nil

--- a/models/attachment_test.go
+++ b/models/attachment_test.go
@@ -116,3 +116,15 @@ func TestUpdateAttachment(t *testing.T) {
 
 	AssertExistsAndLoadBean(t, &Attachment{Name: "new_name"})
 }
+
+func TestGetAttachmentsByUUIDs(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	attachList, err := GetAttachmentsByUUIDs([]string{"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17", "not-existing-uuid"})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(attachList))
+	assert.Equal(t, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", attachList[0].UUID)
+	assert.Equal(t, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17", attachList[1].UUID)
+	assert.Equal(t, int64(1), attachList[0].IssueID)
+	assert.Equal(t, int64(5), attachList[1].IssueID)
+}

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -567,16 +567,9 @@ func updateCommentInfos(e *xorm.Session, opts *CreateCommentOptions, comment *Co
 		}
 
 		// Check attachments
-		attachments := make([]*Attachment, 0, len(opts.Attachments))
-		for _, uuid := range opts.Attachments {
-			attach, err := getAttachmentByUUID(e, uuid)
-			if err != nil {
-				if IsErrAttachmentNotExist(err) {
-					continue
-				}
-				return fmt.Errorf("getAttachmentByUUID [%s]: %v", uuid, err)
-			}
-			attachments = append(attachments, attach)
+		attachments, err := getAttachmentsByUUIDs(e, opts.Attachments)
+		if err != nil {
+			return fmt.Errorf("getAttachmentsByUUIDs [uuids: %v]: %v", opts.Attachments, err)
 		}
 
 		for i := range attachments {

--- a/models/release.go
+++ b/models/release.go
@@ -129,16 +129,9 @@ func UpdateRelease(rel *Release) error {
 // AddReleaseAttachments adds a release attachments
 func AddReleaseAttachments(releaseID int64, attachmentUUIDs []string) (err error) {
 	// Check attachments
-	var attachments = make([]*Attachment, 0)
-	for _, uuid := range attachmentUUIDs {
-		attach, err := getAttachmentByUUID(x, uuid)
-		if err != nil {
-			if IsErrAttachmentNotExist(err) {
-				continue
-			}
-			return fmt.Errorf("getAttachmentByUUID [%s]: %v", uuid, err)
-		}
-		attachments = append(attachments, attach)
+	attachments, err := GetAttachmentsByUUIDs(attachmentUUIDs)
+	if err != nil {
+		return fmt.Errorf("GetAttachmentsByUUIDs [uuids: %v]: %v", attachmentUUIDs, err)
 	}
 
 	for i := range attachments {


### PR DESCRIPTION
Following #9309, I extracted a refactor from #7956 of common code already existing. And add a unit test.

This simplify code and make only one request to database for the attachement list.