### PR TITLE
ui: Show git-pull-request icon for closed pull request

### DIFF
--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -95,9 +95,9 @@
 											{{if .LatestPullRequest.HasMerged}}
 												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple mini label">{{svg "octicon-git-merge" 16}} {{$.i18n.Tr "repo.pulls.merged"}}</a>
 											{{else if .LatestPullRequest.Issue.IsClosed}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-issue-closed" 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red mini label">{{svg "octicon-git-pull-request" 16}} {{$.i18n.Tr "repo.issues.closed_title"}}</a>
 											{{else}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-issue-opened" 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green mini label">{{svg "octicon-git-pull-request" 16}} {{$.i18n.Tr "repo.issues.open_title"}}</a>
 											{{end}}
 										{{end}}
 									</td>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -19,7 +19,7 @@
 	{{if .HasMerged}}
 		<div class="ui purple large label">{{svg "octicon-git-merge" 16}} {{.i18n.Tr "repo.pulls.merged"}}</div>
 	{{else if .Issue.IsClosed}}
-		<div class="ui red large label">{{svg "octicon-issue-closed" 16}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
+		<div class="ui red large label">{{if .Issue.IsPull}}{{svg "octicon-git-pull-request" 16}}{{else}}{{svg "octicon-issue-closed" 16}}{{end}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
 		<div class="ui green large label">{{svg "octicon-git-pull-request" 16}} {{.i18n.Tr "repo.issues.open_title"}}</div>
 	{{else}}


### PR DESCRIPTION
As title, I think it's more reasonable, and it's the same as GH.

example view:
![image](https://user-images.githubusercontent.com/25342410/92328248-d7d1da80-f091-11ea-9a57-0610a5138136.png)

![image](https://user-images.githubusercontent.com/25342410/92328278-3303cd00-f092-11ea-88f0-be4c7b55ac2a.png)
