### PR TITLE
Update discord domain

### DIFF
--- a/templates/repo/settings/webhook/discord.tmpl
+++ b/templates/repo/settings/webhook/discord.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "discord"}}
-	<p>{{.i18n.Tr "repo.settings.add_discord_hook_desc" "https://discordapp.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_discord_hook_desc" "https://discord.com" | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/discord/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">


### PR DESCRIPTION
Update discord domain in webhook repository settings.

[Reference Article](https://support.discord.com/hc/en-us/articles/360042987951-Discordapp-com-is-now-Discord-com)
