### PR TITLE
Account autocreation from LDAP after reverse proxy authentication

### DIFF
--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -65,11 +65,7 @@ func (r *ReverseProxy) Verify(req *http.Request, w http.ResponseWriter, store Da
 		return nil
 	}
 
-	// Just return user if session is estabilshed already.
-	user := SessionUser(sess)
-	if user != nil {
-		return user
-	}
+	var user *user_model.User = nil
 
 	username := r.getUserName(req)
 	if len(username) == 0 {


### PR DESCRIPTION
Gitea allows autocreation of account from external source after successful
basic auth but not after successful reverse proxy auth. This mod adds such
feature.

It also adds full name, email and is_active synchronization from LDAP on
user login (as cron task already does).

Related: https://github.com/gogs/gogs/issues/2498
Author-Change-Id: IB#1104925
