### PR TITLE
Fix CSS specificity issue with easymde's css

### DIFF
--- a/web_src/js/features/comp/EasyMDE.js
+++ b/web_src/js/features/comp/EasyMDE.js
@@ -25,10 +25,10 @@ export async function importEasyMDE() {
   // https://github.com/codemirror/CodeMirror/issues/5484
   // https://github.com/codemirror/CodeMirror/issues/4838
 
+  // easymde's css is loaded via webpack config
   const [{default: EasyMDE}, {default: CodeMirror}] = await Promise.all([
     import(/* webpackChunkName: "easymde" */'easymde'),
     import(/* webpackChunkName: "codemirror" */'codemirror'),
-    import(/* webpackChunkName: "easymde" */'easymde/dist/easymde.min.css'),
   ]);
 
   // CodeMirror plugins must be loaded by a "Plain browser env"

--- a/web_src/js/features/comp/EasyMDE.js
+++ b/web_src/js/features/comp/EasyMDE.js
@@ -25,7 +25,7 @@ export async function importEasyMDE() {
   // https://github.com/codemirror/CodeMirror/issues/5484
   // https://github.com/codemirror/CodeMirror/issues/4838
 
-  // easymde's css is loaded via webpack config
+  // EasyMDE's CSS should be loaded via webpack config, otherwise our own styles can not overwrite the default styles.
   const [{default: EasyMDE}, {default: CodeMirror}] = await Promise.all([
     import(/* webpackChunkName: "easymde" */'easymde'),
     import(/* webpackChunkName: "codemirror" */'codemirror'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ export default {
       resolve(__dirname, 'web_src/js/jquery.js'),
       resolve(__dirname, 'web_src/fomantic/build/semantic.js'),
       resolve(__dirname, 'web_src/js/index.js'),
+      resolve(__dirname, 'node_modules/easymde/dist/easymde.min.css'),
       resolve(__dirname, 'web_src/fomantic/build/semantic.css'),
       resolve(__dirname, 'web_src/less/misc.css'),
       resolve(__dirname, 'web_src/less/index.less'),


### PR DESCRIPTION
PR #18069 introduced a regression in certain overwritten editor styles because the dynamic loading of easymde.min.css causes its's style to apply after our supposed override styles, so they won in terms of CSS specificity over our styles.

Solve this by bundling the styles from easymde.min.css into index.css. We should later aim to completely replace easymde.min.css with our own styles so there are no more conflicts.

Before:
<img width="770" alt="Screen Shot 2022-01-07 at 03 34 14" src="https://user-images.githubusercontent.com/115237/148482518-efb693fd-3c63-4b4d-adae-a6f143803a28.png">

After:
<img width="770" alt="Screen Shot 2022-01-07 at 03 34 53" src="https://user-images.githubusercontent.com/115237/148482519-1e4c36c0-a21e-4a64-b4b7-3be401ebc82e.png">