### PR TITLE
Re-enable listing of forks when logged out

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -83,8 +83,8 @@
 						</div>
 					</form>
 					{{if and (not .IsEmpty) ($.Permission.CanRead $.UnitTypeCode)}}
-						<div class="ui labeled button {{if not $.IsSigned}} disabled{{end}}" tabindex="0">
-							<a class="ui compact small basic button {{if or (not $.IsSigned) (not $.CanSignedUserFork)}}poping up{{end}}" {{if $.CanSignedUserFork}}href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else if $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{ else }} data-content="{{$.i18n.Tr "repo.fork_guest_user" }}" rel="nofollow" href="{{AppSubUrl}}/user/login?redirect_to={{AppSubUrl}}/repo/fork/{{.ID}}" {{end}} data-position="top center" data-variation="tiny">
+						<div class="ui labeled button{{if not $.IsSigned}} disabled{{end}}" tabindex="0">
+							<a class="ui compact small basic button{{if not $.CanSignedUserFork}} poping up{{end}}"{{if $.CanSignedUserFork}} href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else if $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{else}} data-content="{{$.i18n.Tr "repo.fork_guest_user"}}"{{end}} data-position="top center" data-variation="tiny">
 								{{svg "octicon-repo-forked"}}{{$.i18n.Tr "repo.fork"}}
 							</a>
 							<a class="ui basic label" href="{{.Link}}/forks">

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -83,8 +83,8 @@
 						</div>
 					</form>
 					{{if and (not .IsEmpty) ($.Permission.CanRead $.UnitTypeCode)}}
-						<div class="ui labeled button{{if not $.IsSigned}} disabled{{end}}" tabindex="0">
-							<a class="ui compact small basic button{{if not $.CanSignedUserFork}} poping up{{end}}"{{if $.CanSignedUserFork}} href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else if $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{else}} data-content="{{$.i18n.Tr "repo.fork_guest_user"}}"{{end}} data-position="top center" data-variation="tiny">
+						<div class="ui labeled button{{if not $.CanSignedUserFork}} poping up disabled{{end}}"{{if and (not $.CanSignedUserFork) $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{else if not $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_guest_user"}}"{{end}} data-position="top center" data-variation="tiny" tabindex="0">
+							<a class="ui compact small basic button"{{if $.CanSignedUserFork}} href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{end}}>
 								{{svg "octicon-repo-forked"}}{{$.i18n.Tr "repo.fork"}}
 							</a>
 							<a class="ui basic label" href="{{.Link}}/forks">

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1585,6 +1585,7 @@ a.ui.label:hover {
   border-left: none;
 }
 
+.ui.labeled.button.disabled > .button:hover,
 .ui.basic.buttons .button,
 .ui.basic.button {
   color: var(--color-text-light);

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1585,7 +1585,7 @@ a.ui.label:hover {
   border-left: none;
 }
 
-.ui.labeled.button.disabled > .button:hover,
+.ui.labeled.button.disabled > .button,
 .ui.basic.buttons .button,
 .ui.basic.button {
   color: var(--color-text-light);

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2856,18 +2856,25 @@ tbody.commit-list {
   align-items: center;
 }
 
-.repo-buttons button[disabled],
 .repo-buttons button[disabled] ~ .label {
   opacity: var(--opacity-disabled);
 }
 
-.repo-buttons .ui.labeled.button.disabled {
-  pointer-events: inherit !important;
-}
+.repo-buttons .ui.labeled.button {
+  cursor: initial;
 
-.repo-buttons .ui.labeled.button > .label {
-  border-left: 0 !important;
-  margin: 0 !important;
+  > .label {
+    border-left: 0 !important;
+    margin: 0 !important;
+  }
+
+  &.disabled {
+    pointer-events: inherit !important;
+
+    > .button {
+      pointer-events: none !important;
+    }
+  }
 }
 
 .tag-code {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2861,6 +2861,10 @@ tbody.commit-list {
   opacity: var(--opacity-disabled);
 }
 
+.repo-buttons .ui.labeled.button.disabled {
+  pointer-events: inherit !important;
+}
+
 .repo-buttons .ui.labeled.button > .label {
   border-left: 0 !important;
   margin: 0 !important;


### PR DESCRIPTION
This PR addresses point 1 of #14926 further by further aligning the look-and-feel of the fork button to that of the other buttons.

When hovering above the fork button, a guest user will still be prompted to log in, but no action is performed on mouse click, exactly like the other two buttons. The user will still be able to list forks when logged out.