### PR TITLE
Comments on migrated issues/prs must link to the comment ID

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -29,7 +29,7 @@
 									{{ .OriginalAuthor }}
 								</span>
 								<span class="text grey">
-									{{$.i18n.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
+									{{$.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
 								</span>
 								<span class="text migrate">
 									({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}


### PR DESCRIPTION
Instead of the issue ID which is not a valid anchor.

![image](https://user-images.githubusercontent.com/35190819/152661741-9b7a2ce4-eafc-4cc0-b095-0ce091822964.png)
