### PR TITLE
Fix styling for PR merge section when no checks

### DIFF
--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -194,7 +194,7 @@ func TestCantMergeWorkInProgress(t *testing.T) {
 		req := NewRequest(t, "GET", resp.Header().Get("Location"))
 		resp = session.MakeRequest(t, req, http.StatusOK)
 		htmlDoc := NewHTMLParser(t, resp.Body)
-		text := strings.TrimSpace(htmlDoc.doc.Find(".attached.header > .text.grey").Last().Text())
+		text := strings.TrimSpace(htmlDoc.doc.Find(".attached.merge-section.no-header > .text.grey").Last().Text())
 		assert.NotEmpty(t, text, "Can't find WIP text")
 
 		// remove <strong /> from lang

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -75,7 +75,7 @@
 	{{- else}}red{{end}}">{{svg "octicon-git-merge" 32}}</a>
 	<div class="content">
 		{{template "repo/pulls/status" .}}
-		<div class="ui {{if not $.LatestCommitStatus}}top attached header{{else}}attached merge-section segment{{end}}">
+		<div class="ui attached merge-section segment {{if not $.LatestCommitStatus}}no-header{{end}}">
 			{{if .Issue.PullRequest.HasMerged}}
 				<div class="item text purple">
 					{{if .Issue.PullRequest.MergedCommitID}}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -921,6 +921,10 @@
                     > .merge-section {
                         background-color: #f7f7f7;
 
+                        .item + .item {
+                            padding-top: .5rem;
+                        }
+
                         .divider {
                             margin-left: -1rem;
                             margin-right: -1rem;

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -881,17 +881,6 @@
                 }
 
                 .content {
-                    > .merge-section {
-                        .divider {
-                            margin-left: -1rem;
-                            margin-right: -1rem;
-                        }
-
-                        &.no-header {
-                            #avatar-arrow;
-                        }
-                    }
-
                     > .header {
                         #avatar-arrow;
                         font-weight: normal;
@@ -931,6 +920,15 @@
 
                     > .merge-section {
                         background-color: #f7f7f7;
+
+                        .divider {
+                            margin-left: -1rem;
+                            margin-right: -1rem;
+                        }
+
+                        &.no-header {
+                            #avatar-arrow;
+                        }
                     }
 
                     .markdown {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -881,6 +881,10 @@
                 }
 
                 .content {
+                    > .merge-section.no-header {
+                        #avatar-arrow;
+                    }
+
                     > .header {
                         #avatar-arrow;
                         font-weight: normal;
@@ -919,7 +923,6 @@
                     }
 
                     > .merge-section {
-                        border-top: 1px solid #d4d4d5;
                         background-color: #f7f7f7;
                     }
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -881,8 +881,15 @@
                 }
 
                 .content {
-                    > .merge-section.no-header {
-                        #avatar-arrow;
+                    > .merge-section {
+                        .divider {
+                            margin-left: -1rem;
+                            margin-right: -1rem;
+                        }
+
+                        &.no-header {
+                            #avatar-arrow;
+                        }
                     }
 
                     > .header {


### PR DESCRIPTION
Makes styling consistent between two cases. Also removed unnecessary double border.

Before:
![chrome_2020-05-24_19-53-37](https://user-images.githubusercontent.com/1447794/82761109-721a5500-9df8-11ea-9ea2-d24f7e31a7c9.png)
![chrome_2020-05-24_19-53-25](https://user-images.githubusercontent.com/1447794/82761112-77779f80-9df8-11ea-93de-614ec2941fbc.png)

After:
![chrome_2020-05-25_01-09-30](https://user-images.githubusercontent.com/1447794/82767028-7eb4a280-9e24-11ea-9bee-4a7143ea8508.png)
![chrome_2020-05-25_01-10-04](https://user-images.githubusercontent.com/1447794/82767029-807e6600-9e24-11ea-9697-d8aa75bec481.png)