### PR TITLE
Remove unused session config on UI

### DIFF
--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -281,8 +281,6 @@
 				<dd>{{.SessionConfig.Maxlifetime}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
 				<dt>{{.i18n.Tr "admin.config.https_only"}}</dt>
 				<dd><i class="fa fa{{if .SessionConfig.Secure}}-check{{end}}-square-o"></i></dd>
-				<dt>{{.i18n.Tr "admin.config.cookie_life_time"}}</dt>
-				<dd>{{.SessionConfig.CookieLifeTime}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
 			</dl>
 		</div>
 


### PR DESCRIPTION
Fixes #10073 
Caused by #10050 so no backport needed.

This isn't used anywhere in the code-base as far as I can tell. It's not even a config option, and Macaron default is 0.

I left the translation in our locales in case it's ever used in the future, but simply removing it from this template fixes the error.