### PR TITLE
Check for context exceeded in WalkGitLog

### DIFF
--- a/modules/git/log_name_status.go
+++ b/modules/git/log_name_status.go
@@ -350,6 +350,9 @@ heaploop:
 		}
 		current, err := g.Next(treepath, path2idx, changed, maxpathlen)
 		if err != nil {
+			if err == context.DeadlineExceeded {
+				break heaploop
+			}
 			g.Close()
 			return nil, err
 		}


### PR DESCRIPTION
There is a slight race in checking of a context deadline exceed in #16467
which leads to a 500 on the repository page.

The solution is to check the error coming back from `*LogNameStatusRepoParser.Next()`
and if it is the `ContextDeadlineExceeded` break from the loop.

Fix #17314
Regression #16467

Signed-off-by: Andrew Thornton <art27@cantab.net>
