### PR TITLE
Make app.ini permissions more restrictive

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1159,6 +1159,19 @@ func CreateOrAppendToCustomConf(callback func(cfg *ini.File)) {
 	if err := cfg.SaveTo(CustomConf); err != nil {
 		log.Fatal("error saving to custom config: %v", err)
 	}
+
+	// Change permissions to be more restrictive
+	fi, err := os.Stat(CustomConf)
+	if err != nil {
+		log.Error("Failed to determine current conf file permissions: %v", err)
+		return
+	}
+
+	if fi.Mode().Perm() > 0o600 {
+		if err = os.Chmod(CustomConf, 0o600); err != nil {
+			log.Warn("Failed changing conf file permissions to -rw-------. Consider changing them manually.")
+		}
+	}
 }
 
 // NewServices initializes the services


### PR DESCRIPTION
 Gitea's `app.ini` contains several security related configuration settings like `SECRET_KEY` and `JWT_SECRET` (amongst others.) Files containing security related settings should by default be created with mode `0600` (`-rw-------`) but unfortunately (prior to this PR) Gitea would create its `app.ini` with the default mask, which is often `0644`, allowing everyone with access to the directory to read the content.

This PR changes Gitea to only ever create or recreate `app.ini` with mode `0600`. (This change does not affect `environment-to-ini`.)

## :warning: BREAKING :warning: 

Although this change will only take effect if Gitea needs to recreate the `app.ini` due to a missing security setting - system administrators should be advised that this permission change may occur and should not rely on group or other read permissions to read the `app.ini`.

----

Fixes #5959
Signed-off-by: Steven Kriegler <61625851+justusbunsi@users.noreply.github.com>