### PR TITLE
Add SyncTags to uploader interface

### DIFF
--- a/modules/migrations/base/uploader.go
+++ b/modules/migrations/base/uploader.go
@@ -11,7 +11,8 @@ type Uploader interface {
 	CreateRepo(repo *Repository, opts MigrateOptions) error
 	CreateTopics(topic ...string) error
 	CreateMilestones(milestones ...*Milestone) error
-	CreateReleases(syncTags bool, releases ...*Release) error
+	CreateReleases(releases ...*Release) error
+	SyncTags() error
 	CreateLabels(labels ...*Label) error
 	CreateIssues(issues ...*Issue) error
 	CreateComments(comments ...*Comment) error

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -288,11 +288,8 @@ func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 
 		rels = append(rels, &rel)
 	}
-	if err := models.InsertReleases(rels...); err != nil {
-		return err
-	}
 
-	return nil
+	return models.InsertReleases(rels...)
 }
 
 // SyncTags syncs releases with tags in the database

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -201,7 +201,7 @@ func (g *GiteaLocalUploader) CreateLabels(labels ...*base.Label) error {
 }
 
 // CreateReleases creates releases
-func (g *GiteaLocalUploader) CreateReleases(syncTags bool, releases ...*base.Release) error {
+func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 	var rels = make([]*models.Release, 0, len(releases))
 	for _, release := range releases {
 		var rel = models.Release{
@@ -292,12 +292,12 @@ func (g *GiteaLocalUploader) CreateReleases(syncTags bool, releases ...*base.Rel
 		return err
 	}
 
-	if syncTags {
-		// sync tags to releases in database
-		return models.SyncReleasesWithTags(g.repo, g.gitRepo)
-	}
-
 	return nil
+}
+
+// SyncTags syncs releases with tags in the database
+func (g *GiteaLocalUploader) SyncTags() error {
+	return models.SyncReleasesWithTags(g.repo, g.gitRepo)
 }
 
 // CreateIssues creates issues

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -161,19 +161,20 @@ func migrateRepository(downloader base.Downloader, uploader base.Uploader, opts 
 		}
 
 		relBatchSize := uploader.MaxBatchInsertSize("release")
-		syncTags := false
 		for len(releases) > 0 {
-			if len(releases) <= relBatchSize {
-				if len(releases) < relBatchSize {
-					relBatchSize = len(releases)
-				}
-				syncTags = true
+			if len(releases) < relBatchSize {
+				relBatchSize = len(releases)
 			}
 
-			if err := uploader.CreateReleases(syncTags, releases[:relBatchSize]...); err != nil {
+			if err := uploader.CreateReleases(releases[:relBatchSize]...); err != nil {
 				return err
 			}
 			releases = releases[relBatchSize:]
+		}
+
+		// Once all releases (if any) are inserted, sync any remaining non-release tags
+		if err := uploader.SyncTags(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Follow-up for #9319 

If there are no releases, the uploader will still sync tags at the end.