### PR TITLE
fix navbar for organisation dashboard

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -71,8 +71,8 @@
 						</div>
 					</div>
 				</div>
+			</div>
 		{{end}}
-	</div>
 
 	{{if .ContextUser.IsOrganization}}
 		<div class="right stackable menu">
@@ -101,5 +101,6 @@
 			</div>
 		</div>
 	{{end}}
+	</div>
 </div>
 <div class="ui divider"></div>


### PR DESCRIPTION
There is a missing and a misplaced `</div>` closing tag in the navbar.tmpl.

For the organisation dashboard, this resulted in the footer being displayed incorrectly (immediately after the content instead of at the bottom of the page):

![image](https://user-images.githubusercontent.com/2212615/112679661-b76e3f80-8e6c-11eb-948a-22d9bb85d229.png)

This should be backported to 1.14 as well.
