### PR TITLE
Revert "Dockerfile: Support socat use cases (#13208)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN apk --no-cache add \
     openssh \
     s6 \
     sqlite \
-    socat \
     su-exec \
     gnupg
 


### PR DESCRIPTION
This reverts commit ff50274ff34e4342d8f6b9470345a1df341d8428.

I think we shouldn't pack `socat` binary by default in the gitea docker image.

It is not a big threat but it is better to not offer some leverage to help an attacker as it can be used for two-way shell and data exfiltration.

If some users want it for their very specific use case they can easily do so and do what is needed to limit the risk knowingly.

For example: https://gtfobins.github.io/gtfobins/socat/