### PR TITLE
TrimSpace when reading InternalToken from a file (#11502)

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -7,9 +7,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"code.gitea.io/gitea/modules/generate"
 
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli"
 )
 
@@ -59,7 +61,12 @@ func runGenerateInternalToken(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("%s\n", internalToken)
+	fmt.Printf("%s", internalToken)
+
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Printf("\n")
+	}
+
 	return nil
 }
 
@@ -69,7 +76,12 @@ func runGenerateLfsJwtSecret(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("%s\n", JWTSecretBase64)
+	fmt.Printf("%s", JWTSecretBase64)
+
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Printf("\n")
+	}
+
 	return nil
 }
 
@@ -79,6 +91,11 @@ func runGenerateSecretKey(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("%s\n", secretKey)
+	fmt.Printf("%s", secretKey)
+
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Printf("\n")
+	}
+
 	return nil
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1069,7 +1069,7 @@ func loadInternalToken(sec *ini.Section) string {
 			return token
 		}
 
-		return string(buf)
+		return strings.TrimSpace(string(buf))
 	default:
 		log.Fatal("Unsupported URI-Scheme %q (INTERNAL_TOKEN_URI = %q)", tempURI.Scheme, uri)
 	}


### PR DESCRIPTION
Backport #11502 

InternalTokens are fixed as alphanum strings therefore TrimSpace from these.
Also use isatty to not add a terminal newline when redirecting generate.

Fix #11498

Signed-off-by: Andrew Thornton <art27@cantab.net>
