### PR TITLE
[Docs] Switch renderer for restructured text (rst2html.py -> pandoc)

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -70,7 +70,7 @@ IS_INPUT_FILE = true
 [markup.restructuredtext]
 ENABLED = true
 FILE_EXTENSIONS = .rst
-RENDER_COMMAND = rst2html.py
+RENDER_COMMAND = "timeout 30s pandoc +RTS -M512M -RTS -f rst"
 IS_INPUT_FILE = false
 ```
 


### PR DESCRIPTION
rst2html.py create artifacts:

![Bildschirmfoto zu 2021-04-29 11-24-43](https://user-images.githubusercontent.com/24977596/116530166-01b86580-a8de-11eb-8912-6b6bba86ac42.png)

pandoc works as expected:
[demo](https://codeberg.org/sph/mopidy-autoplay/)