### PR TITLE
Fix typo in app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -121,7 +121,7 @@ RUN_MODE = ; prod
 ;SSH_SERVER_MACS = hmac-sha2-256-etm@openssh.com, hmac-sha2-256, hmac-sha1, hmac-sha1-96
 ;;
 ;; For the built-in SSH server, choose the keypair to offer as the host key
-;; The private key should be at SSH_SERVER_HOST_KEY and the public SSH_SERVER_HOST_KEY.pub
+;; The private key should be at SSH_SERVER_HOST_KEYS and the public SSH_SERVER_HOST_KEYS.pub
 ;; relative paths are made absolute relative to the APP_DATA_PATH
 ;SSH_SERVER_HOST_KEYS=ssh/gitea.rsa, ssh/gogs.rsa
 ;;


### PR DESCRIPTION
Small typos in `app.example.ini`: the comment lines mention variable `SSH_SERVER_HOST_KEY`, whereas the configuration variable is `SSH_SERVER_HOST_KEYS` (+`S` at the end). This variable is used in [setting.go](https://github.com/go-gitea/gitea/blob/b5a9ee94fd1f3bbe35bd19dfc4c7025e9f8e0768/modules/setting/setting.go#L141).

Thanks for considering this PR for merging!