### PR TITLE
Fix anonymous GL migration

### DIFF
--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -76,9 +76,10 @@ type GitlabDownloader struct {
 func NewGitlabDownloader(ctx context.Context, baseURL, repoPath, username, password, token string) (*GitlabDownloader, error) {
 	var gitlabClient *gitlab.Client
 	var err error
-	if token != "" {
-		gitlabClient, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
-	} else {
+	gitlabClient, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
+	// Only use basic auth if token is blank and username is NOT
+	// Basic auth will fail with empty strings, but empty token will allow anonymous public API usage
+	if token == "" && username != "" {
 		gitlabClient, err = gitlab.NewBasicAuthClient(username, password, gitlab.WithBaseURL(baseURL))
 	}
 

--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -77,9 +77,9 @@ func NewGitlabDownloader(ctx context.Context, baseURL, repoPath, username, passw
 	var gitlabClient *gitlab.Client
 	var err error
 	gitlabClient, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
-	// Only use basic auth if token is blank and username is NOT
+	// Only use basic auth if token is blank and password is NOT
 	// Basic auth will fail with empty strings, but empty token will allow anonymous public API usage
-	if token == "" && username != "" {
+	if token == "" && password != "" {
 		gitlabClient, err = gitlab.NewBasicAuthClient(username, password, gitlab.WithBaseURL(baseURL))
 	}
 


### PR DESCRIPTION
Using basic auth will fail as the GL client wants to get an OAuth token, which fails with invalid basic auth.

Using a blank token allows anonymous usage, however.