### PR TITLE
Improve SyncMirrors logging

### DIFF
--- a/models/lfs.go
+++ b/models/lfs.go
@@ -193,12 +193,13 @@ func LFSAutoAssociate(metas []*LFSMetaObject, user *user_model.User, repoID int6
 		// admin can associate any LFS object to any repository, and we do not care about errors (eg: duplicated unique key),
 		// even if error occurs, it won't hurt users and won't make things worse
 		for i := range metas {
+			p := lfs.Pointer{Oid: metas[i].Oid, Size: metas[i].Size}
 			_, err = sess.Insert(&LFSMetaObject{
-				Pointer:      lfs.Pointer{Oid: metas[i].Oid, Size: metas[i].Size},
+				Pointer:      p,
 				RepositoryID: repoID,
 			})
 			if err != nil {
-				log.Warn("failed to insert LFS meta object into database, err=%v", err)
+				log.Warn("failed to insert LFS meta object %-v for repo_id: %d into database, err=%v", p, repoID, err)
 			}
 		}
 	}

--- a/modules/lfs/pointer.go
+++ b/modules/lfs/pointer.go
@@ -14,6 +14,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"code.gitea.io/gitea/modules/log"
 )
 
 const (
@@ -109,6 +111,17 @@ func (p Pointer) RelativePath() string {
 	}
 
 	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid[4:])
+}
+
+// ColorFormat provides a basic color format for a Team
+func (p Pointer) ColorFormat(s fmt.State) {
+	if p.Oid == "" && p.Size == 0 {
+		log.ColorFprintf(s, "<empty>")
+		return
+	}
+	log.ColorFprintf(s, "%s:%d",
+		log.NewColoredIDValue(p.Oid),
+		p.Size)
 }
 
 // GeneratePointer generates a pointer for arbitrary content

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -254,7 +254,7 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 		opts.Page = page
 		rels, err := models.GetReleasesByRepoID(repo.ID, opts)
 		if err != nil {
-			return fmt.Errorf("GetReleasesByRepoID: %v", err)
+			return fmt.Errorf("unable to GetReleasesByRepoID in Repo[%d:%s/%s]: %w", repo.ID, repo.OwnerName, repo.Name, err)
 		}
 		if len(rels) == 0 {
 			break
@@ -265,11 +265,11 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 			}
 			commitID, err := gitRepo.GetTagCommitID(rel.TagName)
 			if err != nil && !git.IsErrNotExist(err) {
-				return fmt.Errorf("GetTagCommitID: %s: %v", rel.TagName, err)
+				return fmt.Errorf("unable to GetTagCommitID for %q in Repo[%d:%s/%s]: %w", rel.TagName, repo.ID, repo.OwnerName, repo.Name, err)
 			}
 			if git.IsErrNotExist(err) || commitID != rel.Sha1 {
 				if err := models.PushUpdateDeleteTag(repo, rel.TagName); err != nil {
-					return fmt.Errorf("PushUpdateDeleteTag: %s: %v", rel.TagName, err)
+					return fmt.Errorf("unable to PushUpdateDeleteTag for %q in Repo[%d:%s/%s]: %w", rel.TagName, repo.ID, repo.OwnerName, repo.Name, err)
 				}
 			} else {
 				existingRelTags[strings.ToLower(rel.TagName)] = struct{}{}
@@ -278,12 +278,12 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 	}
 	tags, err := gitRepo.GetTags(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetTags: %v", err)
+		return fmt.Errorf("unable to GetTags in Repo[%d:%s/%s]: %w", repo.ID, repo.OwnerName, repo.Name, err)
 	}
 	for _, tagName := range tags {
 		if _, ok := existingRelTags[strings.ToLower(tagName)]; !ok {
 			if err := PushUpdateAddTag(repo, gitRepo, tagName); err != nil {
-				return fmt.Errorf("pushUpdateAddTag: %v", err)
+				return fmt.Errorf("unable to PushUpdateAddTag %q to Repo[%d:%s/%s]: %w", tagName, repo.ID, repo.OwnerName, repo.Name, err)
 			}
 		}
 	}
@@ -294,11 +294,11 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 func PushUpdateAddTag(repo *repo_model.Repository, gitRepo *git.Repository, tagName string) error {
 	tag, err := gitRepo.GetTag(tagName)
 	if err != nil {
-		return fmt.Errorf("GetTag: %v", err)
+		return fmt.Errorf("unable to GetTag: %w", err)
 	}
 	commit, err := tag.Commit(gitRepo)
 	if err != nil {
-		return fmt.Errorf("Commit: %v", err)
+		return fmt.Errorf("unable to get tag Commit: %w", err)
 	}
 
 	sig := tag.Tagger
@@ -315,14 +315,14 @@ func PushUpdateAddTag(repo *repo_model.Repository, gitRepo *git.Repository, tagN
 	if sig != nil {
 		author, err = user_model.GetUserByEmail(sig.Email)
 		if err != nil && !user_model.IsErrUserNotExist(err) {
-			return fmt.Errorf("GetUserByEmail: %v", err)
+			return fmt.Errorf("unable to GetUserByEmail for %q: %w", sig.Email, err)
 		}
 		createdAt = sig.When
 	}
 
 	commitsCount, err := commit.CommitsCount()
 	if err != nil {
-		return fmt.Errorf("CommitsCount: %v", err)
+		return fmt.Errorf("unable to get CommitsCount: %w", err)
 	}
 
 	rel := models.Release{
@@ -359,14 +359,14 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 			_, err := models.NewLFSMetaObject(&models.LFSMetaObject{Pointer: p, RepositoryID: repo.ID})
 			if err != nil {
-				log.Error("Error creating LFS meta object %v: %v", p, err)
+				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, p, err)
 				return err
 			}
 
 			if err := contentStore.Put(p, content); err != nil {
-				log.Error("Error storing content for LFS meta object %v: %v", p, err)
+				log.Error("Repo[%-v]: Error storing content for LFS meta object %-v: %v", repo, p, err)
 				if _, err2 := models.RemoveLFSMetaObjectByOid(repo.ID, p.Oid); err2 != nil {
-					log.Error("Error removing LFS meta object %v: %v", p, err2)
+					log.Error("Repo[%-v]: Error removing LFS meta object %-v: %v", repo, p, err2)
 				}
 				return err
 			}
@@ -386,32 +386,32 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 	for pointerBlob := range pointerChan {
 		meta, err := models.GetLFSMetaObjectByOid(repo.ID, pointerBlob.Oid)
 		if err != nil && err != models.ErrLFSObjectNotExist {
-			log.Error("Error querying LFS meta object %v: %v", pointerBlob.Pointer, err)
+			log.Error("Repo[%-v]: Error querying LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
 			return err
 		}
 		if meta != nil {
-			log.Trace("Skipping unknown LFS meta object %v", pointerBlob.Pointer)
+			log.Trace("Repo[%-v]: Skipping unknown LFS meta object %-v", repo, pointerBlob.Pointer)
 			continue
 		}
 
-		log.Trace("LFS object %v not present in repository %s", pointerBlob.Pointer, repo.FullName())
+		log.Trace("Repo[%-v]: LFS object %-v not present in repository", repo, pointerBlob.Pointer)
 
 		exist, err := contentStore.Exists(pointerBlob.Pointer)
 		if err != nil {
-			log.Error("Error checking if LFS object %v exists: %v", pointerBlob.Pointer, err)
+			log.Error("Repo[%-v]: Error checking if LFS object %-v exists: %v", repo, pointerBlob.Pointer, err)
 			return err
 		}
 
 		if exist {
-			log.Trace("LFS object %v already present; creating meta object", pointerBlob.Pointer)
+			log.Trace("Repo[%-v]: LFS object %-v already present; creating meta object", repo, pointerBlob.Pointer)
 			_, err := models.NewLFSMetaObject(&models.LFSMetaObject{Pointer: pointerBlob.Pointer, RepositoryID: repo.ID})
 			if err != nil {
-				log.Error("Error creating LFS meta object %v: %v", pointerBlob.Pointer, err)
+				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
 				return err
 			}
 		} else {
 			if setting.LFS.MaxFileSize > 0 && pointerBlob.Size > setting.LFS.MaxFileSize {
-				log.Info("LFS object %v download denied because of LFS_MAX_FILE_SIZE=%d < size %d", pointerBlob.Pointer, setting.LFS.MaxFileSize, pointerBlob.Size)
+				log.Info("Repo[%-v]: LFS object %-v download denied because of LFS_MAX_FILE_SIZE=%d < size %d", repo, pointerBlob.Pointer, setting.LFS.MaxFileSize, pointerBlob.Size)
 				continue
 			}
 
@@ -432,7 +432,7 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 	err, has := <-errChan
 	if has {
-		log.Error("Error enumerating LFS objects for repository: %v", err)
+		log.Error("Repo[%-v]: Error enumerating LFS objects for repository: %v", repo, err)
 		return err
 	}
 

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -269,7 +269,7 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 			}
 			if git.IsErrNotExist(err) || commitID != rel.Sha1 {
 				if err := models.PushUpdateDeleteTag(repo, rel.TagName); err != nil {
-					return fmt.Errorf("unable to PushUpdateDeleteTag for %q in Repo[%d:%s/%s]: %w", rel.TagName, repo.ID, repo.OwnerName, repo.Name, err)
+					return fmt.Errorf("unable to PushUpdateDeleteTag: %q in Repo[%d:%s/%s]: %w", rel.TagName, repo.ID, repo.OwnerName, repo.Name, err)
 				}
 			} else {
 				existingRelTags[strings.ToLower(rel.TagName)] = struct{}{}
@@ -283,7 +283,7 @@ func SyncReleasesWithTags(repo *repo_model.Repository, gitRepo *git.Repository) 
 	for _, tagName := range tags {
 		if _, ok := existingRelTags[strings.ToLower(tagName)]; !ok {
 			if err := PushUpdateAddTag(repo, gitRepo, tagName); err != nil {
-				return fmt.Errorf("unable to PushUpdateAddTag %q to Repo[%d:%s/%s]: %w", tagName, repo.ID, repo.OwnerName, repo.Name, err)
+				return fmt.Errorf("unable to PushUpdateAddTag: %q to Repo[%d:%s/%s]: %w", tagName, repo.ID, repo.OwnerName, repo.Name, err)
 			}
 		}
 	}


### PR DESCRIPTION
Yet another issue has come up where the logging from SyncMirrors does not provide
enough context. This PR adds more context to these logging events.

Related #19038

Signed-off-by: Andrew Thornton <art27@cantab.net>
