### PR TITLE
Add a /user/login landing page option

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -290,7 +290,8 @@ ENABLE_GZIP = false
 ENABLE_PPROF = false
 ; PPROF_DATA_PATH, use an absolute path when you start gitea as service
 PPROF_DATA_PATH = data/tmp/pprof
-; Landing page, can be "home", "explore", or "organizations"
+; Landing page, can be "home", "explore", "organizations" or "login"
+; The "login" choice is not a security measure but just a UI flow change, use REQUIRE_SIGNIN_VIEW to force users to log in.
 LANDING_PAGE = home
 ; Enables git-lfs support. true or false, default is false.
 LFS_START_SERVER = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -186,7 +186,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `STATIC_ROOT_PATH`: **./**: Upper level of template and static files path.
 - `STATIC_CACHE_TIME`: **6h**: Web browser cache time for static resources on `custom/`, `public/` and all uploaded avatars.
 - `ENABLE_GZIP`: **false**: Enables application-level GZIP support.
-- `LANDING_PAGE`: **home**: Landing page for unauthenticated users  \[home, explore\].
+- `LANDING_PAGE`: **home**: Landing page for unauthenticated users \[home, explore, organizations, login\].
 - `LFS_START_SERVER`: **false**: Enables git-lfs support.
 - `LFS_CONTENT_PATH`: **./data/lfs**: Where to store LFS files.
 - `LFS_JWT_SECRET`: **\<empty\>**: LFS authentication secret, change this a unique string.

--- a/integrations/setting_test.go
+++ b/integrations/setting_test.go
@@ -99,5 +99,10 @@ func TestSettingLandingPage(t *testing.T) {
 	resp = MakeRequest(t, req, http.StatusFound)
 	assert.Equal(t, "/explore/organizations", resp.Header().Get("Location"))
 
+	setting.LandingPageURL = setting.LandingPageLogin
+	req = NewRequest(t, "GET", "/")
+	resp = MakeRequest(t, req, http.StatusFound)
+	assert.Equal(t, "/user/login", resp.Header().Get("Location"))
+
 	setting.LandingPageURL = landingPage
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -54,6 +54,7 @@ const (
 	LandingPageHome          LandingPage = "/"
 	LandingPageExplore       LandingPage = "/explore"
 	LandingPageOrganizations LandingPage = "/explore/organizations"
+	LandingPageLogin         LandingPage = "/user/login"
 )
 
 // enumerates all the types of captchas
@@ -648,6 +649,8 @@ func NewContext() {
 		LandingPageURL = LandingPageExplore
 	case "organizations":
 		LandingPageURL = LandingPageOrganizations
+	case "login":
+		LandingPageURL = LandingPageLogin
 	default:
 		LandingPageURL = LandingPageHome
 	}


### PR DESCRIPTION
This pull request adds a landing page option `login` that redirects to `/user/login`. It closes #9597.