### PR TITLE
Fix thick scrollbar on filter menu

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -175,9 +175,10 @@
 
         .menu {
             max-height: 300px;
-            overflow-x: auto;
+            overflow-x: hidden;
             right: 0 !important;
             left: auto !important;
+            scrollbar-width: thin;
         }
 
         .dropdown.item {


### PR DESCRIPTION
Before:
![firefox_2020-03-26_12-32-26](https://user-images.githubusercontent.com/1447794/77643236-4e08d780-6f5f-11ea-9185-42e8fef8eef7.png)
![firefox_2020-03-26_12-32-45](https://user-images.githubusercontent.com/1447794/77643380-890b0b00-6f5f-11ea-9f84-9b8f02bcfd9d.png)


After:
![firefox_2020-03-26_12-38-38](https://user-images.githubusercontent.com/1447794/77643273-5e20b700-6f5f-11ea-998f-7de02b6d8fbb.png)
![firefox_2020-03-26_12-44-49](https://user-images.githubusercontent.com/1447794/77643409-9922ea80-6f5f-11ea-90fc-cbae9fb61c5e.png)
