### PR TITLE
Fix panic when adding long comment (#12892)

### DIFF
--- a/modules/notification/action/action.go
+++ b/modules/notification/action/action.go
@@ -102,7 +102,7 @@ func (a *actionNotifier) NotifyCreateIssueComment(doer *models.User, repo *model
 	content := ""
 
 	if len(comment.Content) > 200 {
-		content = content[:strings.LastIndex(comment.Content[0:200], " ")] + "…"
+		content = comment.Content[:strings.LastIndex(comment.Content[0:200], " ")] + "…"
 	} else {
 		content = comment.Content
 	}


### PR DESCRIPTION
Previous PR #12881 causes out of bounds panic by working on wrong string.

Backport of #12892
