### PR TITLE
Allow mocking timeutil

### DIFF
--- a/models/user_heatmap_test.go
+++ b/models/user_heatmap_test.go
@@ -7,9 +7,11 @@ package models
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/json"
+	"code.gitea.io/gitea/modules/timeutil"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,6 +40,10 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 	}
 	// Prepare
 	assert.NoError(t, db.PrepareTestDatabase())
+
+	// Mock time
+	timeutil.Set(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer timeutil.Unset()
 
 	for i, tc := range testCases {
 		user := db.AssertExistsAndLoadBean(t, &User{ID: tc.userID}).(*User)

--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -13,8 +13,24 @@ import (
 // TimeStamp defines a timestamp
 type TimeStamp int64
 
+// mock is NOT concurrency-safe!!
+var mock time.Time
+
+// Set sets the time to a mocked time.Time
+func Set(now time.Time) {
+	mock = now
+}
+
+// Unset will unset the mocked time.Time
+func Unset() {
+	mock = time.Time{}
+}
+
 // TimeStampNow returns now int64
 func TimeStampNow() TimeStamp {
+	if !mock.IsZero() {
+		return TimeStamp(mock.Unix())
+	}
 	return TimeStamp(time.Now().Unix())
 }
 


### PR DESCRIPTION
This should allow us to avoid the heatmap issues in our tests. 

A better mocking system may need to be implemented in the future, this is still somewhat bandaid.