### PR TITLE
Increase size of the language column in language_stat

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -222,6 +222,8 @@ var migrations = []Migration{
 	NewMigration("recalculate Stars number for all user", recalculateStars),
 	// v144 -> v145
 	NewMigration("update Matrix Webhook http method to 'PUT'", updateMatrixWebhookHTTPMethod),
+	// v145 -> v146
+	NewMigration("Increase Language field to 50 in LanguageStats", increaseLanguageField),
 }
 
 // GetCurrentDBVersion returns the current db version
@@ -464,7 +466,6 @@ func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...strin
 			sess.Rollback()
 			return fmt.Errorf("Drop table `%s` columns %v: %v", tableName, columnNames, err)
 		}
-
 		return sess.Commit()
 	default:
 		log.Fatal("Unrecognized DB")

--- a/models/migrations/v145.go
+++ b/models/migrations/v145.go
@@ -49,7 +49,7 @@ func increaseLanguageField(x *xorm.Engine) error {
 			return err
 		}
 	case setting.Database.UsePostgreSQL:
-		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat ALTER COLUMN language %s", sqlType)); err != nil {
+		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat ALTER COLUMN language TYPE %s", sqlType)); err != nil {
 			return err
 		}
 	}

--- a/models/migrations/v145.go
+++ b/models/migrations/v145.go
@@ -1,0 +1,58 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"code.gitea.io/gitea/modules/setting"
+	"xorm.io/xorm"
+)
+
+func increaseLanguageField(x *xorm.Engine) error {
+	type LanguageStat struct {
+		Language string `xorm:"VARCHAR(50) UNIQUE(s) INDEX NOT NULL"`
+	}
+
+	if err := x.Sync2(new(LanguageStat)); err != nil {
+		return err
+	}
+
+	if setting.Database.UseSQLite3 {
+		// SQLite maps VARCHAR to TEXT without size so we're done
+		return nil
+	}
+
+	// need to get the correct type for the new column
+	inferredTable, err := x.TableInfo(new(LanguageStat))
+	if err != nil {
+		return err
+	}
+	column := inferredTable.GetColumn("language")
+	sqlType := x.Dialect().SQLType(column)
+
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	switch {
+	case setting.Database.UseMySQL:
+		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat MODIFY COLUMN language %s", sqlType)); err != nil {
+			return err
+		}
+	case setting.Database.UseMSSQL:
+		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat ALTER COLUMN language %s", sqlType)); err != nil {
+			return err
+		}
+	case setting.Database.UsePostgreSQL:
+		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat ALTER COLUMN language %s", sqlType)); err != nil {
+			return err
+		}
+	}
+
+	return sess.Commit()
+}

--- a/models/migrations/v145.go
+++ b/models/migrations/v145.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"code.gitea.io/gitea/modules/setting"
+
 	"xorm.io/xorm"
 )
 

--- a/models/repo_language_stats.go
+++ b/models/repo_language_stats.go
@@ -19,7 +19,7 @@ type LanguageStat struct {
 	RepoID      int64 `xorm:"UNIQUE(s) INDEX NOT NULL"`
 	CommitID    string
 	IsPrimary   bool
-	Language    string             `xorm:"VARCHAR(30) UNIQUE(s) INDEX NOT NULL"`
+	Language    string             `xorm:"VARCHAR(50) UNIQUE(s) INDEX NOT NULL"`
 	Percentage  float32            `xorm:"-"`
 	Size        int64              `xorm:"NOT NULL DEFAULT 0"`
 	Color       string             `xorm:"-"`


### PR DESCRIPTION
In #12379 it was discovered that enry v2 has a maximum language length
of 34 characters which is larger than the 30 previously provided.

This PR updates the language column to 50.

Fix #12379
Fix #13013

Signed-off-by: Andrew Thornton <art27@cantab.net>
