### PR TITLE
Fix reset password email template

### DIFF
--- a/templates/mail/auth/reset_passwd.tmpl
+++ b/templates/mail/auth/reset_passwd.tmpl
@@ -9,7 +9,7 @@
 <body>
 	<p>{{.i18n.Tr "mail.hi_user_x" .DisplayName | Str2html}}</p><br>
 	<p>{{.i18n.Tr "mail.reset_password.text" .ResetPwdCodeLives | Str2html}}</p><p><a href="{{$recover_url}}">{{$recover_url}}</a></p><br>
-	<p>{{.i18n.Tr "mail.link_not_working_do_paste" .DisplayName AppName | Str2html}}</p>
+	<p>{{.i18n.Tr "mail.link_not_working_do_paste"}}</p>
 
 	<p>© <a target="_blank" rel="noopener noreferrer" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>


### PR DESCRIPTION
Removed unused variable passed to mail.link_not_working_do_paste.

Fixes #17023 