### PR TITLE
Move Errored PRs out of StatusChecking (#9675)

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -35,6 +35,7 @@ const (
 	PullRequestStatusChecking
 	PullRequestStatusMergeable
 	PullRequestStatusManuallyMerged
+	PullRequestStatusError
 )
 
 // PullRequest represents relation between pull request and repositories.
@@ -513,7 +514,7 @@ func (pr *PullRequest) apiFormat(e Engine) *api.PullRequest {
 	}
 
 	if pr.Status != PullRequestStatusChecking {
-		mergeable := pr.Status != PullRequestStatusConflict && !pr.IsWorkInProgress()
+		mergeable := !(pr.Status == PullRequestStatusConflict || pr.Status == PullRequestStatusError) && !pr.IsWorkInProgress()
 		apiPullRequest.Mergeable = mergeable
 	}
 	if pr.HasMerged {

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -194,10 +194,14 @@ func TestPullRequests(ctx context.Context) {
 			if err != nil {
 				log.Error("GetPullRequestByID[%s]: %v", prID, err)
 				continue
+			} else if pr.Status != models.PullRequestStatusChecking {
+				continue
 			} else if manuallyMerged(pr) {
 				continue
 			} else if err = TestPatch(pr); err != nil {
 				log.Error("testPatch[%d]: %v", pr.ID, err)
+				pr.Status = models.PullRequestStatusError
+				pr.UpdateCols("status")
 				continue
 			}
 			checkAndUpdateStatus(pr)

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -201,7 +201,9 @@ func TestPullRequests(ctx context.Context) {
 			} else if err = TestPatch(pr); err != nil {
 				log.Error("testPatch[%d]: %v", pr.ID, err)
 				pr.Status = models.PullRequestStatusError
-				pr.UpdateCols("status")
+				if err := pr.UpdateCols("status"); err != nil {
+					log.Error("Unable to update status of pr %d: %v", pr.ID, err)
+				}
 				continue
 			}
 			checkAndUpdateStatus(pr)


### PR DESCRIPTION
* Set Errored PRs out of StatusChecking

* Ensure that api status is correctly set too

Co-authored-by: John Olheiser <42128690+jolheiser@users.noreply.github.com>
