### PR TITLE
Hide PR action box for logged out users

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -63,6 +63,7 @@
 	</div>
 {{end}}
 <div class="timeline-item comment merge box">
+	{{if .IsSigned}}
 	<a class="timeline-avatar text  {{if .Issue.PullRequest.HasMerged}}purple
 	{{- else if .Issue.IsClosed}}grey
 	{{- else if .IsPullWorkInProgress}}grey
@@ -402,4 +403,5 @@
 			{{end}}
 		</div>
 	</div>
+	{{end}}
 </div>


### PR DESCRIPTION
#### TL;DR
As consulted with @zeripath , I figured that casually browsing users don't need the info about PR mergeability, hence we don't show them the merge box thing.
#### Longer-ish story:
To name a particularly odd case, a message saying "`signing.wont_sign.%!s(<nil>)`" - as due to a missing signing key - was shown (pic 1), even though there in fact *does* exist a default signing key (pic 3) which is why the message kind of comes across as confusing.
It might therefore be safer (read: less confusing) to not display the mergeability status to a casual user (as in pic 2).

Before:
![before](https://user-images.githubusercontent.com/61180606/90959560-1feedb80-e49c-11ea-9d4a-8b60417c5ee1.png)

After:
![after](https://user-images.githubusercontent.com/61180606/90959565-254c2600-e49c-11ea-8576-7369eb1b02a6.png)

There is a signing key:
![thereisasigningkey](https://user-images.githubusercontent.com/61180606/90959868-e323e400-e49d-11ea-9785-67a067444115.png)

