### PR TITLE
Prevent panic during wrappedConn close at hammertime

### DIFF
--- a/modules/graceful/server.go
+++ b/modules/graceful/server.go
@@ -253,7 +253,7 @@ func (w wrappedConn) Close() error {
 		defer func() {
 			if err := recover(); err != nil {
 				select {
-				case GetManager().IsHammer():
+				case <-GetManager().IsHammer():
 					// Likely deadlocked request released at hammertime
 					log.Warn("Panic during connection close! %v. Likely there has been a deadlocked request which has been released by forced shutdown.", err)
 				default:

--- a/modules/graceful/server.go
+++ b/modules/graceful/server.go
@@ -250,6 +250,17 @@ type wrappedConn struct {
 
 func (w wrappedConn) Close() error {
 	if atomic.CompareAndSwapInt32(w.closed, 0, 1) {
+		defer func() {
+			if err := recover(); err != nil {
+				select {
+				case GetManager().IsHammer():
+					// Likely deadlocked request released at hammertime
+					log.Warn("Panic during connection close! %v. Likely there has been a deadlocked request which has been released by forced shutdown.", err)
+				default:
+					log.Error("Panic during connection close! %v", err)
+				}
+			}
+		}()
 		w.server.wg.Done()
 	}
 	return w.Conn.Close()

--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -328,7 +328,6 @@ func (r *HTMLRenderer) renderIcon(w util.BufWriter, source []byte, node ast.Node
 func (r *HTMLRenderer) renderTaskCheckBoxListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*TaskCheckBoxListItem)
 	if entering {
-		n.Dump(source, 0)
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<li")
 			html.RenderAttributes(w, n, html.ListItemAttributeFilter)


### PR DESCRIPTION
When reviewing #10549 there is a subtle race during forced shutdown/hammertime that can lead to a panic. This is relatively benign - but it's clearly distracting from the real problem. 

Please note this is **not** the cause of #10549 and will not fix that issue - that issue is a deadlock within the DB. 

Signed-off-by: Andrew Thornton <art27@cantab.net>
