### PR TITLE
Use html.Parse rather than html.ParseFragment

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -309,6 +309,10 @@ func postProcess(ctx *RenderContext, procs []processor, input io.Reader, output 
 		return &postProcessError{"invalid HTML", err}
 	}
 
+	if node.Type == html.DocumentNode {
+		node = node.FirstChild
+	}
+
 	visitNode(ctx, procs, node, true)
 
 	newNodes := make([]*html.Node, 0, 5)

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -304,27 +304,22 @@ func postProcess(ctx *RenderContext, procs []processor, input io.Reader, output 
 	_, _ = res.WriteString("</body></html>")
 
 	// parse the HTML
-	nodes, err := html.ParseFragment(res, nil)
+	node, err := html.Parse(res)
 	if err != nil {
 		return &postProcessError{"invalid HTML", err}
 	}
 
-	for _, node := range nodes {
-		visitNode(ctx, procs, node, true)
+	visitNode(ctx, procs, node, true)
+
+	newNodes := make([]*html.Node, 0, 5)
+
+	if node.Data == "html" {
+		node = node.FirstChild
+		for node != nil && node.Data != "body" {
+			node = node.NextSibling
+		}
 	}
-
-	newNodes := make([]*html.Node, 0, len(nodes))
-
-	for _, node := range nodes {
-		if node.Data == "html" {
-			node = node.FirstChild
-			for node != nil && node.Data != "body" {
-				node = node.NextSibling
-			}
-		}
-		if node == nil {
-			continue
-		}
+	if node != nil {
 		if node.Data == "body" {
 			child := node.FirstChild
 			for child != nil {


### PR DESCRIPTION
There have been a few issues with html.ParseFragment - just use html.Parse instead.

Signed-off-by: Andrew Thornton <art27@cantab.net>
