### PR TITLE
When recreating hooks, delete them first so they are recreated with the umask

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -967,6 +967,7 @@ func CreateDelegateHooks(repoPath string) error {
 
 // createDelegateHooks creates all the hooks scripts for the repo
 func createDelegateHooks(repoPath string) (err error) {
+
 	var (
 		hookNames = []string{"pre-receive", "update", "post-receive"}
 		hookTpls  = []string{
@@ -992,10 +993,16 @@ func createDelegateHooks(repoPath string) (err error) {
 		}
 
 		// WARNING: This will override all old server-side hooks
+		if err = os.Remove(oldHookPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("unable to pre-remove old hook file '%s' prior to rewriting: %v ", oldHookPath, err)
+		}
 		if err = ioutil.WriteFile(oldHookPath, []byte(hookTpls[i]), 0777); err != nil {
 			return fmt.Errorf("write old hook file '%s': %v", oldHookPath, err)
 		}
 
+		if err = os.Remove(newHookPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("unable to pre-remove new hook file '%s' prior to rewriting: %v", newHookPath, err)
+		}
 		if err = ioutil.WriteFile(newHookPath, []byte(giteaHookTpls[i]), 0777); err != nil {
 			return fmt.Errorf("write new hook file '%s': %v", newHookPath, err)
 		}


### PR DESCRIPTION
ioutil.WriteFile will not change the permissions of an existing file - so if somehow the hooks have lost their executable flag this will not be restored by createDelegateHooks.

If we delete them before rewriting them then these should be recreated with the current umask. Thus fixing #9091 - however, it's worth noting that if the user has a very restrictive umask that prevents default creation with executable bit then the file will still be created without the executable bit and we would require additional settings to set the default mode (which could be set to 0755).

Fix #9091