### PR TITLE
Add fetch.writeCommitGraph to gitconfig

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -238,6 +238,9 @@ func syncGitConfig() (err error) {
 		if err := configSet("gc.writeCommitGraph", "true"); err != nil {
 			return err
 		}
+		if err := configSet("fetch.writeCommitGraph", "true"); err != nil {
+			return err
+		}
 	}
 
 	if SupportProcReceive {


### PR DESCRIPTION
Add fetch.writeCommitGraph to gitconfig to ensure that a commit-graph will be written
on git fetch calls.

Signed-off-by: Andrew Thornton <art27@cantab.net>
