### PR TITLE
Fix double webhook for new PR

### DIFF
--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -818,8 +818,6 @@ func CompareAndPullRequestPost(ctx *context.Context, form auth.CreateIssueForm) 
 		return
 	}
 
-	notification.NotifyNewPullRequest(pullRequest)
-
 	log.Trace("Pull request created: %d/%d", repo.ID, pullIssue.ID)
 	ctx.Redirect(ctx.Repo.RepoLink + "/pulls/" + com.ToStr(pullIssue.Index))
 }


### PR DESCRIPTION
As title. `notification.NotifyNewPullRequest` is already called in the service.