### PR TITLE
Document 409 error returned by repos/migrate api

### DIFF
--- a/routers/api/v1/repo/migrate.go
+++ b/routers/api/v1/repo/migrate.go
@@ -52,6 +52,8 @@ func Migrate(ctx *context.APIContext) {
 	//     "$ref": "#/responses/Repository"
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
+	//   "409":
+	//     description: The repository with the same name already exists.
 	//   "422":
 	//     "$ref": "#/responses/validationError"
 

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -2222,6 +2222,9 @@
           "403": {
             "$ref": "#/responses/forbidden"
           },
+          "409": {
+            "description": "The repository with the same name already exists."
+          },
           "422": {
             "$ref": "#/responses/validationError"
           }


### PR DESCRIPTION
<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
The API `/repos/migrate` could return a `409 Conflict` error if a repo with the same name already exists. This pull request document this error code in swagger.