### PR TITLE
Make searching issues by keyword case insensitive on DB

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1706,17 +1706,18 @@ func GetRepoIssueStats(repoID, uid int64, filterMode int, isPull bool) (numOpen 
 func SearchIssueIDsByKeyword(kw string, repoIDs []int64, limit, start int) (int64, []int64, error) {
 	var repoCond = builder.In("repo_id", repoIDs)
 	var subQuery = builder.Select("id").From("issue").Where(repoCond)
+	kw = strings.ToUpper(kw)
 	var cond = builder.And(
 		repoCond,
 		builder.Or(
-			builder.Like{"name", kw},
-			builder.Like{"content", kw},
+			builder.Like{"UPPER(name)", kw},
+			builder.Like{"UPPER(content)", kw},
 			builder.In("id", builder.Select("issue_id").
 				From("comment").
 				Where(builder.And(
 					builder.Eq{"type": CommentTypeComment},
 					builder.In("issue_id", subQuery),
-					builder.Like{"content", kw},
+					builder.Like{"UPPER(content)", kw},
 				)),
 			),
 		),


### PR DESCRIPTION
Most DBs apart from SQLite will use a default Collation that is not case insensitive.
This means that SearchIssuesByKeyword becomes case sensitive for db indexing - in
contrast to the bleve and elastic indexers.

This PR simply uses UPPER(...) to do the LIKE - and although it may be more efficient
to change collations this would be a non-trivial task.

Fix #13663

Signed-off-by: Andrew Thornton <art27@cantab.net>
