### PR TITLE
 Fix admin user list pagination (#18957)

### DIFF
--- a/modules/context/pagination.go
+++ b/modules/context/pagination.go
@@ -55,3 +55,12 @@ func (p *Pagination) SetDefaultParams(ctx *Context) {
 	p.AddParam(ctx, "tab", "TabName")
 	p.AddParam(ctx, "t", "queryType")
 }
+
+// SetUserFilterParams sets common pagination params for user filtering, e.g. the admin userlist
+func (p *Pagination) SetUserFilterParams(ctx *Context) {
+	p.AddParamString("status_filter[is_active]", ctx.FormString("status_filter[is_active]"))
+	p.AddParamString("status_filter[is_admin]", ctx.FormString("status_filter[is_admin]"))
+	p.AddParamString("status_filter[is_restricted]", ctx.FormString("status_filter[is_restricted]"))
+	p.AddParamString("status_filter[is_2fa_enabled]", ctx.FormString("status_filter[is_2fa_enabled]"))
+	p.AddParamString("status_filter[is_prohibit_login]", ctx.FormString("status_filter[is_prohibit_login]"))
+}

--- a/routers/web/explore/user.go
+++ b/routers/web/explore/user.go
@@ -84,6 +84,7 @@ func RenderUserSearch(ctx *context.Context, opts *user_model.SearchUserOptions, 
 
 	pager := context.NewPagination(int(count), opts.PageSize, opts.Page, 5)
 	pager.SetDefaultParams(ctx)
+	pager.SetUserFilterParams(ctx)
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)


### PR DESCRIPTION
Backport #18957

The pagination in the admin user list is broken, because the filters aren't applied.

I created a new function, because I suspect that user pagination with filters might be added in other places, too.
