### PR TITLE
Changed width of commit signature avatar

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1481,7 +1481,7 @@
     .ui.signature.avatar {
       height: 16px;
       margin-bottom: 0;
-      width: auto;
+      width: 16px;
     }
 
     .detail.icon {


### PR DESCRIPTION
Changed width of commit signature avatar from auto to 16px.
Fixes #12959 

I've build and ran gitea locally to confirm that this fix resolves the issue.