### PR TITLE
More test case for STORAGE_TYPE overrides (and fixes)

### DIFF
--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -43,20 +43,36 @@ func getStorage(name, typ string, targetSec *ini.Section) Storage {
 	sec.Key("MINIO_LOCATION").MustString("us-east-1")
 	sec.Key("MINIO_USE_SSL").MustBool(false)
 
-	nameSec := Cfg.Section(sectionName + "." + name)
-	typeSec := Cfg.Section(sectionName + "." + typ)
-	for _, override := range []*ini.Section{nameSec, typeSec, sec} {
+	var storage Storage
+	storage.Section = targetSec
+	storage.Type = typ
+
+	overrides := make([]*ini.Section, 0, 3)
+	nameSec, err := Cfg.GetSection(sectionName + "." + name)
+	if err == nil {
+		overrides = append(overrides, nameSec)
+	}
+
+	typeSec, err := Cfg.GetSection(sectionName + "." + typ)
+	if err == nil {
+		overrides = append(overrides, typeSec)
+		nextType := typeSec.Key("STORAGE_TYPE").String()
+		if len(nextType) > 0 {
+			storage.Type = nextType // Support custom STORAGE_TYPE
+		}
+	}
+	overrides = append(overrides, sec)
+
+	for _, override := range overrides {
 		for _, key := range override.Keys() {
 			if !targetSec.HasKey(key.Name()) {
 				_, _ = targetSec.NewKey(key.Name(), key.Value())
 			}
 		}
+		if len(storage.Type) == 0 {
+			storage.Type = override.Key("STORAGE_TYPE").String()
+		}
 	}
-
-	var storage Storage
-	storage.Section = targetSec
-
-	storage.Type = typeSec.Key("STORAGE_TYPE").MustString(typ)
 	storage.ServeDirect = storage.Section.Key("SERVE_DIRECT").MustBool(false)
 
 	// Specific defaults

--- a/modules/setting/storage_test.go
+++ b/modules/setting/storage_test.go
@@ -77,10 +77,14 @@ MINIO_BUCKET = gitea
 func Test_getStorageSpecificOverridesStorage(t *testing.T) {
 	iniStr := `
 [attachment]
+STORAGE_TYPE = minio
 MINIO_BUCKET = gitea-attachment
 
 [storage.attachments]
 MINIO_BUCKET = gitea
+
+[storage]
+STORAGE_TYPE = local
 `
 	Cfg, _ = ini.Load([]byte(iniStr))
 
@@ -88,6 +92,7 @@ MINIO_BUCKET = gitea
 	storageType := sec.Key("STORAGE_TYPE").MustString("")
 	storage := getStorage("attachments", storageType, sec)
 
+	assert.EqualValues(t, "minio", storage.Type)
 	assert.EqualValues(t, "gitea-attachment", storage.Section.Key("MINIO_BUCKET").String())
 }
 
@@ -161,4 +166,32 @@ MINIO_BUCKET = gitea-storage
 
 		assert.EqualValues(t, "gitea-storage", storage.Section.Key("MINIO_BUCKET").String())
 	}
+}
+
+func Test_getStorageInheritStorageType(t *testing.T) {
+	iniStr := `
+[storage]
+STORAGE_TYPE = minio
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "minio", storage.Type)
+}
+
+func Test_getStorageInheritNameSectionType(t *testing.T) {
+	iniStr := `
+[storage.attachments]
+STORAGE_TYPE = minio
+`
+	Cfg, _ = ini.Load([]byte(iniStr))
+
+	sec := Cfg.Section("attachment")
+	storageType := sec.Key("STORAGE_TYPE").MustString("")
+	storage := getStorage("attachments", storageType, sec)
+
+	assert.EqualValues(t, "minio", storage.Type)
 }


### PR DESCRIPTION
Following up my previous PR.

The previous version fails these new tests:

```
--- FAIL: Test_getStorageSpecificOverridesStorage (0.00s)
    storage_test.go:95: 
                Error Trace:    storage_test.go:95
                Error:          Not equal: 
                                expected: "minio"
                                actual  : "local"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -minio
                                +local
                Test:           Test_getStorageSpecificOverridesStorage
--- FAIL: Test_getStorageInheritNameSectionType (0.00s)
    storage_test.go:196: 
                Error Trace:    storage_test.go:196
                Error:          Not equal: 
                                expected: "minio"
                                actual  : ""
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -minio
                                +
                Test:           Test_getStorageInheritNameSectionType
FAIL
FAIL    code.gitea.io/gitea/modules/setting     0.021s
FAIL
```