### PR TITLE
Fix for AvatarURL database type (#18487)

### DIFF
--- a/models/user/external_login_user.go
+++ b/models/user/external_login_user.go
@@ -60,7 +60,7 @@ type ExternalLoginUser struct {
 	LastName          string
 	NickName          string
 	Description       string
-	AvatarURL         string
+	AvatarURL         string `xorm:"TEXT"`
 	Location          string
 	AccessToken       string `xorm:"TEXT"`
 	AccessTokenSecret string `xorm:"TEXT"`


### PR DESCRIPTION
Backport #18487

Some oauth2 providers may give very long avatar urls (i.e. Google). We already have database migration for this (v179), but we also need to specify proper type for xorm. At least database dump is broken without proper xorm tag.