### PR TITLE
Explicitly specify width and height for svg

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -298,8 +298,8 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return false
 		},
-		"svg": func(icon string, size int) template.HTML {
-			return template.HTML(fmt.Sprintf(`<svg class="svg %s" width="%d" height="%d" aria-hidden="true"><use xlink:href="#%s" /></svg>`, icon, size, size, icon))
+		"svg": func(icon string, width int, height int) template.HTML {
+			return template.HTML(fmt.Sprintf(`<svg class="svg %s" width="%d" height="%d" aria-hidden="true"><use xlink:href="#%s" /></svg>`, icon, width, height, icon))
 		},
 	}}
 }

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -21,44 +21,44 @@
 					<tbody>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.delete_inactive_accounts"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_inactive_accounts">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_inactive_accounts">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.delete_repo_archives"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_repo_archives">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_repo_archives">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.delete_missing_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_missing_repos">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_missing_repos">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.git_gc_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="git_gc_repos">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="git_gc_repos">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.resync_all_sshkeys"}}<br/>
 							{{.i18n.Tr "admin.dashboard.resync_all_sshkeys.desc"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="resync_all_sshkeys">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="resync_all_sshkeys">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.resync_all_hooks"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="resync_all_hooks">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="resync_all_hooks">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.reinit_missing_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="reinit_missing_repos">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="reinit_missing_repos">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.sync_external_users"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="sync_external_users">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="sync_external_users">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.repo_health_check"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="repo_health_check">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="repo_health_check">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.delete_generated_repository_avatars"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-triangle-right" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-triangle-right" 16 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 					</tbody>
 				</table>

--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -23,7 +23,7 @@
 					<tbody>
 						{{range .Entries}}
 							<tr>
-								<td><button type="submit" class="ui green button" name="op" value="{{.Name}}" title="{{$.i18n.Tr "admin.dashboard.operation_run"}}">{{svg "octicon-triangle-right" 16}}</button></td>
+								<td><button type="submit" class="ui green button" name="op" value="{{.Name}}" title="{{$.i18n.Tr "admin.dashboard.operation_run"}}">{{svg "octicon-triangle-right" 16 16}}</button></td>
 								<td>{{$.i18n.Tr (printf "admin.dashboard.%s" .Name)}}</td>
 								<td>{{.Spec}}</td>
 								<td>{{DateFmtLong .Next}}</td>

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -32,7 +32,7 @@
 							<td>
 								<a href="{{.HomeLink}}">{{.Name}}</a>
 								{{if .Visibility.IsPrivate}}
-									<span class="text gold">{{svg "octicon-lock" 16}}</span>
+									<span class="text gold">{{svg "octicon-lock" 12 16}}</span>
 								{{end}}
 							</td>
 							<td>{{.NumTeams}}</td>

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -33,7 +33,7 @@
 							<td>
 								<a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a>
 								{{if .Owner.Visibility.IsPrivate}}
-									<span class="text gold">{{svg "octicon-lock" 16}}</span>
+									<span class="text gold">{{svg "octicon-lock" 12 16}}</span>
 								{{end}}
 							</td>
 							<td><a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -118,7 +118,7 @@
 						{{.i18n.Tr "your_profile"}}<!-- Your profile -->
 					</a>
 					<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}?tab=stars">
-						{{svg "octicon-star" 16 16}}
+						{{svg "octicon-star" 14 16}}
 						{{.i18n.Tr "your_starred"}}
 					</a>
 					<a class="{{if .PageIsUserSettings}}active{{end}} item" href="{{AppSubUrl}}/user/settings">

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -114,7 +114,7 @@
 
 					<div class="divider"></div>
 					<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}">
-						{{svg "octicon-person" 16 16}}
+						{{svg "octicon-person" 12 16}}
 						{{.i18n.Tr "your_profile"}}<!-- Your profile -->
 					</a>
 					<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}?tab=stars">
@@ -151,7 +151,7 @@
 		<div class="right stackable menu">
 			{{if .ShowRegistrationButton}}
 				<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
-					{{svg "octicon-person" 16 16}} {{.i18n.Tr "register"}}
+					{{svg "octicon-person" 12 16}} {{.i18n.Tr "register"}}
 				</a>
 			{{end}}
 			<a class="item{{if .PageIsSignIn}} active{{end}}" rel="nofollow" href="{{AppSubUrl}}/user/login?redirect_to={{.CurrentURL}}">

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -50,7 +50,7 @@
 					<img class="ui tiny avatar image" width="24" height="24" src="{{.SignedUser.RelAvatarLink}}">
 					<span class="sr-only">{{.i18n.Tr "user_profile_and_more"}}</span>
 					<span class="mobile-only">{{.SignedUser.Name}}</span>
-					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down" 16}}</span>
+					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down" 16 16}}</span>
 				</span>
 				<div class="menu user-menu" tabindex="-1">
 					<div class="ui header">
@@ -59,7 +59,7 @@
 
 					<div class="divider"></div>
 					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
-						{{svg "octicon-sign-out" 16}}
+						{{svg "octicon-sign-out" 16 16}}
 						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 					</a>
 				</div><!-- end content avatar menu -->
@@ -69,7 +69,7 @@
 		<div class="right stackable menu">
 			<a href="{{AppSubUrl}}/notifications" class="item poping up" data-content='{{.i18n.Tr "notifications"}}' data-variation="tiny inverted">
 				<span class="text">
-					<span class="fitted">{{svg "octicon-bell" 16}}</span>
+					<span class="fitted">{{svg "octicon-bell" 15 16}}</span>
 					<span class="sr-mobile-only">{{.i18n.Tr "notifications"}}</span>
 					{{$notificationUnreadCount := 0}}
 					{{if .NotificationUnreadCount}}{{$notificationUnreadCount = call .NotificationUnreadCount}}{{end}}
@@ -81,20 +81,20 @@
 
 			<div class="ui dropdown jump item poping up" data-content="{{.i18n.Tr "create_new"}}" data-variation="tiny inverted">
 				<span class="text">
-					<span class="fitted">{{svg "octicon-plus" 16}}</span>
+					<span class="fitted">{{svg "octicon-plus" 12 16}}</span>
 					<span class="sr-mobile-only">{{.i18n.Tr "create_new"}}</span>
-					<span class="fitted not-mobile">{{svg "octicon-triangle-down" 16}}</span>
+					<span class="fitted not-mobile">{{svg "octicon-triangle-down" 16 16}}</span>
 				</span>
 				<div class="menu">
 					<a class="item" href="{{AppSubUrl}}/repo/create">
-						<span class="fitted">{{svg "octicon-plus" 16}}</span> {{.i18n.Tr "new_repo"}}
+						<span class="fitted">{{svg "octicon-plus" 12 16}}</span> {{.i18n.Tr "new_repo"}}
 					</a>
 					<a class="item" href="{{AppSubUrl}}/repo/migrate">
-						<span class="fitted">{{svg "octicon-repo-clone" 16}}</span> {{.i18n.Tr "new_migrate"}}
+						<span class="fitted">{{svg "octicon-repo-clone" 16 16}}</span> {{.i18n.Tr "new_migrate"}}
 					</a>
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
-						<span class="fitted">{{svg "octicon-organization" 16}}</span> {{.i18n.Tr "new_org"}}
+						<span class="fitted">{{svg "octicon-organization" 16 16}}</span> {{.i18n.Tr "new_org"}}
 					</a>
 					{{end}}
 				</div><!-- end content create new menu -->
@@ -105,7 +105,7 @@
 					<img class="ui tiny avatar image" width="24" height="24" src="{{.SignedUser.RelAvatarLink}}">
 					<span class="sr-only">{{.i18n.Tr "user_profile_and_more"}}</span>
 					<span class="mobile-only">{{.SignedUser.Name}}</span>
-					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down" 16}}</span>
+					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down" 16 16}}</span>
 				</span>
 				<div class="menu user-menu" tabindex="-1">
 					<div class="ui header">
@@ -114,19 +114,19 @@
 
 					<div class="divider"></div>
 					<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}">
-						{{svg "octicon-person" 16}}
+						{{svg "octicon-person" 16 16}}
 						{{.i18n.Tr "your_profile"}}<!-- Your profile -->
 					</a>
 					<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}?tab=stars">
-						{{svg "octicon-star" 16}}
+						{{svg "octicon-star" 16 16}}
 						{{.i18n.Tr "your_starred"}}
 					</a>
 					<a class="{{if .PageIsUserSettings}}active{{end}} item" href="{{AppSubUrl}}/user/settings">
-						{{svg "octicon-settings" 16}}
+						{{svg "octicon-settings" 16 16}}
 						{{.i18n.Tr "your_settings"}}<!-- Your settings -->
 					</a>
 					<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">
-						{{svg "octicon-question" 16}}
+						{{svg "octicon-question" 16 16}}
 						{{.i18n.Tr "help"}}<!-- Help -->
 					</a>
 					{{if .IsAdmin}}
@@ -140,7 +140,7 @@
 
 					<div class="divider"></div>
 					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
-						{{svg "octicon-sign-out" 16}}
+						{{svg "octicon-sign-out" 16 16}}
 						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 					</a>
 				</div><!-- end content avatar menu -->
@@ -151,11 +151,11 @@
 		<div class="right stackable menu">
 			{{if .ShowRegistrationButton}}
 				<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
-					{{svg "octicon-person" 16}} {{.i18n.Tr "register"}}
+					{{svg "octicon-person" 16 16}} {{.i18n.Tr "register"}}
 				</a>
 			{{end}}
 			<a class="item{{if .PageIsSignIn}} active{{end}}" rel="nofollow" href="{{AppSubUrl}}/user/login?redirect_to={{.CurrentURL}}">
-				{{svg "octicon-sign-in" 16}} {{.i18n.Tr "sign_in"}}
+				{{svg "octicon-sign-in" 16 16}} {{.i18n.Tr "sign_in"}}
 			</a>
 		</div><!-- end anonymous right menu -->
 	{{end}}

--- a/templates/explore/navbar.tmpl
+++ b/templates/explore/navbar.tmpl
@@ -1,16 +1,16 @@
 <div class="ui secondary pointing tabular top attached borderless stackable menu navbar">
 	<a class="{{if .PageIsExploreRepositories}}active{{end}} item" href="{{AppSubUrl}}/explore/repos">
-		{{svg "octicon-repo" 16}} {{.i18n.Tr "explore.repos"}}
+		{{svg "octicon-repo" 12 16}} {{.i18n.Tr "explore.repos"}}
 	</a>
 	<a class="{{if .PageIsExploreUsers}}active{{end}} item" href="{{AppSubUrl}}/explore/users">
-		{{svg "octicon-person" 16}} {{.i18n.Tr "explore.users"}}
+		{{svg "octicon-person" 16 16}} {{.i18n.Tr "explore.users"}}
 	</a>
 	<a class="{{if .PageIsExploreOrganizations}}active{{end}} item" href="{{AppSubUrl}}/explore/organizations">
-		{{svg "octicon-organization" 16}} {{.i18n.Tr "explore.organizations"}}
+		{{svg "octicon-organization" 16 16}} {{.i18n.Tr "explore.organizations"}}
 	</a>
 	{{if .IsRepoIndexerEnabled}}
 	<a class="{{if .PageIsExploreCode}}active{{end}} item" href="{{AppSubUrl}}/explore/code">
-		{{svg "octicon-code" 16}} {{.i18n.Tr "explore.code"}}
+		{{svg "octicon-code" 16 16}} {{.i18n.Tr "explore.code"}}
 	</a>
 	{{end}}
 </div>

--- a/templates/explore/navbar.tmpl
+++ b/templates/explore/navbar.tmpl
@@ -3,14 +3,14 @@
 		{{svg "octicon-repo" 12 16}} {{.i18n.Tr "explore.repos"}}
 	</a>
 	<a class="{{if .PageIsExploreUsers}}active{{end}} item" href="{{AppSubUrl}}/explore/users">
-		{{svg "octicon-person" 16 16}} {{.i18n.Tr "explore.users"}}
+		{{svg "octicon-person" 12 16}} {{.i18n.Tr "explore.users"}}
 	</a>
 	<a class="{{if .PageIsExploreOrganizations}}active{{end}} item" href="{{AppSubUrl}}/explore/organizations">
 		{{svg "octicon-organization" 16 16}} {{.i18n.Tr "explore.organizations"}}
 	</a>
 	{{if .IsRepoIndexerEnabled}}
 	<a class="{{if .PageIsExploreCode}}active{{end}} item" href="{{AppSubUrl}}/explore/code">
-		{{svg "octicon-code" 16 16}} {{.i18n.Tr "explore.code"}}
+		{{svg "octicon-code" 14 16}} {{.i18n.Tr "explore.code"}}
 	</a>
 	{{end}}
 </div>

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -12,18 +12,18 @@
 					<span class="header">
 						<a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}
 						{{if .Visibility.IsPrivate}}
-							<span class="text gold">{{svg "octicon-lock" 16}}</span>
+							<span class="text gold">{{svg "octicon-lock" 12 16}}</span>
 						{{end}}
 					</span>
 					<div class="description">
 						{{if .Location}}
-							{{svg "octicon-location" 16}} {{.Location}}
+							{{svg "octicon-location" 16 16}} {{.Location}}
 						{{end}}
 						{{if and .Website}}
-							{{svg "octicon-link" 16}}
+							{{svg "octicon-link" 16 16}}
 							<a href="{{.Website}}" rel="nofollow">{{.Website}}</a>
 						{{end}}
-						{{svg "octicon-clock" 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					</div>
 				  </div>
 				</div>

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -17,13 +17,13 @@
 					</span>
 					<div class="description">
 						{{if .Location}}
-							{{svg "octicon-location" 16 16}} {{.Location}}
+							{{svg "octicon-location" 12 16}} {{.Location}}
 						{{end}}
 						{{if and .Website}}
 							{{svg "octicon-link" 16 16}}
 							<a href="{{.Website}}" rel="nofollow">{{.Website}}</a>
 						{{end}}
-						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					</div>
 				  </div>
 				</div>

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -10,20 +10,20 @@
 					{{if .IsArchived}}<i class="archive icon archived-icon"></i>{{end}}
 				</a>
 				{{if .IsPrivate}}
-					<span class="middle text gold">{{svg "octicon-lock" 16}}</span>
+					<span class="middle text gold">{{svg "octicon-lock" 12 16}}</span>
 				{{else if and (not .IsMirror) (not .IsFork) (.Owner.Visibility.IsPrivate) }}
-					<span class="text gold">{{svg "octicon-internal-repo" 16}}</span>
+					<span class="text gold">{{svg "octicon-internal-repo" 13 16}}</span>
 				{{else if .IsFork}}
-					<span class="middle">{{svg "octicon-repo-forked" 16}}</span>
+					<span class="middle">{{svg "octicon-repo-forked" 10 16}}</span>
 				{{else if .IsMirror}}
-					<span class="middle">{{svg "octicon-repo-clone" 16}}</span>
+					<span class="middle">{{svg "octicon-repo-clone" 16 16}}</span>
 				{{end}}
 				<div class="ui right metas">
 					{{if .PrimaryLanguage }}
 					<span class="text grey"><i class="color-icon" style="background-color: {{.PrimaryLanguage.Color}}"></i>{{ .PrimaryLanguage.Language }}</span>
 					{{end}}
-					<span class="text grey">{{svg "octicon-star" 16}} {{.NumStars}}</span>
-					<span class="text grey">{{svg "octicon-git-branch" 16}} {{.NumForks}}</span>
+					<span class="text grey">{{svg "octicon-star" 16 16}} {{.NumStars}}</span>
+					<span class="text grey">{{svg "octicon-git-branch" 16 16}} {{.NumForks}}</span>
 				</div>
 			</div>
 			<div class="description">

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -22,7 +22,7 @@
 					{{if .PrimaryLanguage }}
 					<span class="text grey"><i class="color-icon" style="background-color: {{.PrimaryLanguage.Color}}"></i>{{ .PrimaryLanguage.Language }}</span>
 					{{end}}
-					<span class="text grey">{{svg "octicon-star" 16 16}} {{.NumStars}}</span>
+					<span class="text grey">{{svg "octicon-star" 14 16}} {{.NumStars}}</span>
 					<span class="text grey">{{svg "octicon-git-branch" 10 16}} {{.NumForks}}</span>
 				</div>
 			</div>

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -23,7 +23,7 @@
 					<span class="text grey"><i class="color-icon" style="background-color: {{.PrimaryLanguage.Color}}"></i>{{ .PrimaryLanguage.Language }}</span>
 					{{end}}
 					<span class="text grey">{{svg "octicon-star" 16 16}} {{.NumStars}}</span>
-					<span class="text grey">{{svg "octicon-git-branch" 16 16}} {{.NumForks}}</span>
+					<span class="text grey">{{svg "octicon-git-branch" 10 16}} {{.NumForks}}</span>
 				</div>
 			</div>
 			<div class="description">

--- a/templates/explore/users.tmpl
+++ b/templates/explore/users.tmpl
@@ -12,13 +12,13 @@
 					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}</span>
 					<div class="description">
 						{{if .Location}}
-							{{svg "octicon-location" 16}} {{.Location}}
+							{{svg "octicon-location" 16 16}} {{.Location}}
 						{{end}}
 						{{if and $.ShowUserEmail .Email $.IsSigned (not .KeepEmailPrivate)}}
-							{{svg "octicon-mail" 16}}
+							{{svg "octicon-mail" 16 16}}
 							<a href="mailto:{{.Email}}" rel="nofollow">{{.Email}}</a>
 						{{end}}
-						{{svg "octicon-clock" 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					</div>
 				  </div>
 				</div>

--- a/templates/explore/users.tmpl
+++ b/templates/explore/users.tmpl
@@ -12,13 +12,13 @@
 					<span class="header"><a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}</span>
 					<div class="description">
 						{{if .Location}}
-							{{svg "octicon-location" 16 16}} {{.Location}}
+							{{svg "octicon-location" 12 16}} {{.Location}}
 						{{end}}
 						{{if and $.ShowUserEmail .Email $.IsSigned (not .KeepEmailPrivate)}}
-							{{svg "octicon-mail" 16 16}}
+							{{svg "octicon-clock" 14 16}}
 							<a href="mailto:{{.Email}}" rel="nofollow">{{.Email}}</a>
 						{{end}}
-						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					</div>
 				  </div>
 				</div>

--- a/templates/explore/users.tmpl
+++ b/templates/explore/users.tmpl
@@ -15,7 +15,7 @@
 							{{svg "octicon-location" 12 16}} {{.Location}}
 						{{end}}
 						{{if and $.ShowUserEmail .Email $.IsSigned (not .KeepEmailPrivate)}}
-							{{svg "octicon-clock" 14 16}}
+							{{svg "octicon-mail" 14 16}}
 							<a href="mailto:{{.Email}}" rel="nofollow">{{.Email}}</a>
 						{{end}}
 						{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -16,7 +16,7 @@
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-flame" 16 16}} {{.i18n.Tr "startpage.install"}}
+				{{svg "octicon-flame" 12 16}} {{.i18n.Tr "startpage.install"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.install_desc" | Str2html}}
@@ -42,7 +42,7 @@
 		</div>
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-code" 16 16}} {{.i18n.Tr "startpage.license"}}
+				{{svg "octicon-code" 14 16}} {{.i18n.Tr "startpage.license"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.license_desc" | Str2html}}

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -16,7 +16,7 @@
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-flame" 16}} {{.i18n.Tr "startpage.install"}}
+				{{svg "octicon-flame" 16 16}} {{.i18n.Tr "startpage.install"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.install_desc" | Str2html}}
@@ -24,7 +24,7 @@
 		</div>
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-device-desktop" 16}} {{.i18n.Tr "startpage.platform"}}
+				{{svg "octicon-device-desktop" 16 16}} {{.i18n.Tr "startpage.platform"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.platform_desc" | Str2html}}
@@ -34,7 +34,7 @@
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-rocket" 16}} {{.i18n.Tr "startpage.lightweight"}}
+				{{svg "octicon-rocket" 16 16}} {{.i18n.Tr "startpage.lightweight"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.lightweight_desc" | Str2html}}
@@ -42,7 +42,7 @@
 		</div>
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-code" 16}} {{.i18n.Tr "startpage.license"}}
+				{{svg "octicon-code" 16 16}} {{.i18n.Tr "startpage.license"}}
 			</h1>
 			<p class="large">
 				{{.i18n.Tr "startpage.license_desc" | Str2html}}

--- a/templates/org/header.tmpl
+++ b/templates/org/header.tmpl
@@ -9,11 +9,11 @@
 					<div class="ui right">
 						<div class="ui menu">
 							<a class="{{if $.PageIsOrgMembers}}active{{end}} item" href="{{$.OrgLink}}/members">
-								{{svg "octicon-organization" 16}}&nbsp;{{$.i18n.Tr "org.people"}}
+								{{svg "octicon-organization" 16 16}}&nbsp;{{$.i18n.Tr "org.people"}}
 								<div class="floating ui black label">{{.NumMembers}}</div>
 							</a>
 							<a class="{{if $.PageIsOrgTeams}}active{{end}} item" href="{{$.OrgLink}}/teams">
-								{{svg "octicon-jersey" 16}}&nbsp;{{$.i18n.Tr "org.teams"}}
+								{{svg "octicon-jersey" 16 16}}&nbsp;{{$.i18n.Tr "org.teams"}}
 								<div class="floating ui black label">{{.NumTeams}}</div>
 							</a>
 						</div>

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -7,12 +7,12 @@
 		<div id="org-info">
 			<div class="ui header">
 				{{.Org.DisplayName}}
-				{{if .IsOrganizationOwner}}<a class="middle text grey" href="{{.OrgLink}}/settings">{{svg "octicon-gear" 16}}</a>{{end}}
+				{{if .IsOrganizationOwner}}<a class="middle text grey" href="{{.OrgLink}}/settings">{{svg "octicon-gear" 16 16}}</a>{{end}}
 			</div>
 			{{if .Org.Description}}<p class="desc">{{.Org.Description}}</p>{{end}}
 			<div class="text grey meta">
-				{{if .Org.Location}}<div class="item">{{svg "octicon-location" 16}} <span>{{.Org.Location}}</span></div>{{end}}
-				{{if .Org.Website}}<div class="item">{{svg "octicon-link" 16}} <a target="_blank" rel="noopener noreferrer" href="{{.Org.Website}}">{{.Org.Website}}</a></div>{{end}}
+				{{if .Org.Location}}<div class="item">{{svg "octicon-location" 16 16}} <span>{{.Org.Location}}</span></div>{{end}}
+				{{if .Org.Website}}<div class="item">{{svg "octicon-link" 16 16}} <a target="_blank" rel="noopener noreferrer" href="{{.Org.Website}}">{{.Org.Website}}</a></div>{{end}}
 			</div>
 		</div>
 	</div>
@@ -38,7 +38,7 @@
 					<strong>{{.i18n.Tr "org.people"}}</strong>
 					{{if .IsOrganizationMember}}
 						<div class="ui right">
-							<a class="text grey" href="{{.OrgLink}}/members">{{.Org.NumMembers}} {{svg "octicon-chevron-right" 16}}</a>
+							<a class="text grey" href="{{.OrgLink}}/members">{{.Org.NumMembers}} {{svg "octicon-chevron-right" 16 16}}</a>
 						</div>
 					{{end}}
 				</h4>
@@ -55,7 +55,7 @@
 					<div class="ui top attached header">
 						<strong>{{.i18n.Tr "org.teams"}}</strong>
 						<div class="ui right">
-							<a class="text grey" href="{{.OrgLink}}/teams"><span>{{.Org.NumTeams}}</span> {{svg "octicon-chevron-right" 16}}</a>
+							<a class="text grey" href="{{.OrgLink}}/teams"><span>{{.Org.NumTeams}}</span> {{svg "octicon-chevron-right" 16 16}}</a>
 						</div>
 					</div>
 					<div class="ui attached table segment teams">

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -11,7 +11,7 @@
 			</div>
 			{{if .Org.Description}}<p class="desc">{{.Org.Description}}</p>{{end}}
 			<div class="text grey meta">
-				{{if .Org.Location}}<div class="item">{{svg "octicon-location" 16 16}} <span>{{.Org.Location}}</span></div>{{end}}
+				{{if .Org.Location}}<div class="item">{{svg "octicon-location" 12 16}} <span>{{.Org.Location}}</span></div>{{end}}
 				{{if .Org.Website}}<div class="item">{{svg "octicon-link" 16 16}} <a target="_blank" rel="noopener noreferrer" href="{{.Org.Website}}">{{.Org.Website}}</a></div>{{end}}
 			</div>
 		</div>

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -7,7 +7,7 @@
 		<div id="org-info">
 			<div class="ui header">
 				{{.Org.DisplayName}}
-				{{if .IsOrganizationOwner}}<a class="middle text grey" href="{{.OrgLink}}/settings">{{svg "octicon-gear" 16 16}}</a>{{end}}
+				{{if .IsOrganizationOwner}}<a class="middle text grey" href="{{.OrgLink}}/settings">{{svg "octicon-gear" 14 16}}</a>{{end}}
 			</div>
 			{{if .Org.Description}}<p class="desc">{{.Org.Description}}</p>{{end}}
 			<div class="text grey meta">

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -34,7 +34,7 @@
 							{{$.i18n.Tr "org.members.member_role"}}
 						</div>
 						<div class="meta">
-							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock" 16 16}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
+							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock" 14 16}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
 						</div>
 					</div>
 					<div class="ui one wide column center">
@@ -44,9 +44,9 @@
 						<div class="meta">
 							<strong>
 								{{if index $.MembersTwoFaStatus .ID}}
-									<span class="text green">{{svg "octicon-check" 16 16}}</span>
+									<span class="text green">{{svg "octicon-check" 12 16}}</span>
 								{{else}}
-									{{svg "octicon-x" 16 16}}
+									{{svg "octicon-x" 12 16}}
 								{{end}}
 							</strong>
 						</div>

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -34,7 +34,7 @@
 							{{$.i18n.Tr "org.members.member_role"}}
 						</div>
 						<div class="meta">
-							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock" 16}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
+							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock" 16 16}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
 						</div>
 					</div>
 					<div class="ui one wide column center">
@@ -44,9 +44,9 @@
 						<div class="meta">
 							<strong>
 								{{if index $.MembersTwoFaStatus .ID}}
-									<span class="text green">{{svg "octicon-check" 16}}</span>
+									<span class="text green">{{svg "octicon-check" 16 16}}</span>
 								{{else}}
-									{{svg "octicon-x" 16}}
+									{{svg "octicon-x" 16 16}}
 								{{end}}
 							</strong>
 						</div>

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -11,7 +11,7 @@
 				</h4>
 				<div class="ui attached warning segment">
 					<div class="ui red message">
-						<p class="text left">{{svg "octicon-alert" 16}} {{.i18n.Tr "org.settings.delete_prompt" | Str2html}}</p>
+						<p class="text left">{{svg "octicon-alert" 16 16}} {{.i18n.Tr "org.settings.delete_prompt" | Str2html}}</p>
 					</div>
 					<form class="ui form ignore-dirty" id="delete-form" action="{{.Link}}" method="post">
 						{{.CsrfTokenHtml}}

--- a/templates/org/team/navbar.tmpl
+++ b/templates/org/team/navbar.tmpl
@@ -1,4 +1,4 @@
 <div class="ui top attached tabular menu">
-  <a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}">{{svg "octicon-person" 16 16}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.i18n.Tr "org.lower_members"}}</a>
+  <a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}">{{svg "octicon-person" 12 16}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.i18n.Tr "org.lower_members"}}</a>
   <a class="item{{if .PageIsOrgTeamRepos}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/repositories">{{svg "octicon-repo" 12 16}} <strong>{{.Team.NumRepos}}</strong>&nbsp; {{$.i18n.Tr "org.lower_repositories"}}</a>
 </div>

--- a/templates/org/team/navbar.tmpl
+++ b/templates/org/team/navbar.tmpl
@@ -1,4 +1,4 @@
 <div class="ui top attached tabular menu">
-  <a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}">{{svg "octicon-person" 16}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.i18n.Tr "org.lower_members"}}</a>
-  <a class="item{{if .PageIsOrgTeamRepos}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/repositories">{{svg "octicon-repo" 16}} <strong>{{.Team.NumRepos}}</strong>&nbsp; {{$.i18n.Tr "org.lower_repositories"}}</a>
+  <a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}">{{svg "octicon-person" 16 16}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.i18n.Tr "org.lower_members"}}</a>
+  <a class="item{{if .PageIsOrgTeamRepos}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/repositories">{{svg "octicon-repo" 12 16}} <strong>{{.Team.NumRepos}}</strong>&nbsp; {{$.i18n.Tr "org.lower_repositories"}}</a>
 </div>

--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -42,13 +42,13 @@
 							{{end}}
 							<a class="member" href="{{AppSubUrl}}/{{$.Org.Name}}/{{.Name}}">
 								{{if .IsPrivate}}
-									{{svg "octicon-lock" 16}}
+									{{svg "octicon-lock" 12 16}}
 								{{else if .IsFork}}
-									{{svg "octicon-repo-forked" 16}}
+									{{svg "octicon-repo-forked" 10 16}}
 								{{else if .IsMirror}}
-									{{svg "octicon-repo-clone" 16}}
+									{{svg "octicon-repo-clone" 16 16}}
 								{{else}}
-									{{svg "octicon-repo" 16}}
+									{{svg "octicon-repo" 12 16}}
 								{{end}}
 								<strong>{{$.Org.Name}}/{{.Name}}</strong>
 							</a>

--- a/templates/org/team/sidebar.tmpl
+++ b/templates/org/team/sidebar.tmpl
@@ -55,7 +55,7 @@
 	</div>
 	{{if .IsOrganizationOwner}}
 		<div class="ui bottom attached segment">
-			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/edit">{{svg "octicon-gear" 16}} {{$.i18n.Tr "org.teams.settings"}}</a>
+			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/edit">{{svg "octicon-gear" 16 16}} {{$.i18n.Tr "org.teams.settings"}}</a>
 		</div>
 	{{end}}
 </div>

--- a/templates/org/team/sidebar.tmpl
+++ b/templates/org/team/sidebar.tmpl
@@ -55,7 +55,7 @@
 	</div>
 	{{if .IsOrganizationOwner}}
 		<div class="ui bottom attached segment">
-			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/edit">{{svg "octicon-gear" 16 16}} {{$.i18n.Tr "org.teams.settings"}}</a>
+			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName}}/edit">{{svg "octicon-gear" 14 16}} {{$.i18n.Tr "org.teams.settings"}}</a>
 		</div>
 	{{end}}
 </div>

--- a/templates/org/team/teams.tmpl
+++ b/templates/org/team/teams.tmpl
@@ -5,7 +5,7 @@
 		{{template "base/alert" .}}
 		{{if .IsOrganizationOwner}}
 			<div class="text right">
-				<a class="ui green button" href="{{.OrgLink}}/teams/new">{{svg "octicon-plus" 16}} {{.i18n.Tr "org.create_new_team"}}</a>
+				<a class="ui green button" href="{{.OrgLink}}/teams/new">{{svg "octicon-plus" 12 16}} {{.i18n.Tr "org.create_new_team"}}</a>
 			</div>
 			<div class="ui divider"></div>
 		{{end}}

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -67,7 +67,7 @@
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n") }}
 				</a>
 				<a href="#proposed-pull-requests" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-git-branch" 16 16}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
+					<span class="text green">{{svg "octicon-git-branch" 10 16}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRCount "repo.activity.opened_prs_count_1" "repo.activity.opened_prs_count_n") }}
 				</a>
 			{{end}}
@@ -155,7 +155,7 @@
 
 		{{if gt .Activity.OpenedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="proposed-pull-requests">
-				<span class="text">{{svg "octicon-git-branch" 16 16}}</span>
+				<span class="text">{{svg "octicon-git-branch" 10 16}}</span>
 				{{.i18n.Tr "repo.activity.title.prs_opened_by" (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n") .Activity.OpenedPRCount) (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.OpenedPRAuthorCount) }}
 			</h4>
 			<div class="list">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -63,21 +63,21 @@
 		<div class="ui attached segment horizontal segments">
 			{{if .Permission.CanRead $.UnitTypePullRequests}}
 				<a href="#merged-pull-requests" class="ui attached segment text center">
-					<span class="text purple">{{svg "octicon-git-pull-request" 16}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
+					<span class="text purple">{{svg "octicon-git-pull-request" 16 16}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n") }}
 				</a>
 				<a href="#proposed-pull-requests" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-git-branch" 16}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
+					<span class="text green">{{svg "octicon-git-branch" 16 16}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRCount "repo.activity.opened_prs_count_1" "repo.activity.opened_prs_count_n") }}
 				</a>
 			{{end}}
 			{{if .Permission.CanRead $.UnitTypeIssues}}
 				<a href="#closed-issues" class="ui attached segment text center">
-					<span class="text red">{{svg "octicon-issue-closed" 16}}</span> <strong>{{.Activity.ClosedIssueCount}}</strong><br>
+					<span class="text red">{{svg "octicon-issue-closed" 16 16}}</span> <strong>{{.Activity.ClosedIssueCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.ClosedIssueCount "repo.activity.closed_issues_count_1" "repo.activity.closed_issues_count_n") }}
 				</a>
 				<a href="#new-issues" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-issue-opened" 16}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
+					<span class="text green">{{svg "octicon-issue-opened" 16 16}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueCount "repo.activity.new_issues_count_1" "repo.activity.new_issues_count_n") }}
 				</a>
 			{{end}}
@@ -120,7 +120,7 @@
 
 		{{if gt .Activity.PublishedReleaseCount 0}}
 			<h4 class="ui horizontal divider header" id="published-releases">
-				<span class="text">{{svg "octicon-tag" 16}}</span>
+				<span class="text">{{svg "octicon-tag" 16 16}}</span>
 				{{.i18n.Tr "repo.activity.title.releases_published_by" (.i18n.Tr (TrN .i18n.Lang .Activity.PublishedReleaseCount "repo.activity.title.releases_1" "repo.activity.title.releases_n") .Activity.PublishedReleaseCount) (.i18n.Tr (TrN .i18n.Lang .Activity.PublishedReleaseAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.PublishedReleaseAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -139,7 +139,7 @@
 
 		{{if gt .Activity.MergedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="merged-pull-requests">
-				<span class="text">{{svg "octicon-git-pull-request" 16}}</span>
+				<span class="text">{{svg "octicon-git-pull-request" 16 16}}</span>
 				{{.i18n.Tr "repo.activity.title.prs_merged_by" (.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n") .Activity.MergedPRCount) (.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.MergedPRAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -155,7 +155,7 @@
 
 		{{if gt .Activity.OpenedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="proposed-pull-requests">
-				<span class="text">{{svg "octicon-git-branch" 16}}</span>
+				<span class="text">{{svg "octicon-git-branch" 16 16}}</span>
 				{{.i18n.Tr "repo.activity.title.prs_opened_by" (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n") .Activity.OpenedPRCount) (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.OpenedPRAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -171,7 +171,7 @@
 
 		{{if gt .Activity.ClosedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="closed-issues">
-				<span class="text">{{svg "octicon-issue-closed" 16}}</span>
+				<span class="text">{{svg "octicon-issue-closed" 16 16}}</span>
 				{{.i18n.Tr "repo.activity.title.issues_closed_by" (.i18n.Tr (TrN .i18n.Lang .Activity.ClosedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n") .Activity.ClosedIssueCount) (.i18n.Tr (TrN .i18n.Lang .Activity.ClosedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.ClosedIssueAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -187,7 +187,7 @@
 
 		{{if gt .Activity.OpenedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="new-issues">
-				<span class="text">{{svg "octicon-issue-opened" 16}}</span>
+				<span class="text">{{svg "octicon-issue-opened" 16 16}}</span>
 				{{.i18n.Tr "repo.activity.title.issues_created_by" (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n") .Activity.OpenedIssueCount) (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.OpenedIssueAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -203,7 +203,7 @@
 
 		{{if gt .Activity.UnresolvedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="unresolved-conversations">
-				<span class="text">{{svg "octicon-comment-discussion" 16}}</span>
+				<span class="text">{{svg "octicon-comment-discussion" 16 16}}</span>
 				{{.i18n.Tr (TrN .i18n.Lang .Activity.UnresolvedIssueCount "repo.activity.title.unresolved_conv_1" "repo.activity.title.unresolved_conv_n") .Activity.UnresolvedIssueCount }}
 			</h4>
 			<div class="text center desc">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -63,7 +63,7 @@
 		<div class="ui attached segment horizontal segments">
 			{{if .Permission.CanRead $.UnitTypePullRequests}}
 				<a href="#merged-pull-requests" class="ui attached segment text center">
-					<span class="text purple">{{svg "octicon-git-pull-request" 16 16}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
+					<span class="text purple">{{svg "octicon-git-pull-request" 12 16}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n") }}
 				</a>
 				<a href="#proposed-pull-requests" class="ui attached segment text center">
@@ -77,7 +77,7 @@
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.ClosedIssueCount "repo.activity.closed_issues_count_1" "repo.activity.closed_issues_count_n") }}
 				</a>
 				<a href="#new-issues" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-issue-opened" 16 16}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
+					<span class="text green">{{svg "octicon-issue-opened" 14 16}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
 					{{.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueCount "repo.activity.new_issues_count_1" "repo.activity.new_issues_count_n") }}
 				</a>
 			{{end}}
@@ -139,7 +139,7 @@
 
 		{{if gt .Activity.MergedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="merged-pull-requests">
-				<span class="text">{{svg "octicon-git-pull-request" 16 16}}</span>
+				<span class="text">{{svg "octicon-git-pull-request" 12 16}}</span>
 				{{.i18n.Tr "repo.activity.title.prs_merged_by" (.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n") .Activity.MergedPRCount) (.i18n.Tr (TrN .i18n.Lang .Activity.MergedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.MergedPRAuthorCount) }}
 			</h4>
 			<div class="list">
@@ -187,7 +187,7 @@
 
 		{{if gt .Activity.OpenedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="new-issues">
-				<span class="text">{{svg "octicon-issue-opened" 16 16}}</span>
+				<span class="text">{{svg "octicon-issue-opened" 14 16}}</span>
 				{{.i18n.Tr "repo.activity.title.issues_created_by" (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n") .Activity.OpenedIssueCount) (.i18n.Tr (TrN .i18n.Lang .Activity.OpenedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n") .Activity.OpenedIssueAuthorCount) }}
 			</h4>
 			<div class="list">

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -18,14 +18,14 @@
                     </div>
                     {{if .Repository.CanEnableEditor}}
                         {{if .CanEditFile}}
-                            <a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span></a>
+                            <a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16 16}}</span></a>
                         {{else}}
-                            <span class="btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span>
+                            <span class="btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16 16}}</span>
                         {{end}}
                         {{if .CanDeleteFile}}
-                            <a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span></a>
+                            <a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16 16}}</span></a>
                         {{else}}
-                            <span class="btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span>
+                            <span class="btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16 16}}</span>
                         {{end}}
                     {{end}}
                 </div>

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -16,10 +16,10 @@
 						{{range .Branches}}
 							{{if eq .Name $.DefaultBranch}}
 								{{if .IsProtected}}
-									{{svg "octicon-shield-lock" 16}}
+									{{svg "octicon-shield-lock" 16 16}}
 								{{end}}
 								<a href="{{$.RepoLink}}/src/branch/{{$.DefaultBranch | EscapePound}}">{{$.DefaultBranch}}</a>
-								<p class="info">{{svg "octicon-git-commit" 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
+								<p class="info">{{svg "octicon-git-commit" 16 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
 							{{end}}
 						{{end}}
 						</td>
@@ -27,8 +27,8 @@
 							<div class="ui basic jump dropdown icon button poping up" data-content="{{$.i18n.Tr "repo.branch.download" ($.DefaultBranch)}}" data-variation="tiny inverted" data-position="top right">
 							  <i class="download icon"></i>
 							  <div class="menu">
-							    <a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.DefaultBranch}}.zip">{{svg "octicon-file-zip" 16}}&nbsp;ZIP</a>
-							    <a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.DefaultBranch}}.tar.gz">{{svg "octicon-file-zip" 16}}&nbsp;TAR.GZ</a>
+							    <a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.DefaultBranch}}.zip">{{svg "octicon-file-zip" 16 16}}&nbsp;ZIP</a>
+							    <a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.DefaultBranch}}.tar.gz">{{svg "octicon-file-zip" 16 16}}&nbsp;TAR.GZ</a>
 							  </div>
 							</div>
 						</td>
@@ -53,10 +53,10 @@
 										<p class="info">{{$.i18n.Tr "repo.branch.deleted_by" .DeletedBranch.DeletedBy.Name}} {{TimeSinceUnix .DeletedBranch.DeletedUnix $.i18n.Lang}}</p>
 									{{else}}
 										{{if .IsProtected}}
-											{{svg "octicon-shield-lock" 16}}
+											{{svg "octicon-shield-lock" 16 16}}
 										{{end}}
 										<a href="{{$.RepoLink}}/src/branch/{{.Name | EscapePound}}">{{.Name}}</a>
-										<p class="info">{{svg "octicon-git-commit" 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
+										<p class="info">{{svg "octicon-git-commit" 16 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
 									{{end}}
 									</td>
 									<td class="three wide ui">
@@ -77,7 +77,7 @@
 										{{if not .LatestPullRequest}}
 											{{if .IsIncluded}}
 												<a class="ui poping up orange small label" data-content="{{$.i18n.Tr "repo.branch.included_desc"}}" data-variation="tiny inverted" data-position="top right">
-													{{svg "octicon-git-pull-request" 16}} {{$.i18n.Tr "repo.branch.included"}}
+													{{svg "octicon-git-pull-request" 16 16}} {{$.i18n.Tr "repo.branch.included"}}
 												</a>
 											{{else if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{$.DefaultBranch | EscapePound}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | EscapePound}}">
@@ -93,11 +93,11 @@
 										{{else}}
 											<a href="{{.LatestPullRequest.Issue.HTMLURL}}">{{if not .LatestPullRequest.IsSameRepo}}{{.LatestPullRequest.BaseRepo.FullName}}{{end}}#{{.LatestPullRequest.Issue.Index}}</a>
 											{{if .LatestPullRequest.HasMerged}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple mini label">{{svg "octicon-git-merge" 16}} {{$.i18n.Tr "repo.pulls.merged"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple mini label">{{svg "octicon-git-merge" 16 16}} {{$.i18n.Tr "repo.pulls.merged"}}</a>
 											{{else if .LatestPullRequest.Issue.IsClosed}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
 											{{else}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
 											{{end}}
 										{{end}}
 									</td>
@@ -106,14 +106,14 @@
 											<div class="ui basic jump dropdown icon button poping up" data-content="{{$.i18n.Tr "repo.branch.download" (.Name)}}" data-variation="tiny inverted" data-position="top right">
 												<i class="download icon"></i>
 												<div class="menu">
-													<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound .Name}}.zip">{{svg "octicon-file-zip" 16}}&nbsp;ZIP</a>
-													<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound .Name}}.tar.gz">{{svg "octicon-file-zip" 16}}&nbsp;TAR.GZ</a>
+													<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound .Name}}.zip">{{svg "octicon-file-zip" 16 16}}&nbsp;ZIP</a>
+													<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound .Name}}.tar.gz">{{svg "octicon-file-zip" 16 16}}&nbsp;TAR.GZ</a>
 												</div>
 											</div>
 										{{end}}
 										{{if and $.IsWriter (not $.IsMirror) (not $.Repository.IsArchived) (not .IsProtected)}}
 											{{if .IsDeleted}}
-												<a class="ui basic jump button icon poping up undo-button" href data-url="{{$.Link}}/restore?branch_id={{.DeletedBranch.ID | urlquery}}&name={{.DeletedBranch.Name | urlquery}}" data-content="{{$.i18n.Tr "repo.branch.restore" (.Name)}}" data-variation="tiny inverted" data-position="top right"><span class="text blue">{{svg "octicon-reply" 16}}</span></a>
+												<a class="ui basic jump button icon poping up undo-button" href data-url="{{$.Link}}/restore?branch_id={{.DeletedBranch.ID | urlquery}}&name={{.DeletedBranch.Name | urlquery}}" data-content="{{$.i18n.Tr "repo.branch.restore" (.Name)}}" data-variation="tiny inverted" data-position="top right"><span class="text blue">{{svg "octicon-reply" 16 16}}</span></a>
 											{{else}}
 												<a class="ui basic jump button icon poping up delete-branch-button" href data-url="{{$.Link}}/delete?name={{.Name | urlquery}}" data-content="{{$.i18n.Tr "repo.branch.delete" (.Name)}}" data-variation="tiny inverted" data-position="top right" data-name="{{.Name}}"><i class="trash icon text red"></i></a>
 											{{end}}

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -16,7 +16,7 @@
 						{{range .Branches}}
 							{{if eq .Name $.DefaultBranch}}
 								{{if .IsProtected}}
-									{{svg "octicon-shield-lock" 16 16}}
+									{{svg "octicon-shield-lock" 14 16}}
 								{{end}}
 								<a href="{{$.RepoLink}}/src/branch/{{$.DefaultBranch | EscapePound}}">{{$.DefaultBranch}}</a>
 								<p class="info">{{svg "octicon-git-commit" 16 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
@@ -53,7 +53,7 @@
 										<p class="info">{{$.i18n.Tr "repo.branch.deleted_by" .DeletedBranch.DeletedBy.Name}} {{TimeSinceUnix .DeletedBranch.DeletedUnix $.i18n.Lang}}</p>
 									{{else}}
 										{{if .IsProtected}}
-											{{svg "octicon-shield-lock" 16 16}}
+											{{svg "octicon-shield-lock" 14 16}}
 										{{end}}
 										<a href="{{$.RepoLink}}/src/branch/{{.Name | EscapePound}}">{{.Name}}</a>
 										<p class="info">{{svg "octicon-git-commit" 16 16}}<a href="{{$.RepoLink}}/commit/{{.Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n.Lang}}</p>
@@ -77,7 +77,7 @@
 										{{if not .LatestPullRequest}}
 											{{if .IsIncluded}}
 												<a class="ui poping up orange small label" data-content="{{$.i18n.Tr "repo.branch.included_desc"}}" data-variation="tiny inverted" data-position="top right">
-													{{svg "octicon-git-pull-request" 16 16}} {{$.i18n.Tr "repo.branch.included"}}
+													{{svg "octicon-git-pull-request" 12 16}} {{$.i18n.Tr "repo.branch.included"}}
 												</a>
 											{{else if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{$.DefaultBranch | EscapePound}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | EscapePound}}">
@@ -97,7 +97,7 @@
 											{{else if .LatestPullRequest.Issue.IsClosed}}
 												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
 											{{else}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
 											{{end}}
 										{{end}}
 									</td>

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -2,7 +2,7 @@
 	<div class="ui floating filter dropdown custom" data-can-create-branch="{{.CanCreateBranch}}" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
 		<div class="ui basic small compact button" @click="menuVisible = !menuVisible" @keyup.enter="menuVisible = !menuVisible">
 			<span class="text">
-				{{svg "octicon-git-branch" 16 16}}
+				{{svg "octicon-git-branch" 10 16}}
 				{{if .IsViewBranch}}{{.i18n.Tr "repo.branch"}}{{else}}{{.i18n.Tr "repo.tree"}}{{end}}:
 				<strong>{{if .IsViewBranch}}{{.BranchName}}{{else}}{{ShortSha .BranchName}}{{end}}</strong>
 			</span>
@@ -26,7 +26,7 @@
 					<div class="two column row">
 						<a class="reference column" href="#" @click="mode = 'branches'; focusSearchField()">
 							<span class="text" :class="{black: mode == 'branches'}">
-								{{svg "octicon-git-branch" 16 16}} {{.i18n.Tr "repo.branches"}}
+								{{svg "octicon-git-branch" 10 16}} {{.i18n.Tr "repo.branches"}}
 							</span>
 						</a>
 						<a class="reference column" href="#" @click="mode = 'tags'; focusSearchField()">
@@ -42,7 +42,7 @@
 				<div class="item" v-if="showCreateNewBranch" :class="{active: active == filteredItems.length}" :ref="'listItem' + filteredItems.length">
 					<a href="#" @click="createNewBranch()">
 						<div>
-							{{svg "octicon-git-branch" 16 16}}
+							{{svg "octicon-git-branch" 10 16}}
 							{{.i18n.Tr "repo.branch.create_branch" `${ searchTerm }` | Safe}}
 						</div>
 						<div class="text small">

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -2,7 +2,7 @@
 	<div class="ui floating filter dropdown custom" data-can-create-branch="{{.CanCreateBranch}}" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
 		<div class="ui basic small compact button" @click="menuVisible = !menuVisible" @keyup.enter="menuVisible = !menuVisible">
 			<span class="text">
-				{{svg "octicon-git-branch" 16}}
+				{{svg "octicon-git-branch" 16 16}}
 				{{if .IsViewBranch}}{{.i18n.Tr "repo.branch"}}{{else}}{{.i18n.Tr "repo.tree"}}{{end}}:
 				<strong>{{if .IsViewBranch}}{{.BranchName}}{{else}}{{ShortSha .BranchName}}{{end}}</strong>
 			</span>
@@ -26,7 +26,7 @@
 					<div class="two column row">
 						<a class="reference column" href="#" @click="mode = 'branches'; focusSearchField()">
 							<span class="text" :class="{black: mode == 'branches'}">
-								{{svg "octicon-git-branch" 16}} {{.i18n.Tr "repo.branches"}}
+								{{svg "octicon-git-branch" 16 16}} {{.i18n.Tr "repo.branches"}}
 							</span>
 						</a>
 						<a class="reference column" href="#" @click="mode = 'tags'; focusSearchField()">
@@ -42,7 +42,7 @@
 				<div class="item" v-if="showCreateNewBranch" :class="{active: active == filteredItems.length}" :ref="'listItem' + filteredItems.length">
 					<a href="#" @click="createNewBranch()">
 						<div>
-							{{svg "octicon-git-branch" 16}}
+							{{svg "octicon-git-branch" 16 16}}
 							{{.i18n.Tr "repo.branch.create_branch" `${ searchTerm }` | Safe}}
 						</div>
 						<div class="text small">

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -28,7 +28,7 @@
 				<pre class="commit-body">{{RenderCommitBody .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>
 			{{end}}
 			{{if .BranchName}}
-				<span class="text grey">{{svg "octicon-git-branch" 16}}{{.BranchName}}</span>
+				<span class="text grey">{{svg "octicon-git-branch" 16 16}}{{.BranchName}}</span>
 			{{end}}
 		</div>
 		<div class="ui attached info segment {{$class}}">
@@ -48,7 +48,7 @@
 					<span class="text grey" id="authored-time">{{TimeSince .Commit.Author.When $.Lang}}</span>
 					{{if or (ne .Commit.Committer.Name .Commit.Author.Name) (ne .Commit.Committer.Email .Commit.Author.Email)}}
 						<div class="committed-by">
-							<span class="text grey">{{svg "octicon-git-commit" 16}}{{.i18n.Tr "repo.diff.committed_by"}}</span>
+							<span class="text grey">{{svg "octicon-git-commit" 16 16}}{{.i18n.Tr "repo.diff.committed_by"}}</span>
 							{{if ne .Verification.CommittingUser.ID 0}}
 								<img class="ui avatar image" src="{{.Verification.CommittingUser.RelAvatarLink}}" />
 								<a href="{{.Verification.CommittingUser.HomeLink}}"><strong>{{.Commit.Committer.Name}}</strong> &lt;{{.Commit.Committer.Email}}&gt;</a>

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -28,7 +28,7 @@
 				<pre class="commit-body">{{RenderCommitBody .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>
 			{{end}}
 			{{if .BranchName}}
-				<span class="text grey">{{svg "octicon-git-branch" 16 16}}{{.BranchName}}</span>
+				<span class="text grey">{{svg "octicon-git-branch" 10 16}}{{.BranchName}}</span>
 			{{end}}
 		</div>
 		<div class="ui attached info segment {{$class}}">

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -8,7 +8,7 @@
 			<div class="fitted item">
 				<a href="{{.RepoLink}}/graph" class="ui basic small compact button">
 					<span class="text">
-						{{svg "octicon-git-branch" 16}}
+						{{svg "octicon-git-branch" 16 16}}
 					</span>
 					{{.i18n.Tr "repo.commit_graph"}}
 				</a>

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -8,7 +8,7 @@
 			<div class="fitted item">
 				<a href="{{.RepoLink}}/graph" class="ui basic small compact button">
 					<span class="text">
-						{{svg "octicon-git-branch" 16 16}}
+						{{svg "octicon-git-branch" 10 16}}
 					</span>
 					{{.i18n.Tr "repo.commit_graph"}}
 				</a>

--- a/templates/repo/commits_list_small.tmpl
+++ b/templates/repo/commits_list_small.tmpl
@@ -5,7 +5,7 @@
 	{{ $tag := printf "%s-%d" $.comment.HashTag $index }}
 	{{ $index = Add $index 1}}
 	<div class="singular-commit" id="{{$tag}}">
-		<span class="badge badge-commit">{{svg "octicon-git-commit" 16}}</span>
+		<span class="badge badge-commit">{{svg "octicon-git-commit" 16 16}}</span>
 		{{if .User}}
 			<a class="ui avatar image" href="{{AppSubUrl}}/{{.User.Name}}"><img src="{{.User.RelAvatarLink}}" alt=""/></a>
 		{{else}}

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -21,9 +21,9 @@
 					<button class="ui blue tiny button" data-panel="#add-deploy-key-panel" data-tooltip={{.i18n.Tr "repo.commits.search.tooltip"}}>{{.i18n.Tr "repo.commits.find"}}</button>
 				</form>
 			{{else if .IsDiffCompare}}
-				<a href="{{$.CommitRepoLink}}/commit/{{.BeforeCommitID}}" class="ui green sha label">{{if not .BaseIsCommit}}{{if .BaseIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .BaseIsTag}}{{svg "octicon-tag" 16}}{{end}}{{.BaseBranch}}{{else}}{{ShortSha .BaseBranch}}{{end}}</a>
+				<a href="{{$.CommitRepoLink}}/commit/{{.BeforeCommitID}}" class="ui green sha label">{{if not .BaseIsCommit}}{{if .BaseIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .BaseIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.BaseBranch}}{{else}}{{ShortSha .BaseBranch}}{{end}}</a>
 				...
-				<a href="{{$.CommitRepoLink}}/commit/{{.AfterCommitID}}" class="ui green sha label">{{if not .HeadIsCommit}}{{if .HeadIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .HeadIsTag}}{{svg "octicon-tag" 16}}{{end}}{{.HeadBranch}}{{else}}{{ShortSha .HeadBranch}}{{end}}</a>
+				<a href="{{$.CommitRepoLink}}/commit/{{.AfterCommitID}}" class="ui green sha label">{{if not .HeadIsCommit}}{{if .HeadIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .HeadIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.HeadBranch}}{{else}}{{ShortSha .HeadBranch}}{{end}}</a>
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -21,9 +21,9 @@
 					<button class="ui blue tiny button" data-panel="#add-deploy-key-panel" data-tooltip={{.i18n.Tr "repo.commits.search.tooltip"}}>{{.i18n.Tr "repo.commits.find"}}</button>
 				</form>
 			{{else if .IsDiffCompare}}
-				<a href="{{$.CommitRepoLink}}/commit/{{.BeforeCommitID}}" class="ui green sha label">{{if not .BaseIsCommit}}{{if .BaseIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .BaseIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.BaseBranch}}{{else}}{{ShortSha .BaseBranch}}{{end}}</a>
+				<a href="{{$.CommitRepoLink}}/commit/{{.BeforeCommitID}}" class="ui green sha label">{{if not .BaseIsCommit}}{{if .BaseIsBranch}}{{svg "octicon-git-branch" 10 16}}{{else if .BaseIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.BaseBranch}}{{else}}{{ShortSha .BaseBranch}}{{end}}</a>
 				...
-				<a href="{{$.CommitRepoLink}}/commit/{{.AfterCommitID}}" class="ui green sha label">{{if not .HeadIsCommit}}{{if .HeadIsBranch}}{{svg "octicon-git-branch" 16}}{{else if .HeadIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.HeadBranch}}{{else}}{{ShortSha .HeadBranch}}{{end}}</a>
+				<a href="{{$.CommitRepoLink}}/commit/{{.AfterCommitID}}" class="ui green sha label">{{if not .HeadIsCommit}}{{if .HeadIsBranch}}{{svg "octicon-git-branch" 10 16}}{{else if .HeadIsTag}}{{svg "octicon-tag" 16 16}}{{end}}{{.HeadBranch}}{{else}}{{ShortSha .HeadBranch}}{{end}}</a>
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -10,7 +10,7 @@
       <i class="ui blob-excerpt fa fa-caret-up" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="{{$.Anchor}}"></i>
       {{end}}
       {{if eq $line.GetExpandDirection 2}}
-      <span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="{{$.Anchor}}">{{svg "octicon-fold" 16}}</span>
+      <span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="{{$.Anchor}}">{{svg "octicon-fold" 14 16}}</span>
       {{end}}
     </td>
     <td colspan="5" class="lines-code lines-code-old "><span class="mono wrap{{if $.highlightClass}} language-{{$.highlightClass}}{{else}} nohighlight{{end}}">{{$.section.GetComputedInlineDiffFor $line}}</span></td>
@@ -36,7 +36,7 @@
       <i class="ui blob-excerpt fa fa-caret-down" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=down" data-anchor="{{$.Anchor}}"></i>
       {{end}}
       {{if eq $line.GetExpandDirection 2}}
-      <span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=" data-anchor="{{$.Anchor}}">{{svg "octicon-fold" 16}}</span>
+      <span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=" data-anchor="{{$.Anchor}}">{{svg "octicon-fold" 14 16}}</span>
       {{end}}
     </td>
     {{else}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -133,7 +133,7 @@
 																		<i class="ui blob-excerpt fa fa-caret-up" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}"></i>
 																	{{end}}
 																	{{if eq $line.GetExpandDirection 2}}
-																		<span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">{{svg "octicon-fold" 16}}</span>
+																		<span class="ui blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">{{svg "octicon-fold" 14 16}}</span>
 																	{{end}}
 																</td>
 																<td colspan="5" class="lines-code lines-code-old "><span class="mono wrap{{if $highlightClass}} language-{{$highlightClass}}{{else}} nohighlight{{end}}">{{$section.GetComputedInlineDiffFor $line}}</span></td>
@@ -158,11 +158,11 @@
 																		<div class="ui top attached header">
 																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
 																			<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
-																				{{svg "octicon-unfold" 16}}
+																				{{svg "octicon-unfold" 16 16}}
 																				{{$.i18n.Tr "repo.issues.review.show_resolved"}}
 																			</button>
 																			<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-																				{{svg "octicon-fold" 16}}
+																				{{svg "octicon-fold" 14 16}}
 																				{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
 																			</button>
 																		</div>
@@ -192,15 +192,15 @@
 																<td class="add-comment-right">
 																	{{if and $resolved (eq $line.GetCommentSide "proposed")}}
 																		<div class="ui top attached header">
-																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>	
+																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
 																			<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
-																				{{svg "octicon-unfold" 16}}
+																				{{svg "octicon-unfold" 16 16}}
 																				{{$.i18n.Tr "repo.issues.review.show_resolved"}}
 																			</button>
 																			<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-																				{{svg "octicon-fold" 16}}
+																				{{svg "octicon-fold" 14 16}}
 																				{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
-																			</button>	
+																			</button>
 																		</div>
 																	{{end}}
 																	{{if eq $line.GetCommentSide "proposed"}}

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -24,7 +24,7 @@
 			</div>
 		</div>
 		<div class="field footer">
-			<span class="markdown-info">{{svg "octicon-markdown" 16}} {{$.root.i18n.Tr "repo.diff.comment.markdown_info"}}</span>
+			<span class="markdown-info">{{svg "octicon-markdown" 16 16}} {{$.root.i18n.Tr "repo.diff.comment.markdown_info"}}</span>
 			<div class="ui right">
 				{{if $.reply}}
 					<button class="ui submit green tiny button btn-reply" onclick="window.submitReply(this);">{{$.root.i18n.Tr "repo.diff.comment.reply"}}</button>

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -13,7 +13,7 @@
 			{{ end }}
 		</h2>
 		<div class="ui segment choose branch">
-			{{svg "octicon-git-compare" 16}}
+			{{svg "octicon-git-compare" 16 16}}
 			<div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
 				<div class="ui basic small button">
 					<span class="text">{{.i18n.Tr "repo.pulls.compare_base"}}: {{$.BaseName}}:{{$.BaseBranch}}</span>

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -12,7 +12,7 @@
 					<i class="ui blob-excerpt fa fa-caret-up" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}"></i>
 				{{end}}
 				{{if eq $line.GetExpandDirection 2}}
-					<span class="ui blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">{{svg "octicon-fold" 16}}</span>
+					<span class="ui blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">{{svg "octicon-fold" 14 16}}</span>
 				{{end}}
 				</td>
 			{{else}}
@@ -33,11 +33,11 @@
 					<div class = "ui attached header">
 						<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.root.i18n.Tr "repo.issues.review.resolved_by"}}</span>
 						<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
-							{{svg "octicon-unfold" 16}}
+							{{svg "octicon-unfold" 16 16}}
 								{{$.root.i18n.Tr "repo.issues.review.show_resolved"}}
 						</button>
 						<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-							{{svg "octicon-fold" 16}}
+							{{svg "octicon-fold" 14 16}}
 							{{$.root.i18n.Tr "repo.issues.review.hide_resolved"}}
 						</button>
 					</div>

--- a/templates/repo/editor/commit_form.tmpl
+++ b/templates/repo/editor/commit_form.tmpl
@@ -41,7 +41,7 @@
 						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.i18n.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
 					{{end}}
 					<label>
-						{{svg "octicon-git-pull-request" 16 16}}
+						{{svg "octicon-git-pull-request" 12 16}}
 						{{if $pullRequestEnabled}}
 							{{.i18n.Tr "repo.editor.create_new_branch" | Safe}}
 						{{else}}

--- a/templates/repo/editor/commit_form.tmpl
+++ b/templates/repo/editor/commit_form.tmpl
@@ -17,7 +17,7 @@
 				<div class="ui radio checkbox {{if not .CanCommitToBranch.CanCommitToBranch}}disabled{{end}}">
 					<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="direct" button_text="{{.i18n.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "direct"}}checked{{end}}>
 					<label>
-						{{svg "octicon-git-commit" 16}}
+						{{svg "octicon-git-commit" 16 16}}
 						{{.i18n.Tr "repo.editor.commit_directly_to_this_branch" (.BranchName|Escape) | Safe}}
 						{{if not .CanCommitToBranch.CanCommitToBranch}}
 						<div class="ui visible small warning message">
@@ -41,7 +41,7 @@
 						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.i18n.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
 					{{end}}
 					<label>
-						{{svg "octicon-git-pull-request" 16}}
+						{{svg "octicon-git-pull-request" 16 16}}
 						{{if $pullRequestEnabled}}
 							{{.i18n.Tr "repo.editor.create_new_branch" | Safe}}
 						{{else}}
@@ -52,7 +52,7 @@
 			</div>
 			<div class="quick-pull-branch-name {{if not (eq .commit_choice "commit-to-new-branch")}}hide{{end}}">
 				<div class="new-branch-name-input field {{if .Err_NewBranchName}}error{{end}}">
-					{{svg "octicon-git-branch" 16}}
+					{{svg "octicon-git-branch" 16 16}}
 					<input type="text" name="new_branch_name" value="{{.new_branch_name}}" class="input-contrast mr-2 js-quick-pull-new-branch-name" placeholder="{{.i18n.Tr "repo.editor.new_branch_name_desc"}}" {{if eq .commit_choice "commit-to-new-branch"}}required{{end}}>
 					<span class="text-muted js-quick-pull-normalization-info"></span>
 				</div>

--- a/templates/repo/editor/commit_form.tmpl
+++ b/templates/repo/editor/commit_form.tmpl
@@ -52,7 +52,7 @@
 			</div>
 			<div class="quick-pull-branch-name {{if not (eq .commit_choice "commit-to-new-branch")}}hide{{end}}">
 				<div class="new-branch-name-input field {{if .Err_NewBranchName}}error{{end}}">
-					{{svg "octicon-git-branch" 16 16}}
+					{{svg "octicon-git-branch" 10 16}}
 					<input type="text" name="new_branch_name" value="{{.new_branch_name}}" class="input-contrast mr-2 js-quick-pull-new-branch-name" placeholder="{{.i18n.Tr "repo.editor.new_branch_name_desc"}}" {{if eq .commit_choice "commit-to-new-branch"}}required{{end}}>
 					<span class="text-muted js-quick-pull-normalization-info"></span>
 				</div>

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -28,7 +28,7 @@
 			</div>
 			<div class="field">
 				<div class="ui top attached tabular menu" data-write="write" data-preview="preview" data-diff="diff">
-					<a class="active item" data-tab="write">{{svg "octicon-code" 16 16}} {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
+					<a class="active item" data-tab="write">{{svg "octicon-code" 14 16}} {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
 					{{if not .IsNewFile}}
 					<a class="item" data-tab="preview" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL | EscapePound}}" data-preview-file-modes="{{.PreviewableFileModes}}" data-markdown-mode="gfm">{{svg "octicon-eye" 16 16}} {{.i18n.Tr "preview"}}</a>
 					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | EscapePound}}/{{.TreePath | EscapePound}}" data-context="{{.BranchLink}}">{{svg "octicon-diff" 16 16}} {{.i18n.Tr "repo.editor.preview_changes"}}</a>

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -16,7 +16,7 @@
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
 								<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-editorconfig="{{$.Editorconfig}}" required autofocus>
-								<span class="poping up" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-info" 16}}</span>
+								<span class="poping up" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-info" 16 16}}</span>
 							{{else}}
 								<span class="section"><a href="{{EscapePound $.BranchLink}}/{{index $.TreePaths $i | EscapePound}}">{{$v}}</a></span>
 							{{end}}
@@ -28,10 +28,10 @@
 			</div>
 			<div class="field">
 				<div class="ui top attached tabular menu" data-write="write" data-preview="preview" data-diff="diff">
-					<a class="active item" data-tab="write">{{svg "octicon-code" 16}} {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
+					<a class="active item" data-tab="write">{{svg "octicon-code" 16 16}} {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
 					{{if not .IsNewFile}}
-					<a class="item" data-tab="preview" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL | EscapePound}}" data-preview-file-modes="{{.PreviewableFileModes}}" data-markdown-mode="gfm">{{svg "octicon-eye" 16}} {{.i18n.Tr "preview"}}</a>
-					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | EscapePound}}/{{.TreePath | EscapePound}}" data-context="{{.BranchLink}}">{{svg "octicon-diff" 16}} {{.i18n.Tr "repo.editor.preview_changes"}}</a>
+					<a class="item" data-tab="preview" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL | EscapePound}}" data-preview-file-modes="{{.PreviewableFileModes}}" data-markdown-mode="gfm">{{svg "octicon-eye" 16 16}} {{.i18n.Tr "preview"}}</a>
+					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | EscapePound}}/{{.TreePath | EscapePound}}" data-context="{{.BranchLink}}">{{svg "octicon-diff" 16 16}} {{.i18n.Tr "repo.editor.preview_changes"}}</a>
 					{{end}}
 				</div>
 				<div class="ui bottom attached active tab segment" data-tab="write">

--- a/templates/repo/editor/upload.tmpl
+++ b/templates/repo/editor/upload.tmpl
@@ -15,7 +15,7 @@
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
 								<input type="text" id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.add_subdir"}}" autofocus>
-								<span class="poping up" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-info" 16}}</span>
+								<span class="poping up" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-info" 16 16}}</span>
 							{{else}}
 								<span class="section"><a href="{{EscapePound $.BranchLink}}/{{index $.TreePaths $i | EscapePound}}">{{$v}}</a></span>
 							{{end}}

--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -35,7 +35,7 @@
 								{{end}}
 								{{if not (and $.DisableHTTP $.DisableSSH)}}
 									<button class="ui basic button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-										{{svg "octicon-clippy" 16}}
+										{{svg "octicon-clippy" 16 16}}
 									</button>
 								{{end}}
 							</div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -105,7 +105,7 @@
 
 				{{if .Permission.CanRead $.UnitTypeIssues}}
 					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
-						{{svg "octicon-issue-opened" 16 16}} {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
+						{{svg "octicon-issue-opened" 14 16}} {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
 					</a>
 				{{end}}
 
@@ -117,7 +117,7 @@
 
 				{{if and .Repository.CanEnablePulls (.Permission.CanRead $.UnitTypePullRequests)}}
 					<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
-						{{svg "octicon-git-pull-request" 16 16}} {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
+						{{svg "octicon-git-pull-request" 12 16}} {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
 					</a>
 				{{end}}
 

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -7,25 +7,25 @@
 					<img class="ui avatar image" src="{{.RelAvatarLink}}">
 				{{else if .IsTemplate}}
 					{{if .IsPrivate}}
-						{{svg "octicon-repo-template-private" 32}}
+						{{svg "octicon-repo-template-private" 28 32}}
 					{{else}}
-						{{svg "octicon-repo-template" 32}}
+						{{svg "octicon-repo-template" 28 32}}
 					{{end}}
 				{{else}}
 					{{if .IsPrivate}}
-						{{svg "octicon-lock" 32}}
+						{{svg "octicon-lock" 24 32}}
 					{{else if and (not .IsMirror) (not .IsFork) (.Owner)}}
 						{{if .Owner.Visibility.IsPrivate}}
-							{{svg "octicon-internal-repo" 32}}
+							{{svg "octicon-internal-repo" 26 32}}
 						{{else}}
-							{{svg "octicon-repo" 32}}
+							{{svg "octicon-repo" 24 32}}
 						{{end}}
 					{{else if .IsMirror}}
-						{{svg "octicon-repo-clone" 32}}
+						{{svg "octicon-repo-clone" 32 32}}
 					{{else if .IsFork}}
-						{{svg "octicon-repo-forked" 32}}
+						{{svg "octicon-repo-forked" 20 32}}
 					{{else}}
-						{{svg "octicon-repo" 32}}
+						{{svg "octicon-repo" 24 32}}
 					{{end}}
 				{{end}}
 				<a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a>
@@ -34,19 +34,19 @@
 				{{if .RelAvatarLink}}
 					{{if .IsTemplate}}
 						{{if .IsPrivate}}
-							{{svg "octicon-repo-template-private" 32}}
+							{{svg "octicon-repo-template-private" 28 32}}
 						{{else}}
-							{{svg "octicon-repo-template" 32}}
+							{{svg "octicon-repo-template" 28 32}}
 						{{end}}
 					{{else}}
 						{{if .IsPrivate}}
-							{{svg "octicon-lock" 32}}
+							{{svg "octicon-lock" 24 32}}
 						{{else if .IsMirror}}
-							{{svg "octicon-repo-clone" 32}}
+							{{svg "octicon-repo-clone" 32 32}}
 						{{else if .IsFork}}
-							{{svg "octicon-repo-forked" 32}}
+							{{svg "octicon-repo-forked" 20 32}}
 						{{else}}
-							{{svg "octicon-repo" 32}}
+							{{svg "octicon-repo" 24 32}}
 						{{end}}
 					{{end}}
 				{{end}}
@@ -82,7 +82,7 @@
 					{{if and (not .IsEmpty) ($.Permission.CanRead $.UnitTypeCode)}}
 						<div class="ui labeled button {{if and ($.IsSigned) (not $.CanSignedUserFork)}}disabled-repo-button{{end}}" tabindex="0">
 							<a class="ui compact basic button {{if or (not $.IsSigned) (not $.CanSignedUserFork)}}poping up{{end}}" {{if $.CanSignedUserFork}}href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else if $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{ else }} data-content="{{$.i18n.Tr "repo.fork_guest_user" }}" rel="nofollow" href="{{AppSubUrl}}/user/login?redirect_to={{AppSubUrl}}/repo/fork/{{.ID}}" {{end}} data-position="top center" data-variation="tiny">
-								{{svg "octicon-repo-forked" 15}}{{$.i18n.Tr "repo.fork"}}
+								{{svg "octicon-repo-forked" 15 15}}{{$.i18n.Tr "repo.fork"}}
 							</a>
 							<a class="ui basic label" href="{{.Link}}/forks">
 								{{.NumForks}}
@@ -99,43 +99,43 @@
 			<div class="ui tabular stackable menu navbar">
 				{{if .Permission.CanRead $.UnitTypeCode}}
 				<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}{{if (ne .BranchName .Repository.DefaultBranch)}}/src/{{.BranchNameSubURL | EscapePound}}{{end}}">
-					{{svg "octicon-code" 16}} {{.i18n.Tr "repo.code"}}
+					{{svg "octicon-code" 16 16}} {{.i18n.Tr "repo.code"}}
 				</a>
 				{{end}}
 
 				{{if .Permission.CanRead $.UnitTypeIssues}}
 					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
-						{{svg "octicon-issue-opened" 16}} {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
+						{{svg "octicon-issue-opened" 16 16}} {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
 					</a>
 				{{end}}
 
 				{{if .Permission.CanRead $.UnitTypeExternalTracker}}
 					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoExternalIssuesLink}}" target="_blank" rel="noopener noreferrer">
-						{{svg "octicon-link-external" 16}} {{.i18n.Tr "repo.issues"}} </span>
+						{{svg "octicon-link-external" 16 16}} {{.i18n.Tr "repo.issues"}} </span>
 					</a>
 				{{end}}
 
 				{{if and .Repository.CanEnablePulls (.Permission.CanRead $.UnitTypePullRequests)}}
 					<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
-						{{svg "octicon-git-pull-request" 16}} {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
+						{{svg "octicon-git-pull-request" 16 16}} {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
 					</a>
 				{{end}}
 
 				{{if and (.Permission.CanRead $.UnitTypeReleases) (not .IsEmptyRepo) }}
 				<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
-					{{svg "octicon-tag" 16}} {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .NumReleases}}gray{{else}}blue{{end}} small label">{{.NumReleases}}</span>
+					{{svg "octicon-tag" 16 16}} {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .NumReleases}}gray{{else}}blue{{end}} small label">{{.NumReleases}}</span>
 				</a>
 				{{end}}
 
 				{{if or (.Permission.CanRead $.UnitTypeWiki) (.Permission.CanRead $.UnitTypeExternalWiki)}}
 					<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki" {{if (.Permission.CanRead $.UnitTypeExternalWiki)}} target="_blank" rel="noopener noreferrer" {{end}}>
-						{{svg "octicon-book" 16}} {{.i18n.Tr "repo.wiki"}}
+						{{svg "octicon-book" 16 16}} {{.i18n.Tr "repo.wiki"}}
 					</a>
 				{{end}}
 
 				{{if and (.Permission.CanReadAny $.UnitTypePullRequests $.UnitTypeIssues $.UnitTypeReleases) (not .IsEmptyRepo)}}
 					<a class="{{if .PageIsActivity}}active{{end}} item" href="{{.RepoLink}}/activity">
-						{{svg "octicon-pulse" 16}} {{.i18n.Tr "repo.activity"}}
+						{{svg "octicon-pulse" 16 16}} {{.i18n.Tr "repo.activity"}}
 					</a>
 				{{end}}
 
@@ -144,7 +144,7 @@
 				{{if .Permission.IsAdmin}}
 					<div class="right menu">
 						<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
-							{{svg "octicon-tools" 16}} {{.i18n.Tr "repo.settings"}}
+							{{svg "octicon-tools" 16 16}} {{.i18n.Tr "repo.settings"}}
 						</a>
 					</div>
 				{{end}}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -99,7 +99,7 @@
 			<div class="ui tabular stackable menu navbar">
 				{{if .Permission.CanRead $.UnitTypeCode}}
 				<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}{{if (ne .BranchName .Repository.DefaultBranch)}}/src/{{.BranchNameSubURL | EscapePound}}{{end}}">
-					{{svg "octicon-code" 16 16}} {{.i18n.Tr "repo.code"}}
+					{{svg "octicon-code" 14 16}} {{.i18n.Tr "repo.code"}}
 				</a>
 				{{end}}
 

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -127,14 +127,14 @@
 						{{end}}
 						{{if or (not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH))}}
 							<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-								{{svg "octicon-clippy" 16}}
+								{{svg "octicon-clippy" 16 16}}
 							</button>
 						{{end}}
 						<div class="ui basic jump dropdown icon button poping up" data-content="{{.i18n.Tr "repo.download_archive"}}" data-variation="tiny inverted" data-position="top right">
 							<i class="download icon"></i>
 							<div class="menu">
-								<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip">{{svg "octicon-file-zip" 16}}&nbsp;ZIP</a>
-								<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.tar.gz">{{svg "octicon-file-zip" 16}}&nbsp;TAR.GZ</a>
+								<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip">{{svg "octicon-file-zip" 16 16}}&nbsp;ZIP</a>
+								<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.tar.gz">{{svg "octicon-file-zip" 16 16}}&nbsp;TAR.GZ</a>
 							</div>
 						</div>
 					</div>

--- a/templates/repo/issue/branch_selector_field.tmpl
+++ b/templates/repo/issue/branch_selector_field.tmpl
@@ -15,7 +15,7 @@
 				<div class="two column row">
 					<a class="reference column" href="#" data-target="#branch-list">
 						<span class="text black">
-							{{svg "octicon-git-branch" 16 16}} {{.i18n.Tr "repo.branches"}}
+							{{svg "octicon-git-branch" 10 16}} {{.i18n.Tr "repo.branches"}}
 						</span>
 					</a>
 					<a class="reference column" href="#" data-target="#tag-list">

--- a/templates/repo/issue/branch_selector_field.tmpl
+++ b/templates/repo/issue/branch_selector_field.tmpl
@@ -15,7 +15,7 @@
 				<div class="two column row">
 					<a class="reference column" href="#" data-target="#branch-list">
 						<span class="text black">
-							{{svg "octicon-git-branch" 16}} {{.i18n.Tr "repo.branches"}}
+							{{svg "octicon-git-branch" 16 16}} {{.i18n.Tr "repo.branches"}}
 						</span>
 					</a>
 					<a class="reference column" href="#" data-target="#tag-list">

--- a/templates/repo/issue/labels/label_list.tmpl
+++ b/templates/repo/issue/labels/label_list.tmpl
@@ -40,9 +40,9 @@
 				</div>
 				<div class="three wide column">
 					{{if $.PageIsOrgSettingsLabels}}
-						<a class="ui right open-issues" href="/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{else}}
-						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{end}}
 				</div>
 				<div class="three wide column">
@@ -82,7 +82,7 @@
 							</div>
 						</div>
 						<div class="three wide column">
-								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
+								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
 						</div>
 						<div class="three wide column">
 						</div>

--- a/templates/repo/issue/labels/label_list.tmpl
+++ b/templates/repo/issue/labels/label_list.tmpl
@@ -31,7 +31,7 @@
 			<li class="item">
 			<div class="ui grid middle aligned">
 				<div class="four wide column">
-					<div class="ui label" style="color: {{.ForegroundColor}}; background-color: {{.Color}}">{{svg "octicon-tag" 16}} {{.Name | RenderEmoji}}</div>
+					<div class="ui label" style="color: {{.ForegroundColor}}; background-color: {{.Color}}">{{svg "octicon-tag" 16 16}} {{.Name | RenderEmoji}}</div>
 				</div>
 				<div class="six wide column">
 					<div class="ui">
@@ -40,18 +40,18 @@
 				</div>
 				<div class="three wide column">
 					{{if $.PageIsOrgSettingsLabels}}
-						<a class="ui right open-issues" href="/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{else}}
-						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{end}}
 				</div>
 				<div class="three wide column">
 					{{if and (not $.PageIsOrgSettingsLabels ) (not $.Repository.IsArchived) (or $.CanWriteIssues $.CanWritePulls)}}
-						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
-						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil" 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
 					{{else if $.PageIsOrgSettingsLabels}}
-						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
-						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil" 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
 					{{end}}
 				</div>
 			</div>
@@ -74,7 +74,7 @@
 					<li class="item">
 					<div class="ui grid middle aligned">
 						<div class="three wide column">
-							<div class="ui label" style="color: {{.ForegroundColor}}; background-color: {{.Color}}">{{svg "octicon-tag" 16}} {{.Name | RenderEmoji}}</div>
+							<div class="ui label" style="color: {{.ForegroundColor}}; background-color: {{.Color}}">{{svg "octicon-tag" 16 16}} {{.Name | RenderEmoji}}</div>
 						</div>
 						<div class="seven wide column">
 							<div class="ui">
@@ -82,7 +82,7 @@
 							</div>
 						</div>
 						<div class="three wide column">
-								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
+								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
 						</div>
 						<div class="three wide column">
 						</div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -30,11 +30,11 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16}}
+						{{svg "octicon-issue-opened" 16 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-closed" 16}}
+						{{svg "octicon-issue-closed" 16 16}}
 						{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
 					</a>
 				</div>
@@ -51,7 +51,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if .IsSelected}}{{svg "octicon-check" 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if .IsSelected}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>
@@ -124,11 +124,11 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16}}
+						{{svg "octicon-issue-opened" 16 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-closed" 16}}
+						{{svg "octicon-issue-closed" 16 16}}
 						{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
 					</a>
 				</div>
@@ -155,7 +155,7 @@
 						<div class="menu">
 							{{range .Labels}}
 								<div class="item issue-action" data-action="toggle" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/labels">
-									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 								</div>
 							{{end}}
 						</div>
@@ -224,11 +224,11 @@
 					{{end}}
 
 					{{if .NumComments}}
-						<span class="comment ui right">{{svg "octicon-comment" 16}} {{.NumComments}}</span>
+						<span class="comment ui right">{{svg "octicon-comment" 16 16}} {{.NumComments}}</span>
 					{{end}}
 
 					{{if .TotalTrackedTime}}
-						<span class="comment ui right">{{svg "octicon-clock" 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+						<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 					{{end}}
 
 					<p class="desc">
@@ -243,24 +243,24 @@
 
 						{{if .Milestone}}
 							<a class="milestone" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.Milestone.ID}}&assignee={{$.AssigneeID}}">
-								{{svg "octicon-milestone" 16}} {{.Milestone.Name}}
+								{{svg "octicon-milestone" 16 16}} {{.Milestone.Name}}
 							</a>
 						{{end}}
 						{{if .Ref}}
 							<a class="ref" href="{{index $.IssueRefURLs .ID}}">
-								{{svg "octicon-git-branch" 16}} {{index $.IssueRefEndNames .ID}}
+								{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
 							</a>
 						{{end}}
 						{{$tasks := .GetTasks}}
 						{{if gt $tasks 0}}
 							{{$tasksDone := .GetTasksDone}}
 							<span class="checklist">
-								{{svg "octicon-checklist" 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
+								{{svg "octicon-checklist" 16 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
 							</span>
 						{{end}}
 						{{if ne .DeadlineUnix 0}}
 							<span class="due-date poping up" data-content="{{$.i18n.Tr "repo.issues.due_date"}}" data-variation="tiny inverted" data-position="right center">
-								{{svg "octicon-calendar" 16}}<span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
+								{{svg "octicon-calendar" 16 16}}<span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
 							</span>
 						{{end}}
 						{{range .Assignees}}
@@ -273,25 +273,25 @@
 							{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 							{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 							{{if gt $approveOfficial 0}}
-								<span class="approvals">{{svg "octicon-check" 16}}
+								<span class="approvals">{{svg "octicon-check" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 								</span>
 							{{end}}
 
 							{{if gt $rejectOfficial 0}}
-								<span class="rejects">{{svg "octicon-request-changes" 16}}
+								<span class="rejects">{{svg "octicon-request-changes" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $rejectOfficial "repo.pulls.reject_count_1" "repo.pulls.reject_count_n") $rejectOfficial}}
 								</span>
 							{{end}}
 
 							{{if gt $waitingOfficial 0}}
-								<span class="waiting">{{svg "octicon-eye" 16}}
+								<span class="waiting">{{svg "octicon-eye" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n") $waitingOfficial}}
 								</span>
 							{{end}}
 
 							{{if and (not .PullRequest.HasMerged) (gt (len .PullRequest.ConflictedFiles) 0)}}
-								<span class="conflicting">{{svg "octicon-mirror" 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
+								<span class="conflicting">{{svg "octicon-mirror" 16 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
 							{{end}}
 						{{end}}
 					</p>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -51,7 +51,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if .IsSelected}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 14 16}}{{else if .IsSelected}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -30,7 +30,7 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16 16}}
+						{{svg "octicon-issue-opened" 14 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
@@ -51,7 +51,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if .IsSelected}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if .IsSelected}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>
@@ -124,7 +124,7 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16 16}}
+						{{svg "octicon-issue-opened" 14 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
@@ -155,7 +155,7 @@
 						<div class="menu">
 							{{range .Labels}}
 								<div class="item issue-action" data-action="toggle" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/labels">
-									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 								</div>
 							{{end}}
 						</div>
@@ -243,7 +243,7 @@
 
 						{{if .Milestone}}
 							<a class="milestone" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.Milestone.ID}}&assignee={{$.AssigneeID}}">
-								{{svg "octicon-milestone" 16 16}} {{.Milestone.Name}}
+								{{svg "octicon-milestone" 14 16}} {{.Milestone.Name}}
 							</a>
 						{{end}}
 						{{if .Ref}}
@@ -273,7 +273,7 @@
 							{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 							{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 							{{if gt $approveOfficial 0}}
-								<span class="approvals">{{svg "octicon-check" 16 16}}
+								<span class="approvals">{{svg "octicon-check" 12 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 								</span>
 							{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -228,7 +228,7 @@
 					{{end}}
 
 					{{if .TotalTrackedTime}}
-						<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+						<span class="comment ui right">{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 					{{end}}
 
 					<p class="desc">
@@ -248,7 +248,7 @@
 						{{end}}
 						{{if .Ref}}
 							<a class="ref" href="{{index $.IssueRefURLs .ID}}">
-								{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
+								{{svg "octicon-git-branch" 10 16}} {{index $.IssueRefEndNames .ID}}
 							</a>
 						{{end}}
 						{{$tasks := .GetTasks}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -40,7 +40,7 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16 16}}
+						{{svg "octicon-issue-opened" 14 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
@@ -61,7 +61,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>
@@ -118,7 +118,7 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16 16}}
+						{{svg "octicon-issue-opened" 14 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
@@ -149,7 +149,7 @@
 						<div class="menu">
 							{{range .Labels}}
 								<div class="item issue-action" data-action="toggle" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/labels">
-									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 								</div>
 							{{end}}
 						</div>
@@ -243,7 +243,7 @@
 							{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 							{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 							{{if gt $approveOfficial 0}}
-								<span class="approvals">{{svg "octicon-check" 16 16}}
+								<span class="approvals">{{svg "octicon-check" 12 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 								</span>
 							{{end}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -61,7 +61,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 14 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 12 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -22,7 +22,7 @@
             <div class="column">
                 {{ $closedDate:= TimeSinceUnix .Milestone.ClosedDateUnix $.Lang }}
                 {{if .IsClosed}}
-					{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+					{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
                 {{else}}
 					{{svg "octicon-calendar" 16 16}}
                     {{if .Milestone.DeadlineString}}
@@ -204,7 +204,7 @@
 					{{end}}
 
 					{{if .TotalTrackedTime}}
-						<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+						<span class="comment ui right">{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 					{{end}}
 
 					<p class="desc">
@@ -219,7 +219,7 @@
 
 						{{if .Ref}}
 							<a class="ref" href="{{index $.IssueRefURLs .ID}}">
-								{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
+								{{svg "octicon-git-branch" 10 16}} {{index $.IssueRefEndNames .ID}}
 							</a>
 						{{end}}
 						{{$tasks := .GetTasks}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -22,9 +22,9 @@
             <div class="column">
                 {{ $closedDate:= TimeSinceUnix .Milestone.ClosedDateUnix $.Lang }}
                 {{if .IsClosed}}
-					{{svg "octicon-clock" 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+					{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
                 {{else}}
-					{{svg "octicon-calendar" 16}}
+					{{svg "octicon-calendar" 16 16}}
                     {{if .Milestone.DeadlineString}}
                         <span {{if .IsOverdue}}class="overdue"{{end}}>{{.Milestone.DeadlineString}}</span>
                     {{else}}
@@ -40,11 +40,11 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16}}
+						{{svg "octicon-issue-opened" 16 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-closed" 16}}
+						{{svg "octicon-issue-closed" 16 16}}
 						{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
 					</a>
 				</div>
@@ -61,7 +61,7 @@
 							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
-								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
+								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.ID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash" 16}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
 						</div>
 					</div>
@@ -118,11 +118,11 @@
 			<div class="six wide column">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state=open&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-opened" 16}}
+						{{svg "octicon-issue-opened" 16 16}}
 						{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&assignee={{.AssigneeID}}">
-						{{svg "octicon-issue-closed" 16}}
+						{{svg "octicon-issue-closed" 16 16}}
 						{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
 					</a>
 				</div>
@@ -149,7 +149,7 @@
 						<div class="menu">
 							{{range .Labels}}
 								<div class="item issue-action" data-action="toggle" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/labels">
-									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+									{{if contain $.SelLabelIDs .ID}}{{svg "octicon-check" 16 16}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 								</div>
 							{{end}}
 						</div>
@@ -200,11 +200,11 @@
 					{{end}}
 
 					{{if .NumComments}}
-						<span class="comment ui right">{{svg "octicon-comment" 16}} {{.NumComments}}</span>
+						<span class="comment ui right">{{svg "octicon-comment" 16 16}} {{.NumComments}}</span>
 					{{end}}
 
 					{{if .TotalTrackedTime}}
-						<span class="comment ui right">{{svg "octicon-clock" 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+						<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 					{{end}}
 
 					<p class="desc">
@@ -219,18 +219,18 @@
 
 						{{if .Ref}}
 							<a class="ref" href="{{index $.IssueRefURLs .ID}}">
-								{{svg "octicon-git-branch" 16}} {{index $.IssueRefEndNames .ID}}
+								{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
 							</a>
 						{{end}}
 						{{$tasks := .GetTasks}}
 						{{if gt $tasks 0}}
 							{{$tasksDone := .GetTasksDone}}
 							<span class="checklist">
-								{{svg "octicon-checklist" 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
+								{{svg "octicon-checklist" 16 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
 							</span>
 						{{end}}
 						{{if ne .DeadlineUnix 0}}
-							{{svg "octicon-calendar" 16}}
+							{{svg "octicon-calendar" 16 16}}
 							<span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
 						{{end}}
 						{{range .Assignees}}
@@ -243,25 +243,25 @@
 							{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 							{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 							{{if gt $approveOfficial 0}}
-								<span class="approvals">{{svg "octicon-check" 16}}
+								<span class="approvals">{{svg "octicon-check" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 								</span>
 							{{end}}
 
 							{{if gt $rejectOfficial 0}}
-								<span class="rejects">{{svg "octicon-request-changes" 16}}
+								<span class="rejects">{{svg "octicon-request-changes" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $rejectOfficial "repo.pulls.reject_count_1" "repo.pulls.reject_count_n") $rejectOfficial}}
 								</span>
 							{{end}}
 
 							{{if gt $waitingOfficial 0}}
-								<span class="waiting">{{svg "octicon-eye" 16}}
+								<span class="waiting">{{svg "octicon-eye" 16 16}}
 									{{$.i18n.Tr (TrN $.i18n.Lang $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n") $waitingOfficial}}
 								</span>
 							{{end}}
 
 							{{if and (not .PullRequest.HasMerged) (gt (len .PullRequest.ConflictedFiles) 0)}}
-								<span class="conflicting">{{svg "octicon-mirror" 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
+								<span class="conflicting">{{svg "octicon-mirror" 16 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
 							{{end}}
 						{{end}}
 					</p>

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -14,11 +14,11 @@
 		{{template "base/alert" .}}
 		<div class="ui tiny basic buttons">
 			<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.RepoLink}}/milestones?state=open">
-				{{svg "octicon-milestone" 16 16}}
+				{{svg "octicon-milestone" 14 16}}
 				{{.i18n.Tr "repo.milestones.open_tab" .OpenCount}}
 			</a>
 			<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.RepoLink}}/milestones?state=closed">
-				{{svg "octicon-milestone" 16 16}}
+				{{svg "octicon-milestone" 14 16}}
 				{{.i18n.Tr "repo.milestones.close_tab" .ClosedCount}}
 			</a>
 		</div>
@@ -43,7 +43,7 @@
 		<div class="milestone list">
 			{{range .Milestones}}
 				<li class="item">
-					{{svg "octicon-milestone" 16 16}} <a href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
+					{{svg "octicon-milestone" 14 16}} <a href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
 					<div class="ui right green progress" data-percent="{{.Completeness}}">
 						<div class="bar" {{if not .Completeness}}style="background-color: transparent"{{end}}>
 							<div class="progress"></div>
@@ -62,7 +62,7 @@
 							{{end}}
 						{{end}}
 						<span class="issue-stats">
-							{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.open_tab" .NumOpenIssues}}
+							{{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.issues.open_tab" .NumOpenIssues}}
 							{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.issues.close_tab" .NumClosedIssues}}
 							{{if .TotalTrackedTime}}{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
 						</span>
@@ -71,9 +71,9 @@
 						<div class="ui right operate">
 							<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
 							{{if .IsClosed}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check" 16 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check" 12 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
 							{{else}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x" 16 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x" 12 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
 							{{end}}
 							<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
 						</div>

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -52,7 +52,7 @@
 					<div class="meta">
 						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.Lang }}
 						{{if .IsClosed}}
-							{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+							{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
 						{{else}}
 							{{svg "octicon-calendar" 16 16}}
 							{{if .DeadlineString}}
@@ -64,7 +64,7 @@
 						<span class="issue-stats">
 							{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.open_tab" .NumOpenIssues}}
 							{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.issues.close_tab" .NumClosedIssues}}
-							{{if .TotalTrackedTime}}{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
+							{{if .TotalTrackedTime}}{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
 						</span>
 					</div>
 					{{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -14,11 +14,11 @@
 		{{template "base/alert" .}}
 		<div class="ui tiny basic buttons">
 			<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.RepoLink}}/milestones?state=open">
-				{{svg "octicon-milestone" 16}}
+				{{svg "octicon-milestone" 16 16}}
 				{{.i18n.Tr "repo.milestones.open_tab" .OpenCount}}
 			</a>
 			<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.RepoLink}}/milestones?state=closed">
-				{{svg "octicon-milestone" 16}}
+				{{svg "octicon-milestone" 16 16}}
 				{{.i18n.Tr "repo.milestones.close_tab" .ClosedCount}}
 			</a>
 		</div>
@@ -43,7 +43,7 @@
 		<div class="milestone list">
 			{{range .Milestones}}
 				<li class="item">
-					{{svg "octicon-milestone" 16}} <a href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
+					{{svg "octicon-milestone" 16 16}} <a href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
 					<div class="ui right green progress" data-percent="{{.Completeness}}">
 						<div class="bar" {{if not .Completeness}}style="background-color: transparent"{{end}}>
 							<div class="progress"></div>
@@ -52,9 +52,9 @@
 					<div class="meta">
 						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.Lang }}
 						{{if .IsClosed}}
-							{{svg "octicon-clock" 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+							{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
 						{{else}}
-							{{svg "octicon-calendar" 16}}
+							{{svg "octicon-calendar" 16 16}}
 							{{if .DeadlineString}}
 								<span {{if .IsOverdue}}class="overdue"{{end}}>{{.DeadlineString}}</span>
 							{{else}}
@@ -62,20 +62,20 @@
 							{{end}}
 						{{end}}
 						<span class="issue-stats">
-							{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.open_tab" .NumOpenIssues}}
-							{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.issues.close_tab" .NumClosedIssues}}
-							{{if .TotalTrackedTime}}{{svg "octicon-clock" 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
+							{{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.issues.open_tab" .NumOpenIssues}}
+							{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.issues.close_tab" .NumClosedIssues}}
+							{{if .TotalTrackedTime}}{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
 						</span>
 					</div>
 					{{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}
 						<div class="ui right operate">
-							<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+							<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
 							{{if .IsClosed}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check" 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check" 16 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
 							{{else}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x" 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x" 16 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
 							{{end}}
-							<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+							<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
 						</div>
 					{{end}}
 					{{if .Content}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -42,7 +42,7 @@
 				<span class="text">
 					<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
-						{{svg "octicon-gear" 16}}
+						{{svg "octicon-gear" 16 16}}
 					{{end}}
 				</span>
 				<div class="filter menu" data-id="#label_ids">
@@ -56,13 +56,13 @@
 					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 					{{if or .Labels .OrgLabels}}
 						{{range .Labels}}
-							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 							{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 						{{end}}
-					
+
 						<div class="ui divider"></div>
 						{{range .OrgLabels}}
-							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 							{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 						{{end}}
 					{{else}}
@@ -87,7 +87,7 @@
 				<span class="text">
 					<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
-						{{svg "octicon-gear" 16}}
+						{{svg "octicon-gear" 16 16}}
 					{{end}}
 				</span>
 				<div class="menu">
@@ -107,7 +107,7 @@
 						{{if .OpenMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{svg "octicon-milestone" 16}}
+								{{svg "octicon-milestone" 16 16}}
 								{{.i18n.Tr "repo.issues.new.open_milestone"}}
 							</div>
 							{{range .OpenMilestones}}
@@ -117,7 +117,7 @@
 						{{if .ClosedMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{svg "octicon-milestone" 16}}
+								{{svg "octicon-milestone" 16 16}}
 								{{.i18n.Tr "repo.issues.new.closed_milestone"}}
 							</div>
 							{{range .ClosedMilestones}}
@@ -143,7 +143,7 @@
 					<span class="text">
 						<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
 						{{if .HasIssuesOrPullsWritePermission}}
-							{{svg "octicon-gear" 16}}
+							{{svg "octicon-gear" 16 16}}
 						{{end}}
 					</span>
 					<div class="filter menu" data-id="#assignee_ids">
@@ -155,7 +155,7 @@
 						<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignees"}}</div>
 						{{range .Assignees}}
 							<a class="item" href="#" data-id="{{.ID}}" data-id-selector="#assignee_{{.ID}}">
-								<span class="octicon-check invisible">{{svg "octicon-check" 16}}</span>
+								<span class="octicon-check invisible">{{svg "octicon-check" 16 16}}</span>
 								<span class="text">
 									<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 								</span>

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -42,7 +42,7 @@
 				<span class="text">
 					<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
-						{{svg "octicon-gear" 16 16}}
+						{{svg "octicon-gear" 14 16}}
 					{{end}}
 				</span>
 				<div class="filter menu" data-id="#label_ids">
@@ -56,13 +56,13 @@
 					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 					{{if or .Labels .OrgLabels}}
 						{{range .Labels}}
-							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 							{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 						{{end}}
 
 						<div class="ui divider"></div>
 						{{range .OrgLabels}}
-							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 							{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 						{{end}}
 					{{else}}
@@ -87,7 +87,7 @@
 				<span class="text">
 					<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
-						{{svg "octicon-gear" 16 16}}
+						{{svg "octicon-gear" 14 16}}
 					{{end}}
 				</span>
 				<div class="menu">
@@ -107,7 +107,7 @@
 						{{if .OpenMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{svg "octicon-milestone" 16 16}}
+								{{svg "octicon-milestone" 14 16}}
 								{{.i18n.Tr "repo.issues.new.open_milestone"}}
 							</div>
 							{{range .OpenMilestones}}
@@ -117,7 +117,7 @@
 						{{if .ClosedMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{svg "octicon-milestone" 16 16}}
+								{{svg "octicon-milestone" 14 16}}
 								{{.i18n.Tr "repo.issues.new.closed_milestone"}}
 							</div>
 							{{range .ClosedMilestones}}
@@ -143,7 +143,7 @@
 					<span class="text">
 						<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
 						{{if .HasIssuesOrPullsWritePermission}}
-							{{svg "octicon-gear" 16 16}}
+							{{svg "octicon-gear" 14 16}}
 						{{end}}
 					</span>
 					<div class="filter menu" data-id="#assignee_ids">
@@ -155,7 +155,7 @@
 						<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignees"}}</div>
 						{{range .Assignees}}
 							<a class="item" href="#" data-id="{{.ID}}" data-id-selector="#assignee_{{.ID}}">
-								<span class="octicon-check invisible">{{svg "octicon-check" 16 16}}</span>
+								<span class="octicon-check invisible">{{svg "octicon-check" 12 16}}</span>
 								<span class="text">
 									<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 								</span>

--- a/templates/repo/issue/view_content/add_reaction.tmpl
+++ b/templates/repo/issue/view_content/add_reaction.tmpl
@@ -1,8 +1,8 @@
 {{if .ctx.IsSigned}}
 <div class="item action ui pointing top right select-reaction dropdown" data-action-url="{{ .ActionURL }}">
 	<a class="add-reaction">
-		{{svg "octicon-plus-small" 16}}
-		{{svg "octicon-smiley" 16}}
+		{{svg "octicon-plus-small" 7 16}}
+		{{svg "octicon-smiley" 16 16}}
 	</a>
 	<div class="menu">
 		<div class="header">{{ .ctx.i18n.Tr "repo.pick_reaction"}}</div>

--- a/templates/repo/issue/view_content/attachments.tmpl
+++ b/templates/repo/issue/view_content/attachments.tmpl
@@ -2,9 +2,9 @@
 <div class="twelve wide column" style="padding: 6px;">
 	<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
 	{{if FilenameIsImage .Name}}
-		<span class="ui image">{{svg "octicon-file-media" 16}}</span>
+		<span class="ui image">{{svg "octicon-file-media" 16 16}}</span>
 	{{else}}
-		<span class="ui image">{{svg "octicon-desktop-download" 16}}</span>
+		<span class="ui image">{{svg "octicon-desktop-download" 16 16}}</span>
 	{{end}}
 		<span><strong>{{.Name}}</strong></span>
 	</a>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -70,7 +70,7 @@
 		</div>
 	{{else if eq .Type 1}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-primitive-dot" 16}}</span>
+			<span class="badge">{{svg "octicon-primitive-dot" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -85,7 +85,7 @@
 		</div>
 	{{else if eq .Type 2}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-circle-slash" 16}}</span>
+			<span class="badge">{{svg "octicon-circle-slash" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -100,7 +100,7 @@
 		</div>
 	{{else if eq .Type 28}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge purple">{{svg "octicon-git-merge" 16}}</span>
+			<span class="badge purple">{{svg "octicon-git-merge" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -125,7 +125,7 @@
 		{{end}}
 		{{ $createdStr:= TimeSinceUnix .CreatedUnix $.Lang }}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-bookmark" 16}}</span>
+			<span class="badge">{{svg "octicon-bookmark" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -142,7 +142,7 @@
 		</div>
 	{{else if eq .Type 4}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-bookmark" 16}}</span>
+			<span class="badge">{{svg "octicon-bookmark" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -151,14 +151,14 @@
 				{{$.i18n.Tr "repo.issues.commit_ref_at" .EventTag $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-git-commit" 16}}
+				{{svg "octicon-git-commit" 16 16}}
 				<span class="text grey">{{.Content | Str2html}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 7}}
 		{{if .Label}}
 			<div class="timeline-item event" id="{{.HashTag}}">
-				<span class="badge">{{svg "octicon-tag" 16}}</span>
+				<span class="badge">{{svg "octicon-tag" 16 16}}</span>
 				<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 					<img src="{{.Poster.RelAvatarLink}}">
 				</a>
@@ -170,7 +170,7 @@
 		{{end}}
 	{{else if eq .Type 8}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-milestone" 16}}</span>
+			<span class="badge">{{svg "octicon-milestone" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -181,7 +181,7 @@
 		</div>
 	{{else if eq .Type 9}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-person" 16}}</span>
+			<span class="badge">{{svg "octicon-person" 16 16}}</span>
 			{{if gt .AssigneeID 0}}
 				{{if .RemovedAssignee}}
 					<a class="ui avatar image" href="{{.Assignee.HomeLink}}">
@@ -212,7 +212,7 @@
 		</div>
 	{{else if eq .Type 10}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-pencil" 16}}</span>
+			<span class="badge">{{svg "octicon-pencil" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -223,7 +223,7 @@
 		</div>
 	{{else if eq .Type 11}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-git-branch" 16}}</span>
+			<span class="badge">{{svg "octicon-git-branch" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -234,7 +234,7 @@
 		</div>
 	{{else if eq .Type 12}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -245,7 +245,7 @@
 		</div>
 	{{else if eq .Type 13}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -254,13 +254,13 @@
 				{{$.i18n.Tr "repo.issues.stop_tracking_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16}}
+				{{svg "octicon-clock" 16 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 14}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -269,13 +269,13 @@
 				{{$.i18n.Tr "repo.issues.add_time_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16}}
+				{{svg "octicon-clock" 16 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 15}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -286,7 +286,7 @@
 		</div>
 	{{else if eq .Type 16}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -297,7 +297,7 @@
 		</div>
 	{{else if eq .Type 17}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -308,7 +308,7 @@
 		</div>
 	{{else if eq .Type 18}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -319,7 +319,7 @@
 		</div>
 	{{else if eq .Type 19}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-dependent" 16}}</span>
+			<span class="badge">{{svg "octicon-dependent" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -329,7 +329,7 @@
 			</span>
 			{{if .DependentIssue}}
 				<div class="detail">
-					{{svg "octicon-plus" 16}}
+					{{svg "octicon-plus" 12 16}}
 					<span class="text grey">
 						<a href="{{.DependentIssue.HTMLURL}}">
 							{{if eq .DependentIssue.RepoID .Issue.RepoID}}
@@ -344,7 +344,7 @@
 		</div>
 	{{else if eq .Type 20}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-dependent" 16}}</span>
+			<span class="badge">{{svg "octicon-dependent" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -354,7 +354,7 @@
 			</span>
 			{{if .DependentIssue}}
 				<div class="detail">
-					<span class="text grey">{{svg "octicon-trashcan" 16}}</span>
+					<span class="text grey">{{svg "octicon-trashcan" 16 16}}</span>
 					<span class="text grey">
 						<a href="{{.DependentIssue.HTMLURL}}">
 							{{if eq .DependentIssue.RepoID .Issue.RepoID}}
@@ -379,7 +379,7 @@
 				<span class="badge {{if eq .Review.Type 1}}green
 				{{- else if eq .Review.Type 2}}grey
 				{{- else if eq .Review.Type 3}}red
-				{{- else}}grey{{end}}">{{svg (printf "octicon-%s" .Review.Type.Icon) 16}}</span>
+				{{- else}}grey{{end}}">{{svg (printf "octicon-%s" .Review.Type.Icon) 16 16}}</span>
 				<span class="text grey">
 					{{if .OriginalAuthor }}
 						<span class="text black"><i class="fa {{MigrationIcon $.Repository.GetOriginalURLHostname}}" aria-hidden="true"></i> {{ .OriginalAuthor }}</span><span class="text grey"> {{if $.Repository.OriginalURL}}</span><span class="text migrate">({{$.i18n.Tr "repo.migrated_from" $.Repository.OriginalURL $.Repository.GetOriginalURLHostname | Safe }}){{end}}</span>
@@ -437,7 +437,7 @@
 									{{$isNotPending := (not (eq (index $comms 0).Review.Type 0))}}
 								{{if or $invalid $resolved}}
 									<button id="show-outdated-{{(index $comms 0).ID}}" data-comment="{{(index $comms 0).ID}}" class="ui compact right labeled button show-outdated">
-										{{svg "octicon-unfold" 16}}
+										{{svg "octicon-unfold" 16 16}}
 										{{if $invalid }}
 											{{$.i18n.Tr "repo.issues.review.show_outdated"}}
 										{{else}}
@@ -445,7 +445,7 @@
 										{{end}}
 									</button>
 									<button id="hide-outdated-{{(index $comms 0).ID}}" data-comment="{{(index $comms 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-										{{svg "octicon-fold" 16}}
+										{{svg "octicon-fold" 14 16}}
 										{{if $invalid}}
 											{{$.i18n.Tr "repo.issues.review.hide_outdated"}}
 										{{else}}
@@ -529,7 +529,7 @@
 		</div>
 	{{else if eq .Type 23}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-lock" 16}}</span>
+			<span class="badge">{{svg "octicon-lock" 12 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -547,7 +547,7 @@
 		</div>
 	{{else if eq .Type 24}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-key" 16}}</span>
+			<span class="badge">{{svg "octicon-key" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -558,7 +558,7 @@
 		</div>
 	{{else if eq .Type 25}}
 		<div class="timeline-item event">
-			<span class="badge">{{svg "octicon-git-branch" 16}}</span>
+			<span class="badge">{{svg "octicon-git-branch" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -569,7 +569,7 @@
 		</div>
 	{{else if eq .Type 26}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -578,13 +578,13 @@
 				{{$.i18n.Tr "repo.issues.del_time_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16}}
+				{{svg "octicon-clock" 16 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 27}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-eye" 16}}</span>
+			<span class="badge">{{svg "octicon-eye" 16 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -603,7 +603,7 @@
 		</div>
 	{{else if and (eq .Type 29) (or (gt .CommitsNum 0) .IsForcePush)}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-repo-force-push" 16}}</span>
+			<span class="badge">{{svg "octicon-repo-force-push" 16 16}}</span>
 			<span class="text grey">
 				<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 				{{ if .IsForcePush }}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -170,7 +170,7 @@
 		{{end}}
 	{{else if eq .Type 8}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-milestone" 16 16}}</span>
+			<span class="badge">{{svg "octicon-milestone" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -85,7 +85,7 @@
 		</div>
 	{{else if eq .Type 2}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-circle-slash" 16 16}}</span>
+			<span class="badge">{{svg "octicon-circle-slash" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -181,7 +181,7 @@
 		</div>
 	{{else if eq .Type 9}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-person" 16 16}}</span>
+			<span class="badge">{{svg "octicon-person" 12 16}}</span>
 			{{if gt .AssigneeID 0}}
 				{{if .RemovedAssignee}}
 					<a class="ui avatar image" href="{{.Assignee.HomeLink}}">
@@ -223,7 +223,7 @@
 		</div>
 	{{else if eq .Type 11}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-git-branch" 16 16}}</span>
+			<span class="badge">{{svg "octicon-git-branch" 10 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -234,7 +234,7 @@
 		</div>
 	{{else if eq .Type 12}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -245,7 +245,7 @@
 		</div>
 	{{else if eq .Type 13}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -254,13 +254,13 @@
 				{{$.i18n.Tr "repo.issues.stop_tracking_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16 16}}
+				{{svg "octicon-clock" 14 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 14}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -269,13 +269,13 @@
 				{{$.i18n.Tr "repo.issues.add_time_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16 16}}
+				{{svg "octicon-clock" 14 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>
 	{{else if eq .Type 15}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -286,7 +286,7 @@
 		</div>
 	{{else if eq .Type 16}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -297,7 +297,7 @@
 		</div>
 	{{else if eq .Type 17}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -308,7 +308,7 @@
 		</div>
 	{{else if eq .Type 18}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -558,7 +558,7 @@
 		</div>
 	{{else if eq .Type 25}}
 		<div class="timeline-item event">
-			<span class="badge">{{svg "octicon-git-branch" 16 16}}</span>
+			<span class="badge">{{svg "octicon-git-branch" 10 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -569,7 +569,7 @@
 		</div>
 	{{else if eq .Type 26}}
 		<div class="timeline-item event" id="{{.HashTag}}">
-			<span class="badge">{{svg "octicon-clock" 16 16}}</span>
+			<span class="badge">{{svg "octicon-clock" 14 16}}</span>
 			<a class="ui avatar image" href="{{.Poster.HomeLink}}">
 				<img src="{{.Poster.RelAvatarLink}}">
 			</a>
@@ -578,7 +578,7 @@
 				{{$.i18n.Tr "repo.issues.del_time_history"  $createdStr | Safe}}
 			</span>
 			<div class="detail">
-				{{svg "octicon-clock" 16 16}}
+				{{svg "octicon-clock" 14 16}}
 				<span class="text grey">{{.Content}}</span>
 			</div>
 		</div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -26,10 +26,10 @@
 
 							{{if $canChoose }}
 								<a href="#" class="ui poping up icon re-request-review" data-is-checked="{{if  eq .Type 4}}remove{{else}}add{{end}}" data-issue-id="{{$.Issue.ID}}" data-content="{{ if eq .Type 4 }} {{$.i18n.Tr "repo.issues.remove_request_review"}} {{else}} {{$.i18n.Tr "repo.issues.re_request_review"}} {{end}}"  data-id="{{.ReviewerID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
-									{{svg "octicon-sync" 16}}
+									{{svg "octicon-sync" 16 16}}
 								</a>
 							{{end}}
-							{{svg (printf "octicon-%s" .Type.Icon) 16}}
+							{{svg (printf "octicon-%s" .Type.Icon) 16 16}}
 						</span>
 						{{if .Stale}}
 						<span class="type-icon text grey">
@@ -72,7 +72,7 @@
 	{{- else if and .RequireSigned (not .WillSign)}}red
 	{{- else if .Issue.PullRequest.IsChecking}}yellow
 	{{- else if .Issue.PullRequest.CanAutoMerge}}green
-	{{- else}}red{{end}}">{{svg "octicon-git-merge" 32}}</a>
+	{{- else}}red{{end}}">{{svg "octicon-git-merge" 32 32}}</a>
 	<div class="content">
 		{{template "repo/pulls/status" .}}
 		<div class="ui attached merge-section segment {{if not $.LatestCommitStatus}}no-header{{end}}">
@@ -107,7 +107,7 @@
 				{{end}}
 			{{else if .IsPullFilesConflicted}}
 				<div class="item text grey">
-					{{svg "octicon-x" 16}}
+					{{svg "octicon-x" 16 16}}
 					{{$.i18n.Tr "repo.pulls.files_conflicted"}}
 					{{range .ConflictedFiles}}
 						<div>{{.}}</div>
@@ -115,48 +115,48 @@
 				</div>
 			{{else if .IsPullRequestBroken}}
 				<div class="item text red">
-					<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+					<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.data_broken"}}
 				</div>
 			{{else if .IsPullWorkInProgress}}
 				<div class="item text grey">
-					<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+					<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.cannot_merge_work_in_progress" .WorkInProgressPrefix | Str2html}}
 				</div>
 			{{else if .Issue.PullRequest.IsChecking}}
 				<div class="item text yellow">
-					<i class="icon icon-octicon">{{svg "octicon-sync" 16}}</i>
+					<i class="icon icon-octicon">{{svg "octicon-sync" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.is_checking"}}
 				</div>
 			{{else if .Issue.PullRequest.CanAutoMerge}}
 				{{if .IsBlockedByApprovals}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsError .RequiredStatusCheckState.IsFailure)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 						{{$.i18n.Tr "repo.pulls.required_status_check_missing"}}
 					</div>
 				{{else if and .RequireSigned (not .WillSign)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 					<div class="item text yellow">
@@ -168,12 +168,12 @@
 				{{if and (or $.IsRepoAdmin (not $notAllOverridableChecksOk)) (or (not .RequireSigned) .WillSign)}}
 					{{if $notAllOverridableChecksOk}}
 						<div class="item text yellow">
-							<i class="icon icon-octicon">{{svg "octicon-primitive-dot" 16}}</i>
+							<i class="icon icon-octicon">{{svg "octicon-primitive-dot" 16 16}}</i>
 							{{$.i18n.Tr "repo.pulls.required_status_check_administrator"}}
 						</div>
 					{{else}}
 						<div class="item text green">
-							<i class="icon icon-octicon">{{svg "octicon-check" 16}}</i>
+							<i class="icon icon-octicon">{{svg "octicon-check" 16 16}}</i>
 							{{$.i18n.Tr "repo.pulls.can_auto_merge_desc"}}
 						</div>
 					{{end}}
@@ -265,7 +265,7 @@
 							{{end}}
 							<div class="ui {{if $notAllOverridableChecksOk}}red{{else}}green{{end}} buttons merge-button">
 								<button class="ui button" data-do="{{.MergeStyle}}">
-									{{svg "octicon-git-merge" 16}}
+									{{svg "octicon-git-merge" 16 16}}
 									<span class="button-text">
 									{{if eq .MergeStyle "merge"}}
 										{{$.i18n.Tr "repo.pulls.merge_pull_request"}}
@@ -301,17 +301,17 @@
 							</div>
 						{{else}}
 							<div class="item text red">
-								{{svg "octicon-x" 16}}
+								{{svg "octicon-x" 16 16}}
 								{{$.i18n.Tr "repo.pulls.no_merge_desc"}}
 							</div>
 							<div class="item text grey">
-								{{svg "octicon-info" 16}}
+								{{svg "octicon-info" 16 16}}
 								{{$.i18n.Tr "repo.pulls.no_merge_helper"}}
 							</div>
 						{{end}}
 					{{else}}
 						<div class="item text grey">
-							{{svg "octicon-info" 16}}
+							{{svg "octicon-info" 16 16}}
 							{{$.i18n.Tr "repo.pulls.no_merge_access"}}
 						</div>
 					{{end}}
@@ -320,7 +320,7 @@
 				<div class="ui very compact branch-update grid">
 						<div class="row">
 						<div class="item text gray eleven wide left floated column">
-							<i class="icon icon-octicon">{{svg "octicon-alert" 16}}</i>
+							<i class="icon icon-octicon">{{svg "octicon-alert" 16 16}}</i>
 							{{$.i18n.Tr "repo.pulls.outdated_with_base_branch"}}
 						</div>
 						{{if .UpdateAllowed}}
@@ -340,36 +340,36 @@
 				{{/* Merge conflict without specific file. Suggest manual merge, only if all reviews and status checks OK. */}}
 				{{if .IsBlockedByApprovals}}
 					<div class="item text red">
-						{{svg "octicon-x" 16}}
+						{{svg "octicon-x" 16 16}}
 					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item text red">
-						{{svg "octicon-x" 16}}
+						{{svg "octicon-x" 16 16}}
 					{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
-						{{svg "octicon-x" 16}}
+						{{svg "octicon-x" 16 16}}
 						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .RequireSigned (not .WillSign)}}
 					<div class="item text red">
-						{{svg "octicon-x" 16}}
+						{{svg "octicon-x" 16 16}}
 						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 				{{else}}
 					<div class="item text red">
-						{{svg "octicon-x" 16}}
+						{{svg "octicon-x" 16 16}}
 						{{$.i18n.Tr "repo.pulls.cannot_auto_merge_desc"}}
 					</div>
 					<div class="item text grey">
-						{{svg "octicon-info" 16}}
+						{{svg "octicon-info" 16 16}}
 						{{$.i18n.Tr "repo.pulls.cannot_auto_merge_helper"}}
 					</div>
 				{{end}}

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -107,7 +107,7 @@
 				{{end}}
 			{{else if .IsPullFilesConflicted}}
 				<div class="item text grey">
-					{{svg "octicon-x" 16 16}}
+					{{svg "octicon-x" 12 16}}
 					{{$.i18n.Tr "repo.pulls.files_conflicted"}}
 					{{range .ConflictedFiles}}
 						<div>{{.}}</div>
@@ -115,12 +115,12 @@
 				</div>
 			{{else if .IsPullRequestBroken}}
 				<div class="item text red">
-					<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+					<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.data_broken"}}
 				</div>
 			{{else if .IsPullWorkInProgress}}
 				<div class="item text grey">
-					<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+					<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.cannot_merge_work_in_progress" .WorkInProgressPrefix | Str2html}}
 				</div>
 			{{else if .Issue.PullRequest.IsChecking}}
@@ -131,32 +131,32 @@
 			{{else if .Issue.PullRequest.CanAutoMerge}}
 				{{if .IsBlockedByApprovals}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsError .RequiredStatusCheckState.IsFailure)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 						{{$.i18n.Tr "repo.pulls.required_status_check_missing"}}
 					</div>
 				{{else if and .RequireSigned (not .WillSign)}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 					<div class="item text yellow">
@@ -173,7 +173,7 @@
 						</div>
 					{{else}}
 						<div class="item text green">
-							<i class="icon icon-octicon">{{svg "octicon-check" 16 16}}</i>
+							<i class="icon icon-octicon">{{svg "octicon-check" 12 16}}</i>
 							{{$.i18n.Tr "repo.pulls.can_auto_merge_desc"}}
 						</div>
 					{{end}}
@@ -301,7 +301,7 @@
 							</div>
 						{{else}}
 							<div class="item text red">
-								{{svg "octicon-x" 16 16}}
+								{{svg "octicon-x" 12 16}}
 								{{$.i18n.Tr "repo.pulls.no_merge_desc"}}
 							</div>
 							<div class="item text grey">
@@ -340,32 +340,32 @@
 				{{/* Merge conflict without specific file. Suggest manual merge, only if all reviews and status checks OK. */}}
 				{{if .IsBlockedByApprovals}}
 					<div class="item text red">
-						{{svg "octicon-x" 16 16}}
+						{{svg "octicon-x" 12 16}}
 					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item text red">
-						{{svg "octicon-x" 16 16}}
+						{{svg "octicon-x" 12 16}}
 					{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item text red">
-						<i class="icon icon-octicon">{{svg "octicon-x" 16 16}}</i>
+						<i class="icon icon-octicon">{{svg "octicon-x" 12 16}}</i>
 					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
-						{{svg "octicon-x" 16 16}}
+						{{svg "octicon-x" 12 16}}
 						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .RequireSigned (not .WillSign)}}
 					<div class="item text red">
-						{{svg "octicon-x" 16 16}}
+						{{svg "octicon-x" 12 16}}
 						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 				{{else}}
 					<div class="item text red">
-						{{svg "octicon-x" 16 16}}
+						{{svg "octicon-x" 12 16}}
 						{{$.i18n.Tr "repo.pulls.cannot_auto_merge_desc"}}
 					</div>
 					<div class="item text grey">

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -9,7 +9,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.review.reviewers"}}</strong>
 				{{if and .CanChooseReviewer (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16}}
+					{{svg "octicon-gear" 16 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
@@ -28,7 +28,7 @@
 
 					{{range $.PullReviewers}}
 						{{if eq .ReviewerID $ReviewerID }}
-							{{$notReviewed = false }} 
+							{{$notReviewed = false }}
 							{{if  eq .Type 4 }}
 								{{$checked = true}}
 								{{if or (eq $ReviewerID $.SignedUserID) $.Permission.IsAdmin}}
@@ -45,7 +45,7 @@
 					{{end}}
 
 					<a class="{{if not $canChoose}}ui poping up{{end}} item {{if $checked}} checked {{end}}" href="#" data-id="{{.ID}}" data-id-selector="#review_request_{{.ID}}" data-can-change="{{if not $canChoose}}block{{end}}" {{if not $canChoose}} data-content="{{$.i18n.Tr "repo.issues.remove_request_review_block"}}"{{end}} data-is-checked="{{if $checked}}add{{else}}remove{{end}}">
-						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16}}</span>
+						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span>
 						<span class="text">
 							<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 						</span>
@@ -79,10 +79,10 @@
 
 							{{if $canChoose}}
 								<a href="#" class="ui poping up icon re-request-review" data-is-checked="{{if  eq .Type 4}}remove{{else}}add{{end}}" data-content="{{ if eq .Type 4 }} {{$.i18n.Tr "repo.issues.remove_request_review"}} {{else}} {{$.i18n.Tr "repo.issues.re_request_review"}} {{end}}" data-issue-id="{{$.Issue.ID}}"  data-id="{{.ReviewerID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
-									{{svg "octicon-sync" 16}}
+									{{svg "octicon-sync" 16 16}}
 								</a>
 							{{end}}
-							{{svg (printf "octicon-%s" .Type.Icon) 16}}
+							{{svg (printf "octicon-%s" .Type.Icon) 16 16}}
 						</span>
 					</div>
 				{{end}}
@@ -97,7 +97,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16}}
+					{{svg "octicon-gear" 16 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
@@ -111,12 +111,12 @@
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 				{{if or .Labels .OrgLabels}}
 					{{range .Labels}}
-						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 						{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 					{{end}}
 					<div class="ui divider"></div>
 					{{range .OrgLabels}}
-						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 						{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 					{{end}}
 				{{else}}
@@ -145,7 +145,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16}}
+					{{svg "octicon-gear" 16 16}}
 				{{end}}
 			</span>
 			<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/milestone">
@@ -165,7 +165,7 @@
 					{{if .OpenMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{svg "octicon-milestone" 16}}
+							{{svg "octicon-milestone" 16 16}}
 							{{.i18n.Tr "repo.issues.new.open_milestone"}}
 						</div>
 						{{range .OpenMilestones}}
@@ -175,7 +175,7 @@
 					{{if .ClosedMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{svg "octicon-milestone" 16}}
+							{{svg "octicon-milestone" 16 16}}
 							{{.i18n.Tr "repo.issues.new.closed_milestone"}}
 						</div>
 						{{range .ClosedMilestones}}
@@ -201,7 +201,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16}}
+					{{svg "octicon-gear" 16 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/assignee">
@@ -225,7 +225,7 @@
 								{{$checked = true}}
 							{{end}}
 						{{end}}
-						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16}}</span>
+						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span>
 						<span class="text">
 							<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 						</span>
@@ -268,10 +268,10 @@
 						{{$.CsrfTokenHtml}}
 						<button class="fluid ui button">
 							{{if $.IssueWatch.IsWatching}}
-								{{svg "octicon-mute" 16}}
+								{{svg "octicon-mute" 16 16}}
 								{{.i18n.Tr "repo.issues.unsubscribe"}}
 							{{else}}
-								{{svg "octicon-unmute" 16}}
+								{{svg "octicon-unmute" 16 16}}
 								{{.i18n.Tr "repo.issues.subscribe"}}
 							{{end}}
 						</button>
@@ -356,7 +356,7 @@
 			</div>
 			{{if ne .Issue.DeadlineUnix 0}}
 				<p>
-					{{svg "octicon-calendar" 16}}
+					{{svg "octicon-calendar" 16 16}}
 					{{.Issue.DeadlineUnix.FormatShort}}
 					{{if .Issue.IsOverdue}}
 						<span style="color: red;">{{.i18n.Tr "repo.issues.due_date_overdue"}}</span>
@@ -482,10 +482,10 @@
 				<div>
 					<button class="fluid ui  show-modal button {{if .Issue.IsLocked }} negative {{ end }}" data-modal="#lock">
 							{{if .Issue.IsLocked}}
-								{{svg "octicon-key" 16}}
+								{{svg "octicon-key" 16 16}}
 								{{.i18n.Tr "repo.issues.unlock"}}
 							{{else}}
-								{{svg "octicon-lock" 16}}
+								{{svg "octicon-lock" 12 16}}
 								{{.i18n.Tr "repo.issues.lock"}}
 							{{end}}
 						</button>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -9,7 +9,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.review.reviewers"}}</strong>
 				{{if and .CanChooseReviewer (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16 16}}
+					{{svg "octicon-gear" 14 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
@@ -45,7 +45,7 @@
 					{{end}}
 
 					<a class="{{if not $canChoose}}ui poping up{{end}} item {{if $checked}} checked {{end}}" href="#" data-id="{{.ID}}" data-id-selector="#review_request_{{.ID}}" data-can-change="{{if not $canChoose}}block{{end}}" {{if not $canChoose}} data-content="{{$.i18n.Tr "repo.issues.remove_request_review_block"}}"{{end}} data-is-checked="{{if $checked}}add{{else}}remove{{end}}">
-						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span>
+						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span>
 						<span class="text">
 							<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 						</span>
@@ -97,7 +97,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16 16}}
+					{{svg "octicon-gear" 14 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
@@ -111,12 +111,12 @@
 				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
 				{{if or .Labels .OrgLabels}}
 					{{range .Labels}}
-						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 						{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 					{{end}}
 					<div class="ui divider"></div>
 					{{range .OrgLabels}}
-						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
+						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
 						{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 					{{end}}
 				{{else}}
@@ -145,7 +145,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16 16}}
+					{{svg "octicon-gear" 14 16}}
 				{{end}}
 			</span>
 			<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/milestone">
@@ -165,7 +165,7 @@
 					{{if .OpenMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{svg "octicon-milestone" 16 16}}
+							{{svg "octicon-milestone" 14 16}}
 							{{.i18n.Tr "repo.issues.new.open_milestone"}}
 						</div>
 						{{range .OpenMilestones}}
@@ -175,7 +175,7 @@
 					{{if .ClosedMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{svg "octicon-milestone" 16 16}}
+							{{svg "octicon-milestone" 14 16}}
 							{{.i18n.Tr "repo.issues.new.closed_milestone"}}
 						</div>
 						{{range .ClosedMilestones}}
@@ -201,7 +201,7 @@
 			<span class="text">
 				<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-					{{svg "octicon-gear" 16 16}}
+					{{svg "octicon-gear" 14 16}}
 				{{end}}
 			</span>
 			<div class="filter menu" data-action="" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/assignee">
@@ -225,7 +225,7 @@
 								{{$checked = true}}
 							{{end}}
 						{{end}}
-						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 16 16}}</span>
+						<span class="octicon-check {{if not $checked}}invisible{{end}}">{{svg "octicon-check" 12 16}}</span>
 						<span class="text">
 							<img class="ui avatar image" src="{{.RelAvatarLink}}"> {{.GetDisplayName}}
 						</span>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -17,13 +17,13 @@
 		{{end}}
 	</div>
 	{{if .HasMerged}}
-		<div class="ui purple large label">{{svg "octicon-git-merge" 16}} {{.i18n.Tr "repo.pulls.merged"}}</div>
+		<div class="ui purple large label">{{svg "octicon-git-merge" 16 16}} {{.i18n.Tr "repo.pulls.merged"}}</div>
 	{{else if .Issue.IsClosed}}
-		<div class="ui red large label">{{svg "octicon-issue-closed" 16}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
+		<div class="ui red large label">{{svg "octicon-issue-closed" 16 16}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
-		<div class="ui green large label">{{svg "octicon-git-pull-request" 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-git-pull-request" 16 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
 	{{else}}
-		<div class="ui green large label">{{svg "octicon-issue-opened" 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-issue-opened" 16 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
 	{{end}}
 
 	{{if .Issue.IsPull}}
@@ -51,7 +51,7 @@
                 		<span class="text">{{.i18n.Tr "repo.pulls.compare_compare"}}: {{$.HeadTarget}}</span>
                 	</div>
                 </div>
-                {{svg "octicon-arrow-right" 16}}
+                {{svg "octicon-arrow-right" 16 16}}
                  <div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
                 	<div class="ui basic small button">
                 		<span class="text" id="pull-target-branch" data-basename="{{$.BaseName}}" data-branch="{{$.BaseBranch}}">{{.i18n.Tr "repo.pulls.compare_base"}}: {{$.BaseName}}:{{$.BaseBranch}}</span>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -21,9 +21,9 @@
 	{{else if .Issue.IsClosed}}
 		<div class="ui red large label">{{svg "octicon-issue-closed" 16 16}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
-		<div class="ui green large label">{{svg "octicon-git-pull-request" 16 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-git-pull-request" 12 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
 	{{else}}
-		<div class="ui green large label">{{svg "octicon-issue-opened" 16 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-issue-opened" 14 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
 	{{end}}
 
 	{{if .Issue.IsPull}}

--- a/templates/repo/pulls/tab_menu.tmpl
+++ b/templates/repo/pulls/tab_menu.tmpl
@@ -1,16 +1,16 @@
 <div class="ui top attached pull tabular stackable menu">
 	<a class="item {{if .PageIsPullConversation}}active{{end}}" href="{{.RepoLink}}/pulls/{{.Issue.Index}}">
-		{{svg "octicon-comment-discussion" 16}}
+		{{svg "octicon-comment-discussion" 16 16}}
 		{{$.i18n.Tr "repo.pulls.tab_conversation"}}
 		<span class="ui {{if not .Issue.NumComments}}gray{{else}}blue{{end}} small label">{{.Issue.NumComments}}</span>
 	</a>
 	<a class="item {{if .PageIsPullCommits}}active{{end}}" {{if .NumCommits}}href="{{.RepoLink}}/pulls/{{.Issue.Index}}/commits"{{end}}>
-		{{svg "octicon-git-commit" 16}}
+		{{svg "octicon-git-commit" 16 16}}
 		{{$.i18n.Tr "repo.pulls.tab_commits"}}
 		<span class="ui {{if not .NumCommits}}gray{{else}}blue{{end}} small label">{{if .NumCommits}}{{.NumCommits}}{{else}}N/A{{end}}</span>
 	</a>
 	<a class="item {{if .PageIsPullFiles}}active{{end}}" {{if .NumFiles}}href="{{.RepoLink}}/pulls/{{.Issue.Index}}/files"{{end}}>
-		{{svg "octicon-diff" 16}}
+		{{svg "octicon-diff" 16 16}}
 		{{$.i18n.Tr "repo.pulls.tab_files"}}
 		<span class="ui {{if not .NumFiles}}gray{{else}}blue{{end}} small label">{{if .NumFiles}}{{.NumFiles}}{{else}}N/A{{end}}</span>
 	</a>

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -43,8 +43,8 @@
 							<div class="download">
 							{{if $.Permission.CanRead $.UnitTypeCode}}
 								<a href="{{$.RepoLink}}/src/commit/{{.Sha1}}" rel="nofollow"><i class="code icon"></i> {{ShortSha .Sha1}}</a>
-								<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.zip" rel="nofollow">{{svg "octicon-file-zip" 16}}&nbsp;ZIP</a>
-								<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.tar.gz">{{svg "octicon-file-zip" 16}}&nbsp;TAR.GZ</a>
+								<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.zip" rel="nofollow">{{svg "octicon-file-zip" 16 16}}&nbsp;ZIP</a>
+								<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.tar.gz">{{svg "octicon-file-zip" 16 16}}&nbsp;TAR.GZ</a>
 							{{end}}
 							</div>
 						{{else}}
@@ -80,18 +80,18 @@
 										<ul class="list">
 											{{if $.Permission.CanRead $.UnitTypeCode}}
 												<li>
-													<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.zip" rel="nofollow"><strong>{{svg "octicon-file-zip" 16}} {{$.i18n.Tr "repo.release.source_code"}} (ZIP)</strong></a>
+													<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.zip" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 16}} {{$.i18n.Tr "repo.release.source_code"}} (ZIP)</strong></a>
 												</li>
 												<li>
-													<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.tar.gz"><strong>{{svg "octicon-file-zip" 16}} {{$.i18n.Tr "repo.release.source_code"}} (TAR.GZ)</strong></a>
+													<a href="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.tar.gz"><strong>{{svg "octicon-file-zip" 16 16}} {{$.i18n.Tr "repo.release.source_code"}} (TAR.GZ)</strong></a>
 												</li>
 											{{end}}
 											{{if .Attachments}}
 												{{range .Attachments}}
 													<li>
-														<span class="ui text right" data-tooltip="{{$.i18n.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}" data-position="bottom right">{{svg "octicon-info" 16}}</span>
+														<span class="ui text right" data-tooltip="{{$.i18n.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}" data-position="bottom right">{{svg "octicon-info" 16 16}}</span>
 														<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}">
-															<strong><span class="ui image" title='{{.Name}}'>{{svg "octicon-package" 16}}</span> {{.Name}}</strong>
+															<strong><span class="ui image" title='{{.Name}}'>{{svg "octicon-package" 16 16}}</span> {{.Name}}</strong>
 															<span class="ui text grey right">{{.Size | FileSize}}</span>
 														</a>
 													</li>

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -23,7 +23,7 @@
 						<span class="at">@</span>
 						<div class="ui selection dropdown">
 							<input type="hidden" name="tag_target" value="{{.tag_target}}"/>
-							{{svg "octicon-git-branch" 16 16}}
+							{{svg "octicon-git-branch" 10 16}}
 							<div class="text">
 								{{.i18n.Tr "repo.release.target"}} :
 								<strong id="repo-branch-current">{{.Repository.DefaultBranch}}</strong>

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -23,7 +23,7 @@
 						<span class="at">@</span>
 						<div class="ui selection dropdown">
 							<input type="hidden" name="tag_target" value="{{.tag_target}}"/>
-							{{svg "octicon-git-branch" 16}}
+							{{svg "octicon-git-branch" 16 16}}
 							<div class="text">
 								{{.i18n.Tr "repo.release.target"}} :
 								<strong id="repo-branch-current">{{.Repository.DefaultBranch}}</strong>

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -18,7 +18,7 @@
 						</a>
 					</div>
 					<div class="ui eight wide column">
-						{{svg "octicon-shield-lock" 16 16}}
+						{{svg "octicon-shield-lock" 14 16}}
 						<div class="ui inline dropdown">
 							<div class="text">{{if eq .Collaboration.Mode 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .Collaboration.Mode 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .Collaboration.Mode 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 							<i class="dropdown icon"></i>
@@ -67,7 +67,7 @@
 						</a>
 					</div>
 					<div class="ui eight wide column poping up" data-content="{{$.i18n.Tr "repo.settings.change_team_permission_tip"}}">
-						{{svg "octicon-shield-lock" 16 16}}
+						{{svg "octicon-shield-lock" 14 16}}
 						<div class="ui inline dropdown">
 							<div class="text">{{if eq .Authorize 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .Authorize 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .Authorize 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else if eq .Authorize 4}}{{$.i18n.Tr "repo.settings.collaboration.owner"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 						</div>

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -18,7 +18,7 @@
 						</a>
 					</div>
 					<div class="ui eight wide column">
-						{{svg "octicon-shield-lock" 16}}
+						{{svg "octicon-shield-lock" 16 16}}
 						<div class="ui inline dropdown">
 							<div class="text">{{if eq .Collaboration.Mode 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .Collaboration.Mode 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .Collaboration.Mode 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 							<i class="dropdown icon"></i>
@@ -67,7 +67,7 @@
 						</a>
 					</div>
 					<div class="ui eight wide column poping up" data-content="{{$.i18n.Tr "repo.settings.change_team_permission_tip"}}">
-						{{svg "octicon-shield-lock" 16}}
+						{{svg "octicon-shield-lock" 16 16}}
 						<div class="ui inline dropdown">
 							<div class="text">{{if eq .Authorize 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .Authorize 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .Authorize 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else if eq .Authorize 4}}{{$.i18n.Tr "repo.settings.collaboration.owner"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 						</div>

--- a/templates/repo/settings/deploy_keys.tmpl
+++ b/templates/repo/settings/deploy_keys.tmpl
@@ -25,7 +25,7 @@
 								</button>
 						    </div>
 						    <div class="left floated content">
-								<i class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted"{{end}}>{{svg "octicon-key" 32}}</i>
+								<i class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted"{{end}}>{{svg "octicon-key" 32 32}}</i>
 							</div>
 							<div class="content">
 								<strong>{{.Name}}</strong>
@@ -33,7 +33,7 @@
 									{{.Fingerprint}}
 								</div>
 								<div class="activity meta">
-									<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}} - <span>{{$.i18n.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.i18n.Tr "settings.can_write_info"}} {{end}}</span></i>
+									<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}} - <span>{{$.i18n.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.i18n.Tr "settings.can_write_info"}} {{end}}</span></i>
 								</div>
 							</div>
 						</div>

--- a/templates/repo/settings/githooks.tmpl
+++ b/templates/repo/settings/githooks.tmpl
@@ -14,7 +14,7 @@
 				</div>
 				{{range .Hooks}}
 					<div class="item">
-						<span class="text {{if .IsActive}}green{{else}}grey{{end}}">{{svg "octicon-primitive-dot" 16}}</span>
+						<span class="text {{if .IsActive}}green{{else}}grey{{end}}">{{svg "octicon-primitive-dot" 16 16}}</span>
 						<span>{{.Name}}</span>
 						<a class="text blue ui right" href="{{$.RepoLink}}/settings/hooks/git/{{.Name}}"><i class="fa fa-pencil"></i></a>
 					</div>

--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -7,8 +7,8 @@
 		<h4 class="ui top attached header">
 			{{.i18n.Tr "repo.settings.lfs_filelist"}} ({{.i18n.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui black tiny show-panel button" href="{{.Link}}/locks"><span class="octicon-tiny">{{svg "octicon-lock" 16}}</span>{{.i18n.Tr "repo.settings.lfs_locks"}}</a>
-				<a class="ui blue tiny show-panel button" href="{{.Link}}/pointers"><span class="octicon-tiny">{{svg "octicon-search" 16}}</span>&nbsp;{{.i18n.Tr "repo.settings.lfs_findpointerfiles"}}</a>
+				<a class="ui black tiny show-panel button" href="{{.Link}}/locks"><span class="octicon-tiny">{{svg "octicon-lock" 12 16}}</span>{{.i18n.Tr "repo.settings.lfs_locks"}}</a>
+				<a class="ui blue tiny show-panel button" href="{{.Link}}/pointers"><span class="octicon-tiny">{{svg "octicon-search" 16 16}}</span>&nbsp;{{.i18n.Tr "repo.settings.lfs_findpointerfiles"}}</a>
 			</div>
 		</h4>
 		<table id="lfs-files-table" class="ui attached segment single line table">
@@ -27,7 +27,7 @@
 						<td class="right aligned">
 							<a class="ui blue show-panel button" href="{{$.Link}}/find?oid={{.Oid}}&size={{.Size}}">{{$.i18n.Tr "repo.settings.lfs_findcommits"}}</a>
 							<button class="ui basic show-modal icon button" data-modal="#delete-{{.Oid}}">
-								<span class="btn-octicon btn-octicon-danger poping up"  data-content="{{$.i18n.Tr "repo.editor.delete_this_file"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span>
+								<span class="btn-octicon btn-octicon-danger poping up"  data-content="{{$.i18n.Tr "repo.editor.delete_this_file"}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16 16}}</span>
 							</button>
 						</td>
 					</tr>

--- a/templates/repo/settings/lfs_file_find.tmpl
+++ b/templates/repo/settings/lfs_file_find.tmpl
@@ -24,7 +24,7 @@
 								</span>
 							</td>
 							<td>
-								<span class="text grey">{{svg "octicon-git-branch" 16 16}}{{.BranchName}}</span>
+								<span class="text grey">{{svg "octicon-git-branch" 10 16}}{{.BranchName}}</span>
 							</td>
 							<td>
 								{{if .ParentHashes}}

--- a/templates/repo/settings/lfs_file_find.tmpl
+++ b/templates/repo/settings/lfs_file_find.tmpl
@@ -13,7 +13,7 @@
 					{{range .Results}}
 						<tr>
 							<td>
-								{{svg "octicon-file" 16}}
+								{{svg "octicon-file" 16 16}}
 								<a href="{{EscapePound $.RepoLink}}/src/commit/{{.SHA}}/{{EscapePound .Name}}" title="{{.Name}}">{{.Name}}</a>
 							</td>
 							<td class="message">
@@ -24,7 +24,7 @@
 								</span>
 							</td>
 							<td>
-								<span class="text grey">{{svg "octicon-git-branch" 16}}{{.BranchName}}</span>
+								<span class="text grey">{{svg "octicon-git-branch" 16 16}}{{.BranchName}}</span>
 							</td>
 							<td>
 								{{if .ParentHashes}}

--- a/templates/repo/settings/lfs_locks.tmpl
+++ b/templates/repo/settings/lfs_locks.tmpl
@@ -23,14 +23,14 @@
 						<tr>
 							<td>
 								{{if index $.Linkable $index}}
-									{{svg "octicon-file" 16}}
+									{{svg "octicon-file" 16 16}}
 								<a href="{{EscapePound $.RepoLink}}/src/branch/{{EscapePound $lock.Repo.DefaultBranch}}/{{EscapePound $lock.Path}}" title="{{$lock.Path}}">{{$lock.Path}}</a>
 								{{else}}
-									{{svg "octicon-diff" 16}}
+									{{svg "octicon-diff" 16 16}}
 								<span class="poping up" title="{{$.i18n.Tr "repo.settings.lfs_lock_file_no_exist"}}">{{$lock.Path}}</span>
 								{{end}}
 								{{if not (index $.Lockables $index)}}
-									<span class="poping up" title="{{$.i18n.Tr "repo.settings.lfs_noattribute"}}">{{svg "octicon-alert" 16}}</span>
+									<span class="poping up" title="{{$.i18n.Tr "repo.settings.lfs_noattribute"}}">{{svg "octicon-alert" 16 16}}</span>
 								{{end}}
 							</td>
 							<td>
@@ -43,7 +43,7 @@
 							<td class="right aligned">
 								<form action="{{$.LFSFilesLink}}/locks/{{$lock.ID}}/unlock" method="POST">
 									{{$.CsrfTokenHtml}}
-									<button class="ui blue button"><span class="btn-octicon">{{svg "octicon-lock" 16}}</span>{{$.i18n.Tr "repo.settings.lfs_force_unlock"}}</button>
+									<button class="ui blue button"><span class="btn-octicon">{{svg "octicon-lock" 12 16}}</span>{{$.i18n.Tr "repo.settings.lfs_force_unlock"}}</button>
 								</form>
 							</td>
 						</tr>

--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -65,7 +65,7 @@
 									<div class="menu">
 										{{range .Teams}}
 											<div class="item" data-value="{{.ID}}">
-												{{svg "octicon-jersey" 16}}
+												{{svg "octicon-jersey" 16 16}}
 												{{.Name}}
 											</div>
 										{{end}}
@@ -115,7 +115,7 @@
 								<div class="menu">
 								{{range .Teams}}
 									<div class="item" data-value="{{.ID}}">
-										{{svg "octicon-jersey" 16}}
+										{{svg "octicon-jersey" 16 16}}
 									{{.Name}}
 									</div>
 								{{end}}
@@ -195,7 +195,7 @@
 									<div class="menu">
 									{{range .Teams}}
 										<div class="item" data-value="{{.ID}}">
-											{{svg "octicon-jersey" 16}}
+											{{svg "octicon-jersey" 16 16}}
 										{{.Name}}
 										</div>
 									{{end}}

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -14,9 +14,9 @@
 				<div class="item">
 					<div class="meta">
 						{{if .IsSucceed}}
-							<span class="text green">{{svg "octicon-check" 16}}</span>
+							<span class="text green">{{svg "octicon-check" 16 16}}</span>
 						{{else}}
-							<span class="text red">{{svg "octicon-alert" 16}}</span>
+							<span class="text red">{{svg "octicon-alert" 16 16}}</span>
 						{{end}}
 						<a class="ui blue sha label toggle button" data-target="#info-{{.ID}}">{{.UUID}}</a>
 						<div class="ui right">

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -14,7 +14,7 @@
 				<div class="item">
 					<div class="meta">
 						{{if .IsSucceed}}
-							<span class="text green">{{svg "octicon-check" 16 16}}</span>
+							<span class="text green">{{svg "octicon-check" 12 16}}</span>
 						{{else}}
 							<span class="text red">{{svg "octicon-alert" 16 16}}</span>
 						{{end}}

--- a/templates/repo/settings/webhook/list.tmpl
+++ b/templates/repo/settings/webhook/list.tmpl
@@ -44,7 +44,7 @@
 		{{range .Webhooks}}
 			<div class="item">
 				{{if eq .LastStatus 1}}
-					<span class="text green">{{svg "octicon-check" 16 16}}</span>
+					<span class="text green">{{svg "octicon-check" 12 16}}</span>
 				{{else if eq .LastStatus 2}}
 					<span class="text red">{{svg "octicon-alert" 16 16}}</span>
 				{{else}}

--- a/templates/repo/settings/webhook/list.tmpl
+++ b/templates/repo/settings/webhook/list.tmpl
@@ -44,11 +44,11 @@
 		{{range .Webhooks}}
 			<div class="item">
 				{{if eq .LastStatus 1}}
-					<span class="text green">{{svg "octicon-check" 16}}</span>
+					<span class="text green">{{svg "octicon-check" 16 16}}</span>
 				{{else if eq .LastStatus 2}}
-					<span class="text red">{{svg "octicon-alert" 16}}</span>
+					<span class="text red">{{svg "octicon-alert" 16 16}}</span>
 				{{else}}
-					<span class="text grey">{{svg "octicon-primitive-dot" 16}}</span>
+					<span class="text grey">{{svg "octicon-primitive-dot" 16 16}}</span>
 				{{end}}
 				<a class="dont-break-out" href="{{$.BaseLink}}/{{.ID}}">{{.URL}}</a>
 				<div class="ui right">

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -8,7 +8,7 @@
 			{{end}}
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo) }}
 				<div class="item{{if .PageIsBranches}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/branches/">{{svg "octicon-git-branch" 16 16}} <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
+					<a class="ui" href="{{.RepoLink}}/branches/">{{svg "octicon-git-branch" 10 16}} <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
 				</div>
 				<div class="item">
 					<a class="ui" href="#">{{svg "octicon-database" 16 16}} <b>{{SizeFmt .Repository.Size}}</b></a>

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -3,15 +3,15 @@
 		<div class="ui two horizontal center link list">
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo)}}
 				<div class="item{{if .PageIsCommits}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}">{{svg "octicon-history" 16}} <b>{{.CommitsCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
+					<a class="ui" href="{{.RepoLink}}/commits{{if .IsViewBranch}}/branch{{else if .IsViewTag}}/tag{{else if .IsViewCommit}}/commit{{end}}/{{EscapePound .BranchName}}">{{svg "octicon-history" 16 16}} <b>{{.CommitsCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .CommitsCount "repo.commit" "repo.commits") }}</a>
 				</div>
 			{{end}}
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo) }}
 				<div class="item{{if .PageIsBranches}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/branches/">{{svg "octicon-git-branch" 16}} <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
+					<a class="ui" href="{{.RepoLink}}/branches/">{{svg "octicon-git-branch" 16 16}} <b>{{.BranchesCount}}</b> {{.i18n.Tr (TrN .i18n.Lang .BranchesCount "repo.branch" "repo.branches") }}</a>
 				</div>
 				<div class="item">
-					<a class="ui" href="#">{{svg "octicon-database" 16}} <b>{{SizeFmt .Repository.Size}}</b></a>
+					<a class="ui" href="#">{{svg "octicon-database" 16 16}} <b>{{SizeFmt .Repository.Size}}</b></a>
 				</div>
 			{{end}}
 		</div>

--- a/templates/repo/user_cards.tmpl
+++ b/templates/repo/user_cards.tmpl
@@ -16,9 +16,9 @@
 					{{if .Website}}
 						{{svg "octicon-link" 16 16}} <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>
 					{{else if .Location}}
-						{{svg "octicon-location" 16 16}} {{.Location}}
+						{{svg "octicon-location" 12 16}} {{.Location}}
 					{{else}}
-						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					{{end}}
 				</div>
 			</li>

--- a/templates/repo/user_cards.tmpl
+++ b/templates/repo/user_cards.tmpl
@@ -14,11 +14,11 @@
 
 				<div class="meta">
 					{{if .Website}}
-						{{svg "octicon-link" 16}} <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>
+						{{svg "octicon-link" 16 16}} <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>
 					{{else if .Location}}
-						{{svg "octicon-location" 16}} {{.Location}}
+						{{svg "octicon-location" 16 16}} {{.Location}}
 					{{else}}
-						{{svg "octicon-clock" 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					{{end}}
 				</div>
 			</li>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -49,14 +49,14 @@
 				</div>
 				{{if .Repository.CanEnableEditor}}
 					{{if .CanEditFile}}
-						<a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span></a>
+						<a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16 16}}</span></a>
 					{{else}}
-						<span class="btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span>
+						<span class="btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16 16}}</span>
 					{{end}}
 					{{if .CanDeleteFile}}
-						<a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span></a>
+						<a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16 16}}</span></a>
 					{{else}}
-						<span class="btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span>
+						<span class="btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16 16}}</span>
 					{{end}}
 				{{end}}
 			</div>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -36,7 +36,7 @@
 	<tbody>
 		{{if .HasParentPath}}
 			<tr class="has-parent">
-				<td colspan="3">{{svg "octicon-mail-reply" 16}}<a href="{{EscapePound .BranchLink}}{{.ParentPath}}">..</a></td>
+				<td colspan="3">{{svg "octicon-mail-reply" 16 16}}<a href="{{EscapePound .BranchLink}}{{.ParentPath}}">..</a></td>
 			</tr>
 		{{end}}
 		{{range $item := .Files}}
@@ -46,7 +46,7 @@
 				{{if $entry.IsSubModule}}
 					<td>
 						<span class="truncate">
-							{{svg "octicon-file-submodule" 16}}
+							{{svg "octicon-file-submodule" 16 16}}
 							{{$refURL := $commit.RefURL AppUrl $.Repository.FullName}}
 							{{if $refURL}}
 								<a href="{{$refURL}}">{{$entry.Name}}</a> @ <a href="{{$refURL}}/commit/{{$commit.RefID}}">{{ShortSha $commit.RefID}}</a>
@@ -61,7 +61,7 @@
 							{{if $entry.IsDir}}
 								{{$subJumpablePathName := $entry.GetSubJumpablePathName}}
 								{{$subJumpablePath := SubJumpablePath $subJumpablePathName}}
-								{{svg "octicon-file-directory" 16}}
+								{{svg "octicon-file-directory" 16 16}}
 								<a href="{{EscapePound $.TreeLink}}/{{EscapePound $subJumpablePathName}}" title="{{$subJumpablePathName}}">
 									{{if eq (len $subJumpablePath) 2}}
 										<span class="jumpable-path">{{index  $subJumpablePath 0}}</span>{{index  $subJumpablePath 1}}
@@ -70,7 +70,7 @@
 									{{end}}
 								</a>
 							{{else}}
-								{{svg (printf "octicon-%s" (EntryIcon $entry)) 16}}
+								{{svg (printf "octicon-%s" (EntryIcon $entry)) 16 16}}
 								<a href="{{EscapePound $.TreeLink}}/{{EscapePound $entry.Name}}" title="{{$entry.Name}}">{{$entry.Name}}</a>
 							{{end}}
 						</span>

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -15,7 +15,7 @@
 				{{range .Pages}}
 					<tr>
 						<td>
-							{{svg "octicon-file" 16}}
+							{{svg "octicon-file" 16 16}}
 							<a href="{{$.RepoLink}}/wiki/{{.SubURL}}">{{.Name}}</a>
 						</td>
 						{{$timeSince := TimeSinceUnix .UpdatedUnix $.Lang}}

--- a/templates/repo/wiki/revision.tmpl
+++ b/templates/repo/wiki/revision.tmpl
@@ -23,7 +23,7 @@
 					{{end}}
 					{{if or (not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH))}}
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-							{{svg "octicon-clippy" 16}}
+							{{svg "octicon-clippy" 16 16}}
 						</button>
 					{{end}}
 				</div>

--- a/templates/repo/wiki/start.tmpl
+++ b/templates/repo/wiki/start.tmpl
@@ -3,7 +3,7 @@
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui center segment">
-			{{svg "octicon-book" 32}}
+			{{svg "octicon-book" 32 32}}
 			<h2>{{.i18n.Tr "repo.wiki.welcome"}}</h2>
 			<p>{{.i18n.Tr "repo.wiki.welcome_desc"}}</p>
 			{{if and .CanWriteWiki (not .Repository.IsMirror)}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -47,7 +47,7 @@
 					{{end}}
 					{{if or (not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH))}}
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
-							{{svg "octicon-clippy" 16}}
+							{{svg "octicon-clippy" 16 16}}
 						</button>
 					{{end}}
 				</div>

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -101,7 +101,7 @@
 				</div>
 			</div>
 			<div class="ui two wide right aligned column">
-				<span class="text grey">{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 32}}</span>
+				<span class="text grey">{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 32 32}}</span>
 			</div>
 		</div>
 		<div class="ui divider"></div>

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -132,7 +132,7 @@
 								<span class="comment ui right">{{svg "octicon-comment" 16 16}} {{.NumComments}}</span>
 							{{end}}
 							{{if .TotalTrackedTime}}
-								<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+								<span class="comment ui right">{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 							{{end}}
 
 							<p class="desc">
@@ -150,7 +150,7 @@
 								{{end}}
 								{{if .Ref}}
 									<a class="ref" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}{{index $.IssueRefURLs .ID}}">
-										{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
+										{{svg "octicon-git-branch" 10 16}} {{index $.IssueRefEndNames .ID}}
 									</a>
 								{{end}}
 								{{range .Assignees}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -56,11 +56,11 @@
 					<div class="column">
 						<div class="ui tiny basic status buttons">
 							<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open&q={{$.Keyword}}">
-								{{svg "octicon-issue-opened" 16}}
+								{{svg "octicon-issue-opened" 16 16}}
 								{{.i18n.Tr "repo.issues.open_tab" .ShownIssueStats.OpenCount}}
 							</a>
 							<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed&q={{$.Keyword}}">
-								{{svg "octicon-issue-closed" 16}}
+								{{svg "octicon-issue-closed" 16 16}}
 								{{.i18n.Tr "repo.issues.close_tab" .ShownIssueStats.ClosedCount}}
 							</a>
 						</div>
@@ -129,10 +129,10 @@
 							{{end}}
 
 							{{if .NumComments}}
-								<span class="comment ui right">{{svg "octicon-comment" 16}} {{.NumComments}}</span>
+								<span class="comment ui right">{{svg "octicon-comment" 16 16}} {{.NumComments}}</span>
 							{{end}}
 							{{if .TotalTrackedTime}}
-								<span class="comment ui right">{{svg "octicon-clock" 16}} {{.TotalTrackedTime | Sec2Time}}</span>
+								<span class="comment ui right">{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime | Sec2Time}}</span>
 							{{end}}
 
 							<p class="desc">
@@ -145,12 +145,12 @@
 								{{end}}
 								{{if .Milestone}}
 									<a class="milestone" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.Milestone.ID}}&assignee={{$.AssigneeID}}">
-										{{svg "octicon-milestone" 16}} {{.Milestone.Name}}
+										{{svg "octicon-milestone" 16 16}} {{.Milestone.Name}}
 									</a>
 								{{end}}
 								{{if .Ref}}
 									<a class="ref" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}{{index $.IssueRefURLs .ID}}">
-										{{svg "octicon-git-branch" 16}} {{index $.IssueRefEndNames .ID}}
+										{{svg "octicon-git-branch" 16 16}} {{index $.IssueRefEndNames .ID}}
 									</a>
 								{{end}}
 								{{range .Assignees}}
@@ -162,12 +162,12 @@
 								{{if gt $tasks 0}}
 									{{$tasksDone := .GetTasksDone}}
 									<span class="checklist">
-										{{svg "octicon-checklist" 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
+										{{svg "octicon-checklist" 16 16}} {{$tasksDone}} / {{$tasks}} <span class="progress-bar"><span class="progress" style="width:calc(100% * {{$tasksDone}} / {{$tasks}});"></span></span>
 									</span>
 								{{end}}
 								{{if ne .DeadlineUnix 0}}
 									<span class="due-date poping up" data-content="{{$.i18n.Tr "repo.issues.due_date"}}" data-variation="tiny inverted" data-position="right center">
-										{{svg "octicon-calendar" 16}}<span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
+										{{svg "octicon-calendar" 16 16}}<span{{if .IsOverdue}} class="overdue"{{end}}>{{.DeadlineUnix.FormatShort}}</span>
 									</span>
 								{{end}}
 								{{if .IsPull}}
@@ -175,25 +175,25 @@
 									{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 									{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 									{{if gt $approveOfficial 0}}
-										<span class="approvals">{{svg "octicon-check" 16}}
+										<span class="approvals">{{svg "octicon-check" 16 16}}
 											{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 										</span>
 									{{end}}
 
 									{{if gt $rejectOfficial 0}}
-										<span class="rejects">{{svg "octicon-request-changes" 16}}
+										<span class="rejects">{{svg "octicon-request-changes" 16 16}}
 											{{$.i18n.Tr (TrN $.i18n.Lang $rejectOfficial "repo.pulls.reject_count_1" "repo.pulls.reject_count_n") $rejectOfficial}}
 										</span>
 									{{end}}
 
 									{{if gt $waitingOfficial 0}}
-										<span class="waiting">{{svg "octicon-eye" 16}}
+										<span class="waiting">{{svg "octicon-eye" 16 16}}
 											{{$.i18n.Tr (TrN $.i18n.Lang $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n") $waitingOfficial}}
 										</span>
 									{{end}}
 
 									{{if and (not .PullRequest.HasMerged) (gt (len .PullRequest.ConflictedFiles) 0)}}
-										<span class="conflicting">{{svg "octicon-mirror" 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
+										<span class="conflicting">{{svg "octicon-mirror" 16 16}} {{$.i18n.Tr (TrN $.i18n.Lang (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n") (len .PullRequest.ConflictedFiles)}}</span>
 									{{end}}
 								{{end}}
 							</p>

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -56,7 +56,7 @@
 					<div class="column">
 						<div class="ui tiny basic status buttons">
 							<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open&q={{$.Keyword}}">
-								{{svg "octicon-issue-opened" 16 16}}
+								{{svg "octicon-issue-opened" 14 16}}
 								{{.i18n.Tr "repo.issues.open_tab" .ShownIssueStats.OpenCount}}
 							</a>
 							<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed&q={{$.Keyword}}">
@@ -145,7 +145,7 @@
 								{{end}}
 								{{if .Milestone}}
 									<a class="milestone" href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.Milestone.ID}}&assignee={{$.AssigneeID}}">
-										{{svg "octicon-milestone" 16 16}} {{.Milestone.Name}}
+										{{svg "octicon-milestone" 14 16}} {{.Milestone.Name}}
 									</a>
 								{{end}}
 								{{if .Ref}}
@@ -175,7 +175,7 @@
 									{{$rejectOfficial := call $approvalCounts .ID "reject"}}
 									{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 									{{if gt $approveOfficial 0}}
-										<span class="approvals">{{svg "octicon-check" 16 16}}
+										<span class="approvals">{{svg "octicon-check" 12 16}}
 											{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 										</span>
 									{{end}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -36,11 +36,11 @@
 			<div class="twelve wide column content">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open">
-						{{svg "octicon-issue-opened" 16}}
+						{{svg "octicon-issue-opened" 16 16}}
 						{{.i18n.Tr "repo.milestones.open_tab" .MilestoneStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed">
-						{{svg "octicon-issue-closed" 16}}
+						{{svg "octicon-issue-closed" 16 16}}
 						{{.i18n.Tr "repo.milestones.close_tab" .MilestoneStats.ClosedCount}}
 					</a>
 				</div>
@@ -66,7 +66,7 @@
                     {{range .Milestones}}
                         <li class="item">
                             <div class="ui label">{{.Repo.FullName}}</div>
-							{{svg "octicon-milestone" 16}} <a href="{{.Repo.Link }}/milestone/{{.ID}}">{{.Name}}</a>
+							{{svg "octicon-milestone" 16 16}} <a href="{{.Repo.Link }}/milestone/{{.ID}}">{{.Name}}</a>
                             <div class="ui right green progress" data-percent="{{.Completeness}}">
                                 <div class="bar" {{if not .Completeness}}style="background-color: transparent"{{end}}>
                                     <div class="progress"></div>
@@ -75,9 +75,9 @@
                             <div class="meta">
                                 {{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.Lang }}
                                 {{if .IsClosed}}
-									{{svg "octicon-clock" 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+									{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
                                 {{else}}
-									{{svg "octicon-calendar" 16}}
+									{{svg "octicon-calendar" 16 16}}
                                     {{if .DeadlineString}}
                                         <span {{if .IsOverdue}}class="overdue"{{end}}>{{.DeadlineString}}</span>
                                     {{else}}
@@ -85,20 +85,20 @@
                                     {{end}}
                                 {{end}}
                                 <span class="issue-stats">
-                                    {{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.milestones.open_tab" .NumOpenIssues}}
-									{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.milestones.close_tab" .NumClosedIssues}}
-                                    {{if .TotalTrackedTime}}{{svg "octicon-clock" 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
+                                    {{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.milestones.open_tab" .NumOpenIssues}}
+									{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.milestones.close_tab" .NumClosedIssues}}
+                                    {{if .TotalTrackedTime}}{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
                                 </span>
                             </div>
                             {{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}
                                 <div class="ui right operate">
-                                    <a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+                                    <a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
                                     {{if .IsClosed}}
-                                        <a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check" 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+                                        <a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check" 16 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
                                     {{else}}
-                                        <a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x" 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+                                        <a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x" 16 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
                                     {{end}}
-                                    <a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+                                    <a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
                                 </div>
                             {{end}}
                             {{if .Content}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -75,7 +75,7 @@
                             <div class="meta">
                                 {{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.Lang }}
                                 {{if .IsClosed}}
-									{{svg "octicon-clock" 16 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+									{{svg "octicon-clock" 14 16}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
                                 {{else}}
 									{{svg "octicon-calendar" 16 16}}
                                     {{if .DeadlineString}}
@@ -87,7 +87,7 @@
                                 <span class="issue-stats">
                                     {{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.milestones.open_tab" .NumOpenIssues}}
 									{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.milestones.close_tab" .NumClosedIssues}}
-                                    {{if .TotalTrackedTime}}{{svg "octicon-clock" 16 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
+                                    {{if .TotalTrackedTime}}{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
                                 </span>
                             </div>
                             {{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -36,7 +36,7 @@
 			<div class="twelve wide column content">
 				<div class="ui tiny basic status buttons">
 					<a class="ui {{if not .IsShowClosed}}green active{{end}} basic button" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open">
-						{{svg "octicon-issue-opened" 16 16}}
+						{{svg "octicon-issue-opened" 14 16}}
 						{{.i18n.Tr "repo.milestones.open_tab" .MilestoneStats.OpenCount}}
 					</a>
 					<a class="ui {{if .IsShowClosed}}red active{{end}} basic button" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed">
@@ -66,7 +66,7 @@
                     {{range .Milestones}}
                         <li class="item">
                             <div class="ui label">{{.Repo.FullName}}</div>
-							{{svg "octicon-milestone" 16 16}} <a href="{{.Repo.Link }}/milestone/{{.ID}}">{{.Name}}</a>
+							{{svg "octicon-milestone" 14 16}} <a href="{{.Repo.Link }}/milestone/{{.ID}}">{{.Name}}</a>
                             <div class="ui right green progress" data-percent="{{.Completeness}}">
                                 <div class="bar" {{if not .Completeness}}style="background-color: transparent"{{end}}>
                                     <div class="progress"></div>
@@ -85,7 +85,7 @@
                                     {{end}}
                                 {{end}}
                                 <span class="issue-stats">
-                                    {{svg "octicon-issue-opened" 16 16}} {{$.i18n.Tr "repo.milestones.open_tab" .NumOpenIssues}}
+                                    {{svg "octicon-issue-opened" 14 16}} {{$.i18n.Tr "repo.milestones.open_tab" .NumOpenIssues}}
 									{{svg "octicon-issue-closed" 16 16}} {{$.i18n.Tr "repo.milestones.close_tab" .NumClosedIssues}}
                                     {{if .TotalTrackedTime}}{{svg "octicon-clock" 14 16}} {{.TotalTrackedTime|Sec2Time}}{{end}}
                                 </span>
@@ -94,9 +94,9 @@
                                 <div class="ui right operate">
                                     <a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil" 16 16}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
                                     {{if .IsClosed}}
-                                        <a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check" 16 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+                                        <a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check" 12 16}} {{$.i18n.Tr "repo.milestones.open"}}</a>
                                     {{else}}
-                                        <a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x" 16 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+                                        <a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x" 12 16}} {{$.i18n.Tr "repo.milestones.close"}}</a>
                                     {{end}}
                                     <a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trashcan" 16 16}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
                                 </div>

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -35,17 +35,17 @@
 		{{if .ContextUser.IsOrganization}}
 			<div class="right stackable menu">
 				<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/dashboard">
-					{{svg "octicon-rss" 16 16}}&nbsp;{{.i18n.Tr "activities"}}
+					{{svg "octicon-rss" 10 16}}&nbsp;{{.i18n.Tr "activities"}}
 				</a>
 				<a class="{{if .PageIsIssues}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/issues">
-					{{svg "octicon-issue-opened" 16 16}}&nbsp;{{.i18n.Tr "issues"}}
+					{{svg "octicon-issue-opened" 14 16}}&nbsp;{{.i18n.Tr "issues"}}
 				</a>
 				<a class="{{if .PageIsPulls}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/pulls">
-					{{svg "octicon-git-pull-request" 16 16}}&nbsp;{{.i18n.Tr "pull_requests"}}
+					{{svg "octicon-git-pull-request" 12 16}}&nbsp;{{.i18n.Tr "pull_requests"}}
 				</a>
 				{{if .ShowMilestonesDashboardPage}}
 					<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/milestones">
-						{{svg "octicon-milestone" 16 16}}&nbsp;{{.i18n.Tr "milestones"}}
+						{{svg "octicon-milestone" 14 16}}&nbsp;{{.i18n.Tr "milestones"}}
 					</a>
 				{{end}}
 				<div class="item">

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -25,7 +25,7 @@
 					</div>
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
-						{{svg "octicon-plus" 16}}&nbsp;&nbsp;&nbsp;{{.i18n.Tr "new_org"}}
+						{{svg "octicon-plus" 12 16}}&nbsp;&nbsp;&nbsp;{{.i18n.Tr "new_org"}}
 					</a>
 					{{end}}
 				</div>
@@ -35,17 +35,17 @@
 		{{if .ContextUser.IsOrganization}}
 			<div class="right stackable menu">
 				<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/dashboard">
-					{{svg "octicon-rss" 16}}&nbsp;{{.i18n.Tr "activities"}}
+					{{svg "octicon-rss" 16 16}}&nbsp;{{.i18n.Tr "activities"}}
 				</a>
 				<a class="{{if .PageIsIssues}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/issues">
-					{{svg "octicon-issue-opened" 16}}&nbsp;{{.i18n.Tr "issues"}}
+					{{svg "octicon-issue-opened" 16 16}}&nbsp;{{.i18n.Tr "issues"}}
 				</a>
 				<a class="{{if .PageIsPulls}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/pulls">
-					{{svg "octicon-git-pull-request" 16}}&nbsp;{{.i18n.Tr "pull_requests"}}
+					{{svg "octicon-git-pull-request" 16 16}}&nbsp;{{.i18n.Tr "pull_requests"}}
 				</a>
 				{{if .ShowMilestonesDashboardPage}}
 					<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/milestones">
-						{{svg "octicon-milestone" 16}}&nbsp;{{.i18n.Tr "milestones"}}
+						{{svg "octicon-milestone" 16 16}}&nbsp;{{.i18n.Tr "milestones"}}
 					</a>
 				{{end}}
 				<div class="item">

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -107,7 +107,7 @@
 							<strong class="text truncate item-name">${repo.full_name}</strong>
 							<i v-if="repo.archived" class="archive icon archived-icon"></i>
 							<span class="ui right text light grey">
-								${repo.stars_count} <span class="rear">{{svg "octicon-star" 16 16}}</span>
+								${repo.stars_count} <span class="rear">{{svg "octicon-star" 14 16}}</span>
 							</span>
 						</a>
 					</li>

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -103,11 +103,11 @@
 				<ul class="repo-owner-name-list">
 					<li v-for="repo in repos" :class="{'private': repo.private || repo.internal}">
 						<a :href="suburl + '/' + repo.full_name">
-							<svg :class="'svg ' + repoClass(repo)" width="16" height="16" aria-hidden="true"><use :xlink:href="'#' + repoClass(repo)" /></svg>
+							<svg :class="'svg ' + repoClass(repo).icon" :width="repoClass(repo).width" :height="repoClass(repo).height" aria-hidden="true"><use :xlink:href="'#' + repoClass(repo).icon" /></svg>
 							<strong class="text truncate item-name">${repo.full_name}</strong>
 							<i v-if="repo.archived" class="archive icon archived-icon"></i>
 							<span class="ui right text light grey">
-								${repo.stars_count} <span class="rear">{{svg "octicon-star" 16}}</span>
+								${repo.stars_count} <span class="rear">{{svg "octicon-star" 16 16}}</span>
 							</span>
 						</a>
 					</li>
@@ -151,10 +151,10 @@
 				<ul class="repo-owner-name-list">
 					<li v-for="org in organizations">
 						<a :href="suburl + '/' + org.name">
-							{{svg "octicon-organization" 16}}
+							{{svg "octicon-organization" 16 16}}
 							<strong class="text truncate item-name">${org.name}</strong>
 							<span class="ui right text light grey">
-								${org.num_repos} <span class="rear">{{svg "octicon-repo" 16}}</span>
+								${org.num_repos} <span class="rear">{{svg "octicon-repo" 12 16}}</span>
 							</span>
 						</a>
 					</li>

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -15,7 +15,7 @@
                     {{$.CsrfTokenHtml}}
                     <div class="{{if not $notificationUnreadCount}}hide{{end}}">
                         <button class="ui mini button primary" title='{{$.i18n.Tr "notification.mark_all_as_read"}}'>
-                            {{svg "octicon-checklist" 16}}
+                            {{svg "octicon-checklist" 16 16}}
                         </button>
                     </div>
                 </form>
@@ -38,22 +38,22 @@
                             <tr id="notification_{{.ID}}">
                                 <td class="collapsing" data-href="{{.HTMLURL}}">
                                     {{if eq .Status 3}}
-                                        <span class="blue">{{svg "octicon-pin" 16}}</span>
+                                        <span class="blue">{{svg "octicon-pin" 16 16}}</span>
                                     {{else if $issue.IsPull}}
                                         {{if $issue.IsClosed}}
                                             {{if $issue.GetPullRequest.HasMerged}}
-                                                <span class="purple">{{svg "octicon-git-merge" 16}}</span>
+                                                <span class="purple">{{svg "octicon-git-merge" 16 16}}</span>
                                             {{else}}
-                                                <span class="red">{{svg "octicon-git-pull-request" 16}}</span>
+                                                <span class="red">{{svg "octicon-git-pull-request" 16 16}}</span>
                                             {{end}}
                                         {{else}}
-                                            <span class="green">{{svg "octicon-git-pull-request" 16}}</span>
+                                            <span class="green">{{svg "octicon-git-pull-request" 16 16}}</span>
                                         {{end}}
                                     {{else}}
                                         {{if $issue.IsClosed}}
-                                            <span class="red">{{svg "octicon-issue-closed" 16}}</span>
+                                            <span class="red">{{svg "octicon-issue-closed" 16 16}}</span>
                                         {{else}}
-                                            <span class="green">{{svg "octicon-issue-opened" 16}}</span>
+                                            <span class="green">{{svg "octicon-issue-opened" 16 16}}</span>
                                         {{end}}
                                     {{end}}
                                 </td>
@@ -79,7 +79,7 @@
                                                 data-page="{{$.Page.Paginater.Current}}"
                                                 data-notification-id="{{.ID}}"
                                                 data-q="{{$.Keyword}}">
-                                                {{svg "octicon-pin" 16}}
+                                                {{svg "octicon-pin" 16 16}}
                                             </button>
                                         </form>
                                     {{end}}
@@ -97,7 +97,7 @@
                                                 data-page="{{$.Page.Paginater.Current}}"
                                                 data-notification-id="{{.ID}}"
                                                 data-q="{{$.Keyword}}">
-                                                {{svg "octicon-check" 16}}
+                                                {{svg "octicon-check" 16 16}}
                                             </button>
                                         </form>
                                     {{else if eq .Status 2}}
@@ -112,7 +112,7 @@
                                                 data-page="{{$.Page.Paginater.Current}}"
                                                 data-notification-id="{{.ID}}"
                                                 data-q="{{$.Keyword}}">
-                                                {{svg "octicon-bell" 16}}
+                                                {{svg "octicon-bell" 15 16}}
                                             </button>
                                         </form>
                                     {{end}}

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -44,16 +44,16 @@
                                             {{if $issue.GetPullRequest.HasMerged}}
                                                 <span class="purple">{{svg "octicon-git-merge" 16 16}}</span>
                                             {{else}}
-                                                <span class="red">{{svg "octicon-git-pull-request" 16 16}}</span>
+                                                <span class="red">{{svg "octicon-git-pull-request" 12 16}}</span>
                                             {{end}}
                                         {{else}}
-                                            <span class="green">{{svg "octicon-git-pull-request" 16 16}}</span>
+                                            <span class="green">{{svg "octicon-git-pull-request" 12 16}}</span>
                                         {{end}}
                                     {{else}}
                                         {{if $issue.IsClosed}}
                                             <span class="red">{{svg "octicon-issue-closed" 16 16}}</span>
                                         {{else}}
-                                            <span class="green">{{svg "octicon-issue-opened" 16 16}}</span>
+                                            <span class="green">{{svg "octicon-issue-opened" 14 16}}</span>
                                         {{end}}
                                     {{end}}
                                 </td>
@@ -97,7 +97,7 @@
                                                 data-page="{{$.Page.Paginater.Current}}"
                                                 data-notification-id="{{.ID}}"
                                                 data-q="{{$.Keyword}}">
-                                                {{svg "octicon-check" 16 16}}
+                                                {{svg "octicon-check" 12 16}}
                                             </button>
                                         </form>
                                     {{else if eq .Status 2}}

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -20,11 +20,11 @@
 					<div class="extra content wrap">
 						<ul class="text black">
 							{{if .Owner.Location}}
-								<li>{{svg "octicon-location" 16 16}} {{.Owner.Location}}</li>
+								<li>{{svg "octicon-location" 12 16}} {{.Owner.Location}}</li>
 							{{end}}
 							{{if .ShowUserEmail }}
 								<li>
-									{{svg "octicon-mail" 16 16}}
+									{{svg "octicon-clock" 14 16}}
 									<a href="mailto:{{.Owner.Email}}" rel="nofollow">{{.Owner.Email}}</a>
 								</li>
 							{{end}}
@@ -48,7 +48,7 @@
 									</li>
 								{{end}}
 							{{end}}
-							<li>{{svg "octicon-clock" 16 16}} {{.i18n.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
+							<li>{{svg "octicon-clock" 14 16}} {{.i18n.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
 							{{if and .Orgs .HasOrgsVisible}}
 							<li>
 								<ul class="user-orgs">
@@ -67,12 +67,12 @@
 								{{if .SignedUser.IsFollowing .Owner.ID}}
 									<form method="post" action="{{.Link}}/action/unfollow?redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic red button">{{svg "octicon-person" 16 16}} {{.i18n.Tr "user.unfollow"}}</button>
+										<button type="submit" class="ui basic red button">{{svg "octicon-person" 12 16}} {{.i18n.Tr "user.unfollow"}}</button>
 									</form>
 								{{else}}
 									<form method="post" action="{{.Link}}/action/follow?redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic green button">{{svg "octicon-person" 16 16}} {{.i18n.Tr "user.follow"}}</button>
+										<button type="submit" class="ui basic green button">{{svg "octicon-person" 12 16}} {{.i18n.Tr "user.follow"}}</button>
 									</form>
 								{{end}}
 							</li>
@@ -94,11 +94,11 @@
 						<div class="ui label">{{.Owner.NumStars}}</div>
 					</a>
 					<a class='{{if eq .TabName "following"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=following">
-						{{svg "octicon-person" 16 16}}  {{.i18n.Tr "user.following"}}
+						{{svg "octicon-person" 12 16}}  {{.i18n.Tr "user.following"}}
 						<div class="ui label">{{.Owner.NumFollowing}}</div>
 					</a>
 					<a class='{{if eq .TabName "followers"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=followers">
-						{{svg "octicon-person" 16 16}}  {{.i18n.Tr "user.followers"}}
+						{{svg "octicon-person" 12 16}}  {{.i18n.Tr "user.followers"}}
 						<div class="ui label">{{.Owner.NumFollowers}}</div>
 					</a>
 				</div>

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -24,7 +24,7 @@
 							{{end}}
 							{{if .ShowUserEmail }}
 								<li>
-									{{svg "octicon-clock" 14 16}}
+									{{svg "octicon-mail" 14 16}}
 									<a href="mailto:{{.Owner.Email}}" rel="nofollow">{{.Owner.Email}}</a>
 								</li>
 							{{end}}
@@ -87,10 +87,10 @@
 						{{svg "octicon-repo" 12 16}} {{.i18n.Tr "user.repositories"}}
 					</a>
 					<a class='{{if eq .TabName "activity"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=activity">
-						{{svg "octicon-rss" 16 16}} {{.i18n.Tr "user.activity"}}
+						{{svg "octicon-rss" 10 16}} {{.i18n.Tr "user.activity"}}
 					</a>
 					<a class='{{if eq .TabName "stars"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=stars">
-						{{svg "octicon-star" 16 16}}  {{.i18n.Tr "user.starred"}}
+						{{svg "octicon-star" 14 16}}  {{.i18n.Tr "user.starred"}}
 						<div class="ui label">{{.Owner.NumStars}}</div>
 					</a>
 					<a class='{{if eq .TabName "following"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=following">

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -20,23 +20,23 @@
 					<div class="extra content wrap">
 						<ul class="text black">
 							{{if .Owner.Location}}
-								<li>{{svg "octicon-location" 16}} {{.Owner.Location}}</li>
+								<li>{{svg "octicon-location" 16 16}} {{.Owner.Location}}</li>
 							{{end}}
 							{{if .ShowUserEmail }}
 								<li>
-									{{svg "octicon-mail" 16}}
+									{{svg "octicon-mail" 16 16}}
 									<a href="mailto:{{.Owner.Email}}" rel="nofollow">{{.Owner.Email}}</a>
 								</li>
 							{{end}}
 							{{if .Owner.Website}}
 								<li>
-									{{svg "octicon-link" 16}}
+									{{svg "octicon-link" 16 16}}
 									<a target="_blank" rel="noopener noreferrer me" href="{{.Owner.Website}}">{{.Owner.Website}}</a>
 								</li>
 							{{end}}
 							{{if .Owner.Description}}
 								<li>
-									{{svg "octicon-info" 16}}
+									{{svg "octicon-info" 16 16}}
 									<span>{{.Owner.Description}}</span>
 								</li>
 							{{end}}
@@ -48,7 +48,7 @@
 									</li>
 								{{end}}
 							{{end}}
-							<li>{{svg "octicon-clock" 16}} {{.i18n.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
+							<li>{{svg "octicon-clock" 16 16}} {{.i18n.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
 							{{if and .Orgs .HasOrgsVisible}}
 							<li>
 								<ul class="user-orgs">
@@ -67,12 +67,12 @@
 								{{if .SignedUser.IsFollowing .Owner.ID}}
 									<form method="post" action="{{.Link}}/action/unfollow?redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic red button">{{svg "octicon-person" 16}} {{.i18n.Tr "user.unfollow"}}</button>
+										<button type="submit" class="ui basic red button">{{svg "octicon-person" 16 16}} {{.i18n.Tr "user.unfollow"}}</button>
 									</form>
 								{{else}}
 									<form method="post" action="{{.Link}}/action/follow?redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic green button">{{svg "octicon-person" 16}} {{.i18n.Tr "user.follow"}}</button>
+										<button type="submit" class="ui basic green button">{{svg "octicon-person" 16 16}} {{.i18n.Tr "user.follow"}}</button>
 									</form>
 								{{end}}
 							</li>
@@ -84,21 +84,21 @@
 			<div class="ui eleven wide column">
 				<div class="ui secondary stackable pointing menu">
 					<a class='{{if and (ne .TabName "activity") (ne .TabName "following") (ne .TabName "followers") (ne .TabName "stars")}}active{{end}} item' href="{{.Owner.HomeLink}}">
-						{{svg "octicon-repo" 16}} {{.i18n.Tr "user.repositories"}}
+						{{svg "octicon-repo" 12 16}} {{.i18n.Tr "user.repositories"}}
 					</a>
 					<a class='{{if eq .TabName "activity"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=activity">
-						{{svg "octicon-rss" 16}} {{.i18n.Tr "user.activity"}}
+						{{svg "octicon-rss" 16 16}} {{.i18n.Tr "user.activity"}}
 					</a>
 					<a class='{{if eq .TabName "stars"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=stars">
-						{{svg "octicon-star" 16}}  {{.i18n.Tr "user.starred"}}
+						{{svg "octicon-star" 16 16}}  {{.i18n.Tr "user.starred"}}
 						<div class="ui label">{{.Owner.NumStars}}</div>
 					</a>
 					<a class='{{if eq .TabName "following"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=following">
-						{{svg "octicon-person" 16}}  {{.i18n.Tr "user.following"}}
+						{{svg "octicon-person" 16 16}}  {{.i18n.Tr "user.following"}}
 						<div class="ui label">{{.Owner.NumFollowing}}</div>
 					</a>
 					<a class='{{if eq .TabName "followers"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=followers">
-						{{svg "octicon-person" 16}}  {{.i18n.Tr "user.followers"}}
+						{{svg "octicon-person" 16 16}}  {{.i18n.Tr "user.followers"}}
 						<div class="ui label">{{.Owner.NumFollowers}}</div>
 					</a>
 				</div>

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -172,7 +172,7 @@
 		</h4>
 		<div class="ui attached warning segment">
 			<div class="ui red message">
-				<p class="text left">{{svg "octicon-alert" 16}} {{.i18n.Tr "settings.delete_prompt" | Str2html}}</p>
+				<p class="text left">{{svg "octicon-alert" 16 16}} {{.i18n.Tr "settings.delete_prompt" | Str2html}}</p>
 			</div>
 			<form class="ui form ignore-dirty" id="delete-form" action="{{AppSubUrl}}/user/settings/account/delete" method="post">
 				{{.CsrfTokenHtml}}

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -22,7 +22,7 @@
 						<div class="content">
 							<strong>{{.Name}}</strong>
 							<div class="activity meta">
-								<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
+								<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
 							</div>
 						</div>
 					</div>

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -17,7 +17,7 @@
 					</button>
 				</div>
 				<div class="left floated content">
-					<span class="{{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}">{{svg "octicon-key" 32}}</span>
+					<span class="{{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}">{{svg "octicon-key" 32 32}}</span>
 				</div>
 				<div class="content">
 					{{range .Emails}}<strong>{{.Email}} </strong>{{end}}

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -21,7 +21,7 @@
                     </button>
                 </div>
                 <div class="left floated content">
-                	<span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32}}</span>
+                	<span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32 32}}</span>
                 </div>
                 <div class="content">
                     <strong>{{.Name}}</strong>
@@ -29,7 +29,7 @@
                         {{.Fingerprint}}
                     </div>
                     <div class="activity meta">
-                        <i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —	{{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
+                        <i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —	{{svg "octicon-info" 16 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
                     </div>
                 </div>
 			</div>

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -13,13 +13,13 @@
 					<div class="item">
 						<div class="content">
 							{{if .IsPrivate}}
-								<span class="text gold iconFloat">{{svg "octicon-lock" 16}}</span>
+								<span class="text gold iconFloat">{{svg "octicon-lock" 12 16}}</span>
 							{{else if .IsFork}}
-								<span class="iconFloat">{{svg "octicon-repo-forked" 16}}</span>
+								<span class="iconFloat">{{svg "octicon-repo-forked" 10 16}}</span>
 							{{else if .IsMirror}}
-								<span class="iconFloat">{{svg "octicon-repo-clone" 16}}</span>
+								<span class="iconFloat">{{svg "octicon-repo-clone" 16 16}}</span>
 							{{else}}
-								<span class="iconFloat">{{svg "octicon-repo" 16}}</span>
+								<span class="iconFloat">{{svg "octicon-repo" 12 16}}</span>
 							{{end}}
 							<a class="name" href="{{AppSubUrl}}/{{$.Owner.Name}}/{{.Name}}">{{$.Owner.Name}}/{{.Name}}</a>
 							<span>{{SizeFmt .Size}}</span>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2955,17 +2955,17 @@ function initVueComponents() {
 
       repoClass(repo) {
         if (repo.fork) {
-          return 'octicon-repo-forked';
+          return {icon: 'octicon-repo-forked', width: 10, height: 16};
         } if (repo.mirror) {
-          return 'octicon-repo-clone';
+          return {icon: 'octicon-repo-clone', width: 16, height: 16};
         } if (repo.template) {
-          return `octicon-repo-template${repo.private ? '-private' : ''}`;
+          return {icon: `octicon-repo-template${repo.private ? '-private' : ''}`, width: 14, height: 16};
         } if (repo.private) {
-          return 'octicon-lock';
+          return {icon: 'octicon-lock', width: 12, height: 16};
         } if (repo.internal) {
-          return 'octicon-internal-repo';
+          return {icon: 'octicon-internal-repo', width: 13, height: 16};
         }
-        return 'octicon-repo';
+        return {icon: 'octicon-repo', width: 12, height: 16};
       }
     }
   });


### PR DESCRIPTION
Lot of octicons are not ideally 16x16. The issues were mostly invisible but they could be noticed for `fold` icon having improper positioning. What made it very visible is recently introduced internal icon which looks awful with 16px width.

Refactored `svg` template helper to accept width and height explicitly and changed most visible octicons according to data from https://primer.style/octicons/