### PR TITLE
docs: add permission notes to `SSH Container Passthrough`

### DIFF
--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -333,10 +333,11 @@ sudo -u git ssh-keygen -t rsa -b 4096 -C "Gitea Host Key"
 In the next step a file named `/app/gitea/gitea` (with executable permissions) needs to be created on the host. This file will issue the SSH forwarding from the host to the container. Add the following contents to `/app/gitea/gitea`:
 
 ```bash
+#!/bin/sh
 ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"
 ```
 
-Here you may also need to set the permisson of `/app/gitea/gitea` correctly:
+Here you should also make sure that you've set the permisson of `/app/gitea/gitea` correctly:
 
 ```bash
 sudo chmod +x /app/gitea/gitea

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -336,6 +336,12 @@ In the next step a file named `/app/gitea/gitea` (with executable permissions) n
 ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"
 ```
 
+Here you may also need to set the permisson of `/app/gitea/gitea` correctly:
+
+```bash
+sudo chmod +x /app/gitea/gitea
+```
+
 To make the forwarding work, the SSH port of the container (22) needs to be mapped to the host port 2222 in `docker-compose.yml` . Since this port does not need to be exposed to the outside world, it can be mapped to the `localhost` of the host machine:
 
 ```bash


### PR DESCRIPTION
This step is necessary in most cases and should be noted in the docs.