### PR TITLE
Reaction picker display improvements

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2340,9 +2340,10 @@
 
             > .item {
                 float: left;
-                padding: .5rem !important;
+                padding: .25rem !important;
+                margin: .25rem;
                 font-size: 1.5em;
-                width: 45px;
+                width: 39px;
                 left: 13px;
 
                 img.emoji {
@@ -2356,10 +2357,9 @@
         padding: 0;
         display: flex;
 
-        .ui.label,
-        .ui.label.visible {
+        .ui.label {
             max-height: 40px;
-            padding: .4rem .8rem;
+            padding: 7px 18px;
             display: flex !important;
             align-items: center;
             border: 0;
@@ -2367,7 +2367,7 @@
             border-radius: 0;
             margin: 0;
             font-size: 14px;
-            font-weight: 100;
+            font-weight: normal;
             border-color: inherit !important;
 
             &.disabled {
@@ -2388,10 +2388,21 @@
         .select-reaction {
             display: flex;
             align-items: center;
-            padding: 0 .5rem;
+            padding: 0 14px;
 
             &:not(.active) a {
                 display: none;
+            }
+
+            .item {
+                border-radius: 6px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+
+            .item:hover {
+                background: #4183c4;
             }
         }
 

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -704,6 +704,16 @@ a.ui.basic.green.label:hover {
     border-color: #26577b !important;
 }
 
+.repository .segment.reactions .ui.label.basic.blue {
+    color: #a0cc75 !important;
+    background: #305020 !important;
+    border-color: #404552 !important;
+}
+
+.repository .segment.reactions .select-reaction .item:hover {
+    background: #305020;
+}
+
 .ui.menu .item > .label {
     background: #565454;
 }


### PR DESCRIPTION
- Remove overly thin font-width on counter
- Add hover effect on reaction picker
- Change colors on arc-green to green to match the theme

Some parts of this extracted from https://github.com/go-gitea/gitea/pull/12448.

<img width="474" alt="Screen Shot 2020-08-23 at 15 09 41" src="https://user-images.githubusercontent.com/115237/90979115-11173000-e553-11ea-8d39-f79e72b024f3.png">
<img width="466" alt="image" src="https://user-images.githubusercontent.com/115237/90979121-1d9b8880-e553-11ea-90b0-0b762e42961f.png">
