### PR TITLE
Fix 500 error when creating blank repo with non-master default branch

### DIFF
--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -82,7 +82,8 @@ func (repo *Repository) IsEmpty() (bool, error) {
 	var errbuf strings.Builder
 	if err := NewCommandContext(repo.Ctx, "log", "-1").RunInDirPipeline(repo.Path, nil, &errbuf); err != nil {
 		if strings.Contains(errbuf.String(), "fatal: bad default revision 'HEAD'") ||
-			strings.Contains(errbuf.String(), "fatal: your current branch 'master' does not have any commits yet") {
+			(strings.Contains(errbuf.String(), "fatal: your current branch '") &&
+				strings.Contains(errbuf.String(), "' does not have any commits yet")) {
 			return true, nil
 		}
 		return true, fmt.Errorf("check empty: %v - %s", err, errbuf.String())

--- a/modules/git/tests/repos/repo2_empty/HEAD
+++ b/modules/git/tests/repos/repo2_empty/HEAD
@@ -1,1 +1,1 @@
-ref: refs/heads/master
+ref: refs/heads/unicorn


### PR DESCRIPTION
Fixes #18413 and updates associated test

Respectfully, PR #18422 does not work as submitted, as GetDefaultBranch returns the full ref string which would have to be trimmed down to get just the branch name.  Why perform another git command call and several string manipulations, for a value that's ultimately not used in any meaningful way?