### PR TITLE
Fix tag/release deletion

### DIFF
--- a/modules/repofiles/update.go
+++ b/modules/repofiles/update.go
@@ -698,7 +698,7 @@ func createCommitRepoActions(repo *models.Repository, gitRepo *git.Repository, o
 			return nil, fmt.Errorf("Old and new revisions are both %s", git.EmptySHA)
 		}
 		var commits = &repo_module.PushCommits{}
-		if opts.IsNewTag() {
+		if opts.IsTag() {
 			// If is tag reference
 			tagName := opts.TagName()
 			if opts.IsDelRef() {


### PR DESCRIPTION
Currently you cannot delete a light tag from a repo because deleting a tag is never a "new tag".

1. Create a repo
2. Push a new light tag `git tag test && git push --tags`
3. Delete the tag and update it in remote `git tag -d test && git push origin :test`
4. Tag still shows up in release tab