### PR TITLE
Fix login with email for ldap users

### DIFF
--- a/services/auth/signin.go
+++ b/services/auth/signin.go
@@ -64,7 +64,7 @@ func UserSignIn(username, password string) (*user_model.User, *auth.Source, erro
 			return nil, nil, smtp.ErrUnsupportedLoginType
 		}
 
-		user, err := authenticator.Authenticate(user, username, password)
+		user, err := authenticator.Authenticate(user, user.LoginName, password)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
`authenticator.Authenticate` has assume the login name is not an email, but `username` maybe an email. So when we find the user via email address, we should use `user.LoginName` instead of `username` which is an email address.