### PR TITLE
Use exact search instead of fuzzy search for branch filter dropdown

### DIFF
--- a/web_src/js/features/repo-common.js
+++ b/web_src/js/features/repo-common.js
@@ -110,14 +110,14 @@ export function initRepoCommonBranchOrTagDropdown(selector) {
 export function initRepoCommonFilterSearchDropdown(selector) {
   const $dropdown = $(selector);
   $dropdown.dropdown({
-    fullTextSearch: true,
+    fullTextSearch: 'exact',
     selectOnKeydown: false,
     onChange(_text, _value, $choice) {
-      if ($choice.data('url')) {
-        window.location.href = $choice.data('url');
+      if ($choice.attr('data-url')) {
+        window.location.href = $choice.attr('data-url');
       }
     },
-    message: {noResults: $dropdown.data('no-results')},
+    message: {noResults: $dropdown.attr('data-no-results')},
   });
 }
 


### PR DESCRIPTION
The `fullTextSearch: true` is for fuzzy search, which is not ideal for the branch filter.

Change to `fullTextSearch: 'exact'` to do the exact search.

Close #19778
* #19778