### PR TITLE
Gitlab Migrator: dont ignore reactions of last request (#16903)

### DIFF
--- a/modules/migrations/gitlab.go
+++ b/modules/migrations/gitlab.go
@@ -396,12 +396,15 @@ func (g *GitlabDownloader) GetIssues(page, perPage int) ([]*base.Issue, bool, er
 			if err != nil {
 				return nil, false, fmt.Errorf("error while listing issue awards: %v", err)
 			}
-			if len(awards) < perPage {
-				break
-			}
+
 			for i := range awards {
 				reactions = append(reactions, g.awardToReaction(awards[i]))
 			}
+
+			if len(awards) < perPage {
+				break
+			}
+
 			awardPage++
 		}
 
@@ -558,12 +561,15 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 			if err != nil {
 				return nil, false, fmt.Errorf("error while listing merge requests awards: %v", err)
 			}
-			if len(awards) < perPage {
-				break
-			}
+
 			for i := range awards {
 				reactions = append(reactions, g.awardToReaction(awards[i]))
 			}
+
+			if len(awards) < perPage {
+				break
+			}
+
 			awardPage++
 		}
 


### PR DESCRIPTION
Backport #16903

Fix bug related to early breaking when migrating reactions.

Co-authored-by: 6543 <6543@obermui.de>