### PR TITLE
Add environment-to-ini to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
  && make clean-all build
 
+# Begin env-to-ini build
+RUN go build contrib/environment-to-ini/environment-to-ini.go
+
 FROM alpine:3.13
 LABEL maintainer="maintainers@gitea.io"
 
@@ -62,4 +65,5 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 
 COPY docker/root /
 COPY --from=build-env /go/src/code.gitea.io/gitea/gitea /app/gitea/gitea
+COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
 RUN ln -s /app/gitea/gitea /usr/local/bin/gitea

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -54,7 +54,7 @@ RUN chown git:git /var/lib/gitea /etc/gitea
 
 COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
-COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
 
 USER git:git
 ENV GITEA_WORK_DIR /var/lib/gitea

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -22,6 +22,9 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
  && make clean-all build
 
+# Begin env-to-ini build
+RUN go build contrib/environment-to-ini/environment-to-ini.go
+
 FROM alpine:3.13
 LABEL maintainer="maintainers@gitea.io"
 
@@ -51,6 +54,7 @@ RUN chown git:git /var/lib/gitea /etc/gitea
 
 COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
+COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
 
 USER git:git
 ENV GITEA_WORK_DIR /var/lib/gitea

--- a/contrib/environment-to-ini/README
+++ b/contrib/environment-to-ini/README
@@ -25,8 +25,8 @@ The environment variables should be of the form:
 Environment variables are usually restricted to a reduced character
 set "0-9A-Z_" - in order to allow the setting of sections with
 characters outside of that set, they should be escaped as following:
-"_0X2E_" for ".". The entire section and key names can be escaped as
-a UTF8 byte string if necessary. E.g. to configure:
+"_0X2E_" for "." and "_0X2D_" for "-". The entire section and key names 
+can be escaped as a UTF8 byte string if necessary. E.g. to configure:
 
 	"""
 	...

--- a/contrib/environment-to-ini/README
+++ b/contrib/environment-to-ini/README
@@ -22,6 +22,8 @@ The environment variables should be of the form:
 
 	GITEA__SECTION_NAME__KEY_NAME
 
+Note, SECTION_NAME in the notation above is case-insensitive.
+
 Environment variables are usually restricted to a reduced character
 set "0-9A-Z_" - in order to allow the setting of sections with
 characters outside of that set, they should be escaped as following:

--- a/contrib/environment-to-ini/README
+++ b/contrib/environment-to-ini/README
@@ -40,27 +40,6 @@ You would set the environment variables: "GITEA__LOG_0x2E_CONSOLE__COLORIZE=fals
 and "GITEA__LOG_0x2E_CONSOLE__STDERR=false". Other examples can be found
 on the configuration cheat sheet.
 
-To plug this command in to the docker, you simply compile the provided go file using:
+To build locally, run:
 
-	go build environment-to-ini.go
-
-And copy the resulting `environment-to-ini` command to /app/gitea in the docker.
-
-Apply the below patch to /etc/s6/gitea.setup to wire this in.
-
-If you find this useful please comment on #7287
-
-
-diff --git a/docker/root/etc/s6/gitea/setup b/docker/root/etc/s6/gitea/setup
-index f87ce9115..565bfcba9 100755
---- a/docker/root/etc/s6/gitea/setup
-+++ b/docker/root/etc/s6/gitea/setup
-@@ -44,6 +44,8 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
-     SECRET_KEY=${SECRET_KEY:-""} \
-     envsubst < /etc/templates/app.ini > ${GITEA_CUSTOM}/conf/app.ini
-
-+    /app/gitea/environment-to-ini -c ${GITEA_CUSTOM}/conf/app.ini
-+
-     chown ${USER}:git ${GITEA_CUSTOM}/conf/app.ini
- fi
-
+	go build contrib/environment-to-ini/environment-to-ini.go

--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -224,5 +224,6 @@ func DecodeSectionKey(encoded string) (string, string) {
 	} else {
 		key += remaining
 	}
+	section = strings.ToLower(section)
 	return section, key
 }

--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -48,7 +48,7 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
     chown ${USER}:git ${GITEA_CUSTOM}/conf/app.ini
 fi
 
-# Replace app.ini settings with env variables in the form GITEA__section_name__KEY_NAME
+# Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
 environment-to-ini --config ${GITEA_CUSTOM}/conf/app.ini
 
 # only chown if current owner is not already the gitea ${USER}. No recursive check to save time

--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -48,6 +48,9 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
     chown ${USER}:git ${GITEA_CUSTOM}/conf/app.ini
 fi
 
+# Replace app.ini settings with env variables in the form GITEA__section_name__KEY_NAME
+environment-to-ini --config ${GITEA_CUSTOM}/conf/app.ini
+
 # only chown if current owner is not already the gitea ${USER}. No recursive check to save time
 if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/gitea; fi
 if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi

--- a/docker/rootless/usr/local/bin/docker-setup.sh
+++ b/docker/rootless/usr/local/bin/docker-setup.sh
@@ -46,3 +46,6 @@ if [ ! -f ${GITEA_APP_INI} ]; then
     SECRET_KEY=${SECRET_KEY:-""} \
     envsubst < /etc/templates/app.ini > ${GITEA_APP_INI}
 fi
+
+# Replace app.ini settings with env variables in the form GITEA__section_name__KEY_NAME
+environment-to-ini --config ${GITEA_APP_INI}

--- a/docker/rootless/usr/local/bin/docker-setup.sh
+++ b/docker/rootless/usr/local/bin/docker-setup.sh
@@ -47,5 +47,5 @@ if [ ! -f ${GITEA_APP_INI} ]; then
     envsubst < /etc/templates/app.ini > ${GITEA_APP_INI}
 fi
 
-# Replace app.ini settings with env variables in the form GITEA__section_name__KEY_NAME
+# Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
 environment-to-ini --config ${GITEA_APP_INI}

--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -289,6 +289,28 @@ docker-compose up -d
   - Set START_SSH_SERVER = true
 - Use image gitea/gitea:latest-rootless
 
+## Managing Deployments With Environment Variables
+
+In addition to the environment variables above, any settings in `app.ini` can be set or overridden with an environment variable of the form: `GITEA__SECTION_NAME__KEY_NAME`. These settings are applied each time the docker container starts. Full information [here](https://github.com/go-gitea/gitea/tree/master/contrib/environment-to-ini).
+
+These environment variables can be passed to the docker container in `docker-compose.yml`. The following example will enable an smtp mail server if the required env variables `GITEA__mailer__FROM`, `GITEA__mailer__HOST`, `GITEA__mailer__PASSWD` are set on the host or in a `.env` file in the same directory as `docker-compose.yml`:
+
+```bash
+...
+services:
+  server:
+    environment:
+    - GITEA__mailer__ENABLED=true
+    - GITEA__mailer__FROM=${GITEA__mailer__FROM:?GITEA__mailer__FROM not set}
+    - GITEA__mailer__MAILER_TYPE=smtp
+    - GITEA__mailer__HOST=${GITEA__mailer__HOST:?GITEA__mailer__HOST not set}
+    - GITEA__mailer__IS_TLS_ENABLED=true
+    - GITEA__mailer__USER=${GITEA__mailer__USER:-apikey}
+    - GITEA__mailer__PASSWD="""${GITEA__mailer__PASSWD:?GITEA__mailer__PASSWD not set}"""
+```
+
+To set required TOKEN and SECRET values, consider using gitea's built-in [generate utility functions](https://docs.gitea.io/en-us/command-line/#generate).
+
 # SSH Container Passthrough (not tested)
 
 This should be possible by forcing `authorized_keys` generation via `gitea admin regenerate keys`.

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -306,6 +306,28 @@ docker-compose pull
 docker-compose up -d
 ```
 
+## Managing Deployments With Environment Variables
+
+In addition to the environment variables above, any settings in `app.ini` can be set or overridden with an environment variable of the form: `GITEA__SECTION_NAME__KEY_NAME`. These settings are applied each time the docker container starts. Full information [here](https://github.com/go-gitea/gitea/tree/master/contrib/environment-to-ini).
+
+These environment variables can be passed to the docker container in `docker-compose.yml`. The following example will enable an smtp mail server if the required env variables `GITEA__mailer__FROM`, `GITEA__mailer__HOST`, `GITEA__mailer__PASSWD` are set on the host or in a `.env` file in the same directory as `docker-compose.yml`:
+
+```bash
+...
+services:
+  server:
+    environment:
+    - GITEA__mailer__ENABLED=true
+    - GITEA__mailer__FROM=${GITEA__mailer__FROM:?GITEA__mailer__FROM not set}
+    - GITEA__mailer__MAILER_TYPE=smtp
+    - GITEA__mailer__HOST=${GITEA__mailer__HOST:?GITEA__mailer__HOST not set}
+    - GITEA__mailer__IS_TLS_ENABLED=true
+    - GITEA__mailer__USER=${GITEA__mailer__USER:-apikey}
+    - GITEA__mailer__PASSWD="""${GITEA__mailer__PASSWD:?GITEA__mailer__PASSWD not set}"""
+```
+
+To set required TOKEN and SECRET values, consider using gitea's built-in [generate utility functions](https://docs.gitea.io/en-us/command-line/#generate).
+
 ## SSH Container Passthrough
 
 Since SSH is running inside the container, SSH needs to be passed through from the host to the container if SSH support is desired. One option would be to run the container SSH on a non-standard port (or moving the host port to a non-standard port). Another option which might be more straightforward is to forward SSH connections from the host to the container. This setup is explained in the following.


### PR DESCRIPTION
The question of how to support automated deployment configs has come up a lot lately with many different solutions, so I'd like to add official support for the [environment-to-ini](https://github.com/go-gitea/gitea/tree/master/contrib/environment-to-ini) util function.

I've added it to the docker build and call it in the docker setup function. Note that I have it outside of the `[ ! -f ${GITEA_CUSTOM}/conf/app.ini ]` check so that it is run every time the container is started.

If there is support for this I can add a section to https://docs.gitea.io/en-us/install-with-docker/