### PR TITLE
alpine 3.16 (#19797)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Build stage
-FROM golang:1.18-alpine3.15 AS build-env
+FROM golang:1.18-alpine3.16 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -23,7 +23,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM alpine:3.13
+FROM alpine:3.16
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 22 3000

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,5 +1,5 @@
 #Build stage
-FROM golang:1.18-alpine3.15 AS build-env
+FROM golang:1.18-alpine3.16 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -23,7 +23,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM alpine:3.13
+FROM alpine:3.16
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 2222 3000


### PR DESCRIPTION
Co-authored-by: 6543 <6543@obermui.de>
(cherry picked from commit 0cbec3cd373941405a3e2d49d4ad9784972c00e3)

Conflicts:
	Dockerfile
	Dockerfile.rootless
	 jump directly from 3.13 to 3.16 as backports were not done
	 for intermediate alpine versions
