### PR TITLE
Index code and stats only for non-empty repositories

### DIFF
--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -4,6 +4,7 @@
   owner_name: user2
   lower_name: repo1
   name: repo1
+  is_empty: false
   is_private: false
   num_issues: 2
   num_closed_issues: 1

--- a/modules/indexer/stats/queue.go
+++ b/modules/indexer/stats/queue.go
@@ -14,7 +14,7 @@ import (
 )
 
 // statsQueue represents a queue to handle repository stats updates
-var statsQueue queue.Queue
+var statsQueue queue.UniqueQueue
 
 // handle passed PR IDs and test the PRs
 func handle(data ...queue.Data) {
@@ -27,7 +27,7 @@ func handle(data ...queue.Data) {
 }
 
 func initStatsQueue() error {
-	statsQueue = queue.CreateQueue("repo_stats_update", handle, int64(0)).(queue.Queue)
+	statsQueue = queue.CreateUniqueQueue("repo_stats_update", handle, int64(0)).(queue.UniqueQueue)
 	if statsQueue == nil {
 		return fmt.Errorf("Unable to create repo_stats_update Queue")
 	}


### PR DESCRIPTION
Optimizes to not add empty repositories to indexing queue

Also switch language stats calculation queue to unique queue as there is no point to recalculate stats for same repo multiple times

Fixes #10246