### PR TITLE
Fix locale init

### DIFF
--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -64,7 +64,7 @@ func InitLocales() {
 				// just log if lang is already loaded since we can not reload it
 				log.Warn("Can not load language '%s' since already loaded", setting.Langs[i])
 			} else {
-				log.Fatal("Failed to set messages to %s: %v", setting.Langs[i], err)
+				log.Error("Failed to set messages to %s: %v", setting.Langs[i], err)
 			}
 		}
 	}

--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -5,6 +5,8 @@
 package translation
 
 import (
+	"errors"
+
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/options"
 	"code.gitea.io/gitea/modules/setting"
@@ -57,8 +59,13 @@ func InitLocales() {
 	matcher = language.NewMatcher(tags)
 	for i := range setting.Names {
 		key := "locale_" + setting.Langs[i] + ".ini"
-		if err := i18n.SetMessageWithDesc(setting.Langs[i], setting.Names[i], localFiles[key]); err != nil {
-			log.Fatal("Failed to set messages to %s: %v", setting.Langs[i], err)
+		if err = i18n.SetMessageWithDesc(setting.Langs[i], setting.Names[i], localFiles[key]); err != nil {
+			if errors.Is(err, i18n.ErrLangAlreadyExist) {
+				// just log if lang is already loaded since we can not reload it
+				log.Warn("Can not load language '%s' since already loaded", setting.Langs[i])
+			} else {
+				log.Fatal("Failed to set messages to %s: %v", setting.Langs[i], err)
+			}
 		}
 	}
 	i18n.SetDefaultLang("en-US")


### PR DESCRIPTION
Fixes #14577 

Locales were being init twice on new installs, which caused a failure.