### PR TITLE
Return nil proxy function if proxy not enabled

### DIFF
--- a/modules/proxy/proxy.go
+++ b/modules/proxy/proxy.go
@@ -56,7 +56,9 @@ func Match(u string) bool {
 // Proxy returns the system proxy
 func Proxy() func(req *http.Request) (*url.URL, error) {
 	if !setting.Proxy.Enabled {
-		return nil
+		return func(req *http.Request) (*url.URL, error) {
+			return nil, nil
+		}
 	}
 	if setting.Proxy.ProxyURL == "" {
 		return http.ProxyFromEnvironment


### PR DESCRIPTION
Unfortunately #16704 contains a bug whereby if the proxy is not enabled all requests fail due to a panic.

This PR sets the proxy function to return a nil function if the proxy is not enabled. 

Signed-off-by: Andrew Thornton <art27@cantab.net>
