### PR TITLE
Fix double blob-hunk on diff page (#19404)

### DIFF
--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -32,7 +32,6 @@
 					<td class="chroma lines-code blob-hunk">{{/*
 						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
 					*/}}
-				{{$line.Content}}
 					</td>
 				{{else}}
 					<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*


### PR DESCRIPTION
- Backport #19404
  - Don't show the blob-hunk twice.
  - Before:
![image](https://user-images.githubusercontent.com/25481501/163435226-bc4d7b29-fff0-440f-940f-12a35df4781c.png)

  - After:
![image](https://user-images.githubusercontent.com/25481501/163435186-56d35385-1fc6-48cf-9e36-71c001fe92e8.png)

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
