### PR TITLE
Fix filepath basename on Windows for SVG bindata

### DIFF
--- a/modules/svg/discover_bindata.go
+++ b/modules/svg/discover_bindata.go
@@ -7,7 +7,6 @@
 package svg
 
 import (
-	"path"
 	"path/filepath"
 
 	"code.gitea.io/gitea/modules/public"
@@ -22,7 +21,7 @@ func Discover() map[string]string {
 		if matched {
 			content, err := public.Asset(file)
 			if err == nil {
-				filename := path.Base(file)
+				filename := filepath.Base(file)
 				svgs[filename[:len(filename)-4]] = string(content)
 			}
 		}

--- a/modules/svg/discover_nobindata.go
+++ b/modules/svg/discover_nobindata.go
@@ -8,7 +8,6 @@ package svg
 
 import (
 	"io/ioutil"
-	"path"
 	"path/filepath"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -18,11 +17,11 @@ import (
 func Discover() map[string]string {
 	svgs := make(map[string]string)
 
-	files, _ := filepath.Glob(path.Join(setting.StaticRootPath, "public", "img", "svg", "*.svg"))
+	files, _ := filepath.Glob(filepath.Join(setting.StaticRootPath, "public", "img", "svg", "*.svg"))
 	for _, file := range files {
 		content, err := ioutil.ReadFile(file)
 		if err == nil {
-			filename := path.Base(file)
+			filename := filepath.Base(file)
 			svgs[filename[:len(filename)-4]] = string(content)
 		}
 	}


### PR DESCRIPTION
Misuse of both `filepath` and `path` when constructing glob path was causing map to contain paths with `\` character on Windows, but `path.Join` explicitly only looks for `/`.

Ref. https://golang.org/pkg/path/filepath