### PR TITLE
Ensure that git repository is closed before transfer (#18049)

### DIFF
--- a/routers/api/v1/repo/transfer.go
+++ b/routers/api/v1/repo/transfer.go
@@ -96,6 +96,11 @@ func Transfer(ctx *context.APIContext) {
 		}
 	}
 
+	if ctx.Repo.GitRepo != nil {
+		ctx.Repo.GitRepo.Close()
+		ctx.Repo.GitRepo = nil
+	}
+
 	if err := repo_service.StartRepositoryTransfer(ctx.User, newOwner, ctx.Repo.Repository, teams); err != nil {
 		if models.IsErrRepoTransferInProgress(err) {
 			ctx.Error(http.StatusConflict, "CreatePendingRepositoryTransfer", err)

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -319,6 +319,11 @@ func acceptOrRejectRepoTransfer(ctx *context.Context, accept bool) error {
 	}
 
 	if accept {
+		if ctx.Repo.GitRepo != nil {
+			ctx.Repo.GitRepo.Close()
+			ctx.Repo.GitRepo = nil
+		}
+
 		if err := repo_service.TransferOwnership(repoTransfer.Doer, repoTransfer.Recipient, ctx.Repo.Repository, repoTransfer.Teams); err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport #18049

Repository Transfer requires that the repository directory is renamed - which
is not possible on Windows if the git repository is open.

Fix #17885

Signed-off-by: Andrew Thornton <art27@cantab.net>
