### PR TITLE
Handle deleted base branch in PR

### DIFF
--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -356,6 +356,16 @@ func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.Compare
 		return nil
 	}
 	defer baseGitRepo.Close()
+
+	if !baseGitRepo.IsBranchExist(pull.BaseBranch) {
+		ctx.Data["IsPullRequestBroken"] = true
+		ctx.Data["BaseTarget"] = pull.BaseBranch
+		ctx.Data["HeadTarget"] = pull.HeadBranch
+		ctx.Data["NumCommits"] = 0
+		ctx.Data["NumFiles"] = 0
+		return nil
+	}
+
 	var headBranchExist bool
 	var headBranchSha string
 	// HeadRepo may be missing


### PR DESCRIPTION
If you delete the base branch of a PR, although the PR will be closed if you view the PR you will be presented with a 500. This PR will handle this case.

See for an example PR https://try.gitea.io/arandomer/anudderrepo/pulls/1

Signed-off-by: Andrew Thornton <art27@cantab.net>