### PR TITLE
Change default charset for MySQL on install to utf8mb4

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -73,12 +73,12 @@
 						<div class="inline required field">
 							<label>{{.i18n.Tr "install.charset"}}</label>
 							<div class="ui selection database type dropdown">
-								<input type="hidden" name="charset" value="{{if .charset}}{{.charset}}{{else}}utf8{{end}}">
-								<div class="default text">utf8</div>
+								<input type="hidden" name="charset" value="{{if .charset}}{{.charset}}{{else}}utf8mb4{{end}}">
+								<div class="default text">utf8mb4</div>
 								<i class="dropdown icon"></i>
 								<div class="menu">
-									<div class="item" data-value="utf8">utf8</div>
 									<div class="item" data-value="utf8mb4">utf8mb4</div>
+									<div class="item" data-value="utf8">utf8</div>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
Set the default to utf8mb4

Signed-off-by: Andrew Thornton <art27@cantab.net>
