### PR TITLE
Fix wording in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -26,7 +26,7 @@ body:
   id: git-ver
   attributes:
     label: Git Version
-    description: The version of git running on the server's systemm
+    description: The version of git running on the server
 - type: input
   id: os-ver
   attributes:


### PR DESCRIPTION
There was a typo `systemm` here. I opted to just remove the superfluos word altogether.