### PR TITLE
Hide migration failed by default

### DIFF
--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -23,7 +23,7 @@
 							<div id="repo_migrating_progress">
 								<p>{{.i18n.Tr "repo.migrate.migrating" .CloneAddr | Safe}}</p>
 							</div>
-							<div id="repo_migrating_failed">
+							<div id="repo_migrating_failed" hidden>
 								<p>{{.i18n.Tr "repo.migrate.migrating_failed" .CloneAddr | Safe}}</p>
 								<p id="repo_migrating_failed_error"></p>
 							</div>


### PR DESCRIPTION
Small change to prevent the "migrating_failed" message from showing up briefly before the javascript loads.
