### PR TITLE
Only return valid stopwatches to the EventSource

### DIFF
--- a/models/issue_stopwatch.go
+++ b/models/issue_stopwatch.go
@@ -75,7 +75,7 @@ type UserStopwatch struct {
 // GetUIDsAndNotificationCounts between the two provided times
 func GetUIDsAndStopwatch() ([]*UserStopwatch, error) {
 	sws := []*Stopwatch{}
-	if err := db.GetEngine(db.DefaultContext).Find(&sws); err != nil {
+	if err := db.GetEngine(db.DefaultContext).Where("issue_id != 0").Find(&sws); err != nil {
 		return nil, err
 	}
 	if len(sws) == 0 {


### PR DESCRIPTION
Looking through the logs of try.gitea.io I am seeing a number of reports
of being unable to APIformat stopwatches because the issueID is 0. These
are invalid StopWatches and they represent a db inconsistency.

This PR simply stops sending them to the eventsource.

Signed-off-by: Andrew Thornton <art27@cantab.net>
