### PR TITLE
Fix Swagger AccessToken

### DIFF
--- a/routers/api/v1/swagger/app.go
+++ b/routers/api/v1/swagger/app.go
@@ -14,3 +14,10 @@ type swaggerResponseOAuth2Application struct {
 	// in:body
 	Body api.OAuth2Application `json:"body"`
 }
+
+// AccessToken represents an API access token.
+// swagger:response AccessToken
+type swaggerResponseAccessToken struct {
+	// in:body
+	Body api.AccessToken `json:"body"`
+}

--- a/routers/api/v1/swagger/options.go
+++ b/routers/api/v1/swagger/options.go
@@ -165,5 +165,8 @@ type swaggerParameterBodies struct {
 	CreateTagOption api.CreateTagOption
 
 	// in:body
+	CreateAccessTokenOption api.CreateAccessTokenOption
+
+	// in:body
 	UserSettingsOptions api.UserSettingsOptions
 }

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -76,15 +76,10 @@ func CreateAccessToken(ctx *context.APIContext) {
 	//   description: username of user
 	//   type: string
 	//   required: true
-	// - name: accessToken
+	// - name: userCreateToken
 	//   in: body
 	//   schema:
-	//     type: object
-	//     required:
-	//       - name
-	//     properties:
-	//       name:
-	//         type: string
+	//     "$ref": "#/definitions/CreateAccessTokenOption"
 	// responses:
 	//   "201":
 	//     "$ref": "#/responses/AccessToken"

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -11917,18 +11917,10 @@
             "required": true
           },
           {
-            "name": "accessToken",
+            "name": "userCreateToken",
             "in": "body",
             "schema": {
-              "type": "object",
-              "required": [
-                "name"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/CreateAccessTokenOption"
             }
           }
         ],
@@ -12650,6 +12642,17 @@
         "url": {
           "type": "string",
           "x-go-name": "URL"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
+    "CreateAccessTokenOption": {
+      "description": "CreateAccessTokenOption options when create access token",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
@@ -17045,20 +17048,8 @@
   "responses": {
     "AccessToken": {
       "description": "AccessToken represents an API access token.",
-      "headers": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "name": {
-          "type": "string"
-        },
-        "sha1": {
-          "type": "string"
-        },
-        "token_last_eight": {
-          "type": "string"
-        }
+      "schema": {
+        "$ref": "#/definitions/AccessToken"
       }
     },
     "AccessTokenList": {


### PR DESCRIPTION
There is a subtle problem with the Swagger definition for AccessTokens which causes
autogeneration of APIs for these endpoints to fail.

This PR corrects these errors.

Ref: https://github.com/zeripath/java-gitea-api/issues/4

Signed-off-by: Andrew Thornton <art27@cantab.net>
