### PR TITLE
Don't show dashboard links for globally disabled repo units

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -46,16 +46,20 @@
 				<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/dashboard">
 					{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
 				</a>
+				{{if not .UnitIssuesGlobalDisabled}}
 				<a class="{{if .PageIsIssues}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/issues">
 					{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
 				</a>
+				{{end}}
+				{{if not .UnitPullsGlobalDisabled}}
 				<a class="{{if .PageIsPulls}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/pulls">
 					{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
 				</a>
-				{{if .ShowMilestonesDashboardPage}}
-					<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/milestones">
-						{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
-					</a>
+				{{end}}
+				{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
+				<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{AppSubUrl}}/org/{{.ContextUser.Name}}/milestones">
+					{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
+				</a>
 				{{end}}
 				<div class="item">
 					<a class="ui blue basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>


### PR DESCRIPTION
This applies the same checks from `base/head_navbar.tmpl` to `user/dashboard/navbar.tmpl` so no links are shown for globally disabled repo units