### PR TITLE
Do not include global arguments in process manager

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -32,10 +32,11 @@ const DefaultLocale = "C"
 
 // Command represents a command with its subcommands or arguments.
 type Command struct {
-	name          string
-	args          []string
-	parentContext context.Context
-	desc          string
+	name             string
+	args             []string
+	parentContext    context.Context
+	desc             string
+	globalArgsLength int
 }
 
 func (c *Command) String() string {
@@ -51,9 +52,10 @@ func NewCommand(ctx context.Context, args ...string) *Command {
 	cargs := make([]string, len(globalCommandArgs))
 	copy(cargs, globalCommandArgs)
 	return &Command{
-		name:          GitExecutable,
-		args:          append(cargs, args...),
-		parentContext: ctx,
+		name:             GitExecutable,
+		args:             append(cargs, args...),
+		parentContext:    ctx,
+		globalArgsLength: len(globalCommandArgs),
 	}
 }
 
@@ -140,7 +142,7 @@ func (c *Command) RunWithContext(rc *RunContext) error {
 
 	desc := c.desc
 	if desc == "" {
-		desc = fmt.Sprintf("%s %s [repo_path: %s]", c.name, strings.Join(c.args, " "), rc.Dir)
+		desc = fmt.Sprintf("%s %s [repo_path: %s]", c.name, strings.Join(c.args[c.globalArgsLength:], " "), rc.Dir)
 	}
 
 	ctx, cancel, finished := process.GetManager().AddContextTimeout(c.parentContext, rc.Timeout, desc)


### PR DESCRIPTION
The git command by default adds a number of global arguments. These are not
helpful to be displayed in the process manager and so should be skipped for
default process descriptions.

Signed-off-by: Andrew Thornton <art27@cantab.net>
