### PR TITLE
Remove unneeded debug messages to stdout.

### DIFF
--- a/modules/markup/common/footnote.go
+++ b/modules/markup/common/footnote.go
@@ -10,7 +10,6 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strconv"
 	"unicode"
 
@@ -415,7 +414,6 @@ func (r *FootnoteHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegist
 func (r *FootnoteHTMLRenderer) renderFootnoteLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		n := node.(*FootnoteLink)
-		n.Dump(source, 0)
 		is := strconv.Itoa(n.Index)
 		_, _ = w.WriteString(`<sup id="fnref:`)
 		_, _ = w.Write(n.Name)
@@ -431,7 +429,6 @@ func (r *FootnoteHTMLRenderer) renderFootnoteLink(w util.BufWriter, source []byt
 func (r *FootnoteHTMLRenderer) renderFootnoteBackLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		n := node.(*FootnoteBackLink)
-		fmt.Fprintf(os.Stdout, "source:\n%s\n", string(n.Text(source)))
 		_, _ = w.WriteString(` <a href="#fnref:`)
 		_, _ = w.Write(n.Name)
 		_, _ = w.WriteString(`" class="footnote-backref" role="doc-backlink">`)
@@ -444,7 +441,6 @@ func (r *FootnoteHTMLRenderer) renderFootnoteBackLink(w util.BufWriter, source [
 func (r *FootnoteHTMLRenderer) renderFootnote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*Footnote)
 	if entering {
-		fmt.Fprintf(os.Stdout, "source:\n%s\n", string(n.Text(source)))
 		_, _ = w.WriteString(`<li id="fn:`)
 		_, _ = w.Write(n.Name)
 		_, _ = w.WriteString(`" role="doc-endnote"`)


### PR DESCRIPTION
Hi there,

I'm seeing messages like this in my syslog whenever someone (incl. bots) looks at some markdown file with a footnote:

```
Jan 15 15:29:07 *** gitea[2975]: GiteaFootnoteLink {
Jan 15 15:29:07 *** gitea[2975]:     Index: 1
Jan 15 15:29:07 *** gitea[2975]:     Name: [117 115 101 114 45 99 111 110 116 101 110 116 45 49]
Jan 15 15:29:07 *** gitea[2975]: }
Jan 15 15:29:07 *** gitea[2975]: source:
Jan 15 15:29:07 *** gitea[2975]: [...text of the footnote...]
Jan 15 15:29:07 *** gitea[2975]: source:
```

I'm assuming that this is just from some debug helpers left over from when the code was written and can be safely removed.