### PR TITLE
Preserve color when inverting emojis

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -549,7 +549,7 @@ td.blob-excerpt {
 .emoji[aria-label="paw prints"],
 .emoji[aria-label="musical note"],
 .emoji[aria-label="musical notes"] {
-  filter: invert(100%);
+  filter: invert(100%) hue-rotate(180deg);
 }
 
 .edit-diff > div > .ui.table {


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/17795

Windows:

<img width="46" alt="image" src="https://user-images.githubusercontent.com/115237/143229493-e9ac5758-94b4-40da-b747-4c28a8970189.png">

Mac:

<img width="43" alt="image" src="https://user-images.githubusercontent.com/115237/143229560-74929c26-b7cc-4582-b222-bd2c7f77d0be.png">
