### PR TITLE
Disable dropzone's timeout

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -899,6 +899,7 @@ async function initRepository() {
             dictInvalidFileType: $dropzone.data('invalid-input-type'),
             dictFileTooBig: $dropzone.data('file-too-big'),
             dictRemoveFile: $dropzone.data('remove-file'),
+            timeout: 0,
             init() {
               this.on('success', (file, data) => {
                 filenameDict[file.name] = {
@@ -2304,6 +2305,7 @@ $(document).ready(async () => {
       dictInvalidFileType: $dropzone.data('invalid-input-type'),
       dictFileTooBig: $dropzone.data('file-too-big'),
       dictRemoveFile: $dropzone.data('remove-file'),
+      timeout: 0,
       init() {
         this.on('success', (file, data) => {
           filenameDict[file.name] = data.uuid;


### PR DESCRIPTION
Dropzone 4.4 introduced a 30s XHR timeout that will kill any upload still in progress. This disables that timeout again.

Ref: https://www.dropzonejs.com/#config-timeout
Ref: https://xhr.spec.whatwg.org/#the-timeout-attribute
Ref: https://github.com/go-gitea/gitea/pull/10645
Fixes: https://github.com/go-gitea/gitea/issues/12022
Fixes: https://github.com/go-gitea/gitea/issues/11906