### PR TITLE
Fix API to use author for commits instead of committer

### DIFF
--- a/modules/convert/git_commit.go
+++ b/modules/convert/git_commit.go
@@ -155,8 +155,8 @@ func ToCommit(repo *models.Repository, commit *git.Commit, userCache map[string]
 			URL: repo.APIURL() + "/git/commits/" + commit.ID.String(),
 			Author: &api.CommitUser{
 				Identity: api.Identity{
-					Name:  commit.Committer.Name,
-					Email: commit.Committer.Email,
+					Name:  commit.Author.Name,
+					Email: commit.Author.Email,
 				},
 				Date: commit.Author.When.Format(time.RFC3339),
 			},


### PR DESCRIPTION
There is a bug in modules/convert.ToCommit where the committer is used in place of the author.

This PR fixes this.