### PR TITLE
Reset the conflicted files list in testpatch

### DIFF
--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -235,6 +235,7 @@ func checkConflicts(pr *models.PullRequest, gitRepo *git.Repository, tmpBasePath
 	}()
 
 	numberOfConflicts := 0
+	pr.ConflictedFiles = make([]string, 0, 5)
 	conflict := false
 
 	for file := range unmerged {


### PR DESCRIPTION
Although #18004 will seriously reduce the likelihood of finding
conflicts in the first place - one bug was introduced whereby the
conflicted files status was not being reset properly. This leads to
conflicted PRs remaining conflicted when the conflict has been resolved.

Fix #18130

Signed-off-by: Andrew Thornton <art27@cantab.net>
