### PR TITLE
Expose resolver via API

### DIFF
--- a/integrations/api_pull_review_test.go
+++ b/integrations/api_pull_review_test.go
@@ -66,7 +66,7 @@ func TestAPIPullReview(t *testing.T) {
 	var reviewComments []*api.PullReviewComment
 	DecodeJSON(t, resp, &reviewComments)
 	assert.Len(t, reviewComments, 1)
-	assert.EqualValues(t, "Ghost", reviewComments[0].Reviewer.UserName)
+	assert.EqualValues(t, "Ghost", reviewComments[0].Poster.UserName)
 	assert.EqualValues(t, "a review from a deleted user", reviewComments[0].Body)
 	assert.EqualValues(t, comment.ID, reviewComments[0].ID)
 	assert.EqualValues(t, comment.UpdatedUnix, reviewComments[0].Updated.Unix())

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -87,7 +87,7 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 					ID:           comment.ID,
 					Body:         comment.Content,
 					Poster:       ToUser(comment.Poster, doer),
-          Resolver:     ToUser(comment.ResolveDoer, doer),
+					Resolver:     ToUser(comment.ResolveDoer, doer),
 					ReviewID:     review.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),

--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -88,14 +88,19 @@ func ToPullReviewCommentList(review *models.Review, doer *models.User) ([]*api.P
 	for _, lines := range review.CodeComments {
 		for _, comments := range lines {
 			for _, comment := range comments {
-				auth := false
+				authPoster := false
 				if doer != nil {
-					auth = doer.IsAdmin || doer.ID == comment.Poster.ID
+					authPoster = doer.IsAdmin || doer.ID == comment.Poster.ID
+				}
+				authResolver := false
+				if doer != nil {
+					authResolver = doer.IsAdmin || (comment.ResolveDoer != nil && doer.ID == comment.ResolveDoer.ID)
 				}
 				apiComment := &api.PullReviewComment{
 					ID:           comment.ID,
 					Body:         comment.Content,
-					Reviewer:     ToUser(comment.Poster, doer != nil, auth),
+					Poster:       ToUser(comment.Poster, doer != nil, authPoster),
+					Resolver:     ToUser(comment.ResolveDoer, doer != nil, authResolver),
 					ReviewID:     review.ID,
 					Created:      comment.CreatedUnix.AsTime(),
 					Updated:      comment.UpdatedUnix.AsTime(),

--- a/modules/structs/pull_review.go
+++ b/modules/structs/pull_review.go
@@ -49,7 +49,8 @@ type PullReview struct {
 type PullReviewComment struct {
 	ID       int64  `json:"id"`
 	Body     string `json:"body"`
-	Reviewer *User  `json:"user"`
+	Poster   *User  `json:"user"`
+	Resolver *User  `json:"resolver"`
 	ReviewID int64  `json:"pull_request_review_id"`
 
 	// swagger:strfmt date-time

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -15455,6 +15455,9 @@
           "type": "string",
           "x-go-name": "HTMLPullURL"
         },
+        "resolver": {
+          "$ref": "#/definitions/User"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time",


### PR DESCRIPTION
* Add a new field to the API to expose the "resolver" of a comment/
  conversation. This is not available in the GitHub API v3.
* Extend struct to contain "Resolver". Might be empty (nil).
* Rename "Reviewer" to "Poster" in PullReviewComment to make it
  clear this is the person posting a comment. The API is unchanged
  ('user').
* Only the first comment of a conversation might have a resolver,
  the others seem to be always nil.