### PR TITLE
Remove redundant call to UpdateRepoStats during migration (#18591)

### DIFF
--- a/models/migrate.go
+++ b/models/migrate.go
@@ -52,10 +52,6 @@ func InsertIssues(issues ...*Issue) error {
 			return err
 		}
 	}
-	err = UpdateRepoStats(ctx, issues[0].RepoID)
-	if err != nil {
-		return err
-	}
 	return committer.Commit()
 }
 
@@ -146,11 +142,6 @@ func InsertPullRequests(prs ...*PullRequest) error {
 		if _, err := sess.NoAutoTime().Insert(pr); err != nil {
 			return err
 		}
-	}
-
-	err = UpdateRepoStats(ctx, prs[0].Issue.RepoID)
-	if err != nil {
-		return err
 	}
 	return committer.Commit()
 }

--- a/models/migrate_test.go
+++ b/models/migrate_test.go
@@ -32,8 +32,9 @@ func TestMigrate_InsertMilestones(t *testing.T) {
 	unittest.CheckConsistencyFor(t, &Milestone{})
 }
 
-func assertCreateIssues(t *testing.T, reponame string, isPull bool) {
+func assertCreateIssues(t *testing.T, isPull bool) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
+	reponame := "repo1"
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{Name: reponame}).(*repo_model.Repository)
 	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID}).(*user_model.User)
 	label := unittest.AssertExistsAndLoadBean(t, &Label{ID: 1}).(*Label)
@@ -63,38 +64,14 @@ func assertCreateIssues(t *testing.T, reponame string, isPull bool) {
 
 	i := unittest.AssertExistsAndLoadBean(t, &Issue{Title: title}).(*Issue)
 	unittest.AssertExistsAndLoadBean(t, &Reaction{Type: "heart", UserID: owner.ID, IssueID: i.ID})
-
-	labelModified := unittest.AssertExistsAndLoadBean(t, &Label{ID: 1}).(*Label)
-	assert.EqualValues(t, label.NumIssues+1, labelModified.NumIssues)
-	assert.EqualValues(t, label.NumClosedIssues+1, labelModified.NumClosedIssues)
-
-	milestoneModified := unittest.AssertExistsAndLoadBean(t, &Milestone{ID: milestone.ID}).(*Milestone)
-	assert.EqualValues(t, milestone.NumIssues+1, milestoneModified.NumIssues)
-	assert.EqualValues(t, milestone.NumClosedIssues+1, milestoneModified.NumClosedIssues)
 }
 
 func TestMigrate_CreateIssuesIsPullFalse(t *testing.T) {
-	assert.NoError(t, unittest.PrepareTestDatabase())
-	reponame := "repo1"
-	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{Name: reponame}).(*repo_model.Repository)
-
-	assertCreateIssues(t, reponame, false)
-
-	repoModified := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: repo.ID}).(*repo_model.Repository)
-	assert.EqualValues(t, repo.NumIssues+1, repoModified.NumIssues)
-	assert.EqualValues(t, repo.NumClosedIssues+1, repoModified.NumClosedIssues)
+	assertCreateIssues(t, false)
 }
 
 func TestMigrate_CreateIssuesIsPullTrue(t *testing.T) {
-	assert.NoError(t, unittest.PrepareTestDatabase())
-	reponame := "repo1"
-	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{Name: reponame}).(*repo_model.Repository)
-
-	assertCreateIssues(t, reponame, true)
-
-	repoModified := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: repo.ID}).(*repo_model.Repository)
-	assert.EqualValues(t, repo.NumPulls+1, repoModified.NumPulls)
-	assert.EqualValues(t, repo.NumClosedPulls+1, repoModified.NumClosedPulls)
+	assertCreateIssues(t, true)
 }
 
 func TestMigrate_InsertIssueComments(t *testing.T) {


### PR DESCRIPTION
This backport of https://github.com/go-gitea/gitea/pull/18591 is required because the migration will fail if there are no pull request in the migrated project. A workaround is to create a pull request until this backport lands.

From the [bug report in the chat room](https://discord.com/channels/322538954119184384/322538954119184384/943805857068642334):

```
2022/02/17 09:44:01 ...ices/task/migrate.go:47:func1() [C] PANIC during runMigrateTask[6] by DoerID[1] to RepoID[6] for OwnerID[1]: runtime error: index out of range [0] with length 0

    Stacktrace: /usr/local/go/src/runtime/panic.go:90 (0x43b334)

    /go/src/code.gitea.io/gitea/models/migrate.go:151 (0x123d897)

    /go/src/code.gitea.io/gitea/services/migrations/gitea_uploader.go:586 (0x1c63178)

    /go/src/code.gitea.io/gitea/services/migrations/migrate.go:376 (0x1c78395)

    /go/src/code.gitea.io/gitea/services/migrations/migrate.go:129 (0x1c76d39)

    /go/src/code.gitea.io/gitea/services/task/migrate.go:112 (0x1d1f1b5)

    /go/src/code.gitea.io/gitea/services/task/task.go:33 (0x1d20044)

    /go/src/code.gitea.io/gitea/services/task/task.go:55 (0x1d2030f)

    /go/src/code.gitea.io/gitea/modules/queue/workerpool.go:416 (0x14a0da2)

    /go/src/code.gitea.io/gitea/modules/queue/workerpool.go:266 (0x149ff56)

    /usr/local/go/src/runtime/asm_amd64.s:1581 (0x471e40)
```