### PR TITLE
If the default branch is not present do not report error on stats indexing (#15546 & #15583)

### DIFF
--- a/modules/indexer/stats/db.go
+++ b/modules/indexer/stats/db.go
@@ -38,7 +38,11 @@ func (db *DBIndexer) Index(id int64) error {
 	// Get latest commit for default branch
 	commitID, err := gitRepo.GetBranchCommitID(repo.DefaultBranch)
 	if err != nil {
-		log.Error("Unable to get commit ID for defaultbranch %s in %s", repo.DefaultBranch, repo.RepoPath())
+		if git.IsErrBranchNotExist(err) || git.IsErrNotExist((err)) {
+			log.Debug("Unable to get commit ID for defaultbranch %s in %s ... skipping this repository", repo.DefaultBranch, repo.RepoPath())
+			return nil
+		}
+		log.Error("Unable to get commit ID for defaultbranch %s in %s. Error: %v", repo.DefaultBranch, repo.RepoPath(), err)
 		return err
 	}
 


### PR DESCRIPTION
Backport #15546
Backport #15583

 #15546 doesn't completely fix this problem because the error returned is an ObjectNotExist
error not a BranchNotExist error.

Add test for ErrObjectNotExist too

Fix #15257

Signed-off-by: Andrew Thornton <art27@cantab.net>
