### PR TITLE
Fix notifications page links

### DIFF
--- a/routers/user/notification.go
+++ b/routers/user/notification.go
@@ -174,6 +174,7 @@ func NotificationStatusPost(c *context.Context) {
 	if c.Written() {
 		return
 	}
+	c.Data["Link"] = fmt.Sprintf("%snotifications", setting.AppURL)
 
 	c.HTML(http.StatusOK, tplNotificationDiv)
 }


### PR DESCRIPTION
When you click read or pinned buttons on the notifications page - the page links become broken with an extraneous `/status` added.

Signed-off-by: Andrew Thornton <art27@cantab.net>
