### PR TITLE
fix: add type=text for user_name (password manager)

### DIFF
--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -30,7 +30,7 @@
 				</div>
 				<div class="required field {{if .Err_UserName}}error{{end}}">
 					<label for="user_name">{{.i18n.Tr "username"}}</label>
-					<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+					<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 				</div>
 				<div class="required field {{if .Err_Email}}error{{end}}">
 					<label for="email">{{.i18n.Tr "email"}}</label>

--- a/templates/user/auth/finalize_openid.tmpl
+++ b/templates/user/auth/finalize_openid.tmpl
@@ -13,7 +13,7 @@
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
 						<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
-						<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Password}}error{{end}}">
 						<label for="password">{{.i18n.Tr "password"}}</label>

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -13,7 +13,7 @@
 					{{if .user_email }}
 						<div class="inline field">
 							<label for="user_name">{{.i18n.Tr "email"}}</label>
-							<input id="user_name" type="text" type="text" value="{{ .user_email }}" disabled>
+							<input id="user_name" type="text" value="{{ .user_email }}" disabled>
 						</div>
 					{{end}}
 					{{if .IsResetForm}}

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -13,7 +13,7 @@
 					{{if .user_email }}
 						<div class="inline field">
 							<label for="user_name">{{.i18n.Tr "email"}}</label>
-							<input id="user_name" type="text" value="{{ .user_email }}" disabled>
+							<input id="user_name" type="text" type="text" value="{{ .user_email }}" disabled>
 						</div>
 					{{end}}
 					{{if .IsResetForm}}

--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -13,7 +13,7 @@
 			{{.CsrfTokenHtml}}
 			<div class="required inline field {{if and (.Err_UserName) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
 				<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
-				<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+				<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 			</div>
 			{{if or (not .DisablePassword) .LinkAccountMode}}
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">

--- a/templates/user/auth/signup_inner.tmpl
+++ b/templates/user/auth/signup_inner.tmpl
@@ -19,7 +19,7 @@
 					{{else}}
 						<div class="required inline field {{if and (.Err_UserName) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
 							<label for="user_name">{{.i18n.Tr "username"}}</label>
-							<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+							<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 						</div>
 						<div class="required inline field {{if .Err_Email}}error{{end}}">
 							<label for="email">{{.i18n.Tr "email"}}</label>

--- a/templates/user/auth/signup_openid_connect.tmpl
+++ b/templates/user/auth/signup_openid_connect.tmpl
@@ -14,7 +14,7 @@
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
 						<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
-						<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Password}}error{{end}}">
 						<label for="password">{{.i18n.Tr "password"}}</label>

--- a/templates/user/auth/signup_openid_register.tmpl
+++ b/templates/user/auth/signup_openid_register.tmpl
@@ -14,7 +14,7 @@
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
 						<label for="user_name">{{.i18n.Tr "username"}}</label>
-						<input id="user_name" name="user_name" value="{{.user_name}}" autofocus required>
+						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Email}}error{{end}}">
 						<label for="email">{{.i18n.Tr "email"}}</label>


### PR DESCRIPTION
Hello,

I'm using [Passbolt](https://www.passbolt.com/) as my password manager and form autocompletion does not work for the email. I noticed that input field needed `type="text"` to make it working. Moreover, i think it is a better practice to have this property :)

I added it everywhere there is the name property with the value `user_name`.

Any question are welcomed :)
Thank you for your work !