### PR TITLE
Mirror System Notice reports are too frequent

### DIFF
--- a/modules/cron/setting.go
+++ b/modules/cron/setting.go
@@ -17,13 +17,15 @@ type Config interface {
 	DoRunAtStart() bool
 	GetSchedule() string
 	FormatMessage(name, status string, doer *models.User, args ...interface{}) string
+	DoNoticeOnSuccess() bool
 }
 
 // BaseConfig represents the basic config for a Cron task
 type BaseConfig struct {
-	Enabled    bool
-	RunAtStart bool
-	Schedule   string
+	Enabled         bool
+	RunAtStart      bool
+	Schedule        string
+	NoSuccessNotice bool
 }
 
 // OlderThanConfig represents a cron task with OlderThan setting
@@ -51,6 +53,11 @@ func (b *BaseConfig) IsEnabled() bool {
 // DoRunAtStart returns whether the task should be run at the start
 func (b *BaseConfig) DoRunAtStart() bool {
 	return b.RunAtStart
+}
+
+// DoNoticeOnSuccess returns whether a success notice should be posted
+func (b *BaseConfig) DoNoticeOnSuccess() bool {
+	return !b.NoSuccessNotice
 }
 
 // FormatMessage returns a message for the task

--- a/modules/cron/tasks.go
+++ b/modules/cron/tasks.go
@@ -98,8 +98,10 @@ func (t *Task) RunWithUser(doer *models.User, config Config) {
 			}
 			return
 		}
-		if err := models.CreateNotice(models.NoticeTask, config.FormatMessage(t.Name, "finished", doer)); err != nil {
-			log.Error("CreateNotice: %v", err)
+		if config.DoNoticeOnSuccess() {
+			if err := models.CreateNotice(models.NoticeTask, config.FormatMessage(t.Name, "finished", doer)); err != nil {
+				log.Error("CreateNotice: %v", err)
+			}
 		}
 	})
 }

--- a/modules/cron/tasks_basic.go
+++ b/modules/cron/tasks_basic.go
@@ -16,9 +16,10 @@ import (
 
 func registerUpdateMirrorTask() {
 	RegisterTaskFatal("update_mirrors", &BaseConfig{
-		Enabled:    true,
-		RunAtStart: false,
-		Schedule:   "@every 10m",
+		Enabled:         true,
+		RunAtStart:      false,
+		Schedule:        "@every 10m",
+		NoSuccessNotice: true,
 	}, func(ctx context.Context, _ *models.User, _ Config) error {
 		return mirror_service.Update(ctx)
 	})


### PR DESCRIPTION
This PR switches off the success reports from the Update Mirrors cron job
as they are too frequent and not necessarily helpful.

Signed-off-by: Andrew Thornton <art27@cantab.net>
