### PR TITLE
GitLab reviews may not have the updated_at field set

### DIFF
--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -641,10 +641,10 @@ func (g *GitlabDownloader) GetReviews(context base.IssueContext) ([]*base.Review
 	}
 
 	var createdAt time.Time
-	if approvals.UpdatedAt != nil {
-		createdAt = *approvals.UpdatedAt
-	} else if approvals.CreatedAt != nil {
+	if approvals.CreatedAt != nil {
 		createdAt = *approvals.CreatedAt
+	} else if approvals.UpdatedAt != nil {
+		createdAt = *approvals.UpdatedAt
 	} else {
 		createdAt = time.Now()
 	}

--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -640,13 +640,22 @@ func (g *GitlabDownloader) GetReviews(context base.IssueContext) ([]*base.Review
 		return nil, err
 	}
 
+	var createdAt time.Time
+	if approvals.UpdatedAt != nil {
+		createdAt = *approvals.UpdatedAt
+	} else if approvals.CreatedAt != nil {
+		createdAt = *approvals.CreatedAt
+	} else {
+		createdAt = time.Now()
+	}
+
 	reviews := make([]*base.Review, 0, len(approvals.ApprovedBy))
 	for _, user := range approvals.ApprovedBy {
 		reviews = append(reviews, &base.Review{
 			IssueIndex:   context.LocalID(),
 			ReviewerID:   int64(user.User.ID),
 			ReviewerName: user.User.Username,
-			CreatedAt:    *approvals.UpdatedAt,
+			CreatedAt:    createdAt,
 			// All we get are approvals
 			State: base.ReviewStateApproved,
 		})

--- a/services/migrations/main_test.go
+++ b/services/migrations/main_test.go
@@ -6,8 +6,6 @@
 package migrations
 
 import (
-	"fmt"
-	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -28,11 +26,6 @@ func timePtr(t time.Time) *time.Time {
 
 func assertTimeEqual(t *testing.T, expected, actual time.Time) {
 	assert.Equal(t, expected.UTC(), actual.UTC())
-}
-
-func assertTimeEqualEpsilon(t *testing.T, expected, actual time.Time) {
-	d := expected.UTC().Sub(actual.UTC()).Seconds()
-	assert.True(t, math.Abs(d) < 1, fmt.Sprintf("%v - %v >= 1", expected, actual))
 }
 
 func assertTimePtrEqual(t *testing.T, expected, actual *time.Time) {
@@ -237,7 +230,7 @@ func assertReviewEqual(t *testing.T, expected, actual *base.Review) {
 	assert.Equal(t, expected.Official, actual.Official, "Official")
 	assert.Equal(t, expected.CommitID, actual.CommitID, "CommitID")
 	assert.Equal(t, expected.Content, actual.Content, "Content")
-	assertTimeEqualEpsilon(t, expected.CreatedAt, actual.CreatedAt)
+	assert.WithinDuration(t, expected.CreatedAt, actual.CreatedAt, 10*time.Second)
 	assert.Equal(t, expected.State, actual.State, "State")
 	assertReviewCommentsEqual(t, expected.Comments, actual.Comments)
 }

--- a/services/migrations/main_test.go
+++ b/services/migrations/main_test.go
@@ -6,6 +6,8 @@
 package migrations
 
 import (
+	"fmt"
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -26,6 +28,11 @@ func timePtr(t time.Time) *time.Time {
 
 func assertTimeEqual(t *testing.T, expected, actual time.Time) {
 	assert.Equal(t, expected.UTC(), actual.UTC())
+}
+
+func assertTimeEqualEpsilon(t *testing.T, expected, actual time.Time) {
+	d := expected.UTC().Sub(actual.UTC()).Seconds()
+	assert.True(t, math.Abs(d) < 1, fmt.Sprintf("%v - %v >= 1", expected, actual))
 }
 
 func assertTimePtrEqual(t *testing.T, expected, actual *time.Time) {
@@ -223,15 +230,15 @@ func assertRepositoryEqual(t *testing.T, expected, actual *base.Repository) {
 }
 
 func assertReviewEqual(t *testing.T, expected, actual *base.Review) {
-	assert.Equal(t, expected.ID, actual.ID)
-	assert.Equal(t, expected.IssueIndex, actual.IssueIndex)
-	assert.Equal(t, expected.ReviewerID, actual.ReviewerID)
-	assert.Equal(t, expected.ReviewerName, actual.ReviewerName)
-	assert.Equal(t, expected.Official, actual.Official)
-	assert.Equal(t, expected.CommitID, actual.CommitID)
-	assert.Equal(t, expected.Content, actual.Content)
-	assertTimeEqual(t, expected.CreatedAt, actual.CreatedAt)
-	assert.Equal(t, expected.State, actual.State)
+	assert.Equal(t, expected.ID, actual.ID, "ID")
+	assert.Equal(t, expected.IssueIndex, actual.IssueIndex, "IsssueIndex")
+	assert.Equal(t, expected.ReviewerID, actual.ReviewerID, "ReviewerID")
+	assert.Equal(t, expected.ReviewerName, actual.ReviewerName, "ReviewerName")
+	assert.Equal(t, expected.Official, actual.Official, "Official")
+	assert.Equal(t, expected.CommitID, actual.CommitID, "CommitID")
+	assert.Equal(t, expected.Content, actual.Content, "Content")
+	assertTimeEqualEpsilon(t, expected.CreatedAt, actual.CreatedAt)
+	assert.Equal(t, expected.State, actual.State, "State")
 	assertReviewCommentsEqual(t, expected.Comments, actual.Comments)
 }
 


### PR DESCRIPTION
> On behalf of [Loïc Dachary](https://lab.forgefriends.org/dachary)

Fallback to created_at if that the case and to time.Now() if it is
also missing.

Fixes: #18434

---
[source](https://lab.forgefriends.org/forgefriends/forgefriends/-/merge_requests/37)