### PR TITLE
When the git repository on storage is changed, the repository modal should also be updated

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -850,6 +850,11 @@ func renderCode(ctx *context.Context) {
 			return
 		}
 		// the repo is not really empty, so we should update the modal in database
+		// such problem may be caused by:
+		// 1) an error occurs during pushing/receiving.  2) the user replaces an empty git repo manually
+		// and even more: the IsEmpty flag is deeply broken and should be removed with the UI changed to manage to cope with empty repos.
+		// it's possible for a repository to be non-empty by that flag but still 500
+		// because there are no branches - only tags -or the default branch is non-extant as it has been 0-pushed.
 		ctx.Repo.Repository.IsEmpty = false
 		if err = repo_model.UpdateRepositoryCols(ctx.Repo.Repository, "is_empty"); err != nil {
 			ctx.ServerError("UpdateRepositoryCols", err)


### PR DESCRIPTION
I saw some issues about "after pushing the git repository to Gitea, the Gitea web still shows the repository is empty" (I can not remember the issue number now ....)

And I meet the same problem today. This problem would be caused by some cases:

1. An error occurs during the git pushing/receiving
2. A user replaces the Gitea's empty repository manually

The reason behind the problem is that the `repoModal.IsEmpty` is out of sync of the real status of the repo.

This PR fixes the problem. When a user is viewing the repository web page, if the `repoModal.IsEmpty` is true, we check the git repository again to detect whether it is really empty.

This PR was tested on my side, and I can view the non-empty git repository correctly now.

**Maybe we should fix more inconsistent data, please help to review and suggest, thank you**
