### PR TITLE
Fix storage config implementation

### DIFF
--- a/modules/setting/storage_test.go
+++ b/modules/setting/storage_test.go
@@ -1,0 +1,164 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ini "gopkg.in/ini.v1"
+)
+
+func Test_getStorageCustomType(t *testing.T) {
+	iniStr := `
+[attachment]
+STORAGE_TYPE = my_minio
+MINIO_BUCKET = gitea-attachment
+
+[storage.my_minio]
+STORAGE_TYPE = minio
+MINIO_ENDPOINT = my_minio:9000
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "minio", storage.Type)
+	assert.EqualValues(t, "my_minio:9000", storage.Section.Key("MINIO_ENDPOINT").String())
+	assert.EqualValues(t, "gitea-attachment", storage.Section.Key("MINIO_BUCKET").String())
+}
+
+func Test_getStorageNameSectionOverridesTypeSection(t *testing.T) {
+	iniStr := `
+[attachment]
+STORAGE_TYPE = minio
+
+[storage.attachments]
+MINIO_BUCKET = gitea-attachment
+
+[storage.minio]
+MINIO_BUCKET = gitea
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "minio", storage.Type)
+	assert.EqualValues(t, "gitea-attachment", storage.Section.Key("MINIO_BUCKET").String())
+}
+
+func Test_getStorageTypeSectionOverridesStorageSection(t *testing.T) {
+	iniStr := `
+[attachment]
+STORAGE_TYPE = minio
+
+[storage.minio]
+MINIO_BUCKET = gitea-minio
+
+[storage]
+MINIO_BUCKET = gitea
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "minio", storage.Type)
+	assert.EqualValues(t, "gitea-minio", storage.Section.Key("MINIO_BUCKET").String())
+}
+
+func Test_getStorageSpecificOverridesStorage(t *testing.T) {
+	iniStr := `
+[attachment]
+MINIO_BUCKET = gitea-attachment
+
+[storage.attachments]
+MINIO_BUCKET = gitea
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "gitea-attachment", storage.Section.Key("MINIO_BUCKET").String())
+}
+
+func Test_getStorageGetDefaults(t *testing.T) {
+	Cfg, _ = ini.Load([]byte(""))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "gitea", storage.Section.Key("MINIO_BUCKET").String())
+}
+
+func Test_getStorageMultipleName(t *testing.T) {
+	iniStr := `
+[lfs]
+MINIO_BUCKET = gitea-lfs
+
+[attachment]
+MINIO_BUCKET = gitea-attachment
+
+[storage]
+MINIO_BUCKET = gitea-storage
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	{
+		sec := Cfg.Section("attachment")
+		storageType := sec.Key("STORAGE_TYPE").MustString("")
+		storage := getStorage("attachments", storageType, sec)
+
+		assert.EqualValues(t, "gitea-attachment", storage.Section.Key("MINIO_BUCKET").String())
+	}
+	{
+		sec := Cfg.Section("lfs")
+		storageType := sec.Key("STORAGE_TYPE").MustString("")
+		storage := getStorage("lfs", storageType, sec)
+
+		assert.EqualValues(t, "gitea-lfs", storage.Section.Key("MINIO_BUCKET").String())
+	}
+	{
+		sec := Cfg.Section("avatar")
+		storageType := sec.Key("STORAGE_TYPE").MustString("")
+		storage := getStorage("avatars", storageType, sec)
+
+		assert.EqualValues(t, "gitea-storage", storage.Section.Key("MINIO_BUCKET").String())
+	}
+}
+
+func Test_getStorageUseOtherNameAsType(t *testing.T) {
+	iniStr := `
+[attachment]
+STORAGE_TYPE = lfs
+
+[storage.lfs]
+MINIO_BUCKET = gitea-storage
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	{
+		sec := Cfg.Section("attachment")
+		storageType := sec.Key("STORAGE_TYPE").MustString("")
+		storage := getStorage("attachments", storageType, sec)
+
+		assert.EqualValues(t, "gitea-storage", storage.Section.Key("MINIO_BUCKET").String())
+	}
+	{
+		sec := Cfg.Section("lfs")
+		storageType := sec.Key("STORAGE_TYPE").MustString("")
+		storage := getStorage("lfs", storageType, sec)
+
+		assert.EqualValues(t, "gitea-storage", storage.Section.Key("MINIO_BUCKET").String())
+	}
+}


### PR DESCRIPTION
The design is very flexible, but not implemented correctly.
This commit fixes several issues:
* Costom storage type stated in https://docs.gitea.io/en-us/config-cheat-sheet/#storage-storage not working
* [storage.attachments], [storage.minio] section not respected

If you run these tests with old `storage.go`:

```
--- FAIL: Test_getStorageCustomType (0.00s)
    storage_test.go:30: 
                Error Trace:    storage_test.go:30
                Error:          Not equal: 
                                expected: "minio"
                                actual  : "my_minio"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -minio
                                +my_minio
                Test:           Test_getStorageCustomType
    storage_test.go:31: 
                Error Trace:    storage_test.go:31
                Error:          Not equal: 
                                expected: "my_minio:9000"
                                actual  : "localhost:9000"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -my_minio:9000
                                +localhost:9000
                Test:           Test_getStorageCustomType
--- FAIL: Test_getStorageNameSectionOverridesTypeSection (0.00s)
    storage_test.go:53: 
                Error Trace:    storage_test.go:53
                Error:          Not equal: 
                                expected: "gitea-attachment"
                                actual  : "gitea"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -gitea-attachment
                                +gitea
                Test:           Test_getStorageNameSectionOverridesTypeSection
--- FAIL: Test_getStorageTypeSectionOverridesStorageSection (0.00s)
    storage_test.go:74: 
                Error Trace:    storage_test.go:74
                Error:          Not equal: 
                                expected: "gitea-minio"
                                actual  : "gitea"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -gitea-minio
                                +gitea
                Test:           Test_getStorageTypeSectionOverridesStorageSection
--- FAIL: Test_getStorageUseOtherNameAsType (0.00s)
    storage_test.go:155: 
                Error Trace:    storage_test.go:155
                Error:          Not equal: 
                                expected: "gitea-storage"
                                actual  : "gitea"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -gitea-storage
                                +gitea
                Test:           Test_getStorageUseOtherNameAsType
    storage_test.go:162: 
                Error Trace:    storage_test.go:162
                Error:          Not equal: 
                                expected: "gitea-storage"
                                actual  : "gitea"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -gitea-storage
                                +gitea
                Test:           Test_getStorageUseOtherNameAsType
FAIL
FAIL    code.gitea.io/gitea/modules/setting     0.023s
FAIL
```

EDIT: followup:  #14096