### PR TITLE
Fix icon alignment for show/hide outdated link on resolved conversation

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1152,6 +1152,11 @@
 
                 .segments {
                     box-shadow: none;
+
+                    .show-outdated,
+                    .hide-outdated {
+                        display: block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before:
![chrome_2020-06-13_15-52-11](https://user-images.githubusercontent.com/1447794/84570489-2838e500-ad8e-11ea-83b9-d8b679f1c260.png)

After:
![chrome_2020-06-13_15-51-58](https://user-images.githubusercontent.com/1447794/84570487-27a04e80-ad8e-11ea-9946-0e00185553c3.png)
