### PR TITLE
Only show accessible teams in dashboard dropdown list

### DIFF
--- a/modules/context/org.go
+++ b/modules/context/org.go
@@ -72,12 +72,6 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 	ctx.ContextUser = org.AsUser()
 	ctx.Data["Org"] = org
 
-	teams, err := org.LoadTeams()
-	if err != nil {
-		ctx.ServerError("LoadTeams", err)
-	}
-	ctx.Data["OrgTeams"] = teams
-
 	// Admin has super access.
 	if ctx.IsSigned && ctx.Doer.IsAdmin {
 		ctx.Org.IsOwner = true

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -61,7 +61,7 @@
 							<a class="{{if not $.Team}}active selected{{end}} item" title="{{.i18n.Tr "all"}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}">
 								{{.i18n.Tr "all"}}
 							</a>
-							{{range .OrgTeams}}
+							{{range .Teams}}
 								{{if not .IncludesAllRepositories}}
 									<a class="{{if $.Team}}{{if eq $.Team.ID .ID}}active selected{{end}}{{end}} item" title="{{.Name}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}/{{.Name}}">
 										{{.Name}}


### PR DESCRIPTION
Fixes #19637 

Use the "Teams" variable as set in
https://github.com/go-gitea/gitea/blob/cab3a8b59d6f9d66804479ad2a20d02ef0e0f79f/routers/web/user/home.go#L55

which is filtered to those teams the current user has access too here:

https://github.com/go-gitea/gitea/blob/cab3a8b59d6f9d66804479ad2a20d02ef0e0f79f/modules/context/org.go#L151-L163