### PR TITLE
tests: s/GITEA_UNIT_TESTS_VERBOSE/GITEA_UNIT_TESTS_LOG_SQL/

### DIFF
--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -277,7 +277,7 @@ There are two types of test run by Gitea: Unit tests and Integration Tests.
 ### Unit Tests
 
 Unit tests are covered by `*_test.go` in `go test` system.
-You can set environment variable `GITEA_UNIT_TESTS_VERBOSE=1` to see detail logs during the test.
+You can set the environment variable `GITEA_UNIT_TESTS_LOG_SQL=1` to display all SQL statements when running the tests in verbose mode (i.e. when `GOTESTFLAGS=-v` is set).
 
 ```bash
 TAGS="bindata sqlite sqlite_unlock_notify" make test # Runs the unit tests

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -14,6 +14,7 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/storage"
 	"code.gitea.io/gitea/modules/util"
@@ -152,7 +153,7 @@ func CreateTestEngine(opts FixturesOptions) error {
 	if err = db.SyncAllTables(); err != nil {
 		return err
 	}
-	switch os.Getenv("GITEA_UNIT_TESTS_VERBOSE") {
+	switch os.Getenv("GITEA_UNIT_TESTS_LOG_SQL") {
 	case "true", "1":
 		x.ShowSQL(true)
 	}

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -14,7 +14,6 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/base"
-	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/storage"
 	"code.gitea.io/gitea/modules/util"


### PR DESCRIPTION
The GITEA_UNIT_TESTS_VERBOSE variable is an undocumented variable
introduced in 2017 (see 1028ef2defd94a64f2433b07fe5d93681864cebb)
whose sole purpose has been to log SQL statements when running unit
tests.

It is renamed for clarity and a warning is displayed for backward
compatibility for people and scripts that know about it.

The documentation is updated to reflect this change.
