### PR TITLE
Fix middleware function's placements (#19377)

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -374,8 +374,8 @@ func RegisterRoutes(m *web.Route) {
 
 	m.Group("/user", func() {
 		// r.Get("/feeds", binding.Bind(auth.FeedsForm{}), user.Feeds)
-		m.Get("/activate", auth.Activate, reqSignIn)
-		m.Post("/activate", auth.ActivatePost, reqSignIn)
+		m.Get("/activate", auth.Activate)
+		m.Post("/activate", auth.ActivatePost)
 		m.Any("/activate_email", auth.ActivateEmail)
 		m.Get("/avatar/{username}/{size}", user.AvatarByUserName)
 		m.Get("/recover_account", auth.ResetPasswd)
@@ -383,7 +383,7 @@ func RegisterRoutes(m *web.Route) {
 		m.Get("/forgot_password", auth.ForgotPasswd)
 		m.Post("/forgot_password", auth.ForgotPasswdPost)
 		m.Post("/logout", auth.SignOut)
-		m.Get("/task/{task}", user.TaskStatus)
+		m.Get("/task/{task}", reqSignIn, user.TaskStatus)
 	})
 	// ***** END: User *****
 


### PR DESCRIPTION
- Backport #19377
  - Add reqSignIn to `/task/{task}` as it specific to a logged in user currently not-logged in user could cause a NPE.
  - Remove `/active` reqSignIn middleware, because when you want to active a account you're not "signed in" so it doesn't make sense to add that middleware.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
