### PR TITLE
Tags cleanup

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -450,7 +450,7 @@ func RepoAssignment() macaron.Handler {
 		}
 
 		ctx.Data["NumTags"], err = models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, models.FindReleasesOptions{
-			IncludeTags:   true,
+			IncludeTags: true,
 		})
 		if err != nil {
 			ctx.ServerError("GetReleaseCountByRepoID", err)

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -449,10 +449,14 @@ func RepoAssignment() macaron.Handler {
 			ctx.Data["RepoExternalIssuesLink"] = unit.ExternalTrackerConfig().ExternalTrackerURL
 		}
 
-		ctx.Data["NumReleases"], err = models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, models.FindReleasesOptions{
-			IncludeDrafts: false,
+		ctx.Data["NumTags"], err = models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, models.FindReleasesOptions{
 			IncludeTags:   true,
 		})
+		if err != nil {
+			ctx.ServerError("GetReleaseCountByRepoID", err)
+			return
+		}
+		ctx.Data["NumReleases"], err = models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, models.FindReleasesOptions{})
 		if err != nil {
 			ctx.ServerError("GetReleaseCountByRepoID", err)
 			return

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -810,6 +810,7 @@ commits = Commits
 commit = Commit
 release = Release
 releases = Releases
+tag = Tag
 released_this = released this
 file_raw = Raw
 file_history = History

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -10,7 +10,7 @@
 				</div>
 				{{if $.Permission.CanRead $.UnitTypeCode}}
 					<div class="item">
-						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{.NumReleases}}</b> {{.i18n.Tr (TrN .i18n.Lang .NumReleases "repo.release" "repo.releases") }}</a>
+						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{.NumTags}}</b> {{.i18n.Tr (TrN .i18n.Lang .NumTags "repo.tag" "repo.tags") }}</a>
 					</div>
 				{{end}}
 				<div class="item">


### PR DESCRIPTION
Resolves #13426 

Adds new context data for number of tags (that **are not** releases) and displays it on repository sub-menu.  
Also renames the sub-menu from "release(s)" to "tag(s)"

![Screenshot from 2020-11-04 21-24-30](https://user-images.githubusercontent.com/42128690/98194067-2a8a1000-1ee4-11eb-85de-dad6069c7d1b.png)
