### PR TITLE
Keep attachments on tasklist update of issue and comment content

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1727,9 +1727,12 @@ func UpdateIssueContent(ctx *context.Context) {
 		return
 	}
 
-	if err := updateAttachments(issue, ctx.FormStrings("files[]")); err != nil {
-		ctx.ServerError("UpdateAttachments", err)
-		return
+	// when update the request doesn't intend to update attachments (eg: change checkbox state), ignore attachment updates
+	if !ctx.FormBool("ignore_attachments") {
+		if err := updateAttachments(issue, ctx.FormStrings("files[]")); err != nil {
+			ctx.ServerError("UpdateAttachments", err)
+			return
+		}
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{
@@ -2148,10 +2151,6 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	if ctx.FormBool("ignore_attachments") {
-		return
-	}
-
 	if comment.Type == models.CommentTypeComment {
 		if err := comment.LoadAttachments(); err != nil {
 			ctx.ServerError("LoadAttachments", err)
@@ -2159,9 +2158,12 @@ func UpdateCommentContent(ctx *context.Context) {
 		}
 	}
 
-	if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {
-		ctx.ServerError("UpdateAttachments", err)
-		return
+	// when the update request doesn't intend to update attachments (eg: change checkbox state), ignore attachment updates
+	if !ctx.FormBool("ignore_attachments") {
+		if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {
+			ctx.ServerError("UpdateAttachments", err)
+			return
+		}
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{


### PR DESCRIPTION
Previous PR about "Keep attachments on tasklist update": https://github.com/go-gitea/gitea/pull/16750 is incomplete. Related issue: https://github.com/go-gitea/gitea/issues/16746

The PR #16750 only patches the update of comment, but not the update of the issue, which make the bug still exist.


And I think the new logic is more clear, we should not just `return` when `ignore_attachments=true`, which will bypass all remaining logic, may lead to problem in the future.

