### PR TITLE
Add charset handling to backup/restore doc

### DIFF
--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -75,7 +75,7 @@ mv custom/conf/app.ini /etc/gitea/conf/app.ini # or mv app.ini /etc/gitea/conf/a
 unzip gitea-repo.zip
 mv gitea-repo/* /var/lib/gitea/repositories/
 chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea/repositories/
-mysql -u$USER -p$PASS $DATABASE <gitea-db.sql
+mysql --default-character-set=utf8mb4 -u$USER -p$PASS $DATABASE <gitea-db.sql
 # or  sqlite3 $DATABASE_PATH <gitea-db.sql
 service gitea restart
 ```

--- a/docs/content/doc/usage/backup-and-restore.zh-cn.md
+++ b/docs/content/doc/usage/backup-and-restore.zh-cn.md
@@ -54,7 +54,7 @@ mv custom/conf/app.ini /etc/gitea/conf/app.ini
 unzip gitea-repo.zip
 mv gitea-repo/* /var/lib/gitea/repositories/
 chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea/repositories/
-mysql -u$USER -p$PASS $DATABASE <gitea-db.sql
+mysql --default-character-set=utf8mb4 -u$USER -p$PASS $DATABASE <gitea-db.sql
 # or  sqlite3 $DATABASE_PATH <gitea-db.sql
 service gitea restart
 ```


### PR DESCRIPTION
The documentation for backing up/restoring a Gitea instance includes a line which pipes the mysql dump to the new database. But as the mysql client doesn't necessarily use UTF8 ([as Gitea does](https://docs.gitea.io/en-us/database-prep/)), this can screw up the content. I added the use of a command line option which sets the encoding to UTF8.