### PR TITLE
Fix: npx webpack make: *** [Makefile:699: public/js/index.js] Error -…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,8 @@ import {fileURLToPath} from 'url';
 
 const {VueLoaderPlugin} = VueLoader;
 const {ESBuildMinifyPlugin} = EsBuildLoader;
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const {SourceMapDevToolPlugin} = webpack;
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const glob = (pattern) => fastGlob.sync(pattern, {cwd: __dirname, absolute: true});
 
 const themes = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,12 +5,14 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import LicenseCheckerWebpackPlugin from 'license-checker-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin';
-import {VueLoaderPlugin} from 'vue-loader';
-import {ESBuildMinifyPlugin} from 'esbuild-loader';
+import VueLoader from 'vue-loader';
+import EsBuildLoader from 'esbuild-loader';
 import {resolve, parse, dirname} from 'path';
 import webpack from 'webpack';
 import {fileURLToPath} from 'url';
 
+const {VueLoaderPlugin} = VueLoader;
+const {ESBuildMinifyPlugin} = EsBuildLoader;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const {SourceMapDevToolPlugin} = webpack;
 const glob = (pattern) => fastGlob.sync(pattern, {cwd: __dirname, absolute: true});


### PR DESCRIPTION
when I execute `TAGS="bindata" make build` to build gitea, it shows:
**npx webpack make: *** [Makefile:699: public/js/index.js] Error -1073741819**
```bash
$ webpack -v
webpack 5.11.1
webpack-cli 4.3.1

$ TAGS="bindata" make build
rm -rf public/js public/css public/fonts public/img/webpack public/serviceworker.js
npx webpack
[webpack-cli] Failed to load 'E:\C_Language\Workspaces\GoProjects\gitea\webpack.config.js' config
[webpack-cli] file:///E:/C_Language/Workspaces/GoProjects/gitea/webpack.config.js:9
import {VueLoaderPlugin} from 'vue-loader';
        ^^^^^^^^^^^^^^^
SyntaxError: The requested module 'vue-loader' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
For example:
import pkg from 'vue-loader';
const {VueLoaderPlugin} = pkg;
    at ModuleJob._instantiate (internal/modules/esm/module_job.js:98:21)
    at async ModuleJob.run (internal/modules/esm/module_job.js:137:5)
    at async Loader.import (internal/modules/esm/loader.js:165:24)
    at async loadConfig (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:1346:35)
    at async WebpackCLI.resolveConfig (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:1454:38)
    at async WebpackCLI.createCompiler (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:1839:22)
    at async WebpackCLI.buildCommand (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:1954:20)
    at async Command.<anonymous> (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:735:25)
    at async Promise.all (index 1)
    at async Command.<anonymous> (E:\C_Language\Workspaces\GoProjects\gitea\node_modules\webpack-cli\lib\webpack-cli.js:1284:13)
make: *** [Makefile:699: public/js/index.js] Error 2
```
