### PR TITLE
Fix misaligned button in settings

### DIFF
--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -7,8 +7,8 @@
 		<h4 class="ui top attached header">
 			{{.i18n.Tr "repo.settings.lfs_filelist"}} ({{.i18n.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui tiny show-panel button" href="{{.Link}}/locks"><span class="octicon-tiny">{{svg "octicon-lock"}}</span>{{.i18n.Tr "repo.settings.lfs_locks"}}</a>
-				<a class="ui primary tiny show-panel button" href="{{.Link}}/pointers"><span class="octicon-tiny">{{svg "octicon-search"}}</span>&nbsp;{{.i18n.Tr "repo.settings.lfs_findpointerfiles"}}</a>
+				<a class="ui tiny show-panel button" href="{{.Link}}/locks">{{.i18n.Tr "repo.settings.lfs_locks"}}</a>
+				<a class="ui primary tiny show-panel button" href="{{.Link}}/pointers">&nbsp;{{.i18n.Tr "repo.settings.lfs_findpointerfiles"}}</a>
 			</div>
 		</h4>
 		<table id="lfs-files-table" class="ui attached segment single line table">


### PR DESCRIPTION
I noticed that the buttons in the LFS tab of the settings is slightly misaligned when compared to the rest of the tabs. This was due to icons that were not scaled properly. 

Every other tab does not display icons, so I figured they probably shouldn't be there anyway to keep the UI consistent.

### Before

![image](https://user-images.githubusercontent.com/32395585/116471275-c59cea80-a874-11eb-8c56-257451e71a8c.png)

### After

![image](https://user-images.githubusercontent.com/32395585/116471320-d2b9d980-a874-11eb-878e-4e6934c1e40e.png)

