### PR TITLE
Fix double divider on issue sidebar

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -88,10 +88,8 @@
 				{{end}}
 			</div>
 		</div>
-
-		{{end}}
-
 		<div class="ui divider"></div>
+		{{end}}
 
 		<div class="ui {{if or (not .HasIssuesOrPullsWritePermission) .Repository.IsArchived}}disabled{{end}} floating jump select-label dropdown">
 			<span class="text">


### PR DESCRIPTION
![firefox_2020-06-17_00-16-26](https://user-images.githubusercontent.com/1447794/84833547-d31bfe00-b02f-11ea-839f-f03911a34378.png)

Move divider after reviewers to inside conditional, so that it isn't shown on issue page.