### PR TITLE
Sleep longer if request speed is over github limitation

### DIFF
--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -33,7 +33,7 @@ type DownloaderFactory interface {
 }
 
 var (
-	_ Downloader = &RetryDownloader{}
+	_ Downloader = &LimitDownloader{}
 )
 
 // RetryDownloader retry the downloads
@@ -64,15 +64,6 @@ func (d *RetryDownloader) GetRequestLimit() float32 {
 	return d.Downloader.GetRequestLimit()
 }
 
-func (d *RetryDownloader) sleep() {
-	secs := int(time.Now().Sub(d.startTime) / time.Second)
-	var sleepTime = time.Second * time.Duration(d.RetryDelay)
-	if secs > 0 && float32(d.GetRequestTimes()/secs) > d.GetRequestLimit() {
-		sleepTime = time.Second * time.Duration(d.RetryDelay+int(float32(d.GetRequestTimes())/d.GetRequestLimit())-secs)
-	}
-	time.Sleep(sleepTime)
-}
-
 // GetRepoInfo returns a repository information with retry
 func (d *RetryDownloader) GetRepoInfo() (*Repository, error) {
 	var (
@@ -84,7 +75,7 @@ func (d *RetryDownloader) GetRepoInfo() (*Repository, error) {
 		if repo, err = d.Downloader.GetRepoInfo(); err == nil {
 			return repo, nil
 		}
-		d.sleep()
+		time.Sleep(time.Second * time.Duration(d.RetryDelay))
 	}
 	return nil, err
 }
@@ -200,4 +191,87 @@ func (d *RetryDownloader) GetPullRequests(page, perPage int) ([]*PullRequest, er
 		time.Sleep(time.Second * time.Duration(d.RetryDelay))
 	}
 	return nil, err
+}
+
+var (
+	_ Downloader = &LimitDownloader{}
+)
+
+// LimitDownloader limit the downloads
+type LimitDownloader struct {
+	Downloader
+	startTime time.Time // start time
+}
+
+// NewLimitDownloader creates a limit downloader
+func NewLimitDownloader(downloader Downloader) *LimitDownloader {
+	return &LimitDownloader{
+		Downloader: downloader,
+		startTime:  time.Now(),
+	}
+}
+
+// GetRequestTimes returns request times
+func (d *LimitDownloader) GetRequestTimes() int {
+	return d.Downloader.GetRequestTimes()
+}
+
+// GetRequestLimit returns the limitation of the http request times per seconds.
+func (d *LimitDownloader) GetRequestLimit() float32 {
+	return d.Downloader.GetRequestLimit()
+}
+
+func (d *LimitDownloader) sleep() {
+	secs := int(time.Now().Sub(d.startTime) / time.Second)
+	if secs > 0 && float32(d.GetRequestTimes()/secs) > d.GetRequestLimit() {
+		time.Sleep(time.Second * time.Duration(int(float32(d.GetRequestTimes())/d.GetRequestLimit())-secs))
+	}
+}
+
+// GetRepoInfo returns a repository information with retry
+func (d *LimitDownloader) GetRepoInfo() (*Repository, error) {
+	d.sleep()
+	return d.Downloader.GetRepoInfo()
+}
+
+// GetTopics returns a repository's topics with retry
+func (d *LimitDownloader) GetTopics() ([]string, error) {
+	d.sleep()
+	return d.Downloader.GetTopics()
+}
+
+// GetMilestones returns a repository's milestones with retry
+func (d *LimitDownloader) GetMilestones() ([]*Milestone, error) {
+	d.sleep()
+	return d.Downloader.GetMilestones()
+}
+
+// GetReleases returns a repository's releases with retry
+func (d *LimitDownloader) GetReleases() ([]*Release, error) {
+	d.sleep()
+	return d.Downloader.GetReleases()
+}
+
+// GetLabels returns a repository's labels with retry
+func (d *LimitDownloader) GetLabels() ([]*Label, error) {
+	d.sleep()
+	return d.Downloader.GetLabels()
+}
+
+// GetIssues returns a repository's issues with retry
+func (d *LimitDownloader) GetIssues(page, perPage int) ([]*Issue, bool, error) {
+	d.sleep()
+	return d.Downloader.GetIssues(page, perPage)
+}
+
+// GetComments returns a repository's comments with retry
+func (d *LimitDownloader) GetComments(issueNumber int64) ([]*Comment, error) {
+	d.sleep()
+	return d.Downloader.GetComments(issueNumber)
+}
+
+// GetPullRequests returns a repository's pull requests with retry
+func (d *LimitDownloader) GetPullRequests(page, perPage int) ([]*PullRequest, error) {
+	d.sleep()
+	return d.Downloader.GetPullRequests(page, perPage)
 }

--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -39,9 +39,8 @@ var (
 // RetryDownloader retry the downloads
 type RetryDownloader struct {
 	Downloader
-	RetryTimes int       // the total execute times
-	RetryDelay int       // time to delay seconds
-	startTime  time.Time // start time
+	RetryTimes int // the total execute times
+	RetryDelay int // time to delay seconds
 }
 
 // NewRetryDownloader creates a retry downloader
@@ -50,7 +49,6 @@ func NewRetryDownloader(downloader Downloader, retryTimes, retryDelay int) *Retr
 		Downloader: downloader,
 		RetryTimes: retryTimes,
 		RetryDelay: retryDelay,
-		startTime:  time.Now(),
 	}
 }
 

--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -6,6 +6,7 @@
 package base
 
 import (
+	"context"
 	"time"
 
 	"code.gitea.io/gitea/modules/structs"
@@ -13,6 +14,7 @@ import (
 
 // Downloader downloads the site repo informations
 type Downloader interface {
+	SetContext(context.Context)
 	GetRepoInfo() (*Repository, error)
 	GetTopics() ([]string, error)
 	GetMilestones() ([]*Milestone, error)
@@ -48,6 +50,11 @@ func NewRetryDownloader(downloader Downloader, retryTimes, retryDelay int) *Retr
 		RetryTimes: retryTimes,
 		RetryDelay: retryDelay,
 	}
+}
+
+// SetContext set context
+func (d *RetryDownloader) SetContext(ctx context.Context) {
+	d.Downloader.SetContext(ctx)
 }
 
 // GetRepoInfo returns a repository information with retry

--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -220,7 +220,7 @@ func (d *LimitDownloader) GetRequestLimit() float32 {
 }
 
 func (d *LimitDownloader) sleep() {
-	secs := int(time.Now().Sub(d.startTime) / time.Second)
+	secs := int(time.Since(d.startTime) / time.Second)
 	if secs > 0 && float32(d.GetRequestTimes()/secs) > d.GetRequestLimit() {
 		time.Sleep(time.Second * time.Duration(int(float32(d.GetRequestTimes())/d.GetRequestLimit())-secs))
 	}

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -28,16 +28,6 @@ func NewPlainGitDownloader(ownerName, repoName, remoteURL string) *PlainGitDownl
 	}
 }
 
-// GetRequestTimes returns request times to the git service
-func (g *PlainGitDownloader) GetRequestTimes() int {
-	return 1
-}
-
-// GetRequestLimit returns the limitation of the http request times per seconds.
-func (g *PlainGitDownloader) GetRequestLimit() float32 {
-	return 999999999.00
-}
-
 // GetRepoInfo returns a repository information
 func (g *PlainGitDownloader) GetRepoInfo() (*base.Repository, error) {
 	// convert github repo to stand Repo

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -5,8 +5,9 @@
 package migrations
 
 import (
-	"code.gitea.io/gitea/modules/migrations/base"
 	"context"
+
+	"code.gitea.io/gitea/modules/migrations/base"
 )
 
 var (

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -28,6 +28,16 @@ func NewPlainGitDownloader(ownerName, repoName, remoteURL string) *PlainGitDownl
 	}
 }
 
+// GetRequestTimes returns request times to the git service
+func (g *PlainGitDownloader) GetRequestTimes() int {
+	return 1
+}
+
+// GetRequestLimit returns the limitation of the http request times per seconds.
+func (g *PlainGitDownloader) GetRequestLimit() float32 {
+	return 999999999.00
+}
+
 // GetRepoInfo returns a repository information
 func (g *PlainGitDownloader) GetRepoInfo() (*base.Repository, error) {
 	// convert github repo to stand Repo

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -6,6 +6,7 @@ package migrations
 
 import (
 	"code.gitea.io/gitea/modules/migrations/base"
+	"context"
 )
 
 var (
@@ -26,6 +27,10 @@ func NewPlainGitDownloader(ownerName, repoName, remoteURL string) *PlainGitDownl
 		repoName:  repoName,
 		remoteURL: remoteURL,
 	}
+}
+
+// SetContext set context
+func (g *PlainGitDownloader) SetContext(ctx context.Context) {
 }
 
 // GetRepoInfo returns a repository information

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -6,6 +6,7 @@
 package migrations
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +36,7 @@ var (
 
 // GiteaLocalUploader implements an Uploader to gitea sites
 type GiteaLocalUploader struct {
+	ctx            context.Context
 	doer           *models.User
 	repoOwner      string
 	repoName       string
@@ -49,8 +51,9 @@ type GiteaLocalUploader struct {
 }
 
 // NewGiteaLocalUploader creates an gitea Uploader via gitea API v1
-func NewGiteaLocalUploader(doer *models.User, repoOwner, repoName string) *GiteaLocalUploader {
+func NewGiteaLocalUploader(ctx context.Context, doer *models.User, repoOwner, repoName string) *GiteaLocalUploader {
 	return &GiteaLocalUploader{
+		ctx:         ctx,
 		doer:        doer,
 		repoOwner:   repoOwner,
 		repoName:    repoName,

--- a/modules/migrations/gitea_test.go
+++ b/modules/migrations/gitea_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
@@ -27,7 +28,7 @@ func TestGiteaUploadRepo(t *testing.T) {
 	var (
 		downloader = NewGithubDownloaderV3("", "", "go-xorm", "builder")
 		repoName   = "builder-" + time.Now().Format("2006-01-02-15-04-05")
-		uploader   = NewGiteaLocalUploader(user, user.Name, repoName)
+		uploader   = NewGiteaLocalUploader(graceful.GetManager().HammerContext(), user, user.Name, repoName)
 	)
 
 	err := migrateRepository(downloader, uploader, structs.MigrateRepoOption{

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -110,7 +110,7 @@ func NewGithubDownloaderV3(userName, password, repoOwner, repoName string) *Gith
 }
 
 func (g *GithubDownloaderV3) sleep() {
-	for g.rate.Remaining <= 0 {
+	for g.rate != nil && g.rate.Remaining <= 0 {
 		time.Sleep(g.rate.Reset.Sub(time.Now()))
 		rates, _, err := g.client.RateLimits(g.ctx)
 		if err != nil {

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -116,10 +116,12 @@ func (g *GithubDownloaderV3) SetContext(ctx context.Context) {
 
 func (g *GithubDownloaderV3) sleep() {
 	for g.rate != nil && g.rate.Remaining <= 0 {
+		timer := time.NewTimer(time.Now().Sub(g.rate.Reset.Time))
 		select {
 		case <-g.ctx.Done():
+			timer.Stop()
 			return
-		case <-time.After(time.Now().Sub(g.rate.Reset.Time)):
+		case <-timer.C:
 		}
 
 		rates, _, err := g.client.RateLimits(g.ctx)

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -116,7 +116,7 @@ func (g *GithubDownloaderV3) SetContext(ctx context.Context) {
 
 func (g *GithubDownloaderV3) sleep() {
 	for g.rate != nil && g.rate.Remaining <= 0 {
-		timer := time.NewTimer(time.Now().Sub(g.rate.Reset.Time))
+		timer := time.NewTimer(time.Until(g.rate.Reset.Time))
 		select {
 		case <-g.ctx.Done():
 			timer.Stop()

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -111,7 +111,7 @@ func NewGithubDownloaderV3(userName, password, repoOwner, repoName string) *Gith
 
 func (g *GithubDownloaderV3) sleep() {
 	for g.rate != nil && g.rate.Remaining <= 0 {
-		time.Sleep(g.rate.Reset.Sub(time.Now()))
+		time.Sleep(time.Until(g.rate.Reset.Time))
 		rates, _, err := g.client.RateLimits(g.ctx)
 		if err != nil {
 			log.Error("g.client.RateLimits: %s", err)

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -65,8 +65,6 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 
 	uploader.gitServiceType = opts.GitServiceType
 
-	downloader = base.NewLimitDownloader(downloader)
-
 	if setting.Migrations.MaxAttempts > 1 {
 		downloader = base.NewRetryDownloader(downloader, setting.Migrations.MaxAttempts, setting.Migrations.RetryBackoff)
 	}

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -65,6 +65,8 @@ func MigrateRepository(doer *models.User, ownerName string, opts base.MigrateOpt
 
 	uploader.gitServiceType = opts.GitServiceType
 
+	downloader = base.NewLimitDownloader(downloader)
+
 	if setting.Migrations.MaxAttempts > 1 {
 		downloader = base.NewRetryDownloader(downloader, setting.Migrations.MaxAttempts, setting.Migrations.RetryBackoff)
 	}

--- a/modules/task/migrate.go
+++ b/modules/task/migrate.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations"
 	"code.gitea.io/gitea/modules/notification"
@@ -95,7 +96,7 @@ func runMigrateTask(t *models.Task) (err error) {
 	}
 
 	opts.MigrateToRepoID = t.RepoID
-	repo, err := migrations.MigrateRepository(t.Doer, t.Owner.Name, *opts)
+	repo, err := migrations.MigrateRepository(graceful.GetManager().HammerContext(), t.Doer, t.Owner.Name, *opts)
 	if err == nil {
 		log.Trace("Repository migrated [%d]: %s/%s", repo.ID, t.Owner.Name, repo.Name)
 		return nil

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -18,6 +18,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/convert"
 	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations"
 	"code.gitea.io/gitea/modules/notification"
@@ -481,7 +482,7 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 		}
 	}()
 
-	if _, err = migrations.MigrateRepository(ctx.User, ctxUser.Name, opts); err != nil {
+	if _, err = migrations.MigrateRepository(graceful.GetManager().HammerContext(), ctx.User, ctxUser.Name, opts); err != nil {
 		handleMigrateError(ctx, ctxUser, remoteAddr, err)
 		return
 	}


### PR DESCRIPTION
Since github has a 5000 API request times per hour per token limitation, we have to add a limit for migrating from those bigger repository.