### PR TITLE
Removable media support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,14 +25,14 @@ environment:
 apps:
   gitea:
     command: gitea
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, removable-media]
   web:
     command: gitea web
     daemon: simple
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, removable-media]
   dump:
     command: gitea dump
-    plugs: [home]
+    plugs: [home, removable-media]
   version:
     command: gitea --version
   sqlite:


### PR DESCRIPTION
# Note
The snap version of the gitia are most convenient way to quickly install the gitea service. But snap version can not get accses to removable devices. For example mounted external drives. 

# Descritpion
Added support removable media for snap version of gitia.
For get more info about removable media interface see the snapcraft [documentation](https://snapcraft.io/docs/removable-media-interface)

