### PR TITLE
Use ServerError provided by Context

### DIFF
--- a/routers/admin/users.go
+++ b/routers/admin/users.go
@@ -188,7 +188,7 @@ func prepareUserInfo(ctx *context.Context) *models.User {
 	_, err = models.GetTwoFactorByUID(u.ID)
 	if err != nil {
 		if !models.IsErrTwoFactorNotEnrolled(err) {
-			ctx.InternalServerError(err)
+			ctx.ServerError("IsErrTwoFactorNotEnrolled", err)
 			return nil
 		}
 		ctx.Data["TwoFactorEnabled"] = false
@@ -268,7 +268,7 @@ func EditUserPost(ctx *context.Context, form auth.AdminEditUserForm) {
 			return
 		}
 		if err = u.SetPassword(form.Password); err != nil {
-			ctx.InternalServerError(err)
+			ctx.ServerError("SetPassword", err)
 			return
 		}
 	}
@@ -285,12 +285,12 @@ func EditUserPost(ctx *context.Context, form auth.AdminEditUserForm) {
 	if form.Reset2FA {
 		tf, err := models.GetTwoFactorByUID(u.ID)
 		if err != nil && !models.IsErrTwoFactorNotEnrolled(err) {
-			ctx.InternalServerError(err)
+			ctx.ServerError("GetTwoFactorByUID", err)
 			return
 		}
 
 		if err = models.DeleteTwoFactorByID(tf.ID, u.ID); err != nil {
-			ctx.InternalServerError(err)
+			ctx.ServerError("DeleteTwoFactorByID", err)
 			return
 		}
 	}

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -1117,7 +1117,7 @@ func ViewIssue(ctx *context.Context) {
 		iw.IssueID = issue.ID
 		iw.IsWatching, err = models.CheckIssueWatch(ctx.User, issue)
 		if err != nil {
-			ctx.InternalServerError(err)
+			ctx.ServerError("CheckIssueWatch", err)
 			return
 		}
 	}

--- a/routers/repo/projects.go
+++ b/routers/repo/projects.go
@@ -355,7 +355,7 @@ func DeleteProjectBoard(ctx *context.Context) {
 
 	pb, err := models.GetProjectBoard(ctx.ParamsInt64(":boardID"))
 	if err != nil {
-		ctx.InternalServerError(err)
+		ctx.ServerError("GetProjectBoard", err)
 		return
 	}
 	if pb.ProjectID != ctx.ParamsInt64(":id") {
@@ -445,7 +445,7 @@ func EditProjectBoardTitle(ctx *context.Context, form auth.EditProjectBoardTitle
 
 	board, err := models.GetProjectBoard(ctx.ParamsInt64(":boardID"))
 	if err != nil {
-		ctx.InternalServerError(err)
+		ctx.ServerError("GetProjectBoard", err)
 		return
 	}
 	if board.ProjectID != ctx.ParamsInt64(":id") {

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -713,11 +713,11 @@ func UpdatePullRequest(ctx *context.Context) {
 	}
 
 	if err := issue.PullRequest.LoadBaseRepo(); err != nil {
-		ctx.InternalServerError(err)
+		ctx.ServerError("LoadBaseRepo", err)
 		return
 	}
 	if err := issue.PullRequest.LoadHeadRepo(); err != nil {
-		ctx.InternalServerError(err)
+		ctx.ServerError("LoadHeadRepo", err)
 		return
 	}
 


### PR DESCRIPTION
`ctx.InternalServerError(err)` could not be used with `context.Context` because it's a method of `macaron.Context` or `context.APIContext`.

Bugs introduced in #14243, #10967, #9784, #8346