### PR TITLE
When deleting a tracked time through the API return 404 not 500

### DIFF
--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -317,6 +317,10 @@ func DeleteTime(ctx *context.APIContext) {
 
 	time, err := models.GetTrackedTimeByID(ctx.ParamsInt64(":id"))
 	if err != nil {
+		if models.IsErrNotExist(err) {
+			ctx.NotFound(err)
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetTrackedTimeByID", err)
 		return
 	}


### PR DESCRIPTION
as title