### PR TITLE
Add minimum versions of databases to the docs

### DIFF
--- a/docs/content/doc/installation/database-preparation.en-us.md
+++ b/docs/content/doc/installation/database-preparation.en-us.md
@@ -15,7 +15,7 @@ menu:
 
 # Database Preparation
 
-You need a database to use Gitea. Gitea supports PostgreSQL, MySQL, SQLite, and MSSQL. This page will guide into preparing database. Only PostgreSQL and MySQL will be covered here since those database engines are widely-used in production.
+You need a database to use Gitea. Gitea supports PostgreSQL (>=10), MySQL (>=5.7), SQLite, and MSSQL (>=2008R2 SP3). This page will guide into preparing database. Only PostgreSQL and MySQL will be covered here since those database engines are widely-used in production.
 
 Database instance can be on same machine as Gitea (local database setup), or on different machine (remote database).
 

--- a/docs/content/page/index.en-us.md
+++ b/docs/content/page/index.en-us.md
@@ -69,10 +69,10 @@ Windows, on architectures like amd64, i386, ARM, PowerPC, and others.
 - Logging
 - Configuration
     - Databases
-        - MySQL
-        - PostgreSQL
+        - MySQL (>=5.7)
+        - PostgreSQL (>=10)
         - SQLite3
-        - MSSQL
+        - MSSQL (>=2008R2 SP3)
         - TiDB (experimental, not recommended)
     - Configuration file
         - [app.ini](https://github.com/go-gitea/gitea/blob/master/custom/conf/app.example.ini)


### PR DESCRIPTION
We do not currently state the minimum versions of databases we support.

This PR sets them to:
* MySQL >=5.7
* Postgres >=10
* MSSQL >=2008R2 SP3

Reference #17067

Signed-off-by: Andrew Thornton <art27@cantab.net>
