### PR TITLE
Update nginx reverse proxy docs

### DIFF
--- a/docs/content/doc/usage/reverse-proxies.en-us.md
+++ b/docs/content/doc/usage/reverse-proxies.en-us.md
@@ -30,6 +30,10 @@ server {
 
     location / {
         proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 ```
@@ -47,6 +51,10 @@ server {
     location /git/ { 
         # Note: Trailing slash
         proxy_pass http://localhost:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 ```


### PR DESCRIPTION
The present documentation on using nginx includes the bare minimum required ( proxy_pass). However, there are 4 more lines required to ensure gitea receives key header information. This is useful for logs 