### PR TITLE
Use "main" as default branch name

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -879,7 +879,7 @@ PATH =
 ;DISABLE_STARS = false
 ;;
 ;; The default branch name of new repositories
-;DEFAULT_BRANCH = master
+;DEFAULT_BRANCH = main
 ;;
 ;; Allow adoption of unadopted repositories
 ;ALLOW_ADOPTION_OF_UNADOPTED_REPOSITORIES = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -75,7 +75,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 - `PREFIX_ARCHIVE_FILES`: **true**: Prefix archive files by placing them in a directory named after the repository.
 - `DISABLE_MIGRATIONS`: **false**: Disable migrating feature.
 - `DISABLE_STARS`: **false**: Disable stars feature.
-- `DEFAULT_BRANCH`: **master**: Default branch name of all repositories.
+- `DEFAULT_BRANCH`: **main**: Default branch name of all repositories.
 - `ALLOW_ADOPTION_OF_UNADOPTED_REPOSITORIES`: **false**: Allow non-admin users to adopt unadopted repositories
 - `ALLOW_DELETION_OF_UNADOPTED_REPOSITORIES`: **false**: Allow non-admin users to delete unadopted repositories
 

--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -165,6 +165,7 @@ func initIntegrationTest() {
 
 	setting.SetCustomPathAndConf("", "", "")
 	setting.LoadForTest()
+	setting.Repository.DefaultBranch = "master" // many test code still assume that default branch is called "master"
 	_ = util.RemoveAll(models.LocalCopyPath())
 	git.CheckLFSVersion()
 	setting.InitDBConfig()

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -69,6 +69,7 @@ func MainTest(m *testing.M, pathToGiteaRoot string, fixtureFiles ...string) {
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
 	setting.Database.UseSQLite3 = true
+	setting.Repository.DefaultBranch = "master" // many test code still assume that default branch is called "master"
 	repoRootPath, err := os.MkdirTemp(os.TempDir(), "repos")
 	if err != nil {
 		fatalTestError("TempDir: %v\n", err)

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -154,7 +154,7 @@ var (
 		PrefixArchiveFiles:                      true,
 		DisableMigrations:                       false,
 		DisableStars:                            false,
-		DefaultBranch:                           "master",
+		DefaultBranch:                           "main",
 
 		// Repository editor settings
 		Editor: struct {


### PR DESCRIPTION
Close #19351


## :warning: BREAKING :warning:

This changes the the default value of `repository.DEFAULT_BRANCH` from `master` to `main`.
If some users have to use `master` as the default branch name, they should set the `DEFAULT_BRANCH` option manually in `app.ini`