### PR TITLE
Fix wrong notification on merge

### DIFF
--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -106,7 +106,7 @@ func (m *mailNotifier) NotifyMergePullRequest(pr *models.PullRequest, doer *mode
 		return
 	}
 
-	if err := mailer.MailParticipants(pr.Issue, doer, models.ActionClosePullRequest); err != nil {
+	if err := mailer.MailParticipants(pr.Issue, doer, models.ActionMergePullRequest); err != nil {
 		log.Error("MailParticipants: %v", err)
 	}
 }


### PR DESCRIPTION
This PR fixes the mail notification on a merge action, which was notified as "closed" instead of "merged".