### PR TITLE
Fix wrong original git service type on a migrated repository

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -292,6 +292,8 @@ var migrations = []Migration{
 	NewMigration("Add block on rejected reviews branch protection", addBlockOnRejectedReviews),
 	// v118 -> v119
 	NewMigration("Add commit id and stale to reviews", addReviewCommitAndStale),
+	// v119 -> v120
+	NewMigration("Fix migrated repositories' git service type", fixMigratedRepositoryServiceType),
 }
 
 // Migrate database to current version

--- a/models/migrations/v119.go
+++ b/models/migrations/v119.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"code.gitea.io/gitea/modules/structs"
+
+	"xorm.io/xorm"
+)
+
+func fixMigratedRepositoryServiceType(x *xorm.Engine) error {
+	_, err := x.Exec("UPDATE repository SET original_service_type = ? WHERE original_url LIKE 'https://github.com/%'", structs.GithubService)
+	return err
+}

--- a/models/repo.go
+++ b/models/repo.go
@@ -1071,17 +1071,18 @@ func initRepoCommit(tmpPath string, repo *Repository, u *User) (err error) {
 
 // CreateRepoOptions contains the create repository options
 type CreateRepoOptions struct {
-	Name        string
-	Description string
-	OriginalURL string
-	Gitignores  string
-	IssueLabels string
-	License     string
-	Readme      string
-	IsPrivate   bool
-	IsMirror    bool
-	AutoInit    bool
-	Status      RepositoryStatus
+	Name           string
+	Description    string
+	OriginalURL    string
+	GitServiceType structs.GitServiceType
+	Gitignores     string
+	IssueLabels    string
+	License        string
+	Readme         string
+	IsPrivate      bool
+	IsMirror       bool
+	AutoInit       bool
+	Status         RepositoryStatus
 }
 
 func getRepoInitFile(tp, name string) ([]byte, error) {
@@ -1369,6 +1370,7 @@ func CreateRepository(doer, u *User, opts CreateRepoOptions) (_ *Repository, err
 		LowerName:                       strings.ToLower(opts.Name),
 		Description:                     opts.Description,
 		OriginalURL:                     opts.OriginalURL,
+		OriginalServiceType:             opts.GitServiceType,
 		IsPrivate:                       opts.IsPrivate,
 		IsFsckEnabled:                   !opts.IsMirror,
 		CloseIssuesViaCommitInAnyBranch: setting.Repository.DefaultCloseIssuesViaCommitsInAnyBranch,

--- a/models/task.go
+++ b/models/task.go
@@ -194,12 +194,13 @@ func CreateMigrateTask(doer, u *User, opts base.MigrateOptions) (*Task, error) {
 	}
 
 	repo, err := CreateRepository(doer, u, CreateRepoOptions{
-		Name:        opts.RepoName,
-		Description: opts.Description,
-		OriginalURL: opts.OriginalURL,
-		IsPrivate:   opts.Private,
-		IsMirror:    opts.Mirror,
-		Status:      RepositoryBeingMigrated,
+		Name:           opts.RepoName,
+		Description:    opts.Description,
+		OriginalURL:    opts.OriginalURL,
+		GitServiceType: opts.GitServiceType,
+		IsPrivate:      opts.Private,
+		IsMirror:       opts.Mirror,
+		Status:         RepositoryBeingMigrated,
 	})
 	if err != nil {
 		task.EndTime = timeutil.TimeStampNow()

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -101,12 +101,13 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, opts base.Migrate
 	var r *models.Repository
 	if opts.MigrateToRepoID <= 0 {
 		r, err = models.CreateRepository(g.doer, owner, models.CreateRepoOptions{
-			Name:        g.repoName,
-			Description: repo.Description,
-			OriginalURL: repo.OriginalURL,
-			IsPrivate:   opts.Private,
-			IsMirror:    opts.Mirror,
-			Status:      models.RepositoryBeingMigrated,
+			Name:           g.repoName,
+			Description:    repo.Description,
+			OriginalURL:    repo.OriginalURL,
+			GitServiceType: opts.GitServiceType,
+			IsPrivate:      opts.Private,
+			IsMirror:       opts.Mirror,
+			Status:         models.RepositoryBeingMigrated,
 		})
 	} else {
 		r, err = models.GetRepositoryByID(opts.MigrateToRepoID)

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -485,12 +485,13 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 	}
 
 	repo, err := models.CreateRepository(ctx.User, ctxUser, models.CreateRepoOptions{
-		Name:        opts.RepoName,
-		Description: opts.Description,
-		OriginalURL: form.CloneAddr,
-		IsPrivate:   opts.Private,
-		IsMirror:    opts.Mirror,
-		Status:      models.RepositoryBeingMigrated,
+		Name:           opts.RepoName,
+		Description:    opts.Description,
+		OriginalURL:    form.CloneAddr,
+		GitServiceType: gitServiceType,
+		IsPrivate:      opts.Private,
+		IsMirror:       opts.Mirror,
+		Status:         models.RepositoryBeingMigrated,
 	})
 	if err != nil {
 		handleMigrateError(ctx, ctxUser, remoteAddr, err)

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -6,6 +6,7 @@ package repo
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/task"
 	"code.gitea.io/gitea/modules/util"
 	repo_service "code.gitea.io/gitea/services/repository"
@@ -330,22 +332,29 @@ func MigratePost(ctx *context.Context, form auth.MigrateRepoForm) {
 		return
 	}
 
+	var gitServiceType = structs.PlainGitService
+	u, err := url.Parse(form.CloneAddr)
+	if err == nil && strings.EqualFold(u.Host, "github.com") {
+		gitServiceType = structs.GithubService
+	}
+
 	var opts = migrations.MigrateOptions{
-		OriginalURL:  form.CloneAddr,
-		CloneAddr:    remoteAddr,
-		RepoName:     form.RepoName,
-		Description:  form.Description,
-		Private:      form.Private || setting.Repository.ForcePrivate,
-		Mirror:       form.Mirror,
-		AuthUsername: form.AuthUsername,
-		AuthPassword: form.AuthPassword,
-		Wiki:         form.Wiki,
-		Issues:       form.Issues,
-		Milestones:   form.Milestones,
-		Labels:       form.Labels,
-		Comments:     true,
-		PullRequests: form.PullRequests,
-		Releases:     form.Releases,
+		OriginalURL:    form.CloneAddr,
+		GitServiceType: gitServiceType,
+		CloneAddr:      remoteAddr,
+		RepoName:       form.RepoName,
+		Description:    form.Description,
+		Private:        form.Private || setting.Repository.ForcePrivate,
+		Mirror:         form.Mirror,
+		AuthUsername:   form.AuthUsername,
+		AuthPassword:   form.AuthPassword,
+		Wiki:           form.Wiki,
+		Issues:         form.Issues,
+		Milestones:     form.Milestones,
+		Labels:         form.Labels,
+		Comments:       true,
+		PullRequests:   form.PullRequests,
+		Releases:       form.Releases,
 	}
 	if opts.Mirror {
 		opts.Issues = false


### PR DESCRIPTION
The original git service type should be 2 but now it's 0. This PR will fix that.