### PR TITLE
Add a link to the gitea repo in the footer

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -67,8 +67,8 @@ func NewFuncMap() []template.FuncMap {
 		"AppVer": func() string {
 			return setting.AppVer
 		},
-		// render the application version with a link arount it
-		// if the version string contains a git commit hash one
+		// render the application version with a link around it
+		// if the version string contains a git commit hash
 		"AppVerLink": func() string {
 			matches := commitHashRe.FindStringSubmatch(setting.AppVer)
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -75,8 +75,8 @@ func NewFuncMap() []template.FuncMap {
 			if len(matches) > 1 {
 				prefix := template.HTMLEscapeString(matches[1])
 				hash := template.HTMLEscapeString(matches[2])
-				return fmt.Sprintf(`%s<a class="muted" target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/commit/%s">%s</a>`,
-					prefix, hash, hash)
+				return fmt.Sprintf(`<a class="muted" target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/commit/%s">%s%s</a>`,
+					hash, prefix, hash)
 			}
 
 			return template.HTMLEscapeString(setting.AppVer)

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -41,6 +41,7 @@ import (
 
 // Used from static.go && dynamic.go
 var mailSubjectSplit = regexp.MustCompile(`(?m)^-{3,}[\s]*$`)
+var commitHashRe = regexp.MustCompile(`^(.+-g)([0-9a-f]+)$`)
 
 // NewFuncMap returns functions for injecting to templates
 func NewFuncMap() []template.FuncMap {
@@ -65,6 +66,20 @@ func NewFuncMap() []template.FuncMap {
 		},
 		"AppVer": func() string {
 			return setting.AppVer
+		},
+		// render the application version with a link on the git commit hash
+		// if the version string contains one
+		"AppVerHTML": func() string {
+			matches := commitHashRe.FindStringSubmatch(setting.AppVer)
+
+			if len(matches) > 1 {
+				prefix := template.HTMLEscapeString(matches[1])
+				hash := template.HTMLEscapeString(matches[2])
+				return fmt.Sprintf(`%s<a class="muted" target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/commit/%s">%s</a>`,
+					prefix, hash, hash)
+			}
+
+			return template.HTMLEscapeString(setting.AppVer)
 		},
 		"AppBuiltWith": func() string {
 			return setting.AppBuiltWith

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -72,7 +72,7 @@ func NewFuncMap() []template.FuncMap {
 		"AppVerLink": func() string {
 			matches := commitHashRe.FindStringSubmatch(setting.AppVer)
 
-			if len(matches) > 1 {
+			if len(matches) == 3 {
 				prefix := template.HTMLEscapeString(matches[1])
 				hash := template.HTMLEscapeString(matches[2])
 				return fmt.Sprintf(`<a class="muted" target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/commit/%s">%s%s</a>`,

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -67,8 +67,8 @@ func NewFuncMap() []template.FuncMap {
 		"AppVer": func() string {
 			return setting.AppVer
 		},
-		// render the application version with a link on the git commit hash
-		// if the version string contains one
+		// render the application version with a link arount it
+		// if the version string contains a git commit hash one
 		"AppVerHTML": func() string {
 			matches := commitHashRe.FindStringSubmatch(setting.AppVer)
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -69,7 +69,7 @@ func NewFuncMap() []template.FuncMap {
 		},
 		// render the application version with a link arount it
 		// if the version string contains a git commit hash one
-		"AppVerHTML": func() string {
+		"AppVerLink": func() string {
 			matches := commitHashRe.FindStringSubmatch(setting.AppVer)
 
 			if len(matches) > 1 {

--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -1,7 +1,7 @@
 <footer>
 	<div class="ui container">
 		<div class="ui left">
-			{{.i18n.Tr "powered_by" "Gitea"}} {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
+			{{.i18n.Tr "powered_by" "Gitea"}} {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{Safe AppVerHTML}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
 		</div>
 		<div class="ui right links">
 			{{if .ShowFooterBranding}}

--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -1,7 +1,7 @@
 <footer>
 	<div class="ui container">
 		<div class="ui left">
-			{{.i18n.Tr "powered_by" "Gitea"}} {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{Safe AppVerHTML}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
+			{{.i18n.Tr "powered_by" "Gitea"}} {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{Safe AppVerLink}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
 		</div>
 		<div class="ui right links">
 			{{if .ShowFooterBranding}}


### PR DESCRIPTION
This adds a link around the git hash in the application version to commit on GitHub. It should be useful for development to know the exact commit one is currently on.

<img width="369" alt="image" src="https://user-images.githubusercontent.com/115237/132556130-7864736f-4e54-4340-9937-8ffdbdbb101d.png">


Maybe the repo base URL should be extracted to a constant somewhere, but I'm not sure where to put it (maybe `main.go`?).