### PR TITLE
Use subdir named gitea-version in make release-sources generated arti…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,7 @@ release-sources: | $(DIST_DIRS)
 	echo $(VERSION) > $(STORED_VERSION_FILE)
 # bsdtar needs a ^ to prevent matching subdirectories
 	$(eval EXCL := --exclude=$(shell tar --help | grep -q bsdtar && echo "^")./)
-	tar $(addprefix $(EXCL),$(TAR_EXCLUDES)) -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
+	tar $(addprefix $(EXCL),$(TAR_EXCLUDES)) --transform='flags=r;s|^\./|./gitea-$(VERSION)/|g' -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
 	rm -f $(STORED_VERSION_FILE)
 
 .PHONY: release-docs


### PR DESCRIPTION
Use `tar --transform` to  place gitea sources within a sub-directory called `gitea-${VERSION}` to prevent tar bombing.

Fix #19066

## :warning: BREAKING :warning: 

Prior to this PR the gitea src tar.gz would extract to the current directory. Users requiring the previous behaviour should use tar options as appropriate.