### PR TITLE
Publish docker rootless docs

### DIFF
--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -4,7 +4,7 @@ title: "Installation with Docker (rootless)"
 slug: "install-with-docker-rootless"
 weight: 10
 toc: false
-draft: true
+draft: false
 menu:
   sidebar:
     parent: "installation"


### PR DESCRIPTION
I seems to have forgotten to remove the draft params on the rootless docs before merging.
We need to set draft to false to publish the page on docs.gitea.io.