### PR TITLE
Fix lfs management find (#15537)

### DIFF
--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -149,10 +149,10 @@ headerLoop:
 // constant hextable to help quickly convert between 20byte and 40byte hashes
 const hextable = "0123456789abcdef"
 
-// to40ByteSHA converts a 20-byte SHA in a 40-byte slice into a 40-byte sha in place
+// To40ByteSHA converts a 20-byte SHA in a 40-byte slice into a 40-byte sha in place
 // without allocations. This is at least 100x quicker that hex.EncodeToString
 // NB This requires that sha is a 40-byte slice
-func to40ByteSHA(sha []byte) []byte {
+func To40ByteSHA(sha []byte) []byte {
 	for i := 19; i >= 0; i-- {
 		v := sha[i]
 		vhi, vlo := v>>4, v&0x0f

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -300,7 +300,7 @@ revListLoop:
 					commits[0] = string(commitID)
 				}
 			}
-			treeID = to40ByteSHA(treeID)
+			treeID = To40ByteSHA(treeID)
 			_, err = batchStdinWriter.Write(treeID)
 			if err != nil {
 				return nil, err

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -127,11 +127,12 @@ func FindLFSFile(repo *git.Repository, hash git.SHA1) ([]*LFSResult, error) {
 			case "tree":
 				var n int64
 				for n < size {
-					mode, fname, sha, count, err := git.ParseTreeLine(batchReader, modeBuf, fnameBuf, workingShaBuf)
+					mode, fname, sha20byte, count, err := git.ParseTreeLine(batchReader, modeBuf, fnameBuf, workingShaBuf)
 					if err != nil {
 						return nil, err
 					}
 					n += int64(count)
+					sha := git.To40ByteSHA(sha20byte)
 					if bytes.Equal(sha, []byte(hashStr)) {
 						result := LFSResult{
 							Name:         curPath + string(fname),

--- a/routers/repo/lfs.go
+++ b/routers/repo/lfs.go
@@ -504,6 +504,7 @@ func createPointerResultsFromCatFileBatch(catFileBatchReader *io.PipeReader, wg 
 			_ = catFileBatchReader.CloseWithError(err)
 			break
 		}
+		sha = strings.TrimSpace(sha)
 		// Throw away the blob
 		if _, err := bufferedReader.ReadString(' '); err != nil {
 			_ = catFileBatchReader.CloseWithError(err)


### PR DESCRIPTION
Fix #15236, backport from #15537

* Do not do 40byte conversion within ParseTreeLine
* Missed a to40ByteSHA

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: Andrew Thornton <art27@cantab.net>