### PR TITLE
Add projects and project boards in exposed metrics

### DIFF
--- a/models/statistic.go
+++ b/models/statistic.go
@@ -25,14 +25,15 @@ type Statistic struct {
 
 // GetStatistic returns the database statistics
 func GetStatistic() (stats Statistic) {
+	e := db.GetEngine(db.DefaultContext)
 	stats.Counter.User = CountUsers()
 	stats.Counter.Org = CountOrganizations()
-	stats.Counter.PublicKey, _ = db.GetEngine(db.DefaultContext).Count(new(PublicKey))
+	stats.Counter.PublicKey, _ = e.Count(new(PublicKey))
 	stats.Counter.Repo = CountRepositories(true)
-	stats.Counter.Watch, _ = db.GetEngine(db.DefaultContext).Count(new(Watch))
-	stats.Counter.Star, _ = db.GetEngine(db.DefaultContext).Count(new(Star))
-	stats.Counter.Action, _ = db.GetEngine(db.DefaultContext).Count(new(Action))
-	stats.Counter.Access, _ = db.GetEngine(db.DefaultContext).Count(new(Access))
+	stats.Counter.Watch, _ = e.Count(new(Watch))
+	stats.Counter.Star, _ = e.Count(new(Star))
+	stats.Counter.Action, _ = e.Count(new(Action))
+	stats.Counter.Access, _ = e.Count(new(Access))
 
 	type IssueCount struct {
 		Count    int64
@@ -40,7 +41,7 @@ func GetStatistic() (stats Statistic) {
 	}
 	issueCounts := []IssueCount{}
 
-	_ = db.GetEngine(db.DefaultContext).Select("COUNT(*) AS count, is_closed").Table("issue").GroupBy("is_closed").Find(&issueCounts)
+	_ = e.Select("COUNT(*) AS count, is_closed").Table("issue").GroupBy("is_closed").Find(&issueCounts)
 	for _, c := range issueCounts {
 		if c.IsClosed {
 			stats.Counter.IssueClosed = c.Count
@@ -51,19 +52,19 @@ func GetStatistic() (stats Statistic) {
 
 	stats.Counter.Issue = stats.Counter.IssueClosed + stats.Counter.IssueOpen
 
-	stats.Counter.Comment, _ = db.GetEngine(db.DefaultContext).Count(new(Comment))
+	stats.Counter.Comment, _ = e.Count(new(Comment))
 	stats.Counter.Oauth = 0
-	stats.Counter.Follow, _ = db.GetEngine(db.DefaultContext).Count(new(Follow))
-	stats.Counter.Mirror, _ = db.GetEngine(db.DefaultContext).Count(new(Mirror))
-	stats.Counter.Release, _ = db.GetEngine(db.DefaultContext).Count(new(Release))
+	stats.Counter.Follow, _ = e.Count(new(Follow))
+	stats.Counter.Mirror, _ = e.Count(new(Mirror))
+	stats.Counter.Release, _ = e.Count(new(Release))
 	stats.Counter.LoginSource = login.CountSources()
-	stats.Counter.Webhook, _ = db.GetEngine(db.DefaultContext).Count(new(Webhook))
-	stats.Counter.Milestone, _ = db.GetEngine(db.DefaultContext).Count(new(Milestone))
-	stats.Counter.Label, _ = db.GetEngine(db.DefaultContext).Count(new(Label))
-	stats.Counter.HookTask, _ = db.GetEngine(db.DefaultContext).Count(new(HookTask))
-	stats.Counter.Team, _ = db.GetEngine(db.DefaultContext).Count(new(Team))
-	stats.Counter.Attachment, _ = db.GetEngine(db.DefaultContext).Count(new(Attachment))
-	stats.Counter.Project, _ = db.GetEngine(db.DefaultContext).Count(new(Project))
-	stats.Counter.ProjectBoard, _ = db.GetEngine(db.DefaultContext).Count(new(ProjectBoard))
+	stats.Counter.Webhook, _ = e.Count(new(Webhook))
+	stats.Counter.Milestone, _ = e.Count(new(Milestone))
+	stats.Counter.Label, _ = e.Count(new(Label))
+	stats.Counter.HookTask, _ = e.Count(new(HookTask))
+	stats.Counter.Team, _ = e.Count(new(Team))
+	stats.Counter.Attachment, _ = e.Count(new(Attachment))
+	stats.Counter.Project, _ = e.Count(new(Project))
+	stats.Counter.ProjectBoard, _ = e.Count(new(ProjectBoard))
 	return
 }

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -18,7 +18,8 @@ type Statistic struct {
 		Comment, Oauth, Follow,
 		Mirror, Release, LoginSource, Webhook,
 		Milestone, Label, HookTask,
-		Team, UpdateTask, Attachment int64
+		Team, UpdateTask, Project,
+		ProjectBoard, Attachment int64
 	}
 }
 
@@ -62,5 +63,7 @@ func GetStatistic() (stats Statistic) {
 	stats.Counter.HookTask, _ = db.GetEngine(db.DefaultContext).Count(new(HookTask))
 	stats.Counter.Team, _ = db.GetEngine(db.DefaultContext).Count(new(Team))
 	stats.Counter.Attachment, _ = db.GetEngine(db.DefaultContext).Count(new(Attachment))
+	stats.Counter.Project, _ = db.GetEngine(db.DefaultContext).Count(new(Project))
+	stats.Counter.ProjectBoard, _ = db.GetEngine(db.DefaultContext).Count(new(ProjectBoard))
 	return
 }

--- a/modules/metrics/collector.go
+++ b/modules/metrics/collector.go
@@ -30,6 +30,8 @@ type Collector struct {
 	Mirrors       *prometheus.Desc
 	Oauths        *prometheus.Desc
 	Organizations *prometheus.Desc
+	Projects      *prometheus.Desc
+	ProjectBoards *prometheus.Desc
 	PublicKeys    *prometheus.Desc
 	Releases      *prometheus.Desc
 	Repositories  *prometheus.Desc
@@ -119,6 +121,16 @@ func NewCollector() Collector {
 			"Number of Organizations",
 			nil, nil,
 		),
+		Projects: prometheus.NewDesc(
+			namespace+"projects",
+			"Number of project",
+			nil, nil,
+		),
+		ProjectBoards: prometheus.NewDesc(
+			namespace+"projects_boards",
+			"Number of project boards",
+			nil, nil,
+		),
 		PublicKeys: prometheus.NewDesc(
 			namespace+"publickeys",
 			"Number of PublicKeys",
@@ -185,6 +197,8 @@ func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.Mirrors
 	ch <- c.Oauths
 	ch <- c.Organizations
+	ch <- c.Projects
+	ch <- c.ProjectBoards
 	ch <- c.PublicKeys
 	ch <- c.Releases
 	ch <- c.Repositories
@@ -274,6 +288,16 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 		c.Organizations,
 		prometheus.GaugeValue,
 		float64(stats.Counter.Org),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.Projects,
+		prometheus.GaugeValue,
+		float64(stats.Counter.Project),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.ProjectBoards,
+		prometheus.GaugeValue,
+		float64(stats.Counter.ProjectBoard),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.PublicKeys,

--- a/modules/metrics/collector.go
+++ b/modules/metrics/collector.go
@@ -123,7 +123,7 @@ func NewCollector() Collector {
 		),
 		Projects: prometheus.NewDesc(
 			namespace+"projects",
-			"Number of project",
+			"Number of projects",
 			nil, nil,
 		),
 		ProjectBoards: prometheus.NewDesc(


### PR DESCRIPTION
Today, there is no metrics for projects. 

I added "gitea_projects" and "gitea_projects_boards" in exposed metrics.