### PR TITLE
Report the correct number of pushes on the feeds (#16811)

### DIFF
--- a/modules/repository/commits.go
+++ b/modules/repository/commits.go
@@ -31,6 +31,7 @@ type PushCommits struct {
 	Commits    []*PushCommit
 	HeadCommit *PushCommit
 	CompareURL string
+	Len        int
 
 	avatars    map[string]string
 	emailUsers map[string]*models.User
@@ -182,5 +183,12 @@ func ListToPushCommits(l *list.List) *PushCommits {
 		commit := CommitToPushCommit(e.Value.(*git.Commit))
 		commits = append(commits, commit)
 	}
-	return &PushCommits{commits, nil, "", make(map[string]string), make(map[string]*models.User)}
+	return &PushCommits{
+		Commits:    commits,
+		HeadCommit: nil,
+		CompareURL: "",
+		Len:        len(commits),
+		avatars:    make(map[string]string),
+		emailUsers: make(map[string]*models.User),
+	}
 }

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -848,6 +848,11 @@ func ActionContent2Commits(act Actioner) *repository.PushCommits {
 	if err := json.Unmarshal([]byte(act.GetContent()), push); err != nil {
 		log.Error("json.Unmarshal:\n%s\nERROR: %v", act.GetContent(), err)
 	}
+
+	if push.Len == 0 {
+		push.Len = len(push.Commits)
+	}
+
 	return push
 }
 

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -101,7 +101,7 @@
 										</li>
 									{{end}}
 								{{end}}
-								{{if and (gt (len $push.Commits) 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.i18n.Tr "action.compare_commits" (len $push.Commits)}} »</a></li>{{end}}
+								{{if and (gt $push.Len 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.i18n.Tr "action.compare_commits" $push.Len}} »</a></li>{{end}}
 							</ul>
 						</div>
 					{{else if eq .GetOpType 6}}


### PR DESCRIPTION
* Report the correct number of pushes on the feeds

Since the number of commits in the Action table has been limited to 5
the number of commits reported on the feeds page is now incorrectly also
limited to 5. The correct number is available as the Len and this PR
changes this to report this.

Fix #16804

Backports #16811