### PR TITLE
Add links to previous blame

### DIFF
--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -218,7 +218,9 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 					avatar = string(templates.AvatarByEmail(commit.Author.Email, commit.Author.Name, 18, "mr-3"))
 				}
 
-				commitInfo.WriteString(fmt.Sprintf(`<div class="blame-info%s"><div class="blame-data"><div class="blame-avatar">%s</div><div class="blame-message"><a href="%s/commit/%s" title="%[5]s">%[5]s</a></div><div class="blame-time">%s</div></div></div>`, attr, avatar, repoLink, part.Sha, html.EscapeString(commit.CommitMessage), commitSince))
+				previousBlameLink := fmt.Sprintf(`<a class="blame-previous" href="%s/blame/commit/%s/%s">⎗</a>`, repoLink, part.Sha, ctx.Repo.TreePath)
+				commitInfo.WriteString(fmt.Sprintf(`<div class="blame-info%s"><div class="blame-data"><div class="blame-avatar">%s</div><div class="blame-message"><a href="%s/commit/%s" title="%[5]s">%[5]s</a></div><div class="blame-time">%s</div>%s</div></div>`,
+					attr, avatar, repoLink, part.Sha, html.EscapeString(commit.CommitMessage), commitSince, previousBlameLink))
 			} else {
 				commitInfo.WriteString(fmt.Sprintf(`<div class="blame-info%s">&#8203;</div>`, attr))
 			}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1512,6 +1512,8 @@ a.ui.label:hover {
   .ui.avatar.image {
     height: 18px;
     width: 18px;
+    display: block;
+    margin-top: 1px;
   }
 }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1498,8 +1498,13 @@ a.ui.label:hover {
       }
 
       .blame-time,
-      .blame-avatar {
+      .blame-avatar,
+      .blame-previous {
         flex-shrink: 0;
+      }
+
+      .blame-previous {
+        padding-left: 8px;
       }
     }
   }


### PR DESCRIPTION
- add link to previous blame (fixes #15109)
- fix blame row alignment on firefox (commit info column was 1px higher than other columns due to avatar placement)

WIP, help wanted: this probably needs an SVG icon + i18n-ed tooltip, how would I do this with this non-template code..? D: