### PR TITLE
Only attempt to flush queue if the underlying worker pool is not finished (#18593)

### DIFF
--- a/modules/queue/manager.go
+++ b/modules/queue/manager.go
@@ -72,7 +72,7 @@ type ManagedPool interface {
 	BoostWorkers() int
 	// SetPoolSettings sets the user updatable settings for the pool
 	SetPoolSettings(maxNumberOfWorkers, boostWorkers int, timeout time.Duration)
-	// Done returns a channel that will be closed when this Pool's baseCtx is closed
+	// Done returns a channel that will be closed when the Pool's baseCtx is closed
 	Done() <-chan struct{}
 }
 

--- a/modules/queue/manager.go
+++ b/modules/queue/manager.go
@@ -72,6 +72,8 @@ type ManagedPool interface {
 	BoostWorkers() int
 	// SetPoolSettings sets the user updatable settings for the pool
 	SetPoolSettings(maxNumberOfWorkers, boostWorkers int, timeout time.Duration)
+	// Done returns a channel that will be closed when this Pool's baseCtx is closed
+	Done() <-chan struct{}
 }
 
 // ManagedQueueList implements the sort.Interface
@@ -141,7 +143,6 @@ func (m *Manager) Remove(qid int64) {
 	delete(m.Queues, qid)
 	m.mutex.Unlock()
 	log.Trace("Queue Manager removed: QID: %d", qid)
-
 }
 
 // GetManagedQueue by qid
@@ -193,6 +194,17 @@ func (m *Manager) FlushAll(baseCtx context.Context, timeout time.Duration) error
 				wg.Done()
 				continue
 			}
+
+			if pool, ok := mq.Managed.(ManagedPool); ok {
+				// no point flushing pools were their base ctx is already done
+				select {
+				case <-pool.Done():
+					wg.Done()
+					continue
+				default:
+				}
+			}
+
 			allEmpty = false
 			if flushable, ok := mq.Managed.(Flushable); ok {
 				log.Debug("Flushing (flushable) queue: %s", mq.Name)
@@ -225,7 +237,6 @@ func (m *Manager) FlushAll(baseCtx context.Context, timeout time.Duration) error
 		wg.Wait()
 	}
 	return nil
-
 }
 
 // ManagedQueues returns the managed queues

--- a/modules/queue/manager.go
+++ b/modules/queue/manager.go
@@ -196,7 +196,7 @@ func (m *Manager) FlushAll(baseCtx context.Context, timeout time.Duration) error
 			}
 
 			if pool, ok := mq.Managed.(ManagedPool); ok {
-				// no point flushing pools were their base ctx is already done
+				// No point into flushing pools when their base's ctx is already done.
 				select {
 				case <-pool.Done():
 					wg.Done()

--- a/modules/queue/workerpool.go
+++ b/modules/queue/workerpool.go
@@ -95,7 +95,7 @@ func (p *WorkerPool) zeroBoost() {
 		boost = p.maxNumberOfWorkers - p.numberOfWorkers
 	}
 	if mq != nil {
-		log.Warn("WorkerPool: %d (for %s) has zero workers - adding %d temporary workers for %s", p.qid, mq.Name, boost, p.boostTimeout)
+		log.Debug("WorkerPool: %d (for %s) has zero workers - adding %d temporary workers for %s", p.qid, mq.Name, boost, p.boostTimeout)
 
 		start := time.Now()
 		pid := mq.RegisterWorkers(boost, start, true, start.Add(p.boostTimeout), cancel, false)
@@ -103,7 +103,7 @@ func (p *WorkerPool) zeroBoost() {
 			mq.RemoveWorkers(pid)
 		}
 	} else {
-		log.Warn("WorkerPool: %d has zero workers - adding %d temporary workers for %s", p.qid, p.boostWorkers, p.boostTimeout)
+		log.Debug("WorkerPool: %d has zero workers - adding %d temporary workers for %s", p.qid, p.boostWorkers, p.boostTimeout)
 	}
 	p.lock.Unlock()
 	p.addWorkers(ctx, cancel, boost)


### PR DESCRIPTION
Backport #18593

There is a possible race whereby a worker pool could be cancelled but yet the
underlying queue is not empty. This will lead to flush-all cycling because it
cannot empty the pool.

* On shutdown of Persistant Channel Queues close datachan and empty

Partial Backport #18415

Although we attempt to empty the datachan in queues - due to
races we are better off just closing the channel and forcibly emptying
it in shutdown.

Fix #18618

Make temporary workers warning debug instead. 

Fix #18617 

Signed-off-by: Andrew Thornton <art27@cantab.net>
