### PR TITLE
Re-implement semantic label images

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1178,3 +1178,9 @@ i.icon.centerlock {
     box-shadow: inset 0 0 0 1px #1678c2 !important;
     color: #1678c2 !important;
 }
+
+.ui.label > img {
+    width: auto !important;
+    vertical-align: middle;
+    height: 2.1666em !important;
+}


### PR DESCRIPTION
Fix #9602 

Using `!important` is not ideal, but this style is a copy from my instance which is before fomantic.  
Please let me know if there is a better fix, I'd be happy to make further changes. :smiley: 

![Screenshot from 2020-01-04 20-38-46](https://user-images.githubusercontent.com/42128690/71774385-39eea480-2f33-11ea-96c4-7af3733ad4cc.png)
