### PR TITLE
If rendering has failed due to a net.OpError stop rendering (attempt 2) (#19049)

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -266,7 +266,7 @@ func (ctx *Context) ServerError(logMsg string, logErr error) {
 func (ctx *Context) serverErrorInternal(logMsg string, logErr error) {
 	if logErr != nil {
 		log.ErrorWithSkip(2, "%s: %v", logMsg, logErr)
-		if errors.Is(logErr, &net.OpError{}) {
+		if _, ok := logErr.(*net.OpError); ok || errors.Is(logErr, &net.OpError{}) {
 			// This is an error within the underlying connection
 			// and further rendering will not work so just return
 			return


### PR DESCRIPTION
Backport #19049

Unfortunately #18642 does not work because a `*net.OpError` does not implement
the `Is` interface to make `errors.Is` work correctly - thus leading to the
irritating conclusion that a `*net.OpError` is not a `*net.OpError`.

Here we keep the `errors.Is` because presumably this will be fixed at
some point in the golang main source code but also we add a simply type
cast to also check.

Fix #18629

Signed-off-by: Andrew Thornton <art27@cantab.net>
