### PR TITLE
Change default TMPDIR path in rootless containers

### DIFF
--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -60,6 +60,8 @@ USER git:git
 ENV GITEA_WORK_DIR /var/lib/gitea
 ENV GITEA_CUSTOM /var/lib/gitea/custom
 ENV GITEA_TEMP /tmp/gitea
+ENV TMPDIR /tmp/gitea
+
 #TODO add to docs the ability to define the ini to load (usefull to test and revert a config)
 ENV GITEA_APP_INI /etc/gitea/app.ini
 ENV HOME "/var/lib/gitea/git"


### PR DESCRIPTION
Using the current helm-chart with the rootless image and all `securityContext` options enabled breaks the repository creation. GItea cannot write into the `/tmp` directory. While this can be fixed without this change by overwriting the `TMPDIR` environment variable from the Kubernetes resources, the image itself should use a default path that works in all environments properly.

Signed-off-by: Steven Kriegler <61625851+justusbunsi@users.noreply.github.com>

Fixes: https://github.com/go-gitea/gitea/issues/15875