### PR TITLE
release docs as an archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,14 +582,14 @@ release-sources: | $(DIST_DIRS) node_modules
 
 .PHONY: release-docs
 release-docs: | $(DIST_DIRS) docs
-	tar -czf $(DIST)/release/gitea-docs-$(VERSION).tar.gz ./docs/public
+	tar -czf $(DIST)/release/gitea-docs-$(VERSION).tar.gz -C ./docs/public .
 
 .PHONY: docs
 docs:
 	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		GO111MODULE=off $(GO) get -u github.com/gohugoio/hugo; \
 	fi
-	cd docs; make trans-copy clean build;
+	cd docs; make trans-copy clean build-offline;
 
 node_modules: package-lock.json
 	npm install --no-save

--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
 	CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -mod=vendor $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
 
 .PHONY: release
-release: frontend generate release-windows release-linux release-darwin release-copy release-compress release-sources release-check
+release: frontend generate release-windows release-linux release-darwin release-copy release-compress release-sources release-docs release-check
 
 $(DIST_DIRS):
 	mkdir -p $(DIST_DIRS)
@@ -579,6 +579,17 @@ release-sources: | $(DIST_DIRS) node_modules
 	echo $(VERSION) > $(STORED_VERSION_FILE)
 	tar --exclude=./$(DIST) --exclude=./.git --exclude=./$(MAKE_EVIDENCE_DIR) --exclude=./node_modules/.cache -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
 	rm -f $(STORED_VERSION_FILE)
+
+.PHONY: release-docs
+release-docs: | $(DIST_DIRS) docs
+	tar -czf $(DIST)/release/gitea-docs-$(VERSION).tar.gz ./docs/public
+
+.PHONY: docs
+docs:
+	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+		GO111MODULE=off $(GO) get -u github.com/gohugoio/hugo; \
+	fi
+	cd docs; make trans-copy clean build;
 
 node_modules: package-lock.json
 	npm install --no-save

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,6 +21,10 @@ server: $(THEME)
 build: $(THEME)
 	hugo --cleanDestinationDir
 
+.PHONY: build-offline
+build-offline: $(THEME)
+	hugo --baseURL="/" --cleanDestinationDir
+
 .PHONY: update
 update: $(THEME)
 


### PR DESCRIPTION
This PR add a step to the release process to generate and package docs.

I hesitate between this solution and editing the the docs pipeline in drone so let me know  if you prefer these solution.

This solution is far from perfect because the result is a folder with html file that could be serve via a local server but will be displayed with broken style (but readable) if open directly (file:// protocol). Hugo, which is used to the generate the docs, doesn't support an offline export solution and the relative path management needed for that.

Fix #4086