### PR TITLE
Fix panic in team repos API

### DIFF
--- a/models/organization/team_repo.go
+++ b/models/organization/team_repo.go
@@ -48,7 +48,7 @@ func GetTeamRepositories(ctx context.Context, opts *SearchTeamRepoOptions) ([]*r
 		)
 	}
 	if opts.PageSize > 0 {
-		sess.Limit(opts.PageSize, (opts.Page - 1)*opts.PageSize)
+		sess.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize)
 	}
 	var repos []*repo_model.Repository
 	return repos, sess.OrderBy("repository.name").

--- a/models/organization/team_repo.go
+++ b/models/organization/team_repo.go
@@ -48,7 +48,7 @@ func GetTeamRepositories(ctx context.Context, opts *SearchTeamRepoOptions) ([]*r
 		)
 	}
 	if opts.PageSize > 0 {
-		sess.Limit(opts.PageSize, opts.Page*opts.PageSize)
+		sess.Limit(opts.PageSize, (opts.Page - 1)*opts.PageSize)
 	}
 	var repos []*repo_model.Repository
 	return repos, sess.OrderBy("repository.name").

--- a/routers/api/v1/org/team.go
+++ b/routers/api/v1/org/team.go
@@ -545,7 +545,7 @@ func GetTeamRepos(ctx *context.APIContext) {
 		ctx.Error(http.StatusInternalServerError, "GetTeamRepos", err)
 		return
 	}
-	repos := make([]*api.Repository, len(team.Repos))
+	repos := make([]*api.Repository, len(teamRepos))
 	for i, repo := range teamRepos {
 		access, err := models.AccessLevel(ctx.Doer, repo)
 		if err != nil {

--- a/routers/web/misc/markdown.go
+++ b/routers/web/misc/markdown.go
@@ -16,6 +16,7 @@ import (
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
+
 	"mvdan.cc/xurls/v2"
 )
 


### PR DESCRIPTION
Same situation as https://github.com/go-gitea/gitea/commit/d139c23967a2a376ce61acd9a7a1af5887b818f1, probably happened during some refactoring.