### PR TITLE
Simplify and fix migration 216 (#20035)

### DIFF
--- a/models/migrations/v216.go
+++ b/models/migrations/v216.go
@@ -42,26 +42,5 @@ func (a *improveActionTableIndicesAction) TableIndices() []*schemas.Index {
 }
 
 func improveActionTableIndices(x *xorm.Engine) error {
-	{
-		type Action struct {
-			ID          int64 `xorm:"pk autoincr"`
-			UserID      int64 `xorm:"INDEX"` // Receiver user id.
-			OpType      int
-			ActUserID   int64 `xorm:"INDEX"` // Action user id.
-			RepoID      int64 `xorm:"INDEX"`
-			CommentID   int64 `xorm:"INDEX"`
-			IsDeleted   bool  `xorm:"INDEX NOT NULL DEFAULT false"`
-			RefName     string
-			IsPrivate   bool               `xorm:"INDEX NOT NULL DEFAULT false"`
-			Content     string             `xorm:"TEXT"`
-			CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
-		}
-		if err := x.Sync2(&Action{}); err != nil {
-			return err
-		}
-		if err := x.DropIndexes(&Action{}); err != nil {
-			return err
-		}
-	}
 	return x.Sync2(&improveActionTableIndicesAction{})
 }


### PR DESCRIPTION
Backport #20035 

There appears to be a strange bug whereby the comment_id index can sometimes be missed
or missing from the action table despite the sync2 that should create it in the earlier
part of this migration. However, looking through the code for Sync2 there is no need
for this pre-code to exist and Sync2 should drop/create the indices as necessary.

I think therefore we should simplify the migration to simply be Sync2.

Signed-off-by: Andrew Thornton <art27@cantab.net>
