### PR TITLE
exclude running docker build on cron tasks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -731,6 +731,9 @@ trigger:
   ref:
   - refs/heads/master
   - "refs/tags/**"
+  event:
+    exclude:
+    - cron
 
 steps:
   - name: fetch-tags
@@ -833,6 +836,10 @@ trigger:
   ref:
   - refs/heads/master
   - "refs/tags/**"
+  event:
+    exclude:
+    - cron
+
 steps:
   - name: fetch-tags
     image: docker:git
@@ -917,6 +924,9 @@ trigger:
   ref:
   - refs/heads/master
   - "refs/tags/**"
+  event:
+    exclude:
+    - cron
 
 depends_on:
   - docker-linux-amd64-release


### PR DESCRIPTION
follow up to translation cron PR, this is to prevent docker builds from happening on cron builds