### PR TITLE
Prevent empty query parameter being set on dashboard

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2850,7 +2850,12 @@ function initVueComponents() {
           params.set('repo-search-page', `${this.page}`);
         }
 
-        window.history.replaceState({}, '', `?${params.toString()}`);
+        const queryString = params.toString();
+        if (queryString) {
+          window.history.replaceState({}, '', `?${queryString}`);
+        } else {
+          window.history.replaceState({}, '', window.location.pathname);
+        }
       },
 
       toggleArchivedFilter() {


### PR DESCRIPTION
Prevent the dashboard from setting an empty query parameter

Fix #11543

Signed-off-by: Andrew Thornton <art27@cantab.net>
