### PR TITLE
Use keys.openpgp.org instead of pgp.mit.edu

### DIFF
--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -26,10 +26,10 @@ chmod +x gitea
 ```
 
 ## Verify GPG signature
-Gitea signs all binaries with a [GPG key](https://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0x2D9AE806EC1592E2) to prevent against unwanted modification of binaries. To validate the binary, download the signature file which ends in `.asc` for the binary you downloaded and use the gpg command line tool.
+Gitea signs all binaries with a [GPG key](https://keys.openpgp.org/search?q=teabot%40gitea.io) to prevent against unwanted modification of binaries. To validate the binary, download the signature file which ends in `.asc` for the binary you downloaded and use the gpg command line tool.
 
 ```sh
-gpg --keyserver pgp.mit.edu --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
+gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
 gpg --verify gitea-{{< version >}}-linux-amd64.asc gitea-{{< version >}}-linux-amd64
 ```
 


### PR DESCRIPTION
The SKS Keyserver network has been under attack with poisoned
certificates since at least 2019. Downloading a poisoned certificate has
the awful side-effect of completely breaking your keyring and most
software has now moved off the network and uses the keys.openpgp.org
which has a different protocol instead - in fact one whereby emails are
verified.

For more details regarding the attack see: https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f

See: https://keys.openpgp.org/about and https://keys.openpgp.org/about/faq

Signed-off-by: Andrew Thornton <art27@cantab.net>
