### PR TITLE
Configure OpenSSH log level via Environment in Docker

### DIFF
--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -49,6 +49,7 @@ if [ -d /etc/ssh ]; then
     SSH_DSA_CERT="${SSH_DSA_CERT:+"HostCertificate "}${SSH_DSA_CERT}" \
     SSH_MAX_STARTUPS="${SSH_MAX_STARTUPS:+"MaxStartups "}${SSH_MAX_STARTUPS}" \
     SSH_MAX_SESSIONS="${SSH_MAX_SESSIONS:+"MaxSessions "}${SSH_MAX_SESSIONS}" \
+    SSH_LOG_LEVEL=${SSH_LOG_LEVEL:-"INFO"} \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -49,7 +49,7 @@ if [ -d /etc/ssh ]; then
     SSH_DSA_CERT="${SSH_DSA_CERT:+"HostCertificate "}${SSH_DSA_CERT}" \
     SSH_MAX_STARTUPS="${SSH_MAX_STARTUPS:+"MaxStartups "}${SSH_MAX_STARTUPS}" \
     SSH_MAX_SESSIONS="${SSH_MAX_SESSIONS:+"MaxSessions "}${SSH_MAX_SESSIONS}" \
-    SSH_LOG_LEVEL=${SSH_LOG_LEVEL:+"INFO"} \
+    SSH_LOG_LEVEL=${SSH_LOG_LEVEL:-"INFO"} \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/s6/openssh/setup
+++ b/docker/root/etc/s6/openssh/setup
@@ -49,7 +49,7 @@ if [ -d /etc/ssh ]; then
     SSH_DSA_CERT="${SSH_DSA_CERT:+"HostCertificate "}${SSH_DSA_CERT}" \
     SSH_MAX_STARTUPS="${SSH_MAX_STARTUPS:+"MaxStartups "}${SSH_MAX_STARTUPS}" \
     SSH_MAX_SESSIONS="${SSH_MAX_SESSIONS:+"MaxSessions "}${SSH_MAX_SESSIONS}" \
-    SSH_LOG_LEVEL=${SSH_LOG_LEVEL:-"INFO"} \
+    SSH_LOG_LEVEL=${SSH_LOG_LEVEL:+"INFO"} \
     envsubst < /etc/templates/sshd_config > /etc/ssh/sshd_config
 
     chmod 0644 /etc/ssh/sshd_config

--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -8,7 +8,7 @@ ListenAddress ::
 ${SSH_MAX_STARTUPS}
 ${SSH_MAX_SESSIONS}
 
-LogLevel INFO
+LogLevel ${SSH_LOG_LEVEL}
 
 HostKey /data/ssh/ssh_host_ed25519_key
 ${SSH_ED25519_CERT}


### PR DESCRIPTION
- For Docker, make the OpenSSH's log level configurable via environment.
- Resolves #19232
