### PR TITLE
Git 2.28 no longer permits diff with ... on unrelated branches

### DIFF
--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -272,11 +272,12 @@ func AllCommitsCount(repoPath string) (int64, error) {
 	return strconv.ParseInt(strings.TrimSpace(stdout), 10, 64)
 }
 
-func commitsCount(repoPath, revision, relpath string) (int64, error) {
+func commitsCount(repoPath string, revision, relpath []string) (int64, error) {
 	cmd := NewCommand("rev-list", "--count")
-	cmd.AddArguments(revision)
+	cmd.AddArguments(revision...)
 	if len(relpath) > 0 {
-		cmd.AddArguments("--", relpath)
+		cmd.AddArguments("--")
+		cmd.AddArguments(relpath...)
 	}
 
 	stdout, err := cmd.RunInDir(repoPath)
@@ -289,7 +290,7 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 
 // CommitsCount returns number of total commits of until given revision.
 func CommitsCount(repoPath, revision string) (int64, error) {
-	return commitsCount(repoPath, revision, "")
+	return commitsCount(repoPath, []string{revision}, []string{})
 }
 
 // CommitsCount returns number of total commits of until current revision.

--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -319,7 +319,7 @@ func (repo *Repository) FileChangedBetweenCommits(filename, id1, id2 string) (bo
 
 // FileCommitsCount return the number of files at a revison
 func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
-	return commitsCount(repo.Path, revision, file)
+	return commitsCount(repo.Path, []string{revision}, []string{file})
 }
 
 // CommitsByFileAndRange return the commits according revison file and the page
@@ -345,6 +345,11 @@ func (repo *Repository) CommitsByFileAndRangeNoFollow(revision, file string, pag
 // FilesCountBetween return the number of files changed between two commits
 func (repo *Repository) FilesCountBetween(startCommitID, endCommitID string) (int, error) {
 	stdout, err := NewCommand("diff", "--name-only", startCommitID+"..."+endCommitID).RunInDir(repo.Path)
+	if err != nil && strings.Contains(err.Error(), "no merge base") {
+		// git >= 2.28 now returns an error if startCommitID and endCommitID have become unrelated.
+		// previously it would return the results of git diff --name-only startCommitID endCommitID so let's try that...
+		stdout, err = NewCommand("diff", "--name-only", startCommitID, endCommitID).RunInDir(repo.Path)
+	}
 	if err != nil {
 		return 0, err
 	}
@@ -359,6 +364,11 @@ func (repo *Repository) CommitsBetween(last *Commit, before *Commit) (*list.List
 		stdout, err = NewCommand("rev-list", last.ID.String()).RunInDirBytes(repo.Path)
 	} else {
 		stdout, err = NewCommand("rev-list", before.ID.String()+"..."+last.ID.String()).RunInDirBytes(repo.Path)
+		if err != nil && strings.Contains(err.Error(), "no merge base") {
+			// future versions of git >= 2.28 are likely to return an error if before and last have become unrelated.
+			// previously it would return the results of git rev-list before last so let's try that...
+			stdout, err = NewCommand("rev-list", before.ID.String(), last.ID.String()).RunInDirBytes(repo.Path)
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -374,6 +384,11 @@ func (repo *Repository) CommitsBetweenLimit(last *Commit, before *Commit, limit,
 		stdout, err = NewCommand("rev-list", "--max-count", strconv.Itoa(limit), "--skip", strconv.Itoa(skip), last.ID.String()).RunInDirBytes(repo.Path)
 	} else {
 		stdout, err = NewCommand("rev-list", "--max-count", strconv.Itoa(limit), "--skip", strconv.Itoa(skip), before.ID.String()+"..."+last.ID.String()).RunInDirBytes(repo.Path)
+		if err != nil && strings.Contains(err.Error(), "no merge base") {
+			// future versions of git >= 2.28 are likely to return an error if before and last have become unrelated.
+			// previously it would return the results of git rev-list --max-count n before last so let's try that...
+			stdout, err = NewCommand("rev-list", "--max-count", strconv.Itoa(limit), "--skip", strconv.Itoa(skip), before.ID.String(), last.ID.String()).RunInDirBytes(repo.Path)
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -399,7 +414,14 @@ func (repo *Repository) CommitsBetweenIDs(last, before string) (*list.List, erro
 
 // CommitsCountBetween return numbers of commits between two commits
 func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
-	return commitsCount(repo.Path, start+"..."+end, "")
+	count, err := commitsCount(repo.Path, []string{start + "..." + end}, []string{})
+	if err != nil && strings.Contains(err.Error(), "no merge base") {
+		// future versions of git >= 2.28 are likely to return an error if before and last have become unrelated.
+		// previously it would return the results of git rev-list before last so let's try that...
+		return commitsCount(repo.Path, []string{start, end}, []string{})
+	}
+
+	return count, err
 }
 
 // commitsBefore the limit is depth, not total number of returned commits.

--- a/modules/git/repo_compare.go
+++ b/modules/git/repo_compare.go
@@ -115,7 +115,7 @@ func (repo *Repository) GetDiffNumChangedFiles(base, head string) (int, error) {
 
 	if err := NewCommand("diff", "-z", "--name-only", base+"..."+head).
 		RunInDirPipeline(repo.Path, w, stderr); err != nil {
-		if strings.Contains(err.Error(), "no merge base") {
+		if strings.Contains(stderr.String(), "no merge base") {
 			// git >= 2.28 now returns an error if base and head have become unrelated.
 			// previously it would return the results of git diff -z --name-only base head so let's try that...
 			w = &lineCountWriter{}

--- a/modules/git/repo_compare.go
+++ b/modules/git/repo_compare.go
@@ -68,7 +68,7 @@ func (repo *Repository) GetCompareInfo(basePath, baseBranch, headBranch string) 
 	compareInfo := new(CompareInfo)
 	compareInfo.MergeBase, remoteBranch, err = repo.GetMergeBase(tmpRemote, baseBranch, headBranch)
 	if err == nil {
-		// We have a common base
+		// We have a common base - therefore we know that ... should work
 		logs, err := NewCommand("log", compareInfo.MergeBase+"..."+headBranch, prettyLogFormat).RunInDirBytes(repo.Path)
 		if err != nil {
 			return nil, err
@@ -115,6 +115,15 @@ func (repo *Repository) GetDiffNumChangedFiles(base, head string) (int, error) {
 
 	if err := NewCommand("diff", "-z", "--name-only", base+"..."+head).
 		RunInDirPipeline(repo.Path, w, stderr); err != nil {
+		if strings.Contains(err.Error(), "no merge base") {
+			// git >= 2.28 now returns an error if base and head have become unrelated.
+			// previously it would return the results of git diff -z --name-only base head so let's try that...
+			w = &lineCountWriter{}
+			stderr.Reset()
+			if err = NewCommand("diff", "-z", "--name-only", base, head).RunInDirPipeline(repo.Path, w, stderr); err == nil {
+				return w.numLines, nil
+			}
+		}
 		return 0, fmt.Errorf("%v: Stderr: %s", err, stderr)
 	}
 	return w.numLines, nil
@@ -122,7 +131,11 @@ func (repo *Repository) GetDiffNumChangedFiles(base, head string) (int, error) {
 
 // GetDiffShortStat counts number of changed files, number of additions and deletions
 func (repo *Repository) GetDiffShortStat(base, head string) (numFiles, totalAdditions, totalDeletions int, err error) {
-	return GetDiffShortStat(repo.Path, base+"..."+head)
+	numFiles, totalAdditions, totalDeletions, err = GetDiffShortStat(repo.Path, base+"..."+head)
+	if err != nil && strings.Contains(err.Error(), "no merge base") {
+		return GetDiffShortStat(repo.Path, base, head)
+	}
+	return
 }
 
 // GetDiffShortStat counts number of changed files, number of additions and deletions
@@ -193,12 +206,24 @@ func (repo *Repository) GetDiff(base, head string, w io.Writer) error {
 
 // GetPatch generates and returns format-patch data between given revisions.
 func (repo *Repository) GetPatch(base, head string, w io.Writer) error {
-	return NewCommand("format-patch", "--binary", "--stdout", base+"..."+head).
-		RunInDirPipeline(repo.Path, w, nil)
+	stderr := new(bytes.Buffer)
+	err := NewCommand("format-patch", "--binary", "--stdout", base+"..."+head).
+		RunInDirPipeline(repo.Path, w, stderr)
+	if err != nil && bytes.Contains(stderr.Bytes(), []byte("no merge base")) {
+		return NewCommand("format-patch", "--binary", "--stdout", base, head).
+			RunInDirPipeline(repo.Path, w, nil)
+	}
+	return err
 }
 
 // GetDiffFromMergeBase generates and return patch data from merge base to head
 func (repo *Repository) GetDiffFromMergeBase(base, head string, w io.Writer) error {
-	return NewCommand("diff", "-p", "--binary", base+"..."+head).
-		RunInDirPipeline(repo.Path, w, nil)
+	stderr := new(bytes.Buffer)
+	err := NewCommand("diff", "-p", "--binary", base+"..."+head).
+		RunInDirPipeline(repo.Path, w, stderr)
+	if err != nil && bytes.Contains(stderr.Bytes(), []byte("no merge base")) {
+		return NewCommand("diff", "-p", "--binary", base, head).
+			RunInDirPipeline(repo.Path, w, nil)
+	}
+	return err
 }

--- a/routers/private/hook.go
+++ b/routers/private/hook.go
@@ -39,6 +39,7 @@ func verifyCommits(oldCommitID, newCommitID string, repo *git.Repository, env []
 		_ = stdoutWriter.Close()
 	}()
 
+	// This is safe as force pushes are already forbidden
 	err = git.NewCommand("rev-list", oldCommitID+"..."+newCommitID).
 		RunInDirTimeoutEnvFullPipelineFunc(env, -1, repo.Path,
 			stdoutWriter, nil, nil,
@@ -70,6 +71,7 @@ func checkFileProtection(oldCommitID, newCommitID string, patterns []glob.Glob, 
 		_ = stdoutWriter.Close()
 	}()
 
+	// This use of ...  is safe as force-pushes have already been ruled out.
 	err = git.NewCommand("diff", "--name-only", oldCommitID+"..."+newCommitID).
 		RunInDirTimeoutEnvFullPipelineFunc(env, -1, repo.Path,
 			stdoutWriter, nil, nil,

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -752,6 +752,12 @@ func GetDiffRangeWithWhitespaceBehavior(repoPath, beforeCommitID, afterCommitID 
 		shortstatArgs = []string{git.EmptyTreeSHA, afterCommitID}
 	}
 	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(repoPath, shortstatArgs...)
+	if err != nil && strings.Contains(err.Error(), "no merge base") {
+		// git >= 2.28 now returns an error if base and head have become unrelated.
+		// previously it would return the results of git diff --shortstat base head so let's try that...
+		shortstatArgs = []string{beforeCommitID, afterCommitID}
+		diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(repoPath, shortstatArgs...)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Annoyingly git 2.28 now strictly enforces that when doing `git diff base...head` base and head must have a merge-base. Unfortunately this is a breaking change as previously this would just fall back to `git diff base head`. Therefore we need to detect this new error and handle it. 

In preparation for further changes I have also predicted that rev-list base...head may break in future too. Therefore I have attempted to protect against this too.

1.12 will also be affected by this and therefore we should backport these changes if possible. 

Closes #12362

Signed-off-by: Andrew Thornton <art27@cantab.net>
