### PR TITLE
docs: Mention file extension for issue_template directory

### DIFF
--- a/docs/content/doc/usage/issue-pull-request-templates.en-us.md
+++ b/docs/content/doc/usage/issue-pull-request-templates.en-us.md
@@ -85,7 +85,7 @@ Possible directory names for issue templates:
 - `.gitlab/ISSUE_TEMPLATE`
 - `.gitlab/issue_template`
 
-Inside the directory can be multiple issue templates with the form
+Inside the directory can be multiple markdown (`.md`) issue templates of the form
 
 ```md
 ---


### PR DESCRIPTION
I noticed that [the docs on the issue templates directory](https://docs.gitea.io/en-us/issue-pull-request-templates/#issue-template-directory) do not mention the file extension requirement. This confused me and I had to dig in the code to find out, why my templates were not working.

This trivial PR addresses this.