### PR TITLE
Use next gen codecov uploader

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -305,7 +305,7 @@ steps:
 
   - name: coverage-codecov
     pull: always
-    image: plugins/codecov
+    image: woodpeckerci/plugin-codecov:next-alpine
     settings:
       files:
         - coverage.all


### PR DESCRIPTION
current plugin do use https://github.com/codecov/codecov-bash witch will stop working on **On February 1, 2022**