### PR TITLE
Do not send activation email if manual confirm is set

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -282,6 +282,7 @@ register_helper_msg = Already have an account? Sign in now!
 social_register_helper_msg = Already have an account? Link it now!
 disable_register_prompt = Registration is disabled. Please contact your site administrator.
 disable_register_mail = Email confirmation for registration is disabled.
+manual_activation_only = Contact your site administrator to complete activation.
 remember_me = Remember this Device
 forgot_password_title= Forgot Password
 forgot_password = Forgot password?

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -621,6 +621,12 @@ func handleUserCreated(ctx *context.Context, u *user_model.User, gothUser *goth.
 
 	// Send confirmation email
 	if !u.IsActive && u.ID > 1 {
+		if setting.Service.RegisterManualConfirm {
+			ctx.Data["ManualActivationOnly"] = true
+			ctx.HTML(http.StatusOK, TplActivate)
+			return
+		}
+
 		mailer.SendActivateAccountMail(ctx.Locale, u)
 
 		ctx.Data["IsSendRegisterMail"] = true

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -32,6 +32,8 @@
 							<p>{{.i18n.Tr "auth.confirmation_mail_sent_prompt" (.Email|Escape) .ActiveCodeLives | Str2html}}</p>
 						{{else if .IsActivateFailed}}
 							<p>{{.i18n.Tr "auth.invalid_code"}}</p>
+						{{else if .ManualActivationOnly}}
+							<p class="center">{{.i18n.Tr "auth.manual_activation_only"}}</p>
 						{{else}}
 							<p>{{.i18n.Tr "auth.has_unconfirmed_mail" (.SignedUser.Name|Escape) (.SignedUser.Email|Escape) | Str2html}}</p>
 							<div class="ui divider"></div>


### PR DESCRIPTION
If the mailer is configured then even if Manual confirm is set an activation email
is still being sent because `handleUserCreated` is not checking for this case.

Fix #17263

Signed-off-by: Andrew Thornton <art27@cantab.net>
