### PR TITLE
[Fix] AllowedReaction code

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -81,6 +81,9 @@ func NewFuncMap() []template.FuncMap {
 		"LoadTimes": func(startTime time.Time) string {
 			return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"
 		},
+		"AllowedReactions": func() []string {
+			return setting.UI.Reactions
+		},
 		"AvatarLink":    base.AvatarLink,
 		"Safe":          Safe,
 		"SafeJS":        SafeJS,

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -705,7 +705,6 @@ func ViewIssue(ctx *context.Context) {
 		}
 	}
 	ctx.Data["IssueWatch"] = iw
-	ctx.Data["AllowedReactions"] = setting.UI.Reactions
 
 	issue.RenderedContent = string(markdown.Render([]byte(issue.Content), ctx.Repo.RepoLink,
 		ctx.Repo.Repository.ComposeMetas()))

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -423,7 +423,6 @@ func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.Compare
 
 	ctx.Data["NumCommits"] = compareInfo.Commits.Len()
 	ctx.Data["NumFiles"] = compareInfo.NumFiles
-	ctx.Data["AllowedReactions"] = setting.UI.Reactions
 	return compareInfo
 }
 

--- a/templates/repo/diff/comments.tmpl
+++ b/templates/repo/diff/comments.tmpl
@@ -38,7 +38,7 @@
 		{{$reactions := .Reactions.GroupByType}}
 		{{if $reactions}}
 			<div class="ui attached segment reactions">
-			{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.root.RepoLink .ID) "Reactions" $reactions "AllowedReactions" $.AllowedReactions }}
+			{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.root.RepoLink .ID) "Reactions" $reactions}}
 			</div>
 		{{end}}
 	</div>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -28,7 +28,7 @@
 					{{end}}
 						{{if not $.Repository.IsArchived}}
 							<div class="ui right actions">
-								{{template "repo/issue/view_content/add_reaction" Dict "ctx" $ "ActionURL" (Printf "%s/issues/%d/reactions" $.RepoLink .Issue.Index) "AllowedReactions" $.AllowedReactions}}
+								{{template "repo/issue/view_content/add_reaction" Dict "ctx" $ "ActionURL" (Printf "%s/issues/%d/reactions" $.RepoLink .Issue.Index)}}
 								{{template "repo/issue/view_content/context_menu" Dict "ctx" $ "item" .Issue "delete" false "diff" false }}
 							</div>
 						{{end}}
@@ -47,7 +47,7 @@
 					{{$reactions := .Issue.Reactions.GroupByType}}
 					{{if $reactions}}
 						<div class="ui attached segment reactions">
-							{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/issues/%d/reactions" $.RepoLink .Issue.Index) "Reactions" $reactions "AllowedReactions" $.AllowedReactions}}
+							{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/issues/%d/reactions" $.RepoLink .Issue.Index) "Reactions" $reactions}}
 						</div>
 					{{end}}
 					{{if .Issue.Attachments}}

--- a/templates/repo/issue/view_content/add_reaction.tmpl
+++ b/templates/repo/issue/view_content/add_reaction.tmpl
@@ -7,7 +7,7 @@
 	<div class="menu has-emoji">
 		<div class="header">{{ .ctx.i18n.Tr "repo.pick_reaction"}}</div>
 		<div class="divider"></div>
-		{{range $value := .AllowedReactions}}
+		{{range $value := AllowedReactions}}
 			{{if eq $value "hooray"}}
 				<div class="item" data-content="hooray">:tada:</div>
 			{{else if eq $value "laugh"}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -36,7 +36,7 @@
 									{{end}}
 								</div>
 							{{end}}
-							{{template "repo/issue/view_content/add_reaction" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.RepoLink .ID) "AllowedReactions" $.AllowedReactions}}
+							{{template "repo/issue/view_content/add_reaction" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.RepoLink .ID)}}
 							{{template "repo/issue/view_content/context_menu" Dict "ctx" $ "item" . "delete" true "diff" false }}
 						</div>
 					{{end}}
@@ -55,7 +55,7 @@
 				{{$reactions := .Reactions.GroupByType}}
 				{{if $reactions}}
 					<div class="ui attached segment reactions">
-						{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.RepoLink .ID) "Reactions" $reactions "AllowedReactions" $.AllowedReactions}}
+						{{template "repo/issue/view_content/reactions" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.RepoLink .ID) "Reactions" $reactions}}
 					</div>
 				{{end}}
 				{{if .Attachments}}

--- a/templates/repo/issue/view_content/reactions.tmpl
+++ b/templates/repo/issue/view_content/reactions.tmpl
@@ -10,6 +10,6 @@
 		{{len $value}}
 	</a>
 {{end}}
-{{if $.AllowedReactions}}
-	{{template "repo/issue/view_content/add_reaction" Dict "ctx" $.ctx "ActionURL" .ActionURL "AllowedReactions" $.AllowedReactions}}
+{{if AllowedReactions}}
+	{{template "repo/issue/view_content/add_reaction" Dict "ctx" $.ctx "ActionURL" .ActionURL}}
 {{end}}


### PR DESCRIPTION
fix/optimize code from #8886

before: AllowedReaction was piped throu multible templates in the worst case
now: just exec func AllowedReaction

## Fix:
if you change reactions you are not able anymore to add it by this UI element:
![Bildschirmfoto zu 2019-12-27 18-38-15](https://user-images.githubusercontent.com/24977596/71526647-2363a000-28d8-11ea-9482-7d78eb1b94a0.png)
