### PR TITLE
Add serviceworker.js to KnownPublicEntries

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -29,6 +29,7 @@ import (
 	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/public"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
@@ -879,7 +880,7 @@ func (u *User) IsGhost() bool {
 }
 
 var (
-	reservedUsernames = []string{
+	reservedUsernames = append([]string{
 		".",
 		"..",
 		".well-known",
@@ -889,17 +890,13 @@ var (
 		"attachments",
 		"avatars",
 		"commits",
-		"css",
 		"debug",
 		"error",
 		"explore",
-		"fomantic",
 		"ghost",
 		"help",
-		"img",
 		"install",
 		"issues",
-		"js",
 		"less",
 		"login",
 		"manifest.json",
@@ -917,8 +914,8 @@ var (
 		"stars",
 		"template",
 		"user",
-		"vendor",
-	}
+	}, public.KnownPublicEntries...)
+
 	reservedUserPatterns = []string{"*.keys", "*.gpg"}
 )
 

--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -30,12 +30,13 @@ type Options struct {
 	Prefix       string
 }
 
-// List of known entries inside the `public` directory
-var knownEntries = []string{
+// KnownPublicEntries list all direct children in the `public` directory
+var KnownPublicEntries = []string{
 	"css",
 	"fomantic",
 	"img",
 	"js",
+	"serviceworker.js",
 	"vendor",
 }
 
@@ -114,7 +115,7 @@ func (opts *Options) handle(ctx *macaron.Context, log *log.Logger, opt *Options)
 			if len(parts) < 2 {
 				return false
 			}
-			for _, entry := range knownEntries {
+			for _, entry := range KnownPublicEntries {
 				if entry == parts[1] {
 					ctx.Resp.WriteHeader(404)
 					return true


### PR DESCRIPTION
Fixes a wrong 302 redirect to the login page, see https://github.com/go-gitea/gitea/issues/11989. Also made it so the reserved username list is extended with those known entries so we avoid code duplication.

Should be backported to 1.12.