### PR TITLE
Fix DB session cleanup

### DIFF
--- a/models/session.go
+++ b/models/session.go
@@ -117,6 +117,6 @@ func CountSessions() (int64, error) {
 
 // CleanupSessions cleans up expired sessions
 func CleanupSessions(maxLifetime int64) error {
-	_, err := x.Where("created_unix <= ?", timeutil.TimeStampNow().Add(-maxLifetime)).Delete(&Session{})
+	_, err := x.Where("expiry <= ?", timeutil.TimeStampNow().Add(-maxLifetime)).Delete(&Session{})
 	return err
 }


### PR DESCRIPTION
The DB session clean up needs to check expiry not created_unix.

Signed-off-by: Andrew Thornton <art27@cantab.net>
