### PR TITLE
Update GitHub docs links for SSH & GPG

### DIFF
--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -36,7 +36,7 @@
 	</div>
 </div>
 <br>
-<p>{{.i18n.Tr "settings.gpg_helper" "https://help.github.com/articles/about-gpg/" | Str2html}}</p>
+<p>{{.i18n.Tr "settings.gpg_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/about-commit-signature-verification#gpg-commit-signature-verification" | Str2html}}</p>
 <div {{if not .HasGPGError}}class="hide"{{end}} id="add-gpg-key-panel">
 	<h4 class="ui top attached header">
 		 {{.i18n.Tr "settings.add_new_gpg_key"}}

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -37,7 +37,7 @@
 	</div>
 </div>
 <br>
-<p>{{.i18n.Tr "settings.ssh_helper" "https://help.github.com/articles/generating-ssh-keys" "https://help.github.com/ssh-issues/" | Str2html}}</p>
+<p>{{.i18n.Tr "settings.ssh_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/connecting-to-github-with-ssh" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/troubleshooting-ssh" | Str2html}}</p>
 <div {{if not .HasSSHError}}class="hide"{{end}} id="add-ssh-key-panel">
 	<h4 class="ui top attached header">
 		{{.i18n.Tr "settings.add_new_key"}}


### PR DESCRIPTION
As per title.

The links now redirected to docs.github.com. `common SSH problems` link
is misredirected to `Authenticating to GitHub` page, so it has been
corrected to the proper `troubleshooting SSH` page.

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
