### PR TITLE
issue #11369 add two missing german translations

### DIFF
--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -912,6 +912,8 @@ issues.close_comment_issue=Kommentieren und schließen
 issues.reopen_issue=Wieder öffnen
 issues.reopen_comment_issue=Kommentieren und wieder öffnen
 issues.create_comment=Kommentieren
+issues.closed_at = `schloss dieses Issue <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.reopened_at = `eröffnete dieses Issue wieder am <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.commit_ref_at=`hat dieses Issue <a id="%[1]s" href="#%[1]s">%[2]s</a> aus einem Commit referenziert`
 issues.ref_issue_from=`<a href="%[3]s">verweist auf dieses Issue %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_pull_from=`<a href="%[3]s">verweist auf diesen Pull Request %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`


### PR DESCRIPTION
This PR just adds two translation keys.
I came to this because of #11369 but I weren't able which are the proper keys for `lines` and `words`