### PR TITLE
Update arc-green blob-excerpt

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1476,3 +1476,7 @@ a.ui.labels .label:hover {
         background-color: #383c4a;
     }
 }
+
+td.blob-excerpt {
+    background-color: #2e323e;
+}


### PR DESCRIPTION
Fix #10179 

It uses the same idea as `gitea` theme by making the excerpt the same color as the line number side-bar. On `arc-green` it doesn't stand out as much, but it's noticeable enough imo.  
Feel free to suggest changes.

![blob-excerpt](https://user-images.githubusercontent.com/42128690/74051280-44221980-499d-11ea-95a2-b02d73afff2f.png)
