### PR TITLE
Display issue due date as UTC yyyy-mm-dd

### DIFF
--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -75,6 +75,11 @@ func (ts TimeStamp) FormatShort() string {
 	return ts.Format("Jan 02, 2006")
 }
 
+// FormatUTCDate formats as UTC date yyyy-mm-dd
+func (ts TimeStamp) FormatUTCDate() string {
+	return ts.Format(time.RFC3339)[:10]
+}
+
 // IsZero is zero time
 func (ts TimeStamp) IsZero() bool {
 	return ts.AsTimeInLocation(time.Local).IsZero()

--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -77,7 +77,7 @@ func (ts TimeStamp) FormatShort() string {
 
 // FormatUTCDate formats as UTC date yyyy-mm-dd
 func (ts TimeStamp) FormatUTCDate() string {
-	return ts.Format(time.RFC3339)[:10]
+	return time.Unix(int64(ts), 0).UTC().String()[:10]
 }
 
 // IsZero is zero time

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -28,7 +28,7 @@
 
 					{{range $.PullReviewers}}
 						{{if eq .ReviewerID $ReviewerID }}
-							{{$notReviewed = false }} 
+							{{$notReviewed = false }}
 							{{if  eq .Type 4 }}
 								{{$checked = true}}
 								{{if or (eq $ReviewerID $.SignedUserID) $.Permission.IsAdmin}}
@@ -357,7 +357,7 @@
 			{{if ne .Issue.DeadlineUnix 0}}
 				<p>
 					{{svg "octicon-calendar" 16}}
-					{{.Issue.DeadlineUnix.FormatShort}}
+					{{.Issue.DeadlineUnix.FormatUTCDate}}
 					{{if .Issue.IsOverdue}}
 						<span style="color: red;">{{.i18n.Tr "repo.issues.due_date_overdue"}}</span>
 					{{end}}


### PR DESCRIPTION
Previous version did convert to server time zone which was incorrect because the due date is stored as 00:00 utc and it should not be timezone-converted as it may display a different day.

Fixes: https://github.com/go-gitea/gitea/issues/11686