### PR TITLE
Set correct language for Dockerfile variants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 /.eslintrc linguist-language=YAML
 /.stylelintrc linguist-language=YAML
 /web_src/fomantic/build/** linguist-generated
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
This enabled correct syntax highlighting for `Dockerfile.rootless`.