### PR TITLE
move fomantic target, update 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,11 @@ help:
 	@echo " - clean-all         delete all generated files (integration test, build, css and js files)"
 	@echo " - css               rebuild only css files"
 	@echo " - js                rebuild only js files"
-	@echo " - generate          run \"make css js\" and \"go generate\""
+	@echo " - fomantic          rebuild fomantic-ui files"
+	@echo " - generate          run \"make fomantic css js\" and \"go generate\""
 	@echo " - fmt               format the code"
 	@echo " - generate-swagger  generate the swagger spec from code comments"
-	@echo " - swagger-validate  check if the swagger spec is valide"
+	@echo " - swagger-validate  check if the swagger spec is valid"
 	@echo " - revive            run code linter revive"
 	@echo " - misspell          check if a word is written wrong"
 	@echo " - vet               examines Go source code and reports suspicious constructs"
@@ -159,7 +160,7 @@ vet:
 	$(GO) vet $(PACKAGES)
 
 .PHONY: generate
-generate: js css
+generate: fomantic js css
 	GO111MODULE=on $(GO) generate -mod=vendor $(PACKAGES)
 
 .PHONY: generate-swagger
@@ -475,7 +476,7 @@ npm-update: node-check node_modules
 	npm install --package-lock
 
 .PHONY: js
-js: node-check fomantic $(JS_DEST)
+js: node-check $(JS_DEST)
 
 $(JS_DEST): node_modules $(JS_SOURCES)
 	npx eslint web_src/js webpack.config.js
@@ -489,7 +490,7 @@ $(FOMANTIC_DEST_DIR): node_modules semantic.json web_src/fomantic/theme.config.l
 	npx gulp -f node_modules/fomantic-ui/gulpfile.js build
 
 .PHONY: css
-css: node-check fomantic $(CSS_DEST)
+css: node-check $(CSS_DEST)
 
 $(CSS_DEST): node_modules $(CSS_SOURCES)
 	npx stylelint web_src/less


### PR DESCRIPTION
I'd like to run webpack without fomantic in the prereqs so move it to the `generate` target.

I can see why @lunny added it to js/css but I think it's better for now to separate those to be able to individually call those steps.