### PR TITLE
Release docs as archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,7 @@ release-docs: | $(DIST_DIRS) docs
 .PHONY: docs
 docs:
 	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		GO111MODULE=off $(GO) get -u github.com/gohugoio/hugo; \
+		$(GO) get -u github.com/gohugoio/hugo; \
 	fi
 	cd docs; make trans-copy clean build-offline;
 


### PR DESCRIPTION
It is ok to use go modules at this point as release-source make target has already been run. Otherwise hugo fails to build. Example of failed build: https://drone.gitea.io/go-gitea/gitea/27976/5/3
