### PR TITLE
Remove raw-loader dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,37 +6848,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "raw-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "monaco-editor-webpack-plugin": "3.0.1",
     "postcss": "8.2.8",
     "pretty-ms": "7.0.1",
-    "raw-loader": "4.0.2",
     "sortablejs": "1.13.0",
     "swagger-ui-dist": "3.45.1",
     "terser-webpack-plugin": "5.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,11 +207,7 @@ module.exports = {
       {
         test: /\.svg$/,
         include: resolve(__dirname, 'public/img/svg'),
-        use: [
-          {
-            loader: 'raw-loader',
-          },
-        ],
+        type: 'asset/source',
       },
       {
         test: /\.(ttf|woff2?)$/,


### PR DESCRIPTION
Webpack now includes this functionality, allowing us to drop this now-deprecated dependency.

Ref: https://webpack.js.org/guides/asset-modules/
Ref: https://webpack.js.org/loaders/raw-loader/