### PR TITLE
Changelog 1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
+## [1.15.3](https://github.com/go-gitea/gitea/releases/tag/v1.15.3) - 2021-09-19
+
+* ENHANCEMENTS
+  * Add fluid to ui container class to remove margin (#16396) (#16976)
+  * Add caller to cat-file batch calls (#17082) (#17089)
+* BUGFIXES
+  * Render full plain readme. (#17083) (#17090)
+  * Upgrade xorm to v1.2.4 (#17059)
+  * Fix bug of migrate comments which only fetch one page (#17055) (#17058)
+  * Do not show issue context popup on external issues (#17050) (#17054)
+  * Decrement Fork Num when converting from Fork (#17035) (#17046)
+  * Correctly rollback in ForkRepository (#17034) (#17045)
+  * Fix missing close in WalkGitLog (#17008) (#17009)
+  * Add prefix to SVG id/class attributes (#16997) (#17000)
+  * Fix bug of migrated repository not index (#16991) (#16996)
+  * Skip AllowedUserVisibilityModes validation on update user if it is an organisation (#16988) (#16990)
+  * Fix storage Iterate bug and Add storage doctor to delete garbage attachments (#16971) (#16977)
+  * Fix issue with issue default mail template (#16956) (#16975)
+  * Ensure that rebase conflicts are handled in updates (#16952) (#16960)
+  * Prevent panic on diff generation (#16950) (#16951)
+
 ## [1.15.2](https://github.com/go-gitea/gitea/releases/tag/v1.15.2) - 2021-09-03
 
 * BUGFIXES


### PR DESCRIPTION
## [1.15.3](https://github.com/go-gitea/gitea/releases/tag/v1.15.3) - 2021-09-19

* ENHANCEMENTS
  * Add fluid to ui container class to remove margin (#16396) (#16976)
  * Add caller to cat-file batch calls (#17082) (#17089)
* BUGFIXES
  * Render full plain readme. (#17083) (#17090)
  * Upgrade xorm to v1.2.4 (#17059)
  * Fix bug of migrate comments which only fetch one page (#17055) (#17058)
  * Do not show issue context popup on external issues (#17050) (#17054)
  * Decrement Fork Num when converting from Fork (#17035) (#17046)
  * Correctly rollback in ForkRepository (#17034) (#17045)
  * Fix missing close in WalkGitLog (#17008) (#17009)
  * Add prefix to SVG id/class attributes (#16997) (#17000)
  * Fix bug of migrated repository not index (#16991) (#16996)
  * Skip AllowedUserVisibilityModes validation on update user if it is an organisation (#16988) (#16990)
  * Fix storage Iterate bug and Add storage doctor to delete garbage attachments (#16971) (#16977)
  * Fix issue with issue default mail template (#16956) (#16975)
  * Ensure that rebase conflicts are handled in updates (#16952) (#16960)
  * Prevent panic on diff generation (#16950) (#16951)

Signed-off-by: Andrew Thornton <art27@cantab.net>
