### PR TITLE
Fix setting version table in dump

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -320,7 +320,7 @@ func DumpDatabase(filePath, dbType string) error {
 		ID      int64 `xorm:"pk autoincr"`
 		Version int64
 	}
-	t, err := x.TableInfo(Version{})
+	t, err := x.TableInfo(&Version{})
 	if err != nil {
 		return err
 	}

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -25,7 +25,7 @@ func TestDumpDatabase(t *testing.T) {
 		ID      int64 `xorm:"pk autoincr"`
 		Version int64
 	}
-	assert.NoError(t, x.Sync2(Version{}))
+	assert.NoError(t, x.Sync2(new(Version)))
 
 	for _, dbName := range setting.SupportedDatabases {
 		dbType := setting.GetDBTypeByName(dbName)


### PR DESCRIPTION
As noted on Discord there is a problem with gitea dump where the version table
is not being dumped correctly.

This is due to a missing pointer in the TableInfo.

This PR fixes this.

Fix #15678 

Signed-off-by: Andrew Thornton <art27@cantab.net>
