### PR TITLE
Avoid MoreThanOne error when creating a branch whose name conflicts with other ref names

### DIFF
--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -35,7 +35,7 @@ func CreateNewBranch(doer *user_model.User, repo *repo_model.Repository, oldBran
 
 	if err := git.Push(git.DefaultContext, repo.RepoPath(), git.PushOptions{
 		Remote: repo.RepoPath(),
-		Branch: fmt.Sprintf("%s:%s%s", oldBranchName, git.BranchPrefix, branchName),
+		Branch: fmt.Sprintf("%s%s:%s%s", git.BranchPrefix, oldBranchName, git.BranchPrefix, branchName),
 		Env:    models.PushingEnvironment(doer, repo),
 	}); err != nil {
 		if git.IsErrPushOutOfDate(err) || git.IsErrPushRejected(err) {


### PR DESCRIPTION
Hi ! this is the backport of #19557 

This simple commit will ensure that we specify the "Branch" prefix when we want to create new branch. Fix https://github.com/go-gitea/gitea/issues/19346

Otherwise git would check between /refs/heads/tags and /refs/heads/branch and return
error: src refspec mytest matches more than one.
error: failed to push some refs to 'branch'
when there is a tag sharing the same name than the branch.

Tested also since we discussed in comments :
1 - making a branch named "thistag"
2 - creating a tag from it named "thistag"
3 - created a branch from the branch "thistag"
4 - created a PR from the new branch into branch "thistag", merged it, this works too !

Have a good day