### PR TITLE
Ensure BlameReaders close at end of request

### DIFF
--- a/modules/git/blame_test.go
+++ b/modules/git/blame_test.go
@@ -5,6 +5,7 @@
 package git
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -93,8 +94,10 @@ func TestReadingBlameOutput(t *testing.T) {
 	if _, err = tempFile.WriteString(exampleBlame); err != nil {
 		panic(err)
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	blameReader, err := createBlameReader("", "cat", tempFile.Name())
+	blameReader, err := createBlameReader(ctx, "", "cat", tempFile.Name())
 	if err != nil {
 		panic(err)
 	}

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -123,7 +123,7 @@ func RefBlame(ctx *context.Context) {
 		return
 	}
 
-	blameReader, err := git.CreateBlameReader(models.RepoPath(userName, repoName), commitID, fileName)
+	blameReader, err := git.CreateBlameReader(ctx.Req.Context(), models.RepoPath(userName, repoName), commitID, fileName)
 	if err != nil {
 		ctx.NotFound("CreateBlameReader", err)
 		return


### PR DESCRIPTION
#11716 reports multiple git blame processes hanging around
this was thought to be due to timeouts, however on closer look this
appears to be due to the Close() function of the BlameReader hanging
with a blocked stdout pipe.

This PR fixes this Close function to:

* Cancel the context of the cmd
* Close the StdoutReader - ensuring that the output pipe is closed

Further it makes the context of the `git blame` command a child of the
request context - ensuring that even if Close() is not called, on
cancellation of the Request the blame command will also be cancelled.

Fixes #11716
Closes #11727

Signed-off-by: Andrew Thornton <art27@cantab.net>
