### PR TITLE
WIP: Custom Webhooks

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -5,11 +5,13 @@
 package cmd
 
 import (
+	"code.gitea.io/gitea/modules/webhook"
 	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	_ "net/http/pprof" // Used for debugging if enabled and a web server is running
@@ -156,6 +158,12 @@ func runWeb(ctx *cli.Context) error {
 	// Perform global initialization
 	setting.LoadFromExisting()
 	routers.GlobalInitInstalled(graceful.GetManager().HammerContext())
+
+	if err := webhook.Init(filepath.Join(setting.CustomPath, "webhooks")); err != nil {
+		log.Fatal("Could not load custom webhooks: %v", err)
+	}
+
+	log.Info("%#v\n", webhook.Webhooks)
 
 	// We check that AppDataPath exists here (it should have been created during installation)
 	// We can't check it in `GlobalInitInstalled`, because some integration tests

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"code.gitea.io/gitea/modules/webhook"
 	"context"
 	"fmt"
 	"net"
@@ -20,6 +19,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/process"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/webhook"
 	"code.gitea.io/gitea/routers"
 	"code.gitea.io/gitea/routers/install"
 
@@ -162,8 +162,6 @@ func runWeb(ctx *cli.Context) error {
 	if err := webhook.Init(filepath.Join(setting.CustomPath, "webhooks")); err != nil {
 		log.Fatal("Could not load custom webhooks: %v", err)
 	}
-
-	log.Info("%#v\n", webhook.Webhooks)
 
 	// We check that AppDataPath exists here (it should have been created during installation)
 	// We can't check it in `GlobalInitInstalled`, because some integration tests

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/gogs/go-gogs-client v0.0.0-20210131175652-1d7215cd8d85
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-github/v39 v39.2.0
+	github.com/google/go-jsonnet v0.18.0
 	github.com/google/pprof v0.0.0-20220509035851-59ca7ad80af3
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/feeds v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,7 @@ github.com/ethantkoenig/rupture v1.0.1 h1:6aAXghmvtnngMgQzy7SMGdicMvkV86V4n9fT0m
 github.com/ethantkoenig/rupture v1.0.1/go.mod h1:Sjqo/nbffZp1pVVXNGhpugIjsWmuS9KiIB4GtpEBur4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -745,6 +746,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
+github.com/google/go-jsonnet v0.18.0 h1:/6pTy6g+Jh1a1I2UMoAODkqELFiVIdOxbNwv0DDzoOg=
+github.com/google/go-jsonnet v0.18.0/go.mod h1:C3fTzyVJDslXdiTqw/bTFk7vSGyCtH3MGRbDfvEwGd0=
 github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOmkVoJOpwnS0wfdsJCV9CoD5nJYsHoFk/0CrTK4M=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -1120,6 +1123,7 @@ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcncea
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -2317,6 +2321,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -387,6 +387,8 @@ var migrations = []Migration{
 	NewMigration("Add auto merge table", addAutoMergeTable),
 	// v215 -> v216
 	NewMigration("allow to view files in PRs", addReviewViewedFiles),
+	// v216 -> v217
+	NewMigration("Add custom webhooks", addCustomWebhooks),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v217.go
+++ b/models/migrations/v217.go
@@ -1,0 +1,77 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"fmt"
+
+	"code.gitea.io/gitea/modules/timeutil"
+
+	"xorm.io/xorm"
+)
+
+func addCustomWebhooks(x *xorm.Engine) error {
+	type HookContentType int
+
+	type HookEvents struct {
+		Create               bool `json:"create"`
+		Delete               bool `json:"delete"`
+		Fork                 bool `json:"fork"`
+		Issues               bool `json:"issues"`
+		IssueAssign          bool `json:"issue_assign"`
+		IssueLabel           bool `json:"issue_label"`
+		IssueMilestone       bool `json:"issue_milestone"`
+		IssueComment         bool `json:"issue_comment"`
+		Push                 bool `json:"push"`
+		PullRequest          bool `json:"pull_request"`
+		PullRequestAssign    bool `json:"pull_request_assign"`
+		PullRequestLabel     bool `json:"pull_request_label"`
+		PullRequestMilestone bool `json:"pull_request_milestone"`
+		PullRequestComment   bool `json:"pull_request_comment"`
+		PullRequestReview    bool `json:"pull_request_review"`
+		PullRequestSync      bool `json:"pull_request_sync"`
+		Repository           bool `json:"repository"`
+		Release              bool `json:"release"`
+	}
+
+	type HookEvent struct {
+		PushOnly       bool   `json:"push_only"`
+		SendEverything bool   `json:"send_everything"`
+		ChooseEvents   bool   `json:"choose_events"`
+		BranchFilter   string `json:"branch_filter"`
+
+		HookEvents `json:"events"`
+	}
+
+	type HookType = string
+
+	type HookStatus int
+
+	type Webhook struct {
+		ID              int64  `xorm:"pk autoincr"`
+		CustomID        string `xorm:"VARCHAR(20) 'custom_id'"`
+		RepoID          int64  `xorm:"INDEX"` // An ID of 0 indicates either a default or system webhook
+		OrgID           int64  `xorm:"INDEX"`
+		IsSystemWebhook bool
+		URL             string `xorm:"url TEXT"`
+		HTTPMethod      string `xorm:"http_method"`
+		ContentType     HookContentType
+		Secret          string `xorm:"TEXT"`
+		Events          string `xorm:"TEXT"`
+		*HookEvent      `xorm:"-"`
+		IsActive        bool       `xorm:"INDEX"`
+		Type            HookType   `xorm:"VARCHAR(16) 'type'"`
+		Meta            string     `xorm:"TEXT"` // store hook-specific attributes
+		LastStatus      HookStatus // Last delivery status
+
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+
+	if err := x.Sync2(new(Webhook)); err != nil {
+		return fmt.Errorf("Sync2: %v", err)
+	}
+	return nil
+}

--- a/models/webhook/webhook.go
+++ b/models/webhook/webhook.go
@@ -163,6 +163,7 @@ const (
 	MATRIX     HookType = "matrix"
 	WECHATWORK HookType = "wechatwork"
 	PACKAGIST  HookType = "packagist"
+	CUSTOM     HookType = "custom"
 )
 
 // HookStatus is the status of a web hook
@@ -177,9 +178,10 @@ const (
 
 // Webhook represents a web hook object.
 type Webhook struct {
-	ID              int64 `xorm:"pk autoincr"`
-	RepoID          int64 `xorm:"INDEX"` // An ID of 0 indicates either a default or system webhook
-	OrgID           int64 `xorm:"INDEX"`
+	ID              int64  `xorm:"pk autoincr"`
+	CustomID        string `xorm:"VARCHAR(20) 'custom_id'"`
+	RepoID          int64  `xorm:"INDEX"` // An ID of 0 indicates either a default or system webhook
+	OrgID           int64  `xorm:"INDEX"`
 	IsSystemWebhook bool
 	URL             string `xorm:"url TEXT"`
 	HTTPMethod      string `xorm:"http_method"`

--- a/modules/webhook/schema.json
+++ b/modules/webhook/schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitea.com/gitea/gitea/modules/webhook/schema.json",
+  "title": "Custom webhook configuration",
+  "description": "A custom webhook for Gitea",
+  "type": "object",
+  "required": ["id", "label", "docs", "form"],
+  "oneOf": [
+    {
+      "required": ["exec"]
+    },
+    {
+      "required": ["http"]
+    }
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "description": "Webhook ID",
+      "type": "string"
+    },
+    "label": {
+      "description": "Webhook Label",
+      "type": "string"
+    },
+    "docs": {
+      "description": "Webhook Docs URL",
+      "type": "string"
+    },
+    "http": {
+      "description": "HTTP Endpoint",
+      "type": "string"
+    },
+    "exec": {
+      "description": "Command to execute",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "form": {
+      "description": "Webhook form",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "type"],
+        "properties": {
+          "id": {
+            "description": "Form ID",
+            "type": "string"
+          },
+          "label": {
+            "description": "Form label",
+            "type": "string"
+          },
+          "type": {
+            "description": "Form type",
+            "type": "string",
+            "enum": ["text", "number", "bool", "secret"]
+          },
+          "required": {
+            "description": "Input required",
+            "type": "boolean"
+          },
+          "default": {
+            "description": "Input default",
+            "type": "string"
+          },
+          "pattern": {
+            "description": "Input pattern",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/webhook/webhook.go
+++ b/modules/webhook/webhook.go
@@ -46,6 +46,7 @@ type Form struct {
 	Type     string `yaml:"type"`
 	Required bool   `yaml:"required"`
 	Default  string `yaml:"default"`
+	Pattern  string `yaml:"pattern"`
 }
 
 // InputType returns the HTML input type of a Form.Type

--- a/modules/webhook/webhook.go
+++ b/modules/webhook/webhook.go
@@ -21,7 +21,7 @@ var Webhooks = make(map[string]*Webhook)
 type Webhook struct {
 	ID    string   `yaml:"id"`
 	Label string   `yaml:"label"`
-	URL   string   `yaml:"url"`
+	Docs  string   `yaml:"docs"`
 	HTTP  string   `yaml:"http"`
 	Exec  []string `yaml:"exec"`
 	Form  []Form   `yaml:"form"`

--- a/modules/webhook/webhook.go
+++ b/modules/webhook/webhook.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package webhook
+
+import (
+	"errors"
+	"io"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Webhook is a custom webhook
+type Webhook struct {
+	ID   string   `yaml:"id"`
+	HTTP string   `yaml:"http"`
+	Exec []string `yaml:"exec"`
+	Form []Form   `yaml:"form"`
+}
+
+// Form is a webhook form
+type Form struct {
+	ID       string `yaml:"id"`
+	Label    string `yaml:"label"`
+	Type     string `yaml:"type"`
+	Required bool   `yaml:"required"`
+	Default  string `yaml:"default"`
+}
+
+func (w *Webhook) validate() error {
+	if w.ID == "" {
+		return errors.New("webhook id is required")
+	}
+	if (w.HTTP == "" && len(w.Exec) == 0) || (w.HTTP != "" && len(w.Exec) > 0) {
+		return errors.New("webhook requires one of exec or http")
+	}
+	for _, form := range w.Form {
+		if form.ID == "" {
+			return errors.New("form id is required")
+		}
+		if form.Label == "" {
+			return errors.New("form label is required")
+		}
+		if form.Type == "" {
+			return errors.New("form type is required")
+		}
+	}
+	return nil
+}
+
+// Parse parses a Webhooks from an io.Reader
+func Parse(r io.Reader) (*Webhook, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var w Webhook
+	if err := yaml.Unmarshal(b, &w); err != nil {
+		return nil, err
+	}
+
+	if err := w.validate(); err != nil {
+		return nil, err
+	}
+
+	return &w, nil
+}

--- a/modules/webhook/webhook.go
+++ b/modules/webhook/webhook.go
@@ -19,13 +19,12 @@ var Webhooks = make(map[string]*Webhook)
 
 // Webhook is a custom webhook
 type Webhook struct {
-	ID    string   `yaml:"id"`
-	Label string   `yaml:"label"`
-	Docs  string   `yaml:"docs"`
-	HTTP  string   `yaml:"http"`
-	Exec  []string `yaml:"exec"`
-	Form  []Form   `yaml:"form"`
-	Path  string   `yaml:"-"`
+	ID    string `yaml:"id"`
+	Label string `yaml:"label"`
+	Docs  string `yaml:"docs"`
+	HTTP  string `yaml:"http"`
+	Form  []Form `yaml:"form"`
+	Path  string `yaml:"-"`
 }
 
 // Image returns a custom webhook image if it exists, else the default image
@@ -69,8 +68,8 @@ func (w *Webhook) validate() error {
 	if w.ID == "" {
 		return errors.New("webhook id is required")
 	}
-	if (w.HTTP == "" && len(w.Exec) == 0) || (w.HTTP != "" && len(w.Exec) > 0) {
-		return errors.New("webhook requires one of exec or http")
+	if w.HTTP == "" {
+		return errors.New("webhook http is required")
 	}
 	for _, form := range w.Form {
 		if form.ID == "" {

--- a/modules/webhook/webhook_test.go
+++ b/modules/webhook/webhook_test.go
@@ -1,0 +1,44 @@
+package webhook
+
+import (
+	"bytes"
+	"code.gitea.io/gitea/testdata"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWebhook(t *testing.T) {
+	tt := []struct {
+		Name string
+		File string
+		Err  bool
+	}{
+		{
+			Name: "Executable",
+			File: "executable.yml",
+		},
+		{
+			Name: "HTTP",
+			File: "http.yml",
+		},
+		{
+			Name: "Bad",
+			File: "bad.yml",
+			Err:  true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			contents, err := testdata.Webhook.ReadFile("webhook/" + tc.File)
+			assert.NoError(t, err, "expected to read file")
+
+			_, err = Parse(bytes.NewReader(contents))
+			if tc.Err {
+				assert.Error(t, err, "expected to get an error")
+			} else {
+				assert.NoError(t, err, "expected to not get an error")
+			}
+		})
+	}
+}

--- a/modules/webhook/webhook_test.go
+++ b/modules/webhook/webhook_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package webhook
 
 import (

--- a/modules/webhook/webhook_test.go
+++ b/modules/webhook/webhook_test.go
@@ -2,9 +2,11 @@ package webhook
 
 import (
 	"bytes"
-	"code.gitea.io/gitea/testdata"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"code.gitea.io/gitea/testdata"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWebhook(t *testing.T) {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1921,6 +1921,7 @@ settings.webhook.payload = Content
 settings.webhook.body = Body
 settings.webhook.replay.description = Replay this webhook.
 settings.webhook.delivery.success = An event has been added to the delivery queue. It may take few seconds before it shows up in the delivery history.
+settings.webhook.display_name = Display Name
 settings.githooks_desc = "Git Hooks are powered by Git itself. You can edit hook files below to set up custom operations."
 settings.githook_edit_desc = If the hook is inactive, sample content will be presented. Leaving content to an empty value will disable this hook.
 settings.githook_name = Hook Name

--- a/routers/web/admin/hooks.go
+++ b/routers/web/admin/hooks.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
+	cwebhook "code.gitea.io/gitea/modules/webhook"
 )
 
 const (
@@ -25,6 +26,7 @@ func DefaultOrSystemWebhooks(ctx *context.Context) {
 
 	ctx.Data["PageIsAdminSystemHooks"] = true
 	ctx.Data["PageIsAdminDefaultHooks"] = true
+	ctx.Data["CustomWebhooks"] = cwebhook.Webhooks
 
 	def := make(map[string]interface{}, len(ctx.Data))
 	sys := make(map[string]interface{}, len(ctx.Data))

--- a/routers/web/org/setting.go
+++ b/routers/web/org/setting.go
@@ -21,6 +21,7 @@ import (
 	repo_module "code.gitea.io/gitea/modules/repository"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web"
+	cwebhook "code.gitea.io/gitea/modules/webhook"
 	user_setting "code.gitea.io/gitea/routers/web/user/setting"
 	"code.gitea.io/gitea/services/forms"
 	"code.gitea.io/gitea/services/org"
@@ -206,6 +207,7 @@ func Webhooks(ctx *context.Context) {
 	ctx.Data["BaseLink"] = ctx.Org.OrgLink + "/settings/hooks"
 	ctx.Data["BaseLinkNew"] = ctx.Org.OrgLink + "/settings/hooks"
 	ctx.Data["Description"] = ctx.Tr("org.settings.hooks_desc")
+	ctx.Data["CustomWebhooks"] = cwebhook.Webhooks
 
 	ws, err := webhook.ListWebhooksByOpts(&webhook.ListWebhookOptions{OrgID: ctx.Org.Organization.ID})
 	if err != nil {

--- a/routers/web/repo/webhook_custom.go
+++ b/routers/web/repo/webhook_custom.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package repo
 
 import (

--- a/routers/web/repo/webhook_custom.go
+++ b/routers/web/repo/webhook_custom.go
@@ -32,6 +32,7 @@ func CustomHooksNewPost(ctx *context.Context) {
 		ctx.ServerError("getOrgRepoCtx", err)
 		return
 	}
+	ctx.Data["BaseLink"] = orCtx.LinkNew
 
 	hookType, isCustom := checkHookType(ctx)
 	if !isCustom {

--- a/routers/web/repo/webhook_custom.go
+++ b/routers/web/repo/webhook_custom.go
@@ -1,0 +1,145 @@
+package repo
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"code.gitea.io/gitea/models/webhook"
+	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/json"
+	"code.gitea.io/gitea/modules/web"
+	cwebhook "code.gitea.io/gitea/modules/webhook"
+	"code.gitea.io/gitea/services/forms"
+	webhook_service "code.gitea.io/gitea/services/webhook"
+)
+
+// CustomHooksNewPost response for creating custom hook
+func CustomHooksNewPost(ctx *context.Context) {
+	form := web.GetForm(ctx).(*forms.NewCustomWebhookForm)
+	ctx.Data["Title"] = ctx.Tr("repo.settings")
+	ctx.Data["PageIsSettingsHooks"] = true
+	ctx.Data["PageIsSettingsHooksNew"] = true
+	ctx.Data["Webhook"] = webhook.Webhook{HookEvent: &webhook.HookEvent{}}
+	ctx.Data["HookType"] = webhook.CUSTOM
+
+	orCtx, err := getOrgRepoCtx(ctx)
+	if err != nil {
+		ctx.ServerError("getOrgRepoCtx", err)
+		return
+	}
+
+	hookType, isCustom := checkHookType(ctx)
+	if !isCustom {
+		ctx.NotFound("checkHookType", nil)
+		return
+	}
+	hook := cwebhook.Webhooks[hookType]
+	if isCustom {
+		ctx.Data["CustomHook"] = hook
+	}
+
+	if ctx.HasError() {
+		ctx.HTML(http.StatusOK, orCtx.NewTemplate)
+		return
+	}
+
+	meta, err := json.Marshal(&webhook_service.CustomMeta{
+		DisplayName: form.DisplayName,
+		Form:        form.Form,
+		Secret:      form.Secret,
+	})
+	if err != nil {
+		ctx.ServerError("Marshal", err)
+		return
+	}
+
+	w := &webhook.Webhook{
+		URL:             form.DisplayName,
+		Secret:          form.Secret,
+		RepoID:          orCtx.RepoID,
+		ContentType:     webhook.ContentTypeJSON,
+		HookEvent:       ParseHookEvent(form.WebhookForm),
+		IsActive:        form.Active,
+		Type:            webhook.CUSTOM,
+		CustomID:        hook.ID,
+		Meta:            string(meta),
+		OrgID:           orCtx.OrgID,
+		IsSystemWebhook: orCtx.IsSystemWebhook,
+	}
+	if err := w.UpdateEvent(); err != nil {
+		ctx.ServerError("UpdateEvent", err)
+		return
+	} else if err := webhook.CreateWebhook(ctx, w); err != nil {
+		ctx.ServerError("CreateWebhook", err)
+		return
+	}
+
+	ctx.Flash.Success(ctx.Tr("repo.settings.add_hook_success"))
+	ctx.Redirect(orCtx.Link)
+}
+
+// CustomHooksEditPost response for editing custom hook
+func CustomHooksEditPost(ctx *context.Context) {
+	form := web.GetForm(ctx).(*forms.NewCustomWebhookForm)
+	ctx.Data["Title"] = ctx.Tr("repo.settings")
+	ctx.Data["PageIsSettingsHooks"] = true
+	ctx.Data["PageIsSettingsHooksEdit"] = true
+
+	orCtx, w := checkWebhook(ctx)
+	if ctx.Written() {
+		return
+	}
+	ctx.Data["Webhook"] = w
+
+	if ctx.HasError() {
+		ctx.HTML(http.StatusOK, orCtx.NewTemplate)
+		return
+	}
+
+	meta, err := json.Marshal(&webhook_service.CustomMeta{
+		DisplayName: form.DisplayName,
+		Form:        form.Form,
+		Secret:      form.Secret,
+	})
+	if err != nil {
+		ctx.ServerError("Marshal", err)
+		return
+	}
+
+	w.Meta = string(meta)
+	w.URL = form.DisplayName
+	w.Secret = form.Secret
+	w.HookEvent = ParseHookEvent(form.WebhookForm)
+	w.IsActive = form.Active
+	if err := w.UpdateEvent(); err != nil {
+		ctx.ServerError("UpdateEvent", err)
+		return
+	} else if err := webhook.UpdateWebhook(w); err != nil {
+		ctx.ServerError("UpdateWebhook", err)
+		return
+	}
+
+	ctx.Flash.Success(ctx.Tr("repo.settings.update_hook_success"))
+	ctx.Redirect(fmt.Sprintf("%s/%d", orCtx.Link, w.ID))
+}
+
+// CustomWebhookImage gets the image for a custom webhook
+func CustomWebhookImage(ctx *context.Context) {
+	id := ctx.Params("custom_id")
+	hook, ok := cwebhook.Webhooks[id]
+	if !ok {
+		ctx.NotFound("no webhook found", nil)
+		return
+	}
+	img, err := hook.Image()
+	if err != nil {
+		ctx.ServerError(fmt.Sprintf("webhook image not found for %q", id), err)
+		return
+	}
+	defer img.Close()
+	if _, err := io.Copy(ctx.Resp, img); err != nil {
+		ctx.ServerError(fmt.Sprintf("could not stream webhook image for %q", id), err)
+		return
+	}
+}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -529,6 +529,7 @@ func RegisterRoutes(m *web.Route) {
 			m.Post("/feishu/{id}", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksEditPost)
 			m.Post("/wechatwork/{id}", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksEditPost)
 			m.Post("/packagist/{id}", bindIgnErr(forms.NewPackagistHookForm{}), repo.PackagistHooksEditPost)
+			m.Post("/{type}/{id}", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksEditPost)
 		}, webhooksEnabled)
 
 		m.Group("/{configType:default-hooks|system-hooks}", func() {
@@ -544,6 +545,9 @@ func RegisterRoutes(m *web.Route) {
 			m.Post("/feishu/new", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksNewPost)
 			m.Post("/wechatwork/new", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksNewPost)
 			m.Post("/packagist/new", bindIgnErr(forms.NewPackagistHookForm{}), repo.PackagistHooksNewPost)
+			m.Post("/{type}/new", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksNewPost)
+
+			m.Get("/{custom_id}/image", repo.CustomWebhookImage)
 		})
 
 		m.Group("/auths", func() {
@@ -662,6 +666,7 @@ func RegisterRoutes(m *web.Route) {
 					m.Post("/msteams/new", bindIgnErr(forms.NewMSTeamsHookForm{}), repo.MSTeamsHooksNewPost)
 					m.Post("/feishu/new", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksNewPost)
 					m.Post("/wechatwork/new", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksNewPost)
+					m.Post("/{type}/{id}", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksEditPost)
 					m.Group("/{id}", func() {
 						m.Get("", repo.WebHooksEdit)
 						m.Post("/replay/{uuid}", repo.ReplayWebhook)
@@ -676,6 +681,9 @@ func RegisterRoutes(m *web.Route) {
 					m.Post("/msteams/{id}", bindIgnErr(forms.NewMSTeamsHookForm{}), repo.MSTeamsHooksEditPost)
 					m.Post("/feishu/{id}", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksEditPost)
 					m.Post("/wechatwork/{id}", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksEditPost)
+					m.Post("/{type}/new", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksNewPost)
+
+					m.Get("/{custom_id}/image", repo.CustomWebhookImage)
 				}, webhooksEnabled)
 
 				m.Group("/labels", func() {
@@ -781,6 +789,7 @@ func RegisterRoutes(m *web.Route) {
 				m.Post("/feishu/new", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksNewPost)
 				m.Post("/wechatwork/new", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksNewPost)
 				m.Post("/packagist/new", bindIgnErr(forms.NewPackagistHookForm{}), repo.PackagistHooksNewPost)
+				m.Post("/{type}/{id}", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksEditPost)
 				m.Group("/{id}", func() {
 					m.Get("", repo.WebHooksEdit)
 					m.Post("/test", repo.TestWebhook)
@@ -797,6 +806,9 @@ func RegisterRoutes(m *web.Route) {
 				m.Post("/feishu/{id}", bindIgnErr(forms.NewFeishuHookForm{}), repo.FeishuHooksEditPost)
 				m.Post("/wechatwork/{id}", bindIgnErr(forms.NewWechatWorkHookForm{}), repo.WechatworkHooksEditPost)
 				m.Post("/packagist/{id}", bindIgnErr(forms.NewPackagistHookForm{}), repo.PackagistHooksEditPost)
+				m.Post("/{type}/new", bindIgnErr(forms.NewCustomWebhookForm{}), repo.CustomHooksNewPost)
+
+				m.Get("/{custom_id}/image", repo.CustomWebhookImage)
 			}, webhooksEnabled)
 
 			m.Group("/keys", func() {

--- a/services/webhook/custom.go
+++ b/services/webhook/custom.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package webhook
 
 import (

--- a/services/webhook/custom.go
+++ b/services/webhook/custom.go
@@ -1,0 +1,51 @@
+package webhook
+
+import (
+	"errors"
+
+	webhook_model "code.gitea.io/gitea/models/webhook"
+	"code.gitea.io/gitea/modules/json"
+	"code.gitea.io/gitea/modules/log"
+	api "code.gitea.io/gitea/modules/structs"
+)
+
+type (
+	// CustomPayload is a payload for a custom webhook
+	CustomPayload struct {
+		Form    map[string]interface{} `json:"form"`
+		Payload api.Payloader          `json:"payload"`
+	}
+
+	// CustomMeta is the meta information for a custom webhook
+	CustomMeta struct {
+		DisplayName string
+		Form        map[string]interface{}
+		Secret      string
+	}
+)
+
+// GetCustomHook returns custom metadata
+func GetCustomHook(w *webhook_model.Webhook) *CustomMeta {
+	s := &CustomMeta{}
+	if err := json.Unmarshal([]byte(w.Meta), s); err != nil {
+		log.Error("webhook.GetCustomHook(%d): %v", w.ID, err)
+	}
+	return s
+}
+
+func (c CustomPayload) JSONPayload() ([]byte, error) {
+	return json.Marshal(c)
+}
+
+// GetCustomPayload converts a custom webhook into a CustomPayload
+func GetCustomPayload(p api.Payloader, _ webhook_model.HookEventType, meta string) (api.Payloader, error) {
+	s := new(CustomPayload)
+
+	custom := &CustomMeta{}
+	if err := json.Unmarshal([]byte(meta), &custom); err != nil {
+		return s, errors.New("GetPackagistPayload meta json:" + err.Error())
+	}
+	s.Form = custom.Form
+	s.Payload = p
+	return s, nil
+}

--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -183,6 +183,6 @@ func createDingtalkPayload(title, text, singleTitle, singleURL string) *Dingtalk
 }
 
 // GetDingtalkPayload converts a ding talk webhook into a DingtalkPayload
-func GetDingtalkPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetDingtalkPayload(p api.Payloader, event webhook_model.HookEventType, _ *webhook_model.Webhook) (api.Payloader, error) {
 	return convertPayloader(new(DingtalkPayload), p, event)
 }

--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -243,11 +243,11 @@ func (d *DiscordPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 }
 
 // GetDiscordPayload converts a discord webhook into a DiscordPayload
-func GetDiscordPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetDiscordPayload(p api.Payloader, event webhook_model.HookEventType, w *webhook_model.Webhook) (api.Payloader, error) {
 	s := new(DiscordPayload)
 
 	discord := &DiscordMeta{}
-	if err := json.Unmarshal([]byte(meta), &discord); err != nil {
+	if err := json.Unmarshal([]byte(w.Meta), &discord); err != nil {
 		return s, errors.New("GetDiscordPayload meta json:" + err.Error())
 	}
 	s.Username = discord.Username

--- a/services/webhook/feishu.go
+++ b/services/webhook/feishu.go
@@ -153,6 +153,6 @@ func (f *FeishuPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 }
 
 // GetFeishuPayload converts a ding talk webhook into a FeishuPayload
-func GetFeishuPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetFeishuPayload(p api.Payloader, event webhook_model.HookEventType, _ *webhook_model.Webhook) (api.Payloader, error) {
 	return convertPayloader(new(FeishuPayload), p, event)
 }

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -222,11 +222,11 @@ func (m *MatrixPayloadUnsafe) Repository(p *api.RepositoryPayload) (api.Payloade
 }
 
 // GetMatrixPayload converts a Matrix webhook into a MatrixPayloadUnsafe
-func GetMatrixPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetMatrixPayload(p api.Payloader, event webhook_model.HookEventType, w *webhook_model.Webhook) (api.Payloader, error) {
 	s := new(MatrixPayloadUnsafe)
 
 	matrix := &MatrixMeta{}
-	if err := json.Unmarshal([]byte(meta), &matrix); err != nil {
+	if err := json.Unmarshal([]byte(w.Meta), &matrix); err != nil {
 		return s, errors.New("GetMatrixPayload meta json:" + err.Error())
 	}
 

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -282,7 +282,7 @@ func (m *MSTeamsPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 }
 
 // GetMSTeamsPayload converts a MSTeams webhook into a MSTeamsPayload
-func GetMSTeamsPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetMSTeamsPayload(p api.Payloader, event webhook_model.HookEventType, _ *webhook_model.Webhook) (api.Payloader, error) {
 	return convertPayloader(new(MSTeamsPayload), p, event)
 }
 

--- a/services/webhook/packagist.go
+++ b/services/webhook/packagist.go
@@ -100,11 +100,11 @@ func (f *PackagistPayload) Release(p *api.ReleasePayload) (api.Payloader, error)
 }
 
 // GetPackagistPayload converts a packagist webhook into a PackagistPayload
-func GetPackagistPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetPackagistPayload(p api.Payloader, event webhook_model.HookEventType, w *webhook_model.Webhook) (api.Payloader, error) {
 	s := new(PackagistPayload)
 
 	packagist := &PackagistMeta{}
-	if err := json.Unmarshal([]byte(meta), &packagist); err != nil {
+	if err := json.Unmarshal([]byte(w.Meta), &packagist); err != nil {
 		return s, errors.New("GetPackagistPayload meta json:" + err.Error())
 	}
 	s.PackagistRepository.URL = packagist.PackageURL

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -271,11 +271,11 @@ func (s *SlackPayload) createPayload(text string, attachments []SlackAttachment)
 }
 
 // GetSlackPayload converts a slack webhook into a SlackPayload
-func GetSlackPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetSlackPayload(p api.Payloader, event webhook_model.HookEventType, w *webhook_model.Webhook) (api.Payloader, error) {
 	s := new(SlackPayload)
 
 	slack := &SlackMeta{}
-	if err := json.Unmarshal([]byte(meta), &slack); err != nil {
+	if err := json.Unmarshal([]byte(w.Meta), &slack); err != nil {
 		return s, errors.New("GetSlackPayload meta json:" + err.Error())
 	}
 

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -179,7 +179,7 @@ func (t *TelegramPayload) Release(p *api.ReleasePayload) (api.Payloader, error) 
 }
 
 // GetTelegramPayload converts a telegram webhook into a TelegramPayload
-func GetTelegramPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetTelegramPayload(p api.Payloader, event webhook_model.HookEventType, _ *webhook_model.Webhook) (api.Payloader, error) {
 	return convertPayloader(new(TelegramPayload), p, event)
 }
 

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -64,6 +64,10 @@ var webhooks = map[webhook_model.HookType]*webhook{
 		name:           webhook_model.PACKAGIST,
 		payloadCreator: GetPackagistPayload,
 	},
+	webhook_model.CUSTOM: {
+		name:           webhook_model.CUSTOM,
+		payloadCreator: GetCustomPayload,
+	},
 }
 
 // RegisterWebhook registers a webhook

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -24,7 +24,7 @@ import (
 
 type webhook struct {
 	name           webhook_model.HookType
-	payloadCreator func(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error)
+	payloadCreator func(p api.Payloader, event webhook_model.HookEventType, w *webhook_model.Webhook) (api.Payloader, error)
 }
 
 var webhooks = map[webhook_model.HookType]*webhook{
@@ -201,7 +201,7 @@ func prepareWebhook(w *webhook_model.Webhook, repo *repo_model.Repository, event
 	var err error
 	webhook, ok := webhooks[w.Type]
 	if ok {
-		payloader, err = webhook.payloadCreator(p, event, w.Meta)
+		payloader, err = webhook.payloadCreator(p, event, w)
 		if err != nil {
 			return fmt.Errorf("create payload for %s[%s]: %v", w.Type, event, err)
 		}

--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -174,6 +174,6 @@ func (f *WechatworkPayload) Release(p *api.ReleasePayload) (api.Payloader, error
 }
 
 // GetWechatworkPayload GetWechatworkPayload converts a ding talk webhook into a WechatworkPayload
-func GetWechatworkPayload(p api.Payloader, event webhook_model.HookEventType, meta string) (api.Payloader, error) {
+func GetWechatworkPayload(p api.Payloader, event webhook_model.HookEventType, _ *webhook_model.Webhook) (api.Payloader, error) {
 	return convertPayloader(new(WechatworkPayload), p, event)
 }

--- a/templates/repo/settings/webhook/base_list.tmpl
+++ b/templates/repo/settings/webhook/base_list.tmpl
@@ -37,6 +37,11 @@
 				<a class="item" href="{{.BaseLinkNew}}/packagist/new">
 					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/packagist.png">{{.i18n.Tr "repo.settings.web_hook_name_packagist"}}
 				</a>
+				{{range .CustomWebhooks}}
+					<a class="item" href="{{$.BaseLinkNew}}/{{.ID}}/new">
+						<img width="20" height="20" src="{{$.BaseLinkNew}}/{{.ID}}/image">{{.Label}}
+					</a>
+				{{end}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/settings/webhook/custom.tmpl
+++ b/templates/repo/settings/webhook/custom.tmpl
@@ -1,5 +1,5 @@
 {{if .CustomHook}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" .CustomHook.URL .CustomHook.Label | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" .CustomHook.Docs .CustomHook.Label | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/{{.CustomHook.ID}}/{{or .Webhook.ID "new"}}" method="post">
 		{{template "base/disable_form_autofill"}}
 		{{.CsrfTokenHtml}}

--- a/templates/repo/settings/webhook/custom.tmpl
+++ b/templates/repo/settings/webhook/custom.tmpl
@@ -10,7 +10,16 @@
 		{{range .CustomHook.Form}}
 		<div class="field {{if .Required}}required{{end}} {{if ne (index $ (printf "Err_%s" .ID)) nil}}error{{end}}">
 			<label for="{{.ID}}">{{.Label}}</label>
-			<input id="{{.ID}}" name="{{.ID}}" type="{{.InputType}}" value="{{if eq .InputType "checkbox"}}true{{else}}{{index $ (printf "CustomHook_%s" .ID)}}{{end}}" {{if and (eq .InputType "checkbox") (eq (printf "%v" (index $ (printf "CustomHook_%s" .ID))) "true")}}checked{{end}} {{if .Default}}placeholder="{{.Default}}" {{end}} {{if .Required}}required{{end}}>
+			<input
+				id="{{.ID}}"
+				name="{{.ID}}"
+				type="{{.InputType}}"
+				value="{{if eq .InputType "checkbox"}}true{{else}}{{index $ (printf "CustomHook_%s" .ID)}}{{end}}"
+				{{if and (eq .InputType "checkbox") (eq (printf "%v" (index $ (printf "CustomHook_%s" .ID))) "true")}}checked{{end}}
+				{{if .Default}}placeholder="{{.Default}}" {{end}}
+				{{if .Pattern}}pattern="{{.Pattern}}"{{end}}
+				{{if .Required}}required{{end}}
+			>
 		</div>
 		{{end}}
 		<div class="field {{if .Err_Secret}}error{{end}}">

--- a/templates/repo/settings/webhook/custom.tmpl
+++ b/templates/repo/settings/webhook/custom.tmpl
@@ -1,0 +1,22 @@
+{{if .CustomHook}}
+	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" .CustomHook.URL .CustomHook.Label | Str2html}}</p>
+	<form class="ui form" action="{{.BaseLink}}/{{.CustomHook.ID}}/{{or .Webhook.ID "new"}}" method="post">
+		{{template "base/disable_form_autofill"}}
+		{{.CsrfTokenHtml}}
+		<div class="field required {{if .Err_DisplayName}}error{{end}}">
+			<label for="display_name">{{.i18n.Tr "repo.settings.webhook.display_name"}}</label>
+			<input id="display_name" name="display_name" value="{{.Webhook.URL}}" required>
+		</div>
+		{{range .CustomHook.Form}}
+		<div class="field {{if .Required}}required{{end}} {{if ne (index $ (printf "Err_%s" .ID)) nil}}error{{end}}">
+			<label for="{{.ID}}">{{.Label}}</label>
+			<input id="{{.ID}}" name="{{.ID}}" type="{{.InputType}}" value="{{if eq .InputType "checkbox"}}true{{else}}{{index $ (printf "CustomHook_%s" .ID)}}{{end}}" {{if and (eq .InputType "checkbox") (eq (printf "%v" (index $ (printf "CustomHook_%s" .ID))) "true")}}checked{{end}} {{if .Default}}placeholder="{{.Default}}" {{end}} {{if .Required}}required{{end}}>
+		</div>
+		{{end}}
+		<div class="field {{if .Err_Secret}}error{{end}}">
+			<label for="secret">{{.i18n.Tr "repo.settings.secret"}}</label>
+			<input id="secret" name="secret" type="password" value="{{.Webhook.Secret}}" autocomplete="off">
+		</div>
+		{{template "repo/settings/webhook/settings" .}}
+	</form>
+{{end}}

--- a/templates/repo/settings/webhook/discord.tmpl
+++ b/templates/repo/settings/webhook/discord.tmpl
@@ -1,4 +1,4 @@
-{{if eq .HookType "discord"}}
+	{{if eq .HookType "discord"}}
 	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://discord.com" (.i18n.Tr "repo.settings.web_hook_name_discord") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/discord/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}

--- a/templates/repo/settings/webhook/new.tmpl
+++ b/templates/repo/settings/webhook/new.tmpl
@@ -27,8 +27,10 @@
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/matrix.svg">
 				{{else if eq .HookType "wechatwork"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/wechatwork.png">
-				{{else if eq .HookType "packagist"}}
+        {{else if eq .HookType "packagist"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/packagist.png">
+        {{else}}
+					<img width="26" height="26" src="./image">{{.Label}}
 				{{end}}
 			</div>
 		</h4>
@@ -44,6 +46,7 @@
 			{{template "repo/settings/webhook/matrix" .}}
 			{{template "repo/settings/webhook/wechatwork" .}}
 			{{template "repo/settings/webhook/packagist" .}}
+			{{template "repo/settings/webhook/custom" .}}
 		</div>
 
 		{{template "repo/settings/webhook/history" .}}

--- a/templates/repo/settings/webhook/new.tmpl
+++ b/templates/repo/settings/webhook/new.tmpl
@@ -27,9 +27,9 @@
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/matrix.svg">
 				{{else if eq .HookType "wechatwork"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/wechatwork.png">
-        {{else if eq .HookType "packagist"}}
+				{{else if eq .HookType "packagist"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/packagist.png">
-        {{else if eq .HookType "custom"}}
+				{{else if eq .HookType "custom"}}
 					<img width="26" height="26" src="{{$.BaseLink}}/{{.CustomHook.ID}}/image">
 				{{end}}
 			</div>

--- a/templates/repo/settings/webhook/new.tmpl
+++ b/templates/repo/settings/webhook/new.tmpl
@@ -29,8 +29,8 @@
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/wechatwork.png">
         {{else if eq .HookType "packagist"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/packagist.png">
-        {{else}}
-					<img width="26" height="26" src="./image">{{.Label}}
+        {{else if eq .HookType "custom"}}
+					<img width="26" height="26" src="{{$.BaseLink}}/{{.CustomHook.ID}}/image">
 				{{end}}
 			</div>
 		</h4>

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package testdata
 
 import "embed"

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -1,0 +1,8 @@
+package testdata
+
+import "embed"
+
+var (
+	//go:embed webhook
+	Webhook embed.FS
+)

--- a/testdata/webhook/bad.yml
+++ b/testdata/webhook/bad.yml
@@ -1,0 +1,1 @@
+# Malformed or no data

--- a/testdata/webhook/executable.go
+++ b/testdata/webhook/executable.go
@@ -1,0 +1,87 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+type Payload struct {
+	Form map[string]struct {
+		Label    string      `json:"label"`
+		Type     string      `json:"type"`
+		Required bool        `json:"required"`
+		Default  interface{} `json:"default"`
+		Value    interface{} `json:"value"`
+	} `json:"form"`
+}
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+
+	var p Payload
+	if err := json.Unmarshal(data, &p); err != nil {
+		panic(err)
+	}
+
+	username, ok := p.Form["username"]
+	if !ok {
+		panic("username not found in form data")
+	}
+	checkType(username.Type, username.Value)
+	if username.Value.(string) != "jolheiser" {
+		panic("username should be jolheiser")
+	}
+
+	favNum, ok := p.Form["favorite-number"]
+	if !ok {
+		panic("favorite-number not found in form data")
+	}
+	checkType(favNum.Type, favNum.Value)
+	if username.Value.(float64) != 12 {
+		panic("favNum should be 12")
+	}
+
+	pineapple, ok := p.Form["pineapple"]
+	if !ok {
+		panic("pineapple not found in form data")
+	}
+	checkType(pineapple.Type, pineapple.Value)
+	if pineapple.Value.(bool) {
+		panic("pineapple should be false")
+	}
+
+	secret, ok := p.Form["secret"]
+	if !ok {
+		panic("secret not found in form data")
+	}
+	checkType(secret.Type, secret.Value)
+	if secret.Value.(string) != "sn34ky" {
+		panic("secret should be sn34ky")
+	}
+}
+
+func checkType(typ string, val interface{}) {
+	var ok bool
+	switch typ {
+	case "text", "secret":
+		_, ok = val.(string)
+	case "bool":
+		_, ok = val.(bool)
+	case "number":
+		_, ok = val.(float64)
+	}
+	if !ok {
+		panic(fmt.Sprintf("unexpected type %q for %v", typ, val))
+	}
+}
+
+// override panic
+func panic(v interface{}) {
+	fmt.Println(v)
+	os.Exit(1)
+}

--- a/testdata/webhook/executable.go
+++ b/testdata/webhook/executable.go
@@ -1,4 +1,8 @@
-package webhook
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package main
 
 import (
 	"encoding/json"
@@ -8,12 +12,11 @@ import (
 )
 
 type Payload struct {
-	Form map[string]struct {
-		Label    string      `json:"label"`
-		Type     string      `json:"type"`
-		Required bool        `json:"required"`
-		Default  interface{} `json:"default"`
-		Value    interface{} `json:"value"`
+	Form struct {
+		Username       string `json:"username"`
+		FavoriteNumber int    `json:"favorite-number"`
+		Pineapple      bool   `json:"pineapple"`
+		Passphrase     string `json:"passphrase"`
 	} `json:"form"`
 }
 
@@ -28,55 +31,20 @@ func main() {
 		panic(err)
 	}
 
-	username, ok := p.Form["username"]
-	if !ok {
-		panic("username not found in form data")
-	}
-	checkType(username.Type, username.Value)
-	if username.Value.(string) != "jolheiser" {
+	if p.Form.Username != "jolheiser" {
 		panic("username should be jolheiser")
 	}
 
-	favNum, ok := p.Form["favorite-number"]
-	if !ok {
-		panic("favorite-number not found in form data")
-	}
-	checkType(favNum.Type, favNum.Value)
-	if username.Value.(float64) != 12 {
+	if p.Form.FavoriteNumber != 12 {
 		panic("favNum should be 12")
 	}
 
-	pineapple, ok := p.Form["pineapple"]
-	if !ok {
-		panic("pineapple not found in form data")
-	}
-	checkType(pineapple.Type, pineapple.Value)
-	if pineapple.Value.(bool) {
+	if p.Form.Pineapple {
 		panic("pineapple should be false")
 	}
 
-	secret, ok := p.Form["secret"]
-	if !ok {
-		panic("secret not found in form data")
-	}
-	checkType(secret.Type, secret.Value)
-	if secret.Value.(string) != "sn34ky" {
+	if p.Form.Passphrase != "sn34ky" {
 		panic("secret should be sn34ky")
-	}
-}
-
-func checkType(typ string, val interface{}) {
-	var ok bool
-	switch typ {
-	case "text", "secret":
-		_, ok = val.(string)
-	case "bool":
-		_, ok = val.(bool)
-	case "number":
-		_, ok = val.(float64)
-	}
-	if !ok {
-		panic(fmt.Sprintf("unexpected type %q for %v", typ, val))
 	}
 }
 

--- a/testdata/webhook/executable.yml
+++ b/testdata/webhook/executable.yml
@@ -1,0 +1,17 @@
+id: executable
+exec: ["go", "run", "executable.go"]
+form:
+  - id: username        # Required
+    label: Username     # Required, the label for the input
+    type: text          # Required, the type of input (text, number, bool, secret)
+    required: true      # Optional, defaults to false
+  - id: favorite-number
+    label: Favorite Number
+    type: number
+    default: 12        # Optional, a default value
+  - id: pineapple
+    label: Pineapple on Pizza
+    type: bool
+  - id: secret
+    label: Passphrase
+    type: secret

--- a/testdata/webhook/http.yml
+++ b/testdata/webhook/http.yml
@@ -1,0 +1,17 @@
+id: http
+http: "http://localhost:4665"
+form:
+  - id: username        # Required
+    label: Username     # Required, the label for the input
+    type: text          # Required, the type of input (text, number, bool, secret)
+    required: true      # Optional, defaults to false
+  - id: favorite-number
+    label: Favorite Number
+    type: number
+    default: 12        # Optional, a default value
+  - id: pineapple
+    label: Pineapple on Pizza
+    type: bool
+  - id: secret
+    label: Passphrase
+    type: secret


### PR DESCRIPTION
This is a draft of custom webhooks.

It will close #14693 as well, as it includes both HTTP and binary-based webhooks.
This should also resolve #1089, at least as closely as I can think of without a true plugin system.

A configuration looks like this:

Executable
```yaml
id: executable          # This is used to map the webhook type to this webhook
label: Executable       # The display name of the webhook
docs: https://google.com # The URL to the webhook's documentation (if any)
exec: ["./executable"]  # Command args to run
form:
  - id: username        # Required
    label: Username     # Required, the label for the input
    type: text          # Required, the type of input (text, number, bool, secret)
    required: true      # Optional, defaults to false
  - id: favorite-number
    label: Favorite Number
    type: number
    default: 12        # Optional, a default value
  - id: pineapple
    label: Pineapple on Pizza
    type: bool
  - id: passphrase
    label: Passphrase
    type: secret
```

Executables are executed relative to the path the custom webhook lives in, which is currently `CUSTOM_PATH/webhooks`

HTTP
```yaml
id: http
label: HTTP
docs: https://duckduckgo.com
http: "https://dev.jolheiser.com" # The URL to send the payload to
# Same form config as above
```

Each custom webhook requires 2-3 files, namely an `image.png`, a `config.yml`, and possibly an executable if required.

On startup, Gitea scans the custom webhook directory (again, currently set to `CUSTOM_PATH/webhooks`) and adds them to a map of webhooks.

The payload sent to either type of webhook (via `stdin` for executables) is
```json
{
  "form": {...},
  "payload": {...}
}
```
For executables, any headers are set in the environment as the header name, ie `X-Gitea-Signature`

-----

Notes:

- What to do if a custom webhook is ever removed?
   - Do I set all matching ones to inactive, or remove them? I lean towards the former.
- I want to get this implementation as solid as possible prior to moving forward, so as to not create a fragile custom webhook ecosystem for developers.
