### PR TITLE
Fix typo in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
-      - singleCaseSwitch # Every time this occured in the code, there  was no other way.
+      - singleCaseSwitch # Every time this occurred in the code, there  was no other way.
 
 issues:
   exclude-rules:


### PR DESCRIPTION
occured -> occurred
