### PR TITLE
Kd/add bountysource

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 open_collective: gitea
+custom: https://www.bountysource.com/teams/gitea

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@
   <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea" title="TODOs">
     <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea">
   </a>
+  <a href="https://img.shields.io/bountysource/team/gitea" title="Bountysource">
+    <img src="https://img.shields.io/bountysource/team/gitea/activity">
+  </a>
 </p>
 
 <p align="center">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -42,6 +42,9 @@
   <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea" title="TODOs">
     <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea">
   </a>
+  <a href="https://img.shields.io/bountysource/team/gitea" title="Bountysource">
+    <img src="https://img.shields.io/bountysource/team/gitea/activity">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Add bountysource to sponsors and readme page. 

Unfortunately, the "activity" badge for bountysource isn't a great metric (would be much better to have the $ amount of outstanding bounties), but unfortunately I couldn't find a way to get that. I believe this is better than nothing.

  <a href="https://img.shields.io/bountysource/team/gitea" title="Bountysource">
    <img src="https://img.shields.io/bountysource/team/gitea/activity">
  </a>
