### PR TITLE
Fix git.Blob.DataAsync(): close pipe since we return a NopCloser (#16899)

### DIFF
--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -46,8 +46,8 @@ func (b *Blob) DataAsync() (io.ReadCloser, error) {
 
 	if size < 4096 {
 		bs, err := ioutil.ReadAll(io.LimitReader(rd, size))
+		defer cancel()
 		if err != nil {
-			cancel()
 			return nil, err
 		}
 		_, err = rd.Discard(1)
@@ -105,12 +105,12 @@ func (b *blobReader) Read(p []byte) (n int, err error) {
 
 // Close implements io.Closer
 func (b *blobReader) Close() error {
+	defer b.cancel()
 	if b.n > 0 {
 		for b.n > math.MaxInt32 {
 			n, err := b.rd.Discard(math.MaxInt32)
 			b.n -= int64(n)
 			if err != nil {
-				b.cancel()
 				return err
 			}
 			b.n -= math.MaxInt32
@@ -118,14 +118,12 @@ func (b *blobReader) Close() error {
 		n, err := b.rd.Discard(int(b.n))
 		b.n -= int64(n)
 		if err != nil {
-			b.cancel()
 			return err
 		}
 	}
 	if b.n == 0 {
 		_, err := b.rd.Discard(1)
 		b.n--
-		b.cancel()
 		return err
 	}
 	return nil

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -618,11 +618,14 @@ func getBranchesAndTagsForRepo(user *models.User, repo *models.Repository) (bool
 // CompareDiff show different from one commit to another commit
 func CompareDiff(ctx *context.Context) {
 	headUser, headRepo, headGitRepo, compareInfo, baseBranch, headBranch := ParseCompareInfo(ctx)
-
+	defer func() {
+		if headGitRepo != nil {
+			headGitRepo.Close()
+		}
+	}()
 	if ctx.Written() {
 		return
 	}
-	defer headGitRepo.Close()
 
 	nothingToCompare := PrepareCompareDiff(ctx, headUser, headRepo, headGitRepo, compareInfo, baseBranch, headBranch,
 		gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -419,9 +419,6 @@ func RetrieveRepoMilestonesAndAssignees(ctx *context.Context, repo *models.Repos
 	}
 
 	handleTeamMentions(ctx)
-	if ctx.Written() {
-		return
-	}
 }
 
 func retrieveProjects(ctx *context.Context, repo *models.Repository) {

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1016,10 +1016,14 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 	)
 
 	headUser, headRepo, headGitRepo, prInfo, baseBranch, headBranch := ParseCompareInfo(ctx)
+	defer func() {
+		if headGitRepo != nil {
+			headGitRepo.Close()
+		}
+	}()
 	if ctx.Written() {
 		return
 	}
-	defer headGitRepo.Close()
 
 	labelIDs, assigneeIDs, milestoneID, _ := ValidateRepoMetas(ctx, *form, true)
 	if ctx.Written() {


### PR DESCRIPTION
Backport #16899

* make sure headGitRepo is closed on err too
* refactor
* Fix git.Blob.DataAsync(): exec cancel since we already read all bytes (close pipe since we return a NopCloser)