### PR TITLE
Ensure emoji render with regular font-weight

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1257,9 +1257,9 @@ i.icon.centerlock {
 .reaction {
     font-size: 1.5em;
     line-height: 1.2;
-    font-weight: 400;
+    font-style: normal !important;
+    font-weight: normal !important;
     vertical-align: middle;
-    font-style: normal;
 }
 
 #issue-title > .emoji {


### PR DESCRIPTION
Emoji characters don't support bold attributes and may do weird things like rendering monochrome when bolded.