### PR TITLE
Prefix all user-generated IDs in markup

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -58,6 +58,9 @@ var (
 	emailRegex = regexp.MustCompile("(?:\\s|^|\\(|\\[)([a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9]{2,}(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)(?:\\s|$|\\)|\\]|\\.(\\s|$))")
 
 	linkRegex, _ = xurls.StrictMatchingScheme("https?://")
+
+	// blackfriday extensions create IDs like fn:user-content-footnote
+	blackfridayExtRegex = regexp.MustCompile(`[^:]*:user-content-`)
 )
 
 // CSS class for action keywords (e.g. "closes: #1")
@@ -314,7 +317,7 @@ func (ctx *postProcessCtx) postProcess(rawHTML []byte) ([]byte, error) {
 func (ctx *postProcessCtx) visitNode(node *html.Node) {
 	// Add user-content- to IDs if they don't already have them
 	for idx, attr := range node.Attr {
-		if attr.Key == "id" && !strings.HasPrefix(attr.Val, "user-content-") {
+		if attr.Key == "id" && !(strings.HasPrefix(attr.Val, "user-content-") || blackfridayExtRegex.MatchString(attr.Val)) {
 			node.Attr[idx].Val = "user-content-" + attr.Val
 		}
 	}

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -312,6 +312,12 @@ func (ctx *postProcessCtx) postProcess(rawHTML []byte) ([]byte, error) {
 }
 
 func (ctx *postProcessCtx) visitNode(node *html.Node) {
+	// Add user-content- to IDs if they don't already have them
+	for idx, attr := range node.Attr {
+		if attr.Key == "id" && !strings.HasPrefix(attr.Val, "user-content-") {
+			node.Attr[idx].Val = "user-content-" + attr.Val
+		}
+	}
 	// We ignore code, pre and already generated links.
 	switch node.Type {
 	case html.TextNode:

--- a/modules/markup/markdown/markdown.go
+++ b/modules/markup/markdown/markdown.go
@@ -146,7 +146,9 @@ const (
 func RenderRaw(body []byte, urlPrefix string, wikiMarkdown bool) []byte {
 	renderer := &Renderer{
 		Renderer: blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{
-			Flags: blackfridayHTMLFlags,
+			Flags:                blackfridayHTMLFlags,
+			FootnoteAnchorPrefix: "user-content-",
+			HeadingIDPrefix:      "user-content-",
 		}),
 		URLPrefix: urlPrefix,
 		IsWiki:    wikiMarkdown,

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -116,11 +116,11 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 <li><a href="` + baseURLContent + `/plot_var_example" rel="nofollow">Plot var helper</a></li>
 </ul>
 `,
-		`<h2 id="what-is-wine-staging">What is Wine Staging?</h2>
+		`<h2 id="user-content-what-is-wine-staging">What is Wine Staging?</h2>
 
 <p><strong>Wine Staging</strong> on website <a href="http://wine-staging.com" rel="nofollow">wine-staging.com</a>.</p>
 
-<h2 id="quick-links">Quick Links</h2>
+<h2 id="user-content-quick-links">Quick Links</h2>
 
 <p>Here are some links to the most important topics. You can find the full list of pages at the sidebar.</p>
 
@@ -149,11 +149,11 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 <a href="` + baseURLImages + `/images/2.png" rel="nofollow"><img src="` + baseURLImages + `/images/2.png" title="2.png" alt="images/2.png"/></a></li>
 </ol>
 
-<h2 id="custom-id">More tests</h2>
+<h2 id="user-content-custom-id">More tests</h2>
 
 <p>(from <a href="https://www.markdownguide.org/extended-syntax/" rel="nofollow">https://www.markdownguide.org/extended-syntax/</a>)</p>
 
-<h3 id="definition-list">Definition list</h3>
+<h3 id="user-content-definition-list">Definition list</h3>
 
 <dl>
 <dt>First Term</dt>
@@ -163,18 +163,18 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 <dd>This is another definition of the second term.</dd>
 </dl>
 
-<h3 id="footnotes">Footnotes</h3>
+<h3 id="user-content-footnotes">Footnotes</h3>
 
-<p>Here is a simple footnote,<sup id="fnref:1"><a href="#fn:1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="fnref:bignote"><a href="#fn:bignote" rel="nofollow">2</a></sup></p>
+<p>Here is a simple footnote,<sup id="user-content-fnref:1"><a href="#fn:1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="user-content-fnref:bignote"><a href="#fn:bignote" rel="nofollow">2</a></sup></p>
 
 <div>
 
 <hr/>
 
 <ol>
-<li id="fn:1">This is the first footnote.</li>
+<li id="user-content-fn:1">This is the first footnote.</li>
 
-<li id="fn:bignote"><p>Here is one with multiple paragraphs and code.</p>
+<li id="user-content-fn:bignote"><p>Here is one with multiple paragraphs and code.</p>
 
 <p>Indent paragraphs to include them in the footnote.</p>
 

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -165,16 +165,16 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 
 <h3 id="user-content-footnotes">Footnotes</h3>
 
-<p>Here is a simple footnote,<sup id="user-content-fnref:1"><a href="#user-content-fn:1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="user-content-fnref:bignote"><a href="#user-content-fn:bignote" rel="nofollow">2</a></sup></p>
+<p>Here is a simple footnote,<sup id="fnref:user-content-1"><a href="#fn:user-content-1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="fnref:user-content-bignote"><a href="#fn:user-content-bignote" rel="nofollow">2</a></sup></p>
 
 <div>
 
 <hr/>
 
 <ol>
-<li id="user-content-fn:1">This is the first footnote.</li>
+<li id="fn:user-content-1">This is the first footnote.</li>
 
-<li id="user-content-fn:bignote"><p>Here is one with multiple paragraphs and code.</p>
+<li id="fn:user-content-bignote"><p>Here is one with multiple paragraphs and code.</p>
 
 <p>Indent paragraphs to include them in the footnote.</p>
 

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -165,7 +165,7 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 
 <h3 id="user-content-footnotes">Footnotes</h3>
 
-<p>Here is a simple footnote,<sup id="user-content-fnref:1"><a href="#fn:1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="user-content-fnref:bignote"><a href="#fn:bignote" rel="nofollow">2</a></sup></p>
+<p>Here is a simple footnote,<sup id="user-content-fnref:1"><a href="#user-content-fn:1" rel="nofollow">1</a></sup> and here is a longer one.<sup id="user-content-fnref:bignote"><a href="#user-content-fn:bignote" rel="nofollow">2</a></sup></p>
 
 <div>
 

--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -87,11 +87,11 @@ Here are some links to the most important topics. You can find the full list of 
 [[images/icon-bug.png]]
 `,
 		// rendered
-		`<h2 id="what-is-wine-staging">What is Wine Staging?</h2>
+		`<h2 id="user-content-what-is-wine-staging">What is Wine Staging?</h2>
 
 <p><strong>Wine Staging</strong> on website <a href="http://wine-staging.com" rel="nofollow">wine-staging.com</a>.</p>
 
-<h2 id="quick-links">Quick Links</h2>
+<h2 id="user-content-quick-links">Quick Links</h2>
 
 <p>Here are some links to the most important topics. You can find the full list of pages at the sidebar.</p>
 

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2472,21 +2472,10 @@ $(document).ready(() => {
 
   // Set anchor.
   $('.markdown').each(function () {
-    const headers = {};
     $(this).find('h1, h2, h3, h4, h5, h6').each(function () {
       let node = $(this);
-      const val = encodeURIComponent(node.text().toLowerCase().replace(/[^\u00C0-\u1FFF\u2C00-\uD7FF\w\- ]/g, '').replace(/[ ]/g, '-'));
-      let name = val;
-      if (headers[val] > 0) {
-        name = `${val}-${headers[val]}`;
-      }
-      if (headers[val] === undefined) {
-        headers[val] = 1;
-      } else {
-        headers[val] += 1;
-      }
-      node = node.wrap(`<div id="${name}" class="anchor-wrap" ></div>`);
-      node.append(`<a class="anchor" href="#${name}"><span class="octicon octicon-link"></span></a>`);
+      node = node.wrap('<div class="anchor-wrap"></div>');
+      node.append(`<a class="anchor" href="#${node.attr('id')}"><span class="octicon octicon-link"></span></a>`);
     });
   });
 

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2475,7 +2475,7 @@ $(document).ready(() => {
     $(this).find('h1, h2, h3, h4, h5, h6').each(function () {
       let node = $(this);
       node = node.wrap('<div class="anchor-wrap"></div>');
-      node.append(`<a class="anchor" href="#${node.attr('id')}"><span class="octicon octicon-link"></span></a>`);
+      node.append(`<a class="anchor" href="#${encodeURIComponent(node.attr('id'))}"><span class="octicon octicon-link"></span></a>`);
     });
   });
 


### PR DESCRIPTION
Resolves #9467 

One thing to note with this PR, it **does not** fix the headers getting anchored, but that is for another PR. The JS changes are simply to avoid a conflicting ID.  
We no longer need to keep track of an arbitrary index because blackfriday already does so. We just need to copy the auto-generated ID for our anchor's `href`

This PR prefixes any marked up elements with a user-defined ID (including the auto-generated IDs from blackfriday) with `user-content-` in order to avoid clashing with (most) other IDs.