### PR TITLE
Use horizontal tabs for repo header on mobile

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -144,7 +144,7 @@
 		</div><!-- end grid -->
 	</div><!-- end container -->
 {{end}}
-	<div class="ui tabs container">
+	<div class="ui tabs container repo-header-container">
 		{{if not (or .Repository.IsBeingCreated .Repository.IsBroken)}}
 			<div class="ui tabular stackable menu navbar">
 				{{if .Permission.CanRead $.UnitTypeCode}}

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2956,11 +2956,21 @@ tbody.commit-list {
   justify-content: space-between;
   flex-wrap: wrap;
   word-break: break-word;
+
+  @media @mediaSm {
+    + .container {
+      margin-top: 7px;
+    }
+  }
 }
 
 .repo-buttons {
   display: flex;
   align-items: center;
+
+  @media @mediaSm {
+    margin-top: 1em;
+  }
 }
 
 .repo-buttons .ui.labeled.button > .label:hover {
@@ -3225,5 +3235,20 @@ td.blob-excerpt {
 
 .repository.migrate .card:hover {
   transform: scale(105%);
-  box-shadow: 0 .5rem 1rem var(--color-shadow) !important;
+  box-shadow: 0 0.5rem 1rem var(--color-shadow) !important;
+}
+
+@media @mediaSm {
+  .repo-header-container {
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    .ui.stackable.menu {
+      flex-direction: row;
+
+      .item {
+        width: initial !important;
+      }
+    }
+  }
 }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3235,7 +3235,7 @@ td.blob-excerpt {
 
 .repository.migrate .card:hover {
   transform: scale(105%);
-  box-shadow: 0 0.5rem 1rem var(--color-shadow) !important;
+  box-shadow: 0 .5rem 1rem var(--color-shadow) !important;
 }
 
 @media @mediaSm {


### PR DESCRIPTION
- The current behavior of the repo header on mobile is to display them vertically column-by-column. I've only experience annoyance due to this while trying to visit gitea instanced on mobile. This commit changes
this behavior to use horizontal tabs, it uses less tabs and doesn't bloat 60% of your mobile screen with the repo headers.
- A small fix added in this commit is to give some space around the repo buttons, current behavior is that they are too "close" to the repo title.

Before:

<img src="https://user-images.githubusercontent.com/25481501/164795021-d4812f9e-8d1f-45e0-a8c5-996deedd1604.jpg" width="512px">

After:

<img src="https://user-images.githubusercontent.com/25481501/164795066-fa294e42-0652-490e-8ae1-65ba250c7297.jpg" width="512px">
