### PR TITLE
cross compile using go 1.13.x (#10684)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -379,7 +379,7 @@ steps:
 
   - name: static
     pull: always
-    image: techknowlogick/xgo:latest
+    image: techknowlogick/xgo:go-1.13.x
     commands:
       - apt update && apt -y install curl
       - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
@@ -477,7 +477,7 @@ steps:
 
   - name: static
     pull: always
-    image: techknowlogick/xgo:latest
+    image: techknowlogick/xgo:go-1.13.x
     commands:
       - apt update && apt -y install curl
       - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs


### PR DESCRIPTION
Frontport from #10684. Pin xgo to v1.13 until #10467 merged.