### PR TITLE
Remove stray fmt.Printf in services/pull/patch.go

### DIFF
--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -171,7 +171,6 @@ func TestPatch(pr *models.PullRequest) error {
 				scanner := bufio.NewScanner(stderrReader)
 				for scanner.Scan() {
 					line := scanner.Text()
-					fmt.Printf("%s\n", line)
 					if strings.HasPrefix(line, prefix) {
 						conflict = true
 						filepath := strings.TrimSpace(strings.Split(line[len(prefix):], ":")[0])


### PR DESCRIPTION
Unfortunately #9302 introduced a stray fmt.Printf(...) which should be removed.