### PR TITLE
Fix mermaid chart size

### DIFF
--- a/web_src/less/markdown/mermaid.less
+++ b/web_src/less/markdown/mermaid.less
@@ -3,8 +3,7 @@
   justify-content: center;
   align-items: center;
   padding: 1rem;
-  margin: 1rem 0;
-  max-width: 100% !important;
+  margin: 1rem auto;
   height: auto;
 }
 

--- a/web_src/less/markdown/mermaid.less
+++ b/web_src/less/markdown/mermaid.less
@@ -4,6 +4,8 @@
   align-items: center;
   padding: 1rem;
   margin: 1rem 0;
+  max-width: 100% !important;
+  height: auto;
 }
 
 /* mermaid's errorRenderer seems to unavoidably spew stuff into <body>, hide it */


### PR DESCRIPTION
Seems like one of the recent updates to the module unexpectedly shrunk these charts, bring them back up to actual width.

Before:

<img width="855" alt="Screen Shot 2020-12-05 at 22 28 08" src="https://user-images.githubusercontent.com/115237/101265767-57328100-3749-11eb-9144-14dc0172154c.png">

After:

<img width="861" alt="image" src="https://user-images.githubusercontent.com/115237/101265828-ee97d400-3749-11eb-8d0f-3f4cd15bb6cf.png">

