### PR TITLE
Lock goth/gothic and Re-attempt OAuth2 registration on login if registration failed at startup (#16564)

### DIFF
--- a/models/oauth2.go
+++ b/models/oauth2.go
@@ -155,11 +155,6 @@ func initOAuth2LoginSources() error {
 		err := oauth2.RegisterProvider(source.Name, oAuth2Config.Provider, oAuth2Config.ClientID, oAuth2Config.ClientSecret, oAuth2Config.OpenIDConnectAutoDiscoveryURL, oAuth2Config.CustomURLMapping)
 		if err != nil {
 			log.Critical("Unable to register source: %s due to Error: %v. This source will be disabled.", source.Name, err)
-			source.IsActived = false
-			if err = UpdateSource(source); err != nil {
-				log.Critical("Unable to update source %s to disable it. Error: %v", err)
-				return err
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Backport #16564

This PR has two parts:

* Add locking to goth and gothic calls with a RWMutex

The goth and gothic calls are currently unlocked and thus are a cause of multiple potential races

* Reattempt OAuth2 registration on login if registration failed

If OAuth2 registration fails at startup we currently disable the login_source however an alternative approach could be to reattempt registration on login attempt.
    
Fix #16096
    
    