### PR TITLE
Better describe what `/repos/{owner}/{repo}/raw/{filepath}` returns on 200

### DIFF
--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -53,7 +53,7 @@ func GetRawFile(ctx *context.APIContext) {
 	//   required: false
 	// responses:
 	//   200:
-	//     description: success
+	//     description: Returns raw file content.
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -8628,7 +8628,7 @@
         ],
         "responses": {
           "200": {
-            "description": "success"
+            "description": "Returns raw file content."
           },
           "404": {
             "$ref": "#/responses/notFound"


### PR DESCRIPTION
- Set on the description that it returns the raw file content.
- Resolves #19514
