### PR TITLE
Check if column exist before rename if exist, just return with no error (#17870)

### DIFF
--- a/models/migrations/v184.go
+++ b/models/migrations/v184.go
@@ -5,6 +5,7 @@
 package migrations
 
 import (
+	"context"
 	"fmt"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -19,6 +20,22 @@ func renameTaskErrorsToMessage(x *xorm.Engine) error {
 		Status int `xorm:"index"`
 	}
 
+	// This migration maybe rerun so that we should check if it has been run
+	messageExist, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "task", "message")
+	if err != nil {
+		return err
+	}
+
+	if messageExist {
+		errorsExist, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "task", "errors")
+		if err != nil {
+			return err
+		}
+		if !errorsExist {
+			return nil
+		}
+	}
+
 	sess := x.NewSession()
 	defer sess.Close()
 	if err := sess.Begin(); err != nil {
@@ -27,6 +44,13 @@ func renameTaskErrorsToMessage(x *xorm.Engine) error {
 
 	if err := sess.Sync2(new(Task)); err != nil {
 		return fmt.Errorf("error on Sync2: %v", err)
+	}
+
+	if messageExist {
+		// if both errors and message exist, drop message at first
+		if err := dropTableColumns(sess, "task", "message"); err != nil {
+			return err
+		}
 	}
 
 	switch {


### PR DESCRIPTION
backport from #17870 

* Check if column exist before rename if exist, just return with no error

* Also check if errors column exist

* Add comment for migration

* Fix sqlite test
