### PR TITLE
Better vertical align of buttons in headers

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1679,11 +1679,6 @@ a.ui.basic.label:hover {
   visibility: hidden;
 }
 
-/* prevent stacking context issue on webhook dropdown */
-.ui.segment {
-  position: static;
-}
-
 .ui.segment,
 .ui.segments,
 .ui.attached.segment {
@@ -1712,8 +1707,11 @@ a.ui.basic.label:hover {
 .ui.attached.header .right {
   position: absolute;
   right: .78571429rem;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
+  height: 30px;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 /* https://github.com/go-gitea/gitea/issues/10210 */


### PR DESCRIPTION
The previous method used `transform` which formed a CSS stacking context which caused issues with dropdowns appearing behind other elements which made `position: static` necessary but that again caused even more issues.

This method achieves the same as before, but without the additional stacking context. There should be no actual visual change with this PR.

<img width="166" alt="image" src="https://user-images.githubusercontent.com/115237/101805113-a9d9b780-3b12-11eb-9b2c-43a0f0487dec.png">


