### PR TITLE
eliminate horizontal scroll caused by footer

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -774,6 +774,7 @@ footer {
     .container {
         width: 100vw !important;
         padding: 0 0.5rem;
+        max-width: calc(100vw - 1rem) !important;
 
         .fa {
             width: 16px;


### PR DESCRIPTION
fixes an issue with horizontal scroll on all pages on mobile, caused by the page footer being too wide for some reason.

### Before (notice horizontal scrollbar)

![](https://user-images.githubusercontent.com/115237/72089986-6e84a680-330d-11ea-8b38-c619d863b18d.png)

### After (no more horizontal scrollbar)

![](https://user-images.githubusercontent.com/115237/72090029-82300d00-330d-11ea-8ab3-831acfd3b630.png)
