### PR TITLE
Remove system-ui and create a color-emoji stack

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -63,7 +63,17 @@
         url('../vendor/assets/noto-color-emoji/NotoColorEmoji.ttf') format('truetype');
 }
 
-@default-fonts: -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+@font-face {
+    font-family: 'color-emoji';
+    src:
+        local('Apple Color Emoji'),
+        local('Segoe UI Emoji'),
+        local('Segoe UI Symbol'),
+        local('Noto Color Emoji'),
+        url('../vendor/assets/noto-color-emoji/NotoColorEmoji.ttf') format('truetype');
+}
+
+@default-fonts: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, 'color-emoji';
 @monospaced-fonts: 'SF Mono', Consolas, Menlo, 'Liberation Mono', Monaco, 'Lucida Console';
 
 .override-fonts(@fonts) {

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -71,6 +71,7 @@
         local('Segoe UI Symbol'),
         local('Noto Color Emoji'),
         url('../vendor/assets/noto-color-emoji/NotoColorEmoji.ttf') format('truetype');
+    font-weight: 400;
 }
 
 @default-fonts: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, 'color-emoji';


### PR DESCRIPTION
As per https://infinnie.github.io/blog/2017/systemui.html

The system-ui font selector causes trouble if deja-vu sans is in the font-stack as several monochrome emoji are provided within that font - but also there are problems with non-latin alphabet locales.

Signed-off-by: Andrew Thornton <art27@cantab.net>
