### PR TITLE
Fix webhook migration

### DIFF
--- a/models/migrations/v130.go
+++ b/models/migrations/v130.go
@@ -7,17 +7,23 @@ package migrations
 import (
 	"encoding/json"
 
+	"code.gitea.io/gitea/modules/setting"
+
 	"xorm.io/xorm"
 )
 
 func expandWebhooks(x *xorm.Engine) error {
 
-	type ChooseEvents struct {
+	type HookEvents struct {
+		Create               bool `json:"create"`
+		Delete               bool `json:"delete"`
+		Fork                 bool `json:"fork"`
 		Issues               bool `json:"issues"`
 		IssueAssign          bool `json:"issue_assign"`
 		IssueLabel           bool `json:"issue_label"`
 		IssueMilestone       bool `json:"issue_milestone"`
 		IssueComment         bool `json:"issue_comment"`
+		Push                 bool `json:"push"`
 		PullRequest          bool `json:"pull_request"`
 		PullRequestAssign    bool `json:"pull_request_assign"`
 		PullRequestLabel     bool `json:"pull_request_label"`
@@ -25,14 +31,17 @@ func expandWebhooks(x *xorm.Engine) error {
 		PullRequestComment   bool `json:"pull_request_comment"`
 		PullRequestReview    bool `json:"pull_request_review"`
 		PullRequestSync      bool `json:"pull_request_sync"`
+		Repository           bool `json:"repository"`
+		Release              bool `json:"release"`
 	}
 
-	type Events struct {
-		PushOnly       bool         `json:"push_only"`
-		SendEverything bool         `json:"send_everything"`
-		ChooseEvents   bool         `json:"choose_events"`
-		BranchFilter   string       `json:"branch_filter"`
-		Events         ChooseEvents `json:"events"`
+	type HookEvent struct {
+		PushOnly       bool   `json:"push_only"`
+		SendEverything bool   `json:"send_everything"`
+		ChooseEvents   bool   `json:"choose_events"`
+		BranchFilter   string `json:"branch_filter"`
+
+		HookEvents `json:"events"`
 	}
 
 	type Webhook struct {
@@ -40,10 +49,9 @@ func expandWebhooks(x *xorm.Engine) error {
 		Events string
 	}
 
-	var events Events
 	var bytes []byte
 	var last int
-	const batchSize = 50
+	batchSize := setting.Database.IterateBufferSize
 	sess := x.NewSession()
 	defer sess.Close()
 	for {
@@ -63,24 +71,29 @@ func expandWebhooks(x *xorm.Engine) error {
 		last += len(results)
 
 		for _, res := range results {
+			var events HookEvent
 			if err = json.Unmarshal([]byte(res.Events), &events); err != nil {
 				return err
 			}
 
-			if events.Events.Issues {
-				events.Events.IssueAssign = true
-				events.Events.IssueLabel = true
-				events.Events.IssueMilestone = true
-				events.Events.IssueComment = true
+			if !events.ChooseEvents {
+				continue
 			}
 
-			if events.Events.PullRequest {
-				events.Events.PullRequestAssign = true
-				events.Events.PullRequestLabel = true
-				events.Events.PullRequestMilestone = true
-				events.Events.PullRequestComment = true
-				events.Events.PullRequestReview = true
-				events.Events.PullRequestSync = true
+			if events.Issues {
+				events.IssueAssign = true
+				events.IssueLabel = true
+				events.IssueMilestone = true
+				events.IssueComment = true
+			}
+
+			if events.PullRequest {
+				events.PullRequestAssign = true
+				events.PullRequestLabel = true
+				events.PullRequestMilestone = true
+				events.PullRequestComment = true
+				events.PullRequestReview = true
+				events.PullRequestSync = true
 			}
 
 			if bytes, err = json.Marshal(&events); err != nil {


### PR DESCRIPTION
This PR should correct the granular webhook migration. It also tidies up the migration to make it easier to compare to the models structs.

I think the biggest things to note are

1. Completing the structs, as otherwise I think JSON may have incorrectly assigned some values.
2. Having a new `HookEvent` for each loop, as otherwise I think re-using it can cause muddied data.

Proof of concept on why it was failing before: https://play.golang.org/p/_L6VYgQsn1a