### PR TITLE
Build go-git variants for windows (#15482)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -577,6 +577,9 @@ release-windows: | $(DIST_DIRS)
 		$(GO) install src.techknowlogick.com/xgo@latest; \
 	fi
 	CGO_CFLAGS="$(CGO_CFLAGS)" xgo -go $(XGO_VERSION) -buildmode exe -dest $(DIST)/binaries -tags 'netgo osusergo $(TAGS)' -ldflags '-linkmode external -extldflags "-static" $(LDFLAGS)' -targets 'windows/*' -out gitea-$(VERSION) .
+ifeq (,$(findstring gogit,$(TAGS)))
+	CGO_CFLAGS="$(CGO_CFLAGS)" xgo -go $(XGO_VERSION) -buildmode exe -dest $(DIST)/binaries -tags 'netgo osusergo gogit $(TAGS)' -ldflags '-linkmode external -extldflags "-static" $(LDFLAGS)' -targets 'windows/*' -out gitea-$(VERSION)-gogit .
+endif
 ifeq ($(CI),drone)
 	cp /build/* $(DIST)/binaries
 endif


### PR DESCRIPTION
Backport #15482

It appears that there are significant performance problems with the pure git backend
on windows.

Therefore until we can sort this out - provide go-git backend builds.

Signed-off-by: Andrew Thornton <art27@cantab.net>
