### PR TITLE
Stop spurious APIFormat stopwatches logs

### DIFF
--- a/modules/eventsource/manager_run.go
+++ b/modules/eventsource/manager_run.go
@@ -94,7 +94,9 @@ loop:
 				for _, userStopwatches := range usersStopwatches {
 					apiSWs, err := convert.ToStopWatches(userStopwatches.StopWatches)
 					if err != nil {
-						log.Error("Unable to APIFormat stopwatches: %v", err)
+						if !issues_model.IsErrIssueNotExist(err) {
+							log.Error("Unable to APIFormat stopwatches: %v", err)
+						}
 						continue
 					}
 					dataBs, err := json.Marshal(apiSWs)

--- a/routers/web/repo/issue_stopwatch.go
+++ b/routers/web/repo/issue_stopwatch.go
@@ -99,7 +99,9 @@ func GetActiveStopwatch(ctx *context.Context) {
 
 	issue, err := issues_model.GetIssueByID(ctx, sw.IssueID)
 	if err != nil || issue == nil {
-		ctx.ServerError("GetIssueByID", err)
+		if !issues_model.IsErrIssueNotExist(err) {
+			ctx.ServerError("GetIssueByID", err)
+		}
 		return
 	}
 	if err = issue.LoadRepo(ctx); err != nil {


### PR DESCRIPTION
If there are dangling stopwatches with missing issues there will be repeated
logging of Unable to APIFormat stopwatches. These are unhelpful and instead
we should only log if the error is not an issue not exist error.

Signed-off-by: Andrew Thornton <art27@cantab.net>
