### PR TITLE
Update documentation to reflect #15219

### DIFF
--- a/docs/content/doc/advanced/adding-legal-pages.en-us.md
+++ b/docs/content/doc/advanced/adding-legal-pages.en-us.md
@@ -32,7 +32,7 @@ You absolutely must not place a general ToS or privacy statement that implies th
 Create or append to `/path/to/custom/templates/custom/extra_links_footer.tmpl`:
 
 ```go
-<a class="item" href="{{AppSubUrl}}/privacy.html">Privacy Policy</a>
+<a class="item" href="{{AppSubUrl}}/assets/privacy.html">Privacy Policy</a>
 ```
 
 Restart Gitea to see the changes.

--- a/docs/content/doc/advanced/customizing-gitea.en-us.md
+++ b/docs/content/doc/advanced/customizing-gitea.en-us.md
@@ -102,7 +102,7 @@ For instance, let's say you are in Germany and must add the famously legally-req
 just place it under your "$GITEA_CUSTOM/public/" directory (for instance `$GITEA_CUSTOM/public/impressum.html`) and put a link to it in either `$GITEA_CUSTOM/templates/custom/extra_links.tmpl` or `$GITEA_CUSTOM/templates/custom/extra_links_footer.tmpl`.
 
 To match the current style, the link should have the class name "item", and you can use `{{AppSubUrl}}` to get the base URL:
-`<a class="item" href="{{AppSubUrl}}/impressum.html">Impressum</a>`
+`<a class="item" href="{{AppSubUrl}}/assets/impressum.html">Impressum</a>`
 
 For more information, see [Adding Legal Pages](https://docs.gitea.io/en-us/adding-legal-pages).
 
@@ -174,13 +174,13 @@ You can display STL file directly in Gitea by adding:
 
   if ($('.view-raw>a[href$=".stl" i]').length) {
     $("body").append(
-      '<link href="/Madeleine.js/src/css/Madeleine.css" rel="stylesheet">'
+      '<link href="/assets/Madeleine.js/src/css/Madeleine.css" rel="stylesheet">'
     );
     Promise.all([
-      lS("/Madeleine.js/src/lib/stats.js"),
-      lS("/Madeleine.js/src/lib/detector.js"),
-      lS("/Madeleine.js/src/lib/three.min.js"),
-      lS("/Madeleine.js/src/Madeleine.js"),
+      lS("/assets/Madeleine.js/src/lib/stats.js"),
+      lS("/assets/Madeleine.js/src/lib/detector.js"),
+      lS("/assets/Madeleine.js/src/lib/three.min.js"),
+      lS("/assets/Madeleine.js/src/Madeleine.js"),
     ]).then(function () {
       $(".view-raw")
         .attr("id", "view-raw")
@@ -188,7 +188,7 @@ You can display STL file directly in Gitea by adding:
       new Madeleine({
         target: "view-raw",
         data: $('.view-raw>a[href$=".stl" i]').attr("href"),
-        path: "/Madeleine.js/src",
+        path: "/assets/Madeleine.js/src",
       });
       $('.view-raw>a[href$=".stl"]').remove();
     });

--- a/docs/content/doc/advanced/customizing-gitea.zh-cn.md
+++ b/docs/content/doc/advanced/customizing-gitea.zh-cn.md
@@ -61,7 +61,7 @@ Gitea 引用 `custom` 目录中的自定义配置文件来覆盖配置、模板�
 "custom/public/"目录下（比如 `custom/public/impressum.html`）并且将它与 `custom/templates/custom/extra_links.tmpl` 链接起来即可。
 
 这个链接应当使用一个名为“item”的 class 来匹配当前样式，您可以使用 `{{AppSubUrl}}` 来获取 base URL:
-`<a class="item" href="{{AppSubUrl}}/impressum.html">Impressum</a>`
+`<a class="item" href="{{AppSubUrl}}/assets/impressum.html">Impressum</a>`
 
 同理，您可以将页签添加到 `extra_tabs.tmpl` 中，使用同样的方式来添加页签。它的具体样式需要与
 `templates/repo/header.tmpl` 中已有的其他选项卡的样式匹配

--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -164,5 +164,5 @@ And so you could write some CSS:
 
 Add your stylesheet to your custom directory e.g `custom/public/css/my-style-XXXXX.css` and import it using a custom header file `custom/templates/custom/header.tmpl`:
 ```html
-<link type="text/css" href="{{AppSubUrl}}/css/my-style-XXXXX.css" />
+<link type="text/css" href="{{AppSubUrl}}/assets/css/my-style-XXXXX.css" />
 ```


### PR DESCRIPTION
The move to render custom/public as within /assets in #15219 missed updating
several documentation pages.

This PR updates this documentation.

Signed-off-by: Andrew Thornton <art27@cantab.net>