### PR TITLE
If PatchURL is empty, skip pull patch download when migrating (Partial #16356)

### DIFF
--- a/modules/migrations/gitea_uploader.go
+++ b/modules/migrations/gitea_uploader.go
@@ -555,6 +555,9 @@ func (g *GiteaLocalUploader) newPullRequest(pr *base.PullRequest) (*models.PullR
 
 	// download patch file
 	err := func() error {
+		if pr.PatchURL == "" {
+			return nil
+		}
 		// pr.PatchURL maybe a local file
 		ret, err := uri.Open(pr.PatchURL)
 		if err != nil {


### PR DESCRIPTION
Partial backport #16356

Whilst looking at adding migration support for onedev it has become apparent that gitea would attempt to pull patches on other migration targets even if that PatchURL was empty.