### PR TITLE
Fix double-indirection bug in logging IDs

### DIFF
--- a/modules/log/colors.go
+++ b/modules/log/colors.go
@@ -355,7 +355,7 @@ func NewColoredValueBytes(value interface{}, colorBytes *[]byte) *ColoredValue {
 // The Value will be colored with FgCyan
 // If a ColoredValue is provided it is not changed
 func NewColoredIDValue(value interface{}) *ColoredValue {
-	return NewColoredValueBytes(&value, &fgCyanBytes)
+	return NewColoredValueBytes(value, &fgCyanBytes)
 }
 
 // Format will format the provided value and protect against ANSI color spoofing within the value


### PR DESCRIPTION
This PR fixes a bug in log.NewColoredIDValue() which led to a double
indirection and incorrect IDs being printed out.

Signed-off-by: Andrew Thornton <art27@cantab.net>