### PR TITLE
Fix middleware function's placements

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -429,8 +429,8 @@ func RegisterRoutes(m *web.Route) {
 
 	m.Group("/user", func() {
 		// r.Get("/feeds", binding.Bind(auth.FeedsForm{}), user.Feeds)
-		m.Get("/activate", auth.Activate, reqSignIn)
-		m.Post("/activate", auth.ActivatePost, reqSignIn)
+		m.Get("/activate", auth.Activate)
+		m.Post("/activate", auth.ActivatePost)
 		m.Any("/activate_email", auth.ActivateEmail)
 		m.Get("/avatar/{username}/{size}", user.AvatarByUserName)
 		m.Get("/recover_account", auth.ResetPasswd)
@@ -438,9 +438,9 @@ func RegisterRoutes(m *web.Route) {
 		m.Get("/forgot_password", auth.ForgotPasswd)
 		m.Post("/forgot_password", auth.ForgotPasswdPost)
 		m.Post("/logout", auth.SignOut)
-		m.Get("/task/{task}", user.TaskStatus)
-		m.Get("/stopwatches", user.GetStopwatches, reqSignIn)
-		m.Get("/search", user.Search, ignExploreSignIn)
+		m.Get("/task/{task}", reqSignIn, user.TaskStatus)
+		m.Get("/stopwatches", reqSignIn, user.GetStopwatches)
+		m.Get("/search", ignExploreSignIn, user.Search)
 	})
 	// ***** END: User *****
 


### PR DESCRIPTION
- Add reqSignIn to `/task/{task}` as it specific to a logged in user currently not-logged in user could cause a NPE.
- Move `/stopwatch` & `/search` middleware before the actual function is called, because functions are executed in order and currently hadn't any effect and could as well cause a NPE due to that.
- Remove `/active` reqSignIn middleware, because when you want to active a account you're not "signed in" so it doesn't make sense to add that middleware.
