### PR TITLE
Remove q.lock.Unlock() in setInternal to prevent panic

### DIFF
--- a/modules/queue/queue_wrapped.go
+++ b/modules/queue/queue_wrapped.go
@@ -62,7 +62,6 @@ func (q *delayedStarter) setInternal(atShutdown func(context.Context, func()), h
 			queue, err := NewQueue(q.underlying, handle, q.cfg, exemplar)
 			if err == nil {
 				q.internal = queue
-				q.lock.Unlock()
 				break
 			}
 			if err.Error() != "resource temporarily unavailable" {


### PR DESCRIPTION
Unfortunately an extraneous q.lock.Unlock() was missed in setInternal due to a requested change in #9363. This can cause a panic and therefore needs to be removed. 