### PR TITLE
Ignore missing comment for user notifications

### DIFF
--- a/models/notification.go
+++ b/models/notification.go
@@ -505,7 +505,7 @@ func (nl NotificationList) LoadAttributes() (err error) {
 			return
 		}
 	}
-	return
+	return nil
 }
 
 func (nl NotificationList) getPendingRepoIDs() []int64 {

--- a/models/notification.go
+++ b/models/notification.go
@@ -498,11 +498,12 @@ func (n *Notification) APIURL() string {
 type NotificationList []*Notification
 
 // LoadAttributes load Repo Issue User and Comment if not loaded
-func (nl NotificationList) LoadAttributes() (err error) {
+func (nl NotificationList) LoadAttributes() error {
+	var err error
 	for i := 0; i < len(nl); i++ {
 		err = nl[i].LoadAttributes()
 		if err != nil && !IsErrCommentNotExist(err) {
-			return
+			return err
 		}
 	}
 	return nil

--- a/routers/api/v1/notify/repo.go
+++ b/routers/api/v1/notify/repo.go
@@ -121,7 +121,7 @@ func ListRepoNotifications(ctx *context.APIContext) {
 		return
 	}
 	err = nl.LoadAttributes()
-	if err != nil && !models.IsErrCommentNotExist(err) {
+	if err != nil {
 		ctx.InternalServerError(err)
 		return
 	}

--- a/routers/api/v1/notify/user.go
+++ b/routers/api/v1/notify/user.go
@@ -81,7 +81,7 @@ func ListNotifications(ctx *context.APIContext) {
 		return
 	}
 	err = nl.LoadAttributes()
-	if err != nil {
+	if err != nil && !models.IsErrCommentNotExist(err) {
 		ctx.InternalServerError(err)
 		return
 	}

--- a/routers/api/v1/notify/user.go
+++ b/routers/api/v1/notify/user.go
@@ -81,7 +81,7 @@ func ListNotifications(ctx *context.APIContext) {
 		return
 	}
 	err = nl.LoadAttributes()
-	if err != nil && !models.IsErrCommentNotExist(err) {
+	if err != nil {
 		ctx.InternalServerError(err)
 		return
 	}


### PR DESCRIPTION
This extends #17550 to another place, where an internal server error may occur, when a notification is pointing to a deleted comment. (In fact, this fixes the original issue in #17499, which occurred in the user notification endpoint.)

Tested and is working for me.