### PR TITLE
Generate coverage with sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,10 @@ bench-pgsql: integrations.pgsql.test generate-ini-pgsql
 integration-test-coverage: integrations.cover.test generate-ini-mysql
 	GITEA_ROOT="$(CURDIR)" GITEA_CONF=integrations/mysql.ini ./integrations.cover.test -test.coverprofile=integration.coverage.out
 
+.PHONY: integration-test-coverage-sqlite
+integration-test-coverage-sqlite: integrations.cover.sqlite.test generate-ini-sqlite
+	GITEA_ROOT="$(CURDIR)" GITEA_CONF=integrations/sqlite.ini ./integrations.cover.sqlite.test -test.coverprofile=integration.coverage.out
+
 integrations.mysql.test: git-check $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/integrations -o integrations.mysql.test
 
@@ -531,6 +535,9 @@ integrations.sqlite.test: git-check $(GO_SOURCES)
 
 integrations.cover.test: git-check $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/integrations -coverpkg $(shell echo $(GO_PACKAGES) | tr ' ' ',') -o integrations.cover.test
+
+integrations.cover.sqlite.test: git-check $(GO_SOURCES)
+	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/integrations -coverpkg $(shell echo $(GO_PACKAGES) | tr ' ' ',') -o integrations.cover.sqlite.test -tags '$(TEST_TAGS)'
 
 .PHONY: migrations.mysql.test
 migrations.mysql.test: $(GO_SOURCES)


### PR DESCRIPTION
Added a new make switch to generate coverage with sqlite. The usual integration test command (`test-sqlite`) uses sqlite, so there should be a corresponding coverage command.

This will generate a simple HTML coverage report:
```
make unit-test-coverage integration-test-coverage-sqlite coverage
go tool cover -html=coverage-bodged.out -o=coverage.html
```