### PR TITLE
Fix a broken link in customizing-gitea.en-us.md

### DIFF
--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -42,7 +42,7 @@ environment variable; this can be used to override the default path to something
 `GITEA_CUSTOM` might, for example, be set by an init script. You can check whether the value
 is set under the "Configuration" tab on the site administration page.
 
-- [List of Environment Variables](https://docs.gitea.io/en-us/specific-variables/)
+- [List of Environment Variables](https://docs.gitea.io/en-us/environment-variables/)
 
 **Note:** Gitea must perform a full restart to see configuration changes.
 


### PR DESCRIPTION
I found a broken link in the documentation of Gitea. More specifically, on the page https://docs.gitea.io/en-us/customizing-gitea/ the link to `List of Environment Variables` on line 45 in `customizing-gitea.en-us.md` appears to link to a non-existing page. 

This PR proposes a quick fix for the problem. I have not filled an issue.

Best regards, rk-mlu 
