### PR TITLE
add missing awaits

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@ rules:
   multiline-comment-style: [2, separate-lines]
   newline-per-chained-call: [0]
   no-alert: [0]
+  no-await-in-loop: [0]
   no-cond-assign: [2, except-parens]
   no-console: [1, {allow: [info, warn, error]}]
   no-continue: [0]

--- a/web_src/js/features/serviceworker.js
+++ b/web_src/js/features/serviceworker.js
@@ -5,7 +5,7 @@ async function unregister() {
   for (const registration of await navigator.serviceWorker.getRegistrations()) {
     const serviceWorker = registration.active;
     if (!serviceWorker) continue;
-    registration.unregister();
+    await registration.unregister();
   }
 }
 
@@ -19,7 +19,7 @@ async function checkCacheValidity() {
 
   // invalidate cache if it belongs to a different gitea version
   if (cacheKey && storedCacheKey !== cacheKey) {
-    invalidateCache();
+    await invalidateCache();
     localStorage.setItem('staticCacheKey', cacheKey);
   }
 }


### PR DESCRIPTION
Forgot these earlier. Those are mostly stylistical here but I think it's generally good practice to await all promises. The [linter rule](https://eslint.org/docs/rules/no-await-in-loop) is nonsensical in my opinion as Promise.all would make the code less readable.