### PR TITLE
Truncate long commit message header

### DIFF
--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -6,7 +6,7 @@
 			<a class="ui floated right blue tiny button" href="{{EscapePound .SourcePath}}">
 				{{.i18n.Tr "repo.diff.browse_source"}}
 			</a>
-			<h3 class="has-emoji">{{RenderCommitMessage .Commit.Message $.RepoLink $.Repository.ComposeMetas}}{{template "repo/commit_status" .CommitStatus}}</h3>
+			<h3 class="has-emoji"><span class="message-wrapper"><span class="commit-summary" title="{{.Commit.Summary}}">{{RenderCommitMessage .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</span></span>{{template "repo/commit_status" .CommitStatus}}</h3>
 			{{if IsMultilineCommitMessage .Commit.Message}}
 				<pre class="commit-body">{{RenderCommitBody .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>
 			{{end}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -29,7 +29,7 @@
 				</a>
 				{{template "repo/commit_status" .LatestCommitStatus}}
 				{{ $commitLink:= printf "%s/commit/%s" .RepoLink .LatestCommit.ID }}
-				<span class="grey has-emoji commit-summary" title="{{.LatestCommit.Summary}}"><span class="message-wrapper" style="width: min(calc((max(100vw, 768px) - 768px) * 800 + 20rem), calc((max(100vw, 992px) - 992px) * 800 + 360px), calc((max(100vw, 1200px) - 1200px) * 800 + 500px), calc((min(100vw, 1200px) - 1200px) * (0 - 800) + 700px));">{{RenderCommitMessageLinkSubject .LatestCommit.Message $.RepoLink $commitLink $.Repository.ComposeMetas}}</span>
+				<span class="grey has-emoji commit-summary" title="{{.LatestCommit.Summary}}"><span class="message-wrapper">{{RenderCommitMessageLinkSubject .LatestCommit.Message $.RepoLink $commitLink $.Repository.ComposeMetas}}</span>
 				{{if IsMultilineCommitMessage .LatestCommit.Message}}
 					<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
 					<pre class="commit-body" style="display: none;">{{RenderCommitBody .LatestCommit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -29,7 +29,7 @@
 				</a>
 				{{template "repo/commit_status" .LatestCommitStatus}}
 				{{ $commitLink:= printf "%s/commit/%s" .RepoLink .LatestCommit.ID }}
-				<span class="grey has-emoji commit-summary" title="{{.LatestCommit.Summary}}">{{RenderCommitMessageLinkSubject .LatestCommit.Message $.RepoLink $commitLink $.Repository.ComposeMetas}}
+				<span class="grey has-emoji commit-summary" title="{{.LatestCommit.Summary}}"><span class="message-wrapper" style="width: min(calc((max(100vw, 768px) - 768px) * 800 + 20rem), calc((max(100vw, 992px) - 992px) * 800 + 360px), calc((max(100vw, 1200px) - 1200px) * 800 + 500px), calc((min(100vw, 1200px) - 1200px) * (0 - 800) + 700px));">{{RenderCommitMessageLinkSubject .LatestCommit.Message $.RepoLink $commitLink $.Repository.ComposeMetas}}</span>
 				{{if IsMultilineCommitMessage .LatestCommit.Message}}
 					<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
 					<pre class="commit-body" style="display: none;">{{RenderCommitBody .LatestCommit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2397,7 +2397,7 @@ tbody.commit-list {
     }
     th .message-wrapper {
         display: block;
-        max-width: 90vw;
+        max-width: calc(100vw - 70px);
     }
 }
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2396,7 +2396,8 @@ tbody.commit-list {
         width: 100%;
     }
     th .message-wrapper {
-        max-width: 200px;
+        display: block;
+        max-width: 90vw;
     }
 }
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2383,7 +2383,7 @@ tbody.commit-list {
     vertical-align: baseline;
 }
 
-.commit-list .message-wrapper {
+.message-wrapper {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: calc(100% - 50px);

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2392,26 +2392,38 @@ tbody.commit-list {
 }
 
 @media only screen and (max-width: 767.98px) {
+    tr.commit-list {
+        width: 100%;
+    }
     th .message-wrapper {
-        width: 200px;
+        max-width: 200px;
     }
 }
 
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
+    tr.commit-list {
+        width: 723px;
+    }
     th .message-wrapper {
-        width: 300px;
+        max-width: 280px;
     }
 }
 
 @media only screen and (min-width: 992px) and (max-width: 1199.98px) {
+    tr.commit-list {
+        width: 933px;
+    }
     th .message-wrapper {
-        width: 500px;
+        max-width: 490px;
     }
 }
 
 @media only screen and (min-width: 1200px) {
+    tr.commit-list {
+        width: 1127px;
+    }
     th .message-wrapper {
-        width: 700px;
+        max-width: 680px;
     }
 }
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2391,6 +2391,30 @@ tbody.commit-list {
     vertical-align: middle;
 }
 
+@media only screen and (max-width: 767.98px) {
+    th .message-wrapper {
+        width: 200px;
+    }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 991.98px) {
+    th .message-wrapper {
+        width: 300px;
+    }
+}
+
+@media only screen and (min-width: 992px) and (max-width: 1199.98px) {
+    th .message-wrapper {
+        width: 500px;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    th .message-wrapper {
+        width: 700px;
+    }
+}
+
 .commit-list .commit-summary a {
     text-decoration: underline;
     text-decoration-style: dashed;


### PR DESCRIPTION
* Make the message-wrapper style no longer require being inside a commit-list.
* Wrap the header on the commit page in a message-wrapper

Fix #8900 
Fix #10209 