### PR TITLE
Fix pushing to 1-x-dev docker tag (#18578)

### DIFF
--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,9 +1,4 @@
-# tag: {{build.tag}}
-# commit: {{build.commit}}
-# ref: {{build.ref}}
-# branch: {{build.branch}}
-#
-image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}-rootless
+image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-rootless
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -13,12 +8,12 @@ tags:
 {{/if}}
 manifests:
   -
-    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}-linux-amd64-rootless
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-linux-amd64-rootless
     platform:
       architecture: amd64
       os: linux
   -
-    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}-linux-arm64-rootless
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-linux-arm64-rootless
     platform:
       architecture: arm64
       os: linux

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,9 +1,4 @@
-# tag: {{build.tag}}
-# commit: {{build.commit}}
-# ref: {{build.ref}}
-# branch: {{build.branch}}
-#
-image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}
+image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -12,12 +7,12 @@ tags:
 {{/if}}
 manifests:
   -
-    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}-linux-amd64
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#equal build.ref "refs/heads/main"}}dev{{else}}{{trimPrefix "refs/heads/release/v" build.ref}}-dev{{/equal}}{{/if}}-linux-arm64
+    image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
Backport #18578

It appears that #18551 and #18573 have a mistake in that raymond does not have
an {{else}} on {{#equal}}. This PR notes that Sprig has a hasPrefix function
and so we use this with another if.

Signed-off-by: Andrew Thornton <art27@cantab.net>
