### PR TITLE
Make cancel from CatFileBatch and CatFileBatchCheck wait for the command to end (#16479)

### DIFF
--- a/modules/util/remove.go
+++ b/modules/util/remove.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const WIN_ERROR_SHARING_VIOLATION syscall.Errno = 32
+const windowsSharingViolationError syscall.Errno = 32
 
 // Remove removes the named file or (empty) directory with at most 5 attempts.
 func Remove(name string) error {
@@ -28,7 +28,7 @@ func Remove(name string) error {
 			continue
 		}
 
-		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
+		if unwrapped == windowsSharingViolationError && runtime.GOOS == "windows" {
 			// try again
 			<-time.After(100 * time.Millisecond)
 			continue
@@ -57,7 +57,7 @@ func RemoveAll(name string) error {
 			continue
 		}
 
-		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
+		if unwrapped == windowsSharingViolationError && runtime.GOOS == "windows" {
 			// try again
 			<-time.After(100 * time.Millisecond)
 			continue
@@ -86,7 +86,7 @@ func Rename(oldpath, newpath string) error {
 			continue
 		}
 
-		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
+		if unwrapped == windowsSharingViolationError && runtime.GOOS == "windows" {
 			// try again
 			<-time.After(100 * time.Millisecond)
 			continue

--- a/modules/util/remove.go
+++ b/modules/util/remove.go
@@ -6,9 +6,12 @@ package util
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 )
+
+const WIN_ERROR_SHARING_VIOLATION syscall.Errno = 32
 
 // Remove removes the named file or (empty) directory with at most 5 attempts.
 func Remove(name string) error {
@@ -20,6 +23,12 @@ func Remove(name string) error {
 		}
 		unwrapped := err.(*os.PathError).Err
 		if unwrapped == syscall.EBUSY || unwrapped == syscall.ENOTEMPTY || unwrapped == syscall.EPERM || unwrapped == syscall.EMFILE || unwrapped == syscall.ENFILE {
+			// try again
+			<-time.After(100 * time.Millisecond)
+			continue
+		}
+
+		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
 			// try again
 			<-time.After(100 * time.Millisecond)
 			continue
@@ -48,6 +57,12 @@ func RemoveAll(name string) error {
 			continue
 		}
 
+		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
+			// try again
+			<-time.After(100 * time.Millisecond)
+			continue
+		}
+
 		if unwrapped == syscall.ENOENT {
 			// it's already gone
 			return nil
@@ -66,6 +81,12 @@ func Rename(oldpath, newpath string) error {
 		}
 		unwrapped := err.(*os.LinkError).Err
 		if unwrapped == syscall.EBUSY || unwrapped == syscall.ENOTEMPTY || unwrapped == syscall.EPERM || unwrapped == syscall.EMFILE || unwrapped == syscall.ENFILE {
+			// try again
+			<-time.After(100 * time.Millisecond)
+			continue
+		}
+
+		if unwrapped == WIN_ERROR_SHARING_VIOLATION && runtime.GOOS == "windows" {
 			// try again
 			<-time.After(100 * time.Millisecond)
 			continue


### PR DESCRIPTION
Backport #16479

Unfortunately, it appears like #16435 still isn't enough. This PR adjusts the cancel functions to make them block till the end of the command in the hopes that this finally allows windows to rename the directory.

Fix #16427 (again!)
Fix #16475

Signed-off-by: Andrew Thornton <art27@cantab.net>
