### PR TITLE
Fix incorrect key name so registerManualConfirm works

### DIFF
--- a/modules/setting/service.go
+++ b/modules/setting/service.go
@@ -67,7 +67,7 @@ func newService() {
 	Service.DisableRegistration = sec.Key("DISABLE_REGISTRATION").MustBool()
 	Service.AllowOnlyExternalRegistration = sec.Key("ALLOW_ONLY_EXTERNAL_REGISTRATION").MustBool()
 	if !sec.Key("REGISTER_EMAIL_CONFIRM").MustBool() {
-		Service.RegisterManualConfirm = sec.Key("REGISTER_EMAIL_CONFIRM").MustBool(false)
+		Service.RegisterManualConfirm = sec.Key("REGISTER_MANUAL_CONFIRM").MustBool(false)
 	} else {
 		Service.RegisterManualConfirm = false
 	}


### PR DESCRIPTION
Fix incorrect key name so registerManualConfirm works.
Otherwise, the registerManualConfirm setting is never enabled in the code.

The current code seems to have an obvious typo in the key name.