### PR TITLE
fix wrong file link in code search page

### DIFF
--- a/routers/repo/search.go
+++ b/routers/repo/search.go
@@ -6,7 +6,6 @@ package repo
 
 import (
 	"net/http"
-	"path"
 	"strings"
 
 	"code.gitea.io/gitea/modules/base"
@@ -41,7 +40,7 @@ func Search(ctx *context.Context) {
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language
 	ctx.Data["queryType"] = queryType
-	ctx.Data["SourcePath"] = path.Join(setting.AppSubURL, ctx.Repo.Repository.Owner.Name, ctx.Repo.Repository.Name)
+	ctx.Data["SourcePath"] = ctx.Repo.Repository.HTMLURL()
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 	ctx.Data["RequireHighlightJS"] = true


### PR DESCRIPTION
in previous the grenrated link is
``testg/testrepo/src/commit/....``
which is not right.

the right version is ``/testg/testrepo/.......``
(start with ``/``)
or ``http://127.0.0.1:3000/xxxxx`` (full link)

to make it hase same result with explore page
I choose the secound style.

fix #15438
