### PR TITLE
Adjust issues.closed locale strings

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1227,9 +1227,9 @@ issues.action_assignee_no_select = No assignee
 issues.opened_by = opened %[1]s by <a href="%[2]s">%[3]s</a>
 pulls.merged_by = merged %[1]s by <a href="%[2]s">%[3]s</a>
 pulls.merged_by_fake = merged %[1]s by %[2]s
-issues.closed_by = closed %[1]s by <a href="%[2]s">%[3]s</a>
+issues.closed_by = by <a href="%[2]s">%[3]s</a> closed %[1]s
 issues.opened_by_fake = opened %[1]s by %[2]s
-issues.closed_by_fake = closed %[1]s by %[2]s
+issues.closed_by_fake = by %[2]s closed %[1]s
 issues.previous = Previous
 issues.next = Next
 issues.open_title = Open


### PR DESCRIPTION
Rearrange the order of by and closed to make it clearer that the user is the opening
user - not the closing user.

Fix #17942

Signed-off-by: Andrew Thornton <art27@cantab.net>
