### PR TITLE
Set auto-tag to false on rootless manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -792,6 +792,18 @@ platform:
   arch: amd64
 
 steps:
+  - name: manifest-rootless
+    pull: always
+    image: plugins/manifest
+    settings:
+      auto_tag: false
+      ignore_missing: true
+      spec: docker/manifest.rootless.tmpl
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+
   - name: manifest
     pull: always
     image: plugins/manifest
@@ -804,17 +816,6 @@ steps:
       username:
         from_secret: docker_username
 
-  - name: manifest-rootless
-    pull: always
-    image: plugins/manifest
-    settings:
-      auto_tag: true
-      ignore_missing: true
-      spec: docker/manifest.rootless.tmpl
-      password:
-        from_secret: docker_password
-      username:
-        from_secret: docker_username
 trigger:
   ref:
   - refs/heads/master


### PR DESCRIPTION
Currently rootless overrides rootful image (latest). I've also moved rootless manifest to occur before rootful just in case as well.

This is a temp fix as I am about to head to bed and don't want to wake up to many people reporting issues who auto-update on latest. We can look into correct behaviour later.

