### PR TITLE
Remove `indent-error-flow` to benefit from Golang's if-else

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,6 @@ linters-settings:
       - name: receiver-naming
       - name: time-naming
       - name: unexported-return
-      - name: indent-error-flow
       - name: errorf
       - name: duplicated-imports
       - name: modifies-value-receiver


### PR DESCRIPTION
Golang syntax are friendly to write code like this:

```go
if val, err := foo(); err != nil {
    // do something with err
} else {
    useTheVal(val, ...)  // simple and clear
}
```

However, the lint rule `indent-error-flow` disallows such syntax, it makes code more wordy:


```go
var val string   // why should the `val` and `err` be declared again and again .....
var err error
if val, err = foo(); err != nil {
    // do something with err
}
useTheVal(val, ...)
```


So, it's better to remove such lint rule.
