### PR TITLE
Fix args in tasks.json

### DIFF
--- a/contrib/ide/vscode/tasks.json
+++ b/contrib/ide/vscode/tasks.json
@@ -12,15 +12,14 @@
         "focus": false,
         "panel": "shared"
       },
-      "args": ["build"],
       "linux": {
-        "args": [ "-o", "gitea", "${workspaceRoot}/main.go" ]
+        "args": ["build", "-o", "gitea", "${workspaceRoot}/main.go" ]
       },
       "osx": {
-        "args": [ "-o", "gitea", "${workspaceRoot}/main.go" ]
+        "args": ["build", "-o", "gitea", "${workspaceRoot}/main.go" ]
       },
       "windows": {
-        "args": [ "-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
+        "args": ["build", "-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
       },
       "problemMatcher": ["$go"]
     },
@@ -35,15 +34,14 @@
         "focus": false,
         "panel": "shared"
       },
-      "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\""],
       "linux": {
-        "args": ["-o", "gitea", "${workspaceRoot}/main.go"]
+        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea", "${workspaceRoot}/main.go"]
       },
       "osx": {
-        "args": ["-o", "gitea", "${workspaceRoot}/main.go"]
+        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea", "${workspaceRoot}/main.go"]
       },
       "windows": {
-        "args": ["-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
+        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
       },
       "problemMatcher": ["$go"]
     }


### PR DESCRIPTION
Hi there! :)

## Problem
The VSCode setup as described in [IDE and code editor configuration](https://github.com/go-gitea/gitea/tree/master/contrib/ide) doesn't work. Specifically, using the provided `tasks.json`, the argument `build` gets lost from the `go build` command.

## Context

According to the [VS Code docs](https://code.visualstudio.com/docs/editor/tasks#_operating-system-specific-properties), "Properties defined in an operating system specific scope override properties defined in the task or global scope."

## My Solution
Remove the global `args` and specify its content as part of the OS-specifc `args`.