### PR TITLE
Remove q.lock.Unlock() in setInternal to prevent panic (#9705)

### DIFF
--- a/modules/queue/queue_wrapped.go
+++ b/modules/queue/queue_wrapped.go
@@ -62,7 +62,6 @@ func (q *delayedStarter) setInternal(atShutdown func(context.Context, func()), h
 			queue, err := NewQueue(q.underlying, handle, q.cfg, exemplar)
 			if err == nil {
 				q.internal = queue
-				q.lock.Unlock()
 				break
 			}
 			if err.Error() != "resource temporarily unavailable" {


### PR DESCRIPTION
Backport #9705 