### PR TITLE
Update .gitattributes for .tmpl files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 * text=auto eol=lf
-/vendor/** -text -eol linguist-vendored
-/public/vendor/** -text -eol linguist-vendored
-/web_src/js/vendor/** -text -eol linguist-vendored
-/templates/**/*.tmpl linguist-language=Handlebars
+*.tmpl linguist-language=Handlebars
 /.eslintrc linguist-language=YAML
 /.stylelintrc linguist-language=YAML
+/public/vendor/** -text -eol linguist-vendored
+/vendor/** -text -eol linguist-vendored
 /web_src/fomantic/build/** linguist-generated
+/web_src/js/vendor/** -text -eol linguist-vendored
 Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
There are a few .tmpl files outside the templates directory. Match these as well by using `*.tmpl` glob in `.gitattributes`. Also, sort the file alphabetically.