### PR TITLE
Move diff split code into own template file

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -118,57 +118,7 @@
 											{{template "repo/diff/image_diff" dict "file" . "root" $}}
 										{{else}}
 											{{if $.IsSplitStyle}}
-												{{range $j, $section := $file.Sections}}
-													{{range $k, $line := $section.Lines}}
-														<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
-															{{if eq .GetType 4}}
-																<td class="lines-num lines-num-old">
-																	{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold-down"}}
-																		</a>
-																	{{end}}
-																	{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold-up"}}
-																		</a>
-																	{{end}}
-																	{{if eq $line.GetExpandDirection 2}}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold"}}
-																		</a>
-																	{{end}}
-																</td>
-																<td colspan="5" class="lines-code lines-code-old "><code class="code-inner">{{$section.GetComputedInlineDiffFor $line}}</span></td>
-															{{else}}
-																<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
-																<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-old halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui primary button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
-																<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
-																<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-new halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui primary button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
-															{{end}}
-														</tr>
-														{{if gt (len $line.Comments) 0}}
-															<tr class="add-code-comment">
-																<td class="lines-num"></td>
-																<td class="lines-type-marker"></td>
-																<td class="add-comment-left">
-																	{{if eq $line.GetCommentSide "previous"}}
-																		{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
-																	{{end}}
-																</td>
-																<td class="lines-num"></td>
-																<td class="lines-type-marker"></td>
-																<td class="add-comment-right">
-																	{{if eq $line.GetCommentSide "proposed"}}
-																		{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
-																	{{end}}
-																</td>
-															</tr>
-														{{end}}
-													{{end}}
-												{{end}}
+												{{template "repo/diff/section_split" dict "file" . "root" $}}
 											{{else}}
 												{{template "repo/diff/section_unified" dict "file" . "root" $}}
 											{{end}}

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -36,14 +36,14 @@
 				<td class="lines-type-marker"></td>
 				<td class="add-comment-left">
 					{{if eq $line.GetCommentSide "previous"}}
-						{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
+						{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
 					{{end}}
 				</td>
 				<td class="lines-num"></td>
 				<td class="lines-type-marker"></td>
 				<td class="add-comment-right">
 					{{if eq $line.GetCommentSide "proposed"}}
-						{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
+						{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
 					{{end}}
 				</td>
 			</tr>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -1,0 +1,52 @@
+{{$file := .file}}
+{{range $j, $section := $file.Sections}}
+	{{range $k, $line := $section.Lines}}
+		<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
+			{{if eq .GetType 4}}
+				<td class="lines-num lines-num-old">
+					{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
+						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+							{{svg "octicon-fold-down"}}
+						</a>
+					{{end}}
+					{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
+						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+							{{svg "octicon-fold-up"}}
+						</a>
+					{{end}}
+					{{if eq $line.GetExpandDirection 2}}
+						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+							{{svg "octicon-fold"}}
+						</a>
+					{{end}}
+				</td>
+				<td colspan="5" class="lines-code lines-code-old "><code class="code-inner">{{$section.GetComputedInlineDiffFor $line}}</span></td>
+			{{else}}
+				<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
+				<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+				<td class="lines-code lines-code-old halfwidth">{{if and $.root.SignedUserID $line.CanComment $.root.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui primary button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
+				<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
+				<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+				<td class="lines-code lines-code-new halfwidth">{{if and $.root.SignedUserID $line.CanComment $.root.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui primary button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
+			{{end}}
+		</tr>
+		{{if gt (len $line.Comments) 0}}
+			<tr class="add-code-comment">
+				<td class="lines-num"></td>
+				<td class="lines-type-marker"></td>
+				<td class="add-comment-left">
+					{{if eq $line.GetCommentSide "previous"}}
+						{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
+					{{end}}
+				</td>
+				<td class="lines-num"></td>
+				<td class="lines-type-marker"></td>
+				<td class="add-comment-right">
+					{{if eq $line.GetCommentSide "proposed"}}
+						{{template "repo/diff/conversation" mergeinto $ "comments" $line.Comments}}
+					{{end}}
+				</td>
+			</tr>
+		{{end}}
+	{{end}}
+{{end}}


### PR DESCRIPTION
Separate split diff view same as unified already is. Mainly because I'm working on a separate PR with this change and merge conflicts for each change to box.tmpl are annoying and I'm worried about breaking something subtle while trying to resolve them.