### PR TITLE
fixed error calling eq: incompatible types for comparison

### DIFF
--- a/templates/repo/graph/svgcontainer.tmpl
+++ b/templates/repo/graph/svgcontainer.tmpl
@@ -9,7 +9,7 @@
 						M {{Add (Mul $glyph.Column 5) 10}} {{Add (Mul $glyph.Row 12) 0}} l -10 12 {{/* */ -}}
 					{{- else if eq $glyph.Glyph '\\' -}}
 						M {{Add (Mul $glyph.Column 5) 0}} {{Add (Mul $glyph.Row 12) 0}} l 10 12 {{/* */ -}}
-					{{- else if or (eq $glyph.Glyph '-') (eq $glyph.Glyph '.') -}}
+					{{- else if or (eq $glyph.Glyph '-') (eq $glyph.Glyph '\.') -}}
 						M {{Add (Mul $glyph.Column 5) 0}} {{Add (Mul $glyph.Row 12) 12}} h 5 {{/* */ -}}
 					{{- else if eq $glyph.Glyph '_' -}}
 						M {{Add (Mul $glyph.Column 5) 0}} {{Add (Mul $glyph.Row 12) 12}} h 10 {{/* */ -}}


### PR DESCRIPTION
This pull requests fixes an error in the templates/graph/svgcontainer.tmpl file.

full error:

```
500 internal server error
template: repo/graph/svgcontainer:12:43: executing "repo/graph/svgcontainer" at <eq $glyph.Glyph '.'>: error calling eq: incompatible types for comparison
```

This was caused by an _ symbol in the output of the git graph command. When coming across '.', go templates interprets the . character as per https://golang.org/pkg/text/template/, second paragraph:

`Execution of the template walks the structure and sets the cursor, represented by a period '.' and called "dot", to the value at the current location in the structure as execution proceeds.`

Adding a \ eliminates interpretation and allows the code to proceed.
