### PR TITLE
Fixed git args duplication

### DIFF
--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -74,6 +74,9 @@ func newGit() {
 		log.Fatal("Error retrieving git version: %v", err)
 	}
 
+	// force cleanup args
+	git.GlobalCommandArgs = []string{}
+
 	if git.CheckGitVersionAtLeast("2.9") == nil {
 		// Explicitly disable credential helper, otherwise Git credentials might leak
 		git.GlobalCommandArgs = append(git.GlobalCommandArgs, "-c", "credential.helper=")


### PR DESCRIPTION
Because newGit() invoked twice (inside PreInstallInit() and GlobalInit()) and git parameters is global object, all git commands call with duplicated args `-c credential.helper= -c protocol.version=2`

