### PR TITLE
Fix respect of x-real-ip / x-forwarded-for headers in context

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -511,9 +511,19 @@ func (ctx *Context) GetCookieFloat64(name string) float64 {
 	return v
 }
 
-// RemoteAddr returns the client machie ip address
+// RemoteAddr returns the client machine ip address. It respects the X-Real-IP (preferred) or X-Forwarded-For header.
 func (ctx *Context) RemoteAddr() string {
-	return ctx.Req.RemoteAddr
+	addr := ctx.Req.Header.Get("X-Real-IP")
+	if len(addr) == 0 {
+		addr = ctx.Req.Header.Get("X-Forwarded-For")
+		if addr == "" {
+			addr = ctx.Req.RemoteAddr
+			if i := strings.LastIndex(addr, ":"); i > -1 {
+				addr = addr[:i]
+			}
+		}
+	}
+	return addr
 }
 
 // Params returns the param on route

--- a/modules/context/context_test.go
+++ b/modules/context/context_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package context
+
+import (
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/modules/context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteAddrNoHeader(t *testing.T) {
+	expected := "123.456.78.9"
+	req, _ := http.NewRequest(http.MethodGet, "url", nil)
+	req.RemoteAddr = expected
+
+	ctx := context.Context{Req: req}
+
+	assert.Equal(t, expected, ctx.RemoteAddr(), "RemoteAddr should match the expected response")
+}
+
+func TestRemoteAddrXRealIpHeader(t *testing.T) {
+	expected := "123.456.78.9"
+	req, _ := http.NewRequest(http.MethodGet, "url", nil)
+	req.Header.Add("X-Real-IP", expected)
+
+	ctx := context.Context{Req: req}
+
+	assert.Equal(t, expected, ctx.RemoteAddr(), "RemoteAddr should match the expected response")
+}
+
+func TestRemoteAddrXForwardedForHeader(t *testing.T) {
+	expected := "123.456.78.9"
+	req, _ := http.NewRequest(http.MethodGet, "url", nil)
+	req.Header.Add("X-Forwarded-For", expected)
+
+	ctx := context.Context{Req: req}
+
+	assert.Equal(t, expected, ctx.RemoteAddr(), "RemoteAddr should match the expected response")
+}

--- a/modules/context/context_test.go
+++ b/modules/context/context_test.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"code.gitea.io/gitea/modules/context"
-
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
According to the https://docs.gitea.io/en-us/fail2ban-setup gitea
respects the X-Real-IP forwarded proxy header and according to the implementation
prior to the commit below also X-Forwarded-For.

6433ba0ec3dfde67f45267aa12bd713c4a44c740 removes this logic,
see https://github.com/go-gitea/gitea/blob/b223d361955f8b722f7dd0b358b2e57e6f359edf/modules/context/context.go line 514.

This commit reverts the implementation and adds basic unit tests for it. 