### PR TITLE
Fix repository setup instructions when default branch is not master (#12122)

### DIFF
--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -49,7 +49,7 @@
 								<div class="markdown">
 									<pre><code>touch README.md
 git init
-{{if ne .Repository.DefaultBranch "master"}}git branch -m master {{.Repository.DefaultBranch}}{{end}}
+{{if ne .Repository.DefaultBranch "master"}}git checkout -b {{.Repository.DefaultBranch}}{{end}}
 git add README.md
 git commit -m "first commit"
 git remote add origin <span class="clone-url">{{if $.DisableSSH}}{{$.CloneLink.HTTPS}}{{else}}{{$.CloneLink.SSH}}{{end}}</span>


### PR DESCRIPTION
Backport #12122 

the initial repo push instructions do not work, at least when the default branch is not master.

This should fix it.