### PR TITLE
Import git from alpine 3.16 repository as 2.30.4 is needed for `safe.directory = '*'` to work but alpine 3.13 has 2.30.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,14 @@ RUN apk --no-cache add \
     ca-certificates \
     curl \
     gettext \
-    git \
     linux-pam \
     openssh \
     s6 \
     sqlite \
     su-exec \
     gnupg
+
+RUN apk add git --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main
 
 RUN addgroup \
     -S -g 1000 \

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -32,9 +32,10 @@ RUN apk --no-cache add \
     bash \
     ca-certificates \
     gettext \
-    git \
     curl \
     gnupg
+
+RUN apk add git --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main
 
 RUN addgroup \
     -S -g 1000 \


### PR DESCRIPTION
Refs: #19455
