### PR TITLE
Fix missing username on dashboard context switch navbar

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -20,6 +20,7 @@
 					<div class="scrolling menu items">
 						<a class="{{if eq .ContextUser.ID .SignedUser.ID}}active selected{{end}} item" href="{{AppSubUrl}}/{{if .PageIsIssues}}issues{{else if .PageIsPulls}}pulls{{else if .PageIsMilestonesDashboard}}milestones{{end}}">
 							{{avatar .SignedUser}}
+							{{.SignedUser.ShortName 20}}
 						</a>
 						{{range .Orgs}}
 							<a class="{{if eq $.ContextUser.ID .ID}}active selected{{end}} item" title="{{.Name}}" href="{{AppSubUrl}}/org/{{.Name}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}">


### PR DESCRIPTION
Fix missing username on dashboard context switch navbar

Introduced by https://github.com/go-gitea/gitea/pull/13649

![chrome_2020-12-12_02-01-17](https://user-images.githubusercontent.com/1447794/101968156-f362f900-3c1d-11eb-9996-6153e7eb3ab0.png)
