### PR TITLE
Use gitea.svg instead of logo.svg

### DIFF
--- a/build/generate-svg.js
+++ b/build/generate-svg.js
@@ -65,7 +65,7 @@ async function main() {
   await Promise.all([
     ...processFiles('../node_modules/@primer/octicons/build/svg/*-16.svg', {prefix: 'octicon'}),
     ...processFiles('../web_src/svg/*.svg'),
-    ...processFiles('../assets/logo.svg', {fullName: 'gitea-gitea'}),
+    ...processFiles('../public/img/gitea.svg', {fullName: 'gitea-gitea'}),
   ]);
 }
 


### PR DESCRIPTION
Small fix to use gitea.svg instead of logo.svg for `public/img/svg/gitea-gitea.svg`

Prevents user from breaking the gitea svg when they update `assets/logo.svg`