### PR TITLE
Cause NotifyMigrateRepository to emit a repo create webhook

### DIFF
--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -122,7 +122,6 @@ func (m *webhookNotifier) NotifyDeleteRepository(doer *models.User, repo *models
 	}
 }
 
-// NotifyMigrateRepository places a place holder function
 func (m *webhookNotifier) NotifyMigrateRepository(doer *models.User, u *models.User, repo *models.Repository) {
 	// Add to hook queue for created repo after session commit.
 	if err := webhook_services.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{

--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -122,6 +122,19 @@ func (m *webhookNotifier) NotifyDeleteRepository(doer *models.User, repo *models
 	}
 }
 
+// NotifyMigrateRepository places a place holder function
+func (m *webhookNotifier) NotifyMigrateRepository(doer *models.User, u *models.User, repo *models.Repository) {
+	// Add to hook queue for created repo after session commit.
+	if err := webhook_services.PrepareWebhooks(repo, models.HookEventRepository, &api.RepositoryPayload{
+		Action:       api.HookRepoCreated,
+		Repository:   convert.ToRepo(repo, models.AccessModeOwner),
+		Organization: convert.ToUser(u, false, false),
+		Sender:       convert.ToUser(doer, false, false),
+	}); err != nil {
+		log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
+	}
+}
+
 func (m *webhookNotifier) NotifyIssueChangeAssignee(doer *models.User, issue *models.Issue, assignee *models.User, removed bool, comment *models.Comment) {
 	if issue.IsPull {
 		mode, _ := models.AccessLevelUnit(doer, issue.Repo, models.UnitTypePullRequests)


### PR DESCRIPTION
This PR simply makes NotifyMigrateRepository emit a Create Repo webhook.
The reason for no new payload is that the information sent to
NotifyMigrateRepository is only essentially the same as
NotifyCreateRepository

Fix #13996

Signed-off-by: Andrew Thornton <art27@cantab.net>
