### PR TITLE
Add documentation how to render PlantUML in code blocks.

### DIFF
--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -18,7 +18,8 @@ menu:
 Customizing Gitea is typically done using the `CustomPath` folder - by default this is
 the `custom` folder from the running directory, but may be different if your build has
 set this differently. This is the central place to override configuration settings,
-templates, etc. You can check the `CustomPath` using `gitea help`. You can override
+templates, etc. You can check the `CustomPath` using `gitea help`. You can also find
+the path on the _Configuration_ tab in the _Site Administrator_ page. You can override
 the `CustomPath` by setting either the `GITEA_CUSTOM` environment variable or by
 using the `--custom-path` option on the `gitea` binary. (The option will override the
 environment variable.)
@@ -144,8 +145,8 @@ Mermaid will detect and use tags with `class="language-mermaid"`.
 You can add [PlantUML](https://plantuml.com/) support to Gitea's markdown by using a PlantUML server.
 The data is encoded and sent to the PlantUML server which generates the picture. There is an online 
 demo server at http://www.plantuml.com/plantuml, but if you (or your users) have sensitive data you 
-can set up your own [PlantUML server](https://plantuml.com/server) instead. To set up PlantUML rendering
-copy javascript files from https://gitea.com/davidsvantesson/plantuml-code-highlight and put in your
+can set up your own [PlantUML server](https://plantuml.com/server) instead. To set up PlantUML rendering,
+copy javascript files from https://gitea.com/davidsvantesson/plantuml-code-highlight and put them in your
 `custom/public` folder. Then add the following to `custom/footer.tmpl`:
 
 ```html
@@ -162,13 +163,13 @@ parsePlantumlCodeBlocks("http://www.plantuml..com/plantuml")
 
 You can then add blocks like below to your markdown:
 
-```plantuml
-Alice -> Bob: Authentication Request
-Bob --> Alice: Authentication Response
-
-Alice -> Bob: Another authentication Request
-Alice <-- Bob: Another authentication Response
-```
+    ```plantuml
+        Alice -> Bob: Authentication Request
+        Bob --> Alice: Authentication Response
+        
+        Alice -> Bob: Another authentication Request
+        Alice <-- Bob: Another authentication Response
+    ```
 
 The script will detect tags with `class="language-plantuml"`, but you can change this by providing a second argument to `parsePlantumlCodeBlocks`.
 

--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -19,7 +19,7 @@ Customizing Gitea is typically done using the `CustomPath` folder - by default t
 the `custom` folder from the running directory, but may be different if your build has
 set this differently. This is the central place to override configuration settings,
 templates, etc. You can check the `CustomPath` using `gitea help`. You can also find
-the path on the _Configuration_ tab in the _Site Administrator_ page. You can override
+the path on the _Configuration_ tab in the _Site Administration_ page. You can override
 the `CustomPath` by setting either the `GITEA_CUSTOM` environment variable or by
 using the `--custom-path` option on the `gitea` binary. (The option will override the
 environment variable.)
@@ -161,7 +161,7 @@ parsePlantumlCodeBlocks("http://www.plantuml..com/plantuml")
 {{end}}
 ```
 
-You can then add blocks like below to your markdown:
+You can then add blocks like the following to your markdown:
 
     ```plantuml
         Alice -> Bob: Authentication Request

--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -139,6 +139,39 @@ you would need to remove `{{if .RequireHighlightJS}}` and `{{end}}`.
 
 Mermaid will detect and use tags with `class="language-mermaid"`.
 
+#### Example: PlantUML
+
+You can add [PlantUML](https://plantuml.com/) support to Gitea's markdown by using a PlantUML server.
+The data is encoded and sent to the PlantUML server which generates the picture. There is an online 
+demo server at http://www.plantuml.com/plantuml, but if you (or your users) have sensitive data you 
+can set up your own [PlantUML server](https://plantuml.com/server) instead. To set up PlantUML rendering
+copy javascript files from https://gitea.com/davidsvantesson/plantuml-code-highlight and put in your
+`custom/public` folder. Then add the following to `custom/footer.tmpl`:
+
+```html
+{{if .RequireHighlightJS}}
+<script src="https://your-server.com/deflate.js"></script>
+<script src="https://your-server.com/encode.js"></script>
+<script src="https://your-server.com/plantuml_codeblock_parse.js"></script>
+<script>
+<!-- Replace call with address to your plantuml server-->
+parsePlantumlCodeBlocks("http://www.plantuml..com/plantuml")
+</script>
+{{end}}
+```
+
+You can then add blocks like below to your markdown:
+
+```plantuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+
+Alice -> Bob: Another authentication Request
+Alice <-- Bob: Another authentication Response
+```
+
+The script will detect tags with `class="language-plantuml"`, but you can change this by providing a second argument to `parsePlantumlCodeBlocks`.
+
 ## Customizing Gitea mails
 
 The `custom/templates/mail` folder allows changing the body of every mail of Gitea.

--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -22,7 +22,7 @@ it is just a matter of:
 * add some configuration to your `app.ini` file
 * restart your Gitea instance
 
-This supports rendering of whole files. If you want to render code blocks in markdown you would need to do something with javascript, see some examples on the [Customizing Gitea](../customizing-gitea) page.
+This supports rendering of whole files. If you want to render code blocks in markdown you would need to do something with javascript. See some examples on the [Customizing Gitea](../customizing-gitea) page.
 
 ## Installing external binaries
 

--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -22,7 +22,7 @@ it is just a matter of:
 * add some configuration to your `app.ini` file
 * restart your Gitea instance
 
-This support rendering of complete files. If you wan't to render code blocks in markdown you would need to do something with javascript, see some examples on the [Customizing Gitea](../customizing-gitea) page.
+This supports rendering of whole files. If you want to render code blocks in markdown you would need to do something with javascript, see some examples on the [Customizing Gitea](../customizing-gitea) page.
 
 ## Installing external binaries
 

--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -22,6 +22,8 @@ it is just a matter of:
 * add some configuration to your `app.ini` file
 * restart your Gitea instance
 
+This support rendering of complete files. If you wan't to render code blocks in markdown you would need to do something with javascript, see some examples on the [Customizing Gitea](../customizing-gitea) page.
+
 ## Installing external binaries
 
 In order to get file rendering through external binaries, their associated packages must be installed. 


### PR DESCRIPTION
I managed to get plantuml working by using a plantuml server. I think this would be quite similar how Gitlab does it. This PR suggest adding documentation of it to https://docs.gitea.io/en-us/customizing-gitea/.

Related: #3902.
Related #9553.