### PR TITLE
gitconfig: set safe.directory = *

### DIFF
--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -68,6 +68,8 @@ adduser \
    git
 ```
 
+**NOTE:** If such a dedicated Gitea user is not created and Gitea is run from an already existing user instead, it may modify the global git configuration file. It is possible to use an altnerate global git configuration file by setting the [GIT_CONFIG_GLOBAL](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode) if [git version 2.32 or above](https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt#L92-L93) is installed.
+
 ### Create required directory structure
 
 ```sh

--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -68,8 +68,6 @@ adduser \
    git
 ```
 
-**NOTE:** If such a dedicated Gitea user is not created and Gitea is run from an already existing user instead, it may modify the global git configuration file. It is possible to use an altnerate global git configuration file by setting the [GIT_CONFIG_GLOBAL](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode) if [git version 2.32 or above](https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt#L92-L93) is installed.
-
 ### Create required directory structure
 
 ```sh

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -254,16 +254,10 @@ func syncGitConfig() (err error) {
 	// Disable the security check because Gitea runs the git CLI from within the
 	// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
 	// safe.directory accept * was introduced in https://github.com/git/git/blob/main/Documentation/RelNotes/2.30.4.txt
-	if CheckGitVersionAtLeast("2.30.4") == nil {
-		if err := configAddNonExist("safe.directory", "*"); err != nil {
-			return err
-		}
-	} else {
-		if err := configSet("safe.directory", setting.RepoRootPath); err != nil {
-			return err
-		}
+	// Although only supported by Git 2.30.4/2.31.3/2.32.2/2.33.3/2.34.3/2.35.3/2.36 and later - this setting is tolerated by earlier versions
+	if err := configAddNonExist("safe.directory", "*"); err != nil {
+		return err
 	}
-
 	if runtime.GOOS == "windows" {
 		if err := configSet("core.longpaths", "true"); err != nil {
 			return err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -251,6 +251,16 @@ func syncGitConfig() (err error) {
 		}
 	}
 
+	if CheckGitVersionAtLeast("2.36") == nil {
+		//
+		// Disable the security check because Gitea runs the git CLI from within the
+		// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
+		//
+		if err := checkAndSetConfig("safe.directory", "*", true); err != nil {
+			return err
+		}
+	}
+
 	if runtime.GOOS == "windows" {
 		if err := configSet("core.longpaths", "true"); err != nil {
 			return err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -251,14 +251,12 @@ func syncGitConfig() (err error) {
 		}
 	}
 
-	if CheckGitVersionAtLeast("2.36") == nil {
-		//
-		// Disable the security check because Gitea runs the git CLI from within the
-		// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
-		//
-		if err := checkAndSetConfig("safe.directory", "*", true); err != nil {
-			return err
-		}
+	//
+	// Disable the security check because Gitea runs the git CLI from within the
+	// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
+	//
+	if err := configAddNonExist("safe.directory", "*"); err != nil {
+		return err
 	}
 
 	if runtime.GOOS == "windows" {

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -251,9 +251,15 @@ func syncGitConfig() (err error) {
 		}
 	}
 
-	// Disable the security check because Gitea runs the git CLI from within the
-	// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
-	// safe.directory accept * was introduced in https://github.com/git/git/blob/main/Documentation/RelNotes/2.30.4.txt
+	// Due to CVE-2022-24765, git now denies access to git directories which are not owned by current user
+	// however, some docker users and samba users find it difficult to configure their systems so that Gitea's git repositories are owned by the Gitea user. (Possibly Windows Service users - but ownership in this case should really be set correctly on the filesystem.)
+	// see issue: https://github.com/go-gitea/gitea/issues/19455
+	// Fundamentally the problem lies with the uid-gid-mapping mechanism for filesystems in docker on windows (and to a lesser extent samba). 
+	// Docker's configuration mechanism for local filesystems provides no way of setting this mapping and although there is a mechanism for setting this uid through using cifs mounting it is complicated and essentially undocumented
+	// Thus the owner uid/gid for files on these filesystems will be marked as root.
+	// As Gitea now always use its internal git config file, and access to the git repositories is managed through Gitea,
+	// it is now safe to set "safe.directory=*" for internal usage only 
+	// Please note: the wildcard "*" is only supported by Git 2.30.4/2.31.3/2.32.2/2.33.3/2.34.3/2.35.3/2.36 and later
 	// Although only supported by Git 2.30.4/2.31.3/2.32.2/2.33.3/2.34.3/2.35.3/2.36 and later - this setting is tolerated by earlier versions
 	if err := configAddNonExist("safe.directory", "*"); err != nil {
 		return err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -254,11 +254,11 @@ func syncGitConfig() (err error) {
 	// Due to CVE-2022-24765, git now denies access to git directories which are not owned by current user
 	// however, some docker users and samba users find it difficult to configure their systems so that Gitea's git repositories are owned by the Gitea user. (Possibly Windows Service users - but ownership in this case should really be set correctly on the filesystem.)
 	// see issue: https://github.com/go-gitea/gitea/issues/19455
-	// Fundamentally the problem lies with the uid-gid-mapping mechanism for filesystems in docker on windows (and to a lesser extent samba). 
+	// Fundamentally the problem lies with the uid-gid-mapping mechanism for filesystems in docker on windows (and to a lesser extent samba).
 	// Docker's configuration mechanism for local filesystems provides no way of setting this mapping and although there is a mechanism for setting this uid through using cifs mounting it is complicated and essentially undocumented
 	// Thus the owner uid/gid for files on these filesystems will be marked as root.
 	// As Gitea now always use its internal git config file, and access to the git repositories is managed through Gitea,
-	// it is now safe to set "safe.directory=*" for internal usage only 
+	// it is now safe to set "safe.directory=*" for internal usage only.
 	// Please note: the wildcard "*" is only supported by Git 2.30.4/2.31.3/2.32.2/2.33.3/2.34.3/2.35.3/2.36 and later
 	// Although only supported by Git 2.30.4/2.31.3/2.32.2/2.33.3/2.34.3/2.35.3/2.36 and later - this setting is tolerated by earlier versions
 	if err := configAddNonExist("safe.directory", "*"); err != nil {

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -251,12 +251,17 @@ func syncGitConfig() (err error) {
 		}
 	}
 
-	//
 	// Disable the security check because Gitea runs the git CLI from within the
 	// repository. See https://github.com/go-gitea/gitea/issues/19455 for the full discussion.
-	//
-	if err := configAddNonExist("safe.directory", "*"); err != nil {
-		return err
+	// safe.directory accept * was introduced in https://github.com/git/git/blob/main/Documentation/RelNotes/2.30.4.txt
+	if CheckGitVersionAtLeast("2.30.4") == nil {
+		if err := configAddNonExist("safe.directory", "*"); err != nil {
+			return err
+		}
+	} else {
+		if err := configSet("safe.directory", setting.RepoRootPath); err != nil {
+			return err
+		}
 	}
 
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Allow git push to work when networked file systems with mixed
ownership are used with Gitea docker images >= 1.16.6 or Gitea
binaries running alongside git versions published after 04/2022.

There are circumstances independent of Gitea (networked file systems
with various permission systems) by which the git repositories managed
by Gitea may have mixed owners. It is not a behavior that Gitea have
control over nor is it a problem as long as the permissions for Gitea to
operate are correct. Gitea instances have been operating under these
conditions for a number of years.

It is detected as a potential security risk ( see
https://github.com/git-for-windows/git/security/advisories/GHSA-vw2c-22j4-2fh2
) by the most recent git versions. However, Gitea always runs git
commands with a current directory matching the repository on
which it operates. That makes Gitea immune from this security problem
and it is safe to ignore the mixed owner permission check.

This gitconfig modification is done on a file dedicated to the user
exclusively used by Gitea.

Fixes: #19455

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
