### PR TITLE
Disable cssnano's colormin plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,7 @@ export default {
               discardComments: {
                 removeAll: true,
               },
+              colormin: false,
             },
           ],
         },


### PR DESCRIPTION
It produces odd rgba values which also seem to cause issues in monaco's color parser where the scoll shadow went red for some reason.

Ref: https://github.com/cssnano/cssnano/issues/1042
Regressed By: https://github.com/go-gitea/gitea/pull/15333

Before:
<img width="1153" alt="Screen Shot 2021-04-08 at 19 07 23" src="https://user-images.githubusercontent.com/115237/114068155-e38eb500-989d-11eb-9995-1dc41048a678.png">

After:
<img width="1144" alt="Screen Shot 2021-04-08 at 19 07 30" src="https://user-images.githubusercontent.com/115237/114068158-e4bfe200-989d-11eb-9d03-28b6e16a3c18.png">
