### PR TITLE
[API] add endpoint to check notifications [Extend #9488]

### DIFF
--- a/integrations/api_notification_test.go
+++ b/integrations/api_notification_test.go
@@ -83,7 +83,7 @@ func TestAPINotification(t *testing.T) {
 
 	// -- check notifications --
 	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications/new?token=%s", token))
-	resp = session.MakeRequest(t, req, http.StatusFound)
+	resp = session.MakeRequest(t, req, http.StatusOK)
 
 	// -- mark notifications as read --
 	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications?token=%s", token))

--- a/integrations/api_notification_test.go
+++ b/integrations/api_notification_test.go
@@ -81,6 +81,10 @@ func TestAPINotification(t *testing.T) {
 	assert.EqualValues(t, thread5.Issue.APIURL(), apiN.Subject.URL)
 	assert.EqualValues(t, thread5.Repository.HTMLURL(), apiN.Repository.HTMLURL)
 
+	// -- check notifications --
+	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications/new?token=%s", token))
+	resp = session.MakeRequest(t, req, http.StatusFound)
+
 	// -- mark notifications as read --
 	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications?token=%s", token))
 	resp = session.MakeRequest(t, req, http.StatusOK)
@@ -103,4 +107,8 @@ func TestAPINotification(t *testing.T) {
 	assert.Equal(t, models.NotificationStatusUnread, thread5.Status)
 	thread5 = models.AssertExistsAndLoadBean(t, &models.Notification{ID: 5}).(*models.Notification)
 	assert.Equal(t, models.NotificationStatusRead, thread5.Status)
+
+	// -- check notifications --
+	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications/new?token=%s", token))
+	resp = session.MakeRequest(t, req, http.StatusNoContent)
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -7,7 +7,6 @@ package models
 
 import (
 	"fmt"
-	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -324,7 +323,7 @@ func (issue *Issue) GetIsRead(userID int64) error {
 
 // APIURL returns the absolute APIURL to this issue.
 func (issue *Issue) APIURL() string {
-	return issue.Repo.APIURL() + "/" + path.Join("issues", fmt.Sprint(issue.Index))
+	return fmt.Sprintf("%s/issues/%d", issue.Repo.APIURL(), issue.Index)
 }
 
 // HTMLURL returns the absolute URL to this issue.

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -8,7 +8,6 @@ package models
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"code.gitea.io/gitea/modules/git"
@@ -249,7 +248,7 @@ func (c *Comment) APIURL() string {
 		return ""
 	}
 
-	return c.Issue.Repo.APIURL() + "/" + path.Join("issues/comments", fmt.Sprint(c.ID))
+	return fmt.Sprintf("%s/issues/comments/%d", c.Issue.Repo.APIURL(), c.ID)
 }
 
 // IssueURL formats a URL-string to the issue

--- a/models/notification.go
+++ b/models/notification.go
@@ -403,7 +403,7 @@ func (n *Notification) loadComment(e Engine) (err error) {
 	if n.Comment == nil && n.CommentID > 0 {
 		n.Comment, err = GetCommentByID(n.CommentID)
 		if err != nil {
-			return fmt.Errorf("GetCommentByID [%d]: %v", n.CommentID, err)
+			return fmt.Errorf("GetCommentByID [%d] for issue ID [%d]: %v", n.CommentID, n.IssueID, err)
 		}
 	}
 	return nil

--- a/models/notification.go
+++ b/models/notification.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -292,6 +293,20 @@ func notificationsForUser(e Engine, user *User, statuses []NotificationStatus, p
 
 	err = sess.Find(&notifications)
 	return
+}
+
+// UnreadAvailable check if unread notifications exist
+func UnreadAvailable(user *User) bool {
+	return unreadAvailable(x, user.ID)
+}
+
+func unreadAvailable(e Engine, userID int64) bool {
+	exist, err := e.Where("user_id = ?", userID).And("status = ?", NotificationStatusUnread).Get(new(Notification))
+	if err != nil {
+		log.Error("newsAvailable", err)
+		return false
+	}
+	return exist
 }
 
 // APIFormat converts a Notification to api.NotificationThread

--- a/models/notification.go
+++ b/models/notification.go
@@ -295,16 +295,16 @@ func notificationsForUser(e Engine, user *User, statuses []NotificationStatus, p
 	return
 }
 
-// UnreadAvailable check if unread notifications exist
-func UnreadAvailable(user *User) bool {
-	return unreadAvailable(x, user.ID)
+// CountUnread count unread notifications for a user
+func CountUnread(user *User) int64 {
+	return countUnread(x, user.ID)
 }
 
-func unreadAvailable(e Engine, userID int64) bool {
-	exist, err := e.Where("user_id = ?", userID).And("status = ?", NotificationStatusUnread).Get(new(Notification))
+func countUnread(e Engine, userID int64) int64 {
+	exist, err := e.Where("user_id = ?", userID).And("status = ?", NotificationStatusUnread).Count(new(Notification))
 	if err != nil {
-		log.Error("newsAvailable", err)
-		return false
+		log.Error("countUnread", err)
+		return 0
 	}
 	return exist
 }

--- a/modules/structs/notifications.go
+++ b/modules/structs/notifications.go
@@ -26,3 +26,8 @@ type NotificationSubject struct {
 	LatestCommentURL string `json:"latest_comment_url"`
 	Type             string `json:"type" binding:"In(Issue,Pull,Commit)"`
 }
+
+// NotificationCount number of unread notifications
+type NotificationCount struct {
+	New int64 `json:"new"`
+}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -518,6 +518,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Combo("").
 				Get(notify.ListNotifications).
 				Put(notify.ReadNotifications)
+			m.Get("/new", notify.NewAvailable)
 			m.Combo("/threads/:id").
 				Get(notify.GetThread).
 				Patch(notify.ReadThread)

--- a/routers/api/v1/notify/notifications.go
+++ b/routers/api/v1/notify/notifications.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"net/http"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/context"
+)
+
+// NewAvailable check if unread notifications exist
+func NewAvailable(ctx *context.APIContext) {
+	// swagger:operation GET /notifications/new notification notifyNewAvailable
+	// ---
+	// summary: Check if unread notifications exist
+	// responses:
+	//   "204":
+	//     description: No unread notification
+	//   "302":
+	//     description: Unread notification found
+
+	if models.UnreadAvailable(ctx.User) {
+		ctx.Status(http.StatusFound)
+	} else {
+		ctx.Status(http.StatusNoContent)
+	}
+}

--- a/routers/api/v1/notify/notifications.go
+++ b/routers/api/v1/notify/notifications.go
@@ -9,6 +9,7 @@ import (
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
+	api "code.gitea.io/gitea/modules/structs"
 )
 
 // NewAvailable check if unread notifications exist
@@ -20,10 +21,12 @@ func NewAvailable(ctx *context.APIContext) {
 	//   "204":
 	//     description: No unread notification
 	//   "302":
-	//     description: Unread notification found
+	//    "$ref": "#/responses/NotificationCount"
 
-	if models.UnreadAvailable(ctx.User) {
-		ctx.Status(http.StatusFound)
+	count := models.CountUnread(ctx.User)
+
+	if count > 0 {
+		ctx.JSON(http.StatusFound, api.NotificationCount{New: count})
 	} else {
 		ctx.Status(http.StatusNoContent)
 	}

--- a/routers/api/v1/notify/notifications.go
+++ b/routers/api/v1/notify/notifications.go
@@ -18,15 +18,15 @@ func NewAvailable(ctx *context.APIContext) {
 	// ---
 	// summary: Check if unread notifications exist
 	// responses:
+	//   "200":
+	//    "$ref": "#/responses/NotificationCount"
 	//   "204":
 	//     description: No unread notification
-	//   "302":
-	//    "$ref": "#/responses/NotificationCount"
 
 	count := models.CountUnread(ctx.User)
 
 	if count > 0 {
-		ctx.JSON(http.StatusFound, api.NotificationCount{New: count})
+		ctx.JSON(http.StatusOK, api.NotificationCount{New: count})
 	} else {
 		ctx.Status(http.StatusNoContent)
 	}

--- a/routers/api/v1/swagger/notify.go
+++ b/routers/api/v1/swagger/notify.go
@@ -21,3 +21,10 @@ type swaggerNotificationThreadList struct {
 	// in:body
 	Body []api.NotificationThread `json:"body"`
 }
+
+// Number of unread notifications
+// swagger:response NotificationCount
+type swaggerNotificationCount struct {
+	// in:body
+	Body api.NotificationCount `json:"body"`
+}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -502,11 +502,11 @@
         "summary": "Check if unread notifications exist",
         "operationId": "notifyNewAvailable",
         "responses": {
+          "200": {
+            "$ref": "#/responses/NotificationCount"
+          },
           "204": {
             "description": "No unread notification"
-          },
-          "302": {
-            "$ref": "#/responses/NotificationCount"
           }
         }
       }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -494,6 +494,23 @@
         }
       }
     },
+    "/notifications/new": {
+      "get": {
+        "tags": [
+          "notification"
+        ],
+        "summary": "Check if unread notifications exist",
+        "operationId": "notifyNewAvailable",
+        "responses": {
+          "204": {
+            "description": "No unread notification"
+          },
+          "302": {
+            "description": "Unread notification found"
+          }
+        }
+      }
+    },
     "/notifications/threads/{id}": {
       "get": {
         "consumes": [

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -506,7 +506,7 @@
             "description": "No unread notification"
           },
           "302": {
-            "description": "Unread notification found"
+            "$ref": "#/responses/NotificationCount"
           }
         }
       }
@@ -10928,6 +10928,18 @@
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
+    "NotificationCount": {
+      "description": "NotificationCount number of unread notifications",
+      "type": "object",
+      "properties": {
+        "new": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "New"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
     "NotificationSubject": {
       "description": "NotificationSubject contains the notification subject (Issue/Pull/Commit)",
       "type": "object",
@@ -12412,6 +12424,12 @@
         "items": {
           "$ref": "#/definitions/Milestone"
         }
+      }
+    },
+    "NotificationCount": {
+      "description": "Number of unread notifications",
+      "schema": {
+        "$ref": "#/definitions/NotificationCount"
       }
     },
     "NotificationThread": {


### PR DESCRIPTION
# extend #9488

an endpoint wich e.g. mobile clients can use to check if news are available (use less bandwith than any other notification endpoint ...)

-> `GET /notifications/new`
* status 200 (OK) -> Notifications Available
* status 204 (No Content) -> News Notifications