### PR TITLE
fix location for custom/options/license

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -43,7 +43,7 @@ MIRROR_QUEUE_LENGTH = 1000
 ; Patch test queue length, increase if pull request patch testing starts hanging
 PULL_REQUEST_QUEUE_LENGTH = 1000
 ; Preferred Licenses to place at the top of the List
-; The name here must match the filename in conf/license or custom/conf/license
+; The name here must match the filename in options/license or custom/options/license
 PREFERRED_LICENSES = Apache License 2.0,MIT License
 ; Disable the ability to interact with repositories using the HTTP protocol
 DISABLE_HTTP_GIT = false


### PR DESCRIPTION
I tested and confirm the custom/options/license location. My distro package (Arch) does not include options/license so I'm only guess there but it seems consistent with location in repo.
