### PR TITLE
Return nicer error for ForcePrivate

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -443,6 +443,7 @@ lang_select_error = Select a language from the list.
 username_been_taken = The username is already taken.
 username_change_not_local_user = Non-local users are not allowed to change their username.
 repo_name_been_taken = The repository name is already used.
+repository_force_private = Force Private is enabled: private repositories cannot be made public.
 repository_files_already_exist = Files already exist for this repository. Contact the system administrator.
 repository_files_already_exist.adopt = Files already exist for this repository and can only be Adopted.
 repository_files_already_exist.delete = Files already exist for this repository. You must delete them.

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -144,7 +144,7 @@ func SettingsPost(ctx *context.Context) {
 		visibilityChanged := repo.IsPrivate != form.Private
 		// when ForcePrivate enabled, you could change public repo to private, but only admin users can change private to public
 		if visibilityChanged && setting.Repository.ForcePrivate && !form.Private && !ctx.User.IsAdmin {
-			ctx.ServerError("Force Private enabled", errors.New("cannot change private repository to public"))
+			ctx.RenderWithErr(ctx.Tr("form.repository_force_private"), tplSettingsOptions, form)
 			return
 		}
 


### PR DESCRIPTION
Instead of returning an ISE just return the form with a flash error instead.

Fix #17967

Signed-off-by: Andrew Thornton <art27@cantab.net>
