### PR TITLE
Prevent NPE on invalid diff

### DIFF
--- a/integrations/compare_test.go
+++ b/integrations/compare_test.go
@@ -6,6 +6,7 @@ package integrations
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +22,8 @@ func TestCompareTag(t *testing.T) {
 	selection := htmlDoc.doc.Find(".choose.branch .filter.dropdown")
 	// A dropdown for both base and head.
 	assert.Lenf(t, selection.Nodes, 2, "The template has changed")
+
+	req = NewRequest(t, "GET", "/user2/repo1/compare/invalid")
+	resp = session.MakeRequest(t, req, http.StatusNotFound)
+	assert.False(t, strings.Contains(resp.Body.String(), "/assets/img/500.png"), "expect 404 page not 500")
 }

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -635,7 +635,7 @@ func getBranchesAndTagsForRepo(user *models.User, repo *models.Repository) (bool
 func CompareDiff(ctx *context.Context) {
 	ci := ParseCompareInfo(ctx)
 	defer func() {
-		if ci.HeadGitRepo != nil {
+		if ci != nil && ci.HeadGitRepo != nil {
 			ci.HeadGitRepo.Close()
 		}
 	}()

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1043,7 +1043,7 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 
 	ci := ParseCompareInfo(ctx)
 	defer func() {
-		if ci.HeadGitRepo != nil {
+		if ci != nil && ci.HeadGitRepo != nil {
 			ci.HeadGitRepo.Close()
 		}
 	}()


### PR DESCRIPTION
If ParseCompareInfo returns a nil compare info the defer function needs to ensure
that it does not attempt to close the HeadGitRepo.

Fix #17193
Regression #16635 

Signed-off-by: Andrew Thornton <art27@cantab.net>

