### PR TITLE
Fix Workerpool deadlock (#10283)

### DIFF
--- a/modules/queue/queue_channel_test.go
+++ b/modules/queue/queue_channel_test.go
@@ -25,12 +25,13 @@ func TestChannelQueue(t *testing.T) {
 
 	queue, err := NewChannelQueue(handle,
 		ChannelQueueConfiguration{
-			QueueLength:  20,
-			Workers:      1,
+			QueueLength:  0,
 			MaxWorkers:   10,
 			BlockTimeout: 1 * time.Second,
 			BoostTimeout: 5 * time.Minute,
 			BoostWorkers: 5,
+			Workers:      0,
+			Name:         "TestChannelQueue",
 		}, &testData{})
 	assert.NoError(t, err)
 

--- a/modules/queue/workerpool.go
+++ b/modules/queue/workerpool.go
@@ -96,8 +96,8 @@ func (p *WorkerPool) pushBoost(data Data) {
 				p.blockTimeout /= 2
 				p.lock.Unlock()
 			}()
-			p.addWorkers(ctx, boost)
 			p.lock.Unlock()
+			p.addWorkers(ctx, boost)
 			p.dataChan <- data
 		}
 	}


### PR DESCRIPTION
Backport #10283 

* Prevent deadlock on boost
* Force a boost in testchannelqueue
