### PR TITLE
Allow commit status popup on /pulls page

### DIFF
--- a/web_src/js/features/repo-commit.js
+++ b/web_src/js/features/repo-commit.js
@@ -49,3 +49,16 @@ export function initRepoCommitLastCommitLoader() {
     });
   });
 }
+
+export function initCommitStatuses() {
+  $('.commit-statuses-trigger').each(function () {
+    const positionRight = $('.repository.file.list').length > 0 || $('.repository.diff').length > 0;
+    const popupPosition = positionRight ? 'right center' : 'left center';
+    $(this)
+      .popup({
+        on: 'click',
+        lastResort: popupPosition, // prevent error message "Popup does not fit within the boundaries of the viewport"
+        position: popupPosition,
+      });
+  });
+}

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -418,11 +418,6 @@ async function onEditContent(event) {
 }
 
 export function initRepository() {
-  if ($('.repository').length === 0) {
-    return;
-  }
-
-
   // Commit statuses
   $('.commit-statuses-trigger').each(function () {
     const positionRight = $('.repository.file.list').length > 0 || $('.repository.diff').length > 0;
@@ -434,6 +429,10 @@ export function initRepository() {
         position: popupPosition,
       });
   });
+  
+  if ($('.repository').length === 0) {
+    return;
+  }
 
   // File list and commits
   if ($('.repository.file.list').length > 0 || $('.branch-dropdown').length > 0 ||

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -418,21 +418,10 @@ async function onEditContent(event) {
 }
 
 export function initRepository() {
-  // Commit statuses
-  $('.commit-statuses-trigger').each(function () {
-    const positionRight = $('.repository.file.list').length > 0 || $('.repository.diff').length > 0;
-    const popupPosition = positionRight ? 'right center' : 'left center';
-    $(this)
-      .popup({
-        on: 'click',
-        lastResort: popupPosition, // prevent error message "Popup does not fit within the boundaries of the viewport"
-        position: popupPosition,
-      });
-  });
-  
   if ($('.repository').length === 0) {
     return;
   }
+
 
   // File list and commits
   if ($('.repository.file.list').length > 0 || $('.branch-dropdown').length > 0 ||

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -165,6 +165,8 @@ $(document).ready(() => {
   initRepoWikiForm();
   initRepository();
 
+  initCommitStatuses();
+
   initUserAuthLinkAccountView();
   initUserAuthOauth2();
   initUserAuthWebAuthn();

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -38,7 +38,11 @@ import {
   initRepoPullRequestMergeInstruction,
   initRepoPullRequestReview,
 } from './features/repo-issue.js';
-import {initRepoEllipsisButton, initRepoCommitLastCommitLoader} from './features/repo-commit.js';
+import {
+  initRepoEllipsisButton,
+  initRepoCommitLastCommitLoader,
+  initCommitStatuses,
+} from './features/repo-commit.js';
 import {
   checkAppUrl,
   initFootLanguageMenu,


### PR DESCRIPTION
The /pulls page doesn't contain a "repository" element, so the early-out here was preventing the commit status popup hook from working. However, the only thing the .repository element is being used for here is determining whether the popup should be on the right or on the left, so we don't actually need the element to exist for the hook to work.