### PR TITLE
Add NeedPostProcess for Parser interface to improve performance of csv parser and some external parser

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -831,12 +831,14 @@ Gitea can support Markup using external tools. The example below will add a mark
 ```ini
 [markup.asciidoc]
 ENABLED = true
+NEED_POSTPROCESS = true
 FILE_EXTENSIONS = .adoc,.asciidoc
 RENDER_COMMAND = "asciidoc --out-file=- -"
 IS_INPUT_FILE = false
 ```
 
 - ENABLED: **false** Enable markup support; set to **true** to enable this renderer.
+- NEED\_POSTPROCESS: **true** set to **true** to replace links / sha1 and etc.
 - FILE\_EXTENSIONS: **\<empty\>** List of file extensions that should be rendered by an external
    command. Multiple extentions needs a comma as splitter.
 - RENDER\_COMMAND: External command to render all matching extensions.

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -297,12 +297,14 @@ test01.xls: application/vnd.ms-excel; charset=binary
 ```ini
 [markup.asciidoc]
 ENABLED = false
+NEED_POSTPROCESS = true
 FILE_EXTENSIONS = .adoc,.asciidoc
 RENDER_COMMAND = "asciidoc --out-file=- -"
 IS_INPUT_FILE = false
 ```
 
 - ENABLED: 是否启用，默认为false。
+- NEED\_POSTPROCESS: **true** 设置为 true 则会替换渲染文件中的内部链接和Commit ID 等。
 - FILE_EXTENSIONS: 关联的文档的扩展名，多个扩展名用都好分隔。
 - RENDER_COMMAND: 工具的命令行命令及参数。
 - IS_INPUT_FILE: 输入方式是最后一个参数为文件路径还是从标准输入读取。

--- a/modules/markup/csv/csv.go
+++ b/modules/markup/csv/csv.go
@@ -28,6 +28,9 @@ func (Parser) Name() string {
 	return "csv"
 }
 
+// NeedPostProcess implements markup.Parser
+func (Parser) NeedPostProcess() bool { return false }
+
 // Extensions implements markup.Parser
 func (Parser) Extensions() []string {
 	return []string{".csv", ".tsv"}

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -38,6 +38,11 @@ func (p *Parser) Name() string {
 	return p.MarkupName
 }
 
+// NeedPostProcess implements markup.Parser
+func (p *Parser) NeedPostProcess() bool {
+	return p.MarkupParser.NeedPostProcess
+}
+
 // Extensions returns the supported extensions of the tool
 func (p *Parser) Extensions() []string {
 	return p.FileExtensions

--- a/modules/markup/markdown/markdown.go
+++ b/modules/markup/markdown/markdown.go
@@ -228,6 +228,9 @@ func (Parser) Name() string {
 	return MarkupName
 }
 
+// NeedPostProcess implements markup.Parser
+func (Parser) NeedPostProcess() bool { return true }
+
 // Extensions implements markup.Parser
 func (Parser) Extensions() []string {
 	return setting.Markdown.FileExtensions

--- a/modules/markup/markup.go
+++ b/modules/markup/markup.go
@@ -33,6 +33,7 @@ func Init() {
 type Parser interface {
 	Name() string // markup format name
 	Extensions() []string
+	NeedPostProcess() bool
 	Render(rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte
 }
 
@@ -82,10 +83,13 @@ func RenderWiki(filename string, rawBytes []byte, urlPrefix string, metas map[st
 
 func render(parser Parser, rawBytes []byte, urlPrefix string, metas map[string]string, isWiki bool) []byte {
 	result := parser.Render(rawBytes, urlPrefix, metas, isWiki)
-	// TODO: one day the error should be returned.
-	result, err := PostProcess(result, urlPrefix, metas, isWiki)
-	if err != nil {
-		log.Error("PostProcess: %v", err)
+	if parser.NeedPostProcess() {
+		var err error
+		// TODO: one day the error should be returned.
+		result, err = PostProcess(result, urlPrefix, metas, isWiki)
+		if err != nil {
+			log.Error("PostProcess: %v", err)
+		}
 	}
 	return SanitizeBytes(result)
 }

--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -30,6 +30,9 @@ func (Parser) Name() string {
 	return "orgmode"
 }
 
+// NeedPostProcess implements markup.Parser
+func (Parser) NeedPostProcess() bool { return true }
+
 // Extensions implements markup.Parser
 func (Parser) Extensions() []string {
 	return []string{".org"}

--- a/modules/setting/markup.go
+++ b/modules/setting/markup.go
@@ -21,11 +21,12 @@ var (
 
 // MarkupParser defines the external parser configured in ini
 type MarkupParser struct {
-	Enabled        bool
-	MarkupName     string
-	Command        string
-	FileExtensions []string
-	IsInputFile    bool
+	Enabled         bool
+	MarkupName      string
+	Command         string
+	FileExtensions  []string
+	IsInputFile     bool
+	NeedPostProcess bool
 }
 
 // MarkupSanitizerRule defines the policy for whitelisting attributes on
@@ -124,10 +125,11 @@ func newMarkupRenderer(name string, sec *ini.Section) {
 	}
 
 	ExternalMarkupParsers = append(ExternalMarkupParsers, MarkupParser{
-		Enabled:        sec.Key("ENABLED").MustBool(false),
-		MarkupName:     name,
-		FileExtensions: exts,
-		Command:        command,
-		IsInputFile:    sec.Key("IS_INPUT_FILE").MustBool(false),
+		Enabled:         sec.Key("ENABLED").MustBool(false),
+		MarkupName:      name,
+		FileExtensions:  exts,
+		Command:         command,
+		IsInputFile:     sec.Key("IS_INPUT_FILE").MustBool(false),
+		NeedPostProcess: sec.Key("NEED_POSTPROCESS").MustBool(true),
 	})
 }


### PR DESCRIPTION
Before this PR, it took `15s` to render a 900 lines csv file with 6 columns on my macOS pro 2020.
After this PR, it will spend about `250ms`.

So `PostProcess` is very slow and it's useless for rendering csv file.

This PR also make some external markup tool faster to allow them ignore `PostProcess`.