### PR TITLE
Fix svg octicon-key placement

### DIFF
--- a/templates/repo/settings/deploy_keys.tmpl
+++ b/templates/repo/settings/deploy_keys.tmpl
@@ -20,20 +20,22 @@
 					{{range .Deploykeys}}
 						<div class="item">
 						    <div class="right floated content">
-									<button class="ui red tiny button delete-button" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
-										{{$.i18n.Tr "settings.delete_key"}}
-									</button>
+								<button class="ui red tiny button delete-button" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
+									{{$.i18n.Tr "settings.delete_key"}}
+								</button>
 						    </div>
+						    <div class="left floated content">
 								<i class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted"{{end}}>{{svg "octicon-key" 32}}</i>
-								<div class="content">
-									<strong>{{.Name}}</strong>
-									<div class="print meta">
-										{{.Fingerprint}}
-									</div>
-									<div class="activity meta">
-										<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}} - <span>{{$.i18n.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.i18n.Tr "settings.can_write_info"}} {{end}}</span></i>
-									</div>
+							</div>
+							<div class="content">
+								<strong>{{.Name}}</strong>
+								<div class="print meta">
+									{{.Fingerprint}}
 								</div>
+								<div class="activity meta">
+									<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}} - <span>{{$.i18n.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.i18n.Tr "settings.can_write_info"}} {{end}}</span></i>
+								</div>
+							</div>
 						</div>
 					{{end}}
 				</div>

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -16,7 +16,9 @@
 						{{$.i18n.Tr "settings.delete_key"}}
 					</button>
 				</div>
-				<span class="{{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}">{{svg "octicon-key" 32}}</span>
+				<div class="left floated content">
+					<span class="{{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}">{{svg "octicon-key" 32}}</span>
+				</div>
 				<div class="content">
 					{{range .Emails}}<strong>{{.Email}} </strong>{{end}}
 					<div class="print meta">

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -20,7 +20,9 @@
                         {{$.i18n.Tr "settings.delete_key"}}
                     </button>
                 </div>
-                <span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32}}</span>
+                <div class="left floated content">
+                	<span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32}}</span>
+                </div>
                 <div class="content">
                     <strong>{{.Name}}</strong>
                     <div class="print meta">


### PR DESCRIPTION
Introduced by https://github.com/go-gitea/gitea/pull/10107

Before:
![firefox_2020-05-14_18-30-21](https://user-images.githubusercontent.com/1447794/81960870-e3e0ea80-9611-11ea-8cde-ffc42b40429a.png)

After:
![chrome_2020-05-14_18-31-12](https://user-images.githubusercontent.com/1447794/81960883-e6dbdb00-9611-11ea-8e21-844b6984c800.png)
