### PR TITLE
Fix panic in recursive cache

### DIFF
--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -94,7 +94,8 @@ func (c *LastCommitCache) recursiveCache(ctx context.Context, commit *Commit, tr
 		if err := c.Put(commit.ID.String(), path.Join(treePath, entry), entryCommit.ID.String()); err != nil {
 			return err
 		}
-		if entryMap[entry].IsDir() {
+		// entryMap won't contain "" therefore skip this.
+		if treeEntry := entryMap[entry]; treeEntry != nil && treeEntry.IsDir() {
 			subTree, err := tree.SubTree(entry)
 			if err != nil {
 				return err


### PR DESCRIPTION
There is a bug with last commit cache recursive cache where the last
commit information that refers to the current tree itself will cause a
panic due to its path ("") not being included in the expected tree entry
paths.

This PR fixes this by skipping the missing entry.

Fix #16290

Signed-off-by: Andrew Thornton <art27@cantab.net>
