### PR TITLE
Add missing card component to semantic.json

### DIFF
--- a/semantic.json
+++ b/semantic.json
@@ -25,6 +25,7 @@
     "api",
     "breadcrumb",
     "button",
+    "card",
     "checkbox",
     "comment",
     "container",


### PR DESCRIPTION
Fixes missing `.ui.card` in Fomantic, introduced in https://github.com/go-gitea/gitea/pull/9561 and surfaced now due to https://github.com/go-gitea/gitea/pull/11244

We use this component on user page.