### PR TITLE
Fix line break for MS teams webhook

### DIFF
--- a/modules/webhook/msteams.go
+++ b/modules/webhook/msteams.go
@@ -229,7 +229,7 @@ func (m *MSTeamsPayload) Push(p *api.PushPayload) (api.Payloader, error) {
 			strings.TrimRight(commit.Message, "\r\n"), commit.Author.Name)
 		// add linebreak to each commit but the last
 		if i < len(p.Commits)-1 {
-			text += "\n"
+			text += "\n\n"
 		}
 	}
 


### PR DESCRIPTION
Adds an extra line break to multi commit messages from MS teams webhook.

This is how it looks now:

![image](https://user-images.githubusercontent.com/27286/95541139-6a261080-09a7-11eb-85e3-5226dccaf24e.png)

Fixes #12255.