### PR TITLE
Prevent dangling cat-files (#17154)

### DIFF
--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -92,10 +92,8 @@ func CatFileBatch(repoPath string) (io.WriteCloser, *bufio.Reader, func()) {
 
 	cancel := func() {
 		ctxCancel()
-		_ = batchStdinReader.Close()
 		_ = batchStdinWriter.Close()
 		_ = batchStdoutReader.Close()
-		_ = batchStdoutWriter.Close()
 	}
 
 	go func() {

--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"code.gitea.io/gitea/modules/log"
 
@@ -41,29 +40,15 @@ func CatFileBatchCheck(repoPath string) (io.WriteCloser, *bufio.Reader, func()) 
 	cmd := NewCommandContext(ctx, "cat-file", "--batch-check").
 		SetDescription(desc)
 
-	closed := make(chan struct{})
 	cancel := func() {
 		ctxCancel()
 		_ = batchStdinReader.Close()
 		_ = batchStdinWriter.Close()
 		_ = batchStdoutReader.Close()
 		_ = batchStdoutWriter.Close()
-		for {
-			select {
-			case <-closed:
-				return
-			case <-time.After(10 * time.Second):
-				log.Warn("%s still running 10s after cancellation. Reattempt Kill", desc)
-				err := cmd.Kill()
-				if err != nil {
-					log.Error("Error whilst trying to kill: %s. Error: %v", desc, err)
-				}
-			}
-		}
 	}
 
 	go func() {
-		defer close(closed)
 		defer ctxCancel()
 
 		stderr := strings.Builder{}
@@ -105,29 +90,15 @@ func CatFileBatch(repoPath string) (io.WriteCloser, *bufio.Reader, func()) {
 	cmd := NewCommandContext(ctx, "cat-file", "--batch").
 		SetDescription(desc)
 
-	closed := make(chan struct{})
 	cancel := func() {
 		ctxCancel()
 		_ = batchStdinReader.Close()
 		_ = batchStdinWriter.Close()
 		_ = batchStdoutReader.Close()
 		_ = batchStdoutWriter.Close()
-		for {
-			select {
-			case <-closed:
-				return
-			case <-time.After(10 * time.Second):
-				log.Warn("%s still running 10s after cancellation. Reattempt Kill", desc)
-				err := cmd.Kill()
-				if err != nil {
-					log.Error("Error whilst trying to kill: %s. Error: %v", desc, err)
-				}
-			}
-		}
 	}
 
 	go func() {
-		defer close(closed)
 		defer ctxCancel()
 
 		stderr := strings.Builder{}

--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -29,7 +29,7 @@ func CatFileBatchCheck(repoPath string) (io.WriteCloser, *bufio.Reader, func()) 
 	if err != nil {
 		log.Critical("Unable to open pipe for cat-file --batch: %v", err)
 		rd, wr := io.Pipe()
-		rd.CloseWithError(err)
+		_ = rd.CloseWithError(err)
 		return wr, bufio.NewReader(rd), nil
 	}
 	batchStdoutReader, batchStdoutWriter := io.Pipe()
@@ -91,7 +91,7 @@ func CatFileBatch(repoPath string) (io.WriteCloser, *bufio.Reader, func()) {
 	if err != nil {
 		log.Critical("Unable to open pipe for cat-file --batch: %v", err)
 		rd, wr := io.Pipe()
-		rd.CloseWithError(err)
+		_ = rd.CloseWithError(err)
 		return wr, bufio.NewReader(rd), nil
 	}
 

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -36,6 +36,7 @@ type Command struct {
 	args          []string
 	parentContext context.Context
 	desc          string
+	cmd           *exec.Cmd
 }
 
 func (c *Command) String() string {
@@ -123,15 +124,15 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 	ctx, cancel := context.WithTimeout(c.parentContext, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, c.name, c.args...)
+	c.cmd = exec.CommandContext(ctx, c.name, c.args...)
 	if env == nil {
-		cmd.Env = os.Environ()
+		c.cmd.Env = os.Environ()
 	} else {
-		cmd.Env = env
+		c.cmd.Env = env
 	}
 
-	cmd.Env = append(
-		cmd.Env,
+	c.cmd.Env = append(
+		c.cmd.Env,
 		fmt.Sprintf("LC_ALL=%s", DefaultLocale),
 		// avoid prompting for credentials interactively, supported since git v2.3
 		"GIT_TERMINAL_PROMPT=0",
@@ -139,13 +140,13 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 
 	// TODO: verify if this is still needed in golang 1.15
 	if goVersionLessThan115 {
-		cmd.Env = append(cmd.Env, "GODEBUG=asyncpreemptoff=1")
+		c.cmd.Env = append(c.cmd.Env, "GODEBUG=asyncpreemptoff=1")
 	}
-	cmd.Dir = dir
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	cmd.Stdin = stdin
-	if err := cmd.Start(); err != nil {
+	c.cmd.Dir = dir
+	c.cmd.Stdout = stdout
+	c.cmd.Stderr = stderr
+	c.cmd.Stdin = stdin
+	if err := c.cmd.Start(); err != nil {
 		return err
 	}
 
@@ -160,16 +161,25 @@ func (c *Command) RunInDirTimeoutEnvFullPipelineFunc(env []string, timeout time.
 		err := fn(ctx, cancel)
 		if err != nil {
 			cancel()
-			_ = cmd.Wait()
+			_ = c.cmd.Wait()
 			return err
 		}
 	}
 
-	if err := cmd.Wait(); err != nil && ctx.Err() != context.DeadlineExceeded {
+	if err := c.cmd.Wait(); err != nil && ctx.Err() != context.DeadlineExceeded {
 		return err
 	}
 
 	return ctx.Err()
+}
+
+// Kill kills a running Command - WARNING: This is racy
+func (c *Command) Kill() error {
+	if c.cmd == nil {
+		return nil
+	}
+
+	return c.cmd.Process.Kill()
 }
 
 // RunInDirTimeoutPipeline executes the command in given directory with given timeout,

--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -9,6 +9,7 @@ package git
 import (
 	"bufio"
 	"context"
+	"io"
 	"path"
 
 	"code.gitea.io/gitea/modules/log"
@@ -38,7 +39,7 @@ func NewLastCommitCache(repoPath string, gitRepo *Repository, ttl func() int64, 
 }
 
 // Get get the last commit information by commit id and entry path
-func (c *LastCommitCache) Get(ref, entryPath string, wr WriteCloserError, rd *bufio.Reader) (interface{}, error) {
+func (c *LastCommitCache) Get(ref, entryPath string, wr io.WriteCloser, rd *bufio.Reader) (interface{}, error) {
 	v := c.cache.Get(c.getCacheKey(c.repoPath, ref, entryPath))
 	if vs, ok := v.(string); ok {
 		log.Debug("LastCommitCache hit level 1: [%s:%s:%s]", ref, entryPath, vs)

--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"io"
 	"path/filepath"
 
 	"code.gitea.io/gitea/modules/log"
@@ -26,11 +27,11 @@ type Repository struct {
 
 	batchCancel context.CancelFunc
 	batchReader *bufio.Reader
-	batchWriter WriteCloserError
+	batchWriter io.WriteCloser
 
 	checkCancel context.CancelFunc
 	checkReader *bufio.Reader
-	checkWriter WriteCloserError
+	checkWriter io.WriteCloser
 }
 
 // OpenRepository opens the repository at the given path.
@@ -54,7 +55,7 @@ func OpenRepository(repoPath string) (*Repository, error) {
 }
 
 // CatFileBatch obtains a CatFileBatch for this repository
-func (repo *Repository) CatFileBatch() (WriteCloserError, *bufio.Reader, func()) {
+func (repo *Repository) CatFileBatch() (io.WriteCloser, *bufio.Reader, func()) {
 	if repo.batchCancel == nil || repo.batchReader.Buffered() > 0 {
 		log.Debug("Opening temporary cat file batch for: %s", repo.Path)
 		return CatFileBatch(repo.Path)
@@ -63,7 +64,7 @@ func (repo *Repository) CatFileBatch() (WriteCloserError, *bufio.Reader, func())
 }
 
 // CatFileBatchCheck obtains a CatFileBatchCheck for this repository
-func (repo *Repository) CatFileBatchCheck() (WriteCloserError, *bufio.Reader, func()) {
+func (repo *Repository) CatFileBatchCheck() (io.WriteCloser, *bufio.Reader, func()) {
 	if repo.checkCancel == nil || repo.checkReader.Buffered() > 0 {
 		log.Debug("Opening temporary cat file batch-check: %s", repo.Path)
 		return CatFileBatchCheck(repo.Path)

--- a/modules/indexer/code/bleve.go
+++ b/modules/indexer/code/bleve.go
@@ -177,7 +177,7 @@ func NewBleveIndexer(indexDir string) (*BleveIndexer, bool, error) {
 	return indexer, created, err
 }
 
-func (b *BleveIndexer) addUpdate(batchWriter git.WriteCloserError, batchReader *bufio.Reader, commitSha string,
+func (b *BleveIndexer) addUpdate(batchWriter io.WriteCloser, batchReader *bufio.Reader, commitSha string,
 	update fileUpdate, repo *models.Repository, batch *gitea_bleve.FlushingBatch) error {
 	// Ignore vendored files in code search
 	if setting.Indexer.ExcludeVendored && analyze.IsVendor(update.Filename) {

--- a/modules/indexer/code/elastic_search.go
+++ b/modules/indexer/code/elastic_search.go
@@ -175,7 +175,7 @@ func (b *ElasticSearchIndexer) init() (bool, error) {
 	return exists, nil
 }
 
-func (b *ElasticSearchIndexer) addUpdate(batchWriter git.WriteCloserError, batchReader *bufio.Reader, sha string, update fileUpdate, repo *models.Repository) ([]elastic.BulkableRequest, error) {
+func (b *ElasticSearchIndexer) addUpdate(batchWriter io.WriteCloser, batchReader *bufio.Reader, sha string, update fileUpdate, repo *models.Repository) ([]elastic.BulkableRequest, error) {
 	// Ignore vendored files in code search
 	if setting.Indexer.ExcludeVendored && analyze.IsVendor(update.Filename) {
 		return nil, nil


### PR DESCRIPTION
Backport #17154

In #17138 it appears that on Windows a git cat-file can fail to be killed.

This PR attempts to prevent this by:

1. Using os.Pipes for the input - this should mean that the stdin is definitely closed.
2. If the cat-file is doesn't close properly it will attempt to kill it repeatedly logging this.

Fix #17138

Signed-off-by: Andrew Thornton <art27@cantab.net>
