### PR TITLE
Explicitly refer to PR in squash-merge commit message in case of external tracker

### DIFF
--- a/docs/content/doc/usage/linked-references.en-us.md
+++ b/docs/content/doc/usage/linked-references.en-us.md
@@ -136,7 +136,8 @@ the `!` marker to identify pull requests. For example:
 > This is pull request [!1234](#), and links to a pull request in Gitea.
 
 The `!` and `#` can be used interchangeably for issues and pull request _except_
-for this case, where a distinction is required.
+for this case, where a distinction is required. If the repository uses external
+tracker, commit message for squash merge will use `!` as reference by default.
 
 ## Issues and Pull Requests References Summary
 

--- a/models/pull.go
+++ b/models/pull.go
@@ -390,6 +390,13 @@ func (pr *PullRequest) GetDefaultSquashMessage() string {
 		log.Error("LoadIssue: %v", err)
 		return ""
 	}
+	if err := pr.LoadBaseRepo(); err != nil {
+		log.Error("LoadBaseRepo: %v", err)
+		return ""
+	}
+	if pr.BaseRepo.UnitEnabled(UnitTypeExternalTracker) {
+		return fmt.Sprintf("%s (!%d)", pr.Issue.Title, pr.Issue.Index)
+	}
 	return fmt.Sprintf("%s (#%d)", pr.Issue.Title, pr.Issue.Index)
 }
 


### PR DESCRIPTION
To avoid creating a link to external tracker, i.e. use `!` instead of `#`. As I think it would be controversial to change this on all repositories, I only change it for those having external tracker enabled.

This is related to changes intoduced by #9116, so could be considered for backporting to 1.11.