### PR TITLE
Show all branches and tags that commit belongs to on diff view

### DIFF
--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -466,7 +466,7 @@ func (c *Commit) GetSubModule(entryname string) (*SubModule, error) {
 	return nil, nil
 }
 
-// GetBranchName gets the closes branch name (as returned by 'git name-rev --name-only')
+// GetBranchName gets the closest branch name (as returned by 'git name-rev --name-only')
 func (c *Commit) GetBranchName() (string, error) {
 	data, err := NewCommand("name-rev", "--name-only", "--no-undefined", c.ID.String()).RunInDir(c.repo.Path)
 	if err != nil {
@@ -480,6 +480,38 @@ func (c *Commit) GetBranchName() (string, error) {
 
 	// name-rev commitID output will be "master" or "master~12"
 	return strings.SplitN(strings.TrimSpace(data), "~", 2)[0], nil
+}
+
+// GetBranches gets all branches that commit exists in
+func (c *Commit) GetBranches() ([]string, error) {
+	data, err := NewCommand("branch", "--format", "%(refname:short)", "--contains", c.ID.String()).RunInDir(c.repo.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	// handle case where there are no refs for given commit
+	if len(strings.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
+
+	// name-rev commitID output will be "master" or "master~12"
+	return strings.SplitN(strings.TrimSpace(data), "\n", -1), nil
+}
+
+// GetTags gets all branches that commit exists in
+func (c *Commit) GetTags() ([]string, error) {
+	data, err := NewCommand("tag", "--format", "%(refname:short)", "--contains", c.ID.String()).RunInDir(c.repo.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	// handle case where there are no refs for given commit
+	if len(strings.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
+
+	// name-rev commitID output will be "master" or "master~12"
+	return strings.SplitN(strings.TrimSpace(data), "\n", -1), nil
 }
 
 // CommitFileStatus represents status of files in a commit.

--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -498,7 +498,7 @@ func (c *Commit) GetBranches() ([]string, error) {
 	return strings.SplitN(strings.TrimSpace(data), "\n", -1), nil
 }
 
-// GetTags gets all branches that commit exists in
+// GetTags gets all tags that commit exists in
 func (c *Commit) GetTags() ([]string, error) {
 	data, err := NewCommand("tag", "--format", "%(refname:short)", "--contains", c.ID.String()).RunInDir(c.repo.Path)
 	if err != nil {

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -132,7 +132,7 @@ func SearchCommits(ctx *context.Context) {
 	}
 
 	all := ctx.QueryBool("all")
-	opts := git.NewSearchCommitsOptions(query, all)
+	opts := git.NewSearchCommitsOptions(query, all, ctx.Repo.BranchName)
 	commits, err := ctx.Repo.Commit.SearchCommits(opts)
 	if err != nil {
 		ctx.ServerError("SearchCommits", err)
@@ -306,9 +306,15 @@ func Diff(ctx *context.Context) {
 		ctx.Data["NoteAuthor"] = models.ValidateCommitWithEmail(note.Commit)
 	}
 
-	ctx.Data["BranchName"], err = commit.GetBranchName()
+	ctx.Data["Branches"], err = commit.GetBranches()
 	if err != nil {
-		ctx.ServerError("commit.GetBranchName", err)
+		ctx.ServerError("commit.GetBranches", err)
+		return
+	}
+
+	ctx.Data["Tags"], err = commit.GetTags()
+	if err != nil {
+		ctx.ServerError("commit.GetTags", err)
 		return
 	}
 	ctx.HTML(200, tplCommitPage)

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -27,8 +27,11 @@
 			{{if IsMultilineCommitMessage .Commit.Message}}
 				<pre class="commit-body">{{RenderCommitBody .Commit.Message $.RepoLink $.Repository.ComposeMetas}}</pre>
 			{{end}}
-			{{if .BranchName}}
-				<span class="text grey">{{svg "octicon-git-branch" 16}}{{.BranchName}}</span>
+			{{range $branch := .Branches}}
+				<span class="text grey">{{svg "octicon-git-branch" 16}}{{$branch}}</span>
+			{{end}}
+			{{range $tag := .Tags}}
+				<span class="text grey">{{svg "octicon-tag" 16}}{{$tag}}</span>
 			{{end}}
 		</div>
 		<div class="ui attached info segment {{$class}}">


### PR DESCRIPTION
Instead of showing only closest branch, show all branches and tags that commit exists in.