### PR TITLE
Fix mispelling of starred as stared

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2786,7 +2786,7 @@ publish_release  = `released <a href="%s/releases/tag/%s"> "%[4]s" </a> at <a hr
 review_dismissed = `dismissed review from <b>%[4]s</b> for <a href="%[1]s/pulls/%[2]s">%[3]s#%[2]s</a>`
 review_dismissed_reason = Reason:
 create_branch = created branch <a href="%[1]s/src/branch/%[2]s">%[3]s</a> in <a href="%[1]s">%[4]s</a>
-stared_repo = stared <a href="%[1]s">%[2]s</a>
+starred_repo = starred <a href="%[1]s">%[2]s</a>
 watched_repo = started watching <a href="%[1]s">%[2]s</a>
 
 [tool]

--- a/routers/web/feed/convert.go
+++ b/routers/web/feed/convert.go
@@ -83,7 +83,7 @@ func feedActionsToFeedItems(ctx *context.Context, actions []*models.Action) (ite
 		case models.ActionPullReviewDismissed:
 			title += ctx.Tr("action.review_dismissed", act.GetRepoLink(), act.GetIssueInfos()[0], act.ShortRepoPath(), act.GetIssueInfos()[1])
 		case models.ActionStarRepo:
-			title += ctx.Tr("action.stared_repo", act.GetRepoLink(), act.GetRepoPath())
+			title += ctx.Tr("action.starred_repo", act.GetRepoLink(), act.GetRepoPath())
 			link = &feeds.Link{Href: act.GetRepoLink()}
 		case models.ActionWatchRepo:
 			title += ctx.Tr("action.watched_repo", act.GetRepoLink(), act.GetRepoPath())


### PR DESCRIPTION
There was a recent spelling mistake added to the locale file where stared was used
instead of starred.

This PR changes this to starred.

Signed-off-by: Andrew Thornton <art27@cantab.net>
