### PR TITLE
Remove unreachable code after log.Fatal

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -40,7 +40,6 @@ func runConvert(ctx *cli.Context) error {
 
 	if err := models.ConvertUtf8ToUtf8mb4(); err != nil {
 		log.Fatal("Failed to convert database from utf8 to utf8mb4: %v", err)
-		return err
 	}
 
 	fmt.Println("Converted successfully, please confirm your database's character set is now utf8mb4")

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -36,7 +36,6 @@ func runMigrate(ctx *cli.Context) error {
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {
 		log.Fatal("Failed to initialize ORM engine: %v", err)
-		return err
 	}
 
 	return nil

--- a/cmd/migrate_storage.go
+++ b/cmd/migrate_storage.go
@@ -104,7 +104,6 @@ func runMigrateStorage(ctx *cli.Context) error {
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {
 		log.Fatal("Failed to initialize ORM engine: %v", err)
-		return err
 	}
 
 	if err := storage.Init(); err != nil {
@@ -117,8 +116,7 @@ func runMigrateStorage(ctx *cli.Context) error {
 	case setting.LocalStorageType:
 		p := ctx.String("path")
 		if p == "" {
-			log.Fatal("Path must be given when storage is loal")
-			return nil
+			log.Fatal("Path must be given when storage is local")
 		}
 		dstStorage, err = storage.NewLocalStorage(p)
 	case setting.MinioStorageType:

--- a/models/u2f.go
+++ b/models/u2f.go
@@ -53,7 +53,6 @@ func (list U2FRegistrationList) ToRegistrations() []u2f.Registration {
 		r, err := reg.Parse()
 		if err != nil {
 			log.Fatal("parsing u2f registration: %v", err)
-			continue
 		}
 		regs = append(regs, *r)
 	}

--- a/modules/queue/queue_disk_channel.go
+++ b/modules/queue/queue_disk_channel.go
@@ -142,7 +142,6 @@ func (q *PersistableChannelQueue) Run(atShutdown, atTerminate func(context.Conte
 		q.lock.Unlock()
 		if err != nil {
 			log.Fatal("Unable to create internal queue for %s Error: %v", q.Name(), err)
-			return
 		}
 	} else {
 		q.lock.Unlock()

--- a/modules/queue/queue_wrapped.go
+++ b/modules/queue/queue_wrapped.go
@@ -229,7 +229,6 @@ func (q *WrappedQueue) Run(atShutdown, atTerminate func(context.Context, func())
 		q.lock.Unlock()
 		if err != nil {
 			log.Fatal("Unable to set the internal queue for %s Error: %v", q.Name(), err)
-			return
 		}
 		go func() {
 			for data := range q.channel {

--- a/modules/queue/unique_queue_disk_channel.go
+++ b/modules/queue/unique_queue_disk_channel.go
@@ -169,7 +169,6 @@ func (q *PersistableChannelUniqueQueue) Run(atShutdown, atTerminate func(context
 		q.lock.Unlock()
 		if err != nil {
 			log.Fatal("Unable to create internal queue for %s Error: %v", q.Name(), err)
-			return
 		}
 	} else {
 		q.lock.Unlock()

--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -85,7 +85,6 @@ func newLFSService() {
 			LFS.JWTSecretBase64, err = generate.NewJwtSecret()
 			if err != nil {
 				log.Fatal("Error generating JWT Secret for custom config: %v", err)
-				return
 			}
 
 			// Save secret
@@ -104,7 +103,6 @@ func newLFSService() {
 			}
 			if err := cfg.SaveTo(CustomConf); err != nil {
 				log.Fatal("Error saving generated JWT Secret to custom config: %v", err)
-				return
 			}
 		}
 	}

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -445,7 +445,6 @@ func U2FSign(ctx *context.Context, signResp u2f.SignResponse) {
 		r, err := reg.Parse()
 		if err != nil {
 			log.Fatal("parsing u2f registration: %v", err)
-			continue
 		}
 		newCounter, authErr := r.Authenticate(signResp, *challenge, reg.Counter)
 		if authErr == nil {


### PR DESCRIPTION
This PR contains removal of code after calls to `log.Fata()` because it will never be executed