### PR TITLE
Fix buttons left-margin

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2869,7 +2869,7 @@ td.blob-excerpt {
     overflow: hidden;
 }
 
-.ui .right .ui.button {
+.ui.form .right .ui.button {
     margin-left: .25em;
     margin-right: 0;
 }


### PR DESCRIPTION
Introduced by https://github.com/go-gitea/gitea/pull/11139

Fixes this:
![firefox_2020-05-15_23-19-03](https://user-images.githubusercontent.com/1447794/82097070-7e205b80-9702-11ea-8173-4d7b492bda07.png)
