### PR TITLE
Fix count bug

### DIFF
--- a/models/consistency.go
+++ b/models/consistency.go
@@ -95,7 +95,8 @@ func CountOrphanedIssues() (int64, error) {
 	return db.GetEngine(db.DefaultContext).Table("issue").
 		Join("LEFT", "repository", "issue.repo_id=repository.id").
 		Where(builder.IsNull{"repository.id"}).
-		Count("id")
+		Select("id").
+		Count()
 }
 
 // DeleteOrphanedIssues delete issues without a repo
@@ -141,7 +142,8 @@ func CountOrphanedObjects(subject, refobject, joinCond string) (int64, error) {
 	return db.GetEngine(db.DefaultContext).Table("`"+subject+"`").
 		Join("LEFT", "`"+refobject+"`", joinCond).
 		Where(builder.IsNull{"`" + refobject + "`.id"}).
-		Count("id")
+		Select("id").
+		Count()
 }
 
 // DeleteOrphanedObjects delete subjects with have no existing refobject anymore
@@ -241,7 +243,6 @@ func FixIssueLabelWithOutsideLabels() (int64, error) {
 				WHERE
 					(label.org_id = 0 AND issue.repo_id != label.repo_id) OR (label.repo_id = 0 AND label.org_id != repository.owner_id)
 	) AS il_too )`)
-
 	if err != nil {
 		return 0, err
 	}

--- a/models/consistency.go
+++ b/models/consistency.go
@@ -95,7 +95,7 @@ func CountOrphanedIssues() (int64, error) {
 	return db.GetEngine(db.DefaultContext).Table("issue").
 		Join("LEFT", "repository", "issue.repo_id=repository.id").
 		Where(builder.IsNull{"repository.id"}).
-		Select("id").
+		Select("COUNT(`issue`.`id`)").
 		Count()
 }
 
@@ -141,8 +141,8 @@ func DeleteOrphanedIssues() error {
 func CountOrphanedObjects(subject, refobject, joinCond string) (int64, error) {
 	return db.GetEngine(db.DefaultContext).Table("`"+subject+"`").
 		Join("LEFT", "`"+refobject+"`", joinCond).
-		Where(builder.IsNull{"`" + refobject + "`.id"}).
-		Select("`" + subject + "`.id").
+		Where(builder.IsNull{"`" + refobject + "`.`id`"}).
+		Select("COUNT(`" + subject + "`.`id`)").
 		Count()
 }
 

--- a/models/consistency.go
+++ b/models/consistency.go
@@ -142,7 +142,7 @@ func CountOrphanedObjects(subject, refobject, joinCond string) (int64, error) {
 	return db.GetEngine(db.DefaultContext).Table("`"+subject+"`").
 		Join("LEFT", "`"+refobject+"`", joinCond).
 		Where(builder.IsNull{"`" + refobject + "`.id"}).
-		Select("id").
+		Select("`" + subject + "`.id").
 		Count()
 }
 


### PR DESCRIPTION
`Count` does not accept a string as parameter, just use `Select`.