### PR TITLE
Fix the editor height in review box

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -462,7 +462,8 @@ export function initRepoPullRequestReview() {
     (async () => {
       // the editor's height is too large in some cases, and the panel cannot be scrolled with page now because there is `.repository .diff-detail-box.sticky { position: sticky; }`
       // the temporary solution is to make the editor's height smaller (about 4 lines). GitHub also only show 4 lines for default. We can improve the UI (including Dropzone area) in future
-      await createCommentEasyMDE($reviewBox.find('textarea'), {minHeight: '80px', maxHeight: 'calc(100vh - 360px)'});
+      // EasyMDE's options can not handle minHeight & maxHeight together correctly, we have to set max-height for .CodeMirror-scroll in CSS.
+      await createCommentEasyMDE($reviewBox.find('textarea'), {minHeight: '80px'});
       initCompImagePaste($reviewBox);
     })();
   }

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -197,6 +197,13 @@ a.blob-excerpt:hover {
   color: #fff;
 }
 
+// See the comment of createCommentEasyMDE() for the review editor
+// EasyMDE's options can not handle minHeight & maxHeight together correctly, we have to set minHeight in JS code
+#review-box .CodeMirror-scroll {
+  min-height: 80px;
+  max-height: calc(100vh - 360px);
+}
+
 @media @mediaSm {
   #review-box > .menu {
     > .ui.segment {


### PR DESCRIPTION
Fix the height problem in  https://github.com/go-gitea/gitea/pull/18862#issuecomment-1059329539

I have tested this fix.

# Screenshots

### Min-height

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/2114189/156811831-93d4d31a-1b0a-4c4c-a7b4-fafc706133d6.png">

### Max-height

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/2114189/156811889-10ae41de-c63b-45e7-9d89-21a1ed29e58b.png">
