### PR TITLE
Need RepoID in the languagestat field

### DIFF
--- a/models/migrations/v145.go
+++ b/models/migrations/v145.go
@@ -14,6 +14,7 @@ import (
 
 func increaseLanguageField(x *xorm.Engine) error {
 	type LanguageStat struct {
+		RepoID   int64  `xorm:"UNIQUE(s) INDEX NOT NULL"`
 		Language string `xorm:"VARCHAR(50) UNIQUE(s) INDEX NOT NULL"`
 	}
 


### PR DESCRIPTION
#12396 is a broken migration. 

Fix #13013

Signed-off-by: Andrew Thornton <art27@cantab.net>
