### PR TITLE
Remove appSubUrl from pasted images (#17572)

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -362,7 +362,7 @@ function initImagePaste(target) {
           const name = img.name.substr(0, img.name.lastIndexOf('.'));
           insertAtCursor(textarea, `![${name}]()`);
           const data = await uploadFile(img, uploadUrl);
-          replaceAndKeepCursor(textarea, `![${name}]()`, `![${name}](${AppSubUrl}/attachments/${data.uuid})`);
+          replaceAndKeepCursor(textarea, `![${name}]()`, `![${name}](/attachments/${data.uuid})`);
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           dropzoneFiles.appendChild(input[0]);
         }
@@ -378,7 +378,7 @@ function initSimpleMDEImagePaste(simplemde, dropzone, files) {
       const name = img.name.substr(0, img.name.lastIndexOf('.'));
       const data = await uploadFile(img, uploadUrl);
       const pos = simplemde.codemirror.getCursor();
-      simplemde.codemirror.replaceRange(`![${name}](${AppSubUrl}/attachments/${data.uuid})`, pos);
+      simplemde.codemirror.replaceRange(`![${name}](/attachments/${data.uuid})`, pos);
       const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
       files.append(input);
     }


### PR DESCRIPTION
Backport #17572

* Remove appSubUrl from pasted images

Since we fixed the url base for the links in repositories we no longer need to add
the appsuburl to pasted image links.

Fix #17057

Signed-off-by: Andrew Thornton <art27@cantab.net>
