### PR TITLE
Fix issue with issue default mail template

### DIFF
--- a/templates/mail/issue/default.tmpl
+++ b/templates/mail/issue/default.tmpl
@@ -62,7 +62,7 @@
 		{{end -}}
 		{{- range .ReviewComments}}
 			<hr>
-			{{.i18n.Tr "mail.issue.in_tree_path" .TreePath}}
+			{{$.i18n.Tr "mail.issue.in_tree_path" .TreePath}}
 			<div class="review">
 				<pre>{{.Patch}}</pre>
 				<div>{{.RenderedContent | Safe}}</div>


### PR DESCRIPTION
The mail template rendering was failing with the error -
`...vices/mailer/mail.go:301:composeIssueCommentMessages() [E] ExecuteTemplate [issue/default/body]: template: issue/default:65:10: executing "issue/default" at <.i18n.Tr>: can't evaluate field i18n in type *models.Comment`

The issue was the template variable i18n is available in the outer scope.

Fixes #16877

