### PR TITLE
Fix manifest encoding

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1059,10 +1059,10 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 	if err == nil && parsedPrefix.Hostname() == "" {
 		if staticURLPrefix == "" {
 			return strings.TrimSuffix(appURL, "/")
-		} else {
-			// handle the case if StaticURLPrefix is just a path
-			return strings.TrimSuffix(appURL, "/") + strings.TrimSuffix(staticURLPrefix, "/")
 		}
+
+		// StaticURLPrefix is just a path
+		return strings.TrimSuffix(appURL, "/") + strings.TrimSuffix(staticURLPrefix, "/")
 	}
 
 	return strings.TrimSuffix(staticURLPrefix, "/")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1056,7 +1056,7 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 		log.Fatal("Unable to parse STATIC_URL_PREFIX: %v", err)
 	}
 
-	if parsedPrefix.Hostname() == "" {
+	if err == nil && parsedPrefix.Hostname() == "" {
 		if staticURLPrefix == "" {
 			return strings.TrimSuffix(appURL, "/")
 		} else {
@@ -1082,7 +1082,7 @@ func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []
 		Icons     []manifestIcon `json:"icons"`
 	}
 
-	bs, err := json.Marshal(&manifestJSON{
+	bytes, err := json.Marshal(&manifestJSON{
 		Name:      appName,
 		ShortName: appName,
 		StartURL:  appURL,
@@ -1112,9 +1112,10 @@ func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []
 
 	if err != nil {
 		log.Error("unable to marshal manifest JSON. Error: %v", err)
+		return make([]byte, 0)
 	}
 
-	return bs
+	return bytes
 }
 
 // NewServices initializes the services

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1059,7 +1059,7 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 	}
 
 	if parsedPrefix.Hostname() == "" {
-		if (staticURLPrefix == "") {
+		if staticURLPrefix == "" {
 			ret = strings.TrimSuffix(appURL, "/")
 		} else {
 			// handle the case if StaticURLPrefix is just a path
@@ -1078,18 +1078,16 @@ func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []
 	}
 
 	type manifestJSON struct {
-		ShortName       string         `json:"short_name"`
-		Name            string         `json:"name"`
-		Icons           []manifestIcon `json:"icons"`
-		StartURL        string         `json:"start_url"`
-		Scope           string         `json:"scope"`
-		BackgroundColor string         `json:"background_color"`
-		Display         string         `json:"display"`
+		Name      string         `json:"name"`
+		ShortName string         `json:"short_name"`
+		StartURL  string         `json:"start_url"`
+		Icons     []manifestIcon `json:"icons"`
 	}
 
 	bs, err := json.Marshal(&manifestJSON{
-		ShortName: appName,
 		Name:      appName,
+		ShortName: appName,
+		StartURL:  appURL,
 		Icons: []manifestIcon{
 			{
 				Src:   absoluteAssetURL + "/img/logo-lg.png",
@@ -1112,10 +1110,6 @@ func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []
 				Sizes: "120x120",
 			},
 		},
-		StartURL:        appURL,
-		Scope:           appURL,
-		BackgroundColor: "#FAFAFA",
-		Display:         "standalone",
 	})
 
 	if err != nil {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -603,7 +603,7 @@ func NewContext() {
 
 	AbsoluteAssetURL = MakeAbsoluteAssetURL(AppURL, StaticURLPrefix)
 
-	manifestBytes := MakeManifestData(AppName, AbsoluteAssetURL)
+	manifestBytes := MakeManifestData(AppName, AppURL, AbsoluteAssetURL)
 	ManifestData = `application/json;base64,` + base64.StdEncoding.EncodeToString(manifestBytes)
 
 	var defaultLocalURL string
@@ -1070,7 +1070,7 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 	return ret
 }
 
-func MakeManifestData(appName string, absoluteAssetURL string) []byte {
+func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []byte {
 	type manifestIcon struct {
 		Src   string `json:"src"`
 		Type  string `json:"type"`

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1050,27 +1050,27 @@ func loadOrGenerateInternalToken(sec *ini.Section) string {
 }
 
 // makeAbsoluteAssetURL returns the absolute asset url prefix without a trailing slash
-func MakeAbsoluteAssetURL(AppURL string, StaticURLPrefix string) string {
-	ret := strings.TrimSuffix(StaticURLPrefix, "/")
+func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
+	ret := strings.TrimSuffix(staticURLPrefix, "/")
 
-	parsedPrefix, err := url.Parse(strings.TrimSuffix(StaticURLPrefix, "/"))
+	parsedPrefix, err := url.Parse(strings.TrimSuffix(staticURLPrefix, "/"))
 	if err != nil {
 		log.Fatal("Unable to parse STATIC_URL_PREFIX: %v", err)
 	}
 
 	if parsedPrefix.Hostname() == "" {
-		if (StaticURLPrefix == "") {
-			ret = strings.TrimSuffix(AppURL, "/")
+		if (staticURLPrefix == "") {
+			ret = strings.TrimSuffix(appURL, "/")
 		} else {
 			// handle the case if StaticURLPrefix is just a path
-			ret = strings.TrimSuffix(AppURL, "/") + strings.TrimSuffix(StaticURLPrefix, "/")
+			ret = strings.TrimSuffix(appURL, "/") + strings.TrimSuffix(staticURLPrefix, "/")
 		}
 	}
 
 	return ret
 }
 
-func MakeManifestData(AppName string, AbsoluteAssetURL string) []byte {
+func MakeManifestData(appName string, absoluteAssetURL string) []byte {
 	type manifestIcon struct {
 		Src   string `json:"src"`
 		Type  string `json:"type"`
@@ -1088,32 +1088,32 @@ func MakeManifestData(AppName string, AbsoluteAssetURL string) []byte {
 	}
 
 	bs, err := json.Marshal(&manifestJSON{
-		ShortName: AppName,
-		Name:      AppName,
+		ShortName: appName,
+		Name:      appName,
 		Icons: []manifestIcon{
 			{
-				Src:   AbsoluteAssetURL + "/img/logo-lg.png",
+				Src:   absoluteAssetURL + "/img/logo-lg.png",
 				Type:  "image/png",
 				Sizes: "880x880",
 			},
 			{
-				Src:   AbsoluteAssetURL + "/img/logo-512.png",
+				Src:   absoluteAssetURL + "/img/logo-512.png",
 				Type:  "image/png",
 				Sizes: "512x512",
 			},
 			{
-				Src:   AbsoluteAssetURL + "/img/logo-192.png",
+				Src:   absoluteAssetURL + "/img/logo-192.png",
 				Type:  "image/png",
 				Sizes: "192x192",
 			},
 			{
-				Src:   AbsoluteAssetURL + "/img/logo-sm.png",
+				Src:   absoluteAssetURL + "/img/logo-sm.png",
 				Type:  "image/png",
 				Sizes: "120x120",
 			},
 		},
-		StartURL:        AppURL,
-		Scope:           AppURL,
+		StartURL:        appURL,
+		Scope:           appURL,
 		BackgroundColor: "#FAFAFA",
 		Display:         "standalone",
 	})

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1049,7 +1049,7 @@ func loadOrGenerateInternalToken(sec *ini.Section) string {
 	return token
 }
 
-// makeAbsoluteAssetURL returns the absolute asset url prefix without a trailing slash
+// MakeAbsoluteAssetURL returns the absolute asset url prefix without a trailing slash
 func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 	parsedPrefix, err := url.Parse(strings.TrimSuffix(staticURLPrefix, "/"))
 	if err != nil {
@@ -1068,6 +1068,7 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 	return strings.TrimSuffix(staticURLPrefix, "/")
 }
 
+// MakeManifestData generates web app manifest JSON
 func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []byte {
 	type manifestIcon struct {
 		Src   string `json:"src"`

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1051,8 +1051,6 @@ func loadOrGenerateInternalToken(sec *ini.Section) string {
 
 // makeAbsoluteAssetURL returns the absolute asset url prefix without a trailing slash
 func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
-	ret := strings.TrimSuffix(staticURLPrefix, "/")
-
 	parsedPrefix, err := url.Parse(strings.TrimSuffix(staticURLPrefix, "/"))
 	if err != nil {
 		log.Fatal("Unable to parse STATIC_URL_PREFIX: %v", err)
@@ -1060,14 +1058,14 @@ func MakeAbsoluteAssetURL(appURL string, staticURLPrefix string) string {
 
 	if parsedPrefix.Hostname() == "" {
 		if staticURLPrefix == "" {
-			ret = strings.TrimSuffix(appURL, "/")
+			return strings.TrimSuffix(appURL, "/")
 		} else {
 			// handle the case if StaticURLPrefix is just a path
-			ret = strings.TrimSuffix(appURL, "/") + strings.TrimSuffix(staticURLPrefix, "/")
+			return strings.TrimSuffix(appURL, "/") + strings.TrimSuffix(staticURLPrefix, "/")
 		}
 	}
 
-	return ret
+	return strings.TrimSuffix(staticURLPrefix, "/")
 }
 
 func MakeManifestData(appName string, appURL string, absoluteAssetURL string) []byte {

--- a/modules/setting/setting_test.go
+++ b/modules/setting/setting_test.go
@@ -24,6 +24,6 @@ func TestMakeAbsoluteAssetURL(t *testing.T) {
 }
 
 func TestMakeManifestData(t *testing.T) {
-	jsonBytes := MakeManifestData(`Example App '\"`, "https://example.com", "https://example.com/foo/bar");
+	jsonBytes := MakeManifestData(`Example App '\"`, "https://example.com", "https://example.com/foo/bar")
 	assert.True(t, json.Valid(jsonBytes))
 }

--- a/modules/setting/setting_test.go
+++ b/modules/setting/setting_test.go
@@ -24,6 +24,6 @@ func TestMakeAbsoluteAssetURL(t *testing.T) {
 }
 
 func TestMakeManifestData(t *testing.T) {
-	jsonBytes := MakeManifestData(`Example App '\"`, "https://example.com/foo/bar");
+	jsonBytes := MakeManifestData(`Example App '\"`, "https://example.com", "https://example.com/foo/bar");
 	assert.True(t, json.Valid(jsonBytes))
 }

--- a/modules/setting/setting_test.go
+++ b/modules/setting/setting_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package setting
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeAbsoluteAssetURL(t *testing.T) {
+	assert.Equal(t, "https://localhost:2345", MakeAbsoluteAssetURL("https://localhost:1234", "https://localhost:2345"))
+	assert.Equal(t, "https://localhost:2345", MakeAbsoluteAssetURL("https://localhost:1234/", "https://localhost:2345"))
+	assert.Equal(t, "https://localhost:2345", MakeAbsoluteAssetURL("https://localhost:1234/", "https://localhost:2345/"))
+	assert.Equal(t, "https://localhost:1234/foo", MakeAbsoluteAssetURL("https://localhost:1234", "/foo"))
+	assert.Equal(t, "https://localhost:1234/foo", MakeAbsoluteAssetURL("https://localhost:1234/", "/foo"))
+	assert.Equal(t, "https://localhost:1234/foo", MakeAbsoluteAssetURL("https://localhost:1234/", "/foo/"))
+	assert.Equal(t, "https://localhost:1234/foo/bar", MakeAbsoluteAssetURL("https://localhost:1234/foo", "/bar"))
+	assert.Equal(t, "https://localhost:1234/foo/bar", MakeAbsoluteAssetURL("https://localhost:1234/foo/", "/bar"))
+	assert.Equal(t, "https://localhost:1234/foo/bar", MakeAbsoluteAssetURL("https://localhost:1234/foo/", "/bar/"))
+}
+
+func TestMakeManifestData(t *testing.T) {
+	jsonBytes := MakeManifestData(`Example App '\"`, "https://example.com/foo/bar");
+	assert.True(t, json.Valid(jsonBytes))
+}

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -5,7 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<title>{{if .Title}}{{.Title | RenderEmojiPlain}} - {{end}} {{if .Repository.Name}}{{.Repository.Name}} - {{end}}{{AppName}} </title>
-	<link rel="manifest" href="{{.ManifestData}}"/>
+	<link rel="manifest" href="data:{{.ManifestData}}"/>
 	<meta name="theme-color" content="{{ThemeColorMetaTag}}">
 	<meta name="default-theme" content="{{DefaultTheme}}" />
 	<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}{{MetaAuthor}}{{end}}" />


### PR DESCRIPTION
The previous URL encoding would encode spaces to '+' for the app name (e.g. `Gitea:+Git+with+a+cup+of+tea`) which is incorrect. Use base64 encoding instead which does not have such issues. Also, use JSON escaping which is sufficient for the data.