### PR TITLE
Update repository size on cron gc task

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -740,15 +740,12 @@ func (repo *Repository) updateSize(e Engine) error {
 		return fmt.Errorf("updateSize: %v", err)
 	}
 
-	objs, err := repo.GetLFSMetaObjects(-1, 0)
+	lfsSize, err := e.Where("repository_id = ?", repo.ID).SumInt(new(LFSMetaObject), "size")
 	if err != nil {
 		return fmt.Errorf("updateSize: GetLFSMetaObjects: %v", err)
 	}
-	for _, obj := range objs {
-		size += obj.Size
-	}
 
-	repo.Size = size
+	repo.Size = size + lfsSize
 	_, err = e.ID(repo.ID).Cols("size").Update(repo)
 	return err
 }

--- a/modules/repository/check.go
+++ b/modules/repository/check.go
@@ -99,7 +99,7 @@ func GitGcRepos(ctx context.Context, timeout time.Duration, args ...string) erro
 				if err = models.CreateRepositoryNotice(desc); err != nil {
 					log.Error("CreateRepositoryNotice: %v", err)
 				}
-				return fmt.Errorf("Updating size as part of  garbage collection failed in repo: %s: Error: %v", repo.FullName(), err)
+				return fmt.Errorf("Updating size as part of garbage collection failed in repo: %s: Error: %v", repo.FullName(), err)
 			}
 
 			return nil

--- a/modules/repository/check.go
+++ b/modules/repository/check.go
@@ -95,7 +95,7 @@ func GitGcRepos(ctx context.Context, timeout time.Duration, args ...string) erro
 			// Now update the size of the repository
 			if err := repo.UpdateSize(models.DefaultDBContext()); err != nil {
 				log.Error("Updating size as part of garbage collection failed for %v. Stdout: %s\nError: %v", repo, stdout, err)
-				desc := fmt.Sprintf("Updating size as part of  garbage collection failed for %s. Stdout: %s\nError: %v", repo.RepoPath(), stdout, err)
+				desc := fmt.Sprintf("Updating size as part of garbage collection failed for %s. Stdout: %s\nError: %v", repo.RepoPath(), stdout, err)
 				if err = models.CreateRepositoryNotice(desc); err != nil {
 					log.Error("CreateRepositoryNotice: %v", err)
 				}

--- a/modules/repository/check.go
+++ b/modules/repository/check.go
@@ -91,6 +91,17 @@ func GitGcRepos(ctx context.Context, timeout time.Duration, args ...string) erro
 				}
 				return fmt.Errorf("Repository garbage collection failed in repo: %s: Error: %v", repo.FullName(), err)
 			}
+
+			// Now update the size of the repository
+			if err := repo.UpdateSize(models.DefaultDBContext()); err != nil {
+				log.Error("Updating size as part of garbage collection failed for %v. Stdout: %s\nError: %v", repo, stdout, err)
+				desc := fmt.Sprintf("Updating size as part of  garbage collection failed for %s. Stdout: %s\nError: %v", repo.RepoPath(), stdout, err)
+				if err = models.CreateRepositoryNotice(desc); err != nil {
+					log.Error("CreateRepositoryNotice: %v", err)
+				}
+				return fmt.Errorf("Updating size as part of  garbage collection failed in repo: %s: Error: %v", repo.FullName(), err)
+			}
+
 			return nil
 		},
 	); err != nil {


### PR DESCRIPTION
git gc cron could change the size of the repository therefore we should update the
size of the repo stored in our database.

Also significantly improve the efficiency of counting lfs associated with the
repository

Fix #14862

Signed-off-by: Andrew Thornton <art27@cantab.net>
