### PR TITLE
Touch mirrors on even on fail to update

### DIFF
--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -113,6 +113,17 @@ func UpdateMirror(m *Mirror) error {
 	return updateMirror(db.GetEngine(db.DefaultContext), m)
 }
 
+func touchMirror(e db.Engine, m *Mirror) error {
+	m.UpdatedUnix = timeutil.TimeStampNow()
+	_, err := e.ID(m.ID).Cols("updated_unix").Update(m)
+	return err
+}
+
+// TouchMirror updates the mirror updatedUnix
+func TouchMirror(m *Mirror) error {
+	return touchMirror(db.GetEngine(db.DefaultContext), m)
+}
+
 // DeleteMirrorByRepoID deletes a mirror by repoID
 func DeleteMirrorByRepoID(repoID int64) error {
 	_, err := db.GetEngine(db.DefaultContext).Delete(&Mirror{RepoID: repoID})

--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -6,6 +6,7 @@
 package repo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -113,15 +114,11 @@ func UpdateMirror(m *Mirror) error {
 	return updateMirror(db.GetEngine(db.DefaultContext), m)
 }
 
-func touchMirror(e db.Engine, m *Mirror) error {
-	m.UpdatedUnix = timeutil.TimeStampNow()
-	_, err := e.ID(m.ID).Cols("updated_unix").Update(m)
-	return err
-}
-
 // TouchMirror updates the mirror updatedUnix
-func TouchMirror(m *Mirror) error {
-	return touchMirror(db.GetEngine(db.DefaultContext), m)
+func TouchMirror(ctx context.Context, m *Mirror) error {
+	m.UpdatedUnix = timeutil.TimeStampNow()
+	_, err := db.GetEngine(ctx).ID(m.ID).Cols("updated_unix").Update(m)
+	return err
 }
 
 // DeleteMirrorByRepoID deletes a mirror by repoID

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -401,7 +401,6 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 	if !ok {
 		if err = repo_model.TouchMirror(ctx, m); err != nil {
 			log.Error("SyncMirrors [repo: %-v]: failed to TouchMirror: %v", m.Repo, err)
-			return false
 		}
 		return false
 	}

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -399,7 +399,7 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 	log.Trace("SyncMirrors [repo: %-v]: Running Sync", m.Repo)
 	results, ok := runSync(ctx, m)
 	if !ok {
-		if err = repo_model.TouchMirror(m); err != nil {
+		if err = repo_model.TouchMirror(ctx, m); err != nil {
 			log.Error("SyncMirrors [repo: %-v]: failed to TouchMirror: %v", m.Repo, err)
 			return false
 		}

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -399,6 +399,10 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 	log.Trace("SyncMirrors [repo: %-v]: Running Sync", m.Repo)
 	results, ok := runSync(ctx, m)
 	if !ok {
+		if err = repo_model.TouchMirror(m); err != nil {
+			log.Error("SyncMirrors [repo: %-v]: failed to TouchMirror: %v", m.Repo, err)
+			return false
+		}
 		return false
 	}
 


### PR DESCRIPTION
If a mirror fails to be synchronised it should be pushed to the bottom of the queue
of the awaiting mirrors to be synchronised. At present if there LIMIT number of
broken mirrors they can effectively prevent all other mirrors from being synchronized
as their last_updated time will remain earlier than other mirrors.

Signed-off-by: Andrew Thornton <art27@cantab.net>
