### PR TITLE
Change ShortRepoPath to return new repo path

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -186,7 +186,17 @@ func (a *Action) GetRepoPath() string {
 // ShortRepoPath returns the virtual path to the action repository
 // trimmed to max 20 + 1 + 33 chars.
 func (a *Action) ShortRepoPath() string {
-	return path.Join(a.ShortRepoUserName(), a.ShortRepoName())
+	act := new(Action)
+	name := a.ShortRepoName()
+	ok, err := db.GetEngine(db.DefaultContext).Where("op_type = 2 AND repo_id = ? AND id > ?", a.RepoID, a.ID).Get(act)
+	if err != nil {
+		log.Error("GetRepoNameAcordingToAction: %v", err)
+		return "500 when get RepoName"
+	}
+	if ok {
+		name = act.Content
+	}
+	return path.Join(a.ShortRepoUserName(), name)
 }
 
 // GetRepoLink returns relative link to action repository.


### PR DESCRIPTION
* Fix Rename a repository twice, then the first rename action target became the latest name. #18007

Change ShortRepoPath to return new repo path instead of recent repo path:
ShortRepoPath always returned actual repo name instead of new repo name according to the action:
A->C, B->C instead of A->B, B->C
Now it returns proper repo name.

Fix #18007

Signed-off-by: Viktor Yakovchuk <viktor@yakovchuk.net>

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/master/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
