### PR TITLE
Fix typo in app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1883,7 +1883,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = f;alse
+;NO_SUCCESS_NOTICE = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1907,7 +1907,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = f;alse
+;NO_SUCCESS_NOTICE = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This fixes small typo created in 4a84022d2559 - `Comment out app.example.ini (#15807)`.