### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{go, tmpl, html}]
+[*.{go,tmpl,html}]
 indent_style = tab
 
 [Makefile]


### PR DESCRIPTION
These whitespaces introduced in #13698 seem to break my editorconfig plugin resulting in tab-indented files getting converted to spaces on save. Those globs are not matching `*.tmpl`, only `* .tmpl`.

cc: @6543 