### PR TITLE
Tagger can be empty, as can Commit and Author - tolerate this (#15835)

### DIFF
--- a/modules/git/commit_reader.go
+++ b/modules/git/commit_reader.go
@@ -17,7 +17,9 @@ import (
 // If used as part of a cat-file --batch stream you need to limit the reader to the correct size
 func CommitFromReader(gitRepo *Repository, sha SHA1, reader io.Reader) (*Commit, error) {
 	commit := &Commit{
-		ID: sha,
+		ID:        sha,
+		Author:    &Signature{},
+		Committer: &Signature{},
 	}
 
 	payloadSB := new(strings.Builder)

--- a/modules/git/tag.go
+++ b/modules/git/tag.go
@@ -35,6 +35,7 @@ func (tag *Tag) Commit() (*Commit, error) {
 // \n\n separate headers from message
 func parseTagData(data []byte) (*Tag, error) {
 	tag := new(Tag)
+	tag.Tagger = &Signature{}
 	// we now have the contents of the commit object. Let's investigate...
 	nextline := 0
 l:


### PR DESCRIPTION
Backport #15835

Unfortunately some old repositories can have tags with empty Tagger, Commit
or Author. Go-Git variants will always have empty values for these whereas
the native git variant leaves them at nil. The simplest solution is just to
always have these set to empty Signatures.

v156 migration also makes the incorrect assumption that these cannot be empty.
Therefore add some handling to this and add logging and adjust broken
logging elsewhere in this migration.

Signed-off-by: Andrew Thornton <art27@cantab.net>
