### PR TITLE
Prevent showing webauthn error for every time visiting `/user/settings/security`

### DIFF
--- a/web_src/js/features/user-auth-webauthn.js
+++ b/web_src/js/features/user-auth-webauthn.js
@@ -150,13 +150,12 @@ export function initUserAuthWebAuthnRegister() {
     return;
   }
 
-  if (!detectWebAuthnSupport()) {
-    return;
-  }
-
   $('#webauthn-error').modal({allowMultiple: false});
   $('#register-webauthn').on('click', (e) => {
     e.preventDefault();
+    if (!detectWebAuthnSupport()) {
+      return;
+    }
     webAuthnRegisterRequest();
   });
 }


### PR DESCRIPTION
It's quite annoying that the webauthn error is popped up every time when visiting `/user/settings/security`.

After this fix, the error is only shown after the user clicks the register (add security key) button.

![image](https://user-images.githubusercontent.com/2114189/150767024-0c8c8ff6-077a-44da-986e-80bfba122e44.png)

