### PR TITLE
Paginate releases page & set default page size to 10

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -907,6 +907,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
 ;ALLOWED_TYPES =
+;DEFAULT_PAGING_NUM = 10
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -115,6 +115,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 ### Repository - Release (`repository.release`)
 
 - `ALLOWED_TYPES`: **\<empty\>**: Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
+- `DEFAULT_PAGING_NUM`: **10**: The default paging number of releases user interface
 
 ### Repository - Signing (`repository.signing`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -36,6 +36,11 @@ menu:
 - `MAX_CREATION_LIMIT`: 全局最大每个用户创建的git工程数目， `-1` 表示没限制。
 - `PULL_REQUEST_QUEUE_LENGTH`: 小心：合并请求测试队列的长度，尽量放大。
 
+### Repository - Release (`repository.release`)
+
+- `ALLOWED_TYPES`: **\<empty\>**: 允许扩展名的列表，用逗号分隔 (`.zip`), mime 类型 (`text/plain`) 或者匹配符号 (`image/*`, `audio/*`, `video/*`). 空值或者 `*/*` 允许所有类型。
+- `DEFAULT_PAGING_NUM`: **10**: 默认的发布版本页面分页。
+
 ## UI (`ui`)
 
 - `EXPLORE_PAGING_NUM`: 探索页面每页显示的仓库数量。

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -87,7 +87,8 @@ var (
 		} `ini:"repository.issue"`
 
 		Release struct {
-			AllowedTypes string
+			AllowedTypes     string
+			DefaultPagingNum int
 		} `ini:"repository.release"`
 
 		Signing struct {
@@ -223,9 +224,11 @@ var (
 		},
 
 		Release: struct {
-			AllowedTypes string
+			AllowedTypes     string
+			DefaultPagingNum int
 		}{
-			AllowedTypes: "",
+			AllowedTypes:     "",
+			DefaultPagingNum: 10,
 		},
 
 		// Signing settings

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -13,7 +13,6 @@ import (
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/convert"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/markdown"
@@ -93,11 +92,18 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 
 	writeAccess := ctx.Repo.CanWrite(models.UnitTypeReleases)
 	ctx.Data["CanCreateRelease"] = writeAccess && !ctx.Repo.Repository.IsArchived
+	page := ctx.FormInt("limit")
+	if page == 0 {
+		page = setting.Repository.Release.DefaultPagingNum
+	}
+	if page > setting.API.MaxResponseItems {
+		page = setting.API.MaxResponseItems
+	}
 
 	opts := models.FindReleasesOptions{
 		ListOptions: models.ListOptions{
 			Page:     ctx.FormInt("page"),
-			PageSize: convert.ToCorrectPageSize(ctx.FormInt("limit")),
+			PageSize: page,
 		},
 		IncludeDrafts: writeAccess && !isTagList,
 		IncludeTags:   isTagList,

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -92,18 +92,18 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 
 	writeAccess := ctx.Repo.CanWrite(models.UnitTypeReleases)
 	ctx.Data["CanCreateRelease"] = writeAccess && !ctx.Repo.Repository.IsArchived
-	page := ctx.FormInt("limit")
-	if page == 0 {
-		page = setting.Repository.Release.DefaultPagingNum
+	limit := ctx.FormInt("limit")
+	if limit == 0 {
+		limit = setting.Repository.Release.DefaultPagingNum
 	}
-	if page > setting.API.MaxResponseItems {
-		page = setting.API.MaxResponseItems
+	if limit > setting.API.MaxResponseItems {
+		limit = setting.API.MaxResponseItems
 	}
 
 	opts := models.FindReleasesOptions{
 		ListOptions: models.ListOptions{
 			Page:     ctx.FormInt("page"),
-			PageSize: page,
+			PageSize: limit,
 		},
 		IncludeDrafts: writeAccess && !isTagList,
 		IncludeTags:   isTagList,


### PR DESCRIPTION
Reduce the number of releases shown on the releases page from 30 to 10 and add paging.

## :warning: BREAKING :warning: 

Users may change the default value by setting

```ini
[repository.release]
DEFAULT_PAGING_NUM=10
```
