### PR TITLE
Do not convert file path to lowercase

### DIFF
--- a/integrations/migrate_test.go
+++ b/integrations/migrate_test.go
@@ -27,14 +27,14 @@ func TestMigrateLocalPath(t *testing.T) {
 	lowercasePath, err := ioutil.TempDir("", "lowercase") // may not be lowercase because TempDir creates a random directory name which may be mixedcase
 	assert.NoError(t, err)
 	defer os.RemoveAll(lowercasePath)
-	
+
 	err = migrations.IsMigrateURLAllowed(lowercasePath, adminUser)
 	assert.NoError(t, err, "case lowercase path")
 
 	mixedcasePath, err := ioutil.TempDir("", "mIxeDCaSe")
 	assert.NoError(t, err)
 	defer os.RemoveAll(mixedcasePath)
-	
+
 	err = migrations.IsMigrateURLAllowed(mixedcasePath, adminUser)
 	assert.NoError(t, err, "case mixedcase path")
 

--- a/integrations/migrate_test.go
+++ b/integrations/migrate_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/migrations"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigrateLocalPath(t *testing.T) {
+	assert.NoError(t, models.PrepareTestDatabase())
+
+	adminUser := models.AssertExistsAndLoadBean(t, &models.User{Name: "user1"}).(*models.User)
+
+	old := setting.ImportLocalPaths
+	setting.ImportLocalPaths = true
+
+	lowercasePath, err := ioutil.TempDir("", "lowercase") // may not be lowercase because TempDir creates a random directory name which may be mixedcase
+	assert.NoError(t, err)
+	defer os.RemoveAll(lowercasePath)
+	
+	err = migrations.IsMigrateURLAllowed(lowercasePath, adminUser)
+	assert.NoError(t, err, "case lowercase path")
+
+	mixedcasePath, err := ioutil.TempDir("", "mIxeDCaSe")
+	assert.NoError(t, err)
+	defer os.RemoveAll(mixedcasePath)
+	
+	err = migrations.IsMigrateURLAllowed(mixedcasePath, adminUser)
+	assert.NoError(t, err, "case mixedcase path")
+
+	setting.ImportLocalPaths = old
+}

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -72,12 +72,13 @@ func IsMigrateURLAllowed(remoteURL string, doer *models.User) error {
 		return &models.ErrInvalidCloneAddr{Host: u.Host, IsProtocolInvalid: true, IsPermissionDenied: true, IsURLError: true}
 	}
 
+	host := strings.ToLower(u.Host)
 	if len(setting.Migrations.AllowedDomains) > 0 {
-		if !allowList.Match(u.Host) {
+		if !allowList.Match(host) {
 			return &models.ErrInvalidCloneAddr{Host: u.Host, IsPermissionDenied: true}
 		}
 	} else {
-		if blockList.Match(u.Host) {
+		if blockList.Match(host) {
 			return &models.ErrInvalidCloneAddr{Host: u.Host, IsPermissionDenied: true}
 		}
 	}

--- a/modules/migrations/migrate.go
+++ b/modules/migrations/migrate.go
@@ -39,7 +39,7 @@ func RegisterDownloaderFactory(factory base.DownloaderFactory) {
 // IsMigrateURLAllowed checks if an URL is allowed to be migrated from
 func IsMigrateURLAllowed(remoteURL string, doer *models.User) error {
 	// Remote address can be HTTP/HTTPS/Git URL or local path.
-	u, err := url.Parse(strings.ToLower(remoteURL))
+	u, err := url.Parse(remoteURL)
 	if err != nil {
 		return &models.ErrInvalidCloneAddr{IsURLError: true}
 	}

--- a/modules/migrations/migrate_test.go
+++ b/modules/migrations/migrate_test.go
@@ -29,6 +29,9 @@ func TestMigrateWhiteBlocklist(t *testing.T) {
 	err = IsMigrateURLAllowed("https://github.com/go-gitea/gitea.git", nonAdminUser)
 	assert.NoError(t, err)
 
+	err = IsMigrateURLAllowed("https://gITHUb.com/go-gitea/gitea.git", nonAdminUser)
+	assert.NoError(t, err)
+
 	setting.Migrations.AllowedDomains = []string{}
 	setting.Migrations.BlockedDomains = []string{"github.com"}
 	assert.NoError(t, Init())


### PR DESCRIPTION
This fixes a random integration test error caused by invalid lowercase filepaths.

Example:
Go creates a random working directory
`/tmp/tmp.HjvjKQ29GM/integrations/...`

`IsMigrateURLAllowed` uses the lowercase path for its test which fails on case sensitive filesystems
`/tmp/tmp.hjvjkq29gm/integrations/...`