### PR TITLE
Internal ssh server respect Ciphers, MACs and  KeyExchanges settings

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -241,13 +241,17 @@ func publicKeyHandler(ctx ssh.Context, key ssh.PublicKey) bool {
 
 // Listen starts a SSH server listens on given port.
 func Listen(host string, port int, ciphers []string, keyExchanges []string, macs []string) {
-	// TODO: Handle ciphers, keyExchanges, and macs
-
 	srv := ssh.Server{
 		Addr:             fmt.Sprintf("%s:%d", host, port),
 		PublicKeyHandler: publicKeyHandler,
 		Handler:          sessionHandler,
-
+		ServerConfigCallback: func(ctx ssh.Context) *gossh.ServerConfig {
+			config := &gossh.ServerConfig{}
+			config.KeyExchanges = keyExchanges
+			config.MACs = macs
+			config.Ciphers = ciphers
+			return config
+		},
 		// We need to explicitly disable the PtyCallback so text displays
 		// properly.
 		PtyCallback: func(ctx ssh.Context, pty ssh.Pty) bool {


### PR DESCRIPTION
Fix `// TODO: Handle ciphers, keyExchanges, and macs` for internal ssh server.
Fix #14518

Details see [here](https://github.com/gliderlabs/ssh/pull/95) (despite it was [renamed](https://github.com/gliderlabs/ssh/pull/112)).

Testconfig:

```
START_SSH_SERVER = true
SSH_SERVER_MACS  = hmac-sha2-256-etm@openssh.com, hmac-sha2-256
SSH_PORT                   = 2222
```

Before:
```
# nmap --script ssh2-enum-algos -sV -p 2222 gitea.example.com
Starting Nmap 7.80 ( https://nmap.org ) at 2021-01-29 17:46 CET
Nmap scan report for gitea.example.com (xxx.xxx.xxx.xxx)
Host is up (0.00055s latency).

PORT     STATE SERVICE VERSION
2222/tcp open  ssh     (protocol 2.0)
| fingerprint-strings: 
|   NULL: 
|_    SSH-2.0-Go
| ssh2-enum-algos: 
|   kex_algorithms: (5)
|       curve25519-sha256@libssh.org
|       ecdh-sha2-nistp256
|       ecdh-sha2-nistp384
|       ecdh-sha2-nistp521
|       diffie-hellman-group14-sha1
|   server_host_key_algorithms: (1)
|       ssh-rsa
|   encryption_algorithms: (5)
|       aes128-gcm@openssh.com
|       chacha20-poly1305@openssh.com
|       aes128-ctr
|       aes192-ctr
|       aes256-ctr
|   mac_algorithms: (4)
|       hmac-sha2-256-etm@openssh.com
|       hmac-sha2-256
|       hmac-sha1
|       hmac-sha1-96
|   compression_algorithms: (1)
|_      none
```

Afterwards:
```
# nmap --script ssh2-enum-algos -sV -p 2222 gitea.lan | sed 's,gitea\.lan,gitea.example.com,g'
Starting Nmap 7.80 ( https://nmap.org ) at 2021-01-29 17:47 CET
Nmap scan report for gitea.example.com (xxx.xxx.xxx.xxx)
Host is up (0.00052s latency).

PORT     STATE SERVICE VERSION
2222/tcp open  ssh     (protocol 2.0)
| fingerprint-strings: 
|   NULL: 
|_    SSH-2.0-Go
| ssh2-enum-algos: 
|   kex_algorithms: (6)
|       diffie-hellman-group1-sha1
|       diffie-hellman-group14-sha1
|       ecdh-sha2-nistp256
|       ecdh-sha2-nistp384
|       ecdh-sha2-nistp521
|       curve25519-sha256@libssh.org
|   server_host_key_algorithms: (1)
|       ssh-rsa
|   encryption_algorithms: (6)
|       aes128-ctr
|       aes192-ctr
|       aes256-ctr
|       aes128-gcm@openssh.com
|       arcfour256
|       arcfour128
|   mac_algorithms: (2)
|       hmac-sha2-256-etm@openssh.com
|       hmac-sha2-256
|   compression_algorithms: (1)
|_      none
```