### PR TITLE
Fix margin between icon and repo name on dashboard

### DIFF
--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -104,7 +104,7 @@
 						<a class="df ac sb" :href="suburl + '/' + repo.full_name">
 							<div class="f1 df ac">
 								<component v-bind:is="repoIcon(repo)" size="16"></component>
-								<strong class="text truncate item-name">${repo.full_name}</strong>
+								<strong class="text truncate item-name ml-2">${repo.full_name}</strong>
 								<i v-if="repo.archived" class="archive icon archived-icon"></i>
 							</div>
 							<div class="text light grey df ac">


### PR DESCRIPTION
Before:
![firefox_2020-12-06_18-49-32](https://user-images.githubusercontent.com/1447794/101288107-024c4480-37f5-11eb-81c8-e10c828e0575.png)

After:
![firefox_2020-12-06_18-49-11](https://user-images.githubusercontent.com/1447794/101288105-01b3ae00-37f5-11eb-98b4-fa247c4dbb22.png)

The same margin (2px) is applied on Organizations tab as `mr-2` but on icon itself; I haven't figured out how to apply it on Repository tab due to usage of dynamic Vue components there.