### PR TITLE
Regression: Gitea commits API again returns commit summaries, not full messages

### DIFF
--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -298,7 +298,7 @@ func toCommit(ctx *context.APIContext, repo *models.Repository, commit *git.Comm
 				},
 				Date: commit.Committer.When.Format(time.RFC3339),
 			},
-			Message: commit.Summary(),
+			Message: commit.Message(),
 			Tree: &api.CommitMeta{
 				URL: repo.APIURL() + "/git/trees/" + commit.ID.String(),
 				SHA: commit.ID.String(),


### PR DESCRIPTION
#6408 introduced a small regression switching the API to return git commit message summary not the whole message.

This PR causes the API to return the full message once again.

Closes #12185.