### PR TITLE
do not recompute issue comment stats to speedup migration

### DIFF
--- a/models/migrate.go
+++ b/models/migrate.go
@@ -92,11 +92,6 @@ func InsertIssueComments(comments []*Comment) error {
 		return nil
 	}
 
-	issueIDs := make(map[int64]bool)
-	for _, comment := range comments {
-		issueIDs[comment.IssueID] = true
-	}
-
 	ctx, committer, err := db.TxContext()
 	if err != nil {
 		return err
@@ -118,11 +113,6 @@ func InsertIssueComments(comments []*Comment) error {
 		}
 	}
 
-	for issueID := range issueIDs {
-		if _, err := db.Exec(ctx, "UPDATE issue set num_comments = (SELECT count(*) FROM comment WHERE issue_id = ? AND `type`=?) WHERE id = ?", issueID, CommentTypeComment, issueID); err != nil {
-			return err
-		}
-	}
 	return committer.Commit()
 }
 

--- a/models/migrate_test.go
+++ b/models/migrate_test.go
@@ -95,8 +95,7 @@ func TestMigrate_InsertIssueComments(t *testing.T) {
 	err := InsertIssueComments([]*Comment{comment})
 	assert.NoError(t, err)
 
-	issueModified := unittest.AssertExistsAndLoadBean(t, &Issue{ID: 1}).(*Issue)
-	assert.EqualValues(t, issue.NumComments+1, issueModified.NumComments)
+	_ = unittest.AssertExistsAndLoadBean(t, &Issue{ID: 1}).(*Issue)
 
 	unittest.CheckConsistencyFor(t, &Issue{})
 }


### PR DESCRIPTION
The InsertIssueComments function is only for the purpose of
migration. It does not need to update the num_comment field of the
issues, it will be updated for all issues in the repository when the
gitea uploader Finish function calls UpdateRepoStats.

The InsertIssueComments function is in the models/migrate.go file
with all other functions exclusively used for migration. They are not
designed to be used in any other context
