### PR TITLE
Fix delete nonexist oauth application 500 and prevent deadlock

### DIFF
--- a/integrations/api_oauth2_apps_test.go
+++ b/integrations/api_oauth2_apps_test.go
@@ -93,6 +93,7 @@ func testAPIDeleteOAuth2Application(t *testing.T) {
 
 	models.AssertNotExistsBean(t, &models.OAuth2Application{UID: oldApp.UID, Name: oldApp.Name})
 
+	req = NewRequest(t, "DELETE", urlStr)
 	// Delete again will return not found
 	session.MakeRequest(t, req, http.StatusNotFound)
 }

--- a/integrations/api_oauth2_apps_test.go
+++ b/integrations/api_oauth2_apps_test.go
@@ -92,6 +92,9 @@ func testAPIDeleteOAuth2Application(t *testing.T) {
 	session.MakeRequest(t, req, http.StatusNoContent)
 
 	models.AssertNotExistsBean(t, &models.OAuth2Application{UID: oldApp.UID, Name: oldApp.Name})
+
+	// Delete again will return not found
+	session.MakeRequest(t, req, http.StatusNotFound)
 }
 
 func testAPIGetOAuth2Application(t *testing.T) {

--- a/integrations/api_oauth2_apps_test.go
+++ b/integrations/api_oauth2_apps_test.go
@@ -93,7 +93,6 @@ func testAPIDeleteOAuth2Application(t *testing.T) {
 
 	models.AssertNotExistsBean(t, &models.OAuth2Application{UID: oldApp.UID, Name: oldApp.Name})
 
-	req = NewRequest(t, "DELETE", urlStr)
 	// Delete again will return not found
 	session.MakeRequest(t, req, http.StatusNotFound)
 }

--- a/integrations/api_oauth2_apps_test.go
+++ b/integrations/api_oauth2_apps_test.go
@@ -94,6 +94,7 @@ func testAPIDeleteOAuth2Application(t *testing.T) {
 	models.AssertNotExistsBean(t, &models.OAuth2Application{UID: oldApp.UID, Name: oldApp.Name})
 
 	// Delete again will return not found
+	req = NewRequest(t, "DELETE", urlStr)
 	session.MakeRequest(t, req, http.StatusNotFound)
 }
 

--- a/models/migrate.go
+++ b/models/migrate.go
@@ -39,6 +39,7 @@ func InsertMilestones(ms ...*Milestone) (err error) {
 // InsertIssues insert issues to database
 func InsertIssues(issues ...*Issue) error {
 	sess := x.NewSession()
+	defer sess.Close()
 	if err := sess.Begin(); err != nil {
 		return err
 	}
@@ -194,6 +195,7 @@ func InsertPullRequests(prs ...*PullRequest) error {
 // InsertReleases migrates release
 func InsertReleases(rels ...*Release) error {
 	sess := x.NewSession()
+	defer sess.Close()
 	if err := sess.Begin(); err != nil {
 		return err
 	}

--- a/models/oauth2_application.go
+++ b/models/oauth2_application.go
@@ -261,10 +261,10 @@ func deleteOAuth2Application(sess *xorm.Session, id, userid int64) error {
 // DeleteOAuth2Application deletes the application with the given id and the grants and auth codes related to it. It checks if the userid was the creator of the app.
 func DeleteOAuth2Application(id, userid int64) error {
 	sess := x.NewSession()
+	defer sess.Close()
 	if err := sess.Begin(); err != nil {
 		return err
 	}
-	defer sess.Close()
 
 	if err := deleteOAuth2Application(sess, id, userid); err != nil {
 		return err

--- a/models/oauth2_application.go
+++ b/models/oauth2_application.go
@@ -264,6 +264,8 @@ func DeleteOAuth2Application(id, userid int64) error {
 	if err := sess.Begin(); err != nil {
 		return err
 	}
+	defer sess.Close()
+
 	if err := deleteOAuth2Application(sess, id, userid); err != nil {
 		return err
 	}

--- a/models/oauth2_application.go
+++ b/models/oauth2_application.go
@@ -235,7 +235,7 @@ func deleteOAuth2Application(sess *xorm.Session, id, userid int64) error {
 	if deleted, err := sess.Delete(&OAuth2Application{ID: id, UID: userid}); err != nil {
 		return err
 	} else if deleted == 0 {
-		return fmt.Errorf("cannot find oauth2 application")
+		return ErrOAuthApplicationNotFound{ID: id}
 	}
 	codes := make([]*OAuth2AuthorizationCode, 0)
 	// delete correlating auth codes

--- a/models/oauth2_application.go
+++ b/models/oauth2_application.go
@@ -265,7 +265,6 @@ func DeleteOAuth2Application(id, userid int64) error {
 	if err := sess.Begin(); err != nil {
 		return err
 	}
-
 	if err := deleteOAuth2Application(sess, id, userid); err != nil {
 		return err
 	}

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -274,7 +274,11 @@ func DeleteOauth2Application(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 	appID := ctx.ParamsInt64(":id")
 	if err := models.DeleteOAuth2Application(appID, ctx.User.ID); err != nil {
-		ctx.Error(http.StatusInternalServerError, "DeleteOauth2ApplicationByID", err)
+		if models.IsErrOAuthApplicationNotFound(err) {
+			ctx.NotFound()
+		} else {
+			ctx.Error(http.StatusInternalServerError, "DeleteOauth2ApplicationByID", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
Return 404 when asked to delete OAuth2 Application and ensure that the session is closed too.

Fix #15356 
