### PR TITLE
Replace pubkey with privkey in keys_ssh.tmpl

### DIFF
--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -75,7 +75,7 @@
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
 								<p>{{$.i18n.Tr "settings.ssh_token_help"}}</p>
-								<p><code>{{printf "echo -n '%s' | ssh-keygen -Y sign -n gitea -f /path_to_your_pubkey" $.TokenToSign}}</code></p>
+								<p><code>{{printf "echo -n '%s' | ssh-keygen -Y sign -n gitea -f /path_to_your_privkey" $.TokenToSign}}</code></p>
 							</div>
 							<br>
 						</div>


### PR DESCRIPTION
If a user wants to verify an SSH public key from their account they have
to sign the randomly generated token with their private key.

Prior to this change the example command prompted to sign the token with
their public key instead.

Signed-off-by: Robert Lützner <robert.luetzner@pm.me>