### PR TITLE
Fix merge of PR with meta/empty commit

### DIFF
--- a/integrations/pull_status_test.go
+++ b/integrations/pull_status_test.go
@@ -105,7 +105,12 @@ func doAPICreateCommitStatus(ctx APITestContext, commitID string, status api.Com
 	}
 }
 
-func TestPullCreate_EmptyChangesWithCommits(t *testing.T) {
+func TestPullCreate_EmptyChangesWithDifferentCommits(t *testing.T) {
+	// Merge must continue if commits SHA are different, even if content is same
+	// Reason: gitflow and merging master back into develop, where is high possiblity, there are no changes
+	// but just commit saying "Merge branch". And this meta commit can be also tagged,
+	// so we need to have this meta commit also in develop branch.
+
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
 		session := loginUser(t, "user1")
 		testRepoFork(t, session, "user2", "repo1", "user1", "repo1")
@@ -126,6 +131,6 @@ func TestPullCreate_EmptyChangesWithCommits(t *testing.T) {
 		doc := NewHTMLParser(t, resp.Body)
 
 		text := strings.TrimSpace(doc.doc.Find(".merge-section").Text())
-		assert.Contains(t, text, "This branch is equal with the target branch.")
+		assert.Contains(t, text, "This pull request can be merged automatically.")
 	})
 }

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1210,6 +1210,7 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 		BaseRepo:            repo,
 		MergeBase:           ci.CompareInfo.MergeBase,
 		Type:                issues_model.PullRequestGitea,
+		HeadCommitID:        ci.CompareInfo.HeadCommitID,
 		AllowMaintainerEdit: form.AllowMaintainerEdit,
 	}
 	// FIXME: check error in the case two people send pull request at almost same time, give nice error prompt

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -284,8 +284,13 @@ func checkConflicts(ctx context.Context, pr *issues_model.PullRequest, gitRepo *
 	}
 
 	if !conflict {
-		log.Info("PullRequest[%d]: Head SHA: %s, Merge base SHA: %s", pr.ID, pr.HeadCommitID, pr.MergeBase)
+		log.Debug("PullRequest[%d]: Head SHA: %s, Merge base SHA: %s", pr.ID, pr.HeadCommitID, pr.MergeBase)
 		if pr.HeadCommitID == pr.MergeBase {
+			// Merge must continue if commits SHA are different, even if content is same
+			// Reason: gitflow and merging master back into develop, where is high possiblity, there are no changes
+			// but just commit saying "Merge branch". And this meta commit can be also tagged,
+			// so we need to have this meta commit also in develop branch.
+
 			log.Debug("PullRequest[%d]: Commits are equal - ignoring", pr.ID)
 			pr.Status = issues_model.PullRequestStatusEmpty
 		}

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -284,18 +284,9 @@ func checkConflicts(ctx context.Context, pr *issues_model.PullRequest, gitRepo *
 	}
 
 	if !conflict {
-		var treeHash string
-		treeHash, _, err = git.NewCommand(ctx, "write-tree").RunStdString(&git.RunOpts{Dir: tmpBasePath})
-		if err != nil {
-			return false, err
-		}
-		treeHash = strings.TrimSpace(treeHash)
-		baseTree, err := gitRepo.GetTree("base")
-		if err != nil {
-			return false, err
-		}
-		if treeHash == baseTree.ID.String() {
-			log.Debug("PullRequest[%d]: Patch is empty - ignoring", pr.ID)
+		log.Info("PullRequest[%d]: Head SHA: %s, Merge base SHA: %s", pr.ID, pr.HeadCommitID, pr.MergeBase)
+		if pr.HeadCommitID == pr.MergeBase {
+			log.Debug("PullRequest[%d]: Commits are equal - ignoring", pr.ID)
 			pr.Status = issues_model.PullRequestStatusEmpty
 		}
 


### PR DESCRIPTION
Hi,
this will fix the issue #19603 regarding different SHA commits, but same content.

The change is to populate HeadCommitID in PullRequest which was previously empty
and compare real SHA commits. It means merge must be always allowed, when there are different SHAs.
Even it the content is same. 

Usecase: gitflow
* merge from develop -> release (no changes)
* merge from release -> master (no changes)
* tag master
* merge from master -> develop (no file changes ! just meta commit with merging note)
 
Best regards
Jarek

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
