### PR TITLE
Fix Storage mapping

### DIFF
--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -46,7 +46,7 @@ func getStorage(name, typ string, overrides ...*ini.Section) Storage {
 
 	var storage Storage
 
-	storage.Type = sec.Key("STORAGE_TYPE").MustString("")
+	storage.Type = sec.Key("STORAGE_TYPE").MustString(typ)
 	storage.ServeDirect = sec.Key("SERVE_DIRECT").MustBool(false)
 
 	// Global Defaults

--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -21,7 +21,7 @@ type Storage struct {
 
 // MapTo implements the Mappable interface
 func (s *Storage) MapTo(v interface{}) error {
-	pathValue := reflect.ValueOf(v).FieldByName("Path")
+	pathValue := reflect.ValueOf(v).Elem().FieldByName("Path")
 	if pathValue.IsValid() && pathValue.Kind() == reflect.String {
 		pathValue.SetString(s.Path)
 	}

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -143,24 +143,24 @@ func NewStorage(typStr string, cfg interface{}) (ObjectStorage, error) {
 
 func initAvatars() (err error) {
 	log.Info("Initialising Avatar storage with type: %s", setting.Avatar.Storage.Type)
-	Avatars, err = NewStorage(setting.Avatar.Storage.Type, setting.Avatar.Storage)
+	Avatars, err = NewStorage(setting.Avatar.Storage.Type, &setting.Avatar.Storage)
 	return
 }
 
 func initAttachments() (err error) {
 	log.Info("Initialising Attachment storage with type: %s", setting.Attachment.Storage.Type)
-	Attachments, err = NewStorage(setting.Attachment.Storage.Type, setting.Attachment.Storage)
+	Attachments, err = NewStorage(setting.Attachment.Storage.Type, &setting.Attachment.Storage)
 	return
 }
 
 func initLFS() (err error) {
 	log.Info("Initialising LFS storage with type: %s", setting.LFS.Storage.Type)
-	LFS, err = NewStorage(setting.LFS.Storage.Type, setting.LFS.Storage)
+	LFS, err = NewStorage(setting.LFS.Storage.Type, &setting.LFS.Storage)
 	return
 }
 
 func initRepoAvatars() (err error) {
 	log.Info("Initialising Repository Avatar storage with type: %s", setting.RepoAvatar.Storage.Type)
-	RepoAvatars, err = NewStorage(setting.RepoAvatar.Storage.Type, setting.RepoAvatar.Storage)
+	RepoAvatars, err = NewStorage(setting.RepoAvatar.Storage.Type, &setting.RepoAvatar.Storage)
 	return
 }


### PR DESCRIPTION
This PR fixes several bugs in setting storage

* The default STORAGE_TYPE should be the provided type.
* The Storage config should be passed in to NewStorage as a pointer - otherwise the Mappable interface function MapTo will not be found
* There was a bug in the MapTo function.

Fix #13286

Signed-off-by: Andrew Thornton <art27@cantab.net>
