### PR TITLE
Improve config cheat sheet (en-us)

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -582,7 +582,7 @@ Define allowed algorithms and their minimum key length (use -1 to disable a type
 ## Session (`session`)
 
 - `PROVIDER`: **memory**: Session engine provider \[memory, file, redis, db, mysql, couchbase, memcache, postgres\].
-- `PROVIDER_CONFIG`: **data/sessions**: For file, the root path; for others, the connection string.
+- `PROVIDER_CONFIG`: **data/sessions**: For file, the root path; for db, empty (database config will be used); for others, the connection string.
 - `COOKIE_SECURE`: **false**: Enable this to force using HTTPS for all session access.
 - `COOKIE_NAME`: **i\_like\_gitea**: The name of the cookie used for the session ID.
 - `GC_INTERVAL_TIME`: **86400**: GC interval in seconds.


### PR DESCRIPTION
Add more guide about `PROVIDER_CONFIG` when `PROVIDER` is `db`

Related issue: #14016 