### PR TITLE
Frontend build improvements, hopefully fix Fomantic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 
 #Checkout version if set
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
- && make clean build
+ && make clean-all build
 
 FROM alpine:3.11
 LABEL maintainer="maintainers@gitea.io"


### PR DESCRIPTION
- add package-lock.json to webpack/fomantic prereqs making them always rebuild when dependencies change.
- remove FOMANTIC_EVIDENCE. It seemed better to just track a few output files instead.
- delete fomantic output files before build to prevent possible bugs in fomantic's build.
- resolve WEBPACK_SOURCES only once for performance
- reorder variables for clarity
- use clean-all in Dockerfile
- detect busybox for find syntax

Fixes: https://github.com/go-gitea/gitea/issues/10569
Fixes: https://github.com/go-gitea/gitea/issues/10565
Fixes: https://github.com/go-gitea/gitea/issues/10570
Fixes: https://github.com/go-gitea/gitea/issues/10568
