### PR TITLE
Fix show repositories filter (#9234)

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2896,7 +2896,7 @@ function initVueApp() {
     data: {
       searchLimit: document.querySelector('meta[name=_search_limit]').content,
       suburl: document.querySelector('meta[name=_suburl]').content,
-      uid: document.querySelector('meta[name=_context_uid]').content,
+      uid: Number(document.querySelector('meta[name=_context_uid]').content),
     },
   });
 }


### PR DESCRIPTION
Fix #9234

We have unexpected behavior when trying to strictly compare uid and id, which as it turned out to have different types (`string uid` and `number id`):
https://github.com/go-gitea/gitea/blob/ac361aec782f3adeebd6b1355314d199b9d98012/web_src/js/index.js#L2823-L2836


**Screenshots:**
![Screen Shot 2019-12-17 at 05 47 27](https://user-images.githubusercontent.com/844963/70960713-d0e0e300-2090-11ea-969a-ede6b4725736.png)
![Screen Shot 2019-12-17 at 05 47 31](https://user-images.githubusercontent.com/844963/70960700-c9213e80-2090-11ea-99ef-e84a7afb0524.png)
