### PR TITLE
When handling errors in storageHandler check underlying error (#13178)

### DIFF
--- a/modules/storage/minio.go
+++ b/modules/storage/minio.go
@@ -58,6 +58,26 @@ type MinioStorage struct {
 	basePath string
 }
 
+func convertMinioErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	errResp, ok := err.(minio.ErrorResponse)
+	if !ok {
+		return err
+	}
+
+	// Convert two responses to standard analogues
+	switch errResp.Code {
+	case "NoSuchKey":
+		return os.ErrNotExist
+	case "AccessDenied":
+		return os.ErrPermission
+	}
+
+	return err
+}
+
 // NewMinioStorage returns a minio storage
 func NewMinioStorage(ctx context.Context, cfg interface{}) (ObjectStorage, error) {
 	configInterface, err := toConfig(MinioStorageConfig{}, cfg)

--- a/modules/storage/minio.go
+++ b/modules/storage/minio.go
@@ -30,7 +30,7 @@ type minioObject struct {
 func (m *minioObject) Stat() (os.FileInfo, error) {
 	oi, err := m.Object.Stat()
 	if err != nil {
-		return nil, err
+		return nil, convertMinioErr(err)
 	}
 
 	return &minioFileInfo{oi}, nil

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"text/template"

--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -7,6 +7,8 @@ package routes
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -125,7 +127,13 @@ func storageHandler(storageSetting setting.Storage, prefix string, objStore stor
 			rPath := strings.TrimPrefix(req.RequestURI, "/"+prefix)
 			u, err := objStore.URL(rPath, path.Base(rPath))
 			if err != nil {
-				ctx.Error(500, err.Error())
+				if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
+					log.Warn("Unable to find %s %s", prefix, rPath)
+					ctx.Error(404, "file not found")
+					return
+				}
+				log.Error("Error whilst getting URL for %s %s. Error: %v", prefix, rPath, err)
+				ctx.Error(500, fmt.Sprintf("Error whilst getting URL for %s %s", prefix, rPath))
 				return
 			}
 			http.Redirect(
@@ -152,7 +160,13 @@ func storageHandler(storageSetting setting.Storage, prefix string, objStore stor
 		//If we have matched and access to release or issue
 		fr, err := objStore.Open(rPath)
 		if err != nil {
-			ctx.Error(500, err.Error())
+			if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
+				log.Warn("Unable to find %s %s", prefix, rPath)
+				ctx.Error(404, "file not found")
+				return
+			}
+			log.Error("Error whilst opening %s %s. Error: %v", prefix, rPath, err)
+			ctx.Error(500, fmt.Sprintf("Error whilst opening %s %s", prefix, rPath))
 			return
 		}
 		defer fr.Close()


### PR DESCRIPTION
Unfortunately there was a mistake in #13164 which fails to handle
os.PathError wrapping an os.ErrNotExist

Credit to @zeripath 