### PR TITLE
Don't WARN log UserNotExist errors on ExternalUserLogin failure

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -856,7 +856,11 @@ func UserSignIn(username, password string) (*User, error) {
 			return authUser, nil
 		}
 
-		log.Warn("Failed to login '%s' via '%s': %v", username, source.Name, err)
+		if IsErrUserNotExist(err) {
+			log.Debug("Failed to login '%s' via '%s': %v", username, source.Name, err)
+		} else {
+			log.Warn("Failed to login '%s' via '%s': %v", username, source.Name, err)
+		}
 	}
 
 	return nil, ErrUserNotExist{user.ID, user.Name, 0}


### PR DESCRIPTION
Instead log these at debug - with warn logging for other errors.

Fix #16235

Signed-off-by: Andrew Thornton <art27@cantab.net>
