### PR TITLE
Correctly upload LFS files

### DIFF
--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -353,6 +353,7 @@ func CreateOrUpdateRepoFile(repo *repo_model.Repository, doer *user_model.User, 
 		filename2attribute2info, err := t.gitRepo.CheckAttribute(git.CheckAttributeOpts{
 			Attributes: []string{"filter"},
 			Filenames:  []string{treePath},
+			CachedOnly: true,
 		})
 		if err != nil {
 			return nil, err

--- a/services/repository/files/upload.go
+++ b/services/repository/files/upload.go
@@ -97,6 +97,7 @@ func UploadRepoFiles(repo *repo_model.Repository, doer *user_model.User, opts *U
 		filename2attribute2info, err = t.gitRepo.CheckAttribute(git.CheckAttributeOpts{
 			Attributes: []string{"filter"},
 			Filenames:  names,
+			CachedOnly: true,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
We need to use the cached .gitattributes file for checking if a file
should be stored in the lfs.

Fix #18297

Signed-off-by: Andrew Thornton <art27@cantab.net>
