### PR TITLE
Remove padding/border-radius on image diffs

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -440,7 +440,8 @@
                 }
 
                 img {
-                    padding: 5px 5px 0;
+                    padding: 0;
+                    border-radius: 0;
                 }
             }
 


### PR DESCRIPTION
Before:

<img width="112" alt="image" src="https://user-images.githubusercontent.com/115237/88644511-587cde80-d0c3-11ea-9d90-ef4f1ef60129.png">

After:

<img width="100" alt="image" src="https://user-images.githubusercontent.com/115237/88644538-62064680-d0c3-11ea-8349-abfbb703cfde.png">
