### PR TITLE
Reset locale on login (#18023)

### DIFF
--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -106,12 +106,12 @@ func AutoSignIn(ctx *context.Context) (bool, error) {
 	return true, nil
 }
 
-func resetLocale(ctx *context.Context, u *user_model.User) error {
+func resetLocale(ctx *context.Context, u *models.User) error {
 	// Language setting of the user overwrites the one previously set
 	// If the user does not have a locale set, we save the current one.
 	if len(u.Language) == 0 {
 		u.Language = ctx.Locale.Language()
-		if err := user_model.UpdateUserCols(db.DefaultContext, u, "language"); err != nil {
+		if err := models.UpdateUserCols(u, "language"); err != nil {
 			return err
 		}
 	}

--- a/routers/web/user/auth.go
+++ b/routers/web/user/auth.go
@@ -98,8 +98,31 @@ func AutoSignIn(ctx *context.Context) (bool, error) {
 		return false, err
 	}
 
+	if err := resetLocale(ctx, u); err != nil {
+		return false, err
+	}
+
 	middleware.DeleteCSRFCookie(ctx.Resp)
 	return true, nil
+}
+
+func resetLocale(ctx *context.Context, u *user_model.User) error {
+	// Language setting of the user overwrites the one previously set
+	// If the user does not have a locale set, we save the current one.
+	if len(u.Language) == 0 {
+		u.Language = ctx.Locale.Language()
+		if err := user_model.UpdateUserCols(db.DefaultContext, u, "language"); err != nil {
+			return err
+		}
+	}
+
+	middleware.SetLocaleCookie(ctx.Resp, u.Language, 0)
+
+	if ctx.Locale.Language() != u.Language {
+		ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
+	}
+
+	return nil
 }
 
 func checkAutoLogin(ctx *context.Context) bool {
@@ -736,6 +759,11 @@ func handleOAuth2SignIn(ctx *context.Context, u *models.User, gothUser goth.User
 		// update external user information
 		if err := models.UpdateExternalUser(u, gothUser); err != nil {
 			log.Error("UpdateExternalUser failed: %v", err)
+		}
+
+		if err := resetLocale(ctx, u); err != nil {
+			ctx.ServerError("resetLocale", err)
+			return
 		}
 
 		if redirectTo := ctx.GetCookie("redirect_to"); len(redirectTo) > 0 {
@@ -1445,6 +1473,11 @@ func handleAccountActivation(ctx *context.Context, user *models.User) {
 	}
 	if err := ctx.Session.Release(); err != nil {
 		log.Error("Error storing session[%s]: %v", ctx.Session.ID(), err)
+	}
+
+	if err := resetLocale(ctx, user); err != nil {
+		ctx.ServerError("resetLocale", err)
+		return
 	}
 
 	ctx.Flash.Success(ctx.Tr("auth.account_activated"))


### PR DESCRIPTION
Backport #18023

Although we reset the locale in a number of places there were several ways of logging in that were missing the same code.

Fix #18020

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: Gusted <williamzijl7@hotmail.com>
