### PR TITLE
fix double 'push tag' action feed

### DIFF
--- a/modules/notification/action/action.go
+++ b/modules/notification/action/action.go
@@ -332,7 +332,8 @@ func (a *actionNotifier) NotifyPushCommits(pusher *models.User, repo *models.Rep
 func (a *actionNotifier) NotifyCreateRef(doer *models.User, repo *models.Repository, refType, refFullName string) {
 	opType := models.ActionCommitRepo
 	if refType == "tag" {
-		opType = models.ActionPushTag
+		// has sent same action in `NotifyPushCommits`, so skip it.
+		return
 	}
 	if err := models.NotifyWatchers(&models.Action{
 		ActUserID: doer.ID,
@@ -350,7 +351,8 @@ func (a *actionNotifier) NotifyCreateRef(doer *models.User, repo *models.Reposit
 func (a *actionNotifier) NotifyDeleteRef(doer *models.User, repo *models.Repository, refType, refFullName string) {
 	opType := models.ActionDeleteBranch
 	if refType == "tag" {
-		opType = models.ActionDeleteTag
+		// has sent same action in `NotifyPushCommits`, so skip it.
+		return
 	}
 	if err := models.NotifyWatchers(&models.Action{
 		ActUserID: doer.ID,


### PR DESCRIPTION
test
```SHELL
git clone ``http://xxxx/test-event.git``
cd test-event
echo "init commit" > README.md
git commit -m "init commit" 
git tag v1
git push -u origin master --tags
git tag -d v1
git push origin :refs/tags/v1
```

before this change:
![image](https://user-images.githubusercontent.com/25342410/111892792-7ecc0180-8a39-11eb-930e-6a67c93263c3.png)

after:
![image](https://user-images.githubusercontent.com/25342410/111892809-9e632a00-8a39-11eb-9c15-5eabc7e2f337.png)


