### PR TITLE
Fix archive error when rename repo or user

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1764,22 +1764,6 @@ func GetPrivateRepositoryCount(u *User) (int64, error) {
 	return getPrivateRepositoryCount(x, u)
 }
 
-// DeleteRepositoryArchives deletes all repositories' archives.
-func DeleteRepositoryArchives(ctx context.Context) error {
-	return x.
-		Where("id > 0").
-		Iterate(new(Repository),
-			func(idx int, bean interface{}) error {
-				repo := bean.(*Repository)
-				select {
-				case <-ctx.Done():
-					return ErrCancelledf("before deleting repository archives for %s", repo.FullName())
-				default:
-				}
-				return util.RemoveAll(filepath.Join(repo.RepoPath(), "archives"))
-			})
-}
-
 // DeleteOldRepositoryArchives deletes old repository archives.
 func DeleteOldRepositoryArchives(ctx context.Context, olderThan time.Duration) error {
 	log.Trace("Doing: ArchiveCleanup")

--- a/models/repo_archiver.go
+++ b/models/repo_archiver.go
@@ -52,12 +52,7 @@ func (archiver *RepoArchiver) LoadRepo() (*Repository, error) {
 
 // RelativePath returns relative path
 func (archiver *RepoArchiver) RelativePath() (string, error) {
-	repo, err := archiver.LoadRepo()
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%d/%s/%s.%s", repo.ID, archiver.CommitID[:2], archiver.CommitID, archiver.Type.String()), nil
+	return fmt.Sprintf("%d/%s/%s.%s", archiver.RepoID, archiver.CommitID[:2], archiver.CommitID, archiver.Type.String()), nil
 }
 
 // GetRepoArchiver get an archiver

--- a/models/repo_archiver.go
+++ b/models/repo_archiver.go
@@ -57,7 +57,7 @@ func (archiver *RepoArchiver) RelativePath() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s/%s/%s.%s", repo.FullName(), archiver.CommitID[:2], archiver.CommitID, archiver.Type.String()), nil
+	return fmt.Sprintf("%d/%s/%s.%s", repo.ID, archiver.CommitID[:2], archiver.CommitID, archiver.Type.String()), nil
 }
 
 // GetRepoArchiver get an archiver
@@ -82,5 +82,11 @@ func AddRepoArchiver(ctx DBContext, archiver *RepoArchiver) error {
 // UpdateRepoArchiverStatus updates archiver's status
 func UpdateRepoArchiverStatus(ctx DBContext, archiver *RepoArchiver) error {
 	_, err := ctx.e.ID(archiver.ID).Cols("status").Update(archiver)
+	return err
+}
+
+// DeleteAllRepoArchives deletes all repo archives records
+func DeleteAllRepoArchives() error {
+	_, err := x.Where("1=1").Delete(new(RepoArchiver))
 	return err
 }

--- a/modules/cron/tasks_extended.go
+++ b/modules/cron/tasks_extended.go
@@ -33,7 +33,7 @@ func registerDeleteRepositoryArchives() {
 		RunAtStart: false,
 		Schedule:   "@annually",
 	}, func(ctx context.Context, _ *models.User, _ Config) error {
-		return models.DeleteRepositoryArchives(ctx)
+		return repo_module.DeleteRepositoryArchives(ctx)
 	})
 }
 

--- a/modules/repository/archive.go
+++ b/modules/repository/archive.go
@@ -1,0 +1,20 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repository
+
+import (
+	"context"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/storage"
+)
+
+// DeleteRepositoryArchives deletes all repositories' archives.
+func DeleteRepositoryArchives(ctx context.Context) error {
+	if err := models.DeleteAllRepoArchives(); err != nil {
+		return err
+	}
+	return storage.Clean(storage.RepoArchives)
+}

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -88,6 +88,13 @@ func Copy(dstStorage ObjectStorage, dstPath string, srcStorage ObjectStorage, sr
 	return dstStorage.Save(dstPath, f, size)
 }
 
+// Clean delete all the objects in this storage
+func Clean(storage ObjectStorage) error {
+	return storage.IterateObjects(func(path string, obj Object) error {
+		return storage.Delete(path)
+	})
+}
+
 // SaveFrom saves data to the ObjectStorage with path p from the callback
 func SaveFrom(objStorage ObjectStorage, p string, callback func(w io.Writer) error) error {
 	pr, pw := io.Pipe()


### PR DESCRIPTION
Fix #16390

#14723 introduced two bugs, one is to delete all archivers may failed, another is after rename repo or user, visit archivers may failed.

This PR will fix them. But it's a break change. After applying the patch, please run `Delete all repositories' archives` to remove all old files which may become garbages.