### PR TITLE
Fix signing info on PR view if not logged in

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -151,7 +151,7 @@
 							<i class="icon lock green"></i>
 							{{$.i18n.Tr "repo.signing.will_sign" .SigningKey}}
 						</div>
-					{{else}}
+					{{else if .IsSigned}}
 						<div class="item text yellow">
 							<i class="icon unlock grey"></i>
 							{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}


### PR DESCRIPTION
## Before Fix:
![Bildschirmfoto zu 2020-01-15 21-05-22](https://user-images.githubusercontent.com/24977596/72467248-cffbb800-37da-11ea-831c-f666a3325e11.png)

## After Fix:
![Bildschirmfoto zu 2020-01-15 21-04-34](https://user-images.githubusercontent.com/24977596/72467266-d8ec8980-37da-11ea-9d66-805d046aac44.png)