### PR TITLE
No longer show the db-downgrade SQL in production

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -450,9 +450,12 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 
 	// Downgrading Gitea's database version not supported
 	if int(v-minDBVersion) > len(migrations) {
-		msg := fmt.Sprintf("Downgrading database version from '%d' to '%d' is not supported and may result in loss of data integrity.\nIf you really know what you're doing, execute `UPDATE version SET version=%d WHERE id=1;`\n",
-			v, minDBVersion+len(migrations), minDBVersion+len(migrations))
-		fmt.Fprint(os.Stderr, msg)
+		msg := fmt.Sprintf("Your database (migration version: %d) is for a newer Gita, you can not use the newer database for this old Gitea release (%d).", v, minDBVersion+len(migrations))
+		msg += "\nForcing setting the migration version to a lower number may result in loss of data integrity."
+		if !setting.IsProd {
+			msg += "\n" + fmt.Sprintf("If you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;\n", minDBVersion+len(migrations))
+		}
+		_, _ = fmt.Fprintln(os.Stderr, msg)
 		log.Fatal(msg)
 		return nil
 	}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -451,9 +451,9 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 	// Downgrading Gitea's database version not supported
 	if int(v-minDBVersion) > len(migrations) {
 		msg := fmt.Sprintf("Your database (migration version: %d) is for a newer Gita, you can not use the newer database for this old Gitea release (%d).", v, minDBVersion+len(migrations))
-		msg += "\nForcing setting the migration version to a lower number may result in loss of data integrity."
+		msg += "\nGitea will exit to keep your database safe and unchanged. Please use the correct Gitea release, do not change the migration version manually (incorrect manual operation may lose data)."
 		if !setting.IsProd {
-			msg += fmt.Sprintf("\nIf you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;\n", minDBVersion+len(migrations))
+			msg += fmt.Sprintf("\nIf you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;", minDBVersion+len(migrations))
 		}
 		_, _ = fmt.Fprintln(os.Stderr, msg)
 		log.Fatal(msg)

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -453,7 +453,7 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 		msg := fmt.Sprintf("Your database (migration version: %d) is for a newer Gita, you can not use the newer database for this old Gitea release (%d).", v, minDBVersion+len(migrations))
 		msg += "\nForcing setting the migration version to a lower number may result in loss of data integrity."
 		if !setting.IsProd {
-			msg += "\n" + fmt.Sprintf("If you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;\n", minDBVersion+len(migrations))
+			msg += fmt.Sprintf("\nIf you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;\n", minDBVersion+len(migrations))
 		}
 		_, _ = fmt.Fprintln(os.Stderr, msg)
 		log.Fatal(msg)


### PR DESCRIPTION
I see many users force downgrading their database from 1.16 to 1.15. 

Actually the database structure might change a lot across release, such operation is very risky.

We had better only show the downgrade SQL in development.

```
Your database (migration version: 210) is for a newer Gita, you can not use the newer database for this old Gitea release (209).
Gitea will exit to keep your database safe and unchanged. Please use the correct Gitea release, do not change the migration version manually (incorrect manual operation may lose data).
(only in development) If you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=209 WHERE id=1;
```