### PR TITLE
Git migration UX improvements

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -56,8 +56,10 @@ func (f *CreateRepoForm) Validate(ctx *macaron.Context, errs binding.Errors) bin
 type MigrateRepoForm struct {
 	// required: true
 	CloneAddr    string `json:"clone_addr" binding:"Required"`
+	Service      int    `json:"service"`
 	AuthUsername string `json:"auth_username"`
 	AuthPassword string `json:"auth_password"`
+	AuthToken    string `json:"auth_token"`
 	// required: true
 	UID int64 `json:"uid" binding:"Required"`
 	// required: true

--- a/modules/migrations/base/downloader.go
+++ b/modules/migrations/base/downloader.go
@@ -7,13 +7,20 @@ package base
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"code.gitea.io/gitea/modules/structs"
 )
 
+// AssetDownloader downloads an asset (attachment) for a release
+type AssetDownloader interface {
+	GetAsset(tag string, id int64) (io.ReadCloser, error)
+}
+
 // Downloader downloads the site repo informations
 type Downloader interface {
+	AssetDownloader
 	SetContext(context.Context)
 	GetRepoInfo() (*Repository, error)
 	GetTopics() ([]string, error)
@@ -28,7 +35,6 @@ type Downloader interface {
 
 // DownloaderFactory defines an interface to match a downloader implementation and create a downloader
 type DownloaderFactory interface {
-	Match(opts MigrateOptions) (bool, error)
 	New(opts MigrateOptions) (Downloader, error)
 	GitServiceType() structs.GitServiceType
 }

--- a/modules/migrations/base/release.go
+++ b/modules/migrations/base/release.go
@@ -8,7 +8,7 @@ import "time"
 
 // ReleaseAsset represents a release asset
 type ReleaseAsset struct {
-	URL           string
+	ID            int64
 	Name          string
 	ContentType   *string
 	Size          *int

--- a/modules/migrations/base/uploader.go
+++ b/modules/migrations/base/uploader.go
@@ -11,7 +11,7 @@ type Uploader interface {
 	CreateRepo(repo *Repository, opts MigrateOptions) error
 	CreateTopics(topic ...string) error
 	CreateMilestones(milestones ...*Milestone) error
-	CreateReleases(releases ...*Release) error
+	CreateReleases(downloader Downloader, releases ...*Release) error
 	SyncTags() error
 	CreateLabels(labels ...*Label) error
 	CreateIssues(issues ...*Issue) error

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -5,9 +5,9 @@
 package migrations
 
 import (
-	"context"
-
 	"code.gitea.io/gitea/modules/migrations/base"
+	"context"
+	"io"
 )
 
 var (
@@ -61,6 +61,11 @@ func (g *PlainGitDownloader) GetLabels() ([]*base.Label, error) {
 
 // GetReleases returns releases
 func (g *PlainGitDownloader) GetReleases() ([]*base.Release, error) {
+	return nil, ErrNotSupported
+}
+
+// GetAsset returns an asset
+func (g *PlainGitDownloader) GetAsset(_ string, _ int64) (io.ReadCloser, error) {
 	return nil, ErrNotSupported
 }
 

--- a/modules/migrations/git.go
+++ b/modules/migrations/git.go
@@ -5,9 +5,10 @@
 package migrations
 
 import (
-	"code.gitea.io/gitea/modules/migrations/base"
 	"context"
 	"io"
+
+	"code.gitea.io/gitea/modules/migrations/base"
 )
 
 var (

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -100,7 +100,7 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, opts base.Migrate
 		}
 		u.User = url.UserPassword(opts.AuthUsername, opts.AuthPassword)
 		if len(opts.AuthToken) > 0 {
-			u.User = url.User(opts.AuthToken)
+			u.User = url.UserPassword("oauth2", opts.AuthToken)
 		}
 		remoteAddr = u.String()
 	}

--- a/modules/migrations/gitea.go
+++ b/modules/migrations/gitea.go
@@ -93,12 +93,15 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, opts base.Migrate
 	}
 
 	var remoteAddr = repo.CloneURL
-	if len(opts.AuthUsername) > 0 {
+	if len(opts.AuthToken) > 0 || len(opts.AuthUsername) > 0 {
 		u, err := url.Parse(repo.CloneURL)
 		if err != nil {
 			return err
 		}
 		u.User = url.UserPassword(opts.AuthUsername, opts.AuthPassword)
+		if len(opts.AuthToken) > 0 {
+			u.User = url.User(opts.AuthToken)
+		}
 		remoteAddr = u.String()
 	}
 
@@ -210,7 +213,7 @@ func (g *GiteaLocalUploader) CreateLabels(labels ...*base.Label) error {
 }
 
 // CreateReleases creates releases
-func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
+func (g *GiteaLocalUploader) CreateReleases(downloader base.Downloader, releases ...*base.Release) error {
 	var rels = make([]*models.Release, 0, len(releases))
 	for _, release := range releases {
 		var rel = models.Release{
@@ -269,13 +272,11 @@ func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 
 			// download attachment
 			err = func() error {
-				resp, err := http.Get(asset.URL)
+				rc, err := downloader.GetAsset(rel.TagName, asset.ID)
 				if err != nil {
 					return err
 				}
-				defer resp.Body.Close()
-
-				_, err = storage.Attachments.Save(attach.RelativePath(), resp.Body)
+				_, err = storage.Attachments.Save(attach.RelativePath(), rc)
 				return err
 			}()
 			if err != nil {

--- a/modules/migrations/gitea_test.go
+++ b/modules/migrations/gitea_test.go
@@ -26,7 +26,7 @@ func TestGiteaUploadRepo(t *testing.T) {
 	user := models.AssertExistsAndLoadBean(t, &models.User{ID: 1}).(*models.User)
 
 	var (
-		downloader = NewGithubDownloaderV3("", "", "go-xorm", "builder")
+		downloader = NewGithubDownloaderV3("", "", "", "go-xorm", "builder")
 		repoName   = "builder-" + time.Now().Format("2006-01-02-15-04-05")
 		uploader   = NewGiteaLocalUploader(graceful.GetManager().HammerContext(), user, user.Name, repoName)
 	)

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -6,8 +6,11 @@
 package migrations
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -37,16 +40,6 @@ func init() {
 type GithubDownloaderV3Factory struct {
 }
 
-// Match returns ture if the migration remote URL matched this downloader factory
-func (f *GithubDownloaderV3Factory) Match(opts base.MigrateOptions) (bool, error) {
-	u, err := url.Parse(opts.CloneAddr)
-	if err != nil {
-		return false, err
-	}
-
-	return strings.EqualFold(u.Host, "github.com") && opts.AuthUsername != "", nil
-}
-
 // New returns a Downloader related to this factory according MigrateOptions
 func (f *GithubDownloaderV3Factory) New(opts base.MigrateOptions) (base.Downloader, error) {
 	u, err := url.Parse(opts.CloneAddr)
@@ -60,7 +53,7 @@ func (f *GithubDownloaderV3Factory) New(opts base.MigrateOptions) (base.Download
 
 	log.Trace("Create github downloader: %s/%s", oldOwner, oldName)
 
-	return NewGithubDownloaderV3(opts.AuthUsername, opts.AuthPassword, oldOwner, oldName), nil
+	return NewGithubDownloaderV3(opts.AuthUsername, opts.AuthPassword, opts.AuthToken, oldOwner, oldName), nil
 }
 
 // GitServiceType returns the type of git service
@@ -81,7 +74,7 @@ type GithubDownloaderV3 struct {
 }
 
 // NewGithubDownloaderV3 creates a github Downloader via github v3 API
-func NewGithubDownloaderV3(userName, password, repoOwner, repoName string) *GithubDownloaderV3 {
+func NewGithubDownloaderV3(userName, password, token, repoOwner, repoName string) *GithubDownloaderV3 {
 	var downloader = GithubDownloaderV3{
 		userName:  userName,
 		password:  password,
@@ -90,23 +83,19 @@ func NewGithubDownloaderV3(userName, password, repoOwner, repoName string) *Gith
 		repoName:  repoName,
 	}
 
-	var client *http.Client
-	if userName != "" {
-		if password == "" {
-			ts := oauth2.StaticTokenSource(
-				&oauth2.Token{AccessToken: userName},
-			)
-			client = oauth2.NewClient(downloader.ctx, ts)
-		} else {
-			client = &http.Client{
-				Transport: &http.Transport{
-					Proxy: func(req *http.Request) (*url.URL, error) {
-						req.SetBasicAuth(userName, password)
-						return nil, nil
-					},
-				},
-			}
-		}
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(req *http.Request) (*url.URL, error) {
+				req.SetBasicAuth(userName, password)
+				return nil, nil
+			},
+		},
+	}
+	if token != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		client = oauth2.NewClient(downloader.ctx, ts)
 	}
 	downloader.client = github.NewClient(client)
 	return &downloader
@@ -290,10 +279,8 @@ func (g *GithubDownloaderV3) convertGithubRelease(rel *github.RepositoryRelease)
 	}
 
 	for _, asset := range rel.Assets {
-		u, _ := url.Parse(*asset.BrowserDownloadURL)
-		u.User = url.UserPassword(g.userName, g.password)
 		r.Assets = append(r.Assets, base.ReleaseAsset{
-			URL:           u.String(),
+			ID:            *asset.ID,
 			Name:          *asset.Name,
 			ContentType:   asset.ContentType,
 			Size:          asset.Size,
@@ -329,6 +316,18 @@ func (g *GithubDownloaderV3) GetReleases() ([]*base.Release, error) {
 		}
 	}
 	return releases, nil
+}
+
+// GetAsset returns an asset
+func (g *GithubDownloaderV3) GetAsset(_ string, id int64) (io.ReadCloser, error) {
+	asset, redir, err := g.client.Repositories.DownloadReleaseAsset(g.ctx, g.repoOwner, g.repoName, id, http.DefaultClient)
+	if err != nil {
+		return nil, err
+	}
+	if asset == nil {
+		return ioutil.NopCloser(bytes.NewBufferString(redir)), nil
+	}
+	return asset, nil
 }
 
 // GetIssues returns issues according start and limit

--- a/modules/migrations/github_test.go
+++ b/modules/migrations/github_test.go
@@ -64,7 +64,7 @@ func assertLabelEqual(t *testing.T, name, color, description string, label *base
 
 func TestGitHubDownloadRepo(t *testing.T) {
 	GithubLimitRateRemaining = 3 //Wait at 3 remaining since we could have 3 CI in //
-	downloader := NewGithubDownloaderV3(os.Getenv("GITHUB_READ_TOKEN"), "", "go-gitea", "test_repo")
+	downloader := NewGithubDownloaderV3("", "", os.Getenv("GITHUB_READ_TOKEN"), "go-gitea", "test_repo")
 	err := downloader.RefreshRate()
 	assert.NoError(t, err)
 

--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -32,21 +34,6 @@ func init() {
 type GitlabDownloaderFactory struct {
 }
 
-// Match returns true if the migration remote URL matched this downloader factory
-func (f *GitlabDownloaderFactory) Match(opts base.MigrateOptions) (bool, error) {
-	var matched bool
-
-	u, err := url.Parse(opts.CloneAddr)
-	if err != nil {
-		return false, err
-	}
-	if strings.EqualFold(u.Host, "gitlab.com") && opts.AuthUsername != "" {
-		matched = true
-	}
-
-	return matched, nil
-}
-
 // New returns a Downloader related to this factory according MigrateOptions
 func (f *GitlabDownloaderFactory) New(opts base.MigrateOptions) (base.Downloader, error) {
 	u, err := url.Parse(opts.CloneAddr)
@@ -59,7 +46,7 @@ func (f *GitlabDownloaderFactory) New(opts base.MigrateOptions) (base.Downloader
 
 	log.Trace("Create gitlab downloader. BaseURL: %s RepoName: %s", baseURL, repoNameSpace)
 
-	return NewGitlabDownloader(baseURL, repoNameSpace, opts.AuthUsername, opts.AuthPassword), nil
+	return NewGitlabDownloader(baseURL, repoNameSpace, opts.AuthUsername, opts.AuthPassword, opts.AuthToken), nil
 }
 
 // GitServiceType returns the type of git service
@@ -85,15 +72,10 @@ type GitlabDownloader struct {
 // NewGitlabDownloader creates a gitlab Downloader via gitlab API
 //   Use either a username/password, personal token entered into the username field, or anonymous/public access
 //   Note: Public access only allows very basic access
-func NewGitlabDownloader(baseURL, repoPath, username, password string) *GitlabDownloader {
-	var gitlabClient *gitlab.Client
-	var err error
-	if username != "" {
-		if password == "" {
-			gitlabClient, err = gitlab.NewClient(username, gitlab.WithBaseURL(baseURL))
-		} else {
-			gitlabClient, err = gitlab.NewBasicAuthClient(username, password, gitlab.WithBaseURL(baseURL))
-		}
+func NewGitlabDownloader(baseURL, repoPath, username, password, token string) *GitlabDownloader {
+	gitlabClient, err := gitlab.NewBasicAuthClient(username, password, gitlab.WithBaseURL(baseURL))
+	if token != "" {
+		gitlabClient, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
 	}
 
 	if err != nil {
@@ -284,7 +266,7 @@ func (g *GitlabDownloader) convertGitlabRelease(rel *gitlab.Release) *base.Relea
 
 	for k, asset := range rel.Assets.Links {
 		r.Assets = append(r.Assets, base.ReleaseAsset{
-			URL:         asset.URL,
+			ID:          int64(asset.ID),
 			Name:        asset.Name,
 			ContentType: &rel.Assets.Sources[k].Format,
 		})
@@ -313,6 +295,21 @@ func (g *GitlabDownloader) GetReleases() ([]*base.Release, error) {
 		}
 	}
 	return releases, nil
+}
+
+// GetAsset returns an asset
+func (g *GitlabDownloader) GetAsset(tag string, id int64) (io.ReadCloser, error) {
+	link, _, err := g.client.ReleaseLinks.GetReleaseLink(g.repoID, tag, int(id))
+	if  err != nil {
+		return nil, err
+	}
+	resp, err := http.Get(link.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	// resp.Body is closed by the uploader
+	return resp.Body, nil
 }
 
 // GetIssues returns issues according start and limit

--- a/modules/migrations/gitlab_test.go
+++ b/modules/migrations/gitlab_test.go
@@ -27,7 +27,7 @@ func TestGitlabDownloadRepo(t *testing.T) {
 		t.Skipf("Can't access test repo, skipping %s", t.Name())
 	}
 
-	downloader := NewGitlabDownloader("https://gitlab.com", "gitea/test_repo", gitlabPersonalAccessToken, "")
+	downloader := NewGitlabDownloader("https://gitlab.com", "gitea/test_repo", "", "", gitlabPersonalAccessToken)
 	if downloader == nil {
 		t.Fatal("NewGitlabDownloader is nil")
 	}

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -32,7 +32,7 @@ func MigrateRepository(ctx context.Context, doer *models.User, ownerName string,
 	var (
 		downloader base.Downloader
 		uploader   = NewGiteaLocalUploader(ctx, doer, ownerName, opts.RepoName)
-		err error
+		err        error
 	)
 
 	for _, factory := range factories {

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -13,7 +13,6 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations/base"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/modules/structs"
 )
 
 // MigrateOptions is equal to base.MigrateOptions
@@ -33,18 +32,15 @@ func MigrateRepository(ctx context.Context, doer *models.User, ownerName string,
 	var (
 		downloader base.Downloader
 		uploader   = NewGiteaLocalUploader(ctx, doer, ownerName, opts.RepoName)
-		theFactory base.DownloaderFactory
+		err error
 	)
 
 	for _, factory := range factories {
-		if match, err := factory.Match(opts); err != nil {
-			return nil, err
-		} else if match {
+		if factory.GitServiceType() == opts.GitServiceType {
 			downloader, err = factory.New(opts)
 			if err != nil {
 				return nil, err
 			}
-			theFactory = factory
 			break
 		}
 	}
@@ -57,11 +53,8 @@ func MigrateRepository(ctx context.Context, doer *models.User, ownerName string,
 		opts.Comments = false
 		opts.Issues = false
 		opts.PullRequests = false
-		opts.GitServiceType = structs.PlainGitService
 		downloader = NewPlainGitDownloader(ownerName, opts.RepoName, opts.CloneAddr)
 		log.Trace("Will migrate from git: %s", opts.OriginalURL)
-	} else if opts.GitServiceType == structs.NotMigrated {
-		opts.GitServiceType = theFactory.GitServiceType()
 	}
 
 	uploader.gitServiceType = opts.GitServiceType
@@ -169,7 +162,7 @@ func migrateRepository(downloader base.Downloader, uploader base.Uploader, opts 
 				relBatchSize = len(releases)
 			}
 
-			if err := uploader.CreateReleases(releases[:relBatchSize]...); err != nil {
+			if err := uploader.CreateReleases(downloader, releases[:relBatchSize]...); err != nil {
 				return err
 			}
 			releases = releases[relBatchSize:]

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -259,6 +259,7 @@ type MigrateRepoOption struct {
 	CloneAddr    string `json:"clone_addr" binding:"Required"`
 	AuthUsername string `json:"auth_username"`
 	AuthPassword string `json:"auth_password"`
+	AuthToken    string `json:"auth_token"`
 	// required: true
 	UID int `json:"uid" binding:"Required"`
 	// required: true

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -218,6 +218,32 @@ func (gt GitServiceType) Name() string {
 	return ""
 }
 
+// Title represents the service type's proper title
+func (gt GitServiceType) Title() string {
+	switch gt {
+	case GithubService:
+		return "GitHub"
+	case GiteaService:
+		return "Gitea"
+	case GitlabService:
+		return "GitLab"
+	case GogsService:
+		return "Gogs"
+	case PlainGitService:
+		return "Git"
+	}
+	return ""
+}
+
+// TokenAuth represents whether a service type supports token-based auth
+func (gt GitServiceType) TokenAuth() bool {
+	switch gt {
+	case GithubService, GiteaService, GitlabService:
+		return true
+	}
+	return false
+}
+
 var (
 	// SupportedFullGitService represents all git services supported to migrate issues/labels/prs and etc.
 	// TODO: add to this list after new git service added

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -25,6 +25,7 @@ licenses = Licenses
 username = Username
 email = Email Address
 password = Password
+access_token = Access Token
 re_type = Re-Type Password
 captcha = CAPTCHA
 twofa = Two-Factor Authentication
@@ -707,6 +708,7 @@ form.name_pattern_not_allowed = The pattern '%s' is not allowed in a repository 
 
 need_auth = Clone Authorization
 migrate_type = Migration Type
+migrate_service = Migration Service
 migrate_type_helper = This repository will be a <span class="text blue">mirror</span>
 migrate_type_helper_disabled = Your site administrator has disabled new mirrors.
 migrate_items = Migration Items
@@ -724,7 +726,7 @@ migrate.permission_denied = You are not allowed to import local repositories.
 migrate.invalid_local_path = "The local path is invalid. It does not exist or is not a directory."
 migrate.failed = Migration failed: %v
 migrate.lfs_mirror_unsupported = Mirroring LFS objects is not supported - use 'git lfs fetch --all' and 'git lfs push --all' instead.
-migrate.migrate_items_options = When migrating from github, input a username and migration options will be displayed.
+migrate.migrate_items_options = Authentication is needed to migrate items from a service that supports them.
 migrated_from = Migrated from <a href="%[1]s">%[2]s</a>
 migrated_from_fake = Migrated From %[1]s
 migrate.migrating = Migrating from <b>%s</b> ...

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -707,10 +707,10 @@ form.name_reserved = The repository name '%s' is reserved.
 form.name_pattern_not_allowed = The pattern '%s' is not allowed in a repository name.
 
 need_auth = Clone Authorization
-migrate_type = Migration Type
+migrate_options = Migration Options
 migrate_service = Migration Service
-migrate_type_helper = This repository will be a <span class="text blue">mirror</span>
-migrate_type_helper_disabled = Your site administrator has disabled new mirrors.
+migrate_options_mirror_helper = This repository will be a <span class="text blue">mirror</span>
+migrate_options_mirror_disabled = Your site administrator has disabled new mirrors.
 migrate_items = Migration Items
 migrate_items_wiki = Wiki
 migrate_items_milestones = Milestones

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -269,6 +269,9 @@ func Migrate(ctx *context.Context) {
 	ctx.Data["pull_requests"] = ctx.Query("pull_requests") == "1"
 	ctx.Data["releases"] = ctx.Query("releases") == "1"
 	ctx.Data["LFSActive"] = setting.LFS.StartServer
+	// Plain git should be first
+	ctx.Data["service"] = structs.PlainGitService
+	ctx.Data["Services"] = append([]structs.GitServiceType{structs.PlainGitService}, structs.SupportedFullGitService...)
 
 	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))
 	if ctx.Written() {

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -45,6 +45,19 @@
 						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}}data-need-clear="true"{{end}}>
 					</div>
 
+					<div class="inline field">
+						<label>{{.i18n.Tr "repo.migrate_options"}}</label>
+						<div class="ui checkbox">
+							{{if .DisableMirrors}}
+								<input id="mirror" name="mirror" type="checkbox" readonly>
+								<label>{{.i18n.Tr "repo.migrate_options_mirror_disabled"}}</label>
+							{{else}}
+								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
+							{{end}}
+						</div>
+					</div>
+
 					<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
 					<div id="migrate_items">
 						<div class="inline field">
@@ -121,18 +134,6 @@
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
-							{{end}}
-						</div>
-					</div>
-					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_type"}}</label>
-						<div class="ui checkbox">
-							{{if .DisableMirrors}}
-								<input id="mirror" name="mirror" type="checkbox" readonly>
-								<label>{{.i18n.Tr "repo.migrate_type_helper_disabled"}}</label>
-							{{else}}
-								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_type_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -14,24 +14,70 @@
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
 						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
-						<br/>{{.i18n.Tr "repo.migrate.migrate_items_options"}}
 						{{if .LFSActive}}<br/>{{.i18n.Tr "repo.migrate.lfs_mirror_unsupported"}}{{end}}
 						</span>
 					</div>
-					<div class="ui accordion optional field">
-						<div class="title {{if .Err_Auth}}text red active{{end}}">
-							<i class="icon dropdown"></i>
-							{{.i18n.Tr "repo.need_auth"}}
-						</div>
-						<div class="content {{if .Err_Auth}}active{{end}}">
-							<div class="inline field {{if .Err_Auth}}error{{end}}">
-								<label for="auth_username">{{.i18n.Tr "username"}}</label>
-								<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
+
+					<div class="inline field">
+						<label>{{.i18n.Tr "repo.migrate_service"}}</label>
+						<div class="ui selection dropdown">
+							<input id="service_type" type="hidden" name="service" value="{{.service}}">
+							<div class="default text"></div>
+							<i class="dropdown icon"></i>
+							<div class="menu">
+								{{range .Services}}
+									<div id="service-{{.}}" class="item" data-token="{{.TokenAuth}}" data-value="{{.}}">{{.Title}}</div>
+								{{end}}
 							</div>
-							<input class="fake" type="password">
-							<div class="inline field {{if .Err_Auth}}error{{end}}">
-								<label for="auth_password">{{.i18n.Tr "password"}}</label>
-								<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
+						</div>
+					</div>
+					<div class="inline field {{if .Err_Auth}}error{{end}}">
+						<label for="auth_username">{{.i18n.Tr "username"}}</label>
+						<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
+					</div>
+					<input class="fake" type="password">
+					<div class="inline field {{if .Err_Auth}}error{{end}}">
+						<label for="auth_password">{{.i18n.Tr "password"}}</label>
+						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
+					</div>
+					<div class="inline field {{if .Err_Auth}}error{{end}}">
+						<label for="auth_token">{{.i18n.Tr "access_token"}}</label>
+						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}}data-need-clear="true"{{end}}>
+					</div>
+
+					<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+					<div id="migrate_items">
+						<div class="inline field">
+							<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+							<div class="ui checkbox">
+								<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							</div>
+							<div class="ui checkbox">
+								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+							</div>
+						</div>
+						<div class="inline field">
+							<label></label>
+							<div class="ui checkbox">
+								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+							</div>
+							<div class="ui checkbox">
+								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+							</div>
+						</div>
+						<div class="inline field">
+							<label></label>
+							<div class="ui checkbox">
+								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
+							</div>
+							<div class="ui checkbox">
+								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
+								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -88,41 +134,6 @@
 								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
 								<label>{{.i18n.Tr "repo.migrate_type_helper" | Safe}}</label>
 							{{end}}
-						</div>
-					</div>
-					<div id="migrate_items" class="ui field">
-						<div class="inline field">
-							<label>{{.i18n.Tr "repo.migrate_items"}}</label>
-							<div class="ui checkbox">
-								<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
-							</div>
-							<div class="ui checkbox">
-								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
-							</div>
-						</div>
-						<div class="inline field">
-							<label></label>
-							<div class="ui checkbox">
-								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
-							</div>
-							<div class="ui checkbox">
-								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
-							</div>
-						</div>
-						<div class="inline field">
-							<label></label>
-							<div class="ui checkbox">
-								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
-							</div>
-							<div class="ui checkbox">
-								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
-							</div>
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -13446,6 +13446,10 @@
           "type": "string",
           "x-go-name": "AuthPassword"
         },
+        "auth_token": {
+          "type": "string",
+          "x-go-name": "AuthToken"
+        },
         "auth_username": {
           "type": "string",
           "x-go-name": "AuthUsername"
@@ -13489,6 +13493,11 @@
         "repo_name": {
           "type": "string",
           "x-go-name": "RepoName"
+        },
+        "service": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Service"
         },
         "uid": {
           "type": "integer",

--- a/web_src/js/features/migration.js
+++ b/web_src/js/features/migration.js
@@ -11,6 +11,14 @@ export default function initMigration() {
   $user.on('keyup', () => {checkItems(false)});
   $pass.on('keyup', () => {checkItems(false)});
   $token.on('keyup', () => {checkItems(true)});
+
+  const $cloneAddr = $('#clone_addr');
+  $cloneAddr.on('change', () => {
+    const $repoName = $('#repo_name');
+    if ($cloneAddr.val().length > 0 && $repoName.val().length === 0) { // Only modify if repo_name input is blank
+      $repoName.val($cloneAddr.val().match(/^(.*\/)?((.+?)(\.git)?)$/)[3]);
+    }
+  });
 }
 
 function checkAuth() {

--- a/web_src/js/features/migration.js
+++ b/web_src/js/features/migration.js
@@ -1,0 +1,45 @@
+const $service = $('#service_type');
+const $user = $('#auth_username');
+const $pass = $('#auth_password');
+const $token = $('#auth_token');
+const $items = $('#migrate_items').find('.field');
+
+export default function initMigration() {
+  checkAuth();
+
+  $service.on('change', checkAuth);
+  $user.on('keyup', () => {checkItems(false)});
+  $pass.on('keyup', () => {checkItems(false)});
+  $token.on('keyup', () => {checkItems(true)});
+}
+
+function checkAuth() {
+  const serviceType = $service.val();
+  const tokenAuth = $(`#service-${serviceType}`).data('token');
+
+  if (tokenAuth) {
+    $user.parent().addClass('disabled');
+    $pass.parent().addClass('disabled');
+    $token.parent().removeClass('disabled');
+  } else {
+    $user.parent().removeClass('disabled');
+    $pass.parent().removeClass('disabled');
+    $token.parent().addClass('disabled');
+  }
+
+  checkItems(tokenAuth);
+}
+
+function checkItems(tokenAuth) {
+  let enableItems;
+  if (tokenAuth) {
+    enableItems = $token.val() !== '';
+  } else {
+    enableItems = $user.val() !== '' || $pass.val() !== '';
+  }
+  if (enableItems && $service.val() > 1) {
+    $items.removeClass('disabled');
+  } else {
+    $items.addClass('disabled');
+  }
+}

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -8,7 +8,7 @@ import {htmlEscape} from 'escape-goat';
 import 'jquery.are-you-sure';
 import './vendor/semanticdropdown.js';
 
-import initMigration from "./features/migration";
+import initMigration from './features/migration.js';
 import initContextPopups from './features/contextpopup.js';
 import initGitGraph from './features/gitgraph.js';
 import initClipboard from './features/clipboard.js';

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2459,14 +2459,6 @@ $(document).ready(async () => {
     }
   }
 
-  const $cloneAddr = $('#clone_addr');
-  $cloneAddr.on('change', () => {
-    const $repoName = $('#repo_name');
-    if ($cloneAddr.val().length > 0 && $repoName.val().length === 0) { // Only modify if repo_name input is blank
-      $repoName.val($cloneAddr.val().match(/^(.*\/)?((.+?)(\.git)?)$/)[3]);
-    }
-  });
-
   // parallel init of async loaded features
   await Promise.all([
     attachTribute(document.querySelectorAll('#content, .emoji-input')),

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -8,6 +8,7 @@ import {htmlEscape} from 'escape-goat';
 import 'jquery.are-you-sure';
 import './vendor/semanticdropdown.js';
 
+import initMigration from "./features/migration";
 import initContextPopups from './features/contextpopup.js';
 import initGitGraph from './features/gitgraph.js';
 import initClipboard from './features/clipboard.js';
@@ -1153,25 +1154,6 @@ async function initRepository() {
       $('.language-stats-details, .repository-menu').slideToggle();
     });
   }
-}
-
-function initMigration() {
-  const toggleMigrations = function () {
-    const authUserName = $('#auth_username').val();
-    const cloneAddr = $('#clone_addr').val();
-    if (!$('#mirror').is(':checked') && (authUserName && authUserName.length > 0) &&
-        (cloneAddr !== undefined && (cloneAddr.startsWith('https://github.com') || cloneAddr.startsWith('http://github.com') || cloneAddr.startsWith('http://gitlab.com') || cloneAddr.startsWith('https://gitlab.com')))) {
-      $('#migrate_items').show();
-    } else {
-      $('#migrate_items').hide();
-    }
-  };
-
-  toggleMigrations();
-
-  $('#clone_addr').on('input', toggleMigrations);
-  $('#auth_username').on('input', toggleMigrations);
-  $('#mirror').on('change', toggleMigrations);
 }
 
 function initPullRequestReview() {

--- a/web_src/less/_form.less
+++ b/web_src/less/_form.less
@@ -180,6 +180,11 @@
         text-align: center;
       }
 
+      .selection.dropdown {
+        vertical-align: middle;
+        width: 50% !important;
+      }
+
       @media only screen and (max-width: 768px) {
         label,
         input,


### PR DESCRIPTION
This PR aims to fix some bugs and improve overall migration UX.

Closes #9096 

## Bugs

1. GitHub token authentication had a bug where private repositories would not get their release assets correctly because the code was trying to retrieve them without auth.
2. GitLab's API wants a very specific format for their repo name, which would probably fail more often than not.
   * While munging the clone address we retrieved the "project path", however it retained `.git` at the end which would cause the client to fail

If you would like me to split out the bugs into a separate patch, I could probably take out the GitLab one. The GH one, however, mostly relies on other changes in this PR to get the downloader inside the uploader for retrieving assets with auth.

## Enhancements

1. No more "username is a token" magic
   * If the git service supports a token, the UI will disable basic auth fields and handle it appropriately on the backend
2. Migration options are always shown, however they are disabled if no authentication is provided
3. Authentication remains optional for _all_ service types, however just as before items will not be available

-----

Overall I hope the UI is a little clearer as to what is expected from the user.

This PR was tested with a private repository on both GitHub/GitLab, and was able to fully migrate everything in both cases.  
I was also able to do a plain migration from private repositories on BitBucket as well as Gitea.

## UI Example

![Screenshot from 2020-08-26 22-41-17](https://user-images.githubusercontent.com/42128690/91381662-8d2ca480-e7ed-11ea-89ce-1c602f6ff399.png)
