### PR TITLE
Fix navbar UI

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -1,6 +1,6 @@
 <div class="ui container" id="navbar">
 	<div class="item brand" style="justify-content: space-between;">
-		<a href="{{AppSubUrl}}/" class="item poping up" data-content="{{if .IsSigned}}{{.i18n.Tr "dashboard"}}{{else}}{{.i18n.Tr "home"}}{{end}}" data-variation="tiny inverted">
+		<a href="{{AppSubUrl}}/" data-content="{{if .IsSigned}}{{.i18n.Tr "dashboard"}}{{else}}{{.i18n.Tr "home"}}{{end}}" data-variation="tiny inverted">
 			<img class="ui mini image" width="30" height="30" src="{{AssetUrlPrefix}}/img/logo.svg">
 		</a>
 		<div class="ui basic icon button mobile-only" id="navbar-expand-toggle">


### PR DESCRIPTION
The bug is introduced by https://github.com/go-gitea/gitea/pull/16844 . The wrong css classes were added to `<a>` .

After this fix:

* Mobile
![image](https://user-images.githubusercontent.com/2114189/136145562-82976c89-77a9-4628-86c9-aff6024e164b.png)

* Desktop
![image](https://user-images.githubusercontent.com/2114189/136145647-2f2bf7bb-639d-479c-bff1-0d0773369fa7.png)


