### PR TITLE
Check if column exist before rename if exist, just return with no error

### DIFF
--- a/models/migrations/v184.go
+++ b/models/migrations/v184.go
@@ -35,7 +35,18 @@ func renameTaskErrorsToMessage(x *xorm.Engine) error {
 		return err
 	}
 	if exist {
-		return nil
+		errorsExist, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "task", "errors")
+		if err != nil {
+			return err
+		}
+		if !errorsExist {
+			return nil
+		}
+
+		// if both errors and message exist, drop message at first
+		if err := dropTableColumns(sess, "task", "message"); err != nil {
+			return err
+		}
 	}
 
 	switch {

--- a/models/migrations/v184.go
+++ b/models/migrations/v184.go
@@ -5,6 +5,7 @@
 package migrations
 
 import (
+	"context"
 	"fmt"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -27,6 +28,14 @@ func renameTaskErrorsToMessage(x *xorm.Engine) error {
 
 	if err := sess.Sync2(new(Task)); err != nil {
 		return fmt.Errorf("error on Sync2: %v", err)
+	}
+
+	exist, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "task", "message")
+	if err != nil {
+		return err
+	}
+	if exist {
+		return nil
 	}
 
 	switch {

--- a/models/migrations/v184.go
+++ b/models/migrations/v184.go
@@ -30,6 +30,7 @@ func renameTaskErrorsToMessage(x *xorm.Engine) error {
 		return fmt.Errorf("error on Sync2: %v", err)
 	}
 
+	// This migration maybe rerun so that we should check if it has been run
 	exist, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "task", "message")
 	if err != nil {
 		return err


### PR DESCRIPTION
Some people upgrade failed because of duplicated column message on task. Don't know how it addressed, but this PR could  prevent the failed upgrade.