### PR TITLE
Collaborator trust model should trust collaborators (#18539)

### DIFF
--- a/models/commit.go
+++ b/models/commit.go
@@ -18,7 +18,7 @@ func ConvertFromGitCommit(commits []*git.Commit, repo *repo_model.Repository) []
 			user_model.ValidateCommitsWithEmails(commits),
 			repo.GetTrustModel(),
 			func(user *user_model.User) (bool, error) {
-				return IsUserRepoAdmin(repo, user)
+				return IsOwnerMemberCollaborator(repo, user.ID)
 			},
 		),
 		repo,

--- a/modules/gitgraph/graph_models.go
+++ b/modules/gitgraph/graph_models.go
@@ -117,7 +117,7 @@ func (graph *Graph) LoadAndProcessCommits(repository *repo_model.Repository, git
 		c.Verification = asymkey_model.ParseCommitWithSignature(c.Commit)
 
 		_ = asymkey_model.CalculateTrustStatus(c.Verification, repository.GetTrustModel(), func(user *user_model.User) (bool, error) {
-			return models.IsUserRepoAdmin(repository, user)
+			return models.IsOwnerMemberCollaborator(repository, user.ID)
 		}, &keyMap)
 
 		statuses, _, err := models.GetLatestCommitStatus(repository.ID, c.Commit.ID.String(), db.ListOptions{})

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -351,7 +351,7 @@ func Diff(ctx *context.Context) {
 	ctx.Data["DiffNotAvailable"] = diff.NumFiles == 0
 
 	if err := asymkey_model.CalculateTrustStatus(verification, ctx.Repo.Repository.GetTrustModel(), func(user *user_model.User) (bool, error) {
-		return models.IsUserRepoAdmin(ctx.Repo.Repository, user)
+		return models.IsOwnerMemberCollaborator(ctx.Repo.Repository, user.ID)
 	}, nil); err != nil {
 		ctx.ServerError("CalculateTrustStatus", err)
 		return

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -800,7 +800,7 @@ func renderDirectoryFiles(ctx *context.Context, timeout time.Duration) git.Entri
 		verification := asymkey_model.ParseCommitWithSignature(latestCommit)
 
 		if err := asymkey_model.CalculateTrustStatus(verification, ctx.Repo.Repository.GetTrustModel(), func(user *user_model.User) (bool, error) {
-			return models.IsUserRepoAdmin(ctx.Repo.Repository, user)
+			return models.IsOwnerMemberCollaborator(ctx.Repo.Repository, user.ID)
 		}, nil); err != nil {
 			ctx.ServerError("CalculateTrustStatus", err)
 			return nil


### PR DESCRIPTION
Backport #18539

There was an unintended regression in #17917 which leads to only
repository admin commits being trusted. This PR restores the old logic.

Fix #18501

Signed-off-by: Andrew Thornton <art27@cantab.net>
