### PR TITLE
Change won't sign information text to black.

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -152,7 +152,7 @@
 							{{$.i18n.Tr "repo.signing.will_sign" .SigningKey}}
 						</div>
 					{{else if .IsSigned}}
-						<div class="item text yellow">
+						<div class="item text black">
 							<i class="icon unlock grey"></i>
 							{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
 						</div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -129,7 +129,7 @@
 						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 					<div class="item text yellow">
-						<i class="icon unlock grey"></i>
+						<i class="icon unlock"></i>
 						{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
 					</div>
 				{{end}}
@@ -152,8 +152,8 @@
 							{{$.i18n.Tr "repo.signing.will_sign" .SigningKey}}
 						</div>
 					{{else if .IsSigned}}
-						<div class="item text black">
-							<i class="icon unlock grey"></i>
+						<div class="item text">
+							<i class="icon unlock"></i>
 							{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
 						</div>
 					{{end}}


### PR DESCRIPTION
Small patch to #9708.

When protected branch doesn't require signed commits, there should still be an information in the pull request if the commit will be signed. However I don't think it should be a warning, as it would be normal for persons/organizations that don't use commit signing. Therefore I suggest changing this text from yellow to black.

## Screenshot
Before change:
![bild](https://user-images.githubusercontent.com/161914/72630286-5090f480-3952-11ea-810d-a223d7e18a1e.png)

After change:
![bild](https://user-images.githubusercontent.com/161914/72630100-e9734000-3951-11ea-9fd6-4ed00eb4605d.png)
