### PR TITLE
Fix setting redis db path (#15698)

### DIFF
--- a/modules/nosql/manager_redis.go
+++ b/modules/nosql/manager_redis.go
@@ -152,7 +152,7 @@ func (m *Manager) GetRedisClient(connection string) redis.UniversalClient {
 			opts.Addrs = append(opts.Addrs, strings.Split(uri.Host, ",")...)
 		}
 		if uri.Path != "" {
-			if db, err := strconv.Atoi(uri.Path); err == nil {
+			if db, err := strconv.Atoi(uri.Path[1:]); err == nil {
 				opts.DB = db
 			}
 		}
@@ -168,7 +168,7 @@ func (m *Manager) GetRedisClient(connection string) redis.UniversalClient {
 			opts.Addrs = append(opts.Addrs, strings.Split(uri.Host, ",")...)
 		}
 		if uri.Path != "" {
-			if db, err := strconv.Atoi(uri.Path); err == nil {
+			if db, err := strconv.Atoi(uri.Path[1:]); err == nil {
 				opts.DB = db
 			}
 		}
@@ -186,7 +186,7 @@ func (m *Manager) GetRedisClient(connection string) redis.UniversalClient {
 			opts.Addrs = append(opts.Addrs, strings.Split(uri.Host, ",")...)
 		}
 		if uri.Path != "" {
-			if db, err := strconv.Atoi(uri.Path); err == nil {
+			if db, err := strconv.Atoi(uri.Path[1:]); err == nil {
 				opts.DB = db
 			}
 		}


### PR DESCRIPTION
Backport #15698

There is a bug setting the redis db in the common nosql manager whereby the db path
always fails.

This PR fixes this.

Signed-off-by: Andrew Thornton <art27@cantab.net>