### PR TITLE
Support `hostname:port` to pass host matcher's check

### DIFF
--- a/modules/hostmatcher/hostmatcher.go
+++ b/modules/hostmatcher/hostmatcher.go
@@ -125,13 +125,18 @@ func (hl *HostMatchList) checkIP(ip net.IP) bool {
 
 // MatchHostName checks if the host matches an allow/deny(block) list
 func (hl *HostMatchList) MatchHostName(host string) bool {
+	hostname, _, err := net.SplitHostPort(host)
+	if err != nil {
+		hostname = host
+	}
+
 	if hl == nil {
 		return false
 	}
-	if hl.checkPattern(host) {
+	if hl.checkPattern(hostname) {
 		return true
 	}
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := net.ParseIP(hostname); ip != nil {
 		return hl.checkIP(ip)
 	}
 	return false

--- a/modules/hostmatcher/hostmatcher_test.go
+++ b/modules/hostmatcher/hostmatcher_test.go
@@ -38,6 +38,7 @@ func TestHostOrIPMatchesList(t *testing.T) {
 
 		{"", net.ParseIP("10.0.1.1"), true},
 		{"10.0.1.1", nil, true},
+		{"10.0.1.1:8080", nil, true},
 		{"", net.ParseIP("192.168.1.1"), true},
 		{"192.168.1.1", nil, true},
 		{"", net.ParseIP("fd00::1"), true},
@@ -48,6 +49,7 @@ func TestHostOrIPMatchesList(t *testing.T) {
 
 		{"mydomain.com", net.IPv4zero, false},
 		{"sub.mydomain.com", net.IPv4zero, true},
+		{"sub.mydomain.com:8080", net.IPv4zero, true},
 
 		{"", net.ParseIP("169.254.1.1"), true},
 		{"169.254.1.1", nil, true},


### PR DESCRIPTION
Before: `ip:port` or `hostname:port` won't be matched.

Now we split the hostname from the `hostname:port` string, use the correct hostname to do the match.