### PR TITLE
Fix webhook template when validation errors occur

### DIFF
--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -180,7 +180,7 @@ func GiteaHooksNewPost(ctx *context.Context, form auth.NewWebhookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
-	ctx.Data["HookType"] = "gitea"
+	ctx.Data["HookType"] = models.GITEA.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -234,7 +234,7 @@ func newGogsWebhookPost(ctx *context.Context, form auth.NewGogshookForm, kind mo
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
-	ctx.Data["HookType"] = "gogs"
+	ctx.Data["HookType"] = models.GOGS.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -282,6 +282,7 @@ func DiscordHooksNewPost(ctx *context.Context, form auth.NewDiscordHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.DISCORD.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -332,6 +333,7 @@ func DingtalkHooksNewPost(ctx *context.Context, form auth.NewDingtalkHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.DINGTALK.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -373,6 +375,7 @@ func TelegramHooksNewPost(ctx *context.Context, form auth.NewTelegramHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.TELEGRAM.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -423,6 +426,7 @@ func MatrixHooksNewPost(ctx *context.Context, form auth.NewMatrixHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.MATRIX.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -475,6 +479,7 @@ func MSTeamsHooksNewPost(ctx *context.Context, form auth.NewMSTeamsHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.MSTEAMS.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -516,6 +521,7 @@ func SlackHooksNewPost(ctx *context.Context, form auth.NewSlackHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.SLACK.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {
@@ -574,6 +580,7 @@ func FeishuHooksNewPost(ctx *context.Context, form auth.NewFeishuHookForm) {
 	ctx.Data["PageIsSettingsHooks"] = true
 	ctx.Data["PageIsSettingsHooksNew"] = true
 	ctx.Data["Webhook"] = models.Webhook{HookEvent: &models.HookEvent{}}
+	ctx.Data["HookType"] = models.FEISHU.Name()
 
 	orCtx, err := getOrgRepoCtx(ctx)
 	if err != nil {

--- a/templates/repo/settings/webhook/matrix.tmpl
+++ b/templates/repo/settings/webhook/matrix.tmpl
@@ -4,7 +4,7 @@
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_HomeserverURL}}error{{end}}">
 			<label for="homeserver_url">{{.i18n.Tr "repo.settings.matrix.homeserver_url"}}</label>
-			<input id="homeserver_url" name="homeserver_url" type="text" value="{{.MatrixHook.HomeserverURL}}" autofocus required>
+			<input id="homeserver_url" name="homeserver_url" type="url" value="{{.MatrixHook.HomeserverURL}}" autofocus required>
 		</div>
 		<div class="required field {{if .Err_Room}}error{{end}}">
         	<label for="room_id">{{.i18n.Tr "repo.settings.matrix.room_id"}}</label>


### PR DESCRIPTION
When creating a new webhook with bad data, the validation fails and Gitea tries to render the page with the "new webhook" templates - that fails most of the time, because none of the webhook post handler functions set the `HookType` template variable. Therefore, trying to add a new webhook with invalid data fails with `emplate: repo/settings/webhook/new:10:9: executing "repo/settings/webhook/new" at <eq .HookType "gitea">: error calling eq: incompatible types for comparison` and the actual error message is never displayed.

This PR fixes that by setting the `HookType` variable in all handler functions. (Maybe there's a better way to do this?).

This hasn't been noticed until now because most of the webhooks either do frontend validation or no validation at all. I've noticed this with the matrix webhook which only does backend validation and therefore fails hard with the mentioned error message.