### PR TITLE
Fix make find command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,18 @@ endif
 
 ifeq ($(OS), Windows_NT)
 	EXECUTABLE ?= gitea.exe
+	FIND_PWD_REGEXP := find . -regextype posix-egrep
 else
 	EXECUTABLE ?= gitea
 	UNAME_S := $(shell uname -s)
+	FIND_PWD_REGEXP := find . -regextype posix-egrep
 	ifeq ($(UNAME_S),Darwin)
 		SED_INPLACE := sed -i ''
+		FIND_PWD_REGEXP := find -E .
 	endif
 	ifeq ($(UNAME_S),FreeBSD)
 		SED_INPLACE := sed -i ''
+		FIND_PWD_REGEXP := find -E .
 	endif
 endif
 
@@ -63,7 +67,7 @@ LDFLAGS := $(LDFLAGS) -X "main.MakeVersion=$(MAKE_VERSION)" -X "main.Version=$(G
 
 PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations/migration-test,$(filter-out code.gitea.io/gitea/integrations,$(shell GO111MODULE=on $(GO) list -mod=vendor ./... | grep -v /vendor/)))
 
-GO_SOURCES ?= $(shell find . -type d \( -path ./node_modules -o -path ./docs -o -path ./public -o -path ./options -o -path ./contrib -o -path ./data \) -prune -o -type f -name '*.go' -print)
+GO_SOURCES ?= $(shell $(FIND_PWD_REGEXP) -regex '\./(node_modules|docs|public|options|contrib|data)' -prune -o -name "*.go" -type f -print)
 GO_SOURCES_OWN := $(filter-out ./vendor/% %/bindata.go, $(GO_SOURCES))
 
 WEBPACK_SOURCES ?= $(shell find web_src/js web_src/less -type f)


### PR DESCRIPTION
Continuation of #10577

This version also includes an additional fix for Darwin and FreeBSD which do not accept the `-regextype` option, but only `-E` and the argument order is specifically required like this for `-E` to work.

@jolheiser please confirm this works for you.