### PR TITLE
Fix repo-restore bug with poster not replaced

### DIFF
--- a/modules/migrations/dump.go
+++ b/modules/migrations/dump.go
@@ -573,19 +573,20 @@ func RestoreRepository(ctx context.Context, baseDir string, ownerName, repoName 
 		return err
 	}
 	if err = migrateRepository(downloader, uploader, base.MigrateOptions{
-		Wiki:          true,
-		Issues:        true,
-		Milestones:    true,
-		Labels:        true,
-		Releases:      true,
-		Comments:      true,
-		PullRequests:  true,
-		ReleaseAssets: true,
+		Wiki:           true,
+		Issues:         true,
+		Milestones:     true,
+		Labels:         true,
+		Releases:       true,
+		Comments:       true,
+		PullRequests:   true,
+		ReleaseAssets:  true,
+		GitServiceType: downloader.serviceType,
 	}); err != nil {
 		if err1 := uploader.Rollback(); err1 != nil {
 			log.Error("rollback failed: %v", err1)
 		}
 		return err
 	}
-	return nil
+	return updateMigrationPosterIDByGitService(ctx, downloader.serviceType)
 }

--- a/modules/migrations/dump.go
+++ b/modules/migrations/dump.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"code.gitea.io/gitea/models"
@@ -19,6 +20,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations/base"
 	"code.gitea.io/gitea/modules/repository"
+	"code.gitea.io/gitea/modules/structs"
 
 	"gopkg.in/yaml.v2"
 )
@@ -572,6 +574,12 @@ func RestoreRepository(ctx context.Context, baseDir string, ownerName, repoName 
 	if err != nil {
 		return err
 	}
+	opts, err := downloader.getRepoOptions()
+	if err != nil {
+		return err
+	}
+	tp, _ := strconv.Atoi(opts["service_type"])
+
 	if err = migrateRepository(downloader, uploader, base.MigrateOptions{
 		Wiki:           true,
 		Issues:         true,
@@ -581,12 +589,12 @@ func RestoreRepository(ctx context.Context, baseDir string, ownerName, repoName 
 		Comments:       true,
 		PullRequests:   true,
 		ReleaseAssets:  true,
-		GitServiceType: downloader.serviceType,
+		GitServiceType: structs.GitServiceType(tp),
 	}); err != nil {
 		if err1 := uploader.Rollback(); err1 != nil {
 			log.Error("rollback failed: %v", err1)
 		}
 		return err
 	}
-	return updateMigrationPosterIDByGitService(ctx, downloader.serviceType)
+	return updateMigrationPosterIDByGitService(ctx, structs.GitServiceType(tp))
 }

--- a/modules/migrations/restore.go
+++ b/modules/migrations/restore.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	"code.gitea.io/gitea/modules/migrations/base"
-	"code.gitea.io/gitea/modules/structs"
 
 	"gopkg.in/yaml.v2"
 )
@@ -21,11 +20,10 @@ import (
 // RepositoryRestorer implements an Downloader from the local directory
 type RepositoryRestorer struct {
 	base.NullDownloader
-	ctx         context.Context
-	baseDir     string
-	repoOwner   string
-	repoName    string
-	serviceType structs.GitServiceType
+	ctx       context.Context
+	baseDir   string
+	repoOwner string
+	repoName  string
 }
 
 // NewRepositoryRestorer creates a repository restorer which could restore repository from a dumped folder
@@ -55,8 +53,7 @@ func (r *RepositoryRestorer) SetContext(ctx context.Context) {
 	r.ctx = ctx
 }
 
-// GetRepoInfo returns a repository information
-func (r *RepositoryRestorer) GetRepoInfo() (*base.Repository, error) {
+func (r *RepositoryRestorer) getRepoOptions() (map[string]string, error) {
 	p := filepath.Join(r.baseDir, "repo.yml")
 	bs, err := ioutil.ReadFile(p)
 	if err != nil {
@@ -68,10 +65,17 @@ func (r *RepositoryRestorer) GetRepoInfo() (*base.Repository, error) {
 	if err != nil {
 		return nil, err
 	}
+	return opts, nil
+}
+
+// GetRepoInfo returns a repository information
+func (r *RepositoryRestorer) GetRepoInfo() (*base.Repository, error) {
+	opts, err := r.getRepoOptions()
+	if err != nil {
+		return nil, err
+	}
 
 	isPrivate, _ := strconv.ParseBool(opts["is_private"])
-	tp, _ := strconv.Atoi(opts["service_type"])
-	r.serviceType = structs.GitServiceType(tp)
 
 	return &base.Repository{
 		Owner:         r.repoOwner,

--- a/modules/migrations/restore.go
+++ b/modules/migrations/restore.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"code.gitea.io/gitea/modules/migrations/base"
+	"code.gitea.io/gitea/modules/structs"
 
 	"gopkg.in/yaml.v2"
 )
@@ -20,10 +21,11 @@ import (
 // RepositoryRestorer implements an Downloader from the local directory
 type RepositoryRestorer struct {
 	base.NullDownloader
-	ctx       context.Context
-	baseDir   string
-	repoOwner string
-	repoName  string
+	ctx         context.Context
+	baseDir     string
+	repoOwner   string
+	repoName    string
+	serviceType structs.GitServiceType
 }
 
 // NewRepositoryRestorer creates a repository restorer which could restore repository from a dumped folder
@@ -68,6 +70,8 @@ func (r *RepositoryRestorer) GetRepoInfo() (*base.Repository, error) {
 	}
 
 	isPrivate, _ := strconv.ParseBool(opts["is_private"])
+	tp, _ := strconv.Atoi(opts["service_type"])
+	r.serviceType = structs.GitServiceType(tp)
 
 	return &base.Repository{
 		Owner:         r.repoOwner,


### PR DESCRIPTION
Currently, when execute restore-repo command, the user will not be replaced by link account because the service type hasn't been stored on the database correctly.