### PR TITLE
Upgrade golangci-lint to 1.24.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -621,6 +621,6 @@ pr\#%: clean-all
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		export BINARY="golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.20.0; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.24.0; \
 	fi
-	golangci-lint run --timeout 5m
+	env GO111MODULE=on golangci-lint run --timeout 5m

--- a/models/error.go
+++ b/models/error.go
@@ -227,7 +227,7 @@ func IsErrUserNotAllowedCreateOrg(err error) bool {
 }
 
 func (err ErrUserNotAllowedCreateOrg) Error() string {
-	return fmt.Sprintf("user is not allowed to create organizations")
+	return "user is not allowed to create organizations"
 }
 
 // ErrReachLimitOfRepo represents a "ReachLimitOfRepo" kind of error.
@@ -561,7 +561,7 @@ func IsErrAccessTokenEmpty(err error) bool {
 }
 
 func (err ErrAccessTokenEmpty) Error() string {
-	return fmt.Sprintf("access token is empty")
+	return "access token is empty"
 }
 
 // ________                            .__                __  .__
@@ -1107,7 +1107,7 @@ func IsErrSHAOrCommitIDNotProvided(err error) bool {
 }
 
 func (err ErrSHAOrCommitIDNotProvided) Error() string {
-	return fmt.Sprintf("a SHA or commmit ID must be proved when updating a file")
+	return "a SHA or commmit ID must be proved when updating a file"
 }
 
 //  __      __      ___.   .__                   __

--- a/models/notification.go
+++ b/models/notification.go
@@ -611,7 +611,7 @@ func (nl NotificationList) LoadIssues() ([]int, error) {
 
 // Without returns the notification list without the failures
 func (nl NotificationList) Without(failures []int) NotificationList {
-	if failures == nil || len(failures) == 0 {
+	if len(failures) == 0 {
 		return nl
 	}
 	remaining := make([]*Notification, 0, len(nl))

--- a/modules/private/key.go
+++ b/modules/private/key.go
@@ -34,7 +34,7 @@ func UpdatePublicKeyInRepo(keyID, repoID int64) error {
 // and returns public key found.
 func AuthorizedPublicKeyByContent(content string) (string, error) {
 	// Ask for running deliver hook and test pull request tasks.
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/ssh/authorized_keys")
+	reqURL := setting.LocalURL + "api/internal/ssh/authorized_keys"
 	req := newInternalRequest(reqURL, "POST")
 	req.Param("content", content)
 	resp, err := req.Response()

--- a/modules/private/manager.go
+++ b/modules/private/manager.go
@@ -15,7 +15,7 @@ import (
 
 // Shutdown calls the internal shutdown function
 func Shutdown() (int, string) {
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/manager/shutdown")
+	reqURL := setting.LocalURL + "api/internal/manager/shutdown"
 
 	req := newInternalRequest(reqURL, "POST")
 	resp, err := req.Response()
@@ -33,7 +33,7 @@ func Shutdown() (int, string) {
 
 // Restart calls the internal restart function
 func Restart() (int, string) {
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/manager/restart")
+	reqURL := setting.LocalURL + "api/internal/manager/restart"
 
 	req := newInternalRequest(reqURL, "POST")
 	resp, err := req.Response()
@@ -57,7 +57,7 @@ type FlushOptions struct {
 
 // FlushQueues calls the internal flush-queues function
 func FlushQueues(timeout time.Duration, nonBlocking bool) (int, string) {
-	reqURL := setting.LocalURL + fmt.Sprintf("api/internal/manager/flush-queues")
+	reqURL := setting.LocalURL + "api/internal/manager/flush-queues"
 
 	req := newInternalRequest(reqURL, "POST")
 	if timeout > 0 {

--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -422,7 +422,6 @@ func CompareDiff(ctx *context.Context) {
 	beforeCommitID := ctx.Data["BeforeCommitID"].(string)
 	afterCommitID := ctx.Data["AfterCommitID"].(string)
 
-
 	ctx.Data["Title"] = "Comparing " + base.ShortSha(beforeCommitID) + "..." + base.ShortSha(afterCommitID)
 
 	ctx.Data["IsRepoToolbarCommits"] = true

--- a/routers/repo/pull_review.go
+++ b/routers/repo/pull_review.go
@@ -51,13 +51,14 @@ func CreateCodeComment(ctx *context.Context, form auth.CodeCommentForm) {
 		return
 	}
 
-	log.Trace("Comment created: %d/%d/%d", ctx.Repo.Repository.ID, issue.ID, comment.ID)
-
-	if comment != nil {
-		ctx.Redirect(comment.HTMLURL())
-	} else {
+	if comment == nil {
+		log.Trace("Comment not created: %-v #%d[%d]", ctx.Repo.Repository, issue.Index, issue.ID)
 		ctx.Redirect(fmt.Sprintf("%s/pulls/%d/files", ctx.Repo.RepoLink, issue.Index))
+		return
 	}
+
+	log.Trace("Comment created: %-v #%d[%d] Comment[%d]", ctx.Repo.Repository, issue.Index, issue.ID, comment.ID)
+	ctx.Redirect(comment.HTMLURL())
 }
 
 // SubmitReview creates a review out of the existing pending review or creates a new one if no pending review exist


### PR DESCRIPTION
* upgrade golangci-lint to 1.24.0 to allow go 1.14 compatibility
* fix golangci-lint errors
* make `make golangci-lint` work when out of go-path

Signed-off-by: Andrew Thornton <art27@cantab.net>
