### PR TITLE
Improve 404 error message

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -79,6 +79,8 @@ write = Write
 preview = Preview
 loading = Loading…
 
+error404 = The page you are trying to reach either <strong>does not exist</strong> or <strong>you are not authorized</strong> to view it.
+
 [startpage]
 app_desc = A painless, self-hosted Git service
 install = Easy to install

--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -4,6 +4,7 @@
 	<p style="margin-top: 100px"><img src="{{StaticUrlPrefix}}/img/404.png" alt="404"/></p>
 	<div class="ui divider"></div>
 	<br>
+	<p>{{.i18n.Tr "error404" | Safe}}
 	{{if .ShowFooterVersion}}<p>Application Version: {{AppVer}}</p>{{end}}
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
Since `404` does not exactly mean "page not found" as it should, I thought it would be nice to add some clarification about the error message for better usability.

![image](https://user-images.githubusercontent.com/18600385/74177520-a5095600-4c18-11ea-9774-9673b742740c.png)
