### PR TITLE
Add pre-receive hook to check for email privacy

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -511,6 +511,7 @@ email_preference_set_success = Email preference has been set successfully.
 add_openid_success = The new OpenID address has been added.
 keep_email_private = Hide Email Address
 keep_email_private_popup = Your email address will be hidden from other users.
+keep_email_private_noreply = Gitea will stop allowing you to commit with your real email. Instead, use your noreply email, <code>%s</code>
 openid_desc = OpenID lets you delegate authentication to an external provider.
 
 manage_ssh_keys = Manage SSH Keys
@@ -931,7 +932,7 @@ ext_issues = Ext. Issues
 ext_issues.desc = Link to an external issue tracker.
 
 projects = Projects
-projects.desc = Manage issues and pulls in project boards. 
+projects.desc = Manage issues and pulls in project boards.
 projects.description = Description (optional)
 projects.description_placeholder = Description
 projects.create = Create Project

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -32,6 +32,7 @@
 					<div class="ui checkbox" id="keep-email-private">
 						<label class="poping up" data-content="{{.i18n.Tr "settings.keep_email_private_popup"}}"><strong>{{.i18n.Tr "settings.keep_email_private"}}</strong></label>
 						<input name="keep_email_private" type="checkbox" {{if .SignedUser.KeepEmailPrivate}}checked{{end}}>
+						<p>{{$.i18n.Tr "settings.keep_email_private_noreply" .SignedUser.GetEmail | Safe}}</p>
 					</div>
 				</div>
 				<div class="field {{if .Err_Description}}error{{end}}">


### PR DESCRIPTION
This PR aims to help keep email private for those users who wish to do so.

It adds a check in pre-receive that checks incoming commits and checks if the commit author email matches the user committing.  
If it matches any email and the user has indicated they want their email to remain private, the hook fails, telling them why.

This PR also adds a message to the user profile where they set their email privacy, letting them know what their noreply alternative is.

Now, a few questions and why this is a draft...

-----

1. Wording. I'm not a huge fan of the wording I've chosen, and I would like feedback.
2. Should a push option be added so a user can force the commit through, rather than making them open the web UI to change their privacy?
3. Currently this only checks commit author. Should it also check committer?