### PR TITLE
Remove spurious DataAsync Error logging

### DIFF
--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	gitea_log "code.gitea.io/gitea/modules/log"
 )
 
 // Blob represents a Git object.
@@ -35,7 +33,6 @@ func (b *Blob) DataAsync() (io.ReadCloser, error) {
 		err := NewCommand("cat-file", "--batch").RunInDirFullPipeline(b.repoPath, stdoutWriter, stderr, strings.NewReader(b.ID.String()+"\n"))
 		if err != nil {
 			err = ConcatenateError(err, stderr.String())
-			gitea_log.Error("Blob.DataAsync Error: %v", err)
 			_ = stdoutWriter.CloseWithError(err)
 		} else {
 			_ = stdoutWriter.Close()


### PR DESCRIPTION
Breaking the pipe is a valid way of killing a piped command and any error from
a broken cat-file batch command should be passed back up to the writer any way
therefore specifically logging it is unnecessary.

Signed-off-by: Andrew Thornton <art27@cantab.net>
