### PR TITLE
Fix missing unlock in uniquequeue (#9790)

### DIFF
--- a/modules/sync/unique_queue.go
+++ b/modules/sync/unique_queue.go
@@ -82,6 +82,7 @@ func (q *UniqueQueue) AddFunc(id interface{}, fn func()) {
 	idStr := com.ToStr(id)
 	q.table.lock.Lock()
 	if _, ok := q.table.pool[idStr]; ok {
+		q.table.lock.Unlock()
 		return
 	}
 	q.table.pool[idStr] = struct{}{}


### PR DESCRIPTION
Fixes a missing unlock in uniquequeue that will cause a deadlock.

Fix #9667
Likely Fixes #9759 