### PR TITLE
Disable password complexity check default

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -497,9 +497,9 @@ DISABLE_GIT_HOOKS = false
 ; Set to false to allow pushes to gitea repositories despite having an incomplete environment - NOT RECOMMENDED
 ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
 ;Comma separated list of character classes required to pass minimum complexity.
-;If left empty or no valid values are specified, the default values ("lower,upper,digit,spec") will be used.
-;Use "off" to disable checking.
-PASSWORD_COMPLEXITY = lower,upper,digit,spec
+;If left empty or no valid values are specified, the default is off (no checking)
+;Classes include "lower,upper,digit,spec"
+PASSWORD_COMPLEXITY = off
 ; Password Hash algorithm, either "pbkdf2", "argon2", "scrypt" or "bcrypt"
 PASSWORD_HASH_ALGO = pbkdf2
 ; Set false to allow JavaScript to read CSRF cookie

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -323,7 +323,7 @@ set name for unique queues. Individual queues will default to
 - `INTERNAL_TOKEN_URI`: **<empty>**: Instead of defining internal token in the configuration, this configuration option can be used to give Gitea a path to a file that contains the internal token (example value: `file:/etc/gitea/internal_token`)
 - `PASSWORD_HASH_ALGO`: **pbkdf2**: The hash algorithm to use \[pbkdf2, argon2, scrypt, bcrypt\].
 - `CSRF_COOKIE_HTTP_ONLY`: **true**: Set false to allow JavaScript to read CSRF cookie.
-- `PASSWORD_COMPLEXITY`: **lower,upper,digit,spec**: Comma separated list of character classes required to pass minimum complexity. If left empty or no valid values are specified, the default values will be used. Possible values are: 
+- `PASSWORD_COMPLEXITY`: **off**: Comma separated list of character classes required to pass minimum complexity. If left empty or no valid values are specified, checking is disabled (off):
     - lower - use one or more lower latin characters
     - upper - use one or more upper latin characters
     - digit - use one or more digits

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -825,6 +825,10 @@ func NewContext() {
 	InternalToken = loadInternalToken(sec)
 
 	cfgdata := sec.Key("PASSWORD_COMPLEXITY").Strings(",")
+	if len(cfgdata) == 0 {
+		cfgdata = []string{
+			"off"}
+	}
 	PasswordComplexity = make([]string, 0, len(cfgdata))
 	for _, name := range cfgdata {
 		name := strings.ToLower(strings.Trim(name, `"`))

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -826,8 +826,7 @@ func NewContext() {
 
 	cfgdata := sec.Key("PASSWORD_COMPLEXITY").Strings(",")
 	if len(cfgdata) == 0 {
-		cfgdata = []string{
-			"off"}
+		cfgdata = []string{"off"}
 	}
 	PasswordComplexity = make([]string, 0, len(cfgdata))
 	for _, name := range cfgdata {


### PR DESCRIPTION
These features enourange bad passwords/are annoying for people using better password methods, and at minimum we shouldn't force that as a default for obvious reasons. Disable any default check to avoid regular complaints.

Close #12284