### PR TITLE
Fix URL of gitea emoji

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -484,7 +484,7 @@ func createCustomEmoji(alias, class string) *html.Node {
 	}
 	if class != "" {
 		img.Attr = append(img.Attr, html.Attribute{Key: "alt", Val: fmt.Sprintf(`:%s:`, alias)})
-		img.Attr = append(img.Attr, html.Attribute{Key: "src", Val: fmt.Sprintf(`%s/img/emoji/%s.png`, setting.StaticURLPrefix, alias)})
+		img.Attr = append(img.Attr, html.Attribute{Key: "src", Val: fmt.Sprintf(`%s/assets/img/emoji/%s.png`, setting.StaticURLPrefix, alias)})
 	}
 
 	span.AppendChild(img)

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -283,7 +283,7 @@ func TestRender_emoji(t *testing.T) {
 	//Text that should be turned into or recognized as emoji
 	test(
 		":gitea:",
-		`<p><span class="emoji" aria-label="gitea"><img alt=":gitea:" src="`+setting.StaticURLPrefix+`/img/emoji/gitea.png"/></span></p>`)
+		`<p><span class="emoji" aria-label="gitea"><img alt=":gitea:" src="`+setting.StaticURLPrefix+`/assets/img/emoji/gitea.png"/></span></p>`)
 
 	test(
 		"Some text with 😄 in the middle",


### PR DESCRIPTION
Fixes regression from #15219. Issue seen in title of https://try.gitea.io/silverwind/symlink-test/issues/6.

Frontend code that also outputs these images is not affected because `StaticURLPrefix` includes `/assets` there, while the same-named backend variable doesn't. We should later rename the frontend variable to clear up this potential confusion.