### PR TITLE
Add fluid-icon

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -99,6 +99,7 @@
 	</script>
 	<link rel="shortcut icon" href="{{StaticUrlPrefix}}/img/favicon.png">
 	<link rel="mask-icon" href="{{StaticUrlPrefix}}/img/gitea-safari.svg" color="#609926">
+	<link rel="fluid-icon" href="{{StaticUrlPrefix}}/img/gitea-lg.png" title="{{AppName}}">
 	<link rel="stylesheet" href="{{StaticUrlPrefix}}/vendor/assets/font-awesome/css/font-awesome.min.css">
 	<link rel="preload" as="font" href="{{StaticUrlPrefix}}/fomantic/themes/default/assets/fonts/icons.woff2" type="font/woff2" crossorigin="anonymous">
 	<link rel="preload" as="font" href="{{StaticUrlPrefix}}/fomantic/themes/default/assets/fonts/outline-icons.woff2" type="font/woff2" crossorigin="anonymous">


### PR DESCRIPTION
This provides Firefox (and possible other browsers) with a high-resolution rich icon, in place of the previously removed apple-touch-icon without having to use that one as it lacks an alpha channel. This is the same method GH uses.

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/UI_considerations#Rich_icons