### PR TITLE
Allow hyphen in language name

### DIFF
--- a/modules/markup/sanitizer.go
+++ b/modules/markup/sanitizer.go
@@ -38,7 +38,7 @@ func NewSanitizer() {
 func ReplaceSanitizer() {
 	sanitizer.policy = bluemonday.UGCPolicy()
 	// We only want to allow HighlightJS specific classes for code blocks
-	sanitizer.policy.AllowAttrs("class").Matching(regexp.MustCompile(`^language-\w+$`)).OnElements("code")
+	sanitizer.policy.AllowAttrs("class").Matching(regexp.MustCompile(`^language-[\w-]+$`)).OnElements("code")
 
 	// Checkboxes
 	sanitizer.policy.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")


### PR DESCRIPTION
Highlight js has a language class jboss-cli that we will currently sanitize away. 

We should allow hyphens in markdown code block names.