### PR TITLE
Only offer hostcertificates if they exist (#15849)

### DIFF
--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -24,9 +24,29 @@ if [ ! -f /data/ssh/ssh_host_ecdsa_key ]; then
     ssh-keygen -t ecdsa -b 256 -f /data/ssh/ssh_host_ecdsa_key -N "" > /dev/null
 fi
 
+if [ -e /data/ssh/ssh_host_ed25519_cert ]; then
+  SSH_ED25519_CERT=${SSH_ED25519_CERT:-"/data/ssh/ssh_host_ed25519_cert"}
+fi
+
+if [ -e /data/ssh/ssh_host_rsa_cert ]; then
+  SSH_RSA_CERT=${SSH_RSA_CERT:-"/data/ssh/ssh_host_rsa_cert"}
+fi
+
+if [ -e /data/ssh/ssh_host_ecdsa_cert ]; then
+  SSH_ECDSA_CERT=${SSH_ECDSA_CERT:-"/data/ssh/ssh_host_ecdsa_cert"}
+fi
+
+if [ -e /data/ssh/ssh_host_dsa_cert ]; then
+  SSH_DSA_CERT=${SSH_DSA_CERT:-"/data/ssh/ssh_host_dsa_cert"}
+fi
+
 if [ -d /etc/ssh ]; then
     SSH_PORT=${SSH_PORT:-"22"} \
     SSH_LISTEN_PORT=${SSH_LISTEN_PORT:-"${SSH_PORT}"} \
+    SSH_ED25519_CERT="${SSH_ED25519_CERT:+"HostCertificate "}${SSH_ED25519_CERT}" \
+    SSH_RSA_CERT="${SSH_RSA_CERT:+"HostCertificate "}${SSH_RSA_CERT}" \
+    SSH_ECDSA_CERT="${SSH_ECDSA_CERT:+"HostCertificate "}${SSH_ECDSA_CERT}" \
+    SSH_DSA_CERT="${SSH_DSA_CERT:+"HostCertificate "}${SSH_DSA_CERT}" \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -8,13 +8,13 @@ ListenAddress ::
 LogLevel INFO
 
 HostKey /data/ssh/ssh_host_ed25519_key
-HostCertificate /data/ssh/ssh_host_ed25519_cert
+${SSH_ED25519_CERT}
 HostKey /data/ssh/ssh_host_rsa_key
-HostCertificate /data/ssh/ssh_host_rsa_cert
+${SSH_RSA_CERT}
 HostKey /data/ssh/ssh_host_ecdsa_key
-HostCertificate /data/ssh/ssh_host_ecdsa_cert
+${SSH_ECDSA_CERT}
 HostKey /data/ssh/ssh_host_dsa_key
-HostCertificate /data/ssh/ssh_host_dsa_cert
+${SSH_DSA_CERT}
 
 AuthorizedKeysFile .ssh/authorized_keys
 AuthorizedPrincipalsFile .ssh/authorized_principals


### PR DESCRIPTION
Backport #15849

A common bug report is the otherwise harmless sshd logging:

```
Could not load host certificate "/data/ssh/ssh_host_ed25519_cert": No such file or directory
```

This PR simply checks if these files exist before creation of sshd_config and if
they do not exist, doesn't add a reference to them.

Close #14110
Close #13724

Signed-off-by: Andrew Thornton <art27@cantab.net>

Co-authored-by: silverwind <me@silverwind.io>
