### PR TITLE
Fix NPE in fuzzer (#16680)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -778,7 +778,7 @@ func fullIssuePatternProcessor(ctx *RenderContext, node *html.Node) {
 
 		// extract repo and org name from matched link like
 		// http://localhost:3000/gituser/myrepo/issues/1
-		linkParts := strings.Split(path.Clean(link), "/")
+		linkParts := strings.Split(link, "/")
 		matchOrg := linkParts[len(linkParts)-4]
 		matchRepo := linkParts[len(linkParts)-3]
 

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -5,6 +5,7 @@
 package markup_test
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -525,4 +526,19 @@ func BenchmarkEmojiPostprocess(b *testing.B) {
 		}, strings.NewReader(data), &res)
 		assert.NoError(b, err)
 	}
+}
+
+func TestFuzz(t *testing.T) {
+	s := "t/l/issues/8#/../../a"
+	renderContext := RenderContext{
+		URLPrefix: "https://example.com/go-gitea/gitea",
+		Metas: map[string]string{
+			"user": "go-gitea",
+			"repo": "gitea",
+		},
+	}
+
+	err := PostProcess(&renderContext, strings.NewReader(s), io.Discard)
+
+	assert.NoError(t, err)
 }

--- a/tools/fuzz.go
+++ b/tools/fuzz.go
@@ -12,6 +12,7 @@ import (
 
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/markdown"
+	"code.gitea.io/gitea/modules/setting"
 )
 
 // Contains fuzzing functions executed by
@@ -32,6 +33,7 @@ var (
 )
 
 func FuzzMarkdownRenderRaw(data []byte) int {
+	setting.AppURL = "http://localhost:3000/"
 	err := markdown.RenderRaw(&renderContext, bytes.NewReader(data), io.Discard)
 	if err != nil {
 		return 0
@@ -40,6 +42,7 @@ func FuzzMarkdownRenderRaw(data []byte) int {
 }
 
 func FuzzMarkupPostProcess(data []byte) int {
+	setting.AppURL = "http://localhost:3000/"
 	err := markup.PostProcess(&renderContext, bytes.NewReader(data), io.Discard)
 	if err != nil {
 		return 0


### PR DESCRIPTION
Backport #16680

The fuzzer found an issue with the issue pattern processor where there is a spurious
path.Clean which does not need to be there. This PR also sets the default AppURL for
the fuzzer too.

Signed-off-by: Andrew Thornton <art27@cantab.net>