### PR TITLE
Add missing return to handleSettingRemoteAddrError (#16794)

### DIFF
--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -742,6 +742,7 @@ func handleSettingRemoteAddrError(ctx *context.Context, err error, form *forms.R
 		default:
 			ctx.ServerError("Unknown error", err)
 		}
+		return
 	}
 	ctx.RenderWithErr(ctx.Tr("repo.mirror_address_url_invalid"), tplSettingsOptions, form)
 }


### PR DESCRIPTION
Backport #16794

There is a missing return in handleSettingRemoteAddrError which means
that the error page for repo settings is duplicately rendered.

Fix #16771

Signed-off-by: Andrew Thornton <art27@cantab.net>
