### PR TITLE
Ignore review comment when ref commit is missed

### DIFF
--- a/modules/migrations/gitea_uploader.go
+++ b/modules/migrations/gitea_uploader.go
@@ -880,7 +880,8 @@ func (g *GiteaLocalUploader) CreateReviews(reviews ...*base.Review) error {
 			}
 			headCommitID, err := g.gitRepo.GetRefCommitID(pr.GetGitRefName())
 			if err != nil {
-				return fmt.Errorf("GetRefCommitID[%s]: %v", pr.GetGitRefName(), err)
+				log.Warn("GetRefCommitID[%s]: %v, the review comment will be ignored", pr.GetGitRefName(), err)
+				continue
 			}
 
 			var patch string


### PR DESCRIPTION
When force push to a pull request, some commits to review comments will be disappeared. So when migrating a commit-missed review comment, just ignore them but not stop the migration process. 