### PR TITLE
Add scroll-margin-top to account for sticky header

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1343,7 +1343,7 @@ function initPullRequestReview() {
         $(`#code-comments-${id}`).removeClass('hide');
         $(`#code-preview-${id}`).removeClass('hide');
         $(`#hide-outdated-${id}`).removeClass('hide');
-        $(window).scrollTop(commentDiv.offset().top);
+        commentDiv[0].scrollIntoView();
       }
     }
   }

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -177,11 +177,7 @@ a.blob-excerpt:hover {
 .pull.files.diff [id] {
   scroll-margin-top: 99px;
 
-  @media @mediaMd {
-    scroll-margin-top: 130px;
-  }
-
-  @media @mediaSm {
+  @media @mediaMdAndDown {
     scroll-margin-top: 130px;
   }
 }

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -173,3 +173,15 @@ a.blob-excerpt:hover {
 .review-box > .segment {
   border: none !important;
 }
+
+.pull.files.diff [id] {
+  scroll-margin-top: 99px;
+
+  @media @mediaMd {
+    scroll-margin-top: 130px;
+  }
+
+  @media @mediaSm {
+    scroll-margin-top: 130px;
+  }
+}


### PR DESCRIPTION
When navigating directly to a specific review comment link, like https://try.gitea.io/jpraet/test/pulls/9/files#issuecomment-76046, the review comment is covered by the sticky header.

This PR adds a scroll margin to account for this header.

Fixes #16263
