### PR TITLE
Fix route wrap

### DIFF
--- a/modules/web/wrap_convert.go
+++ b/modules/web/wrap_convert.go
@@ -93,6 +93,9 @@ func convertHandler(handler interface{}) wrappedHandlerFunc {
 			}
 			routing.UpdateFuncInfo(req.Context(), funcInfo)
 			t(next).ServeHTTP(resp, req)
+			if r, ok := resp.(context.ResponseWriter); ok && r.Status() > 0 {
+				done = true
+			}
 			return
 		}
 	default:


### PR DESCRIPTION
Because we introduced the new code:

* https://github.com/wxiaoguang/gitea/pull/3

We must make sure every `converted handler` can return `done=true` correctly.

Otherwise, there will be duplicated calls to `others` again and again. Known problems caused by this bug:
* visit `/api/swagger` triggers panic
* many APIs return duplicated response


```
func wrapInternal(handlers []wrappedHandlerFunc) http.HandlerFunc {
	return func(resp http.ResponseWriter, req *http.Request) {
		var defers []func()
		defer func() {
			for i := len(defers) - 1; i >= 0; i-- {
				defers[i]()
			}
		}()
		for i := 0; i < len(handlers); i++ {
			handler := handlers[i]
			others := handlers[i+1:]
			done, deferrable := handler(resp, req, others...)
			if deferrable != nil {
				defers = append(defers, deferrable)
			}
			if done {
				return
			}
		}
	}
}
```