### PR TITLE
Improve Description in new/ edit Project template

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -926,7 +926,8 @@ ext_issues = Ext. Issues
 ext_issues.desc = Link to an external issue tracker.
 
 projects = Projects
-projects.desc = Manage issues and pulls in project boards.
+projects.description = Description (optional)
+projects.description_placeholder = Description
 projects.create = Create Project
 projects.title = Title
 projects.new = New project

--- a/templates/repo/projects/new.tmpl
+++ b/templates/repo/projects/new.tmpl
@@ -29,8 +29,8 @@
 					<input name="title" placeholder="{{.i18n.Tr "repo.projects.title"}}" value="{{.title}}" autofocus required>
 				</div>
 				<div class="field">
-					<label>{{.i18n.Tr "repo.projects.desc"}}</label>
-					<textarea name="content">{{.content}}</textarea>
+					<label>{{.i18n.Tr "repo.projects.description"}}</label>
+					<textarea name="content" placeholder="{{.i18n.Tr "repo.projects.description_placeholder"}}">{{.content}}</textarea>
 				</div>
 
 				{{if not .PageIsEditProjects}}


### PR DESCRIPTION
Previously, non-descriptive text was displayed where a user is prompted to add a project description.
That has been updated with a more descriptive text.

Fixes #14358
