### PR TITLE
fix: media links in org files not liked to media files

### DIFF
--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -96,12 +96,12 @@ func (r *Renderer) WriteRegularLink(l org.RegularLink) {
 	switch l.Kind() {
 	case "image":
 		imageSrc := getMediaURL(link)
-		r.WriteString(fmt.Sprintf(`<img src="%s" alt="%s" title="%s" />`, imageSrc, description, description))
+		fmt.Fprintf(r, `<img src="%s" alt="%s" title="%s" />`, imageSrc, description, description)
 	case "video":
 		videoSrc := getMediaURL(link)
-		r.WriteString(fmt.Sprintf(`<video src="%s" title="%s">%s</video>`, videoSrc, description, description))
+		fmt.Fprintf(r, `<video src="%s" title="%s">%s</video>`, videoSrc, description, description)
 	default:
-		r.WriteString(fmt.Sprintf(`<a href="%s" title="%s">%s</a>`, link, description, description))
+		fmt.Fprintf(r, `<a href="%s" title="%s">%s</a>`, link, description, description)
 	}
 }
 

--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"html"
+	"strings"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
@@ -94,10 +95,23 @@ func (r *Renderer) WriteRegularLink(l org.RegularLink) {
 	}
 	switch l.Kind() {
 	case "image":
-		r.WriteString(fmt.Sprintf(`<img src="%s" alt="%s" title="%s" />`, link, description, description))
+		imageSrc := getMediaURL(link)
+		r.WriteString(fmt.Sprintf(`<img src="%s" alt="%s" title="%s" />`, imageSrc, description, description))
 	case "video":
-		r.WriteString(fmt.Sprintf(`<video src="%s" title="%s">%s</video>`, link, description, description))
+		videoSrc := getMediaURL(link)
+		r.WriteString(fmt.Sprintf(`<video src="%s" title="%s">%s</video>`, videoSrc, description, description))
 	default:
 		r.WriteString(fmt.Sprintf(`<a href="%s" title="%s">%s</a>`, link, description, description))
 	}
+}
+
+func getMediaURL(l []byte) string {
+	srcURL := string(l)
+
+	// Check if link is valid
+	if len(srcURL) > 0 && !markup.IsLink(l) {
+		srcURL = strings.Replace(srcURL, "/src/", "/media/", 1)
+	}
+
+	return srcURL
 }


### PR DESCRIPTION

In Org files, links to images and videos will be linked to "/media/" path, similar to 

https://github.com/go-gitea/gitea/blob/6a1a6332de5b5000d31ec26efaef6f78a4ee10f0/modules/markup/markdown/goldmark.go#L87-L93

Fixes #12831 