### PR TITLE
Fix lock modal content rendering outside modal

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -578,8 +578,6 @@
 					{{end}}
 				</button>
 			</div>
-
-
 			<div class="ui tiny modal" id="lock">
 				<div class="header">
 					{{ if .Issue.IsLocked }}
@@ -643,7 +641,6 @@
 						</div>
 					</form>
 				</div>
-			</div>
 			</div>
 		{{end}}
 	</div>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -588,61 +588,61 @@
 						{{.i18n.Tr "repo.issues.lock.title"}}
 					{{end}}
 				</div>
-			</div>
-			<div class="content">
-				<div class="ui warning message text left">
-					{{ if .Issue.IsLocked }}
-						{{.i18n.Tr "repo.issues.unlock.notice_1"}}<br>
-						{{.i18n.Tr "repo.issues.unlock.notice_2"}}<br>
-					{{else}}
-						{{.i18n.Tr "repo.issues.lock.notice_1"}}<br>
-						{{.i18n.Tr "repo.issues.lock.notice_2"}}<br>
-						{{.i18n.Tr "repo.issues.lock.notice_3"}}<br>
-					{{end}}
-				</div>
+				<div class="content">
+					<div class="ui warning message text left">
+						{{ if .Issue.IsLocked }}
+							{{.i18n.Tr "repo.issues.unlock.notice_1"}}<br>
+							{{.i18n.Tr "repo.issues.unlock.notice_2"}}<br>
+						{{else}}
+							{{.i18n.Tr "repo.issues.lock.notice_1"}}<br>
+							{{.i18n.Tr "repo.issues.lock.notice_2"}}<br>
+							{{.i18n.Tr "repo.issues.lock.notice_3"}}<br>
+						{{end}}
+					</div>
 
-				<form class="ui form" action="{{$.RepoLink}}/issues/{{.Issue.Index}}{{ if .Issue.IsLocked }}/unlock{{else}}/lock{{end}}"
-					method="post">
-					{{.CsrfTokenHtml}}
+					<form class="ui form" action="{{$.RepoLink}}/issues/{{.Issue.Index}}{{ if .Issue.IsLocked }}/unlock{{else}}/lock{{end}}"
+						method="post">
+						{{.CsrfTokenHtml}}
 
-					{{ if not .Issue.IsLocked }}
-						<div class="field">
-							<strong> {{ .i18n.Tr "repo.issues.lock.reason" }} </strong>
-						</div>
+						{{ if not .Issue.IsLocked }}
+							<div class="field">
+								<strong> {{ .i18n.Tr "repo.issues.lock.reason" }} </strong>
+							</div>
 
-						<div class="field">
-							<div class="ui fluid dropdown selection" tabindex="0">
+							<div class="field">
+								<div class="ui fluid dropdown selection" tabindex="0">
 
-								<select name="reason">
-									<option value=""> </option>
-									{{range .LockReasons}}
-										<option value="{{.}}">{{.}}</option>
-									{{end}}
-								</select>
-								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+									<select name="reason">
+										<option value=""> </option>
+										{{range .LockReasons}}
+											<option value="{{.}}">{{.}}</option>
+										{{end}}
+									</select>
+									{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 
-								<div class="default text"> </div>
+									<div class="default text"> </div>
 
-								<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
-									{{range .LockReasons}}
-										<div class="item" data-value="{{.}}">{{.}}</div>
-									{{end}}
+									<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
+										{{range .LockReasons}}
+											<div class="item" data-value="{{.}}">{{.}}</div>
+										{{end}}
+									</div>
 								</div>
 							</div>
-						</div>
-					{{end}}
+						{{end}}
 
-					<div class="text right actions">
-						<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-						<button class="ui red button">
-							{{ if .Issue.IsLocked }}
-								{{.i18n.Tr "repo.issues.unlock_confirm"}}
-							{{else}}
-								{{.i18n.Tr "repo.issues.lock_confirm"}}
-							{{end}}
-						</button>
-					</div>
-				</form>
+						<div class="text right actions">
+							<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
+							<button class="ui red button">
+								{{ if .Issue.IsLocked }}
+									{{.i18n.Tr "repo.issues.unlock_confirm"}}
+								{{else}}
+									{{.i18n.Tr "repo.issues.lock_confirm"}}
+								{{end}}
+							</button>
+						</div>
+					</form>
+				</div>
 			</div>
 			</div>
 		{{end}}


### PR DESCRIPTION
Fix regression introduced by https://github.com/go-gitea/gitea/commit/dc081959dbf5aea99f975b79275d43efe681bc25. A extraneous `</div>` caused `.content` to not be a child to `.modal` any more so it was rendering outside the actual modal.

#### Before
<img width="288" alt="Screen Shot 2021-03-21 at 18 31 13" src="https://user-images.githubusercontent.com/115237/111914915-4990d500-8a74-11eb-8ecd-59331327d4ac.png">
<img width="574" alt="Screen Shot 2021-03-21 at 18 31 18" src="https://user-images.githubusercontent.com/115237/111914917-4ac20200-8a74-11eb-92aa-9058779e8ba0.png">

#### After
<img width="278" alt="Screen Shot 2021-03-21 at 18 30 30" src="https://user-images.githubusercontent.com/115237/111914920-501f4c80-8a74-11eb-9351-cb040f16e4e9.png">
<img width="567" alt="Screen Shot 2021-03-21 at 18 30 40" src="https://user-images.githubusercontent.com/115237/111914921-50b7e300-8a74-11eb-84fd-a341a9ccd223.png">
