### PR TITLE
Stop printing 03d after escaped characters in logs

### DIFF
--- a/modules/log/colors.go
+++ b/modules/log/colors.go
@@ -259,7 +259,7 @@ normalLoop:
 		}
 
 		// Process naughty character
-		if _, err := fmt.Fprintf(c.w, `\%#o03d`, bytes[i]); err != nil {
+		if _, err := fmt.Fprintf(c.w, `\%#03o`, bytes[i]); err != nil {
 			return totalWritten, err
 		}
 		i++


### PR DESCRIPTION
Strangely a weird bug was present in the log escaping code whereby any escaped
character would gain 03d - this was due to a mistake in the format string where
it should have read %03o but read instead %o03d. This has led to spurious 03d
trailing characters on these escaped characters!

Signed-off-by: Andrew Thornton <art27@cantab.net>
