### PR TITLE
[WIP] Restart after install page

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -209,5 +209,6 @@ func runWeb(ctx *cli.Context) error {
 	<-graceful.GetManager().Done()
 	log.Info("PID: %d Gitea Web Finished", os.Getpid())
 	log.Close()
+	graceful.GetManager().DoFinalRestartIfNeeded()
 	return nil
 }

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -209,6 +209,5 @@ func runWeb(ctx *cli.Context) error {
 	<-graceful.GetManager().Done()
 	log.Info("PID: %d Gitea Web Finished", os.Getpid())
 	log.Close()
-	graceful.GetManager().DoFinalRestartIfNeeded()
-	return nil
+	return graceful.GetManager().DoFinalRestartIfNeeded()
 }

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -34,6 +34,7 @@ const (
 type Manager struct {
 	ctx                    context.Context
 	isChild                bool
+	needsRestart           bool
 	lock                   *sync.RWMutex
 	state                  state
 	shutdown               chan struct{}
@@ -173,6 +174,14 @@ func (g *Manager) DoGracefulShutdown() {
 		g.lock.Unlock()
 		g.doShutdown()
 	}
+}
+
+// DoForcedRestart causes a graceful shutdown and restart during Terminate phase
+func (g *Manager) DoForcedRestart() {
+	g.lock.Lock()
+	g.needsRestart = true
+	g.lock.Unlock()
+	g.DoGracefulShutdown()
 }
 
 // RegisterServer registers the running of a listening server.

--- a/modules/graceful/net_unix.go
+++ b/modules/graceful/net_unix.go
@@ -25,10 +25,6 @@ const (
 	startFD   = 3
 )
 
-// In order to keep the working directory the same as when we started we record
-// it at startup.
-var originalWD, _ = os.Getwd()
-
 var (
 	once  = sync.Once{}
 	mutex = sync.Mutex{}

--- a/modules/graceful/restart.go
+++ b/modules/graceful/restart.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package graceful
+
+import (
+	"os"
+	"os/exec"
+)
+
+// RestartProcessNoListeners starts a new process without passing it the active listeners.
+func RestartProcessNoListeners() (int, error) {
+	// Use the original binary location. This works with symlinks such that if
+	// the file it points to has been changed we will use the updated symlink.
+	argv0, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return 0, err
+	}
+	process, err := os.StartProcess(argv0, os.Args, &os.ProcAttr{
+		Dir:   originalWD,
+		Env:   os.Environ(),
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return process.Pid, nil
+}

--- a/modules/graceful/restart.go
+++ b/modules/graceful/restart.go
@@ -9,6 +9,10 @@ import (
 	"os/exec"
 )
 
+// In order to keep the working directory the same as when we started we record
+// it at startup.
+var originalWD, _ = os.Getwd()
+
 // RestartProcessNoListeners starts a new process without passing it the active listeners.
 func RestartProcessNoListeners() (int, error) {
 	// Use the original binary location. This works with symlinks such that if

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -191,6 +191,7 @@ run_user_not_match = The 'run as' username is not the current username: %s -> %s
 save_config_failed = Failed to save configuration: %v
 invalid_admin_setting = Administrator account setting is invalid: %v
 install_success = Welcome! Thank you for choosing Gitea. Have fun and take care!
+install_restart = Gitea will now attempt to restart. You will be redirected to <a href="%s">User Login</a> in 5 seconds.
 invalid_log_root_path = The log path is invalid: %v
 default_keep_email_private = Hide Email Addresses by Default
 default_keep_email_private_popup = Hide email addresses of new user accounts by default.

--- a/routers/install.go
+++ b/routers/install.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// tplInstall template for installation page
-	tplInstall base.TplName = "install"
+	tplInstall        base.TplName = "install"
+	tplInstallSuccess base.TplName = "install_success"
 )
 
 // InstallInit prepare for rendering installation page
@@ -393,12 +394,7 @@ func InstallPost(ctx *context.Context, form auth.InstallForm) {
 	}
 
 	log.Info("First-time run install finished!")
-	// FIXME: This isn't really enough to completely take account of new configuration
-	// We should really be restarting:
-	// - On windows this is probably just a simple restart
-	// - On linux we can't just use graceful.RestartProcess() everything that was passed in on LISTEN_FDS
-	//   (active or not) needs to be passed out and everything new passed out too.
-	//   This means we need to prevent the cleanup goroutine from running prior to the second GlobalInit
-	ctx.Flash.Success(ctx.Tr("install.install_success"))
-	ctx.Redirect(form.AppURL + "user/login")
+	ctx.Data["RedirectURL"] = form.AppURL + "user/login"
+	ctx.HTML(200, tplInstallSuccess)
+	graceful.GetManager().DoForcedRestart()
 }

--- a/routers/private/manager_unix.go
+++ b/routers/private/manager_unix.go
@@ -14,9 +14,9 @@ import (
 	"gitea.com/macaron/macaron"
 )
 
-// Restart causes the server to perform a graceful restart
+// Restart causes the server to perform a graceful restart if possible but otherwise a graceful shutdown and restart
 func Restart(ctx *macaron.Context) {
-	graceful.GetManager().DoGracefulRestart()
+	graceful.GetManager().DoForcedRestart()
 	ctx.PlainText(http.StatusOK, []byte("success"))
 
 }

--- a/routers/private/manager_windows.go
+++ b/routers/private/manager_windows.go
@@ -16,9 +16,8 @@ import (
 
 // Restart is not implemented for Windows based servers as they can't fork
 func Restart(ctx *macaron.Context) {
-	ctx.JSON(http.StatusNotImplemented, map[string]interface{}{
-		"err": "windows servers cannot be gracefully restarted - shutdown and restart manually",
-	})
+	graceful.GetManager().DoForcedRestart()
+	ctx.PlainText(http.StatusOK, []byte("success"))
 }
 
 // Shutdown causes the server to perform a graceful shutdown

--- a/templates/install_success.tmpl
+++ b/templates/install_success.tmpl
@@ -1,0 +1,19 @@
+{{template "base/head" .}}
+<div class="install">
+    <div class="ui middle very relaxed page grid">
+		<div class="sixteen wide center aligned centered column">
+			<h3 class="ui top attached header">
+				{{.i18n.Tr "install.title"}}
+			</h3>
+            <p>{{.i18n.Tr "install_success"}}</p>
+            <p>{{.i18n.Tr "install_restart" (.RedirectURL|Escape)}}</p>
+            <script type="text/javascript">
+            setTimeout(function () {
+   //Redirect with JavaScript
+   window.location.href= '{{.RedirectURL}}';
+}, 5000);
+            </script>
+        </div>
+    </div>
+</div>
+{{template "base/footer" .}}

--- a/templates/install_success.tmpl
+++ b/templates/install_success.tmpl
@@ -5,8 +5,8 @@
 			<h3 class="ui top attached header">
 				{{.i18n.Tr "install.title"}}
 			</h3>
-            <p>{{.i18n.Tr "install_success"}}</p>
-            <p>{{.i18n.Tr "install_restart" (.RedirectURL|Escape)}}</p>
+            <p>{{.i18n.Tr "install.install_success"}}</p>
+            <p>{{.i18n.Tr "install.install_restart" (.RedirectURL|Escape)}}</p>
             <script type="text/javascript">
             setTimeout(function () {
    //Redirect with JavaScript


### PR DESCRIPTION
Currently Gitea will simply try to run normally after the install page has completed. This unfortunately doesn't quite work with duplicate log entries and other problems.

This PR causes Gitea to completely restart after the install page has been run.

Signed-off-by: Andrew Thornton <art27@cantab.net>

