### PR TITLE
In docker rootless use $GITEA_APP_INI if provided (#18524)

### DIFF
--- a/docker/rootless/usr/local/bin/gitea
+++ b/docker/rootless/usr/local/bin/gitea
@@ -32,7 +32,7 @@ for i in "$@"; do
 done
 
 if [ -z "$APP_INI_SET" ]; then
-	CONF_ARG="-c \"$APP_INI\""
+	CONF_ARG="-c \"${GITEA_APP_INI:-$APP_INI}\""
 fi
 
 


### PR DESCRIPTION
Currently when calling `gitea` from any shell in rootless docker image it won't respect my `$GITEA_APP_INI`. Which this change it will use that value when defined instead of the default value.

- https://discourse.gitea.io/t/gitea-1-16-0-unable-to-find-configuration-file/4543
- https://gitea.com/gitea/helm-chart/issues/287
