### PR TITLE
Ensure text remain visible during webfont load with font-display

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -8,6 +8,7 @@
         local('Roboto-Regular'),
         /* Chrome 26+, Opera 23+, Firefox 39+ */
         url('../vendor/assets/roboto-fonts/roboto-v20-latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext-regular.woff2') format('woff2');
+    font-display: swap;
 }
 
 /* roboto-italic - latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext */
@@ -19,6 +20,7 @@
         local('Roboto Italic'),
         local('Roboto-Italic'),
         url('../vendor/assets/roboto-fonts/roboto-v20-latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext-italic.woff2') format('woff2');
+    font-display: swap;
 }
 
 /* roboto-700 - latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext */
@@ -30,6 +32,7 @@
         local('Roboto Bold'),
         local('Roboto-Bold'),
         url('../vendor/assets/roboto-fonts/roboto-v20-latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext-700.woff2') format('woff2');
+    font-display: swap;
 }
 
 /* roboto-700italic - latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext */
@@ -41,18 +44,21 @@
         local('Roboto Bold Italic'),
         local('Roboto-BoldItalic'),
         url('../vendor/assets/roboto-fonts/roboto-v20-latin-ext_cyrillic-ext_latin_greek_vietnamese_cyrillic_greek-ext-700italic.woff2') format('woff2');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Yu Gothic';
     src: local('Yu Gothic Medium');
     font-weight: 400;
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Yu Gothic';
     src: local('Yu Gothic Bold');
     font-weight: 700;
+    font-display: swap;
 }
 
 @font-face {
@@ -61,6 +67,7 @@
         local('Noto Color Emoji'),
         local('Noto-Color-Emoji'),
         url('../vendor/assets/noto-color-emoji/NotoColorEmoji.ttf') format('truetype');
+    font-display: swap;
 }
 
 @default-fonts: -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";


### PR DESCRIPTION
The `swap` argument on `font-display` instruct browsers to use fallback
font for displaying texts until `@font-face` have been fully downloaded.
Not specifying `font-display` cause PageSpeed Insights to complain on
"Opportunities" category.

GIF Example on my LXD container:

![gitea-font-display-swap](https://user-images.githubusercontent.com/40219486/84128125-58b91000-aa6a-11ea-9453-d1baedb9519f.gif)
