### PR TITLE
Fix CountOrphanedLabels in orphan check

### DIFF
--- a/models/issues/label.go
+++ b/models/issues/label.go
@@ -733,7 +733,7 @@ func DeleteLabelsByRepoID(ctx context.Context, repoID int64) error {
 
 // CountOrphanedLabels return count of labels witch are broken and not accessible via ui anymore
 func CountOrphanedLabels() (int64, error) {
-	noref, err := db.GetEngine(db.DefaultContext).Table("label").Where("repo_id=? AND org_id=?", 0, 0).Count("label.id")
+	noref, err := db.GetEngine(db.DefaultContext).Table("label").Where("repo_id=? AND org_id=?", 0, 0).Count()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
gitea doctor --run check-db-consistency is currently broken due to an incorrect
and old use of Count() with a string.

Signed-off-by: Andrew Thornton <art27@cantab.net>
