### PR TITLE
Add uploadpack.allowAnySHA1InWant to allow --filter=blob:none with older git clients

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -148,7 +148,7 @@ func Init(ctx context.Context) error {
 
 	// By default partial clones are disabled, enable them from git v2.22
 	if !setting.Git.DisablePartialClone && CheckGitVersionAtLeast("2.22") == nil {
-		globalCommandArgs = append(globalCommandArgs, "-c", "uploadpack.allowfilter=true")
+		globalCommandArgs = append(globalCommandArgs, "-c", "uploadpack.allowfilter=true", "-c", "uploadpack.allowAnySHA1InWant=true")
 	}
 
 	// Save current git version on init to gitVersion otherwise it would require an RWMutex


### PR DESCRIPTION
Older git clients need uploadpack.allowAnySHA1InWant if partial cloning is allowed.

Fix #19118

Signed-off-by: Andrew Thornton <art27@cantab.net>
