### PR TITLE
Added port 80 for letsencrypt usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 FROM alpine:3.11
 LABEL maintainer="maintainers@gitea.io"
 
-EXPOSE 22 3000
+EXPOSE 22 3000 80
 
 RUN apk --no-cache add \
     bash \


### PR DESCRIPTION
Added port 80 to the Dockerfile so that letsencrypt can be used inside the docker container.
Port 80 is used for redirection and the letsencrypt verification key.  