### PR TITLE
Move POST /{username}/action/{action} to simply POST /{username}

### DIFF
--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -363,7 +363,7 @@ func Action(ctx *context.Context) {
 	}
 
 	var err error
-	switch ctx.Params(":action") {
+	switch ctx.FormString("action") {
 	case "follow":
 		err = user_model.FollowUser(ctx.User.ID, u.ID)
 	case "unfollow":
@@ -371,7 +371,7 @@ func Action(ctx *context.Context) {
 	}
 
 	if err != nil {
-		ctx.ServerError(fmt.Sprintf("Action (%s)", ctx.Params(":action")), err)
+		ctx.ServerError(fmt.Sprintf("Action (%s)", ctx.FormString("action")), err)
 		return
 	}
 	// FIXME: We should check this URL and make sure that it's a valid Gitea URL

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -484,9 +484,7 @@ func RegisterRoutes(m *web.Route) {
 		m.Get("/attachments/{uuid}", repo.GetAttachment)
 	}, ignSignIn)
 
-	m.Group("/{username}", func() {
-		m.Post("/action/{action}", user.Action)
-	}, reqSignIn)
+	m.Post("/{username}", reqSignIn, user.Action)
 
 	if !setting.IsProd {
 		m.Get("/template/*", dev.TemplatePreview)

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -66,12 +66,12 @@
 							{{if and .IsSigned (ne .SignedUserName .Owner.Name)}}
 							<li class="follow">
 								{{if $.IsFollowing}}
-									<form method="post" action="{{.Link}}/action/unfollow?redirect_to={{$.Link}}">
+									<form method="post" action="{{.Link}}?action=unfollow&redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
 										<button type="submit" class="ui basic red button">{{svg "octicon-person"}} {{.i18n.Tr "user.unfollow"}}</button>
 									</form>
 								{{else}}
-									<form method="post" action="{{.Link}}/action/follow?redirect_to={{$.Link}}">
+									<form method="post" action="{{.Link}}?action=follow&redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
 										<button type="submit" class="ui basic green button">{{svg "octicon-person"}} {{.i18n.Tr "user.follow"}}</button>
 									</form>


### PR DESCRIPTION
The current code unfortunately requires that `action` be a reserved
repository name as it prevents posts to change the settings for
action repositories. However, we can simply change action handler
to work on POST /{username} instead.

Fix #18037

Signed-off-by: Andrew Thornton <art27@cantab.net>
