### PR TITLE
Fix issue search with db indexer because of mysql 5.7 sqlmode

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1724,12 +1724,12 @@ func SearchIssueIDsByKeyword(kw string, repoIDs []int64, limit, start int) (int6
 	)
 
 	var ids = make([]int64, 0, limit)
-	err := x.Distinct("id").Table("issue").Where(cond).OrderBy("`updated_unix` DESC").Limit(limit, start).Find(&ids)
+	err := x.Select("id").Table("issue").Where(cond).OrderBy("`updated_unix` DESC").Limit(limit, start).Find(&ids)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	total, err := x.Distinct("id").Table("issue").Where(cond).Count()
+	total, err := x.Select("id").Table("issue").Where(cond).Count()
 	if err != nil {
 		return 0, nil, err
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -1724,12 +1724,21 @@ func SearchIssueIDsByKeyword(kw string, repoIDs []int64, limit, start int) (int6
 	)
 
 	var ids = make([]int64, 0, limit)
-	err := x.Select("id").Table("issue").Where(cond).OrderBy("`updated_unix` DESC").Limit(limit, start).Find(&ids)
+	var res = make([]struct {
+		ID          int64
+		UpdatedUnix int64
+	}, 0, limit)
+	err := x.Distinct("id", "updated_unix").Table("issue").Where(cond).
+		OrderBy("`updated_unix` DESC").Limit(limit, start).
+		Find(&res)
 	if err != nil {
 		return 0, nil, err
 	}
+	for _, r := range res {
+		ids = append(ids, r.ID)
+	}
 
-	total, err := x.Select("id").Table("issue").Where(cond).Count()
+	total, err := x.Distinct("id").Table("issue").Where(cond).Count()
 	if err != nil {
 		return 0, nil, err
 	}


### PR DESCRIPTION
Fix #14905 caused by #14353. ~Since `id` in `issue` table is a primary key, `distinct` is unnecessary. Change that to `Select` should resolve the problem.~

UPDATE: Distinct is necessary, so I added updated_unix on select columns and then convert it to id slice.