### PR TITLE
chore: bump minio to RELEASE.2021-01-16T02-19-44Z

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -176,7 +176,7 @@ services:
     image: elasticsearch:7.5.0
 
   - name: minio
-    image: minio/minio:RELEASE.2020-10-09T22-55-05Z
+    image: minio/minio:RELEASE.2021-01-16T02-19-44Z
     commands:
     - minio server /data
     environment:


### PR DESCRIPTION
As title says, bump minio version to a newer release, specifically like this here:
```diff
-    image: minio/minio:RELEASE.2020-10-09T22-55-05Z
+    image: minio/minio:RELEASE.2021-01-16T02-19-44Z
```