### PR TITLE
enable ENABLE_HARD_LINE_BREAK by default

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -201,8 +201,10 @@ DESCRIPTION = Gitea (Git with a cup of tea) is a painless self-hosted Git servic
 KEYWORDS = go,git,self-hosted,gitea
 
 [markdown]
-; Enable hard line break extension
-ENABLE_HARD_LINE_BREAK = false
+; Render soft line breaks as hard line, which means a single newline character between paragraphs
+; will cause a line break and adding trailing whitespace to paragraphs is not neccessary to force
+; a line break.
+ENABLE_HARD_LINE_BREAK = true
 ; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
 ; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)
 ; URLs starting with http and https are always displayed, whatever is put in this entry.

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -201,9 +201,9 @@ DESCRIPTION = Gitea (Git with a cup of tea) is a painless self-hosted Git servic
 KEYWORDS = go,git,self-hosted,gitea
 
 [markdown]
-; Render soft line breaks as hard line, which means a single newline character between paragraphs
-; will cause a line break and adding trailing whitespace to paragraphs is not neccessary to force
-; a line break.
+; Render soft line breaks as hard line breaks, which means a single newline character between
+; paragraphs will cause a line break and adding trailing whitespace to paragraphs is not
+; neccessary to force a line break.
 ENABLE_HARD_LINE_BREAK = true
 ; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
 ; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -203,7 +203,7 @@ KEYWORDS = go,git,self-hosted,gitea
 [markdown]
 ; Render soft line breaks as hard line breaks, which means a single newline character between
 ; paragraphs will cause a line break and adding trailing whitespace to paragraphs is not
-; neccessary to force a line break.
+; necessary to force a line break.
 ENABLE_HARD_LINE_BREAK = true
 ; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
 ; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -142,7 +142,9 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 
 ## Markdown (`markdown`)
 
-- `ENABLE_HARD_LINE_BREAK`: **false**: Enable Markdown's hard line break extension.
+- `ENABLE_HARD_LINE_BREAK`: **true**: Render soft line breaks as hard line, which means a single
+  newline character between paragraphs will cause a line break and adding trailing whitespace to
+  paragraphs is not neccessary to force a line break.
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -142,9 +142,9 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 
 ## Markdown (`markdown`)
 
-- `ENABLE_HARD_LINE_BREAK`: **true**: Render soft line breaks as hard line, which means a single
-  newline character between paragraphs will cause a line break and adding trailing whitespace to
-  paragraphs is not neccessary to force a line break.
+- `ENABLE_HARD_LINE_BREAK`: **true**: Render soft line breaks as hard line breaks, which
+  means a single newline character between paragraphs will cause a line break and adding
+  trailing whitespace to paragraphs is not neccessary to force a line break.
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -144,7 +144,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 
 - `ENABLE_HARD_LINE_BREAK`: **true**: Render soft line breaks as hard line breaks, which
   means a single newline character between paragraphs will cause a line break and adding
-  trailing whitespace to paragraphs is not neccessary to force a line break.
+  trailing whitespace to paragraphs is not necessary to force a line break.
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -133,9 +133,9 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 `,
 		`<p><a href="http://www.excelsiorjet.com/" rel="nofollow">Excelsior JET</a> allows you to create native executables for Windows, Linux and Mac OS X.</p>
 <ol>
-<li><a href="https://github.com/libgdx/libgdx/wiki/Gradle-on-the-Commandline#packaging-for-the-desktop" rel="nofollow">Package your libGDX application</a>
+<li><a href="https://github.com/libgdx/libgdx/wiki/Gradle-on-the-Commandline#packaging-for-the-desktop" rel="nofollow">Package your libGDX application</a><br/>
 <a href="` + baseURLImages + `/images/1.png" rel="nofollow"><img src="` + baseURLImages + `/images/1.png" title="1.png" alt="images/1.png"/></a></li>
-<li>Perform a test run by hitting the Run! button.
+<li>Perform a test run by hitting the Run! button.<br/>
 <a href="` + baseURLImages + `/images/2.png" rel="nofollow"><img src="` + baseURLImages + `/images/2.png" title="2.png" alt="images/2.png"/></a></li>
 </ol>
 <h2 id="user-content-custom-id">More tests</h2>

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -241,7 +241,7 @@ var (
 		CustomURLSchemes    []string `ini:"CUSTOM_URL_SCHEMES"`
 		FileExtensions      []string
 	}{
-		EnableHardLineBreak: false,
+		EnableHardLineBreak: true,
 		FileExtensions:      strings.Split(".md,.markdown,.mdown,.mkd", ","),
 	}
 

--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -94,7 +94,7 @@ Here are some links to the most important topics. You can find the full list of 
 <p><strong>Wine Staging</strong> on website <a href="http://wine-staging.com" rel="nofollow">wine-staging.com</a>.</p>
 <h2 id="user-content-quick-links">Quick Links</h2>
 <p>Here are some links to the most important topics. You can find the full list of pages at the sidebar.</p>
-<p><a href="` + AppSubURL + `wiki/Configuration" rel="nofollow">Configuration</a>
+<p><a href="` + AppSubURL + `wiki/Configuration" rel="nofollow">Configuration</a><br/>
 <a href="` + AppSubURL + `wiki/raw/images/icon-bug.png" rel="nofollow"><img src="` + AppSubURL + `wiki/raw/images/icon-bug.png" title="icon-bug.png" alt="images/icon-bug.png"/></a></p>
 `,
 		// Guard wiki sidebar: special syntax


### PR DESCRIPTION
This matches GitHub's rendering.

Fixes: https://github.com/go-gitea/gitea/issues/11155