### PR TITLE
Add QueryEscape to general funcmap

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -379,6 +379,7 @@ func NewFuncMap() []template.FuncMap {
 		"MermaidMaxSourceCharacters": func() int {
 			return setting.MermaidMaxSourceCharacters
 		},
+		"QueryEscape": url.QueryEscape,
 	}}
 }
 


### PR DESCRIPTION
QueryEscape was only added to the text funcmap in #17518 . Add this to the main template funcmap
too.

Fix #17525

Signed-off-by: Andrew Thornton <art27@cantab.net>
