### PR TITLE
Prevent NPE on update mirror settings

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -391,7 +391,7 @@ func repoAssignment(ctx *Context, repo *repo_model.Repository) {
 				ctx.ServerError("GetMirrorByRepoID", err)
 				return
 			}
-			ctx.Repo.Mirror.Repo = ctx.Repo.Repository
+			ctx.Repo.Mirror.Repo = repo
 			ctx.Data["MirrorEnablePrune"] = ctx.Repo.Mirror.EnablePrune
 			ctx.Data["MirrorInterval"] = ctx.Repo.Mirror.Interval
 			ctx.Data["Mirror"] = ctx.Repo.Mirror

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -32,7 +32,7 @@ const gitShortEmptySha = "0000000"
 // UpdateAddress writes new address to Git repository and database
 func UpdateAddress(ctx context.Context, m *repo_model.Mirror, addr string) error {
 	remoteName := m.GetRemoteName()
-	repoPath := m.Repo.RepoPath()
+	repoPath := m.GetRepository().RepoPath()
 	// Remove old remote
 	_, _, err := git.NewCommand(ctx, "remote", "rm", remoteName).RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil && !strings.HasPrefix(err.Error(), "exit status 128 - fatal: No such remote ") {


### PR DESCRIPTION
A `repo_model.Mirror` repository field (`.Repo`) will not automatically
be set, but is used without checking in mirror_pull.go:UpdateAddress.
This will cause an NPE.

This PR changes UpdateAddress to use the helper function GetRepository()
helping prevent future NPEs but also changes modules/context/repo.go to
ensure that the Mirror.Repo is set.

Signed-off-by: Andrew Thornton <art27@cantab.net>
