### PR TITLE
Add jest rootDir and test-frontend dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-backend:
 	@$(GO) test $(GOTESTFLAGS) -mod=vendor -tags='$(TEST_TAGS)' $(GO_PACKAGES)
 
 .PHONY: test-frontend
-test-frontend:
+test-frontend: node_modules
 	@NODE_OPTIONS="--experimental-vm-modules --no-warnings" npx jest --color
 
 .PHONY: test-check

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
 export default {
   setupFilesAfterEnv: ['jest-extended'],
   testTimeout: 20000,
+  rootDir: 'web_src',
   testMatch: [
-    '**/web_src/**/*.test.js',
+    '<rootDir>/**/*.test.js',
   ],
   transform: {},
   verbose: false,


### PR DESCRIPTION
- Define jest rootDir to limit where it looks for test files, speeding it up a bit
- Add missing dependency on test-frontend target so it can be ran from a clean checkout