### PR TITLE
Reduce emoji size

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1224,35 +1224,20 @@ table th[data-sortt-desc] {
 
 .emoji,
 .reaction {
-    font-size: 1.5em;
-    line-height: 1.2;
+    font-size: 1.25em;
+    line-height: 1;
     font-style: normal !important;
     font-weight: normal !important;
-    vertical-align: middle;
+    vertical-align: -.075em;
 }
 
-#issue-title > .emoji {
-    font-size: 1em;
-}
-
-.commit-summary > .emoji {
-    font-size: 1em;
-}
-
-.label > .emoji {
-    font-size: 1em;
-}
-
-.dropdown .emoji {
-    font-size: 1em;
-}
 .emoji img,
 .reaction img {
     border-width: 0 !important;
     margin: 0 !important;
     width: 1em !important;
     height: 1em !important;
-    vertical-align: middle !important;
+    vertical-align: -.15em;
 }
 
 /* https://github.com/go-gitea/gitea/pull/11486 */

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2387,7 +2387,7 @@
         .select-reaction {
             display: flex;
             align-items: center;
-            padding: .5rem;
+            padding: 0 .5rem;
 
             &:not(.active) a {
                 display: none;


### PR DESCRIPTION
Rendering should now pretty much match GitHub with 1.25em. I verified that emojis don't increase the line height and removed unecessary size overrides because now all emojis should appear similar in relation to the font size.

Before:

<img width="888" alt="image" src="https://user-images.githubusercontent.com/115237/88421137-4dd2f880-cde8-11ea-8382-d62f8ca02da8.png">


After:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/115237/88421068-2845ef00-cde8-11ea-9480-4e4140c2987f.png">

Note this does not fully resolve https://github.com/go-gitea/gitea/issues/12312 because of a bug in the backend detection of emojis and the missed ones (all except 🤪 in the screenshot) are not sized up at all (e.g. 1em).
