### PR TITLE
Prevent deadlock in create issue

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -141,7 +141,7 @@ func (issue *Issue) isTimetrackerEnabled(ctx context.Context) bool {
 		log.Error(fmt.Sprintf("loadRepo: %v", err))
 		return false
 	}
-	return issue.Repo.IsTimetrackerEnabled()
+	return issue.Repo.IsTimetrackerEnabledCtx(ctx)
 }
 
 // GetPullRequest returns the issue pull request

--- a/models/repo/issue.go
+++ b/models/repo/issue.go
@@ -28,13 +28,18 @@ func (repo *Repository) CanEnableTimetracker() bool {
 
 // IsTimetrackerEnabled returns whether or not the timetracker is enabled. It returns the default value from config if an error occurs.
 func (repo *Repository) IsTimetrackerEnabled() bool {
+	return repo.IsTimetrackerEnabledCtx(db.DefaultContext)
+}
+
+// IsTimetrackerEnabled returns whether or not the timetracker is enabled. It returns the default value from config if an error occurs.
+func (repo *Repository) IsTimetrackerEnabledCtx(ctx context.Context) bool {
 	if !setting.Service.EnableTimetracking {
 		return false
 	}
 
 	var u *RepoUnit
 	var err error
-	if u, err = repo.GetUnit(unit.TypeIssues); err != nil {
+	if u, err = repo.GetUnitCtx(ctx, unit.TypeIssues); err != nil {
 		return setting.Service.DefaultEnableTimetracking
 	}
 	return u.IssuesConfig().EnableTimetracker
@@ -59,7 +64,7 @@ func (repo *Repository) IsDependenciesEnabled() bool {
 func (repo *Repository) IsDependenciesEnabledCtx(ctx context.Context) bool {
 	var u *RepoUnit
 	var err error
-	if u, err = repo.getUnit(ctx, unit.TypeIssues); err != nil {
+	if u, err = repo.GetUnitCtx(ctx, unit.TypeIssues); err != nil {
 		log.Trace("%s", err)
 		return setting.Service.DefaultEnableDependencies
 	}

--- a/models/repo/issue.go
+++ b/models/repo/issue.go
@@ -31,7 +31,7 @@ func (repo *Repository) IsTimetrackerEnabled() bool {
 	return repo.IsTimetrackerEnabledCtx(db.DefaultContext)
 }
 
-// IsTimetrackerEnabled returns whether or not the timetracker is enabled. It returns the default value from config if an error occurs.
+// IsTimetrackerEnabledCtx returns whether or not the timetracker is enabled. It returns the default value from config if an error occurs.
 func (repo *Repository) IsTimetrackerEnabledCtx(ctx context.Context) bool {
 	if !setting.Service.EnableTimetracking {
 		return false

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -312,10 +312,11 @@ func (repo *Repository) MustGetUnit(tp unit.Type) *RepoUnit {
 
 // GetUnit returns a RepoUnit object
 func (repo *Repository) GetUnit(tp unit.Type) (*RepoUnit, error) {
-	return repo.getUnit(db.DefaultContext, tp)
+	return repo.GetUnitCtx(db.DefaultContext, tp)
 }
 
-func (repo *Repository) getUnit(ctx context.Context, tp unit.Type) (*RepoUnit, error) {
+// GetUnitCtx returns a RepoUnit object
+func (repo *Repository) GetUnitCtx(ctx context.Context, tp unit.Type) (*RepoUnit, error) {
 	if err := repo.LoadUnits(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When we have a transaction - queries to tables already queried must be queried within
that transaction.

repo.IsTimeTrackerEnabled() called repo.GetUnit() meaning that issue.loadAttributes
causes a deadlock.

Signed-off-by: Andrew Thornton <art27@cantab.net>
