### PR TITLE
Return 404 when public gpg key is not exist

### DIFF
--- a/routers/api/v1/misc/signing.go
+++ b/routers/api/v1/misc/signing.go
@@ -24,6 +24,8 @@ func SigningKey(ctx *context.APIContext) {
 	//     description: "GPG armored public key"
 	//     schema:
 	//       type: string
+	//   "404":
+	//     "$ref": "#/responses/notFound"
 
 	// swagger:operation GET /repos/{owner}/{repo}/signing-key.gpg repository repoSigningKey
 	// ---
@@ -46,6 +48,8 @@ func SigningKey(ctx *context.APIContext) {
 	//     description: "GPG armored public key"
 	//     schema:
 	//       type: string
+	//   "404":
+	//     "$ref": "#/responses/notFound"
 
 	path := ""
 	if ctx.Repo != nil && ctx.Repo.Repository != nil {
@@ -57,6 +61,12 @@ func SigningKey(ctx *context.APIContext) {
 		ctx.Error(http.StatusInternalServerError, "gpg export", err)
 		return
 	}
+
+	if len(content) == 0 {
+		ctx.NotFound()
+		return
+	}
+
 	_, err = ctx.Write([]byte(content))
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "gpg export", fmt.Errorf("Error writing key content %v", err))

--- a/routers/api/v1/misc/signing.go
+++ b/routers/api/v1/misc/signing.go
@@ -25,7 +25,7 @@ func SigningKey(ctx *context.APIContext) {
 	//     schema:
 	//       type: string
 	//   "404":
-	//     "$ref": "#/responses/notFound"
+	//     "$ref": "#/responses/empty"
 
 	// swagger:operation GET /repos/{owner}/{repo}/signing-key.gpg repository repoSigningKey
 	// ---
@@ -49,7 +49,7 @@ func SigningKey(ctx *context.APIContext) {
 	//     schema:
 	//       type: string
 	//   "404":
-	//     "$ref": "#/responses/notFound"
+	//     "$ref": "#/responses/empty"
 
 	path := ""
 	if ctx.Repo != nil && ctx.Repo.Repository != nil {
@@ -63,7 +63,7 @@ func SigningKey(ctx *context.APIContext) {
 	}
 
 	if len(content) == 0 {
-		ctx.NotFound()
+		ctx.Status(http.StatusNotFound)
 		return
 	}
 

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -7979,6 +7979,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       }
@@ -8786,6 +8789,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -7981,7 +7981,7 @@
             }
           },
           "404": {
-            "$ref": "#/responses/notFound"
+            "$ref": "#/responses/empty"
           }
         }
       }
@@ -8791,7 +8791,7 @@
             }
           },
           "404": {
-            "$ref": "#/responses/notFound"
+            "$ref": "#/responses/empty"
           }
         }
       }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -7979,9 +7979,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          "404": {
-            "$ref": "#/responses/empty"
           }
         }
       }
@@ -8789,9 +8786,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          "404": {
-            "$ref": "#/responses/empty"
           }
         }
       }


### PR DESCRIPTION
I think it's better than return an empty string.