### PR TITLE
Fixes #16559 - Do not trim leading spaces for tab delimited

### DIFF
--- a/modules/csv/csv.go
+++ b/modules/csv/csv.go
@@ -22,7 +22,11 @@ var quoteRegexp = regexp.MustCompile(`["'][\s\S]+?["']`)
 func CreateReader(input io.Reader, delimiter rune) *stdcsv.Reader {
 	rd := stdcsv.NewReader(input)
 	rd.Comma = delimiter
-	rd.TrimLeadingSpace = true
+	if delimiter != '\t' && delimiter != ' ' {
+		// TrimLeadingSpace can't be true when delimiter is a tab or a space as the value for a column might be empty,
+		// thus would change `\t\t` to just `\t` or `  ` (two spaces) to just ` ` (single space)
+		rd.TrimLeadingSpace = true
+	}
 	return rd
 }
 

--- a/modules/csv/csv_test.go
+++ b/modules/csv/csv_test.go
@@ -18,15 +18,52 @@ func TestCreateReader(t *testing.T) {
 }
 
 func TestCreateReaderAndGuessDelimiter(t *testing.T) {
-	input := "a;b;c\n1;2;3\n4;5;6"
+	var csvToRowsMap = map[string][][]string{
+		`col1	col2	col3
+a	b	c
+	e	f
+g	h	i
+j		l
+m	n	
+p	q	r
+		u
+v	w	x
+y		
+		`: {{"col1", "col2", "col3"},
+			{"a", "b", "c"},
+			{"", "e", "f"},
+			{"g", "h", "i"},
+			{"j", "", "l"},
+			{"m", "n", ""},
+			{"p", "q", "r"},
+			{"", "", "u"},
+			{"v", "w", "x"},
+			{"y", "", ""},
+			{"", "", ""}},
+		` col1,col2,col3
+ a, b, c
+d,e,f
+ ,h, i
+j, , 
+ , , `: {{"col1", "col2", "col3"},
+			{"a", "b", "c"},
+			{"d", "e", "f"},
+			{"", "h", "i"},
+			{"j", "", ""},
+			{"", "", ""}},
+	}
 
-	rd, err := CreateReaderAndGuessDelimiter(strings.NewReader(input))
-	assert.NoError(t, err)
-	assert.Equal(t, ';', rd.Comma)
+	for csv, expectedRows := range csvToRowsMap {
+		rd, err := CreateReaderAndGuessDelimiter(strings.NewReader(csv))
+		assert.NoError(t, err)
+		rows, err := rd.ReadAll()
+		assert.NoError(t, err)
+		assert.EqualValues(t, rows, expectedRows)
+	}
 }
 
 func TestGuessDelimiter(t *testing.T) {
-	var kases = map[string]rune{
+	var csvToDelimiterMap = map[string]rune{
 		"a":                         ',',
 		"1,2":                       ',',
 		"1;2":                       ';',
@@ -37,7 +74,7 @@ func TestGuessDelimiter(t *testing.T) {
 		"<br/>":                     ',',
 	}
 
-	for k, v := range kases {
-		assert.EqualValues(t, guessDelimiter([]byte(k)), v)
+	for csv, expectedDelimiter := range csvToDelimiterMap {
+		assert.EqualValues(t, guessDelimiter([]byte(csv)), expectedDelimiter)
 	}
 }

--- a/modules/csv/csv_test.go
+++ b/modules/csv/csv_test.go
@@ -17,6 +17,7 @@ func TestCreateReader(t *testing.T) {
 	assert.Equal(t, ',', rd.Comma)
 }
 
+//nolint
 func TestCreateReaderAndGuessDelimiter(t *testing.T) {
 	var csvToRowsMap = map[string][][]string{
 		`a;b;c
@@ -43,7 +44,7 @@ y
 			{"v", "w", "x"},
 			{"y", "", ""},
 			{"", "", ""}},
-		`col1,col2,col3
+		` col1,col2,col3
  a, b, c
 d,e,f
  ,h, i

--- a/modules/csv/csv_test.go
+++ b/modules/csv/csv_test.go
@@ -19,6 +19,9 @@ func TestCreateReader(t *testing.T) {
 
 func TestCreateReaderAndGuessDelimiter(t *testing.T) {
 	var csvToRowsMap = map[string][][]string{
+		`a;b;c
+1;2;3
+4;5;6`: {{"a", "b", "c"}, {"1", "2", "3"}, {"4", "5", "6"}},
 		`col1	col2	col3
 a	b	c
 	e	f

--- a/modules/csv/csv_test.go
+++ b/modules/csv/csv_test.go
@@ -43,7 +43,7 @@ y
 			{"v", "w", "x"},
 			{"y", "", ""},
 			{"", "", ""}},
-		` col1,col2,col3
+		`col1,col2,col3
  a, b, c
 d,e,f
  ,h, i


### PR DESCRIPTION
Fixes #16559

If delimiter is tab (or space, as that is possible if we ever want to support it) the TrimLeadingSpace setting should NOT be set to true as that trims any leading white space (spaces or tabs) from every column value, thus if there is no text value, it takes `\t\t` and makes it just `\t` resulting in the wrong number of columns. (See issue for example)

Adds tests for both a tab delimited CSV to NOT have leading spaces trimmed, and a comma delimited CSV with many leading spaces to be trimmed (such as always delimiting by a comma AND a space)