### PR TITLE
Changelog v1.15.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
+## [1.15.9](https://github.com/go-gitea/gitea/releases/tag/v1.15.9) - 2021-12-28
+
+* BUGFIXES
+  * Revert "Fix delete u2f keys bug (#18042)" (#18107)
+  * Migrating wiki don't require token, so we should move it out of the require form (#17645) (#18104)
+  * Prevent NPE if gitea uploader fails to open url (#18080) (#18101)
+  * Reset locale on login (#17734) (#18100)
+  * Correctly handle failed migrations (#17575) (#18099)
+  * Instead of using routerCtx just escape the url before routing (#18086) (#18098)
+  * Quote references to the user table in consistency checks (#18072) (#18073)
+  * Add NotFound handler (#18062) (#18067)
+  * Ensure that git repository is closed before transfer (#18049) (#18057)
+  * Use common sessioner for API and web routes (#18114)
+* TRANSLATION
+  * Fix code search result hint on zh-CN (#18053)
+
 ## [1.15.8](https://github.com/go-gitea/gitea/releases/tag/v1.15.8) - 2021-12-20
 
 * BUGFIXES


### PR DESCRIPTION
* BUGFIXES
  * Revert "Fix delete u2f keys bug (#18042)" (#18107)
  * Migrating wiki don't require token, so we should move it out of the require form (#17645) (#18104)
  * Prevent NPE if gitea uploader fails to open url (#18080) (#18101)
  * Reset locale on login (#17734) (#18100)
  * Correctly handle failed migrations (#17575) (#18099)
  * Instead of using routerCtx just escape the url before routing (#18086) (#18098)
  * Quote references to the user table in consistency checks (#18072) (#18073)
  * Add NotFound handler (#18062) (#18067)
  * Ensure that git repository is closed before transfer (#18049) (#18057)
  * Use common sessioner for API and web routes (#18114)
* TRANSLATION
  * Fix code search result hint on zh-CN (#18053)

Signed-off-by: Andrew Thornton <art27@cantab.net>
