### PR TITLE
Backport: Upgrade EasyMDE 2.16.1 (package-lock.json)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@claviska/jquery-minicolors": "2.3.5",
         "@primer/octicons": "13.0.0",
         "add-asset-webpack-plugin": "2.0.1",
-        "codemirror": "5.61.0",
+        "codemirror": "5.65.0",
         "css-loader": "5.2.4",
         "dropzone": "5.9.2",
         "easymde": "2.16.1",
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "node_modules/codemirror-spell-checker": {
       "version": "1.1.2",
@@ -3599,11 +3599,6 @@
         "codemirror-spell-checker": "1.1.2",
         "marked": "^4.0.10"
       }
-    },
-    "node_modules/easymde/node_modules/codemirror": {
-      "version": "5.65.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
-      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -15951,9 +15946,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "codemirror-spell-checker": {
       "version": "1.1.2",
@@ -16719,13 +16714,6 @@
         "codemirror": "^5.63.1",
         "codemirror-spell-checker": "1.1.2",
         "marked": "^4.0.10"
-      },
-      "dependencies": {
-        "codemirror": {
-          "version": "5.65.0",
-          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
-          "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
-        }
       }
     },
     "ecc-jsbn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -15725,9 +15725,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "codemirror": "5.61.0",
         "css-loader": "5.2.4",
         "dropzone": "5.9.2",
-        "easymde": "2.15.0",
+        "easymde": "2.16.1",
         "esbuild-loader": "2.13.0",
         "escape-goat": "4.0.0",
         "fast-glob": "3.2.5",
@@ -1160,9 +1160,9 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "0.0.109",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
-      "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
       "dependencies": {
         "@types/tern": "*"
       }
@@ -1235,9 +1235,9 @@
       "dev": true
     },
     "node_modules/@types/marked": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.2.tgz",
-      "integrity": "sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag=="
     },
     "node_modules/@types/mdast": {
       "version": "3.0.3",
@@ -1284,9 +1284,9 @@
       "dev": true
     },
     "node_modules/@types/tern": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
       "dependencies": {
         "@types/estree": "*"
       }
@@ -3589,16 +3589,21 @@
       "integrity": "sha512-5t2z51DzIsWDbTpwcJIvUlwxBbvcwdCApz0yb9ecKJwG155Xm92KMEZmHW1B0MzoXOKvFwdd0nPu5cpeVcvPHQ=="
     },
     "node_modules/easymde": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.15.0.tgz",
-      "integrity": "sha512-9jMRIVvKt1d0UjRN45yotUYECAM4xvw0TTAQw8sYDONP++keWJVnd8Xrn+V+vQEN/v9/X0SWEoo1rFSgCooGpw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.16.1.tgz",
+      "integrity": "sha512-FihYgjRsKfhGNk89SHSqxKLC4aJ1kfybPWW6iAmtb5GnXu+tnFPSzSaGBmk1RRlCuhFSjhF0SnIMGVPjEzkr6g==",
       "dependencies": {
-        "@types/codemirror": "0.0.109",
-        "@types/marked": "^2.0.2",
-        "codemirror": "^5.61.0",
+        "@types/codemirror": "^5.60.4",
+        "@types/marked": "^4.0.1",
+        "codemirror": "^5.63.1",
         "codemirror-spell-checker": "1.1.2",
-        "marked": "^2.0.3"
+        "marked": "^4.0.10"
       }
+    },
+    "node_modules/easymde/node_modules/codemirror": {
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -7844,14 +7849,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -14732,9 +14737,9 @@
       }
     },
     "@types/codemirror": {
-      "version": "0.0.109",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
-      "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
       "requires": {
         "@types/tern": "*"
       }
@@ -14807,9 +14812,9 @@
       "dev": true
     },
     "@types/marked": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.2.tgz",
-      "integrity": "sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag=="
     },
     "@types/mdast": {
       "version": "3.0.3",
@@ -14856,9 +14861,9 @@
       "dev": true
     },
     "@types/tern": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
       "requires": {
         "@types/estree": "*"
       }
@@ -16705,15 +16710,22 @@
       "integrity": "sha512-5t2z51DzIsWDbTpwcJIvUlwxBbvcwdCApz0yb9ecKJwG155Xm92KMEZmHW1B0MzoXOKvFwdd0nPu5cpeVcvPHQ=="
     },
     "easymde": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.15.0.tgz",
-      "integrity": "sha512-9jMRIVvKt1d0UjRN45yotUYECAM4xvw0TTAQw8sYDONP++keWJVnd8Xrn+V+vQEN/v9/X0SWEoo1rFSgCooGpw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.16.1.tgz",
+      "integrity": "sha512-FihYgjRsKfhGNk89SHSqxKLC4aJ1kfybPWW6iAmtb5GnXu+tnFPSzSaGBmk1RRlCuhFSjhF0SnIMGVPjEzkr6g==",
       "requires": {
-        "@types/codemirror": "0.0.109",
-        "@types/marked": "^2.0.2",
-        "codemirror": "^5.61.0",
+        "@types/codemirror": "^5.60.4",
+        "@types/marked": "^4.0.1",
+        "codemirror": "^5.63.1",
         "codemirror-spell-checker": "1.1.2",
-        "marked": "^2.0.3"
+        "marked": "^4.0.10"
+      },
+      "dependencies": {
+        "codemirror": {
+          "version": "5.65.0",
+          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+          "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
+        }
       }
     },
     "ecc-jsbn": {
@@ -19976,9 +19988,9 @@
       }
     },
     "marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@claviska/jquery-minicolors": "2.3.5",
     "@primer/octicons": "13.0.0",
     "add-asset-webpack-plugin": "2.0.1",
-    "codemirror": "5.61.0",
+    "codemirror": "5.65.0",
     "css-loader": "5.2.4",
     "dropzone": "5.9.2",
     "easymde": "2.16.1",


### PR DESCRIPTION
This PR follows #18279 to add forgotten package-lock.json

npm suggests:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```

So the `caniuse-lite` is also updated.