### PR TITLE
Move user password verification after checking his groups on ldap auth

### DIFF
--- a/services/auth/source/ldap/source_search.go
+++ b/services/auth/source/ldap/source_search.go
@@ -433,14 +433,6 @@ func (ls *Source) SearchEntry(name, passwd string, directBind bool) *SearchResul
 		isRestricted = checkRestricted(l, ls, userDN)
 	}
 
-	if !directBind && ls.AttributesInBind {
-		// binds user (checking password) after looking-up attributes in BindDN context
-		err = bindUser(l, userDN, passwd)
-		if err != nil {
-			return nil
-		}
-	}
-
 	if isAtributeAvatarSet {
 		Avatar = sr.Entries[0].GetRawAttributeValue(ls.AttributeAvatar)
 	}
@@ -449,6 +441,14 @@ func (ls *Source) SearchEntry(name, passwd string, directBind bool) *SearchResul
 	teamsToRemove := make(map[string][]string)
 	if ls.GroupsEnabled && (ls.GroupTeamMap != "" || ls.GroupTeamMapRemoval) {
 		teamsToAdd, teamsToRemove = ls.getMappedMemberships(l, uid)
+	}
+
+	if !directBind && ls.AttributesInBind {
+		// binds user (checking password) after looking-up attributes in BindDN context
+		err = bindUser(l, userDN, passwd)
+		if err != nil {
+			return nil
+		}
 	}
 
 	return &SearchResult{


### PR DESCRIPTION
This PR move the user password verifications after groups checking.

In my LDAP setup i noticed that groups check always failed because the bind dn changed to be the user one, or the user don't have the permission to see his roles
