### PR TITLE
Prevent duplicate records in organizations list when creating a repository

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -476,7 +476,7 @@ func GetOrgsCanCreateRepoByUserID(userID int64) ([]*User, error) {
 	return orgs, x.Where("id IN ("+
 		"SELECT `user`.id FROM `user` "+
 		"INNER JOIN `team_user` ON `team_user`.org_id = `user`.id "+
-		"INNER JOIN `team` on `team`.id = `team_user`.team_id "+
+		"INNER JOIN `team` ON `team`.id = `team_user`.team_id "+
 		"WHERE `team_user`.uid = ? AND "+
 		"(`team`.authorize = ? OR `team`.can_create_org_repo = ?) "+
 		"GROUP BY `user`.id)", userID, AccessModeOwner, true).

--- a/models/org.go
+++ b/models/org.go
@@ -478,7 +478,7 @@ func GetOrgsCanCreateRepoByUserID(userID int64) ([]*User, error) {
 		Join("INNER", "`team`", "`team`.id=`team_user`.team_id").
 		Where("`team_user`.uid=?", userID).
 		And(builder.Eq{"`team`.authorize": AccessModeOwner}.Or(builder.Eq{"`team`.can_create_org_repo": true})).
-		Desc("`user`.updated_unix").GroupBy("user.id").Table("user").Cols("user.id").
+		Desc("`user`.updated_unix").GroupBy("`user`.id").Table("`user`").Cols("`user`.id").
 		Find(&orgIDs); err != nil {
 		return nil, err
 	}

--- a/models/org.go
+++ b/models/org.go
@@ -477,8 +477,7 @@ func GetOrgsCanCreateRepoByUserID(userID int64) ([]*User, error) {
 		Join("INNER", "`team_user`", "`team_user`.org_id = `user`.id").
 		Join("INNER", "`team`", "`team`.id = `team_user`.team_id").
 		Where(builder.Eq{"`team_user`.uid": userID}).
-		And(builder.Eq{"`team`.authorize": AccessModeOwner}.Or(builder.Eq{"`team`.can_create_org_repo": true})).
-		GroupBy("`user`.id"))).
+		And(builder.Eq{"`team`.authorize": AccessModeOwner}.Or(builder.Eq{"`team`.can_create_org_repo": true})))).
 		Desc("`user`.updated_unix").Find(&orgs)
 }
 

--- a/models/org.go
+++ b/models/org.go
@@ -471,14 +471,20 @@ func GetOwnedOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
 // GetOrgsCanCreateRepoByUserID returns a list of organizations where given user ID
 // are allowed to create repos.
 func GetOrgsCanCreateRepoByUserID(userID int64) ([]*User, error) {
-	orgs := make([]*User, 0, 10)
+	orgIDs := make([]int64, 0, 10)
 
-	return orgs, x.Join("INNER", "`team_user`", "`team_user`.org_id=`user`.id").
+	// because xorm do not return all cols, we have to collect IDs first and return user based on them afterwards
+	if err := x.Join("INNER", "`team_user`", "`team_user`.org_id=`user`.id").
 		Join("INNER", "`team`", "`team`.id=`team_user`.team_id").
 		Where("`team_user`.uid=?", userID).
 		And(builder.Eq{"`team`.authorize": AccessModeOwner}.Or(builder.Eq{"`team`.can_create_org_repo": true})).
-		Desc("`user`.updated_unix").
-		Find(&orgs)
+		Desc("`user`.updated_unix").GroupBy("user.id").Table("user").Cols("user.id").
+		Find(&orgIDs); err != nil {
+		return nil, err
+	}
+
+	orgs := make([]*User, 0, len(orgIDs))
+	return orgs, x.In("id", orgIDs).Find(&orgs)
 }
 
 // GetOrgUsersByUserID returns all organization-user relations by user ID.


### PR DESCRIPTION
prevent double entries in results of `GetOrgsCanCreateRepoByUserID`

I first try to only add GroupBy directly but xorm return broken user objects ...

... solution was to just query related UserIDs(OrgIDs) first and return OrgUsers based on this IDs

close #11258