### PR TITLE
Fix issue ref migration

### DIFF
--- a/models/migrations/v139.go
+++ b/models/migrations/v139.go
@@ -16,6 +16,8 @@ func prependRefsHeadsToIssueRefs(x *xorm.Engine) error {
 	switch {
 	case setting.Database.UseMSSQL:
 		query = "UPDATE `issue` SET `ref` = 'refs/heads/' + `ref` WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%'"
+	case setting.Database.UseMySQL:
+		query = "UPDATE `issue` SET `ref` = CONCAT('refs/heads/', `ref`) WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%';"
 	default:
 		query = "UPDATE `issue` SET `ref` = 'refs/heads/' || `ref` WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%'"
 	}


### PR DESCRIPTION
The migration introduced in #8742 breaks mysql installations. This pr fixes that by correctly using `CONCAT`.