### PR TITLE
Add pam account authorization check (#19040)

### DIFF
--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -35,6 +35,10 @@ func Auth(serviceName, userName, passwd string) (string, error) {
 	if err = t.Authenticate(0); err != nil {
 		return "", err
 	}
+	
+	if err = t.AcctMgmt(0); err != nil {
+	  return "", err
+  }
 
 	// PAM login names might suffer transformations in the PAM stack.
 	// We should take whatever the PAM stack returns for it.


### PR DESCRIPTION
Backport #19040

The PAM module has previously only checked the results of the authentication module.

However, in normal PAM practice most users will expect account module authorization to also be checked. Without doing this check in almost every configuration expired accounts and accounts with expired passwords will still be able to login.

This is likely to represent a significant gotcha in most configurations and cause most users configurations to be potentially insecure. Therefore we should add in the account authorization check.

## :warning: **BREAKING** :warning: 

Users of the PAM module who rely on account modules not being checked will need to change their PAM configuration.

However, as it is likely that the vast majority of users of PAM will be expecting account authorization to be checked in addition to authentication we should make this breaking change to make the default behaviour correct for the majority.

---

I suggest we backport this despite the BREAKING nature because of the surprising nature of this.

Thanks to @ysf for bringing this to our attention.
Co-authored-by: ysf <34326+ysf@users.noreply.github.com>