### PR TITLE
Allow unauthenticated users to compare

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2270,6 +2270,7 @@ transfer_repo = transferred repository <code>%s</code> to <a href="%s">%s</a>
 push_tag = pushed tag <a href="%s/src/tag/%s">%[2]s</a> to <a href="%[1]s">%[3]s</a>
 delete_tag = deleted tag %[2]s from <a href="%[1]s">%[3]s</a>
 delete_branch = deleted branch %[2]s from <a href="%[1]s">%[3]s</a>
+compare_branch = Compare
 compare_commits = Compare %d commits
 compare_commits_general = Compare commits
 mirror_sync_push = synced commits to <a href="%[1]s/src/%[2]s">%[3]s</a> at <a href="%[1]s">%[4]s</a> from mirror

--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -46,6 +46,7 @@ func Branches(ctx *context.Context) {
 	ctx.Data["AllowsPulls"] = ctx.Repo.Repository.AllowsPulls()
 	ctx.Data["IsWriter"] = ctx.Repo.CanWrite(models.UnitTypeCode)
 	ctx.Data["IsMirror"] = ctx.Repo.Repository.IsMirror
+	ctx.Data["CanPull"] = ctx.Repo.CanWrite(models.UnitTypeCode) || (ctx.IsSigned && ctx.User.HasForkedRepo(ctx.Repo.Repository.ID))
 	ctx.Data["PageIsViewCode"] = true
 	ctx.Data["PageIsBranches"] = true
 

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -709,6 +709,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Group("/milestone", func() {
 			m.Get("/:id", repo.MilestoneIssuesAndPulls)
 		}, reqRepoIssuesOrPullsReader, context.RepoRef())
+		m.Combo("/compare/*", repo.MustBeNotEmpty, reqRepoCodeReader, repo.SetEditorconfigIfExists).
+			Get(repo.SetDiffViewStyle, repo.CompareDiff).
+			Post(reqSignIn, context.RepoMustNotBeArchived(), reqRepoPullsReader, repo.MustAllowPulls, bindIgnErr(auth.CreateIssueForm{}), repo.CompareAndPullRequestPost)
 	}, context.RepoAssignment(), context.UnitTypes())
 
 	// Grouping for those endpoints that do require authentication
@@ -769,9 +772,6 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Post("/:id/:action", repo.ChangeMilestonStatus)
 			m.Post("/delete", repo.DeleteMilestone)
 		}, context.RepoMustNotBeArchived(), reqRepoIssuesOrPullsWriter, context.RepoRef())
-		m.Combo("/compare/*", repo.MustBeNotEmpty, reqRepoCodeReader, repo.SetEditorconfigIfExists).
-			Get(repo.SetDiffViewStyle, repo.CompareDiff).
-			Post(context.RepoMustNotBeArchived(), reqRepoPullsReader, repo.MustAllowPulls, bindIgnErr(auth.CreateIssueForm{}), repo.CompareAndPullRequestPost)
 		m.Group("/pull", func() {
 			m.Post("/:index/target_branch", repo.UpdatePullRequestTarget)
 		}, context.RepoMustNotBeArchived())

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -81,13 +81,13 @@
 												</a>
 											{{else if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{$.DefaultBranch | EscapePound}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | EscapePound}}">
-												<button id="new-pull-request" class="ui compact basic button">{{$.i18n.Tr "repo.pulls.compare_changes"}}</button>
+												<button id="new-pull-request" class="ui compact basic button">{{if $.CanPull}}{{$.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{$.i18n.Tr "action.compare_branch"}}{{end}}</button>
 											</a>
 											{{end}}
 										{{else if and .LatestPullRequest.HasMerged .MergeMovedOn}}
 											{{if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{$.DefaultBranch | EscapePound}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | EscapePound}}">
-												<button id="new-pull-request" class="ui compact basic button">{{$.i18n.Tr "repo.pulls.compare_changes"}}</button>
+												<button id="new-pull-request" class="ui compact basic button">{{if $.CanPull}}{{$.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{$.i18n.Tr "action.compare_branch"}}{{end}}</button>
 											</a>
 											{{end}}
 										{{else}}

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -5,7 +5,7 @@
 
 	{{if .PageIsComparePull}}
 		<h2 class="ui header">
-			{{if not .Repository.IsArchived}}
+			{{if and $.IsSigned (not .Repository.IsArchived)}}
 				{{.i18n.Tr "repo.pulls.compare_changes"}}
 				<div class="sub header">{{.i18n.Tr "repo.pulls.compare_changes_desc"}}</div>
 			{{ else }}
@@ -64,22 +64,24 @@
         	<div class="ui segment">
         		{{.i18n.Tr "repo.pulls.has_pull_request" $.RepoLink $.RepoRelPath .PullRequest.Index | Safe}}
         	</div>
-        {{else}}
-        	{{if not .Repository.IsArchived}}
-        	<div class="ui info message show-form-container">
-        		<button class="ui button green show-form">{{.i18n.Tr "repo.pulls.new"}}</button>
-        	</div>
-        	{{ else }}
-        		<div class="ui warning message">
-        			{{.i18n.Tr "repo.archive.title"}}
-        		</div>
-        	{{ end }}
-        	<div class="pullrequest-form" style="display: none">
-        		{{template "repo/issue/new_form" .}}
-        	</div>
-        	{{template "repo/commits_table" .}}
-        	{{template "repo/diff/box" .}}
-        {{end}}
+		{{else}}
+			{{if and $.IsSigned (not .Repository.IsArchived)}}
+				<div class="ui info message show-form-container">
+					<button class="ui button green show-form">{{.i18n.Tr "repo.pulls.new"}}</button>
+				</div>
+			{{else if .Repository.IsArchived}}
+				<div class="ui warning message">
+					{{.i18n.Tr "repo.archive.title"}}
+				</div>
+			{{end}}
+			{{if $.IsSigned}}
+				<div class="pullrequest-form" style="display: none">
+					{{template "repo/issue/new_form" .}}
+				</div>
+			{{end}}
+			{{template "repo/commits_table" .}}
+			{{template "repo/diff/box" .}}
+		{{end}}
 	{{else}}
 		{{template "repo/commits_table" .}}
 		{{template "repo/diff/box" .}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -62,10 +62,10 @@
 			{{ $l := Subtract $n 1}}
 			<!-- If home page, show new PR. If not, show breadcrumb -->
 			{{if eq $n 0}}
-				{{if and .PullRequestCtx.Allowed .IsViewBranch (not .Repository.IsArchived)}}
+				{{if and .CanCompareOrPull .IsViewBranch (not .Repository.IsArchived)}}
 					<div class="fitted item">
 						<a href="{{.BaseRepo.Link}}/compare/{{.BaseRepo.DefaultBranch | EscapePound}}...{{if ne .Repository.Owner.Name .BaseRepo.Owner.Name}}{{.Repository.Owner.Name}}:{{end}}{{.BranchName | EscapePound}}">
-							<button id="new-pull-request" class="ui compact basic button">{{.i18n.Tr "repo.pulls.compare_changes"}}</button>
+							<button id="new-pull-request" class="ui compact basic button">{{if .PullRequestCtx.Allowed}}{{.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{.i18n.Tr "action.compare_branch"}}{{end}}</button>
 						</a>
 					</div>
 				{{end}}


### PR DESCRIPTION
This brings Gitea slightly closer to GitHub parity as far as branch comparisons go. If a repository is public, there's no reason (that I can see) that unauthenticated users shouldn't be able to compare branches.

This pull request improves the unauthenticated user experience ever-so-slightly, by:

1.) Allowing unauthenticated users to compare branches,
2.) Adding "Compare" buttons for unauthenticated users to the repo's home route, so they can easily compare the branch they're viewing like they can on GitHub -- it goes where the Pull Request button normally goes, and actually just replaces the verbiage as the routes are the same.
3.) Changes "New Pull Request" verbiage on the branch listing (e.g. https://try.gitea.io/kevans/test_repo/branches/) to "Compare" for unauthenticated users, no longer leading to a sign-in form.