### PR TITLE
Send 404 on `/{org}.gpg`

### DIFF
--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -5,7 +5,9 @@
 package org
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/models/db"
@@ -23,7 +25,14 @@ const (
 
 // Home show organization home page
 func Home(ctx *context.Context) {
-	ctx.SetParams(":org", ctx.Params(":username"))
+	uname := ctx.Params(":username")
+
+	if strings.HasSuffix(uname, ".keys") || strings.HasSuffix(uname, ".gpg") {
+		ctx.NotFound("Unimplemented feature", fmt.Errorf("organisations has no keys"))
+		return
+	}
+
+	ctx.SetParams(":org", uname)
 	context.HandleOrgAssignment(ctx)
 	if ctx.Written() {
 		return

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -5,7 +5,6 @@
 package org
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -28,7 +27,7 @@ func Home(ctx *context.Context) {
 	uname := ctx.Params(":username")
 
 	if strings.HasSuffix(uname, ".keys") || strings.HasSuffix(uname, ".gpg") {
-		ctx.NotFound("Unimplemented feature", fmt.Errorf("organisations has no keys"))
+		ctx.NotFound("", nil)
 		return
 	}
 


### PR DESCRIPTION
- Organizations currently cannot have any GPG/SSH keys, so send 404 status instead of a internal server error.
- Resolves #18952
