### PR TITLE
Touch mirrors on even on fail to update (#19217)

### DIFF
--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -6,6 +6,7 @@
 package repo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -113,6 +114,13 @@ func updateMirror(e db.Engine, m *Mirror) error {
 // UpdateMirror updates the mirror
 func UpdateMirror(m *Mirror) error {
 	return updateMirror(db.GetEngine(db.DefaultContext), m)
+}
+
+// TouchMirror updates the mirror updatedUnix
+func TouchMirror(ctx context.Context, m *Mirror) error {
+	m.UpdatedUnix = timeutil.TimeStampNow()
+	_, err := db.GetEngine(ctx).ID(m.ID).Cols("updated_unix").Update(m)
+	return err
 }
 
 // DeleteMirrorByRepoID deletes a mirror by repoID

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -387,6 +387,9 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 	log.Trace("SyncMirrors [repo: %-v]: Running Sync", m.Repo)
 	results, ok := runSync(ctx, m)
 	if !ok {
+		if err = repo_model.TouchMirror(ctx, m); err != nil {
+			log.Error("SyncMirrors [repo: %-v]: failed to TouchMirror: %v", m.Repo, err)
+		}
 		return false
 	}
 


### PR DESCRIPTION
Backport #19217

If a mirror fails to be synchronised it should be pushed to the bottom of the queue
of the awaiting mirrors to be synchronised. At present if there LIMIT number of
broken mirrors they can effectively prevent all other mirrors from being synchronized
as their last_updated time will remain earlier than other mirrors.

Signed-off-by: Andrew Thornton <art27@cantab.net>
