### PR TITLE
Do not send notification emails to inactive users (part 2)

### DIFF
--- a/services/mailer/mail_issue.go
+++ b/services/mailer/mail_issue.go
@@ -126,6 +126,10 @@ func mailIssueCommentBatch(ctx *mailCommentContext, users []*user_model.User, vi
 
 	langMap := make(map[string][]*user_model.User)
 	for _, user := range users {
+		if !user.IsActive {
+			// Exclude deactivated users
+			continue
+		}
 		// At this point we exclude:
 		// user that don't have all mails enabled or users only get mail on mention and this is one ...
 		if !(user.EmailNotificationsPreference == user_model.EmailNotificationsEnabled ||


### PR DESCRIPTION
Unfortunately fixing changes to `mail_issue.go` did not get included in #19131.

We also need to not send issue comment mails to deactivated users.

Fix #18950

Signed-off-by: Andrew Thornton <art27@cantab.net>
