### PR TITLE
Remove legacy `+build:` constraint

### DIFF
--- a/build.go
+++ b/build.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build vendor
-// +build vendor
 
 package main
 

--- a/build/code-batch-process.go
+++ b/build/code-batch-process.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/generate-bindata.go
+++ b/build/generate-bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/generate-emoji.go
+++ b/build/generate-emoji.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/generate-gitignores.go
+++ b/build/generate-gitignores.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/generate-licenses.go
+++ b/build/generate-licenses.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/gitea-format-imports.go
+++ b/build/gitea-format-imports.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/build/gocovmerge.go
+++ b/build/gocovmerge.go
@@ -7,7 +7,6 @@
 // merges them into one profile
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package cmd
 

--- a/cmd/embedded_stub.go
+++ b/cmd/embedded_stub.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package cmd
 

--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build pam
-// +build pam
 
 package pam
 

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !pam
-// +build !pam
 
 package pam
 

--- a/modules/auth/pam/pam_test.go
+++ b/modules/auth/pam/pam_test.go
@@ -1,5 +1,4 @@
 //go:build pam
-// +build pam
 
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/avatar/identicon/identicon_test.go
+++ b/modules/avatar/identicon/identicon_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build test_avatar_identicon
-// +build test_avatar_identicon
 
 package identicon
 

--- a/modules/git/blob_gogit.go
+++ b/modules/git/blob_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/command_race_test.go
+++ b/modules/git/command_race_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build race
-// +build race
 
 package git
 

--- a/modules/git/commit_convert_gogit.go
+++ b/modules/git/commit_convert_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/commit_info_gogit.go
+++ b/modules/git/commit_info_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/commit_info_nogogit.go
+++ b/modules/git/commit_info_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/last_commit_cache_gogit.go
+++ b/modules/git/last_commit_cache_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/last_commit_cache_nogogit.go
+++ b/modules/git/last_commit_cache_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/notes_gogit.go
+++ b/modules/git/notes_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/notes_nogogit.go
+++ b/modules/git/notes_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/parse_gogit.go
+++ b/modules/git/parse_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/parse_gogit_test.go
+++ b/modules/git/parse_gogit_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/parse_nogogit.go
+++ b/modules/git/parse_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/parse_nogogit_test.go
+++ b/modules/git/parse_nogogit_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/pipeline/lfs.go
+++ b/modules/git/pipeline/lfs.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package pipeline
 

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package pipeline
 

--- a/modules/git/repo_base_gogit.go
+++ b/modules/git/repo_base_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_blob_gogit.go
+++ b/modules/git/repo_blob_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_blob_nogogit.go
+++ b/modules/git/repo_blob_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_branch_gogit.go
+++ b/modules/git/repo_branch_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_commit_gogit.go
+++ b/modules/git/repo_commit_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_commitgraph_gogit.go
+++ b/modules/git/repo_commitgraph_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_language_stats_gogit.go
+++ b/modules/git/repo_language_stats_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_language_stats_nogogit.go
+++ b/modules/git/repo_language_stats_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_language_stats_test.go
+++ b/modules/git/repo_language_stats_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_ref_gogit.go
+++ b/modules/git/repo_ref_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_ref_nogogit.go
+++ b/modules/git/repo_ref_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_tag_gogit.go
+++ b/modules/git/repo_tag_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_tag_nogogit.go
+++ b/modules/git/repo_tag_nogogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/repo_tree_gogit.go
+++ b/modules/git/repo_tree_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/sha1_gogit.go
+++ b/modules/git/sha1_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/sha1_nogogit.go
+++ b/modules/git/sha1_nogogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/signature_gogit.go
+++ b/modules/git/signature_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/signature_nogogit.go
+++ b/modules/git/signature_nogogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/tree_blob_gogit.go
+++ b/modules/git/tree_blob_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/tree_blob_nogogit.go
+++ b/modules/git/tree_blob_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/tree_entry_gogit.go
+++ b/modules/git/tree_entry_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/git/tree_entry_test.go
+++ b/modules/git/tree_entry_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/tree_gogit.go
+++ b/modules/git/tree_gogit.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package git
 

--- a/modules/git/tree_nogogit.go
+++ b/modules/git/tree_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package git
 

--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package graceful
 

--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -4,7 +4,6 @@
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
 
 //go:build windows
-// +build windows
 
 package graceful
 

--- a/modules/graceful/net_unix.go
+++ b/modules/graceful/net_unix.go
@@ -4,7 +4,6 @@
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
 
 //go:build !windows
-// +build !windows
 
 package graceful
 

--- a/modules/graceful/net_windows.go
+++ b/modules/graceful/net_windows.go
@@ -4,7 +4,6 @@
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
 
 //go:build windows
-// +build windows
 
 package graceful
 

--- a/modules/graceful/restart_unix.go
+++ b/modules/graceful/restart_unix.go
@@ -4,7 +4,6 @@
 // This code is heavily inspired by the archived gofacebook/gracenet/net.go handler
 
 //go:build !windows
-// +build !windows
 
 package graceful
 

--- a/modules/lfs/pointer_scanner_gogit.go
+++ b/modules/lfs/pointer_scanner_gogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gogit
-// +build gogit
 
 package lfs
 

--- a/modules/lfs/pointer_scanner_nogogit.go
+++ b/modules/lfs/pointer_scanner_nogogit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !gogit
-// +build !gogit
 
 package lfs
 

--- a/modules/migration/schemas_bindata.go
+++ b/modules/migration/schemas_bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package migration
 

--- a/modules/migration/schemas_dynamic.go
+++ b/modules/migration/schemas_dynamic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package migration
 

--- a/modules/migration/schemas_static.go
+++ b/modules/migration/schemas_static.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package migration
 

--- a/modules/options/dynamic.go
+++ b/modules/options/dynamic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package options
 

--- a/modules/options/options_bindata.go
+++ b/modules/options/options_bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package options
 

--- a/modules/options/static.go
+++ b/modules/options/static.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package options
 

--- a/modules/public/public_bindata.go
+++ b/modules/public/public_bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package public
 

--- a/modules/public/serve_dynamic.go
+++ b/modules/public/serve_dynamic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package public
 

--- a/modules/public/serve_static.go
+++ b/modules/public/serve_static.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package public
 

--- a/modules/setting/database_sqlite.go
+++ b/modules/setting/database_sqlite.go
@@ -1,5 +1,4 @@
 //go:build sqlite
-// +build sqlite
 
 // Copyright 2014 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style

--- a/modules/svg/discover_bindata.go
+++ b/modules/svg/discover_bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package svg
 

--- a/modules/svg/discover_nobindata.go
+++ b/modules/svg/discover_nobindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package svg
 

--- a/modules/templates/dynamic.go
+++ b/modules/templates/dynamic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !bindata
-// +build !bindata
 
 package templates
 

--- a/modules/templates/static.go
+++ b/modules/templates/static.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package templates
 

--- a/modules/templates/templates_bindata.go
+++ b/modules/templates/templates_bindata.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build bindata
-// +build bindata
 
 package templates
 

--- a/routers/api/v1/auth.go
+++ b/routers/api/v1/auth.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package v1
 

--- a/routers/private/manager_unix.go
+++ b/routers/private/manager_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package private
 

--- a/routers/private/manager_windows.go
+++ b/routers/private/manager_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package private
 

--- a/routers/web/auth.go
+++ b/routers/web/auth.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package web
 

--- a/tools/fuzz.go
+++ b/tools/fuzz.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gofuzz
-// +build gofuzz
 
 package fuzz
 


### PR DESCRIPTION
Go 1.17 and later use modern `//go:build` constraints, the old `// +build:` constraints should be removed.

https://pkg.go.dev/cmd/go#hdr-Build_constraints

This PR is a simple search & replace