### PR TITLE
Fix 64-bit atomic operations on 32-bit machines (#19531)

### DIFF
--- a/modules/queue/workerpool.go
+++ b/modules/queue/workerpool.go
@@ -19,6 +19,10 @@ import (
 // they use to detect if there is a block and will grow and shrink in
 // response to demand as per configuration.
 type WorkerPool struct {
+	// This field requires to be the first one in the struct.
+	// This is to allow 64 bit atomic operations on 32-bit machines.
+	// See: https://pkg.go.dev/sync/atomic#pkg-note-BUG & Gitea issue 19518
+	numInQueue         int64
 	lock               sync.Mutex
 	baseCtx            context.Context
 	baseCtxCancel      context.CancelFunc
@@ -32,7 +36,6 @@ type WorkerPool struct {
 	blockTimeout       time.Duration
 	boostTimeout       time.Duration
 	boostWorkers       int
-	numInQueue         int64
 }
 
 // WorkerPoolConfiguration is the basic configuration for a WorkerPool


### PR DESCRIPTION
- Backport #19531
  - Doing 64-bit atomic operations on 32-bit machines is a bit tricky by golang, as they can only be done under certain set of conditions(https://pkg.go.dev/sync/atomic#pkg-note-BUG).
  - This PR fixes such case whereby the conditions weren't met, it moves the int64 to the first field of the struct, which will 64-bit operations happening on this property on 32-bit machines.
  - Resolves #19518

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
