### PR TITLE
Fix EasyMDE error when input Enter

### DIFF
--- a/web_src/js/features/comp/EasyMDE.js
+++ b/web_src/js/features/comp/EasyMDE.js
@@ -74,10 +74,10 @@ export async function createCommentEasyMDE(textarea, easyMDEOptions = {}) {
   const inputField = easyMDE.codemirror.getInputField();
   inputField.classList.add('js-quick-submit');
   easyMDE.codemirror.setOption('extraKeys', {
-    Enter: () => {
+    Enter: (cm) => {
       const tributeContainer = document.querySelector('.tribute-container');
       if (!tributeContainer || tributeContainer.style.display === 'none') {
-        return window.CodeMirror.Pass;
+        cm.execCommand('newlineAndIndent');
       }
     },
     Backspace: (cm) => {


### PR DESCRIPTION
The PR https://github.com/go-gitea/gitea/pull/18911  removes global `window.CodeMirror`, now when input Enter in EasyMDE, there is an error (`window.CodeMirror.Pass`):

```
EasyMDE.js:80 Uncaught TypeError: Cannot read properties of undefined (reading 'Pass')
    at Enter (EasyMDE.js:80:34)
    at doHandleBinding (easymde.js:8129:14)
    at easymde.js:8200:61
    at lookupKey (easymde.js:7774:26)
    at lookupKeyForEditor (easymde.js:8142:37)
    at dispatchKeyInner (easymde.js:8170:18)
    at dispatchKey (easymde.js:8166:12)
    at handleKeyBinding (easymde.js:8200:14)
    at CodeMirror.onKeyDown (easymde.js:8219:19)
    at HTMLTextAreaElement.<anonymous> (easymde.js:4928:22)
```

This PR fixes the error.