### PR TITLE
Use fmt.Sprintf correctly

### DIFF
--- a/contrib/pr/checkout.go
+++ b/contrib/pr/checkout.go
@@ -215,7 +215,7 @@ func main() {
 		//Use git cli command for windows
 		runCmd("git", "fetch", remoteUpstream, fmt.Sprintf("pull/%s/head:%s", pr, branch))
 	} else {
-		ref := fmt.Sprintf(gitea_git.PullPrefix+"%s/head:%s", pr, branchRef)
+		ref := fmt.Sprintf("%s%s/head:%s", gitea_git.PullPrefix, pr, branchRef)
 		err = repo.Fetch(&git.FetchOptions{
 			RemoteName: remoteUpstream,
 			RefSpecs: []config.RefSpec{

--- a/models/pull.go
+++ b/models/pull.go
@@ -350,7 +350,7 @@ func (pr *PullRequest) GetDefaultSquashMessage() string {
 
 // GetGitRefName returns git ref for hidden pull request branch
 func (pr *PullRequest) GetGitRefName() string {
-	return fmt.Sprintf(git.PullPrefix+"%d/head", pr.Index)
+	return fmt.Sprintf("%s%d/head", git.PullPrefix, pr.Index)
 }
 
 // IsChecking returns true if this pull request is still checking conflict.

--- a/modules/convert/pull.go
+++ b/modules/convert/pull.go
@@ -79,7 +79,7 @@ func ToAPIPullRequest(pr *models.PullRequest, doer *user_model.User) *api.PullRe
 		},
 		Head: &api.PRBranchInfo{
 			Name:   pr.HeadBranch,
-			Ref:    fmt.Sprintf(git.PullPrefix+"%d/head", pr.Index),
+			Ref:    fmt.Sprintf("%s%d/head", git.PullPrefix, pr.Index),
 			RepoID: -1,
 		},
 	}

--- a/modules/migration/pullrequest.go
+++ b/modules/migration/pullrequest.go
@@ -45,7 +45,7 @@ func (p *PullRequest) IsForkPullRequest() bool {
 
 // GetGitRefName returns pull request relative path to head
 func (p PullRequest) GetGitRefName() string {
-	return fmt.Sprintf(git.PullPrefix+"%d/head", p.Number)
+	return fmt.Sprintf("%s%d/head", git.PullPrefix, p.Number)
 }
 
 // PullRequestBranch represents a pull request branch


### PR DESCRIPTION
Previously, String concatenation was mixed into `fmt.Sprintf` in some places.
Refactored those places to only use `fmt.Sprintf`.   
