### PR TITLE
Set HeadCommit when creating tags

### DIFF
--- a/services/release/release.go
+++ b/services/release/release.go
@@ -72,13 +72,17 @@ func createTag(gitRepo *git.Repository, rel *models.Release, msg string) (bool, 
 			created = true
 			rel.LowerTagName = strings.ToLower(rel.TagName)
 
+			commits := repository.NewPushCommits()
+			commits.HeadCommit = repository.CommitToPushCommit(commit)
+			commits.CompareURL = rel.Repo.ComposeCompareURL(git.EmptySHA, commit.ID.String())
+
 			notification.NotifyPushCommits(
 				rel.Publisher, rel.Repo,
 				&repository.PushUpdateOptions{
 					RefFullName: git.TagPrefix + rel.TagName,
 					OldCommitID: git.EmptySHA,
 					NewCommitID: commit.ID.String(),
-				}, repository.NewPushCommits())
+				}, commits)
 			notification.NotifyCreateRef(rel.Publisher, rel.Repo, "tag", git.TagPrefix+rel.TagName)
 			rel.CreatedUnix = timeutil.TimeStampNow()
 		}

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -121,13 +121,22 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 				delTags = append(delTags, tagName)
 				notification.NotifyDeleteRef(pusher, repo, "tag", opts.RefFullName)
 			} else { // is new tag
+				newCommit, err := gitRepo.GetCommit(opts.NewCommitID)
+				if err != nil {
+					return fmt.Errorf("gitRepo.GetCommit: %v", err)
+				}
+
+				commits := repo_module.NewPushCommits()
+				commits.HeadCommit = repo_module.CommitToPushCommit(newCommit)
+				commits.CompareURL = repo.ComposeCompareURL(git.EmptySHA, opts.NewCommitID)
+
 				notification.NotifyPushCommits(
 					pusher, repo,
 					&repo_module.PushUpdateOptions{
 						RefFullName: git.TagPrefix + tagName,
 						OldCommitID: git.EmptySHA,
 						NewCommitID: opts.NewCommitID,
-					}, repo_module.NewPushCommits())
+					}, commits)
 
 				addTags = append(addTags, tagName)
 				notification.NotifyCreateRef(pusher, repo, "tag", opts.RefFullName)


### PR DESCRIPTION
fixes #18112

It's the same behaviour as if you create a branch: empty commit list but the head commit is the last commit.

I'm not sure about the compare url. With `git.EmptySHA` you will see a 404 page. GitHub displays a "There isn’t anything to compare" page in this case.