### PR TITLE
Set appropriate `autocomplete` attributes on password fields

### DIFF
--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -27,7 +27,7 @@
 	<input class="fake" type="password">
 	<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
 		<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
-		<input id="bind_password" name="bind_password" type="password" value="{{.bind_password}}">
+		<input id="bind_password" name="bind_password" type="password" autocomplete="off" value="{{.bind_password}}">
 		<p class="help text red">{{.i18n.Tr "admin.auths.bind_password_helper"}}</p>
 	</div>
 	<div class="binddnrequired {{if (eq .type 2)}}required{{end}} field">

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -43,7 +43,7 @@
 				<input class="fake" type="password">
 				<div class="local field {{if .Err_Password}}error{{end}} {{if not (or (.User.IsLocal) (.User.IsOAuth2))}}hide{{end}}">
 					<label for="password">{{.i18n.Tr "password"}}</label>
-					<input id="password" name="password" type="password">
+					<input id="password" name="password" type="password" autocomplete="new-password">
 					<p class="help">{{.i18n.Tr "admin.users.password_helper"}}</p>
 				</div>
 				<div class="field {{if .Err_Website}}error{{end}}">

--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -39,7 +39,7 @@
 				<input class="fake" type="password">
 				<div class="required local field {{if .Err_Password}}error{{end}} {{if not (eq .login_type "0-0")}}hide{{end}}">
 					<label for="password">{{.i18n.Tr "password"}}</label>
-					<input id="password" name="password" type="password" value="{{.password}}" {{if eq .login_type "0-0"}}required{{end}}>
+					<input id="password" name="password" type="password" autocomplete="new-password" value="{{.password}}" {{if eq .login_type "0-0"}}required{{end}}>
 				</div>
 
 				<div class="inline field local{{if ne .login_type "0-0"}} hide{{end}}">

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -284,11 +284,11 @@
 							</div>
 							<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
 								<label for="admin_passwd">{{.i18n.Tr "install.admin_password"}}</label>
-								<input id="admin_passwd" name="admin_passwd" type="password" value="{{.admin_passwd}}">
+								<input id="admin_passwd" name="admin_passwd" type="password" autocomplete="new-password" value="{{.admin_passwd}}">
 							</div>
 							<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
 								<label for="admin_confirm_passwd">{{.i18n.Tr "install.confirm_password"}}</label>
-								<input id="admin_confirm_passwd" name="admin_confirm_passwd" type="password" value="{{.admin_confirm_passwd}}">
+								<input id="admin_confirm_passwd" name="admin_confirm_passwd" autocomplete="new-password" type="password" value="{{.admin_confirm_passwd}}">
 							</div>
 							<div class="inline field {{if .Err_AdminEmail}}error{{end}}">
 								<label for="admin_email">{{.i18n.Tr "install.admin_email"}}</label>

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -18,7 +18,7 @@
 						<input class="fake" type="password">
 						<div class="inline required field {{if .Err_Password}}error{{end}}">
 							<label for="password">{{.i18n.Tr "password"}}</label>
-							<input id="password" name="password" type="password" autofocus required>
+							<input id="password" name="password" type="password" autocomplete="off" autofocus required>
 						</div>
 						<div class="ui red button delete-button" data-type="form" data-form="#delete-form">
 							{{.i18n.Tr "org.settings.confirm_delete_account"}}

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -107,7 +107,7 @@
 							<input class="fake" type="password">
 							<div class="inline field {{if .Err_Auth}}error{{end}}">
 								<label for="mirror_password">{{.i18n.Tr "password"}}</label>
-								<input id="mirror_password" name="mirror_password" type="password" value="{{MirrorPassword .Mirror}}" {{if not .mirror_password}}data-need-clear="true"{{end}}>
+								<input id="mirror_password" name="mirror_password" type="password" value="{{MirrorPassword .Mirror}}" {{if not .mirror_password}}data-need-clear="true"{{end}} autocomplete="off">
 							</div>
 						</div>
 					</div>

--- a/templates/user/auth/change_passwd_inner.tmpl
+++ b/templates/user/auth/change_passwd_inner.tmpl
@@ -9,13 +9,13 @@
 			{{.CsrfTokenHtml}}
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
 				<label for="password">{{.i18n.Tr "password"}}</label>
-				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="off" required>
+				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="new-password" required>
 			</div>
 
 
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
 				<label for="retype">{{.i18n.Tr "re_type"}}</label>
-				<input id="retype" name="retype" type="password" autocomplete="off" required>
+				<input id="retype" name="retype" type="password" autocomplete="new-password" required>
 			</div>
 
 			<div class="inline field">

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -19,7 +19,7 @@
 					{{if .IsResetForm}}
 						<div class="required inline field {{if .Err_Password}}error{{end}}">
 							<label for="password">{{.i18n.Tr "settings.new_password"}}</label>
-							<input id="password" name="password" type="password"  value="{{.password}}" autocomplete="off" autofocus required>
+							<input id="password" name="password" type="password"  value="{{.password}}" autocomplete="new-password" autofocus required>
 						</div>
 						{{if not .user_signed_in}}
 						<div class="inline field">

--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -18,7 +18,7 @@
 			{{if or (not .DisablePassword) .LinkAccountMode}}
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
 				<label for="password">{{.i18n.Tr "password"}}</label>
-				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="off" required>
+				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="current-password" required>
 			</div>
 			{{end}}
 			{{if not .LinkAccountMode}}

--- a/templates/user/auth/signup_inner.tmpl
+++ b/templates/user/auth/signup_inner.tmpl
@@ -29,11 +29,11 @@
 						{{if not .DisablePassword}}
 							<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
 								<label for="password">{{.i18n.Tr "password"}}</label>
-								<input id="password" name="password" type="password" value="{{.password}}" autocomplete="off" required>
+								<input id="password" name="password" type="password" value="{{.password}}" autocomplete="new-password" required>
 							</div>
 							<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
 								<label for="retype">{{.i18n.Tr "re_type"}}</label>
-								<input id="retype" name="retype" type="password" value="{{.retype}}" autocomplete="off" required>
+								<input id="retype" name="retype" type="password" value="{{.retype}}" autocomplete="new-password" required>
 							</div>
 						{{end}}
 						{{if and .EnableCaptcha (eq .CaptchaType "image")}}

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -13,16 +13,16 @@
 				{{if .SignedUser.IsPasswordSet}}
 				<div class="required field {{if .Err_OldPassword}}error{{end}}">
 					<label for="old_password">{{.i18n.Tr "settings.old_password"}}</label>
-					<input id="old_password" name="old_password" type="password" autocomplete="off" autofocus required>
+					<input id="old_password" name="old_password" type="password" autocomplete="current-password" autofocus required>
 				</div>
 				{{end}}
 				<div class="required field {{if .Err_Password}}error{{end}}">
 					<label for="password">{{.i18n.Tr "settings.new_password"}}</label>
-					<input id="password" name="password" type="password" autocomplete="off" required>
+					<input id="password" name="password" type="password" autocomplete="new-password" required>
 				</div>
 				<div class="required field {{if .Err_Password}}error{{end}}">
 					<label for="retype">{{.i18n.Tr "settings.retype_new_password"}}</label>
-					<input id="retype" name="retype" type="password" autocomplete="off" required>
+					<input id="retype" name="retype" type="password" autocomplete="new-password" required>
 				</div>
 
 				<div class="field">
@@ -179,7 +179,7 @@
 				<input class="fake" type="password">
 				<div class="required field {{if .Err_Password}}error{{end}}">
 					<label for="password-confirmation">{{.i18n.Tr "password"}}</label>
-					<input id="password-confirmation" name="password" type="password" required>
+					<input id="password-confirmation" name="password" type="password" autocomplete="off" required>
 				</div>
 				<div class="field">
 					<div class="ui red button delete-button" id="delete-account" data-type="form" data-form="#delete-form">


### PR DESCRIPTION
`new-password` prevents annoying autocompletion in some cases, thought it's not semantically correct to use that for example on all three fields on the user account page, so some annoyances remain.