### PR TITLE
Fix missing icons and colorpicker when mounted on suburl

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -182,7 +182,7 @@ export default {
         type: 'asset/source',
       },
       {
-        test: /\.(ttf|woff2?)$/g,
+        test: /\.(ttf|woff2?)$/,
         type: 'asset/resource',
         generator: {
           filename: 'fonts/[name][ext]',
@@ -190,7 +190,7 @@ export default {
         }
       },
       {
-        test: /\.png$/ig,
+        test: /\.png$/i,
         type: 'asset/resource',
         generator: {
           filename: 'img/webpack/[name][ext]',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -182,19 +182,19 @@ export default {
         type: 'asset/source',
       },
       {
-        test: /\.(ttf|woff2?)$/,
+        test: /\.(ttf|woff2?)$/g,
         type: 'asset/resource',
         generator: {
           filename: 'fonts/[name][ext]',
-          publicPath: '/', // required to remove css/ path segment
+          publicPath: '../', // required to remove css/ path segment
         }
       },
       {
-        test: /\.png$/i,
+        test: /\.png$/ig,
         type: 'asset/resource',
         generator: {
           filename: 'img/webpack/[name][ext]',
-          publicPath: '/', // required to remove css/ path segment
+          publicPath: '../', // required to remove css/ path segment
         }
       },
     ],


### PR DESCRIPTION
icons and colorpicker are missing when mounted on a suburl. This PR fixes this.

Signed-off-by: Andrew Thornton <art27@cantab.net>
