### PR TITLE
Fixed #15020

### DIFF
--- a/integrations/git_test.go
+++ b/integrations/git_test.go
@@ -527,7 +527,9 @@ func doEnsureDiffNoChange(ctx APITestContext, pr api.PullRequest, diffStr string
 		if actualMaxLen > 800 {
 			actualMaxLen = 800
 		}
-		assert.Equal(t, diffStr, actual, "Unexpected change in the diff string: expected: %s but was actually: %s", diffStr[:expectedMaxLen], actual[:actualMaxLen])
+
+		equal := diffStr == actual
+		assert.True(t, equal, "Unexpected change in the diff string: expected: %s but was actually: %s", diffStr[:expectedMaxLen], actual[:actualMaxLen])
 	}
 }
 


### PR DESCRIPTION
Addition for #15020.

`assert.Equals` itself [prints both values](https://drone.gitea.io/go-gitea/gitea/37379/3/5) so the previous fix was only half the work.
![grafik](https://user-images.githubusercontent.com/1666336/111917916-b7dc9400-8a82-11eb-878a-c8c973ccebd8.png)
