### PR TITLE
Fix Github OAuth provider configuration

### DIFF
--- a/services/auth/source/oauth2/providers_custom.go
+++ b/services/auth/source/oauth2/providers_custom.go
@@ -55,7 +55,7 @@ var _ (GothProvider) = &CustomProvider{}
 func init() {
 	RegisterGothProvider(NewCustomProvider(
 		"github", "GitHub", &CustomURLSettings{
-			TokenURL:   availableAttribute(gitea.TokenURL),
+			TokenURL:   availableAttribute(github.TokenURL),
 			AuthURL:    availableAttribute(github.AuthURL),
 			ProfileURL: availableAttribute(github.ProfileURL),
 			EmailURL:   availableAttribute(github.EmailURL),


### PR DESCRIPTION
There was a regression in #16544 whereby the default token url
for github was changed to the gitea one.

This PR restores this.

Signed-off-by: Andrew Thornton <art27@cantab.net>
