### PR TITLE
copyable line numbers

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -98,7 +98,7 @@
 						{{range $line, $code := .FileContent}}
 						<tr>
 							<td id="L{{$line}}" class="lines-num">
-								<span id="L{{$line}}" data-line-number="{{$line}}"></span>
+								<a href="#L{{$line}}"><span id="L{{$line}}" data-line-number="{{$line}}"></span></a>
 							</td>
 							<td rel="L{{$line}}" class="lines-code chroma">
 								<code>{{$code | Safe}}</code>


### PR DESCRIPTION
Improves shareability of direct links to line numbers in file view. 
Just right click the line number and copy link location.