### PR TITLE
AutoRegistration is supposed to be working with disabled registration (backport)

### DIFF
--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -617,7 +617,7 @@ func SignInOAuthCallback(ctx *context.Context) {
 	}
 
 	if u == nil {
-		if !(setting.Service.DisableRegistration || setting.Service.AllowOnlyInternalRegistration) && setting.OAuth2Client.EnableAutoRegistration {
+		if !setting.Service.AllowOnlyInternalRegistration && setting.OAuth2Client.EnableAutoRegistration {
 			// create new user with details from oauth2 provider
 			var missingFields []string
 			if gothUser.UserID == "" {


### PR DESCRIPTION
Backport of PR #17219.

Auto registration should be working even if standard registration is disabled. Common use of auto registration is when we have trusted auth provider (openid, google e.t.c.) and all other types of registration are disabled.
