### PR TITLE
Fix milestones with too many repos

### DIFF
--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -528,12 +528,10 @@ func DeleteMilestoneByRepoID(repoID, id int64) error {
 // CountMilestonesByRepoIDs map from repoIDs to number of milestones matching the options`
 func CountMilestonesByRepoIDs(repoIDs []int64, isClosed bool) (map[int64]int64, error) {
 
-	const chunkSize = 200
-
 	countMap := make(map[int64]int64, 50)
 
 	for i := 0; i < len(repoIDs); {
-		chunk := i + chunkSize
+		chunk := i + maxQueryParameters
 		if chunk > len(repoIDs) {
 			chunk = len(repoIDs)
 		}
@@ -561,7 +559,7 @@ func CountMilestonesByRepoIDs(repoIDs []int64, isClosed bool) (map[int64]int64, 
 
 // GetMilestonesByRepoIDs returns a list of milestones of given repositories and status.
 func GetMilestonesByRepoIDs(repoIDs []int64, page int, isClosed bool, sortType string) (MilestoneList, error) {
-	if len(repoIDs) <= 200 {
+	if len(repoIDs) <= maxQueryParameters {
 		return getMilestonesByRepoIDs(x.In("repo_id", repoIDs), page, isClosed, sortType)
 	}
 
@@ -620,12 +618,10 @@ type MilestonesStats struct {
 
 // GetMilestonesStats returns milestone statistic information for dashboard by given conditions.
 func GetMilestonesStats(userRepoIDs []int64) (*MilestonesStats, error) {
-	const chunkSize = 200
-
 	stats := &MilestonesStats{}
 
 	for i := 0; i < len(userRepoIDs); {
-		chunk := i + chunkSize
+		chunk := i + maxQueryParameters
 		if chunk > len(userRepoIDs) {
 			chunk = len(userRepoIDs)
 		}

--- a/models/issue_milestone.go
+++ b/models/issue_milestone.go
@@ -528,7 +528,7 @@ func DeleteMilestoneByRepoID(repoID, id int64) error {
 // CountMilestonesByRepoIDs map from repoIDs to number of milestones matching the options`
 func CountMilestonesByRepoIDs(repoIDs []int64, isClosed bool) (map[int64]int64, error) {
 
-	const chunkSize = 1 // GAP
+	const chunkSize = 200
 
 	countMap := make(map[int64]int64, 50)
 
@@ -561,7 +561,7 @@ func CountMilestonesByRepoIDs(repoIDs []int64, isClosed bool) (map[int64]int64, 
 
 // GetMilestonesByRepoIDs returns a list of milestones of given repositories and status.
 func GetMilestonesByRepoIDs(repoIDs []int64, page int, isClosed bool, sortType string) (MilestoneList, error) {
-	if len(repoIDs) <= 1 { // GAP
+	if len(repoIDs) <= 200 {
 		return getMilestonesByRepoIDs(x.In("repo_id", repoIDs), page, isClosed, sortType)
 	}
 
@@ -620,7 +620,7 @@ type MilestonesStats struct {
 
 // GetMilestonesStats returns milestone statistic information for dashboard by given conditions.
 func GetMilestonesStats(userRepoIDs []int64) (*MilestonesStats, error) {
-	const chunkSize = 1 // GAP
+	const chunkSize = 200
 
 	stats := &MilestonesStats{}
 

--- a/models/models.go
+++ b/models/models.go
@@ -48,6 +48,12 @@ type Engine interface {
 	SumInt(bean interface{}, columnName string) (res int64, err error)
 }
 
+const (
+	// When queries are broken down in parts because of the number
+	// of parameters, attempt to break by this amount
+	maxQueryParameters = 300
+)
+
 var (
 	x      *xorm.Engine
 	tables []interface{}

--- a/models/temp_table.go
+++ b/models/temp_table.go
@@ -15,9 +15,9 @@ import (
 
 var tempTableSequence uint64
 
-// createSimpleTemporaryTable will create a temporary table with the given
-// name template and column definitions; it returns the actual name used
-// and a cleanup function.
+// createSimpleTemporaryTable creates a temporary table with the given
+// column definitions and a random name; it returns the generated name
+// and a cleanup function (which is of optional execution).
 func createSimpleTemporaryTable(sess *xorm.Session, columns string) (string, func() error, error) {
 
 	var name, create, drop string
@@ -47,7 +47,10 @@ func createSimpleTemporaryTable(sess *xorm.Session, columns string) (string, fun
 	return name, func() (err error) {
 		// Note: calling the cleanup function is optional
 		// as the temporary table will be dropped when the connection
-		// is reset for the next request.
+		// is reset for the next request. Calling this function
+		// is justified if many big temporary tables are expected
+		// to be generated within the same connection to free up
+		// space earlier.
 		_, err = sess.Exec(drop)
 		return
 	}, nil

--- a/models/temp_table.go
+++ b/models/temp_table.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"code.gitea.io/gitea/modules/setting"
+
+	"xorm.io/xorm"
+)
+
+var tempTableSequence uint64
+
+// createSimpleTemporaryTable will create a temporary table with the given
+// name template and column definitions; it returns the actual name used
+// and a cleanup function.
+func createSimpleTemporaryTable(sess *xorm.Session, columns string) (string, func() error, error) {
+
+	var name, create, drop string
+
+	seq := atomic.AddUint64(&tempTableSequence, 1)
+
+	switch {
+	case setting.Database.UseSQLite3:
+		name = fmt.Sprintf("temp.temp_table_%d", seq)
+		create = fmt.Sprintf("CREATE TABLE %s (%s)", name, columns)
+		drop = fmt.Sprintf("DROP TABLE %s", name)
+	case setting.Database.UseMSSQL:
+		name = fmt.Sprintf("#temp_table_%d", seq)
+		create = fmt.Sprintf("CREATE TABLE %s (%s)", name, columns)
+		drop = fmt.Sprintf("DROP TABLE %s", name)
+	default:
+		name = fmt.Sprintf("temp_table_%d", seq)
+		create = fmt.Sprintf("CREATE TEMPORARY TABLE %s (%s)", name, columns)
+		drop = fmt.Sprintf("DROP TEMPORARY TABLE %s", name)
+	}
+	_, err := sess.Exec(create)
+	if err != nil {
+		return "", func() error {
+			return nil
+		}, err
+	}
+	return name, func() (err error) {
+		// Note: calling the cleanup function is optional
+		// as the temporary table will be dropped when the connection
+		// is reset for the next request.
+		_, err = sess.Exec(drop)
+		return
+	}, nil
+}


### PR DESCRIPTION
This is my wild attempt of fixing #9841 to (hopefully) bring the release of 1.11.0 a little closer.

Just like the problem in #9755, we're attempting queries with too many parameters. This should be solvable by means of rewriting the query, but I found it very difficult in this case, so I attempted a different way instead:

- For statistics collection (e.g. counting records), break down the query in smaller chunks and accumulate the results (same solution as #10176).
- For the actual list of milestones (which is paginated), I've used a temporary table (a table that is dropped as soon as the connection is closed/reset).

So the concept is, instead of using the `IN (list of ids)` operator, I'm using `INNER JOIN` with a table containing my list of ids. I only attempt this if the list of ids is big enough.

To be honest, I just wanted to test the waters on using temporary tables, which I believe could prove useful in the future. This works just fine in all database engines, so in that regard I think it's a success.

There is room for improvement (for example, the temporary tables could be managed by xorm), but for the time being I'd like to hear your reactions. 😄

Fixes #9841