### PR TITLE
Fix create repo bugs

### DIFF
--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -180,6 +180,7 @@ func CreatePost(ctx *context.Context, form auth.CreateRepoForm) {
 		return
 	}
 
+	var repo *models.Repository
 	var err error
 	if form.RepoTemplate > 0 {
 		opts := models.GenerateRepoOptions{
@@ -209,14 +210,14 @@ func CreatePost(ctx *context.Context, form auth.CreateRepoForm) {
 			return
 		}
 
-		repo, err := repo_service.GenerateRepository(ctx.User, ctxUser, templateRepo, opts)
+		repo, err = repo_service.GenerateRepository(ctx.User, ctxUser, templateRepo, opts)
 		if err == nil {
 			log.Trace("Repository generated [%d]: %s/%s", repo.ID, ctxUser.Name, repo.Name)
 			ctx.Redirect(setting.AppSubURL + "/" + ctxUser.Name + "/" + repo.Name)
 			return
 		}
 	} else {
-		repo, err := repo_service.CreateRepository(ctx.User, ctxUser, models.CreateRepoOptions{
+		repo, err = repo_service.CreateRepository(ctx.User, ctxUser, models.CreateRepoOptions{
 			Name:        form.RepoName,
 			Description: form.Description,
 			Gitignores:  form.Gitignores,

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2271,7 +2271,7 @@ function initTemplateSearch() {
   const checkTemplate = function () {
     const $templateUnits = $('#template_units');
     const $nonTemplate = $('#non_template');
-    if ($repoTemplate.val() !== '') {
+    if ($repoTemplate.val() !== '' && $repoTemplate.val() !== '0') {
       $templateUnits.show();
       $nonTemplate.hide();
     } else {


### PR DESCRIPTION
1. Errors on repository creation were out of scope of the handling function, so Gitea showed the 500 page (because err was nil).  
2. When an error occured, templateID was set to int default 0 and the JS was showing template units even though no template was chosen.