### PR TITLE
Allow SPNEGO with SSPI for repo access via GIT over HTTP(S)

### DIFF
--- a/routers/web/repo/http.go
+++ b/routers/web/repo/http.go
@@ -159,6 +159,12 @@ func httpBase(ctx *context.Context) (h *serviceHandler) {
 		if !ctx.IsSigned {
 			// TODO: support digit auth - which would be Authorization header with digit
 			ctx.Resp.Header().Set("WWW-Authenticate", "Basic realm=\".\"")
+
+			if auth.IsSSPIEnabled() {
+				// if SSPI is enabled add Negotiate to the list of supported authentication methods
+				ctx.Resp.Header().Add("WWW-Authenticate", "Negotiate")
+			}
+
 			ctx.Error(http.StatusUnauthorized)
 			return
 		}

--- a/services/auth/sspi_windows.go
+++ b/services/auth/sspi_windows.go
@@ -178,6 +178,14 @@ func (s *SSPI) shouldAuthenticate(req *http.Request) (shouldAuth bool) {
 		}
 	} else if middleware.IsAPIPath(req) || isAttachmentDownload(req) {
 		shouldAuth = true
+	} else if isGitRawReleaseOrLFSPath(req) {
+		// Allow login via SSPI if access to the repo is requested and
+		// a negotiation authorization header is present
+		_, err := sspiAuth.GetAuthData(req, nil)
+		if err == nil {
+			log.Trace("SSPI Authorization: Got authorization header, try to login")
+			shouldAuth = true
+		}
 	}
 	return
 }


### PR DESCRIPTION
This changes allows SPNEGO / Kerberos negotiation for access to the git repo (clone, push, ...).

Note: The git config must be [changed ](https://docs.gitlab.com/ee/integration/kerberos.html#http-basic-access-denied-when-cloning)so that empty http authentication is allowed.
(Kerberos ticket already contains the username).

```
git config --global http.emptyAuth true
```

![grafik](https://user-images.githubusercontent.com/1390036/164224441-52f38b18-d4d0-4c93-9508-0d0390d7c371.png)
![grafik](https://user-images.githubusercontent.com/1390036/164224948-3a1844cd-b4bc-44bc-aa2d-b37a47ce1034.png)


<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
