### PR TITLE
Use node:16.5 for frontend instead of node:16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,7 +71,7 @@ steps:
     depends_on: [lint-backend]
 
   - name: test-frontend
-    image: node:16
+    image: node:16.5
     commands:
       - make test-frontend
     depends_on: [lint-frontend]

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,12 +15,12 @@ trigger:
 steps:
   - name: deps-frontend
     pull: always
-    image: node:16
+    image: node:16.5
     commands:
       - make node_modules
 
   - name: lint-frontend
-    image: node:16
+    image: node:16.5
     commands:
       - make lint-frontend
     depends_on: [deps-frontend]
@@ -58,7 +58,7 @@ steps:
       TAGS: bindata gogit sqlite sqlite_unlock_notify
 
   - name: checks-frontend
-    image: node:16
+    image: node:16.5
     commands:
       - make checks-frontend
     depends_on: [deps-frontend]
@@ -77,7 +77,7 @@ steps:
     depends_on: [lint-frontend]
 
   - name: build-frontend
-    image: node:16
+    image: node:16.5
     commands:
       - make frontend
     depends_on: [test-frontend]

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ watch-backend: go-check
 	air -c .air.conf
 
 .PHONY: test
-test: test-backend
+test: test-frontend test-backend
 
 .PHONY: test-backend
 test-backend:

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ watch-backend: go-check
 	air -c .air.conf
 
 .PHONY: test
-test: test-frontend test-backend
+test: test-backend
 
 .PHONY: test-backend
 test-backend:


### PR DESCRIPTION
Webpack does not appear to work on the latest node 16.6.0 and fails with an inscrutable
message.

I have been unable to work out what the problem is. This PR forcibly uses node 16.5 everywhere instead of node 16.

Close #16592

Signed-off-by: Andrew Thornton <art27@cantab.net>
