### PR TITLE
Account for empty lines in receive-hook message

### DIFF
--- a/models/error.go
+++ b/models/error.go
@@ -1423,7 +1423,7 @@ func (err *ErrPushRejected) GenerateMessage() {
 		}
 		i += 8
 		nl := strings.IndexByte(err.StdErr[i:], '\n')
-		if nl > 0 {
+		if nl >= 0 {
 			messageBuilder.WriteString(err.StdErr[i : i+nl+1])
 			i = i + nl + 1
 		} else {


### PR DESCRIPTION
There is a bug with the remote message parsing in #10373 which leads to empty lines in remote messages being mishandled.

This PR fixes this. 