### PR TITLE
Add a timeout to createBlameReader

### DIFF
--- a/modules/git/blame.go
+++ b/modules/git/blame.go
@@ -101,7 +101,7 @@ func CreateBlameReader(repoPath, commitID, file string) (*BlameReader, error) {
 }
 
 func createBlameReader(dir string, command ...string) (*BlameReader, error) {
-	// This timeout was abritrarily chosen just so that there are not hundreds of `git blame`
+	// This timeout was arbitrarily chosen just so that there are not hundreds of `git blame`
 	// processes sticking around after some operations.
 	ctx, cancel := context.WithTimeout(DefaultContext, 5*time.Minute)
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)

--- a/modules/git/blame.go
+++ b/modules/git/blame.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"time"
 
 	"code.gitea.io/gitea/modules/process"
 )
@@ -100,8 +101,9 @@ func CreateBlameReader(repoPath, commitID, file string) (*BlameReader, error) {
 }
 
 func createBlameReader(dir string, command ...string) (*BlameReader, error) {
-	// FIXME: graceful: This should have a timeout
-	ctx, cancel := context.WithCancel(DefaultContext)
+	// This timeout was abritrarily chosen just so that there are not hundreds of `git blame`
+	// processes sticking around after some operations.
+	ctx, cancel := context.WithTimeout(DefaultContext, 5*time.Minute)
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
The timeout duration is arbitrary. The value needs to be longer than any
actual use, and should only kick in when processes aren't reaped
manually for some reason.

Closes #11716