### PR TITLE
Skip SSPI authentication attempts for /api/internal (#12556)

### DIFF
--- a/modules/auth/sso/oauth2.go
+++ b/modules/auth/sso/oauth2.go
@@ -121,7 +121,7 @@ func (o *OAuth2) VerifyAuthData(ctx *macaron.Context, sess session.Store) *model
 		return nil
 	}
 
-	if !isAPIPath(ctx) && !isAttachmentDownload(ctx) {
+	if isInternalPath(ctx) || !isAPIPath(ctx) && !isAttachmentDownload(ctx) {
 		return nil
 	}
 

--- a/modules/auth/sso/sso.go
+++ b/modules/auth/sso/sso.go
@@ -100,6 +100,11 @@ func isAPIPath(ctx *macaron.Context) bool {
 	return strings.HasPrefix(ctx.Req.URL.Path, "/api/")
 }
 
+// isInternalPath returns true if the specified URL is an internal API path
+func isInternalPath(ctx *macaron.Context) bool {
+	return strings.HasPrefix(ctx.Req.URL.Path, "/api/internal/")
+}
+
 // isAttachmentDownload check if request is a file download (GET) with URL to an attachment
 func isAttachmentDownload(ctx *macaron.Context) bool {
 	return strings.HasPrefix(ctx.Req.URL.Path, "/attachments/") && ctx.Req.Method == "GET"

--- a/modules/auth/sso/sspi_windows.go
+++ b/modules/auth/sso/sspi_windows.go
@@ -148,6 +148,8 @@ func (s *SSPI) shouldAuthenticate(ctx *macaron.Context) (shouldAuth bool) {
 		} else if ctx.Req.FormValue("auth_with_sspi") == "1" {
 			shouldAuth = true
 		}
+	} else if isInternalPath(ctx) {
+		shouldAuth = false
 	} else if isAPIPath(ctx) || isAttachmentDownload(ctx) {
 		shouldAuth = true
 	}


### PR DESCRIPTION
Backport #12556

SSPI fails badly on authentication attempts to /api/internal which
it can never successfully authenticate.

Fix #11260

Signed-off-by: Andrew Thornton <art27@cantab.net>
