### PR TITLE
Fix vertical-align for add-reaction svg

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2236,6 +2236,10 @@
             }
         }
 
+        .add-reaction > svg {
+            vertical-align: middle;
+        }
+
         &:hover .select-reaction a {
             display: block;
         }


### PR DESCRIPTION
Before:
![chrome_2020-05-18_20-30-27](https://user-images.githubusercontent.com/1447794/82247985-ab118000-9947-11ea-8607-a6ecafcc469e.png)

After:
![chrome_2020-05-18_20-30-39](https://user-images.githubusercontent.com/1447794/82247989-af3d9d80-9947-11ea-821b-885ced1286a0.png)