### PR TITLE
tweak code tags in markdown

### DIFF
--- a/web_src/less/_markdown.less
+++ b/web_src/less/_markdown.less
@@ -371,19 +371,11 @@
 
     code,
     tt {
-        padding: .2em 0;
+        padding: .2em .3em;
         margin: 0;
         font-size: 85%;
         background-color: rgba(0, 0, 0, .04);
         border-radius: 3px;
-    }
-
-    code:before,
-    code:after,
-    tt:before,
-    tt:after {
-        letter-spacing: -.2em;
-        content: "\00a0";
     }
 
     code br,

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1584,6 +1584,11 @@ body .xdsoft_datetimepicker {
     border-left-color: #888;
 }
 
+.markdown:not(code) code,
+.markdown:not(code) tt {
+    background-color: rgba(0, 0, 0, .12);
+}
+
 footer .container .links > * {
     border-left-color: #888;
 }


### PR DESCRIPTION
- remove whitespace before and after
- increase horizontal padding
- make blocks more apparant on arc-green

Before:
<img width="418" src="https://user-images.githubusercontent.com/115237/78653425-619f3100-78c3-11ea-8dbd-74ccc9dcb5e8.png">

After:
<img width="390" src="https://user-images.githubusercontent.com/115237/78653432-64018b00-78c3-11ea-974b-f2ee77aba352.png">
