### PR TITLE
Fix 500 on first wiki page

### DIFF
--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -90,6 +90,9 @@ func prepareWikiFileName(gitRepo *git.Repository, wikiName string) (bool, string
 	// Look for both files
 	filesInIndex, err := gitRepo.LsTree("master", unescaped, escaped)
 	if err != nil {
+		if strings.Contains(err.Error(), "Not a valid object name master") {
+			return false, escaped, nil
+		}
 		log.Error("%v", err)
 		return false, escaped, err
 	}

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -5,11 +5,14 @@
 package wiki
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -260,4 +263,29 @@ func TestPrepareWikiFileName(t *testing.T) {
 			assert.Equal(t, tt.wikiPath, newWikiPath)
 		})
 	}
+}
+
+func TestPrepareWikiFileName_FirstPage(t *testing.T) {
+	models.PrepareTestEnv(t)
+
+	// Now create a temporaryDirectory
+	tmpDir, err := ioutil.TempDir("", "empty-wiki")
+	assert.NoError(t, err)
+	defer func() {
+		if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+			_ = util.RemoveAll(tmpDir)
+		}
+	}()
+
+	err = git.InitRepository(tmpDir, true)
+	assert.NoError(t, err)
+
+	gitRepo, err := git.OpenRepository(tmpDir)
+	defer gitRepo.Close()
+	assert.NoError(t, err)
+
+	existence, newWikiPath, err := prepareWikiFileName(gitRepo, "Home")
+	assert.False(t, existence)
+	assert.NoError(t, err)
+	assert.Equal(t, "Home.md", newWikiPath)
 }

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/util"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
There is a mistake in #16319 and #16487 which means that the first time
a wiki page is created a 500 is reported because the `master` branch is
not in existence in that wiki yet.

This PR simply checks for this error and returns not found.

Fix #16584
Fix #16615

Signed-off-by: Andrew Thornton <art27@cantab.net>
