### PR TITLE
Fix broken Activities link in team dashboard (#17255)

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -296,7 +296,7 @@ func (u *User) CanImportLocal() bool {
 // DashboardLink returns the user dashboard page link.
 func (u *User) DashboardLink() string {
 	if u.IsOrganization() {
-		return u.OrganisationLink() + "/dashboard/"
+		return u.OrganisationLink() + "/dashboard"
 	}
 	return setting.AppSubURL + "/"
 }


### PR DESCRIPTION
Backport of #17255

Remove '/' suffix from organization dashboard link

Fixes #17250
