### PR TITLE
Fix stats upon searching issues (#17566)

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1517,12 +1517,12 @@ func GetIssueStats(opts *IssueStatsOptions) (*IssueStats, error) {
 func getIssueStatsChunk(opts *IssueStatsOptions, issueIDs []int64) (*IssueStats, error) {
 	stats := &IssueStats{}
 
-	countSession := func(opts *IssueStatsOptions) *xorm.Session {
+	countSession := func(opts *IssueStatsOptions, issueIDs []int64) *xorm.Session {
 		sess := x.
 			Where("issue.repo_id = ?", opts.RepoID)
 
-		if len(opts.IssueIDs) > 0 {
-			sess.In("issue.id", opts.IssueIDs)
+		if len(issueIDs) > 0 {
+			sess.In("issue.id", issueIDs)
 		}
 
 		if len(opts.Labels) > 0 && opts.Labels != "0" {
@@ -1572,13 +1572,13 @@ func getIssueStatsChunk(opts *IssueStatsOptions, issueIDs []int64) (*IssueStats,
 	}
 
 	var err error
-	stats.OpenCount, err = countSession(opts).
+	stats.OpenCount, err = countSession(opts, issueIDs).
 		And("issue.is_closed = ?", false).
 		Count(new(Issue))
 	if err != nil {
 		return stats, err
 	}
-	stats.ClosedCount, err = countSession(opts).
+	stats.ClosedCount, err = countSession(opts, issueIDs).
 		And("issue.is_closed = ?", true).
 		Count(new(Issue))
 	return stats, err


### PR DESCRIPTION
Backport #17566

- Fixes a issue whereby the given chunk of issueIDs wasn't respected and
thus the returned results where not the correct results. More specifically when the amount of returned results are above `maxQueryParameters`.

To reproduce this issue easily:
- Set the constant `maxQueryParameters` within the code to a value of `5`.
- Create a new repo.
- Create more than 5 issues(I'm using 7) with the same description(e.g. `Hello`).
- Go to the issues tab and search for that description: `Hello`.
- See that amount of open issues is inaccurate and way above the correct amount.

^ This PR fixes that issue.

Their is a interesting comment above the relevant code:
https://github.com/go-gitea/gitea/blob/bd613c704c0d74352d427ab32369310a04f5b721/models/issue.go#L1502-L1505

I do think that the person writing that comment was hitting into this bug whereby the wrong issuesIDs were used in the database action and I do think it can be removed, but I'm not sure.

Screenshots(The repo had 7 issues with the description of `Helo`):

Before:
![image](https://user-images.githubusercontent.com/25481501/140609340-ef6a6c05-fdcc-49e8-94f0-3d69cf60b8ff.png)

After:
![image](https://user-images.githubusercontent.com/25481501/140609326-c508c3e5-1aca-4c61-976a-7b78de700103.png)

