### PR TITLE
Escape provider name in oauth2 provider redirect

### DIFF
--- a/modules/auth/oauth2/oauth2.go
+++ b/modules/auth/oauth2/oauth2.go
@@ -6,6 +6,7 @@ package oauth2
 
 import (
 	"net/http"
+	"net/url"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -119,7 +120,7 @@ func RemoveProvider(providerName string) {
 
 // used to create different types of goth providers
 func createProvider(providerName, providerType, clientID, clientSecret, openIDConnectAutoDiscoveryURL string, customURLMapping *CustomURLMapping) (goth.Provider, error) {
-	callbackURL := setting.AppURL + "user/oauth2/" + providerName + "/callback"
+	callbackURL := setting.AppURL + "user/oauth2/" + url.PathEscape(providerName) + "/callback"
 
 	var provider goth.Provider
 	var err error


### PR DESCRIPTION
Fix #12647 

Signed-off-by: Andrew Thornton <art27@cantab.net>
