### PR TITLE
Doc: Mail-Tempales: Fix AppUrl function name

### DIFF
--- a/docs/content/doc/advanced/mail-templates-us.md
+++ b/docs/content/doc/advanced/mail-templates-us.md
@@ -208,7 +208,7 @@ Please check [Gitea's logs](https://docs.gitea.io/en-us/logging-configuration/) 
     {{end}}
     <p>
         <p>
-        <a href="{{AppURL}}/{{.Doer.LowerName}}">@{{.Doer.Name}}</a>
+        <a href="{{AppUrl}}/{{.Doer.LowerName}}">@{{.Doer.Name}}</a>
         {{if not (eq .Doer.FullName "")}}
             ({{.Doer.FullName}})
         {{end}}


### PR DESCRIPTION
Thanks to https://github.com/go-gitea/gitea/pull/16788 I can see why our docker container kept restarting when adding the custom mail template example.
[The example template](https://docs.gitea.io/en-us/mail-templates/#example) has an error

```
2021/09/03 10:55:25 cmd/web.go:91:func1() [F] PANIC: template: mail/issue/default:35: function "AppURL" not defined
        /usr/local/go/src/html/template/template.go:374 (0x1563bb8)
        /go/src/code.gitea.io/gitea/vendor/github.com/unrolled/render/render.go:322 (0x1563782)
        /go/src/code.gitea.io/gitea/vendor/github.com/unrolled/render/render.go:202 (0x1562f8b)
        /go/src/code.gitea.io/gitea/vendor/github.com/unrolled/render/render.go:146 (0x15629d2)
        /go/src/code.gitea.io/gitea/modules/templates/base.go:88 (0x16b0769)
        /go/src/code.gitea.io/gitea/routers/web/base.go:125 (0x225f284)
        /go/src/code.gitea.io/gitea/routers/web/web.go:95 (0x2261284)
        /go/src/code.gitea.io/gitea/routers/init.go:147 (0x22817ba)
        /go/src/code.gitea.io/gitea/cmd/web.go:158 (0x239741a)
        /go/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/app.go:524 (0x1740884)
        /go/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/command.go:173 (0x17415f8)
        /go/src/code.gitea.io/gitea/vendor/github.com/urfave/cli/app.go:277 (0x173e8c7)
        /go/src/code.gitea.io/gitea/main.go:115 (0x23d3e69)
        /usr/local/go/src/runtime/proc.go:225 (0x443995)
        /usr/local/go/src/runtime/asm_amd64.s:1371 (0x47b360)
```

Thanks for maintaining Gitea! 💚