### PR TITLE
Remove utf8 option from installation page

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -78,7 +78,6 @@
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 								<div class="menu">
 									<div class="item" data-value="utf8mb4">utf8mb4</div>
-									<div class="item" data-value="utf8">utf8</div>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
We should only support utf8mb4 for mysql database because it's real utf8 .

This will not break any old system but for newly create system, user have to chose utf8mb4.

Dont' remove it from installation page for reminding user to create a database with utf8mb4 character setting.