### PR TITLE
Ensure that the default visibility is set on the user create page (#16845)

### DIFF
--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -28,7 +28,7 @@
 				<div class="inline field {{if .Err_Visibility}}error{{end}}">
 					<span class="inline required field"><label for="visibility">{{.i18n.Tr "settings.visibility"}}</label></span>
 					<div class="ui selection type dropdown">
-						<input type="hidden" id="visibility" name="visibility" value="{{.visibility}}">
+						<input type="hidden" id="visibility" name="visibility" value="{{if .visibility}}{{.visibility}}{{else}}{{printf "%d" .DefaultUserVisibilityMode}}{{end}}">
 						<div class="text">
 							{{if .DefaultUserVisibilityMode.IsPublic}}{{.i18n.Tr "settings.visibility.public"}}{{end}}
 							{{if .DefaultUserVisibilityMode.IsLimited}}{{.i18n.Tr "settings.visibility.limited"}}{{end}}


### PR DESCRIPTION
Backport #16845

Set the default visibility on the user create page.

Fix #16840

Signed-off-by: Andrew Thornton <art27@cantab.net>

