### PR TITLE
Adjust margin-top for repo header label

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -16,6 +16,7 @@
 
             .label {
                 vertical-align: middle;
+                margin-top: -.29165em;
             }
 
             &.repo-title .repo-header-icon {


### PR DESCRIPTION
Very minor, mirror what Fomantic does for normal `.header` class:
```css
.ui.header > .ui.label {
    margin-top: -.29165em;
}
```

Before:
![firefox_2020-07-07_11-10-36](https://user-images.githubusercontent.com/1447794/86756371-a06b9100-c042-11ea-9fab-010a8b8dc992.png)

After:
![firefox_2020-07-07_11-10-51](https://user-images.githubusercontent.com/1447794/86756355-9e093700-c042-11ea-8d63-53a51db4d1f7.png)

The screenshots don't show it very well but the label is not ideally centered without this adjustement.