### PR TITLE
Only write config in environment-to-ini if there are changes

### DIFF
--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -110,6 +110,8 @@ func runEnvironmentToIni(c *cli.Context) error {
 	}
 	cfg.NameMapper = ini.SnackCase
 
+	changed := false
+
 	prefix := c.String("prefix") + "__"
 
 	for _, kv := range os.Environ() {
@@ -143,15 +145,21 @@ func runEnvironmentToIni(c *cli.Context) error {
 				continue
 			}
 		}
+		oldValue := key.Value()
+		if oldValue != value {
+			changed = true
+		}
 		key.SetValue(value)
 	}
 	destination := c.String("out")
 	if len(destination) == 0 {
 		destination = setting.CustomConf
 	}
-	err = cfg.SaveTo(destination)
-	if err != nil {
-		return err
+	if destination != setting.CustomConf || changed {
+		err = cfg.SaveTo(destination)
+		if err != nil {
+			return err
+		}
 	}
 	if c.Bool("clear") {
 		for _, kv := range os.Environ() {

--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -146,7 +146,7 @@ func runEnvironmentToIni(c *cli.Context) error {
 			}
 		}
 		oldValue := key.Value()
-		if oldValue != value {
+		if !changed && oldValue != value {
 			changed = true
 		}
 		key.SetValue(value)


### PR DESCRIPTION
Only write the new config in environment-to-ini if there are changes or the
destination is not the same as the customconf.

Fix #15719
Fix #15857

Signed-off-by: Andrew Thornton <art27@cantab.net>
