### PR TITLE
Fix value of User.IsRestricted when oauth2 user registration

### DIFF
--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -681,13 +681,14 @@ func SignInOAuthCallback(ctx *context.Context) {
 				return
 			}
 			u = &user_model.User{
-				Name:        getUserName(&gothUser),
-				FullName:    gothUser.Name,
-				Email:       gothUser.Email,
-				IsActive:    !setting.OAuth2Client.RegisterEmailConfirm,
-				LoginType:   login.OAuth2,
-				LoginSource: loginSource.ID,
-				LoginName:   gothUser.UserID,
+				Name:         getUserName(&gothUser),
+				FullName:     gothUser.Name,
+				Email:        gothUser.Email,
+				IsActive:     !setting.OAuth2Client.RegisterEmailConfirm,
+				LoginType:    login.OAuth2,
+				LoginSource:  loginSource.ID,
+				LoginName:    gothUser.UserID,
+				IsRestricted: setting.Service.DefaultUserIsRestricted,
 			}
 
 			if !createAndHandleCreatedUser(ctx, base.TplName(""), nil, u, &gothUser, setting.OAuth2Client.AccountLinking != setting.OAuth2AccountLinkingDisabled) {


### PR DESCRIPTION
Fix value of `User.IsRestricted` to default setting (`service.DEFAULT_USER_IS_RESTRICTED`) when oauth2 user auto registration (`oauth2_client.ENABLE_AUTO_REGISTRATION`);