### PR TITLE
Run gitea rootless with a custom user

### DIFF
--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -35,28 +35,15 @@ RUN apk --no-cache add \
     ca-certificates \
     gettext \
     git \
-    gnupg
-
-RUN addgroup \
-    -S -g 1000 \
-    git && \
-  adduser \
-    -S -H -D \
-    -h /var/lib/gitea/git \
-    -s /bin/bash \
-    -u 1000 \
-    -G git \
-    git && \
-  echo "git:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
+    gnupg \
+    su-exec
 
 RUN mkdir -p /var/lib/gitea /etc/gitea
-RUN chown git:git /var/lib/gitea /etc/gitea
 
 COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
 
-USER git:git
 ENV GITEA_WORK_DIR /var/lib/gitea
 ENV GITEA_CUSTOM /var/lib/gitea/custom
 ENV GITEA_TEMP /tmp/gitea

--- a/docker/rootless/usr/local/bin/docker-entrypoint.sh
+++ b/docker/rootless/usr/local/bin/docker-entrypoint.sh
@@ -1,11 +1,29 @@
 #!/bin/sh
 
+docker_switch_user() {
+    GITEA_USERNAME=${GITEA_USERNAME:-"git"}
+    GITEA_GROUPNAME=${GITEA_GROUPNAME:-"git"}
+    GITEA_UID=${GITEA_UID:-"1000"}
+    GITEA_GID=${GITEA_GID:-"1000"}
+    GITEA_HOME=${HOME:-"/var/lib/gitea/git"}
+
+    addgroup -S -g "${GITEA_GID}" "${GITEA_GROUPNAME}" && \
+    adduser -S -H -D -h "${HOME}" -s /bin/bash \
+            -u "${GITEA_UID}" -G "${GITEA_GROUPNAME}" "${GITEA_USERNAME}" 
+    chown -R "${GITEA_USERNAME}:${GITEA_GROUPNAME}" "${GITEA_CUSTOM}" "${GITEA_WORK_DIR}" "${GITEA_TEMP}" /etc/gitea
+    echo "${GITEA_USERNAME}:$(dd if=/dev/urandom bs=24 count=1 status=none | base64)" | chpasswd
+
+    if [ $# -gt 0 ]; then
+        exec su-exec "${GITEA_USERNAME}:${GITEA_GROUPNAME}" "$@" 
+    else
+        exec su-exec "${GITEA_USERNAME}:${GITEA_GROUPNAME}" /usr/local/bin/gitea -c ${GITEA_APP_INI} web
+    fi
+}
+
+USER=${GITEA_USERNAME:-"git"}
+
 if [ -x /usr/local/bin/docker-setup.sh ]; then
     /usr/local/bin/docker-setup.sh || { echo 'docker setup failed' ; exit 1; }
 fi
 
-if [ $# -gt 0 ]; then
-    exec "$@"
-else
-    exec /usr/local/bin/gitea -c ${GITEA_APP_INI} web
-fi
+docker_switch_user


### PR DESCRIPTION
Main motivation for this PR is that gitea helmchart will work in an Enterprise environment where volume are shared using NFS/Kerberos. In this case we need to run the gitea process as a specific UID defined in Active Directory.

Optional user properties can be specified using the following environment variables

   GITEA_UID, GITEA_GID, GITEA_USERNAME, GITEA_GROUPNAME

```bash

# Run as the default git user


# Default user
> docker run --name=c1 -d gitea:rootless
> docker exec -it c1 cat /etc/passwd|grep git
git:x:1000:1000:Linux User,,,:/var/lib/gitea/git:/bin/bash
> docker exec -it c1 ps aux|grep gitea
    1 git       0:00 /usr/local/bin/gitea -c /etc/gitea/app.ini web

# Custom username/groupname
> docker run --name=c2 -e GITEA_USERNAME=gitea -e GITEA_GROUPNAME=gitea -d gitea:rootless
> docker exec -it c2 cat /etc/passwd|grep git
> gitea:x:1000:1000:Linux User,,,:/var/lib/gitea/git:/bin/bash
> docker exec -it c2 cat /etc/group|grep gitea
gitea:x:1000:gitea


# Custom UID/GID
> docker run --name=c3 -e GITEA_UID=2000 -e GITEA_GID=2000 -d gitea:rootless
> docker exec -it c3 cat /etc/passwd|grep git
git:x:2000:2000:Linux User,,,:/var/lib/gitea/git:/bin/bash
> docker exec -it c3 ps aux|grep git
    1 git       0:00 /usr/local/bin/gitea -c /etc/gitea/app.ini web
```

https://github.com/go-gitea/gitea/issues/14780

