### PR TITLE
Add specific event type to header

### DIFF
--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -114,20 +114,20 @@ func Deliver(t *models.HookTask) error {
 	}
 
 	event := t.EventType.Event()
-	eventSingle := string(t.EventType)
+	eventType := string(t.EventType)
 	req.Header.Add("X-Gitea-Delivery", t.UUID)
 	req.Header.Add("X-Gitea-Event", event)
-	req.Header.Add("X-Gitea-Event-Single", eventSingle)
+	req.Header.Add("X-Gitea-Event-Type", eventType)
 	req.Header.Add("X-Gitea-Signature", signatureSHA256)
 	req.Header.Add("X-Gogs-Delivery", t.UUID)
 	req.Header.Add("X-Gogs-Event", event)
-	req.Header.Add("X-Gogs-Event-Single", eventSingle)
+	req.Header.Add("X-Gogs-Event-Type", eventType)
 	req.Header.Add("X-Gogs-Signature", signatureSHA256)
 	req.Header.Add("X-Hub-Signature", "sha1="+signatureSHA1)
 	req.Header.Add("X-Hub-Signature-256", "sha256="+signatureSHA256)
 	req.Header["X-GitHub-Delivery"] = []string{t.UUID}
 	req.Header["X-GitHub-Event"] = []string{event}
-	req.Header["X-GitHub-Event-Single"] = []string{eventSingle}
+	req.Header["X-GitHub-Event-Type"] = []string{eventType}
 
 	// Record delivery information.
 	t.RequestInfo = &models.HookRequest{

--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -113,16 +113,21 @@ func Deliver(t *models.HookTask) error {
 		signatureSHA256 = hex.EncodeToString(sig256.Sum(nil))
 	}
 
+	event := t.EventType.Event()
+	eventSingle := string(t.EventType)
 	req.Header.Add("X-Gitea-Delivery", t.UUID)
-	req.Header.Add("X-Gitea-Event", t.EventType.Event())
+	req.Header.Add("X-Gitea-Event", event)
+	req.Header.Add("X-Gitea-Event-Single", eventSingle)
 	req.Header.Add("X-Gitea-Signature", signatureSHA256)
 	req.Header.Add("X-Gogs-Delivery", t.UUID)
-	req.Header.Add("X-Gogs-Event", t.EventType.Event())
+	req.Header.Add("X-Gogs-Event", event)
+	req.Header.Add("X-Gogs-Event-Single", eventSingle)
 	req.Header.Add("X-Gogs-Signature", signatureSHA256)
 	req.Header.Add("X-Hub-Signature", "sha1="+signatureSHA1)
 	req.Header.Add("X-Hub-Signature-256", "sha256="+signatureSHA256)
 	req.Header["X-GitHub-Delivery"] = []string{t.UUID}
-	req.Header["X-GitHub-Event"] = []string{t.EventType.Event()}
+	req.Header["X-GitHub-Event"] = []string{event}
+	req.Header["X-GitHub-Event-Single"] = []string{eventSingle}
 
 	// Record delivery information.
 	t.RequestInfo = &models.HookRequest{


### PR DESCRIPTION
This PR adds the _specific_ event of a webhook to the request header.

Currently we add an `action` field to the JSON which, combined with the current header, can be used to deduce the specific action.  
That being said, it is _much_ easier to check the header and do a complete JSON unmarshal rather than partially unmarshaling to get the action and then fully unmarshaling after.

This is somewhat in an effort to make webhook interceptors easier to implement for Gitea.  
Ideally in the future I'd like to be able to automate example webhook payloads for a given Gitea version. :slightly_smiling_face: 