### PR TITLE
Add test to ensure that dumping of login sources remains correct

### DIFF
--- a/models/models_test.go
+++ b/models/models_test.go
@@ -5,12 +5,15 @@
 package models
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
+	"xorm.io/xorm/schemas"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,4 +34,47 @@ func TestDumpDatabase(t *testing.T) {
 		dbType := setting.GetDBTypeByName(dbName)
 		assert.NoError(t, DumpDatabase(filepath.Join(dir, dbType+".sql"), dbType))
 	}
+}
+
+type TestSource struct {
+	Provider                      string
+	ClientID                      string
+	ClientSecret                  string
+	OpenIDConnectAutoDiscoveryURL string
+	IconURL                       string
+}
+
+// FromDB fills up a LDAPConfig from serialized format.
+func (source *TestSource) FromDB(bs []byte) error {
+	return json.Unmarshal(bs, &source)
+}
+
+// ToDB exports a LDAPConfig to a serialized format.
+func (source *TestSource) ToDB() ([]byte, error) {
+	return json.Marshal(source)
+}
+
+func TestDumpLoginSource(t *testing.T) {
+	assert.NoError(t, PrepareTestDatabase())
+
+	loginSourceSchema, err := x.TableInfo(new(LoginSource))
+	assert.NoError(t, err)
+
+	RegisterLoginTypeConfig(LoginOAuth2, new(TestSource))
+
+	CreateLoginSource(&LoginSource{
+		Type:     LoginOAuth2,
+		Name:     "TestSource",
+		IsActive: false,
+		Cfg: &TestSource{
+			Provider: "ConvertibleSourceName",
+			ClientID: "42",
+		},
+	})
+
+	sb := new(strings.Builder)
+
+	x.DumpTables([]*schemas.Table{loginSourceSchema}, sb)
+
+	assert.Contains(t, sb.String(), `"Provider":"ConvertibleSourceName"`)
 }


### PR DESCRIPTION
#16831 has occurred because of a missed regression. This PR adds a simple test to
try to prevent this occuring again.

Signed-off-by: Andrew Thornton <art27@cantab.net>
