### PR TITLE
Refactor admin user filter query parameters

### DIFF
--- a/models/user/search.go
+++ b/models/user/search.go
@@ -20,6 +20,7 @@ import (
 // SearchUserOptions contains the options for searching
 type SearchUserOptions struct {
 	db.ListOptions
+
 	Keyword       string
 	Type          UserType
 	UID           int64
@@ -33,6 +34,8 @@ type SearchUserOptions struct {
 	IsRestricted       util.OptionalBool
 	IsTwoFactorEnabled util.OptionalBool
 	IsProhibitLogin    util.OptionalBool
+
+	ExtraParamStrings map[string]string
 }
 
 func (opts *SearchUserOptions) toSearchQueryBase() *xorm.Session {

--- a/modules/context/pagination.go
+++ b/modules/context/pagination.go
@@ -55,12 +55,3 @@ func (p *Pagination) SetDefaultParams(ctx *Context) {
 	p.AddParam(ctx, "tab", "TabName")
 	p.AddParam(ctx, "t", "queryType")
 }
-
-// SetUserFilterParams sets common pagination params for user filtering, e.g. the admin userlist
-func (p *Pagination) SetUserFilterParams(ctx *Context) {
-	p.AddParamString("status_filter[is_active]", ctx.FormString("status_filter[is_active]"))
-	p.AddParamString("status_filter[is_admin]", ctx.FormString("status_filter[is_admin]"))
-	p.AddParamString("status_filter[is_restricted]", ctx.FormString("status_filter[is_restricted]"))
-	p.AddParamString("status_filter[is_2fa_enabled]", ctx.FormString("status_filter[is_2fa_enabled]"))
-	p.AddParamString("status_filter[is_prohibit_login]", ctx.FormString("status_filter[is_prohibit_login]"))
-}

--- a/routers/web/admin/users.go
+++ b/routers/web/admin/users.go
@@ -41,10 +41,16 @@ func Users(ctx *context.Context) {
 	ctx.Data["PageIsAdmin"] = true
 	ctx.Data["PageIsAdminUsers"] = true
 
+	extraParamStrings := map[string]string{}
 	statusFilterKeys := []string{"is_active", "is_admin", "is_restricted", "is_2fa_enabled", "is_prohibit_login"}
 	statusFilterMap := map[string]string{}
 	for _, filterKey := range statusFilterKeys {
-		statusFilterMap[filterKey] = ctx.FormString("status_filter[" + filterKey + "]")
+		paramKey := "status_filter[" + filterKey + "]"
+		paramVal := ctx.FormString(paramKey)
+		statusFilterMap[filterKey] = paramVal
+		if paramVal != "" {
+			extraParamStrings[paramKey] = paramVal
+		}
 	}
 
 	sortType := ctx.FormString("sort")
@@ -68,6 +74,7 @@ func Users(ctx *context.Context) {
 		IsRestricted:       util.OptionalBoolParse(statusFilterMap["is_restricted"]),
 		IsTwoFactorEnabled: util.OptionalBoolParse(statusFilterMap["is_2fa_enabled"]),
 		IsProhibitLogin:    util.OptionalBoolParse(statusFilterMap["is_prohibit_login"]),
+		ExtraParamStrings:  extraParamStrings,
 	}, tplUsers)
 }
 

--- a/routers/web/explore/user.go
+++ b/routers/web/explore/user.go
@@ -82,7 +82,9 @@ func RenderUserSearch(ctx *context.Context, opts *user_model.SearchUserOptions, 
 
 	pager := context.NewPagination(int(count), opts.PageSize, opts.Page, 5)
 	pager.SetDefaultParams(ctx)
-	pager.SetUserFilterParams(ctx)
+	for paramKey, paramVal := range opts.ExtraParamStrings {
+		pager.AddParamString(paramKey, paramVal)
+	}
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)


### PR DESCRIPTION
Follows 
* https://github.com/go-gitea/gitea/pull/18957

Changes:

* Only pass `status_filter` on admin page
* Use a more general method to pass query parameters, remove hard-coded keys

Fix the strange URL:

```
https://try.gitea.io/explore/users?page=3&sort=alphabetically&q=&status_filter[is_active]=&status_filter[is_admin]=&status_filter[is_restricted]=&status_filter[is_2fa_enabled]=&status_filter[is_prohibit_login]=
```

![image](https://user-images.githubusercontent.com/2114189/156295547-e1cab14e-76f4-4f1e-bebe-cdc23365722b.png)

