### PR TITLE
Refactor db/engine.go and clean up legacy code

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -108,7 +108,7 @@ func runRecreateTable(ctx *cli.Context) error {
 		names = append(names, args.Get(i))
 	}
 
-	beans, err := db.TablesToBeans(names...)
+	beans, err := db.NamesToTableBeans(names...)
 	if err != nil {
 		return err
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -108,7 +108,7 @@ func runRecreateTable(ctx *cli.Context) error {
 		names = append(names, args.Get(i))
 	}
 
-	beans, err := db.NamesToBean(names...)
+	beans, err := db.TablesToBeans(names...)
 	if err != nil {
 		return err
 	}

--- a/integrations/migration-test/migration_test.go
+++ b/integrations/migration-test/migration_test.go
@@ -260,7 +260,7 @@ func doMigrationTest(t *testing.T, version string) {
 	assert.NoError(t, err)
 	currentEngine.Close()
 
-	beans, _ := db.NamesToBean()
+	beans, _ := db.TablesToBeans()
 
 	err = db.InitEngineWithMigration(context.Background(), func(x *xorm.Engine) error {
 		currentEngine = x

--- a/integrations/migration-test/migration_test.go
+++ b/integrations/migration-test/migration_test.go
@@ -260,7 +260,7 @@ func doMigrationTest(t *testing.T, version string) {
 	assert.NoError(t, err)
 	currentEngine.Close()
 
-	beans, _ := db.TablesToBeans()
+	beans, _ := db.NamesToTableBeans()
 
 	err = db.InitEngineWithMigration(context.Background(), func(x *xorm.Engine) error {
 		currentEngine = x

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -205,8 +205,8 @@ func InitEngineWithMigration(ctx context.Context, migrateFunc func(*xorm.Engine)
 	return nil
 }
 
-// TablesToBeans return a list of beans for tables or an error
-func TablesToBeans(names ...string) ([]interface{}, error) {
+// NamesToTableBeans return a list of beans for tables or an error
+func NamesToTableBeans(names ...string) ([]interface{}, error) {
 	var beans []interface{}
 	if len(names) == 0 {
 		beans = append(beans, tables...)

--- a/models/org.go
+++ b/models/org.go
@@ -447,10 +447,7 @@ func GetUserOrgsList(user *User) ([]*MinimalOrg, error) {
 	sess := db.NewSession(db.DefaultContext)
 	defer sess.Close()
 
-	schema, err := db.TableInfo(new(User))
-	if err != nil {
-		return nil, err
-	}
+	tableName := sess.Engine().TableName(new(User))
 
 	outputCols := []string{
 		"id",
@@ -464,7 +461,7 @@ func GetUserOrgsList(user *User) ([]*MinimalOrg, error) {
 
 	groupByCols := &strings.Builder{}
 	for _, col := range outputCols {
-		fmt.Fprintf(groupByCols, "`%s`.%s,", schema.Name, col)
+		_, _ = fmt.Fprintf(groupByCols, "`%s`.%s,", tableName, col)
 	}
 	groupByStr := groupByCols.String()
 	groupByStr = groupByStr[0 : len(groupByStr)-1]

--- a/modules/indexer/stats/indexer.go
+++ b/modules/indexer/stats/indexer.go
@@ -40,7 +40,10 @@ func populateRepoIndexer() {
 
 	isShutdown := graceful.GetManager().IsShutdown()
 
-	exist, err := db.IsTableNotEmpty("repository")
+	engine := db.GetEngine(db.DefaultContext)
+	tableRepository := new(models.Repository)
+
+	exist, err := engine.Table(tableRepository).Exist()
 	if err != nil {
 		log.Fatal("System error: %v", err)
 	} else if !exist {
@@ -48,7 +51,7 @@ func populateRepoIndexer() {
 	}
 
 	var maxRepoID int64
-	if maxRepoID, err = db.GetMaxID("repository"); err != nil {
+	if _, err = engine.Select("MAX(id)").Table(tableRepository).Get(&maxRepoID); err != nil {
 		log.Fatal("System error: %v", err)
 	}
 

--- a/modules/migrations/gitea_uploader.go
+++ b/modules/migrations/gitea_uploader.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/models"
-	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/migrations/base"
@@ -70,17 +69,17 @@ func NewGiteaLocalUploader(ctx context.Context, doer *models.User, repoOwner, re
 func (g *GiteaLocalUploader) MaxBatchInsertSize(tp string) int {
 	switch tp {
 	case "issue":
-		return db.MaxBatchInsertSize(new(models.Issue))
+		return 50
 	case "comment":
-		return db.MaxBatchInsertSize(new(models.Comment))
+		return 50
 	case "milestone":
-		return db.MaxBatchInsertSize(new(models.Milestone))
+		return 100
 	case "label":
-		return db.MaxBatchInsertSize(new(models.Label))
+		return 100
 	case "release":
-		return db.MaxBatchInsertSize(new(models.Release))
+		return 50
 	case "pullrequest":
-		return db.MaxBatchInsertSize(new(models.PullRequest))
+		return 50
 	}
 	return 10
 }

--- a/services/auth/signin.go
+++ b/services/auth/signin.go
@@ -27,7 +27,7 @@ func UserSignIn(username, password string) (*models.User, *login.Source, error) 
 	if strings.Contains(username, "@") {
 		user = &models.User{Email: strings.ToLower(strings.TrimSpace(username))}
 		// check same email
-		cnt, err := db.Count(user)
+		cnt, err := db.GetEngine(db.DefaultContext).Count(user)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -956,6 +956,7 @@ func parseHunks(curFile *DiffFile, maxLines, maxLineCharacters int, input *bufio
 	lastLeftIdx := -1
 	leftLine, rightLine := 1, 1
 
+	engine := db.GetEngine(db.DefaultContext)
 	for {
 		for isFragment {
 			curFile.IsIncomplete = true
@@ -1126,7 +1127,7 @@ func parseHunks(curFile *DiffFile, maxLines, maxLineCharacters int, input *bufio
 			oid := strings.TrimPrefix(line[1:], lfs.MetaFileOidPrefix)
 			if len(oid) == 64 {
 				m := &models.LFSMetaObject{Pointer: lfs.Pointer{Oid: oid}}
-				count, err := db.Count(m)
+				count, err := engine.Count(m)
 
 				if err == nil && count > 0 {
 					curFile.IsBin = true


### PR DESCRIPTION
As the title.

Some comments:

* Why `db.MaxBatchInsertSize` is removed: it just did `return 999 / columnCount`, it was a magic formula. Actually some table fields contain large contents (LONGTEXT), we can make the batch size of such tables smaller. So the old `db.MaxBatchInsertSize` didn't help much.
* `TestDumpLoginSource` is rewritten, it should not depend on xorm internal engine or DumpTable
* Many services/modules used `db.Xxx` directly before. This PR doesn't change it, and now `db.GetEngine` is used instead. Adding new packages is NOT the task or purpose of this PR.