### PR TITLE
Fix Issue & Pull Request comment headers on mobile

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -996,11 +996,9 @@
             position: relative;
             color: #767676;
             background-color: #f7f7f7;
-
-            .text {
-              padding-top: 10px;
-              padding-bottom: 10px;
-            }
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
 
             &.arrow-top::before,
             &.arrow-top::after {
@@ -1017,11 +1015,16 @@
               left: 7px;
             }
 
-            .actions a {
-              color: rgba(0, 0, 0, .4);
+            .actions {
+              display: flex;
+              padding: 0 .5rem;
 
-              &:hover {
-                color: rgba(0, 0, 0, .8);
+              a {
+                color: rgba(0, 0, 0, .4);
+
+                &:hover {
+                  color: rgba(0, 0, 0, .8);
+                }
               }
             }
           }


### PR DESCRIPTION
This PR fixes the Issue and PR comment headers on mobile. The changes I made also work on desktop which is why I didn't use media queries. This has the nice side effect to make the header look good in edge cases where user's have really long names which wouldn't fit the header even on desktop.

We could also discuss hiding the avatar completely and let the comments take the full width on mobile (like github does) but that would be a separate change.

Before:

![Screen Shot 2020-10-05 at 21 55 37](https://user-images.githubusercontent.com/13721712/95131170-e7f6db80-075d-11eb-8dfc-cabc998564ea.png)

After:

![Screen Shot 2020-10-05 at 21 58 29](https://user-images.githubusercontent.com/13721712/95131188-ee855300-075d-11eb-8430-1713db08bf64.png)
