### PR TITLE
Respond with a 401 on git push when password isn't changed yet (#20026)

### DIFF
--- a/modules/context/auth.go
+++ b/modules/context/auth.go
@@ -7,6 +7,7 @@ package context
 
 import (
 	"net/http"
+	"strings"
 
 	"code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/modules/log"
@@ -41,6 +42,10 @@ func Toggle(options *ToggleOptions) func(ctx *Context) {
 
 			if ctx.Doer.MustChangePassword {
 				if ctx.Req.URL.Path != "/user/settings/change_password" {
+					if strings.HasPrefix(ctx.Req.UserAgent(), "git") {
+						ctx.Error(http.StatusUnauthorized, ctx.Tr("auth.must_change_password"))
+						return
+					}
 					ctx.Data["Title"] = ctx.Tr("auth.must_change_password")
 					ctx.Data["ChangePasscodeLink"] = setting.AppSubURL + "/user/change_password"
 					if ctx.Req.URL.Path != "/user/events" {


### PR DESCRIPTION
backport of #20026

If the user-agent starts with git and user must change password but
hasn't return a 401 with the message.

It must be a 401, git doesn't seem to show the contents of the error message
when we return a 403

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
