### PR TITLE
Always emit the configuration path

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -31,6 +31,7 @@ func runConvert(ctx *cli.Context) error {
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)
 	log.Info("Log path: %s", setting.LogRootPath)
+	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
 	if !setting.Database.UseMySQL {

--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -84,6 +84,7 @@ func runDumpRepository(ctx *cli.Context) error {
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)
 	log.Info("Log path: %s", setting.LogRootPath)
+	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
 	var (

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -32,6 +32,7 @@ func runMigrate(ctx *cli.Context) error {
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)
 	log.Info("Log path: %s", setting.LogRootPath)
+	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {

--- a/cmd/migrate_storage.go
+++ b/cmd/migrate_storage.go
@@ -114,6 +114,7 @@ func runMigrateStorage(ctx *cli.Context) error {
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)
 	log.Info("Log path: %s", setting.LogRootPath)
+	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
 	if err := models.NewEngine(context.Background(), migrations.Migrate); err != nil {

--- a/routers/init.go
+++ b/routers/init.go
@@ -81,6 +81,7 @@ func GlobalInit(ctx context.Context) {
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)
 	log.Info("Log path: %s", setting.LogRootPath)
+	log.Info("Configuration file: %s", setting.CustomConf)
 	log.Info("Run Mode: %s", strings.Title(setting.RunMode))
 
 	// Setup i18n

--- a/routers/install/setting.go
+++ b/routers/install/setting.go
@@ -22,6 +22,7 @@ func PreloadSettings(ctx context.Context) bool {
 		log.Info("AppWorkPath: %s", setting.AppWorkPath)
 		log.Info("Custom path: %s", setting.CustomPath)
 		log.Info("Log path: %s", setting.LogRootPath)
+		log.Info("Configuration file: %s", setting.CustomConf)
 		log.Info("Preparing to run install page")
 		translation.InitLocales()
 		if setting.EnableSQLite3 {


### PR DESCRIPTION
Often when handling problems it is not clear which configuration file Gitea is
using. This PR simply ensures that the configuration file is emitted.

Signed-off-by: Andrew Thornton <art27@cantab.net>
