### PR TITLE
Upgrade Alpine Linux from 3.13 to 3.14

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -411,7 +411,7 @@ steps:
 
   - name: update
     pull: default
-    image: alpine:3.13
+    image: alpine:3.14
     commands:
       - ./build/update-locales.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 ###################################
 #Build stage
-FROM golang:1.17-alpine3.13 AS build-env
+FROM golang:1.17-alpine3.14 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -25,7 +25,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM alpine:3.13
+FROM alpine:3.14
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 22 3000

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,7 +1,7 @@
 
 ###################################
 #Build stage
-FROM golang:1.17-alpine3.13 AS build-env
+FROM golang:1.17-alpine3.14 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -25,7 +25,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM alpine:3.13
+FROM alpine:3.14
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 2222 3000


### PR DESCRIPTION
* Upgrades Alpine from 3.13 to 3.14

Includes fixes for: 
* apk-tools CVE-2021-36159
* openssl CVE-2021-3711 and CVE-2021-3712
