### PR TITLE
Use [:space:] instead of \s (#10508)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ help:
 
 .PHONY: go-check
 go-check:
-	$(eval GO_VERSION := $(shell printf "%03d%03d%03d" $(shell go version | grep -Eo '[0-9]+\.?[0-9]+?\.?[0-9]?\s' | tr '.' ' ');))
+	$(eval GO_VERSION := $(shell printf "%03d%03d%03d" $(shell go version | grep -Eo '[0-9]+\.?[0-9]+?\.?[0-9]?[[:space:]]' | tr '.' ' ');))
 	@if [ "$(GO_VERSION)" -lt "001011000" ]; then \
 		echo "Gitea requires Go 1.11.0 or greater to build. You can get it at https://golang.org/dl/"; \
 		exit 1; \


### PR DESCRIPTION
Backport #10508 

Although modern versions of GNU grep make \s a synonym for [:space:] this is not POSIX compliant. We should use [:space:]

Fix #10507