### PR TITLE
Installing LTS nodejs 16.13.1 (fix build on arm/v7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 
 ###################################
 #Build stage
+FROM node:16.13.1-alpine AS node
 FROM golang:1.17-alpine3.13 AS build-env
 
 ARG GOPROXY
@@ -12,7 +13,13 @@ ENV TAGS "bindata timetzdata $TAGS"
 ARG CGO_EXTRA_CFLAGS
 
 #Build deps
-RUN apk --no-cache add build-base git nodejs npm
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/share /usr/local/share
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
+
+RUN apk --no-cache add build-base git npm
 
 #Setup repo
 COPY . ${GOPATH}/src/code.gitea.io/gitea


### PR DESCRIPTION
Alpine's outdated node package doesn't play well with package-lock V2
This pulls the current long term support binaries from a more recent
alpine image rather than installing the registry's old one.

Why this patch: I tried to build a docker image for my raspberry pi for the better part of a day (both directly on the pi as well as on my computer using buildx). It kept falling all the time and stopping around Makefile's line 709 complaining some javascript callback `cb()` wasn't getting called. I tried to investigate the whereabouts of that `cb()` but I was unsuccessful.
At the same time, I noticed npm was consistently comparing about expecting a `package-lock` file V1 and instead of getting a V2, and ultimately blaming on its self the failure.
That prompted me to check what version of node was been installed and, with my great dismay, I was facing an ancient 14.*

At that point getting node to at least an LTS version was the sensible way to go. So here it is. Tested and working with buildx for `linux/amd64`, `linux/arm64`, `linux/arm/v7`.
This can potentially be great for other fellow raspberry pi users like me as (even with the fix) building something like gitea on a raspberry pi is not exactly a great experience 😅
