### PR TITLE
Stop double encoding blame commit messages

### DIFF
--- a/routers/web/repo/blame.go
+++ b/routers/web/repo/blame.go
@@ -6,7 +6,6 @@ package repo
 
 import (
 	"fmt"
-	"html"
 	gotemplate "html/template"
 	"net/http"
 	"strings"
@@ -239,7 +238,7 @@ func renderBlame(ctx *context.Context, blameParts []git.BlamePart, commitNames m
 				br.PreviousSha = previousSha
 				br.PreviousShaURL = fmt.Sprintf("%s/blame/commit/%s/%s", repoLink, previousSha, ctx.Repo.TreePath)
 				br.CommitURL = fmt.Sprintf("%s/commit/%s", repoLink, part.Sha)
-				br.CommitMessage = html.EscapeString(commit.CommitMessage)
+				br.CommitMessage = commit.CommitMessage
 				br.CommitSince = commitSince
 			}
 


### PR DESCRIPTION
The call to html.EscapeString in routers/web/repo/blame.go:renderBlame is extraneous
as the commit message is now rendered by the template. The template will correctly
escape strings - therefore we are currently double escaping.

This PR fixes this.

Fix #17492

Signed-off-by: Andrew Thornton <art27@cantab.net>
