### PR TITLE
Set default AppVer for main branch

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// Version holds the current Gitea version
-	Version = "development"
+	Version = "1.16.9999+dev-main"
 	// Tags holds the build tags used
 	Tags = ""
 	// MakeVersion holds the current Make version if built with make


### PR DESCRIPTION
I propose to always have a valid AppVer in code base, and we should bump it for every major release.

For example, in this PR:

* https://github.com/go-gitea/gitea/pull/18124

The gitea-sdk expects to get a valid AppVer from server response, and the gitea-sdk also have some version-depended behaviors.
