### PR TITLE
Remove spurious set name from eventsource.sharedworker.js

### DIFF
--- a/web_src/js/features/eventsource.sharedworker.js
+++ b/web_src/js/features/eventsource.sharedworker.js
@@ -1,5 +1,3 @@
-self.name = 'eventsource.sharedworker.js';
-
 const sourcesByUrl = {};
 const sourcesByPort = {};
 


### PR DESCRIPTION
Fix #15617

Signed-off-by: Andrew Thornton <art27@cantab.net>

