### PR TITLE
Fix links to repositories in /user/setting/repos

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -284,7 +284,7 @@
 					</div>
 				</div>
 
-				{{if and (not .IsMirror) (.Repository.UnitEnabled $.UnitTypePullRequests)}}
+				{{if not .IsMirror}}
 					<div class="ui divider"></div>
 					{{$pullRequestEnabled := .Repository.UnitEnabled $.UnitTypePullRequests}}
 					{{$prUnit := .Repository.MustGetUnit $.UnitTypePullRequests}}

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -119,7 +119,7 @@
 									{{else}}
 										<span class="iconFloat">{{svg "octicon-repo"}}</span>
 									{{end}}
-									<a class="name" href="{{AppSubUrl}}/{{$.OwnerName}}/{{.Name}}">{{$.OwnerName}}/{{.Name}}</a>
+									<a class="name" href="{{AppSubUrl}}/{{.OwnerName}}/{{.Name}}">{{.OwnerName}}/{{.Name}}</a>
 									<span>{{SizeFmt .Size}}</span>
 									{{if .IsFork}}
 										{{$.i18n.Tr "repo.forked_from"}}


### PR DESCRIPTION
Somehow the links on /user/setting/repos gained a spurious $ in the links.

Also simplify the enable push pages to allow people to re-enable pushes.

Fix #13359 

Signed-off-by: Andrew Thornton <art27@cantab.net>
