### PR TITLE
Update document to use FHS `/usr/local/bin/gitea` instead of `/app/...` for Docker

### DIFF
--- a/docker/root/usr/local/bin/gitea
+++ b/docker/root/usr/local/bin/gitea
@@ -13,5 +13,3 @@ CUSTOM_PATH="/data/gitea"
 
 # Provide docker defaults
 GITEA_WORK_DIR="${GITEA_WORK_DIR:-$WORK_DIR}" GITEA_CUSTOM="${GITEA_CUSTOM:-$CUSTOM_PATH}" exec -a "$0" "$GITEA" $CONF_ARG "$@"
-
-

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -389,16 +389,6 @@ In this option, the idea is that the host simply uses the `authorized_keys` that
     sudo chmod +x /usr/local/bin/gitea
     ```
 
-  - For Gitea v1.15.x and earlier. As an administrative user on the host run:
-
-    ```bash
-    cat <<"EOF" | sudo tee /app/gitea/gitea
-    #!/bin/sh
-    ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"
-    EOF
-    sudo chmod +x /app/gitea/gitea
-    ```
-
 Here is a detailed explanation what is happening when a SSH request is made:
 
 1. The client adds their SSH public key to Gitea using the webpage.
@@ -431,7 +421,7 @@ Never add the `Gitea Host Key` as a SSH key to a user on the Gitea interface.
 
 In this option, the idea is that the host simply uses the `authorized_keys` that gitea creates but at step 8 above we change the shell that the host runs to ssh directly into the docker and then run the shell there. This means that the `gitea` that is then run is the real docker `gitea`.
 
-- In this case we setup as per SSHing Shim except instead of creating `/usr/local/bin/gitea` or `/app/gitea/gitea`
+- In this case we setup as per SSHing Shim except instead of creating `/usr/local/bin/gitea`
 we create a new shell for the git user. As an administrative user on the host run:
 
   ```bash

--- a/docs/content/doc/installation/with-docker.zh-cn.md
+++ b/docs/content/doc/installation/with-docker.zh-cn.md
@@ -301,7 +301,7 @@ volumes:
 sudo -u git ssh-keygen -t rsa -b 4096 -C "Gitea Host Key"
 ```
 
-在下一步中，需要在主机上创建一个名为 `/app/gitea/gitea` 的文件（具有可执行权限）。该文件将发出从主机到容器的 SSH 转发。将以下内容添加到 `/app/gitea/gitea`：
+在下一步中，需要在主机上创建一个名为 `/user/local/bin/gitea` 的文件（具有可执行权限）。该文件将发出从主机到容器的 SSH 转发。将以下内容添加到 `/user/local/bin`：
 
 ```bash
 ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"
@@ -324,14 +324,14 @@ ports:
 ssh-rsa <Gitea Host Key>
 
 # other keys from users
-command="/app/gitea/gitea --config=/data/gitea/conf/app.ini serv key-1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty <user pubkey>
+command="/user/local/bin/gitea --config=/data/gitea/conf/app.ini serv key-1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty <user pubkey>
 ```
 
 这是详细的说明，当发出 SSH 请求时会发生什么：
 
 1. 使用 `git` 用户向主机发出 SSH 请求，例如 `git clone git@domain:user/repo.git`。
-2. 在 `/home/git/.ssh/authorized_keys` 中，该命令执行 `/app/gitea/gitea` 脚本。
-3. `/app/gitea/gitea` 将 SSH 请求转发到端口 2222，该端口已映射到容器的 SSH 端口（22）。
+2. 在 `/home/git/.ssh/authorized_keys` 中，该命令执行 `/user/local/bin/gitea` 脚本。
+3. `/user/local/bin/gitea` 将 SSH 请求转发到端口 2222，该端口已映射到容器的 SSH 端口（22）。
 4. 由于 `/home/git/.ssh/authorized_keys` 中存在 `git` 用户的公钥，因此身份验证主机 → 容器成功，并且 SSH 请求转发到在 docker 容器中运行的 Gitea。
 
 如果在 Gitea Web 界面中添加了新的 SSH 密钥，它将以与现有密钥相同的方式附加到 `.ssh/authorized_keys` 中。

--- a/docs/content/doc/installation/with-docker.zh-cn.md
+++ b/docs/content/doc/installation/with-docker.zh-cn.md
@@ -301,7 +301,7 @@ volumes:
 sudo -u git ssh-keygen -t rsa -b 4096 -C "Gitea Host Key"
 ```
 
-在下一步中，需要在主机上创建一个名为 `/user/local/bin/gitea` 的文件（具有可执行权限）。该文件将发出从主机到容器的 SSH 转发。将以下内容添加到 `/user/local/bin`：
+在下一步中，需要在主机上创建一个名为 `/user/local/bin/gitea` 的文件（具有可执行权限）。该文件将发出从主机到容器的 SSH 转发。将以下内容添加到 `/user/local/bin/gitea`：
 
 ```bash
 ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $0 $@"

--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -57,7 +57,7 @@ The command has to be executed with the `RUN_USER = <OS_USERNAME>` specified in 
 Example:
 
 ```none
-docker exec -u <OS_USERNAME> -it -w <--tempdir> $(docker ps -qf 'name=^<NAME_OF_DOCKER_CONTAINER>$') bash -c '/app/gitea/gitea dump -c </path/to/app.ini>'
+docker exec -u <OS_USERNAME> -it -w <--tempdir> $(docker ps -qf 'name=^<NAME_OF_DOCKER_CONTAINER>$') bash -c '/user/local/bin/gitea dump -c </path/to/app.ini>'
 ```
 
 \*Note: `--tempdir` refers to the temporary directory of the docker environment used by Gitea; if you have not specified a custom `--tempdir`, then Gitea uses `/tmp` or the `TMPDIR` environment variable of the docker container. For `--tempdir` adjust your `docker exec` command options accordingly.


### PR DESCRIPTION
Follow #17846

Now Gitea (in Docker) always use unified FHS `/usr/local/bin/gitea`. Update documents.
