### PR TITLE
Fix typo in app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -555,7 +555,7 @@ REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
 REVERSE_PROXY_AUTHENTICATION_EMAIL = X-WEBAUTH-EMAIL
 ; Interpret X-Forwarded-For header or the X-Real-IP header and set this as the remote IP for the request
 REVERSE_PROXY_LIMIT = 1
-; List of IP addresses and networks seperated by comma of trusted proxy servers. Use `*` to trust all.
+; List of IP addresses and networks separated by comma of trusted proxy servers. Use `*` to trust all.
 REVERSE_PROXY_TRUSTED_PROXIES = 127.0.0.0/8,::1/128
 ; The minimum password length for new Users
 MIN_PASSWORD_LENGTH = 6


### PR DESCRIPTION
seperated -> separated
