### PR TITLE
use http.StatusTemporaryRedirect(307) when serve avatar directly

### DIFF
--- a/routers/web/base.go
+++ b/routers/web/base.go
@@ -62,7 +62,7 @@ func storageHandler(storageSetting setting.Storage, prefix string, objStore stor
 					w,
 					req,
 					u.String(),
-					http.StatusPermanentRedirect,
+					http.StatusTemporaryRedirect,
 				)
 			})
 		}


### PR DESCRIPTION
use http.StatusTemporaryRedirect(307) when serve avatar directly

browser caches 301 redirections, pre-signed s3 url would expire at some later point

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
