### PR TITLE
Fix branch pagination error

### DIFF
--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -217,7 +217,7 @@ func loadBranches(ctx *context.Context, skip, limit int) ([]*Branch, int) {
 		branches = append(branches, deletedBranches...)
 	}
 
-	return branches, totalNumOfBranches - 1
+	return branches, totalNumOfBranches
 }
 
 func loadOneBranch(ctx *context.Context, rawBranch *git.Branch, protectedBranches []*models.ProtectedBranch,


### PR DESCRIPTION
Fix #16801

Even if default branch is removed from the current page, but the total branches number should be still kept. So that the pagination calculation will be correct. 