### PR TITLE
Set the initial commit status to Success otherwise it will always be Pending

### DIFF
--- a/services/pull/commit_status.go
+++ b/services/pull/commit_status.go
@@ -23,7 +23,7 @@ func MergeRequiredContextsCommitStatus(commitStatuses []*models.CommitStatus, re
 		return structs.CommitStatusSuccess
 	}
 
-	var returnedStatus = structs.CommitStatusPending
+	var returnedStatus = structs.CommitStatusSuccess
 	for _, ctx := range requiredContexts {
 		var targetStatus structs.CommitStatusState
 		for _, commitStatus := range commitStatuses {


### PR DESCRIPTION
The commit status code has a bug whereby setting the initial status to Pending means you can never have the status of Success - it should be set to Success.