### PR TITLE
Fix emoji replacements, make emoji images consistent

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -481,6 +481,7 @@ func createCustomEmoji(alias, class string) *html.Node {
 		Attr:     []html.Attribute{},
 	}
 	if class != "" {
+		img.Attr = append(img.Attr, html.Attribute{Key: "alt", Val: fmt.Sprintf(`:%s:`, alias)})
 		img.Attr = append(img.Attr, html.Attribute{Key: "src", Val: fmt.Sprintf(`%s/img/emoji/%s.png`, setting.StaticURLPrefix, alias)})
 	}
 

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -255,7 +255,7 @@ func TestRender_emoji(t *testing.T) {
 	//Text that should be turned into or recognized as emoji
 	test(
 		":gitea:",
-		`<p><span class="emoji" aria-label="gitea"><img src="`+setting.StaticURLPrefix+`/img/emoji/gitea.png"/></span></p>`)
+		`<p><span class="emoji" aria-label="gitea"><img alt=":gitea:" src="`+setting.StaticURLPrefix+`/img/emoji/gitea.png"/></span></p>`)
 
 	test(
 		"Some text with 😄 in the middle",

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -607,7 +607,7 @@ func ReactionToEmoji(reaction string) template.HTML {
 	if val != nil {
 		return template.HTML(val.Emoji)
 	}
-	return template.HTML(fmt.Sprintf(`<img src=%s/img/emoji/%s.png></img>`, setting.StaticURLPrefix, reaction))
+	return template.HTML(fmt.Sprintf(`<img alt=":%s:" src="%s/img/emoji/%s.png"></img>`, reaction, setting.StaticURLPrefix, reaction))
 }
 
 // RenderNote renders the contents of a git-notes file as a commit message.

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -218,7 +218,7 @@
 			</a>
 			<span class="text grey">
 				<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-				{{$.i18n.Tr "repo.issues.change_title_at" (.OldTitle|Escape) (.NewTitle|Escape) $createdStr | Safe}}
+				{{$.i18n.Tr "repo.issues.change_title_at" (.OldTitle|RenderEmoji) (.NewTitle|RenderEmoji) $createdStr | Safe}}
 			</span>
 		</div>
 	{{else if eq .Type 11}}

--- a/web_src/js/features/emoji.js
+++ b/web_src/js/features/emoji.js
@@ -24,7 +24,7 @@ for (const key of emojiKeys) {
 export function emojiHTML(name) {
   let inner;
   if (name === 'gitea') {
-    inner = `<img class="emoji" alt=":${name}:" src="${StaticUrlPrefix}/img/emoji/gitea.png" align="absmiddle">`;
+    inner = `<img alt=":${name}:" src="${StaticUrlPrefix}/img/emoji/gitea.png">`;
   } else {
     inner = emojiString(name);
   }


### PR DESCRIPTION
- Fix emoji not being replaced in issue title change text
- Make the image attributes consistent, add alt, remove align

Before:
<img width="668" alt="Screen Shot 2020-08-22 at 20 02 15" src="https://user-images.githubusercontent.com/115237/90963756-ee393d00-e4ba-11ea-8e1b-a2ddd11b2b4b.png">

After:
<img width="567" alt="Screen Shot 2020-08-22 at 21 01 15" src="https://user-images.githubusercontent.com/115237/90963757-f0030080-e4ba-11ea-8a74-cf35d9072e13.png">