### PR TITLE
Add SSH_DISPLAY_USER configuration

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -915,6 +915,10 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 		sshUser = setting.SSH.BuiltinServerUser
 	}
 
+	if setting.SSH.DisplayUser != "" {
+		sshUser = setting.SSH.DisplayUser
+	}
+
 	cl := new(CloneLink)
 
 	// if we have a ipv6 literal we need to put brackets around it

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -147,6 +147,7 @@ var (
 		TrustedUserCAKeys              []string          `ini:"SSH_TRUSTED_USER_CA_KEYS"`
 		TrustedUserCAKeysFile          string            `ini:"SSH_TRUSTED_USER_CA_KEYS_FILENAME"`
 		TrustedUserCAKeysParsed        []gossh.PublicKey `ini:"-"`
+		DisplayUser                    string            `ini:"SSH_DISPLAY_USER"`
 	}{
 		Disabled:            false,
 		StartBuiltinServer:  false,


### PR DESCRIPTION
This adds a `SSH_DISPLAY_USER` configuration parameter in order to change what's displayed in clone URL.

You might wonder about the use case:
I'm running gitea in a docker container and have configured [SSH Container Passthrough](https://docs.gitea.io/en-us/install-with-docker/#ssh-container-passthrough). However the host ssh user is "gitea" and not "git" (as used in the container). Everything works fine but I was unable to customize the ssh clone URL shown in the web ui.

![image](https://user-images.githubusercontent.com/10254103/113895433-43fff280-97c9-11eb-91a4-1fd270eae5ff.png)
