### PR TITLE
Set the name Mapper in migrations (#14526)

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -16,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 
 	"xorm.io/xorm"
+	"xorm.io/xorm/names"
 )
 
 const minDBVersion = 70 // Gitea 1.5.3
@@ -296,6 +297,8 @@ func EnsureUpToDate(x *xorm.Engine) error {
 
 // Migrate database to current version
 func Migrate(x *xorm.Engine) error {
+	// Set a new clean the default mapper to GonicMapper as that is the default for Gitea.
+	x.SetMapper(names.GonicMapper{})
 	if err := x.Sync(new(Version)); err != nil {
 		return fmt.Errorf("sync: %v", err)
 	}
@@ -334,6 +337,8 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 	// Migrate
 	for i, m := range migrations[v-minDBVersion:] {
 		log.Info("Migration[%d]: %s", v+int64(i), m.Description())
+		// Reset the mapper between each migration - migrations are not supposed to depend on each other
+		x.SetMapper(names.GonicMapper{})
 		if err = m.Migrate(x); err != nil {
 			return fmt.Errorf("do migrate: %v", err)
 		}


### PR DESCRIPTION
Backport #14526:

Migrations currently uses the default Xorm mapper which is
not the same as the mapper Gitea actually uses.

This means that there is a difference between the struct
parsing and mapping to database tables in migrations as
compared to normal Sync2.

This was the cause for the catastrophic problem in v168 -
untagged fields are not mapped in the same way in migrations
as compared to outside of migrations.

This is also likely the cause of some weird subtle failures
in other migrations as any untagged field may not be being
mapped exactly the same way.

This PR suggests that we ensure that the mapper is set at
the start of the migrations code - but also enforces a strict
clean mapper between each migration.

Signed-off-by: Andrew Thornton <art27@cantab.net>