### PR TITLE
Fix webpack chunk loading with STATIC_URL_PREFIX

### DIFF
--- a/web_src/js/publicpath.js
+++ b/web_src/js/publicpath.js
@@ -1,5 +1,10 @@
-// This sets up webpack's chunk loading to load resources from the 'public'
-// directory. This file must be imported before any lazy-loading is being attempted.
+// This sets up the URL prefix used in webpack's chunk loading.
+// This file must be imported before any lazy-loading is being attempted.
+const {StaticUrlPrefix} = window.config;
 
-const url = new URL(document.currentScript.src);
-__webpack_public_path__ = url.pathname.replace(/\/[^/]*?\/[^/]*?$/, '/');
+if (StaticUrlPrefix) {
+  __webpack_public_path__ = StaticUrlPrefix.endsWith('/') ? StaticUrlPrefix : `${StaticUrlPrefix}/`;
+} else {
+  const url = new URL(document.currentScript.src);
+  __webpack_public_path__ = url.pathname.replace(/\/[^/]*?\/[^/]*?$/, '/');
+}


### PR DESCRIPTION
Previously, we had only set `__webpack_public_path__` to a path which caused webpack chunks to be loaded from the current origin which is incorrect when STATIC_URL_PREFIX points to another origin.

This should fix the issue currently seen on gitea.com.