### PR TITLE
Remove newline when highlighting random chunks of code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,8 +100,8 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/xanzy/go-gitlab v0.31.0
 	github.com/yohcop/openid-go v1.0.0
-	github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691
 	github.com/yuin/goldmark v1.1.32
+	github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691
 	github.com/yuin/goldmark-meta v0.0.0-20191126180153-f0638e958b60
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -43,6 +43,11 @@ func NewContext() {
 func Code(fileName, code string) string {
 	NewContext()
 
+	// don't process empty lines
+	if code == "\n" {
+		return code
+	}
+
 	if len(code) > sizeLimit {
 		return code
 	}

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -81,7 +81,9 @@ func Code(fileName, code string) string {
 	}
 
 	htmlw.Flush()
-	return htmlbuf.String()
+	// Strip any newline that chroma might have added since this may be one of multiple
+	// highlights on what should display as a single line of code
+	return strings.TrimSuffix(htmlbuf.String(), "\n")
 }
 
 // File returns map with line lumbers and HTML version of code with chroma syntax highlighting classes

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -14,6 +14,7 @@ import (
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters/html"
 	"github.com/alecthomas/chroma/lexers"
 	"github.com/alecthomas/chroma/styles"
@@ -43,11 +44,6 @@ func NewContext() {
 func Code(fileName, code string) string {
 	NewContext()
 
-	// don't process empty lines
-	if code == "\n" {
-		return code
-	}
-
 	if len(code) > sizeLimit {
 		return code
 	}
@@ -73,7 +69,7 @@ func Code(fileName, code string) string {
 		lexer = lexers.Fallback
 	}
 
-	iterator, err := lexer.Tokenise(nil, string(code))
+	iterator, err := lexer.Tokenise(&chroma.TokeniseOptions{State: "root", Nested: true}, string(code))
 	if err != nil {
 		log.Error("Can't tokenize code: %v", err)
 		return code
@@ -86,9 +82,7 @@ func Code(fileName, code string) string {
 	}
 
 	htmlw.Flush()
-	// Strip any newline that chroma might have added since this may be one of multiple
-	// highlights on what should display as a single line of code
-	return strings.TrimSuffix(htmlbuf.String(), "\n")
+	return htmlbuf.String()
 }
 
 // File returns map with line lumbers and HTML version of code with chroma syntax highlighting classes


### PR DESCRIPTION
By default Chroma will always add new lines for any pieces of code for certain file formats. See :

https://github.com/alecthomas/chroma/blob/bac6996317c811706b2ade529f31d276a1accae8/regexp.go#L433-L435

And

https://github.com/alecthomas/chroma/blob/bac6996317c811706b2ade529f31d276a1accae8/lexers/m/make.go#L16
 
This breaks the way we render diff when one of these formats also has a line of added/deleted code within a new/del line. Make sure this doesn't happen by overriding the default lexer options and setting the Nested flag to true.

Fixes #12172