### PR TITLE
Removes dangling < on emails/list.tmpl

### DIFF
--- a/templates/admin/emails/list.tmpl
+++ b/templates/admin/emails/list.tmpl
@@ -52,7 +52,7 @@
 							<td><a href="{{AppSubUrl}}/{{.Name}}">{{.Name}}</a></td>
 							<td><span class="text truncate">{{.FullName}}</span></td>
 							<td><span class="text email">{{.Email}}</span></td>
-							<td>{{if .IsPrimary}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td><
+							<td>{{if .IsPrimary}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
 							<td>
 								{{if .CanChange}}
 									<a class="link-email-action" href data-uid="{{.UID}}"


### PR DESCRIPTION
A dangling character was leftover from commit c85bb6263503ebd335863f413214a775973a1fac from PR #13860.
This change removes such character that was showing up on "User Emails" panel.

![screenshot](https://user-images.githubusercontent.com/57538841/102001135-bca8e380-3cee-11eb-869b-3188d81eb84a.png)
