### PR TITLE
Use -1 to disable key algorithm type in ssh.minimum_key_sizes (#11635)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -730,6 +730,8 @@ func NewContext() {
 	for _, key := range minimumKeySizes {
 		if key.MustInt() != -1 {
 			SSH.MinimumKeySizes[strings.ToLower(key.Name())] = key.MustInt()
+		} else {
+			delete(SSH.MinimumKeySizes, strings.ToLower(key.Name()))
 		}
 	}
 	SSH.AuthorizedKeysBackup = sec.Key("SSH_AUTHORIZED_KEYS_BACKUP").MustBool(true)


### PR DESCRIPTION
Backport #11635

Fix #11634

Signed-off-by: Andrew Thornton <art27@cantab.net>
