### PR TITLE
Add call to load repo prior to redirect in add/remove dependency code

### DIFF
--- a/routers/repo/issue_dependency.go
+++ b/routers/repo/issue_dependency.go
@@ -29,6 +29,11 @@ func AddDependency(ctx *context.Context) {
 		return
 	}
 
+	if err = issue.LoadRepo(); err != nil {
+		ctx.ServerError("LoadRepo", err)
+		return
+	}
+
 	// Redirect
 	defer ctx.Redirect(issue.HTMLURL(), http.StatusSeeOther)
 
@@ -80,6 +85,11 @@ func RemoveDependency(ctx *context.Context) {
 	issue, err := models.GetIssueByIndex(ctx.Repo.Repository.ID, issueIndex)
 	if err != nil {
 		ctx.ServerError("GetIssueByIndex", err)
+		return
+	}
+
+	if err = issue.LoadRepo(); err != nil {
+		ctx.ServerError("LoadRepo", err)
 		return
 	}
 


### PR DESCRIPTION
The redirect call in the code to add or remove a dependency is failing on the call to issue.HTMLURL(). I added calls to first load the repo. 

Ref issue: #9483 