### PR TITLE
Restore propagation of ErrDependenciesLeft

### DIFF
--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -105,7 +105,10 @@ func Merge(pr *models.PullRequest, doer *user_model.User, baseGitRepo *git.Repos
 		close := ref.RefAction == references.XRefActionCloses
 		if close != ref.Issue.IsClosed {
 			if err = issue_service.ChangeStatus(ref.Issue, doer, close); err != nil {
-				return err
+				// Allow ErrDependenciesLeft
+				if !models.IsErrDependenciesLeft(err) {
+					return err
+				}
 			}
 		}
 	}

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -514,7 +514,7 @@ func CloseBranchPulls(doer *user_model.User, repoID int64, branch string) error 
 
 	var errs errlist
 	for _, pr := range prs {
-		if err = issue_service.ChangeStatus(pr.Issue, doer, true); err != nil && !models.IsErrPullWasClosed(err) {
+		if err = issue_service.ChangeStatus(pr.Issue, doer, true); err != nil && !models.IsErrPullWasClosed(err) && !models.IsErrDependenciesLeft(err) {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Unfortunately #17643 prevented all propagation of ErrDependenciesLeft meaning
that dependency errors that prevent closing of issues get swallowed.

This PR restores propagation of the error but instead swallows the error in the
places where it needs to be swallowed.

Fix #18223

Signed-off-by: Andrew Thornton <art27@cantab.net>

