### PR TITLE
Only set CanColorStdout / CanColorStderr to true if the stdout/stderr is a terminal

### DIFF
--- a/modules/log/console_other.go
+++ b/modules/log/console_other.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build !windows
+
+package log
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+func init() {
+	// when running gitea as a systemd unit with logging set to console, the output can not be colorized,
+	// otherwise it spams the journal / syslog with escape sequences like "#033[0m#033[32mcmd/web.go:102:#033[32m"
+	// this file covers non-windows platforms.
+	CanColorStdout = isatty.IsTerminal(os.Stdout.Fd())
+	CanColorStderr = isatty.IsTerminal(os.Stderr.Fd())
+}


### PR DESCRIPTION
When running gitea as a systemd unit with logging set to console, the output should not be colorized,
otherwise it spams the journal / syslog with escape sequences like `#033[0m#033[32mcmd/web.go:102:#033[32m`

This PR adds IsTerminal checks for non-WIndows platforms. For Windows, it was already done correctly in `console_window.go`

Close #19469
* #19469