### PR TITLE
Don't panic on `ErrEmailInvalid` (#19441)

### DIFF
--- a/integrations/api_user_email_test.go
+++ b/integrations/api_user_email_test.go
@@ -69,6 +69,12 @@ func TestAPIAddEmail(t *testing.T) {
 			Primary:  false,
 		},
 	}, emails)
+
+	opts = api.CreateEmailOption{
+		Emails: []string{"notAEmail"},
+	}
+	req = NewRequestWithJSON(t, "POST", "/api/v1/user/emails?token="+token, &opts)
+	session.MakeRequest(t, req, http.StatusUnprocessableEntity)
 }
 
 func TestAPIDeleteEmail(t *testing.T) {

--- a/routers/api/v1/user/email.go
+++ b/routers/api/v1/user/email.go
@@ -80,9 +80,16 @@ func AddEmail(ctx *context.APIContext) {
 	if err := user_model.AddEmailAddresses(emails); err != nil {
 		if user_model.IsErrEmailAlreadyUsed(err) {
 			ctx.Error(http.StatusUnprocessableEntity, "", "Email address has been used: "+err.(user_model.ErrEmailAlreadyUsed).Email)
-		} else if user_model.IsErrEmailCharIsNotSupported(err) ||
-			user_model.IsErrEmailInvalid(err) {
-			errMsg := fmt.Sprintf("Email address %s invalid", err.(user_model.ErrEmailInvalid).Email)
+		} else if user_model.IsErrEmailCharIsNotSupported(err) || user_model.IsErrEmailInvalid(err) {
+			email := ""
+			if typedError, ok := err.(user_model.ErrEmailInvalid); ok {
+				email = typedError.Email
+			}
+			if typedError, ok := err.(user_model.ErrEmailCharIsNotSupported); ok {
+				email = typedError.Email
+			}
+
+			errMsg := fmt.Sprintf("Email address %q invalid", email)
 			ctx.Error(http.StatusUnprocessableEntity, "", errMsg)
 		} else {
 			ctx.Error(http.StatusInternalServerError, "AddEmailAddresses", err)


### PR DESCRIPTION
- Backport #19441
  - Don't panic on `ErrEmailInvalid`, this was caused due that we were trying to force `ErrEmailCharIsNotSupported` interface, which panics.
  - Resolves #19397

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
