### PR TITLE
Skip appending authorized_keys file if asked not to

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -362,7 +362,7 @@ func CheckPublicKeyString(content string) (_ string, err error) {
 // appendAuthorizedKeysToFile appends new SSH keys' content to authorized_keys file.
 func appendAuthorizedKeysToFile(keys ...*PublicKey) error {
 	// Don't need to rewrite this file if builtin SSH server is enabled.
-	if setting.SSH.StartBuiltinServer {
+	if setting.SSH.StartBuiltinServer || !setting.SSH.CreateAuthorizedKeysFile {
 		return nil
 	}
 


### PR DESCRIPTION
I found a missing check before writing authorized_keys file.

Before appending to the file we should check that this function is not deactivated like here: 
https://github.com/go-gitea/gitea/blob/9066d09c57d3eaddd27c4986900e6afc0885e0c7/models/ssh_key.go#L707 and https://github.com/go-gitea/gitea/blob/1b9d5074a7ebb1b470f468cc9195d54915291ee3/cmd/doctor.go#L395