### PR TITLE
Ensure complexity, minlength and ispwned are checked on password setting (#18005)

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -335,6 +335,10 @@ func runChangePassword(c *cli.Context) error {
 	if err := initDB(); err != nil {
 		return err
 	}
+	if len(c.String("password")) < setting.MinPasswordLength {
+		return fmt.Errorf("Password is not long enough. Needs to be at least %d", setting.MinPasswordLength)
+	}
+
 	if !pwd.IsComplexEnough(c.String("password")) {
 		return errors.New("Password does not meet complexity requirements")
 	}

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -16,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/convert"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/password"
+	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/api/v1/user"
@@ -167,6 +168,10 @@ func EditUser(ctx *context.APIContext) {
 	}
 
 	if len(form.Password) != 0 {
+		if len(form.Password) < setting.MinPasswordLength {
+			ctx.Error(http.StatusBadRequest, "PasswordTooShort", fmt.Errorf("password must be at least %d characters", setting.MinPasswordLength))
+			return
+		}
 		if !password.IsComplexEnough(form.Password) {
 			err := errors.New("PasswordComplexity")
 			ctx.Error(http.StatusBadRequest, "PasswordComplexity", err)


### PR DESCRIPTION
Backport #18005

It appears that there are several places that password length, complexity and ispwned
are not currently been checked when changing passwords. This PR adds these.

Fix #17977
Fix #18036

Signed-off-by: Andrew Thornton <art27@cantab.net>
