### PR TITLE
Fixed formatting of the English installation documentation 

### DIFF
--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -123,7 +123,7 @@ If pre-built frontend files are present it is possible to only build the backend
 
 ```bash
 TAGS="bindata" make backend
-``
+```
 
 ## Test
 


### PR DESCRIPTION
There is a code block in the English [Installation from source documentation](https://docs.gitea.io/en-us/install-from-source/), which is not properly closed. This pull request adds the missing backtick `` ` `` to close this codeblock.
