### PR TITLE
Fix language stat calculation

### DIFF
--- a/models/repo_language_stats.go
+++ b/models/repo_language_stats.go
@@ -53,8 +53,6 @@ func (stats LanguageStatList) getLanguagePercentages() map[string]float32 {
 			langPerc[stat.Language] = perc
 		}
 		otherPerc = float32(math.Round(float64(otherPerc)*10) / 10)
-	} else {
-		otherPerc = 100
 	}
 	if otherPerc > 0 {
 		langPerc["other"] = otherPerc

--- a/models/repo_language_stats.go
+++ b/models/repo_language_stats.go
@@ -26,22 +26,6 @@ type LanguageStat struct {
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
 
-// specialLanguages defines list of languages that are excluded from the calculation
-// unless they are the only language present in repository. Only languages which under
-// normal circumstances are not considered to be code should be listed here.
-var specialLanguages = map[string]struct{}{
-	"XML":      {},
-	"JSON":     {},
-	"TOML":     {},
-	"YAML":     {},
-	"INI":      {},
-	"SQL":      {},
-	"SVG":      {},
-	"Text":     {},
-	"Markdown": {},
-	"other":    {},
-}
-
 // LanguageStatList defines a list of language statistics
 type LanguageStatList []*LanguageStat
 
@@ -55,27 +39,12 @@ func (stats LanguageStatList) getLanguagePercentages() map[string]float32 {
 	langPerc := make(map[string]float32)
 	var otherPerc float32 = 100
 	var total int64
-	// Check that repository has at least one non-special language
-	var skipSpecial bool
+
 	for _, stat := range stats {
-		if _, ok := specialLanguages[stat.Language]; !ok {
-			skipSpecial = true
-			break
-		}
-	}
-	for _, stat := range stats {
-		// Exclude specific languages from percentage calculation
-		if _, ok := specialLanguages[stat.Language]; ok && skipSpecial {
-			continue
-		}
 		total += stat.Size
 	}
 	if total > 0 {
 		for _, stat := range stats {
-			// Exclude specific languages from percentage calculation
-			if _, ok := specialLanguages[stat.Language]; ok && skipSpecial {
-				continue
-			}
 			perc := float32(math.Round(float64(stat.Size)/float64(total)*1000) / 10)
 			if perc <= 0.1 {
 				continue

--- a/modules/git/repo_language_stats.go
+++ b/modules/git/repo_language_stats.go
@@ -57,7 +57,7 @@ func (repo *Repository) GetLanguageStats(commitID string) (map[string]int64, err
 
 	sizes := make(map[string]int64)
 	err = tree.Files().ForEach(func(f *object.File) error {
-		if enry.IsVendor(f.Name) || enry.IsDotFile(f.Name) ||
+		if f.Size == 0 || enry.IsVendor(f.Name) || enry.IsDotFile(f.Name) ||
 			enry.IsDocumentation(f.Name) || enry.IsConfiguration(f.Name) {
 			return nil
 		}
@@ -73,6 +73,12 @@ func (repo *Repository) GetLanguageStats(commitID string) (map[string]int64, err
 		language := analyze.GetCodeLanguage(f.Name, content)
 		if language == enry.OtherLanguage || language == "" {
 			return nil
+		}
+
+		// group languages, such as Pug -> HTML; SCSS -> CSS
+		group := enry.GetLanguageGroup(language)
+		if group != "" {
+			language = group
 		}
 
 		sizes[language] += f.Size

--- a/modules/indexer/stats/indexer_test.go
+++ b/modules/indexer/stats/indexer_test.go
@@ -39,7 +39,5 @@ func TestRepoStatsIndex(t *testing.T) {
 	assert.Equal(t, "65f1bf27bc3bf70f64657658635e66094edbcb4d", status.CommitSha)
 	langs, err := repo.GetTopLanguageStats(5)
 	assert.NoError(t, err)
-	assert.Len(t, langs, 1)
-	assert.Equal(t, "other", langs[0].Language)
-	assert.Equal(t, float32(100), langs[0].Percentage)
+	assert.Empty(t, langs)
 }


### PR DESCRIPTION
As discussed on Discord; https://github.com/go-gitea/gitea/pull/11681 broke primary language selection by storing excluded languages in database along with explicit "other".

This PR makes it so that "other" and excluded languages are not stored in database allowing us to replicate languages API the same way GitHub does.

---

- Fixes issue where excluded language was stored in database as primary language but not displayed on language bar, causing situation where repo was shown as YAML on explore page but no YAML was present on language bar
- Removes storing of "other" in database
- Ignore files with 0 size
- Use language grouping (SCSS->CSS; Pug->HTML)
- Removes SQL from list of special languages