### PR TITLE
Fix RocketChat Webhook (#9908) (#9921)

### DIFF
--- a/models/webhook_slack.go
+++ b/models/webhook_slack.go
@@ -283,8 +283,10 @@ func getSlackPushPayload(p *api.PushPayload, slack *SlackMeta) (*SlackPayload, e
 		Username: slack.Username,
 		IconURL:  slack.IconURL,
 		Attachments: []SlackAttachment{{
-			Color: slack.Color,
-			Text:  attachmentText,
+			Color:     slack.Color,
+			Title:     p.Repo.HTMLURL,
+			TitleLink: p.Repo.HTMLURL,
+			Text:      attachmentText,
 		}},
 	}, nil
 }
@@ -380,12 +382,11 @@ func getSlackPullRequestApprovalPayload(p *api.PullRequestPayload, slack *SlackM
 
 func getSlackRepositoryPayload(p *api.RepositoryPayload, slack *SlackMeta) (*SlackPayload, error) {
 	senderLink := SlackLinkFormatter(setting.AppURL+p.Sender.UserName, p.Sender.UserName)
-	var text, title, attachmentText string
+	var text string
 
 	switch p.Action {
 	case api.HookRepoCreated:
 		text = fmt.Sprintf("[%s] Repository created by %s", p.Repository.FullName, senderLink)
-		title = p.Repository.HTMLURL
 	case api.HookRepoDeleted:
 		text = fmt.Sprintf("[%s] Repository deleted by %s", p.Repository.FullName, senderLink)
 	}
@@ -395,12 +396,6 @@ func getSlackRepositoryPayload(p *api.RepositoryPayload, slack *SlackMeta) (*Sla
 		Text:     text,
 		Username: slack.Username,
 		IconURL:  slack.IconURL,
-		Attachments: []SlackAttachment{{
-			Color:     slack.Color,
-			Title:     title,
-			TitleLink: title,
-			Text:      attachmentText,
-		}},
 	}, nil
 }
 


### PR DESCRIPTION
Backport to `release/v1.10`

This commit is not cherry-picked because the files moved between 1.10-1.11 but they are the same changes.