### PR TITLE
Return go-get info on subdirs. Fixes #15625

### DIFF
--- a/routers/routes/web.go
+++ b/routers/routes/web.go
@@ -1128,6 +1128,13 @@ func RegisterRoutes(m *web.Route) {
 
 			m.Head("/tasks/trigger", repo.TriggerTask)
 		})
+		m.Get("/{reponame}/*", func(ctx *context.Context) {
+			if ctx.Query("go-get") != "1" {
+				ctx.NotFound("", nil)
+				web.Wrap(routers.NotFound)
+			}
+		}, goGet)
+
 	})
 	// ***** END: Repository *****
 


### PR DESCRIPTION
Return go-get info on subdirs, if we're not requesting "?go-get=1" return NotFound
Fixes #15625 