### PR TITLE
Add auto logging of goroutine pid label

### DIFF
--- a/modules/log/groutinelabel.go
+++ b/modules/log/groutinelabel.go
@@ -7,7 +7,7 @@ package log
 import "unsafe"
 
 //go:linkname runtime_getProfLabel runtime/pprof.runtime_getProfLabel
-func runtime_getProfLabel() unsafe.Pointer
+func runtime_getProfLabel() unsafe.Pointer // nolint
 
 type labelMap map[string]string
 

--- a/modules/log/groutinelabel.go
+++ b/modules/log/groutinelabel.go
@@ -13,8 +13,8 @@ type labelMap map[string]string
 
 func getGoroutineLabels() map[string]string {
 	l := (*labelMap)(runtime_getProfLabel())
-	if l == nil || *l == nil {
-		return map[string]string{}
+	if l == nil {
+		return nil
 	}
 	return *l
 }

--- a/modules/log/groutinelabel.go
+++ b/modules/log/groutinelabel.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import "unsafe"
+
+//go:linkname runtime_getProfLabel runtime/pprof.runtime_getProfLabel
+func runtime_getProfLabel() unsafe.Pointer
+
+type labelMap map[string]string
+
+func getGoroutineLabels() map[string]string {
+	l := (*labelMap)(runtime_getProfLabel())
+	if l == nil {
+		return map[string]string{}
+	}
+	return *l
+}

--- a/modules/log/groutinelabel.go
+++ b/modules/log/groutinelabel.go
@@ -13,7 +13,7 @@ type labelMap map[string]string
 
 func getGoroutineLabels() map[string]string {
 	l := (*labelMap)(runtime_getProfLabel())
-	if l == nil {
+	if l == nil || *l == nil {
 		return map[string]string{}
 	}
 	return *l

--- a/modules/log/groutinelabel_test.go
+++ b/modules/log/groutinelabel_test.go
@@ -26,7 +26,9 @@ func Test_getGoroutineLabels(t *testing.T) {
 				assert.EqualValues(t, value, currentLabels[key])
 				return true
 			})
-			assert.EqualValues(t, "Test_getGoroutineLabels_child1", currentLabels["Test_getGoroutineLabels"])
+			if assert.NotNil(t, currentLabels) {
+				assert.EqualValues(t, "Test_getGoroutineLabels_child1", currentLabels["Test_getGoroutineLabels"])
+			}
 		})
 	})
 }

--- a/modules/log/groutinelabel_test.go
+++ b/modules/log/groutinelabel_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"context"
+	"runtime/pprof"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getGoroutineLabels(t *testing.T) {
+	pprof.Do(context.Background(), pprof.Labels(), func(ctx context.Context) {
+		currentLabels := getGoroutineLabels()
+		pprof.ForLabels(ctx, func(key, value string) bool {
+			assert.EqualValues(t, value, currentLabels[key])
+			return true
+		})
+
+		pprof.Do(ctx, pprof.Labels("Test_getGoroutineLabels", "Test_getGoroutineLabels_child1"), func(ctx context.Context) {
+			currentLabels := getGoroutineLabels()
+			pprof.ForLabels(ctx, func(key, value string) bool {
+				assert.EqualValues(t, value, currentLabels[key])
+				return true
+			})
+			assert.EqualValues(t, "Test_getGoroutineLabels_child1", currentLabels["Test_getGoroutineLabels"])
+		})
+	})
+}

--- a/modules/log/multichannel.go
+++ b/modules/log/multichannel.go
@@ -72,6 +72,13 @@ func (l *MultiChannelledLogger) Log(skip int, level Level, format string, v ...i
 	if len(v) > 0 {
 		msg = ColorSprintf(format, v...)
 	}
+	labels := getGoroutineLabels()
+	if labels != nil {
+		pid, ok := labels["pid"]
+		if ok {
+			msg = "[" + ColorString(FgHiYellow) + pid + ColorString(Reset) + "] " + msg
+		}
+	}
 	stack := ""
 	if l.GetStacktraceLevel() <= level {
 		stack = Stack(skip + 1)


### PR DESCRIPTION
This PR uses `unsafe` to export the hidden `runtime_getProfLabel` function from the
`runtime` package and then casts the result to a `map[string]string`.

We can then interrogate this map to get the `pid` label from the goroutine allowing
us to log it with any logging request.

Reference #19202

Signed-off-by: Andrew Thornton <art27@cantab.net>
