### PR TITLE
Prevent NPE when checking repo units if the user is nil (#19625)

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -132,7 +132,7 @@ func CheckRepoUnitUser(repo *repo_model.Repository, user *user_model.User, unitT
 }
 
 func checkRepoUnitUser(ctx context.Context, repo *repo_model.Repository, user *user_model.User, unitType unit.Type) bool {
-	if user.IsAdmin {
+	if user != nil && user.IsAdmin {
 		return true
 	}
 	perm, err := getUserRepoPermission(ctx, repo, user)


### PR DESCRIPTION
Backport #19625

CheckRepoUnitUser should tolerate nil users.

Fix #19613

Signed-off-by: Andrew Thornton <art27@cantab.net>
