### PR TITLE
load new services in 'make pr'

### DIFF
--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -105,7 +105,9 @@ func runPR() {
 	com.CopyDir(path.Join(curDir, "integrations/gitea-repositories-meta"), setting.RepoRootPath)
 
 	log.Printf("[PR] Setting up gitea\n")
-	routes.GlobalInitAfterSettings(m)
+	routes.GlobalInitAfterSettings(graceful.GetManager().HammerContext())
+	m := routes.NewMacaron()
+	routes.RegisterRoutes(m)
 
 	log.Printf("[PR] Ready for testing !\n")
 	log.Printf("[PR] Login with user1, user2, user3, ... with pass: password\n")

--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -26,7 +26,9 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/routers"
 	"code.gitea.io/gitea/routers/routes"
 
 	"github.com/go-git/go-git/v5"
@@ -105,7 +107,10 @@ func runPR() {
 	com.CopyDir(path.Join(curDir, "integrations/gitea-repositories-meta"), setting.RepoRootPath)
 
 	log.Printf("[PR] Setting up gitea\n")
-	routes.GlobalInitAfterSettings(graceful.GetManager().HammerContext())
+	managerCtx, cancel := context.WithCancel(context.Background())
+	graceful.InitManager(managerCtx)
+	defer cancel()
+	routers.GlobalInitAfterSettings(graceful.GetManager().HammerContext())
 	m := routes.NewMacaron()
 	routes.RegisterRoutes(m)
 

--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -26,10 +26,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/models"
-	"code.gitea.io/gitea/modules/markup"
-	"code.gitea.io/gitea/modules/markup/external"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/routers"
 	"code.gitea.io/gitea/routers/routes"
 
 	"github.com/go-git/go-git/v5"
@@ -81,18 +78,10 @@ func runPR() {
 	setting.RunUser = curUser.Username
 
 	log.Printf("[PR] Loading fixtures data ...\n")
-	setting.CheckLFSVersion()
-	//models.LoadConfigs()
-	/*
-		setting.Database.Type = "sqlite3"
-		setting.Database.Path = ":memory:"
-		setting.Database.Timeout = 500
-	*/
 	db := setting.Cfg.Section("database")
 	db.NewKey("DB_TYPE", "sqlite3")
 	db.NewKey("PATH", ":memory:")
 
-	routers.NewServices()
 	setting.Database.LogSQL = true
 	//x, err = xorm.NewEngine("sqlite3", "file::memory:?cache=shared")
 
@@ -115,12 +104,8 @@ func runPR() {
 	os.RemoveAll(models.LocalCopyPath())
 	com.CopyDir(path.Join(curDir, "integrations/gitea-repositories-meta"), setting.RepoRootPath)
 
-	log.Printf("[PR] Setting up router\n")
-	//routers.GlobalInit()
-	external.RegisterParsers()
-	markup.Init()
-	m := routes.NewMacaron()
-	routes.RegisterRoutes(m)
+	log.Printf("[PR] Setting up gitea\n")
+	routes.GlobalInitAfterSettings(m)
 
 	log.Printf("[PR] Ready for testing !\n")
 	log.Printf("[PR] Login with user1, user2, user3, ... with pass: password\n")

--- a/routers/init.go
+++ b/routers/init.go
@@ -89,7 +89,6 @@ func GlobalInitAfterSettings(ctx context.Context) {
 	if err := git.Init(ctx); err != nil {
 		log.Fatal("Git module init failed: %v", err)
 	}
-
 	setting.CheckLFSVersion()
 	log.Trace("AppPath: %s", setting.AppPath)
 	log.Trace("AppWorkPath: %s", setting.AppWorkPath)

--- a/routers/init.go
+++ b/routers/init.go
@@ -81,9 +81,15 @@ func initDBEngine(ctx context.Context) (err error) {
 // GlobalInit is for global configuration reload-able.
 func GlobalInit(ctx context.Context) {
 	setting.NewContext()
+	GlobalInitAfterSettings(ctx)
+}
+
+// GlobalInitAfterSettings init everything after settings are set.
+func GlobalInitAfterSettings(ctx context.Context) {
 	if err := git.Init(ctx); err != nil {
 		log.Fatal("Git module init failed: %v", err)
 	}
+
 	setting.CheckLFSVersion()
 	log.Trace("AppPath: %s", setting.AppPath)
 	log.Trace("AppWorkPath: %s", setting.AppWorkPath)


### PR DESCRIPTION
Few services were added lately and the 'make pr' doesn't start them. 

I break the GlobalInit function in two to be able to init and launch all the services the same as the standard way.