### PR TITLE
 Adding Chi's GetHead middleware

### DIFF
--- a/routers/routes/web.go
+++ b/routers/routes/web.go
@@ -162,7 +162,8 @@ func WebRoutes() *web.Route {
 	}
 	// Removed: toolbox.Toolboxer middleware will provide debug informations which seems unnecessary
 	r.Use(context.Contexter())
-	// Removed: SetAutoHead allow a get request redirect to head if get method is not exist
+	// GetHead allows a HEAD request redirect to GET if HEAD method is not defined for that route
+	r.Use(middleware.GetHead)
 
 	if setting.EnableAccessLog {
 		r.Use(context.AccessLogger())


### PR DESCRIPTION
Before moving to Chi, HEAD requests were automatically answered by GET
handlers (SetAutoHead(true) from macaron was used).

This Change will restore the previous behaviour.
