### PR TITLE
Exclude certain languages from repo stats

### DIFF
--- a/modules/git/repo_language_stats.go
+++ b/modules/git/repo_language_stats.go
@@ -20,6 +20,16 @@ import (
 
 const fileSizeLimit int64 = 16 * 1024 * 1024
 
+// specialLanguages defines list of languages that are excluded from calculation
+// unless they are the only language present in repository
+var specialLanguages = []string{
+	"YAML",
+	"JSON",
+	"SVG",
+	"Text",
+	"Markdown",
+}
+
 // GetLanguageStats calculates language stats for git repository at specified commit
 func (repo *Repository) GetLanguageStats(commitID string) (map[string]float32, error) {
 	r, err := git.PlainOpen(repo.Path)
@@ -70,6 +80,14 @@ func (repo *Repository) GetLanguageStats(commitID string) (map[string]float32, e
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// filter special languages unless they are the only language
+	if len(sizes) > 1 {
+		for _, language := range specialLanguages {
+			total -= sizes[language]
+			delete(sizes, language)
+		}
 	}
 
 	stats := make(map[string]float32)

--- a/modules/git/repo_language_stats.go
+++ b/modules/git/repo_language_stats.go
@@ -20,8 +20,9 @@ import (
 
 const fileSizeLimit int64 = 16 * 1024 * 1024
 
-// specialLanguages defines list of languages that are excluded from calculation
-// unless they are the only language present in repository
+// specialLanguages defines list of languages that are excluded from the calculation
+// unless they are the only language present in repository. Only languages which under
+// normal circumstances are not considered to be code should be listed here.
 var specialLanguages = []string{
 	"YAML",
 	"JSON",

--- a/modules/git/repo_language_stats.go
+++ b/modules/git/repo_language_stats.go
@@ -29,6 +29,7 @@ var specialLanguages = []string{
 	"SVG",
 	"Text",
 	"Markdown",
+	"TOML",
 }
 
 // GetLanguageStats calculates language stats for git repository at specified commit


### PR DESCRIPTION
For one reason or another, Linguist sometimes decides that it is better to not mark file as generated, so that its diff is not suppressed on GitHub. 

One such example is `yarn.lock`, often present in Node repositories using Yarn as package manager. Due to it's nature it was decided to not include it as generated file as it is easy to inspect its diff for security purposes (lockfile poison).

---

However, despite that, GitHub still does not include such files in their language bar, unless they are the only file present in repository.

Further tests revealed that in fact, GitHub explicitly ignores certain languages unless they have 100% presence in repository. There is no publicly available list of such exclusions, however prominent examples are JSON and YAML - you can verify this by trying to search GitHub repositories by `language:`.

This PR aims to add support for similar logic in Gitea. The list of languages present right now might not be full, the only real way to find would be to test every language GitHub knows about.