### PR TITLE
Add link to shop in docs

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -48,8 +48,8 @@ menu:
       url: https://blog.gitea.io/
       weight: 30
       pre: rss
-    - name: Code
-      url: https://code.gitea.io/
+    - name: Shop
+      url: https://shop.gitea.io/
       weight: 40
       pre: code
     - name: Translation


### PR DESCRIPTION
Replaced link to code.gitea.io as that subdomain isn't meant for human consumption, but rather for our vanity go import URLs
Only replaced link for english, open to adding links for other languages if anyone is able/willing to add them
