### PR TITLE
Fix documentation for the fallback mail subject

### DIFF
--- a/docs/content/doc/advanced/mail-templates-us.md
+++ b/docs/content/doc/advanced/mail-templates-us.md
@@ -130,7 +130,7 @@ did not include a subject part), Gitea's **internal default** will be used.
 The internal default (fallback) subject is the equivalent of:
 
 ```sh
-{{.SubjectPrefix}}[{{.Repo}}] {{.Issue.Title}} (#.Issue.Index)
+{{.SubjectPrefix}}[{{.Repo}}] {{.Issue.Title}} (#{{.Issue.Index}})
 ```
 
 For example: `Re: [mike/stuff] New color palette (#38)`


### PR DESCRIPTION
The documentation for the [fallback mail subject](https://github.com/go-gitea/gitea/blob/d989247bb08d2b8eb144e7a0edeaedfc26d08175/services/mailer/mail_issue.go#L14-L16) was missing `{{}}` around `.Issue.Index`. This change adds the missing `{{}}`.
