### PR TITLE
Update back-up restore example for 1.13 changes

### DIFF
--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -72,15 +72,21 @@ involves moving files to their correct locations and restoring a database dump.
 Example:
 
 ```sh
-apt-get install gitea
-unzip gitea-dump-1482906742.zip
-cd gitea-dump-1482906742
-mv custom/conf/app.ini /etc/gitea/conf/app.ini # or mv app.ini /etc/gitea/conf/app.ini
-unzip gitea-repo.zip
-mv gitea-repo/* /var/lib/gitea/repositories/
-chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea/repositories/
+unzip gitea-dump-1610949662.zip
+cd gitea-dump-1610949662
+mv data/conf/app.ini /etc/gitea/conf/app.ini
+mv data/* /var/lib/gitea/data/
+mv log/* /var/lib/gitea/log/
+mv repos/* /var/lib/gitea/repositories/
+chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea
+
+# mysql
 mysql --default-character-set=utf8mb4 -u$USER -p$PASS $DATABASE <gitea-db.sql
-# or  sqlite3 $DATABASE_PATH <gitea-db.sql
+# sqlite3
+sqlite3 $DATABASE_PATH <gitea-db.sql
+# postgres
+psql -U $USER -d $DATABASE < gitea-db.sql
+
 service gitea restart
 ```
 

--- a/docs/content/doc/usage/backup-and-restore.zh-cn.md
+++ b/docs/content/doc/usage/backup-and-restore.zh-cn.md
@@ -46,15 +46,21 @@ Gitea 已经实现了 `dump` 命令可以用来备份所有需要的文件到一
 
 例如：
 
-```
-apt-get install gitea
-unzip gitea-dump-1482906742.zip
-cd gitea-dump-1482906742
-mv custom/conf/app.ini /etc/gitea/conf/app.ini
-unzip gitea-repo.zip
-mv gitea-repo/* /var/lib/gitea/repositories/
-chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea/repositories/
+```sh
+unzip gitea-dump-1610949662.zip
+cd gitea-dump-1610949662
+mv data/conf/app.ini /etc/gitea/conf/app.ini
+mv data/* /var/lib/gitea/data/
+mv log/* /var/lib/gitea/log/
+mv repos/* /var/lib/gitea/repositories/
+chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea
+
+# mysql
 mysql --default-character-set=utf8mb4 -u$USER -p$PASS $DATABASE <gitea-db.sql
-# or  sqlite3 $DATABASE_PATH <gitea-db.sql
+# sqlite3
+sqlite3 $DATABASE_PATH <gitea-db.sql
+# postgres
+psql -U $USER -d $DATABASE < gitea-db.sql
+
 service gitea restart
 ```

--- a/docs/content/doc/usage/backup-and-restore.zh-tw.md
+++ b/docs/content/doc/usage/backup-and-restore.zh-tw.md
@@ -43,3 +43,23 @@ Gitea 目前支援 `dump` 指令，用來將資料備份成 zip 檔案，後續�
 ## 還原指令 (`restore`)
 
 持續更新中: 此文件尚未完成.
+
+例:
+```sh
+unzip gitea-dump-1610949662.zip
+cd gitea-dump-1610949662
+mv data/conf/app.ini /etc/gitea/conf/app.ini
+mv data/* /var/lib/gitea/data/
+mv log/* /var/lib/gitea/log/
+mv repos/* /var/lib/gitea/repositories/
+chown -R gitea:gitea /etc/gitea/conf/app.ini /var/lib/gitea
+
+# mysql
+mysql --default-character-set=utf8mb4 -u$USER -p$PASS $DATABASE <gitea-db.sql
+# sqlite3
+sqlite3 $DATABASE_PATH <gitea-db.sql
+# postgres
+psql -U $USER -d $DATABASE < gitea-db.sql
+
+service gitea restart
+```


### PR DESCRIPTION
Update back-up/restore documentation with the recent changes made to the `gitea dump` command in version 1.13

Fixes #14373

Signed-off-by: Daniël Vos <danielvos@outlook.com>
