### PR TITLE
Keep attachments on tasklist update

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -2148,7 +2148,7 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	if ctx.FormString("action") == "ignoreAttachments" {
+	if ctx.FormBool("ignore_attachments") {
 		return
 	}
 

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -2148,7 +2148,7 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	if ctx.FormString("action") == "tasklist" {
+	if ctx.FormString("action") == "ignoreAttachments" {
 		return
 	}
 

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -2127,13 +2127,6 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	if comment.Type == models.CommentTypeComment {
-		if err := comment.LoadAttachments(); err != nil {
-			ctx.ServerError("LoadAttachments", err)
-			return
-		}
-	}
-
 	if !ctx.IsSigned || (ctx.User.ID != comment.PosterID && !ctx.Repo.CanWriteIssuesOrPulls(comment.Issue.IsPull)) {
 		ctx.Error(http.StatusForbidden)
 		return
@@ -2153,6 +2146,17 @@ func UpdateCommentContent(ctx *context.Context) {
 	if err = comment_service.UpdateComment(comment, ctx.User, oldContent); err != nil {
 		ctx.ServerError("UpdateComment", err)
 		return
+	}
+
+	if ctx.FormString("action") == "tasklist" {
+		return
+	}
+
+	if comment.Type == models.CommentTypeComment {
+		if err := comment.LoadAttachments(); err != nil {
+			ctx.ServerError("LoadAttachments", err)
+			return
+		}
 	}
 
 	if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {

--- a/web_src/js/markup/tasklist.js
+++ b/web_src/js/markup/tasklist.js
@@ -46,7 +46,7 @@ export function initMarkupTasklist() {
           const {updateUrl, context} = editContentZone.dataset;
 
           await $.post(updateUrl, {
-            action: 'tasklist',
+            action: 'ignoreAttachments',
             _csrf: window.config.csrf,
             content: newContent,
             context

--- a/web_src/js/markup/tasklist.js
+++ b/web_src/js/markup/tasklist.js
@@ -43,20 +43,13 @@ export function initMarkupTasklist() {
 
         try {
           const editContentZone = container.querySelector('.edit-content-zone');
-          const {updateUrl, context, attachmentUrl} = editContentZone.dataset;
-
-          const resp = await fetch(attachmentUrl);
-          const attachments = await resp.json();
-          const files = [];
-          for (const attachment of attachments) {
-            files.push(attachment.uuid);
-          }
+          const {updateUrl, context} = editContentZone.dataset;
 
           await $.post(updateUrl, {
+            action: 'tasklist',
             _csrf: window.config.csrf,
             content: newContent,
-            context,
-            files
+            context
           });
 
           rawContent.textContent = newContent;

--- a/web_src/js/markup/tasklist.js
+++ b/web_src/js/markup/tasklist.js
@@ -43,12 +43,20 @@ export function initMarkupTasklist() {
 
         try {
           const editContentZone = container.querySelector('.edit-content-zone');
-          const {updateUrl, context} = editContentZone.dataset;
+          const {updateUrl, context, attachmentUrl} = editContentZone.dataset;
+
+          const resp = await fetch(attachmentUrl);
+          const attachments = await resp.json();
+          const files = [];
+          for (const attachment of attachments) {
+            files.push(attachment.uuid);
+          }
 
           await $.post(updateUrl, {
             _csrf: window.config.csrf,
             content: newContent,
             context,
+            files
           });
 
           rawContent.textContent = newContent;

--- a/web_src/js/markup/tasklist.js
+++ b/web_src/js/markup/tasklist.js
@@ -46,7 +46,7 @@ export function initMarkupTasklist() {
           const {updateUrl, context} = editContentZone.dataset;
 
           await $.post(updateUrl, {
-            action: 'ignoreAttachments',
+            ignore_attachments: true,
             _csrf: window.config.csrf,
             content: newContent,
             context


### PR DESCRIPTION
fixes #16746

An alternative (better?) solution may be an `ignoreAttachments` parameter.
```js
await $.post(updateUrl, {
  _csrf: window.config.csrf,
  content: newContent,
  context,
  ignoreAttachments: true
});
```
```go
if !ctx.FormBool("ignoreAttachments") {
	if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {
		ctx.ServerError("UpdateAttachments", err)
		return
	}
}
```