### PR TITLE
Allow setting DB schema in docker

### DIFF
--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -39,6 +39,7 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
     DB_NAME=${DB_NAME:-"gitea"} \
     DB_USER=${DB_USER:-"root"} \
     DB_PASSWD=${DB_PASSWD:-""} \
+    DB_SCHEMA=${DB_SCHEMA:-""} \
     INSTALL_LOCK=${INSTALL_LOCK:-"false"} \
     DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-"false"} \
     REQUIRE_SIGNIN_VIEW=${REQUIRE_SIGNIN_VIEW:-"false"} \

--- a/docker/root/etc/templates/app.ini
+++ b/docker/root/etc/templates/app.ini
@@ -29,6 +29,7 @@ HOST    = $DB_HOST
 NAME    = $DB_NAME
 USER    = $DB_USER
 PASSWD  = $DB_PASSWD
+SCHEMA  = $DB_SCHEMA
 LOG_SQL = false
 
 [indexer]

--- a/docker/rootless/etc/templates/app.ini
+++ b/docker/rootless/etc/templates/app.ini
@@ -32,6 +32,7 @@ HOST    = $DB_HOST
 NAME    = $DB_NAME
 USER    = $DB_USER
 PASSWD  = $DB_PASSWD
+SCHEMA  = $DB_SCHEMA
 
 [session]
 PROVIDER_CONFIG = $GITEA_WORK_DIR/data/sessions

--- a/docker/rootless/usr/local/bin/docker-setup.sh
+++ b/docker/rootless/usr/local/bin/docker-setup.sh
@@ -40,6 +40,7 @@ if [ ! -f ${GITEA_APP_INI} ]; then
     DB_NAME=${DB_NAME:-"gitea"} \
     DB_USER=${DB_USER:-"root"} \
     DB_PASSWD=${DB_PASSWD:-""} \
+    DB_SCHEMA=${DB_SCHEMA:-""} \
     INSTALL_LOCK=${INSTALL_LOCK:-"false"} \
     DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-"false"} \
     REQUIRE_SIGNIN_VIEW=${REQUIRE_SIGNIN_VIEW:-"false"} \

--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -253,6 +253,7 @@ You can configure some of Gitea's settings via environment variables:
 * `DB_NAME`: **gitea**: Database name.
 * `DB_USER`: **root**: Database username.
 * `DB_PASSWD`: **"\<empty>"**: Database user password. Use \`your password\` for quoting if you use special characters in the password.
+* `DB_SCHEMA`: **"\<empty>"**: Database schema name for Postgres. If not set the public schema will be used.
 * `INSTALL_LOCK`: **false**: Disallow access to the install page.
 * `SECRET_KEY`: **""**: Global secret key. This should be changed. If this has a value and `INSTALL_LOCK` is empty, `INSTALL_LOCK` will automatically set to `true`.
 * `DISABLE_REGISTRATION`: **false**: Disable registration, after which only admin can create accounts for users.

--- a/docs/content/doc/installation/with-docker.zh-cn.md
+++ b/docs/content/doc/installation/with-docker.zh-cn.md
@@ -251,6 +251,7 @@ MySQL 或 PostgreSQL 容器将需要分别创建。
 - `DB_NAME`：**gitea**：数据库名称。
 - `DB_USER`：**root**：数据库用户名。
 - `DB_PASSWD`：**"\<empty>"** ：数据库用户密码。如果您在密码中使用特殊字符，请使用“您的密码”进行引用。
+- `DB_SCHEMA`：**"\<empty>"** ：
 - `INSTALL_LOCK`：**false**：禁止访问安装页面。
 - `SECRET_KEY`：**""** ：全局密钥。这应该更改。如果它具有一个值并且 `INSTALL_LOCK` 为空，则 `INSTALL_LOCK` 将自动设置为 `true`。
 - `DISABLE_REGISTRATION`：**false**：禁用注册，之后只有管理员才能为用户创建帐户。


### PR DESCRIPTION
This lets you use an env variable to set the schema name when using Postgres with the docker container. 
