### PR TITLE
Add note to README about make parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If pre-built frontend files are present it is possible to only build the backend
 
 		TAGS="bindata" make backend
 
+Parallelism is not supported for these targets, so please don't include `-j <num>`.
+
 More info: https://docs.gitea.io/en-us/install-from-source/
 
 ## Using


### PR DESCRIPTION
Alternative to https://github.com/go-gitea/gitea/pull/12367

Parallelism will screw our build in two ways:

- It may run `generate` and `frontend` at the same time which breaks the public bindata
- It may run `$(EXECUTABLE)` and `generate` at the same time which breaks all bindata

It could be solved by adding a proper dependency chain that enforces serialization but that would introduce a frontend/Node.js dependency on the backend chain which we want to avoid for users that don't have Node installed (e.g. building off the `src` tarballs). I think it's best to not intermingle backend/frontend dependency chains and just recommend not enabling parallelism as there is nothing that can run in parallel in the regular build (but not forbid it either so useful things like `make -j2 watch-backend watch frontend` will still work).