### PR TITLE
Fix ellipsis in files table

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -49,7 +49,7 @@
 							{{svg "octicon-file-submodule" 16}}
 							{{$refURL := $commit.RefURL AppUrl $.Repository.FullName}}
 							{{if $refURL}}
-								<a class="flex-0" href="{{$refURL}}">{{$entry.Name}}</a><span class="at">@</span><a class="flex-1" href="{{$refURL}}/commit/{{$commit.RefID}}">{{ShortSha $commit.RefID}}</a>
+								<a href="{{$refURL}}">{{$entry.Name}}</a><span class="at">@</span><a href="{{$refURL}}/commit/{{$commit.RefID}}">{{ShortSha $commit.RefID}}</a>
 							{{else}}
 								{{$entry.Name}}<span class="at">@</span>{{ShortSha $commit.RefID}}
 							{{end}}
@@ -58,7 +58,7 @@
 								{{$subJumpablePathName := $entry.GetSubJumpablePathName}}
 								{{$subJumpablePath := SubJumpablePath $subJumpablePathName}}
 								{{svg "octicon-file-directory" 16}}
-								<a class="flex-1" href="{{EscapePound $.TreeLink}}/{{EscapePound $subJumpablePathName}}" title="{{$subJumpablePathName}}">
+								<a href="{{EscapePound $.TreeLink}}/{{EscapePound $subJumpablePathName}}" title="{{$subJumpablePathName}}">
 									{{if eq (len $subJumpablePath) 2}}
 										<span class="jumpable-path">{{index  $subJumpablePath 0}}</span>{{index  $subJumpablePath 1}}
 									{{else}}
@@ -67,14 +67,14 @@
 								</a>
 							{{else}}
 								{{svg (printf "octicon-%s" (EntryIcon $entry)) 16}}
-								<a class="flex-1" href="{{EscapePound $.TreeLink}}/{{EscapePound $entry.Name}}" title="{{$entry.Name}}">{{$entry.Name}}</a>
+								<a href="{{EscapePound $.TreeLink}}/{{EscapePound $entry.Name}}" title="{{$entry.Name}}">{{$entry.Name}}</a>
 							{{end}}
 						{{end}}
 					</span>
 				</td>
 				<td class="message nine wide">
 					<span class="truncate">
-						<a class="flex-1" href="{{$.RepoLink}}/commit/{{$commit.ID}}" title="{{$commit.Summary}}">{{$commit.Summary | RenderEmoji}}</a>
+						<a href="{{$.RepoLink}}/commit/{{$commit.ID}}" title="{{$commit.Summary}}">{{$commit.Summary | RenderEmoji}}</a>
 					</span>
 				</td>
 				<td class="text right age three wide">{{TimeSince $commit.Committer.When $.Lang}}</td>

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -362,12 +362,13 @@
         }
 
         .truncate {
-          display: inline-flex;
-          align-items: center;
+          display: inline-block;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
           width: 100%;
+          padding-top: 8px;
+          padding-bottom: 8px;
         }
 
         a {


### PR DESCRIPTION
Fix another regression from https://github.com/go-gitea/gitea/pull/12553 and subsequently https://github.com/go-gitea/gitea/pull/12603.

Turns out text ellipsis does not work in combination with flexbox and while wrapping in a display:block can help in some cases, I could not get this to work properly so this changes the truncate to inline-block again and reduces the clickable area to just vertical expansion from the
links.

Clickable area:

<img width="1180" alt="Screen Shot 2020-08-26 at 23 04 01" src="https://user-images.githubusercontent.com/115237/91357158-17c2d300-e7f1-11ea-9af4-90659917d903.png">
