### PR TITLE
Fix styling and padding for commit list on PR view

### DIFF
--- a/templates/repo/commits_list_small.tmpl
+++ b/templates/repo/commits_list_small.tmpl
@@ -1,9 +1,10 @@
 {{ $r:= List .Commits}}
 {{ $index := 0}}
+<div class="timeline-item commits-list">
 {{range $r}}
 	{{ $tag := printf "%s-%d" $.HashTag $index }}
 	{{ $index = Add $index 1}}
-	<div class="timeline-item event small-line-spacing" id="{{$tag}}">
+	<div class="singular-commit" id="{{$tag}}">
 		<span class="badge badge-commit">{{svg "octicon-git-commit" 16}}</span>
 		{{if .User}}
 			<a class="ui avatar image" href="{{AppSubUrl}}/{{.User.Name}}"><img src="{{.User.RelAvatarLink}}" alt=""/></a>
@@ -42,7 +43,7 @@
 
 		<span class="message-wrapper">
 			{{ $commitLink:= printf "%s/%s/%s/commit/%s" AppSubUrl  $.Issue.PullRequest.BaseRepo.OwnerName $.Issue.PullRequest.BaseRepo.Name .ID }}
-			<span class="commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{RenderCommitMessageLinkSubject .Message ($.Issue.PullRequest.BaseRepo.Link|Escape) $commitLink $.Issue.PullRequest.BaseRepo.ComposeMetas}}</span>
+			<span class="mono commit-summary has-emoji{{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{RenderCommitMessageLinkSubject .Message ($.Issue.PullRequest.BaseRepo.Link|Escape) $commitLink $.Issue.PullRequest.BaseRepo.ComposeMetas}}</span>
 		</span>
 		{{if IsMultilineCommitMessage .Message}}
 			<button class="basic compact mini ui icon button commit-button"><i class="ellipsis horizontal icon"></i></button>
@@ -55,3 +56,4 @@
 		{{end}}
 	</div>
 {{end}}
+</div>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -602,7 +602,7 @@
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
 			<span class="text grey">
-				<a href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
+				<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 				{{ if .IsForcePush }}
 					{{$.i18n.Tr "repo.issues.force_push_codes" $.Issue.PullRequest.HeadBranch (ShortSha .OldCommit) ($.Issue.Repo.CommitLink .OldCommit)  (ShortSha .NewCommit) ($.Issue.Repo.CommitLink .NewCommit) $createdStr | Safe}}
 				{{else}}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -751,11 +751,11 @@
                     }
                 }
 
-                &:first-child {
+                &:first-child:not(.commit) {
                     padding-top: 0 !important;
                 }
 
-                &:last-child {
+                &:last-child:not(.commit) {
                     padding-bottom: 0 !important;
                 }
 
@@ -807,8 +807,9 @@
                     line-height: 30px;
                 }
 
-                &.event.small-line-spacing {
-                    padding: 2px 0 0 15px;
+                &.commits-list {
+                    padding-left: 15px;
+                    padding-top: 0;
                 }
 
                 &.event > .commit-status-link {


### PR DESCRIPTION
This one was really annoying, had to tweak template to fix the issue.

Before:
![chrome_2020-05-23_20-30-37](https://user-images.githubusercontent.com/1447794/82739785-e8f51680-9d42-11ea-8219-947624b29706.png)

After:
![chrome_2020-05-23_22-12-57](https://user-images.githubusercontent.com/1447794/82739789-ed213400-9d42-11ea-91bd-e0b4a0879191.png)
![chrome_2020-05-23_22-13-12](https://user-images.githubusercontent.com/1447794/82739790-edb9ca80-9d42-11ea-911e-7c7db72f4341.png)

Additionally opted for monospace font for commit message itself to differentiate it visually from other events.