### PR TITLE
Allow Loading of Diffs that are too large

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2043,6 +2043,7 @@ diff.file_suppressed = File diff suppressed because it is too large
 diff.file_suppressed_line_too_long = File diff suppressed because one or more lines are too long
 diff.too_many_files = Some files were not shown because too many files have changed in this diff
 diff.show_more = Show More
+diff.load = Load Diff
 diff.generated = generated
 diff.vendored = vendored
 diff.comment.placeholder = Leave a comment

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -287,20 +287,17 @@ func Diff(ctx *context.Context) {
 	}
 
 	fileOnly := ctx.FormBool("file-only")
-	maxLines, maxLineCharacters, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles
+	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	files := ctx.FormStrings("files")
 	if fileOnly && (len(files) == 2 || len(files) == 1) {
-		maxLines, maxLineCharacters, maxFiles = -1, 4096, -1
-		if setting.Git.MaxGitDiffLineCharacters > maxLineCharacters {
-			maxLineCharacters = setting.Git.MaxGitDiffLineCharacters
-		}
+		maxLines, maxFiles = -1, -1
 	}
 
-	diff, err := gitdiff.GetDiff(gitRepo, gitdiff.DiffOptions{
+	diff, err := gitdiff.GetDiff(gitRepo, &gitdiff.DiffOptions{
 		AfterCommitID:      commitID,
 		SkipTo:             ctx.FormString("skip-to"),
 		MaxLines:           maxLines,
-		MaxLineCharacters:  maxLineCharacters,
+		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 		MaxFiles:           maxFiles,
 		WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)),
 	}, files...)

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -569,22 +569,19 @@ func PrepareCompareDiff(
 		beforeCommitID = ci.CompareInfo.BaseCommitID
 	}
 
-	maxLines, maxLineCharacters, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles
+	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	files := ctx.FormStrings("files")
 	if len(files) == 2 || len(files) == 1 {
-		maxLines, maxLineCharacters, maxFiles = -1, 4096, -1
-		if setting.Git.MaxGitDiffLineCharacters > maxLineCharacters {
-			maxLineCharacters = setting.Git.MaxGitDiffLineCharacters
-		}
+		maxLines, maxFiles = -1, -1
 	}
 
 	diff, err := gitdiff.GetDiff(ci.HeadGitRepo,
-		gitdiff.DiffOptions{
+		&gitdiff.DiffOptions{
 			BeforeCommitID:     beforeCommitID,
 			AfterCommitID:      headCommitID,
 			SkipTo:             ctx.FormString("skip-to"),
 			MaxLines:           maxLines,
-			MaxLineCharacters:  maxLineCharacters,
+			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 			MaxFiles:           maxFiles,
 			WhitespaceBehavior: whitespaceBehavior,
 			DirectComparison:   ci.DirectComparison,

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -633,10 +633,27 @@ func ViewPullFiles(ctx *context.Context) {
 	ctx.Data["Reponame"] = ctx.Repo.Repository.Name
 	ctx.Data["AfterCommitID"] = endCommitID
 
-	diff, err := gitdiff.GetDiffRangeWithWhitespaceBehavior(gitRepo,
-		startCommitID, endCommitID, ctx.FormString("skip-to"), setting.Git.MaxGitDiffLines,
-		setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles,
-		gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)), false)
+	fileOnly := ctx.FormBool("file-only")
+
+	maxLines, maxLineCharacters, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles
+	files := ctx.FormStrings("files")
+	if fileOnly && (len(files) == 2 || len(files) == 1) {
+		maxLines, maxLineCharacters, maxFiles = -1, 4096, -1
+		if setting.Git.MaxGitDiffLineCharacters > maxLineCharacters {
+			maxLineCharacters = setting.Git.MaxGitDiffLineCharacters
+		}
+	}
+
+	diff, err := gitdiff.GetDiff(gitRepo,
+		gitdiff.DiffOptions{
+			BeforeCommitID:     startCommitID,
+			AfterCommitID:      endCommitID,
+			SkipTo:             ctx.FormString("skip-to"),
+			MaxLines:           maxLines,
+			MaxLineCharacters:  maxLineCharacters,
+			MaxFiles:           maxFiles,
+			WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)),
+		}, ctx.FormStrings("files")...)
 	if err != nil {
 		ctx.ServerError("GetDiffRangeWithWhitespaceBehavior", err)
 		return

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -635,22 +635,19 @@ func ViewPullFiles(ctx *context.Context) {
 
 	fileOnly := ctx.FormBool("file-only")
 
-	maxLines, maxLineCharacters, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles
+	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	files := ctx.FormStrings("files")
 	if fileOnly && (len(files) == 2 || len(files) == 1) {
-		maxLines, maxLineCharacters, maxFiles = -1, 4096, -1
-		if setting.Git.MaxGitDiffLineCharacters > maxLineCharacters {
-			maxLineCharacters = setting.Git.MaxGitDiffLineCharacters
-		}
+		maxLines, maxFiles = -1, -1
 	}
 
 	diff, err := gitdiff.GetDiff(gitRepo,
-		gitdiff.DiffOptions{
+		&gitdiff.DiffOptions{
 			BeforeCommitID:     startCommitID,
 			AfterCommitID:      endCommitID,
 			SkipTo:             ctx.FormString("skip-to"),
 			MaxLines:           maxLines,
-			MaxLineCharacters:  maxLineCharacters,
+			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 			MaxFiles:           maxFiles,
 			WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)),
 		}, ctx.FormStrings("files")...)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1294,7 +1294,7 @@ type DiffOptions struct {
 // GetDiff builds a Diff between two commits of a repository.
 // Passing the empty string as beforeCommitID returns a diff from the parent commit.
 // The whitespaceBehavior is either an empty string or a git flag
-func GetDiff(gitRepo *git.Repository, opts DiffOptions, files ...string) (*Diff, error) {
+func GetDiff(gitRepo *git.Repository, opts *DiffOptions, files ...string) (*Diff, error) {
 	repoPath := gitRepo.Path
 
 	commit, err := gitRepo.GetCommit(opts.AfterCommitID)

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -694,7 +694,7 @@ func TestGetDiffRangeWithWhitespaceBehavior(t *testing.T) {
 	defer gitRepo.Close()
 	for _, behavior := range []string{"-w", "--ignore-space-at-eol", "-b", ""} {
 		diffs, err := GetDiff(gitRepo,
-			DiffOptions{
+			&DiffOptions{
 				AfterCommitID:      "bd7063cc7c04689c4d082183d32a604ed27a24f9",
 				BeforeCommitID:     "559c156f8e0178b71cb44355428f24001b08fc68",
 				MaxLines:           setting.Git.MaxGitDiffLines,

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -693,8 +693,15 @@ func TestGetDiffRangeWithWhitespaceBehavior(t *testing.T) {
 	}
 	defer gitRepo.Close()
 	for _, behavior := range []string{"-w", "--ignore-space-at-eol", "-b", ""} {
-		diffs, err := GetDiffRangeWithWhitespaceBehavior(gitRepo, "559c156f8e0178b71cb44355428f24001b08fc68", "bd7063cc7c04689c4d082183d32a604ed27a24f9", "",
-			setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles, behavior, false)
+		diffs, err := GetDiff(gitRepo,
+			DiffOptions{
+				AfterCommitID:      "bd7063cc7c04689c4d082183d32a604ed27a24f9",
+				BeforeCommitID:     "559c156f8e0178b71cb44355428f24001b08fc68",
+				MaxLines:           setting.Git.MaxGitDiffLines,
+				MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
+				MaxFiles:           setting.Git.MaxGitDiffFiles,
+				WhitespaceBehavior: behavior,
+			})
 		assert.NoError(t, err, fmt.Sprintf("Error when diff with %s", behavior))
 		for _, f := range diffs.Files {
 			assert.True(t, len(f.Sections) > 0, fmt.Sprintf("%s should have sections", f.Name))

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -112,6 +112,7 @@
 											{{$.i18n.Tr "repo.diff.file_suppressed_line_too_long"}}
 										{{else}}
 											{{$.i18n.Tr "repo.diff.file_suppressed"}}
+											<a class="ui basic tiny button diff-show-more-button" data-href="{{$.Link}}?file-only=true&files={{$file.Name}}&files={{$file.OldName}}">{{$.i18n.Tr "repo.diff.load"}}</a>
 										{{end}}
 									{{else}}
 										{{$.i18n.Tr "repo.diff.bin_not_shown"}}

--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -103,4 +103,27 @@ export function initRepoDiffShowMore() {
       $('#diff-incomplete').replaceWith($(resp).find('#diff-file-boxes').children());
     });
   });
+  $(document).on('click', 'a.diff-show-more-button', (e) => {
+    e.preventDefault();
+    const $target = $(e.target);
+
+    if ($target.hasClass('disabled')) {
+      return;
+    }
+
+    $target.addClass('disabled');
+
+    const url = $target.data('href');
+    $.ajax({
+      type: 'GET',
+      url,
+    }).done((resp) => {
+      if (!resp || resp.html === '' || resp.empty) {
+        $target.removeClass('disabled');
+        return;
+      }
+
+      $target.parent().replaceWith($(resp).find('#diff-file-boxes .diff-file-body .file-body').children());
+    });
+  });
 }

--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -94,13 +94,15 @@ export function initRepoDiffShowMore() {
       type: 'GET',
       url,
     }).done((resp) => {
-      if (!resp || resp.html === '' || resp.empty) {
+      if (!resp) {
         $('#diff-show-more-files, #diff-show-more-files-stats').removeClass('disabled');
         return;
       }
       $('#diff-too-many-files-stats').remove();
       $('#diff-files').append($(resp).find('#diff-files li'));
       $('#diff-incomplete').replaceWith($(resp).find('#diff-file-boxes').children());
+    }).fail(() => {
+      $('#diff-show-more-files, #diff-show-more-files-stats').removeClass('disabled');
     });
   });
   $(document).on('click', 'a.diff-show-more-button', (e) => {
@@ -118,12 +120,14 @@ export function initRepoDiffShowMore() {
       type: 'GET',
       url,
     }).done((resp) => {
-      if (!resp || resp.html === '' || resp.empty) {
+      if (!resp) {
         $target.removeClass('disabled');
         return;
       }
 
       $target.parent().replaceWith($(resp).find('#diff-file-boxes .diff-file-body .file-body').children());
+    }).fail(() => {
+      $target.removeClass('disabled');
     });
   });
 }


### PR DESCRIPTION
This PR allows the loading of diffs that are suppressed because the file
is too large. It does not handle diffs of files which have lines which
are too long.

Fix #17738

Signed-off-by: Andrew Thornton <art27@cantab.net>
