### PR TITLE
Increase Salt randomness

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -363,6 +363,8 @@ var migrations = []Migration{
 	NewMigration("Add Sorting to ProjectIssue table", addProjectIssueSorting),
 	// v204 -> v205
 	NewMigration("Add key is verified to ssh key", addSSHKeyIsVerified),
+	// v205 -> v206
+	NewMigration("Migrate to higher varchar on user struct", migrateUserPasswordSalt),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v205.go
+++ b/models/migrations/v205.go
@@ -16,11 +16,6 @@ func migrateUserPasswordSalt(x *xorm.Engine) error {
 		return nil
 	}
 
-	// type User struct {
-	// 	Rands string `xorm:"VARCHAR(32)"`
-	// 	Salt  string `xorm:"VARCHAR(32)"`
-	// }
-
 	if err := modifyColumn(x, "user", &schemas.Column{
 		Name: "rands",
 		SQLType: schemas.SQLType{

--- a/models/migrations/v205.go
+++ b/models/migrations/v205.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
+)
+
+func migrateUserPasswordSalt(x *xorm.Engine) error {
+	dbType := x.Dialect().URI().DBType
+	// For SQLITE, the max length doesn't matter.
+	if dbType == schemas.SQLITE {
+		return nil
+	}
+
+	// type User struct {
+	// 	Rands string `xorm:"VARCHAR(32)"`
+	// 	Salt  string `xorm:"VARCHAR(32)"`
+	// }
+
+	if err := modifyColumn(x, "user", &schemas.Column{
+		Name: "rands",
+		SQLType: schemas.SQLType{
+			Name: "VARCHAR",
+		},
+		Length: 32,
+	}); err != nil {
+		return err
+	}
+
+	return modifyColumn(x, "user", &schemas.Column{
+		Name: "salt",
+		SQLType: schemas.SQLType{
+			Name: "VARCHAR",
+		},
+		Length: 32,
+	})
+}

--- a/models/migrations/v205.go
+++ b/models/migrations/v205.go
@@ -22,6 +22,8 @@ func migrateUserPasswordSalt(x *xorm.Engine) error {
 			Name: "VARCHAR",
 		},
 		Length: 32,
+		// MySQL will like us again.
+		Nullable: true,
 	}); err != nil {
 		return err
 	}
@@ -31,6 +33,7 @@ func migrateUserPasswordSalt(x *xorm.Engine) error {
 		SQLType: schemas.SQLType{
 			Name: "VARCHAR",
 		},
-		Length: 32,
+		Length:   32,
+		Nullable: true,
 	})
 }

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -363,18 +363,18 @@ func hashPassword(passwd, salt, algo string) (string, error) {
 	var saltBytes []byte
 
 	// There are two formats for the Salt value:
-	// * The new format is a 32-byte hex-encoded string
+	// * The new format is a (32+)-byte hex-encoded string
 	// * The old format was a 10-byte binary format
 	// We have to tolerate both here but Authenticate should
 	// regenerate the Salt following a successful validation.
-	if len(salt) == 32 {
+	if len(salt) == 10 {
+		saltBytes = []byte(salt)
+	} else {
 		var err error
 		saltBytes, err = hex.DecodeString(salt)
 		if err != nil {
 			return "", err
 		}
-	} else {
-		saltBytes = []byte(salt)
 	}
 
 	switch algo {
@@ -526,13 +526,14 @@ func IsUserExist(uid int64, name string) (bool, error) {
 	return isUserExist(db.GetEngine(db.DefaultContext), uid, name)
 }
 
-// GetUserSalt returns a random user salt token.
-//
 // Note: As of the beginning of 2022, it is recommended to use at least
 // 64 bits of salt, but NIST is already recommending to use to 128 bits.
 // (16 bytes = 16 * 8 = 128 bits)
+const SaltByteLength = 16
+
+// GetUserSalt returns a random user salt token.
 func GetUserSalt() (string, error) {
-	rBytes, err := util.RandomBytes(16)
+	rBytes, err := util.RandomBytes(SaltByteLength)
 	if err != nil {
 		return "", err
 	}

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -362,10 +362,11 @@ func hashPassword(passwd, salt, algo string) (string, error) {
 	var tempPasswd []byte
 	var saltBytes []byte
 
-	// Salt is encoded as hex, because certain bytes won't translates well into
-	// it's string correlation. But only decode it when salt has a length of 32.
-	// Because we should tolerate hashing a password when a user has the old format
-	// of salt.
+	// There are two formats for the Salt value:
+	// * The new format is a 32-byte hex-encoded string
+	// * The old format was a 10-byte binary format
+	// We have to tolerate both here but, Authenticate should
+	// regenerate the Salt following a successful validation.
 	if len(salt) == 32 {
 		var err error
 		saltBytes, err = hex.DecodeString(salt)

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -360,12 +360,22 @@ func (u *User) NewGitSig() *git.Signature {
 
 func hashPassword(passwd, salt, algo string) (string, error) {
 	var tempPasswd []byte
+	var saltBytes []byte
+
 	// Salt is encoded as hex, because certain bytes won't translates well into
-	// it's string correlation.
-	saltBytes, err := hex.DecodeString(salt)
-	if err != nil {
-		return "", err
+	// it's string correlation. But only decode it when salt has a length of 32.
+	// Because we should tolerate hashing a password when a user has the old format
+	// of salt.
+	if len(salt) == 32 {
+		var err error
+		saltBytes, err = hex.DecodeString(salt)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		saltBytes = []byte(salt)
 	}
+
 	switch algo {
 	case algoBcrypt:
 		tempPasswd, _ = bcrypt.GenerateFromPassword([]byte(passwd), bcrypt.DefaultCost)

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -365,7 +365,7 @@ func hashPassword(passwd, salt, algo string) (string, error) {
 	// There are two formats for the Salt value:
 	// * The new format is a 32-byte hex-encoded string
 	// * The old format was a 10-byte binary format
-	// We have to tolerate both here but, Authenticate should
+	// We have to tolerate both here but Authenticate should
 	// regenerate the Salt following a successful validation.
 	if len(salt) == 32 {
 		var err error
@@ -528,10 +528,9 @@ func IsUserExist(uid int64, name string) (bool, error) {
 
 // GetUserSalt returns a random user salt token.
 //
-// Note on the used size here. As of begin of 2022, it's recommended to use
-// 64 bits of salt, certain recommended like NIST are already recommending to use
-// 128 bits of salt. Given it's more leaning to 128 bits of salt, we're using this
-// and taking a security margin. Again, why 16? 16 bytes = 16 * 8 = 128 bits.
+// Note: As of the beginning of 2022, it is recommended to use at least
+// 64 bits of salt, but NIST is already recommending to use to 128 bits.
+// (16 bytes = 16 * 8 = 128 bits)
 func GetUserSalt() (string, error) {
 	rBytes, err := util.RandomBytes(16)
 	if err != nil {

--- a/modules/util/util.go
+++ b/modules/util/util.go
@@ -139,11 +139,11 @@ func MergeInto(dict map[string]interface{}, values ...interface{}) (map[string]i
 
 // RandomInt returns a random integer between 0 and limit, inclusive
 func RandomInt(limit int64) (int64, error) {
-	int, err := rand.Int(rand.Reader, big.NewInt(limit))
+	rInt, err := rand.Int(rand.Reader, big.NewInt(limit))
 	if err != nil {
 		return 0, err
 	}
-	return int.Int64(), nil
+	return rInt.Int64(), nil
 }
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -160,4 +160,21 @@ func RandomString(length int64) (string, error) {
 		bytes[i] = letters[num]
 	}
 	return string(bytes), nil
+}
+
+// RandomBytes generates `len` bytes
+// This differ from RandomString, as RandomString is limited to each byte only
+// having a maximum value of 63 instead of 255(max byte size) and thus decrease the
+// security implications of it.
+func RandomBytes(length int64) ([]byte, error) {
+	bytes := make([]byte, length)
+	limit := int64(^uint8(0))
+	for i := range bytes {
+		num, err := RandomInt(limit)
+		if err != nil {
+			return []byte{}, err
+		}
+		bytes[i] = uint8(num)
+	}
+	return bytes, nil
 }

--- a/modules/util/util.go
+++ b/modules/util/util.go
@@ -167,13 +167,6 @@ func RandomString(length int64) (string, error) {
 // a maximum value of 63 instead of 255(max byte size)
 func RandomBytes(length int64) ([]byte, error) {
 	bytes := make([]byte, length)
-	limit := int64(^uint8(0))
-	for i := range bytes {
-		num, err := RandomInt(limit)
-		if err != nil {
-			return []byte{}, err
-		}
-		bytes[i] = uint8(num)
-	}
-	return bytes, nil
+	_, err := rand.Read(bytes)
+	return bytes, err
 }

--- a/modules/util/util.go
+++ b/modules/util/util.go
@@ -162,10 +162,9 @@ func RandomString(length int64) (string, error) {
 	return string(bytes), nil
 }
 
-// RandomBytes generates `len` bytes
-// This differ from RandomString, as RandomString is limited to each byte only
-// having a maximum value of 63 instead of 255(max byte size) and thus decrease the
-// security implications of it.
+// RandomBytes generates `length` bytes
+// This differs from RandomString, as RandomString is limits each byte to have
+// a maximum value of 63 instead of 255(max byte size)
 func RandomBytes(length int64) ([]byte, error) {
 	bytes := make([]byte, length)
 	limit := int64(^uint8(0))

--- a/modules/util/util_test.go
+++ b/modules/util/util_test.go
@@ -157,6 +157,24 @@ func Test_RandomString(t *testing.T) {
 	assert.NotEqual(t, str3, str4)
 }
 
+func Test_RandomBytes(t *testing.T) {
+	bytes1, err := RandomBytes(32)
+	assert.NoError(t, err)
+
+	bytes2, err := RandomBytes(32)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, bytes1, bytes2)
+
+	bytes3, err := RandomBytes(256)
+	assert.NoError(t, err)
+
+	bytes4, err := RandomBytes(256)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, bytes3, bytes4)
+}
+
 func Test_OptionalBool(t *testing.T) {
 	assert.Equal(t, OptionalBoolNone, OptionalBoolParse(""))
 	assert.Equal(t, OptionalBoolNone, OptionalBoolParse("x"))

--- a/services/auth/source/db/authenticate.go
+++ b/services/auth/source/db/authenticate.go
@@ -21,9 +21,9 @@ func Authenticate(user *user_model.User, login, password string) (*user_model.Us
 	}
 
 	// Update password hash if server password hash algorithm have changed
-	// Or update the password when the salt has a length of 10, this in order
-	// to migrate user's salts to a more secure salt.
-	if user.PasswdHashAlgo != setting.PasswordHashAlgo || len(user.Salt) == 10 {
+	// Or update the password when the salt length doesn't match the current
+	// recommended salt length, this in order to migrate user's salts to a more secure salt.
+	if user.PasswdHashAlgo != setting.PasswordHashAlgo || len(user.Salt) != user_model.SaltByteLength*2 {
 		if err := user.SetPassword(password); err != nil {
 			return nil, err
 		}

--- a/services/auth/source/db/authenticate.go
+++ b/services/auth/source/db/authenticate.go
@@ -21,7 +21,9 @@ func Authenticate(user *user_model.User, login, password string) (*user_model.Us
 	}
 
 	// Update password hash if server password hash algorithm have changed
-	if user.PasswdHashAlgo != setting.PasswordHashAlgo {
+	// Or update the password when the salt has a length of 10, this in order
+	// to migrate user's salts to a more secure salt.
+	if user.PasswdHashAlgo != setting.PasswordHashAlgo || len(user.Salt) == 10 {
 		if err := user.SetPassword(password); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- The current implementation of `RandomString` doesn't give you a most-possible unique randomness. It gives you 6*`length` instead of the possible 8*`length` bits(or as `length`x bytes) randomness. This is because `RandomString` is being limited to a max value of 63, this in order to represent the random byte as a letter/digit.
- The recommendation of pbkdf2 is to use 64+ bit salt, which the `RandomString` doesn't give with a length of 10, instead of increasing 10 to a higher number, this patch adds a new function called `RandomBytes` which does give you the guarentee of 8*`length` randomness and thus corresponding of `length`x bytes randomness.
- Use hexadecimal to store the bytes value in the database, as mentioned, it doesn't play nice in order to convert it to a string. This will always be a length of 32(with `length` being 16).
- When we detect on `Authenticate`(source: db) that a user has the old format of salt, re-hash the password such that the user will have it's password hashed with increased salt.

Thanks to @zeripath for working out the rouge edges from my first commit 😄.