### PR TITLE
Fix handling of migration errors

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -11,6 +11,7 @@ import (
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/routers/utils"
 
 	"gitea.com/macaron/binding"
@@ -57,11 +58,11 @@ func (f *CreateRepoForm) Validate(ctx *macaron.Context, errs binding.Errors) bin
 // this is used to interact with web ui
 type MigrateRepoForm struct {
 	// required: true
-	CloneAddr    string `json:"clone_addr" binding:"Required"`
-	Service      int    `json:"service"`
-	AuthUsername string `json:"auth_username"`
-	AuthPassword string `json:"auth_password"`
-	AuthToken    string `json:"auth_token"`
+	CloneAddr    string                 `json:"clone_addr" binding:"Required"`
+	Service      structs.GitServiceType `json:"service"`
+	AuthUsername string                 `json:"auth_username"`
+	AuthPassword string                 `json:"auth_password"`
+	AuthToken    string                 `json:"auth_token"`
 	// required: true
 	UID int64 `json:"uid" binding:"Required"`
 	// required: true

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -13231,6 +13231,12 @@
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
+    "GitServiceType": {
+      "description": "GitServiceType represents a git service",
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
     "GitTreeResponse": {
       "description": "GitTreeResponse returns a git tree",
       "type": "object",
@@ -13658,9 +13664,7 @@
           "x-go-name": "RepoName"
         },
         "service": {
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Service"
+          "$ref": "#/definitions/GitServiceType"
         },
         "uid": {
           "type": "integer",


### PR DESCRIPTION
The migration type selection screen PR did not correctly handle errors
and any user input error on the migration page would simply redirect
back to the selection page. This meant that the error would simply be
lost and the user would be none the wiser as to what happened.

Signed-off-by: Andrew Thornton <art27@cantab.net>
