### PR TITLE
Update go-chi/session (fixes "race" in tests)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	gitea.com/go-chi/binding v0.0.0-20210301195521-1fe1c9a555e7
 	gitea.com/go-chi/cache v0.0.0-20210110083709-82c4c9ce2d5e
 	gitea.com/go-chi/captcha v0.0.0-20210110083842-e7696c336a1e
-	gitea.com/go-chi/session v0.0.0-20210108030337-0cb48c5ba8ee
+	gitea.com/go-chi/session v0.0.0-20210913064732-2ac132b0fa07
 	gitea.com/lunny/levelqueue v0.4.1
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ gitea.com/go-chi/cache v0.0.0-20210110083709-82c4c9ce2d5e h1:zgPGaf3kXP0cVm9J0l8
 gitea.com/go-chi/cache v0.0.0-20210110083709-82c4c9ce2d5e/go.mod h1:k2V/gPDEtXGjjMGuBJiapffAXTv76H4snSmlJRLUhH0=
 gitea.com/go-chi/captcha v0.0.0-20210110083842-e7696c336a1e h1:YjaQU6XFicdhPN+MlGolcXO8seYY2+EY5g7vZPB17CQ=
 gitea.com/go-chi/captcha v0.0.0-20210110083842-e7696c336a1e/go.mod h1:nfA7JaGv3hbGQ1ktdhAsZhdS84qKffI8NMlHr+Opsog=
-gitea.com/go-chi/session v0.0.0-20210108030337-0cb48c5ba8ee h1:9U6HuKUBt/cGK6T/64dEuz0r7Yp97WAAEJvXHDlY3ws=
-gitea.com/go-chi/session v0.0.0-20210108030337-0cb48c5ba8ee/go.mod h1:Ozg8IchVNb/Udg+ui39iHRYqVHSvf3C99ixdpLR8Vu0=
+gitea.com/go-chi/session v0.0.0-20210913064732-2ac132b0fa07 h1:1xF0xbIgDWnBB0iURAUFCoac4KfhGDdI7y7+3/8I8i4=
+gitea.com/go-chi/session v0.0.0-20210913064732-2ac132b0fa07/go.mod h1:Ozg8IchVNb/Udg+ui39iHRYqVHSvf3C99ixdpLR8Vu0=
 gitea.com/lunny/levelqueue v0.4.1 h1:RZ+AFx5gBsZuyqCvofhAkPQ9uaVDPJnsULoJZIYaJNw=
 gitea.com/lunny/levelqueue v0.4.1/go.mod h1:HBqmLbz56JWpfEGG0prskAV97ATNRoj5LDmPicD22hU=
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a h1:lSA0F4e9A2NcQSqGqTOXqu2aRi/XEQxDCBwM8yJtE6s=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ gitea.com/go-chi/cache/memcache
 # gitea.com/go-chi/captcha v0.0.0-20210110083842-e7696c336a1e
 ## explicit
 gitea.com/go-chi/captcha
-# gitea.com/go-chi/session v0.0.0-20210108030337-0cb48c5ba8ee
+# gitea.com/go-chi/session v0.0.0-20210913064732-2ac132b0fa07
 ## explicit
 gitea.com/go-chi/session
 gitea.com/go-chi/session/couchbase


### PR DESCRIPTION
Update to latest go-chi/session where the NewManager causes a new
Provider instantiation instead of reconfiguring an old one.
(https://gitea.com/go-chi/session/pulls/1)

The NewManager call is now concurrency safe and would allow live
reconfiguration in future but for now this PR simply fixes an
intermittent "data-race" detected in our tests.  (See
https://drone.gitea.io/go-gitea/gitea/43900/2/14)

Related #17027
Related #1441

Signed-off-by: Andrew Thornton <art27@cantab.net>
