### PR TITLE
Ensure complexity, minlength and ispwned are checked on password setting

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -379,6 +379,10 @@ func runChangePassword(c *cli.Context) error {
 	if err := initDB(ctx); err != nil {
 		return err
 	}
+	if len(c.String("password")) < setting.MinPasswordLength {
+		return fmt.Errorf("Password is not long enough. Needs to be at least %d", setting.MinPasswordLength)
+	}
+
 	if !pwd.IsComplexEnough(c.String("password")) {
 		return errors.New("Password does not meet complexity requirements")
 	}

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -20,6 +20,7 @@ import (
 	"code.gitea.io/gitea/modules/convert"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/password"
+	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/api/v1/user"
@@ -173,6 +174,10 @@ func EditUser(ctx *context.APIContext) {
 	}
 
 	if len(form.Password) != 0 {
+		if len(form.Password) < setting.MinPasswordLength {
+			ctx.Error(http.StatusBadRequest, "PasswordTooShort", fmt.Errorf("password must be at least %d characters", setting.MinPasswordLength))
+			return
+		}
 		if !password.IsComplexEnough(form.Password) {
 			err := errors.New("PasswordComplexity")
 			ctx.Error(http.StatusBadRequest, "PasswordComplexity", err)

--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -1873,8 +1873,23 @@ func MustChangePasswordPost(ctx *context.Context) {
 		ctx.RenderWithErr(ctx.Tr("auth.password_too_short", setting.MinPasswordLength), tplMustChangePassword, &form)
 		return
 	}
+	if !password.IsComplexEnough(form.Password) {
+		ctx.Data["Err_Password"] = true
+		ctx.RenderWithErr(password.BuildComplexityError(ctx), tplMustChangePassword, &form)
+		return
+	}
+	pwned, err := password.IsPwned(ctx, form.Password)
+	if pwned {
+		ctx.Data["Err_Password"] = true
+		errMsg := ctx.Tr("auth.password_pwned")
+		if err != nil {
+			log.Error(err.Error())
+			errMsg = ctx.Tr("auth.password_pwned_err")
+		}
+		ctx.RenderWithErr(errMsg, tplMustChangePassword, &form)
+		return
+	}
 
-	var err error
 	if err = u.SetPassword(form.Password); err != nil {
 		ctx.ServerError("UpdateUser", err)
 		return


### PR DESCRIPTION
It appears that there are several places that password length, complexity and ispwned
are not currently been checked when changing passwords. This PR adds these.

Fix #17977
Fix #18036 

Signed-off-by: Andrew Thornton <art27@cantab.net>
