### PR TITLE
Quote the table name in CountOrphanedObjects (#17487)

### DIFF
--- a/models/consistency.go
+++ b/models/consistency.go
@@ -302,7 +302,7 @@ func DeleteOrphanedIssues() error {
 // CountOrphanedObjects count subjects with have no existing refobject anymore
 func CountOrphanedObjects(subject, refobject, joinCond string) (int64, error) {
 	return x.Table("`"+subject+"`").
-		Join("LEFT", refobject, joinCond).
+		Join("LEFT", "`"+refobject+"`", joinCond).
 		Where(builder.IsNull{"`" + refobject + "`.id"}).
 		Count("id")
 }


### PR DESCRIPTION
Backport #17487

CountOrphanedObjects needs to quote the table it is joining with as this table may
be `user`.

Fix #17485

Signed-off-by: Andrew Thornton <art27@cantab.net>
