### PR TITLE
Fix broken .comment > .content caused by #13457

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1000,7 +1000,9 @@
         .comment-container {
           border: 1px solid var(--color-secondary);
           border-radius: var(--border-radius);
+        }
 
+        .content {
           > .merge-section {
             background-color: var(--color-box-body);
 


### PR DESCRIPTION
I have no idea how it happened but somehow I completely missed the fact that `.comment > .content` does not refer to actual comments only but also to all other boxes on comment timeline.

Before:
![firefox_2020-11-09_21-03-14](https://user-images.githubusercontent.com/1447794/98592742-71a44680-22d2-11eb-9da3-11762665064f.png)

After:
![chrome_2020-11-09_21-23-04](https://user-images.githubusercontent.com/1447794/98592736-710bb000-22d2-11eb-8cca-7d75d78aed7a.png)

