### PR TITLE
Changelog 1.15.2 (#16940)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
+## [1.15.2](https://github.com/go-gitea/gitea/releases/tag/v1.15.2) - 2021-09-03
+
+* BUGFIXES
+  * Add unique constraint back into issue_index (#16938)
+  * Close storage objects before cleaning (#16934) (#16942)
+
 ## [1.15.1](https://github.com/go-gitea/gitea/releases/tag/v1.15.1) - 2021-09-02
 
 * BUGFIXES


### PR DESCRIPTION
Frontport #16940

## [1.15.2](https://github.com/go-gitea/gitea/releases/tag/v1.15.2) - 2021-09-03

* BUGFIXES
  * Add unique constraint back into issue_index (#16938)
  * Close storage objects before cleaning (#16934) (#16942)

Signed-off-by: Andrew Thornton <art27@cantab.net>
