### PR TITLE
Disable unnecessary OpenID/OAuth2 elements

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -277,15 +277,9 @@ func RegisterRoutes(m *web.Route) {
 			m.Get("/{provider}", auth.SignInOAuth)
 			m.Get("/{provider}/callback", auth.SignInOAuthCallback)
 		})
-		m.Group("/link_account", func() {
-			m.Get("", auth.LinkAccount)
-		}, openIDSignInEnabled)
-		m.Group("/link_account_signin", func() {
-			m.Post("", bindIgnErr(forms.SignInForm{}), auth.LinkAccountPostSignIn)
-		}, openIDSignInEnabled)
-		m.Group("/link_account_signup", func() {
-			m.Post("", bindIgnErr(forms.RegisterForm{}), auth.LinkAccountPostRegister)
-		}, openIDSignUpEnabled)
+		m.Get("/link_account", openIDSignInEnabled, auth.LinkAccount)
+		m.Post("/link_account_signin", openIDSignInEnabled, bindIgnErr(forms.SignInForm{}), auth.LinkAccountPostSignIn)
+		m.Post("/link_account_signup", openIDSignUpEnabled, bindIgnErr(forms.RegisterForm{}), auth.LinkAccountPostRegister)
 		m.Group("/two_factor", func() {
 			m.Get("", auth.TwoFactor)
 			m.Post("", bindIgnErr(forms.TwoFactorAuthForm{}), auth.TwoFactorPost)
@@ -348,9 +342,7 @@ func RegisterRoutes(m *web.Route) {
 				m.Post("/delete", security.DeleteOpenID)
 				m.Post("/toggle_visibility", security.ToggleOpenIDVisibility)
 			}, openIDSignInEnabled)
-			m.Group("/account_link", func() {
-				m.Post("", security.DeleteAccountLink)
-			}, openIDSignInEnabled)
+			m.Post("/account_link", openIDSignInEnabled, security.DeleteAccountLink)
 		})
 		m.Group("/applications/oauth2", func() {
 			m.Get("/{id}", user_setting.OAuth2ApplicationShow)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -277,9 +277,15 @@ func RegisterRoutes(m *web.Route) {
 			m.Get("/{provider}", auth.SignInOAuth)
 			m.Get("/{provider}/callback", auth.SignInOAuthCallback)
 		})
-		m.Get("/link_account", auth.LinkAccount)
-		m.Post("/link_account_signin", bindIgnErr(forms.SignInForm{}), auth.LinkAccountPostSignIn)
-		m.Post("/link_account_signup", bindIgnErr(forms.RegisterForm{}), auth.LinkAccountPostRegister)
+		m.Group("/link_account", func() {
+			m.Get("", auth.LinkAccount)
+		}, openIDSignInEnabled)
+		m.Group("/link_account_signin", func() {
+			m.Post("", bindIgnErr(forms.SignInForm{}), auth.LinkAccountPostSignIn)
+		}, openIDSignInEnabled)
+		m.Group("/link_account_signup", func() {
+			m.Post("", bindIgnErr(forms.RegisterForm{}), auth.LinkAccountPostRegister)
+		}, openIDSignUpEnabled)
 		m.Group("/two_factor", func() {
 			m.Get("", auth.TwoFactor)
 			m.Post("", bindIgnErr(forms.TwoFactorAuthForm{}), auth.TwoFactorPost)
@@ -342,7 +348,9 @@ func RegisterRoutes(m *web.Route) {
 				m.Post("/delete", security.DeleteOpenID)
 				m.Post("/toggle_visibility", security.ToggleOpenIDVisibility)
 			}, openIDSignInEnabled)
-			m.Post("/account_link", security.DeleteAccountLink)
+			m.Group("/account_link", func() {
+				m.Post("", security.DeleteAccountLink)
+			}, openIDSignInEnabled)
 		})
 		m.Group("/applications/oauth2", func() {
 			m.Get("/{id}", user_setting.OAuth2ApplicationShow)


### PR DESCRIPTION
This mod fixes disabling unnecessary OpenID/OAuth2 elements.

Related: https://github.com/go-gitea/gitea/pull/13129
Author-Change-Id: IB#1115256
