### PR TITLE
Remove final newline from rendered code

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1134,6 +1134,9 @@ PATH =
 ;;
 ;; Whether to enable a Service Worker to cache frontend assets
 ;USE_SERVICE_WORKER = false
+;;
+;; Whether to hide final newline in rendered code
+;HIDE_FINAL_NEWLINE = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1135,7 +1135,7 @@ PATH =
 ;; Whether to enable a Service Worker to cache frontend assets
 ;USE_SERVICE_WORKER = false
 ;;
-;; Whether to hide final newline in rendered code
+;; Whether to hide a final newline in rendered code
 ;HIDE_FINAL_NEWLINE = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -190,6 +190,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `DEFAULT_SHOW_FULL_NAME`: **false**: Whether the full name of the users should be shown where possible. If the full name isn't set, the username will be used.
 - `SEARCH_REPO_DESCRIPTION`: **true**: Whether to search within description at repository search on explore page.
 - `USE_SERVICE_WORKER`: **false**: Whether to enable a Service Worker to cache frontend assets.
+- `HIDE_FINAL_NEWLINE`: **true**: Whether to hide final newline in rendered code
 
 ### UI - Admin (`ui.admin`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -190,7 +190,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `DEFAULT_SHOW_FULL_NAME`: **false**: Whether the full name of the users should be shown where possible. If the full name isn't set, the username will be used.
 - `SEARCH_REPO_DESCRIPTION`: **true**: Whether to search within description at repository search on explore page.
 - `USE_SERVICE_WORKER`: **false**: Whether to enable a Service Worker to cache frontend assets.
-- `HIDE_FINAL_NEWLINE`: **true**: Whether to hide final newline in rendered code
+- `HIDE_FINAL_NEWLINE`: **true**: Whether to hide a final newline in rendered code
 
 ### UI - Admin (`ui.admin`)
 

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -127,6 +127,7 @@ func CodeFromLexer(lexer chroma.Lexer, code string) string {
 	}
 
 	htmlw.Flush()
+
 	// Chroma will add newlines for certain lexers in order to highlight them properly
 	// Once highlighted, strip them here so they don't cause copy/paste trouble in HTML output
 	return strings.TrimSuffix(htmlbuf.String(), "\n")
@@ -191,6 +192,11 @@ func File(numLines int, fileName, language string, code []byte) []string {
 
 	htmlw.Flush()
 
+	finalNewLine := false
+	if !setting.UI.HideFinalNewline && len(code) > 0 {
+		finalNewLine = code[len(code)-1] == '\n'
+	}
+
 	m := make([]string, 0, numLines)
 	for _, v := range strings.SplitN(htmlbuf.String(), "\n", numLines) {
 		content := string(v)
@@ -203,6 +209,10 @@ func File(numLines int, fileName, language string, code []byte) []string {
 		content = strings.TrimSuffix(content, `<span class="w">`)
 		content = strings.TrimPrefix(content, `</span>`)
 		m = append(m, content)
+	}
+
+	if finalNewLine {
+		m = append(m, "<span class=\"w\">\n</span>")
 	}
 
 	return m

--- a/modules/highlight/highlight.go
+++ b/modules/highlight/highlight.go
@@ -190,10 +190,6 @@ func File(numLines int, fileName, language string, code []byte) []string {
 	}
 
 	htmlw.Flush()
-	finalNewLine := false
-	if len(code) > 0 {
-		finalNewLine = code[len(code)-1] == '\n'
-	}
 
 	m := make([]string, 0, numLines)
 	for _, v := range strings.SplitN(htmlbuf.String(), "\n", numLines) {
@@ -207,9 +203,6 @@ func File(numLines int, fileName, language string, code []byte) []string {
 		content = strings.TrimSuffix(content, `<span class="w">`)
 		content = strings.TrimPrefix(content, `</span>`)
 		m = append(m, content)
-	}
-	if finalNewLine {
-		m = append(m, "<span class=\"w\">\n</span>")
 	}
 
 	return m

--- a/modules/highlight/highlight_test.go
+++ b/modules/highlight/highlight_test.go
@@ -53,8 +53,6 @@ steps:
 				`</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go build -v</span>`,
 				`</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go test -v -race -coverprofile=coverage.txt -covermode=atomic</span><span class="w">
 </span></span></span>`,
-				`<span class="w">
-</span>`,
 			},
 		},
 		{

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -228,6 +228,7 @@ var (
 		CustomEmojisMap       map[string]string `ini:"-"`
 		SearchRepoDescription bool
 		UseServiceWorker      bool
+		HideFinalNewline      bool
 
 		Notification struct {
 			MinTimeout            time.Duration
@@ -1069,6 +1070,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	UI.DefaultShowFullName = Cfg.Section("ui").Key("DEFAULT_SHOW_FULL_NAME").MustBool(false)
 	UI.SearchRepoDescription = Cfg.Section("ui").Key("SEARCH_REPO_DESCRIPTION").MustBool(true)
 	UI.UseServiceWorker = Cfg.Section("ui").Key("USE_SERVICE_WORKER").MustBool(false)
+	UI.HideFinalNewline = Cfg.Section("ui").Key("HIDE_FINAL_NEWLINE").MustBool(true)
 
 	HasRobotsTxt, err = util.IsFile(path.Join(CustomPath, "robots.txt"))
 	if err != nil {


### PR DESCRIPTION
#16678 introduced rendering of the final newline in files but I feel this rendering is not useful and just distracting. Omit rendering this empty line which matches GH behaviour in both rendering and copied content (no final newline copied, tested in Chrome and Firefox).

Before:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/115237/147147646-3cae4892-b24c-499b-a233-fab0cc2a2d36.png">

After:
<img width="303" alt="image" src="https://user-images.githubusercontent.com/115237/147147605-0b3a4104-424f-4570-96cd-ea331f0c96d4.png">
