### PR TITLE
Fix U2F button icon

### DIFF
--- a/templates/user/settings/security_u2f.tmpl
+++ b/templates/user/settings/security_u2f.tmpl
@@ -24,7 +24,7 @@
 				<label for="nickname">{{.i18n.Tr "settings.u2f_nickname"}}</label>
 				<input id="nickname" name="nickname" type="text" required>
 			</div>
-			<button id="register-security-key" class="positive ui labeled icon button"><i class="usb icon"></i>{{.i18n.Tr "settings.u2f_register_key"}}</button>
+			<button id="register-security-key" class="ui green button">{{svg "octicon-key" 16}} {{.i18n.Tr "settings.u2f_register_key"}}</button>
 		</div>
 	{{else}}
 		<b>{{.i18n.Tr "settings.u2f_require_twofa"}}</b>


### PR DESCRIPTION
I assumed the file being unused but it's apparently in use on the "Add Security Key" button where a USB icon is shown.

@CirnoT please confirm if possible.