### PR TITLE
Ensure search action button is coalesced to adjacent input

### DIFF
--- a/templates/admin/emails/list.tmpl
+++ b/templates/admin/emails/list.tmpl
@@ -24,8 +24,8 @@
 			</div>
 			<form class="ui form ignore-dirty"  style="max-width: 90%">
 				<div class="ui fluid action input">
-				<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-				<button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>
+					<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+					<button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -3,9 +3,9 @@
 	{{template "explore/navbar" .}}
 	<div class="ui container">
 		<form class="ui form ignore-dirty" style="max-width: 100%">
+            <input type="hidden" name="tab" value="{{$.TabName}}">
             <div class="ui fluid action input">
                 <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-                <input type="hidden" name="tab" value="{{$.TabName}}">
                 <button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>
             </div>
         </form>

--- a/templates/explore/repo_search.tmpl
+++ b/templates/explore/repo_search.tmpl
@@ -20,10 +20,10 @@
     </div>
 </div>
 <form class="ui form ignore-dirty" style="max-width: 90%">
+    <input type="hidden" name="tab" value="{{$.TabName}}">
+    <input type="hidden" name="sort" value="{{$.SortType}}">
     <div class="ui fluid action input">
         <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-        <input type="hidden" name="tab" value="{{$.TabName}}">
-        <input type="hidden" name="sort" value="{{$.SortType}}">
         <button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>
     </div>
 </form>

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -16,9 +16,9 @@
 	</div>
 </div>
 <form class="ui form ignore-dirty" style="max-width: 90%">
+	<input type="hidden" name="tab" value="{{$.TabName}}">
 	<div class="ui fluid action input">
 	  <input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-	  <input type="hidden" name="tab" value="{{$.TabName}}">
 	  <button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/repo/issue/search.tmpl
+++ b/templates/repo/issue/search.tmpl
@@ -7,7 +7,7 @@
 		<input type="hidden" name="assignee" value="{{$.AssigneeID}}"/>
 		<div class="ui search action input">
 			<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+			<button class="ui blue button" type="submit">{{.i18n.Tr "explore.search"}}</button>
 		</div>
-		<button class="ui blue button" type="submit">{{.i18n.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -74,8 +74,8 @@
 								<input type="hidden" name="state" value="{{$.State}}"/>
 								<div class="ui search action input">
 									<input name="q" value="{{$.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+									<button class="ui blue button" type="submit">{{.i18n.Tr "explore.search"}}</button>
 								</div>
-								<button class="ui blue button" type="submit">{{.i18n.Tr "explore.search"}}</button>
 							</div>
 						</form>
 					</div>


### PR DESCRIPTION
Fomantic-ui's action button syntax requires that the button is
the next sibling of the input it is attached to and that they
are both children of a div.action.

Fix #11375

Signed-off-by: Andrew Thornton <art27@cantab.net>
