### PR TITLE
Synthesize .npmrc from Makefile; Fix bsdtar on older Debian/Ubuntu/macOS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -495,7 +495,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.16.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt -y install nodejs bsdtar\|libarchive-tools
+      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
@@ -591,7 +591,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.16.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs bsdtar\|libarchive-tools
+      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ coverage.all
 /integrations/mysql8.ini
 /integrations/pgsql.ini
 /integrations/mssql.ini
+
+# Frontend
+.npmrc
 /node_modules
 /yarn.lock
 /public/js

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,8 @@ coverage.all
 
 # Frontend
 .npmrc
-/node_modules
+.npm-cache
+node_modules
 /yarn.lock
 /public/js
 /public/serviceworker.js
@@ -84,6 +85,7 @@ coverage.all
 /public/fonts
 /public/img/webpack
 /web_src/fomantic/node_modules
+/web_src/fomantic/package-lock.json
 /web_src/fomantic/semantic.json
 /web_src/fomantic/build/*
 !/web_src/fomantic/build/semantic.js
@@ -98,7 +100,6 @@ coverage.all
 !/web_src/fomantic/build/themes/default/assets/fonts/outline-icons.woff2
 /VERSION
 /.air
-/.npm-cache
 
 # Snapcraft
 snap/.snapcraft/

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-audit=false
-fund=false
-package-lock=true
-save-exact=true
-cache=.npm-cache

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ else
 
 # This is the "normal" part of the Makefile
 
-TAR := $(shell hash bsdtar > /dev/null 2>&1 && echo "bsdtar --no-xattrs" || echo "tar" )
+TAR := $(shell hash bsdtar > /dev/null 2>&1 && echo "bsdtar" || echo "tar" )
+ifneq ($(shell $(TAR) --version | grep "bsdtar 3"),)
+	TAR += --format=gnutar
+endif
 
 DIST := dist
 DIST_DIRS := $(DIST)/binaries $(DIST)/release

--- a/web_src/fomantic/.npmrc
+++ b/web_src/fomantic/.npmrc
@@ -1,3 +1,0 @@
-optional=false
-package-lock=false
-cache=../../.npm-cache

--- a/web_src/fomantic/package.json
+++ b/web_src/fomantic/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "fomantic-ui": "^2.8.7"
+  }
+}


### PR DESCRIPTION
Summary on `bsdtar`:
- Arch/Fedora and derivatives use latest `bsdtar` (3.3.x+) and, when SELinux is enabled (by default on Fedora), requires `--no-xattrs` or a `--format` flag with similar effect
- Debian and derivatives use an older `bsdtar` (3.1.x/3.2.x) until recently (Debian 10/Ubuntu 20.04), which does not support `--no-xattrs`, but supports `--format=gnutar` which is largely the same:
  - GNU Tar is based on a draft version of PAX, which is what is used by `bsdtar`/libarchive by default, but uses a different style for storing extended attributes (disabled by default for compatibility)
  - using the `gnutar` writer of libarchive will ignore them
  - GNU Tar reads both GNU and PAX formats (sans extended attributes for the latter) just fine, so there are no compatibility issues
- macOS < 10.15 uses an ancient `bsdtar` from 2010 (2.8.3) which by default doesn't store extended attributes at all (unless `--format=pax` is passed), so no flag is needed at all
  - macOS 10.15+, on the other hand, uses `bsdtar` 3.3.x+, which is functionally equivalent to Linux distros shipping this version and thus handled as case 1

Note that `bsdtar` is achieving better compression (among other benefits) even with `--format=gnutar` enabled
![Bildschirmfoto von 2021-04-02 22-37-20](https://user-images.githubusercontent.com/1714243/113453256-e4d76200-9405-11eb-8803-bd368229f3cc.png)

Summary on changes to `Makefile`:
- `.npmrc` is now synthesized right before initial `npm install` (but will be included in the tarball), so edits of npm configs should now take place in `Makefile` (these files are added to .gitignore)
  - this is a better solution, by far, than a pre-commit hook (aborting commit and displaying a warning message if `.npm-cache` is present), or `git update-index --skip-worktree` (decoupling the file from working tree if it has uncommitted changes, breaking all kinds of stuff)
- `printf` is leveraged instead of `tr` to avoid expansion partially, reducing console output

Fix: #15251

Edit: Refer to comment for details on the merged fix: https://github.com/CL-Jeremy/gitea/pull/7#issue-608320291

Edit 2: Reference regarding TAR/libarchive features and effectiveness of `--format=gnutar` option: https://github.com/libarchive/libarchive/issues/242 http://cdrtools.sourceforge.net/private/portability-of-tar-features.html