### PR TITLE
Remove unimplemented searchbar from project view

### DIFF
--- a/templates/repo/projects/view.tmpl
+++ b/templates/repo/projects/view.tmpl
@@ -6,9 +6,6 @@
 			<div class="column">
 				{{template "repo/issue/navbar" .}}
 			</div>
-			<div class="column center aligned">
-				{{template "repo/issue/search" .}}
-			</div>
 			<div class="column right aligned">
 				{{if and .CanWriteProjects (not .Repository.IsArchived) .PageIsProjects}}
 					<a class="ui green button show-modal item" data-modal="#new-board-item">{{.i18n.Tr "new_project_board"}}</a>


### PR DESCRIPTION
This came up in discord; there is no handler for the search params on a project, and it is unclear to me how this searchbar should behave. As a quickfix remove it.
The searchbar was probably added by copy/paste error
