### PR TITLE
Skip frontend ROOT_URL check on installation page, remove unnecessary global var

### DIFF
--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -42,20 +42,18 @@ const (
 	tplPostInstall base.TplName = "post-install"
 )
 
-var supportedDbTypeNames []map[string]string // use a slice to keep order
-func getDbTypeNames() []map[string]string {
-	if supportedDbTypeNames == nil {
-		for _, t := range setting.SupportedDatabaseTypes {
-			supportedDbTypeNames = append(supportedDbTypeNames, map[string]string{"type": t, "name": setting.DatabaseTypeNames[t]})
-		}
+// getSupportedDbTypeNames returns a slice for supported database types and names. The slice is used to keep the order
+func getSupportedDbTypeNames() (dbTypeNames []map[string]string) {
+	for _, t := range setting.SupportedDatabaseTypes {
+		dbTypeNames = append(dbTypeNames, map[string]string{"type": t, "name": setting.DatabaseTypeNames[t]})
 	}
-	return supportedDbTypeNames
+	return dbTypeNames
 }
 
 // Init prepare for rendering installation page
 func Init(next http.Handler) http.Handler {
 	rnd := templates.HTMLRenderer()
-
+	dbTypeNames := getSupportedDbTypeNames()
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if setting.InstallLock {
 			resp.Header().Add("Refresh", "1; url="+setting.AppURL+"user/login")
@@ -74,7 +72,7 @@ func Init(next http.Handler) http.Handler {
 				"i18n":          locale,
 				"Title":         locale.Tr("install.install"),
 				"PageIsInstall": true,
-				"DbTypeNames":   getDbTypeNames(),
+				"DbTypeNames":   dbTypeNames,
 				"AllLangs":      translation.AllLangs(),
 				"PageStartTime": startTime,
 

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -358,6 +358,9 @@ export function checkAppUrl() {
   if (curUrl.startsWith(appUrl)) {
     return;
   }
+  if (document.querySelector('.page-content.install')) {
+    return; // no need to show the message on the installation page
+  }
   showGlobalErrorMessage(`Your ROOT_URL in app.ini is ${appUrl} but you are visiting ${curUrl}
 You should set ROOT_URL correctly, otherwise the web may not work correctly.`);
 }


### PR DESCRIPTION
1. It's not necessary to run `checkAppUrl` on installation page, because at that time, the ROOT_URL is not determined yet
    * introduced by #18971
3. Move global var `supportedDbTypeNames` into `install.Init` as a local var
    * as suggested by 6543 in #19282