### PR TITLE
 Don't allow merging PR's which are being conflict checked (#19357)

### DIFF
--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -36,7 +36,7 @@ var (
 	ErrUserNotAllowedToMerge = errors.New("user not allowed to merge")
 	ErrHasMerged             = errors.New("has already been merged")
 	ErrIsWorkInProgress      = errors.New("work in progress PRs cannot be merged")
-	ErrIsChecking            = errors.New("PRs which are still being conflict checked cannot be merged")
+	ErrIsChecking            = errors.New("cannot merge while conflict checking is in progress")
 	ErrNotMergableState      = errors.New("not in mergeable state")
 	ErrDependenciesLeft      = errors.New("is blocked by an open dependency")
 )

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -36,6 +36,7 @@ var (
 	ErrUserNotAllowedToMerge = errors.New("user not allowed to merge")
 	ErrHasMerged             = errors.New("has already been merged")
 	ErrIsWorkInProgress      = errors.New("work in progress PRs cannot be merged")
+	ErrIsChecking            = errors.New("PRs which are still being conflict checked cannot be merged")
 	ErrNotMergableState      = errors.New("not in mergeable state")
 	ErrDependenciesLeft      = errors.New("is blocked by an open dependency")
 )
@@ -86,6 +87,10 @@ func CheckPullMergable(ctx context.Context, doer *user_model.User, perm *models.
 
 	if !pr.CanAutoMerge() {
 		return ErrNotMergableState
+	}
+
+	if pr.IsChecking() {
+		return ErrIsChecking
 	}
 
 	if err := CheckPRReadyToMerge(pr, false); err != nil {


### PR DESCRIPTION
- Backport of #19357
  - When a PR is still being conflict checked, don't allow the PR to be merged(the merge button could already be visible before e.g. a new commit was pushed to the PR).
  - Resolves #19352

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
