### PR TITLE
fix documentation for REFRESH_TOKEN_EXPIRATION_TIME

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -967,7 +967,7 @@ DEFAULT_MAX_BLOB_SIZE = 10485760
 ENABLE = true
 ; Lifetime of an OAuth2 access token in seconds
 ACCESS_TOKEN_EXPIRATION_TIME=3600
-; Lifetime of an OAuth2 access token in hours
+; Lifetime of an OAuth2 refresh token in hours
 REFRESH_TOKEN_EXPIRATION_TIME=730
 ; Check if refresh token got already used
 INVALIDATE_REFRESH_TOKENS=false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -615,7 +615,7 @@ NB: You must `REDIRECT_MACARON_LOG` and have `DISABLE_ROUTER_LOG` set to `false`
 
 - `ENABLE`: **true**: Enables OAuth2 provider.
 - `ACCESS_TOKEN_EXPIRATION_TIME`: **3600**: Lifetime of an OAuth2 access token in seconds
-- `REFRESH_TOKEN_EXPIRATION_TIME`: **730**: Lifetime of an OAuth2 access token in hours
+- `REFRESH_TOKEN_EXPIRATION_TIME`: **730**: Lifetime of an OAuth2 refresh token in hours
 - `INVALIDATE_REFRESH_TOKEN`: **false**: Check if refresh token got already used
 - `JWT_SECRET`: **\<empty\>**: OAuth2 authentication secret for access and refresh tokens, change this a unique string.
 - `MAX_TOKEN_LENGTH`: **32767**: Maximum length of token/cookie to accept from OAuth2 provider


### PR DESCRIPTION
REFRESH_TOKEN_EXPIRATION_TIME refers to the refresh token not the access token

Fix #12641

Signed-off-by: Andrew Thornton <art27@cantab.net>