### PR TITLE
Fix wrong user returned in API

### DIFF
--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -96,7 +96,7 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 				apiComment := &api.PullReviewComment{
 					ID:           comment.ID,
 					Body:         comment.Content,
-					Reviewer:     ToUser(review.Reviewer, doer != nil, auth),
+					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
 					ReviewID:     review.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -96,7 +96,7 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 					ID:           comment.ID,
 					Body:         comment.Content,
 					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
-					ReviewID:     comment.Poster.ID,
+					ReviewID:     comment.PosterID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),
 					Path:         comment.TreePath,

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -96,8 +96,8 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 				apiComment := &api.PullReviewComment{
 					ID:           comment.ID,
 					Body:         comment.Content,
-					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
-					ReviewID:     review.ID,
+					Reviewer:     ToUser(comment.Poster, doer != nil, doer.IsAdmin || doer.ID == comment.Poster.ID),
+					ReviewID:     comment.Poster.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),
 					Path:         comment.TreePath,

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -85,18 +85,17 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 
 	apiComments := make([]*api.PullReviewComment, 0, len(review.CodeComments))
 
-	auth := false
-	if doer != nil {
-		auth = doer.IsAdmin || doer.ID == review.ReviewerID
-	}
-
 	for _, lines := range review.CodeComments {
 		for _, comments := range lines {
 			for _, comment := range comments {
+				auth := false
+				if doer != nil {
+					auth = doer.IsAdmin || doer.ID == comment.Poster.ID
+				}
 				apiComment := &api.PullReviewComment{
 					ID:           comment.ID,
 					Body:         comment.Content,
-					Reviewer:     ToUser(comment.Poster, doer != nil, doer.IsAdmin || doer.ID == comment.Poster.ID),
+					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
 					ReviewID:     comment.Poster.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),


### PR DESCRIPTION
The API call: GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
returns always the reviewer, but should return the poster.

close #15127