### PR TITLE
Backport: fix markdown checkbox rendering

### DIFF
--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -159,11 +159,17 @@
   .task-list-item {
     list-style-type: none;
     position: relative;
+    line-height: 1.5rem;
+    min-height: 1.5rem; // to render a checkbox list without content `- [ ]`, we need this min-height to make sure the <li> can be visible
 
     input[type="checkbox"] {
       position: absolute;
       top: .25em;
       left: -1.6em;
+    }
+
+    p {
+      line-height: 1.5rem;
     }
   }
 


### PR DESCRIPTION
Backport #17425

We allow to render empty check list item - [ ], while GitHub doesn't allow.

To make the rendering correct, we need tune the UI (the last PR #17413 uses absolute layout, which makes the empty checkbox item can not be displayed correctly)