### PR TITLE
Add /public/fomantic and /public/img/svg/icons.svg to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,9 @@ coverage.all
 /public/serviceworker.js
 /public/css
 /public/fonts
+/public/fomantic
 /public/img/webpack
+/public/img/svg/icons.svg
 /web_src/fomantic/build
 /VERSION
 /.air


### PR DESCRIPTION
The `/public/fomantic` and `/public/img/svg/icons.svg` are not covered by `.gitignore` before this PR, thus such build artifact triggered `Untracked files` on `git status`.

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
