### PR TITLE
Refactor "refs/*" string usage by using constants

### DIFF
--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -215,7 +215,7 @@ func main() {
 		//Use git cli command for windows
 		runCmd("git", "fetch", remoteUpstream, fmt.Sprintf("pull/%s/head:%s", pr, branch))
 	} else {
-		ref := fmt.Sprintf("refs/pull/%s/head:%s", pr, branchRef)
+		ref := fmt.Sprintf(gitea_git.PullPrefix+"%s/head:%s", pr, branchRef)
 		err = repo.Fetch(&git.FetchOptions{
 			RemoteName: remoteUpstream,
 			RefSpecs: []config.RefSpec{

--- a/models/issue.go
+++ b/models/issue.go
@@ -20,6 +20,7 @@ import (
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/references"
 	api "code.gitea.io/gitea/modules/structs"
@@ -761,8 +762,8 @@ func (issue *Issue) ChangeRef(doer *user_model.User, oldRef string) (err error) 
 	if err = issue.loadRepo(db.GetEngine(ctx)); err != nil {
 		return fmt.Errorf("loadRepo: %v", err)
 	}
-	oldRefFriendly := strings.TrimPrefix(oldRef, "refs/heads/")
-	newRefFriendly := strings.TrimPrefix(issue.Ref, "refs/heads/")
+	oldRefFriendly := strings.TrimPrefix(oldRef, git.BranchPrefix)
+	newRefFriendly := strings.TrimPrefix(issue.Ref, git.BranchPrefix)
 
 	opts := &CreateCommentOptions{
 		Type:   CommentTypeChangeIssueRef,

--- a/models/pull.go
+++ b/models/pull.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -349,7 +350,7 @@ func (pr *PullRequest) GetDefaultSquashMessage() string {
 
 // GetGitRefName returns git ref for hidden pull request branch
 func (pr *PullRequest) GetGitRefName() string {
-	return fmt.Sprintf("refs/pull/%d/head", pr.Index)
+	return fmt.Sprintf(git.PullPrefix+"%d/head", pr.Index)
 }
 
 // IsChecking returns true if this pull request is still checking conflict.

--- a/modules/convert/pull.go
+++ b/modules/convert/pull.go
@@ -79,7 +79,7 @@ func ToAPIPullRequest(pr *models.PullRequest, doer *user_model.User) *api.PullRe
 		},
 		Head: &api.PRBranchInfo{
 			Name:   pr.HeadBranch,
-			Ref:    fmt.Sprintf("refs/pull/%d/head", pr.Index),
+			Ref:    fmt.Sprintf(git.PullPrefix+"%d/head", pr.Index),
 			RepoID: -1,
 		},
 	}

--- a/modules/git/commit.go
+++ b/modules/git/commit.go
@@ -141,7 +141,7 @@ func CommitChangesWithArgs(repoPath string, args []string, opts CommitChangesOpt
 func AllCommitsCount(repoPath string, hidePRRefs bool, files ...string) (int64, error) {
 	args := []string{"--all", "--count"}
 	if hidePRRefs {
-		args = append([]string{"--exclude=refs/pull/*"}, args...)
+		args = append([]string{"--exclude=" + PullPrefix + "*"}, args...)
 	}
 	cmd := NewCommand("rev-list")
 	cmd.AddArguments(args...)

--- a/modules/git/ref.go
+++ b/modules/git/ref.go
@@ -6,6 +6,15 @@ package git
 
 import "strings"
 
+const (
+	// RemotePrefix is the base directory of the remotes information of git.
+	RemotePrefix = "refs/remotes/"
+	// PullPrefix is the base directory of the pull information of git.
+	PullPrefix = "refs/pull/"
+
+	pullLen = len(PullPrefix)
+)
+
 // Reference represents a Git ref.
 type Reference struct {
 	Name   string
@@ -24,17 +33,17 @@ func (ref *Reference) ShortName() string {
 	if ref == nil {
 		return ""
 	}
-	if strings.HasPrefix(ref.Name, "refs/heads/") {
-		return ref.Name[11:]
+	if strings.HasPrefix(ref.Name, BranchPrefix) {
+		return strings.TrimPrefix(ref.Name, BranchPrefix)
 	}
-	if strings.HasPrefix(ref.Name, "refs/tags/") {
-		return ref.Name[10:]
+	if strings.HasPrefix(ref.Name, TagPrefix) {
+		return strings.TrimPrefix(ref.Name, TagPrefix)
 	}
-	if strings.HasPrefix(ref.Name, "refs/remotes/") {
-		return ref.Name[13:]
+	if strings.HasPrefix(ref.Name, RemotePrefix) {
+		return strings.TrimPrefix(ref.Name, RemotePrefix)
 	}
-	if strings.HasPrefix(ref.Name, "refs/pull/") && strings.IndexByte(ref.Name[10:], '/') > -1 {
-		return ref.Name[10 : strings.IndexByte(ref.Name[10:], '/')+10]
+	if strings.HasPrefix(ref.Name, PullPrefix) && strings.IndexByte(ref.Name[pullLen:], '/') > -1 {
+		return ref.Name[pullLen : strings.IndexByte(ref.Name[pullLen:], '/')+pullLen]
 	}
 
 	return ref.Name
@@ -45,16 +54,16 @@ func (ref *Reference) RefGroup() string {
 	if ref == nil {
 		return ""
 	}
-	if strings.HasPrefix(ref.Name, "refs/heads/") {
+	if strings.HasPrefix(ref.Name, BranchPrefix) {
 		return "heads"
 	}
-	if strings.HasPrefix(ref.Name, "refs/tags/") {
+	if strings.HasPrefix(ref.Name, TagPrefix) {
 		return "tags"
 	}
-	if strings.HasPrefix(ref.Name, "refs/remotes/") {
+	if strings.HasPrefix(ref.Name, RemotePrefix) {
 		return "remotes"
 	}
-	if strings.HasPrefix(ref.Name, "refs/pull/") && strings.IndexByte(ref.Name[10:], '/') > -1 {
+	if strings.HasPrefix(ref.Name, PullPrefix) && strings.IndexByte(ref.Name[pullLen:], '/') > -1 {
 		return "pull"
 	}
 	return ""

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -371,7 +371,7 @@ func parseSize(objects string) *CountObject {
 
 // GetLatestCommitTime returns time for latest commit in repository (across all branches)
 func GetLatestCommitTime(repoPath string) (time.Time, error) {
-	cmd := NewCommand("for-each-ref", "--sort=-committerdate", "refs/heads/", "--count", "1", "--format=%(committerdate)")
+	cmd := NewCommand("for-each-ref", "--sort=-committerdate", BranchPrefix, "--count", "1", "--format=%(committerdate)")
 	stdout, err := cmd.RunInDir(repoPath)
 	if err != nil {
 		return time.Time{}, err

--- a/modules/git/repo_compare.go
+++ b/modules/git/repo_compare.go
@@ -33,7 +33,7 @@ func (repo *Repository) GetMergeBase(tmpRemote string, base, head string) (strin
 	}
 
 	if tmpRemote != "origin" {
-		tmpBaseName := "refs/remotes/" + tmpRemote + "/tmp_" + base
+		tmpBaseName := RemotePrefix + tmpRemote + "/tmp_" + base
 		// Fetch commit into a temporary branch in order to be able to handle commits and tags
 		_, err := NewCommandContext(repo.Ctx, "fetch", tmpRemote, base+":"+tmpBaseName).RunInDir(repo.Path)
 		if err == nil {

--- a/modules/git/repo_ref_nogogit.go
+++ b/modules/git/repo_ref_nogogit.go
@@ -66,7 +66,7 @@ func (repo *Repository) GetRefsFiltered(pattern string) ([]*Reference, error) {
 		refName = refName[:len(refName)-1]
 
 		// refName cannot be HEAD but can be remotes or stash
-		if strings.HasPrefix(refName, "/refs/remotes/") || refName == "/refs/stash" {
+		if strings.HasPrefix(refName, RemotePrefix) || refName == "/refs/stash" {
 			continue
 		}
 

--- a/modules/gitgraph/graph.go
+++ b/modules/gitgraph/graph.go
@@ -29,7 +29,7 @@ func GetCommitGraph(r *git.Repository, page int, maxAllowedColors int, hidePRRef
 	args = append(args, "--graph", "--date-order", "--decorate=full")
 
 	if hidePRRefs {
-		args = append(args, "--exclude=refs/pull/*")
+		args = append(args, "--exclude="+git.PullPrefix+"*")
 	}
 
 	if len(branches) == 0 {

--- a/modules/migration/pullrequest.go
+++ b/modules/migration/pullrequest.go
@@ -8,6 +8,8 @@ package migration
 import (
 	"fmt"
 	"time"
+
+	"code.gitea.io/gitea/modules/git"
 )
 
 // PullRequest defines a standard pull request information
@@ -43,7 +45,7 @@ func (p *PullRequest) IsForkPullRequest() bool {
 
 // GetGitRefName returns pull request relative path to head
 func (p PullRequest) GetGitRefName() string {
-	return fmt.Sprintf("refs/pull/%d/head", p.Number)
+	return fmt.Sprintf(git.PullPrefix+"%d/head", p.Number)
 }
 
 // PullRequestBranch represents a pull request branch

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -104,7 +104,7 @@ func Graph(ctx *context.Context) {
 	copy(realBranches, branches)
 	for i, branch := range realBranches {
 		if strings.HasPrefix(branch, "--") {
-			realBranches[i] = "refs/heads/" + branch
+			realBranches[i] = git.BranchPrefix + branch
 		}
 	}
 	ctx.Data["SelectedBranches"] = realBranches

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -403,7 +403,7 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 
 	for _, result := range results {
 		// Discard GitHub pull requests, i.e. refs/pull/*
-		if strings.HasPrefix(result.refName, "refs/pull/") {
+		if strings.HasPrefix(result.refName, git.PullPrefix) {
 			continue
 		}
 
@@ -499,7 +499,7 @@ func checkAndUpdateEmptyRepository(m *models.Mirror, gitRepo *git.Repository, re
 	}
 	firstName := ""
 	for _, result := range results {
-		if strings.HasPrefix(result.refName, "refs/pull/") {
+		if strings.HasPrefix(result.refName, git.PullPrefix) {
 			continue
 		}
 		tp, name := git.SplitRefName(result.refName)

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -421,9 +421,9 @@ func rawMerge(pr *models.PullRequest, doer *user_model.User, mergeStyle models.M
 	var pushCmd *git.Command
 	if mergeStyle == models.MergeStyleRebaseUpdate {
 		// force push the rebase result to head brach
-		pushCmd = git.NewCommand("push", "-f", "head_repo", stagingBranch+":refs/heads/"+pr.HeadBranch)
+		pushCmd = git.NewCommand("push", "-f", "head_repo", stagingBranch+":"+git.BranchPrefix+pr.HeadBranch)
 	} else {
-		pushCmd = git.NewCommand("push", "origin", baseBranch+":refs/heads/"+pr.BaseBranch)
+		pushCmd = git.NewCommand("push", "origin", baseBranch+":"+git.BranchPrefix+pr.BaseBranch)
 	}
 
 	// Push back to upstream.

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -451,8 +451,8 @@ func pushToBaseRepoHelper(pr *models.PullRequest, prefixHeadBranch string) (err 
 				log.Info("Can't push with %s%s", prefixHeadBranch, pr.HeadBranch)
 				return err
 			}
-			log.Info("Retrying to push with refs/heads/%s", pr.HeadBranch)
-			err = pushToBaseRepoHelper(pr, "refs/heads/")
+			log.Info("Retrying to push with "+git.BranchPrefix+"%s", pr.HeadBranch)
+			err = pushToBaseRepoHelper(pr, git.BranchPrefix)
 			return err
 		}
 		log.Error("Unable to push PR head for %s#%d (%-v:%s) due to Error: %v", pr.BaseRepo.FullName(), pr.Index, pr.BaseRepo, gitRefName, err)

--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -152,8 +152,8 @@ func RenameBranch(repo *models.Repository, doer *user_model.User, gitRepo *git.R
 		return "", err
 	}
 
-	notification.NotifyDeleteRef(doer, repo, "branch", "refs/heads/"+from)
-	notification.NotifyCreateRef(doer, repo, "branch", "refs/heads/"+to)
+	notification.NotifyDeleteRef(doer, repo, "branch", git.BranchPrefix+from)
+	notification.NotifyCreateRef(doer, repo, "branch", git.BranchPrefix+to)
 
 	return "", nil
 }

--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -266,7 +266,7 @@ func (t *TemporaryUploadRepository) Push(doer *user_model.User, commitHash strin
 	env := models.PushingEnvironment(doer, t.repo)
 	if err := git.Push(t.gitRepo.Ctx, t.basePath, git.PushOptions{
 		Remote: t.repo.RepoPath(),
-		Branch: strings.TrimSpace(commitHash) + ":refs/heads/" + strings.TrimSpace(branch),
+		Branch: strings.TrimSpace(commitHash) + ":" + git.BranchPrefix + strings.TrimSpace(branch),
 		Env:    env,
 	}); err != nil {
 		if git.IsErrPushOutOfDate(err) {


### PR DESCRIPTION
Fixes #16478

I tried my best to refactor everything, but I left a few spots:
- the DB migration code, as I suspect this represent the status of the DB at a moment in time, and should be left untouched in case the value of the const change
- the tests (kinda for the same reason)
- one function in ./modules/structs/hook.go , as it create a  loop git git/ref.go, and fixing that mean a bigger refactor, which is maybe not the solution (maybe moving the function somewhere else ?)

Then there is various format strings, like  ```ref := fmt.Sprintf("refs/pull/%s/head:%s", pr, branchRef)```.

On one hand, I think they should also be refactored, on the other, I wonder if this doesn't make the code less readable. 