### PR TITLE
Fix commit view

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2534,7 +2534,7 @@ td.blob-excerpt {
 }
 
 .diff-file-box[data-folded="true"] .diff-file-body {
-    visibility: hidden;
+    display: none;
 }
 
 .diff-file-box[data-folded="true"] .diff-file-header {


### PR DESCRIPTION
I'm guessing it fixes #10163 and it was mis-reported, but I could be wrong.

Unsure about the effect on a11y, but `visibility: hidden` doesn't "reclaim" space and so effectively didn't do what collapse is intended for.