### PR TITLE
Show correct "No" icon

### DIFF
--- a/templates/base/delete_modal_actions.tmpl
+++ b/templates/base/delete_modal_actions.tmpl
@@ -1,6 +1,6 @@
 <div class="actions">
 	<div class="ui red basic inverted cancel button">
-		{{svg "octicon-trash"}}
+		{{svg "octicon-x"}}
 		{{.i18n.Tr "modal.no"}}
 	</div>
 	<div class="ui green basic inverted ok button">


### PR DESCRIPTION
Replaced the previously present "Trash" icon on "No" with the intended cross:
(ignore the filename at the bottom, that was an oversight while taking the screenshot)
![image](https://user-images.githubusercontent.com/51889757/140088862-0c9cabb0-5f81-43e2-81a1-8b1f7cc62ada.png)

This way, there won't be confusion in case you delete something and the "No" icon displays the trash can.

It is possible that something else will look slightly worse afterwards, but that is a tradeoff I'm willing to make as it does not lead to as much confusion as it does now.

Fixes #17535.
Backports: #17537, #17538
