### PR TITLE
Add git hook "warning" to admin panel

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1880,6 +1880,7 @@ users.prohibit_login = Disable Sign-In
 users.is_admin = Is Administrator
 users.is_restricted = Is Restricted
 users.allow_git_hook = May Create Git Hooks
+users.allow_git_hook_tooltip = Git Hooks are executed as the OS user running Gitea and will have the same level of host access
 users.allow_import_local = May Import Local Repositories
 users.allow_create_organization = May Create Organizations
 users.update_profile = Update User Account

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -90,7 +90,7 @@
 					</div>
 				</div>
 				<div class="inline field">
-					<div class="ui checkbox">
+					<div class="ui checkbox" data-tooltip="{{.i18n.Tr "admin.users.allow_git_hook_tooltip"}}">
 						<label><strong>{{.i18n.Tr "admin.users.allow_git_hook"}}</strong></label>
 						<input name="allow_git_hook" type="checkbox" {{if .User.CanEditGitHook}}checked{{end}} {{if DisableGitHooks}}disabled{{end}}>
 					</div>


### PR DESCRIPTION
This PR just adds a little explanation about git hooks in the admin panel.

Some Gitea admins may not know the full extent of git hooks or what they can do.