### PR TITLE
Trim the branch prefix from action.GetBranch

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -238,7 +239,7 @@ func (a *Action) getCommentLink(e Engine) string {
 
 // GetBranch returns the action's repository branch.
 func (a *Action) GetBranch() string {
-	return a.RefName
+	return strings.TrimPrefix(git.BranchPrefix, a.RefName)
 }
 
 // GetContent returns the action's content.

--- a/models/action.go
+++ b/models/action.go
@@ -239,7 +239,7 @@ func (a *Action) getCommentLink(e Engine) string {
 
 // GetBranch returns the action's repository branch.
 func (a *Action) GetBranch() string {
-	return strings.TrimPrefix(git.BranchPrefix, a.RefName)
+	return strings.TrimPrefix(a.RefName, git.BranchPrefix)
 }
 
 // GetContent returns the action's content.


### PR DESCRIPTION
 #13882 has revealed that the refname of an action is actually only a
refname pattern and necessarily a branch. For examplem pushing to
refs/heads/master will result in action with refname refs/heads/master
but pushing to master will result in a refname master.

The simplest solution to providing a fix here is to trim the prefix
therefore this PR proposes this.

Fix #13979 

Signed-off-by: Andrew Thornton <art27@cantab.net>
