### PR TITLE
Fix case change in ownernames (#16045)

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1349,6 +1349,26 @@ func UpdateRepository(repo *Repository, visibilityChanged bool) (err error) {
 	return sess.Commit()
 }
 
+// UpdateRepositoryOwnerNames updates repository owner_names (this should only be used when the ownerName has changed case)
+func UpdateRepositoryOwnerNames(ownerID int64, ownerName string) error {
+	if ownerID == 0 {
+		return nil
+	}
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	if _, err := sess.Where("owner_id = ?", ownerID).Cols("owner_name").Update(&Repository{
+		OwnerName: ownerName,
+	}); err != nil {
+		return err
+	}
+
+	return sess.Commit()
+}
+
 // UpdateRepositoryUpdatedTime updates a repository's updated time
 func UpdateRepositoryUpdatedTime(repoID int64, updateTime time.Time) error {
 	_, err := x.Exec("UPDATE repository SET updated_unix = ? WHERE id = ?", updateTime.Unix(), repoID)

--- a/routers/user/setting/profile.go
+++ b/routers/user/setting/profile.go
@@ -67,8 +67,13 @@ func HandleUsernameChange(ctx *context.Context, user *models.User, newName strin
 			}
 			return err
 		}
-		log.Trace("User name changed: %s -> %s", user.Name, newName)
+	} else {
+		if err := models.UpdateRepositoryOwnerNames(user.ID, newName); err != nil {
+			ctx.ServerError("UpdateRepository", err)
+			return err
+		}
 	}
+	log.Trace("User name changed: %s -> %s", user.Name, newName)
 	return nil
 }
 
@@ -84,6 +89,7 @@ func ProfilePost(ctx *context.Context) {
 	}
 
 	if len(form.Name) != 0 && ctx.User.Name != form.Name {
+		log.Debug("Changing name for %s to %s", ctx.User.Name, form.Name)
 		if err := HandleUsernameChange(ctx, ctx.User, form.Name); err != nil {
 			ctx.Redirect(setting.AppSubURL + "/user/settings")
 			return


### PR DESCRIPTION
Backport #16045

If you change the case of a username the change needs to be propagated to their
repositories.

Signed-off-by: Andrew Thornton <art27@cantab.net>
