### PR TITLE
Fix broken Activities link in team dashboard

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -300,7 +300,7 @@ func (u *User) CanImportLocal() bool {
 // DashboardLink returns the user dashboard page link.
 func (u *User) DashboardLink() string {
 	if u.IsOrganization() {
-		return u.OrganisationLink() + "/dashboard/"
+		return u.OrganisationLink() + "/dashboard"
 	}
 	return setting.AppSubURL + "/"
 }


### PR DESCRIPTION
Remove '/' suffix from organization dashboard link.
I checked the other locations where DashboardLink is referenced: this should not cause any issues.

Fixes #17250