### PR TITLE
Fix Keep attachments on tasklist update (#16750)

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1727,9 +1727,11 @@ func UpdateIssueContent(ctx *context.Context) {
 		return
 	}
 
-	if err := updateAttachments(issue, ctx.FormStrings("files[]")); err != nil {
-		ctx.ServerError("UpdateAttachments", err)
-		return
+	if !ctx.FormBool("ignore_attachments") {
+		if err := updateAttachments(issue, ctx.FormStrings("files[]")); err != nil {
+			ctx.ServerError("UpdateAttachments", err)
+			return
+		}
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{
@@ -2148,10 +2150,6 @@ func UpdateCommentContent(ctx *context.Context) {
 		return
 	}
 
-	if ctx.FormBool("ignore_attachments") {
-		return
-	}
-
 	if comment.Type == models.CommentTypeComment {
 		if err := comment.LoadAttachments(); err != nil {
 			ctx.ServerError("LoadAttachments", err)
@@ -2159,9 +2157,11 @@ func UpdateCommentContent(ctx *context.Context) {
 		}
 	}
 
-	if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {
-		ctx.ServerError("UpdateAttachments", err)
-		return
+	if !ctx.FormBool("ignore_attachments") {
+		if err := updateAttachments(comment, ctx.FormStrings("files[]")); err != nil {
+			ctx.ServerError("UpdateAttachments", err)
+			return
+		}
 	}
 
 	content, err := markdown.RenderString(&markup.RenderContext{


### PR DESCRIPTION
The old fix only worked for comments. I reverted the skipping of the json response.