### PR TITLE
Handle duplicate keys on GPG key ring

### DIFF
--- a/models/gpg_key_add.go
+++ b/models/gpg_key_add.go
@@ -109,15 +109,22 @@ func AddGPGKey(ownerID int64, content, token, signature string) ([]*GPGKey, erro
 			if original, has := id2key[id]; has {
 				// Coalesce this with the other one
 				for _, subkey := range ekey.Subkeys {
+					if subkey.PublicKey == nil {
+						continue
+					}
+					found := false
+
 					for _, originalSubkey := range original.Subkeys {
-						if subkey.PublicKey == nil || originalSubkey.PublicKey == nil {
+						if originalSubkey.PublicKey == nil {
 							continue
 						}
 						if originalSubkey.PublicKey.KeyId == subkey.PublicKey.KeyId {
-							continue
+							found = true
+							break
 						}
+					}
+					if !found {
 						original.Subkeys = append(original.Subkeys, subkey)
-						break
 					}
 				}
 				for name, identity := range ekey.Identities {

--- a/models/gpg_key_add.go
+++ b/models/gpg_key_add.go
@@ -103,7 +103,7 @@ func AddGPGKey(ownerID int64, content, token, signature string) ([]*GPGKey, erro
 
 	if len(ekeys) > 1 {
 		id2key := map[string]*openpgp.Entity{}
-		newKeys := make([]*openpgp.Entity, 0, len(ekeys))
+		newEKeys := make([]*openpgp.Entity, 0, len(ekeys))
 		for _, ekey := range ekeys {
 			id := ekey.PrimaryKey.KeyIdString()
 			if original, has := id2key[id]; has {
@@ -136,9 +136,9 @@ func AddGPGKey(ownerID int64, content, token, signature string) ([]*GPGKey, erro
 				continue
 			}
 			id2key[id] = ekey
-			newKeys = append(newKeys, ekey)
+			newEKeys = append(newEKeys, ekey)
 		}
-		ekeys = newKeys
+		ekeys = newEKeys
 	}
 
 	for _, ekey := range ekeys {


### PR DESCRIPTION
It is possible that a keyring can contain duplicate keys on a keyring due to jpegs or
other layers. This currently leads to a confusing error for the user - where we report
a duplicate key insertion.

This PR simply coalesces keys into one key if there are duplicates.

Signed-off-by: Andrew Thornton <art27@cantab.net>
