### PR TITLE
Allow extended config on cron settings

### DIFF
--- a/modules/setting/cron.go
+++ b/modules/setting/cron.go
@@ -4,8 +4,26 @@
 
 package setting
 
+import "reflect"
+
 // GetCronSettings maps the cron subsection to the provided config
 func GetCronSettings(name string, config interface{}) (interface{}, error) {
-	err := Cfg.Section("cron." + name).MapTo(config)
-	return config, err
+	if err := Cfg.Section("cron." + name).MapTo(config); err != nil {
+		return config, err
+	}
+
+	typ := reflect.TypeOf(config).Elem()
+	val := reflect.ValueOf(config).Elem()
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := val.Field(i)
+		tpField := typ.Field(i)
+		if tpField.Type.Kind() == reflect.Struct && tpField.Anonymous {
+			if err := Cfg.Section("cron." + name).MapTo(field.Addr().Interface()); err != nil {
+				return config, err
+			}
+		}
+	}
+
+	return config, nil
 }

--- a/modules/setting/cron_test.go
+++ b/modules/setting/cron_test.go
@@ -1,0 +1,43 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ini "gopkg.in/ini.v1"
+)
+
+func Test_GetCronSettings(t *testing.T) {
+
+	type BaseStruct struct {
+		Base   bool
+		Second string
+	}
+
+	type Extended struct {
+		BaseStruct
+		Extend bool
+	}
+
+	iniStr := `
+[cron.test]
+Base = true
+Second = white rabbit
+Extend = true
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	extended := &Extended{
+		BaseStruct: BaseStruct{
+			Second: "queen of hearts",
+		},
+	}
+
+	_, err := GetCronSettings("test", extended)
+
+	assert.NoError(t, err)
+	assert.True(t, extended.Base)
+	assert.EqualValues(t, extended.Second, "white rabbit")
+	assert.True(t, extended.Extend)
+
+}

--- a/modules/setting/cron_test.go
+++ b/modules/setting/cron_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package setting
 
 import (


### PR DESCRIPTION
Workaround odd behaviour in go-ini whereby an embedded field does not get the values from the same section.

Fix #12934

Signed-off-by: Andrew Thornton <art27@cantab.net>

