### PR TITLE
Fix repo-list private and total count bugs (#11500)

### DIFF
--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -78,9 +78,9 @@ func Search(ctx *context.APIContext) {
 	//   in: query
 	//   description: include private repositories this user has access to (defaults to true)
 	//   type: boolean
-	// - name: onlyPrivate
+	// - name: is_private
 	//   in: query
-	//   description: only include private repositories this user has access to (defaults to false)
+	//   description: show only pubic, private or all repositories (defaults to all)
 	//   type: boolean
 	// - name: template
 	//   in: query
@@ -133,7 +133,6 @@ func Search(ctx *context.APIContext) {
 		TopicOnly:          ctx.QueryBool("topic"),
 		Collaborate:        util.OptionalBoolNone,
 		Private:            ctx.IsSigned && (ctx.Query("private") == "" || ctx.QueryBool("private")),
-		OnlyPrivate:        ctx.IsSigned && ctx.QueryBool("onlyPrivate"),
 		Template:           util.OptionalBoolNone,
 		StarredByID:        ctx.QueryInt64("starredBy"),
 		IncludeDescription: ctx.QueryBool("includeDesc"),
@@ -167,6 +166,10 @@ func Search(ctx *context.APIContext) {
 
 	if ctx.Query("archived") != "" {
 		opts.Archived = util.OptionalBoolOf(ctx.QueryBool("archived"))
+	}
+
+	if ctx.Query("is_private") != "" {
+		opts.IsPrivate = util.OptionalBoolOf(ctx.QueryBool("is_private"))
 	}
 
 	var sortMode = ctx.Query("sort")

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1771,8 +1771,8 @@
           },
           {
             "type": "boolean",
-            "description": "only include private repositories this user has access to (defaults to false)",
-            "name": "onlyPrivate",
+            "description": "show only pubic, private or all repositories (defaults to all)",
+            "name": "is_private",
             "in": "query"
           },
           {

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -101,7 +101,7 @@
 			</div>
 			<div class="ui attached table segment">
 				<ul class="repo-owner-name-list">
-					<li v-for="repo in repos" :class="{'private': repo.private}" v-show="showRepo(repo)">
+					<li v-for="repo in repos" :class="{'private': repo.private}">
 						<a :href="suburl + '/' + repo.full_name">
 							<svg :class="'svg ' + repoClass(repo)" width="16" height="16" aria-hidden="true"><use :xlink:href="'#' + repoClass(repo)" /></svg>
 							<strong class="text truncate item-name">${repo.full_name}</strong>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2745,7 +2745,7 @@ function initVueComponents() {
         }&page=${this.page}&limit=${this.searchLimit}&mode=${this.repoTypes[this.reposFilter].searchMode
         }${this.reposFilter !== 'all' ? '&exclusive=1' : ''
         }${this.archivedFilter === 'archived' ? '&archived=true' : ''}${this.archivedFilter === 'unarchived' ? '&archived=false' : ''
-        }${this.privateFilter === 'private' ? '&onlyPrivate=true' : ''}${this.privateFilter === 'public' ? '&private=false' : ''
+        }${this.privateFilter === 'private' ? '&is_private=true' : ''}${this.privateFilter === 'public' ? '&is_private=false' : ''
         }`;
       },
       repoTypeCount() {
@@ -2911,55 +2911,17 @@ function initVueComponents() {
         this.searchRepos();
       },
 
-      showArchivedRepo(repo) {
-        switch (this.archivedFilter) {
-          case 'both':
-            return true;
-          case 'unarchived':
-            return !repo.archived;
-          case 'archived':
-            return repo.archived;
-          default:
-            return !repo.archived;
-        }
-      },
-
-      showPrivateRepo(repo) {
-        switch (this.privateFilter) {
-          case 'both':
-            return true;
-          case 'public':
-            return !repo.private;
-          case 'private':
-            return repo.private;
-          default:
-            return true;
-        }
-      },
-
-      showFilteredRepo(repo) {
-        switch (this.reposFilter) {
-          case 'sources':
-            return repo.owner.id === this.uid && !repo.mirror && !repo.fork;
-          case 'forks':
-            return repo.owner.id === this.uid && !repo.mirror && repo.fork;
-          case 'mirrors':
-            return repo.mirror;
-          case 'collaborative':
-            return repo.owner.id !== this.uid && !repo.mirror;
-          default:
-            return true;
-        }
-      },
-
-      showRepo(repo) {
-        return this.showArchivedRepo(repo) && this.showPrivateRepo(repo) && this.showFilteredRepo(repo);
-      },
-
       searchRepos() {
         const self = this;
 
         this.isLoading = true;
+
+        if (!this.reposTotalCount) {
+          const totalCountSearchURL = `${this.suburl}/api/v1/repos/search?sort=updated&order=desc&uid=${this.uid}&q=&page=1&mode=`;
+          $.getJSON(totalCountSearchURL, (_result, _textStatus, request) => {
+            self.reposTotalCount = request.getResponseHeader('X-Total-Count');
+          });
+        }
 
         const searchedMode = this.repoTypes[this.reposFilter].searchMode;
         const searchedURL = this.searchURL;


### PR DESCRIPTION
Backport #11500 

Fixes issue with the repo-list total count number not showing up and just sets the "private" toggle to match repo.is_private state.

A more complete refactor of these toggles is required in future but this is a simple backportable bug-fix

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: guillep2k <18600385+guillep2k@users.noreply.github.com>