### PR TITLE
Remove PAM from auth dropdown when unavailable

### DIFF
--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -12,6 +12,9 @@ import (
 	"github.com/msteinert/pam"
 )
 
+// Supported is true when built with PAM
+var Supported = true
+
 // Auth pam auth service
 func Auth(serviceName, userName, passwd string) (string, error) {
 	t, err := pam.StartFunc(serviceName, userName, func(s pam.Style, msg string) (string, error) {

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -10,6 +10,9 @@ import (
 	"errors"
 )
 
+// Supported is false when built without PAM
+var Supported = false
+
 // Auth not supported lack of pam tag
 func Auth(serviceName, userName, passwd string) (string, error) {
 	return "", errors.New("PAM not supported")

--- a/routers/admin/auths.go
+++ b/routers/admin/auths.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/modules/auth"
 	"code.gitea.io/gitea/modules/auth/ldap"
 	"code.gitea.io/gitea/modules/auth/oauth2"
+	"code.gitea.io/gitea/modules/auth/pam"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/log"
@@ -57,14 +58,20 @@ type dropdownItem struct {
 }
 
 var (
-	authSources = []dropdownItem{
-		{models.LoginNames[models.LoginLDAP], models.LoginLDAP},
-		{models.LoginNames[models.LoginDLDAP], models.LoginDLDAP},
-		{models.LoginNames[models.LoginSMTP], models.LoginSMTP},
-		{models.LoginNames[models.LoginPAM], models.LoginPAM},
-		{models.LoginNames[models.LoginOAuth2], models.LoginOAuth2},
-		{models.LoginNames[models.LoginSSPI], models.LoginSSPI},
-	}
+	authSources = func() []dropdownItem {
+		items := []dropdownItem{
+			{models.LoginNames[models.LoginLDAP], models.LoginLDAP},
+			{models.LoginNames[models.LoginDLDAP], models.LoginDLDAP},
+			{models.LoginNames[models.LoginSMTP], models.LoginSMTP},
+			{models.LoginNames[models.LoginOAuth2], models.LoginOAuth2},
+			{models.LoginNames[models.LoginSSPI], models.LoginSSPI},
+		}
+		if pam.Supported {
+			items = append(items, dropdownItem{models.LoginNames[models.LoginPAM], models.LoginPAM})
+		}
+		return items
+	}()
+
 	securityProtocols = []dropdownItem{
 		{models.SecurityProtocolNames[ldap.SecurityProtocolUnencrypted], ldap.SecurityProtocolUnencrypted},
 		{models.SecurityProtocolNames[ldap.SecurityProtocolLDAPS], ldap.SecurityProtocolLDAPS},


### PR DESCRIPTION
Related to #13257 

This will at least remove the option when PAM is not supported.