### PR TITLE
Remove `/email2user` endpoint

### DIFF
--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -769,17 +769,3 @@ func ShowGPGKeys(ctx *context.Context, uid int64) {
 	writer.Close()
 	ctx.PlainTextBytes(http.StatusOK, buf.Bytes())
 }
-
-// Email2User show user page via email
-func Email2User(ctx *context.Context) {
-	u, err := user_model.GetUserByEmail(ctx.FormString("email"))
-	if err != nil {
-		if user_model.IsErrUserNotExist(err) {
-			ctx.NotFound("GetUserByEmail", err)
-		} else {
-			ctx.ServerError("GetUserByEmail", err)
-		}
-		return
-	}
-	ctx.Redirect(u.HomeLink())
-}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -376,7 +376,6 @@ func RegisterRoutes(m *web.Route) {
 		m.Post("/activate", user.ActivatePost, reqSignIn)
 		m.Any("/activate_email", user.ActivateEmail)
 		m.Get("/avatar/{username}/{size}", user.AvatarByUserName)
-		m.Get("/email2user", user.Email2User)
 		m.Get("/recover_account", user.ResetPasswd)
 		m.Post("/recover_account", user.ResetPasswdPost)
 		m.Get("/forgot_password", user.ForgotPasswd)


### PR DESCRIPTION
The `/email2user` endpoint is not used anymore.

It was introduced [a long time ago](https://github.com/go-gitea/gitea/commit/90f6aa8cd19e489723ddffc40d6507782c29756c).

This endpoint is a possible security problem too because you can query if an email is registered on the instance.