### PR TITLE
Add review pending filter on pull request overview

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1018,6 +1018,7 @@ issues.filter_type.all_issues = All issues
 issues.filter_type.assigned_to_you = Assigned to you
 issues.filter_type.created_by_you = Created by you
 issues.filter_type.mentioning_you = Mentioning you
+issues.filter_type.review_pending = Review pending
 issues.filter_sort = Sort
 issues.filter_sort.latest = Newest
 issues.filter_sort.oldest = Oldest

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -113,16 +113,17 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 	var err error
 	viewType := ctx.Query("type")
 	sortType := ctx.Query("sort")
-	types := []string{"all", "your_repositories", "assigned", "created_by", "mentioned"}
+	types := []string{"all", "your_repositories", "assigned", "created_by", "mentioned", "review_pending"}
 	if !com.IsSliceContainsStr(types, viewType) {
 		viewType = "all"
 	}
 
 	var (
-		assigneeID  = ctx.QueryInt64("assignee")
-		posterID    int64
-		mentionedID int64
-		forceEmpty  bool
+		assigneeID      = ctx.QueryInt64("assignee")
+		posterID        int64
+		mentionedID     int64
+		reviewPendingID int64
+		forceEmpty      bool
 	)
 
 	if ctx.IsSigned {
@@ -133,6 +134,8 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 			mentionedID = ctx.User.ID
 		case "assigned":
 			assigneeID = ctx.User.ID
+		case "review_pending":
+			reviewPendingID = ctx.User.ID
 		}
 	}
 
@@ -169,14 +172,15 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 		issueStats = &models.IssueStats{}
 	} else {
 		issueStats, err = models.GetIssueStats(&models.IssueStatsOptions{
-			RepoID:      repo.ID,
-			Labels:      selectLabels,
-			MilestoneID: milestoneID,
-			AssigneeID:  assigneeID,
-			MentionedID: mentionedID,
-			PosterID:    posterID,
-			IsPull:      isPullOption,
-			IssueIDs:    issueIDs,
+			RepoID:          repo.ID,
+			Labels:          selectLabels,
+			MilestoneID:     milestoneID,
+			AssigneeID:      assigneeID,
+			MentionedID:     mentionedID,
+			PosterID:        posterID,
+			ReviewPendingID: reviewPendingID,
+			IsPull:          isPullOption,
+			IssueIDs:        issueIDs,
 		})
 		if err != nil {
 			ctx.ServerError("GetIssueStats", err)
@@ -217,17 +221,18 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 				Page:     pager.Paginater.Current(),
 				PageSize: setting.UI.IssuePagingNum,
 			},
-			RepoIDs:      []int64{repo.ID},
-			AssigneeID:   assigneeID,
-			PosterID:     posterID,
-			MentionedID:  mentionedID,
-			MilestoneIDs: mileIDs,
-			ProjectID:    projectID,
-			IsClosed:     util.OptionalBoolOf(isShowClosed),
-			IsPull:       isPullOption,
-			LabelIDs:     labelIDs,
-			SortType:     sortType,
-			IssueIDs:     issueIDs,
+			RepoIDs:         []int64{repo.ID},
+			AssigneeID:      assigneeID,
+			PosterID:        posterID,
+			MentionedID:     mentionedID,
+			ReviewPendingID: reviewPendingID,
+			MilestoneIDs:    mileIDs,
+			ProjectID:       projectID,
+			IsClosed:        util.OptionalBoolOf(isShowClosed),
+			IsPull:          isPullOption,
+			LabelIDs:        labelIDs,
+			SortType:        sortType,
+			IssueIDs:        issueIDs,
 		})
 		if err != nil {
 			ctx.ServerError("Issues", err)

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -374,6 +374,8 @@ func Issues(ctx *context.Context) {
 			filterMode = models.FilterModeCreate
 		case "mentioned":
 			filterMode = models.FilterModeMention
+		case "review_pending":
+			filterMode = models.FilterModeReviewPending
 		case "your_repositories": // filterMode already set to All
 		default:
 			viewType = "your_repositories"
@@ -452,6 +454,8 @@ func Issues(ctx *context.Context) {
 		opts.PosterID = ctxUser.ID
 	case models.FilterModeMention:
 		opts.MentionedID = ctxUser.ID
+	case models.FilterModeReviewPending:
+		opts.ReviewPendingID = ctxUser.ID
 	}
 
 	var forceEmpty bool

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -96,6 +96,9 @@
 								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
 								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
 								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
+								{{if .PageIsPullList}}
+									<a class="{{if eq .ViewType "review_pending"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_pending&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.review_pending"}}</a>
+								{{end}}
 							</div>
 						</div>
 					{{end}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -94,6 +94,7 @@
 								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
 								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
 								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
+								<a class="{{if eq .ViewType "review_pending"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_pending&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.review_pending"}}</a>
 							</div>
 						</div>
 					{{end}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -22,6 +22,12 @@
 							{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}
 							<strong class="ui right">{{CountFmt .IssueStats.MentionCount}}</strong>
 						</a>
+						{{if .PageIsPulls}}
+							<a class="{{if eq .ViewType "review_pending"}}ui basic blue button{{end}} item" href="{{.Link}}?type=review_pending&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
+								{{.i18n.Tr "repo.issues.filter_type.review_pending"}}
+								<strong class="ui right">{{CountFmt .IssueStats.ReviewPendingCount}}</strong>
+							</a>
+						{{end}}
 					{{end}}
 					<div class="ui divider"></div>
 					<a class="{{if not $.RepoIDs}}ui basic blue button{{end}} repo name item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&q={{$.Keyword}}">


### PR DESCRIPTION
Related to #13682

This adds a filter on the pull request overview pages that allows you to find the pull requests for which you have pending review comments. There were some concerns raised in the ticket about not overloading the UI with too many filtering options though.

From my point of view, this filter would be quite useful so you don't lose track of unsubmitted review comments.
But I think the "Review Requested" filter in #13701 is more critical (also exists on GitHub).