### PR TITLE
Fix double PR notification from API

### DIFF
--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -16,7 +16,6 @@ import (
 	"code.gitea.io/gitea/modules/convert"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
-	"code.gitea.io/gitea/modules/notification"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/routers/api/v1/utils"
@@ -325,8 +324,6 @@ func CreatePullRequest(ctx *context.APIContext, form api.CreatePullRequestOption
 		ctx.Error(http.StatusInternalServerError, "NewPullRequest", err)
 		return
 	}
-
-	notification.NotifyNewPullRequest(pr)
 
 	log.Trace("Pull request created: %d/%d", repo.ID, prIssue.ID)
 	ctx.JSON(http.StatusCreated, convert.ToAPIPullRequest(pr))


### PR DESCRIPTION
`NotifyNewPullRequest` is already called in the service:

https://github.com/go-gitea/gitea/blob/084a2b00268ed561f59ac19b1b6660a3c58573b3/services/pull/pull.go#L50