### PR TITLE
Fix topics dropdown

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3329,7 +3329,7 @@ function initTopicbar() {
       label: 'ui small label'
     },
     apiSettings: {
-      url: `${suburl}/api/v1/topics/search?q={encodeURIComponent(query)}`,
+      url: `${suburl}/api/v1/topics/search?q={query}`,
       throttle: 500,
       cache: false,
       onResponse(res) {


### PR DESCRIPTION
Fixes #10160

Related to fomantic switch, so needs a backport as well.

Note that `{variable}` is semantic syntax, not JS `${variable}`