### PR TITLE
Reference in new issue modal: dont pre-populate issue title

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1006,7 +1006,6 @@ async function initRepository() {
       const reference = $this.data('reference');
 
       const $modal = $($this.data('modal'));
-      $modal.find('input[name="title"').val(subject);
       $modal.find('textarea[name="content"]').val(`${content}\n\n_Originally posted by @${poster} in ${reference}_`);
 
       $modal.modal('show');

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -1000,7 +1000,6 @@ async function initRepository() {
       $this.closest('.dropdown').find('.menu').toggle('visible');
 
       const content = $(`#comment-${$this.data('target')}`).text();
-      const subject = content.split('\n', 1)[0].slice(0, 255);
 
       const poster = $this.data('poster-username');
       const reference = $this.data('reference');


### PR DESCRIPTION
Examples like https://github.com/go-git/go-git/issues/384 and https://github.com/go-gitea/gitea/issues/17182 highlight, that good defaults matter, to frame it positively.

btw, interesting that this malformed selector worked in the first place!