### PR TITLE
Save TimeStamps for Star, Label, Follow, Watch and Collaboration to Database

### DIFF
--- a/models/issue_label.go
+++ b/models/issue_label.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"code.gitea.io/gitea/modules/timeutil"
+
 	"xorm.io/builder"
 	"xorm.io/xorm"
 )
@@ -21,14 +23,17 @@ var LabelColorPattern = regexp.MustCompile("^#[0-9a-fA-F]{6}$")
 
 // Label represents a label of repository for issues.
 type Label struct {
-	ID                int64 `xorm:"pk autoincr"`
-	RepoID            int64 `xorm:"INDEX"`
-	OrgID             int64 `xorm:"INDEX"`
-	Name              string
-	Description       string
-	Color             string `xorm:"VARCHAR(7)"`
-	NumIssues         int
-	NumClosedIssues   int
+	ID              int64 `xorm:"pk autoincr"`
+	RepoID          int64 `xorm:"INDEX"`
+	OrgID           int64 `xorm:"INDEX"`
+	Name            string
+	Description     string
+	Color           string `xorm:"VARCHAR(7)"`
+	NumIssues       int
+	NumClosedIssues int
+	CreatedUnix     timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix     timeutil.TimeStamp `xorm:"INDEX updated"`
+
 	NumOpenIssues     int    `xorm:"-"`
 	NumOpenRepoIssues int64  `xorm:"-"`
 	IsChecked         bool   `xorm:"-"`

--- a/models/issue_label_test.go
+++ b/models/issue_label_test.go
@@ -263,7 +263,10 @@ func TestUpdateLabel(t *testing.T) {
 	label.Name = update.Name
 	assert.NoError(t, UpdateLabel(update))
 	newLabel := AssertExistsAndLoadBean(t, &Label{ID: 1}).(*Label)
-	assert.Equal(t, *label, *newLabel)
+	assert.EqualValues(t, label.ID, newLabel.ID)
+	assert.EqualValues(t, label.Color, newLabel.Color)
+	assert.EqualValues(t, label.Name, newLabel.Name)
+	assert.EqualValues(t, label.Description, newLabel.Description)
 	CheckConsistencyFor(t, &Label{}, &Repository{})
 }
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -242,6 +242,8 @@ var migrations = []Migration{
 	NewMigration("add TrustModel field to Repository", addTrustModelToRepository),
 	// v153 > v154
 	NewMigration("add Team review request support", addTeamReviewRequestSupport),
+	// v154 > v155
+	NewMigration("add timestamps to Star, Label, LanguageStat, Follow, Watch and Collaboration", addTimeStamps),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -243,7 +243,7 @@ var migrations = []Migration{
 	// v153 > v154
 	NewMigration("add Team review request support", addTeamReviewRequestSupport),
 	// v154 > v155
-	NewMigration("add timestamps to Star, Label, LanguageStat, Follow, Watch and Collaboration", addTimeStamps),
+	NewMigration("add timestamps to Star, Label, Follow, Watch and Collaboration", addTimeStamps),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v154.go
+++ b/models/migrations/v154.go
@@ -30,14 +30,6 @@ func addTimeStamps(x *xorm.Engine) error {
 		return err
 	}
 
-	// LanguageStat describes language statistics of a repository
-	type LanguageStat struct {
-		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
-	}
-	if err := x.Sync2(new(LanguageStat)); err != nil {
-		return err
-	}
-
 	// Follow represents relations of user and his/her followers.
 	type Follow struct {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`

--- a/models/migrations/v154.go
+++ b/models/migrations/v154.go
@@ -16,7 +16,6 @@ func addTimeStamps(x *xorm.Engine) error {
 	// Star represents a starred repo by an user.
 	type Star struct {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
-		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 	if err := x.Sync2(new(Star)); err != nil {
 		return err

--- a/models/migrations/v154.go
+++ b/models/migrations/v154.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"code.gitea.io/gitea/modules/timeutil"
+
+	"xorm.io/xorm"
+)
+
+func addTimeStamps(x *xorm.Engine) error {
+	// this will add timestamps where it is useful to have
+
+	// Star represents a starred repo by an user.
+	type Star struct {
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	if err := x.Sync2(new(Star)); err != nil {
+		return err
+	}
+
+	// Label represents a label of repository for issues.
+	type Label struct {
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	if err := x.Sync2(new(Label)); err != nil {
+		return err
+	}
+
+	// LanguageStat describes language statistics of a repository
+	type LanguageStat struct {
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	if err := x.Sync2(new(LanguageStat)); err != nil {
+		return err
+	}
+
+	// Follow represents relations of user and his/her followers.
+	type Follow struct {
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	}
+	if err := x.Sync2(new(Follow)); err != nil {
+		return err
+	}
+
+	// Watch is connection request for receiving repository notification.
+	type Watch struct {
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	if err := x.Sync2(new(Watch)); err != nil {
+		return err
+	}
+
+	// Collaboration represent the relation between an individual and a repository.
+	type Collaboration struct {
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	return x.Sync2(new(Collaboration))
+}

--- a/models/repo_collaboration.go
+++ b/models/repo_collaboration.go
@@ -8,15 +8,19 @@ package models
 import (
 	"fmt"
 
+	"code.gitea.io/gitea/modules/timeutil"
+
 	"xorm.io/builder"
 )
 
 // Collaboration represent the relation between an individual and a repository.
 type Collaboration struct {
-	ID     int64      `xorm:"pk autoincr"`
-	RepoID int64      `xorm:"UNIQUE(s) INDEX NOT NULL"`
-	UserID int64      `xorm:"UNIQUE(s) INDEX NOT NULL"`
-	Mode   AccessMode `xorm:"DEFAULT 2 NOT NULL"`
+	ID          int64              `xorm:"pk autoincr"`
+	RepoID      int64              `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	UserID      int64              `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	Mode        AccessMode         `xorm:"DEFAULT 2 NOT NULL"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 }
 
 func (repo *Repository) addCollaborator(e Engine, u *User) error {

--- a/models/repo_language_stats.go
+++ b/models/repo_language_stats.go
@@ -23,7 +23,8 @@ type LanguageStat struct {
 	Percentage  float32            `xorm:"-"`
 	Size        int64              `xorm:"NOT NULL DEFAULT 0"`
 	Color       string             `xorm:"-"`
-	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 }
 
 // LanguageStatList defines a list of language statistics

--- a/models/repo_language_stats.go
+++ b/models/repo_language_stats.go
@@ -23,8 +23,7 @@ type LanguageStat struct {
 	Percentage  float32            `xorm:"-"`
 	Size        int64              `xorm:"NOT NULL DEFAULT 0"`
 	Color       string             `xorm:"-"`
-	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
-	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
 
 // LanguageStatList defines a list of language statistics

--- a/models/repo_watch.go
+++ b/models/repo_watch.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/timeutil"
 )
 
 // RepoWatchMode specifies what kind of watch the user has on a repository
@@ -26,10 +27,12 @@ const (
 
 // Watch is connection request for receiving repository notification.
 type Watch struct {
-	ID     int64         `xorm:"pk autoincr"`
-	UserID int64         `xorm:"UNIQUE(watch)"`
-	RepoID int64         `xorm:"UNIQUE(watch)"`
-	Mode   RepoWatchMode `xorm:"SMALLINT NOT NULL DEFAULT 1"`
+	ID          int64              `xorm:"pk autoincr"`
+	UserID      int64              `xorm:"UNIQUE(watch)"`
+	RepoID      int64              `xorm:"UNIQUE(watch)"`
+	Mode        RepoWatchMode      `xorm:"SMALLINT NOT NULL DEFAULT 1"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 }
 
 // getWatch gets what kind of subscription a user has on a given repository; returns dummy record if none found

--- a/models/star.go
+++ b/models/star.go
@@ -14,7 +14,6 @@ type Star struct {
 	UID         int64              `xorm:"UNIQUE(s)"`
 	RepoID      int64              `xorm:"UNIQUE(s)"`
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
-	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 }
 
 // StarRepo or unstar repository.

--- a/models/star.go
+++ b/models/star.go
@@ -4,11 +4,17 @@
 
 package models
 
+import (
+	"code.gitea.io/gitea/modules/timeutil"
+)
+
 // Star represents a starred repo by an user.
 type Star struct {
-	ID     int64 `xorm:"pk autoincr"`
-	UID    int64 `xorm:"UNIQUE(s)"`
-	RepoID int64 `xorm:"UNIQUE(s)"`
+	ID          int64              `xorm:"pk autoincr"`
+	UID         int64              `xorm:"UNIQUE(s)"`
+	RepoID      int64              `xorm:"UNIQUE(s)"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 }
 
 // StarRepo or unstar repository.
@@ -39,7 +45,7 @@ func StarRepo(userID, repoID int64, star bool) error {
 			return nil
 		}
 
-		if _, err := sess.Delete(&Star{0, userID, repoID}); err != nil {
+		if _, err := sess.Delete(&Star{UID: userID, RepoID: repoID}); err != nil {
 			return err
 		}
 		if _, err := sess.Exec("UPDATE `repository` SET num_stars = num_stars - 1 WHERE id = ?", repoID); err != nil {
@@ -59,7 +65,7 @@ func IsStaring(userID, repoID int64) bool {
 }
 
 func isStaring(e Engine, userID, repoID int64) bool {
-	has, _ := e.Get(&Star{0, userID, repoID})
+	has, _ := e.Get(&Star{UID: userID, RepoID: repoID})
 	return has
 }
 

--- a/models/user_follow.go
+++ b/models/user_follow.go
@@ -4,11 +4,16 @@
 
 package models
 
+import (
+	"code.gitea.io/gitea/modules/timeutil"
+)
+
 // Follow represents relations of user and his/her followers.
 type Follow struct {
-	ID       int64 `xorm:"pk autoincr"`
-	UserID   int64 `xorm:"UNIQUE(follow)"`
-	FollowID int64 `xorm:"UNIQUE(follow)"`
+	ID          int64              `xorm:"pk autoincr"`
+	UserID      int64              `xorm:"UNIQUE(follow)"`
+	FollowID    int64              `xorm:"UNIQUE(follow)"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 }
 
 // IsFollowing returns true if user is following followID.


### PR DESCRIPTION
as title

if there was only a created but not a updated added, the only update this table get is a delete then

xorm create and update this timestamps  - so we do not have to do add extra code to handle

this pull is mainly to have data saved, adding features & functions based on this is **NOT** part of **THIS** pull 