### PR TITLE
Limit snap build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,11 @@ confinement: strict
 base: core18
 adopt-info: gitea
 
+architectures:
+  - build-on: armhf
+  - build-on: amd64
+  - build-on: arm64
+
 environment:
   GITEA_CUSTOM: "$SNAP_COMMON"
   GITEA_WORK_DIR: "$SNAP_DATA"


### PR DESCRIPTION
Builds will fail on s390x, i386 and ppc64el because we depend on nodejs 14+, which is only published for armhf, arm64 and amd64. This change merely tells the snap build farm to not waste time trying to build on architectures will will guarantee failure. Apologies for overlooking this in our previous PR.

Example build failures can be seen at [i386](https://launchpad.net/~build.snapcraft.io/+snap/53d5570c233b8b3663242f8d94dc21ad/+build/945935), [ppc64el](https://launchpad.net/~build.snapcraft.io/+snap/53d5570c233b8b3663242f8d94dc21ad/+build/945939), [s390x](https://launchpad.net/~build.snapcraft.io/+snap/53d5570c233b8b3663242f8d94dc21ad/+build/945940)
