### PR TITLE
Some more e-mail notification fixes

### DIFF
--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -53,6 +53,7 @@ func (m *mailNotifier) NotifyNewIssue(issue *models.Issue) {
 
 func (m *mailNotifier) NotifyIssueChangeStatus(doer *models.User, issue *models.Issue, actionComment *models.Comment, isClosed bool) {
 	var actionType models.ActionType
+	issue.Content = ""
 	if issue.IsPull {
 		if isClosed {
 			actionType = models.ActionClosePullRequest
@@ -105,7 +106,7 @@ func (m *mailNotifier) NotifyMergePullRequest(pr *models.PullRequest, doer *mode
 		log.Error("pr.LoadIssue: %v", err)
 		return
 	}
-
+	pr.Issue.Content = ""
 	if err := mailer.MailParticipants(pr.Issue, doer, models.ActionMergePullRequest); err != nil {
 		log.Error("MailParticipants: %v", err)
 	}

--- a/templates/mail/issue/assigned.tmpl
+++ b/templates/mail/issue/assigned.tmpl
@@ -1,17 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<style>
+		.footer { font-size:small; color:#666;}
+	</style>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title>{{.Subject}}</title>
 </head>
 
 <body>
 	<p>@{{.Doer.Name}} assigned you to the {{if .IsPull}}pull request{{else}}issue{{end}} <a href="{{.Link}}">#{{.Issue.Index}}</a> in repository {{.Repo}}.</p>
-    <p>
-        ---
-        <br>
-        <a href="{{.Link}}">View it on {{AppName}}</a>.
-    </p>
-
+	<div class="footer">
+	    <p>
+	        ---
+	        <br>
+	        <a href="{{.Link}}">View it on {{AppName}}</a>.
+	    </p>
+	</div>
 </body>
 </html>

--- a/templates/mail/issue/default.tmpl
+++ b/templates/mail/issue/default.tmpl
@@ -3,12 +3,15 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title>{{.Subject}}</title>
-	{{if .ReviewComments}}
+
 	<style>
-		.review { padding-left: 1em; margin: 1em 0; }
-		.review > pre { padding: 1em; border-left: 1px solid grey; }
+		.footer { font-size:small; color:#666;}
+		{{if .ReviewComments}}
+			.review { padding-left: 1em; margin: 1em 0; }
+			.review > pre { padding: 1em; border-left: 1px solid grey; }
+		{{end}}
 	</style>
-	{{end}}
+
 </head>
 
 <body>
@@ -18,6 +21,8 @@
 			Closed #{{.Issue.Index}}.
 		{{else if eq .ActionName "reopen"}}
 			Reopened #{{.Issue.Index}}.
+		{{else if eq .ActionName "merge"}}
+			Merged #{{.Issue.Index}} into {{.Issue.PullRequest.BaseBranch}}.
 		{{else if eq .ActionName "approve"}}
 			<b>@{{.Doer.Name}}</b> approved this pull request.
 		{{else if eq .ActionName "reject"}}
@@ -42,10 +47,12 @@
 			</div>
 		{{end -}}		
 	</p>
+	<div class="footer">
 	<p>
 		---
 		<br>
 		<a href="{{.Link}}">View it on {{AppName}}</a>.
 	</p>
+	</div>
 </body>
 </html>

--- a/templates/mail/notify/collaborator.tmpl
+++ b/templates/mail/notify/collaborator.tmpl
@@ -1,16 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<style>
+		.footer { font-size:small; color:#666;}
+	</style>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title>{{.Subject}}</title>
 </head>
 
 <body>
 	<p>You have been added as a collaborator of repository: <code>{{.RepoName}}</code></p>
-	<p>
-		---
-		<br>
-		<a href="{{.Link}}">View it on Gitea</a>.
-	</p>
+	<div class="footer">
+	    <p>
+	        ---
+	        <br>
+	        <a href="{{.Link}}">View it on {{AppName}}</a>.
+	    </p>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
A few more small e-mail notification fixes/changes

* Style footer of notification email to be smaller
* Include text for when pull request is merged
* Don't include original body of issue or PR when merging/closing by setting issue.Content to "" in these cases

* Set Re: prefix and Message-ID headers based on actName instead of checking for a comment. This fixes a bug where certain actions that didn't have a comment were setting Message-ID instead of In-Reply-To which caused some mail programs not to show those messages as they would have had the same Message-ID as a previous message. Also fixes the case where a final comment and closing message would have been displayed out of order if you didn't have a copy of the original issue/pr creation message.
