### PR TITLE
Add missing templates for Matrix system webhooks

### DIFF
--- a/templates/admin/hook_new.tmpl
+++ b/templates/admin/hook_new.tmpl
@@ -26,6 +26,8 @@
 					<img class="img-13" src="{{StaticUrlPrefix}}/img/msteams.png">
 				{{else if eq .HookType "feishu"}}
 					<img class="img-13" src="{{StaticUrlPrefix}}/img/feishu.png">
+				{{else if eq .HookType "matrix"}}
+					<img class="img-13" src="{{StaticUrlPrefix}}/img/matrix.svg">
 				{{end}}
 			</div>
 		</h4>
@@ -38,6 +40,7 @@
 			{{template "repo/settings/webhook/telegram" .}}
 			{{template "repo/settings/webhook/msteams" .}}
 			{{template "repo/settings/webhook/feishu" .}}
+			{{template "repo/settings/webhook/matrix" .}}
 		</div>
 
 		{{template "repo/settings/webhook/history" .}}

--- a/templates/org/settings/hook_new.tmpl
+++ b/templates/org/settings/hook_new.tmpl
@@ -25,6 +25,8 @@
 							<img class="img-13" src="{{StaticUrlPrefix}}/img/msteams.png">
 						{{else if eq .HookType "feishu"}}
 							<img class="img-13" src="{{StaticUrlPrefix}}/img/feishu.png">
+						{{else if eq .HookType "matrix"}}
+							<img class="img-13" src="{{StaticUrlPrefix}}/img/matrix.svg">
 						{{end}}
 					</div>
 				</h4>
@@ -37,6 +39,7 @@
 					{{template "repo/settings/webhook/telegram" .}}
 					{{template "repo/settings/webhook/msteams" .}}
 					{{template "repo/settings/webhook/feishu" .}}
+					{{template "repo/settings/webhook/matrix" .}}
 				</div>
 
 				{{template "repo/settings/webhook/history" .}}


### PR DESCRIPTION
As per https://github.com/go-gitea/gitea/pull/10831#issuecomment-637167315 it seems that I've missed the system webhooks. This fixes it.