### PR TITLE
fix: support delete non-urlencoded wiki page

### DIFF
--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -309,6 +309,9 @@ func DeleteWikiPage(doer *models.User, repo *models.Repository, wikiName string)
 	}
 
 	found, wikiPath, err := prepareWikiFileName(gitRepo, wikiName)
+	if err != nil {
+		return err
+	}
 	if found {
 		err := gitRepo.RemoveFilesFromIndex(wikiPath)
 		if err != nil {

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -308,15 +308,7 @@ func DeleteWikiPage(doer *models.User, repo *models.Repository, wikiName string)
 		return fmt.Errorf("Unable to read HEAD tree to index in: %s %v", basePath, err)
 	}
 
-	wikiPath := NameToFilename(wikiName)
-	filesInIndex, err := gitRepo.LsFiles(wikiPath)
-	found := false
-	for _, file := range filesInIndex {
-		if file == wikiPath {
-			found = true
-			break
-		}
-	}
+	found, wikiPath, err := prepareWikiFileName(gitRepo, wikiName)
 	if found {
 		err := gitRepo.RemoveFilesFromIndex(wikiPath)
 		if err != nil {


### PR DESCRIPTION
Related to issue #16122, this patch is a continuation of #16139.

This patch allows users to use the delete button to delete a wiki page with a non-urlencoded file name.
