### PR TITLE
Consolidate API for getting single commit

### DIFF
--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -21,18 +21,14 @@ func TestAPIReposGitCommits(t *testing.T) {
 	session := loginUser(t, user.Name)
 	token := getTokenForLoggedInUser(t, session)
 
-	//check invalid requests for GetCommitsBySHA
-	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/master?token="+token, user.Name)
-	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
-
-	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/12345?token="+token, user.Name)
+	// check invalid requests
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/12345?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusNotFound)
 
-	//check invalid requests for GetCommitsByRef
-	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/..?token="+token, user.Name)
+	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/..?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
 
-	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/branch-not-exist?token="+token, user.Name)
+	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/branch-not-exist?token="+token, user.Name)
 	session.MakeRequest(t, req, http.StatusNotFound)
 
 	for _, ref := range [...]string{
@@ -41,20 +37,8 @@ func TestAPIReposGitCommits(t *testing.T) {
 		"65f1",   // short sha
 		"65f1bf27bc3bf70f64657658635e66094edbcb4d", // full sha
 	} {
-		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/commits/%s?token="+token, user.Name, ref)
-		resp := session.MakeRequest(t, req, http.StatusOK)
-		commitByRef := new(api.Commit)
-		DecodeJSON(t, resp, commitByRef)
-		assert.Len(t, commitByRef.SHA, 40)
-		assert.EqualValues(t, commitByRef.SHA, commitByRef.RepoCommit.Tree.SHA)
-		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/%s?token="+token, user.Name, commitByRef.SHA)
-		resp = session.MakeRequest(t, req, http.StatusOK)
-		commitBySHA := new(api.Commit)
-		DecodeJSON(t, resp, commitBySHA)
-
-		assert.EqualValues(t, commitByRef.SHA, commitBySHA.SHA)
-		assert.EqualValues(t, commitByRef.HTMLURL, commitBySHA.HTMLURL)
-		assert.EqualValues(t, commitByRef.RepoCommit.Message, commitBySHA.RepoCommit.Message)
+		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/commits/%s?token="+token, user.Name, ref)
+		session.MakeRequest(t, req, http.StatusOK)
 	}
 }
 

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -817,14 +817,13 @@ func RegisterRoutes(m *macaron.Macaron) {
 				m.Group("/commits", func() {
 					m.Get("", repo.GetAllCommits)
 					m.Group("/:ref", func() {
-						m.Get("", repo.GetSingleCommitByRef)
 						m.Get("/status", repo.GetCombinedCommitStatusByRef)
 						m.Get("/statuses", repo.GetCommitStatusesByRef)
 					})
 				}, reqRepoReader(models.UnitTypeCode))
 				m.Group("/git", func() {
 					m.Group("/commits", func() {
-						m.Get("/:sha", repo.GetSingleCommitBySHA)
+						m.Get("/:sha", repo.GetSingleCommitByRef)
 					})
 					m.Get("/refs", repo.GetGitAllRefs)
 					m.Get("/refs/*", repo.GetGitRefs)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -823,7 +823,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 				}, reqRepoReader(models.UnitTypeCode))
 				m.Group("/git", func() {
 					m.Group("/commits", func() {
-						m.Get("/:sha", repo.GetSingleCommitByRef)
+						m.Get("/:sha", repo.GetSingleCommit)
 					})
 					m.Get("/refs", repo.GetGitAllRefs)
 					m.Get("/refs/*", repo.GetGitRefs)

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -21,9 +21,9 @@ import (
 	"code.gitea.io/gitea/routers/api/v1/utils"
 )
 
-// GetSingleCommitBySHA get a commit via sha
-func GetSingleCommitBySHA(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha} repository repoGetSingleCommitBySHA
+// GetSingleCommitByRef get a commit via sha
+func GetSingleCommitByRef(ctx *context.APIContext) {
+	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{ref} repository repoGetSingleCommitByRef
 	// ---
 	// summary: Get a single commit from a repository
 	// produces:
@@ -52,53 +52,12 @@ func GetSingleCommitBySHA(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	sha := ctx.Params(":sha")
+	sha := ctx.Params(":ref")
 	if (validation.GitRefNamePatternInvalid.MatchString(sha) || !validation.CheckGitRefAdditionalRulesValid(sha)) && !git.SHAPattern.MatchString(sha) {
-		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid sha: %s", sha))
+		ctx.Error(http.StatusUnprocessableEntity, "no valid ref", fmt.Sprintf("no valid ref: %s", sha))
 		return
 	}
 	getCommit(ctx, sha)
-}
-
-// GetSingleCommitByRef get a commit via ref
-func GetSingleCommitByRef(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/commits/{ref} repository repoGetSingleCommitByRef
-	// ---
-	// summary: Get a single commit from a repository
-	// produces:
-	// - application/json
-	// parameters:
-	// - name: owner
-	//   in: path
-	//   description: owner of the repo
-	//   type: string
-	//   required: true
-	// - name: repo
-	//   in: path
-	//   description: name of the repo
-	//   type: string
-	//   required: true
-	// - name: ref
-	//   in: path
-	//   description: a git ref
-	//   type: string
-	//   required: true
-	// responses:
-	//   "200":
-	//     "$ref": "#/responses/Commit"
-	//   "422":
-	//     "$ref": "#/responses/validationError"
-	//   "404":
-	//     "$ref": "#/responses/notFound"
-
-	ref := ctx.Params("ref")
-
-	if (validation.GitRefNamePatternInvalid.MatchString(ref) || !validation.CheckGitRefAdditionalRulesValid(ref)) && !git.SHAPattern.MatchString(ref) {
-		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid ref: %s", ref))
-		return
-	}
-
-	getCommit(ctx, ref)
 }
 
 func getCommit(ctx *context.APIContext, identifier string) {

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -21,9 +21,9 @@ import (
 	"code.gitea.io/gitea/routers/api/v1/utils"
 )
 
-// GetSingleCommitByRef get a commit via sha
-func GetSingleCommitByRef(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{ref} repository repoGetSingleCommitByRef
+// GetSingleCommit get a commit via sha
+func GetSingleCommit(ctx *context.APIContext) {
+	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha} repository repoGetSingleCommit
 	// ---
 	// summary: Get a single commit from a repository
 	// produces:
@@ -41,7 +41,7 @@ func GetSingleCommitByRef(ctx *context.APIContext) {
 	//   required: true
 	// - name: sha
 	//   in: path
-	//   description: the commit hash
+	//   description: a git ref or commit sha
 	//   type: string
 	//   required: true
 	// responses:
@@ -52,9 +52,9 @@ func GetSingleCommitByRef(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	sha := ctx.Params(":ref")
+	sha := ctx.Params(":sha")
 	if (validation.GitRefNamePatternInvalid.MatchString(sha) || !validation.CheckGitRefAdditionalRulesValid(sha)) && !git.SHAPattern.MatchString(sha) {
-		ctx.Error(http.StatusUnprocessableEntity, "no valid ref", fmt.Sprintf("no valid ref: %s", sha))
+		ctx.Error(http.StatusUnprocessableEntity, "no valid ref or sha", fmt.Sprintf("no valid ref or sha: %s", sha))
 		return
 	}
 	getCommit(ctx, sha)

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -53,7 +53,7 @@ func GetSingleCommitBySHA(ctx *context.APIContext) {
 	//     "$ref": "#/responses/notFound"
 
 	sha := ctx.Params(":sha")
-	if !git.SHAPattern.MatchString(sha) {
+	if (validation.GitRefNamePatternInvalid.MatchString(sha) || !validation.CheckGitRefAdditionalRulesValid(sha)) && !git.SHAPattern.MatchString(sha) {
 		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid sha: %s", sha))
 		return
 	}
@@ -93,7 +93,7 @@ func GetSingleCommitByRef(ctx *context.APIContext) {
 
 	ref := ctx.Params("ref")
 
-	if validation.GitRefNamePatternInvalid.MatchString(ref) || !validation.CheckGitRefAdditionalRulesValid(ref) {
+	if (validation.GitRefNamePatternInvalid.MatchString(ref) || !validation.CheckGitRefAdditionalRulesValid(ref)) && !git.SHAPattern.MatchString(ref) {
 		ctx.Error(http.StatusUnprocessableEntity, "no valid sha", fmt.Sprintf("no valid ref: %s", ref))
 		return
 	}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3020,7 +3020,7 @@
         }
       }
     },
-    "/repos/{owner}/{repo}/git/commits/{ref}": {
+    "/repos/{owner}/{repo}/git/commits/{sha}": {
       "get": {
         "produces": [
           "application/json"
@@ -3029,7 +3029,7 @@
           "repository"
         ],
         "summary": "Get a single commit from a repository",
-        "operationId": "repoGetSingleCommitByRef",
+        "operationId": "repoGetSingleCommit",
         "parameters": [
           {
             "type": "string",
@@ -3047,8 +3047,8 @@
           },
           {
             "type": "string",
-            "description": "a git ref",
-            "name": "ref",
+            "description": "a git ref or commit sha",
+            "name": "sha",
             "in": "path",
             "required": true
           }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -2549,52 +2549,6 @@
         }
       }
     },
-    "/repos/{owner}/{repo}/commits/{ref}": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Get a single commit from a repository",
-        "operationId": "repoGetSingleCommitByRef",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "owner of the repo",
-            "name": "owner",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of the repo",
-            "name": "repo",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "a git ref",
-            "name": "ref",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/Commit"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          },
-          "422": {
-            "$ref": "#/responses/validationError"
-          }
-        }
-      }
-    },
     "/repos/{owner}/{repo}/commits/{ref}/statuses": {
       "get": {
         "produces": [
@@ -3066,7 +3020,7 @@
         }
       }
     },
-    "/repos/{owner}/{repo}/git/commits/{sha}": {
+    "/repos/{owner}/{repo}/git/commits/{ref}": {
       "get": {
         "produces": [
           "application/json"
@@ -3075,7 +3029,7 @@
           "repository"
         ],
         "summary": "Get a single commit from a repository",
-        "operationId": "repoGetSingleCommitBySHA",
+        "operationId": "repoGetSingleCommitByRef",
         "parameters": [
           {
             "type": "string",
@@ -3093,8 +3047,8 @@
           },
           {
             "type": "string",
-            "description": "the commit hash",
-            "name": "sha",
+            "description": "a git ref",
+            "name": "ref",
             "in": "path",
             "required": true
           }


### PR DESCRIPTION
This is an alternative to https://github.com/go-gitea/gitea/pull/11367

As discussed on Discord; this PR removes new API endpoint introduced by https://github.com/go-gitea/gitea/pull/10915 and reverts it's breaking change of disallowing Git ref on already existing ones. It makes https://github.com/drone/go-scm/pull/50 unnecessary. 

In addition, this PR updates documentation regarding this API endpoint to make it obvious that it accepts valid git ref.

Functionally, https://github.com/go-gitea/gitea/pull/10915 made no changes except introducing redundant API endpoint.

Closes #11367 