### PR TITLE
Remove the final test from the testlogger safely

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -120,7 +120,7 @@ func TestMain(m *testing.M) {
 	}
 	exitCode := m.Run()
 
-	writerCloser.t = nil
+	writerCloser.Reset()
 
 	if err = util.RemoveAll(setting.Indexer.IssuePath); err != nil {
 		fmt.Printf("util.RemoveAll: %v\n", err)

--- a/integrations/testlogger.go
+++ b/integrations/testlogger.go
@@ -90,6 +90,21 @@ func (w *testLoggerWriterCloser) Close() error {
 	return nil
 }
 
+func (w *testLoggerWriterCloser) Reset() {
+	w.Lock()
+	if len(w.t) > 0 {
+		for _, t := range w.t {
+			if t == nil {
+				continue
+			}
+			fmt.Fprintf(os.Stdout, "Unclosed logger writer in test: %s", (*t).Name())
+			(*t).Errorf("Unclosed logger writer in test: %s", (*t).Name())
+		}
+		w.t = nil
+	}
+	w.Unlock()
+}
+
 // PrintCurrentTest prints the current test to os.Stdout
 func PrintCurrentTest(t testing.TB, skip ...int) func() {
 	start := time.Now()


### PR DESCRIPTION
It is possible to get a data race right at the end of the TestMain
in integrations during the final removal of the test from the testlogger. This PR
uses a Reset function to remove any final tests but adds some extra
logging which will forcibly fail if there is an unclosed logger.

Related #1441

Signed-off-by: Andrew Thornton <art27@cantab.net>