### PR TITLE
Add warning when using relative path to app.ini

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -511,6 +511,7 @@ func SetCustomPathAndConf(providedCustom, providedConf, providedWorkPath string)
 		CustomConf = path.Join(CustomPath, "conf/app.ini")
 	} else if !filepath.IsAbs(CustomConf) {
 		CustomConf = path.Join(CustomPath, CustomConf)
+		log.Warn("Using 'custom' directory as relative origin for configuration file: '%s'", CustomConf)
 	}
 }
 


### PR DESCRIPTION
Mitigation for #10082 

```
$ gitea --config ./app.ini doctor
2020/02/01 18:35:38 ...s/setting/setting.go:514:SetCustomPathAndConf() [W] Using 'custom' directory as relative origin for configuration file: '/home/user/custom/app.ini'
2020/02/01 18:35:38 ...s/setting/setting.go:514:SetCustomPathAndConf() [W] Using 'custom' directory as relative origin for configuration file: '/home/user/custom/app.ini'
[ 1 ] Check paths and basic configuration
- Failed to find configuration file at '/home/user/custom/app.ini'.
- If you've never ran Gitea yet, this is normal and '/home/user/custom/app.ini' will be created for you on first run.
- Otherwise check that you are running this command from the correct path and/or provide a `--config` parameter.
Error: can't proceed without a configuration file
$
```

It beats me why it's showing the warning twice, but I don't think it's too important.

Notice: this warning will be showing in hooks too.