### PR TITLE
Fix golangci-lint warnings (#17598 et al)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - unused
     - structcheck
     - varcheck
-    - golint
     - dupl
     #- gocyclo # The cyclomatic complexety of a lot of functions is too high, we should refactor those another time.
     - gofmt

--- a/build.go
+++ b/build.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build vendor
+//go:build vendor
+// +build vendor
 
 package main
 

--- a/build/generate-bindata.go
+++ b/build/generate-bindata.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/build/generate-emoji.go
+++ b/build/generate-emoji.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/build/generate-gitignores.go
+++ b/build/generate-gitignores.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/build/generate-licenses.go
+++ b/build/generate-licenses.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/build/gocovmerge.go
+++ b/build/gocovmerge.go
@@ -6,6 +6,7 @@
 // gocovmerge takes the results from multiple `go test -coverprofile` runs and
 // merges them into one profile
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -43,7 +43,11 @@ func runDocs(ctx *cli.Context) error {
 		// Clean up markdown. The following bug was fixed in v2, but is present in v1.
 		// It affects markdown output (even though the issue is referring to man pages)
 		// https://github.com/urfave/cli/issues/1040
-		docs = docs[strings.Index(docs, "#"):]
+		firstHashtagIndex := strings.Index(docs, "#")
+
+		if firstHashtagIndex > 0 {
+			docs = docs[firstHashtagIndex:]
+		}
 	}
 
 	out := os.Stdout

--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build bindata
 // +build bindata
 
 package cmd

--- a/cmd/embedded_stub.go
+++ b/cmd/embedded_stub.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !bindata
 // +build !bindata
 
 package cmd

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -7,6 +7,7 @@ package migrations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -762,8 +763,14 @@ func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...strin
 		}
 		tableSQL := string(res[0]["sql"])
 
+		// Get the string offset for column definitions: `CREATE TABLE ( column-definitions... )`
+		columnDefinitionsIndex := strings.Index(tableSQL, "(")
+		if columnDefinitionsIndex < 0 {
+			return errors.New("couldn't find column definitions")
+		}
+
 		// Separate out the column definitions
-		tableSQL = tableSQL[strings.Index(tableSQL, "("):]
+		tableSQL = tableSQL[columnDefinitionsIndex:]
 
 		// Remove the required columnNames
 		for _, name := range columnNames {

--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -1,3 +1,4 @@
+//go:build pam
 // +build pam
 
 // Copyright 2014 The Gogs Authors. All rights reserved.

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -1,9 +1,9 @@
-//go:build !pam
-// +build !pam
-
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !pam
+// +build !pam
 
 package pam
 

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -1,3 +1,4 @@
+//go:build !pam
 // +build !pam
 
 // Copyright 2014 The Gogs Authors. All rights reserved.

--- a/modules/auth/pam/pam_test.go
+++ b/modules/auth/pam/pam_test.go
@@ -1,3 +1,4 @@
+//go:build pam
 // +build pam
 
 // Copyright 2021 The Gitea Authors. All rights reserved.

--- a/modules/git/blob_gogit.go
+++ b/modules/git/blob_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/command_test.go
+++ b/modules/git/command_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package git

--- a/modules/git/commit_convert_gogit.go
+++ b/modules/git/commit_convert_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/commit_info_gogit.go
+++ b/modules/git/commit_info_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/last_commit_cache_gogit.go
+++ b/modules/git/last_commit_cache_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/notes_gogit.go
+++ b/modules/git/notes_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/notes_nogogit.go
+++ b/modules/git/notes_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/parse_gogit.go
+++ b/modules/git/parse_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/parse_gogit_test.go
+++ b/modules/git/parse_gogit_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/parse_nogogit.go
+++ b/modules/git/parse_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/parse_nogogit_test.go
+++ b/modules/git/parse_nogogit_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/pipeline/lfs.go
+++ b/modules/git/pipeline/lfs.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package pipeline

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package pipeline

--- a/modules/git/repo_base_gogit.go
+++ b/modules/git/repo_base_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_blob_gogit.go
+++ b/modules/git/repo_blob_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_blob_nogogit.go
+++ b/modules/git/repo_blob_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_branch_gogit.go
+++ b/modules/git/repo_branch_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_commit_gogit.go
+++ b/modules/git/repo_commit_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_commitgraph_gogit.go
+++ b/modules/git/repo_commitgraph_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_language_stats_gogit.go
+++ b/modules/git/repo_language_stats_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_language_stats_nogogit.go
+++ b/modules/git/repo_language_stats_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_ref_gogit.go
+++ b/modules/git/repo_ref_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_ref_nogogit.go
+++ b/modules/git/repo_ref_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_tag_gogit.go
+++ b/modules/git/repo_tag_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_tag_nogogit.go
+++ b/modules/git/repo_tag_nogogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/repo_tree_gogit.go
+++ b/modules/git/repo_tree_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/sha1_gogit.go
+++ b/modules/git/sha1_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/sha1_nogogit.go
+++ b/modules/git/sha1_nogogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/signature_gogit.go
+++ b/modules/git/signature_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/signature_nogogit.go
+++ b/modules/git/signature_nogogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/submodule.go
+++ b/modules/git/submodule.go
@@ -52,9 +52,7 @@ func getRefURL(refURL, urlPrefix, repoFullName, sshDomain string) string {
 		urlPrefixHostname = prefixURL.Host
 	}
 
-	if strings.HasSuffix(urlPrefix, "/") {
-		urlPrefix = urlPrefix[:len(urlPrefix)-1]
-	}
+	urlPrefix = strings.TrimSuffix(urlPrefix, "/")
 
 	// FIXME: Need to consider branch - which will require changes in modules/git/commit.go:GetSubModules
 	// Relative url prefix check (according to git submodule documentation)

--- a/modules/git/tree_blob_gogit.go
+++ b/modules/git/tree_blob_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/tree_blob_nogogit.go
+++ b/modules/git/tree_blob_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/tree_entry_gogit.go
+++ b/modules/git/tree_entry_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/git/tree_entry_test.go
+++ b/modules/git/tree_entry_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/tree_gogit.go
+++ b/modules/git/tree_gogit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package git

--- a/modules/git/tree_nogogit.go
+++ b/modules/git/tree_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package git

--- a/modules/gitgraph/graph_models.go
+++ b/modules/gitgraph/graph_models.go
@@ -217,11 +217,9 @@ func newRefsFromRefNames(refNames []byte) []git.Reference {
 			continue
 		}
 		refName := string(refNameBytes)
-		if strings.HasPrefix(refName, "tag: ") {
-			refName = strings.TrimPrefix(refName, "tag: ")
-		} else if strings.HasPrefix(refName, "HEAD -> ") {
-			refName = strings.TrimPrefix(refName, "HEAD -> ")
-		}
+		refName = strings.TrimPrefix(refName, "tag: ")
+		refName = strings.TrimPrefix(refName, "HEAD -> ")
+
 		refs = append(refs, git.Reference{
 			Name: refName,
 		})

--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -1,9 +1,9 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !windows
+// +build !windows
 
 package graceful
 

--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -1,10 +1,10 @@
-//go:build windows
-// +build windows
-
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
+
+//go:build windows
+// +build windows
 
 package graceful
 

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.

--- a/modules/graceful/net_unix.go
+++ b/modules/graceful/net_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.

--- a/modules/graceful/net_unix.go
+++ b/modules/graceful/net_unix.go
@@ -1,10 +1,10 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
+
+//go:build !windows
+// +build !windows
 
 package graceful
 

--- a/modules/graceful/net_windows.go
+++ b/modules/graceful/net_windows.go
@@ -1,10 +1,10 @@
-//go:build windows
-// +build windows
-
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
+
+//go:build windows
+// +build windows
 
 package graceful
 

--- a/modules/graceful/net_windows.go
+++ b/modules/graceful/net_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.

--- a/modules/graceful/restart_unix.go
+++ b/modules/graceful/restart_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2019 The Gitea Authors. All rights reserved.

--- a/modules/graceful/restart_unix.go
+++ b/modules/graceful/restart_unix.go
@@ -1,10 +1,10 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
+
+//go:build !windows
+// +build !windows
 
 package graceful
 

--- a/modules/indexer/code/bleve.go
+++ b/modules/indexer/code/bleve.go
@@ -174,6 +174,10 @@ func NewBleveIndexer(indexDir string) (*BleveIndexer, bool, error) {
 		indexDir: indexDir,
 	}
 	created, err := indexer.init()
+	if err != nil {
+		indexer.Close()
+		return nil, false, err
+	}
 	return indexer, created, err
 }
 

--- a/modules/indexer/code/elastic_search.go
+++ b/modules/indexer/code/elastic_search.go
@@ -83,7 +83,10 @@ func NewElasticSearchIndexer(url, indexerName string) (*ElasticSearchIndexer, bo
 		indexerAliasName: indexerName,
 	}
 	exists, err := indexer.init()
-
+	if err != nil {
+		indexer.Close()
+		return nil, false, err
+	}
 	return indexer, !exists, err
 }
 

--- a/modules/indexer/code/indexer.go
+++ b/modules/indexer/code/indexer.go
@@ -188,9 +188,6 @@ func Init() {
 
 			rIndexer, populate, err = NewBleveIndexer(setting.Indexer.RepoPath)
 			if err != nil {
-				if rIndexer != nil {
-					rIndexer.Close()
-				}
 				cancel()
 				indexer.Close()
 				close(waitChannel)
@@ -208,9 +205,6 @@ func Init() {
 
 			rIndexer, populate, err = NewElasticSearchIndexer(setting.Indexer.RepoConnStr, setting.Indexer.RepoIndexerName)
 			if err != nil {
-				if rIndexer != nil {
-					rIndexer.Close()
-				}
 				cancel()
 				indexer.Close()
 				close(waitChannel)

--- a/modules/indexer/stats/queue.go
+++ b/modules/indexer/stats/queue.go
@@ -27,7 +27,7 @@ func handle(data ...queue.Data) {
 }
 
 func initStatsQueue() error {
-	statsQueue = queue.CreateUniqueQueue("repo_stats_update", handle, int64(0)).(queue.UniqueQueue)
+	statsQueue = queue.CreateUniqueQueue("repo_stats_update", handle, int64(0))
 	if statsQueue == nil {
 		return fmt.Errorf("Unable to create repo_stats_update Queue")
 	}

--- a/modules/lfs/endpoint.go
+++ b/modules/lfs/endpoint.go
@@ -29,9 +29,7 @@ func endpointFromCloneURL(rawurl string) *url.URL {
 		return ep
 	}
 
-	if strings.HasSuffix(ep.Path, "/") {
-		ep.Path = ep.Path[:len(ep.Path)-1]
-	}
+	ep.Path = strings.TrimSuffix(ep.Path, "/")
 
 	if ep.Scheme == "file" {
 		return ep

--- a/modules/lfs/pointer_scanner_gogit.go
+++ b/modules/lfs/pointer_scanner_gogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gogit
 // +build gogit
 
 package lfs

--- a/modules/lfs/pointer_scanner_nogogit.go
+++ b/modules/lfs/pointer_scanner_nogogit.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !gogit
 // +build !gogit
 
 package lfs

--- a/modules/markup/common/footnote.go
+++ b/modules/markup/common/footnote.go
@@ -126,7 +126,7 @@ type Footnote struct {
 func (n *Footnote) Dump(source []byte, level int) {
 	m := map[string]string{}
 	m["Index"] = fmt.Sprintf("%v", n.Index)
-	m["Ref"] = fmt.Sprintf("%s", n.Ref)
+	m["Ref"] = string(n.Ref)
 	m["Name"] = fmt.Sprintf("%v", n.Name)
 	ast.DumpHelper(n, source, level, m, nil)
 }

--- a/modules/options/dynamic.go
+++ b/modules/options/dynamic.go
@@ -1,3 +1,4 @@
+//go:build !bindata
 // +build !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/options/dynamic.go
+++ b/modules/options/dynamic.go
@@ -1,9 +1,9 @@
-//go:build !bindata
-// +build !bindata
-
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !bindata
+// +build !bindata
 
 package options
 

--- a/modules/options/options_bindata.go
+++ b/modules/options/options_bindata.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//go:build bindata
+// +build bindata
 
 package options
 

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -1,3 +1,4 @@
+//go:build bindata
 // +build bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/public/dynamic.go
+++ b/modules/public/dynamic.go
@@ -1,3 +1,4 @@
+//go:build !bindata
 // +build !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/public/dynamic.go
+++ b/modules/public/dynamic.go
@@ -1,9 +1,9 @@
-//go:build !bindata
-// +build !bindata
-
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !bindata
+// +build !bindata
 
 package public
 

--- a/modules/public/public_bindata.go
+++ b/modules/public/public_bindata.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//go:build bindata
+// +build bindata
 
 package public
 

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -1,3 +1,4 @@
+//go:build bindata
 // +build bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/repository/adopt.go
+++ b/modules/repository/adopt.go
@@ -152,7 +152,7 @@ func ListUnadoptedRepositories(query string, opts *models.ListOptions) ([]string
 	count := 0
 
 	// We're going to iterate by pagesize.
-	root := filepath.Join(setting.RepoRootPath)
+	root := filepath.Clean(setting.RepoRootPath)
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/modules/setting/database_sqlite.go
+++ b/modules/setting/database_sqlite.go
@@ -1,3 +1,4 @@
+//go:build sqlite
 // +build sqlite
 
 // Copyright 2014 The Gogs Authors. All rights reserved.

--- a/modules/svg/discover_bindata.go
+++ b/modules/svg/discover_bindata.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build bindata
 // +build bindata
 
 package svg

--- a/modules/svg/discover_nobindata.go
+++ b/modules/svg/discover_nobindata.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !bindata
 // +build !bindata
 
 package svg

--- a/modules/templates/dynamic.go
+++ b/modules/templates/dynamic.go
@@ -1,3 +1,4 @@
+//go:build !bindata
 // +build !bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/templates/dynamic.go
+++ b/modules/templates/dynamic.go
@@ -1,9 +1,9 @@
-//go:build !bindata
-// +build !bindata
-
 // Copyright 2016 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !bindata
+// +build !bindata
 
 package templates
 

--- a/modules/templates/static.go
+++ b/modules/templates/static.go
@@ -1,3 +1,4 @@
+//go:build bindata
 // +build bindata
 
 // Copyright 2016 The Gitea Authors. All rights reserved.

--- a/modules/templates/templates_bindata.go
+++ b/modules/templates/templates_bindata.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-//+build bindata
+//go:build bindata
+// +build bindata
 
 package templates
 

--- a/routers/private/manager_unix.go
+++ b/routers/private/manager_unix.go
@@ -1,9 +1,9 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2020 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build !windows
+// +build !windows
 
 package private
 

--- a/routers/private/manager_unix.go
+++ b/routers/private/manager_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2020 The Gitea Authors. All rights reserved.

--- a/routers/private/manager_windows.go
+++ b/routers/private/manager_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2020 The Gitea Authors. All rights reserved.

--- a/routers/private/manager_windows.go
+++ b/routers/private/manager_windows.go
@@ -1,9 +1,9 @@
-//go:build windows
-// +build windows
-
 // Copyright 2020 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
 
 package private
 

--- a/routers/web/base.go
+++ b/routers/web/base.go
@@ -130,14 +130,6 @@ func Recovery() func(next http.Handler) http.Handler {
 					log.Error("%v", combinedErr)
 
 					sessionStore := session.GetSession(req)
-					if sessionStore == nil {
-						if setting.IsProd() {
-							http.Error(w, http.StatusText(500), 500)
-						} else {
-							http.Error(w, combinedErr, 500)
-						}
-						return
-					}
 
 					var lc = middleware.Locale(w, req)
 					var store = dataStore{

--- a/routers/web/user/setting/adopt.go
+++ b/routers/web/user/setting/adopt.go
@@ -27,7 +27,7 @@ func AdoptOrDeleteRepository(ctx *context.Context) {
 	action := ctx.Query("action")
 
 	ctxUser := ctx.User
-	root := filepath.Join(models.UserPath(ctxUser.LowerName))
+	root := models.UserPath(ctxUser.LowerName)
 
 	// check not a repo
 	has, err := models.IsRepositoryExist(ctxUser, dir)

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -246,7 +246,7 @@ func Repos(ctx *context.Context) {
 		repoNames := make([]string, 0, setting.UI.Admin.UserPagingNum)
 		repos := map[string]*models.Repository{}
 		// We're going to iterate by pagesize.
-		root := filepath.Join(models.UserPath(ctxUser.Name))
+		root := models.UserPath(ctxUser.Name)
 		if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				if os.IsNotExist(err) {

--- a/services/auth/placeholder.go
+++ b/services/auth/placeholder.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package auth

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -254,7 +254,7 @@ func CheckPrsForBaseBranch(baseRepo *models.Repository, baseBranchName string) e
 
 // Init runs the task queue to test all the checking status pull requests
 func Init() error {
-	prQueue = queue.CreateUniqueQueue("pr_patch_checker", handle, "").(queue.UniqueQueue)
+	prQueue = queue.CreateUniqueQueue("pr_patch_checker", handle, "")
 
 	if prQueue == nil {
 		return fmt.Errorf("Unable to create pr_patch_checker Queue")

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -273,8 +273,8 @@ func rawMerge(pr *models.PullRequest, doer *models.User, mergeStyle models.Merge
 					filepath.Join(tmpBasePath, ".git", "rebase-merge", "stopped-sha"),     // Git >= 2.26
 				}
 				for _, failingCommitPath := range failingCommitPaths {
-					if _, statErr := os.Stat(filepath.Join(failingCommitPath)); statErr == nil {
-						commitShaBytes, readErr := ioutil.ReadFile(filepath.Join(failingCommitPath))
+					if _, statErr := os.Stat(failingCommitPath); statErr == nil {
+						commitShaBytes, readErr := ioutil.ReadFile(failingCommitPath)
 						if readErr != nil {
 							// Abandon this attempt to handle the error
 							log.Error("git rebase staging on to base [%s:%s -> %s:%s]: %v\n%s\n%s", pr.HeadRepo.FullName(), pr.HeadBranch, pr.BaseRepo.FullName(), pr.BaseBranch, err, outbuf.String(), errbuf.String())

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -36,7 +36,7 @@ func handle(data ...queue.Data) {
 }
 
 func initPushQueue() error {
-	pushQueue = queue.CreateQueue("push_update", handle, []*repo_module.PushUpdateOptions{}).(queue.Queue)
+	pushQueue = queue.CreateQueue("push_update", handle, []*repo_module.PushUpdateOptions{})
 	if pushQueue == nil {
 		return fmt.Errorf("Unable to create push_update Queue")
 	}

--- a/tools/fuzz.go
+++ b/tools/fuzz.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build gofuzz
 // +build gofuzz
 
 package fuzz


### PR DESCRIPTION
Backport #17598 
Backport #17606 
Backport #17608 
Backport #17609

- Since https://gitea.com/gitea/test-env/pulls/10 the golangci-lint has been upgraded and is erroring about new warnings in the code, this PR fixes those warnings.
