### PR TITLE
Don't auto-init SimpleMDE for review textarea

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -213,7 +213,7 @@
 											<a class="preview item" data-url="{{$.Repository.APIURL}}/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "preview"}}</a>
 									</div>
 									<div class="ui bottom attached active write tab segment">
-											<textarea tabindex="1" name="content"></textarea>
+											<textarea class="review-textarea" tabindex="1" name="content"></textarea>
 									</div>
 									<div class="ui bottom attached tab preview segment markdown">
 									{{$.i18n.Tr "loading"}}

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -325,7 +325,7 @@ function initCommentForm() {
     return;
   }
 
-  setCommentSimpleMDE($('.comment.form textarea'));
+  setCommentSimpleMDE($('.comment.form textarea:not(.review-textarea)'));
   initBranchSelector();
   initCommentPreviewTab($('.comment.form'));
   initImagePaste($('.comment.form textarea'));


### PR DESCRIPTION
Fix #9442 

Admittedly I am not very fond of this implementation, however I could not think of a way to do it without more involved refactoring.

In an effort to reuse JS, we auto-init some comment form textareas. However, the SimpleMDE changes were causing a double-init because the textarea is reused as a "template" to copy-paste in pull reviews, however SimpleMDE has a need to init it upon creation because of how it works as well as initializing the image paste (as far as I can tell, anyways)  

This PR simply skips the first "init" by using a `:not` in the jQuery selector.

If I am incorrect, I would be more than happy to make changes.

## References

HTML of "template" pull review edit comment
https://github.com/go-gitea/gitea/blob/7bdf17ec29851b857bf88d5e5f39436799732dd6/templates/repo/diff/box.tmpl#L209-L226

Auto-init of `.comment.form textarea`
https://github.com/go-gitea/gitea/blob/7bdf17ec29851b857bf88d5e5f39436799732dd6/web_src/js/index.js#L323-L328

Manual init when clicking `edit` on a pull review
https://github.com/go-gitea/gitea/blob/7bdf17ec29851b857bf88d5e5f39436799732dd6/web_src/js/index.js#L858-L861
https://github.com/go-gitea/gitea/blob/7bdf17ec29851b857bf88d5e5f39436799732dd6/web_src/js/index.js#L941-L944
