### PR TITLE
Fix add team on collaborator page when same name as organization

### DIFF
--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -581,7 +581,7 @@ func AddTeamPost(ctx *context.Context) {
 	}
 
 	name := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Query("team")))
-	if len(name) == 0 || ctx.Repo.Owner.LowerName == name {
+	if len(name) == 0 {
 		ctx.Redirect(ctx.Repo.RepoLink + "/settings/collaboration")
 		return
 	}


### PR DESCRIPTION
Backport #9767.