### PR TITLE
Fix Migration 176 yet again (#15131)

### DIFF
--- a/models/consistency.go
+++ b/models/consistency.go
@@ -338,7 +338,7 @@ func FixCommentTypeLabelWithEmptyLabel() (int64, error) {
 
 // CountCommentTypeLabelWithOutsideLabels count label comments with outside label
 func CountCommentTypeLabelWithOutsideLabels() (int64, error) {
-	return x.Where("comment.type = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND repository.owner_id != label.org_id))", CommentTypeLabel).
+	return x.Where("comment.type = ? AND ((label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id))", CommentTypeLabel).
 		Table("comment").
 		Join("inner", "label", "label.id = comment.label_id").
 		Join("inner", "issue", "issue.id = comment.issue_id ").
@@ -354,8 +354,9 @@ func FixCommentTypeLabelWithOutsideLabels() (int64, error) {
 				FROM comment AS com
 					INNER JOIN label ON com.label_id = label.id
 					INNER JOIN issue on issue.id = com.issue_id
+					INNER JOIN repository ON issue.repo_id = repository.id
 				WHERE
-					com.type = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != repo.owner_id))
+					com.type = ? AND ((label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id))
 	) AS il_too)`, CommentTypeLabel)
 	if err != nil {
 		return 0, err
@@ -366,7 +367,7 @@ func FixCommentTypeLabelWithOutsideLabels() (int64, error) {
 
 // CountIssueLabelWithOutsideLabels count label comments with outside label
 func CountIssueLabelWithOutsideLabels() (int64, error) {
-	return x.Where(builder.Expr("issue.repo_id != label.repo_id OR (label.repo_id = 0 AND repository.owner_id != label.org_id)")).
+	return x.Where(builder.Expr("(label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id)")).
 		Table("issue_label").
 		Join("inner", "label", "issue_label.label_id = label.id ").
 		Join("inner", "issue", "issue.id = issue_label.issue_id ").
@@ -384,7 +385,7 @@ func FixIssueLabelWithOutsideLabels() (int64, error) {
 					INNER JOIN issue on issue.id = il_too_too.issue_id
 					INNER JOIN repository on repository.id = issue.repo_id
 				WHERE
-					issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != repository.owner_id)
+					(label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id)
 	) AS il_too )`)
 
 	if err != nil {

--- a/models/migrations/v176.go
+++ b/models/migrations/v176.go
@@ -52,7 +52,7 @@ func removeInvalidLabels(x *xorm.Engine) error {
 					INNER JOIN issue on issue.id = il_too_too.issue_id
 					INNER JOIN repository on repository.id = issue.repo_id
 				WHERE
-					issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != repository.owner_id)
+					(label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id)
 	) AS il_too )`); err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func removeInvalidLabels(x *xorm.Engine) error {
 					INNER JOIN issue on issue.id = com.issue_id
 					INNER JOIN repository on repository.id = issue.repo_id
 				WHERE
-					com.type = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != repository.owner_id))
+					com.type = ? AND ((label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id))
 	) AS il_too)`, 7); err != nil {
 		return err
 	}

--- a/models/repo_transfer.go
+++ b/models/repo_transfer.go
@@ -333,7 +333,7 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) (err e
 						INNER JOIN label ON il_too_too.label_id = label.id
 						INNER JOIN issue on issue.id = il_too_too.issue_id
 					WHERE
-						issue.repo_id = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != ?))
+						issue.repo_id = ? AND ((label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != ?))
 		) AS il_too )`, repo.ID, newOwner.ID); err != nil {
 			return fmt.Errorf("Unable to remove old org labels: %v", err)
 		}
@@ -343,9 +343,9 @@ func TransferOwnership(doer *User, newOwnerName string, repo *Repository) (err e
 				SELECT com.id
 					FROM comment AS com
 						INNER JOIN label ON com.label_id = label.id
-						INNER JOIN issue on issue.id = com.issue_id
+						INNER JOIN issue ON issue.id = com.issue_id
 					WHERE
-						com.type = ? AND issue.repo_id = ? AND (issue.repo_id != label.repo_id OR (label.repo_id = 0 AND label.org_id != ?))
+						com.type = ? AND issue.repo_id = ? AND ((label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != ?))
 		) AS il_too)`, CommentTypeLabel, repo.ID, newOwner.ID); err != nil {
 			return fmt.Errorf("Unable to remove old org label comments: %v", err)
 		}


### PR DESCRIPTION
Backport #15131

Whilst creating a test for v176 in the migrations_test PR
it has become clear that this was still wrong.

This is now fixed. Genuinely.

Also fix repo transfer

Signed-off-by: Andrew Thornton <art27@cantab.net>
