### PR TITLE
Remove errant third curly brackets from account.tmpl and pull.tmpl and send account ID in account.tmpl

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -69,7 +69,7 @@
 	{{- else if .IsBlockedByOutdatedBranch}}red
 	{{- else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsFailure .RequiredStatusCheckState.IsError)}}red
 	{{- else if and .EnableStatusCheck (or (not $.LatestCommitStatus) .RequiredStatusCheckState.IsPending .RequiredStatusCheckState.IsWarning)}}yellow
-	{{- else if and .RequireSigned (not .WillSign)}}}red
+	{{- else if and .RequireSigned (not .WillSign)}}red
 	{{- else if .Issue.PullRequest.IsChecking}}yellow
 	{{- else if .Issue.PullRequest.CanAutoMerge}}green
 	{{- else}}red{{end}}">{{svg "octicon-git-merge" 32}}</a>

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -92,7 +92,7 @@
 								<form action="{{AppSubUrl}}/user/settings/account/email" method="post">
 									{{$.CsrfTokenHtml}}
 									<input name="_method" type="hidden" value="SENDACTIVATION">
-									<input name="id" type="hidden" value="{{if .IsPrimary}}PRIMARY{{else}}.ID{{end}}">
+									<input name="id" type="hidden" value="{{if .IsPrimary}}PRIMARY{{else}}{{.ID}}{{end}}">
 									{{if $.ActivationsPending}}
 										<button disabled class="ui blue tiny button">{{$.i18n.Tr "settings.activations_pending"}}</button>
 									{{else}}

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -92,7 +92,7 @@
 								<form action="{{AppSubUrl}}/user/settings/account/email" method="post">
 									{{$.CsrfTokenHtml}}
 									<input name="_method" type="hidden" value="SENDACTIVATION">
-									<input name="id" type="hidden" value="{{if .IsPrimary}}PRIMARY{{else}}}.ID{{end}}">
+									<input name="id" type="hidden" value="{{if .IsPrimary}}PRIMARY{{else}}.ID{{end}}">
 									{{if $.ActivationsPending}}
 										<button disabled class="ui blue tiny button">{{$.i18n.Tr "settings.activations_pending"}}</button>
 									{{else}}


### PR DESCRIPTION
Unfortunately there is a bug with VSCode which means that occasionally a third closing curly bracket is added when writing templates. The important case here is in account.tmpl where it prevents the sending of activation emails for non-primary accounts. 

Fix #11128 