### PR TITLE
Ensure that zero-leading gpg key IDs verify

### DIFF
--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -609,10 +609,10 @@ func ParseCommitWithSignature(c *git.Commit) *CommitVerification {
 
 	keyID := ""
 	if sig.IssuerKeyId != nil && (*sig.IssuerKeyId) != 0 {
-		keyID = fmt.Sprintf("%X", *sig.IssuerKeyId)
+		keyID = fmt.Sprintf("%016X", *sig.IssuerKeyId)
 	}
 	if keyID == "" && sig.IssuerFingerprint != nil && len(sig.IssuerFingerprint) > 0 {
-		keyID = fmt.Sprintf("%X", sig.IssuerFingerprint[12:20])
+		keyID = fmt.Sprintf("%016X", sig.IssuerFingerprint[12:20])
 	}
 
 	defaultReason := NoKeyFound


### PR DESCRIPTION
Convert IDs to 16 character hexadecimals before matching with the DB.

Fix #10591

Signed-off-by: Andrew Thornton <art27@cantab.net>
