### PR TITLE
Prevent off-by-one error on comments on newly appended lines (#18029)

### DIFF
--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -153,6 +153,7 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 
 	for scanner.Scan() {
 		lof := scanner.Text()
+		fmt.Printf("%03d: %s\n", currentLine, lof)
 		// Add header to enable parsing
 
 		if isHeader(lof, inHunk) {
@@ -218,6 +219,8 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 				} else {
 					otherLine++
 				}
+			case '\\':
+				// FIXME: handle `\ No newline at end of file`
 			default:
 				currentLine++
 				otherLine++

--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -153,7 +153,6 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 
 	for scanner.Scan() {
 		lof := scanner.Text()
-		fmt.Printf("%03d: %s\n", currentLine, lof)
 		// Add header to enable parsing
 
 		if isHeader(lof, inHunk) {

--- a/modules/git/diff_test.go
+++ b/modules/git/diff_test.go
@@ -83,7 +83,6 @@ index d46c152..a7d2d55 100644
 func TestCutDiffAroundLineIssue17875(t *testing.T) {
 	result, err := CutDiffAroundLine(strings.NewReader(issue17875Diff), 23, false, 3)
 	assert.NoError(t, err)
-	// resultByLine := strings.Split(result, "\n")
 	expected := `diff --git a/Geschäftsordnung.md b/Geschäftsordnung.md
 --- a/Geschäftsordnung.md
 +++ b/Geschäftsordnung.md

--- a/modules/git/diff_test.go
+++ b/modules/git/diff_test.go
@@ -42,6 +42,58 @@ index d8e4c92..19dc8ad 100644
  /
 `
 
+var issue17875Diff = `diff --git a/Geschäftsordnung.md b/Geschäftsordnung.md
+index d46c152..a7d2d55 100644
+--- a/Geschäftsordnung.md
++++ b/Geschäftsordnung.md
+@@ -1,5 +1,5 @@
+ ---
+-date: "23.01.2021"
++date: "30.11.2021"
+ ...
+ ` + `
+ # Geschäftsordnung
+@@ -16,4 +16,22 @@ Diese Geschäftsordnung regelt alle Prozesse des Vereins, solange diese nicht du
+ ` + `
+ ## § 3 Datenschutzverantwortlichkeit
+ ` + `
+-1. Der Verein bestellt eine datenschutzverantwortliche Person mit den Aufgaben nach Artikel 39 DSGVO.
+\ No newline at end of file
++1. Der Verein bestellt eine datenschutzverantwortliche Person mit den Aufgaben nach Artikel 39 DSGVO.
++
++## §4 Umgang mit der SARS-Cov-2-Pandemie
++
++1. Der Vorstand hat die Befugnis, in Rücksprache mit den Vereinsmitgliedern, verschiedene Hygienemaßnahmen für Präsenzveranstaltungen zu beschließen.
++
++2. Die Einführung, Änderung und Abschaffung dieser Maßnahmen sind nur zum Zweck der Eindämmung der SARS-Cov-2-Pandemie zulässig.
++
++3. Die Einführung, Änderung und Abschaffung von Maßnahmen nach Abs. 2 bedarf einer wissenschaftlichen Grundlage.
++
++4. Die Maßnahmen nach Abs. 2 setzen sich aus den folgenden Bausteinen inklusive einer ihrer Ausprägungen zusammen.
++
++	1. Maskenpflicht: Keine; Maskenpflicht, außer am Platz, oder wo Abstände nicht eingehalten werden können; Maskenpflicht, wenn Abstände nicht eingehalten werden können;  Maskenpflicht
++
++	2. Geimpft-, Genesen- oder Testnachweis: Kein Nachweis notwendig; Nachweis, dass Person geimpft, genesen oder tagesaktuell getestet ist (3G); Nachweis, dass Person geimpft oder genesen ist (2G); Nachweis, dass Person geimpft bzw. genesen und tagesaktuell getestet ist (2G+)
++
++	3. Online-Veranstaltung: Keine, parallele Online-Veranstaltung, ausschließlich Online-Veranstaltung
++
++5. Bei Präsenzveranstungen gelten außerdem die Hygienevorschriften des Veranstaltungsorts. Bei Regelkollision greift die restriktivere Regel.
+\ No newline at end of file`
+
+func TestCutDiffAroundLineIssue17875(t *testing.T) {
+	result, err := CutDiffAroundLine(strings.NewReader(issue17875Diff), 23, false, 3)
+	assert.NoError(t, err)
+	// resultByLine := strings.Split(result, "\n")
+	expected := `diff --git a/Geschäftsordnung.md b/Geschäftsordnung.md
+--- a/Geschäftsordnung.md
++++ b/Geschäftsordnung.md
+@@ -20,0 +21,3 @@
++## §4 Umgang mit der SARS-Cov-2-Pandemie
++
++1. Der Vorstand hat die Befugnis, in Rücksprache mit den Vereinsmitgliedern, verschiedene Hygienemaßnahmen für Präsenzveranstaltungen zu beschließen.`
+	assert.Equal(t, expected, result)
+}
+
 func TestCutDiffAroundLine(t *testing.T) {
 	result, err := CutDiffAroundLine(strings.NewReader(exampleDiff), 4, false, 3)
 	assert.NoError(t, err)


### PR DESCRIPTION
Backport #18029

There was a bug in CutDiffAroundLine whereby if a file without a terminal new line
has a patch which appends lines to it and a comment is placed on one of those lines
the comment diff will be a line out of place.

This fixes CutDiffAroundLine to simply ignore the missing terminal newline - however,
we should really improve this rendering to add a marker to say that there was a
previously missing terminal newline.

Fix #17875

Signed-off-by: Andrew Thornton <art27@cantab.net>
