### PR TITLE
Generate Diff and Patch direct from Pull head (#10936)

### DIFF
--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -31,32 +31,19 @@ func DownloadPatch(pr *models.PullRequest, w io.Writer, patch bool) error {
 
 // DownloadDiffOrPatch will write the patch for the pr to the writer
 func DownloadDiffOrPatch(pr *models.PullRequest, w io.Writer, patch bool) error {
-	// Clone base repo.
-	tmpBasePath, err := createTemporaryRepo(pr)
-	if err != nil {
-		log.Error("CreateTemporaryPath: %v", err)
+	if err := pr.LoadBaseRepo(); err != nil {
+		log.Error("Unable to load base repository ID %d for pr #%d [%d]", pr.BaseRepoID, pr.Index, pr.ID)
 		return err
 	}
-	defer func() {
-		if err := models.RemoveTemporaryPath(tmpBasePath); err != nil {
-			log.Error("DownloadDiff: RemoveTemporaryPath: %s", err)
-		}
-	}()
 
-	gitRepo, err := git.OpenRepository(tmpBasePath)
+	gitRepo, err := git.OpenRepository(pr.BaseRepo.RepoPath())
 	if err != nil {
 		return fmt.Errorf("OpenRepository: %v", err)
 	}
 	defer gitRepo.Close()
-
-	pr.MergeBase, err = git.NewCommand("merge-base", "--", "base", "tracking").RunInDir(tmpBasePath)
-	if err != nil {
-		pr.MergeBase = "base"
-	}
-	pr.MergeBase = strings.TrimSpace(pr.MergeBase)
-	if err := gitRepo.GetDiffOrPatch(pr.MergeBase, "tracking", w, patch); err != nil {
-		log.Error("Unable to get patch file from %s to %s in %s/%s Error: %v", pr.MergeBase, pr.HeadBranch, pr.BaseRepo.MustOwner().Name, pr.BaseRepo.Name, err)
-		return fmt.Errorf("Unable to get patch file from %s to %s in %s/%s Error: %v", pr.MergeBase, pr.HeadBranch, pr.BaseRepo.MustOwner().Name, pr.BaseRepo.Name, err)
+	if err := gitRepo.GetDiffOrPatch(pr.MergeBase, pr.GetGitRefName(), w, patch); err != nil {
+		log.Error("Unable to get patch file from %s to %s in %s Error: %v", pr.MergeBase, pr.HeadBranch, pr.BaseRepo.FullName(), err)
+		return fmt.Errorf("Unable to get patch file from %s to %s in %s Error: %v", pr.MergeBase, pr.HeadBranch, pr.BaseRepo.FullName(), err)
 	}
 	return nil
 }


### PR DESCRIPTION
Backport #10936

* Generate Diff and Patch direct from Pull head

Fix #10932
Also fix "Empty Diff/Patch File when pull is merged"

Closes #10934

* Add tests to ensure that diff does not change
* Ensure diffs and pulls pages work if head branch is deleted too

Signed-off-by: Andrew Thornton <art27@cantab.net>

See below for a comment on why this code might not necessarily always be correct in 1.11
