### PR TITLE
Fix repository create/delete event webhooks

### DIFF
--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -99,30 +99,26 @@ func (m *webhookNotifier) NotifyForkRepository(doer *models.User, oldRepo, repo 
 
 func (m *webhookNotifier) NotifyCreateRepository(doer *models.User, u *models.User, repo *models.Repository) {
 	// Add to hook queue for created repo after session commit.
-	if u.IsOrganization() {
-		if err := webhook_module.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{
-			Action:       api.HookRepoCreated,
-			Repository:   repo.APIFormat(models.AccessModeOwner),
-			Organization: u.APIFormat(),
-			Sender:       doer.APIFormat(),
-		}); err != nil {
-			log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
-		}
+	if err := webhook_module.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{
+		Action:       api.HookRepoCreated,
+		Repository:   repo.APIFormat(models.AccessModeOwner),
+		Organization: u.APIFormat(),
+		Sender:       doer.APIFormat(),
+	}); err != nil {
+		log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
 	}
 }
 
 func (m *webhookNotifier) NotifyDeleteRepository(doer *models.User, repo *models.Repository) {
 	u := repo.MustOwner()
 
-	if u.IsOrganization() {
-		if err := webhook_module.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{
-			Action:       api.HookRepoDeleted,
-			Repository:   repo.APIFormat(models.AccessModeOwner),
-			Organization: u.APIFormat(),
-			Sender:       doer.APIFormat(),
-		}); err != nil {
-			log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
-		}
+	if err := webhook_module.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{
+		Action:       api.HookRepoDeleted,
+		Repository:   repo.APIFormat(models.AccessModeOwner),
+		Organization: u.APIFormat(),
+		Sender:       doer.APIFormat(),
+	}); err != nil {
+		log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
 	}
 }
 

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -64,14 +64,11 @@ func DeleteRepository(doer *models.User, repo *models.Repository) error {
 		log.Error("CloseRepoBranchesPulls failed: %v", err)
 	}
 
-	// If the repo has a webhook, we need to trigger it before deleting it...
+	// If the repo itself has webhooks, we need to trigger them before deleting it...
 	notification.NotifyDeleteRepository(doer, repo)
 
-	if err := models.DeleteRepository(doer, repo.OwnerID, repo.ID); err != nil {
-		return err
-	}
-
-	return nil
+	err := models.DeleteRepository(doer, repo.OwnerID, repo.ID)
+	return err
 }
 
 // PushCreateRepo creates a repository when a new repository is pushed to an appropriate namespace

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -64,11 +64,12 @@ func DeleteRepository(doer *models.User, repo *models.Repository) error {
 		log.Error("CloseRepoBranchesPulls failed: %v", err)
 	}
 
+	// If the repo has a webhook, we need to trigger it before deleting it...
+	notification.NotifyDeleteRepository(doer, repo)
+
 	if err := models.DeleteRepository(doer, repo.OwnerID, repo.ID); err != nil {
 		return err
 	}
-
-	notification.NotifyDeleteRepository(doer, repo)
 
 	return nil
 }


### PR DESCRIPTION
This small PR changes the webhook trigger behaviour to be more in line with what's expected. (When 'repository' events are enabled, of course)

In other words:
- For system-wide or default webhooks, repository events will now trigger said webhook. Previously it had to be under an organization for create events to be visible - a tad unexpected!
- Deleting a repository will now fire its own defined webhooks, not just organisational and system ones.

In order to enable the latter the webhook has to now be triggered before the actual repo undergoes deletion. I'm willing to tweak this to try and 'grab' the webhook model beforehand and trigger the webhook notifier directly afterwards, but this may make the code more complex for little benefit.

Closes #11766, #9180.