### PR TITLE
Ensure public repositories in private organizations are visible and fix admin organizations list

### DIFF
--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -249,14 +249,35 @@ func SearchRepositoryCondition(opts *SearchRepoOptions) builder.Cond {
 		}
 
 		if opts.Collaborate != util.OptionalBoolFalse {
+			// A Collaboration is:
 			collaborateCond := builder.And(
+				// 1. Repository we don't own
+				builder.Neq{"owner_id": opts.OwnerID},
+				// 2. But we can see because of:
 				builder.Or(
-					builder.Expr("repository.id IN (SELECT repo_id FROM `access` WHERE access.user_id = ?)", opts.OwnerID),
-					builder.In("id", builder.Select("`team_repo`.repo_id").
+					// A. We have access
+					builder.In("`repository`.id",
+						builder.Select("`access`.repo_id").
+							From("access").
+							Where(builder.Eq{"`access`.user_id": opts.OwnerID})),
+					// B. We are in a team for
+					builder.In("`repository`.id", builder.Select("`team_repo`.repo_id").
 						From("team_repo").
 						Where(builder.Eq{"`team_user`.uid": opts.OwnerID}).
-						Join("INNER", "team_user", "`team_user`.team_id = `team_repo`.team_id"))),
-				builder.Neq{"owner_id": opts.OwnerID})
+						Join("INNER", "team_user", "`team_user`.team_id = `team_repo`.team_id")),
+					// C. Public repositories in private organizations that we are member of
+					builder.And(
+						builder.Eq{"`repository`.is_private": false},
+						builder.In("`repository`.owner_id",
+							builder.Select("`org_user`.org_id").
+								From("org_user").
+								Join("INNER", "user", "`user`.id = `org_user`.org_id").
+								Where(builder.Eq{
+									"`org_user`.uid":    opts.OwnerID,
+									"`user`.type":       UserTypeOrganization,
+									"`user`.visibility": structs.VisibleTypePrivate,
+								})))),
+			)
 			if !opts.Private {
 				collaborateCond = collaborateCond.And(builder.Expr("owner_id NOT IN (SELECT org_id FROM org_user WHERE org_user.uid = ? AND org_user.is_public = ?)", opts.OwnerID, false))
 			}

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -271,7 +271,7 @@ func SearchRepositoryCondition(opts *SearchRepoOptions) builder.Cond {
 						builder.In("`repository`.owner_id",
 							builder.Select("`org_user`.org_id").
 								From("org_user").
-								Join("INNER", "user", "`user`.id = `org_user`.org_id").
+								Join("INNER", "`user`", "`user`.id = `org_user`.org_id").
 								Where(builder.Eq{
 									"`org_user`.uid":    opts.OwnerID,
 									"`user`.type":       UserTypeOrganization,

--- a/routers/home.go
+++ b/routers/home.go
@@ -194,7 +194,6 @@ func RenderUserSearch(ctx *context.Context, opts *models.SearchUserOptions, tplN
 	if opts.Page <= 1 {
 		opts.Page = 1
 	}
-	opts.Actor = ctx.User
 
 	var (
 		users   []*models.User
@@ -252,6 +251,7 @@ func ExploreUsers(ctx *context.Context) {
 	ctx.Data["IsRepoIndexerEnabled"] = setting.Indexer.RepoIndexerEnabled
 
 	RenderUserSearch(ctx, &models.SearchUserOptions{
+		Actor:       ctx.User,
 		Type:        models.UserTypeIndividual,
 		ListOptions: models.ListOptions{PageSize: setting.UI.ExplorePagingNum},
 		IsActive:    util.OptionalBoolTrue,
@@ -272,6 +272,7 @@ func ExploreOrganizations(ctx *context.Context) {
 	}
 
 	RenderUserSearch(ctx, &models.SearchUserOptions{
+		Actor:       ctx.User,
 		Type:        models.UserTypeOrganization,
 		ListOptions: models.ListOptions{PageSize: setting.UI.ExplorePagingNum},
 		Visible:     visibleTypes,


### PR DESCRIPTION
Although the #11442 fixed the accessibleRepositoryCondition, the collaboration condition also needed fixing. This PR fixes this.

Also fixes the organization list on the administration page.

Fix #10144 