### PR TITLE
Prevent security failure due to bad APP_ID

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1061,11 +1061,14 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	}
 
 	// FIXME: DEPRECATED to be removed in v1.18.0
+	U2F.AppID = strings.TrimSuffix(AppURL, "/")
 	if Cfg.Section("U2F").HasKey("APP_ID") {
 		log.Error("Deprecated setting `[U2F]` `APP_ID` present. This fallback will be removed in v1.18.0")
+		U2F.AppID = Cfg.Section("U2F").Key("APP_ID").MustString(strings.TrimSuffix(AppURL, "/"))
+	} else if Cfg.Section("u2f").HasKey("APP_ID") {
+		log.Error("Deprecated setting `[u2]` `APP_ID` present. This fallback will be removed in v1.18.0")
+		U2F.AppID = Cfg.Section("u2f").Key("APP_ID").MustString(strings.TrimSuffix(AppURL, "/"))
 	}
-	sec = Cfg.Section("U2F")
-	U2F.AppID = sec.Key("APP_ID").MustString(strings.TrimSuffix(AppURL, "/"))
 }
 
 func parseAuthorizedPrincipalsAllow(values []string) ([]string, bool) {

--- a/web_src/js/features/user-auth-webauthn.js
+++ b/web_src/js/features/user-auth-webauthn.js
@@ -24,6 +24,19 @@ export function initUserAuthWebAuthn() {
         .then((credential) => {
           verifyAssertion(credential);
         }).catch((err) => {
+          // Try again... without the appid
+          if (makeAssertionOptions.publicKey.extensions && makeAssertionOptions.publicKey.extensions.appid) {
+            delete makeAssertionOptions.publicKey.extensions['appid'];
+            navigator.credentials.get({
+              publicKey: makeAssertionOptions.publicKey
+            })
+              .then((credential) => {
+                verifyAssertion(credential);
+              }).catch((err) => {
+                webAuthnError('general', err.message);
+              });
+            return;
+          }
           webAuthnError('general', err.message);
         });
     }).fail(() => {


### PR DESCRIPTION
WebAuthn may cause a security exception if the provided APP_ID is not allowed for the
current origin. Therefore we should reattempt authentication without the appid
extension.

Also we should allow [u2f] as-well as [U2F] sections.

Signed-off-by: Andrew Thornton <art27@cantab.net>
