### PR TITLE
Fix webhook list styling

### DIFF
--- a/templates/repo/settings/webhook/list.tmpl
+++ b/templates/repo/settings/webhook/list.tmpl
@@ -41,9 +41,8 @@
 		<div class="item">
 			{{.Description | Str2html}}
 		</div>
-		<div class="ui divider"></div>
 		{{range .Webhooks}}
-			<div class="item p-2">
+			<div class="item">
 				{{if eq .LastStatus 1}}
 					<span class="text green">{{svg "octicon-check"}}</span>
 				{{else if eq .LastStatus 2}}

--- a/templates/repo/settings/webhook/list.tmpl
+++ b/templates/repo/settings/webhook/list.tmpl
@@ -44,9 +44,9 @@
 		{{range .Webhooks}}
 			<div class="item">
 				{{if eq .LastStatus 1}}
-					<span class="text green">{{svg "octicon-check"}}</span>
+					<span class="text green mr-3">{{svg "octicon-check"}}</span>
 				{{else if eq .LastStatus 2}}
-					<span class="text red">{{svg "octicon-alert"}}</span>
+					<span class="text red mr-3">{{svg "octicon-alert"}}</span>
 				{{else}}
 					<span class="text grey mr-3">{{svg "octicon-dot-fill"}}</span>
 				{{end}}

--- a/web_src/less/_admin.less
+++ b/web_src/less/_admin.less
@@ -1,4 +1,14 @@
 .admin {
+  &.hooks .list {
+    > .item {
+      &:not(:first-child) {
+        border-top: 1px solid var(--color-secondary);
+        padding: 1rem;
+        margin: 15px -1rem -1rem;
+      }
+    }
+  }
+
   .table.segment {
     padding: 0;
     font-size: 13px;


### PR DESCRIPTION
#13860 tried to fix webhook list styling on admin dashboard, but in turn it broke for repository settings.

Before:
![chrome_2020-12-15_20-57-31](https://user-images.githubusercontent.com/1447794/102265990-2952f680-3f18-11eb-910c-7cf6e6e65e7b.png)
![chrome_2020-12-15_20-56-58](https://user-images.githubusercontent.com/1447794/102265938-150ef980-3f18-11eb-88b4-130307829275.png)


After:
![chrome_2020-12-15_20-56-37](https://user-images.githubusercontent.com/1447794/102265909-09bbce00-3f18-11eb-9dde-977f15b12437.png)
![chrome_2020-12-15_21-07-23](https://user-images.githubusercontent.com/1447794/102267004-8ef3b280-3f19-11eb-9e5a-b7dce6b78cc3.png)
