### PR TITLE
Prevent dangling cat-file calls (goroutine alternative) (#19454)

### DIFF
--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -54,6 +54,12 @@ func CatFileBatchCheck(ctx context.Context, repoPath string) (WriteCloserError, 
 		<-closed
 	}
 
+	// Ensure cancel is called as soon as the provided context is cancelled
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+
 	_, filename, line, _ := runtime.Caller(2)
 	filename = strings.TrimPrefix(filename, callerPrefix)
 
@@ -92,6 +98,12 @@ func CatFileBatch(ctx context.Context, repoPath string) (WriteCloserError, *bufi
 		_ = batchStdoutReader.Close()
 		<-closed
 	}
+
+	// Ensure cancel is called as soon as the provided context is cancelled
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
 
 	_, filename, line, _ := runtime.Caller(2)
 	filename = strings.TrimPrefix(filename, callerPrefix)


### PR DESCRIPTION
Backport #19454

If an `os/exec.Command` is passed non `*os.File` as an input/output, go
will create `os.Pipe`s and wait for their closure in `cmd.Wait()`.  If
the code following this is responsible for closing `io.Pipe`s or other
handlers then on process death from context cancellation the `Wait` can
hang.

There are two possible solutions:

1. use `os.Pipe` as the input/output as `cmd.Wait` does not wait for these.
2. create a goroutine waiting on the context cancellation that will close the inputs.

This PR provides the second option - which is a simpler change that can
be more easily backported.

Signed-off-by: Andrew Thornton <art27@cantab.net>