### PR TITLE
Fix list_options GetStartEnd

### DIFF
--- a/models/list_options.go
+++ b/models/list_options.go
@@ -41,7 +41,7 @@ func (opts *ListOptions) setEnginePagination(e Engine) Engine {
 func (opts *ListOptions) GetStartEnd() (start, end int) {
 	opts.setDefaultValues()
 	start = (opts.Page - 1) * opts.PageSize
-	end = start + opts.Page
+	end = start + opts.PageSize
 	return
 }
 


### PR DESCRIPTION
end is start + pageSize and not start + page

as mentioned in https://github.com/go-gitea/gitea/pull/16300