### PR TITLE
Change the order of issues.closed_by to list opening user first

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -894,9 +894,9 @@ issues.action_assignee_no_select = No assignee
 issues.opened_by = opened %[1]s by <a href="%[2]s">%[3]s</a>
 pulls.merged_by = merged %[1]s by <a href="%[2]s">%[3]s</a>
 pulls.merged_by_fake = merged %[1]s by %[2]s
-issues.closed_by = closed %[1]s by <a href="%[2]s">%[3]s</a>
+issues.closed_by = by <a href="%[2]s">%[3]s</a> closed %[1]s
 issues.opened_by_fake = opened %[1]s by %[2]s
-issues.closed_by_fake = closed %[1]s by %[2]s
+issues.closed_by_fake = by %[2]s closed %[1]s
 issues.previous = Previous
 issues.next = Next
 issues.open_title = Open


### PR DESCRIPTION
The simplest fix for the confusing `closed x minutes ago by opening_user` problem is to rearrange the order of the `issues.closed_by` string to `by opening_user closed x minutes ago`

Fix #8266

Signed-off-by: Andrew Thornton <art27@cantab.net>
