### PR TITLE
Enforce transparent background on editor toolbar elements

### DIFF
--- a/web_src/less/_editor.less
+++ b/web_src/less/_editor.less
@@ -29,6 +29,10 @@
     opacity: 1 !important;
 }
 
+.editor-toolbar a:not(:hover) {
+    background-color: transparent !important;
+}
+
 .editor-toolbar i.separator {
     border-left: none;
 }


### PR DESCRIPTION
Before:
![chrome_2020-05-23_02-21-45](https://user-images.githubusercontent.com/1447794/82717399-28b4f300-9c9c-11ea-8fc5-0235dc5a16c1.png)

After:
![chrome_2020-05-23_02-21-24](https://user-images.githubusercontent.com/1447794/82717404-2ce11080-9c9c-11ea-88c4-ea0f28ae39ff.png)

Generally the issue was present only for `.disabled-for-preview` case via CSS from SimpleMDE:
```css
.editor-toolbar.disabled-for-preview a:not(.no-disable) {
    pointer-events: none;
    background: #fff;
    border-color: transparent;
    text-shadow: inherit;
}
```
I have decided to ensure background is transparent globally, I have no idea why SimpleMDE would want to override backgrounds here, they don't do it for any other case.