### PR TITLE
Fix double blob-hunk on diff page

### DIFF
--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -31,9 +31,7 @@
 				{{if eq .GetType 4}}
 					<td class="chroma lines-code blob-hunk">{{/*
 						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
-					*/}}
-				{{$line.Content}}
-					</td>
+					*/}}</td>
 				{{else}}
 					<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*


### PR DESCRIPTION
- Don't show the blob-hunk twice.

Before:
![image](https://user-images.githubusercontent.com/25481501/163435226-bc4d7b29-fff0-440f-940f-12a35df4781c.png)

After:
![image](https://user-images.githubusercontent.com/25481501/163435186-56d35385-1fc6-48cf-9e36-71c001fe92e8.png)
