### PR TITLE
Remove whitespace inside rendered code `<td>`

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -103,12 +103,8 @@
 						{{range $idx, $code := .FileContent}}
 						{{$line := Add $idx 1}}
 						<tr>
-							<td id="L{{$line}}" class="lines-num">
-								<span id="L{{$line}}" data-line-number="{{$line}}"></span>
-							</td>
-							<td rel="L{{$line}}" class="lines-code chroma">
-								<code class="code-inner">{{$code | Safe}}</code>
-							</td>
+							<td id="L{{$line}}" class="lines-num"><span id="L{{$line}}" data-line-number="{{$line}}"></span></td>
+							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$code | Safe}}</code></td>
 						</tr>
 						{{end}}
 					</tbody>


### PR DESCRIPTION
This extra whitespace caused isses in Firefox where it would copy a extra space character at the start and the end. Additionally, in Chrome, the text selection indicated a space on the end of the selection where there was none. Both issues are fixed with the removal of whitespace.