### PR TITLE
Restore functionality for pushing non-standard refs (Partial #16705)

### DIFF
--- a/routers/private/hook.go
+++ b/routers/private/hook.go
@@ -392,11 +392,6 @@ func HookPreReceive(ctx *gitea_context.PrivateContext) {
 				})
 				return
 			}
-		} else {
-			log.Error("Unexpected ref: %s", refFullName)
-			ctx.JSON(http.StatusInternalServerError, private.Response{
-				Err: fmt.Sprintf("Unexpected ref: %s", refFullName),
-			})
 		}
 	}
 


### PR DESCRIPTION
Partial Backport #16705

There was an inadvertent breaking change in #15629 meaning that notes refs and other
git extension refs will be automatically rejected.

This PR removes this incorrect forced rejection of non-standard refs.

Fix #16688

Signed-off-by: Andrew Thornton <art27@cantab.net>
