### PR TITLE
Simplify `IsVendor`

### DIFF
--- a/modules/analyze/vendor.go
+++ b/modules/analyze/vendor.go
@@ -5,66 +5,10 @@
 package analyze
 
 import (
-	"regexp"
-	"sort"
-	"strings"
-
-	"github.com/go-enry/go-enry/v2/data"
+	"github.com/go-enry/go-enry/v2"
 )
-
-var isVendorRegExp *regexp.Regexp
-
-func init() {
-	matchers := data.VendorMatchers
-
-	caretStrings := make([]string, 0, 10)
-	caretShareStrings := make([]string, 0, 10)
-
-	matcherStrings := make([]string, 0, len(matchers))
-	for _, matcher := range matchers {
-		str := matcher.String()
-		if str[0] == '^' {
-			caretStrings = append(caretStrings, str[1:])
-		} else if str[0:5] == "(^|/)" {
-			caretShareStrings = append(caretShareStrings, str[5:])
-		} else {
-			matcherStrings = append(matcherStrings, str)
-		}
-	}
-
-	sort.Strings(caretShareStrings)
-	sort.Strings(caretStrings)
-	sort.Strings(matcherStrings)
-
-	sb := &strings.Builder{}
-	sb.WriteString("(?:^(?:")
-	sb.WriteString(caretStrings[0])
-	for _, matcher := range caretStrings[1:] {
-		sb.WriteString(")|(?:")
-		sb.WriteString(matcher)
-	}
-	sb.WriteString("))")
-	sb.WriteString("|")
-	sb.WriteString("(?:(?:^|/)(?:")
-	sb.WriteString(caretShareStrings[0])
-	for _, matcher := range caretShareStrings[1:] {
-		sb.WriteString(")|(?:")
-		sb.WriteString(matcher)
-	}
-	sb.WriteString("))")
-	sb.WriteString("|")
-	sb.WriteString("(?:")
-	sb.WriteString(matcherStrings[0])
-	for _, matcher := range matcherStrings[1:] {
-		sb.WriteString(")|(?:")
-		sb.WriteString(matcher)
-	}
-	sb.WriteString(")")
-	combined := sb.String()
-	isVendorRegExp = regexp.MustCompile(combined)
-}
 
 // IsVendor returns whether or not path is a vendor path.
 func IsVendor(path string) bool {
-	return isVendorRegExp.MatchString(path)
+	return enry.IsVendor(path)
 }


### PR DESCRIPTION
The changes in this file were upstreamed directly into go-enry as https://github.com/go-enry/go-enry/pull/44
and therefore they are no longer needed.