### PR TITLE
Disable broken OAuth2 providers at startup

### DIFF
--- a/models/oauth2.go
+++ b/models/oauth2.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"code.gitea.io/gitea/modules/auth/oauth2"
+	"code.gitea.io/gitea/modules/log"
 )
 
 // OAuth2Provider describes the display values of a single OAuth2 provider
@@ -145,7 +146,12 @@ func initOAuth2LoginSources() error {
 		oAuth2Config := source.OAuth2()
 		err := oauth2.RegisterProvider(source.Name, oAuth2Config.Provider, oAuth2Config.ClientID, oAuth2Config.ClientSecret, oAuth2Config.OpenIDConnectAutoDiscoveryURL, oAuth2Config.CustomURLMapping)
 		if err != nil {
-			return err
+			log.Critical("Unable to register source: %s due to Error: %v. This source will be disabled.", source.Name, err)
+			source.IsActived = false
+			if err = UpdateSource(source); err != nil {
+				log.Critical("Unable to update source %s to disable it. Error: %v", err)
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Instead of causing a log.Fatal, we should handle broken OAuth2
providers by disabling them.

Fix #8930

Signed-off-by: Andrew Thornton <art27@cantab.net>

