### PR TITLE
Backport - Fix issue sidebar menus having an infinite height

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -89,6 +89,7 @@
     .metas {
         .menu {
             overflow-x: auto;
+            max-height: 300px;
         }
 
         .ui.list {


### PR DESCRIPTION
A backport of #10239 to fix #10218.