### PR TITLE
Flip RUN_MODE detection in router

### DIFF
--- a/routers/init.go
+++ b/routers/init.go
@@ -43,13 +43,15 @@ import (
 )
 
 func checkRunMode() {
-	switch setting.Cfg.Section("").Key("RUN_MODE").String() {
-	case "prod":
+	switch setting.RunMode {
+	case "dev":
+		git.Debug = true
+	case "test":
+		git.Debug = true
+	default:
 		macaron.Env = macaron.PROD
 		macaron.ColorLog = false
 		setting.ProdMode = true
-	default:
-		git.Debug = true
 	}
 	log.Info("Run Mode: %s", strings.Title(macaron.Env))
 }


### PR DESCRIPTION
Missed that part in https://github.com/go-gitea/gitea/pull/13765. It's already in [the 1.13 backport](https://github.com/go-gitea/gitea/pull/13767) so this forward-ports that change again.