### PR TITLE
Resolve Object { type: "error", data: undefined } in stopwatch.js

### DIFF
--- a/web_src/js/features/stopwatch.js
+++ b/web_src/js/features/stopwatch.js
@@ -9,6 +9,11 @@ export async function initStopwatch() {
   }
 
   const stopwatchEl = $('.active-stopwatch-trigger');
+
+  if (!stopwatchEl.length) {
+    return;
+  }
+
   stopwatchEl.removeAttr('href'); // intended for noscript mode only
   stopwatchEl.popup({
     position: 'bottom right',
@@ -19,10 +24,6 @@ export async function initStopwatch() {
   $('form > button', stopwatchEl).on('click', function () {
     $(this).parent().trigger('submit');
   });
-
-  if (!stopwatchEl) {
-    return;
-  }
 
   if (NotificationSettings.EventSourceUpdateTime > 0 && !!window.EventSource && window.SharedWorker) {
     // Try to connect to the event source via the shared worker first


### PR DESCRIPTION
type of `stopwatchEl` is `JQuery<HTMLElement>` returned by `$('.active-stopwatch-trigger')`. 

Resolves spamming of
```
Object { type: "error", data: undefined }
stopwatch.js:48:16
```
when the stopwatch doesn't exist (such as when a user is not logged in).

![image](https://user-images.githubusercontent.com/12700993/113518776-94671e00-9545-11eb-9e17-3a05b377a437.png)