### PR TITLE
[Docs] Hacking Gitea - Manual git clone

### DIFF
--- a/docs/content/doc/advanced/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/advanced/hacking-on-gitea.en-us.md
@@ -66,6 +66,18 @@ cd "$GOPATH/src/code.gitea.io/gitea"
 This will clone the Gitea source code to: `"$GOPATH/src/code.gitea.io/gitea"`, or if `$GOPATH`
 is not set `"$HOME/go/src/code.gitea.io/gitea"`.
 
+Alternatively, you can manually clone the source code by:
+
+```
+git clone https://github.com/go-gitea/gitea.git $GOPATH/src/code.gitea.io/gitea
+```
+
+If `$GOPATH` is not set:
+
+```
+git clone https://github.com/go-gitea/gitea.git $HOME/go/src/code.gitea.io/gitea
+```
+
 ## Forking Gitea
 
 As stated above, you cannot clone Gitea to an arbitrary path. Download the master Gitea source


### PR DESCRIPTION
Well, most docs for other Go projects have manual `git clone` method instead of using `go get`. This PR add this other method to clone Gitea source.