### PR TITLE
Prevent 500 on draft releases without tag (#16634)

### DIFF
--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -82,7 +82,9 @@
 									<a class="mono" href="{{$.RepoLink}}/src/commit/{{.Sha1}}" rel="nofollow">{{svg "octicon-git-commit" 16 "mr-2"}}{{ShortSha .Sha1}}</a>
 								</span>
 							{{end}}
-							{{template "repo/branch_dropdown" dict "root" $ "release" .}}
+							{{if .Sha1 }}
+								{{template "repo/branch_dropdown" dict "root" $ "release" .}}
+							{{end}}
 						{{end}}
 					</div>
 					<div class="ui twelve wide column detail">


### PR DESCRIPTION
It is possible to create draft releases prior to creating a tag. This will cause a
500 on the releases page due to compare page failing.

This PR only shows the compare button if there is a SHA1 present.

Fix #16610

Signed-off-by: Andrew Thornton <art27@cantab.net>

Backport of #16634