### PR TITLE
Update font stack to bootstrap's latest

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1,10 +1,10 @@
 :root {
   /* documented customizable variables */
-  --fonts-proportional: -apple-system, "BlinkMacSystemFont", system-ui, "Segoe UI", "Roboto", "Helvetica", "Arial";
-  --fonts-monospace: "SF Mono", "Consolas", "Menlo", "Liberation Mono", "Monaco", "Lucida Console", monospace;
-  --fonts-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji Mozilla";
+  --fonts-proportional: system-ui, -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", "Liberation Sans", sans-serif;
+  --fonts-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
+  --fonts-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", "Twemoji Mozilla";
   /* other variables */
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), sans-serif;
+  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji);
   --border-radius: .28571429rem;
   --color-primary: #4183c4;
   --color-primary-dark-1: #3876b3;


### PR DESCRIPTION
Update to latest Bootstrap font stack [1].

Should fix https://github.com/go-gitea/gitea/issues/13784.

[1] https://github.com/twbs/bootstrap/blob/bf3c4d0b6891c21377e6b1fb7962f5fbf198325f/scss/_variables.scss#L396