### PR TITLE
Fix panic bug in handling multiple references in commit

### DIFF
--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -235,77 +235,81 @@ func findAllIssueReferencesMarkdown(content string) []*rawReference {
 	return findAllIssueReferencesBytes(bcontent, links)
 }
 
+func convertFullHTMLReferencesToShortRefs(re *regexp.Regexp, contentBytes *[]byte) {
+	// We will iterate through the content, rewrite and simplify full references.
+	//
+	// We want to transform something like:
+	//
+	// 0         1         2         3         4         5         6
+	// 012345678901234567890123456789012345678901234567890123456789012345789
+	// this is a https://ourgitea.com/git/owner/repo/issues/123456789, foo
+	// https://ourgitea.com/git/owner/repo/pulls/123456789
+	//
+	// Into something like:
+	//
+	// this is a #123456789, foo
+	// !123456789
+
+	pos := 0
+	for {
+		// re looks for something like: (\s|^|\(|\[)https://ourgitea.com/git/(owner/repo)/(issues)/(123456789)(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)
+		match := re.FindSubmatchIndex((*contentBytes)[pos:])
+		if match == nil {
+			break
+		}
+		// match is a bunch of indices into the content from pos onwards so if our content is:
+
+		// To simplify things let's just add pos to all of the indices in match
+		for i := range match {
+			match[i] += pos
+		}
+
+		// match[0]-match[1] is whole string
+		// match[2]-match[3] is preamble
+
+		// move the position to the end of the preamble
+		pos = match[3]
+
+		// match[4]-match[5] is owner/repo
+		// now copy the owner/repo to end of the preamble
+		endPos := pos + match[5] - match[4]
+		copy((*contentBytes)[pos:endPos], (*contentBytes)[match[4]:match[5]])
+
+		// move the current position to the end of the newly copied owner/repo
+		pos = endPos
+
+		// Now set the issue/pull marker:
+		//
+		// match[6]-match[7] == 'issues'
+		(*contentBytes)[pos] = '#'
+		if string((*contentBytes)[match[6]:match[7]]) == "pulls" {
+			(*contentBytes)[pos] = '!'
+		}
+		pos++
+
+		// Then add the issue/pull number
+		//
+		// match[8]-match[9] is the number
+		endPos = pos + match[9] - match[8]
+		copy((*contentBytes)[pos:endPos], (*contentBytes)[match[8]:match[9]])
+
+		// Now copy what's left at the end of the string to the new end position
+		copy((*contentBytes)[endPos:], (*contentBytes)[match[9]:])
+		// now we reset the length
+
+		// our new section has length endPos - match[3]
+		// our old section has length match[9] - match[3]
+		(*contentBytes) = (*contentBytes)[:len((*contentBytes))-match[9]+endPos]
+		pos = endPos
+	}
+}
+
 // FindAllIssueReferences returns a list of unvalidated references found in a string.
 func FindAllIssueReferences(content string) []IssueReference {
 	// Need to convert fully qualified html references to local system to #/! short codes
 	contentBytes := []byte(content)
 	if re := getGiteaIssuePullPattern(); re != nil {
-		// We will iterate through the content, rewrite and simplify full references.
-		//
-		// We want to transform something like:
-		//
-		// 0         1         2         3         4         5         6
-		// 012345678901234567890123456789012345678901234567890123456789012345789
-		// this is a https://ourgitea.com/git/owner/repo/issues/123456789, foo
-		// https://ourgitea.com/git/owner/repo/pulls/123456789
-		//
-		// Into something like:
-		//
-		// this is a #123456789, foo
-		// !123456789
-
-		pos := 0
-		for {
-			// re looks for something like: (\s|^|\(|\[)https://ourgitea.com/git/(owner/repo)/(issues)/(123456789)(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)
-			match := re.FindSubmatchIndex(contentBytes[pos:])
-			if match == nil {
-				break
-			}
-			// match is a bunch of indices into the content from pos onwards so if our content is:
-
-			// To simplify things let's just add pos to all of the indices in match
-			for i := range match {
-				match[i] += pos
-			}
-
-			// match[0]-match[1] is whole string
-			// match[2]-match[3] is preamble
-
-			// move the position to the end of the preamble
-			pos = match[3]
-
-			// match[4]-match[5] is owner/repo
-			// now copy the owner/repo to end of the preamble
-			endPos := pos + match[5] - match[4]
-			copy(contentBytes[pos:endPos], contentBytes[match[4]:match[5]])
-
-			// move the current position to the end of the newly copied owner/repo
-			pos = endPos
-
-			// Now set the issue/pull marker:
-			//
-			// match[6]-match[7] == 'issues'
-			contentBytes[pos] = '#'
-			if string(contentBytes[match[6]:match[7]]) == "pulls" {
-				contentBytes[pos] = '!'
-			}
-			pos++
-
-			// Then add the issue/pull number
-			//
-			// match[8]-match[9] is the number
-			endPos = pos + match[9] - match[8]
-			copy(contentBytes[pos:endPos], contentBytes[match[8]:match[9]])
-
-			// Now copy what's left at the end of the string to the new end position
-			copy(contentBytes[endPos:], contentBytes[match[9]:])
-			// now we reset the length
-
-			// our new section has length endPos - match[3]
-			// our old section has length match[9] - match[3]
-			contentBytes = contentBytes[:len(contentBytes)-match[9]+endPos]
-			pos = endPos
-		}
+		convertFullHTMLReferencesToShortRefs(re, &contentBytes)
 	} else {
 		log.Debug("No GiteaIssuePullPattern pattern")
 	}

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -240,30 +240,67 @@ func FindAllIssueReferences(content string) []IssueReference {
 	// Need to convert fully qualified html references to local system to #/! short codes
 	contentBytes := []byte(content)
 	if re := getGiteaIssuePullPattern(); re != nil {
+		// We will iterate through the content, rewrite and simplify full references.
+		//
+		// We want to transform something like:
+		//
+		// 0         1         2         3         4         5         6
+		// 012345678901234567890123456789012345678901234567890123456789012345789
+		// this is a https://ourgitea.com/git/owner/repo/issues/123456789, foo
+		// https://ourgitea.com/git/owner/repo/pulls/123456789
+		//
+		// Into something like:
+		//
+		// this is a #123456789, foo
+		// !123456789
+
 		pos := 0
 		for {
+			// re looks for something like: (\s|^|\(|\[)https://ourgitea.com/git/(owner/repo)/(issues)/(123456789)(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)
 			match := re.FindSubmatchIndex(contentBytes[pos:])
 			if match == nil {
 				break
 			}
+			// match is a bunch of indices into the content from pos onwards so if our content is:
+
+			// To simplify things let's just add pos to all of the indices in match
+			for i := range match {
+				match[i] += pos
+			}
+
 			// match[0]-match[1] is whole string
 			// match[2]-match[3] is preamble
-			pos += match[3]
+
+			// move the position to the end of the preamble
+			pos = match[3]
+
 			// match[4]-match[5] is owner/repo
+			// now copy the owner/repo to end of the preamble
 			endPos := pos + match[5] - match[4]
 			copy(contentBytes[pos:endPos], contentBytes[match[4]:match[5]])
+
+			// move the current position to the end of the newly copied owner/repo
 			pos = endPos
+
+			// Now set the issue/pull marker:
+			//
 			// match[6]-match[7] == 'issues'
 			contentBytes[pos] = '#'
 			if string(contentBytes[match[6]:match[7]]) == "pulls" {
 				contentBytes[pos] = '!'
 			}
 			pos++
+
+			// Then add the issue/pull number
+			//
 			// match[8]-match[9] is the number
 			endPos = pos + match[9] - match[8]
 			copy(contentBytes[pos:endPos], contentBytes[match[8]:match[9]])
+
+			// Now copy what's left at the end of the string to the new end position
 			copy(contentBytes[endPos:], contentBytes[match[9]:])
 			// now we reset the length
+
 			// our new section has length endPos - match[3]
 			// our old section has length match[9] - match[3]
 			contentBytes = contentBytes[:len(contentBytes)-match[9]+endPos]

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -257,9 +257,8 @@ func convertFullHTMLReferencesToShortRefs(re *regexp.Regexp, contentBytes *[]byt
 		if match == nil {
 			break
 		}
-		// match is a bunch of indices into the content from pos onwards so if our content is:
-
-		// To simplify things let's just add pos to all of the indices in match
+		// match is a bunch of indices into the content from pos onwards so
+		// to simplify things let's just add pos to all of the indices in match
 		for i := range match {
 			match[i] += pos
 		}

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -240,8 +240,6 @@ func convertFullHTMLReferencesToShortRefs(re *regexp.Regexp, contentBytes *[]byt
 	//
 	// We want to transform something like:
 	//
-	// 0         1         2         3         4         5         6
-	// 012345678901234567890123456789012345678901234567890123456789012345789
 	// this is a https://ourgitea.com/git/owner/repo/issues/123456789, foo
 	// https://ourgitea.com/git/owner/repo/pulls/123456789
 	//

--- a/modules/references/references_test.go
+++ b/modules/references/references_test.go
@@ -5,6 +5,7 @@
 package references
 
 import (
+	"regexp"
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -27,6 +28,26 @@ type testResult struct {
 	RefLocation    *RefSpan
 	ActionLocation *RefSpan
 	TimeLog        string
+}
+
+func TestConvertFullHTMLReferencesToShortRefs(t *testing.T) {
+	re := regexp.MustCompile(`(\s|^|\(|\[)` +
+		regexp.QuoteMeta("https://ourgitea.com/git/") +
+		`([0-9a-zA-Z-_\.]+/[0-9a-zA-Z-_\.]+)/` +
+		`((?:issues)|(?:pulls))/([0-9]+)(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)`)
+	test := `this is a https://ourgitea.com/git/owner/repo/issues/123456789, foo
+https://ourgitea.com/git/owner/repo/pulls/123456789
+  And https://ourgitea.com/git/owner/repo/pulls/123
+`
+	expect := `this is a owner/repo#123456789, foo
+owner/repo!123456789
+  And owner/repo!123
+`
+
+	contentBytes := []byte(test)
+	convertFullHTMLReferencesToShortRefs(re, &contentBytes)
+	result := string(contentBytes)
+	assert.EqualValues(t, expect, result)
 }
 
 func TestFindAllIssueReferences(t *testing.T) {

--- a/modules/references/references_test.go
+++ b/modules/references/references_test.go
@@ -107,6 +107,13 @@ func TestFindAllIssueReferences(t *testing.T) {
 			},
 		},
 		{
+			"This http://gitea.com:3000/user4/repo5/pulls/202 yes. http://gitea.com:3000/user4/repo5/pulls/203 no",
+			[]testResult{
+				{202, "user4", "repo5", "202", true, XRefActionNone, nil, nil, ""},
+				{203, "user4", "repo5", "203", true, XRefActionNone, nil, nil, ""},
+			},
+		},
+		{
 			"This http://GiTeA.COM:3000/user4/repo6/pulls/205 yes.",
 			[]testResult{
 				{205, "user4", "repo6", "205", true, XRefActionNone, nil, nil, ""},


### PR DESCRIPTION
The issue lay in determining the position of matches on a second run round
a commit message in FindAllIssueReferences.

Fix #13483

Signed-off-by: Andrew Thornton <art27@cantab.net>
