### PR TITLE
Add lockfile-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ lockfile-check:
 	@diff=$$(git diff package-lock.json); \
 	if [ -n "$$diff" ]; then \
 		echo "package-lock.json is inconsistent with package.json"; \
-		echo "Please run 'npm install' and commit the result:"; \
+		echo "Please run 'npm install --package-lock-only' and commit the result:"; \
 		echo "$${diff}"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ fmt-check:
 checks: checks-frontend checks-backend
 
 .PHONY: checks-frontend
-checks-frontend: svg-check
+checks-frontend: lockfile-check svg-check
 
 .PHONY: checks-backend
 checks-backend: swagger-check swagger-validate
@@ -696,6 +696,17 @@ svg-check: svg
 	@diff=$$(git diff --cached $(SVG_DEST_DIR)); \
 	if [ -n "$$diff" ]; then \
 		echo "Please run 'make svg' and 'git add $(SVG_DEST_DIR)' and commit the result:"; \
+		echo "$${diff}"; \
+		exit 1; \
+	fi
+
+.PHONY: lockfile-check
+lockfile-check:
+	npm install
+	@diff=$$(git diff package-lock.json); \
+	if [ -n "$$diff" ]; then \
+		echo "package-lock.json is inconsistent with package.json"; \
+		echo "Please run 'npm install' and commit the result:"; \
 		echo "$${diff}"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -702,7 +702,7 @@ svg-check: svg
 
 .PHONY: lockfile-check
 lockfile-check:
-	npm install
+	npm install --package-lock-only
 	@diff=$$(git diff package-lock.json); \
 	if [ -n "$$diff" ]; then \
 		echo "package-lock.json is inconsistent with package.json"; \

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gitea",
       "license": "MIT",
       "dependencies": {
         "@claviska/jquery-minicolors": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "gitea",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This check runs `npm install --package-lock-only` which will rewrite the lockfile in case it is inconsistent with package.json. This check detects this and will fail the CI in such a case.