### PR TITLE
fix some ui bug about draft release (#15137)

### DIFF
--- a/models/fixtures/release.yml
+++ b/models/fixtures/release.yml
@@ -43,3 +43,15 @@
   is_tag: true
   created_unix: 946684800
 
+-
+  id: 4
+  repo_id: 1
+  publisher_id: 2
+  tag_name: "draft-release"
+  lower_tag_name: "draft-release"
+  target: "master"
+  title: "draft-release"
+  is_draft: true
+  is_prerelease: false
+  is_tag: false
+  created_unix: 1619524806

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -722,7 +722,7 @@ func getRefName(ctx *Context, pathType RepoRefType) string {
 
 // RepoRefByType handles repository reference name for a specific type
 // of repository reference
-func RepoRefByType(refType RepoRefType) func(*Context) {
+func RepoRefByType(refType RepoRefType, ignoreNotExistErr ...bool) func(*Context) {
 	return func(ctx *Context) {
 		// Empty repository does not have reference information.
 		if ctx.Repo.Repository.IsEmpty {
@@ -811,6 +811,9 @@ func RepoRefByType(refType RepoRefType) func(*Context) {
 						util.URLJoin(setting.AppURL, strings.Replace(ctx.Req.URL.RequestURI(), refName, ctx.Repo.Commit.ID.String(), 1))))
 				}
 			} else {
+				if len(ignoreNotExistErr) > 0 && ignoreNotExistErr[0] {
+					return
+				}
 				ctx.NotFound("RepoRef invalid repo", fmt.Errorf("branch or tag not exist: %s", refName))
 				return
 			}

--- a/routers/routes/web.go
+++ b/routers/routes/web.go
@@ -901,8 +901,8 @@ func RegisterRoutes(m *web.Route) {
 			m.Get("/", repo.Releases)
 			m.Get("/tag/*", repo.SingleRelease)
 			m.Get("/latest", repo.LatestRelease)
-			m.Get("/attachments/{uuid}", repo.GetAttachment)
-		}, repo.MustBeNotEmpty, reqRepoReleaseReader, context.RepoRefByType(context.RepoRefTag))
+		}, repo.MustBeNotEmpty, reqRepoReleaseReader, context.RepoRefByType(context.RepoRefTag, true))
+		m.Get("/releases/attachments/{uuid}", repo.GetAttachment, repo.MustBeNotEmpty, reqRepoReleaseReader)
 		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -75,11 +75,13 @@
 								<span class="ui green label">{{$.i18n.Tr "repo.release.stable"}}</span>
 							{{end}}
 							<span class="tag text blue">
-								<a class="df ac je" href="{{$.RepoLink}}/src/tag/{{.TagName | EscapePound}}" rel="nofollow">{{svg "octicon-tag" 16 "mr-2"}}{{.TagName}}</a>
+								<a class="df ac je" href="{{if .IsDraft}}#{{else}}{{$.RepoLink}}/src/tag/{{.TagName | EscapePound}}{{end}}" rel="nofollow">{{svg "octicon-tag" 16 "mr-2"}}{{.TagName}}</a>
 							</span>
-							<span class="commit">
-								<a class="mono" href="{{$.RepoLink}}/src/commit/{{.Sha1}}" rel="nofollow">{{svg "octicon-git-commit" 16 "mr-2"}}{{ShortSha .Sha1}}</a>
-							</span>
+							{{if not .IsDraft}}
+								<span class="commit">
+									<a class="mono" href="{{$.RepoLink}}/src/commit/{{.Sha1}}" rel="nofollow">{{svg "octicon-git-commit" 16 "mr-2"}}{{ShortSha .Sha1}}</a>
+								</span>
+							{{end}}
 						{{end}}
 					</div>
 					<div class="ui twelve wide column detail">
@@ -127,9 +129,11 @@
 									{{$.i18n.Tr "repo.released_this"}}
 								</span>
 								{{if .CreatedUnix}}
-									<span class="time">{{TimeSinceUnix .CreatedUnix $.Lang}}</span> | 
+									<span class="time">{{TimeSinceUnix .CreatedUnix $.Lang}}</span>
 								{{end}}
-								<span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | EscapePound}}...{{.Target}}">{{$.i18n.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.i18n.Tr "repo.release.ahead.target" .Target}}</span>
+								{{if not .IsDraft}}
+									| <span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | EscapePound}}...{{.Target}}">{{$.i18n.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.i18n.Tr "repo.release.ahead.target" .Target}}</span>
+								{{end}}
 							</p>
 							<div class="markdown desc">
 								{{Str2html .Note}}
@@ -141,7 +145,7 @@
 								</h2>
 								<div class="content {{if eq $idx 0}}active{{end}}">
 									<ul class="list">
-										{{if $.Permission.CanRead $.UnitTypeCode}}
+										{{if and (not .IsDraft) ($.Permission.CanRead $.UnitTypeCode)}}
 											<li>
 												<a class="archive-link" data-url="{{$.RepoLink}}/archive/{{.TagName | EscapePound}}.zip" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 "mr-2"}}{{$.i18n.Tr "repo.release.source_code"}} (ZIP)</strong></a>
 											</li>


### PR DESCRIPTION
Backport #15137

* fix some ui bug about draft release

- should not show draft release in tag list because
  it will't create real tag
- still show draft release without tag and commit message
  for draft release instead of 404 error
- remove tag load for attachement links because it's useles