### PR TITLE
Fix issue due date always being UTC

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3409,7 +3409,6 @@ window.updateDeadline = function (deadlineString) {
   $('#deadline-err-invalid-date').hide();
   $('#deadline-loader').addClass('loading');
 
-  let realDeadline = null;
   if (deadlineString !== '') {
     const newDate = Date.parse(deadlineString);
 
@@ -3418,12 +3417,11 @@ window.updateDeadline = function (deadlineString) {
       $('#deadline-err-invalid-date').show();
       return false;
     }
-    realDeadline = new Date(newDate);
   }
 
   $.ajax(`${$('#update-issue-deadline-form').attr('action')}/deadline`, {
     data: JSON.stringify({
-      due_date: realDeadline,
+      due_date: deadlineString ? new Date(`${deadlineString} 00:00:00`).toISOString() : null,
     }),
     headers: {
       'X-Csrf-Token': csrf,


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/11686

Creates a local `00:00` date and `toISOString` will convert it to UTC. So essentially the exact due time is now always `00:00` in the user's current timezone instead of previously `00:00` UTC.