### PR TITLE
use level config in log section when sub log section not set level

### DIFF
--- a/modules/setting/log.go
+++ b/modules/setting/log.go
@@ -94,7 +94,7 @@ type defaultLogOptions struct {
 
 func newDefaultLogOptions() defaultLogOptions {
 	return defaultLogOptions{
-		levelName:      LogLevel,
+		levelName:      LogLevel.String(),
 		flags:          "stdflags",
 		filename:       filepath.Join(LogRootPath, "gitea.log"),
 		bufferLength:   10000,
@@ -115,9 +115,9 @@ type LogDescription struct {
 	SubLogDescriptions []SubLogDescription
 }
 
-func getLogLevel(section *ini.Section, key string, defaultValue string) string {
-	value := section.Key(key).MustString("info")
-	return log.FromString(value).String()
+func getLogLevel(section *ini.Section, key string, defaultValue log.Level) log.Level {
+	value := section.Key(key).MustString(defaultValue.String())
+	return log.FromString(value)
 }
 
 func getStacktraceLogLevel(section *ini.Section, key string, defaultValue string) string {
@@ -126,8 +126,7 @@ func getStacktraceLogLevel(section *ini.Section, key string, defaultValue string
 }
 
 func generateLogConfig(sec *ini.Section, name string, defaults defaultLogOptions) (mode, jsonConfig, levelName string) {
-	levelName = getLogLevel(sec, "LEVEL", LogLevel)
-	level := log.FromString(levelName)
+	level := getLogLevel(sec, "LEVEL", LogLevel)
 	stacktraceLevelName := getStacktraceLogLevel(sec, "STACKTRACE_LEVEL", StacktraceLogLevel)
 	stacktraceLevel := log.FromString(stacktraceLevelName)
 	mode = name

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -304,7 +304,7 @@ var (
 	}
 
 	// Log settings
-	LogLevel           string
+	LogLevel           log.Level
 	StacktraceLogLevel string
 	LogRootPath        string
 	DisableRouterLog   bool
@@ -553,7 +553,7 @@ func NewContext() {
 	}
 	homeDir = strings.ReplaceAll(homeDir, "\\", "/")
 
-	LogLevel = getLogLevel(Cfg.Section("log"), "LEVEL", "Info")
+	LogLevel = getLogLevel(Cfg.Section("log"), "LEVEL", log.INFO)
 	StacktraceLogLevel = getStacktraceLogLevel(Cfg.Section("log"), "STACKTRACE_LEVEL", "None")
 	LogRootPath = Cfg.Section("log").Key("ROOT_PATH").MustString(path.Join(AppWorkPath, "log"))
 	forcePathSeparator(LogRootPath)

--- a/routers/install.go
+++ b/routers/install.go
@@ -373,7 +373,7 @@ func InstallPost(ctx *context.Context) {
 	cfg.Section("session").Key("PROVIDER").SetValue("file")
 
 	cfg.Section("log").Key("MODE").SetValue("console")
-	cfg.Section("log").Key("LEVEL").SetValue(setting.LogLevel)
+	cfg.Section("log").Key("LEVEL").SetValue(setting.LogLevel.String())
 	cfg.Section("log").Key("ROOT_PATH").SetValue(form.LogRootPath)
 	cfg.Section("log").Key("ROUTER").SetValue("console")
 


### PR DESCRIPTION
in previouse if a log subsetcion not set level
it will use ``info`` as default value.

this pr will make default value (``[log] -> LEVEL``) useable.

example config:
```INI
[log]
MODE = console
LEVEL = Trace

[log.console]
LEVEL =
STDERR = false
```

## :warning: BREAKING :warning: 

Prior to this change sub loggers would use the default logger level of `INFO` if not set - they will now inherit from the main logger.

Administrators should check their log configuration.

## Screenshots

previous result:
![p1](https://user-images.githubusercontent.com/25342410/112709265-ca2b5780-8ef2-11eb-8f6f-9a70f5c5813a.png)


after:
![p2](https://user-images.githubusercontent.com/25342410/112709266-d0b9cf00-8ef2-11eb-8ae7-c631ec5f6d47.png)

fix #15170