### PR TITLE
Add node_modules and minified files to .ignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,5 +1,8 @@
-/vendor
-/public/vendor/plugins
+*.min.css
+*.min.js
 /modules/options/bindata.go
 /modules/public/bindata.go
 /modules/templates/bindata.go
+/public/vendor/plugins
+/vendor
+node_modules


### PR DESCRIPTION
Exclude node_modules and minified files from search tools like `rg` and `ag`.

Benefit here is that even when one specifies `rg something web_src`, those files will still be excluded from search results.