### PR TITLE
remove unused truncate.

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -196,9 +196,6 @@ func (u *User) BeforeUpdate() {
 	}
 
 	u.LowerName = strings.ToLower(u.Name)
-	u.Location = base.TruncateString(u.Location, 255)
-	u.Website = base.TruncateString(u.Website, 255)
-	u.Description = base.TruncateString(u.Description, 255)
 }
 
 // AfterLoad is invoked from XORM after filling all the fields of this object.


### PR DESCRIPTION
Separated from the previous pr ( #15828 )

Because the three columns has been form validated before it is saved, truncating it here will cause a truncate utf8 string bug