### PR TITLE
Fix 404 after activating secondary email

### DIFF
--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -1219,7 +1219,7 @@ func ActivateEmail(ctx *context.Context) {
 		ctx.Flash.Success(ctx.Tr("settings.add_email_success"))
 	}
 
-	ctx.Redirect(setting.AppSubURL + "/user/settings/email")
+	ctx.Redirect(setting.AppSubURL + "/user/settings/account")
 }
 
 // ForgotPasswd render the forget pasword page


### PR DESCRIPTION
After confirming a secondary email, users get redirected to a non-existing URL and get a 404, this should fix it.