### PR TITLE
Only request write when necessary #18657

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -8,7 +8,6 @@ package setting
 import (
 	"encoding/base64"
 	"fmt"
-	"io"
 	"math"
 	"net"
 	"net/url"
@@ -1080,15 +1079,9 @@ func loadInternalToken(sec *ini.Section) string {
 	}
 	switch tempURI.Scheme {
 	case "file":
-		fp, err := os.OpenFile(tempURI.RequestURI(), os.O_RDWR, 0o600)
-		if err != nil {
+		buf, err := os.ReadFile(tempURI.RequestURI())
+		if err != nil && !os.IsNotExist(err) {
 			log.Fatal("Failed to open InternalTokenURI (%s): %v", uri, err)
-		}
-		defer fp.Close()
-
-		buf, err := io.ReadAll(fp)
-		if err != nil {
-			log.Fatal("Failed to read InternalTokenURI (%s): %v", uri, err)
 		}
 		// No token in the file, generate one and store it.
 		if len(buf) == 0 {
@@ -1096,12 +1089,12 @@ func loadInternalToken(sec *ini.Section) string {
 			if err != nil {
 				log.Fatal("Error generate internal token: %v", err)
 			}
-			if _, err := io.WriteString(fp, token); err != nil {
+			err = os.WriteFile(tempURI.RequestURI(), []byte(token), 0o600)
+			if err != nil {
 				log.Fatal("Error writing to InternalTokenURI (%s): %v", uri, err)
 			}
 			return token
 		}
-
 		return strings.TrimSpace(string(buf))
 	default:
 		log.Fatal("Unsupported URI-Scheme %q (INTERNAL_TOKEN_URI = %q)", tempURI.Scheme, uri)


### PR DESCRIPTION
backport #18657

* Only request write when necessary

- Only request write for `INTERNAL_TOKEN_URI` when no token was found.
- Resolves #18655

* Fix perm

* Update setting.go

* Update setting.go

* Update setting.go

Co-authored-by: wxiaoguang <wxiaoguang@gmail.com>
Co-authored-by: zeripath <art27@cantab.net>
