### PR TITLE
Don't show double error response in git hook

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -92,7 +92,7 @@ func fail(userMessage, logMessage string, args ...interface{}) error {
 	if len(logMessage) > 0 {
 		_ = private.SSHLog(ctx, true, fmt.Sprintf(logMessage+": ", args...))
 	}
-	return cli.NewExitError(fmt.Sprintf("Gitea: %s", userMessage), 1)
+	return cli.NewExitError("", 1)
 }
 
 func runServ(c *cli.Context) error {


### PR DESCRIPTION
if return a error message to cli, it will print it
to stderr which is duplicate with our code (line 82
in same file). so user will see two line same
error message in git output. I think it's not mecessary,
so suggerst not return error message to cli. Thanks.

from:
![image](https://user-images.githubusercontent.com/25342410/149644868-85b024b7-c245-4af0-9a3e-e010a42ace2c.png)
----
to:
![image](https://user-images.githubusercontent.com/25342410/149644873-ceee2a91-9cc4-4eb6-8df9-84a62041e2c0.png)
