### PR TITLE
Remove obsolete change of email on profile page (#13341)

### DIFF
--- a/integrations/auth_ldap_test.go
+++ b/integrations/auth_ldap_test.go
@@ -141,7 +141,7 @@ func TestLDAPUserSignin(t *testing.T) {
 
 	assert.Equal(t, u.UserName, htmlDoc.GetInputValueByName("name"))
 	assert.Equal(t, u.FullName, htmlDoc.GetInputValueByName("full_name"))
-	assert.Equal(t, u.Email, htmlDoc.GetInputValueByName("email"))
+	assert.Equal(t, u.Email, htmlDoc.Find(`label[for="email"]`).Siblings().First().Text())
 }
 
 func TestLDAPUserSync(t *testing.T) {

--- a/integrations/html_helper.go
+++ b/integrations/html_helper.go
@@ -37,6 +37,13 @@ func (doc *HTMLDoc) GetInputValueByName(name string) string {
 	return text
 }
 
+// Find gets the descendants of each element in the current set of
+// matched elements, filtered by a selector. It returns a new Selection
+// object containing these matched elements.
+func (doc *HTMLDoc) Find(selector string) *goquery.Selection {
+	return doc.doc.Find(selector)
+}
+
 // GetCSRF for get CSRC token value from input
 func (doc *HTMLDoc) GetCSRF() string {
 	return doc.GetInputValueByName("_csrf")

--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -196,14 +196,14 @@ func (f *AccessTokenForm) Validate(ctx *macaron.Context, errs binding.Errors) bi
 
 // UpdateProfileForm form for updating profile
 type UpdateProfileForm struct {
-	Name             string `binding:"AlphaDashDot;MaxSize(40)"`
-	FullName         string `binding:"MaxSize(100)"`
-	Email            string `binding:"Required;Email;MaxSize(254)"`
-	KeepEmailPrivate bool
-	Website          string `binding:"ValidUrl;MaxSize(255)"`
-	Location         string `binding:"MaxSize(50)"`
-	Language         string `binding:"Size(5)"`
-	Description      string `binding:"MaxSize(255)"`
+	Name                string `binding:"AlphaDashDot;MaxSize(40)"`
+	FullName            string `binding:"MaxSize(100)"`
+	KeepEmailPrivate    bool
+	Website             string `binding:"ValidUrl;MaxSize(255)"`
+	Location            string `binding:"MaxSize(50)"`
+	Language            string `binding:"Size(5)"`
+	Description         string `binding:"MaxSize(255)"`
+	KeepActivityPrivate bool
 }
 
 // Validate validates the fields

--- a/routers/user/setting/profile.go
+++ b/routers/user/setting/profile.go
@@ -90,7 +90,6 @@ func ProfilePost(ctx *context.Context, form auth.UpdateProfileForm) {
 	}
 
 	ctx.User.FullName = form.FullName
-	ctx.User.Email = form.Email
 	ctx.User.KeepEmailPrivate = form.KeepEmailPrivate
 	ctx.User.Website = form.Website
 	ctx.User.Location = form.Location

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -21,9 +21,9 @@
 					<label for="full_name">{{.i18n.Tr "settings.full_name"}}</label>
 					<input id="full_name" name="full_name" value="{{.SignedUser.FullName}}">
 				</div>
-				<div class="required field {{if .Err_Email}}error{{end}}">
+				<div class="field {{if .Err_Email}}error{{end}}">
 					<label for="email">{{.i18n.Tr "email"}}</label>
-					<input id="email" name="email" value="{{.SignedUser.Email}}">
+					<p>{{.SignedUser.Email}}</p>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox" id="keep-email-private">


### PR DESCRIPTION
* Remove obsolete change of email on profile page

The change email on the account profile page is out-of-date
and unnecessary.

Changing email should be done using the account page.

Fix #13336

Signed-off-by: Andrew Thornton <art27@cantab.net>

Credit @zeripath 