### PR TITLE
Remove unnecessary `X-Remote` HTTP header in AJAX request

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -59,7 +59,6 @@ function updateDeadline(deadlineString) {
     }),
     headers: {
       'X-Csrf-Token': csrfToken,
-      'X-Remote': true,
     },
     contentType: 'application/json',
     type: 'POST',

--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -25,7 +25,6 @@ async function initRepoProjectSortable() {
             data: JSON.stringify({sorting: i, color: rgbToHex($(column).css('backgroundColor'))}),
             headers: {
               'X-Csrf-Token': csrfToken,
-              'X-Remote': true,
             },
             contentType: 'application/json',
             method: 'PUT',
@@ -47,7 +46,6 @@ async function initRepoProjectSortable() {
         $.ajax(`${url}/${issue}`, {
           headers: {
             'X-Csrf-Token': csrfToken,
-            'X-Remote': true,
           },
           contentType: 'application/json',
           type: 'POST',
@@ -90,7 +88,6 @@ export default function initRepoProject() {
           data: JSON.stringify({title: projectTitleInput.val(), color: projectColorInput.val()}),
           headers: {
             'X-Csrf-Token': csrfToken,
-            'X-Remote': true,
           },
           contentType: 'application/json',
           method: 'PUT',
@@ -114,7 +111,6 @@ export default function initRepoProject() {
       url: $(this).data('url'),
       headers: {
         'X-Csrf-Token': csrfToken,
-        'X-Remote': true,
       },
       contentType: 'application/json',
     });
@@ -130,7 +126,6 @@ export default function initRepoProject() {
         url: $(this).data('url'),
         headers: {
           'X-Csrf-Token': csrfToken,
-          'X-Remote': true,
         },
         contentType: 'application/json',
         method: 'DELETE',
@@ -151,7 +146,6 @@ export default function initRepoProject() {
       data: JSON.stringify({title: boardTitle.val(), color: projectColorInput.val()}),
       headers: {
         'X-Csrf-Token': csrfToken,
-        'X-Remote': true,
       },
       contentType: 'application/json',
       method: 'POST',


### PR DESCRIPTION
There are many `X-Remote: true` header in jQuery AJAX request.

These headers is likely added by misunderstanding and copy&paste.

This PR removes these unnecessary headers, and prevent developers from copying&pasting these incorrect headers to new code in future.
