### PR TITLE
Fix regression of renderer

### DIFF
--- a/modules/setting/markup.go
+++ b/modules/setting/markup.go
@@ -38,6 +38,8 @@ type MarkupSanitizerRule struct {
 }
 
 func newMarkup() {
+	ExternalMarkupRenderers = make([]MarkupRenderer, 0, 10)
+	ExternalSanitizerRules = make([]MarkupSanitizerRule, 0, 10)
 	for _, sec := range Cfg.Section("markup").ChildSections() {
 		name := strings.TrimPrefix(sec.Name(), "markup.")
 		if name == "" {


### PR DESCRIPTION
Unfortunately, #15175 missed a feature that `csv` or external renderer could ignore `PostProcess` to make the render speed up which introduced at #15153. This PR will fix that.

This PR also fixed another bug which external renderers will load twice when settings reload. From https://discord.com/channels/322538954119184384/323701541297192961/851123308321046538 thanks @KN4CK3R 