### PR TITLE
Fix authentication for /api/v1/orgs/<org>/teams/*

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -992,7 +992,7 @@ func Routes() *web.Route {
 				m.Combo("", reqToken()).Get(org.ListTeams).
 					Post(reqOrgOwnership(), bind(api.CreateTeamOption{}), org.CreateTeam)
 				m.Get("/search", org.SearchTeam)
-			}, reqOrgMembership())
+			}, reqToken(), reqOrgMembership())
 			m.Group("/labels", func() {
 				m.Get("", org.ListLabels)
 				m.Post("", reqToken(), reqOrgOwnership(), bind(api.CreateLabelOption{}), org.CreateLabel)


### PR DESCRIPTION
These routes would throw 500 errors when called without a authenticated user.
fixes #16192