### PR TITLE
[Backport] Fix invalid CSRF token bug, make sure CSRF tokens can be up-to-date

### DIFF
--- a/modules/context/csrf.go
+++ b/modules/context/csrf.go
@@ -229,6 +229,7 @@ func Csrfer(opt CsrfOptions, ctx *Context) CSRF {
 		}
 	}
 
+	needsNew = needsNew || ctx.Req.Method == "GET" // If this request is a Get request, it will generate a new token, make sure the token is always up-to-date.
 	if needsNew {
 		// FIXME: actionId.
 		x.Token = GenerateToken(x.Secret, x.ID, "POST")


### PR DESCRIPTION
Related to:
* https://github.com/go-gitea/gitea/pull/19337

This is a simple fix, this PR just does what the comment says: `If this request is a Get request, it will generate a new token`

Then the CSRF token can be kept up-to-date.