### PR TITLE
Fix nondeterministic behavior

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -138,7 +138,7 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 		fn(ctx, cancel)
 	}
 
-	if err := cmd.Wait(); err != nil {
+	if err := cmd.Wait(); err != nil && ctx.Err() != context.DeadlineExceeded {
 		return err
 	}
 

--- a/modules/git/command_test.go
+++ b/modules/git/command_test.go
@@ -30,7 +30,7 @@ func TestRunInDirTimeoutPipelineAlwaysTimeout(t *testing.T) {
 	maxLoops := 1000
 
 	// 'git hash-object --stdin' blocks on stdin so we can have the timeout triggered.
-	cmd := NewCommand("hash-object --stdin")
+	cmd := NewCommand("hash-object", "--stdin")
 	for i := 0; i < maxLoops; i++ {
 		if err := cmd.RunInDirTimeoutPipeline(1*time.Microsecond, "", nil, nil); err != nil {
 			if err != context.DeadlineExceeded {


### PR DESCRIPTION
The underlying implementation of os.exec uses channels and goroutines.
It is possible to have time-variant error values returned from Cmd.Wait
depending on which comes first.

Fixes a flaky test in modules/git/command_test.go

For #1441 