### PR TITLE
Fix a JS error in initRepoCommitLastCommitLoader's entryMap

### DIFF
--- a/web_src/js/features/repo-commit.js
+++ b/web_src/js/features/repo-commit.js
@@ -45,7 +45,12 @@ export function initRepoCommitLastCommitLoader() {
         $('table#repo-files-table .commit-list').replaceWith(row);
         return;
       }
-      entryMap[$(row).attr('data-entryname')].replaceWith(row);
+      // there are other <tr> rows in response (eg: <tr class="has-parent">)
+      // at the moment only the "data-entryname" rows should be processed
+      const entryName = $(row).attr('data-entryname');
+      if (entryName) {
+        entryMap[entryName].replaceWith(row);
+      }
     });
   });
 }


### PR DESCRIPTION
The problem is that there are unrecognized tr rows in response, and the JS code didn't handle it correctly.

Close #19995
