### PR TITLE
Return 400 but not 500 when request archive with wrong format (#17691)

### DIFF
--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/models/unittest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIDownloadArchive(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	repo := unittest.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
+	user2 := unittest.AssertExistsAndLoadBean(t, &models.User{ID: 2}).(*models.User)
+	session := loginUser(t, user2.LowerName)
+	token := getTokenForLoggedInUser(t, session)
+
+	link, _ := url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.zip", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp := MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 320, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.tar.gz", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 266, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.bundle", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
+	bs, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 382, len(bs))
+
+	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master", user2.Name, repo.Name))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+	MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusBadRequest)
+}

--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -38,13 +38,6 @@ func TestAPIDownloadArchive(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 266, len(bs))
 
-	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master.bundle", user2.Name, repo.Name))
-	link.RawQuery = url.Values{"token": {token}}.Encode()
-	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
-	bs, err = io.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	assert.EqualValues(t, 382, len(bs))
-
 	link, _ = url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/archive/master", user2.Name, repo.Name))
 	link.RawQuery = url.Values{"token": {token}}.Encode()
 	MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusBadRequest)

--- a/integrations/api_repo_archive_test.go
+++ b/integrations/api_repo_archive_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models"
-	"code.gitea.io/gitea/models/unittest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,8 +19,8 @@ import (
 func TestAPIDownloadArchive(t *testing.T) {
 	defer prepareTestEnv(t)()
 
-	repo := unittest.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
-	user2 := unittest.AssertExistsAndLoadBean(t, &models.User{ID: 2}).(*models.User)
+	repo := models.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository)
+	user2 := models.AssertExistsAndLoadBean(t, &models.User{ID: 2}).(*models.User)
 	session := loginUser(t, user2.LowerName)
 	token := getTokenForLoggedInUser(t, session)
 

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -371,7 +371,11 @@ func Download(ctx *context.Context) {
 	uri := ctx.Params("*")
 	aReq, err := archiver_service.NewRequest(ctx.Repo.Repository.ID, ctx.Repo.GitRepo, uri)
 	if err != nil {
-		ctx.ServerError("archiver_service.NewRequest", err)
+		if errors.Is(err, archiver_service.ErrUnknownArchiveFormat{}) {
+			ctx.Error(http.StatusBadRequest, err.Error())
+		} else {
+			ctx.ServerError("archiver_service.NewRequest", err)
+		}
 		return
 	}
 	if aReq == nil {

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -38,6 +38,22 @@ type ArchiveRequest struct {
 // the way to 64.
 var shaRegex = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
 
+// ErrUnknownArchiveFormat request archive format is not supported
+type ErrUnknownArchiveFormat struct {
+	RequestFormat string
+}
+
+// Error implements error
+func (err ErrUnknownArchiveFormat) Error() string {
+	return fmt.Sprintf("unknown format: %s", err.RequestFormat)
+}
+
+// Is implements error
+func (ErrUnknownArchiveFormat) Is(err error) bool {
+	_, ok := err.(ErrUnknownArchiveFormat)
+	return ok
+}
+
 // NewRequest creates an archival request, based on the URI.  The
 // resulting ArchiveRequest is suitable for being passed to ArchiveRepository()
 // if it's determined that the request still needs to be satisfied.
@@ -55,7 +71,7 @@ func NewRequest(repoID int64, repo *git.Repository, uri string) (*ArchiveRequest
 		ext = ".tar.gz"
 		r.Type = git.TARGZ
 	default:
-		return nil, fmt.Errorf("Unknown format: %s", uri)
+		return nil, ErrUnknownArchiveFormat{RequestFormat: uri}
 	}
 
 	r.refName = strings.TrimSuffix(uri, ext)

--- a/services/archiver/archiver_test.go
+++ b/services/archiver/archiver_test.go
@@ -5,6 +5,7 @@
 package archiver
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,10 +18,6 @@ import (
 
 func TestMain(m *testing.M) {
 	models.MainTest(m, filepath.Join("..", ".."))
-}
-
-func waitForCount(t *testing.T, num int) {
-
 }
 
 func TestArchive_Basic(t *testing.T) {
@@ -83,11 +80,8 @@ func TestArchive_Basic(t *testing.T) {
 	inFlight[2] = secondReq
 
 	ArchiveRepository(zipReq)
-	waitForCount(t, 1)
 	ArchiveRepository(tgzReq)
-	waitForCount(t, 2)
 	ArchiveRepository(secondReq)
-	waitForCount(t, 3)
 
 	// Make sure sending an unprocessed request through doesn't affect the queue
 	// count.
@@ -131,4 +125,9 @@ func TestArchive_Basic(t *testing.T) {
 	// Ideally, the extension would match what we originally requested.
 	assert.NotEqual(t, zipReq.GetArchiveName(), tgzReq.GetArchiveName())
 	assert.NotEqual(t, zipReq.GetArchiveName(), secondReq.GetArchiveName())
+}
+
+func TestErrUnknownArchiveFormat(t *testing.T) {
+	var err = ErrUnknownArchiveFormat{RequestFormat: "master"}
+	assert.True(t, errors.Is(err, ErrUnknownArchiveFormat{}))
 }


### PR DESCRIPTION
backport #17691