### PR TITLE
Add fullTextSearch to dropdowns by default

### DIFF
--- a/web_src/js/features/gitgraph.js
+++ b/web_src/js/features/gitgraph.js
@@ -74,6 +74,7 @@ export default async function initGitGraph() {
   $('#flow-select-refs-dropdown').dropdown('set selected', dropdownSelected);
   $('#flow-select-refs-dropdown').dropdown({
     clearable: true,
+    fullTextSeach: 'exact',
     onRemove(toRemove) {
       if (toRemove === '...flow-hide-pr-refs') {
         params.delete('hide-pr-refs');

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2408,18 +2408,23 @@ $(document).ready(async () => {
   });
 
   // Semantic UI modules.
-  $('.dropdown:not(.custom)').dropdown();
+  $('.dropdown:not(.custom)').dropdown({
+    fullTextSearch: 'exact'
+  });
   $('.jump.dropdown').dropdown({
     action: 'hide',
     onShow() {
       $('.poping.up').popup('hide');
-    }
+    },
+    fullTextSearch: 'exact'
   });
   $('.slide.up.dropdown').dropdown({
-    transition: 'slide up'
+    transition: 'slide up',
+    fullTextSearch: 'exact'
   });
   $('.upward.dropdown').dropdown({
-    direction: 'upward'
+    direction: 'upward',
+    fullTextSearch: 'exact'
   });
   $('.ui.accordion').accordion();
   $('.ui.checkbox').checkbox();
@@ -3465,6 +3470,7 @@ function initTopicbar() {
   topicDropdown.dropdown({
     allowAdditions: true,
     forceSelection: false,
+    fullTextSearch: 'exact',
     fields: {name: 'description', value: 'data-value'},
     saveRemoteData: false,
     label: {


### PR DESCRIPTION
This PR adds `fullTextSearch: 'exact'` to most dropdown
invocations meaning that if there is a search box for the
dropdown it will automatically do a fullTextSearch looking
for the provided fragment instead of starting at the beginning

We should consider changing other places that use
`fullTextSearch: true` to `'exact'` because these will be using a
fuzzy-textual search that doesn't necessarily return the
expected results.

Fix #14689

Signed-off-by: Andrew Thornton <art27@cantab.net>
