### PR TITLE
Avoid setting the CONN_STR in queues unless it is meant to be set

### DIFF
--- a/modules/setting/queue.go
+++ b/modules/setting/queue.go
@@ -6,7 +6,6 @@ package setting
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -94,7 +93,7 @@ func NewQueueService() {
 	}
 	Queue.Length = sec.Key("LENGTH").MustInt(20)
 	Queue.BatchLength = sec.Key("BATCH_LENGTH").MustInt(20)
-	Queue.ConnectionString = sec.Key("CONN_STR").MustString(path.Join(AppDataPath, ""))
+	Queue.ConnectionString = sec.Key("CONN_STR").MustString("")
 	Queue.Type = sec.Key("TYPE").MustString("persistable-channel")
 	Queue.Network, Queue.Addresses, Queue.Password, Queue.DBIndex, _ = ParseQueueConnStr(Queue.ConnectionString)
 	Queue.WrapIfNecessary = sec.Key("WRAP_IF_NECESSARY").MustBool(true)

--- a/modules/setting/task.go
+++ b/modules/setting/task.go
@@ -10,9 +10,10 @@ func newTaskService() {
 	switch taskSec.Key("QUEUE_TYPE").MustString(ChannelQueueType) {
 	case ChannelQueueType:
 		queueTaskSec.Key("TYPE").MustString("persistable-channel")
+		queueTaskSec.Key("CONN_STR").MustString(taskSec.Key("QUEUE_CONN_STR").MustString(""))
 	case RedisQueueType:
 		queueTaskSec.Key("TYPE").MustString("redis")
+		queueTaskSec.Key("CONN_STR").MustString(taskSec.Key("QUEUE_CONN_STR").MustString("addrs=127.0.0.1:6379 db=0"))
 	}
 	queueTaskSec.Key("LENGTH").MustInt(taskSec.Key("QUEUE_LENGTH").MustInt(1000))
-	queueTaskSec.Key("CONN_STR").MustString(taskSec.Key("QUEUE_CONN_STR").MustString("addrs=127.0.0.1:6379 db=0"))
 }


### PR DESCRIPTION
Since the move to common leveldb and common redis the disk queue code (#12385)
will check the connection string before defaulting to the DATADIR.

Therefore we should ensure that the connection string is kept empty
unless it is actually set.

Fix #13023

Signed-off-by: Andrew Thornton <art27@cantab.net>
