### PR TITLE
Stop trimming preceding and suffixing spaces from editor filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Add left padding for chunk header of split diff view (#13397)
   * Allow U2F 2FA without TOTP (#11573)
 * BUGFIXES
+  * Stop trimming preceding and suffixing spaces from editor filenames (#18334)
   * Restore propagation of ErrDependenciesLeft (#18325)
   * Fix PR comments UI (#18323)
   * Use indirect comparison when showing pull requests (#18313)

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -728,7 +728,7 @@ func UploadFilePost(ctx *context.Context) {
 
 func cleanUploadFileName(name string) string {
 	// Rebase the filename
-	name = strings.Trim(path.Clean("/"+name), " /")
+	name = strings.Trim(path.Clean("/"+name), "/")
 	// Git disallows any filenames to have a .git directory in them.
 	for _, part := range strings.Split(name, "/") {
 		if strings.ToLower(part) == ".git" {

--- a/services/repository/files/file.go
+++ b/services/repository/files/file.go
@@ -129,7 +129,7 @@ func GetAuthorAndCommitterUsers(author, committer *IdentityOptions, doer *user_m
 // CleanUploadFileName Trims a filename and returns empty string if it is a .git directory
 func CleanUploadFileName(name string) string {
 	// Rebase the filename
-	name = strings.Trim(path.Clean("/"+name), " /")
+	name = strings.Trim(path.Clean("/"+name), "/")
 	// Git disallows any filenames to have a .git directory in them.
 	for _, part := range strings.Split(name, "/") {
 		if strings.ToLower(part) == ".git" {


### PR DESCRIPTION
In #5702 it was decided to trim preceding and suffixed spaces aswell as / from
editing file filenames. This was because at this point in time the url-safety of
gitea was much poorer.

We can now drop this requirement and file editing should work correctly.

Fix #18176

Signed-off-by: Andrew Thornton <art27@cantab.net>
