### PR TITLE
Set the base url when migrating from Gitlab using access token or username without password (#11852)

### DIFF
--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -90,7 +90,7 @@ func NewGitlabDownloader(baseURL, repoPath, username, password string) *GitlabDo
 	var err error
 	if username != "" {
 		if password == "" {
-			gitlabClient, err = gitlab.NewClient(username)
+			gitlabClient, err = gitlab.NewClient(username, gitlab.WithBaseURL(baseURL))
 		} else {
 			gitlabClient, err = gitlab.NewBasicAuthClient(username, password, gitlab.WithBaseURL(baseURL))
 		}


### PR DESCRIPTION
Backport #11852

When migrating from gitlab, set the baseUrl in NewGitlabDownloader when using an access token or username without password

Fix #11851
