### PR TITLE
Fix margin between avatars on org pages (#15194)

### DIFF
--- a/web_src/less/_organization.less
+++ b/web_src/less/_organization.less
@@ -89,6 +89,7 @@
         width: 48px;
         height: 48px;
         margin-right: 5px;
+        margin-bottom: 5px;
       }
     }
   }


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/15194 to 1.14.