### PR TITLE
Skip duplicated Docker filesystem layers in package-registry

### DIFF
--- a/routers/api/packages/container/manifest.go
+++ b/routers/api/packages/container/manifest.go
@@ -355,6 +355,10 @@ func createFileFromBlobReference(ctx context.Context, pv, uploadVersion *package
 	}
 	var err error
 	if pf, err = packages_model.TryInsertFile(ctx, pf); err != nil {
+		if err == packages_model.ErrDuplicatePackageFile {
+			// Skip this blob because the manifest contains the same filesystem layer multiple times.
+			return nil
+		}
 		log.Error("Error inserting package file: %v", err)
 		return err
 	}


### PR DESCRIPTION
A Docker manifest may contain multiple filesystem layers with the same hash. This PR skips the duplicated layers.