### PR TITLE
Add Horizontal scrollbar to inner menu on Chrome (#17086)

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -181,6 +181,7 @@ details summary > * {
 
 ::-webkit-scrollbar {
   width: 10px;
+  height: 10px;
 }
 ::-webkit-scrollbar-thumb {
   box-shadow: inset 0 0 0 6px var(--color-primary);
@@ -1285,6 +1286,7 @@ footer {
   display: flex;
   margin-left: auto;
   margin-right: auto;
+  overflow-x: auto;
 }
 
 @media @mediaSm {


### PR DESCRIPTION
Backport #17086

There is a longstanding bug whereby the admin pages, in particular, have not had
a horizontal scrollbar on chrome when the page is narrow.

This PR simply adds overflow-x and adds a default height to the scrollbar to
match that of the vertical bar.

Signed-off-by: Andrew Thornton <art27@cantab.net>
