### PR TITLE
Prevent race in PersistableChannelUniqueQueue.Has (#14651)

### DIFF
--- a/modules/queue/unique_queue_disk_channel.go
+++ b/modules/queue/unique_queue_disk_channel.go
@@ -149,6 +149,11 @@ func (q *PersistableChannelUniqueQueue) Has(data Data) (bool, error) {
 	if err != nil || has {
 		return has, err
 	}
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.internal == nil {
+		return false, nil
+	}
 	return q.internal.(UniqueQueue).Has(data)
 }
 


### PR DESCRIPTION
Backport #14651

There is potentially a race with a slow starting internal
queue causing a NPE if Has is checked before the internal
queue has been setup.

This PR adds a lock on the Has() fn.

Fix #14311

Signed-off-by: Andrew Thornton <art27@cantab.net>
