### PR TITLE
Avoid setting the CONN_STR in issue indexer queue unless it is meant to be set

### DIFF
--- a/modules/setting/indexer.go
+++ b/modules/setting/indexer.go
@@ -77,7 +77,7 @@ func newIndexerService() {
 
 	Indexer.IssueQueueType = sec.Key("ISSUE_INDEXER_QUEUE_TYPE").MustString(LevelQueueType)
 	Indexer.IssueQueueDir = sec.Key("ISSUE_INDEXER_QUEUE_DIR").MustString(path.Join(AppDataPath, "indexers/issues.queue"))
-	Indexer.IssueQueueConnStr = sec.Key("ISSUE_INDEXER_QUEUE_CONN_STR").MustString(path.Join(AppDataPath, ""))
+	Indexer.IssueQueueConnStr = sec.Key("ISSUE_INDEXER_QUEUE_CONN_STR").MustString("")
 	Indexer.IssueQueueBatchNumber = sec.Key("ISSUE_INDEXER_QUEUE_BATCH_NUMBER").MustInt(20)
 
 	Indexer.RepoIndexerEnabled = sec.Key("REPO_INDEXER_ENABLED").MustBool(false)


### PR DESCRIPTION
Part 2 of #13025 

Since the move to common leveldb and common redis the disk queue code (#12385)
will check the connection string before defaulting to the DATADIR.

Therefore we should ensure that the connection string is kept empty
unless it is actually set.

Unforunately the issue indexer was missed in #13025 this PR fixes this omission

Fix #13062
Fix #13061 

Signed-off-by: Andrew Thornton <art27@cantab.net>
