### PR TITLE
Fix markdown checkboxes on Blink

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -101,6 +101,9 @@
   --color-code-bg: #ffffff;
   --color-markdown-code-block: #00000010;
   --color-secondary-bg: #f4f4f4;
+  /* backgrounds */
+  --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
+  --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
 }
 
 :root:lang(ja) {

--- a/web_src/less/_markdown.less
+++ b/web_src/less/_markdown.less
@@ -203,16 +203,19 @@
     pointer-events: none;
     background: var(--color-text);
     mask-size: cover;
+    -webkit-mask-size: cover;
   }
 
   input[type="checkbox"]:checked::after {
     content: "";
-    mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
+    mask-image: var(--checkbox-mask-checked);
+    -webkit-mask-image: var(--checkbox-mask-checked);
   }
 
   input[type="checkbox"]:indeterminate::after {
     content: "";
-    mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
+    mask-image: var(--checkbox-mask-indeterminate);
+    -webkit-mask-image: var(--checkbox-mask-indeterminate);
   }
 
   ul ul,


### PR DESCRIPTION
Blink still requires a vendor prefix for `mask-image` and `mask-size`, so add that here to fix the rendering.

<img width="26" alt="image" src="https://user-images.githubusercontent.com/115237/102141027-77a4be80-3e60-11eb-97bd-31e872ef1388.png">
