### PR TITLE
Prevent accidential selection of language stats bar

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2193,6 +2193,7 @@
             white-space: nowrap;
             width: 100%;
             border-radius: 0;
+            user-select: none;
 
             .bar {
                 white-space: nowrap;


### PR DESCRIPTION
Prevents selection like seen in the bottom left here when clicking twice on the bar:

<img width="208" alt="image" src="https://user-images.githubusercontent.com/115237/75564715-e8532980-5a4c-11ea-9ab7-b778b6c0cbc1.png">
