### PR TITLE
In the Organization member page, 2fa column is too narrow for Simplified Chinese and Chinese Traditional.

### DIFF
--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -37,7 +37,7 @@
 							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock"}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
 						</div>
 					</div>
-					<div class="ui one wide column center">
+					<div class="ui two wide column center">
 						<div class="meta">
 							{{$.i18n.Tr "admin.users.2fa"}}
 						</div>
@@ -51,7 +51,7 @@
 							</strong>
 						</div>
 					</div>
-					<div class="ui four wide column">
+					<div class="ui three wide column">
 						<div class="text right">
 							{{if eq $.SignedUser.ID .ID}}
 								<form>


### PR DESCRIPTION
In the Organization member page, 2fa column is too narrow for Simplified Chinese and Chinese Traditional.

Expand 2fa column and Narrow the last column.

Before
![QHWQX(M%H)VLQKA3J5UHA$B](https://user-images.githubusercontent.com/16610170/148650990-3cf4704f-b951-4d5b-8849-57d79a650f22.jpg)

After
![9`EZ{TAPVU$7 NQ$TV_3 ~C](https://user-images.githubusercontent.com/16610170/148650995-051d0fcc-45cf-4fd7-a8f0-a256f3f988ae.jpg)

