### PR TITLE
Update 1.16.0 changelog to set #17846 as breaking (#18533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 * BREAKING
   * Remove golang vendored directory (#18277)
   * Paginate releases page & set default page size to 10 (#16857)
+  * Use shadowing script for docker (#17846)
   * Only allow webhook to send requests to allowed hosts (#17482)
 * SECURITY
   * Disable content sniffing on `PlainTextBytes` (#18359) (#18365)
@@ -307,7 +308,6 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 * BUILD
   * Add lockfile-check (#18285)
   * Don't store assets modified time into generated files (#18193)
-  * Use shadowing script for docker (#17846)
 * MISC
   * Update JS dependencies (#17611)
 


### PR DESCRIPTION
Backport #18533

Unfortunately #17846 was determined to be breaking due to affecting ssh passthrough
however, this discovery happened after the changelog was created. Update the
Changelog to mark this as breaking.

Signed-off-by: Andrew Thornton <art27@cantab.net>
