### PR TITLE
Prevent panic in serv.go with Deploy Keys

### DIFF
--- a/routers/private/serv.go
+++ b/routers/private/serv.go
@@ -283,7 +283,7 @@ func ServCommand(ctx *context.PrivateContext) {
 		(mode > models.AccessModeRead ||
 			repo.IsPrivate ||
 			owner.Visibility.IsPrivate() ||
-			user.IsRestricted ||
+			(user != nil && user.IsRestricted) || // user will be nil if the key is a deploykey
 			setting.Service.RequireSignInView) {
 		if key.Type == models.KeyTypeDeploy {
 			if deployKey.Mode < mode {


### PR DESCRIPTION
Unfortunately there was a regression in #17373 which missed that the user is not
for deploy keys. This leads to a panic when pushing with deploy keys.

Fix #17412

Signed-off-by: Andrew Thornton <art27@cantab.net>
