### PR TITLE
Fix backspace in SimpleMDE

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1490,7 +1490,9 @@ function setCommentSimpleMDE($editArea) {
       }
     },
     Backspace: (cm) => {
-      cm.getInputField().trigger('input');
+      if (cm.getInputField().trigger) {
+        cm.getInputField().trigger('input');
+      }
       cm.execCommand('delCharBefore');
     }
   });


### PR DESCRIPTION
The SimpleMDE backspace function refers to a trigger method of the textarea - which is not always present. This simple fix checks if the trigger is there before attempting to run it.

I'm not certain what is supposed to be being triggered here @blueworrybear do you have any more information?

Fix #9493 
