### PR TITLE
Fixed log path in fail2ban documentation

### DIFF
--- a/docs/content/doc/usage/fail2ban-setup.en-us.md
+++ b/docs/content/doc/usage/fail2ban-setup.en-us.md
@@ -89,7 +89,7 @@ chain in **iptables**. Configure it in `/etc/fail2ban/jail.d/gitea-docker.conf`:
 [gitea-docker]
 enabled = true
 filter = gitea
-logpath = /home/git/gitea/log/gitea.log
+logpath = /var/lib/gitea/log/gitea.log
 maxretry = 10
 findtime = 3600
 bantime = 900


### PR DESCRIPTION
This updates the log path in the [gitea-docker] jail configuration
to match the path in the [gitea] jail, which was updated in #13726.