### PR TITLE
Add API to get commit diff/patch

### DIFF
--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -109,3 +109,19 @@ func TestAPIReposGitCommitListDifferentBranch(t *testing.T) {
 	assert.Equal(t, "f27c2b2b03dcab38beaf89b0ab4ff61f6de63441", apiData[0].CommitMeta.SHA)
 	compareCommitFiles(t, []string{"readme.md"}, apiData[0].Files)
 }
+
+func TestDownloadCommitDiffOrPatch(t *testing.T) {
+	defer prepareTestEnv(t)()
+	user := db.AssertExistsAndLoadBean(t, &models.User{ID: 2}).(*models.User)
+	// Login as User2.
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	// Test getting diff
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.diff?token="+token, user.Name)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+
+	// Test getting patch
+	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.patch?token="+token, user.Name)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+}

--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -119,9 +119,11 @@ func TestDownloadCommitDiffOrPatch(t *testing.T) {
 
 	// Test getting diff
 	reqDiff := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.diff?token="+token, user.Name)
-	session.MakeRequest(t, reqDiff, http.StatusOK)
+	resp := session.MakeRequest(t, reqDiff, http.StatusOK)
+	assert.EqualValues(t, "commit f27c2b2b03dcab38beaf89b0ab4ff61f6de63441\nAuthor: User2 <user2@example.com>\nDate:   Sun Aug 6 19:55:01 2017 +0200\n\n    good signed commit\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n", string(resp.Body.Bytes()))
 
 	// Test getting patch
 	reqPatch := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.patch?token="+token, user.Name)
-	session.MakeRequest(t, reqPatch, http.StatusOK)
+	resp = session.MakeRequest(t, reqPatch, http.StatusOK)
+	assert.EqualValues(t, "From f27c2b2b03dcab38beaf89b0ab4ff61f6de63441 Mon Sep 17 00:00:00 2001\nFrom: User2 <user2@example.com>\nDate: Sun, 6 Aug 2017 19:55:01 +0200\nSubject: [PATCH] good signed commit\n\n---\n readme.md | 1 +\n 1 file changed, 1 insertion(+)\n create mode 100644 readme.md\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n", string(resp.Body.Bytes()))
 }

--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -118,10 +118,10 @@ func TestDownloadCommitDiffOrPatch(t *testing.T) {
 	token := getTokenForLoggedInUser(t, session)
 
 	// Test getting diff
-	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.diff?token="+token, user.Name)
-	resp := session.MakeRequest(t, req, http.StatusOK)
+	reqDiff := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.diff?token="+token, user.Name)
+	session.MakeRequest(t, reqDiff, http.StatusOK)
 
 	// Test getting patch
-	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.patch?token="+token, user.Name)
-	resp := session.MakeRequest(t, req, http.StatusOK)
+	reqPatch := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.patch?token="+token, user.Name)
+	session.MakeRequest(t, reqPatch, http.StatusOK)
 }

--- a/integrations/api_repo_git_commits_test.go
+++ b/integrations/api_repo_git_commits_test.go
@@ -120,10 +120,15 @@ func TestDownloadCommitDiffOrPatch(t *testing.T) {
 	// Test getting diff
 	reqDiff := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.diff?token="+token, user.Name)
 	resp := session.MakeRequest(t, reqDiff, http.StatusOK)
-	assert.EqualValues(t, "commit f27c2b2b03dcab38beaf89b0ab4ff61f6de63441\nAuthor: User2 <user2@example.com>\nDate:   Sun Aug 6 19:55:01 2017 +0200\n\n    good signed commit\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n", string(resp.Body.Bytes()))
+	assert.EqualValues(t,
+		"commit f27c2b2b03dcab38beaf89b0ab4ff61f6de63441\nAuthor: User2 <user2@example.com>\nDate:   Sun Aug 6 19:55:01 2017 +0200\n\n    good signed commit\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n",
+		resp.Body.String())
 
 	// Test getting patch
 	reqPatch := NewRequestf(t, "GET", "/api/v1/repos/%s/repo16/git/commits/f27c2b2b03dcab38beaf89b0ab4ff61f6de63441.patch?token="+token, user.Name)
 	resp = session.MakeRequest(t, reqPatch, http.StatusOK)
-	assert.EqualValues(t, "From f27c2b2b03dcab38beaf89b0ab4ff61f6de63441 Mon Sep 17 00:00:00 2001\nFrom: User2 <user2@example.com>\nDate: Sun, 6 Aug 2017 19:55:01 +0200\nSubject: [PATCH] good signed commit\n\n---\n readme.md | 1 +\n 1 file changed, 1 insertion(+)\n create mode 100644 readme.md\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n", string(resp.Body.Bytes()))
+	assert.EqualValues(t,
+		"From f27c2b2b03dcab38beaf89b0ab4ff61f6de63441 Mon Sep 17 00:00:00 2001\nFrom: User2 <user2@example.com>\nDate: Sun, 6 Aug 2017 19:55:01 +0200\nSubject: [PATCH] good signed commit\n\n---\n readme.md | 1 +\n 1 file changed, 1 insertion(+)\n create mode 100644 readme.md\n\ndiff --git a/readme.md b/readme.md\nnew file mode 100644\nindex 0000000..458121c\n--- /dev/null\n+++ b/readme.md\n@@ -0,0 +1 @@\n+good sign\n",
+		resp.Body.String())
+
 }

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -937,10 +937,7 @@ func Routes(sessioner func(http.Handler) http.Handler) *web.Route {
 				m.Group("/git", func() {
 					m.Group("/commits", func() {
 						m.Get("/{sha}", repo.GetSingleCommit)
-						m.Get("/{sha}.diff",
-							repo.DownloadCommitDiff)
-						m.Get("/{sha}.patch",
-							repo.DownloadCommitPatch)
+						m.Get("/{sha}.{diffType:diff|patch}", repo.DownloadCommitDiffOrPatch)
 					})
 					m.Get("/refs", repo.GetGitAllRefs)
 					m.Get("/refs/*", repo.GetGitRefs)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -937,6 +937,10 @@ func Routes(sessioner func(http.Handler) http.Handler) *web.Route {
 				m.Group("/git", func() {
 					m.Group("/commits", func() {
 						m.Get("/{sha}", repo.GetSingleCommit)
+						m.Get("/{sha}.diff",
+							repo.DownloadCommitDiff)
+						m.Get("/{sha}.patch",
+							repo.DownloadCommitPatch)
 					})
 					m.Get("/refs", repo.GetGitAllRefs)
 					m.Get("/refs/*", repo.GetGitRefs)

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -275,8 +275,7 @@ func DownloadCommitPatch(ctx *context.APIContext) {
 }
 
 func DownloadCommitDiffOrPatch(ctx *context.APIContext, diffType string) {
-	var repoPath string
-	repoPath = models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	repoPath := models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 	if err := git.GetRawDiff(
 		repoPath,
 		ctx.Params(":sha"),

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -214,11 +214,11 @@ func GetAllCommits(ctx *context.APIContext) {
 	ctx.JSON(http.StatusOK, &apiCommits)
 }
 
-// DownloadCommitDiff render a commit's raw diff
-func DownloadCommitDiff(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha}.diff repository repoDownloadCommitDiff
+// DownloadCommitDiffOrPatch render a commit's raw diff or patch
+func DownloadCommitDiffOrPatch(ctx *context.APIContext) {
+	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha}.{diffType} repository repoDownloadCommitDiffOrPatch
 	// ---
-	// summary: Get a commit diff
+	// summary: Get a commit's diff or patch
 	// produces:
 	// - text/plain
 	// parameters:
@@ -237,52 +237,22 @@ func DownloadCommitDiff(ctx *context.APIContext) {
 	//   description: SHA of the commit to get
 	//   type: string
 	//   required: true
+	// - name: diffType
+	//	 in: path
+	//	 description: whether the output is diff or patch
+	//	 type: string
+	//	 enum: [diff, patch]
+	//	 required: true
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/string"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
-	DownloadCommitDiffOrPatch(ctx, "diff")
-}
-
-// DownloadCommitPatch render a commit's raw patch
-func DownloadCommitPatch(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha}.patch repository repoDownloadCommitPatch
-	// ---
-	// summary: Get a commit patch
-	// produces:
-	// - text/plain
-	// parameters:
-	// - name: owner
-	//   in: path
-	//   description: owner of the repo
-	//   type: string
-	//   required: true
-	// - name: repo
-	//   in: path
-	//   description: name of the repo
-	//   type: string
-	//   required: true
-	// - name: sha
-	//   in: path
-	//   description: SHA of the commit to get
-	//   type: string
-	//   required: true
-	// responses:
-	//   "200":
-	//     "$ref": "#/responses/string"
-	//   "404":
-	//     "$ref": "#/responses/notFound"
-	DownloadCommitDiffOrPatch(ctx, "patch")
-}
-
-// DownloadCommitDiffOrPatch render a commit's raw diff
-func DownloadCommitDiffOrPatch(ctx *context.APIContext, diffType string) {
 	repoPath := models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 	if err := git.GetRawDiff(
 		repoPath,
 		ctx.Params(":sha"),
-		git.RawDiffType(diffType),
+		git.RawDiffType(ctx.Params(":type")),
 		ctx.Resp,
 	); err != nil {
 		if git.IsErrNotExist(err) {

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -238,11 +238,11 @@ func DownloadCommitDiffOrPatch(ctx *context.APIContext) {
 	//   type: string
 	//   required: true
 	// - name: diffType
-	//	 in: path
-	//	 description: whether the output is diff or patch
-	//	 type: string
-	//	 enum: [diff, patch]
-	//	 required: true
+	//   in: path
+	//   description: whether the output is diff or patch
+	//   type: string
+	//   enum: [diff, patch]
+	//   required: true
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/string"

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -252,7 +252,7 @@ func DownloadCommitDiffOrPatch(ctx *context.APIContext) {
 	if err := git.GetRawDiff(
 		repoPath,
 		ctx.Params(":sha"),
-		git.RawDiffType(ctx.Params(":type")),
+		git.RawDiffType(ctx.Params(":diffType")),
 		ctx.Resp,
 	); err != nil {
 		if git.IsErrNotExist(err) {

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -214,6 +214,7 @@ func GetAllCommits(ctx *context.APIContext) {
 	ctx.JSON(http.StatusOK, &apiCommits)
 }
 
+// DownloadCommitDiff render a commit's raw diff
 func DownloadCommitDiff(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha}.diff repository repoDownloadCommitDiff
 	// ---
@@ -244,6 +245,7 @@ func DownloadCommitDiff(ctx *context.APIContext) {
 	DownloadCommitDiffOrPatch(ctx, "diff")
 }
 
+// DownloadCommitPatch render a commit's raw patch
 func DownloadCommitPatch(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/commits/{sha}.patch repository repoDownloadCommitPatch
 	// ---
@@ -274,6 +276,7 @@ func DownloadCommitPatch(ctx *context.APIContext) {
 	DownloadCommitDiffOrPatch(ctx, "patch")
 }
 
+// DownloadCommitDiffOrPatch render a commit's raw diff
 func DownloadCommitDiffOrPatch(ctx *context.APIContext, diffType string) {
 	repoPath := models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 	if err := git.GetRawDiff(

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3581,7 +3581,7 @@
         }
       }
     },
-    "/repos/{owner}/{repo}/git/commits/{sha}.diff": {
+    "/repos/{owner}/{repo}/git/commits/{sha}.{diffType}": {
       "get": {
         "produces": [
           "text/plain"
@@ -3589,51 +3589,8 @@
         "tags": [
           "repository"
         ],
-        "summary": "Get a commit diff",
-        "operationId": "repoDownloadCommitDiff",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "owner of the repo",
-            "name": "owner",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of the repo",
-            "name": "repo",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "SHA of the commit to get",
-            "name": "sha",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/string"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          }
-        }
-      }
-    },
-    "/repos/{owner}/{repo}/git/commits/{sha}.patch": {
-      "get": {
-        "produces": [
-          "text/plain"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Get a commit patch",
-        "operationId": "repoDownloadCommitPatch",
+        "summary": "Get a commit's diff or patch",
+        "operationId": "repoDownloadCommitDiffOrPatch",
         "parameters": [
           {
             "type": "string",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3612,6 +3612,17 @@
             "name": "sha",
             "in": "path",
             "required": true
+          },
+          {
+            "enum": [
+              "diff",
+              "patch"
+            ],
+            "type": "string",
+            "description": "whether the output is diff or patch",
+            "name": "diffType",
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3581,6 +3581,92 @@
         }
       }
     },
+    "/repos/{owner}/{repo}/git/commits/{sha}.diff": {
+      "get": {
+        "produces": [
+          "text/plain"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Get a commit diff",
+        "operationId": "repoDownloadCommitDiff",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "SHA of the commit to get",
+            "name": "sha",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/string"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/commits/{sha}.patch": {
+      "get": {
+        "produces": [
+          "text/plain"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Get a commit patch",
+        "operationId": "repoDownloadCommitPatch",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "SHA of the commit to get",
+            "name": "sha",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/string"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      }
+    },
     "/repos/{owner}/{repo}/git/notes/{sha}": {
       "get": {
         "produces": [


### PR DESCRIPTION
This PR adds an API endpoint to get the diff or patch file of a commit. It uses the same mechanism as the "site" `<host>/<owner>/<repo>/commit/<sha>.<diff or patch>`.

Endpoints:
Get diff `/repos/{owner}/{repo}/git/commits/{sha}.diff`
Get patch `/repos/{owner}/{repo}/git/commits/{sha}.patch`

Could close #10921 #13012