### PR TITLE
Fix sorting users by last login date

### DIFF
--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -199,10 +199,14 @@ const (
 	SearchOrderBySizeReverse           SearchOrderBy = "size DESC"
 	SearchOrderByID                    SearchOrderBy = "id ASC"
 	SearchOrderByIDReverse             SearchOrderBy = "id DESC"
-	SearchOrderByStars                 SearchOrderBy = "num_stars ASC"
-	SearchOrderByStarsReverse          SearchOrderBy = "num_stars DESC"
-	SearchOrderByForks                 SearchOrderBy = "num_forks ASC"
-	SearchOrderByForksReverse          SearchOrderBy = "num_forks DESC"
+	// repo
+	SearchOrderByStars        SearchOrderBy = "num_stars ASC"
+	SearchOrderByStarsReverse SearchOrderBy = "num_stars DESC"
+	SearchOrderByForks        SearchOrderBy = "num_forks ASC"
+	SearchOrderByForksReverse SearchOrderBy = "num_forks DESC"
+	// user
+	SearchOrderByRecentLogin        SearchOrderBy = "last_login_unix ASC"
+	SearchOrderByRecentLoginReverse SearchOrderBy = "last_login_unix DESC"
 )
 
 // SearchRepositoryCondition creates a query condition according search repository options

--- a/routers/home.go
+++ b/routers/home.go
@@ -213,6 +213,10 @@ func RenderUserSearch(ctx *context.Context, opts *models.SearchUserOptions, tplN
 		orderBy = models.SearchOrderByRecentUpdated
 	case "leastupdate":
 		orderBy = models.SearchOrderByLeastUpdated
+	case "recentlogin":
+		orderBy = models.SearchOrderByRecentLogin
+	case "recentloginreverse":
+		orderBy = models.SearchOrderByRecentLoginReverse
 	case "reversealphabetically":
 		orderBy = models.SearchOrderByAlphabeticallyReverse
 	case "alphabetically":

--- a/templates/admin/base/search.tmpl
+++ b/templates/admin/base/search.tmpl
@@ -12,6 +12,8 @@
 			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
 			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
 			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+			<a class="{{if eq .SortType "recentlogin"}}active{{end}} item" href="{{$.Link}}?sort=recentlogin&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentlogin"}}</a>
+			<a class="{{if eq .SortType "recentloginreverse"}}active{{end}} item" href="{{$.Link}}?sort=recentloginreverse&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentloginreverse"}}</a>
 		</div>
 	</div>
 </div>

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -24,10 +24,7 @@
 						<th>{{.i18n.Tr "admin.orgs.teams"}}</th>
 						<th>{{.i18n.Tr "admin.orgs.members"}}</th>
 						<th>{{.i18n.Tr "admin.users.repos"}}</th>
-						<th data-sortt-asc="recentupdate" data-sortt-desc="leastupdate">
-							{{.i18n.Tr "admin.users.created"}}
-							{{SortArrow "recentupdate" "leastupdate" $.SortType false}}
-						</th>
+						<th>{{.i18n.Tr "admin.users.created"}}</th>
 						<th>{{.i18n.Tr "admin.users.edit"}}</th>
 					</tr>
 				</thead>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -28,9 +28,9 @@
 						<th>{{.i18n.Tr "admin.users.2fa"}}</th>
 						<th>{{.i18n.Tr "admin.users.repos"}}</th>
 						<th>{{.i18n.Tr "admin.users.created"}}</th>
-						<th data-sortt-asc="recentupdate" data-sortt-desc="leastupdate">
+						<th data-sortt-asc="recentlogin" data-sortt-desc="recentloginreverse">
 							{{.i18n.Tr "admin.users.last_login"}}
-							{{SortArrow "recentupdate" "leastupdate" $.SortType false}}
+							{{SortArrow "recentlogin" "recentloginreverse" $.SortType false}}
 						</th>
 						<th>{{.i18n.Tr "admin.users.edit"}}</th>
 					</tr>


### PR DESCRIPTION
On the admin user listing, sorting users by last login date was actually sorting by `last_updated_unix`.

As the orgs listing doesn't have a last login column, I dropped the broken sorter there (thinking about adding more sort options in a followup).

fixes #14942