### PR TITLE
Tweak language stats bar

### DIFF
--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -1,4 +1,4 @@
-<div class="ui segments">
+<div class="ui segments repository-summary">
 	<div class="ui segment sub-menu repository-menu">
 		<div class="ui two horizontal center link list">
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo)}}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2011,19 +2011,31 @@
         }
     }
 
-    .segment.language-stats {
-        padding: 0;
-        height: .6em;
-        display: flex;
-        white-space: nowrap;
-        width: 100%;
+    .repository-summary {
+        height: 48px;
+        overflow: hidden;
 
-        .bar {
-            white-space: nowrap;
-            border: 0;
+        .segment.language-stats-details,
+        .segment.repository-summary {
+            border-top: none;
+            background: none;
+        }
+
+        .segment.language-stats {
             padding: 0;
-            margin: 0;
-            height: .6em;
+            height: 11px;
+            display: flex;
+            white-space: nowrap;
+            width: 100%;
+            border-radius: 0;
+
+            .bar {
+                white-space: nowrap;
+                border: 0;
+                padding: 0;
+                margin: 0;
+                height: 100%;
+            }
         }
     }
 }


### PR DESCRIPTION
- Ensure bar does not overflow parent (fixing border-radii)
- Remove unneccessary borders/background
- Fix shaky page caused by JS animation miscalculation by setting fixed height on the summary box. Box itself is still shaky during animation, but better it then the whole page.

Fixes: https://github.com/go-gitea/gitea/issues/10474

Before:

![image](https://user-images.githubusercontent.com/115237/75381532-30e9d600-58d9-11ea-88e7-1f644027183e.png)

After:

![image](https://user-images.githubusercontent.com/115237/75382012-0c422e00-58da-11ea-9605-d56794e39b65.png)

