### PR TITLE
When dumping trim the standard suffices instead of a random suffix

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -160,7 +160,12 @@ func runDump(ctx *cli.Context) error {
 			fatal("Deleting default logger failed. Can not write to stdout: %v", err)
 		}
 	} else {
-		fileName = strings.TrimSuffix(fileName, path.Ext(fileName))
+		for _, suffix := range outputTypeEnum.Enum {
+			if strings.HasSuffix(fileName, "."+suffix) {
+				fileName = strings.TrimSuffix(fileName, "."+suffix)
+				break
+			}
+		}
 		fileName += "." + outType
 	}
 	setting.LoadFromExisting()

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -86,7 +86,7 @@ func (o outputType) String() string {
 }
 
 var outputTypeEnum = &outputType{
-	Enum:    []string{"zip", "rar", "tar", "sz", "tar.gz", "tar.xz", "tar.bz2", "tar.br", "tar.lz4"},
+	Enum:    []string{"zip", "tar", "tar.sz", "tar.gz", "tar.xz", "tar.bz2", "tar.br", "tar.lz4"},
 	Default: "zip",
 }
 


### PR DESCRIPTION
Instead of using the `path.Ext()` to trim the last "extension" suffix, just iterate
through the supported suffices and trim those.

Fix #19424

Signed-off-by: Andrew Thornton <art27@cantab.net>
