### PR TITLE
Fix private repo permission problem

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1613,6 +1613,7 @@ settings.transfer_form_title = Enter the repository name as confirmation:
 settings.transfer_in_progress = There is currently an ongoing transfer. Please cancel it if you will like to transfer this repository to another user.
 settings.transfer_notices_1 = - You will lose access to the repository if you transfer it to an individual user.
 settings.transfer_notices_2 = - You will keep access to the repository if you transfer it to an organization that you (co-)own.
+settings.transfer_notices_3 = - If the repository is private and is transferred to an individual user, this action makes sure that the user does have at least read permission (and changes permissions if necessary).
 settings.transfer_owner = New Owner
 settings.transfer_perform = Perform Transfer
 settings.transfer_started = This repository has been marked for transfer and awaits confirmation from "%s"

--- a/services/repository/transfer_test.go
+++ b/services/repository/transfer_test.go
@@ -52,3 +52,24 @@ func TestTransferOwnership(t *testing.T) {
 
 	models.CheckConsistencyFor(t, &models.Repository{}, &models.User{}, &models.Team{})
 }
+
+func TestStartRepositoryTransferSetPermission(t *testing.T) {
+	assert.NoError(t, models.PrepareTestDatabase())
+
+	doer := models.AssertExistsAndLoadBean(t, &models.User{ID: 3}).(*models.User)
+	recipient := models.AssertExistsAndLoadBean(t, &models.User{ID: 5}).(*models.User)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: 3}).(*models.Repository)
+	repo.Owner = models.AssertExistsAndLoadBean(t, &models.User{ID: repo.OwnerID}).(*models.User)
+
+	hasAccess, err := models.HasAccess(recipient.ID, repo)
+	assert.NoError(t, err)
+	assert.False(t, hasAccess)
+
+	assert.NoError(t, StartRepositoryTransfer(doer, recipient, repo, nil))
+
+	hasAccess, err = models.HasAccess(recipient.ID, repo)
+	assert.NoError(t, err)
+	assert.True(t, hasAccess)
+
+	models.CheckConsistencyFor(t, &models.Repository{}, &models.User{}, &models.Team{})
+}

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -649,7 +649,8 @@
 		<div class="content">
 			<div class="ui warning message text left">
 				{{.i18n.Tr "repo.settings.transfer_notices_1"}} <br>
-				{{.i18n.Tr "repo.settings.transfer_notices_2"}}
+				{{.i18n.Tr "repo.settings.transfer_notices_2"}} <br>
+				{{.i18n.Tr "repo.settings.transfer_notices_3"}}
 			</div>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}


### PR DESCRIPTION
This PR fixes a permission problem which could happen when transferring a private repo.  If the recipient did not have at least read access to repo it was not possible to accept the transfer. The fix here sets the read permission if the recipient does not have access.

Closes: https://github.com/go-gitea/gitea/issues/16006