### PR TITLE
Set -i on git read-tree

### DIFF
--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -266,7 +266,7 @@ func TestCantMergeUnrelated(t *testing.T) {
 		}).(*models.Repository)
 		path := models.RepoPath(user1.Name, repo1.Name)
 
-		_, err := git.NewCommand("read-tree", "--empty").RunInDir(path)
+		_, err := git.NewCommand("read-tree", "-i", "--empty").RunInDir(path)
 		assert.NoError(t, err)
 
 		stdin := bytes.NewBufferString("Unrelated File")

--- a/modules/git/repo_index.go
+++ b/modules/git/repo_index.go
@@ -38,7 +38,7 @@ func (repo *Repository) readTreeToIndex(id SHA1, indexFilename ...string) error 
 	if len(indexFilename) > 0 {
 		env = append(os.Environ(), "GIT_INDEX_FILE="+indexFilename[0])
 	}
-	_, err := NewCommand("read-tree", id.String()).RunInDirWithEnv(repo.Path, env)
+	_, err := NewCommand("read-tree", "-i", id.String()).RunInDirWithEnv(repo.Path, env)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (repo *Repository) ReadTreeToTemporaryIndex(treeish string) (filename strin
 
 // EmptyIndex empties the index
 func (repo *Repository) EmptyIndex() error {
-	_, err := NewCommand("read-tree", "--empty").RunInDir(repo.Path)
+	_, err := NewCommand("read-tree", "-i", "--empty").RunInDir(repo.Path)
 	return err
 }
 

--- a/modules/repofiles/temp_repo.go
+++ b/modules/repofiles/temp_repo.go
@@ -75,7 +75,7 @@ func (t *TemporaryUploadRepository) Clone(branch string) error {
 
 // SetDefaultIndex sets the git index to our HEAD
 func (t *TemporaryUploadRepository) SetDefaultIndex() error {
-	if _, err := git.NewCommand("read-tree", "HEAD").RunInDir(t.basePath); err != nil {
+	if _, err := git.NewCommand("read-tree", "-i", "HEAD").RunInDir(t.basePath); err != nil {
 		return fmt.Errorf("SetDefaultIndex: %v", err)
 	}
 	return nil

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -202,7 +202,7 @@ func rawMerge(pr *models.PullRequest, doer *models.User, mergeStyle models.Merge
 	errbuf.Reset()
 
 	// Read base branch index
-	if err := git.NewCommand("read-tree", "HEAD").RunInDirPipeline(tmpBasePath, &outbuf, &errbuf); err != nil {
+	if err := git.NewCommand("read-tree", "-i", "HEAD").RunInDirPipeline(tmpBasePath, &outbuf, &errbuf); err != nil {
 		log.Error("git read-tree HEAD: %v\n%s\n%s", err, outbuf.String(), errbuf.String())
 		return "", fmt.Errorf("Unable to read base branch in to the index: %v\n%s\n%s", err, outbuf.String(), errbuf.String())
 	}

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -137,7 +137,7 @@ func checkConflicts(pr *models.PullRequest, gitRepo *git.Repository, tmpBasePath
 	pr.Status = models.PullRequestStatusChecking
 
 	// 3. Read the base branch in to the index of the temporary repository
-	_, err = git.NewCommand("read-tree", "base").RunInDir(tmpBasePath)
+	_, err = git.NewCommand("read-tree", "-i", "base").RunInDir(tmpBasePath)
 	if err != nil {
 		return false, fmt.Errorf("git read-tree %s: %v", pr.BaseBranch, err)
 	}


### PR DESCRIPTION
None of our uses of read-tree are supposed to affect the working-tree therefore
explicitly ignore it.

Fix #17092

Signed-off-by: Andrew Thornton <art27@cantab.net>
