### PR TITLE
Fix SetExpr failed

### DIFF
--- a/models/update.go
+++ b/models/update.go
@@ -103,10 +103,10 @@ func pushUpdateDeleteTags(e Engine, repo *Repository, tags []string) error {
 	if _, err := e.
 		Where("repo_id = ? AND is_tag = ?", repo.ID, false).
 		In("lower_tag_name", lowerTags).
-		SetExpr("is_draft", true).
-		SetExpr("num_commits", 0).
-		SetExpr("sha1", "").
-		Update(new(Release)); err != nil {
+		Cols("is_draft", "num_commits", "sha1").
+		Update(&Release{
+			IsDraft: true,
+		}); err != nil {
 		return fmt.Errorf("Update: %v", err)
 	}
 


### PR DESCRIPTION
Currently, xorm only support 
```go
SetExpr("is_draft", "true").
SetExpr("num_commits", "0").
SetExpr("sha1", "''")
```
but not
```go
SetExpr("is_draft", true).
SetExpr("num_commits", 0).
SetExpr("sha1", "")
```