### PR TITLE
Remove hardcoded ES indexername (#12521)

### DIFF
--- a/modules/indexer/issues/indexer.go
+++ b/modules/indexer/issues/indexer.go
@@ -171,7 +171,7 @@ func InitIssueIndexer(syncReindex bool) {
 			log.Debug("Created Bleve Indexer")
 		case "elasticsearch":
 			graceful.GetManager().RunWithShutdownFns(func(_, atTerminate func(context.Context, func())) {
-				issueIndexer, err := NewElasticSearchIndexer(setting.Indexer.IssueConnStr, "gitea_issues")
+				issueIndexer, err := NewElasticSearchIndexer(setting.Indexer.IssueConnStr, setting.Indexer.IssueIndexerName)
 				if err != nil {
 					log.Fatal("Unable to initialize Elastic Search Issue Indexer at connection: %s Error: %v", setting.Indexer.IssueConnStr, err)
 				}


### PR DESCRIPTION
Backport #12521 

This makes the `ISSUE_INDEXER_NAME` option actually work

Credit: @42wim 