### PR TITLE
[doctor] authorized-keys: fix displayed check name

### DIFF
--- a/modules/doctor/authorizedkeys.go
+++ b/modules/doctor/authorizedkeys.go
@@ -72,8 +72,8 @@ func checkAuthorizedKeys(ctx context.Context, logger log.Logger, autofix bool) e
 				"authorized_keys file %q is out of date.\nRegenerate it with:\n\t\"%s\"\nor\n\t\"%s\"",
 				fPath,
 				"gitea admin regenerate keys",
-				"gitea doctor --run authorized_keys --fix")
-			return fmt.Errorf(`authorized_keys is out of date and should be regenerated with "gitea admin regenerate keys" or "gitea doctor --run authorized_keys --fix"`)
+				"gitea doctor --run authorized-keys --fix")
+			return fmt.Errorf(`authorized_keys is out of date and should be regenerated with "gitea admin regenerate keys" or "gitea doctor --run authorized-keys --fix"`)
 		}
 		logger.Warn("authorized_keys is out of date. Attempting rewrite...")
 		err = asymkey_model.RewriteAllPublicKeys()


### PR DESCRIPTION
The registered check name is `authorized-keys`, not `authorized_keys`:
```
$ ./gitea-1.16.5-linux-amd64 --config /etc/gitea/gitea.ini --work-path /srv/gitea doctor --all
[...]
[6] Check if OpenSSH authorized_keys file is up-to-date
 - [C] authorized_keys file "/srv/gitea/.ssh/authorized_keys" is out of date.
	Regenerate it with:
		"gitea admin regenerate keys"
	or
		"gitea doctor --run authorized_keys --fix"
ERROR
[...]
$ gitea-1.16.5-linux-amd64 --config /etc/gitea/gitea.ini --work-path /srv/gitea doctor --run authorized_keys --fix # nothing is done
$ gitea-1.16.5-linux-amd64 --config /etc/gitea/gitea.ini --work-path /srv/gitea doctor --run authorized-keys --fix
[1] Check if OpenSSH authorized_keys file is up-to-date
 - [W] authorized_keys is out of date. Attempting rewrite...
[...]
OK
```