### PR TITLE
Rename models.ProtectedBranchRepoID/PRID to models.EnvRepoID/PRID and ensure EnvPusherEmail is set

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -170,7 +170,7 @@ Gitea or set your environment appropriately.`, "")
 	username := os.Getenv(models.EnvRepoUsername)
 	reponame := os.Getenv(models.EnvRepoName)
 	userID, _ := strconv.ParseInt(os.Getenv(models.EnvPusherID), 10, 64)
-	prID, _ := strconv.ParseInt(os.Getenv(models.ProtectedBranchPRID), 10, 64)
+	prID, _ := strconv.ParseInt(os.Getenv(models.EnvPRID), 10, 64)
 	isDeployKey, _ := strconv.ParseBool(os.Getenv(models.EnvIsDeployKey))
 
 	hookOptions := private.HookOptions{

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -206,9 +206,10 @@ func runServ(c *cli.Context) error {
 	os.Setenv(models.EnvRepoName, results.RepoName)
 	os.Setenv(models.EnvRepoUsername, results.OwnerName)
 	os.Setenv(models.EnvPusherName, results.UserName)
+	os.Setenv(models.EnvPusherEmail, results.UserEmail)
 	os.Setenv(models.EnvPusherID, strconv.FormatInt(results.UserID, 10))
-	os.Setenv(models.ProtectedBranchRepoID, strconv.FormatInt(results.RepoID, 10))
-	os.Setenv(models.ProtectedBranchPRID, fmt.Sprintf("%d", 0))
+	os.Setenv(models.EnvRepoID, strconv.FormatInt(results.RepoID, 10))
+	os.Setenv(models.EnvPRID, fmt.Sprintf("%d", 0))
 	os.Setenv(models.EnvIsDeployKey, fmt.Sprintf("%t", results.IsDeployKey))
 	os.Setenv(models.EnvKeyID, fmt.Sprintf("%d", results.KeyID))
 

--- a/models/branches.go
+++ b/models/branches.go
@@ -19,13 +19,6 @@ import (
 	"github.com/unknwon/com"
 )
 
-const (
-	// ProtectedBranchRepoID protected Repo ID
-	ProtectedBranchRepoID = "GITEA_REPO_ID"
-	// ProtectedBranchPRID protected Repo PR ID
-	ProtectedBranchPRID = "GITEA_PR_ID"
-)
-
 // ProtectedBranch struct
 type ProtectedBranch struct {
 	ID                        int64  `xorm:"pk autoincr"`

--- a/models/helper_environment.go
+++ b/models/helper_environment.go
@@ -14,12 +14,14 @@ import (
 const (
 	EnvRepoName     = "GITEA_REPO_NAME"
 	EnvRepoUsername = "GITEA_REPO_USER_NAME"
+	EnvRepoID       = "GITEA_REPO_ID"
 	EnvRepoIsWiki   = "GITEA_REPO_IS_WIKI"
 	EnvPusherName   = "GITEA_PUSHER_NAME"
 	EnvPusherEmail  = "GITEA_PUSHER_EMAIL"
 	EnvPusherID     = "GITEA_PUSHER_ID"
 	EnvKeyID        = "GITEA_KEY_ID"
 	EnvIsDeployKey  = "GITEA_IS_DEPLOY_KEY"
+	EnvPRID         = "GITEA_PR_ID"
 	EnvIsInternal   = "GITEA_INTERNAL_PUSH"
 )
 
@@ -48,9 +50,7 @@ func FullPushingEnvironment(author, committer *User, repo *Repository, repoName 
 	authorSig := author.NewGitSig()
 	committerSig := committer.NewGitSig()
 
-	// We should add "SSH_ORIGINAL_COMMAND=gitea-internal",
-	// once we have hook and pushing infrastructure working correctly
-	return append(os.Environ(),
+	environ := append(os.Environ(),
 		"GIT_AUTHOR_NAME="+authorSig.Name,
 		"GIT_AUTHOR_EMAIL="+authorSig.Email,
 		"GIT_COMMITTER_NAME="+committerSig.Name,
@@ -60,9 +60,15 @@ func FullPushingEnvironment(author, committer *User, repo *Repository, repoName 
 		EnvRepoIsWiki+"="+isWiki,
 		EnvPusherName+"="+committer.Name,
 		EnvPusherID+"="+fmt.Sprintf("%d", committer.ID),
-		ProtectedBranchRepoID+"="+fmt.Sprintf("%d", repo.ID),
-		ProtectedBranchPRID+"="+fmt.Sprintf("%d", prID),
+		EnvRepoID+"="+fmt.Sprintf("%d", repo.ID),
+		EnvPRID+"="+fmt.Sprintf("%d", prID),
 		"SSH_ORIGINAL_COMMAND=gitea-internal",
 	)
+
+	if !committer.KeepEmailPrivate {
+		environ = append(environ, EnvPusherEmail+"="+committer.Email)
+	}
+
+	return environ
 
 }

--- a/modules/private/serv.go
+++ b/modules/private/serv.go
@@ -47,6 +47,7 @@ type ServCommandResults struct {
 	KeyID       int64
 	KeyName     string
 	UserName    string
+	UserEmail   string
 	UserID      int64
 	OwnerName   string
 	RepoName    string

--- a/routers/private/serv.go
+++ b/routers/private/serv.go
@@ -217,6 +217,18 @@ func ServCommand(ctx *macaron.Context) {
 		// so for now use the owner of the repository
 		results.UserName = results.OwnerName
 		results.UserID = repo.OwnerID
+		if err = repo.GetOwner(); err != nil {
+			log.Error("Unable to get owner for repo %-v. Error: %v", repo, err)
+			ctx.JSON(http.StatusInternalServerError, map[string]interface{}{
+				"results": results,
+				"type":    "InternalServerError",
+				"err":     fmt.Sprintf("Unable to get owner for repo: %s/%s.", results.OwnerName, results.RepoName),
+			})
+			return
+		}
+		if !repo.Owner.KeepEmailPrivate {
+			results.UserEmail = repo.Owner.Email
+		}
 	} else {
 		// Get the user represented by the Key
 		var err error
@@ -239,6 +251,9 @@ func ServCommand(ctx *macaron.Context) {
 			return
 		}
 		results.UserName = user.Name
+		if !user.KeepEmailPrivate {
+			results.UserEmail = user.Email
+		}
 	}
 
 	// Don't allow pushing if the repo is archived

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -323,7 +323,7 @@ func HTTP(ctx *context.Context) {
 		}
 	}
 
-	environ = append(environ, models.ProtectedBranchRepoID+fmt.Sprintf("=%d", repo.ID))
+	environ = append(environ, models.EnvRepoID+fmt.Sprintf("=%d", repo.ID))
 
 	w := ctx.Resp
 	r := ctx.Req.Request


### PR DESCRIPTION
models.ProtectedBranchRepoID is poorly named as it has nothing to do with protected branch and is only the RepoID.

Also we only intermittently set the EnvPusherEmail - this ensures that this is set.

We should probably consider whether the EnvPusherEmail should be set all the time instead of only if KeepEmailPrivate is not set.

Signed-off-by: Andrew Thornton <art27@cantab.net>
