### PR TITLE
Fix bug in commit verification introduced in #13673

### DIFF
--- a/modules/git/commit_reader.go
+++ b/modules/git/commit_reader.go
@@ -36,6 +36,10 @@ readLoop:
 		line, err := bufReader.ReadBytes('\n')
 		if err != nil {
 			if err == io.EOF {
+				if message {
+					_, _ = messageSB.Write(line)
+				}
+				_, _ = payloadSB.Write(line)
 				break readLoop
 			}
 			return nil, err
@@ -86,10 +90,10 @@ readLoop:
 			}
 		} else {
 			_, _ = messageSB.Write(line)
+			_, _ = payloadSB.Write(line)
 		}
 	}
 	commit.CommitMessage = messageSB.String()
-	_, _ = payloadSB.WriteString(commit.CommitMessage)
 	commit.Signature = &CommitGPGSignature{
 		Signature: signatureSB.String(),
 		Payload:   payloadSB.String(),


### PR DESCRIPTION
There is a slight bug in the commit_reader introduced in #13673 whereby
commit messages which have a final unterminated line miss their final line.

This PR fixes this.

Related #13673

Signed-off-by: Andrew Thornton <art27@cantab.net>
