### PR TITLE
Don't redirect to the main page after logout

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -58,7 +58,7 @@
 					</div>
 
 					<div class="divider"></div>
-					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
+					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout">
 						{{svg "octicon-sign-out" 16}}
 						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 					</a>
@@ -139,7 +139,7 @@
 					{{end}}
 
 					<div class="divider"></div>
-					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
+					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout">
 						{{svg "octicon-sign-out" 16}}
 						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 					</a>


### PR DESCRIPTION
I don't think it is necessary to redirect to the home page after logout, because users may still want to use this page, only reload is enough.
