### PR TITLE
Gitea Snap update issue #16209

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -444,7 +444,19 @@ func getAppPath() (string, error) {
 	}
 	// Note: we don't use path.Dir here because it does not handle case
 	//	which path starts with two "/" in Windows: "//psf/Home/..."
-	return strings.ReplaceAll(appPath, "\\", "/"), err
+	appPath = strings.ReplaceAll(appPath, "\\", "/")
+
+	// Fix issue 16209
+	snap := os.Getenv("SNAP")
+	if snap != "" && strings.HasPrefix(appPath, snap) {
+		split := strings.Split(appPath, "/")
+		if len(split) >= 3 {
+			split[len(split)-2] = "current"
+			appPath = strings.Join(split, "/");
+		}
+	}
+
+	return appPath, err
 }
 
 func getWorkPath(appPath string) string {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -452,7 +452,7 @@ func getAppPath() (string, error) {
 		split := strings.Split(appPath, "/")
 		if len(split) >= 3 {
 			split[len(split)-2] = "current"
-			appPath = strings.Join(split, "/");
+			appPath = strings.Join(split, "/")
 		}
 	}
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -446,7 +446,12 @@ func getAppPath() (string, error) {
 	//	which path starts with two "/" in Windows: "//psf/Home/..."
 	appPath = strings.ReplaceAll(appPath, "\\", "/")
 
-	// Fix issue 16209
+	// Fix issue 16209: When runnung in a snap and repositories are
+	// created, paths in the hooks include the snap revision. But as new
+	// revisions come out the older revisions are eventually deleted, and
+	// the hooks begin to fail.
+	// The code below replaces the snap revision with "current", which
+	// always points to the current snap revision.
 	snap := os.Getenv("SNAP")
 	if snap != "" && strings.HasPrefix(appPath, snap) {
 		split := strings.Split(appPath, "/")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -456,12 +456,21 @@ func getAppPath() (string, error) {
 	if snap != "" && strings.HasPrefix(appPath, snap) {
 		split := strings.Split(appPath, "/")
 		if len(split) >= 3 {
+			oldAppPath := appPath
 			split[len(split)-2] = "current"
-			appPath = strings.Join(split, "/")
+			newAppPath := strings.Join(split, "-")
+			appPath, err = exec.LookPath(newAppPath)
+			if err != nil {
+				appPath = oldAppPath
+				log.error("Could not change AppPath from %s to %s while running in snap. Hooks for new repositories may fail after snap upgrades.", oldAppPath, newAppPath)
+			} else {
+				appPath = newAppPath
+				log.debug("Apppath changed from %s to %s because we are running in snap.", oldAppPath, newAppPath)
+			}
 		}
 	}
 
-	return appPath, err
+	return appPath, nil
 }
 
 func getWorkPath(appPath string) string {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -451,7 +451,7 @@ func getAppPath() (string, error) {
 	// revisions come out the older revisions are eventually deleted, and
 	// the hooks begin to fail.
 	// The code below replaces the snap revision with "current", which
-	// always points to the current snap revision.
+	// is a link to the current snap revision.
 	snap := os.Getenv("SNAP")
 	if snap != "" && strings.HasPrefix(appPath, snap) {
 		split := strings.Split(appPath, "/")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -446,7 +446,7 @@ func getAppPath() (string, error) {
 	//	which path starts with two "/" in Windows: "//psf/Home/..."
 	appPath = strings.ReplaceAll(appPath, "\\", "/")
 
-	// Fix issue 16209: When runnung in a snap and repositories are
+	// Fix issue 16209: When running in a snap and repositories are
 	// created, paths in the hooks include the snap revision. But as new
 	// revisions come out the older revisions are eventually deleted, and
 	// the hooks begin to fail.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -464,7 +464,6 @@ func getAppPath() (string, error) {
 				appPath = oldAppPath
 				log.Error("Could not change AppPath from %s to %s while running in snap. Hooks for new repositories may fail after snap upgrades.", oldAppPath, newAppPath)
 			} else {
-				appPath = newAppPath
 				log.Info("AppPath changed from %s to %s because we are running in snap.", oldAppPath, newAppPath)
 			}
 		}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -458,14 +458,14 @@ func getAppPath() (string, error) {
 		if len(split) >= 3 {
 			oldAppPath := appPath
 			split[len(split)-2] = "current"
-			newAppPath := strings.Join(split, "-")
+			newAppPath := strings.Join(split, "/")
 			appPath, err = exec.LookPath(newAppPath)
 			if err != nil {
 				appPath = oldAppPath
-				log.error("Could not change AppPath from %s to %s while running in snap. Hooks for new repositories may fail after snap upgrades.", oldAppPath, newAppPath)
+				log.Error("Could not change AppPath from %s to %s while running in snap. Hooks for new repositories may fail after snap upgrades.", oldAppPath, newAppPath)
 			} else {
 				appPath = newAppPath
-				log.debug("Apppath changed from %s to %s because we are running in snap.", oldAppPath, newAppPath)
+				log.Info("AppPath changed from %s to %s because we are running in snap.", oldAppPath, newAppPath)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/16209 for new repositories created. The problem is that hooks in new repositories created when running in snap include the snap revision in the path. As the snap is refreshed the hooks eventually break.
This pull request does not fix repositories already created. Here a good workaround has been suggested by JensTheCoder.
Please be aware that I am a newbie to both gitea, snap and golang.