### PR TITLE
Update image URL for Discord webhook

### DIFF
--- a/routers/web/repo/webhook.go
+++ b/routers/web/repo/webhook.go
@@ -147,7 +147,6 @@ func WebhooksNew(ctx *context.Context) {
 	if hookType == "discord" {
 		ctx.Data["DiscordHook"] = map[string]interface{}{
 			"Username": "Gitea",
-			"IconURL":  setting.AppURL + "img/favicon.png",
 		}
 	}
 	ctx.Data["BaseLink"] = orCtx.LinkNew

--- a/templates/repo/settings/webhook/discord.tmpl
+++ b/templates/repo/settings/webhook/discord.tmpl
@@ -12,7 +12,7 @@
 		</div>
 		<div class="field">
 			<label for="icon_url">{{.i18n.Tr "repo.settings.discord_icon_url"}}</label>
-			<input id="icon_url" name="icon_url" value="{{.DiscordHook.IconURL}}" placeholder="e.g. https://example.com/img/favicon.png">
+			<input id="icon_url" name="icon_url" value="{{.DiscordHook.IconURL}}" placeholder="e.g. https://example.com/assets/img/logo.svg">
 		</div>
 		{{template "repo/settings/webhook/settings" .}}
 	</form>


### PR DESCRIPTION
This PR removes the "default" icon URL for a discord webhook. 
When setting up a webhook in Discord, you can give it an image, so I think the default on Gitea's side should be blank.
I have, however, updated the placeholder for people who want to easily reference the logo path.

I'm not married to removing the default, so if people really preferred it I can add it back (with the updated path).