### PR TITLE
Attempt to prevent intermittent failure TestGit/xxx/BranchProtectMerge/MergePR

### DIFF
--- a/integrations/api_helper_for_declarative_test.go
+++ b/integrations/api_helper_for_declarative_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -262,14 +263,18 @@ func doAPIMergePullRequest(ctx APITestContext, owner, repo string, index int64) 
 	return func(t *testing.T) {
 		urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/merge?token=%s",
 			owner, repo, index, ctx.Token)
-		req := NewRequestWithJSON(t, http.MethodPost, urlStr, &forms.MergePullRequestForm{
-			MergeMessageField: "doAPIMergePullRequest Merge",
-			Do:                string(repo_model.MergeStyleMerge),
-		})
 
-		resp := ctx.Session.MakeRequest(t, req, NoExpectedStatus)
+		var req *http.Request
+		var resp *httptest.ResponseRecorder
 
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 6; i++ {
+			req = NewRequestWithJSON(t, http.MethodPost, urlStr, &forms.MergePullRequestForm{
+				MergeMessageField: "doAPIMergePullRequest Merge",
+				Do:                string(repo_model.MergeStyleMerge),
+			})
+
+			resp = ctx.Session.MakeRequest(t, req, NoExpectedStatus)
+
 			if resp.Code != http.StatusMethodNotAllowed {
 				break
 			}
@@ -278,11 +283,6 @@ func doAPIMergePullRequest(ctx APITestContext, owner, repo string, index int64) 
 			assert.EqualValues(t, "Please try again later", err.Message)
 			queue.GetManager().FlushAll(context.Background(), 5*time.Second)
 			<-time.After(1 * time.Second)
-			req = NewRequestWithJSON(t, http.MethodPost, urlStr, &forms.MergePullRequestForm{
-				MergeMessageField: "doAPIMergePullRequest Merge",
-				Do:                string(repo_model.MergeStyleMerge),
-			})
-			resp = ctx.Session.MakeRequest(t, req, NoExpectedStatus)
 		}
 
 		expected := ctx.ExpectedCode


### PR DESCRIPTION
One of the repeated intermittent failures we see in testing is a failure due to
branches not being ready to merge.

Prior to the immediate queue implementation we would attempt to flush all the queues
and this would prevent the issue. However, the immediate queue is not flushable so
the flushall is not successful at preventing this.

This PR proposes an alternative solution - wait some time and try again up to 5 times.

If this fails then there is a genuine issue and we should fail.

Related #17719

Signed-off-by: Andrew Thornton <art27@cantab.net>
