### PR TITLE
Improve arc-green code colors

### DIFF
--- a/web_src/less/_chroma.less
+++ b/web_src/less/_chroma.less
@@ -221,7 +221,6 @@
 /* LiteralStringRegex */
 
 .chroma .sr {
-    font-weight: bold;
     color: #22863a;
 }
 /* LiteralStringSingle */
@@ -303,7 +302,6 @@
 
 .chroma .cs {
     color: #999999;
-    font-style: italic;
 }
 /* CommentPreproc */
 
@@ -325,7 +323,6 @@
 
 .chroma .ge {
     color: #000000;
-    font-style: italic;
 }
 /* GenericError */
 

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -46,99 +46,92 @@
 /* Keyword */
 
 .chroma .k {
-    color: #9daccc;
-    font-weight: bold;
+    color: #f63;
 }
 /* KeywordConstant */
 
 .chroma .kc {
-    color: #9daccc;
-    font-weight: bold;
+    color: #fa1;
 }
 /* KeywordDeclaration */
 
 .chroma .kd {
     color: #9daccc;
-    font-weight: bold;
 }
 /* KeywordNamespace */
 
 .chroma .kn {
-    color: #9daccc;
-    font-weight: bold;
+    color: #fa1;
 }
 /* KeywordPseudo */
 
 .chroma .kp {
-    color: #9daccc;
-    font-weight: bold;
+    color: #5f8700;
 }
 /* KeywordReserved */
 
 .chroma .kr {
-    color: #9daccc;
-    font-weight: bold;
+    color: #f63;
 }
 /* KeywordType */
 
 .chroma .kt {
     color: #9daccc;
-    font-weight: bold;
 }
 /* NameAttribute */
 
 .chroma .na {
-    color: #8ff;
+    color: #8a8a8a;
 }
 /* NameBuiltin */
 
 .chroma .nb {
-    color: #e0c46c;
+    color: #9daccc;
 }
 /* NameBuiltinPseudo */
 
 .chroma .bp {
-    color: #999999;
+    color: #9daccc;
 }
 /* NameClass */
 
 .chroma .nc {
-    color: #445588;
+    color: #fa1;
 }
 /* NameConstant */
 
 .chroma .no {
-    color: #8ff;
+    color: #fa1;
 }
 /* NameDecorator */
 
 .chroma .nd {
-    color: #3c5d5d;
+    color: #9daccc;
 }
 /* NameEntity */
 
 .chroma .ni {
-    color: #f8f;
+    color: #fa1;
 }
 /* NameException */
 
 .chroma .ne {
-    color: #f88;
+    color: #af8700;
 }
 /* NameFunction */
 
 .chroma .nf {
-    color: #986c88;
+    color: #9daccc;
 }
 /* NameLabel */
 
 .chroma .nl {
-    color: #f88;
+    color: #fa1;
 }
 /* NameNamespace */
 
 .chroma .nn {
-    color: #555555;
+    color: #fa1;
 }
 /* NameOther */
 
@@ -148,206 +141,205 @@
 /* NameTag */
 
 .chroma .nt {
-    color: #88f;
+    color: #9daccc;
 }
 /* NameVariable */
 
 .chroma .nv {
-    color: #cb7832;
+    color: #9daccc;
 }
 /* NameVariableClass */
 
 .chroma .vc {
-    color: #cb7832;
+    color: #f81;
 }
 /* NameVariableGlobal */
 
 .chroma .vg {
-    color: #cb7832;
+    color: #fa1;
 }
 /* NameVariableInstance */
 
 .chroma .vi {
-    color: #cb7832;
+    color: #fa1;
 }
 /* LiteralString */
 
 .chroma .s {
-    color: #8ab398;
+    color: #1af;
 }
 /* LiteralStringAffix */
 
 .chroma .sa {
-    color: #8ab398;
+    color: #1af;
 }
 /* LiteralStringBacktick */
 
 .chroma .sb {
-    color: #8ab398;
+    color: #a0cc75;
 }
 /* LiteralStringChar */
 
 .chroma .sc {
-    color: #8ab398;
+    color: #1af;
 }
 /* LiteralStringDelimiter */
 
 .chroma .dl {
-    color: #8ab398;
+    color: #1af;
 }
 /* LiteralStringDoc */
 
 .chroma .sd {
-    color: #8ab398;
+    color: #6a737d;
 }
 /* LiteralStringDouble */
 
 .chroma .s2 {
-    color: #8ab398;
+    color: #a0cc75;
 }
 /* LiteralStringEscape */
 
 .chroma .se {
-    color: #8ab398;
+    color: #f63;
 }
 /* LiteralStringHeredoc */
 
 .chroma .sh {
-    color: #8ab398;
+    color: #1af;
 }
 /* LiteralStringInterpol */
 
 .chroma .si {
-    color: #8ab398;
+    color: #fa1;
 }
 /* LiteralStringOther */
 
 .chroma .sx {
-    color: #8ab398;
+    color: #fa1;
 }
 /* LiteralStringRegex */
 
 .chroma .sr {
-    color: #6896ba;
+    color: #97c;
 }
 /* LiteralStringSingle */
 
 .chroma .s1 {
-    color: #8ab398;
+    color: #a0cc75;
 }
 /* LiteralStringSymbol */
 
 .chroma .ss {
-    color: #6896ba;
+    color: #fa1;
 }
 /* LiteralNumber */
 
 .chroma .m {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberBin */
 
 .chroma .mb {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberFloat */
 
 .chroma .mf {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberHex */
 
 .chroma .mh {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberInteger */
 
 .chroma .mi {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberIntegerLong */
 
 .chroma .il {
-    color: #6896ba;
+    color: #1af;
 }
 /* LiteralNumberOct */
 
 .chroma .mo {
-    color: #6896ba;
+    color: #1af;
 }
 /* Operator */
 
 .chroma .o {
-    color: #9daccc;
+    color: #f63;
 }
 /* OperatorWord */
 
 .chroma .ow {
-    color: #9daccc;
+    color: #5f8700;
 }
 /* Comment */
 
 .chroma .c {
-    color: #7f7f7f;
+    color: #6a737d;
 }
 /* CommentHashbang */
 
 .chroma .ch {
-    color: #7f7f7f;
+    color: #6a737d;
 }
 /* CommentMultiline */
 
 .chroma .cm {
-    color: #7f7f7f;
+    color: #6a737d;
 }
 /* CommentSingle */
 
 .chroma .c1 {
-    color: #7f7f7f;
+    color: #6a737d;
 }
 /* CommentSpecial */
 
 .chroma .cs {
-    color: #7f7f7f;
+    color: #6a737d;
     font-style: italic;
 }
 /* CommentPreproc */
 
 .chroma .cp {
-    color: #7f7f7f;
+    color: #fc6;
 }
 /* CommentPreprocFile */
 
 .chroma .cpf {
-    color: #7f7f7f;
+    color: #fc6;
 }
 /* GenericDeleted */
 
 .chroma .gd {
-    color: #9e9e9e;
-    background-color: #ffdddd;
+    color: #fff;
+    background-color: #d33;
 }
 /* GenericEmph */
 
 .chroma .ge {
-    color: #9e9e9e;
     font-style: italic;
 }
 /* GenericError */
 
 .chroma .gr {
-    color: #aa0000;
+    color: #f33;
 }
 /* GenericHeading */
 
 .chroma .gh {
-    color: #999999;
+    color: #fa1;
 }
 /* GenericInserted */
 
 .chroma .gi {
-    color: #9e9e9e;
-    background-color: #ddffdd;
+    color: #fff;
+    background-color: #3a3;
 }
 /* GenericOutput */
 
@@ -362,18 +354,17 @@
 /* GenericStrong */
 
 .chroma .gs {
-    color: #a8a8a2;
     font-weight: bold;
 }
 /* GenericSubheading */
 
 .chroma .gu {
-    color: #888;
+    color: #9daccc;
 }
 /* GenericTraceback */
 
 .chroma .gt {
-    color: #aa0000;
+    color: #f63;
 }
 /* GenericUnderline */
 

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -301,8 +301,7 @@
 /* CommentSpecial */
 
 .chroma .cs {
-    color: #6a737d;
-    font-style: italic;
+    color: #637d;
 }
 /* CommentPreproc */
 
@@ -318,7 +317,7 @@
 
 .chroma .gd {
     color: #fff;
-    background-color: #d33;
+    background-color: #5f3737;
 }
 /* GenericEmph */
 
@@ -339,7 +338,7 @@
 
 .chroma .gi {
     color: #fff;
-    background-color: #3a3;
+    background-color: #3a523a;
 }
 /* GenericOutput */
 


### PR DESCRIPTION
This should fix all previous colors that had too few contrast on the background. I took solarized-dark as a baseline and did various changes, adding some more color in general. I removed bold/italic flags because I don't think they fit and generally other tools also don't use those font flags.

# before
<img width="976" alt="image" src="https://user-images.githubusercontent.com/115237/86269783-8b1ddf00-bbca-11ea-8bd6-da089a0ff244.png">
<img width="661" alt="image" src="https://user-images.githubusercontent.com/115237/86270027-e0f28700-bbca-11ea-8108-8ac3c6bab824.png">

# after
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/115237/86269829-97a23780-bbca-11ea-81ca-e5c49d687e64.png">
<img width="642" alt="image" src="https://user-images.githubusercontent.com/115237/86270050-ea7bef00-bbca-11ea-90fd-694262a3f63f.png">
<img width="435" alt="image" src="https://user-images.githubusercontent.com/115237/86271305-f23c9300-bbcc-11ea-9052-2ecf2da503bc.png">

