### PR TITLE
Immediately Hammer if second kill is sent

### DIFF
--- a/modules/graceful/manager.go
+++ b/modules/graceful/manager.go
@@ -193,6 +193,7 @@ func (g *Manager) RunAtHammer(hammer func()) {
 
 func (g *Manager) doShutdown() {
 	if !g.setStateTransition(stateRunning, stateShuttingDown) {
+		g.DoImmediateHammer()
 		return
 	}
 	g.lock.Lock()

--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -168,8 +168,12 @@ func (g *Manager) DoGracefulRestart() {
 	if setting.GracefulRestartable {
 		log.Info("PID: %d. Forking...", os.Getpid())
 		err := g.doFork()
-		if err != nil && err.Error() != "another process already forked. Ignoring this one" {
-			log.Error("Error whilst forking from PID: %d : %v", os.Getpid(), err)
+		if err != nil {
+			if err.Error() == "another process already forked. Ignoring this one" {
+				g.DoImmediateHammer()
+			} else {
+				log.Error("Error whilst forking from PID: %d : %v", os.Getpid(), err)
+			}
 		}
 	} else {
 		log.Info("PID: %d. Not set restartable. Shutting down...", os.Getpid())


### PR DESCRIPTION
Currently Gitea will wait for HammerTime or nice shutdown if kill -1 or kill -2
is sent. We should just immediately hammer if there is a second kill.

Signed-off-by: Andrew Thornton <art27@cantab.net>
