### PR TITLE
ui: change time-line event icons tyle

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -554,7 +554,7 @@ func updateIssueCols(e Engine, issue *Issue, cols ...string) error {
 	return nil
 }
 
-func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed bool) (*Comment, error) {
+func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed, isMerge bool) (*Comment, error) {
 	// Reload the issue
 	currentIssue, err := getIssueByID(e, issue.ID)
 	if err != nil {
@@ -623,10 +623,11 @@ func (issue *Issue) changeStatus(e *xorm.Session, doer *User, isClosed bool) (*C
 	}
 
 	return createComment(e, &CreateCommentOptions{
-		Type:  cmtType,
-		Doer:  doer,
-		Repo:  issue.Repo,
-		Issue: issue,
+		Type:            cmtType,
+		Doer:            doer,
+		Repo:            issue.Repo,
+		Issue:           issue,
+		RemovedAssignee: isMerge, // use RemovedAssignee as isMerge
 	})
 }
 
@@ -645,7 +646,7 @@ func (issue *Issue) ChangeStatus(doer *User, isClosed bool) (*Comment, error) {
 		return nil, err
 	}
 
-	comment, err := issue.changeStatus(sess, doer, isClosed)
+	comment, err := issue.changeStatus(sess, doer, isClosed, false)
 	if err != nil {
 		return nil, err
 	}

--- a/models/pull.go
+++ b/models/pull.go
@@ -561,7 +561,7 @@ func (pr *PullRequest) SetMerged() (bool, error) {
 		return false, err
 	}
 
-	if _, err := pr.Issue.changeStatus(sess, pr.Merger, true); err != nil {
+	if _, err := pr.Issue.changeStatus(sess, pr.Merger, true, true); err != nil {
 		return false, fmt.Errorf("Issue.changeStatus: %v", err)
 	}
 

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -913,6 +913,7 @@ issues.context.edit = Edit
 issues.context.delete = Delete
 issues.no_content = There is no content yet.
 issues.close_issue = Close
+issues.pull_merged_at = `merged commit <a href="%[1]s">%[2]s</a> into <code>%[3]s</code> %[4]s`
 issues.close_comment_issue = Comment and Close
 issues.reopen_issue = Reopen
 issues.reopen_comment_issue = Comment and Reopen

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -939,6 +939,10 @@ func ViewIssue(ctx *context.Context) {
 				ctx.ServerError("LoadReview", err)
 				return
 			}
+			if err = comment.LoadIsOfficeReview(); err != nil {
+				ctx.ServerError("LoadIsOfficeReview", err)
+				return
+			}
 			participants = addParticipant(comment.Poster, participants)
 			if comment.Review == nil {
 				continue

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -3,8 +3,9 @@
 	{{ $createdStr:= TimeSinceUnix .CreatedUnix $.Lang }}
 
 	<!-- 0 = COMMENT, 1 = REOPEN, 2 = CLOSE, 3 = ISSUE_REF, 4 = COMMIT_REF,
-	 5 = COMMENT_REF, 6 = PULL_REF, 7 = COMMENT_LABEL, 12 = START_TRACKING,
-	 13 = STOP_TRACKING, 14 = ADD_TIME_MANUAL, 16 = ADDED_DEADLINE, 17 = MODIFIED_DEADLINE,
+	 5 = COMMENT_REF, 6 = PULL_REF, 7 = COMMENT_LABEL, 8 = COMMENT_MIlESTONE, 9 = COMMENT_ASSIGNEES,
+	 10 = COMMENT_CHANGE_TITLE, 11 = DELETE_BRANCH, 12 = START_TRACKING, 13 = STOP_TRACKING, 
+	 14 = ADD_TIME_MANUAL, 15 = CANCEL_TRACKING, 16 = ADDED_DEADLINE, 17 = MODIFIED_DEADLINE,
 	 18 = REMOVED_DEADLINE, 19 = ADD_DEPENDENCY, 20 = REMOVE_DEPENDENCY, 21 = CODE,
 	 22 = REVIEW, 23 = ISSUE_LOCKED, 24 = ISSUE_UNLOCKED, 25 = TARGET_BRANCH_CHANGED,
 	 26 = DELETE_TIME_MANUAL -->
@@ -70,7 +71,7 @@
 		</div>
 	{{else if eq .Type 1}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol bg-green white">{{svg "octicon-primitive-dot" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -78,12 +79,27 @@
 		</div>
 	{{else if eq .Type 2}}
 		<div class="event" id="{{.HashTag}}">
-			<span class="issue-symbol">{{svg "octicon-circle-slash" 16}}</span>
+			<span class="issue-symbol {{if .RemovedAssignee}} bg-purple {{else}} bg-red {{end}} white">
+				{{if .RemovedAssignee}}
+					{{svg "octicon-git-merge" 16}}
+				{{else}}
+					{{svg "octicon-circle-slash" 16}}
+				{{end}}
+			</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
-			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a> {{$.i18n.Tr "repo.issues.closed_at" .EventTag $createdStr | Safe}}</span>
+			<span class="text grey">
+				<a href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
+				{{if .RemovedAssignee}}
+					{{$link := printf "%s/commit/%s" $.Repository.HTMLURL $.Issue.PullRequest.MergedCommitID}}
+					{{$.i18n.Tr "repo.issues.pull_merged_at" $link (ShortSha $.Issue.PullRequest.MergedCommitID) $.BaseTarget $createdStr | Str2html}}
+				{{else}}
+					{{$.i18n.Tr "repo.issues.closed_at" .EventTag $createdStr | Safe}}
+				{{end}}
+			</span>
 		</div>
+		<div class="ui divider"></div>
 	{{else if eq .Type 3 5 6}}
 		{{ $refFrom:= "" }}
 		{{if ne .RefRepoID .Issue.RepoID}}
@@ -99,7 +115,7 @@
 		{{end}}
 		{{ $createdStr:= TimeSinceUnix .CreatedUnix $.Lang }}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-bookmark" 16}}
+			<span class="issue-symbol green">{{svg "octicon-bookmark" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -115,7 +131,7 @@
 		</div>
 	{{else if eq .Type 4}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-bookmark" 16}}
+			<span class="issue-symbol green">{{svg "octicon-bookmark" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -129,7 +145,7 @@
 	{{else if eq .Type 7}}
 		{{if .Label}}
 			<div class="event" id="{{.HashTag}}">
-				{{svg "octicon-primitive-dot" 16}}
+				<span class="issue-symbol green">{{svg "octicon-tag" 16}}</span>
 				<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 					<img src="{{.Poster.RelAvatarLink}}">
 				</a>
@@ -139,7 +155,7 @@
 		{{end}}
 	{{else if eq .Type 8}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-milestone" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -148,7 +164,7 @@
 		</div>
 	{{else if eq .Type 9}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-person" 16}}</span>
 			{{if gt .AssigneeID 0}}
 				{{if .RemovedAssignee}}
 					<a class="ui avatar image" href="{{.Assignee.HomeLink}}">
@@ -179,7 +195,7 @@
 		</div>
 	{{else if eq .Type 10}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-pencil" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -189,7 +205,7 @@
 		</div>
 	{{else if eq .Type 11}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-git-branch" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -199,7 +215,7 @@
 		</div>
 	{{else if eq .Type 12}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -207,7 +223,7 @@
 		</div>
 	{{else if eq .Type 13}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -220,7 +236,7 @@
 		</div>
 	{{else if eq .Type 14}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -232,7 +248,7 @@
 		</div>
 	{{else if eq .Type 15}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -240,7 +256,7 @@
 		</div>
 	{{else if eq .Type 16}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -250,7 +266,7 @@
 		</div>
 	{{else if eq .Type 17}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -260,7 +276,7 @@
 		</div>
 	{{else if eq .Type 18}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -270,7 +286,7 @@
 		</div>
 	{{else if eq .Type 19}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-dependent" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -294,7 +310,7 @@
 		</div>
 	{{else if eq .Type 20}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-dependent" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -318,10 +334,18 @@
 		</div>
 	{{else if eq .Type 22}}
 		<div class="event" id="{{.HashTag}}">
-			<span class="issue-symbol {{if eq .Review.Type 1}}green
-			{{- else if eq .Review.Type 2}}grey
-			{{- else if eq .Review.Type 3}}red
-			{{- else}}grey{{end}}">{{svg (printf "octicon-%s" .Review.Type.Icon) 16}}</span>
+			<span class="issue-symbol  
+			{{- if .IsOfficeReview}}
+				{{- if eq .Review.Type 1}} bg-green white
+				{{- else if eq .Review.Type 3}} bg-red white
+				{{- else }} grey {{end}}
+			{{- end}}
+			{{- if not .IsOfficeReview}}
+				{{- if eq .Review.Type 1}} green
+				{{- else if eq .Review.Type 2}} grey
+				{{- else if eq .Review.Type 3}} red
+				{{- else}} grey{{end}} 
+			{{- end}}">{{svg (printf "octicon-%s" .Review.Type.Icon) 16}}</span>
 			{{if .OriginalAuthor }}
 			{{else}}
 				<a class="ui avatar image"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
@@ -420,7 +444,7 @@
 		</div>
 	{{else if eq .Type 23}}
 		<div class="event" id="{{.HashTag}}">
-			<span class="issue-symbol">{{svg "octicon-lock" 16}}</span>
+			<span class="issue-symbol green">{{svg "octicon-lock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -437,7 +461,7 @@
 		</div>
 	{{else if eq .Type 24}}
 		<div class="event" id="{{.HashTag}}">
-			<span class="issue-symbol">{{svg "octicon-key" 16}}</span>
+			<span class="issue-symbol green">{{svg "octicon-key" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -448,7 +472,7 @@
 		</div>
 	{{else if eq .Type 25}}
 		<div class="event">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-git-branch" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -458,13 +482,12 @@
 		</div>
 	{{else if eq .Type 26}}
 		<div class="event" id="{{.HashTag}}">
-			{{svg "octicon-primitive-dot" 16}}
+			<span class="issue-symbol green">{{svg "octicon-clock" 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
 			<span class="text grey"><a href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a> {{$.i18n.Tr "repo.issues.del_time_history"  $createdStr | Safe}}</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1186,6 +1186,9 @@ i.icon.centerlock {
     span.purple & {
         color: #a333c8;
     }
+    span.white & {
+        color: white;
+    }
 }
 
 .ui.popup .ui.label {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -901,6 +901,30 @@
                 margin: 15px 0 15px 79px;
                 padding-left: 25px;
 
+                .issue-symbol {
+                    position: relative;
+                    display: flex;
+                    width: 35px;
+                    height: 35px;
+                    background-color: #eee;
+                    border: 2px solid #fff;
+                    align-items: center;
+                    margin-left: -39px;
+                    border-radius: 50%;
+                }
+
+                .bg-green {
+                    background-color: #21ba45 !important;
+                }
+
+                .bg-red {
+                    background-color: #db2828 !important;
+                }
+
+                .bg-purple {
+                    background-color: #a333c8 !important;
+                }
+
                 & > .svg:not(.issue-symbol) {
                     text-shadow: -2px 0 #fff, 0 2px #fff, 2px 0 #fff, 0 -2px #fff;
                 }
@@ -946,36 +970,68 @@
                     text-align: center;
 
                     &.octicon-circle-slash {
-                        margin-top: 5px;
-                        margin-left: -35.5px;
                         height: 20px;
-                        color: #bd2c00;
+                    }
+
+                    &.octicon-comment {
+                        height: 20px;
+                    }
+
+                    &.octicon-git-merge {
+                        height: 20px;
+                    }
+
+                    &.octicon-tag {
+                        height: 20px;
+                    }
+
+                    &.octicon-request-changes {
+                        height: 20px;
+                    }
+
+                    &.octicon-check {
+                        height: 20px;
+                    }
+
+                    &.octicon-milestone {
+                        height: 20px;
+                    }
+
+                    &.octicon-person {
+                        height: 20px;
+                    }
+
+                    &.octicon-pencil {
+                        height: 20px;
+                    }
+
+                    &.octicon-clock {
+                        height: 20px;
+                    }
+
+                    &.octicon-dependent {
+                        height: 20px;
                     }
 
                     &.octicon-primitive-dot {
                         margin-top: -1px;
-                        margin-left: -35.5px;
                         margin-right: -1px;
-                        height: 30px;
-                        color: #6cc644;
+                        height: 20px;
                     }
 
                     &.octicon-bookmark {
                         margin-top: 2px;
-                        margin-left: -35.5px;
                         margin-right: -1px;
-                        height: 25px;
+                        height: 20px;
                     }
 
                     &.octicon-eye {
                         margin-top: 3px;
-                        margin-left: -35.5px;
                         margin-right: 0;
                         height: 22px;
                     }
 
                     &.octicon-x {
-                        margin-left: -35.5px;
                         height: 25px;
                     }
                 }


### PR DESCRIPTION
* Fix timeline icons offset #10864

Co-authored-by: Sorien <sorien@mail.com>

* change icons style on time-line to a more meaningfull icon like github instead of  primitive-dot

* change merge comment style to distinguish it from close

view:
<img width="644" alt="js1" src="https://user-images.githubusercontent.com/25342410/78371950-397dac80-75fb-11ea-93a2-b462578f2b62.png">

----

<img width="688" alt="js2" src="https://user-images.githubusercontent.com/25342410/78371987-45696e80-75fb-11ea-875d-5fdd205c60bc.png">

----

<img width="767" alt="js3" src="https://user-images.githubusercontent.com/25342410/78372013-50bc9a00-75fb-11ea-9865-083b549e92de.png">

----

<img width="674" alt="js4" src="https://user-images.githubusercontent.com/25342410/78372044-5f0ab600-75fb-11ea-9002-e95e7f5b88f1.png">

-----

<img width="761" alt="js5" src="https://user-images.githubusercontent.com/25342410/78372886-67afbc00-75fc-11ea-90bb-efb0a719c2d0.png">


Close #10864