### PR TITLE
Add email headers

### DIFF
--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -11,6 +11,7 @@ import (
 	"html/template"
 	"mime"
 	"regexp"
+	"strconv"
 	"strings"
 	texttmpl "text/template"
 
@@ -174,7 +175,7 @@ func SendCollaboratorMail(u, doer *models.User, repo *models.Repository) {
 	SendAsync(msg)
 }
 
-func composeIssueCommentMessages(ctx *mailCommentContext, lang string, tos []string, fromMention bool, info string) ([]*Message, error) {
+func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipients []*models.User, fromMention bool, info string) ([]*Message, error) {
 	var (
 		subject string
 		link    string
@@ -265,9 +266,9 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, tos []str
 	}
 
 	// Make sure to compose independent messages to avoid leaking user emails
-	msgs := make([]*Message, 0, len(tos))
-	for _, to := range tos {
-		msg := NewMessageFrom([]string{to}, ctx.Doer.DisplayName(), setting.MailService.FromEmail, subject, mailBody.String())
+	msgs := make([]*Message, 0, len(recipients))
+	for _, recipient := range recipients {
+		msg := NewMessageFrom([]string{recipient.Email}, ctx.Doer.DisplayName(), setting.MailService.FromEmail, subject, mailBody.String())
 		msg.Info = fmt.Sprintf("Subject: %s, %s", subject, info)
 
 		// Set Message-ID on first message so replies know what to reference
@@ -277,10 +278,49 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, tos []str
 			msg.SetHeader("In-Reply-To", "<"+ctx.Issue.ReplyReference()+">")
 			msg.SetHeader("References", "<"+ctx.Issue.ReplyReference()+">")
 		}
+
+		for key, value := range generateAdditionalHeaders(ctx, actType, recipient) {
+			msg.SetHeader(key, value)
+		}
+
 		msgs = append(msgs, msg)
 	}
 
 	return msgs, nil
+}
+
+func generateAdditionalHeaders(ctx *mailCommentContext, actionType string, recipient *models.User) map[string]string {
+	repo := ctx.Issue.Repo
+
+	return map[string]string{
+		// https://datatracker.ietf.org/doc/html/rfc2919
+		"List-ID": fmt.Sprintf("%s <%s.%s.%s>", repo.FullName(), repo.Name, repo.OwnerName, setting.Domain),
+
+		// https://datatracker.ietf.org/doc/html/rfc2369
+		"List-Archive": fmt.Sprintf("<%s>", repo.HTMLURL()),
+		//"List-Post": https://github.com/go-gitea/gitea/pull/13585
+		//"List-Unsubscribe": https://github.com/go-gitea/gitea/issues/10808, https://github.com/go-gitea/gitea/issues/13283
+
+		"X-Gitea-Reason":            actionType,
+		"X-Gitea-Sender":            ctx.Doer.DisplayName(),
+		"X-Gitea-Recipient":         recipient.DisplayName(),
+		"X-Gitea-Recipient-Address": recipient.Email,
+		"X-Gitea-Repository":        repo.Name,
+		"X-Gitea-Repository-Path":   repo.FullName(),
+		"X-Gitea-Repository-Link":   repo.HTMLURL(),
+		"X-Gitea-Issue-ID":          strconv.FormatInt(ctx.Issue.Index, 10),
+		"X-Gitea-Issue-Link":        ctx.Issue.HTMLURL(),
+
+		"X-GitHub-Reason":            actionType,
+		"X-GitHub-Sender":            ctx.Doer.DisplayName(),
+		"X-GitHub-Recipient":         recipient.DisplayName(),
+		"X-GitHub-Recipient-Address": recipient.Email,
+
+		"X-GitLab-NotificationReason": actionType,
+		"X-GitLab-Project":            repo.Name,
+		"X-GitLab-Project-Path":       repo.FullName(),
+		"X-GitLab-Issue-IID":          strconv.FormatInt(ctx.Issue.Index, 10),
+	}
 }
 
 func sanitizeSubject(subject string) string {
@@ -294,9 +334,9 @@ func sanitizeSubject(subject string) string {
 
 // SendIssueAssignedMail composes and sends issue assigned email
 func SendIssueAssignedMail(issue *models.Issue, doer *models.User, content string, comment *models.Comment, recipients []*models.User) error {
-	langMap := make(map[string][]string)
+	langMap := make(map[string][]*models.User)
 	for _, user := range recipients {
-		langMap[user.Language] = append(langMap[user.Language], user.Email)
+		langMap[user.Language] = append(langMap[user.Language], user)
 	}
 
 	for lang, tos := range langMap {

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -289,7 +289,7 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipient
 	return msgs, nil
 }
 
-func generateAdditionalHeaders(ctx *mailCommentContext, actionType string, recipient *models.User) map[string]string {
+func generateAdditionalHeaders(ctx *mailCommentContext, reason string, recipient *models.User) map[string]string {
 	repo := ctx.Issue.Repo
 
 	return map[string]string{
@@ -301,7 +301,7 @@ func generateAdditionalHeaders(ctx *mailCommentContext, actionType string, recip
 		//"List-Post": https://github.com/go-gitea/gitea/pull/13585
 		//"List-Unsubscribe": https://github.com/go-gitea/gitea/issues/10808, https://github.com/go-gitea/gitea/issues/13283
 
-		"X-Gitea-Reason":            actionType,
+		"X-Gitea-Reason":            reason,
 		"X-Gitea-Sender":            ctx.Doer.DisplayName(),
 		"X-Gitea-Recipient":         recipient.DisplayName(),
 		"X-Gitea-Recipient-Address": recipient.Email,
@@ -311,12 +311,12 @@ func generateAdditionalHeaders(ctx *mailCommentContext, actionType string, recip
 		"X-Gitea-Issue-ID":          strconv.FormatInt(ctx.Issue.Index, 10),
 		"X-Gitea-Issue-Link":        ctx.Issue.HTMLURL(),
 
-		"X-GitHub-Reason":            actionType,
+		"X-GitHub-Reason":            reason,
 		"X-GitHub-Sender":            ctx.Doer.DisplayName(),
 		"X-GitHub-Recipient":         recipient.DisplayName(),
 		"X-GitHub-Recipient-Address": recipient.Email,
 
-		"X-GitLab-NotificationReason": actionType,
+		"X-GitLab-NotificationReason": reason,
 		"X-GitLab-Project":            repo.Name,
 		"X-GitLab-Project-Path":       repo.FullName(),
 		"X-GitLab-Issue-IID":          strconv.FormatInt(ctx.Issue.Index, 10),

--- a/services/mailer/mail_issue.go
+++ b/services/mailer/mail_issue.go
@@ -116,7 +116,7 @@ func mailIssueCommentBatch(ctx *mailCommentContext, users []*models.User, visite
 		checkUnit = models.UnitTypePullRequests
 	}
 
-	langMap := make(map[string][]string)
+	langMap := make(map[string][]*models.User)
 	for _, user := range users {
 		// At this point we exclude:
 		// user that don't have all mails enabled or users only get mail on mention and this is one ...
@@ -138,7 +138,7 @@ func mailIssueCommentBatch(ctx *mailCommentContext, users []*models.User, visite
 			continue
 		}
 
-		langMap[user.Language] = append(langMap[user.Language], user.Email)
+		langMap[user.Language] = append(langMap[user.Language], user)
 	}
 
 	for lang, receivers := range langMap {


### PR DESCRIPTION
fixes #15926
related #13585, #10808, #13283

Added some custom headers to issue emails to support better filters. See #15926 for details.

Like in webhooks I have added `X-GitHub-` and `X-GitLab-` headers too but want your opinion if we want to send them or not. The `...-Reason` header may not match what they are sending.

Part of a test mail (sorted):
```
In-Reply-To: <KN4CK3R/TestRepo/issues/1@localhost>
List-Archive: <http://localhost:3000/KN4CK3R/TestRepo>
List-ID: KN4CK3R/TestRepo <TestRepo.KN4CK3R.localhost>
References: <KN4CK3R/TestRepo/issues/1@localhost>
Subject: Re: [KN4CK3R/TestRepo] Test (#1)
To: kn4ck3r@gitea.test
X-Auto-Response-Suppress: All
X-GitHub-Reason: issue
X-GitHub-Recipient-Address: kn4ck3r@gitea.test
X-GitHub-Recipient: KN4CK3R
X-GitHub-Sender: KN4CK3R2
X-GitLab-Issue-IID: 1
X-GitLab-NotificationReason: issue
X-GitLab-Project-Path: KN4CK3R/TestRepo
X-GitLab-Project: TestRepo
X-Gitea-Issue-ID: 1
X-Gitea-Issue-Link: http://localhost:3000/KN4CK3R/TestRepo/issues/1
X-Gitea-Reason: issue
X-Gitea-Recipient-Address: kn4ck3r@gitea.test
X-Gitea-Recipient: KN4CK3R
X-Gitea-Repository-Link: http://localhost:3000/KN4CK3R/TestRepo
X-Gitea-Repository-Path: KN4CK3R/TestRepo
X-Gitea-Repository: TestRepo
X-Gitea-Sender: KN4CK3R2
```