### PR TITLE
Add missing `sorting` column in `project_issue` table

### DIFF
--- a/models/project/issue.go
+++ b/models/project/issue.go
@@ -19,6 +19,9 @@ type ProjectIssue struct { //revive:disable-line:exported
 
 	// If 0, then it has not been added to a specific board in the project
 	ProjectBoardID int64 `xorm:"INDEX"`
+
+	// the sorting order on the board
+	Sorting int64 `xorm:"NOT NULL DEFAULT 0"`
 }
 
 func init() {


### PR DESCRIPTION
The column `sorting` was missing in the model (well, it's lost during refactoring)

It would cause problems for a fresh installation: there will be no such column in table and users meet SQL errors.

This PR adds the missing column, close #19332