### PR TITLE
Fuzzer finds an NPE due to incorrect URLPrefix

### DIFF
--- a/tools/fuzz.go
+++ b/tools/fuzz.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	renderContext = markup.RenderContext{
-		URLPrefix: "https://example.com",
+		URLPrefix: "https://example.com/go-gitea/gitea",
 		Metas: map[string]string{
 			"user": "go-gitea",
 			"repo": "gitea",


### PR DESCRIPTION
The Fuzzer is running on a non-repo urlprefix which is incorrect for RenderRaw

Signed-off-by: Andrew Thornton <art27@cantab.net>
