### PR TITLE
Double the avatar size factor

### DIFF
--- a/models/avatar.go
+++ b/models/avatar.go
@@ -44,7 +44,7 @@ const DefaultAvatarSize = -1
 const DefaultAvatarPixelSize = 28
 
 // AvatarRenderedSizeFactor is the factor by which the default size is increased for finer rendering
-const AvatarRenderedSizeFactor = 2
+const AvatarRenderedSizeFactor = 4
 
 // HashEmail hashes email address to MD5 string.
 // https://en.gravatar.com/site/implement/hash/

--- a/modules/repository/commits_test.go
+++ b/modules/repository/commits_test.go
@@ -112,13 +112,13 @@ func TestPushCommits_AvatarLink(t *testing.T) {
 	pushCommits.Len = len(pushCommits.Commits)
 
 	assert.Equal(t,
-		"https://secure.gravatar.com/avatar/ab53a2911ddf9b4817ac01ddcd3d975f?d=identicon&s=56",
+		"https://secure.gravatar.com/avatar/ab53a2911ddf9b4817ac01ddcd3d975f?d=identicon&s=112",
 		pushCommits.AvatarLink("user2@example.com"))
 
 	assert.Equal(t,
 		"https://secure.gravatar.com/avatar/"+
 			fmt.Sprintf("%x", md5.Sum([]byte("nonexistent@example.com")))+
-			"?d=identicon&s=56",
+			"?d=identicon&s=112",
 		pushCommits.AvatarLink("nonexistent@example.com"))
 }
 


### PR DESCRIPTION
This results in finer Avatar rendering on Hi-DPI display for external avatars like Gravatar.

Before:
<img width="83" alt="Screen Shot 2021-05-21 at 17 59 55" src="https://user-images.githubusercontent.com/115237/119166492-f977c400-ba5e-11eb-8c72-79bd32381c7d.png">

After:
<img width="85" alt="Screen Shot 2021-05-21 at 18 01 49" src="https://user-images.githubusercontent.com/115237/119166506-fda3e180-ba5e-11eb-8073-04b287a26384.png">
