### PR TITLE
Switch back to node 16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,12 +15,12 @@ trigger:
 steps:
   - name: deps-frontend
     pull: always
-    image: node:14
+    image: node:16
     commands:
       - make node_modules
 
   - name: lint-frontend
-    image: node:14
+    image: node:16
     commands:
       - make lint-frontend
     depends_on: [deps-frontend]
@@ -58,7 +58,7 @@ steps:
       TAGS: bindata gogit sqlite sqlite_unlock_notify
 
   - name: checks-frontend
-    image: node:14
+    image: node:16
     commands:
       - make checks-frontend
     depends_on: [deps-frontend]
@@ -71,13 +71,13 @@ steps:
     depends_on: [lint-backend]
 
   - name: test-frontend
-    image: node:14
+    image: node:16
     commands:
       - make test-frontend
     depends_on: [lint-frontend]
 
   - name: build-frontend
-    image: node:14
+    image: node:16
     commands:
       - make frontend
     depends_on: [test-frontend]
@@ -514,7 +514,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.16.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
+      - curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
@@ -610,7 +610,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.16.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
+      - curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:


### PR DESCRIPTION
Now that node 16.6.1 is out we can (if desired) switch back to node 16.

This PR proposes changing drone to run node:16

Signed-off-by: Andrew Thornton <art27@cantab.net>
