### PR TITLE
Fix data URI scramble (#16098)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -403,24 +403,19 @@ func (ctx *postProcessCtx) visitNode(node *html.Node, visitText bool) {
 		}
 	case html.ElementNode:
 		if node.Data == "img" {
-			attrs := node.Attr
-			for idx, attr := range attrs {
+			for _, attr := range node.Attr {
 				if attr.Key != "src" {
 					continue
 				}
-				link := []byte(attr.Val)
-				if len(link) > 0 && !IsLink(link) {
+				if len(attr.Val) > 0 && !isLinkStr(attr.Val) && !strings.HasPrefix(attr.Val, "data:image/") {
 					prefix := ctx.urlPrefix
 					if ctx.isWikiMarkdown {
 						prefix = util.URLJoin(prefix, "wiki", "raw")
 					}
 					prefix = strings.Replace(prefix, "/src/", "/media/", 1)
 
-					lnk := string(link)
-					lnk = util.URLJoin(prefix, lnk)
-					link = []byte(lnk)
+					attr.Val = util.URLJoin(prefix, attr.Val)
 				}
-				node.Attr[idx].Val = string(link)
 			}
 		} else if node.Data == "a" {
 			visitText = false

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -420,11 +420,8 @@ func TestIssue16020(t *testing.T) {
 
 	data := `<img src="data:image/png;base64,i//V"/>`
 
-	var res strings.Builder
-	err := PostProcess(&RenderContext{
-		URLPrefix: "https://example.com",
-		Metas:     localMetas,
-	}, strings.NewReader(data), &res)
+	// func PostProcess(rawHTML []byte, urlPrefix string, metas map[string]string, isWikiMarkdown bool) ([]byte, error)
+	res, err := PostProcess([]byte(data), "https://example.com", localMetas, false)
 	assert.NoError(t, err)
-	assert.Equal(t, data, res.String())
+	assert.Equal(t, data, string(res))
 }

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -408,3 +408,23 @@ func Test_ParseClusterFuzz(t *testing.T) {
 
 	assert.NotContains(t, string(val), "<html")
 }
+
+func TestIssue16020(t *testing.T) {
+	setting.AppURL = AppURL
+	setting.AppSubURL = AppSubURL
+
+	var localMetas = map[string]string{
+		"user": "go-gitea",
+		"repo": "gitea",
+	}
+
+	data := `<img src="data:image/png;base64,i//V"/>`
+
+	var res strings.Builder
+	err := PostProcess(&RenderContext{
+		URLPrefix: "https://example.com",
+		Metas:     localMetas,
+	}, strings.NewReader(data), &res)
+	assert.NoError(t, err)
+	assert.Equal(t, data, res.String())
+}


### PR DESCRIPTION
Backport #16098

* No prefix for data uris.

* Added test to prevent regressions.