### PR TITLE
Fix NPE in due to missing signing key on commit page

### DIFF
--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -104,8 +104,10 @@
 				{{else}}
 				  <i class="unlock icon"></i>
 				  {{.i18n.Tr .Verification.Reason}}
-				  {{if and .Verification.SigningKey (ne .Verification.SigningKey.KeyID "")}}
-					<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="warning icon"></i>{{.Verification.SigningKey.KeyID}}</span>
+				  {{if .Verification.SigningKey}}
+				  	{{if ne .Verification.SigningKey.KeyID ""}}
+						<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="warning icon"></i>{{.Verification.SigningKey.KeyID}}</span>
+				  	{{end}}
 				  {{end}}
 				{{end}}
 			</div>


### PR DESCRIPTION
Go template's `{{if ...}}` does not shortcut its tests therefore it is
possible to cause a NPE unless you separate ifs into two.

Fix #11230 

Signed-off-by: Andrew Thornton <art27@cantab.net>
