### PR TITLE
Keep attachments on tasklist update (#16750)

### DIFF
--- a/web_src/js/markup/tasklist.js
+++ b/web_src/js/markup/tasklist.js
@@ -46,9 +46,10 @@ export function initMarkupTasklist() {
           const {updateUrl, context} = editContentZone.dataset;
 
           await $.post(updateUrl, {
+            ignore_attachments: true,
             _csrf: window.config.csrf,
             content: newContent,
-            context,
+            context
           });
 
           rawContent.textContent = newContent;


### PR DESCRIPTION
Backport #16750
Backport #16762 

* Send attachments too.

* Use tasklist flag.

* use action="ignoreAttachments" instead of "tasklist"

* Use boolean parameter.

Co-authored-by: zeripath <art27@cantab.net>