### PR TITLE
Fix form action template substitutions on admin pages (backport #11519)

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -15,7 +15,7 @@
 			{{.i18n.Tr "admin.dashboard.operations"}}
 		</h4>
 		<div class="ui attached table segment">
-			<form method="post" action="{{.AppSubUrl}}/admin">
+			<form method="post" action="{{AppSubUrl}}/admin">
 				{{.CsrfTokenHtml}}
 				<table class="ui very basic table">
 					<tbody>

--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -7,7 +7,7 @@
 			{{.i18n.Tr "admin.monitor.cron"}}
 		</h4>
 		<div class="ui attached table segment">
-			<form method="post" action="{{.AppSubUrl}}/admin">
+			<form method="post" action="{{AppSubUrl}}/admin">
 				{{.CsrfTokenHtml}}
 				<table class="ui very basic striped table">
 					<thead>


### PR DESCRIPTION
Backport of #11519 

Hope I did this correctly -- first backport one I've done.