### PR TITLE
Use conditions but not repo ids as query condition

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1351,16 +1351,21 @@ func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *User, team
 		if team != nil {
 			cond = cond.And(teamUnitsRepoCond(repoIDstr, userID, org.ID, team.ID, unitType)) // special team member repos
 		} else {
-			cond = cond.And(orgUnitsRepoCond(repoIDstr, userID, org.ID, unitType)) // team member repos
+			cond = cond.And(
+				builder.Or(
+					userOrgUnitRepoCond(repoIDstr, userID, org.ID, unitType), // team member repos
+					userOrgPublicUnitRepoCond(userID, org.ID),                // user org public non-member repos, TODO: check repo has issues
+				),
+			)
 		}
 	} else {
 		cond = cond.And(
 			builder.Or(
-				userOwnedRepoCond(userID),                            // owned repos
-				userCollaborationRepoCond(repoIDstr, userID),         // collaboration repos
-				userAssignedRepoCond(repoIDstr, userID),              // user has been assigned accessible repos
-				userMentionedRepoCond(repoIDstr, userID),             // user has been mentioned accessible repos
-				userCreateIssueRepoCond(repoIDstr, userID, unitType), // user has created issue/pr accessible repos
+				userOwnedRepoCond(userID),                          // owned repos
+				userCollaborationRepoCond(repoIDstr, userID),       // collaboration repos
+				userAssignedRepoCond(repoIDstr, userID),            // user has been assigned accessible public repos
+				userMentionedRepoCond(repoIDstr, userID),           // user has been mentioned accessible public repos
+				userCreateIssueRepoCond(repoIDstr, userID, isPull), // user has created issue/pr accessible public repos
 			),
 		)
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -1186,9 +1186,9 @@ type IssuesOptions struct {
 	// prioritize issues from this repo
 	PriorityRepoID int64
 	IsArchived     util.OptionalBool
-	Org            *User // issues permission scope
-	Team           *Team // issues permission scope
-	User           *User // issues permission scope
+	Org            *Organization // issues permission scope
+	Team           *Team         // issues permission scope
+	User           *User         // issues permission scope
 }
 
 // sortIssuesSession sort an issues-related session based on the provided
@@ -1341,7 +1341,7 @@ func (opts *IssuesOptions) setupSession(sess *xorm.Session) {
 }
 
 // issuePullAccessibleRepoCond userID must not be zero, this condition require join repository table
-func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *User, team *Team, isPull bool) builder.Cond {
+func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *Organization, team *Team, isPull bool) builder.Cond {
 	var cond = builder.NewCond()
 	var unitType = unit.TypeIssues
 	if isPull {
@@ -1687,7 +1687,7 @@ type UserIssueStatsOptions struct {
 	IssueIDs   []int64
 	IsArchived util.OptionalBool
 	LabelIDs   []int64
-	Org        *User
+	Org        *Organization
 	Team       *Team
 }
 

--- a/models/issue.go
+++ b/models/issue.go
@@ -1343,9 +1343,9 @@ func (opts *IssuesOptions) setupSession(sess *xorm.Session) {
 // issuePullAccessibleRepoCond userID must not be zero, this condition require join repository table
 func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *User, team *Team, isPull bool) builder.Cond {
 	var cond = builder.NewCond()
-	var unitType = UnitTypeIssues
+	var unitType = unit.TypeIssues
 	if isPull {
-		unitType = UnitTypePullRequests
+		unitType = unit.TypePullRequests
 	}
 	if org != nil {
 		if team != nil {

--- a/models/issue.go
+++ b/models/issue.go
@@ -1711,13 +1711,15 @@ func GetUserIssueStats(opts UserIssueStatsOptions) (*IssueStats, error) {
 
 	sess := func(cond builder.Cond) *xorm.Session {
 		s := db.GetEngine(db.DefaultContext).Where(cond)
-		s.Join("INNER", "repository", "issue.repo_id = repository.id")
 		if len(opts.LabelIDs) > 0 {
 			s.Join("INNER", "issue_label", "issue_label.issue_id = issue.id").
 				In("issue_label.label_id", opts.LabelIDs)
 		}
-		if opts.IsArchived != util.OptionalBoolNone {
-			s.And(builder.Eq{"repository.is_archived": opts.IsArchived.IsTrue()})
+		if opts.UserID > 0 || opts.IsArchived != util.OptionalBoolNone {
+			s.Join("INNER", "repository", "issue.repo_id = repository.id")
+			if opts.IsArchived != util.OptionalBoolNone {
+				s.And(builder.Eq{"repository.is_archived": opts.IsArchived.IsTrue()})
+			}
 		}
 		return s
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -1672,17 +1672,16 @@ func getIssueStatsChunk(opts *IssueStatsOptions, issueIDs []int64) (*IssueStats,
 
 // UserIssueStatsOptions contains parameters accepted by GetUserIssueStats.
 type UserIssueStatsOptions struct {
-	UserID      int64
-	RepoIDs     []int64
-	UserRepoIDs []int64
-	FilterMode  int
-	IsPull      bool
-	IsClosed    bool
-	IssueIDs    []int64
-	IsArchived  util.OptionalBool
-	LabelIDs    []int64
-	Org         *User
-	Team        *Team
+	UserID     int64
+	RepoIDs    []int64
+	FilterMode int
+	IsPull     bool
+	IsClosed   bool
+	IssueIDs   []int64
+	IsArchived util.OptionalBool
+	LabelIDs   []int64
+	Org        *User
+	Team       *Team
 }
 
 // GetUserIssueStats returns issue statistic information for dashboard by given conditions.
@@ -1718,13 +1717,13 @@ func GetUserIssueStats(opts UserIssueStatsOptions) (*IssueStats, error) {
 
 	switch opts.FilterMode {
 	case FilterModeAll:
-		stats.OpenCount, err = applyReposCondition(sess(cond), opts.UserRepoIDs).
+		stats.OpenCount, err = sess(cond).
 			And("issue.is_closed = ?", false).
 			Count(new(Issue))
 		if err != nil {
 			return nil, err
 		}
-		stats.ClosedCount, err = applyReposCondition(sess(cond), opts.UserRepoIDs).
+		stats.ClosedCount, err = sess(cond).
 			And("issue.is_closed = ?", true).
 			Count(new(Issue))
 		if err != nil {
@@ -1800,7 +1799,7 @@ func GetUserIssueStats(opts UserIssueStatsOptions) (*IssueStats, error) {
 		return nil, err
 	}
 
-	stats.YourRepositoriesCount, err = applyReposCondition(sess(cond), opts.UserRepoIDs).Count(new(Issue))
+	stats.YourRepositoriesCount, err = sess(cond).Count(new(Issue))
 	if err != nil {
 		return nil, err
 	}

--- a/models/issue.go
+++ b/models/issue.go
@@ -1186,9 +1186,9 @@ type IssuesOptions struct {
 	// prioritize issues from this repo
 	PriorityRepoID int64
 	IsArchived     util.OptionalBool
-	Org            *Organization // issues permission scope
-	Team           *Team         // issues permission scope
-	User           *User         // issues permission scope
+	Org            *Organization    // issues permission scope
+	Team           *Team            // issues permission scope
+	User           *user_model.User // issues permission scope
 }
 
 // sortIssuesSession sort an issues-related session based on the provided

--- a/models/issue_list.go
+++ b/models/issue_list.go
@@ -25,6 +25,9 @@ const (
 func (issues IssueList) getRepoIDs() []int64 {
 	repoIDs := make(map[int64]struct{}, len(issues))
 	for _, issue := range issues {
+		if issue.Repo != nil {
+			continue
+		}
 		if _, ok := repoIDs[issue.RepoID]; !ok {
 			repoIDs[issue.RepoID] = struct{}{}
 		}
@@ -56,8 +59,12 @@ func (issues IssueList) loadRepositories(e db.Engine) ([]*repo_model.Repository,
 	}
 
 	for _, issue := range issues {
-		issue.Repo = repoMaps[issue.RepoID]
-		if issue.PullRequest != nil {
+		if issue.Repo == nil {
+			issue.Repo = repoMaps[issue.RepoID]
+		} else {
+			repoMaps[issue.RepoID] = issue.Repo
+		}
+		if issue.PullRequest != nil && issue.PullRequest.BaseRepo == nil {
 			issue.PullRequest.BaseRepo = issue.Repo
 		}
 	}

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -267,11 +267,13 @@ func TestGetUserIssueStats(t *testing.T) {
 			},
 		},
 	} {
-		stats, err := GetUserIssueStats(test.Opts)
-		if !assert.NoError(t, err) {
-			continue
-		}
-		assert.Equal(t, test.ExpectedIssueStats, *stats)
+		t.Run(fmt.Sprintf("%#v", test.Opts), func(t *testing.T) {
+			stats, err := GetUserIssueStats(test.Opts)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.ExpectedIssueStats, *stats)
+		})
 	}
 }
 

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -234,23 +234,23 @@ func TestGetUserIssueStats(t *testing.T) {
 				FilterMode: FilterModeAssign,
 			},
 			IssueStats{
-				YourRepositoriesCount: 0,
-				AssignCount:           2,
-				CreateCount:           2,
-				OpenCount:             2,
+				YourRepositoriesCount: 1, // 6
+				AssignCount:           1, // 6
+				CreateCount:           1, // 6
+				OpenCount:             1, // 6
 				ClosedCount:           0,
 			},
 		},
-		/*{
+		{
 			UserIssueStatsOptions{
 				UserID:     1,
 				FilterMode: FilterModeCreate,
 			},
 			IssueStats{
-				YourRepositoriesCount: 0,
-				AssignCount:           2,
-				CreateCount:           2,
-				OpenCount:             2,
+				YourRepositoriesCount: 1, // 6
+				AssignCount:           1, // 6
+				CreateCount:           1, // 6
+				OpenCount:             1, // 6
 				ClosedCount:           0,
 			},
 		},
@@ -260,9 +260,10 @@ func TestGetUserIssueStats(t *testing.T) {
 				FilterMode: FilterModeMention,
 			},
 			IssueStats{
-				YourRepositoriesCount: 0,
-				AssignCount:           2,
-				CreateCount:           2,
+				YourRepositoriesCount: 1, // 6
+				AssignCount:           1, // 6
+				CreateCount:           1, // 6
+				MentionCount:          0,
 				OpenCount:             0,
 				ClosedCount:           0,
 			},
@@ -274,13 +275,13 @@ func TestGetUserIssueStats(t *testing.T) {
 				IssueIDs:   []int64{1},
 			},
 			IssueStats{
-				YourRepositoriesCount: 0,
-				AssignCount:           1,
-				CreateCount:           1,
-				OpenCount:             1,
+				YourRepositoriesCount: 1, // 1
+				AssignCount:           1, // 1
+				CreateCount:           1, // 1
+				OpenCount:             1, // 1
 				ClosedCount:           0,
 			},
-		},*/
+		},
 	} {
 		t.Run(fmt.Sprintf("%#v", test.Opts), func(t *testing.T) {
 			stats, err := GetUserIssueStats(test.Opts)

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -206,11 +206,26 @@ func TestGetUserIssueStats(t *testing.T) {
 				FilterMode: FilterModeAll,
 			},
 			IssueStats{
-				YourRepositoriesCount: 0,
-				AssignCount:           1,
-				CreateCount:           1,
-				OpenCount:             0,
-				ClosedCount:           0,
+				YourRepositoriesCount: 1, // 6
+				AssignCount:           1, // 6
+				CreateCount:           1, // 6
+				OpenCount:             1, // 6
+				ClosedCount:           1, // 1
+			},
+		},
+		{
+			UserIssueStatsOptions{
+				UserID:     1,
+				RepoIDs:    []int64{1},
+				FilterMode: FilterModeAll,
+				IsClosed:   true,
+			},
+			IssueStats{
+				YourRepositoriesCount: 1, // 6
+				AssignCount:           0,
+				CreateCount:           0,
+				OpenCount:             1, // 6
+				ClosedCount:           1, // 1
 			},
 		},
 		{
@@ -226,7 +241,7 @@ func TestGetUserIssueStats(t *testing.T) {
 				ClosedCount:           0,
 			},
 		},
-		{
+		/*{
 			UserIssueStatsOptions{
 				UserID:     1,
 				FilterMode: FilterModeCreate,
@@ -265,7 +280,7 @@ func TestGetUserIssueStats(t *testing.T) {
 				OpenCount:             1,
 				ClosedCount:           0,
 			},
-		},
+		},*/
 	} {
 		t.Run(fmt.Sprintf("%#v", test.Opts), func(t *testing.T) {
 			stats, err := GetUserIssueStats(test.Opts)

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -241,21 +241,6 @@ func TestGetUserIssueStats(t *testing.T) {
 		},
 		{
 			UserIssueStatsOptions{
-				UserID:      2,
-				UserRepoIDs: []int64{1, 2},
-				FilterMode:  FilterModeAll,
-				IsClosed:    true,
-			},
-			IssueStats{
-				YourRepositoriesCount: 2,
-				AssignCount:           0,
-				CreateCount:           2,
-				OpenCount:             2,
-				ClosedCount:           2,
-			},
-		},
-		{
-			UserIssueStatsOptions{
 				UserID:     1,
 				FilterMode: FilterModeMention,
 			},

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -731,15 +731,6 @@ func CountUserRepositories(userID int64, private bool) int64 {
 	return countRepositories(userID, private)
 }
 
-// GetUserMirrorRepositories returns a list of mirror repositories of given user.
-func GetUserMirrorRepositories(userID int64) ([]*Repository, error) {
-	repos := make([]*Repository, 0, 10)
-	return repos, db.GetEngine(db.DefaultContext).
-		Where("owner_id = ?", userID).
-		And("is_mirror = ?", true).
-		Find(&repos)
-}
-
 func getRepositoryCount(e db.Engine, ownerID int64) (int64, error) {
 	return e.Count(&Repository{OwnerID: ownerID})
 }
@@ -765,26 +756,4 @@ func GetPublicRepositoryCount(u *user_model.User) (int64, error) {
 // GetPrivateRepositoryCount returns the total number of private repositories of user.
 func GetPrivateRepositoryCount(u *user_model.User) (int64, error) {
 	return getPrivateRepositoryCount(db.GetEngine(db.DefaultContext), u)
-}
-
-// IterateRepository iterate repositories
-func IterateRepository(f func(repo *Repository) error) error {
-	var start int
-	batchSize := setting.Database.IterateBufferSize
-	for {
-		repos := make([]*Repository, 0, batchSize)
-		if err := db.GetEngine(db.DefaultContext).Limit(batchSize, start).Find(&repos); err != nil {
-			return err
-		}
-		if len(repos) == 0 {
-			return nil
-		}
-		start += len(repos)
-
-		for _, repo := range repos {
-			if err := f(repo); err != nil {
-				return err
-			}
-		}
-	}
 }

--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repo
+
+import (
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+// GetUserMirrorRepositories returns a list of mirror repositories of given user.
+func GetUserMirrorRepositories(userID int64) ([]*Repository, error) {
+	repos := make([]*Repository, 0, 10)
+	return repos, db.GetEngine(db.DefaultContext).
+		Where("owner_id = ?", userID).
+		And("is_mirror = ?", true).
+		Find(&repos)
+}
+
+// IterateRepository iterate repositories
+func IterateRepository(f func(repo *Repository) error) error {
+	var start int
+	batchSize := setting.Database.IterateBufferSize
+	for {
+		repos := make([]*Repository, 0, batchSize)
+		if err := db.GetEngine(db.DefaultContext).Limit(batchSize, start).Find(&repos); err != nil {
+			return err
+		}
+		if len(repos) == 0 {
+			return nil
+		}
+		start += len(repos)
+
+		for _, repo := range repos {
+			if err := f(repo); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// FindReposMapByIDs find repos as map
+func FindReposMapByIDs(repoIDs []int64, res map[int64]*Repository) error {
+	return db.GetEngine(db.DefaultContext).In("id", repoIDs).Find(&res)
+}

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -12,7 +12,10 @@ import (
 	"code.gitea.io/gitea/models/perm"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
+<<<<<<< HEAD
 	user_model "code.gitea.io/gitea/models/user"
+=======
+>>>>>>> f548ff512 (Fix test)
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
@@ -275,13 +278,13 @@ func userOrgTeamRepoBuilder(userID int64) *builder.Builder {
 		Where(builder.Eq{"`team_user`.uid": userID})
 }
 
-func userOrgTeamUnitRepoBuilder(userID int64, unitType UnitType) *builder.Builder {
+func userOrgTeamUnitRepoBuilder(userID int64, unitType unit.Type) *builder.Builder {
 	return userOrgTeamRepoBuilder(userID).
 		Join("INNER", "team_unit", "`team_unit`.team_id = `team_repo`.team_id").
 		Where(builder.Eq{"`team_unit`.`type`": unitType})
 }
 
-func userOrgUnitRepoCond(idStr string, userID, orgID int64, unitType UnitType) builder.Cond {
+func userOrgUnitRepoCond(idStr string, userID, orgID int64, unitType unit.Type) builder.Cond {
 	return builder.In(idStr,
 		userOrgTeamUnitRepoBuilder(userID, unitType).
 			And(builder.Eq{"org_id": orgID}),

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -641,8 +641,3 @@ func GetUserRepositories(opts *SearchRepoOptions) ([]*repo_model.Repository, int
 	repos := make([]*repo_model.Repository, 0, opts.PageSize)
 	return repos, count, db.SetSessionPagination(sess, opts).Find(&repos)
 }
-
-// FindReposMapByIDs find repos as map
-func FindReposMapByIDs(repoIDs []int64, res map[int64]*Repository) error {
-	return db.GetEngine(db.DefaultContext).In("id", repoIDs).Find(&res)
-}

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -315,7 +315,7 @@ func userOrgPublicRepoCondPrivate(userID int64) builder.Cond {
 				Join("INNER", "`user`", "`user`.id = `org_user`.org_id").
 				Where(builder.Eq{
 					"`org_user`.uid":    userID,
-					"`user`.type":       user_model.UserTypeOrganization,
+					"`user`.`type`":     user_model.UserTypeOrganization,
 					"`user`.visibility": structs.VisibleTypePrivate,
 				}),
 		),

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -637,7 +637,6 @@ func FindUserAccessibleRepoIDs(user *user_model.User) ([]int64, error) {
 	return repoIDs, nil
 }
 
-<<<<<<< HEAD
 // GetUserRepositories returns a list of repositories of given user.
 func GetUserRepositories(opts *SearchRepoOptions) ([]*repo_model.Repository, int64, error) {
 	if len(opts.OrderBy) == 0 {
@@ -664,9 +663,9 @@ func GetUserRepositories(opts *SearchRepoOptions) ([]*repo_model.Repository, int
 	sess = sess.Where(cond).OrderBy(opts.OrderBy.String())
 	repos := make([]*repo_model.Repository, 0, opts.PageSize)
 	return repos, count, db.SetSessionPagination(sess, opts).Find(&repos)
-=======
+}
+
 // FindReposMapByIDs find repos as map
 func FindReposMapByIDs(repoIDs []int64, res map[int64]*Repository) error {
-	return x.In("id", repoIDs).Find(&res)
->>>>>>> f6ddec83b (Improve the performance of pulls/issue)
+	return db.GetEngine(db.DefaultContext).In("id", repoIDs).Find(&res)
 }

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -227,6 +227,7 @@ func userMentionedRepoCond(id string, userID int64) builder.Cond {
 	)
 }
 
+// teamUnitsRepoCond returns query condition for those repo id in the special org team with special units access
 func teamUnitsRepoCond(id string, userID, orgID, teamID int64, units ...unit.Type) builder.Cond {
 	return builder.In(id,
 		builder.Select("repo_id").From("team_repo").Where(
@@ -253,7 +254,7 @@ func teamUnitsRepoCond(id string, userID, orgID, teamID int64, units ...unit.Typ
 		))
 }
 
-// userCollaborationRepoCond return user as collabrators repositories list
+// userCollaborationRepoCond returns user as collabrators repositories list
 func userCollaborationRepoCond(idStr string, userID int64) builder.Cond {
 	return builder.In(idStr, builder.Select("repo_id").
 		From("`access`").
@@ -264,10 +265,12 @@ func userCollaborationRepoCond(idStr string, userID int64) builder.Cond {
 	)
 }
 
+// userOrgTeamRepoCond selects repos that the given user has access to through team membership
 func userOrgTeamRepoCond(idStr string, userID int64) builder.Cond {
 	return builder.In(idStr, userOrgTeamRepoBuilder(userID))
 }
 
+// userOrgTeamRepoBuilder returns repo ids where user's teams can access.
 func userOrgTeamRepoBuilder(userID int64) *builder.Builder {
 	return builder.Select("`team_repo`.repo_id").
 		From("team_repo").
@@ -275,12 +278,14 @@ func userOrgTeamRepoBuilder(userID int64) *builder.Builder {
 		Where(builder.Eq{"`team_user`.uid": userID})
 }
 
+// userOrgTeamUnitRepoBuilder returns repo ids where user's teams can access the special unit.
 func userOrgTeamUnitRepoBuilder(userID int64, unitType unit.Type) *builder.Builder {
 	return userOrgTeamRepoBuilder(userID).
 		Join("INNER", "team_unit", "`team_unit`.team_id = `team_repo`.team_id").
 		Where(builder.Eq{"`team_unit`.`type`": unitType})
 }
 
+// userOrgUnitRepoCond selects repos that the given user has access to through org and the special unit
 func userOrgUnitRepoCond(idStr string, userID, orgID int64, unitType unit.Type) builder.Cond {
 	return builder.In(idStr,
 		userOrgTeamUnitRepoBuilder(userID, unitType).
@@ -288,6 +293,7 @@ func userOrgUnitRepoCond(idStr string, userID, orgID int64, unitType unit.Type) 
 	)
 }
 
+// userOrgPublicRepoCond returns the condition that one user could access all public repositories in organizations
 func userOrgPublicRepoCond(userID int64) builder.Cond {
 	return builder.And(
 		builder.Eq{"`repository`.is_private": false},
@@ -299,6 +305,7 @@ func userOrgPublicRepoCond(userID int64) builder.Cond {
 	)
 }
 
+// userOrgPublicRepoCondPrivate returns the condition that one user could access all public repositories in private organizations
 func userOrgPublicRepoCondPrivate(userID int64) builder.Cond {
 	return builder.And(
 		builder.Eq{"`repository`.is_private": false},
@@ -315,6 +322,7 @@ func userOrgPublicRepoCondPrivate(userID int64) builder.Cond {
 	)
 }
 
+// userOrgPublicUnitRepoCond returns the condition that one user could access all public repositories in the special organization
 func userOrgPublicUnitRepoCond(userID, orgID int64) builder.Cond {
 	return userOrgPublicRepoCond(userID).
 		And(builder.Eq{"`repository`.owner_id": orgID})

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -560,6 +560,7 @@ func FindUserAccessibleRepoIDs(user *user_model.User) ([]int64, error) {
 	return repoIDs, nil
 }
 
+<<<<<<< HEAD
 // GetUserRepositories returns a list of repositories of given user.
 func GetUserRepositories(opts *SearchRepoOptions) ([]*repo_model.Repository, int64, error) {
 	if len(opts.OrderBy) == 0 {
@@ -586,4 +587,9 @@ func GetUserRepositories(opts *SearchRepoOptions) ([]*repo_model.Repository, int
 	sess = sess.Where(cond).OrderBy(opts.OrderBy.String())
 	repos := make([]*repo_model.Repository, 0, opts.PageSize)
 	return repos, count, db.SetSessionPagination(sess, opts).Find(&repos)
+=======
+// FindReposMapByIDs find repos as map
+func FindReposMapByIDs(repoIDs []int64, res map[int64]*Repository) error {
+	return x.In("id", repoIDs).Find(&res)
+>>>>>>> f6ddec83b (Improve the performance of pulls/issue)
 }

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -12,10 +12,7 @@ import (
 	"code.gitea.io/gitea/models/perm"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
-<<<<<<< HEAD
 	user_model "code.gitea.io/gitea/models/user"
-=======
->>>>>>> f548ff512 (Fix test)
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
@@ -311,7 +308,7 @@ func userOrgPublicRepoCondPrivate(userID int64) builder.Cond {
 				Join("INNER", "`user`", "`user`.id = `org_user`.org_id").
 				Where(builder.Eq{
 					"`org_user`.uid":    userID,
-					"`user`.type":       UserTypeOrganization,
+					"`user`.type":       user_model.UserTypeOrganization,
 					"`user`.visibility": structs.VisibleTypePrivate,
 				}),
 		),

--- a/models/repo_permission.go
+++ b/models/repo_permission.go
@@ -400,26 +400,6 @@ func HasAccess(userID int64, repo *repo_model.Repository) (bool, error) {
 	return hasAccess(db.DefaultContext, userID, repo)
 }
 
-// FilterOutRepoIdsWithoutUnitAccess filter out repos where user has no access to repositories
-func FilterOutRepoIdsWithoutUnitAccess(u *user_model.User, repoIDs []int64, units ...unit.Type) ([]int64, error) {
-	i := 0
-	for _, rID := range repoIDs {
-		repo, err := repo_model.GetRepositoryByID(rID)
-		if err != nil {
-			return nil, err
-		}
-		perm, err := GetUserRepoPermission(repo, u)
-		if err != nil {
-			return nil, err
-		}
-		if perm.CanReadAny(units...) {
-			repoIDs[i] = rID
-			i++
-		}
-	}
-	return repoIDs[:i], nil
-}
-
 // GetRepoReaders returns all users that have explicit read access or higher to the repository.
 func GetRepoReaders(repo *repo_model.Repository) (_ []*user_model.User, err error) {
 	return getUsersWithAccessMode(db.DefaultContext, repo, perm_model.AccessModeRead)

--- a/models/user.go
+++ b/models/user.go
@@ -15,7 +15,6 @@ import (
 	asymkey_model "code.gitea.io/gitea/models/asymkey"
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
-	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
@@ -28,109 +27,6 @@ func GetOrganizationCount(ctx context.Context, u *user_model.User) (int64, error
 	return db.GetEngine(ctx).
 		Where("uid=?", u.ID).
 		Count(new(OrgUser))
-}
-
-// GetRepositoryIDs returns repositories IDs where user owned and has unittypes
-// Caller shall check that units is not globally disabled
-func GetRepositoryIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	var ids []int64
-
-	sess := db.GetEngine(db.DefaultContext).Table("repository").Cols("repository.id")
-
-	if len(units) > 0 {
-		sess = sess.Join("INNER", "repo_unit", "repository.id = repo_unit.repo_id")
-		sess = sess.In("repo_unit.type", units)
-	}
-
-	return ids, sess.Where("owner_id = ?", u.ID).Find(&ids)
-}
-
-// GetActiveRepositoryIDs returns non-archived repositories IDs where user owned and has unittypes
-// Caller shall check that units is not globally disabled
-func GetActiveRepositoryIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	var ids []int64
-
-	sess := db.GetEngine(db.DefaultContext).Table("repository").Cols("repository.id")
-
-	if len(units) > 0 {
-		sess = sess.Join("INNER", "repo_unit", "repository.id = repo_unit.repo_id")
-		sess = sess.In("repo_unit.type", units)
-	}
-
-	sess.Where(builder.Eq{"is_archived": false})
-
-	return ids, sess.Where("owner_id = ?", u.ID).GroupBy("repository.id").Find(&ids)
-}
-
-// GetOrgRepositoryIDs returns repositories IDs where user's team owned and has unittypes
-// Caller shall check that units is not globally disabled
-func GetOrgRepositoryIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	var ids []int64
-
-	if err := db.GetEngine(db.DefaultContext).Table("repository").
-		Cols("repository.id").
-		Join("INNER", "team_user", "repository.owner_id = team_user.org_id").
-		Join("INNER", "team_repo", "(? != ? and repository.is_private != ?) OR (team_user.team_id = team_repo.team_id AND repository.id = team_repo.repo_id)", true, u.IsRestricted, true).
-		Where("team_user.uid = ?", u.ID).
-		GroupBy("repository.id").Find(&ids); err != nil {
-		return nil, err
-	}
-
-	if len(units) > 0 {
-		return FilterOutRepoIdsWithoutUnitAccess(u, ids, units...)
-	}
-
-	return ids, nil
-}
-
-// GetActiveOrgRepositoryIDs returns non-archived repositories IDs where user's team owned and has unittypes
-// Caller shall check that units is not globally disabled
-func GetActiveOrgRepositoryIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	var ids []int64
-
-	if err := db.GetEngine(db.DefaultContext).Table("repository").
-		Cols("repository.id").
-		Join("INNER", "team_user", "repository.owner_id = team_user.org_id").
-		Join("INNER", "team_repo", "(? != ? and repository.is_private != ?) OR (team_user.team_id = team_repo.team_id AND repository.id = team_repo.repo_id)", true, u.IsRestricted, true).
-		Where("team_user.uid = ?", u.ID).
-		Where(builder.Eq{"is_archived": false}).
-		GroupBy("repository.id").Find(&ids); err != nil {
-		return nil, err
-	}
-
-	if len(units) > 0 {
-		return FilterOutRepoIdsWithoutUnitAccess(u, ids, units...)
-	}
-
-	return ids, nil
-}
-
-// GetAccessRepoIDs returns all repositories IDs where user's or user is a team member organizations
-// Caller shall check that units is not globally disabled
-func GetAccessRepoIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	ids, err := GetRepositoryIDs(u, units...)
-	if err != nil {
-		return nil, err
-	}
-	ids2, err := GetOrgRepositoryIDs(u, units...)
-	if err != nil {
-		return nil, err
-	}
-	return append(ids, ids2...), nil
-}
-
-// GetActiveAccessRepoIDs returns all non-archived repositories IDs where user's or user is a team member organizations
-// Caller shall check that units is not globally disabled
-func GetActiveAccessRepoIDs(u *user_model.User, units ...unit.Type) ([]int64, error) {
-	ids, err := GetActiveRepositoryIDs(u, units...)
-	if err != nil {
-		return nil, err
-	}
-	ids2, err := GetActiveOrgRepositoryIDs(u, units...)
-	if err != nil {
-		return nil, err
-	}
-	return append(ids, ids2...), nil
 }
 
 // deleteBeans deletes all given beans, beans should contain delete conditions.

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -98,25 +98,3 @@ func testIsUserOrgOwner(t *testing.T, uid, orgID int64, expected bool) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, is)
 }
-
-func TestGetOrgRepositoryIDs(t *testing.T) {
-	assert.NoError(t, unittest.PrepareTestDatabase())
-	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
-	user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4}).(*user_model.User)
-	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5}).(*user_model.User)
-
-	accessibleRepos, err := GetOrgRepositoryIDs(user2)
-	assert.NoError(t, err)
-	// User 2's team has access to private repos 3, 5, repo 32 is a public repo of the organization
-	assert.Equal(t, []int64{3, 5, 23, 24, 32}, accessibleRepos)
-
-	accessibleRepos, err = GetOrgRepositoryIDs(user4)
-	assert.NoError(t, err)
-	// User 4's team has access to private repo 3, repo 32 is a public repo of the organization
-	assert.Equal(t, []int64{3, 32}, accessibleRepos)
-
-	accessibleRepos, err = GetOrgRepositoryIDs(user5)
-	assert.NoError(t, err)
-	// User 5's team has no access to any repo
-	assert.Len(t, accessibleRepos, 0)
-}

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -701,14 +701,14 @@ func loadRepoByIDs(ctxUser *user_model.User, issueCountByRepo map[int64]int64, u
 		}
 		repoIDs = append(repoIDs, id)
 		if len(repoIDs) == 500 {
-			if err := models.FindReposMapByIDs(repoIDs, totalRes); err != nil {
+			if err := repo_model.FindReposMapByIDs(repoIDs, totalRes); err != nil {
 				return nil, err
 			}
 			repoIDs = make([]int64, 0, 500)
 		}
 	}
 	if len(repoIDs) > 0 {
-		if err := models.FindReposMapByIDs(repoIDs, totalRes); err != nil {
+		if err := repo_model.FindReposMapByIDs(repoIDs, totalRes); err != nil {
 			return nil, err
 		}
 	}

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -411,7 +411,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 		team = ctx.Org.Team
 	}
 
-	isPullList := unitType == models.UnitTypePullRequests
+	isPullList := unitType == unit.TypePullRequests
 	opts := &models.IssuesOptions{
 		IsPull:     util.OptionalBoolOf(isPullList),
 		SortType:   sortType,

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -405,7 +405,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 
 	// Get repository IDs where User/Org/Team has access.
 	var team *models.Team
-	var org *models.User
+	var org *models.Organization
 	if ctx.Org != nil {
 		org = ctx.Org.Organization
 		team = ctx.Org.Team

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -704,7 +704,7 @@ func loadRepoByIDs(ctxUser *user_model.User, issueCountByRepo map[int64]int64, u
 			if err := repo_model.FindReposMapByIDs(repoIDs, totalRes); err != nil {
 				return nil, err
 			}
-			repoIDs = make([]int64, 0, 500)
+			repoIDs = repoIDs[:0]
 		}
 	}
 	if len(repoIDs) > 0 {

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -61,11 +61,11 @@
 						<div class="ui compact tiny menu">
 							<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open&q={{$.Keyword}}">
 								{{svg "octicon-issue-opened" 16 "mr-3"}}
-								{{.i18n.Tr "repo.issues.open_tab" .ShownIssueStats.OpenCount}}
+								{{.i18n.Tr "repo.issues.open_tab" .IssueStats.OpenCount}}
 							</a>
 							<a class="item{{if .IsShowClosed}} active{{end}}" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed&q={{$.Keyword}}">
 								{{svg "octicon-issue-closed" 16 "mr-3"}}
-								{{.i18n.Tr "repo.issues.close_tab" .ShownIssueStats.ClosedCount}}
+								{{.i18n.Tr "repo.issues.close_tab" .IssueStats.ClosedCount}}
 							</a>
 						</div>
 					</div>


### PR DESCRIPTION
Fix #15412, in my test, over `600` repositories in `/issues` with over `6000` issues will spend `370ms` in my macBook Pro 2020 .