### PR TITLE
DISABLE_2FA parameter for disabling 2FA added

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -372,6 +372,9 @@ INTERNAL_TOKEN=
 ;; Set to true to disable webhooks feature.
 ;DISABLE_WEBHOOKS = false
 ;;
+;; Set to false to disable 2FA feature.
+;DISABLE_2FA = false
+;;
 ;; Set to false to allow pushes to gitea repositories despite having an incomplete environment - NOT RECOMMENDED
 ;ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
 ;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -498,6 +498,7 @@ Certain queues have defaults that override the defaults set in `[queue]` (this o
    Gitea instance and perform arbitrary actions in the name of the Gitea OS user.
    This maybe harmful to you website or your operating system.
 - `DISABLE_WEBHOOKS`: **false**: Set to `true` to disable webhooks feature.
+- `DISABLE_2FA`: **false**: Set to `true` to disable 2FA feature.
 - `ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET`: **true**: Set to `false` to allow local users to push to gitea-repositories without setting up the Gitea environment. This is not recommended and if you want local users to push to Gitea repositories you should set the environment appropriately.
 - `IMPORT_LOCAL_PATHS`: **false**: Set to `false` to prevent all users (including admin) from importing local path on server.
 - `INTERNAL_TOKEN`: **\<random at every install if no uri set\>**: Secret used to validate communication within Gitea binary.

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -706,6 +706,7 @@ func Contexter() func(next http.Handler) http.Handler {
 
 			ctx.Data["EnableSwagger"] = setting.API.EnableSwagger
 			ctx.Data["EnableOpenIDSignIn"] = setting.Service.EnableOpenIDSignIn
+			ctx.Data["EnableOpenIDSignUp"] = setting.Service.EnableOpenIDSignUp
 			ctx.Data["DisableMigrations"] = setting.Repository.DisableMigrations
 			ctx.Data["DisableStars"] = setting.Repository.DisableStars
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -187,6 +187,7 @@ var (
 	ImportLocalPaths                   bool
 	DisableGitHooks                    bool
 	DisableWebhooks                    bool
+	Disable2FA                         bool
 	OnlyAllowPushIfGiteaEnvironmentSet bool
 	PasswordComplexity                 []string
 	PasswordHashAlgo                   string
@@ -868,6 +869,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	ImportLocalPaths = sec.Key("IMPORT_LOCAL_PATHS").MustBool(false)
 	DisableGitHooks = sec.Key("DISABLE_GIT_HOOKS").MustBool(true)
 	DisableWebhooks = sec.Key("DISABLE_WEBHOOKS").MustBool(false)
+	Disable2FA = sec.Key("DISABLE_2FA").MustBool(false)
 	OnlyAllowPushIfGiteaEnvironmentSet = sec.Key("ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET").MustBool(true)
 	PasswordHashAlgo = sec.Key("PASSWORD_HASH_ALGO").MustString("pbkdf2")
 	CSRFCookieHTTPOnly = sec.Key("CSRF_COOKIE_HTTP_ONLY").MustBool(true)

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -236,6 +236,9 @@ func NewFuncMap() []template.FuncMap {
 		"DisableWebhooks": func() bool {
 			return setting.DisableWebhooks
 		},
+		"Disable2FA": func() bool {
+			return setting.Disable2FA
+		},
 		"DisableImportLocal": func() bool {
 			return !setting.ImportLocalPaths
 		},

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -73,7 +73,9 @@
 						<th>{{.i18n.Tr "admin.users.activated"}}</th>
 						<th>{{.i18n.Tr "admin.users.admin"}}</th>
 						<th>{{.i18n.Tr "admin.users.restricted"}}</th>
+						{{if not Disable2FA}}
 						<th>{{.i18n.Tr "admin.users.2fa"}}</th>
+						{{end}}
 						<th>{{.i18n.Tr "admin.users.repos"}}</th>
 						<th>{{.i18n.Tr "admin.users.created"}}</th>
 						<th data-sortt-asc="leastupdate" data-sortt-desc="recentupdate">
@@ -92,7 +94,9 @@
 							<td>{{if .IsActive}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
 							<td>{{if .IsAdmin}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
 							<td>{{if .IsRestricted}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
+							{{if not Disable2FA}}
 							<td>{{if index $.UsersTwoFaStatus .ID}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
+							{{end}}
 							<td>{{.NumRepos}}</td>
 							<td><span title="{{.CreatedUnix.FormatLong}}">{{.CreatedUnix.FormatShort}}</span></td>
 							{{if .LastLoginUnix}}

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -37,6 +37,7 @@
 							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock"}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
 						</div>
 					</div>
+					{{if not Disable2FA}}
 					<div class="ui two wide column center">
 						<div class="meta">
 							{{$.i18n.Tr "admin.users.2fa"}}
@@ -51,6 +52,7 @@
 							</strong>
 						</div>
 					</div>
+					{{end}}
 					<div class="ui three wide column">
 						<div class="text right">
 							{{if eq $.SignedUser.ID .ID}}

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -9,9 +9,11 @@
 		<a class="{{if .PageIsSettingsAppearance}}active{{end}} item" href="{{AppSubUrl}}/user/settings/appearance">
 			{{.i18n.Tr "settings.appearance"}}
 		</a>
+		{{if or (not Disable2FA) .EnableOpenIDSignIn .EnableOpenIDSignUp}}
 		<a class="{{if .PageIsSettingsSecurity}}active{{end}} item" href="{{AppSubUrl}}/user/settings/security">
 			{{.i18n.Tr "settings.security"}}
 		</a>
+		{{end}}
 		<a class="{{if .PageIsSettingsApplications}}active{{end}} item" href="{{AppSubUrl}}/user/settings/applications">
 			{{.i18n.Tr "settings.applications"}}
 		</a>

--- a/templates/user/settings/security/security.tmpl
+++ b/templates/user/settings/security/security.tmpl
@@ -3,9 +3,13 @@
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}
+		{{if not Disable2FA}}
 		{{template "user/settings/security/twofa" .}}
 		{{template "user/settings/security/webauthn" .}}
+		{{end}}
+		{{if .EnableOpenIDSignUp}}
 		{{template "user/settings/security/accountlinks" .}}
+		{{end}}
 		{{if .EnableOpenIDSignIn}}
 		{{template "user/settings/security/openid" .}}
 		{{end}}


### PR DESCRIPTION
Gitea does not use 2FA when reverse proxy auth is enabled. 2FA is hardcoded
and cannot be disabled (i.e. when stronger authentication scheme is
implemented on reverse proxy). Leaving unused elements like 2FA in UI should
be avoided to make UI clean and to avoid unnecessarry maintanance
(questions/problems from users).

This mod introduces new `DISABLE_2FA` parameter in app.ini section
`[security]`. When disabled (default when parameter is not present) gitea
behaves as without this mod (2FA is available). When enabled, 2FA feature
and its UI elements are not avaiable.

This mod also hides those areas on Settings/Security page that are
disabled in config and hides menu link to Security page if all its areas
are disabled in config.

Related: https://github.com/go-gitea/gitea/pull/13129
Author-Change-Id: IB#1115243
