### PR TITLE
make `gitea admin auth list` formatting configurable

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -146,6 +146,37 @@ var (
 		Name:   "list",
 		Usage:  "List auth sources",
 		Action: runListAuth,
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "min-width",
+				Usage: "Minimal cell width including any padding for the formatted table",
+				Value: 0,
+			},
+			cli.IntFlag{
+				Name:  "tab-width",
+				Usage: "width of tab characters in formatted table (equivalent number of spaces)",
+				Value: 8,
+			},
+			cli.IntFlag{
+				Name:  "padding",
+				Usage: "padding added to a cell before computing its width",
+				Value: 1,
+			},
+			cli.StringFlag{
+				Name: "pad-char",
+				Usage: `ASCII char used for padding
+				if padchar == '\\t', the Writer will assume that the
+				width of a '\\t' in the formatted output is tabwidth,
+				and cells are left-aligned independent of align_left
+				(for correct-looking results, tabwidth must correspond
+				to the tab width in the viewer displaying the result)`,
+				Value: "\t",
+			},
+			cli.BoolFlag{
+				Name:  "vertical-bars",
+				Usage: "Set to true to print vertical bars between columns",
+			},
+		},
 	}
 
 	idFlag = cli.Int64Flag{
@@ -535,8 +566,18 @@ func runListAuth(c *cli.Context) error {
 		return err
 	}
 
+	flags := tabwriter.AlignRight
+	if c.Bool("vertical-bars") {
+		flags |= tabwriter.Debug
+	}
+
+	padChar := byte('\t')
+	if len(c.String("pad-char")) > 0 {
+		padChar = c.String("pad-char")[0]
+	}
+
 	// loop through each source and print
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
+	w := tabwriter.NewWriter(os.Stdout, c.Int("min-width"), c.Int("tab-width"), c.Int("padding"), padChar, flags)
 	fmt.Fprintf(w, "ID\tName\tType\tEnabled\n")
 	for _, source := range loginSources {
 		fmt.Fprintf(w, "%d\t%s\t%s\t%t\n", source.ID, source.Name, models.LoginNames[source.Type], source.IsActived)

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -163,13 +163,8 @@ var (
 				Value: 1,
 			},
 			cli.StringFlag{
-				Name: "pad-char",
-				Usage: `ASCII char used for padding
-				if padchar == '\\t', the Writer will assume that the
-				width of a '\\t' in the formatted output is tabwidth,
-				and cells are left-aligned independent of align_left
-				(for correct-looking results, tabwidth must correspond
-				to the tab width in the viewer displaying the result)`,
+				Name:  "pad-char",
+				Usage: `ASCII char used for padding if padchar == '\\t', the Writer will assume that the width of a '\\t' in the formatted output is tabwidth, and cells are left-aligned independent of align_left (for correct-looking results, tabwidth must correspond to the tab width in the viewer displaying the result)`,
 				Value: "\t",
 			},
 			cli.BoolFlag{


### PR DESCRIPTION
* Add a number of options to make `gitea admin auth list` formatting configurable
* Change default to use tabs

Fix #9707

Signed-off-by: Andrew Thornton <art27@cantab.net>