### PR TITLE
Set correct content_type value for Gogs/Gitea webhooks (#9504) (#10456)

### DIFF
--- a/templates/repo/settings/webhook/gitea.tmpl
+++ b/templates/repo/settings/webhook/gitea.tmpl
@@ -21,7 +21,7 @@
 		<div class="field">
 			<label>{{.i18n.Tr "repo.settings.content_type"}}</label>
 			<div class="ui selection dropdown">
-				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}application/json{{end}}">
+				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}1{{end}}">
 				<div class="default text"></div>
 				<i class="dropdown icon"></i>
 				<div class="menu">

--- a/templates/repo/settings/webhook/gogs.tmpl
+++ b/templates/repo/settings/webhook/gogs.tmpl
@@ -9,7 +9,7 @@
 		<div class="field">
 			<label>{{.i18n.Tr "repo.settings.content_type"}}</label>
 			<div class="ui selection dropdown">
-				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}application/json{{end}}">
+				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}1{{end}}">
 				<div class="default text"></div>
 				<i class="dropdown icon"></i>
 				<div class="menu">


### PR DESCRIPTION
Backport #10456

The content_type value was defaulting to the string value of the
ContentType, not the integer value as expected by the backend.

Original by @jvstein 

Fixes #11458 
Fixes #9504