### PR TITLE
Fix follower display on user page

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -17,7 +17,9 @@
 						{{if .Owner.FullName}}<span class="header text center">{{.Owner.FullName}}</span>{{end}}
 						<span class="username text center">{{.Owner.Name}}</span>
 						<a href="{{.Owner.HomeLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{.i18n.Tr "rss_feed"}}" data-position="bottom center">{{svg "octicon-rss" 18}}</i></a>
-						<a class="muted" href="{{.Owner.HomeLink}}?tab=followers">{{svg "octicon-person" 18 "mr-2"}}{{.Owner.NumFollowers}} {{.i18n.Tr "user.followers"}}</a> · <a class="muted" href="{{.Owner.HomeLink}}?tab=following">{{.Owner.NumFollowing}} {{.i18n.Tr "user.following"}}</a>
+						<div class="mt-3">
+							<a class="muted" href="{{.Owner.HomeLink}}?tab=followers">{{svg "octicon-person" 18 "mr-2"}}{{.Owner.NumFollowers}} {{.i18n.Tr "user.followers"}}</a> · <a class="muted" href="{{.Owner.HomeLink}}?tab=following">{{.Owner.NumFollowing}} {{.i18n.Tr "user.following"}}</a>
+						</div>
 					</div>
 					<div class="extra content word-break">
 						<ul>


### PR DESCRIPTION
Missed a wrapper `<div>` in my suggestion in https://github.com/go-gitea/gitea/pull/19482, this adds it.

<img width="276" alt="image" src="https://user-images.githubusercontent.com/115237/170296722-90052023-fed0-45f8-852a-550cc802cc13.png">