### PR TITLE
Remove the spurious space in the .ui.right additional selector

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -5,7 +5,7 @@
     max-height: 45vh;
     max-width: 60vw;
 
-    & .ui.right {
+    &.ui.right {
       // Override `.ui.attached.header .right:not(.dropdown) height: 30px;` which would otherwise lead to
       // the status popup box having its height fixed at 30px. See https://github.com/go-gitea/gitea/issues/18498
       height: auto;


### PR DESCRIPTION
Somehow a spurious space sneaked in to #18538
this PR simply removes it.

Signed-off-by: Andrew Thornton <art27@cantab.net>
