### PR TITLE
When reinitialising DBConfig reset the database use flags (#13796)

### DIFF
--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -62,6 +62,11 @@ func InitDBConfig() {
 	sec := Cfg.Section("database")
 	Database.Type = sec.Key("DB_TYPE").String()
 	defaultCharset := "utf8"
+	Database.UseMySQL = false
+	Database.UseSQLite3 = false
+	Database.UsePostgreSQL = false
+	Database.UseMSSQL = false
+
 	switch Database.Type {
 	case "sqlite3":
 		Database.UseSQLite3 = true


### PR DESCRIPTION
Backport #13796

One perennial issue is users running the install page,
changing the database dialect and then suffering with issues

This PR simply resets all of the database.Use flags on
initDBConfig. This should prevent this issue from occuring.

Fix #13788
Fix #5480

Signed-off-by: Andrew Thornton <art27@cantab.net>
