### PR TITLE
Make a.add-code-comment click handler an event handler

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -480,7 +480,7 @@ export function initRepoPullRequestReview() {
     $(this).closest('.menu').toggle('visible');
   });
 
-  $('a.add-code-comment').on('click', async function (e) {
+  $(document).on('click', 'a.add-code-comment', async function (e) {
     if ($(e.target).hasClass('btn-add-single')) return; // https://github.com/go-gitea/gitea/issues/4745
     e.preventDefault();
 


### PR DESCRIPTION
Instead of directly attaching the add-code-comment on click handler to
the a.add-code-comment elements - make this an event handler on the
document instead.

Fix #17736

Signed-off-by: Andrew Thornton <art27@cantab.net>
