### PR TITLE
Validate Issue Index before querying DB

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1019,7 +1019,7 @@ func NewIssue(repo *Repository, issue *Issue, labelIDs []int64, uuids []string) 
 // GetIssueByIndex returns raw issue without loading attributes by index in a repository.
 func GetIssueByIndex(repoID, index int64) (*Issue, error) {
 	if index < 1 {
-		return nil, fmt.Errorf("index %d is not a valid issue", index)
+		return nil, ErrIssueNotExist{}
 	}
 	issue := &Issue{
 		RepoID: repoID,

--- a/models/issue.go
+++ b/models/issue.go
@@ -1018,6 +1018,9 @@ func NewIssue(repo *Repository, issue *Issue, labelIDs []int64, uuids []string) 
 
 // GetIssueByIndex returns raw issue without loading attributes by index in a repository.
 func GetIssueByIndex(repoID, index int64) (*Issue, error) {
+	if index < 1 {
+		return nil, fmt.Errorf("index %d is not a valid issue", index)
+	}
 	issue := &Issue{
 		RepoID: repoID,
 		Index:  index,


### PR DESCRIPTION
`GetIssueByIndex()` would ignore the index if invalid value is passed (thus parsed as `0`), and continue to return first issue for the repo.
fixes #16405


We alternatively could return a 404, is that cleaner?