### PR TITLE
chmod executables when copying to the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,7 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 COPY docker/root /
 COPY --from=build-env /go/src/code.gitea.io/gitea/gitea /app/gitea/gitea
 COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+RUN chmod 755 /usr/bin/entrypoint
+RUN chmod 755 /app/gitea/gitea
+RUN chmod 755 /usr/local/bin/environment-to-ini
 RUN ln -s /app/gitea/gitea /usr/local/bin/gitea

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,5 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 COPY docker/root /
 COPY --from=build-env /go/src/code.gitea.io/gitea/gitea /app/gitea/gitea
 COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
-RUN chmod 755 /usr/bin/entrypoint
-RUN chmod 755 /app/gitea/gitea
-RUN chmod 755 /usr/local/bin/environment-to-ini
+RUN chmod 755 /usr/bin/entrypoint /app/gitea/gitea /usr/local/bin/environment-to-ini
 RUN ln -s /app/gitea/gitea /usr/local/bin/gitea

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,5 @@ COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/
 RUN chmod 755 /usr/bin/entrypoint
 RUN chmod 755 /app/gitea/gitea
 RUN chmod 755 /usr/local/bin/environment-to-ini
+RUN chmod 755 /etc/s6/gitea/* /etc/s6/openssh/* /etc/s6/.s6-svscan/*
 RUN ln -s /app/gitea/gitea /usr/local/bin/gitea

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -56,6 +56,7 @@ COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-setup.sh
 RUN chmod 755 /app/gitea/gitea
 RUN chmod 755 /usr/local/bin/environment-to-ini
 

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -9,7 +9,7 @@ ENV GOPROXY ${GOPROXY:-direct}
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"
 ENV TAGS "bindata timetzdata $TAGS"
-ARG CGO_EXTRA_CFLAGS 
+ARG CGO_EXTRA_CFLAGS
 
 #Build deps
 RUN apk --no-cache add build-base git nodejs npm
@@ -55,6 +55,9 @@ RUN chown git:git /var/lib/gitea /etc/gitea
 COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /app/gitea/gitea
+RUN chmod 755 /usr/local/bin/environment-to-ini
 
 #git:git
 USER 1000:1000

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -55,9 +55,7 @@ RUN chown git:git /var/lib/gitea /etc/gitea
 COPY docker/rootless /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
-RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
-RUN chmod 755 /app/gitea/gitea
-RUN chmod 755 /usr/local/bin/environment-to-ini
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh /app/gitea/gitea /usr/local/bin/environment-to-ini
 
 #git:git
 USER 1000:1000


### PR DESCRIPTION
Run chmod on the executables and the entrypoint when copying them to the
docker in dockerfile.

Signed-off-by: Andrew Thornton <art27@cantab.net>
