### PR TITLE
Set default language to first element of LANGS

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1178,6 +1178,7 @@ JWT_SECRET =
 MAX_TOKEN_LENGTH = 32767
 
 [i18n]
+; List of locales shown in language selector. First element is default language.
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR
 NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,Português de Portugal,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -813,7 +813,7 @@ NB: You must have `DISABLE_ROUTER_LOG` set to `false` for this option to take ef
 
 ## i18n (`i18n`)
 
-- `LANGS`: **en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR**: List of locales shown in language selector
+- `LANGS`: **en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR**: List of locales shown in language selector. First element is default language.
 - `NAMES`: **English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,Português de Portugal,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어**: Visible names corresponding to the locales
 
 ## U2F (`U2F`)

--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -68,7 +68,8 @@ func InitLocales() {
 			}
 		}
 	}
-	i18n.SetDefaultLang("en-US")
+
+	i18n.SetDefaultLang(setting.Langs[0])
 
 	allLangs = make([]LangType, 0, i18n.Count()-1)
 	langs := i18n.ListLangs()

--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -27,8 +27,9 @@ type LangType struct {
 }
 
 var (
-	matcher  language.Matcher
-	allLangs []LangType
+	matcher     language.Matcher
+	allLangs    []LangType
+	defaultLang string
 )
 
 // AllLangs returns all supported langauages
@@ -69,6 +70,7 @@ func InitLocales() {
 		}
 	}
 
+	defaultLang = setting.Langs[0]
 	i18n.SetDefaultLang(setting.Langs[0])
 
 	allLangs = make([]LangType, 0, i18n.Count()-1)
@@ -91,6 +93,9 @@ type locale struct {
 
 // NewLocale return a locale
 func NewLocale(lang string) Locale {
+	if len(lang) == 0 {
+		lang = defaultLang
+	}
 	return &locale{
 		Lang: lang,
 	}


### PR DESCRIPTION
The first element of `LANGS` in `[i18n]` section will be teh default language.
Witch is used if no language is set to translate strings.