### PR TITLE
Ignore empty avatars in v115.go

### DIFF
--- a/models/migrations/v115.go
+++ b/models/migrations/v115.go
@@ -47,7 +47,10 @@ func renameExistingUserAvatarName(x *xorm.Engine) error {
 		for _, user := range users {
 			oldAvatar := user.Avatar
 
-			if _, err := os.Stat(filepath.Join(setting.AvatarUploadPath, oldAvatar)); err != nil {
+			if stat, err := os.Stat(filepath.Join(setting.AvatarUploadPath, oldAvatar)); err != nil || !stat.Mode().IsRegular() {
+				if stat != nil && stat.IsDir() {
+					err = fmt.Errorf("Error: \"%s\" is not a regular file", oldAvatar)
+				}
 				log.Warn("[user: %s] os.Stat: %v", user.LowerName, err)
 				// avatar doesn't exist in the storage
 				// no need to move avatar and update database

--- a/models/migrations/v115.go
+++ b/models/migrations/v115.go
@@ -48,7 +48,7 @@ func renameExistingUserAvatarName(x *xorm.Engine) error {
 			oldAvatar := user.Avatar
 
 			if stat, err := os.Stat(filepath.Join(setting.AvatarUploadPath, oldAvatar)); err != nil || !stat.Mode().IsRegular() {
-				if stat != nil && stat.IsDir() {
+				if err == nil {
 					err = fmt.Errorf("Error: \"%s\" is not a regular file", oldAvatar)
 				}
 				log.Warn("[user: %s] os.Stat: %v", user.LowerName, err)


### PR DESCRIPTION
Ignore empty avatars or avatars that do not match a regular file in v115 migration.