### PR TITLE
Fix issue with docker-rootless shimming script (#18690)

### DIFF
--- a/contrib/fhs-compliant-script/gitea
+++ b/contrib/fhs-compliant-script/gitea
@@ -33,10 +33,8 @@ for i in "$@"; do
 done
 
 if [ -z "$APP_INI_SET" ]; then
-	CONF_ARG="-c \"$APP_INI\""
+	CONF_ARG=("-c" "${GITEA_APP_INI:-$APP_INI}")
 fi
 
 # Provide FHS compliant defaults
-GITEA_WORK_DIR="${GITEA_WORK_DIR:-$WORK_DIR}" exec -a "$0" "$GITEA" $CONF_ARG "$@"
-
-
+GITEA_WORK_DIR="${GITEA_WORK_DIR:-$WORK_DIR}" exec -a "$0" "$GITEA" "${CONF_ARG[@]}"  "$@"

--- a/docker/rootless/usr/local/bin/gitea
+++ b/docker/rootless/usr/local/bin/gitea
@@ -32,11 +32,9 @@ for i in "$@"; do
 done
 
 if [ -z "$APP_INI_SET" ]; then
-	CONF_ARG="-c \"${GITEA_APP_INI:-$APP_INI}\""
+	CONF_ARG=("-c" "${GITEA_APP_INI:-$APP_INI}")
 fi
 
 
 # Provide docker defaults
-GITEA_WORK_DIR="${GITEA_WORK_DIR:-$WORK_DIR}" exec -a "$0" "$GITEA" $CONF_ARG "$@"
-
-
+GITEA_WORK_DIR="${GITEA_WORK_DIR:-$WORK_DIR}" exec -a "$0" "$GITEA" "${CONF_ARG[@]}" "$@"


### PR DESCRIPTION
Backport #18690

There is a problem with the current shimming script in that it will double quote the
provided GITEA_APP_INI due to a mistake in the bash. Here we change this to use a bash array.

Fix https://gitea.com/gitea/helm-chart/issues/287

Signed-off-by: Andrew Thornton <art27@cantab.net>
