### PR TITLE
 Fix git config fixed-value, use quoted regexp instead #20029

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -337,7 +338,7 @@ func configSetNonExist(key, value string) error {
 }
 
 func configAddNonExist(key, value string) error {
-	_, _, err := NewCommand(DefaultContext, "config", "--fixed-value", "--get", key, value).RunStdString(nil)
+	_, _, err := NewCommand(DefaultContext, "config", "--get", key, regexp.QuoteMeta(value)).RunStdString(nil)
 	if err == nil {
 		// already exist
 		return nil
@@ -357,7 +358,7 @@ func configUnsetAll(key, value string) error {
 	_, _, err := NewCommand(DefaultContext, "config", "--get", key).RunStdString(nil)
 	if err == nil {
 		// exist, need to remove
-		_, _, err = NewCommand(DefaultContext, "config", "--global", "--fixed-value", "--unset-all", key, value).RunStdString(nil)
+		_, _, err = NewCommand(DefaultContext, "config", "--global", "--unset-all", key, regexp.QuoteMeta(value)).RunStdString(nil)
 		if err != nil {
 			return fmt.Errorf("failed to unset git global config %s, err: %w", key, err)
 		}

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -78,4 +78,10 @@ func TestGitConfig(t *testing.T) {
 
 	assert.NoError(t, configUnsetAll("test.key-b", "val-2b"))
 	assert.False(t, gitConfigContains("key-b = val-2b"))
+
+	assert.NoError(t, configSet("test.key-x", "*"))
+	assert.True(t, gitConfigContains("key-x = *"))
+	assert.NoError(t, configSetNonExist("test.key-x", "*"))
+	assert.NoError(t, configUnsetAll("test.key-x", "*"))
+	assert.False(t, gitConfigContains("key-x = *"))
 }


### PR DESCRIPTION
Backport #20029

`--fixed-value` is not supported by old Git.

So the `regexp.QuoteMeta` must be used instead, otherwise the `git config --get key "*"` will exit with error `error: invalid pattern: *`.
