### PR TITLE
fix webhook timeout bug

### DIFF
--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -271,14 +271,10 @@ func InitDeliverHooks() {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: setting.Webhook.SkipTLSVerify},
 			Proxy:           webhookProxy(),
 			Dial: func(netw, addr string) (net.Conn, error) {
-				conn, err := net.DialTimeout(netw, addr, timeout)
-				if err != nil {
-					return nil, err
-				}
-
-				return conn, conn.SetDeadline(time.Now().Add(timeout))
+				return net.DialTimeout(netw, addr, timeout) // dial timeout
 			},
 		},
+		Timeout: timeout, // request timeout
 	}
 
 	go graceful.GetManager().RunWithShutdownContext(DeliverHooks)


### PR DESCRIPTION
`conn.SetDeadline` will set a timeout based on connection succeed but not per request. Since a connection maybe resued for multiple http requests. This will result in many timeout on webhook requests.

This PR fix the problem which also found in gitea.com

This PR also changed a similiar problem on `httplib`. Because it will always create a new client when request, so it will not be affected currently. But creating a new client per request is really a problem should be fixed.