### PR TITLE
Prevent zombie processes

### DIFF
--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -5,6 +5,7 @@
 package external
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,6 +16,7 @@ import (
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
+	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 )
@@ -96,7 +98,14 @@ func (p *Renderer) Render(ctx *markup.RenderContext, input io.Reader, output io.
 		args = append(args, f.Name())
 	}
 
-	cmd := exec.Command(commands[0], args...)
+	// FIXME this should use process
+	processCtx, cancel := context.WithCancel(ctx.Ctx)
+	defer cancel()
+
+	pid := process.GetManager().Add(fmt.Sprintf("Render [%s] for %s", commands[0], ctx.URLPrefix), cancel)
+	defer process.GetManager().Remove(pid)
+
+	cmd := exec.CommandContext(processCtx, commands[0], args...)
 	cmd.Env = append(
 		os.Environ(),
 		"GITEA_PREFIX_SRC="+ctx.URLPrefix,

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -98,7 +98,6 @@ func (p *Renderer) Render(ctx *markup.RenderContext, input io.Reader, output io.
 		args = append(args, f.Name())
 	}
 
-	// FIXME this should use process
 	processCtx, cancel := context.WithCancel(ctx.Ctx)
 	defer cancel()
 

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -66,7 +66,7 @@ func sessionHandler(session ssh.Session) {
 
 	args := []string{"serv", "key-" + keyID, "--config=" + setting.CustomConf}
 	log.Trace("SSH: Arguments: %v", args)
-	cmd := exec.Command(setting.AppPath, args...)
+	cmd := exec.CommandContext(session.Context(), setting.AppPath, args...)
 	cmd.Env = append(
 		os.Environ(),
 		"SSH_ORIGINAL_COMMAND="+command,


### PR DESCRIPTION
Unfortunately go doesn't always ensure that execd processes are completely
waited for. On linux this means that zombie processes can occur.

This PR ensures that these are waited for by using signal notifier in serv and
passing a context elsewhere.

Signed-off-by: Andrew Thornton <art27@cantab.net>
