### PR TITLE
Dockerfile: upgrade to git >= 2.36 and set safe.directory = *

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,20 @@ RUN apk --no-cache add \
     ca-certificates \
     curl \
     gettext \
-    git \
     linux-pam \
     openssh \
     s6 \
     sqlite \
     su-exec \
     gnupg
+
+#
+# Only required until git > 2.36 is released in alpine because Gitea needs
+# support for *
+#
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory
+#
+RUN apk add git --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 RUN addgroup \
     -S -g 1000 \

--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -68,6 +68,8 @@ adduser \
    git
 ```
 
+**NOTE:** If such a dedicated Gitea user is not created and Gitea is run from an already existing user instead, it may modify the global git configuration file. It is possible to use an altnerate global git configuration file by setting the [GIT_CONFIG_GLOBAL](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode) if [git version 2.32 or above](https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt#L92-L93) is installed.
+
 ### Create required directory structure
 
 ```sh

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -206,6 +206,12 @@ func Init(ctx context.Context) error {
 		SupportProcReceive = false
 	}
 
+	if CheckGitVersionAtLeast("2.36") == nil {
+		if err := checkAndSetConfig("safe.directory", "*", true); err != nil {
+			return err
+		}
+	}
+
 	if runtime.GOOS == "windows" {
 		if err := checkAndSetConfig("core.longpaths", "true", true); err != nil {
 			return err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -207,6 +207,10 @@ func Init(ctx context.Context) error {
 	}
 
 	if CheckGitVersionAtLeast("2.36") == nil {
+		//
+		// Disable the security check because Gitea runs the git CLI from within the
+		// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
+		//
 		if err := checkAndSetConfig("safe.directory", "*", true); err != nil {
 			return err
 		}


### PR DESCRIPTION
See original [merge request from Loïc Dachary @ forgefriends](https://lab.forgefriends.org/forgefriends/forgefriends/-/merge_requests/50)

---

See also https://discourse.gitea.io/t/upgrading-git-push-fails-due-to-changed-security-policy-safe-directory/5185/4 for discussion.

Fixes: #19455
