### PR TITLE
Disable federation by default (#20045)

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2247,10 +2247,10 @@ PATH =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Enable/Disable federation capabilities
-; ENABLED = true
+;ENABLED = false
 ;;
 ;; Enable/Disable user statistics for nodeinfo if federation is enabled
-; SHARE_USER_STATISTICS = true
+;SHARE_USER_STATISTICS = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -1088,7 +1088,7 @@ Task queue configuration has been moved to `queue.task`. However, the below conf
 
 ## Federation (`federation`)
 
-- `ENABLED`: **true**: Enable/Disable federation capabilities
+- `ENABLED`: **false**: Enable/Disable federation capabilities
 - `SHARE_USER_STATISTICS`: **true**: Enable/Disable user statistics for nodeinfo if federation is enabled
 
 ## Packages (`packages`)

--- a/integrations/api_nodeinfo_test.go
+++ b/integrations/api_nodeinfo_test.go
@@ -11,17 +11,20 @@ import (
 
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/routers"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNodeinfo(t *testing.T) {
-	onGiteaRun(t, func(*testing.T, *url.URL) {
-		setting.Federation.Enabled = true
-		defer func() {
-			setting.Federation.Enabled = false
-		}()
+	setting.Federation.Enabled = true
+	c = routers.NormalRoutes()
+	defer func() {
+		setting.Federation.Enabled = false
+		c = routers.NormalRoutes()
+	}()
 
+	onGiteaRun(t, func(*testing.T, *url.URL) {
 		req := NewRequestf(t, "GET", "/api/v1/nodeinfo")
 		resp := MakeRequest(t, req, http.StatusOK)
 		var nodeinfo api.NodeInfo

--- a/modules/setting/federation.go
+++ b/modules/setting/federation.go
@@ -12,7 +12,7 @@ var (
 		Enabled             bool
 		ShareUserStatistics bool
 	}{
-		Enabled:             true,
+		Enabled:             false,
 		ShareUserStatistics: true,
 	}
 )


### PR DESCRIPTION
- Backport #20045
  - A Gitea instance should choose whetever they want to federate(as once it has more features also brings extra costs/moderation/unexpected behavior) with other AP/ForgeFed software.


