### PR TITLE
Implement basic global webhooks from config

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -600,6 +600,8 @@ PROXY_URL =
 PROXY_HOSTS =
 ; A list of URLs to POST any events to as webhook type Gitea in JSON format
 GLOBAL_WEBHOOKS =
+; A secret to be applied to all global webhooks in order to prove the request is legitimate
+GLOBAL_SECRET =
 
 [mailer]
 ENABLED = false

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -598,6 +598,8 @@ PAGING_NUM = 10
 PROXY_URL =
 ; Comma separated list of host names requiring proxy. Glob patterns (*) are accepted; use ** to match all hosts.
 PROXY_HOSTS =
+; A list of URLs to POST any events to as webhook type Gitea in JSON format
+GLOBAL_WEBHOOKS =
 
 [mailer]
 ENABLED = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -363,6 +363,7 @@ set name for unique queues. Individual queues will default to
 - `PAGING_NUM`: **10**: Number of webhook history events that are shown in one page.
 - `PROXY_URL`: ****: Proxy server URL, support http://, https//, socks://, blank will follow environment http_proxy/https_proxy
 - `PROXY_HOSTS`: ****: Comma separated list of host names requiring proxy. Glob patterns (*) are accepted; use ** to match all hosts.
+- `GLOBAL_HOOKS`: ****: Comma separated list of URLs to act as a system-wide webhook of type Gitea in JSON mode POSTing for all events. Useful for developing custom behaviour and plugins.
 
 ## Mailer (`mailer`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -364,6 +364,7 @@ set name for unique queues. Individual queues will default to
 - `PROXY_URL`: ****: Proxy server URL, support http://, https//, socks://, blank will follow environment http_proxy/https_proxy
 - `PROXY_HOSTS`: ****: Comma separated list of host names requiring proxy. Glob patterns (*) are accepted; use ** to match all hosts.
 - `GLOBAL_HOOKS`: ****: Comma separated list of URLs to act as a system-wide webhook of type Gitea in JSON mode POSTing for all events. Useful for developing custom behaviour and plugins.
+- `GLOBAL_SECRET`: ****: A string secret applied to all global hooks in order to help prove the request is legitimate.
 
 ## Mailer (`mailer`)
 

--- a/modules/setting/webhook.go
+++ b/modules/setting/webhook.go
@@ -22,6 +22,7 @@ var (
 		ProxyURLFixed  *url.URL
 		ProxyHosts     []string
 		GlobalWebhooks []string // A list of URLs to POST any events to as webhook type Gitea
+		GlobalSecret   string
 	}{
 		QueueLength:    1000,
 		DeliverTimeout: 5,
@@ -51,4 +52,5 @@ func newWebhookService() {
 	}
 	Webhook.ProxyHosts = sec.Key("PROXY_HOSTS").Strings(",")
 	Webhook.GlobalWebhooks = sec.Key("GLOBAL_WEBHOOKS").Strings(",")
+	Webhook.GlobalSecret = sec.Key("GLOBAL_SECRET").MustString("")
 }

--- a/modules/setting/webhook.go
+++ b/modules/setting/webhook.go
@@ -21,6 +21,7 @@ var (
 		ProxyURL       string
 		ProxyURLFixed  *url.URL
 		ProxyHosts     []string
+		GlobalWebhooks []string // A list of URLs to POST any events to as webhook type Gitea
 	}{
 		QueueLength:    1000,
 		DeliverTimeout: 5,
@@ -28,6 +29,7 @@ var (
 		PagingNum:      10,
 		ProxyURL:       "",
 		ProxyHosts:     []string{},
+		GlobalWebhooks: []string{},
 	}
 )
 
@@ -48,4 +50,5 @@ func newWebhookService() {
 		}
 	}
 	Webhook.ProxyHosts = sec.Key("PROXY_HOSTS").Strings(",")
+	Webhook.GlobalWebhooks = sec.Key("GLOBAL_WEBHOOKS").Strings(",")
 }

--- a/modules/webhook/webhook.go
+++ b/modules/webhook/webhook.go
@@ -182,6 +182,7 @@ func getGlobalWebhooks() []*models.Webhook {
 				SendEverything: true,
 				BranchFilter:   "*",
 			},
+			Secret:     setting.Webhook.GlobalSecret,
 			HTTPMethod: "POST",
 		}
 		hooks = append(hooks, hook)


### PR DESCRIPTION
This PR adds a _very primitive_ way of having webhooks configured that work for all repositories across the system. Originally I misinterpreted `Default Webhooks` as system-wide setting for this feature, and not just a template for new repositories - Doh 🤦‍♂ 

The rationale for this change (as potentally hinted [here](https://github.com/go-gitea/gitea/issues/6998#issuecomment-543582502)) would be to enable more custom integrations. I was investigating at creating a custom authentication layer for a Docker registry, but wanted to know when a repository was deleted in order to remove images automatically. I was also looking at creating a utility to comment Jira tickets on PRs - equally in need of knowing events happening on the system.

I accept if this isn't a desired method, so alternatively we could look at implenting system webhooks in the UI and DB (while trying to avoid any confusion with default webhooks) or even a full 'apps/plugin API'? I'm also not that fluent at Go, so all comments are welcome! 😄 