### PR TITLE
Backport Fix LFS commit finder not working (#15856)

### DIFF
--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -149,17 +149,18 @@ headerLoop:
 // constant hextable to help quickly convert between 20byte and 40byte hashes
 const hextable = "0123456789abcdef"
 
-// To40ByteSHA converts a 20-byte SHA in a 40-byte slice into a 40-byte sha in place
-// without allocations. This is at least 100x quicker that hex.EncodeToString
-// NB This requires that sha is a 40-byte slice
-func To40ByteSHA(sha []byte) []byte {
+// To40ByteSHA converts a 20-byte SHA into a 40-byte sha. Input and output can be the
+// same 40 byte slice to support in place conversion without allocations.
+// This is at least 100x quicker that hex.EncodeToString
+// NB This requires that out is a 40-byte slice
+func To40ByteSHA(sha, out []byte) []byte {
 	for i := 19; i >= 0; i-- {
 		v := sha[i]
 		vhi, vlo := v>>4, v&0x0f
 		shi, slo := hextable[vhi], hextable[vlo]
-		sha[i*2], sha[i*2+1] = shi, slo
+		out[i*2], out[i*2+1] = shi, slo
 	}
-	return sha
+	return out
 }
 
 // ParseTreeLineSkipMode reads an entry from a tree in a cat-file --batch stream

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -303,7 +303,7 @@ revListLoop:
 					commits[0] = string(commitID)
 				}
 			}
-			treeID = To40ByteSHA(treeID)
+			treeID = To40ByteSHA(treeID, treeID)
 			_, err = batchStdinWriter.Write(treeID)
 			if err != nil {
 				return nil, err

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -43,8 +43,6 @@ func FindLFSFile(repo *git.Repository, hash git.SHA1) ([]*LFSResult, error) {
 
 	basePath := repo.Path
 
-	hashStr := hash.String()
-
 	// Use rev-list to provide us with all commits in order
 	revListReader, revListWriter := io.Pipe()
 	defer func() {
@@ -74,7 +72,7 @@ func FindLFSFile(repo *git.Repository, hash git.SHA1) ([]*LFSResult, error) {
 
 	fnameBuf := make([]byte, 4096)
 	modeBuf := make([]byte, 40)
-	workingShaBuf := make([]byte, 40)
+	workingShaBuf := make([]byte, 20)
 
 	for scan.Scan() {
 		// Get the next commit ID
@@ -132,8 +130,7 @@ func FindLFSFile(repo *git.Repository, hash git.SHA1) ([]*LFSResult, error) {
 						return nil, err
 					}
 					n += int64(count)
-					sha := git.To40ByteSHA(sha20byte)
-					if bytes.Equal(sha, []byte(hashStr)) {
+					if bytes.Equal(sha20byte, hash[:]) {
 						result := LFSResult{
 							Name:         curPath + string(fname),
 							SHA:          curCommit.ID.String(),
@@ -143,7 +140,9 @@ func FindLFSFile(repo *git.Repository, hash git.SHA1) ([]*LFSResult, error) {
 						}
 						resultsMap[curCommit.ID.String()+":"+curPath+string(fname)] = &result
 					} else if string(mode) == git.EntryModeTree.String() {
-						trees = append(trees, sha)
+						sha40Byte := make([]byte, 40)
+						git.To40ByteSHA(sha20byte, sha40Byte)
+						trees = append(trees, sha40Byte)
 						paths = append(paths, curPath+string(fname)+"/")
 					}
 				}


### PR DESCRIPTION
Backport of #15856

* Create a copy of the sha bytes.

Co-authored-by: Andrew Thornton <art27@cantab.net>