### PR TITLE
Fix monospace font size for .mono CSS class

### DIFF
--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -4,7 +4,7 @@
 .js { justify-content: flex-start; }
 .je { justify-content: flex-end; }
 .sb { justify-content: space-between; }
-.mono { font-family: var(--fonts-monospace); }
+.mono { font-family: var(--fonts-monospace); font-size: .9em; /* compensate for monospace fonts being usually slighty larger */ }
 .rounded { border-radius: var(--border-radius) !important; }
 .word-break { word-wrap: break-word; word-break: break-all; }
 


### PR DESCRIPTION
This is a small fix on top of https://github.com/go-gitea/gitea/pull/13435 which seems to have missed `.mono` class when adjusting size.

![firefox_2020-11-07_11-49-11](https://user-images.githubusercontent.com/1447794/98439063-50cfcb80-20ef-11eb-9754-f962d82dbb7c.png)

![firefox_2020-11-07_11-49-32](https://user-images.githubusercontent.com/1447794/98439064-52998f00-20ef-11eb-8b4e-016c7473131c.png)
