### PR TITLE
Add primary_key to issue_index (#16813)

### DIFF
--- a/models/index.go
+++ b/models/index.go
@@ -14,7 +14,7 @@ import (
 // ResourceIndex represents a resource index which could be used as issue/release and others
 // We can create different tables i.e. issue_index, release_index and etc.
 type ResourceIndex struct {
-	GroupID  int64 `xorm:"unique"`
+	GroupID  int64 `xorm:"pk"`
 	MaxIndex int64 `xorm:"index"`
 }
 

--- a/models/migrations/v182.go
+++ b/models/migrations/v182.go
@@ -10,8 +10,8 @@ import (
 
 func addIssueResourceIndexTable(x *xorm.Engine) error {
 	type ResourceIndex struct {
-		GroupID  int64 `xorm:"index unique(s)"`
-		MaxIndex int64 `xorm:"index unique(s)"`
+		GroupID  int64 `xorm:"pk"`
+		MaxIndex int64 `xorm:"index"`
 	}
 
 	sess := x.NewSession()

--- a/models/migrations/v182_test.go
+++ b/models/migrations/v182_test.go
@@ -33,8 +33,8 @@ func Test_addIssueResourceIndexTable(t *testing.T) {
 	}
 
 	type ResourceIndex struct {
-		GroupID  int64 `xorm:"index unique(s)"`
-		MaxIndex int64 `xorm:"index unique(s)"`
+		GroupID  int64 `xorm:"pk"`
+		MaxIndex int64 `xorm:"index"`
 	}
 
 	var start = 0


### PR DESCRIPTION
Backport #16813

Make the group_id a primary key in issue_index. This already has an
unique index and therefore is a good candidate for becoming a primary
key.

This PR also changes all other uses of this table to add the group_id as
the primary key.

The migration v192 from #16813 has not been backported but Xorm will
work fine with non-primary keyed tables. If a user on 1.15 wishes to
have the correct schema sooner than 1.16 - they can use `gitea doctor
recreate-table issue_index` and gitea will recreate the table with the
primary key.

Fix #16802

Signed-off-by: Andrew Thornton art27@cantab.net
