### PR TITLE
Improved ref comment link when origin is body/title

### DIFF
--- a/models/issue_xref.go
+++ b/models/issue_xref.go
@@ -296,7 +296,7 @@ func CommentTypeIsRef(t CommentType) bool {
 // RefCommentHTMLURL returns the HTML URL for the comment that created this reference
 func (comment *Comment) RefCommentHTMLURL() string {
 	if comment.RefCommentID == 0 {
-		return ""
+		return comment.RefIssueHTMLURL()
 	}
 	if err := comment.LoadRefComment(); err != nil { // Silently dropping errors :unamused:
 		log.Error("LoadRefComment(%d): %v", comment.RefCommentID, err)

--- a/models/issue_xref.go
+++ b/models/issue_xref.go
@@ -295,6 +295,7 @@ func CommentTypeIsRef(t CommentType) bool {
 
 // RefCommentHTMLURL returns the HTML URL for the comment that created this reference
 func (comment *Comment) RefCommentHTMLURL() string {
+	// Edge case for when the reference is inside the title or the description of the referring issue
 	if comment.RefCommentID == 0 {
 		return comment.RefIssueHTMLURL()
 	}


### PR DESCRIPTION
Comments with references use `RefCommentHTMLURL()` to fetch the URL location to link to.

However for references originating in body text or titles, this falls back to a value of `""`.

This means that when a reference comes from a body/title, the link just reloads the current page, which is weird.

![image](https://user-images.githubusercontent.com/96976531/169019638-20ef6225-d580-4ce9-a539-6c5ba6cf41c6.png)


This PR changes the fallback behaviour to return the URL of the originating issue/PR. This way if the body text of `pulls/X` links to an issue, then the cross ref comment will link to 'pulls/X'.

![image](https://user-images.githubusercontent.com/96976531/169019814-e1834672-c79f-41d6-b2d5-a65a256a2092.png)


There are no other references to `RefCommentHTMLURL()` in the codebase so I don't think this has any risk.