### PR TITLE
Remove licence file placeholder in development mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,11 +1558,6 @@
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
-    "add-asset-webpack-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-asset-webpack-plugin/-/add-asset-webpack-plugin-1.0.0.tgz",
-      "integrity": "sha512-Pg6UTxMPmVpGobpBTBmTO54aKvZfnY/rm7YvY86BXv4toE8I29ail6kAzsf0GyEMK6MgvGVDxs4IZXPTCUooNw=="
-    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@babel/runtime": "7.12.1",
     "@claviska/jquery-minicolors": "2.3.5",
     "@primer/octicons": "11.0.0",
-    "add-asset-webpack-plugin": "1.0.0",
     "babel-loader": "8.1.0",
     "clipboard": "2.0.6",
     "core-js": "3.6.5",


### PR DESCRIPTION
add-asset-webpack-plugin will probably not be updated for webpack 5 in the near future, so drop the plugin to not block that update and I guess that absent placeholder in dev mode is a non-issue.

Ref: https://github.com/sindresorhus/add-asset-webpack-plugin/issues/5