### PR TITLE
Fix deadlock when deleting team user

### DIFF
--- a/models/repo_permission.go
+++ b/models/repo_permission.go
@@ -178,7 +178,7 @@ func getUserRepoPermission(e Engine, repo *Repository, user *User) (perm Permiss
 
 	// Prevent strangers from checking out public repo of private orginization
 	// Allow user if they are collaborator of a repo within a private orginization but not a member of the orginization itself
-	if repo.Owner.IsOrganization() && !HasOrgVisible(repo.Owner, user) && !isCollaborator {
+	if repo.Owner.IsOrganization() && !hasOrgVisible(e, repo.Owner, user) && !isCollaborator {
 		perm.AccessMode = AccessModeNone
 		return
 	}


### PR DESCRIPTION
`models.getUserRepoPermission(...)` calls `HasOrgVisible` which
uses `models.x` potentially outside of the transaction `e` provided
as an argument to `getUserRepoPermission`.

This PR switches to use `hasOrgVisible(e, ...)`.

Fix #12983

Signed-off-by: Andrew Thornton <art27@cantab.net>
