### PR TITLE
api.Context.NotFound(...) should tolerate nil (#11288)

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -212,6 +212,11 @@ func (ctx *APIContext) NotFound(objs ...interface{}) {
 	var message = "Not Found"
 	var errors []string
 	for _, obj := range objs {
+		// Ignore nil
+		if obj == nil {
+			continue
+		}
+
 		if err, ok := obj.(error); ok {
 			errors = append(errors, err.Error())
 		} else {


### PR DESCRIPTION
Backport #11288 

There is an unfortunate signature change with the api.Context
NotFound function; whereas the normal modules/context/Context
NotFound function requires an error or nil, the api.Context
variant will panic with an NPE if a nil is provided.

This PR will allow api.Context.NotFound to tolerate a being
passed a nil.

Signed-off-by: Andrew Thornton <art27@cantab.net>

Co-authored-by: Lauris BH <lauris@nix.lv>
