### PR TITLE
Prevent NPE if gitea uploader fails to open url

### DIFF
--- a/modules/uri/uri.go
+++ b/modules/uri/uri.go
@@ -34,7 +34,7 @@ func Open(uriStr string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		return f.Body, err
+		return f.Body, nil
 	case "file":
 		return os.Open(u.Path)
 	default:

--- a/modules/uri/uri.go
+++ b/modules/uri/uri.go
@@ -31,6 +31,9 @@ func Open(uriStr string) (io.ReadCloser, error) {
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
 		f, err := http.Get(uriStr)
+		if err != nil {
+			return nil, err
+		}
 		return f.Body, err
 	case "file":
 		return os.Open(u.Path)


### PR DESCRIPTION
If http.Get() returns an error return nil and err before attempting to
use the broken file.

Thanks to walker xiong for spotting this bug.

Signed-off-by: Andrew Thornton <art27@cantab.net>
