### PR TITLE
Increase minimal required git version to 2.0

### DIFF
--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -50,7 +50,8 @@ Of note, configuring `GITEA_WORK_DIR` will tell Gitea where to base its working 
 
 ### Prepare environment
 
-Check that Git is installed on the server. If it is not, install it first.
+Check that Git is installed on the server. If it is not, install it first. Gitea requires Git version >= 2.0.
+
 ```sh
 git --version
 ```

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -8,6 +8,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -20,10 +21,8 @@ import (
 )
 
 var (
-	// Prefix the log prefix
-	Prefix = "[git-module] "
 	// GitVersionRequired is the minimum Git version required
-	GitVersionRequired = "1.7.2"
+	GitVersionRequired = "2.0.0"
 
 	// GitExecutable is the command name of git
 	// Could be updated to an absolute path while initialization
@@ -87,13 +86,13 @@ func SetExecutablePath(path string) error {
 	}
 	absPath, err := exec.LookPath(GitExecutable)
 	if err != nil {
-		return fmt.Errorf("Git not found: %v", err)
+		return fmt.Errorf("git not found: %w", err)
 	}
 	GitExecutable = absPath
 
 	err = LoadGitVersion()
 	if err != nil {
-		return fmt.Errorf("Git version missing: %v", err)
+		return fmt.Errorf("unable to load git version: %w", err)
 	}
 
 	versionRequired, err := version.NewVersion(GitVersionRequired)
@@ -102,7 +101,15 @@ func SetExecutablePath(path string) error {
 	}
 
 	if gitVersion.LessThan(versionRequired) {
-		return fmt.Errorf("Git version not supported. Requires version > %v", GitVersionRequired)
+		moreHint := "get git: https://git-scm.com/download/"
+		if runtime.GOOS == "linux" {
+			// there are a lot of CentOS/RHEL users using old git, so we add a special hint for them
+			if _, err = os.Stat("/etc/redhat-release"); err == nil {
+				// ius.io is the recommended official(git-scm.com) method to install git
+				moreHint = "get git: https://git-scm.com/download/linux and https://ius.io"
+			}
+		}
+		return fmt.Errorf("installed git version %q is not supported, Gitea requires git version >= %q, %s", gitVersion.Original(), GitVersionRequired, moreHint)
 	}
 
 	return nil

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -22,6 +22,9 @@ import (
 
 var (
 	// GitVersionRequired is the minimum Git version required
+	// At the moment, all code for git 1.x are not changed, if some users want to test with old git client
+	// or bypass the check, they still have a chance to edit this variable manually.
+	// If everything works fine, the code for git 1.x could be removed in a separate PR before 1.17 frozen.
 	GitVersionRequired = "2.0.0"
 
 	// GitExecutable is the command name of git


### PR DESCRIPTION
Close #19554
* #19554

This PR only upgrades the `GitVersionRequired` variable to `2.0.0`. All code for git 1.x are not changed, then if some users want to test with old git client or bypass the check, they still have a chance to edit the GitVersionRequired manually.

Code for git 1.x could be removed in a separate PR before 1.17 frozen.

And since there are a lot of CentOS 7 users, a friendly hint is added to tell them how to install latest git client.


## :warning: BREAKING :warning: 

This PR makes Gitea require git >= 2.0, follow https://git-scm.com/download/ to install latest git client if your git is too old.
