### PR TITLE
Fix the PR review form bug during frontend refactor

### DIFF
--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -21,7 +21,7 @@ export function initRepoDiffFileViewToggle() {
 }
 
 export function initRepoDiffConversationForm() {
-  $('.conversation-holder form').on('submit', async (e) => {
+  $(document).on('submit', '.conversation-holder form', async (e) => {
     e.preventDefault();
     const form = $(e.target);
     const newConversationHolder = $(await $.post(form.attr('action'), form.serialize()));


### PR DESCRIPTION
The line was `$(document).on('submit', '.conversation-holder form', async (e) => {`, it was changed unintentionally.

The bug makes the first "Start Review" form can not be submitted correctly.