### PR TITLE
Fix review request notification email links when external issue tracker is enabled

### DIFF
--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -104,7 +104,7 @@ func (m *mailNotifier) NotifyIssueChangeAssignee(doer *models.User, issue *model
 
 func (m *mailNotifier) NotifyPullReviewRequest(doer *models.User, issue *models.Issue, reviewer *models.User, isRequest bool, comment *models.Comment) {
 	if isRequest && doer.ID != reviewer.ID && reviewer.EmailNotifications() == models.EmailNotificationsEnabled {
-		ct := fmt.Sprintf("Requested to review #%d.", issue.Index)
+		ct := fmt.Sprintf("Requested to review %s.", issue.HTMLURL())
 		mailer.SendIssueAssignedMail(issue, doer, ct, comment, []string{reviewer.Email})
 	}
 }


### PR DESCRIPTION
Fixes #13720 

Use !%d issue notation instead of #%d in review request notification when external issue tracker is enabled.

Or would it be preferrable to just always use the !%d notation here?
I noticed in other places like the default squash commit messages the choice between ! and # is also done based on whether external issue tracker is enabled. So I did it here as well.