### PR TITLE
Fix top margin for bottom attached header

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1234,7 +1234,7 @@ i.icon.centerlock {
 }
 
 /* https://github.com/go-gitea/gitea/issues/10210 */
-.ui.attached.segment ~ .ui.attached.header {
+.ui.attached.segment ~ .ui.top.attached.header {
     margin-top: 1rem;
 }
 


### PR DESCRIPTION
Introduced by https://github.com/go-gitea/gitea/pull/10235

Before:
![chrome_2020-05-18_10-29-58](https://user-images.githubusercontent.com/1447794/82191446-d3bb5a80-98f2-11ea-974e-9205eb47c630.png)

After:
![chrome_2020-05-18_10-30-14](https://user-images.githubusercontent.com/1447794/82191451-d74ee180-98f2-11ea-94e4-8efadfc27e6c.png)