### PR TITLE
Fix eslint errors by selectively enabling vue parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@ reportUnusedDisableDirectives: true
 
 ignorePatterns:
   - /web_src/js/vendor
+  - /templates/base/head_script.tmpl
+  - /templates/repo/issue/view_content/pull.tmpl
 
 parserOptions:
   sourceType: module
@@ -15,9 +17,6 @@ plugins:
   - eslint-plugin-html
   - eslint-plugin-jquery
 
-extends:
-  - plugin:vue/recommended
-
 env:
   es2022: true
   node: true
@@ -29,7 +28,9 @@ settings:
   html/html-extensions: [".tmpl"]
 
 overrides:
-  - files: ["web_src/**/*.js", "web_src/**/*.vue", "templates/**/*.tmpl"]
+  - files: ["web_src/**/*.vue"]
+    parser: vue-eslint-parser
+  - files: ["web_src/**/*.js", "web_src/**/*.vue", "templates/**/*.tmpl", "docs/**/*.js"]
     env:
       browser: true
       node: false
@@ -502,11 +503,37 @@ rules:
   use-isnan: [2]
   valid-typeof: [2, {requireStringLiterals: true}]
   vars-on-top: [0]
+  vue/attribute-hyphenation: [2]
   vue/attributes-order: [0]
   vue/component-definition-name-casing: [0]
+  vue/component-tags-order: [2]
+  vue/first-attribute-linebreak: [2]
+  vue/html-closing-bracket-newline: [2]
   vue/html-closing-bracket-spacing: [0]
+  vue/html-end-tags: [2]
+  vue/html-indent: [2]
+  vue/html-quotes: [2]
+  vue/html-self-closing: [2]
   vue/max-attributes-per-line: [0]
+  vue/multiline-html-element-content-newline: [2]
+  vue/mustache-interpolation-spacing: [2]
+  vue/no-lone-template: [2]
+  vue/no-multi-spaces: [2]
+  vue/no-multiple-slot-args: [2]
+  vue/no-side-effects-in-computed-properties: [2]
+  vue/no-spaces-around-equal-signs-in-attribute: [2]
+  vue/no-template-shadow: [2]
+  vue/no-v-html: [2]
   vue/one-component-per-file: [0]
+  vue/order-in-components: [2]
+  vue/prop-name-casing: [2]
+  vue/require-default-prop: [2]
+  vue/require-prop-types: [2]
+  vue/singleline-html-element-content-newline: [2]
+  vue/this-in-template: [2]
+  vue/v-bind-style: [2]
+  vue/v-on-style: [2]
+  vue/v-slot-style: [2]
   wrap-iife: [2, inside]
   wrap-regex: [0]
   yield-star-spacing: [2, after]

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -4,7 +4,6 @@ If you are customizing Gitea, please do not change this file.
 If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 */}}
 <script>
-	<!-- /* eslint-disable */ -->
 	window.addEventListener('error', function(e) {window._globalHandlerErrors=window._globalHandlerErrors||[]; window._globalHandlerErrors.push(e);});
 	window.config = {
 		appVer: '{{AppVer}}',

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -333,7 +333,6 @@
 						{{end}}
 						<div class="ui divider"></div>
 						<script>
-							<!-- /* eslint-disable */ -->
 							(() => {
 								const defaultMergeTitle = {{.DefaultMergeMessage}};
 								const defaultSquashMergeTitle = {{.DefaultSquashMergeMessage}};

--- a/web_src/js/components/PullRequestMergeForm.vue
+++ b/web_src/js/components/PullRequestMergeForm.vue
@@ -10,8 +10,9 @@
       -d '{"context": "test/context", "description": "description", "state": "${state}", "target_url": "http://localhost"}'
   -->
   <div>
-    <!-- eslint-disable -->
-    <div v-if="mergeForm.hasPendingPullRequestMerge" v-html="mergeForm.hasPendingPullRequestMergeTip" class="ui info message"></div>
+    <div v-if="mergeForm.hasPendingPullRequestMerge" class="ui info message">
+      {{ mergeForm.hasPendingPullRequestMergeTip }}
+    </div>
 
     <div class="ui form" v-if="showActionForm">
       <form :action="mergeForm.baseLink+'/merge'" method="post">


### PR DESCRIPTION
eslint currently gives some [errors](https://drone.gitea.io/go-gitea/gitea/56685/1/4) because the vue parser when loaded via recommended config parses all files but can not handle hashbangs and newer ECMAScript features like the default eslint parser can (it did downgraded our parser from es2022 to es2020).

Selectively enable the vue parser only for .vue files and define rules explicitely to fix that issue.