### PR TITLE
[Fix] Release attachment should use DownloadURL() not Name

### DIFF
--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -426,7 +426,7 @@ func RedirectDownload(ctx *context.Context) {
 			return
 		}
 		if att != nil {
-			ctx.Redirect(setting.AppSubURL + "/attachments/" + att.UUID)
+			ctx.Redirect(att.DownloadURL())
 			return
 		}
 	}

--- a/templates/repo/issue/view_content/attachments.tmpl
+++ b/templates/repo/issue/view_content/attachments.tmpl
@@ -1,7 +1,7 @@
 {{range .Attachments}}
-  <a target="_blank" rel="noopener noreferrer" href="{{AppSubUrl}}/attachments/{{.UUID}}">
+  <a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}">
     {{if FilenameIsImage .Name}}
-      <img class="ui image" src="{{AppSubUrl}}/attachments/{{.UUID}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
+      <img class="ui image" src="{{.DownloadURL}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
     {{else}}
       <span class="ui image octicon octicon-desktop-download" title='{{$.ctx.i18n.Tr "repo.issues.attachment.download" .Name}}'></span>
     {{end}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -82,11 +82,11 @@
 									</li>
 									{{end}}
 									{{if .Attachments}}
-										{{range $attachment := .Attachments}}
+										{{range .Attachments}}
 										<li>
-											<a target="_blank" rel="noopener noreferrer" href="{{$attachment.DownloadURL}}">
-												<strong><span class="ui image octicon octicon-package" title='{{$attachment.Name}}'></span> {{$attachment.Name}}</strong>
-												<span class="ui text grey right">{{$attachment.Size | FileSize}}</span>
+											<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}">
+												<strong><span class="ui image octicon octicon-package" title='{{.Name}}'></span> {{.Name}}</strong>
+												<span class="ui text grey right">{{.Size | FileSize}}</span>
 											</a>
 										</li>
 										{{end}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -84,7 +84,7 @@
 									{{if .Attachments}}
 										{{range $attachment := .Attachments}}
 										<li>
-											<a target="_blank" rel="noopener noreferrer" href="{{$.RepoLink}}/releases/download/{{$release.TagName | PathEscape}}/{{$attachment.Name | PathEscape}}">
+											<a target="_blank" rel="noopener noreferrer" href="{{$attachment.DownloadURL}}">
 												<strong><span class="ui image octicon octicon-package" title='{{$attachment.Name}}'></span> {{$attachment.Name}}</strong>
 												<span class="ui text grey right">{{$attachment.Size | FileSize}}</span>
 											</a>


### PR DESCRIPTION
**Problem: attachments with same name (only first uploaded is downloadable)**

* fix `templates/repo/release/list.tmpl `
* template refactor `templates/repo/issue/view_content/attachments.tmpl`
* code refactor `routers/repo/repo.go`