### PR TITLE
Fix branch api canPush and canMerge

### DIFF
--- a/integrations/api_branch_test.go
+++ b/integrations/api_branch_test.go
@@ -28,6 +28,8 @@ func testAPIGetBranch(t *testing.T, branchName string, exists bool) {
 	var branch api.Branch
 	DecodeJSON(t, resp, &branch)
 	assert.EqualValues(t, branchName, branch.Name)
+	assert.True(t, branch.UserCanPush)
+	assert.True(t, branch.UserCanMerge)
 }
 
 func testAPIGetBranchProtection(t *testing.T, branchName string, expectedHTTPStatus int) {

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -72,7 +72,13 @@ func GetBranch(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, convert.ToBranch(ctx.Repo.Repository, branch, c, branchProtection, ctx.User, ctx.Repo.IsAdmin()))
+	br, err := convert.ToBranch(ctx.Repo.Repository, branch, c, branchProtection, ctx.User, ctx.Repo.IsAdmin())
+	if err != nil {
+		ctx.Error(http.StatusInternalServerError, "convert.ToBranch", err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, br)
 }
 
 // ListBranches list all the branches of a repository
@@ -115,7 +121,11 @@ func ListBranches(ctx *context.APIContext) {
 			ctx.Error(http.StatusInternalServerError, "GetBranchProtection", err)
 			return
 		}
-		apiBranches[i] = convert.ToBranch(ctx.Repo.Repository, branches[i], c, branchProtection, ctx.User, ctx.Repo.IsAdmin())
+		apiBranches[i], err = convert.ToBranch(ctx.Repo.Repository, branches[i], c, branchProtection, ctx.User, ctx.Repo.IsAdmin())
+		if err != nil {
+			ctx.Error(http.StatusInternalServerError, "convert.ToBranch", err)
+			return
+		}
 	}
 
 	ctx.JSON(http.StatusOK, &apiBranches)


### PR DESCRIPTION
#10767 missed to fix `UserCanPush` and `UserCanMerge`, this PR will fix them. It should not be always `true` even if there is no branch protection. It depends if user login and have permission to write to the code unit. 