### PR TITLE
Fix 64-bit atomic operations on 32-bit machines

### DIFF
--- a/modules/queue/workerpool.go
+++ b/modules/queue/workerpool.go
@@ -22,6 +22,10 @@ import (
 // they use to detect if there is a block and will grow and shrink in
 // response to demand as per configuration.
 type WorkerPool struct {
+	// This field requires to be the first one in the struct.
+	// This is to allow 64 bit atomic operations on 32-bit machines.
+	// See: https://pkg.go.dev/sync/atomic#pkg-note-BUG & Gitea issue 19518
+	numInQueue         int64
 	lock               sync.Mutex
 	baseCtx            context.Context
 	baseCtxCancel      context.CancelFunc
@@ -38,7 +42,6 @@ type WorkerPool struct {
 	blockTimeout       time.Duration
 	boostTimeout       time.Duration
 	boostWorkers       int
-	numInQueue         int64
 }
 
 var (


### PR DESCRIPTION
- Doing 64-bit atomic operations on 32-bit machines is a bit tricky by golang, as they can only be done under certain set of conditions(https://pkg.go.dev/sync/atomic#pkg-note-BUG).
- This PR fixes such case whereby the conditions weren't met, it moves the int64 to the first field of the struct, which will 64-bit operations happening on this property on 32-bit machines.
- Resolves #19518