### PR TITLE
ui: fix 404 and 500 image size in small size screen

### DIFF
--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -1,7 +1,7 @@
 {{template "base/head" .}}
 {{if .IsRepo}}<div class="repository">{{template "repo/header" .}}</div>{{end}}
 <div class="ui container center">
-	<p style="margin-top: 100px"><img src="{{StaticUrlPrefix}}/img/404.png" alt="404"/></p>
+	<p style="margin-top: 100px"><img class="ui centered image" src="{{StaticUrlPrefix}}/img/404.png" alt="404"/></p>
 	<div class="ui divider"></div>
 	<br>
 	<p>{{.i18n.Tr "error404" | Safe}}

--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -1,6 +1,6 @@
 {{template "base/head" .}}
 <div class="ui container center">
-	<p style="margin-top: 100px"><img src="{{StaticUrlPrefix}}/img/500.png" alt="500"/></p>
+	<p style="margin-top: 100px"><img class="ui centered image" src="{{StaticUrlPrefix}}/img/500.png" alt="500"/></p>
 	<div class="ui divider"></div>
 	<br>
 	{{if .ErrorMsg}}<p>An error has occurred :</p>


### PR DESCRIPTION
do it by define Semantic UI image class

from:  
    
![ttyy](https://user-images.githubusercontent.com/25342410/79045259-c39dc480-7c3c-11ea-895f-94887a983d7e.jpg)

----

to:  
<img width="305" alt="jf1" src="https://user-images.githubusercontent.com/25342410/79045238-9f41e800-7c3c-11ea-80dd-449d184cee5e.png">
