### PR TITLE
Ensure correct SSH permissions check for private and restricted users (#17370)

### DIFF
--- a/routers/private/serv.go
+++ b/routers/private/serv.go
@@ -278,7 +278,12 @@ func ServCommand(ctx *context.PrivateContext) {
 	}
 
 	// Permissions checking:
-	if repoExist && (mode > models.AccessModeRead || repo.IsPrivate || setting.Service.RequireSignInView) {
+	if repoExist &&
+		(mode > models.AccessModeRead ||
+			repo.IsPrivate ||
+			owner.Visibility.IsPrivate() ||
+			user.IsRestricted ||
+			setting.Service.RequireSignInView) {
 		if key.Type == models.KeyTypeDeploy {
 			if deployKey.Mode < mode {
 				ctx.JSON(http.StatusUnauthorized, private.ErrServCommand{


### PR DESCRIPTION
Backport #17370

Repositories owned by private users and organisations and pulls by restricted users
need to have permissions checked. Previously Serv would simply assumed that if the
user could log in and the repository was not private then it would be visible.

Fix #17364

Signed-off-by: Andrew Thornton <art27@cantab.net>