### PR TITLE
Add separate SSH_USER config option

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -82,11 +82,14 @@ RUN_MODE = ; prod
 ;; Whether to use the builtin SSH server or not.
 ;START_SSH_SERVER = false
 ;;
-;; Username to use for the builtin SSH server. If blank, then it is the value of RUN_USER.
-;BUILTIN_SSH_SERVER_USER =
+;; Username to use for the builtin SSH server.
+;BUILTIN_SSH_SERVER_USER = %(RUN_USER)s
 ;;
 ;; Domain name to be exposed in clone URL
 ;SSH_DOMAIN = %(DOMAIN)s
+;;
+;; SSH username displayed in clone URLs.
+;SSH_USER = %(BUILTIN_SSH_SERVER_USER)s
 ;;
 ;; The network interface the builtin SSH server should listen on
 ;SSH_LISTEN_HOST =

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -265,6 +265,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `DISABLE_SSH`: **false**: Disable SSH feature when it's not available.
 - `START_SSH_SERVER`: **false**: When enabled, use the built-in SSH server.
 - `BUILTIN_SSH_SERVER_USER`: **%(RUN_USER)s**: Username to use for the built-in SSH Server.
+- `SSH_USER`: **%(BUILTIN_SSH_SERVER_USER)**: SSH username displayed in clone URLs. This is only for people who configure the SSH server themselves; in most cases, you want to leave this blank and modify the `BUILTIN_SSH_SERVER_USER`.
 - `SSH_DOMAIN`: **%(DOMAIN)s**: Domain name of this server, used for displayed clone URL.
 - `SSH_PORT`: **22**: SSH port displayed in clone URL.
 - `SSH_LISTEN_HOST`: **0.0.0.0**: Listen address for the built-in SSH server.

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -135,7 +135,7 @@ func TestViewRepo1CloneLinkAuthorized(t *testing.T) {
 	assert.Equal(t, setting.AppURL+"user2/repo1.git", link)
 	link, exists = htmlDoc.doc.Find("#repo-clone-ssh").Attr("data-link")
 	assert.True(t, exists, "The template has changed")
-	sshURL := fmt.Sprintf("ssh://%s@%s:%d/user2/repo1.git", setting.SSH.BuiltinServerUser, setting.SSH.Domain, setting.SSH.Port)
+	sshURL := fmt.Sprintf("ssh://%s@%s:%d/user2/repo1.git", setting.SSH.User, setting.SSH.Domain, setting.SSH.Port)
 	assert.Equal(t, sshURL, link)
 }
 

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -540,10 +540,7 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 		repoName += ".wiki"
 	}
 
-	sshUser := setting.RunUser
-	if setting.SSH.StartBuiltinServer {
-		sshUser = setting.SSH.BuiltinServerUser
-	}
+	sshUser := setting.SSH.User
 
 	cl := new(CloneLink)
 

--- a/models/repo/wiki_test.go
+++ b/models/repo/wiki_test.go
@@ -19,7 +19,7 @@ func TestRepository_WikiCloneLink(t *testing.T) {
 
 	repo := unittest.AssertExistsAndLoadBean(t, &Repository{ID: 1}).(*Repository)
 	cloneLink := repo.WikiCloneLink()
-	assert.Equal(t, "ssh://runuser@try.gitea.io:3000/user2/repo1.wiki.git", cloneLink.SSH)
+	assert.Equal(t, "ssh://sshuser@try.gitea.io:3000/user2/repo1.wiki.git", cloneLink.SSH)
 	assert.Equal(t, "https://try.gitea.io/user2/repo1.wiki.git", cloneLink.HTTPS)
 }
 

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -64,6 +64,8 @@ func MainTest(m *testing.M, pathToGiteaRoot string, fixtureFiles ...string) {
 
 	setting.AppURL = "https://try.gitea.io/"
 	setting.RunUser = "runuser"
+	setting.SSH.User = "sshuser"
+	setting.SSH.BuiltinServerUser = "builtinuser"
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
 	setting.Database.UseSQLite3 = true

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -131,6 +131,7 @@ var (
 		BuiltinServerUser                     string             `ini:"BUILTIN_SSH_SERVER_USER"`
 		Domain                                string             `ini:"SSH_DOMAIN"`
 		Port                                  int                `ini:"SSH_PORT"`
+		User                                  string             `ini:"SSH_USER"`
 		ListenHost                            string             `ini:"SSH_LISTEN_HOST"`
 		ListenPort                            int                `ini:"SSH_LISTEN_PORT"`
 		RootPath                              string             `ini:"SSH_ROOT_PATH"`
@@ -970,6 +971,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	}
 
 	SSH.BuiltinServerUser = Cfg.Section("server").Key("BUILTIN_SSH_SERVER_USER").MustString(RunUser)
+	SSH.User = Cfg.Section("server").Key("SSH_USER").MustString(SSH.BuiltinServerUser)
 
 	newRepository()
 


### PR DESCRIPTION
This lets the user shown in SSH URLs be customised even when the built-in server is disabled. In my case, I customised my SSH server to accept logins from a username other than the one that gitea is logged into, and the way I currently do this is by running the built-in SSH server to override the displayed URL without actually using it. I think that this method is much cleaner, and doesn't add too much complexity to the configuration. In fact, IMHO, it actually simplifies things for non-niche users as well.

The value of this will default to the `BUILTIN_SSH_SERVER_USER` if not provided, which will default to `RUN_USER` if that's also not provided, meaning that for most people this will "just work." However, I did put some caveats below.

I technically filed a ticket for this a while back but it got closed due to confusion about the actual implementation, so, I don't think it's worth it to link it here. But if anyone is curious, I can probably find it.

## :warning:  BREAKING :warning: 

This is technically a breaking change, since people who have modified `BUILTIN_SSH_SERVER_USER` but don't actually have the built-in server running will have their URLs show the value they chose for that, which will presumably not work. Initially I considered modifying this change to default to `BUILTIN_SSH_SERVER_USER` only when the built-in server was enabled, and `RUN_USER` otherwise, but I ultimately chose to abandon this approach since:

1. It's more-complicated in both code and explanation.
2. The number of people who have made these changes is likely small
3. The people who have `BUILTIN_SSH_SERVER_USER` set to something other than `RUN_USER` without the built-in server running probably just forgot to remove that section from their config, and probably should fix that
4. Explaining the extra default rules adds more complexity to the ruleset when it makes more sense to just let the variables default in the order of `SSH_USER` -> `BUILTIN_SSH_SERVER_USER` -> `RUN_USER`.

# Clarification of my specific use case

This is mostly for the curious people who are wondering how I have this set up, and is not important to the PR itself. Here, I explain how I allow SSH to connect to gitea via a user different than the one gitea uses.

1. I'm running on Arch Linux where gitea is running under a `gitea` user and group.
2. For the sake of simplicity, let's say that the extra user for SSH is `g`.
3. I modified `SSH_AUTHORIZED_KEYS_COMMAND_TEMPLATE` to run a custom script that wraps the `gitea serv key` command. (Before this option was added, I wrapped the authorized keys command in my SSH config directly to modify the output.)
4. The `g` user has no permissions, although in the sudoers file it's allowed to run commands as the gitea user without a password and while passing its environment.
5. My wrapper script runs `sudo -Eu gitea gitea serv key-$1`, where `$1` is the passed key ID. It's only allowed to execute as the `g` user.
6. This user is normally not allowed to connect via SSH, but is allowed to connect via SSH on a separate IP and port only to execute these commands.