### PR TITLE
Fix inconsistent PR comment counts (#18260)

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -762,13 +762,12 @@ func updateCommentInfos(e *xorm.Session, opts *CreateCommentOptions, comment *Co
 			}
 		}
 		fallthrough
-	case CommentTypeReview:
-		fallthrough
 	case CommentTypeComment:
 		if _, err = e.Exec("UPDATE `issue` SET num_comments=num_comments+1 WHERE id=?", opts.Issue.ID); err != nil {
 			return err
 		}
-
+		fallthrough
+	case CommentTypeReview:
 		// Check attachments
 		attachments, err := getAttachmentsByUUIDs(e, opts.Attachments)
 		if err != nil {


### PR DESCRIPTION
Backport of #18260:
This makes the comment count on PRs consistent with repostats cronjob behaviour again: ie. don't try to count review comments towards issue comment count (fixing a regression from #16075).