### PR TITLE
Show if a PR has conflicting files on the PR lists

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1066,6 +1066,7 @@ pulls.blocked_by_rejection = "This Pull Request has changes requested by an offi
 pulls.can_auto_merge_desc = This pull request can be merged automatically.
 pulls.cannot_auto_merge_desc = This pull request cannot be merged automatically due to conflicts.
 pulls.cannot_auto_merge_helper = Merge manually to resolve the conflicts.
+pulls.num_conflicting_files = "%d conflicting files"
 pulls.no_merge_desc = This pull request cannot be merged because all repository merge options are disabled.
 pulls.no_merge_helper = Enable merge options in the repository settings or merge the pull request manually.
 pulls.no_merge_wip = This pull request can not be merged because it is marked as being a work in progress.

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -212,9 +212,9 @@
 					<div class="ui {{if .IsClosed}}{{if .IsPull}}{{if .PullRequest.HasMerged}}purple{{else}}red{{end}}{{else}}red{{end}}{{else}}{{if .IsRead}}white{{else}}green{{end}}{{end}} label">#{{.Index}}</div>
 					<a class="title has-emoji" href="{{$.Link}}/{{.Index}}">{{.Title}}</a>
 
-                    {{if .IsPull }}
-                        {{if (index $.CommitStatus .PullRequest.ID)}}
-                            {{template "repo/commit_status" (index $.CommitStatus .PullRequest.ID)}}
+					{{if .IsPull }}
+						{{if (index $.CommitStatus .PullRequest.ID)}}
+							{{template "repo/commit_status" (index $.CommitStatus .PullRequest.ID)}}
 						{{end}}
 					{{end}}
 
@@ -266,6 +266,11 @@
 							<a class="ui right assignee poping up" href="{{.HomeLink}}" data-content="{{.Name}}" data-variation="inverted" data-position="left center">
 								<img class="ui avatar image" src="{{.RelAvatarLink}}">
 							</a>
+						{{end}}
+						{{if .IsPull}}
+							{{if (len .PullRequest.ConflictedFiles) gt 0}}
+								<span class="conflicting"><i class="octicon octicon-mirror"></i> {{$.i18n.Tr "repo.pulls.num_conflicting_files" (len .PullRequest.ConflictedFiles)}}</span>
+							{{end}}
 						{{end}}
 					</p>
 				</li>

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -91,11 +91,11 @@
 							<div class="ui label">{{.Repo.FullName}}#{{.Index}}</div>
 							<a class="title has-emoji" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Title}}</a>
 
-                            {{if .IsPull }}
-                                {{if (index $.CommitStatus .PullRequest.ID)}}
-                                    {{template "repo/commit_status" (index $.CommitStatus .PullRequest.ID)}}
-                                {{end}}
-                            {{end}}
+							{{if .IsPull}}
+									{{if (index $.CommitStatus .PullRequest.ID)}}
+											{{template "repo/commit_status" (index $.CommitStatus .PullRequest.ID)}}
+									{{end}}
+							{{end}}
 
 							{{with .Labels}}
 								{{/* If we have any labels, we should show them
@@ -150,6 +150,11 @@
 									<span class="due-date poping up" data-content="{{$.i18n.Tr "repo.issues.due_date"}}" data-variation="tiny inverted" data-position="right center">
 										<span class="octicon octicon-calendar"></span><span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
 									</span>
+								{{end}}
+								{{if .IsPull}}
+									{{if (len .PullRequest.ConflictedFiles) gt 0}}
+										<span class="conflicting"><i class="octicon octicon-mirror"></i> {{$.i18n.Tr "repo.pulls.num_conflicting_files" (len .PullRequest.ConflictedFiles)}}</span>
+									{{end}}
 								{{end}}
 							</p>
 						</li>

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2125,6 +2125,10 @@
                 }
             }
 
+            .conflicting {
+                padding-left: 5px;
+            }
+
             .due-date {
                 padding-left: 5px;
             }


### PR DESCRIPTION
As hinted in #8659, this PR adds a simple message to PR lists if a PR has conflicting files. This is all achieved through tweaks to templates - `ConflictingFiles` array already exists on PR objects. I've chosen mirror as the octicon but I'm sure there's a better one!

![image](https://user-images.githubusercontent.com/7294642/73675712-d929c780-46aa-11ea-8f60-c3fe03da3644.png)
