### PR TITLE
Remove librejs header in <head>

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -26,39 +26,6 @@
 	<meta name="go-source" content="{{.GoGetImport}} _ {{.GoDocDirectory}} {{.GoDocFile}}">
 {{end}}
 	<script>
-	{{SafeJS `/*
-	@licstart  The following is the entire license notice for the
-        JavaScript code in this page.
-
-	Copyright (c) 2016 The Gitea Authors
-	Copyright (c) 2015 The Gogs Authors
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy
-	of this software and associated documentation files (the "Software"), to deal
-	in the Software without restriction, including without limitation the rights
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the Software is
-	furnished to do so, subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in
-	all copies or substantial portions of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-	THE SOFTWARE.
-	---
-	Licensing information for additional javascript libraries can be found at:
-	  {{StaticUrlPrefix}}/js/licenses.txt
-
-	@licend  The above is the entire license notice
-        for the JavaScript code in this page.
-	*/`}}
-	</script>
-	<script>
 		window.config = {
 			AppVer: '{{AppVer}}',
 			AppSubUrl: '{{AppSubUrl}}',


### PR DESCRIPTION
For the sake of performance and simplicity, remove this seemingly useless license header. It's related to LibreJS which we already pretty much killed of in an earlier commit [1]. Initially added in [2]. Note that the `StaticUrlPrefix` here was never actually correctly resolved and has rendered including the template fences.

[1] https://github.com/go-gitea/gitea/pull/11810
[2] https://github.com/go-gitea/gitea/commit/a915a09e4f8edc7734c9374ad9f9a51b39241ee3