### PR TITLE
Pre-fill suggested New File 'name' and 'content' with Query Params

### DIFF
--- a/docs/content/doc/developers/integrations.en-us.md
+++ b/docs/content/doc/developers/integrations.en-us.md
@@ -24,3 +24,22 @@ If you are looking for [CI/CD](https://gitea.com/gitea/awesome-gitea#user-conten
 an [SDK](https://gitea.com/gitea/awesome-gitea#user-content-sdk),
 or even some extra [themes](https://gitea.com/gitea/awesome-gitea#user-content-themes),
 you can find them listed in the [awesome-gitea](https://gitea.com/gitea/awesome-gitea) repository!
+
+## Pre-Fill New File name and contents
+
+If you'd like to open a new file with a given name and contents,
+you can do so with query parameters:
+
+```txt
+GET /{{org}}/{{repo}}/_new/{{filepath}}
+    ?filename={{filename}}
+    &value={{content}}
+```
+
+For example:
+
+```txt
+GET https://git.example.com/johndoe/bliss/_new/articles/
+    ?filename=hello-world.md
+    &value=Hello%2C%20World!
+```

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -81,7 +81,11 @@ func editFile(ctx *context.Context, isNewFile bool) {
 		return
 	}
 
-	treeNames, treePaths := getParentTreeFields(ctx.Repo.TreePath)
+	// Check if the filename (and additional path) is specified in the querystring
+	// (filename is a misnomer, but kept for compatibility with Github)
+	filePath, fileName := path.Split(ctx.Req.URL.Query().Get("filename"))
+	filePath = strings.Trim(filePath, "/")
+	treeNames, treePaths := getParentTreeFields(path.Join(ctx.Repo.TreePath, filePath))
 
 	if !isNewFile {
 		entry, err := ctx.Repo.Commit.GetTreeEntryByPath(ctx.Repo.TreePath)
@@ -136,7 +140,8 @@ func editFile(ctx *context.Context, isNewFile bool) {
 			ctx.Data["FileContent"] = content
 		}
 	} else {
-		treeNames = append(treeNames, "") // Append empty string to allow user name the new file.
+		// Append filename from query, or empty string to allow user name the new file.
+		treeNames = append(treeNames, fileName)
 	}
 
 	ctx.Data["TreeNames"] = treeNames

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1825,7 +1825,7 @@ async function initEditor() {
   const $editArea = $('.repository.editor textarea#edit_area');
   if (!$editArea.length) return;
 
-  await createCodeEditor($editArea[0], $editFilename[0], previewFileModes);
+  const editor = await createCodeEditor($editArea[0], $editFilename[0], previewFileModes);
 
   // Using events from https://github.com/codedance/jquery.AreYouSure#advanced-usage
   // to enable or disable the commit button
@@ -1848,6 +1848,14 @@ async function initEditor() {
       $commitButton.prop('disabled', !dirty);
     }
   });
+
+  // Update the editor from query params, if available,
+  // only after the dirtyFileClass initialization
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('value');
+  if (value) {
+    editor.setValue(value);
+  }
 
   $commitButton.on('click', (event) => {
     // A modal which asks if an empty file should be committed


### PR DESCRIPTION
Re: https://github.com/go-gitea/gitea/issues/16398

Use the same GET as the "New File" link, as seen here:

<kbd><img width="978" alt="Screen Shot 2021-07-27 at 7 00 32 PM" src="https://user-images.githubusercontent.com/122831/127246982-59d9da31-ad7a-4b30-bc88-d37ba1be5001.png"></kbd>

And allow 3rd-party frontends to append `?filename=x&value=y` to pre-populate the form:

<kbd><img width="847" alt="Screen Shot 2021-07-27 at 7 01 19 PM" src="https://user-images.githubusercontent.com/122831/127246989-9697a033-2949-4d65-aabb-2271f63e1c45.png"></kbd>

See also: [Screen Capture Demo](https://youtu.be/5a-z-ZLeQj0).

## Pre-Fill New File Name & Contents w/ Query Params

If you'd like to open the New File page with suggested name and contents,
you can do so with the `filename` and `value` query parameters (just like GitHub):

```txt
GET /{{org}}/{{repo}}/_new/{{filepath}}
    ?filename={{filename}}
    &value={{content}}
```

For example:

```txt
GET https://git.example.com/johndoe/bliss/_new/articles/
    ?filename=hello-world.md
    &value=Hello%2C%20World!
```

This mirrors the [documented behavior of Github](https://github.com/isaacs/github/issues/1527#issuecomment-617466083), and fixes the known bug. Gist will also have this feature [soon](https://twitter.com/JasonEtco/status/1419703200450588685).

## For Integration with File Templates

This allows you to use File Templating tools such as [Bliss](https://github.com/coolaj86/bliss) - which allows you to create blog articles, with FrontMatter, for Static Site blogs - acting as a de facto frontend for such platforms.

## Test Binary

```bash
# Install Go
curl -sS https://webinstall.dev/golang | bash
```

```bash
# Clone Repo and Build
git clone https://github.com/coolaj86/gitea

pushd ./gitea

git checkout bliss

TAGS="bindata sqlite sqlite_unlock_notify" make build
```

- Pre-built: https://coolaj86.com/gitea-linux-v1.15-rc2-bliss.zip