### PR TITLE
Secure Defaults for HTTPS/TLS and for Password-Based Key Derivation

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -465,8 +465,8 @@ ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
 ;If left empty or no valid values are specified, the default values ("lower,upper,digit,spec") will be used.
 ;Use "off" to disable checking.
 PASSWORD_COMPLEXITY = lower,upper,digit,spec
-; Password Hash algorithm, either "pbkdf2", "argon2", "scrypt" or "bcrypt"
-PASSWORD_HASH_ALGO = pbkdf2
+; Password Hash algorithm, either "argon2", "pbkdf2", "scrypt" or "bcrypt"
+PASSWORD_HASH_ALGO = argon2
 ; Set false to allow JavaScript to read CSRF cookie
 CSRF_COOKIE_HTTP_ONLY = true
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -291,7 +291,7 @@ set name for unique queues. Individual queues will default to
 - `IMPORT_LOCAL_PATHS`: **false**: Set to `false` to prevent all users (including admin) from importing local path on server.
 - `INTERNAL_TOKEN`: **\<random at every install if no uri set\>**: Secret used to validate communication within Gitea binary.
 - `INTERNAL_TOKEN_URI`: **<empty>**: Instead of defining internal token in the configuration, this configuration option can be used to give Gitea a path to a file that contains the internal token (example value: `file:/etc/gitea/internal_token`)
-- `PASSWORD_HASH_ALGO`: **pbkdf2**: The hash algorithm to use \[pbkdf2, argon2, scrypt, bcrypt\].
+- `PASSWORD_HASH_ALGO`: **argon2**: The hash algorithm to use \[argon2, pbkdf2, scrypt, bcrypt\].
 - `CSRF_COOKIE_HTTP_ONLY`: **true**: Set false to allow JavaScript to read CSRF cookie.
 - `PASSWORD_COMPLEXITY`: **lower,upper,digit,spec**: Comma separated list of character classes required to pass minimum complexity. If left empty or no valid values are specified, the default values will be used. Possible values are: 
     - lower - use one or more lower latin characters

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -7,7 +7,7 @@
   full_name: User One
   email: user1@example.com
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: true
@@ -24,7 +24,7 @@
   email: user2@example.com
   keep_email_private: true
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -43,7 +43,7 @@
   full_name: " <<<< >> >> > >> > >>> >> "
   email: user3@example.com
   email_notifications_preference: onmention
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -60,7 +60,7 @@
   full_name: "          "
   email: user4@example.com
   email_notifications_preference: onmention
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -77,7 +77,7 @@
   full_name: User Five
   email: user5@example.com
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -95,7 +95,7 @@
   full_name: User Six
   email: user6@example.com
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -112,7 +112,7 @@
   full_name: User Seven
   email: user7@example.com
   email_notifications_preference: disabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -129,7 +129,7 @@
   full_name: User Eight
   email: user8@example.com
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -147,7 +147,7 @@
   full_name: User Nine
   email: user9@example.com
   email_notifications_preference: onmention
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -162,7 +162,7 @@
   name: user10
   full_name: User Ten
   email: user10@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -177,7 +177,7 @@
   name: user11
   full_name: User Eleven
   email: user11@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -192,7 +192,7 @@
   name: user12
   full_name: User 12
   email: user12@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -207,7 +207,7 @@
   name: user13
   full_name: User 13
   email: user13@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -222,7 +222,7 @@
   name: user14
   full_name: User 14
   email: user14@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -237,7 +237,7 @@
   name: user15
   full_name: User 15
   email: user15@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -252,7 +252,7 @@
   name: user16
   full_name: User 16
   email: user16@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -267,7 +267,7 @@
   name: user17
   full_name: User 17
   email: user17@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -284,7 +284,7 @@
   name: user18
   full_name: User 18
   email: user18@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -299,7 +299,7 @@
   name: user19
   full_name: User 19
   email: user19@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -316,7 +316,7 @@
   name: user20
   full_name: User 20
   email: user20@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -331,7 +331,7 @@
   name: user21
   full_name: User 21
   email: user21@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -346,7 +346,7 @@
   name: limited_org
   full_name: Limited Org
   email: limited_org@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -364,7 +364,7 @@
   name: privated_org
   full_name: Privated Org
   email: privated_org@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -383,7 +383,7 @@
   full_name: "user24"
   email: user24@example.com
   keep_email_private: true
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -401,7 +401,7 @@
   name: org25
   full_name: "org25"
   email: org25@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -418,7 +418,7 @@
   full_name: "Org26"
   email: org26@example.com
   email_notifications_preference: onmention
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 1 # organization
   salt: ZogKvWdyEx
   is_admin: false
@@ -436,7 +436,7 @@
   full_name: User Twenty-Seven
   email: user27@example.com
   email_notifications_preference: enabled
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -451,7 +451,7 @@
   full_name: "user27"
   email: user28@example.com
   keep_email_private: true
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false
@@ -469,7 +469,7 @@
   name: user29
   full_name: User 29
   email: user29@example.com
-  passwd: 7d93daa0d1e6f2305cc8fa496847d61dc7320bb16262f9c55dd753480207234cdd96a93194e408341971742f4701772a025a # password
+  passwd: a3d5fcd92bae586c2e3dbe72daea7a0d27833a8d0227aa1704f4bbd775c1f3b03535b76dd93b0d4d8d22a519dca47df1547b # password
   type: 0 # individual
   salt: ZogKvWdyEx
   is_admin: false

--- a/models/migrations/v124.go
+++ b/models/migrations/v124.go
@@ -12,7 +12,7 @@ func addUserRepoMissingColumns(x *xorm.Engine) error {
 
 	type VisibleType int
 	type User struct {
-		PasswdHashAlgo string      `xorm:"NOT NULL DEFAULT 'pbkdf2'"`
+		PasswdHashAlgo string      `xorm:"NOT NULL DEFAULT 'argon2'"`
 		Visibility     VisibleType `xorm:"NOT NULL DEFAULT 0"`
 	}
 

--- a/models/user.go
+++ b/models/user.go
@@ -104,7 +104,7 @@ type User struct {
 	KeepEmailPrivate             bool
 	EmailNotificationsPreference string `xorm:"VARCHAR(20) NOT NULL DEFAULT 'enabled'"`
 	Passwd                       string `xorm:"NOT NULL"`
-	PasswdHashAlgo               string `xorm:"NOT NULL DEFAULT 'pbkdf2'"`
+	PasswdHashAlgo               string `xorm:"NOT NULL DEFAULT 'argon2'"`
 
 	// MustChangePassword is an attribute that determines if a user
 	// is to change his/her password after registration.

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -239,7 +239,7 @@ func TestHashPasswordDeterministic(t *testing.T) {
 	b := make([]byte, 16)
 	rand.Read(b)
 	u := &User{Salt: string(b)}
-	algos := []string{"pbkdf2", "argon2", "scrypt", "bcrypt"}
+	algos := []string{"argon2", "pbkdf2", "scrypt", "bcrypt"}
 	for j := 0; j < len(algos); j++ {
 		u.PasswdHashAlgo = algos[j]
 		for i := 0; i < 50; i++ {

--- a/modules/graceful/server.go
+++ b/modules/graceful/server.go
@@ -128,6 +128,8 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string, serve ServeFuncti
 func (srv *Server) ListenAndServeTLSConfig(tlsConfig *tls.Config, serve ServeFunction) error {
 	go srv.awaitShutdown()
 
+	tlsConfig.MinVersion = tls.VersionTLS12
+
 	l, err := GetListener(srv.network, srv.address)
 	if err != nil {
 		log.Error("Unable to get Listener: %v", err)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -809,7 +809,7 @@ func NewContext() {
 	ImportLocalPaths = sec.Key("IMPORT_LOCAL_PATHS").MustBool(false)
 	DisableGitHooks = sec.Key("DISABLE_GIT_HOOKS").MustBool(false)
 	OnlyAllowPushIfGiteaEnvironmentSet = sec.Key("ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET").MustBool(true)
-	PasswordHashAlgo = sec.Key("PASSWORD_HASH_ALGO").MustString("pbkdf2")
+	PasswordHashAlgo = sec.Key("PASSWORD_HASH_ALGO").MustString("argon2")
 	CSRFCookieHTTPOnly = sec.Key("CSRF_COOKIE_HTTP_ONLY").MustBool(true)
 
 	InternalToken = loadInternalToken(sec)


### PR DESCRIPTION
Hello,

I represent [Symbolic Software](https://symbolic.software), an applied cryptography consultancy that has been [a happy Gitea user](https://source.symbolic.software) for quite some time 😄I am submitting this pull request which provides two important changes to the default configurations of TLS and of password hashing in Gitea.

All changes made in this pull request have been fully tested.

## Changes to TLS

Currently, Gitea allows TLS 1.0 and TLS 1.1 for HTTPS connections. These versions of TLS have long been [deprecated due to security vulnerabilities](https://www.keycdn.com/blog/deprecating-tls-1-0-and-1-1), and are also [no longer necessary for wide browser compatibility](https://caniuse.com/#feat=tls1-2). The change I propose in this pull request sets TLS 1.2 as the minimum TLS version, with additional support for TLS 1.3.

On SSLLabs, we can see the difference. Before my changes:

<img width="600" alt="Screen Shot 2020-03-04 at 9 46 22 AM" src="https://user-images.githubusercontent.com/9953/75867697-45612d80-5e07-11ea-8057-7de9191b8b7e.png">

After my changes:

<img width="600" alt="Screen Shot 2020-03-04 at 10 40 38 AM" src="https://user-images.githubusercontent.com/9953/75867714-4a25e180-5e07-11ea-91d1-be86c3908f3e.png">

## Changes to Password-Based Key Derivation

Currently, Gitea uses `pbkdf2` as the default password hashing function. In this pull request, I replace that with `argon2` as the default, for the following reasons:

- `pbkdf2` is uniquely vulnerable to [GPU and ASIC-based attacks](https://github.com/WOnder93/pbkdf2-gpu) that `argon2` and `scrypt` are much less vulnerable against.
- `pbkdf2` is vulnerable to [acceleration attacks](https://www.usenix.org/conference/woot16/workshop-program/presentation/ruddick) and to [a host of other attacks](https://link.springer.com/chapter/10.1007/978-3-319-26823-1_9) that `argon2` and `scrypt` are not vulnerable to.

Therefore, given the above and especially given that `argon2` is a well-specified, formally studied design that has won the [Password Hashing Competition](https://password-hashing.net/#argon2), I think using it as the default instead of `pbkdf2` makes complete sense.

Thank you very much for your work on Gitea, we are huge Gitea fans and look forward to perhaps contributing more in the future.