### PR TITLE
Fix source code line highlighting on external tracker (#18729)

### DIFF
--- a/web_src/js/features/repo-code.js
+++ b/web_src/js/features/repo-code.js
@@ -15,11 +15,14 @@ function selectRange($list, $select, $from) {
   const $issue = $('a.ref-in-new-issue');
   const $copyPermalink = $('a.copy-line-permalink');
 
-  if ($issue.length === 0 || $copyPermalink.length === 0) {
+  if ($copyPermalink.length === 0) {
     return;
   }
 
-  const updateIssueHref = function(anchor) {
+  const updateIssueHref = function (anchor) {
+    if ($issue.length === 0) {
+      return;
+    }
     let href = $issue.attr('href');
     href = `${href.replace(/%23L\d+$|%23L\d+-L\d+$/, '')}%23${anchor}`;
     $issue.attr('href', href);


### PR DESCRIPTION
Backport #18729

When the issues repo unit is disabled, or an external issue tracker is used, there is no "a.ref-in-new-issue".

Fixes #18721