### PR TITLE
Ensure that template compilation panics are sent to the logs

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -86,6 +86,11 @@ func runWeb(ctx *cli.Context) error {
 		_ = log.DelLogger("console")
 		log.NewLogger(0, "console", "console", fmt.Sprintf(`{"level": "fatal", "colorize": %t, "stacktraceLevel": "none"}`, log.CanColorStdout))
 	}
+	defer func() {
+		if panicked := recover(); panicked != nil {
+			log.Fatal("PANIC: %v\n%s", panicked, string(log.Stack(2)))
+		}
+	}()
 
 	managerCtx, cancel := context.WithCancel(context.Background())
 	graceful.InitManager(managerCtx)


### PR DESCRIPTION
Although panics within the rendering pipeline are caught and dealt with,
panics that occur before that starts are unprotected and will kill Gitea
without being sent to the logs.

This PR adds a basic recovery handler to catch panics that occur after
the logger is initialised and ensure that they're sent to the logger.

Related #16784

Signed-off-by: Andrew Thornton <art27@cantab.net>
