### PR TITLE
Run processors on whole of text (#16155)

### DIFF
--- a/modules/emoji/emoji.go
+++ b/modules/emoji/emoji.go
@@ -6,6 +6,7 @@
 package emoji
 
 import (
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -145,6 +146,8 @@ func (n *rememberSecondWriteWriter) Write(p []byte) (int, error) {
 	if n.writecount == 2 {
 		n.idx = n.pos
 		n.end = n.pos + len(p)
+		n.pos += len(p)
+		return len(p), io.EOF
 	}
 	n.pos += len(p)
 	return len(p), nil
@@ -155,6 +158,8 @@ func (n *rememberSecondWriteWriter) WriteString(s string) (int, error) {
 	if n.writecount == 2 {
 		n.idx = n.pos
 		n.end = n.pos + len(s)
+		n.pos += len(s)
+		return len(s), io.EOF
 	}
 	n.pos += len(s)
 	return len(s), nil

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -425,3 +425,19 @@ func TestIssue16020(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, data, string(res))
 }
+
+func BenchmarkEmojiPostprocess(b *testing.B) {
+	data := "🥰 "
+	for len(data) < 1<<16 {
+		data += data
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := PostProcess(
+			[]byte(data),
+			"https://example.com",
+			localMetas,
+			false)
+		assert.NoError(b, err)
+	}
+}


### PR DESCRIPTION
Backport #16155

There is an inefficiency in the design of our processors which means that Emoji
and other processors run in order n^2 time.

This PR forces the processors to process the entirety of text node before passing
back up. The fundamental inefficiency remains but it should be significantly
ameliorated.

Signed-off-by: Andrew Thornton <art27@cantab.net>