### PR TITLE
Add missing icon set for `ActionRenameRepo`

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -777,7 +777,7 @@ type Actioner interface {
 // ActionIcon accepts an action operation type and returns an icon class name.
 func ActionIcon(opType models.ActionType) string {
 	switch opType {
-	case models.ActionCreateRepo, models.ActionTransferRepo:
+	case models.ActionCreateRepo, models.ActionTransferRepo, models.ActionRenameRepo:
 		return "repo"
 	case models.ActionCommitRepo, models.ActionPushTag, models.ActionDeleteTag, models.ActionDeleteBranch:
 		return "git-commit"


### PR DESCRIPTION
As title, just a small nit, or it will use `question` ico as default:
![image](https://user-images.githubusercontent.com/25342410/132224225-b6d7bc96-04b0-4e96-9e27-7ed5f8b5aaf3.png)
