### PR TITLE
Send error message when CSRF token is missing

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -169,7 +169,7 @@ func (ctx *APIContext) RequireCSRF() {
 	if len(headerToken) > 0 || len(formValueToken) > 0 {
 		csrf.Validate(ctx.Context.Context, ctx.csrf)
 	} else {
-		ctx.Context.Error(401)
+		ctx.Context.Error(401, "Missing CSRF token.")
 	}
 }
 


### PR DESCRIPTION
I was having the problem described in #13484. It turns out the 401 response was because the CSRF token was missing. This PR adds an error message for that case.