### PR TITLE
Escape user name in heatmap request

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3002,7 +3002,7 @@ window.initHeatmap = function (appElementId, heatmapUser, locale) {
     methods: {
       loadHeatmap(userName) {
         const self = this;
-        $.get(`${this.suburl}/api/v1/users/${encodeURI(userName)}/heatmap`, (chartRawData) => {
+        $.get(`${this.suburl}/api/v1/users/${encodeURIComponent(userName)}/heatmap`, (chartRawData) => {
           const chartData = [];
           for (let i = 0; i < chartRawData.length; i++) {
             self.totalContributions += chartRawData[i].contributions;

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3002,7 +3002,7 @@ window.initHeatmap = function (appElementId, heatmapUser, locale) {
     methods: {
       loadHeatmap(userName) {
         const self = this;
-        $.get(`${this.suburl}/api/v1/users/${userName}/heatmap`, (chartRawData) => {
+        $.get(`${this.suburl}/api/v1/users/${encodeURI(userName)}/heatmap`, (chartRawData) => {
           const chartData = [];
           for (let i = 0; i < chartRawData.length; i++) {
             self.totalContributions += chartRawData[i].contributions;


### PR DESCRIPTION
Fixes heatmap URL when user name contains special characters. In particular, it fixes PAM user names containing `\` from a Windows domain.

For user `contoso\isabella`, changes:
```
http://gitea.mydomain:3000/api/v1/users/contoso/isabella/heatmap
```

into:
```
http://gitea.mydomain:3000/api/v1/users/contoso%5Cisabella/heatmap
```
