### PR TITLE
Update docs for bad ini syntax in noreply

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -689,10 +689,12 @@ DEFAULT_ENABLE_TIMETRACKING = true
 ; Default value for AllowOnlyContributorsToTrackTime
 ; Only users with write permissions can track time if this is true
 DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME = true
-; Default value for the domain part of the user's email address in the git log
-; if he has set KeepEmailPrivate to true. The user's email will be replaced with a
-; concatenation of the user name in lower case, "@" and NO_REPLY_ADDRESS.
-NO_REPLY_ADDRESS = noreply.%(DOMAIN)s
+; Value for the domain part of the user's email address in the git log if user
+; has set KeepEmailPrivate to true. The user's email will be replaced with a
+; concatenation of the user name in lower case, "@" and NO_REPLY_ADDRESS. Default
+; value is "noreply." + DOMAIN, where DOMAIN resolves to the value from server.DOMAIN
+; Note: do not use the <DOMAIN> notation below
+NO_REPLY_ADDRESS = noreply.<DOMAIN>
 ; Show Registration button
 SHOW_REGISTRATION_BUTTON = true
 ; Show milestones dashboard page - a view of all the user's milestones

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -482,7 +482,7 @@ relation to port exhaustion.
 - `DEFAULT_ORG_VISIBILITY`: **public**: Set default visibility mode for organisations, either "public", "limited" or "private".
 - `DEFAULT_ORG_MEMBER_VISIBLE`: **false** True will make the membership of the users visible when added to the organisation.
 - `ALLOW_ONLY_EXTERNAL_REGISTRATION`: **false** Set to true to force registration only using third-party services.
-- `NO_REPLY_ADDRESS`: **DOMAIN** Default value for the domain part of the user's email address in the git log if he has set KeepEmailPrivate to true.
+- `NO_REPLY_ADDRESS`: **noreply.DOMAIN** Value for the domain part of the user's email address in the git log if user has set KeepEmailPrivate to true. DOMAIN resolves to the value in server.DOMAIN.
   The user's email will be replaced with a concatenation of the user name in lower case, "@" and NO_REPLY_ADDRESS.
 - `USER_DELETE_WITH_COMMENTS_MAX_TIME`: **0** Minimum amount of time a user must exist before comments are kept when the user is deleted.
 


### PR DESCRIPTION
Small nit, but the example used in `app.example.ini` for `NO_REPLY_ADDRESS` will cause gitea to error with:
```
models/avatar.go:72:LibravatarURL() [E] LibravatarService.FromEmail(email=user@noreply.%(domain)s): error mail: expected single address, got "s"
```
Ini only supports [recursive values](https://ini.unknwon.io/docs/howto/work_with_values#recursive-values) in `For all value of keys, there is a special syntax %(<name>)s, where <name> is the key name in same section or default section` 

Note: I've added an [upstream feature request](https://github.com/go-ini/ini/issues/286) to allow ini to reference values from other sections.