### PR TITLE
Fix label display on new issues

### DIFF
--- a/routers/repo/compare.go
+++ b/routers/repo/compare.go
@@ -184,6 +184,7 @@ func ParseCompareInfo(ctx *context.Context) (*models.User, *models.Repository, *
 	ctx.Data["BaseIsCommit"] = baseIsCommit
 	ctx.Data["BaseIsBranch"] = baseIsBranch
 	ctx.Data["BaseIsTag"] = baseIsTag
+	ctx.Data["IsPull"] = true
 
 	// Now we have the repository that represents the base
 

--- a/templates/repo/issue/labels/label.tmpl
+++ b/templates/repo/issue/labels/label.tmpl
@@ -1,0 +1,11 @@
+<div class="item">
+	<a
+		class="ui label {{if not .label.IsChecked}}hide{{end}}"
+		id="label_{{.label.ID}}"
+		href="{{.root.RepoLink}}/{{if or .root.IsPull .root.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.label.ID}}"
+		style="color: {{.label.ForegroundColor}}; background-color: {{.label.Color}}"
+		title="{{.label.Description | RenderEmojiPlain}}"
+	>
+			{{.label.Name | RenderEmoji}}
+	</a>
+</div>

--- a/templates/repo/issue/labels/label.tmpl
+++ b/templates/repo/issue/labels/label.tmpl
@@ -1,11 +1,9 @@
-<div class="item">
-	<a
-		class="ui label {{if not .label.IsChecked}}hide{{end}}"
-		id="label_{{.label.ID}}"
-		href="{{.root.RepoLink}}/{{if or .root.IsPull .root.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.label.ID}}"
-		style="color: {{.label.ForegroundColor}}; background-color: {{.label.Color}}"
-		title="{{.label.Description | RenderEmojiPlain}}"
-	>
-			{{.label.Name | RenderEmoji}}
-	</a>
-</div>
+<a
+	class="ui label item {{if not .label.IsChecked}}hide{{end}}"
+	id="label_{{.label.ID}}"
+	href="{{.root.RepoLink}}/{{if or .root.IsPull .root.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.label.ID}}"
+	style="color: {{.label.ForegroundColor}}; background-color: {{.label.Color}}"
+	title="{{.label.Description | RenderEmojiPlain}}"
+>
+		{{.label.Name | RenderEmoji}}
+</a>

--- a/templates/repo/issue/labels/labels_sidebar.tmpl
+++ b/templates/repo/issue/labels/labels_sidebar.tmpl
@@ -1,0 +1,9 @@
+<div class="ui labels list">
+	<span class="no-select item {{if .ctx.HasSelectedLabel}}hide{{end}}">{{.ctx.i18n.Tr "repo.issues.new.no_label"}}</span>
+	{{range .ctx.Labels}}
+		{{template "repo/issue/labels/label" dict "root" $ "label" .}}
+	{{end}}
+	{{range .ctx.OrgLabels}}
+		{{template "repo/issue/labels/label" dict "root" $ "label" .}}
+	{{end}}
+</div>

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -73,14 +73,10 @@
 			<div class="ui labels list">
 				<span class="no-select item {{if .HasSelectedLabel}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_label"}}</span>
 				{{range .Labels}}
-					{{if .IsChecked}}
-						<a class="item" id="label_{{.ID}}" href="{{$.RepoLink}}/issues?labels={{.ID}}"><span class="label color" style="background-color: {{.Color}}"></span> <span class="text">{{.Name | RenderEmoji}}</span></a>
-					{{end}}
+					{{template "repo/issue/labels/label" dict "root" $ "label" .}}
 				{{end}}
 				{{range .OrgLabels}}
-					{{if .IsChecked}}
-						<a class="item" id="label_{{.ID}}" href="/issues?labels={{.ID}}"><span class="label color" style="background-color: {{.Color}}"></span> <span class="text">{{.Name | RenderEmoji}}</span></a>
-					{{end}}
+					{{template "repo/issue/labels/label" dict "root" $ "label" .}}
 				{{end}}
 			</div>
 

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -70,15 +70,7 @@
 					{{end}}
 				</div>
 			</div>
-			<div class="ui labels list">
-				<span class="no-select item {{if .HasSelectedLabel}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_label"}}</span>
-				{{range .Labels}}
-					{{template "repo/issue/labels/label" dict "root" $ "label" .}}
-				{{end}}
-				{{range .OrgLabels}}
-					{{template "repo/issue/labels/label" dict "root" $ "label" .}}
-				{{end}}
-			</div>
+			{{template "repo/issue/labels/labels_sidebar" dict "root" $ "ctx" .}}
 
 			<div class="ui divider"></div>
 

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -125,15 +125,7 @@
 				{{end}}
 			</div>
 		</div>
-		<div class="ui labels list">
-			<span class="no-select item {{if .HasSelectedLabel}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_label"}}</span>
-			{{range .Labels}}
-				{{template "repo/issue/labels/label" dict "root" $ "label" .}}
-			{{end}}
-			{{range .OrgLabels}}
-				{{template "repo/issue/labels/label" dict "root" $ "label" .}}
-			{{end}}
-		</div>
+		{{template "repo/issue/labels/labels_sidebar" dict "root" $ "ctx" .}}
 
 		<div class="ui divider"></div>
 

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -126,22 +126,12 @@
 			</div>
 		</div>
 		<div class="ui labels list">
-			{{if not .HasSelectedLabel}}
-				<span class="no-select item">{{.i18n.Tr "repo.issues.new.no_label"}}</span>
-			{{end}}
+			<span class="no-select item {{if .HasSelectedLabel}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_label"}}</span>
 			{{range .Labels}}
-				{{if .IsChecked}}
-					<div class="item">
-						<a class="ui label" id="label_{{.ID}}" href="{{$.RepoLink}}/{{if $.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.ID}}" style="color: {{.ForegroundColor}}; background-color: {{.Color}}" title="{{.Description | RenderEmojiPlain}}">{{.Name | RenderEmoji}}</a>
-					</div>
-				{{end}}
+				{{template "repo/issue/labels/label" dict "root" $ "label" .}}
 			{{end}}
 			{{range .OrgLabels}}
-				{{if .IsChecked}}
-					<div class="item">
-						<a class="ui label" id="label_{{.ID}}" href="{{$.RepoLink}}/{{if $.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.ID}}" style="color: {{.ForegroundColor}}; background-color: {{.Color}}" title="{{.Description | RenderEmojiPlain}}">{{.Name | RenderEmoji}}</a>
-					</div>
-				{{end}}
+				{{template "repo/issue/labels/label" dict "root" $ "label" .}}
 			{{end}}
 		</div>
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2980,12 +2980,15 @@
 }
 
 .labels.list .item {
-  padding: 0 !important;
-  margin-bottom: 2px;
+  display: inline-block;
+  padding: 3px 7px !important;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 3px;
 }
 
 .labels.list .item + .item {
-  margin-left: 2px;
+  margin-left: 3px;
 }
 
 tbody.commit-list {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -133,11 +133,6 @@
           max-width: 100px;
         }
       }
-
-      .label.color {
-        padding: 0 8px;
-        margin-right: 5px;
-      }
     }
 
     #deadlineForm input {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2980,8 +2980,7 @@
 }
 
 .labels.list .item {
-  display: inline-block;
-  padding: 3px 7px !important;
+  padding: .3em .5em !important;
   margin-left: 0;
   margin-right: 0;
   margin-bottom: 3px;


### PR DESCRIPTION
PR #13570 broke label rendering for new issues and pulls because I missed the fact that the code was relying on the DOM elements being toggled by JavaScript.

On top of that, the label rendering for new issues and pull was using an outdated template which I consolidated in a new shared template.