### PR TITLE
Prevent empty div when editing comment

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -1975,7 +1975,7 @@ func updateAttachments(item interface{}, files []string) error {
 	case *models.Comment:
 		attachments = content.Attachments
 	default:
-		return fmt.Errorf("Unknow Type")
+		return fmt.Errorf("Unknown Type: %T", content)
 	}
 	for i := 0; i < len(attachments); i++ {
 		if util.IsStringInSlice(attachments[i].UUID, files) {
@@ -1993,7 +1993,7 @@ func updateAttachments(item interface{}, files []string) error {
 		case *models.Comment:
 			err = content.UpdateAttachments(files)
 		default:
-			return fmt.Errorf("Unknow Type")
+			return fmt.Errorf("Unknown Type: %T", content)
 		}
 		if err != nil {
 			return err
@@ -2005,7 +2005,7 @@ func updateAttachments(item interface{}, files []string) error {
 	case *models.Comment:
 		content.Attachments, err = models.GetAttachmentsByCommentID(content.ID)
 	default:
-		return fmt.Errorf("Unknow Type")
+		return fmt.Errorf("Unknown Type: %T", content)
 	}
 	return err
 }

--- a/templates/repo/issue/view_content/attachments.tmpl
+++ b/templates/repo/issue/view_content/attachments.tmpl
@@ -1,4 +1,4 @@
-{{range .Attachments}}
+{{- range .Attachments -}}
 <div class="twelve wide column" style="padding: 6px;">
 	<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
 	{{if FilenameIsImage .Name}}
@@ -12,4 +12,4 @@
 <div class="four wide column" style="padding: 0px;">
 	<span class="ui text grey right">{{.Size | FileSize}}</span>
 </div>
-{{end}}
+{{end -}}


### PR DESCRIPTION
The template for attachments needs to remove whitespace and return an empty response when there are no attachments.
    
Fix #10220
    
Signed-off-by: Andrew Thornton <art27@cantab.net>
