### PR TITLE
Fix 500 error on repos with no tags

### DIFF
--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -484,7 +484,7 @@ func (c *Commit) GetBranchName() (string, error) {
 
 // GetTagName gets the current tag name for given commit
 func (c *Commit) GetTagName() (string, error) {
-	data, err := NewCommand("describe", "--exact-match", "--tags", c.ID.String()).RunInDir(c.repo.Path)
+	data, err := NewCommand("describe", "--exact-match", "--tags", "--always", c.ID.String()).RunInDir(c.repo.Path)
 	if err != nil {
 		// handle special case where there is no tag for this commit
 		if strings.Contains(err.Error(), "no tag exactly matches") {


### PR DESCRIPTION
 #11846 Introduced feature to show exact tag on commit view. However if a repo has no tags at all git prints out a separate and unhandled error " No names found, cannot describe anything.":

https://github.com/go-gitea/gitea/blob/bc4f7ba69b01c6f10f6ea26325bf61485adaa0ff/modules/git/commit.go#L490

 Adding --always to the command makes it always use the error in the style of "fatal: no tag exactly matches" even if there are no tags at all.

 Fixes #11869
 Fixes #11868
