### PR TITLE
Fix mirror_lfs source string in en-US locale

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -726,7 +726,7 @@ mirror_address = Clone From URL
 mirror_address_desc = Put any required credentials in the Clone Authorization section.
 mirror_address_url_invalid = The provided url is invalid. You must escape all components of the url correctly.
 mirror_address_protocol_invalid = The provided url is invalid. Only http(s):// or git:// locations can be mirrored from.
-mirror_lfs = Large File System (LFS)
+mirror_lfs = Large File Storage (LFS)
 mirror_lfs_desc = Activate mirroring of LFS data.
 mirror_lfs_endpoint = LFS Endpoint
 mirror_lfs_endpoint_desc = Sync will attempt to use the clone url to <a target="_blank" rel="noopener noreferrer" href="%s">determine the LFS server</a>. You can also specify a custom endpoint if the repository LFS data is stored somewhere else.


### PR DESCRIPTION
The mirror_lfs source string was set to "Large File System" instead of "Large File Storage"

This pull request aim at fixing it 