### PR TITLE
ui: hide gear icon for user who can't use them on sidebar

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -5,7 +5,9 @@
 		<div class="ui {{if or (not .IsIssueWriter) .Repository.IsArchived}}disabled{{end}} floating jump select-label dropdown">
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
-				{{svg "octicon-gear" 16}}
+				{{if and .IsIssueWriter (not .Repository.IsArchived)}}
+					{{svg "octicon-gear" 16}}
+				{{end}}
 			</span>
 			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
@@ -30,7 +32,9 @@
 		<div class="ui {{if or (not .IsIssueWriter) .Repository.IsArchived}}disabled{{end}} floating jump select-milestone dropdown">
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
-				{{svg "octicon-gear" 16}}
+				{{if and .IsIssueWriter (not .Repository.IsArchived)}}
+					{{svg "octicon-gear" 16}}
+				{{end}}
 			</span>
 			<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/milestone">
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_milestone"}}</div>
@@ -71,7 +75,9 @@
 		<div class="ui {{if or (not .IsIssueWriter) .Repository.IsArchived}}disabled{{end}} floating jump select-assignees-modify dropdown">
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
-				{{svg "octicon-gear" 16}}
+				{{if and .IsIssueWriter (not .Repository.IsArchived)}}
+					{{svg "octicon-gear" 16}}
+				{{end}}
 			</span>
 			<div class="filter menu" data-action="" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/assignee">
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignees"}}</div>


### PR DESCRIPTION
reason:
If user can't choose the Assignees labels and Milestone It's
not usefull to show a gear label , and it It will mislead the
user into thinking that it's a BUG rather than thy don't have
permission to chosse them.
