### PR TITLE
Prevent intermittent failures in RepoIndexerTest (2)

### DIFF
--- a/modules/indexer/stats/indexer_test.go
+++ b/modules/indexer/stats/indexer_test.go
@@ -12,6 +12,7 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/queue"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -26,6 +27,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestRepoStatsIndex(t *testing.T) {
+	if err := git.Init(context.Background()); !assert.NoError(t, err) {
+		return
+	}
+
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	setting.Cfg = ini.Empty()
 


### PR DESCRIPTION
So whilst #19225 fixes one issue it caused another. We need to initialise the Git
module first.

Related #19225
Fix #19162

Signed-off-by: Andrew Thornton <art27@cantab.net>
