### PR TITLE
Only sync tags after all migration release batches are completed

### DIFF
--- a/modules/migrations/base/uploader.go
+++ b/modules/migrations/base/uploader.go
@@ -11,7 +11,7 @@ type Uploader interface {
 	CreateRepo(repo *Repository, opts MigrateOptions) error
 	CreateTopics(topic ...string) error
 	CreateMilestones(milestones ...*Milestone) error
-	CreateReleases(releases ...*Release) error
+	CreateReleases(syncTags bool, releases ...*Release) error
 	CreateLabels(labels ...*Label) error
 	CreateIssues(issues ...*Issue) error
 	CreateComments(comments ...*Comment) error

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -201,7 +201,7 @@ func (g *GiteaLocalUploader) CreateLabels(labels ...*base.Label) error {
 }
 
 // CreateReleases creates releases
-func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
+func (g *GiteaLocalUploader) CreateReleases(syncTags bool, releases ...*base.Release) error {
 	var rels = make([]*models.Release, 0, len(releases))
 	for _, release := range releases {
 		var rel = models.Release{
@@ -292,8 +292,12 @@ func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 		return err
 	}
 
-	// sync tags to releases in database
-	return models.SyncReleasesWithTags(g.repo, g.gitRepo)
+	if syncTags {
+		// sync tags to releases in database
+		return models.SyncReleasesWithTags(g.repo, g.gitRepo)
+	}
+
+	return nil
 }
 
 // CreateIssues creates issues

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -161,12 +161,16 @@ func migrateRepository(downloader base.Downloader, uploader base.Uploader, opts 
 		}
 
 		relBatchSize := uploader.MaxBatchInsertSize("release")
+		syncTags := false
 		for len(releases) > 0 {
-			if len(releases) < relBatchSize {
-				relBatchSize = len(releases)
+			if len(releases) <= relBatchSize {
+				if len(releases) < relBatchSize {
+					relBatchSize = len(releases)
+				}
+				syncTags = true
 			}
 
-			if err := uploader.CreateReleases(releases[:relBatchSize]...); err != nil {
+			if err := uploader.CreateReleases(syncTags, releases[:relBatchSize]...); err != nil {
 				return err
 			}
 			releases = releases[relBatchSize:]


### PR DESCRIPTION
Fixes #8812 

Previously we were syncing tags after the first batch of releases, regardless of whether there were more batches to complete.

![Screenshot from 2019-12-10 23-24-13](https://user-images.githubusercontent.com/42128690/70593972-9369ea80-1ba4-11ea-831c-d545bba1f920.png)
