### PR TITLE
Prevent Firefox from using apple-touch-icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,8 @@ coverage.all
 
 /bin
 /dist
-/custom
+!/custom/conf/app.ini
+/custom/*
 /data
 /indexers
 /log

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,10 @@ coverage.all
 
 /bin
 /dist
-!/custom/conf/app.ini
 /custom/*
+!/custom/conf
+/custom/conf/*
+!/custom/conf/app.ini.sample
 /data
 /indexers
 /log

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -217,7 +217,7 @@ FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
 PROTOCOL = http
 DOMAIN = localhost
 ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
-; when STATIC_URL_PREFIX is empty it will follow APP_URL
+; when STATIC_URL_PREFIX is empty it will follow ROOT_URL
 STATIC_URL_PREFIX =
 ; The address to listen on. Either a IPv4/IPv6 address or the path to a unix socket.
 HTTP_ADDR = 0.0.0.0

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -1002,6 +1002,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 		}
 	})
 
+	m.Get("/apple-touch-icon.png", func(ctx *context.Context) {
+		ctx.Redirect(path.Join(setting.StaticURLPrefix, "img/apple-touch-icon.png"), 301)
+	})
+
 	// Progressive Web App
 	m.Get("/manifest.json", templates.JSONRenderer(), func(ctx *context.Context) {
 		ctx.HTML(200, "pwa/manifest_json")

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -96,7 +96,6 @@
 		};
 	</script>
 	<link rel="shortcut icon" href="{{StaticUrlPrefix}}/img/favicon.png">
-	<link rel="apple-touch-icon" href="{{StaticUrlPrefix}}/img/apple-touch-icon.png">
 	<link rel="mask-icon" href="{{StaticUrlPrefix}}/img/gitea-safari.svg" color="#609926">
 	<link rel="stylesheet" href="{{StaticUrlPrefix}}/vendor/assets/font-awesome/css/font-awesome.min.css">
 	<link rel="preload" as="font" href="{{StaticUrlPrefix}}/fomantic/themes/default/assets/fonts/icons.woff2" type="font/woff2" crossorigin="anonymous">


### PR DESCRIPTION
The opaque background does not work well in Firefox which uses the icon as a "rich icon". Prevent this by not specifying it in HTML. Real Apple devices will still request the icon on the static path.

Fixes: https://github.com/go-gitea/gitea/issues/10394