### PR TITLE
Fix commit graph author link

### DIFF
--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -68,7 +68,7 @@
 								{{$userName = $commit.User.FullName}}
 							{{end}}
 							{{avatar $commit.User}}
-							<a href="{{AppSubUrl}}/{{$commit.User}}">{{$userName}}</a>
+							<a href="{{$commit.User.HomeLink}}">{{$userName}}</a>
 						{{else}}
 							{{avatarByEmail $commit.Commit.Author.Email $userName}}
 							{{$userName}}


### PR DESCRIPTION
The author link on the commit graph is incorrect and isn't providing a link to the author.

Signed-off-by: Andrew Thornton <art27@cantab.net>
