### PR TITLE
Hide sync ssh keys button on admin dashboard if ssh disabled or builtin-ssh enabled

### DIFF
--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -131,6 +131,7 @@ func Dashboard(ctx *context.Context) {
 	// FIXME: update periodically
 	updateSystemStatus()
 	ctx.Data["SysStatus"] = sysStatus
+	ctx.Data["SSH"] = setting.SSH
 	ctx.HTML(200, tplDashboard)
 }
 

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -35,11 +35,13 @@
 							<td>{{.i18n.Tr "admin.dashboard.git_gc_repos"}}</td>
 							<td><button type="submit" class="ui green button" name="op" value="git_gc_repos">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
+						{{if and (not .SSH.Disabled) (not .SSH.StartBuiltinServer)}}
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.resync_all_sshkeys"}}<br/>
 							{{.i18n.Tr "admin.dashboard.resync_all_sshkeys.desc"}}</td>
 							<td><button type="submit" class="ui green button" name="op" value="resync_all_sshkeys">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
+						{{end}}
 						<tr>
 							<td>{{.i18n.Tr "admin.dashboard.resync_all_hooks"}}</td>
 							<td><button type="submit" class="ui green button" name="op" value="resync_all_hooks">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>


### PR DESCRIPTION
As title.