### PR TITLE
Display error if twofaSecret cannot be retrieved

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -625,6 +625,7 @@ or_enter_secret = Or enter the secret: %s
 then_enter_passcode = And enter the passcode shown in the application:
 passcode_invalid = The passcode is incorrect. Try again.
 twofa_enrolled = Your account has been enrolled into two-factor authentication. Store your scratch token (%s) in a safe place as it is only shown once!
+twofa_failed_get_secret = Failed to get secret.
 
 u2f_desc = Security keys are hardware devices containing cryptographic keys. They can be used for two-factor authentication. Security keys must support the <a rel="noreferrer" href="https://fidoalliance.org/">FIDO U2F</a> standard.
 u2f_require_twofa = Your account must be enrolled in two-factor authentication to use security keys.

--- a/routers/user/setting/security_twofa.go
+++ b/routers/user/setting/security_twofa.go
@@ -189,7 +189,14 @@ func EnrollTwoFactorPost(ctx *context.Context, form auth.TwoFactorAuthForm) {
 		return
 	}
 
-	secret := ctx.Session.Get("twofaSecret").(string)
+	secretRaw := ctx.Session.Get("twofaSecret")
+	if secretRaw == nil {
+		ctx.Flash.Error(ctx.Tr("settings.twofa_failed_get_secret"))
+		ctx.Redirect(setting.AppSubURL + "/user/settings/security/two_factor/enroll")
+		return
+	}
+
+	secret := secretRaw.(string)
 	if !totp.Validate(form.Passcode, secret) {
 		if !twofaGenerateSecretAndQr(ctx) {
 			return


### PR DESCRIPTION
This PR fixes an issue discussed at https://github.com/go-gitea/gitea/issues/14144 where the `twofaSecret` cannot be retrieved from the session. Here we capture this scenario, display the error message `Failed to get secret.` and handle it gracefully instead of returning a 500:

![Settings - Gitea: Git with a cup of tea 2021-01-18 13-28-58](https://user-images.githubusercontent.com/9525/104866324-68022380-5992-11eb-830b-2ab35b2e0a28.png)
