### PR TITLE
Update example config file

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -818,13 +818,13 @@ ITEM_TTL = 8760h
 COMMITS_COUNT = 1000
 
 [session]
-; Either "memory", "file", or "redis", default is "memory"
+; Either "memory", "file", "db" or "redis", default is "memory"
 PROVIDER = memory
 ; Provider config options
 ; memory: doesn't have any config yet
 ; file: session file path, e.g. `data/sessions`
+; db: leave blank, [database] config above will be applied
 ; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
-; mysql: go-sql-driver/mysql dsn config string, e.g. `root:password@/session_table`
 PROVIDER_CONFIG = data/sessions
 ; Session cookie name
 COOKIE_NAME = i_like_gitea


### PR DESCRIPTION
Update examples for session config in `app.example.ini`. Replace outdated option `mysql` with new option `db`.

Related issue: #14016 

