### PR TITLE
Fix panic in BasicAuthDecode

### DIFF
--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -63,6 +64,11 @@ func BasicAuthDecode(encoded string) (string, string, error) {
 	}
 
 	auth := strings.SplitN(string(s), ":", 2)
+
+	if len(auth) < 2 {
+		return "", "", errors.New("invalid basic authentication")
+	}
+
 	return auth[0], auth[1], nil
 }
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -65,7 +65,7 @@ func BasicAuthDecode(encoded string) (string, string, error) {
 
 	auth := strings.SplitN(string(s), ":", 2)
 
-	if len(auth) < 2 {
+	if len(auth) != 2 {
 		return "", "", errors.New("invalid basic authentication")
 	}
 

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -43,6 +43,12 @@ func TestBasicAuthDecode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", user)
 	assert.Equal(t, "bar", pass)
+
+	_, _, err = BasicAuthDecode("aW52YWxpZA==")
+	assert.Error(t, err)
+
+	_, _, err = BasicAuthDecode("invalid")
+	assert.Error(t, err)
 }
 
 func TestBasicAuthEncode(t *testing.T) {


### PR DESCRIPTION
If the decoded string does not contain ":" that function would run into an `index out of range [1] with length 1` error. prevent that.