### PR TITLE
UI: Fix input field border size for filter button in green theme

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -600,14 +600,12 @@ footer {
 
 .ui.input input {
     background: #404552;
-    border: 2px solid #353945;
     color: #dbdbdb;
 }
 
 .ui.input input:focus,
 .ui.input.focus input {
     background: #404552;
-    border: 2px solid #353945;
     color: #dbdbdb;
 }
 


### PR DESCRIPTION
This fixes wrong size of input field

Before:
![image](https://user-images.githubusercontent.com/10697207/90210368-730ac380-ddf6-11ea-83d5-33465ea8d26c.png)

After:
![image](https://user-images.githubusercontent.com/10697207/90210348-64bca780-ddf6-11ea-9925-128d8186b161.png)
