### PR TITLE
Close storage objects before cleaning (#16934)

### DIFF
--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -91,6 +91,7 @@ func Copy(dstStorage ObjectStorage, dstPath string, srcStorage ObjectStorage, sr
 // Clean delete all the objects in this storage
 func Clean(storage ObjectStorage) error {
 	return storage.IterateObjects(func(path string, obj Object) error {
+		_ = obj.Close()
 		return storage.Delete(path)
 	})
 }


### PR DESCRIPTION
Backport #16934

Storage.Iterate provides the path and an open object. On windows using
local storage means that the objects will be locked thus preventing clean
from deleting them.

This PR simply closes the objects early.

Fix #16932

Signed-off-by: Andrew Thornton <art27@cantab.net>
