### PR TITLE
Dropzone styling improvements

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -999,6 +999,9 @@ async function initRepository() {
             dictFileTooBig: $dropzone.data('file-too-big'),
             dictRemoveFile: $dropzone.data('remove-file'),
             timeout: 0,
+            thumbnailMethod: 'contain',
+            thumbnailWidth: 480,
+            thumbnailHeight: 480,
             init() {
               this.on('success', (file, data) => {
                 filenameDict[file.name] = {
@@ -2624,6 +2627,9 @@ $(document).ready(async () => {
       dictFileTooBig: $dropzone.data('file-too-big'),
       dictRemoveFile: $dropzone.data('remove-file'),
       timeout: 0,
+      thumbnailMethod: 'contain',
+      thumbnailWidth: 480,
+      thumbnailHeight: 480,
       init() {
         this.on('success', (file, data) => {
           filenameDict[file.name] = data.uuid;

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1021,11 +1021,6 @@
             color: var(--color-text-light-2);
             font-style: italic;
           }
-
-          .dropzone-attachments .thumbnails .ui.image {
-            max-height: 150px;
-          }
-
         }
 
         .ui.form {
@@ -2481,29 +2476,6 @@
 
 .page.buttons {
   padding-top: 15px;
-}
-
-.ui.form {
-  .dropzone {
-    border: 2px dashed var(--color-secondary);
-    background: none;
-    box-shadow: none !important;
-    padding: 0;
-    min-height: 5rem;
-    border-radius: 4px;
-
-    .dz-button {
-      color: rgba(0, 0, 0, .6);
-    }
-
-    &:hover .dz-button {
-      color: rgba(0, 0, 0, .8);
-    }
-
-    .dz-error-message {
-      top: 140px;
-    }
-  }
 }
 
 .settings {

--- a/web_src/less/features/dropzone.less
+++ b/web_src/less/features/dropzone.less
@@ -1,0 +1,45 @@
+.dropzone {
+  border: 2px dashed var(--color-secondary) !important;
+  background: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  min-height: 5rem !important;
+  border-radius: 4px !important;
+}
+
+.dropzone .dz-button {
+  color: var(--color-text-light) !important;
+}
+
+.dropzone:hover .dz-button {
+  color: var(--color-text) !important;
+}
+
+.dropzone .dz-error-message {
+  top: 120px !important;
+}
+
+.dropzone .dz-image {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border-radius: 0 !important;
+}
+
+.dropzone .dz-image img {
+  max-width: 100% !important;
+  max-height: 100% !important;
+  object-fit: contain !important;
+}
+
+.dropzone .dz-preview.dz-image-preview,
+.dropzone-attachments .thumbnails img {
+  background: transparent !important;
+}
+
+.dropzone-attachments .thumbnails img {
+  height: 120px !important;
+  width: 120px !important;
+  object-fit: contain !important;
+  margin-bottom: 0 !important;
+}

--- a/web_src/less/features/dropzone.less
+++ b/web_src/less/features/dropzone.less
@@ -43,3 +43,7 @@
   object-fit: contain !important;
   margin-bottom: 0 !important;
 }
+
+.dropzone .dz-preview:hover .dz-image img {
+  filter: opacity(.5) !important;
+}

--- a/web_src/less/index.less
+++ b/web_src/less/index.less
@@ -2,8 +2,9 @@
 
 @import "./variables.less";
 @import "./shared/issuelist.less";
-@import "./features/gitgraph.less";
 @import "./features/animations.less";
+@import "./features/dropzone.less";
+@import "./features/gitgraph.less";
 @import "./features/heatmap.less";
 @import "./features/imagediff.less";
 @import "./features/codeeditor.less";

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -426,14 +426,6 @@ td.blob-hunk {
   box-shadow: 0 0 0 1px rgba(121, 71, 66, .5) inset, 0 0 0 0 transparent;
 }
 
-.ui.form .dropzone .dz-button {
-  color: rgba(158, 158, 158, .8);
-}
-
-.ui.form .dropzone:hover .dz-button {
-  color: rgba(158, 158, 158, 1);
-}
-
 .ui.list .list > .item .header,
 .ui.list > .item .header {
   color: #dedede;


### PR DESCRIPTION
- Move all dropzone styles to separate file
- Fix white background in arc-green
- Fix rendering of non-square images and previews

Before:
<img width="348" alt="Screen Shot 2021-04-05 at 15 28 16" src="https://user-images.githubusercontent.com/115237/113579065-0f066b00-9624-11eb-9ead-836d626ea1af.png">

After:
<img width="334" alt="Screen Shot 2021-04-05 at 15 29 25" src="https://user-images.githubusercontent.com/115237/113579082-162d7900-9624-11eb-9820-47333ab2034b.png">
