### PR TITLE
When Deleting Repository only explicitly close PRs whose base is not this repository (#14823)

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -475,7 +475,7 @@ func CloseBranchPulls(doer *models.User, repoID int64, branch string) error {
 	return nil
 }
 
-// CloseRepoBranchesPulls close all pull requests which head branches are in the given repository
+// CloseRepoBranchesPulls close all pull requests which head branches are in the given repository, but only whose base repo is not in the given repository
 func CloseRepoBranchesPulls(doer *models.User, repo *models.Repository) error {
 	branches, err := git.GetBranchesByPath(repo.RepoPath())
 	if err != nil {
@@ -494,6 +494,11 @@ func CloseRepoBranchesPulls(doer *models.User, repo *models.Repository) error {
 		}
 
 		for _, pr := range prs {
+			// If the base repository for this pr is this repository there is no need to close it
+			// as it is going to be deleted anyway
+			if pr.BaseRepoID == repo.ID {
+				continue
+			}
 			if err = issue_service.ChangeStatus(pr.Issue, doer, true); err != nil && !models.IsErrPullWasClosed(err) {
 				errs = append(errs, err)
 			}


### PR DESCRIPTION


Backport #14823

When Deleting Repository only explicitly close PRs whose base is not this repository

Fix #14775

Signed-off-by: Andrew Thornton <art27@cantab.net>
