### PR TITLE
Improve signing documentation

### DIFF
--- a/docs/content/doc/advanced/signing.en-us.md
+++ b/docs/content/doc/advanced/signing.en-us.md
@@ -109,7 +109,7 @@ when creating a repository. The possible values are:
 - `always`: Always sign
 
 Options other than `never` and `always` can be combined as a comma
-separated list.
+separated list. The commit will be signed if all selected options are true.
 
 ### `WIKI`
 
@@ -123,7 +123,7 @@ The possible values are:
 - `always`: Always sign
 
 Options other than `never` and `always` can be combined as a comma
-separated list.
+separated list. The commit will be signed if all selected options are true.
 
 ### `CRUD_ACTIONS`
 
@@ -137,7 +137,7 @@ editor or API CRUD actions. The possible values are:
 - `always`: Always sign
 
 Options other than `never` and `always` can be combined as a comma
-separated list.
+separated list. The change will be signed if all selected options are true.
 
 ### `MERGES`
 
@@ -154,7 +154,7 @@ The possible options are:
 - `always`: Always sign
 
 Options other than `never` and `always` can be combined as a comma
-separated list.
+separated list. The merge will be signed if all selected options are true.
 
 ## Obtaining the Public Key of the Signing Key
 


### PR DESCRIPTION
I configured signing on my installation yesterday. I used the default signing options and couldn't get gitea to sign a commit from the webeditor. So I read the signing documentation and my first thought was that multiple options are linked with an OR-Operation (if one returns true the commit (or whatever) will be signed).

Therefor I suspected a bad configuration and spent some time trying to find the error. 

After some hours I looked at [repo_sign.go](https://github.com/go-gitea/gitea/blob/2a42d80d14e97fe962658bbcb3d2341571f2afcf/models/repo_sign.go) and noticed that the options are not linked with OR but with AND instead.

I've added a sentence to each option on documentation page to clarify this behaviour for other users in the future.