### PR TITLE
Only create pprof files for gitea serv if explicitly asked for

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -191,7 +191,7 @@ func runServ(c *cli.Context) error {
 		return fail("Invalid repo name", "Invalid repo name: %s", reponame)
 	}
 
-	if setting.EnablePprof || c.Bool("enable-pprof") {
+	if c.Bool("enable-pprof") {
 		if err := os.MkdirAll(setting.PprofDataPath, os.ModePerm); err != nil {
 			return fail("Error while trying to create PPROF_DATA_PATH", "Error while trying to create PPROF_DATA_PATH: %v", err)
 		}


### PR DESCRIPTION
Currently when ENABLE_PPROF is set gitea serv will create pprof files every time it
is called. This is somewhat surprising as the intention of ENABLE_PPROF is to pprof
the server and the utility of pprof files for examining serv is limited. (Especially
since it has become little more than an API calling shim.)

Should users wish to generate pprof files for serv they can still enable them using --enable-pprof.

Signed-off-by: Andrew Thornton <art27@cantab.net>

## :warning: BREAKING :warning: 

This is technically a BREAKING change because it means that in the unlikely case that a server administrator actually wants
to generate these files they will now need to change the `authorized_keys` file (or better the `SSH_AUTHORIZED_KEYS_COMMAND_TEMPLATE`) to add the `--enable-pprof` option.

However, for almost every user this is a non-breaking change.

Users who have had `ENABLE_PPROF` are advised to check their `PPROF_DATA_PATH` (which defaults to `%APP_WORK_PATH%/data/tmp/pprof`) and remove the unnecessary files.
