### PR TITLE
Add note to GPG key response if user has no keys

### DIFF
--- a/integrations/user_test.go
+++ b/integrations/user_test.go
@@ -121,6 +121,7 @@ func TestExportUserGPGKeys(t *testing.T) {
 	defer prepareTestEnv(t)()
 	// Export empty key list
 	testExportUserGPGKeys(t, "user1", `-----BEGIN PGP PUBLIC KEY BLOCK-----
+Note: This user hasn't uploaded any GPG keys.
 
 
 =twTO

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -736,6 +736,11 @@ func ShowGPGKeys(ctx *context.Context, uid int64) {
 		ctx.ServerError("ListGPGKeys", err)
 		return
 	}
+	if len(keys) == 0 {
+		ctx.NotFound("", nil)
+		return
+	}
+
 	entities := make([]*openpgp.Entity, 0)
 	failedEntitiesID := make([]string, 0)
 	for _, k := range keys {

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -736,10 +736,6 @@ func ShowGPGKeys(ctx *context.Context, uid int64) {
 		ctx.ServerError("ListGPGKeys", err)
 		return
 	}
-	if len(keys) == 0 {
-		ctx.NotFound("", nil)
-		return
-	}
 
 	entities := make([]*openpgp.Entity, 0)
 	failedEntitiesID := make([]string, 0)
@@ -760,6 +756,8 @@ func ShowGPGKeys(ctx *context.Context, uid int64) {
 	headers := make(map[string]string)
 	if len(failedEntitiesID) > 0 { // If some key need re-import to be exported
 		headers["Note"] = fmt.Sprintf("The keys with the following IDs couldn't be exported and need to be reuploaded %s", strings.Join(failedEntitiesID, ", "))
+	} else if len(entities) == 0 {
+		headers["Note"] = "This user hasn't uploaded any GPG keys."
 	}
 	writer, _ := armor.Encode(&buf, "PGP PUBLIC KEY BLOCK", headers)
 	for _, e := range entities {


### PR DESCRIPTION
~~Prevents the [invalid reponse](https://gitea.com/KN4CK3R.gpg) if there are no keys:~~
```
-----BEGIN PGP PUBLIC KEY BLOCK-----


=twTO
-----END PGP PUBLIC KEY BLOCK-----
```

~~Additional questions:~~
- ~~Should `ShowSSHKeys` do the same?~~
- ~~Is this an "api" endpoint and the response should be just the plain 404 response code instead of the html page? If yes we need to add an addition route for `/orgs/<org>.gpg` to get the same behaviour there too.~~

Adds a note if user has no keys.