### PR TITLE
Fix spacing of issue/pulls list review status icons

### DIFF
--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -92,7 +92,7 @@
 						{{$waitingOfficial := call $approvalCounts .ID "waiting"}}
 						{{if gt $approveOfficial 0}}
 							<span class="approvals df ac">
-								{{svg "octicon-check" 14 "mr-2"}}
+								{{svg "octicon-check" 14 "mr-1"}}
 								{{$.i18n.Tr (TrN $.i18n.Lang $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n") $approveOfficial}}
 							</span>
 						{{end}}
@@ -104,7 +104,7 @@
 						{{end}}
 						{{if gt $waitingOfficial 0}}
 							<span class="waiting df ac">
-								{{svg "octicon-eye" 14}}
+								{{svg "octicon-eye" 14 "mr-2"}}
 								{{$.i18n.Tr (TrN $.i18n.Lang $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n") $waitingOfficial}}
 							</span>
 						{{end}}


### PR DESCRIPTION
As title.

Before:
![Bildschirmfoto von 2021-03-13 12-56-49](https://user-images.githubusercontent.com/1714243/111029566-97b33200-83fd-11eb-99f3-714b62b27c1c.png)

After:
![Bildschirmfoto von 2021-03-13 12-57-15](https://user-images.githubusercontent.com/1714243/111029568-997cf580-83fd-11eb-862e-263ce2cf8eb5.png)
