### PR TITLE
Change the style in admin notice content view from <p> to <pre>

### DIFF
--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -77,7 +77,7 @@
 	<i class="close icon"></i>
 	<div class="header">{{$.i18n.Tr "admin.notices.view_detail_header"}}</div>
 	<div class="content">
-		<p></p>
+		<pre></pre>
 	</div>
 </div>
 {{template "base/footer" .}}

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2019,7 +2019,7 @@ function initAdmin() {
 
     // Attach view detail modals
     $('.view-detail').on('click', function () {
-      $detailModal.find('.content p').text($(this).data('content'));
+      $detailModal.find('.content pre').text($(this).data('content'));
       $detailModal.modal('show');
       return false;
     });


### PR DESCRIPTION
That's because many notic have more than one lines. So I think pre is more better to used in here than p

from:
![f1](https://user-images.githubusercontent.com/25342410/81078403-c67c9400-8f20-11ea-883b-54f8fb191c00.jpg)

to:
![f2](https://user-images.githubusercontent.com/25342410/81078426-ce3c3880-8f20-11ea-800e-3a0d589eb9b5.jpg)
