### PR TITLE
Honor selected branch name when searching commits

### DIFF
--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -347,10 +347,11 @@ type SearchCommitsOptions struct {
 	Authors, Committers []string
 	After, Before       string
 	All                 bool
+	Branch              string
 }
 
 // NewSearchCommitsOptions construct a SearchCommitsOption from a space-delimited search string
-func NewSearchCommitsOptions(searchString string, forAllRefs bool) SearchCommitsOptions {
+func NewSearchCommitsOptions(searchString string, forAllRefs bool, branch string) SearchCommitsOptions {
 	var keywords, authors, committers []string
 	var after, before string
 
@@ -377,6 +378,7 @@ func NewSearchCommitsOptions(searchString string, forAllRefs bool) SearchCommits
 		After:      after,
 		Before:     before,
 		All:        forAllRefs,
+		Branch:     branch,
 	}
 }
 

--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -260,7 +260,7 @@ func (repo *Repository) searchCommits(id SHA1, opts SearchCommitsOptions) (*list
 				hashCmd := NewCommand("log", "-1", prettyLogFormat)
 				hashCmd.AddArguments(args...)
 				hashCmd.AddArguments(v)
-				hashMatching, err := hashCmd.RunInDirBytes(repo.Path)
+				hashMatching, err := hashCmd.RunInDirBytes(opts.Branch)
 				if err != nil || bytes.Contains(stdout, hashMatching) {
 					continue
 				}

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -132,7 +132,7 @@ func SearchCommits(ctx *context.Context) {
 	}
 
 	all := ctx.QueryBool("all")
-	opts := git.NewSearchCommitsOptions(query, all)
+	opts := git.NewSearchCommitsOptions(query, all, ctx.Repo.BranchName)
 	commits, err := ctx.Repo.Commit.SearchCommits(opts)
 	if err != nil {
 		ctx.ServerError("SearchCommits", err)


### PR DESCRIPTION
When searching commits on specific branch we should use it instead of HEAD