### PR TITLE
Fix size and clickable area on file table back link

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -400,6 +400,13 @@
         background-color: #ffffee;
       }
 
+      tr.has-parent a {
+        display: inline-block;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        width: calc(100% - 1.25rem);
+      }
+
       .jumpable-path {
         color: #888888;
       }


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/13038

Should backport to 1.13.

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/115237/96385582-17add680-1195-11eb-9754-4b4b1c599ad2.png">
