### PR TITLE
Make repository file list useable on mobile

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -36,8 +36,9 @@
 			</th>
 			<th class="text grey right age">
 				<span class="mobile-align">
-					{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}</th>
+					{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}
 				</span>
+			</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -92,8 +93,9 @@
 				</td>
 				<td class="text right age three wide">
 					<span class="truncate">
-						{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}</td>
+						{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}
 					</span>
+				</td>
 			</tr>
 		{{end}}
 	</tbody>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -34,11 +34,7 @@
 					</span>
 				{{end}}
 			</th>
-			<th class="text grey right age">
-				<span class="mobile-align">
-					{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}
-				</span>
-			</th>
+			<th class="text grey right age">{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -91,11 +87,7 @@
 						{{end}}
 					</span>
 				</td>
-				<td class="text right age three wide">
-					<span class="truncate">
-						{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}
-					</span>
-				</td>
+				<td class="text right age three wide">{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}</td>
 			</tr>
 		{{end}}
 	</tbody>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -34,7 +34,10 @@
 					</span>
 				{{end}}
 			</th>
-			<th class="text grey right age">{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}</th>
+			<th class="text grey right age">
+				<span class="mobile-align">
+					{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n.Lang}}{{end}}{{end}}</th>
+				</span>
 		</tr>
 	</thead>
 	<tbody>
@@ -87,7 +90,10 @@
 						{{end}}
 					</span>
 				</td>
-				<td class="text right age three wide">{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}</td>
+				<td class="text right age three wide">
+					<span class="truncate">
+						{{if $commit}}{{TimeSince $commit.Committer.When $.i18n.Lang}}{{end}}</td>
+					</span>
 			</tr>
 		{{end}}
 	</tbody>

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3243,6 +3243,7 @@ td.blob-excerpt {
     #repo-files-table {
       .entry,
       .commit-list {
+        align-items: center;
         display: flex !important;
         padding-top: 4px;
         padding-bottom: 4px;
@@ -3255,11 +3256,6 @@ td.blob-excerpt {
         td.message,
         span.commit-summary {
           display: none !important;
-        }
-
-        th .mobile-align {
-          display: inline-block;
-          padding-top: 5px;
         }
       }
     }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3251,4 +3251,30 @@ td.blob-excerpt {
       }
     }
   }
+
+  .repository.file.list {
+    #repo-files-table {
+      .entry,
+      .commit-list {
+        display: flex !important;
+        padding-top: 4px;
+        padding-bottom: 4px;
+
+        td.age,
+        th.age {
+          margin-left: auto !important;
+        }
+
+        td.message,
+        span.commit-summary {
+          display: none !important;
+        }
+
+        th .mobile-align {
+          display: inline-block;
+          padding-top: 5px;
+        }
+      }
+    }
+  }
 }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3249,7 +3249,7 @@ td.blob-excerpt {
 
         td.age,
         th.age {
-          margin-left: auto !important;
+          margin-left: auto;
         }
 
         td.message,


### PR DESCRIPTION
- When you're browsing a repository on mobile, you're met by a giant block called the "repository file list". The current design is not useable for mobile and is a big annoyance while browsing a repo on
mobile. This PR removes that annoyance by making it more suitable design when on mobile.
- Adds HTML for the commit/file time to align it vertically(noticeable on mobile, not on PC).
- Show all information horizontally and not vertically.
- Remove the last commit message of the file, there isn't enough space on mobile to place this anywhere, so we're not trying to make a best-effort here and instead just not display it.

Before:
<img src="https://user-images.githubusercontent.com/25481501/165389254-f045681f-55c2-4e78-88f5-f24a1e13d265.jpg" width="512"/>

After:
<img src="https://user-images.githubusercontent.com/25481501/165389273-fb0e7640-bdc0-40bf-b9f6-2fc8cdcecf4e.jpg" width="512"/>

