### PR TITLE
Revert "enable ENABLE_HARD_LINE_BREAK by default (#11162)"

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -213,10 +213,8 @@ TIMEOUT_STEP = 10s
 EVENT_SOURCE_UPDATE_TIME = 10s
 
 [markdown]
-; Render soft line breaks as hard line breaks, which means a single newline character between
-; paragraphs will cause a line break and adding trailing whitespace to paragraphs is not
-; necessary to force a line break.
-ENABLE_HARD_LINE_BREAK = true
+; Enable hard line break extension
+ENABLE_HARD_LINE_BREAK = false
 ; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
 ; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)
 ; URLs starting with http and https are always displayed, whatever is put in this entry.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -152,9 +152,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 
 ## Markdown (`markdown`)
 
-- `ENABLE_HARD_LINE_BREAK`: **true**: Render soft line breaks as hard line breaks, which
-  means a single newline character between paragraphs will cause a line break and adding
-  trailing whitespace to paragraphs is not necessary to force a line break.
+- `ENABLE_HARD_LINE_BREAK`: **false**: Enable Markdown's hard line break extension.
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -133,9 +133,9 @@ func testAnswers(baseURLContent, baseURLImages string) []string {
 `,
 		`<p><a href="http://www.excelsiorjet.com/" rel="nofollow">Excelsior JET</a> allows you to create native executables for Windows, Linux and Mac OS X.</p>
 <ol>
-<li><a href="https://github.com/libgdx/libgdx/wiki/Gradle-on-the-Commandline#packaging-for-the-desktop" rel="nofollow">Package your libGDX application</a><br/>
+<li><a href="https://github.com/libgdx/libgdx/wiki/Gradle-on-the-Commandline#packaging-for-the-desktop" rel="nofollow">Package your libGDX application</a>
 <a href="` + baseURLImages + `/images/1.png" rel="nofollow"><img src="` + baseURLImages + `/images/1.png" title="1.png" alt="images/1.png"/></a></li>
-<li>Perform a test run by hitting the Run! button.<br/>
+<li>Perform a test run by hitting the Run! button.
 <a href="` + baseURLImages + `/images/2.png" rel="nofollow"><img src="` + baseURLImages + `/images/2.png" title="2.png" alt="images/2.png"/></a></li>
 </ol>
 <h2 id="user-content-custom-id">More tests</h2>

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -260,7 +260,7 @@ var (
 		CustomURLSchemes    []string `ini:"CUSTOM_URL_SCHEMES"`
 		FileExtensions      []string
 	}{
-		EnableHardLineBreak: true,
+		EnableHardLineBreak: false,
 		FileExtensions:      strings.Split(".md,.markdown,.mdown,.mkd", ","),
 	}
 

--- a/routers/api/v1/misc/markdown_test.go
+++ b/routers/api/v1/misc/markdown_test.go
@@ -94,7 +94,7 @@ Here are some links to the most important topics. You can find the full list of 
 <p><strong>Wine Staging</strong> on website <a href="http://wine-staging.com" rel="nofollow">wine-staging.com</a>.</p>
 <h2 id="user-content-quick-links">Quick Links</h2>
 <p>Here are some links to the most important topics. You can find the full list of pages at the sidebar.</p>
-<p><a href="` + AppSubURL + `wiki/Configuration" rel="nofollow">Configuration</a><br/>
+<p><a href="` + AppSubURL + `wiki/Configuration" rel="nofollow">Configuration</a>
 <a href="` + AppSubURL + `wiki/raw/images/icon-bug.png" rel="nofollow"><img src="` + AppSubURL + `wiki/raw/images/icon-bug.png" title="icon-bug.png" alt="images/icon-bug.png"/></a></p>
 `,
 		// Guard wiki sidebar: special syntax


### PR DESCRIPTION
This reverts commit 7e20f1cb5b3ef494676f3629e4980c8cdd64525b.

This commit causes Gitea to diverge from Github not move towards it
and should be reverted.

The underlying problem is that GFM hard line breaks are subtle.

Let's look at the following markdown:

```
This is a line
with a break before with with no spaces and after with  
two spaces. GFM says the first doesn't get a `<br>`, only the second does.

This is a line
with no spaces

this is two lines  
with two spaces
```

## GH renders as
![Screenshot from 2020-05-19 10-15-10](https://user-images.githubusercontent.com/1824502/82308436-b0a7ae00-99b9-11ea-95eb-3e0b8084ff09.png)

This is a line
with a break before with with no spaces and after with  
two spaces. GFM says the first doesn't get a `<br>`, only the second does.

This is a line
with no spaces

this is two lines  
with two spaces

## Gitea with HARD_LINE_BREAKS=true renders as:
https://try.gitea.io/tester_mailinator.com/anudderrepo/src/branch/master/linkbreaks.md

![Screenshot from 2020-05-19 10-10-35](https://user-images.githubusercontent.com/1824502/82307953-02036d80-99b9-11ea-94c7-0a80449c67f9.png)

## Gitea with HARD_LINE_BREAKS=false renders as:
![Screenshot from 2020-05-19 10-12-33](https://user-images.githubusercontent.com/1824502/82308141-47279f80-99b9-11ea-8426-d026aa3076da.png)
