### PR TITLE
Add hyperlink markup for Reviewed-on links on Pull Request textareas

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -261,7 +261,7 @@
 										<input type="text" name="merge_title_field" value="{{.Issue.PullRequest.GetDefaultMergeMessage}}">
 									</div>
 									<div class="field">
-										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">Reviewed-on: {{$.Issue.HTMLURL}}&#13;&#10;{{$approvers}}</textarea>
+										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">Reviewed-on: [{{$.Issue.HTMLURL}}]&#13;&#10;{{$approvers}}</textarea>
 									</div>
 									<button class="ui green button" type="submit" name="do" value="merge">
 										{{$.i18n.Tr "repo.pulls.merge_pull_request"}}
@@ -293,7 +293,7 @@
 										<input type="text" name="merge_title_field" value="{{.Issue.PullRequest.GetDefaultMergeMessage}}">
 									</div>
 									<div class="field">
-										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">Reviewed-on: {{$.Issue.HTMLURL}}&#13;&#10;{{$approvers}}</textarea>
+										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">Reviewed-on: [{{$.Issue.HTMLURL}}]&#13;&#10;{{$approvers}}</textarea>
 									</div>
 									<button class="ui green button" type="submit" name="do" value="rebase-merge">
 										{{$.i18n.Tr "repo.pulls.rebase_merge_commit_pull_request"}}
@@ -312,7 +312,7 @@
 										<input type="text" name="merge_title_field" value="{{.Issue.PullRequest.GetDefaultSquashMessage}}">
 									</div>
 									<div class="field">
-										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">{{.GetCommitMessages}}Reviewed-on: {{$.Issue.HTMLURL}}&#13;&#10;{{$approvers}}</textarea>
+										<textarea name="merge_message_field" rows="5" placeholder="{{$.i18n.Tr "repo.editor.commit_message_desc"}}">{{.GetCommitMessages}}Reviewed-on: [{{$.Issue.HTMLURL}}]&#13;&#10;{{$approvers}}</textarea>
 									</div>
 									<button class="ui green button" type="submit" name="do" value="squash">
 										{{$.i18n.Tr "repo.pulls.squash_merge_pull_request"}}


### PR DESCRIPTION
At work we have some webhooks that use the data submitted by the PR textarea to add a comment to a Jira instance. We also decorate the text submitted with some additional jira-markup, so it appears inside a panel, with all lines converted to italic (prepending and appending a `_` character to each line, among other things - we'd like to not touch this process if possible).

However, the `Reviewed-on:` lines don't get correctly formatted, as Jira thinks that the `_` ending character is part of the URL. Adding the brackets around the url is enough to fix our issue and get those lines correctly formatted, and doesn't seem to affect gitea, as the url is rendered anyways, no matter if it's enclosed by brackets or not. 

Currently we use a custom template for this file, but that forces us to keep the file in sync every time we upgrade, which is not ideal, hence the PR (no issue created for it as it is a trivial change).


txs,
juan pablo
