### PR TITLE
Fix broken link to v1.130-rc1 tag in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
-## [1.13.0-RC1](https://github.com/go-gitea/gitea/releases/tag/v1.13.0-RC1) - 2020-10-14
+## [1.13.0-RC1](https://github.com/go-gitea/gitea/releases/tag/v1.13.0-rc1) - 2020-10-14
 
 * SECURITY
   * Mitigate Security vulnerability in the git hook feature (#13058)


### PR DESCRIPTION
tag name in gh is case-sensitive, The previous link will return 404.

![image](https://user-images.githubusercontent.com/25342410/96369203-34451100-118b-11eb-8849-4eda854b2a67.png)
