### PR TITLE
fix message key

### DIFF
--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -870,8 +870,8 @@ func MergePullRequest(ctx *context.Context, form auth.MergePullRequestForm) {
 		} else if models.IsErrRebaseConflicts(err) {
 			conflictError := err.(models.ErrRebaseConflicts)
 			flashError, err := ctx.HTMLString(string(tplAlertDetails), map[string]interface{}{
-				"Message": ctx.Tr("repo.editor.rebase_conflict", utils.SanitizeFlashErrorString(conflictError.CommitSHA)),
-				"Summary": ctx.Tr("repo.editor.rebase_conflict_summary"),
+				"Message": ctx.Tr("repo.pulls.rebase_conflict", utils.SanitizeFlashErrorString(conflictError.CommitSHA)),
+				"Summary": ctx.Tr("repo.pulls.rebase_conflict_summary"),
 				"Details": utils.SanitizeFlashErrorString(conflictError.StdErr) + "<br>" + utils.SanitizeFlashErrorString(conflictError.StdOut),
 			})
 			if err != nil {


### PR DESCRIPTION
Message key `repo.editor.rebase_conflict` and `repo.editor.rebase_conflict_summary` don't exist in the message ini file.

`repo.pulls.rebase_conflict` and `repo.pulls.rebase_conflict_summary` would be correct.
