### PR TITLE
gitea dump: include version &  Check InstallLock

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -186,6 +186,10 @@ func runDump(ctx *cli.Context) error {
 	if _, err := setting.Cfg.Section("log.console").NewKey("STDERR", "true"); err != nil {
 		fatal("Setting console logger to stderr failed: %v", err)
 	}
+	if !setting.InstallLock {
+		log.Error("Is '%s' really the right config path?\n", setting.CustomConf)
+		return fmt.Errorf("gitea is not initalized")
+	}
 	setting.NewServices() // cannot access session settings otherwise
 
 	err := models.SetEngine()

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -188,7 +188,7 @@ func runDump(ctx *cli.Context) error {
 	}
 	if !setting.InstallLock {
 		log.Error("Is '%s' really the right config path?\n", setting.CustomConf)
-		return fmt.Errorf("gitea is not initalized")
+		return fmt.Errorf("gitea is not initialized")
 	}
 	setting.NewServices() // cannot access session settings otherwise
 

--- a/models/models.go
+++ b/models/models.go
@@ -302,6 +302,17 @@ func DumpDatabase(filePath string, dbType string) error {
 		}
 		tbs = append(tbs, t)
 	}
+
+	type Version struct {
+		ID      int64 `xorm:"pk autoincr"`
+		Version int64
+	}
+	t, err := x.TableInfo(Version{})
+	if err != nil {
+		return err
+	}
+	tbs = append(tbs, t)
+
 	if len(dbType) > 0 {
 		return x.DumpTablesToFile(tbs, filePath, schemas.DBType(dbType))
 	}

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -21,6 +21,12 @@ func TestDumpDatabase(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "dump")
 	assert.NoError(t, err)
 
+	type Version struct {
+		ID      int64 `xorm:"pk autoincr"`
+		Version int64
+	}
+	assert.NoError(t, x.Sync2(Version{}))
+
 	for _, dbName := range setting.SupportedDatabases {
 		dbType := setting.GetDBTypeByName(dbName)
 		assert.NoError(t, DumpDatabase(filepath.Join(dir, dbType+".sql"), dbType))


### PR DESCRIPTION
close #12757

this way if it is restored and use with an later version it should migrate as usual

close #12759:
```sh
[user@PC gitea]$ ./gitea dump -c wrong-conf.ini -f gitea-dump.zip
2020/09/07 19:55:47 ...s/setting/setting.go:522:SetCustomPathAndConf() [W] Using 'custom' directory as relative origin for configuration file: '/home/maddl/git/own/gitea/custom/wrong-conf.ini'
2020/09/07 19:55:47 ...s/setting/setting.go:540:NewContext() [W] Custom config '/home/user/gitea/custom/wrong-conf.ini' not found, ignore this if you're running first time
2020/09/07 19:55:47 ...dules/setting/git.go:91:newGit() [I] Git Version: 2.28.0, Wire Protocol Version 2 Enabled
2020/09/07 19:55:47 cmd/dump.go:190:runDump() [E] Is '/home/user/gitea/custom/wrong-conf.ini' really the right config path?
2020/09/07 19:55:47 main.go:112:main() [F] Failed to run app with [./gitea dump -c wrong-conf.ini -f gitea-dump.zip]: gitea is not initialized
```
before it just tell the user: `Failed to connect to database: Unknown database type:`
