### PR TITLE
Redirect on bad CSRF instead of presenting bad page (#14937)

### DIFF
--- a/modules/context/csrf.go
+++ b/modules/context/csrf.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web/middleware"
 
 	"github.com/unknwon/com"
@@ -266,7 +267,12 @@ func Validate(ctx *Context, x CSRF) {
 				-1,
 				x.GetCookiePath(),
 				x.GetCookieDomain()) // FIXME: Do we need to set the Secure, httpOnly and SameSite values too?
-			x.Error(ctx.Resp)
+			if middleware.IsAPIPath(ctx.Req) {
+				x.Error(ctx.Resp)
+				return
+			}
+			ctx.Flash.Error(ctx.Tr("error.invalid_csrf"))
+			ctx.Redirect(setting.AppSubURL + "/")
 		}
 		return
 	}
@@ -277,10 +283,19 @@ func Validate(ctx *Context, x CSRF) {
 				-1,
 				x.GetCookiePath(),
 				x.GetCookieDomain()) // FIXME: Do we need to set the Secure, httpOnly and SameSite values too?
-			x.Error(ctx.Resp)
+			if middleware.IsAPIPath(ctx.Req) {
+				x.Error(ctx.Resp)
+				return
+			}
+			ctx.Flash.Error(ctx.Tr("error.invalid_csrf"))
+			ctx.Redirect(setting.AppSubURL + "/")
 		}
 		return
 	}
-
-	http.Error(ctx.Resp, "Bad Request: no CSRF token present", http.StatusBadRequest)
+	if middleware.IsAPIPath(ctx.Req) {
+		http.Error(ctx.Resp, "Bad Request: no CSRF token present", http.StatusBadRequest)
+		return
+	}
+	ctx.Flash.Error(ctx.Tr("error.missing_csrf"))
+	ctx.Redirect(setting.AppSubURL + "/")
 }

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -96,6 +96,8 @@ error404 = The page you are trying to reach either <strong>does not exist</stron
 [error]
 occurred = An error has occurred
 report_message = If you are sure this is a Gitea bug, please search for issue on <a href="https://github.com/go-gitea/gitea/issues">GitHub</a> and open new issue if necessary.
+missing_csrf = Bad Request: no CSRF token present
+invalid_csrf = Bad Request: Invalid CSRF token
 
 [startpage]
 app_desc = A painless, self-hosted Git service


### PR DESCRIPTION
Backport #14937

The current CSRF handler is a bit harsh with bad CSRF tokens on webpages
I think we can be a little kinder and redirect to base page with a flash error

Signed-off-by: Andrew Thornton <art27@cantab.net>