### PR TITLE
Fix repo page language stat span color

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2153,6 +2153,7 @@
 
       .item {
         width: 100%;
+        color: var(--color-text);
 
         &:first-of-type {
           border-radius: var(--border-radius) 0 0 var(--border-radius);
@@ -2168,10 +2169,6 @@
           &:hover {
             color: var(--color-primary-light-2);
           }
-        }
-
-        span.ui {
-          color: var(--color-text);
         }
 
         &.active {


### PR DESCRIPTION
![try gitea io_CL-Jeremy_symlink-test](https://user-images.githubusercontent.com/1714243/111074640-3619c300-84e4-11eb-8aa7-427430a2aa48.png)

It seems there has been a rework on this on master that extracted the text out of `.item > span.ui` without noticing this (probably only tested in arc-green?). This PR, besides matching arc-green in this regard, gives more freedom to such reworks.