### PR TITLE
Update `TODOs` badge to reflect new default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
   <a href="https://crowdin.com/project/gitea" title="Crowdin">
     <img src="https://badges.crowdin.net/gitea/localized.svg">
   </a>
-  <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea" title="TODOs">
-    <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea">
+  <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea&branch=main" title="TODOs">
+    <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea/main">
   </a>
   <a href="https://www.bountysource.com/teams/gitea" title="Bountysource">
     <img src="https://img.shields.io/bountysource/team/gitea/activity">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -36,8 +36,8 @@
   <a href="https://crowdin.com/project/gitea" title="Crowdin">
     <img src="https://badges.crowdin.net/gitea/localized.svg">
   </a>
-  <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea" title="TODOs">
-    <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea">
+  <a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea&branch=main" title="TODOs">
+    <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea/main">
   </a>
   <a href="https://img.shields.io/bountysource/team/gitea" title="Bountysource">
     <img src="https://img.shields.io/bountysource/team/gitea/activity">


### PR DESCRIPTION
Some time ago, the default branch was changed from `master` -> `main`. [`tickgit`](https://www.tickgit.com/), which powers the TODOs badge in the README(s) still defaults to `master` when no branch is specified. This updates the badges to include the branch name as `main`, so that the indexed TODOs are correct.

<a href="https://www.tickgit.com/browse?repo=github.com/go-gitea/gitea&branch=main" title="TODOs">
  <img src="https://badgen.net/https/api.tickgit.com/badgen/github.com/go-gitea/gitea/main">
</a>