### PR TITLE
Remove js redundancy

### DIFF
--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -3,8 +3,8 @@ import {initVueSvg, vueDelimiters} from './VueComponentLoader.js';
 
 const {AppSubUrl, AssetUrlPrefix, pageData} = window.config;
 
-function syncQueryParam(params, queryKey, queryValue, definedValue) {
-  if (queryValue === definedValue) {
+function syncQueryParam(params, queryKey, queryValue, defaultValue) {
+  if (queryValue === defaultValue) {
     params.delete(queryKey);
   } else {
     params.set(queryKey, queryValue);

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -15,7 +15,8 @@ function refreshRepoSearch(repoSearch, page = 1) {
   repoSearch.page = page;
   repoSearch.repos = [];
   repoSearch.setCheckboxes();
-  // Needed to inform Vue that the value has changed initially
+  // If Vue is not notified manually, the computed property `repoTypeCount` doesn't get updated correctly
+  // Leading to a not-rendered round counter initially
   Vue.set(repoSearch.counts, `${repoSearch.reposFilter}:${repoSearch.archivedFilter}:${repoSearch.privateFilter}`, 0);
   repoSearch.searchRepos();
 }

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -216,7 +216,7 @@ function initVueComponents() {
         setOrDeleteParam(params, this.page, 1, 'repo-search-page', this.page.toString());
 
         const queryString = params.toString();
-        window.history.replaceState({}, '', queryString ? `?${queryString}` :  window.location.pathname);
+        window.history.replaceState({}, '', queryString ? '?'.concat(queryString) :  window.location.pathname);
       },
 
       toggleArchivedFilter() {

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -15,8 +15,8 @@ function refreshRepoSearch(repoSearch, page = 1) {
   repoSearch.page = page;
   repoSearch.repos = [];
   repoSearch.setCheckboxes();
-  const countKey = `${repoSearch.reposFilter}:${repoSearch.archivedFilter}:${repoSearch.privateFilter}`;
-  repoSearch.counts[countKey] = 0;
+  // Needed to inform Vue that the value has changed initially
+  Vue.set(repoSearch.counts, `${repoSearch.reposFilter}:${repoSearch.archivedFilter}:${repoSearch.privateFilter}`, 0);
   repoSearch.searchRepos();
 }
 

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -4,7 +4,7 @@ import {initVueSvg, vueDelimiters} from './VueComponentLoader.js';
 const {AppSubUrl, AssetUrlPrefix, pageData} = window.config;
 
 function setOrDeleteParam(params, data, isEqual, param, customValue = undefined) {
-  if(data === isEqual) {
+  if (data === isEqual) {
     params.delete(param);
   } else {
     params.set(param, customValue ? customValue : data);
@@ -209,14 +209,14 @@ function initVueComponents() {
         const params = new URLSearchParams(window.location.search);
 
         setOrDeleteParam(params, this.tab, 'repos', 'repo-search-tab');
-        setOrDeleteParam(params, this.reposFilter, 'all','repo-search-filter');
-        setOrDeleteParam(params, this.privateFilter, 'both','repo-search-private');
-        setOrDeleteParam(params, this.archivedFilter, 'unarchived','repo-search-archived');
-        setOrDeleteParam(params, this.searchQuery, '','repo-search-query');
+        setOrDeleteParam(params, this.reposFilter, 'all', 'repo-search-filter');
+        setOrDeleteParam(params, this.privateFilter, 'both', 'repo-search-private');
+        setOrDeleteParam(params, this.archivedFilter, 'unarchived', 'repo-search-archived');
+        setOrDeleteParam(params, this.searchQuery, '', 'repo-search-query');
         setOrDeleteParam(params, this.page, 1, 'repo-search-page', this.page.toString());
 
         const queryString = params.toString();
-        window.history.replaceState({}, '', queryString ? '?'.concat(queryString) :  window.location.pathname);
+        window.history.replaceState({}, '', queryString ? '?'.concat(queryString) : window.location.pathname);
       },
 
       toggleArchivedFilter() {

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -218,7 +218,8 @@ function initVueComponents() {
         syncQueryParam(params, 'repo-search-page', this.page.toString(), '1');
 
         const queryString = params.toString();
-        window.history.replaceState({}, '', queryString ? '?'.concat(queryString) : window.location.pathname);
+        const newUrl = queryString ? `?${queryString}` : window.location.pathname;
+        window.history.replaceState({}, '', newUrl);
       },
 
       toggleArchivedFilter() {

--- a/web_src/js/components/DashboardRepoList.js
+++ b/web_src/js/components/DashboardRepoList.js
@@ -11,7 +11,7 @@ function setOrDeleteParam(params, data, isEqual, param, customValue = undefined)
   }
 }
 
-function resetPage($this = this, page = 1) {
+function resetPage($this, page = 1) {
   $this.page = page;
   $this.repos = [];
   $this.setCheckboxes();
@@ -202,7 +202,7 @@ function initVueComponents() {
 
       changeReposFilter(filter) {
         this.reposFilter = filter;
-        resetPage();
+        resetPage(this);
       },
 
       updateHistory() {
@@ -232,7 +232,7 @@ function initVueComponents() {
             this.archivedFilter = 'unarchived';
             break;
         }
-        resetPage();
+        resetPage(this);
       },
 
       togglePrivateFilter() {
@@ -248,7 +248,7 @@ function initVueComponents() {
             this.privateFilter = 'both';
             break;
         }
-        resetPage();
+        resetPage(this);
       },
 
 

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -32,8 +32,7 @@ export function initHeadNavbarContentToggle() {
 
 export function initFootLanguageMenu() {
   function linkLanguageAction() {
-    const $this = $(this);
-    $.post($this.data('url')).always(() => {
+    $.post($(this).data('url')).always(() => {
       window.location.reload();
     });
   }

--- a/web_src/js/features/lastcommitloader.js
+++ b/web_src/js/features/lastcommitloader.js
@@ -5,8 +5,10 @@ export async function initLastCommitLoader() {
 
   const entries = $('table#repo-files-table tr.notready')
     .map((_, v) => {
-      entryMap[$(v).attr('data-entryname')] = $(v);
-      return $(v).attr('data-entryname');
+      elem = $(v);
+      key  = elem.attr('data-entryname');
+      entryMap[key] = elem;
+      return key;
     })
     .get();
 
@@ -22,19 +24,18 @@ export async function initLastCommitLoader() {
     }, (data) => {
       $('table#repo-files-table').replaceWith(data);
     });
-    return;
-  }
-
-  $.post(lastCommitLoaderURL, {
-    _csrf: csrf,
-    'f': entries,
-  }, (data) => {
-    $(data).find('tr').each((_, row) => {
-      if (row.className === 'commit-list') {
-        $('table#repo-files-table .commit-list').replaceWith(row);
-        return;
-      }
-      entryMap[$(row).attr('data-entryname')].replaceWith(row);
+  } else {
+    $.post(lastCommitLoaderURL, {
+      _csrf: csrf,
+      'f': entries,
+    }, (data) => {
+      $(data).find('tr').each((_, row) => {
+        if (row.className === 'commit-list') {
+          $('table#repo-files-table .commit-list').replaceWith(row);
+        } else {
+          entryMap[$(row).attr('data-entryname')].replaceWith(row);
+        }
+      });
     });
-  });
+  }
 }

--- a/web_src/js/features/lastcommitloader.js
+++ b/web_src/js/features/lastcommitloader.js
@@ -24,18 +24,19 @@ export async function initLastCommitLoader() {
     }, (data) => {
       $('table#repo-files-table').replaceWith(data);
     });
-  } else {
-    $.post(lastCommitLoaderURL, {
-      _csrf: csrf,
-      'f': entries,
-    }, (data) => {
-      $(data).find('tr').each((_, row) => {
-        if (row.className === 'commit-list') {
-          $('table#repo-files-table .commit-list').replaceWith(row);
-        } else {
-          entryMap[$(row).attr('data-entryname')].replaceWith(row);
-        }
-      });
-    });
+    return;
   }
+
+  $.post(lastCommitLoaderURL, {
+    _csrf: csrf,
+    'f': entries,
+  }, (data) => {
+    $(data).find('tr').each((_, row) => {
+      if (row.className === 'commit-list') {
+        $('table#repo-files-table .commit-list').replaceWith(row);
+      } else {
+        entryMap[$(row).attr('data-entryname')].replaceWith(row);
+      }
+    });
+  });
 }

--- a/web_src/js/features/lastcommitloader.js
+++ b/web_src/js/features/lastcommitloader.js
@@ -5,8 +5,8 @@ export async function initLastCommitLoader() {
 
   const entries = $('table#repo-files-table tr.notready')
     .map((_, v) => {
-      elem = $(v);
-      key  = elem.attr('data-entryname');
+      const elem = $(v);
+      const key = elem.attr('data-entryname');
       entryMap[key] = elem;
       return key;
     })


### PR DESCRIPTION
Removed redundancy inside `components/DashboadRepoList` by adding two additional methods.
Additionally simplified some statements.


I think all these actions should be idempotent, I couldn't see any difference when testing locally.

The only thing I am uncertain about is whether it was a previously unnoticed bug that `changeReposFilter` did not call `this.setCheckboxes();`, or whether I added a bug myself with that. What exactly does `setCheckboxes` do?