### PR TITLE
Storage configuration support `[storage]`

### DIFF
--- a/integrations/lfs_getobject_test.go
+++ b/integrations/lfs_getobject_test.go
@@ -78,6 +78,7 @@ func storeAndGetLfs(t *testing.T, content *[]byte, extraHeader *http.Header, exp
 			}
 		}
 	}
+
 	resp := session.MakeRequest(t, req, expectedStatus)
 
 	return resp
@@ -210,7 +211,7 @@ func TestGetLFSRange(t *testing.T) {
 		{"bytes=0-10", "123456789\n", http.StatusPartialContent},
 		// end-range bigger than length-1 is ignored
 		{"bytes=0-11", "123456789\n", http.StatusPartialContent},
-		{"bytes=11-", "", http.StatusPartialContent},
+		{"bytes=11-", "Requested Range Not Satisfiable", http.StatusRequestedRangeNotSatisfiable},
 		// incorrect header value cause whole header to be ignored
 		{"bytes=-", "123456789\n", http.StatusOK},
 		{"foobar", "123456789\n", http.StatusOK},

--- a/integrations/mysql.ini.tmpl
+++ b/integrations/mysql.ini.tmpl
@@ -45,19 +45,21 @@ START_SSH_SERVER = true
 OFFLINE_MODE     = false
 
 LFS_START_SERVER = true
-LFS_CONTENT_PATH = integrations/gitea-integration-mysql/datalfs-mysql
 LFS_JWT_SECRET   = Tv_MjmZuHqpIY6GFl12ebgkRAMt4RlWt0v4EHKSXO0w
-LFS_STORE_TYPE = minio
-LFS_SERVE_DIRECT = false
-LFS_MINIO_ENDPOINT = minio:9000
-LFS_MINIO_ACCESS_KEY_ID = 123456
-LFS_MINIO_SECRET_ACCESS_KEY = 12345678
-LFS_MINIO_BUCKET = gitea
-LFS_MINIO_LOCATION = us-east-1
-LFS_MINIO_BASE_PATH = lfs/
-LFS_MINIO_USE_SSL = false
+
+[lfs]
+MINIO_BASE_PATH = lfs/
 
 [attachment]
+MINIO_BASE_PATH = attachments/
+
+[avatars]
+MINIO_BASE_PATH = avatars/
+
+[repo-avatars]
+MINIO_BASE_PATH = repo-avatars/
+
+[storage]
 STORAGE_TYPE = minio
 SERVE_DIRECT = false
 MINIO_ENDPOINT = minio:9000
@@ -65,7 +67,6 @@ MINIO_ACCESS_KEY_ID = 123456
 MINIO_SECRET_ACCESS_KEY = 12345678
 MINIO_BUCKET = gitea
 MINIO_LOCATION = us-east-1
-MINIO_BASE_PATH = attachments/
 MINIO_USE_SSL = false
 
 [mailer]
@@ -87,9 +88,6 @@ ENABLE_NOTIFY_MAIL                = true
 [picture]
 DISABLE_GRAVATAR              = false
 ENABLE_FEDERATED_AVATAR       = false
-
-AVATAR_UPLOAD_PATH            = integrations/gitea-integration-mysql/data/avatars
-REPOSITORY_AVATAR_UPLOAD_PATH = integrations/gitea-integration-mysql/data/repo-avatars
 
 [session]
 PROVIDER        = file

--- a/modules/lfs/content_store.go
+++ b/modules/lfs/content_store.go
@@ -35,7 +35,7 @@ func (s *ContentStore) Get(meta *models.LFSMetaObject, fromByte int64) (io.ReadC
 		return nil, err
 	}
 	if fromByte > 0 {
-		_, err = f.Seek(fromByte, os.SEEK_CUR)
+		_, err = f.Seek(fromByte, io.SeekStart)
 		if err != nil {
 			log.Error("Whilst trying to read LFS OID[%s]: Unable to seek to %d Error: %v", meta.Oid, fromByte, err)
 		}

--- a/modules/lfs/content_store.go
+++ b/modules/lfs/content_store.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -20,6 +21,21 @@ var (
 	errHashMismatch = errors.New("Content hash does not match OID")
 	errSizeMismatch = errors.New("Content size does not match")
 )
+
+// ErrRangeNotSatisfiable represents an error which request range is not satisfiable.
+type ErrRangeNotSatisfiable struct {
+	FromByte int64
+}
+
+func (err ErrRangeNotSatisfiable) Error() string {
+	return fmt.Sprintf("Requested range %d is not satisfiable", err.FromByte)
+}
+
+// IsErrRangeNotSatisfiable returns true if the error is an ErrRangeNotSatisfiable
+func IsErrRangeNotSatisfiable(err error) bool {
+	_, ok := err.(ErrRangeNotSatisfiable)
+	return ok
+}
 
 // ContentStore provides a simple file system based storage.
 type ContentStore struct {
@@ -35,6 +51,11 @@ func (s *ContentStore) Get(meta *models.LFSMetaObject, fromByte int64) (io.ReadC
 		return nil, err
 	}
 	if fromByte > 0 {
+		if fromByte >= meta.Size {
+			return nil, ErrRangeNotSatisfiable{
+				FromByte: fromByte,
+			}
+		}
 		_, err = f.Seek(fromByte, io.SeekStart)
 		if err != nil {
 			log.Error("Whilst trying to read LFS OID[%s]: Unable to seek to %d Error: %v", meta.Oid, fromByte, err)

--- a/modules/lfs/server.go
+++ b/modules/lfs/server.go
@@ -191,8 +191,12 @@ func getContentHandler(ctx *context.Context) {
 	contentStore := &ContentStore{ObjectStorage: storage.LFS}
 	content, err := contentStore.Get(meta, fromByte)
 	if err != nil {
-		// Errors are logged in contentStore.Get
-		writeStatus(ctx, 404)
+		if IsErrRangeNotSatisfiable(err) {
+			writeStatus(ctx, http.StatusRequestedRangeNotSatisfiable)
+		} else {
+			// Errors are logged in contentStore.Get
+			writeStatus(ctx, 404)
+		}
 		return
 	}
 	defer content.Close()

--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -32,14 +32,12 @@ func (s *Storage) MapTo(v interface{}) error {
 }
 
 func getStorage(name, typ string, overrides ...*ini.Section) Storage {
-	sectionName := "storage"
-	if len(name) > 0 {
-		sectionName = sectionName + "." + typ
-	}
+	const sectionName = "storage"
 	sec := Cfg.Section(sectionName)
 
 	if len(overrides) == 0 {
 		overrides = []*ini.Section{
+			Cfg.Section(sectionName + "." + typ),
 			Cfg.Section(sectionName + "." + name),
 		}
 	}


### PR DESCRIPTION
This PR adjusted the override sequence, `[storage]` <- `[storage.minio]` <- `[storage.attachments]`. Right section will override left.

In fact, `[storage]` is expected because it's more easier to remember.

This will also enable storage tests with minio when mysql integration tests.

This also changed the behaviour of lfs serve when given a range start value out of bounds, now it will return 416, but not ignore that like before.