### PR TITLE
Style blockquote for default issue mail template

### DIFF
--- a/templates/mail/issue/default.tmpl
+++ b/templates/mail/issue/default.tmpl
@@ -5,6 +5,7 @@
 	<title>{{.Subject}}</title>
 
 	<style>
+		blockquote { padding-left: 1em; margin: 1em 0; border-left: 1px solid grey; color: #777}
 		.footer { font-size:small; color:#666;}
 		{{if .ReviewComments}}
 			.review { padding-left: 1em; margin: 1em 0; }


### PR DESCRIPTION
Style blockquotes as one might expect for html email to disinguish them from other text

Before:
<img width="712" alt="Screen Shot 2020-01-27 at 2 00 18 PM" src="https://user-images.githubusercontent.com/1669571/73204671-5b474880-410d-11ea-816b-3f1a64ce8726.png">
After:
<img width="722" alt="Screen Shot 2020-01-27 at 2 00 37 PM" src="https://user-images.githubusercontent.com/1669571/73204696-669a7400-410d-11ea-80f5-27b2b9e7a953.png">
