### PR TITLE
Use DisplayName() instead of FullName in Oauth Provider

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -215,7 +215,7 @@ func newAccessTokenResponse(ctx stdContext.Context, grant *auth.OAuth2Grant, ser
 			Nonce: grant.Nonce,
 		}
 		if grant.ScopeContains("profile") {
-			idToken.Name = user.FullName
+			idToken.Name = user.GetDisplayName()
 			idToken.PreferredUsername = user.Name
 			idToken.Profile = user.HTMLURL()
 			idToken.Picture = user.AvatarLink()

--- a/routers/web/auth/oauth_test.go
+++ b/routers/web/auth/oauth_test.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/services/auth/source/oauth2"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -63,6 +64,24 @@ func TestNewAccessTokenResponse_OIDCToken(t *testing.T) {
 	grants, err = auth.GetOAuth2GrantsByUserID(db.DefaultContext, user.ID)
 	assert.NoError(t, err)
 	assert.Len(t, grants, 1)
+
+	// Scopes: openid profile email
+	oidcToken = createAndParseToken(t, grants[0])
+	assert.Equal(t, user.Name, oidcToken.Name)
+	assert.Equal(t, user.Name, oidcToken.PreferredUsername)
+	assert.Equal(t, user.HTMLURL(), oidcToken.Profile)
+	assert.Equal(t, user.AvatarLink(), oidcToken.Picture)
+	assert.Equal(t, user.Website, oidcToken.Website)
+	assert.Equal(t, user.UpdatedUnix, oidcToken.UpdatedAt)
+	assert.Equal(t, user.Email, oidcToken.Email)
+	assert.Equal(t, user.IsActive, oidcToken.EmailVerified)
+
+	// set DefaultShowFullName to true
+	oldDefaultShowFullName := setting.UI.DefaultShowFullName
+	setting.UI.DefaultShowFullName = true
+	defer func() {
+		setting.UI.DefaultShowFullName = oldDefaultShowFullName
+	}()
 
 	// Scopes: openid profile email
 	oidcToken = createAndParseToken(t, grants[0])


### PR DESCRIPTION
Use DisplayName() in Oauth as this provides a fallback if FullName is not set.

Closes #19382