### PR TITLE
DISABLE_ACCESS_TOKENS parameter for disabling access tokens added

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -372,6 +372,9 @@ INTERNAL_TOKEN=
 ;; Set to true to disable webhooks feature.
 ;DISABLE_WEBHOOKS = false
 ;;
+;; Set to false to disable access tokens feature.
+;DISABLE_ACCESS_TOKENS = false
+;;
 ;; Set to false to allow pushes to gitea repositories despite having an incomplete environment - NOT RECOMMENDED
 ;ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET = true
 ;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -498,6 +498,7 @@ Certain queues have defaults that override the defaults set in `[queue]` (this o
    Gitea instance and perform arbitrary actions in the name of the Gitea OS user.
    This maybe harmful to you website or your operating system.
 - `DISABLE_WEBHOOKS`: **false**: Set to `true` to disable webhooks feature.
+- `DISABLE_ACCESS_TOKENS`: **false**: Set to `true` to disable access tokens feature.
 - `ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET`: **true**: Set to `false` to allow local users to push to gitea-repositories without setting up the Gitea environment. This is not recommended and if you want local users to push to Gitea repositories you should set the environment appropriately.
 - `IMPORT_LOCAL_PATHS`: **false**: Set to `false` to prevent all users (including admin) from importing local path on server.
 - `INTERNAL_TOKEN`: **\<random at every install if no uri set\>**: Secret used to validate communication within Gitea binary.

--- a/models/token.go
+++ b/models/token.go
@@ -94,6 +94,12 @@ func GetAccessTokenBySHA(token string) (*AccessToken, error) {
 	if token == "" {
 		return nil, ErrAccessTokenEmpty{}
 	}
+
+	// Existing tokens are invalid if access tokens feature is disabled.
+	if setting.DisableAccessTokens {
+		return nil, ErrAccessTokenNotExist{token}
+	}
+
 	// A token is defined as being SHA1 sum these are 40 hexadecimal bytes long
 	if len(token) != 40 {
 		return nil, ErrAccessTokenNotExist{token}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -187,6 +187,7 @@ var (
 	ImportLocalPaths                   bool
 	DisableGitHooks                    bool
 	DisableWebhooks                    bool
+	DisableAccessTokens                bool
 	OnlyAllowPushIfGiteaEnvironmentSet bool
 	PasswordComplexity                 []string
 	PasswordHashAlgo                   string
@@ -868,6 +869,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	ImportLocalPaths = sec.Key("IMPORT_LOCAL_PATHS").MustBool(false)
 	DisableGitHooks = sec.Key("DISABLE_GIT_HOOKS").MustBool(true)
 	DisableWebhooks = sec.Key("DISABLE_WEBHOOKS").MustBool(false)
+	DisableAccessTokens = sec.Key("DISABLE_ACCESS_TOKENS").MustBool(false)
 	OnlyAllowPushIfGiteaEnvironmentSet = sec.Key("ONLY_ALLOW_PUSH_IF_GITEA_ENVIRONMENT_SET").MustBool(true)
 	PasswordHashAlgo = sec.Key("PASSWORD_HASH_ALGO").MustString("pbkdf2")
 	CSRFCookieHTTPOnly = sec.Key("CSRF_COOKIE_HTTP_ONLY").MustBool(true)

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -236,6 +236,12 @@ func NewFuncMap() []template.FuncMap {
 		"DisableWebhooks": func() bool {
 			return setting.DisableWebhooks
 		},
+		"DisableAccessTokens": func() bool {
+			return setting.DisableAccessTokens
+		},
+		"DisableOAuth2": func() bool {
+			return !setting.OAuth2.Enable
+		},
 		"DisableImportLocal": func() bool {
 			return !setting.ImportLocalPaths
 		},

--- a/routers/web/user/setting/applications.go
+++ b/routers/web/user/setting/applications.go
@@ -95,7 +95,7 @@ func DeleteApplication(ctx *context.Context) {
 }
 
 func loadApplicationsData(ctx *context.Context) {
-	if setting.DisableAccessTokens {
+	if !setting.DisableAccessTokens {
 		tokens, err := models.ListAccessTokens(models.ListAccessTokensOptions{UserID: ctx.User.ID})
 		if err != nil {
 			ctx.ServerError("ListAccessTokens", err)

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -3,6 +3,7 @@
 	{{template "user/settings/navbar" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}
+		{{if not DisableAccessTokens}}
 		<h4 class="ui top attached header">
 			{{.i18n.Tr "settings.manage_access_token"}}
 		</h4>
@@ -46,6 +47,7 @@
 				</button>
 			</form>
 		</div>
+		{{end}}
 
 		{{if .EnableOAuth2}}
 			{{template "user/settings/grants_oauth2" .}}

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -12,9 +12,11 @@
 		<a class="{{if .PageIsSettingsSecurity}}active{{end}} item" href="{{AppSubUrl}}/user/settings/security">
 			{{.i18n.Tr "settings.security"}}
 		</a>
+		{{if or (not DisableAccessTokens) (not DisableOAuth2)}}
 		<a class="{{if .PageIsSettingsApplications}}active{{end}} item" href="{{AppSubUrl}}/user/settings/applications">
 			{{.i18n.Tr "settings.applications"}}
 		</a>
+		{{end}}
 		<a class="{{if .PageIsSettingsKeys}}active{{end}} item" href="{{AppSubUrl}}/user/settings/keys">
 			{{.i18n.Tr "settings.ssh_gpg_keys"}}
 		</a>


### PR DESCRIPTION
Access tokens are hardcoded and cannot be disabled (i.e. when
owner doesn't want this kind of authentication).
    
This mod introduces new DISABLE_ACCESS_TOKENS parameter in app.ini
section [security]. When disabled (default when parameter is not
present) gitea behaves as without this mod (access tokens feature
is available). When enabled, access tokens feature and its UI
elements are not avaiable.
    
This mod also hides those areas on Settings/Applications page
that are disabled in config and hides menu link to Applications
page if all its areas are disabled in config.
    
Related: https://github.com/go-gitea/gitea/pull/13129
Author-Change-Id: IB#1115254
