### PR TITLE
Migrations: Gitea should not fail just because of no apiConfig return (#13229)

### DIFF
--- a/modules/migrations/gitea_downloader.go
+++ b/modules/migrations/gitea_downloader.go
@@ -101,12 +101,13 @@ func NewGiteaDownloader(ctx context.Context, baseURL, repoPath, username, passwo
 	// set small maxPerPage since we can only guess
 	// (default would be 50 but this can differ)
 	maxPerPage := 10
-	// new gitea instances can tell us what maximum they have
-	if giteaClient.CheckServerVersionConstraint(">=1.13.0") == nil {
-		apiConf, _, err := giteaClient.GetGlobalAPISettings()
-		if err != nil {
-			return nil, err
-		}
+	// gitea instances >=1.13 can tell us what maximum they have
+	apiConf, _, err := giteaClient.GetGlobalAPISettings()
+	if err != nil {
+		log.Info("Unable to get global API settings. Ignoring these.")
+		log.Debug("giteaClient.GetGlobalAPISettings. Error: %v", err)
+	}
+	if apiConf != nil {
 		maxPerPage = apiConf.MaxResponseItems
 	}
 


### PR DESCRIPTION
Backport of #13229