### PR TITLE
Fix bogus http requests on diffs

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2118,6 +2118,7 @@ function initCodeView() {
   });
   $(document).on('click', '.blob-excerpt', async ({currentTarget}) => {
     const {url, query, anchor} = currentTarget.dataset;
+    if (!url) return;
     const blob = await $.get(`${url}?${query}&anchor=${anchor}`);
     currentTarget.closest('tr').outerHTML = blob;
   });


### PR DESCRIPTION
Not all .blob-excerpt elements have these data attributes resulting in bogus http request when expanding a diff and clicking into the expanded area. This prevents those.

Should backport to 1.13.

Fixes: https://github.com/go-gitea/gitea/issues/13759