### PR TITLE
Fix inconsistent type of HookTask.Typ

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -642,8 +642,8 @@ type HookTask struct {
 	HookID          int64
 	UUID            string
 	Typ             HookTaskType `xorm:"char(16) 'type'"`
-	URL             string `xorm:"TEXT"`
-	Signature       string `xorm:"TEXT"`
+	URL             string       `xorm:"TEXT"`
+	Signature       string       `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -641,7 +641,7 @@ type HookTask struct {
 	RepoID          int64 `xorm:"INDEX"`
 	HookID          int64
 	UUID            string
-	Typ             HookTaskType
+	Typ             HookTaskType `xorm:"char(16) 'type'"`
 	URL             string `xorm:"TEXT"`
 	Signature       string `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`


### PR DESCRIPTION
Webhook type has been changed to string ([CHAR(16)](https://github.com/lunny/gitea/blob/29440279184defe8d43147bb395ef708f9dff7cd/models/migrations/v161.go#L37)) in #13664 and will be synced to the database, but this field in webhook.go has not. This may result in `...rm/session_schema.go:339:Sync2() [W] Table hook_task column typ db type is CHAR(16), struct type is VARCHAR(255)` error and failure quries.