### PR TITLE
Only attempt to flush queue if the underlying worker pool is not finished

### DIFF
--- a/modules/queue/manager.go
+++ b/modules/queue/manager.go
@@ -84,7 +84,7 @@ type ManagedPool interface {
 	BoostWorkers() int
 	// SetPoolSettings sets the user updatable settings for the pool
 	SetPoolSettings(maxNumberOfWorkers, boostWorkers int, timeout time.Duration)
-	// Done returns a channel that will be closed when this Pool's baseCtx is closed
+	// Done returns a channel that will be closed when the Pool's baseCtx is closed
 	Done() <-chan struct{}
 }
 
@@ -214,7 +214,7 @@ func (m *Manager) FlushAll(baseCtx context.Context, timeout time.Duration) error
 				}
 			}
 			if pool, ok := mq.Managed.(ManagedPool); ok {
-				// no point flushing pools were their base ctx is already done
+				// No point into flushing pools when their base's ctx is already done.
 				select {
 				case <-pool.Done():
 					wg.Done()

--- a/modules/queue/workerpool.go
+++ b/modules/queue/workerpool.go
@@ -74,6 +74,11 @@ func NewWorkerPool(handle HandlerFunc, config WorkerPoolConfiguration) *WorkerPo
 	return pool
 }
 
+// Done returns when this worker pool's base context has been cancelled
+func (p *WorkerPool) Done() <-chan struct{} {
+	return p.baseCtx.Done()
+}
+
 // Push pushes the data to the internal channel
 func (p *WorkerPool) Push(data Data) {
 	atomic.AddInt64(&p.numInQueue, 1)


### PR DESCRIPTION
There is a possible race whereby a worker pool could be cancelled but yet the
underlying queue is not empty. This will lead to flush-all cycling because it
cannot empty the pool.

The solution here is to add another function to the managed pools which will allow testing if the managed pool has been finished before attempting to flush.

Signed-off-by: Andrew Thornton <art27@cantab.net>

