### PR TITLE
modules/log: remove noop written variables

### DIFF
--- a/modules/log/conn_test.go
+++ b/modules/log/conn_test.go
@@ -27,8 +27,6 @@ func listenReadAndClose(t *testing.T, l net.Listener, expected string) {
 }
 
 func TestConnLogger(t *testing.T) {
-	var written []byte
-
 	protocol := "tcp"
 	address := ":3099"
 
@@ -78,8 +76,6 @@ func TestConnLogger(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	wg.Wait()
-
-	written = written[:0]
 
 	event.level = WARN
 	expected = fmt.Sprintf("%s%s %s:%d:%s [%c] %s\n", prefix, dateString, event.filename, event.line, event.caller, strings.ToUpper(event.level.String())[0], event.msg)
@@ -156,8 +152,6 @@ func TestConnLoggerFailConnect(t *testing.T) {
 }
 
 func TestConnLoggerClose(t *testing.T) {
-	var written []byte
-
 	protocol := "tcp"
 	address := ":3099"
 
@@ -216,8 +210,6 @@ func TestConnLoggerClose(t *testing.T) {
 	assert.Equal(t, flags, connLogger.Flags)
 	assert.Equal(t, level, connLogger.Level)
 	assert.Equal(t, level, logger.GetLevel())
-
-	written = written[:0]
 
 	event.level = WARN
 	expected = fmt.Sprintf("%s%s %s:%d:%s [%c] %s\n", prefix, dateString, event.filename, event.line, event.caller, strings.ToUpper(event.level.String())[0], event.msg)


### PR DESCRIPTION
This removes the `written` byteslice from `TestConnLogger()` and `TestConnLoggerClose()`, where it was doing nothing.