### PR TITLE
Simplify split diff view generation and remove JS dependency (#16775)

### DIFF
--- a/modules/repofiles/diff_test.go
+++ b/modules/repofiles/diff_test.go
@@ -83,6 +83,7 @@ func TestGetDiffPreview(t *testing.T) {
 							{
 								LeftIdx:  3,
 								RightIdx: 0,
+								Match:    4,
 								Type:     3,
 								Content:  "-Description for repo1",
 								Comments: nil,
@@ -90,6 +91,7 @@ func TestGetDiffPreview(t *testing.T) {
 							{
 								LeftIdx:  0,
 								RightIdx: 3,
+								Match:    3,
 								Type:     2,
 								Content:  "+Description for repo1",
 								Comments: nil,
@@ -97,6 +99,7 @@ func TestGetDiffPreview(t *testing.T) {
 							{
 								LeftIdx:  0,
 								RightIdx: 4,
+								Match:    -1,
 								Type:     2,
 								Content:  "+this is a new line",
 								Comments: nil,

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -154,33 +154,5 @@
 		{{end}}
 
 		{{template "repo/issue/view_content/reference_issue_dialog" .}}
-
-		{{if .IsSplitStyle}}
-			<script>
-				document.addEventListener('DOMContentLoaded', () => {
-					$('tr.add-code').each(function() {
-						let prev = $(this).prev();
-						if (prev.is('.del-code') && prev.children().eq(5).text().trim() === '') {
-							while (prev.prev().is('.del-code') && prev.prev().children().eq(5).text().trim() === '') {
-								prev = prev.prev();
-							}
-							prev.children().eq(3).attr('data-line-num', $(this).children().eq(3).attr('data-line-num'));
-							prev.children().eq(3).html($(this).children().eq(3).html());
-							prev.children().eq(4).html($(this).children().eq(4).html());
-							prev.children().eq(5).html($(this).children().eq(5).html());
-
-							prev.children().eq(0).addClass('del-code');
-							prev.children().eq(1).addClass('del-code');
-							prev.children().eq(2).addClass('del-code');
-							prev.children().eq(3).addClass('add-code');
-							prev.children().eq(4).addClass('add-code');
-							prev.children().eq(5).addClass('add-code');
-
-							$(this).remove();
-						}
-					});
-				});
-			</script>
-		{{end}}
 	</div>
 {{end}}

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -1,52 +1,97 @@
 {{$file := .file}}
 {{range $j, $section := $file.Sections}}
 	{{range $k, $line := $section.Lines}}
-		<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
-			{{if eq .GetType 4}}
-				<td class="lines-num lines-num-old">
-					{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
-						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-							{{svg "octicon-fold-down"}}
-						</a>
-					{{end}}
-					{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
-						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-							{{svg "octicon-fold-up"}}
-						</a>
-					{{end}}
-					{{if eq $line.GetExpandDirection 2}}
-						<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
-							{{svg "octicon-fold"}}
-						</a>
-					{{end}}
-				</td>
-				<td colspan="5" class="lines-code lines-code-old "><code class="code-inner">{{$section.GetComputedInlineDiffFor $line}}</span></td>
-			{{else}}
-				<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
-				<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-				<td class="lines-code lines-code-old halfwidth">{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
-				<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
-				<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
-				<td class="lines-code lines-code-new halfwidth">{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
-			{{end}}
-		</tr>
-		{{if gt (len $line.Comments) 0}}
-			<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
-				<td class="lines-num"></td>
-				<td class="lines-type-marker"></td>
-				<td class="add-comment-left">
-					{{if eq $line.GetCommentSide "previous"}}
-						{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
-					{{end}}
-				</td>
-				<td class="lines-num"></td>
-				<td class="lines-type-marker"></td>
-				<td class="add-comment-right">
-					{{if eq $line.GetCommentSide "proposed"}}
-						{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
-					{{end}}
-				</td>
+		{{$hasmatch := ne $line.Match -1}}
+		{{if or (ne .GetType 2) (not $hasmatch)}}
+			<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
+				{{if eq .GetType 4}}
+					<td class="lines-num lines-num-old">
+						{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5) }}
+							<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=down" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+								{{svg "octicon-fold-down"}}
+							</a>
+						{{end}}
+						{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 4) }}
+							<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=up" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+								{{svg "octicon-fold-up"}}
+							</a>
+						{{end}}
+						{{if eq $line.GetExpandDirection 2}}
+							<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{$.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=split&direction=" data-anchor="diff-{{Sha1 $file.Name}}K{{$line.SectionInfo.RightIdx}}">
+								{{svg "octicon-fold"}}
+							</a>
+						{{end}}
+					</td>
+					<td colspan="5" class="lines-code lines-code-old "><code class="code-inner">{{$section.GetComputedInlineDiffFor $line}}</span></td>
+				{{else if and (eq .GetType 3) $hasmatch}}{{/* DEL */}}
+					{{$match := index $section.Lines $line.Match}}
+					<td class="lines-num lines-num-old del-code" data-line-num="{{$line.LeftIdx}}"><span rel="diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}"></span></td>
+					<td class="lines-type-marker lines-type-marker-old del-code"><span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
+					<td class="lines-code lines-code-old halfwidth del-code">{{if and $.root.SignedUserID $.root.PageIsPullFiles}}<a class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
+					<td class="lines-num lines-num-new add-code" data-line-num="{{if $match.RightIdx}}{{$match.RightIdx}}{{end}}"><span rel="{{if $match.RightIdx}}diff-{{Sha1 $file.Name}}R{{$match.RightIdx}}{{end}}"></span></td>
+					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
+					<td class="lines-code lines-code-new halfwidth add-code">{{if and $.root.SignedUserID $.root.PageIsPullFiles}}<a class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="right" data-idx="{{$match.RightIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $match.RightIdx}}{{$section.GetComputedInlineDiffFor $match}}{{end}}</code></td>
+				{{else}}
+					<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{Sha1 $file.Name}}L{{$line.LeftIdx}}{{end}}"></span></td>
+					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+					<td class="lines-code lines-code-old halfwidth">{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2))}}<a class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="left" data-idx="{{$line.LeftIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.LeftIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
+					<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{Sha1 $file.Name}}R{{$line.RightIdx}}{{end}}"></span></td>
+					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
+					<td class="lines-code lines-code-new halfwidth">{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3))}}<a class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} invisible{{end}}" data-path="{{$file.Name}}" data-side="right" data-idx="{{$line.RightIdx}}" data-new-comment-url="{{$.root.Issue.HTMLURL}}/files/reviews/new_comment">{{svg "octicon-plus"}}</a>{{end}}<code class="code-inner">{{if $line.RightIdx}}{{$section.GetComputedInlineDiffFor $line}}{{end}}</code></td>
+				{{end}}
 			</tr>
+			{{if and (eq .GetType 3) $hasmatch}}
+				{{$match := index $section.Lines $line.Match}}
+				{{if or (gt (len $line.Comments) 0) (gt (len $match.Comments) 0)}}
+					<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+						<td class="lines-num"></td>
+						<td class="lines-type-marker"></td>
+						<td class="add-comment-left">
+							{{if gt (len $line.Comments) 0}}
+								{{if eq $line.GetCommentSide "previous"}}
+									{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
+								{{end}}
+							{{end}}
+							{{if gt (len $match.Comments) 0}}
+								{{if eq $match.GetCommentSide "previous"}}
+									{{template "repo/diff/conversation" mergeinto $.root "comments" $match.Comments}}
+								{{end}}
+							{{end}}
+						</td>
+						<td class="lines-num"></td>
+						<td class="lines-type-marker"></td>
+						<td class="add-comment-right">
+							{{if eq $line.GetCommentSide "proposed"}}
+								{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
+							{{end}}
+							{{if gt (len $match.Comments) 0}}
+								{{if eq $match.GetCommentSide "proposed"}}
+									{{template "repo/diff/conversation" mergeinto $.root "comments" $match.Comments}}
+								{{end}}
+							{{end}}
+						</td>
+					</tr>
+				{{end}}
+			{{else if gt (len $line.Comments) 0}}
+				<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+					<td class="lines-num"></td>
+					<td class="lines-type-marker"></td>
+					<td class="add-comment-left">
+						{{if gt (len $line.Comments) 0}}
+							{{if eq $line.GetCommentSide "previous"}}
+								{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
+							{{end}}
+						{{end}}
+					</td>
+					<td class="lines-num"></td>
+					<td class="lines-type-marker"></td>
+					<td class="add-comment-right">
+						{{if eq $line.GetCommentSide "proposed"}}
+							{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
+						{{end}}
+					</td>
+				</tr>
+			{{end}}
 		{{end}}
 	{{end}}
 {{end}}


### PR DESCRIPTION
Backport #16775

Gitea has relied on some slow JS code to match up added and deleted lines on the
diff pages. This can cause a considerable slow down on large diff pages.

This PR makes a small change meaning that the matching up can occur much more simply.

Partial fix #1351

Signed-off-by: Andrew Thornton <art27@cantab.net>
