### PR TITLE
Move Errored PRs out of StatusChecking

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -518,7 +518,7 @@ func (pr *PullRequest) apiFormat(e Engine) *api.PullRequest {
 	}
 
 	if pr.Status != PullRequestStatusChecking {
-		mergeable := (pr.Status != PullRequestStatusConflict || pr.Status != PullRequestStatusError) && !pr.IsWorkInProgress()
+		mergeable := !(pr.Status == PullRequestStatusConflict || pr.Status == PullRequestStatusError) && !pr.IsWorkInProgress()
 		apiPullRequest.Mergeable = mergeable
 	}
 	if pr.HasMerged {

--- a/models/pull.go
+++ b/models/pull.go
@@ -35,6 +35,7 @@ const (
 	PullRequestStatusChecking
 	PullRequestStatusMergeable
 	PullRequestStatusManuallyMerged
+	PullRequestStatusError
 )
 
 // PullRequest represents relation between pull request and repositories.

--- a/models/pull.go
+++ b/models/pull.go
@@ -518,7 +518,7 @@ func (pr *PullRequest) apiFormat(e Engine) *api.PullRequest {
 	}
 
 	if pr.Status != PullRequestStatusChecking {
-		mergeable := pr.Status != PullRequestStatusConflict && !pr.IsWorkInProgress()
+		mergeable := (pr.Status != PullRequestStatusConflict || pr.Status != PullRequestStatusError) && !pr.IsWorkInProgress()
 		apiPullRequest.Mergeable = mergeable
 	}
 	if pr.HasMerged {

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -194,10 +194,14 @@ func TestPullRequests(ctx context.Context) {
 			if err != nil {
 				log.Error("GetPullRequestByID[%s]: %v", prID, err)
 				continue
+			} else if pr.Status != models.PullRequestStatusChecking {
+				continue
 			} else if manuallyMerged(pr) {
 				continue
 			} else if err = TestPatch(pr); err != nil {
 				log.Error("testPatch[%d]: %v", pr.ID, err)
+				pr.Status = models.PullRequestStatusError
+				pr.UpdateCols("status")
 				continue
 			}
 			checkAndUpdateStatus(pr)


### PR DESCRIPTION
One of the consequences of the fix in #9282 to ensure that PRs are rechecked is that an PR which errors in TestPatch will remain in StatusChecking. This previously didn't matter as PRs would never get rechecked whilst Gitea was running however now this means that these broken PRs will get repeatedly tested.

This PR moves these PRs to StatusError.