### PR TITLE
Re-fix #12095 again

### DIFF
--- a/web_src/js/features/eventsource.sharedworker.js
+++ b/web_src/js/features/eventsource.sharedworker.js
@@ -16,7 +16,7 @@ class Source {
   }
 
   register(port) {
-    if (!this.clients.includes(port)) return;
+    if (this.clients.includes(port)) return;
 
     this.clients.push(port);
 

--- a/web_src/js/features/notification.js
+++ b/web_src/js/features/notification.js
@@ -29,7 +29,7 @@ async function receiveUpdateCount(event) {
       notificationCount.classList.add('hidden');
     }
 
-    notificationCount.text(`${data.Count}`);
+    notificationCount.textContent = `${data.Count}`;
     await updateNotificationTable();
   } catch (error) {
     console.error(error, event);


### PR DESCRIPTION
Unfortunately some of the suggested changes to #12095 introduced
bugs which due to caching behaviour of sharedworkers were not caught
on simple tests.

These are as follows:

* Changing from simple for loop to use includes here:

```js
  register(port) {
    if (!this.clients.includes(port)) return;

    this.clients.push(port);

    port.postMessage({
      type: 'status',
      message: `registered to ${this.url}`,
    });
  }
```

The additional `!` prevents any clients from being added and should
read:

```js
    if (this.clients.includes(port)) return;
```

* Dropping the use of jQuery `$(...)` selection and using DOM
`querySelector` here:

```js
async function receiveUpdateCount(event) {
  try {
    const data = JSON.parse(event.data);

    const notificationCount = document.querySelector('.notification_count');
    if (data.Count > 0) {
      notificationCount.classList.remove('hidden');
    } else {
      notificationCount.classList.add('hidden');
    }

    notificationCount.text() = `${data.Count}`;
    await updateNotificationTable();
  } catch (error) {
    console.error(error, event);
  }
}
```

Requires that `notificationCount.text()` be changed to use `textContent`
instead.

Signed-off-by: Andrew Thornton <art27@cantab.net>
