### PR TITLE
Add X-Hub-Signature header to webhook deliveries

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -127,6 +127,7 @@ type Webhook struct {
 	IsSystemWebhook bool
 	URL             string `xorm:"url TEXT"`
 	Signature       string `xorm:"TEXT"`
+	SignatureGitub  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`
 	ContentType     HookContentType
 	Secret          string `xorm:"TEXT"`
@@ -654,6 +655,7 @@ type HookTask struct {
 	Typ             HookTaskType `xorm:"VARCHAR(16) index"`
 	URL             string       `xorm:"TEXT"`
 	Signature       string       `xorm:"TEXT"`
+	SignatureGithub string       `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -655,7 +655,7 @@ type HookTask struct {
 	Typ             HookTaskType `xorm:"VARCHAR(16) index"`
 	URL             string       `xorm:"TEXT"`
 	Signature       string       `xorm:"TEXT"`
-	SignatureGithub string       `xorm:"TEXT"`
+	SignatureSHA1   string       `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	HTTPMethod      string `xorm:"http_method"`

--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -97,6 +97,7 @@ func Deliver(t *models.HookTask) error {
 	req.Header.Add("X-Gogs-Delivery", t.UUID)
 	req.Header.Add("X-Gogs-Event", t.EventType.Event())
 	req.Header.Add("X-Gogs-Signature", t.Signature)
+	req.Header.Add("X-Hub-Signature", t.SignatureGithub)
 	req.Header["X-GitHub-Delivery"] = []string{t.UUID}
 	req.Header["X-GitHub-Event"] = []string{t.EventType.Event()}
 

--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -97,7 +97,7 @@ func Deliver(t *models.HookTask) error {
 	req.Header.Add("X-Gogs-Delivery", t.UUID)
 	req.Header.Add("X-Gogs-Event", t.EventType.Event())
 	req.Header.Add("X-Gogs-Signature", t.Signature)
-	req.Header.Add("X-Hub-Signature", t.SignatureGithub)
+	req.Header.Add("X-Hub-Signature", "sha1="+t.SignatureSHA1)
 	req.Header["X-GitHub-Delivery"] = []string{t.UUID}
 	req.Header["X-GitHub-Event"] = []string{t.EventType.Event()}
 

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -195,17 +195,17 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 	}
 
 	if err = models.CreateHookTask(&models.HookTask{
-		RepoID:						repo.ID,
-		HookID:						w.ID,
-		Typ:							w.Type,
-		URL:							w.URL,
-		Signature:				signature,
-		SignatureGithub:	signaturegithub,
-		Payloader:				payloader,
-		HTTPMethod:				w.HTTPMethod,
-		ContentType:			w.ContentType,
-		EventType:				event,
-		IsSSL:						w.IsSSL,
+		RepoID:          repo.ID,
+		HookID:          w.ID,
+		Typ:             w.Type,
+		URL:             w.URL,
+		Signature:       signature,
+		SignatureGithub: signaturegithub,
+		Payloader:       payloader,
+		HTTPMethod:      w.HTTPMethod,
+		ContentType:     w.ContentType,
+		EventType:       event,
+		IsSSL:           w.IsSSL,
 	}); err != nil {
 		return fmt.Errorf("CreateHookTask: %v", err)
 	}

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -195,17 +195,17 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 	}
 
 	if err = models.CreateHookTask(&models.HookTask{
-		RepoID:      			repo.ID,
-		HookID:      			w.ID,
-		Typ:         			w.Type,
-		URL:         			w.URL,
-		Signature:   			signature,
+		RepoID:						repo.ID,
+		HookID:						w.ID,
+		Typ:							w.Type,
+		URL:							w.URL,
+		Signature:				signature,
 		SignatureGithub:	signaturegithub,
-		Payloader:   			payloader,
-		HTTPMethod:  			w.HTTPMethod,
-		ContentType: 			w.ContentType,
-		EventType:   			event,
-		IsSSL:       			w.IsSSL,
+		Payloader:				payloader,
+		HTTPMethod:				w.HTTPMethod,
+		ContentType:			w.ContentType,
+		EventType:				event,
+		IsSSL:						w.IsSSL,
 	}); err != nil {
 		return fmt.Errorf("CreateHookTask: %v", err)
 	}

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -200,7 +200,7 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 		Typ:         			w.Type,
 		URL:         			w.URL,
 		Signature:   			signature,
-		SignatureGithub: 	signaturegithub,
+		SignatureGithub:	signaturegithub,
 		Payloader:   			payloader,
 		HTTPMethod:  			w.HTTPMethod,
 		ContentType: 			w.ContentType,

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -180,7 +180,7 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 		signature = hex.EncodeToString(sig.Sum(nil))
 	}
 
-	var signaturegithub string
+	var signatureSHA1 string
 	if len(w.Secret) > 0 {
 		data, err := payloader.JSONPayload()
 		if err != nil {
@@ -191,21 +191,21 @@ func prepareWebhook(w *models.Webhook, repo *models.Repository, event models.Hoo
 		if err != nil {
 			log.Error("prepareWebhooks.sigWrite: %v", err)
 		}
-		signaturegithub = "sha1=" + hex.EncodeToString(sig.Sum(nil))
+		signatureSHA1 = hex.EncodeToString(sig.Sum(nil))
 	}
 
 	if err = models.CreateHookTask(&models.HookTask{
-		RepoID:          repo.ID,
-		HookID:          w.ID,
-		Typ:             w.Type,
-		URL:             w.URL,
-		Signature:       signature,
-		SignatureGithub: signaturegithub,
-		Payloader:       payloader,
-		HTTPMethod:      w.HTTPMethod,
-		ContentType:     w.ContentType,
-		EventType:       event,
-		IsSSL:           w.IsSSL,
+		RepoID:        repo.ID,
+		HookID:        w.ID,
+		Typ:           w.Type,
+		URL:           w.URL,
+		Signature:     signature,
+		SignatureSHA1: signatureSHA1,
+		Payloader:     payloader,
+		HTTPMethod:    w.HTTPMethod,
+		ContentType:   w.ContentType,
+		EventType:     event,
+		IsSSL:         w.IsSSL,
 	}); err != nil {
 		return fmt.Errorf("CreateHookTask: %v", err)
 	}


### PR DESCRIPTION
This PR adds support for Github style webhook integration by adding X-Hub-Signature header to webhook deliveries.

It fixes https://github.com/go-gitea/gitea/issues/7788