### PR TITLE
Adjust label padding

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1037,6 +1037,10 @@ i.icon.centerlock {
     top: 1.45em;
 }
 
+.ui.label {
+    padding: 0.5em;
+}
+
 .ui.label > .detail .icons {
     margin-right: .25em;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1038,7 +1038,7 @@ i.icon.centerlock {
 }
 
 .ui.label {
-    padding: .5em;
+    padding: .3em .5em;
 }
 
 .ui.label > .detail .icons {

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1038,7 +1038,7 @@ i.icon.centerlock {
 }
 
 .ui.label {
-    padding: 0.5em;
+    padding: .5em;
 }
 
 .ui.label > .detail .icons {


### PR DESCRIPTION
The default label padding isn't semetrical and is also a bit large, leading most labels to really look more like buttons. This adjusts the padding to make them look more like labels and feel less bulky.

| old | new |
|-----|-----|
|<img width="158" alt="Screen Shot 2020-04-04 at 12 25 01 PM" src="https://user-images.githubusercontent.com/1669571/78456095-c06c6c80-766f-11ea-995d-cfb3ef18a501.png"> |<img width="194" alt="Screen Shot 2020-04-04 at 1 09 39 PM" src="https://user-images.githubusercontent.com/1669571/78457099-dda43980-7675-11ea-9958-81876a2463d7.png">

