### PR TITLE
Fix issue pasted image missing if no release permission

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -830,7 +830,7 @@ func RegisterRoutes(m *web.Route) {
 
 	}, ignSignIn, context.RepoAssignment, context.UnitTypes(), reqRepoReleaseReader)
 
-	// for compitable old attachments
+	// to maintain compatibility with old attachments
 	m.Group("/{username}/{reponame}", func() {
 		m.Get("/attachments/{uuid}", repo.GetAttachment)
 	}, ignSignIn, context.RepoAssignment, context.UnitTypes())

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -827,8 +827,13 @@ func RegisterRoutes(m *web.Route) {
 			}
 			ctx.Data["CommitsCount"] = ctx.Repo.CommitsCount
 		})
-		m.Get("/attachments/{uuid}", repo.GetAttachment)
+
 	}, ignSignIn, context.RepoAssignment, context.UnitTypes(), reqRepoReleaseReader)
+
+	// for compitable old attachments
+	m.Group("/{username}/{reponame}", func() {
+		m.Get("/attachments/{uuid}", repo.GetAttachment)
+	}, ignSignIn, context.RepoAssignment, context.UnitTypes())
 
 	m.Group("/{username}/{reponame}", func() {
 		m.Post("/topics", repo.TopicsPost)


### PR DESCRIPTION
Fix the bug when a user has no release unit read permission, then all images pasted in issues will be missed.