### PR TITLE
Fix clone url JS error for the empty repo page

### DIFF
--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -50,14 +50,17 @@ git push -u origin {{.Repository.DefaultBranch}}</code></pre>
 git push -u origin {{.Repository.DefaultBranch}}</code></pre>
 								</div>
 							</div>
-							<script defer>
-								/* eslint-disable no-undef */
-								const cloneUrls = document.getElementsByClassName('clone-url');
-								if (cloneUrls) {
-									for (let i = 0; i < cloneUrls.length; i++) {
-										cloneUrls[i].textContent = (isSSH ? sshButton : httpsButton).getAttribute('data-link');
+							<script>
+								(() => {
+									const proto = localStorage.getItem('repo-clone-protocol') || 'https';
+									const btn = document.getElementById(`repo-clone-${proto}`) || document.getElementById(`repo-clone-https`) || document.getElementById(`repo-clone-ssh`);
+									if (btn) {
+										const cloneUrls = document.getElementsByClassName('clone-url');
+										for (let i = 0; i < cloneUrls.length; i++) {
+											cloneUrls[i].textContent = btn.getAttribute('data-link');
+										}
 									}
-								}
+								})();
 							</script>
 						{{end}}
 					{{else}}


### PR DESCRIPTION
The `eslint-disable no-undef` make the lint can not find the bug .....

Now we use a stable method to do the JS work

Fix:
* #19028
* #19205
* `Uncaught ReferenceError: isSSH is not defined`, because the variables are scoped and doesn't share between sub templates.