### PR TITLE
Dont overwrite err with nil & rename PullCheckingFuncs to reflect there usage

### DIFF
--- a/routers/private/hook_pre_receive.go
+++ b/routers/private/hook_pre_receive.go
@@ -343,7 +343,7 @@ func preReceiveBranch(ctx *preReceiveContext, oldCommitID, newCommitID, refFullN
 		}
 
 		// Check all status checks and reviews are ok
-		if err := pull_service.CheckPRReadyToMerge(ctx, pr, true); err != nil {
+		if err := pull_service.CheckPullBranchProtections(ctx, pr, true); err != nil {
 			if models.IsErrDisallowedToMerge(err) {
 				log.Warn("Forbidden: User %d is not allowed push to protected branch %s in %-v and pr #%d is not ready to be merged: %s", ctx.opts.UserID, branchName, repo, pr.Index, err.Error())
 				ctx.JSON(http.StatusForbidden, private.Response{

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -81,6 +81,13 @@ func CheckPullMergable(ctx context.Context, doer *user_model.User, perm *models.
 		return nil
 	}
 
+	if pr.ProtectedBranch != nil && (!pr.ProtectedBranch.HasEnoughApprovals(ctx, pr) ||
+		pr.ProtectedBranch.MergeBlockedByRejectedReview(ctx, pr) ||
+		pr.ProtectedBranch.MergeBlockedByOfficialReviewRequests(ctx, pr) ||
+		pr.ProtectedBranch.MergeBlockedByOutdatedBranch(pr)) {
+		return ErrUserNotAllowedToMerge
+	}
+
 	if pr.IsWorkInProgress() {
 		return ErrIsWorkInProgress
 	}

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -81,9 +81,9 @@ func CheckPullMergable(ctx context.Context, doer *user_model.User, perm *models.
 		return nil
 	}
 
-	if pr.ProtectedBranch != nil && (!pr.ProtectedBranch.HasEnoughApprovals(ctx, pr) ||
-		pr.ProtectedBranch.MergeBlockedByRejectedReview(ctx, pr) ||
-		pr.ProtectedBranch.MergeBlockedByOfficialReviewRequests(ctx, pr) ||
+	if pr.ProtectedBranch != nil && (!pr.ProtectedBranch.HasEnoughApprovals(pr) ||
+		pr.ProtectedBranch.MergeBlockedByRejectedReview(pr) ||
+		pr.ProtectedBranch.MergeBlockedByOfficialReviewRequests(pr) ||
 		pr.ProtectedBranch.MergeBlockedByOutdatedBranch(pr)) {
 		return ErrUserNotAllowedToMerge
 	}

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -32,7 +32,7 @@ import (
 var prPatchCheckerQueue queue.UniqueQueue
 
 var (
-	ErrIsClosed              = errors.New("pull is cosed")
+	ErrIsClosed              = errors.New("pull is closed")
 	ErrUserNotAllowedToMerge = models.ErrDisallowedToMerge{}
 	ErrHasMerged             = errors.New("has already been merged")
 	ErrIsWorkInProgress      = errors.New("work in progress PRs cannot be merged")

--- a/services/pull/check_test.go
+++ b/services/pull/check_test.go
@@ -41,7 +41,7 @@ func TestPullRequest_AddToTaskQueue(t *testing.T) {
 	queueShutdown := []func(){}
 	queueTerminate := []func(){}
 
-	prQueue = q.(queue.UniqueQueue)
+	prPatchCheckerQueue = q.(queue.UniqueQueue)
 
 	pr := unittest.AssertExistsAndLoadBean(t, &models.PullRequest{ID: 2}).(*models.PullRequest)
 	AddToTaskQueue(pr)
@@ -51,11 +51,11 @@ func TestPullRequest_AddToTaskQueue(t *testing.T) {
 		return pr.Status == models.PullRequestStatusChecking
 	}, 1*time.Second, 100*time.Millisecond)
 
-	has, err := prQueue.Has(strconv.FormatInt(pr.ID, 10))
+	has, err := prPatchCheckerQueue.Has(strconv.FormatInt(pr.ID, 10))
 	assert.True(t, has)
 	assert.NoError(t, err)
 
-	prQueue.Run(func(shutdown func()) {
+	prPatchCheckerQueue.Run(func(shutdown func()) {
 		queueShutdown = append(queueShutdown, shutdown)
 	}, func(terminate func()) {
 		queueTerminate = append(queueTerminate, terminate)
@@ -68,7 +68,7 @@ func TestPullRequest_AddToTaskQueue(t *testing.T) {
 		assert.Fail(t, "Timeout: nothing was added to pullRequestQueue")
 	}
 
-	has, err = prQueue.Has(strconv.FormatInt(pr.ID, 10))
+	has, err = prPatchCheckerQueue.Has(strconv.FormatInt(pr.ID, 10))
 	assert.False(t, has)
 	assert.NoError(t, err)
 
@@ -82,5 +82,5 @@ func TestPullRequest_AddToTaskQueue(t *testing.T) {
 		callback()
 	}
 
-	prQueue = nil
+	prPatchCheckerQueue = nil
 }

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -662,8 +662,8 @@ func IsUserAllowedToMerge(pr *models.PullRequest, p models.Permission, user *use
 	return false, nil
 }
 
-// CheckPRReadyToMerge checks whether the PR is ready to be merged (reviews and status checks)
-func CheckPRReadyToMerge(ctx context.Context, pr *models.PullRequest, skipProtectedFilesCheck bool) (err error) {
+// CheckPullBranchProtections checks whether the PR is ready to be merged (reviews and status checks)
+func CheckPullBranchProtections(ctx context.Context, pr *models.PullRequest, skipProtectedFilesCheck bool) (err error) {
 	if err = pr.LoadBaseRepoCtx(ctx); err != nil {
 		return fmt.Errorf("LoadBaseRepo: %v", err)
 	}


### PR DESCRIPTION
- dont overwrite err with nil unintentionaly
- rename CheckPRReadyToMerge to CheckPullBranchProtections
- rename prQueue to prPatchCheckerQueue

from #9307