### PR TITLE
Hide command line instructions when merge form is visible

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -363,8 +363,8 @@
 									{{end}}
 								</div>
 							</div>
-							<div class="dib ml-3">{{$.i18n.Tr "repo.pulls.merge_instruction_hint" | Safe}}</div>
-							<div class="instruct" style="display:none">
+							<div class="instruct dib ml-3">{{$.i18n.Tr "repo.pulls.merge_instruction_hint" | Safe}}</div>
+							<div class="instruct content" style="display:none">
 								<div class="ui divider"></div>
 								<div><h3 class="di">{{$.i18n.Tr "step1"}} </h3>{{$.i18n.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
 								<div class="ui secondary segment">

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -363,8 +363,8 @@
 									{{end}}
 								</div>
 							</div>
-							<div class="instruct dib ml-3">{{$.i18n.Tr "repo.pulls.merge_instruction_hint" | Safe}}</div>
-							<div class="instruct content" style="display:none">
+							<div class="instruct-toggle ml-3">{{$.i18n.Tr "repo.pulls.merge_instruction_hint" | Safe}}</div>
+							<div class="instruct-content" style="display:none">
 								<div class="ui divider"></div>
 								<div><h3 class="di">{{$.i18n.Tr "step1"}} </h3>{{$.i18n.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
 								<div class="ui secondary segment">

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1123,6 +1123,7 @@ async function initRepository() {
       e.preventDefault();
       $(`.${$(this).data('do')}-fields`).show();
       $(this).parent().hide();
+      $('.instruct').hide();
     });
     $('.merge-button > .dropdown').dropdown({
       onChange(_text, _value, $choice) {
@@ -1136,6 +1137,7 @@ async function initRepository() {
       e.preventDefault();
       $(this).closest('.form').hide();
       $mergeButton.parent().show();
+      $('.instruct.dib').show();
     });
     initReactionSelector();
   }
@@ -1202,7 +1204,7 @@ async function initRepository() {
 
 function initPullRequestMergeInstruction() {
   $('.show-instruction').on('click', () => {
-    $('.instruct').toggle();
+    $('.instruct.content').toggle();
   });
 }
 

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1123,7 +1123,8 @@ async function initRepository() {
       e.preventDefault();
       $(`.${$(this).data('do')}-fields`).show();
       $(this).parent().hide();
-      $('.instruct').hide();
+      $('.instruct-toggle').hide();
+      $('.instruct-content').hide();
     });
     $('.merge-button > .dropdown').dropdown({
       onChange(_text, _value, $choice) {
@@ -1137,7 +1138,7 @@ async function initRepository() {
       e.preventDefault();
       $(this).closest('.form').hide();
       $mergeButton.parent().show();
-      $('.instruct.dib').show();
+      $('.instruct-toggle').show();
     });
     initReactionSelector();
   }
@@ -1204,7 +1205,7 @@ async function initRepository() {
 
 function initPullRequestMergeInstruction() {
   $('.show-instruction').on('click', () => {
-    $('.instruct.content').toggle();
+    $('.instruct-content').toggle();
   });
 }
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -593,6 +593,10 @@
   }
 
   &.view.issue {
+    .instruct-toggle {
+      display: inline-block;
+    }
+
     .title {
       padding-bottom: 0 !important;
 


### PR DESCRIPTION
Hides element introduced by https://github.com/go-gitea/gitea/pull/13840 when merge form is visible.

Before:
![chrome_2020-12-12_01-36-25](https://user-images.githubusercontent.com/1447794/101967053-77b37d00-3c1a-11eb-82d7-cfd3836727c1.png)

After:
![chrome_2020-12-12_01-37-12](https://user-images.githubusercontent.com/1447794/101967070-91ed5b00-3c1a-11eb-8d9b-1988cc210ebe.png)
![chrome_2020-12-12_01-37-42](https://user-images.githubusercontent.com/1447794/101967092-a3cefe00-3c1a-11eb-91e1-9ddf0f4e7f6c.png)
