### PR TITLE
Match arc-green code tag color to code blocks

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1586,7 +1586,7 @@ body .xdsoft_datetimepicker {
 
 .markdown:not(code) code,
 .markdown:not(code) tt {
-    background-color: rgba(0, 0, 0, .12);
+    background-color: #2a2e3a;
 }
 
 footer .container .links > * {


### PR DESCRIPTION
Before:

<img width="139" alt="Screenshot 2020-04-09 at 11 25 48" src="https://user-images.githubusercontent.com/115237/78880112-2f253d80-7a55-11ea-8098-dc50ef3620e8.png">

After (now matching `pre > code` background):

<img width="136" alt="Screenshot 2020-04-09 at 11 25 32" src="https://user-images.githubusercontent.com/115237/78880111-2e8ca700-7a55-11ea-9ff7-9cd746d175e3.png">