### PR TITLE
Docs: Installation from package

### DIFF
--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -17,14 +17,11 @@ menu:
 
 ## Alpine Linux
 
-Alpine Linux has gitea in its community repository. It follows the latest stable version.
-for more information look at https://pkgs.alpinelinux.org/packages?name=gitea&branch=edge.
+Alpine Linux has [Gitea](https://pkgs.alpinelinux.org/packages?name=gitea&branch=edge) in its community repository which follows the latest stable version.
 
-install as usual:
 ```sh
 apk add gitea
 ```
-config is found in **/etc/gitea/app.ini**
 
 ## Arch Linux
 

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -36,6 +36,14 @@ apk add gitea
 ```
 config is found in **/etc/gitea/app.ini**
 
+## Arch Linux
+
+The rolling release distribution has [Gitea](https://www.archlinux.org/packages/community/x86_64/gitea/) in their official community repository and package updates are provided with new Gitea releases.
+
+```sh
+pacman -S gitea
+```
+
 ## Windows
 
 There is a [Gitea](https://chocolatey.org/packages/gitea) package for Windows by [Chocolatey](https://chocolatey.org/).

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -15,16 +15,6 @@ menu:
 
 # Installation from package
 
-## Debian
-
-Although there is a package of Gitea in Debian's [contrib](https://wiki.debian.org/SourcesList),
-it is not supported directly by us.
-
-Unfortunately, the package is not maintained anymore and broken because of missing sources.
-Please follow the [deployment from binary]({{< relref "from-binary.en-us.md" >}}) guide instead.
-
-Should the packages get updated and fixed, we will provide up-to-date installation instructions here.
-
 ## Alpine Linux
 
 Alpine Linux has gitea in its community repository. It follows the latest stable version.

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -44,6 +44,14 @@ The rolling release distribution has [Gitea](https://www.archlinux.org/packages/
 pacman -S gitea
 ```
 
+## Archl Linux ARM
+
+Arch Linux ARM provides packages for [aarch64](https://archlinuxarm.org/packages/aarch64/gitea), [armv7h](https://archlinuxarm.org/packages/armv7h/gitea) and [armv6h](https://archlinuxarm.org/packages/armv6h/gitea).
+
+```sh
+pacman -S gitea
+```
+
 ## Windows
 
 There is a [Gitea](https://chocolatey.org/packages/gitea) package for Windows by [Chocolatey](https://chocolatey.org/).

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -31,7 +31,7 @@ The rolling release distribution has [Gitea](https://www.archlinux.org/packages/
 pacman -S gitea
 ```
 
-## Archl Linux ARM
+## Arch Linux ARM
 
 Arch Linux ARM provides packages for [aarch64](https://archlinuxarm.org/packages/aarch64/gitea), [armv7h](https://archlinuxarm.org/packages/armv7h/gitea) and [armv6h](https://archlinuxarm.org/packages/armv6h/gitea).
 


### PR DESCRIPTION
This PR ...
... adds information to **docs** about Linux distributions providing official Gitea packages:
* Arch Linux
* Arch Linux ARM

... changes
* Alpine Linux: Content shrinking and fixing minor typo.

... removes
* Debian: There are no Debian packages available, so i removed this part completely.

If you know other distributions with official packages: Please let me know and I'll add them as well.