### PR TITLE
Make tabs smaller

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,6 +11,7 @@ rules:
   declaration-empty-line-before: null
   indentation: 4
   no-descending-specificity: null
+  no-duplicate-selectors: null
   number-leading-zero: never
   rule-empty-line-before: null
   selector-pseudo-element-colon-notation: null

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,7 +11,6 @@ rules:
   declaration-empty-line-before: null
   indentation: 4
   no-descending-specificity: null
-  no-duplicate-selectors: null
   number-leading-zero: never
   rule-empty-line-before: null
   selector-pseudo-element-colon-notation: null

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -887,6 +887,7 @@ footer {
     padding-top: 15px !important;
     margin-top: -15px !important;
     margin-bottom: 15px !important;
+    background: #fafafa;
     border-width: 1px !important;
 }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1289,8 +1289,6 @@ i.icon.centerlock {
 }
 
 .ui.tabular.menu {
-    min-height: 40px;
-
     .item {
         padding: 10px 12px;
         color: rgba(0, 0, 0, .5);

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -895,6 +895,7 @@ footer {
     .ui.menu.new-menu {
         overflow-x: auto !important;
         justify-content: left !important;
+        padding-bottom: 2px;
     }
 
     .ui.menu.new-menu::-webkit-scrollbar {
@@ -1306,9 +1307,9 @@ i.icon.centerlock {
     min-height: 36px;
 }
 .ui.tabular.menu .item {
-    padding: 0 10px;
+    padding: 0 11px;
 }
 /* admin page */
 .ui.secondary.pointing.menu .item {
-    padding: 10px;
+    padding: 11px;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -887,7 +887,6 @@ footer {
     padding-top: 15px !important;
     margin-top: -15px !important;
     margin-bottom: 15px !important;
-    background-color: #fafafa !important;
     border-width: 1px !important;
 }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1292,7 +1292,7 @@ i.icon.centerlock {
     min-height: 40px;
 
     .item {
-        padding: 4px 12px;
+        padding: 6px 12px;
         color: rgba(0, 0, 0, .5);
     }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1289,10 +1289,10 @@ i.icon.centerlock {
 }
 
 .ui.tabular.menu {
-    min-height: 36px;
+    min-height: 40px;
 
     .item {
-        padding: 0 .75rem;
+        padding: 4px 12px;
         color: rgba(0, 0, 0, .5);
     }
 
@@ -1302,9 +1302,10 @@ i.icon.centerlock {
 
     .item.active {
         color: rgba(0, 0, 0, .9);
+        margin-top: 1px; /* offset fomantic's margin-bottom: -1px */
     }
 }
 
 .ui.secondary.pointing.menu .item {
-    padding: .75rem;
+    padding: 12px;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1290,7 +1290,7 @@ i.icon.centerlock {
 
 .ui.tabular.menu {
     .item {
-        padding: 10px 12px;
+        padding: 11px 12px;
         color: rgba(0, 0, 0, .5);
     }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1289,10 +1289,10 @@ i.icon.centerlock {
 }
 
 .ui.tabular.menu {
-    min-height: 40px;
+    min-height: 36px;
 
     .item {
-        padding: 6px 12px;
+        padding: 8px 12px;
         color: rgba(0, 0, 0, .5);
     }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1011,19 +1011,6 @@ footer {
     margin-top: 3em !important;
 }
 
-/* Tab color tweaks */
-.ui.tabular.menu .item {
-    color: rgba(0, 0, 0, .5);
-}
-
-.ui.tabular.menu .item:hover {
-    color: rgba(0, 0, 0, .8);
-}
-
-.ui.tabular.menu .item.active {
-    color: rgba(0, 0, 0, .9);
-}
-
 /* multiple radio or checkboxes as inline element */
 .inline-grouped-list {
     display: inline-block;
@@ -1301,15 +1288,23 @@ i.icon.centerlock {
     text-transform: none;
 }
 
-/* reduce padding around tab items to save some space */
-/* repo header */
 .ui.tabular.menu {
     min-height: 36px;
+
+    .item {
+        padding: 0 11px;
+        color: rgba(0, 0, 0, .5);
+    }
+
+    .item:hover {
+        color: rgba(0, 0, 0, .8);
+    }
+
+    .item.active {
+        color: rgba(0, 0, 0, .9);
+    }
 }
-.ui.tabular.menu .item {
-    padding: 0 11px;
-}
-/* admin page */
+
 .ui.secondary.pointing.menu .item {
     padding: 11px;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1300,3 +1300,13 @@ i.icon.centerlock {
 .ui.sub.header {
     text-transform: none;
 }
+
+/* reduce padding around tab items to save some space */
+/* repo header */
+.ui.tabular.menu .item {
+    padding: 0 .75rem;
+}
+/* admin page */
+.ui.secondary.pointing.menu .item {
+    padding: .75rem;
+}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1289,10 +1289,10 @@ i.icon.centerlock {
 }
 
 .ui.tabular.menu {
-    min-height: 36px;
+    min-height: 40px;
 
     .item {
-        padding: 8px 12px;
+        padding: 10px 12px;
         color: rgba(0, 0, 0, .5);
     }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -895,7 +895,6 @@ footer {
     .ui.menu.new-menu {
         overflow-x: auto !important;
         justify-content: left !important;
-        padding-bottom: 5px;
     }
 
     .ui.menu.new-menu::-webkit-scrollbar {
@@ -1303,10 +1302,13 @@ i.icon.centerlock {
 
 /* reduce padding around tab items to save some space */
 /* repo header */
+.ui.tabular.menu {
+    min-height: 36px;
+}
 .ui.tabular.menu .item {
-    padding: 0 .75rem;
+    padding: 0 10px;
 }
 /* admin page */
 .ui.secondary.pointing.menu .item {
-    padding: .75rem;
+    padding: 10px;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1292,7 +1292,7 @@ i.icon.centerlock {
     min-height: 36px;
 
     .item {
-        padding: 0 11px;
+        padding: 0 .75rem;
         color: rgba(0, 0, 0, .5);
     }
 
@@ -1306,5 +1306,5 @@ i.icon.centerlock {
 }
 
 .ui.secondary.pointing.menu .item {
-    padding: 11px;
+    padding: .75rem;
 }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3037,3 +3037,13 @@ td.blob-excerpt {
 .added-code {
     background-color: #99ff99;
 }
+
+.repository .ui.menu.new-menu {
+    background: none !important;
+
+    @media only screen and (max-width: 1200px) {
+        &:after {
+            background: none !important;
+        }
+    }
+}

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -903,10 +903,11 @@ a.ui.basic.green.label:hover {
 
 .ui.menu.new-menu {
     background-color: #2a2e3a !important;
+    border: none !important;
 
     @media only screen and (max-width: 1200px) {
         &:after {
-            background-image: linear-gradient(to right, rgba(42, 46, 42, 0), rgba(42, 46, 42, 1) 100%);
+            background-image: linear-gradient(to right, transparent 0%, #2a2e3a 100%);
         }
     }
 }

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -522,7 +522,7 @@ a.ui.basic.green.label:hover {
         border-top-color: transparent;
         border-left-color: transparent;
         border-right-color: transparent;
-        background: #404552;
+        background: #383c4a;
         color: #dbdbdb;
     }
 
@@ -536,7 +536,6 @@ a.ui.basic.green.label:hover {
 
     &.navbar {
         .item.active {
-            background: #383c4a;
             border-left-color: transparent;
             border-right-color: transparent;
             border-top: none;
@@ -859,8 +858,6 @@ a.ui.basic.green.label:hover {
 
 .ui.secondary.pointing.menu .active.item {
     color: #dbdbdb;
-    border: 0;
-    background: #383c4a;
 }
 
 .ui.user.list .item:not(:first-child) {
@@ -870,7 +867,6 @@ a.ui.basic.green.label:hover {
 .ui.secondary.pointing.menu .active.item:hover {
     border-color: #af8b4c;
     color: #dbdbdb;
-    background: #4b5162;
 }
 
 .ui.secondary.pointing.menu .dropdown.item:hover,
@@ -903,7 +899,7 @@ a.ui.basic.green.label:hover {
 
 .ui.menu.new-menu {
     background-color: #2a2e3a !important;
-    border: none !important;
+    border-color: rgba(187, 187, 187, .24) !important;
 
     @media only screen and (max-width: 1200px) {
         &:after {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -516,7 +516,7 @@ a.ui.basic.green.label:hover {
 }
 
 .ui.tabular.menu {
-    border-bottom-color: rgba(187, 187, 187, .24);
+    border-bottom-color: rgba(255, 255, 255, .1);
 
     .item.active {
         border-top-color: transparent;
@@ -856,6 +856,10 @@ a.ui.basic.green.label:hover {
     background: #353945;
 }
 
+.ui.secondary.pointing.menu {
+    border-bottom-color: rgba(255, 255, 255, .15);
+}
+
 .ui.secondary.pointing.menu .active.item {
     color: #dbdbdb;
 }
@@ -897,12 +901,12 @@ a.ui.basic.green.label:hover {
 }
 
 .ui.menu.new-menu {
-    background-color: #2a2e3a !important;
-    border-color: rgba(187, 187, 187, .24) !important;
+    background-color: #383c4a !important;
+    border-color: rgba(255, 255, 255, .15) !important;
 
     @media only screen and (max-width: 1200px) {
         &:after {
-            background-image: linear-gradient(to right, transparent 0%, #2a2e3a 100%);
+            background-image: linear-gradient(to right, transparent 0%, #383c4a 100%);
         }
     }
 }
@@ -1355,7 +1359,7 @@ a.ui.labels .label:hover {
             background: #404552;
         }
 
-        border-color: rgba(187, 187, 187, .24);
+        border-color: rgba(255, 255, 255, .15);
     }
 
     .footer {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -900,12 +900,12 @@ a.ui.basic.green.label:hover {
 }
 
 .ui.menu.new-menu {
-    background-color: #383c4a !important;
-    border-color: rgba(255, 255, 255, .15) !important;
+    background: #2a2e3a;
+    border-color: transparent !important;
 
     @media only screen and (max-width: 1200px) {
         &:after {
-            background-image: linear-gradient(to right, transparent 0%, #383c4a 100%);
+            background: linear-gradient(to right, transparent 0%, #2a2e3a 100%);
         }
     }
 }

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -865,7 +865,6 @@ a.ui.basic.green.label:hover {
 }
 
 .ui.secondary.pointing.menu .active.item:hover {
-    border-color: #af8b4c;
     color: #dbdbdb;
 }
 

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -538,7 +538,6 @@ a.ui.basic.green.label:hover {
         .item.active {
             border-left-color: transparent;
             border-right-color: transparent;
-            border-top: none;
         }
     }
 }


### PR DESCRIPTION
Fomantic's tabs are excessively wide and with another tab added on the repo tab bar (https://github.com/go-gitea/gitea/pull/8346) it would break the layout on the english language.

Globally reduce tab bar padding to around half of the previous values. Also the "pointing" tab bar now follows the original styling more in arc-green.

Before:

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/115237/85233128-6bd1c580-b404-11ea-8f8b-44cacbf4714a.png">
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/115237/85234405-62009000-b40d-11ea-81c1-9f4d251e1869.png">
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/115237/85234327-e4d51b00-b40c-11ea-94e8-a2be0f4fa778.png">


After:

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/115237/85233801-6aef6280-b409-11ea-9851-8455f72559bc.png">
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/115237/85234386-52814700-b40d-11ea-8195-6cff99a43cca.png">
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/115237/85234334-f6b6be00-b40c-11ea-8ec1-d957a75b9239.png">



