### PR TITLE
Introduce 'all' build tag for linting

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,29 +33,7 @@ steps:
     environment:
       GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
       GOSUMDB: sum.golang.org
-      TAGS: bindata sqlite sqlite_unlock_notify
-
-  - name: lint-backend-windows
-    pull: always
-    image: gitea/test_env:linux-arm64  # https://gitea.com/gitea/test-env
-    commands:
-      - make golangci-lint vet
-    environment:
-      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
-      GOSUMDB: sum.golang.org
-      TAGS: bindata sqlite sqlite_unlock_notify
-      GOOS: windows
-      GOARCH: amd64
-
-  - name: lint-backend-gogit
-    pull: always
-    image: gitea/test_env:linux-arm64  # https://gitea.com/gitea/test-env
-    commands:
-      - make lint-backend
-    environment:
-      GOPROXY: https://goproxy.cn # proxy.golang.org is blocked in China, this proxy is not
-      GOSUMDB: sum.golang.org
-      TAGS: bindata gogit sqlite sqlite_unlock_notify
+      TAGS: all
 
   - name: checks-frontend
     image: node:14

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,20 @@
 linters:
   enable:
-    - gosimple
     - deadcode
-    - typecheck
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - structcheck
-    - varcheck
-    - golint
     - dupl
-    #- gocyclo # The cyclomatic complexety of a lot of functions is too high, we should refactor those another time.
-    - gofmt
-    - misspell
+    - errcheck
     - gocritic
+    # - gocyclo # The cyclomatic complexety of a lot of functions is too high, we should refactor those another time.
+    - gofmt
+    - golint
+    - gosimple
+    - govet
+    - misspell
+    # - staticcheck # Causes out-of-memory issues on CI
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
   enable-all: false
   disable-all: true
   fast: false

--- a/Makefile
+++ b/Makefile
@@ -766,7 +766,7 @@ pr\#%: clean-all
 golangci-lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		export BINARY="golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.37.0; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.39.0; \
 	fi
 	GOGC=20 golangci-lint run --verbose --build-tags all --timeout 10m
 

--- a/Makefile
+++ b/Makefile
@@ -768,7 +768,7 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.37.0; \
 	fi
-	golangci-lint run --timeout 10m
+	golangci-lint run --build-tags all --timeout 10m
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,15 @@ swagger-validate:
 	$(SWAGGER) validate './$(SWAGGER_SPEC)'
 	$(SED_INPLACE) '$(SWAGGER_SPEC_S_TMPL)' './$(SWAGGER_SPEC)'
 
+.PHONY: build-constraints-check
+build-constraints-check:
+	@output=$$(grep '+build' $(GO_SOURCES_OWN) | grep -v all); \
+	if [ $$? -ne 1 ]; then \
+		echo "Please include the 'all' tag in all +build constraints:"; \
+		echo "$${output}"; \
+		exit 1; \
+	fi
+
 .PHONY: errcheck
 errcheck:
 	@hash errcheck > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
@@ -317,7 +326,7 @@ checks: checks-frontend checks-backend
 checks-frontend: svg-check
 
 .PHONY: checks-backend
-checks-backend: misspell-check test-vendor swagger-check swagger-validate
+checks-backend: misspell-check test-vendor swagger-check swagger-validate build-constraints-check
 
 .PHONY: lint
 lint: lint-frontend lint-backend

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ swagger-validate:
 
 .PHONY: build-constraints-check
 build-constraints-check:
-	@output=$$(grep '+build' $(GO_SOURCES_OWN) | grep -v all); \
+	@output=$$(grep '+build' $(GO_SOURCES_OWN) | grep -v ' all '); \
 	if [ $$? -ne 1 ]; then \
 		echo "Please include the 'all' tag in all +build constraints:"; \
 		echo "$${output}"; \

--- a/Makefile
+++ b/Makefile
@@ -768,7 +768,7 @@ golangci-lint:
 		export BINARY="golangci-lint"; \
 		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.37.0; \
 	fi
-	golangci-lint run --build-tags all --timeout 10m
+	GOGC=20 golangci-lint run --verbose --build-tags all --timeout 10m
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ swagger-validate:
 build-constraints-check:
 	@output=$$(grep '+build' $(GO_SOURCES_OWN) | grep -v ' all '); \
 	if [ $$? -ne 1 ]; then \
-		echo "Please include the 'all' tag in all +build constraints:"; \
+		echo "Please include the 'all' tag in all +build constraints, e.g. '// +build all yourtag'"; \
 		echo "$${output}"; \
 		exit 1; \
 	fi

--- a/build.go
+++ b/build.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build vendor
+//+build all vendor
 
 package main
 

--- a/build/generate-bindata.go
+++ b/build/generate-bindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/build/generate-emoji.go
+++ b/build/generate-emoji.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/build/generate-gitignores.go
+++ b/build/generate-gitignores.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/build/generate-licenses.go
+++ b/build/generate-licenses.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/build/gocovmerge.go
+++ b/build/gocovmerge.go
@@ -6,7 +6,7 @@
 // gocovmerge takes the results from multiple `go test -coverprofile` runs and
 // merges them into one profile
 
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/build/lint.go
+++ b/build/lint.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+// +build all ignore
 
 package main
 

--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build bindata
+// +build all bindata
 
 package cmd
 

--- a/cmd/embedded_stub.go
+++ b/cmd/embedded_stub.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !bindata
+// +build all !bindata
 
 package cmd
 

--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -1,4 +1,4 @@
-// +build pam
+// +build all pam
 
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -1,4 +1,4 @@
-// +build !pam
+// +build all !pam
 
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/auth/pam/pam_test.go
+++ b/modules/auth/pam/pam_test.go
@@ -1,4 +1,4 @@
-// +build pam
+// +build all pam
 
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/git/blob_gogit.go
+++ b/modules/git/blob_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/command_test.go
+++ b/modules/git/command_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build race
+// +build all race
 
 package git
 

--- a/modules/git/commit_convert_gogit.go
+++ b/modules/git/commit_convert_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/commit_info_gogit.go
+++ b/modules/git/commit_info_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/last_commit_cache_gogit.go
+++ b/modules/git/last_commit_cache_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/notes_gogit.go
+++ b/modules/git/notes_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/notes_nogogit.go
+++ b/modules/git/notes_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/parse_gogit.go
+++ b/modules/git/parse_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/parse_gogit_test.go
+++ b/modules/git/parse_gogit_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/parse_nogogit.go
+++ b/modules/git/parse_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/parse_nogogit_test.go
+++ b/modules/git/parse_nogogit_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/pipeline/lfs.go
+++ b/modules/git/pipeline/lfs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package pipeline
 

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package pipeline
 

--- a/modules/git/repo_base_gogit.go
+++ b/modules/git/repo_base_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_blob_gogit.go
+++ b/modules/git/repo_blob_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_blob_nogogit.go
+++ b/modules/git/repo_blob_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_branch_gogit.go
+++ b/modules/git/repo_branch_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_commit_gogit.go
+++ b/modules/git/repo_commit_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_commitgraph_gogit.go
+++ b/modules/git/repo_commitgraph_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_language_stats_gogit.go
+++ b/modules/git/repo_language_stats_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_language_stats_nogogit.go
+++ b/modules/git/repo_language_stats_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_ref_gogit.go
+++ b/modules/git/repo_ref_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_ref_nogogit.go
+++ b/modules/git/repo_ref_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_tag_gogit.go
+++ b/modules/git/repo_tag_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_tag_nogogit.go
+++ b/modules/git/repo_tag_nogogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/repo_tree_gogit.go
+++ b/modules/git/repo_tree_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/sha1_gogit.go
+++ b/modules/git/sha1_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/sha1_nogogit.go
+++ b/modules/git/sha1_nogogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/signature_gogit.go
+++ b/modules/git/signature_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/signature_nogogit.go
+++ b/modules/git/signature_nogogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/tree_blob_gogit.go
+++ b/modules/git/tree_blob_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/tree_blob_nogogit.go
+++ b/modules/git/tree_blob_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/tree_entry_gogit.go
+++ b/modules/git/tree_entry_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/git/tree_entry_test.go
+++ b/modules/git/tree_entry_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/tree_gogit.go
+++ b/modules/git/tree_gogit.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package git
 

--- a/modules/git/tree_nogogit.go
+++ b/modules/git/tree_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package git
 

--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build all !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build all windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/graceful/net_unix.go
+++ b/modules/graceful/net_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build all !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/graceful/net_windows.go
+++ b/modules/graceful/net_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build all windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/graceful/restart_unix.go
+++ b/modules/graceful/restart_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build all !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/lfs/pointer_scanner_gogit.go
+++ b/modules/lfs/pointer_scanner_gogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gogit
+// +build all gogit
 
 package lfs
 

--- a/modules/lfs/pointer_scanner_nogogit.go
+++ b/modules/lfs/pointer_scanner_nogogit.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !gogit
+// +build all !gogit
 
 package lfs
 

--- a/modules/options/dynamic.go
+++ b/modules/options/dynamic.go
@@ -1,4 +1,4 @@
-// +build !bindata
+// +build all !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/options/options_bindata.go
+++ b/modules/options/options_bindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//+build all bindata
 
 package options
 

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -1,4 +1,4 @@
-// +build bindata
+// +build all bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/public/dynamic.go
+++ b/modules/public/dynamic.go
@@ -1,4 +1,4 @@
-// +build !bindata
+// +build all !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/public/public_bindata.go
+++ b/modules/public/public_bindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//+build all bindata
 
 package public
 

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -1,4 +1,4 @@
-// +build bindata
+// +build all bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/setting/database_sqlite.go
+++ b/modules/setting/database_sqlite.go
@@ -1,4 +1,4 @@
-// +build sqlite
+// +build all sqlite
 
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/svg/discover_bindata.go
+++ b/modules/svg/discover_bindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build bindata
+// +build all bindata
 
 package svg
 

--- a/modules/svg/discover_nobindata.go
+++ b/modules/svg/discover_nobindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !bindata
+// +build all !bindata
 
 package svg
 

--- a/modules/templates/dynamic.go
+++ b/modules/templates/dynamic.go
@@ -1,4 +1,4 @@
-// +build !bindata
+// +build all !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/templates/static.go
+++ b/modules/templates/static.go
@@ -1,4 +1,4 @@
-// +build bindata
+// +build all bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/templates/templates_bindata.go
+++ b/modules/templates/templates_bindata.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//+build all bindata
 
 package templates
 

--- a/routers/private/manager_unix.go
+++ b/routers/private/manager_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build all !windows
 
 // Copyright 2020 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/routers/private/manager_windows.go
+++ b/routers/private/manager_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build all windows
 
 // Copyright 2020 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/tools/fuzz.go
+++ b/tools/fuzz.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// +build gofuzz
+// +build all gofuzz
 
 package fuzz
 


### PR DESCRIPTION
By introducing a new 'all' build tag on all build conditionals, we can make the linters run on all files, eliminating two costly steps on each CI run. Thanks to https://github.com/golangci/golangci-lint/issues/1646#issuecomment-825906765 for the idea.