### PR TITLE
CSS table fixes

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -893,6 +893,11 @@ a.ui.basic.green.label:hover {
   color: #dbdbdb !important;
 }
 
+.ui.ui.ui.ui.table tr.grey:not(.marked),
+.ui.ui.table td.grey:not(.marked) {
+  background: none;
+}
+
 .repository.file.list #repo-files-table tr {
   background: #2a2e3a;
 }


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/13692 to 1.13.

(Yes, fix is completely different because of the lack of variables)