### PR TITLE
Fix correct usage of teams

### DIFF
--- a/modules/context/org.go
+++ b/modules/context/org.go
@@ -69,6 +69,12 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 	org := ctx.Org.Organization
 	ctx.Data["Org"] = org
 
+	teams, err := org.LoadTeams()
+	if err != nil {
+		ctx.ServerError("LoadTeams", err)
+	}
+	ctx.Data["OrgTeams"] = teams
+
 	// Admin has super access.
 	if ctx.IsSigned && ctx.User.IsAdmin {
 		ctx.Org.IsOwner = true

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -61,7 +61,7 @@
 							<a class="{{if not $.Team}}active selected{{end}} item" title="{{.i18n.Tr "all"}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}">
 								{{.i18n.Tr "all"}}
 							</a>
-							{{range .Org.Teams}}
+							{{range .OrgTeams}}
 								{{if not .IncludesAllRepositories}}
 									<a class="{{if $.Team}}{{if eq $.Team.ID .ID}}active selected{{end}}{{end}} item" title="{{.Name}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}/{{.Name}}">
 										{{.Name}}
@@ -85,7 +85,7 @@
 			</a>
 			{{end}}
 			{{if not .UnitPullsGlobalDisabled}}
-			<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape.Team.Name}}{{end}}">
+			<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
 				{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
 			</a>
 			{{end}}


### PR DESCRIPTION
- `.Teams` isn't a field on the User type, thus using the seperate loaded teams.
- Add a space between `PathEscape` and argument.


