### PR TITLE
Expose default theme in meta and API

### DIFF
--- a/modules/structs/settings.go
+++ b/modules/structs/settings.go
@@ -12,6 +12,7 @@ type GeneralRepoSettings struct {
 
 // GeneralUISettings contains global ui settings exposed by API
 type GeneralUISettings struct {
+	DefaultTheme     string   `json:"default_theme"`
 	AllowedReactions []string `json:"allowed_reactions"`
 }
 

--- a/routers/api/v1/settings/settings.go
+++ b/routers/api/v1/settings/settings.go
@@ -23,6 +23,7 @@ func GetGeneralUISettings(ctx *context.APIContext) {
 	//   "200":
 	//     "$ref": "#/responses/GeneralUISettings"
 	ctx.JSON(http.StatusOK, api.GeneralUISettings{
+		DefaultTheme:     setting.UI.DefaultTheme,
 		AllowedReactions: setting.UI.Reactions,
 	})
 }

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -7,6 +7,7 @@
 	<title>{{if .Title}}{{.Title | RenderEmojiPlain}} - {{end}} {{if .Repository.Name}}{{.Repository.Name}} - {{end}}{{AppName}} </title>
 	<link rel="manifest" href="{{AppSubUrl}}/manifest.json" crossorigin="use-credentials">
 	<meta name="theme-color" content="{{ThemeColorMetaTag}}">
+	<meta name="default-theme" content="{{DefaultTheme}}" />
 	<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}{{MetaAuthor}}{{end}}" />
 	<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}{{MetaDescription}}{{end}}" />
 	<meta name="keywords" content="{{MetaKeywords}}">

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -13523,6 +13523,10 @@
             "type": "string"
           },
           "x-go-name": "AllowedReactions"
+        },
+        "default_theme": {
+          "type": "string",
+          "x-go-name": "DefaultTheme"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"


### PR DESCRIPTION
As title, this was requested in Discord primarily for a dark reader to be able to check the DOM for the default theme.

As well, this adds the default theme to the UI API.