### PR TITLE
Always use 'image' as name for pasted images

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -352,11 +352,10 @@ function initImagePaste(target) {
     const field = this;
     field.addEventListener('paste', (event) => {
       retrieveImageFromClipboardAsBlob(event, (img) => {
-        const name = img.name.substr(0, img.name.lastIndexOf('.'));
-        insertAtCursor(field, `![${name}]()`);
+        insertAtCursor(field, `![image]()`);
         uploadFile(img, (res) => {
           const data = JSON.parse(res);
-          replaceAndKeepCursor(field, `![${name}]()`, `![${name}](${AppSubUrl}/attachments/${data.uuid})`);
+          replaceAndKeepCursor(field, `![image]()`, `![image](${AppSubUrl}/attachments/${data.uuid})`);
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           $('.files').append(input);
         });
@@ -368,11 +367,10 @@ function initImagePaste(target) {
 function initSimpleMDEImagePaste(simplemde, files) {
   simplemde.codemirror.on('paste', (_, event) => {
     retrieveImageFromClipboardAsBlob(event, (img) => {
-      const name = img.name.substr(0, img.name.lastIndexOf('.'));
       uploadFile(img, (res) => {
         const data = JSON.parse(res);
         const pos = simplemde.codemirror.getCursor();
-        simplemde.codemirror.replaceRange(`![${name}](${AppSubUrl}/attachments/${data.uuid})`, pos);
+        simplemde.codemirror.replaceRange(`![image](${AppSubUrl}/attachments/${data.uuid})`, pos);
         const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
         files.append(input);
       });


### PR DESCRIPTION
Some browsers seem to put file system paths into blob.name which look rather odd and should not be part of the posted content. Always set name to static "image" like GH does.

Ref: https://github.com/go-gitea/gitea/pull/13333#issuecomment-717917236

@a1012112796 please confirm this works for you, also test multiple pastes.