### PR TITLE
Disable content sniffing on `PlainTextBytes`

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -292,6 +292,7 @@ func (ctx *Context) PlainTextBytes(status int, bs []byte) {
 	}
 	ctx.Resp.WriteHeader(status)
 	ctx.Resp.Header().Set("Content-Type", "text/plain;charset=utf-8")
+	ctx.Resp.Header().Set("X-Content-Type-Options", "nosniff")
 	if _, err := ctx.Resp.Write(bs); err != nil {
 		log.Error("Write bytes failed: %v", err)
 	}


### PR DESCRIPTION
- Disable the browser's function to "sniff" for the content-type on the provided plain text, this will prevent the attacks when there will be a usage of user-controlled data being sent, which could be malicious.
