### PR TITLE
Report the correct number of pushes on the feeds

### DIFF
--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -99,7 +99,7 @@
 										</span>
 									</li>
 								{{end}}
-								{{if and (gt (len $push.Commits) 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.i18n.Tr "action.compare_commits" (len $push.Commits)}} »</a></li>{{end}}
+								{{if and (gt (len $push.Commits) 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.i18n.Tr "action.compare_commits" $push.Len}} »</a></li>{{end}}
 							</ul>
 						</div>
 					{{else if eq .GetOpType 6}}


### PR DESCRIPTION
Since the number of commits in the Action table has been limited to 5
the number of commits reported on the feeds page is now incorrectly also
limited to 5. The correct number is available as the Len and this PR
changes this to report this.

Fix #16804

Signed-off-by: Andrew Thornton <art27@cantab.net>
