### PR TITLE
Remove the confusing preview tab on wiki editor

### DIFF
--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -18,7 +18,6 @@
 			</div>
 			<div class="ui top attached tabular menu previewtabs">
 				<a class="active item" data-tab="write">{{.i18n.Tr "write"}}</a>
-				<a class="item" data-tab="preview">{{.i18n.Tr "preview"}}</a>
 			</div>
 			<div class="field">
 				<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.APIURL}}/markdown" data-context="{{.RepoLink}}" required>{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>


### PR DESCRIPTION
Fix #14196 

Since there is already a button on toolbar to preview, it's unnecessary to add another tab to preview because it's confusing.