### PR TITLE
[API] Error dont return html

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -73,6 +73,11 @@ type APIRedirect struct{}
 // swagger:response string
 type APIString string
 
+// ServerError responds with error message, status is 500
+func (ctx *APIContext) ServerError(title string, err error) {
+	ctx.Error(http.StatusInternalServerError, title, err)
+}
+
 // Error responds with an error message to client with given obj as the message.
 // If status is 500, also it prints error to log.
 func (ctx *APIContext) Error(status int, title string, obj interface{}) {


### PR DESCRIPTION
regression of #11355

Explanation:
`ctx.ServerError()` was not overloaded by APIContext so it would respond with an html error page instead of json :/

in the past I rewrote it with ctx.Error() or ctx.InternalServerError() but this issue is so common that it's better to overload this function instead