### PR TITLE
Honor REGISTER_MANUAL_CONFIRM when doing openid registration

### DIFF
--- a/routers/user/auth_openid.go
+++ b/routers/user/auth_openid.go
@@ -415,7 +415,7 @@ func RegisterOpenIDPost(ctx *context.Context) {
 		Name:     form.UserName,
 		Email:    form.Email,
 		Passwd:   password,
-		IsActive: !setting.Service.RegisterEmailConfirm,
+		IsActive: !(setting.Service.RegisterEmailConfirm || setting.Service.RegisterManualConfirm),
 	}
 	//nolint: dupl
 	if err := models.CreateUser(u); err != nil {


### PR DESCRIPTION
REGISTER_MANUAL_CONFIRM is not honored when doing performing an openid registration. The new account is directly accessible.

With this patch, the manual confirm flag gets honored in the same way as a "normal" registration (as found in routers/user/auth.go).