### PR TITLE
Restore token authentication for git http when 2FA active

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -174,7 +174,7 @@ func httpBase(ctx *context.Context) (h *serviceHandler) {
 			return
 		}
 
-		if ctx.IsBasicAuth {
+		if ctx.IsBasicAuth && ctx.Data["IsApiToken"] != true {
 			_, err = models.GetTwoFactorByUID(ctx.User.ID)
 			if err == nil {
 				// TODO: This response should be changed to "invalid credentials" for security reasons once the expectation behind it (creating an app token to authenticate) is properly documented


### PR DESCRIPTION
There was a small regression in #15303 whereby token auth
with 2FA active would be disallowed.

This PR fixes this.

Signed-off-by: Andrew Thornton <art27@cantab.net>
