### PR TITLE
Collapse Swagger UI tags by default

### DIFF
--- a/web_src/js/standalone/swagger.js
+++ b/web_src/js/standalone/swagger.js
@@ -18,6 +18,7 @@ window.addEventListener('load', async () => {
     spec,
     dom_id: '#swagger-ui',
     deepLinking: true,
+    docExpansion: 'none',
     presets: [
       SwaggerUI.presets.apis
     ],


### PR DESCRIPTION
This makes is slightly faster to navigate through the swagger docs by initially collapsing the tags like 'admin' or 'miscellaneous'.

Before:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/115237/89337843-eea09e00-d69b-11ea-932e-05fb20ad4fef.png">

After:

<img width="248" alt="image" src="https://user-images.githubusercontent.com/115237/89337884-011ad780-d69c-11ea-8e96-bc104abbbf6f.png">
