### PR TITLE
Fix bug of migrate comments which only fetch one page

### DIFF
--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -535,6 +535,8 @@ func (g *GithubDownloaderV3) GetAllComments(page, perPage int) ([]*base.Comment,
 	if err != nil {
 		return nil, false, fmt.Errorf("error while listing repos: %v", err)
 	}
+	var isEnd = resp.NextPage == 0
+
 	log.Trace("Request get comments %d/%d, but in fact get %d", perPage, page, len(comments))
 	g.rate = &resp.Rate
 	for _, comment := range comments {
@@ -575,7 +577,7 @@ func (g *GithubDownloaderV3) GetAllComments(page, perPage int) ([]*base.Comment,
 		})
 	}
 
-	return allComments, len(allComments) < perPage, nil
+	return allComments, isEnd, nil
 }
 
 // GetPullRequests returns pull requests according page and perPage

--- a/modules/migrations/github.go
+++ b/modules/migrations/github.go
@@ -521,6 +521,9 @@ func (g *GithubDownloaderV3) GetAllComments(page, perPage int) ([]*base.Comment,
 		created     = "created"
 		asc         = "asc"
 	)
+	if perPage > g.maxPerPage {
+		perPage = g.maxPerPage
+	}
 	opt := &github.IssueListCommentsOptions{
 		Sort:      &created,
 		Direction: &asc,
@@ -537,7 +540,7 @@ func (g *GithubDownloaderV3) GetAllComments(page, perPage int) ([]*base.Comment,
 	}
 	var isEnd = resp.NextPage == 0
 
-	log.Trace("Request get comments %d/%d, but in fact get %d", perPage, page, len(comments))
+	log.Trace("Request get comments %d/%d, but in fact get %d, next page is %d", perPage, page, len(comments), resp.NextPage)
 	g.rate = &resp.Rate
 	for _, comment := range comments {
 		// get reactions


### PR DESCRIPTION
This will fix a bug when migrating comments from github which only fetch one page because of wrong pagination calculation.

When requesting get comments perPage as 1000, but github returned maximum 100, then `isEnd != gotNumber < requestNumber`.

Caused by https://github.com/go-gitea/gitea/pull/16070/files#diff-ef4e6341279bca2a7bdb3242b667b31051663c5a0f56c115060326feeadb2fe3R603