### PR TITLE
Ensure template renderer is available before storage handler (#13164)

### DIFF
--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -223,10 +223,11 @@ func NewMacaron() *macaron.Macaron {
 		},
 	))
 
+	m.Use(templates.HTMLRenderer())
+
 	m.Use(storageHandler(setting.Avatar.Storage, "avatars", storage.Avatars))
 	m.Use(storageHandler(setting.RepoAvatar.Storage, "repo-avatars", storage.RepoAvatars))
 
-	m.Use(templates.HTMLRenderer())
 	mailer.InitMailRender(templates.Mailer())
 
 	localeNames, err := options.Dir("locale")


### PR DESCRIPTION
`ctx.Error` requires that templates are available for this to
render the error page otherwise there will be a panic at this
time.

This was fixed in #13164 but was not completely backported.

Fix #13971

Signed-off-by: Andrew Thornton <art27@cantab.net>
