### PR TITLE
Document Makefile requiring dev NODE_ENV

### DIFF
--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -103,7 +103,7 @@ development and testing easier, but is not ideal for a production deployment.
 To include assets, add the `bindata` tag:
 
 ```bash
-TAGS="bindata" make build
+NODE_ENV="development" TAGS="bindata" make build
 ```
 
 In the default release build of our continuous integration system, the build


### PR DESCRIPTION
Hopefully this'll be temporary, or even rejected over a better solution. To quickly summarize: Some npm devDependencies are required for the frontend build steps, and it doesn't seem to be documented that development node environment is required in order for make to work.

### Longer explanation:

Due to some dependencies, like `webpack-cli` for example, being required to build the project whilst still being in the devDependencies of the `package.json` file, the project fails to build if someone has their default NODE_ENV set to production instead of development.

As of writing this, if NODE_ENV is set to production, eslint fails first, due to at least missing `eslint-config-airbnb-base`. Then webpack fails due to missing webpack-cli. Then stylelint fails. And lastly, postcss is missing.