### PR TITLE
Git graph: fix UI elements getting underline like links

### DIFF
--- a/web_src/less/features/gitgraph.less
+++ b/web_src/less/features/gitgraph.less
@@ -82,7 +82,7 @@
       font-size: 80%;
     }
 
-    a:hover {
+    a:not(.ui):hover {
       text-decoration: underline;
     }
 


### PR DESCRIPTION
UI elements (labels, buttons) have hover highlighting and do not require underlining (checked that this code exist since introduction of this feature).

For whatever reason, signed commit labels already do not respond to this rule before this PR (they do after my rework, so this fixes that), so this goes further to exclude just everything of class `ui` (I don't think there will be nested links).