### PR TITLE
Separate the details links of commit-statuses in headers (#18661)

### DIFF
--- a/templates/repo/commit_statuses.tmpl
+++ b/templates/repo/commit_statuses.tmpl
@@ -2,11 +2,11 @@
 <div class="ui popup very wide fixed basic commit-statuses">
 	<div class="ui relaxed list divided">
 		{{range .Statuses}}
-			<div class="ui item singular-status">
+			<div class="ui item singular-status df">
 				<span>{{template "repo/commit_status" .}}</span>
-				<span class="ui">{{.Context}} <span class="text grey">{{.Description}}</span></span>
+				<span class="ui f1">{{.Context}} <span class="text grey">{{.Description}}</span></span>
 				{{if .TargetURL}}
-					<div class="ui right"><a href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{$.root.i18n.Tr "repo.pulls.status_checks_details"}}</a></div>
+					<div class="ui"><a href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{$.root.i18n.Tr "repo.pulls.status_checks_details"}}</a></div>
 				{{end}}
 			</div>
 		{{end}}


### PR DESCRIPTION
Backport #18661

Although #18538 fixes the size of the header block the details links are still
coalescing.

Here we simply display: flex these instead of using .right

Fix #18498

Signed-off-by: Andrew Thornton <art27@cantab.net>

