### PR TITLE
[wip] Pin repositories

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -111,6 +111,7 @@ type Repository struct {
 	IsEmpty    bool `xorm:"INDEX"`
 	IsArchived bool `xorm:"INDEX"`
 	IsMirror   bool `xorm:"INDEX"`
+	IsPinned   bool
 	*Mirror    `xorm:"-"`
 	Status     RepositoryStatus `xorm:"NOT NULL DEFAULT 0"`
 

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -93,6 +93,8 @@ type Repository struct {
 	AvatarURL                 string           `json:"avatar_url"`
 	Internal                  bool             `json:"internal"`
 	MirrorInterval            string           `json:"mirror_interval"`
+    Pinned                    bool             `json:"pinned"`
+    PinnedOrder               int              `json:"pinned_order"`
 }
 
 // CreateRepoOption options when creating repository
@@ -180,6 +182,10 @@ type EditRepoOption struct {
 	Archived *bool `json:"archived,omitempty"`
 	// set to a string like `8h30m0s` to set the mirror interval time
 	MirrorInterval *string `json:"mirror_interval,omitempty"`
+    // pins the repo on the start of the user home page
+    Pinned *bool `json:"pinned"`
+    // defines in which order the repo will shown up at the pinned list
+    PinnedOrder *int `json:"pinned_order"`
 }
 
 // GenerateRepoOption options when creating repository using a template

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -93,8 +93,8 @@ type Repository struct {
 	AvatarURL                 string           `json:"avatar_url"`
 	Internal                  bool             `json:"internal"`
 	MirrorInterval            string           `json:"mirror_interval"`
-    Pinned                    bool             `json:"pinned"`
-    PinnedOrder               int              `json:"pinned_order"`
+	Pinned                    bool             `json:"pinned"`
+	PinnedOrder               int              `json:"pinned_order"`
 }
 
 // CreateRepoOption options when creating repository
@@ -182,10 +182,10 @@ type EditRepoOption struct {
 	Archived *bool `json:"archived,omitempty"`
 	// set to a string like `8h30m0s` to set the mirror interval time
 	MirrorInterval *string `json:"mirror_interval,omitempty"`
-    // pins the repo on the start of the user home page
-    Pinned *bool `json:"pinned"`
-    // defines in which order the repo will shown up at the pinned list
-    PinnedOrder *int `json:"pinned_order"`
+	// pins the repo on the start of the user home page
+	Pinned *bool `json:"pinned"`
+	// defines in which order the repo will shown up at the pinned list
+	PinnedOrder *int `json:"pinned_order"`
 }
 
 // GenerateRepoOption options when creating repository using a template

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -574,6 +574,7 @@ func GetByID(ctx *context.APIContext) {
 	}
 	ctx.JSON(http.StatusOK, convert.ToRepo(repo, perm.AccessMode))
 }
+
 //TODO pin repo
 // Edit edit repository properties
 func Edit(ctx *context.APIContext) {

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -574,7 +574,7 @@ func GetByID(ctx *context.APIContext) {
 	}
 	ctx.JSON(http.StatusOK, convert.ToRepo(repo, perm.AccessMode))
 }
-
+//TODO pin repo
 // Edit edit repository properties
 func Edit(ctx *context.APIContext) {
 	// swagger:operation PATCH /repos/{owner}/{repo} repository repoEdit

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -48,6 +48,15 @@
 					<label for="website">{{.i18n.Tr "repo.settings.site"}}</label>
 					<input id="website" name="website" type="url" value="{{.Repository.Website}}">
 				</div>
+            
+
+                <div class="inline field {{if .Err_Pinned}}error{{end}}">
+                    <div class="ui checkbox">
+						<input name="pinned" type="checkbox" {{if .Repository.IsPinned}}checked{{end}}>
+						<label>{{.i18n.Tr "repo.PinRepo"}}</label>
+					</div>
+				</div>
+
 
 				<div class="field">
 					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>


### PR DESCRIPTION
<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/master/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
Just a placeholder for #10375 MR in order to get feedback as I go with the changes (my first time coding at gitea).

My plan is:

- Add the fields pinned (boolean) and pinnedOrder (int) to the repo itself, and for now, allow changing these fields with the edit repository API call. I'm not sure if this is the best path or I should create an API just for this.
- We probably want to limit the number of pinned repositories. Even if we don't use it right now, I think I will code the ability to do it in the backend.
