### PR TITLE
Fix consistency check

### DIFF
--- a/models/consistency.go
+++ b/models/consistency.go
@@ -368,7 +368,7 @@ func FixCommentTypeLabelWithOutsideLabels() (int64, error) {
 func CountIssueLabelWithOutsideLabels() (int64, error) {
 	return x.Where(builder.Expr("issue.repo_id != label.repo_id OR (label.repo_id = 0 AND repository.owner_id != label.org_id)")).
 		Table("issue_label").
-		Join("inner", "label", "issue_label.id = label.id ").
+		Join("inner", "label", "issue_label.label_id = label.id ").
 		Join("inner", "issue", "issue.id = issue_label.issue_id ").
 		Join("inner", "repository", "issue.repo_id = repository.id").
 		Count(new(IssueLabel))


### PR DESCRIPTION
In my last fix I missed adding the label_ prefix to the consistency check count. The incorrect count does not have any negative effects but should be fixed.

Continues #15110 

Signed-off-by: Andrew Thornton <art27@cantab.net>
