### PR TITLE
Fix yellow background on active elements in code review

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1167,7 +1167,7 @@ i.icon.centerlock {
         width: 100%;
     }
 
-    .active {
+    .lines-code .active {
         background: #fff866;
     }
 }

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1137,7 +1137,7 @@ td.blob-excerpt {
     background-color: rgba(0, 0, 0, .15);
 }
 
-.code-view .active {
+.lines-code .code-view .active {
     background: #554a00;
 }
 


### PR DESCRIPTION
This PR ensures that yellow background on `.active` element is applied only to actual code lines. 

Fixes this issue:
![chrome_2020-05-15_02-18-00](https://user-images.githubusercontent.com/1447794/81998364-9cc71980-9652-11ea-9fb8-22d223626add.png)

![chrome_2020-05-15_02-18-14](https://user-images.githubusercontent.com/1447794/81998365-9d5fb000-9652-11ea-9b18-32ac29636163.png)
