### PR TITLE
Add Cache-Control to avatar redirects

### DIFF
--- a/routers/web/user/avatar.go
+++ b/routers/web/user/avatar.go
@@ -13,9 +13,15 @@ import (
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/httpcache"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
+
+func doRedirect(ctx *context.Context, location string) {
+	ctx.Resp.Header().Set("Cache-Control", httpcache.GetCacheControl())
+	ctx.Redirect(location)
+}
 
 // Avatar redirect browser to user avatar of requested size
 func Avatar(ctx *context.Context) {
@@ -43,7 +49,7 @@ func Avatar(ctx *context.Context) {
 		user = models.NewGhostUser()
 	}
 
-	ctx.Redirect(user.RealSizedAvatarLink(size))
+	doRedirect(ctx, user.RealSizedAvatarLink(size))
 }
 
 // AvatarByEmailHash redirects the browser to the appropriate Avatar link
@@ -63,7 +69,7 @@ func AvatarByEmailHash(ctx *context.Context) {
 		return
 	}
 	if len(email) == 0 {
-		ctx.Redirect(models.DefaultAvatarLink())
+		doRedirect(ctx, models.DefaultAvatarLink())
 		return
 	}
 	size := ctx.FormInt("size")
@@ -94,5 +100,5 @@ func AvatarByEmailHash(ctx *context.Context) {
 		}
 	}
 
-	ctx.Redirect(models.MakeFinalAvatarURL(avatarURL, size))
+	doRedirect(ctx, models.MakeFinalAvatarURL(avatarURL, size))
 }

--- a/routers/web/user/avatar.go
+++ b/routers/web/user/avatar.go
@@ -18,7 +18,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 )
 
-func doRedirect(ctx *context.Context, location string) {
+func cacheableRedirect(ctx *context.Context, location string) {
 	ctx.Resp.Header().Set("Cache-Control", httpcache.GetCacheControl())
 	ctx.Redirect(location)
 }
@@ -49,7 +49,7 @@ func Avatar(ctx *context.Context) {
 		user = models.NewGhostUser()
 	}
 
-	doRedirect(ctx, user.RealSizedAvatarLink(size))
+	cacheableRedirect(ctx, user.RealSizedAvatarLink(size))
 }
 
 // AvatarByEmailHash redirects the browser to the appropriate Avatar link
@@ -69,7 +69,7 @@ func AvatarByEmailHash(ctx *context.Context) {
 		return
 	}
 	if len(email) == 0 {
-		doRedirect(ctx, models.DefaultAvatarLink())
+		cacheableRedirect(ctx, models.DefaultAvatarLink())
 		return
 	}
 	size := ctx.FormInt("size")
@@ -100,5 +100,5 @@ func AvatarByEmailHash(ctx *context.Context) {
 		}
 	}
 
-	doRedirect(ctx, models.MakeFinalAvatarURL(avatarURL, size))
+	cacheableRedirect(ctx, models.MakeFinalAvatarURL(avatarURL, size))
 }


### PR DESCRIPTION
This does seem to do the trick to make the Avatar redirects cachable in Chrome.

In Firefox, it does not seem to work, thought and I found no way to suppress the requests to the original URLs, I even tried setting 301 or an Etag to no avail.

Related discussion in https://github.com/go-gitea/gitea/issues/16964.