### PR TITLE
Add the bindata source as a target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ backend: go-check generate $(EXECUTABLE)
 $(BINDATA_DEST): generate 
 
 .PHONY: generate
-generate: $(TAGS_PREREQ) | frontend
+generate: $(TAGS_PREREQ) | $(FOMANTIC_DEST) $(WEBPACK_DEST)
 	CC= GOOS= GOARCH= $(GO) generate -mod=vendor -tags '$(TAGS)' $(GO_PACKAGES)
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)

--- a/Makefile
+++ b/Makefile
@@ -525,11 +525,12 @@ frontend: node-check $(FOMANTIC_DEST) $(WEBPACK_DEST)
 .PHONY: backend
 backend: go-check generate $(EXECUTABLE)
 
-$(BINDATA_DEST): generate 
-
 .PHONY: generate
-generate: $(TAGS_PREREQ) | $(FOMANTIC_DEST) $(WEBPACK_DEST)
+.NOTPARALLEL: generate
+generate: $(TAGS_PREREQ)
 	CC= GOOS= GOARCH= $(GO) generate -mod=vendor -tags '$(TAGS)' $(GO_PACKAGES)
+
+$(BINDATA_DEST): generate
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
 	CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -mod=vendor $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@

--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ backend: go-check generate $(EXECUTABLE)
 $(BINDATA_DEST): generate 
 
 .PHONY: generate
-generate: $(TAGS_PREREQ)
+generate: $(TAGS_PREREQ) | frontend
 	CC= GOOS= GOARCH= $(GO) generate -mod=vendor -tags '$(TAGS)' $(GO_PACKAGES)
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ build: frontend backend
 frontend: node-check $(FOMANTIC_DEST) $(WEBPACK_DEST)
 
 .PHONY: backend
-backend: | go-check generate $(EXECUTABLE)
+backend: go-check generate $(EXECUTABLE)
 
 $(BINDATA_DEST): generate 
 

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,9 @@ build: frontend backend
 frontend: node-check $(FOMANTIC_DEST) $(WEBPACK_DEST)
 
 .PHONY: backend
-backend: go-check generate $(EXECUTABLE)
+backend: | go-check generate $(EXECUTABLE)
+
+$(BINDATA_DEST): generate 
 
 .PHONY: generate
 generate: $(TAGS_PREREQ)


### PR DESCRIPTION
`make backend` fails if parallelism is turned on with `make -jx`.

This happens because when the executable starts to be built the sources
for the bindata files are not available.

If however, we add a target that makes the sources for the bindata -
i.e. the generate target - then parallelism will work again.

References: #11756

Signed-off-by: Andrew Thornton <art27@cantab.net>
