### PR TITLE
Default MSSQL port 0 to allow automatic detection by default

### DIFF
--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -163,7 +163,7 @@ func getPostgreSQLConnectionString(dbHost, dbUser, dbPasswd, dbName, dbParam, db
 
 // ParseMSSQLHostPort splits the host into host and port
 func ParseMSSQLHostPort(info string) (string, string) {
-	host, port := "127.0.0.1", "1433"
+	host, port := "127.0.0.1", "0"
 	if strings.Contains(info, ":") {
 		host = strings.Split(info, ":")[0]
 		port = strings.Split(info, ":")[1]


### PR DESCRIPTION
As discussed in #11633 setting the default port to 1433 prevents automatic detection by default - which although appropriate in many environments - is not expected by most users of MSSQL. Setting the port to be "0" allows automatic detection by default.

(Marked as bug because I think it conflicts so much with expected behaviour.)

Fix #11633

Signed-off-by: Andrew Thornton <art27@cantab.net>
