### PR TITLE
Make PR message on pushes configurable

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -870,7 +870,9 @@ MAX_GIT_DIFF_FILES = 100
 ; see more on http://git-scm.com/docs/git-gc/
 GC_ARGS =
 ; If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
-EnableAutoGitWireProtocol = true
+ENABLE_AUTO_GIT_WIRE_PROTOCOL = true
+; Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
+PULL_REQUEST_PUSH_MESSAGE = true
 
 ; Operation timeout in seconds
 [git.timeout]

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -541,6 +541,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 - `MAX_GIT_DIFF_FILES`: **100**: Max number of files shown in diff view.
 - `GC_ARGS`: **\<empty\>**: Arguments for command `git gc`, e.g. `--aggressive --auto`. See more on http://git-scm.com/docs/git-gc/
 - `ENABLE_AUTO_GIT_WIRE_PROTOCOL`: **true**: If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
+- `PULL_REQUEST_PUSH_MESSAGE`: **true**: Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
 - `VERBOSE_PUSH`: **true**: Print status information about pushes as they are being processed.
 - `VERBOSE_PUSH_DELAY`: **5s**: Only print verbose information if push takes longer than this delay.
 

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -25,6 +25,7 @@ var (
 		VerbosePushDelay          time.Duration
 		GCArgs                    []string `ini:"GC_ARGS" delim:" "`
 		EnableAutoGitWireProtocol bool
+		PullRequestPushMessage bool
 		Timeout                   struct {
 			Default int
 			Migrate int
@@ -42,6 +43,7 @@ var (
 		VerbosePushDelay:          5 * time.Second,
 		GCArgs:                    []string{},
 		EnableAutoGitWireProtocol: true,
+		PullRequestPushMessage: true,
 		Timeout: struct {
 			Default int
 			Migrate int

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -25,7 +25,7 @@ var (
 		VerbosePushDelay          time.Duration
 		GCArgs                    []string `ini:"GC_ARGS" delim:" "`
 		EnableAutoGitWireProtocol bool
-		PullRequestPushMessage bool
+		PullRequestPushMessage    bool
 		Timeout                   struct {
 			Default int
 			Migrate int
@@ -43,7 +43,7 @@ var (
 		VerbosePushDelay:          5 * time.Second,
 		GCArgs:                    []string{},
 		EnableAutoGitWireProtocol: true,
-		PullRequestPushMessage: true,
+		PullRequestPushMessage:    true,
 		Timeout: struct {
 			Default int
 			Migrate int

--- a/routers/private/hook.go
+++ b/routers/private/hook.go
@@ -19,6 +19,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/private"
 	"code.gitea.io/gitea/modules/repofiles"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	pull_service "code.gitea.io/gitea/services/pull"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -428,14 +429,14 @@ func HookPostReceive(ctx *macaron.Context, opts private.HookOptions) {
 					branch = fmt.Sprintf("%s:%s", repo.OwnerName, branch)
 				}
 				results = append(results, private.HookPostReceiveBranchResult{
-					Message: true,
+					Message: setting.Git.PullRequestPushMessage && repo.AllowsPulls(),
 					Create:  true,
 					Branch:  branch,
 					URL:     fmt.Sprintf("%s/compare/%s...%s", baseRepo.HTMLURL(), util.PathEscapeSegments(baseRepo.DefaultBranch), util.PathEscapeSegments(branch)),
 				})
 			} else {
 				results = append(results, private.HookPostReceiveBranchResult{
-					Message: true,
+					Message: setting.Git.PullRequestPushMessage && repo.AllowsPulls(),
 					Create:  false,
 					Branch:  branch,
 					URL:     fmt.Sprintf("%s/pulls/%d", baseRepo.HTMLURL(), pr.Index),


### PR DESCRIPTION
Resolves #5801 

This PR adds a global config to enable/disable the new PR message on pushing

e.g.
```
remote: Create a new pull request for 'test2':
remote:   http://localhost:3000/Test2/tag/compare/master...test2
```

It also suppresses the message if the repo in question has PRs disabled.
