### PR TITLE
Re-enable import local paths after reversion from #13610 (#14925)

### DIFF
--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -52,6 +52,13 @@ func isMigrateURLAllowed(remoteURL string) error {
 		}
 	}
 
+	if u.Host == "" {
+		if !setting.ImportLocalPaths {
+			return &models.ErrMigrationNotAllowed{Host: "<LOCAL_FILESYSTEM>"}
+		}
+		return nil
+	}
+
 	if !setting.Migrations.AllowLocalNetworks {
 		addrList, err := net.LookupIP(strings.Split(u.Host, ":")[0])
 		if err != nil {

--- a/modules/migrations/migrate_test.go
+++ b/modules/migrations/migrate_test.go
@@ -31,4 +31,16 @@ func TestMigrateWhiteBlocklist(t *testing.T) {
 
 	err = isMigrateURLAllowed("https://github.com/go-gitea/gitea.git")
 	assert.Error(t, err)
+
+	old := setting.ImportLocalPaths
+	setting.ImportLocalPaths = false
+
+	err = isMigrateURLAllowed("/home/foo/bar/goo")
+	assert.Error(t, err)
+
+	setting.ImportLocalPaths = true
+	err = isMigrateURLAllowed("/home/foo/bar/goo")
+	assert.NoError(t, err)
+
+	setting.ImportLocalPaths = old
 }


### PR DESCRIPTION
Backport #14925

PR #13610 unfortunately disabled importing repositories from local paths.
This PR restores this functionality.

Fix #14700

Signed-off-by: Andrew Thornton <art27@cantab.net>
