### PR TITLE
Migrated Repository will show modifications when possible

### DIFF
--- a/modules/git/repo_compare_test.go
+++ b/modules/git/repo_compare_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"code.gitea.io/gitea/modules/util"
@@ -18,11 +19,11 @@ import (
 func TestGetFormatPatch(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
 	clonedPath, err := cloneRepo(bareRepo1Path, testReposDir, "repo1_TestGetFormatPatch")
-	assert.NoError(t, err)
 	defer util.RemoveAll(clonedPath)
-	repo, err := OpenRepository(clonedPath)
 	assert.NoError(t, err)
+	repo, err := OpenRepository(clonedPath)
 	defer repo.Close()
+	assert.NoError(t, err)
 	rd := &bytes.Buffer{}
 	err = repo.GetPatch("8d92fc95^", "8d92fc95", rd)
 	assert.NoError(t, err)
@@ -31,4 +32,50 @@ func TestGetFormatPatch(t *testing.T) {
 	patch := string(patchb)
 	assert.Regexp(t, "^From 8d92fc95", patch)
 	assert.Contains(t, patch, "Subject: [PATCH] Add file2.txt")
+}
+
+func TestReadPatch(t *testing.T) {
+	// Ensure we can read the patch files
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+	repo, err := OpenRepository(bareRepo1Path)
+	defer repo.Close()
+	assert.NoError(t, err)
+	// This patch doesn't exist
+	noFile, err := repo.ReadPatchCommit(0)
+	assert.Error(t, err)
+	// This patch is an empty one (sometimes it's a 404)
+	noCommit, err := repo.ReadPatchCommit(1)
+	assert.Error(t, err)
+	// This patch is legit and should return a commit
+	oldCommit, err := repo.ReadPatchCommit(2)
+	assert.NoError(t, err)
+
+	assert.Empty(t, noFile)
+	assert.Empty(t, noCommit)
+	assert.Len(t, oldCommit, 40)
+	assert.True(t, oldCommit == "6e8e2a6f9efd71dbe6917816343ed8415ad696c3")
+}
+
+func TestReadWritePullHead(t *testing.T) {
+	// Ensure we can write SHA1 head corresponding to PR and open them
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+	repo, err := OpenRepository(bareRepo1Path)
+	assert.NoError(t, err)
+	defer repo.Close()
+	// Try to open non-existing Pull
+	_, err = repo.ReadPullHead(0)
+	assert.Error(t, err)
+	// Write a fake sha1 with only 40 zeros
+	newCommit := strings.Repeat("0", 40)
+	err = repo.WritePullHead(1, newCommit)
+	assert.NoError(t, err)
+	headFile := filepath.Join(repo.Path, "refs/pull/1/head")
+	// Remove file after the test
+	defer util.Remove(headFile)
+	assert.FileExists(t, headFile)
+	// Read the file created
+	headContents, err := repo.ReadPullHead(1)
+	assert.NoError(t, err)
+	assert.Len(t, string(headContents), 40)
+	assert.True(t, string(headContents) == newCommit)
 }

--- a/modules/git/tests/repos/repo1_bare/pulls/2.patch
+++ b/modules/git/tests/repos/repo1_bare/pulls/2.patch
@@ -1,0 +1,39 @@
+From 6e8e2a6f9efd71dbe6917816343ed8415ad696c3 Mon Sep 17 00:00:00 2001
+From: 99rgosse <renaud@mycompany.com>
+Date: Fri, 26 Mar 2021 12:44:22 +0000
+Subject: [PATCH] Update gitea_import_actions.py
+
+---
+ gitea_import_actions.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gitea_import_actions.py b/gitea_import_actions.py
+index f0d72cd..7b31963 100644
+--- a/gitea_import_actions.py
++++ b/gitea_import_actions.py
+@@ -3,14 +3,14 @@
+ # git log --pretty=format:'%H,%at,%s' --date=default > /tmp/commit.log
+ # to get the commits logfile for a repository
+
+-import mysql.connector as mariadb
++import psycopg2
+
+ # set the following variables to fit your need...
+ USERID = 1
+ REPOID = 1
+ BRANCH = "master"
+
+-mydb = mariadb.connect(
++mydb = psycopg2.connect(
+   host="localhost",
+   user="user",
+   passwd="password",
+@@ -31,4 +31,4 @@ with open("/tmp/commit.log") as f:
+
+ mydb.commit()
+
+-print("actions inserted.")
+\ No newline at end of file
++print("actions inserted.")
+--
+GitLab

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -320,8 +320,46 @@ func PrepareMergedViewPullInfo(ctx *context.Context, issue *models.Issue) *git.C
 	setMergeTarget(ctx, pull)
 	ctx.Data["HasMerged"] = true
 
+	var baseCommit string
+	// Some migrated PR won't have any Base SHA and lose history, try to get one
+	if pull.MergeBase == "" {
+		var commitSHA, parentCommit string
+		// If there is a head or a patch file, and it is readable, grab info
+		commitSHA, err := ctx.Repo.GitRepo.ReadPullHead(pull.Index)
+		if err != nil {
+			// Head File does not exist, try the patch
+			commitSHA, err = ctx.Repo.GitRepo.ReadPatchCommit(pull.Index)
+			if err == nil {
+				// Recreate pull head in files for next time
+				if err := ctx.Repo.GitRepo.WritePullHead(pull.Index, commitSHA); err != nil {
+					log.Error("Could not write head file", err)
+				}
+			} else {
+				// There is no history available
+				log.Trace("No history file available for PR %d", pull.Index)
+			}
+		}
+		if commitSHA != "" {
+			// Get immediate parent of the first commit in the patch, grab history back
+			parentCommit, err = git.NewCommandContext(ctx, "rev-list", "-1", "--skip=1", commitSHA).RunInDir(ctx.Repo.GitRepo.Path)
+			if err == nil {
+				parentCommit = strings.TrimSpace(parentCommit)
+			}
+			// Special case on Git < 2.25 that doesn't fail on immediate empty history
+			if err != nil || parentCommit == "" {
+				log.Info("No known parent commit for PR %d, error: %v", pull.Index, err)
+				// bring at least partial history if it can work
+				parentCommit = commitSHA
+			}
+		}
+		baseCommit = parentCommit
+	} else {
+		// Keep an empty history or original commit
+		baseCommit = pull.MergeBase
+	}
+
 	compareInfo, err := ctx.Repo.GitRepo.GetCompareInfo(ctx.Repo.Repository.RepoPath(),
-		pull.MergeBase, pull.GetGitRefName(), true, false)
+		baseCommit, pull.GetGitRefName(), true, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "fatal: Not a valid object name") || strings.Contains(err.Error(), "unknown revision or path not in the working tree") {
 			ctx.Data["IsPullRequestBroken"] = true


### PR DESCRIPTION
This PR aims to recover Pull Request history for migrated repositories from Gitlab and Github :

Imported repositories with deleted branches or reverted changes will lose the base commit, but still export the patch files.

These imported repo won't show changes or commits:

![image](https://user-images.githubusercontent.com/61579380/135429131-1d433bc0-6dd0-4288-8a31-2dba117e491f.png)

This pull request handle the cases when there is no PR Base commit and a patch file.
If this patch file is readable, it will read the first commit of this file and getting it's rev-list parent to "retrace the history"
Then it writes the correct SHA1 (if relevant) into the refs/pulls/#pr/head file

Result with local patch : 
![image](https://user-images.githubusercontent.com/61579380/135640488-81aab295-9477-4bd5-a265-5aac05ace154.png)

See this repository : https://try.gitea.io/99rgosse/PR_dl_test2222/pulls/2

- [X] Passes "make test" / Make SQLite tests
- [X] Some PR from Gitlab migrated repository - Tested on some huge repo ok
- [X] Some PR from Github migrated repository 

This would help people migrating from other services with big repositories without losing too much history


