### PR TITLE
Fix protected branch status check settings

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1116,7 +1116,7 @@ function initRepository() {
   // Branches
   if ($('.repository.settings.branches').length > 0) {
     initFilterSearchDropdown('.protected-branches .dropdown');
-    $('.enable-protection, .enable-whitelist').change(function () {
+    $('.enable-protection, .enable-whitelist, .enable-statuscheck').change(function () {
       if (this.checked) {
         $($(this).data('target')).removeClass('disabled');
       } else {


### PR DESCRIPTION
When enabling status checks in branch protection, currently you have to enable, save, _then_ check the required contexts and save again.

This PR enables selecting contexts at the same time as enabling the protection.