### PR TITLE
Always wait for the cmd to finish

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -153,6 +153,7 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 		err := fn(ctx, cancel)
 		if err != nil {
 			cancel()
+			_ = cmd.Wait()
 			return err
 		}
 	}


### PR DESCRIPTION
After cancelling the context we still need to wait for the
command to finish otherwise zombie processes may occur

Fix #13987

Signed-off-by: Andrew Thornton <art27@cantab.net>
