### PR TITLE
Enable rule.unused-paramater

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -24,3 +24,4 @@ warningCode = 1
 [rule.indent-error-flow]
 [rule.errorf]
 [rule.duplicated-imports]
+[rule.unused-parameter]

--- a/cmd/admin_auth_ldap_test.go
+++ b/cmd/admin_auth_ldap_test.go
@@ -215,11 +215,11 @@ func TestAddLdapBindDn(t *testing.T) {
 				createdLoginSource = loginSource
 				return nil
 			},
-			updateLoginSource: func(loginSource *login.Source) error {
+			updateLoginSource: func(_ *login.Source) error {
 				assert.FailNow(t, "case %d: should not call updateLoginSource", n)
 				return nil
 			},
-			getLoginSourceByID: func(id int64) (*login.Source, error) {
+			getLoginSourceByID: func(_ int64) (*login.Source, error) {
 				assert.FailNow(t, "case %d: should not call getLoginSourceByID", n)
 				return nil, nil
 			},
@@ -446,11 +446,11 @@ func TestAddLdapSimpleAuth(t *testing.T) {
 				createdLoginSource = loginSource
 				return nil
 			},
-			updateLoginSource: func(loginSource *login.Source) error {
+			updateLoginSource: func(_ *login.Source) error {
 				assert.FailNow(t, "case %d: should not call updateLoginSource", n)
 				return nil
 			},
-			getLoginSourceByID: func(id int64) (*login.Source, error) {
+			getLoginSourceByID: func(_ int64) (*login.Source, error) {
 				assert.FailNow(t, "case %d: should not call getLoginSourceByID", n)
 				return nil, nil
 			},
@@ -867,7 +867,7 @@ func TestUpdateLdapBindDn(t *testing.T) {
 			initDB: func(context.Context) error {
 				return nil
 			},
-			createLoginSource: func(loginSource *login.Source) error {
+			createLoginSource: func(_ *login.Source) error {
 				assert.FailNow(t, "case %d: should not call createLoginSource", n)
 				return nil
 			},
@@ -1231,7 +1231,7 @@ func TestUpdateLdapSimpleAuth(t *testing.T) {
 			initDB: func(context.Context) error {
 				return nil
 			},
-			createLoginSource: func(loginSource *login.Source) error {
+			createLoginSource: func(_ *login.Source) error {
 				assert.FailNow(t, "case %d: should not call createLoginSource", n)
 				return nil
 			},

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -22,7 +22,7 @@ var CmdConvert = cli.Command{
 	Action:      runConvert,
 }
 
-func runConvert(ctx *cli.Context) error {
+func runConvert(_ *cli.Context) error {
 	stdCtx, cancel := installSignals()
 	defer cancel()
 

--- a/cmd/embedded_stub.go
+++ b/cmd/embedded_stub.go
@@ -24,7 +24,7 @@ var (
 	}
 )
 
-func extractorNotImplemented(c *cli.Context) error {
+func extractorNotImplemented(_ *cli.Context) error {
 	err := fmt.Errorf("Sorry: the 'embedded' subcommand is not available in builds without bindata")
 	fmt.Fprintf(os.Stderr, "%s\n", err)
 	return err

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func runGenerateInternalToken(c *cli.Context) error {
+func runGenerateInternalToken(_ *cli.Context) error {
 	internalToken, err := generate.NewInternalToken()
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func runGenerateInternalToken(c *cli.Context) error {
 	return nil
 }
 
-func runGenerateLfsJwtSecret(c *cli.Context) error {
+func runGenerateLfsJwtSecret(_ *cli.Context) error {
 	JWTSecretBase64, err := generate.NewJwtSecretBase64()
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func runGenerateLfsJwtSecret(c *cli.Context) error {
 	return nil
 }
 
-func runGenerateSecretKey(c *cli.Context) error {
+func runGenerateSecretKey(_ *cli.Context) error {
 	secretKey, err := generate.NewSecretKey()
 	if err != nil {
 		return err

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -168,7 +168,7 @@ func runHookPreReceive(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("hooks/pre-receive.log", c.Bool("debug"))
+	setup(c.Bool("debug"))
 
 	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
 		if setting.OnlyAllowPushIfGiteaEnvironmentSet {
@@ -299,7 +299,7 @@ Gitea or set your environment appropriately.`, "")
 	return nil
 }
 
-func runHookUpdate(c *cli.Context) error {
+func runHookUpdate(_ *cli.Context) error {
 	// Update is empty and is kept only for backwards compatibility
 	return nil
 }
@@ -318,7 +318,7 @@ func runHookPostReceive(c *cli.Context) error {
 		return nil
 	}
 
-	setup("hooks/post-receive.log", c.Bool("debug"))
+	setup(c.Bool("debug"))
 
 	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
 		if setting.OnlyAllowPushIfGiteaEnvironmentSet {
@@ -484,7 +484,7 @@ func pushOptions() map[string]string {
 }
 
 func runHookProcReceive(c *cli.Context) error {
-	setup("hooks/proc-receive.log", c.Bool("debug"))
+	setup(c.Bool("debug"))
 
 	if len(os.Getenv("SSH_ORIGINAL_COMMAND")) == 0 {
 		if setting.OnlyAllowPushIfGiteaEnvironmentSet {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -65,7 +65,7 @@ func runKeys(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("keys.log", false)
+	setup(false)
 
 	authorizedString, err := private.AuthorizedPublicKeyByContent(ctx, content)
 	if err != nil {

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -230,7 +230,7 @@ var (
 )
 
 func runRemoveLogger(c *cli.Context) error {
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	group := c.String("group")
 	if len(group) == 0 {
 		group = log.DEFAULT
@@ -250,7 +250,7 @@ func runRemoveLogger(c *cli.Context) error {
 }
 
 func runAddSMTPLogger(c *cli.Context) error {
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	vals := map[string]interface{}{}
 	mode := "smtp"
 	if c.IsSet("host") {
@@ -281,7 +281,7 @@ func runAddSMTPLogger(c *cli.Context) error {
 }
 
 func runAddConnLogger(c *cli.Context) error {
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	vals := map[string]interface{}{}
 	mode := "conn"
 	vals["net"] = "tcp"
@@ -308,7 +308,7 @@ func runAddConnLogger(c *cli.Context) error {
 }
 
 func runAddFileLogger(c *cli.Context) error {
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	vals := map[string]interface{}{}
 	mode := "file"
 	if c.IsSet("filename") {
@@ -338,7 +338,7 @@ func runAddFileLogger(c *cli.Context) error {
 }
 
 func runAddConsoleLogger(c *cli.Context) error {
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	vals := map[string]interface{}{}
 	mode := "console"
 	if c.IsSet("stderr") && c.Bool("stderr") {
@@ -391,7 +391,7 @@ func runShutdown(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.Shutdown(ctx)
 	switch statusCode {
 	case http.StatusInternalServerError:
@@ -406,7 +406,7 @@ func runRestart(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.Restart(ctx)
 	switch statusCode {
 	case http.StatusInternalServerError:
@@ -421,7 +421,7 @@ func runFlushQueues(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.FlushQueues(ctx, c.Duration("timeout"), c.Bool("non-blocking"))
 	switch statusCode {
 	case http.StatusInternalServerError:
@@ -436,7 +436,7 @@ func runPauseLogging(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.PauseLogging(ctx)
 	switch statusCode {
 	case http.StatusInternalServerError:
@@ -451,7 +451,7 @@ func runResumeLogging(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.ResumeLogging(ctx)
 	switch statusCode {
 	case http.StatusInternalServerError:
@@ -466,7 +466,7 @@ func runReleaseReopenLogging(c *cli.Context) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 
-	setup("manager", c.Bool("debug"))
+	setup(c.Bool("debug"))
 	statusCode, msg := private.ReleaseReopenLogging(ctx)
 	switch statusCode {
 	case http.StatusInternalServerError:

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -23,7 +23,7 @@ var CmdMigrate = cli.Command{
 	Action:      runMigrate,
 }
 
-func runMigrate(ctx *cli.Context) error {
+func runMigrate(_ *cli.Context) error {
 	stdCtx, cancel := installSignals()
 	defer cancel()
 

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -50,7 +50,7 @@ var CmdServ = cli.Command{
 	},
 }
 
-func setup(logPath string, debug bool) {
+func setup(debug bool) {
 	_ = log.DelLogger("console")
 	if debug {
 		_ = log.NewLogger(1000, "console", "console", `{"level":"trace","stacktracelevel":"NONE","stderr":true}`)
@@ -98,7 +98,7 @@ func runServ(c *cli.Context) error {
 	defer cancel()
 
 	// FIXME: This needs to internationalised
-	setup("serv.log", c.Bool("debug"))
+	setup(c.Bool("debug"))
 
 	if setting.SSH.Disabled {
 		println("Gitea: SSH has been disabled")

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -109,7 +109,7 @@ func runWeb(ctx *cli.Context) error {
 	}
 
 	// Perform pre-initialization
-	needsInstall := install.PreloadSettings(graceful.GetManager().HammerContext())
+	needsInstall := install.PreloadSettings()
 	if needsInstall {
 		// Flag for port number in case first time run conflict
 		if ctx.IsSet("port") {

--- a/integrations/api_repo_edit_test.go
+++ b/integrations/api_repo_edit_test.go
@@ -132,7 +132,7 @@ func getNewRepoEditOption(opts *api.EditRepoOption) *api.EditRepoOption {
 }
 
 func TestAPIRepoEdit(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		bFalse, bTrue := false, true
 
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16

--- a/integrations/api_repo_file_create_test.go
+++ b/integrations/api_repo_file_create_test.go
@@ -108,7 +108,7 @@ func getExpectedFileResponseForCreate(commitID, treePath string) *api.FileRespon
 }
 
 func BenchmarkAPICreateFileSmall(b *testing.B) {
-	onGiteaRunTB(b, func(t testing.TB, u *url.URL) {
+	onGiteaRunTB(b, func(t testing.TB, _ *url.URL) {
 		b := t.(*testing.B)
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)     // owner of the repo1 & repo16
 		repo1 := unittest.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository) // public repo
@@ -123,7 +123,7 @@ func BenchmarkAPICreateFileSmall(b *testing.B) {
 func BenchmarkAPICreateFileMedium(b *testing.B) {
 	data := make([]byte, 10*1024*1024)
 
-	onGiteaRunTB(b, func(t testing.TB, u *url.URL) {
+	onGiteaRunTB(b, func(t testing.TB, _ *url.URL) {
 		b := t.(*testing.B)
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)     // owner of the repo1 & repo16
 		repo1 := unittest.AssertExistsAndLoadBean(t, &models.Repository{ID: 1}).(*models.Repository) // public repo
@@ -138,7 +138,7 @@ func BenchmarkAPICreateFileMedium(b *testing.B) {
 }
 
 func TestAPICreateFile(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16
 		user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)       // owner of the repo3, is an org
 		user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4}).(*user_model.User)       // owner of neither repos

--- a/integrations/api_repo_file_delete_test.go
+++ b/integrations/api_repo_file_delete_test.go
@@ -38,7 +38,7 @@ func getDeleteFileOptions() *api.DeleteFileOptions {
 }
 
 func TestAPIDeleteFile(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16
 		user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)       // owner of the repo3, is an org
 		user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4}).(*user_model.User)       // owner of neither repos

--- a/integrations/api_repo_file_update_test.go
+++ b/integrations/api_repo_file_update_test.go
@@ -104,7 +104,7 @@ func getExpectedFileResponseForUpdate(commitID, treePath string) *api.FileRespon
 }
 
 func TestAPIUpdateFile(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16
 		user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)       // owner of the repo3, is an org
 		user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4}).(*user_model.User)       // owner of neither repos

--- a/integrations/api_repo_get_contents_list_test.go
+++ b/integrations/api_repo_get_contents_list_test.go
@@ -52,7 +52,7 @@ func TestAPIGetContentsList(t *testing.T) {
 	onGiteaRun(t, testAPIGetContentsList)
 }
 
-func testAPIGetContentsList(t *testing.T, u *url.URL) {
+func testAPIGetContentsList(t *testing.T, _ *url.URL) {
 	/*** SETUP ***/
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)       // owner of the repo3, is an org

--- a/integrations/api_repo_get_contents_test.go
+++ b/integrations/api_repo_get_contents_test.go
@@ -53,7 +53,7 @@ func TestAPIGetContents(t *testing.T) {
 	onGiteaRun(t, testAPIGetContents)
 }
 
-func testAPIGetContents(t *testing.T, u *url.URL) {
+func testAPIGetContents(t *testing.T, _ *url.URL) {
 	/*** SETUP ***/
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)       // owner of the repo1 & repo16
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)       // owner of the repo3, is an org

--- a/integrations/api_repo_languages_test.go
+++ b/integrations/api_repo_languages_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRepoLanguages(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user2")
 
 		// Request editor page

--- a/integrations/benchmarks_test.go
+++ b/integrations/benchmarks_test.go
@@ -25,7 +25,7 @@ func StringWithCharset(length int, charset string) string {
 }
 
 func BenchmarkRepoBranchCommit(b *testing.B) {
-	onGiteaRunTB(b, func(t testing.TB, u *url.URL) {
+	onGiteaRunTB(b, func(t testing.TB, _ *url.URL) {
 		b := t.(*testing.B)
 
 		samples := []int64{1, 2, 3}

--- a/integrations/branches_test.go
+++ b/integrations/branches_test.go
@@ -31,7 +31,7 @@ func TestDeleteBranch(t *testing.T) {
 }
 
 func TestUndoDeleteBranch(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		deleteBranch(t)
 		htmlDoc, name := branchAction(t, ".undo-button")
 		assert.Contains(t,

--- a/integrations/editor_test.go
+++ b/integrations/editor_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCreateFile(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user2")
 
 		// Request editor page
@@ -39,7 +39,7 @@ func TestCreateFile(t *testing.T) {
 }
 
 func TestCreateFileOnProtectedBranch(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user2")
 
 		csrf := GetCSRF(t, session, "/user2/repo1/settings/branches")
@@ -151,14 +151,14 @@ func testEditFileToNewBranch(t *testing.T, session *TestSession, user, repo, bra
 }
 
 func TestEditFile(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user2")
 		testEditFile(t, session, "user2", "repo1", "master", "README.md", "Hello, World (Edited)\n")
 	})
 }
 
 func TestEditFileToNewBranch(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user2")
 		testEditFileToNewBranch(t, session, "user2", "repo1", "master", "feature/test", "README.md", "Hello, World (Edited)\n")
 	})

--- a/integrations/git_test.go
+++ b/integrations/git_test.go
@@ -664,7 +664,7 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, baseBranch, headB
 		})
 
 		t.Run("Push", func(t *testing.T) {
-			_, err := git.NewCommand("push", "origin", "HEAD:refs/for/master", "-o", "topic="+headBranch).RunInDir(dstPath)
+			_, err := git.NewCommand("push", "origin", "HEAD:refs/for/"+baseBranch, "-o", "topic="+headBranch).RunInDir(dstPath)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -685,7 +685,7 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, baseBranch, headB
 			assert.Contains(t, "Testing commit 1", prMsg.Body)
 			assert.Equal(t, commit, prMsg.Head.Sha)
 
-			_, err = git.NewCommand("push", "origin", "HEAD:refs/for/master/test/"+headBranch).RunInDir(dstPath)
+			_, err = git.NewCommand("push", "origin", "HEAD:refs/for/"+baseBranch+"/test/"+headBranch).RunInDir(dstPath)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -738,7 +738,7 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, baseBranch, headB
 		})
 
 		t.Run("Push2", func(t *testing.T) {
-			_, err := git.NewCommand("push", "origin", "HEAD:refs/for/master", "-o", "topic="+headBranch).RunInDir(dstPath)
+			_, err := git.NewCommand("push", "origin", "HEAD:refs/for/"+baseBranch, "-o", "topic="+headBranch).RunInDir(dstPath)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -750,7 +750,7 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, baseBranch, headB
 			assert.Equal(t, false, prMsg.HasMerged)
 			assert.Equal(t, commit, prMsg.Head.Sha)
 
-			_, err = git.NewCommand("push", "origin", "HEAD:refs/for/master/test/"+headBranch).RunInDir(dstPath)
+			_, err = git.NewCommand("push", "origin", "HEAD:refs/for/"+baseBranch+"/test/"+headBranch).RunInDir(dstPath)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -763,6 +763,6 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, baseBranch, headB
 			assert.Equal(t, commit, prMsg.Head.Sha)
 		})
 		t.Run("Merge", doAPIMergePullRequest(*ctx, ctx.Username, ctx.Reponame, pr1.Index))
-		t.Run("CheckoutMasterAgain", doGitCheckoutBranch(dstPath, "master"))
+		t.Run("CheckoutMasterAgain", doGitCheckoutBranch(dstPath, baseBranch))
 	}
 }

--- a/integrations/org_count_test.go
+++ b/integrations/org_count_test.go
@@ -21,7 +21,7 @@ func TestOrgCounts(t *testing.T) {
 	onGiteaRun(t, testOrgCounts)
 }
 
-func testOrgCounts(t *testing.T, u *url.URL) {
+func testOrgCounts(t *testing.T, _ *url.URL) {
 	orgOwner := "user2"
 	orgName := "testOrg"
 	orgCollaborator := "user4"

--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -44,7 +44,7 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch, titl
 }
 
 func TestPullCreate(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
@@ -72,7 +72,7 @@ func TestPullCreate(t *testing.T) {
 }
 
 func TestPullCreate_TitleEscape(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
@@ -134,7 +134,7 @@ func testDeleteRepository(t *testing.T, session *TestSession, ownerName, repoNam
 }
 
 func TestPullBranchDelete(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		defer prepareTestEnv(t)()
 
 		session := loginUser(t, "user1")

--- a/integrations/pull_merge_test.go
+++ b/integrations/pull_merge_test.go
@@ -63,7 +63,7 @@ func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum str
 }
 
 func TestPullMerge(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		hookTasks, err := webhook.HookTasks(1, 1) //Retrieve previous hook number
 		assert.NoError(t, err)
 		hookTasksLenBefore := len(hookTasks)
@@ -85,7 +85,7 @@ func TestPullMerge(t *testing.T) {
 }
 
 func TestPullRebase(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		hookTasks, err := webhook.HookTasks(1, 1) //Retrieve previous hook number
 		assert.NoError(t, err)
 		hookTasksLenBefore := len(hookTasks)
@@ -107,7 +107,7 @@ func TestPullRebase(t *testing.T) {
 }
 
 func TestPullRebaseMerge(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		hookTasks, err := webhook.HookTasks(1, 1) //Retrieve previous hook number
 		assert.NoError(t, err)
 		hookTasksLenBefore := len(hookTasks)
@@ -129,7 +129,7 @@ func TestPullRebaseMerge(t *testing.T) {
 }
 
 func TestPullSquash(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		hookTasks, err := webhook.HookTasks(1, 1) //Retrieve previous hook number
 		assert.NoError(t, err)
 		hookTasksLenBefore := len(hookTasks)
@@ -152,7 +152,7 @@ func TestPullSquash(t *testing.T) {
 }
 
 func TestPullCleanUpAfterMerge(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFileToNewBranch(t, session, "user1", "repo1", "master", "feature/test", "README.md", "Hello, World (Edited - TestPullCleanUpAfterMerge)\n")
@@ -187,7 +187,7 @@ func TestPullCleanUpAfterMerge(t *testing.T) {
 }
 
 func TestCantMergeWorkInProgress(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFile(t, session, "user1", "repo1", "master", "README.md", "Hello, World (Edited)\n")
@@ -206,7 +206,7 @@ func TestCantMergeWorkInProgress(t *testing.T) {
 }
 
 func TestCantMergeConflict(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFileToNewBranch(t, session, "user1", "repo1", "master", "conflict", "README.md", "Hello, World (Edited Once)\n")
@@ -240,11 +240,11 @@ func TestCantMergeConflict(t *testing.T) {
 		gitRepo, err := git.OpenRepository(models.RepoPath(user1.Name, repo1.Name))
 		assert.NoError(t, err)
 
-		err = pull.Merge(pr, user1, gitRepo, models.MergeStyleMerge, "CONFLICT")
+		err = pull.Merge(pr, user1, models.MergeStyleMerge, "CONFLICT")
 		assert.Error(t, err, "Merge should return an error due to conflict")
 		assert.True(t, models.IsErrMergeConflicts(err), "Merge error is not a conflict error")
 
-		err = pull.Merge(pr, user1, gitRepo, models.MergeStyleRebase, "CONFLICT")
+		err = pull.Merge(pr, user1, models.MergeStyleRebase, "CONFLICT")
 		assert.Error(t, err, "Merge should return an error due to conflict")
 		assert.True(t, models.IsErrRebaseConflicts(err), "Merge error is not a conflict error")
 		gitRepo.Close()
@@ -252,7 +252,7 @@ func TestCantMergeConflict(t *testing.T) {
 }
 
 func TestCantMergeUnrelated(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFileToNewBranch(t, session, "user1", "repo1", "master", "base", "README.md", "Hello, World (Edited Twice)\n")
@@ -328,7 +328,7 @@ func TestCantMergeUnrelated(t *testing.T) {
 			BaseBranch: "base",
 		}).(*models.PullRequest)
 
-		err = pull.Merge(pr, user1, gitRepo, models.MergeStyleMerge, "UNRELATED")
+		err = pull.Merge(pr, user1, models.MergeStyleMerge, "UNRELATED")
 		assert.Error(t, err, "Merge should return an error due to unrelated")
 		assert.True(t, models.IsErrMergeUnrelatedHistories(err), "Merge error is not a unrelated histories error")
 		gitRepo.Close()

--- a/integrations/pull_status_test.go
+++ b/integrations/pull_status_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPullCreate_CommitStatus(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFileToNewBranch(t, session, "user1", "repo1", "master", "status1", "README.md", "status1")
@@ -95,7 +95,7 @@ func TestPullCreate_CommitStatus(t *testing.T) {
 }
 
 func TestPullCreate_EmptyChangesWithCommits(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
 		testEditFileToNewBranch(t, session, "user1", "repo1", "master", "status1", "README.md", "status1")

--- a/integrations/pull_update_test.go
+++ b/integrations/pull_update_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestAPIPullUpdate(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		//Create PR to test
 		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
 		org26 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 26}).(*user_model.User)
@@ -49,7 +49,7 @@ func TestAPIPullUpdate(t *testing.T) {
 }
 
 func TestAPIPullUpdateByRebase(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		//Create PR to test
 		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
 		org26 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 26}).(*user_model.User)

--- a/integrations/release_test.go
+++ b/integrations/release_test.go
@@ -146,7 +146,7 @@ func TestViewReleaseListNoLogin(t *testing.T) {
 	assert.Equal(t, 2, releases.Length())
 
 	links := make([]string, 0, 5)
-	releases.Each(func(i int, s *goquery.Selection) {
+	releases.Each(func(_ int, s *goquery.Selection) {
 		link, exist := s.Find(".release-list-title a").Attr("href")
 		if !exist {
 			return
@@ -173,7 +173,7 @@ func TestViewReleaseListLogin(t *testing.T) {
 	assert.Equal(t, 3, releases.Length())
 
 	links := make([]string, 0, 5)
-	releases.Each(func(i int, s *goquery.Selection) {
+	releases.Each(func(_ int, s *goquery.Selection) {
 		link, exist := s.Find(".release-list-title a").Attr("href")
 		if !exist {
 			return
@@ -204,7 +204,7 @@ func TestViewTagsList(t *testing.T) {
 	assert.Equal(t, 3, tags.Length())
 
 	tagNames := make([]string, 0, 5)
-	tags.Each(func(i int, s *goquery.Selection) {
+	tags.Each(func(_ int, s *goquery.Selection) {
 		tagNames = append(tagNames, s.Find(".tag a.df.ac").Text())
 	})
 

--- a/integrations/repo_activity_test.go
+++ b/integrations/repo_activity_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestRepoActivity(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 
 		session := loginUser(t, "user1")
 

--- a/integrations/repo_branch_test.go
+++ b/integrations/repo_branch_test.go
@@ -40,7 +40,7 @@ func TestCreateBranch(t *testing.T) {
 	onGiteaRun(t, testCreateBranches)
 }
 
-func testCreateBranches(t *testing.T, giteaURL *url.URL) {
+func testCreateBranches(t *testing.T, _ *url.URL) {
 	tests := []struct {
 		OldRefSubURL   string
 		NewBranch      string

--- a/integrations/repo_search_test.go
+++ b/integrations/repo_search_test.go
@@ -60,6 +60,6 @@ func testSearch(t *testing.T, url string, expected []string) {
 	assert.EqualValues(t, expected, filenames)
 }
 
-func executeIndexer(t *testing.T, repo *models.Repository, op func(*models.Repository)) {
+func executeIndexer(_ *testing.T, repo *models.Repository, op func(*models.Repository)) {
 	op(repo)
 }

--- a/integrations/repo_test.go
+++ b/integrations/repo_test.go
@@ -50,7 +50,7 @@ func testViewRepo(t *testing.T) {
 
 	var items []file
 
-	files.Each(func(i int, s *goquery.Selection) {
+	files.Each(func(_ int, s *goquery.Selection) {
 		tds := s.Find("td")
 		var f file
 		tds.Each(func(i int, s *goquery.Selection) {
@@ -149,7 +149,7 @@ func TestViewRepoWithSymlinks(t *testing.T) {
 
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	files := htmlDoc.doc.Find("#repo-files-table > TBODY > TR > TD.name > SPAN.truncate")
-	items := files.Map(func(i int, s *goquery.Selection) string {
+	items := files.Map(func(_ int, s *goquery.Selection) string {
 		cls, _ := s.Find("SVG").Attr("class")
 		file := strings.Trim(s.Find("A").Text(), " \t\n")
 		return fmt.Sprintf("%s: %s", file, cls)

--- a/integrations/repo_watch_test.go
+++ b/integrations/repo_watch_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRepoWatch(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		// Test round-trip auto-watch
 		setting.Service.AutoWatchOnChanges = true
 		session := loginUser(t, "user2")

--- a/integrations/repofiles_delete_test.go
+++ b/integrations/repofiles_delete_test.go
@@ -33,7 +33,7 @@ func getDeleteRepoFileOptions(repo *models.Repository) *files_service.DeleteRepo
 	}
 }
 
-func getExpectedDeleteFileResponse(u *url.URL) *api.FileResponse {
+func getExpectedDeleteFileResponse() *api.FileResponse {
 	// Just returns fields that don't change, i.e. fields with commit SHAs and dates can't be determined
 	return &api.FileResponse{
 		Content: nil,
@@ -65,7 +65,7 @@ func TestDeleteRepoFile(t *testing.T) {
 	onGiteaRun(t, testDeleteRepoFile)
 }
 
-func testDeleteRepoFile(t *testing.T, u *url.URL) {
+func testDeleteRepoFile(t *testing.T, _ *url.URL) {
 	// setup
 	unittest.PrepareTestEnv(t)
 	ctx := test.MockContext(t, "user2/repo1")
@@ -82,7 +82,7 @@ func testDeleteRepoFile(t *testing.T, u *url.URL) {
 	t.Run("Delete README.md file", func(t *testing.T) {
 		fileResponse, err := files_service.DeleteRepoFile(repo, doer, opts)
 		assert.NoError(t, err)
-		expectedFileResponse := getExpectedDeleteFileResponse(u)
+		expectedFileResponse := getExpectedDeleteFileResponse()
 		assert.NotNil(t, fileResponse)
 		assert.Nil(t, fileResponse.Content)
 		assert.EqualValues(t, expectedFileResponse.Commit.Message, fileResponse.Commit.Message)
@@ -104,7 +104,7 @@ func TestDeleteRepoFileWithoutBranchNames(t *testing.T) {
 	onGiteaRun(t, testDeleteRepoFileWithoutBranchNames)
 }
 
-func testDeleteRepoFileWithoutBranchNames(t *testing.T, u *url.URL) {
+func testDeleteRepoFileWithoutBranchNames(t *testing.T, _ *url.URL) {
 	// setup
 	unittest.PrepareTestEnv(t)
 	ctx := test.MockContext(t, "user2/repo1")
@@ -124,7 +124,7 @@ func testDeleteRepoFileWithoutBranchNames(t *testing.T, u *url.URL) {
 	t.Run("Delete README.md without Branch Name", func(t *testing.T) {
 		fileResponse, err := files_service.DeleteRepoFile(repo, doer, opts)
 		assert.NoError(t, err)
-		expectedFileResponse := getExpectedDeleteFileResponse(u)
+		expectedFileResponse := getExpectedDeleteFileResponse()
 		assert.NotNil(t, fileResponse)
 		assert.Nil(t, fileResponse.Content)
 		assert.EqualValues(t, expectedFileResponse.Commit.Message, fileResponse.Commit.Message)

--- a/integrations/repofiles_update_test.go
+++ b/integrations/repofiles_update_test.go
@@ -184,7 +184,7 @@ func getExpectedFileResponseForRepofilesUpdate(commitID, filename string) *api.F
 
 func TestCreateOrUpdateRepoFileForCreate(t *testing.T) {
 	// setup
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		ctx := test.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
 		test.LoadRepo(t, ctx, 1)
@@ -220,7 +220,7 @@ func TestCreateOrUpdateRepoFileForCreate(t *testing.T) {
 
 func TestCreateOrUpdateRepoFileForUpdate(t *testing.T) {
 	// setup
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		ctx := test.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
 		test.LoadRepo(t, ctx, 1)
@@ -253,7 +253,7 @@ func TestCreateOrUpdateRepoFileForUpdate(t *testing.T) {
 
 func TestCreateOrUpdateRepoFileForUpdateWithFileMove(t *testing.T) {
 	// setup
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		ctx := test.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
 		test.LoadRepo(t, ctx, 1)
@@ -303,7 +303,7 @@ func TestCreateOrUpdateRepoFileForUpdateWithFileMove(t *testing.T) {
 // Test opts with branch names removed, should get same results as above test
 func TestCreateOrUpdateRepoFileWithoutBranchNames(t *testing.T) {
 	// setup
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		ctx := test.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
 		test.LoadRepo(t, ctx, 1)
@@ -334,7 +334,7 @@ func TestCreateOrUpdateRepoFileWithoutBranchNames(t *testing.T) {
 
 func TestCreateOrUpdateRepoFileErrors(t *testing.T) {
 	// setup
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		ctx := test.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
 		test.LoadRepo(t, ctx, 1)

--- a/integrations/ssh_key_test.go
+++ b/integrations/ssh_key_test.go
@@ -115,7 +115,7 @@ func testKeyOnlyOneType(t *testing.T, u *url.URL) {
 
 			t.Run("FailToClone", doGitCloneFail(sshURL))
 
-			t.Run("CreateUserKey", doAPICreateUserKey(ctx, keyname, keyFile, func(t *testing.T, publicKey api.PublicKey) {
+			t.Run("CreateUserKey", doAPICreateUserKey(ctx, keyname, keyFile, func(_ *testing.T, publicKey api.PublicKey) {
 				userKeyPublicKeyID = publicKey.ID
 			}))
 
@@ -186,7 +186,7 @@ func testKeyOnlyOneType(t *testing.T, u *url.URL) {
 
 			t.Run("RecreateRepository", doAPICreateRepository(ctx, false))
 
-			t.Run("CreateUserKey", doAPICreateUserKey(ctx, keyname, keyFile, func(t *testing.T, publicKey api.PublicKey) {
+			t.Run("CreateUserKey", doAPICreateUserKey(ctx, keyname, keyFile, func(_ *testing.T, publicKey api.PublicKey) {
 				userKeyPublicKeyID = publicKey.ID
 			}))
 

--- a/integrations/user_avatar_test.go
+++ b/integrations/user_avatar_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestUserAvatar(t *testing.T) {
-	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User) // owner of the repo3, is an org
 
 		seed := user2.Email

--- a/models/branches.go
+++ b/models/branches.go
@@ -5,7 +5,6 @@
 package models
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -581,7 +580,7 @@ func RemoveDeletedBranch(repoID int64, branch string) error {
 }
 
 // RemoveOldDeletedBranches removes old deleted branches
-func RemoveOldDeletedBranches(ctx context.Context, olderThan time.Duration) {
+func RemoveOldDeletedBranches(olderThan time.Duration) {
 	// Nothing to do for shutdown or terminate
 	log.Trace("Doing: DeletedBranchesCleanup")
 

--- a/models/db/log.go
+++ b/models/db/log.go
@@ -89,7 +89,7 @@ func (l *XORMLogBridge) Level() xormlog.LogLevel {
 }
 
 // SetLevel set the logger level
-func (l *XORMLogBridge) SetLevel(lvl xormlog.LogLevel) {
+func (l *XORMLogBridge) SetLevel(_ xormlog.LogLevel) {
 }
 
 // ShowSQL set if record SQL

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -270,7 +270,7 @@ func (c *Comment) BeforeUpdate() {
 }
 
 // AfterLoad is invoked from XORM after setting the values of all fields of this object.
-func (c *Comment) AfterLoad(session *xorm.Session) {
+func (c *Comment) AfterLoad(_ *xorm.Session) {
 	c.Patch = c.PatchQuoted
 	if len(c.PatchQuoted) > 0 && c.PatchQuoted[0] == '"' {
 		unquoted, err := strconv.Unquote(c.PatchQuoted)
@@ -1358,7 +1358,7 @@ func getCommitIDsFromRepo(repo *Repository, oldCommitID, newCommitID, baseBranch
 		}
 	}
 
-	if err = commitBranchCheck(gitRepo, newCommit, oldCommitID, baseBranch, commitChecks); err != nil {
+	if err = commitBranchCheck(newCommit, oldCommitID, baseBranch, commitChecks); err != nil {
 		return
 	}
 
@@ -1377,7 +1377,7 @@ type commitBranchCheckItem struct {
 	Checked bool
 }
 
-func commitBranchCheck(gitRepo *git.Repository, startCommit *git.Commit, endCommitID, baseBranch string, commitList map[string]*commitBranchCheckItem) error {
+func commitBranchCheck(startCommit *git.Commit, endCommitID, baseBranch string, commitList map[string]*commitBranchCheckItem) error {
 	if startCommit.ID.String() == endCommitID {
 		return nil
 	}

--- a/models/issue_xref_test.go
+++ b/models/issue_xref_test.go
@@ -168,7 +168,7 @@ func testCreatePR(t *testing.T, repo, doer int64, title, content string) *PullRe
 
 func testCreateComment(t *testing.T, repo, doer, issue int64, content string) *Comment {
 	d := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: doer}).(*user_model.User)
-	i := unittest.AssertExistsAndLoadBean(t, &Issue{ID: issue}).(*Issue)
+	i := unittest.AssertExistsAndLoadBean(t, &Issue{ID: issue, RepoID: repo}).(*Issue)
 	c := &Comment{Type: CommentTypeComment, PosterID: doer, Poster: d, IssueID: issue, Issue: i, Content: content}
 
 	ctx, committer, err := db.TxContext()

--- a/models/migrations/v199.go
+++ b/models/migrations/v199.go
@@ -8,7 +8,7 @@ import (
 	"xorm.io/xorm"
 )
 
-func addRemoteVersionTableNoop(x *xorm.Engine) error {
+func addRemoteVersionTableNoop(_ *xorm.Engine) error {
 	// we used to use a table `remote_version` to store information for updater, now we use `AppState`, so this migration task is a no-op now.
 	return nil
 }

--- a/models/org_test.go
+++ b/models/org_test.go
@@ -522,7 +522,7 @@ func TestAccessibleReposEnv_CountRepos(t *testing.T) {
 func TestAccessibleReposEnv_RepoIDs(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	org := unittest.AssertExistsAndLoadBean(t, &Organization{ID: 3}).(*Organization)
-	testSuccess := func(userID, _, pageSize int64, expectedRepoIDs []int64) {
+	testSuccess := func(userID, _, _ int64, expectedRepoIDs []int64) {
 		env, err := org.AccessibleReposEnv(userID)
 		assert.NoError(t, err)
 		repoIDs, err := env.RepoIDs(1, 100)

--- a/models/repo.go
+++ b/models/repo.go
@@ -1246,7 +1246,7 @@ func DecrementRepoForkNum(ctx context.Context, repoID int64) error {
 }
 
 // ChangeRepositoryName changes all corresponding setting from old repository name to new one.
-func ChangeRepositoryName(doer *user_model.User, repo *Repository, newRepoName string) (err error) {
+func ChangeRepositoryName(repo *Repository, newRepoName string) (err error) {
 	oldRepoName := repo.Name
 	newRepoName = strings.ToLower(newRepoName)
 	if err = IsUsableRepoName(newRepoName); err != nil {
@@ -1824,7 +1824,7 @@ func GetPrivateRepositoryCount(u *user_model.User) (int64, error) {
 }
 
 // DeleteOldRepositoryArchives deletes old repository archives.
-func DeleteOldRepositoryArchives(ctx context.Context, olderThan time.Duration) error {
+func DeleteOldRepositoryArchives(olderThan time.Duration) error {
 	log.Trace("Doing: ArchiveCleanup")
 
 	for {
@@ -1839,7 +1839,7 @@ func DeleteOldRepositoryArchives(ctx context.Context, olderThan time.Duration) e
 		}
 
 		for _, archiver := range archivers {
-			if err := deleteOldRepoArchiver(ctx, &archiver); err != nil {
+			if err := deleteOldRepoArchiver(&archiver); err != nil {
 				return err
 			}
 		}
@@ -1854,7 +1854,7 @@ func DeleteOldRepositoryArchives(ctx context.Context, olderThan time.Duration) e
 
 var delRepoArchiver = new(RepoArchiver)
 
-func deleteOldRepoArchiver(ctx context.Context, archiver *RepoArchiver) error {
+func deleteOldRepoArchiver(archiver *RepoArchiver) error {
 	p, err := archiver.RelativePath()
 	if err != nil {
 		return err

--- a/models/repo_avatar.go
+++ b/models/repo_avatar.go
@@ -61,7 +61,7 @@ func RemoveRandomAvatars(ctx context.Context) error {
 	return db.GetEngine(db.DefaultContext).
 		Where("id > 0").BufferSize(setting.Database.IterateBufferSize).
 		Iterate(new(Repository),
-			func(idx int, bean interface{}) error {
+			func(_ int, bean interface{}) error {
 				repository := bean.(*Repository)
 				select {
 				case <-ctx.Done():

--- a/models/repo_generate.go
+++ b/models/repo_generate.go
@@ -80,7 +80,7 @@ func GenerateTopics(ctx context.Context, templateRepo, generateRepo *Repository)
 }
 
 // GenerateGitHooks generates git hooks from a template repository
-func GenerateGitHooks(ctx context.Context, templateRepo, generateRepo *Repository) error {
+func GenerateGitHooks(templateRepo, generateRepo *Repository) error {
 	generateGitRepo, err := git.OpenRepository(generateRepo.RepoPath())
 	if err != nil {
 		return err

--- a/models/repo_pushmirror_test.go
+++ b/models/repo_pushmirror_test.go
@@ -40,7 +40,7 @@ func TestPushMirrorsIterate(t *testing.T) {
 
 	time.Sleep(1 * time.Millisecond)
 
-	PushMirrorsIterate(func(idx int, bean interface{}) error {
+	PushMirrorsIterate(func(_ int, bean interface{}) error {
 		m, ok := bean.(*PushMirror)
 		assert.True(t, ok)
 		assert.Equal(t, "test-1", m.RemoteName)

--- a/models/ssh_key_authorized_keys.go
+++ b/models/ssh_key_authorized_keys.go
@@ -183,7 +183,7 @@ func RegeneratePublicKeys(t io.StringWriter) error {
 }
 
 func regeneratePublicKeys(e db.Engine, t io.StringWriter) error {
-	if err := e.Where("type != ?", KeyTypePrincipal).Iterate(new(PublicKey), func(idx int, bean interface{}) (err error) {
+	if err := e.Where("type != ?", KeyTypePrincipal).Iterate(new(PublicKey), func(_ int, bean interface{}) (err error) {
 		_, err = t.WriteString((bean.(*PublicKey)).AuthorizedString())
 		return err
 	}); err != nil {

--- a/models/ssh_key_authorized_principals.go
+++ b/models/ssh_key_authorized_principals.go
@@ -106,7 +106,7 @@ func RegeneratePrincipalKeys(t io.StringWriter) error {
 }
 
 func regeneratePrincipalKeys(e db.Engine, t io.StringWriter) error {
-	if err := e.Where("type = ?", KeyTypePrincipal).Iterate(new(PublicKey), func(idx int, bean interface{}) (err error) {
+	if err := e.Where("type = ?", KeyTypePrincipal).Iterate(new(PublicKey), func(_ int, bean interface{}) (err error) {
 		_, err = t.WriteString((bean.(*PublicKey)).AuthorizedString())
 		return err
 	}); err != nil {

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -15,6 +15,6 @@ import (
 var Supported = false
 
 // Auth not supported lack of pam tag
-func Auth(serviceName, userName, passwd string) (string, error) {
+func Auth(_, _, _ string) (string, error) {
 	return "", errors.New("PAM not supported")
 }

--- a/modules/avatar/identicon/block.go
+++ b/modules/avatar/identicon/block.go
@@ -41,7 +41,7 @@ func drawBlock(img *image.Paletted, x, y, size int, angle int, points []int) {
 //  |      |
 //  |      |
 //  --------
-func b0(img *image.Paletted, x, y, size int, angle int) {}
+func b0(_ *image.Paletted, _, _, _, _ int) {}
 
 // full-filled
 //
@@ -50,7 +50,7 @@ func b0(img *image.Paletted, x, y, size int, angle int) {}
 //  |######|
 //  |######|
 //  --------
-func b1(img *image.Paletted, x, y, size int, angle int) {
+func b1(img *image.Paletted, x, y, size, _ int) {
 	for i := x; i < x+size; i++ {
 		for j := y; j < y+size; j++ {
 			img.SetColorIndex(i, j, 1)
@@ -65,7 +65,7 @@ func b1(img *image.Paletted, x, y, size int, angle int) {
 //  |  ####  |
 //  |        |
 //  ----------
-func b2(img *image.Paletted, x, y, size int, angle int) {
+func b2(img *image.Paletted, x, y, size, _ int) {
 	l := size / 4
 	x += l
 	y += l
@@ -88,7 +88,7 @@ func b2(img *image.Paletted, x, y, size int, angle int) {
 //  |  ###  |
 //  |   #   |
 //  ---------
-func b3(img *image.Paletted, x, y, size int, angle int) {
+func b3(img *image.Paletted, x, y, size, _ int) {
 	m := size / 2
 	drawBlock(img, x, y, size, 0, []int{
 		m, 0,
@@ -108,7 +108,7 @@ func b3(img *image.Paletted, x, y, size int, angle int) {
 //  |##   |
 //  |#    |
 //  |------
-func b4(img *image.Paletted, x, y, size int, angle int) {
+func b4(img *image.Paletted, x, y, size, angle int) {
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
 		size, 0,
@@ -124,7 +124,7 @@ func b4(img *image.Paletted, x, y, size int, angle int) {
 //  |  ###  |
 //  | ##### |
 //  |#######|
-func b5(img *image.Paletted, x, y, size int, angle int) {
+func b5(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		m, 0,
@@ -141,7 +141,7 @@ func b5(img *image.Paletted, x, y, size int, angle int) {
 //  |###   |
 //  |###   |
 //  --------
-func b6(img *image.Paletted, x, y, size int, angle int) {
+func b6(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
@@ -160,7 +160,7 @@ func b6(img *image.Paletted, x, y, size int, angle int) {
 //  |  #####|
 //  |   ####|
 //  |--------
-func b7(img *image.Paletted, x, y, size int, angle int) {
+func b7(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
@@ -181,7 +181,7 @@ func b7(img *image.Paletted, x, y, size int, angle int) {
 //  | ### ### |
 //  |#########|
 //  -----------
-func b8(img *image.Paletted, x, y, size int, angle int) {
+func b8(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	mm := m / 2
 
@@ -219,7 +219,7 @@ func b8(img *image.Paletted, x, y, size int, angle int) {
 //  |  #### |
 //  |   #   |
 //  ---------
-func b9(img *image.Paletted, x, y, size int, angle int) {
+func b9(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
@@ -241,7 +241,7 @@ func b9(img *image.Paletted, x, y, size int, angle int) {
 //  |##      |
 //  |#       |
 //  ----------
-func b10(img *image.Paletted, x, y, size int, angle int) {
+func b10(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		m, 0,
@@ -267,7 +267,7 @@ func b10(img *image.Paletted, x, y, size int, angle int) {
 //  |        |
 //  |        |
 //  ----------
-func b11(img *image.Paletted, x, y, size int, angle int) {
+func b11(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
@@ -287,7 +287,7 @@ func b11(img *image.Paletted, x, y, size int, angle int) {
 //  |  #####  |
 //  |    #    |
 //  -----------
-func b12(img *image.Paletted, x, y, size int, angle int) {
+func b12(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, m,
@@ -306,7 +306,7 @@ func b12(img *image.Paletted, x, y, size int, angle int) {
 //  |  #####  |
 //  |#########|
 //  -----------
-func b13(img *image.Paletted, x, y, size int, angle int) {
+func b13(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		m, m,
@@ -325,7 +325,7 @@ func b13(img *image.Paletted, x, y, size int, angle int) {
 //  |       |
 //  |       |
 //  ---------
-func b14(img *image.Paletted, x, y, size int, angle int) {
+func b14(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		m, 0,
@@ -344,7 +344,7 @@ func b14(img *image.Paletted, x, y, size int, angle int) {
 //  |        |
 //  |        |
 //  ----------
-func b15(img *image.Paletted, x, y, size int, angle int) {
+func b15(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		0, 0,
@@ -364,7 +364,7 @@ func b15(img *image.Paletted, x, y, size int, angle int) {
 //  | ##### |
 //  |#######|
 //  ---------
-func b16(img *image.Paletted, x, y, size int, angle int) {
+func b16(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	drawBlock(img, x, y, size, angle, []int{
 		m, 0,
@@ -390,7 +390,7 @@ func b16(img *image.Paletted, x, y, size int, angle int) {
 //  |      ##|
 //  |      ##|
 //  ----------
-func b17(img *image.Paletted, x, y, size int, angle int) {
+func b17(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 
 	drawBlock(img, x, y, size, angle, []int{
@@ -419,7 +419,7 @@ func b17(img *image.Paletted, x, y, size int, angle int) {
 //  |##      |
 //  |#       |
 //  ----------
-func b18(img *image.Paletted, x, y, size int, angle int) {
+func b18(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 
 	drawBlock(img, x, y, size, angle, []int{
@@ -439,7 +439,7 @@ func b18(img *image.Paletted, x, y, size int, angle int) {
 //  |###  ###|
 //  |########|
 //  ----------
-func b19(img *image.Paletted, x, y, size int, angle int) {
+func b19(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 
 	drawBlock(img, x, y, size, angle, []int{
@@ -480,7 +480,7 @@ func b19(img *image.Paletted, x, y, size int, angle int) {
 //  |##       |
 //  |#        |
 //  ----------
-func b20(img *image.Paletted, x, y, size int, angle int) {
+func b20(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -501,7 +501,7 @@ func b20(img *image.Paletted, x, y, size int, angle int) {
 //  |##      |
 //  |#       |
 //  ----------
-func b21(img *image.Paletted, x, y, size int, angle int) {
+func b21(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -529,7 +529,7 @@ func b21(img *image.Paletted, x, y, size int, angle int) {
 //  |##    ##|
 //  |#      #|
 //  ----------
-func b22(img *image.Paletted, x, y, size int, angle int) {
+func b22(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -557,7 +557,7 @@ func b22(img *image.Paletted, x, y, size int, angle int) {
 //  |##      |
 //  |#       |
 //  ----------
-func b23(img *image.Paletted, x, y, size int, angle int) {
+func b23(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -585,7 +585,7 @@ func b23(img *image.Paletted, x, y, size int, angle int) {
 //  |##  ##  |
 //  |#   #   |
 //  ----------
-func b24(img *image.Paletted, x, y, size int, angle int) {
+func b24(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -613,7 +613,7 @@ func b24(img *image.Paletted, x, y, size int, angle int) {
 //  |######  |
 //  |####    |
 //  ----------
-func b25(img *image.Paletted, x, y, size int, angle int) {
+func b25(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -641,7 +641,7 @@ func b25(img *image.Paletted, x, y, size int, angle int) {
 //  |###  ###|
 //  |#      #|
 //  ----------
-func b26(img *image.Paletted, x, y, size int, angle int) {
+func b26(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 
@@ -683,7 +683,7 @@ func b26(img *image.Paletted, x, y, size int, angle int) {
 //  |###   ##|
 //  |########|
 //  ----------
-func b27(img *image.Paletted, x, y, size int, angle int) {
+func b27(img *image.Paletted, x, y, size, angle int) {
 	m := size / 2
 	q := size / 4
 

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -156,7 +156,7 @@ func (r *Repository) CanUseTimetracker(issue *models.Issue, user *user_model.Use
 }
 
 // CanCreateIssueDependencies returns whether or not a user can create dependencies.
-func (r *Repository) CanCreateIssueDependencies(user *user_model.User, isPull bool) bool {
+func (r *Repository) CanCreateIssueDependencies(isPull bool) bool {
 	return r.Repository.IsDependenciesEnabled() && r.Permission.CanWriteIssuesOrPulls(isPull)
 }
 

--- a/modules/csv/csv_test.go
+++ b/modules/csv/csv_test.go
@@ -100,7 +100,7 @@ j, ,
 
 type mockReader struct{}
 
-func (r *mockReader) Read(buf []byte) (int, error) {
+func (r *mockReader) Read(_ []byte) (int, error) {
 	return 0, io.ErrShortBuffer
 }
 

--- a/modules/doctor/fix16961.go
+++ b/modules/doctor/fix16961.go
@@ -271,7 +271,7 @@ func fixBrokenRepoUnits16961(logger log.Logger, autofix bool) error {
 		builder.Gt{
 			"id": 0,
 		},
-		func(idx int, bean interface{}) error {
+		func(_ int, bean interface{}) error {
 			unit := bean.(*RepoUnit)
 
 			bs := unit.Config

--- a/modules/doctor/misc.go
+++ b/modules/doctor/misc.go
@@ -37,7 +37,7 @@ func iterateRepositories(each func(*models.Repository) error) error {
 	return err
 }
 
-func checkScriptType(logger log.Logger, autofix bool) error {
+func checkScriptType(logger log.Logger, _ bool) error {
 	path, err := exec.LookPath(setting.ScriptType)
 	if err != nil {
 		logger.Critical("ScriptType \"%q\" is not on the current PATH. Error: %v", setting.ScriptType, err)
@@ -72,7 +72,7 @@ func checkHooks(logger log.Logger, autofix bool) error {
 	return nil
 }
 
-func checkUserStarNum(logger log.Logger, autofix bool) error {
+func checkUserStarNum(logger log.Logger, _ bool) error {
 	if err := models.DoctorUserStarNum(); err != nil {
 		logger.Critical("Unable update User Stars numbers")
 		return err

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -31,7 +31,7 @@ func (tes Entries) GetCommitsInfo(ctx context.Context, commit *Commit, treePath 
 	var revs map[string]*Commit
 	if cache != nil {
 		var unHitPaths []string
-		revs, unHitPaths, err = getLastCommitForPathsByCache(ctx, commit.ID.String(), treePath, entryPaths, cache)
+		revs, unHitPaths, err = getLastCommitForPathsByCache(commit.ID.String(), treePath, entryPaths, cache)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -99,7 +99,7 @@ func (tes Entries) GetCommitsInfo(ctx context.Context, commit *Commit, treePath 
 	return commitsInfo, treeCommit, nil
 }
 
-func getLastCommitForPathsByCache(ctx context.Context, commitID, treePath string, paths []string, cache *LastCommitCache) (map[string]*Commit, []string, error) {
+func getLastCommitForPathsByCache(commitID, treePath string, paths []string, cache *LastCommitCache) (map[string]*Commit, []string, error) {
 	wr, rd, cancel := cache.repo.CatFileBatch()
 	defer cancel()
 

--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -293,7 +293,7 @@ func GetAffectedFiles(oldCommitID, newCommitID string, env []string, repo *Repos
 	err = NewCommand("diff", "--name-only", oldCommitID, newCommitID).
 		RunInDirTimeoutEnvFullPipelineFunc(env, -1, repo.Path,
 			stdoutWriter, nil, nil,
-			func(ctx context.Context, cancel context.CancelFunc) error {
+			func(_ context.Context, _ context.CancelFunc) error {
 				// Close the writer end of the pipe to begin processing
 				_ = stdoutWriter.Close()
 				defer func() {

--- a/modules/git/repo_blame.go
+++ b/modules/git/repo_blame.go
@@ -6,11 +6,6 @@ package git
 
 import "fmt"
 
-// FileBlame return the Blame object of file
-func (repo *Repository) FileBlame(revision, path, file string) ([]byte, error) {
-	return NewCommand("blame", "--root", "--", file).RunInDirBytes(path)
-}
-
 // LineBlame returns the latest commit at the given line
 func (repo *Repository) LineBlame(revision, path, file string, line uint) (*Commit, error) {
 	res, err := NewCommand("blame", fmt.Sprintf("-L %d,%d", line, line), "-p", revision, "--", file).RunInDir(path)

--- a/modules/git/repo_stats.go
+++ b/modules/git/repo_stats.go
@@ -70,7 +70,7 @@ func (repo *Repository) GetCodeActivityStats(fromTime time.Time, branch string) 
 	err = NewCommand(args...).RunInDirTimeoutEnvFullPipelineFunc(
 		nil, -1, repo.Path,
 		stdoutWriter, stderr, nil,
-		func(ctx context.Context, cancel context.CancelFunc) error {
+		func(_ context.Context, _ context.CancelFunc) error {
 			_ = stdoutWriter.Close()
 
 			scanner := bufio.NewScanner(stdoutReader)

--- a/modules/graceful/context.go
+++ b/modules/graceful/context.go
@@ -47,7 +47,7 @@ func (ctx *ChannelContext) Err() error {
 }
 
 // Value returns nil for all calls as no values are or can be associated with this context
-func (ctx *ChannelContext) Value(key interface{}) interface{} {
+func (ctx *ChannelContext) Value(_ interface{}) interface{} {
 	return nil
 }
 

--- a/modules/indexer/issues/db.go
+++ b/modules/indexer/issues/db.go
@@ -16,12 +16,12 @@ func (db *DBIndexer) Init() (bool, error) {
 }
 
 // Index dummy function
-func (db *DBIndexer) Index(issue []*IndexerData) error {
+func (db *DBIndexer) Index(_ []*IndexerData) error {
 	return nil
 }
 
 // Delete dummy function
-func (db *DBIndexer) Delete(ids ...int64) error {
+func (db *DBIndexer) Delete(_ ...int64) error {
 	return nil
 }
 

--- a/modules/indexer/issues/indexer.go
+++ b/modules/indexer/issues/indexer.go
@@ -171,7 +171,7 @@ func InitIssueIndexer(syncReindex bool) {
 			})
 			log.Debug("Created Bleve Indexer")
 		case "elasticsearch":
-			graceful.GetManager().RunWithShutdownFns(func(_, atTerminate func(func())) {
+			graceful.GetManager().RunWithShutdownFns(func(_, _ func(func())) {
 				issueIndexer, err := NewElasticSearchIndexer(setting.Indexer.IssueConnStr, setting.Indexer.IssueIndexerName)
 				if err != nil {
 					log.Fatal("Unable to initialize Elastic Search Issue Indexer at connection: %s Error: %v", setting.Indexer.IssueConnStr, err)

--- a/modules/lfs/filesystem_client.go
+++ b/modules/lfs/filesystem_client.go
@@ -39,7 +39,7 @@ func (c *FilesystemClient) objectPath(oid string) string {
 }
 
 // Download reads the specific LFS object from the target path
-func (c *FilesystemClient) Download(ctx context.Context, objects []Pointer, callback DownloadCallback) error {
+func (c *FilesystemClient) Download(_ context.Context, objects []Pointer, callback DownloadCallback) error {
 	for _, object := range objects {
 		p := Pointer{object.Oid, object.Size}
 
@@ -58,7 +58,7 @@ func (c *FilesystemClient) Download(ctx context.Context, objects []Pointer, call
 }
 
 // Upload writes the specific LFS object to the target path
-func (c *FilesystemClient) Upload(ctx context.Context, objects []Pointer, callback UploadCallback) error {
+func (c *FilesystemClient) Upload(_ context.Context, objects []Pointer, callback UploadCallback) error {
 	for _, object := range objects {
 		p := Pointer{object.Oid, object.Size}
 

--- a/modules/lfs/http_client_test.go
+++ b/modules/lfs/http_client_test.go
@@ -30,15 +30,15 @@ func (a *DummyTransferAdapter) Name() string {
 	return "dummy"
 }
 
-func (a *DummyTransferAdapter) Download(ctx context.Context, l *Link) (io.ReadCloser, error) {
+func (a *DummyTransferAdapter) Download(_ context.Context, _ *Link) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewBufferString("dummy")), nil
 }
 
-func (a *DummyTransferAdapter) Upload(ctx context.Context, l *Link, p Pointer, r io.Reader) error {
+func (a *DummyTransferAdapter) Upload(_ context.Context, _ *Link, _ Pointer, _ io.Reader) error {
 	return nil
 }
 
-func (a *DummyTransferAdapter) Verify(ctx context.Context, l *Link, p Pointer) error {
+func (a *DummyTransferAdapter) Verify(_ context.Context, _ *Link, _ Pointer) error {
 	return nil
 }
 
@@ -241,7 +241,7 @@ func TestHTTPClientDownload(t *testing.T) {
 		}
 		client.transfers["dummy"] = dummy
 
-		err := client.Download(context.Background(), []Pointer{p}, func(p Pointer, content io.ReadCloser, objectError error) error {
+		err := client.Download(context.Background(), []Pointer{p}, func(_ Pointer, content io.ReadCloser, objectError error) error {
 			if objectError != nil {
 				return objectError
 			}

--- a/modules/log/conn_test.go
+++ b/modules/log/conn_test.go
@@ -103,7 +103,7 @@ func TestConnLoggerBadConfig(t *testing.T) {
 	logger.Close()
 }
 
-func TestConnLoggerCloseBeforeSend(t *testing.T) {
+func TestConnLoggerCloseBeforeSend(_ *testing.T) {
 	protocol := "tcp"
 	address := ":3099"
 

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -225,7 +225,7 @@ func compressOldLogFile(fname string, compressionLevel int) error {
 
 func (log *FileLogger) deleteOldLog() {
 	dir := filepath.Dir(log.Filename)
-	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) (returnErr error) {
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, _ error) (returnErr error) {
 		defer func() {
 			if r := recover(); r != nil {
 				returnErr = fmt.Errorf("Unable to delete old log '%s', error: %+v", path, r)

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -195,7 +195,7 @@ func IsFatal() bool {
 
 // Pause pauses all the loggers
 func Pause() {
-	NamedLoggers.Range(func(key, value interface{}) bool {
+	NamedLoggers.Range(func(_, value interface{}) bool {
 		logger := value.(*MultiChannelledLogger)
 		logger.Pause()
 		logger.Flush()
@@ -205,7 +205,7 @@ func Pause() {
 
 // Resume resumes all the loggers
 func Resume() {
-	NamedLoggers.Range(func(key, value interface{}) bool {
+	NamedLoggers.Range(func(_, value interface{}) bool {
 		logger := value.(*MultiChannelledLogger)
 		logger.Resume()
 		return true

--- a/modules/log/smtp_test.go
+++ b/modules/log/smtp_test.go
@@ -56,7 +56,7 @@ func TestSMTPLogger(t *testing.T) {
 	var envFrom string
 	var envTo []string
 	var envMsg []byte
-	smtpLogger.sendMailFn = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+	smtpLogger.sendMailFn = func(addr string, _ smtp.Auth, from string, to []string, msg []byte) error {
 		envToHost = addr
 		envFrom = from
 		envTo = to

--- a/modules/log/writer_test.go
+++ b/modules/log/writer_test.go
@@ -257,7 +257,7 @@ func TestBrokenRegexp(t *testing.T) {
 	var closed bool
 
 	c := CallbackWriteCloser{
-		callback: func(p []byte, close bool) {
+		callback: func(_ []byte, close bool) {
 			closed = close
 		},
 	}

--- a/modules/markup/common/footnote.go
+++ b/modules/markup/common/footnote.go
@@ -194,7 +194,7 @@ func (b *footnoteBlockParser) Trigger() []byte {
 	return []byte{'['}
 }
 
-func (b *footnoteBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+func (b *footnoteBlockParser) Open(_ ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
 	line, segment := reader.PeekLine()
 	pos := pc.BlockOffset()
 	if pos < 0 || line[pos] != '[' {
@@ -232,7 +232,7 @@ func (b *footnoteBlockParser) Open(parent ast.Node, reader text.Reader, pc parse
 	return item, parser.HasChildren
 }
 
-func (b *footnoteBlockParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+func (b *footnoteBlockParser) Continue(_ ast.Node, reader text.Reader, _ parser.Context) parser.State {
 	line, _ := reader.PeekLine()
 	if util.IsBlank(line) {
 		return parser.Continue | parser.HasChildren
@@ -245,7 +245,7 @@ func (b *footnoteBlockParser) Continue(node ast.Node, reader text.Reader, pc par
 	return parser.Continue | parser.HasChildren
 }
 
-func (b *footnoteBlockParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+func (b *footnoteBlockParser) Close(node ast.Node, _ text.Reader, pc parser.Context) {
 	var list *FootnoteList
 	if tlist := pc.Get(footnoteListKey); tlist != nil {
 		list = tlist.(*FootnoteList)
@@ -283,7 +283,7 @@ func (s *footnoteParser) Trigger() []byte {
 	return []byte{'!', '['}
 }
 
-func (s *footnoteParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+func (s *footnoteParser) Parse(_ ast.Node, block text.Reader, pc parser.Context) ast.Node {
 	line, segment := block.PeekLine()
 	pos := 1
 	if len(line) > 0 && line[0] == '!' {
@@ -349,7 +349,7 @@ func NewFootnoteASTTransformer() parser.ASTTransformer {
 	return defaultFootnoteASTTransformer
 }
 
-func (a *footnoteASTTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
+func (a *footnoteASTTransformer) Transform(node *ast.Document, _ text.Reader, pc parser.Context) {
 	var list *FootnoteList
 	if tlist := pc.Get(footnoteListKey); tlist != nil {
 		list = tlist.(*FootnoteList)
@@ -458,7 +458,7 @@ func (r *FootnoteHTMLRenderer) renderFootnote(w util.BufWriter, source []byte, n
 	return ast.WalkContinue, nil
 }
 
-func (r *FootnoteHTMLRenderer) renderFootnoteList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *FootnoteHTMLRenderer) renderFootnoteList(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	tag := "div"
 	if entering {
 		_, _ = w.WriteString("<")

--- a/modules/markup/common/linkify.go
+++ b/modules/markup/common/linkify.go
@@ -135,7 +135,7 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 	return link
 }
 
-func (s *linkifyParser) CloseBlock(parent ast.Node, pc parser.Context) {
+func (s *linkifyParser) CloseBlock(_ ast.Node, _ parser.Context) {
 	// nothing to do
 }
 

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -853,7 +853,7 @@ func issueIndexPatternProcessor(ctx *RenderContext, node *html.Node) {
 
 		// Decorate action keywords if actionable
 		var keyword *html.Node
-		if references.IsXrefActionable(ref, exttrack, alphanum) {
+		if references.IsXrefActionable(ref, exttrack) {
 			keyword = createKeyword(node.Data[ref.ActionLocation.Start:ref.ActionLocation.End])
 		} else {
 			keyword = &html.Node{
@@ -927,7 +927,7 @@ func fullSha1PatternProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 // emojiShortCodeProcessor for rendering text like :smile: into emoji
-func emojiShortCodeProcessor(ctx *RenderContext, node *html.Node) {
+func emojiShortCodeProcessor(_ *RenderContext, node *html.Node) {
 	start := 0
 	next := node.NextSibling
 	for node != nil && node != next && start < len(node.Data) {
@@ -961,7 +961,7 @@ func emojiShortCodeProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 // emoji processor to match emoji and add emoji class
-func emojiProcessor(ctx *RenderContext, node *html.Node) {
+func emojiProcessor(_ *RenderContext, node *html.Node) {
 	start := 0
 	next := node.NextSibling
 	for node != nil && node != next && start < len(node.Data) {
@@ -1046,7 +1046,7 @@ func sha1CurrentPatternProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 // emailAddressProcessor replaces raw email addresses with a mailto: link.
-func emailAddressProcessor(ctx *RenderContext, node *html.Node) {
+func emailAddressProcessor(_ *RenderContext, node *html.Node) {
 	next := node.NextSibling
 	for node != nil && node != next {
 		m := emailRegex.FindStringSubmatchIndex(node.Data)
@@ -1062,7 +1062,7 @@ func emailAddressProcessor(ctx *RenderContext, node *html.Node) {
 
 // linkProcessor creates links for any HTTP or HTTPS URL not captured by
 // markdown.
-func linkProcessor(ctx *RenderContext, node *html.Node) {
+func linkProcessor(_ *RenderContext, node *html.Node) {
 	next := node.NextSibling
 	for node != nil && node != next {
 		m := common.LinkRegex.FindStringIndex(node.Data)
@@ -1077,7 +1077,7 @@ func linkProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 func genDefaultLinkProcessor(defaultLink string) processor {
-	return func(ctx *RenderContext, node *html.Node) {
+	return func(_ *RenderContext, node *html.Node) {
 		ch := &html.Node{
 			Parent: node,
 			Type:   html.TextNode,
@@ -1096,7 +1096,7 @@ func genDefaultLinkProcessor(defaultLink string) processor {
 }
 
 // descriptionLinkProcessor creates links for DescriptionHTML
-func descriptionLinkProcessor(ctx *RenderContext, node *html.Node) {
+func descriptionLinkProcessor(_ *RenderContext, node *html.Node) {
 	next := node.NextSibling
 	for node != nil && node != next {
 		m := common.LinkRegex.FindStringIndex(node.Data)

--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -289,7 +289,7 @@ func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(east.KindTaskCheckBox, r.renderTaskCheckBox)
 }
 
-func (r *HTMLRenderer) renderDocument(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderDocument(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.Document)
 
 	if val, has := n.AttributeString("lang"); has {
@@ -314,7 +314,7 @@ func (r *HTMLRenderer) renderDocument(w util.BufWriter, source []byte, node ast.
 	return ast.WalkContinue, nil
 }
 
-func (r *HTMLRenderer) renderDetails(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderDetails(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
 	var err error
 	if entering {
 		_, err = w.WriteString("<details>")
@@ -329,7 +329,7 @@ func (r *HTMLRenderer) renderDetails(w util.BufWriter, source []byte, node ast.N
 	return ast.WalkContinue, nil
 }
 
-func (r *HTMLRenderer) renderSummary(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderSummary(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
 	var err error
 	if entering {
 		_, err = w.WriteString("<summary>")
@@ -346,7 +346,7 @@ func (r *HTMLRenderer) renderSummary(w util.BufWriter, source []byte, node ast.N
 
 var validNameRE = regexp.MustCompile("^[a-z ]+$")
 
-func (r *HTMLRenderer) renderIcon(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderIcon(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
 		return ast.WalkContinue, nil
 	}
@@ -375,7 +375,7 @@ func (r *HTMLRenderer) renderIcon(w util.BufWriter, source []byte, node ast.Node
 	return ast.WalkContinue, nil
 }
 
-func (r *HTMLRenderer) renderTaskCheckBoxListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderTaskCheckBoxListItem(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*TaskCheckBoxListItem)
 	if entering {
 		if n.Attributes() != nil {
@@ -411,6 +411,6 @@ func (r *HTMLRenderer) renderTaskCheckBoxListItem(w util.BufWriter, source []byt
 	return ast.WalkContinue, nil
 }
 
-func (r *HTMLRenderer) renderTaskCheckBox(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *HTMLRenderer) renderTaskCheckBox(_ util.BufWriter, _ []byte, _ ast.Node, _ bool) (ast.WalkStatus, error) {
 	return ast.WalkContinue, nil
 }

--- a/modules/markup/mdstripper/mdstripper.go
+++ b/modules/markup/mdstripper/mdstripper.go
@@ -55,7 +55,7 @@ func (r *stripRenderer) Render(w io.Writer, source []byte, doc ast.Node) error {
 			}
 			return ast.WalkContinue, nil
 		case *ast.Link:
-			r.processLink(w, v.Destination)
+			r.processLink(v.Destination)
 			return ast.WalkSkipChildren, nil
 		case *ast.AutoLink:
 			// This could be a reference to an issue or pull - if so convert it
@@ -125,7 +125,7 @@ func (r *stripRenderer) processAutoLink(w io.Writer, link []byte) {
 	_, _ = w.Write([]byte(parts[4]))
 }
 
-func (r *stripRenderer) processLink(w io.Writer, link []byte) {
+func (r *stripRenderer) processLink(link []byte) {
 	// Links are processed out of band
 	r.links = append(r.links, string(link))
 }

--- a/modules/migration/null_downloader.go
+++ b/modules/migration/null_downloader.go
@@ -46,7 +46,7 @@ func (n NullDownloader) GetLabels() ([]*Label, error) {
 }
 
 // GetIssues returns issues according start and limit
-func (n NullDownloader) GetIssues(page, perPage int) ([]*Issue, bool, error) {
+func (n NullDownloader) GetIssues(_, _ int) ([]*Issue, bool, error) {
 	return nil, false, &ErrNotSupported{Entity: "Issues"}
 }
 
@@ -56,12 +56,12 @@ func (n NullDownloader) GetComments(GetCommentOptions) ([]*Comment, bool, error)
 }
 
 // GetPullRequests returns pull requests according page and perPage
-func (n NullDownloader) GetPullRequests(page, perPage int) ([]*PullRequest, bool, error) {
+func (n NullDownloader) GetPullRequests(_, _ int) ([]*PullRequest, bool, error) {
 	return nil, false, &ErrNotSupported{Entity: "PullRequests"}
 }
 
 // GetReviews returns pull requests review
-func (n NullDownloader) GetReviews(pullRequestContext IssueContext) ([]*Review, error) {
+func (n NullDownloader) GetReviews(_ IssueContext) ([]*Review, error) {
 	return nil, &ErrNotSupported{Entity: "Reviews"}
 }
 

--- a/modules/notification/action/action.go
+++ b/modules/notification/action/action.go
@@ -30,7 +30,7 @@ func NewNotifier() base.Notifier {
 	return &actionNotifier{}
 }
 
-func (a *actionNotifier) NotifyNewIssue(issue *models.Issue, mentions []*user_model.User) {
+func (a *actionNotifier) NotifyNewIssue(issue *models.Issue, _ []*user_model.User) {
 	if err := issue.LoadPoster(); err != nil {
 		log.Error("issue.LoadPoster: %v", err)
 		return
@@ -89,12 +89,12 @@ func (a *actionNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *m
 
 // NotifyCreateIssueComment notifies comment on an issue to notifiers
 func (a *actionNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *models.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, _ []*user_model.User) {
 	act := &models.Action{
 		ActUserID: doer.ID,
 		ActUser:   doer,
-		RepoID:    issue.Repo.ID,
-		Repo:      issue.Repo,
+		RepoID:    repo.ID,
+		Repo:      repo,
 		Comment:   comment,
 		CommentID: comment.ID,
 		IsPrivate: issue.Repo.IsPrivate,
@@ -121,7 +121,7 @@ func (a *actionNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *m
 	}
 }
 
-func (a *actionNotifier) NotifyNewPullRequest(pull *models.PullRequest, mentions []*user_model.User) {
+func (a *actionNotifier) NotifyNewPullRequest(pull *models.PullRequest, _ []*user_model.User) {
 	if err := pull.LoadIssue(); err != nil {
 		log.Error("pull.LoadIssue: %v", err)
 		return
@@ -178,7 +178,7 @@ func (a *actionNotifier) NotifyTransferRepository(doer *user_model.User, repo *m
 	}
 }
 
-func (a *actionNotifier) NotifyCreateRepository(doer *user_model.User, u *user_model.User, repo *models.Repository) {
+func (a *actionNotifier) NotifyCreateRepository(doer *user_model.User, _ *user_model.User, repo *models.Repository) {
 	if err := models.NotifyWatchers(&models.Action{
 		ActUserID: doer.ID,
 		ActUser:   doer,
@@ -191,10 +191,11 @@ func (a *actionNotifier) NotifyCreateRepository(doer *user_model.User, u *user_m
 	}
 }
 
-func (a *actionNotifier) NotifyForkRepository(doer *user_model.User, oldRepo, repo *models.Repository) {
+func (a *actionNotifier) NotifyForkRepository(doer *user_model.User, _, repo *models.Repository) {
 	if err := models.NotifyWatchers(&models.Action{
 		ActUserID: doer.ID,
 		ActUser:   doer,
+		// TODO: Create ActionForkRepo
 		OpType:    models.ActionCreateRepo,
 		RepoID:    repo.ID,
 		Repo:      repo,
@@ -204,7 +205,7 @@ func (a *actionNotifier) NotifyForkRepository(doer *user_model.User, oldRepo, re
 	}
 }
 
-func (a *actionNotifier) NotifyPullRequestReview(pr *models.PullRequest, review *models.Review, comment *models.Comment, mentions []*user_model.User) {
+func (a *actionNotifier) NotifyPullRequestReview(_ *models.PullRequest, review *models.Review, comment *models.Comment, _ []*user_model.User) {
 	if err := review.LoadReviewer(); err != nil {
 		log.Error("LoadReviewer '%d/%d': %v", review.ID, review.ReviewerID, err)
 		return
@@ -375,8 +376,8 @@ func (a *actionNotifier) NotifySyncPushCommits(pusher *user_model.User, repo *mo
 	}
 
 	if err := models.NotifyWatchers(&models.Action{
-		ActUserID: repo.OwnerID,
-		ActUser:   repo.MustOwner(),
+		ActUserID: pusher.ID,
+		ActUser:   pusher,
 		OpType:    models.ActionMirrorSyncPush,
 		RepoID:    repo.ID,
 		Repo:      repo,
@@ -388,10 +389,10 @@ func (a *actionNotifier) NotifySyncPushCommits(pusher *user_model.User, repo *mo
 	}
 }
 
-func (a *actionNotifier) NotifySyncCreateRef(doer *user_model.User, repo *models.Repository, refType, refFullName string) {
+func (a *actionNotifier) NotifySyncCreateRef(doer *user_model.User, repo *models.Repository, _, refFullName string) {
 	if err := models.NotifyWatchers(&models.Action{
-		ActUserID: repo.OwnerID,
-		ActUser:   repo.MustOwner(),
+		ActUserID: doer.ID,
+		ActUser:   doer,
 		OpType:    models.ActionMirrorSyncCreate,
 		RepoID:    repo.ID,
 		Repo:      repo,
@@ -402,10 +403,10 @@ func (a *actionNotifier) NotifySyncCreateRef(doer *user_model.User, repo *models
 	}
 }
 
-func (a *actionNotifier) NotifySyncDeleteRef(doer *user_model.User, repo *models.Repository, refType, refFullName string) {
+func (a *actionNotifier) NotifySyncDeleteRef(doer *user_model.User, repo *models.Repository, _, refFullName string) {
 	if err := models.NotifyWatchers(&models.Action{
-		ActUserID: repo.OwnerID,
-		ActUser:   repo.MustOwner(),
+		ActUserID: doer.ID,
+		ActUser:   doer,
 		OpType:    models.ActionMirrorSyncDelete,
 		RepoID:    repo.ID,
 		Repo:      repo,

--- a/modules/notification/base/null.go
+++ b/modules/notification/base/null.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//revive:disable:unused-parameter A lot of "reference" implementation.
+
 package base
 
 import (

--- a/modules/notification/indexer/indexer.go
+++ b/modules/notification/indexer/indexer.go
@@ -30,8 +30,8 @@ func NewNotifier() base.Notifier {
 	return &indexerNotifier{}
 }
 
-func (r *indexerNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *models.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+func (r *indexerNotifier) NotifyCreateIssueComment(_ *user_model.User, _ *models.Repository,
+	issue *models.Issue, comment *models.Comment, _ []*user_model.User) {
 	if comment.Type == models.CommentTypeComment {
 		if issue.Comments == nil {
 			if err := issue.LoadDiscussComments(); err != nil {
@@ -46,15 +46,15 @@ func (r *indexerNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *
 	}
 }
 
-func (r *indexerNotifier) NotifyNewIssue(issue *models.Issue, mentions []*user_model.User) {
+func (r *indexerNotifier) NotifyNewIssue(issue *models.Issue, _ []*user_model.User) {
 	issue_indexer.UpdateIssueIndexer(issue)
 }
 
-func (r *indexerNotifier) NotifyNewPullRequest(pr *models.PullRequest, mentions []*user_model.User) {
+func (r *indexerNotifier) NotifyNewPullRequest(pr *models.PullRequest, _ []*user_model.User) {
 	issue_indexer.UpdateIssueIndexer(pr.Issue)
 }
 
-func (r *indexerNotifier) NotifyUpdateComment(doer *user_model.User, c *models.Comment, oldContent string) {
+func (r *indexerNotifier) NotifyUpdateComment(_ *user_model.User, c *models.Comment, _ string) {
 	if c.Type == models.CommentTypeComment {
 		var found bool
 		if c.Issue.Comments != nil {
@@ -78,7 +78,7 @@ func (r *indexerNotifier) NotifyUpdateComment(doer *user_model.User, c *models.C
 	}
 }
 
-func (r *indexerNotifier) NotifyDeleteComment(doer *user_model.User, comment *models.Comment) {
+func (r *indexerNotifier) NotifyDeleteComment(_ *user_model.User, comment *models.Comment) {
 	if comment.Type == models.CommentTypeComment {
 		if err := comment.LoadIssue(); err != nil {
 			log.Error("LoadIssue: %v", err)
@@ -107,14 +107,14 @@ func (r *indexerNotifier) NotifyDeleteComment(doer *user_model.User, comment *mo
 	}
 }
 
-func (r *indexerNotifier) NotifyDeleteRepository(doer *user_model.User, repo *models.Repository) {
+func (r *indexerNotifier) NotifyDeleteRepository(_ *user_model.User, repo *models.Repository) {
 	issue_indexer.DeleteRepoIssueIndexer(repo)
 	if setting.Indexer.RepoIndexerEnabled {
 		code_indexer.UpdateRepoIndexer(repo)
 	}
 }
 
-func (r *indexerNotifier) NotifyMigrateRepository(doer *user_model.User, u *user_model.User, repo *models.Repository) {
+func (r *indexerNotifier) NotifyMigrateRepository(_ *user_model.User, _ *user_model.User, repo *models.Repository) {
 	issue_indexer.UpdateRepoIndexer(repo)
 	if setting.Indexer.RepoIndexerEnabled && !repo.IsEmpty {
 		code_indexer.UpdateRepoIndexer(repo)
@@ -124,7 +124,7 @@ func (r *indexerNotifier) NotifyMigrateRepository(doer *user_model.User, u *user
 	}
 }
 
-func (r *indexerNotifier) NotifyPushCommits(pusher *user_model.User, repo *models.Repository, opts *repository.PushUpdateOptions, commits *repository.PushCommits) {
+func (r *indexerNotifier) NotifyPushCommits(_ *user_model.User, repo *models.Repository, opts *repository.PushUpdateOptions, _ *repository.PushCommits) {
 	if setting.Indexer.RepoIndexerEnabled && opts.RefFullName == git.BranchPrefix+repo.DefaultBranch {
 		code_indexer.UpdateRepoIndexer(repo)
 	}
@@ -133,7 +133,7 @@ func (r *indexerNotifier) NotifyPushCommits(pusher *user_model.User, repo *model
 	}
 }
 
-func (r *indexerNotifier) NotifySyncPushCommits(pusher *user_model.User, repo *models.Repository, opts *repository.PushUpdateOptions, commits *repository.PushCommits) {
+func (r *indexerNotifier) NotifySyncPushCommits(_ *user_model.User, repo *models.Repository, opts *repository.PushUpdateOptions, _ *repository.PushCommits) {
 	if setting.Indexer.RepoIndexerEnabled && opts.RefFullName == git.BranchPrefix+repo.DefaultBranch {
 		code_indexer.UpdateRepoIndexer(repo)
 	}
@@ -142,14 +142,14 @@ func (r *indexerNotifier) NotifySyncPushCommits(pusher *user_model.User, repo *m
 	}
 }
 
-func (r *indexerNotifier) NotifyIssueChangeContent(doer *user_model.User, issue *models.Issue, oldContent string) {
+func (r *indexerNotifier) NotifyIssueChangeContent(_ *user_model.User, issue *models.Issue, _ string) {
 	issue_indexer.UpdateIssueIndexer(issue)
 }
 
-func (r *indexerNotifier) NotifyIssueChangeTitle(doer *user_model.User, issue *models.Issue, oldTitle string) {
+func (r *indexerNotifier) NotifyIssueChangeTitle(_ *user_model.User, issue *models.Issue, _ string) {
 	issue_indexer.UpdateIssueIndexer(issue)
 }
 
-func (r *indexerNotifier) NotifyIssueChangeRef(doer *user_model.User, issue *models.Issue, oldRef string) {
+func (r *indexerNotifier) NotifyIssueChangeRef(_ *user_model.User, issue *models.Issue, _ string) {
 	issue_indexer.UpdateIssueIndexer(issue)
 }

--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -27,7 +27,7 @@ func NewNotifier() base.Notifier {
 	return &mailNotifier{}
 }
 
-func (m *mailNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *models.Repository,
+func (m *mailNotifier) NotifyCreateIssueComment(_ *user_model.User, _ *models.Repository,
 	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
 	var act models.ActionType
 	if comment.Type == models.CommentTypeClose {
@@ -53,7 +53,7 @@ func (m *mailNotifier) NotifyNewIssue(issue *models.Issue, mentions []*user_mode
 	}
 }
 
-func (m *mailNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, actionComment *models.Comment, isClosed bool) {
+func (m *mailNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, _ *models.Comment, isClosed bool) {
 	var actionType models.ActionType
 	if issue.IsPull {
 		if isClosed {
@@ -92,7 +92,7 @@ func (m *mailNotifier) NotifyNewPullRequest(pr *models.PullRequest, mentions []*
 	}
 }
 
-func (m *mailNotifier) NotifyPullRequestReview(pr *models.PullRequest, r *models.Review, comment *models.Comment, mentions []*user_model.User) {
+func (m *mailNotifier) NotifyPullRequestReview(pr *models.PullRequest, _ *models.Review, comment *models.Comment, mentions []*user_model.User) {
 	var act models.ActionType
 	if comment.Type == models.CommentTypeClose {
 		act = models.ActionCloseIssue
@@ -141,7 +141,7 @@ func (m *mailNotifier) NotifyMergePullRequest(pr *models.PullRequest, doer *user
 	}
 }
 
-func (m *mailNotifier) NotifyPullRequestPushCommits(doer *user_model.User, pr *models.PullRequest, comment *models.Comment) {
+func (m *mailNotifier) NotifyPullRequestPushCommits(doer *user_model.User, _ *models.PullRequest, comment *models.Comment) {
 	var err error
 	if err = comment.LoadIssue(); err != nil {
 		log.Error("comment.LoadIssue: %v", err)
@@ -165,7 +165,7 @@ func (m *mailNotifier) NotifyPullRequestPushCommits(doer *user_model.User, pr *m
 	m.NotifyCreateIssueComment(doer, comment.Issue.Repo, comment.Issue, comment, nil)
 }
 
-func (m *mailNotifier) NotifyPullRevieweDismiss(doer *user_model.User, review *models.Review, comment *models.Comment) {
+func (m *mailNotifier) NotifyPullRevieweDismiss(_ *user_model.User, review *models.Review, comment *models.Comment) {
 	if err := mailer.MailParticipantsComment(comment, models.ActionPullReviewDismissed, review.Issue, nil); err != nil {
 		log.Error("MailParticipantsComment: %v", err)
 	}

--- a/modules/notification/ui/ui.go
+++ b/modules/notification/ui/ui.go
@@ -51,7 +51,7 @@ func (ns *notificationService) Run() {
 	graceful.GetManager().RunWithShutdownFns(ns.issueQueue.Run)
 }
 
-func (ns *notificationService) NotifyCreateIssueComment(doer *user_model.User, repo *models.Repository,
+func (ns *notificationService) NotifyCreateIssueComment(doer *user_model.User, _ *models.Repository,
 	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
 	var opts = issueNotificationOpts{
 		IssueID:              issue.ID,
@@ -88,9 +88,10 @@ func (ns *notificationService) NotifyNewIssue(issue *models.Issue, mentions []*u
 	}
 }
 
-func (ns *notificationService) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, actionComment *models.Comment, isClosed bool) {
+func (ns *notificationService) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, actionComment *models.Comment, _ bool) {
 	_ = ns.issueQueue.Push(issueNotificationOpts{
 		IssueID:              issue.ID,
+		CommentID:            actionComment.ID,
 		NotificationAuthorID: doer.ID,
 	})
 }

--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -137,7 +137,7 @@ func (m *webhookNotifier) NotifyMigrateRepository(doer *user_model.User, u *user
 	}
 }
 
-func (m *webhookNotifier) NotifyIssueChangeAssignee(doer *user_model.User, issue *models.Issue, assignee *user_model.User, removed bool, comment *models.Comment) {
+func (m *webhookNotifier) NotifyIssueChangeAssignee(doer *user_model.User, issue *models.Issue, _ *user_model.User, removed bool, _ *models.Comment) {
 	if issue.IsPull {
 		mode, _ := models.AccessLevelUnit(doer, issue.Repo, unit.TypePullRequests)
 
@@ -224,7 +224,7 @@ func (m *webhookNotifier) NotifyIssueChangeTitle(doer *user_model.User, issue *m
 	}
 }
 
-func (m *webhookNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, actionComment *models.Comment, isClosed bool) {
+func (m *webhookNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *models.Issue, _ *models.Comment, isClosed bool) {
 	mode, _ := models.AccessLevel(issue.Poster, issue.Repo)
 	var err error
 	if issue.IsPull {
@@ -264,7 +264,7 @@ func (m *webhookNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *
 	}
 }
 
-func (m *webhookNotifier) NotifyNewIssue(issue *models.Issue, mentions []*user_model.User) {
+func (m *webhookNotifier) NotifyNewIssue(issue *models.Issue, _ []*user_model.User) {
 	if err := issue.LoadRepo(); err != nil {
 		log.Error("issue.LoadRepo: %v", err)
 		return
@@ -286,7 +286,7 @@ func (m *webhookNotifier) NotifyNewIssue(issue *models.Issue, mentions []*user_m
 	}
 }
 
-func (m *webhookNotifier) NotifyNewPullRequest(pull *models.PullRequest, mentions []*user_model.User) {
+func (m *webhookNotifier) NotifyNewPullRequest(pull *models.PullRequest, _ []*user_model.User) {
 	if err := pull.LoadIssue(); err != nil {
 		log.Error("pull.LoadIssue: %v", err)
 		return
@@ -402,7 +402,7 @@ func (m *webhookNotifier) NotifyUpdateComment(doer *user_model.User, c *models.C
 }
 
 func (m *webhookNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *models.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, _ []*user_model.User) {
 	mode, _ := models.AccessLevel(doer, repo)
 
 	var err error
@@ -477,7 +477,7 @@ func (m *webhookNotifier) NotifyDeleteComment(doer *user_model.User, comment *mo
 }
 
 func (m *webhookNotifier) NotifyIssueChangeLabels(doer *user_model.User, issue *models.Issue,
-	addedLabels []*models.Label, removedLabels []*models.Label) {
+	_ []*models.Label, _ []*models.Label) {
 	var err error
 
 	if err = issue.LoadRepo(); err != nil {
@@ -521,7 +521,7 @@ func (m *webhookNotifier) NotifyIssueChangeLabels(doer *user_model.User, issue *
 	}
 }
 
-func (m *webhookNotifier) NotifyIssueChangeMilestone(doer *user_model.User, issue *models.Issue, oldMilestoneID int64) {
+func (m *webhookNotifier) NotifyIssueChangeMilestone(doer *user_model.User, issue *models.Issue, _ int64) {
 	var hookAction api.HookIssueAction
 	var err error
 	if issue.MilestoneID > 0 {
@@ -655,7 +655,7 @@ func (m *webhookNotifier) NotifyPullRequestChangeTargetBranch(doer *user_model.U
 	}
 }
 
-func (m *webhookNotifier) NotifyPullRequestReview(pr *models.PullRequest, review *models.Review, comment *models.Comment, mentions []*user_model.User) {
+func (m *webhookNotifier) NotifyPullRequestReview(pr *models.PullRequest, review *models.Review, _ *models.Comment, _ []*user_model.User) {
 	var reviewHookType webhook.HookEventType
 
 	switch review.Type {
@@ -769,12 +769,12 @@ func sendReleaseHook(doer *user_model.User, rel *models.Release, action api.Hook
 		return
 	}
 
-	mode, _ := models.AccessLevel(rel.Publisher, rel.Repo)
+	mode, _ := models.AccessLevel(doer, rel.Repo)
 	if err := webhook_services.PrepareWebhooks(rel.Repo, webhook.HookEventRelease, &api.ReleasePayload{
 		Action:     action,
 		Release:    convert.ToRelease(rel),
 		Repository: convert.ToRepo(rel.Repo, mode),
-		Sender:     convert.ToUser(rel.Publisher, nil),
+		Sender:     convert.ToUser(doer, nil),
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
 	}

--- a/modules/queue/bytefifo.go
+++ b/modules/queue/bytefifo.go
@@ -31,12 +31,12 @@ var _ ByteFIFO = &DummyByteFIFO{}
 type DummyByteFIFO struct{}
 
 // PushFunc returns nil
-func (*DummyByteFIFO) PushFunc(ctx context.Context, data []byte, fn func() error) error {
+func (*DummyByteFIFO) PushFunc(_ context.Context, _ []byte, _ func() error) error {
 	return nil
 }
 
 // Pop returns nil
-func (*DummyByteFIFO) Pop(ctx context.Context) ([]byte, error) {
+func (*DummyByteFIFO) Pop(_ context.Context) ([]byte, error) {
 	return []byte{}, nil
 }
 
@@ -46,7 +46,7 @@ func (*DummyByteFIFO) Close() error {
 }
 
 // Len is always 0
-func (*DummyByteFIFO) Len(ctx context.Context) int64 {
+func (*DummyByteFIFO) Len(_ context.Context) int64 {
 	return 0
 }
 
@@ -58,6 +58,6 @@ type DummyUniqueByteFIFO struct {
 }
 
 // Has always returns false
-func (*DummyUniqueByteFIFO) Has(ctx context.Context, data []byte) (bool, error) {
+func (*DummyUniqueByteFIFO) Has(_ context.Context, _ []byte) (bool, error) {
 	return false, nil
 }

--- a/modules/queue/queue.go
+++ b/modules/queue/queue.go
@@ -65,7 +65,7 @@ type Queue interface {
 const DummyQueueType Type = "dummy"
 
 // NewDummyQueue creates a new DummyQueue
-func NewDummyQueue(handler HandlerFunc, opts, exemplar interface{}) (Queue, error) {
+func NewDummyQueue(_ HandlerFunc, _, _ interface{}) (Queue, error) {
 	return &DummyQueue{}, nil
 }
 
@@ -110,7 +110,7 @@ func (*DummyQueue) IsEmpty() bool {
 const ImmediateType Type = "immediate"
 
 // NewImmediate creates a new false queue to execute the function when push
-func NewImmediate(handler HandlerFunc, opts, exemplar interface{}) (Queue, error) {
+func NewImmediate(handler HandlerFunc, _, _ interface{}) (Queue, error) {
 	return &Immediate{
 		handler: handler,
 	}, nil

--- a/modules/queue/queue_disk.go
+++ b/modules/queue/queue_disk.go
@@ -85,7 +85,7 @@ func NewLevelQueueByteFIFO(connection, prefix string) (*LevelQueueByteFIFO, erro
 }
 
 // PushFunc will push data into the fifo
-func (fifo *LevelQueueByteFIFO) PushFunc(ctx context.Context, data []byte, fn func() error) error {
+func (fifo *LevelQueueByteFIFO) PushFunc(_ context.Context, data []byte, fn func() error) error {
 	if fn != nil {
 		if err := fn(); err != nil {
 			return err
@@ -95,7 +95,7 @@ func (fifo *LevelQueueByteFIFO) PushFunc(ctx context.Context, data []byte, fn fu
 }
 
 // Pop pops data from the start of the fifo
-func (fifo *LevelQueueByteFIFO) Pop(ctx context.Context) ([]byte, error) {
+func (fifo *LevelQueueByteFIFO) Pop(_ context.Context) ([]byte, error) {
 	data, err := fifo.internal.RPop()
 	if err != nil && err != levelqueue.ErrNotFound {
 		return nil, err
@@ -111,7 +111,7 @@ func (fifo *LevelQueueByteFIFO) Close() error {
 }
 
 // Len returns the length of the fifo
-func (fifo *LevelQueueByteFIFO) Len(ctx context.Context) int64 {
+func (fifo *LevelQueueByteFIFO) Len(_ context.Context) int64 {
 	return fifo.internal.Len()
 }
 

--- a/modules/queue/unique_queue_disk.go
+++ b/modules/queue/unique_queue_disk.go
@@ -89,12 +89,12 @@ func NewLevelUniqueQueueByteFIFO(connection, prefix string) (*LevelUniqueQueueBy
 }
 
 // PushFunc pushes data to the end of the fifo and calls the callback if it is added
-func (fifo *LevelUniqueQueueByteFIFO) PushFunc(ctx context.Context, data []byte, fn func() error) error {
+func (fifo *LevelUniqueQueueByteFIFO) PushFunc(_ context.Context, data []byte, fn func() error) error {
 	return fifo.internal.LPushFunc(data, fn)
 }
 
 // Pop pops data from the start of the fifo
-func (fifo *LevelUniqueQueueByteFIFO) Pop(ctx context.Context) ([]byte, error) {
+func (fifo *LevelUniqueQueueByteFIFO) Pop(_ context.Context) ([]byte, error) {
 	data, err := fifo.internal.RPop()
 	if err != nil && err != levelqueue.ErrNotFound {
 		return nil, err
@@ -103,12 +103,12 @@ func (fifo *LevelUniqueQueueByteFIFO) Pop(ctx context.Context) ([]byte, error) {
 }
 
 // Len returns the length of the fifo
-func (fifo *LevelUniqueQueueByteFIFO) Len(ctx context.Context) int64 {
+func (fifo *LevelUniqueQueueByteFIFO) Len(_ context.Context) int64 {
 	return fifo.internal.Len()
 }
 
 // Has returns whether the fifo contains this data
-func (fifo *LevelUniqueQueueByteFIFO) Has(ctx context.Context, data []byte) (bool, error) {
+func (fifo *LevelUniqueQueueByteFIFO) Has(_ context.Context, data []byte) (bool, error) {
 	return fifo.internal.Has(data)
 }
 

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -537,7 +537,7 @@ func findActionKeywords(content []byte, start int) (XRefAction, *RefSpan) {
 }
 
 // IsXrefActionable returns true if the xref action is actionable (i.e. produces a result when resolved)
-func IsXrefActionable(ref *RenderizableReference, extTracker bool, alphaNum bool) bool {
+func IsXrefActionable(ref *RenderizableReference, extTracker bool) bool {
 	if extTracker {
 		// External issues cannot be automatically closed
 		return false

--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -23,7 +23,7 @@ import (
 	"github.com/unknwon/com"
 )
 
-func prepareRepoCommit(ctx context.Context, repo *models.Repository, tmpDir, repoPath string, opts models.CreateRepoOptions) error {
+func prepareRepoCommit(repo *models.Repository, tmpDir, repoPath string, opts models.CreateRepoOptions) error {
 	commitTimeStr := time.Now().Format(time.RFC3339)
 	authorSig := repo.Owner.NewGitSig()
 
@@ -215,7 +215,7 @@ func initRepository(ctx context.Context, repoPath string, u *user_model.User, re
 			}
 		}()
 
-		if err = prepareRepoCommit(ctx, repo, tmpDir, repoPath, opts); err != nil {
+		if err = prepareRepoCommit(repo, tmpDir, repoPath, opts); err != nil {
 			return fmt.Errorf("prepareRepoCommit: %v", err)
 		}
 

--- a/modules/session/db.go
+++ b/modules/session/db.go
@@ -91,7 +91,7 @@ type DBProvider struct {
 
 // Init initializes DB session provider.
 // connStr: username:password@protocol(address)/dbname?param=value
-func (p *DBProvider) Init(maxLifetime int64, connStr string) error {
+func (p *DBProvider) Init(maxLifetime int64, _ string) error {
 	p.maxLifetime = maxLifetime
 	return nil
 }

--- a/modules/session/virtual.go
+++ b/modules/session/virtual.go
@@ -69,7 +69,7 @@ func (o *VirtualSessionProvider) Read(sid string) (session.RawStore, error) {
 }
 
 // Exist returns true if session with given ID exists.
-func (o *VirtualSessionProvider) Exist(sid string) bool {
+func (o *VirtualSessionProvider) Exist(_ string) bool {
 	return true
 }
 

--- a/modules/storage/local.go
+++ b/modules/storage/local.go
@@ -65,7 +65,7 @@ func (l *LocalStorage) Open(path string) (Object, error) {
 }
 
 // Save a file
-func (l *LocalStorage) Save(path string, r io.Reader, size int64) (int64, error) {
+func (l *LocalStorage) Save(path string, r io.Reader, _ int64) (int64, error) {
 	p := filepath.Join(l.dir, path)
 	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
 		return 0, err
@@ -116,7 +116,7 @@ func (l *LocalStorage) Delete(path string) error {
 }
 
 // URL gets the redirect URL to a file
-func (l *LocalStorage) URL(path, name string) (*url.URL, error) {
+func (l *LocalStorage) URL(_, _ string) (*url.URL, error) {
 	return nil, ErrURLNotSupported
 }
 

--- a/modules/test/context_tests.go
+++ b/modules/test/context_tests.go
@@ -123,14 +123,14 @@ func (rw *mockResponseWriter) Size() int {
 	return rw.size
 }
 
-func (rw *mockResponseWriter) Push(target string, opts *http.PushOptions) error {
+func (rw *mockResponseWriter) Push(_ string, _ *http.PushOptions) error {
 	return nil
 }
 
 type mockRender struct {
 }
 
-func (tr *mockRender) TemplateLookup(tmpl string) *template.Template {
+func (tr *mockRender) TemplateLookup(_ string) *template.Template {
 	return nil
 }
 

--- a/routers/api/v1/admin/adopt.go
+++ b/routers/api/v1/admin/adopt.go
@@ -168,7 +168,7 @@ func DeleteUnadoptedRepository(ctx *context.APIContext) {
 		return
 	}
 
-	if err := repo_service.DeleteUnadoptedRepository(ctx.User, ctxUser, repoName); err != nil {
+	if err := repo_service.DeleteUnadoptedRepository(ctxUser, repoName); err != nil {
 		ctx.InternalServerError(err)
 		return
 	}

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -836,7 +836,7 @@ func MergePullRequest(ctx *context.APIContext) {
 		message += "\n\n" + form.MergeMessageField
 	}
 
-	if err := pull_service.Merge(pr, ctx.User, ctx.Repo.GitRepo, models.MergeStyle(form.Do), message); err != nil {
+	if err := pull_service.Merge(pr, ctx.User, models.MergeStyle(form.Do), message); err != nil {
 		if models.IsErrInvalidMergeStyle(err) {
 			ctx.Error(http.StatusMethodNotAllowed, "Invalid merge style", fmt.Errorf("%s is not allowed an allowed merge style for this repository", models.MergeStyle(form.Do)))
 			return

--- a/routers/install/setting.go
+++ b/routers/install/setting.go
@@ -15,7 +15,7 @@ import (
 )
 
 // PreloadSettings preloads the configuration to check if we need to run install
-func PreloadSettings(ctx context.Context) bool {
+func PreloadSettings() bool {
 	setting.NewContext()
 	if !setting.InstallLock {
 		log.Info("AppPath: %s", setting.AppPath)

--- a/routers/private/hook_pre_receive.go
+++ b/routers/private/hook_pre_receive.go
@@ -123,9 +123,9 @@ func HookPreReceive(ctx *gitea_context.PrivateContext) {
 		case strings.HasPrefix(refFullName, git.BranchPrefix):
 			preReceiveBranch(ourCtx, oldCommitID, newCommitID, refFullName)
 		case strings.HasPrefix(refFullName, git.TagPrefix):
-			preReceiveTag(ourCtx, oldCommitID, newCommitID, refFullName)
+			preReceiveTag(ourCtx, refFullName)
 		case git.SupportProcReceive && strings.HasPrefix(refFullName, git.PullRequestPrefix):
-			preReceivePullRequest(ourCtx, oldCommitID, newCommitID, refFullName)
+			preReceivePullRequest(ourCtx, refFullName)
 		default:
 			ourCtx.AssertCanWriteCode()
 		}
@@ -354,7 +354,7 @@ func preReceiveBranch(ctx *preReceiveContext, oldCommitID, newCommitID, refFullN
 	}
 }
 
-func preReceiveTag(ctx *preReceiveContext, oldCommitID, newCommitID, refFullName string) {
+func preReceiveTag(ctx *preReceiveContext, refFullName string) {
 	if !ctx.AssertCanWriteCode() {
 		return
 	}
@@ -390,7 +390,7 @@ func preReceiveTag(ctx *preReceiveContext, oldCommitID, newCommitID, refFullName
 	}
 }
 
-func preReceivePullRequest(ctx *preReceiveContext, oldCommitID, newCommitID, refFullName string) {
+func preReceivePullRequest(ctx *preReceiveContext, refFullName string) {
 	if !ctx.AssertCreatePullRequest() {
 		return
 	}

--- a/routers/private/hook_verification.go
+++ b/routers/private/hook_verification.go
@@ -47,7 +47,7 @@ func verifyCommits(oldCommitID, newCommitID string, repo *git.Repository, env []
 	err = git.NewCommand("rev-list", oldCommitID+"..."+newCommitID).
 		RunInDirTimeoutEnvFullPipelineFunc(env, -1, repo.Path,
 			stdoutWriter, nil, nil,
-			func(ctx context.Context, cancel context.CancelFunc) error {
+			func(_ context.Context, cancel context.CancelFunc) error {
 				_ = stdoutWriter.Close()
 				err := readAndVerifyCommitsFromShaReader(stdoutReader, repo, env)
 				if err != nil {
@@ -91,7 +91,7 @@ func readAndVerifyCommit(sha string, repo *git.Repository, env []string) error {
 	return git.NewCommand("cat-file", "commit", sha).
 		RunInDirTimeoutEnvFullPipelineFunc(env, -1, repo.Path,
 			stdoutWriter, nil, nil,
-			func(ctx context.Context, cancel context.CancelFunc) error {
+			func(_ context.Context, cancel context.CancelFunc) error {
 				_ = stdoutWriter.Close()
 				commit, err := git.CommitFromReader(repo, hash, stdoutReader)
 				if err != nil {

--- a/routers/web/admin/repos.go
+++ b/routers/web/admin/repos.go
@@ -156,7 +156,7 @@ func AdoptOrDeleteRepository(ctx *context.Context) {
 		}
 		ctx.Flash.Success(ctx.Tr("repo.adopt_preexisting_success", dir))
 	} else if action == "delete" {
-		if err := repo_service.DeleteUnadoptedRepository(ctx.User, ctxUser, dirSplit[1]); err != nil {
+		if err := repo_service.DeleteUnadoptedRepository(ctxUser, dirSplit[1]); err != nil {
 			ctx.ServerError("repository.AdoptRepository", err)
 			return
 		}

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -698,7 +698,7 @@ func RetrieveRepoMetas(ctx *context.Context, repo *models.Repository, isPull boo
 	ctx.Data["Branches"] = brs
 
 	// Contains true if the user can create issue dependencies
-	ctx.Data["CanCreateIssueDependencies"] = ctx.Repo.CanCreateIssueDependencies(ctx.User, isPull)
+	ctx.Data["CanCreateIssueDependencies"] = ctx.Repo.CanCreateIssueDependencies(isPull)
 
 	return labels
 }
@@ -1308,7 +1308,7 @@ func ViewIssue(ctx *context.Context) {
 	}
 
 	// Check if the user can use the dependencies
-	ctx.Data["CanCreateIssueDependencies"] = ctx.Repo.CanCreateIssueDependencies(ctx.User, issue.IsPull)
+	ctx.Data["CanCreateIssueDependencies"] = ctx.Repo.CanCreateIssueDependencies(issue.IsPull)
 
 	// check if dependencies can be created across repositories
 	ctx.Data["AllowCrossRepositoryDependencies"] = setting.Service.AllowCrossRepositoryDependencies

--- a/routers/web/repo/issue_dependency.go
+++ b/routers/web/repo/issue_dependency.go
@@ -22,7 +22,7 @@ func AddDependency(ctx *context.Context) {
 	}
 
 	// Check if the Repo is allowed to have dependencies
-	if !ctx.Repo.CanCreateIssueDependencies(ctx.User, issue.IsPull) {
+	if !ctx.Repo.CanCreateIssueDependencies(issue.IsPull) {
 		ctx.Error(http.StatusForbidden, "CanCreateIssueDependencies")
 		return
 	}
@@ -81,7 +81,7 @@ func RemoveDependency(ctx *context.Context) {
 	}
 
 	// Check if the Repo is allowed to have dependencies
-	if !ctx.Repo.CanCreateIssueDependencies(ctx.User, issue.IsPull) {
+	if !ctx.Repo.CanCreateIssueDependencies(issue.IsPull) {
 		ctx.Error(http.StatusForbidden, "CanCreateIssueDependencies")
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -932,7 +932,7 @@ func MergePullRequest(ctx *context.Context) {
 		return
 	}
 
-	if err = pull_service.Merge(pr, ctx.User, ctx.Repo.GitRepo, models.MergeStyle(form.Do), message); err != nil {
+	if err = pull_service.Merge(pr, ctx.User, models.MergeStyle(form.Do), message); err != nil {
 		if models.IsErrInvalidMergeStyle(err) {
 			ctx.Flash.Error(ctx.Tr("repo.pulls.invalid_merge_option"))
 			ctx.Redirect(issue.Link())

--- a/routers/web/user/setting/adopt.go
+++ b/routers/web/user/setting/adopt.go
@@ -54,7 +54,7 @@ func AdoptOrDeleteRepository(ctx *context.Context) {
 		}
 		ctx.Flash.Success(ctx.Tr("repo.adopt_preexisting_success", dir))
 	} else if action == "delete" && allowDelete {
-		if err := repo_service.DeleteUnadoptedRepository(ctxUser, ctxUser, dir); err != nil {
+		if err := repo_service.DeleteUnadoptedRepository(ctxUser, dir); err != nil {
 			ctx.ServerError("repository.AdoptRepository", err)
 			return
 		}

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -42,7 +42,7 @@ func (b *Basic) Name() string {
 // "Authorization" header of the request and returns the corresponding user object for that
 // name/token on successful validation.
 // Returns nil if header is empty or validation fails.
-func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
+func (b *Basic) Verify(req *http.Request, _ http.ResponseWriter, store DataStore, _ SessionStore) *user_model.User {
 	// Basic authentication should only fire on API, Download or on Git or LFSPaths
 	if !middleware.IsAPIPath(req) && !isAttachmentDownload(req) && !isGitRawReleaseOrLFSPath(req) {
 		return nil

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -111,7 +111,7 @@ func (o *OAuth2) userIDFromToken(req *http.Request, store DataStore) int64 {
 // or the "Authorization" header and returns the corresponding user object for that ID.
 // If verification is successful returns an existing user object.
 // Returns nil if verification fails.
-func (o *OAuth2) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
+func (o *OAuth2) Verify(req *http.Request, _ http.ResponseWriter, store DataStore, _ SessionStore) *user_model.User {
 	if !db.HasEngine {
 		return nil
 	}

--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -30,7 +30,7 @@ func (s *Session) Name() string {
 // Verify checks if there is a user uid stored in the session and returns the user
 // object for that uid.
 // Returns nil if there is no user uid stored in the session.
-func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
+func (s *Session) Verify(_ *http.Request, _ http.ResponseWriter, _ DataStore, sess SessionStore) *user_model.User {
 	user := SessionUser(sess)
 	if user != nil {
 		return user

--- a/services/auth/source/db/source.go
+++ b/services/auth/source/db/source.go
@@ -13,7 +13,7 @@ import (
 type Source struct{}
 
 // FromDB fills up an OAuth2Config from serialized format.
-func (source *Source) FromDB(bs []byte) error {
+func (source *Source) FromDB(_ []byte) error {
 	return nil
 }
 

--- a/services/auth/source/oauth2/providers_custom.go
+++ b/services/auth/source/oauth2/providers_custom.go
@@ -32,7 +32,7 @@ func (c *CustomProvider) CustomURLSettings() *CustomURLSettings {
 }
 
 // CreateGothProvider creates a GothProvider from this Provider
-func (c *CustomProvider) CreateGothProvider(providerName, callbackURL string, source *Source) (goth.Provider, error) {
+func (c *CustomProvider) CreateGothProvider(_, callbackURL string, source *Source) (goth.Provider, error) {
 	custom := c.customURLSettings.OverrideWith(source.CustomURLMapping)
 
 	return c.newFn(source.ClientID, source.ClientSecret, callbackURL, custom)

--- a/services/auth/source/oauth2/providers_simple.go
+++ b/services/auth/source/oauth2/providers_simple.go
@@ -30,7 +30,7 @@ type SimpleProvider struct {
 }
 
 // CreateGothProvider creates a GothProvider from this Provider
-func (c *SimpleProvider) CreateGothProvider(providerName, callbackURL string, source *Source) (goth.Provider, error) {
+func (c *SimpleProvider) CreateGothProvider(_, callbackURL string, source *Source) (goth.Provider, error) {
 	return c.newFn(source.ClientID, source.ClientSecret, callbackURL, c.scopes...), nil
 }
 

--- a/services/auth/source/oauth2/store.go
+++ b/services/auth/source/oauth2/store.go
@@ -61,7 +61,7 @@ func (st *SessionsStore) getOrNew(r *http.Request, name string, override bool) (
 }
 
 // Save should persist session to the underlying store implementation.
-func (st *SessionsStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
+func (st *SessionsStore) Save(r *http.Request, _ http.ResponseWriter, session *sessions.Session) error {
 	chiStore := chiSession.GetSession(r)
 
 	if err := chiStore.Set(session.Name(), session); err != nil {

--- a/services/auth/source/smtp/auth.go
+++ b/services/auth/source/smtp/auth.go
@@ -25,7 +25,7 @@ type loginAuthenticator struct {
 	username, password string
 }
 
-func (auth *loginAuthenticator) Start(server *smtp.ServerInfo) (string, []byte, error) {
+func (auth *loginAuthenticator) Start(_ *smtp.ServerInfo) (string, []byte, error) {
 	return "LOGIN", []byte(auth.username), nil
 }
 

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -78,9 +78,9 @@ func registerArchiveCleanup() {
 			Schedule:   "@midnight",
 		},
 		OlderThan: 24 * time.Hour,
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
+	}, func(_ context.Context, _ *user_model.User, config Config) error {
 		acConfig := config.(*OlderThanConfig)
-		return models.DeleteOldRepositoryArchives(ctx, acConfig.OlderThan)
+		return models.DeleteOldRepositoryArchives(acConfig.OlderThan)
 	})
 }
 
@@ -106,9 +106,9 @@ func registerDeletedBranchesCleanup() {
 			Schedule:   "@midnight",
 		},
 		OlderThan: 24 * time.Hour,
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
+	}, func(_ context.Context, _ *user_model.User, config Config) error {
 		realConfig := config.(*OlderThanConfig)
-		models.RemoveOldDeletedBranches(ctx, realConfig.OlderThan)
+		models.RemoveOldDeletedBranches(realConfig.OlderThan)
 		return nil
 	})
 }

--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -35,8 +35,8 @@ func registerDeleteRepositoryArchives() {
 		Enabled:    false,
 		RunAtStart: false,
 		Schedule:   "@annually",
-	}, func(ctx context.Context, _ *user_model.User, _ Config) error {
-		return repo_service.DeleteRepositoryArchives(ctx)
+	}, func(_ context.Context, _ *user_model.User, _ Config) error {
+		return repo_service.DeleteRepositoryArchives()
 	})
 }
 
@@ -128,7 +128,7 @@ func registerDeleteOldActions() {
 			Schedule:   "@every 168h",
 		},
 		OlderThan: 365 * 24 * time.Hour,
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
+	}, func(_ context.Context, _ *user_model.User, config Config) error {
 		olderThanConfig := config.(*OlderThanConfig)
 		return models.DeleteOldActions(olderThanConfig.OlderThan)
 	})
@@ -146,7 +146,7 @@ func registerUpdateGiteaChecker() {
 			Schedule:   "@every 168h",
 		},
 		HTTPEndpoint: "https://dl.gitea.io/gitea/version.json",
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
+	}, func(_ context.Context, _ *user_model.User, config Config) error {
 		updateCheckerConfig := config.(*UpdateCheckerConfig)
 		return updatechecker.GiteaUpdateChecker(updateCheckerConfig.HTTPEndpoint)
 	})

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -411,7 +411,7 @@ func fixupBrokenSpans(diffs []diffmatchpatch.Diff) []diffmatchpatch.Diff {
 	return fixedup
 }
 
-func diffToHTML(fileName string, diffs []diffmatchpatch.Diff, lineType DiffLineType) template.HTML {
+func diffToHTML(diffs []diffmatchpatch.Diff, lineType DiffLineType) template.HTML {
 	buf := bytes.NewBuffer(nil)
 	match := ""
 
@@ -580,7 +580,7 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine) tem
 	diffRecord := diffMatchPatch.DiffMain(highlight.Code(diffSection.FileName, language, diff1[1:]), highlight.Code(diffSection.FileName, language, diff2[1:]), true)
 	diffRecord = diffMatchPatch.DiffCleanupEfficiency(diffRecord)
 
-	return diffToHTML(diffSection.FileName, diffRecord, diffLine.Type)
+	return diffToHTML(diffRecord, diffLine.Type)
 }
 
 // DiffFile represents a file diff.

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -33,21 +33,21 @@ func assertEqual(t *testing.T, s1 string, s2 template.HTML) {
 
 func TestDiffToHTML(t *testing.T) {
 	setting.Cfg = ini.Empty()
-	assertEqual(t, "foo <span class=\"added-code\">bar</span> biz", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "foo <span class=\"added-code\">bar</span> biz", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "foo "},
 		{Type: dmp.DiffInsert, Text: "bar"},
 		{Type: dmp.DiffDelete, Text: " baz"},
 		{Type: dmp.DiffEqual, Text: " biz"},
 	}, DiffLineAdd))
 
-	assertEqual(t, "foo <span class=\"removed-code\">bar</span> biz", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "foo <span class=\"removed-code\">bar</span> biz", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "foo "},
 		{Type: dmp.DiffDelete, Text: "bar"},
 		{Type: dmp.DiffInsert, Text: " baz"},
 		{Type: dmp.DiffEqual, Text: " biz"},
 	}, DiffLineDel))
 
-	assertEqual(t, "<span class=\"k\">if</span> <span class=\"p\">!</span><span class=\"nx\">nohl</span> <span class=\"o\">&amp;&amp;</span> <span class=\"added-code\"><span class=\"p\">(</span></span><span class=\"nx\">lexer</span> <span class=\"o\">!=</span> <span class=\"kc\">nil</span><span class=\"added-code\"> <span class=\"o\">||</span> <span class=\"nx\">r</span><span class=\"p\">.</span><span class=\"nx\">GuessLanguage</span><span class=\"p\">)</span></span> <span class=\"p\">{</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"k\">if</span> <span class=\"p\">!</span><span class=\"nx\">nohl</span> <span class=\"o\">&amp;&amp;</span> <span class=\"added-code\"><span class=\"p\">(</span></span><span class=\"nx\">lexer</span> <span class=\"o\">!=</span> <span class=\"kc\">nil</span><span class=\"added-code\"> <span class=\"o\">||</span> <span class=\"nx\">r</span><span class=\"p\">.</span><span class=\"nx\">GuessLanguage</span><span class=\"p\">)</span></span> <span class=\"p\">{</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "<span class=\"k\">if</span> <span class=\"p\">!</span><span class=\"nx\">nohl</span> <span class=\"o\">&amp;&amp;</span> <span class=\""},
 		{Type: dmp.DiffInsert, Text: "p\">(</span><span class=\""},
 		{Type: dmp.DiffEqual, Text: "nx\">lexer</span> <span class=\"o\">!=</span> <span class=\"kc\">nil"},
@@ -55,7 +55,7 @@ func TestDiffToHTML(t *testing.T) {
 		{Type: dmp.DiffEqual, Text: "</span> <span class=\"p\">{</span>"},
 	}, DiffLineAdd))
 
-	assertEqual(t, "<span class=\"nx\">tagURL</span> <span class=\"o\">:=</span> <span class=\"removed-code\"><span class=\"nx\">fmt</span><span class=\"p\">.</span><span class=\"nf\">Sprintf</span><span class=\"p\">(</span><span class=\"s\">&#34;## [%s](%s/%s/%s/%s?q=&amp;type=all&amp;state=closed&amp;milestone=%d) - %s&#34;</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Milestone\"</span></span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">BaseURL</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Owner</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Repo</span><span class=\"p\">,</span> <span class=\"removed-code\"><span class=\"nx\">from</span><span class=\"p\">,</span> <span class=\"nx\">milestoneID</span><span class=\"p\">,</span> <span class=\"nx\">time</span><span class=\"p\">.</span><span class=\"nf\">Now</span><span class=\"p\">(</span><span class=\"p\">)</span><span class=\"p\">.</span><span class=\"nf\">Format</span><span class=\"p\">(</span><span class=\"s\">&#34;2006-01-02&#34;</span><span class=\"p\">)</span></span><span class=\"p\">)</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"nx\">tagURL</span> <span class=\"o\">:=</span> <span class=\"removed-code\"><span class=\"nx\">fmt</span><span class=\"p\">.</span><span class=\"nf\">Sprintf</span><span class=\"p\">(</span><span class=\"s\">&#34;## [%s](%s/%s/%s/%s?q=&amp;type=all&amp;state=closed&amp;milestone=%d) - %s&#34;</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Milestone\"</span></span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">BaseURL</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Owner</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Repo</span><span class=\"p\">,</span> <span class=\"removed-code\"><span class=\"nx\">from</span><span class=\"p\">,</span> <span class=\"nx\">milestoneID</span><span class=\"p\">,</span> <span class=\"nx\">time</span><span class=\"p\">.</span><span class=\"nf\">Now</span><span class=\"p\">(</span><span class=\"p\">)</span><span class=\"p\">.</span><span class=\"nf\">Format</span><span class=\"p\">(</span><span class=\"s\">&#34;2006-01-02&#34;</span><span class=\"p\">)</span></span><span class=\"p\">)</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "<span class=\"nx\">tagURL</span> <span class=\"o\">:=</span> <span class=\"n"},
 		{Type: dmp.DiffDelete, Text: "x\">fmt</span><span class=\"p\">.</span><span class=\"nf\">Sprintf</span><span class=\"p\">(</span><span class=\"s\">&#34;## [%s](%s/%s/%s/%s?q=&amp;type=all&amp;state=closed&amp;milestone=%d) - %s&#34;</span><span class=\"p\">,</span> <span class=\"nx\">ge</span><span class=\"p\">.</span><span class=\"nx\">Milestone\""},
 		{Type: dmp.DiffInsert, Text: "f\">getGiteaTagURL</span><span class=\"p\">(</span><span class=\"nx\">client"},
@@ -65,7 +65,7 @@ func TestDiffToHTML(t *testing.T) {
 		{Type: dmp.DiffEqual, Text: "</span><span class=\"p\">)</span>"},
 	}, DiffLineDel))
 
-	assertEqual(t, "<span class=\"nx\">r</span><span class=\"p\">.</span><span class=\"nf\">WrapperRenderer</span><span class=\"p\">(</span><span class=\"nx\">w</span><span class=\"p\">,</span> <span class=\"removed-code\"><span class=\"nx\">language</span><span class=\"p\">,</span> <span class=\"kc\">true</span><span class=\"p\">,</span> <span class=\"nx\">attrs</span></span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"nx\">r</span><span class=\"p\">.</span><span class=\"nf\">WrapperRenderer</span><span class=\"p\">(</span><span class=\"nx\">w</span><span class=\"p\">,</span> <span class=\"removed-code\"><span class=\"nx\">language</span><span class=\"p\">,</span> <span class=\"kc\">true</span><span class=\"p\">,</span> <span class=\"nx\">attrs</span></span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "<span class=\"nx\">r</span><span class=\"p\">.</span><span class=\"nf\">WrapperRenderer</span><span class=\"p\">(</span><span class=\"nx\">w</span><span class=\"p\">,</span> <span class=\"nx\">"},
 		{Type: dmp.DiffDelete, Text: "language</span><span "},
 		{Type: dmp.DiffEqual, Text: "c"},
@@ -73,14 +73,14 @@ func TestDiffToHTML(t *testing.T) {
 		{Type: dmp.DiffEqual, Text: "</span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>"},
 	}, DiffLineDel))
 
-	assertEqual(t, "<span class=\"added-code\">language</span><span class=\"p\">,</span> <span class=\"kc\">true</span><span class=\"p\">,</span> <span class=\"nx\">attrs</span></span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"added-code\">language</span><span class=\"p\">,</span> <span class=\"kc\">true</span><span class=\"p\">,</span> <span class=\"nx\">attrs</span></span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffInsert, Text: "language</span><span "},
 		{Type: dmp.DiffEqual, Text: "c"},
 		{Type: dmp.DiffInsert, Text: "lass=\"p\">,</span> <span class=\"kc\">true</span><span class=\"p\">,</span> <span class=\"nx\">attrs"},
 		{Type: dmp.DiffEqual, Text: "</span><span class=\"p\">,</span> <span class=\"kc\">false</span><span class=\"p\">)</span>"},
 	}, DiffLineAdd))
 
-	assertEqual(t, "<span class=\"k\">print</span><span class=\"added-code\"><span class=\"p\">(</span></span><span class=\"sa\"></span><span class=\"s2\">&#34;</span><span class=\"s2\">// </span><span class=\"s2\">&#34;</span><span class=\"p\">,</span> <span class=\"n\">sys</span><span class=\"o\">.</span><span class=\"n\">argv</span><span class=\"added-code\"><span class=\"p\">)</span></span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"k\">print</span><span class=\"added-code\"><span class=\"p\">(</span></span><span class=\"sa\"></span><span class=\"s2\">&#34;</span><span class=\"s2\">// </span><span class=\"s2\">&#34;</span><span class=\"p\">,</span> <span class=\"n\">sys</span><span class=\"o\">.</span><span class=\"n\">argv</span><span class=\"added-code\"><span class=\"p\">)</span></span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "<span class=\"k\">print</span>"},
 		{Type: dmp.DiffInsert, Text: "<span"},
 		{Type: dmp.DiffEqual, Text: " "},
@@ -89,14 +89,14 @@ func TestDiffToHTML(t *testing.T) {
 		{Type: dmp.DiffInsert, Text: "<span class=\"p\">)</span>"},
 	}, DiffLineAdd))
 
-	assertEqual(t, "sh <span class=\"added-code\">&#39;useradd -u $(stat -c &#34;%u&#34; .gitignore) jenkins&#39;</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "sh <span class=\"added-code\">&#39;useradd -u $(stat -c &#34;%u&#34; .gitignore) jenkins&#39;</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "sh &#3"},
 		{Type: dmp.DiffDelete, Text: "4;useradd -u 111 jenkins&#34"},
 		{Type: dmp.DiffInsert, Text: "9;useradd -u $(stat -c &#34;%u&#34; .gitignore) jenkins&#39"},
 		{Type: dmp.DiffEqual, Text: ";"},
 	}, DiffLineAdd))
 
-	assertEqual(t, "<span class=\"x\">							&lt;h<span class=\"added-code\">4 class=&#34;release-list-title df ac&#34;</span>&gt;</span>", diffToHTML("", []dmp.Diff{
+	assertEqual(t, "<span class=\"x\">							&lt;h<span class=\"added-code\">4 class=&#34;release-list-title df ac&#34;</span>&gt;</span>", diffToHTML([]dmp.Diff{
 		{Type: dmp.DiffEqual, Text: "<span class=\"x\">							&lt;h"},
 		{Type: dmp.DiffInsert, Text: "4 class=&#"},
 		{Type: dmp.DiffEqual, Text: "3"},
@@ -716,12 +716,12 @@ func TestDiffToHTML_14231(t *testing.T) {
 	diffRecord = diffMatchPatch.DiffCleanupEfficiency(diffRecord)
 
 	expected := `		<span class="n">run</span><span class="added-code"><span class="o">(</span><span class="n">db</span></span><span class="o">)</span>`
-	output := diffToHTML("main.v", diffRecord, DiffLineAdd)
+	output := diffToHTML(diffRecord, DiffLineAdd)
 
 	assertEqual(t, expected, output)
 }
 
-func TestNoCrashes(t *testing.T) {
+func TestNoCrashes(_ *testing.T) {
 	type testcase struct {
 		gitdiff string
 	}

--- a/services/lfs/server.go
+++ b/services/lfs/server.go
@@ -57,7 +57,7 @@ func (rc *requestContext) UploadLink(p lfs_module.Pointer) string {
 }
 
 // VerifyLink builds a URL for verifying the object.
-func (rc *requestContext) VerifyLink(p lfs_module.Pointer) string {
+func (rc *requestContext) VerifyLink() string {
 	return setting.AppURL + path.Join(url.PathEscape(rc.User), url.PathEscape(rc.Repo+".git"), "info/lfs/verify")
 }
 
@@ -455,7 +455,7 @@ func buildObjectResponse(rc *requestContext, pointer lfs_module.Pointer, downloa
 			// This is only needed to workaround https://github.com/git-lfs/git-lfs/issues/3662
 			verifyHeader["Accept"] = lfs_module.MediaType
 
-			rep.Actions["verify"] = &lfs_module.Link{Href: rc.VerifyLink(pointer), Header: verifyHeader}
+			rep.Actions["verify"] = &lfs_module.Link{Href: rc.VerifyLink(), Header: verifyHeader}
 		}
 	}
 	return rep

--- a/services/mailer/mailer.go
+++ b/services/mailer/mailer.go
@@ -106,7 +106,7 @@ func LoginAuth(username, password string) smtp.Auth {
 }
 
 // Start start SMTP login auth
-func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+func (a *loginAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
 	return "LOGIN", []byte{}, nil
 }
 

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -69,7 +69,7 @@ func NewRepositoryDumper(ctx context.Context, baseDir, repoOwner, repoName strin
 }
 
 // MaxBatchInsertSize returns the table's max batch insert size
-func (g *RepositoryDumper) MaxBatchInsertSize(tp string) int {
+func (g *RepositoryDumper) MaxBatchInsertSize(_ string) int {
 	return 1000
 }
 

--- a/services/migrations/git.go
+++ b/services/migrations/git.go
@@ -32,7 +32,7 @@ func NewPlainGitDownloader(ownerName, repoName, remoteURL string) *PlainGitDownl
 }
 
 // SetContext set context
-func (g *PlainGitDownloader) SetContext(ctx context.Context) {
+func (g *PlainGitDownloader) SetContext(_ context.Context) {
 }
 
 // GetRepoInfo returns a repository information

--- a/services/migrations/gitbucket.go
+++ b/services/migrations/gitbucket.go
@@ -67,6 +67,6 @@ func (g *GitBucketDownloader) SupportGetRepoComments() bool {
 }
 
 // GetReviews is not supported
-func (g *GitBucketDownloader) GetReviews(context base.IssueContext) ([]*base.Review, error) {
+func (g *GitBucketDownloader) GetReviews(_ base.IssueContext) ([]*base.Review, error) {
 	return nil, &base.ErrNotSupported{Entity: "Reviews"}
 }

--- a/services/migrations/restore.go
+++ b/services/migrations/restore.go
@@ -187,7 +187,8 @@ func (r *RepositoryRestorer) GetLabels() ([]*base.Label, error) {
 }
 
 // GetIssues returns issues according start and limit
-func (r *RepositoryRestorer) GetIssues(page, perPage int) ([]*base.Issue, bool, error) {
+// FIXME: use the provided page and perPage
+func (r *RepositoryRestorer) GetIssues(_, _ int) ([]*base.Issue, bool, error) {
 	var issues = make([]*base.Issue, 0, 10)
 	p := filepath.Join(r.baseDir, "issue.yml")
 	_, err := os.Stat(p)
@@ -238,7 +239,8 @@ func (r *RepositoryRestorer) GetComments(opts base.GetCommentOptions) ([]*base.C
 }
 
 // GetPullRequests returns pull requests according page and perPage
-func (r *RepositoryRestorer) GetPullRequests(page, perPage int) ([]*base.PullRequest, bool, error) {
+// FIXME: use the provided page and perPage
+func (r *RepositoryRestorer) GetPullRequests(_, _ int) ([]*base.PullRequest, bool, error) {
 	var pulls = make([]*base.PullRequest, 0, 10)
 	p := filepath.Join(r.baseDir, "pull_request.yml")
 	_, err := os.Stat(p)

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -31,7 +31,7 @@ import (
 // Merge merges pull request to base repository.
 // Caller should check PR is ready to be merged (review and status checks)
 // FIXME: add repoWorkingPull make sure two merges does not happen at same time.
-func Merge(pr *models.PullRequest, doer *user_model.User, baseGitRepo *git.Repository, mergeStyle models.MergeStyle, message string) (err error) {
+func Merge(pr *models.PullRequest, doer *user_model.User, mergeStyle models.MergeStyle, message string) (err error) {
 	if err = pr.LoadHeadRepo(); err != nil {
 		log.Error("LoadHeadRepo: %v", err)
 		return fmt.Errorf("LoadHeadRepo: %v", err)

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -181,7 +181,7 @@ func checkConflicts(pr *models.PullRequest, gitRepo *git.Repository, tmpBasePath
 		RunInDirTimeoutEnvFullPipelineFunc(
 			nil, -1, tmpBasePath,
 			nil, stderrWriter, nil,
-			func(ctx context.Context, cancel context.CancelFunc) error {
+			func(_ context.Context, _ context.CancelFunc) error {
 				// Close the writer end of the pipe to begin processing
 				_ = stderrWriter.Close()
 				defer func() {

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -234,7 +234,7 @@ func checkForInvalidation(requests models.PullRequestList, repoID int64, doer *u
 // and generate new patch for testing as needed.
 func AddTestPullRequestTask(doer *user_model.User, repoID int64, branch string, isSync bool, oldCommitID, newCommitID string) {
 	log.Trace("AddTestPullRequestTask [head_repo_id: %d, head_branch: %s]: finding pull requests", repoID, branch)
-	graceful.GetManager().RunWithShutdownContext(func(ctx context.Context) {
+	graceful.GetManager().RunWithShutdownContext(func(_ context.Context) {
 		// There is no sensible way to shut this down ":-("
 		// If you don't let it run all the way then you will lose data
 		// FIXME: graceful: AddTestPullRequestTask needs to become a queue!

--- a/services/repository/adopt.go
+++ b/services/repository/adopt.go
@@ -69,7 +69,7 @@ func AdoptRepository(doer, u *user_model.User, opts models.CreateRepoOptions) (*
 		if err := models.CreateRepository(ctx, doer, u, repo, true); err != nil {
 			return err
 		}
-		if err := adoptRepository(ctx, repoPath, doer, repo, opts); err != nil {
+		if err := adoptRepository(ctx, repoPath, repo, opts); err != nil {
 			return fmt.Errorf("createDelegateHooks: %v", err)
 		}
 		if err := repo.CheckDaemonExportOK(ctx); err != nil {
@@ -99,7 +99,7 @@ func AdoptRepository(doer, u *user_model.User, opts models.CreateRepoOptions) (*
 	return repo, nil
 }
 
-func adoptRepository(ctx context.Context, repoPath string, u *user_model.User, repo *models.Repository, opts models.CreateRepoOptions) (err error) {
+func adoptRepository(ctx context.Context, repoPath string, repo *models.Repository, opts models.CreateRepoOptions) (err error) {
 	isExist, err := util.IsExist(repoPath)
 	if err != nil {
 		log.Error("Unable to check if %s exists. Error: %v", repoPath, err)
@@ -186,7 +186,7 @@ func adoptRepository(ctx context.Context, repoPath string, u *user_model.User, r
 }
 
 // DeleteUnadoptedRepository deletes unadopted repository files from the filesystem
-func DeleteUnadoptedRepository(doer, u *user_model.User, repoName string) error {
+func DeleteUnadoptedRepository(u *user_model.User, repoName string) error {
 	if err := models.IsUsableRepoName(repoName); err != nil {
 		return err
 	}

--- a/services/repository/archive.go
+++ b/services/repository/archive.go
@@ -5,14 +5,12 @@
 package repository
 
 import (
-	"context"
-
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/modules/storage"
 )
 
 // DeleteRepositoryArchives deletes all repositories' archives.
-func DeleteRepositoryArchives(ctx context.Context) error {
+func DeleteRepositoryArchives() error {
 	if err := models.DeleteAllRepoArchives(); err != nil {
 		return err
 	}

--- a/services/repository/check.go
+++ b/services/repository/check.go
@@ -29,7 +29,7 @@ func GitFsck(ctx context.Context, timeout time.Duration, args []string) error {
 		db.DefaultContext,
 		new(models.Repository),
 		builder.Expr("id>0 AND is_fsck_enabled=?", true),
-		func(idx int, bean interface{}) error {
+		func(_ int, bean interface{}) error {
 			repo := bean.(*models.Repository)
 			select {
 			case <-ctx.Done():
@@ -64,7 +64,7 @@ func GitGcRepos(ctx context.Context, timeout time.Duration, args ...string) erro
 		db.DefaultContext,
 		new(models.Repository),
 		builder.Gt{"id": 0},
-		func(idx int, bean interface{}) error {
+		func(_ int, bean interface{}) error {
 			repo := bean.(*models.Repository)
 			select {
 			case <-ctx.Done():
@@ -121,7 +121,7 @@ func gatherMissingRepoRecords(ctx context.Context) ([]*models.Repository, error)
 		db.DefaultContext,
 		new(models.Repository),
 		builder.Gt{"id": 0},
-		func(idx int, bean interface{}) error {
+		func(_ int, bean interface{}) error {
 			repo := bean.(*models.Repository)
 			select {
 			case <-ctx.Done():

--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -301,7 +301,7 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 	var finalErr error
 
 	if err := git.NewCommand("diff-index", "--src-prefix=\\a/", "--dst-prefix=\\b/", "--cached", "-p", "HEAD").
-		RunInDirTimeoutEnvFullPipelineFunc(nil, 30*time.Second, t.basePath, stdoutWriter, stderr, nil, func(ctx context.Context, cancel context.CancelFunc) error {
+		RunInDirTimeoutEnvFullPipelineFunc(nil, 30*time.Second, t.basePath, stdoutWriter, stderr, nil, func(_ context.Context, cancel context.CancelFunc) error {
 			_ = stdoutWriter.Close()
 			diff, finalErr = gitdiff.ParsePatch(setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, stdoutReader, "")
 			if finalErr != nil {

--- a/services/repository/generate.go
+++ b/services/repository/generate.go
@@ -46,7 +46,7 @@ func GenerateRepository(doer, owner *user_model.User, templateRepo *models.Repos
 
 		// Git Hooks
 		if opts.GitHooks {
-			if err = models.GenerateGitHooks(ctx, templateRepo, generateRepo); err != nil {
+			if err = models.GenerateGitHooks(templateRepo, generateRepo); err != nil {
 				return err
 			}
 		}

--- a/services/repository/hooks.go
+++ b/services/repository/hooks.go
@@ -25,7 +25,7 @@ func SyncRepositoryHooks(ctx context.Context) error {
 		db.DefaultContext,
 		new(models.Repository),
 		builder.Gt{"id": 0},
-		func(idx int, bean interface{}) error {
+		func(_ int, bean interface{}) error {
 			repo := bean.(*models.Repository)
 			select {
 			case <-ctx.Done():

--- a/services/repository/transfer.go
+++ b/services/repository/transfer.go
@@ -61,7 +61,7 @@ func ChangeRepositoryName(doer *user_model.User, repo *models.Repository, newRep
 	// local copy's origin accordingly.
 
 	repoWorkingPool.CheckIn(fmt.Sprint(repo.ID))
-	if err := models.ChangeRepositoryName(doer, repo, newRepoName); err != nil {
+	if err := models.ChangeRepositoryName(repo, newRepoName); err != nil {
 		repoWorkingPool.CheckOut(fmt.Sprint(repo.ID))
 		return err
 	}

--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -186,6 +186,6 @@ func createDingtalkPayload(title, text, singleTitle, singleURL string) *Dingtalk
 }
 
 // GetDingtalkPayload converts a ding talk webhook into a DingtalkPayload
-func GetDingtalkPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetDingtalkPayload(p api.Payloader, event webhook_model.HookEventType, _ string) (api.Payloader, error) {
 	return convertPayloader(new(DingtalkPayload), p, event)
 }

--- a/services/webhook/feishu.go
+++ b/services/webhook/feishu.go
@@ -155,6 +155,6 @@ func (f *FeishuPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 }
 
 // GetFeishuPayload converts a ding talk webhook into a FeishuPayload
-func GetFeishuPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetFeishuPayload(p api.Payloader, event webhook_model.HookEventType, _ string) (api.Payloader, error) {
 	return convertPayloader(new(FeishuPayload), p, event)
 }

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -18,7 +18,7 @@ import (
 type linkFormatter = func(string, string) string
 
 // noneLinkFormatter does not create a link but just returns the text
-func noneLinkFormatter(url string, text string) string {
+func noneLinkFormatter(_ string, text string) string {
 	return text
 }
 

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -284,7 +284,7 @@ func (m *MSTeamsPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 }
 
 // GetMSTeamsPayload converts a MSTeams webhook into a MSTeamsPayload
-func GetMSTeamsPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetMSTeamsPayload(p api.Payloader, event webhook_model.HookEventType, _ string) (api.Payloader, error) {
 	return convertPayloader(new(MSTeamsPayload), p, event)
 }
 

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -181,7 +181,7 @@ func (t *TelegramPayload) Release(p *api.ReleasePayload) (api.Payloader, error) 
 }
 
 // GetTelegramPayload converts a telegram webhook into a TelegramPayload
-func GetTelegramPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetTelegramPayload(p api.Payloader, event webhook_model.HookEventType, _ string) (api.Payloader, error) {
 	return convertPayloader(new(TelegramPayload), p, event)
 }
 

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -21,42 +21,33 @@ import (
 )
 
 type webhook struct {
-	name           webhook_model.HookType
 	payloadCreator func(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error)
 }
 
 var (
 	webhooks = map[webhook_model.HookType]*webhook{
 		webhook_model.SLACK: {
-			name:           webhook_model.SLACK,
 			payloadCreator: GetSlackPayload,
 		},
 		webhook_model.DISCORD: {
-			name:           webhook_model.DISCORD,
 			payloadCreator: GetDiscordPayload,
 		},
 		webhook_model.DINGTALK: {
-			name:           webhook_model.DINGTALK,
 			payloadCreator: GetDingtalkPayload,
 		},
 		webhook_model.TELEGRAM: {
-			name:           webhook_model.TELEGRAM,
 			payloadCreator: GetTelegramPayload,
 		},
 		webhook_model.MSTEAMS: {
-			name:           webhook_model.MSTEAMS,
 			payloadCreator: GetMSTeamsPayload,
 		},
 		webhook_model.FEISHU: {
-			name:           webhook_model.FEISHU,
 			payloadCreator: GetFeishuPayload,
 		},
 		webhook_model.MATRIX: {
-			name:           webhook_model.MATRIX,
 			payloadCreator: GetMatrixPayload,
 		},
 		webhook_model.WECHATWORK: {
-			name:           webhook_model.WECHATWORK,
 			payloadCreator: GetWechatworkPayload,
 		},
 	}

--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -183,6 +183,6 @@ func (f *WechatworkPayload) Release(p *api.ReleasePayload) (api.Payloader, error
 }
 
 // GetWechatworkPayload GetWechatworkPayload converts a ding talk webhook into a WechatworkPayload
-func GetWechatworkPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetWechatworkPayload(p api.Payloader, event webhook_model.HookEventType, _ string) (api.Payloader, error) {
 	return convertPayloader(new(WechatworkPayload), p, event)
 }


### PR DESCRIPTION
- As title, it enables a new linter rule.
- Over the few weeks that I've traversed trough the code-base I've seen a little bit _too many_ issues that were caused by not used the correct paramaters, this could be prevented if a rule was erroring that the code has a unused paramater. With this rule you can be sure that you only use the paramaters that are needed, and within code-review, the reviewer knows that a certain paramater is not used within the scope of that function.
- Most are replaced with `_` some of them are "fixed". Added few `//FIXME/TODO` for things that I saw while going to a bit too many files.

Just to note, I'm still using `_` and not completely removing the parameter, as if I was reading such code it makes it more clear that it won't be used.