### PR TITLE
feat: improve render time in large file diffs

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1746,6 +1746,8 @@
       }
 
       clear: right;
+      content-visibility: auto;
+      contain-intrinsic-size: 500px;
     }
 
     .ui.bottom.attached.table.segment {


### PR DESCRIPTION
By using content-visibility: auto we get an immediate performance boost in browsers that support that feature at the cost of a bit delayed rendering and jumping scrollbars while scrolling. See https://css-tricks.com/almanac/properties/c/content-visibility/ for a better explanation.

I'm adding this because I was just working on a pull request with >7000 lines changed. Before this change the rendering performance in Chrome on my late 2013 MacBook Pro was that bad that I was not even able to click on the reply button on comments. After this change: no problem.

I'm pretty sure the 500px of the `contain-intrinsic-size` can be chosen more wisely. I just did a random guess.
Might also be that this rule is better preserved in a different selector.

Signed-off-by: Dominik Pschenitschni <mail@celement.de>