### PR TITLE
Reading pull attachments should depend on read UnitTypePullRequests (#10346)

### DIFF
--- a/models/attachment.go
+++ b/models/attachment.go
@@ -79,7 +79,11 @@ func (a *Attachment) LinkedRepository() (*Repository, UnitType, error) {
 			return nil, UnitTypeIssues, err
 		}
 		repo, err := GetRepositoryByID(iss.RepoID)
-		return repo, UnitTypeIssues, err
+		unitType := UnitTypeIssues
+		if iss.IsPull {
+			unitType = UnitTypePullRequests
+		}
+		return repo, unitType, err
 	} else if a.ReleaseID != 0 {
 		rel, err := GetReleaseByID(a.ReleaseID)
 		if err != nil {

--- a/models/attachment_test.go
+++ b/models/attachment_test.go
@@ -138,7 +138,7 @@ func TestLinkedRepository(t *testing.T) {
 		expectedUnitType UnitType
 	}{
 		{"LinkedIssue", 1, &Repository{ID: 1}, UnitTypeIssues},
-		{"LinkedComment", 3, &Repository{ID: 1}, UnitTypeIssues},
+		{"LinkedComment", 3, &Repository{ID: 1}, UnitTypePullRequests},
 		{"LinkedRelease", 9, &Repository{ID: 1}, UnitTypeReleases},
 		{"Notlinked", 10, nil, -1},
 	}


### PR DESCRIPTION
Backport #10346 

Make pull attachments depend on read UnitTypePullRequests
