### PR TITLE
Remove not relevant option from issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -20,7 +20,6 @@
 - Can you reproduce the bug at https://try.gitea.io:
   - [ ] Yes (provide example URL)
   - [ ] No
-  - [ ] Not relevant
 - Log gist:
 
 ## Description


### PR DESCRIPTION
Almost every use of "Not relevant" I see is the opposite -- it is relevant to have an example on try.gitea.io and often we can't do anything until the user provides one. Remove the not-relevant option so people have to decide yes/no if they are going to attempt to reproduce it which will hopefully encourage them to do so in simple cases. 

For actual not-relevant issues No should be a fine answer as well as it would be clear to us when you can't reproduce an example there.

Hopefully this will encourage more examples when people file issues which would lead to quicker fixes.