### PR TITLE
 Validate issue index before querying DB (#16406)

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1035,7 +1035,7 @@ func newIssueAttempt(repo *Repository, issue *Issue, labelIDs []int64, uuids []s
 // GetIssueByIndex returns raw issue without loading attributes by index in a repository.
 func GetIssueByIndex(repoID, index int64) (*Issue, error) {
 	if index < 1 {
-		return nil, fmt.Errorf("index %d is not a valid issue", index)
+		return nil, ErrIssueNotExist{}
 	}
 	issue := &Issue{
 		RepoID: repoID,

--- a/models/issue.go
+++ b/models/issue.go
@@ -1034,6 +1034,9 @@ func newIssueAttempt(repo *Repository, issue *Issue, labelIDs []int64, uuids []s
 
 // GetIssueByIndex returns raw issue without loading attributes by index in a repository.
 func GetIssueByIndex(repoID, index int64) (*Issue, error) {
+	if index < 1 {
+		return nil, fmt.Errorf("index %d is not a valid issue", index)
+	}
 	issue := &Issue{
 		RepoID: repoID,
 		Index:  index,


### PR DESCRIPTION
GetIssueByIndex() would ignore the index if invalid value is passed (thus parsed as 0), and continue to return first issue for the repo. Return a 404 instead.

backport of  #16406

