### PR TITLE
misc webpack tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ js: node-check fomantic $(JS_DEST)
 
 $(JS_DEST): node_modules $(JS_SOURCES)
 	npx eslint web_src/js webpack.config.js
-	npx webpack
+	npx webpack --hide-modules --display-entrypoints=false
 
 .PHONY: fomantic
 fomantic: node-check $(FOMANTIC_DEST_DIR)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,29 +38,31 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              [
-                '@babel/preset-env',
-                {
-                  useBuiltIns: 'usage',
-                  corejs: 3,
-                }
-              ]
-            ],
-            plugins: [
-              [
-                '@babel/plugin-transform-runtime',
-                {
-                  regenerator: true,
-                }
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    useBuiltIns: 'usage',
+                    corejs: 3,
+                  }
+                ]
               ],
-              '@babel/plugin-proposal-object-rest-spread',
-            ],
-          }
-        }
+              plugins: [
+                [
+                  '@babel/plugin-transform-runtime',
+                  {
+                    regenerator: true,
+                  }
+                ],
+                '@babel/plugin-proposal-object-rest-spread',
+              ],
+            }
+          },
+        ],
       },
       {
         test: /\.css$/i,
@@ -73,6 +75,8 @@ module.exports = {
     new SourceMapDevToolPlugin({
       filename: '[name].js.map',
       exclude: [
+        'gitgraph.js',
+        'jquery.js',
         'swagger.js',
       ],
     }),
@@ -84,4 +88,7 @@ module.exports = {
       return !filename.endsWith('.map') && filename !== 'swagger.js';
     }
   },
+  resolve: {
+    symlinks: false,
+  }
 };


### PR DESCRIPTION
- reduce verbosity during build
- use array form `use` to allow easier extension
- disable uninteresting source maps
- disable symlink resolution for a speedup

Overall this gives about 10% speedup on the webpack build.