### PR TITLE
Do not display org avatar near icon for internal repos

### DIFF
--- a/templates/repo/icon.tmpl
+++ b/templates/repo/icon.tmpl
@@ -4,11 +4,6 @@
 	{{else}}
 		{{if $.IsPrivate}}
 			{{svg "octicon-lock" 32}}
-		{{else if and (not $.IsMirror) (not $.IsFork) ($.Owner)}}
-			{{svg "octicon-repo" 32}}
-			{{if $.Owner.Visibility.IsPrivate}}
-				{{avatar $.Owner}}
-			{{end}}
 		{{else if $.IsMirror}}
 			{{svg "octicon-mirror" 32}}
 		{{else if $.IsFork}}


### PR DESCRIPTION
This was introduced in https://github.com/go-gitea/gitea/pull/11895 as a way to distinguish internal repositories within organizations, however since then numerous CSS changes broken the nicely aligned tiny avatar and we also gained a label explicitly indicating visibility type next to name (https://github.com/go-gitea/gitea/pull/11891), rendering this solution useless.

As such, this PR removes this half-broken functionality completely (styling was removed in https://github.com/go-gitea/gitea/pull/13891)

---

Before:
![chrome_2020-12-12_01-47-41](https://user-images.githubusercontent.com/1447794/101967727-08d72380-3c1c-11eb-924d-2420a894bf8a.png)

After:
![chrome_2020-12-12_01-46-25](https://user-images.githubusercontent.com/1447794/101967717-fe1c8e80-3c1b-11eb-92c0-4ed9ed7364e3.png)