### PR TITLE
Set is_private in fixtures

### DIFF
--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -218,6 +218,7 @@
   lower_name: repo15
   name: repo15
   is_empty: true
+  is_private: true
   status: 0
 
 -
@@ -459,6 +460,7 @@
   owner_name: user2
   lower_name: repo20
   name: repo20
+  is_private: true
   num_stars: 0
   num_forks: 0
   num_issues: 0


### PR DESCRIPTION
This PR is part of a series of PRs with the goal to set database fields to `NOT NULL DEFAULT xxx`.
Without the changes from this PR the database change-PR fails some integration tests.

With `IsPrivate` you would expect them to default to `false` in the tests but as you can see, the tests only succeed if they are set to `true`.