### PR TITLE
Fully remove fomantic-ui from frontend build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ FOMANTIC_CONFIGS := semantic.json web_src/fomantic/theme.config.less web_src/fom
 FOMANTIC_DEST := web_src/fomantic/build/semantic.js web_src/fomantic/build/semantic.css
 FOMANTIC_DEST_DIR := web_src/fomantic/build
 
-WEBPACK_SOURCES := $(shell find web_src/js web_src/less -type f) $(FOMANTIC_DEST)
+WEBPACK_SOURCES := $(shell find web_src/js web_src/less -type f)
 WEBPACK_CONFIGS := webpack.config.js
 WEBPACK_DEST := public/js/index.js public/css/index.css
 WEBPACK_DEST_ENTRIES := public/js public/css public/fonts public/img/webpack public/serviceworker.js


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/pull/13332. Turns out I missed this dependency which resulted in fomantic-ui being uselessly rebuild on CI. This fully removes it from the chain so it's not attempted to be build as part of the main build process.