### PR TITLE
Rename db Engines related functions

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,7 +65,7 @@ func initDBDisableConsole(disableConsole bool) error {
 	setting.InitDBConfig()
 
 	setting.NewXORMLogService(disableConsole)
-	if err := db.SetEngine(); err != nil {
+	if err := db.InitEngine(); err != nil {
 		return fmt.Errorf("models.SetEngine: %v", err)
 	}
 	return nil

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -96,7 +96,7 @@ func runRecreateTable(ctx *cli.Context) error {
 	setting.Cfg.Section("log").Key("XORM").SetValue(",")
 
 	setting.NewXORMLogService(!ctx.Bool("debug"))
-	if err := db.SetEngine(); err != nil {
+	if err := db.InitEngine(); err != nil {
 		fmt.Println(err)
 		fmt.Println("Check if you are using the right config file. You can use a --config directive to specify one.")
 		return nil
@@ -114,7 +114,7 @@ func runRecreateTable(ctx *cli.Context) error {
 	}
 	recreateTables := migrations.RecreateTables(beans...)
 
-	return db.NewEngine(context.Background(), func(x *xorm.Engine) error {
+	return db.InitEngineWithMigration(context.Background(), func(x *xorm.Engine) error {
 		if err := migrations.EnsureUpToDate(x); err != nil {
 			return err
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -173,7 +173,7 @@ func runDump(ctx *cli.Context) error {
 	}
 	setting.NewServices() // cannot access session settings otherwise
 
-	err := db.SetEngine()
+	err := db.InitEngine()
 	if err != nil {
 		return err
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -35,7 +35,7 @@ func runMigrate(ctx *cli.Context) error {
 	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
-	if err := db.NewEngine(context.Background(), migrations.Migrate); err != nil {
+	if err := db.InitEngineWithMigration(context.Background(), migrations.Migrate); err != nil {
 		log.Fatal("Failed to initialize ORM engine: %v", err)
 		return err
 	}

--- a/cmd/migrate_storage.go
+++ b/cmd/migrate_storage.go
@@ -118,7 +118,7 @@ func runMigrateStorage(ctx *cli.Context) error {
 	log.Info("Configuration file: %s", setting.CustomConf)
 	setting.InitDBConfig()
 
-	if err := db.NewEngine(context.Background(), migrations.Migrate); err != nil {
+	if err := db.InitEngineWithMigration(context.Background(), migrations.Migrate); err != nil {
 		log.Fatal("Failed to initialize ORM engine: %v", err)
 		return err
 	}

--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -95,7 +95,7 @@ func runPR() {
 	setting.Database.LogSQL = true
 	//x, err = xorm.NewEngine("sqlite3", "file::memory:?cache=shared")
 
-	db.NewEngine(context.Background(), func(_ *xorm.Engine) error {
+	db.InitEngineWithMigration(context.Background(), func(_ *xorm.Engine) error {
 		return nil
 	})
 	db.HasEngine = true

--- a/integrations/migration-test/migration_test.go
+++ b/integrations/migration-test/migration_test.go
@@ -256,13 +256,13 @@ func doMigrationTest(t *testing.T, version string) {
 
 	setting.NewXORMLogService(false)
 
-	err := db.NewEngine(context.Background(), wrappedMigrate)
+	err := db.InitEngineWithMigration(context.Background(), wrappedMigrate)
 	assert.NoError(t, err)
 	currentEngine.Close()
 
 	beans, _ := db.NamesToBean()
 
-	err = db.NewEngine(context.Background(), func(x *xorm.Engine) error {
+	err = db.InitEngineWithMigration(context.Background(), func(x *xorm.Engine) error {
 		currentEngine = x
 		return migrations.RecreateTables(beans...)(x)
 	})
@@ -270,7 +270,7 @@ func doMigrationTest(t *testing.T, version string) {
 	currentEngine.Close()
 
 	// We do this a second time to ensure that there is not a problem with retained indices
-	err = db.NewEngine(context.Background(), func(x *xorm.Engine) error {
+	err = db.InitEngineWithMigration(context.Background(), func(x *xorm.Engine) error {
 		currentEngine = x
 		return migrations.RecreateTables(beans...)(x)
 	})

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -95,8 +95,8 @@ func init() {
 	}
 }
 
-// GetNewEngine returns a new xorm engine from the configuration
-func GetNewEngine() (*xorm.Engine, error) {
+// NewEngine returns a new xorm engine from the configuration
+func NewEngine() (*xorm.Engine, error) {
 	connStr, err := setting.DBConnStr()
 	if err != nil {
 		return nil, err
@@ -131,8 +131,8 @@ func syncTables() error {
 // NewInstallTestEngine creates a new xorm.Engine for testing during install
 //
 // This function will cause the basic database schema to be created
-func NewInstallTestEngine(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
-	x, err = GetNewEngine()
+func InitInstallTestEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
+	x, err = NewEngine()
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
@@ -160,9 +160,9 @@ func NewInstallTestEngine(ctx context.Context, migrateFunc func(*xorm.Engine) er
 	return syncTables()
 }
 
-// SetEngine sets the xorm.Engine
-func SetEngine() (err error) {
-	x, err = GetNewEngine()
+// InitEngine sets the xorm.Engine
+func InitEngine() (err error) {
+	x, err = NewEngine()
 	if err != nil {
 		return fmt.Errorf("Failed to connect to database: %v", err)
 	}
@@ -178,13 +178,13 @@ func SetEngine() (err error) {
 	return nil
 }
 
-// NewEngine initializes a new xorm.Engine
+// InitEngineWithMigration initializes a new xorm.Engine
 // This function must never call .Sync2() if the provided migration function fails.
 // When called from the "doctor" command, the migration function is a version check
 // that prevents the doctor from fixing anything in the database if the migration level
 // is different from the expected value.
-func NewEngine(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
-	if err = SetEngine(); err != nil {
+func InitEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
+	if err = InitEngine(); err != nil {
 		return err
 	}
 

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -128,10 +128,10 @@ func syncTables() error {
 	return x.StoreEngine("InnoDB").Sync2(tables...)
 }
 
-// InitInstallTestEngineWithMigration creates a new xorm.Engine for testing during install
+// InitInstallEngineWithMigration creates a new xorm.Engine for testing during install
 //
 // This function will cause the basic database schema to be created
-func InitInstallTestEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
+func InitInstallEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {
 	x, err = NewEngine()
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -128,7 +128,7 @@ func syncTables() error {
 	return x.StoreEngine("InnoDB").Sync2(tables...)
 }
 
-// NewInstallTestEngine creates a new xorm.Engine for testing during install
+// InitInstallTestEngineWithMigration creates a new xorm.Engine for testing during install
 //
 // This function will cause the basic database schema to be created
 func InitInstallTestEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine) error) (err error) {

--- a/models/migrations/migrations_test.go
+++ b/models/migrations/migrations_test.go
@@ -84,8 +84,8 @@ func removeAllWithRetry(dir string) error {
 	return err
 }
 
-// SetEngine sets the xorm.Engine
-func SetEngine() (*xorm.Engine, error) {
+// newEngine sets the xorm.Engine
+func newEngine() (*xorm.Engine, error) {
 	x, err := db.NewEngine()
 	if err != nil {
 		return x, fmt.Errorf("Failed to connect to database: %v", err)
@@ -212,7 +212,7 @@ func prepareTestEnv(t *testing.T, skip int, syncModels ...interface{}) (*xorm.En
 		return nil, deferFn
 	}
 
-	x, err := SetEngine()
+	x, err := newEngine()
 	assert.NoError(t, err)
 	if x != nil {
 		oldDefer := deferFn

--- a/models/migrations/migrations_test.go
+++ b/models/migrations/migrations_test.go
@@ -86,7 +86,7 @@ func removeAllWithRetry(dir string) error {
 
 // SetEngine sets the xorm.Engine
 func SetEngine() (*xorm.Engine, error) {
-	x, err := db.GetNewEngine()
+	x, err := db.NewEngine()
 	if err != nil {
 		return x, fmt.Errorf("Failed to connect to database: %v", err)
 	}

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -74,7 +74,7 @@ func genericOrphanCheck(name, subject, refobject, joincond string) consistencyCh
 
 func checkDBConsistency(logger log.Logger, autofix bool) error {
 	// make sure DB version is uptodate
-	if err := db.NewEngine(context.Background(), migrations.EnsureUpToDate); err != nil {
+	if err := db.InitEngineWithMigration(context.Background(), migrations.EnsureUpToDate); err != nil {
 		logger.Critical("Model version on the database does not match the current Gitea version. Model consistency will not be checked until the database is upgraded")
 		return err
 	}

--- a/modules/doctor/dbversion.go
+++ b/modules/doctor/dbversion.go
@@ -13,7 +13,7 @@ import (
 )
 
 func checkDBVersion(logger log.Logger, autofix bool) error {
-	if err := db.NewEngine(context.Background(), migrations.EnsureUpToDate); err != nil {
+	if err := db.InitEngineWithMigration(context.Background(), migrations.EnsureUpToDate); err != nil {
 		if !autofix {
 			logger.Critical("Error: %v during ensure up to date", err)
 			return err
@@ -21,7 +21,7 @@ func checkDBVersion(logger log.Logger, autofix bool) error {
 		logger.Warn("Got Error: %v during ensure up to date", err)
 		logger.Warn("Attempting to migrate to the latest DB version to fix this.")
 
-		err = db.NewEngine(context.Background(), migrations.Migrate)
+		err = db.InitEngineWithMigration(context.Background(), migrations.Migrate)
 		if err != nil {
 			logger.Critical("Error: %v during migration", err)
 		}

--- a/modules/doctor/doctor.go
+++ b/modules/doctor/doctor.go
@@ -47,7 +47,7 @@ func initDBDisableConsole(disableConsole bool) error {
 	setting.InitDBConfig()
 
 	setting.NewXORMLogService(disableConsole)
-	if err := db.SetEngine(); err != nil {
+	if err := db.InitEngine(); err != nil {
 		return fmt.Errorf("models.SetEngine: %v", err)
 	}
 	return nil

--- a/routers/common/db.go
+++ b/routers/common/db.go
@@ -25,7 +25,7 @@ func InitDBEngine(ctx context.Context) (err error) {
 		default:
 		}
 		log.Info("ORM engine initialization attempt #%d/%d...", i+1, setting.Database.DBConnectRetries)
-		if err = db.NewEngine(ctx, migrations.Migrate); err == nil {
+		if err = db.InitEngineWithMigration(ctx, migrations.Migrate); err == nil {
 			break
 		} else if i == setting.Database.DBConnectRetries-1 {
 			return err

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -209,7 +209,7 @@ func SubmitInstall(ctx *context.Context) {
 	}
 
 	// Set test engine.
-	if err = db.NewInstallTestEngine(ctx, migrations.Migrate); err != nil {
+	if err = db.InitInstallTestEngineWithMigration(ctx, migrations.Migrate); err != nil {
 		if strings.Contains(err.Error(), `Unknown database type: sqlite3`) {
 			ctx.Data["Err_DbType"] = true
 			ctx.RenderWithErr(ctx.Tr("install.sqlite3_not_available", "https://docs.gitea.io/en-us/install-from-binary/"), tplInstall, &form)

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -209,7 +209,7 @@ func SubmitInstall(ctx *context.Context) {
 	}
 
 	// Set test engine.
-	if err = db.InitInstallTestEngineWithMigration(ctx, migrations.Migrate); err != nil {
+	if err = db.InitInstallEngineWithMigration(ctx, migrations.Migrate); err != nil {
 		if strings.Contains(err.Error(), `Unknown database type: sqlite3`) {
 			ctx.Data["Err_DbType"] = true
 			ctx.RenderWithErr(ctx.Tr("install.sqlite3_not_available", "https://docs.gitea.io/en-us/install-from-binary/"), tplInstall, &form)


### PR DESCRIPTION
To make it not confusing, this PR renamed some functions related database Engine.

- [x] `GetNewEngine` -> `NewEngine`: this function will return a `xorm.Engine` as the first return parameter, so call it `New` is suitable.
- [x] `SetEngine` -> `InitEngine`: it will call the original `GetNewEngine` and assign engine to the `db` package variable `x`. So we call it `Init`.
- [x] `NewEngine` -> `InitEngineWithMigration`: the function will call `SetEngine` with some migration functions.
- [x] `NewInstallTestEngine` -> `InitInstallEngineWithMigration`: the function will call `SetEngine` with some `test` special statements.