### PR TITLE
Fix missing stylesheets on installation page

### DIFF
--- a/routers/routes/chi.go
+++ b/routers/routes/chi.go
@@ -230,6 +230,12 @@ func RegisterInstallRoute(c chi.Router) {
 	m := NewMacaron()
 	RegisterMacaronInstallRoute(m)
 
+	// We need at least one handler in chi so that it does not drop
+	// our middleware: https://github.com/go-gitea/gitea/issues/13725#issuecomment-735244395
+	c.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		m.ServeHTTP(w, req)
+	})
+
 	c.NotFound(func(w http.ResponseWriter, req *http.Request) {
 		m.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
When running gitea for the first time, the stylesheets for the
installation page are broken since the middleware that statically serves
stylesheets does not get executed by chi. This is because if no handlers
are registered in chi, it will drop all middleware.

This commit introduces a "dummy" handler to deal with that quirk.

Closes #13725

Thanks: Lunny Xiao <xiaolunwen@gmail.com> for finding the quirk