### PR TITLE
Add metrics to get issues by repository

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2043,6 +2043,8 @@ PATH =
 ;TOKEN =
 ;; Enable issue by label metrics; default is false
 ;ENABLED_ISSUE_BY_LABEL = false
+;; Enable issue by repository metrics; default is false
+;ENABLED_ISSUE_BY_REPOSITORY = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -853,7 +853,8 @@ NB: You must have `DISABLE_ROUTER_LOG` set to `false` for this option to take ef
 ## Metrics (`metrics`)
 
 - `ENABLED`: **false**: Enables /metrics endpoint for prometheus.
-- `ENABLED_ISSUE_BY_LABEL`: **false**: Enable issue by label metrics
+- `ENABLED_ISSUE_BY_LABEL`: **false**: Enable issue by label metrics with format `gitea_issues_by_label{label="bug"} 2`.
+- `ENABLED_ISSUE_BY_REPOSITORY`: **false**: Enable issue by repository metrics with format `gitea_issues_by_repository{repository="org/repo"} 5`.
 - `TOKEN`: **\<empty\>**: You need to specify the token, if you want to include in the authorization the metrics . The same token need to be used in prometheus parameters `bearer_token` or `bearer_token_file`.
 
 ## API (`api`)

--- a/modules/metrics/collector.go
+++ b/modules/metrics/collector.go
@@ -15,33 +15,34 @@ const namespace = "gitea_"
 // Collector implements the prometheus.Collector interface and
 // exposes gitea metrics for prometheus
 type Collector struct {
-	Accesses      *prometheus.Desc
-	Actions       *prometheus.Desc
-	Attachments   *prometheus.Desc
-	Comments      *prometheus.Desc
-	Follows       *prometheus.Desc
-	HookTasks     *prometheus.Desc
-	Issues        *prometheus.Desc
-	IssuesOpen    *prometheus.Desc
-	IssuesClosed  *prometheus.Desc
-	IssuesByLabel *prometheus.Desc
-	Labels        *prometheus.Desc
-	LoginSources  *prometheus.Desc
-	Milestones    *prometheus.Desc
-	Mirrors       *prometheus.Desc
-	Oauths        *prometheus.Desc
-	Organizations *prometheus.Desc
-	Projects      *prometheus.Desc
-	ProjectBoards *prometheus.Desc
-	PublicKeys    *prometheus.Desc
-	Releases      *prometheus.Desc
-	Repositories  *prometheus.Desc
-	Stars         *prometheus.Desc
-	Teams         *prometheus.Desc
-	UpdateTasks   *prometheus.Desc
-	Users         *prometheus.Desc
-	Watches       *prometheus.Desc
-	Webhooks      *prometheus.Desc
+	Accesses           *prometheus.Desc
+	Actions            *prometheus.Desc
+	Attachments        *prometheus.Desc
+	Comments           *prometheus.Desc
+	Follows            *prometheus.Desc
+	HookTasks          *prometheus.Desc
+	Issues             *prometheus.Desc
+	IssuesOpen         *prometheus.Desc
+	IssuesClosed       *prometheus.Desc
+	IssuesByLabel      *prometheus.Desc
+	IssuesByRepository *prometheus.Desc
+	Labels             *prometheus.Desc
+	LoginSources       *prometheus.Desc
+	Milestones         *prometheus.Desc
+	Mirrors            *prometheus.Desc
+	Oauths             *prometheus.Desc
+	Organizations      *prometheus.Desc
+	Projects           *prometheus.Desc
+	ProjectBoards      *prometheus.Desc
+	PublicKeys         *prometheus.Desc
+	Releases           *prometheus.Desc
+	Repositories       *prometheus.Desc
+	Stars              *prometheus.Desc
+	Teams              *prometheus.Desc
+	UpdateTasks        *prometheus.Desc
+	Users              *prometheus.Desc
+	Watches            *prometheus.Desc
+	Webhooks           *prometheus.Desc
 }
 
 // NewCollector returns a new Collector with all prometheus.Desc initialized
@@ -87,6 +88,11 @@ func NewCollector() Collector {
 			namespace+"issues_by_label",
 			"Number of Issues",
 			[]string{"label"}, nil,
+		),
+		IssuesByRepository: prometheus.NewDesc(
+			namespace+"issues_by_repository",
+			"Number of Issues",
+			[]string{"repository"}, nil,
 		),
 		IssuesOpen: prometheus.NewDesc(
 			namespace+"issues_open",
@@ -196,6 +202,7 @@ func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.HookTasks
 	ch <- c.Issues
 	ch <- c.IssuesByLabel
+	ch <- c.IssuesByRepository
 	ch <- c.IssuesOpen
 	ch <- c.IssuesClosed
 	ch <- c.Labels
@@ -262,6 +269,14 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			float64(il.Count),
 			il.Label,
+		)
+	}
+	for _, ir := range stats.Counter.IssueByRepository {
+		ch <- prometheus.MustNewConstMetric(
+			c.IssuesByRepository,
+			prometheus.GaugeValue,
+			float64(ir.Count),
+			ir.OwnerName+"/"+ir.Repository,
 		)
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -390,13 +390,15 @@ var (
 
 	// Metrics settings
 	Metrics = struct {
-		Enabled             bool
-		Token               string
-		EnabledIssueByLabel bool
+		Enabled                  bool
+		Token                    string
+		EnabledIssueByLabel      bool
+		EnabledIssueByRepository bool
 	}{
-		Enabled:             false,
-		Token:               "",
-		EnabledIssueByLabel: false,
+		Enabled:                  false,
+		Token:                    "",
+		EnabledIssueByLabel:      false,
+		EnabledIssueByRepository: false,
 	}
 
 	// I18n settings


### PR DESCRIPTION
Similary to #17201

Add a metrics which return the number of issue by repository with format `gitea_issues_by_repository{repository="org/repo"} 32`.

To avoid performance issue, this feature is disable by default with setting `ENABLED_ISSUE_BY_REPOSITORY`.