### PR TITLE
Use a better OlderThan for DeleteInactiveUsers

### DIFF
--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -26,7 +26,7 @@ func registerDeleteInactiveUsers() {
 			RunAtStart: false,
 			Schedule:   "@annually",
 		},
-		OlderThan: time.Second * time.Duration(setting.Service.ActiveCodeLives),
+		OlderThan: time.Minute * time.Duration(setting.Service.ActiveCodeLives),
 	}, func(ctx context.Context, _ *user_model.User, config Config) error {
 		olderThanConfig := config.(*OlderThanConfig)
 		return user_service.DeleteInactiveUsers(ctx, olderThanConfig.OlderThan)

--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -26,7 +26,7 @@ func registerDeleteInactiveUsers() {
 			RunAtStart: false,
 			Schedule:   "@annually",
 		},
-		OlderThan: 0 * time.Second,
+		OlderThan: time.Second * time.Duration(setting.Service.ActiveCodeLives),
 	}, func(ctx context.Context, _ *user_model.User, config Config) error {
 		olderThanConfig := config.(*OlderThanConfig)
 		return user_service.DeleteInactiveUsers(ctx, olderThanConfig.OlderThan)


### PR DESCRIPTION
- Currently the OlderThan is zero, for instances that enable or run this task this could actually delete just new created users that still need to confirm their email.
- This patch fixes that by setting the default OlderThan to the `ActiveCodeLives` setting, which corresponds to the amount of time that a user can active their account via email and thus avoiding the issue of deleting 'legit' unactivated users.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
