### PR TITLE
Make sshd_config more flexible regarding connections

### DIFF
--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -5,8 +5,8 @@ AddressFamily any
 ListenAddress 0.0.0.0
 ListenAddress ::
 
-MaxStartups ${SSHD_MAX_STARTUPS}
-MaxSessions ${SSHD_MAX_SESSIONS}
+MaxStartups ${SSH_MAX_STARTUPS}
+MaxSessions ${SSH_MAX_SESSIONS}
 
 LogLevel INFO
 

--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -5,6 +5,9 @@ AddressFamily any
 ListenAddress 0.0.0.0
 ListenAddress ::
 
+MaxStartups ${SSHD_MAX_STARTUPS}
+MaxSessions ${SSHD_MAX_SESSIONS}
+
 LogLevel INFO
 
 HostKey /data/ssh/ssh_host_ed25519_key


### PR DESCRIPTION
refs  #16008

Make sshd_config more flexible regarding MaxStartups and MaxSessions.

See https://man.openbsd.org/sshd_config
for more information.
