### PR TITLE
Disable all mirror feature elements when DISABLE_MIRRORS is enabled

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -60,7 +60,7 @@ DISABLED_REPO_UNITS =
 DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki,repo.projects
 ; Prefix archive files by placing them in a directory named after the repository
 PREFIX_ARCHIVE_FILES = true
-; Disable the creation of new mirrors. Pre-existing mirrors remain valid.
+; Disable mirroring feature. Pre-existing mirrors remain valid but cannot be updated (may be converted to regular repo).
 DISABLE_MIRRORS = false
 ; The default branch name of new repositories
 DEFAULT_BRANCH=master

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -70,7 +70,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `ENABLE_PUSH_CREATE_USER`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for a user.
 - `ENABLE_PUSH_CREATE_ORG`:  **false**: Allow users to push local repositories to Gitea and have them automatically created for an org.
 - `PREFIX_ARCHIVE_FILES`: **true**: Prefix archive files by placing them in a directory named after the repository.
-- `DISABLE_MIRRORS`: **false**: Disable the creation of **new** mirrors. Pre-existing mirrors remain valid.
+- `DISABLE_MIRRORS`: **false**: Disable mirroring feature. Pre-existing mirrors remain valid but cannot be updated (may be converted to regular repo).
 - `DEFAULT_BRANCH`: **master**: Default branch name of all repositories.
 
 ### Repository - Pull Request (`repository.pull-request`)

--- a/modules/cron/tasks_basic.go
+++ b/modules/cron/tasks_basic.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/migrations"
 	repository_service "code.gitea.io/gitea/modules/repository"
+	"code.gitea.io/gitea/modules/setting"
 	mirror_service "code.gitea.io/gitea/services/mirror"
 )
 
@@ -109,7 +110,9 @@ func registerUpdateMigrationPosterID() {
 }
 
 func initBasicTasks() {
-	registerUpdateMirrorTask()
+	if !setting.Repository.DisableMirrors {
+		registerUpdateMirrorTask()
+	}
 	registerRepoHealthCheck()
 	registerCheckRepoStats()
 	registerArchiveCleanup()

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -110,6 +110,7 @@ func Dashboard(ctx *context.Context) {
 
 	ctx.Data["Title"] = ctxUser.DisplayName() + " - " + ctx.Tr("dashboard")
 	ctx.Data["PageIsDashboard"] = true
+	ctx.Data["DisableMirrors"] = setting.Repository.DisableMirrors
 	ctx.Data["PageIsNews"] = true
 	ctx.Data["SearchLimit"] = setting.UI.User.RepoPagingNum
 	// no heatmap access for admins; GetUserHeatmapDataByUser ignores the calling user

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -28,16 +28,11 @@
 						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
 					</div>
 
-					<div class="inline field">
+					<div class="inline field" {{if .DisableMirrors}} hidden{{end}}>
 						<label>{{.i18n.Tr "repo.migrate_options"}}</label>
 						<div class="ui checkbox">
-							{{if .DisableMirrors}}
-								<input id="mirror" name="mirror" type="checkbox" readonly>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_disabled"}}</label>
-							{{else}}
-								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
-							{{end}}
+							<input id="mirror" name="mirror" type="checkbox"{{if and (not .DisableMirrors) (.mirror)}} checked{{end}}>
+							<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
 						</div>
 					</div>
 

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -25,16 +25,11 @@
 						<a target=”_blank” href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">{{svg "octicon-question"}}</a>
 					</div>
 
-					<div class="inline field">
+					<div class="inline field" {{if .DisableMirrors}} hidden{{end}}>
 						<label>{{.i18n.Tr "repo.migrate_options"}}</label>
 						<div class="ui checkbox">
-							{{if .DisableMirrors}}
-								<input id="mirror" name="mirror" type="checkbox" readonly>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_disabled"}}</label>
-							{{else}}
-								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
-							{{end}}
+							<input id="mirror" name="mirror" type="checkbox"{{if and (not .DisableMirrors) (.mirror)}} checked{{end}}>
+							<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
 						</div>
 					</div>
 

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -25,16 +25,11 @@
 						<a  target=”_blank” href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html">{{svg "octicon-question"}}</a>
 					</div>
 
-					<div class="inline field">
+					<div class="inline field" {{if .DisableMirrors}} hidden{{end}}>
 						<label>{{.i18n.Tr "repo.migrate_options"}}</label>
 						<div class="ui checkbox">
-							{{if .DisableMirrors}}
-								<input id="mirror" name="mirror" type="checkbox" readonly>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_disabled"}}</label>
-							{{else}}
-								<input id="mirror" name="mirror" type="checkbox" {{if .mirror}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
-							{{end}}
+							<input id="mirror" name="mirror" type="checkbox"{{if and (not .DisableMirrors) (.mirror)}} checked{{end}}>
+							<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
 						</div>
 					</div>
 

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -81,10 +81,12 @@
 						{{.i18n.Tr "forks"}}
 						<div v-show="reposFilter === 'forks'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
-					<a class="item" :class="{active: reposFilter === 'mirrors'}" @click="changeReposFilter('mirrors')">
-						{{.i18n.Tr "mirrors"}}
-						<div v-show="reposFilter === 'mirrors'" class="ui circular mini grey label">${repoTypeCount}</div>
-					</a>
+					{{if not .DisableMirrors}}
+						<a class="item" :class="{active: reposFilter === 'mirrors'}" @click="changeReposFilter('mirrors')">
+							{{.i18n.Tr "mirrors"}}
+							<div v-show="reposFilter === 'mirrors'" class="ui circular mini grey label">${repoTypeCount}</div>
+						</a>
+					{{end}}
 					<a class="item" :class="{active: reposFilter === 'collaborative'}" @click="changeReposFilter('collaborative')">
 						{{.i18n.Tr "collaborative"}}
 						<div v-show="reposFilter === 'collaborative'" class="ui circular mini grey label">${repoTypeCount}</div>


### PR DESCRIPTION
Parameter DISABLE_MIRRORS should disable all elements of
mirroring feature (i.e. filters in UI, updating cron job)
not just creating new mirrors. This mod fixes it and still
allows exiting mirrors to be converted to regular repos when
DISABLE_MIRRORS=true.

If one need disabling only new mirror creation, should
create mod with separate parameter like DISABLE_MIRROR_CREATE.

Fixes: a6fd2f23f7e6bdc60c092207ac43af3a9a291f8f
Author-Change-Id: IB#1105104
