### PR TITLE
Fix sticky diff stats container

### DIFF
--- a/semantic.json
+++ b/semantic.json
@@ -52,7 +52,6 @@
     "segment",
     "sidebar",
     "site",
-    "sticky",
     "tab",
     "table",
     "text",

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -1,37 +1,37 @@
 {{if .DiffNotAvailable}}
 	<div class="diff-detail-box diff-box ui sticky">
-		<div>
-			<div class="ui right">
-				{{if .PageIsPullFiles}}
-					{{template "repo/diff/whitespace_dropdown" .}}
-				{{else}}
-					<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
-				{{end}}
-				{{template "repo/diff/options_dropdown" .}}
-				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
-					{{template "repo/diff/new_review" .}}
-				{{end}}
-			</div>
+		<div class="ui right">
+			{{if .PageIsPullFiles}}
+				{{template "repo/diff/whitespace_dropdown" .}}
+			{{else}}
+				<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
+			{{end}}
+			{{template "repo/diff/options_dropdown" .}}
+			{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
+				{{template "repo/diff/new_review" .}}
+			{{end}}
 		</div>
 	</div>
-	<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
+	<div id="diff-detail-container">
+		<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
+	</div>
 {{else}}
-	<div>
-		<div class="diff-detail-box diff-box ui sticky">
-			<i class="fa fa-retweet"></i>
-			{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
-			<div class="ui right">
-				{{if .PageIsPullFiles}}
-					{{template "repo/diff/whitespace_dropdown" .}}
-				{{else}}
-					<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
-				{{end}}
-				{{template "repo/diff/options_dropdown" .}}
-				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
-					{{template "repo/diff/new_review" .}}
-				{{end}}
-			</div>
+	<div class="diff-detail-box diff-box ui sticky">
+		<i class="fa fa-retweet"></i>
+		{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
+		<div class="ui right">
+			{{if .PageIsPullFiles}}
+				{{template "repo/diff/whitespace_dropdown" .}}
+			{{else}}
+				<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
+			{{end}}
+			{{template "repo/diff/options_dropdown" .}}
+			{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
+				{{template "repo/diff/new_review" .}}
+			{{end}}
 		</div>
+	</div>
+	<div id="diff-detail-container">
 		<ol class="diff-detail-box diff-stats detail-files hide" id="diff-files">
 			{{range .Diff.Files}}
 				<li>
@@ -192,7 +192,7 @@
 																<td class="add-comment-right">
 																	{{if and $resolved (eq $line.GetCommentSide "proposed")}}
 																		<div class="ui top attached header">
-																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>	
+																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
 																			<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
 																				{{svg "octicon-unfold" 16}}
 																				{{$.i18n.Tr "repo.issues.review.show_resolved"}}
@@ -200,7 +200,7 @@
 																			<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
 																				{{svg "octicon-fold" 16}}
 																				{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
-																			</button>	
+																			</button>
 																		</div>
 																	{{end}}
 																	{{if eq $line.GetCommentSide "proposed"}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -1,37 +1,37 @@
 {{if .DiffNotAvailable}}
-	<div class="diff-detail-box diff-box ui sticky">
-		<div class="ui right">
-			{{if .PageIsPullFiles}}
-				{{template "repo/diff/whitespace_dropdown" .}}
-			{{else}}
-				<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
-			{{end}}
-			{{template "repo/diff/options_dropdown" .}}
-			{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
-				{{template "repo/diff/new_review" .}}
-			{{end}}
+	<div class="diff-detail-box diff-box sticky">
+		<div>
+			<div class="ui right">
+				{{if .PageIsPullFiles}}
+					{{template "repo/diff/whitespace_dropdown" .}}
+				{{else}}
+					<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
+				{{end}}
+				{{template "repo/diff/options_dropdown" .}}
+				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
+					{{template "repo/diff/new_review" .}}
+				{{end}}
+			</div>
 		</div>
 	</div>
-	<div id="diff-detail-container">
-		<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
-	</div>
+	<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
 {{else}}
-	<div class="diff-detail-box diff-box ui sticky">
-		<i class="fa fa-retweet"></i>
-		{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
-		<div class="ui right">
-			{{if .PageIsPullFiles}}
-				{{template "repo/diff/whitespace_dropdown" .}}
-			{{else}}
-				<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
-			{{end}}
-			{{template "repo/diff/options_dropdown" .}}
-			{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
-				{{template "repo/diff/new_review" .}}
-			{{end}}
+	<div>
+		<div class="diff-detail-box diff-box sticky">
+			<i class="fa fa-retweet"></i>
+			{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
+			<div class="ui right">
+				{{if .PageIsPullFiles}}
+					{{template "repo/diff/whitespace_dropdown" .}}
+				{{else}}
+					<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
+				{{end}}
+				{{template "repo/diff/options_dropdown" .}}
+				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
+					{{template "repo/diff/new_review" .}}
+				{{end}}
+			</div>
 		</div>
-	</div>
-	<div id="diff-detail-container">
 		<ol class="diff-detail-box diff-stats detail-files hide" id="diff-files">
 			{{range .Diff.Files}}
 				<li>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1081,6 +1081,10 @@ async function initRepository() {
       const addPercent = parseFloat(addLine) / (parseFloat(addLine) + parseFloat(delLine)) * 100;
       $item.find('.bar .add').css('width', `${addPercent}%`);
     });
+
+    $('.diff-detail-box.ui.sticky').sticky({
+      context: '#diff-detail-container'
+    });
   }
 
   // Quick start and repository home
@@ -1114,6 +1118,8 @@ async function initRepository() {
       $repoComparePull.find('.pullrequest-form').show();
       autoSimpleMDE.codemirror.refresh();
       $(this).parent().hide();
+
+      $('.diff-detail-box.ui.sticky').sticky('refresh');
     });
   }
 
@@ -1204,7 +1210,7 @@ function initPullRequestReview() {
     return;
   }
 
-  $('.diff-detail-box.ui.sticky').sticky();
+  $('.diff-detail-box.ui.sticky').sticky('refresh');
 
   $('.btn-review').on('click', function (e) {
     e.preventDefault();
@@ -2042,7 +2048,7 @@ function initCodeView() {
     $.get(`${$blob.data('url')}?${$blob.data('query')}&anchor=${$blob.data('anchor')}`, (blob) => {
       $row.replaceWith(blob);
       $(`[data-anchor="${$blob.data('anchor')}"]`).on('click', (e) => { insertBlobExcerpt(e) });
-      $('.diff-detail-box.ui.sticky').sticky();
+      $('.diff-detail-box.ui.sticky').sticky('refresh');
     });
   }
   $('.ui.blob-excerpt').on('click', (e) => { insertBlobExcerpt(e) });

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1081,10 +1081,6 @@ async function initRepository() {
       const addPercent = parseFloat(addLine) / (parseFloat(addLine) + parseFloat(delLine)) * 100;
       $item.find('.bar .add').css('width', `${addPercent}%`);
     });
-
-    $('.diff-detail-box.ui.sticky').sticky({
-      context: '#diff-detail-container'
-    });
   }
 
   // Quick start and repository home
@@ -1118,8 +1114,6 @@ async function initRepository() {
       $repoComparePull.find('.pullrequest-form').show();
       autoSimpleMDE.codemirror.refresh();
       $(this).parent().hide();
-
-      $('.diff-detail-box.ui.sticky').sticky('refresh');
     });
   }
 
@@ -1209,8 +1203,6 @@ function initPullRequestReview() {
   if ($('.repository.pull.diff').length === 0) {
     return;
   }
-
-  $('.diff-detail-box.ui.sticky').sticky('refresh');
 
   $('.btn-review').on('click', function (e) {
     e.preventDefault();
@@ -2048,7 +2040,6 @@ function initCodeView() {
     $.get(`${$blob.data('url')}?${$blob.data('query')}&anchor=${$blob.data('anchor')}`, (blob) => {
       $row.replaceWith(blob);
       $(`[data-anchor="${$blob.data('anchor')}"]`).on('click', (e) => { insertBlobExcerpt(e) });
-      $('.diff-detail-box.ui.sticky').sticky('refresh');
     });
   }
   $('.ui.blob-excerpt').on('click', (e) => { insertBlobExcerpt(e) });

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1567,6 +1567,14 @@
         background: #ffffff;
         line-height: 30px;
 
+        &.sticky {
+            position: sticky;
+            top: 0;
+            z-index: 800;
+            margin-bottom: 10px;
+            border-bottom: 1px solid #d4d4d5;
+        }
+
         > div:after {
             clear: both;
             content: "";

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1573,6 +1573,8 @@
             z-index: 800;
             margin-bottom: 10px;
             border-bottom: 1px solid #d4d4d5;
+            padding-left: 5px;
+            padding-right: 5px;
         }
 
         > div:after {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1338,7 +1338,7 @@ a.ui.labels .label:hover {
     }
 
     &.sticky {
-        border-bottom-color: rgba(255,255,255,.1);
+        border-bottom-color: rgba(255, 255, 255, .1);
     }
 }
 

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1336,6 +1336,10 @@ a.ui.labels .label:hover {
     .detail-files {
         background-color: inherit;
     }
+
+    &.sticky {
+        border-bottom-color: rgba(255,255,255,.1);
+    }
 }
 
 .comment-code-cloud {


### PR DESCRIPTION
Use pure CSS `position: sticky` and disable Fomantic sticky component

![chrome_2020-06-21_13-41-48](https://user-images.githubusercontent.com/1447794/85223707-25a94180-b3c5-11ea-8d6d-94f26253bfec.png)
![chrome_2020-06-21_13-42-02](https://user-images.githubusercontent.com/1447794/85223710-26da6e80-b3c5-11ea-9446-4607349ab4e0.png)

The border is applied always because there isn't any way to check if element is stuck or not without delegating to JS.