### PR TITLE
Sort locales according to their names

### DIFF
--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -5,6 +5,8 @@
 package translation
 
 import (
+	"sort"
+
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/options"
 	"code.gitea.io/gitea/modules/setting"
@@ -72,6 +74,11 @@ func InitLocales() {
 	for i, v := range langs {
 		allLangs = append(allLangs, LangType{v, names[i]})
 	}
+
+	// Sort languages according to their name - needed for the user settings
+	sort.Slice(allLangs, func(i, j int) bool {
+		return allLangs[i].Name < allLangs[j].Name
+	})
 }
 
 // Match matches accept languages

--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -6,6 +6,7 @@ package translation
 
 import (
 	"sort"
+	"strings"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/options"
@@ -33,7 +34,7 @@ var (
 	supportedTags []language.Tag
 )
 
-// AllLangs returns all supported langauages
+// AllLangs returns all supported languages sorted by name
 func AllLangs() []LangType {
 	return allLangs
 }
@@ -75,9 +76,9 @@ func InitLocales() {
 		allLangs = append(allLangs, LangType{v, names[i]})
 	}
 
-	// Sort languages according to their name - needed for the user settings
+	// Sort languages case insensitive according to their name - needed for the user settings
 	sort.Slice(allLangs, func(i, j int) bool {
-		return allLangs[i].Name < allLangs[j].Name
+		return strings.ToLower(allLangs[i].Name) < strings.ToLower(allLangs[j].Name)
 	})
 }
 


### PR DESCRIPTION
Previously, it was pretty random where which language can be found in the user settings.
This PR fixes this by sorting locales **once** when initializing Gitea based on their names.
I thought that this change was too small and easy to open an issue for hence I implemented it quickly.

~~It is a breaking change if any implementation previously needed locales to be at specific indices, which I hope it didn't, especially as it is now clearer than before where which locale will be.~~ According to a quick search, there should be nothing that needs a specific index.

(**Note**: I manually disabled the max-width in the following screenshots to show the old vs. new comparison, that's not how Gitea behaves normally.)

Now, it is also visible that for some reason many locales have lowercase names while others have uppercase names.
Should we unify them to all be uppercased or lowercased (where possible)?

## Previous appearance
(tested on a private Gitea 1.15.9 instance)
![image](https://user-images.githubusercontent.com/51889757/148640656-92c55af4-7ecc-48cd-b2ad-beeb9fe6bd2f.png)

## New appearance
![image](https://user-images.githubusercontent.com/51889757/148641725-e7cff038-f32b-431d-84c4-8ba32d79291b.png)

