### PR TITLE
Fix overflow in commit graph

### DIFF
--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -28,7 +28,7 @@
 							{{- end -}}
 						</a>
 					</span>
-					<span class="message df ac mr-2">{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</span>
+					<span class="message dib ellipsis mr-2">{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</span>
 					<span class="tags df ac">
 						{{range $commit.Refs}}
 							{{$refGroup := .RefGroup}}

--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -28,27 +28,29 @@
 							{{- end -}}
 						</a>
 					</span>
-					<span class="message dib ellipsis mr-2">{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</span>
+					<span class="message dib ellipsis mr-2">
+						<div class="di">{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</div>
+					</span>
 					<span class="tags df ac">
 						{{range $commit.Refs}}
 							{{$refGroup := .RefGroup}}
 							{{if eq $refGroup "pull"}}
 								{{if or (not $.HidePRRefs) (containGeneric $.SelectedBranches .Name)}}
 									<!-- it's intended to use issues not pulls, if it's a pull you will get redirected -->
-									<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/{{if $.Repository.UnitEnabled $.UnitTypePullRequests}}pulls{{else}}issues{{end}}/{{.ShortName|PathEscape}}">
+									<a class="ui labelled icon button basic tiny mr-2" href="{{$.RepoLink}}/{{if $.Repository.UnitEnabled $.UnitTypePullRequests}}pulls{{else}}issues{{end}}/{{.ShortName|PathEscape}}">
 										{{svg "octicon-git-pull-request" 16 "mr-2"}}#{{.ShortName}}
 									</a>
 								{{end}}
 							{{else if eq $refGroup "tags"}}
-								<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/src/tag/{{.ShortName|PathEscape}}">
+								<a class="ui labelled icon button basic tiny mr-2" href="{{$.RepoLink}}/src/tag/{{.ShortName|PathEscape}}">
 									{{svg "octicon-tag" 16 "mr-2"}}{{.ShortName}}
 								</a>
 							{{else if eq $refGroup "remotes"}}
-								<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/src/commit/{{$commit.Rev|PathEscape}}">
+								<a class="ui labelled icon button basic tiny mr-2" href="{{$.RepoLink}}/src/commit/{{$commit.Rev|PathEscape}}">
 									{{svg "octicon-cross-reference" 16 "mr-2"}}{{.ShortName}}
 								</a>
 							{{else if eq $refGroup "heads"}}
-								<a class="ui labelled icon button basic tiny" href="{{$.RepoLink}}/src/branch/{{.ShortName|PathEscape}}">
+								<a class="ui labelled icon button basic tiny mr-2" href="{{$.RepoLink}}/src/branch/{{.ShortName|PathEscape}}">
 									{{svg "octicon-git-branch" 16 "mr-2"}}{{.ShortName}}
 								</a>
 							{{else}}

--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -29,7 +29,7 @@
 						</a>
 					</span>
 					<span class="message dib ellipsis mr-2">
-						<div class="di">{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</div>
+						<span>{{RenderCommitMessage $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</span>
 					</span>
 					<span class="tags df ac">
 						{{range $commit.Refs}}

--- a/web_src/less/features/gitgraph.less
+++ b/web_src/less/features/gitgraph.less
@@ -137,7 +137,7 @@
     .author .ui.avatar.image {
       width: auto;
       height: 18px;
-      max-width: initial;
+      max-width: none;
     }
   }
 

--- a/web_src/less/features/gitgraph.less
+++ b/web_src/less/features/gitgraph.less
@@ -137,10 +137,7 @@
     .author .ui.avatar.image {
       width: auto;
       height: 18px;
-    }
-
-    .message {
-      max-width: 50%;
+      max-width: initial;
     }
   }
 

--- a/web_src/less/features/gitgraph.less
+++ b/web_src/less/features/gitgraph.less
@@ -138,6 +138,10 @@
       width: auto;
       height: 18px;
     }
+
+    .message {
+      max-width: 50%;
+    }
   }
 
   #graph-raw-list {

--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -28,6 +28,12 @@
   word-wrap: break-word !important;
 }
 
+.ellipsis {
+  overflow: hidden !important;
+  white-space: nowrap !important;
+  text-overflow: ellipsis !important;
+}
+
 .full-screen-width { width: 100vw !important; }
 .full-screen-height { height: 100vh !important; }
 


### PR DESCRIPTION
Limit commit message to 50% width. This is rather crude but should work for common use cases with not too-long author names.

Fixes: #17944

Before:
<img width="1270" alt="Screenshot 2021-12-10 at 11 09 59" src="https://user-images.githubusercontent.com/115237/145557058-353108fd-5b9d-4f8a-b301-a931cb76c253.png">

After:
<img width="1266" alt="Screenshot 2021-12-10 at 11 10 39" src="https://user-images.githubusercontent.com/115237/145557063-c377beef-4871-4041-a42e-902e1e443fdf.png">
