### PR TITLE
Make cron task no notice on success

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1752,7 +1752,7 @@ PATH =
 ;ENABLED = true
 ;; Whether to always run at least once at start up time (if ENABLED)
 ;RUN_AT_START = true
-;; Notice if not success
+;; Whether to emit notice on successful execution too
 ;NOTICE_ON_SUCCESS = false
 ;; Time interval for job to run
 ;SCHEDULE = @midnight

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1753,7 +1753,7 @@ PATH =
 ;; Whether to always run at least once at start up time (if ENABLED)
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Time interval for job to run
 ;SCHEDULE = @midnight
 ;; Archives created more than OLDER_THAN ago are subject to deletion
@@ -1772,7 +1772,7 @@ PATH =
 ;; Run Update mirrors task when Gitea starts.
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = true
+;NOTICE_ON_SUCCESS = false
 ;; Limit the number of mirrors added to the queue to this number
 ;; (negative values mean no limit, 0 will result in no result in no mirrors being queued effectively disabling pull mirror updating.)
 ;PULL_LIMIT=50
@@ -1793,7 +1793,7 @@ PATH =
 ;; Run Repository health check task when Gitea starts.
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;TIMEOUT = 60s
 ;; Arguments for command 'git fsck', e.g. "--unreachable --tags"
 ;; see more on http://git-scm.com/docs/git-fsck
@@ -1811,7 +1811,7 @@ PATH =
 ;; Run check repository statistics task when Gitea starts.
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @midnight
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1824,7 +1824,7 @@ PATH =
 ;; Update migrated repositories' issues and comments' posterid when starting server (default true)
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization. (default every 24h)
 ;SCHEDULE = @midnight
 
@@ -1839,7 +1839,7 @@ PATH =
 ;; Synchronize external user data when starting server (default false)
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization (default every 24h)
 ;SCHEDULE = @midnight
 ;; Create new users, update existing user data and disable users that are not in external source anymore (default)
@@ -1857,7 +1857,7 @@ PATH =
 ;; Clean-up deleted branches when starting server (default true)
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization (default every 24h)
 ;SCHEDULE = @midnight
 ;; deleted branches than OLDER_THAN ago are subject to deletion
@@ -1900,7 +1900,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @annually
 ;OLDER_THAN = 168h
 
@@ -1913,7 +1913,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @annually;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1925,7 +1925,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 ;TIMEOUT = 60s
 ;; Arguments for command 'git gc'
@@ -1941,7 +1941,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1953,7 +1953,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1965,7 +1965,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1977,7 +1977,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1989,7 +1989,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2001,7 +2001,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 168h
 ;OLDER_THAN = 8760h
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -816,7 +816,7 @@ Default templates for project boards:
 
 - `ENABLED`: **false**: Enable to run all cron tasks periodically with default settings.
 - `RUN_AT_START`: **false**: Run cron tasks at application start-up.
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 
 - `SCHEDULE` accept formats
    - Full crontab specs, e.g. `* * * * * ?`
@@ -835,7 +835,6 @@ Default templates for project boards:
 #### Cron - Update Mirrors (`cron.update_mirrors`)
 
 - `SCHEDULE`: **@every 10m**: Cron syntax for scheduling update mirrors, e.g. `@every 3h`.
-- `NO_SUCCESS_NOTICE`: **true**: The cron task for update mirrors success report is not very useful - as it just means that the mirrors have been queued. Therefore this is turned off by default.
 - `PULL_LIMIT`: **50**: Limit the number of mirrors added to the queue to this number (negative values mean no limit, 0 will result in no mirrors being queued effectively disabling pull mirror updating).
 - `PUSH_LIMIT`: **50**: Limit the number of mirrors added to the queue to this number (negative values mean no limit, 0 will result in no mirrors being queued effectively disabling push mirror updating).
 
@@ -875,43 +874,43 @@ Default templates for project boards:
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 - `TIMEOUT`: **60s**: Time duration syntax for garbage collection execution timeout.
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `ARGS`: **\<empty\>**: Arguments for command `git gc`, e.g. `--aggressive --auto`. The default value is same with [git] -> GC_ARGS
 
 #### Cron - Update the '.ssh/authorized_keys' file with Gitea SSH keys ('cron.resync_all_sshkeys')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 
 #### Cron - Resynchronize pre-receive, update and post-receive hooks of all repositories ('cron.resync_all_hooks')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 
 #### Cron - Reinitialize all missing Git repositories for which records exist ('cron.reinit_missing_repos')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 
 #### Cron - Delete all repositories missing their Git files ('cron.delete_missing_repos')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 
 #### Cron -  Delete generated repository avatars ('cron.delete_generated_repository_avatars')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 72h**: Cron syntax for scheduling repository archive cleanup, e.g. `@every 1h`.
 
 #### Cron -  Delete all old actions from database ('cron.delete_old_actions')
 - `ENABLED`: **false**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
-- `NO_SUCCESS_NOTICE`: **false**: Set to true to switch off success notices.
+- `NOTICE_ON_SUCCESS`: **false**: Set to true to switch on success notices.
 - `SCHEDULE`: **@every 168h**: Cron syntax to set how often to check.
 - `OLDER_THAN`: **@every 8760h**: any action older than this expression will be deleted from database, suggest using `8760h` (1 year) because that's the max length of heatmap.
 

--- a/services/cron/setting.go
+++ b/services/cron/setting.go
@@ -26,7 +26,7 @@ type BaseConfig struct {
 	Enabled         bool
 	RunAtStart      bool
 	Schedule        string
-	NoSuccessNotice bool
+	NoticeOnSuccess bool
 }
 
 // OlderThanConfig represents a cron task with OlderThan setting
@@ -66,7 +66,7 @@ func (b *BaseConfig) DoRunAtStart() bool {
 
 // DoNoticeOnSuccess returns whether a success notice should be posted
 func (b *BaseConfig) DoNoticeOnSuccess() bool {
-	return !b.NoSuccessNotice
+	return b.NoticeOnSuccess
 }
 
 // FormatMessage returns a message for the task

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -28,10 +28,9 @@ func registerUpdateMirrorTask() {
 
 	RegisterTaskFatal("update_mirrors", &UpdateMirrorTaskConfig{
 		BaseConfig: BaseConfig{
-			Enabled:         true,
-			RunAtStart:      false,
-			Schedule:        "@every 10m",
-			NoSuccessNotice: true,
+			Enabled:    true,
+			RunAtStart: false,
+			Schedule:   "@every 10m",
 		},
 		PullLimit: 50,
 		PushLimit: 50,


### PR DESCRIPTION
Change all cron tasks to make them no notice on success default. Instead if a user
wants notices on success they need to add `NOTICE_ON_SUCCESS=true` instead.

## :warning: BREAKING :warning:

This changes the cron config so that notices on success are no longer set by default
and breaks `NO_SUCCESS_NOTICE` settings. Instead users who want notices on success
must set `NOTICE_ON_SUCCESS=true` instead.

Signed-off-by: Andrew Thornton <art27@cantab.net>
