### PR TITLE
Fix external renderers example

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -36,12 +36,12 @@ FROM gitea/gitea:{{< version >}}
 COPY custom/app.ini /data/gitea/conf/app.ini
 [...]
 
-RUN apk --no-cache add asciidoctor freetype freetype-dev gcc g++ libpng python-dev py-pip python3-dev py3-pip py3-pyzmq
+RUN apk --no-cache add asciidoctor freetype freetype-dev gcc g++ libpng libffi-dev python-dev py-pip python3-dev py3-pip py3-pyzmq
 # install any other package you need for your external renderers
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -U setuptools
-RUN pip3 install jupyter matplotlib docutils 
+RUN pip3 install jupyter docutils 
 # add above any other python package you may need to install
 ```
 


### PR DESCRIPTION
* libffi-dev is required for building jupyter
* matplotlib can not be installed using wheels on the used version of alpine
  linux, which means it must be compiled and  a large number of other packages
  have to be installed as well.
  This is very inefficient: see eg.
  https://pythonspeed.com/articles/alpine-docker-python/

  Apart from that, matplotlib is actually not required for rendering
  notebook files in gitea and it will pull in other dependencies which take some
  time to build (ie numpy).