### PR TITLE
Fix webkit calendar icon color on arc-green

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -111,7 +111,7 @@
 }
 
 ::-webkit-calendar-picker-indicator {
-  filter: invert(.75);
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="%23a6aab5" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/><path fill="transparent" d="M0 0h24v24H0z"/></svg>');
 }
 
 .ui.horizontal.segments > .segment {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -111,7 +111,7 @@
 }
 
 ::-webkit-calendar-picker-indicator {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="%23a6aab5" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>');
+  filter: invert(.8);
 }
 
 .ui.horizontal.segments > .segment {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -110,6 +110,10 @@
   --color-project-board-bg: var(--color-secondary-light-2);
 }
 
+::-webkit-calendar-picker-indicator {
+  filter: invert(.75);
+}
+
 .ui.horizontal.segments > .segment {
   background-color: #383c4a;
 }

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -111,7 +111,7 @@
 }
 
 ::-webkit-calendar-picker-indicator {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="%23a6aab5" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/><path fill="transparent" d="M0 0h24v24H0z"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="%23a6aab5" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>');
 }
 
 .ui.horizontal.segments > .segment {


### PR DESCRIPTION
Before:
<img width="221" alt="Screen Shot 2021-05-04 at 00 13 17" src="https://user-images.githubusercontent.com/115237/116940113-bc918c00-ac6d-11eb-8553-a37a0997874e.png">

After:
<img width="219" alt="image" src="https://user-images.githubusercontent.com/115237/116943372-bacac700-ac73-11eb-9e52-63fd1aa1cea4.png">

There seems to be no way to set a color according to [this](https://stackoverflow.com/questions/62162645), so it has to be a filter.
