### PR TITLE
Add primary_key to issue_index

### DIFF
--- a/models/index.go
+++ b/models/index.go
@@ -14,7 +14,7 @@ import (
 // ResourceIndex represents a resource index which could be used as issue/release and others
 // We can create different tables i.e. issue_index, release_index and etc.
 type ResourceIndex struct {
-	GroupID  int64 `xorm:"unique"`
+	GroupID  int64 `xorm:"pk"`
 	MaxIndex int64 `xorm:"index"`
 }
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -336,6 +336,8 @@ var migrations = []Migration{
 	NewMigration("Add agit flow pull request support", addAgitFlowPullRequest),
 	// v191 -> v192
 	NewMigration("Alter issue/comment table TEXT fields to LONGTEXT", alterIssueAndCommentTextFieldsToLongText),
+	// v192 -> v193
+	NewMigration("RecreateIssueResourceIndexTable to have a primary key instead of an unique index", recreateIssueResourceIndexTable),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v182.go
+++ b/models/migrations/v182.go
@@ -10,8 +10,8 @@ import (
 
 func addIssueResourceIndexTable(x *xorm.Engine) error {
 	type ResourceIndex struct {
-		GroupID  int64 `xorm:"index unique(s)"`
-		MaxIndex int64 `xorm:"index unique(s)"`
+		GroupID  int64 `xorm:"pk"`
+		MaxIndex int64 `xorm:"index"`
 	}
 
 	sess := x.NewSession()

--- a/models/migrations/v182_test.go
+++ b/models/migrations/v182_test.go
@@ -33,8 +33,8 @@ func Test_addIssueResourceIndexTable(t *testing.T) {
 	}
 
 	type ResourceIndex struct {
-		GroupID  int64 `xorm:"index unique(s)"`
-		MaxIndex int64 `xorm:"index unique(s)"`
+		GroupID  int64 `xorm:"pk"`
+		MaxIndex int64 `xorm:"index"`
 	}
 
 	var start = 0

--- a/models/migrations/v192.go
+++ b/models/migrations/v192.go
@@ -1,0 +1,18 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"xorm.io/xorm"
+)
+
+func recreateIssueResourceIndexTable(x *xorm.Engine) error {
+	type IssueIndex struct {
+		GroupID  int64 `xorm:"pk"`
+		MaxIndex int64 `xorm:"index"`
+	}
+
+	return RecreateTables(new(IssueIndex))(x)
+}


### PR DESCRIPTION
Make the group_id a primary key in issue_index. This already has an unique index
and therefore is a good candidate for becoming a primary key.

This PR also changes all other uses of this table to add the group_id as the
primary key.

Fix #16802

Signed-off-by: Andrew Thornton <art27@cantab.net>
