### PR TITLE
Fix margin on attached segment headers when they are separated by other element

### DIFF
--- a/templates/user/settings/keys.tmpl
+++ b/templates/user/settings/keys.tmpl
@@ -4,7 +4,6 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		{{template "user/settings/keys_ssh" .}}
-		<br>
 		{{template "user/settings/keys_gpg" .}}
 	</div>
 </div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1225,7 +1225,7 @@ i.icon.centerlock {
 }
 
 /* https://github.com/go-gitea/gitea/issues/10210 */
-.ui.attached.segment + .ui.attached.header {
+.ui.attached.segment ~ .ui.attached.header {
     margin-top: 1rem;
 }
 


### PR DESCRIPTION
Partially fixed in https://github.com/go-gitea/gitea/pull/10235 however the issue was still present if the elements were separated with something else, which happens in user settings.

![chrome_2020-05-15_20-45-01](https://user-images.githubusercontent.com/1447794/82085240-f8de7c00-96ec-11ea-89cf-b4f017929e1d.png)
In this example first segment has proper margin, but the second one does not because there is confirmation modal between them.