### PR TITLE
Allow passcode invalid error to appear

### DIFF
--- a/routers/user/setting/security_twofa.go
+++ b/routers/user/setting/security_twofa.go
@@ -195,7 +195,7 @@ func EnrollTwoFactorPost(ctx *context.Context, form auth.TwoFactorAuthForm) {
 			return
 		}
 		ctx.Flash.Error(ctx.Tr("settings.passcode_invalid"))
-		ctx.HTML(200, tplSettingsTwofaEnroll)
+		ctx.Redirect(setting.AppSubURL + "/user/settings/security/two_factor/enroll")
 		return
 	}
 


### PR DESCRIPTION
This PR fixes a bug where an invalid passcode for 2FA is entered, but the `The passcode is incorrect. Try again.`  error message is not displayed:

![Settings - Gitea: Git with a cup of tea 2021-01-18 13-34-44](https://user-images.githubusercontent.com/9525/104866154-f629da00-5991-11eb-9763-0f0a86f6b2b2.png)

