### PR TITLE
fix: set explicit POSTGRES_PASSWORD for pgsql on drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -229,6 +229,7 @@ services:
     image: postgres:9.5
     environment:
       POSTGRES_DB: test
+      POSTGRES_PASSWORD: postgres
 
   - name: ldap
     pull: default


### PR DESCRIPTION
Since https://github.com/docker-library/postgres/pull/658 POSTGRES_PASSWORD need to be explicitly set. 

Currently this only impact build of https://github.com/go-gitea/gitea/pull/10294 but it should be the same on master when arm64 pull the new image.