### PR TITLE
Fix sending empty notifications (#19589)

### DIFF
--- a/routers/api/v1/notify/repo.go
+++ b/routers/api/v1/notify/repo.go
@@ -214,7 +214,7 @@ func ReadRepoNotifications(ctx *context.APIContext) {
 		targetStatus = models.NotificationStatusRead
 	}
 
-	changed := make([]*structs.NotificationThread, len(nl))
+	changed := make([]*structs.NotificationThread, 0, len(nl))
 
 	for _, n := range nl {
 		notif, err := models.SetNotificationStatus(n.ID, ctx.User, targetStatus)


### PR DESCRIPTION
- Backport #19589
  - Don't send empty notifications on read notifications API.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
