### PR TITLE
Ensure commit-statuses box is sized correctly in headers (#18538)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -4,6 +4,13 @@
     // otherwise some part of the popup will be hidden by viewport boundary
     max-height: 45vh;
     max-width: 60vw;
+
+    & .ui.right {
+      // Override `.ui.attached.header .right:not(.dropdown) height: 30px;` which would otherwise lead to
+      // the status popup box having its height fixed at 30px. See https://github.com/go-gitea/gitea/issues/18498
+      height: auto;
+    }
+
     overflow: auto;
     padding: 0;
 

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -5,7 +5,7 @@
     max-height: 45vh;
     max-width: 60vw;
 
-    & .ui.right {
+    &.ui.right {
       // Override `.ui.attached.header .right:not(.dropdown) height: 30px;` which would otherwise lead to
       // the status popup box having its height fixed at 30px. See https://github.com/go-gitea/gitea/issues/18498
       height: auto;


### PR DESCRIPTION
  Backport #18538
  Backport #18605
    
  * Ensure commit-statuses box is sized correctly in headers
    
  When viewing commits as commits the commit-status box will be fixed at 30px in height
  due to being forced to be this size by a fomantic selector. This PR simply adds a
  few more selectors to force this to have height auto.
    
  Fix #18498
    
  Signed-off-by: Andrew Thornton <art27@cantab.net>
  Co-authored-by: wxiaoguang <wxiaoguang@gmail.com>
