### PR TITLE
Workaround: Finding repository when it is null in PR

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -231,6 +231,13 @@ func PushToBaseRepo(pr *models.PullRequest) (err error) {
 		}
 	}()
 
+	if pr.HeadRepo == nil {
+		pr.HeadRepo, err = models.GetRepositoryByID(pr.HeadRepoID)
+		if err != nil {
+			log.Error("GetRepositoryById[%d]: %v", pr.HeadRepoID, err)
+			return err
+		}
+	}
 	headRepoPath := pr.HeadRepo.RepoPath()
 
 	if err := git.Clone(headRepoPath, tmpBasePath, git.CloneRepoOptions{


### PR DESCRIPTION
This should fix a panic when retrieving the repository owner name. I know this is not a definitive solution but serves as a workaround for release 1.11

Issue #10479