### PR TITLE
Update the webauthn_credential_id_sequence in Postgres (#19048)

### DIFF
--- a/models/migrations/v210.go
+++ b/models/migrations/v210.go
@@ -174,5 +174,11 @@ func remigrateU2FCredentials(x *xorm.Engine) error {
 		regs = regs[:0]
 	}
 
+	if x.Dialect().URI().DBType == schemas.POSTGRES {
+		if _, err := x.Exec("SELECT setval('webauthn_credential_id_seq', COALESCE((SELECT MAX(id)+1 FROM `webauthn_credential`), 1), false)"); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Backport #19048

There is (yet) another problem with v210 in that Postgres will silently allow preset
ID insertions ... but it will not update the sequence value.

This PR simply adds a little step to the end of the v210 migration to update the
sequence number.

Users who have already migrated who find that they cannot insert new
webauthn_credentials into the DB can either run:

```bash
gitea doctor recreate-table webauthn_credential
```

or

```bash
SELECT setval('webauthn_credential_id_seq', COALESCE((SELECT MAX(id)+1 FROM `webauthn_credential`), 1), false)
```

which will fix the bad sequence.

Fix #19012

Signed-off-by: Andrew Thornton <art27@cantab.net>
