### PR TITLE
Stop various tests from adding to the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,6 @@ coverage.all
 /integrations/pgsql.ini
 /integrations/mssql.ini
 /node_modules
-/modules/indexer/issues/indexers
-routers/repo/authorized_keys
 /yarn.lock
 /public/js
 /public/css

--- a/modules/indexer/issues/bleve.go
+++ b/modules/indexer/issues/bleve.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 
+	"code.gitea.io/gitea/modules/log"
 	"github.com/blevesearch/bleve"
 	"github.com/blevesearch/bleve/analysis/analyzer/custom"
 	"github.com/blevesearch/bleve/analysis/token/lowercase"
@@ -182,6 +183,15 @@ func (b *BleveIndexer) Init() (bool, error) {
 
 	b.indexer, err = createIssueIndexer(b.indexDir, issueIndexerLatestVersion)
 	return false, err
+}
+
+// Close will close the bleve indexer
+func (b *BleveIndexer) Close() {
+	if b.indexer != nil {
+		if err := b.indexer.Close(); err != nil {
+			log.Error("Error whilst closing indexer: %v", err)
+		}
+	}
 }
 
 // Index will save the index data

--- a/modules/indexer/issues/bleve_test.go
+++ b/modules/indexer/issues/bleve_test.go
@@ -5,6 +5,7 @@
 package issues
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -12,12 +13,20 @@ import (
 )
 
 func TestBleveIndexAndSearch(t *testing.T) {
-	dir := "./bleve.index"
-	indexer := NewBleveIndexer(dir)
-	defer os.RemoveAll(dir)
-
-	_, err := indexer.Init()
+	dir, err := ioutil.TempDir("", "bleve.index")
 	assert.NoError(t, err)
+	if err != nil {
+		assert.Fail(t, "Unable to create temporary directory")
+		return
+	}
+	defer os.RemoveAll(dir)
+	indexer := NewBleveIndexer(dir)
+	defer indexer.Close()
+
+	if _, err := indexer.Init(); err != nil {
+		assert.Fail(t, "Unable to initialise bleve indexer: %v", err)
+		return
+	}
 
 	err = indexer.Index([]*IndexerData{
 		{


### PR DESCRIPTION
Instead of just adding test generated files to .gitignore. We should prevent them from being produced in the first place.

No test should ever write to the source code tree!

Fixes #9517