### PR TITLE
Allow Token/Basic auth on raw paths

### DIFF
--- a/modules/auth/sso/basic.go
+++ b/modules/auth/sso/basic.go
@@ -51,7 +51,7 @@ func (b *Basic) IsEnabled() bool {
 func (b *Basic) VerifyAuthData(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *models.User {
 
 	// Basic authentication should only fire on API, Download or on Git or LFSPaths
-	if middleware.IsInternalPath(req) || !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitOrLFSPath(req) {
+	if middleware.IsInternalPath(req) || !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawOrLFSPath(req) {
 		return nil
 	}
 

--- a/modules/auth/sso/reverseproxy.go
+++ b/modules/auth/sso/reverseproxy.go
@@ -78,7 +78,7 @@ func (r *ReverseProxy) VerifyAuthData(req *http.Request, w http.ResponseWriter, 
 	}
 
 	// Make sure requests to API paths, attachment downloads, git and LFS do not create a new session
-	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitOrLFSPath(req) {
+	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawOrLFSPath(req) {
 		if sess.Get("uid").(int64) != user.ID {
 			handleSignIn(w, req, sess, user)
 		}

--- a/modules/auth/sso/sso.go
+++ b/modules/auth/sso/sso.go
@@ -104,11 +104,11 @@ func isAttachmentDownload(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, "/attachments/") && req.Method == "GET"
 }
 
-var gitPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/))`)
+var gitRawPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/)|raw/)`)
 var lfsPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/info/lfs/`)
 
-func isGitOrLFSPath(req *http.Request) bool {
-	if gitPathRe.MatchString(req.URL.Path) {
+func isGitRawOrLFSPath(req *http.Request) bool {
+	if gitRawPathRe.MatchString(req.URL.Path) {
 		return true
 	}
 	if setting.LFS.StartServer {

--- a/modules/auth/sso/sso_test.go
+++ b/modules/auth/sso/sso_test.go
@@ -12,7 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 )
 
-func Test_isGitOrLFSPath(t *testing.T) {
+func Test_isGitRawOrLFSPath(t *testing.T) {
 
 	tests := []struct {
 		path string
@@ -64,6 +64,10 @@ func Test_isGitOrLFSPath(t *testing.T) {
 			true,
 		},
 		{
+			"/owner/repo/raw/branch/foo/fanaso",
+			true,
+		},
+		{
 			"/owner/repo/stars",
 			false,
 		},
@@ -98,11 +102,11 @@ func Test_isGitOrLFSPath(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			req, _ := http.NewRequest("POST", "http://localhost"+tt.path, nil)
 			setting.LFS.StartServer = false
-			if got := isGitOrLFSPath(req); got != tt.want {
+			if got := isGitRawOrLFSPath(req); got != tt.want {
 				t.Errorf("isGitOrLFSPath() = %v, want %v", got, tt.want)
 			}
 			setting.LFS.StartServer = true
-			if got := isGitOrLFSPath(req); got != tt.want {
+			if got := isGitRawOrLFSPath(req); got != tt.want {
 				t.Errorf("isGitOrLFSPath() = %v, want %v", got, tt.want)
 			}
 		})
@@ -111,11 +115,11 @@ func Test_isGitOrLFSPath(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt, nil)
 			setting.LFS.StartServer = false
-			if got := isGitOrLFSPath(req); got != setting.LFS.StartServer {
-				t.Errorf("isGitOrLFSPath(%q) = %v, want %v, %v", tt, got, setting.LFS.StartServer, gitPathRe.MatchString(tt))
+			if got := isGitRawOrLFSPath(req); got != setting.LFS.StartServer {
+				t.Errorf("isGitOrLFSPath(%q) = %v, want %v, %v", tt, got, setting.LFS.StartServer, gitRawPathRe.MatchString(tt))
 			}
 			setting.LFS.StartServer = true
-			if got := isGitOrLFSPath(req); got != setting.LFS.StartServer {
+			if got := isGitRawOrLFSPath(req); got != setting.LFS.StartServer {
 				t.Errorf("isGitOrLFSPath(%q) = %v, want %v", tt, got, setting.LFS.StartServer)
 			}
 		})


### PR DESCRIPTION
It appears that people have been using token authentication to navigate to raw paths
and recent changes have broken this. Whilst ideally these paths would not be being used
like this - it was not the intention to be a breaking change.

This PR restores access to these paths.

Fix #13772

Signed-off-by: Andrew Thornton <art27@cantab.net>
