### PR TITLE
Query the DB for the hash before inserting in to email_hash (#15457)

### DIFF
--- a/models/avatar.go
+++ b/models/avatar.go
@@ -96,6 +96,11 @@ func HashedAvatarLink(email string) string {
 			// we don't care about any DB problem just return the lowerEmail
 			return lowerEmail, nil
 		}
+		has, err := sess.Where("email = ? AND hash = ?", emailHash.Email, emailHash.Hash).Get(new(EmailHash))
+		if has || err != nil {
+			// Seriously we don't care about any DB problems just return the lowerEmail - we expect the transaction to fail most of the time
+			return lowerEmail, nil
+		}
 		_, _ = sess.Insert(emailHash)
 		if err := sess.Commit(); err != nil {
 			// Seriously we don't care about any DB problems just return the lowerEmail - we expect the transaction to fail most of the time


### PR DESCRIPTION
Backport #15457

Some postgres users have logging which logs even failed transactions. So
just query the db before trying to insert.

Fix #15451

Signed-off-by: Andrew Thornton art27@cantab.net
Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>

