### PR TITLE
Make Repo Code Indexer an Unique Queue

### DIFF
--- a/integrations/repo_search_test.go
+++ b/integrations/repo_search_test.go
@@ -44,7 +44,6 @@ func TestSearchRepo(t *testing.T) {
 	repo, err = models.GetRepositoryByOwnerAndName("user2", "glob")
 	assert.NoError(t, err)
 
-	executeIndexer(t, repo, code_indexer.DeleteRepoFromIndexer)
 	executeIndexer(t, repo, code_indexer.UpdateRepoIndexer)
 
 	testSearch(t, "/user2/glob/search?q=loren&page=1", []string{"a.txt"})

--- a/modules/notification/indexer/indexer.go
+++ b/modules/notification/indexer/indexer.go
@@ -109,7 +109,7 @@ func (r *indexerNotifier) NotifyDeleteComment(doer *models.User, comment *models
 func (r *indexerNotifier) NotifyDeleteRepository(doer *models.User, repo *models.Repository) {
 	issue_indexer.DeleteRepoIssueIndexer(repo)
 	if setting.Indexer.RepoIndexerEnabled {
-		code_indexer.DeleteRepoFromIndexer(repo)
+		code_indexer.UpdateRepoIndexer(repo)
 	}
 }
 


### PR DESCRIPTION
The functioning of the code indexer queue really only makes sense as an unique queue
and doing this allows use to simplify the indexer data to simply delete the data if
the repo is no longer in the db.

Signed-off-by: Andrew Thornton <art27@cantab.net>
