### PR TITLE
Disable WYSIWYG editor for mobile user agents [rebased on v1.13]

### DIFF
--- a/templates/custom/header.tmpl
+++ b/templates/custom/header.tmpl
@@ -1,0 +1,14 @@
+	<script>
+		document.onreadystatechange = () => {
+			var isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+			if (isMobile && document.readyState === 'complete') {
+				e = document.querySelector("div.editor-toolbar > a.fa.fa-file");
+				if (e) {
+					console.log("*** Disable WYSIWYG issue editor on mobile device.");
+					e.click();
+				}
+			}
+		};
+	</script>
+
+


### PR DESCRIPTION
Written by @ashimokawa for codeberg.org here https://codeberg.org/Codeberg/build-deploy-gitea/commit/840fd48cad0c72933becafbe561addc6cdfb11e2
This PR adds a "custom header" that acts as if a user clicks on the "disable WYSIWYG" button if their user agent suggests a mobile device.

This is clearly only a temporary high-level hotfix for the problem until a more permanent solution is figured out.

I closed the original PR since it was based on "master", now the commit is based on "v1.13" - not sure whether the closing/recreation was necessary. Happy if someone shows me how I could have done it better (I rebased --onto locally)

https://github.com/go-gitea/gitea/pull/14017