### PR TITLE
Don't show context cancelled errors in attribute reader

### DIFF
--- a/modules/git/repo_attribute.go
+++ b/modules/git/repo_attribute.go
@@ -205,7 +205,9 @@ func (c *CheckAttributeReader) Run() error {
 			return nil
 		},
 	})
-	if err != nil && c.ctx.Err() != err && err.Error() != "signal: killed" {
+	if err != nil && //                      If there is an error we need to return but:
+		c.ctx.Err() != err && //             1. We should not pass up error due to the context being cancelled
+		err.Error() != "signal: killed" { // 2. We should not pass up errors due to the program being killed
 		return fmt.Errorf("failed to run attr-check. Error: %w\nStderr: %s", err, stdErr.String())
 	}
 	return nil

--- a/modules/git/repo_attribute.go
+++ b/modules/git/repo_attribute.go
@@ -205,7 +205,7 @@ func (c *CheckAttributeReader) Run() error {
 			return nil
 		},
 	})
-	if err != nil && c.ctx.Err() != nil && err.Error() != "signal: killed" {
+	if err != nil && c.ctx.Err() != err && err.Error() != "signal: killed" {
 		return fmt.Errorf("failed to run attr-check. Error: %w\nStderr: %s", err, stdErr.String())
 	}
 	return nil

--- a/modules/git/repo_attribute.go
+++ b/modules/git/repo_attribute.go
@@ -206,7 +206,7 @@ func (c *CheckAttributeReader) Run() error {
 		},
 	})
 	if err != nil && //                      If there is an error we need to return but:
-		c.ctx.Err() != err && //             1. We should not pass up error due to the context being cancelled
+		c.ctx.Err() != err && //             1. Ignore the context error if the context is cancelled or exceeds the deadline (RunWithContext could return c.ctx.Err() which is Canceled or DeadlineExceeded)
 		err.Error() != "signal: killed" { // 2. We should not pass up errors due to the program being killed
 		return fmt.Errorf("failed to run attr-check. Error: %w\nStderr: %s", err, stdErr.String())
 	}


### PR DESCRIPTION
Fix #18997

Signed-off-by: Andrew Thornton <art27@cantab.net>
