### PR TITLE
Avoid running go vet twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,6 @@ fmt:
 .PHONY: vet
 vet:
 	@echo "Running go vet..."
-	@$(GO) vet $(GO_PACKAGES)
 	@GOOS= GOARCH= $(GO) build -mod=vendor code.gitea.io/gitea-vet
 	@$(GO) vet -vettool=gitea-vet $(GO_PACKAGES)
 


### PR DESCRIPTION
- go vet is [already ran](https://github.com/go-gitea/gitea/blob/7821370c0bc88bd1a02966cad172f33667394bd4/.golangci.yml#L6) by golangci-lint as linter(and must faster). `make vet` will only run gitea-vet(which is as fast as revivie).
- Thanks for @zeripath for pointing out slow linting.

