### PR TITLE
Unset git author/committer variables when running integration tests (#19512)

### DIFF
--- a/integrations/integration_test.go
+++ b/integrations/integration_test.go
@@ -112,6 +112,13 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	os.Unsetenv("GIT_AUTHOR_NAME")
+	os.Unsetenv("GIT_AUTHOR_EMAIL")
+	os.Unsetenv("GIT_AUTHOR_DATE")
+	os.Unsetenv("GIT_COMMITTER_NAME")
+	os.Unsetenv("GIT_COMMITTER_EMAIL")
+	os.Unsetenv("GIT_COMMITTER_DATE")
+
 	err := unittest.InitFixtures(
 		unittest.FixturesOptions{
 			Dir: filepath.Join(filepath.Dir(setting.AppPath), "models/fixtures/"),


### PR DESCRIPTION
Backport #19512

TestAPIGitTag (and likely others) will fail if the running environment contains
GIT_AUTHOR_NAME and other env variables like it.

This PR simply unsets these when running the integration tests.

Fix #14247

Signed-off-by: Andrew Thornton <art27@cantab.net>
