### PR TITLE
Prevent support libraries from compiling into Gitea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ unit-test-coverage:
 
 .PHONY: vendor
 vendor:
-	$(GO) mod tidy && $(GO) mod vendor
+	$(GO) mod tidy && TAGS="$(TAGS) vendor" $(GO) mod vendor
 
 .PHONY: test-vendor
 test-vendor: vendor

--- a/Makefile
+++ b/Makefile
@@ -617,4 +617,4 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.24.0; \
 	fi
-	golangci-lint run --timeout 5m
+	TAGS="$(TAGS) vendor" golangci-lint run --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -617,4 +617,4 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.24.0; \
 	fi
-	TAGS="$(TAGS) vendor" golangci-lint run --timeout 5m
+	golangci-lint run --timeout 5m

--- a/build.go
+++ b/build.go
@@ -4,7 +4,10 @@
 
 //+build vendor
 
-package build
+package main
+
+// Libraries that are included to vendor utilities used during build.
+// These libraries will not be included in a normal compilation.
 
 import (
 	// for lint

--- a/build/vendor.go
+++ b/build/vendor.go
@@ -4,6 +4,8 @@
 
 package build
 
+//+build vendor
+
 import (
 	// for lint
 	_ "github.com/BurntSushi/toml"

--- a/build/vendor.go
+++ b/build/vendor.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package build
-
 //+build vendor
+
+package build
 
 import (
 	// for lint

--- a/main.go
+++ b/main.go
@@ -21,9 +21,6 @@ import (
 	_ "code.gitea.io/gitea/modules/markup/markdown"
 	_ "code.gitea.io/gitea/modules/markup/orgmode"
 
-	// for build
-	_ "code.gitea.io/gitea/build"
-
 	"github.com/urfave/cli"
 )
 


### PR DESCRIPTION
This PR should prevent support vendored libraries from being compiled into Gitea, thus keeping the file size to what is needed.

@lunny https://github.com/go-gitea/gitea/pull/10942#issuecomment-608999742