### PR TITLE
Comment out app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1,1314 +1,2039 @@
 ; This file lists the default values used by Gitea
-; Copy required sections to your own app.ini (default is custom/conf/app.ini)
-; and modify as needed.
-; Do not copy the whole file as-is, as it contains some invalid sections for illustrative purposes.
-; If you don't know what a setting is you should not set it.
+;; Copy required sections to your own app.ini (default is custom/conf/app.ini)
+;; and modify as needed.
+;; Do not copy the whole file as-is, as it contains some invalid sections for illustrative purposes.
+;; If you don't know what a setting is you should not set it.
+;;
+;; see https://docs.gitea.io/en-us/config-cheat-sheet/ for additional documentation.
 
-; see https://docs.gitea.io/en-us/config-cheat-sheet/ for additional documentation.
 
-; App name that shows in every page title
-APP_NAME = Gitea: Git with a cup of tea
-; Change it if you run locally
-RUN_USER = git
-; Application run mode, affects performance and debugging. Either "dev", "prod" or "test", default is "prod"
-RUN_MODE = prod
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; General Settings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; App name that shows in every page title
+APP_NAME = ; Gitea: Git with a cup of tea
+;;
+;; RUN_USER will automatically detect the current user - but you can set it here change it if you run locally
+RUN_USER = ; git
+;;
+;; Application run mode, affects performance and debugging. Either "dev", "prod" or "test", default is "prod"
+RUN_MODE = ; prod
 
-[project]
-; Default templates for project boards
-PROJECT_BOARD_BASIC_KANBAN_TYPE = To Do, In Progress, Done
-PROJECT_BOARD_BUG_TRIAGE_TYPE = Needs Triage, High Priority, Low Priority, Closed
-
-[repository]
-; Root path for storing all repository data. It must be an absolute path. By default, it is stored in a sub-directory of `APP_DATA_PATH`.
-ROOT =
-; The script type this server supports. Usually this is `bash`, but some users report that only `sh` is available.
-SCRIPT_TYPE = bash
-; DETECTED_CHARSETS_ORDER tie-break order for detected charsets.
-; If the charsets have equal confidence, tie-breaking will be done by order in this list
-; with charsets earlier in the list chosen in preference to those later.
-; Adding "defaults" will place the unused charsets at that position.
-DETECTED_CHARSETS_ORDER = UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr
-; Default ANSI charset to override non-UTF-8 charsets to
-ANSI_CHARSET =
-; Force every new repository to be private
-FORCE_PRIVATE = false
-; Default privacy setting when creating a new repository, allowed values: last, private, public. Default is last which means the last setting used.
-DEFAULT_PRIVATE = last
-; Default private when using push-to-create
-DEFAULT_PUSH_CREATE_PRIVATE = true
-; Global limit of repositories per user, applied at creation time. -1 means no limit
-MAX_CREATION_LIMIT = -1
-; Mirror sync queue length, increase if mirror syncing starts hanging
-MIRROR_QUEUE_LENGTH = 1000
-; Patch test queue length, increase if pull request patch testing starts hanging
-PULL_REQUEST_QUEUE_LENGTH = 1000
-; Preferred Licenses to place at the top of the List
-; The name here must match the filename in conf/license or custom/conf/license
-PREFERRED_LICENSES = Apache License 2.0,MIT License
-; Disable the ability to interact with repositories using the HTTP protocol
-DISABLE_HTTP_GIT = false
-; Value for Access-Control-Allow-Origin header, default is not to present
-; WARNING: This may be harmful to your website if you do not give it a right value.
-ACCESS_CONTROL_ALLOW_ORIGIN =
-; Force ssh:// clone url instead of scp-style uri when default SSH port is used
-USE_COMPAT_SSH_URI = false
-; Close issues as long as a commit on any branch marks it as fixed
-DEFAULT_CLOSE_ISSUES_VIA_COMMITS_IN_ANY_BRANCH = false
-; Allow users to push local repositories to Gitea and have them automatically created for a user or an org
-ENABLE_PUSH_CREATE_USER = false
-ENABLE_PUSH_CREATE_ORG = false
-; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki
-DISABLED_REPO_UNITS =
-; Comma separated list of default repo units. Allowed values: repo.code, repo.releases, repo.issues, repo.pulls, repo.wiki, repo.projects.
-; Note: Code and Releases can currently not be deactivated. If you specify default repo units you should still list them for future compatibility.
-; External wiki and issue tracker can't be enabled by default as it requires additional settings.
-; Disabled repo units will not be added to new repositories regardless if it is in the default list.
-DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki,repo.projects
-; Prefix archive files by placing them in a directory named after the repository
-PREFIX_ARCHIVE_FILES = true
-; Disable the creation of new mirrors. Pre-existing mirrors remain valid.
-DISABLE_MIRRORS = false
-; Disable migrating feature.
-DISABLE_MIGRATIONS = false
-; Disable stars feature.
-DISABLE_STARS = false
-; The default branch name of new repositories
-DEFAULT_BRANCH = master
-; Allow adoption of unadopted repositories
-ALLOW_ADOPTION_OF_UNADOPTED_REPOSITORIES = false
-; Allow deletion of unadopted repositories
-ALLOW_DELETION_OF_UNADOPTED_REPOSITORIES = false
-
-[repository.editor]
-; List of file extensions for which lines should be wrapped in the Monaco editor
-; Separate extensions with a comma. To line wrap files without an extension, just put a comma
-LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,
-; Valid file modes that have a preview API associated with them, such as api/v1/markdown
-; Separate the values by commas. The preview tab in edit mode won't be displayed if the file extension doesn't match
-PREVIEWABLE_FILE_MODES = markdown
-
-[repository.local]
-; Path for local repository copy. Defaults to `tmp/local-repo`
-LOCAL_COPY_PATH = tmp/local-repo
-
-[repository.upload]
-; Whether repository file uploads are enabled. Defaults to `true`
-ENABLED = true
-; Path for uploads. Defaults to `data/tmp/uploads` (tmp gets deleted on gitea restart)
-TEMP_PATH = data/tmp/uploads
-; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
-ALLOWED_TYPES =
-; Max size of each file in megabytes. Defaults to 3MB
-FILE_MAX_SIZE = 3
-; Max number of files per upload. Defaults to 5
-MAX_FILES = 5
-
-[repository.pull-request]
-; List of prefixes used in Pull Request title to mark them as Work In Progress
-WORK_IN_PROGRESS_PREFIXES = WIP:,[WIP]
-; List of keywords used in Pull Request comments to automatically close a related issue
-CLOSE_KEYWORDS = close,closes,closed,fix,fixes,fixed,resolve,resolves,resolved
-; List of keywords used in Pull Request comments to automatically reopen a related issue
-REOPEN_KEYWORDS = reopen,reopens,reopened
-; In the default merge message for squash commits include at most this many commits
-DEFAULT_MERGE_MESSAGE_COMMITS_LIMIT = 50
-; In the default merge message for squash commits limit the size of the commit messages to this
-DEFAULT_MERGE_MESSAGE_SIZE = 5120
-; In the default merge message for squash commits walk all commits to include all authors in the Co-authored-by otherwise just use those in the limited list
-DEFAULT_MERGE_MESSAGE_ALL_AUTHORS = false
-; In default merge messages limit the number of approvers listed as Reviewed-by: to this many
-DEFAULT_MERGE_MESSAGE_MAX_APPROVERS = 10
-; In default merge messages only include approvers who are official
-DEFAULT_MERGE_MESSAGE_OFFICIAL_APPROVERS_ONLY = true
-
-[repository.issue]
-; List of reasons why a Pull Request or Issue can be locked
-LOCK_REASONS = Too heated,Off-topic,Resolved,Spam
-
-[repository.release]
-; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
-ALLOWED_TYPES =
-
-[repository.signing]
-; GPG key to use to sign commits, Defaults to the default - that is the value of git config --get user.signingkey
-; run in the context of the RUN_USER
-; Switch to none to stop signing completely
-SIGNING_KEY = default
-; If a SIGNING_KEY ID is provided and is not set to default, use the provided Name and Email address as the signer.
-; These should match a publicized name and email address for the key. (When SIGNING_KEY is default these are set to
-; the results of git config --get user.name and git config --get user.email respectively and can only be overridden
-; by setting the SIGNING_KEY ID to the correct ID.)
-SIGNING_NAME =
-SIGNING_EMAIL =
-; Sets the default trust model for repositories. Options are: collaborator, committer, collaboratorcommitter
-DEFAULT_TRUST_MODEL = collaborator
-; Determines when gitea should sign the initial commit when creating a repository
-; Either:
-; - never
-; - pubkey: only sign if the user has a pubkey
-; - twofa: only sign if the user has logged in with twofa
-; - always
-; options other than none and always can be combined as comma separated list
-INITIAL_COMMIT = always
-; Determines when to sign for CRUD actions
-; - as above
-; - parentsigned: requires that the parent commit is signed.
-CRUD_ACTIONS = pubkey, twofa, parentsigned
-; Determines when to sign Wiki commits
-; - as above
-WIKI = never
-; Determines when to sign on merges
-; - basesigned: require that the parent of commit on the base repo is signed.
-; - commitssigned: require that all the commits in the head branch are signed.
-; - approved: only sign when merging an approved pr to a protected branch
-MERGES = pubkey, twofa, basesigned, commitssigned
-
-[cors]
-; More information about CORS can be found here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers
-; enable cors headers (disabled by default)
-ENABLED = false
-; scheme of allowed requests
-SCHEME = http
-; list of requesting domains that are allowed
-ALLOW_DOMAIN = *
-; allow subdomains of headers listed above to request
-ALLOW_SUBDOMAIN = false
-; list of methods allowed to request
-METHODS = GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS
-; max time to cache response
-MAX_AGE = 10m
-; allow request with credentials
-ALLOW_CREDENTIALS = false
-
-[ui]
-; Number of repositories that are displayed on one explore page
-EXPLORE_PAGING_NUM = 20
-; Number of issues that are displayed on one page
-ISSUE_PAGING_NUM = 10
-; Number of maximum commits displayed in one activity feed
-FEED_MAX_COMMIT_NUM = 5
-; Number of items that are displayed in home feed
-FEED_PAGING_NUM = 20
-; Number of maximum commits displayed in commit graph.
-GRAPH_MAX_COMMIT_NUM = 100
-; Number of line of codes shown for a code comment
-CODE_COMMENT_LINES = 4
-; Value of `theme-color` meta tag, used by Android >= 5.0
-; An invalid color like "none" or "disable" will have the default style
-; More info: https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
-THEME_COLOR_META_TAG = `#6cc644`
-; Max size of files to be displayed (default is 8MiB)
-MAX_DISPLAY_FILE_SIZE = 8388608
-; Whether the email of the user should be shown in the Explore Users page
-SHOW_USER_EMAIL = true
-; Set the default theme for the Gitea install
-DEFAULT_THEME = gitea
-; All available themes. Allow users select personalized themes regardless of the value of `DEFAULT_THEME`.
-THEMES = gitea,arc-green
-;All available reactions users can choose on issues/prs and comments.
-;Values can be emoji alias (:smile:) or a unicode emoji.
-;For custom reactions, add a tightly cropped square image to public/emoji/img/reaction_name.png
-REACTIONS = +1, -1, laugh, hooray, confused, heart, rocket, eyes
-; Whether the full name of the users should be shown where possible. If the full name isn't set, the username will be used.
-DEFAULT_SHOW_FULL_NAME = false
-; Whether to search within description at repository search on explore page.
-SEARCH_REPO_DESCRIPTION = true
-; Whether to enable a Service Worker to cache frontend assets
-USE_SERVICE_WORKER = true
-
-[ui.admin]
-; Number of users that are displayed on one page
-USER_PAGING_NUM = 50
-; Number of repos that are displayed on one page
-REPO_PAGING_NUM = 50
-; Number of notices that are displayed on one page
-NOTICE_PAGING_NUM = 25
-; Number of organizations that are displayed on one page
-ORG_PAGING_NUM = 50
-
-[ui.user]
-; Number of repos that are displayed on one page
-REPO_PAGING_NUM = 15
-
-[ui.meta]
-AUTHOR = Gitea - Git with a cup of tea
-DESCRIPTION = Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go
-KEYWORDS = go,git,self-hosted,gitea
-
-[ui.notification]
-; Control how often the notification endpoint is polled to update the notification
-; The timeout will increase to MAX_TIMEOUT in TIMEOUT_STEPs if the notification count is unchanged
-; Set MIN_TIMEOUT to 0 to turn off
-MIN_TIMEOUT = 10s
-MAX_TIMEOUT = 60s
-TIMEOUT_STEP = 10s
-; This setting determines how often the db is queried to get the latest notification counts.
-; If the browser client supports EventSource and SharedWorker, a SharedWorker will be used in preference to polling notification. Set to -1 to disable the EventSource
-EVENT_SOURCE_UPDATE_TIME = 10s
-
-[ui.svg]
-; Whether to render SVG files as images.  If SVG rendering is disabled, SVG files are displayed as text and cannot be embedded in markdown files as images.
-ENABLE_RENDER = true
-
-[ui.csv]
-; Maximum allowed file size in bytes to render CSV files as table. (Set to 0 for no limit).
-MAX_FILE_SIZE = 524288
-
-[markdown]
-; Render soft line breaks as hard line breaks, which means a single newline character between
-; paragraphs will cause a line break and adding trailing whitespace to paragraphs is not
-; necessary to force a line break.
-; Render soft line breaks as hard line breaks for comments
-ENABLE_HARD_LINE_BREAK_IN_COMMENTS = true
-; Render soft line breaks as hard line breaks for markdown documents
-ENABLE_HARD_LINE_BREAK_IN_DOCUMENTS = false
-; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
-; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)
-; URLs starting with http and https are always displayed, whatever is put in this entry.
-CUSTOM_URL_SCHEMES =
-; List of file extensions that should be rendered/edited as Markdown
-; Separate the extensions with a comma. To render files without any extension as markdown, just put a comma
-FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [server]
-; The protocol the server listens on. One of 'http', 'https', 'unix' or 'fcgi'.
-PROTOCOL = http
-DOMAIN = localhost
-ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
-; when STATIC_URL_PREFIX is empty it will follow ROOT_URL
-STATIC_URL_PREFIX =
-; The address to listen on. Either a IPv4/IPv6 address or the path to a unix socket.
-HTTP_ADDR = 0.0.0.0
-; The port to listen on. Leave empty when using a unix socket.
-HTTP_PORT = 3000
-; If REDIRECT_OTHER_PORT is true, and PROTOCOL is set to https an http server
-; will be started on PORT_TO_REDIRECT and it will redirect plain, non-secure http requests to the main
-; ROOT_URL.  Defaults are false for REDIRECT_OTHER_PORT and 80 for
-; PORT_TO_REDIRECT.
-REDIRECT_OTHER_PORT = false
-PORT_TO_REDIRECT = 80
-; Permission for unix socket
-UNIX_SOCKET_PERMISSION = 666
-; Local (DMZ) URL for Gitea workers (such as SSH update) accessing web service.
-; In most cases you do not need to change the default value.
-; Alter it only if your SSH server node is not the same as HTTP node.
-; Do not set this variable if PROTOCOL is set to 'unix'.
-LOCAL_ROOT_URL = %(PROTOCOL)s://%(HTTP_ADDR)s:%(HTTP_PORT)s/
-; Disable SSH feature when not available
-DISABLE_SSH = false
-; Whether to use the builtin SSH server or not.
-START_SSH_SERVER = false
-; Username to use for the builtin SSH server. If blank, then it is the value of RUN_USER.
-BUILTIN_SSH_SERVER_USER =
-; Domain name to be exposed in clone URL
-SSH_DOMAIN = %(DOMAIN)s
-; The network interface the builtin SSH server should listen on
-SSH_LISTEN_HOST =
-; Port number to be exposed in clone URL
-SSH_PORT = 22
-; The port number the builtin SSH server should listen on
-SSH_LISTEN_PORT = %(SSH_PORT)s
-; Root path of SSH directory, default is '~/.ssh', but you have to use '/home/git/.ssh'.
-SSH_ROOT_PATH =
-; Gitea will create a authorized_keys file by default when it is not using the internal ssh server
-; If you intend to use the AuthorizedKeysCommand functionality then you should turn this off.
-SSH_CREATE_AUTHORIZED_KEYS_FILE = true
-; Gitea will create a authorized_principals file by default when it is not using the internal ssh server
-; If you intend to use the AuthorizedPrincipalsCommand functionality then you should turn this off.
-SSH_CREATE_AUTHORIZED_PRINCIPALS_FILE = true
-; For the built-in SSH server, choose the ciphers to support for SSH connections,
-; for system SSH this setting has no effect
-SSH_SERVER_CIPHERS = aes128-ctr, aes192-ctr, aes256-ctr, aes128-gcm@openssh.com, arcfour256, arcfour128
-; For the built-in SSH server, choose the key exchange algorithms to support for SSH connections,
-; for system SSH this setting has no effect
-SSH_SERVER_KEY_EXCHANGES = diffie-hellman-group1-sha1, diffie-hellman-group14-sha1, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, curve25519-sha256@libssh.org
-; For the built-in SSH server, choose the MACs to support for SSH connections,
-; for system SSH this setting has no effect
-SSH_SERVER_MACS = hmac-sha2-256-etm@openssh.com, hmac-sha2-256, hmac-sha1, hmac-sha1-96
-; For the built-in SSH server, choose the keypair to offer as the host key
-; The private key should be at SSH_SERVER_HOST_KEY and the public SSH_SERVER_HOST_KEY.pub
-; relative paths are made absolute relative to the APP_DATA_PATH
-SSH_SERVER_HOST_KEYS=ssh/gitea.rsa, ssh/gogs.rsa
-; Directory to create temporary files in when testing public keys using ssh-keygen,
-; default is the system temporary directory.
-SSH_KEY_TEST_PATH =
-; Path to ssh-keygen, default is 'ssh-keygen' which means the shell is responsible for finding out which one to call.
-SSH_KEYGEN_PATH = ssh-keygen
-; Enable SSH Authorized Key Backup when rewriting all keys, default is true
-SSH_AUTHORIZED_KEYS_BACKUP = true
-; Determines which principals to allow
-; - empty: if SSH_TRUSTED_USER_CA_KEYS is empty this will default to off, otherwise will default to email, username.
-; - off: Do not allow authorized principals
-; - email: the principal must match the user's email
-; - username: the principal must match the user's username
-; - anything: there will be no checking on the content of the principal
-SSH_AUTHORIZED_PRINCIPALS_ALLOW = email, username
-; Enable SSH Authorized Principals Backup when rewriting all keys, default is true
-SSH_AUTHORIZED_PRINCIPALS_BACKUP = true
-; Specifies the public keys of certificate authorities that are trusted to sign user certificates for authentication.
-; Multiple keys should be comma separated.
-; E.g."ssh-<algorithm> <key>". or "ssh-<algorithm> <key1>, ssh-<algorithm> <key2>".
-; For more information see "TrustedUserCAKeys" in the sshd config manpages.
-SSH_TRUSTED_USER_CA_KEYS =
-; Absolute path of the `TrustedUserCaKeys` file gitea will manage.
-; Default this `RUN_USER`/.ssh/gitea-trusted-user-ca-keys.pem
-; If you're running your own ssh server and you want to use the gitea managed file you'll also need to modify your
-; sshd_config to point to this file. The official docker image will automatically work without further configuration.
-SSH_TRUSTED_USER_CA_KEYS_FILENAME =
-; Enable exposure of SSH clone URL to anonymous visitors, default is false
-SSH_EXPOSE_ANONYMOUS = false
-; Indicate whether to check minimum key size with corresponding type
-MINIMUM_KEY_SIZE_CHECK = false
-; Disable CDN even in "prod" mode
-OFFLINE_MODE = false
-DISABLE_ROUTER_LOG = false
-; Generate steps:
-; $ ./gitea cert -ca=true -duration=8760h0m0s -host=myhost.example.com
-;
-; Or from a .pfx file exported from the Windows certificate store (do
-; not forget to export the private key):
-; $ openssl pkcs12 -in cert.pfx -out cert.pem -nokeys
-; $ openssl pkcs12 -in cert.pfx -out key.pem -nocerts -nodes
-; Paths are relative to CUSTOM_PATH
-CERT_FILE = https/cert.pem
-KEY_FILE = https/key.pem
-; Root directory containing templates and static files.
-; default is the path where Gitea is executed
-STATIC_ROOT_PATH =
-; Default path for App data
-APP_DATA_PATH = data
-; Enable gzip compression for runtime-generated content, static resources excluded
-ENABLE_GZIP = false
-; Application profiling (memory and cpu)
-; For "web" command it listens on localhost:6060
-; For "serve" command it dumps to disk at PPROF_DATA_PATH as (cpuprofile|memprofile)_<username>_<temporary id>
-ENABLE_PPROF = false
-; PPROF_DATA_PATH, use an absolute path when you start gitea as service
-PPROF_DATA_PATH = data/tmp/pprof
-; Landing page, can be "home", "explore", "organizations" or "login"
-; The "login" choice is not a security measure but just a UI flow change, use REQUIRE_SIGNIN_VIEW to force users to log in.
-LANDING_PAGE = home
-; Enables git-lfs support. true or false, default is false.
-LFS_START_SERVER = false
-; Where your lfs files reside, default is data/lfs.
-LFS_CONTENT_PATH = data/lfs
-; LFS authentication secret, change this yourself
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; The protocol the server listens on. One of 'http', 'https', 'unix' or 'fcgi'. Defaults to 'http'
+;PROTOCOL = http
+;;
+;; Set the domain for the server
+;DOMAIN = localhost
+;;
+;; Overwrite the automatically generated public URL. Necessary for proxies and docker.
+;ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
+;;
+;; when STATIC_URL_PREFIX is empty it will follow ROOT_URL
+;STATIC_URL_PREFIX =
+;;
+;; The address to listen on. Either a IPv4/IPv6 address or the path to a unix socket.
+;HTTP_ADDR = 0.0.0.0
+;;
+;; The port to listen on. Leave empty when using a unix socket.
+;HTTP_PORT = 3000
+;;
+;; If REDIRECT_OTHER_PORT is true, and PROTOCOL is set to https an http server
+;; will be started on PORT_TO_REDIRECT and it will redirect plain, non-secure http requests to the main
+;; ROOT_URL.  Defaults are false for REDIRECT_OTHER_PORT and 80 for
+;; PORT_TO_REDIRECT.
+;REDIRECT_OTHER_PORT = false
+;PORT_TO_REDIRECT = 80
+;;
+;; Permission for unix socket
+;UNIX_SOCKET_PERMISSION = 666
+;;
+;; Local (DMZ) URL for Gitea workers (such as SSH update) accessing web service.
+;; In most cases you do not need to change the default value.
+;; Alter it only if your SSH server node is not the same as HTTP node.
+;; Do not set this variable if PROTOCOL is set to 'unix'.
+;LOCAL_ROOT_URL = %(PROTOCOL)s://%(HTTP_ADDR)s:%(HTTP_PORT)s/
+;;
+;; Disable SSH feature when not available
+;DISABLE_SSH = false
+;;
+;; Whether to use the builtin SSH server or not.
+;START_SSH_SERVER = false
+;;
+;; Username to use for the builtin SSH server. If blank, then it is the value of RUN_USER.
+;BUILTIN_SSH_SERVER_USER =
+;;
+;; Domain name to be exposed in clone URL
+;SSH_DOMAIN = %(DOMAIN)s
+;;
+;; The network interface the builtin SSH server should listen on
+;SSH_LISTEN_HOST =
+;;
+;; Port number to be exposed in clone URL
+;SSH_PORT = 22
+;;
+;; The port number the builtin SSH server should listen on
+;SSH_LISTEN_PORT = %(SSH_PORT)s
+;;
+;; Root path of SSH directory, default is '~/.ssh', but you have to use '/home/git/.ssh'.
+;SSH_ROOT_PATH =
+;;
+;; Gitea will create a authorized_keys file by default when it is not using the internal ssh server
+;; If you intend to use the AuthorizedKeysCommand functionality then you should turn this off.
+;SSH_CREATE_AUTHORIZED_KEYS_FILE = true
+;;
+;; Gitea will create a authorized_principals file by default when it is not using the internal ssh server
+;; If you intend to use the AuthorizedPrincipalsCommand functionality then you should turn this off.
+;SSH_CREATE_AUTHORIZED_PRINCIPALS_FILE = true
+;;
+;; For the built-in SSH server, choose the ciphers to support for SSH connections,
+;; for system SSH this setting has no effect
+;SSH_SERVER_CIPHERS = aes128-ctr, aes192-ctr, aes256-ctr, aes128-gcm@openssh.com, arcfour256, arcfour128
+;;
+;; For the built-in SSH server, choose the key exchange algorithms to support for SSH connections,
+;; for system SSH this setting has no effect
+;SSH_SERVER_KEY_EXCHANGES = diffie-hellman-group1-sha1, diffie-hellman-group14-sha1, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, curve25519-sha256@libssh.org
+;;
+;; For the built-in SSH server, choose the MACs to support for SSH connections,
+;; for system SSH this setting has no effect
+;SSH_SERVER_MACS = hmac-sha2-256-etm@openssh.com, hmac-sha2-256, hmac-sha1, hmac-sha1-96
+;;
+;; For the built-in SSH server, choose the keypair to offer as the host key
+;; The private key should be at SSH_SERVER_HOST_KEY and the public SSH_SERVER_HOST_KEY.pub
+;; relative paths are made absolute relative to the APP_DATA_PATH
+;SSH_SERVER_HOST_KEYS=ssh/gitea.rsa, ssh/gogs.rsa
+;;
+;; Directory to create temporary files in when testing public keys using ssh-keygen,
+;; default is the system temporary directory.
+;SSH_KEY_TEST_PATH =
+;;
+;; Path to ssh-keygen, default is 'ssh-keygen' which means the shell is responsible for finding out which one to call.
+;SSH_KEYGEN_PATH = ssh-keygen
+;;
+;; Enable SSH Authorized Key Backup when rewriting all keys, default is true
+;SSH_AUTHORIZED_KEYS_BACKUP = true
+;;
+;; Determines which principals to allow
+;; - empty: if SSH_TRUSTED_USER_CA_KEYS is empty this will default to off, otherwise will default to email, username.
+;; - off: Do not allow authorized principals
+;; - email: the principal must match the user's email
+;; - username: the principal must match the user's username
+;; - anything: there will be no checking on the content of the principal
+;SSH_AUTHORIZED_PRINCIPALS_ALLOW = email, username
+;;
+;; Enable SSH Authorized Principals Backup when rewriting all keys, default is true
+;SSH_AUTHORIZED_PRINCIPALS_BACKUP = true
+;;
+;; Specifies the public keys of certificate authorities that are trusted to sign user certificates for authentication.
+;; Multiple keys should be comma separated.
+;; E.g."ssh-<algorithm> <key>". or "ssh-<algorithm> <key1>, ssh-<algorithm> <key2>".
+;; For more information see "TrustedUserCAKeys" in the sshd config manpages.
+;SSH_TRUSTED_USER_CA_KEYS =
+;; Absolute path of the `TrustedUserCaKeys` file gitea will manage.
+;; Default this `RUN_USER`/.ssh/gitea-trusted-user-ca-keys.pem
+;; If you're running your own ssh server and you want to use the gitea managed file you'll also need to modify your
+;; sshd_config to point to this file. The official docker image will automatically work without further configuration.
+;SSH_TRUSTED_USER_CA_KEYS_FILENAME =
+;;
+;; Enable exposure of SSH clone URL to anonymous visitors, default is false
+;SSH_EXPOSE_ANONYMOUS = false
+;;
+;; Indicate whether to check minimum key size with corresponding type
+;MINIMUM_KEY_SIZE_CHECK = false
+;;
+;; Disable CDN even in "prod" mode
+;OFFLINE_MODE = false
+;DISABLE_ROUTER_LOG = false
+;;
+;; Generate steps:
+;; $ ./gitea cert -ca=true -duration=8760h0m0s -host=myhost.example.com
+;;
+;; Or from a .pfx file exported from the Windows certificate store (do
+;; not forget to export the private key):
+;; $ openssl pkcs12 -in cert.pfx -out cert.pem -nokeys
+;; $ openssl pkcs12 -in cert.pfx -out key.pem -nocerts -nodes
+;; Paths are relative to CUSTOM_PATH
+;CERT_FILE = https/cert.pem
+;KEY_FILE = https/key.pem
+;;
+;; Root directory containing templates and static files.
+;; default is the path where Gitea is executed
+;STATIC_ROOT_PATH =
+;;
+;; Default path for App data
+;APP_DATA_PATH = data
+;;
+;; Enable gzip compression for runtime-generated content, static resources excluded
+;ENABLE_GZIP = false
+;;
+;; Application profiling (memory and cpu)
+;; For "web" command it listens on localhost:6060
+;; For "serve" command it dumps to disk at PPROF_DATA_PATH as (cpuprofile|memprofile)_<username>_<temporary id>
+;ENABLE_PPROF = false
+;;
+;; PPROF_DATA_PATH, use an absolute path when you start gitea as service
+;PPROF_DATA_PATH = data/tmp/pprof
+;;
+;; Landing page, can be "home", "explore", "organizations" or "login"
+;; The "login" choice is not a security measure but just a UI flow change, use REQUIRE_SIGNIN_VIEW to force users to log in.
+;LANDING_PAGE = home
+;;
+;; Enables git-lfs support. true or false, default is false.
+;LFS_START_SERVER = false
+;;
+;; Where your lfs files reside, default is data/lfs.
+;LFS_CONTENT_PATH = data/lfs
+;;
+;; LFS authentication secret, change this yourself
 LFS_JWT_SECRET =
-; LFS authentication validity period (in time.Duration), pushes taking longer than this may fail.
-LFS_HTTP_AUTH_EXPIRY = 20m
-; Maximum allowed LFS file size in bytes (Set to 0 for no limit).
-LFS_MAX_FILE_SIZE = 0
-; Maximum number of locks returned per page
-LFS_LOCKS_PAGING_NUM = 50
-; Allow graceful restarts using SIGHUP to fork
-ALLOW_GRACEFUL_RESTARTS = true
-; After a restart the parent will finish ongoing requests before
-; shutting down. Force shutdown if this process takes longer than this delay.
-; set to a negative value to disable
-GRACEFUL_HAMMER_TIME = 60s
-; Allows the setting of a startup timeout and waithint for Windows as SVC service
-; 0 disables this.
-STARTUP_TIMEOUT = 0
-; Static resources, includes resources on custom/, public/ and all uploaded avatars web browser cache time. Note that this cache is disabled when RUN_MODE is "dev". Default is 6h
-STATIC_CACHE_TIME = 6h
+;;
+;; LFS authentication validity period (in time.Duration), pushes taking longer than this may fail.
+;LFS_HTTP_AUTH_EXPIRY = 20m
+;;
+;; Maximum allowed LFS file size in bytes (Set to 0 for no limit).
+;LFS_MAX_FILE_SIZE = 0
+;;
+;; Maximum number of locks returned per page
+;LFS_LOCKS_PAGING_NUM = 50
+;;
+;; Allow graceful restarts using SIGHUP to fork
+;ALLOW_GRACEFUL_RESTARTS = true
+;;
+;; After a restart the parent will finish ongoing requests before
+;; shutting down. Force shutdown if this process takes longer than this delay.
+;; set to a negative value to disable
+;GRACEFUL_HAMMER_TIME = 60s
+;;
+;; Allows the setting of a startup timeout and waithint for Windows as SVC service
+;; 0 disables this.
+;STARTUP_TIMEOUT = 0
+;;
+;; Static resources, includes resources on custom/, public/ and all uploaded avatars web browser cache time. Note that this cache is disabled when RUN_MODE is "dev". Default is 6h
+;STATIC_CACHE_TIME = 6h
 
-; Define allowed algorithms and their minimum key length (use -1 to disable a type)
-[ssh.minimum_key_sizes]
-ED25519 = 256
-ECDSA = 256
-RSA = 2048
-DSA = -1 ; set to 1024 to switch on
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [database]
-; Database to use. Either "mysql", "postgres", "mssql" or "sqlite3".
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Database to use. Either "mysql", "postgres", "mssql" or "sqlite3".
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MySQL Configuration
+;;
 DB_TYPE = mysql
-HOST = 127.0.0.1:3306
+HOST = 127.0.0.1:3306 ; can use socket e.g. /var/run/mysqld/mysqld.sock
 NAME = gitea
 USER = root
-; Use PASSWD = `your password` for quoting if you use special characters in the password.
-PASSWD =
-; For Postgres, schema to use if different from "public". The schema must exist beforehand,
-; the user must have creation privileges on it, and the user search path must be set
-; to the look into the schema first. e.g.:ALTER USER user SET SEARCH_PATH = schema_name,"$user",public;
-SCHEMA =
-; For Postgres, either "disable" (default), "require", or "verify-full"
-; For MySQL, either "false" (default), "true", or "skip-verify"
-SSL_MODE = disable
-; For MySQL only, either "utf8" or "utf8mb4", default is "utf8mb4".
-; NOTICE: for "utf8mb4" you must use MySQL InnoDB > 5.6. Gitea is unable to check this.
-CHARSET = utf8mb4
-; For "sqlite3" and "tidb", use an absolute path when you start gitea as service
-PATH = data/gitea.db
-; For "sqlite3" only. Query timeout
-SQLITE_TIMEOUT = 500
-; For iterate buffer, default is 50
-ITERATE_BUFFER_SIZE = 50
-; Show the database generated SQL
-LOG_SQL = true
-; Maximum number of DB Connect retries
-DB_RETRIES = 10
-; Backoff time per DB retry (time.Duration)
-DB_RETRY_BACKOFF = 3s
-; Max idle database connections on connection pool, default is 2
-MAX_IDLE_CONNS = 2
-; Database connection max life time, default is 0 or 3s mysql (See #6804 & #7071 for reasoning)
-CONN_MAX_LIFETIME = 3s
-; Database maximum number of open connections, default is 0 meaning no maximum
-MAX_OPEN_CONNS = 0
+;PASSWD = ;Use PASSWD = `your password` for quoting if you use special characters in the password.
+;SSL_MODE = false ; either "false" (default), "true", or "skip-verify"
+;CHARSET = utf8mb4 ;either "utf8" or "utf8mb4", default is "utf8mb4".
+;;
+;; NOTICE: for "utf8mb4" you must use MySQL InnoDB > 5.6. Gitea is unable to check this.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Postgres Configuration
+;;
+;DB_TYPE = postgres
+;HOST = 127.0.0.1:5432 ; can use socket e.g. /var/run/postgresql/
+;NAME = gitea
+;USER = root
+;PASSWD =
+;SCHEMA =
+;SSL_MODE=disable ;either "disable" (default), "require", or "verify-full"
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; SQLite Configuration
+;;
+;DB_TYPE = sqlite3
+;PATH= ; defaults to data/gitea.db
+;SQLITE_TIMEOUT = ; Query timeout defaults to: 500
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MSSQL Configuration
+;;
+;DB_TYPE = mssql
+;HOST = 172.17.0.2:1433
+;NAME = gitea
+;USER = SA
+;PASSWD = MwantsaSecurePassword1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Other settings
+;;
+;; For iterate buffer, default is 50
+;ITERATE_BUFFER_SIZE = 50
+;;
+;; Show the database generated SQL
+LOG_SQL = false ; if unset defaults to true
+;;
+;; Maximum number of DB Connect retries
+;DB_RETRIES = 10
+;;
+;; Backoff time per DB retry (time.Duration)
+;DB_RETRY_BACKOFF = 3s
+;;
+;; Max idle database connections on connection pool, default is 2
+;MAX_IDLE_CONNS = 2
+;;
+;; Database connection max life time, default is 0 or 3s mysql (See #6804 & #7071 for reasoning)
+;CONN_MAX_LIFETIME = 3s
+;;
+;; Database maximum number of open connections, default is 0 meaning no maximum
+;MAX_OPEN_CONNS = 0
 
-[indexer]
-; Issue indexer type, currently support: bleve, db or elasticsearch, default is bleve
-ISSUE_INDEXER_TYPE = bleve
-; Issue indexer connection string, available when ISSUE_INDEXER_TYPE is elasticsearch
-ISSUE_INDEXER_CONN_STR = http://elastic:changeme@localhost:9200
-; Issue indexer name, available when ISSUE_INDEXER_TYPE is elasticsearch
-ISSUE_INDEXER_NAME = gitea_issues
-; Issue indexer storage path, available when ISSUE_INDEXER_TYPE is bleve
-ISSUE_INDEXER_PATH = indexers/issues.bleve
-; Issue indexer queue, currently support: channel, levelqueue or redis, default is levelqueue
-ISSUE_INDEXER_QUEUE_TYPE = levelqueue
-; When ISSUE_INDEXER_QUEUE_TYPE is levelqueue, this will be the path where the queue will be saved.
-; This can be overridden by `ISSUE_INDEXER_QUEUE_CONN_STR`.
-; default is indexers/issues.queue
-ISSUE_INDEXER_QUEUE_DIR = indexers/issues.queue
-; When `ISSUE_INDEXER_QUEUE_TYPE` is `redis`, this will store the redis connection string.
-; When `ISSUE_INDEXER_QUEUE_TYPE` is `levelqueue`, this is a directory or additional options of
-; the form `leveldb://path/to/db?option=value&....`, and overrides `ISSUE_INDEXER_QUEUE_DIR`.
-ISSUE_INDEXER_QUEUE_CONN_STR = "addrs=127.0.0.1:6379 db=0"
-; Batch queue number, default is 20
-ISSUE_INDEXER_QUEUE_BATCH_NUMBER = 20
-; Timeout the indexer if it takes longer than this to start.
-; Set to zero to disable timeout.
-STARTUP_TIMEOUT = 30s
-
-; repo indexer by default disabled, since it uses a lot of disk space
-REPO_INDEXER_ENABLED = false
-; Code search engine type, could be `bleve` or `elasticsearch`.
-REPO_INDEXER_TYPE = bleve
-; Index file used for code search.
-REPO_INDEXER_PATH = indexers/repos.bleve
-; Code indexer connection string, available when `REPO_INDEXER_TYPE` is elasticsearch. i.e. http://elastic:changeme@localhost:9200
-REPO_INDEXER_CONN_STR =
-; Code indexer name, available when `REPO_INDEXER_TYPE` is elasticsearch
-REPO_INDEXER_NAME = gitea_codes
-
-UPDATE_BUFFER_LEN = 20
-MAX_FILE_SIZE = 1048576
-; A comma separated list of glob patterns (see https://github.com/gobwas/glob) to include
-; in the index; default is empty
-REPO_INDEXER_INCLUDE =
-; A comma separated list of glob patterns to exclude from the index; ; default is empty
-REPO_INDEXER_EXCLUDE =
-
-[queue]
-; Specific queues can be individually configured with [queue.name]. [queue] provides defaults
-;
-; General queue queue type, currently support: persistable-channel, channel, level, redis, dummy
-; default to persistable-channel
-TYPE = persistable-channel
-; data-dir for storing persistable queues and level queues, individual queues will be named by their type
-DATADIR = queues/
-; Default queue length before a channel queue will block
-LENGTH = 20
-; Batch size to send for batched queues
-BATCH_LENGTH = 20
-; Connection string for redis queues this will store the redis connection string.
-; When `TYPE` is `persistable-channel`, this provides a directory for the underlying leveldb
-; or additional options of the form `leveldb://path/to/db?option=value&....`, and will override `DATADIR`.
-CONN_STR = "addrs=127.0.0.1:6379 db=0"
-; Provides the suffix of the default redis/disk queue name - specific queues can be overridden within in their [queue.name] sections.
-QUEUE_NAME = "_queue"
-; Provides the suffix of the default redis/disk unique queue set name - specific queues can be overridden within in their [queue.name] sections.
-SET_NAME = "_unique"
-; If the queue cannot be created at startup - level queues may need a timeout at startup - wrap the queue:
-WRAP_IF_NECESSARY = true
-; Attempt to create the wrapped queue at max
-MAX_ATTEMPTS = 10
-; Timeout queue creation
-TIMEOUT = 15m30s
-; Create a pool with this many workers
-WORKERS = 1
-; Dynamically scale the worker pool to at this many workers
-MAX_WORKERS = 10
-; Add boost workers when the queue blocks for BLOCK_TIMEOUT
-BLOCK_TIMEOUT = 1s
-; Remove the boost workers after BOOST_TIMEOUT
-BOOST_TIMEOUT = 5m
-; During a boost add BOOST_WORKERS
-BOOST_WORKERS = 5
-
-[admin]
-; Disallow regular (non-admin) users from creating organizations.
-DISABLE_REGULAR_ORG_CREATION = false
-; Default configuration for email notifications for users (user configurable). Options: enabled, onmention, disabled
-DEFAULT_EMAIL_NOTIFICATIONS = enabled
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [security]
-; Whether the installer is disabled
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Whether the installer is disabled (set to true to disable the installer)
 INSTALL_LOCK = false
-; !!CHANGE THIS TO KEEP YOUR USER DATA SAFE!!
-SECRET_KEY = !#@FDEWREWR&*(
-; How long to remember that a user is logged in before requiring relogin (in days)
-LOGIN_REMEMBER_DAYS = 7
-COOKIE_USERNAME = gitea_awesome
-COOKIE_REMEMBER_NAME = gitea_incredible
-; Reverse proxy authentication header name of user name
-REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
-REVERSE_PROXY_AUTHENTICATION_EMAIL = X-WEBAUTH-EMAIL
-; Interpret X-Forwarded-For header or the X-Real-IP header and set this as the remote IP for the request
-REVERSE_PROXY_LIMIT = 1
-; List of IP addresses and networks separated by comma of trusted proxy servers. Use `*` to trust all.
-REVERSE_PROXY_TRUSTED_PROXIES = 127.0.0.0/8,::1/128
-; The minimum password length for new Users
-MIN_PASSWORD_LENGTH = 6
-; Set to true to allow users to import local server paths
-IMPORT_LOCAL_PATHS = false
-; Set to false to allow users with git hook privileges to create custom git hooks.
-; Custom git hooks can be used to perform arbitrary code execution on the host operating system.
-; This enables the users to access and modify this config file and the Gitea database and interrupt the Gitea service.
-; By modifying the Gitea database, users can gain Gitea administrator privileges.
-; It also enables them to access other resources available to the user on the operating system that is running the Gitea instance and perform arbitrary actions in the name of the Gitea OS user.
-; WARNING: This maybe harmful to you website or your operating system.
-DISABLE_GIT_HOOKS = true
-; Set to true to disable webhooks feature.
-DISABLE_WEBHOOKS = false
-; Set to false to allow pushes to gitea repositories despite having an incomplete environment - NOT RECOMMENDED
-ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
-;Comma separated list of character classes required to pass minimum complexity.
-;If left empty or no valid values are specified, the default is off (no checking)
-;Classes include "lower,upper,digit,spec"
-PASSWORD_COMPLEXITY = off
-; Password Hash algorithm, either "argon2", "pbkdf2", "scrypt" or "bcrypt"
-PASSWORD_HASH_ALGO = pbkdf2
-; Set false to allow JavaScript to read CSRF cookie
-CSRF_COOKIE_HTTP_ONLY = true
-; Validate against https://haveibeenpwned.com/Passwords to see if a password has been exposed
-PASSWORD_CHECK_PWN = false
+;;
+;; Global secret key that will be used - if blank will be regenerated.
+SECRET_KEY =
+;;
+;; Secret used to validate communication within Gitea binary.
+INTERNAL_TOKEN=
+;;
+;; Instead of defining internal token in the configuration, this configuration option can be used to give Gitea a path to a file that contains the internal token (example value: file:/etc/gitea/internal_token)
+;INTERNAL_TOKEN_URI = ;e.g. /etc/gitea/internal_token
+;;
+;; How long to remember that a user is logged in before requiring relogin (in days)
+;LOGIN_REMEMBER_DAYS = 7
+;;
+;; Name of the cookie used to store the current username.
+;COOKIE_USERNAME = gitea_awesome
+;;
+;; Name of cookie used to store authentication information.
+;COOKIE_REMEMBER_NAME = gitea_incredible
+;;
+;; Reverse proxy authentication header name of user name and email
+;REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
+;REVERSE_PROXY_AUTHENTICATION_EMAIL = X-WEBAUTH-EMAIL
+;;
+;; Interpret X-Forwarded-For header or the X-Real-IP header and set this as the remote IP for the request
+;REVERSE_PROXY_LIMIT = 1
+;;
+;; List of IP addresses and networks separated by comma of trusted proxy servers. Use `*` to trust all.
+;REVERSE_PROXY_TRUSTED_PROXIES = 127.0.0.0/8,::1/128
+;;
+;; The minimum password length for new Users
+;MIN_PASSWORD_LENGTH = 6
+;;
+;; Set to true to allow users to import local server paths
+;IMPORT_LOCAL_PATHS = false
+;;
+;; Set to false to allow users with git hook privileges to create custom git hooks.
+;; Custom git hooks can be used to perform arbitrary code execution on the host operating system.
+;; This enables the users to access and modify this config file and the Gitea database and interrupt the Gitea service.
+;; By modifying the Gitea database, users can gain Gitea administrator privileges.
+;; It also enables them to access other resources available to the user on the operating system that is running the Gitea instance and perform arbitrary actions in the name of the Gitea OS user.
+;; WARNING: This maybe harmful to you website or your operating system.
+;DISABLE_GIT_HOOKS = true
+;;
+;; Set to true to disable webhooks feature.
+;DISABLE_WEBHOOKS = false
+;;
+;; Set to false to allow pushes to gitea repositories despite having an incomplete environment - NOT RECOMMENDED
+;ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
+;;
+;;Comma separated list of character classes required to pass minimum complexity.
+;;If left empty or no valid values are specified, the default is off (no checking)
+;;Classes include "lower,upper,digit,spec"
+;PASSWORD_COMPLEXITY = off
+;;
+;; Password Hash algorithm, either "argon2", "pbkdf2", "scrypt" or "bcrypt"
+;PASSWORD_HASH_ALGO = pbkdf2
+;;
+;; Set false to allow JavaScript to read CSRF cookie
+;CSRF_COOKIE_HTTP_ONLY = true
+;;
+;; Validate against https://haveibeenpwned.com/Passwords to see if a password has been exposed
+;PASSWORD_CHECK_PWN = false
 
-[openid]
-;
-; OpenID is an open, standard and decentralized authentication protocol.
-; Your identity is the address of a webpage you provide, which describes
-; how to prove you are in control of that page.
-;
-; For more info: https://en.wikipedia.org/wiki/OpenID
-;
-; Current implementation supports OpenID-2.0
-;
-; Tested to work providers at the time of writing:
-;  - Any GNUSocial node (your.hostname.tld/username)
-;  - Any SimpleID provider (http://simpleid.koinic.net)
-;  - http://openid.org.cn/
-;  - openid.stackexchange.com
-;  - login.launchpad.net
-;  - <username>.livejournal.com
-;
-; Whether to allow signin in via OpenID
-ENABLE_OPENID_SIGNIN = true
-; Whether to allow registering via OpenID
-; Do not include to rely on rhw DISABLE_REGISTRATION setting
-;ENABLE_OPENID_SIGNUP = true
-; Allowed URI patterns (POSIX regexp).
-; Space separated.
-; Only these would be allowed if non-blank.
-; Example value: trusted.domain.org trusted.domain.net
-WHITELISTED_URIS =
-; Forbidden URI patterns (POSIX regexp).
-; Space separated.
-; Only used if WHITELISTED_URIS is blank.
-; Example value: loadaverage.org/badguy stackexchange.com/.*spammer
-BLACKLISTED_URIS =
-
-[oauth2_client]
-; Whether a new auto registered oauth2 user needs to confirm their email.
-; Do not include to use the REGISTER_EMAIL_CONFIRM setting from the `[service]` section.
-REGISTER_EMAIL_CONFIRM =
-; Scopes for the openid connect oauth2 provider (separated by space, the openid scope is implicitly added).
-; Typical values are profile and email.
-; For more information about the possible values see https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
-OPENID_CONNECT_SCOPES =
-; Automatically create user accounts for new oauth2 users.
-ENABLE_AUTO_REGISTRATION = false
-; The source of the username for new oauth2 accounts:
-; userid = use the userid / sub attribute
-; nickname = use the nickname attribute
-; email = use the username part of the email attribute
-USERNAME = nickname
-; Update avatar if available from oauth2 provider.
-; Update will be performed on each login.
-UPDATE_AVATAR = false
-; How to handle if an account / email already exists:
-; disabled = show an error
-; login = show an account linking login
-; auto = link directly with the account
-ACCOUNT_LINKING = login
-
-[service]
-; Time limit to confirm account/email registration
-ACTIVE_CODE_LIVE_MINUTES = 180
-; Time limit to perform the reset of a forgotten password
-RESET_PASSWD_CODE_LIVE_MINUTES = 180
-; Whether a new user needs to confirm their email when registering.
-REGISTER_EMAIL_CONFIRM = false
-; Whether a new user needs to be confirmed manually after registration. (Requires `REGISTER_EMAIL_CONFIRM` to be disabled.)
-REGISTER_MANUAL_CONFIRM = false
-; List of domain names that are allowed to be used to register on a Gitea instance
-; gitea.io,example.com
-EMAIL_DOMAIN_WHITELIST =
-; Comma-separated list of domain names that are not allowed to be used to register on a Gitea instance
-EMAIL_DOMAIN_BLOCKLIST =
-; Disallow registration, only allow admins to create accounts.
-DISABLE_REGISTRATION = false
-; Allow registration only using gitea itself, it works only when DISABLE_REGISTRATION is false
-ALLOW_ONLY_INTERNAL_REGISTRATION = false
-; Allow registration only using third-party services, it works only when DISABLE_REGISTRATION is false
-ALLOW_ONLY_EXTERNAL_REGISTRATION = false
-; User must sign in to view anything.
-REQUIRE_SIGNIN_VIEW = false
-; Mail notification
-ENABLE_NOTIFY_MAIL = false
-; This setting enables gitea to be signed in with HTTP BASIC Authentication using the user's password
-; If you set this to false you will not be able to access the tokens endpoints on the API with your password
-; Please note that setting this to false will not disable OAuth Basic or Basic authentication using a token
-ENABLE_BASIC_AUTHENTICATION = true
-; More detail: https://github.com/gogits/gogs/issues/165
-ENABLE_REVERSE_PROXY_AUTHENTICATION = false
-ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
-ENABLE_REVERSE_PROXY_EMAIL = false
-; Enable captcha validation for registration
-ENABLE_CAPTCHA = false
-; Type of captcha you want to use. Options: image, recaptcha, hcaptcha
-CAPTCHA_TYPE = image
-; Enable recaptcha to use Google's recaptcha service
-; Go to https://www.google.com/recaptcha/admin to sign up for a key
-RECAPTCHA_SECRET =
-RECAPTCHA_SITEKEY =
-; For hCaptcha, create an account at https://accounts.hcaptcha.com/login to get your keys
-HCAPTCHA_SECRET =
-HCAPTCHA_SITEKEY =
-; Change this to use recaptcha.net or other recaptcha service
-RECAPTCHA_URL = https://www.google.com/recaptcha/
-; Default value for KeepEmailPrivate
-; Each new user will get the value of this setting copied into their profile
-DEFAULT_KEEP_EMAIL_PRIVATE = false
-; Default value for AllowCreateOrganization
-; Every new user will have rights set to create organizations depending on this setting
-DEFAULT_ALLOW_CREATE_ORGANIZATION = true
-; Either "public", "limited" or "private", default is "public"
-; Limited is for signed user only
-; Private is only for member of the organization
-; Public is for everyone
-DEFAULT_ORG_VISIBILITY = public
-; Default value for DefaultOrgMemberVisible
-; True will make the membership of the users visible when added to the organisation
-DEFAULT_ORG_MEMBER_VISIBLE = false
-; Default value for EnableDependencies
-; Repositories will use dependencies by default depending on this setting
-DEFAULT_ENABLE_DEPENDENCIES = true
-; Dependencies can be added from any repository where the user is granted access or only from the current repository depending on this setting.
-ALLOW_CROSS_REPOSITORY_DEPENDENCIES = true
-; Enable heatmap on users profiles.
-ENABLE_USER_HEATMAP = true
-; Enable Timetracking
-ENABLE_TIMETRACKING = true
-; Default value for EnableTimetracking
-; Repositories will use timetracking by default depending on this setting
-DEFAULT_ENABLE_TIMETRACKING = true
-; Default value for AllowOnlyContributorsToTrackTime
-; Only users with write permissions can track time if this is true
-DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME = true
-; Value for the domain part of the user's email address in the git log if user
-; has set KeepEmailPrivate to true. The user's email will be replaced with a
-; concatenation of the user name in lower case, "@" and NO_REPLY_ADDRESS. Default
-; value is "noreply." + DOMAIN, where DOMAIN resolves to the value from server.DOMAIN
-; Note: do not use the <DOMAIN> notation below
-NO_REPLY_ADDRESS = noreply.<DOMAIN>
-; Show Registration button
-SHOW_REGISTRATION_BUTTON = true
-; Show milestones dashboard page - a view of all the user's milestones
-SHOW_MILESTONES_DASHBOARD_PAGE = true
-; Default value for AutoWatchNewRepos
-; When adding a repo to a team or creating a new repo all team members will watch the
-; repo automatically if enabled
-AUTO_WATCH_NEW_REPOS = true
-; Default value for AutoWatchOnChanges
-; Make the user watch a repository When they commit for the first time
-AUTO_WATCH_ON_CHANGES = false
-; Minimum amount of time a user must exist before comments are kept when the user is deleted.
-USER_DELETE_WITH_COMMENTS_MAX_TIME = 0
-
-[webhook]
-; Hook task queue length, increase if webhook shooting starts hanging
-QUEUE_LENGTH = 1000
-; Deliver timeout in seconds
-DELIVER_TIMEOUT = 5
-; Allow insecure certification
-SKIP_TLS_VERIFY = false
-; Number of history information in each page
-PAGING_NUM = 10
-; Proxy server URL, support http://, https//, socks://, blank will follow environment http_proxy/https_proxy
-PROXY_URL =
-; Comma separated list of host names requiring proxy. Glob patterns (*) are accepted; use ** to match all hosts.
-PROXY_HOSTS =
-
-[mailer]
-ENABLED = false
-; Buffer length of channel, keep it as it is if you don't know what it is.
-SEND_BUFFER_LEN = 100
-; Prefix displayed before subject in mail
-SUBJECT_PREFIX =
-; Mail server
-; Gmail: smtp.gmail.com:587
-; QQ: smtp.qq.com:465
-; Using STARTTLS on port 587 is recommended per RFC 6409.
-; Note, if the port ends with "465", SMTPS will be used.
-HOST =
-; Disable HELO operation when hostnames are different.
-DISABLE_HELO =
-; Custom hostname for HELO operation, if no value is provided, one is retrieved from system.
-HELO_HOSTNAME =
-; Whether or not to skip verification of certificates; `true` to disable verification. This option is unsafe. Consider adding the certificate to the system trust store instead.
-SKIP_VERIFY = false
-; Use client certificate
-USE_CERTIFICATE = false
-CERT_FILE = custom/mailer/cert.pem
-KEY_FILE = custom/mailer/key.pem
-; Should SMTP connect with TLS, (if port ends with 465 TLS will always be used.)
-; If this is false but STARTTLS is supported the connection will be upgraded to TLS opportunistically.
-IS_TLS_ENABLED = false
-; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
-FROM =
-; Mailer user name and password
-; Please Note: Authentication is only supported when the SMTP server communication is encrypted with TLS (this can be via STARTTLS) or `HOST=localhost`.
-USER =
-; Use PASSWD = `your password` for quoting if you use special characters in the password.
-PASSWD =
-; Send mails as plain text
-SEND_AS_PLAIN_TEXT = false
-; Set Mailer Type (either SMTP, sendmail or dummy to just send to the log)
-MAILER_TYPE = smtp
-; Specify an alternative sendmail binary
-SENDMAIL_PATH = sendmail
-; Specify any extra sendmail arguments
-SENDMAIL_ARGS =
-; Timeout for Sendmail
-SENDMAIL_TIMEOUT = 5m
-
-[cache]
-; if the cache enabled
-ENABLED = true
-; Either "memory", "redis", or "memcache", default is "memory"
-ADAPTER = memory
-; For "memory" only, GC interval in seconds, default is 60
-INTERVAL = 60
-; For "redis" and "memcache", connection host address
-; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
-; memcache: `127.0.0.1:11211`
-HOST =
-; Time to keep items in cache if not used, default is 16 hours.
-; Setting it to 0 disables caching
-ITEM_TTL = 16h
-
-; Last commit cache
-[cache.last_commit]
-; if the cache enabled
-ENABLED = true
-; Time to keep items in cache if not used, default is 8760 hours.
-; Setting it to 0 disables caching
-ITEM_TTL = 8760h
-; Only enable the cache when repository's commits count great than
-COMMITS_COUNT = 1000
-
-[session]
-; Either "memory", "file", or "redis", default is "memory"
-PROVIDER = memory
-; Provider config options
-; memory: doesn't have any config yet
-; file: session file path, e.g. `data/sessions`
-; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
-; mysql: go-sql-driver/mysql dsn config string, e.g. `root:password@/session_table`
-PROVIDER_CONFIG = data/sessions
-; Session cookie name
-COOKIE_NAME = i_like_gitea
-; If you use session in https only, default is false
-COOKIE_SECURE = false
-; Session GC time interval in seconds, default is 86400 (1 day)
-GC_INTERVAL_TIME = 86400
-; Session life time in seconds, default is 86400 (1 day)
-SESSION_LIFE_TIME = 86400
-; SameSite settings. Either "none", "lax", or "strict"
-SAME_SITE=lax
-
-[picture]
-AVATAR_UPLOAD_PATH = data/avatars
-REPOSITORY_AVATAR_UPLOAD_PATH = data/repo-avatars
-; How Gitea deals with missing repository avatars
-; none = no avatar will be displayed; random = random avatar will be displayed; image = default image will be used
-REPOSITORY_AVATAR_FALLBACK = none
-REPOSITORY_AVATAR_FALLBACK_IMAGE = /img/repo_default.png
-; Max Width and Height of uploaded avatars.
-; This is to limit the amount of RAM used when resizing the image.
-AVATAR_MAX_WIDTH = 4096
-AVATAR_MAX_HEIGHT = 3072
-; Maximum allowed file size for uploaded avatars.
-; This is to limit the amount of RAM used when resizing the image.
-AVATAR_MAX_FILE_SIZE = 1048576
-; Chinese users can choose "duoshuo"
-; or a custom avatar source, like: http://cn.gravatar.com/avatar/
-GRAVATAR_SOURCE = gravatar
-; This value will always be true in offline mode.
-DISABLE_GRAVATAR = false
-; Federated avatar lookup uses DNS to discover avatar associated
-; with emails, see https://www.libravatar.org
-; This value will always be false in offline mode or when Gravatar is disabled.
-ENABLE_FEDERATED_AVATAR = false
-
-[attachment]
-; Whether issue and pull request attachments are enabled. Defaults to `true`
-ENABLED = true
-; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
-ALLOWED_TYPES = .docx,.gif,.gz,.jpeg,.jpg,.log,.pdf,.png,.pptx,.txt,.xlsx,.zip
-; Max size of each file. Defaults to 4MB
-MAX_SIZE = 4
-; Max number of files per upload. Defaults to 5
-MAX_FILES = 5
-; Storage type for attachments, `local` for local disk or `minio` for s3 compatible
-; object storage service, default is `local`.
-STORAGE_TYPE = local
-; Allows the storage driver to redirect to authenticated URLs to serve files directly
-; Currently, only `minio` is supported.
-SERVE_DIRECT = false
-; Path for attachments. Defaults to `data/attachments` only available when STORAGE_TYPE is `local`
-PATH = data/attachments
-; Minio endpoint to connect only available when STORAGE_TYPE is `minio`
-MINIO_ENDPOINT = localhost:9000
-; Minio accessKeyID to connect only available when STORAGE_TYPE is `minio`
-MINIO_ACCESS_KEY_ID =
-; Minio secretAccessKey to connect only available when STORAGE_TYPE is `minio`
-MINIO_SECRET_ACCESS_KEY =
-; Minio bucket to store the attachments only available when STORAGE_TYPE is `minio`
-MINIO_BUCKET = gitea
-; Minio location to create bucket only available when STORAGE_TYPE is `minio`
-MINIO_LOCATION = us-east-1
-; Minio base path on the bucket only available when STORAGE_TYPE is `minio`
-MINIO_BASE_PATH = attachments/
-; Minio enabled ssl only available when STORAGE_TYPE is `minio`
-MINIO_USE_SSL = false
-
-[time]
-; Specifies the format for fully outputted dates. Defaults to RFC1123
-; Special supported values are ANSIC, UnixDate, RubyDate, RFC822, RFC822Z, RFC850, RFC1123, RFC1123Z, RFC3339, RFC3339Nano, Kitchen, Stamp, StampMilli, StampMicro and StampNano
-; For more information about the format see http://golang.org/pkg/time/#pkg-constants
-FORMAT =
-; Location the UI time display i.e. Asia/Shanghai
-; Empty means server's location setting
-DEFAULT_UI_LOCATION =
-
-[log]
-ROOT_PATH =
-; Either "console", "file", "conn", "smtp" or "database", default is "console"
-; Use comma to separate multiple modes, e.g. "console, file"
-MODE = console
-; Buffer length of the channel, keep it as it is if you don't know what it is.
-BUFFER_LEN = 10000
-; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
-ROUTER_LOG_LEVEL = Info
-ROUTER = console
-ENABLE_ACCESS_LOG = false
-ACCESS_LOG_TEMPLATE = {{.Ctx.RemoteAddr}} - {{.Identity}} {{.Start.Format "[02/Jan/2006:15:04:05 -0700]" }} "{{.Ctx.Req.Method}} {{.Ctx.Req.URL.RequestURI}} {{.Ctx.Req.Proto}}" {{.ResponseWriter.Status}} {{.ResponseWriter.Size}} "{{.Ctx.Req.Referer}}\" \"{{.Ctx.Req.UserAgent}}"
-ACCESS = file
-; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
-LEVEL = Info
-; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "None"
-STACKTRACE_LEVEL = None
-
-; Generic log modes
-[log.x]
-FLAGS = stdflags
-EXPRESSION =
-PREFIX =
-COLORIZE = false
-
-; For "console" mode only
-[log.console]
-LEVEL =
-STDERR = false
-
-; For "file" mode only
-[log.file]
-LEVEL =
-; Set the file_name for the logger. If this is a relative path this
-; will be relative to ROOT_PATH
-FILE_NAME =
-; This enables automated log rotate(switch of following options), default is true
-LOG_ROTATE = true
-; Max size shift of a single file, default is 28 means 1 << 28, 256MB
-MAX_SIZE_SHIFT = 28
-; Segment log daily, default is true
-DAILY_ROTATE = true
-; delete the log file after n days, default is 7
-MAX_DAYS = 7
-; compress logs with gzip
-COMPRESS = true
-; compression level see godoc for compress/gzip
-COMPRESSION_LEVEL = -1
-
-; For "conn" mode only
-[log.conn]
-LEVEL =
-; Reconnect host for every single message, default is false
-RECONNECT_ON_MSG = false
-; Try to reconnect when connection is lost, default is false
-RECONNECT = false
-; Either "tcp", "unix" or "udp", default is "tcp"
-PROTOCOL = tcp
-; Host address
-ADDR =
-
-; For "smtp" mode only
-[log.smtp]
-LEVEL =
-; Name displayed in mail title, default is "Diagnostic message from server"
-SUBJECT = Diagnostic message from server
-; Mail server
-HOST =
-; Mailer user name and password
-USER =
-; Use PASSWD = `your password` for quoting if you use special characters in the password.
-PASSWD =
-; Receivers, can be one or more, e.g. 1@example.com,2@example.com
-RECEIVERS =
-
-[cron]
-; Enable running all cron tasks periodically with default settings.
-ENABLED = false
-; Run cron tasks when Gitea starts.
-RUN_AT_START = false
-
-; Basic cron tasks - enabled by default
-
-; Clean up old repository archives
-[cron.archive_cleanup]
-; Whether to enable the job
-ENABLED = true
-; Whether to always run at least once at start up time (if ENABLED)
-RUN_AT_START = true
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-; Time interval for job to run
-SCHEDULE = @every 24h
-; Archives created more than OLDER_THAN ago are subject to deletion
-OLDER_THAN = 24h
-
-; Update mirrors
-[cron.update_mirrors]
-SCHEDULE = @every 10m
-; Enable running Update mirrors task periodically.
-ENABLED = true
-; Run Update mirrors task when Gitea starts.
-RUN_AT_START = false
-; Notice if not success
-NO_SUCCESS_NOTICE = true
-
-; Repository health check
-[cron.repo_health_check]
-SCHEDULE = @every 24h
-; Enable running Repository health check task periodically.
-ENABLED = true
-; Run Repository health check task when Gitea starts.
-RUN_AT_START = false
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-TIMEOUT = 60s
-; Arguments for command 'git fsck', e.g. "--unreachable --tags"
-; see more on http://git-scm.com/docs/git-fsck
-ARGS =
-
-; Check repository statistics
-[cron.check_repo_stats]
-; Enable running check repository statistics task periodically.
-ENABLED = true
-; Run check repository statistics task when Gitea starts.
-RUN_AT_START = true
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 24h
-
-[cron.update_migration_poster_id]
-; Update migrated repositories' issues and comments' posterid, it will always attempt synchronization when the instance starts.
-ENABLED = true
-; Update migrated repositories' issues and comments' posterid when starting server (default true)
-RUN_AT_START = true
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-; Interval as a duration between each synchronization. (default every 24h)
-SCHEDULE = @every 24h
-
-; Synchronize external user data (only LDAP user synchronization is supported)
-[cron.sync_external_users]
-ENABLED = true
-; Synchronize external user data when starting server (default false)
-RUN_AT_START = false
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-; Interval as a duration between each synchronization (default every 24h)
-SCHEDULE = @every 24h
-; Create new users, update existing user data and disable users that are not in external source anymore (default)
-;   or only create new users if UPDATE_EXISTING is set to false
-UPDATE_EXISTING = true
-
-; Clean-up deleted branches
-[cron.deleted_branches_cleanup]
-ENABLED = true
-; Clean-up deleted branches when starting server (default true)
-RUN_AT_START = true
-; Notice if not success
-NO_SUCCESS_NOTICE = false
-; Interval as a duration between each synchronization (default every 24h)
-SCHEDULE = @every 24h
-; deleted branches than OLDER_THAN ago are subject to deletion
-OLDER_THAN = 24h
-
-; Cleanup hook_task table
-[cron.cleanup_hook_task_table]
-; Whether to enable the job
-ENABLED = true
-; Whether to always run at start up time (if ENABLED)
-RUN_AT_START = false
-; Time interval for job to run
-SCHEDULE = @every 24h
-; OlderThan or PerWebhook. How the records are removed, either by age (i.e. how long ago hook_task record was delivered) or by the number to keep per webhook (i.e. keep most recent x deliveries per webhook).
-CLEANUP_TYPE = OlderThan
-; If CLEANUP_TYPE is set to OlderThan, then any delivered hook_task records older than this expression will be deleted.
-OLDER_THAN = 168h
-; If CLEANUP_TYPE is set to PerWebhook, this is number of hook_task records to keep for a webhook (i.e. keep the most recent x deliveries).
-NUMBER_TO_KEEP = 10
-
-; Extended cron task - not enabled by default
-
-; Delete all unactivated accounts
-[cron.delete_inactive_accounts]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @annually
-OLDER_THAN = 168h
-
-; Delete all repository archives
-[cron.delete_repo_archives]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @annually
-
-; Garbage collect all repositories
-[cron.git_gc_repos]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-TIMEOUT = 60s
-; Arguments for command 'git gc'
-; The default value is same with [git] -> GC_ARGS
-ARGS =
-
-; Update the '.ssh/authorized_keys' file with Gitea SSH keys
-[cron.resync_all_sshkeys]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-
-; Resynchronize pre-receive, update and post-receive hooks of all repositories.
-[cron.resync_all_hooks]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-
-; Reinitialize all missing Git repositories for which records exist
-[cron.reinit_missing_repos]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-
-; Delete all repositories missing their Git files
-[cron.delete_missing_repos]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-
-; Delete generated repository avatars
-[cron.delete_generated_repository_avatars]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 72h
-
-; Delete all old actions from database
-[cron.delete_old_actions]
-ENABLED = false
-RUN_AT_START = false
-NO_SUCCESS_NOTICE = false
-SCHEDULE = @every 168h
-OLDER_THAN = 8760h
-
-[git]
-; The path of git executable. If empty, Gitea searches through the PATH environment.
-PATH =
-; Disables highlight of added and removed changes
-DISABLE_DIFF_HIGHLIGHT = false
-; Max number of lines allowed in a single file in diff view
-MAX_GIT_DIFF_LINES = 1000
-; Max number of allowed characters in a line in diff view
-MAX_GIT_DIFF_LINE_CHARACTERS = 5000
-; Max number of files shown in diff view
-MAX_GIT_DIFF_FILES = 100
-; Set the default commits range size
-COMMITS_RANGE_SIZE = 50
-; Set the default branches range size
-BRANCHES_RANGE_SIZE = 20
-; Arguments for command 'git gc', e.g. "--aggressive --auto"
-; see more on http://git-scm.com/docs/git-gc/
-GC_ARGS =
-; If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
-ENABLE_AUTO_GIT_WIRE_PROTOCOL = true
-; Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
-PULL_REQUEST_PUSH_MESSAGE = true
-
-; Operation timeout in seconds
-[git.timeout]
-DEFAULT = 360
-MIGRATE = 600
-MIRROR = 300
-CLONE = 300
-PULL = 300
-GC = 60
-
-[mirror]
-; Default interval as a duration between each check
-DEFAULT_INTERVAL = 8h
-; Min interval as a duration must be > 1m
-MIN_INTERVAL = 10m
-
-[api]
-; Enables Swagger. True or false; default is true.
-ENABLE_SWAGGER = true
-; Max number of items in a page
-MAX_RESPONSE_ITEMS = 50
-; Default paging number of api
-DEFAULT_PAGING_NUM = 30
-; Default and maximum number of items per page for git trees api
-DEFAULT_GIT_TREES_PER_PAGE = 1000
-; Default size of a blob returned by the blobs API (default is 10MiB)
-DEFAULT_MAX_BLOB_SIZE = 10485760
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [oauth2]
-; Enables OAuth2 provider
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Enables OAuth2 provider
 ENABLE = true
-; Lifetime of an OAuth2 access token in seconds
-ACCESS_TOKEN_EXPIRATION_TIME = 3600
-; Lifetime of an OAuth2 refresh token in hours
-REFRESH_TOKEN_EXPIRATION_TIME = 730
-; Check if refresh token got already used
-INVALIDATE_REFRESH_TOKENS = false
-; OAuth2 authentication secret for access and refresh tokens, change this yourself to a unique string. CLI generate option is helpful in this case. https://docs.gitea.io/en-us/command-line/#generate
+;;
+;; OAuth2 authentication secret for access and refresh tokens, change this yourself to a unique string. CLI generate option is helpful in this case. https://docs.gitea.io/en-us/command-line/#generate
 JWT_SECRET =
-; Maximum length of oauth2 token/cookie stored on server
-MAX_TOKEN_LENGTH = 32767
+;;
+;; Lifetime of an OAuth2 access token in seconds
+;ACCESS_TOKEN_EXPIRATION_TIME = 3600
+;;
+;; Lifetime of an OAuth2 refresh token in hours
+;REFRESH_TOKEN_EXPIRATION_TIME = 730
+;;
+;; Check if refresh token got already used
+;INVALIDATE_REFRESH_TOKENS = false
+;;
+;; Maximum length of oauth2 token/cookie stored on server
+;MAX_TOKEN_LENGTH = 32767
 
-[i18n]
-LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,Português de Portugal,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [U2F]
-; NOTE: THE DEFAULT VALUES HERE WILL NEED TO BE CHANGED
-; Two Factor authentication with security keys
-; https://developers.yubico.com/U2F/App_ID.html
-;APP_ID = http://localhost:3000/
-; Comma separated list of trusted facets
-;TRUSTED_FACETS = http://localhost:3000/
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; NOTE: THE DEFAULT VALUES HERE WILL NEED TO BE CHANGED
+;; Two Factor authentication with security keys
+;; https://developers.yubico.com/U2F/App_ID.html
+APP_ID = ; e.g. http://localhost:3000/
+;; Comma separated list of trusted facets
+TRUSTED_FACETS = ; e.g. http://localhost:3000/
 
-; Extension mapping to highlight class
-; e.g. .toml=ini
-[highlight.mapping]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[log]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Root path for the log files - defaults to %(GITEA_WORK_DIR)/log
+;ROOT_PATH =
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Main Logger
+;;
+;; Either "console", "file", "conn", "smtp" or "database", default is "console"
+;; Use comma to separate multiple modes, e.g. "console, file"
+MODE = console
+;;
+;; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
+LEVEL = Info
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Router Logger
+;;
+;; Switch off the router log
+;DISABLE_ROUTER_LOG= ; false
+;;
+;; Set the log "modes" for the router log (if file is set the log file will default to router.log)
+ROUTER = console
+;;
+;; The level at which the router logs
+;ROUTER_LOG_LEVEL = Info
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Access Logger (Creates log in NCSA common log format)
+;;
+;ENABLE_ACCESS_LOG = false
+;; Set the log "modes" for the access log (if file is set the log file will default to access.log)
+;ACCESS = file
+;;
+;; Sets the template used to create the access log.
+;ACCESS_LOG_TEMPLATE = {{.Ctx.RemoteAddr}} - {{.Identity}} {{.Start.Format "[02/Jan/2006:15:04:05 -0700]" }} "{{.Ctx.Req.Method}} {{.Ctx.Req.URL.RequestURI}} {{.Ctx.Req.Proto}}" {{.ResponseWriter.Status}} {{.ResponseWriter.Size}} "{{.Ctx.Req.Referer}}\" \"{{.Ctx.Req.UserAgent}}"
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Other Settings
+;;
+;; Print Stacktraces with logs. (Rarely helpful.) Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "None"
+;STACKTRACE_LEVEL = None
+;;
+;; Buffer length of the channel, keep it as it is if you don't know what it is.
+;BUFFER_LEN = 10000
 
-[other]
-SHOW_FOOTER_BRANDING = false
-; Show version information about Gitea and Go in the footer
-SHOW_FOOTER_VERSION = true
-; Show template execution time in the footer
-SHOW_FOOTER_TEMPLATE_LOAD_TIME = true
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Creating specific log configuration
+;;
+;; You can set specific configuration for individual modes and subloggers
+;;
+;; Configuration available to all log modes/subloggers
+;LEVEL=
+;FLAGS = stdflags
+;EXPRESSION =
+;PREFIX =
+;COLORIZE = false
+;;
+;; For "console" mode only
+;STDERR = false
+;;
+;; For "file" mode only
+;LEVEL =
+;; Set the file_name for the logger. If this is a relative path this
+;; will be relative to ROOT_PATH
+;FILE_NAME =
+;; This enables automated log rotate(switch of following options), default is true
+;LOG_ROTATE = true
+;; Max size shift of a single file, default is 28 means 1 << 28, 256MB
+;MAX_SIZE_SHIFT = 28
+;; Segment log daily, default is true
+;DAILY_ROTATE = true
+;; delete the log file after n days, default is 7
+;MAX_DAYS = 7
+;; compress logs with gzip
+;COMPRESS = true
+;; compression level see godoc for compress/gzip
+;COMPRESSION_LEVEL = -1
+;
+;; For "conn" mode only
+;LEVEL =
+;; Reconnect host for every single message, default is false
+;RECONNECT_ON_MSG = false
+;; Try to reconnect when connection is lost, default is false
+;RECONNECT = false
+;; Either "tcp", "unix" or "udp", default is "tcp"
+;PROTOCOL = tcp
+;; Host address
+;ADDR =
+;
+;; For "smtp" mode only
+;LEVEL =
+;; Name displayed in mail title, default is "Diagnostic message from server"
+;SUBJECT = Diagnostic message from server
+;; Mail server
+;HOST =
+;; Mailer user name and password
+;USER =
+;; Use PASSWD = `your password` for quoting if you use special characters in the password.
+;PASSWD =
+;; Receivers, can be one or more, e.g. 1@example.com,2@example.com
+;RECEIVERS =
 
-[markup.sanitizer.1]
-; The following keys can appear once to define a sanitation policy rule.
-; This section can appear multiple times by adding a unique alphanumeric suffix to define multiple rules.
-; e.g., [markup.sanitizer.1] -> [markup.sanitizer.2] -> [markup.sanitizer.TeX]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[git]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; The path of git executable. If empty, Gitea searches through the PATH environment.
+PATH =
+;;
+;; Disables highlight of added and removed changes
+;DISABLE_DIFF_HIGHLIGHT = false
+;;
+;; Max number of lines allowed in a single file in diff view
+;MAX_GIT_DIFF_LINES = 1000
+;;
+;; Max number of allowed characters in a line in diff view
+;MAX_GIT_DIFF_LINE_CHARACTERS = 5000
+;;
+;; Max number of files shown in diff view
+;MAX_GIT_DIFF_FILES = 100
+;;
+;; Set the default commits range size
+;COMMITS_RANGE_SIZE = 50
+;;
+;; Set the default branches range size
+;BRANCHES_RANGE_SIZE = 20
+;;
+;; Arguments for command 'git gc', e.g. "--aggressive --auto"
+;; see more on http://git-scm.com/docs/git-gc/
+;GC_ARGS =
+;;
+;; If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
+;ENABLE_AUTO_GIT_WIRE_PROTOCOL = true
+;;
+;; Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
+;PULL_REQUEST_PUSH_MESSAGE = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[service]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Time limit to confirm account/email registration
+;ACTIVE_CODE_LIVE_MINUTES = 180
+;;
+;; Time limit to perform the reset of a forgotten password
+;RESET_PASSWD_CODE_LIVE_MINUTES = 180
+;;
+;; Whether a new user needs to confirm their email when registering.
+;REGISTER_EMAIL_CONFIRM = false
+;;
+;; Whether a new user needs to be confirmed manually after registration. (Requires `REGISTER_EMAIL_CONFIRM` to be disabled.)
+;REGISTER_MANUAL_CONFIRM = false
+;;
+;; List of domain names that are allowed to be used to register on a Gitea instance
+;; gitea.io,example.com
+;EMAIL_DOMAIN_WHITELIST =
+;;
+;; Comma-separated list of domain names that are not allowed to be used to register on a Gitea instance
+;EMAIL_DOMAIN_BLOCKLIST =
+;;
+;; Disallow registration, only allow admins to create accounts.
+;DISABLE_REGISTRATION = false
+;;
+;; Allow registration only using gitea itself, it works only when DISABLE_REGISTRATION is false
+;ALLOW_ONLY_INTERNAL_REGISTRATION = false
+;;
+;; Allow registration only using third-party services, it works only when DISABLE_REGISTRATION is false
+;ALLOW_ONLY_EXTERNAL_REGISTRATION = false
+;;
+;; User must sign in to view anything.
+;REQUIRE_SIGNIN_VIEW = false
+;;
+;; Mail notification
+;ENABLE_NOTIFY_MAIL = false
+;;
+;; This setting enables gitea to be signed in with HTTP BASIC Authentication using the user's password
+;; If you set this to false you will not be able to access the tokens endpoints on the API with your password
+;; Please note that setting this to false will not disable OAuth Basic or Basic authentication using a token
+;ENABLE_BASIC_AUTHENTICATION = true
+;;
+;; More detail: https://github.com/gogits/gogs/issues/165
+;ENABLE_REVERSE_PROXY_AUTHENTICATION = false
+;ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
+;ENABLE_REVERSE_PROXY_EMAIL = false
+;;
+;; Enable captcha validation for registration
+;ENABLE_CAPTCHA = false
+;;
+;; Type of captcha you want to use. Options: image, recaptcha, hcaptcha
+;CAPTCHA_TYPE = image
+;;
+;; Enable recaptcha to use Google's recaptcha service
+;; Go to https://www.google.com/recaptcha/admin to sign up for a key
+;RECAPTCHA_SECRET =
+;RECAPTCHA_SITEKEY =
+;;
+;; For hCaptcha, create an account at https://accounts.hcaptcha.com/login to get your keys
+;HCAPTCHA_SECRET =
+;HCAPTCHA_SITEKEY =
+;;
+;; Change this to use recaptcha.net or other recaptcha service
+;RECAPTCHA_URL = https://www.google.com/recaptcha/
+;;
+;; Default value for KeepEmailPrivate
+;; Each new user will get the value of this setting copied into their profile
+;DEFAULT_KEEP_EMAIL_PRIVATE = false
+;;
+;; Default value for AllowCreateOrganization
+;; Every new user will have rights set to create organizations depending on this setting
+;DEFAULT_ALLOW_CREATE_ORGANIZATION = true
+;;
+;; Either "public", "limited" or "private", default is "public"
+;; Limited is for signed user only
+;; Private is only for member of the organization
+;; Public is for everyone
+;DEFAULT_ORG_VISIBILITY = public
+;;
+;; Default value for DefaultOrgMemberVisible
+;; True will make the membership of the users visible when added to the organisation
+;DEFAULT_ORG_MEMBER_VISIBLE = false
+;;
+;; Default value for EnableDependencies
+;; Repositories will use dependencies by default depending on this setting
+;DEFAULT_ENABLE_DEPENDENCIES = true
+;;
+;; Dependencies can be added from any repository where the user is granted access or only from the current repository depending on this setting.
+;ALLOW_CROSS_REPOSITORY_DEPENDENCIES = true
+;;
+;; Enable heatmap on users profiles.
+;ENABLE_USER_HEATMAP = true
+;;
+;; Enable Timetracking
+;ENABLE_TIMETRACKING = true
+;;
+;; Default value for EnableTimetracking
+;; Repositories will use timetracking by default depending on this setting
+;DEFAULT_ENABLE_TIMETRACKING = true
+;;
+;; Default value for AllowOnlyContributorsToTrackTime
+;; Only users with write permissions can track time if this is true
+;DEFAULT_ALLOW_ONLY_CONTRIBUTORS_TO_TRACK_TIME = true
+;;
+;; Value for the domain part of the user's email address in the git log if user
+;; has set KeepEmailPrivate to true. The user's email will be replaced with a
+;; concatenation of the user name in lower case, "@" and NO_REPLY_ADDRESS. Default
+;; value is "noreply." + DOMAIN, where DOMAIN resolves to the value from server.DOMAIN
+;; Note: do not use the <DOMAIN> notation below
+;NO_REPLY_ADDRESS = ; noreply.<DOMAIN>
+;;
+;; Show Registration button
+;SHOW_REGISTRATION_BUTTON = true
+;;
+;; Show milestones dashboard page - a view of all the user's milestones
+;SHOW_MILESTONES_DASHBOARD_PAGE = true
+;;
+;; Default value for AutoWatchNewRepos
+;; When adding a repo to a team or creating a new repo all team members will watch the
+;; repo automatically if enabled
+;AUTO_WATCH_NEW_REPOS = true
+;;
+;; Default value for AutoWatchOnChanges
+;; Make the user watch a repository When they commit for the first time
+;AUTO_WATCH_ON_CHANGES = false
+;;
+;; Minimum amount of time a user must exist before comments are kept when the user is deleted.
+;USER_DELETE_WITH_COMMENTS_MAX_TIME = 0
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Other Settings
+;;
+;; Uncomment the [section.header] if you wish to
+;; set the below settings.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Root path for storing all repository data. It must be an absolute path. By default, it is stored in a sub-directory of `APP_DATA_PATH`.
+;ROOT =
+;;
+;; The script type this server supports. Usually this is `bash`, but some users report that only `sh` is available.
+;SCRIPT_TYPE = bash
+;;
+;; DETECTED_CHARSETS_ORDER tie-break order for detected charsets.
+;; If the charsets have equal confidence, tie-breaking will be done by order in this list
+;; with charsets earlier in the list chosen in preference to those later.
+;; Adding "defaults" will place the unused charsets at that position.
+;DETECTED_CHARSETS_ORDER = UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr
+;;
+;; Default ANSI charset to override non-UTF-8 charsets to
+;ANSI_CHARSET =
+;;
+;; Force every new repository to be private
+;FORCE_PRIVATE = false
+;;
+;; Default privacy setting when creating a new repository, allowed values: last, private, public. Default is last which means the last setting used.
+;DEFAULT_PRIVATE = last
+;;
+;; Default private when using push-to-create
+;DEFAULT_PUSH_CREATE_PRIVATE = true
+;;
+;; Global limit of repositories per user, applied at creation time. -1 means no limit
+;MAX_CREATION_LIMIT = -1
+;;
+;; Mirror sync queue length, increase if mirror syncing starts hanging
+;MIRROR_QUEUE_LENGTH = 1000
+;;
+;; Patch test queue length, increase if pull request patch testing starts hanging
+;PULL_REQUEST_QUEUE_LENGTH = 1000
+;;
+;; Preferred Licenses to place at the top of the List
+;; The name here must match the filename in conf/license or custom/conf/license
+;PREFERRED_LICENSES = Apache License 2.0,MIT License
+;;
+;; Disable the ability to interact with repositories using the HTTP protocol
+;;DISABLE_HTTP_GIT = false
+;;
+;; Value for Access-Control-Allow-Origin header, default is not to present
+;; WARNING: This may be harmful to your website if you do not give it a right value.
+;ACCESS_CONTROL_ALLOW_ORIGIN =
+;;
+;; Force ssh:// clone url instead of scp-style uri when default SSH port is used
+;USE_COMPAT_SSH_URI = false
+;;
+;; Close issues as long as a commit on any branch marks it as fixed
+;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki
+;DISABLED_REPO_UNITS =
+;;
+;; Comma separated list of default repo units. Allowed values: repo.code, repo.releases, repo.issues, repo.pulls, repo.wiki, repo.projects.
+;; Note: Code and Releases can currently not be deactivated. If you specify default repo units you should still list them for future compatibility.
+;; External wiki and issue tracker can't be enabled by default as it requires additional settings.
+;; Disabled repo units will not be added to new repositories regardless if it is in the default list.
+;DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki,repo.projects
+;;
+;; Prefix archive files by placing them in a directory named after the repository
+;PREFIX_ARCHIVE_FILES = true
+;;
+;; Disable the creation of new mirrors. Pre-existing mirrors remain valid.
+;DISABLE_MIRRORS = false
+;;
+;; Disable migrating feature.
+;DISABLE_MIGRATIONS = false
+;;
+;; Disable stars feature.
+;DISABLE_STARS = false
+;;
+;; The default branch name of new repositories
+;DEFAULT_BRANCH = master
+;;
+;; Allow adoption of unadopted repositories
+;ALLOW_ADOPTION_OF_UNADOPTED_REPOSITORIES = false
+;;
+;; Allow deletion of unadopted repositories
+;ALLOW_DELETION_OF_UNADOPTED_REPOSITORIES = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.editor]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; List of file extensions for which lines should be wrapped in the Monaco editor
+;; Separate extensions with a comma. To line wrap files without an extension, just put a comma
+;LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,
+;;
+;; Valid file modes that have a preview API associated with them, such as api/v1/markdown
+;; Separate the values by commas. The preview tab in edit mode won't be displayed if the file extension doesn't match
+;PREVIEWABLE_FILE_MODES = markdown
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.local]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Path for local repository copy. Defaults to `tmp/local-repo`
+;LOCAL_COPY_PATH = tmp/local-repo
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.upload]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Whether repository file uploads are enabled. Defaults to `true`
+;ENABLED = true
+;;
+;; Path for uploads. Defaults to `data/tmp/uploads` (tmp gets deleted on gitea restart)
+;TEMP_PATH = data/tmp/uploads
+;;
+;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
+;ALLOWED_TYPES =
+;;
+;; Max size of each file in megabytes. Defaults to 3MB
+;FILE_MAX_SIZE = 3
+;;
+;; Max number of files per upload. Defaults to 5
+;MAX_FILES = 5
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.pull-request]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; List of prefixes used in Pull Request title to mark them as Work In Progress
+;WORK_IN_PROGRESS_PREFIXES = WIP:,[WIP]
+;;
+;; List of keywords used in Pull Request comments to automatically close a related issue
+;CLOSE_KEYWORDS = close,closes,closed,fix,fixes,fixed,resolve,resolves,resolved
+;;
+;; List of keywords used in Pull Request comments to automatically reopen a related issue
+;REOPEN_KEYWORDS = reopen,reopens,reopened
+;;
+;; In the default merge message for squash commits include at most this many commits
+;DEFAULT_MERGE_MESSAGE_COMMITS_LIMIT = 50
+;;
+;; In the default merge message for squash commits limit the size of the commit messages to this
+;DEFAULT_MERGE_MESSAGE_SIZE = 5120
+;;
+;; In the default merge message for squash commits walk all commits to include all authors in the Co-authored-by otherwise just use those in the limited list
+;DEFAULT_MERGE_MESSAGE_ALL_AUTHORS = false
+;;
+;; In default merge messages limit the number of approvers listed as Reviewed-by: to this many
+;DEFAULT_MERGE_MESSAGE_MAX_APPROVERS = 10
+;;
+;; In default merge messages only include approvers who are official
+;DEFAULT_MERGE_MESSAGE_OFFICIAL_APPROVERS_ONLY = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.issue]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; List of reasons why a Pull Request or Issue can be locked
+;LOCK_REASONS = Too heated,Off-topic,Resolved,Spam
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.release]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
+;ALLOWED_TYPES =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[repository.signing]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; GPG key to use to sign commits, Defaults to the default - that is the value of git config --get user.signingkey
+;; run in the context of the RUN_USER
+;; Switch to none to stop signing completely
+;SIGNING_KEY = default
+;;
+;; If a SIGNING_KEY ID is provided and is not set to default, use the provided Name and Email address as the signer.
+;; These should match a publicized name and email address for the key. (When SIGNING_KEY is default these are set to
+;; the results of git config --get user.name and git config --get user.email respectively and can only be overridden
+;; by setting the SIGNING_KEY ID to the correct ID.)
+;SIGNING_NAME =
+;SIGNING_EMAIL =
+;;
+;; Sets the default trust model for repositories. Options are: collaborator, committer, collaboratorcommitter
+;DEFAULT_TRUST_MODEL = collaborator
+;;
+;; Determines when gitea should sign the initial commit when creating a repository
+;; Either:
+;; - never
+;; - pubkey: only sign if the user has a pubkey
+;; - twofa: only sign if the user has logged in with twofa
+;; - always
+;; options other than none and always can be combined as comma separated list
+;INITIAL_COMMIT = always
+;;
+;; Determines when to sign for CRUD actions
+;; - as above
+;; - parentsigned: requires that the parent commit is signed.
+;CRUD_ACTIONS = pubkey, twofa, parentsigned
+;; Determines when to sign Wiki commits
+;; - as above
+;WIKI = never
+;;
+;; Determines when to sign on merges
+;; - basesigned: require that the parent of commit on the base repo is signed.
+;; - commitssigned: require that all the commits in the head branch are signed.
+;; - approved: only sign when merging an approved pr to a protected branch
+;MERGES = pubkey, twofa, basesigned, commitssigned
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[project]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Default templates for project boards
+;PROJECT_BOARD_BASIC_KANBAN_TYPE = To Do, In Progress, Done
+;PROJECT_BOARD_BUG_TRIAGE_TYPE = Needs Triage, High Priority, Low Priority, Closed
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cors]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; More information about CORS can be found here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers
+;; enable cors headers (disabled by default)
+;ENABLED = false
+;;
+;; scheme of allowed requests
+;SCHEME = http
+;;
+;; list of requesting domains that are allowed
+;ALLOW_DOMAIN = *
+;;
+;; allow subdomains of headers listed above to request
+;ALLOW_SUBDOMAIN = false
+;;
+;; list of methods allowed to request
+;METHODS = GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS
+;;
+;; max time to cache response
+;MAX_AGE = 10m
+;;
+;; allow request with credentials
+;ALLOW_CREDENTIALS = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Number of repositories that are displayed on one explore page
+;EXPLORE_PAGING_NUM = 20
+;;
+;; Number of issues that are displayed on one page
+;ISSUE_PAGING_NUM = 10
+;;
+;; Number of maximum commits displayed in one activity feed
+;FEED_MAX_COMMIT_NUM = 5
+;;
+;; Number of items that are displayed in home feed
+;FEED_PAGING_NUM = 20
+;;
+;; Number of maximum commits displayed in commit graph.
+;GRAPH_MAX_COMMIT_NUM = 100
+;;
+;; Number of line of codes shown for a code comment
+;CODE_COMMENT_LINES = 4
+;;
+;; Value of `theme-color` meta tag, used by Android >= 5.0
+;; An invalid color like "none" or "disable" will have the default style
+;; More info: https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
+;THEME_COLOR_META_TAG = `#6cc644`
+;;
+;; Max size of files to be displayed (default is 8MiB)
+;MAX_DISPLAY_FILE_SIZE = 8388608
+;;
+;; Whether the email of the user should be shown in the Explore Users page
+;SHOW_USER_EMAIL = true
+;;
+;; Set the default theme for the Gitea install
+;DEFAULT_THEME = gitea
+;;
+;; All available themes. Allow users select personalized themes regardless of the value of `DEFAULT_THEME`.
+;THEMES = gitea,arc-green
+;;
+;;All available reactions users can choose on issues/prs and comments.
+;;Values can be emoji alias (:smile:) or a unicode emoji.
+;;For custom reactions, add a tightly cropped square image to public/emoji/img/reaction_name.png
+;REACTIONS = +1, -1, laugh, hooray, confused, heart, rocket, eyes
+;;
+;; Whether the full name of the users should be shown where possible. If the full name isn't set, the username will be used.
+;DEFAULT_SHOW_FULL_NAME = false
+;;
+;; Whether to search within description at repository search on explore page.
+;SEARCH_REPO_DESCRIPTION = true
+;;
+;; Whether to enable a Service Worker to cache frontend assets
+;USE_SERVICE_WORKER = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.admin]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Number of users that are displayed on one page
+;USER_PAGING_NUM = 50
+;;
+;; Number of repos that are displayed on one page
+;REPO_PAGING_NUM = 50
+;;
+;; Number of notices that are displayed on one page
+;NOTICE_PAGING_NUM = 25
+;;
+;; Number of organizations that are displayed on one page
+;ORG_PAGING_NUM = 50
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.user]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Number of repos that are displayed on one page
+;REPO_PAGING_NUM = 15
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.meta]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;AUTHOR = Gitea - Git with a cup of tea
+;DESCRIPTION = Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go
+;KEYWORDS = go,git,self-hosted,gitea
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.notification]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Control how often the notification endpoint is polled to update the notification
+;; The timeout will increase to MAX_TIMEOUT in TIMEOUT_STEPs if the notification count is unchanged
+;; Set MIN_TIMEOUT to 0 to turn off
+;MIN_TIMEOUT = 10s
+;MAX_TIMEOUT = 60s
+;TIMEOUT_STEP = 10s
+;;
+;; This setting determines how often the db is queried to get the latest notification counts.
+;; If the browser client supports EventSource and SharedWorker, a SharedWorker will be used in preference to polling notification. Set to -1 to disable the EventSource
+;EVENT_SOURCE_UPDATE_TIME = 10s
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.svg]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Whether to render SVG files as images.  If SVG rendering is disabled, SVG files are displayed as text and cannot be embedded in markdown files as images.
+;ENABLE_RENDER = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.csv]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Maximum allowed file size in bytes to render CSV files as table. (Set to 0 for no limit).
+;MAX_FILE_SIZE = 524288
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[markdown]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Render soft line breaks as hard line breaks, which means a single newline character between
+;; paragraphs will cause a line break and adding trailing whitespace to paragraphs is not
+;; necessary to force a line break.
+;; Render soft line breaks as hard line breaks for comments
+;ENABLE_HARD_LINE_BREAK_IN_COMMENTS = true
+;;
+;; Render soft line breaks as hard line breaks for markdown documents
+;ENABLE_HARD_LINE_BREAK_IN_DOCUMENTS = false
+;;
+;; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
+;; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)
+;; URLs starting with http and https are always displayed, whatever is put in this entry.
+;CUSTOM_URL_SCHEMES =
+;;
+;; List of file extensions that should be rendered/edited as Markdown
+;; Separate the extensions with a comma. To render files without any extension as markdown, just put a comma
+;FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ssh.minimum_key_sizes]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Define allowed algorithms and their minimum key length (use -1 to disable a type)
+;ED25519 = 256
+;ECDSA = 256
+;RSA = 2048
+;DSA = -1 ; set to 1024 to switch on
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[indexer]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Issue Indexer settings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Issue indexer type, currently support: bleve, db or elasticsearch, default is bleve
+;ISSUE_INDEXER_TYPE = bleve
+;;
+;; Issue indexer storage path, available when ISSUE_INDEXER_TYPE is bleve
+;ISSUE_INDEXER_PATH = indexers/issues.bleve
+;;
+;; Issue indexer connection string, available when ISSUE_INDEXER_TYPE is elasticsearch
+;ISSUE_INDEXER_CONN_STR = http://elastic:changeme@localhost:9200
+;;
+;; Issue indexer name, available when ISSUE_INDEXER_TYPE is elasticsearch
+;ISSUE_INDEXER_NAME = gitea_issues
+;;
+;; Timeout the indexer if it takes longer than this to start.
+;; Set to zero to disable timeout.
+;STARTUP_TIMEOUT = 30s
+;;
+;; Issue indexer queue, currently support: channel, levelqueue or redis, default is levelqueue (deprecated - use [queue.issue_indexer])
+;ISSUE_INDEXER_QUEUE_TYPE = levelqueue
+;;
+;; When ISSUE_INDEXER_QUEUE_TYPE is levelqueue, this will be the path where the queue will be saved.
+;; This can be overridden by `ISSUE_INDEXER_QUEUE_CONN_STR`.
+;; default is indexers/issues.queue
+;ISSUE_INDEXER_QUEUE_DIR = indexers/issues.queue
+;;
+;; When `ISSUE_INDEXER_QUEUE_TYPE` is `redis`, this will store the redis connection string.
+;; When `ISSUE_INDEXER_QUEUE_TYPE` is `levelqueue`, this is a directory or additional options of
+;; the form `leveldb://path/to/db?option=value&....`, and overrides `ISSUE_INDEXER_QUEUE_DIR`.
+;ISSUE_INDEXER_QUEUE_CONN_STR = "addrs=127.0.0.1:6379 db=0"
+;;
+;; Batch queue number, default is 20
+;ISSUE_INDEXER_QUEUE_BATCH_NUMBER = 20
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Repository Indexer settings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; repo indexer by default disabled, since it uses a lot of disk space
+;REPO_INDEXER_ENABLED = false
+;;
+;; Code search engine type, could be `bleve` or `elasticsearch`.
+;REPO_INDEXER_TYPE = bleve
+;;
+;; Index file used for code search. available when `REPO_INDEXER_TYPE` is bleve
+;REPO_INDEXER_PATH = indexers/repos.bleve
+;;
+;; Code indexer connection string, available when `REPO_INDEXER_TYPE` is elasticsearch. i.e. http://elastic:changeme@localhost:9200
+;REPO_INDEXER_CONN_STR =
+;;
+;; Code indexer name, available when `REPO_INDEXER_TYPE` is elasticsearch
+;REPO_INDEXER_NAME = gitea_codes
+;;
+;; A comma separated list of glob patterns (see https://github.com/gobwas/glob) to include
+;; in the index; default is empty
+;REPO_INDEXER_INCLUDE =
+;;
+;; A comma separated list of glob patterns to exclude from the index; ; default is empty
+;REPO_INDEXER_EXCLUDE =
+;;
+;;
+;UPDATE_BUFFER_LEN = 20
+;MAX_FILE_SIZE = 1048576
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[queue]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Specific queues can be individually configured with [queue.name]. [queue] provides defaults
+;; ([queue.issue_indexer] is special due to the old configuration described above)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; General queue queue type, currently support: persistable-channel, channel, level, redis, dummy
+;; default to persistable-channel
+;TYPE = persistable-channel
+;;
+;; data-dir for storing persistable queues and level queues, individual queues will be named by their type
+;DATADIR = queues/
+;;
+;; Default queue length before a channel queue will block
+;LENGTH = 20
+;;
+;; Batch size to send for batched queues
+;BATCH_LENGTH = 20
+;;
+;; Connection string for redis queues this will store the redis connection string.
+;; When `TYPE` is `persistable-channel`, this provides a directory for the underlying leveldb
+;; or additional options of the form `leveldb://path/to/db?option=value&....`, and will override `DATADIR`.
+;CONN_STR = "addrs=127.0.0.1:6379 db=0"
+;;
+;; Provides the suffix of the default redis/disk queue name - specific queues can be overridden within in their [queue.name] sections.
+;QUEUE_NAME = "_queue"
+;;
+;; Provides the suffix of the default redis/disk unique queue set name - specific queues can be overridden within in their [queue.name] sections.
+;SET_NAME = "_unique"
+;;
+;; If the queue cannot be created at startup - level queues may need a timeout at startup - wrap the queue:
+;WRAP_IF_NECESSARY = true
+;;
+;; Attempt to create the wrapped queue at max
+;MAX_ATTEMPTS = 10
+;;
+;; Timeout queue creation
+;TIMEOUT = 15m30s
+;;
+;; Create a pool with this many workers
+;WORKERS = 1
+;;
+;; Dynamically scale the worker pool to at this many workers
+;MAX_WORKERS = 10
+;;
+;; Add boost workers when the queue blocks for BLOCK_TIMEOUT
+;BLOCK_TIMEOUT = 1s
+;;
+;; Remove the boost workers after BOOST_TIMEOUT
+;BOOST_TIMEOUT = 5m
+;;
+;; During a boost add BOOST_WORKERS
+;BOOST_WORKERS = 5
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[admin]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Disallow regular (non-admin) users from creating organizations.
+;DISABLE_REGULAR_ORG_CREATION = false
+;;
+;; Default configuration for email notifications for users (user configurable). Options: enabled, onmention, disabled
+;DEFAULT_EMAIL_NOTIFICATIONS = enabled
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[openid]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; OpenID is an open, standard and decentralized authentication protocol.
+;; Your identity is the address of a webpage you provide, which describes
+;; how to prove you are in control of that page.
+;;
+;; For more info: https://en.wikipedia.org/wiki/OpenID
+;;
+;; Current implementation supports OpenID-2.0
+;;
+;; Tested to work providers at the time of writing:
+;;  - Any GNUSocial node (your.hostname.tld/username)
+;;  - Any SimpleID provider (http://simpleid.koinic.net)
+;;  - http://openid.org.cn/
+;;  - openid.stackexchange.com
+;;  - login.launchpad.net
+;;  - <username>.livejournal.com
+;;
+;; Whether to allow signin in via OpenID
+;ENABLE_OPENID_SIGNIN = true
+;;
+;; Whether to allow registering via OpenID
+;; Do not include to rely on rhw DISABLE_REGISTRATION setting
+;;ENABLE_OPENID_SIGNUP = true
+;;
+;; Allowed URI patterns (POSIX regexp).
+;; Space separated.
+;; Only these would be allowed if non-blank.
+;; Example value: trusted.domain.org trusted.domain.net
+;WHITELISTED_URIS =
+;;
+;; Forbidden URI patterns (POSIX regexp).
+;; Space separated.
+;; Only used if WHITELISTED_URIS is blank.
+;; Example value: loadaverage.org/badguy stackexchange.com/.*spammer
+;BLACKLISTED_URIS =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[oauth2_client]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Whether a new auto registered oauth2 user needs to confirm their email.
+;; Do not include to use the REGISTER_EMAIL_CONFIRM setting from the `[service]` section.
+;REGISTER_EMAIL_CONFIRM =
+;;
+;; Scopes for the openid connect oauth2 provider (separated by space, the openid scope is implicitly added).
+;; Typical values are profile and email.
+;; For more information about the possible values see https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+;OPENID_CONNECT_SCOPES =
+;;
+;; Automatically create user accounts for new oauth2 users.
+;ENABLE_AUTO_REGISTRATION = false
+;;
+;; The source of the username for new oauth2 accounts:
+;; userid = use the userid / sub attribute
+;; nickname = use the nickname attribute
+;; email = use the username part of the email attribute
+;USERNAME = nickname
+;;
+;; Update avatar if available from oauth2 provider.
+;; Update will be performed on each login.
+;UPDATE_AVATAR = false
+;;
+;; How to handle if an account / email already exists:
+;; disabled = show an error
+;; login = show an account linking login
+;; auto = link directly with the account
+;ACCOUNT_LINKING = login
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[webhook]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Hook task queue length, increase if webhook shooting starts hanging
+;QUEUE_LENGTH = 1000
+;;
+;; Deliver timeout in seconds
+;DELIVER_TIMEOUT = 5
+;;
+;; Allow insecure certification
+;SKIP_TLS_VERIFY = false
+;;
+;; Number of history information in each page
+;PAGING_NUM = 10
+;;
+;; Proxy server URL, support http://, https//, socks://, blank will follow environment http_proxy/https_proxy
+;PROXY_URL =
+;;
+;; Comma separated list of host names requiring proxy. Glob patterns (*) are accepted; use ** to match all hosts.
+;PROXY_HOSTS =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[mailer]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;ENABLED = false
+;;
+;; Buffer length of channel, keep it as it is if you don't know what it is.
+;SEND_BUFFER_LEN = 100
+;;
+;; Prefix displayed before subject in mail
+;SUBJECT_PREFIX =
+;;
+;; Mail server
+;; Gmail: smtp.gmail.com:587
+;; QQ: smtp.qq.com:465
+;; Using STARTTLS on port 587 is recommended per RFC 6409.
+;; Note, if the port ends with "465", SMTPS will be used.
+;HOST =
+;;
+;; Disable HELO operation when hostnames are different.
+;DISABLE_HELO =
+;;
+;; Custom hostname for HELO operation, if no value is provided, one is retrieved from system.
+;HELO_HOSTNAME =
+;;
+;; Whether or not to skip verification of certificates; `true` to disable verification. This option is unsafe. Consider adding the certificate to the system trust store instead.
+;SKIP_VERIFY = false
+;;
+;; Use client certificate
+;USE_CERTIFICATE = false
+;CERT_FILE = custom/mailer/cert.pem
+;KEY_FILE = custom/mailer/key.pem
+;;
+;; Should SMTP connect with TLS, (if port ends with 465 TLS will always be used.)
+;; If this is false but STARTTLS is supported the connection will be upgraded to TLS opportunistically.
+;IS_TLS_ENABLED = false
+;;
+;; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
+;FROM =
+;;
+;; Mailer user name and password
+;; Please Note: Authentication is only supported when the SMTP server communication is encrypted with TLS (this can be via STARTTLS) or `HOST=localhost`.
+;USER =
+;;
+;; Use PASSWD = `your password` for quoting if you use special characters in the password.
+;PASSWD =
+;;
+;; Send mails as plain text
+;SEND_AS_PLAIN_TEXT = false
+;;
+;; Set Mailer Type (either SMTP, sendmail or dummy to just send to the log)
+;MAILER_TYPE = smtp
+;;
+;; Specify an alternative sendmail binary
+;SENDMAIL_PATH = sendmail
+;;
+;; Specify any extra sendmail arguments
+;SENDMAIL_ARGS =
+;;
+;; Timeout for Sendmail
+;SENDMAIL_TIMEOUT = 5m
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cache]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; if the cache enabled
+;ENABLED = true
+;;
+;; Either "memory", "redis", or "memcache", default is "memory"
+;ADAPTER = memory
+;;
+;; For "memory" only, GC interval in seconds, default is 60
+;INTERVAL = 60
+;;
+;; For "redis" and "memcache", connection host address
+;; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
+;; memcache: `127.0.0.1:11211`
+;HOST =
+;;
+;; Time to keep items in cache if not used, default is 16 hours.
+;; Setting it to 0 disables caching
+;ITEM_TTL = 16h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Last commit cache
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cache.last_commit]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; if the cache enabled
+;ENABLED = true
+;;
+;; Time to keep items in cache if not used, default is 8760 hours.
+;; Setting it to 0 disables caching
+;ITEM_TTL = 8760h
+;;
+;; Only enable the cache when repository's commits count great than
+;COMMITS_COUNT = 1000
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[session]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Either "memory", "file", or "redis", default is "memory"
+;PROVIDER = memory
+;;
+;; Provider config options
+;; memory: doesn't have any config yet
+;; file: session file path, e.g. `data/sessions`
+;; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
+;; mysql: go-sql-driver/mysql dsn config string, e.g. `root:password@/session_table`
+;PROVIDER_CONFIG = data/sessions
+;;
+;; Session cookie name
+;COOKIE_NAME = i_like_gitea
+;;
+;; If you use session in https only, default is false
+;COOKIE_SECURE = false
+;;
+;; Session GC time interval in seconds, default is 86400 (1 day)
+;GC_INTERVAL_TIME = 86400
+;;
+;; Session life time in seconds, default is 86400 (1 day)
+;SESSION_LIFE_TIME = 86400
+;;
+;; SameSite settings. Either "none", "lax", or "strict"
+;SAME_SITE=lax
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[picture]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;AVATAR_UPLOAD_PATH = data/avatars
+;REPOSITORY_AVATAR_UPLOAD_PATH = data/repo-avatars
+;;
+;; How Gitea deals with missing repository avatars
+;; none = no avatar will be displayed; random = random avatar will be displayed; image = default image will be used
+;REPOSITORY_AVATAR_FALLBACK = none
+;REPOSITORY_AVATAR_FALLBACK_IMAGE = /img/repo_default.png
+;;
+;; Max Width and Height of uploaded avatars.
+;; This is to limit the amount of RAM used when resizing the image.
+;AVATAR_MAX_WIDTH = 4096
+;AVATAR_MAX_HEIGHT = 3072
+;;
+;; Maximum allowed file size for uploaded avatars.
+;; This is to limit the amount of RAM used when resizing the image.
+;AVATAR_MAX_FILE_SIZE = 1048576
+;;
+;; Chinese users can choose "duoshuo"
+;; or a custom avatar source, like: http://cn.gravatar.com/avatar/
+;GRAVATAR_SOURCE = gravatar
+;;
+;; This value will always be true in offline mode.
+;DISABLE_GRAVATAR = false
+;;
+;; Federated avatar lookup uses DNS to discover avatar associated
+;; with emails, see https://www.libravatar.org
+;; This value will always be false in offline mode or when Gravatar is disabled.
+;ENABLE_FEDERATED_AVATAR = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[attachment]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Whether issue and pull request attachments are enabled. Defaults to `true`
+;ENABLED = true
+;;
+;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
+;ALLOWED_TYPES = .docx,.gif,.gz,.jpeg,.jpg,.log,.pdf,.png,.pptx,.txt,.xlsx,.zip
+;;
+;; Max size of each file. Defaults to 4MB
+;MAX_SIZE = 4
+;;
+;; Max number of files per upload. Defaults to 5
+;MAX_FILES = 5
+;;
+;; Storage type for attachments, `local` for local disk or `minio` for s3 compatible
+;; object storage service, default is `local`.
+;STORAGE_TYPE = local
+;;
+;; Allows the storage driver to redirect to authenticated URLs to serve files directly
+;; Currently, only `minio` is supported.
+;SERVE_DIRECT = false
+;;
+;; Path for attachments. Defaults to `data/attachments` only available when STORAGE_TYPE is `local`
+;PATH = data/attachments
+;;
+;; Minio endpoint to connect only available when STORAGE_TYPE is `minio`
+;MINIO_ENDPOINT = localhost:9000
+;;
+;; Minio accessKeyID to connect only available when STORAGE_TYPE is `minio`
+;MINIO_ACCESS_KEY_ID =
+;;
+;; Minio secretAccessKey to connect only available when STORAGE_TYPE is `minio`
+;MINIO_SECRET_ACCESS_KEY =
+;;
+;; Minio bucket to store the attachments only available when STORAGE_TYPE is `minio`
+;MINIO_BUCKET = gitea
+;;
+;; Minio location to create bucket only available when STORAGE_TYPE is `minio`
+;MINIO_LOCATION = us-east-1
+;;
+;; Minio base path on the bucket only available when STORAGE_TYPE is `minio`
+;MINIO_BASE_PATH = attachments/
+;;
+;; Minio enabled ssl only available when STORAGE_TYPE is `minio`
+;MINIO_USE_SSL = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[time]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Specifies the format for fully outputted dates. Defaults to RFC1123
+;; Special supported values are ANSIC, UnixDate, RubyDate, RFC822, RFC822Z, RFC850, RFC1123, RFC1123Z, RFC3339, RFC3339Nano, Kitchen, Stamp, StampMilli, StampMicro and StampNano
+;; For more information about the format see http://golang.org/pkg/time/#pkg-constants
+;FORMAT =
+;;
+;; Location the UI time display i.e. Asia/Shanghai
+;; Empty means server's location setting
+;DEFAULT_UI_LOCATION =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Common settings
+;;
+;; Setting this to true will enable all cron tasks periodically with default settings.
+;ENABLED = false
+;; Setting this to true will run all enabled cron tasks when Gitea starts.
+;RUN_AT_START = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Basic cron tasks - enabled by default
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Clean up old repository archives
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.archive_cleanup]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Whether to enable the job
+;ENABLED = true
+;; Whether to always run at least once at start up time (if ENABLED)
+;RUN_AT_START = true
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;; Time interval for job to run
+;SCHEDULE = @every 24h
+;; Archives created more than OLDER_THAN ago are subject to deletion
+;OLDER_THAN = 24h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Update mirrors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.update_mirrors]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;SCHEDULE = @every 10m
+;; Enable running Update mirrors task periodically.
+;ENABLED = true
+;; Run Update mirrors task when Gitea starts.
+;RUN_AT_START = false
+;; Notice if not success
+;NO_SUCCESS_NOTICE = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Repository health check
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.repo_health_check]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;SCHEDULE = @every 24h
+;; Enable running Repository health check task periodically.
+;ENABLED = true
+;; Run Repository health check task when Gitea starts.
+;RUN_AT_START = false
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;TIMEOUT = 60s
+;; Arguments for command 'git fsck', e.g. "--unreachable --tags"
+;; see more on http://git-scm.com/docs/git-fsck
+;ARGS =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Check repository statistics
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.check_repo_stats]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Enable running check repository statistics task periodically.
+;ENABLED = true
+;; Run check repository statistics task when Gitea starts.
+;RUN_AT_START = true
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 24h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.update_migration_poster_id]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Update migrated repositories' issues and comments' posterid, it will always attempt synchronization when the instance starts.
+;ENABLED = true
+;; Update migrated repositories' issues and comments' posterid when starting server (default true)
+;RUN_AT_START = true
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;; Interval as a duration between each synchronization. (default every 24h)
+;SCHEDULE = @every 24h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Synchronize external user data (only LDAP user synchronization is supported)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.sync_external_users]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = true
+;; Synchronize external user data when starting server (default false)
+;RUN_AT_START = false
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;; Interval as a duration between each synchronization (default every 24h)
+;SCHEDULE = @every 24h
+;; Create new users, update existing user data and disable users that are not in external source anymore (default)
+;;   or only create new users if UPDATE_EXISTING is set to false
+;UPDATE_EXISTING = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Clean-up deleted branches
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.deleted_branches_cleanup]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = true
+;; Clean-up deleted branches when starting server (default true)
+;RUN_AT_START = true
+;; Notice if not success
+;NO_SUCCESS_NOTICE = false
+;; Interval as a duration between each synchronization (default every 24h)
+;SCHEDULE = @every 24h
+;; deleted branches than OLDER_THAN ago are subject to deletion
+;OLDER_THAN = 24h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Cleanup hook_task table
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.cleanup_hook_task_table]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Whether to enable the job
+;ENABLED = true
+;; Whether to always run at start up time (if ENABLED)
+;RUN_AT_START = false
+;; Time interval for job to run
+;SCHEDULE = @every 24h
+;; OlderThan or PerWebhook. How the records are removed, either by age (i.e. how long ago hook_task record was delivered) or by the number to keep per webhook (i.e. keep most recent x deliveries per webhook).
+;CLEANUP_TYPE = OlderThan
+;; If CLEANUP_TYPE is set to OlderThan, then any delivered hook_task records older than this expression will be deleted.
+;OLDER_THAN = 168h
+;; If CLEANUP_TYPE is set to PerWebhook, this is number of hook_task records to keep for a webhook (i.e. keep the most recent x deliveries).
+;NUMBER_TO_KEEP = 10
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Extended cron task - not enabled by default
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete all unactivated accounts
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_inactive_accounts]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @annually
+;OLDER_THAN = 168h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete all repository archives
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_repo_archives]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @annually;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Garbage collect all repositories
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.git_gc_repos]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 72h
+;TIMEOUT = 60s
+;; Arguments for command 'git gc'
+;; The default value is same with [git] -> GC_ARGS
+;ARGS =
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Update the '.ssh/authorized_keys' file with Gitea SSH keys
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.resync_all_sshkeys]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 72h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Resynchronize pre-receive, update and post-receive hooks of all repositories.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.resync_all_hooks]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 72h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Reinitialize all missing Git repositories for which records exist
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.reinit_missing_repos]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = f;alse
+;SCHEDULE = @every 72h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete all repositories missing their Git files
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_missing_repos]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 72h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete generated repository avatars
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_generated_repository_avatars]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = f;alse
+;SCHEDULE = @every 72h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete all old actions from database
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_old_actions]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 168h
+;OLDER_THAN = 8760h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Git Operation timeout in seconds
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[git.timeout]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;DEFAULT = 360
+;MIGRATE = 600
+;MIRROR = 300
+;CLONE = 300
+;PULL = 300
+;GC = 60
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[mirror]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Default interval as a duration between each check
+;DEFAULT_INTERVAL = 8h
+;; Min interval as a duration must be > 1m
+;MIN_INTERVAL = 10m
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[api]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Enables Swagger. True or false; default is true.
+;ENABLE_SWAGGER = true
+;; Max number of items in a page
+;MAX_RESPONSE_ITEMS = 50
+;; Default paging number of api
+;DEFAULT_PAGING_NUM = 30
+;; Default and maximum number of items per page for git trees api
+;DEFAULT_GIT_TREES_PER_PAGE = 1000
+;; Default size of a blob returned by the blobs API (default is 10MiB)
+;DEFAULT_MAX_BLOB_SIZE = 10485760
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[i18n]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR
+;NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,Português de Portugal,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[highlight.mapping]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Extension mapping to highlight class
+;; e.g. .toml=ini
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[other]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;SHOW_FOOTER_BRANDING = false
+;; Show version information about Gitea and Go in the footer
+;SHOW_FOOTER_VERSION = true
+;; Show template execution time in the footer
+;SHOW_FOOTER_TEMPLATE_LOAD_TIME = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[markup.sanitizer.1]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; The following keys can appear once to define a sanitation policy rule.
+;; This section can appear multiple times by adding a unique alphanumeric suffix to define multiple rules.
+;; e.g., [markup.sanitizer.1] -> [markup.sanitizer.2] -> [markup.sanitizer.TeX]
 ;ELEMENT = span
 ;ALLOW_ATTR = class
 ;REGEXP = ^(info|warning|error)$
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Other markup formats e.g. asciidoc
+;;
+;; uncomment and enable the below section.
+;; (You can add other markup formats by copying the section and adjusting
+;;  the section name suffix "asciidoc" to something else.)
+;[markup.asciidoc]
+;ENABLED = false
+;; List of file extensions that should be rendered by an external command
+;FILE_EXTENSIONS = .adoc,.asciidoc
+;; External command to render all matching extensions
+;RENDER_COMMAND = "asciidoc --out-file=- -"
+;; Don't pass the file on STDIN, pass the filename as argument instead.
+;IS_INPUT_FILE = false
 
-[markup.asciidoc]
-ENABLED = false
-; List of file extensions that should be rendered by an external command
-FILE_EXTENSIONS = .adoc,.asciidoc
-; External command to render all matching extensions
-RENDER_COMMAND = "asciidoc --out-file=- -"
-; Don't pass the file on STDIN, pass the filename as argument instead.
-IS_INPUT_FILE = false
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[metrics]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Enables metrics endpoint. True or false; default is false.
+;ENABLED = false
+;; If you want to add authorization, specify a token here
+;TOKEN =
 
-[metrics]
-; Enables metrics endpoint. True or false; default is false.
-ENABLED = false
-; If you want to add authorization, specify a token here
-TOKEN =
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[task]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Task queue type, could be `channel` or `redis`.
+;QUEUE_TYPE = channel
+;;
+;; Task queue length, available only when `QUEUE_TYPE` is `channel`.
+;QUEUE_LENGTH = 1000
+;;
+;; Task queue connection string, available only when `QUEUE_TYPE` is `redis`.
+;; If there is a password of redis, use `addrs=127.0.0.1:6379 password=123 db=0`.
+;QUEUE_CONN_STR = "addrs=127.0.0.1:6379 db=0"
 
-[task]
-; Task queue type, could be `channel` or `redis`.
-QUEUE_TYPE = channel
-; Task queue length, available only when `QUEUE_TYPE` is `channel`.
-QUEUE_LENGTH = 1000
-; Task queue connection string, available only when `QUEUE_TYPE` is `redis`.
-; If there is a password of redis, use `addrs=127.0.0.1:6379 password=123 db=0`.
-QUEUE_CONN_STR = "addrs=127.0.0.1:6379 db=0"
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[migrations]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Max attempts per http/https request on migrations.
+;MAX_ATTEMPTS = 3
+;;
+;; Backoff time per http/https request retry (seconds)
+;RETRY_BACKOFF = 3
+;;
+;; Allowed domains for migrating, default is blank. Blank means everything will be allowed.
+;; Multiple domains could be separated by commas.
+;ALLOWED_DOMAINS =
+;;
+;; Blocklist for migrating, default is blank. Multiple domains could be separated by commas.
+;; When ALLOWED_DOMAINS is not blank, this option will be ignored.
+;BLOCKED_DOMAINS =
+;;
+;; Allow private addresses defined by RFC 1918, RFC 1122, RFC 4632 and RFC 4291 (false by default)
+;ALLOW_LOCALNETWORKS = false
 
-[migrations]
-; Max attempts per http/https request on migrations.
-MAX_ATTEMPTS = 3
-; Backoff time per http/https request retry (seconds)
-RETRY_BACKOFF = 3
-; Allowed domains for migrating, default is blank. Blank means everything will be allowed.
-; Multiple domains could be separated by commas.
-ALLOWED_DOMAINS =
-; Blocklist for migrating, default is blank. Multiple domains could be separated by commas.
-; When ALLOWED_DOMAINS is not blank, this option will be ignored.
-BLOCKED_DOMAINS =
-; Allow private addresses defined by RFC 1918, RFC 1122, RFC 4632 and RFC 4291 (false by default)
-ALLOW_LOCALNETWORKS = false
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; default storage for attachments, lfs and avatars
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[storage]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; storage type
+;STORAGE_TYPE = local
 
-; default storage for attachments, lfs and avatars
-[storage]
-; storage type
-STORAGE_TYPE = local
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; lfs storage will override storage
+;;
+;[lfs]
+;STORAGE_TYPE = local
 
-; lfs storage will override storage
-[lfs]
-STORAGE_TYPE = local
-
-; customize storage
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; customize storage
 ;[storage.my_minio]
 ;STORAGE_TYPE = minio
-; Minio endpoint to connect only available when STORAGE_TYPE is `minio`
+;;
+;; Minio endpoint to connect only available when STORAGE_TYPE is `minio`
 ;MINIO_ENDPOINT = localhost:9000
-; Minio accessKeyID to connect only available when STORAGE_TYPE is `minio`
+;;
+;; Minio accessKeyID to connect only available when STORAGE_TYPE is `minio`
 ;MINIO_ACCESS_KEY_ID =
-; Minio secretAccessKey to connect only available when STORAGE_TYPE is `minio`
+;;
+;; Minio secretAccessKey to connect only available when STORAGE_TYPE is `minio`
 ;MINIO_SECRET_ACCESS_KEY =
-; Minio bucket to store the attachments only available when STORAGE_TYPE is `minio`
+;;
+;; Minio bucket to store the attachments only available when STORAGE_TYPE is `minio`
 ;MINIO_BUCKET = gitea
-; Minio location to create bucket only available when STORAGE_TYPE is `minio`
+;;
+;; Minio location to create bucket only available when STORAGE_TYPE is `minio`
 ;MINIO_LOCATION = us-east-1
-; Minio enabled ssl only available when STORAGE_TYPE is `minio`
+;;
+;; Minio enabled ssl only available when STORAGE_TYPE is `minio`
 ;MINIO_USE_SSL = false


### PR DESCRIPTION
This PR is an alternative to #15559.

Instead of deleting the app.example.ini - just comment out most of the
thing. This makes it clear what needs to be set and what is completely
optional - and keeps the documentation.

The app.example.ini is moved around to move the most important settings
higher in the document.

Close #15559

Signed-off-by: Andrew Thornton <art27@cantab.net>
