### PR TITLE
Fix source typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ misspell-check:
 		GO111MODULE=off $(GO) get -u github.com/client9/misspell/cmd/misspell; \
 	fi
 	@echo "Running misspell-check..."
-	@misspell -error -i unknwon,destory $(GO_SOURCES_OWN)
+	@misspell -error -i unknwon $(GO_SOURCES_OWN)
 
 .PHONY: misspell
 misspell:

--- a/integrations/api_repo_lfs_test.go
+++ b/integrations/api_repo_lfs_test.go
@@ -135,7 +135,7 @@ func TestAPILFSBatch(t *testing.T) {
 		assert.Equal(t, "Oid or size are invalid", br.Objects[1].Error.Message)
 	})
 
-	t.Run("PointerSizeMissmatch", func(t *testing.T) {
+	t.Run("PointerSizeMismatch", func(t *testing.T) {
 		defer PrintCurrentTest(t)()
 
 		req := newRequest(t, &lfs.BatchRequest{
@@ -376,7 +376,7 @@ func TestAPILFSUpload(t *testing.T) {
 		session.MakeRequest(t, req, http.StatusOK)
 	})
 
-	t.Run("HashMissmatch", func(t *testing.T) {
+	t.Run("HashMismatch", func(t *testing.T) {
 		defer PrintCurrentTest(t)()
 
 		req := newRequest(t, lfs.Pointer{Oid: "2581dd7bbc1fe44726de4b7dd806a087a978b9c5aec0a60481259e34be09b06a", Size: 1}, "a")
@@ -384,7 +384,7 @@ func TestAPILFSUpload(t *testing.T) {
 		session.MakeRequest(t, req, http.StatusUnprocessableEntity)
 	})
 
-	t.Run("SizeMissmatch", func(t *testing.T) {
+	t.Run("SizeMismatch", func(t *testing.T) {
 		defer PrintCurrentTest(t)()
 
 		req := newRequest(t, lfs.Pointer{Oid: "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb", Size: 2}, "a")

--- a/routers/web/admin/users_test.go
+++ b/routers/web/admin/users_test.go
@@ -122,7 +122,7 @@ func TestNewUserPost_InvalidEmail(t *testing.T) {
 	assert.NotEmpty(t, ctx.Flash.ErrorMsg)
 }
 
-func TestNewUserPost_VisiblityDefaultPublic(t *testing.T) {
+func TestNewUserPost_VisibilityDefaultPublic(t *testing.T) {
 	models.PrepareTestEnv(t)
 	ctx := test.MockContext(t, "admin/users/new")
 


### PR DESCRIPTION
Follow up to e0296b6a6  
Found via `codespell -q 3 -S ./options/locale,./vendor -L ba,pullrequest,pullrequests,readby`