### PR TITLE
Fix protected branch using IssueID

### DIFF
--- a/models/branches.go
+++ b/models/branches.go
@@ -153,7 +153,7 @@ func (protectBranch *ProtectedBranch) HasEnoughApprovals(pr *PullRequest) bool {
 
 // GetGrantedApprovalsCount returns the number of granted approvals for pr. A granted approval must be authored by a user in an approval whitelist.
 func (protectBranch *ProtectedBranch) GetGrantedApprovalsCount(pr *PullRequest) int64 {
-	approvals, err := x.Where("issue_id = ?", pr.Issue.ID).
+	approvals, err := x.Where("issue_id = ?", pr.IssueID).
 		And("type = ?", ReviewTypeApprove).
 		And("official = ?", true).
 		Count(new(Review))


### PR DESCRIPTION
Small regression where protected branch checks don't have the `Issue` loaded for a PR, so we should use `pr.IssueID` rather than `pr.Issue.ID`
