### PR TITLE
Don't fetch Mirror when it's migrating

### DIFF
--- a/models/task.go
+++ b/models/task.go
@@ -181,6 +181,14 @@ func GetMigratingTask(repoID int64) (*Task, error) {
 	return &task, nil
 }
 
+// HasMigratingTask returns if migrating task exist for repo.
+func HasMigratingTask(repoID int64) (bool, error) {
+	return db.GetEngine(db.DefaultContext).Exist(&Task{
+		RepoID: repoID,
+		Type:   structs.TaskTypeMigrateRepo,
+	})
+}
+
 // GetMigratingTaskByID returns the migrating task by repo's id
 func GetMigratingTaskByID(id, doerID int64) (*Task, *migration.MigrateOptions, error) {
 	task := Task{


### PR DESCRIPTION
- When a repository is still being migrated, don't try to fetch the Mirror from the database. Instead skip it. This allows to visit repositories that are still being migrated and were configured to be mirrored.
- Resolves #19585
- Regression: #19295

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
