### PR TITLE
Add pull "merged" notification subject status to API (#15344)

### DIFF
--- a/modules/convert/notification.go
+++ b/modules/convert/notification.go
@@ -47,6 +47,11 @@ func ToNotificationThread(n *models.Notification) *api.NotificationThread {
 			if err == nil && comment != nil {
 				result.Subject.LatestCommentURL = comment.APIURL()
 			}
+
+			pr, _ := n.Issue.GetPullRequest()
+			if pr != nil && pr.HasMerged {
+				result.Subject.State = "merged"
+			}
 		}
 	case models.NotificationSourceCommit:
 		result.Subject = &api.NotificationSubject{


### PR DESCRIPTION
Backport #15344

Current subject status can be "", "open" and "closed". This add "merged" to it.