### PR TITLE
Go linting adjustments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,13 @@ linters:
 run:
   timeout: 3m
 
+skip-dirs:
+  - node_modules
+  - public
+  - templates
+  - vendor
+  - web_src
+
 linters-settings:
   gocritic:
     disabled-checks:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,12 +22,10 @@ linters:
 run:
   timeout: 3m
 
-skip-dirs:
-  - node_modules
-  - public
-  - templates
-  - vendor
-  - web_src
+skip-files:
+  - modules/options/bindata.go
+  - modules/public/bindata.go
+  - modules/templates/bindata.go
 
 linters-settings:
   gocritic:

--- a/Makefile
+++ b/Makefile
@@ -705,7 +705,7 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.33.0; \
 	fi
-	@golangci-lint run --timeout 5m ./ $(addsuffix /...,$(GO_DIRS_OWN))
+	@golangci-lint run --timeout 5m $(addsuffix /...,$(GO_DIRS_OWN))
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -313,8 +313,10 @@ lint: lint-frontend lint-backend
 
 .PHONY: lint-frontend
 lint-frontend: node_modules
-	npx eslint --max-warnings=0 web_src/js build webpack.config.js
-	npx stylelint --max-warnings=0 web_src/less
+	@echo "running eslint..."
+	@npx eslint --max-warnings=0 web_src/js build webpack.config.js
+	@echo "running stylelint..."
+	@npx stylelint --max-warnings=0 web_src/less
 
 .PHONY: lint-backend
 lint-backend: golangci-lint revive vet
@@ -698,11 +700,11 @@ pr\#%: clean-all
 
 .PHONY: golangci-lint
 golangci-lint:
+	@echo "running golangci-lint..."
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.33.0; \
 	fi
-	@echo "running golangci-lint..."
 	@golangci-lint run --timeout 5m ./ $(addsuffix /...,$(GO_DIRS_OWN))
 
 .PHONY: docker

--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,10 @@ fmt:
 
 .PHONY: vet
 vet:
-	# Default vet
-	$(GO) vet $(GO_PACKAGES)
-	# Custom vet
-	$(GO) build -mod=vendor code.gitea.io/gitea-vet
-	$(GO) vet -vettool=gitea-vet $(GO_PACKAGES)
+	@echo "running go vet..."
+	@$(GO) vet $(GO_PACKAGES)
+	@$(GO) build -mod=vendor code.gitea.io/gitea-vet
+	@$(GO) vet -vettool=gitea-vet $(GO_PACKAGES)
 
 .PHONY: $(TAGS_EVIDENCE)
 $(TAGS_EVIDENCE):
@@ -703,7 +702,8 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.33.0; \
 	fi
-	golangci-lint run --timeout 5m ./ $(addsuffix /...,$(GO_DIRS_OWN))
+	@echo "running golangci-lint..."
+	@golangci-lint run --timeout 5m ./ $(addsuffix /...,$(GO_DIRS_OWN))
 
 .PHONY: docker
 docker:

--- a/build.go
+++ b/build.go
@@ -9,7 +9,6 @@ package main
 // Libraries that are included to vendor utilities used during build.
 // These libraries will not be included in a normal compilation.
 
-
 import (
 	// for lint
 	_ "github.com/mgechev/dots"

--- a/build.go
+++ b/build.go
@@ -9,6 +9,7 @@ package main
 // Libraries that are included to vendor utilities used during build.
 // These libraries will not be included in a normal compilation.
 
+
 import (
 	// for lint
 	_ "github.com/mgechev/dots"

--- a/build/generate-gitignores.go
+++ b/build/generate-gitignores.go
@@ -23,14 +23,14 @@ func main() {
 	var (
 		prefix         = "gitea-gitignore"
 		url            = "https://api.github.com/repos/github/gitignore/tarball"
-		githubApiToken = ""
+		githubAPIToken = ""
 		githubUsername = ""
 		destination    = ""
 	)
 
 	flag.StringVar(&destination, "dest", "options/gitignore/", "destination for the gitignores")
 	flag.StringVar(&githubUsername, "username", "", "github username")
-	flag.StringVar(&githubApiToken, "token", "", "github api token")
+	flag.StringVar(&githubAPIToken, "token", "", "github api token")
 	flag.Parse()
 
 	file, err := ioutil.TempFile(os.TempDir(), prefix)
@@ -46,8 +46,8 @@ func main() {
 		log.Fatalf("Failed to download archive. %s", err)
 	}
 
-	if len(githubApiToken) > 0 && len(githubUsername) > 0 {
-		req.SetBasicAuth(githubUsername, githubApiToken)
+	if len(githubAPIToken) > 0 && len(githubUsername) > 0 {
+		req.SetBasicAuth(githubUsername, githubAPIToken)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/build/generate-licenses.go
+++ b/build/generate-licenses.go
@@ -23,14 +23,14 @@ func main() {
 	var (
 		prefix         = "gitea-licenses"
 		url            = "https://api.github.com/repos/spdx/license-list-data/tarball"
-		githubApiToken = ""
+		githubAPIToken = ""
 		githubUsername = ""
 		destination    = ""
 	)
 
 	flag.StringVar(&destination, "dest", "options/license/", "destination for the licenses")
 	flag.StringVar(&githubUsername, "username", "", "github username")
-	flag.StringVar(&githubApiToken, "token", "", "github api token")
+	flag.StringVar(&githubAPIToken, "token", "", "github api token")
 	flag.Parse()
 
 	file, err := ioutil.TempFile(os.TempDir(), prefix)
@@ -46,8 +46,8 @@ func main() {
 		log.Fatalf("Failed to download archive. %s", err)
 	}
 
-	if len(githubApiToken) > 0 && len(githubUsername) > 0 {
-		req.SetBasicAuth(githubUsername, githubApiToken)
+	if len(githubAPIToken) > 0 && len(githubUsername) > 0 {
+		req.SetBasicAuth(githubUsername, githubAPIToken)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -227,7 +227,7 @@ func runExtractDo(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("%s: %s", destdir, err)
 	} else if !fi.IsDir() {
-		return fmt.Errorf("%s is not a directory.", destdir)
+		return fmt.Errorf("%s is not a directory", destdir)
 	}
 
 	fmt.Printf("Extracting to %s:\n", destdir)
@@ -324,9 +324,8 @@ func getPatterns(args []string) ([]glob.Glob, error) {
 	for i := range args {
 		if g, err := glob.Compile(args[i], '/'); err != nil {
 			return nil, fmt.Errorf("'%s': Invalid glob pattern: %v", args[i], err)
-		} else {
-			pat[i] = g
 		}
+		pat[i] = g
 	}
 	return pat, nil
 }

--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -322,7 +322,8 @@ func getPatterns(args []string) ([]glob.Glob, error) {
 	}
 	pat := make([]glob.Glob, len(args))
 	for i := range args {
-		if g, err := glob.Compile(args[i], '/'); err != nil {
+		g, err := glob.Compile(args[i], '/')
+		if err != nil {
 			return nil, fmt.Errorf("'%s': Invalid glob pattern: %v", args[i], err)
 		}
 		pat[i] = g

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -136,11 +136,13 @@ func AssetNames() []string {
 
 // AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
-	if f, err := Assets.Open("/" + name); err != nil {
+	f, err := Assets.Open("/" + name);
+	if err != nil {
 		return false, err
 	}
 	defer f.Close()
-	if fi, err := f.Stat(); err != nil {
+	fi, err := f.Stat()
+	if err != nil {
 		return false, err
 	}
 	return fi.IsDir(), nil

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -53,6 +53,7 @@ func Dir(name string) ([]string, error) {
 	return directories.AddAndGet(name, result), nil
 }
 
+// AssetDir returns the asset directory
 func AssetDir(dirName string) ([]string, error) {
 	d, err := Assets.Open(dirName)
 	if err != nil {
@@ -113,6 +114,7 @@ func fileFromDir(name string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// Asset returns a asset by path
 func Asset(name string) ([]byte, error) {
 	f, err := Assets.Open("/" + name)
 	if err != nil {
@@ -122,6 +124,7 @@ func Asset(name string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// AssetNames returns an array of asset paths
 func AssetNames() []string {
 	realFS := Assets.(vfsgen۰FS)
 	var results = make([]string, 0, len(realFS))
@@ -131,17 +134,16 @@ func AssetNames() []string {
 	return results
 }
 
+// AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
 	if f, err := Assets.Open("/" + name); err != nil {
 		return false, err
-	} else {
-		defer f.Close()
-		if fi, err := f.Stat(); err != nil {
-			return false, err
-		} else {
-			return fi.IsDir(), nil
-		}
 	}
+	defer f.Close()
+	if fi, err := f.Stat(); err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
 }
 
 // IsDynamic will return false when using embedded data (-tags bindata)

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -19,6 +19,7 @@ func Static(opts *Options) func(next http.Handler) http.Handler {
 	return opts.staticHandler("")
 }
 
+// Asset returns a asset by path
 func Asset(name string) ([]byte, error) {
 	f, err := Assets.Open("/" + name)
 	if err != nil {
@@ -28,6 +29,7 @@ func Asset(name string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// AssetNames returns an array of asset paths
 func AssetNames() []string {
 	realFS := Assets.(vfsgen۰FS)
 	var results = make([]string, 0, len(realFS))
@@ -37,15 +39,14 @@ func AssetNames() []string {
 	return results
 }
 
+// AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
 	if f, err := Assets.Open("/" + name); err != nil {
 		return false, err
-	} else {
-		defer f.Close()
-		if fi, err := f.Stat(); err != nil {
-			return false, err
-		} else {
-			return fi.IsDir(), nil
-		}
 	}
+	defer f.Close()
+	if fi, err := f.Stat(); err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
 }

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -41,11 +41,13 @@ func AssetNames() []string {
 
 // AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
-	if f, err := Assets.Open("/" + name); err != nil {
+	f, err := Assets.Open("/" + name);
+	if err != nil {
 		return false, err
 	}
 	defer f.Close()
-	if fi, err := f.Stat(); err != nil {
+	fi, err := f.Stat()
+	if err != nil {
 		return false, err
 	}
 	return fi.IsDir(), nil

--- a/modules/setting/database_sqlite.go
+++ b/modules/setting/database_sqlite.go
@@ -7,7 +7,7 @@
 package setting
 
 import (
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
 
 func init() {

--- a/modules/templates/static.go
+++ b/modules/templates/static.go
@@ -229,11 +229,13 @@ func AssetNames() []string {
 
 // AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
-	if f, err := Assets.Open("/" + name); err != nil {
+	f, err := Assets.Open("/" + name);
+	if err != nil {
 		return false, err
 	}
 	defer f.Close()
-	if fi, err := f.Stat(); err != nil {
+	fi, err := f.Stat()
+	if err != nil {
 		return false, err
 	}
 	return fi.IsDir(), nil

--- a/modules/templates/static.go
+++ b/modules/templates/static.go
@@ -28,15 +28,18 @@ var (
 	bodyTemplates    = template.New("")
 )
 
-type templateFileSystem struct {
+// TemplateFileSystem defines a array of TemplateFile
+type TemplateFileSystem struct {
 	files []macaron.TemplateFile
 }
 
-func (templates templateFileSystem) ListFiles() []macaron.TemplateFile {
+// ListFiles returns a list of files
+func (templates TemplateFileSystem) ListFiles() []macaron.TemplateFile {
 	return templates.files
 }
 
-func (templates templateFileSystem) Get(name string) (io.Reader, error) {
+// Get retrieves a file
+func (templates TemplateFileSystem) Get(name string) (io.Reader, error) {
 	for i := range templates.files {
 		if templates.files[i].Name()+templates.files[i].Ext() == name {
 			return bytes.NewReader(templates.files[i].Data()), nil
@@ -46,8 +49,9 @@ func (templates templateFileSystem) Get(name string) (io.Reader, error) {
 	return nil, fmt.Errorf("file '%s' not found", name)
 }
 
-func NewTemplateFileSystem() templateFileSystem {
-	fs := templateFileSystem{}
+// NewTemplateFileSystem creates a new template file system
+func NewTemplateFileSystem() TemplateFileSystem {
+	fs := TemplateFileSystem{}
 	fs.files = make([]macaron.TemplateFile, 0, 10)
 
 	for _, assetPath := range AssetNames() {
@@ -203,6 +207,7 @@ func Mailer() (*texttmpl.Template, *template.Template) {
 	return subjectTemplates, bodyTemplates
 }
 
+// Asset returns a asset by path
 func Asset(name string) ([]byte, error) {
 	f, err := Assets.Open("/" + name)
 	if err != nil {
@@ -212,6 +217,7 @@ func Asset(name string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// AssetNames returns an array of asset paths
 func AssetNames() []string {
 	realFS := Assets.(vfsgen۰FS)
 	var results = make([]string, 0, len(realFS))
@@ -221,15 +227,14 @@ func AssetNames() []string {
 	return results
 }
 
+// AssetIsDir checks if an asset is a directory
 func AssetIsDir(name string) (bool, error) {
 	if f, err := Assets.Open("/" + name); err != nil {
 		return false, err
-	} else {
-		defer f.Close()
-		if fi, err := f.Stat(); err != nil {
-			return false, err
-		} else {
-			return fi.IsDir(), nil
-		}
 	}
+	defer f.Close()
+	if fi, err := f.Stat(); err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
 }


### PR DESCRIPTION
Seems a major source of linter slowness is that it ventures into directories not containing any go files. Fix that by excluding the worst offending dirs.