### PR TITLE
Fix previous/next review comment button size

### DIFF
--- a/templates/repo/diff/conversation.tmpl
+++ b/templates/repo/diff/conversation.tmpl
@@ -29,10 +29,10 @@
 		<div class="df je ac fw mt-3">
 			<div class="ui buttons mr-2">
 				<button class="ui icon tiny basic button previous-conversation">
-					{{svg "octicon-arrow-up"}} {{$.i18n.Tr "repo.issues.previous"}}
+					{{svg "octicon-arrow-up" 12 "icon"}} {{$.i18n.Tr "repo.issues.previous"}}
 				</button>
 				<button class="ui icon tiny basic button next-conversation">
-					{{svg "octicon-arrow-down"}} {{$.i18n.Tr "repo.issues.next"}}
+					{{svg "octicon-arrow-down" 12 "icon"}} {{$.i18n.Tr "repo.issues.next"}}
 				</button>
 			</div>
 			{{if and $.CanMarkConversation $isNotPending}}


### PR DESCRIPTION
The previous/next buttons added in #16273 are larger than the other buttons next to it. This PR fixes that.

before:

![afbeelding](https://user-images.githubusercontent.com/2212615/123681097-abb65e80-d849-11eb-82f4-b779dbee9fb6.png)

after:

![afbeelding](https://user-images.githubusercontent.com/2212615/123680640-3cd90580-d849-11eb-956c-f5c0461e4fb7.png)
