### PR TITLE
Fix incorrect review comment diffs

### DIFF
--- a/services/pull/review.go
+++ b/services/pull/review.go
@@ -167,16 +167,16 @@ func createCodeComment(doer *models.User, repo *models.Repository, issue *models
 
 	// Only fetch diff if comment is review comment
 	if len(patch) == 0 && reviewID != 0 {
-		if len(commitID) == 0 {
-			commitID, err = gitRepo.GetRefCommitID(pr.GetGitRefName())
-			if err != nil {
-				return nil, fmt.Errorf("GetRefCommitID[%s]: %v", pr.GetGitRefName(), err)
-			}
+		headCommitID, err := gitRepo.GetRefCommitID(pr.GetGitRefName())
+		if err != nil {
+			return nil, fmt.Errorf("GetRefCommitID[%s]: %v", pr.GetGitRefName(), err)
 		}
-
+		if len(commitID) == 0 {
+			commitID = headCommitID
+		}
 		patchBuf := new(bytes.Buffer)
-		if err := git.GetRepoRawDiffForFile(gitRepo, pr.MergeBase, commitID, git.RawDiffNormal, treePath, patchBuf); err != nil {
-			return nil, fmt.Errorf("GetRawDiffForLine[%s, %s, %s, %s]: %v", gitRepo.Path, pr.MergeBase, commitID, treePath, err)
+		if err := git.GetRepoRawDiffForFile(gitRepo, pr.MergeBase, headCommitID, git.RawDiffNormal, treePath, patchBuf); err != nil {
+			return nil, fmt.Errorf("GetRawDiffForLine[%s, %s, %s, %s]: %v", gitRepo.Path, pr.MergeBase, headCommitID, treePath, err)
 		}
 		patch = git.CutDiffAroundLine(patchBuf, int64((&models.Comment{Line: line}).UnsignedLine()), line < 0, setting.UI.CodeCommentLines)
 	}


### PR DESCRIPTION
Fixes #13683.

The diff snippet that provides context for a code review comment on the pull request timeline page used to be calculated based on the `headCommitID`. But in 1.13, with PR #13448, this changed to the `commitID` from the blame for the commented line, which seems to cause these incorrect review comment diff snippets.

This PR reverts back to using the headCommitID for obtaining the diff.