### PR TITLE
review comments: break-word for long file names

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -462,7 +462,7 @@
 				{{ range $filename, $lines := .Review.CodeComments}}
 					{{range $line, $comms := $lines}}
 							<div class="ui segments">
-								<div class="ui segment py-3 df ac sb">
+								<div class="ui segment py-3 df ac sb break-word">
 									{{$invalid := (index $comms 0).Invalidated}}
 									{{$resolved := (index $comms 0).IsResolved}}
 									{{$resolveDoer := (index $comms 0).ResolveDoer}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -462,7 +462,7 @@
 				{{ range $filename, $lines := .Review.CodeComments}}
 					{{range $line, $comms := $lines}}
 							<div class="ui segments">
-								<div class="ui segment py-3 df ac sb break-word">
+								<div class="ui segment py-3 df ac sb word-break">
 									{{$invalid := (index $comms 0).Invalidated}}
 									{{$resolved := (index $comms 0).IsResolved}}
 									{{$resolveDoer := (index $comms 0).ResolveDoer}}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2071,7 +2071,3 @@ table th[data-sortt-desc] {
   margin-top: -.5em;
   margin-bottom: -.5em;
 }
-
-.break-word {
-  word-break: break-word;
-}

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2071,3 +2071,7 @@ table th[data-sortt-desc] {
   margin-top: -.5em;
   margin-bottom: -.5em;
 }
+
+.break-word {
+  word-break: break-word;
+}


### PR DESCRIPTION
Use break-word for long file names in review comment headers.

#### before
![](https://user-images.githubusercontent.com/62021255/123448199-45f37980-d5a0-11eb-9be8-56854af6496b.png)
#### after
![](https://user-images.githubusercontent.com/62021255/123448122-307e4f80-d5a0-11eb-8801-170961f8a3a3.png)

Fixes #16248