### PR TITLE
Prevent intermittent failures in RepoIndexerTest

### DIFF
--- a/modules/indexer/stats/indexer_test.go
+++ b/modules/indexer/stats/indexer_test.go
@@ -5,12 +5,14 @@
 package stats
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/queue"
 	"code.gitea.io/gitea/modules/setting"
 
 	_ "code.gitea.io/gitea/models"
@@ -32,10 +34,14 @@ func TestRepoStatsIndex(t *testing.T) {
 	err := Init()
 	assert.NoError(t, err)
 
-	time.Sleep(5 * time.Second)
-
 	repo, err := repo_model.GetRepositoryByID(1)
 	assert.NoError(t, err)
+
+	err = UpdateRepoIndexer(repo)
+	assert.NoError(t, err)
+
+	queue.GetManager().FlushAll(context.Background(), 5*time.Second)
+
 	status, err := repo_model.GetIndexerStatus(repo, repo_model.RepoIndexerTypeStats)
 	assert.NoError(t, err)
 	assert.Equal(t, "65f1bf27bc3bf70f64657658635e66094edbcb4d", status.CommitSha)


### PR DESCRIPTION
The RepoIndexerTest is failing with considerable frequency due to a race inherrent in
its design. This PR adjust this test to avoid the reliance on waiting for the populate
repo indexer to run and forcibly adds the repo to the queue. It then flushes the queue.

It may be worth separating out the tests somewhat by testing the Index function
directly away from the queue however, this forceful method should solve the current
problem.

Fix #19162

Signed-off-by: Andrew Thornton <art27@cantab.net>
