### PR TITLE
Fix the click behavior for <tr> and <td> with [data-href]

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -119,14 +119,19 @@ export function initGlobalCommon() {
     $($(this).data('target')).slideToggle(100);
   });
 
-  // make table <tr> element clickable like a link
-  $('tr[data-href]').on('click', function () {
-    window.location = $(this).data('href');
-  });
-
-  // make table <td> element clickable like a link
-  $('td[data-href]').click(function () {
-    window.location = $(this).data('href');
+  // make table <tr> and <td> elements clickable like a link
+  $('tr[data-href], td[data-href]').on('click', function (e) {
+    const href = $(this).data('href');
+    if (e.target.nodeName === 'A') {
+      // if a user clicks on <a>, then the <tr> or <td> should not act as a link.
+      return;
+    }
+    if (e.ctrlKey || e.metaKey) {
+      // ctrl+click or meta+click opens a new window in modern browsers
+      window.open(href);
+    } else {
+      window.location = href;
+    }
   });
 }
 


### PR DESCRIPTION
There was JS code making table `<tr>` and `<td>` elements clickable like a link, but the behavior is not the same as modern browsers.

This PR makes the click behavior for `<tr>` and `<td>` with `[data-href]` the same as modern browsers: if a user clicks it with key Ctrl(Windows) or Meta(macOS) pressed, the link will be opened in a new window/tab.

Also, if there is a `<a>` inside the `<td>`, we should not process the click event because the `<a>` already handles it.
