### PR TITLE
Use monaco for the git hook editor

### DIFF
--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -787,7 +787,6 @@ func GitHooks(ctx *context.Context) {
 func GitHooksEdit(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.settings.githooks")
 	ctx.Data["PageIsSettingsGitHooks"] = true
-	ctx.Data["RequireSimpleMDE"] = true
 
 	name := ctx.Params(":name")
 	hook, err := ctx.Repo.GitRepo.GetHook(name)

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -36,7 +36,7 @@
 					{{end}}
 				</div>
 				<div class="ui bottom attached active tab segment" data-tab="write">
-					<textarea id="edit_area" name="content" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
+					<textarea id="edit_area" name="content" class="hide" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 						data-url="{{.Repository.APIURL}}/markdown"
 						data-context="{{.RepoLink}}"
 						data-markdown-file-exts="{{.MarkdownFileExts}}"

--- a/templates/repo/settings/githook_edit.tmpl
+++ b/templates/repo/settings/githook_edit.tmpl
@@ -14,13 +14,13 @@
 				{{with .Hook}}
 					<div class="inline field">
 						<label>{{$.i18n.Tr "repo.settings.githook_name"}}</label>
-						<span>{{.Name}}</span>
+						<span class="hook-filename">{{.Name}}</span>
 					</div>
 					<div class="field">
 						<label for="content">{{$.i18n.Tr "repo.settings.githook_content"}}</label>
-						<textarea id="content" name="content" rows="20" wrap="off" autofocus>{{if .IsActive}}{{.Content}}{{else}}{{.Sample}}{{end}}</textarea>
+						<textarea id="content" name="content" class="hide">{{if .IsActive}}{{.Content}}{{else}}{{.Sample}}{{end}}</textarea>
+						<div class="editor-loading is-loading"></div>
 					</div>
-
 					<div class="inline field">
 						<button class="ui green button">{{$.i18n.Tr "repo.settings.update_githook"}}</button>
 					</div>

--- a/templates/repo/settings/githooks.tmpl
+++ b/templates/repo/settings/githooks.tmpl
@@ -16,7 +16,9 @@
 					<div class="item">
 						<span class="text {{if .IsActive}}green{{else}}grey{{end}}">{{svg "octicon-dot-fill"}}</span>
 						<span>{{.Name}}</span>
-						<a class="text blue ui right" href="{{$.RepoLink}}/settings/hooks/git/{{.Name}}"><i class="fa fa-pencil"></i></a>
+						<a class="text blue ui right" href="{{$.RepoLink}}/settings/hooks/git/{{.Name}}">
+							{{svg "octicon-pencil"}}
+						</a>
 					</div>
 				{{end}}
 			</div>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -23,7 +23,7 @@ import createDropzone from './features/dropzone.js';
 import initTableSort from './features/tablesort.js';
 import ActivityTopAuthors from './components/ActivityTopAuthors.vue';
 import {initNotificationsTable, initNotificationCount} from './features/notification.js';
-import {createCodeEditor} from './features/codeeditor.js';
+import {createCodeEditor, createMonaco} from './features/codeeditor.js';
 import {svg, svgs} from './svg.js';
 import {stripTags} from './utils.js';
 
@@ -1732,15 +1732,10 @@ function initUserSettings() {
   }
 }
 
-function initGithook() {
-  if ($('.edit.githook').length === 0) {
-    return;
-  }
-
-  CodeMirror.autoLoadMode(CodeMirror.fromTextArea($('#content')[0], {
-    lineNumbers: true,
-    mode: 'shell'
-  }), 'shell');
+async function initGithook() {
+  if ($('.edit.githook').length === 0) return;
+  const filename = document.querySelector('.hook-filename').textContent;
+  await createMonaco($('#content')[0], filename, {language: 'shell'});
 }
 
 function initWebhook() {
@@ -2517,7 +2512,6 @@ $(document).ready(async () => {
   initEditForm();
   initEditor();
   initOrganization();
-  initGithook();
   initWebhook();
   initAdmin();
   initCodeView();
@@ -2575,6 +2569,7 @@ $(document).ready(async () => {
     initServiceWorker(),
     initNotificationCount(),
     renderMarkdownContent(),
+    initGithook(),
   ]);
 });
 

--- a/web_src/less/_editor.less
+++ b/web_src/less/_editor.less
@@ -53,10 +53,6 @@
   border-right: 1px solid var(--color-secondary) !important;
 }
 
-#edit_area {
-  display: none;
-}
-
 .monaco-editor-container {
   width: 100%;
   min-height: 200px;
@@ -72,4 +68,9 @@
   border: none !important;
   color: transparent !important;
   background-color: transparent !important;
+}
+
+.edit.githook .monaco-editor-container {
+  border: 1px solid var(--color-secondary);
+  height: 70vh;
 }


### PR DESCRIPTION
Migrate git hook editor to monaco, replacing CodeMirror. Had to do a few refactors to make the monaco instantiation generic enough to be of use.

<img width="1042" alt="Screen Shot 2020-11-13 at 23 30 00" src="https://user-images.githubusercontent.com/115237/99127324-4e4a0600-2608-11eb-9ff2-f4860d6e9987.png">
<img width="1042" alt="Screen Shot 2020-11-13 at 23 30 29" src="https://user-images.githubusercontent.com/115237/99127327-4ee29c80-2608-11eb-8064-9009e54dabec.png">
