### PR TITLE
OAuth2 login: Set account link to "login" as default behavior

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -641,7 +641,7 @@ UPDATE_AVATAR = false
 ; disabled = show an error
 ; login = show an account linking login
 ; auto = link directly with the account
-ACCOUNT_LINKING = disabled
+ACCOUNT_LINKING = login
 
 [service]
 ; Time limit to confirm account/email registration

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -440,7 +440,7 @@ relation to port exhaustion.
     - nickname - use the nickname attribute
     - email - use the username part of the email attribute
 - `UPDATE_AVATAR`: **false**: Update avatar if available from oauth2 provider. Update will be performed on each login.
-- `ACCOUNT_LINKING`: **disabled**: How to handle if an account / email already exists:
+- `ACCOUNT_LINKING`: **login**: How to handle if an account / email already exists:
     - disabled - show an error
     - login - show an account linking login
     - auto - automatically link with the account (Please be aware that this will grant access to an existing account just because the same username or email is provided. You must make sure that this does not cause issues with your authentication providers.)

--- a/modules/setting/oauth2_client.go
+++ b/modules/setting/oauth2_client.go
@@ -71,10 +71,10 @@ func newOAuth2Client() {
 		OAuth2Client.Username = OAuth2UsernameNickname
 	}
 	OAuth2Client.UpdateAvatar = sec.Key("UPDATE_AVATAR").MustBool()
-	OAuth2Client.AccountLinking = OAuth2AccountLinkingType(sec.Key("ACCOUNT_LINKING").MustString(string(OAuth2AccountLinkingDisabled)))
+	OAuth2Client.AccountLinking = OAuth2AccountLinkingType(sec.Key("ACCOUNT_LINKING").MustString(string(OAuth2AccountLinkingLogin)))
 	if !OAuth2Client.AccountLinking.isValid() {
-		log.Warn("Account linking setting is not valid: '%s', will fallback to '%s'", OAuth2Client.AccountLinking, OAuth2AccountLinkingDisabled)
-		OAuth2Client.AccountLinking = OAuth2AccountLinkingDisabled
+		log.Warn("Account linking setting is not valid: '%s', will fallback to '%s'", OAuth2Client.AccountLinking, OAuth2AccountLinkingLogin)
+		OAuth2Client.AccountLinking = OAuth2AccountLinkingLogin
 	}
 }
 


### PR DESCRIPTION
make #5123 non breakning