### PR TITLE
Prevent coverage break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,8 +385,8 @@ test\#%:
 
 .PHONY: coverage
 coverage:
-	grep -v '^0$'coverage.out > coverage-bodged.out
-	grep -v '^0$'integration.coverage.out > integration.coverage-bodged.out
+	grep -v '^0$' coverage.out > coverage-bodged.out
+	grep -v '^0$' integration.coverage.out > integration.coverage-bodged.out
 	GO111MODULE=on $(GO) run -mod=vendor build/gocovmerge.go integration.coverage-bodged.out coverage-bodged.out > coverage.all || (echo "gocovmerge failed"; echo "integration.coverage.out"; cat integration.coverage.out; echo "coverage.out"; cat coverage.out; exit 1)
 
 .PHONY: unit-test-coverage

--- a/Makefile
+++ b/Makefile
@@ -385,8 +385,8 @@ test\#%:
 
 .PHONY: coverage
 coverage:
-	grep -v '^0$' coverage.out > coverage-bodged.out
-	grep -v '^0$' integration.coverage.out > integration.coverage-bodged.out
+	grep -v '^0$$' coverage.out > coverage-bodged.out
+	grep -v '^0$$' integration.coverage.out > integration.coverage-bodged.out
 	GO111MODULE=on $(GO) run -mod=vendor build/gocovmerge.go integration.coverage-bodged.out coverage-bodged.out > coverage.all || (echo "gocovmerge failed"; echo "integration.coverage.out"; cat integration.coverage.out; echo "coverage.out"; cat coverage.out; exit 1)
 
 .PHONY: unit-test-coverage

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,9 @@ test\#%:
 
 .PHONY: coverage
 coverage:
-	GO111MODULE=on $(GO) run -mod=vendor build/gocovmerge.go integration.coverage.out coverage.out > coverage.all
+	grep -v '^0$'coverage.out > coverage-bodged.out
+	grep -v '^0$'integration.coverage.out > integration.coverage-bodged.out
+	GO111MODULE=on $(GO) run -mod=vendor build/gocovmerge.go integration.coverage-bodged.out coverage-bodged.out > coverage.all || (echo "gocovmerge failed"; echo "integration.coverage.out"; cat integration.coverage.out; echo "coverage.out"; cat coverage.out; exit 1)
 
 .PHONY: unit-test-coverage
 unit-test-coverage:


### PR DESCRIPTION
There are repeated failures of our CI due to an intermittent issue with coverage.out
finishing with a spurious `0` on a single line.

This problem is very annoying and very hard to understand where it is coming from,
therefore as the problem appears random and without clear cause we should just strip
this line from our coverage.

These bugs are occurring due to the change to use the race detector - presumably there is some race occurring in the coverage output.

Related #1441

Signed-off-by: Andrew Thornton <art27@cantab.net>
