### PR TITLE
Write Commit-Graphs in RepositoryDumper

### DIFF
--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -182,10 +182,8 @@ func (g *RepositoryDumper) CreateRepo(repo *base.Repository, opts base.MigrateOp
 				if err := os.RemoveAll(wikiPath); err != nil {
 					return fmt.Errorf("Failed to remove %s: %v", wikiPath, err)
 				}
-			} else {
-				if err := git.WriteCommitGraph(g.ctx, wikiPath); err != nil {
-					return err
-				}
+			} else if err := git.WriteCommitGraph(g.ctx, wikiPath); err != nil {
+				return err
 			}
 		}
 	}

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -159,6 +159,9 @@ func (g *RepositoryDumper) CreateRepo(repo *base.Repository, opts base.MigrateOp
 	if err != nil {
 		return fmt.Errorf("Clone: %v", err)
 	}
+	if err := git.WriteCommitGraph(g.ctx, repoPath); err != nil {
+		return err
+	}
 
 	if opts.Wiki {
 		wikiPath := g.wikiPath()
@@ -178,6 +181,10 @@ func (g *RepositoryDumper) CreateRepo(repo *base.Repository, opts base.MigrateOp
 				log.Warn("Clone wiki: %v", err)
 				if err := os.RemoveAll(wikiPath); err != nil {
 					return fmt.Errorf("Failed to remove %s: %v", wikiPath, err)
+				}
+			} else {
+				if err := git.WriteCommitGraph(g.ctx, wikiPath); err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
When migrating git repositories we should ensure that the commit-graph is written.

Signed-off-by: Andrew Thornton <art27@cantab.net>
