### PR TITLE
Fix database deadlock when update issue labels (#17649)

### DIFF
--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -408,18 +408,17 @@ function initCommentForm() {
     $(`.${selector}`).dropdown('setting', 'onHide', () => {
       hasUpdateAction = $listMenu.data('action') === 'update'; // Update the var
       if (hasUpdateAction) {
-        const promises = [];
-        Object.keys(items).forEach((elementId) => {
-          const item = items[elementId];
-          const promise = updateIssuesMeta(
-            item['update-url'],
-            item.action,
-            item['issue-id'],
-            elementId,
-          );
-          promises.push(promise);
-        });
-        Promise.all(promises).then(reload);
+        (async function() {
+          for (const [elementId, item] of Object.entries(items)) {
+            await updateIssuesMeta(
+              item['update-url'],
+              item.action,
+              item['issue-id'],
+              elementId,
+            );
+          }
+          window.location.reload();
+        })();
       }
     });
 


### PR DESCRIPTION
Backport #17649. 

This fix updates issue labels one by one, and won't cause database deadlock.

In future, we can use a batch API (in 1.16 or later) to update all changed labels by one request.

For 1.15, this fix seems enough.
