### PR TITLE
Fixes cli error for Asciidoctor

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -53,7 +53,7 @@ add one `[markup.XXXXX]` section per external renderer on your custom `app.ini`:
 [markup.asciidoc]
 ENABLED = true
 FILE_EXTENSIONS = .adoc,.asciidoc
-RENDER_COMMAND = "asciidoctor -e -a leveloffset=-1 --out-file=- -"
+RENDER_COMMAND = "asciidoctor -s -a showtitle --out-file=- -"
 ; Input is not a standard input but a file
 IS_INPUT_FILE = false
 


### PR DESCRIPTION
The original fix for #8676 introduced illegal arguments for Asciidoctor, causing no rendering at all. This PR fixes the command line arguments so that Asciidoctor properly renders the text. See https://asciidoctor.org/docs/user-manual/#piping-content-through-the-cli as reference.