### PR TITLE
Fix NPE on view commit with notes

### DIFF
--- a/modules/git/notes_nogogit.go
+++ b/modules/git/notes_nogogit.go
@@ -8,6 +8,7 @@ package git
 
 import (
 	"io/ioutil"
+	"strings"
 )
 
 // GetNote retrieves the git-notes data for a given commit.
@@ -49,7 +50,13 @@ func GetNote(repo *Repository, commitID string, note *Note) error {
 	}
 	note.Message = d
 
-	lastCommits, err := GetLastCommitForPaths(notes, "", []string{path})
+	treePath := ""
+	if idx := strings.LastIndex(path, "/"); idx > -1 {
+		treePath = path[:idx]
+		path = path[idx+1:]
+	}
+
+	lastCommits, err := GetLastCommitForPaths(notes, treePath, []string{path})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is a mistake with the native git variant of GetNote when the note is referring to a non-root path. 

This PR simply splits the path and passes the basedir into GetLastCommitPaths separate from the root path. 

Fix #15558

Signed-off-by: Andrew Thornton <art27@cantab.net>
