### PR TITLE
Use ioutil.TmpDir for new created temp directory

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1198,13 +1198,11 @@ func initRepository(e Engine, repoPath string, u *User, repo *Repository, opts C
 		return err
 	}
 
-	tmpDir := filepath.Join(os.TempDir(), "gitea-"+repo.Name+"-"+com.ToStr(time.Now().Nanosecond()))
-
 	// Initialize repository according to user's choice.
 	if opts.AutoInit {
-
-		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
-			return fmt.Errorf("Failed to create dir %s: %v", tmpDir, err)
+		tmpDir, err := ioutil.TempDir(os.TempDir(), "gitea-"+repo.Name)
+		if err != nil {
+			return fmt.Errorf("Failed to create temp dir %s: %v", tmpDir, err)
 		}
 
 		defer os.RemoveAll(tmpDir)

--- a/models/repo.go
+++ b/models/repo.go
@@ -1202,7 +1202,7 @@ func initRepository(e Engine, repoPath string, u *User, repo *Repository, opts C
 	if opts.AutoInit {
 		tmpDir, err := ioutil.TempDir(os.TempDir(), "gitea-"+repo.Name)
 		if err != nil {
-			return fmt.Errorf("Failed to create temp dir %s: %v", tmpDir, err)
+			return fmt.Errorf("Failed to create temp dir for repository %s: %v", repo.repoPath(e), err)
 		}
 
 		defer os.RemoveAll(tmpDir)

--- a/models/repo_generate.go
+++ b/models/repo_generate.go
@@ -179,10 +179,9 @@ func generateRepoCommit(e Engine, repo, templateRepo, generateRepo *Repository, 
 
 // generateRepository initializes repository from template
 func generateRepository(e Engine, repo, templateRepo, generateRepo *Repository) (err error) {
-	tmpDir := filepath.Join(os.TempDir(), "gitea-"+repo.Name+"-"+com.ToStr(time.Now().Nanosecond()))
-
-	if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
-		return fmt.Errorf("Failed to create dir %s: %v", tmpDir, err)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "gitea-"+repo.Name)
+	if err != nil {
+		return fmt.Errorf("Failed to create temp dir %s: %v", tmpDir, err)
 	}
 
 	defer func() {

--- a/models/repo_generate.go
+++ b/models/repo_generate.go
@@ -181,7 +181,7 @@ func generateRepoCommit(e Engine, repo, templateRepo, generateRepo *Repository, 
 func generateRepository(e Engine, repo, templateRepo, generateRepo *Repository) (err error) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "gitea-"+repo.Name)
 	if err != nil {
-		return fmt.Errorf("Failed to create temp dir %s: %v", tmpDir, err)
+		return fmt.Errorf("Failed to create temp dir for repository %s: %v", repo.repoPath(e), err)
 	}
 
 	defer func() {

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -66,7 +66,7 @@ func getMergeCommit(pr *models.PullRequest) (*git.Commit, error) {
 
 	indexTmpPath, err := ioutil.TempDir(os.TempDir(), "gitea-"+pr.BaseRepo.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create temp dir %s: %v", indexTmpPath, err)
+		return nil, fmt.Errorf("Failed to create temp dir for repository %s: %v", pr.BaseRepo.RepoPath(), err)
 	}
 	defer os.RemoveAll(indexTmpPath)
 

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -10,10 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/git"
@@ -67,13 +64,16 @@ func getMergeCommit(pr *models.PullRequest) (*git.Commit, error) {
 		}
 	}
 
-	indexTmpPath := filepath.Join(os.TempDir(), "gitea-"+pr.BaseRepo.Name+"-"+strconv.Itoa(time.Now().Nanosecond()))
-	defer os.Remove(indexTmpPath)
+	indexTmpPath, err := ioutil.TempDir(os.TempDir(), "gitea-"+pr.BaseRepo.Name)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create temp dir %s: %v", indexTmpPath, err)
+	}
+	defer os.RemoveAll(indexTmpPath)
 
 	headFile := pr.GetGitRefName()
 
 	// Check if a pull request is merged into BaseBranch
-	_, err := git.NewCommand("merge-base", "--is-ancestor", headFile, pr.BaseBranch).RunInDirWithEnv(pr.BaseRepo.RepoPath(), []string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()})
+	_, err = git.NewCommand("merge-base", "--is-ancestor", headFile, pr.BaseBranch).RunInDirWithEnv(pr.BaseRepo.RepoPath(), []string{"GIT_INDEX_FILE=" + indexTmpPath, "GIT_DIR=" + pr.BaseRepo.RepoPath()})
 	if err != nil {
 		// Errors are signaled by a non-zero status that is not 1
 		if strings.Contains(err.Error(), "exit status 1") {


### PR DESCRIPTION
Although it's safe enough to use `nanoseconds` but I think `os.TmpDir` should be better.