### PR TITLE
Fix documents for development and bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Found something you weren't expecting?  Report it here!
+description: Found something you weren't expecting? Report it here!
 body:
 - type: markdown
   attributes:
@@ -11,7 +11,8 @@ body:
       1. Please speak English, this is the language all maintainers can speak and write.
       2. Please ask questions or configuration/deploy problems on our Discord
          server (https://discord.gg/gitea) or forum (https://discourse.gitea.io).
-      3. Please take a moment to check that your issue doesn't already exist.
+      3. Make sure you are using the latest release and
+         take a moment to check that your issue hasn't been reported before.
       4. Make sure it's not mentioned in the FAQ (https://docs.gitea.io/en-us/faq)
       5. Please give all relevant information below for bug reports, because
          incomplete details will be handled as an invalid report.
@@ -19,7 +20,7 @@ body:
   id: gitea-ver
   attributes:
     label: Gitea Version
-    description: Gitea version (or commit reference) your instance is running
+    description: Gitea version (or commit reference) of your instance
   validations:
     required: true
 - type: input
@@ -37,8 +38,8 @@ body:
   attributes:
     label: How are you running Gitea?
     description: |
-      Please include information on whether you built gitea yourself, used one of our downloads, are using https://try.gitea.io or are using some other package
-      Please also tell us how you are running gitea, e.g. if it is being run from docker, a command-line, systemd etc.
+      Please include information on whether you built Gitea yourself, used one of our downloads, are using https://try.gitea.io or are using some other package
+      Please also tell us how you are running Gitea, e.g. if it is being run from docker, a command-line, systemd etc.
       If you are using a package or systemd tell us what distribution you are using
   validations:
     required: true
@@ -67,7 +68,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      It really is important to provide pertinent logs
+      It's really important to provide pertinent logs
       Please read https://docs.gitea.io/en-us/logging-configuration/#debugging-problems
       In addition, if your problem relates to git commands set `RUN_MODE=dev` at the top of app.ini
 - type: input
@@ -81,9 +82,9 @@ body:
     label: Description
     description: |
       Please provide a description of your issue here, with a URL if you were able to reproduce the issue (see above)
-      If using a proxy or a CDN (e.g. CloudFlare) in front of gitea, please disable the proxy/CDN fully and connect to gitea directly to confirm the issue still persists without those services.
+      If you are using a proxy or a CDN (e.g. Cloudflare) in front of Gitea, please disable the proxy/CDN fully and access Gitea directly to confirm the issue still persists without those services.
 - type: textarea
   id: screenshots
   attributes:
     label: Screenshots
-    description: If this issue involves the Web Interface, please provide a screenshot or multiple screenshots
+    description: If this issue involves the Web Interface, please provide one or more screenshots

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ clean:
 
 .PHONY: fmt
 fmt:
-	@echo "Running go fmt..."
+	@echo "Running gitea-fmt(with gofmt)..."
 	@$(GO) run build/code-batch-process.go gitea-fmt -s -w '{file-list}'
 
 .PHONY: vet
@@ -280,7 +280,7 @@ errcheck:
 
 .PHONY: fmt-check
 fmt-check:
-	# get all go files and run go fmt on them
+	# get all go files and run gitea-fmt (with gofmt) on them
 	@diff=$$($(GO) run build/code-batch-process.go gitea-fmt -s -d '{file-list}'); \
 	if [ -n "$$diff" ]; then \
 		echo "Please run 'make fmt' and commit the result:"; \

--- a/build/code-batch-process.go
+++ b/build/code-batch-process.go
@@ -21,9 +21,9 @@ import (
 )
 
 // Windows has a limitation for command line arguments, the size can not exceed 32KB.
-// So we have to feed the files to some tools (like gofmt/misspell`) batch by batch
+// So we have to feed the files to some tools (like gofmt/misspell) batch by batch
 
-// We also introduce a `gitea-fmt` command, it does better import formatting than gofmt/goimports
+// We also introduce a `gitea-fmt` command, it does better import formatting than gofmt/goimports. `gitea-fmt` calls `gofmt` internally.
 
 var optionLogVerbose bool
 

--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -29,17 +29,16 @@ required to build the JavaScript and CSS files. The minimum supported Node.js
 version is {{< min-node-version >}} and the latest LTS version is recommended.
 
 **Note**: When executing make tasks that require external tools, like
-`make misspell-check`, Gitea will automatically download and build these as
+`make watch-backend`, Gitea will automatically download and build these as
 necessary. To be able to use these you must have the `"$GOPATH"/bin` directory
 on the executable path. If you don't add the go bin directory to the
 executable path you will have to manage this yourself.
 
-**Note 2**: Go version {{< min-go-version >}} or higher is required; however, it is important
-to note that our continuous integration will check that the formatting of the
-source code is not changed by `gofmt` using `make fmt-check`. Unfortunately,
-the results of `gofmt` can differ by the version of `go`. It is therefore
+**Note 2**: Go version {{< min-go-version >}} or higher is required.
+Gitea uses `gofmt` to format source code. However, the results of 
+`gofmt` can differ by the version of `go`. Therefor it is
 recommended to install the version of Go that our continuous integration is
-running. As of last update, it should be Go version {{< go-version >}}.
+running. As of last update, the Go version should be {{< go-version >}}.
 
 ## Installing Make
 
@@ -149,25 +148,26 @@ On macOS, watching all backend source files may hit the default open files limit
 
 ### Formatting, code analysis and spell check
 
-Our continuous integration will reject PRs that are not properly formatted, fail
-code analysis or spell check.
+Our continuous integration will reject PRs that fail the code linters (including format check, code analysis and spell check).
 
-You should format your code with `go fmt` using:
+You should format your code:
 
 ```bash
 make fmt
 ```
 
-and can test whether your changes would match the results with:
+and lint the source code:
 
 ```bash
-make fmt-check # which runs make fmt internally
+# lint both frontend and backend code
+make lint
+# lint only backend code
+make lint-backend
 ```
 
-**Note**: The results of `go fmt` are dependent on the version of `go` present.
+**Note**: The results of `gofmt` are dependent on the version of `go` present.
 You should run the same version of go that is on the continuous integration
-server as mentioned above. `make fmt-check` will only check if your `go` would
-format differently - this may be different from the CI server version.
+server as mentioned above.
 
 ### Working on JS and CSS
 

--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -36,7 +36,7 @@ executable path you will have to manage this yourself.
 
 **Note 2**: Go version {{< min-go-version >}} or higher is required.
 Gitea uses `gofmt` to format source code. However, the results of 
-`gofmt` can differ by the version of `go`. Therefor it is
+`gofmt` can differ by the version of `go`. Therefore it is
 recommended to install the version of Go that our continuous integration is
 running. As of last update, the Go version should be {{< go-version >}}.
 


### PR DESCRIPTION
This PR fixes some documents and sentences.

1. Tell users to `Make sure you are using the latest release` before submitting an issue.
2. Update `hacking-on-gitea.en-us.md` to tell developers to do lint correctly.
3. Remove out-dated information, eg `make fmt-check`
4. Fix some typos.

Hopefully we can keep documents correct and up-dated.