### PR TITLE
Fix internal server error on checkboxes

### DIFF
--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -85,7 +85,7 @@ func (g *GiteaASTTransformer) Transform(node *ast.Document, reader text.Reader, 
 		case *ast.List:
 			if v.HasChildren() && v.FirstChild().HasChildren() && v.FirstChild().FirstChild().HasChildren() {
 				if _, ok := v.FirstChild().FirstChild().FirstChild().(*east.TaskCheckBox); ok {
-					v.SetAttributeString("class", "task-list")
+					v.SetAttributeString("class", []byte("task-list"))
 				}
 			}
 		}


### PR DESCRIPTION
Annoyingly goldmarks SetAttributeString requires that
the value of the attribute is still a []byte but does
not make it clear in the documentation.

Fix #10842 

Signed-off-by: Andrew Thornton <art27@cantab.net>
