### PR TITLE
Add cloudron to img-src CSP

### DIFF
--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; img-src 'self' https://cloudron.io; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
   X-Frame-Options: DENY
   X-Xss-Protection: 1; mode=block
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
As title, it's currently broken.

![cloudron1](https://user-images.githubusercontent.com/42128690/101366742-f26f4780-386a-11eb-80be-305974f8111c.png)
![cloudron2](https://user-images.githubusercontent.com/42128690/101366745-f307de00-386a-11eb-90b0-8bb05c678963.png)
