### PR TITLE
Convert plumbing.ErrReferenceNotFound to git.ErrNotExist in GetRefCommitID (#10676)

### DIFF
--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/mcuadros/go-version"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // GetRefCommitID returns the last commit ID string of given reference (branch or tag).

--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -12,15 +12,20 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/mcuadros/go-version"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
 // GetRefCommitID returns the last commit ID string of given reference (branch or tag).
 func (repo *Repository) GetRefCommitID(name string) (string, error) {
 	ref, err := repo.gogitRepo.Reference(plumbing.ReferenceName(name), true)
 	if err != nil {
+		if err == plumbing.ErrReferenceNotFound {
+			return "", ErrNotExist{
+				ID: name,
+			}
+		}
 		return "", err
 	}
 

--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -16,8 +16,6 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/repofiles"
 	"code.gitea.io/gitea/modules/util"
-
-	"github.com/go-git/go-git/v5/plumbing"
 )
 
 const (
@@ -253,7 +251,7 @@ func loadBranches(ctx *context.Context) []*Branch {
 					repoIDToGitRepo[pr.BaseRepoID] = baseGitRepo
 				}
 				pullCommit, err := baseGitRepo.GetRefCommitID(pr.GetGitRefName())
-				if err != nil && err != plumbing.ErrReferenceNotFound {
+				if err != nil && !git.IsErrNotExist(err) {
 					ctx.ServerError("GetBranchCommitID", err)
 					return nil
 				}


### PR DESCRIPTION
Backport #10676

Convert plumbing.ErrReferenceNotFound to git.ErrNotExist in GetRefCommitID

Signed-off-by: Andrew Thornton <art27@cantab.net>
