### PR TITLE
Fix docker enviroment variable from TYPE to DB_TYPE

### DIFF
--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -89,7 +89,7 @@ services:
   server:
     image: gitea/gitea:latest-rootless
 +    environment:
-+      - GITEA__database__TYPE=mysql
++      - GITEA__database__DB_TYPE=mysql
 +      - GITEA__database__HOST=db:3306
 +      - GITEA__database__NAME=gitea
 +      - GITEA__database__USER=gitea
@@ -130,7 +130,7 @@ services:
   server:
     image: gitea/gitea:latest-rootless
     environment:
-+      - GITEA__database__TYPE=postgres
++      - GITEA__database__DB_TYPE=postgres
 +      - GITEA__database__HOST=db:5432
 +      - GITEA__database__NAME=gitea
 +      - GITEA__database__USER=gitea

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -118,7 +118,7 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
-+     - GITEA__database__TYPE=mysql
++     - GITEA__database__DB_TYPE=mysql
 +     - GITEA__database__HOST=db:3306
 +     - GITEA__database__NAME=gitea
 +     - GITEA__database__USER=gitea
@@ -169,7 +169,7 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
-+     - GITEA__database__TYPE=postgres
++     - GITEA__database__DB_TYPE=postgres
 +     - GITEA__database__HOST=db:5432
 +     - GITEA__database__NAME=gitea
 +     - GITEA__database__USER=gitea


### PR DESCRIPTION
As documented in https://docs.gitea.io/en-us/config-cheat-sheet/ the database type is defined using db_type not type.

This pull request fixes the documentation to facillitate a correct quickstart with docker.