### PR TITLE
Revert "Avoid '0 new commits' messages to be send to webhook"

### DIFF
--- a/modules/repofiles/action.go
+++ b/modules/repofiles/action.go
@@ -249,12 +249,12 @@ func CommitRepoAction(optsList ...*CommitRepoActionOptions) error {
 			IsPrivate: repo.IsPrivate,
 		}
 
+		var isHookEventPush = true
 		switch opType {
 		case models.ActionCommitRepo: // Push
 			if opts.IsNewBranch() {
 				notification.NotifyCreateRef(pusher, repo, "branch", opts.RefFullName)
 			}
-			notification.NotifyPushCommits(pusher, repo, opts.RefFullName, opts.OldCommitID, opts.NewCommitID, opts.Commits)
 		case models.ActionDeleteBranch: // Delete Branch
 			notification.NotifyDeleteRef(pusher, repo, "branch", opts.RefFullName)
 
@@ -263,6 +263,12 @@ func CommitRepoAction(optsList ...*CommitRepoActionOptions) error {
 
 		case models.ActionDeleteTag: // Delete Tag
 			notification.NotifyDeleteRef(pusher, repo, "tag", opts.RefFullName)
+		default:
+			isHookEventPush = false
+		}
+
+		if isHookEventPush {
+			notification.NotifyPushCommits(pusher, repo, opts.RefFullName, opts.OldCommitID, opts.NewCommitID, opts.Commits)
 		}
 	}
 


### PR DESCRIPTION
Reverts go-gitea/gitea#11082

As per comments by @CirnoT this breaks drone and likely other things as it directly moves us away from GitHub behaviour.

The 0 commits information should be handled elsewhere.

Reopens #10498 