### PR TITLE
Show diff on rename with diff changes (#15338)

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -57,14 +57,12 @@
 				<div class="diff-file-box diff-box file-content">
 					<h4 class="ui top attached normal header rounded">
 						<div class="diff-counter count ui left">
-							{{if not $file.IsRenamed}}
-								<span class="add" data-line="{{.Addition}}">+ {{.Addition}}</span>
-								<span class="bar">
-									<div class="pull-left add"></div>
-									<div class="pull-left del"></div>
-								</span>
-								<span class="del" data-line="{{.Deletion}}">- {{.Deletion}}</span>
-							{{end}}
+							<span class="add" data-line="{{.Addition}}">+ {{.Addition}}</span>
+							<span class="bar">
+								<div class="pull-left add"></div>
+								<div class="pull-left del"></div>
+							</span>
+							<span class="del" data-line="{{.Deletion}}">- {{.Deletion}}</span>
 						</div>
 						<span class="file">{{$file.Name}}</span>
 						<div>{{$.i18n.Tr "repo.diff.file_suppressed"}}</div>
@@ -97,7 +95,7 @@
 						<div class="diff-counter count">
 							{{if $file.IsBin}}
 								{{$.i18n.Tr "repo.diff.bin"}}
-							{{else if not $file.IsRenamed}}
+							{{else}}
 								<span class="add" data-line="{{.Addition}}">+ {{.Addition}}</span>
 								<span class="bar">
 									<div class="pull-left add"></div>
@@ -119,138 +117,136 @@
 						{{end}}
 					</h4>
 					<div class="diff-file-body ui attached unstackable table segment">
-						{{if ne $file.Type 4}}
-							<div class="file-body file-code has-context-menu code-diff {{if $.IsSplitStyle}}code-diff-split{{else}}code-diff-unified{{end}}">
-								<table class="chroma">
-									<tbody>
-										{{if $isImage}}
-											{{template "repo/diff/image_diff" dict "file" . "root" $}}
-										{{else}}
-											{{if $.IsSplitStyle}}
-												{{range $j, $section := $file.Sections}}
-													{{range $k, $line := $section.Lines}}
-														<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
-															{{if eq .GetType 4}}
-																<td class="lines-num lines-num-old">
-																	{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold-down"}}
-																		</a>
-																	{{end}}
-																	{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold-up"}}
-																		</a>
-																	{{end}}
-																	{{if eq $line.GetExpandDirection 2}}
-																		<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-																			{{svg "octicon-fold"}}
-																		</a>
-																	{{end}}
-																</td>
-																<td colspan="5" class="lines-code lines-code-old "><span class="mono wrap">{{$section.GetComputedInlineDiffFor $line}}</span></td>
-															{{else}}
-																<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
-																<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-old halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui green button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
-																<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
-																<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-																<td class="lines-code lines-code-new halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui green button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
-															{{end}}
-														</tr>
-														{{if gt (len $line.Comments) 0}}
-															{{$resolved := (index $line.Comments 0).IsResolved}}
-															{{$resolveDoer := (index $line.Comments 0).ResolveDoer}}
-															{{$isNotPending := (not (eq (index $line.Comments 0).Review.Type 0))}}
-															<tr class="add-code-comment">
-																<td class="lines-num"></td>
-																<td class="lines-type-marker"></td>
-																<td class="add-comment-left">
-																	<div class="conversation-holder">
-																		{{if and $resolved  (eq $line.GetCommentSide "previous")}}
-																			<div class="ui top attached header">
-																				<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
-																				<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
-																					{{svg "octicon-unfold"}}
-																					{{$.i18n.Tr "repo.issues.review.show_resolved"}}
-																				</button>
-																				<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-																					{{svg "octicon-fold"}}
-																					{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
-																				</button>
-																			</div>
-																		{{end}}
-																		{{if eq $line.GetCommentSide "previous"}}
-																			<div id="code-comments-{{(index  $line.Comments 0).ID}}" class="field comment-code-cloud {{if $resolved}}hide{{end}}">
-																				<div class="comment-list">
-																					<ui class="ui comments">
-																					{{ template "repo/diff/comments" dict "root" $ "comments" $line.Comments}}
-																					</ui>
-																				</div>
-																			{{template "repo/diff/comment_form_datahandler" dict "reply" (index $line.Comments 0).ReviewID "hidden" true "root" $ "comment" (index $line.Comments 0)}}
-																				{{if and $.CanMarkConversation $isNotPending}}
-																					<button class="ui icon tiny button resolve-conversation" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index $line.Comments 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation" >
-																						{{if $resolved}}
-																							{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
-																						{{else}}
-																							{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
-																						{{end}}
-																					</button>
-																				{{end}}
-																			</div>
-																		{{end}}
-																	</div>
-																</td>
-																<td class="lines-num"></td>
-																<td class="lines-type-marker"></td>
-																<td class="add-comment-right">
-																	<div class="conversation-holder">
-																		{{if and $resolved (eq $line.GetCommentSide "proposed")}}
-																			<div class="ui top attached header">
-																				<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
-																				<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
-																					{{svg "octicon-unfold"}}
-																					{{$.i18n.Tr "repo.issues.review.show_resolved"}}
-																				</button>
-																				<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
-																					{{svg "octicon-fold"}}
-																					{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
-																				</button>
-																			</div>
-																		{{end}}
-																		{{if eq $line.GetCommentSide "proposed"}}
-																			<div id="code-comments-{{(index  $line.Comments 0).ID}}" class="field comment-code-cloud {{if $resolved}}hide{{end}}">
-																				<div class="comment-list">
-																					<ui class="ui comments">
-																					{{ template "repo/diff/comments" dict "root" $ "comments" $line.Comments}}
-																					</ui>
-																				</div>
-																				{{template "repo/diff/comment_form_datahandler" dict "reply" (index $line.Comments 0).ReviewID "hidden" true "root" $ "comment" (index $line.Comments 0)}}
-																				{{if and $.CanMarkConversation $isNotPending}}
-																					<button class="ui icon tiny button resolve-conversation" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index $line.Comments 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation" >
-																						{{if $resolved}}
-																							{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
-																						{{else}}
-																							{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
-																						{{end}}
-																					</button>
-																				{{end}}
-																			</div>
-																		{{end}}
-																	</div>
-																</td>
-															</tr>
+						<div class="file-body file-code has-context-menu code-diff {{if $.IsSplitStyle}}code-diff-split{{else}}code-diff-unified{{end}}">
+							<table class="chroma">
+								<tbody>
+									{{if $isImage}}
+										{{template "repo/diff/image_diff" dict "file" . "root" $}}
+									{{else}}
+										{{if $.IsSplitStyle}}
+											{{range $j, $section := $file.Sections}}
+												{{range $k, $line := $section.Lines}}
+													<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
+														{{if eq .GetType 4}}
+															<td class="lines-num lines-num-old">
+																{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
+																	<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+																		{{svg "octicon-fold-down"}}
+																	</a>
+																{{end}}
+																{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
+																	<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+																		{{svg "octicon-fold-up"}}
+																	</a>
+																{{end}}
+																{{if eq $line.GetExpandDirection 2}}
+																	<a role="button" class="blob-excerpt" data-url="{{$.RepoLink}}/blob_excerpt/{{$.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+																		{{svg "octicon-fold"}}
+																	</a>
+																{{end}}
+															</td>
+															<td colspan="5" class="lines-code lines-code-old "><span class="mono wrap">{{$section.GetComputedInlineDiffFor $line}}</span></td>
+														{{else}}
+															<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
+															<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+															<td class="lines-code lines-code-old halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui green button add-code-comment add-code-comment-left" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
+															<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
+															<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+															<td class="lines-code lines-code-new halfwidth">{{if and $.SignedUserID $line.CanComment $.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui green button add-code-comment add-code-comment-right" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}" data-type-marker="+"></a>{{end}}<span class="mono wrap">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</span></td>
 														{{end}}
+													</tr>
+													{{if gt (len $line.Comments) 0}}
+														{{$resolved := (index $line.Comments 0).IsResolved}}
+														{{$resolveDoer := (index $line.Comments 0).ResolveDoer}}
+														{{$isNotPending := (not (eq (index $line.Comments 0).Review.Type 0))}}
+														<tr class="add-code-comment">
+															<td class="lines-num"></td>
+															<td class="lines-type-marker"></td>
+															<td class="add-comment-left">
+																<div class="conversation-holder">
+																	{{if and $resolved  (eq $line.GetCommentSide "previous")}}
+																		<div class="ui top attached header">
+																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
+																			<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
+																				{{svg "octicon-unfold"}}
+																				{{$.i18n.Tr "repo.issues.review.show_resolved"}}
+																			</button>
+																			<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
+																				{{svg "octicon-fold"}}
+																				{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
+																			</button>
+																		</div>
+																	{{end}}
+																	{{if eq $line.GetCommentSide "previous"}}
+																		<div id="code-comments-{{(index  $line.Comments 0).ID}}" class="field comment-code-cloud {{if $resolved}}hide{{end}}">
+																			<div class="comment-list">
+																				<ui class="ui comments">
+																				{{ template "repo/diff/comments" dict "root" $ "comments" $line.Comments}}
+																				</ui>
+																			</div>
+																		{{template "repo/diff/comment_form_datahandler" dict "reply" (index $line.Comments 0).ReviewID "hidden" true "root" $ "comment" (index $line.Comments 0)}}
+																			{{if and $.CanMarkConversation $isNotPending}}
+																				<button class="ui icon tiny button resolve-conversation" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index $line.Comments 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation" >
+																					{{if $resolved}}
+																						{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
+																					{{else}}
+																						{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
+																					{{end}}
+																				</button>
+																			{{end}}
+																		</div>
+																	{{end}}
+																</div>
+															</td>
+															<td class="lines-num"></td>
+															<td class="lines-type-marker"></td>
+															<td class="add-comment-right">
+																<div class="conversation-holder">
+																	{{if and $resolved (eq $line.GetCommentSide "proposed")}}
+																		<div class="ui top attached header">
+																			<span class="ui grey text left"><b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}</span>
+																			<button id="show-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="ui compact right labeled button show-outdated">
+																				{{svg "octicon-unfold"}}
+																				{{$.i18n.Tr "repo.issues.review.show_resolved"}}
+																			</button>
+																			<button id="hide-outdated-{{(index $line.Comments 0).ID}}" data-comment="{{(index $line.Comments 0).ID}}" class="hide ui compact right labeled button hide-outdated">
+																				{{svg "octicon-fold"}}
+																				{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
+																			</button>
+																		</div>
+																	{{end}}
+																	{{if eq $line.GetCommentSide "proposed"}}
+																		<div id="code-comments-{{(index  $line.Comments 0).ID}}" class="field comment-code-cloud {{if $resolved}}hide{{end}}">
+																			<div class="comment-list">
+																				<ui class="ui comments">
+																				{{ template "repo/diff/comments" dict "root" $ "comments" $line.Comments}}
+																				</ui>
+																			</div>
+																			{{template "repo/diff/comment_form_datahandler" dict "reply" (index $line.Comments 0).ReviewID "hidden" true "root" $ "comment" (index $line.Comments 0)}}
+																			{{if and $.CanMarkConversation $isNotPending}}
+																				<button class="ui icon tiny button resolve-conversation" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index $line.Comments 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation" >
+																					{{if $resolved}}
+																						{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
+																					{{else}}
+																						{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
+																					{{end}}
+																				</button>
+																			{{end}}
+																		</div>
+																	{{end}}
+																</div>
+															</td>
+														</tr>
 													{{end}}
 												{{end}}
-											{{else}}
-												{{template "repo/diff/section_unified" dict "file" . "root" $}}
 											{{end}}
+										{{else}}
+											{{template "repo/diff/section_unified" dict "file" . "root" $}}
 										{{end}}
-									</tbody>
-								</table>
-							</div>
-						{{end}}
+									{{end}}
+								</tbody>
+							</table>
+						</div>
 					</div>
 				</div>
 			{{end}}


### PR DESCRIPTION
Backport #15338

More recent versions of git have increased support for detection of renames meaning
that a rename with diff changes is now supported.

Although ParsePatch supports this - our templates do not and the simplest solution
is simply to show the diff.

Fix #15335

Signed-off-by: Andrew Thornton <art27@cantab.net>
