### PR TITLE
finaly fix gitlab migration with subdir 2.0

### DIFF
--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -609,8 +609,12 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 
 // GetReviews returns pull requests review
 func (g *GitlabDownloader) GetReviews(pullRequestNumber int64) ([]*base.Review, error) {
-	state, _, err := g.client.MergeRequestApprovals.GetApprovalState(g.repoID, int(pullRequestNumber), gitlab.WithContext(g.ctx))
+	state, resp, err := g.client.MergeRequestApprovals.GetApprovalState(g.repoID, int(pullRequestNumber), gitlab.WithContext(g.ctx))
 	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Error(fmt.Sprintf("GitlabDownloader: while migrating a error occurred: '%s'", err.Error()))
+			return []*base.Review{}, nil
+		}
 		return nil, err
 	}
 

--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -92,7 +92,7 @@ func NewGitlabDownloader(ctx context.Context, baseURL, repoPath, username, passw
 	pathParts := strings.Split(strings.Trim(repoPath, "/"), "/")
 	var resp *gitlab.Response
 	u, _ := url.Parse(baseURL)
-	for len(pathParts) > 2 {
+	for len(pathParts) >= 2 {
 		_, resp, err = gitlabClient.Version.GetVersion()
 		if err == nil || resp != nil && resp.StatusCode == 401 {
 			err = nil // if no authentication given, this still should work


### PR DESCRIPTION
followup of  #13629 based on https://github.com/go-gitea/gitea/issues/13535#issuecomment-730542428

also fix an issue by ignoring 404 error when try to get mergerequest approval

yes befor declare it readdy I'll test this cases:
* [x] https://gitlab.alpinelinux.org/6543/aports
* [x] https://framagit.org/framasoft/peertube/PeerTube.git
* [x] https://gitlab2.pr.gitea.io/gitlab/root/normalprivate.git
* [x] https://gitlab2.pr.gitea.io/gitlab/root/newpublic/
* [x] https://gitlab2.pr.gitea.io/gitlab/g1/subgroup1/asubgroupproject.git
* [x] https://gitlab2.pr.gitea.io/gitlab/g1/subgroup1/subsubgrrr/now-you-know.git
* [ ] https://gitlab.com/Remmina/Remmina -> (#13648)
* [x] https://gitlab2.pr.gitea.io/gitlab/gitlab/root/t2.git
* [x] https://gitlab2.pr.gitea.io/gitlab/gitlab/g1/subgroup1/subsubgrrr/now-you-know.git