### PR TITLE
Add missing padding for multi-commit list on PR view

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -810,6 +810,10 @@
                 &.commits-list {
                     padding-left: 15px;
                     padding-top: 0;
+
+                    .singular-commit:not(:last-child) {
+                        padding-bottom: 3px;
+                    }
                 }
 
                 &.event > .commit-status-link {


### PR DESCRIPTION
Looks like I completely forgot about the padding for multi-commit list in https://github.com/go-gitea/gitea/pull/11588; the default Gitea avatar made me believe it should be fine without.

Before:
![chrome_2020-05-24_03-40-59](https://user-images.githubusercontent.com/1447794/82743823-d4c80e00-9d70-11ea-8f89-d0bcf486f283.png)

After:
![chrome_2020-05-24_03-41-08](https://user-images.githubusercontent.com/1447794/82743825-d560a480-9d70-11ea-8fe5-c1734c51a19a.png)
