### PR TITLE
Move FCGI req.URL.Path fix-up to the FCGI listener (#15292)

### DIFF
--- a/routers/routes/web.go
+++ b/routers/routes/web.go
@@ -168,15 +168,6 @@ func WebRoutes() *web.Route {
 		r.Use(h)
 	}
 
-	if (setting.Protocol == setting.FCGI || setting.Protocol == setting.FCGIUnix) && setting.AppSubURL != "" {
-		r.Use(func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-				req.URL.Path = strings.TrimPrefix(req.URL.Path, setting.AppSubURL)
-				next.ServeHTTP(resp, req)
-			})
-		})
-	}
-
 	mailer.InitMailRender(templates.Mailer())
 
 	if setting.Service.EnableCaptcha {


### PR DESCRIPTION
Backport #15292

Simplify the web.go FCGI path by moving the req.URL.Path fix-up to listener. This makes FCGI work on SubURLs following the Chi migration.

Signed-off-by: Andrew Thornton <art27@cantab.net>
