### PR TITLE
Fix broken TR key on cherry-pick action

### DIFF
--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -45,7 +45,7 @@
 		<div class="menu transition" :class="{visible: menuVisible}" v-if="menuVisible" v-cloak>
 			<div class="ui icon search input">
 				<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-				<input name="search" ref="searchField" autocomplete="off" v-model="searchTerm" @keydown="keydown($event)" placeholder="{{if $.noTag}}{{.root.i18n.Tr "repo.filter_branch"}}{{else if $showBranchesInDropdown}}{{.root.i18n.Tr "repo.filter_branch_and_tag"}}{{else}}{{.root.i18n.Tr "repo.find_tag"}}{{end}}...">
+				<input name="search" ref="searchField" autocomplete="off" v-model="searchTerm" @keydown="keydown($event)" placeholder="{{if $.noTag}}{{.root.i18n.Tr "repo.pulls.filter_branch"}}{{else if $showBranchesInDropdown}}{{.root.i18n.Tr "repo.filter_branch_and_tag"}}{{else}}{{.root.i18n.Tr "repo.find_tag"}}{{end}}...">
 			</div>
 			{{if $showBranchesInDropdown}}
 				<div class="header branch-tag-choice">


### PR DESCRIPTION
- `repo.filter_branch` isn't a translation key so use `repo.pulls.filter_branch` which has the correct translation.

Before:
![image](https://user-images.githubusercontent.com/25481501/166585602-ab8d80b2-bc9d-4a38-896c-088787c27508.png)

After:
![image](https://user-images.githubusercontent.com/25481501/166585580-32d20c7e-80c9-442f-8243-a3950599f580.png)

