### PR TITLE
Slight performance changes to integrations/git_test.go

### DIFF
--- a/integrations/api_branch_test.go
+++ b/integrations/api_branch_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func testAPIGetBranch(t *testing.T, branchName string, exists bool) {
-	defer prepareTestEnv(t)()
-
 	session := loginUser(t, "user2")
 	token := getTokenForLoggedInUser(t, session)
 	req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/branches/%s?token=%s", branchName, token)
@@ -88,6 +86,7 @@ func testAPIDeleteBranch(t *testing.T, branchName string, expectedHTTPStatus int
 }
 
 func TestAPIGetBranch(t *testing.T) {
+	defer prepareTestEnv(t)()
 	for _, test := range []struct {
 		BranchName string
 		Exists     bool

--- a/integrations/git_test.go
+++ b/integrations/git_test.go
@@ -70,6 +70,7 @@ func testGit(t *testing.T, u *url.URL) {
 
 		t.Run("BranchProtectMerge", doBranchProtectPRMerge(&httpContext, dstPath))
 		t.Run("MergeFork", func(t *testing.T) {
+			defer PrintCurrentTest(t)()
 			t.Run("CreatePRAndMerge", doMergeFork(httpContext, forkedUserCtx, "master", httpContext.Username+":master"))
 			rawTest(t, &forkedUserCtx, little, big, littleLFS, bigLFS)
 			mediaTest(t, &forkedUserCtx, little, big, littleLFS, bigLFS)
@@ -109,6 +110,7 @@ func testGit(t *testing.T, u *url.URL) {
 
 			t.Run("BranchProtectMerge", doBranchProtectPRMerge(&sshContext, dstPath))
 			t.Run("MergeFork", func(t *testing.T) {
+				defer PrintCurrentTest(t)()
 				t.Run("CreatePRAndMerge", doMergeFork(sshContext, forkedUserCtx, "master", sshContext.Username+":master"))
 				rawTest(t, &forkedUserCtx, little, big, littleLFS, bigLFS)
 				mediaTest(t, &forkedUserCtx, little, big, littleLFS, bigLFS)
@@ -428,6 +430,7 @@ func doProtectBranch(ctx APITestContext, branch string, userToWhitelist string) 
 
 func doMergeFork(ctx, baseCtx APITestContext, baseBranch, headBranch string) func(t *testing.T) {
 	return func(t *testing.T) {
+		defer PrintCurrentTest(t)()
 		var pr api.PullRequest
 		var err error
 		t.Run("CreatePullRequest", func(t *testing.T) {


### PR DESCRIPTION
* Stop cloning the large repos in the push-to-create test - they unnecessarily slow for testing this feature which does not need them
* Stop using crypto/rand for generating the data in the commits - pseudo random is sufficient - and stop creating 128Mb buffers in memory.