### PR TITLE
Fix Readme render bug

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -357,7 +357,7 @@ func renderReadmeFile(ctx *context.Context, readmeFile *namedBlob, readmeTreelin
 		var result strings.Builder
 		err := markup.Render(&markup.RenderContext{
 			Ctx:          ctx,
-			RelativePath: path.Join(ctx.Repo.TreePath, readmeFile.name),
+			RelativePath: path.Join(ctx.Repo.TreePath, readmeFile.name), // For README renderer, ctx.Repo.TreePath just the path without file name
 			URLPrefix:    readmeTreelink,
 			Metas:        ctx.Repo.Repository.ComposeDocumentMetas(),
 			GitRepo:      ctx.Repo.GitRepo,

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -357,7 +357,7 @@ func renderReadmeFile(ctx *context.Context, readmeFile *namedBlob, readmeTreelin
 		var result strings.Builder
 		err := markup.Render(&markup.RenderContext{
 			Ctx:          ctx,
-			RelativePath: ctx.Repo.TreePath,
+			RelativePath: path.Join(ctx.Repo.TreePath, readmeFile.name),
 			URLPrefix:    readmeTreelink,
 			Metas:        ctx.Repo.Repository.ComposeDocumentMetas(),
 			GitRepo:      ctx.Repo.GitRepo,

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -357,7 +357,7 @@ func renderReadmeFile(ctx *context.Context, readmeFile *namedBlob, readmeTreelin
 		var result strings.Builder
 		err := markup.Render(&markup.RenderContext{
 			Ctx:          ctx,
-			RelativePath: path.Join(ctx.Repo.TreePath, readmeFile.name), // For README renderer, ctx.Repo.TreePath just the path without file name
+			RelativePath: path.Join(ctx.Repo.TreePath, readmeFile.name), // ctx.Repo.TreePath is the directory not the Readme so we must append the Readme filename (and path).
 			URLPrefix:    readmeTreelink,
 			Metas:        ctx.Repo.Repository.ComposeDocumentMetas(),
 			GitRepo:      ctx.Repo.GitRepo,


### PR DESCRIPTION
Fix #19988

The problem is caused sometiems `TreePath` is not the file path but the file's parent dir path.

This is a temporory bug fix, the same variable should not have different ,meaning.

For README render, it's an index file, so `treepath` is `""` or `"/"`, but we need to render the `README.md`. That's the problem.