### PR TITLE
Add debug option to hooks

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -46,18 +46,33 @@ var (
 		Usage:       "Delegate pre-receive Git hook",
 		Description: "This command should only be called by Git",
 		Action:      runHookPreReceive,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name: "debug",
+			},
+		},
 	}
 	subcmdHookUpdate = cli.Command{
 		Name:        "update",
 		Usage:       "Delegate update Git hook",
 		Description: "This command should only be called by Git",
 		Action:      runHookUpdate,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name: "debug",
+			},
+		},
 	}
 	subcmdHookPostReceive = cli.Command{
 		Name:        "post-receive",
 		Usage:       "Delegate post-receive Git hook",
 		Description: "This command should only be called by Git",
 		Action:      runHookPostReceive,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name: "debug",
+			},
+		},
 	}
 )
 
@@ -138,7 +153,7 @@ func runHookPreReceive(c *cli.Context) error {
 		return nil
 	}
 
-	setup("hooks/pre-receive.log", false)
+	setup("hooks/pre-receive.log", c.Bool("debug"))
 
 	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
 		if setting.OnlyAllowPushIfGiteaEnvironmentSet {
@@ -273,7 +288,7 @@ func runHookPostReceive(c *cli.Context) error {
 		return nil
 	}
 
-	setup("hooks/post-receive.log", false)
+	setup("hooks/post-receive.log", c.Bool("debug"))
 
 	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
 		if setting.OnlyAllowPushIfGiteaEnvironmentSet {


### PR DESCRIPTION
Simply adds a --debug to the hooks that could allow help a little more with debugging.

Signed-off-by: Andrew Thornton <art27@cantab.net>
