### PR TITLE
Prevent NPE on empty commit

### DIFF
--- a/modules/git/log_name_status.go
+++ b/modules/git/log_name_status.go
@@ -167,6 +167,9 @@ func (g *LogNameStatusRepoParser) Next(treepath string, paths2ids map[string]int
 				return nil, err
 			}
 		}
+		if len(g.next) == 0 {
+			return &ret, nil
+		}
 		if g.next[0] == '\x00' {
 			g.buffull = false
 			g.next, err = g.rd.ReadSlice('\x00')


### PR DESCRIPTION
Handle completely empty commit as the first commit to a repository.

Fix #16668

Signed-off-by: Andrew Thornton <art27@cantab.net>
