### PR TITLE
Fix missing styling for shabox on PR commit history

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -811,8 +811,73 @@
                     padding-left: 15px;
                     padding-top: 0;
 
-                    .singular-commit:not(:last-child) {
-                        padding-bottom: 3px;
+                    .singular-commit {
+                        &:not(:last-child) {
+                            padding-bottom: 3px;
+                        }
+
+                        .shabox {
+                            .sha.label {
+                                margin: 0;
+                                border: 1px solid #bbbbbb;
+
+                                &.isSigned.isWarning {
+                                    border: 1px solid #db2828;
+                                    background: fade(#db2828, 10%);
+
+                                    .shortsha {
+                                        display: inline-block;
+                                        padding-top: 1px;
+                                    }
+
+                                    &:hover {
+                                        background: fade(#db2828, 30%) !important;
+                                    }
+                                }
+
+                                &.isSigned.isVerified {
+                                    border: 1px solid #21ba45;
+                                    background: fade(#21ba45, 10%);
+
+                                    .shortsha {
+                                        display: inline-block;
+                                        padding-top: 1px;
+                                    }
+
+                                    &:hover {
+                                        background: fade(#21ba45, 30%) !important;
+                                    }
+                                }
+
+                                &.isSigned.isVerifiedUntrusted {
+                                    border: 1px solid #fbbd08;
+                                    background: fade(#fbbd08, 10%);
+
+                                    .shortsha {
+                                        display: inline-block;
+                                        padding-top: 1px;
+                                    }
+
+                                    &:hover {
+                                        background: fade(#fbbd08, 30%) !important;
+                                    }
+                                }
+
+                                &.isSigned.isVerifiedUnmatched {
+                                    border: 1px solid #f2711c;
+                                    background: fade(#f2711c, 10%);
+
+                                    .shortsha {
+                                        display: inline-block;
+                                        padding-top: 1px;
+                                    }
+
+                                    &:hover {
+                                        background: fade(#f2711c, 30%) !important;
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -1066,69 +1131,6 @@
 
                         &::before {
                             width: 20px;
-                        }
-                    }
-                }
-
-                & > .shabox {
-                    .sha.label {
-                        margin: 0;
-                        border: 1px solid #bbbbbb;
-
-                        &.isSigned.isWarning {
-                            border: 1px solid #db2828;
-                            background: fade(#db2828, 10%);
-
-                            .shortsha {
-                                display: inline-block;
-                                padding-top: 1px;
-                            }
-
-                            &:hover {
-                                background: fade(#db2828, 30%) !important;
-                            }
-                        }
-
-                        &.isSigned.isVerified {
-                            border: 1px solid #21ba45;
-                            background: fade(#21ba45, 10%);
-
-                            .shortsha {
-                                display: inline-block;
-                                padding-top: 1px;
-                            }
-
-                            &:hover {
-                                background: fade(#21ba45, 30%) !important;
-                            }
-                        }
-
-                        &.isSigned.isVerifiedUntrusted {
-                            border: 1px solid #fbbd08;
-                            background: fade(#fbbd08, 10%);
-
-                            .shortsha {
-                                display: inline-block;
-                                padding-top: 1px;
-                            }
-
-                            &:hover {
-                                background: fade(#fbbd08, 30%) !important;
-                            }
-                        }
-
-                        &.isSigned.isVerifiedUnmatched {
-                            border: 1px solid #f2711c;
-                            background: fade(#f2711c, 10%);
-
-                            .shortsha {
-                                display: inline-block;
-                                padding-top: 1px;
-                            }
-
-                            &:hover {
-                                background: fade(#f2711c, 30%) !important;
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
I really ought to check this stuff more carefully, no idea how I managed to not notice this.

PR #11588 changed template a little and I forgot to move CSS rule for styling shabox.