### PR TITLE
Use provided database Engine

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -412,7 +412,7 @@ func GetUsersWhoCanCreateOrgRepo(orgID int64) ([]*User, error) {
 
 func getUsersWhoCanCreateOrgRepo(e db.Engine, orgID int64) ([]*User, error) {
 	users := make([]*User, 0, 10)
-	return users, db.GetEngine(db.DefaultContext).
+	return users, e.
 		Join("INNER", "`team_user`", "`team_user`.uid=`user`.id").
 		Join("INNER", "`team`", "`team`.id=`team_user`.team_id").
 		Where(builder.Eq{"team.can_create_org_repo": true}.Or(builder.Eq{"team.authorize": AccessModeOwner})).

--- a/models/user.go
+++ b/models/user.go
@@ -468,7 +468,7 @@ func (u *User) isVisibleToUser(e db.Engine, viewer *User) bool {
 		}
 
 		// Now we need to check if they in some organization together
-		count, err := db.GetEngine(db.DefaultContext).Table("team_user").
+		count, err := e.Table("team_user").
 			Where(
 				builder.And(
 					builder.Eq{"uid": viewer.ID},


### PR DESCRIPTION
- Don't get the engine from `db.DefaultContext`, instead use the
provided one which is passed as paramater `e`.
