### PR TITLE
Fix datarace on repo indexer queue

### DIFF
--- a/modules/indexer/code/indexer.go
+++ b/modules/indexer/code/indexer.go
@@ -38,6 +38,8 @@ func Init() {
 		return
 	}
 
+	initQueue(setting.Indexer.UpdateQueueLength)
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	graceful.GetManager().RunAtTerminate(ctx, func() {

--- a/modules/indexer/code/queue.go
+++ b/modules/indexer/code/queue.go
@@ -21,8 +21,11 @@ type repoIndexerOperation struct {
 
 var repoIndexerOperationQueue chan repoIndexerOperation
 
+func initQueue(queueLength int) {
+	repoIndexerOperationQueue = make(chan repoIndexerOperation, queueLength)
+}
+
 func processRepoIndexerOperationQueue(indexer Indexer) {
-	repoIndexerOperationQueue = make(chan repoIndexerOperation, setting.Indexer.UpdateQueueLength)
 	for {
 		select {
 		case op := <-repoIndexerOperationQueue:


### PR DESCRIPTION
https://drone.gitea.io/go-gitea/gitea/17976/1/12

```
WARNING: DATA RACE
Read at 0x0000039df870 by goroutine 126:
  code.gitea.io/gitea/modules/indexer/code.populateRepoIndexer()
      /go/src/code.gitea.io/gitea/modules/indexer/code/queue.go:123 +0x397

Previous write at 0x0000039df870 by goroutine 41:
  code.gitea.io/gitea/modules/indexer/code.processRepoIndexerOperationQueue()
      /go/src/code.gitea.io/gitea/modules/indexer/code/queue.go:25 +0x8b

Goroutine 126 (running) created at:
  code.gitea.io/gitea/modules/indexer/code.Init.func2()
      /go/src/code.gitea.io/gitea/modules/indexer/code/indexer.go:68 +0x67b

Goroutine 41 (running) created at:
  code.gitea.io/gitea/modules/indexer/code.Init.func2()
      /go/src/code.gitea.io/gitea/modules/indexer/code/indexer.go:65 +0x4d1
```