### PR TITLE
Mute link in diff header

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -77,7 +77,7 @@
 									{{template "repo/diff/stats" dict "file" . "root" $}}
 								{{end}}
 							</div>
-							<span class="file mono"><a href="#diff-{{$nameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} &rarr; {{end}}{{$file.Name}}</a>{{if .IsLFSFile}} ({{$.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
+							<span class="file mono"><a class="muted" href="#diff-{{$nameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} &rarr; {{end}}{{$file.Name}}</a>{{if .IsLFSFile}} ({{$.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
 							{{if $file.IsGenerated}}
 								<span class="ui label ml-3">{{$.i18n.Tr "repo.diff.generated"}}</span>
 							{{end}}


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/pull/19534. Make the link render in color only on hover.

<img width="230" alt="image" src="https://user-images.githubusercontent.com/115237/165945171-7cc2ce5c-1961-4309-98d4-0ddb65154510.png">

Hover:

<img width="236" alt="image" src="https://user-images.githubusercontent.com/115237/165945190-0c1e8f0b-70fb-4a93-af02-5bbf98ff7560.png">
