### PR TITLE
Band-aid solution to make edit buttons focusable

### DIFF
--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -14,8 +14,8 @@
 		</h1>
 		{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .Repository.IsArchived)}}
 			<div class="edit-buttons">
-				<div id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none">{{.i18n.Tr "repo.issues.cancel"}}</div>
-				<div id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}}>{{.i18n.Tr "repo.issues.save"}}</div>
+				<div id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none" tabindex="0">{{.i18n.Tr "repo.issues.cancel"}}</div>
+				<div id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}} tabindex="0">{{.i18n.Tr "repo.issues.save"}}</div>
 			</div>
 		{{end}}
 	</div>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -14,8 +14,8 @@
 		</h1>
 		{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .Repository.IsArchived)}}
 			<div class="edit-buttons">
-				<div id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none" tabindex="0">{{.i18n.Tr "repo.issues.cancel"}}</div>
-				<div id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}} tabindex="0">{{.i18n.Tr "repo.issues.save"}}</div>
+				<button id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none" type="button">{{.i18n.Tr "repo.issues.cancel"}}</button>
+				<button id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}} type="button">{{.i18n.Tr "repo.issues.save"}}</button>
 			</div>
 		{{end}}
 	</div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1816,6 +1816,13 @@ a.ui.label:hover {
 .ui.basic.secondary.buttons .button:active,
 .ui.basic.secondary.button:active {
   color: var(--color-secondary-dark-8) !important;
+  border-color: var(--color-secondary-dark-4) !important;
+}
+
+.ui.basic.secondary.button:focus,
+.ui.basic.secondary.buttons .button:focus {
+  color: var(--color-secondary-dark-8) !important;
+  border-color: var(--color-secondary-dark-6) !important;
 }
 
 .ui.primary.label,


### PR DESCRIPTION
Partially addressing https://github.com/go-gitea/gitea/issues/19769

These will need more work to get done properly.
However, this will require more communication, which might mean
that a fix may or may not make it into the next release.

To improve the situation at least a little bit, allow for
keyboard usage.

I noticed that the `:focus` styling is lost on the cancel button here.
Inspecting the root cause led to a regression caused by https://github.com/go-gitea/gitea/pull/19763
I'd like to have @silverwind look into this if possible, as I lack the
context that led to the mentioned PR. (namely: why `!important`s?)

Regarding the usage of `<div>`s: That was never changed here.
I would assume, there is no specific reason. Should I change the
markup to a proper `<button type="button">` instead? Or are there
side effects I should be aware of?

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>