### PR TITLE
Fix margin positioning for GPG lock icons

### DIFF
--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -90,7 +90,9 @@
 			<div class="ui bottom attached message {{$class}}">
 				{{if .Verification.Verified }}
 					{{if ne .Verification.SigningUser.ID 0}}
-						<i class="lock icon"></i>
+						<i class="icons">
+							<i class="lock icon"></i>
+						</i>
 						{{if eq .Verification.TrustStatus "trusted"}}
 							<span class="ui text">{{.i18n.Tr "repo.commits.signed_by"}}:</span>
 						{{else if eq .Verification.TrustStatus "untrusted"}}
@@ -112,17 +114,21 @@
 						<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="cogs icon" title="{{.i18n.Tr "gpg.default_key"}}"></i>{{.Verification.SigningKey.KeyID}}</span>
 					{{end}}
 				{{else if .Verification.Warning}}
-					<i class="unlock icon"></i>
+					<i class="icons">
+						<i class="unlock icon"></i>
+					</i>
 					<span class="ui text">{{.i18n.Tr .Verification.Reason}}</span>
 					<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="warning icon"></i>{{.Verification.SigningKey.KeyID}}</span>
 				{{else}}
-				  <i class="unlock icon"></i>
-				  {{.i18n.Tr .Verification.Reason}}
-				  {{if .Verification.SigningKey}}
-				  	{{if ne .Verification.SigningKey.KeyID ""}}
-						<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="warning icon"></i>{{.Verification.SigningKey.KeyID}}</span>
-				  	{{end}}
-				  {{end}}
+					<i class="icons">
+						<i class="unlock icon"></i>
+					</i>
+					{{.i18n.Tr .Verification.Reason}}
+					{{if .Verification.SigningKey}}
+						{{if ne .Verification.SigningKey.KeyID ""}}
+							<span class="pull-right"><span class="ui text">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span> <i class="warning icon"></i>{{.Verification.SigningKey.KeyID}}</span>
+						{{end}}
+					{{end}}
 				{{end}}
 			</div>
 		{{end}}

--- a/templates/repo/shabox_badge.tmpl
+++ b/templates/repo/shabox_badge.tmpl
@@ -2,10 +2,12 @@
 	{{if .verification.Verified}}
 		<div title="{{if eq .verification.TrustStatus "trusted"}}{{else if eq .verification.TrustStatus "untrusted"}}{{$.root.i18n.Tr "repo.commits.signed_by_untrusted_user"}}: {{else}}{{$.root.i18n.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}: {{end}}{{.verification.Reason}}">
 		{{if ne .verification.SigningUser.ID 0}}
-			<i class="lock icon"></i>
+			<i class="icons">
+				<i class="lock icon"></i>
+			</i>
 			<img class="ui signature avatar image" src="{{.verification.SigningUser.RelAvatarLink}}" />
 		{{else}}
-			<i title="{{.verification.Reason}}" class="icons">
+			<i class="icons">
 				<i class="lock icon"></i>
 				<i class="tiny inverted cog icon centerlock"></i>
 			</i>


### PR DESCRIPTION
Before:
![firefox_2020-06-20_15-43-00](https://user-images.githubusercontent.com/1447794/85203482-76aa2e80-b30e-11ea-9752-eb0d8392065d.png)
![firefox_2020-06-20_15-53-39](https://user-images.githubusercontent.com/1447794/85203483-7742c500-b30e-11ea-9ec5-448696d5af08.png)

After:
![firefox_2020-06-20_15-51-02](https://user-images.githubusercontent.com/1447794/85203491-7ca00f80-b30e-11ea-8ccd-c6a776a9683c.png)
![firefox_2020-06-20_15-54-10](https://user-images.githubusercontent.com/1447794/85203493-7ca00f80-b30e-11ea-859d-9544112434af.png)
