### PR TITLE
Fix incorrect generated link in documentation page

### DIFF
--- a/docs/content/doc/usage/reverse-proxies.en-us.md
+++ b/docs/content/doc/usage/reverse-proxies.en-us.md
@@ -60,7 +60,7 @@ The front page, a repository view or issue list is dynamic content.
 
 Nginx can serve static resources directly and proxy only the dynamic requests to gitea.
 Nginx is optimized for serving static content, while the proxying of large responses might be the opposite of that
-(see https://serverfault.com/q/587386).
+(see [https://serverfault.com/q/587386](https://serverfault.com/q/587386)).
 
 Download a snapshot of the Gitea source repository to `/path/to/gitea/`.
 After this, run `make frontend` in the repository directory to generate the static resources. We are only interested in the `public/` directory for this task, so you can delete the rest.


### PR DESCRIPTION
In [this](https://docs.gitea.io/en-us/reverse-proxies/) ([https://archive.vn/LfxKx#selection-817.0-819.1](https://archive.vn/LfxKx#selection-817.0-819.1)) generated documentation page, the link "https://serverfault.com/q/587386" is connected with the right parentheses next to it and cannot be opened correctly. Creating an explicit link in the markdown file could fix this.