### PR TITLE
Replace unstyled meter with progress

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -19,8 +19,8 @@
 			</div>
 			<div class="diff-detail-actions df ac">
 				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
-					<meter id="viewed-files-summary" value="{{.Diff.NumViewedFiles}}" max="{{.Diff.NumFiles}}"></meter>
-					<label for="viewed-files-summary" id="viewed-files-summary-label" data-text-changed-template="{{.i18n.Tr "repo.pulls.viewed_files_label"}}">
+					<progress id="viewed-files-summary" class="mr-2" value="{{.Diff.NumViewedFiles}}" max="{{.Diff.NumFiles}}"></progress>
+					<label for="viewed-files-summary" id="viewed-files-summary-label" class="mr-2" data-text-changed-template="{{.i18n.Tr "repo.pulls.viewed_files_label"}}">
 						{{.i18n.Tr "repo.pulls.viewed_files_label" .Diff.NumViewedFiles .Diff.NumFiles}}
 					</label>
 				{{end}}

--- a/web_src/js/features/pull-view-file.js
+++ b/web_src/js/features/pull-view-file.js
@@ -9,8 +9,8 @@ const viewedCheckboxSelector = '.viewed-file-form'; // Selector under which all 
 // Refreshes the summary of viewed files if present
 // The data used will be window.config.pageData.prReview.numberOf{Viewed}Files
 function refreshViewedFilesSummary() {
-  const viewedFilesMeter = document.getElementById('viewed-files-summary');
-  viewedFilesMeter?.setAttribute('value', prReview.numberOfViewedFiles);
+  const viewedFilesProgress = document.getElementById('viewed-files-summary');
+  viewedFilesProgress?.setAttribute('value', prReview.numberOfViewedFiles);
   const summaryLabel = document.getElementById('viewed-files-summary-label');
   if (summaryLabel) summaryLabel.innerHTML = summaryLabel.getAttribute('data-text-changed-template')
     .replace('%[1]d', prReview.numberOfViewedFiles)

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -211,19 +211,19 @@ details summary > * {
 }
 
 progress {
-  background: var(--color-secondary);
+  background: var(--color-secondary-dark-1);
   border-radius: 6px;
   border: none;
   overflow: hidden;
 }
 progress::-webkit-progress-bar {
-  background: var(--color-secondary);
+  background: var(--color-secondary-dark-1);
 }
 progress::-webkit-progress-value {
-  background-color: var(--color-secondary-dark-3);
+  background-color: var(--color-secondary-dark-4);
 }
 progress::-moz-progress-bar {
-  background: var(--color-secondary-dark-3);
+  background: var(--color-secondary-dark-4);
 }
 
 * {

--- a/web_src/less/_review.less
+++ b/web_src/less/_review.less
@@ -280,3 +280,8 @@ a.blob-excerpt:hover {
 .viewed-file-checked-form {
   background-color: var(--color-primary-light-4);
 }
+
+#viewed-files-summary {
+  width: 72px;
+  height: 10px;
+}


### PR DESCRIPTION
Replace the only `<meter>` element in use with a `<progress>` which is styled properly. Also slightly adjust colors on it for better contrast.

Before:

<img width="320" alt="Screen Shot 2022-06-14 at 22 34 59" src="https://user-images.githubusercontent.com/115237/173684737-bc039072-9cc2-4bf8-b8e6-c1e16d6b0295.png">

After:

<img width="323" alt="Screen Shot 2022-06-14 at 22 38 14" src="https://user-images.githubusercontent.com/115237/173684766-eba5fe5c-2ec8-4021-ac96-2609b8c7d479.png">
<img width="333" alt="Screen Shot 2022-06-14 at 22 38 25" src="https://user-images.githubusercontent.com/115237/173684771-fec11e0b-86a9-4b72-808f-de58cc6e5065.png">

