### PR TITLE
prefer NoError/Error over Nil/NotNil

### DIFF
--- a/integrations/repofiles_delete_test.go
+++ b/integrations/repofiles_delete_test.go
@@ -80,7 +80,7 @@ func testDeleteRepoFile(t *testing.T, u *url.URL) {
 
 	t.Run("Delete README.md file", func(t *testing.T) {
 		fileResponse, err := repofiles.DeleteRepoFile(repo, doer, opts)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		expectedFileResponse := getExpectedDeleteFileResponse(u)
 		assert.NotNil(t, fileResponse)
 		assert.Nil(t, fileResponse.Content)
@@ -122,7 +122,7 @@ func testDeleteRepoFileWithoutBranchNames(t *testing.T, u *url.URL) {
 
 	t.Run("Delete README.md without Branch Name", func(t *testing.T) {
 		fileResponse, err := repofiles.DeleteRepoFile(repo, doer, opts)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		expectedFileResponse := getExpectedDeleteFileResponse(u)
 		assert.NotNil(t, fileResponse)
 		assert.Nil(t, fileResponse.Content)

--- a/integrations/repofiles_update_test.go
+++ b/integrations/repofiles_update_test.go
@@ -201,7 +201,7 @@ func TestCreateOrUpdateRepoFileForCreate(t *testing.T) {
 		fileResponse, err := repofiles.CreateOrUpdateRepoFile(repo, doer, opts)
 
 		// asserts
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		gitRepo, _ := git.OpenRepository(repo.RepoPath())
 		defer gitRepo.Close()
 
@@ -237,7 +237,7 @@ func TestCreateOrUpdateRepoFileForUpdate(t *testing.T) {
 		fileResponse, err := repofiles.CreateOrUpdateRepoFile(repo, doer, opts)
 
 		// asserts
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		gitRepo, _ := git.OpenRepository(repo.RepoPath())
 		defer gitRepo.Close()
 
@@ -272,7 +272,7 @@ func TestCreateOrUpdateRepoFileForUpdateWithFileMove(t *testing.T) {
 		fileResponse, err := repofiles.CreateOrUpdateRepoFile(repo, doer, opts)
 
 		// asserts
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		gitRepo, _ := git.OpenRepository(repo.RepoPath())
 		defer gitRepo.Close()
 
@@ -287,7 +287,7 @@ func TestCreateOrUpdateRepoFileForUpdateWithFileMove(t *testing.T) {
 			t.Fatalf("expected git.ErrNotExist, got:%v", err)
 		}
 		toEntry, err := commit.GetTreeEntryByPath(opts.TreePath)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Nil(t, fromEntry)  // Should no longer exist here
 		assert.NotNil(t, toEntry) // Should exist here
 		// assert SHA has remained the same but paths use the new file name
@@ -322,7 +322,7 @@ func TestCreateOrUpdateRepoFileWithoutBranchNames(t *testing.T) {
 		fileResponse, err := repofiles.CreateOrUpdateRepoFile(repo, doer, opts)
 
 		// asserts
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		gitRepo, _ := git.OpenRepository(repo.RepoPath())
 		defer gitRepo.Close()
 

--- a/modules/repofiles/blob_test.go
+++ b/modules/repofiles/blob_test.go
@@ -35,6 +35,6 @@ func TestGetBlobBySHA(t *testing.T) {
 		SHA:      "65f1bf27bc3bf70f64657658635e66094edbcb4d",
 		Size:     180,
 	}
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedGBR, gbr)
 }

--- a/modules/repofiles/content_test.go
+++ b/modules/repofiles/content_test.go
@@ -66,13 +66,13 @@ func TestGetContents(t *testing.T) {
 	t.Run("Get README.md contents with GetContents()", func(t *testing.T) {
 		fileContentResponse, err := GetContents(ctx.Repo.Repository, treePath, ref, false)
 		assert.EqualValues(t, expectedContentsResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("Get REAMDE.md contents with ref as empty string (should then use the repo's default branch) with GetContents()", func(t *testing.T) {
 		fileContentResponse, err := GetContents(ctx.Repo.Repository, treePath, "", false)
 		assert.EqualValues(t, expectedContentsResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 
@@ -101,13 +101,13 @@ func TestGetContentsOrListForDir(t *testing.T) {
 	t.Run("Get root dir contents with GetContentsOrList()", func(t *testing.T) {
 		fileContentResponse, err := GetContentsOrList(ctx.Repo.Repository, treePath, ref)
 		assert.EqualValues(t, expectedContentsListResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("Get root dir contents with ref as empty string (should then use the repo's default branch) with GetContentsOrList()", func(t *testing.T) {
 		fileContentResponse, err := GetContentsOrList(ctx.Repo.Repository, treePath, "")
 		assert.EqualValues(t, expectedContentsListResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 
@@ -129,13 +129,13 @@ func TestGetContentsOrListForFile(t *testing.T) {
 	t.Run("Get README.md contents with GetContentsOrList()", func(t *testing.T) {
 		fileContentResponse, err := GetContentsOrList(ctx.Repo.Repository, treePath, ref)
 		assert.EqualValues(t, expectedContentsResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("Get REAMDE.md contents with ref as empty string (should then use the repo's default branch) with GetContentsOrList()", func(t *testing.T) {
 		fileContentResponse, err := GetContentsOrList(ctx.Repo.Repository, treePath, "")
 		assert.EqualValues(t, expectedContentsResponse, fileContentResponse)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/modules/repofiles/diff_test.go
+++ b/modules/repofiles/diff_test.go
@@ -113,13 +113,13 @@ func TestGetDiffPreview(t *testing.T) {
 
 	t.Run("with given branch", func(t *testing.T) {
 		diff, err := GetDiffPreview(ctx.Repo.Repository, branch, treePath, content)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.EqualValues(t, expectedDiff, diff)
 	})
 
 	t.Run("empty branch, same results", func(t *testing.T) {
 		diff, err := GetDiffPreview(ctx.Repo.Repository, "", treePath, content)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.EqualValues(t, expectedDiff, diff)
 	})
 }

--- a/modules/repofiles/file_test.go
+++ b/modules/repofiles/file_test.go
@@ -99,6 +99,6 @@ func TestGetFileResponseFromCommit(t *testing.T) {
 	expectedFileResponse := getExpectedFileResponse()
 
 	fileResponse, err := GetFileResponseFromCommit(repo, commit, branch, treePath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedFileResponse, fileResponse)
 }

--- a/modules/repofiles/tree_test.go
+++ b/modules/repofiles/tree_test.go
@@ -30,7 +30,7 @@ func TestGetTreeBySHA(t *testing.T) {
 	ctx.SetParams(":sha", sha)
 
 	tree, err := GetTreeBySHA(ctx.Repo.Repository, ctx.Params(":sha"), page, perPage, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	expectedTree := &api.GitTreeResponse{
 		SHA: "65f1bf27bc3bf70f64657658635e66094edbcb4d",
 		URL: "https://try.gitea.io/api/v1/repos/user2/repo1/git/trees/65f1bf27bc3bf70f64657658635e66094edbcb4d",

--- a/modules/webhook/dingtalk_test.go
+++ b/modules/webhook/dingtalk_test.go
@@ -17,14 +17,14 @@ func TestGetDingTalkIssuesPayload(t *testing.T) {
 
 	p.Action = api.HookIssueOpened
 	pl, err := getDingtalkIssuesPayload(p)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "#2 crash", pl.ActionCard.Title)
 	assert.Equal(t, "[test/repo] Issue opened: #2 crash by user1\r\n\r\n", pl.ActionCard.Text)
 
 	p.Action = api.HookIssueClosed
 	pl, err = getDingtalkIssuesPayload(p)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "#2 crash", pl.ActionCard.Title)
 	assert.Equal(t, "[test/repo] Issue closed: #2 crash by user1\r\n\r\n", pl.ActionCard.Text)

--- a/modules/webhook/matrix_test.go
+++ b/modules/webhook/matrix_test.go
@@ -20,14 +20,14 @@ func TestMatrixIssuesPayloadOpened(t *testing.T) {
 
 	p.Action = api.HookIssueOpened
 	pl, err := getMatrixIssuesPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] Issue opened: [#2 crash](http://localhost:3000/test/repo/issues/2) by [user1](https://try.gitea.io/user1)", pl.Body)
 	assert.Equal(t, "[<a href=\"http://localhost:3000/test/repo\">test/repo</a>] Issue opened: <a href=\"http://localhost:3000/test/repo/issues/2\">#2 crash</a> by <a href=\"https://try.gitea.io/user1\">user1</a>", pl.FormattedBody)
 
 	p.Action = api.HookIssueClosed
 	pl, err = getMatrixIssuesPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] Issue closed: [#2 crash](http://localhost:3000/test/repo/issues/2) by [user1](https://try.gitea.io/user1)", pl.Body)
 	assert.Equal(t, "[<a href=\"http://localhost:3000/test/repo\">test/repo</a>] Issue closed: <a href=\"http://localhost:3000/test/repo/issues/2\">#2 crash</a> by <a href=\"https://try.gitea.io/user1\">user1</a>", pl.FormattedBody)
@@ -39,7 +39,7 @@ func TestMatrixIssueCommentPayload(t *testing.T) {
 	sl := &MatrixMeta{}
 
 	pl, err := getMatrixIssueCommentPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] New comment on issue [#2 crash](http://localhost:3000/test/repo/issues/2) by [user1](https://try.gitea.io/user1)", pl.Body)
@@ -52,7 +52,7 @@ func TestMatrixPullRequestCommentPayload(t *testing.T) {
 	sl := &MatrixMeta{}
 
 	pl, err := getMatrixIssueCommentPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] New comment on pull request [#2 Fix bug](http://localhost:3000/test/repo/pulls/2) by [user1](https://try.gitea.io/user1)", pl.Body)
@@ -65,7 +65,7 @@ func TestMatrixReleasePayload(t *testing.T) {
 	sl := &MatrixMeta{}
 
 	pl, err := getMatrixReleasePayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] Release created: [v1.0](http://localhost:3000/test/repo/src/v1.0) by [user1](https://try.gitea.io/user1)", pl.Body)
@@ -78,7 +78,7 @@ func TestMatrixPullRequestPayload(t *testing.T) {
 	sl := &MatrixMeta{}
 
 	pl, err := getMatrixPullRequestPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[[test/repo](http://localhost:3000/test/repo)] Pull request opened: [#2 Fix bug](http://localhost:3000/test/repo/pulls/12) by [user1](https://try.gitea.io/user1)", pl.Body)
@@ -148,7 +148,7 @@ func TestMatrixHookRequest(t *testing.T) {
 }`
 
 	req, err := getMatrixHookRequest(h)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, req)
 
 	assert.Equal(t, "Bearer dummy_access_token", req.Header.Get("Authorization"))

--- a/modules/webhook/slack_test.go
+++ b/modules/webhook/slack_test.go
@@ -20,13 +20,13 @@ func TestSlackIssuesPayloadOpened(t *testing.T) {
 
 	p.Action = api.HookIssueOpened
 	pl, err := getSlackIssuesPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Issue opened: <http://localhost:3000/test/repo/issues/2|#2 crash> by <https://try.gitea.io/user1|user1>", pl.Text)
 
 	p.Action = api.HookIssueClosed
 	pl, err = getSlackIssuesPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Issue closed: <http://localhost:3000/test/repo/issues/2|#2 crash> by <https://try.gitea.io/user1|user1>", pl.Text)
 }
@@ -39,7 +39,7 @@ func TestSlackIssueCommentPayload(t *testing.T) {
 	}
 
 	pl, err := getSlackIssueCommentPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] New comment on issue <http://localhost:3000/test/repo/issues/2|#2 crash> by <https://try.gitea.io/user1|user1>", pl.Text)
@@ -53,7 +53,7 @@ func TestSlackPullRequestCommentPayload(t *testing.T) {
 	}
 
 	pl, err := getSlackIssueCommentPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] New comment on pull request <http://localhost:3000/test/repo/pulls/2|#2 Fix bug> by <https://try.gitea.io/user1|user1>", pl.Text)
@@ -67,7 +67,7 @@ func TestSlackReleasePayload(t *testing.T) {
 	}
 
 	pl, err := getSlackReleasePayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Release created: <http://localhost:3000/test/repo/src/v1.0|v1.0> by <https://try.gitea.io/user1|user1>", pl.Text)
@@ -81,7 +81,7 @@ func TestSlackPullRequestPayload(t *testing.T) {
 	}
 
 	pl, err := getSlackPullRequestPayload(p, sl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Pull request opened: <http://localhost:3000/test/repo/pulls/12|#2 Fix bug> by <https://try.gitea.io/user1|user1>", pl.Text)

--- a/modules/webhook/telegram_test.go
+++ b/modules/webhook/telegram_test.go
@@ -17,7 +17,7 @@ func TestGetTelegramIssuesPayload(t *testing.T) {
 	p.Action = api.HookIssueClosed
 
 	pl, err := getTelegramIssuesPayload(p)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pl)
 
 	assert.Equal(t, "[<a href=\"http://localhost:3000/test/repo\">test/repo</a>] Issue closed: <a href=\"http://localhost:3000/test/repo/issues/2\">#2 crash</a> by <a href=\"https://try.gitea.io/user1\">user1</a>\n\n", pl.Message)


### PR DESCRIPTION
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why is it important?

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.

