### PR TITLE
Disable legal comments in esbuild

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,7 @@ export default {
         target: 'es2015',
         minify: true,
         css: true,
+        legalComments: 'none',
       }),
     ],
     splitChunks: {


### PR DESCRIPTION
We already serve licenses.txt so we don't need these inline comments preserved during esbuild minification. Saves around 4kB before gzip.

Ref: https://esbuild.github.io/api/#legal-comments