### PR TITLE
WIP: Set COMPATIBILITY_LEVEL in MSSQL testing

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -235,6 +235,10 @@ func initIntegrationTest() {
 		if _, err := db.Exec(fmt.Sprintf("If(db_id(N'%s') IS NULL) BEGIN CREATE DATABASE %s; END;", setting.Database.Name, setting.Database.Name)); err != nil {
 			log.Fatal("db.Exec: %v", err)
 		}
+		// set COMPATIBILITY_LEVEL to the lowest we will support
+		if _, err := db.Exec(fmt.Sprintf("BEGIN ALTER DATABASE %s SET COMPATIBILITY_LEVEL = 100; END;", setting.Database.Name)); err != nil {
+			log.Fatal("db.Exec: %v", err)
+		}
 		defer db.Close()
 	}
 	routers.GlobalInit(graceful.GetManager().HammerContext())

--- a/models/migrations/migrations_test.go
+++ b/models/migrations/migrations_test.go
@@ -187,6 +187,10 @@ func deleteDB() error {
 		if _, err = db.Exec(fmt.Sprintf("CREATE DATABASE [%s]", setting.Database.Name)); err != nil {
 			return err
 		}
+		// set COMPATIBILITY_LEVEL to the lowest we will support
+		if _, err := db.Exec(fmt.Sprintf("BEGIN ALTER DATABASE %s SET COMPATIBILITY_LEVEL = 100; END;", setting.Database.Name)); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR sets the COMPATIBILITY_LEVEL to 100 for the integrations tests on MSSQL.

Signed-off-by: Andrew Thornton <art27@cantab.net>
