### PR TITLE
Make build scripts compatible with node 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -734,7 +734,7 @@ generate-gitignore:
 
 .PHONY: generate-images
 generate-images:
-	npm install --no-save --no-package-lock fabric imagemin-zopfli
+	npm install --no-save --no-package-lock fabric@4 imagemin-zopfli@7
 	node build/generate-images.js $(TAGS)
 
 .PHONY: generate-manpage

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ generate-gitignore:
 	GO111MODULE=on $(GO) run build/generate-gitignores.go
 
 .PHONY: generate-images
-generate-images:
+generate-images: | node_modules
 	npm install --no-save --no-package-lock fabric@4 imagemin-zopfli@7
 	node build/generate-images.js $(TAGS)
 

--- a/build/generate-images.js
+++ b/build/generate-images.js
@@ -1,10 +1,11 @@
 import imageminZopfli from 'imagemin-zopfli';
 import {optimize, extendDefaultPlugins} from 'svgo';
 import {fabric} from 'fabric';
-import {readFile, writeFile} from 'fs/promises';
+import fs from 'fs';
 import {resolve, dirname} from 'path';
 import {fileURLToPath} from 'url';
 
+const {readFile, writeFile} = fs.promises;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const logoFile = resolve(__dirname, '../assets/logo.svg');
 

--- a/build/generate-svg.js
+++ b/build/generate-svg.js
@@ -1,9 +1,10 @@
 import fastGlob from 'fast-glob';
 import {optimize, extendDefaultPlugins} from 'svgo';
 import {resolve, parse, dirname} from 'path';
-import {readFile, writeFile, mkdir} from 'fs/promises';
+import fs from 'fs';
 import {fileURLToPath} from 'url';
 
+const {readFile, writeFile, mkdir} = fs.promises;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const glob = (pattern) => fastGlob.sync(pattern, {cwd: resolve(__dirname), absolute: true});
 const outputDir = resolve(__dirname, '../public/img/svg');


### PR DESCRIPTION
`fs/promises` is not in node 12, use a more compatible way to import it. Also, lock major down versions of the image build dependencies to prevent future surprises.