### PR TITLE
Add deprecation notice for webhook payload's secret field

### DIFF
--- a/docs/content/doc/features/webhooks.en-us.md
+++ b/docs/content/doc/features/webhooks.en-us.md
@@ -30,6 +30,8 @@ All event pushes are POST requests. The methods currently supported are:
 
 ### Event information
 
+**WARNING**: The `secret` field in the payload is deprecated as of Gitea 1.13.0 and will be removed in 1.14.0: https://github.com/go-gitea/gitea/issues/11755
+
 The following is an example of event information that will be sent by Gitea to
 a Payload URL:
 


### PR DESCRIPTION
Part of #11755

This PR is against release/v1.13 because the deprecation notice belong in those docs. There should be no need to include it in the master (1.14) docs as the field will no longer exist in the releases based on that branch. A separate PR for that removal will follow.