### PR TITLE
Fix 'make fmt-check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,9 +284,8 @@ errcheck:
 	@errcheck $(GO_PACKAGES)
 
 .PHONY: fmt-check
-fmt-check:
-	# get all go files and run gitea-fmt (with gofmt) on them
-	@diff=$$($(GO) run build/code-batch-process.go gitea-fmt -s -d '{file-list}'); \
+fmt-check: fmt
+	@diff=$$(git diff $(GO_DIRS)); \
 	if [ -n "$$diff" ]; then \
 		echo "Please run 'make fmt' and commit the result:"; \
 		echo "$${diff}"; \

--- a/Makefile
+++ b/Makefile
@@ -231,13 +231,11 @@ clean:
 
 .PHONY: fmt
 fmt:
-	@echo "Running gitea-fmt(with gofmt)..."
-	@$(GO) run build/code-batch-process.go gitea-fmt -s -w '{file-list}'
-	@echo "Running gofumpt"
 	@hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GO) install mvdan.cc/gofumpt@latest; \
 	fi
-	@gofumpt -w -l -extra -lang 1.16 .
+	@echo "Running gitea-fmt (with gofumpt)..."
+	@$(GO) run build/code-batch-process.go gitea-fmt -w '{file-list}'
 
 .PHONY: vet
 vet:
@@ -284,8 +282,12 @@ errcheck:
 	@errcheck $(GO_PACKAGES)
 
 .PHONY: fmt-check
-fmt-check: fmt
-	@diff=$$(git diff $(GO_DIRS)); \
+fmt-check:
+	@hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+		$(GO) install mvdan.cc/gofumpt@latest; \
+	fi
+	# get all go files and run gitea-fmt (with gofmt) on them
+	@diff=$$($(GO) run build/code-batch-process.go gitea-fmt -d '{file-list}'); \
 	if [ -n "$$diff" ]; then \
 		echo "Please run 'make fmt' and commit the result:"; \
 		echo "$${diff}"; \

--- a/build/code-batch-process.go
+++ b/build/code-batch-process.go
@@ -229,9 +229,9 @@ func containsString(a []string, s string) bool {
 	return false
 }
 
-func giteaFormatGoImports(files []string) error {
+func giteaFormatGoImports(files []string, changedFiles, writeFile, outputDiff bool) error {
 	for _, file := range files {
-		if err := codeformat.FormatGoImports(file); err != nil {
+		if err := codeformat.FormatGoImports(file, changedFiles, writeFile, outputDiff); err != nil {
 			log.Printf("failed to format go imports: %s, err=%v", file, err)
 			return err
 		}
@@ -267,10 +267,8 @@ func main() {
 		logVerbose("batch cmd: %s %v", subCmd, substArgs)
 		switch subCmd {
 		case "gitea-fmt":
-			if containsString(subArgs, "-w") {
-				cmdErrors = append(cmdErrors, giteaFormatGoImports(files))
-			}
-			cmdErrors = append(cmdErrors, passThroughCmd("gofmt", substArgs))
+			cmdErrors = append(cmdErrors, giteaFormatGoImports(files, containsString(subArgs, "-l"), containsString(subArgs, "-w"), containsString(subArgs, "-d")))
+			cmdErrors = append(cmdErrors, passThroughCmd("gofumpt", append([]string{"-extra", "-lang", "1.16"}, substArgs...)))
 		case "misspell":
 			cmdErrors = append(cmdErrors, passThroughCmd("misspell", substArgs))
 		default:

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-version v1.3.1
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/huandu/xstrings v1.3.2
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7
 	github.com/json-iterator/go v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/services/mailer/mail_test.go
+++ b/services/mailer/mail_test.go
@@ -17,6 +17,7 @@ import (
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
`make fmt-check` did not run all commands that `make fmt` did, resulting
in missed diffs. Fix that by just depending on the `fmt` target.

Includes: https://github.com/go-gitea/gitea/pull/18633