### PR TITLE
git migration: don't prompt interactively for clone credentials (#15902)

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -124,11 +124,17 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 
 	cmd := exec.CommandContext(ctx, c.name, c.args...)
 	if env == nil {
-		cmd.Env = append(os.Environ(), fmt.Sprintf("LC_ALL=%s", DefaultLocale))
+		cmd.Env = os.Environ()
 	} else {
 		cmd.Env = env
-		cmd.Env = append(cmd.Env, fmt.Sprintf("LC_ALL=%s", DefaultLocale))
 	}
+
+	cmd.Env = append(
+		cmd.Env,
+		fmt.Sprintf("LC_ALL=%s", DefaultLocale),
+		// avoid prompting for credentials interactively, supported since git v2.3
+		"GIT_TERMINAL_PROMPT=0",
+	)
 
 	// TODO: verify if this is still needed in golang 1.15
 	if goVersionLessThan115 {


### PR DESCRIPTION
Backport #15902