### PR TITLE
Fix wrong user returned in API (#15139)

### DIFF
--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -83,19 +83,18 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 
 	apiComments := make([]*api.PullReviewComment, 0, len(review.CodeComments))
 
-	auth := false
-	if doer != nil {
-		auth = doer.IsAdmin || doer.ID == review.ReviewerID
-	}
-
 	for _, lines := range review.CodeComments {
 		for _, comments := range lines {
 			for _, comment := range comments {
+				auth := false
+				if doer != nil {
+					auth = doer.IsAdmin || doer.ID == comment.Poster.ID
+				}
 				apiComment := &api.PullReviewComment{
 					ID:           comment.ID,
 					Body:         comment.Content,
-					Reviewer:     ToUser(review.Reviewer, doer != nil, auth),
-					ReviewID:     review.ID,
+					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
+					ReviewID:     comment.PosterID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),
 					Path:         comment.TreePath,

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -94,7 +94,7 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 					ID:           comment.ID,
 					Body:         comment.Content,
 					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
-					ReviewID:     comment.PosterID,
+					ReviewID:     review.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),
 					Path:         comment.TreePath,


### PR DESCRIPTION
Backport of #15139

The API call: GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
returns always the reviewer, but should return the poster.

Co-authored-by: 6543 <6543@obermui.de>
Co-authored-by: zeripath <art27@cantab.net>