### PR TITLE
Allow manager logging to set SQL

### DIFF
--- a/cmd/manager_logging.go
+++ b/cmd/manager_logging.go
@@ -174,6 +174,14 @@ var (
 						Action: runAddSMTPLogger,
 					},
 				},
+			}, {
+				Name:   "log-sql",
+				Usage:  "Set LogSQL",
+				Action: runSetLogSQL,
+			}, {
+				Name:   "no-log-sql",
+				Usage:  "Switch off LogSQL",
+				Action: runUnSetLogSQL,
 			},
 		},
 	}
@@ -373,6 +381,29 @@ func runReleaseReopenLogging(c *cli.Context) error {
 
 	setup("manager", c.Bool("debug"))
 	statusCode, msg := private.ReleaseReopenLogging(ctx)
+	switch statusCode {
+	case http.StatusInternalServerError:
+		return fail("InternalServerError", msg)
+	}
+
+	fmt.Fprintln(os.Stdout, msg)
+	return nil
+}
+
+func runSetLogSQL(c *cli.Context) error {
+	return runSetLogSQLFlag(c, true)
+}
+
+func runUnSetLogSQL(c *cli.Context) error {
+	return runSetLogSQLFlag(c, false)
+}
+
+func runSetLogSQLFlag(c *cli.Context, set bool) error {
+	ctx, cancel := installSignals()
+	defer cancel()
+	setup("manager", c.Bool("debug"))
+
+	statusCode, msg := private.SetLogSQL(ctx, set)
 	switch statusCode {
 	case http.StatusInternalServerError:
 		return fail("InternalServerError", msg)

--- a/cmd/manager_logging.go
+++ b/cmd/manager_logging.go
@@ -175,13 +175,17 @@ var (
 					},
 				},
 			}, {
-				Name:   "log-sql",
-				Usage:  "Set LogSQL",
+				Name:  "log-sql",
+				Usage: "Set LogSQL",
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name: "debug",
+					}, cli.BoolFlag{
+						Name:  "off",
+						Usage: "Switch off SQL logging",
+					},
+				},
 				Action: runSetLogSQL,
-			}, {
-				Name:   "no-log-sql",
-				Usage:  "Switch off LogSQL",
-				Action: runUnSetLogSQL,
 			},
 		},
 	}
@@ -391,19 +395,12 @@ func runReleaseReopenLogging(c *cli.Context) error {
 }
 
 func runSetLogSQL(c *cli.Context) error {
-	return runSetLogSQLFlag(c, true)
-}
-
-func runUnSetLogSQL(c *cli.Context) error {
-	return runSetLogSQLFlag(c, false)
-}
-
-func runSetLogSQLFlag(c *cli.Context, set bool) error {
 	ctx, cancel := installSignals()
 	defer cancel()
 	setup("manager", c.Bool("debug"))
 
-	statusCode, msg := private.SetLogSQL(ctx, set)
+	off := c.Bool("off")
+	statusCode, msg := private.SetLogSQL(ctx, !off)
 	switch statusCode {
 	case http.StatusInternalServerError:
 		return fail("InternalServerError", msg)

--- a/cmd/manager_logging.go
+++ b/cmd/manager_logging.go
@@ -399,8 +399,7 @@ func runSetLogSQL(c *cli.Context) error {
 	defer cancel()
 	setup("manager", c.Bool("debug"))
 
-	off := c.Bool("off")
-	statusCode, msg := private.SetLogSQL(ctx, !off)
+	statusCode, msg := private.SetLogSQL(ctx, !c.Bool("off"))
 	switch statusCode {
 	case http.StatusInternalServerError:
 		return fail("InternalServerError", msg)

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -287,3 +287,12 @@ func GetMaxID(beanOrTableName interface{}) (maxID int64, err error) {
 	_, err = x.Select("MAX(id)").Table(beanOrTableName).Get(&maxID)
 	return maxID, err
 }
+
+func SetLogSQL(ctx context.Context, on bool) {
+	e := GetEngine(ctx)
+	if x, ok := e.(*xorm.Engine); ok {
+		x.ShowSQL(on)
+	} else if sess, ok := e.(*xorm.Session); ok {
+		sess.Engine().ShowSQL(on)
+	}
+}

--- a/modules/private/manager.go
+++ b/modules/private/manager.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"code.gitea.io/gitea/modules/json"
@@ -137,6 +138,24 @@ func ReleaseReopenLogging(ctx context.Context) (int, string) {
 	}
 
 	return http.StatusOK, "Logging Restarted"
+}
+
+// SetLogSQL sets database logging
+func SetLogSQL(ctx context.Context, on bool) (int, string) {
+	reqURL := setting.LocalURL + "api/internal/manager/set-log-sql?on=" + strconv.FormatBool(on)
+
+	req := newInternalRequest(ctx, reqURL, "POST")
+	resp, err := req.Response()
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Sprintf("Unable to contact gitea: %v", err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, decodeJSONError(resp).Err
+	}
+
+	return http.StatusOK, "Log SQL setting set"
 }
 
 // LoggerOptions represents the options for the add logger call

--- a/routers/private/internal.go
+++ b/routers/private/internal.go
@@ -68,6 +68,7 @@ func Routes() *web.Route {
 	r.Post("/manager/pause-logging", PauseLogging)
 	r.Post("/manager/resume-logging", ResumeLogging)
 	r.Post("/manager/release-and-reopen-logging", ReleaseReopenLogging)
+	r.Post("/manager/set-log-sql", SetLogSQL)
 	r.Post("/manager/add-logger", bind(private.LoggerOptions{}), AddLogger)
 	r.Post("/manager/remove-logger/{group}/{name}", RemoveLogger)
 	r.Get("/manager/processes", Processes)

--- a/routers/private/manager.go
+++ b/routers/private/manager.go
@@ -17,7 +17,6 @@ import (
 	"code.gitea.io/gitea/modules/queue"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web"
-	"xorm.io/xorm"
 )
 
 // FlushQueues flushes all the Queues
@@ -71,13 +70,7 @@ func ReleaseReopenLogging(ctx *context.PrivateContext) {
 
 // SetLogSQL re-sets database SQL logging
 func SetLogSQL(ctx *context.PrivateContext) {
-	on := ctx.FormBool("on")
-	e := db.GetEngine(ctx)
-	if x, ok := e.(*xorm.Engine); ok {
-		x.ShowSQL(on)
-	} else if sess, ok := e.(*xorm.Session); ok {
-		sess.Engine().ShowSQL(on)
-	}
+	db.SetLogSQL(ctx, ctx.FormBool("on"))
 	ctx.PlainText(http.StatusOK, "success")
 }
 

--- a/routers/private/manager.go
+++ b/routers/private/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/json"
@@ -16,6 +17,7 @@ import (
 	"code.gitea.io/gitea/modules/queue"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web"
+	"xorm.io/xorm"
 )
 
 // FlushQueues flushes all the Queues
@@ -63,6 +65,18 @@ func ReleaseReopenLogging(ctx *context.PrivateContext) {
 			Err: fmt.Sprintf("Error during release and reopen: %v", err),
 		})
 		return
+	}
+	ctx.PlainText(http.StatusOK, "success")
+}
+
+// SetLogSQL re-sets database SQL logging
+func SetLogSQL(ctx *context.PrivateContext) {
+	on := ctx.FormBool("on")
+	e := db.GetEngine(ctx)
+	if x, ok := e.(*xorm.Engine); ok {
+		x.ShowSQL(on)
+	} else if sess, ok := e.(*xorm.Session); ok {
+		sess.Engine().ShowSQL(on)
 	}
 	ctx.PlainText(http.StatusOK, "success")
 }


### PR DESCRIPTION
This PR adds a new manager command to switch on SQL logging and to turn it off.

```
gitea manager logging log-sql
gitea manager logging log-sql --off
```

Signed-off-by: Andrew Thornton <art27@cantab.net>
