### PR TITLE
[help wanted] Get basic upload-to-wiki working

### DIFF
--- a/models/helper_environment.go
+++ b/models/helper_environment.go
@@ -43,6 +43,11 @@ func PushingEnvironment(doer *User, repo *Repository) []string {
 	return FullPushingEnvironment(doer, doer, repo, repo.Name, 0)
 }
 
+// WikiPushingEnvironment returns an os environment for wiki repo
+func WikiPushingEnvironment(doer *User, repo *Repository) []string {
+	return FullPushingEnvironment(doer, doer, repo, repo.Name+".wiki", 0)
+}
+
 // FullPushingEnvironment returns an os environment to allow hooks to work on push
 func FullPushingEnvironment(author, committer *User, repo *Repository, repoName string, prID int64) []string {
 	isWiki := "false"

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -652,6 +652,17 @@ func (f *NewWikiForm) Validate(ctx *macaron.Context, errs binding.Errors) bindin
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
 
+// UploadWikiFileForm form for uploading wiki file
+type UploadWikiFileForm struct {
+	CommitMessage string
+	Files         []string
+}
+
+// Validate validates the fields
+func (f *UploadWikiFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
+	return validate(errs, ctx.Data, f, ctx.Locale)
+}
+
 // ___________    .___.__  __
 // \_   _____/  __| _/|__|/  |_
 //  |    __)_  / __ | |  \   __\

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -270,13 +270,15 @@ func (t *TemporaryUploadRepository) CommitTreeWithDate(author, committer *models
 
 // Push the provided commitHash to the repository branch by the provided user
 func (t *TemporaryUploadRepository) push(doer *models.User, commitHash string, branch string, isWiki bool) error {
-	repoPath := t.repo.RepoPath()
-	if isWiki {
-		repoPath = t.repo.WikiPath()
-	}
-
 	// Because calls hooks we need to pass in the environment
 	env := models.PushingEnvironment(doer, t.repo)
+	repoPath := t.repo.RepoPath()
+
+	if isWiki {
+		repoPath = t.repo.WikiPath()
+		env = models.WikiPushingEnvironment(doer, t.repo)
+	}
+
 	if err := git.Push(t.basePath, git.PushOptions{
 		Remote: repoPath,
 		Branch: strings.TrimSpace(commitHash) + ":refs/heads/" + strings.TrimSpace(branch),

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1370,6 +1370,7 @@ wiki.file_revision = Page Revision
 wiki.wiki_page_revisions = Wiki Page Revisions
 wiki.back_to_wiki = Back to wiki page
 wiki.delete_page_button = Delete Page
+wiki.upload_files_button = Upload Files
 wiki.delete_page_notice_1 = Deleting the wiki page '%s' cannot be undone. Continue?
 wiki.page_already_exists = A wiki page with the same name already exists.
 wiki.reserved_page = The wiki page name '%s' is reserved.

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -32,6 +32,13 @@ func MustBeNotEmpty(ctx *context.Context) {
 	}
 }
 
+// MustHaveWiki render when a repo have wiki
+func MustHaveWiki(ctx *context.Context) {
+	if !ctx.Repo.Repository.HasWiki() {
+		ctx.NotFound("MustHaveWiki", nil)
+	}
+}
+
 // MustBeEditable check that repo can be edited
 func MustBeEditable(ctx *context.Context) {
 	if !ctx.Repo.Repository.CanEnableEditor() || ctx.Repo.IsViewCommit {

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -22,6 +22,7 @@ import (
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/repofiles"
 	"code.gitea.io/gitea/modules/timeutil"
+	"code.gitea.io/gitea/modules/upload"
 	"code.gitea.io/gitea/modules/util"
 	wiki_service "code.gitea.io/gitea/services/wiki"
 )
@@ -661,7 +662,9 @@ func DeleteWikiPagePost(ctx *context.Context) {
 func UploadWikiFile(ctx *context.Context) {
 	ctx.Data["PageIsWiki"] = true
 	ctx.Data["PageIsUpload"] = true
-	renderUploadSettings(ctx)
+	ctx.Data["RequireTribute"] = true
+	ctx.Data["RequireSimpleMDE"] = true
+	upload.AddUploadContext(ctx, "repo")
 
 	if !ctx.Repo.Repository.HasWiki() {
 		ctx.Redirect(ctx.Repo.RepoLink + "/wiki")
@@ -682,7 +685,9 @@ func UploadWikiFilePost(ctx *context.Context, form auth.UploadWikiFileForm) {
 
 	ctx.Data["PageIsWiki"] = true
 	ctx.Data["PageIsUpload"] = true
-	renderUploadSettings(ctx)
+	ctx.Data["RequireTribute"] = true
+	ctx.Data["RequireSimpleMDE"] = true
+	upload.AddUploadContext(ctx, "repo")
 
 	if ctx.HasError() {
 		ctx.HTML(200, tplWikiUpload)

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -707,7 +707,10 @@ func UploadWikiFilePost(ctx *context.Context, form auth.UploadWikiFileForm) {
 		Message:      message,
 		Files:        form.Files,
 	}); err != nil {
+		// FIXME: it will get a "The process cannot access the file because it is being used by another process." error when try to remove
+		//        the uploaded cache file. Upload is successed anyway, but still need to fix this one.
 		log.Error("Error during upload to repo %-v : %v", ctx.Repo.Repository, err)
+		ctx.RenderWithErr(ctx.Tr("repo.editor.unable_to_upload_files", "_media", err), tplWikiUpload, &form)
 		return
 	}
 

--- a/routers/routes/macaron.go
+++ b/routers/routes/macaron.go
@@ -713,6 +713,13 @@ func RegisterMacaronRoutes(m *macaron.Macaron) {
 			}, context.RepoRef(), repo.MustBeEditable, repo.MustBeAbleToUpload)
 		}, context.RepoMustNotBeArchived(), reqRepoCodeWriter, repo.MustBeNotEmpty)
 
+		m.Group("", func() {
+			m.Group("", func() {
+				m.Post("/upload-wiki-file", repo.UploadFileToServer)
+				m.Post("/upload-wiki-remove", bindIgnErr(auth.RemoveUploadFileForm{}), repo.RemoveUploadFileFromServer)
+			}, context.RepoRef(), repo.MustBeEditable, repo.MustBeAbleToUpload)
+		}, context.RepoMustNotBeArchived(), reqRepoCodeWriter, repo.MustHaveWiki)
+
 		m.Group("/branches", func() {
 			m.Group("/_new/", func() {
 				m.Post("/branch/*", context.RepoRefByType(context.RepoRefBranch), repo.CreateBranch)
@@ -811,6 +818,8 @@ func RegisterMacaronRoutes(m *macaron.Macaron) {
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.NewWikiPost)
 				m.Combo("/:page/_edit").Get(repo.EditWiki).
 					Post(bindIgnErr(auth.NewWikiForm{}), repo.EditWikiPost)
+				m.Combo("/_upload").Get(repo.UploadWikiFile).
+					Post(bindIgnErr(auth.UploadWikiFileForm{}), repo.UploadWikiFilePost)
 				m.Post("/:page/delete", repo.DeleteWikiPagePost)
 			}, context.RepoMustNotBeArchived(), reqSignIn, reqRepoWikiWriter)
 		}, repo.MustEnableWiki, context.RepoRef(), func(ctx *context.Context) {

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	reservedWikiNames = []string{"_pages", "_new", "_edit", "raw"}
+	reservedWikiNames = []string{"_pages", "_new", "_edit", "_upload", "raw"}
 	wikiWorkingPool   = sync.NewExclusivePool()
 )
 

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -209,13 +209,7 @@ func updateWikiPage(doer *models.User, repo *models.Repository, oldWikiName, new
 	if err := git.Push(basePath, git.PushOptions{
 		Remote: "origin",
 		Branch: fmt.Sprintf("%s:%s%s", commitHash.String(), git.BranchPrefix, "master"),
-		Env: models.FullPushingEnvironment(
-			doer,
-			doer,
-			repo,
-			repo.Name+".wiki",
-			0,
-		),
+		Env:    models.WikiPushingEnvironment(doer, repo),
 	}); err != nil {
 		log.Error("%v", err)
 		if git.IsErrPushOutOfDate(err) || git.IsErrPushRejected(err) {

--- a/templates/repo/wiki/upload.tmpl
+++ b/templates/repo/wiki/upload.tmpl
@@ -1,0 +1,23 @@
+{{template "base/head" .}}
+<div class="repository file editor upload">
+	{{template "repo/header" .}}
+	<div class="ui container">
+		{{template "base/alert" .}}
+		<form class="ui comment form" method="post">
+			{{.CsrfTokenHtml}}
+			<div class="field">
+				<div class="files"></div>
+				<div class="ui dropzone" id="dropzone" data-upload-url="{{.RepoLink}}/upload-wiki-file" data-remove-url="{{.RepoLink}}/upload-wiki-remove" data-csrf="{{.CsrfToken}}" data-accepts="{{.UploadAllowedTypes}}" data-max-file="{{.UploadMaxFiles}}" data-max-size="{{.UploadMaxSize}}" data-default-message="{{.i18n.Tr "dropzone.default_message"}}" data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}" data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}" data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"></div>
+			</div>
+            <div class="field">
+				<input name="message" placeholder="{{.i18n.Tr "repo.wiki.default_commit_message"}}">
+			</div>
+			<div class="text right">
+				<button class="ui green button">
+					{{.i18n.Tr "repo.wiki.upload_files_button"}}
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
+{{template "base/footer" .}} 

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -28,7 +28,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="right fitted item">
+			<div class="right fitted item" id="file-buttons">
+				<div class="ui tiny blue buttons">
+					<a href="{{.RepoLink}}/wiki/_upload" class="ui button">
+						{{.i18n.Tr "repo.wiki.upload_files_button"}}
+					</a>
+				</div>
+			</div>
+			<div class="fitted item">
 				<div class="ui action small input" id="clone-panel">
 					{{if not $.DisableHTTP}}
 						<button class="ui basic clone button" id="repo-clone-https" data-link="{{.WikiCloneLink.HTTPS}}">


### PR DESCRIPTION
Intended to resolve #574 , still WIP, not ready to merge.

------------------

I need this feature and find out there is an issue requesting this feature(#574), so would like to try to implement this feature. I tryed rebasing #6024 onto master but it seems there are too many changes from the codebase so I decided to reimplement the feature directly on master branch. Now the upload works but I do think what I did is probably not the correct way to implement it. I'll explain later.

Here are some WIP screenshots in current PR state:

<details>
<summary>Screenshots about file upload</summary>

![wikipage](https://user-images.githubusercontent.com/10095765/87934169-1cdd8580-cac1-11ea-8233-98bce7e6520d.png)
![uploadpage](https://user-images.githubusercontent.com/10095765/87934173-1f3fdf80-cac1-11ea-9713-0332b34b2b56.png)
</details>

Reason about why I think my current implementation is bad is, when try to hacking on this feature, I found `temp_repo.go` always do operation to the repo when calling `NewTemporaryUploadRepository(repo *models.Repository)`, seems I cannot operate to the wiki repo directly, so I added `CloneWiki()` and `PushWiki()` so I can process the wiki repo instead of the original repo. But I found inside `PushingEnvironment()` there are checks about if it is a wiki repo, so I think I may probably missed something.

The current PR state should be able to upload file to wiki repo, but after clicking the upload button, the page turns blank. I checked the console output and here is the related log:

``` plain
UploadWikiFilePost
[Macaron] 2020-07-20 16:15:12: Started POST /api/internal/hook/pre-receive/blblb/61616 for [::1]
[Macaron] 2020-07-20 16:15:12: Completed POST /api/internal/hook/pre-receive/blblb/61616 200 OK in 2.9995ms
[Macaron] 2020-07-20 16:15:13: Started POST /api/internal/hook/post-receive/blblb/61616 for [::1]
[Macaron] 2020-07-20 16:15:13: Completed POST /api/internal/hook/post-receive/blblb/61616 500 Internal Server Error in 93.0008ms
[Macaron] 2020-07-20 16:15:13: Completed POST /blblb/61616/wiki/_upload 0  in 2.9386116s
[Macaron] 2020-07-20 16:15:13: Started GET /favicon.ico for 127.0.0.1
[Macaron] 2020-07-20 16:15:13: Completed GET /favicon.ico 304 Not Modified in 1.9981ms
[Macaron] 2020-07-20 16:15:15: Started GET /serviceworker.js for 127.0.0.1
[Macaron] [Static] Serving /serviceworker.js
[Macaron] 2020-07-20 16:15:15: Completed GET /serviceworker.js 304 Not Modified in 33.9743ms
```

I guess it is the 500 internal server error which caused the issue. I think it probably because I still missed something which cause it trigger the main repo post-receive hock, but still doesn't know where should I look at.

I still not dig into the whole codebase too deep (actually I'm new to golang), but still would like to help implementing this issue. Any advices / comments / code review would be very helpful. Thanks!

