### PR TITLE
Restrict PAM user names to [A-Z_-]

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -677,6 +677,11 @@ func LoginViaPAM(user *User, login, password string, sourceID int64, cfg *PAMCon
 		return user, nil
 	}
 
+	// Validate username make sure it satisfies requirement.
+	if alphaDashDotPattern.MatchString(login) {
+		return nil, fmt.Errorf("Invalid pattern for attribute 'username' [%s]: must be valid alpha or numeric or dash(-_) or dot characters", login)
+	}
+
 	user = &User{
 		LowerName:   strings.ToLower(login),
 		Name:        login,


### PR DESCRIPTION
Currently, users from PAM authentication can register themselves even if their names contain special characters (e.g. `CONTOSO\mike`). The NETBIOS style will cause all kinds of problems, and email-style name seem to work, but they shouldn't (and they're not necessarily e-mails).
