### PR TITLE
disable image check for non binary files

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -72,10 +72,12 @@
 					<h4 class="diff-file-header sticky-2nd-row ui top attached normal header df ac sb">
 						<div class="df ac">
 							{{$isImage := false}}
-							{{if $file.IsDeleted}}
-								{{$isImage = (call $.IsImageFileInBase $file.Name)}}
-							{{else}}
-								{{$isImage = (call $.IsImageFileInHead $file.Name)}}
+							{{if $file.IsBin}}
+								{{if $file.IsDeleted}}
+									{{$isImage = (call $.IsImageFileInBase $file.Name)}}
+								{{else}}
+									{{$isImage = (call $.IsImageFileInHead $file.Name)}}
+								{{end}}
 							{{end}}
 							{{$isCsv := (call $.IsCsvFile $file)}}
 							{{$showFileViewToggle := or $isImage $isCsv}}


### PR DESCRIPTION
The check for image on each file is really heavy, and i don't think it's mandatory for non binary files.
So i just propose to skip this IsImage check for non binary file.