### PR TITLE
Allow BASIC authentication access to /:owner/:repo/releases/download/* (#16916)

### DIFF
--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -80,11 +80,11 @@ func isAttachmentDownload(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, "/attachments/") && req.Method == "GET"
 }
 
-var gitRawPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/)|raw/)`)
+var gitRawReleasePathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/)|(?:raw/)|(?:releases/download/))`)
 var lfsPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/info/lfs/`)
 
-func isGitRawOrLFSPath(req *http.Request) bool {
-	if gitRawPathRe.MatchString(req.URL.Path) {
+func isGitRawReleaseOrLFSPath(req *http.Request) bool {
+	if gitRawReleasePathRe.MatchString(req.URL.Path) {
 		return true
 	}
 	if setting.LFS.StartServer {

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -83,6 +83,10 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 			"/owner/repo/commit/123456789012345678921234567893124567894",
 			false,
 		},
+		{
+			"/owner/repo/releases/download/tag/repo.tar.gz",
+			true,
+		},
 	}
 	lfsTests := []string{
 		"/owner/repo/info/lfs/",
@@ -102,11 +106,11 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			req, _ := http.NewRequest("POST", "http://localhost"+tt.path, nil)
 			setting.LFS.StartServer = false
-			if got := isGitRawOrLFSPath(req); got != tt.want {
+			if got := isGitRawReleaseOrLFSPath(req); got != tt.want {
 				t.Errorf("isGitOrLFSPath() = %v, want %v", got, tt.want)
 			}
 			setting.LFS.StartServer = true
-			if got := isGitRawOrLFSPath(req); got != tt.want {
+			if got := isGitRawReleaseOrLFSPath(req); got != tt.want {
 				t.Errorf("isGitOrLFSPath() = %v, want %v", got, tt.want)
 			}
 		})
@@ -115,11 +119,11 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt, nil)
 			setting.LFS.StartServer = false
-			if got := isGitRawOrLFSPath(req); got != setting.LFS.StartServer {
-				t.Errorf("isGitOrLFSPath(%q) = %v, want %v, %v", tt, got, setting.LFS.StartServer, gitRawPathRe.MatchString(tt))
+			if got := isGitRawReleaseOrLFSPath(req); got != setting.LFS.StartServer {
+				t.Errorf("isGitOrLFSPath(%q) = %v, want %v, %v", tt, got, setting.LFS.StartServer, gitRawReleasePathRe.MatchString(tt))
 			}
 			setting.LFS.StartServer = true
-			if got := isGitRawOrLFSPath(req); got != setting.LFS.StartServer {
+			if got := isGitRawReleaseOrLFSPath(req); got != setting.LFS.StartServer {
 				t.Errorf("isGitOrLFSPath(%q) = %v, want %v", tt, got, setting.LFS.StartServer)
 			}
 		})

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -49,7 +49,7 @@ func (b *Basic) Free() error {
 // Returns nil if header is empty or validation fails.
 func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *models.User {
 	// Basic authentication should only fire on API, Download or on Git or LFSPaths
-	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawOrLFSPath(req) {
+	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawReleaseOrLFSPath(req) {
 		return nil
 	}
 

--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -78,7 +78,7 @@ func (r *ReverseProxy) Verify(req *http.Request, w http.ResponseWriter, store Da
 	}
 
 	// Make sure requests to API paths, attachment downloads, git and LFS do not create a new session
-	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawOrLFSPath(req) {
+	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawReleaseOrLFSPath(req) {
 		if sess != nil && (sess.Get("uid") == nil || sess.Get("uid").(int64) != user.ID) {
 			handleSignIn(w, req, sess, user)
 		}


### PR DESCRIPTION
Backport #16916

Duplicate #15987 to allow access to releases download through BASIC authentication.

Fix #16914

Signed-off-by: Andrew Thornton <art27@cantab.net>
