### PR TITLE
Set safe dir for git operations in .drone.yml CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -235,6 +235,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -427,6 +428,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -628,6 +630,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: deps-frontend
@@ -746,6 +749,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: deps-frontend
@@ -891,6 +895,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -954,6 +959,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1016,6 +1022,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1112,6 +1119,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1175,6 +1183,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1237,6 +1246,7 @@ steps:
     image: docker:git
     pull: always
     commands:
+      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish


### PR DESCRIPTION
Our drone by necessity runs on git repositories not owned by the drone process. Unfortunately this means that git operations and thence CI builds will fail without the `safe.directory` option being set. 

See: https://drone.gitea.io/go-gitea/gitea/54632/2/8