### PR TITLE
Apply padding to approval icons on PR list

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2475,6 +2475,12 @@
             padding-top: 5px;
             color: #999999;
 
+            .waiting,
+            .approvals,
+            .rejects {
+                padding-left: 5px;
+            }
+
             .checklist {
                 padding-left: 5px;
 


### PR DESCRIPTION
Rather minor nitpick, not worthy backporting.

Before:
![firefox_2020-05-25_20-36-07](https://user-images.githubusercontent.com/1447794/82836864-bd4f6900-9ec7-11ea-82dd-52a3ae7c306f.png)
![firefox_2020-05-25_20-37-15](https://user-images.githubusercontent.com/1447794/82836870-c0e2f000-9ec7-11ea-9e85-8098a6b400a9.png)

After:
![firefox_2020-05-25_20-36-31](https://user-images.githubusercontent.com/1447794/82836873-c50f0d80-9ec7-11ea-996d-abb2fa24a24b.png)
![firefox_2020-05-25_20-37-23](https://user-images.githubusercontent.com/1447794/82836875-c6d8d100-9ec7-11ea-9614-c4fb908457e0.png)

The off-center reject icon is not due to CSS; it's just how it was made.