### PR TITLE
make/pr: enforce vendor for run

### DIFF
--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -250,7 +250,7 @@ func main() {
 	//Force build of js, css, bin, ...
 	runCmd("make", "build")
 	//Start with integration test
-	runCmd("go", "run", "-tags", "sqlite sqlite_unlock_notify", codeFilePath, "-run")
+	runCmd("go", "run", "-mod", "vendor", "-tags", "sqlite sqlite_unlock_notify", codeFilePath, "-run")
 }
 func runCmd(cmd ...string) {
 	log.Printf("Executing : %s ...\n", cmd)


### PR DESCRIPTION
Enforce the use of the vendor folder for `make pr` for the run step