### PR TITLE
Add .ignore file for search tools

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,7 @@
+vendor
+public/js
+public/css
+public/vendor
+modules/options/bindata.go
+modules/public/bindata.go
+modules/templates/bindata.go

--- a/.ignore
+++ b/.ignore
@@ -1,7 +1,7 @@
-vendor
-public/js
-public/css
-public/vendor
-modules/options/bindata.go
-modules/public/bindata.go
-modules/templates/bindata.go
+/vendor
+/public/js
+/public/css
+/public/vendor
+/modules/options/bindata.go
+/modules/public/bindata.go
+/modules/templates/bindata.go

--- a/.ignore
+++ b/.ignore
@@ -1,6 +1,4 @@
 /vendor
-/public/js
-/public/css
 /public/vendor
 /modules/options/bindata.go
 /modules/public/bindata.go


### PR DESCRIPTION
Tools like `rg` [1] and `ag` [2] support a `.ignore` file which defines files that are ignored during a recursive search. This adds the file which makes recursive file searches in the code base ignore files that are generally not desirable to search, like bindata, js built files and js vendor libaries.

[1] https://github.com/BurntSushi/ripgrep/
[2] https://github.com/ggreer/the_silver_searcher