### PR TITLE
Fix Migrate Description (#17692)

### DIFF
--- a/modules/migrations/gitea_uploader.go
+++ b/modules/migrations/gitea_uploader.go
@@ -109,6 +109,7 @@ func (g *GiteaLocalUploader) CreateRepo(repo *base.Repository, opts base.Migrate
 		return err
 	}
 	r.DefaultBranch = repo.DefaultBranch
+	r.Description = repo.Description
 
 	r, err = repository.MigrateRepositoryGitData(g.ctx, owner, r, base.MigrateOptions{
 		RepoName:       g.repoName,


### PR DESCRIPTION
Backport into v.1.15 of the PR https://github.com/go-gitea/gitea/pull/17692

This PR sets the parameter for migrating the description of a repository : solves #17626
Actual behavior is opts.Description is only taken in account

I had to modify services/migrations/gitea_uploader.go as the parameter wasn't modified if not a set one.

Merged already on main branch

Thanks :)