### PR TITLE
WIP: Add commit sha to filepath api

### DIFF
--- a/integrations/api_repo_file_create_test.go
+++ b/integrations/api_repo_file_create_test.go
@@ -62,6 +62,7 @@ func getExpectedFileResponseForCreate(commitID, treePath string) *api.FileRespon
 			SHA:         sha,
 			Size:        16,
 			Type:        "file",
+			Commit:      CommitID,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/integrations/api_repo_file_create_test.go
+++ b/integrations/api_repo_file_create_test.go
@@ -62,7 +62,7 @@ func getExpectedFileResponseForCreate(commitID, treePath string) *api.FileRespon
 			SHA:         sha,
 			Size:        16,
 			Type:        "file",
-			Commit:      CommitID,
+			Commit:      commitID,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/integrations/api_repo_file_update_test.go
+++ b/integrations/api_repo_file_update_test.go
@@ -60,6 +60,7 @@ func getExpectedFileResponseForUpdate(commitID, treePath string) *api.FileRespon
 			SHA:         sha,
 			Type:        "file",
 			Size:        20,
+			Commit:      commitID,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/integrations/api_repo_get_contents_list_test.go
+++ b/integrations/api_repo_get_contents_list_test.go
@@ -33,6 +33,7 @@ func getExpectedContentsListResponseForContents(ref, refType string) []*api.Cont
 			SHA:         sha,
 			Type:        "file",
 			Size:        30,
+			Commit:      "65f1bf27bc3bf70f64657658635e66094edbcb4d",
 			URL:         &selfURL,
 			HTMLURL:     &htmlURL,
 			GitURL:      &gitURL,

--- a/integrations/api_repo_get_contents_test.go
+++ b/integrations/api_repo_get_contents_test.go
@@ -27,12 +27,14 @@ func getExpectedContentsResponseForContents(ref, refType string) *api.ContentsRe
 	htmlURL := setting.AppURL + "user2/repo1/src/" + refType + "/" + ref + "/" + treePath
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/" + sha
 	downloadURL := setting.AppURL + "user2/repo1/raw/" + refType + "/" + ref + "/" + treePath
+	commit := "65f1bf27bc3bf70f64657658635e66094edbcb4d"
 	return &api.ContentsResponse{
 		Name:        treePath,
 		Path:        treePath,
 		SHA:         sha,
 		Type:        "file",
 		Size:        30,
+		Commit:      commit,
 		Encoding:    &encoding,
 		Content:     &content,
 		URL:         &selfURL,

--- a/integrations/repofiles_update_test.go
+++ b/integrations/repofiles_update_test.go
@@ -51,7 +51,6 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 	treePath := "new/file.txt"
 	encoding := "base64"
 	content := "VGhpcyBpcyBhIE5FVyBmaWxl"
-	commit := "9d2e65142f724c83719ec061b481924598e42625"
 	selfURL := setting.AppURL + "api/v1/repos/user2/repo1/contents/" + treePath + "?ref=master"
 	htmlURL := setting.AppURL + "user2/repo1/src/branch/master/" + treePath
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/103ff9234cefeee5ec5361d22b49fbb04d385885"
@@ -63,7 +62,7 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 			SHA:         "103ff9234cefeee5ec5361d22b49fbb04d385885",
 			Type:        "file",
 			Size:        18,
-			Commit:      commit,
+			Commit:      commitID,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,
@@ -120,7 +119,6 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 func getExpectedFileResponseForRepofilesUpdate(commitID, filename string) *api.FileResponse {
 	encoding := "base64"
 	content := "VGhpcyBpcyBVUERBVEVEIGNvbnRlbnQgZm9yIHRoZSBSRUFETUUgZmlsZQ=="
-	commit := "df024f80889e566a554fba187376bb95ae9fdc69"
 	selfURL := setting.AppURL + "api/v1/repos/user2/repo1/contents/" + filename + "?ref=master"
 	htmlURL := setting.AppURL + "user2/repo1/src/branch/master/" + filename
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/dbf8d00e022e05b7e5cf7e535de857de57925647"
@@ -132,7 +130,7 @@ func getExpectedFileResponseForRepofilesUpdate(commitID, filename string) *api.F
 			SHA:         "dbf8d00e022e05b7e5cf7e535de857de57925647",
 			Type:        "file",
 			Size:        43,
-			Commit:      commit,
+			Commit:      commitID,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/integrations/repofiles_update_test.go
+++ b/integrations/repofiles_update_test.go
@@ -51,6 +51,7 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 	treePath := "new/file.txt"
 	encoding := "base64"
 	content := "VGhpcyBpcyBhIE5FVyBmaWxl"
+	commit := "9d2e65142f724c83719ec061b481924598e42625"
 	selfURL := setting.AppURL + "api/v1/repos/user2/repo1/contents/" + treePath + "?ref=master"
 	htmlURL := setting.AppURL + "user2/repo1/src/branch/master/" + treePath
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/103ff9234cefeee5ec5361d22b49fbb04d385885"
@@ -62,6 +63,7 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 			SHA:         "103ff9234cefeee5ec5361d22b49fbb04d385885",
 			Type:        "file",
 			Size:        18,
+			Commit:      commit,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,
@@ -118,6 +120,7 @@ func getExpectedFileResponseForRepofilesCreate(commitID string) *api.FileRespons
 func getExpectedFileResponseForRepofilesUpdate(commitID, filename string) *api.FileResponse {
 	encoding := "base64"
 	content := "VGhpcyBpcyBVUERBVEVEIGNvbnRlbnQgZm9yIHRoZSBSRUFETUUgZmlsZQ=="
+	commit := "df024f80889e566a554fba187376bb95ae9fdc69"
 	selfURL := setting.AppURL + "api/v1/repos/user2/repo1/contents/" + filename + "?ref=master"
 	htmlURL := setting.AppURL + "user2/repo1/src/branch/master/" + filename
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/dbf8d00e022e05b7e5cf7e535de857de57925647"
@@ -129,6 +132,7 @@ func getExpectedFileResponseForRepofilesUpdate(commitID, filename string) *api.F
 			SHA:         "dbf8d00e022e05b7e5cf7e535de857de57925647",
 			Type:        "file",
 			Size:        43,
+			Commit:      commit,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/modules/repofiles/content.go
+++ b/modules/repofiles/content.go
@@ -148,11 +148,12 @@ func GetContents(repo *models.Repository, treePath, ref string, forList bool) (*
 
 	// All content types have these fields in populated
 	contentsResponse := &api.ContentsResponse{
-		Name: entry.Name(),
-		Path: treePath,
-		SHA:  entry.ID.String(),
-		Size: entry.Size(),
-		URL:  &selfURLString,
+		Name:   entry.Name(),
+		Path:   treePath,
+		SHA:    entry.ID.String(),
+		Size:   entry.Size(),
+		Commit: commitID,
+		URL:    &selfURLString,
 		Links: &api.FileLinksResponse{
 			Self: &selfURLString,
 		},

--- a/modules/repofiles/content.go
+++ b/modules/repofiles/content.go
@@ -146,14 +146,19 @@ func GetContents(repo *models.Repository, treePath, ref string, forList bool) (*
 	}
 	selfURLString := selfURL.String()
 
+	lastCommit, err := commit.GetCommitByPath(treePath)
+	if err != nil {
+		return nil, err
+	}
+
 	// All content types have these fields in populated
 	contentsResponse := &api.ContentsResponse{
 		Name:   entry.Name(),
 		Path:   treePath,
 		SHA:    entry.ID.String(),
 		Size:   entry.Size(),
-		Commit: commitID,
 		URL:    &selfURLString,
+		Commit: lastCommit.ID.String(),
 		Links: &api.FileLinksResponse{
 			Self: &selfURLString,
 		},

--- a/modules/repofiles/content_test.go
+++ b/modules/repofiles/content_test.go
@@ -22,6 +22,7 @@ func TestMain(m *testing.M) {
 func getExpectedReadmeContentsResponse() *api.ContentsResponse {
 	treePath := "README.md"
 	sha := "4b4851ad51df6a7d9f25c979345979eaeb5b349f"
+	commit := "65f1bf27bc3bf70f64657658635e66094edbcb4d"
 	encoding := "base64"
 	content := "IyByZXBvMQoKRGVzY3JpcHRpb24gZm9yIHJlcG8x"
 	selfURL := "https://try.gitea.io/api/v1/repos/user2/repo1/contents/" + treePath + "?ref=master"
@@ -34,6 +35,7 @@ func getExpectedReadmeContentsResponse() *api.ContentsResponse {
 		SHA:         "4b4851ad51df6a7d9f25c979345979eaeb5b349f",
 		Type:        "file",
 		Size:        30,
+		Commit:      commit,
 		Encoding:    &encoding,
 		Content:     &content,
 		URL:         &selfURL,

--- a/modules/repofiles/file_test.go
+++ b/modules/repofiles/file_test.go
@@ -19,6 +19,7 @@ import (
 func getExpectedFileResponse() *api.FileResponse {
 	treePath := "README.md"
 	sha := "4b4851ad51df6a7d9f25c979345979eaeb5b349f"
+	commit := "65f1bf27bc3bf70f64657658635e66094edbcb4d"
 	encoding := "base64"
 	content := "IyByZXBvMQoKRGVzY3JpcHRpb24gZm9yIHJlcG8x"
 	selfURL := setting.AppURL + "api/v1/repos/user2/repo1/contents/" + treePath + "?ref=master"
@@ -32,6 +33,7 @@ func getExpectedFileResponse() *api.FileResponse {
 			SHA:         sha,
 			Type:        "file",
 			Size:        30,
+			Commit:      commit,
 			Encoding:    &encoding,
 			Content:     &content,
 			URL:         &selfURL,

--- a/modules/structs/repo_file.go
+++ b/modules/structs/repo_file.go
@@ -59,10 +59,13 @@ type FileLinksResponse struct {
 type ContentsResponse struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
-	SHA  string `json:"sha"`
+	// File SHA
+	SHA string `json:"sha"`
 	// `type` will be `file`, `dir`, `symlink`, or `submodule`
 	Type string `json:"type"`
 	Size int64  `json:"size"`
+	// Last commit touching the entry
+	Commit string `json:"commit"`
 	// `encoding` is populated when `type` is `file`, otherwise null
 	Encoding *string `json:"encoding"`
 	// `content` is populated when `type` is `file`, otherwise null

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -11543,6 +11543,11 @@
         "_links": {
           "$ref": "#/definitions/FileLinksResponse"
         },
+        "commit": {
+          "description": "Last commit touching the entry",
+          "type": "string",
+          "x-go-name": "Commit"
+        },
         "content": {
           "description": "`content` is populated when `type` is `file`, otherwise null",
           "type": "string",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -11579,6 +11579,7 @@
           "x-go-name": "Path"
         },
         "sha": {
+          "description": "File SHA",
           "type": "string",
           "x-go-name": "SHA"
         },


### PR DESCRIPTION
This is an attempt to give a solution to #12840

I'm not really satisfied with the tests yet, as the repo that is used in the test has only one commit, it's not really possible to check that the returned commit is correct.