### PR TITLE
Preserve color when inverting emojis (#17797)

### DIFF
--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -560,7 +560,7 @@ td.blob-excerpt {
 .emoji[aria-label="paw prints"],
 .emoji[aria-label="musical note"],
 .emoji[aria-label="musical notes"] {
-  filter: invert(100%);
+  filter: invert(100%) hue-rotate(180deg);
 }
 
 .edit-diff > div > .ui.table {


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/17797/ to 1.15.