### PR TITLE
Properly handle and return empty string for dangling commits in GetBranchName

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -1129,7 +1129,7 @@ func getCommitIDsFromRepo(repo *Repository, oldCommitID, newCommitID, baseBranch
 		return nil, false, err
 	}
 
-	if oldCommitBranch == "undefined" {
+	if oldCommitBranch == "" {
 		commitIDs = make([]string, 2)
 		commitIDs[0] = oldCommitID
 		commitIDs[1] = newCommitID

--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -468,8 +468,13 @@ func (c *Commit) GetSubModule(entryname string) (*SubModule, error) {
 
 // GetBranchName gets the closes branch name (as returned by 'git name-rev --name-only')
 func (c *Commit) GetBranchName() (string, error) {
-	data, err := NewCommand("name-rev", "--name-only", c.ID.String()).RunInDir(c.repo.Path)
+	data, err := NewCommand("name-rev", "--name-only", "--no-undefined", c.ID.String()).RunInDir(c.repo.Path)
 	if err != nil {
+		// handle special case where git can not describe commit
+		if strings.Contains(err.Error(), "cannot describe") {
+			return "", nil
+		}
+
 		return "", err
 	}
 

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -309,6 +309,7 @@ func Diff(ctx *context.Context) {
 	ctx.Data["BranchName"], err = commit.GetBranchName()
 	if err != nil {
 		ctx.ServerError("commit.GetBranchName", err)
+		return
 	}
 	ctx.HTML(200, tplCommitPage)
 }

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -27,7 +27,9 @@
 			{{if IsMultilineCommitMessage .Commit.Message}}
 				<pre class="commit-body">{{RenderCommitBody .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>
 			{{end}}
-			<span class="text grey">{{svg "octicon-git-branch" 16}}{{.BranchName}}</span>
+			{{if .BranchName}}
+				<span class="text grey">{{svg "octicon-git-branch" 16}}{{.BranchName}}</span>
+			{{end}}
 		</div>
 		<div class="ui attached info segment {{$class}}">
 			<div class="ui stackable grid">


### PR DESCRIPTION
Run git command in `GetBranchName` with `--no-undefined` and handle case where git cannot describe dangling commit by returning empty branch name, instead of relying on git returning us "undefined".

This also fixes:
- Recently introduced commit history on PR view for "undefined" branch name
- Do not show "undefined" in commit view as branch name for dangling commits

Ref: https://git-scm.com/docs/git-name-rev