### PR TITLE
Add debug option to serv to help debug problems

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -65,7 +65,7 @@ Gitea or set your environment appropriately.`, "")
 		}
 	}
 
-	setup("hooks/pre-receive.log")
+	setup("hooks/pre-receive.log", false)
 
 	// the environment setted on serv command
 	isWiki := (os.Getenv(models.EnvRepoIsWiki) == "true")
@@ -131,7 +131,7 @@ Gitea or set your environment appropriately.`, "")
 		}
 	}
 
-	setup("hooks/update.log")
+	setup("hooks/update.log", false)
 
 	return nil
 }
@@ -147,7 +147,7 @@ Gitea or set your environment appropriately.`, "")
 		}
 	}
 
-	setup("hooks/post-receive.log")
+	setup("hooks/post-receive.log", false)
 
 	// the environment setted on serv command
 	repoUser := os.Getenv(models.EnvRepoUsername)

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -62,7 +62,7 @@ func runKeys(c *cli.Context) error {
 		return errors.New("No key type and content provided")
 	}
 
-	setup("keys.log")
+	setup("keys.log", false)
 
 	authorizedString, err := private.AuthorizedPublicKeyByContent(content)
 	if err != nil {

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -43,7 +43,7 @@ var CmdServ = cli.Command{
 		},
 		cli.BoolFlag{
 			Name: "debug",
-		}
+		},
 	},
 }
 

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -41,12 +41,20 @@ var CmdServ = cli.Command{
 		cli.BoolFlag{
 			Name: "enable-pprof",
 		},
+		cli.BoolFlag{
+			Name: "debug",
+		}
 	},
 }
 
-func setup(logPath string) {
-	_ = log.DelLogger("console")
+func setup(logPath string, debug bool) {
+	if !debug {
+		_ = log.DelLogger("console")
+	}
 	setting.NewContext()
+	if debug {
+		setting.ProdMode = false
+	}
 }
 
 func parseCmd(cmd string) (string, string) {
@@ -80,7 +88,7 @@ func fail(userMessage, logMessage string, args ...interface{}) {
 
 func runServ(c *cli.Context) error {
 	// FIXME: This needs to internationalised
-	setup("serv.log")
+	setup("serv.log", c.Bool("debug"))
 
 	if setting.SSH.Disabled {
 		println("Gitea: SSH has been disabled")


### PR DESCRIPTION
Trying to discover why gitea serv might be crashing during setting initialisation is very difficult as the logs are switched off. 

This PR adds a debug option to prevent the deletion of the default logger.