### PR TITLE
Add class to page content to unify top margin

### DIFF
--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin edit authentication">
+<div class="page-content admin edit authentication">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/auth/list.tmpl
+++ b/templates/admin/auth/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin authentication">
+<div class="page-content admin authentication">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin new authentication">
+<div class="page-content admin new authentication">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin config">
+<div class="page-content admin config">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin dashboard">
+<div class="page-content admin dashboard">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/emails/list.tmpl
+++ b/templates/admin/emails/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin user">
+<div class="page-content admin user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/hook_new.tmpl
+++ b/templates/admin/hook_new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin new webhook">
+<div class="page-content admin new webhook">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/hooks.tmpl
+++ b/templates/admin/hooks.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin hooks">
+<div class="page-content admin hooks">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "repo/settings/webhook/list" .}}

--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin monitor">
+<div class="page-content admin monitor">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin notice">
+<div class="page-content admin notice">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin user">
+<div class="page-content admin user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/queue.tmpl
+++ b/templates/admin/queue.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin monitor">
+<div class="page-content admin monitor">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin user">
+<div class="page-content admin user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/repo/unadopted.tmpl
+++ b/templates/admin/repo/unadopted.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin user">
+<div class="page-content admin user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin edit user">
+<div class="page-content admin edit user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin user">
+<div class="page-content admin user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="admin new user">
+<div class="page-content admin new user">
 	{{template "admin/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="explore users">
+<div class="page-content explore users">
 	{{template "explore/navbar" .}}
 	<div class="ui container">
 		<form class="ui form ignore-dirty" style="max-width: 100%">

--- a/templates/explore/navbar.tmpl
+++ b/templates/explore/navbar.tmpl
@@ -1,4 +1,4 @@
-<div class="ui secondary pointing tabular top attached borderless stackable menu navbar">
+<div class="ui secondary pointing tabular top attached borderless stackable menu new-menu navbar">
 	<a class="{{if .PageIsExploreRepositories}}active{{end}} item" href="{{AppSubUrl}}/explore/repos">
 		{{svg "octicon-repo"}} {{.i18n.Tr "explore.repos"}}
 	</a>

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="explore users">
+<div class="page-content explore users">
 	{{template "explore/navbar" .}}
 	<div class="ui container">
 		{{template "explore/search" .}}

--- a/templates/explore/repos.tmpl
+++ b/templates/explore/repos.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="explore repositories">
+<div class="page-content explore repositories">
 	{{template "explore/navbar" .}}
 	<div class="ui container">
 		{{template "explore/repo_search" .}}

--- a/templates/explore/users.tmpl
+++ b/templates/explore/users.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="explore users">
+<div class="page-content explore users">
 	{{template "explore/navbar" .}}
 	<div class="ui container">
 		{{template "explore/search" .}}

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="home">
+<div class="page-content home">
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="sixteen wide center aligned centered column">
 			<div>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="install">
+<div class="page-content install">
 	<div class="ui middle very relaxed page grid">
 		<div class="sixteen wide center aligned centered column">
 			<h3 class="ui top attached header">

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization new org">
+<div class="page-content organization new org">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization profile mt-5">
+<div class="page-content organization profile">
 	{{/* overflow: auto is the clearfix - this avoids the image going beyond
 	the container where it is supposed to stay inside. */}}
 	<div class="ui container" style="overflow: auto">

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization members">
+<div class="page-content organization members">
 	{{template "org/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization settings delete">
+<div class="page-content organization settings delete">
 	{{template "org/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/org/settings/hook_new.tmpl
+++ b/templates/org/settings/hook_new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization settings new webhook">
+<div class="page-content organization settings new webhook">
 	{{template "org/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/org/settings/hooks.tmpl
+++ b/templates/org/settings/hooks.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization settings webhooks">
+<div class="page-content organization settings webhooks">
 	{{template "org/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/org/settings/labels.tmpl
+++ b/templates/org/settings/labels.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization settings labels">
+<div class="page-content organization settings labels">
 	{{template "org/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization settings options">
+<div class="page-content organization settings options">
 	{{template "org/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/org/team/members.tmpl
+++ b/templates/org/team/members.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization teams">
+<div class="page-content organization teams">
 	{{template "org/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization new team">
+<div class="page-content organization new team">
 	{{template "org/header" .}}
 	<div class="ui middle very relaxed page grid">
 		<div class="column">

--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization teams">
+<div class="page-content organization teams">
 	{{template "org/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/org/team/teams.tmpl
+++ b/templates/org/team/teams.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="organization teams">
+<div class="page-content organization teams">
 	{{template "org/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/post-install.tmpl
+++ b/templates/post-install.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="install">
+<div class="page-content install">
     <div class="ui container">
 		<div class="ui grid">
 			<div class="sixteen wide column content">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository commits">
+<div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<h2 class="ui header">{{.DateFrom}} - {{.DateUntil}}

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="ui repository branches">
+<div class="page-content ui repository branches">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository diff">
+<div class="page-content repository diff">
 	{{template "repo/header" .}}
 	<div class="ui container {{if .IsSplitStyle}}fluid padded{{end}}">
 		{{$class := ""}}

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository commits">
+<div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "repo/sub_menu" .}}

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new repo">
+<div class="page-content repository new repo">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository diff {{if .PageIsComparePull}}compare pull{{end}}">
+<div class="page-content repository diff {{if .PageIsComparePull}}compare pull{{end}}">
 	{{template "repo/header" .}}
 	<div class="ui container {{if .IsSplitStyle}}fluid padded{{end}}">
 

--- a/templates/repo/editor/delete.tmpl
+++ b/templates/repo/editor/delete.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file editor delete">
+<div class="page-content repository file editor delete">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file editor edit">
+<div class="page-content repository file editor edit">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/editor/upload.tmpl
+++ b/templates/repo/editor/upload.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file editor upload">
+<div class="page-content repository file editor upload">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository quickstart">
+<div class="page-content repository quickstart">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/repo/forks.tmpl
+++ b/templates/repo/forks.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository forks">
+<div class="page-content repository forks">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<h2 class="ui dividing header">

--- a/templates/repo/graph.tmpl
+++ b/templates/repo/graph.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository commits">
+<div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div id="git-graph-container" class="ui segment{{if eq .Mode "monochrome"}} monochrome{{end}}">

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file list {{if .IsBlame}}blame{{end}}">
+<div class="page-content repository file list {{if .IsBlame}}blame{{end}}">
 	{{template "repo/header" .}}
 	<div class="ui container {{if .IsBlame}}fluid padded{{end}}">
 		{{template "base/alert" .}}

--- a/templates/repo/issue/choose.tmpl
+++ b/templates/repo/issue/choose.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new issue">
+<div class="page-content repository new issue">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/issue/labels.tmpl
+++ b/templates/repo/issue/labels.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository labels">
+<div class="page-content repository labels">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository">
+<div class="page-content repository">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui three column stackable grid">

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository">
+<div class="page-content repository">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui three column stackable grid">

--- a/templates/repo/issue/milestone_new.tmpl
+++ b/templates/repo/issue/milestone_new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new milestone">
+<div class="page-content repository new milestone">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository milestones">
+<div class="page-content repository milestones">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/issue/new.tmpl
+++ b/templates/repo/issue/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new issue">
+<div class="page-content repository new issue">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/issue/view.tmpl
+++ b/templates/repo/issue/view.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository view issue pull">
+<div class="page-content repository view issue pull">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui two column stackable grid">

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new migrate">
+<div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new migrate">
+<div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new migrate">
+<div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new migrate">
+<div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/migrate/migrate.tmpl
+++ b/templates/repo/migrate/migrate.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new migrate">
+<div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<div class="ui three stackable cards">

--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository quickstart">
+<div class="page-content repository quickstart">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui grid">

--- a/templates/repo/projects/list.tmpl
+++ b/templates/repo/projects/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository milestones">
+<div class="page-content repository milestones">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/projects/new.tmpl
+++ b/templates/repo/projects/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new milestone">
+<div class="page-content repository new milestone">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/projects/view.tmpl
+++ b/templates/repo/projects/view.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository">
+<div class="page-content repository">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui three column stackable grid">

--- a/templates/repo/pulls/commits.tmpl
+++ b/templates/repo/pulls/commits.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository view issue pull commits">
+<div class="page-content repository view issue pull commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="navbar">

--- a/templates/repo/pulls/files.tmpl
+++ b/templates/repo/pulls/files.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository view issue pull files diff">
+<div class="page-content repository view issue pull files diff">
 	{{template "repo/header" .}}
 	<div class="ui container {{if .IsSplitStyle}}fluid padded{{end}}">
 		<div class="navbar">

--- a/templates/repo/pulls/fork.tmpl
+++ b/templates/repo/pulls/fork.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new fork">
+<div class="page-content repository new fork">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository release">
+<div class="page-content repository release">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new release">
+<div class="page-content repository new release">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<h2 class="ui dividing header">

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository file list">
+<div class="page-content repository file list">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui repo-search">

--- a/templates/repo/settings/branches.tmpl
+++ b/templates/repo/settings/branches.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings edit">
+<div class="page-content repository settings edit">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings collaboration">
+<div class="page-content repository settings collaboration">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/deploy_keys.tmpl
+++ b/templates/repo/settings/deploy_keys.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings">
+<div class="page-content repository settings">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/githook_edit.tmpl
+++ b/templates/repo/settings/githook_edit.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings edit githook">
+<div class="page-content repository settings edit githook">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/githooks.tmpl
+++ b/templates/repo/settings/githooks.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings githooks">
+<div class="page-content repository settings githooks">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings lfs">
+<div class="page-content repository settings lfs">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/lfs_file.tmpl
+++ b/templates/repo/settings/lfs_file.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings lfs">
+<div class="page-content repository settings lfs">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container repository file list">

--- a/templates/repo/settings/lfs_file_find.tmpl
+++ b/templates/repo/settings/lfs_file_find.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings lfs">
+<div class="page-content repository settings lfs">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container repository file list">

--- a/templates/repo/settings/lfs_locks.tmpl
+++ b/templates/repo/settings/lfs_locks.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings lfs">
+<div class="page-content repository settings lfs">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container repository file list">

--- a/templates/repo/settings/lfs_pointers.tmpl
+++ b/templates/repo/settings/lfs_pointers.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings lfs">
+<div class="page-content repository settings lfs">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings options">
+<div class="page-content repository settings options">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings branches">
+<div class="page-content repository settings branches">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/webhook/base.tmpl
+++ b/templates/repo/settings/webhook/base.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings webhooks">
+<div class="page-content repository settings webhooks">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/settings/webhook/new.tmpl
+++ b/templates/repo/settings/webhook/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository settings new webhook">
+<div class="page-content repository settings new webhook">
 	{{template "repo/header" .}}
 	{{template "repo/settings/navbar" .}}
 	<div class="ui container">

--- a/templates/repo/watchers.tmpl
+++ b/templates/repo/watchers.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository watchers">
+<div class="page-content repository watchers">
 	{{template "repo/header" .}}
 	{{template "repo/user_cards" .}}
 </div>

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository wiki new">
+<div class="page-content repository wiki new">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository wiki pages">
+<div class="page-content repository wiki pages">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<h2 class="ui header df ac sb">

--- a/templates/repo/wiki/revision.tmpl
+++ b/templates/repo/wiki/revision.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository wiki revisions">
+<div class="page-content repository wiki revisions">
 	{{template "repo/header" .}}
 	{{ $title := .title}}
 	<div class="ui container">

--- a/templates/repo/wiki/start.tmpl
+++ b/templates/repo/wiki/start.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository wiki start">
+<div class="page-content repository wiki start">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<div class="ui center segment">

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository wiki view">
+<div class="page-content repository wiki view">
 	{{template "repo/header" .}}
 	{{ $title := .title}}
 	<div class="ui container">

--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -1,10 +1,12 @@
 {{template "base/head" .}}
-{{if .IsRepo}}<div class="repository">{{template "repo/header" .}}</div>{{end}}
-<div class="ui container center">
-	<p style="margin-top: 100px"><img class="ui centered image" src="{{StaticUrlPrefix}}/img/404.png" alt="404"/></p>
-	<div class="ui divider"></div>
-	<br>
-	<p>{{.i18n.Tr "error404" | Safe}}
-	{{if .ShowFooterVersion}}<p>{{.i18n.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
+<div class="page-content ui container center {{if .IsRepo}}repository{{end}}">
+	{{if .IsRepo}}{{template "repo/header" .}}{{end}}
+	<div class="ui container center">
+		<p style="margin-top: 100px"><img class="ui centered image" src="{{StaticUrlPrefix}}/img/404.png" alt="404"/></p>
+		<div class="ui divider"></div>
+		<br>
+		<p>{{.i18n.Tr "error404" | Safe}}
+		{{if .ShowFooterVersion}}<p>{{.i18n.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
+	</div>
 </div>
 {{template "base/footer" .}}

--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="ui container center">
+<div class="page-content ui container center">
 	<p style="margin-top: 100px"><img class="ui centered image" src="{{StaticUrlPrefix}}/img/500.png" alt="500"/></p>
 	<div class="ui divider"></div>
 	<br>

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user activate">
+<div class="page-content user activate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/activate" method="post">

--- a/templates/user/auth/change_passwd.tmpl
+++ b/templates/user/auth/change_passwd.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin{{if .LinkAccountMode}} icon{{end}}">
+<div class="page-content user signin{{if .LinkAccountMode}} icon{{end}}">
 	<div class="ui container">
 		{{template "user/auth/change_passwd_inner" .}}
 	</div>

--- a/templates/user/auth/finalize_openid.tmpl
+++ b/templates/user/auth/finalize_openid.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin">
+<div class="page-content user signin">
 	<div class="ui container">
 		<div class="ui grid">
 			{{template "user/auth/finalize_openid_navbar" .}}

--- a/templates/user/auth/forgot_passwd.tmpl
+++ b/templates/user/auth/forgot_passwd.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user forgot password">
+<div class="page-content user forgot password">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">

--- a/templates/user/auth/grant.tmpl
+++ b/templates/user/auth/grant.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="ui one column stackable center aligned page grid oauth2-authorize-application-box">
+<div class="page-content ui one column stackable center aligned page grid oauth2-authorize-application-box">
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">
 			<h3 class="ui top attached header">

--- a/templates/user/auth/grant_error.tmpl
+++ b/templates/user/auth/grant_error.tmpl
@@ -1,6 +1,6 @@
 {{template "base/head" .}}
-{{if .IsRepo}}<div class="repository">{{template "repo/header" .}}</div>{{end}}
-<div class="ui one column stackable center aligned page grid oauth2-authorize-application-box">
+<div class="page-content ui one column stackable center aligned page grid oauth2-authorize-application-box {{if .IsRepo}}repository{{end}}">
+	{{if .IsRepo}}{{template "repo/header" .}}{{end}}
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">
 			<h1 class="ui top attached header">

--- a/templates/user/auth/link_account.tmpl
+++ b/templates/user/auth/link_account.tmpl
@@ -1,6 +1,5 @@
 {{template "base/head" .}}
-
-<div class="user link-account">
+<div class="page-content user link-account">
 	<div class="ui secondary pointing tabular top attached borderless menu new-menu navbar">
 		<div class="new-menu-inner">
 			<!-- TODO handle .ShowRegistrationButton once other login bugs are fixed -->

--- a/templates/user/auth/prohibit_login.tmpl
+++ b/templates/user/auth/prohibit_login.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user activate">
+<div class="page-content user activate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form">

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user reset password">
+<div class="page-content user reset password">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">

--- a/templates/user/auth/signin.tmpl
+++ b/templates/user/auth/signin.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin{{if .LinkAccountMode}} icon{{end}}">
+<div class="page-content user signin{{if .LinkAccountMode}} icon{{end}}">
 	{{template "user/auth/signin_navbar" .}}
 	<div class="ui middle very relaxed page grid">
 		<div class="ui container column">

--- a/templates/user/auth/signin_navbar.tmpl
+++ b/templates/user/auth/signin_navbar.tmpl
@@ -18,6 +18,4 @@
 		{{end}}
 	</div>
 </div>
-{{else}}
-	<div class="mt-4"></div>
 {{end}}

--- a/templates/user/auth/signin_openid.tmpl
+++ b/templates/user/auth/signin_openid.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin openid">
+<div class="page-content user signin openid">
 	{{template "user/auth/signin_navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/auth/signup.tmpl
+++ b/templates/user/auth/signup.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin{{if .LinkAccountMode}} icon{{end}}">
+<div class="page-content user signin{{if .LinkAccountMode}} icon{{end}}">
 	<div class="ui middle very relaxed page grid">
 		{{template "user/auth/signup_inner" .}}
 	</div>

--- a/templates/user/auth/signup_openid_connect.tmpl
+++ b/templates/user/auth/signup_openid_connect.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signup">
+<div class="page-content user signup">
 	{{template "user/auth/signup_openid_navbar" .}}
 	<div class="ui container">
 				{{template "base/alert" .}}

--- a/templates/user/auth/signup_openid_register.tmpl
+++ b/templates/user/auth/signup_openid_register.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signup">
+<div class="page-content user signup">
 	{{template "user/auth/signup_openid_navbar" .}}
 	<div class="ui container">
 				{{template "base/alert" .}}

--- a/templates/user/auth/twofa.tmpl
+++ b/templates/user/auth/twofa.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin">
+<div class="page-content user signin">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/user/auth/twofa_scratch.tmpl
+++ b/templates/user/auth/twofa_scratch.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin">
+<div class="page-content user signin">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/user/auth/u2f.tmpl
+++ b/templates/user/auth/u2f.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user signin">
+<div class="page-content user signin">
 	<div class="ui middle centered very relaxed page grid">
 		<div class="column">
 			<h3 class="ui top attached header">

--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="dashboard feeds">
+<div class="page-content dashboard feeds">
 	{{template "user/dashboard/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="dashboard issues">
+<div class="page-content dashboard issues">
 	{{template "user/dashboard/navbar" .}}
 	<div class="ui container">
 		<div class="ui stackable grid">

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="dashboard issues repository milestones">
+<div class="page-content dashboard issues repository milestones">
 	{{template "user/dashboard/navbar" .}}
 	<div class="ui container">
 		<div class="ui stackable grid">

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -1,4 +1,4 @@
-<div class="user notification" id="notification_div" data-params="{{.Page.GetParams}}">
+<div class="page-content user notification" id="notification_div" data-params="{{.Page.GetParams}}">
 	<div class="ui container">
 		<h1 class="ui dividing header">{{.i18n.Tr "notification.notifications"}}</h1>
         <div class="ui top attached tabular menu">

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user profile mt-5">
+<div class="page-content user profile">
 	<div class="ui container">
 		<div class="ui stackable grid">
 			<div class="ui five wide column">

--- a/templates/user/project.tmpl
+++ b/templates/user/project.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="repository new repo">
+<div class="page-content repository new repo">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
 			<form class="ui form" action="{{.Link}}" method="post">

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings account">
+<div class="page-content user settings account">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings applications">
+<div class="page-content user settings applications">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/applications_oauth2_edit.tmpl
+++ b/templates/user/settings/applications_oauth2_edit.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings applications">
+<div class="page-content user settings applications">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/keys.tmpl
+++ b/templates/user/settings/keys.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings sshkeys">
+<div class="page-content user settings sshkeys">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/organization.tmpl
+++ b/templates/user/settings/organization.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings organization">
+<div class="page-content user settings organization">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings profile">
+<div class="page-content user settings profile">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings repos">
+<div class="page-content user settings repos">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/security.tmpl
+++ b/templates/user/settings/security.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings security">
+<div class="page-content user settings security">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/templates/user/settings/twofa_enroll.tmpl
+++ b/templates/user/settings/twofa_enroll.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div class="user settings twofa">
+<div class="page-content user settings twofa">
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}

--- a/web_src/less/_admin.less
+++ b/web_src/less/_admin.less
@@ -1,8 +1,4 @@
 .admin {
-  &.notice {
-    padding-top: 15px;
-  }
-
   .table.segment {
     padding: 0;
     font-size: 13px;

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -525,6 +525,10 @@ a.muted:hover,
   height: auto;
 }
 
+.ui.loading.segment::before {
+  background: none;
+}
+
 .ui.loading.loading.input > i.icon svg {
   visibility: hidden;
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -238,6 +238,16 @@ a.muted:hover,
   color: var(--color-text-light-2);
 }
 
+.page-content {
+  margin-top: 15px;
+}
+
+.page-content .header-wrapper,
+.page-content .new-menu {
+  margin-top: -15px !important;
+  padding-top: 15px !important;
+}
+
 .ui.input.focus > input,
 .ui.input > input:focus {
   border-color: var(--color-primary);
@@ -1101,7 +1111,6 @@ footer {
 }
 
 .ui.menu.new-menu {
-  padding-top: 15px;
   margin-bottom: 15px;
   background: var(--color-navbar);
   border-bottom: 1px solid var(--color-secondary) !important;

--- a/web_src/less/_dashboard.less
+++ b/web_src/less/_dashboard.less
@@ -71,7 +71,6 @@
     width: 100vw;
     padding-left: .5rem;
     padding-right: .5rem;
-    padding-top: 15px;
     .org-visibility .label {
       margin-left: 5px;
     }

--- a/web_src/less/_explore.less
+++ b/web_src/less/_explore.less
@@ -1,7 +1,6 @@
 .explore {
   .navbar {
     justify-content: center;
-    padding-top: 15px !important;
     margin-bottom: 15px !important;
     background-color: var(--color-navbar) !important;
     border-width: 1px !important;

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -143,7 +143,6 @@
 
   .header-wrapper {
     background-color: var(--color-navbar);
-    padding-top: 15px;
 
     .ui.tabs.divider {
       border-bottom: 0;


### PR DESCRIPTION
Previously pages would individually set this margin but some didn't so content would stick to the header without any space. Resolve this by adding a new class that is added on all pages. The only place where we remove this margin again is on the pages with menu or wrapper in the header.

Before:
<img width="511" alt="Screen Shot 2020-11-30 at 20 43 12" src="https://user-images.githubusercontent.com/115237/100656265-b6108880-334c-11eb-9a33-e3c093b21f43.png">

After:
<img width="493" alt="Screen Shot 2020-11-30 at 20 43 06" src="https://user-images.githubusercontent.com/115237/100656261-b577f200-334c-11eb-865f-ce30f049546d.png">
