### PR TITLE
v180 migration should be standalone

### DIFF
--- a/models/migrations/v180.go
+++ b/models/migrations/v180.go
@@ -5,9 +5,6 @@
 package migrations
 
 import (
-	"code.gitea.io/gitea/models"
-	"code.gitea.io/gitea/modules/migrations/base"
-	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
 	jsoniter "github.com/json-iterator/go"
@@ -16,20 +13,38 @@ import (
 )
 
 func deleteMigrationCredentials(x *xorm.Engine) (err error) {
+	// Task represents a task
+	type Task struct {
+		ID             int64
+		DoerID         int64 `xorm:"index"` // operator
+		OwnerID        int64 `xorm:"index"` // repo owner id, when creating, the repoID maybe zero
+		RepoID         int64 `xorm:"index"`
+		Type           int
+		Status         int `xorm:"index"`
+		StartTime      int64
+		EndTime        int64
+		PayloadContent string `xorm:"TEXT"`
+		Errors         string `xorm:"TEXT"` // if task failed, saved the error reason
+		Created        int64  `xorm:"created"`
+	}
+
+	const TaskTypeMigrateRepo = 0
+	const TaskStatusStopped = 2
+
 	const batchSize = 100
 
 	// only match migration tasks, that are not pending or running
 	cond := builder.Eq{
-		"type": structs.TaskTypeMigrateRepo,
+		"type": TaskTypeMigrateRepo,
 	}.And(builder.Gte{
-		"status": structs.TaskStatusStopped,
+		"status": TaskStatusStopped,
 	})
 
 	sess := x.NewSession()
 	defer sess.Close()
 
 	for start := 0; ; start += batchSize {
-		tasks := make([]*models.Task, 0, batchSize)
+		tasks := make([]*Task, 0, batchSize)
 		if err = sess.Limit(batchSize, start).Where(cond, 0).Find(&tasks); err != nil {
 			return
 		}
@@ -55,7 +70,41 @@ func deleteMigrationCredentials(x *xorm.Engine) (err error) {
 }
 
 func removeCredentials(payload string) (string, error) {
-	var opts base.MigrateOptions
+	// MigrateOptions defines the way a repository gets migrated
+	// this is for internal usage by migrations module and func who interact with it
+	type MigrateOptions struct {
+		// required: true
+		CloneAddr             string `json:"clone_addr" binding:"Required"`
+		CloneAddrEncrypted    string `json:"clone_addr_encrypted,omitempty"`
+		AuthUsername          string `json:"auth_username"`
+		AuthPassword          string `json:"-"`
+		AuthPasswordEncrypted string `json:"auth_password_encrypted,omitempty"`
+		AuthToken             string `json:"-"`
+		AuthTokenEncrypted    string `json:"auth_token_encrypted,omitempty"`
+		// required: true
+		UID int `json:"uid" binding:"Required"`
+		// required: true
+		RepoName        string `json:"repo_name" binding:"Required"`
+		Mirror          bool   `json:"mirror"`
+		LFS             bool   `json:"lfs"`
+		LFSEndpoint     string `json:"lfs_endpoint"`
+		Private         bool   `json:"private"`
+		Description     string `json:"description"`
+		OriginalURL     string
+		GitServiceType  int
+		Wiki            bool
+		Issues          bool
+		Milestones      bool
+		Labels          bool
+		Releases        bool
+		Comments        bool
+		PullRequests    bool
+		ReleaseAssets   bool
+		MigrateToRepoID int64
+		MirrorInterval  string `json:"mirror_interval"`
+	}
+
+	var opts MigrateOptions
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal([]byte(payload), &opts)
 	if err != nil {


### PR DESCRIPTION
Unfortunately the v180 migration picked up a few non-standalone dependencies. This PR
forcibly copies the important parts back into the migration.

Fix #16150

Signed-off-by: Andrew Thornton <art27@cantab.net>
