### PR TITLE
Set max text height to prevent overflow

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -462,7 +462,7 @@ export function initRepoPullRequestReview() {
     (async () => {
       // the editor's height is too large in some cases, and the panel cannot be scrolled with page now because there is `.repository .diff-detail-box.sticky { position: sticky; }`
       // the temporary solution is to make the editor's height smaller (about 4 lines). GitHub also only show 4 lines for default. We can improve the UI (including Dropzone area) in future
-      await createCommentEasyMDE($reviewBox.find('textarea'), {minHeight: '80px'});
+      await createCommentEasyMDE($reviewBox.find('textarea'), {minHeight: '80px', maxHeight: 'calc(100vh - 360px)'});
       initCompImagePaste($reviewBox);
     })();
   }

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -197,6 +197,10 @@ a.blob-excerpt:hover {
   color: #fff;
 }
 
+#review-box .CodeMirror-scroll {
+  max-height: calc(100vh - 920px);
+}
+
 @media @mediaSm {
   #review-box > .menu {
     > .ui.segment {

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -197,10 +197,6 @@ a.blob-excerpt:hover {
   color: #fff;
 }
 
-#review-box .CodeMirror-scroll {
-  max-height: calc(100vh - 920px);
-}
-
 @media @mediaSm {
   #review-box > .menu {
     > .ui.segment {


### PR DESCRIPTION
Sets a max height for review text boxes to prevent a very annoying bug where users cannot access the "submit" button.

Before:
![image](https://user-images.githubusercontent.com/12700993/155253001-e1dab086-aaf3-4338-889d-6a861728274a.png)

After:
![image](https://user-images.githubusercontent.com/12700993/155253144-5b9a3547-9582-412f-867f-41a45a14a0fe.png)

Interestingly, I don't see this bug on Firefox. 