### PR TITLE
Prevent dangling archiver goroutine (#19516)

### DIFF
--- a/modules/indexer/code/indexer.go
+++ b/modules/indexer/code/indexer.go
@@ -130,7 +130,7 @@ func Init() {
 		log.Info("PID: %d Repository Indexer closed", os.Getpid())
 	})
 
-	waitChannel := make(chan time.Duration)
+	waitChannel := make(chan time.Duration, 1)
 
 	// Create the Queue
 	switch setting.Indexer.RepoType {

--- a/modules/indexer/issues/indexer.go
+++ b/modules/indexer/issues/indexer.go
@@ -98,7 +98,7 @@ var (
 // InitIssueIndexer initialize issue indexer, syncReindex is true then reindex until
 // all issue index done.
 func InitIssueIndexer(syncReindex bool) {
-	waitChannel := make(chan time.Duration)
+	waitChannel := make(chan time.Duration, 1)
 
 	// Create the Queue
 	switch setting.Indexer.IssueType {

--- a/services/repository/archiver/archiver.go
+++ b/services/repository/archiver/archiver.go
@@ -169,7 +169,7 @@ func doArchive(r *ArchiveRequest) (*repo_model.RepoArchiver, error) {
 		w.Close()
 		rd.Close()
 	}()
-	var done = make(chan error)
+	done := make(chan error, 1) // Ensure that there is some capacity which will ensure that the goroutine below can always finish
 	repo, err := repo_model.GetRepositoryByID(archiver.RepoID)
 	if err != nil {
 		return nil, fmt.Errorf("archiver.LoadRepo failed: %v", err)


### PR DESCRIPTION
Backport #19516

Within doArchive there is a service goroutine that performs the
archiving function.  This goroutine reports its error using a `chan
error` called `done`. Prior to this PR this channel had 0 capacity
meaning that the goroutine would block until the `done` channel was
cleared - however there are a couple of ways in which this channel might
not be read.

The simplest solution is to add a single space of capacity to the
goroutine which will mean that the goroutine will always complete and
even if the `done` channel is not read it will be simply garbage
collected away.

(The PR also contains two other places when setting up the indexers
which do not leak but where the blocking of the sending goroutine is
also unnecessary and so we should just add a small amount of capacity
and let the sending goroutine complete as soon as it can.)

Signed-off-by: Andrew Thornton <art27@cantab.net>
