### PR TITLE
[API] Add  delete release by tag & fix unreleased inconsistency

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -754,6 +754,7 @@ func Routes() *web.Route {
 				}, reqToken(), reqAdmin())
 				m.Group("/tags", func() {
 					m.Get("", repo.ListTags)
+					m.Delete("/{tag}", repo.DeleteTag)
 				}, reqRepoReader(models.UnitTypeCode), context.ReferencesGitRepo(true))
 				m.Group("/keys", func() {
 					m.Combo("").Get(repo.ListDeployKeys).

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -862,8 +862,8 @@ func Routes() *web.Route {
 					})
 					m.Group("/tags", func() {
 						m.Combo("/{tag}").
-							Get(repo.GetReleaseTag).
-							Delete(reqToken(), reqRepoWriter(models.UnitTypeReleases), repo.DeleteReleaseTag)
+							Get(repo.GetReleaseByTag).
+							Delete(reqToken(), reqRepoWriter(models.UnitTypeReleases), repo.DeleteReleaseByTag)
 					})
 				}, reqRepoReader(models.UnitTypeReleases))
 				m.Post("/mirror-sync", reqToken(), reqRepoWriter(models.UnitTypeCode), repo.MirrorSync)

--- a/routers/api/v1/repo/release_tags.go
+++ b/routers/api/v1/repo/release_tags.go
@@ -5,7 +5,6 @@
 package repo
 
 import (
-	"errors"
 	"net/http"
 
 	"code.gitea.io/gitea/models"
@@ -14,9 +13,9 @@ import (
 	releaseservice "code.gitea.io/gitea/services/release"
 )
 
-// GetReleaseTag get a single release of a repository by its tagname
-func GetReleaseTag(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/releases/tags/{tag} repository repoGetReleaseTag
+// GetReleaseByTag get a single release of a repository by tag name
+func GetReleaseByTag(ctx *context.APIContext) {
+	// swagger:operation GET /repos/{owner}/{repo}/releases/tags/{tag} repository repoGetReleaseByTag
 	// ---
 	// summary: Get a release by tag name
 	// produces:
@@ -34,7 +33,7 @@ func GetReleaseTag(ctx *context.APIContext) {
 	//   required: true
 	// - name: tag
 	//   in: path
-	//   description: tagname of the release to get
+	//   description: tag name of the release to get
 	//   type: string
 	//   required: true
 	// responses:
@@ -62,11 +61,11 @@ func GetReleaseTag(ctx *context.APIContext) {
 	ctx.JSON(http.StatusOK, convert.ToRelease(release))
 }
 
-// DeleteReleaseTag delete a tag from a repository
-func DeleteReleaseTag(ctx *context.APIContext) {
-	// swagger:operation DELETE /repos/{owner}/{repo}/releases/tags/{tag} repository repoDeleteReleaseTag
+// DeleteReleaseByTag delete a release from a repository by tag name
+func DeleteReleaseByTag(ctx *context.APIContext) {
+	// swagger:operation DELETE /repos/{owner}/{repo}/releases/tags/{tag} repository repoDeleteReleaseByTag
 	// ---
-	// summary: Delete a release tag
+	// summary: Delete a release by tag name
 	// parameters:
 	// - name: owner
 	//   in: path
@@ -80,7 +79,7 @@ func DeleteReleaseTag(ctx *context.APIContext) {
 	//   required: true
 	// - name: tag
 	//   in: path
-	//   description: name of the tag to delete
+	//   description: tag name of the release to delete
 	//   type: string
 	//   required: true
 	// responses:
@@ -96,19 +95,19 @@ func DeleteReleaseTag(ctx *context.APIContext) {
 	release, err := models.GetRelease(ctx.Repo.Repository.ID, tag)
 	if err != nil {
 		if models.IsErrReleaseNotExist(err) {
-			ctx.Error(http.StatusNotFound, "GetRelease", err)
+			ctx.NotFound()
 			return
 		}
 		ctx.Error(http.StatusInternalServerError, "GetRelease", err)
 		return
 	}
 
-	if !release.IsTag {
-		ctx.Error(http.StatusConflict, "IsTag", errors.New("a tag attached to a release cannot be deleted directly"))
+	if release.IsTag {
+		ctx.NotFound()
 		return
 	}
 
-	if err := releaseservice.DeleteReleaseByID(release.ID, ctx.User, true); err != nil {
+	if err = releaseservice.DeleteReleaseByID(release.ID, ctx.User, false); err != nil {
 		ctx.Error(http.StatusInternalServerError, "DeleteReleaseByID", err)
 	}
 

--- a/routers/api/v1/repo/release_tags.go
+++ b/routers/api/v1/repo/release_tags.go
@@ -87,8 +87,6 @@ func DeleteReleaseByTag(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
-	//   "409":
-	//     "$ref": "#/responses/conflict"
 
 	tag := ctx.Params(":tag")
 

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -158,5 +158,5 @@ func DeleteTag(ctx *context.APIContext) {
 		ctx.Error(http.StatusInternalServerError, "DeleteReleaseByID", err)
 	}
 
-	ctx.JSON(http.StatusOK, &tag)
+	ctx.Status(http.StatusNoContent)
 }

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -5,12 +5,15 @@
 package repo
 
 import (
+	"errors"
 	"net/http"
 
+	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/convert"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/routers/api/v1/utils"
+	releaseservice "code.gitea.io/gitea/services/release"
 )
 
 // ListTags list all the tags of a repository
@@ -103,4 +106,57 @@ func GetTag(ctx *context.APIContext) {
 		}
 		ctx.JSON(http.StatusOK, convert.ToAnnotatedTag(ctx.Repo.Repository, tag, commit))
 	}
+}
+
+// DeleteTag delete a specific tag of in a repository by name
+func DeleteTag(ctx *context.APIContext) {
+	// swagger:operation DELETE /repos/{owner}/{repo}/tags/{tag} repository repoDeleteTag
+	// ---
+	// summary: Delete a repository's tag by name
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: tag
+	//   in: path
+	//   description: name of tag to delete
+	//   type: string
+	//   required: true
+	// responses:
+	//   "204":
+	//     "$ref": "#/responses/empty"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
+	//   "409":
+	//     "$ref": "#/responses/conflict"
+
+	tag, err := models.GetRelease(ctx.Repo.Repository.ID, ctx.Params("tag"))
+	if err != nil {
+		if models.IsErrReleaseNotExist(err) {
+			ctx.NotFound()
+			return
+		}
+		ctx.Error(http.StatusInternalServerError, "GetRelease", err)
+		return
+	}
+
+	if !tag.IsTag {
+		ctx.Error(http.StatusConflict, "IsTag", errors.New("a tag attached to a release cannot be deleted directly"))
+		return
+	}
+
+	if err = releaseservice.DeleteReleaseByID(tag.ID, ctx.User, true); err != nil {
+		ctx.Error(http.StatusInternalServerError, "DeleteReleaseByID", err)
+	}
+
+	ctx.JSON(http.StatusOK, &tag)
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -8851,6 +8851,9 @@
           },
           "404": {
             "$ref": "#/responses/notFound"
+          },
+          "409": {
+            "$ref": "#/responses/conflict"
           }
         }
       }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -7964,7 +7964,7 @@
           "repository"
         ],
         "summary": "Get a release by tag name",
-        "operationId": "repoGetReleaseTag",
+        "operationId": "repoGetReleaseByTag",
         "parameters": [
           {
             "type": "string",
@@ -7982,7 +7982,7 @@
           },
           {
             "type": "string",
-            "description": "tagname of the release to get",
+            "description": "tag name of the release to get",
             "name": "tag",
             "in": "path",
             "required": true
@@ -8001,8 +8001,8 @@
         "tags": [
           "repository"
         ],
-        "summary": "Delete a release tag",
-        "operationId": "repoDeleteReleaseTag",
+        "summary": "Delete a release by tag name",
+        "operationId": "repoDeleteReleaseByTag",
         "parameters": [
           {
             "type": "string",
@@ -8020,7 +8020,7 @@
           },
           {
             "type": "string",
-            "description": "name of the tag to delete",
+            "description": "tag name of the release to delete",
             "name": "tag",
             "in": "path",
             "required": true

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -8032,9 +8032,6 @@
           },
           "404": {
             "$ref": "#/responses/notFound"
-          },
-          "409": {
-            "$ref": "#/responses/conflict"
           }
         }
       }
@@ -8811,6 +8808,49 @@
         "responses": {
           "200": {
             "$ref": "#/responses/TagList"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/tags/{tag}": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Delete a repository's tag by name",
+        "operationId": "repoDeleteTag",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of tag to delete",
+            "name": "tag",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/responses/empty"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
           }
         }
       }


### PR DESCRIPTION
**DELETE /repos/{owner}/{repo}/releases/tags/{tag}** moved to **DELETE /repos/{owner}/{repo}/tags/{tag}** && **/repos/{owner}/{repo}/releases/tags/{tag}** now deletes releases by tag name


followup of  #14397 to have a consistent api ...


**need to go into v1.14.0** or it will introduce a breaking change otherwise :/ !!

make api added via #13358 only for releases and this one only for tags ...

TODO:
 * [x] Fix & Extend Tests