### PR TITLE
ui: improve mobile review-box sizing

### DIFF
--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -132,3 +132,14 @@
 .ui.blob-excerpt:hover {
     color: #428bca;
 }
+
+@media only screen and (max-width: 768px) {
+    #review-box > .menu {
+        > .ui.segment {
+            width: 94vw;
+        }
+        .editor-toolbar {
+            overflow-x: auto;
+        }
+    }
+}


### PR DESCRIPTION
On mobile, review is not possible because the button are on the left out of the screen.
This PR is using viewport unit for sizing the review-box.
(which is supported on most browser now https://caniuse.com/#feat=viewport-units)
This also add a scrollbar if needed to the editor bar.

<details>
<summary>After</summary>
<h4>On small screen the review box is kept inside the viewport:</h4>
<img src="https://user-images.githubusercontent.com/4052400/74607990-b4d3df00-50dd-11ea-87ad-0153779a34fa.png" />
<img src="https://user-images.githubusercontent.com/4052400/74607984-a71e5980-50dd-11ea-9ae5-69c77cc7b53e.png" />

<h4>On full screen nothing change:</h4>
<img src="https://user-images.githubusercontent.com/4052400/74607936-573f9280-50dd-11ea-9660-7c7547e3abf1.png" />
<img src="https://user-images.githubusercontent.com/4052400/74607953-763e2480-50dd-11ea-8cb9-f8869efc541a.png" />

</details>


<details>
<summary>Before</summary>
<h4>On small screen the review box is was outside the viewport:</h4>
<img src="https://user-images.githubusercontent.com/4052400/74608048-44798d80-50de-11ea-8e97-cb867e2b764d.png" />
<img src="https://user-images.githubusercontent.com/4052400/74608057-53604000-50de-11ea-904d-1d4e10da8232.png" />

<h4>On full screen nothing change:</h4>
<img src="https://user-images.githubusercontent.com/4052400/74608097-86a2cf00-50de-11ea-8b9c-e3ac03f47e65.png" />
<img src="https://user-images.githubusercontent.com/4052400/74608081-77238600-50de-11ea-9c1e-24b727b82568.png" />
</details>