### PR TITLE
Return 400 but not 500 when request archive with wrong format

### DIFF
--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/models/unittest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIDownloadArchive(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	repo := unittest.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
+	user2 := unittest.AssertExistsAndLoadBean(t, &models.User{ID: 2}).(*models.User)
+	session := loginUser(t, user2.LowerName)
+	token := getTokenForLoggedInUser(t, session)
+
+	link, _ := url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.zip", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp := MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 320, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.tar.gz", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 266, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.bundle", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 382, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	MakeRequest(t, NewRequest(t, "GET", link.String()), 400)
+}

--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Gitea Authors. All rights reserved.
+// Copyright 2021 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -48,5 +48,5 @@ func TestAPIDownloadArchive(t *testing.T) {
 
 	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master", user2.Name, repo.Name))
 	link.RawQuery = url.Values{"token": {token}}.Encode()
-	MakeRequest(t, NewRequest(t, "GET", link.String()), 400)
+	MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusBadRequest)
 }

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -373,7 +373,7 @@ func Download(ctx *context.Context) {
 	uri := ctx.Params("*")
 	aReq, err := archiver_service.NewRequest(ctx.Repo.Repository.ID, ctx.Repo.GitRepo, uri)
 	if err != nil {
-		if errors.Is(err, archiver_service.ErrUnknowArchiveFormat{}) {
+		if errors.Is(err, archiver_service.ErrUnknownArchiveFormat{}) {
 			ctx.Error(http.StatusBadRequest, err.Error())
 		} else {
 			ctx.ServerError("archiver_service.NewRequest", err)

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -22,7 +22,6 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/storage"
 	"code.gitea.io/gitea/modules/web"
-	"code.gitea.io/gitea/services/archiver"
 	archiver_service "code.gitea.io/gitea/services/archiver"
 	"code.gitea.io/gitea/services/forms"
 	repo_service "code.gitea.io/gitea/services/repository"
@@ -374,7 +373,7 @@ func Download(ctx *context.Context) {
 	uri := ctx.Params("*")
 	aReq, err := archiver_service.NewRequest(ctx.Repo.Repository.ID, ctx.Repo.GitRepo, uri)
 	if err != nil {
-		if errors.Is(err, archiver.ErrUnknowArchiveFormat{}) {
+		if errors.Is(err, archiver_service.ErrUnknowArchiveFormat{}) {
 			ctx.Error(http.StatusBadRequest, err.Error())
 		} else {
 			ctx.ServerError("archiver_service.NewRequest", err)

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -39,6 +39,22 @@ type ArchiveRequest struct {
 // the way to 64.
 var shaRegex = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
 
+// ErrUnknowArchiveFormat request archive format is not supported
+type ErrUnknowArchiveFormat struct {
+	RequestFormat string
+}
+
+// Error implements error
+func (err ErrUnknowArchiveFormat) Error() string {
+	return fmt.Sprintf("unknown format: %s", err.RequestFormat)
+}
+
+// Is implements error
+func (ErrUnknowArchiveFormat) Is(err error) bool {
+	_, ok := err.(ErrUnknowArchiveFormat)
+	return ok
+}
+
 // NewRequest creates an archival request, based on the URI.  The
 // resulting ArchiveRequest is suitable for being passed to ArchiveRepository()
 // if it's determined that the request still needs to be satisfied.
@@ -59,7 +75,7 @@ func NewRequest(repoID int64, repo *git.Repository, uri string) (*ArchiveRequest
 		ext = ".bundle"
 		r.Type = git.BUNDLE
 	default:
-		return nil, fmt.Errorf("Unknown format: %s", uri)
+		return nil, ErrUnknowArchiveFormat{RequestFormat: uri}
 	}
 
 	r.refName = strings.TrimSuffix(uri, ext)

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -39,19 +39,19 @@ type ArchiveRequest struct {
 // the way to 64.
 var shaRegex = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
 
-// ErrUnknowArchiveFormat request archive format is not supported
-type ErrUnknowArchiveFormat struct {
+// ErrUnknownArchiveFormat request archive format is not supported
+type ErrUnknownArchiveFormat struct {
 	RequestFormat string
 }
 
 // Error implements error
-func (err ErrUnknowArchiveFormat) Error() string {
+func (err ErrUnknownArchiveFormat) Error() string {
 	return fmt.Sprintf("unknown format: %s", err.RequestFormat)
 }
 
 // Is implements error
-func (ErrUnknowArchiveFormat) Is(err error) bool {
-	_, ok := err.(ErrUnknowArchiveFormat)
+func (ErrUnknownArchiveFormat) Is(err error) bool {
+	_, ok := err.(ErrUnknownArchiveFormat)
 	return ok
 }
 
@@ -75,7 +75,7 @@ func NewRequest(repoID int64, repo *git.Repository, uri string) (*ArchiveRequest
 		ext = ".bundle"
 		r.Type = git.BUNDLE
 	default:
-		return nil, ErrUnknowArchiveFormat{RequestFormat: uri}
+		return nil, ErrUnknownArchiveFormat{RequestFormat: uri}
 	}
 
 	r.refName = strings.TrimSuffix(uri, ext)

--- a/services/archiver/archiver_test.go
+++ b/services/archiver/archiver_test.go
@@ -5,6 +5,7 @@
 package archiver
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,10 +18,6 @@ import (
 
 func TestMain(m *testing.M) {
 	unittest.MainTest(m, filepath.Join("..", ".."))
-}
-
-func waitForCount(t *testing.T, num int) {
-
 }
 
 func TestArchive_Basic(t *testing.T) {
@@ -83,11 +80,8 @@ func TestArchive_Basic(t *testing.T) {
 	inFlight[2] = secondReq
 
 	ArchiveRepository(zipReq)
-	waitForCount(t, 1)
 	ArchiveRepository(tgzReq)
-	waitForCount(t, 2)
 	ArchiveRepository(secondReq)
-	waitForCount(t, 3)
 
 	// Make sure sending an unprocessed request through doesn't affect the queue
 	// count.
@@ -131,4 +125,9 @@ func TestArchive_Basic(t *testing.T) {
 	// Ideally, the extension would match what we originally requested.
 	assert.NotEqual(t, zipReq.GetArchiveName(), tgzReq.GetArchiveName())
 	assert.NotEqual(t, zipReq.GetArchiveName(), secondReq.GetArchiveName())
+}
+
+func TestErrUnknowArchiveFormat(t *testing.T) {
+	var err = ErrUnknowArchiveFormat{RequestFormat: "master"}
+	assert.True(t, errors.Is(err, ErrUnknowArchiveFormat{}))
 }

--- a/services/archiver/archiver_test.go
+++ b/services/archiver/archiver_test.go
@@ -127,7 +127,7 @@ func TestArchive_Basic(t *testing.T) {
 	assert.NotEqual(t, zipReq.GetArchiveName(), secondReq.GetArchiveName())
 }
 
-func TestErrUnknowArchiveFormat(t *testing.T) {
-	var err = ErrUnknowArchiveFormat{RequestFormat: "master"}
-	assert.True(t, errors.Is(err, ErrUnknowArchiveFormat{}))
+func TestErrUnknownArchiveFormat(t *testing.T) {
+	var err = ErrUnknownArchiveFormat{RequestFormat: "master"}
+	assert.True(t, errors.Is(err, ErrUnknownArchiveFormat{}))
 }


### PR DESCRIPTION
Fix #17689