### PR TITLE
WIP: Allow user to specify using credential.helper

### DIFF
--- a/modules/migration/options.go
+++ b/modules/migration/options.go
@@ -39,4 +39,8 @@ type MigrateOptions struct {
 	ReleaseAssets   bool
 	MigrateToRepoID int64
 	MirrorInterval  string `json:"mirror_interval"`
+
+	// This should only be enabled in special cases where Git fails to
+	// handle basic authentication correctly. See https://github.com/go-gitea/gitea/issues/18166
+	UseGitCredentials bool `json:"use_git_credentials"`
 }

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -176,7 +176,15 @@ func MigratePost(ctx *context.Context) {
 		return
 	}
 
-	remoteAddr, err := forms.ParseRemoteAddr(form.CloneAddr, form.AuthUsername, form.AuthPassword)
+	var remoteAddr string
+	var err error
+	if form.UseGitCredentials {
+		// Still perform this as it checks if it's a valid URL.
+		remoteAddr, err = forms.ParseRemoteAddr(form.CloneAddr, "", "")
+	} else {
+		remoteAddr, err = forms.ParseRemoteAddr(form.CloneAddr, form.AuthUsername, form.AuthPassword)
+	}
+
 	if err == nil {
 		err = migrations.IsMigrateURLAllowed(remoteAddr, ctx.User)
 	}
@@ -204,25 +212,26 @@ func MigratePost(ctx *context.Context) {
 	}
 
 	var opts = migrations.MigrateOptions{
-		OriginalURL:    form.CloneAddr,
-		GitServiceType: form.Service,
-		CloneAddr:      remoteAddr,
-		RepoName:       form.RepoName,
-		Description:    form.Description,
-		Private:        form.Private || setting.Repository.ForcePrivate,
-		Mirror:         form.Mirror,
-		LFS:            form.LFS,
-		LFSEndpoint:    form.LFSEndpoint,
-		AuthUsername:   form.AuthUsername,
-		AuthPassword:   form.AuthPassword,
-		AuthToken:      form.AuthToken,
-		Wiki:           form.Wiki,
-		Issues:         form.Issues,
-		Milestones:     form.Milestones,
-		Labels:         form.Labels,
-		Comments:       form.Issues || form.PullRequests,
-		PullRequests:   form.PullRequests,
-		Releases:       form.Releases,
+		OriginalURL:       form.CloneAddr,
+		GitServiceType:    form.Service,
+		CloneAddr:         remoteAddr,
+		RepoName:          form.RepoName,
+		Description:       form.Description,
+		Private:           form.Private || setting.Repository.ForcePrivate,
+		Mirror:            form.Mirror,
+		LFS:               form.LFS,
+		LFSEndpoint:       form.LFSEndpoint,
+		AuthUsername:      form.AuthUsername,
+		AuthPassword:      form.AuthPassword,
+		AuthToken:         form.AuthToken,
+		Wiki:              form.Wiki,
+		Issues:            form.Issues,
+		Milestones:        form.Milestones,
+		Labels:            form.Labels,
+		Comments:          form.Issues || form.PullRequests,
+		PullRequests:      form.PullRequests,
+		Releases:          form.Releases,
+		UseGitCredentials: form.UseGitCredentials,
 	}
 	if opts.Mirror {
 		opts.Issues = false

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -82,6 +82,10 @@ type MigrateRepoForm struct {
 	PullRequests   bool   `json:"pull_requests"`
 	Releases       bool   `json:"releases"`
 	MirrorInterval string `json:"mirror_interval"`
+
+	// This should only be enabled in special cases where Git fails to
+	// handle basic authentication correctly. See https://github.com/go-gitea/gitea/issues/18166
+	UseGitCredentials bool `json:"use_git_credentials"`
 }
 
 // Validate validates the fields

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -77,6 +77,14 @@
 					</div>
 
 					<div class="inline field">
+						<label>Use git credentials (WIP)</label>
+						<div class="ui checkbox">
+							<input name="use_git_credentials" type="checkbox">
+							<label>Only enable this when basic authentication of git fails.</label>
+						</div>
+					</div>
+
+					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
 							{{.i18n.Tr "repo.migrate_repo"}}


### PR DESCRIPTION
- Resolves #18166
- Allow user to choose(in certain conditions) to use -c helper.credentials in order to workaround bug with git.

@zpericic Could you check if this works? Such that I know that the implementation works, before I start moving this to other files. 