### PR TITLE
[wip] try ci cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -311,6 +311,8 @@ steps:
       rebuild: true
       mount:
         - ./node_modules
+    depends_on:
+      - build
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -401,6 +401,15 @@ depends_on:
   - translations
 
 steps:
+  - name: restore-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      restore: true
+      mount:
+        - ./node_modules
   - name: fetch-tags
     pull: default
     image: docker:git
@@ -498,6 +507,15 @@ depends_on:
   - testing
 
 steps:
+  - name: restore-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      restore: true
+      mount:
+        - ./node_modules
   - name: fetch-tags
     pull: default
     image: docker:git
@@ -627,6 +645,16 @@ steps:
         exclude:
           - pull_request
 
+  - name: restore-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      restore: true
+      mount:
+        - ./node_modules
+
   - name: dryrun
     pull: always
     image: plugins/docker:linux-amd64
@@ -689,6 +717,16 @@ steps:
       event:
         exclude:
           - pull_request
+
+  - name: restore-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      restore: true
+      mount:
+        - ./node_modules
 
   - name: dryrun
     pull: always

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,15 @@ services:
     image: gitea/test-openldap:latest
 
 steps:
+  - name: restore-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      restore: true
+      mount:
+        - ./node_modules
   - name: fetch-tags
     pull: default
     image: docker:git
@@ -292,6 +301,16 @@ steps:
       event:
         - push
         - pull_request
+
+  - name: rebuild-cache
+    image: drillster/drone-volume-cache
+    volumes:
+    - name: cache_node_modules
+      path: /cache/node_modules
+    settings:
+      rebuild: true
+      mount:
+        - ./node_modules
 
 ---
 kind: pipeline


### PR DESCRIPTION
To see if there is any advantage. 

Later, we could use the s3 minio as storage for the cache. This way node_modules (and later go mod cache folder) will be accessible via dl.gitea.io which was a concern when deciding to remove all vendoring.