### PR TITLE
Change default value of DefaultCommandExecutionTimeout to match docs

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -22,7 +22,7 @@ var (
 	GlobalCommandArgs []string
 
 	// DefaultCommandExecutionTimeout default command execution timeout duration
-	DefaultCommandExecutionTimeout = 60 * time.Second
+	DefaultCommandExecutionTimeout = 360 * time.Second
 )
 
 // DefaultLocale is the default LC_ALL to run git commands in.


### PR DESCRIPTION
Set the default git timeout to 360s as per the docs not 60s. 

Fix #10575