### PR TITLE
Insert ui divider directly in templates instead of from inside heatmap vue component

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -7,6 +7,7 @@
 			<div class="ui container ten wide column">
 				{{if .EnableHeatmap}}
 					{{template "user/dashboard/heatmap" .}}
+					<div class="ui divider"></div>
 				{{end}}
 				{{template "user/dashboard/feeds" .}}
 			</div>

--- a/templates/user/dashboard/heatmap.tmpl
+++ b/templates/user/dashboard/heatmap.tmpl
@@ -4,5 +4,4 @@
 			<div class="ui active centered inline indeterminate text loader" id="loading-heatmap">{{.i18n.Tr "user.heatmap.loading"}}</div>
 		</div>
 	</activity-heatmap>
-	<div class="ui divider"></div>
 </div>

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -104,16 +104,10 @@
 				</div>
 
 				{{if eq .TabName "activity"}}
-					{{if .EnableHeatmap}}
-						<div id="user-heatmap" style="padding-right: 40px">
-							<activity-heatmap :locale="locale" :suburl="suburl" :user="heatmapUser">
-								<div slot="loading">
-									<div class="ui active centered inline indeterminate text loader" id="loading-heatmap">{{.i18n.Tr "user.heatmap.loading"}}</div>
-								</div>
-							</activity-heatmap>
-						</div>
-						<div class="ui divider"></div>
-					{{end}}
+				{{if .EnableHeatmap}}
+					{{template "user/dashboard/heatmap" .}}
+					<div class="ui divider"></div>
+				{{end}}
 					<div class="feeds">
 						{{template "user/dashboard/feeds" .}}
 					</div>

--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -7,7 +7,6 @@
             {{ totalContributions }} total contributions in the last 12 months
         </h4>
         <calendar-heatmap v-show="!isLoading" :locale="locale" :no-data-text="locale.no_contributions" :tooltip-unit="locale.contributions" :end-date="endDate" :values="values" :range-color="colorRange"/>
-        <div class="ui divider"></div>
     </div>
 </template>
 


### PR DESCRIPTION
Hello there,

This change removes a redundant divider line that sits between the user heatmap and the feeds in the user dashboard view's "Public Activity" tab, so that we could move
from ![image](https://user-images.githubusercontent.com/61180606/82319684-5109cc80-99d2-11ea-9e96-f3c8b8eaf2a4.png)
to ![image](https://user-images.githubusercontent.com/61180606/82319703-5b2bcb00-99d2-11ea-80d5-3e4071297a45.png)
effectively reverting 6ccd19ef86b3b729a3b6dc35076639db5531550a (which introduced this).

Thanks a lot for your work.
Cheers.