### PR TITLE
Fix issue sidebar menus having an infinite height

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -7,7 +7,7 @@
 				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 				{{svg "octicon-gear" 16}}
 			</span>
-			<div class="filter menu labels" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
+			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 				{{range .Labels}}
 					<a class="{{if .IsChecked}}checked{{end}} item has-emoji" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name}}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -152,8 +152,6 @@
         }
 
         &.labels {
-            max-height: 300px;
-
             .label-filter .menu .info {
                 display: inline-block;
                 padding: 9px 7px 7px 7px;

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -83,6 +83,7 @@
     .metas {
         .menu {
             overflow-x: auto;
+            max-height: 300px;
         }
 
         .ui.list {


### PR DESCRIPTION
A partial revert of #10216, yet still an attempt at fixing #10218. This PR sets the `max-height` property to a different selector so it fixes the assignee menu too.

Before:
![image](https://user-images.githubusercontent.com/7294642/74274266-bbdba580-4d09-11ea-8221-5727fa5adcba.png)

After:
![image](https://user-images.githubusercontent.com/7294642/74274299-cd24b200-4d09-11ea-9b42-d50eff544e9c.png)

I'm willing to create a backport for v1.11, as it is quite noticetable on my production instance! 😄 