### PR TITLE
Use correct context in `routers/web`

### DIFF
--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -15,7 +15,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
-	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/structs"
 )
 
 const (
@@ -194,6 +194,6 @@ func NotificationPurgePost(c *context.Context) {
 }
 
 // NewAvailable returns the notification counts
-func NewAvailable(ctx *context.APIContext) {
-	ctx.JSON(http.StatusOK, api.NotificationCount{New: models.CountUnread(ctx.Doer)})
+func NewAvailable(ctx *context.Context) {
+	ctx.JSON(http.StatusOK, structs.NotificationCount{New: models.CountUnread(ctx.Doer)})
 }


### PR DESCRIPTION
- Don't use the `APIContext` in the web routers, avoids panicking while accessing this endpoint.
- Regression from: https://github.com/go-gitea/gitea/pull/19318
