### PR TITLE
Return correct error response for agit `force-push`

### DIFF
--- a/services/agit/agit.go
+++ b/services/agit/agit.go
@@ -213,7 +213,7 @@ func ProcRecive(ctx *context.PrivateContext, opts *private.HookOptions) []privat
 				return nil
 			} else if len(output) > 0 {
 				results = append(results, private.HookProcReceiveRefResult{
-					OriginalRef: oldCommitID,
+					OriginalRef: opts.RefFullNames[i],
 					OldOID:      opts.OldCommitIDs[i],
 					NewOID:      opts.NewCommitIDs[i],
 					Err:         "request `force-push` push option",


### PR DESCRIPTION
feel sorry for my fault. now it will response the corret error message for the froce push request without confirm. example:
![2021-09-08 22-46-06屏幕截图](https://user-images.githubusercontent.com/25342410/132531827-e7ee3770-f648-42e4-b317-2f7a292f43ba.png)
