### PR TITLE
fix gitgraph commit hashes in dark theme

### DIFF
--- a/templates/pwa/serviceworker_js.tmpl
+++ b/templates/pwa/serviceworker_js.tmpl
@@ -19,8 +19,6 @@ var urlsToCache = [
   '{{StaticUrlPrefix}}/vendor/plugins/vue/vue.min.js',
 
   // css
-  '{{StaticUrlPrefix}}/css/gitgraph.css',
-  '{{StaticUrlPrefix}}/css/highlight.css',
   '{{StaticUrlPrefix}}/css/index.css?v={{MD5 AppVer}}',
   '{{StaticUrlPrefix}}/css/swagger.css?v={{MD5 AppVer}}',
   '{{StaticUrlPrefix}}/fomantic/semantic.min.css?v={{MD5 AppVer}}',

--- a/web_src/js/gitGraphLoader.js
+++ b/web_src/js/gitGraphLoader.js
@@ -2,10 +2,7 @@ $(async () => {
   const graphCanvas = document.getElementById('graph-canvas');
   if (!graphCanvas) return;
 
-  const [{ default: gitGraph }] = await Promise.all([
-    import(/* webpackChunkName: "gitgraph" */'./gitGraph.js'),
-    import(/* webpackChunkName: "gitgraph" */'../css/gitGraph.css'),
-  ]);
+  const { default: gitGraph } = await import(/* webpackChunkName: "gitgraph" */'./gitGraph.js');
 
   const graphList = [];
   $('#graph-raw-list li span.node-relation').each(function () {

--- a/web_src/less/index.less
+++ b/web_src/less/index.less
@@ -14,3 +14,4 @@
 @import "_explore";
 @import "_review";
 @import "~highlight.js/styles/github.css";
+@import "../css/gitGraph.css";


### PR DESCRIPTION
because the CSS was lazy-loaded the rules in arc-green did not win. included the css file in the main bundle to fix. the black dots can not be fixed via CSS because they are drawn in a `<canvas>` 
element unfortunately.

Before:
<img width="124" src="https://user-images.githubusercontent.com/115237/73308557-d2b9cc80-4220-11ea-909e-2f2b289f7e3e.png">

After:
<img width="117" src="https://user-images.githubusercontent.com/115237/73308612-f41ab880-4220-11ea-9b47-f677280fe08b.png">


