### PR TITLE
Prevent default for linkAction

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2720,7 +2720,8 @@ function showAddAllPopup() {
   return false;
 }
 
-function linkAction() {
+function linkAction(e) {
+  e.preventDefault();
   const $this = $(this);
   const redirect = $this.data('redirect');
   $.post($this.data('url'), {


### PR DESCRIPTION
Should fix #10647   
Should fix #10740 

`linkAction` was sometimes losing the _race_ to complete the POST before redirecting.