### PR TITLE
Improve /api/v1/repos/issues/search by just getting repo ids

### DIFF
--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -478,7 +478,7 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (RepositoryList, int64, err
 	return SearchRepository(opts)
 }
 
-// SearchRepositoryRepoIDs takes keyword and part of repository name to search,
+// SearchRepositoryIDs takes keyword and part of repository name to search,
 // it returns results in given range and number of total results.
 func SearchRepositoryIDs(opts *SearchRepoOptions) ([]int64, int64, error) {
 	opts.IncludeDescription = false

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -414,6 +414,7 @@ func searchRepositoryByCondition(opts *SearchRepoOptions, cond builder.Cond) (*x
 			Where(cond).
 			Count(new(Repository))
 		if err != nil {
+			_ = sess.Close()
 			return nil, 0, fmt.Errorf("Count: %v", err)
 		}
 	}

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -368,6 +368,7 @@ func SearchRepositoryByCondition(opts *SearchRepoOptions, cond builder.Cond, loa
 	if err != nil {
 		return nil, 0, err
 	}
+	defer sess.Close()
 
 	defaultSize := 50
 	if opts.PageSize > 0 {
@@ -405,7 +406,6 @@ func searchRepositoryByCondition(opts *SearchRepoOptions, cond builder.Cond) (*x
 	}
 
 	sess := x.NewSession()
-	defer sess.Close()
 
 	var count int64
 	if opts.PageSize > 0 {
@@ -489,6 +489,7 @@ func SearchRepositoryIDs(opts *SearchRepoOptions) ([]int64, int64, error) {
 	if err != nil {
 		return nil, 0, err
 	}
+	defer sess.Close()
 
 	defaultSize := 50
 	if opts.PageSize > 0 {


### PR DESCRIPTION
/api/v1/repos/issues/search is a highly inefficient search which is unfortunately
the basis for our dependency searching algorithm. In particular it currently loads
all of the repositories and their owners and their primary coding language all of
which is immediately thrown away.

This PR makes one simple change - just get the IDs.

Related #14560
Related #12827

Signed-off-by: Andrew Thornton <art27@cantab.net>
