### PR TITLE
Add "captcha" to list of reserved usernames

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -789,6 +789,7 @@ var (
 		"assets",
 		"attachments",
 		"avatars",
+		"captcha",
 		"commits",
 		"debug",
 		"error",


### PR DESCRIPTION
A user on Codeberg reported in https://codeberg.org/Codeberg/Community/issues/412 that registering as user `captcha` makes repos inaccessible. 

I reproduced on try.gitea.io by registering a https://try.gitea.io/captcha organization with its test repo being inaccessible: https://try.gitea.io/captcha/test

This PR adds the username `captcha` to the list of reserved usernames I've found.

Thank you :v: