### PR TITLE
Backport: No longer show the db-downgrade SQL in production (#18653)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ _testmain.go
 coverage.all
 cpu.out
 
+/modules/migration/bindata.go
+/modules/migration/bindata.go.hash
 /modules/options/bindata.go
 /modules/options/bindata.go.hash
 /modules/public/bindata.go

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -450,9 +450,12 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 
 	// Downgrading Gitea's database version not supported
 	if int(v-minDBVersion) > len(migrations) {
-		msg := fmt.Sprintf("Downgrading database version from '%d' to '%d' is not supported and may result in loss of data integrity.\nIf you really know what you're doing, execute `UPDATE version SET version=%d WHERE id=1;`\n",
-			v, minDBVersion+len(migrations), minDBVersion+len(migrations))
-		fmt.Fprint(os.Stderr, msg)
+		msg := fmt.Sprintf("Your database (migration version: %d) is for a newer Gita, you can not use the newer database for this old Gitea release (%d).", v, minDBVersion+len(migrations))
+		msg += "\nGitea will exit to keep your database safe and unchanged. Please use the correct Gitea release, do not change the migration version manually (incorrect manual operation may lose data)."
+		if !setting.IsProd {
+			msg += fmt.Sprintf("\nIf you are in development and really know what you're doing, you can force changing the migration version by executing: UPDATE version SET version=%d WHERE id=1;", minDBVersion+len(migrations))
+		}
+		_, _ = fmt.Fprintln(os.Stderr, msg)
 		log.Fatal(msg)
 		return nil
 	}


### PR DESCRIPTION
Backport #18653 

and also updates the gitignore :D