### PR TITLE
ui: fix status label on branches list vertical alignment

### DIFF
--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -18,7 +18,7 @@
                 </h3>
 				<div>
 					{{range $term := .SearchResultLanguages}}
-					<a class="ui language-label {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{AppSubUrl}}/explore/code?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
+					<a class="ui text-label {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{AppSubUrl}}/explore/code?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
 						<i class="color-icon" style="background-color: {{$term.Color}}"></i>
 						{{$term.Language}}
 						<div class="detail">{{$term.Count}}</div>

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -93,11 +93,11 @@
 										{{else}}
 											<a href="{{.LatestPullRequest.Issue.HTMLURL}}">{{if not .LatestPullRequest.IsSameRepo}}{{.LatestPullRequest.BaseRepo.FullName}}{{end}}#{{.LatestPullRequest.Issue.Index}}</a>
 											{{if .LatestPullRequest.HasMerged}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui purple mini label">{{svg "octicon-git-pull-request" 16}} {{$.i18n.Tr "repo.pulls.merged"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple mini label">{{svg "octicon-git-merge" 16}} {{$.i18n.Tr "repo.pulls.merged"}}</a>
 											{{else if .LatestPullRequest.Issue.IsClosed}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui red mini label">{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
 											{{else}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui green mini label">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
 											{{end}}
 										{{end}}
 									</td>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -18,7 +18,7 @@
 			</h3>
 			<div>
 				{{range $term := .SearchResultLanguages}}
-				<a class="ui language-label {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{EscapePound $.SourcePath}}/search?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
+				<a class="ui text-label {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{EscapePound $.SourcePath}}/search?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}">
 					<i class="color-icon" style="background-color: {{$term.Color}}"></i>
 					{{$term.Language}}
 					<div class="detail">{{$term.Count}}</div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1229,11 +1229,11 @@ i.icon.centerlock {
     text-overflow: ellipsis;
 }
 
-.language-label {
+.text-label {
     display: inline-flex !important;
     align-items: center !important;
 }
 
-.language-label .color-icon {
+.text-label .color-icon {
     position: static !important;
 }


### PR DESCRIPTION
* follow #11061 , fix same problem on labels in  branches list view
* change status icon for merged PR to git-merge

Before:
<img width="613" alt="bf" src="https://user-images.githubusercontent.com/25342410/79578228-892e9e80-80f8-11ea-8aa6-1523d4b9c611.png">
After:
<img width="526" alt="af" src="https://user-images.githubusercontent.com/25342410/79579096-b7f94480-80f9-11ea-830b-dcbbba1c9bb8.png">

