### PR TITLE
dump: Add option to skip LFS/attachment files (#15407)

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -129,6 +129,14 @@ It can be used for backup and capture Gitea server image to send to maintainer`,
 			Name:  "skip-custom-dir",
 			Usage: "Skip custom directory",
 		},
+		cli.BoolFlag{
+			Name:  "skip-lfs-data",
+			Usage: "Skip LFS data",
+		},
+		cli.BoolFlag{
+			Name:  "skip-attachment-data",
+			Usage: "Skip attachment data",
+		},
 		cli.GenericFlag{
 			Name:  "type",
 			Value: outputTypeEnum,
@@ -214,7 +222,9 @@ func runDump(ctx *cli.Context) error {
 			fatal("Failed to include repositories: %v", err)
 		}
 
-		if err := storage.LFS.IterateObjects(func(objPath string, object storage.Object) error {
+		if ctx.IsSet("skip-lfs-data") && ctx.Bool("skip-lfs-data") {
+			log.Info("Skip dumping LFS data")
+		} else if err := storage.LFS.IterateObjects(func(objPath string, object storage.Object) error {
 			info, err := object.Stat()
 			if err != nil {
 				return err
@@ -313,7 +323,9 @@ func runDump(ctx *cli.Context) error {
 		}
 	}
 
-	if err := storage.Attachments.IterateObjects(func(objPath string, object storage.Object) error {
+	if ctx.IsSet("skip-attachment-data") && ctx.Bool("skip-attachment-data") {
+		log.Info("Skip dumping attachment data")
+	} else if err := storage.Attachments.IterateObjects(func(objPath string, object storage.Object) error {
 		info, err := object.Stat()
 		if err != nil {
 			return err


### PR DESCRIPTION
Backport #15407

* Add option to skip dumping LFS/attachment files

* Fix fmt issues

Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>
