### PR TITLE
Improve document for developers: Windows CGO, unit test option

### DIFF
--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -73,7 +73,7 @@ One of these three distributions of Make will run on Windows:
   - MSYS2 is a collection of tools and libraries providing you with an easy-to-use environment for building, installing and running native Windows software, it includes MinGW-w64. 
   - In MingGW-w64, the binary is called `mingw32-make.exe` instead of `make.exe`. Add the `bin` folder to `PATH`.
   - In MSYS2, you can use `make` directly. See [MSYS2 Porting](https://www.msys2.org/wiki/Porting/).
-  - To compile Gitea with CGO_ENABLED (eg: SQLite3), you must use [tdm-gcc](https://jmeubank.github.io/tdm-gcc/) instead of MSYS2 gcc, because MSYS2 gcc headers lack some Windows-only CRT functions like `_beginthread`.
+  - To compile Gitea with CGO_ENABLED (eg: SQLite3), you might need to use [tdm-gcc](https://jmeubank.github.io/tdm-gcc/) instead of MSYS2 gcc, because MSYS2 gcc headers lack some Windows-only CRT functions like `_beginthread`.
 - [Chocolatey package](https://chocolatey.org/packages/make). Run `choco install make`
 
 **Note**: If you are attempting to build using make with Windows Command Prompt, you may run into issues. The above prompts (Git bash, or MinGW) are recommended, however if you only have command prompt (or potentially PowerShell) you can set environment variables using the [set](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) command, e.g. `set TAGS=bindata`.

--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -73,6 +73,7 @@ One of these three distributions of Make will run on Windows:
   - MSYS2 is a collection of tools and libraries providing you with an easy-to-use environment for building, installing and running native Windows software, it includes MinGW-w64. 
   - In MingGW-w64, the binary is called `mingw32-make.exe` instead of `make.exe`. Add the `bin` folder to `PATH`.
   - In MSYS2, you can use `make` directly. See [MSYS2 Porting](https://www.msys2.org/wiki/Porting/).
+  - To compile Gitea with CGO_ENABLED (eg: SQLite3), you must use [tdm-gcc](https://jmeubank.github.io/tdm-gcc/) instead of MSYS2 gcc, because MSYS2 gcc headers lack some Windows-only CRT functions like `_beginthread`.
 - [Chocolatey package](https://chocolatey.org/packages/make). Run `choco install make`
 
 **Note**: If you are attempting to build using make with Windows Command Prompt, you may run into issues. The above prompts (Git bash, or MinGW) are recommended, however if you only have command prompt (or potentially PowerShell) you can set environment variables using the [set](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) command, e.g. `set TAGS=bindata`.
@@ -273,9 +274,16 @@ make test-sqlite-migration # with SQLite switched for the appropriate database
 
 There are two types of test run by Gitea: Unit tests and Integration Tests.
 
+### Unit Tests
+
+Unit tests are covered by `*_test.go` in `go test` system.
+You can set environment variable `GITEA_UNIT_TESTS_VERBOSE=1` to see detail logs during the test.
+
 ```bash
 TAGS="bindata sqlite sqlite_unlock_notify" make test # Runs the unit tests
 ```
+
+### Integration Tests
 
 Unit tests will not and cannot completely test Gitea alone. Therefore, we
 have written integration tests; however, these are database dependent.
@@ -288,9 +296,11 @@ will run the integration tests in an SQLite environment. Integration tests
 require `git lfs` to be installed. Other database tests are available but
 may need adjustment to the local environment.
 
-Look at
-[`integrations/README.md`](https://github.com/go-gitea/gitea/blob/main/integrations/README.md)
+Take a look at [`integrations/README.md`](https://github.com/go-gitea/gitea/blob/main/integrations/README.md)
 for more information and how to run a single test.
+
+
+### Testing for a PR
 
 Our continuous integration will test the code passes its unit tests and that
 all supported databases will pass integration test in a Docker environment.


### PR DESCRIPTION
1. Clarify how to compile Gitea on Windows with CGO_ENABLED
2. Document a useful environment variable GITEA_UNIT_TESTS_VERBOSE