### PR TITLE
Prevent NPE when cache service is disabled (#19703)

### DIFF
--- a/routers/web/auth/password.go
+++ b/routers/web/auth/password.go
@@ -80,7 +80,7 @@ func ForgotPasswdPost(ctx *context.Context) {
 		return
 	}
 
-	if ctx.Cache.IsExist("MailResendLimit_" + u.LowerName) {
+	if setting.CacheService.Enabled && ctx.Cache.IsExist("MailResendLimit_"+u.LowerName) {
 		ctx.Data["ResendLimited"] = true
 		ctx.HTML(http.StatusOK, tplForgotPassword)
 		return
@@ -88,8 +88,10 @@ func ForgotPasswdPost(ctx *context.Context) {
 
 	mailer.SendResetPasswordMail(u)
 
-	if err = ctx.Cache.Put("MailResendLimit_"+u.LowerName, u.LowerName, 180); err != nil {
-		log.Error("Set cache(MailResendLimit) fail: %v", err)
+	if setting.CacheService.Enabled {
+		if err = ctx.Cache.Put("MailResendLimit_"+u.LowerName, u.LowerName, 180); err != nil {
+			log.Error("Set cache(MailResendLimit) fail: %v", err)
+		}
 	}
 
 	ctx.Data["ResetPwdCodeLives"] = timeutil.MinutesToFriendly(setting.Service.ResetPwdCodeLives, ctx.Locale.Language())


### PR DESCRIPTION
Backport #19703

The cache service can be disabled - at which point ctx.Cache will be nil
and the use of it will cause an NPE.

The main part of this PR is that the cache is used for restricting
resending of activation mails and without this we cache we cannot
restrict this. Whilst this code could be re-considered to use the db and
probably should be, I think we can simply disable this code in the case
that the cache is disabled.

Signed-off-by: Andrew Thornton <art27@cantab.net>
