### PR TITLE
Report the associated filter if there is an error in LDAP

### DIFF
--- a/services/auth/source/ldap/source_search.go
+++ b/services/auth/source/ldap/source_search.go
@@ -156,7 +156,7 @@ func checkAdmin(l *ldap.Conn, ls *Source, userDN string) bool {
 	sr, err := l.Search(search)
 
 	if err != nil {
-		log.Error("LDAP Admin Search failed unexpectedly! (%v)", err)
+		log.Error("LDAP Admin Search with filter %s for %s failed unexpectedly! (%v)", ls.AdminFilter, userDN, err)
 	} else if len(sr.Entries) < 1 {
 		log.Trace("LDAP Admin Search found no matching entries.")
 	} else {
@@ -181,7 +181,7 @@ func checkRestricted(l *ldap.Conn, ls *Source, userDN string) bool {
 	sr, err := l.Search(search)
 
 	if err != nil {
-		log.Error("LDAP Restrictred Search failed unexpectedly! (%v)", err)
+		log.Error("LDAP Restrictred Search with filter %s for %s failed unexpectedly! (%v)", ls.RestrictedFilter, userDN, err)
 	} else if len(sr.Entries) < 1 {
 		log.Trace("LDAP Restricted Search found no matching entries.")
 	} else {


### PR DESCRIPTION
If there is an error when performing the admin or restricted filter search
ensure that the filter and the userDN are reported.

Signed-off-by: Andrew Thornton <art27@cantab.net>
