### PR TITLE
Align project cards vertically instead of horizontally

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2975,7 +2975,6 @@ tbody.commit-list {
 .board-column > .cards {
   flex: 1;
   display: flex;
-  flex-direction: column;
   margin: 0 !important;
   padding: 0 !important;
 


### PR DESCRIPTION
(This change works on my local machine, but it would be nice if someone could test whether it has unexpected side effects I'm unaware of. However, I doubt that there will be side-effects given the css specificity)

Fixes #15506.

Before:
![image](https://user-images.githubusercontent.com/51889757/114992393-feaf8500-9e9a-11eb-8f0a-ae667489cb7f.png)

After:
![image](https://user-images.githubusercontent.com/51889757/115010568-de3cf600-9ead-11eb-8c3b-228b53664a97.png)

