### PR TITLE
Use local timezone to compare on TestViewRepo2

### DIFF
--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -68,18 +68,19 @@ func testViewRepo(t *testing.T) {
 		items = append(items, f)
 	})
 
+	commitT := time.Date(2017, time.June, 14, 13, 54, 21, 0, time.UTC).In(time.Local).Format(time.RFC1123)
 	assert.EqualValues(t, []file{
 		{
 			fileName:   "doc",
 			commitID:   "2a47ca4b614a9f5a43abbd5ad851a54a616ffee6",
 			commitMsg:  "init project",
-			commitTime: time.Date(2017, time.June, 14, 13, 54, 21, 0, time.UTC).Format(time.RFC1123),
+			commitTime: commitT,
 		},
 		{
 			fileName:   "README.md",
 			commitID:   "2a47ca4b614a9f5a43abbd5ad851a54a616ffee6",
 			commitMsg:  "init project",
-			commitTime: time.Date(2017, time.June, 14, 13, 54, 21, 0, time.UTC).Format(time.RFC1123),
+			commitTime: commitT,
 		},
 	}, items)
 }


### PR DESCRIPTION
error if you have location set on your system:

```log
--- FAIL: TestViewRepo2 (1.80s)                                                                                                                                                                                                                                                
    testlogger.go:73: 2020/02/24 19:17:18 ...ers/routes/routes.go:105:func1() [I] Completed GET /user3/repo3 404 Not Found in 1.595595ms                                                                                                                                       
    testlogger.go:73: 2020/02/24 19:17:19 ...ers/routes/routes.go:99:func1() [I] Started GET /user3/repo3 for                                                                                                                                                                  
    testlogger.go:73: 2020/02/24 19:17:19 ...ers/routes/routes.go:105:func1() [I] Completed GET /user3/repo3 200 OK in 14.631307ms                                                                                                                                             
    repo_test.go:71:                                                                                                                                                                                                                                                           
                Error Trace:    repo_test.go:71                                                                                                                                                                                                                                
                                                        repo_test.go:89                                                                                                                                                                                                        
                Error:          Not equal:                                                                                                                                                                                                                                     
                                expected: []integrations.file{integrations.file{fileName:"doc", commitID:"2a47ca4b614a9f5a43abbd5ad851a54a616ffee6", commitMsg:"init project", commitTime:"Wed, 14 Jun 2017 13:54:21 UTC"}, integrations.file{fileName:"README.md", commitID:"2
a47ca4b614a9f5a43abbd5ad851a54a616ffee6", commitMsg:"init project", commitTime:"Wed, 14 Jun 2017 13:54:21 UTC"}}                                                                                                                                                               
                                actual  : []integrations.file{integrations.file{fileName:"doc", commitID:"2a47ca4b614a9f5a43abbd5ad851a54a616ffee6", commitMsg:"init project", commitTime:"Wed, 14 Jun 2017 15:54:21 CEST"}, integrations.file{fileName:"README.md", commitID:"
2a47ca4b614a9f5a43abbd5ad851a54a616ffee6", commitMsg:"init project", commitTime:"Wed, 14 Jun 2017 15:54:21 CEST"}}                                                                                                                                                             
                                                                                                                                                                                                                                                                               
                                Diff:                                                                                                                                                                                                                                          
                                --- Expected                                                                                                                                                                                                                                   
                                +++ Actual                                                                                                                                                                                                                                     
                                @@ -5,3 +5,3 @@                                                                                                                                                                                                                                
                                   commitMsg: (string) (len=12) "init project",                                                                                                                                                                                                
                                -  commitTime: (string) (len=29) "Wed, 14 Jun 2017 13:54:21 UTC"                                                                                                                                                                               
                                +  commitTime: (string) (len=30) "Wed, 14 Jun 2017 15:54:21 CEST"                                                                                                                                                                              
                                  },                                                                                                                                                                                                                                           
                                @@ -11,3 +11,3 @@                                                                                                                                                                                                                              
                                   commitMsg: (string) (len=12) "init project",                                                                                                                                                                                                
                                -  commitTime: (string) (len=29) "Wed, 14 Jun 2017 13:54:21 UTC"                                                                                                                                                                               
                                +  commitTime: (string) (len=30) "Wed, 14 Jun 2017 15:54:21 CEST"                                                                                                                                                                              
                                  }                                                                                                                                                                                                                                            
                Test:           TestViewRepo2
```

this fix it