### PR TITLE
add package-lock=true in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+package-lock=true
 save-exact=true


### PR DESCRIPTION
Some users (like me) have this option disabled in their global npm config which can lead to package-lock.json not being updated. This explicitely enables the option for this repo, so that the file is always updated when adding/removing dependencies.