### PR TITLE
fix `go to file` link for mirror repository

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -74,7 +74,7 @@
 					</div>
 				{{end}}
 				<div class="fitted item mx-0">
-					<a href="{{.BaseRepo.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button">
+					<a href="{{.Repository.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button">
 						{{.i18n.Tr "repo.find_file.go_to_file"}}
 					</a>
 				</div>


### PR DESCRIPTION
the `BaseRepo` not always exist, should use `Repository`.

