### PR TITLE
Skip AllowedUserVisibilityModes validation on update user if it is an organisation

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -1060,7 +1060,7 @@ func checkDupEmail(e Engine, u *User) error {
 	return nil
 }
 
-// validateUser check if user is valide to insert / update into database
+// validateUser check if user is valid to insert / update into database
 func validateUser(u *User) error {
 	if !setting.Service.AllowedUserVisibilityModesSlice.IsAllowedVisibility(u.Visibility) && !u.IsOrganization() {
 		return fmt.Errorf("visibility Mode not allowed: %s", u.Visibility.String())

--- a/models/user.go
+++ b/models/user.go
@@ -1062,7 +1062,7 @@ func checkDupEmail(e Engine, u *User) error {
 
 // validateUser check if user is valide to insert / update into database
 func validateUser(u *User) error {
-	if !setting.Service.AllowedUserVisibilityModesSlice.IsAllowedVisibility(u.Visibility) {
+	if !setting.Service.AllowedUserVisibilityModesSlice.IsAllowedVisibility(u.Visibility) && !u.IsOrganization() {
 		return fmt.Errorf("visibility Mode not allowed: %s", u.Visibility.String())
 	}
 


### PR DESCRIPTION
if AllowedUserVisibilityModes allow only public & limited, and orgs can be private, a user can create a repo to that organisation whitch will result in an update of the user. On this call the user is validaten and will be rejected since private is not allowed, but its not an user its an valid org ...

---

close https://codeberg.org/Codeberg/Community/issues/516