### PR TITLE
fix: set explicit POSTGRES_PASSWORD for pgsql on drone CI #10302

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -232,6 +232,7 @@ services:
     image: postgres:9.5
     environment:
       POSTGRES_DB: test
+      POSTGRES_PASSWORD: postgres
 
   - name: ldap
     pull: default


### PR DESCRIPTION
Backport of #10302