### PR TITLE
Rework blame template and styling

### DIFF
--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -245,9 +245,9 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 
 			//Line number
 			if len(part.Lines)-1 == index && len(blameParts)-1 != pi {
-				lineNumbers.WriteString(fmt.Sprintf(`<span id="L%d" class="bottom-line">%d</span>`, i, i))
+				lineNumbers.WriteString(fmt.Sprintf(`<span id="L%d" data-line-number="%d" class="bottom-line"></span>`, i, i))
 			} else {
-				lineNumbers.WriteString(fmt.Sprintf(`<span id="L%d">%d</span>`, i, i))
+				lineNumbers.WriteString(fmt.Sprintf(`<span id="L%d" data-line-number="%d"></span>`, i, i))
 			}
 
 			//Code line

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -118,28 +118,14 @@ func RefBlame(ctx *context.Context) {
 
 	ctx.Data["IsBlame"] = true
 
-	if ctx.Repo.CanEnableEditor() {
-		// Check LFS Lock
-		lfsLock, err := ctx.Repo.Repository.GetTreePathLock(ctx.Repo.TreePath)
-		if err != nil {
-			ctx.ServerError("GetTreePathLock", err)
-			return
-		}
-		if lfsLock != nil && lfsLock.OwnerID != ctx.User.ID {
-			ctx.Data["CanDeleteFile"] = false
-			ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.this_file_locked")
-		} else {
-			ctx.Data["CanDeleteFile"] = true
-			ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.delete_this_file")
-		}
-	} else if !ctx.Repo.IsViewBranch {
-		ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.must_be_on_a_branch")
-	} else if !ctx.Repo.CanWrite(models.UnitTypeCode) {
-		ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.must_have_write_access")
-	}
-
 	ctx.Data["FileSize"] = blob.Size()
 	ctx.Data["FileName"] = blob.Name()
+
+	ctx.Data["NumLines"], err = blob.GetBlobLineCount()
+	if err != nil {
+		ctx.NotFound("GetBlobLineCount", err)
+		return
+	}
 
 	blameReader, err := git.CreateBlameReader(models.RepoPath(userName, repoName), commitID, fileName)
 	if err != nil {

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -1,51 +1,51 @@
-<div class="tab-size-8 non-diff-file-content">
-
-	<h4 class="ui top attached header" id="repo-read-file">
-		<div class="ui stackable grid">
-			<div class="eight wide column">
-                <i class="file text outline icon ui left"></i>
-                <strong>{{.FileName}}</strong> <span class="text grey normal">{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
-			</div>
-			<div class="eight wide right aligned column">
-                <div class="ui right file-actions">
-                    <div class="ui buttons">
-                        <a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
-                        {{if not .IsViewCommit}}
-                            <a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
-                        {{end}}
-                        <a class="ui button" href="{{.RepoLink}}/src/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.normal_view"}}</a>
-                        <a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
-                    </div>
-                    {{if .Repository.CanEnableEditor}}
-                        {{if .CanEditFile}}
-                            <a href="{{.RepoLink}}/_edit/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon poping up"  data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span></a>
-                        {{else}}
-                            <span class="btn-octicon poping up disabled" data-content="{{.EditFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-pencil" 16}}</span>
-                        {{end}}
-                        {{if .CanDeleteFile}}
-                            <a href="{{.RepoLink}}/_delete/{{EscapePound .BranchName}}/{{EscapePound .TreePath}}"><span class="btn-octicon btn-octicon-danger poping up"  data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span></a>
-                        {{else}}
-                            <span class="btn-octicon poping up disabled" data-content="{{.DeleteFileTooltip}}" data-position="bottom center" data-variation="tiny inverted">{{svg "octicon-trashcan" 16}}</span>
-                        {{end}}
-                    {{end}}
-                </div>
+<div class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
+	<h4 class="file-header ui top attached header">
+		<div class="file-header-left">
+			<div class="file-info text grey normal mono">
+				{{if .NumLinesSet}}
+					<div class="file-info-entry">
+						{{.NumLines}} {{.i18n.Tr (TrN .i18n.Lang .NumLines "repo.line" "repo.lines") }}
+					</div>
+				{{end}}
+				{{if .FileSize}}
+					<div class="file-info-entry">
+						{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}
+					</div>
+				{{end}}
 			</div>
 		</div>
+		{{if not .ReadmeInList}}
+		<div class="file-header-right">
+			<div class="ui right file-actions">
+				<div class="ui buttons">
+					<a class="ui button" href="{{EscapePound $.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
+					{{if not .IsViewCommit}}
+						<a class="ui button" href="{{.RepoLink}}/src/commit/{{.CommitID}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
+					{{end}}
+					<a class="ui button" href="{{.RepoLink}}/src/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.normal_view"}}</a>
+					<a class="ui button" href="{{.RepoLink}}/commits/{{EscapePound .BranchNameSubURL}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
+				</div>
+			</div>
+		</div>
+		{{end}}
 	</h4>
-
     <div class="ui attached table unstackable segment">
-        <div class="file-view code-view">
-            <table>
-                <tbody>
-                    <tr>
-                        <td class="lines-commit">{{.BlameCommitInfo}}</td>
-                        <td class="lines-num">{{.BlameLineNums}}</td>
-                        <td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.BlameContent}}</ol></code></pre></td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+		<div class="file-view code-view">
+			{{if .FileSize}}
+				<table>
+					<tbody>
+						<tr>
+						{{if .IsFileTooLarge}}
+							<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td>
+						{{else}}
+							<td class="lines-commit">{{.BlameCommitInfo}}</td>
+							<td class="lines-num">{{.BlameLineNums}}</td>
+							<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.BlameContent}}</ol></code></pre></td>
+						{{end}}
+						</tr>
+					</tbody>
+				</table>
+			{{end}}
+		</div>
     </div>
-
-
 </div>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -2,19 +2,12 @@
 	<h4 class="file-header ui top attached header">
 		<div class="file-header-left">
 			<div class="file-info text grey normal mono">
-				{{if .NumLinesSet}}
-					<div class="file-info-entry">
-						{{.NumLines}} {{.i18n.Tr (TrN .i18n.Lang .NumLines "repo.line" "repo.lines") }}
-					</div>
-				{{end}}
-				{{if .FileSize}}
-					<div class="file-info-entry">
-						{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}
-					</div>
-				{{end}}
+				<div class="file-info-entry">
+					{{.NumLines}} {{.i18n.Tr (TrN .i18n.Lang .NumLines "repo.line" "repo.lines") }}
+				</div>
+				<div class="file-info-entry">{{FileSize .FileSize}}</div>
 			</div>
 		</div>
-		{{if not .ReadmeInList}}
 		<div class="file-header-right">
 			<div class="ui right file-actions">
 				<div class="ui buttons">
@@ -27,25 +20,18 @@
 				</div>
 			</div>
 		</div>
-		{{end}}
 	</h4>
     <div class="ui attached table unstackable segment">
 		<div class="file-view code-view">
-			{{if .FileSize}}
-				<table>
-					<tbody>
-						<tr>
-						{{if .IsFileTooLarge}}
-							<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td>
-						{{else}}
-							<td class="lines-commit">{{.BlameCommitInfo}}</td>
-							<td class="lines-num">{{.BlameLineNums}}</td>
-							<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.BlameContent}}</ol></code></pre></td>
-						{{end}}
-						</tr>
-					</tbody>
-				</table>
-			{{end}}
+			<table>
+				<tbody>
+					<tr>
+						<td class="lines-commit">{{.BlameCommitInfo}}</td>
+						<td class="lines-num">{{.BlameLineNums}}</td>
+						<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.BlameContent}}</ol></code></pre></td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
     </div>
 </div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file list">
+<div class="repository file list {{if .IsBlame}}blame{{end}}">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1069,7 +1069,6 @@ i.icons {
 }
 
 .lines-num {
-    vertical-align: top;
     text-align: right !important;
     color: #999999;
     background: #f5f5f5;
@@ -1077,7 +1076,13 @@ i.icons {
     user-select: none;
 
     span {
-        &:before {
+        &.bottom-line {
+            &:after {
+                border-bottom: 1px solid #eaecef;
+            }
+        }
+
+        &:after {
             content: attr(data-line-number);
             line-height: 20px !important;
             padding: 0 10px;
@@ -1090,6 +1095,7 @@ i.icons {
 .lines-num,
 .lines-code {
     padding: 0 !important;
+    vertical-align: top;
 
     pre,
     ol,
@@ -1101,7 +1107,7 @@ i.icons {
         li {
             display: block;
             width: calc(100% - 1ch);
-            margin-left: 1ch;
+            padding-left: 1ch;
         }
     }
 }
@@ -1149,7 +1155,6 @@ i.icons {
     }
 }
 
-.lines-num,
 .lines-code,
 .lines-commit {
     .bottom-line {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1,5 +1,4 @@
 .repository {
-
     padding-top: 15px;
 
     .repo-header {
@@ -242,6 +241,12 @@
     }
 
     &.file.list {
+        &.blame {
+            .ui.container:not(.flex) {
+                width: 98%;
+            }
+        }
+
         .repo-description {
             display: flex;
             justify-content: space-between;
@@ -1634,7 +1639,6 @@
                 width: 1%;
                 min-width: 50px;
                 user-select: none;
-                vertical-align: top;
 
                 span.fold {
                     display: block;


### PR DESCRIPTION
- Fix vertical align between line numbers
![firefox_2020-06-14_18-19-02](https://user-images.githubusercontent.com/1447794/84599312-580ce900-ae71-11ea-8494-d3d6744c9c87.png)
- Update template to use same styling as file view; fixes align of buttons
![firefox_2020-06-14_19-01-32](https://user-images.githubusercontent.com/1447794/84599335-91ddef80-ae71-11ea-9898-a8fefe6a1259.png)
- Increase width to 98% to show more content when browsing blame, similar to GitHub
- Remove edit/delete file buttons during blame view, similar to GitHub
- Make border line continuous 

---

![chrome_2020-06-14_18-58-55](https://user-images.githubusercontent.com/1447794/84599294-3f043800-ae71-11ea-84f4-9b1eae46eb57.png)

![chrome_2020-06-14_18-59-01](https://user-images.githubusercontent.com/1447794/84599296-40cdfb80-ae71-11ea-9355-e482438ce96a.png)
