### PR TITLE
Move System Default Fonts to Higher Priority

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -84,12 +84,12 @@
     h3,
     h4,
     h5 {
-        font-family: Roboto, @fonts, sans-serif;
+        font-family: @fonts, Roboto, sans-serif;
     }
 
     .home .hero h1,
     .home .hero h2 {
-        font-family: 'PT Sans Narrow', Roboto, @fonts, sans-serif;
+        font-family: 'PT Sans Narrow', @fonts, Roboto, sans-serif;
     }
 
     .ui.accordion .title:not(.ui),
@@ -128,7 +128,7 @@
     .ui.steps .step .title,
     .ui.text.container,
     .ui.language > .menu > .item& {
-        font-family: Roboto, @fonts, sans-serif;
+        font-family: @fonts, Roboto, sans-serif;
     }
 }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -69,13 +69,13 @@
 @default-fonts: -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, Helvetica, Arial;
 @monospaced-fonts: 'SF Mono', Consolas, Menlo, 'Liberation Mono', Monaco, 'Lucida Console';
 
-.override-fonts(@fonts) {
+.override-fonts(@default-fonts) {
     textarea {
-        font-family: @fonts, sans-serif;
+        font-family: @default-fonts, sans-serif;
     }
 
     .markdown:not(code) {
-        font-family: @fonts, sans-serif;
+        font-family: @default-fonts, sans-serif;
     }
 
     /* We're going to just override the semantic fonts here */
@@ -84,12 +84,12 @@
     h3,
     h4,
     h5 {
-        font-family: @fonts, Roboto, sans-serif;
+        font-family: @default-fonts, Roboto, sans-serif;
     }
 
     .home .hero h1,
     .home .hero h2 {
-        font-family: 'PT Sans Narrow', @fonts, Roboto, sans-serif;
+        font-family: 'PT Sans Narrow', @default-fonts, Roboto, sans-serif;
     }
 
     .ui.accordion .title:not(.ui),
@@ -128,11 +128,9 @@
     .ui.steps .step .title,
     .ui.text.container,
     .ui.language > .menu > .item& {
-        font-family: @fonts, Roboto, sans-serif;
+        font-family: @default-fonts, Roboto, sans-serif;
     }
 }
-
-.override-fonts(@default-fonts);
 
 body {
     background-color: #ffffff;


### PR DESCRIPTION
Currently, Roboto font will be used regardless of user's OS. On GitHub
and Gitlab, system default font on Windows and MacOS is used instead.

This commit move `@default-fonts` to higher priority listing on `font-family`
property argument, so that system default font on Windows and MacOS
will be utilized, and Roboto is used on other platforms.