### PR TITLE
vendor: go-git: import IsDir() check for readReferenceFile()

### DIFF
--- a/vendor/github.com/go-git/go-git/v5/storage/filesystem/dotgit/dotgit.go
+++ b/vendor/github.com/go-git/go-git/v5/storage/filesystem/dotgit/dotgit.go
@@ -57,6 +57,9 @@ var (
 	// targeting a non-existing object. This usually means the repository
 	// is corrupt.
 	ErrSymRefTargetNotFound = errors.New("symbolic reference target not found")
+	// ErrIsDir is returned when a reference file is attempting to be read,
+	// but the path specified is a directory.
+	ErrIsDir = errors.New("reference path is a directory")
 )
 
 // Options holds configuration for the storage.
@@ -926,6 +929,14 @@ func (d *DotGit) addRefFromHEAD(refs *[]*plumbing.Reference) error {
 
 func (d *DotGit) readReferenceFile(path, name string) (ref *plumbing.Reference, err error) {
 	path = d.fs.Join(path, d.fs.Join(strings.Split(name, "/")...))
+	st, err := d.fs.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if st.IsDir() {
+		return nil, ErrIsDir
+	}
+
 	f, err := d.fs.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fix has been accepted and merged upstream; the gist of the problem is
that readReferenceFile() must check that what it's been requested to read
isn't a directory. read() on a directory fd may work on some platforms (e.g.
FreeBSD), so readReferenceFile() would previously succeed at the earliest
point in a branch name (e.g. "feature" in "feature/myfeature") despite the
fact that this isn't a branch ref but a directory.

Fixes issue #9938

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>

PR notes:
- I've made this against release/v1.11 because that's where we observed the bug, but it's also applicable to master and I've verified that it cleanly [cherry picks forward](https://github.com/kevans91/gitea/tree/gogit-import) as well. Your contributing guidelines lead me to believe that I should target the branch it was observed on, apologies if this is incorrect and I'll create the PR against master instead.
- Corresponds to https://github.com/go-git/go-git/commit/63967abe62ecba22a792e728f1af509f3604881f sans amendment to the tests introduced in the commit just prior to that one.