### PR TITLE
When changing the search term on the repolist reset the page

### DIFF
--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -38,7 +38,7 @@
 			</h4>
 			<div class="ui attached segment repos-search">
 				<div class="ui fluid right action left icon input" :class="{loading: isLoading}">
-					<input @input="searchRepos(reposFilter)" v-model="searchQuery" ref="search" placeholder="{{.i18n.Tr "home.search_repos"}}">
+					<input @input="searchReposInput()" v-model="searchQuery" ref="search" placeholder="{{.i18n.Tr "home.search_repos"}}">
 					<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
 					<div class="ui dropdown icon button" title="{{.i18n.Tr "home.filter"}}">
 						<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3318,6 +3318,11 @@ function initVueComponents() {
         this.searchRepos();
       },
 
+      searchReposInput() {
+        this.page = 1;
+        this.searchRepos();
+      },
+
       searchRepos() {
         this.isLoading = true;
 


### PR DESCRIPTION
When inputing the search term on the repolist on the user home page the component
page should be reset to page 1.

Fix #15425

Signed-off-by: Andrew Thornton <art27@cantab.net>
