### PR TITLE
Present repository name as {{name}}#{{index}} instead of label on dashboard issuelist

### DIFF
--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -31,9 +31,6 @@
 			</div>
 			<div class="issue-item-main f1 fc df">
 				<div class="issue-item-top-row df ac fw">
-					{{if eq $.listType "dashboard"}}
-						<div class="ui label mr-3">{{.Repo.FullName}}</div>
-					{{end}}
 					<a class="title mr-3" href="{{if .HTMLURL}}{{.HTMLURL}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
 						{{RenderEmoji .Title}}
 						{{if .IsPull }}
@@ -50,7 +47,11 @@
 				</div>
 				<div class="desc issue-item-bottom-row df ac fw my-1">
 					<a class="index ml-0 mr-2" href="{{if .HTMLURL}}{{.HTMLURL}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
-						#{{.Index}}
+						{{if eq $.listType "dashboard"}}
+          		{{.Repo.FullName}}#{{.Index}}
+          	{{else}}
+							#{{.Index}}
+						{{end}}
 					</a>
 					{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.Lang }}
 					{{if .OriginalAuthor }}


### PR DESCRIPTION
The label was restored in #14073 but doesn't seem to look very well on long titles. This PR changes how repository name is displayed and makes it so that it's part of `{{name}}#{{index}}` instead of separate label. This is also consistent with how we display these links in other places, such as dashboard activity page.

Before:
![chrome_2020-12-21_07-14-34](https://user-images.githubusercontent.com/1447794/102745488-60803800-435c-11eb-85ec-82c27e9ac1cf.png)

After:
![chrome_2020-12-21_07-12-50](https://user-images.githubusercontent.com/1447794/102745491-6118ce80-435c-11eb-8e11-52ea2b29f107.png)

