### PR TITLE
fix: issue tracker link redirection

### DIFF
--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -35,12 +35,12 @@
 							{{if eq $refGroup "pull"}}
 								{{if $.HidePRRefs}}
 									{{if (containGeneric $.SelectedBranches .Name) }}
-										<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/pulls/{{.ShortName|PathEscape}}">
+										<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/issues/{{.ShortName|PathEscape}}">
 											{{svg "octicon-git-pull-request" 16 "mr-2"}}#{{.ShortName}}
 										</a>
 									{{end}}
 								{{else}}
-									<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/pulls/{{.ShortName|PathEscape}}">
+									<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/issues/{{.ShortName|PathEscape}}">
 										{{svg "octicon-git-pull-request" 16 "mr-2"}}#{{.ShortName}}
 									</a>
 								{{end}}


### PR DESCRIPTION
First of all, kudos to @zeripath for telling me what to do to fix the issue.

There's this issue I've got and this PR fixes it.

In case a repo has got a remote issue tracker configured, the git graph view PR and issue links now correctly point to the issue tracker location, whereas before they were literally pointing at 'pulls' (`/usr/repo/pulls`) and you could have ended up back at the local instance after clicking the link (which, obviously haven't had the pull/issue).
I case there is no remote issue tracker configured, no redirection occurs and a proper issue/PR page is shown.
