### PR TITLE
Add numerical app version metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,7 +40,15 @@ var (
 )
 
 func init() {
+	shortVer := strings.Split(Version, "+")[0]
+	shortVer = strings.Replace(shortVer, ".", "", -1)
+	numVer, err := strconv.Atoi(shortVer)
+	if err != nil {
+		numVer = -1
+	}
+
 	setting.AppVer = Version
+	setting.NumAppVer = numVer
 	setting.AppBuiltWith = formatBuiltWith()
 	setting.AppStartTime = time.Now().UTC()
 

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var (
 
 func init() {
 	shortVer := strings.Split(Version, "+")[0]
-	shortVer = strings.Replace(shortVer, ".", "", -1)
+	shortVer = strings.ReplaceAll(shortVer, ".", "")
 	numVer, err := strconv.Atoi(shortVer)
 	if err != nil {
 		numVer = -1

--- a/modules/metrics/collector.go
+++ b/modules/metrics/collector.go
@@ -6,6 +6,7 @@ package metrics
 
 import (
 	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -41,6 +42,7 @@ type Collector struct {
 	Teams              *prometheus.Desc
 	UpdateTasks        *prometheus.Desc
 	Users              *prometheus.Desc
+	Version            *prometheus.Desc
 	Watches            *prometheus.Desc
 	Webhooks           *prometheus.Desc
 }
@@ -178,6 +180,11 @@ func NewCollector() Collector {
 			"Number of Users",
 			nil, nil,
 		),
+		Version: prometheus.NewDesc(
+			namespace+"version",
+			"Gitea version",
+			nil, nil,
+		),
 		Watches: prometheus.NewDesc(
 			namespace+"watches",
 			"Number of Watches",
@@ -219,6 +226,7 @@ func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.Teams
 	ch <- c.UpdateTasks
 	ch <- c.Users
+	ch <- c.Version
 	ch <- c.Watches
 	ch <- c.Webhooks
 }
@@ -362,6 +370,11 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 		c.Users,
 		prometheus.GaugeValue,
 		float64(stats.Counter.User),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.Version,
+		prometheus.GaugeValue,
+		float64(setting.NumAppVer),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.Watches,

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -67,6 +67,8 @@ const (
 var (
 	// AppVer is the version of the current build of Gitea. It is set in main.go from main.Version.
 	AppVer string
+	// NumAppVer is the version of the current build of Gitea in numerical form. It is set in main.go from main.Version.
+	NumAppVer int
 	// AppBuiltWith represents a human readable version go runtime build version and build tags. (See main.go formatBuiltWith().)
 	AppBuiltWith string
 	// AppStartTime store time gitea has started


### PR DESCRIPTION
- Add `NumAppVer` variable to store the app version numerically
- Add new "version" metric, collector for Prometheus

Resolves: https://github.com/go-gitea/gitea/issues/18061
