### PR TITLE
Use separate asset path for different build

### DIFF
--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -23,8 +23,8 @@ type Options struct {
 	CorsHandler func(http.Handler) http.Handler
 }
 
-// AssetsURLPathPrefix is the path prefix for static asset files
-const AssetsURLPathPrefix = "/assets/"
+// WebPublicDirName is the directory name for public(static) asset files. It may be set to the build time by `static.go`
+var WebPublicDirName = "public-dynamic"
 
 // AssetsHandlerFunc implements the static handler for serving custom or original assets.
 func AssetsHandlerFunc(opts *Options) http.HandlerFunc {

--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -24,7 +24,8 @@ type Options struct {
 }
 
 // WebPublicDirName is the directory name for public(static) asset files. It may be set to the build time by `static.go`
-var WebPublicDirName = "public-dynamic"
+// the char `~` is not valid for user/repo names, so we do not need to reserve the names anymore.
+var WebPublicDirName = "public~dynamic"
 
 // AssetsHandlerFunc implements the static handler for serving custom or original assets.
 func AssetsHandlerFunc(opts *Options) http.HandlerFunc {

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -10,6 +10,7 @@ package public
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -18,12 +19,13 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/log"
-	"code.gitea.io/gitea/modules/timeutil"
 )
+
+var assetModTime time.Time
 
 // GlobalModTime provide a global mod time for embedded asset files
 func GlobalModTime(filename string) time.Time {
-	return timeutil.GetExecutableModTime()
+	return assetModTime
 }
 
 func fileSystem(dir string) http.FileSystem {
@@ -90,4 +92,9 @@ func serveContent(w http.ResponseWriter, req *http.Request, fi os.FileInfo, modt
 
 	http.ServeContent(w, req, fi.Name(), modtime, content)
 	return
+}
+
+func init() {
+	assetModTime = timeutil.GetExecutableModTime()
+	WebPublicDirName = fmt.Sprintf("public-%x", assetModTime.UnixMilli())
 }

--- a/modules/public/static.go
+++ b/modules/public/static.go
@@ -96,5 +96,5 @@ func serveContent(w http.ResponseWriter, req *http.Request, fi os.FileInfo, modt
 
 func init() {
 	assetModTime = timeutil.GetExecutableModTime()
-	WebPublicDirName = fmt.Sprintf("public-%x", assetModTime.UnixMilli())
+	WebPublicDirName = fmt.Sprintf("public~%x", assetModTime.UnixMilli())
 }

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -33,6 +33,7 @@ import (
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
+	"code.gitea.io/gitea/modules/public"
 	"code.gitea.io/gitea/modules/repository"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/svg"
@@ -62,7 +63,7 @@ func NewFuncMap() []template.FuncMap {
 			return setting.AppSubURL
 		},
 		"AssetUrlPrefix": func() string {
-			return setting.StaticURLPrefix + "/assets"
+			return setting.StaticURLPrefix + "/" + public.WebPublicDirName
 		},
 		"AppUrl": func() string {
 			return setting.AppURL
@@ -146,7 +147,6 @@ func NewFuncMap() []template.FuncMap {
 		"DiffLineTypeToStr":              DiffLineTypeToStr,
 		"Sha1":                           Sha1,
 		"ShortSha":                       base.ShortSha,
-		"MD5":                            base.EncodeMD5,
 		"ActionContent2Commits":          ActionContent2Commits,
 		"PathEscape":                     url.PathEscape,
 		"PathEscapeSegments":             util.PathEscapeSegments,

--- a/routers/install/routes.go
+++ b/routers/install/routes.go
@@ -85,9 +85,9 @@ func Routes() *web.Route {
 		r.Use(middle)
 	}
 
-	r.Use(web.WrapWithPrefix(public.AssetsURLPathPrefix, public.AssetsHandlerFunc(&public.Options{
+	r.Use(web.WrapWithPrefix("/"+public.WebPublicDirName, public.AssetsHandlerFunc(&public.Options{
 		Directory: path.Join(setting.StaticRootPath, "public"),
-		Prefix:    public.AssetsURLPathPrefix,
+		Prefix:    "/" + public.WebPublicDirName,
 	}), "InstallAssetsHandler"))
 
 	r.Use(session.Sessioner(session.Options{

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -74,9 +74,9 @@ func CorsHandler() func(next http.Handler) http.Handler {
 func Routes(sessioner func(http.Handler) http.Handler) *web.Route {
 	routes := web.NewRoute()
 
-	routes.Use(web.WrapWithPrefix(public.AssetsURLPathPrefix, public.AssetsHandlerFunc(&public.Options{
+	routes.Use(web.WrapWithPrefix("/"+public.WebPublicDirName, public.AssetsHandlerFunc(&public.Options{
 		Directory:   path.Join(setting.StaticRootPath, "public"),
-		Prefix:      public.AssetsURLPathPrefix,
+		Prefix:      "/" + public.WebPublicDirName,
 		CorsHandler: CorsHandler(),
 	}), "AssetsHandler"))
 

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -22,7 +22,7 @@
 		<script src='https://hcaptcha.com/1/api.js' async></script>
 	{{end}}
 {{end}}
-	<script src="{{AssetUrlPrefix}}/js/index.js?v={{MD5 AppVer}}"></script>
+	<script src="{{AssetUrlPrefix}}/js/index.js"></script>
 {{template "custom/footer" .}}
 </body>
 </html>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -59,7 +59,7 @@
 	</script>
 	<link rel="icon" href="{{AssetUrlPrefix}}/img/logo.svg" type="image/svg+xml">
 	<link rel="alternate icon" href="{{AssetUrlPrefix}}/img/favicon.png" type="image/png">
-	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/index.css?v={{MD5 AppVer}}">
+	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/index.css">
 	<noscript>
 		<style>
 			.dropdown:hover > .menu { display: block; }
@@ -104,10 +104,10 @@
 <meta property="og:site_name" content="{{AppName}}" />
 {{if .IsSigned }}
 	{{ if ne .SignedUser.Theme "gitea" }}
-		<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{.SignedUser.Theme | PathEscape}}.css?v={{MD5 AppVer}}">
+		<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{.SignedUser.Theme | PathEscape}}.css">
 	{{end}}
 {{else if ne DefaultTheme "gitea"}}
-	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{DefaultTheme | PathEscape}}.css?v={{MD5 AppVer}}">
+	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{DefaultTheme | PathEscape}}.css">
 {{end}}
 {{template "custom/header" .}}
 </head>

--- a/templates/swagger/ui.tmpl
+++ b/templates/swagger/ui.tmpl
@@ -3,11 +3,11 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>Gitea API</title>
-		<link href="{{AssetUrlPrefix}}/css/swagger.css?v={{MD5 AppVer}}" rel="stylesheet">
+		<link href="{{AssetUrlPrefix}}/css/swagger.css" rel="stylesheet">
 	</head>
 	<body>
 		<a class="swagger-back-link" href="{{AppUrl}}">{{svg "octicon-reply"}}{{.i18n.Tr "return_to_gitea"}}</a>
 		<div id="swagger-ui" data-source="{{AppUrl}}swagger.{{.APIJSONVersion}}.json"></div>
-		<script src="{{AssetUrlPrefix}}/js/swagger.js?v={{MD5 AppVer}}"></script>
+		<script src="{{AssetUrlPrefix}}/js/swagger.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
# Background

Gitea used to use `/assets/js/index.js?v={{MD5 AppVer}}` to access static files. This mechanism has some problems:

1. not CDN friendly, some CDN would ignore the `?v=...` query string.
2. some files are not rendered by templates and can not get the versioned URL, ex: `/assets/vendor/plugins/codemirror/addon/mode/loadmode.js` and others.

# Plan 

This PR introduces a dynamic path for web URL:
* with dynamic asset files (in development), the path prefix is: `/public~dynamic`: `/public~dynamic/js/index.js`
* with static asset files, the path prefix is: `/public~17e7b119ec1` (versioned with timestamp): `/public~17e7b119ec1/js/index.js`

It's possible to help #18347 and other problems.

There are still more work to do (there are many hard-coded `/assets` strings in code). If this PR is fine, I can continue to work on it.

## More details:

### Why not using `index-{ver}.js` or `index.{ver}.js`?

There are a lot of legacy files (for example, `/plugins/codemirror/addon/mode/loadmode.js`, they are not controlled by webpack). Using hash in filenames could be done in future, but not now.

### Why not using the `/assets` path?

The `assets` is not a good name indeed. Why the `GITEA_CUSTOM/public` was still called `public` but used as `/assets`? We should either call all of them `assets` (rename public) OR `public` (as comment above with `~`) OR `/assets/public-{ver}`. I do not like keeping getting new names for one concept.

### What about reserved path name?

We can use `~` which is not a valid user/repo name, then we do not need restrict any names anymore. 

### What about existing custom templates?

We provide template variable and JS variable, `AssetUrlPrefix`. It's totally transparent to all users. 

If the writer of the custom templates used hard-coded `/assets/`, then they should update. I believe such usage is not recommended, they should use `{{AssetUrlPrefix}}`

## Possible solutions

Please vote:

* Use `/public~{ver}/` for `GITEA_CUSTOM/public`
* Use `/assets~{ver}/` and rename `GITEA_CUSTOM/public` to `GITEA_CUSTOM/assets`
* Use `/assets/public-{ver}/` for `GITEA_CUSTOM/public`