### PR TITLE
Raw file API: don't try to interpret 40char filenames as commit SHA (#17185)

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -695,7 +695,7 @@ func getRefName(ctx *Context, pathType RepoRefType) string {
 		}
 		// For legacy and API support only full commit sha
 		parts := strings.Split(path, "/")
-		if len(parts) > 0 && len(parts[0]) == 40 {
+		if len(parts) > 1 && len(parts[0]) == 40 {
 			ctx.Repo.TreePath = strings.Join(parts[1:], "/")
 			return parts[0]
 		}


### PR DESCRIPTION
This is a stripped down backport of #17185, fixes #17179.
 
 Don't try to interpret treepath as commit hash when path contains no hash-path-separator ('/')
    
  Entering this case when `path` does not contain a '/' doesn't really
    make sense, as that means the tree path is empty, but this case is only
    entered for routes that expect a non-empty tree path.
    
  Treepaths like `<40-char-filename>` will now work, while paths like `<40-char-dirname>/<filename>` will still fail,
    but hopefully don't occur that often. A more complete fix that avoids
    this case too is outlined in #17185, but is too big of a change to functionality to backport
