### PR TITLE
Skip frontend build where unnecessary

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,8 +61,7 @@ steps:
       GOARCH: arm64
       TAGS: bindata
     commands:
-      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
-      - make build # test cross compile
+      - make backend # test cross compile
       - rm ./gitea # clean
     depends_on: [lint-backend]
 
@@ -99,7 +98,7 @@ services:
     image: mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
-      MYSQL_DATABASE: test      
+      MYSQL_DATABASE: test
       GOPROXY: off
       TAGS: bindata sqlite sqlite_unlock_notify
       GITLAB_READ_TOKEN:
@@ -153,8 +152,7 @@ steps:
     pull: always
     image: golang:1.14
     commands:
-      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
-      - make build
+      - make backend
     environment:
       GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       GOSUMDB: sum.golang.org
@@ -300,8 +298,7 @@ steps:
     pull: always
     image: golang:1.14
     commands:
-      - curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt -y install nodejs
-      - make build
+      - make backend
     environment:
       GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       GOSUMDB: sum.golang.org


### PR DESCRIPTION
The testing pipelines and build-backend steps do not depend on frontend files, skip their build for them.