### PR TITLE
Fix bug on branch API

### DIFF
--- a/modules/convert/convert.go
+++ b/modules/convert/convert.go
@@ -49,17 +49,21 @@ func ToBranch(repo *models.Repository, b *git.Branch, c *git.Commit, bp *models.
 		branchProtectionName = bp.BranchName
 	}
 
-	return &api.Branch{
+	branch := &api.Branch{
 		Name:                          b.Name,
 		Commit:                        ToCommit(repo, c),
 		Protected:                     true,
 		RequiredApprovals:             bp.RequiredApprovals,
 		EnableStatusCheck:             bp.EnableStatusCheck,
 		StatusCheckContexts:           bp.StatusCheckContexts,
-		UserCanPush:                   bp.CanUserPush(user.ID),
-		UserCanMerge:                  bp.IsUserMergeWhitelisted(user.ID),
 		EffectiveBranchProtectionName: branchProtectionName,
 	}
+
+	if user != nil {
+		branch.UserCanPush = bp.CanUserPush(user.ID)
+		branch.UserCanMerge = bp.IsUserMergeWhitelisted(user.ID)
+	}
+	return branch
 }
 
 // ToBranchProtection convert a ProtectedBranch to api.BranchProtection


### PR DESCRIPTION
Fix #10738. When request the API with a non-login user, you cannot use `user.ID` so that it will panic. This PR let `canpush` and `canmerge` as `false` if not login.