### PR TITLE
Fix the v176 migration

### DIFF
--- a/models/consistency.go
+++ b/models/consistency.go
@@ -380,7 +380,7 @@ func FixIssueLabelWithOutsideLabels() (int64, error) {
 		SELECT il_too.id FROM (
 			SELECT il_too_too.id
 				FROM issue_label AS il_too_too
-					INNER JOIN label ON il_too_too.id = label.id
+					INNER JOIN label ON il_too_too.label_id = label.id
 					INNER JOIN issue on issue.id = il_too_too.issue_id
 					INNER JOIN repository on repository.id = issue.repo_id
 				WHERE

--- a/models/migrations/v176.go
+++ b/models/migrations/v176.go
@@ -48,7 +48,7 @@ func removeInvalidLabels(x *xorm.Engine) error {
 		SELECT il_too.id FROM (
 			SELECT il_too_too.id
 				FROM issue_label AS il_too_too
-					INNER JOIN label ON il_too_too.id = label.id
+					INNER JOIN label ON il_too_too.label_id = label.id
 					INNER JOIN issue on issue.id = il_too_too.issue_id
 					INNER JOIN repository on repository.id = issue.repo_id
 				WHERE

--- a/models/repo_transfer.go
+++ b/models/repo_transfer.go
@@ -330,7 +330,7 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) (err e
 			SELECT il_too.id FROM (
 				SELECT il_too_too.id
 					FROM issue_label AS il_too_too
-						INNER JOIN label ON il_too_too.id = label.id
+						INNER JOIN label ON il_too_too.label_id = label.id
 						INNER JOIN issue on issue.id = il_too_too.issue_id
 					WHERE
 						issue.repo_id = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != ?))


### PR DESCRIPTION
introduced by https://github.com/go-gitea/gitea/pull/14912

There is a serious issue with the v176 migration where there is a mistaken missing
label_id selection.

Signed-off-by: Andrew Thornton <art27@cantab.net>
