### PR TITLE
Address minor portability issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOFMT ?= gofmt -s
 GOFLAGS := -v
 EXTRA_GOFLAGS ?=
 
-MAKE_VERSION := $(shell make -v | head -n 1)
+MAKE_VERSION := $(shell $(MAKE) -v | head -n 1)
 
 ifneq ($(DRONE_TAG),)
 	VERSION ?= $(subst v,,$(DRONE_TAG))

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		SED_INPLACE := sed -i ''
 	endif
+	ifeq ($(UNAME_S),FreeBSD)
+		SED_INPLACE := sed -i ''
+	endif
 endif
 
 GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*" ! -path "*/bindata.go")


### PR DESCRIPTION
Address some minor annoyances when building on FreeBSD (and possibly other systems):

Use $(MAKE) instead of "make" when determining the GNU Make version
Add OS specific sed for FreeBSD