### PR TITLE
Change the implementation of the go-git version of GetNote in response to a non existent commit (#16658)

### DIFF
--- a/modules/git/notes_gogit.go
+++ b/modules/git/notes_gogit.go
@@ -36,6 +36,9 @@ func GetNote(ctx context.Context, repo *Repository, commitID string, note *Note)
 			remainingCommitID = remainingCommitID[2:]
 		}
 		if err != nil {
+			if err == object.ErrDirectoryNotFound {
+				return ErrNotExist{ID: remainingCommitID, RelPath: path}
+			}
 			return err
 		}
 	}

--- a/modules/git/notes_test.go
+++ b/modules/git/notes_test.go
@@ -39,3 +39,15 @@ func TestGetNestedNotes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("Note 1"), note.Message)
 }
+
+func TestGetNonExistentNotes(t *testing.T) {
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+	bareRepo1, err := OpenRepository(bareRepo1Path)
+	assert.NoError(t, err)
+	defer bareRepo1.Close()
+
+	note := Note{}
+	err = GetNote(context.Background(), bareRepo1, "non_existent_sha", &note)
+	assert.Error(t, err)
+	assert.IsType(t, ErrNotExist{}, err)
+}


### PR DESCRIPTION
Backport #16658

Whilst working on the issue #15373, I discovered that the implementation of the gogit version of git notes differs from the no-gogit version when a non existent commit ID is passed to the function GitNote.

I brought this up on Discord and @zeripath suggested that I provide a fix for this issue in a separate PR so that it can be backported to version 1.15.