### PR TITLE
don't mark each comment poster as OP (#14971)

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -29,7 +29,7 @@
 					</div>
 					<div class="header-right actions df ac">
 						{{if not $.Repository.IsArchived}}
-							{{if or (and (eq .PosterID .Issue.PosterID) (eq .Issue.OriginalAuthorID 0)) (eq .Issue.OriginalAuthorID .OriginalAuthorID) }}
+							{{if or (and (eq .PosterID .Issue.PosterID) (eq .Issue.OriginalAuthorID 0)) (and (eq .Issue.OriginalAuthorID .OriginalAuthorID) (not (eq .OriginalAuthorID 0))) }}
 								<div class="item tag">
 									{{$.i18n.Tr "repo.issues.poster"}}
 								</div>


### PR DESCRIPTION
the last part of the condition was always true for non-migrated repos.

backport of #14971
