### PR TITLE
Use crispEdges rendering for octicon-internal-repo

### DIFF
--- a/web_src/less/_svg.less
+++ b/web_src/less/_svg.less
@@ -6,4 +6,11 @@
     .middle & {
         vertical-align: middle;
     }
+
+    // https://github.com/go-gitea/gitea/pull/11771
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=608812
+    // via https://bugzilla.mozilla.org/show_bug.cgi?id=1165282#c3
+    &.octicon-internal-repo {
+        shape-rendering: crispEdges;
+    }
 }

--- a/web_src/less/_svg.less
+++ b/web_src/less/_svg.less
@@ -8,9 +8,10 @@
     }
 
     // https://github.com/go-gitea/gitea/pull/11771
+    // https://github.com/go-gitea/gitea/pull/11801
     // https://bugzilla.mozilla.org/show_bug.cgi?id=608812
-    // via https://bugzilla.mozilla.org/show_bug.cgi?id=1165282#c3
     &.octicon-internal-repo {
+        // via https://bugzilla.mozilla.org/show_bug.cgi?id=1165282#c3
         shape-rendering: crispEdges;
     }
 }


### PR DESCRIPTION
Came up in https://github.com/go-gitea/gitea/pull/11771#issuecomment-640438994

Applied only to this specific octicon so that it doesn't interfere with others - that octicon is kinda special in a way that it's 13px, unlike others that are 10px, 12px or 14px.