### PR TITLE
Show scrollbar when necessary (#20142)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3051,7 +3051,7 @@ td.blob-excerpt {
   align-items: center;
   display: flex;
   justify-content: space-between;
-  overflow-x: scroll;
+  overflow-x: auto;
   padding: 8px 12px !important;
 }
 


### PR DESCRIPTION
- Backport #20142
  - Firefox on Windows will unconditionally show scrollbars when you specify `overflow: scroll`. This is bad behavior, as you don't always need the scrollbar. Changing the scroll value to auto fixes this issue and only shows the scrollbar when necessary.
  - Resolves #20139

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
