### PR TITLE
When delete tracked time through the API return 404 not 500 (#11319)

### DIFF
--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -289,7 +289,11 @@ func DeleteTime(ctx *context.APIContext) {
 
 	time, err := models.GetTrackedTimeByID(ctx.ParamsInt64(":id"))
 	if err != nil {
-		ctx.Error(500, "GetTrackedTimeByID", err)
+		if models.IsErrNotExist(err) {
+			ctx.NotFound(err)
+			return
+		}
+		ctx.Error(http.StatusInternalServerError, "GetTrackedTimeByID", err)
 		return
 	}
 


### PR DESCRIPTION
backport #11319