### PR TITLE
Fix bug in reverse proxy

### DIFF
--- a/modules/auth/sso/reverseproxy.go
+++ b/modules/auth/sso/reverseproxy.go
@@ -79,7 +79,7 @@ func (r *ReverseProxy) VerifyAuthData(req *http.Request, w http.ResponseWriter, 
 
 	// Make sure requests to API paths, attachment downloads, git and LFS do not create a new session
 	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawOrLFSPath(req) {
-		if sess.Get("uid").(int64) != user.ID {
+		if sess != nil && (sess.Get("uid") == nil || sess.Get("uid").(int64) != user.ID) {
 			handleSignIn(w, req, sess, user)
 		}
 	}


### PR DESCRIPTION
Unfortunately go panics you try to cast a nil interface{} as another primitive
therefore you need to check interfaces are not nil before casting.

Regression from #15304

Fix #16025

Signed-off-by: Andrew Thornton <art27@cantab.net>
