### PR TITLE
Fix repo summary height

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2181,9 +2181,6 @@
     }
 
     .repository-summary {
-        height: 48px;
-        overflow: hidden;
-
         .segment.language-stats-details,
         .segment.repository-summary {
             border-top: none;
@@ -2794,4 +2791,10 @@ td.blob-excerpt {
 
 .diff-file-box[data-folded="true"] .diff-file-header {
     border-radius: .28571429rem !important;
+}
+
+/* prevent page shaking on language bar click */
+.repository.file .repository-summary {
+    height: 48px;
+    overflow: hidden;
 }


### PR DESCRIPTION
Extracted the style that keeps the animation of the language bar in check.

Fixes: https://github.com/go-gitea/gitea/issues/10754

<img width="388" src="https://user-images.githubusercontent.com/115237/77588707-abaf0c80-6eea-11ea-8f2c-e35175badb36.png">
