### PR TITLE
Swagger API: rename repoAddTopíc to repoAddTopic

### DIFF
--- a/routers/api/v1/repo/topic.go
+++ b/routers/api/v1/repo/topic.go
@@ -126,7 +126,7 @@ func UpdateTopics(ctx *context.APIContext) {
 
 // AddTopic adds a topic name to a repo
 func AddTopic(ctx *context.APIContext) {
-	// swagger:operation PUT /repos/{owner}/{repo}/topics/{topic} repository repoAddTopíc
+	// swagger:operation PUT /repos/{owner}/{repo}/topics/{topic} repository repoAddTopic
 	// ---
 	// summary: Add a topic to a repository
 	// produces:

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -16,7 +16,7 @@
     "description": "This documentation describes the Gitea API.",
     "title": "Gitea API.",
     "license": {
-      "name": "MIT"i
+      "name": "MIT"
       "url": "http://opensource.org/licenses/MIT"
     },
     "version": "{{AppVer | JSEscape | Safe}}"
@@ -17818,47 +17818,4 @@
       "description": "Sudo API request as the user provided as the key. Admin privileges are required.",
       "type": "apiKey",
       "name": "Sudo",
-      "in": "header"
-    },
-    "SudoParam": {
-      "description": "Sudo API request as the user provided as the key. Admin privileges are required.",
-      "type": "apiKey",
-      "name": "sudo",
-      "in": "query"
-    },
-    "TOTPHeader": {
-      "description": "Must be used in combination with BasicAuth if two-factor authentication is enabled.",
-      "type": "apiKey",
-      "name": "X-GITEA-OTP",
-      "in": "header"
-    },
-    "Token": {
-      "type": "apiKey",
-      "name": "token",
-      "in": "query"
-    }
-  },
-  "security": [
-    {
-      "BasicAuth": []
-    },
-    {
-      "Token": []
-    },
-    {
-      "AccessToken": []
-    },
-    {
-      "AuthorizationHeaderToken": []
-    },
-    {
-      "SudoParam": []
-    },
-    {
-      "SudoHeader": []
-    },
-    {
-      "TOTPHeader": []
-    }
-  ]
-}
+      "in": "header

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -16,7 +16,7 @@
     "description": "This documentation describes the Gitea API.",
     "title": "Gitea API.",
     "license": {
-      "name": "MIT"
+      "name": "MIT",
       "url": "http://opensource.org/licenses/MIT"
     },
     "version": "{{AppVer | JSEscape | Safe}}"
@@ -17818,4 +17818,47 @@
       "description": "Sudo API request as the user provided as the key. Admin privileges are required.",
       "type": "apiKey",
       "name": "Sudo",
-      "in": "header
+      "in": "header"
+    },
+    "SudoParam": {
+      "description": "Sudo API request as the user provided as the key. Admin privileges are required.",
+      "type": "apiKey",
+      "name": "sudo",
+      "in": "query"
+    },
+    "TOTPHeader": {
+      "description": "Must be used in combination with BasicAuth if two-factor authentication is enabled.",
+      "type": "apiKey",
+      "name": "X-GITEA-OTP",
+      "in": "header"
+    },
+    "Token": {
+      "type": "apiKey",
+      "name": "token",
+      "in": "query"
+    }
+  },
+  "security": [
+    {
+      "BasicAuth": []
+    },
+    {
+      "Token": []
+    },
+    {
+      "AccessToken": []
+    },
+    {
+      "AuthorizationHeaderToken": []
+    },
+    {
+      "SudoParam": []
+    },
+    {
+      "SudoHeader": []
+    },
+    {
+      "TOTPHeader": []
+    }
+  ]
+}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -16,7 +16,7 @@
     "description": "This documentation describes the Gitea API.",
     "title": "Gitea API.",
     "license": {
-      "name": "MIT",
+      "name": "MIT"i
       "url": "http://opensource.org/licenses/MIT"
     },
     "version": "{{AppVer | JSEscape | Safe}}"
@@ -9651,7 +9651,7 @@
           "repository"
         ],
         "summary": "Add a topic to a repository",
-        "operationId": "repoAddTopíc",
+        "operationId": "repoAddTopic",
         "parameters": [
           {
             "type": "string",


### PR DESCRIPTION
This changes the `operationId` of operation "repoAddTopic" to only contain 7-bit ascii, note "i" instead of "í"