### PR TITLE
Remove unused method and rename createcommentWithNoAction

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -664,7 +664,7 @@ func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed bool) (*C
 		cmtType = CommentTypeReopen
 	}
 
-	return createCommentWithNoAction(e, &CreateCommentOptions{
+	return createComment(e, &CreateCommentOptions{
 		Type:  cmtType,
 		Doer:  doer,
 		Repo:  issue.Repo,
@@ -724,7 +724,7 @@ func (issue *Issue) ChangeTitle(doer *User, oldTitle string) (err error) {
 		OldTitle: oldTitle,
 		NewTitle: issue.Title,
 	}
-	if _, err = createCommentWithNoAction(sess, opts); err != nil {
+	if _, err = createComment(sess, opts); err != nil {
 		return fmt.Errorf("createComment: %v", err)
 	}
 	if err = issue.addCrossReferences(sess, doer, true); err != nil {
@@ -752,7 +752,7 @@ func AddDeletePRBranchComment(doer *User, repo *Repository, issueID int64, branc
 		Issue:     issue,
 		CommitSHA: branchName,
 	}
-	if _, err = createCommentWithNoAction(sess, opts); err != nil {
+	if _, err = createComment(sess, opts); err != nil {
 		return err
 	}
 
@@ -894,7 +894,7 @@ func newIssue(e *xorm.Session, doer *User, opts NewIssueOptions) (err error) {
 			OldMilestoneID: 0,
 			MilestoneID:    opts.Issue.MilestoneID,
 		}
-		if _, err = createCommentWithNoAction(e, opts); err != nil {
+		if _, err = createComment(e, opts); err != nil {
 			return err
 		}
 	}

--- a/models/issue_assignees.go
+++ b/models/issue_assignees.go
@@ -140,7 +140,7 @@ func (issue *Issue) toggleAssignee(sess *xorm.Session, doer *User, assigneeID in
 		AssigneeID:      assigneeID,
 	}
 	// Comment
-	comment, err = createCommentWithNoAction(sess, opts)
+	comment, err = createComment(sess, opts)
 	if err != nil {
 		return false, nil, fmt.Errorf("createComment: %v", err)
 	}

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -495,7 +495,7 @@ func (c *Comment) CodeCommentURL() string {
 	return fmt.Sprintf("%s/files#%s", c.Issue.HTMLURL(), c.HashTag())
 }
 
-func createCommentWithNoAction(e *xorm.Session, opts *CreateCommentOptions) (_ *Comment, err error) {
+func createComment(e *xorm.Session, opts *CreateCommentOptions) (_ *Comment, err error) {
 	var LabelID int64
 	if opts.Label != nil {
 		LabelID = opts.Label.ID
@@ -589,55 +589,6 @@ func updateCommentInfos(e *xorm.Session, opts *CreateCommentOptions, comment *Co
 	return updateIssueCols(e, opts.Issue, "updated_unix")
 }
 
-func sendCreateCommentAction(e *xorm.Session, opts *CreateCommentOptions, comment *Comment) (err error) {
-	// Compose comment action, could be plain comment, close or reopen issue/pull request.
-	// This object will be used to notify watchers in the end of function.
-	act := &Action{
-		ActUserID: opts.Doer.ID,
-		ActUser:   opts.Doer,
-		Content:   fmt.Sprintf("%d|%s", opts.Issue.Index, strings.Split(opts.Content, "\n")[0]),
-		RepoID:    opts.Repo.ID,
-		Repo:      opts.Repo,
-		Comment:   comment,
-		CommentID: comment.ID,
-		IsPrivate: opts.Repo.IsPrivate,
-	}
-	// Check comment type.
-	switch opts.Type {
-	case CommentTypeCode:
-		if comment.ReviewID != 0 {
-			if comment.Review == nil {
-				if err := comment.loadReview(e); err != nil {
-					return err
-				}
-			}
-			if comment.Review.Type <= ReviewTypePending {
-				return nil
-			}
-		}
-		fallthrough
-	case CommentTypeComment:
-		act.OpType = ActionCommentIssue
-	case CommentTypeReopen:
-		act.OpType = ActionReopenIssue
-		if opts.Issue.IsPull {
-			act.OpType = ActionReopenPullRequest
-		}
-	case CommentTypeClose:
-		act.OpType = ActionCloseIssue
-		if opts.Issue.IsPull {
-			act.OpType = ActionClosePullRequest
-		}
-	}
-	// Notify watchers for whatever action comes in, ignore if no action type.
-	if act.OpType > 0 {
-		if err = notifyWatchers(e, act); err != nil {
-			log.Error("notifyWatchers: %v", err)
-		}
-	}
-	return nil
-}
-
 func createDeadlineComment(e *xorm.Session, doer *User, issue *Issue, newDeadlineUnix timeutil.TimeStamp) (*Comment, error) {
 	var content string
 	var commentType CommentType
@@ -667,7 +618,7 @@ func createDeadlineComment(e *xorm.Session, doer *User, issue *Issue, newDeadlin
 		Issue:   issue,
 		Content: content,
 	}
-	comment, err := createCommentWithNoAction(e, opts)
+	comment, err := createComment(e, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +643,7 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		Issue:            issue,
 		DependentIssueID: dependentIssue.ID,
 	}
-	if _, err = createCommentWithNoAction(e, opts); err != nil {
+	if _, err = createComment(e, opts); err != nil {
 		return
 	}
 
@@ -703,7 +654,7 @@ func createIssueDependencyComment(e *xorm.Session, doer *User, issue *Issue, dep
 		Issue:            dependentIssue,
 		DependentIssueID: issue.ID,
 	}
-	_, err = createCommentWithNoAction(e, opts)
+	_, err = createComment(e, opts)
 	return
 }
 
@@ -745,27 +696,7 @@ func CreateComment(opts *CreateCommentOptions) (comment *Comment, err error) {
 		return nil, err
 	}
 
-	comment, err = createCommentWithNoAction(sess, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = sess.Commit(); err != nil {
-		return nil, err
-	}
-
-	return comment, nil
-}
-
-// CreateCommentWithNoAction creates comment of issue or commit with no action created
-func CreateCommentWithNoAction(opts *CreateCommentOptions) (comment *Comment, err error) {
-	sess := x.NewSession()
-	defer sess.Close()
-	if err = sess.Begin(); err != nil {
-		return nil, err
-	}
-
-	comment, err = createCommentWithNoAction(sess, opts)
+	comment, err = createComment(sess, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -433,7 +433,7 @@ func newIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (err
 		Label:   label,
 		Content: "1",
 	}
-	if _, err = createCommentWithNoAction(e, opts); err != nil {
+	if _, err = createComment(e, opts); err != nil {
 		return err
 	}
 
@@ -509,7 +509,7 @@ func deleteIssueLabel(e *xorm.Session, issue *Issue, label *Label, doer *User) (
 		Issue: issue,
 		Label: label,
 	}
-	if _, err = createCommentWithNoAction(e, opts); err != nil {
+	if _, err = createComment(e, opts); err != nil {
 		return err
 	}
 

--- a/models/issue_lock.go
+++ b/models/issue_lock.go
@@ -52,7 +52,7 @@ func updateIssueLock(opts *IssueLockOptions, lock bool) error {
 		Type:    commentType,
 		Content: opts.Reason,
 	}
-	if _, err := createCommentWithNoAction(sess, opt); err != nil {
+	if _, err := createComment(sess, opt); err != nil {
 		return err
 	}
 

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -422,7 +422,7 @@ func changeMilestoneAssign(e *xorm.Session, doer *User, issue *Issue, oldMilesto
 			OldMilestoneID: oldMilestoneID,
 			MilestoneID:    issue.MilestoneID,
 		}
-		if _, err := createCommentWithNoAction(e, opts); err != nil {
+		if _, err := createComment(e, opts); err != nil {
 			return err
 		}
 	}

--- a/models/issue_xref.go
+++ b/models/issue_xref.go
@@ -127,11 +127,8 @@ func (issue *Issue) createCrossReferences(e *xorm.Session, ctx *crossReferencesC
 			RefAction:    xref.Action,
 			RefIsPull:    ctx.OrigIssue.IsPull,
 		}
-		comment, err := createCommentWithNoAction(e, opts)
+		_, err := createComment(e, opts)
 		if err != nil {
-			return err
-		}
-		if err = sendCreateCommentAction(e, opts, comment); err != nil {
 			return err
 		}
 	}

--- a/models/review.go
+++ b/models/review.go
@@ -324,7 +324,7 @@ func SubmitReview(doer *User, issue *Issue, reviewType ReviewType, content strin
 		}
 	}
 
-	comm, err := createCommentWithNoAction(sess, &CreateCommentOptions{
+	comm, err := createComment(sess, &CreateCommentOptions{
 		Type:     CommentTypeReview,
 		Doer:     doer,
 		Content:  review.Content,

--- a/services/pull/review.go
+++ b/services/pull/review.go
@@ -144,7 +144,7 @@ func createCodeComment(doer *models.User, repo *models.Repository, issue *models
 		}
 		patch = gitdiff.CutDiffAroundLine(patchBuf, int64((&models.Comment{Line: line}).UnsignedLine()), line < 0, setting.UI.CodeCommentLines)
 	}
-	return models.CreateCommentWithNoAction(&models.CreateCommentOptions{
+	return models.CreateComment(&models.CreateCommentOptions{
 		Type:      models.CommentTypeCode,
 		Doer:      doer,
 		Repo:      repo,


### PR DESCRIPTION
Only one invoke for `sendCreateCommentAction` but they are all referece comments type and `sendCreateCommentAction` only handle `code`, `comment`, `close` and `reopen`. So we can remove it safely.

After that rename `createCommentWithNoAction` back to `createComment` is reasonable.