### PR TITLE
Prevent underline hover on cards

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -248,6 +248,7 @@ a.label,
 .repository-menu a,
 .ui.search .results a,
 .ui .menu a,
+.ui.cards a.card,
 .issue-keyword a {
   text-decoration: none !important;
 }


### PR DESCRIPTION
Prevent a undesired underline effect on hovered cards.

This was regressed by #17898.

Before:
<img width="275" alt="Screen Shot 2022-01-13 at 15 27 05" src="https://user-images.githubusercontent.com/115237/149348759-6fba402c-6e74-4b26-b327-0f6dc8bef041.png">

After:
<img width="273" alt="Screen Shot 2022-01-13 at 15 27 52" src="https://user-images.githubusercontent.com/115237/149348766-21e45443-b53f-4f38-a0a0-fa19d7d36a26.png">
