### PR TITLE
Fix Enter not working in SimpleMDE

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1497,7 +1497,7 @@ function setCommentSimpleMDE($editArea) {
   simplemde.codemirror.setOption('extraKeys', {
     Enter: () => {
       const tributeContainer = document.querySelector('.tribute-container');
-      if (tributeContainer && tributeContainer.style.display !== 'none') {
+      if (tributeContainer && tributeContainer.style.display === 'none') {
         return CodeMirror.Pass;
       }
     },

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1497,7 +1497,7 @@ function setCommentSimpleMDE($editArea) {
   simplemde.codemirror.setOption('extraKeys', {
     Enter: () => {
       const tributeContainer = document.querySelector('.tribute-container');
-      if (tributeContainer && tributeContainer.style.display === 'none') {
+      if (!tributeContainer || tributeContainer.style.display === 'none') {
         return CodeMirror.Pass;
       }
     },


### PR DESCRIPTION
This condition was wrongly inverted, leading to all enter keys being blocked.

Fixes: https://github.com/go-gitea/gitea/issues/11559