### PR TITLE
Add NotFound handler (#18062)

### DIFF
--- a/integrations/links_test.go
+++ b/integrations/links_test.go
@@ -61,6 +61,16 @@ func TestRedirectsNoLogin(t *testing.T) {
 		resp := MakeRequest(t, req, http.StatusFound)
 		assert.EqualValues(t, path.Join(setting.AppSubURL, redirectLink), test.RedirectURL(resp))
 	}
+
+	var temporaryRedirects = map[string]string{
+		"/user2/repo1/": "/user2/repo1",
+	}
+	for link, redirectLink := range temporaryRedirects {
+		req := NewRequest(t, "GET", link)
+		resp := MakeRequest(t, req, http.StatusTemporaryRedirect)
+		assert.EqualValues(t, path.Join(setting.AppSubURL, redirectLink), test.RedirectURL(resp))
+	}
+
 }
 
 func TestNoLoginNotExist(t *testing.T) {

--- a/integrations/signout_test.go
+++ b/integrations/signout_test.go
@@ -18,7 +18,7 @@ func TestSignOut(t *testing.T) {
 	session.MakeRequest(t, req, http.StatusFound)
 
 	// try to view a private repo, should fail
-	req = NewRequest(t, "GET", "/user2/repo2/")
+	req = NewRequest(t, "GET", "/user2/repo2")
 	session.MakeRequest(t, req, http.StatusNotFound)
 
 	// invalidate cached cookies for user2, for subsequent tests

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1036,4 +1036,14 @@ func RegisterRoutes(m *web.Route) {
 	if setting.API.EnableSwagger {
 		m.Get("/swagger.v1.json", SwaggerV1Json)
 	}
+	m.NotFound(func(w http.ResponseWriter, req *http.Request) {
+		escapedPath := req.URL.EscapedPath()
+		if len(escapedPath) > 1 && escapedPath[len(escapedPath)-1] == '/' {
+			http.Redirect(w, req, setting.AppSubURL+escapedPath[:len(escapedPath)-1], http.StatusTemporaryRedirect)
+			return
+		}
+		ctx := context.GetContext(req)
+		ctx.NotFound("", nil)
+	})
+
 }


### PR DESCRIPTION
Backport #18062

PR #17997 means that urls with terminal '/' are no longer immediately mapped
to the url without a terminal slash. However, it has revealed that the NotFound handler
appears to have been lost.

This PR adds back in a NotFound handler that simply redirects to a path without the
terminal slash or runs the NotFound handler.

Fix #18060

Signed-off-by: Andrew Thornton <art27@cantab.net>
