### PR TITLE
Unify issue and PR subtitles

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1197,11 +1197,11 @@ issues.action_milestone_no_select = No milestone
 issues.action_assignee = Assignee
 issues.action_assignee_no_select = No assignee
 issues.opened_by = opened %[1]s by <a href="%[2]s">%[3]s</a>
-pulls.merged_by = by <a href="%[2]s">%[3]s</a> merged %[1]s
-pulls.merged_by_fake = by %[2]s merged %[1]s
-issues.closed_by = by <a href="%[2]s">%[3]s</a> closed %[1]s
-issues.opened_by_fake = by %[2]s opened %[1]s
-issues.closed_by_fake = by %[2]s closed %[1]s
+pulls.merged_by = merged %[1]s by <a href="%[2]s">%[3]s</a>
+pulls.merged_by_fake = merged %[1]s by %[2]s
+issues.closed_by = closed %[1]s by <a href="%[2]s">%[3]s</a>
+issues.opened_by_fake = opened %[1]s by %[2]s
+issues.closed_by_fake = closed %[1]s by %[2]s
 issues.previous = Previous
 issues.next = Next
 issues.open_title = Open


### PR DESCRIPTION
After a migration from GitHub open issues and pulls have differently worded subtitles.

I changed every wording to be similar to GitHub and  unified across every usage.

Before:
![open_issues](https://user-images.githubusercontent.com/23100555/134536858-fd74ba3c-277d-4f23-85a9-0c9e20c8a6b4.png)
![closed_issues](https://user-images.githubusercontent.com/23100555/134536899-f47bc552-5b57-4a9f-ac06-811f705b20d7.png)
![open_pulls](https://user-images.githubusercontent.com/23100555/134536939-c8d3ce1a-d800-49ae-a5e7-82cf55d5772c.png)
![closed_pulls](https://user-images.githubusercontent.com/23100555/134536998-a5462df9-a62b-464b-8f85-a5b45a4eb8f7.png)

After:
![open_issues_new](https://user-images.githubusercontent.com/23100555/134538402-b2bef2ac-1263-4bb6-88e0-c7806093d67e.png)
![closed_issues_new](https://user-images.githubusercontent.com/23100555/134538430-ebebb1c0-a870-4afb-9693-5ca8a82c8d55.png)
![open_pulls_new](https://user-images.githubusercontent.com/23100555/134538494-e1d82fe8-46be-496a-a27f-ba40db3416aa.png)
![closed_pulls_new](https://user-images.githubusercontent.com/23100555/134538527-4a47081c-6ed9-4a35-a457-66f9be1a4fc0.png)
