### PR TITLE
Handle NotifyCreateRef as create branch in feeds

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2495,6 +2495,7 @@ mirror_sync_delete = synced and deleted reference <code>%[2]s</code> at <a href=
 approve_pull_request = `approved <a href="%s/pulls/%s">%s#%[2]s</a>`
 reject_pull_request = `suggested changes for <a href="%s/pulls/%s">%s#%[2]s</a>`
 publish_release  = `released <a href="%s/releases/tag/%s"> "%[4]s" </a> at <a href="%[1]s">%[3]s</a>`
+create_branch = created branch <a href="%[1]s/src/branch/%[2]s">%[3]s</a> in <a href="%[1]s">%[4]s</a>
 
 [tool]
 ago = %s ago

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -18,7 +18,11 @@
 							{{$.i18n.Tr "action.rename_repo" .GetContent .GetRepoLink .ShortRepoPath | Str2html}}
 						{{else if eq .GetOpType 5}}
 							{{ $branchLink := .GetBranch | EscapePound | Escape}}
-							{{$.i18n.Tr "action.commit_repo" .GetRepoLink $branchLink (Escape .GetBranch) .ShortRepoPath | Str2html}}
+							{{if .Content}}
+								{{$.i18n.Tr "action.commit_repo" .GetRepoLink $branchLink (Escape .GetBranch) .ShortRepoPath | Str2html}}
+							{{else}}
+								{{$.i18n.Tr "action.create_branch" .GetRepoLink $branchLink (Escape .GetBranch) .ShortRepoPath | Str2html}}
+							{{end}}
 						{{else if eq .GetOpType 6}}
 							{{ $index := index .GetIssueInfos 0}}
 							{{$.i18n.Tr "action.create_issue" .GetRepoLink $index .ShortRepoPath | Str2html}}


### PR DESCRIPTION
A rather ugly workaround for the fact that `NotifyCreateRef` must use `ActionCommitRepo`.

This is basically how everyone else has to deal with it for webhooks (which follow how GH does it) to catch 'create branch' event.

Avoids having two 'pushed to {{branch}}` actions, one empty and another with actual commits, on dashboard feeds.