### PR TITLE
Manage port in submodule refurl (#11305)

### DIFF
--- a/modules/git/submodule.go
+++ b/modules/git/submodule.go
@@ -52,10 +52,14 @@ func getRefURL(refURL, urlPrefix, repoFullName string) string {
 		urlPrefixHostname = prefixURL.Host
 	}
 
+	if strings.HasSuffix(urlPrefix, "/") {
+		urlPrefix = urlPrefix[:len(urlPrefix)-1]
+	}
+
 	// FIXME: Need to consider branch - which will require changes in modules/git/commit.go:GetSubModules
 	// Relative url prefix check (according to git submodule documentation)
 	if strings.HasPrefix(refURI, "./") || strings.HasPrefix(refURI, "../") {
-		return urlPrefix + path.Clean(path.Join(repoFullName, refURI))
+		return urlPrefix + path.Clean(path.Join("/", repoFullName, refURI))
 	}
 
 	if !strings.Contains(refURI, "://") {
@@ -73,7 +77,7 @@ func getRefURL(refURL, urlPrefix, repoFullName string) string {
 			}
 
 			if urlPrefixHostname == refHostname {
-				return prefixURL.Scheme + "://" + urlPrefixHostname + path.Join(prefixURL.Path, path.Clean(pth))
+				return urlPrefix + path.Clean(path.Join("/", pth))
 			}
 			return "http://" + refHostname + pth
 		}
@@ -94,7 +98,7 @@ func getRefURL(refURL, urlPrefix, repoFullName string) string {
 	for _, scheme := range supportedSchemes {
 		if ref.Scheme == scheme {
 			if urlPrefixHostname == refHostname {
-				return prefixURL.Scheme + "://" + prefixURL.Host + path.Join(prefixURL.Path, ref.Path)
+				return urlPrefix + path.Clean(path.Join("/", ref.Path))
 			} else if ref.Scheme == "http" || ref.Scheme == "https" {
 				if len(ref.User.Username()) > 0 {
 					return ref.Scheme + "://" + fmt.Sprintf("%v", ref.User) + "@" + ref.Host + ref.Path


### PR DESCRIPTION
Backport #11305

* Manage port in submodule refurl

Fix #11304

Signed-off-by: Andrew Thornton <art27@cantab.net>

* fix lint

Signed-off-by: Andrew Thornton <art27@cantab.net>

* URLJoin is causes a cyclic dependency and possibly isn't what what we want anyway

Signed-off-by: Andrew Thornton <art27@cantab.net>

* Protect against leading .. in scp syntax

Signed-off-by: Andrew Thornton <art27@cantab.net>

Co-authored-by: Lauris BH <lauris@nix.lv>
