### PR TITLE
A general QuoteString for SQL

### DIFF
--- a/integrations/database_test.go
+++ b/integrations/database_test.go
@@ -19,10 +19,10 @@ func TestDatabase(t *testing.T) {
 	// test a SQL string
 	assert.Equal(t, "'it''s fine'", db.QuoteString(db.DefaultContext, "it's fine"))
 
-	// test all ASCII chars
-	// Fill the slice with ASCII characters including 1 up until 126.
-	b := make([]byte, 126)
-	for i := byte(0); i < 126; i++ {
+	// Test all ASCII chars. 0 (NUL) char has undefined behaviors across databases and it does no harm, ignore it.
+	// Fill the slice with ASCII characters from 1 to 127.
+	b := make([]byte, 127)
+	for i := byte(0); i < 127; i++ {
 		b[i] = i + 1
 	}
 	raw := string(b)

--- a/integrations/database_test.go
+++ b/integrations/database_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package integrations
+
+import (
+	"fmt"
+	"testing"
+
+	"code.gitea.io/gitea/models/db"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	// test a SQL string
+	assert.Equal(t, "'it''s fine'", db.QuoteString(db.DefaultContext, "it's fine"))
+
+	// test all ASCII chars
+	b := make([]byte, 126) // no 0, no 127, then we have 1-126 ASCII chars
+	for i := 0; i < 126; i++ {
+		b[i] = byte(i + 1)
+	}
+	raw := string(b)
+	quoted := db.QuoteString(db.DefaultContext, raw)
+	var res string
+	_, err := db.GetEngine(db.DefaultContext).SQL(fmt.Sprintf("SELECT %s", quoted)).Get(&res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, raw, res)
+}

--- a/integrations/database_test.go
+++ b/integrations/database_test.go
@@ -20,9 +20,10 @@ func TestDatabase(t *testing.T) {
 	assert.Equal(t, "'it''s fine'", db.QuoteString(db.DefaultContext, "it's fine"))
 
 	// test all ASCII chars
-	b := make([]byte, 126) // no 0, no 127, then we have 1-126 ASCII chars
-	for i := 0; i < 126; i++ {
-		b[i] = byte(i + 1)
+	// Fill the slice with ASCII characters including 1 up until 126.
+	b := make([]byte, 126)
+	for i := byte(0); i < 126; i++ {
+		b[i] = i + 1
 	}
 	raw := string(b)
 	quoted := db.QuoteString(db.DefaultContext, raw)

--- a/models/db/context.go
+++ b/models/db/context.go
@@ -180,7 +180,6 @@ func TableName(bean interface{}) string {
 // EstimateCount returns an estimate of total number of rows in table
 func EstimateCount(ctx context.Context, bean interface{}) (int64, error) {
 	e := GetEngine(ctx)
-	e.Context(ctx)
 
 	var rows int64
 	var err error

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -294,9 +294,10 @@ func GetMaxID(beanOrTableName interface{}) (maxID int64, err error) {
 	return
 }
 
-// QuoteString quotes the string for SQLs. In most cases, SQL should use the ORM builder.
-// This function could only be used in rare cases when there is no other choices.
+// QuoteString quotes the string for SQL. In most cases, SQL should use the ORM builder, not this one.
+// This function is NOT recommended, it could ONLY be used in rare cases when there is no other choice.
 // It panics if the database is not supported to avoid corrupted data
+// At the moment it follows the behavior of convertString and convertStringSingleQuote in XORM, and is covered by tests.
 func QuoteString(ctx context.Context, s string) string {
 	e, ok := GetEngine(ctx).(*xorm.Engine)
 	if !ok {

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -306,6 +306,7 @@ func QuoteString(ctx context.Context, s string) string {
 	// The NUL char doesn't need to be considered because there are undefined behaviors across databases, as long as the NUL char doesn't do harm, let it go.
 	switch e.Dialect().URI().DBType {
 	case schemas.MYSQL:
+		// at the moment, Gitea MySQL runs without NO_BACKSLASH_ESCAPES, so the slashes should be escaped. The same as XORM.convertString
 		s = strings.ReplaceAll(s, "\\", "\\\\")
 		s = strings.ReplaceAll(s, "'", "''")
 		return "'" + s + "'"

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -303,7 +303,7 @@ func QuoteString(ctx context.Context, s string) string {
 	if !ok {
 		panic("can not get the real database engine")
 	}
-
+	// The NUL char doesn't need to be considered because there are undefined behaviors across databases, as long as the NUL char doesn't do harm, let it go.
 	switch e.Dialect().URI().DBType {
 	case schemas.MYSQL:
 		s = strings.ReplaceAll(s, "\\", "\\\\")

--- a/models/repo_list.go
+++ b/models/repo_list.go
@@ -561,7 +561,7 @@ func searchRepositoryByCondition(ctx context.Context, opts *SearchRepoOptions, c
 	} else if strings.Count(opts.Keyword, "/") == 1 {
 		// With "owner/repo" search times, prioritise results which match the owner field
 		orgName := strings.Split(opts.Keyword, "/")[0]
-		opts.OrderBy = db.SearchOrderBy(fmt.Sprintf("CASE WHEN owner_name LIKE '%s' THEN 0 ELSE 1 END, %s", orgName, opts.OrderBy))
+		opts.OrderBy = db.SearchOrderBy(fmt.Sprintf("CASE WHEN owner_name LIKE %s THEN 0 ELSE 1 END, %s", db.QuoteString(ctx, orgName), opts.OrderBy))
 	}
 
 	sess := db.GetEngine(ctx)


### PR DESCRIPTION
In rare cases, some SQL statements could be constructed directly without builder.

So a general `QuoteString` function will help.


Feel free to edit this PR directly.