### PR TITLE
Shorten page title in file view

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -141,6 +141,10 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 		return
 	}
 
+	if ctx.Repo.TreePath != "" {
+		ctx.Data["Title"] = ctx.Tr("repo.file.title", ctx.Repo.Repository.Name+"/"+path.Base(ctx.Repo.TreePath), ctx.Repo.RefName)
+	}
+
 	// 3 for the extensions in exts[] in order
 	// the last one is for a readme that doesn't
 	// strictly match an extension
@@ -374,7 +378,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 	}
 	defer dataRc.Close()
 
-	ctx.Data["Title"] = ctx.Data["Title"].(string) + " - " + ctx.Tr("repo.file.title", ctx.Repo.TreePath, ctx.Repo.RefName)
+	ctx.Data["Title"] = ctx.Tr("repo.file.title", ctx.Repo.Repository.Name+"/"+path.Base(ctx.Repo.TreePath), ctx.Repo.RefName)
 
 	fileSize := blob.Size()
 	ctx.Data["FileIsSymlink"] = entry.IsLink()


### PR DESCRIPTION
Move the more relevant sections of the page title earlier which make it possible to distinguish multiple tabs from each other when tab width is limited.

Before:
<img width="283" alt="Screen Shot 2021-12-15 at 00 51 34" src="https://user-images.githubusercontent.com/115237/146097611-eef2116d-fac1-43a3-b76d-3bf996942ac7.png">

After:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/115237/146097791-0ecb034d-f280-43cc-9cf7-f95d36ea6c6a.png">

