### PR TITLE
Fix vertical alignment on signature box

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2207,10 +2207,6 @@
     }
   }
 
-  .ui.attached.isSigned:not(.isWarning) .pull-right {
-    padding-top: 5px;
-  }
-
   .ui.attached.isSigned.isVerified {
     border-left: 1px solid #a3c293;
     border-right: 1px solid #a3c293;


### PR DESCRIPTION
Before:

<img width="1146" alt="Screenshot 2021-11-26 at 13 14 55" src="https://user-images.githubusercontent.com/115237/143579690-58984f78-c485-46e7-a8d3-5524bf0c3fa2.png">

After:

<img width="1145" alt="Screenshot 2021-11-26 at 13 15 03" src="https://user-images.githubusercontent.com/115237/143579683-e9861a0e-902c-4aa1-a66a-55bc3d2a831c.png">

Not sure what that selector was supposed to fix, but I think it no longer applies.