### PR TITLE
Fix editor.commit_empty_file_text locale string

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -833,7 +833,7 @@ editor.file_deleting_no_longer_exists = The file being deleted, '%s', no longer 
 editor.file_changed_while_editing = The file contents have changed since you started editing. <a target="_blank" rel="noopener noreferrer" href="%s">Click here</a> to see them or <strong>Commit Changes again</strong> to overwrite them.
 editor.file_already_exists = A file named '%s' already exists in this repository.
 editor.commit_empty_file_header = Commit an empty file
-editor.commit_empty_file_text = The file you're about commit is empty. Proceed?
+editor.commit_empty_file_text = The file you're about to commit is empty. Proceed?
 editor.no_changes_to_show = There are no changes to show.
 editor.fail_to_update_file = Failed to update/create file '%s' with error: %v
 editor.push_rejected_no_message = The change was rejected by the server without a message. Please check githooks.


### PR DESCRIPTION
editor.commit_empty_file_text should read `... about to commit ...`
not `... about commit ...`
