### PR TITLE
Fix double divider on profile page

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -112,7 +112,6 @@
 								</div>
 							</activity-heatmap>
 						</div>
-						<div class="ui divider"></div>
 					{{end}}
 					<div class="feeds">
 						{{template "user/dashboard/feeds" .}}


### PR DESCRIPTION
Introduced by https://github.com/go-gitea/gitea/pull/11437

The divider line is now in Vue component and follows general guideline of having divider below element

Closes https://github.com/go-gitea/gitea/pull/11508