### PR TITLE
Quote references to the user table in consistency checks (#18072)

### DIFF
--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -159,13 +159,13 @@ func checkDBConsistency(logger log.Logger, autofix bool) error {
 			"lfs_lock", "repository", "lfs_lock.repo_id=repository.id"),
 		// find collaborations without users
 		genericOrphanCheck("Collaborations without existing user",
-			"collaboration", "user", "collaboration.user_id=user.id"),
+			"collaboration", "user", "collaboration.user_id=`user`.id"),
 		// find collaborations without repository
 		genericOrphanCheck("Collaborations without existing repository",
 			"collaboration", "repository", "collaboration.repo_id=repository.id"),
 		// find access without users
 		genericOrphanCheck("Access entries without existing user",
-			"access", "user", "access.user_id=user.id"),
+			"access", "user", "access.user_id=`user`.id"),
 		// find access without repository
 		genericOrphanCheck("Access entries without existing repository",
 			"access", "repository", "access.repo_id=repository.id"),


### PR DESCRIPTION
Backport #18072

Although #17487 ensured that the table was quoted in the join it missed that the
query part of the check also needed to be quoted.

Fix #17485

Signed-off-by: Andrew Thornton <art27@cantab.net>

