### PR TITLE
Remove test binary from binary installation docs

### DIFF
--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -33,15 +33,6 @@ gpg --keyserver pgp.mit.edu --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
 gpg --verify gitea-{{< version >}}-linux-amd64.asc gitea-{{< version >}}-linux-amd64
 ```
 
-## Test
-
-After getting a binary, it can be tested with `./gitea web` or moved to a permanent
-location. When launched manually, Gitea can be killed using `Ctrl+C`.
-
-```
-./gitea web
-```
-
 ## Recommended server configuration
 
 **NOTE:** Many of the following directories can be configured using [Environment Variables]({{< relref "doc/advanced/specific-variables.en-us.md" >}}) as well!


### PR DESCRIPTION
Even simply _testing_ Gitea will create files and directories, some of which may cause confusion or other problems further along in installation.

I propose to remove the `Test` section from the binary installation docs. Users can still test their binary if they use the [command](https://github.com/go-gitea/gitea/blob/master/docs/content/doc/installation/from-binary.en-us.md#2-running-from-command-lineterminal) detailed further down in the docs, which _should_ be a more accurate environment assuming the rest of the docs were followed.  