### PR TITLE
fix: use Base36 for all code indexers

### DIFF
--- a/modules/indexer/code/bleve.go
+++ b/modules/indexer/code/bleve.go
@@ -37,11 +37,6 @@ import (
 const unicodeNormalizeName = "unicodeNormalize"
 const maxBatchSize = 16
 
-// indexerID a bleve-compatible unique identifier for an integer id
-func indexerID(id int64) string {
-	return strconv.FormatInt(id, 36)
-}
-
 // numericEqualityQuery a numeric equality query for the given value and field
 func numericEqualityQuery(value int64, field string) *query.NumericRangeQuery {
 	f := float64(value)

--- a/modules/indexer/code/indexer.go
+++ b/modules/indexer/code/indexer.go
@@ -51,12 +51,16 @@ func filenameIndexerID(repoID int64, filename string) string {
 	return indexerID(repoID) + "_" + filename
 }
 
+func indexerID(id int64) string {
+	return strconv.FormatInt(id, 36)
+}
+
 func parseIndexerID(indexerID string) (int64, string) {
 	index := strings.IndexByte(indexerID, '_')
 	if index == -1 {
 		log.Error("Unexpected ID in repo indexer: %s", indexerID)
 	}
-	repoID, _ := strconv.ParseInt(indexerID[:index], 10, 64)
+	repoID, _ := strconv.ParseInt(indexerID[:index], 36, 64)
 	return repoID, indexerID[index+1:]
 }
 


### PR DESCRIPTION
Use Base36 for all code indexers. Should fix #12829.