### PR TITLE
Add --quiet and --verbose to gitea web to control initial logging

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -27,10 +27,10 @@ func runConvert(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Trace("AppPath: %s", setting.AppPath)
-	log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-	log.Trace("Custom path: %s", setting.CustomPath)
-	log.Trace("Log path: %s", setting.LogRootPath)
+	log.Info("AppPath: %s", setting.AppPath)
+	log.Info("AppWorkPath: %s", setting.AppWorkPath)
+	log.Info("Custom path: %s", setting.CustomPath)
+	log.Info("Log path: %s", setting.LogRootPath)
 	setting.InitDBConfig()
 
 	if !setting.Database.UseMySQL {

--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -69,7 +69,7 @@ var CmdDumpRepository = cli.Command{
 		cli.StringFlag{
 			Name:  "units",
 			Value: "",
-			Usage: `Which items will be migrated, one or more units should be separated as comma. 
+			Usage: `Which items will be migrated, one or more units should be separated as comma.
 wiki, issues, labels, releases, release_assets, milestones, pull_requests, comments are allowed. Empty means all units.`,
 		},
 	},
@@ -80,10 +80,10 @@ func runDumpRepository(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Trace("AppPath: %s", setting.AppPath)
-	log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-	log.Trace("Custom path: %s", setting.CustomPath)
-	log.Trace("Log path: %s", setting.LogRootPath)
+	log.Info("AppPath: %s", setting.AppPath)
+	log.Info("AppWorkPath: %s", setting.AppWorkPath)
+	log.Info("Custom path: %s", setting.CustomPath)
+	log.Info("Log path: %s", setting.LogRootPath)
 	setting.InitDBConfig()
 
 	var (

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -28,10 +28,10 @@ func runMigrate(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Trace("AppPath: %s", setting.AppPath)
-	log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-	log.Trace("Custom path: %s", setting.CustomPath)
-	log.Trace("Log path: %s", setting.LogRootPath)
+	log.Info("AppPath: %s", setting.AppPath)
+	log.Info("AppWorkPath: %s", setting.AppWorkPath)
+	log.Info("Custom path: %s", setting.CustomPath)
+	log.Info("Log path: %s", setting.LogRootPath)
 	setting.InitDBConfig()
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {

--- a/cmd/migrate_storage.go
+++ b/cmd/migrate_storage.go
@@ -110,10 +110,10 @@ func runMigrateStorage(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Trace("AppPath: %s", setting.AppPath)
-	log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-	log.Trace("Custom path: %s", setting.CustomPath)
-	log.Trace("Log path: %s", setting.LogRootPath)
+	log.Info("AppPath: %s", setting.AppPath)
+	log.Info("AppWorkPath: %s", setting.AppWorkPath)
+	log.Info("Custom path: %s", setting.CustomPath)
+	log.Info("Log path: %s", setting.LogRootPath)
 	setting.InitDBConfig()
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -47,6 +47,14 @@ and it takes care of all the other things for you`,
 			Value: setting.PIDFile,
 			Usage: "Custom pid file path",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "Only display Fatal logging errors until logging is set-up",
+		},
+		cli.BoolFlag{
+			Name:  "verbose",
+			Usage: "Set initial logging to TRACE level until logging is properly set-up",
+		},
 	},
 }
 
@@ -71,6 +79,14 @@ func runHTTPRedirector() {
 }
 
 func runWeb(ctx *cli.Context) error {
+	if ctx.Bool("verbose") {
+		_ = log.DelLogger("console")
+		log.NewLogger(0, "console", "console", fmt.Sprintf(`{"level": "trace", "colorize": %t, "stacktraceLevel": "none"}`, log.CanColorStdout))
+	} else if ctx.Bool("quiet") {
+		_ = log.DelLogger("console")
+		log.NewLogger(0, "console", "console", fmt.Sprintf(`{"level": "fatal", "colorize": %t, "stacktraceLevel": "none"}`, log.CanColorStdout))
+	}
+
 	managerCtx, cancel := context.WithCancel(context.Background())
 	graceful.InitManager(managerCtx)
 	defer cancel()

--- a/docs/content/doc/usage/command-line.en-us.md
+++ b/docs/content/doc/usage/command-line.en-us.md
@@ -46,6 +46,8 @@ Starts the server:
   - `--port number`, `-p number`: Port number. Optional. (default: 3000). Overrides configuration file.
   - `--install-port number`: Port number to run the install page on. Optional. (default: 3000). Overrides configuration file.
   - `--pid path`, `-P path`: Pidfile path. Optional.
+  - `--quiet`, `-q`: Only emit Fatal logs on the console for logs emitted before logging set up.
+  - `--verbose`: Emit tracing logs on the console for logs emitted before logging is set-up.
 - Examples:
   - `gitea web`
   - `gitea web --port 80`

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -469,7 +469,8 @@ func getWorkPath(appPath string) string {
 func init() {
 	IsWindows = runtime.GOOS == "windows"
 	// We can rely on log.CanColorStdout being set properly because modules/log/console_windows.go comes before modules/setting/setting.go lexicographically
-	log.NewLogger(0, "console", "console", fmt.Sprintf(`{"level": "trace", "colorize": %t, "stacktraceLevel": "none"}`, log.CanColorStdout))
+	// By default set this logger at Info - we'll change it later but we need to start with something.
+	log.NewLogger(0, "console", "console", fmt.Sprintf(`{"level": "info", "colorize": %t, "stacktraceLevel": "none"}`, log.CanColorStdout))
 
 	var err error
 	if AppPath, err = getAppPath(); err != nil {

--- a/routers/init.go
+++ b/routers/init.go
@@ -70,10 +70,10 @@ func GlobalInit(ctx context.Context) {
 		log.Fatal("Git module init failed: %v", err)
 	}
 	setting.CheckLFSVersion()
-	log.Trace("AppPath: %s", setting.AppPath)
-	log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-	log.Trace("Custom path: %s", setting.CustomPath)
-	log.Trace("Log path: %s", setting.LogRootPath)
+	log.Info("AppPath: %s", setting.AppPath)
+	log.Info("AppWorkPath: %s", setting.AppWorkPath)
+	log.Info("Custom path: %s", setting.CustomPath)
+	log.Info("Log path: %s", setting.LogRootPath)
 	log.Info("Run Mode: %s", strings.Title(setting.RunMode))
 
 	// Setup i18n

--- a/routers/install/setting.go
+++ b/routers/install/setting.go
@@ -18,11 +18,11 @@ import (
 func PreloadSettings(ctx context.Context) bool {
 	setting.NewContext()
 	if !setting.InstallLock {
-		log.Trace("AppPath: %s", setting.AppPath)
-		log.Trace("AppWorkPath: %s", setting.AppWorkPath)
-		log.Trace("Custom path: %s", setting.CustomPath)
-		log.Trace("Log path: %s", setting.LogRootPath)
-		log.Trace("Preparing to run install page")
+		log.Info("AppPath: %s", setting.AppPath)
+		log.Info("AppWorkPath: %s", setting.AppWorkPath)
+		log.Info("Custom path: %s", setting.CustomPath)
+		log.Info("Log path: %s", setting.LogRootPath)
+		log.Info("Preparing to run install page")
 		translation.InitLocales()
 		if setting.EnableSQLite3 {
 			log.Info("SQLite3 Supported")


### PR DESCRIPTION
One of the repeatedly reported issues has been that gitea produces too much console
logging during set up even if the console logger is turned off.

Fundamentally this is due to some otherwise very helpful logging that has to occur
before logging is set up. This has come to a head with the merging of #16243 where
otherwise potentially helpful Trace logging in the git module now appears on the
console.

This PR proposes three things:

1. Change the initial default logger to Info not Trace.
2. Change the logging for the AppPath things to Info in recompense.
3. Add two new command line options to gitea web: --quiet and --verbose

`gitea web -q` or `gitea web --quiet` will only log Fatal level initially.
`gitea web -verbose` will log at Trace.

Signed-off-by: Andrew Thornton <art27@cantab.net>
