### PR TITLE
Ensure isSSH is set whenever DISABLE_HTTP_GIT is set

### DIFF
--- a/templates/repo/clone_buttons.tmpl
+++ b/templates/repo/clone_buttons.tmpl
@@ -18,9 +18,18 @@
 		{{svg "octicon-paste"}}
 	</button>
 {{end}}
+{{if $.DisableHTTP}}
+	<script defer>
+		const httpsDisabled = true;
+	</script>
+{{else}}
+	<script defer>
+		const httpsDisabled = false;
+	</script>
+{{end}}
 {{if not (and $.DisableHTTP $.DisableSSH)}}
 	<script defer>
-		const isSSH = {{if $.DisableHTTP}}true{{else}}localStorage.getItem('repo-clone-protocol') === 'ssh'{{end}};
+		const isSSH = httpsDisabled || localStorage.getItem('repo-clone-protocol') === 'ssh';
 		const sshButton = document.getElementById('repo-clone-ssh');
 		const httpsButton = document.getElementById('repo-clone-https');
 		const input = document.getElementById('repo-clone-url');

--- a/templates/repo/clone_buttons.tmpl
+++ b/templates/repo/clone_buttons.tmpl
@@ -20,7 +20,7 @@
 {{end}}
 {{if not (and $.DisableHTTP $.DisableSSH)}}
 	<script defer>
-		const isSSH = localStorage.getItem('repo-clone-protocol') === 'ssh';
+		const isSSH = {{if $.DisableHTTP}}true{{else}}localStorage.getItem('repo-clone-protocol') === 'ssh'{{end}};
 		const sshButton = document.getElementById('repo-clone-ssh');
 		const httpsButton = document.getElementById('repo-clone-https');
 		const input = document.getElementById('repo-clone-url');


### PR DESCRIPTION
In clone_buttons.tmpl the defer block sets the javascript isSSH variable.
When DISABLE_HTTP_GIT is set we should always set this to true.

Fix #19020

Signed-off-by: Andrew Thornton <art27@cantab.net>
