### PR TITLE
User contributed git hook scripts folder and script 'commit-current-user-check.sh' added

### DIFF
--- a/contrib/git/git-hook-scripts/README.md
+++ b/contrib/git/git-hook-scripts/README.md
@@ -8,24 +8,25 @@ Those scripts can either be used as local scripts the user can add to his reposi
 Those scripts can also appied to all newly created repositories by git automatically, when following these steps below.
 
 Note:<br />
-It is assumed that git runs as a non-priviledged user and a home directory was created for that user. In oder to execute the following shell commands, replace `<git-user>` with the real username git runs.
+Gitea runs git commands as user `RUN_USER` defined in Gitea configuration file. 
+In the following steps, it is assumed a home directory was created for that user and the global hook scripts shall be placed there. It is also possible to use a different path that is fully accessible by the `RUN_USER`. In order to execute the following shell commands, replace `<RUN_USER>` with the corresponding user name.
 
 1. Create the folders to store the global git hook scripts [needs only to be done once]:
     ```
-    sudo -S -u <git-user> mkdir -p ~/.git-templates/hooks/{pre-receive.d,post-receive.d,update.d}
+    sudo -S -u <RUN_USER> mkdir -p ~/.git-templates/hooks/{pre-receive.d,post-receive.d,update.d}
     ```
 
 1. Enable the global git templates and with it the hook scripts [needs only to be done once]:
     ```
-    sudo -S -u git git config --global init.templatedir '~/.git-templates'
+    sudo -S -u <RUN_USER> git config --global init.templatedir '~/.git-templates'
     ```
 
 1. Add the desired global hook scripts to the correct folders (this example uses `commit-current-user-check.sh`):
     ```
-    sudo -S -u git wget -O ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh https://github.com/go-gitea/gitea/raw/master/contrib/git/git-hook-scripts/pre-receive.d/commit-current-user-check.sh
+    sudo -S -u <RUN_USER> wget -O ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh https://github.com/go-gitea/gitea/raw/master/contrib/git/git-hook-scripts/pre-receive.d/commit-current-user-check.sh
     ```
 
 1. Make the script executable:
     ```
-    sudo -S -u git chmod 740 ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh
+    sudo -S -u <RUN_USER> chmod 740 ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh
     ```

--- a/contrib/git/git-hook-scripts/README.md
+++ b/contrib/git/git-hook-scripts/README.md
@@ -1,0 +1,31 @@
+# git hook scripts
+The subfolders contain common git hook scripts that were updated to be used directly with Gitea. If you are looking for scripts, you can have a look at [Github platform samples](https://github.com/github/platform-samples). If you have own scripts which are from general interest, feel free to share them here.
+
+### local/user scripts
+Those scripts can either be used as local scripts the user can add to his repository (if not disabled in Gitea configuration file).
+
+### global scripts
+Those scripts can also appied to all newly created repositories by git automatically, when following these steps below.
+
+Note:<br />
+It is assumed that git runs as a non-priviledged user and a home directory was created for that user. In oder to execute the following shell commands, replace `<git-user>` with the real username git runs.
+
+1. Create the folders to store the global git hook scripts [needs only to be done once]:
+    ```
+    sudo -S -u <git-user> mkdir -p ~/.git-templates/hooks/{pre-receive.d,post-receive.d,update.d}
+    ```
+
+1. Enable the global git templates and with it the hook scripts [needs only to be done once]:
+    ```
+    sudo -S -u git git config --global init.templatedir '~/.git-templates'
+    ```
+
+1. Add the desired global hook scripts to the correct folders (this example uses `commit-current-user-check.sh`):
+    ```
+    sudo -S -u git wget -O ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh https://github.com/go-gitea/gitea/raw/master/contrib/git/git-hook-scripts/pre-receive.d/commit-current-user-check.sh
+    ```
+
+1. Make the script executable:
+    ```
+    sudo -S -u git chmod 740 ~/.git-templates/hooks/pre-receive.d/commit-current-user-check.sh
+    ```

--- a/contrib/git/git-hook-scripts/pre-receive.d/README.md
+++ b/contrib/git/git-hook-scripts/pre-receive.d/README.md
@@ -1,0 +1,2 @@
+## commit-current-user-check.sh
+This hook script rejects all pushes where the autor or committer are not matching the current user.

--- a/contrib/git/git-hook-scripts/pre-receive.d/commit-current-user-check.sh
+++ b/contrib/git/git-hook-scripts/pre-receive.d/commit-current-user-check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Pre-receive hook that will reject all pushes where author or committer are not current user.
+# ref: https://github.com/github/platform-samples/blob/master/pre-receive-hooks/commit-current-user-check.sh
+
+# If we are on Gitea web interface then we don't need to bother to validate the commit user
+if [[ $SSH_ORIGINAL_COMMAND == "gitea-internal" ]]; then
+  exit $retval
+fi
+
+# the return value (bit-coded error information)
+retval=0
+
+zero_commit="0000000000000000000000000000000000000000"
+
+# Do not traverse over commits that are already in the repository
+# (e.g. in a different branch)
+# This prevents funny errors if pre-receive hooks got enabled after some
+# commits got already in and then somebody tries to create a new branch
+# If this is unwanted behavior, just set the variable to empty
+excludeExisting="--not --all"
+
+while read oldrev newrev refname; do
+  # branch or tag get deleted
+  if [ "$newrev" = "$zero_commit" ]; then
+    continue
+  fi
+
+  # Check for new branch or tag
+  if [ "$oldrev" = "$zero_commit" ]; then
+    span=`git rev-list $newrev $excludeExisting`
+  else
+    span=`git rev-list $oldrev..$newrev $excludeExisting`
+  fi
+
+  for COMMIT in $span;
+    do
+      AUTHOR_USER=`git log --format=%an -n 1 ${COMMIT}`
+      AUTHOR_EMAIL=`git log --format=%ae -n 1 ${COMMIT}`
+      COMMIT_USER=`git log --format=%cn -n 1 ${COMMIT}`
+      COMMIT_EMAIL=`git log --format=%ce -n 1 ${COMMIT}`
+
+      if [[ ${AUTHOR_USER} != ${GITEA_PUSHER_NAME} ]]; then
+        echo -e "ERROR: Commit author (${AUTHOR_USER}) does not match current user (${GITEA_PUSHER_NAME})"
+        retval=$((retval + 1))
+      fi
+
+      if [[ ${COMMIT_USER} != ${GITEA_PUSHER_NAME} ]]; then
+        echo -e "ERROR: Commit User (${COMMIT_USER}) does not match current user (${GITEA_PUSHER_NAME})"
+        retval=$((retval + 2))
+      fi
+
+      if [[ ${AUTHOR_EMAIL} != ${GITEA_PUSHER_EMAIL} ]]; then
+        echo -e "ERROR: Commit author's email (${AUTHOR_EMAIL}) does not match current user's email (${GITEA_PUSHER_EMAIL})"
+        retval=$((retval + 4))
+      fi
+
+      if [[ ${COMMIT_EMAIL} != ${GITEA_PUSHER_EMAIL} ]]; then
+        echo -e "ERROR: Commit user's email (${COMMIT_EMAIL}) does not match current user's email (${GITEA_PUSHER_EMAIL})"
+        retval=$((retval + 8))
+      fi
+  done
+done
+
+exit $retval


### PR DESCRIPTION
This pull request provides a first idea of a folder structure in `contrib` where user added git hook scripts can be stored.

In addition, the script 'commit-current-user-check.sh' is contributed which was adopted to be used with Gitea.