### PR TITLE
Fix crash following ldap authentication update (#16447)

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -73,9 +73,9 @@ var (
 // possible that a Blob may gain an unwanted prefix of 0xff 0xfe.
 func jsonUnmarshalIgnoreErroneousBOM(bs []byte, v interface{}) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := json.Unmarshal(bs, &v)
+	err := json.Unmarshal(bs, v)
 	if err != nil && len(bs) > 2 && bs[0] == 0xff && bs[1] == 0xfe {
-		err = json.Unmarshal(bs[2:], &v)
+		err = json.Unmarshal(bs[2:], v)
 	}
 	return err
 }


### PR DESCRIPTION
Backport #16447

Unfortunately #16268 contained a terrible error, whereby there was a double
indirection taken when unmarshalling the source data. This fatally breaks
authentication configuration reading.

Fix #16342

Signed-off-by: Andrew Thornton <art27@cantab.net>
