### PR TITLE
Fix trace log to show value instead of pointers

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -290,15 +290,12 @@ func (repo *Repository) LoadUnits(ctx context.Context) (err error) {
 	}
 
 	repo.Units, err = getUnitsByRepoID(db.GetEngine(ctx), repo.ID)
-	if log.GetLevel() >= log.TRACE {
-		unitsStr := "["
-		for _, unit := range repo.Units {
-			unitsStr += unit.Type.String()
-			unitsStr += ", "
+	if log.GetLevel() == log.TRACE {
+		unitTypeStrings := make([]string, len(repo.Units))
+		for i, unit := range repo.Units {
+			unitTypeStrings[i] = unit.Type.String()
 		}
-		unitsStr = strings.TrimSuffix(unitsStr, ", ")
-		unitsStr += "]"
-		log.Trace("repo.Units: %s", unitsStr)
+		log.Trace("repo.Units, ID=%d, Types: [%s]", repo.ID, strings.Join(unitTypeStrings, ", "))
 	}
 
 	return err

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -290,7 +290,14 @@ func (repo *Repository) LoadUnits(ctx context.Context) (err error) {
 	}
 
 	repo.Units, err = getUnitsByRepoID(db.GetEngine(ctx), repo.ID)
-	log.Trace("repo.Units: %-+v", repo.Units)
+	unitsStr := "["
+	for _, unit := range repo.Units {
+		unitsStr += unit.Type.String()
+		unitsStr += ", "
+	}
+	unitsStr = strings.TrimSuffix(unitsStr, ", ")
+	unitsStr += "]"
+	log.Trace("repo.Units: %s", unitsStr)
 	return err
 }
 

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -290,7 +290,7 @@ func (repo *Repository) LoadUnits(ctx context.Context) (err error) {
 	}
 
 	repo.Units, err = getUnitsByRepoID(db.GetEngine(ctx), repo.ID)
-	if log.GetLevel() == log.TRACE {
+	if log.IsTrace() {
 		unitTypeStrings := make([]string, len(repo.Units))
 		for i, unit := range repo.Units {
 			unitTypeStrings[i] = unit.Type.String()

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -290,14 +290,17 @@ func (repo *Repository) LoadUnits(ctx context.Context) (err error) {
 	}
 
 	repo.Units, err = getUnitsByRepoID(db.GetEngine(ctx), repo.ID)
-	unitsStr := "["
-	for _, unit := range repo.Units {
-		unitsStr += unit.Type.String()
-		unitsStr += ", "
+	if log.GetLevel() >= log.TRACE {
+		unitsStr := "["
+		for _, unit := range repo.Units {
+			unitsStr += unit.Type.String()
+			unitsStr += ", "
+		}
+		unitsStr = strings.TrimSuffix(unitsStr, ", ")
+		unitsStr += "]"
+		log.Trace("repo.Units: %s", unitsStr)
 	}
-	unitsStr = strings.TrimSuffix(unitsStr, ", ")
-	unitsStr += "]"
-	log.Trace("repo.Units: %s", unitsStr)
+
 	return err
 }
 

--- a/models/repo/repo_unit.go
+++ b/models/repo/repo_unit.go
@@ -39,6 +39,7 @@ type RepoUnit struct { //revive:disable-line:exported
 	Config      convert.Conversion `xorm:"TEXT"`
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
+
 // String returns repoUnit's type.
 func (r RepoUnit) String() string {
 	return r.Type.String()

--- a/models/repo/repo_unit.go
+++ b/models/repo/repo_unit.go
@@ -40,11 +40,6 @@ type RepoUnit struct { //revive:disable-line:exported
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
 
-// String returns repoUnit's type.
-func (r RepoUnit) String() string {
-	return r.Type.String()
-}
-
 func init() {
 	db.RegisterModel(new(RepoUnit))
 }

--- a/models/repo/repo_unit.go
+++ b/models/repo/repo_unit.go
@@ -40,6 +40,10 @@ type RepoUnit struct { //revive:disable-line:exported
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
 
+func (repoUnit RepoUnit) String() string {
+	return repoUnit.Type.String()
+}
+
 func init() {
 	db.RegisterModel(new(RepoUnit))
 }

--- a/models/repo/repo_unit.go
+++ b/models/repo/repo_unit.go
@@ -39,9 +39,9 @@ type RepoUnit struct { //revive:disable-line:exported
 	Config      convert.Conversion `xorm:"TEXT"`
 	CreatedUnix timeutil.TimeStamp `xorm:"INDEX CREATED"`
 }
-
-func (repoUnit RepoUnit) String() string {
-	return repoUnit.Type.String()
+// String returns repoUnit's type.
+func (r RepoUnit) String() string {
+	return r.Type.String()
 }
 
 func init() {


### PR DESCRIPTION
- Fixes a issue with a trace of repo.Units whereby it would show the pointers.

Before:
![image](https://user-images.githubusercontent.com/25481501/155876811-036bf40e-db89-4e09-ac00-0c78ce3f5bef.png)

After:
![image](https://user-images.githubusercontent.com/25481501/155885102-16c9cf29-314b-4f32-bcee-80e332f63dec.png)
