### PR TITLE
[Frontend] Make localstorage read ssh or https correctly

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2438,6 +2438,8 @@ $(document).ready(async () => {
       case 'ssh':
         if ($('#repo-clone-ssh').length > 0) {
           $('#repo-clone-ssh').trigger('click');
+        } else {
+          $('#repo-clone-https').trigger('click');
         }
         break;
       default:

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1109,8 +1109,10 @@ async function initRepository() {
     $('.clone-url').text($(this).data('link'));
     $('#repo-clone-url').val($(this).data('link'));
     $(this).addClass('blue');
-    $('#repo-clone-ssh').removeClass('blue');
-    localStorage.setItem('repo-clone-protocol', 'https');
+    if ($('#repo-clone-ssh').length > 0) {
+      $('#repo-clone-ssh').removeClass('blue');
+      localStorage.setItem('repo-clone-protocol', 'https');
+    }
   });
   $('#repo-clone-url').on('click', function () {
     $(this).select();
@@ -2440,7 +2442,6 @@ $(document).ready(async () => {
           $('#repo-clone-ssh').trigger('click');
         } else {
           $('#repo-clone-https').trigger('click');
-          localStorage.setItem('repo-clone-protocol', 'ssh');
         }
         break;
       default:

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2436,8 +2436,8 @@ $(document).ready(async () => {
   if ($('#repo-clone-url').length > 0) {
     switch (localStorage.getItem('repo-clone-protocol')) {
       case 'ssh':
-        if ($('#repo-clone-ssh').length === 0) {
-          $('#repo-clone-https').trigger('click');
+        if ($('#repo-clone-ssh').length > 0) {
+          $('#repo-clone-ssh').trigger('click');
         }
         break;
       default:

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2440,6 +2440,7 @@ $(document).ready(async () => {
           $('#repo-clone-ssh').trigger('click');
         } else {
           $('#repo-clone-https').trigger('click');
+          localStorage.setItem('repo-clone-protocol', 'ssh');
         }
         break;
       default:


### PR DESCRIPTION
The localstorage has stored the user's option of repo's link type, but it don't read correctly.
This pr fix it : when you select the ssh type link, all repo links you enter later are displayed in ssh form.

The ui about this pr is here:
![image](https://user-images.githubusercontent.com/19653204/82213462-c0d27580-9946-11ea-977a-c779c36dd46d.png)
