### PR TITLE
Make .cs highlighting legible on dark themes. (Backport #19604)

### DIFF
--- a/web_src/less/chroma/dark.less
+++ b/web_src/less/chroma/dark.less
@@ -52,7 +52,7 @@
 .chroma .ch { color: #6a737d; } /* CommentHashbang */
 .chroma .cm { color: #6a737d; } /* CommentMultiline */
 .chroma .c1 { color: #6a737d; } /* CommentSingle */
-.chroma .cs { color: #637d; } /* CommentSpecial */
+.chroma .cs { color: #95ad; } /* CommentSpecial */
 .chroma .cp { color: #fc6; } /* CommentPreproc */
 .chroma .cpf { color: #03dfff; } /* CommentPreprocFile */
 .chroma .gd { color: #fff; background-color: #5f3737; } /* GenericDeleted */


### PR DESCRIPTION
Backport of #19604 

---

Fixes https://github.com/go-gitea/gitea/issues/19602.

Before:
![image](https://user-images.githubusercontent.com/96976531/166662215-5769ab4c-b155-44d5-b897-138e841d4f57.png)

After:
![image](https://user-images.githubusercontent.com/96976531/166662233-8439a096-59f6-488f-97c1-ede229860928.png)

NOTE:

I'm not presently able to build Gitea from source, so I have demo'd this style change by editing theme-arc-green.css in devtools. I hope this is acceptable given the scope of the PR.
