### PR TITLE
Backport to 1.10: issue with paging in /repos/{owner}/{repo}/git/trees/{sha} api

### DIFF
--- a/modules/repofiles/tree.go
+++ b/modules/repofiles/tree.go
@@ -79,11 +79,11 @@ func GetTreeBySHA(repo *models.Repository, sha string, page, perPage int, recurs
 	for e := rangeStart; e < rangeEnd; e++ {
 		i := e - rangeStart
 
-		tree.Entries[e].Path = entries[e].Name()
-		tree.Entries[e].Mode = fmt.Sprintf("%06o", entries[e].Mode())
-		tree.Entries[e].Type = entries[e].Type()
-		tree.Entries[e].Size = entries[e].Size()
-		tree.Entries[e].SHA = entries[e].ID.String()
+		tree.Entries[i].Path = entries[e].Name()
+		tree.Entries[i].Mode = fmt.Sprintf("%06o", entries[e].Mode())
+		tree.Entries[i].Type = entries[e].Type()
+		tree.Entries[i].Size = entries[e].Size()
+		tree.Entries[i].SHA = entries[e].ID.String()
 
 		if entries[e].IsDir() {
 			copy(treeURL[copyPos:], entries[e].ID.String())


### PR DESCRIPTION
Backport of #9459 to 1.10: Fixed issue with paging in /repos/{owner}/{repo}/git/trees/{sha} api. Basically, any page requested other than page 1 (where items should be returned) would fail with an index out of range error (user gets http 500) because the wrong var was being used to build the return list. Hopefully I did this right, this is the first PR I've submitted for a backport.