### PR TITLE
Prevent panic on merge to PR

### DIFF
--- a/integrations/git_test.go
+++ b/integrations/git_test.go
@@ -351,6 +351,17 @@ func doBranchProtectPRMerge(baseCtx *APITestContext, dstPath string) func(t *tes
 			pr, err = doAPICreatePullRequest(ctx, baseCtx.Username, baseCtx.Reponame, "protected", "unprotected")(t)
 			assert.NoError(t, err)
 		})
+		t.Run("GenerateCommit", func(t *testing.T) {
+			_, err := generateCommitWithNewData(littleSize, dstPath, "user2@example.com", "User Two", "branch-data-file-")
+			assert.NoError(t, err)
+		})
+		t.Run("PushToUnprotectedBranch", doGitPushTestRepository(dstPath, "origin", "protected:unprotected-2"))
+		var pr2 api.PullRequest
+		t.Run("CreatePullRequest", func(t *testing.T) {
+			pr2, err = doAPICreatePullRequest(ctx, baseCtx.Username, baseCtx.Reponame, "unprotected", "unprotected-2")(t)
+			assert.NoError(t, err)
+		})
+		t.Run("MergePR2", doAPIMergePullRequest(ctx, baseCtx.Username, baseCtx.Reponame, pr2.Index))
 		t.Run("MergePR", doAPIMergePullRequest(ctx, baseCtx.Username, baseCtx.Reponame, pr.Index))
 		t.Run("PullProtected", doGitPull(dstPath, "origin", "protected"))
 		t.Run("ProtectProtectedBranchWhitelist", doProtectBranch(ctx, "protected", baseCtx.Username))

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -324,6 +324,10 @@ func PushToBaseRepo(pr *models.PullRequest) (err error) {
 		}
 	}()
 
+	if err := pr.LoadHeadRepo(); err != nil {
+		log.Error("Unable to load head repository for PR[%d] Error: %v", pr.ID, err)
+		return err
+	}
 	headRepoPath := pr.HeadRepo.RepoPath()
 
 	if err := git.Clone(headRepoPath, tmpBasePath, git.CloneRepoOptions{
@@ -340,6 +344,10 @@ func PushToBaseRepo(pr *models.PullRequest) (err error) {
 		return fmt.Errorf("OpenRepository: %v", err)
 	}
 
+	if err := pr.LoadBaseRepo(); err != nil {
+		log.Error("Unable to load base repository for PR[%d] Error: %v", pr.ID, err)
+		return err
+	}
 	if err := gitRepo.AddRemote("base", pr.BaseRepo.RepoPath(), false); err != nil {
 		return fmt.Errorf("tmpGitRepo.AddRemote: %v", err)
 	}


### PR DESCRIPTION
If you attempt to merge to a branch which on a PR there will be a nil pointer error in the pull request checker.

This panic is uncaught and will bring down the gitea server.

This PR adds protection to prevent this.