### PR TITLE
Replace 'show-ref' command with 'branch' and 'tag'

### DIFF
--- a/modules/git/repo_tag_nogogit.go
+++ b/modules/git/repo_tag_nogogit.go
@@ -7,6 +7,12 @@
 
 package git
 
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
 // IsTagExist returns true if given tag exists in the repository.
 func (repo *Repository) IsTagExist(name string) bool {
 	return IsReferenceExist(repo.Path, TagPrefix+name)
@@ -14,5 +20,51 @@ func (repo *Repository) IsTagExist(name string) bool {
 
 // GetTags returns all tags of the repository.
 func (repo *Repository) GetTags() ([]string, error) {
-	return callShowRef(repo.Path, TagPrefix, "--tags")
+	return callTag(repo.Path, "--list")
+}
+
+func callTag(repoPath, arg string) ([]string, error) {
+	var tagNames []string
+
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer func() {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+	}()
+
+	go func() {
+		stderrBuilder := &strings.Builder{}
+		err := NewCommand("tag", arg).RunInDirPipeline(repoPath, stdoutWriter, stderrBuilder)
+		if err != nil {
+			if stderrBuilder.Len() == 0 {
+				_ = stdoutWriter.Close()
+				return
+			}
+			_ = stdoutWriter.CloseWithError(ConcatenateError(err, stderrBuilder.String()))
+		} else {
+			_ = stdoutWriter.Close()
+		}
+	}()
+
+	bufReader := bufio.NewReader(stdoutReader)
+	for {
+		// The output of tag is simply a list:
+		// LF
+		tagName, err := bufReader.ReadString('\n')
+		if err == io.EOF {
+			// Reverse order
+			for i := 0; i < len(tagNames)/2; i++ {
+				j := len(tagNames) - i - 1
+				tagNames[i], tagNames[j] = tagNames[j], tagNames[i]
+			}
+
+			return tagNames, nil
+		}
+		if err != nil {
+			// This shouldn't happen... but we'll tolerate it for the sake of peace
+			return nil, err
+		}
+		tagName = strings.TrimSpace(tagName)
+		tagNames = append(tagNames, tagName)
+	}
 }


### PR DESCRIPTION
Supports #14180.

I'm no expert at git but I found that `git show-ref` is much slower than `git branch` and `git tag`. With this PR, the loading time of the PyTorch repo homepage drops from ~20s to 5s.

I also added the reverse logic for `GetTags` which somehow left out in #13673. The reverse logic exists in the gogit variant.