### PR TITLE
Always return a list from GetCommitsFromIDs

### DIFF
--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -504,10 +504,6 @@ func (repo *Repository) getBranches(commit *Commit, limit int) ([]string, error)
 
 // GetCommitsFromIDs get commits from commit IDs
 func (repo *Repository) GetCommitsFromIDs(commitIDs []string) (commits *list.List) {
-	if len(commitIDs) == 0 {
-		return nil
-	}
-
 	commits = list.New()
 
 	for _, commitID := range commitIDs {


### PR DESCRIPTION
`GetCommitsFromIDs` is only used in one place: `LoadPushCommits` where
it expects that `c.Commits` is not nil.

This potentially nil set causes a NPE in in #12953

Fix #12953

Signed-off-by: Andrew Thornton <art27@cantab.net>
