### PR TITLE
Fix margin between avatars on org pages

### DIFF
--- a/web_src/less/_organization.less
+++ b/web_src/less/_organization.less
@@ -89,6 +89,7 @@
         width: 48px;
         height: 48px;
         margin-right: 5px;
+        margin-bottom: 5px;
       }
     }
   }


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/15191

Before:
<img width="354" alt="Screen Shot 2021-03-29 at 21 03 08" src="https://user-images.githubusercontent.com/115237/112886902-d40bb100-90d2-11eb-922a-2bbaeda7619f.png">

After:
<img width="351" alt="Screen Shot 2021-03-29 at 21 05 05" src="https://user-images.githubusercontent.com/115237/112886908-d5d57480-90d2-11eb-81d1-78a647351817.png">
