### PR TITLE
Issue comment reactions should also check pull type (#13349)

### DIFF
--- a/routers/api/v1/repo/issue_reaction.go
+++ b/routers/api/v1/repo/issue_reaction.go
@@ -56,7 +56,11 @@ func GetIssueCommentReactions(ctx *context.APIContext) {
 		return
 	}
 
-	if !ctx.Repo.CanRead(models.UnitTypeIssues) {
+	if err := comment.LoadIssue(); err != nil {
+		ctx.Error(http.StatusInternalServerError, "comment.LoadIssue", err)
+	}
+
+	if !ctx.Repo.CanReadIssuesOrPulls(comment.Issue.IsPull) {
 		ctx.Error(http.StatusForbidden, "GetIssueCommentReactions", errors.New("no permission to get reactions"))
 		return
 	}


### PR DESCRIPTION
Backport #13349

Unfortunately my final push to #13344 didn't register - or I failed to push it properly. GetIssueCommentReactions in routers/api/v1/repo/issue_reaction.go also makes the same mistake.

This PR fixes this.

Signed-off-by: Andrew Thornton <art27@cantab.net>
