### PR TITLE
Fix NPE on try to get tag reference via API

### DIFF
--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -99,12 +99,12 @@ func (repo *Repository) getCommitFromBatchReader(rd *bufio.Reader, id SHA1) (*Co
 		if err != nil {
 			return nil, err
 		}
-		tag, err := parseTagData(repo, data)
+		tag, err := parseTagData(data)
 		if err != nil {
 			return nil, err
 		}
 
-		commit, err := tag.Commit()
+		commit, err := tag.Commit(repo)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -99,11 +99,10 @@ func (repo *Repository) getCommitFromBatchReader(rd *bufio.Reader, id SHA1) (*Co
 		if err != nil {
 			return nil, err
 		}
-		tag, err := parseTagData(data)
+		tag, err := parseTagData(repo, data)
 		if err != nil {
 			return nil, err
 		}
-		tag.repo = repo
 
 		commit, err := tag.Commit()
 		if err != nil {

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -72,7 +72,6 @@ func (repo *Repository) getTag(tagID SHA1, name string) (*Tag, error) {
 			Type:    tp,
 			Tagger:  commit.Committer,
 			Message: commit.Message(),
-			repo:    repo,
 		}
 
 		repo.tagCache.Set(tagID.String(), tag)
@@ -85,7 +84,7 @@ func (repo *Repository) getTag(tagID SHA1, name string) (*Tag, error) {
 		return nil, err
 	}
 
-	tag, err := parseTagData(repo, data)
+	tag, err := parseTagData(data)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -85,14 +85,13 @@ func (repo *Repository) getTag(tagID SHA1, name string) (*Tag, error) {
 		return nil, err
 	}
 
-	tag, err := parseTagData(data)
+	tag, err := parseTagData(repo, data)
 	if err != nil {
 		return nil, err
 	}
 
 	tag.Name = name
 	tag.ID = tagID
-	tag.repo = repo
 	tag.Type = tp
 
 	repo.tagCache.Set(tagID.String(), tag)

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -55,7 +55,6 @@ func TestRepository_GetTag(t *testing.T) {
 	if lTag == nil {
 		assert.FailNow(t, "nil lTag: %s", lTagName)
 	}
-	lTag.repo = nil
 	assert.EqualValues(t, lTagName, lTag.Name)
 	assert.EqualValues(t, lTagCommitID, lTag.ID.String())
 	assert.EqualValues(t, lTagCommitID, lTag.Object.String())

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -30,11 +30,11 @@ func (repo *Repository) getTree(id SHA1) (*Tree, error) {
 		if err != nil {
 			return nil, err
 		}
-		tag, err := parseTagData(repo, data)
+		tag, err := parseTagData(data)
 		if err != nil {
 			return nil, err
 		}
-		commit, err := tag.Commit()
+		commit, err := tag.Commit(repo)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -30,7 +30,7 @@ func (repo *Repository) getTree(id SHA1) (*Tree, error) {
 		if err != nil {
 			return nil, err
 		}
-		tag, err := parseTagData(data)
+		tag, err := parseTagData(repo, data)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/git/tag.go
+++ b/modules/git/tag.go
@@ -17,7 +17,6 @@ const endpgp = "\n-----END PGP SIGNATURE-----"
 type Tag struct {
 	Name      string
 	ID        SHA1
-	repo      *Repository
 	Object    SHA1 // The id of this commit object
 	Type      string
 	Tagger    *Signature
@@ -26,16 +25,15 @@ type Tag struct {
 }
 
 // Commit return the commit of the tag reference
-func (tag *Tag) Commit() (*Commit, error) {
-	return tag.repo.getCommit(tag.Object)
+func (tag *Tag) Commit(gitRepo *Repository) (*Commit, error) {
+	return gitRepo.getCommit(tag.Object)
 }
 
 // Parse commit information from the (uncompressed) raw
 // data from the commit object.
 // \n\n separate headers from message
-func parseTagData(repo *Repository, data []byte) (*Tag, error) {
+func parseTagData(data []byte) (*Tag, error) {
 	tag := new(Tag)
-	tag.repo = repo
 	tag.Tagger = &Signature{}
 	// we now have the contents of the commit object. Let's investigate...
 	nextline := 0

--- a/modules/git/tag.go
+++ b/modules/git/tag.go
@@ -33,8 +33,9 @@ func (tag *Tag) Commit() (*Commit, error) {
 // Parse commit information from the (uncompressed) raw
 // data from the commit object.
 // \n\n separate headers from message
-func parseTagData(data []byte) (*Tag, error) {
+func parseTagData(repo *Repository, data []byte) (*Tag, error) {
 	tag := new(Tag)
+	tag.repo = repo
 	tag.Tagger = &Signature{}
 	// we now have the contents of the commit object. Let's investigate...
 	nextline := 0

--- a/modules/git/tag_test.go
+++ b/modules/git/tag_test.go
@@ -24,7 +24,6 @@ tagger Lucas Michot <lucas@semalead.com> 1484491741 +0100
 `), tag: Tag{
 			Name:      "",
 			ID:        SHA1{},
-			repo:      nil,
 			Object:    SHA1{0x3b, 0x11, 0x4a, 0xb8, 0x0, 0xc6, 0x43, 0x2a, 0xd4, 0x23, 0x87, 0xcc, 0xf6, 0xbc, 0x8d, 0x43, 0x88, 0xa2, 0x88, 0x5a},
 			Type:      "commit",
 			Tagger:    &Signature{Name: "Lucas Michot", Email: "lucas@semalead.com", When: time.Unix(1484491741, 0)},
@@ -42,7 +41,6 @@ o
 ono`), tag: Tag{
 			Name:      "",
 			ID:        SHA1{},
-			repo:      nil,
 			Object:    SHA1{0x7c, 0xdf, 0x42, 0xc0, 0xb1, 0xcc, 0x76, 0x3a, 0xb7, 0xe4, 0xc3, 0x3c, 0x47, 0xa2, 0x4e, 0x27, 0xc6, 0x6b, 0xfc, 0xcc},
 			Type:      "commit",
 			Tagger:    &Signature{Name: "Lucas Michot", Email: "lucas@semalead.com", When: time.Unix(1484553735, 0)},
@@ -52,7 +50,7 @@ ono`), tag: Tag{
 	}
 
 	for _, test := range testData {
-		tag, err := parseTagData(nil, test.data)
+		tag, err := parseTagData(test.data)
 		assert.NoError(t, err)
 		assert.EqualValues(t, test.tag.ID, tag.ID)
 		assert.EqualValues(t, test.tag.Object, tag.Object)

--- a/modules/git/tag_test.go
+++ b/modules/git/tag_test.go
@@ -52,7 +52,7 @@ ono`), tag: Tag{
 	}
 
 	for _, test := range testData {
-		tag, err := parseTagData(test.data)
+		tag, err := parseTagData(nil, test.data)
 		assert.NoError(t, err)
 		assert.EqualValues(t, test.tag.ID, tag.ID)
 		assert.EqualValues(t, test.tag.Object, tag.Object)

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -296,7 +296,7 @@ func PushUpdateAddTag(repo *repo_model.Repository, gitRepo *git.Repository, tagN
 	if err != nil {
 		return fmt.Errorf("GetTag: %v", err)
 	}
-	commit, err := tag.Commit()
+	commit, err := tag.Commit(gitRepo)
 	if err != nil {
 		return fmt.Errorf("Commit: %v", err)
 	}

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -103,7 +103,7 @@ func GetAnnotatedTag(ctx *context.APIContext) {
 	if tag, err := ctx.Repo.GitRepo.GetAnnotatedTag(sha); err != nil {
 		ctx.Error(http.StatusBadRequest, "GetAnnotatedTag", err)
 	} else {
-		commit, err := tag.Commit()
+		commit, err := tag.Commit(ctx.Repo.GitRepo)
 		if err != nil {
 			ctx.Error(http.StatusBadRequest, "GetAnnotatedTag", err)
 		}

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -294,7 +294,7 @@ func pushUpdateAddTags(ctx context.Context, repo *repo_model.Repository, gitRepo
 		if err != nil {
 			return fmt.Errorf("GetTag: %v", err)
 		}
-		commit, err := tag.Commit()
+		commit, err := tag.Commit(gitRepo)
 		if err != nil {
 			return fmt.Errorf("Commit: %v", err)
 		}


### PR DESCRIPTION
In current situation, you need to add the gitRepo into tag, but this is not always posible as it's an unexported field. so if you try to get a tag via api it will cause a 500. this fix it.

fix:
```
2022/01/12 00:13:46 ...common/middleware.go:70:1() [E] PANIC: runtime error: invalid memory address or nil pointer dereference
	/usr/lib/go/src/runtime/panic.go:221 (0x44dca6)
		panicmem: panic(memoryError)
	/usr/lib/go/src/runtime/signal_unix.go:735 (0x44dc76)
		sigpanic: panicmem()
	/home/user/gitea/modules/git/repo_commit_nogogit.go:71 (0xac4ed1)
		(*Repository).getCommit: wr, rd, cancel := repo.CatFileBatch(repo.Ctx)
	/home/user/gitea/modules/git/tag.go:30 (0xad384d)
		(*Tag).Commit: return tag.repo.getCommit(tag.Object)
	/home/user/gitea/modules/git/repo_tree_nogogit.go:37 (0xad381c)
		(*Repository).getTree: commit, err := tag.Commit()
	/home/user/gitea/modules/git/repo_tree_nogogit.go:85 (0xad3f44)
		(*Repository).GetTree: return repo.getTree(id)
	/home/user/gitea/services/repository/files/tree.go:25 (0x1b88257)
		GetTreeBySHA: gitTree, err := gitRepo.GetTree(sha)
	/home/user/gitea/routers/api/v1/repo/tree.go:63 (0x1c66b78)
		GetTree: if tree, err := files_service.GetTreeBySHA(ctx.Repo.Repository, sha, ctx.FormInt("page"), ctx.FormInt("per_page"), ctx.FormBool("recursive")); err != nil {
	/home/user/gitea/modules/web/route.go:80 (0x1b5ff26)
		Wrap.func1: t(ctx)
	/usr/lib/go/src/net/http/server.go:2047 (0x77948e)
		HandlerFunc.ServeHTTP: f(w, r)
	/home/user/gitea/modules/context/api.go:436 (0x13805af)
		RepoRefForAPI.func1: next.ServeHTTP(w, req)
	/usr/lib/go/src/net/http/server.go:2047 (0x77948e)
		HandlerFunc.ServeHTTP: f(w, r)
	/home/user/gitea/modules/web/route.go:95 (0x1b600a5)
```