### PR TITLE
Fix: url.Values map was not initialized

### DIFF
--- a/modules/middlewares/flash.go
+++ b/modules/middlewares/flash.go
@@ -27,6 +27,9 @@ type Flash struct {
 }
 
 func (f *Flash) set(name, msg string, current ...bool) {
+	if f.Values == nil {
+		f.Values = make(map[string][]string)
+	}
 	isShow := false
 	if (len(current) == 0 && FlashNow) ||
 		(len(current) > 0 && current[0]) {


### PR DESCRIPTION
Fixes Error 500 after submission of initial gitea user configuration.

Values map was not initialized, leading to panic

There may be a better way of dealing with this, so please review. Thanks!