### PR TITLE
Fix ambiguous argument error on tags (#15432)

### DIFF
--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -47,14 +47,7 @@ func (repo *Repository) GetBranchCommitID(name string) (string, error) {
 
 // GetTagCommitID returns last commit ID string of given tag.
 func (repo *Repository) GetTagCommitID(name string) (string, error) {
-	stdout, err := NewCommand("rev-list", "-n", "1", TagPrefix+name).RunInDir(repo.Path)
-	if err != nil {
-		if strings.Contains(err.Error(), "unknown revision or path") {
-			return "", ErrNotExist{name, ""}
-		}
-		return "", err
-	}
-	return strings.TrimSpace(stdout), nil
+	return repo.GetRefCommitID(TagPrefix + name)
 }
 
 func convertPGPSignatureForTag(t *object.Tag) *CommitGPGSignature {


### PR DESCRIPTION
Backport #15432

There is a weird gotcha with GetTagCommitID that because it uses git rev-list
can cause an ambiguous argument error.

This PR simply makes tags use the same code as branches.

Signed-off-by: Andrew Thornton <art27@cantab.net>
