### PR TITLE
WIP: Allow all characters in title attribute when rendering

### DIFF
--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -93,6 +93,12 @@ func TestRender_Images(t *testing.T) {
 	test(
 		"[!["+title+"]("+url+")]("+href+")",
 		`<p><a href="`+href+`" rel="nofollow"><img src="`+result+`" alt="`+title+`"/></a></p>`)
+	test(
+		"!["+title+"]("+url+" \"1 -> 2 -> 3 -> 4 -> 5\")",
+		`<p><a href="`+result+`" title="1 -&gt; 2 -&gt; 3 -&gt; 4 -&gt; 5" rel="nofollow"><img src="`+result+`" alt="`+title+`"/></a></p>`)
+	test(
+		"!["+title+"]("+url+" \"this?is#a!test:P\")",
+		`<p><a href="`+result+`" title="this?is#a!test:P" rel="nofollow"><img src="`+result+`" alt="`+title+`"/></a></p>`)
 }
 
 func testAnswers(baseURLContent, baseURLImages string) []string {

--- a/modules/markup/sanitizer.go
+++ b/modules/markup/sanitizer.go
@@ -56,6 +56,9 @@ func ReplaceSanitizer() {
 	// Allow classes for anchors
 	sanitizer.policy.AllowAttrs("class").Matching(regexp.MustCompile(`ref-issue`)).OnElements("a")
 
+	// Allow more characters in title attribute per commonmark spec
+	sanitizer.policy.AllowAttrs("title").Matching(regexp.MustCompile(`(.*?)`)).OnElements("a")
+
 	// Custom keyword markup
 	for _, rule := range setting.ExternalSanitizerRules {
 		if rule.Regexp != nil {


### PR DESCRIPTION
According to the common mark spec:

 https://spec.commonmark.org/0.29/#link-title

You should be able to stick abut anything in there. Right now we're
limited by the default setting of bluemonday which restricts what can go
in a title tag and makes our rendering not compliant with the spec.

This should fix #10326 

Marking WIP to discuss here. According to the commonmark spec just about anything should be allowed in a title attribute. Goldmark will escape things properly when generating links as in the example issue but of course you can just stick raw HTML in as well, try to abuse other links, etc...

Not able to cause problems in limited testing but others should try! FWIW Github seems to let you stick almost anything in there as well (also shown in the example).