### PR TITLE
Only use async pre-empt hack if go < 1.15

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -11,10 +11,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
 	"code.gitea.io/gitea/modules/process"
+	"github.com/mcuadros/go-version"
 )
 
 var (
@@ -130,7 +132,9 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 	}
 
 	// TODO: verify if this is still needed in golang 1.15
-	cmd.Env = append(cmd.Env, "GODEBUG=asyncpreemptoff=1")
+	if version.Compare(runtime.Version(), "go1.15", "<") {
+		cmd.Env = append(cmd.Env, "GODEBUG=asyncpreemptoff=1")
+	}
 	cmd.Dir = dir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
Go 1.15 should have fixed the problems requiring setting GODEBUG=asyncpreempt=off. Therefore if we are running 1.15 we don't need to set this.

Signed-off-by: Andrew Thornton <art27@cantab.net>

