### PR TITLE
Allow Git ref for /repos/{owner}/{repo}/git/commits/{sha}

### DIFF
--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -21,18 +21,20 @@ func TestAPIReposGitCommits(t *testing.T) {
 	session := loginUser(t, user.Name)
 	token := getTokenForLoggedInUser(t, session)
 
-	//check invalid requests for GetCommitsBySHA
-	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/master?token="+token, user.Name)
-	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
-
+	// check invalid requests
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/12345?token="+token, user.Name)
+	session.MakeRequest(t, req, http.StatusNotFound)
 	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/12345?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusNotFound)
 
-	//check invalid requests for GetCommitsByRef
 	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/..?token="+token, user.Name)
+	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
+	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/..?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
 
 	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/branch-not-exist?token="+token, user.Name)
+	session.MakeRequest(t, req, http.StatusNotFound)
+	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/branch-not-exist?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusNotFound)
 
 	for _, ref := range [...]string{
@@ -45,13 +47,14 @@ func TestAPIReposGitCommits(t *testing.T) {
 		resp := session.MakeRequest(t, req, http.StatusOK)
 		commitByRef := new(api.Commit)
 		DecodeJSON(t, resp, commitByRef)
-		assert.Len(t, commitByRef.SHA, 40)
-		assert.EqualValues(t, commitByRef.SHA, commitByRef.RepoCommit.Tree.SHA)
-		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/%s?token="+token, user.Name, commitByRef.SHA)
+
+		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/%s?token="+token, user.Name, ref)
 		resp = session.MakeRequest(t, req, http.StatusOK)
 		commitBySHA := new(api.Commit)
 		DecodeJSON(t, resp, commitBySHA)
 
+		assert.Len(t, commitByRef.SHA, 40)
+		assert.EqualValues(t, commitByRef.SHA, commitByRef.RepoCommit.Tree.SHA)
 		assert.EqualValues(t, commitByRef.SHA, commitBySHA.SHA)
 		assert.EqualValues(t, commitByRef.HTMLURL, commitBySHA.HTMLURL)
 		assert.EqualValues(t, commitByRef.RepoCommit.Message, commitBySHA.RepoCommit.Message)

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -53,7 +53,7 @@ func GetSingleCommitBySHA(ctx *context.APIContext) {
 	//     "$ref": "#/responses/notFound"
 
 	sha := ctx.Params(":sha")
-	if !git.SHAPattern.MatchString(sha) {
+	if (validation.GitRefNamePatternInvalid.MatchString(sha) || !validation.CheckGitRefAdditionalRulesValid(sha)) && !git.SHAPattern.MatchString(sha) {
 		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid sha: %s", sha))
 		return
 	}
@@ -93,7 +93,7 @@ func GetSingleCommitByRef(ctx *context.APIContext) {
 
 	ref := ctx.Params("ref")
 
-	if validation.GitRefNamePatternInvalid.MatchString(ref) || !validation.CheckGitRefAdditionalRulesValid(ref) {
+	if (validation.GitRefNamePatternInvalid.MatchString(ref) || !validation.CheckGitRefAdditionalRulesValid(ref)) && !git.SHAPattern.MatchString(ref) {
 		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid ref: %s", ref))
 		return
 	}


### PR DESCRIPTION
As discussed on Discord, this allows both ref and SHA to be passed to both API endpoints, essentially making them identical. This makes https://github.com/drone/go-scm/pull/50 unnecessary and reverts breaking change introduced by https://github.com/go-gitea/gitea/pull/10915

There is also an alternative PR https://github.com/go-gitea/gitea/pull/11368

Closes #11368 