### PR TITLE
models: fix xorm variable clobber

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -151,7 +151,7 @@ func getEngine() (*xorm.Engine, error) {
 }
 
 // NewTestEngine sets a new test xorm.Engine
-func NewTestEngine(x *xorm.Engine) (err error) {
+func NewTestEngine() (err error) {
 	x, err = getEngine()
 	if err != nil {
 		return fmt.Errorf("Connect to database: %v", err)

--- a/routers/install.go
+++ b/routers/install.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/unknwon/com"
 	"gopkg.in/ini.v1"
-	"xorm.io/xorm"
 )
 
 const (
@@ -161,8 +160,7 @@ func InstallPost(ctx *context.Context, form auth.InstallForm) {
 	}
 
 	// Set test engine.
-	var x *xorm.Engine
-	if err = models.NewTestEngine(x); err != nil {
+	if err = models.NewTestEngine(); err != nil {
 		if strings.Contains(err.Error(), `Unknown database type: sqlite3`) {
 			ctx.Data["Err_DbType"] = true
 			ctx.RenderWithErr(ctx.Tr("install.sqlite3_not_available", "https://docs.gitea.io/en-us/install-from-binary/"), tplInstall, &form)


### PR DESCRIPTION
`NewTestEngine()` takes a `*xorm.Engine` as its argument, and then immediately overwrites it.

This fixes the `model` package to not take an unneeded variable, and changes the `routers` package to not create a nil `*xorm.Engine` that is immediately discarded by `model`.