### PR TITLE
fix location for custom/options/license

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -786,7 +786,7 @@ PATH =
 ;PULL_REQUEST_QUEUE_LENGTH = 1000
 ;;
 ;; Preferred Licenses to place at the top of the List
-;; The name here must match the filename in conf/license or custom/conf/license
+;; The name here must match the filename in options/license or custom/options/license
 ;PREFERRED_LICENSES = Apache License 2.0,MIT License
 ;;
 ;; Disable the ability to interact with repositories using the HTTP protocol


### PR DESCRIPTION
This effectively recreates PR #15669 which was closed in anticipation of #15559 which did not come to be final.
