### PR TITLE
GitLab reviews may not have the updated_at field set (#18450) 

### DIFF
--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -32,8 +32,7 @@ func init() {
 }
 
 // GitlabDownloaderFactory defines a gitlab downloader factory
-type GitlabDownloaderFactory struct {
-}
+type GitlabDownloaderFactory struct{}
 
 // New returns a Downloader related to this factory according MigrateOptions
 func (f *GitlabDownloaderFactory) New(ctx context.Context, opts base.MigrateOptions) (base.Downloader, error) {
@@ -184,16 +183,17 @@ func (g *GitlabDownloader) GetTopics() ([]string, error) {
 
 // GetMilestones returns milestones
 func (g *GitlabDownloader) GetMilestones() ([]*base.Milestone, error) {
-	var perPage = g.maxPerPage
-	var state = "all"
-	var milestones = make([]*base.Milestone, 0, perPage)
+	perPage := g.maxPerPage
+	state := "all"
+	milestones := make([]*base.Milestone, 0, perPage)
 	for i := 1; ; i++ {
 		ms, _, err := g.client.Milestones.ListMilestones(g.repoID, &gitlab.ListMilestonesOptions{
 			State: &state,
 			ListOptions: gitlab.ListOptions{
 				Page:    i,
 				PerPage: perPage,
-			}}, nil, gitlab.WithContext(g.ctx))
+			},
+		}, nil, gitlab.WithContext(g.ctx))
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (g *GitlabDownloader) GetMilestones() ([]*base.Milestone, error) {
 			if m.Description != "" {
 				desc = m.Description
 			}
-			var state = "open"
+			state := "open"
 			var closedAt *time.Time
 			if m.State != "" {
 				state = m.State
@@ -255,8 +255,8 @@ func (g *GitlabDownloader) normalizeColor(val string) string {
 
 // GetLabels returns labels
 func (g *GitlabDownloader) GetLabels() ([]*base.Label, error) {
-	var perPage = g.maxPerPage
-	var labels = make([]*base.Label, 0, perPage)
+	perPage := g.maxPerPage
+	labels := make([]*base.Label, 0, perPage)
 	for i := 1; ; i++ {
 		ls, _, err := g.client.Labels.ListLabels(g.repoID, &gitlab.ListLabelsOptions{ListOptions: gitlab.ListOptions{
 			Page:    i,
@@ -327,8 +327,8 @@ func (g *GitlabDownloader) convertGitlabRelease(rel *gitlab.Release) *base.Relea
 
 // GetReleases returns releases
 func (g *GitlabDownloader) GetReleases() ([]*base.Release, error) {
-	var perPage = g.maxPerPage
-	var releases = make([]*base.Release, 0, perPage)
+	perPage := g.maxPerPage
+	releases := make([]*base.Release, 0, perPage)
 	for i := 1; ; i++ {
 		ls, _, err := g.client.Releases.ListReleases(g.repoID, &gitlab.ListReleasesOptions{
 			Page:    i,
@@ -381,7 +381,7 @@ func (g *GitlabDownloader) GetIssues(page, perPage int) ([]*base.Issue, bool, er
 		},
 	}
 
-	var allIssues = make([]*base.Issue, 0, perPage)
+	allIssues := make([]*base.Issue, 0, perPage)
 
 	issues, _, err := g.client.Issues.ListProjectIssues(g.repoID, opt, nil, gitlab.WithContext(g.ctx))
 	if err != nil {
@@ -389,7 +389,7 @@ func (g *GitlabDownloader) GetIssues(page, perPage int) ([]*base.Issue, bool, er
 	}
 	for _, issue := range issues {
 
-		var labels = make([]*base.Label, 0, len(issue.Labels))
+		labels := make([]*base.Label, 0, len(issue.Labels))
 		for _, l := range issue.Labels {
 			labels = append(labels, &base.Label{
 				Name: l,
@@ -402,7 +402,7 @@ func (g *GitlabDownloader) GetIssues(page, perPage int) ([]*base.Issue, bool, er
 		}
 
 		var reactions []*base.Reaction
-		var awardPage = 1
+		awardPage := 1
 		for {
 			awards, _, err := g.client.AwardEmoji.ListIssueAwardEmoji(g.repoID, issue.IID, &gitlab.ListAwardEmojiOptions{Page: awardPage, PerPage: perPage}, gitlab.WithContext(g.ctx))
 			if err != nil {
@@ -456,9 +456,9 @@ func (g *GitlabDownloader) GetComments(opts base.GetCommentOptions) ([]*base.Com
 		return nil, false, fmt.Errorf("unexpected context: %+v", opts.Context)
 	}
 
-	var allComments = make([]*base.Comment, 0, g.maxPerPage)
+	allComments := make([]*base.Comment, 0, g.maxPerPage)
 
-	var page = 1
+	page := 1
 
 	for {
 		var comments []*gitlab.Discussion
@@ -503,7 +503,6 @@ func (g *GitlabDownloader) GetComments(opts base.GetCommentOptions) ([]*base.Com
 					Created:     *c.CreatedAt,
 				})
 			}
-
 		}
 		if resp.NextPage == 0 {
 			break
@@ -526,7 +525,7 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 		},
 	}
 
-	var allPRs = make([]*base.PullRequest, 0, perPage)
+	allPRs := make([]*base.PullRequest, 0, perPage)
 
 	prs, _, err := g.client.MergeRequests.ListProjectMergeRequests(g.repoID, opt, nil, gitlab.WithContext(g.ctx))
 	if err != nil {
@@ -534,7 +533,7 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 	}
 	for _, pr := range prs {
 
-		var labels = make([]*base.Label, 0, len(pr.Labels))
+		labels := make([]*base.Label, 0, len(pr.Labels))
 		for _, l := range pr.Labels {
 			labels = append(labels, &base.Label{
 				Name: l,
@@ -547,12 +546,12 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 			pr.State = "closed"
 		}
 
-		var mergeTime = pr.MergedAt
+		mergeTime := pr.MergedAt
 		if merged && pr.MergedAt == nil {
 			mergeTime = pr.UpdatedAt
 		}
 
-		var closeTime = pr.ClosedAt
+		closeTime := pr.ClosedAt
 		if merged && pr.ClosedAt == nil {
 			closeTime = pr.UpdatedAt
 		}
@@ -568,7 +567,7 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 		}
 
 		var reactions []*base.Reaction
-		var awardPage = 1
+		awardPage := 1
 		for {
 			awards, _, err := g.client.AwardEmoji.ListMergeRequestAwardEmoji(g.repoID, pr.IID, &gitlab.ListAwardEmojiOptions{Page: awardPage, PerPage: perPage}, gitlab.WithContext(g.ctx))
 			if err != nil {
@@ -641,13 +640,22 @@ func (g *GitlabDownloader) GetReviews(context base.IssueContext) ([]*base.Review
 		return nil, err
 	}
 
-	var reviews = make([]*base.Review, 0, len(approvals.ApprovedBy))
+	var createdAt time.Time
+	if approvals.CreatedAt != nil {
+		createdAt = *approvals.CreatedAt
+	} else if approvals.UpdatedAt != nil {
+		createdAt = *approvals.UpdatedAt
+	} else {
+		createdAt = time.Now()
+	}
+
+	reviews := make([]*base.Review, 0, len(approvals.ApprovedBy))
 	for _, user := range approvals.ApprovedBy {
 		reviews = append(reviews, &base.Review{
 			IssueIndex:   context.LocalID(),
 			ReviewerID:   int64(user.User.ID),
 			ReviewerName: user.User.Username,
-			CreatedAt:    *approvals.UpdatedAt,
+			CreatedAt:    createdAt,
 			// All we get are approvals
 			State: base.ReviewStateApproved,
 		})

--- a/services/migrations/main_test.go
+++ b/services/migrations/main_test.go
@@ -223,15 +223,15 @@ func assertRepositoryEqual(t *testing.T, expected, actual *base.Repository) {
 }
 
 func assertReviewEqual(t *testing.T, expected, actual *base.Review) {
-	assert.Equal(t, expected.ID, actual.ID)
-	assert.Equal(t, expected.IssueIndex, actual.IssueIndex)
-	assert.Equal(t, expected.ReviewerID, actual.ReviewerID)
-	assert.Equal(t, expected.ReviewerName, actual.ReviewerName)
-	assert.Equal(t, expected.Official, actual.Official)
-	assert.Equal(t, expected.CommitID, actual.CommitID)
-	assert.Equal(t, expected.Content, actual.Content)
-	assertTimeEqual(t, expected.CreatedAt, actual.CreatedAt)
-	assert.Equal(t, expected.State, actual.State)
+	assert.Equal(t, expected.ID, actual.ID, "ID")
+	assert.Equal(t, expected.IssueIndex, actual.IssueIndex, "IsssueIndex")
+	assert.Equal(t, expected.ReviewerID, actual.ReviewerID, "ReviewerID")
+	assert.Equal(t, expected.ReviewerName, actual.ReviewerName, "ReviewerName")
+	assert.Equal(t, expected.Official, actual.Official, "Official")
+	assert.Equal(t, expected.CommitID, actual.CommitID, "CommitID")
+	assert.Equal(t, expected.Content, actual.Content, "Content")
+	assert.WithinDuration(t, expected.CreatedAt, actual.CreatedAt, 10*time.Second)
+	assert.Equal(t, expected.State, actual.State, "State")
 	assertReviewCommentsEqual(t, expected.Comments, actual.Comments)
 }
 


### PR DESCRIPTION
Backport #18450

> On behalf of [Loïc Dachary](https://lab.forgefriends.org/dachary)

Use created_at instead of updated_at because it makes more sense. 
Fallback to updated_at if it is missing and to time.Now() if it is
also missing.

Fixes: #18434

Co-authored-by: Loïc Dachary <loic@dachary.org>

Conflicts:
	services/migrations/gitlab.go
	trivial context conflict because var reviews became reviews := in 1.17

---
[source](https://lab.forgefriends.org/forgefriends/forgefriends/-/merge_requests/38#note_921)