### PR TITLE
Fix panic in EscapeReader

### DIFF
--- a/modules/charset/escape.go
+++ b/modules/charset/escape.go
@@ -74,6 +74,7 @@ readingloop:
 	for err == nil {
 		n, err = text.Read(buf[readStart:])
 		bs := buf[:n+readStart]
+		n = len(bs)
 		i := 0
 
 		for i < len(bs) {

--- a/modules/charset/escape_test.go
+++ b/modules/charset/escape_test.go
@@ -200,3 +200,12 @@ func TestEscapeControlReader(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeControlReader_panic(t *testing.T) {
+	bs := make([]byte, 0, 20479)
+	bs = append(bs, 'A')
+	for i := 0; i < 6826; i++ {
+		bs = append(bs, []byte("—")...)
+	}
+	_, _ = EscapeControlBytes(bs)
+}


### PR DESCRIPTION
There is a potential panic due to a mistaken resetting of the length parameter when
multibyte characters go over a read boundary.

Signed-off-by: Andrew Thornton <art27@cantab.net>
