### PR TITLE
Changelog 1.16.0 & 1.15.11 (#18468 & #18455) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ This changelog goes through all the changes that have been made in each release
 without substantial changes to our git log; to see the highlights of what has
 been added to each release, please refer to the [blog](https://blog.gitea.io).
 
-## [1.16.0-rc1](https://github.com/go-gitea/gitea/releases/tag/v1.16.0-rc1) - 2022-01-19
+## [1.16.0](https://github.com/go-gitea/gitea/releases/tag/v1.16.0) - 2022-01-30
 
 * BREAKING
   * Remove golang vendored directory (#18277)
   * Paginate releases page & set default page size to 10 (#16857)
   * Only allow webhook to send requests to allowed hosts (#17482)
 * SECURITY
+  * Disable content sniffing on `PlainTextBytes` (#18359) (#18365)
+  * Only view milestones from current repo (#18414) (#18417)
   * Sanitize user-input on file name (#17666)
   * Use `hostmatcher` to replace `matchlist` to improve blocking of bad hosts in Webhooks (#17605)
 * FEATURES
@@ -228,6 +230,16 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Add left padding for chunk header of split diff view (#13397)
   * Allow U2F 2FA without TOTP (#11573)
 * BUGFIXES
+  * GitLab reviews may not have the updated_at field set (#18450) (#18461)
+  * Fix detection of no commits when the default branch is not master (#18422) (#18423)
+  * Fix broken oauth2 authentication source edit page (#18412) (#18419)
+  * Place inline diff comment dialogs on split diff in 4th and 8th columns (#18403) (#18404)
+  * Fix restore without topic failure (#18387) (#18400)
+  * Fix commit's time (#18375) (#18392)
+  * Fix partial cloning a repo (#18373) (#18377)
+  * Stop trimming preceding and suffixing spaces from editor filenames (#18334)
+  * Prevent showing webauthn error for every time visiting `/user/settings/security` (#18386)
+  * Fix mime-type detection for HTTP server (#18370) (#18371)
   * Stop trimming preceding and suffixing spaces from editor filenames (#18334)
   * Restore propagation of ErrDependenciesLeft (#18325)
   * Fix PR comments UI (#18323)
@@ -298,6 +310,19 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
   * Use shadowing script for docker (#17846)
 * MISC
   * Update JS dependencies (#17611)
+
+## [1.15.11](https://github.com/go-gitea/gitea/releases/tag/v1.15.11) - 2022-01-29
+
+* SECURITY
+  * Only view milestones from current repo (#18414) (#18418)
+* BUGFIXES
+  * Fix broken when no commits and default branch is not master (#18422) (#18424)
+  * Fix commit's time (#18375) (#18409)
+  * Fix restore without topic failure (#18387) (#18401)
+  * Fix mermaid import in 1.15 (it uses ESModule now) (#18382)
+  * Update to go/text 0.3.7 (#18336)
+* MISC
+  * Upgrade EasyMDE to 2.16.1 (#18278) (#18279)
 
 ## [1.15.10](https://github.com/go-gitea/gitea/releases/tag/v1.15.10) - 2022-01-14
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -18,7 +18,7 @@ params:
   description: Git with a cup of tea
   author: The Gitea Authors
   website: https://docs.gitea.io
-  version: 1.15.10
+  version: 1.16.0
   minGoVersion: 1.16
   goVersion: 1.17
   minNodeVersion: 12.17


### PR DESCRIPTION
Frontport #18468 & #18455

Frontport changelog for 1.16, frontport 1.15.11 changelog and update config.yaml

 ## [1.16.0](https://github.com/go-gitea/gitea/releases/tag/v1.16.0) - 2022-01-30

* BREAKING
  * Remove golang vendored directory (#18277)
  * Paginate releases page & set default page size to 10 (#16857)
  * Only allow webhook to send requests to allowed hosts (#17482)
* SECURITY
  * Disable content sniffing on `PlainTextBytes` (#18359) (#18365)
  * Only view milestones from current repo (#18414) (#18417)
  * Sanitize user-input on file name (#17666)
  * Use `hostmatcher` to replace `matchlist` to improve blocking of bad hosts in Webhooks (#17605)
* FEATURES
  * Add/update SMTP auth providers via cli (#18197)
  * Support webauthn (#17957)
  * Team permission allow different unit has different permission (#17811)
  * Implement Well-Known URL for password change (#17777)
  * Add support for ssh commit signing (#17743)
  * Allow Loading of Diffs that are too large (#17739)
  * Add copy button to markdown code blocks (#17638)
  * Add .gitattribute assisted language detection to blame, diff and render (#17590)
  * Add `PULL_LIMIT` and `PUSH_LIMIT` to cron.update_mirror task (#17568)
  * Add Reindex buttons to repository settings page (#17494)
  * Make SSL cipher suite configurable (#17440)
  * Add groups scope/claim to OIDC/OAuth2 Provider (#17367)
  * Add simple update checker to Gitea (#17212)
  * Migrated Repository will show modifications when possible (#17191)
  * Create pub/priv keypair for federation (#17071)
  * Make LDAP be able to skip local 2FA (#16954)
  * Add nodeinfo endpoint for federation purposes (#16953)
  * Save and view issue/comment content history (#16909)
  * Use git attributes to determine generated and vendored status for language stats and diffs (#16773)
  * Add migrate from Codebase (#16768)
  * Add migration from GitBucket (#16767)
  * Add OAuth2 introspection endpoint (#16752)
  * Add proxy settings and support for migration and webhook (#16704)
  * Add microsoft oauth2 providers (#16544)
  * Send registration email on user autoregistration (#16523)
  * Defer Last Commit Info (#16467)
  * Support unprotected file patterns (#16395)
  * Add migrate from OneDev (#16356)
  * Add option to update pull request by `rebase` (#16125)
  * Add RSS/Atom feed support for user actions (#16002)
  * Add support for corporate WeChat webhooks (#15910)
  * Add a simple way to rename branch like gh (#15870)
  * Add bundle download for repository (#14538)
  * Add agit flow support in gitea (#14295)
* API
  * Add MirrorUpdated field to Repository API type (#18267)
  * Adjust Fork API to allow setting a custom repository name (#18066)
  * Add API to manage repo tranfers (#17963)
  * Add API to get file commit history (#17652)
  * Add API to get issue/pull comments and events (timeline) (#17403)
  * Add API to get/edit wiki (#17278)
  * Add API for get user org permissions (#17232)
  * Add HTML urls to notification API (#17178)
  * Add API to get commit diff/patch (#17095)
  * Respond with updated notifications in API (#17064)
  * Add API to fetch git notes (#16649)
  * Generalize list header for API (#16551)
  * Add API Token Cache (#16547)
  * Allow Token API calls be authorized using the reverse-proxy header (#15119)
* ENHANCEMENTS
  * Make the height of the editor in Review Box smaller (4 lines as GitHub) (#18319)
  * Return nicer error if trying to pull from non-existent user (#18288)
  * Show pull link for agit pull request also (#18235)
  * Enable partial clone by default (#18195)
  * Added replay of webhooks (#18191)
  * Show OAuth callback error message (#18185)
  * Increase Salt randomness (#18179)
  * Add MP4 as default allowed attachment type (#18170)
  * Include folders into size cost (#18158)
  * Remove `/email2user` endpoint (#18127)
  * Handle invalid issues (#18111)
  * Load EasyMDE/CodeMirror dynamically, remove RequireEasyMDE (#18069)
  * Support open compare page directly (#17975)
  * Prefer "Hiragino Kaku Gothic ProN" in system-ui-ja (#17954)
  * Clean legacy SimpleMDE code (#17926)
  * Refactor install page (db type) (#17919)
  * Improve interface when comparing a branch which has created a pull request (#17911)
  * Allow default branch to be inferred on compare page (#17908)
  * Display issue/comment role even if repo archived (#17907)
  * Always set a message-id on mails (#17900)
  * Change `<a>` elements to underline on hover (#17898)
  * Render issue references in file table (#17897)
  * Handle relative unix socket paths (#17836)
  * Move accessmode into models/perm (#17828)
  * Fix some org style problems (#17807)
  * Add List-Unsubscribe header (#17804)
  * Create menus for organization pages (#17802)
  * Switch archive URL code back to href attributes (#17796)
  * Refactor "refs/*" string usage by using constants (#17784)
  * Allow forks to org if you can create repos (#17783)
  * Improve install code to avoid low-level mistakes. (#17779)
  * Improve ellipsis buttons (#17773)
  * Add restrict and no-user-rc to authorized_keys (#17772)
  * Add copy Commit ID button in commits list (#17759)
  * Make `bind` error more readable (#17750)
  * Fix navbar on project view (#17749)
  * More pleasantly handle broken or missing git repositories (#17747)
  * Use `*PushUpdateOptions` as receiver (#17724)
  * Remove unused `user` paramater (#17723)
  * Better builtin avatar generator (#17707)
  * Cleanup and use global style on popups (#17674)
  * Move user/org deletion to services (#17673)
  * Added comment for changing issue ref (#17672)
  * Allow admins to change user avatars (#17661)
  * Only set `data-path` once for each file in diff pages (#17657)
  * Add icon to vscode clone link (#17641)
  * Add download button for file viewer (#17640)
  * Add pagination to fork list (#17639)
  * Use a standalone struct name for Organization (#17632)
  * Minor readability patch. (#17627)
  * Add context support for GetUserByID (#17602)
  * Move merge-section to `> .content` (#17582)
  * Remove NewSession method from db.Engine interface (#17577)
  * Move unit into models/unit/ (#17576)
  * Restrict GetDeletedBranchByID to the repositories deleted branches (#17570)
  * Refactor commentTags functionality (#17558)
  * Make Repo Code Indexer an Unique Queue (#17515)
  * Simplify Gothic to use our session store instead of creating a different store (#17507)
  * Add settings to allow different SMTP envelope from address (#17479)
  * Properly determine CSV delimiter (#17459)
  * Hide label comments if labels were added and removed immediately (#17455)
  * Tune UI alignment for nav bar notification icon, avatar image, issue label (#17438)
  * Add appearance section in settings (#17433)
  * Move key forms before list and add cancel button (#17432)
  * When copying executables to the docker chmod them (#17423)
  * Remove deprecated `extendDefaultPlugins` method of svgo (#17399)
  * Fix the click behavior for <tr> and <td> with [data-href] (#17388)
  * Refactor update checker to use AppState (#17387)
  * Improve async/await usage, and sort init calls in `index.js` (#17386)
  * Use a variable but a function for IsProd because of a slight performance increment (#17368)
  * Frontend refactor, PascalCase to camelCase, remove unused code (#17365)
  * Hide command line merge instructions when user can't push (#17339)
  * Move session to models/login (#17338)
  * Sync gitea app path for git hooks and authorized keys when starting (#17335)
  * Make the Mirror Queue a queue (#17326)
  * Add "Copy branch name" button to pull request page (#17323)
  * Fix repository summary on mobile (#17322)
  * Split `index.js` to separate files (#17315)
  * Show direct match on top for user search (#17303)
  * Frontend refactor: move Vue related code from `index.js` to `components` dir, and remove unused codes. (#17301)
  * Upgrade chi to v5 (#17298)
  * Disable form autofill (#17291)
  * Improve behavior of "Fork" button (#17288)
  * Open markdown image links in new window (#17287)
  * Add hints for special Wiki pages (#17283)
  * Move add deploy key form before the list and add a cancel button (#17228)
  * Allow adding multiple issues to a project  (#17226)
  * Add metrics to get issues by repository (#17225)
  * Add specific event type to header (#17222)
  * Redirect on project after issue created (#17211)
  * Reference in new issue modal: dont pre-populate issue title (#17208)
  * Always set a unique Message-ID header (#17206)
  * Add projects and project boards in exposed metrics (#17202)
  * Add metrics to get issues by label (#17201)
  * Add protection to disable Gitea when run as root (#17168)
  * Don't return binary file changes in raw PR diffs by default (#17158)
  * Support sorting for project board issuses (#17152)
  * Force color-adjust for markdown checkboxes (#17146)
  * Add option to copy line permalink (#17145)
  * Move twofactor to models/login (#17143)
  * Multiple tokens support for migrating from github (#17134)
  * Unify issue and PR subtitles (#17133)
  * Make Requests Processes and create process hierarchy. Associate OpenRepository with context. (#17125)
  * Fix problem when database id is not increment as expected (#17124)
  * Avatar refactor, move avatar code from `models` to `models.avatars`, remove duplicated code (#17123)
  * Re-allow clipboard copy on non-https sites (#17118)
  * DBContext is just a Context (#17100)
  * Move login related structs and functions to models/login (#17093)
  * Add SkipLocal2FA option to pam and smtp sources (#17078)
  * Move db related basic functions to models/db (#17075)
  * Fixes username tagging in "Reference in new issue" (#17074)
  * Use light/dark theme based on system preference (#17051)
  * Always emit the configuration path (#17036)
  * Add `AbsoluteListOptions` (#17028)
  * Use common sessioner for API and Web (#17027)
  * Fix overflow label in small view (#17020)
  * Report the associated filter if there is an error in LDAP (#17014)
  * Add "new issue" btn on project (#17001)
  * Add doctor dbconsistency check for release and attachment (#16978)
  * Disable Fomantic's CSS tooltips (#16974)
  * Add Cache-Control to avatar redirects (#16973)
  * Make mirror feature more configurable (#16957)
  * Add skip and limit to git.GetTags (#16897)
  * Remove ParseQueueConnStr as it is unused (#16878)
  * Remove unused Fomantic sidebar module (#16853)
  * Allow LDAP Sources to provide Avatars (#16851)
  * Remove Dashboard/Home button from the navbar (#16844)
  * Use conditions but not repo ids as query condition (#16839)
  * Add user settings key/value DB table (#16834)
  * Add buttons to allow loading of incomplete diffs (#16829)
  * Add information for migrate failure (#16803)
  * Add EdDSA JWT signing algorithm (#16786)
  * Add user status filter to admin user management page (#16770)
  * Add Option to synchronize Admin & Restricted states from OIDC/OAuth2 along with Setting Scopes (#16766)
  * Do not use thin scrollbars on Firefox (#16738)
  * Download LFS in git and web workflow from minio/s3 directly (SERVE_DIRECT) (#16731)
  * Compute proper foreground color for labels (#16729)
  * Add edit button to wiki sidebar and footer (#16719)
  * Fix migration svg color (#16715)
  * Add link to vscode to repo header (#16664)
  * Add filter by owner and team to issue/pulls search endpoint (#16662)
  * Kanban colored boards (#16647)
  * Allow setting X-FRAME-OPTIONS (#16643)
  * Separate open and closed issue in metrics (#16637)
  * Support direct comparison (git diff a..b) as well merge comparison (a…b) (#16635)
  * Add setting to OAuth handlers to skip local 2FA authentication (#16594)
  * Make PR merge options more intuitive (#16582)
  * Show correct text when comparing commits on empty pull request (#16569)
  * Pre-fill suggested New File 'name' and 'content' with Query Params (#16556)
  * Add an abstract json layout to make it's easier to change json library (#16528)
  * Make Mermaid.js limit configurable (#16519)
  * Improve 2FA autofill (#16473)
  * Add modals to Organization and Team remove/leave (#16471)
  * Show tag name on dashboard items list (#16466)
  * Change default cron schedules from @every 24h to @midnight (#16431)
  * Prevent double sanitize (#16386)
  * Replace `list.List` with slices (#16311)
  * Add configuration option to restrict users by default (#16256)
  * Move login out of models (#16199)
  * Support pagination of organizations on user settings pages (#16083)
  * Switch migration icon to svg (#15954)
  * Add left padding for chunk header of split diff view (#13397)
  * Allow U2F 2FA without TOTP (#11573)
* BUGFIXES
  * GitLab reviews may not have the updated_at field set (#18450) (#18461)
  * Fix detection of no commits when the default branch is not master (#18422) (#18423)
  * Fix broken oauth2 authentication source edit page (#18412) (#18419)
  * Place inline diff comment dialogs on split diff in 4th and 8th columns (#18403) (#18404)
  * Fix restore without topic failure (#18387) (#18400)
  * Fix commit's time (#18375) (#18392)
  * Fix partial cloning a repo (#18373) (#18377)
  * Stop trimming preceding and suffixing spaces from editor filenames (#18334)
  * Prevent showing webauthn error for every time visiting `/user/settings/security` (#18386)
  * Fix mime-type detection for HTTP server (#18370) (#18371)
  * Stop trimming preceding and suffixing spaces from editor filenames (#18334)
  * Restore propagation of ErrDependenciesLeft (#18325)
  * Fix PR comments UI (#18323)
  * Use indirect comparison when showing pull requests (#18313)
  * Replace satori/go.uuid with gofrs/uuid (#18311)
  * Fix commit links on compare page (#18310)
  * Don't show double error response in git hook (#18292)
  * Handle missing default branch better in owner/repo/branches page (#18290)
  * Fix CheckRepoStats and reuse it during migration (#18264)
  * Prevent underline hover on cards (#18259)
  * Don't delete branch if other PRs with this branch are open (#18164)
  * Require codereview to have content (#18156)
  * Allow admin to associate missing LFS objects for repositories (#18143)
  * When attempting to subscribe other user to issue report why access denied (#18091)
  * Add option to convert CRLF to LF line endings for sendmail (#18075)
  * Only create pprof files for gitea serv if explicitly asked for (#18068)
  * Abort merge if head has been updated before pressing merge (#18032)
  * Improve TestPatch to use git read-tree -m and implement git-merge-one-file functionality (#18004)
  * Use JSON module instead of stdlib json (#18003)
  * Fixed issue merged/closed wording (#17973)
  * Return nicer error for ForcePrivate (#17971)
  * Fix overflow in commit graph (#17947)
  * Prevent services/mailer/mailer_test.go tests from deleteing data directory (#17941)
  * Use disable_form_autofill on Codebase and Gitbucket (#17936)
  * Fix a panic in NotifyCreateIssueComment (caused by string truncation) (#17928)
  * Fix markdown URL parsing (#17924)
  * Apply CSS Variables to all message elements (#17920)
  * Improve checkBranchName (#17901)
  * Update chi/middleware to chi/v5/middleware (#17888)
  * Fix position of label color picker colors (#17866)
  * Fix ListUnadoptedRepositories incorrect total count (#17865)
  * Remove whitespace inside rendered code `<td>` (#17859)
  * Make Co-committed-by and co-authored-by trailers optional (#17848)
  * Fix value of User.IsRestricted when oauth2 user registration (#17839)
  * Use new OneDev /milestones endpoint (#17782)
  * Prevent deadlock in TestPersistableChannelQueue (#17717)
  * Simplify code for writing SHA to name-rev (#17696)
  * Fix database deadlock when update issue labels (#17649)
  * Add warning for BIDI characters in page renders and in diffs (#17562)
  * Fix ipv6 parsing for builtin ssh server (#17561)
  * Multiple Escaping Improvements (#17551)
  * Fixes #16559 - Do not trim leading spaces for tab delimited (#17442)
  * Show client-side error if wiki page is empty (#17415)
  * Fix context popup error (#17398)
  * Stop sanitizing full name in API (#17396)
  * Fix issue close/comment buttons on mobile (#17317)
  * Fix navbar UI (#17235)
  * Fix problem when database id is not increment as expected (#17229)
  * Open the DingTalk link in browser (#17084)
  * Remove heads pointing to missing old refs (#17076)
  * Fix commit status index problem (#17061)
  * Handle broken references in mirror sync (#17013)
  * Fix for create repo page layout (#17012)
  * Improve LDAP synchronization efficiency (#16994)
  * Add repo_id for attachment (#16958)
  * Clean-up HookPreReceive and restore functionality for pushing non-standard refs (#16705)
  * Remove duplicate csv import in modules/csv/csv.go (#16631)
  * Improve SMTP authentication and Fix user creation bugs  (#16612)
  * Fixed emoji alias not parsed in links (#16221)
  * Calculate label URL on API  (#16186)
* TRANSLATION
  * Fix mispelling of starred as stared (#17465)
  * Re-separate the color translation strings (#17390)
  * Enable Malayalam, Greek, Persian, Hungarian & Indonesian by default (#16998)
* BUILD
  * Add lockfile-check (#18285)
  * Don't store assets modified time into generated files (#18193)
  * Use shadowing script for docker (#17846)
* MISC
  * Update JS dependencies (#17611)

Signed-off-by: Andrew Thornton <art27@cantab.net>
