### PR TITLE
Stop logging an error when notes are not found

### DIFF
--- a/modules/git/notes_gogit.go
+++ b/modules/git/notes_gogit.go
@@ -22,6 +22,9 @@ func GetNote(ctx context.Context, repo *Repository, commitID string, note *Note)
 	log.Trace("Searching for git note corresponding to the commit %q in the repository %q", commitID, repo.Path)
 	notes, err := repo.GetCommit(NotesRef)
 	if err != nil {
+		if IsErrNotExist(err) {
+			return err
+		}
 		log.Error("Unable to get commit from ref %q. Error: %v", NotesRef, err)
 		return err
 	}

--- a/modules/git/notes_nogogit.go
+++ b/modules/git/notes_nogogit.go
@@ -21,6 +21,9 @@ func GetNote(ctx context.Context, repo *Repository, commitID string, note *Note)
 	log.Trace("Searching for git note corresponding to the commit %q in the repository %q", commitID, repo.Path)
 	notes, err := repo.GetCommit(NotesRef)
 	if err != nil {
+		if IsErrNotExist(err) {
+			return err
+		}
 		log.Error("Unable to get commit from ref %q. Error: %v", NotesRef, err)
 		return err
 	}


### PR DESCRIPTION
This is an unnecessary logging event.

Fix #18616

Signed-off-by: Andrew Thornton <art27@cantab.net>
