### PR TITLE
Remove text from action-only webhooks

### DIFF
--- a/modules/webhook/dingtalk.go
+++ b/modules/webhook/dingtalk.go
@@ -139,35 +139,26 @@ func getDingtalkIssuesPayload(p *api.IssuePayload) (*DingtalkPayload, error) {
 		text = p.Issue.Body
 	case api.HookIssueClosed:
 		title = fmt.Sprintf("[%s] Issue closed: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Issue re-opened: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Issue edited: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
 		text = p.Issue.Body
 	case api.HookIssueAssigned:
 		title = fmt.Sprintf("[%s] Issue assigned to %s: #%d %s", p.Repository.FullName,
 			p.Issue.Assignee.UserName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Issue unassigned: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Issue labels updated: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Issue labels cleared: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Issue synchronized: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Issue milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Issue clear milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	}
 
 	return &DingtalkPayload{
@@ -238,10 +229,8 @@ func getDingtalkPullRequestPayload(p *api.PullRequestPayload) (*DingtalkPayload,
 		} else {
 			title = fmt.Sprintf("[%s] Pull request closed: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
 		}
-		text = p.PullRequest.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Pull request re-opened: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Pull request edited: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
 		text = p.PullRequest.Body
@@ -253,25 +242,18 @@ func getDingtalkPullRequestPayload(p *api.PullRequestPayload) (*DingtalkPayload,
 		title = fmt.Sprintf("[%s] Pull request assigned to %s: #%d %s", p.Repository.FullName,
 			strings.Join(list, ", "),
 			p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Pull request unassigned: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Pull request labels updated: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Pull request labels cleared: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Pull request synchronized: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Pull request milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Pull request clear milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	}
 
 	return &DingtalkPayload{

--- a/modules/webhook/discord.go
+++ b/modules/webhook/discord.go
@@ -238,10 +238,8 @@ func getDiscordIssuesPayload(p *api.IssuePayload, meta *DiscordMeta) (*DiscordPa
 	case api.HookIssueClosed:
 		title = fmt.Sprintf("[%s] Issue closed: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
 		color = redColor
-		text = p.Issue.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Issue re-opened: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Issue edited: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
@@ -250,31 +248,24 @@ func getDiscordIssuesPayload(p *api.IssuePayload, meta *DiscordMeta) (*DiscordPa
 	case api.HookIssueAssigned:
 		title = fmt.Sprintf("[%s] Issue assigned to %s: #%d %s", p.Repository.FullName,
 			p.Issue.Assignee.UserName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = greenColor
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Issue unassigned: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Issue labels updated: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Issue labels cleared: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Issue synchronized: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Issue milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Issue clear milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	}
 
@@ -368,10 +359,8 @@ func getDiscordPullRequestPayload(p *api.PullRequestPayload, meta *DiscordMeta) 
 			title = fmt.Sprintf("[%s] Pull request closed: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
 			color = redColor
 		}
-		text = p.PullRequest.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Pull request re-opened: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Pull request edited: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
@@ -385,31 +374,24 @@ func getDiscordPullRequestPayload(p *api.PullRequestPayload, meta *DiscordMeta) 
 		title = fmt.Sprintf("[%s] Pull request assigned to %s: #%d by %s", p.Repository.FullName,
 			strings.Join(list, ", "),
 			p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = greenColor
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Pull request unassigned: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Pull request labels updated: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Pull request labels cleared: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Pull request synchronized: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Pull request milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Pull request clear milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	}
 

--- a/modules/webhook/msteams.go
+++ b/modules/webhook/msteams.go
@@ -277,10 +277,8 @@ func getMSTeamsIssuesPayload(p *api.IssuePayload) (*MSTeamsPayload, error) {
 	case api.HookIssueClosed:
 		title = fmt.Sprintf("[%s] Issue closed: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
 		color = redColor
-		text = p.Issue.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Issue re-opened: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Issue edited: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
@@ -289,31 +287,24 @@ func getMSTeamsIssuesPayload(p *api.IssuePayload) (*MSTeamsPayload, error) {
 	case api.HookIssueAssigned:
 		title = fmt.Sprintf("[%s] Issue assigned to %s: #%d %s", p.Repository.FullName,
 			p.Issue.Assignee.UserName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = greenColor
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Issue unassigned: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Issue labels updated: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Issue labels cleared: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Issue synchronized: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Issue milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Issue clear milestone: #%d %s", p.Repository.FullName, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 		color = yellowColor
 	}
 
@@ -447,10 +438,8 @@ func getMSTeamsPullRequestPayload(p *api.PullRequestPayload) (*MSTeamsPayload, e
 			title = fmt.Sprintf("[%s] Pull request closed: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
 			color = redColor
 		}
-		text = p.PullRequest.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf("[%s] Pull request re-opened: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueEdited:
 		title = fmt.Sprintf("[%s] Pull request edited: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
@@ -464,31 +453,24 @@ func getMSTeamsPullRequestPayload(p *api.PullRequestPayload) (*MSTeamsPayload, e
 		title = fmt.Sprintf("[%s] Pull request assigned to %s: #%d by %s", p.Repository.FullName,
 			strings.Join(list, ", "),
 			p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = greenColor
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf("[%s] Pull request unassigned: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf("[%s] Pull request labels updated: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf("[%s] Pull request labels cleared: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf("[%s] Pull request synchronized: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf("[%s] Pull request milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf("[%s] Pull request clear milestone: #%d %s", p.Repository.FullName, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 		color = yellowColor
 	}
 

--- a/modules/webhook/telegram.go
+++ b/modules/webhook/telegram.go
@@ -135,11 +135,9 @@ func getTelegramIssuesPayload(p *api.IssuePayload) (*TelegramPayload, error) {
 	case api.HookIssueClosed:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue closed: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue re-opened: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueEdited:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue edited: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
@@ -147,31 +145,24 @@ func getTelegramIssuesPayload(p *api.IssuePayload) (*TelegramPayload, error) {
 	case api.HookIssueAssigned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue assigned to %s: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.Assignee.UserName, p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue unassigned: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue labels updated: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue labels cleared: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue synchronized: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue milestone: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Issue clear milestone: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.Issue.URL, p.Index, p.Issue.Title)
-		text = p.Issue.Body
 	}
 
 	return &TelegramPayload{
@@ -219,7 +210,6 @@ func getTelegramPullRequestPayload(p *api.PullRequestPayload) (*TelegramPayload,
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request re-opened: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueEdited:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request edited: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
@@ -231,31 +221,24 @@ func getTelegramPullRequestPayload(p *api.PullRequestPayload) (*TelegramPayload,
 		}
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request assigned to %s: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			list, p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueUnassigned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request unassigned: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueLabelUpdated:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request labels updated: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueLabelCleared:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request labels cleared: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueSynchronized:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request synchronized: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueMilestoned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request milestone: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	case api.HookIssueDemilestoned:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request clear milestone: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
-		text = p.PullRequest.Body
 	}
 
 	return &TelegramPayload{

--- a/modules/webhook/telegram.go
+++ b/modules/webhook/telegram.go
@@ -206,7 +206,6 @@ func getTelegramPullRequestPayload(p *api.PullRequestPayload) (*TelegramPayload,
 			title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request closed: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 				p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)
 		}
-		text = p.PullRequest.Body
 	case api.HookIssueReOpened:
 		title = fmt.Sprintf(`[<a href="%s">%s</a>] Pull request re-opened: <a href="%s">#%d %s</a>`, p.Repository.HTMLURL, p.Repository.FullName,
 			p.PullRequest.HTMLURL, p.Index, p.PullRequest.Title)


### PR DESCRIPTION
This PR removes the body text from most webhooks.  
I'm open to reverting as needed, but imho most webhooks don't need to keep re-displaying the issue/PR text. It just fills up unnecessary space.

After this PR, text/body will only be sent for new and edited issues/PRs.
![webhook](https://user-images.githubusercontent.com/42128690/70940398-d64a1900-200f-11ea-8cce-81708ea381b3.png)
