### PR TITLE
CI: Add unit-test-race

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -216,6 +216,7 @@ steps:
       TAGS: bindata sqlite sqlite_unlock_notify
       GITHUB_READ_TOKEN:
         from_secret: github_read_token
+
   - name: unit-test-race
     image: golang:1.16
     commands:
@@ -224,6 +225,8 @@ steps:
       GOPROXY: off
       TAGS: sqlite sqlite_unlock_notify
       RACE_ENABLED: true
+      GITHUB_READ_TOKEN:
+        from_secret: github_read_token
 
   - name: unit-test-gogit
     pull: always

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,6 +216,14 @@ steps:
       TAGS: bindata sqlite sqlite_unlock_notify
       GITHUB_READ_TOKEN:
         from_secret: github_read_token
+  - name: unit-test-race
+    image: golang:1.16
+    commands:
+      - make test-backend
+    environment:
+      GOPROXY: off
+      TAGS: sqlite sqlite_unlock_notify
+      RACE_ENABLED: true
 
   - name: unit-test-gogit
     pull: always


### PR DESCRIPTION
to prevent things new races ...

since we can only partially enable race detection we have to add a new task who do not generate a coverage file

once #1441 pass, we can remove this step