### PR TITLE
Lock down build-images dependencies (Partial #15479)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,8 +699,8 @@ generate-gitignore:
 	GO111MODULE=on $(GO) run build/generate-gitignores.go
 
 .PHONY: generate-images
-generate-images:
-	npm install --no-save --no-package-lock fabric imagemin-zopfli
+generate-images: | node_modules
+	npm install --no-save --no-package-lock fabric@4 imagemin-zopfli@7
 	node build/generate-images.js $(TAGS)
 
 .PHONY: generate-manpage


### PR DESCRIPTION
Partial extraction from #15479 for 1.14. Locks down build-images dependencies and adds missing node_modules dependency.