### PR TITLE
WIP: Sign Email

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -630,6 +630,10 @@ MAILER_TYPE = smtp
 SENDMAIL_PATH = sendmail
 ; Specify any extra sendmail arguments
 SENDMAIL_ARGS =
+; Signing key
+SIGNING_KEY=default
+; Sign emails
+SIGN_EMAILS=false
 
 [cache]
 ; Either "memory", "redis", or "memcache", default is "memory"

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -380,6 +380,8 @@ relation to port exhaustion.
 - `SENDMAIL_PATH`: **sendmail**: The location of sendmail on the operating system (can be
    command or full path).
 - ``IS_TLS_ENABLED`` :  **false** : Decide if SMTP connections should use TLS.
+- `SIGNING_KEY`: **default**: \[none, KEYID, default \]: Key to sign with.
+- `SIGN_EMAILS`: **false**: Sign emails with signing key.
 
 ## Cache (`cache`)
 

--- a/modules/setting/mailer.go
+++ b/modules/setting/mailer.go
@@ -37,6 +37,10 @@ type Mailer struct {
 	// Sendmail sender
 	SendmailPath string
 	SendmailArgs []string
+
+	// Signing & Encryption
+	SigningKey string
+	SignEmails bool
 }
 
 var (
@@ -70,6 +74,9 @@ func newMailService() {
 		SubjectPrefix:  sec.Key("SUBJECT_PREFIX").MustString(""),
 
 		SendmailPath: sec.Key("SENDMAIL_PATH").MustString("sendmail"),
+
+		SigningKey: sec.Key("SIGNING_KEY").MustString("default"),
+		SignEmails: sec.Key("SIGN_EMAILS").MustBool(false),
 	}
 	MailService.From = sec.Key("FROM").MustString(MailService.User)
 

--- a/services/mailer/mailer.go
+++ b/services/mailer/mailer.go
@@ -29,7 +29,7 @@ import (
 )
 
 func clearSignedMessage(body string) string {
-	if setting.MailService.SignEmails == false || setting.MailService.SigningKey == "none" {
+	if !setting.MailService.SignEmails || setting.MailService.SigningKey == "none" {
 		return body
 	}
 
@@ -48,7 +48,7 @@ func clearSignedMessage(body string) string {
 }
 
 func detachedSignature(body string) string {
-	if setting.MailService.SignEmails == false || setting.MailService.SigningKey == "none" {
+	if !setting.MailService.SignEmails || setting.MailService.SigningKey == "none" {
 		return body
 	}
 


### PR DESCRIPTION
This provides a mechanism for signing email from the gitea server with a GPG key.

There is a slight inefficiency with emails sent to participants of an issue - whereby the signature is generated for each message in turn - because they get sent as individual messages.

Related #4398 