### PR TITLE
Allow to set protected file patterns for files that can not be changed under no conditions

### DIFF
--- a/models/error.go
+++ b/models/error.go
@@ -916,6 +916,25 @@ func (err ErrFilePathInvalid) Error() string {
 	return fmt.Sprintf("path is invalid [path: %s]", err.Path)
 }
 
+// ErrFilePathProtected represents a "FilePathProtected" kind of error.
+type ErrFilePathProtected struct {
+	Message string
+	Path    string
+}
+
+// IsErrFilePathProtected checks if an error is an ErrFilePathProtected.
+func IsErrFilePathProtected(err error) bool {
+	_, ok := err.(ErrFilePathProtected)
+	return ok
+}
+
+func (err ErrFilePathProtected) Error() string {
+	if err.Message != "" {
+		return err.Message
+	}
+	return fmt.Sprintf("path is protected and can not be changed [path: %s]", err.Path)
+}
+
 // ErrUserDoesNotHaveAccessToRepo represets an error where the user doesn't has access to a given repo.
 type ErrUserDoesNotHaveAccessToRepo struct {
 	UserID   int64

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -196,6 +196,8 @@ var migrations = []Migration{
 	NewMigration("Expand webhooks for more granularity", expandWebhooks),
 	// v131 -> v132
 	NewMigration("Add IsSystemWebhook column to webhooks table", addSystemWebhookColumn),
+	// v132 -> v133
+	NewMigration("Add Branch Protection Protected Files Column", addBranchProtectionProtectedFilesColumn),
 }
 
 // Migrate database to current version

--- a/models/migrations/v132.go
+++ b/models/migrations/v132.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"xorm.io/xorm"
+)
+
+func addBranchProtectionProtectedFilesColumn(x *xorm.Engine) error {
+	type ProtectedBranch struct {
+		ProtectedFilePatterns string `xorm:"TEXT"`
+	}
+
+	if err := x.Sync2(new(ProtectedBranch)); err != nil {
+		return fmt.Errorf("Sync2: %v", err)
+	}
+	return nil
+}

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -174,6 +174,7 @@ type ProtectBranchForm struct {
 	BlockOnRejectedReviews   bool
 	DismissStaleApprovals    bool
 	RequireSignedCommits     bool
+	ProtectedFilePatterns    string
 }
 
 // Validate validates the fields

--- a/modules/convert/convert.go
+++ b/modules/convert/convert.go
@@ -120,6 +120,7 @@ func ToBranchProtection(bp *models.ProtectedBranch) *api.BranchProtection {
 		BlockOnRejectedReviews:      bp.BlockOnRejectedReviews,
 		DismissStaleApprovals:       bp.DismissStaleApprovals,
 		RequireSignedCommits:        bp.RequireSignedCommits,
+		ProtectedFilePatterns:       bp.ProtectedFilePatterns,
 		Created:                     bp.CreatedUnix.AsTime(),
 		Updated:                     bp.UpdatedUnix.AsTime(),
 	}

--- a/modules/repofiles/delete.go
+++ b/modules/repofiles/delete.go
@@ -60,19 +60,29 @@ func DeleteRepoFile(repo *models.Repository, doer *models.User, opts *DeleteRepo
 		if err != nil {
 			return nil, err
 		}
-		if protectedBranch != nil && !protectedBranch.CanUserPush(doer.ID) {
-			return nil, models.ErrUserCannotCommit{
-				UserName: doer.LowerName,
-			}
-		}
-		if protectedBranch != nil && protectedBranch.RequireSignedCommits {
-			_, _, err := repo.SignCRUDAction(doer, repo.RepoPath(), opts.OldBranch)
-			if err != nil {
-				if !models.IsErrWontSign(err) {
-					return nil, err
-				}
+		if protectedBranch != nil {
+			if !protectedBranch.CanUserPush(doer.ID) {
 				return nil, models.ErrUserCannotCommit{
 					UserName: doer.LowerName,
+				}
+			}
+			if protectedBranch.RequireSignedCommits {
+				_, _, err := repo.SignCRUDAction(doer, repo.RepoPath(), opts.OldBranch)
+				if err != nil {
+					if !models.IsErrWontSign(err) {
+						return nil, err
+					}
+					return nil, models.ErrUserCannotCommit{
+						UserName: doer.LowerName,
+					}
+				}
+			}
+			patterns := protectedBranch.GetProtectedFilePatterns()
+			for _, pat := range patterns {
+				if pat.Match(strings.ToLower(opts.TreePath)) {
+					return nil, models.ErrFilePathProtected{
+						Path: opts.TreePath,
+					}
 				}
 			}
 		}

--- a/modules/structs/repo_branch.go
+++ b/modules/structs/repo_branch.go
@@ -41,6 +41,7 @@ type BranchProtection struct {
 	BlockOnRejectedReviews      bool     `json:"block_on_rejected_reviews"`
 	DismissStaleApprovals       bool     `json:"dismiss_stale_approvals"`
 	RequireSignedCommits        bool     `json:"require_signed_commits"`
+	ProtectedFilePatterns       string   `json:"protected_file_patterns"`
 	// swagger:strfmt date-time
 	Created time.Time `json:"created_at"`
 	// swagger:strfmt date-time
@@ -67,6 +68,7 @@ type CreateBranchProtectionOption struct {
 	BlockOnRejectedReviews      bool     `json:"block_on_rejected_reviews"`
 	DismissStaleApprovals       bool     `json:"dismiss_stale_approvals"`
 	RequireSignedCommits        bool     `json:"require_signed_commits"`
+	ProtectedFilePatterns       string   `json:"protected_file_patterns"`
 }
 
 // EditBranchProtectionOption options for editing a branch protection
@@ -88,4 +90,5 @@ type EditBranchProtectionOption struct {
 	BlockOnRejectedReviews      *bool    `json:"block_on_rejected_reviews"`
 	DismissStaleApprovals       *bool    `json:"dismiss_stale_approvals"`
 	RequireSignedCommits        *bool    `json:"require_signed_commits"`
+	ProtectedFilePatterns       *string  `json:"protected_file_patterns"`
 }

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1488,6 +1488,8 @@ settings.dismiss_stale_approvals = Dismiss stale approvals
 settings.dismiss_stale_approvals_desc = When new commits that change the content of the pull request are pushed to the branch, old approvals will be dismissed.
 settings.require_signed_commits = Require Signed Commits
 settings.require_signed_commits_desc = Reject pushes to this branch if they are unsigned or unverifiable
+settings.protect_protected_file_patterns = Protected file patterns (separated using semicolon ';'):
+settings.protect_protected_file_patterns_desc = Protected files that are not allowed to be changed directly even if user has rights to add, edit or delete files in this branch. Multiple patterns can be separated using semicolon (';'). See <a href="https://godoc.org/github.com/gobwas/glob#Compile">github.com/gobwas/glob</a> documentation for pattern syntax. Examples: <code>.drone.yml</code>, <code>/docs/**/*.txt</code>.
 settings.add_protected_branch = Enable protection
 settings.delete_protected_branch = Disable protection
 settings.update_protect_branch_success = Branch protection for branch '%s' has been updated.

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -339,6 +339,7 @@ func CreateBranchProtection(ctx *context.APIContext, form api.CreateBranchProtec
 		BlockOnRejectedReviews:   form.BlockOnRejectedReviews,
 		DismissStaleApprovals:    form.DismissStaleApprovals,
 		RequireSignedCommits:     form.RequireSignedCommits,
+		ProtectedFilePatterns:    form.ProtectedFilePatterns,
 	}
 
 	err = models.UpdateProtectBranch(ctx.Repo.Repository, protectBranch, models.WhitelistOptions{
@@ -468,6 +469,10 @@ func EditBranchProtection(ctx *context.APIContext, form api.EditBranchProtection
 
 	if form.RequireSignedCommits != nil {
 		protectBranch.RequireSignedCommits = *form.RequireSignedCommits
+	}
+
+	if form.ProtectedFilePatterns != nil {
+		protectBranch.ProtectedFilePatterns = *form.ProtectedFilePatterns
 	}
 
 	var whitelistUsers []int64

--- a/routers/repo/setting_protected_branch.go
+++ b/routers/repo/setting_protected_branch.go
@@ -247,6 +247,7 @@ func SettingsProtectedBranchPost(ctx *context.Context, f auth.ProtectBranchForm)
 		protectBranch.BlockOnRejectedReviews = f.BlockOnRejectedReviews
 		protectBranch.DismissStaleApprovals = f.DismissStaleApprovals
 		protectBranch.RequireSignedCommits = f.RequireSignedCommits
+		protectBranch.ProtectedFilePatterns = f.ProtectedFilePatterns
 
 		err = models.UpdateProtectBranch(ctx.Repo.Repository, protectBranch, models.WhitelistOptions{
 			UserIDs:          whitelistUsers,

--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -225,6 +225,11 @@
 							<p class="help">{{.i18n.Tr "repo.settings.require_signed_commits_desc"}}</p>
 						</div>
 					</div>
+					<div class="field">
+						<label for="protected_file_patterns">{{.i18n.Tr "repo.settings.protect_protected_file_patterns"}}</label>
+						<input name="protected_file_patterns" id="protected_file_patterns" type="text" value="{{.Branch.ProtectedFilePatterns}}">
+						<p class="help">{{.i18n.Tr "repo.settings.protect_protected_file_patterns_desc" | Safe}}</p>
+					</div>
 
 				</div>
 

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -9818,6 +9818,10 @@
           },
           "x-go-name": "MergeWhitelistUsernames"
         },
+        "protected_file_patterns": {
+          "type": "string",
+          "x-go-name": "ProtectedFilePatterns"
+        },
         "push_whitelist_deploy_keys": {
           "type": "boolean",
           "x-go-name": "PushWhitelistDeployKeys"
@@ -10128,6 +10132,10 @@
             "type": "string"
           },
           "x-go-name": "MergeWhitelistUsernames"
+        },
+        "protected_file_patterns": {
+          "type": "string",
+          "x-go-name": "ProtectedFilePatterns"
         },
         "push_whitelist_deploy_keys": {
           "type": "boolean",
@@ -10927,6 +10935,10 @@
             "type": "string"
           },
           "x-go-name": "MergeWhitelistUsernames"
+        },
+        "protected_file_patterns": {
+          "type": "string",
+          "x-go-name": "ProtectedFilePatterns"
         },
         "push_whitelist_deploy_keys": {
           "type": "boolean",


### PR DESCRIPTION
When pattern is set files that match them can not be changed neither using PR, nor push or web editor.

This could be later in other PR probably improved with exceptions to allow changing in PR

Screenshots:
![image](https://user-images.githubusercontent.com/165205/77354354-5b4d7880-6d4b-11ea-8b55-241246dcbb4d.png)

![image](https://user-images.githubusercontent.com/165205/77354373-656f7700-6d4b-11ea-8132-08a4aa821734.png)

![image](https://user-images.githubusercontent.com/165205/77354393-702a0c00-6d4b-11ea-8b8e-73381ae54efc.png)
