### PR TITLE
Split up monaco's language chunks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,14 +97,6 @@ module.exports = {
     splitChunks: {
       chunks: 'async',
       name: (_, chunks) => chunks.map((item) => item.name).join('-'),
-      cacheGroups: {
-        // this bundles all monaco's languages into one file instead of emitting 1-65.js files
-        monaco: {
-          test: /monaco-editor/,
-          name: 'monaco',
-          chunks: 'async',
-        },
-      },
     },
   },
   module: {
@@ -325,5 +317,10 @@ module.exports = {
   },
   stats: {
     children: false,
+    excludeAssets: [
+      // exclude monaco's language chunks in stats output for brevity
+      // https://github.com/microsoft/monaco-editor-webpack-plugin/issues/113
+      /^js\/[0-9]+\.js$/,
+    ]
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -321,6 +321,6 @@ module.exports = {
       // exclude monaco's language chunks in stats output for brevity
       // https://github.com/microsoft/monaco-editor-webpack-plugin/issues/113
       /^js\/[0-9]+\.js$/,
-    ]
+    ],
   },
 };


### PR DESCRIPTION
This should speed up monaco's loading time by splitting the current 3.71MB chunk monaco.js into 63 individual files named 1 to 63.js in the output directory. There seems to be no way to get a better file naming scheme unfortunately. I opted to exclude those files in the webpack output for brevity.

(This is a exact revival of https://github.com/go-gitea/gitea/pull/12193)