### PR TITLE
Fix max-width of selection dropdowns

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1223,7 +1223,7 @@ i.icon.centerlock {
 
 /* limit width of all direct dropdown menu children */
 /* https://github.com/go-gitea/gitea/pull/10835 */
-.dropdown > .menu > * {
+.dropdown:not(.selection) > .menu > * {
     max-width: 300px;
     overflow-x: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Fix a regression added by https://github.com/go-gitea/gitea/pull/10897.

Before:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/115237/79700566-dfd1df00-8296-11ea-8b6e-3fca25ba9e77.png">

After: 

<img width="451" alt="image" src="https://user-images.githubusercontent.com/115237/79700581-0132cb00-8297-11ea-85ae-8a534f3e36ca.png">

