### PR TITLE
models: break out of loop

### DIFF
--- a/models/pull_sign.go
+++ b/models/pull_sign.go
@@ -27,12 +27,13 @@ func (pr *PullRequest) SignMerge(u *User, tmpBasePath, baseCommit, headCommit st
 	var gitRepo *git.Repository
 	var err error
 
+Loop:
 	for _, rule := range rules {
 		switch rule {
 		case never:
 			return false, "", &ErrWontSign{never}
 		case always:
-			break
+			break Loop
 		case pubkey:
 			keys, err := ListGPGKeys(u.ID, ListOptions{})
 			if err != nil {


### PR DESCRIPTION
I thought I got all of these in 56f222d44cd8d2787ad94105c5e219ebeeb10120, but apparently there was still a stray.

This fixes a `break` inside a `switch` inside a `for` loop, which was only making it past the `switch`.