### PR TITLE
Properly set HEAD when a repo is created with a non-master default branch (#12135)

### DIFF
--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -214,6 +214,13 @@ func initRepository(ctx models.DBContext, repoPath string, u *models.User, repo 
 	repo.DefaultBranch = "master"
 	if len(opts.DefaultBranch) > 0 {
 		repo.DefaultBranch = opts.DefaultBranch
+		gitRepo, err := git.OpenRepository(repo.RepoPath())
+		if err != nil {
+			return fmt.Errorf("openRepository: %v", err)
+		}
+		if err = gitRepo.SetDefaultBranch(repo.DefaultBranch); err != nil {
+			return fmt.Errorf("setDefaultBranch: %v", err)
+		}
 	}
 
 	if err = models.UpdateRepositoryCtx(ctx, repo, false); err != nil {


### PR DESCRIPTION
This fixes an issue I noticed with #10803: when you create a repo with a non-master default branch, gitea doesn't change the remote ref HEAD, so it still points at refs/heads/master. As a result, cloning my repos gives me error messages and doesn't check out the desired default branch, so I need to manually check it out after cloning.

Backport #12135 - Author @xenofem 