### PR TITLE
Fix GO source vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
 	CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -mod=vendor $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: release
-release: frontend generate release-windows release-linux release-darwin release-copy release-compress release-sources release-check
+release: vendor frontend generate release-windows release-linux release-darwin release-copy release-compress release-sources release-check
 
 $(DIST_DIRS):
 	mkdir -p $(DIST_DIRS)


### PR DESCRIPTION
This commit fixes error like this:
```
CC= GOOS= GOARCH= go generate -mod=vendor -tags 'bindata pam sqlite sqlite_unlock_notify' 
go: inconsistent vendoring in /builddir/build/BUILD/gitea-1.12.1:
	src.techknowlogick.com/xgo@v0.0.0-20200602060627-a09175ea9056: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
go: inconsistent vendoring in /builddir/build/BUILD/gitea-1.12.1:
	src.techknowlogick.com/xgo@v0.0.0-20200602060627-a09175ea9056: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
make: *** [Makefile:518: generate] Error 1
```

Maybe somebody's got a better fix? I'm not sure if my decision is right because the vendor is already in the repository.