### PR TITLE
Improve efficiency in FindRenderizableReferenceNumeric and getReference (#16251)

### DIFF
--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -5,6 +5,7 @@
 package references
 
 import (
+	"bytes"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -14,6 +15,8 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup/mdstripper"
 	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/yuin/goldmark/util"
 )
 
 var (
@@ -321,7 +324,7 @@ func FindRenderizableReferenceNumeric(content string, prOnly bool) (bool, *Rende
 			return false, nil
 		}
 	}
-	r := getCrossReference([]byte(content), match[2], match[3], false, prOnly)
+	r := getCrossReference(util.StringToReadOnlyBytes(content), match[2], match[3], false, prOnly)
 	if r == nil {
 		return false, nil
 	}
@@ -465,18 +468,17 @@ func findAllIssueReferencesBytes(content []byte, links []string) []*rawReference
 }
 
 func getCrossReference(content []byte, start, end int, fromLink bool, prOnly bool) *rawReference {
-	refid := string(content[start:end])
-	sep := strings.IndexAny(refid, "#!")
+	sep := bytes.IndexAny(content[start:end], "#!")
 	if sep < 0 {
 		return nil
 	}
-	isPull := refid[sep] == '!'
+	isPull := content[start+sep] == '!'
 	if prOnly && !isPull {
 		return nil
 	}
-	repo := refid[:sep]
-	issue := refid[sep+1:]
-	index, err := strconv.ParseInt(issue, 10, 64)
+	repo := string(content[start : start+sep])
+	issue := string(content[start+sep+1 : end])
+	index, err := strconv.ParseInt(string(issue), 10, 64)
 	if err != nil {
 		return nil
 	}

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -478,7 +478,7 @@ func getCrossReference(content []byte, start, end int, fromLink bool, prOnly boo
 	}
 	repo := string(content[start : start+sep])
 	issue := string(content[start+sep+1 : end])
-	index, err := strconv.ParseInt(string(issue), 10, 64)
+	index, err := strconv.ParseInt(issue, 10, 64)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Backport #16251

* The Fuzzer is running on a non-repo urlprefix which is incorrect for RenderRaw
* Make FindRenderizableReferenceNumeric and getReferences more efficient

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: techknowlogick <techknowlogick@gitea.io>
