### PR TITLE
Changelog for 1.15.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Fix inconsistent PR comment counts (#18260) (#18261)
   * Fix release link broken (#18252) (#18253)
   * Fix update user from site administration page bug (#18250) (#18251)
-  * Set HeadCommit when creating tags. (#18116) (#18173)
+  * Set HeadCommit when creating tags (#18116) (#18173)
   * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
 * MISC
   * Fix purple color in suggested label colors (#18241) (#18242)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 * BUGFIXES
   * Fix inconsistent PR comment counts (#18260) (#18261)
   * Fix release link broken (#18252) (#18253)
-  * Fix update user bug (#18250) (#18251)
+  * Fix update user from site administration page bug (#18250) (#18251)
   * Set HeadCommit when creating tags. (#18116) (#18173)
   * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 * BUGFIXES
   * Fix inconsistent PR comment counts (#18260) (#18261)
   * Fix release link broken (#18252) (#18253)
-  * Fix update user bug (18250) (#18251)
+  * Fix update user bug (#18250) (#18251)
   * Set HeadCommit when creating tags. (#18116) (#18173)
   * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 
 * BUGFIXES
   * Fix inconsistent PR comment counts (#18260) (#18261)
-  * Fix release link broken (#18253)
-  * Fix update user bug (#18251)
+  * Fix release link broken (#18252) (#18253)
+  * Fix update user bug (18250) (#18251)
   * Set HeadCommit when creating tags. (#18116) (#18173)
   * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
 * MISC
-  * Fix purple color in suggested label colors (#18242)
+  * Fix purple color in suggested label colors (#18241) (#18242)
   * Bump mermaid from 8.10.1 to 8.13.8 (#18198) (#18206)
 
 ## [1.15.9](https://github.com/go-gitea/gitea/releases/tag/v1.15.9) - 2021-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Fix update user from site administration page bug (#18250) (#18251)
   * Set HeadCommit when creating tags (#18116) (#18173)
   * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
-* MISC
   * Fix purple color in suggested label colors (#18241) (#18242)
+* SECURITY
   * Bump mermaid from 8.10.1 to 8.13.8 (#18198) (#18206)
 
 ## [1.15.9](https://github.com/go-gitea/gitea/releases/tag/v1.15.9) - 2021-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
+## [1.15.10](https://github.com/go-gitea/gitea/releases/tag/v1.15.10) - 2022-01-14
+
+* BUGFIXES
+  * Fix inconsistent PR comment counts (#18260) (#18261)
+  * Fix release link broken (#18253)
+  * Fix update user bug (#18251)
+  * Set HeadCommit when creating tags. (#18116) (#18173)
+  * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
+* MISC
+  * Fix purple color in suggested label colors (#18242)
+  * Bump mermaid from 8.10.1 to 8.13.8 (#18198) (#18206)
+
 ## [1.15.9](https://github.com/go-gitea/gitea/releases/tag/v1.15.9) - 2021-12-30
 
 * BUGFIXES


### PR DESCRIPTION
## [1.15.10](https://github.com/go-gitea/gitea/releases/tag/v1.15.10) - 2022-01-14

* BUGFIXES
  * Fix inconsistent PR comment counts (#18260) (#18261)
  * Fix release link broken (#18252) (#18253)
  * Fix update user from site administration page bug (#18250) (#18251)
  * Set HeadCommit when creating tags (#18116) (#18173)
  * Use correct translation key for error messages due to max repo limits (#18135 & #18153) (#18152)
  * Fix purple color in suggested label colors (#18241) (#18242)
* SECURITY
  * Bump mermaid from 8.10.1 to 8.13.8 (#18198) (#18206)
