### PR TITLE
Remove padding characters from random strings

### DIFF
--- a/modules/context/secret.go
+++ b/modules/context/secret.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"strings"
 )
 
 // NewSecret creates a new secret
@@ -34,7 +35,11 @@ func randomBytes(len int64) ([]byte, error) {
 
 func randomString(len int64) (string, error) {
 	b, err := randomBytes(len)
-	return base64.RawURLEncoding.EncodeToString(b), err
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.URLEncoding.EncodeToString(b)
+	return strings.TrimRight(encoded, "="), nil
 }
 
 // AesEncrypt encrypts text and given key with AES.

--- a/modules/context/secret.go
+++ b/modules/context/secret.go
@@ -34,7 +34,7 @@ func randomBytes(len int64) ([]byte, error) {
 
 func randomString(len int64) (string, error) {
 	b, err := randomBytes(len)
-	return base64.URLEncoding.EncodeToString(b), err
+	return base64.RawURLEncoding.EncodeToString(b), err
 }
 
 // AesEncrypt encrypts text and given key with AES.


### PR DESCRIPTION
* base64.RawURLEncoding added in go 1.15,
  can remove padding '=' characters from base64 strings

When I use gitea as a OIDC provider, I find the `code` generated by gitea is a base64 string contains `=`

```
P9BIOCLzf9pGeDgg6rc2HpLls5kehMVtWrxNfWUdho4=
```

Then the redirect query become 

```
?code=P9BIOCLzf9pGeDgg6rc2HpLls5kehMVtWrxNfWUdho4%3D&state=MjVmMjhhODMtODA2Yy00
```

The `=` in code encoded to `%3D` and may cause some error. This commit removes the padding characters