### PR TITLE
Allow text selection in markdown rendered checkbox labels

### DIFF
--- a/web_src/less/_markdown.less
+++ b/web_src/less/_markdown.less
@@ -424,6 +424,10 @@
 
   input[type="checkbox"] {
     vertical-align: middle !important;
+    
+    + label {
+      user-select: inherit !important;
+    }
   }
 
   .csv-data td,


### PR DESCRIPTION
Overrides Semantic UI styling of Checkbox labels to allow text selection in markdown rendered content.

fixes #12842