### PR TITLE
Fix missed change to GetManager()

### DIFF
--- a/modules/graceful/net_windows.go
+++ b/modules/graceful/net_windows.go
@@ -13,7 +13,7 @@ import "net"
 // On windows this is basically just a shim around net.Listen.
 func GetListener(network, address string) (net.Listener, error) {
 	// Add a deferral to say that we've tried to grab a listener
-	defer Manager.InformCleanup()
+	defer GetManager().InformCleanup()
 
 	return net.Listen(network, address)
 }


### PR DESCRIPTION
#9282 missed a change to GetManager() in net_windows.go. This PR fixes this.