### PR TITLE
Add wildcard for cloudron CSP

### DIFF
--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -87,7 +87,7 @@ To enable Gitea to run as a service, run `sysrc gitea_enable=YES` and start it w
 Gitea is available as a 1-click install on [Cloudron](https://cloudron.io).
 Cloudron makes it easy to run apps like Gitea on your server and keep them up-to-date and secure.
 
-[![Install](https://cloudron.io/img/button.svg)](https://cloudron.io/button.html?app=io.gitea.cloudronapp)
+[![Install](https://www.cloudron.io/img/button.svg)](https://www.cloudron.io/button.html?app=io.gitea.cloudronapp)
 
 The Gitea package is maintained [here](https://git.cloudron.io/cloudron/gitea-app).
 

--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; img-src 'self' https://cloudron.io; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; img-src 'self' https://*.cloudron.io; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
   X-Frame-Options: DENY
   X-Xss-Protection: 1; mode=block
   X-Content-Type-Options: nosniff

--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; img-src 'self' https://*.cloudron.io; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; img-src 'self' https://www.cloudron.io; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com
   X-Frame-Options: DENY
   X-Xss-Protection: 1; mode=block
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
> Ughhh, https://cloudron.io/img/button.svg redirects to https://www.cloudron.io/img/button.svg, so it's still busted. 😓

As far as I understand CSP directives, this PR should work for both.