### PR TITLE
For language detection do not try to analyze big files by content

### DIFF
--- a/modules/git/repo_language_stats.go
+++ b/modules/git/repo_language_stats.go
@@ -17,7 +17,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-const fileSizeLimit int64 = 16 * 1024 * 1024
+const fileSizeLimit int64 = 16 * 1024 // 16 KiB
+const bigFileSize int64 = 1024 * 1024 // 1 MiB
 
 // specialLanguages defines list of languages that are excluded from the calculation
 // unless they are the only language present in repository. Only languages which under
@@ -62,8 +63,11 @@ func (repo *Repository) GetLanguageStats(commitID string) (map[string]int64, err
 			return nil
 		}
 
-		// If content can not be read just do detection by filename
-		content, _ := readFile(f, fileSizeLimit)
+		// If content can not be read or file is too big just do detection by filename
+		var content []byte
+		if f.Size <= bigFileSize {
+			content, _ = readFile(f, fileSizeLimit)
+		}
 		if enry.IsGenerated(f.Name, content) {
 			return nil
 		}


### PR DESCRIPTION
Even when using Reader go-git will still load file content into memory. Limit language statistics to not analyze files larger than 1MiB. Also fix to read only 16KiB of file to pass to analyze, it was set to 16MiB by mistake :smiling_imp: 

Should fix #11969