### PR TITLE
Add blue box-shadow to blue buttons in normal theme

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1172,3 +1172,9 @@ i.icon.centerlock {
 .octicon-tiny {
     font-size: 0.85714286rem;
 }
+
+.ui.basic.blue.button,
+.ui.basic.blue.buttons .button {
+    box-shadow: inset 0 0 0 1px #1678c2 !important;
+    color: #1678c2 !important;
+}


### PR DESCRIPTION
Fix #9407

It was mentioned in the issue to use `border` instead of `box-shadow`, however semantic (fomantic) used box-shadow so I went with that. `arc-green` also uses `box-shadow`.  
This CSS more or less copies `arc-green` but with blue rather than green.  
The shade of blue matches the hover color, which is how it used to look afaik (or at the very least is how `arc-green` operates)

![Screenshot from 2019-12-31 21-01-59](https://user-images.githubusercontent.com/42128690/71637742-d30a7c00-2c10-11ea-8dc4-4ed85e0e5a2a.png)
