### PR TITLE
Return 404 not 500 from API if team does not exist (#13118)

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -397,7 +397,7 @@ func orgAssignment(args ...bool) macaron.Handler {
 		if assignTeam {
 			ctx.Org.Team, err = models.GetTeamByID(ctx.ParamsInt64(":teamid"))
 			if err != nil {
-				if models.IsErrUserNotExist(err) {
+				if models.IsErrTeamNotExist(err) {
 					ctx.NotFound()
 				} else {
 					ctx.Error(http.StatusInternalServerError, "GetTeamById", err)


### PR DESCRIPTION
Backport #13118

If team does not exist expect ErrTeamNotExist not ErrUserNotEXist

Fix #11336

Signed-off-by: Andrew Thornton <art27@cantab.net>
