### PR TITLE
Prevent NPE on partial match of compare URL (part 2) (#18490)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -945,6 +945,9 @@ func comparePatternProcessor(ctx *RenderContext, node *html.Node) {
 		}
 
 		// Ensure that every group (m[0]...m[7]) has a match
+		if len(m) < 8 {
+			return
+		}
 		for i := 0; i < 8; i++ {
 			if m[i] == -1 {
 				return
@@ -957,7 +960,7 @@ func comparePatternProcessor(ctx *RenderContext, node *html.Node) {
 		text2 := base.ShortSha(node.Data[m[6]:m[7]])
 
 		hash := ""
-		if m[9] > 0 {
+		if len(m) > 9 && m[9] > 0 {
 			hash = node.Data[m[8]:m[9]][1:]
 		}
 


### PR DESCRIPTION
Backport #18490

Unfortunately #18472 only fixed part of the ways a nil pointer can occur in the
compare url. We also need to ensure that the match array has all the matches present.

Fix #18471
Related #18472

Signed-off-by: Andrew Thornton <art27@cantab.net>
