### PR TITLE
Push HEAD instead of master when initialising repositories (#13719)

### DIFF
--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -162,10 +162,10 @@ func initRepoCommit(tmpPath string, repo *models.Repository, u *models.User, def
 		defaultBranch = setting.Repository.DefaultBranch
 	}
 
-	if stdout, err := git.NewCommand("push", "origin", "master:"+defaultBranch).
+	if stdout, err := git.NewCommand("push", "origin", "HEAD:"+defaultBranch).
 		SetDescription(fmt.Sprintf("initRepoCommit (git push): %s", tmpPath)).
 		RunInDirWithEnv(tmpPath, models.InternalPushingEnvironment(u, repo)); err != nil {
-		log.Error("Failed to push back to master: Stdout: %s\nError: %v", stdout, err)
+		log.Error("Failed to push back to HEAD: Stdout: %s\nError: %v", stdout, err)
 		return fmt.Errorf("git push: %v", err)
 	}
 


### PR DESCRIPTION
Backport #13719 

* Push HEAD instead of master when initialising repositories

It is possible on modern gits to change the initial branch to something other than
master. This breaks initialising repositories because we assume that the initial
branch is going to be master unless specifically changed.

This PR simply bypasses this issue by pushing the HEAD rather than the master branch.

Signed-off-by: Andrew Thornton <art27@cantab.net>

* Update modules/repository/init.go

Co-authored-by: mrsdizzie <info@mrsdizzie.com>

Co-authored-by: mrsdizzie <info@mrsdizzie.com>
Co-authored-by: techknowlogick <techknowlogick@gitea.io>
