### PR TITLE
Fix webhook delivery and issue checklist for arc-green (#15195)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3022,8 +3022,8 @@ td.blob-excerpt {
 .webhook-info {
   padding: 7px 12px;
   margin: 10px 0;
-  background-color: #f8f8f8;
-  border: 1px solid #dddddd;
+  background-color: var(--color-markdown-code-block);
+  border: 1px solid var(--color-secondary);
   border-radius: 3px;
   font-size: 13px;
   line-height: 1.5;

--- a/web_src/less/shared/issuelist.less
+++ b/web_src/less/shared/issuelist.less
@@ -60,7 +60,7 @@
     }
 
     .desc {
-      color: #999999;
+      color: var(--color-text-light-2);
 
       a {
         color: inherit;
@@ -86,13 +86,13 @@
           width: 80px;
           height: 6px;
           display: inline-block;
-          background-color: #eeeeee;
+          background-color: var(--color-secondary);
           overflow: hidden;
           border-radius: 3px;
           vertical-align: 2px !important;
 
           .progress {
-            background-color: #cccccc;
+            background-color: var(--color-secondary-dark-3);
             display: block;
             height: 100%;
           }


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/15195 to 1.14.