### PR TITLE
fix label of --id in admin delete user

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -125,9 +125,15 @@ var (
 	}
 
 	microcmdUserDelete = cli.Command{
-		Name:   "delete",
-		Usage:  "Delete specific user",
-		Flags:  []cli.Flag{idFlag},
+		Name:  "delete",
+		Usage: "Delete specific user",
+		Flags: []cli.Flag{cli.Int64Flag{
+			Name:  "id",
+			Usage: "ID of user",
+		}, cli.StringFlag{
+			Name:  "username",
+			Usage: "Username",
+		}},
 		Action: runDeleteUser,
 	}
 
@@ -463,15 +469,21 @@ func runListUsers(c *cli.Context) error {
 }
 
 func runDeleteUser(c *cli.Context) error {
-	if !c.IsSet("id") {
-		return fmt.Errorf("--id flag is missing")
+	if !c.IsSet("id") && !c.IsSet("username") {
+		return fmt.Errorf("--id or --username missing")
 	}
 
 	if err := initDB(); err != nil {
 		return err
 	}
 
-	user, err := models.GetUserByID(c.Int64("id"))
+	var err error
+	var user *models.User
+	if c.IsSet("id") {
+		user, err = models.GetUserByID(c.Int64("id"))
+	} else {
+		user, err = models.GetUserByName(c.String("username"))
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -127,13 +127,16 @@ var (
 	microcmdUserDelete = cli.Command{
 		Name:  "delete",
 		Usage: "Delete specific user",
-		Flags: []cli.Flag{cli.Int64Flag{
-			Name:  "id",
-			Usage: "ID of user",
-		}, cli.StringFlag{
-			Name:  "username",
-			Usage: "Username",
-		}},
+		Flags: []cli.Flag{
+			cli.Int64Flag{
+				Name:  "id",
+				Usage: "ID of user of the user to delete",
+			},
+			cli.StringFlag{
+				Name:  "username,u",
+				Usage: "Username of the user to delete",
+			},
+		},
 		Action: runDeleteUser,
 	}
 

--- a/docs/content/doc/usage/command-line.en-us.md
+++ b/docs/content/doc/usage/command-line.en-us.md
@@ -69,7 +69,9 @@ Admin operations:
         - `gitea admin user list`
     - `delete`:
       - Options:
-        - `--id`: ID of user to be deleted. Required.
+        - `--username`: Username of user to be deleted.
+        - `--id`: ID of user to be deleted.
+        - One of `--id` or `--username` is required.
       - Examples:
         - `gitea admin user delete --id 1`
     - `create`: - Options: - `--name value`: Username. Required. As of gitea 1.9.0, use the `--username` flag instead. - `--username value`: Username. Required. New in gitea 1.9.0. - `--password value`: Password. Required. - `--email value`: Email. Required. - `--admin`: If provided, this makes the user an admin. Optional. - `--access-token`: If provided, an access token will be created for the user. Optional. (default: false). - `--must-change-password`: If provided, the created user will be required to choose a newer password after

--- a/docs/content/doc/usage/command-line.en-us.md
+++ b/docs/content/doc/usage/command-line.en-us.md
@@ -69,9 +69,10 @@ Admin operations:
         - `gitea admin user list`
     - `delete`:
       - Options:
+        - `--email`: Email of the user to be deleted.
         - `--username`: Username of user to be deleted.
         - `--id`: ID of user to be deleted.
-        - One of `--id` or `--username` is required.
+        - One of `--id`, `--username` or `--email` is required. If more than one is provided then all have to match.
       - Examples:
         - `gitea admin user delete --id 1`
     - `create`: - Options: - `--name value`: Username. Required. As of gitea 1.9.0, use the `--username` flag instead. - `--username value`: Username. Required. New in gitea 1.9.0. - `--password value`: Password. Required. - `--email value`: Email. Required. - `--admin`: If provided, this makes the user an admin. Optional. - `--access-token`: If provided, an access token will be created for the user. Optional. (default: false). - `--must-change-password`: If provided, the created user will be required to choose a newer password after


### PR DESCRIPTION
This pr fixes the label descriptor of `gitea admin delete user`
but also adds a `--username` and `--email` option.

Fix #13995

Signed-off-by: Andrew Thornton <art27@cantab.net>
