### PR TITLE
remove google font call

### DIFF
--- a/public/vendor/plugins/fomantic/semantic.css
+++ b/public/vendor/plugins/fomantic/semantic.css
@@ -8,7 +8,6 @@
  * http://opensource.org/licenses/MIT
  *
  */
-@import url('https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin&display=swap');
 /*!
  * # Fomantic-UI - Reset
  * http://github.com/fomantic/Fomantic-UI/

--- a/public/vendor/plugins/fomantic/semantic.min.css
+++ b/public/vendor/plugins/fomantic/semantic.min.css
@@ -7,8 +7,7 @@
  * Released under the MIT license
  * http://opensource.org/licenses/MIT
  *
- */
-@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin&display=swap);/*!
+ *//*!
  * # Fomantic-UI - Reset
  * http://github.com/fomantic/Fomantic-UI/
  *


### PR DESCRIPTION
As title

Edit: I know this edits the vendor'd lib, however there is no other way to remove this (until we move to the other PR where it is managed by npm)