### PR TITLE
Feature: link to previous blames in view blame page

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -735,6 +735,7 @@ delete_preexisting_label = Delete
 delete_preexisting = Delete pre-existing files
 delete_preexisting_content = Delete files in %s
 delete_preexisting_success = Deleted unadopted files in %s
+blame_prior = View blame prior to this change
 
 transfer.accept = Accept Transfer
 transfer.accept_desc =  Transfer to "%s"

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -243,7 +243,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 				br.RepoLink = repoLink
 				br.PartSha = part.Sha
 				br.PreviousSha = previousSha
-				br.PreviousShaUrl = fmt.Sprintf("%s/blame/commit/%s/%s", repoLink, previousSha, ctx.Data["FileName"])
+				br.PreviousShaUrl = fmt.Sprintf("%s/blame/commit/%s/%s", repoLink, previousSha, ctx.Repo.TreePath)
 				br.CommitUrl = fmt.Sprintf("%s/commit/%s", repoLink, part.Sha)
 				br.CommitMessage = html.EscapeString(commit.CommitMessage)
 				br.CommitSince = commitSince

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -31,8 +31,8 @@ type BlameRow struct {
 	RepoLink       string
 	PartSha        string
 	PreviousSha    string
-	PreviousShaUrl string
-	CommitUrl      string
+	PreviousShaURL string
+	CommitURL      string
 	CommitMessage  string
 	CommitSince    gotemplate.HTML
 	Code           gotemplate.HTML
@@ -247,8 +247,8 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 				br.RepoLink = repoLink
 				br.PartSha = part.Sha
 				br.PreviousSha = previousSha
-				br.PreviousShaUrl = fmt.Sprintf("%s/blame/commit/%s/%s", repoLink, previousSha, ctx.Repo.TreePath)
-				br.CommitUrl = fmt.Sprintf("%s/commit/%s", repoLink, part.Sha)
+				br.PreviousShaURL = fmt.Sprintf("%s/blame/commit/%s/%s", repoLink, previousSha, ctx.Repo.TreePath)
+				br.CommitURL = fmt.Sprintf("%s/commit/%s", repoLink, part.Sha)
 				br.CommitMessage = html.EscapeString(commit.CommitMessage)
 				br.CommitSince = commitSince
 			}

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -26,16 +26,16 @@ const (
 )
 
 type BlameRow struct {
-	RowNumber             int
-	Avatar                gotemplate.HTML
-	RepoLink              string
-	PartSha               string
-	PreviousSha           string
-	PreviousShaUrl        string
-	CommitUrl             string
-	CommitMessage         string
-	CommitSince           gotemplate.HTML
-	Code                  gotemplate.HTML
+	RowNumber      int
+	Avatar         gotemplate.HTML
+	RepoLink       string
+	PartSha        string
+	PreviousSha    string
+	PreviousShaUrl string
+	CommitUrl      string
+	CommitMessage  string
+	CommitSince    gotemplate.HTML
+	Code           gotemplate.HTML
 }
 
 // RefBlame render blame page
@@ -218,7 +218,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 		for index, line := range part.Lines {
 			i++
 			lines = append(lines, line)
-			
+
 			br := &BlameRow{
 				RowNumber: i,
 			}
@@ -238,7 +238,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 				} else {
 					avatar = string(templates.AvatarByEmail(commit.Author.Email, commit.Author.Name, 18, "mr-3"))
 				}
-				
+
 				br.Avatar = gotemplate.HTML(avatar)
 				br.RepoLink = repoLink
 				br.PartSha = part.Sha
@@ -256,10 +256,10 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 			line = highlight.Code(fileName, line)
 
 			br.Code = gotemplate.HTML(line)
-      rows = append(rows, br)
+			rows = append(rows, br)
 		}
 	}
 
-  ctx.Data["Codes"] = rows
+	ctx.Data["Codes"] = rows
 	ctx.Data["CommitCnt"] = commitCnt
 }

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -179,7 +179,11 @@ func RefBlame(ctx *context.Context) {
 		// Get previous closest commit sha from the commit
 		previousSha, err := commit.ParentID(0)
 		if err == nil {
-			previousCommits[commit.ID.String()] = previousSha.String()
+			// Verify the commit
+			haz, _ := commit.HasPreviousCommit(previousSha)
+			if haz {
+				previousCommits[commit.ID.String()] = previousSha.String()
+			}
 		}
 
 		commits.PushBack(commit)

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -25,7 +25,7 @@ const (
 	tplBlame base.TplName = "repo/home"
 )
 
-type BlameRow struct {
+type blameRow struct {
 	RowNumber      int
 	Avatar         gotemplate.HTML
 	RepoLink       string
@@ -216,7 +216,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 	repoLink := ctx.Repo.RepoLink
 
 	var lines = make([]string, 0)
-	rows := make([]*BlameRow, 0)
+	rows := make([]*blameRow, 0)
 
 	var i = 0
 	var commitCnt = 0
@@ -225,7 +225,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 			i++
 			lines = append(lines, line)
 
-			br := &BlameRow{
+			br := &blameRow{
 				RowNumber: i,
 			}
 

--- a/routers/repo/blame.go
+++ b/routers/repo/blame.go
@@ -32,6 +32,7 @@ type BlameRow struct {
 	PartSha        string
 	PreviousSha    string
 	PreviousShaURL string
+	IsFirstCommit  bool
 	CommitURL      string
 	CommitMessage  string
 	CommitSince    gotemplate.HTML
@@ -177,12 +178,13 @@ func RefBlame(ctx *context.Context) {
 		}
 
 		// Get previous closest commit sha from the commit
-		previousSha, err := commit.ParentID(0)
+		previousCommit, err := commit.Parent(0)
 		if err == nil {
 			// Verify the commit
-			haz, _ := commit.HasPreviousCommit(previousSha)
-			if haz {
-				previousCommits[commit.ID.String()] = previousSha.String()
+			if haz, _ := commit.HasPreviousCommit(previousCommit.ID); haz {
+				if haz1, _ := previousCommit.HasFile(ctx.Repo.TreePath); haz1 {
+					previousCommits[commit.ID.String()] = previousCommit.ID.String()
+				}
 			}
 		}
 

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -43,7 +43,7 @@
 								</div>
 							</td>
 							<td class="lines-blame-btn">
-							  {{if $row.PreviousSha}}
+							  {{if and (gt $.CommitCnt 1) ($row.PreviousSha)}}
 									<a href="{{$row.PreviousShaUrl}}" class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
 										{{svg "octicon-calendar"}}
 									</a>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -23,11 +23,43 @@
 		<div class="file-view code-view">
 			<table>
 				<tbody>
-					<tr>
-						<td class="lines-commit">{{.BlameCommitInfo}}</td>
-						<td class="lines-num">{{.BlameLineNums}}</td>
-						<td class="lines-code"><code class="chroma"><ol class="linenums">{{.BlameContent}}</ol></code></td>
-					</tr>
+					{{range $row := .Codes}}
+					  <tr class="{{if and (gt $.CommitCnt 1) ($row.CommitMessage)}}bottom-line-blame{{end}}">
+						  <td class="lines-commit">
+								<div class="blame-info">
+									<div class="blame-data">
+										<div class="blame-avatar">
+											{{$row.Avatar}}
+										</div>
+										<div class="blame-message">
+											<a href="{{$row.CommitUrl}}" title="{{$row.CommitMessage}}">
+												{{$row.CommitMessage}}
+											</a>
+										</div>
+										<div class="blame-time">
+											{{$row.CommitSince}}
+										</div>
+									</div>
+								</div>
+							</td>
+							<td class="lines-blame-btn">
+							  <a class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
+								  {{svg "octicon-calendar"}}
+								</a>
+							</td>
+							<td class="lines-num">
+								<span id="L{{$row.RowNumber}}" data-line-number="{{$row.RowNumber}}"></span>
+							</td>
+							<td rel="L{{$row.RowNumber}}" rel="L{{$row.RowNumber}}" class="lines-code blame-code chroma">
+								<code class="code-inner pl-3">{{$row.Code}}</code>
+							</td>
+							{{/* <td class="lines-code">
+								<div class="L{{$row.RowNumber}} chroma" rel="L{{$row.RowNumber}}">
+									{{$row.Code}}
+								<div>
+							</td> */}}
+						</tr>
+					{{end}}
 				</tbody>
 			</table>
 		</div>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -32,7 +32,7 @@
 											{{$row.Avatar}}
 										</div>
 										<div class="blame-message">
-											<a href="{{$row.CommitUrl}}" title="{{$row.CommitMessage}}">
+											<a href="{{$row.CommitURL}}" title="{{$row.CommitMessage}}">
 												{{$row.CommitMessage}}
 											</a>
 										</div>
@@ -44,8 +44,8 @@
 							</td>
 							<td class="lines-blame-btn">
 							  {{if and (gt $.CommitCnt 1) ($row.PreviousSha)}}
-									<a href="{{$row.PreviousShaUrl}}" class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
-										{{svg "octicon-calendar"}}
+									<a href="{{$row.PreviousShaURL}}" class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
+										{{svg "octicon-versions"}}
 									</a>
 								{{end}}
 							</td>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -43,7 +43,7 @@
 								</div>
 							</td>
 							<td class="lines-blame-btn">
-							  {{if and (gt $.CommitCnt 1) ($row.PreviousSha)}}
+							  {{if $row.PreviousSha}}
 									<a href="{{$row.PreviousShaURL}}" class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
 										{{svg "octicon-versions"}}
 									</a>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -43,9 +43,11 @@
 								</div>
 							</td>
 							<td class="lines-blame-btn">
-							  <a class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
-								  {{svg "octicon-calendar"}}
-								</a>
+							  {{if $row.PreviousSha}}
+									<a href="{{$row.PreviousShaUrl}}" class="poping up" data-content='{{$.i18n.Tr "repo.blame_prior"}}' data-variation="tiny inverted">
+										{{svg "octicon-calendar"}}
+									</a>
+								{{end}}
 							</td>
 							<td class="lines-num">
 								<span id="L{{$row.RowNumber}}" data-line-number="{{$row.RowNumber}}"></span>
@@ -53,11 +55,6 @@
 							<td rel="L{{$row.RowNumber}}" rel="L{{$row.RowNumber}}" class="lines-code blame-code chroma">
 								<code class="code-inner pl-3">{{$row.Code}}</code>
 							</td>
-							{{/* <td class="lines-code">
-								<div class="L{{$row.RowNumber}} chroma" rel="L{{$row.RowNumber}}">
-									{{$row.Code}}
-								<div>
-							</td> */}}
 						</tr>
 					{{end}}
 				</tbody>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -2219,7 +2219,7 @@ function initCodeView() {
       const $select = $(this);
       let $list;
       if ($('div.blame').length) {
-        $list = $('.code-view td.lines-code li');
+        $list = $('.code-view td.lines-code.blame-code');
       } else {
         $list = $('.code-view td.lines-code');
       }
@@ -2227,14 +2227,17 @@ function initCodeView() {
       deSelect();
 
       // show code view menu marker
-      showCodeViewMenu();
+      // not show in blame page
+      if ($('div.blame').length === 0) {
+        showCodeViewMenu();
+      }
     });
 
     $(window).on('hashchange', () => {
       let m = window.location.hash.match(/^#(L\d+)-(L\d+)$/);
       let $list;
       if ($('div.blame').length) {
-        $list = $('.code-view td.lines-code li');
+        $list = $('.code-view td.lines-code.blame-code');
       } else {
         $list = $('.code-view td.lines-code');
       }
@@ -2244,7 +2247,10 @@ function initCodeView() {
         selectRange($list, $first, $list.filter(`[rel=${m[2]}]`));
 
         // show code view menu marker
-        showCodeViewMenu();
+        // not show in blame page
+        if ($('div.blame').length === 0) {
+          showCodeViewMenu();
+        }
 
         $('html, body').scrollTop($first.offset().top - 200);
         return;
@@ -2255,7 +2261,10 @@ function initCodeView() {
         selectRange($list, $first);
 
         // show code view menu marker
-        showCodeViewMenu();
+        // not show in blame page
+        if ($('div.blame').length === 0) {
+          showCodeViewMenu();
+        }
 
         $('html, body').scrollTop($first.offset().top - 200);
       }
@@ -2824,13 +2833,14 @@ function selectRange($list, $select, $from) {
 
       // add hashchange to permalink
       const $issue = $('a.ref-in-new-issue');
-      const matched = $issue.attr('href').match(/%23L\d+$|%23L\d+-L\d+$/);
-      if (matched) {
-        $issue.attr('href', $issue.attr('href').replace($issue.attr('href').substr(matched.index), `%23L${a}-L${b}`));
-      } else {
-        $issue.attr('href', `${$issue.attr('href')}%23L${a}-L${b}`);
+      if ($issue && $issue.attr('href')) {
+        const matched = $issue.attr('href').match(/%23L\d+$|%23L\d+-L\d+$/);
+        if (matched) {
+          $issue.attr('href', $issue.attr('href').replace($issue.attr('href').substr(matched.index), `%23L${a}-L${b}`));
+        } else {
+          $issue.attr('href', `${$issue.attr('href')}%23L${a}-L${b}`);
+        }
       }
-
       return;
     }
   }
@@ -2839,11 +2849,13 @@ function selectRange($list, $select, $from) {
 
   // add hashchange to permalink
   const $issue = $('a.ref-in-new-issue');
-  const matched = $issue.attr('href').match(/%23L\d+$|%23L\d+-L\d+$/);
-  if (matched) {
-    $issue.attr('href', $issue.attr('href').replace($issue.attr('href').substr(matched.index), `%23${$select.attr('rel')}`));
-  } else {
-    $issue.attr('href', `${$issue.attr('href')}%23${$select.attr('rel')}`);
+  if ($issue && $issue.attr('href')) {
+    const matched = $issue.attr('href').match(/%23L\d+$|%23L\d+-L\d+$/);
+    if (matched) {
+      $issue.attr('href', $issue.attr('href').replace($issue.attr('href').substr(matched.index), `%23${$select.attr('rel')}`));
+    } else {
+      $issue.attr('href', `${$issue.attr('href')}%23${$select.attr('rel')}`);
+    }
   }
 }
 

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1382,6 +1382,14 @@ a.ui.label:hover {
   margin-right: 0;
 }
 
+.lines-blame-btn {
+  padding-left: 10px;
+  padding-right: 10px;
+  text-align: right !important;
+  background-color: #f5f5f5;
+  width: 2%;
+}
+
 .lines-num {
   padding-left: 10px;
   padding-right: 10px;
@@ -1508,6 +1516,10 @@ a.ui.label:hover {
     height: 18px;
     width: 18px;
   }
+}
+
+.bottom-line-blame {
+  border-bottom: 1px solid var(--color-secondary);
 }
 
 .lines-code,


### PR DESCRIPTION
Feature: 

1. Fix bottom lines mismatched between commit info and code line  in view blame page.
2. Add previous blame links

 Related PR:
[](url)https://github.com/go-gitea/gitea/pull/15148

Feature request issue:
[](url)https://github.com/go-gitea/gitea/issues/15109

Hi, @noerw,  I noticed you created a PR for the request, perhaps this one could more helpful to what we ask for.

Performance:
![blame](https://user-images.githubusercontent.com/5260711/112640319-3028c800-8e7c-11eb-8ea1-b257a4044b88.gif)

