### PR TITLE
Fix commit page js error (1.11 backport)

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -201,6 +201,8 @@ func FileHistory(ctx *context.Context) {
 func Diff(ctx *context.Context) {
 	ctx.Data["PageIsDiff"] = true
 	ctx.Data["RequireHighlightJS"] = true
+	ctx.Data["RequireSimpleMDE"] = true
+	ctx.Data["RequireTribute"] = true
 
 	userName := ctx.Repo.Owner.Name
 	repoName := ctx.Repo.Repository.Name


### PR DESCRIPTION
Partial backport of https://github.com/go-gitea/gitea/commit/fd094eea959a235654b7591da066dcbbee11fc25 to 1.11.

Fixes: https://github.com/go-gitea/gitea/issues/11518