### PR TITLE
Use index of the supported tags to choose user lang (#15452)

### DIFF
--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -27,8 +27,9 @@ type LangType struct {
 }
 
 var (
-	matcher  language.Matcher
-	allLangs []LangType
+	matcher       language.Matcher
+	allLangs      []LangType
+	supportedTags []language.Tag
 )
 
 // AllLangs returns all supported langauages
@@ -51,12 +52,12 @@ func InitLocales() {
 		}
 	}
 
-	tags := make([]language.Tag, len(setting.Langs))
+	supportedTags = make([]language.Tag, len(setting.Langs))
 	for i, lang := range setting.Langs {
-		tags[i] = language.Raw.Make(lang)
+		supportedTags[i] = language.Raw.Make(lang)
 	}
 
-	matcher = language.NewMatcher(tags)
+	matcher = language.NewMatcher(supportedTags)
 	for i := range setting.Names {
 		key := "locale_" + setting.Langs[i] + ".ini"
 		if err = i18n.SetMessageWithDesc(setting.Langs[i], setting.Names[i], localFiles[key]); err != nil {
@@ -79,8 +80,9 @@ func InitLocales() {
 }
 
 // Match matches accept languages
-func Match(tags ...language.Tag) (tag language.Tag, index int, c language.Confidence) {
-	return matcher.Match(tags...)
+func Match(tags ...language.Tag) language.Tag {
+	_, i, _ := matcher.Match(tags...)
+	return supportedTags[i]
 }
 
 // locale represents the information of localization.

--- a/modules/web/middleware/locale.go
+++ b/modules/web/middleware/locale.go
@@ -38,7 +38,7 @@ func Locale(resp http.ResponseWriter, req *http.Request) translation.Locale {
 	// The first element in the list is chosen to be the default language automatically.
 	if len(lang) == 0 {
 		tags, _, _ := language.ParseAcceptLanguage(req.Header.Get("Accept-Language"))
-		tag, _, _ := translation.Match(tags...)
+		tag := translation.Match(tags...)
 		lang = tag.String()
 	}
 


### PR DESCRIPTION
Backport #15452

Fix #14793.

The previous implementation used the first return value of matcher.Match, which is the chosen language tag but may contain extensions such as de-DE-u-rg-chzzzz.

As mentioned in the documentation of language package, matcher.Match also returns the index of the supported tags, so I think it is better to use it rather than manipulate the returned language tag.

Co-authored-by: Naohisa Murakami <tiqwab.ch90@gmail.com>