### PR TITLE
Make Co-committed-by and co-authored-by trailers optional

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -900,6 +900,9 @@ PATH =
 ;;
 ;; In default merge messages only include approvers who are official
 ;DEFAULT_MERGE_MESSAGE_OFFICIAL_APPROVERS_ONLY = true
+;;
+;; Add co-authored-by and co-committed-by trailers if committer does not match author
+;ADD_CO_COMMITTER_TRAILERS = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -98,6 +98,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `DEFAULT_MERGE_MESSAGE_MAX_APPROVERS`: **10**: In default merge messages limit the number of approvers listed as `Reviewed-by:`. Set to `-1` to include all.
 - `DEFAULT_MERGE_MESSAGE_OFFICIAL_APPROVERS_ONLY`: **true**: In default merge messages only include approvers who are officially allowed to review.
 - `POPULATE_SQUASH_COMMENT_WITH_COMMIT_MESSAGES`: **false**: In default squash-merge messages include the commit message of all commits comprising the pull request.
+- `ADD_CO_COMMITTER_TRAILERS`: **true**: Add co-authored-by and co-committed-by trailers to merge commit messages if committer does not match author.
 
 ### Repository - Issue (`repository.issue`)
 

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -76,6 +76,7 @@ var (
 			DefaultMergeMessageMaxApprovers          int
 			DefaultMergeMessageOfficialApproversOnly bool
 			PopulateSquashCommentWithCommitMessages  bool
+			AddCoCommitterTrailers                   bool
 		} `ini:"repository.pull-request"`
 
 		// Issue Setting
@@ -196,6 +197,7 @@ var (
 			DefaultMergeMessageMaxApprovers          int
 			DefaultMergeMessageOfficialApproversOnly bool
 			PopulateSquashCommentWithCommitMessages  bool
+			AddCoCommitterTrailers                   bool
 		}{
 			WorkInProgressPrefixes: []string{"WIP:", "[WIP]"},
 			// Same as GitHub. See
@@ -208,6 +210,7 @@ var (
 			DefaultMergeMessageMaxApprovers:          10,
 			DefaultMergeMessageOfficialApproversOnly: true,
 			PopulateSquashCommentWithCommitMessages:  false,
+			AddCoCommitterTrailers:                   true,
 		},
 
 		// Issue settings

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -359,7 +359,7 @@ func rawMerge(pr *models.PullRequest, doer *user_model.User, mergeStyle models.M
 				return "", fmt.Errorf("git commit [%s:%s -> %s:%s]: %v\n%s\n%s", pr.HeadRepo.FullName(), pr.HeadBranch, pr.BaseRepo.FullName(), pr.BaseBranch, err, outbuf.String(), errbuf.String())
 			}
 		} else {
-			if committer != sig {
+			if setting.Repository.PullRequest.AddCoCommitterTrailers && committer.String() != sig.String() {
 				// add trailer
 				message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 			}


### PR DESCRIPTION
This PR adds another option to app.ini make co-committed-by and co-authored-by trailers
optional on a per server basis.

Also fixes a small bug.

Fix #17194

Signed-off-by: Andrew Thornton <art27@cantab.net>
