### PR TITLE
Add Content-Length header to HEAD requests

### DIFF
--- a/routers/repo/attachment.go
+++ b/routers/repo/attachment.go
@@ -152,7 +152,7 @@ func GetAttachment(ctx *context.Context) {
 		return
 	}
 
-	if err = ServeData(ctx, attach.Name, fr); err != nil {
+	if err = ServeData(ctx, attach.Name, attach.Size, fr); err != nil {
 		ctx.ServerError("ServeData", err)
 		return
 	}

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -8,7 +8,6 @@ package repo
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 	"strings"
 

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -31,7 +31,11 @@ func ServeData(ctx *context.Context, name string, size int64, reader io.Reader) 
 	}
 
 	ctx.Resp.Header().Set("Cache-Control", "public,max-age=86400")
-	ctx.Resp.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+	if size >= 0 {
+		ctx.Resp.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+	} else {
+		log.Error("ServeData called to serve data: %s with size < 0: %d", name, size)
+	}
 	name = path.Base(name)
 
 	// Google Chrome dislike commas in filenames, so let's change it to a space


### PR DESCRIPTION
This change adds the header Content-Length to HEAD HTTP requests.

The previous behavior was blocking some Windows executables (i.e
bitsadmin.exe) from downloading files hosted in Gitea.

This along with PR #14541, makes the web server compliant with HTTP RFC 2616 which states
"The methods GET and HEAD MUST be supported by all general-purpose servers"
and
"The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response."

This should also respond to issues #8030 and #14532.
