### PR TITLE
Possibly fix race in queue tests

### DIFF
--- a/modules/queue/queue_disk_channel_test.go
+++ b/modules/queue/queue_disk_channel_test.go
@@ -52,7 +52,7 @@ func TestPersistableChannelQueue(t *testing.T) {
 	err = queue.Push(&test1)
 	assert.NoError(t, err)
 	go func() {
-		err = queue.Push(&test2)
+		err := queue.Push(&test2)
 		assert.NoError(t, err)
 	}()
 

--- a/modules/queue/queue_disk_test.go
+++ b/modules/queue/queue_disk_test.go
@@ -65,7 +65,7 @@ func TestLevelQueue(t *testing.T) {
 	err = queue.Push(&test1)
 	assert.NoError(t, err)
 	go func() {
-		err = queue.Push(&test2)
+		err := queue.Push(&test2)
 		assert.NoError(t, err)
 	}()
 


### PR DESCRIPTION
#1441 complains of a race in the queue_disk_test and queue_disk_channel_test - I believe that these are related to the assignment to err within the goroutine.

Related #1441 

Signed-off-by: Andrew Thornton <art27@cantab.net>
