### PR TITLE
ci: go back to golangci-lint 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,6 +558,6 @@ pr:
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		export BINARY="golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.22.2; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.20.0; \
 	fi
 	golangci-lint run --timeout 5m


### PR DESCRIPTION
Revert https://github.com/go-gitea/gitea/pull/9711

I don't really know if it will fix thing but worth a try. 😄 
