### PR TITLE
SignIn form disabled when reverse proxy auth is enabled

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -240,6 +240,9 @@ func NewFuncMap() []template.FuncMap {
 		"DisableImportLocal": func() bool {
 			return !setting.ImportLocalPaths
 		},
+		"DisableReverseProxyAuth": func() bool {
+			return !setting.Service.EnableReverseProxyAuth
+		},
 		"Dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {
 				return nil, errors.New("invalid dict call")

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -225,7 +225,7 @@ func RegisterRoutes(m *web.Route) {
 		}
 	}
 
-	// reverseProxyAuthDisabled rquires reverse proxy authentication to be disabled by admin.
+	// reverseProxyAuthDisabled requires reverse proxy authentication to be disabled by admin.
 	reverseProxyAuthDisabled := func(ctx *context.Context) {
 		if setting.Service.EnableReverseProxyAuth {
 			ctx.Error(http.StatusForbidden)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -225,6 +225,14 @@ func RegisterRoutes(m *web.Route) {
 		}
 	}
 
+	// reverseProxyAuthDisabled rquires reverse proxy authentication to be disabled by admin.
+	reverseProxyAuthDisabled := func(ctx *context.Context) {
+		if setting.Service.EnableReverseProxyAuth {
+			ctx.Error(http.StatusForbidden)
+			return
+		}
+	}
+
 	// FIXME: not all routes need go through same middleware.
 	// Especially some AJAX requests, we can reduce middleware number to improve performance.
 	// Routers.
@@ -255,8 +263,8 @@ func RegisterRoutes(m *web.Route) {
 
 	// ***** START: User *****
 	m.Group("/user", func() {
-		m.Get("/login", auth.SignIn)
-		m.Post("/login", bindIgnErr(forms.SignInForm{}), auth.SignInPost)
+		m.Get("/login", reverseProxyAuthDisabled, auth.SignIn)
+		m.Post("/login", reverseProxyAuthDisabled, bindIgnErr(forms.SignInForm{}), auth.SignInPost)
 		m.Group("", func() {
 			m.Combo("/login/openid").
 				Get(auth.SignInOpenID).

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -183,7 +183,7 @@
 				</div><!-- end content avatar menu -->
 			</div><!-- end dropdown avatar menu -->
 		</div><!-- end signed user right menu -->
-	{{else}}
+	{{else if DisableReverseProxyAuth}}
 		<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">{{.i18n.Tr "help"}}</a>
 		<div class="right stackable menu">
 			{{if .ShowRegistrationButton}}


### PR DESCRIPTION
SignIn form should not be enabled when users are authenticated
with reverse proxy.

Author-Change-Id: IB#1115398
