### PR TITLE
Use node 14 instead of node 16 as node 14 is LTS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,12 +15,12 @@ trigger:
 steps:
   - name: deps-frontend
     pull: always
-    image: node:16
+    image: node:14
     commands:
       - make node_modules
 
   - name: lint-frontend
-    image: node:16
+    image: node:14
     commands:
       - make lint-frontend
     depends_on: [deps-frontend]
@@ -58,7 +58,7 @@ steps:
       TAGS: bindata gogit sqlite sqlite_unlock_notify
 
   - name: checks-frontend
-    image: node:16
+    image: node:14
     commands:
       - make checks-frontend
     depends_on: [deps-frontend]
@@ -71,13 +71,13 @@ steps:
     depends_on: [lint-backend]
 
   - name: test-frontend
-    image: node:16
+    image: node:14
     commands:
       - make test-frontend
     depends_on: [lint-frontend]
 
   - name: build-frontend
-    image: node:16
+    image: node:14
     commands:
       - make frontend
     depends_on: [test-frontend]


### PR DESCRIPTION
The recent change in node 16 has caused webpack-cli to break and thence our CI. Ostensibly this has happened because node 16 is not a LTS release.

This PR changes to use Node 14 which is the LTS for node instead of 16.

Closes #16591

Signed-off-by: Andrew Thornton <art27@cantab.net>
