### PR TITLE
Fix NPE `/repos/issues/search` when not signed in

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -245,18 +245,23 @@ func SearchIssues(ctx *context.APIContext) {
 			UpdatedAfterUnix:   since,
 		}
 
+		ctxUserID := int64(0)
+		if ctx.IsSigned {
+			ctxUserID = ctx.User.ID
+		}
+
 		// Filter for: Created by User, Assigned to User, Mentioning User, Review of User Requested
 		if ctx.FormBool("created") {
-			issuesOpt.PosterID = ctx.User.ID
+			issuesOpt.PosterID = ctxUserID
 		}
 		if ctx.FormBool("assigned") {
-			issuesOpt.AssigneeID = ctx.User.ID
+			issuesOpt.AssigneeID = ctxUserID
 		}
 		if ctx.FormBool("mentioned") {
-			issuesOpt.MentionedID = ctx.User.ID
+			issuesOpt.MentionedID = ctxUserID
 		}
 		if ctx.FormBool("review_requested") {
-			issuesOpt.ReviewRequestedID = ctx.User.ID
+			issuesOpt.ReviewRequestedID = ctxUserID
 		}
 
 		if issues, err = models.Issues(issuesOpt); err != nil {


### PR DESCRIPTION
- Don't panic when on `/repos/issues/search?{created,assigned,mentioned,review_requested}=true` when client didn't pass any authentication.
- Resolves #19115

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
