### PR TITLE
fix default avatar url

### DIFF
--- a/templates/repo/diff/comments.tmpl
+++ b/templates/repo/diff/comments.tmpl
@@ -3,7 +3,7 @@
 {{ $createdStr:= TimeSinceUnix .CreatedUnix $.root.Lang }}
 <div class="comment" id="{{.HashTag}}">
 	{{if .OriginalAuthor }}
-		<span class="avatar"><img src="{{AppSubUrl}}/img/avatar_default.png"></span>
+		<span class="avatar"><img src="{{AppSubUrl}}/assets/img/avatar_default.png"></span>
 	{{else}}
 		<a class="avatar" {{if gt .Poster.ID 0}}href="{{.Poster.HomeLink}}"{{end}}>
 			{{avatar .Poster}}

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -13,7 +13,7 @@
 		<ui class="ui timeline">
 			<div id="{{.Issue.HashTag}}" class="timeline-item comment first">
 			{{if .Issue.OriginalAuthor }}
-				<span class="timeline-avatar"><img src="{{AppSubUrl}}/img/avatar_default.png"></span>
+				<span class="timeline-avatar"><img src="{{AppSubUrl}}/assets/img/avatar_default.png"></span>
 			{{else}}
 				<a class="timeline-avatar" {{if gt .Issue.Poster.ID 0}}href="{{.Issue.Poster.HomeLink}}"{{end}}>
 					{{avatar .Issue.Poster}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -13,7 +13,7 @@
 	{{if eq .Type 0}}
 		<div class="timeline-item comment" id="{{.HashTag}}">
 		{{if .OriginalAuthor }}
-			<span class="timeline-avatar"><img src="{{AppSubUrl}}/img/avatar_default.png"></span>
+			<span class="timeline-avatar"><img src="{{AppSubUrl}}/assets/img/avatar_default.png"></span>
 		{{else}}
 			<a class="timeline-avatar" {{if gt .Poster.ID 0}}href="{{.Poster.HomeLink}}"{{end}}>
 				{{avatar .Poster}}


### PR DESCRIPTION
Fixes a regression from #15219: avatars in old issue comments of migrated repositories were broken

