### PR TITLE
Fix bug due to missing MaxStartups and MaxSessions

### DIFF
--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -47,6 +47,8 @@ if [ -d /etc/ssh ]; then
     SSH_RSA_CERT="${SSH_RSA_CERT:+"HostCertificate "}${SSH_RSA_CERT}" \
     SSH_ECDSA_CERT="${SSH_ECDSA_CERT:+"HostCertificate "}${SSH_ECDSA_CERT}" \
     SSH_DSA_CERT="${SSH_DSA_CERT:+"HostCertificate "}${SSH_DSA_CERT}" \
+    SSH_MAX_STARTUPS="${SSH_MAX_STARTUPS:+"MaxStartups "}${SSH_MAX_STARTUPS}" \
+    SSH_MAX_SESSIONS="${SSH_MAX_SESSIONS:+"MaxSessions "}${SSH_MAX_SESSIONS}" \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -5,8 +5,8 @@ AddressFamily any
 ListenAddress 0.0.0.0
 ListenAddress ::
 
-MaxStartups ${SSH_MAX_STARTUPS}
-MaxSessions ${SSH_MAX_SESSIONS}
+${SSH_MAX_STARTUPS}
+${SSH_MAX_SESSIONS}
 
 LogLevel INFO
 


### PR DESCRIPTION
Unforunately #16009 makes these settings mandatory. This PR uses the same technique
as used for the certificates to make these settings non-mandatory.

Fix #16044

Signed-off-by: Andrew Thornton <art27@cantab.net>

