### PR TITLE
Change default cron schedules from @every 24h to @midnight

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1671,7 +1671,7 @@ PATH =
 ;; Notice if not success
 ;NO_SUCCESS_NOTICE = false
 ;; Time interval for job to run
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 ;; Archives created more than OLDER_THAN ago are subject to deletion
 ;OLDER_THAN = 24h
 
@@ -1697,7 +1697,7 @@ PATH =
 ;[cron.repo_health_check]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 ;; Enable running Repository health check task periodically.
 ;ENABLED = true
 ;; Run Repository health check task when Gitea starts.
@@ -1722,7 +1722,7 @@ PATH =
 ;RUN_AT_START = true
 ;; Notice if not success
 ;NO_SUCCESS_NOTICE = false
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1736,7 +1736,7 @@ PATH =
 ;; Notice if not success
 ;NO_SUCCESS_NOTICE = false
 ;; Interval as a duration between each synchronization. (default every 24h)
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1751,7 +1751,7 @@ PATH =
 ;; Notice if not success
 ;NO_SUCCESS_NOTICE = false
 ;; Interval as a duration between each synchronization (default every 24h)
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 ;; Create new users, update existing user data and disable users that are not in external source anymore (default)
 ;;   or only create new users if UPDATE_EXISTING is set to false
 ;UPDATE_EXISTING = true
@@ -1769,7 +1769,7 @@ PATH =
 ;; Notice if not success
 ;NO_SUCCESS_NOTICE = false
 ;; Interval as a duration between each synchronization (default every 24h)
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 ;; deleted branches than OLDER_THAN ago are subject to deletion
 ;OLDER_THAN = 24h
 
@@ -1785,7 +1785,7 @@ PATH =
 ;; Whether to always run at start up time (if ENABLED)
 ;RUN_AT_START = false
 ;; Time interval for job to run
-;SCHEDULE = @every 24h
+;SCHEDULE = @midnight
 ;; OlderThan or PerWebhook. How the records are removed, either by age (i.e. how long ago hook_task record was delivered) or by the number to keep per webhook (i.e. keep most recent x deliveries per webhook).
 ;CLEANUP_TYPE = OlderThan
 ;; If CLEANUP_TYPE is set to OlderThan, then any delivered hook_task records older than this expression will be deleted.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -740,7 +740,7 @@ NB: You must have `DISABLE_ROUTER_LOG` set to `false` for this option to take ef
 
 - `ENABLED`: **true**: Enable service.
 - `RUN_AT_START`: **true**: Run tasks at start up time (if ENABLED).
-- `SCHEDULE`: **@every 24h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
+- `SCHEDULE`: **@midnight**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 - `OLDER_THAN`: **24h**: Archives created more than `OLDER_THAN` ago are subject to deletion, e.g. `12h`.
 
 #### Cron - Update Mirrors (`cron.update_mirrors`)
@@ -750,31 +750,31 @@ NB: You must have `DISABLE_ROUTER_LOG` set to `false` for this option to take ef
 
 #### Cron - Repository Health Check (`cron.repo_health_check`)
 
-- `SCHEDULE`: **@every 24h**: Cron syntax for scheduling repository health check.
+- `SCHEDULE`: **@midnight**: Cron syntax for scheduling repository health check.
 - `TIMEOUT`: **60s**: Time duration syntax for health check execution timeout.
 - `ARGS`: **\<empty\>**: Arguments for command `git fsck`, e.g. `--unreachable --tags`. See more on http://git-scm.com/docs/git-fsck
 
 #### Cron - Repository Statistics Check (`cron.check_repo_stats`)
 
 - `RUN_AT_START`: **true**: Run repository statistics check at start time.
-- `SCHEDULE`: **@every 24h**: Cron syntax for scheduling repository statistics check.
+- `SCHEDULE`: **@midnight**: Cron syntax for scheduling repository statistics check.
 
 ### Cron - Cleanup hook_task Table (`cron.cleanup_hook_task_table`)
 
 - `ENABLED`: **true**: Enable cleanup hook_task job.
 - `RUN_AT_START`: **false**: Run cleanup hook_task at start time (if ENABLED).
-- `SCHEDULE`: **@every 24h**: Cron syntax for cleaning hook_task table.
+- `SCHEDULE`: **@midnight**: Cron syntax for cleaning hook_task table.
 - `CLEANUP_TYPE` **OlderThan** OlderThan or PerWebhook Method to cleanup hook_task, either by age (i.e. how long ago hook_task record was delivered) or by the number to keep per webhook (i.e. keep most recent x deliveries per webhook).
 - `OLDER_THAN`: **168h**: If CLEANUP_TYPE is set to OlderThan, then any delivered hook_task records older than this expression will be deleted.
 - `NUMBER_TO_KEEP`: **10**: If CLEANUP_TYPE is set to PerWebhook, this is number of hook_task records to keep for a webhook (i.e. keep the most recent x deliveries).
 
 #### Cron - Update Migration Poster ID (`cron.update_migration_poster_id`)
 
-- `SCHEDULE`: **@every 24h** : Interval as a duration between each synchronization, it will always attempt synchronization when the instance starts.
+- `SCHEDULE`: **@midnight** : Interval as a duration between each synchronization, it will always attempt synchronization when the instance starts.
 
 #### Cron - Sync External Users (`cron.sync_external_users`)
 
-- `SCHEDULE`: **@every 24h** : Interval as a duration between each synchronization, it will always attempt synchronization when the instance starts.
+- `SCHEDULE`: **@midnight** : Interval as a duration between each synchronization, it will always attempt synchronization when the instance starts.
 - `UPDATE_EXISTING`: **true**: Create new users, update existing user data and disable users that are not in external source anymore (default) or only create new users if UPDATE_EXISTING is set to false.
 
 ### Extended cron tasks (not enabled by default)

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -257,18 +257,18 @@ test01.xls: application/vnd.ms-excel; charset=binary
 
 ### Cron - Repository Health Check (`cron.repo_health_check`)
 
-- `SCHEDULE`: 仓库健康监测的Cron语法，比如：`@every 24h`。
+- `SCHEDULE`: 仓库健康监测的Cron语法，比如：`@midnight`。
 - `TIMEOUT`: 仓库健康监测的超时时间，比如：`60s`.
 - `ARGS`: 执行 `git fsck` 命令的参数，比如：`--unreachable --tags`。
 
 ### Cron - Repository Statistics Check (`cron.check_repo_stats`)
 
 - `RUN_AT_START`: 是否启动时自动运行仓库统计。
-- `SCHEDULE`: 仓库统计时的Cron 语法，比如：`@every 24h`.
+- `SCHEDULE`: 仓库统计时的Cron 语法，比如：`@midnight`.
 
 ### Cron - Update Migration Poster ID (`cron.update_migration_poster_id`)
 
-- `SCHEDULE`: **@every 24h** : 每次同步的间隔时间。此任务总是在启动时自动进行。
+- `SCHEDULE`: **@midnight** : 每次同步的间隔时间。此任务总是在启动时自动进行。
 
 ## Git (`git`)
 

--- a/modules/cron/tasks_basic.go
+++ b/modules/cron/tasks_basic.go
@@ -36,7 +36,7 @@ func registerRepoHealthCheck() {
 		BaseConfig: BaseConfig{
 			Enabled:    true,
 			RunAtStart: false,
-			Schedule:   "@every 24h",
+			Schedule:   "@midnight",
 		},
 		Timeout: 60 * time.Second,
 		Args:    []string{},
@@ -50,7 +50,7 @@ func registerCheckRepoStats() {
 	RegisterTaskFatal("check_repo_stats", &BaseConfig{
 		Enabled:    true,
 		RunAtStart: true,
-		Schedule:   "@every 24h",
+		Schedule:   "@midnight",
 	}, func(ctx context.Context, _ *models.User, _ Config) error {
 		return models.CheckRepoStats(ctx)
 	})
@@ -61,7 +61,7 @@ func registerArchiveCleanup() {
 		BaseConfig: BaseConfig{
 			Enabled:    true,
 			RunAtStart: true,
-			Schedule:   "@every 24h",
+			Schedule:   "@midnight",
 		},
 		OlderThan: 24 * time.Hour,
 	}, func(ctx context.Context, _ *models.User, config Config) error {
@@ -75,7 +75,7 @@ func registerSyncExternalUsers() {
 		BaseConfig: BaseConfig{
 			Enabled:    true,
 			RunAtStart: false,
-			Schedule:   "@every 24h",
+			Schedule:   "@midnight",
 		},
 		UpdateExisting: true,
 	}, func(ctx context.Context, _ *models.User, config Config) error {
@@ -89,7 +89,7 @@ func registerDeletedBranchesCleanup() {
 		BaseConfig: BaseConfig{
 			Enabled:    true,
 			RunAtStart: true,
-			Schedule:   "@every 24h",
+			Schedule:   "@midnight",
 		},
 		OlderThan: 24 * time.Hour,
 	}, func(ctx context.Context, _ *models.User, config Config) error {
@@ -103,7 +103,7 @@ func registerUpdateMigrationPosterID() {
 	RegisterTaskFatal("update_migration_poster_id", &BaseConfig{
 		Enabled:    true,
 		RunAtStart: true,
-		Schedule:   "@every 24h",
+		Schedule:   "@midnight",
 	}, func(ctx context.Context, _ *models.User, _ Config) error {
 		return migrations.UpdateMigrationPosterID(ctx)
 	})
@@ -114,7 +114,7 @@ func registerCleanupHookTaskTable() {
 		BaseConfig: BaseConfig{
 			Enabled:    true,
 			RunAtStart: false,
-			Schedule:   "@every 24h",
+			Schedule:   "@midnight",
 		},
 		CleanupType:  "OlderThan",
 		OlderThan:    168 * time.Hour,


### PR DESCRIPTION
The basic maintenance crons are scheduled @every 24h by default:
https://docs.gitea.io/en-us/config-cheat-sheet/#basic-cron-tasks---enabled-by-default

In practice, this means they will be triggered every 24h from the time that gitea has started. A better default for these would be to perform these tasks at midnight instead.

Fixes #16107.

## :warning: BREAKING :warning: 

The default schedule for basic cron tasks will now occur at midnight rather than at 24 hours after start-up.

At time of merging this changes the defaults for:

```
cron.archive_cleanup
cron.repo_health_check
cron.check_repo_stats
cron.cleanup_hook_task_table
cron.update_migration_poster_id
cron.sync_external_users
```
