### PR TITLE
Syntax highlight expanded code blobs

### DIFF
--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -605,7 +605,8 @@ func ExcerptBlob(ctx *context.Context) {
 		return
 	}
 	section := &gitdiff.DiffSection{
-		Name: filePath,
+		FileName: filePath,
+		Name:     filePath,
 	}
 	if direction == "up" && (idxLeft-lastLeft) > chunkSize {
 		idxLeft -= chunkSize


### PR DESCRIPTION
Expanded code in diffs wasn't being highlighted properly because it wasn't passing the filename to highlighting code.

Fixes #12218