### PR TITLE
Fix redirection path if Slack webhook channel is invalid (#10548)

### DIFF
--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -448,7 +448,7 @@ func SlackHooksNewPost(ctx *context.Context, form auth.NewSlackHookForm) {
 
 	if form.HasInvalidChannel() {
 		ctx.Flash.Error(ctx.Tr("repo.settings.add_webhook.invalid_channel_name"))
-		ctx.Redirect(orCtx.Link + "/settings/hooks/slack/new")
+		ctx.Redirect(orCtx.Link + "/slack/new")
 		return
 	}
 
@@ -642,7 +642,7 @@ func SlackHooksEditPost(ctx *context.Context, form auth.NewSlackHookForm) {
 
 	if form.HasInvalidChannel() {
 		ctx.Flash.Error(ctx.Tr("repo.settings.add_webhook.invalid_channel_name"))
-		ctx.Redirect(fmt.Sprintf("%s/settings/hooks/%d", orCtx.Link, w.ID))
+		ctx.Redirect(fmt.Sprintf("%s/%d", orCtx.Link, w.ID))
 		return
 	}
 


### PR DESCRIPTION
A backport of #10548, potentially pointing at the right branch this time! 😃 