### PR TITLE
Docker ssh pass through documentation appears to be wrong.

### DIFF
--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -332,7 +332,7 @@ make it executable (`chmod +x /app/gitea/gitea`):
 
 ```
 #!/bin/sh
-ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"
+ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 ${SSH_ORIGINAL_COMMAND}
 ```
 
 Your `git` user needs to have an SSH key generated:


### PR DESCRIPTION
If you add a key via gitea web interface it adds the following to the authorizerd_keys file:
```
# gitea public key
command="/app/gitea/gitea --config=\"/data/gitea/conf/app.ini\" serv key-7",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-rsa AAAAB3<obfuscated> me@myhost
```
However that means if you try to do SSH pass through with the script in the original documentation that gitea gets a command it doens't expect:
```
git-upload-pack 'myorginisation/myproject.git'" /app/gitea/gitea --config=/data/gitea/conf/app.ini serv key-7
```
Which results in an error.

Instead with the proposed change to the script it will passthrough:
```
git-upload-pack 'myorg/myproject.git'
```
Which works.

Did something change in how the authorized_keys are saved? As otherwise I can't see how the documented script would ever work.
