### PR TITLE
Alter hook_task TEXT fields to LONGTEXT (#20038)

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -389,6 +389,8 @@ var migrations = []Migration{
 	NewMigration("allow to view files in PRs", addReviewViewedFiles),
 	// v216 -> v217
 	NewMigration("Improve Action table indices", improveActionTableIndices),
+	// v217 -> v218
+	NewMigration("Alter hook_task table TEXT fields to LONGTEXT", alterHookTaskTextFieldsToLongText),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v217.go
+++ b/models/migrations/v217.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"code.gitea.io/gitea/modules/setting"
+
+	"xorm.io/xorm"
+)
+
+func alterHookTaskTextFieldsToLongText(x *xorm.Engine) error {
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	if setting.Database.UseMySQL {
+		if _, err := sess.Exec("ALTER TABLE `hook_task` CHANGE `payload_content` `payload_content` LONGTEXT, CHANGE `request_content` `request_content` LONGTEXT, change `response_content` `response_content` LONGTEXT"); err != nil {
+			return err
+		}
+	}
+	return sess.Commit()
+}

--- a/models/webhook/hooktask.go
+++ b/models/webhook/hooktask.go
@@ -105,7 +105,7 @@ type HookTask struct {
 	HookID          int64
 	UUID            string
 	api.Payloader   `xorm:"-"`
-	PayloadContent  string `xorm:"TEXT"`
+	PayloadContent  string `xorm:"LONGTEXT"`
 	EventType       HookEventType
 	IsDelivered     bool
 	Delivered       int64
@@ -113,9 +113,9 @@ type HookTask struct {
 
 	// History info.
 	IsSucceed       bool
-	RequestContent  string        `xorm:"TEXT"`
+	RequestContent  string        `xorm:"LONGTEXT"`
 	RequestInfo     *HookRequest  `xorm:"-"`
-	ResponseContent string        `xorm:"TEXT"`
+	ResponseContent string        `xorm:"LONGTEXT"`
 	ResponseInfo    *HookResponse `xorm:"-"`
 }
 


### PR DESCRIPTION
Backport of #20038 

Mysql TEXT has a limit of 64KB, change this to LONGTEXT in mysql only so we can have bigger hook payloads.

Postgresql has unlimited TEXT - https://www.postgresql.org/docs/current/datatype-character.html
Sqlite has unlimited TEXT - https://www.sqlitetutorial.net/sqlite-data-types/#:~:text=The%20maximum%20length%20of%20TEXT,SQLite%20supports%20various%20character%20encodings.

