### PR TITLE
[UI] swagger UI: hide iretating search field

### DIFF
--- a/templates/swagger/ui.tmpl
+++ b/templates/swagger/ui.tmpl
@@ -85,13 +85,11 @@ window.onload = function() {
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
+          SwaggerUIBundle.presets.apis
         ],
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
-        ],
-        layout: "StandaloneLayout"
+        ]
       })
       // End Swagger UI call region
 


### PR DESCRIPTION
## remove this:
![Bildschirmfoto zu 2019-12-31 00-28-38](https://user-images.githubusercontent.com/24977596/71604782-a00aae80-2b64-11ea-8cb9-33ec3e6ab03e.png)

close #8184