### PR TITLE
Backport of #12186 to release/v1.12.

### DIFF
--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -298,7 +298,7 @@ func toCommit(ctx *context.APIContext, repo *models.Repository, commit *git.Comm
 				},
 				Date: commit.Committer.When.Format(time.RFC3339),
 			},
-			Message: commit.Summary(),
+			Message: commit.Message(),
 			Tree: &api.CommitMeta{
 				URL: repo.APIURL() + "/git/trees/" + commit.ID.String(),
 				SHA: commit.ID.String(),


### PR DESCRIPTION
#6048 introduced a small regression switching the API to return git commit message summary not the whole message.

This PR causes the API to return the full message once again – in release/v1.12.