### PR TITLE
Fix gpg key deletion

### DIFF
--- a/models/gpg_key.go
+++ b/models/gpg_key.go
@@ -65,7 +65,11 @@ func (key *GPGKey) AfterLoad(session *xorm.Session) {
 
 // ListGPGKeys returns a list of public keys belongs to given user.
 func ListGPGKeys(uid int64, listOptions ListOptions) ([]*GPGKey, error) {
-	sess := x.Where("owner_id=? AND primary_key_id=''", uid)
+	return listGPGKeys(x, uid, listOptions)
+}
+
+func listGPGKeys(e Engine, uid int64, listOptions ListOptions) ([]*GPGKey, error) {
+	sess := e.Table(&GPGKey{}).Where("owner_id=? AND primary_key_id=''", uid)
 	if listOptions.Page != 0 {
 		sess = listOptions.setSessionPagination(sess)
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -1208,7 +1208,7 @@ func deleteUser(e Engine, u *User) error {
 	// ***** END: PublicKey *****
 
 	// ***** START: GPGPublicKey *****
-	keys, err := ListGPGKeys(u.ID, ListOptions{})
+	keys, err := listGPGKeys(e, u.ID, ListOptions{})
 	if err != nil {
 		return fmt.Errorf("ListGPGKeys: %v", err)
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -1208,6 +1208,16 @@ func deleteUser(e Engine, u *User) error {
 	// ***** END: PublicKey *****
 
 	// ***** START: GPGPublicKey *****
+    keys, err := ListGPGKeys(u.ID, ListOptions{})
+    if err != nil {
+        return fmt.Errorf("ListGPGKeys: %v", err)
+    }
+    // Delete GPGKeyImport(s).
+    for _, key := range keys {
+        if _, err = e.Delete(&GPGKeyImport{KeyID: key.KeyID}); err != nil {
+            return fmt.Errorf("deleteGPGKeyImports: %v", err)
+        }
+    }
 	if _, err = e.Delete(&GPGKey{OwnerID: u.ID}); err != nil {
 		return fmt.Errorf("deleteGPGKeys: %v", err)
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -1208,16 +1208,16 @@ func deleteUser(e Engine, u *User) error {
 	// ***** END: PublicKey *****
 
 	// ***** START: GPGPublicKey *****
-    keys, err := ListGPGKeys(u.ID, ListOptions{})
-    if err != nil {
-        return fmt.Errorf("ListGPGKeys: %v", err)
-    }
-    // Delete GPGKeyImport(s).
-    for _, key := range keys {
-        if _, err = e.Delete(&GPGKeyImport{KeyID: key.KeyID}); err != nil {
-            return fmt.Errorf("deleteGPGKeyImports: %v", err)
-        }
-    }
+	keys, err := ListGPGKeys(u.ID, ListOptions{})
+	if err != nil {
+		return fmt.Errorf("ListGPGKeys: %v", err)
+	}
+	// Delete GPGKeyImport(s).
+	for _, key := range keys {
+		if _, err = e.Delete(&GPGKeyImport{KeyID: key.KeyID}); err != nil {
+			return fmt.Errorf("deleteGPGKeyImports: %v", err)
+		}
+	}
 	if _, err = e.Delete(&GPGKey{OwnerID: u.ID}); err != nil {
 		return fmt.Errorf("deleteGPGKeys: %v", err)
 	}


### PR DESCRIPTION
Fixes #14531.

Per #14531, deleting a user account will delete the user's GPG keys
from the `gpg_key` table but not from `gpg_key_import`, which causes
an error when creating an account with the same email and attempting
to re-add the same key. This commit deletes all entries from
`gpg_key_import` that match any GPG key IDs belonging to the user.

Note: Deleting the user's keys from `gpg_key_import` this way seems pretty convoluted,
but I don't see an obvious alternative except for maybe modifying `GPGKeyImport` to
have an `OwnerID` field as in `GPGKey`.