### PR TITLE
Fix typo

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -112,7 +112,7 @@ menu:
 
 ## Service (`service`)
 
-- `ACTIVE_CODE_LIVE_MINUTES`: 登陆验证码失效时间，单位分钟。
+- `ACTIVE_CODE_LIVE_MINUTES`: 登录验证码失效时间，单位分钟。
 - `RESET_PASSWD_CODE_LIVE_MINUTES`: 重置密码失效时间，单位分钟。
 - `REGISTER_EMAIL_CONFIRM`: 启用注册邮件激活，前提是 `Mailer` 已经启用。
 - `DISABLE_REGISTRATION`: 禁用注册，启用后只能用管理员添加用户。

--- a/docs/content/doc/upgrade/from-gogs.zh-cn.md
+++ b/docs/content/doc/upgrade/from-gogs.zh-cn.md
@@ -23,4 +23,4 @@ menu:
 * 如果你还有更多的自定义内容，比如templates和localization文件，你需要手工合并你的修改到 Gitea 的 Options 下对应目录。
 * 拷贝 Gogs 的数据目录 `data/` 到 Gitea 相应位置。这个目录包含附件和头像文件。
 * 运行 Gitea
-* 登陆 Gitea 并进入 管理面板, 运行 `重新生成 '.ssh/authorized_keys' 文件（警告：不是 Gitea 的密钥也会被删除）` 和 `重新生成所有仓库的 Update 钩子（用于自定义配置文件被修改）`。
+* 登录 Gitea 并进入 管理面板, 运行 `重新生成 '.ssh/authorized_keys' 文件（警告：不是 Gitea 的密钥也会被删除）` 和 `重新生成所有仓库的 Update 钩子（用于自定义配置文件被修改）`。


### PR DESCRIPTION
"登陆" is typo, which means disembark. 
the correct one in chinese is “登录”.