### PR TITLE
Enable cloning via Git Wire Protocol v2 over HTTP

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -227,6 +227,12 @@ func (c *Command) RunInDirWithEnv(dir string, env []string) (string, error) {
 	return string(stdout), nil
 }
 
+// RunInDirWithEnvBytes executes the command in given directory
+// and returns stdout in []byte and error (combined with stderr).
+func (c *Command) RunInDirWithEnvBytes(dir string, env []string) ([]byte, error) {
+	return c.RunInDirTimeoutEnv(env, -1, dir)
+}
+
 // RunTimeout executes the command in default working directory with given timeout,
 // and returns stdout in string and error (combined with stderr).
 func (c *Command) RunTimeout(timeout time.Duration) (string, error) {

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -227,12 +227,6 @@ func (c *Command) RunInDirWithEnv(dir string, env []string) (string, error) {
 	return string(stdout), nil
 }
 
-// RunInDirWithEnvBytes executes the command in given directory
-// and returns stdout in []byte and error (combined with stderr).
-func (c *Command) RunInDirWithEnvBytes(dir string, env []string) ([]byte, error) {
-	return c.RunInDirTimeoutEnv(env, -1, dir)
-}
-
 // RunTimeout executes the command in default working directory with given timeout,
 // and returns stdout in string and error (combined with stderr).
 func (c *Command) RunTimeout(timeout time.Duration) (string, error) {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -565,11 +565,7 @@ func serviceRPC(h serviceHandler, service string) {
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, git.GitExecutable, service, "--stateless-rpc", h.dir)
 	cmd.Dir = h.dir
-	if service == "receive-pack" {
-		cmd.Env = append(os.Environ(), h.environ...)
-	} else {
-		cmd.Env = h.environ
-	}
+	cmd.Env = append(os.Environ(), h.environ...)
 	cmd.Stdout = h.w
 	cmd.Stdin = reqBody
 	cmd.Stderr = &stderr
@@ -623,6 +619,7 @@ func getInfoRefs(h serviceHandler) {
 		if protocol := h.r.Header.Get("Git-Protocol"); protocol != "" && safeGitProtocolHeader.MatchString(protocol) {
 			h.environ = append(h.environ, "GIT_PROTOCOL="+protocol)
 		}
+		h.environ = append(os.Environ(), h.environ...)
 
 		refs, err := git.NewCommand(service, "--stateless-rpc", "--advertise-refs", ".").RunInDirTimeoutEnv(h.environ, -1, h.dir)
 		if err != nil {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -624,7 +624,7 @@ func getInfoRefs(h serviceHandler) {
 			h.environ = append(h.environ, "GIT_PROTOCOL="+protocol)
 		}
 
-		refs, err := git.NewCommand(service, "--stateless-rpc", "--advertise-refs", ".").RunInDirWithEnvBytes(h.dir, h.environ)
+		refs, err := git.NewCommand(service, "--stateless-rpc", "--advertise-refs", ".").RunInDirTimeoutEnv(h.environ, -1, h.dir)
 		if err != nil {
 			log.Error(fmt.Sprintf("%v - %s", err, string(refs)))
 		}


### PR DESCRIPTION
This change makes it possible to clone Gitea repositories via HTTP(S) using Git Wire Protocol Version 2, which is not currently possible. Original discussion started with my comment [here](https://github.com/go-gitea/gitea/issues/4002#issuecomment-654471455).

TL;DR - we need to run the `serviceRPC` and `getInfoRefs` with a new environment variable, [`GIT_PROTOCOL`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITPROTOCOLcode).

I compiled and ran it locally using the sqlite backend and successfully got [partial clone](https://git-scm.com/docs/partial-clone) working! (It requires running `git config uploadpack.allowfilter 1` on each repository in `~/gitea-repositories`, but partial clone is considered experimental so some extra work to enable it seems fair.)

![2020-07-06 23 45 11](https://user-images.githubusercontent.com/587740/86704405-d7aa5580-bfe2-11ea-996b-fd0c51989ed3.gif)
