### PR TITLE
Make WIP prefixes case insensitive, e.g. allow `Draft` as a WIP prefix (#19780)

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -880,7 +880,7 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; List of prefixes used in Pull Request title to mark them as Work In Progress
+;; List of prefixes used in Pull Request title to mark them as Work In Progress (matched in a case-insensitive manner)
 ;WORK_IN_PROGRESS_PREFIXES = WIP:,[WIP]
 ;;
 ;; List of keywords used in Pull Request comments to automatically close a related issue

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -87,7 +87,7 @@ Values containing `#` or `;` must be quoted using `` ` `` or `"""`.
 ### Repository - Pull Request (`repository.pull-request`)
 
 - `WORK_IN_PROGRESS_PREFIXES`: **WIP:,\[WIP\]**: List of prefixes used in Pull Request
- title to mark them as Work In Progress
+ title to mark them as Work In Progress. These are matched in a case-insensitive manner.
 - `CLOSE_KEYWORDS`: **close**, **closes**, **closed**, **fix**, **fixes**, **fixed**, **resolve**, **resolves**, **resolved**: List of
  keywords used in Pull Request comments to automatically close a related issue
 - `REOPEN_KEYWORDS`: **reopen**, **reopens**, **reopened**: List of keywords used in Pull Request comments to automatically reopen

--- a/models/pull.go
+++ b/models/pull.go
@@ -622,7 +622,7 @@ func (pr *PullRequest) IsWorkInProgress() bool {
 // HasWorkInProgressPrefix determines if the given PR title has a Work In Progress prefix
 func HasWorkInProgressPrefix(title string) bool {
 	for _, prefix := range setting.Repository.PullRequest.WorkInProgressPrefixes {
-		if strings.HasPrefix(strings.ToUpper(title), prefix) {
+		if strings.HasPrefix(strings.ToUpper(title), strings.ToUpper(prefix)) {
 			return true
 		}
 	}
@@ -643,7 +643,7 @@ func (pr *PullRequest) GetWorkInProgressPrefix() string {
 	}
 
 	for _, prefix := range setting.Repository.PullRequest.WorkInProgressPrefixes {
-		if strings.HasPrefix(strings.ToUpper(pr.Issue.Title), prefix) {
+		if strings.HasPrefix(strings.ToUpper(pr.Issue.Title), strings.ToUpper(prefix)) {
 			return pr.Issue.Title[0:len(prefix)]
 		}
 	}


### PR DESCRIPTION
Backport #19780

The issue was that only the actual title was converted to uppercase, but
not the prefix as specified in `WORK_IN_PROGRESS_PREFIXES`. As a result,
the following did not work:

    WORK_IN_PROGRESS_PREFIXES=Draft:,[Draft],WIP:,[WIP]

One possible workaround was:

    WORK_IN_PROGRESS_PREFIXES=DRAFT:,[DRAFT],WIP:,[WIP]

Then indeed one could use `Draft` (as well as `DRAFT`) in the title.
However, the link `Start the title with DRAFT: to prevent the pull request
from being merged accidentally.` showed the suggestion in uppercase; so
it is not possible to show it as `Draft`. This PR fixes it, and allows
to use `Draft` in `WORK_IN_PROGRESS_PREFIXES`.

Fixes #19779.

Co-authored-by: zeripath <art27@cantab.net>

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
