### PR TITLE
Place inline diff comment dialogs in the 4th column.

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -500,7 +500,7 @@ export function initRepoPullRequestReview() {
             <td class="lines-type-marker"></td>
             <td class="add-comment-right"></td>
           ` : `
-            <td colspan="2" class="lines-num"></td>
+            <td colspan="3" class="lines-num"></td>
             <td class="add-comment-left add-comment-right" colspan="2"></td>
           `}
         </tr>`);


### PR DESCRIPTION
Comment dialogs for inline comments should appear in 4th column (not 3rd column), this PR changes the column that the inline review comment is associated with.

This problem has occurred due to an unrecognised conflict between #17562 and #17315. 

Fix as @zeripath suggested in #18320

Fix #18320 