### PR TITLE
Fix report card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://codecov.io/gh/go-gitea/gitea" title="Codecov">
     <img src="https://codecov.io/gh/go-gitea/gitea/branch/main/graph/badge.svg">
   </a>
-  <a href="https://godoc.org/code.gitea.io/gitea" title="Go Report Card">
+  <a href="https://goreportcard.com/report/code.gitea.io/gitea" title="Go Report Card">
     <img src="https://goreportcard.com/badge/code.gitea.io/gitea">
   </a>
   <a href="https://godoc.org/code.gitea.io/gitea" title="GoDoc">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,7 +15,7 @@
   <a href="https://codecov.io/gh/go-gitea/gitea" title="Codecov">
     <img src="https://codecov.io/gh/go-gitea/gitea/branch/main/graph/badge.svg">
   </a>
-  <a href="https://godoc.org/code.gitea.io/gitea" title="Go Report Card">
+  <a href="https://goreportcard.com/report/code.gitea.io/gitea" title="Go Report Card">
     <img src="https://goreportcard.com/badge/code.gitea.io/gitea">
   </a>
   <a href="https://godoc.org/code.gitea.io/gitea" title="GoDoc">


### PR DESCRIPTION
PS: It seems like https://goreportcard.com cannot link to the source code at code.gitea.io, so it would work a little better if the GitHub repo were used, but I'll leave that decision up to the maintainers...