### PR TITLE
Performance improvement for last commit cache and show-ref (#15455)

### DIFF
--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -102,10 +102,13 @@ func (tes Entries) GetCommitsInfo(commit *Commit, treePath string, cache *LastCo
 }
 
 func getLastCommitForPathsByCache(commitID, treePath string, paths []string, cache *LastCommitCache) (map[string]*Commit, []string, error) {
+	wr, rd, cancel := CatFileBatch(cache.repo.Path)
+	defer cancel()
+
 	var unHitEntryPaths []string
 	var results = make(map[string]*Commit)
 	for _, p := range paths {
-		lastCommit, err := cache.Get(commitID, path.Join(treePath, p))
+		lastCommit, err := cache.Get(commitID, path.Join(treePath, p), wr, rd)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -7,6 +7,8 @@
 package git
 
 import (
+	"bufio"
+	"io"
 	"path"
 )
 
@@ -34,7 +36,7 @@ func NewLastCommitCache(repoPath string, gitRepo *Repository, ttl func() int64, 
 }
 
 // Get get the last commit information by commit id and entry path
-func (c *LastCommitCache) Get(ref, entryPath string) (interface{}, error) {
+func (c *LastCommitCache) Get(ref, entryPath string, wr *io.PipeWriter, rd *bufio.Reader) (interface{}, error) {
 	v := c.cache.Get(c.getCacheKey(c.repoPath, ref, entryPath))
 	if vs, ok := v.(string); ok {
 		log("LastCommitCache hit level 1: [%s:%s:%s]", ref, entryPath, vs)
@@ -46,7 +48,10 @@ func (c *LastCommitCache) Get(ref, entryPath string) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		commit, err := c.repo.getCommit(id)
+		if _, err := wr.Write([]byte(vs + "\n")); err != nil {
+			return nil, err
+		}
+		commit, err := c.repo.getCommitFromBatchReader(rd, id)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport #15455

* Improve performance when there are multiple commits in the last commit cache

* read refs directly if we can

Signed-off-by: Andrew Thornton <art27@cantab.net>
