### PR TITLE
Resolve deprecated INI conversion

### DIFF
--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -104,7 +104,7 @@ func runEnvironmentToIni(c *cli.Context) error {
 	} else {
 		log.Warn("Custom config '%s' not found, ignore this if you're running first time", setting.CustomConf)
 	}
-	cfg.NameMapper = ini.AllCapsUnderscore
+	cfg.NameMapper = ini.SnackCase
 
 	prefix := c.String("prefix") + "__"
 


### PR DESCRIPTION
Per https://github.com/go-ini/ini/blob/8fe474341f7eedd6804eda75896c8f3e4b5dc36a/deprecated.go#L24 SnackCase is the correct replacement.

CI Fails otherwise
```
make golangci-lint 84golangci/golangci-lint info checking GitHub for tag 'v1.20.0'
golangci/golangci-lint info found version: 1.20.0 for v1.20.0/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
golangci-lint run --timeout 5m
contrib/environment-to-ini/environment-to-ini.go:107:19: SA1019: ini.AllCapsUnderscore is deprecated: AllCapsUnderscore converts to format ALL_CAPS_UNDERSCORE. (staticcheck)
    cfg.NameMapper = ini.AllCapsUnderscore
```