### PR TITLE
Fix missing repo link in issue/pull assigned emails

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -345,8 +345,8 @@ reset_password.text = Please click the following link to recover your account wi
 
 register_success = Registration successful
 
-issue_assigned.pull = @%[1]s assigned you to the pull request %[2]s in repository %[3]s.
-issue_assigned.issue = @%[1]s assigned you to the issue %[2]s in repository %[3]s.
+issue_assigned.pull = @%[1]s assigned you to pull request %[2]s in repository %[3]s.
+issue_assigned.issue = @%[1]s assigned you to issue %[2]s in repository %[3]s.
 
 issue.x_mentioned_you = <b>@%s</b> mentioned you:
 issue.action.force_push = <b>%[1]s</b> force-pushed the <b>%[2]s</b> from %[3]s to %[4]s.

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -374,7 +374,7 @@ func SendIssueAssignedMail(issue *models.Issue, doer *models.User, content strin
 	}
 
 	if err := issue.LoadRepo(); err != nil {
-		log.Error("Unable to load rep [%d] for issue #%d [%d]. Error: %v", issue.RepoID, issue.Index, issue.ID, err)
+		log.Error("Unable to load repo [%d] for issue #%d [%d]. Error: %v", issue.RepoID, issue.Index, issue.ID, err)
 		return err
 	}
 

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -372,6 +372,12 @@ func SendIssueAssignedMail(issue *models.Issue, doer *models.User, content strin
 		// No mail service configured
 		return nil
 	}
+
+	if err := issue.LoadRepo(); err != nil {
+		log.Error("Unable to load rep [%d] for issue #%d [%d]. Error: %v", issue.RepoID, issue.Index, issue.ID, err)
+		return err
+	}
+
 	langMap := make(map[string][]*models.User)
 	for _, user := range recipients {
 		langMap[user.Language] = append(langMap[user.Language], user)

--- a/templates/mail/issue/assigned.tmpl
+++ b/templates/mail/issue/assigned.tmpl
@@ -8,7 +8,7 @@
 	<title>{{.Subject}}</title>
 </head>
 
-{{$repo_url := printf "<a href='%s'>%s</a>" .Release.Repo.HTMLURL .Release.Repo.FullName}}
+{{$repo_url := printf "<a href='%s'>%s</a>" .Issue.Repo.HTMLURL .Issue.Repo.FullName}}
 {{$link := printf "<a href='%s'>#%d</a>" .Link .Issue.Index}}
 <body>
 	<p>


### PR DESCRIPTION
There was a mistake in the template file: `templates/mail/issue/assigned.tmpl`
where the repourl was generated from a non-existent release instead of the issue.

This PR changes this to use the issue but also ensure that the issue repo is loaded.

It also slightly improves the English locale string.

Fix #17160

Signed-off-by: Andrew Thornton <art27@cantab.net>
