### PR TITLE
Change default queue settings to be low go-routines

### DIFF
--- a/modules/setting/indexer.go
+++ b/modules/setting/indexer.go
@@ -51,7 +51,7 @@ var (
 		IssueConnStr:          "",
 		IssueIndexerName:      "gitea_issues",
 		IssueQueueType:        LevelQueueType,
-		IssueQueueDir:         "indexers/issues.queue",
+		IssueQueueDir:         "queues/common",
 		IssueQueueConnStr:     "",
 		IssueQueueBatchNumber: 20,
 
@@ -76,7 +76,7 @@ func newIndexerService() {
 	Indexer.IssueIndexerName = sec.Key("ISSUE_INDEXER_NAME").MustString(Indexer.IssueIndexerName)
 
 	Indexer.IssueQueueType = sec.Key("ISSUE_INDEXER_QUEUE_TYPE").MustString(LevelQueueType)
-	Indexer.IssueQueueDir = sec.Key("ISSUE_INDEXER_QUEUE_DIR").MustString(path.Join(AppDataPath, "indexers/issues.queue"))
+	Indexer.IssueQueueDir = sec.Key("ISSUE_INDEXER_QUEUE_DIR").MustString(path.Join(AppDataPath, "queues/common"))
 	Indexer.IssueQueueConnStr = sec.Key("ISSUE_INDEXER_QUEUE_CONN_STR").MustString("")
 	Indexer.IssueQueueBatchNumber = sec.Key("ISSUE_INDEXER_QUEUE_BATCH_NUMBER").MustInt(20)
 

--- a/modules/setting/queue.go
+++ b/modules/setting/queue.go
@@ -48,7 +48,7 @@ func GetQueueSettings(name string) QueueSettings {
 	q.Name = name
 
 	// DataDir is not directly inheritable
-	q.DataDir = filepath.Join(Queue.DataDir, name)
+	q.DataDir = filepath.Join(Queue.DataDir, "common")
 	// QueueName is not directly inheritable either
 	q.QueueName = name + Queue.QueueName
 	for _, key := range sec.Keys() {
@@ -103,11 +103,11 @@ func NewQueueService() {
 	Queue.WrapIfNecessary = sec.Key("WRAP_IF_NECESSARY").MustBool(true)
 	Queue.MaxAttempts = sec.Key("MAX_ATTEMPTS").MustInt(10)
 	Queue.Timeout = sec.Key("TIMEOUT").MustDuration(GracefulHammerTime + 30*time.Second)
-	Queue.Workers = sec.Key("WORKERS").MustInt(1)
+	Queue.Workers = sec.Key("WORKERS").MustInt(0)
 	Queue.MaxWorkers = sec.Key("MAX_WORKERS").MustInt(10)
 	Queue.BlockTimeout = sec.Key("BLOCK_TIMEOUT").MustDuration(1 * time.Second)
 	Queue.BoostTimeout = sec.Key("BOOST_TIMEOUT").MustDuration(5 * time.Minute)
-	Queue.BoostWorkers = sec.Key("BOOST_WORKERS").MustInt(5)
+	Queue.BoostWorkers = sec.Key("BOOST_WORKERS").MustInt(1)
 	Queue.QueueName = sec.Key("QUEUE_NAME").MustString("_queue")
 	Queue.SetName = sec.Key("SET_NAME").MustString("")
 


### PR DESCRIPTION
This PR suggests a change to the default configuration for queues:

* Use a common DATADIR for the queues
* Set starting workers to 0 and make boost a single worker

This will change the baseline default go-routine number to 31.

Fixes #15542

## :warning: BREAKING :warning: 

* As a result of this PR instead of each queue having their own level db by default, the queues will use a common level db. It is recommended to ensure that queues are empty before upgrading using `gitea manager flush-queues` or on the admin pages.
* Starting workers are now 0 with boost workers at 1. If you have explicitly set BOOST_WORKERS = 0 you will need to explicitly set `WORKERS` to at least 1. Administrators of busy sites should tune their WORKERS, BOOST_WORKERS, & DATADIR parameters as needed. 

Signed-off-by: Andrew Thornton <art27@cantab.net>
