### PR TITLE
Add metrics to get issues by label

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2041,6 +2041,8 @@ PATH =
 ;ENABLED = false
 ;; If you want to add authorization, specify a token here
 ;TOKEN =
+;; Enable issue by label metrics; default is false
+;ENABLED_ISSUE_BY_LABEL = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -853,6 +853,7 @@ NB: You must have `DISABLE_ROUTER_LOG` set to `false` for this option to take ef
 ## Metrics (`metrics`)
 
 - `ENABLED`: **false**: Enables /metrics endpoint for prometheus.
+- `ENABLED_ISSUE_BY_LABEL`: **false**: Enable issue by label metrics
 - `TOKEN`: **\<empty\>**: You need to specify the token, if you want to include in the authorization the metrics . The same token need to be used in prometheus parameters `bearer_token` or `bearer_token_file`.
 
 ## API (`api`)

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -51,8 +51,7 @@ func GetStatistic() (stats Statistic) {
 	if setting.Metrics.EnabledIssueByLabel {
 		stats.Counter.IssueByLabel = []IssueByLabelCount{}
 
-		_ = db.GetEngine(db.DefaultContext).
-			Select("COUNT(*) AS count, l.name AS label").
+		_ = e.Select("COUNT(*) AS count, l.name AS label").
 			Join("LEFT", "label l", "l.id=il.label_id").
 			Table("issue_label il").
 			GroupBy("l.name").

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -52,9 +52,8 @@ func GetStatistic() (stats Statistic) {
 
 	_ = db.GetEngine(db.DefaultContext).
 		Select("COUNT(*) AS count, l.name AS label").
-		Join("LEFT", "issue_label il", "i.id=il.issue_id").
 		Join("LEFT", "label l", "l.id=il.label_id").
-		Table("issue i").
+		Table("issue_label il").
 		GroupBy("l.name").
 		Find(&stats.Counter.IssueByLabel)
 

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -23,6 +23,7 @@ type Statistic struct {
 	}
 }
 
+// IssueByLabelCount contains the number of issue group by label
 type IssueByLabelCount struct {
 	Count int64
 	Label string

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -7,6 +7,7 @@ package models
 import (
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/login"
+	"code.gitea.io/gitea/modules/setting"
 )
 
 // Statistic contains the database statistics
@@ -47,15 +48,18 @@ func GetStatistic() (stats Statistic) {
 		IsClosed bool
 	}
 
-	issueCounts := []IssueCount{}
-	stats.Counter.IssueByLabel = []IssueByLabelCount{}
+	if setting.Metrics.EnabledIssueByLabel {
+		stats.Counter.IssueByLabel = []IssueByLabelCount{}
 
-	_ = db.GetEngine(db.DefaultContext).
-		Select("COUNT(*) AS count, l.name AS label").
-		Join("LEFT", "label l", "l.id=il.label_id").
-		Table("issue_label il").
-		GroupBy("l.name").
-		Find(&stats.Counter.IssueByLabel)
+		_ = db.GetEngine(db.DefaultContext).
+			Select("COUNT(*) AS count, l.name AS label").
+			Join("LEFT", "label l", "l.id=il.label_id").
+			Table("issue_label il").
+			GroupBy("l.name").
+			Find(&stats.Counter.IssueByLabel)
+	}
+
+	issueCounts := []IssueCount{}
 
 	_ = e.Select("COUNT(*) AS count, is_closed").Table("issue").GroupBy("is_closed").Find(&issueCounts)
 	for _, c := range issueCounts {

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -51,7 +51,7 @@ func GetStatistic() (stats Statistic) {
 	stats.Counter.IssueByLabel = []IssueByLabelCount{}
 
 	_ = db.GetEngine(db.DefaultContext).
-		Select("COUNT(*) AS count, l.name as label").
+		Select("COUNT(*) AS count, l.name AS label").
 		Join("LEFT", "issue_label il", "i.id=il.issue_id").
 		Join("LEFT", "label l", "l.id=il.label_id").
 		Table("issue i").

--- a/modules/metrics/collector.go
+++ b/modules/metrics/collector.go
@@ -6,6 +6,7 @@ package metrics
 
 import (
 	"code.gitea.io/gitea/models"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -390,11 +390,13 @@ var (
 
 	// Metrics settings
 	Metrics = struct {
-		Enabled bool
-		Token   string
+		Enabled             bool
+		Token               string
+		EnabledIssueByLabel bool
 	}{
-		Enabled: false,
-		Token:   "",
+		Enabled:             false,
+		Token:               "",
+		EnabledIssueByLabel: false,
 	}
 
 	// I18n settings


### PR DESCRIPTION
My team and I need to get a metric "issue_by_label" to have, for example, the number of new issue tagged "bug" this week.

I added metrics which looks like "gitea_issue_by_label{label="bug}", "gitea_issue_by_label{label="enhancement"}", etc
