### PR TITLE
Do not use outdated queue indexer settings for testing 

### DIFF
--- a/integrations/mssql.ini.tmpl
+++ b/integrations/mssql.ini.tmpl
@@ -14,8 +14,8 @@ REPO_INDEXER_ENABLED = true
 REPO_INDEXER_PATH = integrations/gitea-integration-mssql/indexers/repos.bleve
 
 [queue.issue_indexer]
-ISSUE_INDEXER_PATH = integrations/gitea-integration-mssql/indexers/issues.bleve
-ISSUE_INDEXER_QUEUE_DIR = integrations/gitea-integration-mssql/indexers/issues.queue
+PATH = integrations/gitea-integration-mssql/indexers/issues.bleve
+DATADIR = integrations/gitea-integration-mssql/indexers/issues.queue
 
 [queue]
 TYPE = immediate

--- a/integrations/mysql.ini.tmpl
+++ b/integrations/mysql.ini.tmpl
@@ -14,9 +14,9 @@ REPO_INDEXER_ENABLED = true
 REPO_INDEXER_PATH = integrations/gitea-integration-mysql/indexers/repos.bleve
 
 [queue.issue_indexer]
-ISSUE_INDEXER_TYPE = elasticsearch
-ISSUE_INDEXER_CONN_STR = http://elastic:changeme@elasticsearch:9200
-ISSUE_INDEXER_QUEUE_DIR = integrations/gitea-integration-mysql/indexers/issues.queue
+TYPE = elasticsearch
+CONN_STR = http://elastic:changeme@elasticsearch:9200
+DATADIR = integrations/gitea-integration-mysql/indexers/issues.queue
 
 [queue]
 TYPE = immediate

--- a/integrations/mysql8.ini.tmpl
+++ b/integrations/mysql8.ini.tmpl
@@ -14,8 +14,8 @@ REPO_INDEXER_ENABLED = true
 REPO_INDEXER_PATH = integrations/gitea-integration-mysql8/indexers/repos.bleve
 
 [queue.issue_indexer]
-ISSUE_INDEXER_PATH = integrations/gitea-integration-mysql8/indexers/issues.bleve
-ISSUE_INDEXER_QUEUE_DIR = integrations/gitea-integration-mysql8/indexers/issues.queue
+PATH = integrations/gitea-integration-mysql8/indexers/issues.bleve
+DATADIR = integrations/gitea-integration-mysql8/indexers/issues.queue
 
 [queue]
 TYPE = immediate

--- a/integrations/pgsql.ini.tmpl
+++ b/integrations/pgsql.ini.tmpl
@@ -15,8 +15,8 @@ REPO_INDEXER_ENABLED = true
 REPO_INDEXER_PATH = integrations/gitea-integration-pgsql/indexers/repos.bleve
 
 [queue.issue_indexer]
-ISSUE_INDEXER_PATH = integrations/gitea-integration-pgsql/indexers/issues.bleve
-ISSUE_INDEXER_QUEUE_DIR = integrations/gitea-integration-pgsql/indexers/issues.queue
+PATH = integrations/gitea-integration-pgsql/indexers/issues.bleve
+DATADIR = integrations/gitea-integration-pgsql/indexers/issues.queue
 
 [queue]
 TYPE = immediate

--- a/integrations/sqlite.ini.tmpl
+++ b/integrations/sqlite.ini.tmpl
@@ -10,8 +10,8 @@ REPO_INDEXER_ENABLED = true
 REPO_INDEXER_PATH    = integrations/gitea-integration-sqlite/indexers/repos.bleve
 
 [queue.issue_indexer]
-ISSUE_INDEXER_PATH   = integrations/gitea-integration-sqlite/indexers/issues.bleve
-ISSUE_INDEXER_QUEUE_DIR = integrations/gitea-integration-sqlite/indexers/issues.queue
+PATH   = integrations/gitea-integration-sqlite/indexers/issues.bleve
+DATADIR = integrations/gitea-integration-sqlite/indexers/issues.queue
 
 [queue]
 TYPE = immediate


### PR DESCRIPTION
Sorry, I made a mistake in https://github.com/go-gitea/gitea/pull/20124. We should probably be using the new config strings.