### PR TITLE
Improve 2FA autofill

### DIFF
--- a/templates/user/auth/twofa.tmpl
+++ b/templates/user/auth/twofa.tmpl
@@ -11,7 +11,7 @@
 					{{template "base/alert" .}}
 					<div class="required inline field">
 						<label for="passcode">{{.i18n.Tr "passcode"}}</label>
-						<input id="passcode" name="passcode" type="number" autocomplete="off" autofocus required>
+						<input id="passcode" name="passcode" type="text" autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*" autofocus required>
 					</div>
 
 					<div class="inline field">


### PR DESCRIPTION
This improves the autofill suggestion on mobile devices and some password managers.
I got the ideas of those changes from [this article from Twilio](https://www.twilio.com/blog/html-attributes-two-factor-authentication-autocomplete)

It seems to improve autofilling in both mobile devices and desktop password managers as tested in Issue #15403