### PR TITLE
Fixed irritating error message related to go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ help:
 go-check:
 	$(eval GO_VERSION := $(shell printf "%03d%03d%03d" $(shell $(GO) version | grep -Eo '[0-9]+\.[0-9.]+' | tr '.' ' ');))
 	@if [ "$(GO_VERSION)" -lt "$(MIN_GO_VERSION)" ]; then \
-		echo "Gitea requires Go 1.13 or greater to build. You can get it at https://golang.org/dl/"; \
+		echo "Gitea requires Go 1.14 or greater to build. You can get it at https://golang.org/dl/"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
I do have go-1.13.8 installed and get the error message

```
Gitea requires Go 1.13 or greater to build. You can get it at https://golang.org/dl/
```

I do think that Go 1.14 or greater is actually required


