### PR TITLE
Fix lock icon alignment on repo list

### DIFF
--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -17,7 +17,7 @@
 					<span class="middle">{{svg "octicon-repo-clone" 16}}</span>
 				{{else if .Owner}}
 					{{if .Owner.Visibility.IsPrivate}}
-					<span class="text gold">{{svg "octicon-lock" 16}}</span>
+					<span class="middle text gold">{{svg "octicon-lock" 16}}</span>
 					{{end}}
 				{{end}}
 				<div class="ui right metas">


### PR DESCRIPTION
Fixes this:
![chrome_2020-05-17_00-50-53](https://user-images.githubusercontent.com/1447794/82131908-86e46080-97da-11ea-94f6-27f6d2a961a4.png)
