### PR TITLE
Prevent panic on prohibited user login with oauth2

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -822,7 +822,7 @@ func SignInOAuthCallback(ctx *context.Context) {
 	u, gothUser, err := oAuth2UserLoginCallback(authSource, ctx.Req, ctx.Resp)
 	if err != nil {
 		if user_model.IsErrUserProhibitLogin(err) {
-			uplerr := err.(*user_model.ErrUserProhibitLogin)
+			uplerr := err.(user_model.ErrUserProhibitLogin)
 			log.Info("Failed authentication attempt for %s from %s: %v", uplerr.Name, ctx.RemoteAddr(), err)
 			ctx.Data["Title"] = ctx.Tr("auth.prohibit_login")
 			ctx.HTML(http.StatusOK, "user/auth/prohibit_login")


### PR DESCRIPTION
There was an unfortunate regression in #17962 where following detection of the
UserProhibitLogin error the err is cast to a pointer by mistake.

This causes a panic due to an interface error.

Fix #18561

Signed-off-by: Andrew Thornton <art27@cantab.net>
