### PR TITLE
Simply use tmpfs on /tmp (requires .drone.yml signing)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -835,3 +835,8 @@ steps:
         from_secret: discord_webhook_id
       webhook_token:
         from_secret: discord_webhook_token
+---
+kind: signature
+hmac: 9d0f560fde813881e249374cc4ca08356e2e2d465e459b93e3b079e41c051ec0
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -141,6 +141,9 @@ steps:
   - name: fetch-tags
     pull: default
     image: docker:git
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - git fetch --tags --force
     when:
@@ -151,6 +154,9 @@ steps:
   - name: build
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - make backend
     environment:
@@ -161,12 +167,18 @@ steps:
   - name: tag-pre-condition
     pull: always
     image: alpine/git
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - git update-ref refs/heads/tag_test ${DRONE_COMMIT_SHA}
 
   - name: unit-test
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - make unit-test-coverage test-check
     environment:
@@ -232,6 +244,9 @@ steps:
   - name: generate-coverage
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - make coverage
     environment:
@@ -301,6 +316,9 @@ steps:
   - name: fetch-tags
     pull: default
     image: docker:git
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - git fetch --tags --force
     when:
@@ -311,6 +329,9 @@ steps:
   - name: build
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - make backend
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -858,6 +858,6 @@ steps:
         from_secret: discord_webhook_token
 ---
 kind: signature
-hmac: 9d0f560fde813881e249374cc4ca08356e2e2d465e459b93e3b079e41c051ec0
+hmac: 0d90639104af9e9899c21208d9002a340991538968ed8eb237056ea88fa05369
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -178,6 +178,9 @@ steps:
   - name: test-mysql
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
@@ -193,6 +196,9 @@ steps:
   - name: test-mysql8
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
@@ -208,6 +214,9 @@ steps:
   - name: test-mssql
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
@@ -255,6 +264,11 @@ steps:
       event:
         - push
         - pull_request
+
+volumes:
+- name: memtmp
+  temp:
+    medium: memory
 
 ---
 kind: pipeline
@@ -307,6 +321,9 @@ steps:
   - name: test-sqlite
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
@@ -321,6 +338,9 @@ steps:
   - name: test-pgsql
     pull: always
     image: golang:1.14
+    volumes:
+    - name: memtmp
+      path: /tmp
     commands:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
@@ -332,6 +352,11 @@ steps:
       USE_REPO_TEST_DIR: 1
     depends_on:
       - build
+
+volumes:
+- name: memtmp
+  temp:
+    medium: memory
 
 ---
 kind: pipeline

--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ generate-ini-sqlite:
 
 .PHONY: test-sqlite
 test-sqlite: integrations.sqlite.test generate-ini-sqlite
+	df -h ; cat /proc/meminfo || true
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/sqlite.ini ./integrations.sqlite.test
 
 .PHONY: test-sqlite\#%
@@ -364,6 +365,7 @@ generate-ini-mysql:
 
 .PHONY: test-mysql
 test-mysql: integrations.mysql.test generate-ini-mysql
+	df -h ; cat /proc/meminfo || true
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/mysql.ini ./integrations.mysql.test
 
 .PHONY: test-mysql\#%
@@ -384,6 +386,7 @@ generate-ini-mysql8:
 
 .PHONY: test-mysql8
 test-mysql8: integrations.mysql8.test generate-ini-mysql8
+	df -h ; cat /proc/meminfo || true
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/mysql8.ini ./integrations.mysql8.test
 
 .PHONY: test-mysql8\#%
@@ -405,6 +408,7 @@ generate-ini-pgsql:
 
 .PHONY: test-pgsql
 test-pgsql: integrations.pgsql.test generate-ini-pgsql
+	df -h ; cat /proc/meminfo || true
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/pgsql.ini ./integrations.pgsql.test
 
 .PHONY: test-pgsql\#%
@@ -425,6 +429,7 @@ generate-ini-mssql:
 
 .PHONY: test-mssql
 test-mssql: integrations.mssql.test generate-ini-mssql
+	df -h ; cat /proc/meminfo || true
 	GITEA_ROOT=${CURDIR} GITEA_CONF=integrations/mssql.ini ./integrations.mssql.test
 
 .PHONY: test-mssql\#%


### PR DESCRIPTION
This PR _only_ mounts `/tmp` with a `tmpfs` (memory) file-system, as we are already using `/tmp` for temporary repositories.

@techknowlogick You can try signing this. As no other changes have been made, this should work from the get go. 🤞 