### PR TITLE
Fix bug about ListOptions and stars/watchers pagnation

### DIFF
--- a/models/commit_status_test.go
+++ b/models/commit_status_test.go
@@ -18,7 +18,7 @@ func TestGetCommitStatuses(t *testing.T) {
 
 	sha1 := "1234123412341234123412341234123412341234"
 
-	statuses, maxResults, err := GetCommitStatuses(repo1, sha1, &CommitStatusOptions{})
+	statuses, maxResults, err := GetCommitStatuses(repo1, sha1, &CommitStatusOptions{ListOptions: ListOptions{Page: 1, PageSize: 50}})
 	assert.NoError(t, err)
 	assert.Equal(t, int(maxResults), 5)
 	assert.Len(t, statuses, 5)

--- a/models/list_options.go
+++ b/models/list_options.go
@@ -16,13 +16,13 @@ type ListOptions struct {
 	Page     int // start from 1
 }
 
-func (opts ListOptions) getPaginatedSession() *xorm.Session {
+func (opts *ListOptions) getPaginatedSession() *xorm.Session {
 	opts.setDefaultValues()
 
 	return x.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize)
 }
 
-func (opts ListOptions) setSessionPagination(sess *xorm.Session) *xorm.Session {
+func (opts *ListOptions) setSessionPagination(sess *xorm.Session) *xorm.Session {
 	opts.setDefaultValues()
 
 	if opts.PageSize <= 0 {
@@ -31,21 +31,21 @@ func (opts ListOptions) setSessionPagination(sess *xorm.Session) *xorm.Session {
 	return sess.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize)
 }
 
-func (opts ListOptions) setEnginePagination(e Engine) Engine {
+func (opts *ListOptions) setEnginePagination(e Engine) Engine {
 	opts.setDefaultValues()
 
 	return e.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize)
 }
 
 // GetStartEnd returns the start and end of the ListOptions
-func (opts ListOptions) GetStartEnd() (start, end int) {
+func (opts *ListOptions) GetStartEnd() (start, end int) {
 	opts.setDefaultValues()
 	start = (opts.Page - 1) * opts.PageSize
 	end = start + opts.Page
 	return
 }
 
-func (opts ListOptions) setDefaultValues() {
+func (opts *ListOptions) setDefaultValues() {
 	if opts.PageSize <= 0 {
 		opts.PageSize = setting.API.DefaultPagingNum
 	}

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -713,7 +713,10 @@ func RenderUserCards(ctx *context.Context, total int, getter func(opts models.Li
 	pager := context.NewPagination(total, models.ItemsPerPage, page, 5)
 	ctx.Data["Page"] = pager
 
-	items, err := getter(models.ListOptions{Page: pager.Paginater.Current()})
+	items, err := getter(models.ListOptions{
+		Page:     pager.Paginater.Current(),
+		PageSize: models.ItemsPerPage,
+	})
 	if err != nil {
 		ctx.ServerError("getter", err)
 		return
@@ -744,6 +747,7 @@ func Stars(ctx *context.Context) {
 func Forks(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repos.forks")
 
+	// TODO: need pagination
 	forks, err := ctx.Repo.Repository.GetForks(models.ListOptions{})
 	if err != nil {
 		ctx.ServerError("GetForks", err)


### PR DESCRIPTION
`ListOptions` is introduced by #9452. So there is maybe also some bugs on API pagination.

For stars/watchers, the default pagesize should not be the same as ListOptions' default which will be `setting.API.DefaultPagingNum`.

And I also found that `forks` also needs pagination so I added a `TODO` comment.

Fix #14553