### PR TITLE
Fix bug for webhook and feishu caused by API changed.

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -8,6 +8,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"code.gitea.io/gitea/modules/log"
@@ -310,6 +311,7 @@ func CreateWebhook(w *Webhook) error {
 }
 
 func createWebhook(e Engine, w *Webhook) error {
+	w.Type = strings.TrimSpace(w.Type)
 	_, err := e.Insert(w)
 	return err
 }
@@ -547,7 +549,7 @@ func copyDefaultWebhooksToRepo(e Engine, repoID int64) error {
 //        \/                    \/              \/     \/     \/
 
 // HookTaskType is the type of an hook task
-type HookTaskType string
+type HookTaskType = string
 
 // Types of hook tasks
 const (

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -144,7 +144,7 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 
 	var payloader api.Payloader
 	var err error
-	webhook, ok := webhooks[w.Type]
+	webhook, ok := webhooks[strings.TrimSpace(w.Type)] // NOTICE: w.Type maynot be trimmed before store into database
 	if ok {
 		payloader, err = webhook.payloadCreator(p, event, w.Meta)
 		if err != nil {


### PR DESCRIPTION
Just found the type on webhook table has some spaces so that webhook cannot be fired correctly.

This also fix feishu webhook since the API changed. fix #13858, #13907