### PR TITLE
Fix migration svg color

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3161,6 +3161,7 @@ td.blob-excerpt {
   transition: all .1s ease-in-out;
   box-shadow: none !important;
   border: 1px solid var(--color-secondary);
+  color: black;
 }
 
 .repository.migrate .card:hover {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3161,7 +3161,7 @@ td.blob-excerpt {
   transition: all .1s ease-in-out;
   box-shadow: none !important;
   border: 1px solid var(--color-secondary);
-  color: black;
+  color: var(--color-text);
 }
 
 .repository.migrate .card:hover {


### PR DESCRIPTION
The SVGs on the migration page inherit the current text color which created wrong icons.

Before:
![grafik](https://user-images.githubusercontent.com/1666336/129796007-323d8cc6-f5c5-440b-aa4f-477f86fc7ce6.png)

After:
![grafik](https://user-images.githubusercontent.com/1666336/129796028-e54a108d-6abb-4ae2-b7a3-02a10e2fafbf.png)

Possible alternative: `color: unset;`
@silverwind I don't know what is better in this case. `unset` works nice with themes but is still the wrong color.