### PR TITLE
WIP: Fix incorrect open issue count after commit close

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1872,6 +1872,27 @@ func repoStatsCheck(ctx context.Context, checker *repoChecker) {
 	}
 }
 
+// FetchClosedIssueNum fetches the currently stored repositories NumClosedIssues from the database.
+// To further clarify, this method does NOT:
+//    - Recalculate the number of closed issues in the database
+//    - Return the repositories value of the locally stored NumClosedIssues
+// The method will only return an error if an actual SQL error occurred.
+// If no value was found, a -1 and a nil error will be returned.
+func (repo *Repository) FetchClosedIssueNum() (int, error) {
+	var value int
+	found, err := x.Table("repository").
+		Select("num_closed_issues").
+		Where("id = ?", repo.ID).
+		Get(&value)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return -1, nil
+	}
+	return value, nil
+}
+
 // CheckRepoStats checks the repository stats
 func CheckRepoStats(ctx context.Context) {
 	log.Trace("Doing: CheckRepoStats")


### PR DESCRIPTION
This commit fixes the bug that a repositories open issue value is not
updated when an issue is closed through a commit that references such
issue.

More specifically, creating an issue on a repository with currently 0
open bugs lead to the repository showing one open issue.
Closing such issue through a commit onto the branch this issue was
targetting would close the issue correctly but failed to update the
issue counter in the repositories header. Hence the repository would
show one open issue while the open issue list remains empty.

As this commit is a response to #10536, more information about the
bug can be aquired there.

Fixes #10536.

Problem:
The issue comes from the fact that the the commit issue hooks are executed before [this](https://github.com/go-gitea/gitea/blob/master/modules/repofiles/action.go#L277) line, which updates the entire repository into the database.
This overwrites the calls further up in the method which updates the number of closed issues correctly.

Solution:
To solve this (and to run the solving logic as few times as possible) this commit implemented a simple flag in the [CommitRepoAction](https://github.com/go-gitea/gitea/blob/master/modules/repofiles/action.go#L161) method that tracks if any commit actually modifies the closed issue number.

If that is the case, we select the updated value from the database and assign it to the local repository instance so the updated value is saved to the database in line 277.