### PR TITLE
Disable font ligatures

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -135,6 +135,7 @@ body {
     background-color: #ffffff;
     overflow-y: auto;
     -webkit-font-smoothing: antialiased;
+    font-variant-ligatures: none;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
Some fonts like Roboto autmatically form ligatures but I think they make text harder to read and should be avoided.

Before:

<img width="23" alt="image" src="https://user-images.githubusercontent.com/115237/82905237-e0c7f180-9f63-11ea-8360-ee7d3b526e48.png">

After:

<img width="22" alt="image" src="https://user-images.githubusercontent.com/115237/82905307-01904700-9f64-11ea-9454-58b284816a22.png">

