### PR TITLE
Add settings: RequireProvidedUsernameMatchesToken and RequireUsernameWithToken

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -471,6 +471,10 @@ PASSWORD_COMPLEXITY = lower,upper,digit,spec
 PASSWORD_HASH_ALGO = pbkdf2
 ; Set false to allow JavaScript to read CSRF cookie
 CSRF_COOKIE_HTTP_ONLY = true
+; Require Username matches Token if provided
+REQUIRE_PROVIDED_USERNAME_MATCHES_TOKEN = true
+; Require Username with Token
+REQUIRE_USERNAME_WITH_TOKEN = false
 
 [openid]
 ;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -311,6 +311,8 @@ set name for unique queues. Individual queues will default to
     - digit - use one or more digits
     - spec - use one or more special characters as ``!"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~``
     - off - do not check password complexity
+- `REQUIRE_PROVIDED_USERNAME_MATCHES_TOKEN`: **true**: If a username is passed with an access token - ensure that tne token matches the username
+- `REQUIRE_USERNAME_WITH_TOKEN`: **false**: Always require a username with access token authentication. (If true overrides the `REQUIRE_PROVIDED_USERNAME_MATCHES_TOKEN` setting) NB: These two options do not affect OAuth2 authentication.
 
 ## OpenID (`openid`)
 

--- a/modules/auth/sso/basic.go
+++ b/modules/auth/sso/basic.go
@@ -83,9 +83,15 @@ func (b *Basic) VerifyAuthData(ctx *macaron.Context, sess session.Store) *models
 			return nil
 		}
 	}
+
+	if setting.RequireUsernameWithToken {
+		isUsernameToken = false
+		authToken = passwd
+	}
+
 	token, err := models.GetAccessTokenBySHA(authToken)
 	if err == nil {
-		if isUsernameToken {
+		if (isUsernameToken || !setting.RequireProvidedUsernameMatchesToken) && !setting.RequireUsernameWithToken {
 			u, err = models.GetUserByID(token.UID)
 			if err != nil {
 				log.Error("GetUserByID:  %v", err)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -145,19 +145,21 @@ var (
 	}
 
 	// Security settings
-	InstallLock                        bool
-	SecretKey                          string
-	LogInRememberDays                  int
-	CookieUserName                     string
-	CookieRememberName                 string
-	ReverseProxyAuthUser               string
-	ReverseProxyAuthEmail              string
-	MinPasswordLength                  int
-	ImportLocalPaths                   bool
-	DisableGitHooks                    bool
-	OnlyAllowPushIfGiteaEnvironmentSet bool
-	PasswordComplexity                 []string
-	PasswordHashAlgo                   string
+	InstallLock                         bool
+	SecretKey                           string
+	LogInRememberDays                   int
+	CookieUserName                      string
+	CookieRememberName                  string
+	ReverseProxyAuthUser                string
+	ReverseProxyAuthEmail               string
+	MinPasswordLength                   int
+	ImportLocalPaths                    bool
+	DisableGitHooks                     bool
+	OnlyAllowPushIfGiteaEnvironmentSet  bool
+	PasswordComplexity                  []string
+	PasswordHashAlgo                    string
+	RequireProvidedUsernameMatchesToken bool
+	RequireUsernameWithToken            bool
 
 	// UI settings
 	UI = struct {
@@ -815,6 +817,8 @@ func NewContext() {
 	OnlyAllowPushIfGiteaEnvironmentSet = sec.Key("ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET").MustBool(true)
 	PasswordHashAlgo = sec.Key("PASSWORD_HASH_ALGO").MustString("pbkdf2")
 	CSRFCookieHTTPOnly = sec.Key("CSRF_COOKIE_HTTP_ONLY").MustBool(true)
+	RequireProvidedUsernameMatchesToken = sec.Key("REQUIRE_PROVIDED_USERNAME_MATCHES_TOKEN").MustBool(true)
+	RequireUsernameWithToken = sec.Key("REQUIRE_USERNAME_WITH_TOKEN").MustBool(false)
 
 	InternalToken = loadInternalToken(sec)
 

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -185,10 +185,16 @@ func HTTP(ctx *context.Context) {
 					return
 				}
 			}
+
+			if setting.RequireUsernameWithToken {
+				isUsernameToken = false
+				authToken = authPasswd
+			}
+
 			// Assume password is a token.
 			token, err := models.GetAccessTokenBySHA(authToken)
 			if err == nil {
-				if isUsernameToken {
+				if (isUsernameToken || !setting.RequireProvidedUsernameMatchesToken) && !setting.RequireUsernameWithToken {
 					authUser, err = models.GetUserByID(token.UID)
 					if err != nil {
 						ctx.ServerError("GetUserByID", err)


### PR DESCRIPTION
The current situation with tokens and usernames is inconsistent as highlighted by #10902 . This PR adds two options to allow two different levels of enforcement as an alternative to #11015 .

REQUIRE_PROVIDED_USERNAME_MATCHES_TOKEN: If a username is provided ensure it matches the token - can set this to false to ignore the username. (default true)

REQUIRE_USERNAME_WITH_TOKEN: enforce that a username is always provided with an accesstoken.

(In order to cope with REQUIRE_USERNAME_WITH_TOKEN I have had to add a way to pass in a username with tokens one the url query.)

Closes #10902 
Closes #11015 
Fixes #10903 

Signed-off-by: Andrew Thornton <art27@cantab.net>
