### PR TITLE
Remove italics for `due_date_not_set`

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -424,7 +424,7 @@
 					</div>
 				</p>
 			{{else}}
-				<p><i>{{.i18n.Tr "repo.issues.due_date_not_set"}}</i></p>
+				<p>{{.i18n.Tr "repo.issues.due_date_not_set"}}</p>
 			{{end}}
 
 			{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}


### PR DESCRIPTION
To be more consistent and concise we could change the issue_no_dependencies from: `This issue currently doesn't have any dependencies. ` to `No dependencies set.` like we do for the due date and others.

![image](https://user-images.githubusercontent.com/10717998/158813057-1fd42d07-dc0d-49de-a277-bf5d785ff32e.png)
