### PR TITLE
Make getIssueFullPattern() concurrency save - bugfix #16415 (#16155, #16185)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -70,9 +70,6 @@ var (
 // CSS class for action keywords (e.g. "closes: #1")
 const keywordClass = "issue-keyword"
 
-// regexp for full links to issues/pulls
-var issueFullPattern *regexp.Regexp
-
 // IsLink reports whether link fits valid format.
 func IsLink(link []byte) bool {
 	return isLink(link)
@@ -87,13 +84,13 @@ func isLinkStr(link string) bool {
 	return validLinksPattern.MatchString(link)
 }
 
-// FIXME: This function is not concurrent safe
 func getIssueFullPattern() *regexp.Regexp {
-	if issueFullPattern == nil {
-		issueFullPattern = regexp.MustCompile(regexp.QuoteMeta(setting.AppURL) +
-			`\w+/\w+/(?:issues|pulls)/((?:\w{1,10}-)?[1-9][0-9]*)([\?|#]\S+.(\S+)?)?\b`)
-	}
-	return issueFullPattern
+	var issueFullPattern = regexp.MustCompile(regexp.QuoteMeta(setting.AppURL) +
+		`\w+/\w+/(?:issues|pulls)/((?:\w{1,10}-)?[1-9][0-9]*)([\?|#]\S+.(\S+)?)?\b`)
+
+	return func() *regexp.Regexp {
+		return issueFullPattern
+	}()
 }
 
 // CustomLinkURLSchemes allows for additional schemes to be detected when parsing links within text


### PR DESCRIPTION
Run processors on whole of text (#16155) #16185

This PR makes the function concurrent save. Fix the mention in PR #16185 and merge https://github.com/go-gitea/gitea/commit/5ff807acdebdd75960418060f465bb8ba79e96a6

Fixes #16415 