### PR TITLE
Reset locale on login

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -245,6 +245,9 @@ func APIAuth(authMethod auth.Method) func(*APIContext) {
 		// Get user from session if logged in.
 		ctx.User = authMethod.Verify(ctx.Req, ctx.Resp, ctx, ctx.Session)
 		if ctx.User != nil {
+			if ctx.Locale.Language() != ctx.User.Language {
+				ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
+			}
 			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == new(auth.Basic).Name()
 			ctx.IsSigned = true
 			ctx.Data["IsSigned"] = ctx.IsSigned

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -614,6 +614,9 @@ func Auth(authMethod auth.Method) func(*Context) {
 	return func(ctx *Context) {
 		ctx.User = authMethod.Verify(ctx.Req, ctx.Resp, ctx, ctx.Session)
 		if ctx.User != nil {
+			if ctx.Locale.Language() != ctx.User.Language {
+				ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
+			}
 			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == new(auth.Basic).Name()
 			ctx.IsSigned = true
 			ctx.Data["IsSigned"] = ctx.IsSigned

--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -572,6 +572,10 @@ func handleSignInFull(ctx *context.Context, u *models.User, remember bool, obeyR
 
 	middleware.SetLocaleCookie(ctx.Resp, u.Language, 0)
 
+	if ctx.Locale.Language() != u.Language {
+		ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
+	}
+
 	// Clear whatever CSRF has right now, force to generate a new one
 	middleware.DeleteCSRFCookie(ctx.Resp)
 


### PR DESCRIPTION
During login reset the user's locale to ensure that it matches their
preferred locale.

Fix #15612

Signed-off-by: Andrew Thornton <art27@cantab.net>
 
