### PR TITLE
Add secondary authorized_keys file in sshd_config

### DIFF
--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -19,7 +19,7 @@ ${SSH_ECDSA_CERT}
 HostKey /data/ssh/ssh_host_dsa_key
 ${SSH_DSA_CERT}
 
-AuthorizedKeysFile .ssh/authorized_keys
+AuthorizedKeysFile .ssh/authorized_keys /data/ssh/authorized_keys
 AuthorizedPrincipalsFile .ssh/authorized_principals
 TrustedUserCAKeys /data/git/.ssh/gitea-trusted-user-ca-keys.pem
 CASignatureAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256,ssh-rsa


### PR DESCRIPTION
Allows us to "reverse proxy" an ssh connection, as described in [this blog post for GitLab](https://blog.xiaket.org/2017/exposing.ssh.port.in.dockerized.gitlab-ce.html). We can allow an un-managed public key access to ssh so as to allow the docker host user to pass the connection along.
A similar setup exists in GitLab, added in [this issue](https://gitlab.com/gitlab-org/omnibus-gitlab/-/commit/923fd761ed854ca368c413a581b1153cd677dbe5).
