### PR TITLE
Upgrade EasyMDE to 2.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "codemirror": "5.64.0",
     "css-loader": "6.5.1",
     "dropzone": "6.0.0-beta.2",
-    "easymde": "2.15.0",
+    "easymde": "2.16.1",
     "esbuild-loader": "2.16.0",
     "escape-goat": "4.0.0",
     "fast-glob": "3.2.7",


### PR DESCRIPTION
Upgade EasyMDE from 2.15.0 to 2.16.1

Changelog: https://github.com/Ionaru/easy-markdown-editor/blob/master/CHANGELOG.md

A DoS fix: Security issue in marked dependency. 


I tested EasyMDE 2.16.1 on my side (briefly), no breaking.