### PR TITLE
Handle relative unix socket paths

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -247,7 +247,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `HTTP_ADDR`: **0.0.0.0**: HTTP listen address.
    - If `PROTOCOL` is set to `fcgi`, Gitea will listen for FastCGI requests on TCP socket
      defined by `HTTP_ADDR` and `HTTP_PORT` configuration settings.
-   - If `PROTOCOL` is set to `unix` or `fcgi+unix`, this should be the name of the Unix socket file to use.
+   - If `PROTOCOL` is set to `unix` or `fcgi+unix`, this should be the name of the Unix socket file to use. Relative paths will be made absolute against the AppWorkPath.
 - `HTTP_PORT`: **3000**: HTTP listen port.
    - If `PROTOCOL` is set to `fcgi`, Gitea will listen for FastCGI requests on TCP socket
      defined by `HTTP_ADDR` and `HTTP_PORT` configuration settings.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -583,6 +583,10 @@ func NewContext() {
 	sec := Cfg.Section("server")
 	AppName = Cfg.Section("").Key("APP_NAME").MustString("Gitea: Git with a cup of tea")
 
+	Domain = sec.Key("DOMAIN").MustString("localhost")
+	HTTPAddr = sec.Key("HTTP_ADDR").MustString("0.0.0.0")
+	HTTPPort = sec.Key("HTTP_PORT").MustString("3000")
+
 	Protocol = HTTP
 	switch sec.Key("PROTOCOL").String() {
 	case "https":
@@ -605,6 +609,9 @@ func NewContext() {
 			log.Fatal("Failed to parse unixSocketPermission: %s", UnixSocketPermissionRaw)
 		}
 		UnixSocketPermission = uint32(UnixSocketPermissionParsed)
+		if !filepath.IsAbs(HTTPAddr) {
+			HTTPAddr = filepath.Join(AppWorkPath, HTTPAddr)
+		}
 	case "unix":
 		Protocol = UnixSocket
 		UnixSocketPermissionRaw := sec.Key("UNIX_SOCKET_PERMISSION").MustString("666")
@@ -613,6 +620,9 @@ func NewContext() {
 			log.Fatal("Failed to parse unixSocketPermission: %s", UnixSocketPermissionRaw)
 		}
 		UnixSocketPermission = uint32(UnixSocketPermissionParsed)
+		if !filepath.IsAbs(HTTPAddr) {
+			HTTPAddr = filepath.Join(AppWorkPath, HTTPAddr)
+		}
 	}
 	EnableLetsEncrypt = sec.Key("ENABLE_LETSENCRYPT").MustBool(false)
 	LetsEncryptTOS = sec.Key("LETSENCRYPT_ACCEPTTOS").MustBool(false)
@@ -626,9 +636,6 @@ func NewContext() {
 	SSLMaximumVersion = sec.Key("SSL_MAX_VERSION").MustString("")
 	SSLCurvePreferences = sec.Key("SSL_CURVE_PREFERENCES").Strings(",")
 	SSLCipherSuites = sec.Key("SSL_CIPHER_SUITES").Strings(",")
-	Domain = sec.Key("DOMAIN").MustString("localhost")
-	HTTPAddr = sec.Key("HTTP_ADDR").MustString("0.0.0.0")
-	HTTPPort = sec.Key("HTTP_PORT").MustString("3000")
 	GracefulRestartable = sec.Key("ALLOW_GRACEFUL_RESTARTS").MustBool(true)
 	GracefulHammerTime = sec.Key("GRACEFUL_HAMMER_TIME").MustDuration(60 * time.Second)
 	StartupTimeout = sec.Key("STARTUP_TIMEOUT").MustDuration(0 * time.Second)


### PR DESCRIPTION
Make relative unix sockets absolute by making them absolute against the AppWorkPath

Fix #17833

## :warning: BREAKING :warning: 

Prior to this PR relative unix sockets would have been asserted to be relative to the current working directory that gitea, gitea serv, hook and manager etc were running in. Hooks and Serv would have failed to work properly under this situation so we expect that although this is a technically breaking change the previous situation was already broken.

Signed-off-by: Andrew Thornton <art27@cantab.net>
