### PR TITLE
Lock gofumpt to v0.3.0 and run it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ clean:
 .PHONY: fmt
 fmt:
 	@hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GO) install mvdan.cc/gofumpt@latest; \
+		$(GO) install mvdan.cc/gofumpt@v0.3.0; \
 	fi
 	@echo "Running gitea-fmt (with gofumpt)..."
 	@$(GO) run build/code-batch-process.go gitea-fmt -w '{file-list}'
@@ -287,7 +287,7 @@ errcheck:
 .PHONY: fmt-check
 fmt-check:
 	@hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GO) install mvdan.cc/gofumpt@latest; \
+		$(GO) install mvdan.cc/gofumpt@0.3.0; \
 	fi
 	# get all go files and run gitea-fmt (with gofmt) on them
 	@diff=$$($(GO) run build/code-batch-process.go gitea-fmt -l '{file-list}'); \

--- a/models/issue_xref.go
+++ b/models/issue_xref.go
@@ -195,7 +195,8 @@ func (issue *Issue) updateCrossReferenceList(list []*crossReference, xref *cross
 
 // verifyReferencedIssue will check if the referenced issue exists, and whether the doer has permission to do what
 func (issue *Issue) verifyReferencedIssue(stdCtx context.Context, ctx *crossReferencesContext, repo *repo_model.Repository,
-	ref references.IssueReference) (*Issue, references.XRefAction, error) {
+	ref references.IssueReference,
+) (*Issue, references.XRefAction, error) {
 	refIssue := &Issue{RepoID: repo.ID, Index: ref.Index}
 	refAction := ref.Action
 	e := db.GetEngine(stdCtx)

--- a/models/migrations/v210.go
+++ b/models/migrations/v210.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/timeutil"
-	"github.com/tstranex/u2f"
 
+	"github.com/tstranex/u2f"
 	"xorm.io/xorm"
 	"xorm.io/xorm/schemas"
 )

--- a/models/migrations/v210_test.go
+++ b/models/migrations/v210_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/modules/timeutil"
+
 	"github.com/stretchr/testify/assert"
 	"xorm.io/xorm/schemas"
 )

--- a/modules/indexer/code/bleve.go
+++ b/modules/indexer/code/bleve.go
@@ -182,7 +182,8 @@ func NewBleveIndexer(indexDir string) (*BleveIndexer, bool, error) {
 }
 
 func (b *BleveIndexer) addUpdate(ctx context.Context, batchWriter git.WriteCloserError, batchReader *bufio.Reader, commitSha string,
-	update fileUpdate, repo *repo_model.Repository, batch *gitea_bleve.FlushingBatch) error {
+	update fileUpdate, repo *repo_model.Repository, batch *gitea_bleve.FlushingBatch,
+) error {
 	// Ignore vendored files in code search
 	if setting.Indexer.ExcludeVendored && analyze.IsVendor(update.Filename) {
 		return nil

--- a/modules/notification/action/action.go
+++ b/modules/notification/action/action.go
@@ -91,7 +91,8 @@ func (a *actionNotifier) NotifyIssueChangeStatus(doer *user_model.User, issue *m
 
 // NotifyCreateIssueComment notifies comment on an issue to notifiers
 func (a *actionNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	act := &models.Action{
 		ActUserID: doer.ID,
 		ActUser:   doer,

--- a/modules/notification/indexer/indexer.go
+++ b/modules/notification/indexer/indexer.go
@@ -30,7 +30,8 @@ func NewNotifier() base.Notifier {
 }
 
 func (r *indexerNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	if comment.Type == models.CommentTypeComment {
 		if issue.Comments == nil {
 			if err := issue.LoadDiscussComments(); err != nil {

--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -29,7 +29,8 @@ func NewNotifier() base.Notifier {
 }
 
 func (m *mailNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	ctx, _, finished := process.GetManager().AddContext(graceful.GetManager().HammerContext(), fmt.Sprintf("mailNotifier.NotifyCreateIssueComment Issue[%d] #%d in [%d]", issue.ID, issue.Index, issue.RepoID))
 	defer finished()
 

--- a/modules/notification/notification.go
+++ b/modules/notification/notification.go
@@ -39,7 +39,8 @@ func NewContext() {
 
 // NotifyCreateIssueComment notifies issue comment related message to notifiers
 func NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	for _, notifier := range notifiers {
 		notifier.NotifyCreateIssueComment(doer, repo, issue, comment, mentions)
 	}
@@ -201,7 +202,8 @@ func NotifyIssueChangeRef(doer *user_model.User, issue *models.Issue, oldRef str
 
 // NotifyIssueChangeLabels notifies change labels to notifiers
 func NotifyIssueChangeLabels(doer *user_model.User, issue *models.Issue,
-	addedLabels, removedLabels []*models.Label) {
+	addedLabels, removedLabels []*models.Label,
+) {
 	for _, notifier := range notifiers {
 		notifier.NotifyIssueChangeLabels(doer, issue, addedLabels, removedLabels)
 	}

--- a/modules/notification/ui/ui.go
+++ b/modules/notification/ui/ui.go
@@ -53,7 +53,8 @@ func (ns *notificationService) Run() {
 }
 
 func (ns *notificationService) NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	opts := issueNotificationOpts{
 		IssueID:              issue.ID,
 		NotificationAuthorID: doer.ID,

--- a/modules/notification/webhook/webhook.go
+++ b/modules/notification/webhook/webhook.go
@@ -424,7 +424,8 @@ func (m *webhookNotifier) NotifyUpdateComment(doer *user_model.User, c *models.C
 }
 
 func (m *webhookNotifier) NotifyCreateIssueComment(doer *user_model.User, repo *repo_model.Repository,
-	issue *models.Issue, comment *models.Comment, mentions []*user_model.User) {
+	issue *models.Issue, comment *models.Comment, mentions []*user_model.User,
+) {
 	mode, _ := models.AccessLevel(doer, repo)
 
 	var err error
@@ -498,7 +499,8 @@ func (m *webhookNotifier) NotifyDeleteComment(doer *user_model.User, comment *mo
 }
 
 func (m *webhookNotifier) NotifyIssueChangeLabels(doer *user_model.User, issue *models.Issue,
-	addedLabels, removedLabels []*models.Label) {
+	addedLabels, removedLabels []*models.Label,
+) {
 	ctx, _, finished := process.GetManager().AddContext(graceful.GetManager().HammerContext(), fmt.Sprintf("webhook.NotifyIssueChangeLabels User: %s[%d] Issue[%d] #%d in [%d]", doer.Name, doer.ID, issue.ID, issue.Index, issue.RepoID))
 	defer finished()
 

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -220,7 +220,6 @@ type GenerateRepoOption struct {
 // CreateBranchRepoOption options when creating a branch in a repository
 // swagger:model
 type CreateBranchRepoOption struct {
-
 	// Name of the branch to create
 	//
 	// required: true

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -233,7 +233,8 @@ func loadBranches(ctx *context.Context, skip, limit int) (*Branch, []*Branch, in
 
 func loadOneBranch(ctx *context.Context, rawBranch, defaultBranch *git.Branch, protectedBranches []*models.ProtectedBranch,
 	repoIDToRepo map[int64]*repo_model.Repository,
-	repoIDToGitRepo map[int64]*git.Repository) *Branch {
+	repoIDToGitRepo map[int64]*git.Repository,
+) *Branch {
 	log.Trace("loadOneBranch: '%s'", rawBranch.Name)
 
 	commit, err := rawBranch.GetCommit()

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -427,7 +427,8 @@ func SendIssueAssignedMail(issue *models.Issue, doer *user_model.User, content s
 // actionToTemplate returns the type and name of the action facing the user
 // (slightly different from models.ActionType) and the name of the template to use (based on availability)
 func actionToTemplate(issue *models.Issue, actionType models.ActionType,
-	commentType models.CommentType, reviewType models.ReviewType) (typeName, name, template string) {
+	commentType models.CommentType, reviewType models.ReviewType,
+) (typeName, name, template string) {
 	if issue.IsPull {
 		typeName = "pull"
 	} else {

--- a/services/release/release.go
+++ b/services/release/release.go
@@ -186,7 +186,8 @@ func CreateNewTag(ctx context.Context, doer *user_model.User, repo *repo_model.R
 // delAttachmentUUIDs accept a slice of attachments' uuids which will be deleted from the release
 // editAttachments accept a map of attachment uuid to new attachment name which will be updated with attachments.
 func UpdateRelease(doer *user_model.User, gitRepo *git.Repository, rel *models.Release,
-	addAttachmentUUIDs, delAttachmentUUIDs []string, editAttachments map[string]string) (err error) {
+	addAttachmentUUIDs, delAttachmentUUIDs []string, editAttachments map[string]string,
+) (err error) {
 	if rel.ID == 0 {
 		return errors.New("UpdateRelease only accepts an exist release")
 	}


### PR DESCRIPTION
We can't depend on `latest` version of gofumpt because the output will not be stable across versions. Lock it down to the [latest version](https://github.com/mvdan/gofumpt/releases/tag/v0.3.0) released yesterday and run it again.