### PR TITLE
Fix dump and restore respository

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1497,6 +1497,11 @@ func DeleteRepository(doer *User, uid, repoID int64) error {
 		releaseAttachments = append(releaseAttachments, attachments[i].RelativePath())
 	}
 
+	if _, err = sess.In("release_id", builder.Select("id").From("release").Where(builder.Eq{"release.repo_id": repoID})).
+		Delete(&Attachment{}); err != nil {
+		return err
+	}
+
 	if _, err := sess.Exec("UPDATE `user` SET num_stars=num_stars-1 WHERE id IN (SELECT `uid` FROM `star` WHERE repo_id = ?)", repo.ID); err != nil {
 		return err
 	}

--- a/models/repo.go
+++ b/models/repo.go
@@ -1497,7 +1497,7 @@ func DeleteRepository(doer *User, uid, repoID int64) error {
 		releaseAttachments = append(releaseAttachments, attachments[i].RelativePath())
 	}
 
-	if _, err = sess.In("release_id", builder.Select("id").From("release").Where(builder.Eq{"release.repo_id": repoID})).
+	if _, err = sess.In("release_id", builder.Select("id").From("`release`").Where(builder.Eq{"`release`.repo_id": repoID})).
 		Delete(&Attachment{}); err != nil {
 		return err
 	}

--- a/modules/migrations/dump.go
+++ b/modules/migrations/dump.go
@@ -482,8 +482,9 @@ func (g *RepositoryDumper) CreatePullRequests(prs ...*base.PullRequest) error {
 					if err != nil {
 						log.Error("Fetch branch from %s failed: %v", pr.Head.CloneURL, err)
 					} else {
+						// a new branch name with <original_owner_name/original_branchname> will be created to as new head branch
 						ref := path.Join(pr.Head.OwnerName, pr.Head.Ref)
-						headBranch := filepath.Join(g.gitPath(), "refs", "heads", pr.Head.OwnerName, pr.Head.Ref)
+						headBranch := filepath.Join(g.gitPath(), "refs", "heads", ref)
 						if err := os.MkdirAll(filepath.Dir(headBranch), os.ModePerm); err != nil {
 							return err
 						}
@@ -501,7 +502,7 @@ func (g *RepositoryDumper) CreatePullRequests(prs ...*base.PullRequest) error {
 				}
 			}
 		}
-		// store all information into local git repository
+		// whatever it's a forked repo PR, we have to change head info as the same as the base info
 		pr.Head.OwnerName = pr.Base.OwnerName
 		pr.Head.RepoName = pr.Base.RepoName
 	}

--- a/modules/migrations/dump.go
+++ b/modules/migrations/dump.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -481,6 +482,7 @@ func (g *RepositoryDumper) CreatePullRequests(prs ...*base.PullRequest) error {
 					if err != nil {
 						log.Error("Fetch branch from %s failed: %v", pr.Head.CloneURL, err)
 					} else {
+						ref := path.Join(pr.Head.OwnerName, pr.Head.Ref)
 						headBranch := filepath.Join(g.gitPath(), "refs", "heads", pr.Head.OwnerName, pr.Head.Ref)
 						if err := os.MkdirAll(filepath.Dir(headBranch), os.ModePerm); err != nil {
 							return err
@@ -494,10 +496,14 @@ func (g *RepositoryDumper) CreatePullRequests(prs ...*base.PullRequest) error {
 						if err != nil {
 							return err
 						}
+						pr.Head.Ref = ref
 					}
 				}
 			}
 		}
+		// store all information into local git repository
+		pr.Head.OwnerName = pr.Base.OwnerName
+		pr.Head.RepoName = pr.Base.RepoName
 	}
 
 	var err error

--- a/modules/migrations/gitea_uploader.go
+++ b/modules/migrations/gitea_uploader.go
@@ -278,7 +278,7 @@ func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 		if !release.Draft {
 			commit, err := g.gitRepo.GetTagCommit(rel.TagName)
 			if err != nil {
-				return fmt.Errorf("GetCommit: %v", err)
+				return fmt.Errorf("GetTagCommit[%v]: %v", rel.TagName, err)
 			}
 			rel.NumCommits, err = commit.CommitsCount()
 			if err != nil {

--- a/modules/private/restore_repo.go
+++ b/modules/private/restore_repo.go
@@ -54,6 +54,7 @@ func RestoreRepo(ctx context.Context, repoDir, ownerName, repoName string, units
 		if err := json.Unmarshal(body, &ret); err != nil {
 			return http.StatusInternalServerError, fmt.Sprintf("Response body Unmarshal error: %v", err.Error())
 		}
+		return http.StatusInternalServerError, ret.Err
 	}
 
 	return http.StatusOK, fmt.Sprintf("Restore repo %s/%s successfully", ownerName, repoName)

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -126,7 +126,7 @@ func getMergeCommit(pr *models.PullRequest) (*git.Commit, error) {
 
 	commit, err := gitRepo.GetCommit(mergeCommit[:40])
 	if err != nil {
-		return nil, fmt.Errorf("GetCommit: %v", err)
+		return nil, fmt.Errorf("GetMergeCommit[%v]: %v", mergeCommit[:40], err)
 	}
 
 	return commit, nil

--- a/services/release/release.go
+++ b/services/release/release.go
@@ -44,7 +44,7 @@ func createTag(gitRepo *git.Repository, rel *models.Release, msg string) (bool, 
 
 			commit, err := gitRepo.GetCommit(rel.Target)
 			if err != nil {
-				return false, fmt.Errorf("GetCommit: %v", err)
+				return false, fmt.Errorf("createTag::GetCommit[%v]: %v", rel.Target, err)
 			}
 
 			// Trim '--' prefix to prevent command line argument vulnerability.


### PR DESCRIPTION
This PR fixed a bug when dumping repositories' PRs which were created from the forked repositories.

- [x] When migrating, all PRs from forked repositories at original site should be as non-forked PR. And Gitea will create a local branch as head branch of the PR. But we haven't change it correctly before.
- [x] Fix missing delete release attachments database records when deleting repositories