### PR TITLE
Allow 20 characters for "View [organization]" button

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -59,7 +59,7 @@
 				{{end}}
 				<div class="item">
 					<a class="ui blue basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
-						{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 10)}}
+						{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 20)}}
 					</a>
 				</div>
 			</div>


### PR DESCRIPTION
In the "View [organization]" button on the dashboard, the organization name is currently shortened to 10 chars.
This is a bit too limited. In all other places in the code where the name is shortened this was already set to 20 instead of 10.

![image](https://user-images.githubusercontent.com/2212615/101528850-18dad300-3990-11eb-9e6b-302e8bd10c90.png)

