### PR TITLE
Fixed issue merged/closed wording

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1225,11 +1225,11 @@ issues.action_milestone_no_select = No milestone
 issues.action_assignee = Assignee
 issues.action_assignee_no_select = No assignee
 issues.opened_by = opened %[1]s by <a href="%[2]s">%[3]s</a>
-pulls.merged_by = merged %[1]s by <a href="%[2]s">%[3]s</a>
-pulls.merged_by_fake = merged %[1]s by %[2]s
-issues.closed_by = closed %[1]s by <a href="%[2]s">%[3]s</a>
+pulls.merged_by = by <a href="%[2]s">%[3]s</a> was merged %[1]s
+pulls.merged_by_fake = by %[2]s was merged %[1]s
+issues.closed_by = by <a href="%[2]s">%[3]s</a> was closed %[1]s
 issues.opened_by_fake = opened %[1]s by %[2]s
-issues.closed_by_fake = closed %[1]s by %[2]s
+issues.closed_by_fake = by %[2]s was closed %[1]s
 issues.previous = Previous
 issues.next = Next
 issues.open_title = Open


### PR DESCRIPTION
Fixes #17942

old:
```
#xxx opened <time> by <creator>
#xxx merged <time> by <creator>
#xxx closed <time> by <creator>
```

new:
```
#xxx opened <time> by <creator>
#xxx by <creator> was merged <time>
#xxx by <creator> was closed <time>
```