### PR TITLE
Fix number of files, total additions, and deletions on Diff pages

### DIFF
--- a/modules/repofiles/diff_test.go
+++ b/modules/repofiles/diff_test.go
@@ -108,6 +108,7 @@ func TestGetDiffPreview(t *testing.T) {
 		},
 		IsIncomplete: false,
 	}
+	expectedDiff.NumFiles = len(expectedDiff.Files)
 
 	t.Run("with given branch", func(t *testing.T) {
 		diff, err := GetDiffPreview(ctx.Repo.Repository, branch, treePath, content)

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -299,6 +299,11 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 			t.repo.FullName(), err, stderr)
 	}
 
+	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(t.basePath, "--cached", "HEAD")
+	if err != nil {
+		return nil, err
+	}
+
 	return diff, nil
 }
 

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -291,7 +291,7 @@ func Diff(ctx *context.Context) {
 	ctx.Data["Author"] = models.ValidateCommitWithEmail(commit)
 	ctx.Data["Diff"] = diff
 	ctx.Data["Parents"] = parents
-	ctx.Data["DiffNotAvailable"] = diff.NumFiles() == 0
+	ctx.Data["DiffNotAvailable"] = diff.NumFiles == 0
 
 	if err := models.CalculateTrustStatus(verification, ctx.Repo.Repository, nil); err != nil {
 		ctx.ServerError("CalculateTrustStatus", err)

--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -437,7 +437,7 @@ func PrepareCompareDiff(
 		return false
 	}
 	ctx.Data["Diff"] = diff
-	ctx.Data["DiffNotAvailable"] = diff.NumFiles() == 0
+	ctx.Data["DiffNotAvailable"] = diff.NumFiles == 0
 
 	headCommit, err := headGitRepo.GetCommit(headCommitID)
 	if err != nil {

--- a/routers/repo/editor.go
+++ b/routers/repo/editor.go
@@ -339,7 +339,7 @@ func DiffPreviewPost(ctx *context.Context, form auth.EditPreviewDiffForm) {
 		return
 	}
 
-	if diff.NumFiles() == 0 {
+	if diff.NumFiles == 0 {
 		ctx.PlainText(200, []byte(ctx.Tr("repo.editor.no_changes_to_show")))
 		return
 	}

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -611,7 +611,7 @@ func ViewPullFiles(ctx *context.Context) {
 	}
 
 	ctx.Data["Diff"] = diff
-	ctx.Data["DiffNotAvailable"] = diff.NumFiles() == 0
+	ctx.Data["DiffNotAvailable"] = diff.NumFiles == 0
 
 	baseCommit, err := ctx.Repo.GitRepo.GetCommit(startCommitID)
 	if err != nil {

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -367,9 +367,9 @@ func getCommitFileLineCount(commit *git.Commit, filePath string) int {
 
 // Diff represents a difference between two git trees.
 type Diff struct {
-	TotalAddition, TotalDeletion int
-	Files                        []*DiffFile
-	IsIncomplete                 bool
+	NumFiles, TotalAddition, TotalDeletion int
+	Files                                  []*DiffFile
+	IsIncomplete                           bool
 }
 
 // LoadComments loads comments into each line
@@ -396,11 +396,6 @@ func (diff *Diff) LoadComments(issue *models.Issue, currentUser *models.User) er
 		}
 	}
 	return nil
-}
-
-// NumFiles returns number of files changes in a diff.
-func (diff *Diff) NumFiles() int {
-	return len(diff.Files)
 }
 
 const cmdDiffHead = "diff --git "
@@ -639,7 +634,7 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader) (*D
 			}
 		}
 	}
-
+	diff.NumFiles = len(diff.Files)
 	return diff, nil
 }
 
@@ -714,6 +709,11 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 
 	if err = cmd.Wait(); err != nil {
 		return nil, fmt.Errorf("Wait: %v", err)
+	}
+
+	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(repoPath, beforeCommitID+"..."+afterCommitID)
+	if err != nil {
+		return nil, err
 	}
 
 	return diff, nil


### PR DESCRIPTION
Use diff --shortstat to generate number of files, total additions and deletions on diff pages generated from git pages.

Signed-off-by: Andrew Thornton <art27@cantab.net>
