### PR TITLE
Allow inline CSS in docs

### DIFF
--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
   X-Frame-Options: DENY
   X-Xss-Protection: 1; mode=block
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
The heading anchors use inline CSS, so changing this will stop the console CSP errors and style them the same green color our other links use.

Current:
![gitea_black](https://user-images.githubusercontent.com/42128690/70816517-4862f980-1d95-11ea-8ca4-4fcd9dec3606.png)

After:
![gitea_green](https://user-images.githubusercontent.com/42128690/70816519-4862f980-1d95-11ea-9ab2-90858abbd50e.png)