### PR TITLE
In issue comments, put issue participants also in completion list when hitting @

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -78,12 +78,16 @@
 				EventSourceUpdateTime: {{NotificationSettings.EventSourceUpdateTime}},
 			},
       {{if .RequireTribute}}
-			tributeValues: [
-				{{ range .Assignees }}
-				{key: '{{.Name}} {{.FullName}}', value: '{{.Name}}',
-				name: '{{.Name}}', fullname: '{{.FullName}}', avatar: '{{.RelAvatarLink}}'},
+			tributeValues: Array.from(new Map([
+				{{ range .Participants }}
+				['{{.Name}}', {key: '{{.Name}} {{.FullName}}', value: '{{.Name}}',
+				name: '{{.Name}}', fullname: '{{.FullName}}', avatar: '{{.RelAvatarLink}}'}],
 				{{ end }}
-			],
+				{{ range .Assignees }}
+				['{{.Name}}', {key: '{{.Name}} {{.FullName}}', value: '{{.Name}}',
+				name: '{{.Name}}', fullname: '{{.FullName}}', avatar: '{{.RelAvatarLink}}'}],
+				{{ end }}
+			]).values()),
 			{{end}}
 		};
 	</script>


### PR DESCRIPTION
Previous behaviour was only to have completion for project members.

This combines participant lists with the possible assignee lists and removes duplicates.

Duplicate removal is done on the javascript side. It would be probably cleaner to create the list in go code, but this keeps the patch minimal.