### PR TITLE
Fix position of label color picker colors

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2123,10 +2123,10 @@ table th[data-sortt-desc] {
 }
 
 .precolors {
-  padding-left: 0;
-  padding-right: 0;
-  margin: 3px 10px auto;
-  width: 120px;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  margin: 3px 10px auto !important;
+  width: 120px !important;
 
   .color {
     float: left;


### PR DESCRIPTION
Fix Regression from https://github.com/go-gitea/gitea/commit/ecfac78f6ef2cc01e4397c1a92b9a59b7ff0b2ff.

Before:
<img width="314" alt="Screen Shot 2021-11-30 at 17 49 52" src="https://user-images.githubusercontent.com/115237/144091954-0c898e92-3a8c-4dd5-997d-b17878e7838d.png">

After:
<img width="333" alt="Screen Shot 2021-11-30 at 17 50 04" src="https://user-images.githubusercontent.com/115237/144091960-5540b928-7cfa-456c-a36d-c78e21f661a8.png">
