### PR TITLE
Add HTML URL to API Issues

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -381,6 +381,7 @@ func (issue *Issue) apiFormat(e Engine) *api.Issue {
 	apiIssue := &api.Issue{
 		ID:       issue.ID,
 		URL:      issue.APIURL(),
+		HTMLURL:  issue.HTMLURL(),
 		Index:    issue.Index,
 		Poster:   issue.Poster.APIFormat(),
 		Title:    issue.Title,

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -38,6 +38,7 @@ type RepositoryMeta struct {
 type Issue struct {
 	ID               int64      `json:"id"`
 	URL              string     `json:"url"`
+	HTMLURL          string     `json:"html_url"`
 	Index            int64      `json:"number"`
 	Poster           *User      `json:"user"`
 	OriginalAuthor   string     `json:"original_author"`

--- a/modules/webhook/dingtalk.go
+++ b/modules/webhook/dingtalk.go
@@ -142,7 +142,7 @@ func getDingtalkIssuesPayload(p *api.IssuePayload) (*DingtalkPayload, error) {
 			Title:       issueTitle,
 			HideAvatar:  "0",
 			SingleTitle: "view issue",
-			SingleURL:   p.Issue.URL,
+			SingleURL:   p.Issue.HTMLURL,
 		},
 	}, nil
 }

--- a/modules/webhook/discord.go
+++ b/modules/webhook/discord.go
@@ -236,7 +236,7 @@ func getDiscordIssuesPayload(p *api.IssuePayload, meta *DiscordMeta) (*DiscordPa
 			{
 				Title:       text,
 				Description: attachmentText,
-				URL:         p.Issue.URL,
+				URL:         p.Issue.HTMLURL,
 				Color:       color,
 				Author: DiscordEmbedAuthor{
 					Name:    p.Sender.UserName,

--- a/modules/webhook/msteams.go
+++ b/modules/webhook/msteams.go
@@ -299,7 +299,7 @@ func getMSTeamsIssuesPayload(p *api.IssuePayload) (*MSTeamsPayload, error) {
 				Targets: []MSTeamsActionTarget{
 					{
 						Os:  "default",
-						URI: p.Issue.URL,
+						URI: p.Issue.HTMLURL,
 					},
 				},
 			},

--- a/modules/webhook/slack.go
+++ b/modules/webhook/slack.go
@@ -158,7 +158,7 @@ func getSlackIssuesPayload(p *api.IssuePayload, slack *SlackMeta) (*SlackPayload
 		pl.Attachments = []SlackAttachment{{
 			Color:     fmt.Sprintf("%x", color),
 			Title:     issueTitle,
-			TitleLink: p.Issue.URL,
+			TitleLink: p.Issue.HTMLURL,
 			Text:      attachmentText,
 		}}
 	}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -10248,6 +10248,10 @@
           "format": "date-time",
           "x-go-name": "Deadline"
         },
+        "html_url": {
+          "type": "string",
+          "x-go-name": "HTMLURL"
+        },
         "id": {
           "type": "integer",
           "format": "int64",


### PR DESCRIPTION
After the recent refactor, webhooks are sending URLs pointing to the API rather than the instance.  

This PR adds the HTML URL to API Issues. API PRs already have the HTML URL, so I assumed it was okay to add to Issues as well.