### PR TITLE
Drop the event source if we are unauthorized (#15275)

### DIFF
--- a/routers/events/events.go
+++ b/routers/events/events.go
@@ -33,8 +33,8 @@ func Events(ctx *context.Context) {
 	if !ctx.IsSigned {
 		// Return unauthorized status event
 		event := (&eventsource.Event{
-			Name: "unauthorized",
-			Data: "sorry",
+			Name: "close",
+			Data: "unauthorized",
 		})
 		_, _ = event.WriteTo(ctx)
 		ctx.Resp.Flush()

--- a/web_src/js/features/eventsource.sharedworker.js
+++ b/web_src/js/features/eventsource.sharedworker.js
@@ -10,6 +10,7 @@ class Source {
     this.listening = {};
     this.clients = [];
     this.listen('open');
+    this.listen('close');
     this.listen('logout');
     this.listen('notification-count');
     this.listen('stopwatches');

--- a/web_src/js/features/notification.js
+++ b/web_src/js/features/notification.js
@@ -74,6 +74,11 @@ export async function initNotificationCount() {
         });
         worker.port.close();
         window.location.href = AppSubUrl;
+      } else if (event.data.type === 'close') {
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
       }
     });
     worker.port.addEventListener('error', (e) => {

--- a/web_src/js/features/stopwatch.js
+++ b/web_src/js/features/stopwatch.js
@@ -55,6 +55,11 @@ export async function initStopwatch() {
         });
         worker.port.close();
         window.location.href = AppSubUrl;
+      } else if (event.data.type === 'close') {
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
       }
     });
     worker.port.addEventListener('error', (e) => {


### PR DESCRIPTION
Backport #15275

A previous commit that sent unauthorized if the user is unauthorized
simply leads to the repeated reopening of the eventsource. #

This PR changes the event returned to tell the client to close the
eventsource and thus prevents the repeated reopening.

Signed-off-by: Andrew Thornton <art27@cantab.net>
