### PR TITLE
Send commit object in http response header for archives

### DIFF
--- a/integrations/repo_download_test.go
+++ b/integrations/repo_download_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// based on repo_commits_test.go
+
+package integrations
+
+import (
+	"net/http"
+	"path"
+	"testing"
+	"encoding/base64"
+
+	"github.com/stretchr/testify/assert"
+	// gitea/integrations/integration_test.go -> NewRequest
+)
+
+// gitea/routers/web/repo/repo.go: addCommitObjectResponseHeader
+func TestRepoDownloadWithCommitObject(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	// Request repository commits page
+	req := NewRequest(t, "GET", "/user2/repo1/commits/branch/master")
+	resp := MakeRequest(t, req, http.StatusOK)
+
+	doc := NewHTMLParser(t, resp.Body)
+	// Get first commit URL
+	commitURL, exists := doc.doc.Find("#commits-table tbody tr td.sha a").Attr("href")
+	assert.True(t, exists)
+	assert.NotEmpty(t, commitURL)
+
+	commitHash := path.Base(commitURL)
+
+	q2 := NewRequest(t, "GET", "/user2/repo1/archive/"+commitHash+".tar.gz")
+	assert.NotNil(t, q2)
+	q2.Header.Set("X-Commit-Object", "1") // request the commit object
+	r2 := MakeRequest(t, q2, http.StatusOK)
+	// decode the commit object
+	str64 := r2.Header().Get("X-Commit-Object")
+	bytes, err := base64.StdEncoding.DecodeString(str64)
+	assert.NoError(t, err)
+	str := string(bytes)
+	strExpected := (
+		"tree 2a2f1d4670728a2e10049e345bd7a276468beab6\n" +
+		"author user1 <address1@example.com> 1489956479 -0400\n" +
+		"committer Ethan Koenig <ethantkoenig@gmail.com> 1489956479 -0400\n" +
+		"\n" +
+		"Initial commit\n")
+	assert.Equal(t, str, strExpected)
+}

--- a/integrations/repo_download_test.go
+++ b/integrations/repo_download_test.go
@@ -7,14 +7,15 @@
 package integrations
 
 import (
+	"encoding/base64"
 	"net/http"
 	"path"
 	"testing"
-	"encoding/base64"
 
 	"github.com/stretchr/testify/assert"
-	// gitea/integrations/integration_test.go -> NewRequest
 )
+
+// gitea/integrations/integration_test.go -> NewRequest
 
 // gitea/routers/web/repo/repo.go: addCommitObjectResponseHeader
 func TestRepoDownloadWithCommitObject(t *testing.T) {
@@ -41,7 +42,7 @@ func TestRepoDownloadWithCommitObject(t *testing.T) {
 	bytes, err := base64.StdEncoding.DecodeString(str64)
 	assert.NoError(t, err)
 	str := string(bytes)
-	strExpected := (
+	strExpected := ("" +
 		"tree 2a2f1d4670728a2e10049e345bd7a276468beab6\n" +
 		"author user1 <address1@example.com> 1489956479 -0400\n" +
 		"committer Ethan Koenig <ethantkoenig@gmail.com> 1489956479 -0400\n" +

--- a/models/repo_archiver.go
+++ b/models/repo_archiver.go
@@ -6,7 +6,6 @@ package models
 
 import (
 	"code.gitea.io/gitea/models/db"
-
 	repo_model "code.gitea.io/gitea/models/repo"
 )
 

--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -85,6 +85,17 @@ func (repo *Repository) GetCommitByPath(relpath string) (*Commit, error) {
 	return commits[0], nil
 }
 
+// GetCommitObject returns the raw commit object.
+func (repo *Repository) GetCommitObject(commitID string) ([]byte, error) {
+	// we need a bit-exact copy of the commit object for hash calculation
+	// -p = print
+	stdout, err := NewCommandContext(repo.Ctx, "cat-file", "-p", commitID).RunInDirBytes(repo.Path)
+	if err != nil {
+		return nil, err
+	}
+	return stdout, nil
+}
+
 func (repo *Repository) commitsByRange(id SHA1, page, pageSize int) ([]*Commit, error) {
 	stdout, err := NewCommandContext(repo.Ctx, "log", id.String(), "--skip="+strconv.Itoa((page-1)*pageSize),
 		"--max-count="+strconv.Itoa(pageSize), prettyLogFormat).RunInDirBytes(repo.Path)

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -6,12 +6,12 @@
 package repo
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
-	"encoding/base64"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/models/db"


### PR DESCRIPTION
fix #17834

demo

```
url=http://localhost:3000/asdfasdf/asdfasdf/archive/master.zip

curl --verbose --header 'X-Commit-Object: 1' --output /dev/null $url 2>&1 | grep X-Commit-Object 
> X-Commit-Object: 1
< X-Commit-Object: dHJlZSAyZTkwMGI5YTFhOTllZWM3YzlmMDFlN2QxMTNmNDg4YWQyOGU0NmVmCmF1dGhvciBhc2RmYXNkZiA8YXNkZkBsb2NhbGhvc3QubG9jYWxkb21haW4+IDE2Mzg3OTkyNzggKzAxMDAKY29tbWl0dGVyIGFzZGZhc2RmIDxhc2RmQGxvY2FsaG9zdC5sb2NhbGRvbWFpbj4gMTYzODc5OTI3OCArMDEwMAoKSW5pdGlhbCBjb21taXQK

echo -n dHJlZSAyZTkwMGI5YTFhOTllZWM3YzlmMDFlN2QxMTNmNDg4YWQyOGU0NmVmCmF1dGhvciBhc2RmYXNkZiA8YXNkZkBsb2NhbGhvc3QubG9jYWxkb21haW4+IDE2Mzg3OTkyNzggKzAxMDAKY29tbWl0dGVyIGFzZGZhc2RmIDxhc2RmQGxvY2FsaG9zdC5sb2NhbGRvbWFpbj4gMTYzODc5OTI3OCArMDEwMAoKSW5pdGlhbCBjb21taXQK | base64 -d
tree 2e900b9a1a99eec7c9f01e7d113f488ad28e46ef
author asdfasdf <asdf@localhost.localdomain> 1638799278 +0100
committer asdfasdf <asdf@localhost.localdomain> 1638799278 +0100

Initial commit

```
