### PR TITLE
Fix markdown checkbox rendering

### DIFF
--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -159,11 +159,17 @@
   .task-list-item {
     list-style-type: none;
     position: relative;
+    line-height: 1.5rem;
+    min-height: 1.5rem; // to render a checkbox list without content `- [ ]`, we need this min-height to make sure the <li> can be visible
 
     input[type="checkbox"] {
       position: absolute;
       top: .25em;
       left: -1.6em;
+    }
+
+    p {
+      line-height: 1.5rem;
     }
   }
 


### PR DESCRIPTION
We allow to render empty check list item `- [ ]`, while GitHub doesn't allow.

To make the rendering correct, we need tune the UI (the last PR #17411 uses `absolute` layout, which makes the empty checkbox item can not be displayed correctly)

```
- [ ] test checkbox

- [ ] 

- [ ] 

- [x] 


-----



- [ ] test checkbox
- [x] 
- [ ] 
- [x] 

```

### With this PR
![image](https://user-images.githubusercontent.com/2114189/138636389-db810add-bd6f-4e66-8562-cf0ee8d23bd8.png)

### Without this PR

![image](https://user-images.githubusercontent.com/2114189/138636407-283353cf-3b07-4934-b1d8-d135f7d4bda4.png)

