### PR TITLE
fix merge box icon color bug

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -39,8 +39,7 @@
 	</div>
 {{end}}
 <div class="comment merge box">
-	<a class="avatar text
-	{{- if .Issue.PullRequest.HasMerged}}purple
+	<a class="avatar text  {{if .Issue.PullRequest.HasMerged}}purple
 	{{- else if .Issue.IsClosed}}grey
 	{{- else if .IsPullWorkInProgress}}grey
 	{{- else if .IsFilesConflicted}}grey


### PR DESCRIPTION
I 'm sorry, I only add - befor ``if`` to make them in one line but forget to add enough space in #10737. now fix it.

fix #10973