### PR TITLE
v172 migration adds created_unix field instead of expiry

### DIFF
--- a/models/migrations/v172.go
+++ b/models/migrations/v172.go
@@ -12,9 +12,9 @@ import (
 
 func addSessionTable(x *xorm.Engine) error {
 	type Session struct {
-		Key         string `xorm:"pk CHAR(16)"`
-		Data        []byte `xorm:"BLOB"`
-		CreatedUnix timeutil.TimeStamp
+		Key    string `xorm:"pk CHAR(16)"`
+		Data   []byte `xorm:"BLOB"`
+		Expiry timeutil.TimeStamp
 	}
 	return x.Sync2(new(Session))
 }


### PR DESCRIPTION
The Session table must have an Expiry field not a created_unix field - somehow
this migration adds the incorrect named field leading to #15445 reports.

Fix #15445

Signed-off-by: Andrew Thornton <art27@cantab.net>
