### PR TITLE
Prevent leave changes dialogs due to autofill fields (#16912)

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -198,7 +198,7 @@
 									<input type="hidden" name="action" value="push-mirror-add">
 									<div class="field {{if .Err_PushMirrorAddress}}error{{end}}">
 										<label for="push_mirror_address">{{.i18n.Tr "repo.settings.mirror_settings.push_mirror.remote_url"}}</label>
-										<input id="push_mirror_address" name="push_mirror_address" value="{{.push_mirror_address}}" required>
+										<input id="push_mirror_address" name="push_mirror_address" value="{{.push_mirror_address}}" autocomplete="off" required>
 										<p class="help">{{.i18n.Tr "repo.mirror_address_desc"}}</p>
 									</div>
 									<details class="ui optional field" {{if or .Err_PushMirrorAuth .push_mirror_username}}open{{end}}>

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -8,7 +8,7 @@
 		</h4>
 		<div class="ui attached segment">
 			{{if or (.SignedUser.IsLocal) (.SignedUser.IsOAuth2)}}
-			<form class="ui form" action="{{AppSubUrl}}/user/settings/account" method="post">
+			<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/settings/account" method="post">
 				{{.CsrfTokenHtml}}
 				{{if .SignedUser.IsPasswordSet}}
 				<div class="required field {{if .Err_OldPassword}}error{{end}}">


### PR DESCRIPTION
Backport #16912

Add ignore-dirty to /user/settings/account
Add autocomplete="off" to push_mirror_address form on /:owner/:repo/settings

Fix #16861

Signed-off-by: Andrew Thornton <art27@cantab.net>
