### PR TITLE
CSS table fixes

### DIFF
--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -2,14 +2,16 @@
 <div class="repository wiki pages">
 	{{template "repo/header" .}}
 	<div class="ui container">
-		<div class="ui header">
-			{{.i18n.Tr "repo.wiki.pages"}}
-			{{if and .CanWriteWiki (not .IsRepositoryMirror)}}
-			<div class="ui right">
-				<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+		<h2 class="ui header df ac sb">
+			<div>
+				{{.i18n.Tr "repo.wiki.pages"}}
 			</div>
-			{{end}}
-		</div>
+			<div>
+				{{if and .CanWriteWiki (not .IsRepositoryMirror)}}
+					<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+				{{end}}
+			</div>
+		</h2>
 		<table class="ui table">
 			<tbody>
 				{{range .Pages}}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -229,12 +229,20 @@ a:hover,
 
 .ui.table {
   color: var(--color-text);
+  background: var(--color-body);
+  border-color: var(--color-secondary);
 }
 
 .ui.ui.selectable.table > tbody > tr:hover,
 .ui.table tbody tr td.selectable:hover {
   color: var(--color-text);
   background-color: var(--color-secondary-alpha-40);
+}
+
+.ui.ui.ui.ui.table tr.grey:not(.marked),
+.ui.ui.table td.grey:not(.marked) {
+  background: var(--color-body);
+  color: var(--color-text);
 }
 
 .ui.modal {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -891,23 +891,8 @@ a.ui.basic.green.label:hover {
   background-color: #393d4a !important;
 }
 
-.ui.table {
-  border-color: var(--color-secondary);
-  background: #353945;
-}
-
-.ui.table tbody tr {
-  border-color: var(--color-secondary);
-  background: #353945;
-}
-
 .ui .text.grey {
   color: var(--color-secondary-dark-6) !important;
-}
-
-.ui.attached.table.segment {
-  background: #353945;
-  color: #dbdbdb !important;
 }
 
 .markdown:not(code) h2 {


### PR DESCRIPTION
Override the right fomantic selectors and make the header flexbox for some more spacing.

Fixes: https://github.com/go-gitea/gitea/issues/13690

<img width="1163" alt="Screen Shot 2020-11-24 at 18 15 50" src="https://user-images.githubusercontent.com/115237/100128952-39c80200-2e81-11eb-9903-73b84a4a0ce5.png">
<img width="1165" alt="Screen Shot 2020-11-24 at 18 16 41" src="https://user-images.githubusercontent.com/115237/100128956-3a609880-2e81-11eb-931d-0ceb47bffd6b.png">
