### PR TITLE
Mark Cache with ini tag

### DIFF
--- a/modules/setting/cache.go
+++ b/modules/setting/cache.go
@@ -23,7 +23,7 @@ type Cache struct {
 var (
 	// CacheService the global cache
 	CacheService = struct {
-		Cache
+		Cache `ini:"cache"`
 
 		LastCommit struct {
 			Enabled      bool


### PR DESCRIPTION
Fixes #12587 

(Note that this doesn't usually show up in admin UI with `memory` cache, I fudged the template to show it for an example)

![cache](https://user-images.githubusercontent.com/42128690/91230439-1dd18a80-e6f1-11ea-93a5-0f0d3a4bc550.png)
