### PR TITLE
Do not use thin scrollbars on Firefox

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -175,7 +175,6 @@ details summary > * {
 }
 
 * {
-  scrollbar-width: thin;
   scrollbar-color: var(--color-primary) transparent;
   caret-color: var(--color-caret);
 }


### PR DESCRIPTION
Fixes #16737

In #7269, thin scrollbars were added in Arc Green theme. It got moved in base theme in #13361.

This PR removes the use of thin scrollbars which causes an accessibility issue. The scrollbars become too thin to be dragged.
