### PR TITLE
fix webpack polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
               [
                 '@babel/preset-env',
                 {
-                  useBuiltIns: 'entry',
+                  useBuiltIns: 'usage',
                   corejs: 3,
                 }
               ]


### PR DESCRIPTION
webpack polyfills did not work because useBuiltIns: 'entry' expects a explicit core-js import. Changed it to 'usage' which does not require these explicit imports and polyfills based on browserslist.

As a result, the built index.js now went from 128kB to 192kB.

Ref: https://babeljs.io/docs/en/babel-preset-env#usebuiltins