### PR TITLE
Path seems to have moved from /data to /app/data (Docker)

### DIFF
--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -55,7 +55,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -87,7 +87,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -127,7 +127,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
      ports:
@@ -178,7 +178,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -226,8 +226,8 @@ services:
     networks:
       - gitea
     volumes:
--     - ./gitea:/data
-+     - gitea:/data
+-     - ./gitea:/app/data
++     - gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/content/doc/installation/with-docker.fr-fr.md
+++ b/docs/content/doc/installation/with-docker.fr-fr.md
@@ -95,7 +95,7 @@ $ docker run -d --name gitea \
 	--dns 10.12.10.160 \
 	-p 11180:3000 \
 	-p 8322:22 \
-	-v gitea-data:/data \
+	-v gitea-data:/app/data \
 	gitea/gitea:latest
 ```
 

--- a/docs/content/doc/installation/with-docker.zh-cn.md
+++ b/docs/content/doc/installation/with-docker.zh-cn.md
@@ -43,7 +43,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -73,7 +73,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -112,7 +112,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
      ports:
@@ -162,7 +162,7 @@ services:
     networks:
       - gitea
     volumes:
-      - ./gitea:/data
+      - ./gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -207,8 +207,8 @@ services:
     networks:
       - gitea
     volumes:
--     - ./gitea:/data
-+     - gitea:/data
+-     - ./gitea:/app/data
++     - gitea:/app/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:


### PR DESCRIPTION
I kept wondering why I was losing data when closing my docker-compose Gitea server.

Turns out that at some point the default data location was moved to /app/data instead of /data.

This commit amends the documentation to reflect this.

*Used gitea/gitea:1.13