### PR TITLE
When visit /favicon.ico but the static file is not exist return 404 but not continue to handle the route (#14211)

### DIFF
--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -38,6 +38,7 @@ var KnownPublicEntries = []string{
 	"js",
 	"serviceworker.js",
 	"vendor",
+	"favicon.ico",
 }
 
 // Custom implements the macaron static handler for serving custom assets.


### PR DESCRIPTION
backport from #14211