### PR TITLE
Use a common quote to instead of check database type

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -1619,14 +1619,7 @@ func (opts *SearchUserOptions) toConds() builder.Cond {
 	}
 
 	if opts.Actor != nil {
-		var exprCond builder.Cond
-		if setting.Database.UseMySQL {
-			exprCond = builder.Expr("org_user.org_id = user.id")
-		} else if setting.Database.UseMSSQL {
-			exprCond = builder.Expr("org_user.org_id = [user].id")
-		} else {
-			exprCond = builder.Expr("org_user.org_id = \"user\".id")
-		}
+		var exprCond builder.Cond = builder.Expr("org_user.org_id = `user`.id")
 
 		// If Admin - they see all users!
 		if !opts.Actor.IsAdmin {


### PR DESCRIPTION
`` will be converted to different database quote by xorm. So check database type is unnecessary.