### PR TITLE
Don't let repo clone URL overflow

### DIFF
--- a/templates/repo/clone_buttons.tmpl
+++ b/templates/repo/clone_buttons.tmpl
@@ -10,7 +10,7 @@
 	</button>
 {{end}}
 <!-- the value will be updated by initRepoCloneLink, the code below is used to avoid UI flicking  -->
-<input id="repo-clone-url" value="" readonly>
+<input id="repo-clone-url" value="" size="1" readonly>
 <script>
 	(() => {
 		const proto = localStorage.getItem('repo-clone-protocol') || 'https';


### PR DESCRIPTION
- Apparently `<input>` elements differ from other elements have a size attribute that act as a `min-width` CSS property, this causes a overflow on mobile. By setting this size to `1` it doesn't try to force a min-width and nicely shrink down.

## Before:
<img src="https://user-images.githubusercontent.com/25481501/165403470-55b1da35-831d-498b-b746-2a5925834aee.jpg" width="512" />

## After:
<img src="https://user-images.githubusercontent.com/25481501/165403484-5584c26f-a9dd-4bdd-a23c-087702e0c2bd.jpg" width="512" />
