### PR TITLE
Add pprof information to seek-help documents

### DIFF
--- a/docs/content/doc/help/seek-help.en-us.md
+++ b/docs/content/doc/help/seek-help.en-us.md
@@ -22,10 +22,18 @@ menu:
 
 1. Your `app.ini` (with any sensitive data scrubbed as necessary)
 2. The `gitea.log` (and any other appropriate log files for the situation)
-  * e.g. If the error is related to the database, the `xorm.log` might be helpful
+    * e.g. If the error is related to the database, the `xorm.log` might be helpful
 3. Any error messages you are seeing
 4. When possible, try to replicate the issue on [try.gitea.io](https://try.gitea.io) and include steps so that others can reproduce the issue.
-  * This will greatly improve the chance that the root of the issue can be quickly discovered and resolved.
+    * This will greatly improve the chance that the root of the issue can be quickly discovered and resolved.
+5. If you meet slow/hanging/deadlock problems, please report the stack trace when the problem occurs:
+    1. Enable pprof in `app.ini` and restart Gitea
+    ```
+    [server]
+    ENABLE_PPROF = true
+    ```
+    2. Trigger the bug, when Gitea gets stuck, use curl or browser to visit: `http://127.0.0.1:6060/debug/pprof/goroutine?debug=1` (IP is `127.0.0.1` and port is `6060`)
+    3. Report the output (the stack trace doesn't contain sensitive data)
 
 ## Bugs
 
@@ -33,4 +41,4 @@ If you found a bug, please create an [issue on GitHub](https://github.com/go-git
 
 ## Chinese Support
 
-Support for the Chinese language is provided at [Our discourse](https://discourse.gitea.io/c/5-category/5).
+Support for the Chinese language is provided at [Our discourse](https://discourse.gitea.io/c/5-category/5) or QQ Group 328432459.

--- a/docs/content/doc/help/seek-help.zh-cn.md
+++ b/docs/content/doc/help/seek-help.zh-cn.md
@@ -17,7 +17,7 @@ menu:
 
 如果您在使用或者开发过程中遇到问题，请到以下渠道咨询：
 
-- 到[Github issue](https://github.com/go-gitea/gitea/issues)提问(因为项目维护人员来自世界各地，为保证沟通顺畅，请使用英文提问)
-- 中文问题到 [Gitea 论坛](https://discourse.gitea.io/c/5-category/5)提问
-- 访问 [Discord server - 英文](https://discord.gg/Gitea)
+- 到 [GitHub Issue](https://github.com/go-gitea/gitea/issues) 提问(因为项目维护人员来自世界各地，为保证沟通顺畅，请使用英文提问)
+- 中文问题到 [Gitea 论坛](https://discourse.gitea.io/c/5-category/5) 提问
+- 访问 [Discord Gitea 聊天室 - 英文](https://discord.gg/Gitea)
 - 加入 QQ群 328432459 获得进一步的支持

--- a/docs/content/doc/help/seek-help.zh-tw.md
+++ b/docs/content/doc/help/seek-help.zh-tw.md
@@ -22,10 +22,12 @@ menu:
 
 1. 您的 `app.ini` (必要時清除掉任何機密資訊)
 2. `gitea.log` (以及任何有關的日誌檔案)
-  * 例：如果錯誤和資料庫相關，提供 `xorm.log` 可能會有幫助
+    * 例：如果錯誤和資料庫相關，提供 `xorm.log` 可能會有幫助
 3. 您看到的任何錯誤訊息
-5. 儘可能地在 [try.gitea.io](https://try.gitea.io) 觸發您的問題並記下步驟，以便其他人能重現那個問題。
-  * 這將讓我們更有機會快速地找出問題的根源並解決它。
+4. 儘可能地在 [try.gitea.io](https://try.gitea.io) 觸發您的問題並記下步驟，以便其他人能重現那個問題。
+    * 這將讓我們更有機會快速地找出問題的根源並解決它。
+5. 堆棧跟踪，[請參考英文文檔](https://docs.gitea.io/en-us/seek-help/)
 
 ## 錯誤回報
-如果您發現錯誤，請到 [Github 的 Issue](https://github.com/go-gitea/gitea/issues) 回報。
+
+如果您發現錯誤，請到 [GitHub 的 Issue](https://github.com/go-gitea/gitea/issues) 回報。


### PR DESCRIPTION
As the title.

1. Teach users how to get stack trace when slow/hanging/deadlock problem occurs. It helps users:
    * https://github.com/go-gitea/gitea/issues/15542
    * https://github.com/go-gitea/gitea/issues/15143
    * https://github.com/go-gitea/gitea/issues/17138
    * https://github.com/go-gitea/gitea/issues/17504
    * and so on

2. Improve zh-cn and zh-tw documents.