### PR TITLE
Allow package dump skipping

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,10 +26,21 @@ import (
 	"github.com/urfave/cli"
 )
 
-func addFile(w archiver.Writer, filePath, absPath string, verbose bool) error {
+func addReader(w archiver.Writer, r io.ReadCloser, info os.FileInfo, customName string, verbose bool) error {
 	if verbose {
-		log.Info("Adding file %s\n", filePath)
+		log.Info("Adding file %s\n", customName)
 	}
+
+	return w.Write(archiver.File{
+		FileInfo: archiver.FileInfo{
+			FileInfo:   info,
+			CustomName: customName,
+		},
+		ReadCloser: r,
+	})
+}
+
+func addFile(w archiver.Writer, filePath, absPath string, verbose bool) error {
 	file, err := os.Open(absPath)
 	if err != nil {
 		return err
@@ -39,13 +51,7 @@ func addFile(w archiver.Writer, filePath, absPath string, verbose bool) error {
 		return err
 	}
 
-	return w.Write(archiver.File{
-		FileInfo: archiver.FileInfo{
-			FileInfo:   fileInfo,
-			CustomName: filePath,
-		},
-		ReadCloser: file,
-	})
+	return addReader(w, file, fileInfo, filePath, verbose)
 }
 
 func isSubdir(upper, lower string) (bool, error) {
@@ -241,13 +247,7 @@ func runDump(ctx *cli.Context) error {
 				return err
 			}
 
-			return w.Write(archiver.File{
-				FileInfo: archiver.FileInfo{
-					FileInfo:   info,
-					CustomName: path.Join("data", "lfs", objPath),
-				},
-				ReadCloser: object,
-			})
+			return addReader(w, object, info, path.Join("data", "lfs", objPath), verbose)
 		}); err != nil {
 			fatal("Failed to dump LFS objects: %v", err)
 		}
@@ -341,13 +341,7 @@ func runDump(ctx *cli.Context) error {
 			return err
 		}
 
-		return w.Write(archiver.File{
-			FileInfo: archiver.FileInfo{
-				FileInfo:   info,
-				CustomName: path.Join("data", "attachments", objPath),
-			},
-			ReadCloser: object,
-		})
+		return addReader(w, object, info, path.Join("data", "attachments", objPath), verbose)
 	}); err != nil {
 		fatal("Failed to dump attachments: %v", err)
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -28,7 +28,7 @@ import (
 
 func addReader(w archiver.Writer, r io.ReadCloser, info os.FileInfo, customName string, verbose bool) error {
 	if verbose {
-		log.Info("Adding file %s\n", customName)
+		log.Info("Adding file %s", customName)
 	}
 
 	return w.Write(archiver.File{

--- a/docs/content/doc/usage/command-line.en-us.md
+++ b/docs/content/doc/usage/command-line.en-us.md
@@ -313,8 +313,13 @@ in the current directory.
   - `--tempdir path`, `-t path`: Path to the temporary directory used. Optional. (default: /tmp).
   - `--skip-repository`, `-R`: Skip the repository dumping. Optional.
   - `--skip-custom-dir`: Skip dumping of the custom dir. Optional.
+  - `--skip-lfs-data`: Skip dumping of LFS data. Optional.
+  - `--skip-attachment-data`: Skip dumping of attachment data. Optional.
+  - `--skip-package-data`: Skip dumping of package data. Optional.
+  - `--skip-log`: Skip dumping of log data. Optional.
   - `--database`, `-d`: Specify the database SQL syntax. Optional.
   - `--verbose`, `-V`: If provided, shows additional details. Optional.
+  - `--type`: Set the dump output format. Optional. (default: zip)
 - Examples:
   - `gitea dump`
   - `gitea dump --verbose`


### PR DESCRIPTION
Two changes in here:
- first commit enables the `--verbose` flag for LFS and attachments
- second commit allows to skip package dumping