### PR TITLE
ui: fix lable vertical alignment in code search result view

### DIFF
--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -21,7 +21,7 @@
 					<a class="ui {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{AppSubUrl}}/explore/code?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
 						<i class="color-icon" style="background-color: {{$term.Color}}"></i>
 						{{$term.Language}}
-						<div class="detail" style="vertical-align: baseline;">{{$term.Count}}</div>
+						<div class="detail number">{{$term.Count}}</div>
 					</a>
 					{{end}}
 				</div>

--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -21,7 +21,7 @@
 					<a class="ui {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{AppSubUrl}}/explore/code?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
 						<i class="color-icon" style="background-color: {{$term.Color}}"></i>
 						{{$term.Language}}
-						<div class="detail">{{$term.Count}}</div>
+						<div class="detail" style="vertical-align: baseline;">{{$term.Count}}</div>
 					</a>
 					{{end}}
 				</div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1049,6 +1049,10 @@ i.icon.centerlock {
     margin-right: 0;
 }
 
+.ui.label > .detail.number {
+    vertical-align: baseline;
+}
+
 .lines-num {
     vertical-align: top;
     text-align: right !important;


### PR DESCRIPTION
As Semantic UI default define , the style of detail in lable is ``vertical-align: top``, which will make the number higher than words. I think it's not good view, so redefined it as ``vertical-align: baseline``

from:
<img width="156" alt="jf1" src="https://user-images.githubusercontent.com/25342410/79073176-adb10200-7d17-11ea-9aa5-925795fc8c2d.png">

----
to:
<img width="100" alt="jf2" src="https://user-images.githubusercontent.com/25342410/79073185-b6093d00-7d17-11ea-8a3f-475a43fdfedb.png">

<img width="433" alt="jf" src="https://user-images.githubusercontent.com/25342410/79091589-6b6fdb00-7d80-11ea-85af-fe7498accf19.png">
