### PR TITLE
Remove unnecessary parentheses in wiki/view template

### DIFF
--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -45,7 +45,7 @@
 					{{else if and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)}}
 						<input id="repo-clone-url" value="{{$.WikiCloneLink.SSH}}" readonly>
 					{{end}}
-					{{if or ((not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH)))}}
+					{{if or (not $.DisableHTTP) (and (not $.DisableSSH) (or $.IsSigned $.ExposeAnonSSH))}}
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
 							<i class="octicon octicon-clippy"></i>
 						</button>


### PR DESCRIPTION
Fixes #10552 in version 1.11.

It's a backport of #10583 to version 1.11.
