### PR TITLE
Remove unnecessary parentheses in wiki/revision.tmpl to allow 1.11 to build on go1.14 

### DIFF
--- a/templates/repo/wiki/revision.tmpl
+++ b/templates/repo/wiki/revision.tmpl
@@ -21,7 +21,7 @@
 					{{else if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.SSH}}" readonly>
 					{{end}}
-					{{if or ((not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)))}}
+					{{if or (not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH))}}
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
 							<i class="octicon octicon-clippy"></i>
 						</button>


### PR DESCRIPTION
This fixes the error on "Page Revision" page, similar to #10552, in version 1.11.
