### PR TITLE
Fix partially unclickable search button

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -6,7 +6,7 @@
 			<div class="column">
 				{{template "repo/issue/navbar" .}}
 			</div>
-			<div class="column center aligned">
+			<div class="column center aligned search-column">
 				{{template "repo/issue/search" .}}
 			</div>
 			{{if not .Repository.IsArchived}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -65,7 +65,7 @@
 							</a>
 						</div>
 					</div>
-					<div class="column center aligned">
+					<div class="column center aligned search-column">
 						<form class="ui form ignore-dirty">
 							<div class="ui fluid action input">
 								<input type="hidden" name="type" value="{{$.ViewType}}"/>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1303,3 +1303,8 @@ i.icons {
 .ui.sub.header {
     text-transform: none;
 }
+
+/* https://github.com/go-gitea/gitea/issues/11832 */
+.search-column {
+    z-index: 1;
+}


### PR DESCRIPTION
It's another fomantic-ui bug where the `<input>` takes up full width of the parent making the button render partially outside the column.

Fixes: https://github.com/go-gitea/gitea/issues/11832