### PR TITLE
fix calculation for finalPage in repo-search component

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -3389,7 +3389,7 @@ function initVueComponents() {
               this.reposTotalCount = count;
             }
             Vue.set(this.counts, `${this.reposFilter}:${this.archivedFilter}:${this.privateFilter}`, count);
-            this.finalPage = Math.floor(count / this.searchLimit) + 1;
+            this.finalPage = Math.ceil(count / this.searchLimit);
             this.updateHistory();
           }
         }).always(() => {


### PR DESCRIPTION
The `finalPage` was calculated incorrectly in the repo-search component. This caused an empty unnecessary page to be added as described in #15601.

**OLD**
```js
this.finalPage = Math.floor(count / this.searchLimit) + 1;
```
This calculation will round down the number of pages and increment.
> Math.floor(31/15) + 1 = 3
> Math.floor(30/15) + 1 = 3
> Math.floor(29/15) + 1 = 2


**NEW**
```js
this.finalPage = Math.ceil(count / this.searchLimit);
```
This calculation will always round up the number of pages, if it's not an integer
> Math.ceil(31/15) = 3
> Math.ceil(30/15) = 2
> Math.ceil(29/15) = 2

This pull request will fix #15601.