### PR TITLE
Only check access tokens if they are likely to be tokens (#16164)

### DIFF
--- a/models/token.go
+++ b/models/token.go
@@ -57,8 +57,14 @@ func GetAccessTokenBySHA(token string) (*AccessToken, error) {
 	if token == "" {
 		return nil, ErrAccessTokenEmpty{}
 	}
-	if len(token) < 8 {
+	// A token is defined as being SHA1 sum these are 40 hexadecimal bytes long
+	if len(token) != 40 {
 		return nil, ErrAccessTokenNotExist{token}
+	}
+	for _, x := range []byte(token) {
+		if x < '0' || (x > '9' && x < 'a') || x > 'f' {
+			return nil, ErrAccessTokenNotExist{token}
+		}
 	}
 	var tokens []AccessToken
 	lastEight := token[len(token)-8:]


### PR DESCRIPTION
Backport #16164

Gitea will currently check every if every password is an access token even though
most passwords are not and cannot be access tokens.

By creation access tokens are 40 byte hexadecimal strings therefore only these should
be checked.

Signed-off-by: Andrew Thornton <art27@cantab.net>
