### PR TITLE
Add auto-generated serviceworker.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ coverage.all
 /public/fomantic
 /public/img/svg
 /VERSION
+/public/serviceworker.js
 
 # Snapcraft
 snap/.snapcraft/


### PR DESCRIPTION
Since https://github.com/go-gitea/gitea/pull/11538

Needs backport to v1.12