### PR TITLE
Locale: say another issue instead of this issue

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1131,7 +1131,7 @@ issues.start_tracking_short = Start
 issues.start_tracking = Start Time Tracking
 issues.start_tracking_history = `started working %s`
 issues.tracker_auto_close = Timer will be stopped automatically when this issue gets closed
-issues.tracking_already_started = `You have already started time tracking on this <a href="%s">issue</a>!`
+issues.tracking_already_started = `You have already started time tracking on <a href="%s">another issue</a>!`
 issues.stop_tracking = Stop
 issues.stop_tracking_history = `stopped working %s`
 issues.add_time = Manually Add Time


### PR DESCRIPTION
Saying "this issue" is confusing because it could be understood as the issue that the user is currently viewing, not which the "issue" link points to.

Was confused by this and thought that an error occurred and it won't let me starting time tracking.