### PR TITLE
Remove x-ua-compatible meta tag

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -3,7 +3,6 @@
 <head data-suburl="{{AppSubUrl}}">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<title>{{if .Title}}{{.Title | RenderEmojiPlain}} - {{end}} {{if .Repository.Name}}{{.Repository.Name}} - {{end}}{{AppName}} </title>
 	<link rel="manifest" href="data:{{.ManifestData}}"/>
 	<meta name="theme-color" content="{{ThemeColorMetaTag}}">


### PR DESCRIPTION
The header is deprecated since IE 11 so it only serves to support IE 10 and below which are browsers which are long unsupported now.

Ref: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/bg182625(v=vs.85)#document-mode-changes

> Starting with IE11, edge mode is the preferred document mode; it represents the highest support for modern standards available to the browser.

> Starting with IE11, document modes are deprecated and should no longer be used, except on a temporary basis.