### PR TITLE
Fix add authentication page

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -329,6 +329,10 @@ func UpdateSource(source *LoginSource) error {
 		return nil
 	}
 
+	if settable, ok := source.Cfg.(LoginSourceSettable); ok {
+		settable.SetLoginSource(source)
+	}
+
 	registerableSource, ok := source.Cfg.(RegisterableSource)
 	if !ok {
 		return nil

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -36,7 +36,7 @@ func (typ LoginType) String() string {
 	return LoginNames[typ]
 }
 
-// String returns the string name of the LoginType
+// Int returns the int value of the LoginType
 func (typ LoginType) Int() int {
 	return int(typ)
 }

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -36,6 +36,11 @@ func (typ LoginType) String() string {
 	return LoginNames[typ]
 }
 
+// String returns the string name of the LoginType
+func (typ LoginType) Int() int {
+	return int(typ)
+}
+
 // LoginNames contains the name of LoginType values.
 var LoginNames = map[LoginType]string{
 	LoginLDAP:   "LDAP (via BindDN)",
@@ -216,6 +221,10 @@ func CreateLoginSource(source *LoginSource) error {
 
 	if !source.IsActive {
 		return nil
+	}
+
+	if settable, ok := source.Cfg.(LoginSourceSettable); ok {
+		settable.SetLoginSource(source)
 	}
 
 	registerableSource, ok := source.Cfg.(RegisterableSource)

--- a/services/auth/source/ldap/security_protocol.go
+++ b/services/auth/source/ldap/security_protocol.go
@@ -19,6 +19,11 @@ func (s SecurityProtocol) String() string {
 	return SecurityProtocolNames[s]
 }
 
+// String returns the name of the SecurityProtocol
+func (s SecurityProtocol) Int() int {
+	return int(s)
+}
+
 // SecurityProtocolNames contains the name of SecurityProtocol values.
 var SecurityProtocolNames = map[SecurityProtocol]string{
 	SecurityProtocolUnencrypted: "Unencrypted",

--- a/services/auth/source/ldap/security_protocol.go
+++ b/services/auth/source/ldap/security_protocol.go
@@ -19,7 +19,7 @@ func (s SecurityProtocol) String() string {
 	return SecurityProtocolNames[s]
 }
 
-// String returns the name of the SecurityProtocol
+// Int returns the int value of the SecurityProtocol
 func (s SecurityProtocol) Int() int {
 	return int(s)
 }

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -12,7 +12,7 @@
 				<input type="hidden" name="id" value="{{.Source.ID}}">
 				<div class="inline field">
 					<label>{{$.i18n.Tr "admin.auths.auth_type"}}</label>
-					<input type="hidden" id="auth_type" name="type" value="{{.Source.Type}}">
+					<input type="hidden" id="auth_type" name="type" value="{{.Source.Type.Int}}">
 					<span>{{.Source.TypeName}}</span>
 				</div>
 				<div class="required inline field {{if .Err_Name}}error{{end}}">
@@ -31,7 +31,7 @@
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							<div class="menu">
 								{{range .SecurityProtocols}}
-									<div class="item" data-value="{{.Type}}">{{.Name}}</div>
+									<div class="item" data-value="{{.Type.Int}}">{{.Name}}</div>
 								{{end}}
 							</div>
 						</div>

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -13,12 +13,12 @@
 				<div class="inline required field {{if .Err_Type}}error{{end}}">
 					<label>{{.i18n.Tr "admin.auths.auth_type"}}</label>
 					<div class="ui selection type dropdown">
-						<input type="hidden" id="auth_type" name="type" value="{{.type}}">
+						<input type="hidden" id="auth_type" name="type" value="{{.type.Int}}">
 						<div class="text">{{.CurrentTypeName}}</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
 							{{range .AuthSources}}
-								<div class="item" data-value="{{.Type}}">{{.Name}}</div>
+								<div class="item" data-value="{{.Type.Int}}">{{.Name}}</div>
 							{{end}}
 						</div>
 					</div>

--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -7,7 +7,7 @@
 			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 			<div class="menu">
 				{{range .SecurityProtocols}}
-					<div class="item" data-value="{{.Type}}">{{.Name}}</div>
+					<div class="item" data-value="{{.Type.Int}}">{{.Name}}</div>
 				{{end}}
 			</div>
 		</div>


### PR DESCRIPTION
There is a regression in #16199 whereby the add authentication page
fails to react to the change in selected type.

This is due to the String() method on the LoginSourceType which is ameliorated
with an Int() function being added.

Following on from this there are a few other related bugs.

Fix #16541

Signed-off-by: Andrew Thornton <art27@cantab.net>
