### PR TITLE
improve performance of SyncReleasesWithTags

### DIFF
--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -247,7 +247,7 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 	existingRelTags := make(map[string]struct{})
 	opts := models.FindReleasesOptions{
 		IncludeDrafts: true,
-		IncludeTags:   true,
+		IncludeTags:   false,
 		ListOptions:   db.ListOptions{PageSize: 50},
 	}
 	for page := 1; ; page++ {
@@ -276,6 +276,12 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 			}
 		}
 	}
+	// short-circuit to avoid costly tag lookups when there are no releases
+	// to be synced.
+	if len(existingRelTags) == 0 {
+		return nil
+	}
+
 	tags, err := gitRepo.GetTags(0, 0)
 	if err != nil {
 		return fmt.Errorf("GetTags: %v", err)


### PR DESCRIPTION
This PR addresses https://github.com/go-gitea/gitea/issues/18352

A mirror-sync operation not only runs `git remote update`, but also tries to
sync any repo releases with the available repo tags. For large repositories with
many tags, this can be a costly operation, both in time and computational resources.

This commit aims to improve correctness and optimize performance of the `SyncReleasesWithTags` operation, in particular for plain git mirrors (which never have any releases). There are two parts to the commit:

- first, when looking up releases, we should ignore plain tags in
  `FindReleaseOptions`.

- second, if we don't find any releases, we don't need to query all tags of the
  repo (as there is nothing to be synced).

For large mirror repos, with hundreds of tags, this can bring down the duration
of the sync operation from minutes to seconds.


