### PR TITLE
Turn on GOPROXY in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ steps:
     image: golang:1.12 # this step is kept as the lowest version of golang that we support
     environment:
       GO111MODULE: on
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
     commands:
       - go build -mod=vendor -o gitea_no_gcc # test if build succeeds without the sqlite tag
     depends_on: [lint-backend]
@@ -56,7 +56,7 @@ steps:
     image: golang:1.14
     environment:
       GO111MODULE: on
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       GOOS: linux
       GOARCH: 386
     commands:
@@ -145,7 +145,7 @@ steps:
     commands:
       - make unit-test-coverage test-check
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata sqlite sqlite_unlock_notify
       GITHUB_READ_TOKEN:
         from_secret: github_read_token
@@ -158,7 +158,7 @@ steps:
       - apt-get install -y git-lfs
       - make test-mysql-migration integration-test-coverage
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
       TEST_LDAP: 1
     depends_on:
@@ -172,7 +172,7 @@ steps:
       - apt-get install -y git-lfs
       - timeout -s ABRT 40m make test-mysql8-migration test-mysql8
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
       TEST_LDAP: 1
     depends_on:
@@ -186,7 +186,7 @@ steps:
       - apt-get install -y git-lfs
       - make test-mssql-migration test-mssql
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
       TEST_LDAP: 1
     depends_on:
@@ -198,7 +198,7 @@ steps:
     commands:
       - make coverage
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
     depends_on:
       - unit-test
@@ -285,7 +285,7 @@ steps:
       - apt-get install -y git-lfs
       - timeout -s ABRT 40m make test-sqlite-migration test-sqlite
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
     depends_on:
       - build
@@ -298,7 +298,7 @@ steps:
       - apt-get install -y git-lfs
       - timeout -s ABRT 40m make test-pgsql-migration test-pgsql
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata
       TEST_LDAP: 1
     depends_on:
@@ -406,7 +406,7 @@ steps:
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata sqlite sqlite_unlock_notify
 
   - name: gpg-sign
@@ -504,7 +504,7 @@ steps:
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
-      GOPROXY: off
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       TAGS: bindata sqlite sqlite_unlock_notify
 
   - name: gpg-sign

--- a/.drone.yml
+++ b/.drone.yml
@@ -781,3 +781,42 @@ steps:
         from_secret: discord_webhook_id
       webhook_token:
         from_secret: discord_webhook_token
+
+---
+kind: pipeline
+name: test-release
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: src/code.gitea.io/gitea
+
+trigger:
+  event:
+    - pull_request
+
+depends_on:
+  - testing-amd64
+  - testing-arm64
+
+steps:
+  - name: fetch-tags
+    pull: default
+    image: docker:git
+    commands:
+      - git fetch --tags --force
+
+  - name: static
+    pull: always
+    image: techknowlogick/xgo:go-1.14.x
+    commands:
+      - apt update && apt -y install curl
+      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
+      - export PATH=$PATH:$GOPATH/bin
+      - make release
+    environment:
+      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
+      TAGS: bindata sqlite sqlite_unlock_notify


### PR DESCRIPTION
With `GOPROXY` off it seems some targets fail because they need go modules.

This is a quick search/replace to point all `GOPROXY` to `https://goproxy.cn` as we have it elsewhere in the Drone file already.

I am unsure whether this is particularly necessary or if there is another/better way to do it.  
Feel free to supersede this PR if that is the case.