### PR TITLE
Allow site admin to disable mirrors

### DIFF
--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -50,6 +50,8 @@ DISABLED_REPO_UNITS =
 DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki
 ; Prefix archive files by placing them in a directory named after the repository
 PREFIX_ARCHIVE_FILES = true
+; Disable mirror migrations
+DISABLE_MIRRORS = false
 
 [repository.editor]
 ; List of file extensions for which lines should be wrapped in the Monaco editor

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -50,7 +50,7 @@ DISABLED_REPO_UNITS =
 DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki
 ; Prefix archive files by placing them in a directory named after the repository
 PREFIX_ARCHIVE_FILES = true
-; Disable new mirror migrations
+; Disable the creation of new mirrors. Pre-existing mirrors remain valid.
 DISABLE_MIRRORS = false
 
 [repository.editor]

--- a/custom/conf/app.ini.sample
+++ b/custom/conf/app.ini.sample
@@ -50,7 +50,7 @@ DISABLED_REPO_UNITS =
 DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki
 ; Prefix archive files by placing them in a directory named after the repository
 PREFIX_ARCHIVE_FILES = true
-; Disable mirror migrations
+; Disable new mirror migrations
 DISABLE_MIRRORS = false
 
 [repository.editor]

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -69,7 +69,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `ENABLE_PUSH_CREATE_USER`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for a user.
 - `ENABLE_PUSH_CREATE_ORG`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for an org.
 - `PREFIX_ARCHIVE_FILES`: **true**: Prefix archive files by placing them in a directory named after the repository.
-- `DISABLE_MIRRORS`: **false**: Disable mirror migrations
+- `DISABLE_MIRRORS`: **false**: Disable *new* mirror migrations
 
 ### Repository - Pull Request (`repository.pull-request`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -69,7 +69,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `ENABLE_PUSH_CREATE_USER`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for a user.
 - `ENABLE_PUSH_CREATE_ORG`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for an org.
 - `PREFIX_ARCHIVE_FILES`: **true**: Prefix archive files by placing them in a directory named after the repository.
-- `DISABLE_MIRRORS`: **false**: Disable *new* mirror migrations
+- `DISABLE_MIRRORS`: **false**: Disable the creation of **new** mirrors. Pre-existing mirrors remain valid.
 
 ### Repository - Pull Request (`repository.pull-request`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -69,6 +69,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `ENABLE_PUSH_CREATE_USER`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for a user.
 - `ENABLE_PUSH_CREATE_ORG`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for an org.
 - `PREFIX_ARCHIVE_FILES`: **true**: Prefix archive files by placing them in a directory named after the repository.
+- `DISABLE_MIRRORS`: **false**: Disable mirror migrations
 
 ### Repository - Pull Request (`repository.pull-request`)
 

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -40,6 +40,7 @@ var (
 		DisabledRepoUnits                       []string
 		DefaultRepoUnits                        []string
 		PrefixArchiveFiles                      bool
+		DisableMirrors                          bool
 
 		// Repository editor settings
 		Editor struct {
@@ -104,6 +105,7 @@ var (
 		DisabledRepoUnits:                       []string{},
 		DefaultRepoUnits:                        []string{},
 		PrefixArchiveFiles:                      true,
+		DisableMirrors:                          false,
 
 		// Repository editor settings
 		Editor: struct {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -689,6 +689,7 @@ form.name_pattern_not_allowed = The pattern '%s' is not allowed in a repository 
 need_auth = Clone Authorization
 migrate_type = Migration Type
 migrate_type_helper = This repository will be a <span class="text blue">mirror</span>
+migrate_type_helper_disabled = Your site administrator has disabled new mirrors.
 migrate_items = Migration Items
 migrate_items_wiki = Wiki
 migrate_items_milestones = Milestones

--- a/routers/api/v1/repo/migrate.go
+++ b/routers/api/v1/repo/migrate.go
@@ -118,7 +118,7 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 		RepoName:       form.RepoName,
 		Description:    form.Description,
 		Private:        form.Private || setting.Repository.ForcePrivate,
-		Mirror:         form.Mirror,
+		Mirror:         form.Mirror && !setting.Repository.DisableMirrors,
 		AuthUsername:   form.AuthUsername,
 		AuthPassword:   form.AuthPassword,
 		Wiki:           form.Wiki,

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -259,6 +259,7 @@ func Migrate(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("new_migrate")
 	ctx.Data["private"] = getRepoPrivate(ctx)
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["DisableMirrors"] = setting.Repository.DisableMirrors
 	ctx.Data["mirror"] = ctx.Query("mirror") == "1"
 	ctx.Data["wiki"] = ctx.Query("wiki") == "1"
 	ctx.Data["milestones"] = ctx.Query("milestones") == "1"
@@ -360,7 +361,7 @@ func MigratePost(ctx *context.Context, form auth.MigrateRepoForm) {
 		RepoName:       form.RepoName,
 		Description:    form.Description,
 		Private:        form.Private || setting.Repository.ForcePrivate,
-		Mirror:         form.Mirror,
+		Mirror:         form.Mirror && !setting.Repository.DisableMirrors,
 		AuthUsername:   form.AuthUsername,
 		AuthPassword:   form.AuthPassword,
 		Wiki:           form.Wiki,

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -83,7 +83,7 @@
 						<div class="ui checkbox">
 							{{if .DisableMirrors}}
 								<input id="mirror" name="mirror" type="checkbox" readonly>
-								<label>{{.i18n.Tr "repo.migrate_type_helper_disabled" | Safe}}</label>
+								<label>{{.i18n.Tr "repo.migrate_type_helper_disabled"}}</label>
 							{{else}}
 								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
 								<label>{{.i18n.Tr "repo.migrate_type_helper" | Safe}}</label>

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -81,8 +81,13 @@
 					<div class="inline field">
 						<label>{{.i18n.Tr "repo.migrate_type"}}</label>
 						<div class="ui checkbox">
-							<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_type_helper" | Safe}}</label>
+							{{if .DisableMirrors}}
+								<input id="mirror" name="mirror" type="checkbox" readonly>
+								<label>{{.i18n.Tr "repo.migrate_type_helper_disabled" | Safe}}</label>
+							{{else}}
+								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_type_helper" | Safe}}</label>
+							{{end}}
 						</div>
 					</div>
 					<div id="migrate_items" class="ui field">


### PR DESCRIPTION
Wording is consistent with `FORCE_PRIVATE`

![mirrors](https://user-images.githubusercontent.com/42128690/83551739-5d138500-a4ce-11ea-8ced-a83d432cf9c0.png)

This will stop the creation of *new* mirror migrations. For existing mirrors, the site admin will need to turn off the cron for updating them (or delete them).