### PR TITLE
Replace `sync.Map` with normal maps

### DIFF
--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -58,6 +58,7 @@ func NewGiteaLocalUploader(ctx context.Context, doer *user_model.User, repoOwner
 		doer:        doer,
 		repoOwner:   repoOwner,
 		repoName:    repoName,
+		labels:      make(map[string]*models.Label),
 		milestones:  make(map[string]int64),
 		issues:      make(map[int64]*models.Issue),
 		prHeadCache: make(map[string]struct{}),


### PR DESCRIPTION
- These maps aren't being used in any kind of concurrent read/write and thus don't need `sync.Map` and can instead use normal maps.
- Special thanks to dachary.
- Added in: https://github.com/go-gitea/gitea/pull/6290

