### PR TITLE
ssh: add redirect path to username (organisation)

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -182,10 +182,9 @@ func runServ(c *cli.Context) error {
 	rr := strings.SplitN(repoPath, "/", 2)
 	if len(rr) != 2 {
 		if len(setting.SSH.RedirectPath) > 0 {
-			redirectPath := strings.ToLower(setting.SSH.RedirectPath)
-			// Fake repoPath and we know len of rr will be 2
-			repoPath = redirectPath + "/" + repoPath
-			rr = strings.SplitN(repoPath, "/", 2)
+			rr = []string{setting.SSH.RedirectPath, repoPath}
+			// build new repoPath used in gitcmd
+			repoPath = setting.SSH.RedirectPath + "/" + repoPath
 		} else {
 			return fail("Invalid repository path", "Invalid repository path: %s", repoPath)
 		}

--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -181,7 +181,14 @@ func runServ(c *cli.Context) error {
 
 	rr := strings.SplitN(repoPath, "/", 2)
 	if len(rr) != 2 {
-		return fail("Invalid repository path", "Invalid repository path: %v", repoPath)
+		if len(setting.SSH.RedirectPath) > 0 {
+			redirectPath := strings.ToLower(setting.SSH.RedirectPath)
+			// Fake repoPath and we know len of rr will be 2
+			repoPath = redirectPath + "/" + repoPath
+			rr = strings.SplitN(repoPath, "/", 2)
+		} else {
+			return fail("Invalid repository path", "Invalid repository path: %s", repoPath)
+		}
 	}
 
 	username := strings.ToLower(rr[0])

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -171,6 +171,11 @@ RUN_MODE = ; prod
 ;; Will default to the PER_WRITE_PER_KB_TIMEOUT.
 ;SSH_PER_WRITE_PER_KB_TIMEOUT = 30s
 ;;
+;; Redirect path to username / organisation
+;; Only applicable when repository path is missing either user or organization.
+;; Useful when taking over older repository servers "gitserver:repo" -> "gitserver:redirectorg/repo"
+;SSH_REDIRECT_PATH = team22
+;;
 ;; Indicate whether to check minimum key size with corresponding type
 ;MINIMUM_KEY_SIZE_CHECK = false
 ;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -174,7 +174,7 @@ RUN_MODE = ; prod
 ;; Redirect path to username / organisation
 ;; Only applicable when repository path is missing either user or organization.
 ;; Useful when taking over older repository servers "gitserver:repo" -> "gitserver:redirectorg/repo"
-;SSH_REDIRECT_PATH = team22
+;SSH_REDIRECT_PATH =
 ;;
 ;; Indicate whether to check minimum key size with corresponding type
 ;MINIMUM_KEY_SIZE_CHECK = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -289,7 +289,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `SSH_PER_WRITE_TIMEOUT`: **30s**: Timeout for any write to the SSH connections. (Set to
   0 to disable all timeouts.)
 - `SSH_PER_WRITE_PER_KB_TIMEOUT`: **10s**: Timeout per Kb written to SSH connections.
-- `SSH_REDIRECT_PATH`: **username** or **organization**: Gitea will when interacting using git over ssh interface / bearer redirect repos wihtout username or organization prefix use this parameter to redirect such repos to configured user or orginaztion.
+- `SSH_REDIRECT_PATH`: **\<empty\>**: When interacting using git over ssh redirect repositories without username or organization prefix to specified user or organization.
 - `MINIMUM_KEY_SIZE_CHECK`: **true**: Indicate whether to check minimum key size with corresponding type.
 
 - `OFFLINE_MODE`: **false**: Disables use of CDN for static files and Gravatar for profile pictures.

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -289,6 +289,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `SSH_PER_WRITE_TIMEOUT`: **30s**: Timeout for any write to the SSH connections. (Set to
   0 to disable all timeouts.)
 - `SSH_PER_WRITE_PER_KB_TIMEOUT`: **10s**: Timeout per Kb written to SSH connections.
+- `SSH_REDIRECT_PATH`: **username** or **organization**: Gitea will when interacting using git over ssh interface / bearer redirect repos wihtout username or organization prefix use this parameter to redirect such repos to configured user or orginaztion.
 - `MINIMUM_KEY_SIZE_CHECK`: **true**: Indicate whether to check minimum key size with corresponding type.
 
 - `OFFLINE_MODE`: **false**: Disables use of CDN for static files and Gravatar for profile pictures.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -160,6 +160,7 @@ var (
 		TrustedUserCAKeysParsed               []gossh.PublicKey  `ini:"-"`
 		PerWriteTimeout                       time.Duration      `ini:"SSH_PER_WRITE_TIMEOUT"`
 		PerWritePerKbTimeout                  time.Duration      `ini:"SSH_PER_WRITE_PER_KB_TIMEOUT"`
+		RedirectPath                          string             `ini:"SSH_REDIRECT_PATH"`
 	}{
 		Disabled:                      false,
 		StartBuiltinServer:            false,
@@ -175,6 +176,7 @@ var (
 		AuthorizedKeysCommandTemplate: "{{.AppPath}} --config={{.CustomConf}} serv key-{{.Key.ID}}",
 		PerWriteTimeout:               PerWriteTimeout,
 		PerWritePerKbTimeout:          PerWritePerKbTimeout,
+		RedirectPath:                  "",
 	}
 
 	// Security settings

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -829,6 +829,9 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 		SSH.StartBuiltinServer = false
 	}
 
+	// Make sure any SSH.RedirectPath are to lowered
+	SSH.RedirectPath = strings.ToLower(SSH.RedirectPath)
+
 	trustedUserCaKeys := sec.Key("SSH_TRUSTED_USER_CA_KEYS").Strings(",")
 	for _, caKey := range trustedUserCaKeys {
 		pubKey, _, _, _, err := gossh.ParseAuthorizedKey([]byte(caKey))


### PR DESCRIPTION
Useful if taking over old repos which doesn't follow username/<repo>
schema.
Will only be added if username are missing.

In app.ini

```ini
[server]
APP_DATA_PATH    = /data/gitea
DOMAIN           = repos
SSH_DOMAIN       = repos
HTTP_PORT        = 3000
ROOT_URL         = http://localhost:3000/
DISABLE_SSH      = false
SSH_REDIRECT_PATH = org
```

`git clone gitea:stuff` → will then be redirected to org/stuff
