### PR TITLE
fix push mirrors URL are no longer displayed on the UI

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -976,7 +976,7 @@ type remoteAddress struct {
 
 func mirrorRemoteAddress(ctx context.Context, m *repo_model.Repository, remoteName string) remoteAddress {
 	a := remoteAddress{}
-	if !m.IsMirror {
+	if m.IsMirror {
 		return a
 	}
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -976,9 +976,6 @@ type remoteAddress struct {
 
 func mirrorRemoteAddress(ctx context.Context, m *repo_model.Repository, remoteName string) remoteAddress {
 	a := remoteAddress{}
-	if m.IsMirror {
-		return a
-	}
 
 	remoteURL := m.OriginalURL
 	if remoteURL == "" {


### PR DESCRIPTION
I saw after the changes on this PR https://github.com/go-gitea/gitea/pull/18649   the push mirrors URL are no longer displayed on the UI 

![image](https://user-images.githubusercontent.com/98962410/174406724-948d12c3-f866-4c17-a726-26ef4697b0e5.png)
