### PR TITLE
Add unique constraint back into issue_index

### DIFF
--- a/models/index.go
+++ b/models/index.go
@@ -14,7 +14,7 @@ import (
 // ResourceIndex represents a resource index which could be used as issue/release and others
 // We can create different tables i.e. issue_index, release_index and etc.
 type ResourceIndex struct {
-	GroupID  int64 `xorm:"pk"`
+	GroupID  int64 `xorm:"pk unique"`
 	MaxIndex int64 `xorm:"index"`
 }
 


### PR DESCRIPTION
There is a flaw in #16820 where it was missed that although xorm will
not add a primary key to a table during syncing, it will remove an
unique constraint.

Users upgrading from 1.15.0 to 1.15.1 will therefore lose the unique
constraint that makes this table work unless they run `gitea doctor
recreate-table issue_index`.  Postgres helpfully warns about this
situation but MySQL does not.

Main/1.16-dev is not affected by this issue as there is a migration that
does the above recreation by default. Users moving directly to 1.15.1
from 1.14.x or lower are also not affected.

Whilst we could force all users who ran 1.15.0 to do the above
recreate-table call, this PR proposes an alternative: Just add the
unique constraint back in for 1.15.x. This won't have any long term
effects - just some wasted space for the unnecessary index.

Fix #16936

Signed-off-by: Andrew Thornton <art27@cantab.net>
