### PR TITLE
Improve error feedback for duplicate deploy keys

### DIFF
--- a/models/error.go
+++ b/models/error.go
@@ -547,7 +547,7 @@ func IsErrDeployKeyNameAlreadyUsed(err error) bool {
 }
 
 func (err ErrDeployKeyNameAlreadyUsed) Error() string {
-	return fmt.Sprintf("public key already exists [repo_id: %d, name: %s]", err.RepoID, err.Name)
+	return fmt.Sprintf("public key with name already exists [repo_id: %d, name: %s]", err.RepoID, err.Name)
 }
 
 //    _____                                   ___________     __

--- a/routers/api/v1/repo/key.go
+++ b/routers/api/v1/repo/key.go
@@ -177,6 +177,8 @@ func HandleAddKeyError(ctx *context.APIContext, err error) {
 		ctx.Error(http.StatusUnprocessableEntity, "", "Key content has been used as non-deploy key")
 	case models.IsErrKeyNameAlreadyUsed(err):
 		ctx.Error(http.StatusUnprocessableEntity, "", "Key title has been used")
+	case models.IsErrDeployKeyNameAlreadyUsed(err):
+		ctx.Error(http.StatusUnprocessableEntity, "", "A key with the same name already exists")
 	default:
 		ctx.Error(http.StatusInternalServerError, "AddKey", err)
 	}

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -885,6 +885,9 @@ func DeployKeysPost(ctx *context.Context, form auth.AddKeyForm) {
 		case models.IsErrKeyNameAlreadyUsed(err):
 			ctx.Data["Err_Title"] = true
 			ctx.RenderWithErr(ctx.Tr("repo.settings.key_name_used"), tplDeployKeys, &form)
+		case models.IsErrDeployKeyNameAlreadyUsed(err):
+			ctx.Data["Err_Title"] = true
+			ctx.RenderWithErr(ctx.Tr("repo.settings.key_name_used"), tplDeployKeys, &form)
 		default:
 			ctx.ServerError("AddDeployKey", err)
 		}


### PR DESCRIPTION
Instead of a generic HTTP 500 error page, a flash message is rendered with the deploy key page template to inform the user that a key with the intended title already exists. Resolves #13110 
