### PR TITLE
Show/link to proper PR on kanban board ref (#15004)

### DIFF
--- a/templates/repo/projects/view.tmpl
+++ b/templates/repo/projects/view.tmpl
@@ -127,6 +127,15 @@
 								</a>
 								{{ end }}
 							</div>
+							{{- end }}
+							{{- range index $.LinkedPRs .ID }}
+							<div class="meta">
+								<a href="{{$.RepoLink}}/pulls/{{ .Index }}">
+									<span class="{{if .PullRequest.HasMerged}}purple{{else if .IsClosed}}red{{else}}green{{end}}">{{svg "octicon-git-merge"}}</span>
+									{{ .Title}} (#{{ .Index }})
+								</a>
+							</div>
+							{{- end }}
 						</div>
 						<div class="extra content">
 							{{ range .Labels }}


### PR DESCRIPTION
Backport #15004

the issue was that PR references in kanban boards were being generated
using `.ID` instead of `.Index`, which led to constructing incorrect
links to possibly non-existent {PR,issue}s and following that to showing
nonsensical values in the boards.

kudos also go to @zeripath for pointing at the file to fix.

Signed-off-by: wULLSnpAXbWZGYDYyhWTKKspEQoaYxXyhoisqHf <a_mirre@utb.cz>
Co-authored-by: zeripath <art27@cantab.net>