### PR TITLE
silence fomantic error regarding tabs

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -22,6 +22,9 @@ if (typeof (Dropzone) !== 'undefined') {
   Dropzone.autoDiscover = false;
 }
 
+// Silence fomantic's error logging when tabs are used without a target content element
+$.fn.tab.settings.silent = true;
+
 function initCommentPreviewTab($form) {
   const $tabMenu = $form.find('.tabular.menu');
   $tabMenu.find('.item').tab();


### PR DESCRIPTION
Fomantic expects all tabs to have a target element with content as defined by the `data-tab` attribute. All our usage of the tab module seems to use `<a>` element tabs that link to new pages so these content elements are never present and fomantic complains about that in the console with
an "Activated tab cannot be found" error. This silences that error.

Ref: https://fomantic-ui.com/modules/tab.html

Errors can be seen in the browser console on every page containing those link-style tabs, for example https://try.gitea.io/silverwind/symlink-test.