### PR TITLE
Only write to global gitconfig if necessary

### DIFF
--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -198,6 +198,7 @@ func (err *Error) Error() string {
 	return fmt.Sprintf("exec(%d:%s) failed: %v(%v) stdout: %s stderr: %s", err.PID, err.Description, err.Err, err.CtxErr, err.Stdout, err.Stderr)
 }
 
+// Unwrap implements the unwrappable implicit interface for go1.13 Unwrap()
 func (err *Error) Unwrap() error {
 	return err.Err
 }

--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -157,7 +157,14 @@ func (pm *Manager) ExecDirEnvStdIn(timeout time.Duration, dir, desc string, env 
 	pm.Remove(pid)
 
 	if err != nil {
-		err = fmt.Errorf("exec(%d:%s) failed: %v(%v) stdout: %v stderr: %v", pid, desc, err, ctx.Err(), stdOut, stdErr)
+		err = &Error{
+			PID:         pid,
+			Description: desc,
+			Err:         err,
+			CtxErr:      ctx.Err(),
+			Stdout:      stdOut.String(),
+			Stderr:      stdErr.String(),
+		}
 	}
 
 	return stdOut.String(), stdErr.String(), err
@@ -175,4 +182,22 @@ func (l processList) Less(i, j int) bool {
 
 func (l processList) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
+}
+
+// Error is a wrapped error describing the error results of Process Execution
+type Error struct {
+	PID         int64
+	Description string
+	Err         error
+	CtxErr      error
+	Stdout      string
+	Stderr      string
+}
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("exec(%d:%s) failed: %v(%v) stdout: %s stderr: %s", err.PID, err.Description, err.Err, err.CtxErr, err.Stdout, err.Stderr)
+}
+
+func (err *Error) Unwrap() error {
+	return err.Err
 }


### PR DESCRIPTION
Only write to the global gitconfig if necessary.

Also make it possible to unwrap the error returned from process execs to get to the underlying `*exec.ExitError`.

Fix #11855