### PR TITLE
Drop back to use IsAnInteractiveSession for SVC (#15749)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,3 +110,7 @@ issues:
     - text: "exitAfterDefer:"
       linters:
         - gocritic
+    - path: modules/graceful/manager_windows.go
+      linters:
+        - staticcheck
+      text: "svc.IsAnInteractiveSession is deprecated: Use IsWindowsService instead."

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -74,12 +74,14 @@ func (g *Manager) start() {
 
 	// Make SVC process
 	run := svc.Run
-	isWindowsService, err := svc.IsWindowsService()
+
+	//lint:ignore SA1019 We use IsAnInteractiveSession because IsWindowsService has a different permissions profile
+	isAnInteractiveSession, err := svc.IsAnInteractiveSession()
 	if err != nil {
 		log.Error("Unable to ascertain if running as an Windows Service: %v", err)
 		return
 	}
-	if !isWindowsService {
+	if isAnInteractiveSession {
 		log.Trace("Not running a service ... using the debug SVC manager")
 		run = debug.Run
 	}


### PR DESCRIPTION
Backport #15749

There is an apparent permission change problem when using
IsWindowsService to determine if the SVC manager should be
used.

This PR simply drops back to using IsAnInteractiveSession as
this does not change behaviour.

Fix #15454

Signed-off-by: Andrew Thornton <art27@cantab.net>

