### PR TITLE
Use custom favicon when viewing static files if it exists (#19130)

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -98,6 +98,11 @@ func Routes(sessioner func(http.Handler) http.Handler) *web.Route {
 		http.Redirect(w, req, path.Join(setting.StaticURLPrefix, "/assets/img/apple-touch-icon.png"), 301)
 	})
 
+	// redirect default favicon to the path of the custom favicon with a default as a fallback
+	routes.Get("/favicon.ico", func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, path.Join(setting.StaticURLPrefix, "/assets/img/favicon.png"), 301)
+	})
+
 	common := []interface{}{}
 
 	if setting.EnableGzip {


### PR DESCRIPTION
Backport #19130 

Redirect `/favicon.ico` to `/assets/img/favicon.png`.

Fix #19109
