### PR TITLE
Really fix __webpack_public_path__ for 1.11

### DIFF
--- a/web_src/js/publicPath.js
+++ b/web_src/js/publicPath.js
@@ -3,7 +3,7 @@
 const { StaticUrlPrefix } = window.config;
 
 if (StaticUrlPrefix) {
-  __webpack_public_path__ = `${StaticUrlPrefix.endsWith('/') ? StaticUrlPrefix : `${StaticUrlPrefix}/`}js`;
+  __webpack_public_path__ = `${StaticUrlPrefix.endsWith('/') ? StaticUrlPrefix : `${StaticUrlPrefix}/`}js/`;
 } else if (document.currentScript && document.currentScript.src) {
   const url = new URL(document.currentScript.src);
   __webpack_public_path__ = `${url.pathname.replace(/\/[^/]*$/, '')}/`;


### PR DESCRIPTION
Trailing slash is actually significant, fixed that and i've now tested it as well.

Ref: https://github.com/go-gitea/gitea/issues/11839#issuecomment-646203505