### PR TITLE
Trim copied markup code box contents

### DIFF
--- a/web_src/js/markup/codecopy.js
+++ b/web_src/js/markup/codecopy.js
@@ -10,7 +10,8 @@ export function renderCodeCopy() {
 
   for (const el of els) {
     const btn = button.cloneNode(true);
-    btn.setAttribute('data-clipboard-text', el.textContent);
+    const code = (el.textContent || '').replace(/\r?\n$/, '');
+    btn.setAttribute('data-clipboard-text', code);
     el.after(btn);
   }
 }


### PR DESCRIPTION
The markup renderer always produces a final newline at the end of a code block's content, while I don't think that newline is generally considered part of the content and also not copied on manual selection, so I think it's better to trim it off.