### PR TITLE
Fix missing styling for dropdown icon on review button

### DIFF
--- a/templates/repo/diff/new_review.tmpl
+++ b/templates/repo/diff/new_review.tmpl
@@ -1,6 +1,6 @@
 <div class="ui top right pointing dropdown custom" id="review-box">
 	<div class="ui tiny green button btn-review">
-		<span class="text">{{.i18n.Tr "repo.diff.review"}}</span>
+		{{.i18n.Tr "repo.diff.review"}}
 		<i class="dropdown icon"></i>
 	</div>
 	<div class="menu review-box">

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -156,6 +156,12 @@
     color: #428bca;
 }
 
+.btn-review > .dropdown.icon {
+    width: auto;
+    font-size: .85714286em;
+    margin: 0 0 0 1em;
+}
+
 @media only screen and (max-width: 768px) {
     #review-box > .menu {
         > .ui.segment {


### PR DESCRIPTION
After:
![firefox_2020-06-20_21-18-09](https://user-images.githubusercontent.com/1447794/85209903-f5699080-b33b-11ea-9901-e9b1c4706332.png)
Before:
![firefox_2020-06-20_21-18-32](https://user-images.githubusercontent.com/1447794/85209904-f69abd80-b33b-11ea-80a0-a9a7764ae080.png)
After:
![firefox_2020-06-20_21-19-05](https://user-images.githubusercontent.com/1447794/85209905-f7335400-b33b-11ea-8bbd-6efa9bf5ad02.png)
Before:
![firefox_2020-06-20_21-19-14](https://user-images.githubusercontent.com/1447794/85209906-f7335400-b33b-11ea-999d-864b4b0d37c0.png)
