### PR TITLE
allow U2F with default settings for gitea in subpath (#12990)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1032,8 +1032,8 @@ func NewContext() {
 	newMarkup()
 
 	sec = Cfg.Section("U2F")
-	U2F.TrustedFacets, _ = shellquote.Split(sec.Key("TRUSTED_FACETS").MustString(strings.TrimRight(AppURL, "/")))
-	U2F.AppID = sec.Key("APP_ID").MustString(strings.TrimRight(AppURL, "/"))
+	U2F.TrustedFacets, _ = shellquote.Split(sec.Key("TRUSTED_FACETS").MustString(strings.TrimSuffix(AppURL, AppSubURL+"/")))
+	U2F.AppID = sec.Key("APP_ID").MustString(strings.TrimSuffix(AppURL, "/"))
 
 	zip.Verbose = false
 


### PR DESCRIPTION
* allow U2F with default settings for gitea in subpath

* use trim suffix

Backport #12990

Co-authored-by: zeripath <art27@cantab.net>