### PR TITLE
Changelog 1.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
-## [1.15.6](https://github.com/go-gitea/gitea/releases/tag/v1.15.6) - 2021-10-27
+## [1.15.6](https://github.com/go-gitea/gitea/releases/tag/v1.15.6) - 2021-10-28
 
 * BUGFIXES
   * Prevent panic in serv.go with Deploy Keys (#17434) (#17435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Fix CSV render error (#17406) (#17431)
   * Read expected buffer size (#17409) (#17430)
   * Ensure that restricted users can access repos for which they are members (#17460) (#17464)
+  * Make commit-statuses popup show correctly (#17447) (#17466)
 * TESTING
   * Add integration tests for private.NoServCommand and private.ServCommand (#17456) (#17463)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Prevent panic in serv.go with Deploy Keys (#17434) (#17435)
   * Fix CSV render error (#17406) (#17431)
   * Read expected buffer size (#17409) (#17430)
+  * Ensure that restricted users can access repos for which they are members (#17460) (#17464)
 * TESTING
   * Add integration tests for private.NoServCommand and private.ServCommand (#17456) (#17463)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
+## [1.15.6](https://github.com/go-gitea/gitea/releases/tag/v1.15.6) - 2021-10-27
+
+* BUGFIXES
+  * Prevent panic in serv.go with Deploy Keys (#17434) (#17435)
+  * Fix CSV render error (#17406) (#17431)
+  * Read expected buffer size (#17409) (#17430)
+
 ## [1.15.5](https://github.com/go-gitea/gitea/releases/tag/v1.15.5) - 2021-10-21
 
 * SECURITY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Prevent panic in serv.go with Deploy Keys (#17434) (#17435)
   * Fix CSV render error (#17406) (#17431)
   * Read expected buffer size (#17409) (#17430)
+* TESTING
+  * Add integration tests for private.NoServCommand and private.ServCommand (#17456) (#17463)
 
 ## [1.15.5](https://github.com/go-gitea/gitea/releases/tag/v1.15.5) - 2021-10-21
 


### PR DESCRIPTION
Unforunately #17435 contains a fix for a somewhat critical bug and therefore we should
really release 1.15.6 as soon as possible.

## [1.15.6](https://github.com/go-gitea/gitea/releases/tag/v1.15.6) - 2021-10-28

* BUGFIXES
  * Prevent panic in serv.go with Deploy Keys (#17434) (#17435)
  * Fix CSV render error (#17406) (#17431)
  * Read expected buffer size (#17409) (#17430)
  * Ensure that restricted users can access repos for which they are members (#17460) (#17464)
  * Make commit-statuses popup show correctly (#17447) (#17466)
* TESTING
  * Add integration tests for private.NoServCommand and private.ServCommand (#17456) (#17463)

Signed-off-by: Andrew Thornton <art27@cantab.net>
