### PR TITLE
Fix bug where repositories appear unadopted (#15757)

### DIFF
--- a/modules/repository/adopt.go
+++ b/modules/repository/adopt.go
@@ -228,7 +228,7 @@ func ListUnadoptedRepositories(query string, opts *models.ListOptions) ([]string
 					found := false
 				repoLoop:
 					for i, repo := range repos {
-						if repo.Name == name {
+						if repo.LowerName == name {
 							found = true
 							repos = append(repos[:i], repos[i+1:]...)
 							break repoLoop


### PR DESCRIPTION
Backport #15757

Fix bug where repositories with capital letters in their names appear unadopted.

Fix #15755