### PR TITLE
go version should be at least 1.16 because of `io.Discard`(Since Go 1.16, Feb 2021)…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ or if sqlite support is required:
 
 The `build` target is split into two sub-targets:
 
-- `make backend` which requires [Go 1.13](https://golang.org/dl/) or greater.
+- `make backend` which requires [Go 1.16](https://golang.org/dl/) or greater.
 - `make frontend` which requires [Node.js 12.17](https://nodejs.org/en/download/) or greater and Internet connectivity to download npm dependencies.
 
 When building from the official source tarballs which include pre-built frontend files, the `frontend` target will not be triggered, making it possible to build without Node.js and Internet connectivity.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.gitea.io/gitea
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.78.0 // indirect


### PR DESCRIPTION
Currently the go version is `1.14` in `go.mod`, actually there are many usage of `io.Discard`(Since Go 1.16, Feb 2021) in code

![image](https://user-images.githubusercontent.com/2114189/130318422-e82e15de-f42e-442a-b3cb-6917098bf14a.png)

So go version should be at least 1.16 now. And `README.md` is also updated.
