### PR TITLE
Update fail2ban documentation

### DIFF
--- a/docs/content/doc/usage/fail2ban-setup.en-us.md
+++ b/docs/content/doc/usage/fail2ban-setup.en-us.md
@@ -29,22 +29,32 @@ on a bad authentication from the web or CLI using SSH or HTTP respectively:
 ```log
 2020/10/15 16:05:09 modules/ssh/ssh.go:143:publicKeyHandler() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
 ```
+(DEPRECATED: This may be a false positive as the user may still go on to correctly authenticate.)
 
 ```log
 2020/10/15 16:05:09 modules/ssh/ssh.go:155:publicKeyHandler() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
 ```
+(DEPRECATED: This may be a false positive as the user may still go on to correctly authenticate.)
 
 ```log
 2020/10/15 16:05:09 modules/ssh/ssh.go:198:publicKeyHandler() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
 ```
+(DEPRECATED: This may be a false positive as the user may still go on to correctly authenticate.)
 
 ```log
 2020/10/15 16:05:09 modules/ssh/ssh.go:213:publicKeyHandler() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
 ```
+(DEPRECATED: This may be a false positive as the user may still go on to correctly authenticate.)
 
 ```log
 2020/10/15 16:05:09 modules/ssh/ssh.go:227:publicKeyHandler() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
 ```
+(DEPRECATED: This may be a false positive as the user may still go on to correctly authenticate.)
+
+```log
+2020/10/15 16:05:09 modules/ssh/ssh.go:249:sshConnectionFailed() [W] Failed authentication attempt from xxx.xxx.xxx.xxx
+```
+(From 1.15 this new message will available and doesn't have any of the false positive results that above messages from publicKeyHandler do. This will only be logged if the user has completely failed authentication.)
 
 ```log
 2020/10/15 16:08:44 ...s/context/context.go:204:HandleText() [E] invalid credentials from xxx.xxx.xxx.xxx


### PR DESCRIPTION
Following the merge of #16278 we need to update the fail2ban
documentation to take account of the availability of the new
sshConnectionFailed failed authentication attempt log message.

Also add a deprecation notice regarding the previous publicKeyHandler
messages, as these may be a source of false positives.

Signed-off-by: Andrew Thornton <art27@cantab.net>
