### PR TITLE
Set utf8mb4 as the default charset on MySQL if CHARSET is unset

### DIFF
--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -60,11 +60,13 @@ func GetDBTypeByName(name string) string {
 func InitDBConfig() {
 	sec := Cfg.Section("database")
 	Database.Type = sec.Key("DB_TYPE").String()
+	defaultCharset := "utf8"
 	switch Database.Type {
 	case "sqlite3":
 		Database.UseSQLite3 = true
 	case "mysql":
 		Database.UseMySQL = true
+		defaultCharset = "utf8mb4"
 	case "postgres":
 		Database.UsePostgreSQL = true
 	case "mssql":
@@ -78,7 +80,7 @@ func InitDBConfig() {
 	}
 	Database.Schema = sec.Key("SCHEMA").String()
 	Database.SSLMode = sec.Key("SSL_MODE").MustString("disable")
-	Database.Charset = sec.Key("CHARSET").In("utf8", []string{"utf8", "utf8mb4"})
+	Database.Charset = sec.Key("CHARSET").In(defaultCharset, []string{"utf8", "utf8mb4"})
 	Database.Path = sec.Key("PATH").MustString(filepath.Join(AppDataPath, "gitea.db"))
 	Database.Timeout = sec.Key("SQLITE_TIMEOUT").MustInt(500)
 	Database.MaxIdleConns = sec.Key("MAX_IDLE_CONNS").MustInt(2)


### PR DESCRIPTION
MySQL in its infinite wisdom determines that UTF8 does not
mean UTF8. Our install scripts know about this and will set
CHARSET to utf8mb4 if we users choose this but... users who
do not explicitly set this variable will default to utf8mb3
without knowing it.

This PR changes the unset CHARSET value to utf8mb4 if users
choose to use mysql.

Signed-off-by: Andrew Thornton <art27@cantab.net>
