### PR TITLE
Fix `<strong>` html in translation

### DIFF
--- a/templates/org/team/sidebar.tmpl
+++ b/templates/org/team/sidebar.tmpl
@@ -44,10 +44,10 @@
 				</ul>
 				{{if (eq .Team.AccessMode 2)}}
 					<h3>{{.i18n.Tr "org.settings.permission"}}</h3>
-					{{.i18n.Tr "org.teams.write_permission_desc"}}
+					{{.i18n.Tr "org.teams.write_permission_desc" | Str2html}}
 				{{else if (eq .Team.AccessMode 3)}}
 					<h3>{{.i18n.Tr "org.settings.permission"}}</h3>
-					{{.i18n.Tr "org.teams.admin_permission_desc"}}
+					{{.i18n.Tr "org.teams.admin_permission_desc" | Str2html}}
 				{{else}}
 					<table class="ui table">
 						<thead>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25481501/155884934-0d4b7a27-141d-4665-8304-715706e90ab5.png)

After:
![image](https://user-images.githubusercontent.com/25481501/155884922-f25e58cc-6613-4d24-89fc-04053623fb53.png)
