### PR TITLE
Retry rename on lock induced failures (re-fix) (#16461)

### DIFF
--- a/modules/util/remove.go
+++ b/modules/util/remove.go
@@ -64,7 +64,7 @@ func Rename(oldpath, newpath string) error {
 		if err == nil {
 			break
 		}
-		unwrapped := err.(*os.PathError).Err
+		unwrapped := err.(*os.LinkError).Err
 		if unwrapped == syscall.EBUSY || unwrapped == syscall.ENOTEMPTY || unwrapped == syscall.EPERM || unwrapped == syscall.EMFILE || unwrapped == syscall.ENFILE {
 			// try again
 			<-time.After(100 * time.Millisecond)


### PR DESCRIPTION
Backport #16461

Unfortunately #16435 asserts the wrong error and should use
os.LinkError not os.PathError.

Fix #16439

Signed-off-by: Andrew Thornton <art27@cantab.net>
