### PR TITLE
Add migration to sanitize repository original_url

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -282,7 +282,7 @@ var migrations = []Migration{
 	NewMigration("remove release attachments which repository deleted", removeAttachmentMissedRepo),
 	// v113 -> v114
 	NewMigration("new feature: change target branch of pull requests", featureChangeTargetBranch),
-	// v113 -> v114
+	// v114 -> v115
 	NewMigration("Remove authentication credentials from stored URL", sanitizeOriginalURL),
 }
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -282,6 +282,8 @@ var migrations = []Migration{
 	NewMigration("remove release attachments which repository deleted", removeAttachmentMissedRepo),
 	// v113 -> v114
 	NewMigration("new feature: change target branch of pull requests", featureChangeTargetBranch),
+	// v113 -> v114
+	NewMigration("Remove authentication credentials from stored URL", sanitizeOriginalURL),
 }
 
 // Migrate database to current version

--- a/models/migrations/v114.go
+++ b/models/migrations/v114.go
@@ -6,7 +6,6 @@ package migrations
 
 import (
 	"net/url"
-	"strings"
 
 	"xorm.io/xorm"
 )
@@ -45,11 +44,8 @@ func sanitizeOriginalURL(x *xorm.Engine) error {
 			}
 
 			if len(u.User.Username()) > 0 {
-				pass, _ := u.User.Password()
-				userAuth := u.User.Username() + ":" + pass + "@"
-				OriginalURL := strings.Replace(res.OriginalURL, userAuth, "", -1)
-
-				_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", OriginalURL, res.ID)
+				originalURL := u.Scheme + "://" + u.Host + u.Path
+				_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", originalURL, res.ID)
 				if err != nil {
 					return err
 				}

--- a/models/migrations/v114.go
+++ b/models/migrations/v114.go
@@ -42,10 +42,10 @@ func sanitizeOriginalURL(x *xorm.Engine) error {
 			}
 			u.User = nil
 			originalURL := u.String()
-				_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", originalURL, res.ID)
-				if err != nil {
-					return err
-				}
+			_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", originalURL, res.ID)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/models/migrations/v114.go
+++ b/models/migrations/v114.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"net/url"
+	"strings"
+
+	"xorm.io/xorm"
+)
+
+func sanitizeOriginalURL(x *xorm.Engine) error {
+
+	type Repository struct {
+		ID          int64
+		OriginalURL string `xorm:"VARCHAR(2048)"`
+	}
+
+	sess := x.NewSession()
+	defer sess.Close()
+	var last int
+	const batchSize = 50
+	for {
+		var results = make([]Repository, 0, batchSize)
+		err := x.Where("original_url <> '' AND original_url IS NOT NULL").
+			And("original_service_type = 0 OR original_service_type IS NULL").
+			OrderBy("id").
+			Limit(batchSize, last).
+			Find(&results)
+		if err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			break
+		}
+		last += len(results)
+
+		for _, res := range results {
+			u, err := url.Parse(res.OriginalURL)
+			if err != nil {
+				// it is ok to continue here, we only care about fixing URLs that we can read
+				continue
+			}
+
+			if len(u.User.Username()) > 0 {
+				pass, _ := u.User.Password()
+				userAuth := u.User.Username() + ":" + pass + "@"
+				OriginalURL := strings.Replace(res.OriginalURL, userAuth, "", -1)
+
+				_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", OriginalURL, res.ID)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/models/migrations/v114.go
+++ b/models/migrations/v114.go
@@ -17,8 +17,6 @@ func sanitizeOriginalURL(x *xorm.Engine) error {
 		OriginalURL string `xorm:"VARCHAR(2048)"`
 	}
 
-	sess := x.NewSession()
-	defer sess.Close()
 	var last int
 	const batchSize = 50
 	for {
@@ -42,14 +40,12 @@ func sanitizeOriginalURL(x *xorm.Engine) error {
 				// it is ok to continue here, we only care about fixing URLs that we can read
 				continue
 			}
-
-			if len(u.User.Username()) > 0 {
-				originalURL := u.Scheme + "://" + u.Host + u.Path
+			u.User = nil
+			originalURL := u.String()
 				_, err = x.Exec("UPDATE repository SET original_url = ? WHERE id = ?", originalURL, res.ID)
 				if err != nil {
 					return err
 				}
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
During a large code move in #6200 the OriginalURL field was accidentally changed to be populated with the CloneAddr field which will contain the username and/or password provided during a migration.

This behavior was fixed in previous PR #9097 and this migration will remove any authentication details that were stored in the database between those two.