### PR TITLE
Dark theme for line numbers in blame view

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -1446,11 +1446,13 @@ input {
   background-color: #bbbbbb !important;
 }
 
-.lines-commit {
+.lines-commit,
+.blame .lines-num {
   background: #2e323e !important;
 }
 
-.bottom-line {
+.bottom-line,
+.bottom-line:after {
   border-color: #4e525e !important;
 }
 


### PR DESCRIPTION
A small eye-friendly fix.

![Bildschirmfoto 2020-08-29 um 02 48 28](https://user-images.githubusercontent.com/1714243/91624908-6f08a500-e9a3-11ea-9514-d6772d441585.png)

![Bildschirmfoto 2020-08-29 um 02 47 03](https://user-images.githubusercontent.com/1714243/91624909-70d26880-e9a3-11ea-8619-2908552cd638.png)
