### PR TITLE
Make copy/paste work for source code

### DIFF
--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -44,6 +44,9 @@ func NewContext() {
 func Code(fileName, code string) string {
 	NewContext()
 
+	if code == "" {
+		return "\n"
+	}
 	if len(code) > sizeLimit {
 		return code
 	}

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -133,7 +133,12 @@ func File(numLines int, fileName string, code []byte) map[int]string {
 	m := make(map[int]string, numLines)
 	for k, v := range strings.SplitN(htmlbuf.String(), "\n", numLines) {
 		line := k + 1
-		m[line] = string(v)
+		content := string(v)
+		//need to keep lines that are only \n so copy/paste works properly in browser
+		if content == "" {
+			content = "\n"
+		}
+		m[line] = content
 	}
 	return m
 }
@@ -143,7 +148,12 @@ func plainText(code string, numLines int) map[int]string {
 	m := make(map[int]string, numLines)
 	for k, v := range strings.SplitN(string(code), "\n", numLines) {
 		line := k + 1
-		m[line] = string(v)
+		content := string(v)
+		//need to keep lines that are only \n so copy/paste works properly in browser
+		if content == "" {
+			content = "\n"
+		}
+		m[line] = content
 	}
 	return m
 }

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -269,20 +269,20 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine) tem
 	case DiffLineAdd:
 		compareDiffLine = diffSection.GetLine(DiffLineDel, diffLine.RightIdx)
 		if compareDiffLine == nil {
-			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]+"\n"))
+			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]))
 		}
 		diff1 = compareDiffLine.Content
 		diff2 = diffLine.Content
 	case DiffLineDel:
 		compareDiffLine = diffSection.GetLine(DiffLineAdd, diffLine.LeftIdx)
 		if compareDiffLine == nil {
-			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]+"\n"))
+			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]))
 		}
 		diff1 = diffLine.Content
 		diff2 = compareDiffLine.Content
 	default:
 		if strings.IndexByte(" +-", diffLine.Content[0]) > -1 {
-			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]+"\n"))
+			return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content[1:]))
 		}
 		return template.HTML(highlight.Code(diffSection.FileName, diffLine.Content))
 	}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -139,10 +139,10 @@
 															{{else}}
 																<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
 																<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-old halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui green button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}">+</a>{{end}}<span class="mono wrap">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
+																<td class="lines-code lines-code-old halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui green button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
 																<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
 																<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-new halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui green button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}">+</a>{{end}}<span class="mono wrap">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
+																<td class="lines-code lines-code-new halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui green button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
 															{{end}}
 														</tr>
 														{{if gt (len $line.Comments) 0}}

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -22,7 +22,7 @@
 			{{if eq .GetType 4}}
 			<td class="chroma lines-code blob-hunk"><span class="mono wrap">{{$section.GetComputedInlineDiffFor $line}}</span></td>
 			{{else}}
-			<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{if and $.root.SignedUserID $line.CanComment $.root.PageIsPullFiles}}<a class="ui green button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}" data-path="{{$file.Name}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">+</a>{{end}}<span class="mono wrap">{{$section.GetComputedInlineDiffFor $line}}</span></td>
+			<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{if and $.root.SignedUserID $line.CanComment $.root.PageIsPullFiles}}<a class="ui green button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}" data-path="{{$file.Name}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{$section.GetComputedInlineDiffFor $line}}</span></td>
 			{{end}}
 		</tr>
 		{{if gt (len $line.Comments) 0}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file list">
+<div class="repository file list {{if .IsBlame}}blame{{end}}">
 	{{template "repo/header" .}}
 	<div class="ui container {{if .IsBlame}}fluid padded{{end}}">
 		{{template "base/alert" .}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -105,7 +105,7 @@
 								<span id="L{{$line}}" data-line-number="{{$line}}"></span>
 							</td>
 							<td rel="L{{$line}}" class="lines-code chroma">
-								<pre><code>{{$code | Safe}}</code></pre>
+								<code>{{$code | Safe}}</code>
 							</td>
 						</tr>
 						{{end}}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1039,6 +1039,10 @@ i.icon.centerlock {
     }
 }
 
+.lines-code code {
+    white-space: pre;
+}
+
 .blame .lines-num {
     padding: 0 !important;
     background-color: #f5f5f5;


### PR DESCRIPTION
Fix regression casued by #12047 so copy/paste works properly in all browsers.

Fixes #12184

Also while looking at this I saw a small display issue for blame view. I think #12023 was merged into original PR through an update branch before #12047 was merged and made one of the css rules not apply anymore.

Also fix existing and unrelated bug where copy/paste from PR diff would select the + symbol from add comment features