### PR TITLE
In Render tolerate not being passed a context

### DIFF
--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/process"
@@ -99,7 +100,12 @@ func (p *Renderer) Render(ctx *markup.RenderContext, input io.Reader, output io.
 	}
 
 	if ctx == nil || ctx.Ctx == nil {
-		return fmt.Errorf("RenderContext did not provide context")
+		if ctx == nil {
+			log.Warn("RenderContext not provided defaulting to empty ctx")
+			ctx = &markup.RenderContext{}
+		}
+		log.Warn("RenderContext did not provide context, defaulting to Shutdown context")
+		ctx.Ctx = graceful.GetManager().ShutdownContext()
 	}
 
 	processCtx, cancel := context.WithCancel(ctx.Ctx)

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1138,6 +1138,7 @@ func ViewIssue(ctx *context.Context) {
 		URLPrefix: ctx.Repo.RepoLink,
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, issue.Content)
 	if err != nil {
 		ctx.ServerError("RenderString", err)
@@ -1303,6 +1304,7 @@ func ViewIssue(ctx *context.Context) {
 				URLPrefix: ctx.Repo.RepoLink,
 				Metas:     ctx.Repo.Repository.ComposeMetas(),
 				GitRepo:   ctx.Repo.GitRepo,
+				Ctx:       ctx,
 			}, comment.Content)
 			if err != nil {
 				ctx.ServerError("RenderString", err)
@@ -1379,6 +1381,7 @@ func ViewIssue(ctx *context.Context) {
 				URLPrefix: ctx.Repo.RepoLink,
 				Metas:     ctx.Repo.Repository.ComposeMetas(),
 				GitRepo:   ctx.Repo.GitRepo,
+				Ctx:       ctx,
 			}, comment.Content)
 			if err != nil {
 				ctx.ServerError("RenderString", err)
@@ -1739,6 +1742,7 @@ func UpdateIssueContent(ctx *context.Context) {
 		URLPrefix: ctx.FormString("context"),
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, issue.Content)
 	if err != nil {
 		ctx.ServerError("RenderString", err)
@@ -2170,6 +2174,7 @@ func UpdateCommentContent(ctx *context.Context) {
 		URLPrefix: ctx.FormString("context"),
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, comment.Content)
 	if err != nil {
 		ctx.ServerError("RenderString", err)

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -83,6 +83,7 @@ func Milestones(ctx *context.Context) {
 			URLPrefix: ctx.Repo.RepoLink,
 			Metas:     ctx.Repo.Repository.ComposeMetas(),
 			GitRepo:   ctx.Repo.GitRepo,
+			Ctx:       ctx,
 		}, m.Content)
 		if err != nil {
 			ctx.ServerError("RenderString", err)
@@ -276,6 +277,7 @@ func MilestoneIssuesAndPulls(ctx *context.Context) {
 		URLPrefix: ctx.Repo.RepoLink,
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, milestone.Content)
 	if err != nil {
 		ctx.ServerError("RenderString", err)

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -82,6 +82,7 @@ func Projects(ctx *context.Context) {
 			URLPrefix: ctx.Repo.RepoLink,
 			Metas:     ctx.Repo.Repository.ComposeMetas(),
 			GitRepo:   ctx.Repo.GitRepo,
+			Ctx:       ctx,
 		}, projects[i].Description)
 		if err != nil {
 			ctx.ServerError("RenderString", err)
@@ -324,6 +325,7 @@ func ViewProject(ctx *context.Context) {
 		URLPrefix: ctx.Repo.RepoLink,
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, project.Description)
 	if err != nil {
 		ctx.ServerError("RenderString", err)

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -146,6 +146,7 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 			URLPrefix: ctx.Repo.RepoLink,
 			Metas:     ctx.Repo.Repository.ComposeMetas(),
 			GitRepo:   ctx.Repo.GitRepo,
+			Ctx:       ctx,
 		}, r.Note)
 		if err != nil {
 			ctx.ServerError("RenderString", err)
@@ -215,6 +216,7 @@ func SingleRelease(ctx *context.Context) {
 		URLPrefix: ctx.Repo.RepoLink,
 		Metas:     ctx.Repo.Repository.ComposeMetas(),
 		GitRepo:   ctx.Repo.GitRepo,
+		Ctx:       ctx,
 	}, release.Note)
 	if err != nil {
 		ctx.ServerError("RenderString", err)

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -272,6 +272,7 @@ func Milestones(ctx *context.Context) {
 		milestones[i].RenderedContent, err = markdown.RenderString(&markup.RenderContext{
 			URLPrefix: milestones[i].Repo.Link(),
 			Metas:     milestones[i].Repo.ComposeMetas(),
+			Ctx:       ctx,
 		}, milestones[i].Content)
 		if err != nil {
 			ctx.ServerError("RenderString", err)

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -124,6 +124,7 @@ func Profile(ctx *context.Context) {
 			URLPrefix: ctx.Repo.RepoLink,
 			Metas:     map[string]string{"mode": "document"},
 			GitRepo:   ctx.Repo.GitRepo,
+			Ctx:       ctx,
 		}, ctxUser.Description)
 		if err != nil {
 			ctx.ServerError("RenderString", err)


### PR DESCRIPTION
It is possible for RenderString to be passed to an external renderer if markdown
is set to be rendered by an external renderer. No context is currently sent to these
meaning that this will error out.

Fix #16835

Signed-off-by: Andrew Thornton <art27@cantab.net>
