### PR TITLE
Add automatic theme discovery

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -178,8 +178,8 @@ MAX_DISPLAY_FILE_SIZE = 8388608
 SHOW_USER_EMAIL = true
 ; Set the default theme for the Gitea install
 DEFAULT_THEME = gitea
-; All available themes. Allow users select personalized themes regardless of the value of `DEFAULT_THEME`.
-THEMES = gitea,arc-green
+; Comma-separated list of enabled themes. If set to '*' will automatically discover installed themes
+THEMES = *
 ;All available reactions users can choose on issues/prs and comments.
 ;Values can be emoji alias (:smile:) or a unicode emoji.
 ;For custom reactions, add a tightly cropped square image to public/emoji/img/reaction_name.png

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -128,9 +128,8 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `MEMBERS_PAGING_NUM`: **20**: Number of members that are shown in organization members.
 - `FEED_MAX_COMMIT_NUM`: **5**: Number of maximum commits shown in one activity feed.
 - `GRAPH_MAX_COMMIT_NUM`: **100**: Number of maximum commits shown in the commit graph.
-- `DEFAULT_THEME`: **gitea**: \[gitea, arc-green\]: Set the default theme for the Gitea install.
-- `THEMES`:  **gitea,arc-green**: All available themes. Allow users select personalized themes
-  regardless of the value of `DEFAULT_THEME`.
+- `DEFAULT_THEME`: **gitea**: Set the default theme for the Gitea install.
+- `THEMES`: **\***: Comma-separated list of enabled themes. If set to `*` will automatically discover installed themes.
 - `REACTIONS`: All available reactions users can choose on issues/prs and comments
     Values can be emoji alias (:smile:) or a unicode emoji.
     For custom reactions, add a tightly cropped square image to public/emoji/img/reaction_name.png

--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -333,4 +333,4 @@ A full list of supported emoji's is at [emoji list](https://gitea.com/gitea/gite
 ## Customizing the look of Gitea
 
 As of version 1.6.0 Gitea has built-in themes. The two built-in themes are, the default theme `gitea`, and a dark theme `arc-green`. To change the look of your Gitea install change the value of `DEFAULT_THEME` in the [ui](https://docs.gitea.io/en-us/config-cheat-sheet/#ui-ui) section of `app.ini` to another one of the available options.  
-As of version 1.8.0 Gitea also has per-user themes. The list of themes a user can choose from can be configured with the `THEMES` value in the [ui](https://docs.gitea.io/en-us/config-cheat-sheet/#ui-ui) section of `app.ini` (defaults to `gitea` and `arc-green`, light and dark respectively)
+As of version 1.8.0 Gitea also has per-user themes. The list of themes a user can choose from can be configured with the `THEMES` value in the [ui](https://docs.gitea.io/en-us/config-cheat-sheet/#ui-ui) section of `app.ini` (defaults to automatic discovery which is fine unless you want to disable certain themes)

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -167,9 +167,7 @@ Use [Fail2Ban]({{ relref "doc/usage/fail2ban-setup.md" >}}) to monitor and stop 
 Gitea supports two official themes right now, `gitea` and `arc-green` (`light` and `dark` respectively)  
 To add your own theme, currently the only way is to provide a complete theme (not just color overrides)  
   
-As an example, let's say our theme is `arc-blue` (this is a real theme, and can be found [in this issue](https://github.com/go-gitea/gitea/issues/6011))  
-Name the `.css` file `theme-arc-blue.css` and add it to your custom folder in `custom/pulic/css`  
-Allow users to use it by adding `arc-blue` to the list of `THEMES` in your `app.ini`
+As an example, let's say our theme is `arc-blue` (this is a real theme, and can be found [in this issue](https://github.com/go-gitea/gitea/issues/6011)). Name the `.css` file `theme-arc-blue.css` and add it to your custom folder in `custom/public/css`. If `THEMES` is set to `*` (the default), it will be available after Gitea is restarted.
 
 ## SSHD vs built-in SSH
 SSHD is the built-in SSH server on most Unix systems.  

--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/themes"
 
 	"gitea.com/macaron/binding"
 	"gitea.com/macaron/macaron"
@@ -251,11 +252,11 @@ func (f *UpdateThemeForm) Validate(ctx *macaron.Context, errs binding.Errors) bi
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
 
-// IsThemeExists checks if the theme is a theme available in the config.
+// IsThemeExists checks if a theme is available
 func (f UpdateThemeForm) IsThemeExists() bool {
 	var exists bool
 
-	for _, v := range setting.UI.Themes {
+	for _, v := range themes.Themes {
 		if strings.EqualFold(v, f.Theme) {
 			exists = true
 			break

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -213,7 +213,7 @@ var (
 		ThemeColorMetaTag:   `#6cc644`,
 		MaxDisplayFileSize:  8388608,
 		DefaultTheme:        `gitea`,
-		Themes:              []string{`gitea`, `arc-green`},
+		Themes:              []string{`*`},
 		Reactions:           []string{`+1`, `-1`, `laugh`, `hooray`, `confused`, `heart`, `rocket`, `eyes`},
 		Notification: struct {
 			MinTimeout            time.Duration

--- a/modules/themes/discover_bindata.go
+++ b/modules/themes/discover_bindata.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// +build bindata
+
+package themes
+
+import (
+	"path"
+	"path/filepath"
+
+	"code.gitea.io/gitea/modules/public"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/gobwas/glob"
+)
+
+// Discover locates installed themes
+func Discover() []string {
+	themes := []string{"gitea"}
+
+	glob := glob.MustCompile("css/theme-*.css")
+	for _, file := range public.AssetNames() {
+		if glob.Match(file) {
+			filename := path.Base(file)
+			themes = append(themes, filename[6:len(filename)-4]) // chop off "theme-" and ".css"
+		}
+	}
+
+	customFiles, _ := filepath.Glob(path.Join(setting.CustomPath, "public", "css", "theme-*.css"))
+	for _, file := range customFiles {
+		filename := path.Base(file)
+		themes = append(themes, filename[6:len(filename)-4])
+	}
+
+	return themes
+}

--- a/modules/themes/discover_nobindata.go
+++ b/modules/themes/discover_nobindata.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// +build !bindata
+
+package themes
+
+import (
+	"path"
+	"path/filepath"
+
+	"code.gitea.io/gitea/modules/setting"
+)
+
+// Discover locates installed themes
+func Discover() []string {
+	themes := []string{"gitea"}
+
+	staticFiles, _ := filepath.Glob(path.Join(setting.StaticRootPath, "public", "css", "theme-*.css"))
+	for _, file := range staticFiles {
+		filename := path.Base(file)
+		themes = append(themes, filename[6:len(filename)-4]) // chop off "theme-" and ".css"
+	}
+
+	customFiles, _ := filepath.Glob(path.Join(setting.CustomPath, "public", "css", "theme-*.css"))
+	for _, file := range customFiles {
+		filename := path.Base(file)
+		themes = append(themes, filename[6:len(filename)-4])
+	}
+
+	return themes
+}

--- a/modules/themes/themes.go
+++ b/modules/themes/themes.go
@@ -1,0 +1,23 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package themes
+
+import (
+	"reflect"
+
+	"code.gitea.io/gitea/modules/setting"
+)
+
+// Themes lists available themes
+var Themes []string
+
+// Init initializes theme-related variables
+func Init() {
+	if reflect.DeepEqual(setting.UI.Themes, []string{"*"}) {
+		Themes = Discover()
+	} else {
+		Themes = setting.UI.Themes
+	}
+}

--- a/modules/themes/themes_test.go
+++ b/modules/themes/themes_test.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package themes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThemes(t *testing.T) {
+	Init()
+	assert.Contains(t, Themes, "gitea")
+}

--- a/routers/init.go
+++ b/routers/init.go
@@ -29,6 +29,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/ssh"
 	"code.gitea.io/gitea/modules/task"
+	"code.gitea.io/gitea/modules/themes"
 	"code.gitea.io/gitea/modules/webhook"
 	"code.gitea.io/gitea/services/mailer"
 	mirror_service "code.gitea.io/gitea/services/mirror"
@@ -123,6 +124,8 @@ func GlobalInit(ctx context.Context) {
 
 	// Setup i18n
 	InitLocales()
+
+	themes.Init()
 
 	log.Info("%s", unknwoni18n.Tr("en-US", "admin.dashboard.delete_repo_archives"))
 

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -22,6 +22,7 @@ import (
 	"code.gitea.io/gitea/modules/public"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/modules/themes"
 	"code.gitea.io/gitea/modules/validation"
 	"code.gitea.io/gitea/routers"
 	"code.gitea.io/gitea/routers/admin"
@@ -403,7 +404,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/repos", userSetting.Repos)
 	}, reqSignIn, func(ctx *context.Context) {
 		ctx.Data["PageIsUserSettings"] = true
-		ctx.Data["AllThemes"] = setting.UI.Themes
+		ctx.Data["Themes"] = themes.Themes
 	})
 
 	m.Group("/user", func() {

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -146,13 +146,13 @@
 							<input name="theme" type="hidden" value="{{.SignedUser.Theme}}">
 							<i class="dropdown icon"></i>
 							<div class="text">
-								{{range $i,$a := .AllThemes}}
+								{{range $i,$a := .Themes}}
 									{{if eq $.SignedUser.Theme $a}}{{$a}}{{end}}
 								{{end}}
 							</div>
 
 							<div class="menu">
-							{{range $i,$a := .AllThemes}}
+							{{range $i,$a := .Themes}}
 								<div class="item{{if eq $.SignedUser.Theme $a}} active selected{{end}}" data-value="{{$a}}">
 									{{$a}}
 								</div>


### PR DESCRIPTION
Introduce a new special value `*` for `ui.THEMES` which will automatically discover installed themes in bindata, custom folder and regular files.

Ref: https://github.com/go-gitea/gitea/issues/11118