### PR TITLE
Prevent endless loop if templates missing

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -188,6 +188,10 @@ func (ctx *Context) HTML(status int, name base.TplName) {
 		return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"
 	}
 	if err := ctx.Render.HTML(ctx.Resp, status, string(name), ctx.Data); err != nil {
+		if status == http.StatusInternalServerError && name == base.TplName("status/500") {
+			ctx.PlainText(http.StatusInternalServerError, []byte("Unable to find status/500 template"))
+			return
+		}
 		ctx.ServerError("Render failed", err)
 	}
 }


### PR DESCRIPTION
Since the chi upgrade if the templates are missing an endless loop will occur if
status/500.tmpl is missing.

Signed-off-by: Andrew Thornton <art27@cantab.net>
