### PR TITLE
CI: disable push to latest docker tag

### DIFF
--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -4,7 +4,6 @@ tags:
 {{#each build.tags}}
   - {{this}}-rootless
 {{/each}}
-  - "latest-rootless"
 {{/if}}
 manifests:
   -

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -4,7 +4,6 @@ tags:
 {{#each build.tags}}
   - {{this}}
 {{/each}}
-  - "latest"
 {{/if}}
 manifests:
   -


### PR DESCRIPTION
if we publish v1.17.0-rc1 and v1.16.9 afterwards we would have a downgrade!!!

this prevent it