### PR TITLE
Fix typo in customizing-gitea.en-us.md

### DIFF
--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -138,7 +138,7 @@ copy javascript files from https://gitea.com/davidsvantesson/plantuml-code-highl
 <script src="https://your-server.com/plantuml_codeblock_parse.js"></script>
 <script>
   <!-- Replace call with address to your plantuml server-->
-  parsePlantumlCodeBlocks("http://www.plantuml..com/plantuml");
+  parsePlantumlCodeBlocks("http://www.plantuml.com/plantuml");
 </script>
 {{end}}
 ```


### PR DESCRIPTION
Fixed a type in a URL in PlantUML code example in `customizing-gitea.en-us.md`.

Changes: `http://www.plantuml..com/plantuml` -> `http://www.plantuml.com/plantuml`