### PR TITLE
Upgrade webpack to 5.59.1 to resolve the `waitFor` bug with `watch-frontend`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vue-calendar-heatmap": "0.8.4",
         "vue-loader": "15.9.8",
         "vue-template-compiler": "2.6.14",
-        "webpack": "5.58.2",
+        "webpack": "5.59.1",
         "webpack-cli": "4.9.1",
         "workbox-routing": "6.3.0",
         "workbox-strategies": "6.3.0",
@@ -10547,9 +10547,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.2.tgz",
-      "integrity": "sha512-3S6e9Vo1W2ijk4F4PPWRIu6D/uGgqaPmqw+av3W3jLDujuNkdxX5h5c+RQ6GkjVR+WwIPOfgY8av+j5j4tMqJw==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.59.1.tgz",
+      "integrity": "sha512-I01IQV9K96FlpXX3V0L4nvd7gb0r7thfuu1IfT2P4uOHOA77nKARAKDYGe/tScSHKnffNIyQhLC8kRXzY4KEHQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -19013,9 +19013,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.2.tgz",
-      "integrity": "sha512-3S6e9Vo1W2ijk4F4PPWRIu6D/uGgqaPmqw+av3W3jLDujuNkdxX5h5c+RQ6GkjVR+WwIPOfgY8av+j5j4tMqJw==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.59.1.tgz",
+      "integrity": "sha512-I01IQV9K96FlpXX3V0L4nvd7gb0r7thfuu1IfT2P4uOHOA77nKARAKDYGe/tScSHKnffNIyQhLC8kRXzY4KEHQ==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vue-calendar-heatmap": "0.8.4",
     "vue-loader": "15.9.8",
     "vue-template-compiler": "2.6.14",
-    "webpack": "5.58.2",
+    "webpack": "5.59.1",
     "webpack-cli": "4.9.1",
     "workbox-routing": "6.3.0",
     "workbox-strategies": "6.3.0",


### PR DESCRIPTION
Webpack < 5.59 has a bug, which makes `watch-frontend` fail when editing `.less` files.

```
ERROR in ./web_src/less/index.less
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
Error: waitFor can only be called for an already started item
    at AsyncQueue.waitFor (/Users/user/work/gitea/node_modules/webpack/lib/util/AsyncQueue.js:180:5)
    at /Users/user/work/gitea/node_modules/webpack/lib/Compilation.js:4690:25
    at processQueue (/Users/user/work/gitea/node_modules/webpack/lib/util/processAsyncTree.js:50:4)
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```

Related webpack issues and PR: 

```
https://github.com/webpack-contrib/mini-css-extract-plugin/issues/856
https://github.com/webpack/webpack/issues/14484
https://github.com/webpack/webpack/pull/14507
```
