### PR TITLE
Comments on migrated issues/prs must link to the comment ID (#18630)

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -28,7 +28,7 @@
 								{{ .OriginalAuthor }}
 							</span>
 							<span class="text grey">
-								{{$.i18n.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
+								{{$.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
 							</span>
 							<span class="text migrate">
 								({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}


### PR DESCRIPTION
Instead of the issue ID which is not a valid anchor.

Backport of https://github.com/go-gitea/gitea/pull/18630