### PR TITLE
[API] add comments endpoint for single comment

### DIFF
--- a/integrations/api_comment_test.go
+++ b/integrations/api_comment_test.go
@@ -83,6 +83,33 @@ func TestAPICreateComment(t *testing.T) {
 	models.AssertExistsAndLoadBean(t, &models.Comment{ID: updatedComment.ID, IssueID: issue.ID, Content: commentBody})
 }
 
+func TestAPIGetComment(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	comment := models.AssertExistsAndLoadBean(t, &models.Comment{ID: 2}).(*models.Comment)
+	assert.NoError(t, comment.LoadIssue())
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: comment.Issue.RepoID}).(*models.Repository)
+	repoOwner := models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	session := loginUser(t, repoOwner.Name)
+	token := getTokenForLoggedInUser(t, session)
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/comments/%d", repoOwner.Name, repo.Name, comment.ID)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	req = NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/comments/%d?token=%s", repoOwner.Name, repo.Name, comment.ID, token)
+	resp = session.MakeRequest(t, req, http.StatusOK)
+
+	var apiComment api.Comment
+	DecodeJSON(t, resp, &apiComment)
+
+	assert.NoError(t, comment.LoadPoster())
+	expect := comment.APIFormat()
+
+	assert.Equal(t, expect.ID, apiComment.ID)
+	assert.Equal(t, expect.Poster.FullName, apiComment.Poster.FullName)
+	assert.Equal(t, expect.Body, apiComment.Body)
+	assert.Equal(t, expect.Created.Unix(), apiComment.Created.Unix())
+}
+
 func TestAPIEditComment(t *testing.T) {
 	defer prepareTestEnv(t)()
 	const newCommentBody = "This is the new comment body"

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -661,9 +661,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 					m.Group("/comments", func() {
 						m.Get("", repo.ListRepoIssueComments)
 						m.Group("/:id", func() {
-							m.Combo("", reqToken()).
-								Patch(mustNotBeArchived, bind(api.EditIssueCommentOption{}), repo.EditIssueComment).
-								Delete(repo.DeleteIssueComment)
+							m.Combo("").
+								Get(repo.GetIssueComment).
+								Patch(mustNotBeArchived, reqToken(), bind(api.EditIssueCommentOption{}), repo.EditIssueComment).
+								Delete(reqToken(), repo.DeleteIssueComment)
 							m.Combo("/reactions").
 								Get(repo.GetIssueCommentReactions).
 								Post(bind(api.EditReactionOption{}), reqToken(), repo.PostIssueCommentReaction).

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -250,6 +250,15 @@ func GetIssueComment(ctx *context.APIContext) {
 		return
 	}
 
+	if err = comment.LoadIssue(); err != nil {
+		ctx.InternalServerError(err)
+		return
+	}
+	if comment.Issue.RepoID != ctx.Repo.Repository.ID {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
 	if comment.Type != models.CommentTypeComment {
 		ctx.Status(http.StatusNoContent)
 		return

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -204,6 +204,65 @@ func CreateIssueComment(ctx *context.APIContext, form api.CreateIssueCommentOpti
 	ctx.JSON(http.StatusCreated, comment.APIFormat())
 }
 
+// GetIssueComment Get a comment by ID
+func GetIssueComment(ctx *context.APIContext) {
+	// swagger:operation GET /repos/{owner}/{repo}/issues/comments/{id} issue issueGetComment
+	// ---
+	// summary: Get a comment
+	// consumes:
+	// - application/json
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: id
+	//   in: path
+	//   description: id of the comment
+	//   type: integer
+	//   format: int64
+	//   required: true
+	// responses:
+	//   "200":
+	//     "$ref": "#/responses/Comment"
+	//   "204":
+	//     "$ref": "#/responses/empty"
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
+
+	comment, err := models.GetCommentByID(ctx.ParamsInt64(":id"))
+	if err != nil {
+		if models.IsErrCommentNotExist(err) {
+			ctx.NotFound(err)
+		} else {
+			ctx.Error(http.StatusInternalServerError, "GetCommentByID", err)
+		}
+		return
+	}
+
+	if comment.Type != models.CommentTypeComment {
+		ctx.Status(http.StatusNoContent)
+		return
+	}
+
+	if err := comment.LoadPoster(); err != nil {
+		ctx.Error(http.StatusInternalServerError, "comment.LoadPoster", err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, comment.APIFormat())
+}
+
 // EditIssueComment modify a comment of an issue
 func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) {
 	// swagger:operation PATCH /repos/{owner}/{repo}/issues/comments/{id} issue issueEditComment
@@ -237,6 +296,13 @@ func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) 
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/Comment"
+	//   "204":
+	//     "$ref": "#/responses/empty"
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
+
 	editIssueComment(ctx, form)
 }
 
@@ -283,6 +349,8 @@ func EditIssueCommentDeprecated(ctx *context.APIContext, form api.EditIssueComme
 	//     "$ref": "#/responses/empty"
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
 
 	editIssueComment(ctx, form)
 }
@@ -343,6 +411,8 @@ func DeleteIssueComment(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
 
 	deleteIssueComment(ctx)
 }
@@ -380,6 +450,8 @@ func DeleteIssueCommentDeprecated(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
 
 	deleteIssueComment(ctx)
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3002,6 +3002,57 @@
       }
     },
     "/repos/{owner}/{repo}/issues/comments/{id}": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "issue"
+        ],
+        "summary": "Get a comment",
+        "operationId": "issueGetComment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "id of the comment",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Comment"
+          },
+          "204": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
       "delete": {
         "tags": [
           "issue"
@@ -3038,6 +3089,9 @@
           },
           "403": {
             "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       },
@@ -3087,6 +3141,15 @@
         "responses": {
           "200": {
             "$ref": "#/responses/Comment"
+          },
+          "204": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       }
@@ -3491,6 +3554,9 @@
           },
           "403": {
             "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       },
@@ -3554,6 +3620,9 @@
           },
           "403": {
             "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       }


### PR DESCRIPTION
close #9486
usefull at #4811 (#9488)

add `GET /repos/{owner}/{repo}/issues/comments/{id}`

GitHub reference spec: [link](https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment)