### PR TITLE
Always set PullRequestWorkInProgressPrefixes in PrepareViewPullInfo (#18713)

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -392,6 +392,8 @@ func PrepareMergedViewPullInfo(ctx *context.Context, issue *models.Issue) *git.C
 
 // PrepareViewPullInfo show meta information for a pull request preview page
 func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.CompareInfo {
+	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
+
 	repo := ctx.Repo.Repository
 	pull := issue.PullRequest
 
@@ -574,8 +576,6 @@ func PrepareViewPullInfo(ctx *context.Context, issue *models.Issue) *git.Compare
 	if compareInfo.HeadCommitID == compareInfo.MergeBase {
 		ctx.Data["IsNothingToCompare"] = true
 	}
-
-	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
 
 	if pull.IsWorkInProgress() {
 		ctx.Data["IsPullWorkInProgress"] = true


### PR DESCRIPTION
Backport #18713

Move setting PullRequestWorkInProgressPrefixes to the start of PrepareViewPullInfo.

Fix #18706

Signed-off-by: Andrew Thornton <art27@cantab.net>

