### PR TITLE
Extract constant names out for the ReverseProxy and Basic authentication methods

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -245,7 +245,7 @@ func APIAuth(authMethod auth.Method) func(*APIContext) {
 		// Get user from session if logged in.
 		ctx.User = authMethod.Verify(ctx.Req, ctx.Resp, ctx, ctx.Session)
 		if ctx.User != nil {
-			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == new(auth.Basic).Name()
+			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == auth.BasicMethodName
 			ctx.IsSigned = true
 			ctx.Data["IsSigned"] = ctx.IsSigned
 			ctx.Data["SignedUser"] = ctx.User

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -614,7 +614,7 @@ func Auth(authMethod auth.Method) func(*Context) {
 	return func(ctx *Context) {
 		ctx.User = authMethod.Verify(ctx.Req, ctx.Resp, ctx, ctx.Session)
 		if ctx.User != nil {
-			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == new(auth.Basic).Name()
+			ctx.IsBasicAuth = ctx.Data["AuthedMethod"].(string) == auth.BasicMethodName
 			ctx.IsSigned = true
 			ctx.Data["IsSigned"] = ctx.IsSigned
 			ctx.Data["SignedUser"] = ctx.User

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -217,7 +217,7 @@ func reqExploreSignIn() func(ctx *context.APIContext) {
 
 func reqBasicOrRevProxyAuth() func(ctx *context.APIContext) {
 	return func(ctx *context.APIContext) {
-		if ctx.IsSigned && setting.Service.EnableReverseProxyAuth && ctx.Data["AuthedMethod"].(string) == new(auth.ReverseProxy).Name() {
+		if ctx.IsSigned && setting.Service.EnableReverseProxyAuth && ctx.Data["AuthedMethod"].(string) == auth.ReverseProxyMethodName {
 			return
 		}
 		if !ctx.Context.IsBasicAuth {

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -23,6 +23,9 @@ var (
 	_ Named  = &Basic{}
 )
 
+// BasicMethodName is the constant name of the basic authentication method
+const BasicMethodName = "basic"
+
 // Basic implements the Auth interface and authenticates requests (API requests
 // only) by looking for Basic authentication data or "x-oauth-basic" token in the "Authorization"
 // header.
@@ -31,7 +34,7 @@ type Basic struct {
 
 // Name represents the name of auth method
 func (b *Basic) Name() string {
-	return "basic"
+	return BasicMethodName
 }
 
 // Verify extracts and validates Basic data (username and password/token) from the

--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -24,6 +24,9 @@ var (
 	_ Named  = &ReverseProxy{}
 )
 
+// ReverseProxyMethodName is the constant name of the ReverseProxy authentication method
+const ReverseProxyMethodName = "reverse_proxy"
+
 // ReverseProxy implements the Auth interface, but actually relies on
 // a reverse proxy for authentication of users.
 // On successful authentication the proxy is expected to populate the username in the
@@ -43,7 +46,7 @@ func (r *ReverseProxy) getUserName(req *http.Request) string {
 
 // Name represents the name of auth method
 func (r *ReverseProxy) Name() string {
-	return "reverse_proxy"
+	return ReverseProxyMethodName
 }
 
 // Verify extracts the username from the "setting.ReverseProxyAuthUser" header


### PR DESCRIPTION
In order to reduce load on the GC extract out the constant names of the Basic and
ReverseProxy methods.

As mentioned in https://github.com/go-gitea/gitea/pull/15119#discussion_r730352176

Signed-off-by: Andrew Thornton <art27@cantab.net>
