### PR TITLE
Change tab width for go,tmpl,html to 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = false
 
 [*.{go,tmpl,html}]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 
 [*.{less,css}]
 indent_style = space


### PR DESCRIPTION
Make it easier to edit deeply nested code. I plan to convert Less to 2-space so that we have standardized indentation width in the codebase.