### PR TITLE
Ensure serviceworker is created as /serviceworker.js (#11577)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ coverage.all
 /node_modules
 /yarn.lock
 /public/js
+/public/serviceworker.js
 /public/css
 /public/fonts
 /public/fomantic

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
     filename: ({chunk}) => {
       // serviceworker can only manage assets below it's script's directory so
       // we have to put it in / instead of /js/
-      return chunk.id === 'serviceworker' ? '[name].js' : 'js/[name].js';
+      return chunk.name === 'serviceworker' ? '[name].js' : 'js/[name].js';
     },
     chunkFilename: 'js/[name].js',
   },


### PR DESCRIPTION
Backport #11577 

#11538 moved the serviceworker to webbox but unfortunately
created the serviceworker in public/js rather than public/

This PR fixes this, fixing multiple issues with broken js
as a result of that change.

Signed-off-by: Andrew Thornton art27@cantab.net
