### PR TITLE
Fix orgs not being displayed on create repo form

### DIFF
--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -62,6 +62,18 @@ func checkContextUser(ctx *context.Context, uid int64) *models.User {
 		return nil
 	}
 
+	if !ctx.User.IsAdmin {
+		orgsAvailable := []*models.User{}
+		for i := 0; i < len(orgs); i++ {
+			if orgs[i].CanCreateRepo() {
+				orgsAvailable = append(orgsAvailable, orgs[i])
+			}
+		}
+		ctx.Data["Orgs"] = orgsAvailable
+	} else {
+		ctx.Data["Orgs"] = orgs
+	}
+
 	// Not equal means current user is an organization.
 	if uid == ctx.User.ID || uid == 0 {
 		return ctx.User
@@ -83,14 +95,6 @@ func checkContextUser(ctx *context.Context, uid int64) *models.User {
 		return nil
 	}
 	if !ctx.User.IsAdmin {
-		orgsAvailable := []*models.User{}
-		for i := 0; i < len(orgs); i++ {
-			if orgs[i].CanCreateRepo() {
-				orgsAvailable = append(orgsAvailable, orgs[i])
-			}
-		}
-		ctx.Data["Orgs"] = orgsAvailable
-
 		canCreate, err := org.CanCreateOrgRepo(ctx.User.ID)
 		if err != nil {
 			ctx.ServerError("CanCreateOrgRepo", err)


### PR DESCRIPTION
#11183 prevents the Create Repository dialog from displaying orgs that the user has the createRepository permission on.

Steps to reproduce:

* User 1 creates an organization A
* When User 1 attempts to create a new repository, A should be allowed to be chosen as the owner

The problem is that the function MUST put the Orgs list in to the context before second conditional


