### PR TITLE
Increment skip to avoid infinite loop in PR author aggregation

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -610,7 +610,7 @@ func GetCommitMessages(pr *models.PullRequest) string {
 				}
 				element = element.Next()
 			}
-
+			skip += limit
 		}
 	}
 


### PR DESCRIPTION
As title, credit to Anonymoose in Discord for pointing it out. 🙂 