### PR TITLE
feat: add mitigation for the d(HE)ater DoS attack via ssh

### DIFF
--- a/docker/root/etc/templates/sshd_config
+++ b/docker/root/etc/templates/sshd_config
@@ -23,6 +23,10 @@ AuthorizedKeysFile .ssh/authorized_keys
 AuthorizedPrincipalsFile .ssh/authorized_principals
 TrustedUserCAKeys /data/git/.ssh/gitea-trusted-user-ca-keys.pem
 CASignatureAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+KexAlgorithms -ecdh-sha2-*,-diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
 
 UseDNS no
 AllowAgentForwarding no


### PR DESCRIPTION
Hi,

This PR adds SSHd configuration to mitigate the ssh d(HE)eater DoS attack, the mitigation consists in disabling a Diffie-Hellman Key Exchange algorithm (diffie-hellman-group1-sha1), more details can be found at https://github.com/Balasys/dheater
It also applies some ssh hardening from https://www.ssh-audit.com/hardening_guides.html namely settings a hardened list of Key Exchange Algorithms, Ciphers, HostKeyAlgorithms and Message Authentication Code Algorithms.

Please let me know if you need any more clarification.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
