### PR TITLE
rename context.Query to context.Form

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -177,7 +177,7 @@ func genAPILinks(curURL *url.URL, total, pageSize, curPage int) []string {
 
 // SetLinkHeader sets pagination link header by given total number and page size.
 func (ctx *APIContext) SetLinkHeader(total, pageSize int) {
-	links := genAPILinks(ctx.Req.URL, total, pageSize, ctx.QueryInt("page"))
+	links := genAPILinks(ctx.Req.URL, total, pageSize, ctx.FormInt("page"))
 
 	if len(links) > 0 {
 		ctx.Header().Set("Link", strings.Join(links, ","))

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -292,32 +292,32 @@ func (ctx *Context) Form(key string, defaults ...string) string {
 	return (*Forms)(ctx.Req).MustString(key, defaults...)
 }
 
-// QueryTrim returns request form as string with default and trimmed spaces
+// FormTrim returns request form as string with default and trimmed spaces
 func (ctx *Context) FormTrim(key string, defaults ...string) string {
 	return (*Forms)(ctx.Req).MustTrimmed(key, defaults...)
 }
 
-// QueryStrings returns request form as strings with default
+// FormStrings returns request form as strings with default
 func (ctx *Context) FormStrings(key string, defaults ...[]string) []string {
 	return (*Forms)(ctx.Req).MustStrings(key, defaults...)
 }
 
-// QueryInt returns request form as int with default
+// FormInt returns request form as int with default
 func (ctx *Context) FormInt(key string, defaults ...int) int {
 	return (*Forms)(ctx.Req).MustInt(key, defaults...)
 }
 
-// QueryInt64 returns request form as int64 with default
+// FormInt64 returns request form as int64 with default
 func (ctx *Context) FormInt64(key string, defaults ...int64) int64 {
 	return (*Forms)(ctx.Req).MustInt64(key, defaults...)
 }
 
-// QueryBool returns request form as bool with default
+// FormBool returns request form as bool with default
 func (ctx *Context) FormBool(key string, defaults ...bool) bool {
 	return (*Forms)(ctx.Req).MustBool(key, defaults...)
 }
 
-// QueryOptionalBool returns request form as OptionalBool with default
+// FormOptionalBool returns request form as OptionalBool with default
 func (ctx *Context) FormOptionalBool(key string, defaults ...util.OptionalBool) util.OptionalBool {
 	return (*Forms)(ctx.Req).MustOptionalBool(key, defaults...)
 }

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -287,41 +287,38 @@ func (ctx *Context) Header() http.Header {
 	return ctx.Resp.Header()
 }
 
-// FIXME: We should differ Query and Form, currently we just use form as query
-// Currently to be compatible with macaron, we keep it.
-
-// Query returns request form as string with default
-func (ctx *Context) Query(key string, defaults ...string) string {
+// Form returns request form as string with default
+func (ctx *Context) Form(key string, defaults ...string) string {
 	return (*Forms)(ctx.Req).MustString(key, defaults...)
 }
 
 // QueryTrim returns request form as string with default and trimmed spaces
-func (ctx *Context) QueryTrim(key string, defaults ...string) string {
+func (ctx *Context) FormTrim(key string, defaults ...string) string {
 	return (*Forms)(ctx.Req).MustTrimmed(key, defaults...)
 }
 
 // QueryStrings returns request form as strings with default
-func (ctx *Context) QueryStrings(key string, defaults ...[]string) []string {
+func (ctx *Context) FormStrings(key string, defaults ...[]string) []string {
 	return (*Forms)(ctx.Req).MustStrings(key, defaults...)
 }
 
 // QueryInt returns request form as int with default
-func (ctx *Context) QueryInt(key string, defaults ...int) int {
+func (ctx *Context) FormInt(key string, defaults ...int) int {
 	return (*Forms)(ctx.Req).MustInt(key, defaults...)
 }
 
 // QueryInt64 returns request form as int64 with default
-func (ctx *Context) QueryInt64(key string, defaults ...int64) int64 {
+func (ctx *Context) FormInt64(key string, defaults ...int64) int64 {
 	return (*Forms)(ctx.Req).MustInt64(key, defaults...)
 }
 
 // QueryBool returns request form as bool with default
-func (ctx *Context) QueryBool(key string, defaults ...bool) bool {
+func (ctx *Context) FormBool(key string, defaults ...bool) bool {
 	return (*Forms)(ctx.Req).MustBool(key, defaults...)
 }
 
 // QueryOptionalBool returns request form as OptionalBool with default
-func (ctx *Context) QueryOptionalBool(key string, defaults ...util.OptionalBool) util.OptionalBool {
+func (ctx *Context) FormOptionalBool(key string, defaults ...util.OptionalBool) util.OptionalBool {
 	return (*Forms)(ctx.Req).MustOptionalBool(key, defaults...)
 }
 

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -346,7 +346,7 @@ func repoAssignment(ctx *Context, repo *models.Repository) {
 
 	// Check access.
 	if ctx.Repo.Permission.AccessMode == models.AccessModeNone {
-		if ctx.Query("go-get") == "1" {
+		if ctx.Form("go-get") == "1" {
 			EarlyResponseForGoGetMeta(ctx)
 			return
 		}
@@ -415,7 +415,7 @@ func RepoAssignment(ctx *Context) (cancel context.CancelFunc) {
 		owner, err = models.GetUserByName(userName)
 		if err != nil {
 			if models.IsErrUserNotExist(err) {
-				if ctx.Query("go-get") == "1" {
+				if ctx.Form("go-get") == "1" {
 					EarlyResponseForGoGetMeta(ctx)
 					return
 				}
@@ -437,7 +437,7 @@ func RepoAssignment(ctx *Context) (cancel context.CancelFunc) {
 			if err == nil {
 				RedirectToRepo(ctx, redirectRepoID)
 			} else if models.IsErrRepoRedirectNotExist(err) {
-				if ctx.Query("go-get") == "1" {
+				if ctx.Form("go-get") == "1" {
 					EarlyResponseForGoGetMeta(ctx)
 					return
 				}
@@ -618,7 +618,7 @@ func RepoAssignment(ctx *Context) (cancel context.CancelFunc) {
 		}
 	}
 
-	if ctx.Query("go-get") == "1" {
+	if ctx.Form("go-get") == "1" {
 		ctx.Data["GoGetImport"] = ComposeGoGetImport(owner.Name, repo.Name)
 		prefix := setting.AppURL + path.Join(owner.Name, repo.Name, "src", "branch", ctx.Repo.BranchName)
 		ctx.Data["GoDocDirectory"] = prefix + "{/dir}"

--- a/routers/api/v1/admin/adopt.go
+++ b/routers/api/v1/admin/adopt.go
@@ -42,7 +42,7 @@ func ListUnadoptedRepositories(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 
 	listOptions := utils.GetListOptions(ctx)
-	repoNames, count, err := repository.ListUnadoptedRepositories(ctx.Query("query"), &listOptions)
+	repoNames, count, err := repository.ListUnadoptedRepositories(ctx.Form("query"), &listOptions)
 	if err != nil {
 		ctx.InternalServerError(err)
 	}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -93,7 +93,7 @@ import (
 
 func sudo() func(ctx *context.APIContext) {
 	return func(ctx *context.APIContext) {
-		sudo := ctx.Query("sudo")
+		sudo := ctx.Form("sudo")
 		if len(sudo) == 0 {
 			sudo = ctx.Req.Header.Get("Sudo")
 		}

--- a/routers/api/v1/notify/notifications.go
+++ b/routers/api/v1/notify/notifications.go
@@ -37,12 +37,12 @@ func getFindNotificationOptions(ctx *context.APIContext) *models.FindNotificatio
 		UpdatedBeforeUnix: before,
 		UpdatedAfterUnix:  since,
 	}
-	if !ctx.QueryBool("all") {
-		statuses := ctx.QueryStrings("status-types")
+	if !ctx.FormBool("all") {
+		statuses := ctx.FormStrings("status-types")
 		opts.Status = statusStringsToNotificationStatuses(statuses, []string{"unread", "pinned"})
 	}
 
-	subjectTypes := ctx.QueryStrings("subject-type")
+	subjectTypes := ctx.FormStrings("subject-type")
 	if len(subjectTypes) != 0 {
 		opts.Source = subjectToSource(subjectTypes)
 	}

--- a/routers/api/v1/notify/repo.go
+++ b/routers/api/v1/notify/repo.go
@@ -171,7 +171,7 @@ func ReadRepoNotifications(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 
 	lastRead := int64(0)
-	qLastRead := strings.Trim(ctx.Query("last_read_at"), " ")
+	qLastRead := strings.Trim(ctx.Form("last_read_at"), " ")
 	if len(qLastRead) > 0 {
 		tmpLastRead, err := time.Parse(time.RFC3339, qLastRead)
 		if err != nil {
@@ -189,8 +189,8 @@ func ReadRepoNotifications(ctx *context.APIContext) {
 		UpdatedBeforeUnix: lastRead,
 	}
 
-	if !ctx.QueryBool("all") {
-		statuses := ctx.QueryStrings("status-types")
+	if !ctx.FormBool("all") {
+		statuses := ctx.FormStrings("status-types")
 		opts.Status = statusStringsToNotificationStatuses(statuses, []string{"unread"})
 		log.Error("%v", opts.Status)
 	}
@@ -200,7 +200,7 @@ func ReadRepoNotifications(ctx *context.APIContext) {
 		return
 	}
 
-	targetStatus := statusStringToNotificationStatus(ctx.Query("to-status"))
+	targetStatus := statusStringToNotificationStatus(ctx.Form("to-status"))
 	if targetStatus == 0 {
 		targetStatus = models.NotificationStatusRead
 	}

--- a/routers/api/v1/notify/threads.go
+++ b/routers/api/v1/notify/threads.go
@@ -82,7 +82,7 @@ func ReadThread(ctx *context.APIContext) {
 		return
 	}
 
-	targetStatus := statusStringToNotificationStatus(ctx.Query("to-status"))
+	targetStatus := statusStringToNotificationStatus(ctx.Form("to-status"))
 	if targetStatus == 0 {
 		targetStatus = models.NotificationStatusRead
 	}

--- a/routers/api/v1/notify/user.go
+++ b/routers/api/v1/notify/user.go
@@ -122,7 +122,7 @@ func ReadNotifications(ctx *context.APIContext) {
 	//     "$ref": "#/responses/empty"
 
 	lastRead := int64(0)
-	qLastRead := strings.Trim(ctx.Query("last_read_at"), " ")
+	qLastRead := strings.Trim(ctx.Form("last_read_at"), " ")
 	if len(qLastRead) > 0 {
 		tmpLastRead, err := time.Parse(time.RFC3339, qLastRead)
 		if err != nil {
@@ -137,8 +137,8 @@ func ReadNotifications(ctx *context.APIContext) {
 		UserID:            ctx.User.ID,
 		UpdatedBeforeUnix: lastRead,
 	}
-	if !ctx.QueryBool("all") {
-		statuses := ctx.QueryStrings("status-types")
+	if !ctx.FormBool("all") {
+		statuses := ctx.FormStrings("status-types")
 		opts.Status = statusStringsToNotificationStatuses(statuses, []string{"unread"})
 	}
 	nl, err := models.GetNotifications(opts)
@@ -147,7 +147,7 @@ func ReadNotifications(ctx *context.APIContext) {
 		return
 	}
 
-	targetStatus := statusStringToNotificationStatus(ctx.Query("to-status"))
+	targetStatus := statusStringToNotificationStatus(ctx.Form("to-status"))
 	if targetStatus == 0 {
 		targetStatus = models.NotificationStatusRead
 	}

--- a/routers/api/v1/org/label.go
+++ b/routers/api/v1/org/label.go
@@ -43,7 +43,7 @@ func ListLabels(ctx *context.APIContext) {
 	//   "200":
 	//     "$ref": "#/responses/LabelList"
 
-	labels, err := models.GetLabelsByOrgID(ctx.Org.Organization.ID, ctx.Query("sort"), utils.GetListOptions(ctx))
+	labels, err := models.GetLabelsByOrgID(ctx.Org.Organization.ID, ctx.Form("sort"), utils.GetListOptions(ctx))
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "GetLabelsByOrgID", err)
 		return

--- a/routers/api/v1/org/team.go
+++ b/routers/api/v1/org/team.go
@@ -658,9 +658,9 @@ func SearchTeam(ctx *context.APIContext) {
 
 	opts := &models.SearchTeamOptions{
 		UserID:      ctx.User.ID,
-		Keyword:     strings.TrimSpace(ctx.Query("q")),
+		Keyword:     strings.TrimSpace(ctx.Form("q")),
 		OrgID:       ctx.Org.Organization.ID,
-		IncludeDesc: ctx.Query("include_desc") == "" || ctx.QueryBool("include_desc"),
+		IncludeDesc: ctx.Form("include_desc") == "" || ctx.FormBool("include_desc"),
 		ListOptions: listOptions,
 	}
 

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -147,7 +147,7 @@ func GetAllCommits(ctx *context.APIContext) {
 		listOptions.PageSize = setting.Git.CommitsRangeSize
 	}
 
-	sha := ctx.Query("sha")
+	sha := ctx.Form("sha")
 
 	var baseCommit *git.Commit
 	if len(sha) == 0 {

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -62,7 +62,7 @@ func GetRawFile(ctx *context.APIContext) {
 
 	commit := ctx.Repo.Commit
 
-	if ref := ctx.QueryTrim("ref"); len(ref) > 0 {
+	if ref := ctx.FormTrim("ref"); len(ref) > 0 {
 		var err error
 		commit, err = ctx.Repo.GitRepo.GetCommit(ref)
 		if err != nil {
@@ -549,7 +549,7 @@ func GetContents(ctx *context.APIContext) {
 	}
 
 	treePath := ctx.Params("*")
-	ref := ctx.QueryTrim("ref")
+	ref := ctx.FormTrim("ref")
 
 	if fileList, err := repofiles.GetContentsOrList(ctx.Repo.Repository, treePath, ref); err != nil {
 		if git.IsErrNotExist(err) {

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -106,7 +106,7 @@ func SearchIssues(ctx *context.APIContext) {
 	}
 
 	var isClosed util.OptionalBool
-	switch ctx.Query("state") {
+	switch ctx.Form("state") {
 	case "closed":
 		isClosed = util.OptionalBoolTrue
 	case "all":
@@ -140,7 +140,7 @@ func SearchIssues(ctx *context.APIContext) {
 	var issues []*models.Issue
 	var filteredCount int64
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	if strings.IndexByte(keyword, 0) >= 0 {
 		keyword = ""
 	}
@@ -153,7 +153,7 @@ func SearchIssues(ctx *context.APIContext) {
 	}
 
 	var isPull util.OptionalBool
-	switch ctx.Query("type") {
+	switch ctx.Form("type") {
 	case "pulls":
 		isPull = util.OptionalBoolTrue
 	case "issues":
@@ -162,13 +162,13 @@ func SearchIssues(ctx *context.APIContext) {
 		isPull = util.OptionalBoolNone
 	}
 
-	labels := strings.TrimSpace(ctx.Query("labels"))
+	labels := strings.TrimSpace(ctx.Form("labels"))
 	var includedLabelNames []string
 	if len(labels) > 0 {
 		includedLabelNames = strings.Split(labels, ",")
 	}
 
-	milestones := strings.TrimSpace(ctx.Query("milestones"))
+	milestones := strings.TrimSpace(ctx.Form("milestones"))
 	var includedMilestones []string
 	if len(milestones) > 0 {
 		includedMilestones = strings.Split(milestones, ",")
@@ -176,7 +176,7 @@ func SearchIssues(ctx *context.APIContext) {
 
 	// this api is also used in UI,
 	// so the default limit is set to fit UI needs
-	limit := ctx.QueryInt("limit")
+	limit := ctx.FormInt("limit")
 	if limit == 0 {
 		limit = setting.UI.IssuePagingNum
 	} else if limit > setting.API.MaxResponseItems {
@@ -188,7 +188,7 @@ func SearchIssues(ctx *context.APIContext) {
 	if len(keyword) == 0 || len(issueIDs) > 0 || len(includedLabelNames) > 0 || len(includedMilestones) > 0 {
 		issuesOpt := &models.IssuesOptions{
 			ListOptions: models.ListOptions{
-				Page:     ctx.QueryInt("page"),
+				Page:     ctx.FormInt("page"),
 				PageSize: limit,
 			},
 			RepoIDs:            repoIDs,
@@ -197,23 +197,23 @@ func SearchIssues(ctx *context.APIContext) {
 			IncludedLabelNames: includedLabelNames,
 			IncludeMilestones:  includedMilestones,
 			SortType:           "priorityrepo",
-			PriorityRepoID:     ctx.QueryInt64("priority_repo_id"),
+			PriorityRepoID:     ctx.FormInt64("priority_repo_id"),
 			IsPull:             isPull,
 			UpdatedBeforeUnix:  before,
 			UpdatedAfterUnix:   since,
 		}
 
 		// Filter for: Created by User, Assigned to User, Mentioning User, Review of User Requested
-		if ctx.QueryBool("created") {
+		if ctx.FormBool("created") {
 			issuesOpt.PosterID = ctx.User.ID
 		}
-		if ctx.QueryBool("assigned") {
+		if ctx.FormBool("assigned") {
 			issuesOpt.AssigneeID = ctx.User.ID
 		}
-		if ctx.QueryBool("mentioned") {
+		if ctx.FormBool("mentioned") {
 			issuesOpt.MentionedID = ctx.User.ID
 		}
-		if ctx.QueryBool("review_requested") {
+		if ctx.FormBool("review_requested") {
 			issuesOpt.ReviewRequestedID = ctx.User.ID
 		}
 
@@ -319,7 +319,7 @@ func ListIssues(ctx *context.APIContext) {
 	}
 
 	var isClosed util.OptionalBool
-	switch ctx.Query("state") {
+	switch ctx.Form("state") {
 	case "closed":
 		isClosed = util.OptionalBoolTrue
 	case "all":
@@ -331,7 +331,7 @@ func ListIssues(ctx *context.APIContext) {
 	var issues []*models.Issue
 	var filteredCount int64
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	if strings.IndexByte(keyword, 0) >= 0 {
 		keyword = ""
 	}
@@ -345,7 +345,7 @@ func ListIssues(ctx *context.APIContext) {
 		}
 	}
 
-	if splitted := strings.Split(ctx.Query("labels"), ","); len(splitted) > 0 {
+	if splitted := strings.Split(ctx.Form("labels"), ","); len(splitted) > 0 {
 		labelIDs, err = models.GetLabelIDsInRepoByNames(ctx.Repo.Repository.ID, splitted)
 		if err != nil {
 			ctx.Error(http.StatusInternalServerError, "GetLabelIDsInRepoByNames", err)
@@ -354,7 +354,7 @@ func ListIssues(ctx *context.APIContext) {
 	}
 
 	var mileIDs []int64
-	if part := strings.Split(ctx.Query("milestones"), ","); len(part) > 0 {
+	if part := strings.Split(ctx.Form("milestones"), ","); len(part) > 0 {
 		for i := range part {
 			// uses names and fall back to ids
 			// non existent milestones are discarded
@@ -386,7 +386,7 @@ func ListIssues(ctx *context.APIContext) {
 	listOptions := utils.GetListOptions(ctx)
 
 	var isPull util.OptionalBool
-	switch ctx.Query("type") {
+	switch ctx.Form("type") {
 	case "pulls":
 		isPull = util.OptionalBoolTrue
 	case "issues":
@@ -448,7 +448,7 @@ func ListIssues(ctx *context.APIContext) {
 }
 
 func getUserIDForFilter(ctx *context.APIContext, queryName string) int64 {
-	userName := ctx.Query(queryName)
+	userName := ctx.Form(queryName)
 	if len(userName) == 0 {
 		return 0
 	}

--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -90,7 +90,7 @@ func ListTrackedTimes(ctx *context.APIContext) {
 		IssueID:      issue.ID,
 	}
 
-	qUser := strings.Trim(ctx.Query("user"), " ")
+	qUser := strings.Trim(ctx.Form("user"), " ")
 	if qUser != "" {
 		user, err := models.GetUserByName(qUser)
 		if models.IsErrUserNotExist(err) {
@@ -500,7 +500,7 @@ func ListTrackedTimesByRepository(ctx *context.APIContext) {
 	}
 
 	// Filters
-	qUser := strings.Trim(ctx.Query("user"), " ")
+	qUser := strings.Trim(ctx.Form("user"), " ")
 	if qUser != "" {
 		user, err := models.GetUserByName(qUser)
 		if models.IsErrUserNotExist(err) {

--- a/routers/api/v1/repo/key.go
+++ b/routers/api/v1/repo/key.go
@@ -78,8 +78,8 @@ func ListDeployKeys(ctx *context.APIContext) {
 	var keys []*models.DeployKey
 	var err error
 
-	fingerprint := ctx.Query("fingerprint")
-	keyID := ctx.QueryInt64("key_id")
+	fingerprint := ctx.Form("fingerprint")
+	keyID := ctx.FormInt64("key_id")
 	if fingerprint != "" || keyID != 0 {
 		keys, err = models.SearchDeployKeys(ctx.Repo.Repository.ID, keyID, fingerprint)
 	} else {

--- a/routers/api/v1/repo/label.go
+++ b/routers/api/v1/repo/label.go
@@ -49,7 +49,7 @@ func ListLabels(ctx *context.APIContext) {
 	//   "200":
 	//     "$ref": "#/responses/LabelList"
 
-	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Query("sort"), utils.GetListOptions(ctx))
+	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Form("sort"), utils.GetListOptions(ctx))
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "GetLabelsByRepoID", err)
 		return

--- a/routers/api/v1/repo/milestone.go
+++ b/routers/api/v1/repo/milestone.go
@@ -60,8 +60,8 @@ func ListMilestones(ctx *context.APIContext) {
 	milestones, err := models.GetMilestones(models.GetMilestonesOption{
 		ListOptions: utils.GetListOptions(ctx),
 		RepoID:      ctx.Repo.Repository.ID,
-		State:       api.StateType(ctx.Query("state")),
-		Name:        ctx.Query("name"),
+		State:       api.StateType(ctx.Form("state")),
+		Name:        ctx.Form("name"),
 	})
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "GetMilestones", err)

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -86,10 +86,10 @@ func ListPullRequests(ctx *context.APIContext) {
 
 	prs, maxResults, err := models.PullRequests(ctx.Repo.Repository.ID, &models.PullRequestsOptions{
 		ListOptions: listOptions,
-		State:       ctx.QueryTrim("state"),
-		SortType:    ctx.QueryTrim("sort"),
-		Labels:      ctx.QueryStrings("labels"),
-		MilestoneID: ctx.QueryInt64("milestone"),
+		State:       ctx.FormTrim("state"),
+		SortType:    ctx.FormTrim("sort"),
+		Labels:      ctx.FormStrings("labels"),
+		MilestoneID: ctx.FormInt64("milestone"),
 	})
 
 	if err != nil {

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -109,16 +109,16 @@ func ListReleases(ctx *context.APIContext) {
 	//   "200":
 	//     "$ref": "#/responses/ReleaseList"
 	listOptions := utils.GetListOptions(ctx)
-	if listOptions.PageSize == 0 && ctx.QueryInt("per_page") != 0 {
-		listOptions.PageSize = ctx.QueryInt("per_page")
+	if listOptions.PageSize == 0 && ctx.FormInt("per_page") != 0 {
+		listOptions.PageSize = ctx.FormInt("per_page")
 	}
 
 	opts := models.FindReleasesOptions{
 		ListOptions:   listOptions,
 		IncludeDrafts: ctx.Repo.AccessMode >= models.AccessModeWrite,
 		IncludeTags:   false,
-		IsDraft:       ctx.QueryOptionalBool("draft"),
-		IsPreRelease:  ctx.QueryOptionalBool("pre-release"),
+		IsDraft:       ctx.FormOptionalBool("draft"),
+		IsPreRelease:  ctx.FormOptionalBool("pre-release"),
 	}
 
 	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, opts)

--- a/routers/api/v1/repo/release_attachment.go
+++ b/routers/api/v1/repo/release_attachment.go
@@ -190,7 +190,7 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 	}
 
 	var filename = header.Filename
-	if query := ctx.Query("name"); query != "" {
+	if query := ctx.Form("name"); query != "" {
 		filename = query
 	}
 

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -135,27 +135,27 @@ func Search(ctx *context.APIContext) {
 	opts := &models.SearchRepoOptions{
 		ListOptions:        utils.GetListOptions(ctx),
 		Actor:              ctx.User,
-		Keyword:            strings.Trim(ctx.Query("q"), " "),
-		OwnerID:            ctx.QueryInt64("uid"),
-		PriorityOwnerID:    ctx.QueryInt64("priority_owner_id"),
-		TeamID:             ctx.QueryInt64("team_id"),
-		TopicOnly:          ctx.QueryBool("topic"),
+		Keyword:            strings.Trim(ctx.Form("q"), " "),
+		OwnerID:            ctx.FormInt64("uid"),
+		PriorityOwnerID:    ctx.FormInt64("priority_owner_id"),
+		TeamID:             ctx.FormInt64("team_id"),
+		TopicOnly:          ctx.FormBool("topic"),
 		Collaborate:        util.OptionalBoolNone,
-		Private:            ctx.IsSigned && (ctx.Query("private") == "" || ctx.QueryBool("private")),
+		Private:            ctx.IsSigned && (ctx.Form("private") == "" || ctx.FormBool("private")),
 		Template:           util.OptionalBoolNone,
-		StarredByID:        ctx.QueryInt64("starredBy"),
-		IncludeDescription: ctx.QueryBool("includeDesc"),
+		StarredByID:        ctx.FormInt64("starredBy"),
+		IncludeDescription: ctx.FormBool("includeDesc"),
 	}
 
-	if ctx.Query("template") != "" {
-		opts.Template = util.OptionalBoolOf(ctx.QueryBool("template"))
+	if ctx.Form("template") != "" {
+		opts.Template = util.OptionalBoolOf(ctx.FormBool("template"))
 	}
 
-	if ctx.QueryBool("exclusive") {
+	if ctx.FormBool("exclusive") {
 		opts.Collaborate = util.OptionalBoolFalse
 	}
 
-	var mode = ctx.Query("mode")
+	var mode = ctx.Form("mode")
 	switch mode {
 	case "source":
 		opts.Fork = util.OptionalBoolFalse
@@ -173,17 +173,17 @@ func Search(ctx *context.APIContext) {
 		return
 	}
 
-	if ctx.Query("archived") != "" {
-		opts.Archived = util.OptionalBoolOf(ctx.QueryBool("archived"))
+	if ctx.Form("archived") != "" {
+		opts.Archived = util.OptionalBoolOf(ctx.FormBool("archived"))
 	}
 
-	if ctx.Query("is_private") != "" {
-		opts.IsPrivate = util.OptionalBoolOf(ctx.QueryBool("is_private"))
+	if ctx.Form("is_private") != "" {
+		opts.IsPrivate = util.OptionalBoolOf(ctx.FormBool("is_private"))
 	}
 
-	var sortMode = ctx.Query("sort")
+	var sortMode = ctx.Form("sort")
 	if len(sortMode) > 0 {
-		var sortOrder = ctx.Query("order")
+		var sortOrder = ctx.Form("order")
 		if len(sortOrder) == 0 {
 			sortOrder = "asc"
 		}

--- a/routers/api/v1/repo/status.go
+++ b/routers/api/v1/repo/status.go
@@ -190,11 +190,11 @@ func getCommitStatuses(ctx *context.APIContext, sha string) {
 
 	statuses, maxResults, err := models.GetCommitStatuses(repo, sha, &models.CommitStatusOptions{
 		ListOptions: listOptions,
-		SortType:    ctx.QueryTrim("sort"),
-		State:       ctx.QueryTrim("state"),
+		SortType:    ctx.FormTrim("sort"),
+		State:       ctx.FormTrim("state"),
 	})
 	if err != nil {
-		ctx.Error(http.StatusInternalServerError, "GetCommitStatuses", fmt.Errorf("GetCommitStatuses[%s, %s, %d]: %v", repo.FullName(), sha, ctx.QueryInt("page"), err))
+		ctx.Error(http.StatusInternalServerError, "GetCommitStatuses", fmt.Errorf("GetCommitStatuses[%s, %s, %d]: %v", repo.FullName(), sha, ctx.FormInt("page"), err))
 		return
 	}
 

--- a/routers/api/v1/repo/topic.go
+++ b/routers/api/v1/repo/topic.go
@@ -274,7 +274,7 @@ func TopicSearch(ctx *context.APIContext) {
 		return
 	}
 
-	kw := ctx.Query("q")
+	kw := ctx.Form("q")
 
 	listOptions := utils.GetListOptions(ctx)
 

--- a/routers/api/v1/repo/tree.go
+++ b/routers/api/v1/repo/tree.go
@@ -60,7 +60,7 @@ func GetTree(ctx *context.APIContext) {
 		ctx.Error(http.StatusBadRequest, "", "sha not provided")
 		return
 	}
-	if tree, err := repofiles.GetTreeBySHA(ctx.Repo.Repository, sha, ctx.QueryInt("page"), ctx.QueryInt("per_page"), ctx.QueryBool("recursive")); err != nil {
+	if tree, err := repofiles.GetTreeBySHA(ctx.Repo.Repository, sha, ctx.FormInt("page"), ctx.FormInt("per_page"), ctx.FormBool("recursive")); err != nil {
 		ctx.Error(http.StatusBadRequest, "", err.Error())
 	} else {
 		ctx.JSON(http.StatusOK, tree)

--- a/routers/api/v1/user/key.go
+++ b/routers/api/v1/user/key.go
@@ -48,7 +48,7 @@ func listPublicKeys(ctx *context.APIContext, user *models.User) {
 	var keys []*models.PublicKey
 	var err error
 
-	fingerprint := ctx.Query("fingerprint")
+	fingerprint := ctx.Form("fingerprint")
 	username := ctx.Params("username")
 
 	if fingerprint != "" {

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -58,8 +58,8 @@ func Search(ctx *context.APIContext) {
 
 	opts := &models.SearchUserOptions{
 		Actor:       ctx.User,
-		Keyword:     strings.Trim(ctx.Query("q"), " "),
-		UID:         ctx.QueryInt64("uid"),
+		Keyword:     strings.Trim(ctx.Form("q"), " "),
+		UID:         ctx.FormInt64("uid"),
 		Type:        models.UserTypeIndividual,
 		ListOptions: listOptions,
 	}

--- a/routers/api/v1/utils/utils.go
+++ b/routers/api/v1/utils/utils.go
@@ -54,7 +54,7 @@ func parseTime(value string) (int64, error) {
 
 // prepareQueryArg unescape and trim a query arg
 func prepareQueryArg(ctx *context.APIContext, name string) (value string, err error) {
-	value, err = url.PathUnescape(ctx.Query(name))
+	value, err = url.PathUnescape(ctx.Form(name))
 	value = strings.TrimSpace(value)
 	return
 }
@@ -62,7 +62,7 @@ func prepareQueryArg(ctx *context.APIContext, name string) (value string, err er
 // GetListOptions returns list options using the page and limit parameters
 func GetListOptions(ctx *context.APIContext) models.ListOptions {
 	return models.ListOptions{
-		Page:     ctx.QueryInt("page"),
-		PageSize: convert.ToCorrectPageSize(ctx.QueryInt("limit")),
+		Page:     ctx.FormInt("page"),
+		PageSize: convert.ToCorrectPageSize(ctx.FormInt("limit")),
 	}
 }

--- a/routers/common/repo.go
+++ b/routers/common/repo.go
@@ -69,7 +69,7 @@ func ServeData(ctx *context.Context, name string, size int64, reader io.Reader) 
 		fileExtension := strings.ToLower(filepath.Ext(name))
 		mappedMimeType = setting.MimeTypeMap.Map[fileExtension]
 	}
-	if st.IsText() || ctx.QueryBool("render") {
+	if st.IsText() || ctx.FormBool("render") {
 		cs, err := charset.DetectEncoding(buf)
 		if err != nil {
 			log.Error("Detect raw file %s charset failed: %v, using by default utf-8", name, err)

--- a/routers/private/key.go
+++ b/routers/private/key.go
@@ -50,7 +50,7 @@ func UpdatePublicKeyInRepo(ctx *context.PrivateContext) {
 // AuthorizedPublicKeyByContent searches content as prefix (leak e-mail part)
 // and returns public key found.
 func AuthorizedPublicKeyByContent(ctx *context.PrivateContext) {
-	content := ctx.Query("content")
+	content := ctx.Form("content")
 
 	publicKey, err := models.SearchPublicKeyByContent(content)
 	if err != nil {

--- a/routers/private/serv.go
+++ b/routers/private/serv.go
@@ -76,7 +76,7 @@ func ServCommand(ctx *context.PrivateContext) {
 	keyID := ctx.ParamsInt64(":keyid")
 	ownerName := ctx.Params(":owner")
 	repoName := ctx.Params(":repo")
-	mode := models.AccessMode(ctx.QueryInt("mode"))
+	mode := models.AccessMode(ctx.FormInt("mode"))
 
 	// Set the basic parts of the results to return
 	results := private.ServCommandResults{
@@ -126,7 +126,7 @@ func ServCommand(ctx *context.PrivateContext) {
 	if err != nil {
 		if models.IsErrRepoNotExist(err) {
 			repoExist = false
-			for _, verb := range ctx.QueryStrings("verb") {
+			for _, verb := range ctx.FormStrings("verb") {
 				if "git-upload-pack" == verb {
 					// User is fetching/cloning a non-existent repository
 					log.Error("Failed authentication attempt (cannot find repository: %s/%s) from %s", results.OwnerName, results.RepoName, ctx.RemoteAddr())

--- a/routers/web/admin/admin.go
+++ b/routers/web/admin/admin.go
@@ -161,7 +161,7 @@ func DashboardPost(ctx *context.Context) {
 
 // SendTestMail send test mail to confirm mail service is OK
 func SendTestMail(ctx *context.Context) {
-	email := ctx.Query("email")
+	email := ctx.Form("email")
 	// Send a test email to the user's email address and redirect back to Config
 	if err := mailer.SendTestMail(email); err != nil {
 		ctx.Flash.Error(ctx.Tr("admin.config.test_mail_failed", email, err))
@@ -377,7 +377,7 @@ func Flush(ctx *context.Context) {
 		ctx.Status(404)
 		return
 	}
-	timeout, err := time.ParseDuration(ctx.Query("timeout"))
+	timeout, err := time.ParseDuration(ctx.Form("timeout"))
 	if err != nil {
 		timeout = -1
 	}
@@ -399,13 +399,13 @@ func AddWorkers(ctx *context.Context) {
 		ctx.Status(404)
 		return
 	}
-	number := ctx.QueryInt("number")
+	number := ctx.FormInt("number")
 	if number < 1 {
 		ctx.Flash.Error(ctx.Tr("admin.monitor.queue.pool.addworkers.mustnumbergreaterzero"))
 		ctx.Redirect(setting.AppSubURL + "/admin/monitor/queue/" + strconv.FormatInt(qid, 10))
 		return
 	}
-	timeout, err := time.ParseDuration(ctx.Query("timeout"))
+	timeout, err := time.ParseDuration(ctx.Form("timeout"))
 	if err != nil {
 		ctx.Flash.Error(ctx.Tr("admin.monitor.queue.pool.addworkers.musttimeoutduration"))
 		ctx.Redirect(setting.AppSubURL + "/admin/monitor/queue/" + strconv.FormatInt(qid, 10))
@@ -435,9 +435,9 @@ func SetQueueSettings(ctx *context.Context) {
 		return
 	}
 
-	maxNumberStr := ctx.Query("max-number")
-	numberStr := ctx.Query("number")
-	timeoutStr := ctx.Query("timeout")
+	maxNumberStr := ctx.Form("max-number")
+	numberStr := ctx.Form("number")
+	timeoutStr := ctx.Form("timeout")
 
 	var err error
 	var maxNumber, number int

--- a/routers/web/admin/emails.go
+++ b/routers/web/admin/emails.go
@@ -30,7 +30,7 @@ func Emails(ctx *context.Context) {
 	opts := &models.SearchEmailOptions{
 		ListOptions: models.ListOptions{
 			PageSize: setting.UI.Admin.UserPagingNum,
-			Page:     ctx.QueryInt("page"),
+			Page:     ctx.FormInt("page"),
 		},
 	}
 
@@ -51,8 +51,8 @@ func Emails(ctx *context.Context) {
 		orderBy    models.SearchEmailOrderBy
 	)
 
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
+	ctx.Data["SortType"] = ctx.Form("sort")
+	switch ctx.Form("sort") {
 	case "email":
 		orderBy = models.SearchEmailOrderByEmail
 	case "reverseemail":
@@ -66,13 +66,13 @@ func Emails(ctx *context.Context) {
 		orderBy = models.SearchEmailOrderByEmail
 	}
 
-	opts.Keyword = ctx.QueryTrim("q")
+	opts.Keyword = ctx.FormTrim("q")
 	opts.SortType = orderBy
-	if len(ctx.Query("is_activated")) != 0 {
-		opts.IsActivated = util.OptionalBoolOf(ctx.QueryBool("activated"))
+	if len(ctx.Form("is_activated")) != 0 {
+		opts.IsActivated = util.OptionalBoolOf(ctx.FormBool("activated"))
 	}
-	if len(ctx.Query("is_primary")) != 0 {
-		opts.IsPrimary = util.OptionalBoolOf(ctx.QueryBool("primary"))
+	if len(ctx.Form("is_primary")) != 0 {
+		opts.IsPrimary = util.OptionalBoolOf(ctx.FormBool("primary"))
 	}
 
 	if len(opts.Keyword) == 0 || isKeywordValid(opts.Keyword) {
@@ -113,10 +113,10 @@ func ActivateEmail(ctx *context.Context) {
 
 	truefalse := map[string]bool{"1": true, "0": false}
 
-	uid := ctx.QueryInt64("uid")
-	email := ctx.Query("email")
-	primary, okp := truefalse[ctx.Query("primary")]
-	activate, oka := truefalse[ctx.Query("activate")]
+	uid := ctx.FormInt64("uid")
+	email := ctx.Form("email")
+	primary, okp := truefalse[ctx.Form("primary")]
+	activate, oka := truefalse[ctx.Form("activate")]
 
 	if uid == 0 || len(email) == 0 || !okp || !oka {
 		ctx.Error(http.StatusBadRequest)
@@ -139,16 +139,16 @@ func ActivateEmail(ctx *context.Context) {
 
 	redirect, _ := url.Parse(setting.AppSubURL + "/admin/emails")
 	q := url.Values{}
-	if val := ctx.QueryTrim("q"); len(val) > 0 {
+	if val := ctx.FormTrim("q"); len(val) > 0 {
 		q.Set("q", val)
 	}
-	if val := ctx.QueryTrim("sort"); len(val) > 0 {
+	if val := ctx.FormTrim("sort"); len(val) > 0 {
 		q.Set("sort", val)
 	}
-	if val := ctx.QueryTrim("is_primary"); len(val) > 0 {
+	if val := ctx.FormTrim("is_primary"); len(val) > 0 {
 		q.Set("is_primary", val)
 	}
-	if val := ctx.QueryTrim("is_activated"); len(val) > 0 {
+	if val := ctx.FormTrim("is_activated"); len(val) > 0 {
 		q.Set("is_activated", val)
 	}
 	redirect.RawQuery = q.Encode()

--- a/routers/web/admin/hooks.go
+++ b/routers/web/admin/hooks.go
@@ -60,7 +60,7 @@ func DefaultOrSystemWebhooks(ctx *context.Context) {
 
 // DeleteDefaultOrSystemWebhook handler to delete an admin-defined system or default webhook
 func DeleteDefaultOrSystemWebhook(ctx *context.Context) {
-	if err := models.DeleteDefaultSystemWebhook(ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteDefaultSystemWebhook(ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteDefaultWebhook: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.webhook_deletion_success"))

--- a/routers/web/admin/notice.go
+++ b/routers/web/admin/notice.go
@@ -27,7 +27,7 @@ func Notices(ctx *context.Context) {
 	ctx.Data["PageIsAdminNotices"] = true
 
 	total := models.CountNotices()
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -48,7 +48,7 @@ func Notices(ctx *context.Context) {
 
 // DeleteNotices delete the specific notices
 func DeleteNotices(ctx *context.Context) {
-	strs := ctx.QueryStrings("ids[]")
+	strs := ctx.FormStrings("ids[]")
 	ids := make([]int64, 0, len(strs))
 	for i := range strs {
 		id, _ := strconv.ParseInt(strs[i], 10, 64)

--- a/routers/web/admin/repos.go
+++ b/routers/web/admin/repos.go
@@ -41,7 +41,7 @@ func Repos(ctx *context.Context) {
 
 // DeleteRepo delete one repository
 func DeleteRepo(ctx *context.Context) {
-	repo, err := models.GetRepositoryByID(ctx.QueryInt64("id"))
+	repo, err := models.GetRepositoryByID(ctx.FormInt64("id"))
 	if err != nil {
 		ctx.ServerError("GetRepositoryByID", err)
 		return
@@ -59,7 +59,7 @@ func DeleteRepo(ctx *context.Context) {
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.deletion_success"))
 	ctx.JSON(http.StatusOK, map[string]interface{}{
-		"redirect": setting.AppSubURL + "/admin/repos?page=" + ctx.Query("page") + "&sort=" + ctx.Query("sort"),
+		"redirect": setting.AppSubURL + "/admin/repos?page=" + ctx.Form("page") + "&sort=" + ctx.Form("sort"),
 	})
 }
 
@@ -71,7 +71,7 @@ func UnadoptedRepos(ctx *context.Context) {
 
 	opts := models.ListOptions{
 		PageSize: setting.UI.Admin.UserPagingNum,
-		Page:     ctx.QueryInt("page"),
+		Page:     ctx.FormInt("page"),
 	}
 
 	if opts.Page <= 0 {
@@ -80,10 +80,10 @@ func UnadoptedRepos(ctx *context.Context) {
 
 	ctx.Data["CurrentPage"] = opts.Page
 
-	doSearch := ctx.QueryBool("search")
+	doSearch := ctx.FormBool("search")
 
 	ctx.Data["search"] = doSearch
-	q := ctx.Query("q")
+	q := ctx.Form("q")
 
 	if !doSearch {
 		pager := context.NewPagination(0, opts.PageSize, opts.Page, 5)
@@ -109,10 +109,10 @@ func UnadoptedRepos(ctx *context.Context) {
 
 // AdoptOrDeleteRepository adopts or deletes a repository
 func AdoptOrDeleteRepository(ctx *context.Context) {
-	dir := ctx.Query("id")
-	action := ctx.Query("action")
-	page := ctx.QueryInt("page")
-	q := ctx.Query("q")
+	dir := ctx.Form("id")
+	action := ctx.Form("action")
+	page := ctx.FormInt("page")
+	q := ctx.Form("q")
 
 	dirSplit := strings.SplitN(dir, "/", 2)
 	if len(dirSplit) != 2 {

--- a/routers/web/explore/code.go
+++ b/routers/web/explore/code.go
@@ -33,14 +33,14 @@ func Code(ctx *context.Context) {
 	ctx.Data["PageIsExplore"] = true
 	ctx.Data["PageIsExploreCode"] = true
 
-	language := strings.TrimSpace(ctx.Query("l"))
-	keyword := strings.TrimSpace(ctx.Query("q"))
-	page := ctx.QueryInt("page")
+	language := strings.TrimSpace(ctx.Form("l"))
+	keyword := strings.TrimSpace(ctx.Form("q"))
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}
 
-	queryType := strings.TrimSpace(ctx.Query("t"))
+	queryType := strings.TrimSpace(ctx.Form("t"))
 	isMatch := queryType == "match"
 
 	var (

--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -30,7 +30,7 @@ type RepoSearchOptions struct {
 
 // RenderRepoSearch render repositories search page
 func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}
@@ -42,8 +42,8 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		orderBy models.SearchOrderBy
 	)
 
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
+	ctx.Data["SortType"] = ctx.Form("sort")
+	switch ctx.Form("sort") {
 	case "newest":
 		orderBy = models.SearchOrderByNewest
 	case "oldest":
@@ -73,8 +73,8 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		orderBy = models.SearchOrderByRecentUpdated
 	}
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
-	topicOnly := ctx.QueryBool("topic")
+	keyword := strings.Trim(ctx.Form("q"), " ")
+	topicOnly := ctx.FormBool("topic")
 	ctx.Data["TopicOnly"] = topicOnly
 
 	repos, count, err = models.SearchRepository(&models.SearchRepoOptions{

--- a/routers/web/explore/user.go
+++ b/routers/web/explore/user.go
@@ -32,7 +32,7 @@ func isKeywordValid(keyword string) bool {
 
 // RenderUserSearch render user search page
 func RenderUserSearch(ctx *context.Context, opts *models.SearchUserOptions, tplName base.TplName) {
-	opts.Page = ctx.QueryInt("page")
+	opts.Page = ctx.FormInt("page")
 	if opts.Page <= 1 {
 		opts.Page = 1
 	}
@@ -44,8 +44,8 @@ func RenderUserSearch(ctx *context.Context, opts *models.SearchUserOptions, tplN
 		orderBy models.SearchOrderBy
 	)
 
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
+	ctx.Data["SortType"] = ctx.Form("sort")
+	switch ctx.Form("sort") {
 	case "newest":
 		orderBy = models.SearchOrderByIDReverse
 	case "oldest":
@@ -63,7 +63,7 @@ func RenderUserSearch(ctx *context.Context, opts *models.SearchUserOptions, tplN
 		orderBy = models.SearchOrderByAlphabetically
 	}
 
-	opts.Keyword = strings.Trim(ctx.Query("q"), " ")
+	opts.Keyword = strings.Trim(ctx.Form("q"), " ")
 	opts.OrderBy = orderBy
 	if len(opts.Keyword) == 0 || isKeywordValid(opts.Keyword) {
 		users, count, err = models.SearchUsers(opts)

--- a/routers/web/goget.go
+++ b/routers/web/goget.go
@@ -18,7 +18,7 @@ import (
 )
 
 func goGet(ctx *context.Context) {
-	if ctx.Req.Method != "GET" || ctx.Query("go-get") != "1" || len(ctx.Req.URL.Query()) > 1 {
+	if ctx.Req.Method != "GET" || ctx.Form("go-get") != "1" || len(ctx.Req.URL.Query()) > 1 {
 		return
 	}
 

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -51,8 +51,8 @@ func Home(ctx *context.Context) {
 	}
 
 	var orderBy models.SearchOrderBy
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
+	ctx.Data["SortType"] = ctx.Form("sort")
+	switch ctx.Form("sort") {
 	case "newest":
 		orderBy = models.SearchOrderByNewest
 	case "oldest":
@@ -78,10 +78,10 @@ func Home(ctx *context.Context) {
 		orderBy = models.SearchOrderByRecentUpdated
 	}
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	ctx.Data["Keyword"] = keyword
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}

--- a/routers/web/org/members.go
+++ b/routers/web/org/members.go
@@ -26,7 +26,7 @@ func Members(ctx *context.Context) {
 	ctx.Data["Title"] = org.FullName
 	ctx.Data["PageIsOrgMembers"] = true
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -70,7 +70,7 @@ func Members(ctx *context.Context) {
 
 // MembersAction response for operation to a member of organization
 func MembersAction(ctx *context.Context) {
-	uid := ctx.QueryInt64("uid")
+	uid := ctx.FormInt64("uid")
 	if uid == 0 {
 		ctx.Redirect(ctx.Org.OrgLink + "/members")
 		return

--- a/routers/web/org/org_labels.go
+++ b/routers/web/org/org_labels.go
@@ -15,7 +15,7 @@ import (
 
 // RetrieveLabels find all the labels of an organization
 func RetrieveLabels(ctx *context.Context) {
-	labels, err := models.GetLabelsByOrgID(ctx.Org.Organization.ID, ctx.Query("sort"), models.ListOptions{})
+	labels, err := models.GetLabelsByOrgID(ctx.Org.Organization.ID, ctx.Form("sort"), models.ListOptions{})
 	if err != nil {
 		ctx.ServerError("RetrieveLabels.GetLabels", err)
 		return
@@ -25,7 +25,7 @@ func RetrieveLabels(ctx *context.Context) {
 	}
 	ctx.Data["Labels"] = labels
 	ctx.Data["NumLabels"] = len(labels)
-	ctx.Data["SortType"] = ctx.Query("sort")
+	ctx.Data["SortType"] = ctx.Form("sort")
 }
 
 // NewLabel create new label for organization
@@ -79,7 +79,7 @@ func UpdateLabel(ctx *context.Context) {
 
 // DeleteLabel delete a label
 func DeleteLabel(ctx *context.Context) {
-	if err := models.DeleteLabel(ctx.Org.Organization.ID, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteLabel(ctx.Org.Organization.ID, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteLabel: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.issues.label_deletion_success"))

--- a/routers/web/org/setting.go
+++ b/routers/web/org/setting.go
@@ -155,7 +155,7 @@ func SettingsDelete(ctx *context.Context) {
 
 	org := ctx.Org.Organization
 	if ctx.Req.Method == "POST" {
-		if org.Name != ctx.Query("org_name") {
+		if org.Name != ctx.Form("org_name") {
 			ctx.Data["Err_OrgName"] = true
 			ctx.RenderWithErr(ctx.Tr("form.enterred_invalid_org_name"), tplSettingsDelete, nil)
 			return
@@ -198,7 +198,7 @@ func Webhooks(ctx *context.Context) {
 
 // DeleteWebhook response for delete webhook
 func DeleteWebhook(ctx *context.Context) {
-	if err := models.DeleteWebhookByOrgID(ctx.Org.Organization.ID, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteWebhookByOrgID(ctx.Org.Organization.ID, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteWebhookByOrgID: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.webhook_deletion_success"))

--- a/routers/web/org/teams.go
+++ b/routers/web/org/teams.go
@@ -49,13 +49,13 @@ func Teams(ctx *context.Context) {
 
 // TeamsAction response for join, leave, remove, add operations to team
 func TeamsAction(ctx *context.Context) {
-	uid := ctx.QueryInt64("uid")
+	uid := ctx.FormInt64("uid")
 	if uid == 0 {
 		ctx.Redirect(ctx.Org.OrgLink + "/teams")
 		return
 	}
 
-	page := ctx.Query("page")
+	page := ctx.Form("page")
 	var err error
 	switch ctx.Params(":action") {
 	case "join":
@@ -78,7 +78,7 @@ func TeamsAction(ctx *context.Context) {
 			ctx.Error(http.StatusNotFound)
 			return
 		}
-		uname := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Query("uname")))
+		uname := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Form("uname")))
 		var u *models.User
 		u, err = models.GetUserByName(uname)
 		if err != nil {
@@ -140,7 +140,7 @@ func TeamsRepoAction(ctx *context.Context) {
 	action := ctx.Params(":action")
 	switch action {
 	case "add":
-		repoName := path.Base(ctx.Query("repo_name"))
+		repoName := path.Base(ctx.Form("repo_name"))
 		var repo *models.Repository
 		repo, err = models.GetRepositoryByName(ctx.Org.Organization.ID, repoName)
 		if err != nil {
@@ -154,7 +154,7 @@ func TeamsRepoAction(ctx *context.Context) {
 		}
 		err = ctx.Org.Team.AddRepository(repo)
 	case "remove":
-		err = ctx.Org.Team.RemoveRepository(ctx.QueryInt64("repoid"))
+		err = ctx.Org.Team.RemoveRepository(ctx.FormInt64("repoid"))
 	case "addall":
 		err = ctx.Org.Team.AddAllRepositories()
 	case "removeall":

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -71,7 +71,7 @@ func uploadAttachment(ctx *context.Context, allowedTypes string) {
 
 // DeleteAttachment response for deleting issue's attachment
 func DeleteAttachment(ctx *context.Context) {
-	file := ctx.Query("file")
+	file := ctx.Form("file")
 	attach, err := models.GetAttachmentByUUID(file)
 	if err != nil {
 		ctx.Error(http.StatusBadRequest, err.Error())

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -57,12 +57,12 @@ func Branches(ctx *context.Context) {
 	ctx.Data["PageIsViewCode"] = true
 	ctx.Data["PageIsBranches"] = true
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
 
-	limit := ctx.QueryInt("limit")
+	limit := ctx.FormInt("limit")
 	if limit <= 0 || limit > setting.Git.BranchesRangeSize {
 		limit = setting.Git.BranchesRangeSize
 	}
@@ -84,7 +84,7 @@ func Branches(ctx *context.Context) {
 // DeleteBranchPost responses for delete merged branch
 func DeleteBranchPost(ctx *context.Context) {
 	defer redirect(ctx)
-	branchName := ctx.Query("name")
+	branchName := ctx.Form("name")
 
 	if err := repo_service.DeleteBranch(ctx.User, ctx.Repo.Repository, ctx.Repo.GitRepo, branchName); err != nil {
 		switch {
@@ -112,8 +112,8 @@ func DeleteBranchPost(ctx *context.Context) {
 func RestoreBranchPost(ctx *context.Context) {
 	defer redirect(ctx)
 
-	branchID := ctx.QueryInt64("branch_id")
-	branchName := ctx.Query("name")
+	branchID := ctx.FormInt64("branch_id")
+	branchName := ctx.Form("name")
 
 	deletedBranch, err := ctx.Repo.Repository.GetDeletedBranchByID(branchID)
 	if err != nil {

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -56,12 +56,12 @@ func Commits(ctx *context.Context) {
 		return
 	}
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
 
-	pageSize := ctx.QueryInt("limit")
+	pageSize := ctx.FormInt("limit")
 	if pageSize <= 0 {
 		pageSize = setting.Git.CommitsRangeSize
 	}
@@ -94,14 +94,14 @@ func Graph(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.commit_graph")
 	ctx.Data["PageIsCommits"] = true
 	ctx.Data["PageIsViewCode"] = true
-	mode := strings.ToLower(ctx.QueryTrim("mode"))
+	mode := strings.ToLower(ctx.FormTrim("mode"))
 	if mode != "monochrome" {
 		mode = "color"
 	}
 	ctx.Data["Mode"] = mode
-	hidePRRefs := ctx.QueryBool("hide-pr-refs")
+	hidePRRefs := ctx.FormBool("hide-pr-refs")
 	ctx.Data["HidePRRefs"] = hidePRRefs
-	branches := ctx.QueryStrings("branch")
+	branches := ctx.FormStrings("branch")
 	realBranches := make([]string, len(branches))
 	copy(realBranches, branches)
 	for i, branch := range realBranches {
@@ -110,7 +110,7 @@ func Graph(ctx *context.Context) {
 		}
 	}
 	ctx.Data["SelectedBranches"] = realBranches
-	files := ctx.QueryStrings("file")
+	files := ctx.FormStrings("file")
 
 	commitsCount, err := ctx.Repo.GetCommitsCount()
 	if err != nil {
@@ -130,7 +130,7 @@ func Graph(ctx *context.Context) {
 		}
 	}
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 
 	graph, err := gitgraph.GetCommitGraph(ctx.Repo.GitRepo, page, 0, hidePRRefs, realBranches, files)
 	if err != nil {
@@ -167,7 +167,7 @@ func Graph(ctx *context.Context) {
 		paginator.AddParamString("file", file)
 	}
 	ctx.Data["Page"] = paginator
-	if ctx.QueryBool("div-only") {
+	if ctx.FormBool("div-only") {
 		ctx.HTML(http.StatusOK, tplGraphDiv)
 		return
 	}
@@ -180,13 +180,13 @@ func SearchCommits(ctx *context.Context) {
 	ctx.Data["PageIsCommits"] = true
 	ctx.Data["PageIsViewCode"] = true
 
-	query := strings.Trim(ctx.Query("q"), " ")
+	query := strings.Trim(ctx.Form("q"), " ")
 	if len(query) == 0 {
 		ctx.Redirect(ctx.Repo.RepoLink + "/commits/" + ctx.Repo.BranchNameSubURL())
 		return
 	}
 
-	all := ctx.QueryBool("all")
+	all := ctx.FormBool("all")
 	opts := git.NewSearchCommitsOptions(query, all)
 	commits, err := ctx.Repo.Commit.SearchCommits(opts)
 	if err != nil {
@@ -229,7 +229,7 @@ func FileHistory(ctx *context.Context) {
 		return
 	}
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -696,15 +696,15 @@ func CompareDiff(ctx *context.Context) {
 // ExcerptBlob render blob excerpt contents
 func ExcerptBlob(ctx *context.Context) {
 	commitID := ctx.Params("sha")
-	lastLeft := ctx.QueryInt("last_left")
-	lastRight := ctx.QueryInt("last_right")
-	idxLeft := ctx.QueryInt("left")
-	idxRight := ctx.QueryInt("right")
-	leftHunkSize := ctx.QueryInt("left_hunk_size")
-	rightHunkSize := ctx.QueryInt("right_hunk_size")
-	anchor := ctx.Query("anchor")
-	direction := ctx.Query("direction")
-	filePath := ctx.Query("path")
+	lastLeft := ctx.FormInt("last_left")
+	lastRight := ctx.FormInt("last_right")
+	idxLeft := ctx.FormInt("left")
+	idxRight := ctx.FormInt("right")
+	leftHunkSize := ctx.FormInt("left_hunk_size")
+	rightHunkSize := ctx.FormInt("right_hunk_size")
+	anchor := ctx.Form("anchor")
+	direction := ctx.Form("direction")
+	filePath := ctx.Form("path")
 	gitRepo := ctx.Repo.GitRepo
 	chunkSize := gitdiff.BlobExcerptChunkSize
 	commit, err := gitRepo.GetCommit(commitID)

--- a/routers/web/repo/http.go
+++ b/routers/web/repo/http.go
@@ -70,13 +70,13 @@ func httpBase(ctx *context.Context) (h *serviceHandler) {
 	username := ctx.Params(":username")
 	reponame := strings.TrimSuffix(ctx.Params(":reponame"), ".git")
 
-	if ctx.Query("go-get") == "1" {
+	if ctx.Form("go-get") == "1" {
 		context.EarlyResponseForGoGetMeta(ctx)
 		return
 	}
 
 	var isPull, receivePack bool
-	service := ctx.Query("service")
+	service := ctx.Form("service")
 	if service == "git-receive-pack" ||
 		strings.HasSuffix(ctx.Req.URL.Path, "git-receive-pack") {
 		isPull = false

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -110,15 +110,15 @@ func MustAllowPulls(ctx *context.Context) {
 
 func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption util.OptionalBool) {
 	var err error
-	viewType := ctx.Query("type")
-	sortType := ctx.Query("sort")
+	viewType := ctx.Form("type")
+	sortType := ctx.Form("sort")
 	types := []string{"all", "your_repositories", "assigned", "created_by", "mentioned", "review_requested"}
 	if !util.IsStringInSlice(viewType, types, true) {
 		viewType = "all"
 	}
 
 	var (
-		assigneeID        = ctx.QueryInt64("assignee")
+		assigneeID        = ctx.FormInt64("assignee")
 		posterID          int64
 		mentionedID       int64
 		reviewRequestedID int64
@@ -140,7 +140,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 
 	repo := ctx.Repo.Repository
 	var labelIDs []int64
-	selectLabels := ctx.Query("labels")
+	selectLabels := ctx.Form("labels")
 	if len(selectLabels) > 0 && selectLabels != "0" {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectLabels, ","))
 		if err != nil {
@@ -149,7 +149,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 		}
 	}
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	if bytes.Contains([]byte(keyword), []byte{0x00}) {
 		keyword = ""
 	}
@@ -187,13 +187,13 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 		}
 	}
 
-	isShowClosed := ctx.Query("state") == "closed"
+	isShowClosed := ctx.Form("state") == "closed"
 	// if open issues are zero and close don't, use closed as default
-	if len(ctx.Query("state")) == 0 && issueStats.OpenCount == 0 && issueStats.ClosedCount != 0 {
+	if len(ctx.Form("state")) == 0 && issueStats.OpenCount == 0 && issueStats.ClosedCount != 0 {
 		isShowClosed = true
 	}
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -285,7 +285,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 	}
 
 	if repo.Owner.IsOrganization() {
-		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Query("sort"), models.ListOptions{})
+		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Form("sort"), models.ListOptions{})
 		if err != nil {
 			ctx.ServerError("GetLabelsByOrgID", err)
 			return
@@ -301,7 +301,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 	ctx.Data["Labels"] = labels
 	ctx.Data["NumLabels"] = len(labels)
 
-	if ctx.QueryInt64("assignee") == 0 {
+	if ctx.FormInt64("assignee") == 0 {
 		assigneeID = 0 // Reset ID to prevent unexpected selection of assignee.
 	}
 
@@ -371,7 +371,7 @@ func Issues(ctx *context.Context) {
 		ctx.Data["NewIssueChooseTemplate"] = len(ctx.IssueTemplatesFromDefaultBranch()) > 0
 	}
 
-	issues(ctx, ctx.QueryInt64("milestone"), ctx.QueryInt64("project"), util.OptionalBoolOf(isPullList))
+	issues(ctx, ctx.FormInt64("milestone"), ctx.FormInt64("project"), util.OptionalBoolOf(isPullList))
 	if ctx.Written() {
 		return
 	}
@@ -380,7 +380,7 @@ func Issues(ctx *context.Context) {
 	// Get milestones
 	ctx.Data["Milestones"], err = models.GetMilestones(models.GetMilestonesOption{
 		RepoID: ctx.Repo.Repository.ID,
-		State:  api.StateType(ctx.Query("state")),
+		State:  api.StateType(ctx.Form("state")),
 	})
 	if err != nil {
 		ctx.ServerError("GetAllRepoMilestones", err)
@@ -655,7 +655,7 @@ func RetrieveRepoMetas(ctx *context.Context, repo *models.Repository, isPull boo
 	}
 	ctx.Data["Labels"] = labels
 	if repo.Owner.IsOrganization() {
-		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Query("sort"), models.ListOptions{})
+		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Form("sort"), models.ListOptions{})
 		if err != nil {
 			return nil
 		}
@@ -719,9 +719,9 @@ func getFileContentFromDefaultBranch(ctx *context.Context, filename string) (str
 
 func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleDirs []string, possibleFiles []string) {
 	templateCandidates := make([]string, 0, len(possibleFiles))
-	if ctx.Query("template") != "" {
+	if ctx.Form("template") != "" {
 		for _, dirName := range possibleDirs {
-			templateCandidates = append(templateCandidates, path.Join(dirName, ctx.Query("template")))
+			templateCandidates = append(templateCandidates, path.Join(dirName, ctx.Form("template")))
 		}
 	}
 	templateCandidates = append(templateCandidates, possibleFiles...) // Append files to the end because they should be fallback
@@ -741,7 +741,7 @@ func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleDirs [
 			if repoLabels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, "", models.ListOptions{}); err == nil {
 				ctx.Data["Labels"] = repoLabels
 				if ctx.Repo.Owner.IsOrganization() {
-					if orgLabels, err := models.GetLabelsByOrgID(ctx.Repo.Owner.ID, ctx.Query("sort"), models.ListOptions{}); err == nil {
+					if orgLabels, err := models.GetLabelsByOrgID(ctx.Repo.Owner.ID, ctx.Form("sort"), models.ListOptions{}); err == nil {
 						ctx.Data["OrgLabels"] = orgLabels
 						repoLabels = append(repoLabels, orgLabels...)
 					}
@@ -773,16 +773,16 @@ func NewIssue(ctx *context.Context) {
 	ctx.Data["RequireSimpleMDE"] = true
 	ctx.Data["RequireTribute"] = true
 	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
-	title := ctx.Query("title")
+	title := ctx.Form("title")
 	ctx.Data["TitleQuery"] = title
-	body := ctx.Query("body")
+	body := ctx.Form("body")
 	ctx.Data["BodyQuery"] = body
 
 	ctx.Data["IsProjectsEnabled"] = ctx.Repo.CanRead(models.UnitTypeProjects)
 	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
 	upload.AddUploadContext(ctx, "comment")
 
-	milestoneID := ctx.QueryInt64("milestone")
+	milestoneID := ctx.FormInt64("milestone")
 	if milestoneID > 0 {
 		milestone, err := models.GetMilestoneByID(milestoneID)
 		if err != nil {
@@ -793,7 +793,7 @@ func NewIssue(ctx *context.Context) {
 		}
 	}
 
-	projectID := ctx.QueryInt64("project")
+	projectID := ctx.FormInt64("project")
 	if projectID > 0 {
 		project, err := models.GetProjectByID(projectID)
 		if err != nil {
@@ -822,7 +822,7 @@ func NewIssue(ctx *context.Context) {
 func NewIssueChooseTemplate(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.issues.new")
 	ctx.Data["PageIsIssueList"] = true
-	ctx.Data["milestone"] = ctx.QueryInt64("milestone")
+	ctx.Data["milestone"] = ctx.FormInt64("milestone")
 
 	issueTemplates := ctx.IssueTemplatesFromDefaultBranch()
 	ctx.Data["NewIssueChooseTemplate"] = len(issueTemplates) > 0
@@ -1174,7 +1174,7 @@ func ViewIssue(ctx *context.Context) {
 	ctx.Data["Labels"] = labels
 
 	if repo.Owner.IsOrganization() {
-		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Query("sort"), models.ListOptions{})
+		orgLabels, err := models.GetLabelsByOrgID(repo.Owner.ID, ctx.Form("sort"), models.ListOptions{})
 		if err != nil {
 			ctx.ServerError("GetLabelsByOrgID", err)
 			return
@@ -1624,7 +1624,7 @@ func checkIssueRights(ctx *context.Context, issue *models.Issue) {
 }
 
 func getActionIssues(ctx *context.Context) []*models.Issue {
-	commaSeparatedIssueIDs := ctx.Query("issue_ids")
+	commaSeparatedIssueIDs := ctx.Form("issue_ids")
 	if len(commaSeparatedIssueIDs) == 0 {
 		return nil
 	}
@@ -1670,7 +1670,7 @@ func UpdateIssueTitle(ctx *context.Context) {
 		return
 	}
 
-	title := ctx.QueryTrim("title")
+	title := ctx.FormTrim("title")
 	if len(title) == 0 {
 		ctx.Error(http.StatusNoContent)
 		return
@@ -1698,7 +1698,7 @@ func UpdateIssueRef(ctx *context.Context) {
 		return
 	}
 
-	ref := ctx.QueryTrim("ref")
+	ref := ctx.FormTrim("ref")
 
 	if err := issue_service.ChangeIssueRef(issue, ctx.User, ref); err != nil {
 		ctx.ServerError("ChangeRef", err)
@@ -1722,20 +1722,20 @@ func UpdateIssueContent(ctx *context.Context) {
 		return
 	}
 
-	content := ctx.Query("content")
+	content := ctx.Form("content")
 	if err := issue_service.ChangeContent(issue, ctx.User, content); err != nil {
 		ctx.ServerError("ChangeContent", err)
 		return
 	}
 
-	files := ctx.QueryStrings("files[]")
+	files := ctx.FormStrings("files[]")
 	if err := updateAttachments(issue, files); err != nil {
 		ctx.ServerError("UpdateAttachments", err)
 		return
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{
-		URLPrefix: ctx.Query("context"),
+		URLPrefix: ctx.Form("context"),
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
 	}, issue.Content)
@@ -1757,7 +1757,7 @@ func UpdateIssueMilestone(ctx *context.Context) {
 		return
 	}
 
-	milestoneID := ctx.QueryInt64("id")
+	milestoneID := ctx.FormInt64("id")
 	for _, issue := range issues {
 		oldMilestoneID := issue.MilestoneID
 		if oldMilestoneID == milestoneID {
@@ -1782,8 +1782,8 @@ func UpdateIssueAssignee(ctx *context.Context) {
 		return
 	}
 
-	assigneeID := ctx.QueryInt64("id")
-	action := ctx.Query("action")
+	assigneeID := ctx.FormInt64("id")
+	action := ctx.Form("action")
 
 	for _, issue := range issues {
 		switch action {
@@ -1828,8 +1828,8 @@ func UpdatePullReviewRequest(ctx *context.Context) {
 		return
 	}
 
-	reviewID := ctx.QueryInt64("id")
-	action := ctx.Query("action")
+	reviewID := ctx.FormInt64("id")
+	action := ctx.Form("action")
 
 	// TODO: Not support 'clear' now
 	if action != "attach" && action != "detach" {
@@ -1954,7 +1954,7 @@ func UpdateIssueStatus(ctx *context.Context) {
 	}
 
 	var isClosed bool
-	switch action := ctx.Query("action"); action {
+	switch action := ctx.Form("action"); action {
 	case "open":
 		isClosed = false
 	case "close":
@@ -2144,7 +2144,7 @@ func UpdateCommentContent(ctx *context.Context) {
 	}
 
 	oldContent := comment.Content
-	comment.Content = ctx.Query("content")
+	comment.Content = ctx.Form("content")
 	if len(comment.Content) == 0 {
 		ctx.JSON(http.StatusOK, map[string]interface{}{
 			"content": "",
@@ -2156,14 +2156,14 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	files := ctx.QueryStrings("files[]")
+	files := ctx.FormStrings("files[]")
 	if err := updateAttachments(comment, files); err != nil {
 		ctx.ServerError("UpdateAttachments", err)
 		return
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{
-		URLPrefix: ctx.Query("context"),
+		URLPrefix: ctx.Form("context"),
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
 	}, comment.Content)

--- a/routers/web/repo/issue_dependency.go
+++ b/routers/web/repo/issue_dependency.go
@@ -27,7 +27,7 @@ func AddDependency(ctx *context.Context) {
 		return
 	}
 
-	depID := ctx.QueryInt64("newDependency")
+	depID := ctx.FormInt64("newDependency")
 
 	if err = issue.LoadRepo(); err != nil {
 		ctx.ServerError("LoadRepo", err)
@@ -86,7 +86,7 @@ func RemoveDependency(ctx *context.Context) {
 		return
 	}
 
-	depID := ctx.QueryInt64("removeDependencyID")
+	depID := ctx.FormInt64("removeDependencyID")
 
 	if err = issue.LoadRepo(); err != nil {
 		ctx.ServerError("LoadRepo", err)

--- a/routers/web/repo/issue_label.go
+++ b/routers/web/repo/issue_label.go
@@ -53,7 +53,7 @@ func InitializeLabels(ctx *context.Context) {
 
 // RetrieveLabels find all the labels of a repository and organization
 func RetrieveLabels(ctx *context.Context) {
-	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Query("sort"), models.ListOptions{})
+	labels, err := models.GetLabelsByRepoID(ctx.Repo.Repository.ID, ctx.Form("sort"), models.ListOptions{})
 	if err != nil {
 		ctx.ServerError("RetrieveLabels.GetLabels", err)
 		return
@@ -66,7 +66,7 @@ func RetrieveLabels(ctx *context.Context) {
 	ctx.Data["Labels"] = labels
 
 	if ctx.Repo.Owner.IsOrganization() {
-		orgLabels, err := models.GetLabelsByOrgID(ctx.Repo.Owner.ID, ctx.Query("sort"), models.ListOptions{})
+		orgLabels, err := models.GetLabelsByOrgID(ctx.Repo.Owner.ID, ctx.Form("sort"), models.ListOptions{})
 		if err != nil {
 			ctx.ServerError("GetLabelsByOrgID", err)
 			return
@@ -93,7 +93,7 @@ func RetrieveLabels(ctx *context.Context) {
 		}
 	}
 	ctx.Data["NumLabels"] = len(labels)
-	ctx.Data["SortType"] = ctx.Query("sort")
+	ctx.Data["SortType"] = ctx.Form("sort")
 }
 
 // NewLabel create new label for repository
@@ -147,7 +147,7 @@ func UpdateLabel(ctx *context.Context) {
 
 // DeleteLabel delete a label
 func DeleteLabel(ctx *context.Context) {
-	if err := models.DeleteLabel(ctx.Repo.Repository.ID, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteLabel(ctx.Repo.Repository.ID, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteLabel: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.issues.label_deletion_success"))
@@ -165,7 +165,7 @@ func UpdateIssueLabel(ctx *context.Context) {
 		return
 	}
 
-	switch action := ctx.Query("action"); action {
+	switch action := ctx.Form("action"); action {
 	case "clear":
 		for _, issue := range issues {
 			if err := issue_service.ClearLabels(issue, ctx.User); err != nil {
@@ -174,7 +174,7 @@ func UpdateIssueLabel(ctx *context.Context) {
 			}
 		}
 	case "attach", "detach", "toggle":
-		label, err := models.GetLabelByID(ctx.QueryInt64("id"))
+		label, err := models.GetLabelByID(ctx.FormInt64("id"))
 		if err != nil {
 			if models.IsErrRepoLabelNotExist(err) {
 				ctx.Error(http.StatusNotFound, "GetLabelByID")

--- a/routers/web/repo/lfs.go
+++ b/routers/web/repo/lfs.go
@@ -42,7 +42,7 @@ func LFSFiles(ctx *context.Context) {
 		ctx.NotFound("LFSFiles", nil)
 		return
 	}
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -74,7 +74,7 @@ func LFSLocks(ctx *context.Context) {
 	}
 	ctx.Data["LFSFilesLink"] = ctx.Repo.RepoLink + "/settings/lfs"
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -195,7 +195,7 @@ func LFSLockFile(ctx *context.Context) {
 		ctx.NotFound("LFSLocks", nil)
 		return
 	}
-	originalPath := ctx.Query("path")
+	originalPath := ctx.Form("path")
 	lockPath := originalPath
 	if len(lockPath) == 0 {
 		ctx.Flash.Error(ctx.Tr("repo.settings.lfs_invalid_locking_path", originalPath))
@@ -366,13 +366,13 @@ func LFSFileFind(ctx *context.Context) {
 		ctx.NotFound("LFSFind", nil)
 		return
 	}
-	oid := ctx.Query("oid")
-	size := ctx.QueryInt64("size")
+	oid := ctx.Form("oid")
+	size := ctx.FormInt64("size")
 	if len(oid) == 0 || size == 0 {
 		ctx.NotFound("LFSFind", nil)
 		return
 	}
-	sha := ctx.Query("sha")
+	sha := ctx.Form("sha")
 	ctx.Data["Title"] = oid
 	ctx.Data["PageIsSettingsLFS"] = true
 	var hash git.SHA1
@@ -511,7 +511,7 @@ func LFSAutoAssociate(ctx *context.Context) {
 		ctx.NotFound("LFSAutoAssociate", nil)
 		return
 	}
-	oids := ctx.QueryStrings("oid")
+	oids := ctx.FormStrings("oid")
 	metas := make([]*models.LFSMetaObject, len(oids))
 	for i, oid := range oids {
 		idx := strings.IndexRune(oid, ' ')

--- a/routers/web/repo/middlewares.go
+++ b/routers/web/repo/middlewares.go
@@ -34,7 +34,7 @@ func SetEditorconfigIfExists(ctx *context.Context) {
 
 // SetDiffViewStyle set diff style as render variable
 func SetDiffViewStyle(ctx *context.Context) {
-	queryStyle := ctx.Query("style")
+	queryStyle := ctx.Form("style")
 
 	if !ctx.IsSigned {
 		ctx.Data["IsSplitStyle"] = queryStyle == "split"
@@ -62,7 +62,7 @@ func SetDiffViewStyle(ctx *context.Context) {
 
 // SetWhitespaceBehavior set whitespace behavior as render variable
 func SetWhitespaceBehavior(ctx *context.Context) {
-	whitespaceBehavior := ctx.Query("whitespace")
+	whitespaceBehavior := ctx.Form("whitespace")
 	switch whitespaceBehavior {
 	case "ignore-all", "ignore-eol", "ignore-change":
 		ctx.Data["WhitespaceBehavior"] = whitespaceBehavior

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -34,29 +34,29 @@ func Migrate(ctx *context.Context) {
 		return
 	}
 
-	serviceType := structs.GitServiceType(ctx.QueryInt("service_type"))
+	serviceType := structs.GitServiceType(ctx.FormInt("service_type"))
 
 	setMigrationContextData(ctx, serviceType)
 
 	if serviceType == 0 {
-		ctx.Data["Org"] = ctx.Query("org")
-		ctx.Data["Mirror"] = ctx.Query("mirror")
+		ctx.Data["Org"] = ctx.Form("org")
+		ctx.Data["Mirror"] = ctx.Form("mirror")
 
 		ctx.HTML(http.StatusOK, tplMigrate)
 		return
 	}
 
 	ctx.Data["private"] = getRepoPrivate(ctx)
-	ctx.Data["mirror"] = ctx.Query("mirror") == "1"
-	ctx.Data["lfs"] = ctx.Query("lfs") == "1"
-	ctx.Data["wiki"] = ctx.Query("wiki") == "1"
-	ctx.Data["milestones"] = ctx.Query("milestones") == "1"
-	ctx.Data["labels"] = ctx.Query("labels") == "1"
-	ctx.Data["issues"] = ctx.Query("issues") == "1"
-	ctx.Data["pull_requests"] = ctx.Query("pull_requests") == "1"
-	ctx.Data["releases"] = ctx.Query("releases") == "1"
+	ctx.Data["mirror"] = ctx.Form("mirror") == "1"
+	ctx.Data["lfs"] = ctx.Form("lfs") == "1"
+	ctx.Data["wiki"] = ctx.Form("wiki") == "1"
+	ctx.Data["milestones"] = ctx.Form("milestones") == "1"
+	ctx.Data["labels"] = ctx.Form("labels") == "1"
+	ctx.Data["issues"] = ctx.Form("issues") == "1"
+	ctx.Data["pull_requests"] = ctx.Form("pull_requests") == "1"
+	ctx.Data["releases"] = ctx.Form("releases") == "1"
 
-	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))
+	ctxUser := checkContextUser(ctx, ctx.FormInt64("org"))
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -36,7 +36,7 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["PageIsIssueList"] = true
 	ctx.Data["PageIsMilestones"] = true
 
-	isShowClosed := ctx.Query("state") == "closed"
+	isShowClosed := ctx.Form("state") == "closed"
 	stats, err := models.GetMilestonesStatsByRepoCond(builder.And(builder.Eq{"id": ctx.Repo.Repository.ID}))
 	if err != nil {
 		ctx.ServerError("MilestoneStats", err)
@@ -45,11 +45,11 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["OpenCount"] = stats.OpenCount
 	ctx.Data["ClosedCount"] = stats.ClosedCount
 
-	sortType := ctx.Query("sort")
+	sortType := ctx.Form("sort")
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -253,7 +253,7 @@ func ChangeMilestoneStatus(ctx *context.Context) {
 
 // DeleteMilestone delete a milestone
 func DeleteMilestone(ctx *context.Context) {
-	if err := models.DeleteMilestoneByRepoID(ctx.Repo.Repository.ID, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteMilestoneByRepoID(ctx.Repo.Repository.ID, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteMilestoneByRepoID: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.milestones.deletion_success"))

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -46,11 +46,11 @@ func MustEnableProjects(ctx *context.Context) {
 func Projects(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.project_board")
 
-	sortType := ctx.QueryTrim("sort")
+	sortType := ctx.FormTrim("sort")
 
-	isShowClosed := strings.ToLower(ctx.QueryTrim("state")) == "closed"
+	isShowClosed := strings.ToLower(ctx.FormTrim("state")) == "closed"
 	repo := ctx.Repo.Repository
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -346,7 +346,7 @@ func UpdateIssueProject(ctx *context.Context) {
 		return
 	}
 
-	projectID := ctx.QueryInt64("id")
+	projectID := ctx.FormInt64("id")
 	for _, issue := range issues {
 		oldProjectID := issue.ProjectID()
 		if oldProjectID == projectID {

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1120,9 +1120,9 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 
 // TriggerTask response for a trigger task request
 func TriggerTask(ctx *context.Context) {
-	pusherID := ctx.QueryInt64("pusher")
-	branch := ctx.Query("branch")
-	secret := ctx.Query("secret")
+	pusherID := ctx.FormInt64("pusher")
+	branch := ctx.Form("branch")
+	secret := ctx.Form("secret")
 	if len(branch) == 0 || len(secret) == 0 || pusherID <= 0 {
 		ctx.Error(http.StatusNotFound)
 		log.Trace("TriggerTask: branch or secret is empty, or pusher ID is not valid")
@@ -1339,7 +1339,7 @@ func UpdatePullRequestTarget(ctx *context.Context) {
 		return
 	}
 
-	targetBranch := ctx.QueryTrim("target_branch")
+	targetBranch := ctx.FormTrim("target_branch")
 	if len(targetBranch) == 0 {
 		ctx.Error(http.StatusNoContent)
 		return

--- a/routers/web/repo/pull_review.go
+++ b/routers/web/repo/pull_review.go
@@ -101,9 +101,9 @@ func CreateCodeComment(ctx *context.Context) {
 
 // UpdateResolveConversation add or remove an Conversation resolved mark
 func UpdateResolveConversation(ctx *context.Context) {
-	origin := ctx.Query("origin")
-	action := ctx.Query("action")
-	commentID := ctx.QueryInt64("comment_id")
+	origin := ctx.Form("origin")
+	action := ctx.Form("action")
+	commentID := ctx.FormInt64("comment_id")
 
 	comment, err := models.GetCommentByID(commentID)
 	if err != nil {

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -96,8 +96,8 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 
 	opts := models.FindReleasesOptions{
 		ListOptions: models.ListOptions{
-			Page:     ctx.QueryInt("page"),
-			PageSize: convert.ToCorrectPageSize(ctx.QueryInt("limit")),
+			Page:     ctx.FormInt("page"),
+			PageSize: convert.ToCorrectPageSize(ctx.FormInt("limit")),
 		},
 		IncludeDrafts: writeAccess && !isTagList,
 		IncludeTags:   isTagList,
@@ -252,7 +252,7 @@ func NewRelease(ctx *context.Context) {
 	ctx.Data["RequireSimpleMDE"] = true
 	ctx.Data["RequireTribute"] = true
 	ctx.Data["tag_target"] = ctx.Repo.Repository.DefaultBranch
-	if tagName := ctx.Query("tag"); len(tagName) > 0 {
+	if tagName := ctx.Form("tag"); len(tagName) > 0 {
 		rel, err := models.GetRelease(ctx.Repo.Repository.ID, tagName)
 		if err != nil && !models.IsErrReleaseNotExist(err) {
 			ctx.ServerError("GetRelease", err)
@@ -507,7 +507,7 @@ func DeleteTag(ctx *context.Context) {
 }
 
 func deleteReleaseOrTag(ctx *context.Context, isDelTag bool) {
-	if err := releaseservice.DeleteReleaseByID(ctx.QueryInt64("id"), ctx.User, isDelTag); err != nil {
+	if err := releaseservice.DeleteReleaseByID(ctx.FormInt64("id"), ctx.User, isDelTag); err != nil {
 		ctx.Flash.Error("DeleteReleaseByID: " + err.Error())
 	} else {
 		if isDelTag {

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -133,14 +133,14 @@ func Create(ctx *context.Context) {
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["default_branch"] = setting.Repository.DefaultBranch
 
-	ctxUser := checkContextUser(ctx, ctx.QueryInt64("org"))
+	ctxUser := checkContextUser(ctx, ctx.FormInt64("org"))
 	if ctx.Written() {
 		return
 	}
 	ctx.Data["ContextUser"] = ctxUser
 
 	ctx.Data["repo_template_name"] = ctx.Tr("repo.template_select")
-	templateID := ctx.QueryInt64("template_id")
+	templateID := ctx.FormInt64("template_id")
 	if templateID > 0 {
 		templateRepo, err := models.GetRepositoryByID(templateID)
 		if err == nil && templateRepo.CheckUnitUser(ctxUser, models.UnitTypeCode) {
@@ -291,8 +291,8 @@ func Action(ctx *context.Context) {
 			return
 		}
 
-		ctx.Repo.Repository.Description = ctx.Query("desc")
-		ctx.Repo.Repository.Website = ctx.Query("site")
+		ctx.Repo.Repository.Description = ctx.Form("desc")
+		ctx.Repo.Repository.Website = ctx.Form("site")
 		err = models.UpdateRepository(ctx.Repo.Repository, false)
 	}
 
@@ -301,7 +301,7 @@ func Action(ctx *context.Context) {
 		return
 	}
 
-	ctx.RedirectToFirst(ctx.Query("redirect_to"), ctx.Repo.RepoLink)
+	ctx.RedirectToFirst(ctx.Form("redirect_to"), ctx.Repo.RepoLink)
 }
 
 func acceptOrRejectRepoTransfer(ctx *context.Context, accept bool) error {

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -22,13 +22,13 @@ func Search(ctx *context.Context) {
 		ctx.Redirect(ctx.Repo.RepoLink, 302)
 		return
 	}
-	language := strings.TrimSpace(ctx.Query("l"))
-	keyword := strings.TrimSpace(ctx.Query("q"))
-	page := ctx.QueryInt("page")
+	language := strings.TrimSpace(ctx.Form("l"))
+	keyword := strings.TrimSpace(ctx.Form("q"))
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}
-	queryType := strings.TrimSpace(ctx.Query("t"))
+	queryType := strings.TrimSpace(ctx.Form("t"))
 	isMatch := queryType == "match"
 
 	total, searchResults, searchResultLanguages, err := code_indexer.PerformSearch([]int64{ctx.Repo.Repository.ID},

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -70,7 +70,7 @@ func SettingsPost(ctx *context.Context) {
 
 	repo := ctx.Repo.Repository
 
-	switch ctx.Query("action") {
+	switch ctx.Form("action") {
 	case "update":
 		if ctx.HasError() {
 			ctx.HTML(http.StatusOK, tplSettingsOptions)
@@ -560,7 +560,7 @@ func SettingsPost(ctx *context.Context) {
 			return
 		}
 
-		newOwner, err := models.GetUserByName(ctx.Query("new_owner_name"))
+		newOwner, err := models.GetUserByName(ctx.Form("new_owner_name"))
 		if err != nil {
 			if models.IsErrUserNotExist(err) {
 				ctx.RenderWithErr(ctx.Tr("form.enterred_invalid_owner_name"), tplSettingsOptions, nil)
@@ -775,7 +775,7 @@ func Collaboration(ctx *context.Context) {
 
 // CollaborationPost response for actions for a collaboration of a repository
 func CollaborationPost(ctx *context.Context) {
-	name := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Query("collaborator")))
+	name := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Form("collaborator")))
 	if len(name) == 0 || ctx.Repo.Owner.LowerName == name {
 		ctx.Redirect(setting.AppSubURL + ctx.Req.URL.Path)
 		return
@@ -827,15 +827,15 @@ func CollaborationPost(ctx *context.Context) {
 // ChangeCollaborationAccessMode response for changing access of a collaboration
 func ChangeCollaborationAccessMode(ctx *context.Context) {
 	if err := ctx.Repo.Repository.ChangeCollaborationAccessMode(
-		ctx.QueryInt64("uid"),
-		models.AccessMode(ctx.QueryInt("mode"))); err != nil {
+		ctx.FormInt64("uid"),
+		models.AccessMode(ctx.FormInt("mode"))); err != nil {
 		log.Error("ChangeCollaborationAccessMode: %v", err)
 	}
 }
 
 // DeleteCollaboration delete a collaboration for a repository
 func DeleteCollaboration(ctx *context.Context) {
-	if err := ctx.Repo.Repository.DeleteCollaboration(ctx.QueryInt64("id")); err != nil {
+	if err := ctx.Repo.Repository.DeleteCollaboration(ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteCollaboration: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.remove_collaborator_success"))
@@ -854,7 +854,7 @@ func AddTeamPost(ctx *context.Context) {
 		return
 	}
 
-	name := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Query("team")))
+	name := utils.RemoveUsernameParameterSuffix(strings.ToLower(ctx.Form("team")))
 	if len(name) == 0 {
 		ctx.Redirect(ctx.Repo.RepoLink + "/settings/collaboration")
 		return
@@ -900,7 +900,7 @@ func DeleteTeam(ctx *context.Context) {
 		return
 	}
 
-	team, err := models.GetTeamByID(ctx.QueryInt64("id"))
+	team, err := models.GetTeamByID(ctx.FormInt64("id"))
 	if err != nil {
 		ctx.ServerError("GetTeamByID", err)
 		return
@@ -988,7 +988,7 @@ func GitHooksEditPost(ctx *context.Context) {
 		}
 		return
 	}
-	hook.Content = ctx.Query("content")
+	hook.Content = ctx.Form("content")
 	if err = hook.Update(); err != nil {
 		ctx.ServerError("hook.Update", err)
 		return
@@ -1074,7 +1074,7 @@ func DeployKeysPost(ctx *context.Context) {
 
 // DeleteDeployKey response for deleting a deploy key
 func DeleteDeployKey(ctx *context.Context) {
-	if err := models.DeleteDeployKey(ctx.User, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteDeployKey(ctx.User, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteDeployKey: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.deploy_key_deletion_success"))

--- a/routers/web/repo/setting_protected_branch.go
+++ b/routers/web/repo/setting_protected_branch.go
@@ -60,14 +60,14 @@ func ProtectedBranchPost(ctx *context.Context) {
 
 	repo := ctx.Repo.Repository
 
-	switch ctx.Query("action") {
+	switch ctx.Form("action") {
 	case "default_branch":
 		if ctx.HasError() {
 			ctx.HTML(http.StatusOK, tplBranches)
 			return
 		}
 
-		branch := ctx.Query("branch")
+		branch := ctx.Form("branch")
 		if !ctx.Repo.GitRepo.IsBranchExist(branch) {
 			ctx.Status(404)
 			return

--- a/routers/web/repo/tag.go
+++ b/routers/web/repo/tag.go
@@ -161,7 +161,7 @@ func setTagsContext(ctx *context.Context) error {
 }
 
 func selectProtectedTagByContext(ctx *context.Context) *models.ProtectedTag {
-	id := ctx.QueryInt64("id")
+	id := ctx.FormInt64("id")
 	if id == 0 {
 		id = ctx.ParamsInt64(":id")
 	}

--- a/routers/web/repo/topic.go
+++ b/routers/web/repo/topic.go
@@ -23,7 +23,7 @@ func TopicsPost(ctx *context.Context) {
 	}
 
 	var topics = make([]string, 0)
-	var topicsStr = strings.TrimSpace(ctx.Query("topics"))
+	var topicsStr = strings.TrimSpace(ctx.Form("topics"))
 	if len(topicsStr) > 0 {
 		topics = strings.Split(topicsStr, ",")
 	}

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -416,7 +416,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 	isTextFile := st.IsText()
 
 	isLFSFile := false
-	isDisplayingSource := ctx.Query("display") == "source"
+	isDisplayingSource := ctx.Form("display") == "source"
 	isDisplayingRendered := !isDisplayingSource
 
 	//Check for LFS meta file
@@ -756,7 +756,7 @@ func renderCode(ctx *context.Context) {
 
 // RenderUserCards render a page show users according the input template
 func RenderUserCards(ctx *context.Context, total int, getter func(opts models.ListOptions) ([]*models.User, error), tpl base.TplName) {
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}

--- a/routers/web/repo/webhook.go
+++ b/routers/web/repo/webhook.go
@@ -1192,7 +1192,7 @@ func TestWebhook(ctx *context.Context) {
 
 // DeleteWebhook delete a webhook
 func DeleteWebhook(ctx *context.Context) {
-	if err := models.DeleteWebhookByRepoID(ctx.Repo.Repository.ID, ctx.QueryInt64("id")); err != nil {
+	if err := models.DeleteWebhookByRepoID(ctx.Repo.Repository.ID, ctx.FormInt64("id")); err != nil {
 		ctx.Flash.Error("DeleteWebhookByRepoID: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.webhook_deletion_success"))

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -298,7 +298,7 @@ func renderRevisionPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) 
 	ctx.Data["CommitCount"] = commitsCount
 
 	// get page
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}

--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -111,7 +111,7 @@ func checkAutoLogin(ctx *context.Context) bool {
 		return true
 	}
 
-	redirectTo := ctx.Query("redirect_to")
+	redirectTo := ctx.Form("redirect_to")
 	if len(redirectTo) > 0 {
 		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
 	} else {
@@ -1333,7 +1333,7 @@ func handleUserCreated(ctx *context.Context, u *models.User, gothUser *goth.User
 
 // Activate render activate user page
 func Activate(ctx *context.Context) {
-	code := ctx.Query("code")
+	code := ctx.Form("code")
 
 	if len(code) == 0 {
 		ctx.Data["IsActivatePage"] = true
@@ -1381,7 +1381,7 @@ func Activate(ctx *context.Context) {
 
 // ActivatePost handles account activation with password check
 func ActivatePost(ctx *context.Context) {
-	code := ctx.Query("code")
+	code := ctx.Form("code")
 	if len(code) == 0 {
 		ctx.Redirect(setting.AppSubURL + "/user/activate")
 		return
@@ -1397,7 +1397,7 @@ func ActivatePost(ctx *context.Context) {
 
 	// if account is local account, verify password
 	if user.LoginSource == 0 {
-		password := ctx.Query("password")
+		password := ctx.Form("password")
 		if len(password) == 0 {
 			ctx.Data["Code"] = code
 			ctx.Data["NeedsPassword"] = true
@@ -1454,8 +1454,8 @@ func handleAccountActivation(ctx *context.Context, user *models.User) {
 
 // ActivateEmail render the activate email page
 func ActivateEmail(ctx *context.Context) {
-	code := ctx.Query("code")
-	emailStr := ctx.Query("email")
+	code := ctx.Form("code")
+	emailStr := ctx.Form("email")
 
 	// Verify code.
 	if email := models.VerifyActiveEmailCode(code, emailStr); email != nil {
@@ -1491,7 +1491,7 @@ func ForgotPasswd(ctx *context.Context) {
 		return
 	}
 
-	email := ctx.Query("email")
+	email := ctx.Form("email")
 	ctx.Data["Email"] = email
 
 	ctx.Data["IsResetRequest"] = true
@@ -1508,7 +1508,7 @@ func ForgotPasswdPost(ctx *context.Context) {
 	}
 	ctx.Data["IsResetRequest"] = true
 
-	email := ctx.Query("email")
+	email := ctx.Form("email")
 	ctx.Data["Email"] = email
 
 	u, err := models.GetUserByEmail(email)
@@ -1548,7 +1548,7 @@ func ForgotPasswdPost(ctx *context.Context) {
 }
 
 func commonResetPassword(ctx *context.Context) (*models.User, *models.TwoFactor) {
-	code := ctx.Query("code")
+	code := ctx.Form("code")
 
 	ctx.Data["Title"] = ctx.Tr("auth.reset_password")
 	ctx.Data["Code"] = code
@@ -1577,7 +1577,7 @@ func commonResetPassword(ctx *context.Context) (*models.User, *models.TwoFactor)
 		}
 	} else {
 		ctx.Data["has_two_factor"] = true
-		ctx.Data["scratch_code"] = ctx.QueryBool("scratch_code")
+		ctx.Data["scratch_code"] = ctx.FormBool("scratch_code")
 	}
 
 	// Show the user that they are affecting the account that they intended to
@@ -1617,7 +1617,7 @@ func ResetPasswdPost(ctx *context.Context) {
 	}
 
 	// Validate password length.
-	passwd := ctx.Query("password")
+	passwd := ctx.Form("password")
 	if len(passwd) < setting.MinPasswordLength {
 		ctx.Data["IsResetForm"] = true
 		ctx.Data["Err_Password"] = true
@@ -1643,8 +1643,8 @@ func ResetPasswdPost(ctx *context.Context) {
 	// Handle two-factor
 	regenerateScratchToken := false
 	if twofa != nil {
-		if ctx.QueryBool("scratch_code") {
-			if !twofa.VerifyScratchToken(ctx.Query("token")) {
+		if ctx.FormBool("scratch_code") {
+			if !twofa.VerifyScratchToken(ctx.Form("token")) {
 				ctx.Data["IsResetForm"] = true
 				ctx.Data["Err_Token"] = true
 				ctx.RenderWithErr(ctx.Tr("auth.twofa_scratch_token_incorrect"), tplResetPassword, nil)
@@ -1652,7 +1652,7 @@ func ResetPasswdPost(ctx *context.Context) {
 			}
 			regenerateScratchToken = true
 		} else {
-			passcode := ctx.Query("passcode")
+			passcode := ctx.Form("passcode")
 			ok, err := twofa.ValidateTOTP(passcode)
 			if err != nil {
 				ctx.Error(http.StatusInternalServerError, "ValidateTOTP", err.Error())
@@ -1689,7 +1689,7 @@ func ResetPasswdPost(ctx *context.Context) {
 
 	log.Trace("User password reset: %s", u.Name)
 	ctx.Data["IsResetFailed"] = true
-	remember := len(ctx.Query("remember")) != 0
+	remember := len(ctx.Form("remember")) != 0
 
 	if regenerateScratchToken {
 		// Invalidate the scratch token.

--- a/routers/web/user/auth_openid.go
+++ b/routers/web/user/auth_openid.go
@@ -34,7 +34,7 @@ const (
 func SignInOpenID(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("sign_in")
 
-	if ctx.Query("openid.return_to") != "" {
+	if ctx.Form("openid.return_to") != "" {
 		signInOpenIDVerify(ctx)
 		return
 	}
@@ -46,7 +46,7 @@ func SignInOpenID(ctx *context.Context) {
 		return
 	}
 
-	redirectTo := ctx.Query("redirect_to")
+	redirectTo := ctx.Form("redirect_to")
 	if len(redirectTo) > 0 {
 		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
 	} else {

--- a/routers/web/user/avatar.go
+++ b/routers/web/user/avatar.go
@@ -66,7 +66,7 @@ func AvatarByEmailHash(ctx *context.Context) {
 		ctx.Redirect(models.DefaultAvatarLink())
 		return
 	}
-	size := ctx.QueryInt("size")
+	size := ctx.FormInt("size")
 	if size == 0 {
 		size = models.DefaultAvatarSize
 	}

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -157,7 +157,7 @@ func Dashboard(ctx *context.Context) {
 		IncludePrivate:  true,
 		OnlyPerformedBy: false,
 		IncludeDeleted:  false,
-		Date:            ctx.Query("date"),
+		Date:            ctx.Form("date"),
 	})
 
 	if ctx.Written() {
@@ -200,11 +200,11 @@ func Milestones(ctx *context.Context) {
 		repoCond     = userRepoCond
 		repoIDs      []int64
 
-		reposQuery   = ctx.Query("repos")
-		isShowClosed = ctx.Query("state") == "closed"
-		sortType     = ctx.Query("sort")
-		page         = ctx.QueryInt("page")
-		keyword      = strings.Trim(ctx.Query("q"), " ")
+		reposQuery   = ctx.Form("repos")
+		isShowClosed = ctx.Form("state") == "closed"
+		sortType     = ctx.Form("sort")
+		page         = ctx.FormInt("page")
+		keyword      = strings.Trim(ctx.Form("q"), " ")
 	)
 
 	if page <= 1 {
@@ -380,7 +380,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 
 	var (
 		viewType   string
-		sortType   = ctx.Query("sort")
+		sortType   = ctx.Form("sort")
 		filterMode = models.FilterModeAll
 	)
 
@@ -390,14 +390,14 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	// - Remember pre-determined viewType string for later. Will be posted to ctx.Data.
 	//   Organization does not have view type and filter mode.
 	// User:
-	// - Use ctx.Query("type") to determine filterMode.
+	// - Use ctx.Form("type") to determine filterMode.
 	//  The type is set when clicking for example "assigned to me" on the overview page.
 	// - Remember either this or a fallback. Will be posted to ctx.Data.
 	// --------------------------------------------------------------------------------
 
 	// TODO: distinguish during routing
 
-	viewType = ctx.Query("type")
+	viewType = ctx.Form("type")
 	switch viewType {
 	case "assigned":
 		filterMode = models.FilterModeAssign
@@ -456,7 +456,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	}
 
 	// keyword holds the search term entered into the search field.
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	ctx.Data["Keyword"] = keyword
 
 	// Execute keyword search for issues.
@@ -477,7 +477,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	}
 
 	// Educated guess: Do or don't show closed issues.
-	isShowClosed := ctx.Query("state") == "closed"
+	isShowClosed := ctx.Form("state") == "closed"
 	opts.IsClosed = util.OptionalBoolOf(isShowClosed)
 
 	// Filter repos and count issues in them. Count will be used later.
@@ -492,7 +492,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	}
 
 	// Make sure page number is at least 1. Will be posted to ctx.Data.
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 1 {
 		page = 1
 	}
@@ -502,7 +502,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	// Get IDs for labels (a filter option for issues/pulls).
 	// Required for IssuesOptions.
 	var labelIDs []int64
-	selectedLabels := ctx.Query("labels")
+	selectedLabels := ctx.Form("labels")
 	if len(selectedLabels) > 0 && selectedLabels != "0" {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectedLabels, ","))
 		if err != nil {
@@ -512,9 +512,9 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	}
 	opts.LabelIDs = labelIDs
 
-	// Parse ctx.Query("repos") and remember matched repo IDs for later.
+	// Parse ctx.Form("repos") and remember matched repo IDs for later.
 	// Gets set when clicking filters on the issues overview page.
-	repoIDs := getRepoIDs(ctx.Query("repos"))
+	repoIDs := getRepoIDs(ctx.Form("repos"))
 	if len(repoIDs) > 0 {
 		opts.RepoIDs = repoIDs
 	}
@@ -658,7 +658,7 @@ func buildIssueOverview(ctx *context.Context, unitType models.UnitType) {
 	ctx.Data["IsShowClosed"] = isShowClosed
 
 	ctx.Data["IssueRefEndNames"], ctx.Data["IssueRefURLs"] =
-		issue_service.GetRefEndNamesAndURLs(issues, ctx.Query("RepoLink"))
+		issue_service.GetRefEndNamesAndURLs(issues, ctx.Form("RepoLink"))
 
 	ctx.Data["Issues"] = issues
 
@@ -900,7 +900,7 @@ func ShowGPGKeys(ctx *context.Context, uid int64) {
 
 // Email2User show user page via email
 func Email2User(ctx *context.Context) {
-	u, err := models.GetUserByEmail(ctx.Query("email"))
+	u, err := models.GetUserByEmail(ctx.Form("email"))
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
 			ctx.NotFound("GetUserByEmail", err)

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -49,8 +49,8 @@ func Notifications(c *context.Context) {
 	if c.Written() {
 		return
 	}
-	if c.QueryBool("div-only") {
-		c.Data["SequenceNumber"] = c.Query("sequence-number")
+	if c.FormBool("div-only") {
+		c.Data["SequenceNumber"] = c.Form("sequence-number")
 		c.HTML(http.StatusOK, tplNotificationDiv)
 		return
 	}
@@ -59,10 +59,10 @@ func Notifications(c *context.Context) {
 
 func getNotifications(c *context.Context) {
 	var (
-		keyword = strings.Trim(c.Query("q"), " ")
+		keyword = strings.Trim(c.Form("q"), " ")
 		status  models.NotificationStatus
-		page    = c.QueryInt("page")
-		perPage = c.QueryInt("perPage")
+		page    = c.FormInt("page")
+		perPage = c.FormInt("perPage")
 	)
 	if page < 1 {
 		page = 1
@@ -87,7 +87,7 @@ func getNotifications(c *context.Context) {
 	// redirect to last page if request page is more than total pages
 	pager := context.NewPagination(int(total), perPage, page, 5)
 	if pager.Paginater.Current() < page {
-		c.Redirect(fmt.Sprintf("/notifications?q=%s&page=%d", c.Query("q"), pager.Paginater.Current()))
+		c.Redirect(fmt.Sprintf("/notifications?q=%s&page=%d", c.Form("q"), pager.Paginater.Current()))
 		return
 	}
 
@@ -166,8 +166,8 @@ func NotificationStatusPost(c *context.Context) {
 		return
 	}
 
-	if !c.QueryBool("noredirect") {
-		url := fmt.Sprintf("%s/notifications?page=%s", setting.AppSubURL, c.Query("page"))
+	if !c.FormBool("noredirect") {
+		url := fmt.Sprintf("%s/notifications?page=%s", setting.AppSubURL, c.Form("page"))
 		c.Redirect(url, http.StatusSeeOther)
 	}
 

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -143,15 +143,15 @@ func Profile(ctx *context.Context) {
 	ctx.Data["Orgs"] = orgs
 	ctx.Data["HasOrgsVisible"] = models.HasOrgsVisible(orgs, ctx.User)
 
-	tab := ctx.Query("tab")
+	tab := ctx.Form("tab")
 	ctx.Data["TabName"] = tab
 
-	page := ctx.QueryInt("page")
+	page := ctx.FormInt("page")
 	if page <= 0 {
 		page = 1
 	}
 
-	topicOnly := ctx.QueryBool("topic")
+	topicOnly := ctx.FormBool("topic")
 
 	var (
 		repos   []*models.Repository
@@ -160,8 +160,8 @@ func Profile(ctx *context.Context) {
 		orderBy models.SearchOrderBy
 	)
 
-	ctx.Data["SortType"] = ctx.Query("sort")
-	switch ctx.Query("sort") {
+	ctx.Data["SortType"] = ctx.Form("sort")
+	switch ctx.Form("sort") {
 	case "newest":
 		orderBy = models.SearchOrderByNewest
 	case "oldest":
@@ -187,7 +187,7 @@ func Profile(ctx *context.Context) {
 		orderBy = models.SearchOrderByRecentUpdated
 	}
 
-	keyword := strings.Trim(ctx.Query("q"), " ")
+	keyword := strings.Trim(ctx.Form("q"), " ")
 	ctx.Data["Keyword"] = keyword
 	switch tab {
 	case "followers":
@@ -220,7 +220,7 @@ func Profile(ctx *context.Context) {
 			IncludePrivate:  showPrivate,
 			OnlyPerformedBy: true,
 			IncludeDeleted:  false,
-			Date:            ctx.Query("date"),
+			Date:            ctx.Form("date"),
 		})
 		if ctx.Written() {
 			return
@@ -332,5 +332,5 @@ func Action(ctx *context.Context) {
 		return
 	}
 
-	ctx.RedirectToFirst(ctx.Query("redirect_to"), u.HomeLink())
+	ctx.RedirectToFirst(ctx.Form("redirect_to"), u.HomeLink())
 }

--- a/routers/web/user/setting/account.go
+++ b/routers/web/user/setting/account.go
@@ -90,8 +90,8 @@ func EmailPost(ctx *context.Context) {
 	ctx.Data["PageIsSettingsAccount"] = true
 
 	// Make emailaddress primary.
-	if ctx.Query("_method") == "PRIMARY" {
-		if err := models.MakeEmailPrimary(&models.EmailAddress{ID: ctx.QueryInt64("id")}); err != nil {
+	if ctx.Form("_method") == "PRIMARY" {
+		if err := models.MakeEmailPrimary(&models.EmailAddress{ID: ctx.FormInt64("id")}); err != nil {
 			ctx.ServerError("MakeEmailPrimary", err)
 			return
 		}
@@ -101,7 +101,7 @@ func EmailPost(ctx *context.Context) {
 		return
 	}
 	// Send activation Email
-	if ctx.Query("_method") == "SENDACTIVATION" {
+	if ctx.Form("_method") == "SENDACTIVATION" {
 		var address string
 		if ctx.Cache.IsExist("MailResendLimit_" + ctx.User.LowerName) {
 			log.Error("Send activation: activation still pending")
@@ -109,7 +109,7 @@ func EmailPost(ctx *context.Context) {
 			return
 		}
 
-		id := ctx.QueryInt64("id")
+		id := ctx.FormInt64("id")
 		email, err := models.GetEmailAddressByID(ctx.User.ID, id)
 		if err != nil {
 			log.Error("GetEmailAddressByID(%d,%d) error: %v", ctx.User.ID, id, err)
@@ -147,8 +147,8 @@ func EmailPost(ctx *context.Context) {
 		return
 	}
 	// Set Email Notification Preference
-	if ctx.Query("_method") == "NOTIFICATION" {
-		preference := ctx.Query("preference")
+	if ctx.Form("_method") == "NOTIFICATION" {
+		preference := ctx.Form("preference")
 		if !(preference == models.EmailNotificationsEnabled ||
 			preference == models.EmailNotificationsOnMention ||
 			preference == models.EmailNotificationsDisabled) {
@@ -212,7 +212,7 @@ func EmailPost(ctx *context.Context) {
 
 // DeleteEmail response for delete user's email
 func DeleteEmail(ctx *context.Context) {
-	if err := models.DeleteEmailAddress(&models.EmailAddress{ID: ctx.QueryInt64("id"), UID: ctx.User.ID}); err != nil {
+	if err := models.DeleteEmailAddress(&models.EmailAddress{ID: ctx.FormInt64("id"), UID: ctx.User.ID}); err != nil {
 		ctx.ServerError("DeleteEmail", err)
 		return
 	}
@@ -229,7 +229,7 @@ func DeleteAccount(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("settings")
 	ctx.Data["PageIsSettingsAccount"] = true
 
-	if _, err := auth.UserSignIn(ctx.User.Name, ctx.Query("password")); err != nil {
+	if _, err := auth.UserSignIn(ctx.User.Name, ctx.Form("password")); err != nil {
 		if models.IsErrUserNotExist(err) {
 			loadAccountData(ctx)
 

--- a/routers/web/user/setting/adopt.go
+++ b/routers/web/user/setting/adopt.go
@@ -23,8 +23,8 @@ func AdoptOrDeleteRepository(ctx *context.Context) {
 	allowDelete := ctx.IsUserSiteAdmin() || setting.Repository.AllowDeleteOfUnadoptedRepositories
 	ctx.Data["allowDelete"] = allowDelete
 
-	dir := ctx.Query("id")
-	action := ctx.Query("action")
+	dir := ctx.Form("id")
+	action := ctx.Form("action")
 
 	ctxUser := ctx.User
 	root := filepath.Join(models.UserPath(ctxUser.LowerName))

--- a/routers/web/user/setting/applications.go
+++ b/routers/web/user/setting/applications.go
@@ -72,7 +72,7 @@ func ApplicationsPost(ctx *context.Context) {
 
 // DeleteApplication response for delete user access token
 func DeleteApplication(ctx *context.Context) {
-	if err := models.DeleteAccessTokenByID(ctx.QueryInt64("id"), ctx.User.ID); err != nil {
+	if err := models.DeleteAccessTokenByID(ctx.FormInt64("id"), ctx.User.ID); err != nil {
 		ctx.Flash.Error("DeleteAccessTokenByID: " + err.Error())
 	} else {
 		ctx.Flash.Success(ctx.Tr("settings.delete_token_success"))

--- a/routers/web/user/setting/keys.go
+++ b/routers/web/user/setting/keys.go
@@ -193,15 +193,15 @@ func KeysPost(ctx *context.Context) {
 // DeleteKey response for delete user's SSH/GPG key
 func DeleteKey(ctx *context.Context) {
 
-	switch ctx.Query("type") {
+	switch ctx.Form("type") {
 	case "gpg":
-		if err := models.DeleteGPGKey(ctx.User, ctx.QueryInt64("id")); err != nil {
+		if err := models.DeleteGPGKey(ctx.User, ctx.FormInt64("id")); err != nil {
 			ctx.Flash.Error("DeleteGPGKey: " + err.Error())
 		} else {
 			ctx.Flash.Success(ctx.Tr("settings.gpg_key_deletion_success"))
 		}
 	case "ssh":
-		keyID := ctx.QueryInt64("id")
+		keyID := ctx.FormInt64("id")
 		external, err := models.PublicKeyIsExternallyManaged(keyID)
 		if err != nil {
 			ctx.ServerError("sshKeysExternalManaged", err)
@@ -218,7 +218,7 @@ func DeleteKey(ctx *context.Context) {
 			ctx.Flash.Success(ctx.Tr("settings.ssh_key_deletion_success"))
 		}
 	case "principal":
-		if err := models.DeletePublicKey(ctx.User, ctx.QueryInt64("id")); err != nil {
+		if err := models.DeletePublicKey(ctx.User, ctx.FormInt64("id")); err != nil {
 			ctx.Flash.Error("DeletePublicKey: " + err.Error())
 		} else {
 			ctx.Flash.Success(ctx.Tr("settings.ssh_principal_deletion_success"))
@@ -265,5 +265,5 @@ func loadKeysData(ctx *context.Context) {
 	}
 	ctx.Data["Principals"] = principals
 
-	ctx.Data["VerifyingID"] = ctx.Query("verify_gpg")
+	ctx.Data["VerifyingID"] = ctx.Form("verify_gpg")
 }

--- a/routers/web/user/setting/oauth2.go
+++ b/routers/web/user/setting/oauth2.go
@@ -129,7 +129,7 @@ func OAuth2ApplicationShow(ctx *context.Context) {
 
 // DeleteOAuth2Application deletes the given oauth2 application
 func DeleteOAuth2Application(ctx *context.Context) {
-	if err := models.DeleteOAuth2Application(ctx.QueryInt64("id"), ctx.User.ID); err != nil {
+	if err := models.DeleteOAuth2Application(ctx.FormInt64("id"), ctx.User.ID); err != nil {
 		ctx.ServerError("DeleteOAuth2Application", err)
 		return
 	}
@@ -143,11 +143,11 @@ func DeleteOAuth2Application(ctx *context.Context) {
 
 // RevokeOAuth2Grant revokes the grant with the given id
 func RevokeOAuth2Grant(ctx *context.Context) {
-	if ctx.User.ID == 0 || ctx.QueryInt64("id") == 0 {
+	if ctx.User.ID == 0 || ctx.FormInt64("id") == 0 {
 		ctx.ServerError("RevokeOAuth2Grant", fmt.Errorf("user id or grant id is zero"))
 		return
 	}
-	if err := models.RevokeOAuth2Grant(ctx.QueryInt64("id"), ctx.User.ID); err != nil {
+	if err := models.RevokeOAuth2Grant(ctx.FormInt64("id"), ctx.User.ID); err != nil {
 		ctx.ServerError("RevokeOAuth2Grant", err)
 		return
 	}

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -228,7 +228,7 @@ func Repos(ctx *context.Context) {
 
 	opts := models.ListOptions{
 		PageSize: setting.UI.Admin.UserPagingNum,
-		Page:     ctx.QueryInt("page"),
+		Page:     ctx.FormInt("page"),
 	}
 
 	if opts.Page <= 0 {

--- a/routers/web/user/setting/security.go
+++ b/routers/web/user/setting/security.go
@@ -26,7 +26,7 @@ func Security(ctx *context.Context) {
 	ctx.Data["PageIsSettingsSecurity"] = true
 	ctx.Data["RequireU2F"] = true
 
-	if ctx.Query("openid.return_to") != "" {
+	if ctx.Form("openid.return_to") != "" {
 		settingsOpenIDVerify(ctx)
 		return
 	}
@@ -38,7 +38,7 @@ func Security(ctx *context.Context) {
 
 // DeleteAccountLink delete a single account link
 func DeleteAccountLink(ctx *context.Context) {
-	id := ctx.QueryInt64("id")
+	id := ctx.FormInt64("id")
 	if id <= 0 {
 		ctx.Flash.Error("Account link id is not given")
 	} else {

--- a/routers/web/user/setting/security_openid.go
+++ b/routers/web/user/setting/security_openid.go
@@ -106,7 +106,7 @@ func settingsOpenIDVerify(ctx *context.Context) {
 
 // DeleteOpenID response for delete user's openid
 func DeleteOpenID(ctx *context.Context) {
-	if err := models.DeleteUserOpenID(&models.UserOpenID{ID: ctx.QueryInt64("id"), UID: ctx.User.ID}); err != nil {
+	if err := models.DeleteUserOpenID(&models.UserOpenID{ID: ctx.FormInt64("id"), UID: ctx.User.ID}); err != nil {
 		ctx.ServerError("DeleteUserOpenID", err)
 		return
 	}
@@ -120,7 +120,7 @@ func DeleteOpenID(ctx *context.Context) {
 
 // ToggleOpenIDVisibility response for toggle visibility of user's openid
 func ToggleOpenIDVisibility(ctx *context.Context) {
-	if err := models.ToggleUserOpenIDVisibility(ctx.QueryInt64("id")); err != nil {
+	if err := models.ToggleUserOpenIDVisibility(ctx.FormInt64("id")); err != nil {
 		ctx.ServerError("ToggleUserOpenIDVisibility", err)
 		return
 	}

--- a/services/lfs/locks.go
+++ b/services/lfs/locks.go
@@ -68,17 +68,17 @@ func GetListLockHandler(ctx *context.Context) {
 	}
 	ctx.Resp.Header().Set("Content-Type", lfs_module.MediaType)
 
-	cursor := ctx.QueryInt("cursor")
+	cursor := ctx.FormInt("cursor")
 	if cursor < 0 {
 		cursor = 0
 	}
-	limit := ctx.QueryInt("limit")
+	limit := ctx.FormInt("limit")
 	if limit > setting.LFS.LocksPagingNum && setting.LFS.LocksPagingNum > 0 {
 		limit = setting.LFS.LocksPagingNum
 	} else if limit < 0 {
 		limit = 0
 	}
-	id := ctx.Query("id")
+	id := ctx.Form("id")
 	if id != "" { //Case where we request a specific id
 		v, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
@@ -95,7 +95,7 @@ func GetListLockHandler(ctx *context.Context) {
 		return
 	}
 
-	path := ctx.Query("path")
+	path := ctx.Form("path")
 	if path != "" { //Case where we request a specific id
 		lock, err := models.GetLFSLock(repository, path)
 		if err != nil && !models.IsErrLFSLockNotExist(err) {
@@ -224,11 +224,11 @@ func VerifyLockHandler(ctx *context.Context) {
 
 	ctx.Resp.Header().Set("Content-Type", lfs_module.MediaType)
 
-	cursor := ctx.QueryInt("cursor")
+	cursor := ctx.FormInt("cursor")
 	if cursor < 0 {
 		cursor = 0
 	}
-	limit := ctx.QueryInt("limit")
+	limit := ctx.FormInt("limit")
 	if limit > setting.LFS.LocksPagingNum && setting.LFS.LocksPagingNum > 0 {
 		limit = setting.LFS.LocksPagingNum
 	} else if limit < 0 {


### PR DESCRIPTION
The name `Query` on context derived from macaron is confusing because it should only get query parameters from URL query.
This PR renames `Query` to `Form` as the first step. Next step, we need add the real `Query` methods and change some routers' revocations. 