### PR TITLE
Fix remove file on initial comment (#20127)

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -192,7 +192,8 @@ export function initGlobalDropzone() {
       thumbnailWidth: 480,
       thumbnailHeight: 480,
       init() {
-        this.on('success', (_file, data) => {
+        this.on('success', (file, data) => {
+          file.uuid = data.uuid;
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           $dropzone.find('.files').append(input);
         });

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -300,6 +300,7 @@ async function onEditContent(event) {
         thumbnailHeight: 480,
         init() {
           this.on('success', (file, data) => {
+            file.uuid = data.uuid;
             fileUuidDict[file.uuid] = {submitted: false};
             const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
             $dropzone.find('.files').append(input);


### PR DESCRIPTION
- Backport #20127
  - Store the file uuid(which is returned by Gitea in the upload file response) onto the file object, so it can be used for the remove feature to specify this file.
  - Resolves #20115

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
