### PR TITLE
[Backport] Fix markdown anchor links (#9673)

### DIFF
--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -79,6 +79,9 @@ func (g *GiteaASTTransformer) Transform(node *ast.Document, reader text.Reader, 
 				}
 				link = []byte(giteautil.URLJoin(pc.Get(urlPrefixKey).(string), lnk))
 			}
+			if len(link) > 0 && link[0] == '#' {
+				link = []byte("#user-content-" + string(link)[1:])
+			}
 			v.Destination = link
 		}
 		return ast.WalkContinue, nil


### PR DESCRIPTION
Backport of https://github.com/go-gitea/gitea/pull/9673.

I hope I did this correctly as this is my first backport in my life xD