### PR TITLE
Refactor webhooks i18n

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1936,18 +1936,23 @@ settings.update_hook_success = The webhook has been updated.
 settings.delete_webhook = Remove Webhook
 settings.recent_deliveries = Recent Deliveries
 settings.hook_type = Hook Type
-settings.add_slack_hook_desc = Integrate <a href="%s">Slack</a> into your repository.
 settings.slack_token = Token
 settings.slack_domain = Domain
 settings.slack_channel = Channel
-settings.add_discord_hook_desc = Integrate <a href="%s">Discord</a> into your repository.
-settings.add_dingtalk_hook_desc = Integrate <a href="%s">Dingtalk</a> into your repository.
-settings.add_telegram_hook_desc = Integrate <a href="%s">Telegram</a> into your repository.
-settings.add_matrix_hook_desc = Integrate <a href="%s">Matrix</a> into your repository.
-settings.add_msteams_hook_desc = Integrate <a href="%s">Microsoft Teams</a> into your repository.
-settings.add_feishu_hook_desc = Integrate <a href="%s">Feishu</a> into your repository.
-settings.add_Wechat_hook_desc = Integrate <a href="%s">Wechatwork</a> into your repository.
-settings.add_packagist_hook_desc = Integrate <a href="%s">Packagist</a> into your repository.
+settings.add_web_hook_desc = Integrate <a target="_blank" rel="noreferrer" href="%s">%s</a> into your repository.
+settings.web_hook_name_gitea = Gitea
+settings.web_hook_name_gogs = Gogs
+settings.web_hook_name_slack = Slack
+settings.web_hook_name_discord = Discord
+settings.web_hook_name_dingtalk = DingTalk
+settings.web_hook_name_telegram = Telegram
+settings.web_hook_name_matrix = Matrix
+settings.web_hook_name_msteams = Microsoft Teams
+settings.web_hook_name_feishu_or_larksuite = Feishu / Lark Suite
+settings.web_hook_name_feishu = Feishu
+settings.web_hook_name_larksuite = Lark Suite
+settings.web_hook_name_wechatwork = WeCom (Wechat Work)
+settings.web_hook_name_packagist = Packagist
 settings.packagist_username = Packagist username
 settings.packagist_api_token = API token
 settings.packagist_package_url = Packagist package URL

--- a/templates/repo/settings/webhook/base_list.tmpl
+++ b/templates/repo/settings/webhook/base_list.tmpl
@@ -5,37 +5,37 @@
 			<div class="ui blue tiny button">{{.i18n.Tr "repo.settings.add_webhook"}}</div>
 			<div class="menu">
 				<a class="item" href="{{.BaseLinkNew}}/gitea/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gitea.svg">Gitea
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gitea.svg">{{.i18n.Tr "repo.settings.web_hook_name_gitea"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/gogs/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gogs.ico">Gogs
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gogs.ico">{{.i18n.Tr "repo.settings.web_hook_name_gogs"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/slack/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/slack.png">Slack
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/slack.png">{{.i18n.Tr "repo.settings.web_hook_name_slack"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/discord/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/discord.png">Discord
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/discord.png">{{.i18n.Tr "repo.settings.web_hook_name_discord"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/dingtalk/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/dingtalk.ico">Dingtalk
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/dingtalk.ico">{{.i18n.Tr "repo.settings.web_hook_name_dingtalk"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/telegram/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/telegram.png">Telegram
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/telegram.png">{{.i18n.Tr "repo.settings.web_hook_name_telegram"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/msteams/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/msteams.png">Microsoft Teams
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/msteams.png">{{.i18n.Tr "repo.settings.web_hook_name_msteams"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/feishu/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/feishu.png">Feishu
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/feishu.png">{{.i18n.Tr "repo.settings.web_hook_name_feishu_or_larksuite"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/matrix/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/matrix.svg">Matrix
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/matrix.svg">{{.i18n.Tr "repo.settings.web_hook_name_matrix"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/wechatwork/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/wechatwork.png">Wechatwork
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/wechatwork.png">{{.i18n.Tr "repo.settings.web_hook_name_wechatwork"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/packagist/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/packagist.png">Packagist
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/packagist.png">{{.i18n.Tr "repo.settings.web_hook_name_packagist"}}
 				</a>
 			</div>
 		</div>

--- a/templates/repo/settings/webhook/dingtalk.tmpl
+++ b/templates/repo/settings/webhook/dingtalk.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "dingtalk"}}
-	<p>{{.i18n.Tr "repo.settings.add_dingtalk_hook_desc" "https://dingtalk.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://dingtalk.com" (.i18n.Tr "repo.settings.web_hook_name_dingtalk") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/dingtalk/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">

--- a/templates/repo/settings/webhook/discord.tmpl
+++ b/templates/repo/settings/webhook/discord.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "discord"}}
-	<p>{{.i18n.Tr "repo.settings.add_discord_hook_desc" "https://discord.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://discord.com" (.i18n.Tr "repo.settings.web_hook_name_discord") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/discord/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">

--- a/templates/repo/settings/webhook/feishu.tmpl
+++ b/templates/repo/settings/webhook/feishu.tmpl
@@ -1,5 +1,6 @@
 {{if eq .HookType "feishu"}}
-	<p>{{.i18n.Tr "repo.settings.add_feishu_hook_desc" "https://feishu.cn" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://feishu.cn" (.i18n.Tr "repo.settings.web_hook_name_feishu") | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://larksuite.com" (.i18n.Tr "repo.settings.web_hook_name_larksuite") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/feishu/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">

--- a/templates/repo/settings/webhook/gitea.tmpl
+++ b/templates/repo/settings/webhook/gitea.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "gitea"}}
-	<p>{{.i18n.Tr "repo.settings.add_webhook_desc" "https://docs.gitea.io/en-us/webhooks/" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.i18n.Tr "repo.settings.web_hook_name_gitea") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/gitea/{{or .Webhook.ID "new"}}" method="post">
 		{{template "base/disable_form_autofill"}}
 		{{.CsrfTokenHtml}}

--- a/templates/repo/settings/webhook/gogs.tmpl
+++ b/templates/repo/settings/webhook/gogs.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "gogs"}}
-	<p>{{.i18n.Tr "repo.settings.add_webhook_desc" "https://docs.gitea.io/en-us/webhooks/" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.i18n.Tr "repo.settings.web_hook_name_gogs") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/gogs/{{or .Webhook.ID "new"}}" method="post">
 		{{template "base/disable_form_autofill"}}
 		{{.CsrfTokenHtml}}

--- a/templates/repo/settings/webhook/matrix.tmpl
+++ b/templates/repo/settings/webhook/matrix.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "matrix"}}
-	<p>{{.i18n.Tr "repo.settings.add_matrix_hook_desc" "https://matrix.org/" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://matrix.org/" (.i18n.Tr "repo.settings.web_hook_name_matrix") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/matrix/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_HomeserverURL}}error{{end}}">

--- a/templates/repo/settings/webhook/msteams.tmpl
+++ b/templates/repo/settings/webhook/msteams.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "msteams"}}
-	<p>{{.i18n.Tr "repo.settings.add_msteams_hook_desc" "https://teams.microsoft.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://teams.microsoft.com" (.i18n.Tr "repo.settings.web_hook_name_msteams") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/msteams/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">

--- a/templates/repo/settings/webhook/packagist.tmpl
+++ b/templates/repo/settings/webhook/packagist.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "packagist"}}
-	<p>{{.i18n.Tr "repo.settings.add_packagist_hook_desc" "https://packagist.org" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://packagist.org" (.i18n.Tr "repo.settings.web_hook_name_packagist") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/packagist/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_Username}}error{{end}}">

--- a/templates/repo/settings/webhook/slack.tmpl
+++ b/templates/repo/settings/webhook/slack.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "slack"}}
-	<p>{{.i18n.Tr "repo.settings.add_slack_hook_desc" "http://slack.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://slack.com" (.i18n.Tr "repo.settings.web_hook_name_slack") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/slack/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">

--- a/templates/repo/settings/webhook/telegram.tmpl
+++ b/templates/repo/settings/webhook/telegram.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "telegram"}}
-	<p>{{.i18n.Tr "repo.settings.add_telegram_hook_desc" "https://core.telegram.org/bots" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://core.telegram.org/bots" (.i18n.Tr "repo.settings.web_hook_name_telegram") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/telegram/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_BotToken}}error{{end}}">

--- a/templates/repo/settings/webhook/wechatwork.tmpl
+++ b/templates/repo/settings/webhook/wechatwork.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "wechatwork"}}
-	<p>{{.i18n.Tr "repo.settings.add_Wechat_hook_desc" "https://work.weixin.qq.com" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://work.weixin.qq.com" (.i18n.Tr "repo.settings.web_hook_name_wechatwork") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/wechatwork/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">


### PR DESCRIPTION
This PR fixes the following problems:

1. Use generalized i18n message for webhooks
2. Use `<a target="_blank" rel="noreferrer">` instead of `<a>`
3. Use correct webhook names for Wechat Work / DingTalk
4. Fix insecure slack URL: `http`=> `https`


![image](https://user-images.githubusercontent.com/2114189/150718721-80cdc0a0-e901-4ee6-a4e2-7c67445fd91f.png)
