### PR TITLE
Add tab-size support for Firefox

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2965,6 +2965,7 @@
 .generate-tab-size(@n, @i: 1) when (@i =< @n) {
   .tab-size-@{i} {
     tab-size: @i !important;
+    -moz-tab-size: @i !important;
   }
 
   .generate-tab-size(@n, (@i + 1));


### PR DESCRIPTION
`tab-size` is not supported by Firefox, so I added `-moz-tab-size` CSS style.