### PR TITLE
Update documentation for Implicit TLS

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1387,8 +1387,8 @@ PATH =
 ;; Mail server
 ;; Gmail: smtp.gmail.com:587
 ;; QQ: smtp.qq.com:465
-;; Using STARTTLS on port 587 is recommended per RFC 6409.
-;; Note, if the port ends with "465", SMTPS will be used.
+;; As per RFC 8314 using Implicit TLS/SMTPS on port 465 (if supported) is recommended,
+;; otherwise STARTTLS on port 587 should be used.
 ;HOST =
 ;;
 ;; Disable HELO operation when hostnames are different.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -550,9 +550,9 @@ Define allowed algorithms and their minimum key length (use -1 to disable a type
 - `DISABLE_HELO`: **\<empty\>**: Disable HELO operation.
 - `HELO_HOSTNAME`: **\<empty\>**: Custom hostname for HELO operation.
 - `HOST`: **\<empty\>**: SMTP mail host address and port (example: smtp.gitea.io:587).
-  - Using opportunistic TLS via STARTTLS on port 587 is recommended per RFC 6409.
+  - As per RFC 8314, if supported, Implicit TLS/SMTPS on port 465 is recommended, otherwise opportunistic TLS via STARTTLS on port 587 should be used.
 - `IS_TLS_ENABLED` :  **false** : Forcibly use TLS to connect even if not on a default SMTPS port.
-  - Note, if the port ends with `465` SMTPS/SMTP over TLS will be used despite this setting.
+  - Note, if the port ends with `465` Implicit TLS/SMTPS/SMTP over TLS will be used despite this setting.
   - Otherwise if `IS_TLS_ENABLED=false` and the server supports `STARTTLS` this will be used. Thus if `STARTTLS` is preferred you should set `IS_TLS_ENABLED=false`.
 - `FROM`: **\<empty\>**: Mail from address, RFC 5322. This can be just an email address, or
    the "Name" \<email@example.com\> format.


### PR DESCRIPTION
As per RFC 8314, it is now recommended to prefer TLS over STARTTLS.

Fix #16160

Signed-off-by: Andrew Thornton <art27@cantab.net>