### PR TITLE
Show ssh command directly in template instead of i18n translation

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -664,7 +664,6 @@ ssh_invalid_token_signature = The provided SSH key, signature or token do not ma
 ssh_token_required = You must provide a signature for the below token
 ssh_token = Token
 ssh_token_help = You can generate a signature using:
-ssh_token_code = echo -n "%s" | ssh-keygen -Y sign -n gitea -f /path_to_your_pubkey
 ssh_token_signature = Armored SSH signature
 key_signature_ssh_placeholder = Begins with '-----BEGIN SSH SIGNATURE-----'
 verify_ssh_key_success = SSH key '%s' has been verified.

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -664,7 +664,7 @@ ssh_invalid_token_signature=提供的 SSH 密钥、签名或令牌不匹配或�
 ssh_token_required=您必须为下面的令牌提供签名
 ssh_token=令牌
 ssh_token_help=您可以使用以下方式生成签名：
-ssh_token_code=echo -n "%s" | ssh-keygen -Y sign-n gitea -f /path_to_your_pubkey
+ssh_token_code=echo -n "%s" | ssh-keygen -Y sign -n gitea -f /path_to_your_pubkey
 ssh_token_signature=增强 SSH 签名
 key_signature_ssh_placeholder=以 '-----BEGIN SSH SIGNATURE -----' 开头
 verify_ssh_key_success=SSH 密钥 '%s' 已被验证。
@@ -693,8 +693,8 @@ last_used=上次使用在
 no_activity=没有最近活动
 can_read_info=读取
 can_write_info=写入
-key_state_desc=7 天内使用过该密钥 
-token_state_desc=7 天内使用过该密钥 
+key_state_desc=7 天内使用过该密钥
+token_state_desc=7 天内使用过该密钥
 principal_state_desc=7 天内使用过该规则
 show_openid=在个人信息上显示
 hide_openid=在个人信息上隐藏
@@ -875,7 +875,7 @@ watchers=关注者
 stargazers=称赞者
 forks=派生仓库
 pick_reaction=选择你的表情
-reactions_more=再加载 %d 
+reactions_more=再加载 %d
 unit_disabled=站点管理员已禁用此仓库单元。
 language_other=其它
 adopt_search=输入用户名以搜索未被收录的仓库... (留空以查找全部)
@@ -3013,7 +3013,7 @@ filter.type.all=所有
 filter.no_result=您的过滤器没有产生任何结果。
 filter.container.tagged=已加标签
 filter.container.untagged=未加标签
-published_by=于 %[1]s 发布了 <a href="%[2]s">%[3]s</a> 
+published_by=于 %[1]s 发布了 <a href="%[2]s">%[3]s</a>
 published_by_in=<a href="%[2]s">%[3]s</a> 于 %[1]s 发布了 <a href="%[4]s"><strong>%[5]s</strong></a>
 installation=安装
 about=关于这个软件包

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -664,7 +664,7 @@ ssh_invalid_token_signature=提供的 SSH 密钥、签名或令牌不匹配或�
 ssh_token_required=您必须为下面的令牌提供签名
 ssh_token=令牌
 ssh_token_help=您可以使用以下方式生成签名：
-ssh_token_code=echo -n "%s" | ssh-keygen -Y sign -n gitea -f /path_to_your_pubkey
+ssh_token_code=echo -n "%s" | ssh-keygen -Y sign-n gitea -f /path_to_your_pubkey
 ssh_token_signature=增强 SSH 签名
 key_signature_ssh_placeholder=以 '-----BEGIN SSH SIGNATURE -----' 开头
 verify_ssh_key_success=SSH 密钥 '%s' 已被验证。
@@ -693,8 +693,8 @@ last_used=上次使用在
 no_activity=没有最近活动
 can_read_info=读取
 can_write_info=写入
-key_state_desc=7 天内使用过该密钥
-token_state_desc=7 天内使用过该密钥
+key_state_desc=7 天内使用过该密钥 
+token_state_desc=7 天内使用过该密钥 
 principal_state_desc=7 天内使用过该规则
 show_openid=在个人信息上显示
 hide_openid=在个人信息上隐藏
@@ -875,7 +875,7 @@ watchers=关注者
 stargazers=称赞者
 forks=派生仓库
 pick_reaction=选择你的表情
-reactions_more=再加载 %d
+reactions_more=再加载 %d 
 unit_disabled=站点管理员已禁用此仓库单元。
 language_other=其它
 adopt_search=输入用户名以搜索未被收录的仓库... (留空以查找全部)
@@ -3013,7 +3013,7 @@ filter.type.all=所有
 filter.no_result=您的过滤器没有产生任何结果。
 filter.container.tagged=已加标签
 filter.container.untagged=未加标签
-published_by=于 %[1]s 发布了 <a href="%[2]s">%[3]s</a>
+published_by=于 %[1]s 发布了 <a href="%[2]s">%[3]s</a> 
 published_by_in=<a href="%[2]s">%[3]s</a> 于 %[1]s 发布了 <a href="%[4]s"><strong>%[5]s</strong></a>
 installation=安装
 about=关于这个软件包

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -75,7 +75,7 @@
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
 								<p>{{$.i18n.Tr "settings.ssh_token_help"}}</p>
-								<p><code>{{$.i18n.Tr "settings.ssh_token_code" $.TokenToSign}}</code></p>
+								<p><code>{{printf "echo -n '%s' | ssh-keygen -Y sign -n gitea -f /path_to_your_pubkey" $.TokenToSign}}</code></p>
 							</div>
 							<br>
 						</div>


### PR DESCRIPTION
Signed-off-by: Junjie Yuan <yuan@junjie.pro>

If missing space, ssh-keygen will report "Too few arguments for sign: missing namespace" and failed to generate ssh token.