### PR TITLE
issue #12450: return original URL in `original_url` JSON field

### DIFF
--- a/modules/convert/repository.go
+++ b/modules/convert/repository.go
@@ -108,6 +108,7 @@ func innerToRepo(repo *models.Repository, mode models.AccessMode, isParent bool)
 		HTMLURL:                   repo.HTMLURL(),
 		SSHURL:                    cloneLink.SSH,
 		CloneURL:                  cloneLink.HTTPS,
+		OriginalURL:               repo.SanitizedOriginalURL(),
 		Website:                   repo.Website,
 		Stars:                     repo.NumStars,
 		Forks:                     repo.NumForks,


### PR DESCRIPTION
As related in [issue #12450](https://github.com/go-gitea/gitea/issues/12450), the field `original_url` is always empty when requesting the API route **GET** `repos/{orga}/{project}`, even when the project is a mirror repo.

In such case I would excpect to get in `original_url` the URL of the _origin_ repository used to initiate the project.

This PR is my attempt to fix this :
```shell
curl -s -X GET "http://127.0.0.1:3000/api/v1/repos/rico/input-event-daemon?access_token=$TOKKEN" -H "accept: application/json" | jq
{
  "id": 1,
...
  "html_url": "http://localhost:3000/rico/input-event-daemon",
  "ssh_url": "rico@localhost:rico/input-event-daemon.git",
  "clone_url": "http://localhost:3000/rico/input-event-daemon.git",
  "original_url": "https://github.com/eric-belhomme/input-event-daemon.git",
 ...
}
```

I tested my patch with **mysql** and **sqlite3** database backends with no errors.