### PR TITLE
Don't show context cancelled errors in attribute reader (#19006)

### DIFF
--- a/modules/git/repo_attribute.go
+++ b/modules/git/repo_attribute.go
@@ -191,7 +191,9 @@ func (c *CheckAttributeReader) Run() error {
 		}
 		return nil
 	})
-	if err != nil && c.ctx.Err() != nil && err.Error() != "signal: killed" {
+	if err != nil && //                      If there is an error we need to return but:
+		c.ctx.Err() != err && //             1. Ignore the context error if the context is cancelled or exceeds the deadline (RunWithContext could return c.ctx.Err() which is Canceled or DeadlineExceeded)
+		err.Error() != "signal: killed" { // 2. We should not pass up errors due to the program being killed
 		return fmt.Errorf("failed to run attr-check. Error: %w\nStderr: %s", err, stdErr.String())
 	}
 	return nil


### PR DESCRIPTION
Backport #19006

Fix #18997

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: wxiaoguang <wxiaoguang@gmail.com>
