### PR TITLE
Fix inconsistent PR comment counts

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -835,13 +835,12 @@ func updateCommentInfos(ctx context.Context, opts *CreateCommentOptions, comment
 			}
 		}
 		fallthrough
-	case CommentTypeReview:
-		fallthrough
 	case CommentTypeComment:
 		if _, err = e.Exec("UPDATE `issue` SET num_comments=num_comments+1 WHERE id=?", opts.Issue.ID); err != nil {
 			return err
 		}
-
+		fallthrough
+	case CommentTypeReview:
 		// Check attachments
 		attachments, err := repo_model.GetAttachmentsByUUIDs(ctx, opts.Attachments)
 		if err != nil {


### PR DESCRIPTION
This makes the comment count on PRs consistent with repostats cronjob behaviour again: ie. don't try to count review comments towards issue comment count (fixing a regression from #16075).
This is also a bugfix for API clients, that rely on that count to fetch issue comments (but that API does not include review comments, resulting in bad client state).

fixes #16901
In a later PR we can aim at counting PR-reviews & code comments towards the the PR comment count [similar to github](https://github.com/go-gitea/gitea/issues/16901#issuecomment-942083356).


