### PR TITLE
Ensure that setting.LocalURL always has a trailing slash (#19171)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -92,13 +92,15 @@ var (
 	// AppDataPath is the default path for storing data.
 	// It maps to ini:"APP_DATA_PATH" and defaults to AppWorkPath + "/data"
 	AppDataPath string
+	// LocalURL is the url for locally running applications to contact Gitea. It always has a '/' suffix
+	// It maps to ini:"LOCAL_ROOT_URL"
+	LocalURL string
 
 	// Server settings
 	Protocol             Scheme
 	Domain               string
 	HTTPAddr             string
 	HTTPPort             string
-	LocalURL             string
 	RedirectOtherPort    bool
 	PortToRedirect       string
 	OfflineMode          bool
@@ -712,6 +714,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 		}
 	}
 	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(defaultLocalURL)
+	LocalURL = strings.TrimRight(LocalURL, "/") + "/"
 	RedirectOtherPort = sec.Key("REDIRECT_OTHER_PORT").MustBool(false)
 	PortToRedirect = sec.Key("PORT_TO_REDIRECT").MustString("80")
 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()


### PR DESCRIPTION
Backport #19171

Fix #19166

Signed-off-by: Andrew Thornton <art27@cantab.net>
