### PR TITLE
Minor tweak to tag list

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1978,8 +1978,12 @@
     }
 
     #tags-table {
+      .tag {
+        padding: 8px 12px;
+      }
+
       .release-tag-name {
-        font-size: 1.5rem;
+        font-size: 20px;
         font-weight: normal;
       }
     }


### PR DESCRIPTION
Slightly reduce the font size and padding in the tags table, it seemed a bit too big to me.

Before:
<img width="461" alt="Screen Shot 2022-01-16 at 13 13 04" src="https://user-images.githubusercontent.com/115237/149659530-89154448-0e1e-419a-90a8-87801b41fbbc.png">

After:
<img width="462" alt="Screen Shot 2022-01-16 at 13 14 54" src="https://user-images.githubusercontent.com/115237/149659535-23c46573-8703-4d67-8626-708c8dca8652.png">
