### PR TITLE
Update minio image version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -152,7 +152,7 @@ services:
     image: elasticsearch:7.5.0
 
   - name: minio
-    image: minio/minio:RELEASE.2020-05-16T01-33-21Z
+    image: minio/minio:RELEASE.2020-10-09T22-55-05Z
     commands:
     - minio server /data
     environment:


### PR DESCRIPTION
It might be a good idea to update this image, if there's not a hard dependency on the older version somewhere that I don't know about.

older version: `minio/minio:RELEASE.2020-05-16T01-33-21Z`
newer version: `minio/minio:RELEASE.2020-10-09T22-55-05Z`

Already tested this on my machine (yeah, I know..) and it builds just fine 🎉 

Screenshots for illustration purposes
before:
![image](https://user-images.githubusercontent.com/61180606/95719993-f159d980-0c70-11eb-8ba2-e62bd821c7b5.png)
after:
![image](https://user-images.githubusercontent.com/61180606/95720231-4269cd80-0c71-11eb-9e40-8100651f231f.png)


