### PR TITLE
Fix delete u2f keys pop up modal bug

### DIFF
--- a/templates/user/settings/security_u2f.tmpl
+++ b/templates/user/settings/security_u2f.tmpl
@@ -7,7 +7,7 @@
 		{{range .U2FRegistrations}}
 			<div class="item">
 				<div class="right floated content">
-					<button class="ui red tiny button delete-button" id="delete-registration" data-url="{{$.Link}}/u2f/delete" data-id="{{.ID}}">
+					<button class="ui red tiny button delete-button" data-modal-id="delete-registration" data-url="{{$.Link}}/u2f/delete" data-id="{{.ID}}">
 					{{$.i18n.Tr "settings.delete_key"}}
 					</button>
 				</div>


### PR DESCRIPTION
When delete one u2f key, then all keys delete modals popup.

Before(All modals popup at once):

![image](https://user-images.githubusercontent.com/81045/146779005-708f7f6d-5112-4a7d-a5f2-e16896c0dae7.png)

After:

![image](https://user-images.githubusercontent.com/81045/146778903-a4aeb8cd-e9c7-450c-8dda-aba636ee5d76.png)
