### PR TITLE
Fix the missing i18n key for update checker (#18646)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2407,6 +2407,7 @@ dashboard.last_gc_pause = Last GC Pause
 dashboard.gc_times = GC Times
 dashboard.delete_old_actions = Delete all old actions from database
 dashboard.delete_old_actions.started = Delete all old actions from database started.
+dashboard.update_checker = Update checker
 
 users.user_manage_panel = User Account Management
 users.new_account = Create User Account


### PR DESCRIPTION
Backport #18646

Since 1.16 won't get new translations from crowdin, so I am not sure what's the best way to backport, maybe showing the en-US text is enough.