### PR TITLE
Fix TemplateRepo no longer in models.repo

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -683,7 +683,7 @@ func getTemplateRepo(e db.Engine, repo *Repository) (*Repository, error) {
 	return getRepositoryByID(e, repo.TemplateID)
 }
 
-// TemplateRepo returns the repository link
+// TemplateRepo returns the repository, which is template of this repository
 func (repo *Repository) TemplateRepo() *Repository {
 	repos, err := GetTemplateRepo(repo)
 	if err != nil {

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -685,7 +685,7 @@ func getTemplateRepo(e db.Engine, repo *Repository) (*Repository, error) {
 
 // TemplateRepo returns the repository, which is template of this repository
 func (repo *Repository) TemplateRepo() *Repository {
-	repos, err := GetTemplateRepo(repo)
+	repo, err := GetTemplateRepo(repo)
 	if err != nil {
 		log.Error("TemplateRepo: %v", err)
 		return nil

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -683,6 +683,16 @@ func getTemplateRepo(e db.Engine, repo *Repository) (*Repository, error) {
 	return getRepositoryByID(e, repo.TemplateID)
 }
 
+// TemplateRepo returns the repository link
+func (repo *Repository) TemplateRepo() *Repository {
+	repos, err := GetTemplateRepo(repo)
+	if err != nil {
+		log.Error("TemplateRepo: %v", err)
+		return nil
+	}
+	return repos
+}
+
 func countRepositories(userID int64, private bool) int64 {
 	sess := db.GetEngine(db.DefaultContext).Where("id > 0")
 

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -690,7 +690,7 @@ func (repo *Repository) TemplateRepo() *Repository {
 		log.Error("TemplateRepo: %v", err)
 		return nil
 	}
-	return repos
+	return repo
 }
 
 func countRepositories(userID int64, private bool) int64 {


### PR DESCRIPTION
Fixes error 500 that appears when trying to browse code of a repository generated from template


