### PR TITLE
api: integration test for nodeinfo

### DIFF
--- a/integrations/api_nodeinfo_test.go
+++ b/integrations/api_nodeinfo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Gitea Authors. All rights reserved.
+// Copyright 2021 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/integrations/api_nodeinfo_test.go
+++ b/integrations/api_nodeinfo_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
+	api "code.gitea.io/gitea/modules/structs"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeinfo(t *testing.T) {
+	onGiteaRun(t, func(*testing.T, *url.URL) {
+		setting.Federation.Enabled = true
+		defer func() {
+			setting.Federation.Enabled = false
+		}()
+
+		req := NewRequestf(t, "GET", "/api/v1/nodeinfo")
+		resp := MakeRequest(t, req, http.StatusOK)
+		var nodeinfo api.NodeInfo
+		DecodeJSON(t, resp, &nodeinfo)
+		assert.Equal(t, "gitea", nodeinfo.Software.Name)
+	})
+}


### PR DESCRIPTION
Add a minimal integration test for the nodeinfo endpoint added
in https://github.com/go-gitea/gitea/pull/16953

Signed-off-by: Loïc Dachary <loic@dachary.org>

PR created on behalf of [Loïc](https://forum.fedeproxy.eu/u/dachary) 