### PR TITLE
Refactor `i18n` to `locale`

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -794,7 +794,7 @@ func Contexter() func(next http.Handler) http.Handler {
 			ctx.Data["UnitPullsGlobalDisabled"] = unit.TypePullRequests.UnitGlobalDisabled()
 			ctx.Data["UnitProjectsGlobalDisabled"] = unit.TypeProjects.UnitGlobalDisabled()
 
-			ctx.Data["i18n"] = locale
+			ctx.Data["locale"] = locale
 			ctx.Data["AllLangs"] = translation.AllLangs()
 
 			next.ServeHTTP(ctx.Resp, ctx.Req)

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -69,7 +69,7 @@ func Init(next http.Handler) http.Handler {
 			Render:  rnd,
 			Session: session.GetSession(req),
 			Data: map[string]interface{}{
-				"Locale":        locale,
+				"locale":        locale,
 				"Title":         locale.Tr("install.install"),
 				"PageIsInstall": true,
 				"DbTypeNames":   dbTypeNames,

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -69,7 +69,7 @@ func Init(next http.Handler) http.Handler {
 			Render:  rnd,
 			Session: session.GetSession(req),
 			Data: map[string]interface{}{
-				"i18n":          locale,
+				"Locale":        locale,
 				"Title":         locale.Tr("install.install"),
 				"PageIsInstall": true,
 				"DbTypeNames":   dbTypeNames,

--- a/routers/install/routes.go
+++ b/routers/install/routes.go
@@ -57,7 +57,7 @@ func installRecovery() func(next http.Handler) http.Handler {
 					store := dataStore{
 						"Language":       lc.Language(),
 						"CurrentURL":     setting.AppSubURL + req.URL.RequestURI(),
-						"i18n":           lc,
+						"locale":         lc,
 						"SignedUserID":   int64(0),
 						"SignedUserName": "",
 					}

--- a/routers/web/base.go
+++ b/routers/web/base.go
@@ -139,7 +139,7 @@ func Recovery() func(next http.Handler) http.Handler {
 					store := dataStore{
 						"Language":   lc.Language(),
 						"CurrentURL": setting.AppSubURL + req.URL.RequestURI(),
-						"i18n":       lc,
+						"locale":     lc,
 					}
 
 					user := context.GetContextUser(req)

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -80,7 +80,7 @@ func sendUserMail(language string, u *user_model.User, tpl base.TplName, code, s
 		"Code":              code,
 		"Language":          locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}
@@ -131,7 +131,7 @@ func SendActivateEmailMail(u *user_model.User, email *user_model.EmailAddress) {
 		"Email":           email.Email,
 		"Language":        locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}
@@ -162,7 +162,7 @@ func SendRegisterNotifyMail(u *user_model.User) {
 		"Username":    u.Name,
 		"Language":    locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}
@@ -196,7 +196,7 @@ func SendCollaboratorMail(u, doer *user_model.User, repo *repo_model.Repository)
 		"Link":     repo.HTMLURL(),
 		"Language": locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}
@@ -281,7 +281,7 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipient
 		"ReviewComments":  reviewComments,
 		"Language":        locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}

--- a/services/mailer/mail_release.go
+++ b/services/mailer/mail_release.go
@@ -75,7 +75,7 @@ func mailNewRelease(ctx context.Context, lang string, tos []string, rel *models.
 		"Subject":  subject,
 		"Language": locale.Language(),
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}

--- a/services/mailer/mail_repo.go
+++ b/services/mailer/mail_repo.go
@@ -74,7 +74,7 @@ func sendRepoTransferNotifyMailPerLang(lang string, newOwner, doer *user_model.U
 		"Language":    locale.Language(),
 		"Destination": destination,
 		// helper
-		"i18n":      locale,
+		"locale":    locale,
 		"Str2html":  templates.Str2html,
 		"DotEscape": templates.DotEscape,
 	}

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.auths.edit"}}
+			{{.locale.Tr "admin.auths.edit"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -12,12 +12,12 @@
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="id" value="{{.Source.ID}}">
 				<div class="inline field">
-					<label>{{$.i18n.Tr "admin.auths.auth_type"}}</label>
+					<label>{{$.locale.Tr "admin.auths.auth_type"}}</label>
 					<input type="hidden" id="auth_type" name="type" value="{{.Source.Type.Int}}">
 					<span>{{.Source.TypeName}}</span>
 				</div>
 				<div class="required inline field {{if .Err_Name}}error{{end}}">
-					<label for="name">{{.i18n.Tr "admin.auths.auth_name"}}</label>
+					<label for="name">{{.locale.Tr "admin.auths.auth_name"}}</label>
 					<input id="name" name="name" value="{{.Source.Name}}" autofocus required>
 				</div>
 
@@ -25,7 +25,7 @@
 				{{if or .Source.IsLDAP .Source.IsDLDAP}}
 					{{ $cfg:=.Source.Cfg }}
 					<div class="inline required field {{if .Err_SecurityProtocol}}error{{end}}">
-						<label>{{.i18n.Tr "admin.auths.security_protocol"}}</label>
+						<label>{{.locale.Tr "admin.auths.security_protocol"}}</label>
 						<div class="ui selection security-protocol dropdown">
 							<input type="hidden" id="security_protocol" name="security_protocol" value="{{$cfg.SecurityProtocol.Int}}">
 							<div class="text">{{$cfg.SecurityProtocolName}}</div>
@@ -38,74 +38,74 @@
 						</div>
 					</div>
 					<div class="required field">
-						<label for="host">{{.i18n.Tr "admin.auths.host"}}</label>
+						<label for="host">{{.locale.Tr "admin.auths.host"}}</label>
 						<input id="host" name="host" value="{{$cfg.Host}}" placeholder="e.g. mydomain.com" required>
 					</div>
 					<div class="required field">
-						<label for="port">{{.i18n.Tr "admin.auths.port"}}</label>
+						<label for="port">{{.locale.Tr "admin.auths.port"}}</label>
 						<input id="port" name="port" value="{{$cfg.Port}}"  placeholder="e.g. 636" required>
 					</div>
 					<div class="has-tls inline field {{if not .HasTLS}}hide{{end}}">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.auths.skip_tls_verify"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.auths.skip_tls_verify"}}</strong></label>
 							<input name="skip_verify" type="checkbox" {{if .Source.SkipVerify}}checked{{end}}>
 						</div>
 					</div>
 					{{if .Source.IsLDAP}}
 						<div class="field">
-							<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
+							<label for="bind_dn">{{.locale.Tr "admin.auths.bind_dn"}}</label>
 							<input id="bind_dn" name="bind_dn" value="{{$cfg.BindDN}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
 						</div>
 						<div class="field">
-							<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
+							<label for="bind_password">{{.locale.Tr "admin.auths.bind_password"}}</label>
 							<input id="bind_password" name="bind_password" type="password" value="{{$cfg.BindPassword}}">
 						</div>
 					{{end}}
 					<div class="{{if .Source.IsLDAP}}required{{end}} field">
-							<label for="user_base">{{.i18n.Tr "admin.auths.user_base"}}</label>
+							<label for="user_base">{{.locale.Tr "admin.auths.user_base"}}</label>
 							<input id="user_base" name="user_base" value="{{$cfg.UserBase}}" placeholder="e.g. ou=Users,dc=mydomain,dc=com" {{if .Source.IsLDAP}}required{{end}}>
 					</div>
 					{{if .Source.IsDLDAP}}
 						<div class="required field">
-							<label for="user_dn">{{.i18n.Tr "admin.auths.user_dn"}}</label>
+							<label for="user_dn">{{.locale.Tr "admin.auths.user_dn"}}</label>
 							<input id="user_dn" name="user_dn" value="{{$cfg.UserDN}}" placeholder="e.g. uid=%s,ou=Users,dc=mydomain,dc=com" required>
 						</div>
 					{{end}}
 					<div class="required field">
-						<label for="filter">{{.i18n.Tr "admin.auths.filter"}}</label>
+						<label for="filter">{{.locale.Tr "admin.auths.filter"}}</label>
 						<input id="filter" name="filter" value="{{$cfg.Filter}}" placeholder="e.g. (&(objectClass=posixAccount)(uid=%s))" required>
 					</div>
 					<div class="field">
-						<label for="admin_filter">{{.i18n.Tr "admin.auths.admin_filter"}}</label>
+						<label for="admin_filter">{{.locale.Tr "admin.auths.admin_filter"}}</label>
 						<input id="admin_filter" name="admin_filter" value="{{$cfg.AdminFilter}}">
 					</div>
 					<div class="field">
-						<label for="restricted_filter">{{.i18n.Tr "admin.auths.restricted_filter"}}</label>
+						<label for="restricted_filter">{{.locale.Tr "admin.auths.restricted_filter"}}</label>
 						<input id="restricted_filter" name="restricted_filter" value="{{$cfg.RestrictedFilter}}">
-						<p class="help">{{.i18n.Tr "admin.auths.restricted_filter_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.restricted_filter_helper"}}</p>
 					</div>
 					<div class="field">
-						<label for="attribute_username">{{.i18n.Tr "admin.auths.attribute_username"}}</label>
-						<input id="attribute_username" name="attribute_username" value="{{$cfg.AttributeUsername}}" placeholder="{{.i18n.Tr "admin.auths.attribute_username_placeholder"}}">
+						<label for="attribute_username">{{.locale.Tr "admin.auths.attribute_username"}}</label>
+						<input id="attribute_username" name="attribute_username" value="{{$cfg.AttributeUsername}}" placeholder="{{.locale.Tr "admin.auths.attribute_username_placeholder"}}">
 					</div>
 					<div class="field">
-						<label for="attribute_name">{{.i18n.Tr "admin.auths.attribute_name"}}</label>
+						<label for="attribute_name">{{.locale.Tr "admin.auths.attribute_name"}}</label>
 						<input id="attribute_name" name="attribute_name" value="{{$cfg.AttributeName}}">
 					</div>
 					<div class="field">
-						<label for="attribute_surname">{{.i18n.Tr "admin.auths.attribute_surname"}}</label>
+						<label for="attribute_surname">{{.locale.Tr "admin.auths.attribute_surname"}}</label>
 						<input id="attribute_surname" name="attribute_surname" value="{{$cfg.AttributeSurname}}">
 					</div>
 					<div class="required field">
-						<label for="attribute_mail">{{.i18n.Tr "admin.auths.attribute_mail"}}</label>
+						<label for="attribute_mail">{{.locale.Tr "admin.auths.attribute_mail"}}</label>
 						<input id="attribute_mail" name="attribute_mail" value="{{$cfg.AttributeMail}}" placeholder="e.g. mail" required>
 					</div>
 					<div class="field">
-						<label for="attribute_ssh_public_key">{{.i18n.Tr "admin.auths.attribute_ssh_public_key"}}</label>
+						<label for="attribute_ssh_public_key">{{.locale.Tr "admin.auths.attribute_ssh_public_key"}}</label>
 						<input id="attribute_ssh_public_key" name="attribute_ssh_public_key" value="{{$cfg.AttributeSSHPublicKey}}" placeholder="e.g. SshPublicKey">
 					</div>
 					<div class="field">
-						<label for="attribute_avatar">{{.i18n.Tr "admin.auths.attribute_avatar"}}</label>
+						<label for="attribute_avatar">{{.locale.Tr "admin.auths.attribute_avatar"}}</label>
 						<input id="attribute_avatar" name="attribute_avatar" value="{{$cfg.AttributeAvatar}}" placeholder="e.g. jpegPhoto">
 					</div>
 
@@ -113,33 +113,33 @@
 					<!-- ldap group begin -->
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.auths.enable_ldap_groups"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.auths.enable_ldap_groups"}}</strong></label>
 							<input type="checkbox" name="groups_enabled" class="js-ldap-group-toggle" {{if $cfg.GroupsEnabled}}checked{{end}}>
 						</div>
 					</div>
 					<div id="ldap-group-options" class="ui segment secondary" {{if not $cfg.GroupsEnabled}}hidden{{end}}>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.auths.group_search_base"}}</label>
+							<label>{{.locale.Tr "admin.auths.group_search_base"}}</label>
 							<input name="group_dn" value="{{$cfg.GroupDN}}" placeholder="e.g. ou=group,dc=mydomain,dc=com">
 						</div>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.auths.group_attribute_list_users"}}</label>
+							<label>{{.locale.Tr "admin.auths.group_attribute_list_users"}}</label>
 							<input name="group_member_uid" value="{{$cfg.GroupMemberUID}}" placeholder="e.g. memberUid">
 						</div>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.auths.user_attribute_in_group"}}</label>
+							<label>{{.locale.Tr "admin.auths.user_attribute_in_group"}}</label>
 							<input name="user_uid" value="{{$cfg.UserUID}}" placeholder="e.g. uid">
 						</div>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.auths.verify_group_membership"}}</label>
+							<label>{{.locale.Tr "admin.auths.verify_group_membership"}}</label>
 							<input name="group_filter" value="{{$cfg.GroupFilter}}" placeholder="e.g. (|(cn=gitea_users)(cn=admins))">
 						</div>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.auths.map_group_to_team"}}</label>
+							<label>{{.locale.Tr "admin.auths.map_group_to_team"}}</label>
 							<input name="group_team_map" value="{{$cfg.GroupTeamMap}}" placeholder='e.g. {"cn=my-group,cn=groups,dc=example,dc=org": {"MyGiteaOrganization": ["MyGiteaTeam1", "MyGiteaTeam2"]}}'>
 						</div>
 						<div class="ui checkbox">
-							<label>{{.i18n.Tr "admin.auths.map_group_to_team_removal"}}</label>
+							<label>{{.locale.Tr "admin.auths.map_group_to_team_removal"}}</label>
 							<input name="group_team_map_removal" type="checkbox" {{if $cfg.GroupTeamMapRemoval}}checked{{end}}>
 						</div>
 					</div>
@@ -148,31 +148,31 @@
 					{{if .Source.IsLDAP}}
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label for="use_paged_search"><strong>{{.i18n.Tr "admin.auths.use_paged_search"}}</strong></label>
+								<label for="use_paged_search"><strong>{{.locale.Tr "admin.auths.use_paged_search"}}</strong></label>
 								<input id="use_paged_search" name="use_paged_search" type="checkbox" {{if $cfg.UsePagedSearch}}checked{{end}}>
 							</div>
 						</div>
 						<div class="field required search-page-size{{if not $cfg.UsePagedSearch}} hide{{end}}">
-							<label for="search_page_size">{{.i18n.Tr "admin.auths.search_page_size"}}</label>
+							<label for="search_page_size">{{.locale.Tr "admin.auths.search_page_size"}}</label>
 							<input id="search_page_size" name="search_page_size" value="{{if $cfg.UsePagedSearch}}{{$cfg.SearchPageSize}}{{end}}">
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label><strong>{{.i18n.Tr "admin.auths.attributes_in_bind"}}</strong></label>
+								<label><strong>{{.locale.Tr "admin.auths.attributes_in_bind"}}</strong></label>
 								<input name="attributes_in_bind" type="checkbox" {{if $cfg.AttributesInBind}}checked{{end}}>
 							</div>
 						</div>
 					{{end}}
 					<div class="optional field">
 						<div class="ui checkbox">
-							<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+							<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 							<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if $cfg.SkipLocalTwoFA}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 						</div>
 					</div>
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label for="allow_deactivate_all"><strong>{{.i18n.Tr "admin.auths.allow_deactivate_all"}}</strong></label>
+							<label for="allow_deactivate_all"><strong>{{.locale.Tr "admin.auths.allow_deactivate_all"}}</strong></label>
 							<input id="allow_deactivate_all" name="allow_deactivate_all" type="checkbox" {{if $cfg.AllowDeactivateAll}}checked{{end}}>
 						</div>
 					</div>
@@ -182,7 +182,7 @@
 				{{if .Source.IsSMTP}}
 					{{ $cfg:=.Source.Cfg }}
 					<div class="inline required field">
-						<label>{{.i18n.Tr "admin.auths.smtp_auth"}}</label>
+						<label>{{.locale.Tr "admin.auths.smtp_auth"}}</label>
 						<div class="ui selection type dropdown">
 							<input type="hidden" id="smtp_auth" name="smtp_auth" value="{{$cfg.Auth}}" required>
 							<div class="text">{{$cfg.Auth}}</div>
@@ -195,47 +195,47 @@
 						</div>
 					</div>
 					<div class="required field">
-						<label for="smtp_host">{{.i18n.Tr "admin.auths.smtphost"}}</label>
+						<label for="smtp_host">{{.locale.Tr "admin.auths.smtphost"}}</label>
 						<input id="smtp_host" name="smtp_host" value="{{$cfg.Host}}" required>
 					</div>
 					<div class="required field">
-						<label for="smtp_port">{{.i18n.Tr "admin.auths.smtpport"}}</label>
+						<label for="smtp_port">{{.locale.Tr "admin.auths.smtpport"}}</label>
 						<input id="smtp_port" name="smtp_port" value="{{$cfg.Port}}" required>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
-							<label for="force_smtps"><strong>{{.i18n.Tr "admin.auths.force_smtps"}}</strong></label>
+							<label for="force_smtps"><strong>{{.locale.Tr "admin.auths.force_smtps"}}</strong></label>
 							<input id="force_smtps" name="force_smtps" type="checkbox" {{if $cfg.ForceSMTPS}}checked{{end}}>
 						</div>
-						<p class="help">{{.i18n.Tr "admin.auths.force_smtps_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.force_smtps_helper"}}</p>
 					</div>
 					<div class="has-tls inline field {{if not .HasTLS}}hide{{end}}">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.auths.skip_tls_verify"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.auths.skip_tls_verify"}}</strong></label>
 							<input name="skip_verify" type="checkbox" {{if .Source.SkipVerify}}checked{{end}}>
 						</div>
 					</div>
 					<div class="field">
-						<label for="helo_hostname">{{.i18n.Tr "admin.auths.helo_hostname"}}</label>
+						<label for="helo_hostname">{{.locale.Tr "admin.auths.helo_hostname"}}</label>
 						<input id="helo_hostname" name="helo_hostname" value="{{$cfg.HeloHostname}}">
-						<p class="help">{{.i18n.Tr "admin.auths.helo_hostname_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.helo_hostname_helper"}}</p>
 					</div>
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label for="disable_helo"><strong>{{.i18n.Tr "admin.auths.disable_helo"}}</strong></label>
+							<label for="disable_helo"><strong>{{.locale.Tr "admin.auths.disable_helo"}}</strong></label>
 							<input id="disable_helo" name="disable_helo" type="checkbox" {{if $cfg.DisableHelo}}checked{{end}}>
 						</div>
 					</div>
 					<div class="field">
-						<label for="allowed_domains">{{.i18n.Tr "admin.auths.allowed_domains"}}</label>
+						<label for="allowed_domains">{{.locale.Tr "admin.auths.allowed_domains"}}</label>
 						<input id="allowed_domains" name="allowed_domains" value="{{$cfg.AllowedDomains}}">
-						<p class="help">{{.i18n.Tr "admin.auths.allowed_domains_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.allowed_domains_helper"}}</p>
 					</div>
 					<div class="optional field">
 						<div class="ui checkbox">
-							<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+							<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 							<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if $cfg.SkipLocalTwoFA}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 						</div>
 					</div>
 				{{end}}
@@ -244,18 +244,18 @@
 				{{if .Source.IsPAM}}
 					{{ $cfg:=.Source.Cfg }}
 					<div class="required field">
-						<label for="pam_service_name">{{.i18n.Tr "admin.auths.pam_service_name"}}</label>
+						<label for="pam_service_name">{{.locale.Tr "admin.auths.pam_service_name"}}</label>
 						<input id="pam_service_name" name="pam_service_name" value="{{$cfg.ServiceName}}" required>
 					</div>
 					<div class="field">
-						<label for="pam_email_domain">{{.i18n.Tr "admin.auths.pam_email_domain"}}</label>
+						<label for="pam_email_domain">{{.locale.Tr "admin.auths.pam_email_domain"}}</label>
 						<input id="pam_email_domain" name="pam_email_domain" value="{{$cfg.EmailDomain}}">
 					</div>
 					<div class="optional field">
 						<div class="ui checkbox">
-							<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+							<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 							<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if $cfg.SkipLocalTwoFA}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 						</div>
 					</div>
 				{{end}}
@@ -264,7 +264,7 @@
 				{{if .Source.IsOAuth2}}
 					{{ $cfg:=.Source.Cfg }}
 					<div class="inline required field">
-						<label>{{.i18n.Tr "admin.auths.oauth2_provider"}}</label>
+						<label>{{.locale.Tr "admin.auths.oauth2_provider"}}</label>
 						<div class="ui selection type dropdown">
 							<input type="hidden" id="oauth2_provider" name="oauth2_provider" value="{{$cfg.Provider}}" required>
 							<div class="text">{{.CurrentOAuth2Provider.DisplayName}}</div>
@@ -277,52 +277,52 @@
 						</div>
 					</div>
 					<div class="required field">
-						<label for="oauth2_key">{{.i18n.Tr "admin.auths.oauth2_clientID"}}</label>
+						<label for="oauth2_key">{{.locale.Tr "admin.auths.oauth2_clientID"}}</label>
 						<input id="oauth2_key" name="oauth2_key" value="{{$cfg.ClientID}}" required>
 					</div>
 					<div class="required field">
-						<label for="oauth2_secret">{{.i18n.Tr "admin.auths.oauth2_clientSecret"}}</label>
+						<label for="oauth2_secret">{{.locale.Tr "admin.auths.oauth2_clientSecret"}}</label>
 						<input id="oauth2_secret" name="oauth2_secret" value="{{$cfg.ClientSecret}}" required>
 					</div>
 					<div class="optional field">
-						<label for="oauth2_icon_url">{{.i18n.Tr "admin.auths.oauth2_icon_url"}}</label>
+						<label for="oauth2_icon_url">{{.locale.Tr "admin.auths.oauth2_icon_url"}}</label>
 						<input id="oauth2_icon_url" name="oauth2_icon_url" value="{{$cfg.IconURL}}">
 					</div>
 					<div class="open_id_connect_auto_discovery_url required field">
-						<label for="open_id_connect_auto_discovery_url">{{.i18n.Tr "admin.auths.openIdConnectAutoDiscoveryURL"}}</label>
+						<label for="open_id_connect_auto_discovery_url">{{.locale.Tr "admin.auths.openIdConnectAutoDiscoveryURL"}}</label>
 						<input id="open_id_connect_auto_discovery_url" name="open_id_connect_auto_discovery_url" value="{{$cfg.OpenIDConnectAutoDiscoveryURL}}">
 					</div>
 					<div class="optional field">
 						<div class="ui checkbox">
-							<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+							<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 							<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if $cfg.SkipLocalTwoFA}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 						</div>
 					</div>
 					<div class="oauth2_use_custom_url inline field">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.auths.oauth2_use_custom_url"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.auths.oauth2_use_custom_url"}}</strong></label>
 							<input id="oauth2_use_custom_url" name="oauth2_use_custom_url" type="checkbox" {{if $cfg.CustomURLMapping}}checked{{end}}>
 						</div>
 					</div>
 					<div class="oauth2_use_custom_url_field oauth2_auth_url required field">
-						<label for="oauth2_auth_url">{{.i18n.Tr "admin.auths.oauth2_authURL"}}</label>
+						<label for="oauth2_auth_url">{{.locale.Tr "admin.auths.oauth2_authURL"}}</label>
 						<input id="oauth2_auth_url" name="oauth2_auth_url" value="{{if $cfg.CustomURLMapping}}{{$cfg.CustomURLMapping.AuthURL}}{{end}}">
 					</div>
 					<div class="oauth2_use_custom_url_field oauth2_token_url required field">
-						<label for="oauth2_token_url">{{.i18n.Tr "admin.auths.oauth2_tokenURL"}}</label>
+						<label for="oauth2_token_url">{{.locale.Tr "admin.auths.oauth2_tokenURL"}}</label>
 						<input id="oauth2_token_url" name="oauth2_token_url" value="{{if $cfg.CustomURLMapping}}{{$cfg.CustomURLMapping.TokenURL}}{{end}}">
 					</div>
 					<div class="oauth2_use_custom_url_field oauth2_profile_url required field">
-						<label for="oauth2_profile_url">{{.i18n.Tr "admin.auths.oauth2_profileURL"}}</label>
+						<label for="oauth2_profile_url">{{.locale.Tr "admin.auths.oauth2_profileURL"}}</label>
 						<input id="oauth2_profile_url" name="oauth2_profile_url" value="{{if $cfg.CustomURLMapping}}{{$cfg.CustomURLMapping.ProfileURL}}{{end}}">
 					</div>
 					<div class="oauth2_use_custom_url_field oauth2_email_url required field">
-						<label for="oauth2_email_url">{{.i18n.Tr "admin.auths.oauth2_emailURL"}}</label>
+						<label for="oauth2_email_url">{{.locale.Tr "admin.auths.oauth2_emailURL"}}</label>
 						<input id="oauth2_email_url" name="oauth2_email_url" value="{{if $cfg.CustomURLMapping}}{{$cfg.CustomURLMapping.EmailURL}}{{end}}">
 					</div>
 					<div class="oauth2_use_custom_url_field oauth2_tenant required field">
-						<label for="oauth2_tenant">{{.i18n.Tr "admin.auths.oauth2_tenant"}}</label>
+						<label for="oauth2_tenant">{{.locale.Tr "admin.auths.oauth2_tenant"}}</label>
 						<input id="oauth2_tenant" name="oauth2_tenant" value="{{if $cfg.CustomURLMapping}}{{$cfg.CustomURLMapping.Tenant}}{{end}}">
 					</div>
 
@@ -336,29 +336,29 @@
 					{{end}}{{end}}
 
 					<div class="field">
-						<label for="oauth2_scopes">{{.i18n.Tr "admin.auths.oauth2_scopes"}}</label>
+						<label for="oauth2_scopes">{{.locale.Tr "admin.auths.oauth2_scopes"}}</label>
 						<input id="oauth2_scopes" name="oauth2_scopes" value="{{if $cfg.Scopes}}{{Join $cfg.Scopes "," }}{{end}}">
 					</div>
 					<div class="field">
-						<label for="oauth2_required_claim_name">{{.i18n.Tr "admin.auths.oauth2_required_claim_name"}}</label>
+						<label for="oauth2_required_claim_name">{{.locale.Tr "admin.auths.oauth2_required_claim_name"}}</label>
 						<input id="oauth2_required_claim_name" name="oauth2_required_claim_name" values="{{$cfg.RequiredClaimName}}">
-						<p class="help">{{.i18n.Tr "admin.auths.oauth2_required_claim_name_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.oauth2_required_claim_name_helper"}}</p>
 					</div>
 					<div class="field">
-						<label for="oauth2_required_claim_value">{{.i18n.Tr "admin.auths.oauth2_required_claim_value"}}</label>
+						<label for="oauth2_required_claim_value">{{.locale.Tr "admin.auths.oauth2_required_claim_value"}}</label>
 						<input id="oauth2_required_claim_value" name="oauth2_required_claim_value" values="{{$cfg.RequiredClaimValue}}">
-						<p class="help">{{.i18n.Tr "admin.auths.oauth2_required_claim_value_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.oauth2_required_claim_value_helper"}}</p>
 					</div>
 					<div class="field">
-						<label for="oauth2_group_claim_name">{{.i18n.Tr "admin.auths.oauth2_group_claim_name"}}</label>
+						<label for="oauth2_group_claim_name">{{.locale.Tr "admin.auths.oauth2_group_claim_name"}}</label>
 						<input id="oauth2_group_claim_name" name="oauth2_group_claim_name" value="{{$cfg.GroupClaimName}}">
 					</div>
 					<div class="field">
-						<label for="oauth2_admin_group">{{.i18n.Tr "admin.auths.oauth2_admin_group"}}</label>
+						<label for="oauth2_admin_group">{{.locale.Tr "admin.auths.oauth2_admin_group"}}</label>
 						<input id="oauth2_admin_group" name="oauth2_admin_group" value="{{$cfg.AdminGroup}}">
 					</div>
 					<div class="field">
-						<label for="oauth2_restricted_group">{{.i18n.Tr "admin.auths.oauth2_restricted_group"}}</label>
+						<label for="oauth2_restricted_group">{{.locale.Tr "admin.auths.oauth2_restricted_group"}}</label>
 						<input id="oauth2_restricted_group" name="oauth2_restricted_group" value="{{$cfg.RestrictedGroup}}">
 					</div>
 				{{end}}
@@ -368,32 +368,32 @@
 					{{ $cfg:=.Source.Cfg }}
 					<div class="field">
 						<div class="ui checkbox">
-							<label for="sspi_auto_create_users"><strong>{{.i18n.Tr "admin.auths.sspi_auto_create_users"}}</strong></label>
+							<label for="sspi_auto_create_users"><strong>{{.locale.Tr "admin.auths.sspi_auto_create_users"}}</strong></label>
 							<input id="sspi_auto_create_users" name="sspi_auto_create_users" class="sspi-auto-create-users" type="checkbox" {{if $cfg.AutoCreateUsers}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.sspi_auto_create_users_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.sspi_auto_create_users_helper"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
-							<label for="sspi_auto_activate_users"><strong>{{.i18n.Tr "admin.auths.sspi_auto_activate_users"}}</strong></label>
+							<label for="sspi_auto_activate_users"><strong>{{.locale.Tr "admin.auths.sspi_auto_activate_users"}}</strong></label>
 							<input id="sspi_auto_activate_users" name="sspi_auto_activate_users" class="sspi-auto-activate-users" type="checkbox" {{if $cfg.AutoActivateUsers}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.sspi_auto_activate_users_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.sspi_auto_activate_users_helper"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
-							<label for="sspi_strip_domain_names"><strong>{{.i18n.Tr "admin.auths.sspi_strip_domain_names"}}</strong></label>
+							<label for="sspi_strip_domain_names"><strong>{{.locale.Tr "admin.auths.sspi_strip_domain_names"}}</strong></label>
 							<input id="sspi_strip_domain_names" name="sspi_strip_domain_names" class="sspi-strip-domain-names" type="checkbox" {{if $cfg.StripDomainNames}}checked{{end}}>
-							<p class="help">{{.i18n.Tr "admin.auths.sspi_strip_domain_names_helper"}}</p>
+							<p class="help">{{.locale.Tr "admin.auths.sspi_strip_domain_names_helper"}}</p>
 						</div>
 					</div>
 					<div class="required field">
-						<label for="sspi_separator_replacement">{{.i18n.Tr "admin.auths.sspi_separator_replacement"}}</label>
+						<label for="sspi_separator_replacement">{{.locale.Tr "admin.auths.sspi_separator_replacement"}}</label>
 						<input id="sspi_separator_replacement" name="sspi_separator_replacement" value="{{$cfg.SeparatorReplacement}}" required>
-						<p class="help">{{.i18n.Tr "admin.auths.sspi_separator_replacement_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.sspi_separator_replacement_helper"}}</p>
 					</div>
 					<div class="field">
-						<label for="sspi_default_language">{{.i18n.Tr "admin.auths.sspi_default_language"}}</label>
+						<label for="sspi_default_language">{{.locale.Tr "admin.auths.sspi_default_language"}}</label>
 						<div class="ui language selection dropdown" id="sspi_default_language">
 							<input name="sspi_default_language" type="hidden" value="{{$cfg.DefaultLanguage}}">
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -405,27 +405,27 @@
 							{{end}}
 							</div>
 						</div>
-						<p class="help">{{.i18n.Tr "admin.auths.sspi_default_language_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.sspi_default_language_helper"}}</p>
 					</div>
 				{{end}}
 				{{if .Source.IsLDAP}}
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.auths.syncenabled"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.auths.syncenabled"}}</strong></label>
 							<input name="is_sync_enabled" type="checkbox" {{if .Source.IsSyncEnabled}}checked{{end}}>
 						</div>
 					</div>
 				{{end}}
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.auths.activated"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.auths.activated"}}</strong></label>
 						<input name="is_active" type="checkbox" {{if .Source.IsActive}}checked{{end}}>
 					</div>
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{.i18n.Tr "admin.auths.update"}}</button>
-					<div class="ui red button delete-button" data-url="{{$.Link}}/delete" data-id="{{.Source.ID}}">{{.i18n.Tr "admin.auths.delete"}}</div>
+					<button class="ui green button">{{.locale.Tr "admin.auths.update"}}</button>
+					<div class="ui red button delete-button" data-url="{{$.Link}}/delete" data-id="{{.Source.ID}}">{{.locale.Tr "admin.auths.delete"}}</div>
 				</div>
 			</form>
 		</div>
@@ -435,10 +435,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "admin.auths.delete_auth_title"}}
+		{{.locale.Tr "admin.auths.delete_auth_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "admin.auths.delete_auth_desc"}}</p>
+		<p>{{.locale.Tr "admin.auths.delete_auth_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/auth/list.tmpl
+++ b/templates/admin/auth/list.tmpl
@@ -4,9 +4,9 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.auths.auth_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.auths.auth_manage_panel"}} ({{.locale.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/auths/new">{{.i18n.Tr "admin.auths.new"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/auths/new">{{.locale.Tr "admin.auths.new"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached table segment">
@@ -14,12 +14,12 @@
 				<thead>
 					<tr>
 						<th>ID</th>
-						<th>{{.i18n.Tr "admin.auths.name"}}</th>
-						<th>{{.i18n.Tr "admin.auths.type"}}</th>
-						<th>{{.i18n.Tr "admin.auths.enabled"}}</th>
-						<th>{{.i18n.Tr "admin.auths.updated"}}</th>
-						<th>{{.i18n.Tr "admin.users.created"}}</th>
-						<th>{{.i18n.Tr "admin.users.edit"}}</th>
+						<th>{{.locale.Tr "admin.auths.name"}}</th>
+						<th>{{.locale.Tr "admin.auths.type"}}</th>
+						<th>{{.locale.Tr "admin.auths.enabled"}}</th>
+						<th>{{.locale.Tr "admin.auths.updated"}}</th>
+						<th>{{.locale.Tr "admin.users.created"}}</th>
+						<th>{{.locale.Tr "admin.users.edit"}}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.auths.new"}}
+			{{.locale.Tr "admin.auths.new"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -12,7 +12,7 @@
 				{{.CsrfTokenHtml}}
 				<!-- Types and name -->
 				<div class="inline required field {{if .Err_Type}}error{{end}}">
-					<label>{{.i18n.Tr "admin.auths.auth_type"}}</label>
+					<label>{{.locale.Tr "admin.auths.auth_type"}}</label>
 					<div class="ui selection type dropdown">
 						<input type="hidden" id="auth_type" name="type" value="{{.type}}">
 						<div class="text">{{.CurrentTypeName}}</div>
@@ -25,7 +25,7 @@
 					</div>
 				</div>
 				<div class="required inline field {{if .Err_Name}}error{{end}}">
-					<label for="name">{{.i18n.Tr "admin.auths.auth_name"}}</label>
+					<label for="name">{{.locale.Tr "admin.auths.auth_name"}}</label>
 					<input id="name" name="name" value="{{.name}}" autofocus required>
 				</div>
 
@@ -37,16 +37,16 @@
 
 				<!-- PAM -->
 				<div class="pam required field {{if not (eq .type 4)}}hide{{end}}">
-					<label for="pam_service_name">{{.i18n.Tr "admin.auths.pam_service_name"}}</label>
+					<label for="pam_service_name">{{.locale.Tr "admin.auths.pam_service_name"}}</label>
 					<input id="pam_service_name" name="pam_service_name" value="{{.pam_service_name}}" />
-					<label for="pam_email_domain">{{.i18n.Tr "admin.auths.pam_email_domain"}}</label>
+					<label for="pam_email_domain">{{.locale.Tr "admin.auths.pam_email_domain"}}</label>
 					<input id="pam_email_domain" name="pam_email_domain" value="{{.pam_email_domain}}">
 				</div>
 				<div class="pam optional field {{if not (eq .type 4)}}hide{{end}}">
 					<div class="ui checkbox">
-						<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+						<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 						<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if .skip_local_two_fa}}checked{{end}}>
-						<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+						<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 					</div>
 				</div>
 
@@ -58,67 +58,67 @@
 
 				<div class="ldap field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.auths.attributes_in_bind"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.auths.attributes_in_bind"}}</strong></label>
 						<input name="attributes_in_bind" type="checkbox" {{if .attributes_in_bind}}checked{{end}}>
 					</div>
 				</div>
 				<div class="ldap inline field {{if not (eq .type 2)}}hide{{end}}">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.auths.syncenabled"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.auths.syncenabled"}}</strong></label>
 						<input name="is_sync_enabled" type="checkbox" {{if .is_sync_enabled}}checked{{end}}>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.auths.activated"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.auths.activated"}}</strong></label>
 						<input name="is_active" type="checkbox" {{if .is_active}}checked{{end}}>
 					</div>
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{.i18n.Tr "admin.auths.new"}}</button>
+					<button class="ui green button">{{.locale.Tr "admin.auths.new"}}</button>
 				</div>
 			</form>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.auths.tips"}}
+			{{.locale.Tr "admin.auths.tips"}}
 		</h4>
 		<div class="ui attached segment">
 			<h5>GMail Settings:</h5>
 			<p>Host: smtp.gmail.com, Port: 587, Enable TLS Encryption: true</p>
 
-			<h5>{{.i18n.Tr "admin.auths.tips.oauth2.general"}}:</h5>
-			<p>{{.i18n.Tr "admin.auths.tips.oauth2.general.tip"}}</p>
+			<h5>{{.locale.Tr "admin.auths.tips.oauth2.general"}}:</h5>
+			<p>{{.locale.Tr "admin.auths.tips.oauth2.general.tip"}}</p>
 
-			<h5 class="ui top attached header">{{.i18n.Tr "admin.auths.tip.oauth2_provider"}}</h5>
+			<h5 class="ui top attached header">{{.locale.Tr "admin.auths.tip.oauth2_provider"}}</h5>
 			<div class="ui attached segment">
 				<li>Bitbucket</li>
-				<span>{{.i18n.Tr "admin.auths.tip.bitbucket"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.bitbucket"}}</span>
 				<li>Dropbox</li>
-				<span>{{.i18n.Tr "admin.auths.tip.dropbox"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.dropbox"}}</span>
 				<li>Facebook</li>
-				<span>{{.i18n.Tr "admin.auths.tip.facebook"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.facebook"}}</span>
 				<li>GitHub</li>
-				<span>{{.i18n.Tr "admin.auths.tip.github"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.github"}}</span>
 				<li>GitLab</li>
-				<span>{{.i18n.Tr "admin.auths.tip.gitlab"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.gitlab"}}</span>
 				<li>Google</li>
-				<span>{{.i18n.Tr "admin.auths.tip.google_plus"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.google_plus"}}</span>
 				<li>OpenID Connect</li>
-				<span>{{.i18n.Tr "admin.auths.tip.openid_connect"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.openid_connect"}}</span>
 				<li>Twitter</li>
-				<span>{{.i18n.Tr "admin.auths.tip.twitter"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.twitter"}}</span>
 				<li>Discord</li>
-				<span>{{.i18n.Tr "admin.auths.tip.discord"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.discord"}}</span>
 				<li>Gitea</li>
-				<span>{{.i18n.Tr "admin.auths.tip.gitea"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.gitea"}}</span>
 				<li>Nextcloud</li>
-				<span>{{.i18n.Tr "admin.auths.tip.nextcloud"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.nextcloud"}}</span>
 				<li>Yandex</li>
-				<span>{{.i18n.Tr "admin.auths.tip.yandex"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.yandex"}}</span>
 				<li>Mastodon</li>
-				<span>{{.i18n.Tr "admin.auths.tip.mastodon"}}</span>
+				<span>{{.locale.Tr "admin.auths.tip.mastodon"}}</span>
 			</div>
 		</div>
 	</div>

--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -1,6 +1,6 @@
 <div class="ldap dldap field {{if not (or (eq .type 2) (eq .type 5))}}hide{{end}}">
 	<div class="inline required field {{if .Err_SecurityProtocol}}error{{end}}">
-		<label>{{.i18n.Tr "admin.auths.security_protocol"}}</label>
+		<label>{{.locale.Tr "admin.auths.security_protocol"}}</label>
 		<div class="ui selection security-protocol dropdown">
 			<input type="hidden" id="security_protocol" name="security_protocol" value="{{.security_protocol}}">
 			<div class="text">{{.CurrentSecurityProtocol}}</div>
@@ -13,103 +13,103 @@
 		</div>
 	</div>
 	<div class="required field">
-		<label for="host">{{.i18n.Tr "admin.auths.host"}}</label>
+		<label for="host">{{.locale.Tr "admin.auths.host"}}</label>
 		<input id="host" name="host" value="{{.host}}" placeholder="e.g. mydomain.com">
 	</div>
 	<div class="required field">
-		<label for="port">{{.i18n.Tr "admin.auths.port"}}</label>
+		<label for="port">{{.locale.Tr "admin.auths.port"}}</label>
 		<input id="port" name="port" value="{{.port}}"  placeholder="e.g. 636">
 	</div>
 	<div class="has-tls inline field {{if not .HasTLS}}hide{{end}}">
 		<div class="ui checkbox">
-			<label><strong>{{.i18n.Tr "admin.auths.skip_tls_verify"}}</strong></label>
+			<label><strong>{{.locale.Tr "admin.auths.skip_tls_verify"}}</strong></label>
 			<input name="skip_verify" type="checkbox" {{if .skip_verify}}checked{{end}}>
 		</div>
 	</div>
 	<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
-		<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
+		<label for="bind_dn">{{.locale.Tr "admin.auths.bind_dn"}}</label>
 		<input id="bind_dn" name="bind_dn" value="{{.bind_dn}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
 	</div>
 	<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
-		<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
+		<label for="bind_password">{{.locale.Tr "admin.auths.bind_password"}}</label>
 		<input id="bind_password" name="bind_password" type="password" autocomplete="off" value="{{.bind_password}}">
 	</div>
 	<div class="binddnrequired {{if (eq .type 2)}}required{{end}} field">
-		<label for="user_base">{{.i18n.Tr "admin.auths.user_base"}}</label>
+		<label for="user_base">{{.locale.Tr "admin.auths.user_base"}}</label>
 		<input id="user_base" name="user_base" value="{{.user_base}}" placeholder="e.g. ou=Users,dc=mydomain,dc=com">
 	</div>
 	<div class="dldap required field {{if not (eq .type 5)}}hide{{end}}">
-		<label for="user_dn">{{.i18n.Tr "admin.auths.user_dn"}}</label>
+		<label for="user_dn">{{.locale.Tr "admin.auths.user_dn"}}</label>
 		<input id="user_dn" name="user_dn" value="{{.user_dn}}" placeholder="e.g. uid=%s,ou=Users,dc=mydomain,dc=com">
 	</div>
 	<div class="required field">
-		<label for="filter">{{.i18n.Tr "admin.auths.filter"}}</label>
+		<label for="filter">{{.locale.Tr "admin.auths.filter"}}</label>
 		<input id="filter" name="filter" value="{{.filter}}" placeholder="e.g. (&(objectClass=posixAccount)(uid=%s))">
 	</div>
 	<div class="field">
-		<label for="admin_filter">{{.i18n.Tr "admin.auths.admin_filter"}}</label>
+		<label for="admin_filter">{{.locale.Tr "admin.auths.admin_filter"}}</label>
 		<input id="admin_filter" name="admin_filter" value="{{.admin_filter}}">
 	</div>
 	<div class="field">
-		<label for="restricted_filter">{{.i18n.Tr "admin.auths.restricted_filter"}}</label>
+		<label for="restricted_filter">{{.locale.Tr "admin.auths.restricted_filter"}}</label>
 		<input id="restricted_filter" name="admin_filter" value="{{.restricted_filter}}">
-		<p class="help">{{.i18n.Tr "admin.auths.restricted_filter_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.restricted_filter_helper"}}</p>
 	</div>
 	<div class="field">
-		<label for="attribute_username">{{.i18n.Tr "admin.auths.attribute_username"}}</label>
-		<input id="attribute_username" name="attribute_username" value="{{.attribute_username}}" placeholder="{{.i18n.Tr "admin.auths.attribute_username_placeholder"}}">
+		<label for="attribute_username">{{.locale.Tr "admin.auths.attribute_username"}}</label>
+		<input id="attribute_username" name="attribute_username" value="{{.attribute_username}}" placeholder="{{.locale.Tr "admin.auths.attribute_username_placeholder"}}">
 	</div>
 	<div class="field">
-		<label for="attribute_name">{{.i18n.Tr "admin.auths.attribute_name"}}</label>
+		<label for="attribute_name">{{.locale.Tr "admin.auths.attribute_name"}}</label>
 		<input id="attribute_name" name="attribute_name" value="{{.attribute_name}}">
 	</div>
 	<div class="field">
-		<label for="attribute_surname">{{.i18n.Tr "admin.auths.attribute_surname"}}</label>
+		<label for="attribute_surname">{{.locale.Tr "admin.auths.attribute_surname"}}</label>
 		<input id="attribute_surname" name="attribute_surname" value="{{.attribute_surname}}">
 	</div>
 	<div class="required field">
-		<label for="attribute_mail">{{.i18n.Tr "admin.auths.attribute_mail"}}</label>
+		<label for="attribute_mail">{{.locale.Tr "admin.auths.attribute_mail"}}</label>
 		<input id="attribute_mail" name="attribute_mail" value="{{.attribute_mail}}" placeholder="e.g. mail">
 	</div>
 	<div class="field">
-		<label for="attribute_ssh_public_key">{{.i18n.Tr "admin.auths.attribute_ssh_public_key"}}</label>
+		<label for="attribute_ssh_public_key">{{.locale.Tr "admin.auths.attribute_ssh_public_key"}}</label>
 		<input id="attribute_ssh_public_key" name="attribute_ssh_public_key" value="{{.attribute_ssh_public_key}}" placeholder="e.g. SshPublicKey">
 	</div>
 	<div class="field">
-		<label for="attribute_avatar">{{.i18n.Tr "admin.auths.attribute_avatar"}}</label>
+		<label for="attribute_avatar">{{.locale.Tr "admin.auths.attribute_avatar"}}</label>
 		<input id="attribute_avatar" name="attribute_avatar" value="{{.attribute_avatar}}" placeholder="e.g. jpegPhoto">
 	</div>
 
 	<!-- ldap group begin -->
 	<div class="inline field">
 		<div class="ui checkbox">
-			<label><strong>{{.i18n.Tr "admin.auths.enable_ldap_groups"}}</strong></label>
+			<label><strong>{{.locale.Tr "admin.auths.enable_ldap_groups"}}</strong></label>
 			<input type="checkbox" name="groups_enabled" class="js-ldap-group-toggle" {{if .groups_enabled}}checked{{end}}>
 		</div>
 	</div>
 	<div id="ldap-group-options" class="ui segment secondary">
 		<div class="field">
-			<label>{{.i18n.Tr "admin.auths.group_search_base"}}</label>
+			<label>{{.locale.Tr "admin.auths.group_search_base"}}</label>
 			<input name="group_dn" value="{{.group_dn}}" placeholder="e.g. ou=group,dc=mydomain,dc=com">
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "admin.auths.group_attribute_list_users"}}</label>
+			<label>{{.locale.Tr "admin.auths.group_attribute_list_users"}}</label>
 			<input name="group_member_uid" value="{{.group_member_uid}}" placeholder="e.g. memberUid">
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "admin.auths.user_attribute_in_group"}}</label>
+			<label>{{.locale.Tr "admin.auths.user_attribute_in_group"}}</label>
 			<input name="user_uid" value="{{.user_uid}}" placeholder="e.g. uid">
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "admin.auths.verify_group_membership"}}</label>
+			<label>{{.locale.Tr "admin.auths.verify_group_membership"}}</label>
 			<input name="group_filter" value="{{.group_filter}}" placeholder="e.g. (|(cn=gitea_users)(cn=admins))">
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "admin.auths.map_group_to_team"}}</label>
+			<label>{{.locale.Tr "admin.auths.map_group_to_team"}}</label>
 			<input name="group_team_map" value="{{.group_team_map}}" placeholder='e.g. {"cn=my-group,cn=groups,dc=example,dc=org": {"MyGiteaOrganization": ["MyGiteaTeam1", "MyGiteaTeam2"]}}'>
 		</div>
 		<div class="ui checkbox">
-			<label>{{.i18n.Tr "admin.auths.map_group_to_team_removal"}}</label>
+			<label>{{.locale.Tr "admin.auths.map_group_to_team_removal"}}</label>
 			<input name="group_team_map_removal" type="checkbox" {{if .group_team_map_removal}}checked{{end}}>
 		</div>
 	</div>
@@ -117,24 +117,24 @@
 
 	<div class="ldap inline field {{if not (eq .type 2)}}hide{{end}}">
 		<div class="ui checkbox">
-			<label for="use_paged_search"><strong>{{.i18n.Tr "admin.auths.use_paged_search"}}</strong></label>
+			<label for="use_paged_search"><strong>{{.locale.Tr "admin.auths.use_paged_search"}}</strong></label>
 			<input id="use_paged_search" name="use_paged_search" class="use-paged-search" type="checkbox" {{if .use_paged_search}}checked{{end}}>
 		</div>
 	</div>
 	<div class="ldap field search-page-size required {{if or (not (eq .type 2)) (not .use_paged_search)}}hide{{end}}">
-		<label for="search_page_size">{{.i18n.Tr "admin.auths.search_page_size"}}</label>
+		<label for="search_page_size">{{.locale.Tr "admin.auths.search_page_size"}}</label>
 		<input id="search_page_size" name="search_page_size" value="{{.search_page_size}}">
 	</div>
 	<div class="optional field">
 		<div class="ui checkbox">
-			<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+			<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 			<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if .skip_local_two_fa}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 		</div>
 	</div>
 	<div class="inline field">
 		<div class="ui checkbox">
-			<label for="allow_deactivate_all"><strong>{{.i18n.Tr "admin.auths.allow_deactivate_all"}}</strong></label>
+			<label for="allow_deactivate_all"><strong>{{.locale.Tr "admin.auths.allow_deactivate_all"}}</strong></label>
 			<input id="allow_deactivate_all" name="allow_deactivate_all" type="checkbox" {{if .allow_deactivate_all}}checked{{end}}>
 		</div>
 	</div>

--- a/templates/admin/auth/source/oauth.tmpl
+++ b/templates/admin/auth/source/oauth.tmpl
@@ -1,6 +1,6 @@
 <div class="oauth2 field {{if not (eq .type 6)}}hide{{end}}">
 	<div class="inline required field">
-		<label>{{.i18n.Tr "admin.auths.oauth2_provider"}}</label>
+		<label>{{.locale.Tr "admin.auths.oauth2_provider"}}</label>
 		<div class="ui selection type dropdown">
 			<input type="hidden" id="oauth2_provider" name="oauth2_provider" value="{{.oauth2_provider}}">
 			<div class="text">{{.oauth2_provider}}</div>
@@ -13,53 +13,53 @@
 		</div>
 	</div>
 	<div class="required field">
-		<label for="oauth2_key">{{.i18n.Tr "admin.auths.oauth2_clientID"}}</label>
+		<label for="oauth2_key">{{.locale.Tr "admin.auths.oauth2_clientID"}}</label>
 		<input id="oauth2_key" name="oauth2_key" value="{{.oauth2_key}}">
 	</div>
 	<div class="required field">
-		<label for="oauth2_secret">{{.i18n.Tr "admin.auths.oauth2_clientSecret"}}</label>
+		<label for="oauth2_secret">{{.locale.Tr "admin.auths.oauth2_clientSecret"}}</label>
 		<input id="oauth2_secret" name="oauth2_secret" value="{{.oauth2_secret}}">
 	</div>
 	<div class="optional field">
-		<label for="oauth2_icon_url">{{.i18n.Tr "admin.auths.oauth2_icon_url"}}</label>
+		<label for="oauth2_icon_url">{{.locale.Tr "admin.auths.oauth2_icon_url"}}</label>
 		<input id="oauth2_icon_url" name="oauth2_icon_url" value="{{.oauth2_icon_url}}">
 	</div>
 	<div class="open_id_connect_auto_discovery_url required field">
-		<label for="open_id_connect_auto_discovery_url">{{.i18n.Tr "admin.auths.openIdConnectAutoDiscoveryURL"}}</label>
+		<label for="open_id_connect_auto_discovery_url">{{.locale.Tr "admin.auths.openIdConnectAutoDiscoveryURL"}}</label>
 		<input id="open_id_connect_auto_discovery_url" name="open_id_connect_auto_discovery_url" value="{{.open_id_connect_auto_discovery_url}}">
 	</div>
 	<div class="optional field">
 		<div class="ui checkbox">
-			<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+			<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 			<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if .skip_local_two_fa}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 		</div>
 	</div>
 
 	<div class="oauth2_use_custom_url inline field">
 		<div class="ui checkbox">
-			<label><strong>{{.i18n.Tr "admin.auths.oauth2_use_custom_url"}}</strong></label>
+			<label><strong>{{.locale.Tr "admin.auths.oauth2_use_custom_url"}}</strong></label>
 			<input id="oauth2_use_custom_url" name="oauth2_use_custom_url" type="checkbox">
 		</div>
 	</div>
 	<div class="oauth2_use_custom_url_field oauth2_auth_url required field">
-		<label for="oauth2_auth_url">{{.i18n.Tr "admin.auths.oauth2_authURL"}}</label>
+		<label for="oauth2_auth_url">{{.locale.Tr "admin.auths.oauth2_authURL"}}</label>
 		<input id="oauth2_auth_url" name="oauth2_auth_url" value="{{.oauth2_auth_url}}">
 	</div>
 	<div class="oauth2_use_custom_url_field oauth2_token_url required field">
-		<label for="oauth2_token_url">{{.i18n.Tr "admin.auths.oauth2_tokenURL"}}</label>
+		<label for="oauth2_token_url">{{.locale.Tr "admin.auths.oauth2_tokenURL"}}</label>
 		<input id="oauth2_token_url" name="oauth2_token_url" value="{{.oauth2_token_url}}">
 	</div>
 	<div class="oauth2_use_custom_url_field oauth2_profile_url required field">
-		<label for="oauth2_profile_url">{{.i18n.Tr "admin.auths.oauth2_profileURL"}}</label>
+		<label for="oauth2_profile_url">{{.locale.Tr "admin.auths.oauth2_profileURL"}}</label>
 		<input id="oauth2_profile_url" name="oauth2_profile_url" value="{{.oauth2_profile_url}}">
 	</div>
 	<div class="oauth2_use_custom_url_field oauth2_email_url required field">
-		<label for="oauth2_email_url">{{.i18n.Tr "admin.auths.oauth2_emailURL"}}</label>
+		<label for="oauth2_email_url">{{.locale.Tr "admin.auths.oauth2_emailURL"}}</label>
 		<input id="oauth2_email_url" name="oauth2_email_url" value="{{.oauth2_email_url}}">
 	</div>
 	<div class="oauth2_use_custom_url_field oauth2_tenant required field">
-		<label for="oauth2_tenant">{{.i18n.Tr "admin.auths.oauth2_tenant"}}</label>
+		<label for="oauth2_tenant">{{.locale.Tr "admin.auths.oauth2_tenant"}}</label>
 		<input id="oauth2_tenant" name="oauth2_tenant" value="{{.oauth2_tenant}}">
 	</div>
 
@@ -73,29 +73,29 @@
 	{{end}}{{end}}
 
 	<div class="field">
-		<label for="oauth2_scopes">{{.i18n.Tr "admin.auths.oauth2_scopes"}}</label>
+		<label for="oauth2_scopes">{{.locale.Tr "admin.auths.oauth2_scopes"}}</label>
 		<input id="oauth2_scopes" name="oauth2_scopes" values="{{.oauth2_scopes}}">
 	</div>
 	<div class="field">
-		<label for="oauth2_required_claim_name">{{.i18n.Tr "admin.auths.oauth2_required_claim_name"}}</label>
+		<label for="oauth2_required_claim_name">{{.locale.Tr "admin.auths.oauth2_required_claim_name"}}</label>
 		<input id="oauth2_required_claim_name" name="oauth2_required_claim_name" values="{{.oauth2_required_claim_name}}">
-		<p class="help">{{.i18n.Tr "admin.auths.oauth2_required_claim_name_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.oauth2_required_claim_name_helper"}}</p>
 	</div>
 	<div class="field">
-		<label for="oauth2_required_claim_value">{{.i18n.Tr "admin.auths.oauth2_required_claim_value"}}</label>
+		<label for="oauth2_required_claim_value">{{.locale.Tr "admin.auths.oauth2_required_claim_value"}}</label>
 		<input id="oauth2_required_claim_value" name="oauth2_required_claim_value" values="{{.oauth2_required_claim_value}}">
-		<p class="help">{{.i18n.Tr "admin.auths.oauth2_required_claim_value_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.oauth2_required_claim_value_helper"}}</p>
 	</div>
 	<div class="field">
-		<label for="oauth2_group_claim_name">{{.i18n.Tr "admin.auths.oauth2_group_claim_name"}}</label>
+		<label for="oauth2_group_claim_name">{{.locale.Tr "admin.auths.oauth2_group_claim_name"}}</label>
 		<input id="oauth2_group_claim_name" name="oauth2_group_claim_name" value="{{.oauth2_group_claim_name}}">
 	</div>
 	<div class="field">
-		<label for="oauth2_admin_group">{{.i18n.Tr "admin.auths.oauth2_admin_group"}}</label>
+		<label for="oauth2_admin_group">{{.locale.Tr "admin.auths.oauth2_admin_group"}}</label>
 		<input id="oauth2_admin_group" name="oauth2_admin_group" value="{{.oauth2_group_claim_name}}">
 	</div>
 	<div class="field">
-		<label for="oauth2_restricted_group">{{.i18n.Tr "admin.auths.oauth2_restricted_group"}}</label>
+		<label for="oauth2_restricted_group">{{.locale.Tr "admin.auths.oauth2_restricted_group"}}</label>
 		<input id="oauth2_restricted_group" name="oauth2_restricted_group" value="{{.oauth2_group_claim_name}}">
 	</div>
 </div>

--- a/templates/admin/auth/source/smtp.tmpl
+++ b/templates/admin/auth/source/smtp.tmpl
@@ -1,6 +1,6 @@
 <div class="smtp field {{if not (eq .type 3)}}hide{{end}}">
 	<div class="inline required field">
-		<label>{{.i18n.Tr "admin.auths.smtp_auth"}}</label>
+		<label>{{.locale.Tr "admin.auths.smtp_auth"}}</label>
 		<div class="ui selection type dropdown">
 			<input type="hidden" id="smtp_auth" name="smtp_auth" value="{{.smtp_auth}}">
 			<div class="text">{{.smtp_auth}}</div>
@@ -13,47 +13,47 @@
 		</div>
 	</div>
 	<div class="required field">
-		<label for="smtp_host">{{.i18n.Tr "admin.auths.smtphost"}}</label>
+		<label for="smtp_host">{{.locale.Tr "admin.auths.smtphost"}}</label>
 		<input id="smtp_host" name="smtp_host" value="{{.smtp_host}}">
 	</div>
 	<div class="required field">
-		<label for="smtp_port">{{.i18n.Tr "admin.auths.smtpport"}}</label>
+		<label for="smtp_port">{{.locale.Tr "admin.auths.smtpport"}}</label>
 		<input id="smtp_port" name="smtp_port" value="{{.smtp_port}}">
 	</div>
 	<div class="inline field">
 		<div class="ui checkbox">
-			<label for="force_smtps"><strong>{{.i18n.Tr "admin.auths.force_smtps"}}</strong></label>
+			<label for="force_smtps"><strong>{{.locale.Tr "admin.auths.force_smtps"}}</strong></label>
 			<input id="force_smtps" name="force_smtps" type="checkbox" {{if .force_smtps}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.force_smtps_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.force_smtps_helper"}}</p>
 		</div>
 	</div>
 	<div class="inline field">
 		<div class="ui checkbox">
-			<label><strong>{{.i18n.Tr "admin.auths.skip_tls_verify"}}</strong></label>
+			<label><strong>{{.locale.Tr "admin.auths.skip_tls_verify"}}</strong></label>
 			<input name="skip_verify" type="checkbox" {{if .skip_verify}}checked{{end}}>
 		</div>
 	</div>
 	<div class="field">
-		<label for="helo_hostname">{{.i18n.Tr "admin.auths.helo_hostname"}}</label>
+		<label for="helo_hostname">{{.locale.Tr "admin.auths.helo_hostname"}}</label>
 		<input id="helo_hostname" name="helo_hostname" value="{{.helo_hostname}}">
-		<p class="help">{{.i18n.Tr "admin.auths.helo_hostname_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.helo_hostname_helper"}}</p>
 	</div>
 	<div class="inline field">
 		<div class="ui checkbox">
-			<label for="disable_helo"><strong>{{.i18n.Tr "admin.auths.disable_helo"}}</strong></label>
+			<label for="disable_helo"><strong>{{.locale.Tr "admin.auths.disable_helo"}}</strong></label>
 			<input id="disable_helo" name="disable_helo" type="checkbox" {{if .disable_helo}}checked{{end}}>
 		</div>
 	</div>
 	<div class="field">
-		<label for="allowed_domains">{{.i18n.Tr "admin.auths.allowed_domains"}}</label>
+		<label for="allowed_domains">{{.locale.Tr "admin.auths.allowed_domains"}}</label>
 		<input id="allowed_domains" name="allowed_domains" value="{{.allowed_domains}}">
-		<p class="help">{{.i18n.Tr "admin.auths.allowed_domains_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.allowed_domains_helper"}}</p>
 	</div>
 	<div class="optional field">
 		<div class="ui checkbox">
-			<label for="skip_local_two_fa"><strong>{{.i18n.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
+			<label for="skip_local_two_fa"><strong>{{.locale.Tr "admin.auths.skip_local_two_fa"}}</strong></label>
 			<input id="skip_local_two_fa" name="skip_local_two_fa" type="checkbox" {{if .skip_local_two_fa}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.skip_local_two_fa_helper"}}</p>
 		</div>
 	</div>
 </div>

--- a/templates/admin/auth/source/sspi.tmpl
+++ b/templates/admin/auth/source/sspi.tmpl
@@ -1,32 +1,32 @@
 <div class="sspi field {{if not (eq .type 7)}}hide{{end}}">
 	<div class="field">
 		<div class="ui checkbox">
-			<label for="sspi_auto_create_users"><strong>{{.i18n.Tr "admin.auths.sspi_auto_create_users"}}</strong></label>
+			<label for="sspi_auto_create_users"><strong>{{.locale.Tr "admin.auths.sspi_auto_create_users"}}</strong></label>
 			<input id="sspi_auto_create_users" name="sspi_auto_create_users" class="sspi-auto-create-users" type="checkbox" {{if .SSPIAutoCreateUsers}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.sspi_auto_create_users_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.sspi_auto_create_users_helper"}}</p>
 		</div>
 	</div>
 	<div class="field">
 		<div class="ui checkbox">
-			<label for="sspi_auto_activate_users"><strong>{{.i18n.Tr "admin.auths.sspi_auto_activate_users"}}</strong></label>
+			<label for="sspi_auto_activate_users"><strong>{{.locale.Tr "admin.auths.sspi_auto_activate_users"}}</strong></label>
 			<input id="sspi_auto_activate_users" name="sspi_auto_activate_users" class="sspi-auto-activate-users" type="checkbox" {{if .SSPIAutoActivateUsers}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.sspi_auto_activate_users_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.sspi_auto_activate_users_helper"}}</p>
 		</div>
 	</div>
 	<div class="field">
 		<div class="ui checkbox">
-			<label for="sspi_strip_domain_names"><strong>{{.i18n.Tr "admin.auths.sspi_strip_domain_names"}}</strong></label>
+			<label for="sspi_strip_domain_names"><strong>{{.locale.Tr "admin.auths.sspi_strip_domain_names"}}</strong></label>
 			<input id="sspi_strip_domain_names" name="sspi_strip_domain_names" class="sspi-strip-domain-names" type="checkbox" {{if .SSPIStripDomainNames}}checked{{end}}>
-			<p class="help">{{.i18n.Tr "admin.auths.sspi_strip_domain_names_helper"}}</p>
+			<p class="help">{{.locale.Tr "admin.auths.sspi_strip_domain_names_helper"}}</p>
 		</div>
 	</div>
 	<div class="required field">
-		<label for="sspi_separator_replacement">{{.i18n.Tr "admin.auths.sspi_separator_replacement"}}</label>
+		<label for="sspi_separator_replacement">{{.locale.Tr "admin.auths.sspi_separator_replacement"}}</label>
 		<input id="sspi_separator_replacement" name="sspi_separator_replacement" value="{{.SSPISeparatorReplacement}}">
-		<p class="help">{{.i18n.Tr "admin.auths.sspi_separator_replacement_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.sspi_separator_replacement_helper"}}</p>
 	</div>
 	<div class="field">
-		<label for="sspi_default_language">{{.i18n.Tr "admin.auths.sspi_default_language"}}</label>
+		<label for="sspi_default_language">{{.locale.Tr "admin.auths.sspi_default_language"}}</label>
 		<div class="ui language selection dropdown" id="sspi_default_language">
 			<input name="sspi_default_language" type="hidden" value="{{.SSPIDefaultLanguage}}">
 			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -38,6 +38,6 @@
 			{{end}}
 			</div>
 		</div>
-		<p class="help">{{.i18n.Tr "admin.auths.sspi_default_language_helper"}}</p>
+		<p class="help">{{.locale.Tr "admin.auths.sspi_default_language_helper"}}</p>
 	</div>
 </div>

--- a/templates/admin/base/search.tmpl
+++ b/templates/admin/base/search.tmpl
@@ -2,22 +2,22 @@
 <!-- Sort -->
 	<div class="ui dropdown type jump item">
 		<span class="text">
-			{{.i18n.Tr "repo.issues.filter_sort"}}
+			{{.locale.Tr "repo.issues.filter_sort"}}
 			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		</span>
 		<div class="menu">
-			<a class="{{if or (eq .SortType "oldest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
-			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+			<a class="{{if or (eq .SortType "oldest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
+			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
+			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 		</div>
 	</div>
 </div>
 <form class="ui form ignore-dirty"  style="max-width: 90%;">
 	<div class="ui fluid action input">
-		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-		<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+		<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+		<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -4,50 +4,50 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.server_config"}}
+			{{.locale.Tr "admin.config.server_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.app_name"}}</dt>
+				<dt>{{.locale.Tr "admin.config.app_name"}}</dt>
 				<dd>{{AppName}}</dd>
-				<dt>{{.i18n.Tr "admin.config.app_ver"}}</dt>
+				<dt>{{.locale.Tr "admin.config.app_ver"}}</dt>
 				<dd>{{AppVer}}{{AppBuiltWith}}</dd>
-				<dt>{{.i18n.Tr "admin.config.custom_conf"}}</dt>
+				<dt>{{.locale.Tr "admin.config.custom_conf"}}</dt>
 				<dd>{{.CustomConf}}</dd>
-				<dt>{{.i18n.Tr "admin.config.app_url"}}</dt>
+				<dt>{{.locale.Tr "admin.config.app_url"}}</dt>
 				<dd>{{.AppUrl}}</dd>
-				<dt>{{.i18n.Tr "admin.config.domain"}}</dt>
+				<dt>{{.locale.Tr "admin.config.domain"}}</dt>
 				<dd>{{.Domain}}</dd>
-				<dt>{{.i18n.Tr "admin.config.offline_mode"}}</dt>
+				<dt>{{.locale.Tr "admin.config.offline_mode"}}</dt>
 				<dd>{{if .OfflineMode}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.disable_router_log"}}</dt>
+				<dt>{{.locale.Tr "admin.config.disable_router_log"}}</dt>
 				<dd>{{if .DisableRouterLog}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 
 				<div class="ui divider"></div>
 
-				<dt>{{.i18n.Tr "admin.config.run_user"}}</dt>
+				<dt>{{.locale.Tr "admin.config.run_user"}}</dt>
 				<dd>{{.RunUser}}</dd>
-				<dt>{{.i18n.Tr "admin.config.run_mode"}}</dt>
+				<dt>{{.locale.Tr "admin.config.run_mode"}}</dt>
 				<dd>{{.RunMode}}</dd>
 
 				<div class="ui divider"></div>
 
-				<dt>{{.i18n.Tr "admin.config.git_version"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_version"}}</dt>
 				<dd>{{.GitVersion}}</dd>
 
 				<div class="ui divider"></div>
 
-				<dt>{{.i18n.Tr "admin.config.repo_root_path"}}</dt>
+				<dt>{{.locale.Tr "admin.config.repo_root_path"}}</dt>
 				<dd>{{.RepoRootPath}}</dd>
-				<dt>{{.i18n.Tr "admin.config.static_file_root_path"}}</dt>
+				<dt>{{.locale.Tr "admin.config.static_file_root_path"}}</dt>
 				<dd>{{.StaticRootPath}}</dd>
-				<dt>{{.i18n.Tr "admin.config.custom_file_root_path"}}</dt>
+				<dt>{{.locale.Tr "admin.config.custom_file_root_path"}}</dt>
 				<dd>{{.CustomRootPath}}</dd>
-				<dt>{{.i18n.Tr "admin.config.log_file_root_path"}}</dt>
+				<dt>{{.locale.Tr "admin.config.log_file_root_path"}}</dt>
 				<dd>{{.LogRootPath}}</dd>
-				<dt>{{.i18n.Tr "admin.config.script_type"}}</dt>
+				<dt>{{.locale.Tr "admin.config.script_type"}}</dt>
 				<dd>{{.ScriptType}}</dd>
-				<dt>{{.i18n.Tr "admin.config.reverse_auth_user"}}</dt>
+				<dt>{{.locale.Tr "admin.config.reverse_auth_user"}}</dt>
 				<dd>{{.ReverseProxyAuthUser}}</dd>
 
 				{{if .EnvVars }}
@@ -62,33 +62,33 @@
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.ssh_config"}}
+			{{.locale.Tr "admin.config.ssh_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.ssh_enabled"}}</dt>
+				<dt>{{.locale.Tr "admin.config.ssh_enabled"}}</dt>
 				<dd>{{if not .SSH.Disabled}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{if not .SSH.Disabled}}
-					<dt>{{.i18n.Tr "admin.config.ssh_start_builtin_server"}}</dt>
+					<dt>{{.locale.Tr "admin.config.ssh_start_builtin_server"}}</dt>
 					<dd>{{if .SSH.StartBuiltinServer}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-					<dt>{{.i18n.Tr "admin.config.ssh_domain"}}</dt>
+					<dt>{{.locale.Tr "admin.config.ssh_domain"}}</dt>
 					<dd>{{.SSH.Domain}}</dd>
-					<dt>{{.i18n.Tr "admin.config.ssh_port"}}</dt>
+					<dt>{{.locale.Tr "admin.config.ssh_port"}}</dt>
 					<dd>{{.SSH.Port}}</dd>
-					<dt>{{.i18n.Tr "admin.config.ssh_listen_port"}}</dt>
+					<dt>{{.locale.Tr "admin.config.ssh_listen_port"}}</dt>
 					<dd>{{.SSH.ListenPort}}</dd>
 
 					{{if not .SSH.StartBuiltinServer}}
-						<dt>{{.i18n.Tr "admin.config.ssh_root_path"}}</dt>
+						<dt>{{.locale.Tr "admin.config.ssh_root_path"}}</dt>
 						<dd>{{.SSH.RootPath}}</dd>
-						<dt>{{.i18n.Tr "admin.config.ssh_key_test_path"}}</dt>
+						<dt>{{.locale.Tr "admin.config.ssh_key_test_path"}}</dt>
 						<dd>{{.SSH.KeyTestPath}}</dd>
-						<dt>{{.i18n.Tr "admin.config.ssh_keygen_path"}}</dt>
+						<dt>{{.locale.Tr "admin.config.ssh_keygen_path"}}</dt>
 						<dd>{{.SSH.KeygenPath}}</dd>
-						<dt>{{.i18n.Tr "admin.config.ssh_minimum_key_size_check"}}</dt>
+						<dt>{{.locale.Tr "admin.config.ssh_minimum_key_size_check"}}</dt>
 						<dd>{{if .SSH.MinimumKeySizeCheck}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 						{{if .SSH.MinimumKeySizeCheck}}
-							<dt>{{.i18n.Tr "admin.config.ssh_minimum_key_sizes"}}</dt>
+							<dt>{{.locale.Tr "admin.config.ssh_minimum_key_sizes"}}</dt>
 							<dd>{{.SSH.MinimumKeySizes}}</dd>
 						{{end}}
 					{{end}}
@@ -97,304 +97,304 @@
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.lfs_config"}}
+			{{.locale.Tr "admin.config.lfs_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.lfs_enabled"}}</dt>
+				<dt>{{.locale.Tr "admin.config.lfs_enabled"}}</dt>
 				<dd>{{if .LFS.StartServer}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{if .LFS.StartServer}}
-					<dt>{{.i18n.Tr "admin.config.lfs_content_path"}}</dt>
+					<dt>{{.locale.Tr "admin.config.lfs_content_path"}}</dt>
 					<dd>{{.LFS.Path}}</dd>
-					<dt>{{.i18n.Tr "admin.config.lfs_http_auth_expiry"}}</dt>
+					<dt>{{.locale.Tr "admin.config.lfs_http_auth_expiry"}}</dt>
 					<dd>{{.LFS.HTTPAuthExpiry}}</dd>
 				{{end}}
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.db_config"}}
+			{{.locale.Tr "admin.config.db_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.db_type"}}</dt>
+				<dt>{{.locale.Tr "admin.config.db_type"}}</dt>
 				<dd>{{.DbCfg.Type}}</dd>
 				{{if not (eq .DbCfg.Type "sqlite3")}}
-					<dt>{{.i18n.Tr "admin.config.db_host"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_host"}}</dt>
 					<dd>{{if .DbCfg.Host}}{{.DbCfg.Host}}{{else}}-{{end}}</dd>
-					<dt>{{.i18n.Tr "admin.config.db_name"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_name"}}</dt>
 					<dd>{{if .DbCfg.Name}}{{.DbCfg.Name}}{{else}}-{{end}}</dd>
-					<dt>{{.i18n.Tr "admin.config.db_user"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_user"}}</dt>
 					<dd>{{if .DbCfg.User}}{{.DbCfg.User}}{{else}}-{{end}}</dd>
 				{{end}}
 				{{if eq .DbCfg.Type "postgres"}}
-					<dt>{{.i18n.Tr "admin.config.db_schema"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_schema"}}</dt>
 					<dd>{{if .DbCfg.Schema}}{{.DbCfg.Schema}}{{else}}-{{end}}</dd>
-					<dt>{{.i18n.Tr "admin.config.db_ssl_mode"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_ssl_mode"}}</dt>
 					<dd>{{if .DbCfg.SSLMode}}{{.DbCfg.SSLMode}}{{else}}-{{end}}</dd>
 				{{end}}
 				{{if eq .DbCfg.Type "sqlite3"}}
-					<dt>{{.i18n.Tr "admin.config.db_path"}}</dt>
+					<dt>{{.locale.Tr "admin.config.db_path"}}</dt>
 					<dd>{{if .DbCfg.Path}}{{.DbCfg.Path}}{{else}}-{{end}}</dd>
 				{{end}}
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.service_config"}}
+			{{.locale.Tr "admin.config.service_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.register_email_confirm"}}</dt>
+				<dt>{{.locale.Tr "admin.config.register_email_confirm"}}</dt>
 				<dd>{{if .Service.RegisterEmailConfirm}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.disable_register"}}</dt>
+				<dt>{{.locale.Tr "admin.config.disable_register"}}</dt>
 				<dd>{{if .Service.DisableRegistration}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.allow_only_internal_registration"}}</dt>
+				<dt>{{.locale.Tr "admin.config.allow_only_internal_registration"}}</dt>
 				<dd>{{if .Service.AllowOnlyInternalRegistration}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.allow_only_external_registration"}}</dt>
+				<dt>{{.locale.Tr "admin.config.allow_only_external_registration"}}</dt>
 				<dd>{{if .Service.AllowOnlyExternalRegistration}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.show_registration_button"}}</dt>
+				<dt>{{.locale.Tr "admin.config.show_registration_button"}}</dt>
 				<dd>{{if .Service.ShowRegistrationButton}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.enable_openid_signup"}}</dt>
+				<dt>{{.locale.Tr "admin.config.enable_openid_signup"}}</dt>
 				<dd>{{if .Service.EnableOpenIDSignUp}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.enable_openid_signin"}}</dt>
+				<dt>{{.locale.Tr "admin.config.enable_openid_signin"}}</dt>
 				<dd>{{if .Service.EnableOpenIDSignIn}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.require_sign_in_view"}}</dt>
+				<dt>{{.locale.Tr "admin.config.require_sign_in_view"}}</dt>
 				<dd>{{if .Service.RequireSignInView}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.mail_notify"}}</dt>
+				<dt>{{.locale.Tr "admin.config.mail_notify"}}</dt>
 				<dd>{{if .Service.EnableNotifyMail}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.disable_key_size_check"}}</dt>
+				<dt>{{.locale.Tr "admin.config.disable_key_size_check"}}</dt>
 				<dd>{{if .SSH.MinimumKeySizeCheck}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.enable_captcha"}}</dt>
+				<dt>{{.locale.Tr "admin.config.enable_captcha"}}</dt>
 				<dd>{{if .Service.EnableCaptcha}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.default_keep_email_private"}}</dt>
+				<dt>{{.locale.Tr "admin.config.default_keep_email_private"}}</dt>
 				<dd>{{if .Service.DefaultKeepEmailPrivate}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.default_allow_create_organization"}}</dt>
+				<dt>{{.locale.Tr "admin.config.default_allow_create_organization"}}</dt>
 				<dd>{{if .Service.DefaultAllowCreateOrganization}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.enable_timetracking"}}</dt>
+				<dt>{{.locale.Tr "admin.config.enable_timetracking"}}</dt>
 				<dd>{{if .Service.EnableTimetracking}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{if .Service.EnableTimetracking}}
-					<dt>{{.i18n.Tr "admin.config.default_enable_timetracking"}}</dt>
+					<dt>{{.locale.Tr "admin.config.default_enable_timetracking"}}</dt>
 					<dd>{{if .Service.DefaultEnableTimetracking}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-					<dt>{{.i18n.Tr "admin.config.default_allow_only_contributors_to_track_time"}}</dt>
+					<dt>{{.locale.Tr "admin.config.default_allow_only_contributors_to_track_time"}}</dt>
 					<dd>{{if .Service.DefaultAllowOnlyContributorsToTrackTime}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{end}}
-				<dt>{{.i18n.Tr "admin.config.default_visibility_organization"}}</dt>
+				<dt>{{.locale.Tr "admin.config.default_visibility_organization"}}</dt>
 				<dd>{{.Service.DefaultOrgVisibility}}</dd>
 
-				<dt>{{.i18n.Tr "admin.config.no_reply_address"}}</dt>
+				<dt>{{.locale.Tr "admin.config.no_reply_address"}}</dt>
 				<dd>{{if .Service.NoReplyAddress}}{{.Service.NoReplyAddress}}{{else}}-{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.default_enable_dependencies"}}</dt>
+				<dt>{{.locale.Tr "admin.config.default_enable_dependencies"}}</dt>
 				<dd>{{if .Service.DefaultEnableDependencies}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.config.active_code_lives"}}</dt>
-				<dd>{{.Service.ActiveCodeLives}} {{.i18n.Tr "tool.raw_minutes"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.reset_password_code_lives"}}</dt>
-				<dd>{{.Service.ResetPwdCodeLives}} {{.i18n.Tr "tool.raw_minutes"}}</dd>
+				<dt>{{.locale.Tr "admin.config.active_code_lives"}}</dt>
+				<dd>{{.Service.ActiveCodeLives}} {{.locale.Tr "tool.raw_minutes"}}</dd>
+				<dt>{{.locale.Tr "admin.config.reset_password_code_lives"}}</dt>
+				<dd>{{.Service.ResetPwdCodeLives}} {{.locale.Tr "tool.raw_minutes"}}</dd>
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.webhook_config"}}
+			{{.locale.Tr "admin.config.webhook_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.queue_length"}}</dt>
+				<dt>{{.locale.Tr "admin.config.queue_length"}}</dt>
 				<dd>{{.Webhook.QueueLength}}</dd>
-				<dt>{{.i18n.Tr "admin.config.deliver_timeout"}}</dt>
-				<dd>{{.Webhook.DeliverTimeout}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.skip_tls_verify"}}</dt>
+				<dt>{{.locale.Tr "admin.config.deliver_timeout"}}</dt>
+				<dd>{{.Webhook.DeliverTimeout}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.skip_tls_verify"}}</dt>
 				<dd>{{if .Webhook.SkipTLSVerify}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.mailer_config"}}
+			{{.locale.Tr "admin.config.mailer_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.mailer_enabled"}}</dt>
+				<dt>{{.locale.Tr "admin.config.mailer_enabled"}}</dt>
 				<dd>{{if .MailerEnabled}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{if .MailerEnabled}}
-					<dt>{{.i18n.Tr "admin.config.mailer_name"}}</dt>
+					<dt>{{.locale.Tr "admin.config.mailer_name"}}</dt>
 					<dd>{{.Mailer.Name}}</dd>
 					{{if eq .Mailer.MailerType "smtp"}}
-						<dt>{{.i18n.Tr "admin.config.mailer_disable_helo"}}</dt>
+						<dt>{{.locale.Tr "admin.config.mailer_disable_helo"}}</dt>
 						<dd>{{if .DisableHelo}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-						<dt>{{.i18n.Tr "admin.config.mailer_host"}}</dt>
+						<dt>{{.locale.Tr "admin.config.mailer_host"}}</dt>
 						<dd>{{.Mailer.Host}}</dd>
 					{{else if eq .Mailer.MailerType "sendmail"}}
-						<dt>{{.i18n.Tr "admin.config.mailer_use_sendmail"}}</dt>
+						<dt>{{.locale.Tr "admin.config.mailer_use_sendmail"}}</dt>
 						<dd>{{svg "octicon-check"}}</dd>
-						<dt>{{.i18n.Tr "admin.config.mailer_sendmail_path"}}</dt>
+						<dt>{{.locale.Tr "admin.config.mailer_sendmail_path"}}</dt>
 						<dd>{{.Mailer.SendmailPath}}</dd>
-						<dt>{{.i18n.Tr "admin.config.mailer_sendmail_args"}}</dt>
+						<dt>{{.locale.Tr "admin.config.mailer_sendmail_args"}}</dt>
 						<dd>{{.Mailer.SendmailArgs}}</dd>
-						<dt>{{.i18n.Tr "admin.config.mailer_sendmail_timeout"}}</dt>
-						<dd>{{.Mailer.SendmailTimeout}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
+						<dt>{{.locale.Tr "admin.config.mailer_sendmail_timeout"}}</dt>
+						<dd>{{.Mailer.SendmailTimeout}} {{.locale.Tr "tool.raw_seconds"}}</dd>
 					{{end}}
-					<dt>{{.i18n.Tr "admin.config.mailer_user"}}</dt>
+					<dt>{{.locale.Tr "admin.config.mailer_user"}}</dt>
 					<dd>{{if .Mailer.User}}{{.Mailer.User}}{{else}}(empty){{end}}</dd><br>
 					<form class="ui form ignore-dirty" action="{{AppSubUrl}}/admin/config/test_mail" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="inline field ui left">
 							<div class="ui input">
-								<input type="email" name="email" placeholder="{{.i18n.Tr "admin.config.test_email_placeholder"}}" size="29" required>
+								<input type="email" name="email" placeholder="{{.locale.Tr "admin.config.test_email_placeholder"}}" size="29" required>
 							</div>
 						</div>
-						<button class="ui green button" id="test-mail-btn">{{.i18n.Tr "admin.config.send_test_mail"}}</button>
+						<button class="ui green button" id="test-mail-btn">{{.locale.Tr "admin.config.send_test_mail"}}</button>
 					</form>
 				{{end}}
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.cache_config"}}
+			{{.locale.Tr "admin.config.cache_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.cache_adapter"}}</dt>
+				<dt>{{.locale.Tr "admin.config.cache_adapter"}}</dt>
 				<dd>{{.CacheAdapter}}</dd>
 				{{if eq .CacheAdapter "memory"}}
-					<dt>{{.i18n.Tr "admin.config.cache_interval"}}</dt>
-					<dd>{{.CacheInterval}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
+					<dt>{{.locale.Tr "admin.config.cache_interval"}}</dt>
+					<dd>{{.CacheInterval}} {{.locale.Tr "tool.raw_seconds"}}</dd>
 				{{end}}
 				{{if .CacheConn}}
-					<dt>{{.i18n.Tr "admin.config.cache_conn"}}</dt>
+					<dt>{{.locale.Tr "admin.config.cache_conn"}}</dt>
 					<dd><code>{{.CacheConn}}</code></dd>
-					<dt>{{.i18n.Tr "admin.config.cache_item_ttl"}}</dt>
+					<dt>{{.locale.Tr "admin.config.cache_item_ttl"}}</dt>
 					<dd><code>{{.CacheItemTTL}}</code></dd>
 				{{end}}
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.session_config"}}
+			{{.locale.Tr "admin.config.session_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.session_provider"}}</dt>
+				<dt>{{.locale.Tr "admin.config.session_provider"}}</dt>
 				<dd>{{.SessionConfig.Provider}}</dd>
-				<dt>{{.i18n.Tr "admin.config.provider_config"}}</dt>
+				<dt>{{.locale.Tr "admin.config.provider_config"}}</dt>
 				<dd><code>{{if .SessionConfig.ProviderConfig}}{{.SessionConfig.ProviderConfig}}{{else}}-{{end}}</code></dd>
-				<dt>{{.i18n.Tr "admin.config.cookie_name"}}</dt>
+				<dt>{{.locale.Tr "admin.config.cookie_name"}}</dt>
 				<dd>{{.SessionConfig.CookieName}}</dd>
-				<dt>{{.i18n.Tr "admin.config.gc_interval_time"}}</dt>
-				<dd>{{.SessionConfig.Gclifetime}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.session_life_time"}}</dt>
-				<dd>{{.SessionConfig.Maxlifetime}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.https_only"}}</dt>
+				<dt>{{.locale.Tr "admin.config.gc_interval_time"}}</dt>
+				<dd>{{.SessionConfig.Gclifetime}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.session_life_time"}}</dt>
+				<dd>{{.SessionConfig.Maxlifetime}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.https_only"}}</dt>
 				<dd>{{if .SessionConfig.Secure}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.picture_config"}}
+			{{.locale.Tr "admin.config.picture_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.disable_gravatar"}}</dt>
+				<dt>{{.locale.Tr "admin.config.disable_gravatar"}}</dt>
 				<dd>{{if .DisableGravatar}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.config.enable_federated_avatar"}}</dt>
+				<dt>{{.locale.Tr "admin.config.enable_federated_avatar"}}</dt>
 				<dd>{{if .EnableFederatedAvatar}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.git_config"}}
+			{{.locale.Tr "admin.config.git_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.config.git_disable_diff_highlight"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_disable_diff_highlight"}}</dt>
 				<dd>{{if .Git.DisableDiffHighlight}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_max_diff_lines"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_max_diff_lines"}}</dt>
 				<dd>{{.Git.MaxGitDiffLines}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_max_diff_line_characters"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_max_diff_line_characters"}}</dt>
 				<dd>{{.Git.MaxGitDiffLineCharacters}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_max_diff_files"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_max_diff_files"}}</dt>
 				<dd>{{.Git.MaxGitDiffFiles}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_gc_args"}}</dt>
+				<dt>{{.locale.Tr "admin.config.git_gc_args"}}</dt>
 				<dd><code>{{.Git.GCArgs}}</code></dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.config.git_migrate_timeout"}}</dt>
-				<dd>{{.Git.Timeout.Migrate}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_mirror_timeout"}}</dt>
-				<dd>{{.Git.Timeout.Mirror}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_clone_timeout"}}</dt>
-				<dd>{{.Git.Timeout.Clone}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_pull_timeout"}}</dt>
-				<dd>{{.Git.Timeout.Pull}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.i18n.Tr "admin.config.git_gc_timeout"}}</dt>
-				<dd>{{.Git.Timeout.GC}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.git_migrate_timeout"}}</dt>
+				<dd>{{.Git.Timeout.Migrate}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.git_mirror_timeout"}}</dt>
+				<dd>{{.Git.Timeout.Mirror}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.git_clone_timeout"}}</dt>
+				<dd>{{.Git.Timeout.Clone}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.git_pull_timeout"}}</dt>
+				<dd>{{.Git.Timeout.Pull}} {{.locale.Tr "tool.raw_seconds"}}</dd>
+				<dt>{{.locale.Tr "admin.config.git_gc_timeout"}}</dt>
+				<dd>{{.Git.Timeout.GC}} {{.locale.Tr "tool.raw_seconds"}}</dd>
 			</dl>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.config.log_config"}}
+			{{.locale.Tr "admin.config.log_config"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
 				{{range .Loggers.default.SubLogDescriptions}}
-					<dt>{{$.i18n.Tr "admin.config.log_mode"}}</dt>
+					<dt>{{$.locale.Tr "admin.config.log_mode"}}</dt>
 					<dd>{{.Name}} ({{.Provider}})</dd>
-					<dt>{{$.i18n.Tr "admin.config.log_config"}}</dt>
+					<dt>{{$.locale.Tr "admin.config.log_config"}}</dt>
 					<dd><pre>{{.Config | JsonPrettyPrint}}</pre></dd>
 				{{end}}
 				<div class="ui divider"></div>
-				<dt>{{$.i18n.Tr "admin.config.router_log_mode"}}</dt>
+				<dt>{{$.locale.Tr "admin.config.router_log_mode"}}</dt>
 				{{if .DisableRouterLog}}
-					<dd>{{$.i18n.Tr "admin.config.disabled_logger"}}</dd>
+					<dd>{{$.locale.Tr "admin.config.disabled_logger"}}</dd>
 				{{else}}
 					{{if .Loggers.router.SubLogDescriptions}}
-						<dd>{{$.i18n.Tr "admin.config.own_named_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.own_named_logger"}}</dd>
 						{{range .Loggers.router.SubLogDescriptions}}
-							<dt>{{$.i18n.Tr "admin.config.log_mode"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_mode"}}</dt>
 							<dd>{{.Name}} ({{.Provider}})</dd>
-							<dt>{{$.i18n.Tr "admin.config.log_config"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_config"}}</dt>
 							<dd><pre>{{.Config | JsonPrettyPrint}}</pre></dd>
 						{{end}}
 					{{else}}
-						<dd>{{$.i18n.Tr "admin.config.routes_to_default_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.routes_to_default_logger"}}</dd>
 					{{end}}
 				{{end}}
 				<div class="ui divider"></div>
-				<dt>{{$.i18n.Tr "admin.config.access_log_mode"}}</dt>
+				<dt>{{$.locale.Tr "admin.config.access_log_mode"}}</dt>
 				{{if .EnableAccessLog}}
 					{{if .Loggers.access.SubLogDescriptions}}
-						<dd>{{$.i18n.Tr "admin.config.own_named_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.own_named_logger"}}</dd>
 						{{range .Loggers.access.SubLogDescriptions}}
-							<dt>{{$.i18n.Tr "admin.config.log_mode"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_mode"}}</dt>
 							<dd>{{.Name}} ({{.Provider}})</dd>
-							<dt>{{$.i18n.Tr "admin.config.log_config"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_config"}}</dt>
 							<dd><pre>{{.Config | JsonPrettyPrint}}</pre></dd>
 						{{end}}
 					{{else}}
-						<dd>{{$.i18n.Tr "admin.config.routes_to_default_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.routes_to_default_logger"}}</dd>
 					{{end}}
-					<dt>{{$.i18n.Tr "admin.config.access_log_template"}}</dt>
+					<dt>{{$.locale.Tr "admin.config.access_log_template"}}</dt>
 					<dd><code>{{$.AccessLogTemplate}}</code></dd>
 				{{else}}
-					<dd>{{$.i18n.Tr "admin.config.disabled_logger"}}</dd>
+					<dd>{{$.locale.Tr "admin.config.disabled_logger"}}</dd>
 				{{end}}
 				<div class="ui divider"></div>
-				<dt>{{$.i18n.Tr "admin.config.xorm_log_mode"}}</dt>
+				<dt>{{$.locale.Tr "admin.config.xorm_log_mode"}}</dt>
 				{{if .EnableXORMLog}}
 					{{if .Loggers.xorm.SubLogDescriptions}}
-						<dd>{{$.i18n.Tr "admin.config.own_named_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.own_named_logger"}}</dd>
 						{{range .Loggers.xorm.SubLogDescriptions}}
-							<dt>{{$.i18n.Tr "admin.config.log_mode"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_mode"}}</dt>
 							<dd>{{.Name}} ({{.Provider}})</dd>
-							<dt>{{$.i18n.Tr "admin.config.log_config"}}</dt>
+							<dt>{{$.locale.Tr "admin.config.log_config"}}</dt>
 							<dd><pre>{{.Config | JsonPrettyPrint}}</pre></dd>
 						{{end}}
 					{{else}}
-						<dd>{{$.i18n.Tr "admin.config.routes_to_default_logger"}}</dd>
+						<dd>{{$.locale.Tr "admin.config.routes_to_default_logger"}}</dd>
 					{{end}}
-					<dt>{{$.i18n.Tr "admin.config.xorm_log_sql"}}</dt>
+					<dt>{{$.locale.Tr "admin.config.xorm_log_sql"}}</dt>
 					<dd>{{if $.LogSQL}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{else}}
-					<dd>{{$.i18n.Tr "admin.config.disabled_logger"}}</dd>
+					<dd>{{$.locale.Tr "admin.config.disabled_logger"}}</dd>
 				{{end}}
 			</dl>
 		</div>

--- a/templates/admin/cron.tmpl
+++ b/templates/admin/cron.tmpl
@@ -1,5 +1,5 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "admin.monitor.cron"}}
+	{{.locale.Tr "admin.monitor.cron"}}
 </h4>
 <div class="ui attached table segment">
 	<form method="post" action="{{AppSubUrl}}/admin">
@@ -7,24 +7,24 @@
 			<thead>
 				<tr>
 					<th></th>
-					<th>{{.i18n.Tr "admin.monitor.name"}}</th>
-					<th>{{.i18n.Tr "admin.monitor.schedule"}}</th>
-					<th>{{.i18n.Tr "admin.monitor.next"}}</th>
-					<th>{{.i18n.Tr "admin.monitor.previous"}}</th>
-					<th>{{.i18n.Tr "admin.monitor.execute_times"}}</th>
-					<th>{{.i18n.Tr "admin.monitor.last_execution_result"}}</th>
+					<th>{{.locale.Tr "admin.monitor.name"}}</th>
+					<th>{{.locale.Tr "admin.monitor.schedule"}}</th>
+					<th>{{.locale.Tr "admin.monitor.next"}}</th>
+					<th>{{.locale.Tr "admin.monitor.previous"}}</th>
+					<th>{{.locale.Tr "admin.monitor.execute_times"}}</th>
+					<th>{{.locale.Tr "admin.monitor.last_execution_result"}}</th>
 				</tr>
 			</thead>
 			<tbody>
 				{{range .Entries}}
 					<tr>
-						<td><button type="submit" class="ui green button" name="op" value="{{.Name}}" title="{{$.i18n.Tr "admin.dashboard.operation_run"}}">{{svg "octicon-triangle-right"}}</button></td>
-						<td>{{$.i18n.Tr (printf "admin.dashboard.%s" .Name)}}</td>
+						<td><button type="submit" class="ui green button" name="op" value="{{.Name}}" title="{{$.locale.Tr "admin.dashboard.operation_run"}}">{{svg "octicon-triangle-right"}}</button></td>
+						<td>{{$.locale.Tr (printf "admin.dashboard.%s" .Name)}}</td>
 						<td>{{.Spec}}</td>
 						<td>{{DateFmtLong .Next}}</td>
 						<td>{{if gt .Prev.Year 1 }}{{DateFmtLong .Prev}}{{else}}N/A{{end}}</td>
 						<td>{{.ExecTimes}}</td>
-						<td {{if ne .Status ""}}class="tooltip" data-content="{{.FormatLastMessage $.i18n}}"{{end}} >{{if eq .Status "" }}—{{else if eq .Status "finished"}}{{svg "octicon-check" 16}}{{else}}{{svg "octicon-x" 16}}{{end}}</td>
+						<td {{if ne .Status ""}}class="tooltip" data-content="{{.FormatLastMessage $.locale}}"{{end}} >{{if eq .Status "" }}—{{else if eq .Status "finished"}}{{svg "octicon-check" 16}}{{else}}{{svg "octicon-x" 16}}{{end}}</td>
 					</tr>
 				{{end}}
 			</tbody>

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -5,19 +5,19 @@
 		{{template "base/alert" .}}
 		{{if .NeedUpdate}}
 			<div class="ui negative message flash-error">
-				<p>{{(.i18n.Tr "admin.dashboard.new_version_hint" .RemoteVersion AppVer) | Str2html}}</p>
+				<p>{{(.locale.Tr "admin.dashboard.new_version_hint" .RemoteVersion AppVer) | Str2html}}</p>
 			</div>
 		{{end}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.dashboard.statistic"}}
+			{{.locale.Tr "admin.dashboard.statistic"}}
 		</h4>
 		<div class="ui attached segment">
 			<p>
-				{{.i18n.Tr "admin.dashboard.statistic_info" .Stats.Counter.User .Stats.Counter.Org .Stats.Counter.PublicKey .Stats.Counter.Repo .Stats.Counter.Watch .Stats.Counter.Star .Stats.Counter.Action .Stats.Counter.Access .Stats.Counter.Issue .Stats.Counter.Comment .Stats.Counter.Oauth .Stats.Counter.Follow .Stats.Counter.Mirror .Stats.Counter.Release .Stats.Counter.AuthSource .Stats.Counter.Webhook .Stats.Counter.Milestone .Stats.Counter.Label .Stats.Counter.HookTask .Stats.Counter.Team .Stats.Counter.UpdateTask .Stats.Counter.Attachment | Str2html}}
+				{{.locale.Tr "admin.dashboard.statistic_info" .Stats.Counter.User .Stats.Counter.Org .Stats.Counter.PublicKey .Stats.Counter.Repo .Stats.Counter.Watch .Stats.Counter.Star .Stats.Counter.Action .Stats.Counter.Access .Stats.Counter.Issue .Stats.Counter.Comment .Stats.Counter.Oauth .Stats.Counter.Follow .Stats.Counter.Mirror .Stats.Counter.Release .Stats.Counter.AuthSource .Stats.Counter.Webhook .Stats.Counter.Milestone .Stats.Counter.Label .Stats.Counter.HookTask .Stats.Counter.Team .Stats.Counter.UpdateTask .Stats.Counter.Attachment | Str2html}}
 			</p>
 		</div>
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.dashboard.operations"}}
+			{{.locale.Tr "admin.dashboard.operations"}}
 		</h4>
 		<form method="post" action="{{AppSubUrl}}/admin">
 			{{.CsrfTokenHtml}}
@@ -25,52 +25,52 @@
 				<table class="ui very basic table">
 					<tbody>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.delete_inactive_accounts"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_inactive_accounts">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.delete_inactive_accounts"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_inactive_accounts">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.delete_repo_archives"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_repo_archives">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.delete_repo_archives"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_repo_archives">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.delete_missing_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_missing_repos">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.delete_missing_repos"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_missing_repos">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.git_gc_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="git_gc_repos">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.git_gc_repos"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="git_gc_repos">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						{{if and (not .SSH.Disabled) (not .SSH.StartBuiltinServer)}}
 							<tr>
-								<td>{{.i18n.Tr "admin.dashboard.resync_all_sshkeys"}}<br/>
-								{{.i18n.Tr "admin.dashboard.resync_all_sshkeys.desc"}}</td>
-								<td><button type="submit" class="ui green button" name="op" value="resync_all_sshkeys">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+								<td>{{.locale.Tr "admin.dashboard.resync_all_sshkeys"}}<br/>
+								{{.locale.Tr "admin.dashboard.resync_all_sshkeys.desc"}}</td>
+								<td><button type="submit" class="ui green button" name="op" value="resync_all_sshkeys">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 							</tr>
 							<tr>
-								<td>{{.i18n.Tr "admin.dashboard.resync_all_sshprincipals"}}<br/>
-								{{.i18n.Tr "admin.dashboard.resync_all_sshprincipals.desc"}}</td>
-								<td><button type="submit" class="ui green button" name="op" value="resync_all_sshprincipals">{{svg "octicon-play" 16}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+								<td>{{.locale.Tr "admin.dashboard.resync_all_sshprincipals"}}<br/>
+								{{.locale.Tr "admin.dashboard.resync_all_sshprincipals.desc"}}</td>
+								<td><button type="submit" class="ui green button" name="op" value="resync_all_sshprincipals">{{svg "octicon-play" 16}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 							</tr>
 						{{end}}
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.resync_all_hooks"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="resync_all_hooks">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.resync_all_hooks"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="resync_all_hooks">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.reinit_missing_repos"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="reinit_missing_repos">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.reinit_missing_repos"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="reinit_missing_repos">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.sync_external_users"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="sync_external_users">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.sync_external_users"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="sync_external_users">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.repo_health_check"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="repo_health_check">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.repo_health_check"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="repo_health_check">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
-							<td>{{.i18n.Tr "admin.dashboard.delete_generated_repository_avatars"}}</td>
-							<td><button type="submit" class="ui green button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-play"}} {{.i18n.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td>{{.locale.Tr "admin.dashboard.delete_generated_repository_avatars"}}</td>
+							<td><button type="submit" class="ui green button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-play"}} {{.locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 					</tbody>
 				</table>
@@ -78,69 +78,69 @@
 		</form>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.dashboard.system_status"}}
+			{{.locale.Tr "admin.dashboard.system_status"}}
 		</h4>
 		<div class="ui attached table segment">
 			<dl class="dl-horizontal admin-dl-horizontal">
-				<dt>{{.i18n.Tr "admin.dashboard.server_uptime"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.server_uptime"}}</dt>
 				<dd>{{.SysStatus.Uptime}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.current_goroutine"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.current_goroutine"}}</dt>
 				<dd>{{.SysStatus.NumGoroutine}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.dashboard.current_memory_usage"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.current_memory_usage"}}</dt>
 				<dd>{{.SysStatus.MemAllocated}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.total_memory_allocated"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.total_memory_allocated"}}</dt>
 				<dd>{{.SysStatus.MemTotal}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.memory_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.memory_obtained"}}</dt>
 				<dd>{{.SysStatus.MemSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.pointer_lookup_times"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.pointer_lookup_times"}}</dt>
 				<dd>{{.SysStatus.Lookups}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.memory_allocate_times"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.memory_allocate_times"}}</dt>
 				<dd>{{.SysStatus.MemMallocs}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.memory_free_times"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.memory_free_times"}}</dt>
 				<dd>{{.SysStatus.MemFrees}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.dashboard.current_heap_usage"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.current_heap_usage"}}</dt>
 				<dd>{{.SysStatus.HeapAlloc}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.heap_memory_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.heap_memory_obtained"}}</dt>
 				<dd>{{.SysStatus.HeapSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.heap_memory_idle"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.heap_memory_idle"}}</dt>
 				<dd>{{.SysStatus.HeapIdle}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.heap_memory_in_use"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.heap_memory_in_use"}}</dt>
 				<dd>{{.SysStatus.HeapInuse}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.heap_memory_released"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.heap_memory_released"}}</dt>
 				<dd>{{.SysStatus.HeapReleased}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.heap_objects"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.heap_objects"}}</dt>
 				<dd>{{.SysStatus.HeapObjects}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.dashboard.bootstrap_stack_usage"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.bootstrap_stack_usage"}}</dt>
 				<dd>{{.SysStatus.StackInuse}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.stack_memory_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.stack_memory_obtained"}}</dt>
 				<dd>{{.SysStatus.StackSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.mspan_structures_usage"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.mspan_structures_usage"}}</dt>
 				<dd>{{.SysStatus.MSpanInuse}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.mspan_structures_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.mspan_structures_obtained"}}</dt>
 				<dd>{{.SysStatus.MSpanSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.mcache_structures_usage"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.mcache_structures_usage"}}</dt>
 				<dd>{{.SysStatus.MCacheInuse}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.mcache_structures_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.mcache_structures_obtained"}}</dt>
 				<dd>{{.SysStatus.MCacheSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.profiling_bucket_hash_table_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.profiling_bucket_hash_table_obtained"}}</dt>
 				<dd>{{.SysStatus.BuckHashSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.gc_metadata_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.gc_metadata_obtained"}}</dt>
 				<dd>{{.SysStatus.GCSys}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.other_system_allocation_obtained"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.other_system_allocation_obtained"}}</dt>
 				<dd>{{.SysStatus.OtherSys}}</dd>
 				<div class="ui divider"></div>
-				<dt>{{.i18n.Tr "admin.dashboard.next_gc_recycle"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.next_gc_recycle"}}</dt>
 				<dd>{{.SysStatus.NextGC}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.last_gc_time"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.last_gc_time"}}</dt>
 				<dd>{{.SysStatus.LastGC}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.total_gc_pause"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.total_gc_pause"}}</dt>
 				<dd>{{.SysStatus.PauseTotalNs}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.last_gc_pause"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.last_gc_pause"}}</dt>
 				<dd>{{.SysStatus.PauseNs}}</dd>
-				<dt>{{.i18n.Tr "admin.dashboard.gc_times"}}</dt>
+				<dt>{{.locale.Tr "admin.dashboard.gc_times"}}</dt>
 				<dd>{{.SysStatus.NumGC}}</dd>
 			</dl>
 		</div>

--- a/templates/admin/emails/list.tmpl
+++ b/templates/admin/emails/list.tmpl
@@ -4,28 +4,28 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.emails.email_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.emails.email_manage_panel"}} ({{.locale.Tr "admin.total" .Total}})
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui right floated secondary filter menu">
 			<!-- Sort -->
 				<div class="ui dropdown type jump item">
 					<span class="text">
-						{{.i18n.Tr "repo.issues.filter_sort"}}
+						{{.locale.Tr "repo.issues.filter_sort"}}
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 					</span>
 					<div class="menu">
-						<a class="{{if or (eq .SortType "email") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=email&q={{$.Keyword}}">{{.i18n.Tr "admin.emails.filter_sort.email"}}</a>
-						<a class="{{if eq .SortType "reverseemail"}}active{{end}} item" href="{{$.Link}}?sort=reverseemail&q={{$.Keyword}}">{{.i18n.Tr "admin.emails.filter_sort.email_reverse"}}</a>
-						<a class="{{if eq .SortType "username"}}active{{end}} item" href="{{$.Link}}?sort=username&q={{$.Keyword}}">{{.i18n.Tr "admin.emails.filter_sort.name"}}</a>
-						<a class="{{if eq .SortType "reverseusername"}}active{{end}} item" href="{{$.Link}}?sort=reverseusername&q={{$.Keyword}}">{{.i18n.Tr "admin.emails.filter_sort.name_reverse"}}</a>
+						<a class="{{if or (eq .SortType "email") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=email&q={{$.Keyword}}">{{.locale.Tr "admin.emails.filter_sort.email"}}</a>
+						<a class="{{if eq .SortType "reverseemail"}}active{{end}} item" href="{{$.Link}}?sort=reverseemail&q={{$.Keyword}}">{{.locale.Tr "admin.emails.filter_sort.email_reverse"}}</a>
+						<a class="{{if eq .SortType "username"}}active{{end}} item" href="{{$.Link}}?sort=username&q={{$.Keyword}}">{{.locale.Tr "admin.emails.filter_sort.name"}}</a>
+						<a class="{{if eq .SortType "reverseusername"}}active{{end}} item" href="{{$.Link}}?sort=reverseusername&q={{$.Keyword}}">{{.locale.Tr "admin.emails.filter_sort.name_reverse"}}</a>
 					</div>
 				</div>
 			</div>
 			<form class="ui form ignore-dirty"  style="max-width: 90%">
 				<div class="ui fluid action input">
-					<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-					<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+					<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+					<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 				</div>
 			</form>
 		</div>
@@ -34,16 +34,16 @@
 				<thead>
 					<tr>
 						<th data-sortt-asc="username" data-sortt-desc="reverseusername">
-							{{.i18n.Tr "admin.users.name"}}
+							{{.locale.Tr "admin.users.name"}}
 							{{SortArrow "username" "reverseusername" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.users.full_name"}}</th>
+						<th>{{.locale.Tr "admin.users.full_name"}}</th>
 						<th data-sortt-asc="email" data-sortt-desc="reverseemail" data-sortt-default="true">
-							{{.i18n.Tr "email"}}
+							{{.locale.Tr "email"}}
 							{{SortArrow "email" "reverseemail" $.SortType true}}
 						</th>
-						<th>{{.i18n.Tr "admin.emails.primary"}}</th>
-						<th>{{.i18n.Tr "admin.emails.activated"}}</th>
+						<th>{{.locale.Tr "admin.emails.primary"}}</th>
+						<th>{{.locale.Tr "admin.emails.activated"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -75,10 +75,10 @@
 
 		<div class="ui basic modal" id="change-email-modal">
 			<div class="ui icon header">
-				{{.i18n.Tr "admin.emails.change_email_header"}}
+				{{.locale.Tr "admin.emails.change_email_header"}}
 			</div>
 			<div class="content center">
-				<p>{{.i18n.Tr "admin.emails.change_email_text"}}</p>
+				<p>{{.locale.Tr "admin.emails.change_email_text"}}</p>
 
 				<form class="ui form" id="email-action-form" action="{{AppSubUrl}}/admin/emails/activate" method="post">
 					{{$.CsrfTokenHtml}}
@@ -94,8 +94,8 @@
 					<input type="hidden" id="form-activate" name="activate" value="" required>
 
 					<div class="center actions">
-						<div class="ui basic cancel inverted button">{{$.i18n.Tr "settings.cancel"}}</div>
-						<button class="ui basic inverted yellow button">{{$.i18n.Tr "modal.yes"}}</button>
+						<div class="ui basic cancel inverted button">{{$.locale.Tr "settings.cancel"}}</div>
+						<button class="ui basic inverted yellow button">{{$.locale.Tr "modal.yes"}}</button>
 					</div>
 
 				</form>

--- a/templates/admin/hook_new.tmpl
+++ b/templates/admin/hook_new.tmpl
@@ -5,13 +5,13 @@
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
 			{{if .PageIsAdminDefaultHooksNew}}
-				{{.i18n.Tr "admin.defaulthooks.add_webhook"}}
+				{{.locale.Tr "admin.defaulthooks.add_webhook"}}
 			{{else if .PageIsAdminSystemHooksNew}}
-				{{.i18n.Tr "admin.systemhooks.add_webhook"}}
+				{{.locale.Tr "admin.systemhooks.add_webhook"}}
 			{{else if .Webhook.IsSystemWebhook}}
-				{{.i18n.Tr "admin.systemhooks.update_webhook"}}
+				{{.locale.Tr "admin.systemhooks.update_webhook"}}
 			{{else}}
-				{{.i18n.Tr "admin.defaulthooks.update_webhook"}}
+				{{.locale.Tr "admin.defaulthooks.update_webhook"}}
 			{{end}}
 			<div class="ui right">
 				{{if eq .HookType "gitea"}}

--- a/templates/admin/monitor.tmpl
+++ b/templates/admin/monitor.tmpl
@@ -5,17 +5,17 @@
 		{{template "base/alert" .}}
 		{{template "admin/cron" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queues"}}
+			{{.locale.Tr "admin.monitor.queues"}}
 		</h4>
 		<div class="ui attached table segment">
 			<table class="ui very basic striped table unstackable">
 				<thead>
 					<tr>
-						<th>{{.i18n.Tr "admin.monitor.queue.name"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.type"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.exemplar"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.numberworkers"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.numberinqueue"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.name"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.type"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.exemplar"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.numberworkers"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.numberinqueue"}}</th>
 						<th></th>
 					</tr>
 				</thead>
@@ -27,7 +27,7 @@
 							<td>{{.ExemplarType}}</td>
 							<td>{{$sum := .NumberOfWorkers}}{{if lt $sum 0}}-{{else}}{{$sum}}{{end}}</td>
 							<td>{{$sum := .NumberInQueue}}{{if lt $sum 0}}-{{else}}{{$sum}}{{end}}</td>
-							<td><a href="{{$.Link}}/queue/{{.QID}}" class="button">{{if lt $sum 0}}{{$.i18n.Tr "admin.monitor.queue.review"}}{{else}}{{$.i18n.Tr "admin.monitor.queue.review_add"}}{{end}}</a>
+							<td><a href="{{$.Link}}/queue/{{.QID}}" class="button">{{if lt $sum 0}}{{$.locale.Tr "admin.monitor.queue.review"}}{{else}}{{$.locale.Tr "admin.monitor.queue.review_add"}}{{end}}</a>
 						</tr>
 					{{end}}
 				</tbody>
@@ -40,11 +40,11 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{.i18n.Tr "admin.monitor.process.cancel"}}
+		{{.locale.Tr "admin.monitor.process.cancel"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "admin.monitor.process.cancel_notices" `<span class="name"></span>` | Safe}}</p>
-		<p>{{$.i18n.Tr "admin.monitor.process.cancel_desc"}}</p>
+		<p>{{$.locale.Tr "admin.monitor.process.cancel_notices" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "admin.monitor.process.cancel_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/navbar.tmpl
+++ b/templates/admin/navbar.tmpl
@@ -1,39 +1,39 @@
 <div class="ui secondary pointing tabular top attached borderless menu stackable new-menu navbar">
 	<div class="new-menu-inner">
 		<a class="{{if .PageIsAdminDashboard}}active{{end}} item" href="{{AppSubUrl}}/admin">
-			{{.i18n.Tr "admin.dashboard"}}
+			{{.locale.Tr "admin.dashboard"}}
 		</a>
 		<a class="{{if .PageIsAdminUsers}}active{{end}} item" href="{{AppSubUrl}}/admin/users">
-			{{.i18n.Tr "admin.users"}}
+			{{.locale.Tr "admin.users"}}
 		</a>
 		<a class="{{if .PageIsAdminOrganizations}}active{{end}} item" href="{{AppSubUrl}}/admin/orgs">
-			{{.i18n.Tr "admin.organizations"}}
+			{{.locale.Tr "admin.organizations"}}
 		</a>
 		<a class="{{if .PageIsAdminRepositories}}active{{end}} item" href="{{AppSubUrl}}/admin/repos">
-			{{.i18n.Tr "admin.repositories"}}
+			{{.locale.Tr "admin.repositories"}}
 		</a>
 		<a class="{{if .PageIsAdminPackages}}active{{end}} item" href="{{AppSubUrl}}/admin/packages">
-			{{.i18n.Tr "packages.title"}}
+			{{.locale.Tr "packages.title"}}
 		</a>
 		{{if not DisableWebhooks}}
 			<a class="{{if or .PageIsAdminDefaultHooks .PageIsAdminSystemHooks}}active{{end}} item" href="{{AppSubUrl}}/admin/hooks">
-				{{.i18n.Tr "admin.hooks"}}
+				{{.locale.Tr "admin.hooks"}}
 			</a>
 		{{end}}
 		<a class="{{if .PageIsAdminAuthentications}}active{{end}} item" href="{{AppSubUrl}}/admin/auths">
-			{{.i18n.Tr "admin.authentication"}}
+			{{.locale.Tr "admin.authentication"}}
 		</a>
 		<a class="{{if .PageIsAdminEmails}}active{{end}} item" href="{{AppSubUrl}}/admin/emails">
-			{{.i18n.Tr "admin.emails"}}
+			{{.locale.Tr "admin.emails"}}
 		</a>
 		<a class="{{if .PageIsAdminConfig}}active{{end}} item" href="{{AppSubUrl}}/admin/config">
-			{{.i18n.Tr "admin.config"}}
+			{{.locale.Tr "admin.config"}}
 		</a>
 		<a class="{{if .PageIsAdminNotices}}active{{end}} item" href="{{AppSubUrl}}/admin/notices">
-			{{.i18n.Tr "admin.notices"}}
+			{{.locale.Tr "admin.notices"}}
 		</a>
 		<a class="{{if .PageIsAdminMonitor}}active{{end}} item" href="{{AppSubUrl}}/admin/monitor">
-			{{.i18n.Tr "admin.monitor"}}
+			{{.locale.Tr "admin.monitor"}}
 		</a>
 	</div>
 </div>

--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.notices.system_notice_list"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.notices.system_notice_list"}} ({{.locale.Tr "admin.total" .Total}})
 		</h4>
 		<div class="ui attached table segment">
 			<table id="notice-table" class="ui very basic select selectable table unstackable">
@@ -12,10 +12,10 @@
 					<tr>
 						<th></th>
 						<th>ID</th>
-						<th>{{.i18n.Tr "admin.notices.type"}}</th>
-						<th>{{.i18n.Tr "admin.notices.desc"}}</th>
-						<th width="100px">{{.i18n.Tr "admin.users.created"}}</th>
-						<th>{{.i18n.Tr "admin.notices.op"}}</th>
+						<th>{{.locale.Tr "admin.notices.type"}}</th>
+						<th>{{.locale.Tr "admin.notices.desc"}}</th>
+						<th width="100px">{{.locale.Tr "admin.users.created"}}</th>
+						<th>{{.locale.Tr "admin.notices.op"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -27,7 +27,7 @@
 								</div>
 							</td>
 							<td>{{.ID}}</td>
-							<td>{{$.i18n.Tr .TrStr}}</td>
+							<td>{{$.locale.Tr .TrStr}}</td>
 							<td class="view-detail"><span class="notice-description text truncate">{{.Description}}</span></td>
 							<td><span class="notice-created-time tooltip" data-content="{{.CreatedUnix.AsTime}}">{{.CreatedUnix.FormatShort}}</span></td>
 							<td><a href="#">{{svg "octicon-note" 16 "view-detail"}}</a></td>
@@ -42,25 +42,25 @@
 									<div class="ui right">
 										<form method="post" action="{{AppSubUrl}}/admin/notices/empty">
 											{{.CsrfTokenHtml}}
-											<button type="submit" class="ui red small button">{{.i18n.Tr "admin.notices.delete_all"}}</button>
+											<button type="submit" class="ui red small button">{{.locale.Tr "admin.notices.delete_all"}}</button>
 										</form>
 									</div>
 									<div class="ui floating upward dropdown small button">
-										<span class="text">{{.i18n.Tr "admin.notices.actions"}}</span>
+										<span class="text">{{.locale.Tr "admin.notices.actions"}}</span>
 										<div class="menu">
 											<div class="item select action" data-action="select-all">
-												{{.i18n.Tr "admin.notices.select_all"}}
+												{{.locale.Tr "admin.notices.select_all"}}
 											</div>
 											<div class="item select action" data-action="deselect-all">
-												{{.i18n.Tr "admin.notices.deselect_all"}}
+												{{.locale.Tr "admin.notices.deselect_all"}}
 											</div>
 											<div class="item select action" data-action="inverse">
-												{{.i18n.Tr "admin.notices.inverse_selection"}}
+												{{.locale.Tr "admin.notices.inverse_selection"}}
 											</div>
 										</div>
 									</div>
 									<div class="ui small teal button" id="delete-selection" data-link="{{.Link}}/delete" data-redirect="{{.Link}}?page={{.Page.Paginater.Current}}">
-										{{.i18n.Tr "admin.notices.delete_selected"}}
+										{{.locale.Tr "admin.notices.delete_selected"}}
 									</div>
 								</th>
 							</tr>
@@ -75,7 +75,7 @@
 
 <div class="ui modal admin" id="detail-modal">
 	{{svg "octicon-x" 16 "close inside"}}
-	<div class="header">{{$.i18n.Tr "admin.notices.view_detail_header"}}</div>
+	<div class="header">{{$.locale.Tr "admin.notices.view_detail_header"}}</div>
 	<div class="content">
 		<div class="sub header"></div>
 		<pre></pre>

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -4,9 +4,9 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.orgs.org_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.orgs.org_manage_panel"}} ({{.locale.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/org/create">{{.i18n.Tr "admin.orgs.new_orga"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/org/create">{{.locale.Tr "admin.orgs.new_orga"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached segment">
@@ -18,17 +18,17 @@
 					<tr>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">ID{{SortArrow "oldest" "newest" $.SortType false}}</th>
 						<th data-sortt-asc="alphabetically" data-sortt-desc="reversealphabetically" data-sortt-default="true">
-							{{.i18n.Tr "admin.orgs.name"}}
+							{{.locale.Tr "admin.orgs.name"}}
 							{{SortArrow "alphabetically" "reversealphabetically" $.SortType true}}
 						</th>
-						<th>{{.i18n.Tr "admin.orgs.teams"}}</th>
-						<th>{{.i18n.Tr "admin.orgs.members"}}</th>
-						<th>{{.i18n.Tr "admin.users.repos"}}</th>
+						<th>{{.locale.Tr "admin.orgs.teams"}}</th>
+						<th>{{.locale.Tr "admin.orgs.members"}}</th>
+						<th>{{.locale.Tr "admin.users.repos"}}</th>
 						<th data-sortt-asc="recentupdate" data-sortt-desc="leastupdate">
-							{{.i18n.Tr "admin.users.created"}}
+							{{.locale.Tr "admin.users.created"}}
 							{{SortArrow "recentupdate" "leastupdate" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.users.edit"}}</th>
+						<th>{{.locale.Tr "admin.users.edit"}}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/templates/admin/packages/list.tmpl
+++ b/templates/admin/packages/list.tmpl
@@ -4,15 +4,15 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.packages.package_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}}, {{.i18n.Tr "admin.packages.total_size" (FileSize .TotalBlobSize)}})
+			{{.locale.Tr "admin.packages.package_manage_panel"}} ({{.locale.Tr "admin.total" .Total}}, {{.locale.Tr "admin.packages.total_size" (FileSize .TotalBlobSize)}})
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form ignore-dirty">
 				<div class="ui fluid action input">
-					<input name="q" value="{{.Query}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+					<input name="q" value="{{.Query}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
 					<select class="ui dropdown" name="type">
-						<option value="">{{.i18n.Tr "packages.filter.type"}}</option>
-						<option value="all">{{.i18n.Tr "packages.filter.type.all"}}</option>
+						<option value="">{{.locale.Tr "packages.filter.type"}}</option>
+						<option value="all">{{.locale.Tr "packages.filter.type.all"}}</option>
 						<option value="composer" {{if eq .PackageType "composer"}}selected="selected"{{end}}>Composer</option>
 						<option value="conan" {{if eq .PackageType "conan"}}selected="selected"{{end}}>Conan</option>
 						<option value="container" {{if eq .PackageType "container"}}selected="selected"{{end}}>Container</option>
@@ -24,7 +24,7 @@
 						<option value="pypi" {{if eq .PackageType "pypi"}}selected="selected"{{end}}>PyPi</option>
 						<option value="rubygems" {{if eq .PackageType "rubygems"}}selected="selected"{{end}}>RubyGems</option>
 					</select>
-					<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+					<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 				</div>
 			</form>
 		</div>
@@ -33,24 +33,24 @@
 				<thead>
 					<tr>
 						<th>ID</th>
-						<th>{{.i18n.Tr "admin.packages.owner"}}</th>
-						<th>{{.i18n.Tr "admin.packages.type"}}</th>
+						<th>{{.locale.Tr "admin.packages.owner"}}</th>
+						<th>{{.locale.Tr "admin.packages.type"}}</th>
 						<th data-sortt-asc="alphabetically" data-sortt-desc="reversealphabetically">
-							{{.i18n.Tr "admin.packages.name"}}
+							{{.locale.Tr "admin.packages.name"}}
 							{{SortArrow "alphabetically" "reversealphabetically" .SortType false}}
 						</th>
 						<th data-sortt-asc="highestversion" data-sortt-desc="lowestversion">
-							{{.i18n.Tr "admin.packages.version"}}
+							{{.locale.Tr "admin.packages.version"}}
 							{{SortArrow "highestversion" "lowestversion" .SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.packages.creator"}}</th>
-						<th>{{.i18n.Tr "admin.packages.repository"}}</th>
-						<th>{{.i18n.Tr "admin.packages.size"}}</th>
+						<th>{{.locale.Tr "admin.packages.creator"}}</th>
+						<th>{{.locale.Tr "admin.packages.repository"}}</th>
+						<th>{{.locale.Tr "admin.packages.size"}}</th>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">
-							{{.i18n.Tr "admin.packages.published"}}
+							{{.locale.Tr "admin.packages.published"}}
 							{{SortArrow "oldest" "newest" .SortType true}}
 						</th>
-						<th>{{.i18n.Tr "admin.notices.op"}}</th>
+						<th>{{.locale.Tr "admin.notices.op"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -88,10 +88,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "packages.settings.delete"}}
+		{{.locale.Tr "packages.settings.delete"}}
 	</div>
 	<div class="content">
-		{{.i18n.Tr "packages.settings.delete.notice" `<span class="name"></span>` `<span class="dataVersion"></span>` | Safe}}
+		{{.locale.Tr "packages.settings.delete.notice" `<span class="name"></span>` `<span class="dataVersion"></span>` | Safe}}
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/process-row.tmpl
+++ b/templates/admin/process-row.tmpl
@@ -3,7 +3,7 @@
 		<div class="icon ml-3 mr-3">{{if eq .Process.Type "request"}}{{svg "octicon-globe" 16 }}{{else if eq .Process.Type "system"}}{{svg "octicon-cpu" 16 }}{{else}}{{svg "octicon-terminal" 16 }}{{end}}</div>
 		<div class="content f1">
 			<div class="header">{{.Process.Description}}</div>
-			<div class="description"><span title="{{DateFmtLong .Process.Start}}">{{TimeSince .Process.Start .root.i18n}}</span></div>
+			<div class="description"><span title="{{DateFmtLong .Process.Start}}">{{TimeSince .Process.Start .root.locale}}</span></div>
 		</div>
 		<div>
 			{{if ne .Process.Type "system"}}

--- a/templates/admin/process.tmpl
+++ b/templates/admin/process.tmpl
@@ -1,7 +1,7 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "admin.monitor.process"}}
+	{{.locale.Tr "admin.monitor.process"}}
 	<div class="ui right">
-		<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/monitor/stacktrace">{{.i18n.Tr "admin.monitor.stacktrace"}}</a>
+		<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/monitor/stacktrace">{{.locale.Tr "admin.monitor.stacktrace"}}</a>
 	</div>
 </h4>
 <div class="ui attached segment">

--- a/templates/admin/queue.tmpl
+++ b/templates/admin/queue.tmpl
@@ -4,18 +4,18 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue" .Queue.Name}}
+			{{.locale.Tr "admin.monitor.queue" .Queue.Name}}
 		</h4>
 		<div class="ui attached table segment">
 			<table class="ui very basic striped table">
 				<thead>
 					<tr>
-						<th>{{.i18n.Tr "admin.monitor.queue.name"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.type"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.exemplar"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.numberworkers"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.maxnumberworkers"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.numberinqueue"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.name"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.type"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.exemplar"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.numberworkers"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.maxnumberworkers"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.numberinqueue"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -32,141 +32,141 @@
 		</div>
 		{{if lt $sum 0 }}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.nopool.title"}}
+			{{.locale.Tr "admin.monitor.queue.nopool.title"}}
 		</h4>
 		<div class="ui attached segment">
 			{{if eq .Queue.Type "wrapped" }}
-			<p>{{.i18n.Tr "admin.monitor.queue.wrapped.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.wrapped.desc"}}</p>
 			{{else if eq .Queue.Type "persistable-channel"}}
-			<p>{{.i18n.Tr "admin.monitor.queue.persistable-channel.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.persistable-channel.desc"}}</p>
 			{{else}}
-			<p>{{.i18n.Tr "admin.monitor.queue.nopool.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.nopool.desc"}}</p>
 			{{end}}
 		</div>
 		{{else}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.settings.title"}}
+			{{.locale.Tr "admin.monitor.queue.settings.title"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "admin.monitor.queue.settings.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.settings.desc"}}</p>
 			<form method="POST" action="{{.Link}}/set">
 				{{$.CsrfTokenHtml}}
 				<div class="ui form">
 					<div class="inline field">
-						<label for="max-number">{{.i18n.Tr "admin.monitor.queue.settings.maxnumberworkers"}}</label>
-						<input name="max-number" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.settings.maxnumberworkers.placeholder" .Queue.MaxNumberOfWorkers}}">
+						<label for="max-number">{{.locale.Tr "admin.monitor.queue.settings.maxnumberworkers"}}</label>
+						<input name="max-number" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.settings.maxnumberworkers.placeholder" .Queue.MaxNumberOfWorkers}}">
 					</div>
 					<div class="inline field">
-						<label for="timeout">{{.i18n.Tr "admin.monitor.queue.settings.timeout"}}</label>
-						<input name="timeout" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.settings.timeout.placeholder" .Queue.BoostTimeout }}">
+						<label for="timeout">{{.locale.Tr "admin.monitor.queue.settings.timeout"}}</label>
+						<input name="timeout" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.settings.timeout.placeholder" .Queue.BoostTimeout }}">
 					</div>
 					<div class="inline field">
-						<label for="number">{{.i18n.Tr "admin.monitor.queue.settings.numberworkers"}}</label>
-						<input name="number" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.settings.numberworkers.placeholder" .Queue.BoostWorkers}}">
+						<label for="number">{{.locale.Tr "admin.monitor.queue.settings.numberworkers"}}</label>
+						<input name="number" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.settings.numberworkers.placeholder" .Queue.BoostWorkers}}">
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "admin.monitor.queue.settings.blocktimeout"}}</label>
-						<span>{{.i18n.Tr "admin.monitor.queue.settings.blocktimeout.value" .Queue.BlockTimeout}}</span>
+						<label>{{.locale.Tr "admin.monitor.queue.settings.blocktimeout"}}</label>
+						<span>{{.locale.Tr "admin.monitor.queue.settings.blocktimeout.value" .Queue.BlockTimeout}}</span>
 					</div>
-					<button class="ui submit button">{{.i18n.Tr "admin.monitor.queue.settings.submit"}}</button>
+					<button class="ui submit button">{{.locale.Tr "admin.monitor.queue.settings.submit"}}</button>
 				</div>
 			</form>
 		</div>
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.pool.addworkers.title"}}
+			{{.locale.Tr "admin.monitor.queue.pool.addworkers.title"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "admin.monitor.queue.pool.addworkers.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.pool.addworkers.desc"}}</p>
 			<form method="POST" action="{{.Link}}/add">
 				{{$.CsrfTokenHtml}}
 				<div class="ui form">
 					<div class="fields">
 						<div class="field">
-							<label>{{.i18n.Tr "admin.monitor.queue.numberworkers"}}</label>
-							<input name="number" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.pool.addworkers.numberworkers.placeholder"}}">
+							<label>{{.locale.Tr "admin.monitor.queue.numberworkers"}}</label>
+							<input name="number" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.pool.addworkers.numberworkers.placeholder"}}">
 						</div>
 						<div class="field">
-							<label>{{.i18n.Tr "admin.monitor.queue.pool.timeout"}}</label>
-							<input name="timeout" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.pool.addworkers.timeout.placeholder"}}">
+							<label>{{.locale.Tr "admin.monitor.queue.pool.timeout"}}</label>
+							<input name="timeout" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.pool.addworkers.timeout.placeholder"}}">
 						</div>
 					</div>
-					<button class="ui submit button">{{.i18n.Tr "admin.monitor.queue.pool.addworkers.submit"}}</button>
+					<button class="ui submit button">{{.locale.Tr "admin.monitor.queue.pool.addworkers.submit"}}</button>
 				</div>
 			</form>
 		</div>
 		{{if .Queue.Pausable}}
 			{{if .Queue.IsPaused}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "admin.monitor.queue.pool.resume.title"}}
+					{{.locale.Tr "admin.monitor.queue.pool.resume.title"}}
 				</h4>
 				<div class="ui attached segment">
-					<p>{{.i18n.Tr "admin.monitor.queue.pool.resume.desc"}}</p>
+					<p>{{.locale.Tr "admin.monitor.queue.pool.resume.desc"}}</p>
 					<form method="POST" action="{{.Link}}/resume">
 						{{$.CsrfTokenHtml}}
 						<div class="ui form">
-							<button class="ui submit button">{{.i18n.Tr "admin.monitor.queue.pool.resume.submit"}}</button>
+							<button class="ui submit button">{{.locale.Tr "admin.monitor.queue.pool.resume.submit"}}</button>
 						</div>
 					</form>
 				</div>
 			{{else}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "admin.monitor.queue.pool.pause.title"}}
+					{{.locale.Tr "admin.monitor.queue.pool.pause.title"}}
 				</h4>
 				<div class="ui attached segment">
-					<p>{{.i18n.Tr "admin.monitor.queue.pool.pause.desc"}}</p>
+					<p>{{.locale.Tr "admin.monitor.queue.pool.pause.desc"}}</p>
 					<form method="POST" action="{{.Link}}/pause">
 						{{$.CsrfTokenHtml}}
 						<div class="ui form">
-							<button class="ui submit button">{{.i18n.Tr "admin.monitor.queue.pool.pause.submit"}}</button>
+							<button class="ui submit button">{{.locale.Tr "admin.monitor.queue.pool.pause.submit"}}</button>
 						</div>
 					</form>
 				</div>
 			{{end}}
 		{{end}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.pool.flush.title"}}
+			{{.locale.Tr "admin.monitor.queue.pool.flush.title"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "admin.monitor.queue.pool.flush.desc"}}</p>
+			<p>{{.locale.Tr "admin.monitor.queue.pool.flush.desc"}}</p>
 			<form method="POST" action="{{.Link}}/flush">
 				{{$.CsrfTokenHtml}}
 				<div class="ui form">
 					<div class="fields">
 						<div class="field">
-							<label>{{.i18n.Tr "admin.monitor.queue.pool.timeout"}}</label>
-							<input name="timeout" type="text" placeholder="{{.i18n.Tr "admin.monitor.queue.pool.addworkers.timeout.placeholder"}}">
+							<label>{{.locale.Tr "admin.monitor.queue.pool.timeout"}}</label>
+							<input name="timeout" type="text" placeholder="{{.locale.Tr "admin.monitor.queue.pool.addworkers.timeout.placeholder"}}">
 						</div>
 					</div>
-					<button class="ui submit button">{{.i18n.Tr "admin.monitor.queue.pool.flush.submit"}}</button>
+					<button class="ui submit button">{{.locale.Tr "admin.monitor.queue.pool.flush.submit"}}</button>
 				</div>
 			</form>
 		</div>
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.pool.workers.title"}}
+			{{.locale.Tr "admin.monitor.queue.pool.workers.title"}}
 		</h4>
 		<div class="ui attached table segment">
 			<table class="ui very basic striped table">
 				<thead>
 					<tr>
-						<th>{{.i18n.Tr "admin.monitor.queue.numberworkers"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.start"}}</th>
-						<th>{{.i18n.Tr "admin.monitor.queue.pool.timeout"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.numberworkers"}}</th>
+						<th>{{.locale.Tr "admin.monitor.start"}}</th>
+						<th>{{.locale.Tr "admin.monitor.queue.pool.timeout"}}</th>
 						<th></th>
 					</tr>
 				</thead>
 				<tbody>
 					{{range .Queue.Workers}}
 					<tr>
-						<td>{{.Workers}}{{if .IsFlusher}}<span title="{{.i18n.Tr "admin.monitor.queue.flush"}}">{{svg "octicon-sync"}}</span>{{end}}</td>
+						<td>{{.Workers}}{{if .IsFlusher}}<span title="{{.locale.Tr "admin.monitor.queue.flush"}}">{{svg "octicon-sync"}}</span>{{end}}</td>
 						<td>{{DateFmtLong .Start}}</td>
 						<td>{{if .HasTimeout}}{{DateFmtLong .Timeout}}{{else}}-{{end}}</td>
 						<td>
-							<a class="delete-button" href="" data-url="{{$.Link}}/cancel/{{.PID}}" data-id="{{.PID}}" data-name="{{.Workers}}"><span class="text red" title="{{$.i18n.Tr "remove"}}">{{svg "octicon-trash"}}</span></a>
+							<a class="delete-button" href="" data-url="{{$.Link}}/cancel/{{.PID}}" data-id="{{.PID}}" data-name="{{.Workers}}"><span class="text red" title="{{$.locale.Tr "remove"}}">{{svg "octicon-trash"}}</span></a>
 						</td>
 					</tr>
 					{{else}}
 						<tr>
-							<td colspan="4">{{.i18n.Tr "admin.monitor.queue.pool.workers.none" }}
+							<td colspan="4">{{.locale.Tr "admin.monitor.queue.pool.workers.none" }}
 						</tr>
 					{{end}}
 				</tbody>
@@ -174,7 +174,7 @@
 		</div>
 		{{end}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.queue.configuration"}}
+			{{.locale.Tr "admin.monitor.queue.configuration"}}
 		</h4>
 		<div class="ui attached segment">
 			<pre>{{.Queue.Configuration | JsonPrettyPrint}}
@@ -184,11 +184,11 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{.i18n.Tr "admin.monitor.queue.pool.cancel"}}
+		{{.locale.Tr "admin.monitor.queue.pool.cancel"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "admin.monitor.queue.pool.cancel_notices" `<span class="name"></span>` | Safe}}</p>
-		<p>{{$.i18n.Tr "admin.monitor.queue.pool.cancel_desc"}}</p>
+		<p>{{$.locale.Tr "admin.monitor.queue.pool.cancel_notices" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "admin.monitor.queue.pool.cancel_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -4,9 +4,9 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.repos.repo_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.repos.repo_manage_panel"}} ({{.locale.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/repos/unadopted">{{.i18n.Tr "admin.repos.unadopted"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/repos/unadopted">{{.locale.Tr "admin.repos.unadopted"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached segment">
@@ -17,27 +17,27 @@
 				<thead>
 					<tr>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">ID{{SortArrow "oldest" "newest" $.SortType false}}</th>
-						<th>{{.i18n.Tr "admin.repos.owner"}}</th>
+						<th>{{.locale.Tr "admin.repos.owner"}}</th>
 						<th data-sortt-asc="alphabetically" data-sortt-desc="reversealphabetically">
-							{{.i18n.Tr "admin.repos.name"}}
+							{{.locale.Tr "admin.repos.name"}}
 							{{SortArrow "alphabetically" "reversealphabetically" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.repos.watches"}}</th>
+						<th>{{.locale.Tr "admin.repos.watches"}}</th>
 						<th  data-sortt-asc="moststars" data-sortt-desc="feweststars">
-							{{.i18n.Tr "admin.repos.stars"}}
+							{{.locale.Tr "admin.repos.stars"}}
 							{{SortArrow "moststars" "feweststars" $.SortType false}}
 						</th>
 						<th  data-sortt-asc="mostforks" data-sortt-desc="fewestforks">
-							{{.i18n.Tr "admin.repos.forks"}}
+							{{.locale.Tr "admin.repos.forks"}}
 							{{SortArrow "mostforks" "fewestforks" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.repos.issues"}}</th>
+						<th>{{.locale.Tr "admin.repos.issues"}}</th>
 						<th  data-sortt-asc="size" data-sortt-desc="reversesize">
-							{{.i18n.Tr "admin.repos.size"}}
+							{{.locale.Tr "admin.repos.size"}}
 							{{SortArrow "size" "reversesize" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.users.created"}}</th>
-						<th>{{.i18n.Tr "admin.notices.op"}}</th>
+						<th>{{.locale.Tr "admin.users.created"}}</th>
+						<th>{{.locale.Tr "admin.notices.op"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -53,22 +53,22 @@
 							<td>
 								<a href="{{.Link}}">{{.Name}}</a>
 								{{if .IsArchived}}
-									<span class="ui basic mini label">{{$.i18n.Tr "repo.desc.archived"}}</span>
+									<span class="ui basic mini label">{{$.locale.Tr "repo.desc.archived"}}</span>
 								{{end}}
 								{{if .IsTemplate}}
 									{{if .IsPrivate}}
-										<span class="ui basic mini label">{{$.i18n.Tr "repo.desc.private_template"}}</span>
+										<span class="ui basic mini label">{{$.locale.Tr "repo.desc.private_template"}}</span>
 									{{else}}
 										{{if .Owner.Visibility.IsPrivate}}
-											<span class="ui basic mini label">{{$.i18n.Tr "repo.desc.internal_template"}}</span>
+											<span class="ui basic mini label">{{$.locale.Tr "repo.desc.internal_template"}}</span>
 										{{end}}
 									{{end}}
 								{{else}}
 									{{if .IsPrivate}}
-										<span class="ui basic mini label">{{$.i18n.Tr "repo.desc.private"}}</span>
+										<span class="ui basic mini label">{{$.locale.Tr "repo.desc.private"}}</span>
 									{{else}}
 										{{if .Owner.Visibility.IsPrivate}}
-											<span class="ui basic mini label">{{$.i18n.Tr "repo.desc.internal"}}</span>
+											<span class="ui basic mini label">{{$.locale.Tr "repo.desc.internal"}}</span>
 										{{end}}
 									{{end}}
 								{{end}}
@@ -98,12 +98,12 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.settings.delete"}}
+		{{.locale.Tr "repo.settings.delete"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.settings.delete_desc"}}</p>
-		{{.i18n.Tr "repo.settings.delete_notices_2" `<span class="name"></span>` | Safe}}<br>
-		{{.i18n.Tr "repo.settings.delete_notices_fork_1"}}<br>
+		<p>{{.locale.Tr "repo.settings.delete_desc"}}</p>
+		{{.locale.Tr "repo.settings.delete_notices_2" `<span class="name"></span>` | Safe}}<br>
+		{{.locale.Tr "repo.settings.delete_notices_fork_1"}}<br>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/repo/search.tmpl
+++ b/templates/admin/repo/search.tmpl
@@ -2,28 +2,28 @@
 	<!-- Sort -->
 	<div class="ui dropdown type jump item">
 		<span class="text">
-			{{.i18n.Tr "repo.issues.filter_sort"}}
+			{{.locale.Tr "repo.issues.filter_sort"}}
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		</span>
 		<div class="menu">
-			<a class="{{if or (eq .SortType "oldest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
-			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
-			<a class="{{if eq .SortType "moststars"}}active{{end}} item" href="{{$.Link}}?sort=moststars&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.moststars"}}</a>
-			<a class="{{if eq .SortType "feweststars"}}active{{end}} item" href="{{$.Link}}?sort=feweststars&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.feweststars"}}</a>
-			<a class="{{if eq .SortType "mostforks"}}active{{end}} item" href="{{$.Link}}?sort=mostforks&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.mostforks"}}</a>
-			<a class="{{if eq .SortType "fewestforks"}}active{{end}} item" href="{{$.Link}}?sort=fewestforks&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.fewestforks"}}</a>
-			<a class="{{if eq .SortType "size"}}active{{end}} item" href="{{$.Link}}?sort=size&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.by_size"}}</a>
-			<a class="{{if eq .SortType "reversesize"}}active{{end}} item" href="{{$.Link}}?sort=reversesize&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_by_size"}}</a>
+			<a class="{{if or (eq .SortType "oldest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
+			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
+			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+			<a class="{{if eq .SortType "moststars"}}active{{end}} item" href="{{$.Link}}?sort=moststars&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.moststars"}}</a>
+			<a class="{{if eq .SortType "feweststars"}}active{{end}} item" href="{{$.Link}}?sort=feweststars&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.feweststars"}}</a>
+			<a class="{{if eq .SortType "mostforks"}}active{{end}} item" href="{{$.Link}}?sort=mostforks&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.mostforks"}}</a>
+			<a class="{{if eq .SortType "fewestforks"}}active{{end}} item" href="{{$.Link}}?sort=fewestforks&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.fewestforks"}}</a>
+			<a class="{{if eq .SortType "size"}}active{{end}} item" href="{{$.Link}}?sort=size&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.by_size"}}</a>
+			<a class="{{if eq .SortType "reversesize"}}active{{end}} item" href="{{$.Link}}?sort=reversesize&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_by_size"}}</a>
 		</div>
 	</div>
 </div>
 <form class="ui form ignore-dirty"  style="max-width: 90%">
 	<div class="ui fluid action input">
-		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-		<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+		<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+		<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/admin/repo/unadopted.tmpl
+++ b/templates/admin/repo/unadopted.tmpl
@@ -4,17 +4,17 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.repos.unadopted"}}
+			{{.locale.Tr "admin.repos.unadopted"}}
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/repos">{{.i18n.Tr "admin.repos.repo_manage_panel"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/repos">{{.locale.Tr "admin.repos.repo_manage_panel"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form ignore-dirty">
 				<div class="ui fluid action input">
 				<input name="search" value="true" type="hidden">
-				<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "repo.adopt_search"}}" autofocus>
-				<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+				<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "repo.adopt_search"}}" autofocus>
+				<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 				</div>
 			</form>
 		</div>
@@ -28,14 +28,14 @@
 									<span class="icon">{{svg "octicon-file-directory-fill"}}</span>
 									<span class="name">{{$dir}}</span>
 									<div class="right floated content">
-										<button class="ui button submit tiny green adopt show-modal" data-modal="#adopt-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-plus"}}</span><span class="label">{{$.i18n.Tr "repo.adopt_preexisting_label"}}</span></button>
+										<button class="ui button submit tiny green adopt show-modal" data-modal="#adopt-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-plus"}}</span><span class="label">{{$.locale.Tr "repo.adopt_preexisting_label"}}</span></button>
 										<div class="ui basic modal" id="adopt-unadopted-modal-{{$dirI}}">
 											{{svg "octicon-x" 16 "close inside"}}
 											<div class="header">
-												<span class="label">{{$.i18n.Tr "repo.adopt_preexisting"}}</span>
+												<span class="label">{{$.locale.Tr "repo.adopt_preexisting"}}</span>
 											</div>
 											<div class="content">
-												<p>{{$.i18n.Tr "repo.adopt_preexisting_content" $dir}}</p>
+												<p>{{$.locale.Tr "repo.adopt_preexisting_content" $dir}}</p>
 											</div>
 											<form class="ui form" method="POST" action="{{AppSubUrl}}/admin/repos/unadopted">
 												{{$.CsrfTokenHtml}}
@@ -46,23 +46,23 @@
 												<div class="actions">
 													<div class="ui red basic inverted cancel button">
 														{{svg "octicon-trash" 16 "mr-2"}}
-														{{$.i18n.Tr "modal.no"}}
+														{{$.locale.Tr "modal.no"}}
 													</div>
 													<button class="ui green basic inverted ok button">
 														{{svg "octicon-check" 16 "mr-2"}}
-														{{$.i18n.Tr "modal.yes"}}
+														{{$.locale.Tr "modal.yes"}}
 													</button>
 												</div>
 											</form>
 										</div>
-										<button class="ui button submit tiny red delete show-modal" data-modal="#delete-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-x"}}</span><span class="label">{{$.i18n.Tr "repo.delete_preexisting_label"}}</span></button>
+										<button class="ui button submit tiny red delete show-modal" data-modal="#delete-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-x"}}</span><span class="label">{{$.locale.Tr "repo.delete_preexisting_label"}}</span></button>
 										<div class="ui basic modal" id="delete-unadopted-modal-{{$dirI}}">
 											{{svg "octicon-x" 16 "close inside"}}
 											<div class="header">
-												<span class="label">{{$.i18n.Tr "repo.delete_preexisting"}}</span>
+												<span class="label">{{$.locale.Tr "repo.delete_preexisting"}}</span>
 											</div>
 											<div class="content">
-												<p>{{$.i18n.Tr "repo.delete_preexisting_content" $dir}}</p>
+												<p>{{$.locale.Tr "repo.delete_preexisting_content" $dir}}</p>
 											</div>
 											<form class="ui form" method="POST" action="{{AppSubUrl}}/admin/repos/unadopted">
 												{{$.CsrfTokenHtml}}
@@ -73,11 +73,11 @@
 												<div class="actions">
 													<div class="ui red basic inverted cancel button">
 														{{svg "octicon-trash" 16 "mr-2"}}
-														{{$.i18n.Tr "modal.no"}}
+														{{$.locale.Tr "modal.no"}}
 													</div>
 													<button class="ui green basic inverted ok button">
 														{{svg "octicon-check" 16 "mr-2"}}
-														{{$.i18n.Tr "modal.yes"}}
+														{{$.locale.Tr "modal.yes"}}
 													</button>
 												</div>
 											</form>
@@ -90,7 +90,7 @@
 					{{template "base/paginate" .}}
 				{{else}}
 					<div class="item">
-						{{.i18n.Tr "admin.repos.unadopted.no_more"}}
+						{{.locale.Tr "admin.repos.unadopted.no_more"}}
 					</div>
 					{{template "base/paginate" .}}
 				{{end}}

--- a/templates/admin/stacktrace-row.tmpl
+++ b/templates/admin/stacktrace-row.tmpl
@@ -13,7 +13,7 @@
 		</div>
 		<div class="content f1">
 			<div class="header">{{.Process.Description}}</div>
-			<div class="description">{{if ne .Process.Type "none"}}<span title="{{DateFmtLong .Process.Start}}">{{TimeSince .Process.Start .root.i18n}}</span>{{end}}</div>
+			<div class="description">{{if ne .Process.Type "none"}}<span title="{{DateFmtLong .Process.Start}}">{{TimeSince .Process.Start .root.locale}}</span>{{end}}</div>
 		</div>
 		<div>
 			{{if or (eq .Process.Type "request") (eq .Process.Type "normal") }}

--- a/templates/admin/stacktrace.tmpl
+++ b/templates/admin/stacktrace.tmpl
@@ -4,9 +4,9 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.monitor.stacktrace"}}: {{.i18n.Tr "admin.monitor.goroutines" .GoroutineCount}}
+			{{.locale.Tr "admin.monitor.stacktrace"}}: {{.locale.Tr "admin.monitor.goroutines" .GoroutineCount}}
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/monitor">{{.i18n.Tr "admin.monitor"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/monitor">{{.locale.Tr "admin.monitor"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached segment">
@@ -21,11 +21,11 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{.i18n.Tr "admin.monitor.process.cancel"}}
+		{{.locale.Tr "admin.monitor.process.cancel"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "admin.monitor.process.cancel_notices" `<span class="name"></span>` | Safe}}</p>
-		<p>{{$.i18n.Tr "admin.monitor.process.cancel_desc"}}</p>
+		<p>{{$.locale.Tr "admin.monitor.process.cancel_notices" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "admin.monitor.process.cancel_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -4,25 +4,25 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.users.edit_account"}}
+			{{.locale.Tr "admin.users.edit_account"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<div class="field {{if .Err_UserName}}error{{end}}">
-					<label for="user_name">{{.i18n.Tr "username"}}</label>
+					<label for="user_name">{{.locale.Tr "username"}}</label>
 					<input id="user_name" name="user_name" value="{{.User.Name}}" autofocus {{if not .User.IsLocal }}disabled{{end}}>
 				</div>
 				<!-- Types and name -->
 				<div class="inline required field {{if .Err_LoginType}}error{{end}}">
-					<label>{{.i18n.Tr "admin.users.auth_source"}}</label>
+					<label>{{.locale.Tr "admin.users.auth_source"}}</label>
 					<div class="ui selection type dropdown">
 						<input type="hidden" id="login_type" name="login_type" value="{{.LoginSource.Type.Int}}-{{.LoginSource.ID}}" required>
-						<div class="text">{{.i18n.Tr "admin.users.local"}}</div>
+						<div class="text">{{.locale.Tr "admin.users.local"}}</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
-							<div class="item" data-value="0-0">{{.i18n.Tr "admin.users.local"}}</div>
+							<div class="item" data-value="0-0">{{.locale.Tr "admin.users.local"}}</div>
 							{{range .Sources}}
 								<div class="item" data-value="{{.Type.Int}}-{{.ID}}">{{.Name}}</div>
 							{{end}}
@@ -31,25 +31,25 @@
 				</div>
 
 				<div class="inline field {{if .Err_Visibility}}error{{end}}">
-					<span class="inline required field"><label for="visibility">{{.i18n.Tr "settings.visibility"}}</label></span>
+					<span class="inline required field"><label for="visibility">{{.locale.Tr "settings.visibility"}}</label></span>
 					<div class="ui selection type dropdown">
 						{{if .User.Visibility.IsPublic}}<input type="hidden" id="visibility" name="visibility" value="0">{{end}}
 						{{if .User.Visibility.IsLimited}}<input type="hidden" id="visibility" name="visibility" value="1">{{end}}
 						{{if .User.Visibility.IsPrivate}}<input type="hidden" id="visibility" name="visibility" value="2">{{end}}
 						<div class="text">
-							{{if .User.Visibility.IsPublic}}{{.i18n.Tr "settings.visibility.public"}}{{end}}
-							{{if .User.Visibility.IsLimited}}{{.i18n.Tr "settings.visibility.limited"}}{{end}}
-							{{if .User.Visibility.IsPrivate}}{{.i18n.Tr "settings.visibility.private"}}{{end}}
+							{{if .User.Visibility.IsPublic}}{{.locale.Tr "settings.visibility.public"}}{{end}}
+							{{if .User.Visibility.IsLimited}}{{.locale.Tr "settings.visibility.limited"}}{{end}}
+							{{if .User.Visibility.IsPrivate}}{{.locale.Tr "settings.visibility.private"}}{{end}}
 						</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
 							{{range $mode := .AllowedUserVisibilityModes}}
 								{{if $mode.IsPublic}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.i18n.Tr "settings.visibility.public"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.locale.Tr "settings.visibility.public"}}</div>
 								{{else if $mode.IsLimited}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.i18n.Tr "settings.visibility.limited"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.locale.Tr "settings.visibility.limited"}}</div>
 								{{else if $mode.IsPrivate}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.i18n.Tr "settings.visibility.private"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.locale.Tr "settings.visibility.private"}}</div>
 								{{end}}
 							{{end}}
 						</div>
@@ -57,81 +57,81 @@
 				</div>
 
 				<div class="required non-local field {{if .Err_LoginName}}error{{end}} {{if eq .User.LoginSource 0}}hide{{end}}">
-					<label for="login_name">{{.i18n.Tr "admin.users.auth_login_name"}}</label>
+					<label for="login_name">{{.locale.Tr "admin.users.auth_login_name"}}</label>
 					<input id="login_name" name="login_name" value="{{.User.LoginName}}" autofocus>
 				</div>
 				<div class="field {{if .Err_FullName}}error{{end}}">
-					<label for="full_name">{{.i18n.Tr "settings.full_name"}}</label>
+					<label for="full_name">{{.locale.Tr "settings.full_name"}}</label>
 					<input id="full_name" name="full_name" value="{{.User.FullName}}">
 				</div>
 				<div class="required field {{if .Err_Email}}error{{end}}">
-					<label for="email">{{.i18n.Tr "email"}}</label>
+					<label for="email">{{.locale.Tr "email"}}</label>
 					<input id="email" name="email" type="email" value="{{.User.Email}}" autofocus required>
 				</div>
 				<div class="local field {{if .Err_Password}}error{{end}} {{if not (or (.User.IsLocal) (.User.IsOAuth2))}}hide{{end}}">
-					<label for="password">{{.i18n.Tr "password"}}</label>
+					<label for="password">{{.locale.Tr "password"}}</label>
 					<input id="password" name="password" type="password" autocomplete="new-password">
-					<p class="help">{{.i18n.Tr "admin.users.password_helper"}}</p>
+					<p class="help">{{.locale.Tr "admin.users.password_helper"}}</p>
 				</div>
 				<div class="field {{if .Err_Website}}error{{end}}">
-					<label for="website">{{.i18n.Tr "settings.website"}}</label>
+					<label for="website">{{.locale.Tr "settings.website"}}</label>
 					<input id="website" name="website" type="url" value="{{.User.Website}}" placeholder="e.g. http://mydomain.com or https://mydomain.com">
 				</div>
 				<div class="field {{if .Err_Location}}error{{end}}">
-					<label for="location">{{.i18n.Tr "settings.location"}}</label>
+					<label for="location">{{.locale.Tr "settings.location"}}</label>
 					<input id="location" name="location" value="{{.User.Location}}">
 				</div>
 
 				<div class="ui divider"></div>
 
 				<div class="inline field {{if .Err_MaxRepoCreation}}error{{end}}">
-					<label for="max_repo_creation">{{.i18n.Tr "admin.users.max_repo_creation"}}</label>
+					<label for="max_repo_creation">{{.locale.Tr "admin.users.max_repo_creation"}}</label>
 					<input id="max_repo_creation" name="max_repo_creation" type="number" value="{{.User.MaxRepoCreation}}">
-					<p class="help">{{.i18n.Tr "admin.users.max_repo_creation_desc"}}</p>
+					<p class="help">{{.locale.Tr "admin.users.max_repo_creation_desc"}}</p>
 				</div>
 
 				<div class="ui divider"></div>
 
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.is_activated"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.is_activated"}}</strong></label>
 						<input name="active" type="checkbox" {{if .User.IsActive}}checked{{end}}>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.prohibit_login"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.prohibit_login"}}</strong></label>
 						<input name="prohibit_login" type="checkbox" {{if .User.ProhibitLogin}}checked{{end}} {{if (eq .User.ID .SignedUserID)}}disabled{{end}}>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.is_admin"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.is_admin"}}</strong></label>
 						<input name="admin" type="checkbox" {{if .User.IsAdmin}}checked{{end}}>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.is_restricted"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.is_restricted"}}</strong></label>
 						<input name="restricted" type="checkbox" {{if .User.IsRestricted}}checked{{end}}>
 					</div>
 				</div>
 				<div class="inline field"{{if DisableGitHooks}} hidden{{end}}>
-					<div class="ui checkbox tooltip" data-content="{{.i18n.Tr "admin.users.allow_git_hook_tooltip"}}" data-variation="very wide">
-						<label><strong>{{.i18n.Tr "admin.users.allow_git_hook"}}</strong></label>
+					<div class="ui checkbox tooltip" data-content="{{.locale.Tr "admin.users.allow_git_hook_tooltip"}}" data-variation="very wide">
+						<label><strong>{{.locale.Tr "admin.users.allow_git_hook"}}</strong></label>
 						<input name="allow_git_hook" type="checkbox" {{if .User.CanEditGitHook}}checked{{end}} {{if DisableGitHooks}}disabled{{end}}>
 					</div>
 				</div>
 				<div class="inline field" {{if or (DisableImportLocal) (.DisableMigrations)}}hidden{{end}}>
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.allow_import_local"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.allow_import_local"}}</strong></label>
 						<input name="allow_import_local" type="checkbox" {{if .User.CanImportLocal}}checked{{end}} {{if DisableImportLocal}}disabled{{end}}>
 					</div>
 				</div>
 				{{if not .DisableRegularOrgCreation}}
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.allow_create_organization"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.allow_create_organization"}}</strong></label>
 						<input name="allow_create_organization" type="checkbox" {{if .User.CanCreateOrganization}}checked{{end}}>
 					</div>
 				</div>
@@ -141,7 +141,7 @@
 				<div class="ui divider"></div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "admin.users.reset_2fa"}}</strong></label>
+						<label><strong>{{.locale.Tr "admin.users.reset_2fa"}}</strong></label>
 						<input name="reset_2fa" type="checkbox">
 					</div>
 				</div>
@@ -150,14 +150,14 @@
 				<div class="ui divider"></div>
 
 				<div class="field">
-					<button class="ui green button">{{.i18n.Tr "admin.users.update_profile"}}</button>
-					<div class="ui red button delete-button" data-url="{{$.Link}}/delete" data-id="{{.User.ID}}">{{.i18n.Tr "admin.users.delete_account"}}</div>
+					<button class="ui green button">{{.locale.Tr "admin.users.update_profile"}}</button>
+					<div class="ui red button delete-button" data-url="{{$.Link}}/delete" data-id="{{.User.ID}}">{{.locale.Tr "admin.users.delete_account"}}</div>
 				</div>
 			</form>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.avatar"}}
+			{{.locale.Tr "settings.avatar"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}/avatar" method="post" enctype="multipart/form-data">
@@ -166,11 +166,11 @@
 				<div class="inline field">
 					<div class="ui radio checkbox">
 						<input name="source" value="lookup" type="radio" {{if not .User.UseCustomAvatar}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.lookup_avatar_by_mail"}}</label>
+						<label>{{.locale.Tr "settings.lookup_avatar_by_mail"}}</label>
 					</div>
 				</div>
 				<div class="field {{if .Err_Gravatar}}error{{end}}">
-					<label for="gravatar">Avatar {{.i18n.Tr "email"}}</label>
+					<label for="gravatar">Avatar {{.locale.Tr "email"}}</label>
 					<input id="gravatar" name="gravatar" value="{{.User.AvatarEmail}}" />
 				</div>
 				{{end}}
@@ -178,18 +178,18 @@
 				<div class="inline field">
 					<div class="ui radio checkbox">
 						<input name="source" value="local" type="radio" {{if .User.UseCustomAvatar}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.enable_custom_avatar"}}</label>
+						<label>{{.locale.Tr "settings.enable_custom_avatar"}}</label>
 					</div>
 				</div>
 
 				<div class="inline field">
-					<label for="avatar">{{.i18n.Tr "settings.choose_new_avatar"}}</label>
+					<label for="avatar">{{.locale.Tr "settings.choose_new_avatar"}}</label>
 					<input name="avatar" type="file" >
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_avatar"}}</button>
-					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.i18n.Tr "settings.delete_current_avatar"}}</a>
+					<button class="ui green button">{{$.locale.Tr "settings.update_avatar"}}</button>
+					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.locale.Tr "settings.delete_current_avatar"}}</a>
 				</div>
 			</form>
 		</div>
@@ -199,10 +199,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.delete_account_title"}}
+		{{.locale.Tr "settings.delete_account_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.delete_account_desc"}}</p>
+		<p>{{.locale.Tr "settings.delete_account_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -4,9 +4,9 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.users.user_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "admin.users.user_manage_panel"}} ({{.locale.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/users/new">{{.i18n.Tr "admin.users.new_account"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/admin/users/new">{{.locale.Tr "admin.users.new_account"}}</a>
 			</div>
 		</h4>
 		<div class="ui attached segment">
@@ -16,47 +16,47 @@
 				<div class="ui right floated secondary filter menu">
 					<!-- Status Filter Menu Item -->
 					<div class="ui dropdown type jump item">
-						<span class="text">{{.i18n.Tr "admin.users.list_status_filter.menu_text"}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}</span>
+						<span class="text">{{.locale.Tr "admin.users.list_status_filter.menu_text"}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}</span>
 						<div class="menu">
-							<a class="item j-reset-status-filter">{{.i18n.Tr "admin.users.list_status_filter.reset"}}</a>
+							<a class="item j-reset-status-filter">{{.locale.Tr "admin.users.list_status_filter.reset"}}</a>
 							<div class="ui divider"></div>
-							<label class="item"><input type="radio" name="status_filter[is_admin]" value="1"> {{.i18n.Tr "admin.users.list_status_filter.is_admin"}}</label>
-							<label class="item"><input type="radio" name="status_filter[is_admin]" value="0"> {{.i18n.Tr "admin.users.list_status_filter.not_admin"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_admin]" value="1"> {{.locale.Tr "admin.users.list_status_filter.is_admin"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_admin]" value="0"> {{.locale.Tr "admin.users.list_status_filter.not_admin"}}</label>
 							<div class="ui divider"></div>
-							<label class="item"><input type="radio" name="status_filter[is_active]" value="1"> {{.i18n.Tr "admin.users.list_status_filter.is_active"}}</label>
-							<label class="item"><input type="radio" name="status_filter[is_active]" value="0"> {{.i18n.Tr "admin.users.list_status_filter.not_active"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_active]" value="1"> {{.locale.Tr "admin.users.list_status_filter.is_active"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_active]" value="0"> {{.locale.Tr "admin.users.list_status_filter.not_active"}}</label>
 							<div class="ui divider"></div>
-							<label class="item"><input type="radio" name="status_filter[is_restricted]" value="0"> {{.i18n.Tr "admin.users.list_status_filter.not_restricted"}}</label>
-							<label class="item"><input type="radio" name="status_filter[is_restricted]" value="1"> {{.i18n.Tr "admin.users.list_status_filter.is_restricted"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_restricted]" value="0"> {{.locale.Tr "admin.users.list_status_filter.not_restricted"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_restricted]" value="1"> {{.locale.Tr "admin.users.list_status_filter.is_restricted"}}</label>
 							<div class="ui divider"></div>
-							<label class="item"><input type="radio" name="status_filter[is_prohibit_login]" value="0"> {{.i18n.Tr "admin.users.list_status_filter.not_prohibit_login"}}</label>
-							<label class="item"><input type="radio" name="status_filter[is_prohibit_login]" value="1"> {{.i18n.Tr "admin.users.list_status_filter.is_prohibit_login"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_prohibit_login]" value="0"> {{.locale.Tr "admin.users.list_status_filter.not_prohibit_login"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_prohibit_login]" value="1"> {{.locale.Tr "admin.users.list_status_filter.is_prohibit_login"}}</label>
 							<div class="ui divider"></div>
-							<label class="item"><input type="radio" name="status_filter[is_2fa_enabled]" value="1"> {{.i18n.Tr "admin.users.list_status_filter.is_2fa_enabled"}}</label>
-							<label class="item"><input type="radio" name="status_filter[is_2fa_enabled]" value="0"> {{.i18n.Tr "admin.users.list_status_filter.not_2fa_enabled"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_2fa_enabled]" value="1"> {{.locale.Tr "admin.users.list_status_filter.is_2fa_enabled"}}</label>
+							<label class="item"><input type="radio" name="status_filter[is_2fa_enabled]" value="0"> {{.locale.Tr "admin.users.list_status_filter.not_2fa_enabled"}}</label>
 						</div>
 					</div>
 
 					<!-- Sort Menu Item -->
 					<div class="ui dropdown type jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_sort"}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+							{{.locale.Tr "repo.issues.filter_sort"}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<button class="item" name="sort" value="oldest">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</button>
-							<button class="item" name="sort" value="newest">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</button>
-							<button class="item" name="sort" value="alphabetically">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</button>
-							<button class="item" name="sort" value="reversealphabetically">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</button>
-							<button class="item" name="sort" value="recentupdate">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</button>
-							<button class="item" name="sort" value="leastupdate">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</button>
+							<button class="item" name="sort" value="oldest">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</button>
+							<button class="item" name="sort" value="newest">{{.locale.Tr "repo.issues.filter_sort.latest"}}</button>
+							<button class="item" name="sort" value="alphabetically">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</button>
+							<button class="item" name="sort" value="reversealphabetically">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</button>
+							<button class="item" name="sort" value="recentupdate">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</button>
+							<button class="item" name="sort" value="leastupdate">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</button>
 						</div>
 					</div>
 				</div>
 
 				<!-- Search Text -->
 				<div class="ui fluid action input" style="max-width: 70%;">
-					<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-					<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+					<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+					<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 				</div>
 			</form>
 		</div>
@@ -66,21 +66,21 @@
 					<tr>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">ID{{SortArrow "oldest" "newest" .SortType false}}</th>
 						<th data-sortt-asc="alphabetically" data-sortt-desc="reversealphabetically" data-sortt-default="true">
-							{{.i18n.Tr "admin.users.name"}}
+							{{.locale.Tr "admin.users.name"}}
 							{{SortArrow "alphabetically" "reversealphabetically" $.SortType true}}
 						</th>
-						<th>{{.i18n.Tr "email"}}</th>
-						<th>{{.i18n.Tr "admin.users.activated"}}</th>
-						<th>{{.i18n.Tr "admin.users.admin"}}</th>
-						<th>{{.i18n.Tr "admin.users.restricted"}}</th>
-						<th>{{.i18n.Tr "admin.users.2fa"}}</th>
-						<th>{{.i18n.Tr "admin.users.repos"}}</th>
-						<th>{{.i18n.Tr "admin.users.created"}}</th>
+						<th>{{.locale.Tr "email"}}</th>
+						<th>{{.locale.Tr "admin.users.activated"}}</th>
+						<th>{{.locale.Tr "admin.users.admin"}}</th>
+						<th>{{.locale.Tr "admin.users.restricted"}}</th>
+						<th>{{.locale.Tr "admin.users.2fa"}}</th>
+						<th>{{.locale.Tr "admin.users.repos"}}</th>
+						<th>{{.locale.Tr "admin.users.created"}}</th>
 						<th data-sortt-asc="leastupdate" data-sortt-desc="recentupdate">
-							{{.i18n.Tr "admin.users.last_login"}}
+							{{.locale.Tr "admin.users.last_login"}}
 							{{SortArrow "leastupdate" "recentupdate" $.SortType false}}
 						</th>
-						<th>{{.i18n.Tr "admin.users.edit"}}</th>
+						<th>{{.locale.Tr "admin.users.edit"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -98,7 +98,7 @@
 							{{if .LastLoginUnix}}
 								<td><span title="{{.LastLoginUnix.FormatLong}}">{{.LastLoginUnix.FormatShort}}</span></td>
 							{{else}}
-								<td><span>{{$.i18n.Tr "admin.users.never_login"}}</span></td>
+								<td><span>{{$.locale.Tr "admin.users.never_login"}}</span></td>
 							{{end}}
 							<td><a href="{{$.Link}}/{{.ID}}">{{svg "octicon-pencil"}}</a></td>
 						</tr>

--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "admin.users.new_account"}}
+			{{.locale.Tr "admin.users.new_account"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -12,13 +12,13 @@
 				{{.CsrfTokenHtml}}
 				<!-- Types and name -->
 				<div class="inline required field {{if .Err_LoginType}}error{{end}}">
-					<label>{{.i18n.Tr "admin.users.auth_source"}}</label>
+					<label>{{.locale.Tr "admin.users.auth_source"}}</label>
 					<div class="ui selection type dropdown">
 						<input type="hidden" id="login_type" name="login_type" value="{{.login_type}}" data-password="required" required>
-						<div class="text">{{.i18n.Tr "admin.users.local"}}</div>
+						<div class="text">{{.locale.Tr "admin.users.local"}}</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
-							<div class="item" data-value="0-0">{{.i18n.Tr "admin.users.local"}}</div>
+							<div class="item" data-value="0-0">{{.locale.Tr "admin.users.local"}}</div>
 							{{range .Sources}}
 								<div class="item" data-value="{{.Type.Int}}-{{.ID}}">{{.Name}}</div>
 							{{end}}
@@ -27,23 +27,23 @@
 				</div>
 
 				<div class="inline field {{if .Err_Visibility}}error{{end}}">
-					<span class="inline required field"><label for="visibility">{{.i18n.Tr "settings.visibility"}}</label></span>
+					<span class="inline required field"><label for="visibility">{{.locale.Tr "settings.visibility"}}</label></span>
 					<div class="ui selection type dropdown">
 						<input type="hidden" id="visibility" name="visibility" value="{{if .visibility}}{{.visibility}}{{else}}{{printf "%d" .DefaultUserVisibilityMode}}{{end}}">
 						<div class="text">
-							{{if .DefaultUserVisibilityMode.IsPublic}}{{.i18n.Tr "settings.visibility.public"}}{{end}}
-							{{if .DefaultUserVisibilityMode.IsLimited}}{{.i18n.Tr "settings.visibility.limited"}}{{end}}
-							{{if .DefaultUserVisibilityMode.IsPrivate}}{{.i18n.Tr "settings.visibility.private"}}{{end}}
+							{{if .DefaultUserVisibilityMode.IsPublic}}{{.locale.Tr "settings.visibility.public"}}{{end}}
+							{{if .DefaultUserVisibilityMode.IsLimited}}{{.locale.Tr "settings.visibility.limited"}}{{end}}
+							{{if .DefaultUserVisibilityMode.IsPrivate}}{{.locale.Tr "settings.visibility.private"}}{{end}}
 						</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
 							{{range $mode := .AllowedUserVisibilityModes}}
 								{{if $mode.IsPublic}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.i18n.Tr "settings.visibility.public"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.locale.Tr "settings.visibility.public"}}</div>
 								{{else if $mode.IsLimited}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.i18n.Tr "settings.visibility.limited"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.locale.Tr "settings.visibility.limited"}}</div>
 								{{else if $mode.IsPrivate}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.i18n.Tr "settings.visibility.private"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.locale.Tr "settings.visibility.private"}}</div>
 								{{end}}
 							{{end}}
 						</div>
@@ -51,25 +51,25 @@
 				</div>
 
 				<div class="required non-local field {{if .Err_LoginName}}error{{end}} {{if eq .login_type "0-0"}}hide{{end}}">
-					<label for="login_name">{{.i18n.Tr "admin.users.auth_login_name"}}</label>
+					<label for="login_name">{{.locale.Tr "admin.users.auth_login_name"}}</label>
 					<input id="login_name" name="login_name" value="{{.login_name}}">
 				</div>
 				<div class="required field {{if .Err_UserName}}error{{end}}">
-					<label for="user_name">{{.i18n.Tr "username"}}</label>
+					<label for="user_name">{{.locale.Tr "username"}}</label>
 					<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 				</div>
 				<div class="required field {{if .Err_Email}}error{{end}}">
-					<label for="email">{{.i18n.Tr "email"}}</label>
+					<label for="email">{{.locale.Tr "email"}}</label>
 					<input id="email" name="email" type="email" value="{{.email}}" required>
 				</div>
 				<div class="required local field {{if .Err_Password}}error{{end}} {{if not (eq .login_type "0-0")}}hide{{end}}">
-					<label for="password">{{.i18n.Tr "password"}}</label>
+					<label for="password">{{.locale.Tr "password"}}</label>
 					<input id="password" name="password" type="password" autocomplete="new-password" value="{{.password}}" {{if eq .login_type "0-0"}}required{{end}}>
 				</div>
 
 				<div class="inline field local{{if ne .login_type "0-0"}} hide{{end}}">
 					<div class="ui checkbox">
-						<label><strong>{{.i18n.Tr "auth.allow_password_change" }}</strong></label>
+						<label><strong>{{.locale.Tr "auth.allow_password_change" }}</strong></label>
 						<input name="must_change_password" type="checkbox" checked>
 					</div>
 				</div>
@@ -78,14 +78,14 @@
 				{{if .CanSendEmail}}
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label><strong>{{.i18n.Tr "admin.users.send_register_notify"}}</strong></label>
+							<label><strong>{{.locale.Tr "admin.users.send_register_notify"}}</strong></label>
 							<input name="send_notify" type="checkbox" {{if .send_notify}}checked{{end}}>
 						</div>
 					</div>
 				{{end}}
 
 				<div class="field">
-					<button class="ui green button">{{.i18n.Tr "admin.users.new_account"}}</button>
+					<button class="ui green button">{{.locale.Tr "admin.users.new_account"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/base/delete_modal_actions.tmpl
+++ b/templates/base/delete_modal_actions.tmpl
@@ -1,10 +1,10 @@
 <div class="actions">
 	<div class="ui red basic inverted cancel button">
 		{{svg "octicon-x"}}
-		{{.i18n.Tr "modal.no"}}
+		{{.locale.Tr "modal.no"}}
 	</div>
 	<div class="ui green basic inverted ok button">
 		{{svg "octicon-check"}}
-		{{.i18n.Tr "modal.yes"}}
+		{{.locale.Tr "modal.yes"}}
 	</div>
 </div>

--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -1,9 +1,9 @@
 <footer>
 	<div class="ui container">
 		<div class="ui left">
-			{{.i18n.Tr "powered_by" "Gitea"}}
+			{{.locale.Tr "powered_by" "Gitea"}}
 			{{if (or .ShowFooterVersion .PageIsAdmin)}}
-				{{.i18n.Tr "version"}}:
+				{{.locale.Tr "version"}}:
 				{{if .IsAdmin}}
 					<a href="{{AppSubUrl}}/admin/config">{{AppVer}}</a>
 				{{else}}
@@ -11,8 +11,8 @@
 				{{end}}
 			{{end}}
 			{{if and .TemplateLoadTimes ShowFooterTemplateLoadTime}}
-				{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong>
-				{{.i18n.Tr "template"}}
+				{{.locale.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong>
+				{{.locale.Tr "template"}}
 				{{if .TemplateName}} {{.TemplateName}}{{end}}: <strong>{{call .TemplateLoadTimes}}</strong>
 			{{end}}
 		</div>
@@ -22,16 +22,16 @@
 			{{end}}
 			<div class="ui language bottom floating slide up dropdown link item">
 				{{svg "octicon-globe"}}
-				<div class="text">{{.i18n.LangName}}</div>
+				<div class="text">{{.locale.LangName}}</div>
 				<div class="menu language-menu">
 					{{range .AllLangs}}
-						<a lang="{{.Lang}}" data-url="{{AppSubUrl}}/?lang={{.Lang}}" class="item {{if eq $.i18n.Lang .Lang}}active selected{{end}}">{{.Name}}</a>
+						<a lang="{{.Lang}}" data-url="{{AppSubUrl}}/?lang={{.Lang}}" class="item {{if eq $.locale.Lang .Lang}}active selected{{end}}">{{.Name}}</a>
 					{{end}}
 				</div>
 			</div>
-			<a href="{{AssetUrlPrefix}}/js/licenses.txt">{{.i18n.Tr "licenses"}}</a>
+			<a href="{{AssetUrlPrefix}}/js/licenses.txt">{{.locale.Tr "licenses"}}</a>
 			{{if .EnableSwagger}}<a href="{{AppSubUrl}}/api/swagger">API</a>{{end}}
-			<a target="_blank" rel="noopener noreferrer" href="https://gitea.io">{{.i18n.Tr "website"}}</a>
+			<a target="_blank" rel="noopener noreferrer" href="https://gitea.io">{{.locale.Tr "website"}}</a>
 			{{template "custom/extra_links_footer" .}}
 		</div>
 	</div>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{.i18n.Lang}}" class="theme-{{.SignedUser.Theme}}">
+<html lang="{{.locale.Lang}}" class="theme-{{.SignedUser.Theme}}">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
@@ -78,7 +78,7 @@
 	{{template "custom/body_outer_pre" .}}
 
 	<div class="full height">
-		<noscript>{{.i18n.Tr "enable_javascript"}}</noscript>
+		<noscript>{{.locale.Tr "enable_javascript"}}</noscript>
 
 		{{template "custom/body_inner_pre" .}}
 

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -1,7 +1,7 @@
 <div class="ui container" id="navbar">
 	<div class="item brand" style="justify-content: space-between;">
-		<a href="{{AppSubUrl}}/" aria-label="{{if .IsSigned}}{{.i18n.Tr "dashboard"}}{{else}}{{.i18n.Tr "home"}}{{end}}">
-			<img class="ui mini image" width="30" height="30" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{.i18n.Tr "logo"}}" aria-hidden="true">
+		<a href="{{AppSubUrl}}/" aria-label="{{if .IsSigned}}{{.locale.Tr "dashboard"}}{{else}}{{.locale.Tr "home"}}{{end}}">
+			<img class="ui mini image" width="30" height="30" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{.locale.Tr "logo"}}" aria-hidden="true">
 		</a>
 		<div class="ui basic icon button mobile-only" id="navbar-expand-toggle">
 			<i class="sidebar icon"></i>
@@ -12,19 +12,19 @@
 		{{/* No links */}}
 	{{else if .IsSigned}}
 		{{if not .UnitIssuesGlobalDisabled}}
-		<a class="item {{if .PageIsIssues}}active{{end}}" href="{{AppSubUrl}}/issues">{{.i18n.Tr "issues"}}</a>
+		<a class="item {{if .PageIsIssues}}active{{end}}" href="{{AppSubUrl}}/issues">{{.locale.Tr "issues"}}</a>
 		{{end}}
 		{{if not .UnitPullsGlobalDisabled}}
-		<a class="item {{if .PageIsPulls}}active{{end}}" href="{{AppSubUrl}}/pulls">{{.i18n.Tr "pull_requests"}}</a>
+		<a class="item {{if .PageIsPulls}}active{{end}}" href="{{AppSubUrl}}/pulls">{{.locale.Tr "pull_requests"}}</a>
 		{{end}}
 		{{if not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled)}}
-		{{if .ShowMilestonesDashboardPage}}<a class="item {{if .PageIsMilestonesDashboard}}active{{end}}" href="{{AppSubUrl}}/milestones">{{.i18n.Tr "milestones"}}</a>{{end}}
+		{{if .ShowMilestonesDashboardPage}}<a class="item {{if .PageIsMilestonesDashboard}}active{{end}}" href="{{AppSubUrl}}/milestones">{{.locale.Tr "milestones"}}</a>{{end}}
 		{{end}}
-		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.i18n.Tr "explore"}}</a>
+		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.locale.Tr "explore"}}</a>
 	{{else if .IsLandingPageOrganizations}}
-		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/organizations">{{.i18n.Tr "explore"}}</a>
+		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/organizations">{{.locale.Tr "explore"}}</a>
 	{{else}}
-		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.i18n.Tr "explore"}}</a>
+		<a class="item {{if .PageIsExplore}}active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.locale.Tr "explore"}}</a>
 	{{end}}
 
 	{{template "custom/extra_links" .}}
@@ -32,7 +32,7 @@
 	{{/* TODO
 		<div class="item">
 		<div class="ui icon input">
-		<input class="searchbox" type="text" placeholder="{{.i18n.Tr "search_project"}}">
+		<input class="searchbox" type="text" placeholder="{{.locale.Tr "search_project"}}">
 		<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
 		</div>
 		</div>
@@ -41,22 +41,22 @@
 
 	{{if and .IsSigned .MustChangePassword}}
 		<div class="right stackable menu">
-			<div class="ui dropdown jump item tooltip" tabindex="-1" data-content="{{.i18n.Tr "user_profile_and_more"}}">
+			<div class="ui dropdown jump item tooltip" tabindex="-1" data-content="{{.locale.Tr "user_profile_and_more"}}">
 				<span class="text">
 					{{avatar .SignedUser 24 "tiny"}}
-					<span class="sr-only">{{.i18n.Tr "user_profile_and_more"}}</span>
+					<span class="sr-only">{{.locale.Tr "user_profile_and_more"}}</span>
 					<span class="mobile-only">{{.SignedUser.Name}}</span>
 					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down"}}</span>
 				</span>
 				<div class="menu user-menu" tabindex="-1">
 					<div class="ui header">
-						{{.i18n.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
+						{{.locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
 					</div>
 
 					<div class="divider"></div>
 					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
 						{{svg "octicon-sign-out"}}
-						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
+						{{.locale.Tr "sign_out"}}<!-- Sign Out -->
 					</a>
 				</div><!-- end content avatar menu -->
 			</div><!-- end dropdown avatar menu -->
@@ -69,7 +69,7 @@
 						{{svg "octicon-stopwatch"}}
 						<span class="red" style="position:absolute; right:-0.6em; top:-0.6em;">{{svg "octicon-dot-fill"}}</span>
 					</span>
-					<span class="sr-mobile-only">{{.i18n.Tr "active_stopwatch"}}</span>
+					<span class="sr-mobile-only">{{.locale.Tr "active_stopwatch"}}</span>
 				</span>
 			</a>
 			<div class="ui popup very wide">
@@ -85,7 +85,7 @@
 						{{.CsrfTokenHtml}}
 						<button
 							class="ui button mini compact basic icon fitted tooltip"
-							data-content="{{.i18n.Tr "repo.issues.stop_tracking"}}"
+							data-content="{{.locale.Tr "repo.issues.stop_tracking"}}"
 							data-position="top right"
 						>{{svg "octicon-square-fill"}}</button>
 					</form>
@@ -93,17 +93,17 @@
 						{{.CsrfTokenHtml}}
 						<button
 							class="ui button mini compact basic icon fitted tooltip"
-							data-content="{{.i18n.Tr "repo.issues.cancel_tracking"}}"
+							data-content="{{.locale.Tr "repo.issues.cancel_tracking"}}"
 							data-position="top right"
 						>{{svg "octicon-trash"}}</button>
 					</form>
 				</div>
 			</div>
 
-			<a href="{{AppSubUrl}}/notifications" class="item tooltip" data-content='{{.i18n.Tr "notifications"}}'>
+			<a href="{{AppSubUrl}}/notifications" class="item tooltip" data-content='{{.locale.Tr "notifications"}}'>
 				<span class="text">
 					<span class="fitted">{{svg "octicon-bell"}}</span>
-					<span class="sr-mobile-only">{{.i18n.Tr "notifications"}}</span>
+					<span class="sr-mobile-only">{{.locale.Tr "notifications"}}</span>
 					{{$notificationUnreadCount := 0}}
 					{{if .NotificationUnreadCount}}{{$notificationUnreadCount = call .NotificationUnreadCount}}{{end}}
 					<span class="ui red label {{if not $notificationUnreadCount}}hidden{{end}} notification_count">
@@ -112,87 +112,87 @@
 				</span>
 			</a>
 
-			<div class="ui dropdown jump item tooltip" data-content="{{.i18n.Tr "create_new"}}">
+			<div class="ui dropdown jump item tooltip" data-content="{{.locale.Tr "create_new"}}">
 				<span class="text">
 					<span class="fitted">{{svg "octicon-plus"}}</span>
-					<span class="sr-mobile-only">{{.i18n.Tr "create_new"}}</span>
+					<span class="sr-mobile-only">{{.locale.Tr "create_new"}}</span>
 					<span class="fitted not-mobile">{{svg "octicon-triangle-down"}}</span>
 				</span>
 				<div class="menu">
 					<a class="item" href="{{AppSubUrl}}/repo/create">
-						<span class="fitted">{{svg "octicon-plus"}}</span> {{.i18n.Tr "new_repo"}}
+						<span class="fitted">{{svg "octicon-plus"}}</span> {{.locale.Tr "new_repo"}}
 					</a>
 					{{if not .DisableMigrations}}
 						<a class="item" href="{{AppSubUrl}}/repo/migrate">
-							<span class="fitted">{{svg "octicon-repo-push"}}</span> {{.i18n.Tr "new_migrate"}}
+							<span class="fitted">{{svg "octicon-repo-push"}}</span> {{.locale.Tr "new_migrate"}}
 						</a>
 					{{end}}
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
-						<span class="fitted">{{svg "octicon-organization"}}</span> {{.i18n.Tr "new_org"}}
+						<span class="fitted">{{svg "octicon-organization"}}</span> {{.locale.Tr "new_org"}}
 					</a>
 					{{end}}
 				</div><!-- end content create new menu -->
 			</div><!-- end dropdown menu create new -->
 
-			<div class="ui dropdown jump item tooltip" tabindex="-1" data-content="{{.i18n.Tr "user_profile_and_more"}}">
+			<div class="ui dropdown jump item tooltip" tabindex="-1" data-content="{{.locale.Tr "user_profile_and_more"}}">
 				<span class="text">
 					{{avatar .SignedUser 24 "tiny"}}
-					<span class="sr-only">{{.i18n.Tr "user_profile_and_more"}}</span>
+					<span class="sr-only">{{.locale.Tr "user_profile_and_more"}}</span>
 					<span class="mobile-only">{{.SignedUser.Name}}</span>
 					<span class="fitted not-mobile" tabindex="-1">{{svg "octicon-triangle-down"}}</span>
 				</span>
 				<div class="menu user-menu" tabindex="-1">
 					<div class="ui header">
-						{{.i18n.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
+						{{.locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
 					</div>
 
 					<div class="divider"></div>
 					<a class="item" href="{{.SignedUser.HomeLink}}">
 						{{svg "octicon-person"}}
-						{{.i18n.Tr "your_profile"}}<!-- Your profile -->
+						{{.locale.Tr "your_profile"}}<!-- Your profile -->
 					</a>
 					{{if not .DisableStars}}
 						<a class="item" href="{{.SignedUser.HomeLink}}?tab=stars">
 							{{svg "octicon-star"}}
-							{{.i18n.Tr "your_starred"}}
+							{{.locale.Tr "your_starred"}}
 						</a>
 					{{end}}
 					<a class="{{if .PageIsUserSettings}}active{{end}} item" href="{{AppSubUrl}}/user/settings">
 						{{svg "octicon-tools"}}
-						{{.i18n.Tr "your_settings"}}<!-- Your settings -->
+						{{.locale.Tr "your_settings"}}<!-- Your settings -->
 					</a>
 					<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">
 						{{svg "octicon-question"}}
-						{{.i18n.Tr "help"}}<!-- Help -->
+						{{.locale.Tr "help"}}<!-- Help -->
 					</a>
 					{{if .IsAdmin}}
 						<div class="divider"></div>
 
 						<a class="{{if .PageIsAdmin}}active{{end}} item" href="{{AppSubUrl}}/admin">
 							{{svg "octicon-server"}}
-							{{.i18n.Tr "admin_panel"}}<!-- Admin Panel -->
+							{{.locale.Tr "admin_panel"}}<!-- Admin Panel -->
 						</a>
 					{{end}}
 
 					<div class="divider"></div>
 					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
 						{{svg "octicon-sign-out"}}
-						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
+						{{.locale.Tr "sign_out"}}<!-- Sign Out -->
 					</a>
 				</div><!-- end content avatar menu -->
 			</div><!-- end dropdown avatar menu -->
 		</div><!-- end signed user right menu -->
 	{{else}}
-		<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">{{.i18n.Tr "help"}}</a>
+		<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">{{.locale.Tr "help"}}</a>
 		<div class="right stackable menu">
 			{{if .ShowRegistrationButton}}
 				<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
-					{{svg "octicon-person"}} {{.i18n.Tr "register"}}
+					{{svg "octicon-person"}} {{.locale.Tr "register"}}
 				</a>
 			{{end}}
 			<a class="item{{if .PageIsSignIn}} active{{end}}" rel="nofollow" href="{{AppSubUrl}}/user/login{{if not .PageIsSignIn}}?redirect_to={{.CurrentURL}}{{end}}">
-				{{svg "octicon-sign-in"}} {{.i18n.Tr "sign_in"}}
+				{{svg "octicon-sign-in"}} {{.locale.Tr "sign_in"}}
 			</a>
 		</div><!-- end anonymous right menu -->
 	{{end}}

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -38,10 +38,10 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 		mermaidMaxSourceCharacters: {{MermaidMaxSourceCharacters}},
 		{{/* this global i18n object should only contain general texts. for specialized texts, it should be provided inside the related modules by: (1) API response (2) HTML data-attribute (3) PageData */}}
 		i18n: {
-			copy_success: '{{.i18n.Tr "copy_success"}}',
-			copy_error: '{{.i18n.Tr "copy_error"}}',
-			error_occurred: '{{.i18n.Tr "error.occurred"}}',
-			network_error: '{{.i18n.Tr "error.network_error"}}',
+			copy_success: '{{.locale.Tr "copy_success"}}',
+			copy_error: '{{.locale.Tr "copy_error"}}',
+			error_occurred: '{{.locale.Tr "error.occurred"}}',
+			network_error: '{{.locale.Tr "error.network_error"}}',
 		},
 	};
 	{{/* in case some pages don't render the pageData, we make sure it is an object to prevent null access */}}

--- a/templates/base/paginate.tmpl
+++ b/templates/base/paginate.tmpl
@@ -5,11 +5,11 @@
 			<div class="ui borderless pagination menu">
 				<a class="{{if .IsFirst}}disabled{{end}} item navigation" {{if not .IsFirst}}href="{{$.Link}}{{if $paginationLink}}?{{$paginationLink}}{{end}}"{{end}}>
 					{{svg "gitea-double-chevron-left" 16 "mr-2"}}
-					<span class="navigation_label">{{$.i18n.Tr "admin.first_page"}}</span>
+					<span class="navigation_label">{{$.locale.Tr "admin.first_page"}}</span>
 				</a>
 				<a class="{{if not .HasPrevious}}disabled{{end}} item navigation" {{if .HasPrevious}}href="{{$.Link}}?page={{.Previous}}{{if $paginationLink}}&{{$paginationLink}}{{end}}"{{end}}>
 					{{svg "octicon-chevron-left" 16 "mr-2"}}
-					<span class="navigation_label">{{$.i18n.Tr "repo.issues.previous"}}</span>
+					<span class="navigation_label">{{$.locale.Tr "repo.issues.previous"}}</span>
 				</a>
 				{{range .Pages}}
 					{{if eq .Num -1}}
@@ -19,11 +19,11 @@
 					{{end}}
 				{{end}}
 				<a class="{{if not .HasNext}}disabled{{end}} item navigation" {{if .HasNext}}href="{{$.Link}}?page={{.Next}}{{if $paginationLink}}&{{$paginationLink}}{{end}}"{{end}}>
-					<span class="navigation_label">{{$.i18n.Tr "repo.issues.next"}}</span>
+					<span class="navigation_label">{{$.locale.Tr "repo.issues.next"}}</span>
 					{{svg "octicon-chevron-right" 16 "ml-2"}}
 				</a>
 				<a class="{{if .IsLast}}disabled{{end}} item navigation" {{if not .IsLast}}href="{{$.Link}}?page={{.TotalPages}}{{if $paginationLink}}&{{$paginationLink}}{{end}}"{{end}}>
-					<span class="navigation_label">{{$.i18n.Tr "admin.last_page"}}</span>
+					<span class="navigation_label">{{$.locale.Tr "admin.last_page"}}</span>
 					{{svg "gitea-double-chevron-right" 16 "ml-2"}}
 				</a>
 			</div>

--- a/templates/explore/code.tmpl
+++ b/templates/explore/code.tmpl
@@ -4,27 +4,27 @@
 	<div class="ui container">
 		<form class="ui form ignore-dirty" style="max-width: 100%">
 			<div class="ui fluid action input">
-				<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+				<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
 				<div class="ui dropdown selection{{if .CodeIndexerUnavailable }} disabled{{end}}">
 					<input name="t" type="hidden" value="{{.queryType}}"{{if .CodeIndexerUnavailable }} disabled{{end}}>{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-					<div class="text">{{.i18n.Tr (printf "explore.search.%s" (or .queryType "fuzzy"))}}</div>
+					<div class="text">{{.locale.Tr (printf "explore.search.%s" (or .queryType "fuzzy"))}}</div>
 					<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
-						<div class="item" data-value="">{{.i18n.Tr "explore.search.fuzzy"}}</div>
-						<div class="item" data-value="match">{{.i18n.Tr "explore.search.match"}}</div>
+						<div class="item" data-value="">{{.locale.Tr "explore.search.fuzzy"}}</div>
+						<div class="item" data-value="match">{{.locale.Tr "explore.search.match"}}</div>
 					</div>
 				</div>
-				<button class="ui primary button"{{if .CodeIndexerUnavailable }} disabled{{end}}>{{.i18n.Tr "explore.search"}}</button>
+				<button class="ui primary button"{{if .CodeIndexerUnavailable }} disabled{{end}}>{{.locale.Tr "explore.search"}}</button>
 			</div>
 		</form>
 		<div class="ui divider"></div>
 		<div class="ui user list">
 			{{if .CodeIndexerUnavailable }}
 				<div class="ui error message">
-					<p>{{$.i18n.Tr "explore.code_search_unavailable"}}</p>
+					<p>{{$.locale.Tr "explore.code_search_unavailable"}}</p>
 				</div>
 			{{else if .SearchResults}}
 				<h3>
-					{{.i18n.Tr "explore.code_search_results" (.Keyword|Escape) | Str2html }}
+					{{.locale.Tr "explore.code_search_results" (.Keyword|Escape) | Str2html }}
 				</h3>
 				<div class="df ac fw">
 					{{range $term := .SearchResultLanguages}}
@@ -43,11 +43,11 @@
 								<span class="file">
 									<a rel="nofollow" href="{{$repo.HTMLURL}}">{{$repo.FullName}}</a>
 										{{if $repo.IsArchived}}
-											<span class="ui basic label">{{$.i18n.Tr "repo.desc.archived"}}</span>
+											<span class="ui basic label">{{$.locale.Tr "repo.desc.archived"}}</span>
 										{{end}}
 									- {{.Filename}}
 								</span>
-								<a class="ui basic tiny button" rel="nofollow" href="{{$repo.HTMLURL}}/src/commit/{{$result.CommitID | PathEscape}}/{{.Filename | PathEscapeSegments}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+								<a class="ui basic tiny button" rel="nofollow" href="{{$repo.HTMLURL}}/src/commit/{{$result.CommitID | PathEscape}}/{{.Filename | PathEscapeSegments}}">{{$.locale.Tr "repo.diff.view_file"}}</a>
 							</h4>
 							<div class="ui attached table segment">
 								<div class="file-body file-code code-view">
@@ -70,7 +70,7 @@
 					{{end}}
 				</div>
 			{{else}}
-				<div>{{$.i18n.Tr "explore.code_no_results"}}</div>
+				<div>{{$.locale.Tr "explore.code_no_results"}}</div>
 			{{end}}
 		</div>
 

--- a/templates/explore/navbar.tmpl
+++ b/templates/explore/navbar.tmpl
@@ -1,18 +1,18 @@
 <div class="ui secondary pointing tabular top attached borderless stackable menu new-menu navbar">
 	<a class="{{if .PageIsExploreRepositories}}active{{end}} item" href="{{AppSubUrl}}/explore/repos">
-		{{svg "octicon-repo"}} {{.i18n.Tr "explore.repos"}}
+		{{svg "octicon-repo"}} {{.locale.Tr "explore.repos"}}
 	</a>
 	{{if not .UsersIsDisabled}}
 		<a class="{{if .PageIsExploreUsers}}active{{end}} item" href="{{AppSubUrl}}/explore/users">
-			{{svg "octicon-person"}} {{.i18n.Tr "explore.users"}}
+			{{svg "octicon-person"}} {{.locale.Tr "explore.users"}}
 		</a>
 	{{end}}
 	<a class="{{if .PageIsExploreOrganizations}}active{{end}} item" href="{{AppSubUrl}}/explore/organizations">
-		{{svg "octicon-organization"}} {{.i18n.Tr "explore.organizations"}}
+		{{svg "octicon-organization"}} {{.locale.Tr "explore.organizations"}}
 	</a>
 	{{if .IsRepoIndexerEnabled}}
 	<a class="{{if .PageIsExploreCode}}active{{end}} item" href="{{AppSubUrl}}/explore/code">
-		{{svg "octicon-code"}} {{.i18n.Tr "explore.code"}}
+		{{svg "octicon-code"}} {{.locale.Tr "explore.code"}}
 	</a>
 	{{end}}
 </div>

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -12,7 +12,7 @@
 						<span class="header">
 							<a href="{{.HomeLink}}">{{.Name}}</a> {{.FullName}}
 							{{if .Visibility.IsPrivate}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.desc.private"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.desc.private"}}</span>
 							{{end}}
 						</span>
 						<div class="description">
@@ -23,12 +23,12 @@
 								{{svg "octicon-link"}}
 								<a href="{{.Website}}" rel="nofollow">{{.Website}}</a>
 							{{end}}
-							{{svg "octicon-clock"}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+							{{svg "octicon-clock"}} {{$.locale.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 						</div>
 					</div>
 				</div>
 			{{else}}
-				<div>{{$.i18n.Tr "explore.org_no_results"}}</div>
+				<div>{{$.locale.Tr "explore.org_no_results"}}</div>
 			{{end}}
 		</div>
 

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -12,22 +12,22 @@
 					</a>
 					<div class="labels df ac fw">
 						{{if .IsArchived}}
-							<span class="ui basic label">{{$.i18n.Tr "repo.desc.archived"}}</span>
+							<span class="ui basic label">{{$.locale.Tr "repo.desc.archived"}}</span>
 						{{end}}
 						{{if .IsTemplate}}
 							{{if .IsPrivate}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.desc.private_template"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.desc.private_template"}}</span>
 							{{else}}
 								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{$.i18n.Tr "repo.desc.internal_template"}}</span>
+									<span class="ui basic label">{{$.locale.Tr "repo.desc.internal_template"}}</span>
 								{{end}}
 							{{end}}
 						{{else}}
 							{{if .IsPrivate}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.desc.private"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.desc.private"}}</span>
 							{{else}}
 								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{$.i18n.Tr "repo.desc.internal"}}</span>
+									<span class="ui basic label">{{$.locale.Tr "repo.desc.internal"}}</span>
 								{{end}}
 							{{end}}
 						{{end}}
@@ -60,12 +60,12 @@
 					{{end}}
 					</div>
 				{{end}}
-				<p class="time">{{$.i18n.Tr "org.repo_updated"}} {{TimeSinceUnix .UpdatedUnix $.i18n}}</p>
+				<p class="time">{{$.locale.Tr "org.repo_updated"}} {{TimeSinceUnix .UpdatedUnix $.locale}}</p>
 			</div>
 		</div>
 	{{else}}
 	<div>
-		{{$.i18n.Tr "explore.repo_no_results"}}
+		{{$.locale.Tr "explore.repo_no_results"}}
 	</div>
 	{{end}}
 </div>

--- a/templates/explore/repo_search.tmpl
+++ b/templates/explore/repo_search.tmpl
@@ -2,22 +2,22 @@
 	<!-- Sort -->
 	<div class="ui right dropdown type jump item">
 		<span class="text">
-			{{.i18n.Tr "repo.issues.filter_sort"}}
+			{{.locale.Tr "repo.issues.filter_sort"}}
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		</span>
 		<div class="menu">
-			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
-			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
+			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
+			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 			{{if not .DisableStars}}
-				<a class="{{if eq .SortType "moststars"}}active{{end}} item" href="{{$.Link}}?sort=moststars&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.moststars"}}</a>
-				<a class="{{if eq .SortType "feweststars"}}active{{end}} item" href="{{$.Link}}?sort=feweststars&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.feweststars"}}</a>
+				<a class="{{if eq .SortType "moststars"}}active{{end}} item" href="{{$.Link}}?sort=moststars&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.moststars"}}</a>
+				<a class="{{if eq .SortType "feweststars"}}active{{end}} item" href="{{$.Link}}?sort=feweststars&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.feweststars"}}</a>
 			{{end}}
-			<a class="{{if eq .SortType "mostforks"}}active{{end}} item" href="{{$.Link}}?sort=mostforks&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.mostforks"}}</a>
-			<a class="{{if eq .SortType "fewestforks"}}active{{end}} item" href="{{$.Link}}?sort=fewestforks&q={{$.Keyword}}&language={{$.Language}}">{{.i18n.Tr "repo.issues.filter_sort.fewestforks"}}</a>
+			<a class="{{if eq .SortType "mostforks"}}active{{end}} item" href="{{$.Link}}?sort=mostforks&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.mostforks"}}</a>
+			<a class="{{if eq .SortType "fewestforks"}}active{{end}} item" href="{{$.Link}}?sort=fewestforks&q={{$.Keyword}}&language={{$.Language}}">{{.locale.Tr "repo.issues.filter_sort.fewestforks"}}</a>
 		</div>
 	</div>
 </div>
@@ -25,8 +25,8 @@
 	<input type="hidden" name="sort" value="{{$.SortType}}">
 	<input type="hidden" name="language" value="{{$.Language}}">
 	<div class="ui fluid action input">
-		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-		<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+		<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+		<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 	</div>
 </form>
 <div class="ui divider"></div>

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -2,23 +2,23 @@
 <!-- Sort -->
 	<div class="ui right dropdown type jump item">
 		<span class="text">
-			{{.i18n.Tr "repo.issues.filter_sort"}}
+			{{.locale.Tr "repo.issues.filter_sort"}}
 			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		</span>
 		<div class="menu">
-			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
-			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+			<a class="{{if eq .SortType "newest"}}active{{end}} item" href="{{$.Link}}?sort=newest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+			<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?sort=oldest&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+			<a class="{{if eq .SortType "alphabetically"}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
+			<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&q={{$.Keyword}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
+			<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?sort=recentupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+			<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?sort=leastupdate&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 		</div>
 	</div>
 </div>
 <form class="ui form ignore-dirty" style="max-width: 90%">
 	<div class="ui fluid action input">
-		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
-		<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+		<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
+		<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 	</div>
 </form>
 <div class="ui divider"></div>

--- a/templates/explore/users.tmpl
+++ b/templates/explore/users.tmpl
@@ -18,12 +18,12 @@
 								{{svg "octicon-mail"}}
 								<a href="mailto:{{.Email}}" rel="nofollow">{{.Email}}</a>
 							{{end}}
-							{{svg "octicon-clock"}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+							{{svg "octicon-clock"}} {{$.locale.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 						</div>
 					</div>
 				</div>
 			{{else}}
-				<div>{{$.i18n.Tr "explore.user_no_results"}}</div>
+				<div>{{$.locale.Tr "explore.user_no_results"}}</div>
 			{{end}}
 		</div>
 

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -9,43 +9,43 @@
 				<h1 class="ui icon header title">
 					{{AppName}}
 				</h1>
-				<h2>{{.i18n.Tr "startpage.app_desc"}}</h2>
+				<h2>{{.locale.Tr "startpage.app_desc"}}</h2>
 			</div>
 		</div>
 	</div>
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-flame"}} {{.i18n.Tr "startpage.install"}}
+				{{svg "octicon-flame"}} {{.locale.Tr "startpage.install"}}
 			</h1>
 			<p class="large">
-				{{.i18n.Tr "startpage.install_desc" | Str2html}}
+				{{.locale.Tr "startpage.install_desc" | Str2html}}
 			</p>
 		</div>
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-device-desktop"}} {{.i18n.Tr "startpage.platform"}}
+				{{svg "octicon-device-desktop"}} {{.locale.Tr "startpage.platform"}}
 			</h1>
 			<p class="large">
-				{{.i18n.Tr "startpage.platform_desc" | Str2html}}
+				{{.locale.Tr "startpage.platform_desc" | Str2html}}
 			</p>
 		</div>
 	</div>
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-rocket"}} {{.i18n.Tr "startpage.lightweight"}}
+				{{svg "octicon-rocket"}} {{.locale.Tr "startpage.lightweight"}}
 			</h1>
 			<p class="large">
-				{{.i18n.Tr "startpage.lightweight_desc" | Str2html}}
+				{{.locale.Tr "startpage.lightweight_desc" | Str2html}}
 			</p>
 		</div>
 		<div class="eight wide center column">
 			<h1 class="hero ui icon header">
-				{{svg "octicon-code"}} {{.i18n.Tr "startpage.license"}}
+				{{svg "octicon-code"}} {{.locale.Tr "startpage.license"}}
 			</h1>
 			<p class="large">
-				{{.i18n.Tr "startpage.license_desc" | Str2html}}
+				{{.locale.Tr "startpage.license_desc" | Str2html}}
 			</p>
 		</div>
 	</div>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -3,19 +3,19 @@
 	<div class="ui middle very relaxed page grid">
 		<div class="sixteen wide center aligned centered column">
 			<h3 class="ui top attached header">
-				{{.i18n.Tr "install.title"}}
+				{{.locale.Tr "install.title"}}
 			</h3>
 			<div class="ui attached segment">
 				{{template "base/alert" .}}
 
-				<p>{{.i18n.Tr "install.docker_helper" "https://docs.gitea.io/en-us/install-with-docker/" | Safe}}</p>
+				<p>{{.locale.Tr "install.docker_helper" "https://docs.gitea.io/en-us/install-with-docker/" | Safe}}</p>
 
 				<form class="ui form" action="{{AppSubUrl}}/" method="post">
 					<!-- Database Settings -->
-					<h4 class="ui dividing header">{{.i18n.Tr "install.db_title"}}</h4>
-					<p>{{.i18n.Tr "install.require_db_desc"}}</p>
+					<h4 class="ui dividing header">{{.locale.Tr "install.db_title"}}</h4>
+					<p>{{.locale.Tr "install.require_db_desc"}}</p>
 					<div class="inline required field {{if .Err_DbType}}error{{end}}">
-						<label>{{.i18n.Tr "install.db_type"}}</label>
+						<label>{{.locale.Tr "install.db_type"}}</label>
 						<div class="ui selection database type dropdown">
 							<input type="hidden" id="db_type" name="db_type" value="{{.CurDbType}}">
 							<div class="text">{{.CurDbType}}</div>
@@ -30,27 +30,27 @@
 
 					<div class="hide" data-db-setting-for="common-host">
 						<div class="inline required field {{if .Err_DbSetting}}error{{end}}">
-							<label for="db_host">{{.i18n.Tr "install.host"}}</label>
+							<label for="db_host">{{.locale.Tr "install.host"}}</label>
 							<input id="db_host" name="db_host" value="{{.db_host}}">
 						</div>
 						<div class="inline required field {{if .Err_DbSetting}}error{{end}}">
-							<label for="db_user">{{.i18n.Tr "install.user"}}</label>
+							<label for="db_user">{{.locale.Tr "install.user"}}</label>
 							<input id="db_user" name="db_user" value="{{.db_user}}">
 						</div>
 						<div class="inline required field {{if .Err_DbSetting}}error{{end}}">
-							<label for="db_passwd">{{.i18n.Tr "install.password"}}</label>
+							<label for="db_passwd">{{.locale.Tr "install.password"}}</label>
 							<input id="db_passwd" name="db_passwd" type="password" value="{{.db_passwd}}">
 						</div>
 						<div class="inline required field {{if .Err_DbSetting}}error{{end}}">
-							<label for="db_name">{{.i18n.Tr "install.db_name"}}</label>
+							<label for="db_name">{{.locale.Tr "install.db_name"}}</label>
 							<input id="db_name" name="db_name" value="{{.db_name}}">
-							<span class="help">{{.i18n.Tr "install.db_helper"}}</span>
+							<span class="help">{{.locale.Tr "install.db_helper"}}</span>
 						</div>
 					</div>
 
 					<div class="hide" data-db-setting-for="postgres">
 						<div class="inline required field">
-							<label>{{.i18n.Tr "install.ssl_mode"}}</label>
+							<label>{{.locale.Tr "install.ssl_mode"}}</label>
 							<div class="ui selection database type dropdown">
 								<input type="hidden" name="ssl_mode" value="{{if .ssl_mode}}{{.ssl_mode}}{{else}}disable{{end}}">
 								<div class="default text">disable</div>
@@ -63,15 +63,15 @@
 							</div>
 						</div>
 						<div class="inline field {{if .Err_DbSetting}}error{{end}}">
-							<label for="db_schema">{{.i18n.Tr "install.db_schema"}}</label>
+							<label for="db_schema">{{.locale.Tr "install.db_schema"}}</label>
 							<input id="db_schema" name="db_schema" value="{{.db_schema}}">
-							<span class="help">{{.i18n.Tr "install.db_schema_helper"}}</span>
+							<span class="help">{{.locale.Tr "install.db_schema_helper"}}</span>
 						</div>
 					</div>
 
 					<div class="hide" data-db-setting-for="mysql">
 						<div class="inline required field">
-							<label>{{.i18n.Tr "install.charset"}}</label>
+							<label>{{.locale.Tr "install.charset"}}</label>
 							<div class="ui selection database type dropdown">
 								<input type="hidden" name="charset" value="{{if .charset}}{{.charset}}{{else}}utf8mb4{{end}}">
 								<div class="default text">utf8mb4</div>
@@ -85,30 +85,30 @@
 
 					<div class="hide" data-db-setting-for="sqlite3">
 						<div class="inline required field {{if or .Err_DbPath .Err_DbSetting}}error{{end}}">
-							<label for="db_path">{{.i18n.Tr "install.path"}}</label>
+							<label for="db_path">{{.locale.Tr "install.path"}}</label>
 							<input id="db_path" name="db_path" value="{{.db_path}}">
-							<span class="help">{{.i18n.Tr "install.sqlite_helper" | Safe}}</span>
+							<span class="help">{{.locale.Tr "install.sqlite_helper" | Safe}}</span>
 						</div>
 					</div>
 
 					{{if .Err_DbInstalledBefore}}
 					<div>
-						<p class="reinstall-message">{{.i18n.Tr "install.reinstall_confirm_message"}}</p>
+						<p class="reinstall-message">{{.locale.Tr "install.reinstall_confirm_message"}}</p>
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
-								<label>{{.i18n.Tr "install.reinstall_confirm_check_1"}}</label>
+								<label>{{.locale.Tr "install.reinstall_confirm_check_1"}}</label>
 								<input name="reinstall_confirm_first" type="checkbox">
 							</div>
 						</div>
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
-								<label>{{.i18n.Tr "install.reinstall_confirm_check_2"}}</label>
+								<label>{{.locale.Tr "install.reinstall_confirm_check_2"}}</label>
 								<input name="reinstall_confirm_second" type="checkbox">
 							</div>
 						</div>
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
-								<label>{{.i18n.Tr "install.reinstall_confirm_check_3"}}</label>
+								<label>{{.locale.Tr "install.reinstall_confirm_check_3"}}</label>
 								<input name="reinstall_confirm_third" type="checkbox">
 							</div>
 						</div>
@@ -116,88 +116,88 @@
 					{{end}}
 
 					<!-- General Settings -->
-					<h4 class="ui dividing header">{{.i18n.Tr "install.general_title"}}</h4>
+					<h4 class="ui dividing header">{{.locale.Tr "install.general_title"}}</h4>
 					<div class="inline required field {{if .Err_AppName}}error{{end}}">
-						<label for="app_name">{{.i18n.Tr "install.app_name"}}</label>
+						<label for="app_name">{{.locale.Tr "install.app_name"}}</label>
 						<input id="app_name" name="app_name" value="{{.app_name}}" required>
-						<span class="help">{{.i18n.Tr "install.app_name_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.app_name_helper"}}</span>
 					</div>
 					<div class="inline required field {{if .Err_RepoRootPath}}error{{end}}">
-						<label for="repo_root_path">{{.i18n.Tr "install.repo_path"}}</label>
+						<label for="repo_root_path">{{.locale.Tr "install.repo_path"}}</label>
 						<input id="repo_root_path" name="repo_root_path" value="{{.repo_root_path}}" required>
-						<span class="help">{{.i18n.Tr "install.repo_path_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.repo_path_helper"}}</span>
 					</div>
 					<div class="inline field {{if .Err_LFSRootPath}}error{{end}}">
-						<label for="lfs_root_path">{{.i18n.Tr "install.lfs_path"}}</label>
+						<label for="lfs_root_path">{{.locale.Tr "install.lfs_path"}}</label>
 						<input id="lfs_root_path" name="lfs_root_path" value="{{.lfs_root_path}}">
-						<span class="help">{{.i18n.Tr "install.lfs_path_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.lfs_path_helper"}}</span>
 					</div>
 					<div class="inline required field {{if .Err_RunUser}}error{{end}}">
-						<label for="run_user">{{.i18n.Tr "install.run_user"}}</label>
+						<label for="run_user">{{.locale.Tr "install.run_user"}}</label>
 						<input id="run_user" name="run_user" value="{{.run_user}}" required>
-						<span class="help">{{.i18n.Tr "install.run_user_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.run_user_helper"}}</span>
 					</div>
 					<div class="inline required field">
-						<label for="domain">{{.i18n.Tr "install.domain"}}</label>
+						<label for="domain">{{.locale.Tr "install.domain"}}</label>
 						<input id="domain" name="domain" value="{{.domain}}" placeholder="e.g. try.gitea.io" required>
-						<span class="help">{{.i18n.Tr "install.domain_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.domain_helper"}}</span>
 					</div>
 					<div class="inline field">
-						<label for="ssh_port">{{.i18n.Tr "install.ssh_port"}}</label>
+						<label for="ssh_port">{{.locale.Tr "install.ssh_port"}}</label>
 						<input id="ssh_port" name="ssh_port" value="{{.ssh_port}}">
-						<span class="help">{{.i18n.Tr "install.ssh_port_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.ssh_port_helper"}}</span>
 					</div>
 					<div class="inline required field">
-						<label for="http_port">{{.i18n.Tr "install.http_port"}}</label>
+						<label for="http_port">{{.locale.Tr "install.http_port"}}</label>
 						<input id="http_port" name="http_port" value="{{.http_port}}" required>
-						<span class="help">{{.i18n.Tr "install.http_port_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.http_port_helper"}}</span>
 					</div>
 					<div class="inline required field">
-						<label for="app_url">{{.i18n.Tr "install.app_url"}}</label>
+						<label for="app_url">{{.locale.Tr "install.app_url"}}</label>
 						<input id="app_url" name="app_url" value="{{.app_url}}" placeholder="e.g. https://try.gitea.io" required>
-						<span class="help">{{.i18n.Tr "install.app_url_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.app_url_helper"}}</span>
 					</div>
 					<div class="inline required field">
-						<label for="log_root_path">{{.i18n.Tr "install.log_root_path"}}</label>
+						<label for="log_root_path">{{.locale.Tr "install.log_root_path"}}</label>
 						<input id="log_root_path" name="log_root_path" value="{{.log_root_path}}" placeholder="log" required>
-						<span class="help">{{.i18n.Tr "install.log_root_path_helper"}}</span>
+						<span class="help">{{.locale.Tr "install.log_root_path_helper"}}</span>
 					</div>
 
 
 					<!-- Optional Settings -->
-					<h4 class="ui dividing header">{{.i18n.Tr "install.optional_title"}}</h4>
+					<h4 class="ui dividing header">{{.locale.Tr "install.optional_title"}}</h4>
 
 					<!-- Email -->
 					<details class="optional field">
 						<summary class="title py-3{{if .Err_SMTP}} text red{{end}}">
-							{{.i18n.Tr "install.email_title"}}
+							{{.locale.Tr "install.email_title"}}
 						</summary>
 						<div class="inline field">
-							<label for="smtp_host">{{.i18n.Tr "install.smtp_host"}}</label>
+							<label for="smtp_host">{{.locale.Tr "install.smtp_host"}}</label>
 							<input id="smtp_host" name="smtp_host" value="{{.smtp_host}}">
 						</div>
 						<div class="inline field {{if .Err_SMTPFrom}}error{{end}}">
-							<label for="smtp_from">{{.i18n.Tr "install.smtp_from"}}</label>
+							<label for="smtp_from">{{.locale.Tr "install.smtp_from"}}</label>
 							<input id="smtp_from" name="smtp_from" value="{{.smtp_from}}">
-							<span class="help">{{.i18n.Tr "install.smtp_from_helper"}}</span>
+							<span class="help">{{.locale.Tr "install.smtp_from_helper"}}</span>
 						</div>
 						<div class="inline field {{if .Err_SMTPUser}}error{{end}}">
-							<label for="smtp_user">{{.i18n.Tr "install.mailer_user"}}</label>
+							<label for="smtp_user">{{.locale.Tr "install.mailer_user"}}</label>
 							<input id="smtp_user" name="smtp_user" value="{{.smtp_user}}">
 						</div>
 						<div class="inline field">
-							<label for="smtp_passwd">{{.i18n.Tr "install.mailer_password"}}</label>
+							<label for="smtp_passwd">{{.locale.Tr "install.mailer_password"}}</label>
 							<input id="smtp_passwd" name="smtp_passwd" type="password" value="{{.smtp_passwd}}">
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label><strong>{{.i18n.Tr "install.register_confirm"}}</strong></label>
+								<label><strong>{{.locale.Tr "install.register_confirm"}}</strong></label>
 								<input name="register_confirm" type="checkbox" {{if .register_confirm}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label><strong>{{.i18n.Tr "install.mail_notify"}}</strong></label>
+								<label><strong>{{.locale.Tr "install.mail_notify"}}</strong></label>
 								<input name="mail_notify" type="checkbox" {{if .mail_notify}}checked{{end}}>
 							</div>
 						</div>
@@ -206,87 +206,87 @@
 					<!-- Server and other services -->
 					<details class="optional field">
 						<summary class="title py-3{{if .Err_Services}} text red{{end}}">
-							{{.i18n.Tr "install.server_service_title"}}
+							{{.locale.Tr "install.server_service_title"}}
 						</summary>
 						<div class="inline field">
 							<div class="ui checkbox" id="offline-mode">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.offline_mode_popup"}}"><strong>{{.i18n.Tr "install.offline_mode"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.offline_mode_popup"}}"><strong>{{.locale.Tr "install.offline_mode"}}</strong></label>
 								<input name="offline_mode" type="checkbox" {{if .offline_mode}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="disable-gravatar">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.disable_gravatar_popup"}}"><strong>{{.i18n.Tr "install.disable_gravatar"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.disable_gravatar_popup"}}"><strong>{{.locale.Tr "install.disable_gravatar"}}</strong></label>
 								<input name="disable_gravatar" type="checkbox" {{if .disable_gravatar}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="federated-avatar-lookup">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.federated_avatar_lookup_popup"}}"><strong>{{.i18n.Tr "install.federated_avatar_lookup"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.federated_avatar_lookup_popup"}}"><strong>{{.locale.Tr "install.federated_avatar_lookup"}}</strong></label>
 								<input name="enable_federated_avatar" type="checkbox" {{if .enable_federated_avatar}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="enable-openid-signin">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.openid_signin_popup"}}"><strong>{{.i18n.Tr "install.openid_signin"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.openid_signin_popup"}}"><strong>{{.locale.Tr "install.openid_signin"}}</strong></label>
 								<input name="enable_open_id_sign_in" type="checkbox" {{if .enable_open_id_sign_in}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="disable-registration">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.disable_registration_popup"}}"><strong>{{.i18n.Tr "install.disable_registration"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.disable_registration_popup"}}"><strong>{{.locale.Tr "install.disable_registration"}}</strong></label>
 								<input name="disable_registration" type="checkbox" {{if .disable_registration}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="allow-only-external-registration">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.allow_only_external_registration_popup"}}"><strong>{{.i18n.Tr "install.allow_only_external_registration_popup"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.allow_only_external_registration_popup"}}"><strong>{{.locale.Tr "install.allow_only_external_registration_popup"}}</strong></label>
 								<input name="allow_only_external_registration" type="checkbox" {{if .allow_only_external_registration}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="enable-openid-signup">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.openid_signup_popup"}}"><strong>{{.i18n.Tr "install.openid_signup"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.openid_signup_popup"}}"><strong>{{.locale.Tr "install.openid_signup"}}</strong></label>
 								<input name="enable_open_id_sign_up" type="checkbox" {{if .enable_open_id_sign_up}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="enable-captcha">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.enable_captcha_popup"}}"><strong>{{.i18n.Tr "install.enable_captcha"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.enable_captcha_popup"}}"><strong>{{.locale.Tr "install.enable_captcha"}}</strong></label>
 								<input name="enable_captcha" type="checkbox" {{if .enable_captcha}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.require_sign_in_view_popup"}}"><strong>{{.i18n.Tr "install.require_sign_in_view"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.require_sign_in_view_popup"}}"><strong>{{.locale.Tr "install.require_sign_in_view"}}</strong></label>
 								<input name="require_sign_in_view" type="checkbox" {{if .require_sign_in_view}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.default_keep_email_private_popup"}}"><strong>{{.i18n.Tr "install.default_keep_email_private"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.default_keep_email_private_popup"}}"><strong>{{.locale.Tr "install.default_keep_email_private"}}</strong></label>
 								<input name="default_keep_email_private" type="checkbox" {{if .default_keep_email_private}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.default_allow_create_organization_popup"}}"><strong>{{.i18n.Tr "install.default_allow_create_organization"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.default_allow_create_organization_popup"}}"><strong>{{.locale.Tr "install.default_allow_create_organization"}}</strong></label>
 								<input name="default_allow_create_organization" type="checkbox" {{if .default_allow_create_organization}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.i18n.Tr "install.default_enable_timetracking_popup"}}"><strong>{{.i18n.Tr "install.default_enable_timetracking"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.default_enable_timetracking_popup"}}"><strong>{{.locale.Tr "install.default_enable_timetracking"}}</strong></label>
 								<input name="default_enable_timetracking" type="checkbox" {{if .default_enable_timetracking}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">
-							<label for="no_reply_address">{{.i18n.Tr "install.no_reply_address"}}</label>
+							<label for="no_reply_address">{{.locale.Tr "install.no_reply_address"}}</label>
 							<input id="_no_reply_address" name="no_reply_address" value="{{.no_reply_address}}">
-							<span class="help">{{.i18n.Tr "install.no_reply_address_helper"}}</span>
+							<span class="help">{{.locale.Tr "install.no_reply_address_helper"}}</span>
 						</div>
 						<div class="inline field">
-							<label for="password_algorithm">{{.i18n.Tr "install.password_algorithm"}}</label>
+							<label for="password_algorithm">{{.locale.Tr "install.password_algorithm"}}</label>
 							<div class="ui selection dropdown">
 								<input id="password_algorithm" type="hidden" name="password_algorithm" value="{{.password_algorithm}}">
 								<div class="text">{{.password_algorithm}}</div>
@@ -297,30 +297,30 @@
 									{{end}}
 								</div>
 							</div>
-							<span class="help">{{.i18n.Tr "install.password_algorithm_helper"}}</span>
+							<span class="help">{{.locale.Tr "install.password_algorithm_helper"}}</span>
 						</div>
 					</details>
 
 					<!-- Admin -->
 					<details class="optional field">
 						<summary class="title py-3{{if .Err_Admin}} text red{{end}}">
-							{{.i18n.Tr "install.admin_title"}}
+							{{.locale.Tr "install.admin_title"}}
 						</summary>
-						<p class="center">{{.i18n.Tr "install.admin_setting_desc"}}</p>
+						<p class="center">{{.locale.Tr "install.admin_setting_desc"}}</p>
 						<div class="inline field {{if .Err_AdminName}}error{{end}}">
-							<label for="admin_name">{{.i18n.Tr "install.admin_name"}}</label>
+							<label for="admin_name">{{.locale.Tr "install.admin_name"}}</label>
 							<input id="admin_name" name="admin_name" value="{{.admin_name}}">
 						</div>
 						<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
-							<label for="admin_passwd">{{.i18n.Tr "install.admin_password"}}</label>
+							<label for="admin_passwd">{{.locale.Tr "install.admin_password"}}</label>
 							<input id="admin_passwd" name="admin_passwd" type="password" autocomplete="new-password" value="{{.admin_passwd}}">
 						</div>
 						<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
-							<label for="admin_confirm_passwd">{{.i18n.Tr "install.confirm_password"}}</label>
+							<label for="admin_confirm_passwd">{{.locale.Tr "install.confirm_password"}}</label>
 							<input id="admin_confirm_passwd" name="admin_confirm_passwd" autocomplete="new-password" type="password" value="{{.admin_confirm_passwd}}">
 						</div>
 						<div class="inline field {{if .Err_AdminEmail}}error{{end}}">
-							<label for="admin_email">{{.i18n.Tr "install.admin_email"}}</label>
+							<label for="admin_email">{{.locale.Tr "install.admin_email"}}</label>
 							<input id="admin_email" name="admin_email" type="email" value="{{.admin_email}}">
 						</div>
 					</details>
@@ -328,7 +328,7 @@
 					<div class="ui divider"></div>
 					<div class="inline field">
 						<label></label>
-						<button class="ui primary button">{{.i18n.Tr "install.install_btn_confirm"}}</button>
+						<button class="ui primary button">{{.locale.Tr "install.install_btn_confirm"}}</button>
 					</div>
 				</form>
 			</div>

--- a/templates/mail/auth/activate.tmpl
+++ b/templates/mail/auth/activate.tmpl
@@ -3,14 +3,14 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
-	<title>{{.i18n.Tr "mail.activate_account.title" (.DisplayName|DotEscape)}}</title>
+	<title>{{.locale.Tr "mail.activate_account.title" (.DisplayName|DotEscape)}}</title>
 </head>
 
 {{ $activate_url := printf "%suser/activate?code=%s" AppUrl (QueryEscape .Code)}}
 <body>
-	<p>{{.i18n.Tr "mail.activate_account.text_1" (.DisplayName|DotEscape) AppName | Str2html}}</p><br>
-	<p>{{.i18n.Tr "mail.activate_account.text_2" .ActiveCodeLives | Str2html}}</p><p><a href="{{$activate_url}}">{{$activate_url}}</a></p><br>
-	<p>{{.i18n.Tr "mail.link_not_working_do_paste"}}</p>
+	<p>{{.locale.Tr "mail.activate_account.text_1" (.DisplayName|DotEscape) AppName | Str2html}}</p><br>
+	<p>{{.locale.Tr "mail.activate_account.text_2" .ActiveCodeLives | Str2html}}</p><p><a href="{{$activate_url}}">{{$activate_url}}</a></p><br>
+	<p>{{.locale.Tr "mail.link_not_working_do_paste"}}</p>
 
 	<p>© <a target="_blank" rel="noopener noreferrer" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>

--- a/templates/mail/auth/activate_email.tmpl
+++ b/templates/mail/auth/activate_email.tmpl
@@ -2,15 +2,15 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
-	<title>{{.i18n.Tr "mail.activate_email.title" (.DisplayName|DotEscape)}}</title>
+	<meta Name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
+	<title>{{.locale.Tr "mail.activate_email.title" (.DisplayName|DotEscape)}}</title>
 </head>
 
 {{ $activate_url := printf "%suser/activate_email?code=%s&email=%s" AppUrl (QueryEscape .Code) (QueryEscape .Email)}}
 <body>
-	<p>{{.i18n.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
-	<p>{{.i18n.Tr "mail.activate_email.text" .ActiveCodeLives | Str2html}}</p><p><a href="{{$activate_url}}">{{$activate_url}}</a></p><br>
-	<p>{{.i18n.Tr "mail.link_not_working_do_paste"}}</p>
+	<p>{{.locale.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
+	<p>{{.locale.Tr "mail.activate_email.text" .ActiveCodeLives | Str2html}}</p><p><a href="{{$activate_url}}">{{$activate_url}}</a></p><br>
+	<p>{{.locale.Tr "mail.link_not_working_do_paste"}}</p>
 
 	<p>© <a target="_blank" rel="noopener noreferrer" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>

--- a/templates/mail/auth/register_notify.tmpl
+++ b/templates/mail/auth/register_notify.tmpl
@@ -3,15 +3,15 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
-	<title>{{.i18n.Tr "mail.register_notify.title" (.DisplayName|DotEscape) AppName}}</title>
+	<title>{{.locale.Tr "mail.register_notify.title" (.DisplayName|DotEscape) AppName}}</title>
 </head>
 
 {{$set_pwd_url := printf "%[1]suser/forgot_password" AppUrl}}
 <body>
-	<p>{{.i18n.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
-	<p>{{.i18n.Tr "mail.register_notify.text_1" AppName}}</p><br>
-	<p>{{.i18n.Tr "mail.register_notify.text_2" .Username}}</p><p><a href="{{AppUrl}}user/login">{{AppUrl}}user/login</a></p><br>
-	<p>{{.i18n.Tr "mail.register_notify.text_3" ($set_pwd_url | Escape) | Str2html}}</p><br>
+	<p>{{.locale.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
+	<p>{{.locale.Tr "mail.register_notify.text_1" AppName}}</p><br>
+	<p>{{.locale.Tr "mail.register_notify.text_2" .Username}}</p><p><a href="{{AppUrl}}user/login">{{AppUrl}}user/login</a></p><br>
+	<p>{{.locale.Tr "mail.register_notify.text_3" ($set_pwd_url | Escape) | Str2html}}</p><br>
 
 	<p>© <a target="_blank" rel="noopener noreferrer" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>

--- a/templates/mail/auth/reset_passwd.tmpl
+++ b/templates/mail/auth/reset_passwd.tmpl
@@ -3,14 +3,14 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
-	<title>{{.i18n.Tr "mail.reset_password.title" (.DisplayName|DotEscape)}}</title>
+	<title>{{.locale.Tr "mail.reset_password.title" (.DisplayName|DotEscape)}}</title>
 </head>
 
 {{ $recover_url := printf "%suser/recover_account?code=%s" AppUrl (QueryEscape .Code)}}
 <body>
-	<p>{{.i18n.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
-	<p>{{.i18n.Tr "mail.reset_password.text" .ResetPwdCodeLives | Str2html}}</p><p><a href="{{$recover_url}}">{{$recover_url}}</a></p><br>
-	<p>{{.i18n.Tr "mail.link_not_working_do_paste"}}</p>
+	<p>{{.locale.Tr "mail.hi_user_x" (.DisplayName|DotEscape) | Str2html}}</p><br>
+	<p>{{.locale.Tr "mail.reset_password.text" .ResetPwdCodeLives | Str2html}}</p><p><a href="{{$recover_url}}">{{$recover_url}}</a></p><br>
+	<p>{{.locale.Tr "mail.link_not_working_do_paste"}}</p>
 
 	<p>© <a target="_blank" rel="noopener noreferrer" href="{{AppUrl}}">{{AppName}}</a></p>
 </body>

--- a/templates/mail/issue/assigned.tmpl
+++ b/templates/mail/issue/assigned.tmpl
@@ -13,16 +13,16 @@
 <body>
 	<p>
 		{{if .IsPull}}
-			{{.i18n.Tr "mail.issue_assigned.pull" .Doer.Name $link $repo_url | Str2html}}
+			{{.locale.Tr "mail.issue_assigned.pull" .Doer.Name $link $repo_url | Str2html}}
 		{{else}}
-			{{.i18n.Tr "mail.issue_assigned.issue" .Doer.Name $link $repo_url | Str2html}}
+			{{.locale.Tr "mail.issue_assigned.issue" .Doer.Name $link $repo_url | Str2html}}
 		{{end}}
 	</p>
 	<div class="footer">
 		<p>
 			---
 			<br>
-			<a href="{{.Link}}">{{.i18n.Tr "mail.view_it_on" AppName}}</a>.
+			<a href="{{.Link}}">{{.locale.Tr "mail.view_it_on" AppName}}</a>.
 		</p>
 	</div>
 </body>

--- a/templates/mail/issue/default.tmpl
+++ b/templates/mail/issue/default.tmpl
@@ -16,7 +16,7 @@
 </head>
 
 <body>
-	{{if .IsMention}}<p>{{.i18n.Tr "mail.issue.x_mentioned_you" .Doer.Name | Str2html}}</p>{{end}}
+	{{if .IsMention}}<p>{{.locale.Tr "mail.issue.x_mentioned_you" .Doer.Name | Str2html}}</p>{{end}}
 	{{if eq .ActionName "push"}}
 		<p>
 			{{if .Comment.IsForcePush}}
@@ -28,41 +28,41 @@
 				{{$newShortSha := ShortSha .Comment.NewCommit}}
 				{{$newCommitLink := printf "<a href='%[1]s'><b>%[2]s</b></a>" (Escape $newCommitUrl) (Escape $newShortSha)}}
 
-				{{.i18n.Tr "mail.issue.action.force_push" .Doer.Name .Comment.Issue.PullRequest.HeadBranch $oldCommitLink $newCommitLink | Str2html}}
+				{{.locale.Tr "mail.issue.action.force_push" .Doer.Name .Comment.Issue.PullRequest.HeadBranch $oldCommitLink $newCommitLink | Str2html}}
 			{{else}}
-				{{.i18n.TrN (len .Comment.Commits) "mail.issue.action.push_1" "mail.issue.action.push_n" .Doer.Name .Comment.Issue.PullRequest.HeadBranch (len .Comment.Commits) | Str2html}}
+				{{.locale.TrN (len .Comment.Commits) "mail.issue.action.push_1" "mail.issue.action.push_n" .Doer.Name .Comment.Issue.PullRequest.HeadBranch (len .Comment.Commits) | Str2html}}
 			{{end}}
 		</p>
 	{{end}}
 	<p>
 		{{if eq .ActionName "close"}}
-			{{.i18n.Tr "mail.issue.action.close" (Escape .Doer.Name) .Issue.Index | Str2html}}
+			{{.locale.Tr "mail.issue.action.close" (Escape .Doer.Name) .Issue.Index | Str2html}}
 		{{else if eq .ActionName "reopen"}}
-			{{.i18n.Tr "mail.issue.action.reopen" (Escape .Doer.Name) .Issue.Index | Str2html}}
+			{{.locale.Tr "mail.issue.action.reopen" (Escape .Doer.Name) .Issue.Index | Str2html}}
 		{{else if eq .ActionName "merge"}}
-			{{.i18n.Tr "mail.issue.action.merge" (Escape .Doer.Name) .Issue.Index (Escape .Issue.PullRequest.BaseBranch) | Str2html}}
+			{{.locale.Tr "mail.issue.action.merge" (Escape .Doer.Name) .Issue.Index (Escape .Issue.PullRequest.BaseBranch) | Str2html}}
 		{{else if eq .ActionName "approve"}}
-			{{.i18n.Tr "mail.issue.action.approve" (Escape .Doer.Name) | Str2html}}
+			{{.locale.Tr "mail.issue.action.approve" (Escape .Doer.Name) | Str2html}}
 		{{else if eq .ActionName "reject"}}
-			{{.i18n.Tr "mail.issue.action.reject" (Escape .Doer.Name) | Str2html}}
+			{{.locale.Tr "mail.issue.action.reject" (Escape .Doer.Name) | Str2html}}
 		{{else if eq .ActionName "review"}}
-			{{.i18n.Tr "mail.issue.action.review" (Escape .Doer.Name) | Str2html}}
+			{{.locale.Tr "mail.issue.action.review" (Escape .Doer.Name) | Str2html}}
 		{{else if eq .ActionName "review_dismissed"}}
-			{{.i18n.Tr "mail.issue.action.review_dismissed" (Escape .Doer.Name) (Escape .Comment.Review.Reviewer.Name) | Str2html}}
+			{{.locale.Tr "mail.issue.action.review_dismissed" (Escape .Doer.Name) (Escape .Comment.Review.Reviewer.Name) | Str2html}}
 		{{else if eq .ActionName "ready_for_review"}}
-			{{.i18n.Tr "mail.issue.action.ready_for_review" (Escape .Doer.Name) | Str2html}}
+			{{.locale.Tr "mail.issue.action.ready_for_review" (Escape .Doer.Name) | Str2html}}
 		{{end}}
 
 		{{- if eq .Body ""}}
 			{{if eq .ActionName "new"}}
-				{{.i18n.Tr "mail.issue.action.new" (Escape .Doer.Name) .Issue.Index | Str2html}}
+				{{.locale.Tr "mail.issue.action.new" (Escape .Doer.Name) .Issue.Index | Str2html}}
 			{{end}}
 		{{else}}
 			{{.Body | Str2html}}
 		{{end -}}
 		{{- range .ReviewComments}}
 			<hr>
-			{{$.i18n.Tr "mail.issue.in_tree_path" .TreePath}}
+			{{$.locale.Tr "mail.issue.in_tree_path" .TreePath}}
 			<div class="review">
 				<pre>{{.Patch}}</pre>
 				<div>{{.RenderedContent | Safe}}</div>
@@ -84,7 +84,7 @@
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">{{.i18n.Tr "mail.view_it_on" AppName}}</a>.
+		<a href="{{.Link}}">{{.locale.Tr "mail.view_it_on" AppName}}</a>.
 	</p>
 	</div>
 </body>

--- a/templates/mail/notify/collaborator.tmpl
+++ b/templates/mail/notify/collaborator.tmpl
@@ -9,12 +9,12 @@
 </head>
 
 <body>
-	<p>{{.i18n.Tr "mail.repo.collaborator.added.text"}} <code>{{.RepoName}}</code></p>
+	<p>{{.locale.Tr "mail.repo.collaborator.added.text"}} <code>{{.RepoName}}</code></p>
 	<div class="footer">
 		<p>
 			---
 			<br>
-			<a href="{{.Link}}">{{.i18n.Tr "mail.view_it_on" AppName}}</a>.
+			<a href="{{.Link}}">{{.locale.Tr "mail.view_it_on" AppName}}</a>.
 		</p>
 	</div>
 </body>

--- a/templates/mail/notify/repo_transfer.tmpl
+++ b/templates/mail/notify/repo_transfer.tmpl
@@ -8,11 +8,11 @@
 {{$url := printf "<a href='%[1]s'>%[2]s</a>" (Escape .Link) (Escape .Repo)}}
 <body>
 	<p>{{.Subject}}.
-		{{.i18n.Tr "mail.repo.transfer.body" $url | Str2html}}
+		{{.locale.Tr "mail.repo.transfer.body" $url | Str2html}}
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">{{.i18n.Tr "mail.view_it_on" AppName}}</a>.
+		<a href="{{.Link}}">{{.locale.Tr "mail.view_it_on" AppName}}</a>.
 	</p>
 </body>
 </html>

--- a/templates/mail/release.tmpl
+++ b/templates/mail/release.tmpl
@@ -15,11 +15,11 @@
 {{$repo_url := printf "<a href='%s'>%s</a>" (.Release.Repo.HTMLURL | Escape) (.Release.Repo.FullName | Escape)}}
 <body>
 	<p>
-		{{.i18n.Tr "mail.release.new.text" .Release.Publisher.Name $release_url $repo_url | Str2html}}
+		{{.locale.Tr "mail.release.new.text" .Release.Publisher.Name $release_url $repo_url | Str2html}}
 	</p>
-	<h4>{{.i18n.Tr "mail.release.title" .Release.Title}}</h4>
+	<h4>{{.locale.Tr "mail.release.title" .Release.Title}}</h4>
 	<p>
-		{{.i18n.Tr "mail.release.note"}}<br>
+		{{.locale.Tr "mail.release.note"}}<br>
 		{{- if eq .Release.RenderedNote ""}}
 		{{else}}
 			{{.Release.RenderedNote | Str2html}}
@@ -29,13 +29,13 @@
 	<p>
 		---
 		<br>
-		{{.i18n.Tr "mail.release.downloads"}}
+		{{.locale.Tr "mail.release.downloads"}}
 		<ul>
 			<li>
-				<a href="{{.Release.Repo.Link}}/archive/{{.Release.TagName | PathEscapeSegments}}.zip" rel="nofollow"><strong>{{.i18n.Tr "mail.release.download.zip"}}</strong></a>
+				<a href="{{.Release.Repo.Link}}/archive/{{.Release.TagName | PathEscapeSegments}}.zip" rel="nofollow"><strong>{{.locale.Tr "mail.release.download.zip"}}</strong></a>
 			</li>
 			<li>
-				<a href="{{.Release.Repo.Link}}/archive/{{.Release.TagName | PathEscapeSegments}}.tar.gz" rel="nofollow"><strong>{{.i18n.Tr "mail.release.download.targz"}}</strong></a>
+				<a href="{{.Release.Repo.Link}}/archive/{{.Release.TagName | PathEscapeSegments}}.tar.gz" rel="nofollow"><strong>{{.locale.Tr "mail.release.download.targz"}}</strong></a>
 			</li>
 			{{if .Release.Attachments}}
 				{{range .Release.Attachments}}
@@ -52,7 +52,7 @@
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">{{.i18n.Tr "mail.view_it_on" AppName}}</a>.
+		<a href="{{.Link}}">{{.locale.Tr "mail.view_it_on" AppName}}</a>.
 	</p>
 	</div>
 </body>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -5,40 +5,40 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "new_org"}}
+					{{.locale.Tr "new_org"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_OrgName}}error{{end}}">
-						<label for="org_name">{{.i18n.Tr "org.org_name_holder"}}</label>
+						<label for="org_name">{{.locale.Tr "org.org_name_holder"}}</label>
 						<input id="org_name" name="org_name" value="{{.org_name}}" autofocus required>
-						<span class="help">{{.i18n.Tr "org.org_name_helper"}}</span>
+						<span class="help">{{.locale.Tr "org.org_name_helper"}}</span>
 					</div>
 
 					<div class="inline field {{if .Err_OrgVisibility}}error{{end}}">
-						<span class="inline required field"><label for="visibility">{{.i18n.Tr "org.settings.visibility"}}</label></span>
+						<span class="inline required field"><label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label></span>
 						<div class="inline-grouped-list">
 							<div class="ui radio checkbox">
 								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.public"}}</label>
+								<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 							</div>
 							<div class="ui radio checkbox">
 								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.limited"}}</label>
+								<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 							</div>
 							<div class="ui radio checkbox">
 								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
-								<label>{{.i18n.Tr "org.settings.visibility.private"}}</label>
+								<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 							</div>
 						</div>
 					</div>
 
 					<div class="inline field" id="permission_box">
-						<label>{{.i18n.Tr "org.settings.permission"}}</label>
+						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
 								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" checked/>
-								<label>{{.i18n.Tr "org.settings.repoadminchangeteam"}}</label>
+								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>
 					</div>
@@ -46,9 +46,9 @@
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "org.create_org"}}
+							{{.locale.Tr "org.create_org"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/org/header.tmpl
+++ b/templates/org/header.tmpl
@@ -6,8 +6,8 @@
 					{{avatar . 100}}
 					<span class="text thin grey"><a href="{{.HomeLink}}">{{.DisplayName}}</a></span>
 					<span class="org-visibility">
-						{{if .Visibility.IsLimited}}<div class="ui medium orange horizontal label">{{$.i18n.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-						{{if .Visibility.IsPrivate}}<div class="ui medium red horizontal label">{{$.i18n.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+						{{if .Visibility.IsLimited}}<div class="ui medium orange horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+						{{if .Visibility.IsPrivate}}<div class="ui medium red horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 					</span>
 				</div>
 			</div>

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -5,10 +5,10 @@
 		<div id="org-info">
 			<div class="ui header">
 				{{.Org.DisplayName}}
-				<a href="{{.Org.HomeLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{.i18n.Tr "rss_feed"}}" data-position="top center">{{svg "octicon-rss" 36}}</i></a>
+				<a href="{{.Org.HomeLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{.locale.Tr "rss_feed"}}" data-position="top center">{{svg "octicon-rss" 36}}</i></a>
 				<span class="org-visibility">
-					{{if .Org.Visibility.IsLimited}}<div class="ui large basic horizontal label">{{.i18n.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-					{{if .Org.Visibility.IsPrivate}}<div class="ui large basic horizontal label">{{.i18n.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+					{{if .Org.Visibility.IsLimited}}<div class="ui large basic horizontal label">{{.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+					{{if .Org.Visibility.IsPrivate}}<div class="ui large basic horizontal label">{{.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 				</span>
 			</div>
 			{{if $.RenderedDescription}}<p class="render-content markup">{{$.RenderedDescription|Str2html}}</p>{{end}}
@@ -32,15 +32,15 @@
 			<div class="ui five wide column">
 				{{if .CanCreateOrgRepo}}
 					<div class="center aligned">
-						<a class="ui green button" href="{{AppSubUrl}}/repo/create?org={{.Org.ID}}">{{.i18n.Tr "new_repo"}}</a>
+						<a class="ui green button" href="{{AppSubUrl}}/repo/create?org={{.Org.ID}}">{{.locale.Tr "new_repo"}}</a>
 						{{if not .DisableNewPullMirrors}}
-							<a class="ui green button" href="{{AppSubUrl}}/repo/migrate?org={{.Org.ID}}&mirror=1">{{.i18n.Tr "new_migrate"}}</a>
+							<a class="ui green button" href="{{AppSubUrl}}/repo/migrate?org={{.Org.ID}}&mirror=1">{{.locale.Tr "new_migrate"}}</a>
 						{{end}}
 					</div>
 					<div class="ui divider"></div>
 				{{end}}
 				<h4 class="ui top attached header df">
-					<strong class="f1">{{.i18n.Tr "org.people"}}</strong>
+					<strong class="f1">{{.locale.Tr "org.people"}}</strong>
 					{{if .IsOrganizationMember}}
 						<div class="ui">
 							<a class="text grey dif ac" href="{{.OrgLink}}/members"><span>{{.Org.NumMembers}}</span> {{svg "octicon-chevron-right"}}</a>
@@ -60,7 +60,7 @@
 
 				{{if .IsOrganizationMember}}
 					<div class="ui top attached header df">
-						<strong class="f1">{{.i18n.Tr "org.teams"}}</strong>
+						<strong class="f1">{{.locale.Tr "org.teams"}}</strong>
 						<div class="ui">
 							<a class="text grey dif ac" href="{{.OrgLink}}/teams"><span>{{.Org.NumTeams}}</span> {{svg "octicon-chevron-right"}}</a>
 						</div>
@@ -70,15 +70,15 @@
 							<div class="item">
 								<a href="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}"><strong class="team-name">{{.Name}}</strong></a>
 								<p class="text grey">
-									<a href="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}"><strong>{{.NumMembers}}</strong> {{$.i18n.Tr "org.lower_members"}}</a> ·
-									<a href="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}/repositories"><strong>{{.NumRepos}}</strong> {{$.i18n.Tr "org.lower_repositories"}}</a>
+									<a href="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}"><strong>{{.NumMembers}}</strong> {{$.locale.Tr "org.lower_members"}}</a> ·
+									<a href="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}/repositories"><strong>{{.NumRepos}}</strong> {{$.locale.Tr "org.lower_repositories"}}</a>
 								</p>
 							</div>
 						{{end}}
 					</div>
 					{{if .IsOrganizationOwner}}
 						<div class="ui bottom attached segment">
-							<a class="ui primary small button" href="{{.OrgLink}}/teams/new">{{.i18n.Tr "org.create_new_team"}}</a>
+							<a class="ui primary small button" href="{{.OrgLink}}/teams/new">{{.locale.Tr "org.create_new_team"}}</a>
 						</div>
 					{{end}}
 				{{end}}

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -16,30 +16,30 @@
 					</div>
 					<div class="ui four wide column center">
 						<div class="meta">
-							{{$.i18n.Tr "org.members.membership_visibility"}}
+							{{$.locale.Tr "org.members.membership_visibility"}}
 						</div>
 						<div class="meta">
 							{{ $isPublic := index $.MembersIsPublicMember .ID}}
 							{{if $isPublic}}
-								<strong>{{$.i18n.Tr "org.members.public"}}</strong>
-								{{if or (eq $.SignedUser.ID .ID) $.IsOrganizationOwner}}(<a class="link-action" href data-url="{{$.OrgLink}}/members/action/private?uid={{.ID}}">{{$.i18n.Tr "org.members.public_helper"}}</a>){{end}}
+								<strong>{{$.locale.Tr "org.members.public"}}</strong>
+								{{if or (eq $.SignedUser.ID .ID) $.IsOrganizationOwner}}(<a class="link-action" href data-url="{{$.OrgLink}}/members/action/private?uid={{.ID}}">{{$.locale.Tr "org.members.public_helper"}}</a>){{end}}
 							{{else}}
-								<strong>{{$.i18n.Tr "org.members.private"}}</strong>
-								{{if or (eq $.SignedUser.ID .ID) $.IsOrganizationOwner}}(<a class="link-action" href data-url="{{$.OrgLink}}/members/action/public?uid={{.ID}}">{{$.i18n.Tr "org.members.private_helper"}}</a>){{end}}
+								<strong>{{$.locale.Tr "org.members.private"}}</strong>
+								{{if or (eq $.SignedUser.ID .ID) $.IsOrganizationOwner}}(<a class="link-action" href data-url="{{$.OrgLink}}/members/action/public?uid={{.ID}}">{{$.locale.Tr "org.members.private_helper"}}</a>){{end}}
 							{{end}}
 						</div>
 					</div>
 					<div class="ui three wide column center">
 						<div class="meta">
-							{{$.i18n.Tr "org.members.member_role"}}
+							{{$.locale.Tr "org.members.member_role"}}
 						</div>
 						<div class="meta">
-							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock"}} {{$.i18n.Tr "org.members.owner"}}{{else}}{{$.i18n.Tr "org.members.member"}}{{end}}</strong>
+							<strong>{{if index $.MembersIsUserOrgOwner .ID}}{{svg "octicon-shield-lock"}} {{$.locale.Tr "org.members.owner"}}{{else}}{{$.locale.Tr "org.members.member"}}{{end}}</strong>
 						</div>
 					</div>
 					<div class="ui two wide column center">
 						<div class="meta">
-							{{$.i18n.Tr "admin.users.2fa"}}
+							{{$.locale.Tr "admin.users.2fa"}}
 						</div>
 						<div class="meta">
 							<strong>
@@ -58,14 +58,14 @@
 									<button class="ui red small button delete-button" data-modal-id="leave-organization"
 										data-url="{{$.OrgLink}}/members/action/leave" data-datauid="{{.ID}}"
 										data-name="{{.DisplayName}}"
-										data-data-organization-name="{{$.Org.DisplayName}}">{{$.i18n.Tr "org.members.leave"}}</button>
+										data-data-organization-name="{{$.Org.DisplayName}}">{{$.locale.Tr "org.members.leave"}}</button>
 								</form>
 							{{else if $.IsOrganizationOwner}}
 								<form>
 									<button class="ui red small button delete-button" data-modal-id="remove-organization-member"
 										data-url="{{$.OrgLink}}/members/action/remove" data-datauid="{{.ID}}"
 										data-name="{{.DisplayName}}"
-										data-data-organization-name="{{$.Org.DisplayName}}">{{$.i18n.Tr "org.members.remove"}}</button>
+										data-data-organization-name="{{$.Org.DisplayName}}">{{$.locale.Tr "org.members.remove"}}</button>
 								</form>
 							{{end}}
 						</div>
@@ -80,20 +80,20 @@
 <div class="ui small basic delete modal" id="leave-organization">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{$.i18n.Tr "org.members.leave"}}
+		{{$.locale.Tr "org.members.leave"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "org.members.leave.detail" `<span class="dataOrganizationName"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "org.members.leave.detail" `<span class="dataOrganizationName"></span>` | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>
 <div class="ui small basic delete modal" id="remove-organization-member">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{$.i18n.Tr "org.members.remove"}}
+		{{$.locale.Tr "org.members.remove"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "org.members.remove.detail" `<span class="name"></span>` `<span class="dataOrganizationName"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "org.members.remove.detail" `<span class="name"></span>` `<span class="dataOrganizationName"></span>` | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/menu.tmpl
+++ b/templates/org/menu.tmpl
@@ -1,22 +1,22 @@
 <div class="ui tabs container">
 	<div class="ui secondary stackable pointing menu">
 		<a class="{{if .PageIsViewRepositories}}active{{end}} item" href="{{$.Org.HomeLink}}">
-			{{svg "octicon-repo"}} {{.i18n.Tr "user.repositories"}}
+			{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 		</a>
 		{{if .IsPackageEnabled}}
 		<a class="item" href="{{$.Org.HomeLink}}/-/packages">
-			{{svg "octicon-package"}} {{.i18n.Tr "packages.title"}}
+			{{svg "octicon-package"}} {{.locale.Tr "packages.title"}}
 		</a>
 		{{end}}
 		{{if .IsOrganizationMember}}
 			<a class="{{if $.PageIsOrgMembers}}active{{end}} item" href="{{$.OrgLink}}/members">
-				{{svg "octicon-organization"}}&nbsp;{{$.i18n.Tr "org.people"}}
+				{{svg "octicon-organization"}}&nbsp;{{$.locale.Tr "org.people"}}
 				{{if .NumMembers}}
 					<div class="ui primary label">{{.NumMembers}}</div>
 				{{end}}
 			</a>
 			<a class="{{if $.PageIsOrgTeams}}active{{end}} item" href="{{$.OrgLink}}/teams">
-				{{svg "octicon-people"}}&nbsp;{{$.i18n.Tr "org.teams"}}
+				{{svg "octicon-people"}}&nbsp;{{$.locale.Tr "org.teams"}}
 				{{if .NumTeams}}
 					<div class="ui black label">{{.NumTeams}}</div>
 				{{end}}
@@ -26,7 +26,7 @@
 		{{if .IsOrganizationOwner}}
 			<div class="right menu">
 				<a class="{{if .PageIsOrgSettings}}active{{end}} item" href="{{.OrgLink}}/settings">
-				{{svg "octicon-tools"}} {{.i18n.Tr "repo.settings"}}
+				{{svg "octicon-tools"}} {{.locale.Tr "repo.settings"}}
 				</a>
 			</div>
 		{{end}}

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -7,20 +7,20 @@
 			<div class="twelve wide column content">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached error header">
-					{{.i18n.Tr "org.settings.delete_account"}}
+					{{.locale.Tr "org.settings.delete_account"}}
 				</h4>
 				<div class="ui attached error segment">
 					<div class="ui red message">
-						<p class="text left">{{svg "octicon-alert"}} {{.i18n.Tr "org.settings.delete_prompt" | Str2html}}</p>
+						<p class="text left">{{svg "octicon-alert"}} {{.locale.Tr "org.settings.delete_prompt" | Str2html}}</p>
 					</div>
 					<form class="ui form ignore-dirty" id="delete-form" action="{{.Link}}" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="inline required field {{if .Err_OrgName}}error{{end}}">
-							<label for="org_name">{{.i18n.Tr "org.org_name_holder"}}</label>
+							<label for="org_name">{{.locale.Tr "org.org_name_holder"}}</label>
 							<input id="org_name" name="org_name" value="" autocomplete="off" autofocus required>
 						</div>
 						<div class="ui red button delete-button" data-type="form" data-form="#delete-form">
-							{{.i18n.Tr "org.settings.confirm_delete_account"}}
+							{{.locale.Tr "org.settings.confirm_delete_account"}}
 						</div>
 					</form>
 				</div>
@@ -32,10 +32,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "org.settings.delete_org_title"}}
+		{{.locale.Tr "org.settings.delete_org_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "org.settings.delete_org_desc"}}</p>
+		<p>{{.locale.Tr "org.settings.delete_org_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/settings/hook_new.tmpl
+++ b/templates/org/settings/hook_new.tmpl
@@ -7,7 +7,7 @@
 			<div class="twelve wide column content">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{if .PageIsSettingsHooksNew}}{{.i18n.Tr "repo.settings.add_webhook"}}{{else}}{{.i18n.Tr "repo.settings.update_webhook"}}{{end}}
+					{{if .PageIsSettingsHooksNew}}{{.locale.Tr "repo.settings.add_webhook"}}{{else}}{{.locale.Tr "repo.settings.update_webhook"}}{{end}}
 					<div class="ui right">
 						{{if eq .HookType "gitea"}}
 							<img width="26" height="26" src="{{AssetUrlPrefix}}/img/gitea.svg">

--- a/templates/org/settings/labels.tmpl
+++ b/templates/org/settings/labels.tmpl
@@ -7,11 +7,11 @@
 				<div class="ui twelve wide column content">
 					<div class="ui grid">
 						<div class="left floated twelve wide column">
-							{{$.i18n.Tr "org.settings.labels_desc" | Str2html}}
+							{{$.locale.Tr "org.settings.labels_desc" | Str2html}}
 						</div>
 						<div class="right floated three wide column">
 							<div class="ui right">
-								<div class="ui green new-label button">{{.i18n.Tr "repo.issues.new_label"}}</div>
+								<div class="ui green new-label button">{{.locale.Tr "repo.issues.new_label"}}</div>
 							</div>
 						</div>
 					</div>

--- a/templates/org/settings/navbar.tmpl
+++ b/templates/org/settings/navbar.tmpl
@@ -1,19 +1,19 @@
 <div class="four wide column">
 	<div class="ui fluid vertical menu">
-		<div class="header item">{{.i18n.Tr "org.settings"}}</div>
+		<div class="header item">{{.locale.Tr "org.settings"}}</div>
 		<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.OrgLink}}/settings">
-			{{.i18n.Tr "org.settings.options"}}
+			{{.locale.Tr "org.settings.options"}}
 		</a>
 		{{if not DisableWebhooks}}
 		<a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.OrgLink}}/settings/hooks">
-			{{.i18n.Tr "repo.settings.hooks"}}
+			{{.locale.Tr "repo.settings.hooks"}}
 		</a>
 		{{end}}
 		<a class="{{if .PageIsOrgSettingsLabels}}active{{end}} item" href="{{.OrgLink}}/settings/labels">
-			{{.i18n.Tr "repo.labels"}}
+			{{.locale.Tr "repo.labels"}}
 		</a>
 		<a class="{{if .PageIsSettingsDelete}}active{{end}} item" href="{{.OrgLink}}/settings/delete">
-			{{.i18n.Tr "org.settings.delete"}}
+			{{.locale.Tr "org.settings.delete"}}
 		</a>
 	</div>
 </div>

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -7,64 +7,64 @@
 			<div class="twelve wide column content">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "org.settings.options"}}
+					{{.locale.Tr "org.settings.options"}}
 				</h4>
 				<div class="ui attached segment">
 					<form class="ui form" action="{{.Link}}" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="required field {{if .Err_Name}}error{{end}}">
-							<label for="org_name">{{.i18n.Tr "org.org_name_holder"}}
-								<span class="text red hide" id="org-name-change-prompt"> {{.i18n.Tr "org.settings.change_orgname_prompt"}}</span>
-								<span class="text red hide" id="org-name-change-redirect-prompt"> {{.i18n.Tr "org.settings.change_orgname_redirect_prompt"}}</span>
+							<label for="org_name">{{.locale.Tr "org.org_name_holder"}}
+								<span class="text red hide" id="org-name-change-prompt"> {{.locale.Tr "org.settings.change_orgname_prompt"}}</span>
+								<span class="text red hide" id="org-name-change-redirect-prompt"> {{.locale.Tr "org.settings.change_orgname_redirect_prompt"}}</span>
 							</label>
 							<input id="org_name" name="name" value="{{.Org.Name}}" data-org-name="{{.Org.Name}}" autofocus required>
 						</div>
 						<div class="field {{if .Err_FullName}}error{{end}}">
-							<label for="full_name">{{.i18n.Tr "org.org_full_name_holder"}}</label>
+							<label for="full_name">{{.locale.Tr "org.org_full_name_holder"}}</label>
 							<input id="full_name" name="full_name" value="{{.Org.FullName}}">
 						</div>
 						<div class="field {{if .Err_Description}}error{{end}}">
-							<label for="description">{{$.i18n.Tr "org.org_desc"}}</label>
+							<label for="description">{{$.locale.Tr "org.org_desc"}}</label>
 							<textarea id="description" name="description" rows="2">{{.Org.Description}}</textarea>
 						</div>
 						<div class="field {{if .Err_Website}}error{{end}}">
-							<label for="website">{{.i18n.Tr "org.settings.website"}}</label>
+							<label for="website">{{.locale.Tr "org.settings.website"}}</label>
 							<input id="website" name="website" type="url" value="{{.Org.Website}}">
 						</div>
 						<div class="field">
-							<label for="location">{{.i18n.Tr "org.settings.location"}}</label>
+							<label for="location">{{.locale.Tr "org.settings.location"}}</label>
 							<input id="location" name="location"  value="{{.Org.Location}}">
 						</div>
 
 						<div class="ui divider"></div>
 						<div class="field" id="visibility_box">
-							<label for="visibility">{{.i18n.Tr "org.settings.visibility"}}</label>
+							<label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label>
 							<div class="field">
 								<div class="ui radio checkbox">
 									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if eq .CurrentVisibility 0}}checked{{end}}/>
-									<label>{{.i18n.Tr "org.settings.visibility.public"}}</label>
+									<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
 									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if eq .CurrentVisibility 1}}checked{{end}}/>
-									<label>{{.i18n.Tr "org.settings.visibility.limited"}}</label>
+									<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
 									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if eq .CurrentVisibility 2}}checked{{end}}/>
-									<label>{{.i18n.Tr "org.settings.visibility.private"}}</label>
+									<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 								</div>
 							</div>
 						</div>
 
 						<div class="field" id="permission_box">
-							<label>{{.i18n.Tr "org.settings.permission"}}</label>
+							<label>{{.locale.Tr "org.settings.permission"}}</label>
 							<div class="field">
 								<div class="ui checkbox">
 									<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if .RepoAdminChangeTeamAccess}}checked{{end}}/>
-									<label>{{.i18n.Tr "org.settings.repoadminchangeteam"}}</label>
+									<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 								</div>
 							</div>
 						</div>
@@ -73,14 +73,14 @@
 						<div class="ui divider"></div>
 
 						<div class="inline field {{if .Err_MaxRepoCreation}}error{{end}}">
-							<label for="max_repo_creation">{{.i18n.Tr "admin.users.max_repo_creation"}}</label>
+							<label for="max_repo_creation">{{.locale.Tr "admin.users.max_repo_creation"}}</label>
 							<input id="max_repo_creation" name="max_repo_creation" type="number" value="{{.Org.MaxRepoCreation}}">
-							<p class="help">{{.i18n.Tr "admin.users.max_repo_creation_desc"}}</p>
+							<p class="help">{{.locale.Tr "admin.users.max_repo_creation_desc"}}</p>
 						</div>
 						{{end}}
 
 						<div class="field">
-							<button class="ui green button">{{$.i18n.Tr "org.settings.update_settings"}}</button>
+							<button class="ui green button">{{$.locale.Tr "org.settings.update_settings"}}</button>
 						</div>
 					</form>
 
@@ -89,13 +89,13 @@
 					<form class="ui form" action="{{.Link}}/avatar" method="post" enctype="multipart/form-data">
 						{{.CsrfTokenHtml}}
 						<div class="inline field">
-							<label for="avatar">{{.i18n.Tr "settings.choose_new_avatar"}}</label>
+							<label for="avatar">{{.locale.Tr "settings.choose_new_avatar"}}</label>
 							<input name="avatar" type="file" >
 						</div>
 
 						<div class="field">
-							<button class="ui green button">{{$.i18n.Tr "settings.update_avatar"}}</button>
-							<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.i18n.Tr "settings.delete_current_avatar"}}</a>
+							<button class="ui green button">{{$.locale.Tr "settings.update_avatar"}}</button>
+							<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.locale.Tr "settings.delete_current_avatar"}}</a>
 						</div>
 					</form>
 				</div>

--- a/templates/org/team/members.tmpl
+++ b/templates/org/team/members.tmpl
@@ -15,11 +15,11 @@
 							<div class="inline field ui left">
 								<div id="search-user-box" class="ui search">
 									<div class="ui input">
-										<input class="prompt" name="uname" placeholder="{{.i18n.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" required>
+										<input class="prompt" name="uname" placeholder="{{.locale.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" required>
 									</div>
 								</div>
 							</div>
-							<button class="ui green button">{{.i18n.Tr "org.teams.add_team_member"}}</button>
+							<button class="ui green button">{{.locale.Tr "org.teams.add_team_member"}}</button>
 						</form>
 					</div>
 				{{end}}
@@ -31,7 +31,7 @@
 									<button class="ui red button delete-button right" data-modal-id="remove-team-member"
 										data-url="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/remove" data-datauid="{{.ID}}"
 										data-name="{{.DisplayName}}"
-										data-data-team-name="{{$.Team.Name}}">{{$.i18n.Tr "org.members.remove"}}</button>
+										data-data-team-name="{{$.Team.Name}}">{{$.locale.Tr "org.members.remove"}}</button>
 								</form>
 							{{end}}
 							<a href="{{.HomeLink}}">
@@ -41,7 +41,7 @@
 						</div>
 					{{else}}
 						<div class="item">
-							<span class="text grey italic">{{$.i18n.Tr "org.teams.members.none"}}</span>
+							<span class="text grey italic">{{$.locale.Tr "org.teams.members.none"}}</span>
 						</div>
 					{{end}}
 				</div>
@@ -52,10 +52,10 @@
 <div class="ui small basic delete modal" id="remove-team-member">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{$.i18n.Tr "org.members.remove"}}
+		{{$.locale.Tr "org.members.remove"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "org.members.remove.detail" `<span class="name"></span>` `<span class="dataTeamName"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "org.members.remove.detail" `<span class="name"></span>` `<span class="dataTeamName"></span>` | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/team/navbar.tmpl
+++ b/templates/org/team/navbar.tmpl
@@ -1,4 +1,4 @@
 <div class="ui top attached tabular menu">
-	<a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}">{{svg "octicon-person"}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.i18n.Tr "org.lower_members"}}</a>
-	<a class="item{{if .PageIsOrgTeamRepos}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/repositories">{{svg "octicon-repo"}} <strong>{{.Team.NumRepos}}</strong>&nbsp; {{$.i18n.Tr "org.lower_repositories"}}</a>
+	<a class="item{{if .PageIsOrgTeamMembers}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}">{{svg "octicon-person"}} <strong>{{.Team.NumMembers}}</strong>&nbsp; {{$.locale.Tr "org.lower_members"}}</a>
+	<a class="item{{if .PageIsOrgTeamRepos}} active{{end}}" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/repositories">{{svg "octicon-repo"}} <strong>{{.Team.NumRepos}}</strong>&nbsp; {{$.locale.Tr "org.lower_repositories"}}</a>
 </div>

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -7,83 +7,83 @@
 				<form class="ui form" action="{{if .PageIsOrgTeamsNew}}{{.OrgLink}}/teams/new{{else}}{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/edit{{end}}" data-delete-url="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/delete" method="post">
 					{{.CsrfTokenHtml}}
 					<h3 class="ui top attached header">
-						{{if .PageIsOrgTeamsNew}}{{.i18n.Tr "org.create_new_team"}}{{else}}{{.i18n.Tr "org.teams.settings"}}{{end}}
+						{{if .PageIsOrgTeamsNew}}{{.locale.Tr "org.create_new_team"}}{{else}}{{.locale.Tr "org.teams.settings"}}{{end}}
 					</h3>
 					<div class="ui attached segment">
 						{{template "base/alert" .}}
 						<div class="required field {{if .Err_TeamName}}error{{end}}">
-							<label for="team_name">{{.i18n.Tr "org.team_name"}}</label>
+							<label for="team_name">{{.locale.Tr "org.team_name"}}</label>
 							{{if eq .Team.LowerName "owners"}}
 								<input type="hidden" name="team_name" value="{{.Team.Name}}">
 							{{end}}
 							<input id="team_name" name="team_name" value="{{.Team.Name}}" required {{if eq .Team.LowerName "owners"}}disabled{{end}} autofocus>
-							<span class="help">{{.i18n.Tr "org.team_name_helper"}}</span>
+							<span class="help">{{.locale.Tr "org.team_name_helper"}}</span>
 						</div>
 						<div class="field {{if .Err_Description}}error{{end}}">
-							<label for="description">{{.i18n.Tr "org.team_desc"}}</label>
+							<label for="description">{{.locale.Tr "org.team_desc"}}</label>
 							<input id="description" name="description" value="{{.Team.Description}}">
-							<span class="help">{{.i18n.Tr "org.team_desc_helper"}}</span>
+							<span class="help">{{.locale.Tr "org.team_desc_helper"}}</span>
 						</div>
 						{{if not (eq .Team.LowerName "owners")}}
 							<div class="grouped field">
-								<label>{{.i18n.Tr "org.team_access_desc"}}</label>
+								<label>{{.locale.Tr "org.team_access_desc"}}</label>
 								<br>
 								<div class="field">
 									<div class="ui radio checkbox">
 										<input type="radio" name="repo_access" value="specific" {{if not .Team.IncludesAllRepositories}}checked{{end}}>
-										<label>{{.i18n.Tr "org.teams.specific_repositories"}}</label>
-										<span class="help">{{.i18n.Tr "org.teams.specific_repositories_helper" | Str2html}}</span>
+										<label>{{.locale.Tr "org.teams.specific_repositories"}}</label>
+										<span class="help">{{.locale.Tr "org.teams.specific_repositories_helper" | Str2html}}</span>
 									</div>
 								</div>
 								<div class="field">
 									<div class="ui radio checkbox">
 										<input type="radio" name="repo_access" value="all" {{if .Team.IncludesAllRepositories}}checked{{end}}>
-										<label>{{.i18n.Tr "org.teams.all_repositories"}}</label>
-										<span class="help">{{.i18n.Tr "org.teams.all_repositories_helper" | Str2html}}</span>
+										<label>{{.locale.Tr "org.teams.all_repositories"}}</label>
+										<span class="help">{{.locale.Tr "org.teams.all_repositories_helper" | Str2html}}</span>
 									</div>
 								</div>
 
 								<div class="field">
 									<div class="ui checkbox">
-										<label for="can_create_org_repo">{{.i18n.Tr "org.teams.can_create_org_repo"}}</label>
+										<label for="can_create_org_repo">{{.locale.Tr "org.teams.can_create_org_repo"}}</label>
 										<input id="can_create_org_repo" name="can_create_org_repo" type="checkbox" {{if .Team.CanCreateOrgRepo}}checked{{end}}>
-										<span class="help">{{.i18n.Tr "org.teams.can_create_org_repo_helper"}}</span>
+										<span class="help">{{.locale.Tr "org.teams.can_create_org_repo_helper"}}</span>
 									</div>
 								</div>
 							</div>
 							<div class="grouped field">
-								<label>{{.i18n.Tr "org.team_permission_desc"}}</label>
+								<label>{{.locale.Tr "org.team_permission_desc"}}</label>
 								<br>
 								<div class="field">
 									<div class="ui radio checkbox">
 										<input type="radio" name="permission" value="read" {{if or .PageIsOrgTeamsNew (eq .Team.AccessMode 1) (eq .Team.AccessMode 2)}}checked{{end}}>
-										<label>{{.i18n.Tr "org.teams.general_access"}}</label>
-										<span class="help">{{.i18n.Tr "org.teams.general_access_helper"}}</span>
+										<label>{{.locale.Tr "org.teams.general_access"}}</label>
+										<span class="help">{{.locale.Tr "org.teams.general_access_helper"}}</span>
 									</div>
 								</div>
 								<div class="field">
 									<div class="ui radio checkbox">
 										<input type="radio" name="permission" value="admin" {{if eq .Team.AccessMode 3}}checked{{end}}>
-										<label>{{.i18n.Tr "org.teams.admin_access"}}</label>
-										<span class="help">{{.i18n.Tr "org.teams.admin_access_helper"}}</span>
+										<label>{{.locale.Tr "org.teams.admin_access"}}</label>
+										<span class="help">{{.locale.Tr "org.teams.admin_access_helper"}}</span>
 									</div>
 								</div>
 							</div>
 							<div class="ui divider"></div>
 
 							<div class="team-units required grouped field"{{if eq .Team.AccessMode 3}} style="display: none"{{end}}>
-								<label>{{.i18n.Tr "org.team_unit_desc"}}</label>
+								<label>{{.locale.Tr "org.team_unit_desc"}}</label>
 								<table class="ui celled table">
 									<thead>
 										<tr>
-											<th class="center aligned">{{.i18n.Tr "units.unit"}}</th>
-											<th class="center aligned">{{.i18n.Tr "org.teams.none_access"}}
-											<i class="circle help icon link tooltip" data-content="{{.i18n.Tr "org.teams.none_access_helper"}}"></i></th>
-											<th class="center aligned">{{.i18n.Tr "org.teams.read_access"}}
-											<i class="circle help icon link tooltip" data-content="{{.i18n.Tr "org.teams.read_access_helper"}}"></i>
+											<th class="center aligned">{{.locale.Tr "units.unit"}}</th>
+											<th class="center aligned">{{.locale.Tr "org.teams.none_access"}}
+											<i class="circle help icon link tooltip" data-content="{{.locale.Tr "org.teams.none_access_helper"}}"></i></th>
+											<th class="center aligned">{{.locale.Tr "org.teams.read_access"}}
+											<i class="circle help icon link tooltip" data-content="{{.locale.Tr "org.teams.read_access_helper"}}"></i>
 											</th>
-											<th class="center aligned">{{.i18n.Tr "org.teams.write_access"}}
-											<i class="circle help icon link tooltip" data-content="{{.i18n.Tr "org.teams.write_access_helper"}}"></i>
+											<th class="center aligned">{{.locale.Tr "org.teams.write_access"}}
+											<i class="circle help icon link tooltip" data-content="{{.locale.Tr "org.teams.write_access_helper"}}"></i>
 											</th>
 										</tr>
 									</thead>
@@ -92,10 +92,10 @@
 											{{if ge $unit.MaxPerm 2}}
 												<tr>
 													<td>
-														<div {{if $unit.Type.UnitGlobalDisabled}}class="field tooltip" data-content="{{$.i18n.Tr "repo.unit_disabled"}}"{{- else -}}class="field"{{end}}>
+														<div {{if $unit.Type.UnitGlobalDisabled}}class="field tooltip" data-content="{{$.locale.Tr "repo.unit_disabled"}}"{{- else -}}class="field"{{end}}>
 															<div class="ui">
-																<label>{{$.i18n.Tr $unit.NameKey}}{{if $unit.Type.UnitGlobalDisabled}} {{$.i18n.Tr "org.team_unit_disabled"}}{{end}}</label>
-																<span class="help">{{$.i18n.Tr $unit.DescKey}}</span>
+																<label>{{$.locale.Tr $unit.NameKey}}{{if $unit.Type.UnitGlobalDisabled}} {{$.locale.Tr "org.team_unit_disabled"}}{{end}}</label>
+																<span class="help">{{$.locale.Tr $unit.DescKey}}</span>
 															</div>
 														</div>
 													</td>
@@ -121,11 +121,11 @@
 								</table>
 								{{range $t, $unit := $.Units}}
 									{{if lt $unit.MaxPerm 2}}
-										<div {{if $unit.Type.UnitGlobalDisabled}}class="field tooltip" data-content="{{$.i18n.Tr "repo.unit_disabled"}}"{{else}}class="field"{{end}}>
+										<div {{if $unit.Type.UnitGlobalDisabled}}class="field tooltip" data-content="{{$.locale.Tr "repo.unit_disabled"}}"{{else}}class="field"{{end}}>
 											<div class="ui checkbox">
 												<input type="checkbox" class="hidden" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}}>
-												<label>{{$.i18n.Tr $unit.NameKey}}{{if $unit.Type.UnitGlobalDisabled}} {{$.i18n.Tr "org.team_unit_disabled"}}{{end}}</label>
-												<span class="help">{{$.i18n.Tr $unit.DescKey}}</span>
+												<label>{{$.locale.Tr $unit.NameKey}}{{if $unit.Type.UnitGlobalDisabled}} {{$.locale.Tr "org.team_unit_disabled"}}{{end}}</label>
+												<span class="help">{{$.locale.Tr $unit.DescKey}}</span>
 											</div>
 										</div>
 									{{end}}
@@ -135,12 +135,12 @@
 
 						<div class="field">
 							{{if .PageIsOrgTeamsNew}}
-								<button class="ui green button">{{.i18n.Tr "org.create_team"}}</button>
-								<a class="ui button" href="{{.OrgLink}}/teams">{{.i18n.Tr "cancel"}}</a>
+								<button class="ui green button">{{.locale.Tr "org.create_team"}}</button>
+								<a class="ui button" href="{{.OrgLink}}/teams">{{.locale.Tr "cancel"}}</a>
 							{{else}}
-								<button class="ui green button">{{.i18n.Tr "org.teams.update_settings"}}</button>
+								<button class="ui green button">{{.locale.Tr "org.teams.update_settings"}}</button>
 								{{if not (eq .Team.LowerName "owners")}}
-									<button class="ui red button delete-button" data-url="{{.OrgLink}}/teams/{{.team_name | PathEscape}}/delete">{{.i18n.Tr "org.teams.delete_team"}}</button>
+									<button class="ui red button delete-button" data-url="{{.OrgLink}}/teams/{{.team_name | PathEscape}}/delete">{{.locale.Tr "org.teams.delete_team"}}</button>
 								{{end}}
 							{{end}}
 						</div>
@@ -154,10 +154,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "org.teams.delete_team_title"}}
+		{{.locale.Tr "org.teams.delete_team_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "org.teams.delete_team_desc"}}</p>
+		<p>{{.locale.Tr "org.teams.delete_team_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -16,17 +16,17 @@
 								<div class="inline field ui left">
 									<div id="search-repo-box" data-uid="{{.Org.ID}}" class="ui search">
 										<div class="ui input">
-											<input class="prompt" name="repo_name" placeholder="{{.i18n.Tr "org.teams.search_repo_placeholder"}}" autocomplete="off" required>
+											<input class="prompt" name="repo_name" placeholder="{{.locale.Tr "org.teams.search_repo_placeholder"}}" autocomplete="off" required>
 										</div>
 									</div>
 								</div>
-								<button class="ui green button">{{.i18n.Tr "add"}}</button>
+								<button class="ui green button">{{.locale.Tr "add"}}</button>
 							</form>
 						</div>
 						<div class="inline ui field right">
 							<form class="ui form" id="repo-multiple-form" action="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/repositories" method="post">
-								<button class="ui red button delete-button right" data-url="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/repo/removeall">{{.i18n.Tr "remove_all"}}</button>
-								<button class="ui green button add-all-button right" data-url="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/repo/addall">{{.i18n.Tr "add_all"}}</button>
+								<button class="ui red button delete-button right" data-url="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/repo/removeall">{{.locale.Tr "remove_all"}}</button>
+								<button class="ui green button add-all-button right" data-url="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/repo/addall">{{.locale.Tr "add_all"}}</button>
 							</form>
 						</div>
 					</div>
@@ -37,7 +37,7 @@
 							{{if $canAddRemove}}
 								<form method="post" action="{{$.OrgLink}}/teams/{{$.Team.LowerName | PathEscape}}/action/repo/remove">
 									{{$.CsrfTokenHtml}}
-									<button type="submit" class="ui red small button right" name="repoid" value="{{.ID}}">{{$.i18n.Tr "remove"}}</button>
+									<button type="submit" class="ui red small button right" name="repoid" value="{{.ID}}">{{$.locale.Tr "remove"}}</button>
 								</form>
 							{{end}}
 							<a class="member" href="{{$.Org.HomeLink}}/{{.Name | PathEscape}}">
@@ -55,7 +55,7 @@
 						</div>
 					{{else}}
 						<div class="item">
-							<span class="text grey italic">{{$.i18n.Tr "org.teams.repos.none"}}</span>
+							<span class="text grey italic">{{$.locale.Tr "org.teams.repos.none"}}</span>
 						</div>
 					{{end}}
 				</div>
@@ -67,10 +67,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "org.teams.remove_all_repos_title"}}
+		{{.locale.Tr "org.teams.remove_all_repos_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "org.teams.remove_all_repos_desc"}}</p>
+		<p>{{.locale.Tr "org.teams.remove_all_repos_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>
@@ -78,10 +78,10 @@
 <div class="ui small basic addall modal">
 	<div class="ui icon header">
 		<i class="globe icon"></i>
-		{{.i18n.Tr "org.teams.add_all_repos_title"}}
+		{{.locale.Tr "org.teams.add_all_repos_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "org.teams.add_all_repos_desc"}}</p>
+		<p>{{.locale.Tr "org.teams.add_all_repos_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/team/sidebar.tmpl
+++ b/templates/org/team/sidebar.tmpl
@@ -6,13 +6,13 @@
 				<form>
 					<button class="ui red tiny button delete-button" data-modal-id="leave-team-sidebar"
 						data-url="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/action/leave" data-datauid="{{$.SignedUser.ID}}"
-						data-name="{{.Team.Name}}">{{$.i18n.Tr "org.teams.leave"}}</button>
+						data-name="{{.Team.Name}}">{{$.locale.Tr "org.teams.leave"}}</button>
 				</form>
 			{{else if .IsOrganizationOwner}}
 				<form method="post" action="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/action/join">
 					{{$.CsrfTokenHtml}}
 					<input type="hidden" name="page" value="team"/>
-					<button type="submit" class="ui primary tiny button" name="uid" value="{{$.SignedUser.ID}}">{{$.i18n.Tr "org.teams.join"}}</button>
+					<button type="submit" class="ui primary tiny button" name="uid" value="{{$.SignedUser.ID}}">{{$.locale.Tr "org.teams.join"}}</button>
 				</form>
 			{{end}}
 		</div>
@@ -22,51 +22,51 @@
 			{{if .Team.Description}}
 				{{.Team.Description}}
 			{{else}}
-				<span class="text grey italic">{{.i18n.Tr "org.teams.no_desc"}}</span>
+				<span class="text grey italic">{{.locale.Tr "org.teams.no_desc"}}</span>
 			{{end}}
 		</div>
 		{{if eq .Team.LowerName "owners"}}
 			<div class="item">
-				{{.i18n.Tr "org.teams.owners_permission_desc" | Str2html}}
+				{{.locale.Tr "org.teams.owners_permission_desc" | Str2html}}
 			</div>
 		{{else}}
 			<div class="item">
-				<h3>{{.i18n.Tr "org.team_access_desc"}}</h3>
+				<h3>{{.locale.Tr "org.team_access_desc"}}</h3>
 				<ul>
 					{{if .Team.IncludesAllRepositories}}
-						<li>{{.i18n.Tr "org.teams.all_repositories" | Str2html}}
+						<li>{{.locale.Tr "org.teams.all_repositories" | Str2html}}
 					{{else}}
-						<li>{{.i18n.Tr "org.teams.specific_repositories" | Str2html}}
+						<li>{{.locale.Tr "org.teams.specific_repositories" | Str2html}}
 					{{end}}
 					{{if .Team.CanCreateOrgRepo}}
-						<li>{{.i18n.Tr "org.teams.can_create_org_repo"}}
+						<li>{{.locale.Tr "org.teams.can_create_org_repo"}}
 					{{end}}
 				</ul>
 				{{if (eq .Team.AccessMode 2)}}
-					<h3>{{.i18n.Tr "org.settings.permission"}}</h3>
-					{{.i18n.Tr "org.teams.write_permission_desc" | Str2html}}
+					<h3>{{.locale.Tr "org.settings.permission"}}</h3>
+					{{.locale.Tr "org.teams.write_permission_desc" | Str2html}}
 				{{else if (eq .Team.AccessMode 3)}}
-					<h3>{{.i18n.Tr "org.settings.permission"}}</h3>
-					{{.i18n.Tr "org.teams.admin_permission_desc" | Str2html}}
+					<h3>{{.locale.Tr "org.settings.permission"}}</h3>
+					{{.locale.Tr "org.teams.admin_permission_desc" | Str2html}}
 				{{else}}
 					<table class="ui table">
 						<thead>
 							<tr>
-								<th>{{.i18n.Tr "units.unit"}}</th>
-								<th>{{.i18n.Tr "org.team_permission_desc"}}</th>
+								<th>{{.locale.Tr "units.unit"}}</th>
+								<th>{{.locale.Tr "org.team_permission_desc"}}</th>
 							</tr>
 						</thead>
 						<tbody>
 							{{range $t, $unit := $.Units}}
 								{{if and (lt $unit.MaxPerm 2) (not $unit.Type.UnitGlobalDisabled)}}
 									<tr>
-										<td><strong>{{$.i18n.Tr $unit.NameKey}}</strong></td>
+										<td><strong>{{$.locale.Tr $unit.NameKey}}</strong></td>
 										<td>{{if eq ($.Team.UnitAccessMode $unit.Type) 0 -}}
-										{{$.i18n.Tr "org.teams.none_access"}}
+										{{$.locale.Tr "org.teams.none_access"}}
 										{{- else if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $unit.Type) 1) -}}
-										{{$.i18n.Tr "org.teams.read_access"}}
+										{{$.locale.Tr "org.teams.read_access"}}
 										{{- else if eq ($.Team.UnitAccessMode $unit.Type) 2 -}}
-										{{$.i18n.Tr "org.teams.write_access"}}
+										{{$.locale.Tr "org.teams.write_access"}}
 										{{- end}}</td>
 									</tr>
 								{{end}}
@@ -79,17 +79,17 @@
 	</div>
 	{{if .IsOrganizationOwner}}
 		<div class="ui bottom attached segment">
-			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/edit">{{svg "octicon-gear"}} {{$.i18n.Tr "org.teams.settings"}}</a>
+			<a class="ui teal small button" href="{{.OrgLink}}/teams/{{.Team.LowerName | PathEscape}}/edit">{{svg "octicon-gear"}} {{$.locale.Tr "org.teams.settings"}}</a>
 		</div>
 	{{end}}
 </div>
 <div class="ui small basic delete modal" id="leave-team-sidebar">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{$.i18n.Tr "org.teams.leave"}}
+		{{$.locale.Tr "org.teams.leave"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "org.teams.leave.detail" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "org.teams.leave.detail" `<span class="name"></span>` | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/org/team/teams.tmpl
+++ b/templates/org/team/teams.tmpl
@@ -5,7 +5,7 @@
 		{{template "base/alert" .}}
 		{{if .IsOrganizationOwner}}
 			<div class="text right">
-				<a class="ui green button" href="{{.OrgLink}}/teams/new">{{svg "octicon-plus"}} {{.i18n.Tr "org.create_new_team"}}</a>
+				<a class="ui green button" href="{{.OrgLink}}/teams/new">{{svg "octicon-plus"}} {{.locale.Tr "org.create_new_team"}}</a>
 			</div>
 			<div class="ui divider"></div>
 		{{end}}
@@ -20,12 +20,12 @@
 								<form>
 									<button class="ui red tiny button delete-button" data-modal-id="leave-team"
 										data-url="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}/action/leave" data-datauid="{{$.SignedUser.ID}}"
-										data-name="{{.Name}}">{{$.i18n.Tr "org.teams.leave"}}</button>
+										data-name="{{.Name}}">{{$.locale.Tr "org.teams.leave"}}</button>
 								</form>
 							{{else if $.IsOrganizationOwner}}
 								<form method="post" action="{{$.OrgLink}}/teams/{{.LowerName | PathEscape}}/action/join">
 									{{$.CsrfTokenHtml}}
-									<button type="submit" class="ui primary small button" name="uid" value="{{$.SignedUser.ID}}">{{$.i18n.Tr "org.teams.join"}}</button>
+									<button type="submit" class="ui primary small button" name="uid" value="{{$.SignedUser.ID}}">{{$.locale.Tr "org.teams.join"}}</button>
 								</form>
 							{{end}}
 						</div>
@@ -38,7 +38,7 @@
 						{{end}}
 					</div>
 					<div class="ui bottom attached header">
-						<p class="team-meta">{{.NumMembers}} {{$.i18n.Tr "org.lower_members"}} · {{.NumRepos}} {{$.i18n.Tr "org.lower_repositories"}}</p>
+						<p class="team-meta">{{.NumMembers}} {{$.locale.Tr "org.lower_members"}} · {{.NumRepos}} {{$.locale.Tr "org.lower_repositories"}}</p>
 					</div>
 				</div>
 			{{end}}
@@ -48,10 +48,10 @@
 <div class="ui small basic delete modal" id="leave-team">
 	<div class="ui icon header">
 		{{svg "octicon-x" 16 "close inside"}}
-		{{$.i18n.Tr "org.teams.leave"}}
+		{{$.locale.Tr "org.teams.leave"}}
 	</div>
 	<div class="content">
-		<p>{{$.i18n.Tr "org.teams.leave.detail" `<span class="name"></span>` | Safe}}</p>
+		<p>{{$.locale.Tr "org.teams.leave.detail" `<span class="name"></span>` | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/package/content/composer.tmpl
+++ b/templates/package/content/composer.tmpl
@@ -1,9 +1,9 @@
 {{if eq .PackageDescriptor.Package.Type "composer"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.composer.registry" | Safe}}</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.composer.registry" | Safe}}</label>
 				<div class="markup"><pre class="code-block"><code>{
 	"repositories": [{
 			"type": "composer",
@@ -13,34 +13,34 @@
 }</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.composer.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.composer.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>composer require {{.PackageDescriptor.Package.Name}}:{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.composer.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.composer.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{.PackageDescriptor.Metadata.Description}}
 		</div>
 	{{end}}
 
 	{{if or .PackageDescriptor.Metadata.Require .PackageDescriptor.Metadata.RequireDev}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<div class="ui list">
-				{{template "package/content/composer_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.Require "title" (.i18n.Tr "packages.composer.dependencies")}}
-				{{template "package/content/composer_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.RequireDev "title" (.i18n.Tr "packages.composer.dependencies.development")}}
+				{{template "package/content/composer_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.Require "title" (.locale.Tr "packages.composer.dependencies")}}
+				{{template "package/content/composer_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.RequireDev "title" (.locale.Tr "packages.composer.dependencies.development")}}
 			</div>
 		</div>
 	{{end}}
 
 	{{if or .PackageDescriptor.Metadata.Keywords}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.keywords"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.keywords"}}</h4>
 		<div class="ui attached segment">
 			{{range .PackageDescriptor.Metadata.Keywords}}
 				{{.}}

--- a/templates/package/content/composer_dependencies.tmpl
+++ b/templates/package/content/composer_dependencies.tmpl
@@ -3,8 +3,8 @@
 <table class="ui single line very basic table">
 	<thead>
 		<tr>
-			<th class="eleven wide">{{.root.i18n.Tr "packages.dependency.id"}}</th>
-			<th class="five wide">{{.root.i18n.Tr "packages.dependency.version"}}</th>
+			<th class="eleven wide">{{.root.locale.Tr "packages.dependency.id"}}</th>
+			<th class="five wide">{{.root.locale.Tr "packages.dependency.version"}}</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/package/content/conan.tmpl
+++ b/templates/package/content/conan.tmpl
@@ -1,30 +1,30 @@
 {{if eq .PackageDescriptor.Package.Type "conan"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.conan.registry"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.conan.registry"}}</label>
 				<div class="markup"><pre class="code-block"><code>conan remote add gitea {{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/conan</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.conan.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.conan.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>conan install --remote=gitea {{.PackageDescriptor.Package.Name}}/{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.conan.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.conan.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{if .PackageDescriptor.Metadata.Description}}{{.PackageDescriptor.Metadata.Description}}{{end}}
 		</div>
 	{{end}}
 
 	{{if or .PackageDescriptor.Metadata.Keywords}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.keywords"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.keywords"}}</h4>
 		<div class="ui attached segment">
 			{{range .PackageDescriptor.Metadata.Keywords}}
 				{{.}}

--- a/templates/package/content/container.tmpl
+++ b/templates/package/content/container.tmpl
@@ -1,9 +1,9 @@
 {{if eq .PackageDescriptor.Package.Type "container"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.container.pull"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.container.pull"}}</label>
 				{{if eq .PackageDescriptor.Metadata.Type "helm"}}
 				<div class="markup"><pre class="code-block"><code>helm pull oci://{{.RegistryHost}}/{{.PackageDescriptor.Owner.LowerName}}/{{.PackageDescriptor.Package.LowerName}} --version {{.PackageDescriptor.Version.LowerVersion}}</code></pre></div>
 				{{else}}
@@ -15,12 +15,12 @@
 				{{end}}
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.container.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.container.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 	{{if .PackageDescriptor.Metadata.MultiArch}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.container.multi_arch"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.container.multi_arch"}}</h4>
 		<div class="ui attached segment">
 			<div class="ui form">
 			{{range $arch, $digest := .PackageDescriptor.Metadata.MultiArch}}
@@ -35,13 +35,13 @@
 		</div>
 	{{end}}
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{.PackageDescriptor.Metadata.Description}}
 		</div>
 	{{end}}
 	{{if .PackageDescriptor.Metadata.ImageLayers}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.container.layers"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.container.layers"}}</h4>
 		<div class="ui attached segment">
 			<table id="notice-table" class="ui very basic compact table">
 				<tbody>
@@ -55,13 +55,13 @@
 		</div>
 	{{end}}
 	{{if .PackageDescriptor.Metadata.Labels}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.container.labels"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.container.labels"}}</h4>
 		<div class="ui attached segment">
 			<table id="notice-table" class="ui very basic compact table">
 				<thead>
 					<tr>
-						<th>{{.i18n.Tr "packages.container.labels.key"}}</th>
-						<th>{{.i18n.Tr "packages.container.labels.value"}}</th>
+						<th>{{.locale.Tr "packages.container.labels.key"}}</th>
+						<th>{{.locale.Tr "packages.container.labels.value"}}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/templates/package/content/generic.tmpl
+++ b/templates/package/content/generic.tmpl
@@ -1,13 +1,13 @@
 {{if eq .PackageDescriptor.Package.Type "generic"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.generic.download"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.generic.download"}}</label>
 				<div class="markup"><pre class="code-block"><code>curl {{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/generic/{{.PackageDescriptor.Package.Name}}/{{.PackageDescriptor.Version.Version}}/{{(index .PackageDescriptor.Files 0).File.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.generic.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.generic.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/helm.tmpl
+++ b/templates/package/content/helm.tmpl
@@ -1,37 +1,37 @@
 {{if eq .PackageDescriptor.Package.Type "helm"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.helm.registry"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.helm.registry"}}</label>
 				<div class="markup"><pre class="code-block"><code>helm repo add gitea {{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/helm
 helm repo update</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.helm.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.helm.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>helm install {{.PackageDescriptor.Package.Name}} gitea/{{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.helm.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.helm.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{.PackageDescriptor.Metadata.Description}}
 		</div>
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Dependencies}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<table class="ui single line very basic table">
 				<thead>
 					<tr>
-						<th class="ten wide">{{.i18n.Tr "packages.dependency.id"}}</th>
-						<th class="six wide">{{.i18n.Tr "packages.dependency.version"}}</th>
+						<th class="ten wide">{{.locale.Tr "packages.dependency.id"}}</th>
+						<th class="six wide">{{.locale.Tr "packages.dependency.version"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -47,7 +47,7 @@ helm repo update</code></pre></div>
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Keywords}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.keywords"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.keywords"}}</h4>
 		<div class="ui attached segment">
 			{{range .PackageDescriptor.Metadata.Keywords}}
 				{{.}}

--- a/templates/package/content/maven.tmpl
+++ b/templates/package/content/maven.tmpl
@@ -1,9 +1,9 @@
 {{if eq .PackageDescriptor.Package.Type "maven"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.maven.registry" | Safe}}</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.maven.registry" | Safe}}</label>
 				<div class="markup"><pre class="code-block"><code>&lt;repositories&gt;
 	&lt;repository&gt;
 		&lt;id&gt;gitea&lt;/id&gt;
@@ -24,7 +24,7 @@
 &lt;/distributionManagement&gt;</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.maven.install" | Safe}}</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.maven.install" | Safe}}</label>
 				<div class="markup"><pre class="code-block"><code>&lt;dependency&gt;
 	&lt;groupId&gt;{{.PackageDescriptor.Metadata.GroupID}}&lt;/groupId&gt;
 	&lt;artifactId&gt;{{.PackageDescriptor.Metadata.ArtifactID}}&lt;/artifactId&gt;
@@ -32,28 +32,28 @@
 &lt;/dependency&gt;</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.maven.install2"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.maven.install2"}}</label>
 				<div class="markup"><pre class="code-block"><code>mvn install</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.maven.download"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.maven.download"}}</label>
 				<div class="markup"><pre class="code-block"><code>mvn dependency:get -DremoteRepositories={{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/maven -Dartifact={{.PackageDescriptor.Metadata.GroupID}}:{{.PackageDescriptor.Metadata.ArtifactID}}:{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.maven.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.maven.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{.PackageDescriptor.Metadata.Description}}
 		</div>
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Dependencies}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<div class="ui list">
 				{{range .PackageDescriptor.Metadata.Dependencies}}

--- a/templates/package/content/npm.tmpl
+++ b/templates/package/content/npm.tmpl
@@ -1,27 +1,27 @@
 {{if eq .PackageDescriptor.Package.Type "npm"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.npm.registry" | Safe}}</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.npm.registry" | Safe}}</label>
 				<div class="markup"><pre class="code-block"><code>{{if .PackageDescriptor.Metadata.Scope}}{{.PackageDescriptor.Metadata.Scope}}:{{end}}registry={{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/npm/</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.npm.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.npm.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>npm install {{.PackageDescriptor.Package.Name}}@{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.npm.install2"}}</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.npm.install2"}}</label>
 				<div class="markup"><pre class="code-block"><code>&quot;{{.PackageDescriptor.Package.Name}}&quot;: &quot;{{.PackageDescriptor.Version.Version}}&quot;</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.npm.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.npm.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if or .PackageDescriptor.Metadata.Description .PackageDescriptor.Metadata.Readme}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{if .PackageDescriptor.Metadata.Readme}}
 			<div class="markup markdown">
@@ -34,19 +34,19 @@
 	{{end}}
 
 	{{if or .PackageDescriptor.Metadata.Dependencies .PackageDescriptor.Metadata.DevelopmentDependencies .PackageDescriptor.Metadata.PeerDependencies .PackageDescriptor.Metadata.OptionalDependencies}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<div class="ui list">
-				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.Dependencies "title" (.i18n.Tr "packages.npm.dependencies")}}
-				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.DevelopmentDependencies "title" (.i18n.Tr "packages.npm.dependencies.development")}}
-				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.PeerDependencies "title" (.i18n.Tr "packages.npm.dependencies.peer")}}
-				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.OptionalDependencies "title" (.i18n.Tr "packages.npm.dependencies.optional")}}
+				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.Dependencies "title" (.locale.Tr "packages.npm.dependencies")}}
+				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.DevelopmentDependencies "title" (.locale.Tr "packages.npm.dependencies.development")}}
+				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.PeerDependencies "title" (.locale.Tr "packages.npm.dependencies.peer")}}
+				{{template "package/content/npm_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.OptionalDependencies "title" (.locale.Tr "packages.npm.dependencies.optional")}}
 			</div>
 		</div>
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Keywords}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.keywords"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.keywords"}}</h4>
 		<div class="ui attached segment">
 			{{range .PackageDescriptor.Metadata.Keywords}}
 				{{.}}

--- a/templates/package/content/npm_dependencies.tmpl
+++ b/templates/package/content/npm_dependencies.tmpl
@@ -3,8 +3,8 @@
 <table class="ui single line very basic table">
 	<thead>
 		<tr>
-			<th class="eleven wide">{{.root.i18n.Tr "packages.dependency.id"}}</th>
-			<th class="five wide">{{.root.i18n.Tr "packages.dependency.version"}}</th>
+			<th class="eleven wide">{{.root.locale.Tr "packages.dependency.id"}}</th>
+			<th class="five wide">{{.root.locale.Tr "packages.dependency.version"}}</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/package/content/nuget.tmpl
+++ b/templates/package/content/nuget.tmpl
@@ -1,23 +1,23 @@
 {{if eq .PackageDescriptor.Package.Type "nuget"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.nuget.registry"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.nuget.registry"}}</label>
 				<div class="markup"><pre class="code-block"><code>dotnet nuget add source --name Gitea --username your_username --password your_token {{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/nuget/index.json</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.nuget.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.nuget.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>dotnet add package --source Gitea --version {{.PackageDescriptor.Version.Version}} {{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.nuget.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.nuget.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 
 	{{if or .PackageDescriptor.Metadata.Description .PackageDescriptor.Metadata.ReleaseNotes}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{if .PackageDescriptor.Metadata.Description}}{{.PackageDescriptor.Metadata.Description}}{{end}}
 			{{if .PackageDescriptor.Metadata.ReleaseNotes}}{{Str2html .PackageDescriptor.Metadata.ReleaseNotes}}{{end}}
@@ -25,14 +25,14 @@
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Dependencies}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<table class="ui single line very basic table">
 				<thead>
 					<tr>
-						<th class="ten wide">{{.i18n.Tr "packages.dependency.id"}}</th>
-						<th class="three wide">{{.i18n.Tr "packages.dependency.version"}}</th>
-						<th class="three wide">{{.i18n.Tr "packages.nuget.dependency.framework"}}</th>
+						<th class="ten wide">{{.locale.Tr "packages.dependency.id"}}</th>
+						<th class="three wide">{{.locale.Tr "packages.dependency.version"}}</th>
+						<th class="three wide">{{.locale.Tr "packages.nuget.dependency.framework"}}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/templates/package/content/pypi.tmpl
+++ b/templates/package/content/pypi.tmpl
@@ -1,18 +1,18 @@
 {{if eq .PackageDescriptor.Package.Type "pypi"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.pypi.install"}}</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.pypi.install"}}</label>
 				<div class="markup"><pre class="code-block"><code>pip install --extra-index-url {{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/pypi/simple {{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.pypi.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.pypi.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 	{{if or .PackageDescriptor.Metadata.Description .PackageDescriptor.Metadata.LongDescription .PackageDescriptor.Metadata.Summary}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			<p>{{if .PackageDescriptor.Metadata.Summary}}{{.PackageDescriptor.Metadata.Summary}}{{end}}</p>
 			{{if .PackageDescriptor.Metadata.LongDescription}}
@@ -23,9 +23,9 @@
 		</div>
 	{{end}}
 	{{if .PackageDescriptor.Metadata.RequiresPython}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.requirements"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.requirements"}}</h4>
 		<div class="ui attached segment">
-			{{.i18n.Tr "packages.pypi.requires"}}: {{.PackageDescriptor.Metadata.RequiresPython}}
+			{{.locale.Tr "packages.pypi.requires"}}: {{.PackageDescriptor.Metadata.RequiresPython}}
 		</div>
 	{{end}}
 {{end}}

--- a/templates/package/content/rubygems.tmpl
+++ b/templates/package/content/rubygems.tmpl
@@ -1,39 +1,39 @@
 {{if eq .PackageDescriptor.Package.Type "rubygems"}}
-	<h4 class="ui top attached header">{{.i18n.Tr "packages.installation"}}</h4>
+	<h4 class="ui top attached header">{{.locale.Tr "packages.installation"}}</h4>
 	<div class="ui attached segment">
 		<div class="ui form">
 			<div class="field">
-				<label>{{svg "octicon-terminal"}} {{.i18n.Tr "packages.rubygems.install" | Safe}}:</label>
+				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.rubygems.install" | Safe}}:</label>
 				<div class="markup"><pre class="code-block"><code>gem install {{.PackageDescriptor.Package.Name}} --version &quot;{{.PackageDescriptor.Version.Version}}&quot; --source &quot;{{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/rubygems&quot;</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{svg "octicon-code"}} {{.i18n.Tr "packages.rubygems.install2"}}:</label>
+				<label>{{svg "octicon-code"}} {{.locale.Tr "packages.rubygems.install2"}}:</label>
 				<div class="markup"><pre class="code-block"><code>source "{{AppUrl}}api/packages/{{.PackageDescriptor.Owner.Name}}/rubygems" do
 	gem "{{.PackageDescriptor.Package.Name}}", "{{.PackageDescriptor.Version.Version}}"
 end</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.i18n.Tr "packages.rubygems.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.rubygems.documentation" | Safe}}</label>
 			</div>
 		</div>
 	</div>
 	{{if .PackageDescriptor.Metadata.Description}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.about"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">{{.PackageDescriptor.Metadata.Description}}</div>
 	{{end}}
 	{{if or .PackageDescriptor.Metadata.RequiredRubyVersion .PackageDescriptor.Metadata.RequiredRubygemsVersion}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.requirements"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.requirements"}}</h4>
 		<div class="ui attached segment">
-			{{if .PackageDescriptor.Metadata.RequiredRubyVersion}}<p>{{.i18n.Tr "packages.rubygems.required.ruby"}}: {{range $i, $v := .PackageDescriptor.Metadata.RequiredRubyVersion}}{{if gt $i 0}}, {{end}}{{$v.Restriction}}{{$v.Version}}{{end}}</p>{{end}}
-			{{if .PackageDescriptor.Metadata.RequiredRubygemsVersion}}<p>{{.i18n.Tr "packages.rubygems.required.rubygems"}}: {{range $i, $v := .PackageDescriptor.Metadata.RequiredRubygemsVersion}}{{if gt $i 0}}, {{end}}{{$v.Restriction}}{{$v.Version}}{{end}}</p>{{end}}
+			{{if .PackageDescriptor.Metadata.RequiredRubyVersion}}<p>{{.locale.Tr "packages.rubygems.required.ruby"}}: {{range $i, $v := .PackageDescriptor.Metadata.RequiredRubyVersion}}{{if gt $i 0}}, {{end}}{{$v.Restriction}}{{$v.Version}}{{end}}</p>{{end}}
+			{{if .PackageDescriptor.Metadata.RequiredRubygemsVersion}}<p>{{.locale.Tr "packages.rubygems.required.rubygems"}}: {{range $i, $v := .PackageDescriptor.Metadata.RequiredRubygemsVersion}}{{if gt $i 0}}, {{end}}{{$v.Restriction}}{{$v.Version}}{{end}}</p>{{end}}
 		</div>
 	{{end}}
 	{{if or .PackageDescriptor.Metadata.RuntimeDependencies .PackageDescriptor.Metadata.DevelopmentDependencies}}
-		<h4 class="ui top attached header">{{.i18n.Tr "packages.dependencies"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "packages.dependencies"}}</h4>
 		<div class="ui attached segment">
 			<div class="ui list">
-				{{template "package/content/rubygems_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.RuntimeDependencies "title" (.i18n.Tr "packages.rubygems.dependencies.runtime")}}
-				{{template "package/content/rubygems_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.DevelopmentDependencies "title" (.i18n.Tr "packages.rubygems.dependencies.development")}}
+				{{template "package/content/rubygems_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.RuntimeDependencies "title" (.locale.Tr "packages.rubygems.dependencies.runtime")}}
+				{{template "package/content/rubygems_dependencies" dict "root" $ "dependencies" .PackageDescriptor.Metadata.DevelopmentDependencies "title" (.locale.Tr "packages.rubygems.dependencies.development")}}
 			</div>
 		</div>
 	{{end}}

--- a/templates/package/content/rubygems_dependencies.tmpl
+++ b/templates/package/content/rubygems_dependencies.tmpl
@@ -3,8 +3,8 @@
 <table class="ui single line very basic table">
 	<thead>
 		<tr>
-			<th class="eleven wide">{{.root.i18n.Tr "packages.dependency.id"}}</th>
-			<th class="five wide">{{.root.i18n.Tr "packages.dependency.version"}}</th>
+			<th class="eleven wide">{{.root.locale.Tr "packages.dependency.id"}}</th>
+			<th class="five wide">{{.root.locale.Tr "packages.dependency.version"}}</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/package/metadata/composer.tmpl
+++ b/templates/package/metadata/composer.tmpl
@@ -1,5 +1,5 @@
 {{if eq .PackageDescriptor.Package.Type "composer"}}
-	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.Name}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.Homepage}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.Homepage}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{range .PackageDescriptor.Metadata.License}}<div class="item" title="{{$.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
+	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.Name}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.Homepage}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.Homepage}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{range .PackageDescriptor.Metadata.License}}<div class="item" title="{{$.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
 {{end}}

--- a/templates/package/metadata/conan.tmpl
+++ b/templates/package/metadata/conan.tmpl
@@ -1,6 +1,6 @@
 {{if eq .PackageDescriptor.Package.Type "conan"}}
-	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.RepositoryURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.RepositoryURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.conan.details.repository"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.RepositoryURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.RepositoryURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.conan.details.repository"}}</a></div>{{end}}
 {{end}}

--- a/templates/package/metadata/container.tmpl
+++ b/templates/package/metadata/container.tmpl
@@ -1,9 +1,9 @@
 {{if eq .PackageDescriptor.Package.Type "container"}}
-	<div class="item" title="{{.i18n.Tr "packages.container.details.type"}}">{{svg "octicon-package" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Type.Name}}</div>
-	{{if .PackageDescriptor.Metadata.Platform}}<div class="item" title="{{$.i18n.Tr "packages.container.details.platform"}}">{{svg "octicon-cpu" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Platform}}</div>{{end}}
-	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.}}</div>{{end}}
+	<div class="item" title="{{.locale.Tr "packages.container.details.type"}}">{{svg "octicon-package" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Type.Name}}</div>
+	{{if .PackageDescriptor.Metadata.Platform}}<div class="item" title="{{$.locale.Tr "packages.container.details.platform"}}">{{svg "octicon-cpu" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Platform}}</div>{{end}}
+	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.}}</div>{{end}}
 	{{if .PackageDescriptor.Metadata.Licenses}}<div class="item">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Licenses}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{if .PackageDescriptor.Metadata.RepositoryURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.RepositoryURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.container.details.repository_site"}}</a></div>{{end}}
-	{{if .PackageDescriptor.Metadata.DocumentationURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.DocumentationURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.container.details.documentation_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.RepositoryURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.RepositoryURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.container.details.repository_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.DocumentationURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.DocumentationURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.container.details.documentation_site"}}</a></div>{{end}}
 {{end}}

--- a/templates/package/metadata/helm.tmpl
+++ b/templates/package/metadata/helm.tmpl
@@ -1,4 +1,4 @@
 {{if eq .PackageDescriptor.Package.Type "helm"}}
-	{{range .PackageDescriptor.Metadata.Maintainers}}<div class="item" title="{{$.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.Name}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.Home}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.Home}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{range .PackageDescriptor.Metadata.Maintainers}}<div class="item" title="{{$.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.Name}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.Home}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.Home}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
 {{end}}

--- a/templates/package/metadata/maven.tmpl
+++ b/templates/package/metadata/maven.tmpl
@@ -1,5 +1,5 @@
 {{if eq .PackageDescriptor.Package.Type "maven"}}
 	{{if .PackageDescriptor.Metadata.Name}}<div class="item">{{svg "octicon-note" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Name}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{range .PackageDescriptor.Metadata.Licenses}}<div class="item" title="{{$.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{range .PackageDescriptor.Metadata.Licenses}}<div class="item" title="{{$.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
 {{end}}

--- a/templates/package/metadata/npm.tmpl
+++ b/templates/package/metadata/npm.tmpl
@@ -1,8 +1,8 @@
 {{if eq .PackageDescriptor.Package.Type "npm"}}
-	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
 	{{range .PackageDescriptor.Properties}}
-		{{if eq .Name "npm.tag"}}<div class="item" title="{{$.i18n.Tr "packages.npm.details.tag"}}">{{svg "octicon-versions" 16 "mr-3"}} {{.Value}}</div>{{end}}
+		{{if eq .Name "npm.tag"}}<div class="item" title="{{$.locale.Tr "packages.npm.details.tag"}}">{{svg "octicon-versions" 16 "mr-3"}} {{.Value}}</div>{{end}}
 	{{end}}
 {{end}}

--- a/templates/package/metadata/nuget.tmpl
+++ b/templates/package/metadata/nuget.tmpl
@@ -1,4 +1,4 @@
 {{if eq .PackageDescriptor.Package.Type "nuget"}}
-	{{if .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Authors}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Authors}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
 {{end}}

--- a/templates/package/metadata/pypi.tmpl
+++ b/templates/package/metadata/pypi.tmpl
@@ -1,5 +1,5 @@
 {{if eq .PackageDescriptor.Package.Type "pypi"}}
-	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>{{end}}
-	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.Author}}<div class="item" title="{{.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.PackageDescriptor.Metadata.Author}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>{{end}}
+	{{if .PackageDescriptor.Metadata.License}}<div class="item" title="{{.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.PackageDescriptor.Metadata.License}}</div>{{end}}
 {{end}}

--- a/templates/package/metadata/rubygems.tmpl
+++ b/templates/package/metadata/rubygems.tmpl
@@ -1,5 +1,5 @@
 {{if eq .PackageDescriptor.Package.Type "rubygems"}}
-	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.i18n.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.}}</div>{{end}}
-	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.i18n.Tr "packages.details.project_site"}}</a></div>	{{end}}
-	{{range .PackageDescriptor.Metadata.Licenses}}<div class="item" title="{{$.i18n.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
+	{{range .PackageDescriptor.Metadata.Authors}}<div class="item" title="{{$.locale.Tr "packages.details.author"}}">{{svg "octicon-person" 16 "mr-3"}} {{.}}</div>{{end}}
+	{{if .PackageDescriptor.Metadata.ProjectURL}}<div class="item">{{svg "octicon-link-external" 16 "mr-3"}} <a href="{{.PackageDescriptor.Metadata.ProjectURL}}" target="_blank" rel="noopener noreferrer me">{{.locale.Tr "packages.details.project_site"}}</a></div>	{{end}}
+	{{range .PackageDescriptor.Metadata.Licenses}}<div class="item" title="{{$.locale.Tr "packages.details.license"}}">{{svg "octicon-law" 16 "mr-3"}} {{.}}</div>{{end}}
 {{end}}

--- a/templates/package/settings.tmpl
+++ b/templates/package/settings.tmpl
@@ -3,12 +3,12 @@
 	{{template "user/overview/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}
-		<p><a href="{{.PackageDescriptor.FullWebLink}}">{{.PackageDescriptor.Package.Name}} ({{.PackageDescriptor.Version.Version}})</a> / <strong>{{.i18n.Tr "repo.settings"}}</strong></p>
+		<p><a href="{{.PackageDescriptor.FullWebLink}}">{{.PackageDescriptor.Package.Name}} ({{.PackageDescriptor.Version.Version}})</a> / <strong>{{.locale.Tr "repo.settings"}}</strong></p>
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "packages.settings.link"}}
+			{{.locale.Tr "packages.settings.link"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "packages.settings.link.description"}}</p>
+			<p>{{.locale.Tr "packages.settings.link.description"}}</p>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
@@ -21,7 +21,7 @@
 						{{end}}
 						<input type="hidden" name="repo_id" value="{{$repoID}}">
 						<i class="dropdown icon"></i>
-						<div class="default text">{{.i18n.Tr "packages.settings.link.select"}}</div>
+						<div class="default text">{{.locale.Tr "packages.settings.link.select"}}</div>
 						<div class="menu">
 							{{range .Repos}}
 								<div class="item" data-value="{{.ID}}">{{.Name}}</div>
@@ -30,36 +30,36 @@
 					</div>
 				</div>
 				<div class="field">
-					<button class="ui green button">{{.i18n.Tr "packages.settings.link.button"}}</button>
+					<button class="ui green button">{{.locale.Tr "packages.settings.link.button"}}</button>
 				</div>
 			</form>
 		</div>
 		<h4 class="ui top attached error header">
-			{{.i18n.Tr "repo.settings.danger_zone"}}
+			{{.locale.Tr "repo.settings.danger_zone"}}
 		</h4>
 		<div class="ui attached error table danger segment">
 			<div class="item">
 				<div class="ui right">
-					<button class="ui basic red show-modal button" data-modal="#delete-package-modal">{{.i18n.Tr "packages.settings.delete"}}</button>
+					<button class="ui basic red show-modal button" data-modal="#delete-package-modal">{{.locale.Tr "packages.settings.delete"}}</button>
 				</div>
 				<div>
-					<h5>{{.i18n.Tr "packages.settings.delete"}}</h5>
-					<p>{{.i18n.Tr "packages.settings.delete.description"}}</p>
+					<h5>{{.locale.Tr "packages.settings.delete"}}</h5>
+					<p>{{.locale.Tr "packages.settings.delete.description"}}</p>
 				</div>
 				<div class="ui tiny modal" id="delete-package-modal">
 					<div class="header">
-						{{.i18n.Tr "packages.settings.delete"}}
+						{{.locale.Tr "packages.settings.delete"}}
 					</div>
 					<div class="content">
 						<div class="ui warning message text left">
-							{{.i18n.Tr "packages.settings.delete.notice" .PackageDescriptor.Package.Name .PackageDescriptor.Version.Version}}
+							{{.locale.Tr "packages.settings.delete.notice" .PackageDescriptor.Package.Name .PackageDescriptor.Version.Version}}
 						</div>
 						<form class="ui form" action="{{.Link}}" method="post">
 							{{.CsrfTokenHtml}}
 							<input type="hidden" name="action" value="delete">
 							<div class="text right actions">
-								<div class="ui cancel button">{{.i18n.Tr "cancel"}}</div>
-								<button class="ui red button">{{.i18n.Tr "ok"}}</button>
+								<div class="ui cancel button">{{.locale.Tr "cancel"}}</div>
+								<button class="ui red button">{{.locale.Tr "ok"}}</button>
 							</div>
 						</form>
 					</div>

--- a/templates/package/shared/list.tmpl
+++ b/templates/package/shared/list.tmpl
@@ -2,10 +2,10 @@
 	{{template "base/alert" .}}
 	<form class="ui form ignore-dirty">
 		<div class="ui fluid action input">
-			<input name="q" value="{{.Query}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+			<input name="q" value="{{.Query}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
 			<select class="ui dropdown" name="type">
-				<option value="">{{.i18n.Tr "packages.filter.type"}}</option>
-				<option value="all">{{.i18n.Tr "packages.filter.type.all"}}</option>
+				<option value="">{{.locale.Tr "packages.filter.type"}}</option>
+				<option value="all">{{.locale.Tr "packages.filter.type.all"}}</option>
 				<option value="composer" {{if eq .PackageType "composer"}}selected="selected"{{end}}>Composer</option>
 				<option value="conan" {{if eq .PackageType "conan"}}selected="selected"{{end}}>Conan</option>
 				<option value="container" {{if eq .PackageType "container"}}selected="selected"{{end}}>Container</option>
@@ -17,7 +17,7 @@
 				<option value="pypi" {{if eq .PackageType "pypi"}}selected="selected"{{end}}>PyPi</option>
 				<option value="rubygems" {{if eq .PackageType "rubygems"}}selected="selected"{{end}}>RubyGems</option>
 			</select>
-			<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+			<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 		</div>
 	</form>
 	<div class="ui {{if .PackageDescriptors}}issue list{{end}}">
@@ -29,15 +29,15 @@
 						<span class="ui label">{{svg .Package.Type.SVGName 16}} {{.Package.Type.Name}}</span>
 					</div>
 					<div class="desc issue-item-bottom-row df ac fw my-1">
-						{{$timeStr := TimeSinceUnix .Version.CreatedUnix $.i18n}}
+						{{$timeStr := TimeSinceUnix .Version.CreatedUnix $.locale}}
 						{{$hasRepositoryAccess := false}}
 						{{if .Repository}}
 							{{$hasRepositoryAccess = index $.RepositoryAccessMap .Repository.ID}}
 						{{end}}
 						{{if $hasRepositoryAccess}}
-							{{$.i18n.Tr "packages.published_by_in" $timeStr .Creator.HomeLink (.Creator.GetDisplayName | Escape) .Repository.HTMLURL (.Repository.FullName | Escape) | Safe}}
+							{{$.locale.Tr "packages.published_by_in" $timeStr .Creator.HomeLink (.Creator.GetDisplayName | Escape) .Repository.HTMLURL (.Repository.FullName | Escape) | Safe}}
 						{{else}}
-							{{$.i18n.Tr "packages.published_by" $timeStr .Creator.HomeLink (.Creator.GetDisplayName | Escape) | Safe}}
+							{{$.locale.Tr "packages.published_by" $timeStr .Creator.HomeLink (.Creator.GetDisplayName | Escape) | Safe}}
 						{{end}}
 					</div>
 				</div>
@@ -46,11 +46,11 @@
 			{{if not .HasPackages}}
 				<div class="empty center">
 					{{svg "octicon-package" 32}}
-					<h2>{{.i18n.Tr "packages.empty"}}</h2>
-					<p>{{.i18n.Tr "packages.empty.documentation" | Safe}}</p>
+					<h2>{{.locale.Tr "packages.empty"}}</h2>
+					<p>{{.locale.Tr "packages.empty.documentation" | Safe}}</p>
 				</div>
 			{{else}}
-				<p>{{.i18n.Tr "packages.filter.no_result"}}</p>
+				<p>{{.locale.Tr "packages.filter.no_result"}}</p>
 			{{end}}
 		{{end}}
 		{{template "base/paginate" .}}

--- a/templates/package/shared/versionlist.tmpl
+++ b/templates/package/shared/versionlist.tmpl
@@ -1,16 +1,16 @@
 <div class="ui container">
-	<p><a href="{{.PackageDescriptor.PackageWebLink}}">{{.PackageDescriptor.Package.Name}}</a> / <strong>{{.i18n.Tr "packages.versions"}}</strong></p>
+	<p><a href="{{.PackageDescriptor.PackageWebLink}}">{{.PackageDescriptor.Package.Name}}</a> / <strong>{{.locale.Tr "packages.versions"}}</strong></p>
 	<form class="ui form ignore-dirty">
 		<div class="ui fluid action input">
-			<input name="q" value="{{.Query}}" placeholder="{{.i18n.Tr "explore.search"}}..." autofocus>
+			<input name="q" value="{{.Query}}" placeholder="{{.locale.Tr "explore.search"}}..." autofocus>
 			{{if eq .PackageDescriptor.Package.Type "container"}}
 			<select class="ui dropdown" name="tagged">
 				{{$isTagged := or (eq .Tagged "") (eq .Tagged "tagged")}}
-				<option value="tagged" {{if $isTagged}}selected="selected"{{end}}>{{.i18n.Tr "packages.filter.container.tagged"}}</option>
-				<option value="untagged" {{if not $isTagged}}selected="selected"{{end}}>{{.i18n.Tr "packages.filter.container.untagged"}}</option>
+				<option value="tagged" {{if $isTagged}}selected="selected"{{end}}>{{.locale.Tr "packages.filter.container.tagged"}}</option>
+				<option value="untagged" {{if not $isTagged}}selected="selected"{{end}}>{{.locale.Tr "packages.filter.container.untagged"}}</option>
 			</select>
 			{{end}}
-			<button class="ui primary button">{{.i18n.Tr "explore.search"}}</button>
+			<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 		</div>
 	</form>
 	<div class="ui {{if .PackageDescriptors}}issue list{{end}}">
@@ -21,12 +21,12 @@
 						<a class="title" href="{{.FullWebLink}}">{{.Version.LowerVersion}}</a>
 					</div>
 					<div class="desc issue-item-bottom-row df ac fw my-1">
-						{{$.i18n.Tr "packages.published_by" (TimeSinceUnix .Version.CreatedUnix $.i18n) .Creator.HomeLink (.Creator.GetDisplayName | Escape) | Safe}}
+						{{$.locale.Tr "packages.published_by" (TimeSinceUnix .Version.CreatedUnix $.locale) .Creator.HomeLink (.Creator.GetDisplayName | Escape) | Safe}}
 					</div>
 				</div>
 			</li>
 		{{else}}
-			<p>{{.i18n.Tr "packages.filter.no_result"}}</p>
+			<p>{{.locale.Tr "packages.filter.no_result"}}</p>
 		{{end}}
 		{{template "base/paginate" .}}
 	</div>

--- a/templates/package/view.tmpl
+++ b/templates/package/view.tmpl
@@ -9,11 +9,11 @@
 						<h1>{{.PackageDescriptor.Package.Name}} ({{.PackageDescriptor.Version.Version}})</h1>
 					</div>
 					<div>
-						{{$timeStr := TimeSinceUnix .PackageDescriptor.Version.CreatedUnix $.i18n}}
+						{{$timeStr := TimeSinceUnix .PackageDescriptor.Version.CreatedUnix $.locale}}
 						{{if .HasRepositoryAccess}}
-							{{.i18n.Tr "packages.published_by_in" $timeStr .PackageDescriptor.Creator.HomeLink (.PackageDescriptor.Creator.GetDisplayName | Escape) .PackageDescriptor.Repository.HTMLURL (.PackageDescriptor.Repository.FullName | Escape) | Safe}}
+							{{.locale.Tr "packages.published_by_in" $timeStr .PackageDescriptor.Creator.HomeLink (.PackageDescriptor.Creator.GetDisplayName | Escape) .PackageDescriptor.Repository.HTMLURL (.PackageDescriptor.Repository.FullName | Escape) | Safe}}
 						{{else}}
-							{{.i18n.Tr "packages.published_by" $timeStr .PackageDescriptor.Creator.HomeLink (.PackageDescriptor.Creator.GetDisplayName | Escape) | Safe}}
+							{{.locale.Tr "packages.published_by" $timeStr .PackageDescriptor.Creator.HomeLink (.PackageDescriptor.Creator.GetDisplayName | Escape) | Safe}}
 						{{end}}
 					</div>
 					<div class="ui divider"></div>
@@ -32,7 +32,7 @@
 				</div>
 				<div class="four wide column">
 					<div class="ui segment metas">
-						<strong>{{.i18n.Tr "packages.details"}}</strong>
+						<strong>{{.locale.Tr "packages.details"}}</strong>
 						<div class="ui relaxed list">
 							<div class="item">{{svg .PackageDescriptor.Package.Type.SVGName 16 "mr-3"}} {{.PackageDescriptor.Package.Type.Name}}</div>
 							{{if .HasRepositoryAccess}}
@@ -53,7 +53,7 @@
 						</div>
 						{{if not (eq .PackageDescriptor.Package.Type "container")}}
 							<div class="ui divider"></div>
-							<strong>{{.i18n.Tr "packages.assets"}} ({{len .PackageDescriptor.Files}})</strong>
+							<strong>{{.locale.Tr "packages.assets"}} ({{len .PackageDescriptor.Files}})</strong>
 							<div class="ui relaxed list">
 							{{range .PackageDescriptor.Files}}
 								<div class="item">
@@ -65,13 +65,13 @@
 						{{end}}
 						{{if .LatestVersions}}
 							<div class="ui divider"></div>
-							<strong>{{.i18n.Tr "packages.versions"}} ({{.TotalVersionCount}})</strong>
-							<a class="ui right" href="{{$.PackageDescriptor.PackageWebLink}}/versions">{{.i18n.Tr "packages.versions.view_all"}}</a>
+							<strong>{{.locale.Tr "packages.versions"}} ({{.TotalVersionCount}})</strong>
+							<a class="ui right" href="{{$.PackageDescriptor.PackageWebLink}}/versions">{{.locale.Tr "packages.versions.view_all"}}</a>
 							<div class="ui relaxed list">
 							{{range .LatestVersions}}
 								<div class="item">
 									<a href="{{$.PackageDescriptor.PackageWebLink}}/{{PathEscape .LowerVersion}}">{{.Version}}</a>
-									<span class="text small">{{$.i18n.Tr "packages.versions.on"}} {{.CreatedUnix.FormatDate}}</span>
+									<span class="text small">{{$.locale.Tr "packages.versions.on"}} {{.CreatedUnix.FormatDate}}</span>
 								</div>
 							{{end}}
 							</div>
@@ -80,10 +80,10 @@
 							<div class="ui divider"></div>
 							<div class="ui relaxed list">
 								{{if .HasRepositoryAccess}}
-								<div class="item">{{svg "octicon-issue-opened" 16 "mr-3"}} <a href="{{.PackageDescriptor.Repository.HTMLURL}}/issues">{{.i18n.Tr "repo.issues"}}</a></div>
+								<div class="item">{{svg "octicon-issue-opened" 16 "mr-3"}} <a href="{{.PackageDescriptor.Repository.HTMLURL}}/issues">{{.locale.Tr "repo.issues"}}</a></div>
 								{{end}}
 								{{if .CanWritePackages}}
-								<div class="item">{{svg "octicon-tools" 16 "mr-3"}} <a href="{{.Link}}/settings">{{.i18n.Tr "repo.settings"}}</a></div>
+								<div class="item">{{svg "octicon-tools" 16 "mr-3"}} <a href="{{.Link}}/settings">{{.locale.Tr "repo.settings"}}</a></div>
 								{{end}}
 							</div>
 						{{end}}

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -8,18 +8,18 @@
 				<div class="ui floating dropdown jump filter">
 					<div class="ui basic compact button">
 						<span class="text">
-							{{.i18n.Tr "repo.activity.period.filter_label"}} <strong>{{.PeriodText}}</strong>
+							{{.locale.Tr "repo.activity.period.filter_label"}} <strong>{{.PeriodText}}</strong>
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 					</div>
 					<div class="menu">
-						<a class="{{if eq .Period "daily"}}active {{end}}item" href="{{$.RepoLink}}/activity/daily">{{.i18n.Tr "repo.activity.period.daily"}}</a>
-						<a class="{{if eq .Period "halfweekly"}}active {{end}}item" href="{{$.RepoLink}}/activity/halfweekly">{{.i18n.Tr "repo.activity.period.halfweekly"}}</a>
-						<a class="{{if eq .Period "weekly"}}active {{end}}item" href="{{$.RepoLink}}/activity/weekly">{{.i18n.Tr "repo.activity.period.weekly"}}</a>
-						<a class="{{if eq .Period "monthly"}}active {{end}}item" href="{{$.RepoLink}}/activity/monthly">{{.i18n.Tr "repo.activity.period.monthly"}}</a>
-						<a class="{{if eq .Period "quarterly"}}active {{end}}item" href="{{$.RepoLink}}/activity/quarterly">{{.i18n.Tr "repo.activity.period.quarterly"}}</a>
-						<a class="{{if eq .Period "semiyearly"}}active {{end}}item" href="{{$.RepoLink}}/activity/semiyearly">{{.i18n.Tr "repo.activity.period.semiyearly"}}</a>
-						<a class="{{if eq .Period "yearly"}}active {{end}}item" href="{{$.RepoLink}}/activity/yearly">{{.i18n.Tr "repo.activity.period.yearly"}}</a>
+						<a class="{{if eq .Period "daily"}}active {{end}}item" href="{{$.RepoLink}}/activity/daily">{{.locale.Tr "repo.activity.period.daily"}}</a>
+						<a class="{{if eq .Period "halfweekly"}}active {{end}}item" href="{{$.RepoLink}}/activity/halfweekly">{{.locale.Tr "repo.activity.period.halfweekly"}}</a>
+						<a class="{{if eq .Period "weekly"}}active {{end}}item" href="{{$.RepoLink}}/activity/weekly">{{.locale.Tr "repo.activity.period.weekly"}}</a>
+						<a class="{{if eq .Period "monthly"}}active {{end}}item" href="{{$.RepoLink}}/activity/monthly">{{.locale.Tr "repo.activity.period.monthly"}}</a>
+						<a class="{{if eq .Period "quarterly"}}active {{end}}item" href="{{$.RepoLink}}/activity/quarterly">{{.locale.Tr "repo.activity.period.quarterly"}}</a>
+						<a class="{{if eq .Period "semiyearly"}}active {{end}}item" href="{{$.RepoLink}}/activity/semiyearly">{{.locale.Tr "repo.activity.period.semiyearly"}}</a>
+						<a class="{{if eq .Period "yearly"}}active {{end}}item" href="{{$.RepoLink}}/activity/yearly">{{.locale.Tr "repo.activity.period.yearly"}}</a>
 					</div>
 				</div>
 			</div>
@@ -27,7 +27,7 @@
 		<div class="ui divider"></div>
 
 		{{if (or (.Permission.CanRead $.UnitTypeIssues) (.Permission.CanRead $.UnitTypePullRequests))}}
-		<h4 class="ui top attached header">{{.i18n.Tr "repo.activity.overview"}}</h4>
+		<h4 class="ui top attached header">{{.locale.Tr "repo.activity.overview"}}</h4>
 		<div class="ui attached segment two column grid">
 			{{if .Permission.CanRead $.UnitTypePullRequests}}
 				<div class="column">
@@ -41,7 +41,7 @@
 						<a class="table-cell tiny background light grey"></a>
 					</div>
 					{{end}}
-					{{.i18n.TrN .Activity.ActivePRCount "repo.activity.active_prs_count_1" "repo.activity.active_prs_count_n" .Activity.ActivePRCount | Safe }}
+					{{.locale.TrN .Activity.ActivePRCount "repo.activity.active_prs_count_1" "repo.activity.active_prs_count_n" .Activity.ActivePRCount | Safe }}
 				</div>
 			{{end}}
 			{{if .Permission.CanRead $.UnitTypeIssues}}
@@ -56,7 +56,7 @@
 						<a class="table-cell tiny background light grey"></a>
 					</div>
 					{{end}}
-					{{.i18n.TrN .Activity.ActiveIssueCount "repo.activity.active_issues_count_1" "repo.activity.active_issues_count_n" .Activity.ActiveIssueCount | Safe }}
+					{{.locale.TrN .Activity.ActiveIssueCount "repo.activity.active_issues_count_1" "repo.activity.active_issues_count_n" .Activity.ActiveIssueCount | Safe }}
 				</div>
 			{{end}}
 		</div>
@@ -64,21 +64,21 @@
 			{{if .Permission.CanRead $.UnitTypePullRequests}}
 				<a href="#merged-pull-requests" class="ui attached segment text center">
 					<span class="text purple">{{svg "octicon-git-pull-request"}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
-					{{.i18n.TrN .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n"}}
+					{{.locale.TrN .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n"}}
 				</a>
 				<a href="#proposed-pull-requests" class="ui attached segment text center">
 					<span class="text green">{{svg "octicon-git-branch"}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
-					{{.i18n.TrN .Activity.OpenedPRCount "repo.activity.opened_prs_count_1" "repo.activity.opened_prs_count_n"}}
+					{{.locale.TrN .Activity.OpenedPRCount "repo.activity.opened_prs_count_1" "repo.activity.opened_prs_count_n"}}
 				</a>
 			{{end}}
 			{{if .Permission.CanRead $.UnitTypeIssues}}
 				<a href="#closed-issues" class="ui attached segment text center">
 					<span class="text red">{{svg "octicon-issue-closed"}}</span> <strong>{{.Activity.ClosedIssueCount}}</strong><br>
-					{{.i18n.TrN .Activity.ClosedIssueCount "repo.activity.closed_issues_count_1" "repo.activity.closed_issues_count_n"}}
+					{{.locale.TrN .Activity.ClosedIssueCount "repo.activity.closed_issues_count_1" "repo.activity.closed_issues_count_n"}}
 				</a>
 				<a href="#new-issues" class="ui attached segment text center">
 					<span class="text green">{{svg "octicon-issue-opened"}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
-					{{.i18n.TrN .Activity.OpenedIssueCount "repo.activity.new_issues_count_1" "repo.activity.new_issues_count_n"}}
+					{{.locale.TrN .Activity.OpenedIssueCount "repo.activity.new_issues_count_1" "repo.activity.new_issues_count_n"}}
 				</a>
 			{{end}}
 		</div>
@@ -87,26 +87,26 @@
 		{{if .Permission.CanRead $.UnitTypeCode}}
 			{{if eq .Activity.Code.CommitCountInAllBranches 0}}
 				<div class="ui center aligned segment">
-				<h4 class="ui header">{{.i18n.Tr "repo.activity.no_git_activity" }}</h4>
+				<h4 class="ui header">{{.locale.Tr "repo.activity.no_git_activity" }}</h4>
 				</div>
 			{{end}}
 			{{if gt .Activity.Code.CommitCountInAllBranches 0}}
 				<div class="ui attached segment horizontal segments">
 					<div class="ui attached segment text">
-						{{.i18n.Tr "repo.activity.git_stats_exclude_merges" }}
-						<strong>{{.i18n.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_author_1" "repo.activity.git_stats_author_n" .Activity.Code.AuthorCount}}</strong>
-						{{.i18n.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_pushed_1" "repo.activity.git_stats_pushed_n"}}
-						<strong>{{.i18n.TrN .Activity.Code.CommitCount "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCount}}</strong>
-						{{.i18n.Tr "repo.activity.git_stats_push_to_branch" .Repository.DefaultBranch }}
-						<strong>{{.i18n.TrN .Activity.Code.CommitCountInAllBranches "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCountInAllBranches}}</strong>
-						{{.i18n.Tr "repo.activity.git_stats_push_to_all_branches" }}
-						{{.i18n.Tr "repo.activity.git_stats_on_default_branch" .Repository.DefaultBranch }}
-						<strong>{{.i18n.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_file_1" "repo.activity.git_stats_file_n" .Activity.Code.ChangedFiles}}</strong>
-						{{.i18n.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_files_changed_1" "repo.activity.git_stats_files_changed_n"}}
-						{{.i18n.Tr "repo.activity.git_stats_additions" }}
-						<strong class="text green">{{.i18n.TrN .Activity.Code.Additions "repo.activity.git_stats_addition_1" "repo.activity.git_stats_addition_n" .Activity.Code.Additions}}</strong>
-						{{.i18n.Tr "repo.activity.git_stats_and_deletions" }}
-						<strong class="text red">{{.i18n.TrN .Activity.Code.Deletions "repo.activity.git_stats_deletion_1" "repo.activity.git_stats_deletion_n" .Activity.Code.Deletions}}</strong>.
+						{{.locale.Tr "repo.activity.git_stats_exclude_merges" }}
+						<strong>{{.locale.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_author_1" "repo.activity.git_stats_author_n" .Activity.Code.AuthorCount}}</strong>
+						{{.locale.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_pushed_1" "repo.activity.git_stats_pushed_n"}}
+						<strong>{{.locale.TrN .Activity.Code.CommitCount "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCount}}</strong>
+						{{.locale.Tr "repo.activity.git_stats_push_to_branch" .Repository.DefaultBranch }}
+						<strong>{{.locale.TrN .Activity.Code.CommitCountInAllBranches "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCountInAllBranches}}</strong>
+						{{.locale.Tr "repo.activity.git_stats_push_to_all_branches" }}
+						{{.locale.Tr "repo.activity.git_stats_on_default_branch" .Repository.DefaultBranch }}
+						<strong>{{.locale.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_file_1" "repo.activity.git_stats_file_n" .Activity.Code.ChangedFiles}}</strong>
+						{{.locale.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_files_changed_1" "repo.activity.git_stats_files_changed_n"}}
+						{{.locale.Tr "repo.activity.git_stats_additions" }}
+						<strong class="text green">{{.locale.TrN .Activity.Code.Additions "repo.activity.git_stats_addition_1" "repo.activity.git_stats_addition_n" .Activity.Code.Additions}}</strong>
+						{{.locale.Tr "repo.activity.git_stats_and_deletions" }}
+						<strong class="text red">{{.locale.TrN .Activity.Code.Deletions "repo.activity.git_stats_deletion_1" "repo.activity.git_stats_deletion_n" .Activity.Code.Deletions}}</strong>.
 					</div>
 					<div class="ui attached segment">
 						<div id="repo-activity-top-authors-chart"></div>
@@ -118,20 +118,20 @@
 		{{if gt .Activity.PublishedReleaseCount 0}}
 			<h4 class="ui horizontal divider header" id="published-releases">
 				<span class="text">{{svg "octicon-tag"}}</span>
-				{{.i18n.Tr "repo.activity.title.releases_published_by"
-					(.i18n.TrN .Activity.PublishedReleaseCount "repo.activity.title.releases_1" "repo.activity.title.releases_n" .Activity.PublishedReleaseCount)
-					(.i18n.TrN .Activity.PublishedReleaseAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.PublishedReleaseAuthorCount)
+				{{.locale.Tr "repo.activity.title.releases_published_by"
+					(.locale.TrN .Activity.PublishedReleaseCount "repo.activity.title.releases_1" "repo.activity.title.releases_n" .Activity.PublishedReleaseCount)
+					(.locale.TrN .Activity.PublishedReleaseAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.PublishedReleaseAuthorCount)
 				}}
 			</h4>
 			<div class="list">
 				{{range .Activity.PublishedReleases}}
 					<p class="desc">
-						<span class="ui green label">{{$.i18n.Tr "repo.activity.published_release_label"}}</span>
+						<span class="ui green label">{{$.locale.Tr "repo.activity.published_release_label"}}</span>
 						{{.TagName}}
 						{{if not .IsTag}}
 							<a class="title" href="{{$.RepoLink}}/src/{{.TagName | PathEscapeSegments}}">{{.Title | RenderEmoji}}</a>
 						{{end}}
-						{{TimeSinceUnix .CreatedUnix $.i18n}}
+						{{TimeSinceUnix .CreatedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>
@@ -140,17 +140,17 @@
 		{{if gt .Activity.MergedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="merged-pull-requests">
 				<span class="text">{{svg "octicon-git-pull-request"}}</span>
-				{{.i18n.Tr "repo.activity.title.prs_merged_by"
-					(.i18n.TrN .Activity.MergedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n" .Activity.MergedPRCount)
-					(.i18n.TrN .Activity.MergedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.MergedPRAuthorCount)
+				{{.locale.Tr "repo.activity.title.prs_merged_by"
+					(.locale.TrN .Activity.MergedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n" .Activity.MergedPRCount)
+					(.locale.TrN .Activity.MergedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.MergedPRAuthorCount)
 				}}
 			</h4>
 			<div class="list">
 				{{range .Activity.MergedPRs}}
 					<p class="desc">
-						<span class="ui purple label">{{$.i18n.Tr "repo.activity.merged_prs_label"}}</span>
+						<span class="ui purple label">{{$.locale.Tr "repo.activity.merged_prs_label"}}</span>
 						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji}}</a>
-						{{TimeSinceUnix .MergedUnix $.i18n}}
+						{{TimeSinceUnix .MergedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>
@@ -159,17 +159,17 @@
 		{{if gt .Activity.OpenedPRCount 0}}
 			<h4 class="ui horizontal divider header" id="proposed-pull-requests">
 				<span class="text">{{svg "octicon-git-branch"}}</span>
-				{{.i18n.Tr "repo.activity.title.prs_opened_by"
-					(.i18n.TrN .Activity.OpenedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n" .Activity.OpenedPRCount)
-					(.i18n.TrN .Activity.OpenedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.OpenedPRAuthorCount)
+				{{.locale.Tr "repo.activity.title.prs_opened_by"
+					(.locale.TrN .Activity.OpenedPRCount "repo.activity.title.prs_1" "repo.activity.title.prs_n" .Activity.OpenedPRCount)
+					(.locale.TrN .Activity.OpenedPRAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.OpenedPRAuthorCount)
 				}}
 			</h4>
 			<div class="list">
 				{{range .Activity.OpenedPRs}}
 					<p class="desc">
-						<span class="ui green label">{{$.i18n.Tr "repo.activity.opened_prs_label"}}</span>
+						<span class="ui green label">{{$.locale.Tr "repo.activity.opened_prs_label"}}</span>
 						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji}}</a>
-						{{TimeSinceUnix .Issue.CreatedUnix $.i18n}}
+						{{TimeSinceUnix .Issue.CreatedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>
@@ -178,17 +178,17 @@
 		{{if gt .Activity.ClosedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="closed-issues">
 				<span class="text">{{svg "octicon-issue-closed"}}</span>
-				{{.i18n.Tr "repo.activity.title.issues_closed_from"
-					(.i18n.TrN .Activity.ClosedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n" .Activity.ClosedIssueCount)
-					(.i18n.TrN .Activity.ClosedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.ClosedIssueAuthorCount)
+				{{.locale.Tr "repo.activity.title.issues_closed_from"
+					(.locale.TrN .Activity.ClosedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n" .Activity.ClosedIssueCount)
+					(.locale.TrN .Activity.ClosedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.ClosedIssueAuthorCount)
 				}}
 			</h4>
 			<div class="list">
 				{{range .Activity.ClosedIssues}}
 					<p class="desc">
-						<span class="ui red label">{{$.i18n.Tr "repo.activity.closed_issue_label"}}</span>
+						<span class="ui red label">{{$.locale.Tr "repo.activity.closed_issue_label"}}</span>
 						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji}}</a>
-						{{TimeSinceUnix .ClosedUnix $.i18n}}
+						{{TimeSinceUnix .ClosedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>
@@ -197,17 +197,17 @@
 		{{if gt .Activity.OpenedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="new-issues">
 				<span class="text">{{svg "octicon-issue-opened"}}</span>
-				{{.i18n.Tr "repo.activity.title.issues_created_by"
-					(.i18n.TrN .Activity.OpenedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n" .Activity.OpenedIssueCount)
-					(.i18n.TrN .Activity.OpenedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.OpenedIssueAuthorCount)
+				{{.locale.Tr "repo.activity.title.issues_created_by"
+					(.locale.TrN .Activity.OpenedIssueCount "repo.activity.title.issues_1" "repo.activity.title.issues_n" .Activity.OpenedIssueCount)
+					(.locale.TrN .Activity.OpenedIssueAuthorCount "repo.activity.title.user_1" "repo.activity.title.user_n" .Activity.OpenedIssueAuthorCount)
 				}}
 			</h4>
 			<div class="list">
 				{{range .Activity.OpenedIssues}}
 					<p class="desc">
-						<span class="ui green label">{{$.i18n.Tr "repo.activity.new_issue_label"}}</span>
+						<span class="ui green label">{{$.locale.Tr "repo.activity.new_issue_label"}}</span>
 						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji}}</a>
-						{{TimeSinceUnix .CreatedUnix $.i18n}}
+						{{TimeSinceUnix .CreatedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>
@@ -216,22 +216,22 @@
 		{{if gt .Activity.UnresolvedIssueCount 0}}
 			<h4 class="ui horizontal divider header" id="unresolved-conversations">
 				<span class="text">{{svg "octicon-comment-discussion"}}</span>
-				{{.i18n.TrN .Activity.UnresolvedIssueCount "repo.activity.title.unresolved_conv_1" "repo.activity.title.unresolved_conv_n" .Activity.UnresolvedIssueCount}}
+				{{.locale.TrN .Activity.UnresolvedIssueCount "repo.activity.title.unresolved_conv_1" "repo.activity.title.unresolved_conv_n" .Activity.UnresolvedIssueCount}}
 			</h4>
 			<div class="text center desc">
-				{{.i18n.Tr "repo.activity.unresolved_conv_desc"}}
+				{{.locale.Tr "repo.activity.unresolved_conv_desc"}}
 			</div>
 			<div class="list">
 				{{range .Activity.UnresolvedIssues}}
 					<p class="desc">
-						<span class="ui green label">{{$.i18n.Tr "repo.activity.unresolved_conv_label"}}</span>
+						<span class="ui green label">{{$.locale.Tr "repo.activity.unresolved_conv_label"}}</span>
 						#{{.Index}}
 						{{if .IsPull}}
 						<a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Title | RenderEmoji}}</a>
 						{{else}}
 						<a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji}}</a>
 						{{end}}
-						{{TimeSinceUnix .UpdatedUnix $.i18n}}
+						{{TimeSinceUnix .UpdatedUnix $.locale}}
 					</p>
 				{{end}}
 			</div>

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -3,21 +3,21 @@
 		<div class="file-header-left df ac">
 			<div class="file-info text grey normal mono">
 				<div class="file-info-entry">
-					{{.NumLines}} {{.i18n.TrN .NumLines "repo.line" "repo.lines"}}
+					{{.NumLines}} {{.locale.TrN .NumLines "repo.line" "repo.lines"}}
 				</div>
 				<div class="file-info-entry">{{FileSize .FileSize}}</div>
 			</div>
 		</div>
 		<div class="file-header-right file-actions df ac">
 			<div class="ui buttons">
-				<a class="ui tiny button" href="{{$.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
+				<a class="ui tiny button" href="{{$.RawFileLink}}">{{.locale.Tr "repo.file_raw"}}</a>
 				{{if not .IsViewCommit}}
-					<a class="ui tiny button" href="{{.RepoLink}}/src/commit/{{.CommitID | PathEscape}}/{{.TreePath | PathEscapeSegments}}">{{.i18n.Tr "repo.file_permalink"}}</a>
+					<a class="ui tiny button" href="{{.RepoLink}}/src/commit/{{.CommitID | PathEscape}}/{{.TreePath | PathEscapeSegments}}">{{.locale.Tr "repo.file_permalink"}}</a>
 				{{end}}
-				<a class="ui tiny button" href="{{.RepoLink}}/src/{{.BranchNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.i18n.Tr "repo.normal_view"}}</a>
-				<a class="ui tiny button" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.i18n.Tr "repo.file_history"}}</a>
-				<a class="ui tiny button unescape-button">{{.i18n.Tr "repo.unescape_control_characters"}}</a>
-				<a class="ui tiny button escape-button" style="display: none;">{{.i18n.Tr "repo.escape_control_characters"}}</a>
+				<a class="ui tiny button" href="{{.RepoLink}}/src/{{.BranchNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.locale.Tr "repo.normal_view"}}</a>
+				<a class="ui tiny button" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.locale.Tr "repo.file_history"}}</a>
+				<a class="ui tiny button unescape-button">{{.locale.Tr "repo.unescape_control_characters"}}</a>
+				<a class="ui tiny button escape-button" style="display: none;">{{.locale.Tr "repo.escape_control_characters"}}</a>
 			</div>
 		</div>
 	</h4>
@@ -46,7 +46,7 @@
 							</td>
 							<td class="lines-blame-btn">
 								{{if $row.PreviousSha}}
-									<a href="{{$row.PreviousShaURL}}" class="tooltip" data-content='{{$.i18n.Tr "repo.blame_prior"}}'>
+									<a href="{{$row.PreviousShaURL}}" class="tooltip" data-content='{{$.locale.Tr "repo.blame_prior"}}'>
 										{{svg "octicon-versions"}}
 									</a>
 								{{end}}
@@ -55,7 +55,7 @@
 								<span id="L{{$row.RowNumber}}" data-line-number="{{$row.RowNumber}}"></span>
 							</td>
 							{{if $.EscapeStatus.Escaped}}
-								<td class="lines-escape">{{if $row.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+								<td class="lines-escape">{{if $row.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 							{{end}}
 							<td rel="L{{$row.RowNumber}}" rel="L{{$row.RowNumber}}" class="lines-code blame-code chroma">
 								<code class="code-inner pl-3">{{$row.Code}}</code>

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -6,7 +6,7 @@
 		{{template "repo/sub_menu" .}}
 		{{if .DefaultBranchBranch}}
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.default_branch"}}
+				{{.locale.Tr "repo.default_branch"}}
 			</h4>
 
 			<div class="ui attached table segment">
@@ -18,15 +18,15 @@
 									{{svg "octicon-shield-lock"}}
 								{{end}}
 								<a href="{{.RepoLink}}/src/branch/{{PathEscapeSegments .DefaultBranch}}">{{.DefaultBranch}}</a>
-								<p class="info df ac my-2">{{svg "octicon-git-commit" 16 "mr-2"}}<a href="{{.RepoLink}}/commit/{{PathEscape .DefaultBranchBranch.Commit.ID.String}}">{{ShortSha .DefaultBranchBranch.Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage $.Context .DefaultBranchBranch.Commit.CommitMessage .RepoLink .Repository.ComposeMetas}}</span> · {{.i18n.Tr "org.repo_updated"}} {{TimeSince .DefaultBranchBranch.Commit.Committer.When .i18n}}</p>
+								<p class="info df ac my-2">{{svg "octicon-git-commit" 16 "mr-2"}}<a href="{{.RepoLink}}/commit/{{PathEscape .DefaultBranchBranch.Commit.ID.String}}">{{ShortSha .DefaultBranchBranch.Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage $.Context .DefaultBranchBranch.Commit.CommitMessage .RepoLink .Repository.ComposeMetas}}</span> · {{.locale.Tr "org.repo_updated"}} {{TimeSince .DefaultBranchBranch.Commit.Committer.When .locale}}</p>
 							</td>
 							<td class="right aligned overflow-visible">
 								{{if and $.IsWriter (not $.Repository.IsArchived) (not .IsDeleted)}}
-									<div class="ui basic jump button icon tooltip show-create-branch-modal" data-content="{{$.i18n.Tr "repo.branch.new_branch_from" ($.DefaultBranch)}}" data-branch-from="{{$.DefaultBranch}}" data-branch-from-urlcomponent="{{PathEscapeSegments $.DefaultBranch}}" data-modal="#create-branch-modal" data-position="top right">
+									<div class="ui basic jump button icon tooltip show-create-branch-modal" data-content="{{$.locale.Tr "repo.branch.new_branch_from" ($.DefaultBranch)}}" data-branch-from="{{$.DefaultBranch}}" data-branch-from-urlcomponent="{{PathEscapeSegments $.DefaultBranch}}" data-modal="#create-branch-modal" data-position="top right">
 										{{svg "octicon-git-branch"}}
 									</div>
 								{{end}}
-								<div class="ui basic jump dropdown icon button tooltip" data-content="{{$.i18n.Tr "repo.branch.download" ($.DefaultBranch)}}" data-position="top right">
+								<div class="ui basic jump dropdown icon button tooltip" data-content="{{$.locale.Tr "repo.branch.download" ($.DefaultBranch)}}" data-position="top right">
 									{{svg "octicon-download"}}
 									<div class="menu">
 										<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.DefaultBranch}}.zip" rel="nofollow">{{svg "octicon-file-zip"}}&nbsp;ZIP</a>
@@ -42,7 +42,7 @@
 
 		{{if gt (len .Branches) 1}}
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.branches"}}
+				{{.locale.Tr "repo.branches"}}
 			</h4>
 			<div class="ui attached table segment">
 				<table class="ui very basic striped fixed table single line">
@@ -53,13 +53,13 @@
 									<td class="six wide">
 									{{if .IsDeleted}}
 										<s><a href="{{$.RepoLink}}/src/branch/{{PathEscapeSegments .Name}}">{{.Name}}</a></s>
-										<p class="info">{{$.i18n.Tr "repo.branch.deleted_by" .DeletedBranch.DeletedBy.Name}} {{TimeSinceUnix .DeletedBranch.DeletedUnix $.i18n}}</p>
+										<p class="info">{{$.locale.Tr "repo.branch.deleted_by" .DeletedBranch.DeletedBy.Name}} {{TimeSinceUnix .DeletedBranch.DeletedUnix $.locale}}</p>
 									{{else}}
 										{{if .IsProtected}}
 											{{svg "octicon-shield-lock"}}
 										{{end}}
 										<a href="{{$.RepoLink}}/src/branch/{{PathEscapeSegments .Name}}">{{.Name}}</a>
-										<p class="info df ac my-2">{{svg "octicon-git-commit" 16 "mr-2"}}<a href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage $.Context .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.i18n}}</p>
+										<p class="info df ac my-2">{{svg "octicon-git-commit" 16 "mr-2"}}<a href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}">{{ShortSha .Commit.ID.String}}</a> · <span class="commit-message">{{RenderCommitMessage $.Context .Commit.CommitMessage $.RepoLink $.Repository.ComposeMetas}}</span> · {{$.locale.Tr "org.repo_updated"}} {{TimeSince .Commit.Committer.When $.locale}}</p>
 									{{end}}
 									</td>
 									<td class="three wide ui">
@@ -79,39 +79,39 @@
 									<td class="three wide right aligned">
 										{{if not .LatestPullRequest}}
 											{{if .IsIncluded}}
-												<a class="ui tooltip orange large label" data-content="{{$.i18n.Tr "repo.branch.included_desc"}}" data-position="top right">
-													{{svg "octicon-git-pull-request"}} {{$.i18n.Tr "repo.branch.included"}}
+												<a class="ui tooltip orange large label" data-content="{{$.locale.Tr "repo.branch.included_desc"}}" data-position="top right">
+													{{svg "octicon-git-pull-request"}} {{$.locale.Tr "repo.branch.included"}}
 												</a>
 											{{else if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{PathEscapeSegments $.DefaultBranch}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{PathEscape $.Owner.Name}}:{{end}}{{PathEscapeSegments .Name}}">
-												<button id="new-pull-request" class="ui compact basic button mr-0">{{if $.CanPull}}{{$.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{$.i18n.Tr "action.compare_branch"}}{{end}}</button>
+												<button id="new-pull-request" class="ui compact basic button mr-0">{{if $.CanPull}}{{$.locale.Tr "repo.pulls.compare_changes"}}{{else}}{{$.locale.Tr "action.compare_branch"}}{{end}}</button>
 											</a>
 											{{end}}
 										{{else if and .LatestPullRequest.HasMerged .MergeMovedOn}}
 											{{if and (not .IsDeleted) $.AllowsPulls (gt .CommitsAhead 0)}}
 											<a href="{{$.RepoLink}}/compare/{{PathEscapeSegments $.DefaultBranch}}...{{if ne $.Repository.Owner.Name $.Owner.Name}}{{$.Owner.Name}}:{{end}}{{.Name | PathEscapeSegments}}">
-												<button id="new-pull-request" class="ui compact basic button mr-0">{{if $.CanPull}}{{$.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{$.i18n.Tr "action.compare_branch"}}{{end}}</button>
+												<button id="new-pull-request" class="ui compact basic button mr-0">{{if $.CanPull}}{{$.locale.Tr "repo.pulls.compare_changes"}}{{else}}{{$.locale.Tr "action.compare_branch"}}{{end}}</button>
 											</a>
 											{{end}}
 										{{else}}
 											<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="vm ref-issue">{{if not .LatestPullRequest.IsSameRepo}}{{.LatestPullRequest.BaseRepo.FullName}}{{end}}#{{.LatestPullRequest.Issue.Index}}</a>
 											{{if .LatestPullRequest.HasMerged}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple large label vm">{{svg "octicon-git-merge" 16 "mr-2"}}{{$.i18n.Tr "repo.pulls.merged"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label purple large label vm">{{svg "octicon-git-merge" 16 "mr-2"}}{{$.locale.Tr "repo.pulls.merged"}}</a>
 											{{else if .LatestPullRequest.Issue.IsClosed}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red large label vm">{{svg "octicon-git-pull-request" 16 "mr-2"}}{{$.i18n.Tr "repo.issues.closed_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label red large label vm">{{svg "octicon-git-pull-request" 16 "mr-2"}}{{$.locale.Tr "repo.issues.closed_title"}}</a>
 											{{else}}
-												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green large label vm">{{svg "octicon-git-pull-request" 16 "mr-2"}}{{$.i18n.Tr "repo.issues.open_title"}}</a>
+												<a href="{{.LatestPullRequest.Issue.HTMLURL}}" class="ui text-label green large label vm">{{svg "octicon-git-pull-request" 16 "mr-2"}}{{$.locale.Tr "repo.issues.open_title"}}</a>
 											{{end}}
 										{{end}}
 									</td>
 									<td class="two wide right aligned overflow-visible">
 										{{if and $.IsWriter (not $.Repository.IsArchived) (not .IsDeleted)}}
-											<div class="ui basic jump button icon tooltip show-create-branch-modal" data-branch-from="{{.Name}}" data-branch-from-urlcomponent="{{PathEscapeSegments .Name}}" data-content="{{$.i18n.Tr "repo.branch.new_branch_from" .Name}}" data-position="top right" data-modal="#create-branch-modal" data-name="{{.Name}}">
+											<div class="ui basic jump button icon tooltip show-create-branch-modal" data-branch-from="{{.Name}}" data-branch-from-urlcomponent="{{PathEscapeSegments .Name}}" data-content="{{$.locale.Tr "repo.branch.new_branch_from" .Name}}" data-position="top right" data-modal="#create-branch-modal" data-name="{{.Name}}">
 												{{svg "octicon-git-branch"}}
 											</div>
 										{{end}}
 										{{if (not .IsDeleted)}}
-											<div class="ui basic jump dropdown icon button tooltip" data-content="{{$.i18n.Tr "repo.branch.download" (.Name)}}" data-position="top right">
+											<div class="ui basic jump dropdown icon button tooltip" data-content="{{$.locale.Tr "repo.branch.download" (.Name)}}" data-position="top right">
 												{{svg "octicon-download"}}
 												<div class="menu">
 													<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments .Name}}.zip" rel="nofollow">{{svg "octicon-file-zip"}}&nbsp;ZIP</a>
@@ -121,9 +121,9 @@
 										{{end}}
 										{{if and $.IsWriter (not $.IsMirror) (not $.Repository.IsArchived) (not .IsProtected)}}
 											{{if .IsDeleted}}
-												<a class="ui basic jump button icon tooltip undo-button" href data-url="{{$.Link}}/restore?branch_id={{.DeletedBranch.ID}}&name={{.DeletedBranch.Name}}" data-content="{{$.i18n.Tr "repo.branch.restore" (.Name)}}" data-position="top right"><span class="text blue">{{svg "octicon-reply"}}</span></a>
+												<a class="ui basic jump button icon tooltip undo-button" href data-url="{{$.Link}}/restore?branch_id={{.DeletedBranch.ID}}&name={{.DeletedBranch.Name}}" data-content="{{$.locale.Tr "repo.branch.restore" (.Name)}}" data-position="top right"><span class="text blue">{{svg "octicon-reply"}}</span></a>
 											{{else}}
-												<a class="ui basic jump button icon tooltip delete-button delete-branch-button" href data-url="{{$.Link}}/delete?name={{.Name}}" data-content="{{$.i18n.Tr "repo.branch.delete" (.Name)}}" data-position="top right" data-name="{{.Name}}">
+												<a class="ui basic jump button icon tooltip delete-button delete-branch-button" href data-url="{{$.Link}}/delete?name={{.Name}}" data-content="{{$.locale.Tr "repo.branch.delete" (.Name)}}" data-position="top right" data-name="{{.Name}}">
 													{{svg "octicon-trash"}}
 												</a>
 											{{end}}
@@ -143,35 +143,35 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.branch.delete_html"}} <span class="name"></span>
+		{{.locale.Tr "repo.branch.delete_html"}} <span class="name"></span>
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.branch.delete_desc" | Str2html}}</p>
+		<p>{{.locale.Tr "repo.branch.delete_desc" | Str2html}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>
 
 <div class="ui small modal" id="create-branch-modal">
 	<div class="header">
-		{{.i18n.Tr "repo.branch.new_branch"}}
+		{{.locale.Tr "repo.branch.new_branch"}}
 	</div>
 	<div class="content">
 		<form class="ui form" id="create-branch-form" action="" data-base-action="{{.Link}}/_new/branch/" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="field">
 				<label>
-					{{.i18n.Tr "repo.branch.create_new_branch"}}
+					{{.locale.Tr "repo.branch.create_new_branch"}}
 					<span class="text" id="modal-create-branch-from-span"></span>
 				</label>
 			</div>
 			<div class="required field">
-				<label for="new_branch_name">{{.i18n.Tr "repo.branch.name"}}</label>
+				<label for="new_branch_name">{{.locale.Tr "repo.branch.name"}}</label>
 				<input id="new_branch_name" name="new_branch_name" required>
 			</div>
 
 			<div class="text right actions">
-				<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-				<button class="ui green button">{{.i18n.Tr "repo.branch.confirm_create_branch"}}</button>
+				<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+				<button class="ui green button">{{.locale.Tr "repo.branch.confirm_create_branch"}}</button>
 			</div>
 		</form>
 	</div>

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui floating filter dropdown custom"
 		data-branch-form="{{if $.branchForm}}{{$.branchForm}}{{end}}"
 		data-can-create-branch="{{if .canCreateBranch}}{{.canCreateBranch}}{{else}}{{.root.CanCreateBranch}}{{end}}"
-		data-no-results="{{.root.i18n.Tr "repo.pulls.no_results"}}"
+		data-no-results="{{.root.locale.Tr "repo.pulls.no_results"}}"
 		data-set-action="{{.setAction}}" data-submit-form="{{.submitForm}}"
 		data-view-type="{{if and .root.IsViewTag (not .noTag)}}tag{{else if .root.IsViewBranch}}branch{{else}}tree{{end}}"
 		data-ref-name="{{if and .root.IsViewTag (not .noTag)}}{{.root.TagName}}{{else if .root.IsViewBranch}}{{.root.BranchName}}{{else}}{{ShortSha .root.CommitID}}{{end}}"
@@ -16,11 +16,11 @@
 		<div class="ui basic small compact button" @click="menuVisible = !menuVisible" @keyup.enter="menuVisible = !menuVisible">
 			<span class="text">
 				{{if $release}}
-					{{.root.i18n.Tr "repo.release.compare"}}
+					{{.root.locale.Tr "repo.release.compare"}}
 				{{else}}
-					<span :class="{visible: isViewTag}" v-if="isViewTag" v-cloak>{{svg "octicon-tag"}} {{.root.i18n.Tr "repo.tag"}}:</span>
-					<span :class="{visible: isViewBranch}" v-if="isViewBranch" v-cloak>{{svg "octicon-git-branch"}} {{.root.i18n.Tr "repo.branch"}}:</span>
-					<span :class="{visible: isViewTree}" v-if="isViewTree" v-cloak>{{svg "octicon-git-branch"}} {{.root.i18n.Tr "repo.tree"}}:</span>
+					<span :class="{visible: isViewTag}" v-if="isViewTag" v-cloak>{{svg "octicon-tag"}} {{.root.locale.Tr "repo.tag"}}:</span>
+					<span :class="{visible: isViewBranch}" v-if="isViewBranch" v-cloak>{{svg "octicon-git-branch"}} {{.root.locale.Tr "repo.branch"}}:</span>
+					<span :class="{visible: isViewTree}" v-if="isViewTree" v-cloak>{{svg "octicon-git-branch"}} {{.root.locale.Tr "repo.tree"}}:</span>
 					<strong ref="dropdownRefName">{{if and .root.IsViewTag (not .noTag)}}{{.root.TagName}}{{else if .root.IsViewBranch}}{{.root.BranchName}}{{else}}{{ShortSha .root.CommitID}}{{end}}</strong>
 				{{end}}
 			</span>
@@ -45,7 +45,7 @@
 		<div class="menu transition" :class="{visible: menuVisible}" v-if="menuVisible" v-cloak>
 			<div class="ui icon search input">
 				<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-				<input name="search" ref="searchField" autocomplete="off" v-model="searchTerm" @keydown="keydown($event)" placeholder="{{if $.noTag}}{{.root.i18n.Tr "repo.pulls.filter_branch"}}{{else if $showBranchesInDropdown}}{{.root.i18n.Tr "repo.filter_branch_and_tag"}}{{else}}{{.root.i18n.Tr "repo.find_tag"}}{{end}}...">
+				<input name="search" ref="searchField" autocomplete="off" v-model="searchTerm" @keydown="keydown($event)" placeholder="{{if $.noTag}}{{.root.locale.Tr "repo.pulls.filter_branch"}}{{else if $showBranchesInDropdown}}{{.root.locale.Tr "repo.filter_branch_and_tag"}}{{else}}{{.root.locale.Tr "repo.find_tag"}}{{end}}...">
 			</div>
 			{{if $showBranchesInDropdown}}
 				<div class="header branch-tag-choice">
@@ -53,13 +53,13 @@
 						<div class="two column row">
 							<a class="reference column" href="#" @click="createTag = false; mode = 'branches'; focusSearchField()">
 								<span class="text" :class="{black: mode == 'branches'}">
-									{{svg "octicon-git-branch" 16 "mr-2"}}{{.root.i18n.Tr "repo.branches"}}
+									{{svg "octicon-git-branch" 16 "mr-2"}}{{.root.locale.Tr "repo.branches"}}
 								</span>
 							</a>
 							{{if not .noTag}}
 								<a class="reference column" href="#" @click="createTag = true; mode = 'tags'; focusSearchField()">
 									<span class="text" :class="{black: mode == 'tags'}">
-										{{svg "octicon-tag" 16 "mr-2"}}{{.root.i18n.Tr "repo.tags"}}
+										{{svg "octicon-tag" 16 "mr-2"}}{{.root.locale.Tr "repo.tags"}}
 									</span>
 								</a>
 							{{end}}
@@ -73,19 +73,19 @@
 					<a href="#" @click="createNewBranch()">
 						<div v-show="createTag">
 							<i class="reference tags icon"></i>
-							{{.root.i18n.Tr "repo.tag.create_tag" `${ searchTerm }` | Safe}}
+							{{.root.locale.Tr "repo.tag.create_tag" `${ searchTerm }` | Safe}}
 						</div>
 						<div v-show="!createTag">
 							{{svg "octicon-git-branch"}}
-							{{.root.i18n.Tr "repo.branch.create_branch" `${ searchTerm }` | Safe}}
+							{{.root.locale.Tr "repo.branch.create_branch" `${ searchTerm }` | Safe}}
 						</div>
 						<div class="text small">
 							{{if or .root.IsViewBranch $release}}
-								{{.root.i18n.Tr "repo.branch.create_from" .root.BranchName}}
+								{{.root.locale.Tr "repo.branch.create_from" .root.BranchName}}
 							{{else if .root.IsViewTag}}
-								{{.root.i18n.Tr "repo.branch.create_from" .root.TagName}}
+								{{.root.locale.Tr "repo.branch.create_from" .root.TagName}}
 							{{else}}
-								{{.root.i18n.Tr "repo.branch.create_from" (ShortSha .root.CommitID)}}
+								{{.root.locale.Tr "repo.branch.create_from" (ShortSha .root.CommitID)}}
 							{{end}}
 						</div>
 					</a>

--- a/templates/repo/clone_buttons.tmpl
+++ b/templates/repo/clone_buttons.tmpl
@@ -19,6 +19,6 @@
 		document.getElementById('repo-clone-url').value = btn ? btn.getAttribute('data-link') : '';
 	})();
 </script>
-<button class="ui basic icon button tooltip" id="clipboard-btn" data-content="{{.i18n.Tr "copy_url"}}" data-clipboard-target="#repo-clone-url">
+<button class="ui basic icon button tooltip" id="clipboard-btn" data-content="{{.locale.Tr "copy_url"}}" data-clipboard-target="#repo-clone-url">
 	{{svg "octicon-paste"}}
 </button>

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -23,42 +23,42 @@
 				{{if not $.PageIsWiki}}
 					<div class="ui">
 						<a class="ui primary tiny button" href="{{.SourcePath}}">
-							{{.i18n.Tr "repo.diff.browse_source"}}
+							{{.locale.Tr "repo.diff.browse_source"}}
 						</a>
 						{{if and ($.Permission.CanWrite $.UnitTypeCode) (not $.Repository.IsArchived) (not .IsDeleted)}}{{- /* */ -}}
-							<div class="ui primary tiny floating dropdown icon button">{{.i18n.Tr "repo.commit.actions"}}
-								{{svg "octicon-triangle-down" 14 "dropdown icon"}}<span class="sr-mobile-only">{{.i18n.Tr "repo.commit.actions"}}</span>
+							<div class="ui primary tiny floating dropdown icon button">{{.locale.Tr "repo.commit.actions"}}
+								{{svg "octicon-triangle-down" 14 "dropdown icon"}}<span class="sr-mobile-only">{{.locale.Tr "repo.commit.actions"}}</span>
 								<div class="menu">
-									<div class="ui header">{{.i18n.Tr "repo.commit.actions"}}</div>
+									<div class="ui header">{{.locale.Tr "repo.commit.actions"}}</div>
 									<div class="divider"></div>
 									<div class="item show-create-branch-modal"
-										data-content="{{$.i18n.Tr "repo.branch.new_branch_from" (.CommitID)}}"
+										data-content="{{$.locale.Tr "repo.branch.new_branch_from" (.CommitID)}}"
 										data-branch-from="{{ShortSha .CommitID}}"
 										data-branch-from-urlcomponent="{{.CommitID}}"
 										data-modal="#create-branch-modal">
-										{{.i18n.Tr "repo.branch.create_branch_operation"}}
+										{{.locale.Tr "repo.branch.create_branch_operation"}}
 									</div>
 									<div class="item show-create-branch-modal"
-										data-content="{{$.i18n.Tr "repo.branch.new_branch_from" (.CommitID)}}"
+										data-content="{{$.locale.Tr "repo.branch.new_branch_from" (.CommitID)}}"
 										data-branch-from="{{ShortSha .CommitID}}"
 										data-branch-from-urlcomponent="{{.CommitID}}"
 										data-modal="#create-tag-modal"
 										data-modal-from-span="#modal-create-tag-from-span"
 										data-modal-form="#create-tag-form">
-										{{.i18n.Tr "repo.tag.create_tag_operation"}}
+										{{.locale.Tr "repo.tag.create_tag_operation"}}
 									</div>
 									<div class="item show-modal revert-button"
 										data-modal="#cherry-pick-modal"
 										data-modal-cherry-pick-type="revert"
-										data-modal-cherry-pick-header="{{$.i18n.Tr "repo.commit.revert-header" (ShortSha .CommitID)}}"
-										data-modal-cherry-pick-content="{{$.i18n.Tr "repo.commit.revert-content"}}"
-										data-modal-cherry-pick-submit="{{.i18n.Tr "repo.commit.revert"}}">{{.i18n.Tr "repo.commit.revert"}}</a></div>
+										data-modal-cherry-pick-header="{{$.locale.Tr "repo.commit.revert-header" (ShortSha .CommitID)}}"
+										data-modal-cherry-pick-content="{{$.locale.Tr "repo.commit.revert-content"}}"
+										data-modal-cherry-pick-submit="{{.locale.Tr "repo.commit.revert"}}">{{.locale.Tr "repo.commit.revert"}}</a></div>
 									<div class="item cherry-pick-button show-modal"
 										data-modal="#cherry-pick-modal"
 										data-modal-cherry-pick-type="cherry-pick"
-										data-modal-cherry-pick-header="{{$.i18n.Tr "repo.commit.cherry-pick-header" (ShortSha .CommitID)}}"
-										data-modal-cherry-pick-content="{{$.i18n.Tr "repo.commit.cherry-pick-content"}}"
-										data-modal-cherry-pick-submit="{{.i18n.Tr "repo.commit.cherry-pick"}}">{{.i18n.Tr "repo.commit.cherry-pick"}}</a></div>
+										data-modal-cherry-pick-header="{{$.locale.Tr "repo.commit.cherry-pick-header" (ShortSha .CommitID)}}"
+										data-modal-cherry-pick-content="{{$.locale.Tr "repo.commit.cherry-pick-content"}}"
+										data-modal-cherry-pick-submit="{{.locale.Tr "repo.commit.cherry-pick"}}">{{.locale.Tr "repo.commit.cherry-pick"}}</a></div>
 									<div class="ui basic modal" id="cherry-pick-modal">
 										<div class="ui icon header">
 											<span id="cherry-pick-header"></span>
@@ -80,31 +80,31 @@
 									</div>
 									<div class="ui small modal" id="create-branch-modal">
 										<div class="header">
-											{{.i18n.Tr "repo.branch.new_branch"}}
+											{{.locale.Tr "repo.branch.new_branch"}}
 										</div>
 										<div class="content">
 											<form class="ui form" id="create-branch-form" action="" data-base-action="{{.RepoLink}}/branches/_new/commit/" method="post">
 												{{.CsrfTokenHtml}}
 												<div class="field">
 													<label>
-														{{.i18n.Tr "repo.branch.new_branch_from" "<span class=\"text\" id=\"modal-create-branch-from-span\"></span>" | Safe }}
+														{{.locale.Tr "repo.branch.new_branch_from" "<span class=\"text\" id=\"modal-create-branch-from-span\"></span>" | Safe }}
 													</label>
 												</div>
 												<div class="required field">
-													<label for="new_branch_name">{{.i18n.Tr "repo.branch.name"}}</label>
+													<label for="new_branch_name">{{.locale.Tr "repo.branch.name"}}</label>
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
 												<div class="text right actions">
-													<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-													<button class="ui green button">{{.i18n.Tr "repo.branch.confirm_create_branch"}}</button>
+													<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+													<button class="ui green button">{{.locale.Tr "repo.branch.confirm_create_branch"}}</button>
 												</div>
 											</form>
 										</div>
 									</div>
 									<div class="ui small modal" id="create-tag-modal">
 										<div class="header">
-											{{.i18n.Tr "repo.tag.create_tag_operation"}}
+											{{.locale.Tr "repo.tag.create_tag_operation"}}
 										</div>
 										<div class="content">
 											<form class="ui form" id="create-tag-form" action="" data-base-action="{{.RepoLink}}/branches/_new/commit/" method="post">
@@ -112,17 +112,17 @@
 												<input type="hidden" name="create_tag" value="true">
 												<div class="field">
 													<label>
-														{{.i18n.Tr "repo.tag.create_tag_from" "<span class=\"text\" id=\"modal-create-tag-from-span\"></span>" | Safe }}
+														{{.locale.Tr "repo.tag.create_tag_from" "<span class=\"text\" id=\"modal-create-tag-from-span\"></span>" | Safe }}
 													</label>
 												</div>
 												<div class="required field">
-													<label for="new_branch_name">{{.i18n.Tr "repo.release.tag_name"}}</label>
+													<label for="new_branch_name">{{.locale.Tr "repo.release.tag_name"}}</label>
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
 												<div class="text right actions">
-													<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-													<button class="ui green button">{{.i18n.Tr "repo.tag.confirm_create_tag"}}</button>
+													<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+													<button class="ui green button">{{.locale.Tr "repo.tag.confirm_create_tag"}}</button>
 												</div>
 											</form>
 										</div>
@@ -156,9 +156,9 @@
 						{{avatarByEmail .Commit.Author.Email .Commit.Author.Email 28 "mr-3"}}
 						<strong>{{.Commit.Author.Name}}</strong>
 					{{end}}
-					<span class="text grey ml-3" id="authored-time">{{TimeSince .Commit.Author.When $.i18n}}</span>
+					<span class="text grey ml-3" id="authored-time">{{TimeSince .Commit.Author.When $.locale}}</span>
 					{{if or (ne .Commit.Committer.Name .Commit.Author.Name) (ne .Commit.Committer.Email .Commit.Author.Email)}}
-						<span class="text grey mx-3">{{.i18n.Tr "repo.diff.committed_by"}}</span>
+						<span class="text grey mx-3">{{.locale.Tr "repo.diff.committed_by"}}</span>
 						{{if ne .Verification.CommittingUser.ID 0}}
 							{{avatar .Verification.CommittingUser 28 "mx-3"}}
 							<a href="{{.Verification.CommittingUser.HomeLink}}"><strong>{{.Commit.Committer.Name}}</strong></a>
@@ -171,7 +171,7 @@
 				<div class="ui horizontal list df ac">
 					{{if .Parents}}
 						<div class="item">
-							<span>{{.i18n.Tr "repo.diff.parent"}}</span>
+							<span>{{.locale.Tr "repo.diff.parent"}}</span>
 							{{range .Parents}}
 								{{if $.PageIsWiki}}
 									<a class="ui primary sha label" href="{{$.RepoLink}}/wiki/commit/{{PathEscape .}}">{{ShortSha .}}</a>
@@ -182,7 +182,7 @@
 						</div>
 					{{end}}
 					<div class="item">
-						<span>{{.i18n.Tr "repo.diff.commit"}}</span>
+						<span>{{.locale.Tr "repo.diff.commit"}}</span>
 						<span class="ui primary sha label">{{ShortSha .CommitID}}</span>
 					</div>
 				</div>
@@ -194,23 +194,23 @@
 						{{if ne .Verification.SigningUser.ID 0}}
 							{{svg "gitea-lock" 16 "mr-3"}}
 							{{if eq .Verification.TrustStatus "trusted"}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.signed_by"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.signed_by"}}:</span>
 							{{else if eq .Verification.TrustStatus "untrusted"}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
 							{{else}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
 							{{end}}
 							{{avatar .Verification.SigningUser 28}}
 							<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Verification.SigningUser.GetDisplayName}}</strong></a>
 						{{else}}
-							<span title="{{.i18n.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog" 16 "mr-3"}}</span>
-							<span class="ui text mr-3">{{.i18n.Tr "repo.commits.signed_by"}}:</span>
+							<span title="{{.locale.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog" 16 "mr-3"}}</span>
+							<span class="ui text mr-3">{{.locale.Tr "repo.commits.signed_by"}}:</span>
 							{{avatarByEmail .Verification.SigningEmail "" 28}}
 							<strong>{{.Verification.SigningUser.GetDisplayName}}</strong>
 						{{end}}
 					{{else}}
 						{{svg "gitea-unlock" 16 "mr-3"}}
-						<span class="ui text">{{.i18n.Tr .Verification.Reason}}</span>
+						<span class="ui text">{{.locale.Tr .Verification.Reason}}</span>
 					{{end}}
 				</div>
 				<div class="df ac">
@@ -218,43 +218,43 @@
 						{{if ne .Verification.SigningUser.ID 0}}
 							{{svg "octicon-shield-check" 16 "mr-3"}}
 							{{if .Verification.SigningSSHKey}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
 								{{.Verification.SigningSSHKey.Fingerprint}}
 							{{else}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.gpg_key_id"}}:</span>
 								{{.Verification.SigningKey.KeyID}}
 							{{end}}
 						{{else}}
 							{{svg "octicon-shield-lock" 16 "mr-3"}}
 							{{if .Verification.SigningSSHKey}}
-								<span class="ui text mr-3 tooltip" data-content="{{.i18n.Tr "gpg.default_key"}}">{{.i18n.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="ui text mr-3 tooltip" data-content="{{.locale.Tr "gpg.default_key"}}">{{.locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
 								{{.Verification.SigningSSHKey.Fingerprint}}
 							{{else}}
-								<span class="ui text mr-3 tooltip" data-content="{{.i18n.Tr "gpg.default_key"}}">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="ui text mr-3 tooltip" data-content="{{.locale.Tr "gpg.default_key"}}">{{.locale.Tr "repo.commits.gpg_key_id"}}:</span>
 								{{.Verification.SigningKey.KeyID}}
 							{{end}}
 						{{end}}
 					{{else if .Verification.Warning}}
 						{{svg "octicon-shield" 16 "mr-3"}}
 						{{if .Verification.SigningSSHKey}}
-							<span class="ui text mr-3">{{.i18n.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+							<span class="ui text mr-3">{{.locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
 							{{.Verification.SigningSSHKey.Fingerprint}}
 						{{else}}
-							<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
+							<span class="ui text mr-3">{{.locale.Tr "repo.commits.gpg_key_id"}}:</span>
 							{{.Verification.SigningKey.KeyID}}
 						{{end}}
 					{{else}}
 						{{if .Verification.SigningKey}}
 							{{if ne .Verification.SigningKey.KeyID ""}}
 								{{svg "octicon-shield" 16 "mr-3"}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.gpg_key_id"}}:</span>
 								{{.Verification.SigningKey.KeyID}}
 							{{end}}
 						{{end}}
 						{{if .Verification.SigningSSHKey}}
 							{{if ne .Verification.SigningSSHKey.Fingerprint ""}}
 								{{svg "octicon-shield" 16 "mr-3"}}
-								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="ui text mr-3">{{.locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
 								{{.Verification.SigningSSHKey.Fingerprint}}
 							{{end}}
 						{{end}}
@@ -265,7 +265,7 @@
 		{{if .Note}}
 			<div class="ui top attached header segment git-notes">
 				{{svg "octicon-note" 16 "mr-3"}}
-				{{.i18n.Tr "repo.diff.git-notes"}}:
+				{{.locale.Tr "repo.diff.git-notes"}}:
 				{{if .NoteAuthor}}
 					<a href="{{.NoteAuthor.HomeLink}}">
 						{{if .NoteAuthor.FullName}}
@@ -277,7 +277,7 @@
 				{{else}}
 					<strong>{{.NoteCommit.Author.Name}}</strong>
 				{{end}}
-				<span class="text grey" id="note-authored-time">{{TimeSince .NoteCommit.Author.When $.i18n}}</span>
+				<span class="text grey" id="note-authored-time">{{TimeSince .NoteCommit.Author.When $.locale}}</span>
 			</div>
 			<div class="ui bottom attached info segment git-notes">
 				<pre class="commit-body">{{RenderNote $.Context .Note $.RepoLink $.Repository.ComposeMetas}}</pre>

--- a/templates/repo/commit_statuses.tmpl
+++ b/templates/repo/commit_statuses.tmpl
@@ -6,7 +6,7 @@
 				<span>{{template "repo/commit_status" .}}</span>
 				<span class="ui f1">{{.Context}} <span class="text grey">{{.Description}}</span></span>
 				{{if .TargetURL}}
-					<div class="ui"><a href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{$.root.i18n.Tr "repo.pulls.status_checks_details"}}</a></div>
+					<div class="ui"><a href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{$.root.locale.Tr "repo.pulls.status_checks_details"}}</a></div>
 				{{end}}
 			</div>
 		{{end}}

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -10,7 +10,7 @@
 					<span class="text">
 						{{svg "octicon-git-branch"}}
 					</span>
-					{{.i18n.Tr "repo.commit_graph"}}
+					{{.locale.Tr "repo.commit_graph"}}
 				</a>
 			</div>
 		</div>

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -2,10 +2,10 @@
 		<table class="ui very basic striped table unstackable fixed" id="commits-table">
 			<thead>
 				<tr>
-					<th class="four wide">{{.i18n.Tr "repo.commits.author"}}</th>
+					<th class="four wide">{{.locale.Tr "repo.commits.author"}}</th>
 					<th class="two wide sha">SHA1</th>
-					<th class="seven wide message">{{.i18n.Tr "repo.commits.message"}}</th>
-					<th class="three wide right aligned">{{.i18n.Tr "repo.commits.date"}}</th>
+					<th class="seven wide message">{{.locale.Tr "repo.commits.message"}}</th>
+					<th class="three wide right aligned">{{.locale.Tr "repo.commits.date"}}</th>
 				</tr>
 			</thead>
 			<tbody class="commit-list">
@@ -76,9 +76,9 @@
 							{{end}}
 						</td>
 						{{if .Committer}}
-							<td class="text right aligned">{{TimeSince .Committer.When $.i18n}}</td>
+							<td class="text right aligned">{{TimeSince .Committer.When $.locale}}</td>
 						{{else}}
-							<td class="text right aligned">{{TimeSince .Author.When $.i18n}}</td>
+							<td class="text right aligned">{{TimeSince .Author.When $.locale}}</td>
 						{{end}}
 					</tr>
 				{{end}}

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -1,25 +1,25 @@
 <h4 class="ui top attached header commits-table df ac sb">
 	<div class="commits-table-left df ac">
 		{{if or .PageIsCommits (gt .CommitCount 0)}}
-			{{.CommitCount}} {{.i18n.Tr "repo.commits.commits"}} {{if .RefName}}({{.RefName}}){{end}}
+			{{.CommitCount}} {{.locale.Tr "repo.commits.commits"}} {{if .RefName}}({{.RefName}}){{end}}
 		{{else if .IsNothingToCompare}}
-			{{.i18n.Tr "repo.commits.nothing_to_compare" }} {{if .RefName}}({{.RefName}}){{end}}
+			{{.locale.Tr "repo.commits.nothing_to_compare" }} {{if .RefName}}({{.RefName}}){{end}}
 		{{else}}
-			{{.i18n.Tr "repo.commits.no_commits" $.BaseBranch $.HeadBranch}} {{if .RefName}}({{.RefName}}){{end}}
+			{{.locale.Tr "repo.commits.no_commits" $.BaseBranch $.HeadBranch}} {{if .RefName}}({{.RefName}}){{end}}
 		{{end}}
 	</div>
 	<div class="commits-table-right df ac">
 		{{if .PageIsCommits}}
 			<form class="ignore-dirty" action="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/search">
 				<div class="ui tiny search input">
-					<input name="q" placeholder="{{.i18n.Tr "repo.commits.search"}}" value="{{.Keyword}}" autofocus>
+					<input name="q" placeholder="{{.locale.Tr "repo.commits.search"}}" value="{{.Keyword}}" autofocus>
 				</div>
 				&nbsp;
 				<div class="ui checkbox">
 					<input type="checkbox" name="all" id="all" value="true" {{.All}}>
-					<label for="all">{{.i18n.Tr "repo.commits.search_all"}} &nbsp;&nbsp;</label>
+					<label for="all">{{.locale.Tr "repo.commits.search_all"}} &nbsp;&nbsp;</label>
 				</div>
-				<button class="ui primary tiny button mr-0 tooltip" data-panel="#add-deploy-key-panel" data-content={{.i18n.Tr "repo.commits.search.tooltip"}}>{{.i18n.Tr "repo.commits.find"}}</button>
+				<button class="ui primary tiny button mr-0 tooltip" data-panel="#add-deploy-key-panel" data-content={{.locale.Tr "repo.commits.search.tooltip"}}>{{.locale.Tr "repo.commits.find"}}</button>
 			</form>
 		{{else if .IsDiffCompare}}
 			<a href="{{$.CommitRepoLink}}/commit/{{.BeforeCommitID | PathEscape}}" class="ui green sha label">{{if not .BaseIsCommit}}{{if .BaseIsBranch}}{{svg "octicon-git-branch"}}{{else if .BaseIsTag}}{{svg "octicon-tag"}}{{end}}{{.BaseBranch}}{{else}}{{ShortSha .BaseBranch}}{{end}}</a>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -5,22 +5,22 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "new_repo"}}
+					{{.locale.Tr "new_repo"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 
 					{{if not $.DisableMigrations}}
-						<p class="ui center">{{.i18n.Tr "repo.new_repo_helper" ((printf "%s%s" AppSubUrl "/repo/migrate")|Escape) | Safe}}</p>
+						<p class="ui center">{{.locale.Tr "repo.new_repo_helper" ((printf "%s%s" AppSubUrl "/repo/migrate")|Escape) | Safe}}</p>
 					{{end}}
 
 					{{if not .CanCreateRepo}}
 						<div class="ui negative message">
-							<p>{{.i18n.TrN .MaxCreationLimit "repo.form.reach_limit_of_creation_1" "repo.form.reach_limit_of_creation_n" .MaxCreationLimit}}</p>
+							<p>{{.locale.TrN .MaxCreationLimit "repo.form.reach_limit_of_creation_1" "repo.form.reach_limit_of_creation_n" .MaxCreationLimit}}</p>
 						</div>
 					{{end}}
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -41,33 +41,33 @@
 								{{end}}
 							</div>
 						</div>
-						<span class="help">{{.i18n.Tr "repo.owner_helper"}}</span>
+						<span class="help">{{.locale.Tr "repo.owner_helper"}}</span>
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" autofocus required>
-						<span class="help">{{.i18n.Tr "repo.repo_name_helper"}}</span>
+						<span class="help">{{.locale.Tr "repo.repo_name_helper"}}</span>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
-						<span class="help">{{.i18n.Tr "repo.visibility_description"}}</span>
+						<span class="help">{{.locale.Tr "repo.visibility_description"}}</span>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
-						<textarea id="description" name="description" placeholder="{{.i18n.Tr "repo.repo_desc_helper"}}">{{.description}}</textarea>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
+						<textarea id="description" name="description" placeholder="{{.locale.Tr "repo.repo_desc_helper"}}">{{.description}}</textarea>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.template"}}</label>
+						<label>{{.locale.Tr "repo.template"}}</label>
 						<div id="repo_template_search" class="ui search normal selection dropdown">
 							<input type="hidden" id="repo_template" name="repo_template" value="{{.repo_template}}">
 							<div class="default text">{{.repo_template_name}}</div>
@@ -78,48 +78,48 @@
 
 					<div id="template_units" style="display: none;">
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.template.items"}}</label>
+							<label>{{.locale.Tr "repo.template.items"}}</label>
 							<div class="ui checkbox">
 								<input class="hidden" name="git_content" type="checkbox" tabindex="0" {{if .git_content}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.git_content"}}</label>
+								<label>{{.locale.Tr "repo.template.git_content"}}</label>
 							</div>
-							<div class="ui checkbox{{if not .SignedUser.CanEditGitHook}} tooltip{{end}}"{{if not .SignedUser.CanEditGitHook}} data-content="{{.i18n.Tr "repo.template.git_hooks_tooltip"}}"{{end}}>
+							<div class="ui checkbox{{if not .SignedUser.CanEditGitHook}} tooltip{{end}}"{{if not .SignedUser.CanEditGitHook}} data-content="{{.locale.Tr "repo.template.git_hooks_tooltip"}}"{{end}}>
 								<input class="hidden" name="git_hooks" type="checkbox" tabindex="0" {{if .git_hooks}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.git_hooks"}}</label>
+								<label>{{.locale.Tr "repo.template.git_hooks"}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input class="hidden" name="webhooks" type="checkbox" tabindex="0" {{if .webhooks}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.webhooks"}}</label>
+								<label>{{.locale.Tr "repo.template.webhooks"}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input class="hidden" name="topics" type="checkbox" tabindex="0" {{if .topics}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.topics"}}</label>
+								<label>{{.locale.Tr "repo.template.topics"}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input class="hidden" name="avatar" type="checkbox" tabindex="0" {{if .avatar}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.avatar"}}</label>
+								<label>{{.locale.Tr "repo.template.avatar"}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input class="hidden" name="labels" type="checkbox" tabindex="0" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.template.issue_labels"}}</label>
+								<label>{{.locale.Tr "repo.template.issue_labels"}}</label>
 							</div>
 						</div>
 					</div>
 
 					<div id="non_template">
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.issue_labels"}}</label>
+							<label>{{.locale.Tr "repo.issue_labels"}}</label>
 							<div class="ui search normal selection dropdown">
 								<input type="hidden" name="issue_labels" value="{{.issueLabels}}">
-								<div class="default text">{{.i18n.Tr "repo.issue_labels_helper"}}</div>
+								<div class="default text">{{.locale.Tr "repo.issue_labels_helper"}}</div>
 								<div class="menu">
-									<div class="item" data-value="">{{.i18n.Tr "repo.issue_labels_helper"}}</div>
+									<div class="item" data-value="">{{.locale.Tr "repo.issue_labels_helper"}}</div>
 									{{range $template, $labels := .LabelTemplates}}
 										<div class="item" data-value="{{$template}}">{{$template}}<br/><i>({{$labels}})</i></div>
 									{{end}}
@@ -133,82 +133,82 @@
 							<label>.gitignore</label>
 							<div class="ui multiple search normal selection dropdown">
 								<input type="hidden" name="gitignores" value="{{.gitignores}}">
-								<div class="default text">{{.i18n.Tr "repo.repo_gitignore_helper"}}</div>
+								<div class="default text">{{.locale.Tr "repo.repo_gitignore_helper"}}</div>
 								<div class="menu">
 									{{range .Gitignores}}
 										<div class="item" data-value="{{.}}">{{.}}</div>
 									{{end}}
 								</div>
 							</div>
-							<span class="help">{{.i18n.Tr "repo.repo_gitignore_helper_desc"}}</span>
+							<span class="help">{{.locale.Tr "repo.repo_gitignore_helper_desc"}}</span>
 						</div>
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.license"}}</label>
+							<label>{{.locale.Tr "repo.license"}}</label>
 							<div class="ui search selection dropdown">
 								<input type="hidden" name="license" value="{{.license}}">
-								<div class="default text">{{.i18n.Tr "repo.license_helper"}}</div>
+								<div class="default text">{{.locale.Tr "repo.license_helper"}}</div>
 								<div class="menu">
-									<div class="item" data-value="">{{.i18n.Tr "repo.license_helper"}}</div>
+									<div class="item" data-value="">{{.locale.Tr "repo.license_helper"}}</div>
 									{{range .Licenses}}
 										<div class="item" data-value="{{.}}">{{.}}</div>
 									{{end}}
 								</div>
 							</div>
-							<span class="help">{{.i18n.Tr "repo.license_helper_desc" "https://choosealicense.com/" | Str2html}}</span>
+							<span class="help">{{.locale.Tr "repo.license_helper_desc" "https://choosealicense.com/" | Str2html}}</span>
 						</div>
 
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.readme"}}</label>
+							<label>{{.locale.Tr "repo.readme"}}</label>
 							<div class="ui selection dropdown">
 								<input type="hidden" name="readme" value="{{.readme}}">
-								<div class="default text">{{.i18n.Tr "repo.readme_helper"}}</div>
+								<div class="default text">{{.locale.Tr "repo.readme_helper"}}</div>
 								<div class="menu">
 									{{range .Readmes}}
 										<div class="item" data-value="{{.}}">{{.}}</div>
 									{{end}}
 								</div>
 							</div>
-							<span class="help">{{.i18n.Tr "repo.readme_helper_desc"}}</span>
+							<span class="help">{{.locale.Tr "repo.readme_helper_desc"}}</span>
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="auto-init">
 								<input class="hidden" name="auto_init" type="checkbox" tabindex="0" {{if .auto_init}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.auto_init"}}</label>
+								<label>{{.locale.Tr "repo.auto_init"}}</label>
 							</div>
 						</div>
 						<div class="inline field">
-							<label for="default_branch">{{.i18n.Tr "repo.default_branch"}}</label>
+							<label for="default_branch">{{.locale.Tr "repo.default_branch"}}</label>
 							<input id="default_branch" name="default_branch" value="{{.default_branch}}" placeholder="{{.default_branch}}">
-							<span class="help">{{.i18n.Tr "repo.default_branch_helper"}}</span>
+							<span class="help">{{.locale.Tr "repo.default_branch_helper"}}</span>
 						</div>
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.settings.trust_model"}}</label>
+							<label>{{.locale.Tr "repo.settings.trust_model"}}</label>
 							<div class="ui selection owner dropdown">
 								<input type="hidden" id="trust_model" name="trust_model" value="default" required>
-								<div class="default text">{{.i18n.Tr "repo.settings.trust_model"}}</div>
+								<div class="default text">{{.locale.Tr "repo.settings.trust_model"}}</div>
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 								<div class="menu">
-									<div class="item" data-value="default">{{.i18n.Tr "repo.settings.trust_model.default"}}</div>
-									<div class="item" data-value="collaborator">{{.i18n.Tr "repo.settings.trust_model.collaborator"}}</div>
-									<div class="item" data-value="committer">{{.i18n.Tr "repo.settings.trust_model.committer"}}</div>
-									<div class="item" data-value="collaboratorcommitter">{{.i18n.Tr "repo.settings.trust_model.collaboratorcommitter"}}</div>
+									<div class="item" data-value="default">{{.locale.Tr "repo.settings.trust_model.default"}}</div>
+									<div class="item" data-value="collaborator">{{.locale.Tr "repo.settings.trust_model.collaborator"}}</div>
+									<div class="item" data-value="committer">{{.locale.Tr "repo.settings.trust_model.committer"}}</div>
+									<div class="item" data-value="collaboratorcommitter">{{.locale.Tr "repo.settings.trust_model.collaboratorcommitter"}}</div>
 								</div>
 							</div>
 							<div class="help">
-								{{.i18n.Tr "repo.trust_model_helper"}}
+								{{.locale.Tr "repo.trust_model_helper"}}
 								<ul>
-									<li>{{.i18n.Tr "repo.trust_model_helper_collaborator"}}</li>
-									<li>{{.i18n.Tr "repo.trust_model_helper_committer"}}</li>
-									<li>{{.i18n.Tr "repo.trust_model_helper_collaborator_committer"}}</li>
-									<li>{{.i18n.Tr "repo.trust_model_helper_default"}}</li>
+									<li>{{.locale.Tr "repo.trust_model_helper_collaborator"}}</li>
+									<li>{{.locale.Tr "repo.trust_model_helper_committer"}}</li>
+									<li>{{.locale.Tr "repo.trust_model_helper_collaborator_committer"}}</li>
+									<li>{{.locale.Tr "repo.trust_model_helper_default"}}</li>
 								</ul>
 							</div>
 						</div>
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.template"}}</label>
+							<label>{{.locale.Tr "repo.template"}}</label>
 							<div class="ui checkbox">
 								<input class="hidden" name="template" type="checkbox" tabindex="0">
-								<label>{{.i18n.Tr "repo.template_helper"}}</label>
+								<label>{{.locale.Tr "repo.template_helper"}}</label>
 							</div>
 						</div>
 					</div>
@@ -217,9 +217,9 @@
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button{{if not .CanCreateRepo}} disabled{{end}}">
-							{{.i18n.Tr "repo.create_repo"}}
+							{{.locale.Tr "repo.create_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -19,20 +19,20 @@
 					</a>
 				{{end}}
 			</td>
-			<td colspan="5" class="lines-code lines-code-old ">{{$inlineDiff := $.section.GetComputedInlineDiffFor $line}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
+			<td colspan="5" class="lines-code lines-code-old ">{{$inlineDiff := $.section.GetComputedInlineDiffFor $line}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
 		{{else}}
 			{{$inlineDiff := $.section.GetComputedInlineDiffFor $line}}
 			<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$.FileNameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
-			<td class="blob-excerpt lines-escape lines-escape-old">{{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+			<td class="blob-excerpt lines-escape lines-escape-old">{{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 			<td class="blob-excerpt lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker=""></span>{{end}}</td>
 			<td class="blob-excerpt lines-code lines-code-old halfwidth">{{/*
-				*/}}<code {{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{if $line.LeftIdx}}{{$inlineDiff.Content}}{{end}}</code>{{/*
+				*/}}<code {{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{if $line.LeftIdx}}{{$inlineDiff.Content}}{{end}}</code>{{/*
 			*/}}</td>
 			<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$.FileNameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
-			<td class="blob-excerpt lines-escape lines-escape-new">{{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+			<td class="blob-excerpt lines-escape lines-escape-new">{{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 			<td class="blob-excerpt lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker=""></span>{{end}}</td>
 			<td class="blob-excerpt lines-code lines-code-new halfwidth">{{/*
-				*/}}<code {{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{if $line.RightIdx}}{{$inlineDiff.Content}}{{end}}</code>{{/*
+				*/}}<code {{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{if $line.RightIdx}}{{$inlineDiff.Content}}{{end}}</code>{{/*
 			*/}}</td>
 		{{end}}
 	</tr>
@@ -63,9 +63,9 @@
 			<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$.FileNameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
 		{{end}}
 		{{$inlineDiff := $.section.GetComputedInlineDiffFor $line}}
-		<td class="blob-excerpt lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+		<td class="blob-excerpt lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 		<td class="blob-excerpt lines-type-marker"><span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
-		<td class="blob-excerpt lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}"><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
+		<td class="blob-excerpt lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}"><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
 	</tr>
 	{{end}}
 {{end}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -10,18 +10,18 @@
 			</div>
 		</div>
 	</div>
-	<h4>{{.i18n.Tr "repo.diff.data_not_available"}}</h4>
+	<h4>{{.locale.Tr "repo.diff.data_not_available"}}</h4>
 {{else}}
 	<div>
 		<div class="diff-detail-box diff-box sticky df sb ac">
 			<div class="diff-detail-stats df ac">
-				{{svg "octicon-diff" 16 "mr-2"}}{{.i18n.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
+				{{svg "octicon-diff" 16 "mr-2"}}{{.locale.Tr "repo.diff.stats_desc" .Diff.NumFiles .Diff.TotalAddition .Diff.TotalDeletion | Str2html}}
 			</div>
 			<div class="diff-detail-actions df ac">
 				{{if and .PageIsPullFiles $.SignedUserID (not .IsArchived)}}
 					<progress id="viewed-files-summary" class="mr-2" value="{{.Diff.NumViewedFiles}}" max="{{.Diff.NumFiles}}"></progress>
-					<label for="viewed-files-summary" id="viewed-files-summary-label" class="mr-2" data-text-changed-template="{{.i18n.Tr "repo.pulls.viewed_files_label"}}">
-						{{.i18n.Tr "repo.pulls.viewed_files_label" .Diff.NumViewedFiles .Diff.NumFiles}}
+					<label for="viewed-files-summary" id="viewed-files-summary-label" class="mr-2" data-text-changed-template="{{.locale.Tr "repo.pulls.viewed_files_label"}}">
+						{{.locale.Tr "repo.pulls.viewed_files_label" .Diff.NumViewedFiles .Diff.NumFiles}}
 					</label>
 				{{end}}
 				{{template "repo/diff/whitespace_dropdown" .}}
@@ -37,7 +37,7 @@
 					<div class="bold df ac pull-right">
 						{{if .IsBin}}
 							<span class="ml-1 mr-3">
-								{{$.i18n.Tr "repo.diff.bin"}}
+								{{$.locale.Tr "repo.diff.bin"}}
 							</span>
 						{{else}}
 							{{template "repo/diff/stats" dict "file" . "root" $}}
@@ -50,8 +50,8 @@
 			{{end}}
 			{{if .Diff.IsIncomplete}}
 				<li id="diff-too-many-files-stats" class="pt-2">
-					<span class="file df ac sb">{{$.i18n.Tr "repo.diff.too_many_files"}}
-						<a class="ui basic tiny button" id="diff-show-more-files-stats" data-href="{{$.Link}}?skip-to={{.Diff.End}}&file-only=true">{{.i18n.Tr "repo.diff.show_more"}}</a>
+					<span class="file df ac sb">{{$.locale.Tr "repo.diff.too_many_files"}}
+						<a class="ui basic tiny button" id="diff-show-more-files-stats" data-href="{{$.Link}}?skip-to={{.Diff.End}}&file-only=true">{{.locale.Tr "repo.diff.show_more"}}</a>
 					</span>
 				</li>
 			{{end}}
@@ -76,48 +76,48 @@
 							<div class="bold df ac">
 								{{if $file.IsBin}}
 									<span class="ml-1 mr-3">
-										{{$.i18n.Tr "repo.diff.bin"}}
+										{{$.locale.Tr "repo.diff.bin"}}
 									</span>
 								{{else}}
 									{{template "repo/diff/stats" dict "file" . "root" $}}
 								{{end}}
 							</div>
-							<span class="file mono"><a class="muted" href="#diff-{{$file.NameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} &rarr; {{end}}{{$file.Name}}</a>{{if .IsLFSFile}} ({{$.i18n.Tr "repo.stored_lfs"}}){{end}}</span>
+							<span class="file mono"><a class="muted" href="#diff-{{$file.NameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} &rarr; {{end}}{{$file.Name}}</a>{{if .IsLFSFile}} ({{$.locale.Tr "repo.stored_lfs"}}){{end}}</span>
 							{{if $file.IsGenerated}}
-								<span class="ui label ml-3">{{$.i18n.Tr "repo.diff.generated"}}</span>
+								<span class="ui label ml-3">{{$.locale.Tr "repo.diff.generated"}}</span>
 							{{end}}
 							{{if $file.IsVendored}}
-								<span class="ui label ml-3">{{$.i18n.Tr "repo.diff.vendored"}}</span>
+								<span class="ui label ml-3">{{$.locale.Tr "repo.diff.vendored"}}</span>
 							{{end}}
 						</div>
 						<div class="diff-file-header-actions df ac">
 							{{if $showFileViewToggle}}
 								<div class="ui compact icon buttons">
-									<span class="ui tiny basic button tooltip file-view-toggle" data-toggle-selector="#diff-source-{{$i}}" data-content="{{$.i18n.Tr "repo.file_view_source"}}" data-position="bottom center">{{svg "octicon-code"}}</span>
-									<span class="ui tiny basic button tooltip file-view-toggle active" data-toggle-selector="#diff-rendered-{{$i}}" data-content="{{$.i18n.Tr "repo.file_view_rendered"}}" data-position="bottom center">{{svg "octicon-file"}}</span>
+									<span class="ui tiny basic button tooltip file-view-toggle" data-toggle-selector="#diff-source-{{$i}}" data-content="{{$.locale.Tr "repo.file_view_source"}}" data-position="bottom center">{{svg "octicon-code"}}</span>
+									<span class="ui tiny basic button tooltip file-view-toggle active" data-toggle-selector="#diff-rendered-{{$i}}" data-content="{{$.locale.Tr "repo.file_view_rendered"}}" data-position="bottom center">{{svg "octicon-file"}}</span>
 								</div>
 							{{end}}
 							{{if $file.IsProtected}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.diff.protected"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.diff.protected"}}</span>
 							{{end}}
 							{{if not (or $file.IsIncomplete $file.IsBin $file.IsSubmodule)}}
-								<a class="ui basic tiny button unescape-button">{{$.i18n.Tr "repo.unescape_control_characters"}}</a>
-								<a class="ui basic tiny button escape-button" style="display: none;">{{$.i18n.Tr "repo.escape_control_characters"}}</a>
+								<a class="ui basic tiny button unescape-button">{{$.locale.Tr "repo.unescape_control_characters"}}</a>
+								<a class="ui basic tiny button escape-button" style="display: none;">{{$.locale.Tr "repo.escape_control_characters"}}</a>
 							{{end}}
 							{{if and (not $file.IsSubmodule) (not $.PageIsWiki)}}
 								{{if $file.IsDeleted}}
-									<a class="ui basic tiny button" rel="nofollow" href="{{$.BeforeSourcePath}}/{{PathEscapeSegments .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+									<a class="ui basic tiny button" rel="nofollow" href="{{$.BeforeSourcePath}}/{{PathEscapeSegments .Name}}">{{$.locale.Tr "repo.diff.view_file"}}</a>
 								{{else}}
-									<a class="ui basic tiny button" rel="nofollow" href="{{$.SourcePath}}/{{PathEscapeSegments .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+									<a class="ui basic tiny button" rel="nofollow" href="{{$.SourcePath}}/{{PathEscapeSegments .Name}}">{{$.locale.Tr "repo.diff.view_file"}}</a>
 								{{end}}
 							{{end}}
 							{{if and $.IsSigned $.PageIsPullFiles (not $.IsArchived)}}
 								{{if $file.HasChangedSinceLastReview}}
-									<span class="changed-since-last-review unselectable">{{$.i18n.Tr "repo.pulls.has_changed_since_last_review"}}</span>
+									<span class="changed-since-last-review unselectable">{{$.locale.Tr "repo.pulls.has_changed_since_last_review"}}</span>
 								{{end}}
 								<div data-link="{{$.Issue.Link}}/viewed-files" data-headcommit="{{$.PullHeadCommitID}}" class="viewed-file-form unselectable{{if $file.IsViewed}} viewed-file-checked-form{{end}}">
 									<input type="checkbox" name="{{$file.GetDiffFileName}}" id="viewed-file-checkbox-{{$i}}" autocomplete="off" {{if $file.IsViewed}}checked{{end}}></input>
-									<label for="viewed-file-checkbox-{{$i}}">{{$.i18n.Tr "repo.pulls.has_viewed_file"}}</label>
+									<label for="viewed-file-checkbox-{{$i}}">{{$.locale.Tr "repo.pulls.has_viewed_file"}}</label>
 								</div>
 							{{end}}
 						</div>
@@ -128,13 +128,13 @@
 								<div class="diff-file-body binary" style="padding: 5px 10px;">
 									{{if $file.IsIncomplete}}
 										{{if $file.IsIncompleteLineTooLong}}
-											{{$.i18n.Tr "repo.diff.file_suppressed_line_too_long"}}
+											{{$.locale.Tr "repo.diff.file_suppressed_line_too_long"}}
 										{{else}}
-											{{$.i18n.Tr "repo.diff.file_suppressed"}}
-											<a class="ui basic tiny button diff-show-more-button" data-href="{{$.Link}}?file-only=true&files={{$file.Name}}&files={{$file.OldName}}">{{$.i18n.Tr "repo.diff.load"}}</a>
+											{{$.locale.Tr "repo.diff.file_suppressed"}}
+											<a class="ui basic tiny button diff-show-more-button" data-href="{{$.Link}}?file-only=true&files={{$file.Name}}&files={{$file.OldName}}">{{$.locale.Tr "repo.diff.load"}}</a>
 										{{end}}
 									{{else}}
-										{{$.i18n.Tr "repo.diff.bin_not_shown"}}
+										{{$.locale.Tr "repo.diff.bin_not_shown"}}
 									{{end}}
 								</div>
 							{{else}}
@@ -165,8 +165,8 @@
 			{{if .Diff.IsIncomplete}}
 				<div class="diff-file-box diff-box file-content mt-3" id="diff-incomplete">
 					<h4 class="ui top attached normal header df ac sb">
-						{{$.i18n.Tr "repo.diff.too_many_files"}}
-						<a class="ui basic tiny button" id="diff-show-more-files" data-href="{{$.Link}}?skip-to={{.Diff.End}}&file-only=true">{{.i18n.Tr "repo.diff.show_more"}}</a>
+						{{$.locale.Tr "repo.diff.too_many_files"}}
+						<a class="ui basic tiny button" id="diff-show-more-files" data-href="{{$.Link}}?skip-to={{.Diff.End}}&file-only=true">{{.locale.Tr "repo.diff.show_more"}}</a>
 					</h4>
 				</div>
 			{{end}}
@@ -176,18 +176,18 @@
 			<div class="hide" id="edit-content-form">
 				<div class="ui comment form">
 					<div class="ui top attached tabular menu">
-						<a class="active write item">{{$.i18n.Tr "write"}}</a>
-						<a class="preview item" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "preview"}}</a>
+						<a class="active write item">{{$.locale.Tr "write"}}</a>
+						<a class="preview item" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.locale.Tr "preview"}}</a>
 					</div>
 					<div class="ui bottom attached active write tab segment">
 						<textarea class="review-textarea js-quick-submit" tabindex="1" name="content"></textarea>
 					</div>
 					<div class="ui bottom attached tab preview segment markup">
-					{{$.i18n.Tr "loading"}}
+					{{$.locale.Tr "loading"}}
 					</div>
 					<div class="text right edit buttons">
-						<div class="ui basic primary cancel button" tabindex="3">{{.i18n.Tr "repo.issues.cancel"}}</div>
-						<div class="ui green save button" tabindex="2">{{.i18n.Tr "repo.issues.save"}}</div>
+						<div class="ui basic primary cancel button" tabindex="3">{{.locale.Tr "repo.issues.cancel"}}</div>
+						<div class="ui green save button" tabindex="2">{{.locale.Tr "repo.issues.save"}}</div>
 					</div>
 				</div>
 			</div>

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -10,36 +10,36 @@
 		<input type="hidden" name="diff_end_cid">
 		<input type="hidden" name="diff_base_cid">
 		<div class="ui top tabular menu" data-write="write" data-preview="preview">
-			<a class="active item" data-tab="write">{{$.root.i18n.Tr "write"}}</a>
-			<a class="item" data-tab="preview" data-url="{{$.root.Repository.HTMLURL}}/markdown" data-context="{{$.root.RepoLink}}">{{$.root.i18n.Tr "preview"}}</a>
+			<a class="active item" data-tab="write">{{$.root.locale.Tr "write"}}</a>
+			<a class="item" data-tab="preview" data-url="{{$.root.Repository.HTMLURL}}/markdown" data-context="{{$.root.RepoLink}}">{{$.root.locale.Tr "preview"}}</a>
 		</div>
 		<div class="field">
 			<div class="ui active tab" data-tab="write">
-				<textarea name="content" placeholder="{{$.root.i18n.Tr "repo.diff.comment.placeholder"}}"></textarea>
+				<textarea name="content" placeholder="{{$.root.locale.Tr "repo.diff.comment.placeholder"}}"></textarea>
 			</div>
 			<div class="ui tab markup" data-tab="preview">
-			{{.i18n.Tr "loading"}}
+			{{.locale.Tr "loading"}}
 			</div>
 		</div>
 		<div class="field footer mx-3">
-			<span class="markup-info">{{svg "octicon-markup"}} {{$.root.i18n.Tr "repo.diff.comment.markdown_info"}}</span>
+			<span class="markup-info">{{svg "octicon-markup"}} {{$.root.locale.Tr "repo.diff.comment.markdown_info"}}</span>
 			<div class="ui right">
 				{{if $.reply}}
-					<button class="ui submit green tiny button btn-reply" type="submit">{{$.root.i18n.Tr "repo.diff.comment.reply"}}</button>
+					<button class="ui submit green tiny button btn-reply" type="submit">{{$.root.locale.Tr "repo.diff.comment.reply"}}</button>
 					<input type="hidden" name="reply" value="{{$.reply}}">
 				{{else}}
 					{{if $.root.CurrentReview}}
 						<button name="is_review" value="true" type="submit"
-								class="ui submit green tiny button btn-add-comment">{{$.root.i18n.Tr "repo.diff.comment.add_review_comment"}}</button>
+								class="ui submit green tiny button btn-add-comment">{{$.root.locale.Tr "repo.diff.comment.add_review_comment"}}</button>
 					{{else}}
 						<button name="is_review" value="true" type="submit"
-								class="ui submit green tiny button btn-start-review">{{$.root.i18n.Tr "repo.diff.comment.start_review"}}</button>
+								class="ui submit green tiny button btn-start-review">{{$.root.locale.Tr "repo.diff.comment.start_review"}}</button>
 						<button type="submit"
-								class="ui submit tiny basic button btn-add-single">{{$.root.i18n.Tr "repo.diff.comment.add_single_comment"}}</button>
+								class="ui submit tiny basic button btn-add-single">{{$.root.locale.Tr "repo.diff.comment.add_single_comment"}}</button>
 					{{end}}
 				{{end}}
 				{{if or (not $.HasComments) $.hidden}}
-					<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{$.root.i18n.Tr "cancel"}}</button>
+					<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{$.root.locale.Tr "cancel"}}</button>
 				{{end}}
 			</div>
 		</div>

--- a/templates/repo/diff/comments.tmpl
+++ b/templates/repo/diff/comments.tmpl
@@ -1,6 +1,6 @@
 {{range .comments}}
 
-{{ $createdStr:= TimeSinceUnix .CreatedUnix $.root.i18n }}
+{{ $createdStr:= TimeSinceUnix .CreatedUnix $.root.locale }}
 <div class="comment" id="{{.HashTag}}">
 	{{if .OriginalAuthor }}
 		<span class="avatar"><img src="{{AppSubUrl}}/assets/img/avatar_default.png"></span>
@@ -18,11 +18,11 @@
 						{{ .OriginalAuthor }}
 					</span>
 					<span class="text grey">
-						{{$.root.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
+						{{$.root.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
 					</span>
 					<span class="text migrate">
 						{{if $.root.Repository.OriginalURL}}
-							({{$.root.i18n.Tr "repo.migrated_from" ($.root.Repository.OriginalURL | Escape) ($.root.Repository.GetOriginalURLHostname | Escape) | Safe }})
+							({{$.root.locale.Tr "repo.migrated_from" ($.root.Repository.OriginalURL | Escape) ($.root.Repository.GetOriginalURLHostname | Escape) | Safe }})
 						{{end}}
 					</span>
 				{{else}}
@@ -30,19 +30,19 @@
 						<a {{if gt .Poster.ID 0}}href="{{.Poster.HomeLink}}"{{end}}>
 							{{.Poster.GetDisplayName}}
 						</a>
-						{{$.root.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
+						{{$.root.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
 					</span>
 				{{end}}
 			</div>
 			<div class="comment-header-right actions df ac">
 				{{if and .Review}}
 					{{if eq .Review.Type 0}}
-						<div class="ui label basic small yellow pending-label tooltip" data-content="{{$.root.i18n.Tr "repo.issues.review.pending.tooltip" ($.root.i18n.Tr "repo.diff.review") ($.root.i18n.Tr "repo.diff.review.approve") ($.root.i18n.Tr "repo.diff.review.comment") ($.root.i18n.Tr "repo.diff.review.reject")}}">
-						{{$.root.i18n.Tr "repo.issues.review.pending"}}
+						<div class="ui label basic small yellow pending-label tooltip" data-content="{{$.root.locale.Tr "repo.issues.review.pending.tooltip" ($.root.locale.Tr "repo.diff.review") ($.root.locale.Tr "repo.diff.review.approve") ($.root.locale.Tr "repo.diff.review.comment") ($.root.locale.Tr "repo.diff.review.reject")}}">
+						{{$.root.locale.Tr "repo.issues.review.pending"}}
 						</div>
 					{{else}}
 						<div class="ui label basic small">
-						{{$.root.i18n.Tr "repo.issues.review.review"}}
+						{{$.root.locale.Tr "repo.issues.review.review"}}
 						</div>
 					{{end}}
 				{{end}}
@@ -55,7 +55,7 @@
 			{{if .RenderedContent}}
 				{{.RenderedContent|Str2html}}
 			{{else}}
-				<span class="no-content">{{$.root.i18n.Tr "repo.issues.no_content"}}</span>
+				<span class="no-content">{{$.root.locale.Tr "repo.issues.no_content"}}</span>
 			{{end}}
 			</div>
 			<div id="comment-{{.ID}}" class="raw-content hide">{{.Content}}</div>

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -5,10 +5,10 @@
 
 	<h2 class="ui header">
 		{{if and $.PageIsComparePull $.IsSigned (not .Repository.IsArchived)}}
-			{{.i18n.Tr "repo.pulls.compare_changes"}}
-			<div class="sub header">{{.i18n.Tr "repo.pulls.compare_changes_desc"}}</div>
+			{{.locale.Tr "repo.pulls.compare_changes"}}
+			<div class="sub header">{{.locale.Tr "repo.pulls.compare_changes_desc"}}</div>
 		{{ else }}
-			{{.i18n.Tr "action.compare_commits_general"}}
+			{{.locale.Tr "action.compare_commits_general"}}
 		{{ end }}
 	</h2>
 	{{ $BaseCompareName := $.BaseName -}}
@@ -33,28 +33,28 @@
 		{{- end -}}
 	{{- end -}}
 	<div class="ui segment choose branch">
-		<a href="{{$.HeadRepo.Link}}/compare/{{PathEscapeSegments $.HeadBranch}}{{$.CompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.BaseName}}/{{PathEscape $.Repository.Name}}:{{end}}{{PathEscapeSegments $.BaseBranch}}" title="{{.i18n.Tr "repo.pulls.switch_head_and_base"}}">{{svg "octicon-git-compare"}}</a>
-		<div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
+		<a href="{{$.HeadRepo.Link}}/compare/{{PathEscapeSegments $.HeadBranch}}{{$.CompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.BaseName}}/{{PathEscape $.Repository.Name}}:{{end}}{{PathEscapeSegments $.BaseBranch}}" title="{{.locale.Tr "repo.pulls.switch_head_and_base"}}">{{svg "octicon-git-compare"}}</a>
+		<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
 			<div class="ui basic small button">
-				<span class="text">{{if $.PageIsComparePull}}{{.i18n.Tr "repo.pulls.compare_base"}}{{else}}{{.i18n.Tr "repo.compare.compare_base"}}{{end}}: {{$BaseCompareName}}:{{$.BaseBranch}}</span>
+				<span class="text">{{if $.PageIsComparePull}}{{.locale.Tr "repo.pulls.compare_base"}}{{else}}{{.locale.Tr "repo.compare.compare_base"}}{{end}}: {{$BaseCompareName}}:{{$.BaseBranch}}</span>
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 			</div>
 			<div class="menu">
 				<div class="ui icon search input">
 					<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-					<input name="search" placeholder="{{.i18n.Tr "repo.filter_branch_and_tag"}}...">
+					<input name="search" placeholder="{{.locale.Tr "repo.filter_branch_and_tag"}}...">
 				</div>
 				<div class="header">
 					<div class="ui grid">
 						<div class="two column row">
 							<a class="reference column" href="#" data-target=".base-branch-list">
 								<span class="text black">
-									{{svg "octicon-git-branch" 16 "mr-2"}}{{.i18n.Tr "repo.branches"}}
+									{{svg "octicon-git-branch" 16 "mr-2"}}{{.locale.Tr "repo.branches"}}
 								</span>
 							</a>
 							<a class="reference column" href="#" data-target=".base-tag-list">
 								<span class="text black">
-									{{svg "octicon-tag" 16 "mr-2"}}{{.i18n.Tr "repo.tags"}}
+									{{svg "octicon-tag" 16 "mr-2"}}{{.locale.Tr "repo.tags"}}
 								</span>
 							</a>
 						</div>
@@ -102,28 +102,28 @@
 				</div>
 			</div>
 		</div>
-		<a href="{{.RepoLink}}/compare/{{PathEscapeSegments .BaseBranch}}{{.OtherCompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.HeadUser.Name}}/{{PathEscape $.HeadRepo.Name}}:{{end}}{{PathEscapeSegments $.HeadBranch}}" title="{{.i18n.Tr "repo.pulls.switch_comparison_type"}}">{{.CompareSeparator}}</a>
+		<a href="{{.RepoLink}}/compare/{{PathEscapeSegments .BaseBranch}}{{.OtherCompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.HeadUser.Name}}/{{PathEscape $.HeadRepo.Name}}:{{end}}{{PathEscapeSegments $.HeadBranch}}" title="{{.locale.Tr "repo.pulls.switch_comparison_type"}}">{{.CompareSeparator}}</a>
 		<div class="ui floating filter dropdown">
 			<div class="ui basic small button">
-				<span class="text">{{if $.PageIsComparePull}}{{.i18n.Tr "repo.pulls.compare_compare"}}{{else}}{{.i18n.Tr "repo.compare.compare_head"}}{{end}}: {{$HeadCompareName}}:{{$.HeadBranch}}</span>
+				<span class="text">{{if $.PageIsComparePull}}{{.locale.Tr "repo.pulls.compare_compare"}}{{else}}{{.locale.Tr "repo.compare.compare_head"}}{{end}}: {{$HeadCompareName}}:{{$.HeadBranch}}</span>
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 			</div>
 			<div class="menu">
 				<div class="ui icon search input">
 					<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-					<input name="search" placeholder="{{.i18n.Tr "repo.filter_branch_and_tag"}}...">
+					<input name="search" placeholder="{{.locale.Tr "repo.filter_branch_and_tag"}}...">
 				</div>
 				<div class="header">
 					<div class="ui grid">
 						<div class="two column row">
 							<a class="reference column" href="#" data-target=".head-branch-list">
 								<span class="text black">
-									{{svg "octicon-git-branch" 16 "mr-2"}}{{.i18n.Tr "repo.branches"}}
+									{{svg "octicon-git-branch" 16 "mr-2"}}{{.locale.Tr "repo.branches"}}
 								</span>
 							</a>
 							<a class="reference column" href="#" data-target=".head-tag-list">
 								<span class="text black">
-									{{svg "octicon-tag" 16 "mr-2"}}{{.i18n.Tr "repo.tags"}}
+									{{svg "octicon-tag" 16 "mr-2"}}{{.locale.Tr "repo.tags"}}
 								</span>
 							</a>
 						</div>
@@ -175,21 +175,21 @@
 
 	{{if .IsNothingToCompare}}
 		{{if and $.IsSigned $.AllowEmptyPr (not .Repository.IsArchived) }}
-			<div class="ui segment">{{.i18n.Tr "repo.pulls.nothing_to_compare_and_allow_empty_pr"}}</div>
+			<div class="ui segment">{{.locale.Tr "repo.pulls.nothing_to_compare_and_allow_empty_pr"}}</div>
 			<div class="ui info message show-form-container" {{if .Flash}}style="display: none"{{end}}>
-				<button class="ui button green show-form">{{.i18n.Tr "repo.pulls.new"}}</button>
+				<button class="ui button green show-form">{{.locale.Tr "repo.pulls.new"}}</button>
 			</div>
 			<div class="pullrequest-form" {{if not .Flash}}style="display: none"{{end}}>
 				{{template "repo/issue/new_form" .}}
 			</div>
 		{{else}}
-			<div class="ui segment">{{.i18n.Tr "repo.pulls.nothing_to_compare"}}</div>
+			<div class="ui segment">{{.locale.Tr "repo.pulls.nothing_to_compare"}}</div>
 		{{end}}
 	{{else if and .PageIsComparePull (gt .CommitCount 0)}}
 		{{if .HasPullRequest}}
 			<div class="ui segment grid title">
 				<div class="twelve wide column issue-title">
-					{{.i18n.Tr "repo.pulls.has_pull_request" (Escape $.RepoLink) (Escape $.RepoRelPath) .PullRequest.Index | Safe}}
+					{{.locale.Tr "repo.pulls.has_pull_request" (Escape $.RepoLink) (Escape $.RepoRelPath) .PullRequest.Index | Safe}}
 					<h1>
 						<span id="issue-title">{{RenderIssueTitle $.Context .PullRequest.Issue.Title $.RepoLink $.Repository.ComposeMetas}}</span>
 						<span class="index">#{{.PullRequest.Issue.Index}}</span>
@@ -197,21 +197,21 @@
 				</div>
 				<div class="four wide right middle aligned column">
 				{{- if .PullRequest.HasMerged -}}
-				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button purple show-form">{{svg "octicon-git-merge" 16}} {{.i18n.Tr "repo.pulls.view"}}</a>
+				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button purple show-form">{{svg "octicon-git-merge" 16}} {{.locale.Tr "repo.pulls.view"}}</a>
 				{{else if .Issue.IsClosed}}
-				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button red show-form">{{svg "octicon-issue-closed" 16}} {{.i18n.Tr "repo.pulls.view"}}</a>
+				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button red show-form">{{svg "octicon-issue-closed" 16}} {{.locale.Tr "repo.pulls.view"}}</a>
 				{{else}}
-				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button green show-form">{{svg "octicon-git-pull-request" 16}} {{.i18n.Tr "repo.pulls.view"}}</a>
+				<a href="{{Escape $.RepoLink}}/pulls/{{.PullRequest.Issue.Index}}" class="ui button green show-form">{{svg "octicon-git-pull-request" 16}} {{.locale.Tr "repo.pulls.view"}}</a>
 				{{end}}</div>
 			</div>
 		{{else}}
 			{{if and $.IsSigned (not .Repository.IsArchived)}}
 				<div class="ui info message show-form-container" {{if .Flash}}style="display: none"{{end}}>
-					<button class="ui button green show-form">{{.i18n.Tr "repo.pulls.new"}}</button>
+					<button class="ui button green show-form">{{.locale.Tr "repo.pulls.new"}}</button>
 				</div>
 			{{else if .Repository.IsArchived}}
 				<div class="ui warning message">
-					{{.i18n.Tr "repo.archive.title"}}
+					{{.locale.Tr "repo.archive.title"}}
 				</div>
 			{{end}}
 			{{if $.IsSigned}}

--- a/templates/repo/diff/conversation.tmpl
+++ b/templates/repo/diff/conversation.tmpl
@@ -6,16 +6,16 @@
 		<div class="ui attached header resolved-placeholder df ac sb">
 			<div class="ui grey text">
 				{{svg "octicon-check" 16 "icon mr-2"}}
-				<b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}
+				<b>{{$resolveDoer.Name}}</b> {{$.locale.Tr "repo.issues.review.resolved_by"}}
 			</div>
 			<div>
 				<button id="show-outdated-{{(index .comments 0).ID}}" data-comment="{{(index .comments 0).ID}}" class="ui tiny right labeled button show-outdated df ac">
 					{{svg "octicon-unfold" 16 "mr-3"}}
-					{{$.i18n.Tr "repo.issues.review.show_resolved"}}
+					{{$.locale.Tr "repo.issues.review.show_resolved"}}
 				</button>
 				<button id="hide-outdated-{{(index .comments 0).ID}}" data-comment="{{(index .comments 0).ID}}" class="hide ui tiny right labeled button hide-outdated df ac">
 					{{svg "octicon-fold" 16 "mr-3"}}
-					{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
+					{{$.locale.Tr "repo.issues.review.hide_resolved"}}
 				</button>
 			</div>
 		</div>
@@ -29,24 +29,24 @@
 		<div class="df je ac fw mt-3">
 			<div class="ui buttons mr-2">
 				<button class="ui icon tiny basic button previous-conversation">
-					{{svg "octicon-arrow-up" 12 "icon"}} {{$.i18n.Tr "repo.issues.previous"}}
+					{{svg "octicon-arrow-up" 12 "icon"}} {{$.locale.Tr "repo.issues.previous"}}
 				</button>
 				<button class="ui icon tiny basic button next-conversation">
-					{{svg "octicon-arrow-down" 12 "icon"}} {{$.i18n.Tr "repo.issues.next"}}
+					{{svg "octicon-arrow-down" 12 "icon"}} {{$.locale.Tr "repo.issues.next"}}
 				</button>
 			</div>
 			{{if and $.CanMarkConversation $isNotPending}}
 				<button class="ui icon tiny basic button resolve-conversation" data-origin="diff" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index .comments 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation">
 					{{if $resolved}}
-						{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
+						{{$.locale.Tr "repo.issues.review.un_resolve_conversation"}}
 					{{else}}
-						{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
+						{{$.locale.Tr "repo.issues.review.resolve_conversation"}}
 					{{end}}
 				</button>
 			{{end}}
 			{{if and $.SignedUserID (not $.Repository.IsArchived)}}
 				<button class="comment-form-reply ui green tiny labeled icon button ml-2 mr-0">
-					{{svg "octicon-reply" 16 "reply icon mr-2"}}{{$.i18n.Tr "repo.diff.comment.reply"}}
+					{{svg "octicon-reply" 16 "reply icon mr-2"}}{{$.locale.Tr "repo.diff.comment.reply"}}
 				</button>
 			{{end}}
 		</div>

--- a/templates/repo/diff/image_diff.tmpl
+++ b/templates/repo/diff/image_diff.tmpl
@@ -4,10 +4,10 @@
 		<div class="image-diff" data-path-before="{{.root.BeforeRawPath}}/{{PathEscapeSegments .file.OldName}}" data-path-after="{{.root.RawPath}}/{{PathEscapeSegments .file.Name}}">
 			<div class="ui secondary pointing tabular top attached borderless menu stackable new-menu">
 				<div class="new-menu-inner">
-					<a class="item active" data-tab="diff-side-by-side-{{ .file.Index }}">{{.root.i18n.Tr "repo.diff.image.side_by_side"}}</a>
+					<a class="item active" data-tab="diff-side-by-side-{{ .file.Index }}">{{.root.locale.Tr "repo.diff.image.side_by_side"}}</a>
 					{{if and .blobBase .blobHead}}
-					<a class="item" data-tab="diff-swipe-{{ .file.Index }}">{{.root.i18n.Tr "repo.diff.image.swipe"}}</a>
-					<a class="item" data-tab="diff-overlay-{{ .file.Index }}">{{.root.i18n.Tr "repo.diff.image.overlay"}}</a>
+					<a class="item" data-tab="diff-swipe-{{ .file.Index }}">{{.root.locale.Tr "repo.diff.image.swipe"}}</a>
+					<a class="item" data-tab="diff-overlay-{{ .file.Index }}">{{.root.locale.Tr "repo.diff.image.overlay"}}</a>
 					{{end}}
 				</div>
 			</div>
@@ -16,31 +16,31 @@
 					<div class="diff-side-by-side">
 						{{if .blobBase }}
 						<span class="side">
-							<p class="side-header">{{.root.i18n.Tr "repo.diff.file_before"}}</p>
+							<p class="side-header">{{.root.locale.Tr "repo.diff.file_before"}}</p>
 							<span class="before-container"><img class="image-before" /></span>
 							<p>
 								<span class="bounds-info-before">
-									{{.root.i18n.Tr "repo.diff.file_image_width"}}: <span class="text bounds-info-width"></span>
+									{{.root.locale.Tr "repo.diff.file_image_width"}}: <span class="text bounds-info-width"></span>
 									&nbsp;|&nbsp;
-									{{.root.i18n.Tr "repo.diff.file_image_height"}}: <span class="text bounds-info-height"></span>
+									{{.root.locale.Tr "repo.diff.file_image_height"}}: <span class="text bounds-info-height"></span>
 									&nbsp;|&nbsp;
 								</span>
-								{{.root.i18n.Tr "repo.diff.file_byte_size"}}: <span class="text">{{FileSize .blobBase.Size}}</span>
+								{{.root.locale.Tr "repo.diff.file_byte_size"}}: <span class="text">{{FileSize .blobBase.Size}}</span>
 							</p>
 						</span>
 						{{end}}
 						{{if .blobHead }}
 						<span class="side">
-							<p class="side-header">{{.root.i18n.Tr "repo.diff.file_after"}}</p>
+							<p class="side-header">{{.root.locale.Tr "repo.diff.file_after"}}</p>
 							<span class="after-container"><img class="image-after" /></span>
 							<p>
 								<span class="bounds-info-after">
-									{{.root.i18n.Tr "repo.diff.file_image_width"}}: <span class="text bounds-info-width"></span>
+									{{.root.locale.Tr "repo.diff.file_image_width"}}: <span class="text bounds-info-width"></span>
 									&nbsp;|&nbsp;
-									{{.root.i18n.Tr "repo.diff.file_image_height"}}: <span class="text bounds-info-height"></span>
+									{{.root.locale.Tr "repo.diff.file_image_height"}}: <span class="text bounds-info-height"></span>
 									&nbsp;|&nbsp;
 								</span>
-								{{.root.i18n.Tr "repo.diff.file_byte_size"}}: <span class="text">{{FileSize .blobHead.Size}}</span>
+								{{.root.locale.Tr "repo.diff.file_byte_size"}}: <span class="text">{{FileSize .blobHead.Size}}</span>
 							</p>
 						</span>
 						{{end}}

--- a/templates/repo/diff/new_review.tmpl
+++ b/templates/repo/diff/new_review.tmpl
@@ -1,6 +1,6 @@
 <div class="ui top right pointing dropdown custom" id="review-box">
 	<div class="ui tiny green button btn-review">
-		{{.i18n.Tr "repo.diff.review"}}
+		{{.locale.Tr "repo.diff.review"}}
 		<span class="ui small label review-comments-counter" data-pending-comment-number="{{.PendingCodeCommentNumber}}">{{.PendingCodeCommentNumber}}</span>
 		{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	</div>
@@ -10,11 +10,11 @@
 			{{.CsrfTokenHtml}}
 				<input type="hidden" name="commit_id" value="{{.AfterCommitID}}"/>
 				<div class="header df ac pb-3">
-					<div class="f1">{{$.i18n.Tr "repo.diff.review.header"}}</div>
+					<div class="f1">{{$.locale.Tr "repo.diff.review.header"}}</div>
 					<a class="muted close px-3">{{svg "octicon-x" 16}}</a>
 				</div>
 				<div class="ui field">
-					<textarea name="content" tabindex="0" rows="2" placeholder="{{$.i18n.Tr "repo.diff.review.placeholder"}}"></textarea>
+					<textarea name="content" tabindex="0" rows="2" placeholder="{{$.locale.Tr "repo.diff.review.placeholder"}}"></textarea>
 				</div>
 				{{if .IsAttachmentEnabled}}
 					<div class="field">
@@ -22,9 +22,9 @@
 					</div>
 				{{end}}
 				<div class="ui divider"></div>
-				<button type="submit" name="type" value="approve" {{ if and $.IsSigned ($.Issue.IsPoster $.SignedUser.ID) }} disabled {{ end }} class="ui submit green tiny button btn-submit">{{$.i18n.Tr "repo.diff.review.approve"}}</button>
-				<button type="submit" name="type" value="comment" class="ui submit tiny basic button btn-submit">{{$.i18n.Tr "repo.diff.review.comment"}}</button>
-				<button type="submit" name="type" value="reject" {{ if and $.IsSigned ($.Issue.IsPoster $.SignedUser.ID) }} disabled {{ end }} class="ui submit red tiny button btn-submit">{{$.i18n.Tr "repo.diff.review.reject"}}</button>
+				<button type="submit" name="type" value="approve" {{ if and $.IsSigned ($.Issue.IsPoster $.SignedUser.ID) }} disabled {{ end }} class="ui submit green tiny button btn-submit">{{$.locale.Tr "repo.diff.review.approve"}}</button>
+				<button type="submit" name="type" value="comment" class="ui submit tiny basic button btn-submit">{{$.locale.Tr "repo.diff.review.comment"}}</button>
+				<button type="submit" name="type" value="reject" {{ if and $.IsSigned ($.Issue.IsPoster $.SignedUser.ID) }} disabled {{ end }} class="ui submit red tiny button btn-submit">{{$.locale.Tr "repo.diff.review.reject"}}</button>
 			</form>
 		</div>
 	</div>

--- a/templates/repo/diff/options_dropdown.tmpl
+++ b/templates/repo/diff/options_dropdown.tmpl
@@ -1,17 +1,17 @@
 <div class="ui dropdown tiny basic button">
-	{{.i18n.Tr "repo.diff.options_button"}}
+	{{.locale.Tr "repo.diff.options_button"}}
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu">
-		<a class="item tiny basic toggle button" data-target="#diff-files">{{.i18n.Tr "repo.diff.show_diff_stats"}}</a>
+		<a class="item tiny basic toggle button" data-target="#diff-files">{{.locale.Tr "repo.diff.show_diff_stats"}}</a>
 		{{if .Issue.Index}}
-			<a class="item" href="{{$.RepoLink}}/pulls/{{.Issue.Index}}.patch" download="{{.Issue.Index}}.patch">{{.i18n.Tr "repo.diff.download_patch"}}</a>
-			<a class="item" href="{{$.RepoLink}}/pulls/{{.Issue.Index}}.diff" download="{{.Issue.Index}}.diff">{{.i18n.Tr "repo.diff.download_diff"}}</a>
+			<a class="item" href="{{$.RepoLink}}/pulls/{{.Issue.Index}}.patch" download="{{.Issue.Index}}.patch">{{.locale.Tr "repo.diff.download_patch"}}</a>
+			<a class="item" href="{{$.RepoLink}}/pulls/{{.Issue.Index}}.diff" download="{{.Issue.Index}}.diff">{{.locale.Tr "repo.diff.download_diff"}}</a>
 		{{else if $.PageIsWiki}}
-			<a class="item" href="{{$.RepoLink}}/wiki/commit/{{PathEscape .Commit.ID.String}}.patch" download="{{ShortSha .Commit.ID.String}}.patch">{{.i18n.Tr "repo.diff.download_patch"}}</a>
-			<a class="item" href="{{$.RepoLink}}/wiki/commit/{{PathEscape .Commit.ID.String}}.diff" download="{{ShortSha .Commit.ID.String}}.diff">{{.i18n.Tr "repo.diff.download_diff"}}</a>
+			<a class="item" href="{{$.RepoLink}}/wiki/commit/{{PathEscape .Commit.ID.String}}.patch" download="{{ShortSha .Commit.ID.String}}.patch">{{.locale.Tr "repo.diff.download_patch"}}</a>
+			<a class="item" href="{{$.RepoLink}}/wiki/commit/{{PathEscape .Commit.ID.String}}.diff" download="{{ShortSha .Commit.ID.String}}.diff">{{.locale.Tr "repo.diff.download_diff"}}</a>
 		{{else if .Commit.ID.String}}
-			<a class="item" href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}.patch" download="{{ShortSha .Commit.ID.String}}.patch">{{.i18n.Tr "repo.diff.download_patch"}}</a>
-			<a class="item" href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}.diff" download="{{ShortSha .Commit.ID.String}}.diff">{{.i18n.Tr "repo.diff.download_diff"}}</a>
+			<a class="item" href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}.patch" download="{{ShortSha .Commit.ID.String}}.patch">{{.locale.Tr "repo.diff.download_patch"}}</a>
+			<a class="item" href="{{$.RepoLink}}/commit/{{PathEscape .Commit.ID.String}}.diff" download="{{ShortSha .Commit.ID.String}}.diff">{{.locale.Tr "repo.diff.download_diff"}}</a>
 		{{end}}
 	</div>
 </div>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -22,14 +22,14 @@
 							</a>
 						{{end}}
 					</td>{{$inlineDiff := $section.GetComputedInlineDiffFor $line}}
-					<td class="lines-escape lines-escape-old">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
-					<td colspan="6" class="lines-code lines-code-old "><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</span></td>
+					<td class="lines-escape lines-escape-old">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+					<td colspan="6" class="lines-code lines-code-old "><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</span></td>
 				{{else if and (eq .GetType 3) $hasmatch}}{{/* DEL */}}
 					{{$match := index $section.Lines $line.Match}}
 					{{- $leftDiff := ""}}{{if $line.LeftIdx}}{{$leftDiff = $section.GetComputedInlineDiffFor $line}}{{end}}
 					{{- $rightDiff := ""}}{{if $match.RightIdx}}{{$rightDiff = $section.GetComputedInlineDiffFor $match}}{{end}}
 					<td class="lines-num lines-num-old del-code" data-line-num="{{$line.LeftIdx}}"><span rel="diff-{{$file.NameHash}}L{{$line.LeftIdx}}"></span></td>
-					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{if $leftDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
+					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{if $leftDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old halfwidth del-code">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
@@ -38,13 +38,13 @@
 							*/}}</a>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.LeftIdx}}{{/*
-							*/}}<code {{if $leftDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$leftDiff.Content}}</code>{{/*
+							*/}}<code {{if $leftDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$leftDiff.Content}}</code>{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
 					*/}}</td>
 					<td class="lines-num lines-num-new add-code" data-line-num="{{if $match.RightIdx}}{{$match.RightIdx}}{{end}}"><span rel="{{if $match.RightIdx}}diff-{{$file.NameHash}}R{{$match.RightIdx}}{{end}}"></span></td>
-					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{if $rightDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
+					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{if $rightDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new halfwidth add-code">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
@@ -53,7 +53,7 @@
 							*/}}</a>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $match.RightIdx}}{{/*
-							*/}}<code {{if $rightDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$rightDiff.Content}}</code>{{/*
+							*/}}<code {{if $rightDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$rightDiff.Content}}</code>{{/*
 						*/}}{{else}}{{/*
 							*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
@@ -61,7 +61,7 @@
 				{{else}}
 					{{$inlineDiff := $section.GetComputedInlineDiffFor $line}}
 					<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$file.NameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
-					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
+					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old halfwidth">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2))}}{{/*
@@ -70,13 +70,13 @@
 							*/}}</a>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.LeftIdx}}{{/*
-							*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
+							*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
 					*/}}</td>
 					<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$file.NameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
-					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
+					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new halfwidth">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3))}}{{/*
@@ -85,7 +85,7 @@
 							*/}}</a>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.RightIdx}}{{/*
-							*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
+							*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -26,11 +26,11 @@
 					<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$file.NameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
 				{{end}}
 				{{$inlineDiff := $section.GetComputedInlineDiffFor $line -}}
-				<td class="lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+				<td class="lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 				<td class="lines-type-marker"><span class="mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 				{{if eq .GetType 4}}
 					<td class="chroma lines-code blob-hunk">{{/*
-						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
+						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
 					*/}}</td>
 				{{else}}
 					<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*
@@ -39,7 +39,7 @@
 								*/}}{{svg "octicon-plus"}}{{/*
 							*/}}</a>{{/*
 						*/}}{{end}}{{/*
-						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.i18n.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
+						*/}}<code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{$.root.locale.Tr "repo.line_unicode"}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code>{{/*
 					*/}}</td>
 				{{end}}
 			</tr>

--- a/templates/repo/diff/stats.tmpl
+++ b/templates/repo/diff/stats.tmpl
@@ -1,4 +1,4 @@
 {{Add .file.Addition .file.Deletion}}
-<span class="diff-stats-bar tooltip mx-3" data-content="{{.root.i18n.Tr "repo.diff.stats_desc_file" (Add .file.Addition .file.Deletion) .file.Addition .file.Deletion | Str2html}}" data-variation="wide">
+<span class="diff-stats-bar tooltip mx-3" data-content="{{.root.locale.Tr "repo.diff.stats_desc_file" (Add .file.Addition .file.Deletion) .file.Addition .file.Deletion | Str2html}}" data-variation="wide">
 	<div class="diff-stats-add-bar" style="width: {{DiffStatsWidth .file.Addition .file.Deletion}}%"></div>
 </span>

--- a/templates/repo/diff/whitespace_dropdown.tmpl
+++ b/templates/repo/diff/whitespace_dropdown.tmpl
@@ -1,23 +1,23 @@
 <div class="ui dropdown tiny basic button">
-	{{.i18n.Tr "repo.diff.whitespace_button"}}
+	{{.locale.Tr "repo.diff.whitespace_button"}}
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu">
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=show-all">
 			<i class="circle {{ if eq .WhitespaceBehavior "show-all" }}dot{{else}}outline{{end}} icon"></i>
-			{{.i18n.Tr "repo.diff.whitespace_show_everything"}}
+			{{.locale.Tr "repo.diff.whitespace_show_everything"}}
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-all">
 			<i class="circle {{ if eq .WhitespaceBehavior "ignore-all" }}dot{{else}}outline{{end}} icon"></i>
-			{{.i18n.Tr "repo.diff.whitespace_ignore_all_whitespace"}}
+			{{.locale.Tr "repo.diff.whitespace_ignore_all_whitespace"}}
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-change">
 			<i class="circle {{ if eq .WhitespaceBehavior "ignore-change" }}dot{{else}}outline{{end}} icon"></i>
-			{{.i18n.Tr "repo.diff.whitespace_ignore_amount_changes"}}
+			{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-eol">
 			<i class="circle {{ if eq .WhitespaceBehavior "ignore-eol" }}dot{{else}}outline{{end}} icon"></i>
-			{{.i18n.Tr "repo.diff.whitespace_ignore_at_eol"}}
+			{{.locale.Tr "repo.diff.whitespace_ignore_at_eol"}}
 		</a>
 	</div>
 </div>
-<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}&whitespace={{$.WhitespaceBehavior}}">{{ if .IsSplitStyle }}{{.i18n.Tr "repo.diff.show_unified_view"}}{{else}}{{.i18n.Tr "repo.diff.show_split_view"}}{{end}}</a>
+<a class="ui tiny basic toggle button" href="?style={{if .IsSplitStyle}}unified{{else}}split{{end}}&whitespace={{$.WhitespaceBehavior}}">{{ if .IsSplitStyle }}{{.locale.Tr "repo.diff.show_unified_view"}}{{else}}{{.locale.Tr "repo.diff.show_split_view"}}{{end}}</a>

--- a/templates/repo/editor/cherry_pick.tmpl
+++ b/templates/repo/editor/cherry_pick.tmpl
@@ -14,14 +14,14 @@
 						{{$shaurl := printf "%s/commit/%s" $.RepoLink (PathEscape .SHA)}}
 						{{$shalink := printf "<a class=\"ui primary sha label\" href=\"%s\">%s</a>" (Escape $shaurl) (ShortSha .SHA)}}
 						{{if eq .CherryPickType "revert"}}
-							{{.i18n.Tr "repo.editor.revert" $shalink | Str2html}}
+							{{.locale.Tr "repo.editor.revert" $shalink | Str2html}}
 						{{else}}
-							{{.i18n.Tr "repo.editor.cherry_pick" $shalink | Str2html}}
+							{{.locale.Tr "repo.editor.cherry_pick" $shalink | Str2html}}
 						{{end}}
 						<a class="section" href="{{$.RepoLink}}">{{.Repository.FullName}}</a>
 						<div class="divider">:</div>
 						<a class="section" href="{{$.BranchLink}}">{{.BranchName}}</a>
-						<span>{{.i18n.Tr "repo.editor.or"}} <a href="{{$shaurl}}">{{.i18n.Tr "repo.editor.cancel_lower"}}</a></span>
+						<span>{{.locale.Tr "repo.editor.or"}} <a href="{{$shaurl}}">{{.locale.Tr "repo.editor.cancel_lower"}}</a></span>
 					</div>
 				</div>
 			</div>

--- a/templates/repo/editor/commit_form.tmpl
+++ b/templates/repo/editor/commit_form.tmpl
@@ -2,37 +2,37 @@
 	{{avatar .SignedUser 48 "commit-avatar"}}
 	<div class="commit-form">
 		<h3>{{- if .CanCommitToBranch.WillSign}}
-			<span title="{{.i18n.Tr "repo.signing.will_sign" .CanCommitToBranch.SigningKey}}">{{svg "octicon-lock" 24}}</span>
-			{{.i18n.Tr "repo.editor.commit_signed_changes"}}
+			<span title="{{.locale.Tr "repo.signing.will_sign" .CanCommitToBranch.SigningKey}}">{{svg "octicon-lock" 24}}</span>
+			{{.locale.Tr "repo.editor.commit_signed_changes"}}
 		{{- else}}
-			<span title="{{.i18n.Tr (printf "repo.signing.wont_sign.%s" .CanCommitToBranch.WontSignReason)}}">{{svg "octicon-unlock" 24}}</span>
-			{{.i18n.Tr "repo.editor.commit_changes"}}
+			<span title="{{.locale.Tr (printf "repo.signing.wont_sign.%s" .CanCommitToBranch.WontSignReason)}}">{{svg "octicon-unlock" 24}}</span>
+			{{.locale.Tr "repo.editor.commit_changes"}}
 		{{- end}}</h3>
 		<div class="field">
-			<input name="commit_summary" placeholder="{{if .PageIsDelete}}{{.i18n.Tr "repo.editor.delete" .TreePath}}{{else if .PageIsUpload}}{{.i18n.Tr "repo.editor.upload_files_to_dir" .TreePath}}{{else if .IsNewFile}}{{.i18n.Tr "repo.editor.add_tmpl"}}{{else}}{{.i18n.Tr "repo.editor.update" .TreePath}}{{end}}" value="{{.commit_summary}}" autofocus>
+			<input name="commit_summary" placeholder="{{if .PageIsDelete}}{{.locale.Tr "repo.editor.delete" .TreePath}}{{else if .PageIsUpload}}{{.locale.Tr "repo.editor.upload_files_to_dir" .TreePath}}{{else if .IsNewFile}}{{.locale.Tr "repo.editor.add_tmpl"}}{{else}}{{.locale.Tr "repo.editor.update" .TreePath}}{{end}}" value="{{.commit_summary}}" autofocus>
 		</div>
 		<div class="field">
-			<textarea name="commit_message" placeholder="{{.i18n.Tr "repo.editor.commit_message_desc"}}" rows="5">{{.commit_message}}</textarea>
+			<textarea name="commit_message" placeholder="{{.locale.Tr "repo.editor.commit_message_desc"}}" rows="5">{{.commit_message}}</textarea>
 		</div>
 		<div class="inline field">
 			<div class="ui checkbox">
 				<input name="signoff" type="checkbox" tabindex="0" class="hidden">
-				<label>{{.i18n.Tr "repo.editor.signoff_desc"}}</label>
+				<label>{{.locale.Tr "repo.editor.signoff_desc"}}</label>
 			</div>
 		</div>
 		<div class="quick-pull-choice js-quick-pull-choice">
 			<div class="field">
 				<div class="ui radio checkbox {{if not .CanCommitToBranch.CanCommitToBranch}}disabled{{end}}">
-					<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="direct" button_text="{{.i18n.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "direct"}}checked{{end}}>
+					<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="direct" button_text="{{.locale.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "direct"}}checked{{end}}>
 					<label>
 						{{svg "octicon-git-commit"}}
-						{{.i18n.Tr "repo.editor.commit_directly_to_this_branch" (.BranchName|Escape) | Safe}}
+						{{.locale.Tr "repo.editor.commit_directly_to_this_branch" (.BranchName|Escape) | Safe}}
 						{{if not .CanCommitToBranch.CanCommitToBranch}}
 						<div class="ui visible small warning message">
-							{{.i18n.Tr "repo.editor.no_commit_to_branch"}}
+							{{.locale.Tr "repo.editor.no_commit_to_branch"}}
 							<ul>
-								{{if not .CanCommitToBranch.UserCanPush}}<li>{{.i18n.Tr "repo.editor.user_no_push_to_branch"}}</li>{{end}}
-								{{if and .CanCommitToBranch.RequireSigned (not .CanCommitToBranch.WillSign)}}<li>{{.i18n.Tr "repo.editor.require_signed_commit"}}</li>{{end}}
+								{{if not .CanCommitToBranch.UserCanPush}}<li>{{.locale.Tr "repo.editor.user_no_push_to_branch"}}</li>{{end}}
+								{{if and .CanCommitToBranch.RequireSigned (not .CanCommitToBranch.WillSign)}}<li>{{.locale.Tr "repo.editor.require_signed_commit"}}</li>{{end}}
 							</ul>
 						</div>
 						{{end}}
@@ -44,16 +44,16 @@
 				{{$prUnit := .Repository.MustGetUnit $.UnitTypePullRequests}}
 				<div class="ui radio checkbox">
 					{{if $pullRequestEnabled}}
-						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.i18n.Tr "repo.editor.propose_file_change"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
+						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.locale.Tr "repo.editor.propose_file_change"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
 					{{else}}
-						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.i18n.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
+						<input type="radio" class="js-quick-pull-choice-option" name="commit_choice" value="commit-to-new-branch" button_text="{{.locale.Tr "repo.editor.commit_changes"}}" {{if eq .commit_choice "commit-to-new-branch"}}checked{{end}}>
 					{{end}}
 					<label>
 						{{svg "octicon-git-pull-request"}}
 						{{if $pullRequestEnabled}}
-							{{.i18n.Tr "repo.editor.create_new_branch" | Safe}}
+							{{.locale.Tr "repo.editor.create_new_branch" | Safe}}
 						{{else}}
-							{{.i18n.Tr "repo.editor.create_new_branch_np" | Safe}}
+							{{.locale.Tr "repo.editor.create_new_branch_np" | Safe}}
 						{{end}}
 					</label>
 				</div>
@@ -61,14 +61,14 @@
 			<div class="quick-pull-branch-name {{if not (eq .commit_choice "commit-to-new-branch")}}hide{{end}}">
 				<div class="new-branch-name-input field {{if .Err_NewBranchName}}error{{end}}">
 					{{svg "octicon-git-branch"}}
-					<input type="text" name="new_branch_name" value="{{.new_branch_name}}" class="input-contrast mr-2 js-quick-pull-new-branch-name" placeholder="{{.i18n.Tr "repo.editor.new_branch_name_desc"}}" {{if eq .commit_choice "commit-to-new-branch"}}required{{end}}>
+					<input type="text" name="new_branch_name" value="{{.new_branch_name}}" class="input-contrast mr-2 js-quick-pull-new-branch-name" placeholder="{{.locale.Tr "repo.editor.new_branch_name_desc"}}" {{if eq .commit_choice "commit-to-new-branch"}}required{{end}}>
 					<span class="text-muted js-quick-pull-normalization-info"></span>
 				</div>
 			</div>
 		</div>
 	</div>
 	<button id="commit-button" type="submit" class="ui green button">
-		{{if eq .commit_choice "commit-to-new-branch"}}{{.i18n.Tr "repo.editor.propose_file_change"}}{{else}}{{.i18n.Tr "repo.editor.commit_changes"}}{{end}}
+		{{if eq .commit_choice "commit-to-new-branch"}}{{.locale.Tr "repo.editor.propose_file_change"}}{{else}}{{.locale.Tr "repo.editor.commit_changes"}}{{end}}
 	</button>
-	<a class="ui button red" href="{{$.BranchLink}}/{{PathEscapeSegments .TreePath}}">{{.i18n.Tr "repo.editor.cancel"}}</a>
+	<a class="ui button red" href="{{$.BranchLink}}/{{PathEscapeSegments .TreePath}}">{{.locale.Tr "repo.editor.cancel"}}</a>
 </div>

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -16,23 +16,23 @@
 						{{range $i, $v := .TreeNames}}
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
-								<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-editorconfig="{{$.Editorconfig}}" required autofocus>
-								<span class="tooltip" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center">{{svg "octicon-info"}}</span>
+								<input id="file-name" value="{{$v}}" placeholder="{{$.locale.Tr "repo.editor.name_your_file"}}" data-editorconfig="{{$.Editorconfig}}" required autofocus>
+								<span class="tooltip" data-content="{{$.locale.Tr "repo.editor.filename_help"}}" data-position="bottom center">{{svg "octicon-info"}}</span>
 							{{else}}
 								<span class="section"><a href="{{$.BranchLink}}/{{index $.TreePaths $i | PathEscapeSegments}}">{{$v}}</a></span>
 							{{end}}
 						{{end}}
-						<span>{{.i18n.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}{{if not .IsNewFile}}/{{PathEscapeSegments .TreePath}}{{end}}">{{.i18n.Tr "repo.editor.cancel_lower"}}</a></span>
+						<span>{{.locale.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}{{if not .IsNewFile}}/{{PathEscapeSegments .TreePath}}{{end}}">{{.locale.Tr "repo.editor.cancel_lower"}}</a></span>
 						<input type="hidden" id="tree_path" name="tree_path" value="{{.TreePath}}" required>
 					</div>
 				</div>
 			</div>
 			<div class="field">
 				<div class="ui top attached tabular menu" data-write="write" data-preview="preview" data-diff="diff">
-					<a class="active item" data-tab="write">{{svg "octicon-code"}} {{if .IsNewFile}}{{.i18n.Tr "repo.editor.new_file"}}{{else}}{{.i18n.Tr "repo.editor.edit_file"}}{{end}}</a>
+					<a class="active item" data-tab="write">{{svg "octicon-code"}} {{if .IsNewFile}}{{.locale.Tr "repo.editor.new_file"}}{{else}}{{.locale.Tr "repo.editor.edit_file"}}{{end}}</a>
 					{{if not .IsNewFile}}
-					<a class="item" data-tab="preview" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL}}" data-preview-file-modes="{{.PreviewableFileModes}}" data-markdown-mode="gfm">{{svg "octicon-eye"}} {{.i18n.Tr "preview"}}</a>
-					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" data-context="{{.BranchLink}}">{{svg "octicon-diff"}} {{.i18n.Tr "repo.editor.preview_changes"}}</a>
+					<a class="item" data-tab="preview" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}/src/{{.BranchNameSubURL}}" data-preview-file-modes="{{.PreviewableFileModes}}" data-markdown-mode="gfm">{{svg "octicon-eye"}} {{.locale.Tr "preview"}}</a>
+					<a class="item" data-tab="diff" data-url="{{.RepoLink}}/_preview/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" data-context="{{.BranchLink}}">{{svg "octicon-diff"}} {{.locale.Tr "repo.editor.preview_changes"}}</a>
 					{{end}}
 				</div>
 				<div class="ui bottom attached active tab segment" data-tab="write">
@@ -45,10 +45,10 @@
 					<div class="editor-loading is-loading"></div>
 				</div>
 				<div class="ui bottom attached tab segment markup" data-tab="preview">
-					{{.i18n.Tr "loading"}}
+					{{.locale.Tr "loading"}}
 				</div>
 				<div class="ui bottom attached tab segment diff edit-diff" data-tab="diff">
-					{{.i18n.Tr "loading"}}
+					{{.locale.Tr "loading"}}
 				</div>
 			</div>
 			{{template "repo/editor/commit_form" .}}
@@ -59,19 +59,19 @@
 	<div class="ui small basic modal" id="edit-empty-content-modal">
 		<div class="ui icon header">
 			<i class="file icon"></i>
-			{{.i18n.Tr "repo.editor.commit_empty_file_header"}}
+			{{.locale.Tr "repo.editor.commit_empty_file_header"}}
 		</div>
 		<div class="center content">
-			<p>{{.i18n.Tr "repo.editor.commit_empty_file_text"}}</p>
+			<p>{{.locale.Tr "repo.editor.commit_empty_file_text"}}</p>
 		</div>
 		<div class="actions">
 			<div class="ui red basic cancel inverted button">
 				<i class="remove icon"></i>
-				{{.i18n.Tr "repo.editor.cancel"}}
+				{{.locale.Tr "repo.editor.cancel"}}
 			</div>
 			<div class="ui green basic ok inverted button">
 				<i class="save icon"></i>
-				{{.i18n.Tr "repo.editor.commit_changes"}}
+				{{.locale.Tr "repo.editor.commit_changes"}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/editor/patch.tmpl
+++ b/templates/repo/editor/patch.tmpl
@@ -10,11 +10,11 @@
 			<div class="ui secondary menu">
 				<div class="fitted item treepath">
 					<div class="ui breadcrumb field {{if .Err_TreePath}}error{{end}}">
-						{{.i18n.Tr "repo.editor.patching"}}
+						{{.locale.Tr "repo.editor.patching"}}
 						<a class="section" href="{{$.RepoLink}}">{{.Repository.FullName}}</a>
 						<div class="divider">:</div>
 						<a class="section" href="{{$.BranchLink}}">{{.BranchName}}</a>
-						<span>{{.i18n.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}">{{.i18n.Tr "repo.editor.cancel_lower"}}</a></span>
+						<span>{{.locale.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}">{{.locale.Tr "repo.editor.cancel_lower"}}</a></span>
 						<input type="hidden" id="tree_path" name="tree_path" value="" required>
 						<input id="file-name" type="hidden" value="diff.patch">
 					</div>
@@ -22,7 +22,7 @@
 			</div>
 			<div class="field">
 				<div class="ui top attached tabular menu" data-write="write">
-					<a class="active item" data-tab="write">{{svg "octicon-code" 16 "mr-2"}}{{.i18n.Tr "repo.editor.new_patch"}}</a>
+					<a class="active item" data-tab="write">{{svg "octicon-code" 16 "mr-2"}}{{.locale.Tr "repo.editor.new_patch"}}</a>
 				</div>
 				<div class="ui bottom attached active tab segment" data-tab="write">
 					<textarea id="edit_area" name="content" class="hide" data-id="repo-{{.Repository.Name}}-patch"
@@ -39,19 +39,19 @@
 	<div class="ui small basic modal" id="edit-empty-content-modal">
 		<div class="ui icon header">
 			<i class="file icon"></i>
-			{{.i18n.Tr "repo.editor.commit_empty_file_header"}}
+			{{.locale.Tr "repo.editor.commit_empty_file_header"}}
 		</div>
 		<div class="center content">
-			<p>{{.i18n.Tr "repo.editor.commit_empty_file_text"}}</p>
+			<p>{{.locale.Tr "repo.editor.commit_empty_file_text"}}</p>
 		</div>
 		<div class="actions">
 			<div class="ui red basic cancel inverted button">
 				<i class="remove icon"></i>
-				{{.i18n.Tr "repo.editor.cancel"}}
+				{{.locale.Tr "repo.editor.cancel"}}
 			</div>
 			<div class="ui green basic ok inverted button">
 				<i class="save icon"></i>
-				{{.i18n.Tr "repo.editor.commit_changes"}}
+				{{.locale.Tr "repo.editor.commit_changes"}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/editor/upload.tmpl
+++ b/templates/repo/editor/upload.tmpl
@@ -14,13 +14,13 @@
 						{{range $i, $v := .TreeNames}}
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
-								<input type="text" id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.add_subdir"}}" autofocus>
-								<span class="tooltip" data-content="{{$.i18n.Tr "repo.editor.filename_help"}}" data-position="bottom center">{{svg "octicon-info"}}</span>
+								<input type="text" id="file-name" value="{{$v}}" placeholder="{{$.locale.Tr "repo.editor.add_subdir"}}" autofocus>
+								<span class="tooltip" data-content="{{$.locale.Tr "repo.editor.filename_help"}}" data-position="bottom center">{{svg "octicon-info"}}</span>
 							{{else}}
 								<span class="section"><a href="{{$.BranchLink}}/{{index $.TreePaths $i | PathEscapeSegments}}">{{$v}}</a></span>
 							{{end}}
 						{{end}}
-						<span>{{.i18n.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}{{if not .IsNewFile}}/{{.TreePath | PathEscapeSegments}}{{end}}">{{.i18n.Tr "repo.editor.cancel_lower"}}</a></span>
+						<span>{{.locale.Tr "repo.editor.or"}} <a href="{{$.BranchLink}}{{if not .IsNewFile}}/{{.TreePath | PathEscapeSegments}}{{end}}">{{.locale.Tr "repo.editor.cancel_lower"}}</a></span>
 						<input type="hidden" id="tree_path" name="tree_path" value="{{.TreePath}}" required>
 					</div>
 				</div>

--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -7,20 +7,20 @@
 				{{template "base/alert" .}}
 				{{if .Repository.IsArchived}}
 					<div class="ui warning message">
-						{{.i18n.Tr "repo.archive.title"}}
+						{{.locale.Tr "repo.archive.title"}}
 					</div>
 				{{end}}
 				{{if .Repository.IsBroken}}
 						<div class="ui segment center">
-							{{.i18n.Tr "repo.broken_message"}}
+							{{.locale.Tr "repo.broken_message"}}
 						</div>
 				{{else if .CanWriteCode}}
 					<h4 class="ui top attached header">
-						{{.i18n.Tr "repo.quick_guide"}}
+						{{.locale.Tr "repo.quick_guide"}}
 					</h4>
 					<div class="ui attached guide table segment empty-repo-guide">
 						<div class="item">
-							<h3>{{.i18n.Tr "repo.clone_this_repo"}} <small>{{.i18n.Tr "repo.clone_helper" "http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository" | Str2html}}</small></h3>
+							<h3>{{.locale.Tr "repo.clone_this_repo"}} <small>{{.locale.Tr "repo.clone_helper" "http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository" | Str2html}}</small></h3>
 							<div class="ui action small input">
 								{{template "repo/clone_buttons" .}}
 							</div>
@@ -30,7 +30,7 @@
 							<div class="ui divider"></div>
 
 							<div class="item">
-								<h3>{{.i18n.Tr "repo.create_new_repo_command"}}</h3>
+								<h3>{{.locale.Tr "repo.create_new_repo_command"}}</h3>
 								<div class="markup">
 									<pre><code>touch README.md
 git init
@@ -44,7 +44,7 @@ git push -u origin {{.Repository.DefaultBranch}}</code></pre>
 							<div class="ui divider"></div>
 
 							<div class="item">
-								<h3>{{.i18n.Tr "repo.push_exist_repo"}}</h3>
+								<h3>{{.locale.Tr "repo.push_exist_repo"}}</h3>
 								<div class="markup">
 									<pre><code>git remote add origin <span class="clone-url"></span>
 git push -u origin {{.Repository.DefaultBranch}}</code></pre>
@@ -67,7 +67,7 @@ git push -u origin {{.Repository.DefaultBranch}}</code></pre>
 						{{end}}
 					{{else}}
 						<div class="ui segment center">
-							{{.i18n.Tr "repo.empty_message"}}
+							{{.locale.Tr "repo.empty_message"}}
 						</div>
 					{{end}}
 				</div>

--- a/templates/repo/find/files.tmpl
+++ b/templates/repo/find/files.tmpl
@@ -14,7 +14,7 @@
 			</tbody>
 		</table>
 		<div id="repo-find-file-no-result" class="ui row center mt-5" hidden>
-			<h3>{{.i18n.Tr "repo.find_file.no_matching"}}</h3>
+			<h3>{{.locale.Tr "repo.find_file.no_matching"}}</h3>
 		</div>
 	</div>
 </div>

--- a/templates/repo/forks.tmpl
+++ b/templates/repo/forks.tmpl
@@ -3,7 +3,7 @@
 	{{template "repo/header" .}}
 	<div class="ui container">
 		<h2 class="ui dividing header">
-			{{.i18n.Tr "repo.forks"}}
+			{{.locale.Tr "repo.forks"}}
 		</h2>
 		<div class="ui list">
 			{{range .Forks}}

--- a/templates/repo/graph.tmpl
+++ b/templates/repo/graph.tmpl
@@ -4,16 +4,16 @@
 	<div class="ui container">
 		<div id="git-graph-container" class="ui segment{{if eq .Mode "monochrome"}} monochrome{{end}}">
 			<h2 class="ui header dividing">
-				{{.i18n.Tr "repo.commit_graph"}}
+				{{.locale.Tr "repo.commit_graph"}}
 				<div class="ui icon buttons tiny color-buttons">
 					<div class="ui multiple selection search dropdown" id="flow-select-refs-dropdown">
 						<input type="hidden" name="flow">
 						<i class="dropdown icon"></i>
-						<div class="default text">{{.i18n.Tr "repo.commit_graph.select"}}</div>
+						<div class="default text">{{.locale.Tr "repo.commit_graph.select"}}</div>
 						<div class="menu">
 							<div class="item" data-value="...flow-hide-pr-refs">
 								<span class="truncate">
-									{{svg "octicon-eye-closed" 16 "mr-2"}}<span title="{{.i18n.Tr "repo.commit_graph.hide_pr_refs"}}">{{.i18n.Tr "repo.commit_graph.hide_pr_refs"}}</span>
+									{{svg "octicon-eye-closed" 16 "mr-2"}}<span title="{{.locale.Tr "repo.commit_graph.hide_pr_refs"}}">{{.locale.Tr "repo.commit_graph.hide_pr_refs"}}</span>
 								</span>
 							</div>
 							{{range .AllRefs}}
@@ -46,8 +46,8 @@
 							{{end}}
 						</div>
 					</div>
-					<button id="flow-color-monochrome" class="ui labelled icon button{{if eq .Mode "monochrome"}} active{{end}}" title="{{.i18n.Tr "repo.commit_graph.monochrome"}}">{{svg "material-invert-colors" 16 "mr-2"}}{{.i18n.Tr "repo.commit_graph.monochrome"}}</button>
-					<button id="flow-color-colored" class="ui labelled icon button{{if ne .Mode "monochrome"}} active{{end}}" title="{{.i18n.Tr "repo.commit_graph.color"}}">{{svg "material-palette" 16 "mr-2"}}{{.i18n.Tr "repo.commit_graph.color"}}</button>
+					<button id="flow-color-monochrome" class="ui labelled icon button{{if eq .Mode "monochrome"}} active{{end}}" title="{{.locale.Tr "repo.commit_graph.monochrome"}}">{{svg "material-invert-colors" 16 "mr-2"}}{{.locale.Tr "repo.commit_graph.monochrome"}}</button>
+					<button id="flow-color-colored" class="ui labelled icon button{{if ne .Mode "monochrome"}} active{{end}}" title="{{.locale.Tr "repo.commit_graph.color"}}">{{svg "material-palette" 16 "mr-2"}}{{.locale.Tr "repo.commit_graph.color"}}</button>
 				</div>
 			</h2>
 			<div class="ui dividing"></div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -13,62 +13,62 @@
 					<a href="{{.Owner.HomeLink}}">{{.Owner.Name}}</a>
 					<div class="mx-2">/</div>
 					<a href="{{$.RepoLink}}">{{.Name}}</a>
-					<a href="{{$.RepoLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{$.i18n.Tr "rss_feed"}}" data-position="top center">{{svg "octicon-rss" 18}}</i></a>
+					<a href="{{$.RepoLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{$.locale.Tr "rss_feed"}}" data-position="top center">{{svg "octicon-rss" 18}}</i></a>
 					<div class="labels df ac fw">
 						{{if .IsTemplate}}
 							{{if .IsPrivate}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.desc.private_template"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.desc.private_template"}}</span>
 							{{else}}
 								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{$.i18n.Tr "repo.desc.internal_template"}}</span>
+									<span class="ui basic label">{{$.locale.Tr "repo.desc.internal_template"}}</span>
 								{{end}}
 							{{end}}
 						{{else}}
 							{{if .IsPrivate}}
-								<span class="ui basic label">{{$.i18n.Tr "repo.desc.private"}}</span>
+								<span class="ui basic label">{{$.locale.Tr "repo.desc.private"}}</span>
 							{{else}}
 								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{$.i18n.Tr "repo.desc.internal"}}</span>
+									<span class="ui basic label">{{$.locale.Tr "repo.desc.internal"}}</span>
 								{{end}}
 							{{end}}
 						{{end}}
 						{{if .IsArchived}}
-							<span class="ui basic label">{{$.i18n.Tr "repo.desc.archived"}}</span>
+							<span class="ui basic label">{{$.locale.Tr "repo.desc.archived"}}</span>
 						{{end}}
 					</div>
 				</div>
 				{{if $.IsPullMirror}}
 					{{$address := MirrorRemoteAddress $.Context . $.Mirror.GetRemoteName}}
-					<div class="fork-flag">{{$.i18n.Tr "repo.mirror_from"}} <a target="_blank" rel="noopener noreferrer" href="{{$address.Address}}">{{$address.Address}}</a></div>
+					<div class="fork-flag">{{$.locale.Tr "repo.mirror_from"}} <a target="_blank" rel="noopener noreferrer" href="{{$address.Address}}">{{$address.Address}}</a></div>
 				{{end}}
-				{{if .IsFork}}<div class="fork-flag">{{$.i18n.Tr "repo.forked_from"}} <a href="{{.BaseRepo.Link}}">{{.BaseRepo.FullName}}</a></div>{{end}}
-				{{if .IsGenerated}}<div class="fork-flag">{{$.i18n.Tr "repo.generated_from"}} <a href="{{.TemplateRepo.Link}}">{{.TemplateRepo.FullName}}</a></div>{{end}}
+				{{if .IsFork}}<div class="fork-flag">{{$.locale.Tr "repo.forked_from"}} <a href="{{.BaseRepo.Link}}">{{.BaseRepo.FullName}}</a></div>{{end}}
+				{{if .IsGenerated}}<div class="fork-flag">{{$.locale.Tr "repo.generated_from"}} <a href="{{.TemplateRepo.Link}}">{{.TemplateRepo.FullName}}</a></div>{{end}}
 			</div>
 			{{if not (or .IsBeingCreated .IsBroken)}}
 				<div class="repo-buttons">
 					{{if $.RepoTransfer}}
 						<form method="post" action="{{$.RepoLink}}/action/accept_transfer?redirect_to={{$.RepoLink}}">
 							{{$.CsrfTokenHtml}}
-							<div class="ui tooltip" data-content="{{if $.CanUserAcceptTransfer}}{{$.i18n.Tr "repo.transfer.accept_desc" $.RepoTransfer.Recipient.DisplayName}}{{else}}{{$.i18n.Tr "repo.transfer.no_permission_to_accept"}}{{end}}" data-position="bottom center">
+							<div class="ui tooltip" data-content="{{if $.CanUserAcceptTransfer}}{{$.locale.Tr "repo.transfer.accept_desc" $.RepoTransfer.Recipient.DisplayName}}{{else}}{{$.locale.Tr "repo.transfer.no_permission_to_accept"}}{{end}}" data-position="bottom center">
 								<button type="submit" class="ui button {{if $.CanUserAcceptTransfer}}green {{end}} ok inverted small"{{if not $.CanUserAcceptTransfer}} disabled{{end}}>
-									{{$.i18n.Tr "repo.transfer.accept"}}
+									{{$.locale.Tr "repo.transfer.accept"}}
 								</button>
 							</div>
 						</form>
 						<form method="post" action="{{$.RepoLink}}/action/reject_transfer?redirect_to={{$.RepoLink}}">
 							{{$.CsrfTokenHtml}}
-							<div class="ui tooltip" data-content="{{if $.CanUserAcceptTransfer}}{{$.i18n.Tr "repo.transfer.reject_desc" $.RepoTransfer.Recipient.DisplayName}}{{else}}{{$.i18n.Tr "repo.transfer.no_permission_to_reject"}}{{end}}" data-position="bottom center">
+							<div class="ui tooltip" data-content="{{if $.CanUserAcceptTransfer}}{{$.locale.Tr "repo.transfer.reject_desc" $.RepoTransfer.Recipient.DisplayName}}{{else}}{{$.locale.Tr "repo.transfer.no_permission_to_reject"}}{{end}}" data-position="bottom center">
 								<button type="submit" class="ui button {{if $.CanUserAcceptTransfer}}red {{end}}ok inverted small"{{if not $.CanUserAcceptTransfer}} disabled{{end}}>
-									{{$.i18n.Tr "repo.transfer.reject"}}
+									{{$.locale.Tr "repo.transfer.reject"}}
 								</button>
 							</div>
 						</form>
 					{{end}}
 					<form method="post" action="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}">
 						{{$.CsrfTokenHtml}}
-						<div class="ui labeled button{{if not $.IsSigned}} tooltip{{end}}" tabindex="0"{{if not $.IsSigned}} data-content="{{$.i18n.Tr "repo.watch_guest_user" }}" data-position="top center"{{end}}>
+						<div class="ui labeled button{{if not $.IsSigned}} tooltip{{end}}" tabindex="0"{{if not $.IsSigned}} data-content="{{$.locale.Tr "repo.watch_guest_user" }}" data-position="top center"{{end}}>
 							<button type="submit" class="ui compact small basic button"{{if not $.IsSigned}} disabled{{end}}>
-								{{if $.IsWatchingRepo}}{{svg "octicon-eye-closed" 16}}{{$.i18n.Tr "repo.unwatch"}}{{else}}{{svg "octicon-eye"}}{{$.i18n.Tr "repo.watch"}}{{end}}
+								{{if $.IsWatchingRepo}}{{svg "octicon-eye-closed" 16}}{{$.locale.Tr "repo.unwatch"}}{{else}}{{svg "octicon-eye"}}{{$.locale.Tr "repo.watch"}}{{end}}
 							</button>
 							<a class="ui basic label" href="{{.Link}}/watchers">
 								{{CountFmt .NumWatches}}
@@ -78,9 +78,9 @@
 					{{if not $.DisableStars}}
 						<form method="post" action="{{$.RepoLink}}/action/{{if $.IsStaringRepo}}un{{end}}star?redirect_to={{$.Link}}">
 							{{$.CsrfTokenHtml}}
-							<div class="ui labeled button{{if not $.IsSigned}} tooltip{{end}}" tabindex="0"{{if not $.IsSigned}} data-content="{{$.i18n.Tr "repo.star_guest_user" }}" data-position="top center"{{end}}>
+							<div class="ui labeled button{{if not $.IsSigned}} tooltip{{end}}" tabindex="0"{{if not $.IsSigned}} data-content="{{$.locale.Tr "repo.star_guest_user" }}" data-position="top center"{{end}}>
 								<button type="submit" class="ui compact small basic button"{{if not $.IsSigned}} disabled{{end}}>
-									{{if $.IsStaringRepo}}{{svg "octicon-star-fill"}}{{$.i18n.Tr "repo.unstar"}}{{else}}{{svg "octicon-star"}}{{$.i18n.Tr "repo.star"}}{{end}}
+									{{if $.IsStaringRepo}}{{svg "octicon-star-fill"}}{{$.locale.Tr "repo.unstar"}}{{else}}{{svg "octicon-star"}}{{$.locale.Tr "repo.star"}}{{end}}
 								</button>
 								<a class="ui basic label" href="{{.Link}}/stars">
 									{{CountFmt .NumStars}}
@@ -94,9 +94,9 @@
 								tooltip disabled
 							{{end}}"
 							{{if not $.IsSigned}}
-								data-content="{{$.i18n.Tr "repo.fork_guest_user"}}"
+								data-content="{{$.locale.Tr "repo.fork_guest_user"}}"
 							{{else if and (not $.CanSignedUserFork) (eq (len $.UserAndOrgForks) 0)}}
-								data-content="{{$.i18n.Tr "repo.fork_from_self"}}"
+								data-content="{{$.locale.Tr "repo.fork_from_self"}}"
 							{{end}}
 						data-position="top center" data-variation="tiny" tabindex="0">
 							<a class="ui compact{{if $.ShowForkModal}} show-modal{{end}} small basic button"
@@ -113,12 +113,12 @@
 									data-modal="#fork-repo-modal"
 								{{end}}
 							>
-								{{svg "octicon-repo-forked"}}{{$.i18n.Tr "repo.fork"}}
+								{{svg "octicon-repo-forked"}}{{$.locale.Tr "repo.fork"}}
 							</a>
 							<div class="ui small modal" id="fork-repo-modal">
 								{{svg "octicon-x" 16 "close inside"}}
 								<div class="header">
-									{{$.i18n.Tr "repo.already_forked" .Name}}
+									{{$.locale.Tr "repo.already_forked" .Name}}
 								</div>
 								<div class="content tl">
 									<div class="ui list">
@@ -133,7 +133,7 @@
 									{{if $.CanSignedUserFork}}
 									<div class="ui divider"></div>
 									<a href="{{AppSubUrl}}/repo/fork/{{.ID}}">
-										{{$.i18n.Tr "repo.fork_to_different_account"}}
+										{{$.locale.Tr "repo.fork_to_different_account"}}
 									</a>
 									{{end}}
 								</div>
@@ -153,13 +153,13 @@
 			<div class="ui tabular stackable menu navbar">
 				{{if .Permission.CanRead $.UnitTypeCode}}
 				<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}{{if (ne .BranchName .Repository.DefaultBranch)}}/src/{{.BranchNameSubURL}}{{end}}">
-					{{svg "octicon-code"}} {{.i18n.Tr "repo.code"}}
+					{{svg "octicon-code"}} {{.locale.Tr "repo.code"}}
 				</a>
 				{{end}}
 
 				{{if .Permission.CanRead $.UnitTypeIssues}}
 					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
-						{{svg "octicon-issue-opened"}} {{.i18n.Tr "repo.issues"}}
+						{{svg "octicon-issue-opened"}} {{.locale.Tr "repo.issues"}}
 						{{if .Repository.NumOpenIssues}}
 							<span class="ui primary small label">{{CountFmt .Repository.NumOpenIssues}}</span>
 						{{end}}
@@ -168,13 +168,13 @@
 
 				{{if .Permission.CanRead $.UnitTypeExternalTracker}}
 					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoExternalIssuesLink}}" target="_blank" rel="noopener noreferrer">
-						{{svg "octicon-link-external"}} {{.i18n.Tr "repo.issues"}} </span>
+						{{svg "octicon-link-external"}} {{.locale.Tr "repo.issues"}} </span>
 					</a>
 				{{end}}
 
 				{{if and .Repository.CanEnablePulls (.Permission.CanRead $.UnitTypePullRequests)}}
 					<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
-						{{svg "octicon-git-pull-request"}} {{.i18n.Tr "repo.pulls"}}
+						{{svg "octicon-git-pull-request"}} {{.locale.Tr "repo.pulls"}}
 						{{if .Repository.NumOpenPulls}}
 							<span class="ui primary small label">{{CountFmt .Repository.NumOpenPulls}}</span>
 						{{end}}
@@ -183,13 +183,13 @@
 
 				{{if .Permission.CanRead $.UnitTypePackages}}
 					<a href="{{.RepoLink}}/packages" class="{{ if .IsPackagesPage }}active{{end}} item">
-						{{svg "octicon-package"}} {{.i18n.Tr "packages.title"}}
+						{{svg "octicon-package"}} {{.locale.Tr "packages.title"}}
 					</a>
 				{{end}}
 
 				{{ if and (not .UnitProjectsGlobalDisabled) (.Permission.CanRead $.UnitTypeProjects)}}
 					<a href="{{.RepoLink}}/projects" class="{{ if .IsProjectsPage }}active{{end}} item">
-						{{svg "octicon-project"}} {{.i18n.Tr "repo.project_board"}}
+						{{svg "octicon-project"}} {{.locale.Tr "repo.project_board"}}
 						{{if .Repository.NumOpenProjects}}
 							<span class="ui primary small label">{{CountFmt .Repository.NumOpenProjects}}</span>
 						{{end}}
@@ -198,7 +198,7 @@
 
 				{{if and (.Permission.CanRead $.UnitTypeReleases) (not .IsEmptyRepo) }}
 				<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
-					{{svg "octicon-tag"}} {{.i18n.Tr "repo.releases"}}
+					{{svg "octicon-tag"}} {{.locale.Tr "repo.releases"}}
 					{{if .NumReleases}}
 						<span class="ui primary small label">{{CountFmt .NumReleases}}</span>
 					{{end}}
@@ -207,13 +207,13 @@
 
 				{{if or (.Permission.CanRead $.UnitTypeWiki) (.Permission.CanRead $.UnitTypeExternalWiki)}}
 					<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki" {{if (.Permission.CanRead $.UnitTypeExternalWiki)}} target="_blank" rel="noopener noreferrer" {{end}}>
-						{{svg "octicon-book"}} {{.i18n.Tr "repo.wiki"}}
+						{{svg "octicon-book"}} {{.locale.Tr "repo.wiki"}}
 					</a>
 				{{end}}
 
 				{{if and (.Permission.CanReadAny $.UnitTypePullRequests $.UnitTypeIssues $.UnitTypeReleases) (not .IsEmptyRepo)}}
 					<a class="{{if .PageIsActivity}}active{{end}} item" href="{{.RepoLink}}/activity">
-						{{svg "octicon-pulse"}} {{.i18n.Tr "repo.activity"}}
+						{{svg "octicon-pulse"}} {{.locale.Tr "repo.activity"}}
 					</a>
 				{{end}}
 
@@ -222,7 +222,7 @@
 				{{if .Permission.IsAdmin}}
 					<div class="right menu">
 						<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
-							{{svg "octicon-tools"}} {{.i18n.Tr "repo.settings"}}
+							{{svg "octicon-tools"}} {{.locale.Tr "repo.settings"}}
 						</a>
 					</div>
 				{{end}}
@@ -231,7 +231,7 @@
 			<div class="ui tabular stackable menu navbar">
 				<div class="right menu">
 					<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
-						{{svg "octicon-tools"}} {{.i18n.Tr "repo.settings"}}
+						{{svg "octicon-tools"}} {{.locale.Tr "repo.settings"}}
 					</a>
 				</div>
 			</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -6,15 +6,15 @@
 		<div class="ui repo-description">
 			<div id="repo-desc">
 				{{ $description := .Repository.DescriptionHTML $.Context}}
-				{{if $description}}<span class="description">{{$description}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.i18n.Tr "repo.no_desc"}}</span>{{end}}
+				{{if $description}}<span class="description">{{$description}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}
 				<a class="link" href="{{.Repository.Website}}">{{.Repository.Website}}</a>
 			</div>
 			{{if .RepoSearchEnabled}}
 				<div class="ui repo-search">
 					<form class="ui form ignore-dirty" action="{{.RepoLink}}/search" method="get">
 						<div class="field">
-							<div class="ui action input{{if .CodeIndexerUnavailable }} disabled left icon tooltip{{end}}"{{if .CodeIndexerUnavailable }} data-content="{{.i18n.Tr "repo.search.code_search_unavailable"}}"{{end}}>
-								<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.i18n.Tr "repo.search.search_repo"}}">
+							<div class="ui action input{{if .CodeIndexerUnavailable }} disabled left icon tooltip{{end}}"{{if .CodeIndexerUnavailable }} data-content="{{.locale.Tr "repo.search.code_search_unavailable"}}"{{end}}>
+								<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.locale.Tr "repo.search.search_repo"}}">
 								{{if .CodeIndexerUnavailable }}
 									<i class="icon df ac jc">{{svg "octicon-alert"}}</i>
 								{{end}}
@@ -29,7 +29,7 @@
 		</div>
 		<div class="mt-3" id="repo-topics">
 		{{range .Topics}}<a class="ui repo-topic large label topic" href="{{AppSubUrl}}/explore/repos?q={{.Name}}&topic=1">{{.Name}}</a>{{end}}
-		{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}<a id="manage_topic" class="muted">{{.i18n.Tr "repo.topic.manage_topics"}}</a>{{end}}
+		{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}<a id="manage_topic" class="muted">{{.locale.Tr "repo.topic.manage_topics"}}</a>{{end}}
 		</div>
 		{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}
 		<div class="ui repo-topic-edit grid form" id="topic_edit" style="display:none">
@@ -46,17 +46,17 @@
 			</div>
 			<div class="two wide column">
 				<a class="ui button primary" href="javascript:;" id="save_topic"
-				data-link="{{.RepoLink}}/topics">{{.i18n.Tr "repo.topic.done"}}</a>
+				data-link="{{.RepoLink}}/topics">{{.locale.Tr "repo.topic.done"}}</a>
 			</div>
 		</div>
 		{{end}}
 		<div class="hide" id="validate_prompt">
-			<span id="count_prompt">{{.i18n.Tr "repo.topic.count_prompt"}}</span>
-			<span id="format_prompt">{{.i18n.Tr "repo.topic.format_prompt"}}</span>
+			<span id="count_prompt">{{.locale.Tr "repo.topic.count_prompt"}}</span>
+			<span id="format_prompt">{{.locale.Tr "repo.topic.format_prompt"}}</span>
 		</div>
 		{{if .Repository.IsArchived}}
 			<div class="ui warning message">
-				{{.i18n.Tr "repo.archive.title"}}
+				{{.locale.Tr "repo.archive.title"}}
 			</div>
 		{{end}}
 		{{template "repo/sub_menu" .}}
@@ -69,13 +69,13 @@
 				{{if and .CanCompareOrPull .IsViewBranch (not .Repository.IsArchived)}}
 					<div class="fitted item mx-0">
 						<a href="{{.BaseRepo.Link}}/compare/{{PathEscapeSegments .BaseRepo.DefaultBranch}}...{{if ne .Repository.Owner.Name .BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}{{if .BaseRepo.IsFork}}/{{PathEscape .Repository.Name}}{{end}}:{{end}}{{PathEscapeSegments .BranchName}}">
-							<button id="new-pull-request" class="ui compact basic button">{{if .PullRequestCtx.Allowed}}{{.i18n.Tr "repo.pulls.compare_changes"}}{{else}}{{.i18n.Tr "action.compare_branch"}}{{end}}</button>
+							<button id="new-pull-request" class="ui compact basic button">{{if .PullRequestCtx.Allowed}}{{.locale.Tr "repo.pulls.compare_changes"}}{{else}}{{.locale.Tr "action.compare_branch"}}{{end}}</button>
 						</a>
 					</div>
 				{{end}}
 				<div class="fitted item mx-0">
 					<a href="{{.Repository.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button">
-						{{.i18n.Tr "repo.find_file.go_to_file"}}
+						{{.locale.Tr "repo.find_file.go_to_file"}}
 					</a>
 				</div>
 			{{else}}
@@ -86,23 +86,23 @@
 					{{if .Repository.CanEnableEditor}}
 						{{if .CanAddFile}}
 							<a href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" class="ui button">
-								{{.i18n.Tr "repo.editor.new_file"}}
+								{{.locale.Tr "repo.editor.new_file"}}
 							</a>
 						{{end}}
 						{{if .CanUploadFile}}
 							<a href="{{.RepoLink}}/_upload/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" class="ui button">
-								{{.i18n.Tr "repo.editor.upload_file"}}
+								{{.locale.Tr "repo.editor.upload_file"}}
 							</a>
 						{{end}}
 						{{if .CanAddFile}}
 							<a href="{{.RepoLink}}/_diffpatch/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" class="ui button">
-								{{.i18n.Tr "repo.editor.patch"}}
+								{{.locale.Tr "repo.editor.patch"}}
 							</a>
 						{{end}}
 					{{end}}
 					{{if and (ne $n 0) (not .IsViewFile) (not .IsBlame) }}
 						<a href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/{{.TreePath | PathEscapeSegments}}" class="ui button">
-							{{.i18n.Tr "repo.file_history"}}
+							{{.locale.Tr "repo.file_history"}}
 						</a>
 					{{end}}
 				</div>
@@ -113,7 +113,7 @@
 					{{if .Repository.IsTemplate}}
 						<div class="ui tiny primary buttons">
 							<a href="{{AppSubUrl}}/repo/create?template_id={{.Repository.ID}}" class="ui button">
-								{{.i18n.Tr "repo.use_template"}}
+								{{.locale.Tr "repo.use_template"}}
 							</a>
 						</div>
 					{{end}}
@@ -124,13 +124,13 @@
 				{{if eq $n 0}}
 					<div class="ui action tiny input" id="clone-panel">
 						{{template "repo/clone_buttons" .}}
-						<button id="download-btn" class="ui basic jump dropdown icon button tooltip" data-content="{{.i18n.Tr "repo.download_archive"}}" data-position="top right">
+						<button id="download-btn" class="ui basic jump dropdown icon button tooltip" data-content="{{.locale.Tr "repo.download_archive"}}" data-position="top right">
 							{{svg "octicon-download"}}
 							<div class="menu">
-								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.zip" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-3"}}{{.i18n.Tr "repo.download_zip"}}</a>
-								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.tar.gz" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-3"}}{{.i18n.Tr "repo.download_tar"}}</a>
-								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.bundle" rel="nofollow">{{svg "octicon-package" 16 "mr-3"}}{{.i18n.Tr "repo.download_bundle"}}</a>
-								<a class="item" href="vscode://vscode.git/clone?url={{$.RepoCloneLink.HTTPS}}">{{svg "gitea-vscode" 16 "mr-3"}}{{.i18n.Tr "repo.clone_in_vsc"}}</a>
+								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.zip" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-3"}}{{.locale.Tr "repo.download_zip"}}</a>
+								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.tar.gz" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-3"}}{{.locale.Tr "repo.download_tar"}}</a>
+								<a class="item archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.BranchName}}.bundle" rel="nofollow">{{svg "octicon-package" 16 "mr-3"}}{{.locale.Tr "repo.download_bundle"}}</a>
+								<a class="item" href="vscode://vscode.git/clone?url={{$.RepoCloneLink.HTTPS}}">{{svg "gitea-vscode" 16 "mr-3"}}{{.locale.Tr "repo.clone_in_vsc"}}</a>
 							</div>
 						</button>
 					</div>

--- a/templates/repo/issue/branch_selector_field.tmpl
+++ b/templates/repo/issue/branch_selector_field.tmpl
@@ -5,27 +5,27 @@
 	{{$.CsrfTokenHtml}}
 </form>
 
-<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating filter select-branch dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
+<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating filter select-branch dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
 	<div class="ui basic small button">
-		<span class="text branch-name">{{if .Reference}}{{$.RefEndName}}{{else}}{{.i18n.Tr "repo.issues.no_ref"}}{{end}}</span>
+		<span class="text branch-name">{{if .Reference}}{{$.RefEndName}}{{else}}{{.locale.Tr "repo.issues.no_ref"}}{{end}}</span>
 		{{if .HasIssuesOrPullsWritePermission}}{{svg "octicon-triangle-down" 14 "dropdown icon"}}{{end}}
 	</div>
 	<div class="menu">
 		<div class="ui icon search input">
 			<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-			<input name="search" placeholder="{{.i18n.Tr "repo.filter_branch_and_tag"}}...">
+			<input name="search" placeholder="{{.locale.Tr "repo.filter_branch_and_tag"}}...">
 		</div>
 		<div class="header">
 			<div class="ui grid">
 				<div class="two column row">
 					<a class="reference column" href="#" data-target="#branch-list">
 						<span class="text black">
-							{{svg "octicon-git-branch" 16 "mr-2"}}{{.i18n.Tr "repo.branches"}}
+							{{svg "octicon-git-branch" 16 "mr-2"}}{{.locale.Tr "repo.branches"}}
 						</span>
 					</a>
 					<a class="reference column" href="#" data-target="#tag-list">
 						<span class="text">
-							{{svg "octicon-tag" 16 "mr-2"}}{{.i18n.Tr "repo.tags"}}
+							{{svg "octicon-tag" 16 "mr-2"}}{{.locale.Tr "repo.tags"}}
 						</span>
 					</a>
 				</div>
@@ -33,7 +33,7 @@
 		</div>
 		<div id="branch-list" class="scrolling menu reference-list-menu {{if not .Issue}}new-issue{{end}}">
 			{{if .Reference}}
-				<div class="item text small" data-id="" data-id-selector="#ref_selector"><strong><a href="#">{{$.i18n.Tr "repo.clear_ref"}}</a></strong></div>
+				<div class="item text small" data-id="" data-id-selector="#ref_selector"><strong><a href="#">{{$.locale.Tr "repo.clear_ref"}}</a></strong></div>
 			{{end}}
 			{{range .Branches}}
 				<div class="item" data-id="refs/heads/{{.}}" data-name="{{.}}" data-id-selector="#ref_selector">{{.}}</div>
@@ -41,7 +41,7 @@
 		</div>
 		<div id="tag-list" class="scrolling menu reference-list-menu {{if not .Issue}}new-issue{{end}}" style="display: none">
 			{{if .Reference}}
-				<div class="item text small" data-id="" data-id-selector="#ref_selector"><strong><a href="#">{{.i18n.Tr "repo.clear_ref"}}</a></strong></div>
+				<div class="item text small" data-id="" data-id-selector="#ref_selector"><strong><a href="#">{{.locale.Tr "repo.clear_ref"}}</a></strong></div>
 			{{end}}
 			{{range .Tags}}
 				<div class="item" data-id="refs/tags/{{.}}" data-name="tags/{{.}}" data-id-selector="#ref_selector">{{.}}</div>

--- a/templates/repo/issue/choose.tmpl
+++ b/templates/repo/issue/choose.tmpl
@@ -14,7 +14,7 @@
 						<br/>{{.About | RenderEmojiPlain}}
 					</div>
 					<div class="column right aligned">
-						<a href="{{$.RepoLink}}/issues/new?template={{.FileName}}{{if $.milestone}}&milestone={{$.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui green button">{{$.i18n.Tr "repo.issues.choose.get_started"}}</a>
+						<a href="{{$.RepoLink}}/issues/new?template={{.FileName}}{{if $.milestone}}&milestone={{$.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui green button">{{$.locale.Tr "repo.issues.choose.get_started"}}</a>
 					</div>
 				</div>
 			</div>
@@ -22,11 +22,11 @@
 		<div class="ui attached segment">
 			<div class="ui two column grid">
 				<div class="column left aligned">
-					<strong>{{.i18n.Tr "repo.issues.choose.blank"}}</strong>
-					<br/>{{.i18n.Tr "repo.issues.choose.blank_about"}}
+					<strong>{{.locale.Tr "repo.issues.choose.blank"}}</strong>
+					<br/>{{.locale.Tr "repo.issues.choose.blank_about"}}
 				</div>
 				<div class="column right aligned">
-					<a href="{{.RepoLink}}/issues/new?{{if .milestone}}&milestone={{.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui green button">{{$.i18n.Tr "repo.issues.choose.get_started"}}</a>
+					<a href="{{.RepoLink}}/issues/new?{{if .milestone}}&milestone={{.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui green button">{{$.locale.Tr "repo.issues.choose.get_started"}}</a>
 				</div>
 			</div>
 		</div>

--- a/templates/repo/issue/comment_tab.tmpl
+++ b/templates/repo/issue/comment_tab.tmpl
@@ -1,6 +1,6 @@
 <div class="ui top tabular menu" data-write="write" data-preview="preview">
-	<a class="active item" data-tab="write">{{.i18n.Tr "write"}}</a>
-	<a class="item" data-tab="preview" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}">{{.i18n.Tr "preview"}}</a>
+	<a class="active item" data-tab="write">{{.locale.Tr "write"}}</a>
+	<a class="item" data-tab="preview" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}">{{.locale.Tr "preview"}}</a>
 </div>
 <div class="field">
 	<div class="ui bottom active tab" data-tab="write">
@@ -9,7 +9,7 @@
 		</textarea>
 	</div>
 	<div class="ui bottom tab markup" data-tab="preview">
-		{{.i18n.Tr "loading"}}
+		{{.locale.Tr "loading"}}
 	</div>
 </div>
 {{if .IsAttachmentEnabled}}

--- a/templates/repo/issue/labels.tmpl
+++ b/templates/repo/issue/labels.tmpl
@@ -6,7 +6,7 @@
 			{{template "repo/issue/navbar" .}}
 			{{if and (or .CanWriteIssues .CanWritePulls) (not .Repository.IsArchived)}}
 				<div class="ui right">
-					<div class="ui green new-label button">{{.i18n.Tr "repo.issues.new_label"}}</div>
+					<div class="ui green new-label button">{{.locale.Tr "repo.issues.new_label"}}</div>
 				</div>
 			{{end}}
 		</div>

--- a/templates/repo/issue/labels/edit_delete_label.tmpl
+++ b/templates/repo/issue/labels/edit_delete_label.tmpl
@@ -1,26 +1,26 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.issues.label_deletion"}}
+		{{.locale.Tr "repo.issues.label_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.issues.label_deletion_desc"}}</p>
+		<p>{{.locale.Tr "repo.issues.label_deletion_desc"}}</p>
 	</div>
 	<div class="actions">
 		<div class="ui red basic inverted cancel button">
 			<i class="remove icon"></i>
-			{{.i18n.Tr "modal.no"}}
+			{{.locale.Tr "modal.no"}}
 		</div>
 		<div class="ui green basic inverted ok button">
 			<i class="checkmark icon"></i>
-			{{.i18n.Tr "modal.yes"}}
+			{{.locale.Tr "modal.yes"}}
 		</div>
 	</div>
 </div>
 
 <div class="ui small edit-label modal">
 	<div class="header">
-		{{.i18n.Tr "repo.issues.label_modify"}}
+		{{.locale.Tr "repo.issues.label_modify"}}
 	</div>
 	<div class="content">
 		<form class="ui edit-label form ignore-dirty" action="{{$.Link}}/edit" method="post">
@@ -29,12 +29,12 @@
 			<div class="ui grid">
 				<div class="three wide column">
 					<div class="ui small input">
-						<input class="new-label-input emoji-input" name="title" placeholder="{{.i18n.Tr "repo.issues.new_label_placeholder"}}" autofocus required maxlength="50">
+						<input class="new-label-input emoji-input" name="title" placeholder="{{.locale.Tr "repo.issues.new_label_placeholder"}}" autofocus required maxlength="50">
 					</div>
 				</div>
 				<div class="five wide column">
 					<div class="ui small fluid input">
-						<input class="new-label-desc-input" name="description" placeholder="{{.i18n.Tr "repo.issues.new_label_desc_placeholder"}}" maxlength="200">
+						<input class="new-label-desc-input" name="description" placeholder="{{.locale.Tr "repo.issues.new_label_desc_placeholder"}}" maxlength="200">
 					</div>
 				</div>
 				<div class="color picker column">
@@ -48,10 +48,10 @@
 	</div>
 	<div class="actions">
 		<div class="ui negative button">
-			{{.i18n.Tr "cancel"}}
+			{{.locale.Tr "cancel"}}
 		</div>
 		<div class="ui positive button">
-			{{.i18n.Tr "save"}}
+			{{.locale.Tr "save"}}
 		</div>
 	</div>
 </div>

--- a/templates/repo/issue/labels/label_list.tmpl
+++ b/templates/repo/issue/labels/label_list.tmpl
@@ -1,18 +1,18 @@
 <h4 class="ui top attached header">
-		{{.i18n.Tr "repo.issues.label_count" .NumLabels}}
+		{{.locale.Tr "repo.issues.label_count" .NumLabels}}
 		<div class="ui right">
 			<div class="ui right floated secondary filter menu">
 				<!-- Sort -->
 				<div class="ui dropdown type jump item">
 					<span class="text">
-						{{.i18n.Tr "repo.issues.filter_sort"}}
+						{{.locale.Tr "repo.issues.filter_sort"}}
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 					</span>
 					<div class="menu">
-						<a class="{{if or (eq .SortType "alphabetically") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&state={{$.State}}">{{.i18n.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
-						<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&state={{$.State}}">{{.i18n.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
-						<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?sort=leastissues&state={{$.State}}">{{.i18n.Tr "repo.milestones.filter_sort.least_issues"}}</a>
-						<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?sort=mostissues&state={{$.State}}">{{.i18n.Tr "repo.milestones.filter_sort.most_issues"}}</a>
+						<a class="{{if or (eq .SortType "alphabetically") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=alphabetically&state={{$.State}}">{{.locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</a>
+						<a class="{{if eq .SortType "reversealphabetically"}}active{{end}} item" href="{{$.Link}}?sort=reversealphabetically&state={{$.State}}">{{.locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</a>
+						<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?sort=leastissues&state={{$.State}}">{{.locale.Tr "repo.milestones.filter_sort.least_issues"}}</a>
+						<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?sort=mostissues&state={{$.State}}">{{.locale.Tr "repo.milestones.filter_sort.most_issues"}}</a>
 					</div>
 				</div>
 			</div>
@@ -40,18 +40,18 @@
 				</div>
 				<div class="three wide column">
 					{{if $.PageIsOrgSettingsLabels}}
-						<a class="ui right open-issues" href="{{AppSubUrl}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="{{AppSubUrl}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.locale.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{else}}
-						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
+						<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.locale.Tr "repo.issues.label_open_issues" .NumOpenIssues}}</a>
 					{{end}}
 				</div>
 				<div class="three wide column">
 					{{if and (not $.PageIsOrgSettingsLabels ) (not $.Repository.IsArchived) (or $.CanWriteIssues $.CanWritePulls)}}
-						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
-						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil"}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.locale.Tr "repo.issues.label_delete"}}</a>
+						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil"}} {{$.locale.Tr "repo.issues.label_edit"}}</a>
 					{{else if $.PageIsOrgSettingsLabels}}
-						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
-						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil"}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+						<a class="ui right delete-button" href="#" data-url="{{$.Link}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.locale.Tr "repo.issues.label_delete"}}</a>
+						<a class="ui right edit-label-button" href="#" data-id="{{.ID}}" data-title="{{.Name}}" data-description="{{.Description}}" data-color={{.Color}}>{{svg "octicon-pencil"}} {{$.locale.Tr "repo.issues.label_edit"}}</a>
 					{{end}}
 				</div>
 			</div>
@@ -61,9 +61,9 @@
 			<li class="item">
 				<div class="ui grid middle aligned">
 					<div class="ten wide column">
-						{{$.i18n.Tr "repo.org_labels_desc" | Str2html}}
+						{{$.locale.Tr "repo.org_labels_desc" | Str2html}}
 						{{if .IsOrganizationOwner}}
-							<a class="ui" href="{{.OrganizationLink}}/settings/labels">({{$.i18n.Tr "repo.org_labels_desc_manage"}})</a>:
+							<a class="ui" href="{{.OrganizationLink}}/settings/labels">({{$.locale.Tr "repo.org_labels_desc_manage"}})</a>:
 						{{end}}
 					</div>
 				</div>
@@ -82,7 +82,7 @@
 							</div>
 						</div>
 						<div class="three wide column">
-								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.i18n.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
+								<a class="ui right open-issues" href="{{$.RepoLink}}/issues?labels={{.ID}}">{{svg "octicon-issue-opened"}} {{$.locale.Tr "repo.issues.label_open_issues" .NumOpenRepoIssues}}</a>
 						</div>
 						<div class="three wide column">
 						</div>

--- a/templates/repo/issue/labels/label_load_template.tmpl
+++ b/templates/repo/issue/labels/label_load_template.tmpl
@@ -1,14 +1,14 @@
 <div class="ui centered grid">
 	<div class="twelve wide computer column">
 		<div class="ui attached left aligned segment">
-			<p>{{.i18n.Tr "repo.issues.label_templates.info"}}</p>
+			<p>{{.locale.Tr "repo.issues.label_templates.info"}}</p>
 			<br/>
 			<form class="ui form center" action="{{.Link}}/initialize" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="field">
 					<div class="ui selection dropdown">
 						<input type="hidden" name="template_name" value="Default">
-						<div class="default text">{{.i18n.Tr "repo.issues.label_templates.helper"}}</div>
+						<div class="default text">{{.locale.Tr "repo.issues.label_templates.helper"}}</div>
 						<div class="menu">
 							{{range $template, $labels := .LabelTemplates}}
 								<div class="item" data-value="{{$template}}">{{$template}}<br/><i>({{$labels}})</i></div>
@@ -17,7 +17,7 @@
 						{{svg "octicon-triangle-down" 18 "dropdown icon"}}
 					</div>
 				</div>
-				<button type="submit" class="ui primary button">{{.i18n.Tr "repo.issues.label_templates.use"}}</button>
+				<button type="submit" class="ui primary button">{{.locale.Tr "repo.issues.label_templates.use"}}</button>
 			</form>
 		</div>
 	</div>

--- a/templates/repo/issue/labels/label_new.tmpl
+++ b/templates/repo/issue/labels/label_new.tmpl
@@ -4,12 +4,12 @@
 		<div class="ui grid">
 			<div class="three wide column">
 				<div class="ui small input">
-					<input class="new-label-input emoji-input" name="title" placeholder="{{.i18n.Tr "repo.issues.new_label_placeholder"}}" autofocus required maxlength="50">
+					<input class="new-label-input emoji-input" name="title" placeholder="{{.locale.Tr "repo.issues.new_label_placeholder"}}" autofocus required maxlength="50">
 				</div>
 			</div>
 			<div class="three wide column">
 				<div class="ui small fluid input">
-					<input class="new-label-desc-input" name="description" placeholder="{{.i18n.Tr "repo.issues.new_label_desc_placeholder"}}" maxlength="200">
+					<input class="new-label-desc-input" name="description" placeholder="{{.locale.Tr "repo.issues.new_label_desc_placeholder"}}" maxlength="200">
 				</div>
 			</div>
 			<div class="color picker column">
@@ -19,8 +19,8 @@
 				{{template "repo/issue/label_precolors"}}
 			</div>
 			<div class="buttons">
-				<div class="ui secondary small basic cancel button">{{.i18n.Tr "repo.milestones.cancel"}}</div>
-				<button class="ui primary small button">{{.i18n.Tr "repo.issues.create_label"}}</button>
+				<div class="ui secondary small basic cancel button">{{.locale.Tr "repo.milestones.cancel"}}</div>
+				<button class="ui primary small button">{{.locale.Tr "repo.issues.create_label"}}</button>
 			</div>
 		</div>
 	</form>

--- a/templates/repo/issue/labels/labels_sidebar.tmpl
+++ b/templates/repo/issue/labels/labels_sidebar.tmpl
@@ -1,5 +1,5 @@
 <div class="ui labels list">
-	<span class="no-select item {{if .ctx.HasSelectedLabel}}hide{{end}}">{{.ctx.i18n.Tr "repo.issues.new.no_label"}}</span>
+	<span class="no-select item {{if .ctx.HasSelectedLabel}}hide{{end}}">{{.ctx.locale.Tr "repo.issues.new.no_label"}}</span>
 	<span class="labels-list">
 		{{range .ctx.Labels}}
 			{{template "repo/issue/labels/label" dict "root" $.root "label" .}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -12,15 +12,15 @@
 			{{if not .Repository.IsArchived}}
 				<div class="column right aligned">
 					{{if .PageIsIssueList}}
-						<a class="ui green button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}">{{.i18n.Tr "repo.issues.new"}}</a>
+						<a class="ui green button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}">{{.locale.Tr "repo.issues.new"}}</a>
 					{{else}}
-						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.Repository.Link}}/compare/{{.Repository.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.Repository.Link}}/compare/{{.Repository.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{.locale.Tr "repo.pulls.new"}}</a>
 					{{end}}
 				</div>
 			{{else}}
 				{{if not .PageIsIssueList}}
 					<div class="column right aligned">
-						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{$.i18n.Tr "action.compare_commits_general"}}</a>
+						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{$.locale.Tr "action.compare_commits_general"}}</a>
 					</div>
 				{{end}}
 			{{end}}
@@ -35,12 +35,12 @@
 					<!-- Label -->
 					<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item label-filter" style="margin-left: auto">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_label"}}
+							{{.locale.Tr "repo.issues.filter_label"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
-							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
+							<span class="info">{{.locale.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
 								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash"}}{{else if .IsSelected}}{{svg "octicon-check"}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
@@ -50,11 +50,11 @@
 					<!-- Milestone -->
 					<div class="ui {{if not .Milestones}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_milestone"}}
+							{{.locale.Tr "repo.issues.filter_milestone"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_milestone_no_select"}}</a>
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_milestone_no_select"}}</a>
 							{{range .Milestones}}
 								<a class="{{if $.MilestoneID}}{{if eq $.MilestoneID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{.ID}}&assignee={{$.AssigneeID}}">{{.Name}}</a>
 							{{end}}
@@ -64,11 +64,11 @@
 					<!-- Assignee -->
 					<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_assignee"}}
+							{{.locale.Tr "repo.issues.filter_assignee"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}">{{.i18n.Tr "repo.issues.filter_assginee_no_select"}}</a>
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}">{{.locale.Tr "repo.issues.filter_assginee_no_select"}}</a>
 							{{range .Assignees}}
 								<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{.ID}}">
 									{{avatar .}} {{.GetDisplayName}}
@@ -81,16 +81,16 @@
 						<!-- Type -->
 						<div class="ui dropdown type jump item">
 							<span class="text">
-								{{.i18n.Tr "repo.issues.filter_type"}}
+								{{.locale.Tr "repo.issues.filter_type"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							</span>
 							<div class="menu">
-								<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.all_issues"}}</a>
-								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
-								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
-								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
+								<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.all_issues"}}</a>
+								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
+								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.created_by_you"}}</a>
+								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.mentioning_you"}}</a>
 								{{if .PageIsPullList}}
-									<a class="{{if eq .ViewType "review_requested"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_requested&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.review_requested"}}</a>
+									<a class="{{if eq .ViewType "review_requested"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_requested&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.review_requested"}}</a>
 								{{end}}
 							</div>
 						</div>
@@ -99,18 +99,18 @@
 					<!-- Sort -->
 					<div class="ui dropdown type jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_sort"}}
+							{{.locale.Tr "repo.issues.filter_sort"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-							<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-							<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-							<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
-							<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.mostcomment"}}</a>
-							<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastcomment"}}</a>
-							<a class="{{if eq .SortType "nearduedate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=nearduedate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.nearduedate"}}</a>
-							<a class="{{if eq .SortType "farduedate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=farduedate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.farduedate"}}</a>
+							<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+							<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+							<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+							<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+							<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.mostcomment"}}</a>
+							<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.leastcomment"}}</a>
+							<a class="{{if eq .SortType "nearduedate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=nearduedate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.nearduedate"}}</a>
+							<a class="{{if eq .SortType "farduedate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=farduedate&state={{$.State}}&labels={{.SelectLabels}}&milestone={{$.MilestoneID}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.farduedate"}}</a>
 						</div>
 					</div>
 				</div>
@@ -129,14 +129,14 @@
 					{{if not .Repository.IsArchived}}
 					<!-- Action Button -->
 					{{if .IsShowClosed}}
-						<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.i18n.Tr "repo.issues.action_open"}}</div>
+						<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.locale.Tr "repo.issues.action_open"}}</div>
 					{{else}}
-						<div class="ui red active basic button issue-action" data-action="close" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.i18n.Tr "repo.issues.action_close"}}</div>
+						<div class="ui red active basic button issue-action" data-action="close" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.locale.Tr "repo.issues.action_close"}}</div>
 					{{end}}
 					<!-- Labels -->
 					<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.action_label"}}
+							{{.locale.Tr "repo.issues.action_label"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
@@ -151,12 +151,12 @@
 					<!-- Milestone -->
 					<div class="ui {{if not .Milestones}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.action_milestone"}}
+							{{.locale.Tr "repo.issues.action_milestone"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/milestone">
-							{{.i18n.Tr "repo.issues.action_milestone_no_select"}}
+							{{.locale.Tr "repo.issues.action_milestone_no_select"}}
 							</div>
 							{{range .Milestones}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/milestone">
@@ -169,12 +169,12 @@
 					<!-- Projects -->
 					<div class="ui {{if not .Projects}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.project_board"}}
+							{{.locale.Tr "repo.project_board"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/projects">
-							{{.i18n.Tr "repo.issues.new.no_projects"}}
+							{{.locale.Tr "repo.issues.new.no_projects"}}
 							</div>
 							{{range .Projects}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
@@ -187,12 +187,12 @@
 					<!-- Assignees -->
 					<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.action_assignee"}}
+							{{.locale.Tr "repo.issues.action_assignee"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/assignee">
-								{{.i18n.Tr "repo.issues.action_assignee_no_select"}}
+								{{.locale.Tr "repo.issues.action_assignee_no_select"}}
 							</div>
 							{{range .Assignees}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/assignee">

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -9,9 +9,9 @@
 			{{if not .Repository.IsArchived}}
 				<div class="column right aligned">
 					{{if or .CanWriteIssues .CanWritePulls}}
-						<a class="ui button" href="{{.RepoLink}}/milestones/{{.MilestoneID}}/edit">{{.i18n.Tr "repo.milestones.edit"}}</a>
+						<a class="ui button" href="{{.RepoLink}}/milestones/{{.MilestoneID}}/edit">{{.locale.Tr "repo.milestones.edit"}}</a>
 					{{end}}
-					<a class="ui primary button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}?milestone={{.MilestoneID}}">{{.i18n.Tr "repo.issues.new"}}</a>
+					<a class="ui primary button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}?milestone={{.MilestoneID}}">{{.locale.Tr "repo.issues.new"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -22,19 +22,19 @@
 		</div>
 		<div class="ui one column stackable grid">
 			<div class="column">
-				{{ $closedDate:= TimeSinceUnix .Milestone.ClosedDateUnix $.i18n }}
+				{{ $closedDate:= TimeSinceUnix .Milestone.ClosedDateUnix $.locale }}
 				{{if .IsClosed}}
-					{{svg "octicon-clock"}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+					{{svg "octicon-clock"}} {{$.locale.Tr "repo.milestones.closed" $closedDate|Str2html}}
 				{{else}}
 					{{svg "octicon-calendar"}}
 					{{if .Milestone.DeadlineString}}
 						<span {{if .IsOverdue}}class="overdue"{{end}}>{{.Milestone.DeadlineString}}</span>
 					{{else}}
-						{{$.i18n.Tr "repo.milestones.no_due_date"}}
+						{{$.locale.Tr "repo.milestones.no_due_date"}}
 					{{end}}
 				{{end}}
 				&nbsp;
-				<b>{{.i18n.Tr "repo.milestones.completeness" .Milestone.Completeness}}</b>
+				<b>{{.locale.Tr "repo.milestones.completeness" .Milestone.Completeness}}</b>
 			</div>
 		</div>
 		<div class="ui divider"></div>
@@ -47,12 +47,12 @@
 					<!-- Label -->
 					<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item label-filter" style="margin-left: auto">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_label"}}
+							{{.locale.Tr "repo.issues.filter_label"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<span class="info">{{.i18n.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
-							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_label_no_select"}}</a>
+							<span class="info">{{.locale.Tr "repo.issues.filter_label_exclude" | Safe}}</span>
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_label_no_select"}}</a>
 							{{range .Labels}}
 								<a class="item label-filter-item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&assignee={{$.AssigneeID}}" data-label-id="{{.ID}}">{{if .IsExcluded}}{{svg "octicon-circle-slash"}}{{else if contain $.SelLabelIDs .ID}}{{svg "octicon-check"}}{{end}}<span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}</a>
 							{{end}}
@@ -62,11 +62,11 @@
 					<!-- Assignee -->
 					<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_assignee"}}
+							{{.locale.Tr "repo.issues.filter_assignee"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}">{{.i18n.Tr "repo.issues.filter_assginee_no_select"}}</a>
+							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}">{{.locale.Tr "repo.issues.filter_assginee_no_select"}}</a>
 							{{range .Assignees}}
 								<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&assignee={{.ID}}">
 									{{avatar . 28 "mr-2"}}
@@ -80,15 +80,15 @@
 						<!-- Type -->
 						<div class="ui dropdown type jump item">
 							<span class="text">
-								{{.i18n.Tr "repo.issues.filter_type"}}
+								{{.locale.Tr "repo.issues.filter_type"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							</span>
 							<div class="menu">
-								<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.all_issues"}}</a>
-								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
-								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}</a>
-								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}</a>
-								<a class="{{if eq .ViewType "review_requested"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_requested&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_type.review_requested"}}</a>
+								<a class="{{if eq .ViewType "all"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=all&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.all_issues"}}</a>
+								<a class="{{if eq .ViewType "assigned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=assigned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.assigned_to_you"}}</a>
+								<a class="{{if eq .ViewType "created_by"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=created_by&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.created_by_you"}}</a>
+								<a class="{{if eq .ViewType "mentioned"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=mentioned&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.mentioning_you"}}</a>
+								<a class="{{if eq .ViewType "review_requested"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type=review_requested&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_type.review_requested"}}</a>
 							</div>
 						</div>
 					{{end}}
@@ -96,16 +96,16 @@
 					<!-- Sort -->
 					<div class="ui dropdown type jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.filter_sort"}}
+							{{.locale.Tr "repo.issues.filter_sort"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
-							<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-							<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-							<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-							<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
-							<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.mostcomment"}}</a>
-							<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.i18n.Tr "repo.issues.filter_sort.leastcomment"}}</a>
+							<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=latest&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+							<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=oldest&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+							<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=recentupdate&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+							<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastupdate&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+							<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=mostcomment&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.mostcomment"}}</a>
+							<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort=leastcomment&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}">{{.locale.Tr "repo.issues.filter_sort.leastcomment"}}</a>
 						</div>
 					</div>
 				</div>
@@ -124,14 +124,14 @@
 				<div class="ui secondary filter stackable menu">
 					<!-- Action Button -->
 					{{if .IsShowClosed}}
-						<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.i18n.Tr "repo.issues.action_open"}}</div>
+						<div class="ui green active basic button issue-action" data-action="open" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.locale.Tr "repo.issues.action_open"}}</div>
 					{{else}}
-						<div class="ui red active basic button issue-action" data-action="close" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.i18n.Tr "repo.issues.action_close"}}</div>
+						<div class="ui red active basic button issue-action" data-action="close" data-url="{{$.RepoLink}}/issues/status" style="margin-left: auto">{{.locale.Tr "repo.issues.action_close"}}</div>
 					{{end}}
 					<!-- Labels -->
 					<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.action_label"}}
+							{{.locale.Tr "repo.issues.action_label"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
@@ -146,12 +146,12 @@
 					<!-- Assignees -->
 					<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
 						<span class="text">
-							{{.i18n.Tr "repo.issues.action_assignee"}}
+							{{.locale.Tr "repo.issues.action_assignee"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						</span>
 						<div class="menu">
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/assignee">
-								{{.i18n.Tr "repo.issues.action_assignee_no_select"}}
+								{{.locale.Tr "repo.issues.action_assignee_no_select"}}
 							</div>
 							{{range .Assignees}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/assignee">

--- a/templates/repo/issue/milestone_new.tmpl
+++ b/templates/repo/issue/milestone_new.tmpl
@@ -6,18 +6,18 @@
 			{{template "repo/issue/navbar" .}}
 			{{if and (or .CanWriteIssues .CanWritePulls) .PageIsEditMilestone}}
 				<div class="ui right floated secondary menu">
-					<a class="ui green button" href="{{$.RepoLink}}/milestones/new">{{.i18n.Tr "repo.milestones.new"}}</a>
+					<a class="ui green button" href="{{$.RepoLink}}/milestones/new">{{.locale.Tr "repo.milestones.new"}}</a>
 				</div>
 			{{end}}
 		</div>
 		<div class="ui divider"></div>
 		<h2 class="ui dividing header">
 			{{if .PageIsEditMilestone}}
-				{{.i18n.Tr "repo.milestones.edit"}}
-				<div class="sub header">{{.i18n.Tr "repo.milestones.edit_subheader"}}</div>
+				{{.locale.Tr "repo.milestones.edit"}}
+				<div class="sub header">{{.locale.Tr "repo.milestones.edit_subheader"}}</div>
 			{{else}}
-				{{.i18n.Tr "repo.milestones.new"}}
-				<div class="sub header">{{.i18n.Tr "repo.milestones.new_subheader"}}</div>
+				{{.locale.Tr "repo.milestones.new"}}
+				<div class="sub header">{{.locale.Tr "repo.milestones.new_subheader"}}</div>
 			{{end}}
 		</h2>
 		{{template "base/alert" .}}
@@ -25,18 +25,18 @@
 			{{.CsrfTokenHtml}}
 			<div class="twelve wide column">
 				<div class="field {{if .Err_Title}}error{{end}}">
-					<label>{{.i18n.Tr "repo.milestones.title"}}</label>
-					<input name="title" placeholder="{{.i18n.Tr "repo.milestones.title"}}" value="{{.title}}" autofocus required maxlength="50">
+					<label>{{.locale.Tr "repo.milestones.title"}}</label>
+					<input name="title" placeholder="{{.locale.Tr "repo.milestones.title"}}" value="{{.title}}" autofocus required maxlength="50">
 				</div>
 				<div class="field {{if .Err_Deadline}}error{{end}}">
 					<label>
-						{{.i18n.Tr "repo.milestones.due_date"}}
-						<a id="clear-date">{{.i18n.Tr "repo.milestones.clear"}}</a>
+						{{.locale.Tr "repo.milestones.due_date"}}
+						<a id="clear-date">{{.locale.Tr "repo.milestones.clear"}}</a>
 					</label>
-					<input type="date" id="deadline" name="deadline" value="{{.deadline}}" placeholder="{{.i18n.Tr "repo.issues.due_date_form"}}">
+					<input type="date" id="deadline" name="deadline" value="{{.deadline}}" placeholder="{{.locale.Tr "repo.issues.due_date_form"}}">
 				</div>
 				<div class="field">
-					<label>{{.i18n.Tr "repo.milestones.desc"}}</label>
+					<label>{{.locale.Tr "repo.milestones.desc"}}</label>
 					<textarea name="content">{{.content}}</textarea>
 				</div>
 			</div>
@@ -45,14 +45,14 @@
 				<div class="ui right">
 					{{if .PageIsEditMilestone}}
 						<a class="ui primary basic button" href="{{.RepoLink}}/milestones">
-							{{.i18n.Tr "repo.milestones.cancel"}}
+							{{.locale.Tr "repo.milestones.cancel"}}
 						</a>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.milestones.modify"}}
+							{{.locale.Tr "repo.milestones.modify"}}
 						</button>
 					{{else}}
 						<button class="ui green button">
-							{{.i18n.Tr "repo.milestones.create"}}
+							{{.locale.Tr "repo.milestones.create"}}
 						</button>
 					{{end}}
 				</div>

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -6,7 +6,7 @@
 			{{template "repo/issue/navbar" .}}
 			{{if and (or .CanWriteIssues .CanWritePulls) (not .Repository.IsArchived)}}
 				<div class="ui right">
-					<a class="ui green button" href="{{$.Link}}/new">{{.i18n.Tr "repo.milestones.new"}}</a>
+					<a class="ui green button" href="{{$.Link}}/new">{{.locale.Tr "repo.milestones.new"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -18,11 +18,11 @@
 				<div class="ui compact tiny menu">
 					<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{.RepoLink}}/milestones?state=open&q={{$.Keyword}}">
 						{{svg "octicon-milestone" 16 "mr-3"}}
-						{{JsPrettyNumber .OpenCount}}&nbsp;{{.i18n.Tr "repo.issues.open_title"}}
+						{{JsPrettyNumber .OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 					</a>
 					<a class="item{{if .IsShowClosed}} active{{end}}" href="{{.RepoLink}}/milestones?state=closed&q={{$.Keyword}}">
 						{{svg "octicon-check" 16 "mr-3"}}
-						{{JsPrettyNumber .ClosedCount}}&nbsp;{{.i18n.Tr "repo.issues.closed_title"}}
+						{{JsPrettyNumber .ClosedCount}}&nbsp;{{.locale.Tr "repo.issues.closed_title"}}
 					</a>
 				</div>
 			</div>
@@ -32,8 +32,8 @@
 				<form class="ui form ignore-dirty">
 					<div class="ui search fluid action input">
 						<input type="hidden" name="state" value="{{$.State}}"/>
-						<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}...">
-						<button class="ui primary button" type="submit">{{.i18n.Tr "explore.search"}}</button>
+						<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}...">
+						<button class="ui primary button" type="submit">{{.locale.Tr "explore.search"}}</button>
 					</div>
 				</form>
 			</div>
@@ -42,16 +42,16 @@
 				<!-- Sort -->
 				<div class="ui dropdown type jump item">
 					<span class="text">
-						{{.i18n.Tr "repo.issues.filter_sort"}}
+						{{.locale.Tr "repo.issues.filter_sort"}}
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 					</span>
 					<div class="menu">
-						<a class="{{if or (eq .SortType "closestduedate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=closestduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.closest_due_date"}}</a>
-						<a class="{{if eq .SortType "furthestduedate"}}active{{end}} item" href="{{$.Link}}?sort=furthestduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.furthest_due_date"}}</a>
-						<a class="{{if eq .SortType "leastcomplete"}}active{{end}} item" href="{{$.Link}}?sort=leastcomplete&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.least_complete"}}</a>
-						<a class="{{if eq .SortType "mostcomplete"}}active{{end}} item" href="{{$.Link}}?sort=mostcomplete&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.most_complete"}}</a>
-						<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?sort=mostissues&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.most_issues"}}</a>
-						<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?sort=leastissues&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.least_issues"}}</a>
+						<a class="{{if or (eq .SortType "closestduedate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?sort=closestduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.closest_due_date"}}</a>
+						<a class="{{if eq .SortType "furthestduedate"}}active{{end}} item" href="{{$.Link}}?sort=furthestduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.furthest_due_date"}}</a>
+						<a class="{{if eq .SortType "leastcomplete"}}active{{end}} item" href="{{$.Link}}?sort=leastcomplete&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.least_complete"}}</a>
+						<a class="{{if eq .SortType "mostcomplete"}}active{{end}} item" href="{{$.Link}}?sort=mostcomplete&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.most_complete"}}</a>
+						<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?sort=mostissues&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.most_issues"}}</a>
+						<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?sort=leastissues&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.least_issues"}}</a>
 					</div>
 				</div>
 			</div>
@@ -71,35 +71,35 @@
 						</div>
 					</div>
 					<div class="meta">
-						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.i18n }}
+						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.locale }}
 						{{if .IsClosed}}
-							{{svg "octicon-clock"}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+							{{svg "octicon-clock"}} {{$.locale.Tr "repo.milestones.closed" $closedDate|Str2html}}
 						{{else}}
 							{{svg "octicon-calendar"}}
 							{{if .DeadlineString}}
 								<span {{if .IsOverdue}}class="overdue"{{end}}>{{.DeadlineString}}</span>
 							{{else}}
-								{{$.i18n.Tr "repo.milestones.no_due_date"}}
+								{{$.locale.Tr "repo.milestones.no_due_date"}}
 							{{end}}
 						{{end}}
 						<span class="issue-stats">
 							{{svg "octicon-issue-opened" 16 "mr-3"}}
-							{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.i18n.Tr "repo.issues.open_title"}}
+							{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
 							{{svg "octicon-check" 16 "mr-3"}}
-							{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.i18n.Tr "repo.issues.closed_title"}}
+							{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
 							{{if .TotalTrackedTime}}{{svg "octicon-clock"}} {{.TotalTrackedTime|Sec2Time}}{{end}}
-							{{if .UpdatedUnix}}{{svg "octicon-clock"}} {{$.i18n.Tr "repo.milestones.update_ago" (.TimeSinceUpdate|Sec2Time)}}{{end}}
+							{{if .UpdatedUnix}}{{svg "octicon-clock"}} {{$.locale.Tr "repo.milestones.update_ago" (.TimeSinceUpdate|Sec2Time)}}{{end}}
 						</span>
 					</div>
 					{{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}
 						<div class="ui right operate">
-							<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil"}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+							<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil"}} {{$.locale.Tr "repo.issues.label_edit"}}</a>
 							{{if .IsClosed}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check"}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check"}} {{$.locale.Tr "repo.milestones.open"}}</a>
 							{{else}}
-								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x"}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+								<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-x"}} {{$.locale.Tr "repo.milestones.close"}}</a>
 							{{end}}
-							<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+							<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.locale.Tr "repo.issues.label_delete"}}</a>
 						</div>
 					{{end}}
 					{{if .Content}}
@@ -119,19 +119,19 @@
 	<div class="ui small basic delete modal">
 		<div class="ui icon header">
 			{{svg "octicon-trash"}}
-			{{.i18n.Tr "repo.milestones.deletion"}}
+			{{.locale.Tr "repo.milestones.deletion"}}
 		</div>
 		<div class="content">
-			<p>{{.i18n.Tr "repo.milestones.deletion_desc"}}</p>
+			<p>{{.locale.Tr "repo.milestones.deletion_desc"}}</p>
 		</div>
 		<div class="actions">
 			<div class="ui red basic inverted cancel button">
 				<i class="remove icon"></i>
-				{{.i18n.Tr "modal.no"}}
+				{{.locale.Tr "modal.no"}}
 			</div>
 			<div class="ui green basic inverted ok button">
 				<i class="checkmark icon"></i>
-				{{.i18n.Tr "modal.yes"}}
+				{{.locale.Tr "modal.yes"}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/issue/navbar.tmpl
+++ b/templates/repo/issue/navbar.tmpl
@@ -1,4 +1,4 @@
 <div class="ui compact left small menu">
-	<a class="{{if .PageIsLabels}}active{{end}} item" href="{{.RepoLink}}/labels">{{.i18n.Tr "repo.labels"}}</a>
-	<a class="{{if .PageIsMilestones}}active{{end}} item" href="{{.RepoLink}}/milestones">{{.i18n.Tr "repo.milestones"}}</a>
+	<a class="{{if .PageIsLabels}}active{{end}} item" href="{{.RepoLink}}/labels">{{.locale.Tr "repo.labels"}}</a>
+	<a class="{{if .PageIsMilestones}}active{{end}} item" href="{{.RepoLink}}/milestones">{{.locale.Tr "repo.milestones"}}</a>
 </div>

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -13,18 +13,18 @@
 				</a>
 				<div class="ui segment content">
 					<div class="field">
-						<input name="title" id="issue_title" placeholder="{{.i18n.Tr "repo.milestones.title"}}" value="{{if .TitleQuery}}{{.TitleQuery}}{{else if .IssueTemplateTitle}}{{.IssueTemplateTitle}}{{else}}{{.title}}{{end}}" tabindex="3" autofocus required maxlength="255" autocomplete="off">
+						<input name="title" id="issue_title" placeholder="{{.locale.Tr "repo.milestones.title"}}" value="{{if .TitleQuery}}{{.TitleQuery}}{{else if .IssueTemplateTitle}}{{.IssueTemplateTitle}}{{else}}{{.title}}{{end}}" tabindex="3" autofocus required maxlength="255" autocomplete="off">
 						{{if .PageIsComparePull}}
-							<div class="title_wip_desc" data-wip-prefixes="{{Json .PullRequestWorkInProgressPrefixes}}">{{.i18n.Tr "repo.pulls.title_wip_desc" (index .PullRequestWorkInProgressPrefixes 0| Escape) | Safe}}</div>
+							<div class="title_wip_desc" data-wip-prefixes="{{Json .PullRequestWorkInProgressPrefixes}}">{{.locale.Tr "repo.pulls.title_wip_desc" (index .PullRequestWorkInProgressPrefixes 0| Escape) | Safe}}</div>
 						{{end}}
 					</div>
 					{{template "repo/issue/comment_tab" .}}
 					<div class="text right">
 						<button class="ui green button loading-button" tabindex="6">
 							{{if .PageIsComparePull}}
-								{{.i18n.Tr "repo.pulls.create"}}
+								{{.locale.Tr "repo.pulls.create"}}
 							{{else}}
-								{{.i18n.Tr "repo.issues.create"}}
+								{{.locale.Tr "repo.issues.create"}}
 							{{end}}
 						</button>
 					</div>
@@ -40,20 +40,20 @@
 			<input id="label_ids" name="label_ids" type="hidden" value="{{.label_ids}}">
 			<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating jump select-label dropdown">
 				<span class="text">
-					<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
+					<strong>{{.locale.Tr "repo.issues.new.labels"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
 						{{svg "octicon-gear"}}
 					{{end}}
 				</span>
 				<div class="filter menu" data-id="#label_ids">
-					<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_labels_title"}}</div>
+					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_labels_title"}}</div>
 					{{if or .Labels .OrgLabels}}
 					<div class="ui icon search input">
 						<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-						<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_labels"}}">
+						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_labels"}}">
 					</div>
 					{{end}}
-					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
+					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_labels"}}</div>
 					{{if or .Labels .OrgLabels}}
 						{{range .Labels}}
 							<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check"}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
@@ -66,7 +66,7 @@
 							{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 						{{end}}
 					{{else}}
-						<div class="header" style="text-transform: none;font-size:14px;">{{.i18n.Tr "repo.issues.new.no_items"}}</div>
+						<div class="header" style="text-transform: none;font-size:14px;">{{.locale.Tr "repo.issues.new.no_items"}}</div>
 					{{end}}
 				</div>
 			</div>
@@ -77,29 +77,29 @@
 			<input id="milestone_id" name="milestone_id" type="hidden" value="{{.milestone_id}}">
 			<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating jump select-milestone dropdown">
 				<span class="text">
-					<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
+					<strong>{{.locale.Tr "repo.issues.new.milestone"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
 						{{svg "octicon-gear"}}
 					{{end}}
 				</span>
 				<div class="menu">
-					<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_milestone_title"}}</div>
+					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_milestone_title"}}</div>
 					{{if or .OpenMilestones .ClosedMilestones}}
 					<div class="ui icon search input">
 						<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-						<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_milestones"}}">
+						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_milestones"}}">
 					</div>
 					{{end}}
-					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_milestone"}}</div>
+					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_milestone"}}</div>
 					{{if and (not .OpenMilestones) (not .ClosedMilestones)}}
 						<div class="header" style="text-transform: none;font-size:14px;">
-							{{.i18n.Tr "repo.issues.new.no_items"}}
+							{{.locale.Tr "repo.issues.new.no_items"}}
 						</div>
 					{{else}}
 						{{if .OpenMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{.i18n.Tr "repo.issues.new.open_milestone"}}
+								{{.locale.Tr "repo.issues.new.open_milestone"}}
 							</div>
 							{{range .OpenMilestones}}
 								<a class="item" data-id="{{.ID}}" data-href="{{$.RepoLink}}/issues?milestone={{.ID}}">
@@ -111,7 +111,7 @@
 						{{if .ClosedMilestones}}
 							<div class="divider"></div>
 							<div class="header">
-								{{.i18n.Tr "repo.issues.new.closed_milestone"}}
+								{{.locale.Tr "repo.issues.new.closed_milestone"}}
 							</div>
 							{{range .ClosedMilestones}}
 								<a class="item" data-id="{{.ID}}" data-href="{{$.RepoLink}}/issues?milestone={{.ID}}">
@@ -124,7 +124,7 @@
 				</div>
 			</div>
 			<div class="ui select-milestone list">
-				<span class="no-select item {{if .Milestone}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_milestone"}}</span>
+				<span class="no-select item {{if .Milestone}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_milestone"}}</span>
 				<div class="selected">
 					{{if .Milestone}}
 						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/issues?milestone={{.Milestone.ID}}">
@@ -141,29 +141,29 @@
 			<input id="project_id" name="project_id" type="hidden" value="{{.project_id}}">
 			<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating jump select-project dropdown">
 				<span class="text">
-					<strong>{{.i18n.Tr "repo.issues.new.projects"}}</strong>
+					<strong>{{.locale.Tr "repo.issues.new.projects"}}</strong>
 					{{if .HasIssuesOrPullsWritePermission}}
 						{{svg "octicon-gear"}}
 					{{end}}
 				</span>
 				<div class="menu">
-					<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_project_title"}}</div>
+					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_project_title"}}</div>
 					{{if or .OpenProjects .ClosedProjects}}
 					<div class="ui icon search input">
 						<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-						<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_projects"}}">
+						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_projects"}}">
 					</div>
 					{{end}}
-					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_projects"}}</div>
+					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
 					{{if and (not .OpenProjects) (not .ClosedProjects)}}
 						<div class="header" style="text-transform: none;font-size:14px;">
-							{{.i18n.Tr "repo.issues.new.no_items"}}
+							{{.locale.Tr "repo.issues.new.no_items"}}
 						</div>
 					{{else}}
 						{{if .OpenProjects}}
 							<div class="divider"></div>
 							<div class="header">
-								{{.i18n.Tr "repo.issues.new.open_projects"}}
+								{{.locale.Tr "repo.issues.new.open_projects"}}
 							</div>
 							{{range .OpenProjects}}
 								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
@@ -175,7 +175,7 @@
 						{{if .ClosedProjects}}
 							<div class="divider"></div>
 							<div class="header">
-								{{.i18n.Tr "repo.issues.new.closed_projects"}}
+								{{.locale.Tr "repo.issues.new.closed_projects"}}
 							</div>
 							{{range .ClosedProjects}}
 								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
@@ -188,7 +188,7 @@
 				</div>
 			</div>
 			<div class="ui select-project list">
-				<span class="no-select item {{if .Project}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_projects"}}</span>
+				<span class="no-select item {{if .Project}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_projects"}}</span>
 				<div class="selected">
 					{{if .Project}}
 						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/projects/{{.Project.ID}}">
@@ -203,18 +203,18 @@
 				<input id="assignee_ids" name="assignee_ids" type="hidden" value="{{.assignee_ids}}">
 				<div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating jump select-assignees dropdown">
 					<span class="text">
-						<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
+						<strong>{{.locale.Tr "repo.issues.new.assignees"}}</strong>
 						{{if .HasIssuesOrPullsWritePermission}}
 							{{svg "octicon-gear"}}
 						{{end}}
 					</span>
 					<div class="filter menu" data-id="#assignee_ids">
-						<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_assignees_title"}}</div>
+						<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_assignees_title"}}</div>
 						<div class="ui icon search input">
 							<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-							<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_assignees"}}">
+							<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_assignees"}}">
 						</div>
-						<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignees"}}</div>
+						<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_assignees"}}</div>
 						{{range .Assignees}}
 							<a class="item muted" href="#" data-id="{{.ID}}" data-id-selector="#assignee_{{.ID}}">
 								<span class="octicon-check invisible">{{svg "octicon-check"}}</span>
@@ -227,7 +227,7 @@
 				</div>
 				<div class="ui assignees list">
 					<span class="no-select item {{if .HasSelectedLabel}}hide{{end}}">
-						{{.i18n.Tr "repo.issues.new.no_assignees"}}
+						{{.locale.Tr "repo.issues.new.no_assignees"}}
 					</span>
 					{{range .Assignees}}
 						<a class="hide item p-2 muted" id="assignee_{{.ID}}" href="{{$.RepoLink}}/issues?assignee={{.ID}}">
@@ -239,7 +239,7 @@
 				<div class="ui divider"></div>
 				<div class="inline field">
 					<div class="ui checkbox">
-						<label class="tooltip" data-content="{{.i18n.Tr "repo.pulls.allow_edits_from_maintainers_desc"}}"><strong>{{.i18n.Tr "repo.pulls.allow_edits_from_maintainers"}}</strong></label>
+						<label class="tooltip" data-content="{{.locale.Tr "repo.pulls.allow_edits_from_maintainers_desc"}}"><strong>{{.locale.Tr "repo.pulls.allow_edits_from_maintainers"}}</strong></label>
 						<input name="allow_maintainer_edit" type="checkbox">
 					</div>
 				</div>

--- a/templates/repo/issue/openclose.tmpl
+++ b/templates/repo/issue/openclose.tmpl
@@ -5,10 +5,10 @@
 		{{else}}
 			{{svg "octicon-issue-opened" 16 "mr-3"}}
 		{{end}}
-		{{JsPrettyNumber .IssueStats.OpenCount}}&nbsp;{{.i18n.Tr "repo.issues.open_title"}}
+		{{JsPrettyNumber .IssueStats.OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 	</a>
 	<a class="{{if .IsShowClosed}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&type={{.ViewType}}&sort={{$.SortType}}&state=closed&labels={{.SelectLabels}}&milestone={{.MilestoneID}}&assignee={{.AssigneeID}}">
 		{{svg "octicon-check" 16 "mr-3"}}
-		{{JsPrettyNumber .IssueStats.ClosedCount}}&nbsp;{{.i18n.Tr "repo.issues.closed_title"}}
+		{{JsPrettyNumber .IssueStats.ClosedCount}}&nbsp;{{.locale.Tr "repo.issues.closed_title"}}
 	</a>
 </div>

--- a/templates/repo/issue/search.tmpl
+++ b/templates/repo/issue/search.tmpl
@@ -5,7 +5,7 @@
 		<input type="hidden" name="labels" value="{{.SelectLabels}}"/>
 		<input type="hidden" name="milestone" value="{{$.MilestoneID}}"/>
 		<input type="hidden" name="assignee" value="{{$.AssigneeID}}"/>
-		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}...">
-		<button class="ui primary button" type="submit">{{.i18n.Tr "explore.search"}}</button>
+		<input name="q" value="{{.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}...">
+		<button class="ui primary button" type="submit">{{.locale.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/repo/issue/view.tmpl
+++ b/templates/repo/issue/view.tmpl
@@ -9,9 +9,9 @@
 			{{if and (not .Repository.IsArchived) (not .Issue.IsPull)}}
 				<div class="column right aligned">
 					{{if .PageIsIssueList}}
-						<a class="ui green button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}">{{.i18n.Tr "repo.issues.new"}}</a>
+						<a class="ui green button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}">{{.locale.Tr "repo.issues.new"}}</a>
 					{{else}}
-						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.locale.Tr "repo.pulls.new"}}</a>
 					{{end}}
 				</div>
 			{{end}}

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -15,7 +15,7 @@
 	<input type="hidden" id="issueIndex" value="{{.Issue.Index}}"/>
 	<input type="hidden" id="type" value="{{.IssueType}}">
 
-	{{ $createdStr:= TimeSinceUnix .Issue.CreatedUnix $.i18n }}
+	{{ $createdStr:= TimeSinceUnix .Issue.CreatedUnix $.locale }}
 	<div class="twelve wide column comment-list prevent-before-timeline">
 		<ui class="ui timeline">
 			<div id="{{.Issue.HashTag}}" class="timeline-item comment first">
@@ -35,10 +35,10 @@
 									{{ .Issue.OriginalAuthor }}
 								</span>
 								<span class="text grey">
-									{{ .i18n.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe }}
+									{{ .locale.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe }}
 								</span>
 								<span class="text migrate">
-									{{if .Repository.OriginalURL}} ({{$.i18n.Tr "repo.migrated_from" (.Repository.OriginalURL|Escape) (.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}
+									{{if .Repository.OriginalURL}} ({{$.locale.Tr "repo.migrated_from" (.Repository.OriginalURL|Escape) (.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}
 								</span>
 							{{else}}
 								<a class="inline-timeline-avatar" href="{{.Issue.Poster.HomeLink}}">
@@ -46,7 +46,7 @@
 								</a>
 								<span class="text grey">
 									<a class="author"{{if gt .Issue.Poster.ID 0}} href="{{.Issue.Poster.HomeLink}}"{{end}}>{{.Issue.Poster.GetDisplayName}}</a>
-									{{.i18n.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe}}
+									{{.locale.Tr "repo.issues.commented_at" (.Issue.HashTag|Escape) $createdStr | Safe}}
 								</span>
 							{{end}}
 						</div>
@@ -54,12 +54,12 @@
 							{{if gt .Issue.ShowRole 0}}
 								{{if (.Issue.ShowRole.HasRole "Writer")}}
 									<div class="ui basic label role-label">
-										{{$.i18n.Tr "repo.issues.collaborator"}}
+										{{$.locale.Tr "repo.issues.collaborator"}}
 									</div>
 								{{end}}
 								{{if (.Issue.ShowRole.HasRole "Owner")}}
 									<div class="ui basic label role-label">
-										{{$.i18n.Tr "repo.issues.owner"}}
+										{{$.locale.Tr "repo.issues.owner"}}
 									</div>
 								{{end}}
 							{{end}}
@@ -74,7 +74,7 @@
 							{{if .Issue.RenderedContent}}
 								{{.Issue.RenderedContent|Str2html}}
 							{{else}}
-								<span class="no-content">{{.i18n.Tr "repo.issues.no_content"}}</span>
+								<span class="no-content">{{.locale.Tr "repo.issues.no_content"}}</span>
 							{{end}}
 						</div>
 						<div id="comment-{{.Issue.ID}}" class="raw-content hide">{{.Issue.Content}}</div>
@@ -112,17 +112,17 @@
 								<div class="text right">
 									{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .DisableStatusChange)}}
 										{{if .Issue.IsClosed}}
-											<div id="status-button" class="ui green basic button" tabindex="6" data-status="{{.i18n.Tr "repo.issues.reopen_issue"}}" data-status-and-comment="{{.i18n.Tr "repo.issues.reopen_comment_issue"}}" data-status-val="reopen">
-												{{.i18n.Tr "repo.issues.reopen_issue"}}
+											<div id="status-button" class="ui green basic button" tabindex="6" data-status="{{.locale.Tr "repo.issues.reopen_issue"}}" data-status-and-comment="{{.locale.Tr "repo.issues.reopen_comment_issue"}}" data-status-val="reopen">
+												{{.locale.Tr "repo.issues.reopen_issue"}}
 											</div>
 										{{else}}
-											<div id="status-button" class="ui red basic button" tabindex="6" data-status="{{.i18n.Tr "repo.issues.close_issue"}}" data-status-and-comment="{{.i18n.Tr "repo.issues.close_comment_issue"}}" data-status-val="close">
-												{{.i18n.Tr "repo.issues.close_issue"}}
+											<div id="status-button" class="ui red basic button" tabindex="6" data-status="{{.locale.Tr "repo.issues.close_issue"}}" data-status-and-comment="{{.locale.Tr "repo.issues.close_comment_issue"}}" data-status-val="close">
+												{{.locale.Tr "repo.issues.close_issue"}}
 											</div>
 										{{end}}
 									{{end}}
 									<button class="ui green button loading-button" tabindex="5">
-										{{.i18n.Tr "repo.issues.create_comment"}}
+										{{.locale.Tr "repo.issues.create_comment"}}
 									</button>
 								</div>
 							</div>
@@ -132,9 +132,9 @@
 				{{ else if .Repository.IsArchived }}
 					<div class="ui warning message">
 						{{if .Issue.IsPull}}
-							{{.i18n.Tr "repo.archive.pull.nocomment"}}
+							{{.locale.Tr "repo.archive.pull.nocomment"}}
 						{{else}}
-							{{.i18n.Tr "repo.archive.issue.nocomment"}}
+							{{.locale.Tr "repo.archive.issue.nocomment"}}
 						{{end}}
 					</div>
 				{{ end }}
@@ -142,9 +142,9 @@
 			{{if .Repository.IsArchived}}
 				<div class="ui warning message">
 					{{if .Issue.IsPull}}
-						{{.i18n.Tr "repo.archive.pull.nocomment"}}
+						{{.locale.Tr "repo.archive.pull.nocomment"}}
 					{{else}}
-						{{.i18n.Tr "repo.archive.issue.nocomment"}}
+						{{.locale.Tr "repo.archive.issue.nocomment"}}
 					{{end}}
 				</div>
 			{{else}}
@@ -163,17 +163,17 @@
 									<div class="text right">
 										{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .DisableStatusChange)}}
 											{{if .Issue.IsClosed}}
-												<div id="status-button" class="ui green basic button" tabindex="6" data-status="{{.i18n.Tr "repo.issues.reopen_issue"}}" data-status-and-comment="{{.i18n.Tr "repo.issues.reopen_comment_issue"}}" data-status-val="reopen">
-													{{.i18n.Tr "repo.issues.reopen_issue"}}
+												<div id="status-button" class="ui green basic button" tabindex="6" data-status="{{.locale.Tr "repo.issues.reopen_issue"}}" data-status-and-comment="{{.locale.Tr "repo.issues.reopen_comment_issue"}}" data-status-val="reopen">
+													{{.locale.Tr "repo.issues.reopen_issue"}}
 												</div>
 											{{else}}
-												<div id="status-button" class="ui red basic button" tabindex="6" data-status="{{.i18n.Tr "repo.issues.close_issue"}}" data-status-and-comment="{{.i18n.Tr "repo.issues.close_comment_issue"}}" data-status-val="close">
-													{{.i18n.Tr "repo.issues.close_issue"}}
+												<div id="status-button" class="ui red basic button" tabindex="6" data-status="{{.locale.Tr "repo.issues.close_issue"}}" data-status-and-comment="{{.locale.Tr "repo.issues.close_comment_issue"}}" data-status-val="close">
+													{{.locale.Tr "repo.issues.close_issue"}}
 												</div>
 											{{end}}
 										{{end}}
 										<button class="ui green button loading-button" tabindex="5">
-											{{.i18n.Tr "repo.issues.create_comment"}}
+											{{.locale.Tr "repo.issues.create_comment"}}
 										</button>
 									</div>
 								</div>
@@ -183,7 +183,7 @@
 					{{end}}
 				{{else}}
 					<div class="ui warning message">
-						{{.i18n.Tr "repo.issues.sign_in_require_desc" (.SignInLink|Escape) | Safe}}
+						{{.locale.Tr "repo.issues.sign_in_require_desc" (.SignInLink|Escape) | Safe}}
 					</div>
 				{{end}}
 			{{end}}
@@ -197,15 +197,15 @@
 <div class="hide" id="edit-content-form">
 	<div class="ui comment form">
 		<div class="ui top tabular menu">
-			<a class="active write item">{{$.i18n.Tr "write"}}</a>
-			<a class="preview item" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "preview"}}</a>
+			<a class="active write item">{{$.locale.Tr "write"}}</a>
+			<a class="preview item" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.locale.Tr "preview"}}</a>
 		</div>
 		<div class="field">
 			<div class="ui bottom active tab write">
 				<textarea tabindex="1" name="content" class="js-quick-submit"></textarea>
 			</div>
 			<div class="ui bottom tab preview markup">
-				{{$.i18n.Tr "loading"}}
+				{{$.locale.Tr "loading"}}
 			</div>
 		</div>
 		{{if .IsAttachmentEnabled}}
@@ -215,8 +215,8 @@
 		{{end}}
 		<div class="field footer">
 			<div class="text right edit">
-				<div class="ui basic secondary cancel button" tabindex="3">{{.i18n.Tr "repo.issues.cancel"}}</div>
-				<div class="ui primary save button" tabindex="2">{{.i18n.Tr "repo.issues.save"}}</div>
+				<div class="ui basic secondary cancel button" tabindex="3">{{.locale.Tr "repo.issues.cancel"}}</div>
+				<div class="ui primary save button" tabindex="2">{{.locale.Tr "repo.issues.save"}}</div>
 			</div>
 		</div>
 	</div>
@@ -225,16 +225,16 @@
 {{template "repo/issue/view_content/reference_issue_dialog" .}}
 
 <div class="hide" id="no-content">
-	<span class="no-content">{{.i18n.Tr "repo.issues.no_content"}}</span>
+	<span class="no-content">{{.locale.Tr "repo.issues.no_content"}}</span>
 </div>
 
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.branch.delete" .HeadTarget }}
+		{{.locale.Tr "repo.branch.delete" .HeadTarget }}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.branch.delete_desc" | Str2html}}</p>
+		<p>{{.locale.Tr "repo.branch.delete_desc" | Str2html}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/repo/issue/view_content/add_reaction.tmpl
+++ b/templates/repo/issue/view_content/add_reaction.tmpl
@@ -4,7 +4,7 @@
 		{{svg "octicon-smiley"}}
 	</a>
 	<div class="menu">
-		<div class="header">{{ .ctx.i18n.Tr "repo.pick_reaction"}}</div>
+		<div class="header">{{ .ctx.locale.Tr "repo.pick_reaction"}}</div>
 		<div class="divider"></div>
 		{{range $value := AllowedReactions}}
 			<div class="item reaction" data-content="{{$value}}">{{ReactionToEmoji $value}}</div>

--- a/templates/repo/issue/view_content/attachments.tmpl
+++ b/templates/repo/issue/view_content/attachments.tmpl
@@ -6,7 +6,7 @@
 		{{$hasThumbnails := false}}
 		{{- range .Attachments -}}
 			<div class="twelve wide column" style="padding: 6px;">
-				<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
+				<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}" title='{{$.ctx.locale.Tr "repo.issues.attachment.open_tab" .Name}}'>
 					{{if FilenameIsImage .Name}}
 						{{if not (containGeneric $.Content .UUID)}}
 							{{$hasThumbnails = true}}
@@ -31,7 +31,7 @@
 				{{if FilenameIsImage .Name}}
 					{{if not (containGeneric $.Content .UUID)}}
 					<a target="_blank" rel="noopener noreferrer" href="{{.DownloadURL}}">
-						<img class="ui image" src="{{.DownloadURL}}" title='{{$.ctx.i18n.Tr "repo.issues.attachment.open_tab" .Name}}'>
+						<img class="ui image" src="{{.DownloadURL}}" title='{{$.ctx.locale.Tr "repo.issues.attachment.open_tab" .Name}}'>
 					</a>
 					{{end}}
 				{{end}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -1,7 +1,7 @@
 {{ template "base/alert" }}
 {{range .Issue.Comments}}
 	{{if call $.ShouldShowCommentType .Type}}
-		{{ $createdStr:= TimeSinceUnix .CreatedUnix $.i18n }}
+		{{ $createdStr:= TimeSinceUnix .CreatedUnix $.locale }}
 
 		<!-- 0 = COMMENT, 1 = REOPEN, 2 = CLOSE, 3 = ISSUE_REF, 4 = COMMIT_REF,
 		5 = COMMENT_REF, 6 = PULL_REF, 7 = COMMENT_LABEL, 12 = START_TRACKING,
@@ -30,10 +30,10 @@
 									{{ .OriginalAuthor }}
 								</span>
 								<span class="text grey">
-									{{$.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
+									{{$.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}} {{if $.Repository.OriginalURL}}
 								</span>
 								<span class="text migrate">
-									({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}
+									({{$.locale.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}
 								</span>
 							{{else}}
 								{{if gt .Poster.ID 0}}
@@ -45,24 +45,24 @@
 									<a class="author"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
 										{{.Poster.GetDisplayName}}
 									</a>
-									{{$.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
 								</span>
 							{{end}}
 						</div>
 						<div class="comment-header-right actions df ac">
 							{{if (.ShowRole.HasRole "Poster")}}
 								<div class="ui basic label">
-									{{$.i18n.Tr "repo.issues.poster"}}
+									{{$.locale.Tr "repo.issues.poster"}}
 								</div>
 							{{end}}
 							{{if (.ShowRole.HasRole "Writer")}}
 								<div class="ui basic label">
-									{{$.i18n.Tr "repo.issues.collaborator"}}
+									{{$.locale.Tr "repo.issues.collaborator"}}
 								</div>
 							{{end}}
 							{{if (.ShowRole.HasRole "Owner")}}
 								<div class="ui basic label">
-									{{$.i18n.Tr "repo.issues.owner"}}
+									{{$.locale.Tr "repo.issues.owner"}}
 								</div>
 							{{end}}
 							{{if not $.Repository.IsArchived}}
@@ -76,7 +76,7 @@
 							{{if .RenderedContent}}
 								{{.RenderedContent|Str2html}}
 							{{else}}
-								<span class="no-content">{{$.i18n.Tr "repo.issues.no_content"}}</span>
+								<span class="no-content">{{$.locale.Tr "repo.issues.no_content"}}</span>
 							{{end}}
 						</div>
 						<div id="comment-{{.ID}}" class="raw-content hide">{{.Content}}</div>
@@ -102,9 +102,9 @@
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{if .Issue.IsPull }}
-						{{$.i18n.Tr "repo.pulls.reopened_at" .EventTag $createdStr | Safe}}
+						{{$.locale.Tr "repo.pulls.reopened_at" .EventTag $createdStr | Safe}}
 					{{else}}
-						{{$.i18n.Tr "repo.issues.reopened_at" .EventTag $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.reopened_at" .EventTag $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>
@@ -117,9 +117,9 @@
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{if .Issue.IsPull }}
-						{{$.i18n.Tr "repo.pulls.closed_at" .EventTag $createdStr | Safe}}
+						{{$.locale.Tr "repo.pulls.closed_at" .EventTag $createdStr | Safe}}
 					{{else}}
-						{{$.i18n.Tr "repo.issues.closed_at" .EventTag $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.closed_at" .EventTag $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>
@@ -133,16 +133,16 @@
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{$link := printf "%s/commit/%s" $.Repository.HTMLURL ($.Issue.PullRequest.MergedCommitID|PathEscape)}}
 					{{if eq $.Issue.PullRequest.Status 3}}
-						{{$.i18n.Tr "repo.issues.manually_pull_merged_at" ($link|Escape) (ShortSha $.Issue.PullRequest.MergedCommitID) ($.BaseTarget|Escape) $createdStr | Str2html}}
+						{{$.locale.Tr "repo.issues.manually_pull_merged_at" ($link|Escape) (ShortSha $.Issue.PullRequest.MergedCommitID) ($.BaseTarget|Escape) $createdStr | Str2html}}
 					{{else}}
-						{{$.i18n.Tr "repo.issues.pull_merged_at" ($link|Escape) (ShortSha $.Issue.PullRequest.MergedCommitID) ($.BaseTarget|Escape) $createdStr | Str2html}}
+						{{$.locale.Tr "repo.issues.pull_merged_at" ($link|Escape) (ShortSha $.Issue.PullRequest.MergedCommitID) ($.BaseTarget|Escape) $createdStr | Str2html}}
 					{{end}}
 				</span>
 			</div>
 		{{else if eq .Type 3 5 6}}
 			{{ $refFrom:= "" }}
 			{{if ne .RefRepoID .Issue.RepoID}}
-				{{ $refFrom = $.i18n.Tr "repo.issues.ref_from" (.RefRepo.FullName|Escape) }}
+				{{ $refFrom = $.locale.Tr "repo.issues.ref_from" (.RefRepo.FullName|Escape) }}
 			{{end}}
 			{{ $refTr := "repo.issues.ref_issue_from" }}
 			{{if .Issue.IsPull}}
@@ -152,7 +152,7 @@
 			{{else if eq .RefAction 2 }}
 				{{ $refTr = "repo.issues.ref_reopening_from" }}
 			{{end}}
-			{{ $createdStr:= TimeSinceUnix .CreatedUnix $.i18n }}
+			{{ $createdStr:= TimeSinceUnix .CreatedUnix $.locale }}
 			<div class="timeline-item event" id="{{.HashTag}}">
 				<span class="badge">{{svg "octicon-bookmark"}}</span>
 				<a href="{{.Poster.HomeLink}}">
@@ -161,7 +161,7 @@
 				{{if eq .RefAction 3}}<del>{{end}}
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr $refTr (.EventTag|Escape) $createdStr (.RefCommentHTMLURL|Escape) $refFrom | Safe}}
+					{{$.locale.Tr $refTr (.EventTag|Escape) $createdStr (.RefCommentHTMLURL|Escape) $refFrom | Safe}}
 				</span>
 				{{if eq .RefAction 3}}</del>{{end}}
 
@@ -177,7 +177,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.commit_ref_at" .EventTag $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.commit_ref_at" .EventTag $createdStr | Safe}}
 				</span>
 				<div class="detail">
 					{{svg "octicon-git-commit"}}
@@ -194,11 +194,11 @@
 					<span class="text grey">
 						<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 						{{if and .AddedLabels (not .RemovedLabels)}}
-							{{$.i18n.TrN (len .AddedLabels) "repo.issues.add_label" "repo.issues.add_labels" (RenderLabels .AddedLabels) $createdStr | Safe}}
+							{{$.locale.TrN (len .AddedLabels) "repo.issues.add_label" "repo.issues.add_labels" (RenderLabels .AddedLabels) $createdStr | Safe}}
 						{{else if and (not .AddedLabels) .RemovedLabels}}
-							{{$.i18n.TrN (len .RemovedLabels) "repo.issues.remove_label" "repo.issues.remove_labels" (RenderLabels .RemovedLabels) $createdStr | Safe}}
+							{{$.locale.TrN (len .RemovedLabels) "repo.issues.remove_label" "repo.issues.remove_labels" (RenderLabels .RemovedLabels) $createdStr | Safe}}
 						{{else}}
-							{{$.i18n.Tr "repo.issues.add_remove_labels" (RenderLabels .AddedLabels) (RenderLabels .RemovedLabels) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.add_remove_labels" (RenderLabels .AddedLabels) (RenderLabels .RemovedLabels) $createdStr | Safe}}
 						{{end}}
 					</span>
 				</div>
@@ -211,7 +211,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{if gt .OldMilestoneID 0}}{{if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.change_milestone_at" (.OldMilestone.Name|Escape) (.Milestone.Name|Escape) $createdStr | Safe}}{{else}}{{$.i18n.Tr "repo.issues.remove_milestone_at" (.OldMilestone.Name|Escape) $createdStr | Safe}}{{end}}{{else if gt .MilestoneID 0}}{{$.i18n.Tr "repo.issues.add_milestone_at" (.Milestone.Name|Escape) $createdStr | Safe}}{{end}}
+					{{if gt .OldMilestoneID 0}}{{if gt .MilestoneID 0}}{{$.locale.Tr "repo.issues.change_milestone_at" (.OldMilestone.Name|Escape) (.Milestone.Name|Escape) $createdStr | Safe}}{{else}}{{$.locale.Tr "repo.issues.remove_milestone_at" (.OldMilestone.Name|Escape) $createdStr | Safe}}{{end}}{{else if gt .MilestoneID 0}}{{$.locale.Tr "repo.issues.add_milestone_at" (.Milestone.Name|Escape) $createdStr | Safe}}{{end}}
 				</span>
 			</div>
 		{{else if eq .Type 9}}
@@ -225,9 +225,9 @@
 						<span class="text grey">
 							<a class="author" href="{{.Assignee.HomeLink}}">{{.Assignee.GetDisplayName}}</a>
 							{{ if eq .Poster.ID .Assignee.ID }}
-								{{$.i18n.Tr "repo.issues.remove_self_assignment" $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.remove_self_assignment" $createdStr | Safe}}
 							{{ else }}
-								{{$.i18n.Tr "repo.issues.remove_assignee_at" (.Poster.GetDisplayName|Escape) $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.remove_assignee_at" (.Poster.GetDisplayName|Escape) $createdStr | Safe}}
 							{{ end }}
 						</span>
 					{{else}}
@@ -237,9 +237,9 @@
 						<span class="text grey">
 							<a class="author" href="{{.Assignee.HomeLink}}">{{.Assignee.GetDisplayName}}</a>
 							{{if eq .Poster.ID .AssigneeID}}
-								{{$.i18n.Tr "repo.issues.self_assign_at" $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.self_assign_at" $createdStr | Safe}}
 							{{else}}
-								{{$.i18n.Tr "repo.issues.add_assignee_at" (.Poster.GetDisplayName|Escape) $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.add_assignee_at" (.Poster.GetDisplayName|Escape) $createdStr | Safe}}
 							{{end}}
 						</span>
 					{{end}}
@@ -253,7 +253,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.change_title_at" (.OldTitle|RenderEmoji) (.NewTitle|RenderEmoji) $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.change_title_at" (.OldTitle|RenderEmoji) (.NewTitle|RenderEmoji) $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 11}}
@@ -264,7 +264,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.delete_branch_at" (.OldRef|Escape) $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.delete_branch_at" (.OldRef|Escape) $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 12}}
@@ -275,7 +275,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.start_tracking_history"  $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.start_tracking_history"  $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 13}}
@@ -286,7 +286,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.stop_tracking_history"  $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.stop_tracking_history"  $createdStr | Safe}}
 				</span>
 				{{ template "repo/issue/view_content/comments_delete_time" Dict "ctx" $ "comment" . }}
 				<div class="detail">
@@ -302,7 +302,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.add_time_history"  $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.add_time_history"  $createdStr | Safe}}
 				</span>
 				{{ template "repo/issue/view_content/comments_delete_time" Dict "ctx" $ "comment" . }}
 				<div class="detail">
@@ -318,7 +318,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.cancel_tracking_history"  $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.cancel_tracking_history"  $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 16}}
@@ -329,7 +329,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.due_date_added" .Content $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.due_date_added" .Content $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 17}}
@@ -340,7 +340,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.due_date_modified" (.Content | ParseDeadline) $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.due_date_modified" (.Content | ParseDeadline) $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 18}}
@@ -351,7 +351,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.due_date_remove" .Content $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.due_date_remove" .Content $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 19}}
@@ -362,7 +362,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.dependency.added_dependency" $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.dependency.added_dependency" $createdStr | Safe}}
 				</span>
 				{{if .DependentIssue}}
 					<div class="detail">
@@ -387,7 +387,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.dependency.removed_dependency" $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.dependency.removed_dependency" $createdStr | Safe}}
 				</span>
 				{{if .DependentIssue}}
 					<div class="detail">
@@ -421,22 +421,22 @@
 								{{ .OriginalAuthor }}
 							</span>
 							<span class="text grey"> {{if $.Repository.OriginalURL}}</span>
-							<span class="text migrate">({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
+							<span class="text migrate">({{$.locale.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
 						{{else}}
 							<a class="author"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>{{.Poster.GetDisplayName}}</a>
 						{{end}}
 
 						{{if eq .Review.Type 1}}
-							{{$.i18n.Tr "repo.issues.review.approve" $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.approve" $createdStr | Safe}}
 						{{else if eq .Review.Type 2}}
-							{{$.i18n.Tr "repo.issues.review.comment" $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.comment" $createdStr | Safe}}
 						{{else if eq .Review.Type 3}}
-							{{$.i18n.Tr "repo.issues.review.reject" $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.reject" $createdStr | Safe}}
 						{{else}}
-							{{$.i18n.Tr "repo.issues.review.comment" $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.comment" $createdStr | Safe}}
 						{{end}}
 						{{if .Review.Dismissed}}
-							<div class="ui small label">{{$.i18n.Tr "repo.issues.review.dismissed_label"}}</div>
+							<div class="ui small label">{{$.locale.Tr "repo.issues.review.dismissed_label"}}</div>
 						{{end}}
 					</span>
 				</div>
@@ -452,28 +452,28 @@
 											{{ .OriginalAuthor }}
 										</span>
 										<span class="text grey"> {{if $.Repository.OriginalURL}}</span>
-										<span class="text migrate">({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
+										<span class="text migrate">({{$.locale.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
 									{{else}}
 										<a class="author"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>{{.Poster.GetDisplayName}}</a>
 									{{end}}
 
-									{{$.i18n.Tr "repo.issues.review.left_comment" | Safe}}
+									{{$.locale.Tr "repo.issues.review.left_comment" | Safe}}
 								</span>
 							</div>
 							<div class="comment-header-right actions df ac">
 									{{if (.ShowRole.HasRole "Poster")}}
 										<div class="ui basic label">
-												{{$.i18n.Tr "repo.issues.poster"}}
+												{{$.locale.Tr "repo.issues.poster"}}
 										</div>
 									{{end}}
 									{{if (.ShowRole.HasRole "Writer")}}
 										<div class="ui basic label">
-												{{$.i18n.Tr "repo.issues.collaborator"}}
+												{{$.locale.Tr "repo.issues.collaborator"}}
 										</div>
 									{{end}}
 									{{if (.ShowRole.HasRole "Owner")}}
 										<div class="ui basic label">
-												{{$.i18n.Tr "repo.issues.owner"}}
+												{{$.locale.Tr "repo.issues.owner"}}
 										</div>
 									{{end}}
 									{{if not $.Repository.IsArchived}}
@@ -487,7 +487,7 @@
 								{{if .RenderedContent}}
 									{{.RenderedContent|Str2html}}
 								{{else}}
-									<span class="no-content">{{$.i18n.Tr "repo.issues.no_content"}}</span>
+									<span class="no-content">{{$.locale.Tr "repo.issues.no_content"}}</span>
 								{{end}}
 							</div>
 							<div id="comment-{{.ID}}" class="raw-content hide">{{.Content}}</div>
@@ -520,7 +520,7 @@
 											<a href="{{(index $comms 0).CodeCommentURL}}" class="file-comment ml-3 word-break">{{$filename}}</a>
 											{{if $invalid }}
 												<span class="ui label basic small ml-3">
-													{{$.i18n.Tr "repo.issues.review.outdated"}}
+													{{$.locale.Tr "repo.issues.review.outdated"}}
 												</span>
 											{{end}}
 										</div>
@@ -529,17 +529,17 @@
 												<button id="show-outdated-{{(index $comms 0).ID}}" data-comment="{{(index $comms 0).ID}}" class="{{if not $resolved}}hide {{end}}ui compact right labeled button show-outdated df ac">
 													{{svg "octicon-unfold" 16 "mr-3"}}
 													{{if $resolved}}
-														{{$.i18n.Tr "repo.issues.review.show_resolved"}}
+														{{$.locale.Tr "repo.issues.review.show_resolved"}}
 													{{else}}
-														{{$.i18n.Tr "repo.issues.review.show_outdated"}}
+														{{$.locale.Tr "repo.issues.review.show_outdated"}}
 													{{end}}
 												</button>
 												<button id="hide-outdated-{{(index $comms 0).ID}}" data-comment="{{(index $comms 0).ID}}" class="{{if $resolved}}hide {{end}}ui compact right labeled button hide-outdated df ac">
 													{{svg "octicon-fold" 16 "mr-3"}}
 													{{if $resolved}}
-														{{$.i18n.Tr "repo.issues.review.hide_resolved"}}
+														{{$.locale.Tr "repo.issues.review.hide_resolved"}}
 													{{else}}
-														{{$.i18n.Tr "repo.issues.review.hide_outdated"}}
+														{{$.locale.Tr "repo.issues.review.hide_outdated"}}
 													{{end}}
 												</button>
 											{{end}}
@@ -563,7 +563,7 @@
 									<div id="code-comments-{{(index $comms 0).ID}}" class="comment-code-cloud ui segment{{if $resolved}} hide{{end}}">
 										<div class="ui comments mb-0">
 											{{range $comms}}
-												{{ $createdSubStr:= TimeSinceUnix .CreatedUnix $.i18n }}
+												{{ $createdSubStr:= TimeSinceUnix .CreatedUnix $.locale }}
 												<div class="comment code-comment pb-4" id="{{.HashTag}}">
 													<div class="content">
 														<div class="header comment-header">
@@ -580,27 +580,27 @@
 																			{{ .OriginalAuthor }}
 																		</span>
 																		<span class="text grey"> {{if $.Repository.OriginalURL}}</span>
-																		<span class="text migrate">({{$.i18n.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
+																		<span class="text migrate">({{$.locale.Tr "repo.migrated_from" ($.Repository.OriginalURL|Escape) ($.Repository.GetOriginalURLHostname|Escape) | Safe }}){{end}}</span>
 																	{{else}}
 																		<a class="author"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>{{.Poster.GetDisplayName}}</a>
 																	{{end}}
-																	{{$.i18n.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdSubStr | Safe}}
+																	{{$.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdSubStr | Safe}}
 																</span>
 															</div>
 															<div class="comment-header-right actions df ac">
 																{{if (.ShowRole.HasRole "Poster")}}
 																	<div class="ui basic label">
-																		{{$.i18n.Tr "repo.issues.poster"}}
+																		{{$.locale.Tr "repo.issues.poster"}}
 																	</div>
 																{{end}}
 																{{if (.ShowRole.HasRole "Writer")}}
 																	<div class="ui basic label">
-																		{{$.i18n.Tr "repo.issues.collaborator"}}
+																		{{$.locale.Tr "repo.issues.collaborator"}}
 																	</div>
 																{{end}}
 																{{if (.ShowRole.HasRole "Owner")}}
 																	<div class="ui basic label">
-																		{{$.i18n.Tr "repo.issues.owner"}}
+																		{{$.locale.Tr "repo.issues.owner"}}
 																	</div>
 																{{end}}
 																{{if not $.Repository.IsArchived}}
@@ -614,7 +614,7 @@
 															{{if .RenderedContent}}
 																{{.RenderedContent|Str2html}}
 															{{else}}
-																<span class="no-content">{{$.i18n.Tr "repo.issues.no_content"}}</span>
+																<span class="no-content">{{$.locale.Tr "repo.issues.no_content"}}</span>
 															{{end}}
 															</div>
 															<div id="comment-{{.ID}}" class="raw-content hide">{{.Content}}</div>
@@ -635,7 +635,7 @@
 												{{if $resolved}}
 													<div class="ui grey text">
 														{{svg "octicon-check" 16 "mr-2"}}
-														<b>{{$resolveDoer.Name}}</b> {{$.i18n.Tr "repo.issues.review.resolved_by"}}
+														<b>{{$resolveDoer.Name}}</b> {{$.locale.Tr "repo.issues.review.resolved_by"}}
 													</div>
 												{{end}}
 											</div>
@@ -643,15 +643,15 @@
 												{{if and $.CanMarkConversation $isNotPending}}
 													<button class="ui tiny basic button resolve-conversation" data-origin="timeline" data-action="{{if not $resolved}}Resolve{{else}}UnResolve{{end}}" data-comment-id="{{(index $comms 0).ID}}" data-update-url="{{$.RepoLink}}/issues/resolve_conversation">
 														{{if $resolved}}
-															{{$.i18n.Tr "repo.issues.review.un_resolve_conversation"}}
+															{{$.locale.Tr "repo.issues.review.un_resolve_conversation"}}
 														{{else}}
-															{{$.i18n.Tr "repo.issues.review.resolve_conversation"}}
+															{{$.locale.Tr "repo.issues.review.resolve_conversation"}}
 														{{end}}
 													</button>
 												{{end}}
 												{{if and $.SignedUserID (not $.Repository.IsArchived)}}
 													<button class="comment-form-reply ui green tiny labeled icon button ml-2 mr-0">
-														{{svg "octicon-reply" 16 "reply icon mr-2"}}{{$.i18n.Tr "repo.diff.comment.reply"}}
+														{{svg "octicon-reply" 16 "reply icon mr-2"}}{{$.locale.Tr "repo.diff.comment.reply"}}
 													</button>
 												{{end}}
 											</div>
@@ -673,12 +673,12 @@
 				{{ if .Content }}
 					<span class="text grey">
 						<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-						{{$.i18n.Tr "repo.issues.lock_with_reason" .Content $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.lock_with_reason" .Content $createdStr | Safe}}
 					</span>
 				{{ else }}
 					<span class="text grey">
 						<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-						{{$.i18n.Tr "repo.issues.lock_no_reason" $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.lock_no_reason" $createdStr | Safe}}
 					</span>
 				{{ end }}
 			</div>
@@ -690,7 +690,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.unlock_comment" $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.unlock_comment" $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 25}}
@@ -701,7 +701,7 @@
 				</a>
 				<span class="text grey">
 					<a href="{{.Poster.HomeLink}}">{{.Poster.Name}}</a>
-					{{$.i18n.Tr "repo.pulls.change_target_branch_at" (.OldRef|Escape) (.NewRef|Escape) $createdStr | Safe}}
+					{{$.locale.Tr "repo.pulls.change_target_branch_at" (.OldRef|Escape) (.NewRef|Escape) $createdStr | Safe}}
 				</span>
 			</div>
 		{{else if eq .Type 26}}
@@ -712,7 +712,7 @@
 				</a>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.issues.del_time_history"  $createdStr | Safe}}
+					{{$.locale.Tr "repo.issues.del_time_history"  $createdStr | Safe}}
 				</span>
 				<div class="detail">
 					{{svg "octicon-clock"}}
@@ -730,18 +730,18 @@
 					{{if (gt .AssigneeID 0)}}
 						{{if .RemovedAssignee}}
 							{{if eq .PosterID .AssigneeID}}
-								{{$.i18n.Tr "repo.issues.review.remove_review_request_self" $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.review.remove_review_request_self" $createdStr | Safe}}
 							{{else}}
-								{{$.i18n.Tr "repo.issues.review.remove_review_request" (.Assignee.GetDisplayName|Escape) $createdStr | Safe}}
+								{{$.locale.Tr "repo.issues.review.remove_review_request" (.Assignee.GetDisplayName|Escape) $createdStr | Safe}}
 							{{end}}
 						{{else}}
-							{{$.i18n.Tr "repo.issues.review.add_review_request" (.Assignee.GetDisplayName|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.add_review_request" (.Assignee.GetDisplayName|Escape) $createdStr | Safe}}
 						{{end}}
 					{{else}}
 						{{if .RemovedAssignee}}
-							{{$.i18n.Tr "repo.issues.review.remove_review_request" (.AssigneeTeam.Name|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.remove_review_request" (.AssigneeTeam.Name|Escape) $createdStr | Safe}}
 						{{else}}
-							{{$.i18n.Tr "repo.issues.review.add_review_request" (.AssigneeTeam.Name|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.review.add_review_request" (.AssigneeTeam.Name|Escape) $createdStr | Safe}}
 						{{end}}
 					{{end}}
 				</span>
@@ -752,9 +752,9 @@
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{ if .IsForcePush }}
-						{{$.i18n.Tr "repo.issues.force_push_codes" ($.Issue.PullRequest.HeadBranch|Escape) (ShortSha .OldCommit) (($.Issue.Repo.CommitLink .OldCommit)|Escape)  (ShortSha .NewCommit) (($.Issue.Repo.CommitLink .NewCommit)|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.force_push_codes" ($.Issue.PullRequest.HeadBranch|Escape) (ShortSha .OldCommit) (($.Issue.Repo.CommitLink .OldCommit)|Escape)  (ShortSha .NewCommit) (($.Issue.Repo.CommitLink .NewCommit)|Escape) $createdStr | Safe}}
 					{{else}}
-						{{$.i18n.TrN (len .Commits) "repo.issues.push_commit_1" "repo.issues.push_commits_n" (len .Commits) $createdStr | Safe}}
+						{{$.locale.TrN (len .Commits) "repo.issues.push_commit_1" "repo.issues.push_commits_n" (len .Commits) $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>
@@ -772,12 +772,12 @@
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{if gt .OldProjectID 0}}
 						{{if gt .ProjectID 0}}
-							{{$.i18n.Tr "repo.issues.change_project_at" (.OldProject.Title|Escape) (.Project.Title|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.change_project_at" (.OldProject.Title|Escape) (.Project.Title|Escape) $createdStr | Safe}}
 						{{else}}
-							{{$.i18n.Tr "repo.issues.remove_project_at" (.OldProject.Title|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.remove_project_at" (.OldProject.Title|Escape) $createdStr | Safe}}
 						{{end}}
 					{{else if gt .ProjectID 0}}
-						{{$.i18n.Tr "repo.issues.add_project_at" (.Project.Title|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.add_project_at" (.Project.Title|Escape) $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>
@@ -797,7 +797,7 @@
 						{{else}}
 							{{$reviewerName = .Review.OriginalAuthor}}
 						{{end}}
-						{{$.i18n.Tr "repo.issues.review.dismissed" $reviewerName $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.review.dismissed" $reviewerName $createdStr | Safe}}
 					</span>
 				</div>
 				{{if .Content}}
@@ -805,7 +805,7 @@
 						<div class="content">
 							<div class="ui top attached header arrow-top">
 								<span class="text grey">
-									{{$.i18n.Tr "action.review_dismissed_reason"}}
+									{{$.locale.Tr "action.review_dismissed_reason"}}
 								</span>
 							</div>
 							<div class="ui attached segment">
@@ -813,7 +813,7 @@
 									{{if .RenderedContent}}
 										{{.RenderedContent|Str2html}}
 									{{else}}
-										<span class="no-content">{{$.i18n.Tr "repo.issues.no_content"}}</span>
+										<span class="no-content">{{$.locale.Tr "repo.issues.no_content"}}</span>
 									{{end}}
 								</div>
 							</div>
@@ -830,11 +830,11 @@
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
 					{{if and .OldRef .NewRef}}
-						{{$.i18n.Tr "repo.issues.change_ref_at" (.OldRef|Escape) (.NewRef|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.change_ref_at" (.OldRef|Escape) (.NewRef|Escape) $createdStr | Safe}}
 					{{else if .OldRef}}
-						{{$.i18n.Tr "repo.issues.remove_ref_at" (.OldRef|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.remove_ref_at" (.OldRef|Escape) $createdStr | Safe}}
 					{{else}}
-						{{$.i18n.Tr "repo.issues.add_ref_at" (.NewRef|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.add_ref_at" (.NewRef|Escape) $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>
@@ -843,8 +843,8 @@
 				<span class="badge">{{svg "octicon-git-merge" 16}}</span>
 				<span class="text grey">
 					<a class="author" href="{{.Poster.HomeLink}}">{{.Poster.GetDisplayName}}</a>
-					{{if eq .Type 34}}{{$.i18n.Tr "repo.pulls.auto_merge_newly_scheduled_comment" $createdStr | Safe}}
-					{{else}}{{$.i18n.Tr "repo.pulls.auto_merge_canceled_schedule_comment" $createdStr | Safe}}{{end}}
+					{{if eq .Type 34}}{{$.locale.Tr "repo.pulls.auto_merge_newly_scheduled_comment" $createdStr | Safe}}
+					{{else}}{{$.locale.Tr "repo.pulls.auto_merge_canceled_schedule_comment" $createdStr | Safe}}{{end}}
 				</span>
 			</div>
 		{{end}}

--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -6,13 +6,13 @@
 					<form method="POST" class="delete-time-form" action="{{.ctx.RepoLink}}/issues/{{.ctx.Issue.Index}}/times/{{.comment.TimeID}}/delete">
 						{{.ctx.CsrfTokenHtml}}
 					</form>
-					<div class="header">{{.ctx.i18n.Tr "repo.issues.del_time"}}</div>
+					<div class="header">{{.ctx.locale.Tr "repo.issues.del_time"}}</div>
 					<div class="actions">
-						<div class="ui red approve button">{{.ctx.i18n.Tr "repo.issues.context.delete"}}</div>
-						<div class="ui cancel button">{{.ctx.i18n.Tr "repo.issues.add_time_cancel"}}</div>
+						<div class="ui red approve button">{{.ctx.locale.Tr "repo.issues.context.delete"}}</div>
+						<div class="ui cancel button">{{.ctx.locale.Tr "repo.issues.add_time_cancel"}}</div>
 					</div>
 				</div>
-				<button class="ui icon button compact mini issue-delete-time tooltip" data-id="{{.comment.Time.ID}}" data-content="{{.ctx.i18n.Tr "repo.issues.del_time"}}" data-position="top right">
+				<button class="ui icon button compact mini issue-delete-time tooltip" data-id="{{.comment.Time.ID}}" data-content="{{.ctx.locale.Tr "repo.issues.del_time"}}" data-position="top right">
 					{{svg "octicon-trash"}}
 				</button>
 			</span>

--- a/templates/repo/issue/view_content/context_menu.tmpl
+++ b/templates/repo/issue/view_content/context_menu.tmpl
@@ -10,16 +10,16 @@
 		{{ else }}
 			{{ $referenceUrl = Printf "%s/files#%s" .ctx.Issue.HTMLURL .item.HashTag }}
 		{{ end }}
-		<div class="item context" data-clipboard-text="{{$referenceUrl}}">{{.ctx.i18n.Tr "repo.issues.context.copy_link"}}</div>
-		<div class="item context quote-reply {{if .diff}}quote-reply-diff{{end}}" data-target="{{.item.ID}}">{{.ctx.i18n.Tr "repo.issues.context.quote_reply"}}</div>
+		<div class="item context" data-clipboard-text="{{$referenceUrl}}">{{.ctx.locale.Tr "repo.issues.context.copy_link"}}</div>
+		<div class="item context quote-reply {{if .diff}}quote-reply-diff{{end}}" data-target="{{.item.ID}}">{{.ctx.locale.Tr "repo.issues.context.quote_reply"}}</div>
 		{{if not .ctx.UnitIssuesGlobalDisabled}}
-			<div class="item context reference-issue" data-target="{{.item.ID}}" data-modal="#reference-issue-modal" data-poster="{{.item.Poster.GetDisplayName}}" data-poster-username="{{.item.Poster.Name}}" data-reference="{{$referenceUrl}}">{{.ctx.i18n.Tr "repo.issues.context.reference_issue"}}</div>
+			<div class="item context reference-issue" data-target="{{.item.ID}}" data-modal="#reference-issue-modal" data-poster="{{.item.Poster.GetDisplayName}}" data-poster-username="{{.item.Poster.Name}}" data-reference="{{$referenceUrl}}">{{.ctx.locale.Tr "repo.issues.context.reference_issue"}}</div>
 		{{end}}
 		{{if or .ctx.Permission.IsAdmin .IsCommentPoster .ctx.HasIssuesOrPullsWritePermission}}
 			<div class="divider"></div>
-			<div class="item context edit-content">{{.ctx.i18n.Tr "repo.issues.context.edit"}}</div>
+			<div class="item context edit-content">{{.ctx.locale.Tr "repo.issues.context.edit"}}</div>
 			{{if .delete}}
-				<div class="item context delete-comment" data-comment-id={{.item.HashTag}} data-url="{{.ctx.RepoLink}}/comments/{{.item.ID}}/delete" data-locale="{{.ctx.i18n.Tr "repo.issues.delete_comment_confirm"}}">{{.ctx.i18n.Tr "repo.issues.context.delete"}}</div>
+				<div class="item context delete-comment" data-comment-id={{.item.HashTag}} data-url="{{.ctx.RepoLink}}/comments/{{.item.ID}}/delete" data-locale="{{.ctx.locale.Tr "repo.issues.delete_comment_confirm"}}">{{.ctx.locale.Tr "repo.issues.context.delete"}}</div>
 			{{end}}
 		{{end}}
 	</div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -2,9 +2,9 @@
 	<div class="comment box">
 		<div class="content">
 			<div class="ui segment">
-				<h4>{{$.i18n.Tr "repo.issues.review.reviewers"}}</h4>
+				<h4>{{$.locale.Tr "repo.issues.review.reviewers"}}</h4>
 				{{range .PullReviewers}}
-					{{ $createdStr:= TimeSinceUnix .Review.UpdatedUnix $.i18n }}
+					{{ $createdStr:= TimeSinceUnix .Review.UpdatedUnix $.locale }}
 					<div class="ui divider"></div>
 					<div class="review-item">
 						<div class="review-item-left">
@@ -20,46 +20,46 @@
 									<span class="ui text">{{$.Issue.Repo.OwnerName}}/{{.Team.Name}}</span>
 								{{end}}
 								{{if eq .Review.Type 1}}
-									{{$.i18n.Tr "repo.issues.review.approve" $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.review.approve" $createdStr | Safe}}
 								{{else if eq .Review.Type 2}}
-									{{$.i18n.Tr "repo.issues.review.comment" $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.review.comment" $createdStr | Safe}}
 								{{else if eq .Review.Type 3}}
-									{{$.i18n.Tr "repo.issues.review.reject" $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.review.reject" $createdStr | Safe}}
 								{{else if eq .Review.Type 4}}
-									{{$.i18n.Tr "repo.issues.review.wait" $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.review.wait" $createdStr | Safe}}
 								{{else}}
-									{{$.i18n.Tr "repo.issues.review.comment" $createdStr | Safe}}
+									{{$.locale.Tr "repo.issues.review.comment" $createdStr | Safe}}
 								{{end}}
 							</span>
 						</div>
 						<div class="review-item-right">
 							{{if .Review.Stale}}
-								<span class="ui tooltip type-icon text grey" data-content="{{$.i18n.Tr "repo.issues.is_stale"}}">
+								<span class="ui tooltip type-icon text grey" data-content="{{$.locale.Tr "repo.issues.is_stale"}}">
 									{{svg "octicon-hourglass" 16 "icon"}}
 								</span>
 							{{end}}
 							{{if (and $.Permission.IsAdmin (or (eq .Review.Type 1) (eq .Review.Type 3)) (not $.Issue.IsClosed))}}
-								<a href="#" class="ui muted tooltip icon dismiss-review-btn" data-review-id="dismiss-review-{{.Review.ID}}" data-content="{{$.i18n.Tr "repo.issues.dismiss_review"}}">
+								<a href="#" class="ui muted tooltip icon dismiss-review-btn" data-review-id="dismiss-review-{{.Review.ID}}" data-content="{{$.locale.Tr "repo.issues.dismiss_review"}}">
 									{{svg "octicon-x" 16}}
 								</a>
 								<div class="ui small modal" id="dismiss-review-modal">
 									<div class="header">
-										{{$.i18n.Tr "repo.issues.dismiss_review"}}
+										{{$.locale.Tr "repo.issues.dismiss_review"}}
 									</div>
 									<div class="content">
 										<div class="ui warning message text left">
-											{{$.i18n.Tr "repo.issues.dismiss_review_warning"}}
+											{{$.locale.Tr "repo.issues.dismiss_review_warning"}}
 										</div>
 										<form class="ui form dismiss-review-form" id="dismiss-review-{{.Review.ID}}" action="{{$.RepoLink}}/issues/dismiss_review" method="post">
 											{{$.CsrfTokenHtml}}
 											<input type="hidden" name="review_id" value="{{.Review.ID}}">
 											<div class="field">
-												<label for="message">{{$.i18n.Tr "action.review_dismissed_reason"}}</label>
+												<label for="message">{{$.locale.Tr "action.review_dismissed_reason"}}</label>
 												<input id="message" name="message">
 											</div>
 											<div class="text right actions">
-												<div class="ui cancel button">{{$.i18n.Tr "settings.cancel"}}</div>
-												<button class="ui red button" type="submit">{{$.i18n.Tr "ok"}}</button>
+												<div class="ui cancel button">{{$.locale.Tr "settings.cancel"}}</div>
+												<button class="ui red button" type="submit">{{$.locale.Tr "ok"}}</button>
 											</div>
 										</form>
 									</div>
@@ -72,7 +72,7 @@
 								{{else}}grey{{end}}">
 
 								{{if .CanChange }}
-									<a href="#" class="ui tooltip icon re-request-review {{if .Checked}}checked{{end}}" data-issue-id="{{$.Issue.ID}}" data-content="{{if .Checked}} {{$.i18n.Tr "repo.issues.remove_request_review"}} {{else}} {{$.i18n.Tr "repo.issues.re_request_review"}} {{end}}"  data-id="{{.ItemID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
+									<a href="#" class="ui tooltip icon re-request-review {{if .Checked}}checked{{end}}" data-issue-id="{{$.Issue.ID}}" data-content="{{if .Checked}} {{$.locale.Tr "repo.issues.remove_request_review"}} {{else}} {{$.locale.Tr "repo.issues.re_request_review"}} {{end}}"  data-id="{{.ItemID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
 										{{if .Checked}} {{svg "octicon-trash"}} {{else}} {{svg "octicon-sync"}} {{end}}
 									</a>
 								{{end}}
@@ -82,11 +82,11 @@
 					</div>
 				{{end}}
 				{{range .OriginalReviews}}
-					{{ $createdStr:= TimeSinceUnix .UpdatedUnix $.i18n }}
+					{{ $createdStr:= TimeSinceUnix .UpdatedUnix $.locale }}
 					<div class="ui divider"></div>
 					<div class="review-item">
 						<div class="review-item-left">
-							<a href="{{$.Repository.OriginalURL}}" class="ui tooltip" data-content="{{$.i18n.Tr "repo.migrated_from_fake" ($.Repository.GetOriginalURLHostname|Escape) | Safe }}">
+							<a href="{{$.Repository.OriginalURL}}" class="ui tooltip" data-content="{{$.locale.Tr "repo.migrated_from_fake" ($.Repository.GetOriginalURLHostname|Escape) | Safe }}">
 								<span class="text black ">
 									{{svg (MigrationIcon $.Repository.GetOriginalURLHostname)}}
 									{{ .OriginalAuthor }}
@@ -135,38 +135,38 @@
 					{{if .Issue.PullRequest.MergedCommitID}}
 						{{$link := printf "%s/commit/%s" $.Repository.HTMLURL (.Issue.PullRequest.MergedCommitID|PathEscape)}}
 						{{if eq $.Issue.PullRequest.Status 3}}
-							{{$.i18n.Tr "repo.pulls.manually_merged_as" ($link|Escape) (ShortSha .Issue.PullRequest.MergedCommitID) | Safe}}
+							{{$.locale.Tr "repo.pulls.manually_merged_as" ($link|Escape) (ShortSha .Issue.PullRequest.MergedCommitID) | Safe}}
 						{{else}}
-							{{$.i18n.Tr "repo.pulls.merged_as" ($link|Escape) (ShortSha .Issue.PullRequest.MergedCommitID) | Safe}}
+							{{$.locale.Tr "repo.pulls.merged_as" ($link|Escape) (ShortSha .Issue.PullRequest.MergedCommitID) | Safe}}
 						{{end}}
 					{{else}}
-						{{$.i18n.Tr "repo.pulls.has_merged"}}
+						{{$.locale.Tr "repo.pulls.has_merged"}}
 					{{end}}
 				</div>
 				{{if .IsPullBranchDeletable}}
 					<div class="ui divider"></div>
 					<div>
-						<a class="delete-button ui red button" href="" data-url="{{.DeleteBranchLink}}">{{$.i18n.Tr "repo.branch.delete" .HeadTarget}}</a>
+						<a class="delete-button ui red button" href="" data-url="{{.DeleteBranchLink}}">{{$.locale.Tr "repo.branch.delete" .HeadTarget}}</a>
 					</div>
 				{{end}}
 			{{else if .Issue.IsClosed}}
 				<div class="item text">
 					{{if .IsPullRequestBroken}}
-						{{$.i18n.Tr "repo.pulls.cant_reopen_deleted_branch"}}
+						{{$.locale.Tr "repo.pulls.cant_reopen_deleted_branch"}}
 					{{else}}
-						{{$.i18n.Tr "repo.pulls.reopen_to_merge"}}
+						{{$.locale.Tr "repo.pulls.reopen_to_merge"}}
 					{{end}}
 				</div>
 				{{if and .IsPullBranchDeletable ( not .IsPullRequestBroken )}}
 					<div class="ui divider"></div>
 					<div>
-						<a class="delete-button ui red button" href="" data-url="{{.DeleteBranchLink}}">{{$.i18n.Tr "repo.branch.delete" .HeadTarget}}</a>
+						<a class="delete-button ui red button" href="" data-url="{{.DeleteBranchLink}}">{{$.locale.Tr "repo.branch.delete" .HeadTarget}}</a>
 					</div>
 				{{end}}
 			{{else if .IsPullFilesConflicted}}
 				<div class="item text">
 					{{svg "octicon-x"}}
-					{{$.i18n.Tr "repo.pulls.files_conflicted"}}
+					{{$.locale.Tr "repo.pulls.files_conflicted"}}
 					{{range .ConflictedFiles}}
 						<div>{{.}}</div>
 					{{end}}
@@ -174,18 +174,18 @@
 			{{else if .IsPullRequestBroken}}
 				<div class="item">
 					<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.data_broken"}}
+					{{$.locale.Tr "repo.pulls.data_broken"}}
 				</div>
 			{{else if .IsPullWorkInProgress}}
 				<div class="item toggle-wip df ac sb" data-title="{{.Issue.Title}}" data-wip-prefix="{{(.WorkInProgressPrefix|Escape)}}" data-update-url="{{.Issue.Link}}/title">
 					<div>
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-						{{$.i18n.Tr "repo.pulls.cannot_merge_work_in_progress" }}
+						{{$.locale.Tr "repo.pulls.cannot_merge_work_in_progress" }}
 					</div>
 					<div>
 						{{if or .HasIssuesOrPullsWritePermission .IsIssuePoster}}
 							<button class="ui compact button">
-								{{$.i18n.Tr "repo.pulls.remove_prefix" (.WorkInProgressPrefix|Escape) | Safe}}
+								{{$.locale.Tr "repo.pulls.remove_prefix" (.WorkInProgressPrefix|Escape) | Safe}}
 							</button>
 						{{end}}
 					</div>
@@ -193,38 +193,38 @@
 			{{else if .Issue.PullRequest.IsChecking}}
 				<div class="item">
 					<i class="icon icon-octicon">{{svg "octicon-sync"}}</i>
-					{{$.i18n.Tr "repo.pulls.is_checking"}}
+					{{$.locale.Tr "repo.pulls.is_checking"}}
 				</div>
 			{{else if .Issue.PullRequest.IsEmpty}}
 				<div class="item">
 					<i class="icon icon-octicon">{{svg "octicon-alert" 16}}</i>
-					{{$.i18n.Tr "repo.pulls.is_empty"}}
+					{{$.locale.Tr "repo.pulls.is_empty"}}
 				</div>
 			{{else if .Issue.PullRequest.CanAutoMerge}}
 				{{if .IsBlockedByApprovals}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
+					{{$.locale.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
+					{{$.locale.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOfficialReviewRequests}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.blocked_by_official_review_requests"}}
+					{{$.locale.Tr "repo.pulls.blocked_by_official_review_requests"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
+					{{$.locale.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if .IsBlockedByChangedProtectedFiles}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
-						{{$.i18n.TrN $.ChangedProtectedFilesNum "repo.pulls.blocked_by_changed_protected_files_1" "repo.pulls.blocked_by_changed_protected_files_n" | Safe }}
+						{{$.locale.TrN $.ChangedProtectedFilesNum "repo.pulls.blocked_by_changed_protected_files_1" "repo.pulls.blocked_by_changed_protected_files_n" | Safe }}
 						<div class="ui ordered list">
 							{{range .ChangedProtectedFiles}}
 								<div data-value="-" class="item">{{.}}</div>
@@ -234,21 +234,21 @@
 				{{else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsError .RequiredStatusCheckState.IsFailure)}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
+						{{$.locale.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-						{{$.i18n.Tr "repo.pulls.required_status_check_missing"}}
+						{{$.locale.Tr "repo.pulls.required_status_check_missing"}}
 					</div>
 				{{else if and .AllowMerge .RequireSigned (not .WillSign)}}
 					<div class="item">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
+						{{$.locale.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 					<div class="item">
 						<i class="icon unlock"></i>
-						{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
+						{{$.locale.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
 					</div>
 				{{end}}
 
@@ -262,23 +262,23 @@
 					{{if $notAllOverridableChecksOk}}
 						<div class="item">
 							<i class="icon icon-octicon">{{svg "octicon-dot-fill"}}</i>
-							{{$.i18n.Tr "repo.pulls.required_status_check_administrator"}}
+							{{$.locale.Tr "repo.pulls.required_status_check_administrator"}}
 						</div>
 					{{else}}
 						<div class="item">
 							<i class="icon icon-octicon">{{svg "octicon-check"}}</i>
-							{{$.i18n.Tr "repo.pulls.can_auto_merge_desc"}}
+							{{$.locale.Tr "repo.pulls.can_auto_merge_desc"}}
 						</div>
 					{{end}}
 					{{if .WillSign}}
 						<div class="item">
 							<i class="icon lock green"></i>
-							{{$.i18n.Tr "repo.signing.will_sign" .SigningKey}}
+							{{$.locale.Tr "repo.signing.will_sign" .SigningKey}}
 						</div>
 					{{else if .IsSigned}}
 						<div class="item">
 							<i class="icon unlock"></i>
-							{{$.i18n.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
+							{{$.locale.Tr (printf "repo.signing.wont_sign.%s" .WontSignReason) }}
 						</div>
 					{{end}}
 				{{end}}
@@ -288,7 +288,7 @@
 					<div class="item item-section">
 						<div class="item-section-left">
 							<i class="icon icon-octicon">{{svg "octicon-alert"}}</i>
-							{{$.i18n.Tr "repo.pulls.outdated_with_base_branch"}}
+							{{$.locale.Tr "repo.pulls.outdated_with_base_branch"}}
 						</div>
 						<div class="item-section-right">
 							{{if and .UpdateAllowed .UpdateByRebaseAllowed }}
@@ -296,15 +296,15 @@
 									<div class="ui buttons update-button">
 										<button class="ui button" data-do="{{.Link}}/update" data-redirect="{{.Link}}">
 											<span class="button-text">
-												{{$.i18n.Tr "repo.pulls.update_branch"}}
+												{{$.locale.Tr "repo.pulls.update_branch"}}
 											</span>
 										</button>
 
 										<div class="ui dropdown icon button no-text">
 											{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 											<div class="menu">
-												<div class="item active selected" data-do="{{.Link}}/update">{{$.i18n.Tr "repo.pulls.update_branch"}}</div>
-												<div class="item" data-do="{{.Link}}/update?style=rebase">{{$.i18n.Tr "repo.pulls.update_branch_rebase"}}</div>
+												<div class="item active selected" data-do="{{.Link}}/update">{{$.locale.Tr "repo.pulls.update_branch"}}</div>
+												<div class="item" data-do="{{.Link}}/update?style=rebase">{{$.locale.Tr "repo.pulls.update_branch_rebase"}}</div>
 											</div>
 										</div>
 									</div>
@@ -314,7 +314,7 @@
 								<form action="{{.Link}}/update" method="post" class="ui update-branch-form">
 									{{.CsrfTokenHtml}}
 									<button class="ui compact button" data-do="update">
-										<span class="ui text">{{$.i18n.Tr "repo.pulls.update_branch"}}</span>
+										<span class="ui text">{{$.locale.Tr "repo.pulls.update_branch"}}</span>
 									</button>
 								</form>
 							{{end}}
@@ -328,8 +328,8 @@
 					{{if or $prUnit.PullRequestsConfig.AllowMerge $prUnit.PullRequestsConfig.AllowRebase $prUnit.PullRequestsConfig.AllowRebaseMerge $prUnit.PullRequestsConfig.AllowSquash}}
 						{{$hasPendingPullRequestMergeTip := ""}}
 						{{if .HasPendingPullRequestMerge}}
-							{{$createdPRMergeStr := TimeSinceUnix .PendingPullRequestMerge.CreatedUnix $.i18n}}
-							{{$hasPendingPullRequestMergeTip = $.i18n.Tr "repo.pulls.auto_merge_has_pending_schedule" .PendingPullRequestMerge.Doer.Name $createdPRMergeStr}}
+							{{$createdPRMergeStr := TimeSinceUnix .PendingPullRequestMerge.CreatedUnix $.locale}}
+							{{$hasPendingPullRequestMergeTip = $.locale.Tr "repo.pulls.auto_merge_has_pending_schedule" .PendingPullRequestMerge.Doer.Name $createdPRMergeStr}}
 						{{end}}
 						<div class="ui divider"></div>
 						<script>
@@ -340,18 +340,18 @@
 								const defaultMergeMessage = 'Reviewed-on: ' + {{$.Issue.HTMLURL}} + '\n' + {{$approvers}};
 								const mergeForm = {
 									'baseLink': {{.Link}},
-									'textCancel': {{$.i18n.Tr "cancel"}},
-									'textDeleteBranch': {{$.i18n.Tr "repo.branch.delete" .HeadTarget}},
-									'textAutoMergeButtonWhenSucceed': {{$.i18n.Tr "repo.pulls.auto_merge_button_when_succeed"}},
-									'textAutoMergeWhenSucceed': {{$.i18n.Tr "repo.pulls.auto_merge_when_succeed"}},
-									'textAutoMergeCancelSchedule': {{$.i18n.Tr "repo.pulls.auto_merge_cancel_schedule"}},
+									'textCancel': {{$.locale.Tr "cancel"}},
+									'textDeleteBranch': {{$.locale.Tr "repo.branch.delete" .HeadTarget}},
+									'textAutoMergeButtonWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
+									'textAutoMergeWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_when_succeed"}},
+									'textAutoMergeCancelSchedule': {{$.locale.Tr "repo.pulls.auto_merge_cancel_schedule"}},
 
 									'canMergeNow': {{$canMergeNow}},
 									'allOverridableChecksOk': {{not $notAllOverridableChecksOk}},
 									'pullHeadCommitID': {{.PullHeadCommitID}},
 									'isPullBranchDeletable': {{.IsPullBranchDeletable}},
 									'defaultDeleteBranchAfterMerge': {{$prUnit.PullRequestsConfig.DefaultDeleteBranchAfterMerge}},
-									'mergeMessageFieldPlaceHolder': {{$.i18n.Tr "repo.editor.commit_message_desc"}},
+									'mergeMessageFieldPlaceHolder': {{$.locale.Tr "repo.editor.commit_message_desc"}},
 
 									'hasPendingPullRequestMerge': {{.HasPendingPullRequestMerge}},
 									'hasPendingPullRequestMergeTip': {{$hasPendingPullRequestMergeTip}},
@@ -362,7 +362,7 @@
 									{
 										'name': 'merge',
 										'allowed': {{$prUnit.PullRequestsConfig.AllowMerge}},
-										'textDoMerge': {{$.i18n.Tr "repo.pulls.merge_pull_request"}},
+										'textDoMerge': {{$.locale.Tr "repo.pulls.merge_pull_request"}},
 										'mergeTitleFieldText': defaultMergeTitle,
 										'mergeMessageFieldText': defaultMergeMessage,
 										'hideAutoMerge': generalHideAutoMerge,
@@ -370,14 +370,14 @@
 									{
 										'name': 'rebase',
 										'allowed': {{$prUnit.PullRequestsConfig.AllowRebase}},
-										'textDoMerge': {{$.i18n.Tr "repo.pulls.rebase_merge_pull_request"}},
+										'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_pull_request"}},
 										'hideMergeMessageTexts': true,
 										'hideAutoMerge': generalHideAutoMerge,
 									},
 									{
 										'name': 'rebase-merge',
 										'allowed': {{$prUnit.PullRequestsConfig.AllowRebaseMerge}},
-										'textDoMerge': {{$.i18n.Tr "repo.pulls.rebase_merge_commit_pull_request"}},
+										'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}},
 										'mergeTitleFieldText': defaultMergeTitle,
 										'mergeMessageFieldText': defaultMergeMessage,
 										'hideAutoMerge': generalHideAutoMerge,
@@ -385,7 +385,7 @@
 									{
 										'name': 'squash',
 										'allowed': {{$prUnit.PullRequestsConfig.AllowSquash}},
-										'textDoMerge': {{$.i18n.Tr "repo.pulls.squash_merge_pull_request"}},
+										'textDoMerge': {{$.locale.Tr "repo.pulls.squash_merge_pull_request"}},
 										'mergeTitleFieldText': defaultSquashMergeTitle,
 										'mergeMessageFieldText': defaultMergeMessage,
 										'hideAutoMerge': generalHideAutoMerge,
@@ -393,7 +393,7 @@
 									{
 										'name': 'manually-merged',
 										'allowed': {{and $prUnit.PullRequestsConfig.AllowManualMerge $.IsRepoAdmin}},
-										'textDoMerge': {{$.i18n.Tr "repo.pulls.merge_manually"}},
+										'textDoMerge': {{$.locale.Tr "repo.pulls.merge_manually"}},
 										'hideMergeMessageTexts': true,
 										'hideAutoMerge': true,
 									}
@@ -405,18 +405,18 @@
 						<div id="pull-request-merge-form"></div>
 
 						{{if .ShowMergeInstructions}}
-							{{template "repo/issue/view_content/pull_merge_instruction" (dict "i18n" .i18n "Issue" .Issue)}}
+							{{template "repo/issue/view_content/pull_merge_instruction" (dict "locale" .locale "Issue" .Issue)}}
 						{{end}}
 					{{else}}
 						{{/* no merge style was set in repo setting: not or ($prUnit.PullRequestsConfig.AllowMerge ...) */}}
 						<div class="ui divider"></div>
 						<div class="item text red">
 							{{svg "octicon-x"}}
-							{{$.i18n.Tr "repo.pulls.no_merge_desc"}}
+							{{$.locale.Tr "repo.pulls.no_merge_desc"}}
 						</div>
 						<div class="item">
 							{{svg "octicon-info"}}
-							{{$.i18n.Tr "repo.pulls.no_merge_helper"}}
+							{{$.locale.Tr "repo.pulls.no_merge_helper"}}
 						</div>
 					{{end}} {{/* end if the repo was set to use any merge style */}}
 				{{else}}
@@ -424,7 +424,7 @@
 					<div class="ui divider"></div>
 					<div class="item">
 						{{svg "octicon-info"}}
-						{{$.i18n.Tr "repo.pulls.no_merge_access"}}
+						{{$.locale.Tr "repo.pulls.no_merge_access"}}
 					</div>
 				{{end}} {{/* end if user is allowed to merge or not */}}
 			{{else}}
@@ -432,27 +432,27 @@
 				{{if .IsBlockedByApprovals}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-					{{$.i18n.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
+					{{$.locale.Tr "repo.pulls.blocked_by_approvals" .GrantedApprovals .Issue.PullRequest.ProtectedBranch.RequiredApprovals}}
 					</div>
 				{{else if .IsBlockedByRejection}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-						{{$.i18n.Tr "repo.pulls.blocked_by_rejection"}}
+						{{$.locale.Tr "repo.pulls.blocked_by_rejection"}}
 					</div>
 				{{else if .IsBlockedByOfficialReviewRequests}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-						{{$.i18n.Tr "repo.pulls.blocked_by_official_review_requests"}}
+						{{$.locale.Tr "repo.pulls.blocked_by_official_review_requests"}}
 					</div>
 				{{else if .IsBlockedByOutdatedBranch}}
 					<div class="item text red">
 						<i class="icon icon-octicon">{{svg "octicon-x"}}</i>
-					{{$.i18n.Tr "repo.pulls.blocked_by_outdated_branch"}}
+					{{$.locale.Tr "repo.pulls.blocked_by_outdated_branch"}}
 					</div>
 				{{else if .IsBlockedByChangedProtectedFiles}}
 					<div class="item text red">
 						<i class="icon icon-octicon">{{svg "octicon-x" 16}}</i>
-						{{$.i18n.TrN $.ChangedProtectedFilesNum "repo.pulls.blocked_by_changed_protected_files_1" "repo.pulls.blocked_by_changed_protected_files_n" | Safe }}
+						{{$.locale.TrN $.ChangedProtectedFilesNum "repo.pulls.blocked_by_changed_protected_files_1" "repo.pulls.blocked_by_changed_protected_files_n" | Safe }}
 						<div class="ui ordered list">
 							{{range .ChangedProtectedFiles}}
 								<div data-value="-" class="item">{{.}}</div>
@@ -462,21 +462,21 @@
 				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-						{{$.i18n.Tr "repo.pulls.required_status_check_failed"}}
+						{{$.locale.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
 				{{else if and .RequireSigned (not .WillSign)}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-						{{$.i18n.Tr "repo.pulls.require_signed_wont_sign"}}
+						{{$.locale.Tr "repo.pulls.require_signed_wont_sign"}}
 					</div>
 				{{else}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
-						{{$.i18n.Tr "repo.pulls.cannot_auto_merge_desc"}}
+						{{$.locale.Tr "repo.pulls.cannot_auto_merge_desc"}}
 					</div>
 					<div class="item">
 						{{svg "octicon-info"}}
-						{{$.i18n.Tr "repo.pulls.cannot_auto_merge_helper"}}
+						{{$.locale.Tr "repo.pulls.cannot_auto_merge_helper"}}
 					</div>
 				{{end}}
 			{{end}}
@@ -487,20 +487,20 @@
 					<form action="{{.Link}}/merge" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="field">
-							<input type="text" name="merge_commit_id"  placeholder="{{$.i18n.Tr "repo.pulls.merge_commit_id"}}">
+							<input type="text" name="merge_commit_id"  placeholder="{{$.locale.Tr "repo.pulls.merge_commit_id"}}">
 						</div>
 						<button class="ui red button" type="submit" name="do" value="manually-merged">
-							{{$.i18n.Tr "repo.pulls.merge_manually"}}
+							{{$.locale.Tr "repo.pulls.merge_manually"}}
 						</button>
 						<button class="ui button merge-cancel">
-							{{$.i18n.Tr "cancel"}}
+							{{$.locale.Tr "cancel"}}
 						</button>
 					</form>
 				</div>
 
 				<div class="ui red buttons merge-button">
 					<button class="ui button" data-do="manually-merged">
-						{{$.i18n.Tr "repo.pulls.merge_manually"}}
+						{{$.locale.Tr "repo.pulls.merge_manually"}}
 					</button>
 				</div>
 			{{end}}

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -1,7 +1,7 @@
-<div class="instruct-toggle mt-3"> {{$.i18n.Tr "repo.pulls.merge_instruction_hint" | Safe}} </div>
+<div class="instruct-toggle mt-3"> {{$.locale.Tr "repo.pulls.merge_instruction_hint" | Safe}} </div>
 <div class="instruct-content" style="display:none">
 	<div class="ui divider"></div>
-	<div><h3 class="di">{{$.i18n.Tr "step1"}} </h3>{{$.i18n.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
+	<div><h3 class="di">{{$.locale.Tr "step1"}} </h3>{{$.locale.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
 	<div class="ui secondary segment">
 		{{if eq $.Issue.PullRequest.Flow 0}}
 		<div>git checkout -b {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}} {{$.Issue.PullRequest.BaseBranch}}</div>
@@ -10,7 +10,7 @@
 		<div>git fetch origin {{$.Issue.PullRequest.GetGitRefName}}:{{$.Issue.PullRequest.HeadBranch}}</div>
 		{{end}}
 	</div>
-	<div><h3 class="di">{{$.i18n.Tr "step2"}} </h3>{{$.i18n.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
+	<div><h3 class="di">{{$.locale.Tr "step2"}} </h3>{{$.locale.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
 	<div class="ui secondary segment">
 		<div>git checkout {{$.Issue.PullRequest.BaseBranch}}</div>
 		<div>git merge --no-ff {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}}</div>

--- a/templates/repo/issue/view_content/reactions.tmpl
+++ b/templates/repo/issue/view_content/reactions.tmpl
@@ -1,5 +1,5 @@
 {{range $key, $value := .Reactions}}
-	<a class="ui label basic{{if $value.HasUser $.ctx.SignedUserID}} primary{{end}}{{if not $.ctx.IsSigned}} disabled{{end}}" data-title="{{$value.GetFirstUsers}}{{if gt ($value.GetMoreUserCount) 0}} {{ $.ctx.i18n.Tr "repo.reactions_more" $value.GetMoreUserCount}}{{end}}" data-content="{{ $key }}" data-action-url="{{ $.ActionURL }}">
+	<a class="ui label basic{{if $value.HasUser $.ctx.SignedUserID}} primary{{end}}{{if not $.ctx.IsSigned}} disabled{{end}}" data-title="{{$value.GetFirstUsers}}{{if gt ($value.GetMoreUserCount) 0}} {{ $.ctx.locale.Tr "repo.reactions_more" $value.GetMoreUserCount}}{{end}}" data-content="{{ $key }}" data-action-url="{{ $.ActionURL }}">
 		<span class="reaction">{{ReactionToEmoji $key}}</span>
 		<span class="reaction-count">{{len $value}}</span>
 	</a>

--- a/templates/repo/issue/view_content/reference_issue_dialog.tmpl
+++ b/templates/repo/issue/view_content/reference_issue_dialog.tmpl
@@ -1,28 +1,28 @@
 <div class="ui small modal" id="reference-issue-modal">
 	<div class="header">
-		{{.i18n.Tr "repo.issues.context.reference_issue"}}
+		{{.locale.Tr "repo.issues.context.reference_issue"}}
 	</div>
 	<div class="content" style="text-align:left">
 		<form class="ui form" action="{{ Printf "%s/issues/new" .Repository.Link }}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="ui segment content">
 				<div class="field">
-					<span class="text"><strong>{{.i18n.Tr "repository"}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repository"}}</strong></span>
 					<div class="ui search normal selection dropdown issue_reference_repository_search">
 						<div class="default text">{{.Repository.FullName}}</div>
 						<div class="menu"></div>
 					</div>
 				</div>
 				<div class="field">
-					<span class="text"><strong>{{.i18n.Tr "repo.milestones.title"}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repo.milestones.title"}}</strong></span>
 					<input name="title" value="" autofocus required maxlength="255" autocomplete="off">
 				</div>
 				<div class="field">
-					<span class="text"><strong>{{.i18n.Tr "repo.issues.reference_issue.body"}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repo.issues.reference_issue.body"}}</strong></span>
 					<textarea name="content" class="form-control"></textarea>
 				</div>
 				<div class="text right">
-					<button class="ui green button">{{.i18n.Tr "repo.issues.create"}}</button>
+					<button class="ui green button">{{.locale.Tr "repo.issues.create"}}</button>
 				</div>
 			</div>
 		</form>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -7,23 +7,23 @@
 			<input id="reviewer_id" name="reviewer_id" type="hidden" value="{{.reviewer_id}}">
 			<div class="ui {{if or (not .Reviewers) (not .CanChooseReviewer) .Repository.IsArchived}}disabled{{end}} floating jump select-reviewers-modify dropdown">
 				<a class="text df ac muted">
-					<strong>{{.i18n.Tr "repo.issues.review.reviewers"}}</strong>
+					<strong>{{.locale.Tr "repo.issues.review.reviewers"}}</strong>
 					{{if and .CanChooseReviewer (not .Repository.IsArchived)}}
 						{{svg "octicon-gear" 16 "ml-2"}}
 					{{end}}
 				</a>
 				<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
-					<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_reviewer_title"}}</div>
+					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_reviewer_title"}}</div>
 					{{if .Reviewers}}
 						<div class="ui icon search input">
 							<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-							<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_reviewers"}}">
+							<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_reviewers"}}">
 						</div>
 					{{end}}
 					{{if .Reviewers}}
 						{{range .Reviewers}}
 							{{if .User}}
-								<a class="{{if not .CanChange}}ui tooltip{{end}} item {{if .Checked}} checked {{end}} {{if not .CanChange}}ban-change{{end}}" href="#" data-id="{{.ItemID}}" data-id-selector="#review_request_{{.ItemID}}" {{if not .CanChange}} data-content="{{$.i18n.Tr "repo.issues.remove_request_review_block"}}"{{end}}>
+								<a class="{{if not .CanChange}}ui tooltip{{end}} item {{if .Checked}} checked {{end}} {{if not .CanChange}}ban-change{{end}}" href="#" data-id="{{.ItemID}}" data-id-selector="#review_request_{{.ItemID}}" {{if not .CanChange}} data-content="{{$.locale.Tr "repo.issues.remove_request_review_block"}}"{{end}}>
 									<span class="octicon-check {{if not .Checked}}invisible{{end}}">{{svg "octicon-check"}}</span>
 									<span class="text">
 										{{avatar .User 28 "mr-3"}}
@@ -37,7 +37,7 @@
 						<div class="ui divider"></div>
 						{{range .TeamReviewers}}
 							{{if .Team}}
-								<a class="{{if not .CanChange}}ui tooltip{{end}} item {{if .Checked}} checked {{end}} {{if not .CanChange}}ban-change{{end}}" href="#" data-id="{{.ItemID}}" data-id-selector="#review_request_team_{{.Team.ID}}" {{if not .CanChange}} data-content="{{$.i18n.Tr "repo.issues.remove_request_review_block"}}"{{end}}>
+								<a class="{{if not .CanChange}}ui tooltip{{end}} item {{if .Checked}} checked {{end}} {{if not .CanChange}}ban-change{{end}}" href="#" data-id="{{.ItemID}}" data-id-selector="#review_request_team_{{.Team.ID}}" {{if not .CanChange}} data-content="{{$.locale.Tr "repo.issues.remove_request_review_block"}}"{{end}}>
 									<span class="octicon-check {{if not .Checked}}invisible{{end}}">{{svg "octicon-check" 16}}</span>
 									<span class="text">
 										{{svg "octicon-people" 16 "ml-4 mr-2"}}{{$.Issue.Repo.OwnerName}}/{{.Team.Name}}
@@ -50,7 +50,7 @@
 			</div>
 
 			<div class="ui assignees list">
-				<span class="no-select item {{if or .OriginalReviews .PullReviewers}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_reviewers"}}</span>
+				<span class="no-select item {{if or .OriginalReviews .PullReviewers}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_reviewers"}}</span>
 				<div class="selected">
 					{{range .PullReviewers}}
 						<div class="item mb-2">
@@ -69,7 +69,7 @@
 								{{- else}}grey{{end}} right ">
 
 								{{if .CanChange}}
-									<a href="#" class="ui tooltip icon re-request-review {{if .Checked}}checked{{end}}" data-content="{{if .Checked}} {{$.i18n.Tr "repo.issues.remove_request_review"}} {{else}} {{$.i18n.Tr "repo.issues.re_request_review"}} {{end}}" data-issue-id="{{$.Issue.ID}}"  data-id="{{.ItemID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
+									<a href="#" class="ui tooltip icon re-request-review {{if .Checked}}checked{{end}}" data-content="{{if .Checked}} {{$.locale.Tr "repo.issues.remove_request_review"}} {{else}} {{$.locale.Tr "repo.issues.re_request_review"}} {{end}}" data-issue-id="{{$.Issue.ID}}"  data-id="{{.ItemID}}" data-update-url="{{$.RepoLink}}/issues/request_review">
 										{{if .Checked}} {{svg "octicon-trash"}} {{else}} {{svg "octicon-sync"}} {{end}}
 									</a>
 								{{end}}
@@ -79,7 +79,7 @@
 					{{end}}
 					{{range .OriginalReviews}}
 						<div class="item" style="margin-bottom: 10px;">
-							<a href="{{$.Repository.OriginalURL}}" class="ui tooltip" data-content="{{$.i18n.Tr "repo.migrated_from_fake" ($.Repository.GetOriginalURLHostname|Escape) | Safe }}">
+							<a href="{{$.Repository.OriginalURL}}" class="ui tooltip" data-content="{{$.locale.Tr "repo.migrated_from_fake" ($.Repository.GetOriginalURLHostname|Escape) | Safe }}">
 								<span class="text black">
 									{{svg (MigrationIcon $.Repository.GetOriginalURLHostname)}}
 									{{ .OriginalAuthor }}
@@ -99,7 +99,7 @@
 			{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .HasMerged) (not .Issue.IsClosed) (not .IsPullWorkInProgress)}}
 				<div class="toggle-wip" data-title="{{.Issue.Title}}" data-wip-prefix="{{(index .PullRequestWorkInProgressPrefixes 0| Escape)}}" data-update-url="{{.Issue.Link}}/title">
 					<a class="muted">
-						{{.i18n.Tr "repo.pulls.still_in_progress"}} {{.i18n.Tr "repo.pulls.add_prefix" (index .PullRequestWorkInProgressPrefixes 0| Escape) | Safe}}
+						{{.locale.Tr "repo.pulls.still_in_progress"}} {{.locale.Tr "repo.pulls.add_prefix" (index .PullRequestWorkInProgressPrefixes 0| Escape) | Safe}}
 					</a>
 				</div>
 			{{end}}
@@ -108,20 +108,20 @@
 
 		<div class="ui {{if or (not .HasIssuesOrPullsWritePermission) .Repository.IsArchived}}disabled{{end}} floating jump select-label dropdown">
 			<a class="text df ac muted">
-				<strong>{{.i18n.Tr "repo.issues.new.labels"}}</strong>
+				<strong>{{.locale.Tr "repo.issues.new.labels"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
 					{{svg "octicon-gear" 16 "ml-2"}}
 				{{end}}
 			</a>
 			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels">
-				<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_labels_title"}}</div>
+				<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_labels_title"}}</div>
 				{{if or .Labels .OrgLabels}}
 					<div class="ui icon search input">
 						<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-						<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_labels"}}">
+						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_labels"}}">
 					</div>
 				{{end}}
-				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_labels"}}</div>
+				<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_labels"}}</div>
 				{{if or .Labels .OrgLabels}}
 					{{range .Labels}}
 						<a class="{{if .IsChecked}}checked{{end}} item" href="#" data-id="{{.ID}}" data-id-selector="#label_{{.ID}}"><span class="octicon-check {{if not .IsChecked}}invisible{{end}}">{{svg "octicon-check"}}</span><span class="label color" style="background-color: {{.Color}}"></span> {{.Name | RenderEmoji}}
@@ -133,7 +133,7 @@
 						{{if .Description }}<br><small class="desc">{{.Description | RenderEmoji}}</small>{{end}}</a>
 					{{end}}
 				{{else}}
-					<div class="header" style="text-transform: none;font-size:14px;">{{.i18n.Tr "repo.issues.new.no_items"}}</div>
+					<div class="header" style="text-transform: none;font-size:14px;">{{.locale.Tr "repo.issues.new.no_items"}}</div>
 				{{end}}
 			</div>
 		</div>
@@ -143,29 +143,29 @@
 
 		<div class="ui {{if or (not .HasIssuesOrPullsWritePermission) .Repository.IsArchived}}disabled{{end}} floating jump select-milestone dropdown">
 			<a class="text df ac muted">
-				<strong>{{.i18n.Tr "repo.issues.new.milestone"}}</strong>
+				<strong>{{.locale.Tr "repo.issues.new.milestone"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
 					{{svg "octicon-gear" 16 "ml-2"}}
 				{{end}}
 			</a>
 			<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/milestone">
-				<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_milestone_title"}}</div>
+				<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_milestone_title"}}</div>
 				{{if or .OpenMilestones .ClosedMilestones}}
 				<div class="ui icon search input">
 					<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-					<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_milestones"}}">
+					<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_milestones"}}">
 				</div>
 				{{end}}
-				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_milestone"}}</div>
+				<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_milestone"}}</div>
 				{{if and (not .OpenMilestones) (not .ClosedMilestones)}}
 					<div class="header" style="text-transform: none;font-size:14px;">
-						{{.i18n.Tr "repo.issues.new.no_items"}}
+						{{.locale.Tr "repo.issues.new.no_items"}}
 					</div>
 				{{else}}
 					{{if .OpenMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{.i18n.Tr "repo.issues.new.open_milestone"}}
+							{{.locale.Tr "repo.issues.new.open_milestone"}}
 						</div>
 						{{range .OpenMilestones}}
 							<a class="item" data-id="{{.ID}}" data-href="{{$.RepoLink}}/issues?milestone={{.ID}}">
@@ -177,7 +177,7 @@
 					{{if .ClosedMilestones}}
 						<div class="divider"></div>
 						<div class="header">
-							{{.i18n.Tr "repo.issues.new.closed_milestone"}}
+							{{.locale.Tr "repo.issues.new.closed_milestone"}}
 						</div>
 						{{range .ClosedMilestones}}
 							<a class="item" data-id="{{.ID}}" data-href="{{$.RepoLink}}/issues?milestone={{.ID}}">
@@ -190,7 +190,7 @@
 			</div>
 		</div>
 		<div class="ui select-milestone list">
-			<span class="no-select item {{if .Issue.Milestone}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_milestone"}}</span>
+			<span class="no-select item {{if .Issue.Milestone}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_milestone"}}</span>
 			<div class="selected">
 				{{if .Issue.Milestone}}
 					<a class="item muted sidebar-item-link" href="{{.RepoLink}}/milestone/{{.Issue.Milestone.ID}}">
@@ -206,17 +206,17 @@
 
 			<div class="ui {{if or (not .HasIssuesOrPullsWritePermission) .Repository.IsArchived}}disabled{{end}} floating jump select-project dropdown">
 				<a class="text df ac muted">
-					<strong>{{.i18n.Tr "repo.issues.new.projects"}}</strong>
+					<strong>{{.locale.Tr "repo.issues.new.projects"}}</strong>
 					{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
 						{{svg "octicon-gear" 16 "ml-2"}}
 					{{end}}
 				</a>
 				<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/projects">
-					<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_projects"}}</div>
+					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
 					{{if .OpenProjects}}
 						<div class="divider"></div>
 						<div class="header">
-							{{.i18n.Tr "repo.issues.new.open_projects"}}
+							{{.locale.Tr "repo.issues.new.open_projects"}}
 						</div>
 						{{range .OpenProjects}}
 							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
@@ -228,7 +228,7 @@
 					{{if .ClosedProjects}}
 						<div class="divider"></div>
 						<div class="header">
-							{{.i18n.Tr "repo.issues.new.closed_projects"}}
+							{{.locale.Tr "repo.issues.new.closed_projects"}}
 						</div>
 						{{range .ClosedProjects}}
 							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
@@ -240,7 +240,7 @@
 				</div>
 			</div>
 			<div class="ui select-project list">
-				<span class="no-select item {{if .Issue.ProjectID}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_projects"}}</span>
+				<span class="no-select item {{if .Issue.ProjectID}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_projects"}}</span>
 				<div class="selected">
 					{{if .Issue.ProjectID}}
 						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/projects/{{.Issue.ProjectID}}">
@@ -257,18 +257,18 @@
 		<input id="assignee_id" name="assignee_id" type="hidden" value="{{.assignee_id}}">
 		<div class="ui {{if or (not .HasIssuesOrPullsWritePermission) .Repository.IsArchived}}disabled{{end}} floating jump select-assignees-modify dropdown">
 			<a class="text df ac muted">
-				<strong>{{.i18n.Tr "repo.issues.new.assignees"}}</strong>
+				<strong>{{.locale.Tr "repo.issues.new.assignees"}}</strong>
 				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
 					{{svg "octicon-gear" 16 "ml-2"}}
 				{{end}}
 			</a>
 			<div class="filter menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/assignee">
-				<div class="header" style="text-transform: none;font-size:16px;">{{.i18n.Tr "repo.issues.new.add_assignees_title"}}</div>
+				<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_assignees_title"}}</div>
 				<div class="ui icon search input">
 					<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-					<input type="text" placeholder="{{.i18n.Tr "repo.issues.filter_assignees"}}">
+					<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_assignees"}}">
 				</div>
-				<div class="no-select item">{{.i18n.Tr "repo.issues.new.clear_assignees"}}</div>
+				<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_assignees"}}</div>
 				{{range .Assignees}}
 
 					{{$AssigneeID := .ID}}
@@ -289,7 +289,7 @@
 			</div>
 		</div>
 		<div class="ui assignees list">
-			<span class="no-select item {{if .Issue.Assignees}}hide{{end}}">{{.i18n.Tr "repo.issues.new.no_assignees"}}</span>
+			<span class="no-select item {{if .Issue.Assignees}}hide{{end}}">{{.locale.Tr "repo.issues.new.no_assignees"}}</span>
 			<div class="selected">
 				{{range .Issue.Assignees}}
 					<div class="item">
@@ -305,7 +305,7 @@
 		<div class="ui divider"></div>
 
 		{{if .Participants}}
-			<span class="text"><strong>{{.i18n.Tr "repo.issues.num_participants" .NumParticipants}}</strong></span>
+			<span class="text"><strong>{{.locale.Tr "repo.issues.num_participants" .NumParticipants}}</strong></span>
 			<div class="ui list df fw">
 				{{range .Participants}}
 					<a class="ui tooltip" {{if gt .ID 0}}href="{{.HomeLink}}"{{end}} data-content="{{.GetDisplayName}}" data-position="top center">
@@ -319,7 +319,7 @@
 			<div class="ui divider"></div>
 
 			<div class="ui watching">
-				<span class="text"><strong>{{.i18n.Tr "notification.notifications"}}</strong></span>
+				<span class="text"><strong>{{.locale.Tr "notification.notifications"}}</strong></span>
 				<div class="mt-3">
 					<form method="POST" action="{{.Issue.Link}}/watch">
 						<input type="hidden" name="watch" value="{{if $.IssueWatch.IsWatching}}0{{else}}1{{end}}" />
@@ -327,10 +327,10 @@
 						<button class="fluid ui button df jc">
 							{{if $.IssueWatch.IsWatching}}
 								{{svg "octicon-mute" 16 "mr-3"}}
-								{{.i18n.Tr "repo.issues.unsubscribe"}}
+								{{.locale.Tr "repo.issues.unsubscribe"}}
 							{{else}}
 								{{svg "octicon-unmute" 16 "mr-3"}}
-								{{.i18n.Tr "repo.issues.subscribe"}}
+								{{.locale.Tr "repo.issues.subscribe"}}
 							{{end}}
 						</button>
 					</form>
@@ -341,7 +341,7 @@
 			{{if and .CanUseTimetracker (not .Repository.IsArchived)}}
 				<div class="ui divider"></div>
 				<div class="ui timetrack">
-					<span class="text"><strong>{{.i18n.Tr "repo.issues.tracker"}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repo.issues.tracker"}}</strong></span>
 					<div class="mt-3">
 						<form method="POST" action="{{.Issue.Link}}/times/stopwatch/toggle" id="toggle_stopwatch_form">
 							{{$.CsrfTokenHtml}}
@@ -350,30 +350,30 @@
 							{{$.CsrfTokenHtml}}
 						</form>
 						{{if  $.IsStopwatchRunning}}
-							<button class="ui fluid button issue-stop-time">{{.i18n.Tr "repo.issues.stop_tracking"}}</button>
-							<button class="ui fluid negative button issue-cancel-time mt-3">{{.i18n.Tr "repo.issues.cancel_tracking"}}</button>
+							<button class="ui fluid button issue-stop-time">{{.locale.Tr "repo.issues.stop_tracking"}}</button>
+							<button class="ui fluid negative button issue-cancel-time mt-3">{{.locale.Tr "repo.issues.cancel_tracking"}}</button>
 						{{else}}
 							{{if .HasUserStopwatch}}
 								<div class="ui warning message">
-									{{.i18n.Tr "repo.issues.tracking_already_started" (.OtherStopwatchURL|Escape) | Safe}}
+									{{.locale.Tr "repo.issues.tracking_already_started" (.OtherStopwatchURL|Escape) | Safe}}
 								</div>
 							{{end}}
-							<button class="ui fluid button tooltip issue-start-time" data-content='{{.i18n.Tr "repo.issues.start_tracking"}}' data-position="top center">{{.i18n.Tr "repo.issues.start_tracking_short"}}</button>
+							<button class="ui fluid button tooltip issue-start-time" data-content='{{.locale.Tr "repo.issues.start_tracking"}}' data-position="top center">{{.locale.Tr "repo.issues.start_tracking_short"}}</button>
 							<div class="ui mini modal issue-start-time-modal">
-								<div class="header">{{.i18n.Tr "repo.issues.add_time"}}</div>
+								<div class="header">{{.locale.Tr "repo.issues.add_time"}}</div>
 								<div class="content">
 									<form method="POST" id="add_time_manual_form" action="{{.Issue.Link}}/times/add" class="ui action input fluid">
 										{{$.CsrfTokenHtml}}
-										<input placeholder='{{.i18n.Tr "repo.issues.add_time_hours"}}' type="number" name="hours">
-										<input placeholder='{{.i18n.Tr "repo.issues.add_time_minutes"}}' type="number" name="minutes" class="ui compact">
+										<input placeholder='{{.locale.Tr "repo.issues.add_time_hours"}}' type="number" name="hours">
+										<input placeholder='{{.locale.Tr "repo.issues.add_time_minutes"}}' type="number" name="minutes" class="ui compact">
 									</form>
 								</div>
 								<div class="actions">
-									<div class="ui green approve button">{{.i18n.Tr "repo.issues.add_time_short"}}</div>
-									<div class="ui red cancel button">{{.i18n.Tr "repo.issues.add_time_cancel"}}</div>
+									<div class="ui green approve button">{{.locale.Tr "repo.issues.add_time_short"}}</div>
+									<div class="ui red cancel button">{{.locale.Tr "repo.issues.add_time_cancel"}}</div>
 								</div>
 							</div>
-							<button class="ui fluid button green tooltip issue-add-time mt-3" data-content='{{.i18n.Tr "repo.issues.add_time"}}' data-position="top center">{{.i18n.Tr "repo.issues.add_time_short"}}</button>
+							<button class="ui fluid button green tooltip issue-add-time mt-3" data-content='{{.locale.Tr "repo.issues.add_time"}}' data-position="top center">{{.locale.Tr "repo.issues.add_time_short"}}</button>
 						{{end}}
 					</div>
 				</div>
@@ -381,7 +381,7 @@
 			{{if gt (len .WorkingUsers) 0}}
 				<div class="ui divider"></div>
 				<div class="ui comments">
-					<span class="text"><strong>{{.i18n.Tr "repo.issues.time_spent_from_all_authors"  ($.Issue.TotalTrackedTime | Sec2Time) | Safe}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repo.issues.time_spent_from_all_authors"  ($.Issue.TotalTrackedTime | Sec2Time) | Safe}}</strong></span>
 					<div>
 						{{range $user, $trackedtime := .WorkingUsers}}
 							<div class="comment mt-3">
@@ -402,36 +402,36 @@
 		{{end}}
 
 		<div class="ui divider"></div>
-		<span class="text"><strong>{{.i18n.Tr "repo.issues.due_date"}}</strong></span>
+		<span class="text"><strong>{{.locale.Tr "repo.issues.due_date"}}</strong></span>
 		<div class="ui form" id="deadline-loader">
 			<div class="ui negative message" id="deadline-err-invalid-date" style="display: none;">
 				{{svg "octicon-x" 16 "close icon"}}
-				{{.i18n.Tr "repo.issues.due_date_invalid"}}
+				{{.locale.Tr "repo.issues.due_date_invalid"}}
 			</div>
 			{{if ne .Issue.DeadlineUnix 0}}
 				<p>
 					<div class="df sb ac">
-						<div class="due-date tooltip {{if .Issue.IsOverdue}}text red{{end}}" {{if .Issue.IsOverdue}}data-content="{{.i18n.Tr "repo.issues.due_date_overdue"}}"{{end}}>
+						<div class="due-date tooltip {{if .Issue.IsOverdue}}text red{{end}}" {{if .Issue.IsOverdue}}data-content="{{.locale.Tr "repo.issues.due_date_overdue"}}"{{end}}>
 							{{svg "octicon-calendar" 16 "mr-3"}}
 							{{.Issue.DeadlineUnix.FormatDate}}
 						</div>
 						<div>
 							{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
-								<a class="issue-due-edit tooltip muted" data-content="{{$.i18n.Tr "repo.issues.due_date_form_edit"}}">{{svg "octicon-pencil" 16 "mr-2"}}</a>
-								<a class="issue-due-remove tooltip muted" data-content="{{$.i18n.Tr "repo.issues.due_date_form_remove"}}">{{svg "octicon-trash"}}</a>
+								<a class="issue-due-edit tooltip muted" data-content="{{$.locale.Tr "repo.issues.due_date_form_edit"}}">{{svg "octicon-pencil" 16 "mr-2"}}</a>
+								<a class="issue-due-remove tooltip muted" data-content="{{$.locale.Tr "repo.issues.due_date_form_remove"}}">{{svg "octicon-trash"}}</a>
 							{{end}}
 						</div>
 					</div>
 				</p>
 			{{else}}
-				<p>{{.i18n.Tr "repo.issues.due_date_not_set"}}</p>
+				<p>{{.locale.Tr "repo.issues.due_date_not_set"}}</p>
 			{{end}}
 
 			{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
 				<div {{if ne .Issue.DeadlineUnix 0}} style="display: none;"{{end}} id="deadlineForm">
 					<form class="ui fluid action input issue-due-form" action="{{AppSubUrl}}/{{PathEscape .Repository.Owner.Name}}/{{PathEscape .Repository.Name}}/issues/{{.Issue.Index}}/deadline" method="post" id="update-issue-deadline-form">
 						{{$.CsrfTokenHtml}}
-						<input required placeholder="{{.i18n.Tr "repo.issues.due_date_form"}}" {{if gt .Issue.DeadlineUnix 0}}value="{{.Issue.DeadlineUnix.Format "2006-01-02"}}"{{end}} type="date" name="deadlineDate" id="deadlineDate">
+						<input required placeholder="{{.locale.Tr "repo.issues.due_date_form"}}" {{if gt .Issue.DeadlineUnix 0}}value="{{.Issue.DeadlineUnix.Format "2006-01-02"}}"{{end}} type="date" name="deadlineDate" id="deadlineDate">
 						<button class="ui green icon button">
 							{{if ne .Issue.DeadlineUnix 0}}
 								{{svg "octicon-pencil"}}
@@ -449,20 +449,20 @@
 
 			<div class="ui depending">
 				{{if (and (not .BlockedByDependencies) (not .BlockingDependencies))}}
-					<span class="text"><strong>{{.i18n.Tr "repo.issues.dependency.title"}}</strong></span>
+					<span class="text"><strong>{{.locale.Tr "repo.issues.dependency.title"}}</strong></span>
 					<br>
 					<p>
 						{{if .Issue.IsPull}}
-							{{.i18n.Tr "repo.issues.dependency.pr_no_dependencies"}}
+							{{.locale.Tr "repo.issues.dependency.pr_no_dependencies"}}
 						{{else}}
-							{{.i18n.Tr "repo.issues.dependency.issue_no_dependencies"}}
+							{{.locale.Tr "repo.issues.dependency.issue_no_dependencies"}}
 						{{end}}
 					</p>
 				{{end}}
 
 				{{if .BlockingDependencies}}
-					<span class="text tooltip" data-content="{{if .Issue.IsPull}}{{.i18n.Tr "repo.issues.dependency.pr_close_blocks"}}{{else}}{{.i18n.Tr "repo.issues.dependency.issue_close_blocks"}}{{end}}">
-						<strong>{{.i18n.Tr "repo.issues.dependency.blocks_short"}}</strong>
+					<span class="text tooltip" data-content="{{if .Issue.IsPull}}{{.locale.Tr "repo.issues.dependency.pr_close_blocks"}}{{else}}{{.locale.Tr "repo.issues.dependency.issue_close_blocks"}}{{end}}">
+						<strong>{{.locale.Tr "repo.issues.dependency.blocks_short"}}</strong>
 					</span>
 					<div class="ui relaxed divided list">
 						{{range .BlockingDependencies}}
@@ -477,7 +477,7 @@
 								</div>
 								<div class="item-right df ac">
 									{{if and $.CanCreateIssueDependencies (not $.Repository.IsArchived)}}
-										<a class="delete-dependency-button tooltip ci muted" data-id="{{.Issue.ID}}" data-type="blocking" data-content="{{$.i18n.Tr "repo.issues.dependency.remove_info"}}" data-inverted="">
+										<a class="delete-dependency-button tooltip ci muted" data-id="{{.Issue.ID}}" data-type="blocking" data-content="{{$.locale.Tr "repo.issues.dependency.remove_info"}}" data-inverted="">
 											{{svg "octicon-trash" 16}}
 										</a>
 									{{end}}
@@ -488,8 +488,8 @@
 				{{end}}
 
 				{{if .BlockedByDependencies}}
-					<span class="text tooltip" data-content="{{if .Issue.IsPull}}{{.i18n.Tr "repo.issues.dependency.pr_closing_blockedby"}}{{else}}{{.i18n.Tr "repo.issues.dependency.issue_closing_blockedby"}}{{end}}">
-						<strong>{{.i18n.Tr "repo.issues.dependency.blocked_by_short"}}</strong>
+					<span class="text tooltip" data-content="{{if .Issue.IsPull}}{{.locale.Tr "repo.issues.dependency.pr_closing_blockedby"}}{{else}}{{.locale.Tr "repo.issues.dependency.issue_closing_blockedby"}}{{end}}">
+						<strong>{{.locale.Tr "repo.issues.dependency.blocked_by_short"}}</strong>
 					</span>
 					<div class="ui relaxed divided list">
 						{{range .BlockedByDependencies}}
@@ -504,7 +504,7 @@
 								</div>
 								<div class="item-right df ac">
 									{{if and $.CanCreateIssueDependencies (not $.Repository.IsArchived)}}
-										<a class="delete-dependency-button tooltip ci muted" data-id="{{.Issue.ID}}" data-type="blockedBy" data-content="{{$.i18n.Tr "repo.issues.dependency.remove_info"}}" data-inverted="">
+										<a class="delete-dependency-button tooltip ci muted" data-id="{{.Issue.ID}}" data-type="blockedBy" data-content="{{$.locale.Tr "repo.issues.dependency.remove_info"}}" data-inverted="">
 											{{svg "octicon-trash" 16}}
 										</a>
 									{{end}}
@@ -523,7 +523,7 @@
 									<input name="newDependency" type="hidden">
 									{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 									<input type="text" class="search">
-									<div class="default text">{{.i18n.Tr "repo.issues.dependency.add"}}</div>
+									<div class="default text">{{.locale.Tr "repo.issues.dependency.add"}}</div>
 								</div>
 								<button class="ui green icon button">
 									{{svg "octicon-plus"}}
@@ -540,7 +540,7 @@
 				<div class="ui basic modal remove-dependency">
 					<div class="ui icon header">
 						{{svg "octicon-trash"}}
-						{{.i18n.Tr "repo.issues.dependency.remove_header"}}
+						{{.locale.Tr "repo.issues.dependency.remove_header"}}
 					</div>
 					<div class="content">
 						<form method="POST" action="{{.Issue.Link}}/dependency/delete" id="removeDependencyForm">
@@ -549,19 +549,19 @@
 							<input type="hidden" value="" name="dependencyType" id="dependencyType"/>
 						</form>
 						<p>{{if .Issue.IsPull}}
-							{{.i18n.Tr "repo.issues.dependency.pr_remove_text"}}
+							{{.locale.Tr "repo.issues.dependency.pr_remove_text"}}
 						{{else}}
-							{{.i18n.Tr "repo.issues.dependency.issue_remove_text"}}
+							{{.locale.Tr "repo.issues.dependency.issue_remove_text"}}
 						{{end}}</p>
 					</div>
 					<div class="actions">
 						<div class="ui red cancel inverted button">
 							{{svg "octicon-x"}}
-							{{.i18n.Tr "repo.issues.dependency.cancel"}}
+							{{.locale.Tr "repo.issues.dependency.cancel"}}
 						</div>
 						<div class="ui green ok inverted button">
 							{{svg "octicon-check"}}
-							{{.i18n.Tr "repo.issues.dependency.remove"}}
+							{{.locale.Tr "repo.issues.dependency.remove"}}
 						</div>
 					</div>
 				</div>
@@ -572,7 +572,7 @@
 		<div class="ui equal width compact grid">
 			<div class="row ac">
 				{{$issueReferenceLink := printf "%s#%d" .Issue.Repo.FullName .Issue.Index}}
-				<span class="text column truncate">{{.i18n.Tr "repo.issues.reference_link" $issueReferenceLink}}</span>
+				<span class="text column truncate">{{.locale.Tr "repo.issues.reference_link" $issueReferenceLink}}</span>
 				<button class="ui two wide button column p-3" data-clipboard-text="{{$issueReferenceLink}}">{{svg "octicon-copy" 14}}</button>
 			</div>
 		</div>
@@ -583,30 +583,30 @@
 				<button class="fluid ui show-modal button {{if .Issue.IsLocked }} negative {{end}}" data-modal="#lock">
 					{{if .Issue.IsLocked}}
 						{{svg "octicon-key"}}
-						{{.i18n.Tr "repo.issues.unlock"}}
+						{{.locale.Tr "repo.issues.unlock"}}
 					{{else}}
 						{{svg "octicon-lock"}}
-						{{.i18n.Tr "repo.issues.lock"}}
+						{{.locale.Tr "repo.issues.lock"}}
 					{{end}}
 				</button>
 			</div>
 			<div class="ui tiny modal" id="lock">
 				<div class="header">
 					{{ if .Issue.IsLocked }}
-						{{.i18n.Tr "repo.issues.unlock.title"}}
+						{{.locale.Tr "repo.issues.unlock.title"}}
 					{{else}}
-						{{.i18n.Tr "repo.issues.lock.title"}}
+						{{.locale.Tr "repo.issues.lock.title"}}
 					{{end}}
 				</div>
 				<div class="content">
 					<div class="ui warning message text left">
 						{{ if .Issue.IsLocked }}
-							{{.i18n.Tr "repo.issues.unlock.notice_1"}}<br>
-							{{.i18n.Tr "repo.issues.unlock.notice_2"}}<br>
+							{{.locale.Tr "repo.issues.unlock.notice_1"}}<br>
+							{{.locale.Tr "repo.issues.unlock.notice_2"}}<br>
 						{{else}}
-							{{.i18n.Tr "repo.issues.lock.notice_1"}}<br>
-							{{.i18n.Tr "repo.issues.lock.notice_2"}}<br>
-							{{.i18n.Tr "repo.issues.lock.notice_3"}}<br>
+							{{.locale.Tr "repo.issues.lock.notice_1"}}<br>
+							{{.locale.Tr "repo.issues.lock.notice_2"}}<br>
+							{{.locale.Tr "repo.issues.lock.notice_3"}}<br>
 						{{end}}
 					</div>
 
@@ -616,7 +616,7 @@
 
 						{{ if not .Issue.IsLocked }}
 							<div class="field">
-								<strong> {{ .i18n.Tr "repo.issues.lock.reason" }} </strong>
+								<strong> {{ .locale.Tr "repo.issues.lock.reason" }} </strong>
 							</div>
 
 							<div class="field">
@@ -642,12 +642,12 @@
 						{{end}}
 
 						<div class="text right actions">
-							<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
+							<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
 							<button class="ui red button">
 								{{ if .Issue.IsLocked }}
-									{{.i18n.Tr "repo.issues.unlock_confirm"}}
+									{{.locale.Tr "repo.issues.unlock_confirm"}}
 								{{else}}
-									{{.i18n.Tr "repo.issues.lock_confirm"}}
+									{{.locale.Tr "repo.issues.lock_confirm"}}
 								{{end}}
 							</button>
 						</div>
@@ -656,30 +656,30 @@
 			</div>
 			<button class="fluid ui show-modal button negative mt-3" data-modal="#delete">
 				{{svg "octicon-trash"}}
-				{{.i18n.Tr "repo.issues.delete"}}
+				{{.locale.Tr "repo.issues.delete"}}
 			</button>
 			<div class="ui basic modal" id="delete">
 				<div class="ui icon header">
 					{{if .Issue.IsPull}}
-						{{.i18n.Tr "repo.pulls.delete.title"}}
+						{{.locale.Tr "repo.pulls.delete.title"}}
 					{{else}}
-						{{.i18n.Tr "repo.issues.delete.title"}}
+						{{.locale.Tr "repo.issues.delete.title"}}
 					{{end}}
 				</div>
 				<div class="content center">
 					<p>
 						{{if .Issue.IsPull}}
-							{{.i18n.Tr "repo.pulls.delete.text"}}
+							{{.locale.Tr "repo.pulls.delete.text"}}
 						{{else}}
-							{{.i18n.Tr "repo.issues.delete.text"}}
+							{{.locale.Tr "repo.issues.delete.text"}}
 						{{end}}
 					</p>
 				</div>
 				<form action="{{.Issue.Link}}/delete" method="post">
 					{{.CsrfTokenHtml}}
 					<div class="center actions">
-						<div class="ui basic cancel inverted button">{{.i18n.Tr "settings.cancel"}}</div>
-						<button class="ui basic red inverted button">{{.i18n.Tr "modal.yes"}}</button>
+						<div class="ui basic cancel inverted button">{{.locale.Tr "settings.cancel"}}</div>
+						<button class="ui basic red inverted button">{{.locale.Tr "modal.yes"}}</button>
 					</div>
 				</form>
 			</div>
@@ -691,10 +691,10 @@
 				<div class="inline field">
 					<div class="ui checkbox" id="allow-edits-from-maintainers"
 							data-url="{{.Issue.Link}}"
-							data-prompt-tip="{{.i18n.Tr "repo.pulls.allow_edits_from_maintainers_desc"}}"
-							data-prompt-error="{{.i18n.Tr "repo.pulls.allow_edits_from_maintainers_err"}}"
+							data-prompt-tip="{{.locale.Tr "repo.pulls.allow_edits_from_maintainers_desc"}}"
+							data-prompt-error="{{.locale.Tr "repo.pulls.allow_edits_from_maintainers_err"}}"
 						>
-						<label><strong>{{.i18n.Tr "repo.pulls.allow_edits_from_maintainers"}}</strong></label>
+						<label><strong>{{.locale.Tr "repo.pulls.allow_edits_from_maintainers"}}</strong></label>
 						<input type="checkbox" {{if .Issue.PullRequest.AllowMaintainerEdit}}checked{{end}}>
 					</div>
 				</div>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -2,7 +2,7 @@
 	<div class="issue-title" id="issue-title-wrapper">
 		{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .Repository.IsArchived)}}
 			<div class="edit-button">
-				<div id="edit-title" class="ui basic secondary not-in-edit button">{{.i18n.Tr "repo.issues.edit"}}</div>
+				<div id="edit-title" class="ui basic secondary not-in-edit button">{{.locale.Tr "repo.issues.edit"}}</div>
 			</div>
 		{{end}}
 		<h1>
@@ -14,19 +14,19 @@
 		</h1>
 		{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .Repository.IsArchived)}}
 			<div class="edit-buttons">
-				<div id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none">{{.i18n.Tr "repo.issues.cancel"}}</div>
-				<div id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}}>{{.i18n.Tr "repo.issues.save"}}</div>
+				<div id="cancel-edit-title" class="ui basic secondary in-edit button" style="display: none">{{.locale.Tr "repo.issues.cancel"}}</div>
+				<div id="save-edit-title" class="ui primary in-edit button" style="display: none" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title" {{if .Issue.IsPull}}data-target-update-url="{{$.RepoLink}}/pull/{{.Issue.Index}}/target_branch"{{end}}>{{.locale.Tr "repo.issues.save"}}</div>
 			</div>
 		{{end}}
 	</div>
 	{{if .HasMerged}}
-		<div class="ui purple large label">{{svg "octicon-git-merge" 16}} {{if eq .Issue.PullRequest.Status 3}}{{.i18n.Tr "repo.pulls.manually_merged"}}{{else}}{{.i18n.Tr "repo.pulls.merged"}}{{end}}</div>
+		<div class="ui purple large label">{{svg "octicon-git-merge" 16}} {{if eq .Issue.PullRequest.Status 3}}{{.locale.Tr "repo.pulls.manually_merged"}}{{else}}{{.locale.Tr "repo.pulls.merged"}}{{end}}</div>
 	{{else if .Issue.IsClosed}}
-		<div class="ui red large label">{{if .Issue.IsPull}}{{svg "octicon-git-pull-request"}}{{else}}{{svg "octicon-issue-closed"}}{{end}} {{.i18n.Tr "repo.issues.closed_title"}}</div>
+		<div class="ui red large label">{{if .Issue.IsPull}}{{svg "octicon-git-pull-request"}}{{else}}{{svg "octicon-issue-closed"}}{{end}} {{.locale.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
-		<div class="ui green large label">{{svg "octicon-git-pull-request"}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-git-pull-request"}} {{.locale.Tr "repo.issues.open_title"}}</div>
 	{{else}}
-		<div class="ui green large label">{{svg "octicon-issue-opened"}} {{.i18n.Tr "repo.issues.open_title"}}</div>
+		<div class="ui green large label">{{svg "octicon-issue-opened"}} {{.locale.Tr "repo.issues.open_title"}}</div>
 	{{end}}
 
 	{{if .Issue.IsPull}}
@@ -34,45 +34,45 @@
 		{{if .HeadBranchHTMLURL}}
 			{{$headHref = printf "<a href=\"%s\">%s</a>" (.HeadBranchHTMLURL | Escape) $headHref}}
 		{{end}}
-		{{$headHref = printf "%s <a class=\"tooltip\" data-content=\"%s\" data-clipboard-text=\"%s\">%s</a>" $headHref (.i18n.Tr "copy_branch") (.HeadTarget | Escape) (svg "octicon-copy" 14)}}
+		{{$headHref = printf "%s <a class=\"tooltip\" data-content=\"%s\" data-clipboard-text=\"%s\">%s</a>" $headHref (.locale.Tr "copy_branch") (.HeadTarget | Escape) (svg "octicon-copy" 14)}}
 		{{$baseHref := .BaseTarget|Escape}}
 		{{if .BaseBranchHTMLURL}}
 			{{$baseHref = printf "<a href=\"%s\">%s</a>" (.BaseBranchHTMLURL | Escape) $baseHref}}
 		{{end}}
 		{{if .Issue.PullRequest.HasMerged}}
-			{{ $mergedStr:= TimeSinceUnix .Issue.PullRequest.MergedUnix $.i18n }}
+			{{ $mergedStr:= TimeSinceUnix .Issue.PullRequest.MergedUnix $.locale }}
 			{{if .Issue.OriginalAuthor }}
 				{{.Issue.OriginalAuthor}}
-				<span class="pull-desc">{{$.i18n.Tr "repo.pulls.merged_title_desc" .NumCommits $headHref $baseHref $mergedStr | Safe}}</span>
+				<span class="pull-desc">{{$.locale.Tr "repo.pulls.merged_title_desc" .NumCommits $headHref $baseHref $mergedStr | Safe}}</span>
 			{{else}}
 				<a {{if gt .Issue.PullRequest.Merger.ID 0}}href="{{.Issue.PullRequest.Merger.HomeLink}}"{{end}}>{{.Issue.PullRequest.Merger.GetDisplayName}}</a>
-				<span class="pull-desc">{{$.i18n.Tr "repo.pulls.merged_title_desc" .NumCommits $headHref $baseHref $mergedStr | Safe}}</span>
+				<span class="pull-desc">{{$.locale.Tr "repo.pulls.merged_title_desc" .NumCommits $headHref $baseHref $mergedStr | Safe}}</span>
 			{{end}}
 		{{else}}
 			{{if .Issue.OriginalAuthor }}
-				<span id="pull-desc" class="pull-desc">{{.Issue.OriginalAuthor}} {{$.i18n.Tr "repo.pulls.title_desc" .NumCommits $headHref $baseHref | Safe}}</span>
+				<span id="pull-desc" class="pull-desc">{{.Issue.OriginalAuthor}} {{$.locale.Tr "repo.pulls.title_desc" .NumCommits $headHref $baseHref | Safe}}</span>
 			{{else}}
 				<span id="pull-desc" class="pull-desc">
 					<a {{if gt .Issue.Poster.ID 0}}href="{{.Issue.Poster.HomeLink}}"{{end}}>{{.Issue.Poster.GetDisplayName}}</a>
-					{{$.i18n.Tr "repo.pulls.title_desc" .NumCommits $headHref $baseHref | Safe}}
+					{{$.locale.Tr "repo.pulls.title_desc" .NumCommits $headHref $baseHref | Safe}}
 				</span>
 			{{end}}
 			<span id="pull-desc-edit" style="display: none">
 				<div class="ui floating filter dropdown">
 					<div class="ui basic small button">
-						<span class="text">{{.i18n.Tr "repo.pulls.compare_compare"}}: {{$.HeadTarget}}</span>
+						<span class="text">{{.locale.Tr "repo.pulls.compare_compare"}}: {{$.HeadTarget}}</span>
 					</div>
 				</div>
 				{{svg "octicon-arrow-right"}}
-				<div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
+				<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
 					<div class="ui basic small button">
-						<span class="text" id="pull-target-branch" data-basename="{{$.BaseName}}" data-branch="{{$.BaseBranch}}">{{.i18n.Tr "repo.pulls.compare_base"}}: {{$.BaseName}}:{{$.BaseBranch}}</span>
+						<span class="text" id="pull-target-branch" data-basename="{{$.BaseName}}" data-branch="{{$.BaseBranch}}">{{.locale.Tr "repo.pulls.compare_base"}}: {{$.BaseName}}:{{$.BaseBranch}}</span>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 					</div>
 					<div class="menu">
 						<div class="ui icon search input">
 							<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-							<input name="search" placeholder="{{.i18n.Tr "repo.pulls.filter_branch"}}...">
+							<input name="search" placeholder="{{.locale.Tr "repo.pulls.filter_branch"}}...">
 						</div>
 						<div class="scrolling menu" id="branch-select">
 							{{range .Branches}}
@@ -88,17 +88,17 @@
 			</span>
 		{{end}}
 	{{else}}
-		{{ $createdStr:= TimeSinceUnix .Issue.CreatedUnix $.i18n }}
+		{{ $createdStr:= TimeSinceUnix .Issue.CreatedUnix $.locale }}
 		<span class="time-desc">
 			{{if .Issue.OriginalAuthor }}
-				{{$.i18n.Tr "repo.issues.opened_by_fake" $createdStr (.Issue.OriginalAuthor|Escape) | Safe}}
+				{{$.locale.Tr "repo.issues.opened_by_fake" $createdStr (.Issue.OriginalAuthor|Escape) | Safe}}
 			{{else if gt .Issue.Poster.ID 0}}
-				{{$.i18n.Tr "repo.issues.opened_by" $createdStr (.Issue.Poster.HomeLink|Escape) (.Issue.Poster.GetDisplayName|Escape) | Safe}}
+				{{$.locale.Tr "repo.issues.opened_by" $createdStr (.Issue.Poster.HomeLink|Escape) (.Issue.Poster.GetDisplayName|Escape) | Safe}}
 			{{else}}
-				{{$.i18n.Tr "repo.issues.opened_by_fake" $createdStr (.Issue.Poster.GetDisplayName|Escape) | Safe}}
+				{{$.locale.Tr "repo.issues.opened_by_fake" $createdStr (.Issue.Poster.GetDisplayName|Escape) | Safe}}
 			{{end}}
 			·
-			{{$.i18n.Tr "repo.issues.num_comments" .Issue.NumComments}}
+			{{$.locale.Tr "repo.issues.num_comments" .Issue.NumComments}}
 		</span>
 	{{end}}
 	<div class="ui divider"></div>

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -6,25 +6,25 @@
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_username">{{.i18n.Tr "username"}}</label>
+						<label for="auth_username">{{.locale.Tr "username"}}</label>
 						<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
 					</div>
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_password">{{.i18n.Tr "password"}}</label>
+						<label for="auth_password">{{.locale.Tr "password"}}</label>
 						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
 					</div>
 
@@ -32,25 +32,25 @@
 
 					<div id="migrate_items">
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+							<label>{{.locale.Tr "repo.migrate_items"}}</label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -58,7 +58,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -82,32 +82,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -6,24 +6,24 @@
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_username">{{.i18n.Tr "username"}}</label>
+						<label for="auth_username">{{.locale.Tr "username"}}</label>
 						<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
 					</div>
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_password">{{.i18n.Tr "password"}}</label>
+						<label for="auth_password">{{.locale.Tr "password"}}</label>
 						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
 					</div>
 
@@ -32,7 +32,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -56,32 +56,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -6,67 +6,67 @@
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_username">{{.i18n.Tr "username"}}</label>
+						<label for="auth_username">{{.locale.Tr "username"}}</label>
 						<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
 					</div>
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_password">{{.i18n.Tr "password"}}</label>
+						<label for="auth_password">{{.locale.Tr "password"}}</label>
 						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
 					</div>
 
 					{{template "repo/migrate/options" .}}
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+						<label>{{.locale.Tr "repo.migrate_items"}}</label>
 						<div class="ui checkbox">
 							<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
 					</div>
 
 					<div id="migrate_items">
-						<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -74,7 +74,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -98,32 +98,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -5,21 +5,21 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-							{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+							{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_token">{{.i18n.Tr "access_token"}}</label>
+						<label for="auth_token">{{.locale.Tr "access_token"}}</label>
 						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}} data-need-clear="true" {{end}}>
 						<a target="_blank" href="https://docs.gitea.io/en-us/api-usage">{{svg "octicon-question"}}</a>
 					</div>
@@ -27,42 +27,42 @@
 					{{template "repo/migrate/options" .}}
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+						<label>{{.locale.Tr "repo.migrate_items"}}</label>
 						<div class="ui checkbox">
 							<input name="wiki" type="checkbox" {{if .wiki}} checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
 					</div>
 
 					<div id="migrate_items">
-						<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="releases" type="checkbox" {{if .releases}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -70,7 +70,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -94,32 +94,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -5,66 +5,66 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_token">{{.i18n.Tr "access_token"}}</label>
+						<label for="auth_token">{{.locale.Tr "access_token"}}</label>
 						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}}data-need-clear="true"{{end}}>
 						<a target="_blank" href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">{{svg "octicon-question"}}</a>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.github_token_desc"}}
+						{{.locale.Tr "repo.migrate.github_token_desc"}}
 						</span>
 					</div>
 
 					{{template "repo/migrate/options" .}}
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+						<label>{{.locale.Tr "repo.migrate_items"}}</label>
 						<div class="ui checkbox">
 							<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
 					</div>
 					<div id="migrate_items">
-						<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -72,7 +72,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -96,32 +96,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -5,21 +5,21 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_token">{{.i18n.Tr "access_token"}}</label>
+						<label for="auth_token">{{.locale.Tr "access_token"}}</label>
 						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}}data-need-clear="true"{{end}}>
 						<a target="_blank" href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html">{{svg "octicon-question"}}</a>
 					</div>
@@ -27,41 +27,41 @@
 					{{template "repo/migrate/options" .}}
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+						<label>{{.locale.Tr "repo.migrate_items"}}</label>
 						<div class="ui checkbox">
 							<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
 					</div>
 					<div id="migrate_items">
-						<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -69,7 +69,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -93,32 +93,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/gogs.tmpl
+++ b/templates/repo/migrate/gogs.tmpl
@@ -5,21 +5,21 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-							{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+							{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_token">{{.i18n.Tr "access_token"}}</label>
+						<label for="auth_token">{{.locale.Tr "access_token"}}</label>
 						<input id="auth_token" name="auth_token" value="{{.auth_token}}" {{if not .auth_token}} data-need-clear="true" {{end}}>
 						<!-- <a target="_blank" href="https://docs.gitea.io/en-us/api-usage">{{svg "octicon-question"}}</a> -->
 					</div>
@@ -27,31 +27,31 @@
 					{{template "repo/migrate/options" .}}
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+						<label>{{.locale.Tr "repo.migrate_items"}}</label>
 						<div class="ui checkbox">
 							<input name="wiki" type="checkbox" {{if .wiki}} checked{{end}}>
-							<label>{{.i18n.Tr "repo.migrate_items_wiki" | Safe}}</label>
+							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
 					</div>
 
 					<div id="migrate_items">
-						<span class="help">{{.i18n.Tr "repo.migrate.migrate_items_options"}}</span>
+						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 						</div>
 						<!-- Gogs do not support it
@@ -59,11 +59,11 @@
 							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="releases" type="checkbox" {{if .releases}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_releases" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
 							</div>
 						</div>
 						-->
@@ -72,7 +72,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -96,32 +96,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}} checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/migrate.tmpl
+++ b/templates/repo/migrate/migrate.tmpl
@@ -11,7 +11,7 @@
 								{{.Title}}
 							</div>
 							<div class="description tc">
-								{{(Printf "repo.migrate.%s.description" .Name) | $.i18n.Tr }}
+								{{(Printf "repo.migrate.%s.description" .Name) | $.locale.Tr }}
 							</div>
 						</div>
 					</a>

--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -21,21 +21,21 @@
 					<div class="ui stackable middle very relaxed page grid">
 						<div class="sixteen wide center aligned centered column">
 							<div id="repo_migrating_progress">
-								<p>{{.i18n.Tr "repo.migrate.migrating" .CloneAddr | Safe}}</p>
+								<p>{{.locale.Tr "repo.migrate.migrating" .CloneAddr | Safe}}</p>
 								<p id="repo_migrating_progress_message"></p>
 							</div>
 							<div id="repo_migrating_failed" hidden>
 								{{if .CloneAddr}}
-									<p>{{.i18n.Tr "repo.migrate.migrating_failed" .CloneAddr | Safe}}</p>
+									<p>{{.locale.Tr "repo.migrate.migrating_failed" .CloneAddr | Safe}}</p>
 								{{else}}
-									<p>{{.i18n.Tr "repo.migrate.migrating_failed_no_addr" | Safe}}</p>
+									<p>{{.locale.Tr "repo.migrate.migrating_failed_no_addr" | Safe}}</p>
 								{{end}}
 								<p id="repo_migrating_failed_error"></p>
 							</div>
 							{{if and .Failed .Permission.IsAdmin}}
 								<div class="ui divider"></div>
 								<div class="item">
-									<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{.i18n.Tr "repo.settings.delete"}}</button>
+									<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{.locale.Tr "repo.settings.delete"}}</button>
 								</div>
 							{{end}}
 						</div>
@@ -47,14 +47,14 @@
 </div>
 <div class="ui small modal" id="delete-repo-modal">
 	<div class="header">
-		{{.i18n.Tr "repo.settings.delete"}}
+		{{.locale.Tr "repo.settings.delete"}}
 	</div>
 	<div class="content">
 		<div class="ui warning message text left">
-			{{.i18n.Tr "repo.settings.delete_notices_1" | Safe}}<br>
-			{{.i18n.Tr "repo.settings.delete_notices_2" .Repository.FullName | Safe}}
+			{{.locale.Tr "repo.settings.delete_notices_1" | Safe}}<br>
+			{{.locale.Tr "repo.settings.delete_notices_2" .Repository.FullName | Safe}}
 			{{if .Repository.NumForks}}<br>
-			{{.i18n.Tr "repo.settings.delete_notices_fork_1"}}
+			{{.locale.Tr "repo.settings.delete_notices_fork_1"}}
 			{{end}}
 		</div>
 		<form class="ui form" action="{{.Link}}/settings" method="post">
@@ -62,18 +62,18 @@
 			<input type="hidden" name="action" value="delete">
 			<div class="field">
 				<label>
-					{{.i18n.Tr "repo.settings.transfer_form_title"}}
+					{{.locale.Tr "repo.settings.transfer_form_title"}}
 					<span class="text red">{{.Repository.Name}}</span>
 				</label>
 			</div>
 			<div class="required field">
-				<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+				<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 				<input id="repo_name" name="repo_name" required>
 			</div>
 
 			<div class="text right actions">
-				<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-				<button class="ui red button">{{.i18n.Tr "repo.settings.confirm_delete"}}</button>
+				<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+				<button class="ui red button">{{.locale.Tr "repo.settings.confirm_delete"}}</button>
 			</div>
 		</form>
 	</div>

--- a/templates/repo/migrate/onedev.tmpl
+++ b/templates/repo/migrate/onedev.tmpl
@@ -6,25 +6,25 @@
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "repo.migrate.migrate" .service.Title}}
+					{{.locale.Tr "repo.migrate.migrate" .service.Title}}
 					<input id="service_type" type="hidden" name="service" value="{{.service}}">
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
-						<label for="clone_addr">{{.i18n.Tr "repo.migrate.clone_address"}}</label>
+						<label for="clone_addr">{{.locale.Tr "repo.migrate.clone_address"}}</label>
 						<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
 						<span class="help">
-						{{.i18n.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate.clone_local_path"}}{{end}}
+						{{.locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate.clone_local_path"}}{{end}}
 						</span>
 					</div>
 
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_username">{{.i18n.Tr "username"}}</label>
+						<label for="auth_username">{{.locale.Tr "username"}}</label>
 						<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
 					</div>
 					<div class="inline field {{if .Err_Auth}}error{{end}}">
-						<label for="auth_password">{{.i18n.Tr "password"}}</label>
+						<label for="auth_password">{{.locale.Tr "password"}}</label>
 						<input id="auth_password" name="auth_password" type="password" value="{{.auth_password}}">
 					</div>
 
@@ -32,25 +32,25 @@
 
 					<div id="migrate_items">
 						<div class="inline field">
-							<label>{{.i18n.Tr "repo.migrate_items"}}</label>
+							<label>{{.locale.Tr "repo.migrate_items"}}</label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_milestones" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_labels" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_labels" | Safe}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_issues" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
+								<label>{{.locale.Tr "repo.migrate_items_pullrequests" | Safe}}</label>
 							</div>
 						</div>
 					</div>
@@ -58,7 +58,7 @@
 					<div class="ui divider"></div>
 
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -82,32 +82,32 @@
 					</div>
 
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsForcedPrivate}}
 								<input name="private" type="checkbox" checked readonly>
-								<label>{{.i18n.Tr "repo.visibility_helper_forced" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.migrate_repo"}}
+							{{.locale.Tr "repo.migrate_repo"}}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/migrate/options.tmpl
+++ b/templates/repo/migrate/options.tmpl
@@ -1,9 +1,9 @@
 {{if not .DisableNewPullMirrors}}
 <div class="inline field">
-	<label>{{.i18n.Tr "repo.migrate_options"}}</label>
+	<label>{{.locale.Tr "repo.migrate_options"}}</label>
 	<div class="ui checkbox">
 		<input id="mirror" name="mirror" type="checkbox" {{if .mirror}} checked{{end}}>
-		<label>{{.i18n.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
+		<label>{{.locale.Tr "repo.migrate_options_mirror_helper" | Safe}}</label>
 	</div>
 </div>
 {{end}}
@@ -12,15 +12,15 @@
 	<label></label>
 	<div class="ui checkbox">
 		<input id="lfs" name="lfs" type="checkbox" {{if .lfs}} checked{{end}}>
-		<label>{{.i18n.Tr "repo.migrate_options_lfs"}}</label>
+		<label>{{.locale.Tr "repo.migrate_options_lfs"}}</label>
 	</div>
-	<span id="lfs_settings" style="display:none">(<a id="lfs_settings_show" href="#">{{.i18n.Tr "repo.settings.advanced_settings"}}</a>)</span>
+	<span id="lfs_settings" style="display:none">(<a id="lfs_settings_show" href="#">{{.locale.Tr "repo.settings.advanced_settings"}}</a>)</span>
 </div>
 <div id="lfs_endpoint" style="display:none">
-	<span class="help">{{.i18n.Tr "repo.migrate_options_lfs_endpoint.description" "https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md#server-discovery" | Str2html}}{{if .ContextUser.CanImportLocal}} {{.i18n.Tr "repo.migrate_options_lfs_endpoint.description.local"}}{{end}}</span>
+	<span class="help">{{.locale.Tr "repo.migrate_options_lfs_endpoint.description" "https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md#server-discovery" | Str2html}}{{if .ContextUser.CanImportLocal}} {{.locale.Tr "repo.migrate_options_lfs_endpoint.description.local"}}{{end}}</span>
 	<div class="inline field {{if .Err_LFSEndpoint}}error{{end}}">
-		<label>{{.i18n.Tr "repo.migrate_options_lfs_endpoint.label"}}</label>
-		<input name="lfs_endpoint" value="{{.lfs_endpoint}}" placeholder="{{.i18n.Tr "repo.migrate_options_lfs_endpoint.placeholder"}}">
+		<label>{{.locale.Tr "repo.migrate_options_lfs_endpoint.label"}}</label>
+		<input name="lfs_endpoint" value="{{.lfs_endpoint}}" placeholder="{{.locale.Tr "repo.migrate_options_lfs_endpoint.placeholder"}}">
 	</div>
 </div>
 {{end}}

--- a/templates/repo/projects/list.tmpl
+++ b/templates/repo/projects/list.tmpl
@@ -6,7 +6,7 @@
 			{{template "repo/issue/navbar" .}}
 			{{if and .CanWriteProjects (not .Repository.IsArchived)}}
 				<div class="ui right">
-					<a class="ui green button" href="{{$.Link}}/new">{{.i18n.Tr "repo.projects.new"}}</a>
+					<a class="ui green button" href="{{$.Link}}/new">{{.locale.Tr "repo.projects.new"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -15,11 +15,11 @@
 		<div class="ui compact tiny menu">
 			<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{.RepoLink}}/projects?state=open">
 				{{svg "octicon-project" 16 "mr-3"}}
-				{{JsPrettyNumber .OpenCount}}&nbsp;{{.i18n.Tr "repo.issues.open_title"}}
+				{{JsPrettyNumber .OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 			</a>
 			<a class="item{{if .IsShowClosed}} active{{end}}" href="{{.RepoLink}}/projects?state=closed">
 				{{svg "octicon-check" 16 "mr-3"}}
-				{{JsPrettyNumber .ClosedCount}}&nbsp;{{.i18n.Tr "repo.issues.closed_title"}}
+				{{JsPrettyNumber .ClosedCount}}&nbsp;{{.locale.Tr "repo.issues.closed_title"}}
 			</a>
 		</div>
 
@@ -27,13 +27,13 @@
 			<!-- Sort -->
 			<div class="ui dropdown type jump item">
 				<span class="text">
-					{{.i18n.Tr "repo.issues.filter_sort"}}
+					{{.locale.Tr "repo.issues.filter_sort"}}
 					{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 				</span>
 				<div class="menu">
-					<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=oldest&state={{$.State}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-					<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=recentupdate&state={{$.State}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-					<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=leastupdate&state={{$.State}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+					<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=oldest&state={{$.State}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+					<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=recentupdate&state={{$.State}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+					<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?q={{$.Keyword}}&sort=leastupdate&state={{$.State}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
 				</div>
 			</div>
 		</div>
@@ -42,26 +42,26 @@
 				<li class="item">
 					{{svg "octicon-project"}} <a href="{{$.RepoLink}}/projects/{{.ID}}">{{.Title}}</a>
 					<div class="meta">
-						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.i18n }}
+						{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.locale }}
 						{{if .IsClosed }}
-							{{svg "octicon-clock"}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+							{{svg "octicon-clock"}} {{$.locale.Tr "repo.milestones.closed" $closedDate|Str2html}}
 						{{end}}
 						<span class="issue-stats">
 							{{svg "octicon-issue-opened" 16 "mr-3"}}
-							{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.i18n.Tr "repo.issues.open_title"}}
+							{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
 							{{svg "octicon-check" 16 "mr-3"}}
-							{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.i18n.Tr "repo.issues.closed_title"}}
+							{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
 						</span>
 					</div>
 					{{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}
 					<div class="ui right operate">
-						<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Title}}>{{svg "octicon-pencil"}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+						<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Title}}>{{svg "octicon-pencil"}} {{$.locale.Tr "repo.issues.label_edit"}}</a>
 						{{if .IsClosed}}
-							<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check"}} {{$.i18n.Tr "repo.projects.open"}}</a>
+							<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/open">{{svg "octicon-check"}} {{$.locale.Tr "repo.projects.open"}}</a>
 						{{else}}
-							<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-skip"}} {{$.i18n.Tr "repo.projects.close"}}</a>
+							<a class="link-action" href data-url="{{$.Link}}/{{.ID}}/close">{{svg "octicon-skip"}} {{$.locale.Tr "repo.projects.close"}}</a>
 						{{end}}
-						<a class="delete-button" href="#" data-url="{{$.RepoLink}}/projects/{{.ID}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+						<a class="delete-button" href="#" data-url="{{$.RepoLink}}/projects/{{.ID}}/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.locale.Tr "repo.issues.label_delete"}}</a>
 					</div>
 					{{end}}
 					{{if .Description}}
@@ -81,19 +81,19 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.projects.deletion"}}
+		{{.locale.Tr "repo.projects.deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.projects.deletion_desc"}}</p>
+		<p>{{.locale.Tr "repo.projects.deletion_desc"}}</p>
 	</div>
 	<div class="actions">
 		<div class="ui red basic inverted cancel button">
 			<i class="remove icon"></i>
-			{{.i18n.Tr "modal.no"}}
+			{{.locale.Tr "modal.no"}}
 		</div>
 		<div class="ui green basic inverted ok button">
 			<i class="checkmark icon"></i>
-			{{.i18n.Tr "modal.yes"}}
+			{{.locale.Tr "modal.yes"}}
 		</div>
 	</div>
 </div>

--- a/templates/repo/projects/new.tmpl
+++ b/templates/repo/projects/new.tmpl
@@ -6,18 +6,18 @@
 			{{template "repo/issue/navbar" .}}
 			{{if and .CanWriteProjects .PageIsEditProject}}
 			<div class="ui right floated secondary menu">
-				<a class="ui green button" href="{{$.RepoLink}}/projects/new">{{.i18n.Tr "repo.milestones.new"}}</a>
+				<a class="ui green button" href="{{$.RepoLink}}/projects/new">{{.locale.Tr "repo.milestones.new"}}</a>
 			</div>
 			{{end}}
 		</div>
 		<div class="ui divider"></div>
 		<h2 class="ui dividing header">
 			{{if .PageIsEditProjects}}
-			{{.i18n.Tr "repo.projects.edit"}}
-			<div class="sub header">{{.i18n.Tr "repo.projects.edit_subheader"}}</div>
+			{{.locale.Tr "repo.projects.edit"}}
+			<div class="sub header">{{.locale.Tr "repo.projects.edit_subheader"}}</div>
 			{{else}}
-				{{.i18n.Tr "repo.projects.new"}}
-				<div class="sub header">{{.i18n.Tr "repo.projects.new_subheader"}}</div>
+				{{.locale.Tr "repo.projects.new"}}
+				<div class="sub header">{{.locale.Tr "repo.projects.new_subheader"}}</div>
 				{{end}}
 		</h2>
 		{{template "base/alert" .}}
@@ -25,22 +25,22 @@
 			{{.CsrfTokenHtml}}
 			<div class="eleven wide column">
 				<div class="field {{if .Err_Title}}error{{end}}">
-					<label>{{.i18n.Tr "repo.projects.title"}}</label>
-					<input name="title" placeholder="{{.i18n.Tr "repo.projects.title"}}" value="{{.title}}" autofocus required>
+					<label>{{.locale.Tr "repo.projects.title"}}</label>
+					<input name="title" placeholder="{{.locale.Tr "repo.projects.title"}}" value="{{.title}}" autofocus required>
 				</div>
 				<div class="field">
-					<label>{{.i18n.Tr "repo.projects.description"}}</label>
-					<textarea name="content" placeholder="{{.i18n.Tr "repo.projects.description_placeholder"}}">{{.content}}</textarea>
+					<label>{{.locale.Tr "repo.projects.description"}}</label>
+					<textarea name="content" placeholder="{{.locale.Tr "repo.projects.description_placeholder"}}">{{.content}}</textarea>
 				</div>
 
 				{{if not .PageIsEditProjects}}
-					<label>{{.i18n.Tr "repo.projects.template.desc"}}</label>
+					<label>{{.locale.Tr "repo.projects.template.desc"}}</label>
 					<div class="ui selection dropdown">
 						<input type="hidden" name="board_type" value="{{.type}}">
-						<div class="default text">{{.i18n.Tr "repo.projects.template.desc_helper"}}</div>
+						<div class="default text">{{.locale.Tr "repo.projects.template.desc_helper"}}</div>
 						<div class="menu">
 							{{range $element := .ProjectTypes}}
-								<div class="item" data-id="{{$element.BoardType}}" data-value="{{$element.BoardType}}">{{$.i18n.Tr $element.Translation}}</div>
+								<div class="item" data-id="{{$element.BoardType}}" data-value="{{$element.BoardType}}">{{$.locale.Tr $element.Translation}}</div>
 							{{end}}
 						</div>
 					</div>
@@ -51,14 +51,14 @@
 				<div class="ui left">
 					{{if .PageIsEditProjects}}
 					<a class="ui primary basic button" href="{{.RepoLink}}/projects">
-						{{.i18n.Tr "repo.milestones.cancel"}}
+						{{.locale.Tr "repo.milestones.cancel"}}
 					</a>
 					<button class="ui green button">
-						{{.i18n.Tr "repo.projects.modify"}}
+						{{.locale.Tr "repo.projects.modify"}}
 					</button>
 					{{else}}
 						<button class="ui green button">
-							{{.i18n.Tr "repo.projects.create"}}
+							{{.locale.Tr "repo.projects.create"}}
 						</button>
 					{{end}}
 				</div>

--- a/templates/repo/projects/view.tmpl
+++ b/templates/repo/projects/view.tmpl
@@ -8,22 +8,22 @@
 			</div>
 			<div class="column right aligned">
 				{{if and .CanWriteProjects (not .Repository.IsArchived)}}
-					<a class="ui green button show-modal item" href="{{$.RepoLink}}/issues/new/choose?project={{$.Project.ID}}">{{.i18n.Tr "repo.issues.new"}}</a>
-					<a class="ui green button show-modal item" data-modal="#new-board-item">{{.i18n.Tr "new_project_board"}}</a>
+					<a class="ui green button show-modal item" href="{{$.RepoLink}}/issues/new/choose?project={{$.Project.ID}}">{{.locale.Tr "repo.issues.new"}}</a>
+					<a class="ui green button show-modal item" data-modal="#new-board-item">{{.locale.Tr "new_project_board"}}</a>
 				{{end}}
 				<div class="ui small modal new-board-modal" id="new-board-item">
 					<div class="header">
-						{{$.i18n.Tr "repo.projects.board.new"}}
+						{{$.locale.Tr "repo.projects.board.new"}}
 					</div>
 					<div class="content">
 						<form class="ui form">
 							<div class="required field">
-								<label for="new_board">{{$.i18n.Tr "repo.projects.board.new_title"}}</label>
+								<label for="new_board">{{$.locale.Tr "repo.projects.board.new_title"}}</label>
 								<input class="new-board" id="new_board" name="title" required>
 							</div>
 
 							<div class="field color-field">
-								<label for="new_board_color">{{$.i18n.Tr "repo.projects.board.color"}}</label>
+								<label for="new_board_color">{{$.locale.Tr "repo.projects.board.color"}}</label>
 								<div class="color picker column">
 									<input class="color-picker" maxlength="7" placeholder="#c320f6" id="new_board_color_picker" name="color">
 									<div class="column precolors">
@@ -33,8 +33,8 @@
 							</div>
 
 							<div class="text right actions">
-								<div class="ui cancel button">{{$.i18n.Tr "settings.cancel"}}</div>
-								<button data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}" class="ui green button" id="new_board_submit">{{$.i18n.Tr "repo.projects.board.new_submit"}}</button>
+								<div class="ui cancel button">{{$.locale.Tr "settings.cancel"}}</div>
+								<button data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}" class="ui green button" id="new_board_submit">{{$.locale.Tr "repo.projects.board.new_submit"}}</button>
 							</div>
 						</form>
 					</div>
@@ -52,22 +52,22 @@
 					<div class="ui compact right small menu">
 						<a class="item" href="{{$.RepoLink}}/projects/{{.Project.ID}}/edit" data-id={{$.Project.ID}} data-title={{$.Project.Title}}>
 							{{svg "octicon-pencil"}}
-							<span class="mx-3">{{$.i18n.Tr "repo.issues.label_edit"}}</span>
+							<span class="mx-3">{{$.locale.Tr "repo.issues.label_edit"}}</span>
 						</a>
 						{{if .Project.IsClosed}}
 							<a class="item link-action" href data-url="{{$.RepoLink}}/projects/{{.Project.ID}}/open">
 								{{svg "octicon-check"}}
-								<span class="mx-3">{{$.i18n.Tr "repo.projects.open"}}</span>
+								<span class="mx-3">{{$.locale.Tr "repo.projects.open"}}</span>
 							</a>
 						{{else}}
 							<a class="item link-action" href data-url="{{$.RepoLink}}/projects/{{.Project.ID}}/close">
 								{{svg "octicon-skip"}}
-								<span class="mx-3">{{$.i18n.Tr "repo.projects.close"}}</span>
+								<span class="mx-3">{{$.locale.Tr "repo.projects.close"}}</span>
 							</a>
 						{{end}}
 						<a class="item delete-button" href="#" data-url="{{$.RepoLink}}/projects/{{.Project.ID}}/delete" data-id="{{.Project.ID}}">
 							{{svg "octicon-trash"}}
-							<span class="mx-3">{{$.i18n.Tr "repo.issues.label_delete"}}</span>
+							<span class="mx-3">{{$.locale.Tr "repo.issues.label_delete"}}</span>
 						</a>
 					</div>
 				</div>
@@ -96,32 +96,32 @@
 							<div class="menu user-menu" tabindex="-1">
 								<a class="item show-modal button" data-modal="#edit-project-board-modal-{{.ID}}">
 									{{svg "octicon-pencil"}}
-									{{$.i18n.Tr "repo.projects.board.edit"}}
+									{{$.locale.Tr "repo.projects.board.edit"}}
 								</a>
 								{{if not .Default}}
 									<a class="item show-modal button" data-modal="#set-default-project-board-modal-{{.ID}}">
 										{{svg "octicon-pin"}}
-										{{$.i18n.Tr "repo.projects.board.set_default"}}
+										{{$.locale.Tr "repo.projects.board.set_default"}}
 									</a>
 								{{end}}
 								<a class="item show-modal button" data-modal="#delete-board-modal-{{.ID}}">
 									{{svg "octicon-trash"}}
-									{{$.i18n.Tr "repo.projects.board.delete"}}
+									{{$.locale.Tr "repo.projects.board.delete"}}
 								</a>
 
 								<div class="ui small modal edit-project-board" id="edit-project-board-modal-{{.ID}}">
 									<div class="header">
-										{{$.i18n.Tr "repo.projects.board.edit"}}
+										{{$.locale.Tr "repo.projects.board.edit"}}
 									</div>
 									<div class="content">
 										<form class="ui form">
 											<div class="required field">
-												<label for="new_board_title">{{$.i18n.Tr "repo.projects.board.edit_title"}}</label>
+												<label for="new_board_title">{{$.locale.Tr "repo.projects.board.edit_title"}}</label>
 												<input class="project-board-title" id="new_board_title" name="title" value="{{.Title}}" required>
 											</div>
 
 											<div class="field color-field">
-												<label for="new_board_color">{{$.i18n.Tr "repo.projects.board.color"}}</label>
+												<label for="new_board_color">{{$.locale.Tr "repo.projects.board.color"}}</label>
 												<div class="color picker column">
 													<input class="color-picker" maxlength="7" placeholder="#c320f6" id="new_board_color" name="color" value="{{.Color}}">
 													<div class="column precolors">
@@ -131,8 +131,8 @@
 											</div>
 
 											<div class="text right actions">
-												<div class="ui cancel button">{{$.i18n.Tr "settings.cancel"}}</div>
-												<button data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}" class="ui red button">{{$.i18n.Tr "repo.projects.board.edit"}}</button>
+												<div class="ui cancel button">{{$.locale.Tr "settings.cancel"}}</div>
+												<button data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}" class="ui red button">{{$.locale.Tr "repo.projects.board.edit"}}</button>
 											</div>
 										</form>
 									</div>
@@ -140,31 +140,31 @@
 
 								<div class="ui basic modal" id="set-default-project-board-modal-{{.ID}}">
 									<div class="ui icon header">
-										{{$.i18n.Tr "repo.projects.board.set_default"}}
+										{{$.locale.Tr "repo.projects.board.set_default"}}
 									</div>
 									<div class="content center">
 										<label>
-											{{$.i18n.Tr "repo.projects.board.set_default_desc"}}
+											{{$.locale.Tr "repo.projects.board.set_default_desc"}}
 										</label>
 									</div>
 									<div class="text right actions">
-										<div class="ui cancel button">{{$.i18n.Tr "settings.cancel"}}</div>
-										<button class="ui red button set-default-project-board" data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}/default">{{$.i18n.Tr "repo.projects.board.set_default"}}</button>
+										<div class="ui cancel button">{{$.locale.Tr "settings.cancel"}}</div>
+										<button class="ui red button set-default-project-board" data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}/default">{{$.locale.Tr "repo.projects.board.set_default"}}</button>
 									</div>
 								</div>
 
 								<div class="ui basic modal" id="delete-board-modal-{{.ID}}">
 									<div class="ui icon header">
-										{{$.i18n.Tr "repo.projects.board.delete"}}
+										{{$.locale.Tr "repo.projects.board.delete"}}
 									</div>
 									<div class="content center">
 										<label>
-											{{$.i18n.Tr "repo.projects.board.deletion_desc"}}
+											{{$.locale.Tr "repo.projects.board.deletion_desc"}}
 										</label>
 									</div>
 									<div class="text right actions">
-										<div class="ui cancel button">{{$.i18n.Tr "settings.cancel"}}</div>
-										<button class="ui red button delete-project-board" data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}">{{$.i18n.Tr "repo.projects.board.delete"}}</button>
+										<div class="ui cancel button">{{$.locale.Tr "settings.cancel"}}</div>
+										<button class="ui red button delete-project-board" data-url="{{$.RepoLink}}/projects/{{$.Project.ID}}/{{.ID}}">{{$.locale.Tr "repo.projects.board.delete"}}</button>
 									</div>
 								</div>
 							</div>
@@ -207,13 +207,13 @@
 							<div class="meta my-2">
 								<span class="text light grey">
 									#{{.Index}}
-									{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.i18n }}
+									{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.locale }}
 									{{if .OriginalAuthor }}
-										{{$.i18n.Tr .GetLastEventLabelFake $timeStr (.OriginalAuthor|Escape) | Safe}}
+										{{$.locale.Tr .GetLastEventLabelFake $timeStr (.OriginalAuthor|Escape) | Safe}}
 									{{else if gt .Poster.ID 0}}
-										{{$.i18n.Tr .GetLastEventLabel $timeStr (.Poster.HomeLink|Escape) (.Poster.GetDisplayName | Escape) | Safe}}
+										{{$.locale.Tr .GetLastEventLabel $timeStr (.Poster.HomeLink|Escape) (.Poster.GetDisplayName | Escape) | Safe}}
 									{{else}}
-										{{$.i18n.Tr .GetLastEventLabelFake $timeStr (.Poster.GetDisplayName | Escape) | Safe}}
+										{{$.locale.Tr .GetLastEventLabelFake $timeStr (.Poster.GetDisplayName | Escape) | Safe}}
 									{{end}}
 								</span>
 							</div>
@@ -242,7 +242,7 @@
 							{{ end }}
 							<div class="right floated">
 								{{ range .Assignees }}
-									<a class="tooltip" target="_blank" href="{{.HTMLURL}}" data-content="{{$.i18n.Tr "repo.projects.board.assigned_to"}} {{.Name}}">{{avatar . 28 "mini mr-3"}}</a>
+									<a class="tooltip" target="_blank" href="{{.HTMLURL}}" data-content="{{$.locale.Tr "repo.projects.board.assigned_to"}} {{.Name}}">{{avatar . 28 "mini mr-3"}}</a>
 								{{ end }}
 							</div>
 						</div>
@@ -264,19 +264,19 @@
 	<div class="ui small basic delete modal">
 		<div class="ui icon header">
 			{{svg "octicon-trash"}}
-			{{.i18n.Tr "repo.projects.deletion"}}
+			{{.locale.Tr "repo.projects.deletion"}}
 		</div>
 		<div class="content">
-			<p>{{.i18n.Tr "repo.projects.deletion_desc"}}</p>
+			<p>{{.locale.Tr "repo.projects.deletion_desc"}}</p>
 		</div>
 		<div class="actions">
 			<div class="ui red basic inverted cancel button">
 				<i class="remove icon"></i>
-				{{.i18n.Tr "modal.no"}}
+				{{.locale.Tr "modal.no"}}
 			</div>
 			<div class="ui green basic inverted ok button">
 				<i class="checkmark icon"></i>
-				{{.i18n.Tr "modal.yes"}}
+				{{.locale.Tr "modal.yes"}}
 			</div>
 		</div>
 	</div>

--- a/templates/repo/pulls/commits.tmpl
+++ b/templates/repo/pulls/commits.tmpl
@@ -5,7 +5,7 @@
 		<div class="navbar">
 			{{template "repo/issue/navbar" .}}
 			<div class="ui right">
-				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.locale.Tr "repo.pulls.new"}}</a>
 			</div>
 		</div>
 		<div class="ui divider"></div>

--- a/templates/repo/pulls/files.tmpl
+++ b/templates/repo/pulls/files.tmpl
@@ -9,7 +9,7 @@
 		<div class="navbar">
 			{{template "repo/issue/navbar" .}}
 			<div class="ui right">
-				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+				<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.RepoLink}}/compare/{{.BranchName | PathEscapeSegments}}...{{.PullRequestCtx.HeadInfoSubURL}}">{{.locale.Tr "repo.pulls.new"}}</a>
 			</div>
 		</div>
 		<div class="ui divider"></div>

--- a/templates/repo/pulls/fork.tmpl
+++ b/templates/repo/pulls/fork.tmpl
@@ -5,12 +5,12 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "new_fork"}}
+					{{.locale.Tr "new_fork"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -36,32 +36,32 @@
 					</div>
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.fork_from"}}</label>
+						<label>{{.locale.Tr "repo.fork_from"}}</label>
 						<a href="{{.ForkRepo.Link}}">{{.ForkRepo.FullName}}</a>
 					</div>
 					<div class="inline required field {{if .Err_RepoName}}error{{end}}">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" value="{{.repo_name}}" required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui read-only checkbox">
 							<input type="checkbox" {{if .IsPrivate}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.visibility_helper" | Safe}}</label>
+							<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 						</div>
-						<span class="help">{{.i18n.Tr "repo.fork_visibility_helper"}}</span>
+						<span class="help">{{.locale.Tr "repo.fork_visibility_helper"}}</span>
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
-						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
+						<label for="description">{{.locale.Tr "repo.repo_desc"}}</label>
 						<textarea id="description" name="description">{{.description}}</textarea>
 					</div>
 
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.fork_repo"}}
+							{{.locale.Tr "repo.fork_repo"}}
 						</button>
-						<a class="ui button" href="{{.ForkRepo.Link}}">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{.ForkRepo.Link}}">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/repo/pulls/status.tmpl
+++ b/templates/repo/pulls/status.tmpl
@@ -2,17 +2,17 @@
 	{{if not $.Issue.PullRequest.HasMerged}}
 		<div class="ui top attached header">
 			{{if eq .LatestCommitStatus.State "pending"}}
-				{{$.i18n.Tr "repo.pulls.status_checking"}}
+				{{$.locale.Tr "repo.pulls.status_checking"}}
 			{{else if eq .LatestCommitStatus.State "success"}}
-				{{$.i18n.Tr "repo.pulls.status_checks_success"}}
+				{{$.locale.Tr "repo.pulls.status_checks_success"}}
 			{{else if eq .LatestCommitStatus.State "warning"}}
-				{{$.i18n.Tr "repo.pulls.status_checks_warning"}}
+				{{$.locale.Tr "repo.pulls.status_checks_warning"}}
 			{{else if eq .LatestCommitStatus.State "failure"}}
-				{{$.i18n.Tr "repo.pulls.status_checks_failure"}}
+				{{$.locale.Tr "repo.pulls.status_checks_failure"}}
 			{{else if eq .LatestCommitStatus.State "error"}}
-				{{$.i18n.Tr "repo.pulls.status_checks_error"}}
+				{{$.locale.Tr "repo.pulls.status_checks_error"}}
 			{{else}}
-				{{$.i18n.Tr "repo.pulls.status_checking"}}
+				{{$.locale.Tr "repo.pulls.status_checking"}}
 			{{end}}
 			</div>
 	{{end}}
@@ -23,9 +23,9 @@
 			<span class="ui">{{.Context}} <span class="text grey">{{.Description}}</span></span>
 			<div class="ui right">
 				{{if $.is_context_required}}
-					{{if (call $.is_context_required .Context)}}<div class="ui label">{{$.i18n.Tr "repo.pulls.status_checks_requested"}}</div>{{end}}
+					{{if (call $.is_context_required .Context)}}<div class="ui label">{{$.locale.Tr "repo.pulls.status_checks_requested"}}</div>{{end}}
 				{{end}}
-				<span class="ui">{{if .TargetURL}}<a href="{{.TargetURL}}">{{$.i18n.Tr "repo.pulls.status_checks_details"}}</a>{{end}}</span>
+				<span class="ui">{{if .TargetURL}}<a href="{{.TargetURL}}">{{$.locale.Tr "repo.pulls.status_checks_details"}}</a>{{end}}</span>
 			</div>
 		</div>
 	{{end}}

--- a/templates/repo/pulls/tab_menu.tmpl
+++ b/templates/repo/pulls/tab_menu.tmpl
@@ -1,17 +1,17 @@
 <div class="ui top attached pull tabular stackable menu">
 	<a class="item {{if .PageIsPullConversation}}active{{end}}" href="{{.Issue.Link}}">
 		{{svg "octicon-comment-discussion"}}
-		{{$.i18n.Tr "repo.pulls.tab_conversation"}}
+		{{$.locale.Tr "repo.pulls.tab_conversation"}}
 		<span class="ui {{if not .Issue.NumComments}}gray{{else}}primary{{end}} small label">{{.Issue.NumComments}}</span>
 	</a>
 	<a class="item {{if .PageIsPullCommits}}active{{end}}" {{if .NumCommits}}href="{{.Issue.Link}}/commits"{{end}}>
 		{{svg "octicon-git-commit"}}
-		{{$.i18n.Tr "repo.pulls.tab_commits"}}
+		{{$.locale.Tr "repo.pulls.tab_commits"}}
 		<span class="ui {{if not .NumCommits}}gray{{else}}primary{{end}} small label">{{if .NumCommits}}{{.NumCommits}}{{else}}N/A{{end}}</span>
 	</a>
 	<a class="item {{if .PageIsPullFiles}}active{{end}}" {{if .NumFiles}}href="{{.Issue.Link}}/files"{{end}}>
 		{{svg "octicon-diff"}}
-		{{$.i18n.Tr "repo.pulls.tab_files"}}
+		{{$.locale.Tr "repo.pulls.tab_files"}}
 		<span class="ui {{if not .NumFiles}}gray{{else}}primary{{end}} small label">{{if .NumFiles}}{{.NumFiles}}{{else}}N/A{{end}}</span>
 	</a>
 </div>

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -5,15 +5,15 @@
 		{{template "base/alert" .}}
 		<h2 class="ui compact small menu header">
 			{{if .Permission.CanRead $.UnitTypeReleases}}
-				<a class="{{if (not .PageIsTagList)}}active{{end}} item" href="{{.RepoLink}}/releases">{{.i18n.Tr "repo.release.releases"}}</a>
+				<a class="{{if (not .PageIsTagList)}}active{{end}} item" href="{{.RepoLink}}/releases">{{.locale.Tr "repo.release.releases"}}</a>
 			{{end}}
 			{{if .Permission.CanRead $.UnitTypeCode}}
-				<a class="{{if .PageIsTagList}}active{{end}} item" href="{{.RepoLink}}/tags">{{.i18n.Tr "repo.release.tags"}}</a>
+				<a class="{{if .PageIsTagList}}active{{end}} item" href="{{.RepoLink}}/tags">{{.locale.Tr "repo.release.tags"}}</a>
 			{{end}}
 		</h2>
 		{{if (and .CanCreateRelease (not .PageIsTagList))}}
 			<a class="ui right small green button" href="{{$.RepoLink}}/releases/new">
-				{{.i18n.Tr "repo.release.new_release"}}
+				{{.locale.Tr "repo.release.new_release"}}
 			</a>
 		{{end}}
 		{{if .PageIsTagList}}
@@ -21,7 +21,7 @@
 		{{if gt .ReleasesNum 0}}
 		<h4 class="ui top attached header">
 			<div class="five wide column df ac">
-				{{svg "octicon-tag" 16 "mr-2"}}{{.i18n.Tr "repo.release.tags"}}
+				{{svg "octicon-tag" 16 "mr-2"}}{{.locale.Tr "repo.release.tags"}}
 			</div>
 		</h4>
 		<div class="ui attached table segment">
@@ -40,15 +40,15 @@
 										<a class="archive-link mr-3" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.zip" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-2"}}ZIP</a>
 										<a class="archive-link mr-3" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.tar.gz" rel="nofollow">{{svg "octicon-file-zip" 16 "mr-2"}}TAR.GZ</a>
 										{{if (and $.CanCreateRelease $release.IsTag)}}
-											<a class="mr-3" href="{{$.RepoLink}}/releases/new?tag={{.TagName}}">{{svg "octicon-tag" 16 "mr-2"}}{{$.i18n.Tr "repo.release.new_release"}}</a>
+											<a class="mr-3" href="{{$.RepoLink}}/releases/new?tag={{.TagName}}">{{svg "octicon-tag" 16 "mr-2"}}{{$.locale.Tr "repo.release.new_release"}}</a>
 										{{end}}
 										{{if (and ($.Permission.CanWrite $.UnitTypeCode) $release.IsTag)}}
 											<a class="ui red delete-button mr-3" data-url="{{$.RepoLink}}/tags/delete" data-id="{{.ID}}">
-												{{svg "octicon-trash" 16 "mr-2"}}{{$.i18n.Tr "repo.release.delete_tag"}}
+												{{svg "octicon-trash" 16 "mr-2"}}{{$.locale.Tr "repo.release.delete_tag"}}
 											</a>
 										{{end}}
 										{{if (not $release.IsTag)}}
-											<a class="mr-3" href="{{$.RepoLink}}/releases/tag/{{.TagName | PathEscapeSegments}}">{{svg "octicon-tag" 16 "mr-2"}}{{$.i18n.Tr "repo.release.detail"}}</a>
+											<a class="mr-3" href="{{$.RepoLink}}/releases/tag/{{.TagName | PathEscapeSegments}}">{{svg "octicon-tag" 16 "mr-2"}}{{$.locale.Tr "repo.release.detail"}}</a>
 										{{end}}
 									{{end}}
 								</div>
@@ -65,14 +65,14 @@
 				<li class="ui grid">
 					<div class="ui four wide column meta mt-2">
 						{{if .IsTag}}
-							{{if .CreatedUnix}}<span class="time">{{TimeSinceUnix .CreatedUnix $.i18n}}</span>{{end}}
+							{{if .CreatedUnix}}<span class="time">{{TimeSinceUnix .CreatedUnix $.locale}}</span>{{end}}
 						{{else}}
 							{{if .IsDraft}}
-								<span class="ui yellow label">{{$.i18n.Tr "repo.release.draft"}}</span>
+								<span class="ui yellow label">{{$.locale.Tr "repo.release.draft"}}</span>
 							{{else if .IsPrerelease}}
-								<span class="ui orange label">{{$.i18n.Tr "repo.release.prerelease"}}</span>
+								<span class="ui orange label">{{$.locale.Tr "repo.release.prerelease"}}</span>
 							{{else}}
-								<span class="ui green label">{{$.i18n.Tr "repo.release.stable"}}</span>
+								<span class="ui green label">{{$.locale.Tr "repo.release.stable"}}</span>
 							{{end}}
 							<span class="tag text blue">
 								<a class="df ac je" href="{{if .IsDraft}}#{{else}}{{$.RepoLink}}/src/tag/{{.TagName | PathEscapeSegments}}{{end}}" rel="nofollow">{{svg "octicon-tag" 16 "mr-2"}}{{.TagName}}</a>
@@ -99,7 +99,7 @@
 									<a href="{{.Publisher.HomeLink}}">{{.Publisher.Name}}</a>
 								</span>
 								{{ end }}
-								<span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}{{if .Target}}...{{.Target | PathEscapeSegments}}{{end}}">{{$.i18n.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.i18n.Tr "repo.release.ahead.target" $.DefaultBranch}}</span>
+								<span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}{{if .Target}}...{{.Target | PathEscapeSegments}}{{end}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" $.DefaultBranch}}</span>
 							</p>
 							<div class="download">
 							{{if $.Permission.CanRead $.UnitTypeCode}}
@@ -113,7 +113,7 @@
 								<a href="{{$.RepoLink}}/releases/tag/{{.TagName | PathEscapeSegments}}">{{.Title}}</a>
 								{{if $.CanCreateRelease}}
 									<small class="ml-2">
-										(<a href="{{$.RepoLink}}/releases/edit/{{.TagName | PathEscapeSegments}}" rel="nofollow">{{$.i18n.Tr "repo.release.edit"}}</a>)
+										(<a href="{{$.RepoLink}}/releases/edit/{{.TagName | PathEscapeSegments}}" rel="nofollow">{{$.locale.Tr "repo.release.edit"}}</a>)
 									</small>
 								{{end}}
 							</h4>
@@ -129,13 +129,13 @@
 								{{end}}
 								</span>
 								<span class="released">
-									{{$.i18n.Tr "repo.released_this"}}
+									{{$.locale.Tr "repo.released_this"}}
 								</span>
 								{{if .CreatedUnix}}
-									<span class="time">{{TimeSinceUnix .CreatedUnix $.i18n}}</span>
+									<span class="time">{{TimeSinceUnix .CreatedUnix $.locale}}</span>
 								{{end}}
 								{{if not .IsDraft}}
-									| <span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}...{{.Target | PathEscapeSegments}}">{{$.i18n.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.i18n.Tr "repo.release.ahead.target" .Target}}</span>
+									| <span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}...{{.Target | PathEscapeSegments}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" .Target}}</span>
 								{{end}}
 							</p>
 							<div class="markup desc">
@@ -143,15 +143,15 @@
 							</div>
 							<details class="download border-secondary-top mt-4 pt-4" {{if eq $idx 0}}open{{end}}>
 								<summary class="mb-4">
-									{{$.i18n.Tr "repo.release.downloads"}}
+									{{$.locale.Tr "repo.release.downloads"}}
 								</summary>
 								<ul class="list">
 									{{if and (not .IsDraft) ($.Permission.CanRead $.UnitTypeCode)}}
 										<li>
-											<a class="archive-link" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.zip" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 "mr-2"}}{{$.i18n.Tr "repo.release.source_code"}} (ZIP)</strong></a>
+											<a class="archive-link" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.zip" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 "mr-2"}}{{$.locale.Tr "repo.release.source_code"}} (ZIP)</strong></a>
 										</li>
 										<li>
-											<a class="archive-link" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.tar.gz" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 "mr-2"}}{{$.i18n.Tr "repo.release.source_code"}} (TAR.GZ)</strong></a>
+											<a class="archive-link" href="{{$.RepoLink}}/archive/{{.TagName | PathEscapeSegments}}.tar.gz" rel="nofollow"><strong>{{svg "octicon-file-zip" 16 "mr-2"}}{{$.locale.Tr "repo.release.source_code"}} (TAR.GZ)</strong></a>
 										</li>
 									{{end}}
 									{{if .Attachments}}
@@ -159,7 +159,7 @@
 											<li>
 												<span class="ui text middle aligned right">
 													<span class="ui text grey">{{.Size | FileSize}}</span>
-													<span class="tooltip" data-content="{{$.i18n.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}">
+													<span class="tooltip" data-content="{{$.locale.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}">
 														{{svg "octicon-info"}}
 													</span>
 												</span>
@@ -186,10 +186,10 @@
 	<div class="ui small basic delete modal">
 		<div class="ui header">
 			{{svg "octicon-trash" 16 "mr-2"}}
-			{{.i18n.Tr "repo.release.delete_tag"}}
+			{{.locale.Tr "repo.release.delete_tag"}}
 		</div>
 		<div class="content">
-			<p>{{.i18n.Tr "repo.release.deletion_tag_desc"}}</p>
+			<p>{{.locale.Tr "repo.release.deletion_tag_desc"}}</p>
 		</div>
 		{{template "base/delete_modal_actions" .}}
 	</div>

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -4,11 +4,11 @@
 	<div class="ui container">
 		<h2 class="ui dividing header">
 			{{if .PageIsEditRelease}}
-				{{.i18n.Tr "repo.release.edit_release"}}
-				<div class="sub header">{{.i18n.Tr "repo.release.edit_subheader"}}</div>
+				{{.locale.Tr "repo.release.edit_release"}}
+				<div class="sub header">{{.locale.Tr "repo.release.edit_subheader"}}</div>
 			{{else}}
-				{{.i18n.Tr "repo.release.new_release"}}
-				<div class="sub header">{{.i18n.Tr "repo.release.new_subheader"}}</div>
+				{{.locale.Tr "repo.release.new_release"}}
+				<div class="sub header">{{.locale.Tr "repo.release.new_subheader"}}</div>
 			{{end}}
 		</h2>
 		{{template "base/alert" .}}
@@ -19,13 +19,13 @@
 					{{if .PageIsEditRelease}}
 						<b>{{.tag_name}}</b><span class="at">@</span><strong>{{.tag_target}}</strong>
 					{{else}}
-						<input id="tag-name" name="tag_name" value="{{.tag_name}}" placeholder="{{.i18n.Tr "repo.release.tag_name"}}" autofocus required maxlength="255">
+						<input id="tag-name" name="tag_name" value="{{.tag_name}}" placeholder="{{.locale.Tr "repo.release.tag_name"}}" autofocus required maxlength="255">
 						<span class="at">@</span>
 						<div class="ui selection dropdown">
 							<input type="hidden" name="tag_target" value="{{.tag_target}}"/>
 							{{svg "octicon-git-branch"}}
 							<div class="text">
-								{{.i18n.Tr "repo.release.target"}} :
+								{{.locale.Tr "repo.release.target"}} :
 								<strong id="repo-branch-current">{{.Repository.DefaultBranch}}</strong>
 							</div>
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -35,40 +35,40 @@
 								{{end}}
 							</div>
 						</div>
-						<span class="help">{{.i18n.Tr "repo.release.tag_helper"}}</span>
+						<span class="help">{{.locale.Tr "repo.release.tag_helper"}}</span>
 					{{end}}
 				</div>
 			</div>
 			<div class="eleven wide column">
 				<div class="field {{if .Err_Title}}error{{end}}">
-					<label>{{.i18n.Tr "repo.release.title"}}</label>
-					<input name="title" placeholder="{{.i18n.Tr "repo.release.title"}}" value="{{.title}}" autofocus required maxlength="255">
+					<label>{{.locale.Tr "repo.release.title"}}</label>
+					<input name="title" placeholder="{{.locale.Tr "repo.release.title"}}" value="{{.title}}" autofocus required maxlength="255">
 				</div>
 				<div class="field content-editor">
-					<label>{{.i18n.Tr "repo.release.content"}}</label>
+					<label>{{.locale.Tr "repo.release.content"}}</label>
 					<div class="ui top tabular menu" data-write="write" data-preview="preview">
-						<a class="active write item" data-tab="write">{{$.i18n.Tr "write"}}</a>
-						<a class="preview item" data-tab="preview" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "preview"}}</a>
+						<a class="active write item" data-tab="write">{{$.locale.Tr "write"}}</a>
+						<a class="preview item" data-tab="preview" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.locale.Tr "preview"}}</a>
 					</div>
 					<div class="ui bottom active tab" data-tab="write">
 						<textarea name="content">{{.content}}</textarea>
 					</div>
 					<div class="ui bottom tab markup" data-tab="preview">
-						{{$.i18n.Tr "loading"}}
+						{{$.locale.Tr "loading"}}
 					</div>
 				</div>
 				{{range .attachments}}
 					<div class="field" id="attachment-{{.ID}}">
 						<div class="ui right df ac wrap_remove">
 							<a class="ui mini compact red button remove-rel-attach" data-id="{{.ID}}" data-uuid="{{.UUID}}">
-								{{$.i18n.Tr "remove"}}
+								{{$.locale.Tr "remove"}}
 							</a>
 						</div>
 						<div class="df ac">
 							<input name="attachment-edit-{{.UUID}}" class="mr-3 attachment_edit" required value="{{.Name}}"/>
 							<input name="attachment-del-{{.UUID}}" type="hidden" value="false"/>
 							<span class="ui text grey mr-3">{{.Size | FileSize}}</span>
-							<span class="tooltip" data-content="{{$.i18n.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}">
+							<span class="tooltip" data-content="{{$.locale.Tr "repo.release.download_count" (.DownloadCount | PrettyNumber)}}">
 								{{svg "octicon-info"}}
 							</span>
 						</div>
@@ -87,7 +87,7 @@
 						<div class="tag-message field">
 							<div class="ui checkbox">
 								<input type="checkbox" name="add_tag_msg">
-								<label><strong>{{.i18n.Tr "repo.release.add_tag_msg"}}</strong></label>
+								<label><strong>{{.locale.Tr "repo.release.add_tag_msg"}}</strong></label>
 							</div>
 						</div>
 					{{else}}
@@ -96,35 +96,35 @@
 					<div class="prerelease field">
 						<div class="ui checkbox">
 							<input type="checkbox" name="prerelease" {{if .prerelease}}checked{{end}}>
-							<label><strong>{{.i18n.Tr "repo.release.prerelease_desc"}}</strong></label>
+							<label><strong>{{.locale.Tr "repo.release.prerelease_desc"}}</strong></label>
 						</div>
 					</div>
-					<span class="help">{{.i18n.Tr "repo.release.prerelease_helper"}}</span>
+					<span class="help">{{.locale.Tr "repo.release.prerelease_helper"}}</span>
 					<div class="field">
 						{{if .PageIsEditRelease}}
 							<a class="ui button" href="{{.RepoLink}}/releases">
-								{{.i18n.Tr "repo.release.cancel"}}
+								{{.locale.Tr "repo.release.cancel"}}
 							</a>
 							<a class="ui red button delete-button" data-url="{{$.RepoLink}}/releases/delete" data-id="{{.ID}}">
-								{{$.i18n.Tr "repo.release.delete_release"}}
+								{{$.locale.Tr "repo.release.delete_release"}}
 							</a>
 							{{if .IsDraft}}
-								<input class="ui button" type="submit" name="draft" value="{{.i18n.Tr "repo.release.save_draft"}}"/>
+								<input class="ui button" type="submit" name="draft" value="{{.locale.Tr "repo.release.save_draft"}}"/>
 								<button class="ui primary button">
-									{{.i18n.Tr "repo.release.publish"}}
+									{{.locale.Tr "repo.release.publish"}}
 								</button>
 							{{else}}
 								<button class="ui primary button">
-									{{.i18n.Tr "repo.release.edit_release"}}
+									{{.locale.Tr "repo.release.edit_release"}}
 								</button>
 							{{end}}
 						{{else}}
 							{{if not .tag_name}}
-								<input class="ui grey button" type="submit" name="tag_only" value="{{.i18n.Tr "repo.release.add_tag"}}"/>
+								<input class="ui grey button" type="submit" name="tag_only" value="{{.locale.Tr "repo.release.add_tag"}}"/>
 							{{end}}
-							<input class="ui button" type="submit" name="draft" value="{{.i18n.Tr "repo.release.save_draft"}}"/>
+							<input class="ui button" type="submit" name="draft" value="{{.locale.Tr "repo.release.save_draft"}}"/>
 							<button class="ui primary button">
-								{{.i18n.Tr "repo.release.publish"}}
+								{{.locale.Tr "repo.release.publish"}}
 							</button>
 						{{end}}
 					</div>
@@ -138,10 +138,10 @@
 	<div class="ui small basic delete modal">
 		<div class="ui icon header">
 			{{svg "octicon-trash"}}
-			{{.i18n.Tr "repo.release.deletion"}}
+			{{.locale.Tr "repo.release.deletion"}}
 		</div>
 		<div class="content">
-			<p>{{.i18n.Tr "repo.release.deletion_desc"}}</p>
+			<p>{{.locale.Tr "repo.release.deletion_desc"}}</p>
 		</div>
 		{{template "base/delete_modal_actions" .}}
 	</div>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -5,13 +5,13 @@
 		<div class="ui repo-search">
 			<form class="ui form ignore-dirty" method="get">
 				<div class="ui fluid action input">
-					<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.i18n.Tr "repo.search.search_repo"}}">
+					<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable }} disabled{{end}} placeholder="{{.locale.Tr "repo.search.search_repo"}}">
 					<div class="ui dropdown selection{{if .CodeIndexerUnavailable }} disabled{{end}}">
 						<input name="t" type="hidden"{{if .CodeIndexerUnavailable }} disabled{{end}} value="{{.queryType}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="text">{{.i18n.Tr (printf "repo.search.%s" (or .queryType "fuzzy"))}}</div>
+						<div class="text">{{.locale.Tr (printf "repo.search.%s" (or .queryType "fuzzy"))}}</div>
 						<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
-							<div class="item" data-value="">{{.i18n.Tr "repo.search.fuzzy"}}</div>
-							<div class="item" data-value="match">{{.i18n.Tr "repo.search.match"}}</div>
+							<div class="item" data-value="">{{.locale.Tr "repo.search.fuzzy"}}</div>
+							<div class="item" data-value="match">{{.locale.Tr "repo.search.match"}}</div>
 						</div>
 					</div>
 					<button class="ui icon button"{{if .CodeIndexerUnavailable }} disabled{{end}} type="submit">{{svg "octicon-search" 16}}</button>
@@ -20,11 +20,11 @@
 		</div>
 		{{if .CodeIndexerUnavailable }}
 			<div class="ui error message">
-				<p>{{$.i18n.Tr "repo.search.code_search_unavailable"}}</p>
+				<p>{{$.locale.Tr "repo.search.code_search_unavailable"}}</p>
 			</div>
 		{{else if .Keyword}}
 			<h3>
-				{{.i18n.Tr "repo.search.results" (.Keyword|Escape) (.RepoLink|Escape) (.RepoName|Escape) | Str2html }}
+				{{.locale.Tr "repo.search.results" (.Keyword|Escape) (.RepoLink|Escape) (.RepoName|Escape) | Str2html }}
 			</h3>
 			{{if .SearchResults}}
 				<div class="df ac fw">
@@ -41,7 +41,7 @@
 						<div class="diff-file-box diff-box file-content non-diff-file-content repo-search-result">
 							<h4 class="ui top attached normal header">
 								<span class="file">{{.Filename}}</span>
-								<a class="ui basic tiny button" rel="nofollow" href="{{$.SourcePath}}/src/commit/{{PathEscape $result.CommitID}}/{{PathEscapeSegments .Filename}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+								<a class="ui basic tiny button" rel="nofollow" href="{{$.SourcePath}}/src/commit/{{PathEscape $result.CommitID}}/{{PathEscapeSegments .Filename}}">{{$.locale.Tr "repo.diff.view_file"}}</a>
 							</h4>
 							<div class="ui attached table segment">
 								<div class="file-body file-code code-view">
@@ -65,7 +65,7 @@
 				</div>
 				{{template "base/paginate" .}}
 			{{else}}
-				<div>{{$.i18n.Tr "repo.search.code_no_results"}}</div>
+				<div>{{$.locale.Tr "repo.search.code_no_results"}}</div>
 			{{end}}
 		{{end}}
 	</div>

--- a/templates/repo/settings/branches.tmpl
+++ b/templates/repo/settings/branches.tmpl
@@ -6,15 +6,15 @@
 		{{template "base/alert" .}}
 		{{if .Repository.IsArchived}}
 			<div class="ui warning message">
-				{{.i18n.Tr "repo.settings.archive.branchsettings_unavailable"}}
+				{{.locale.Tr "repo.settings.archive.branchsettings_unavailable"}}
 			</div>
 		{{else}}
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.default_branch"}}
+				{{.locale.Tr "repo.default_branch"}}
 			</h4>
 			<div class="ui attached segment">
 				<p>
-					{{.i18n.Tr "repo.settings.default_branch_desc"}}
+					{{.locale.Tr "repo.settings.default_branch_desc"}}
 				</p>
 				<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
@@ -35,14 +35,14 @@
 								{{end}}
 							</div>
 						</div>
-						<button class="ui green button">{{$.i18n.Tr "repo.settings.branches.update_default_branch"}}</button>
+						<button class="ui green button">{{$.locale.Tr "repo.settings.branches.update_default_branch"}}</button>
 					</div>
 					{{end}}
 				</form>
 			</div>
 
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.settings.protected_branch"}}
+				{{.locale.Tr "repo.settings.protected_branch"}}
 			</h4>
 
 			<div class="ui attached table segment">
@@ -50,7 +50,7 @@
 					<div class="eight wide column">
 						<div class="ui fluid dropdown selection" tabindex="0">
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-							<div class="default text">{{.i18n.Tr "repo.settings.choose_branch"}}</div>
+							<div class="default text">{{.locale.Tr "repo.settings.choose_branch"}}</div>
 							<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
 								{{range .LeftBranches}}
 									<a class="item" href="{{$.Repository.Link}}/settings/branches/{{. | PathEscapeSegments}}">{{.}}</a>
@@ -67,10 +67,10 @@
 								{{range .ProtectedBranches}}
 									<tr>
 										<td><div class="ui basic primary label">{{.BranchName}}</div></td>
-										<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName | PathEscapeSegments}}">{{$.i18n.Tr "repo.settings.edit_protected_branch"}}</a></td>
+										<td class="right aligned"><a class="rm ui button" href="{{$.Repository.Link}}/settings/branches/{{.BranchName | PathEscapeSegments}}">{{$.locale.Tr "repo.settings.edit_protected_branch"}}</a></td>
 									</tr>
 								{{else}}
-									<tr class="center aligned"><td>{{.i18n.Tr "repo.settings.no_protected_branch"}}</td></tr>
+									<tr class="center aligned"><td>{{.locale.Tr "repo.settings.no_protected_branch"}}</td></tr>
 								{{end}}
 							</tbody>
 						</table>
@@ -80,21 +80,21 @@
 
 			{{if $.Repository.CanCreateBranch}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "repo.settings.rename_branch"}}
+					{{.locale.Tr "repo.settings.rename_branch"}}
 				</h4>
 				<div class="ui attached segment">
 					<form class="ui form" action="{{$.Repository.Link}}/settings/rename_branch" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="required field">
-							<label for="from">{{.i18n.Tr "repo.settings.rename_branch_from"}}</label>
+							<label for="from">{{.locale.Tr "repo.settings.rename_branch_from"}}</label>
 							<input id="from" name="from" required>
 						</div>
 						<div class="required field {{if .Err_BranchName}}error{{end}}">
-							<label for="to">{{.i18n.Tr "repo.settings.rename_branch_to"}}</label>
+							<label for="to">{{.locale.Tr "repo.settings.rename_branch_to"}}</label>
 							<input id="to" name="to" required>
 						</div>
 						<div class="field">
-							<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+							<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 						</div>
 					</form>
 				</div>

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.collaboration"}}
+			{{.locale.Tr "repo.settings.collaboration"}}
 		</h4>
 		{{if .Collaborators}}
 		<div class="ui attached segment collaborator list">
@@ -20,18 +20,18 @@
 					<div class="ui eight wide column">
 						{{svg "octicon-shield-lock"}}
 						<div class="ui inline dropdown access-mode" data-url="{{$.Link}}/access_mode" data-uid="{{.ID}}" data-last-value="{{printf "%d" .Collaboration.Mode}}">
-							<div class="text">{{if eq .Collaboration.Mode 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .Collaboration.Mode 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .Collaboration.Mode 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
+							<div class="text">{{if eq .Collaboration.Mode 1}}{{$.locale.Tr "repo.settings.collaboration.read"}}{{else if eq .Collaboration.Mode 2}}{{$.locale.Tr "repo.settings.collaboration.write"}}{{else if eq .Collaboration.Mode 3}}{{$.locale.Tr "repo.settings.collaboration.admin"}}{{else}}{{$.locale.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							<div class="menu">
-								<div class="item" data-text="{{$.i18n.Tr "repo.settings.collaboration.admin"}}" data-value="3">{{$.i18n.Tr "repo.settings.collaboration.admin"}}</div>
-								<div class="item" data-text="{{$.i18n.Tr "repo.settings.collaboration.write"}}" data-value="2">{{$.i18n.Tr "repo.settings.collaboration.write"}}</div>
-								<div class="item" data-text="{{$.i18n.Tr "repo.settings.collaboration.read"}}" data-value="1">{{$.i18n.Tr "repo.settings.collaboration.read"}}</div>
+								<div class="item" data-text="{{$.locale.Tr "repo.settings.collaboration.admin"}}" data-value="3">{{$.locale.Tr "repo.settings.collaboration.admin"}}</div>
+								<div class="item" data-text="{{$.locale.Tr "repo.settings.collaboration.write"}}" data-value="2">{{$.locale.Tr "repo.settings.collaboration.write"}}</div>
+								<div class="item" data-text="{{$.locale.Tr "repo.settings.collaboration.read"}}" data-value="1">{{$.locale.Tr "repo.settings.collaboration.read"}}</div>
 							</div>
 						</div>
 					</div>
 					<div class="ui two wide column">
 						<button class="ui red tiny button inline text-thin delete-button" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
-							{{$.i18n.Tr "repo.settings.delete_collaborator"}}
+							{{$.locale.Tr "repo.settings.delete_collaborator"}}
 						</button>
 					</div>
 				</div>
@@ -44,17 +44,17 @@
 				<div class="inline field ui left">
 					<div id="search-user-box" class="ui search">
 						<div class="ui input">
-							<input class="prompt" name="collaborator" placeholder="{{.i18n.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" autofocus required>
+							<input class="prompt" name="collaborator" placeholder="{{.locale.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" autofocus required>
 						</div>
 					</div>
 				</div>
-				<button class="ui green button">{{.i18n.Tr "repo.settings.add_collaborator"}}</button>
+				<button class="ui green button">{{.locale.Tr "repo.settings.add_collaborator"}}</button>
 			</form>
 		</div>
 
 		{{if .RepoOwnerIsOrganization}}
 		<h4 class="ui top attached header">
-			{{$.i18n.Tr "repo.settings.teams"}}
+			{{$.locale.Tr "repo.settings.teams"}}
 		</h4>
 		{{ $allowedToChangeTeams := ( or (.Org.RepoAdminChangeTeamAccess) (.Permission.IsOwner)) }}
 		{{if .Teams}}
@@ -66,22 +66,22 @@
 							{{.Name}}
 						</a>
 					</div>
-					<div class="ui eight wide column tooltip" data-content="{{$.i18n.Tr "repo.settings.change_team_permission_tip"}}">
+					<div class="ui eight wide column tooltip" data-content="{{$.locale.Tr "repo.settings.change_team_permission_tip"}}">
 						{{svg "octicon-shield-lock"}}
 						<div class="ui inline dropdown">
-							<div class="text">{{if eq .AccessMode 1}}{{$.i18n.Tr "repo.settings.collaboration.read"}}{{else if eq .AccessMode 2}}{{$.i18n.Tr "repo.settings.collaboration.write"}}{{else if eq .AccessMode 3}}{{$.i18n.Tr "repo.settings.collaboration.admin"}}{{else if eq .AccessMode 4}}{{$.i18n.Tr "repo.settings.collaboration.owner"}}{{else}}{{$.i18n.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
+							<div class="text">{{if eq .AccessMode 1}}{{$.locale.Tr "repo.settings.collaboration.read"}}{{else if eq .AccessMode 2}}{{$.locale.Tr "repo.settings.collaboration.write"}}{{else if eq .AccessMode 3}}{{$.locale.Tr "repo.settings.collaboration.admin"}}{{else if eq .AccessMode 4}}{{$.locale.Tr "repo.settings.collaboration.owner"}}{{else}}{{$.locale.Tr "repo.settings.collaboration.undefined"}}{{end}}</div>
 						</div>
 						{{ if or (eq .AccessMode 1) (eq .AccessMode 2) }}
 							{{ $first := true }}
 							<div class="description">
-							Sections: {{range $u, $unit := $.Units}}{{if and ($.Repo.UnitEnabled $unit.Type) ($team.UnitEnabled $unit.Type)}}{{if $first}}{{ $first = false }}{{else}}, {{end}}{{$.i18n.Tr $unit.NameKey}}{{end}}{{end}} {{if $first}}None{{end}}
+							Sections: {{range $u, $unit := $.Units}}{{if and ($.Repo.UnitEnabled $unit.Type) ($team.UnitEnabled $unit.Type)}}{{if $first}}{{ $first = false }}{{else}}, {{end}}{{$.locale.Tr $unit.NameKey}}{{end}}{{end}} {{if $first}}None{{end}}
 							</div>
 						{{end}}
 					</div>
 					{{if $allowedToChangeTeams}}
-						<div class="ui two wide column {{if .IncludesAllRepositories}}tooltip{{end}}" {{if .IncludesAllRepositories}} data-content="{{$.i18n.Tr "repo.settings.delete_team_tip"}}"{{end}}>
+						<div class="ui two wide column {{if .IncludesAllRepositories}}tooltip{{end}}" {{if .IncludesAllRepositories}} data-content="{{$.locale.Tr "repo.settings.delete_team_tip"}}"{{end}}>
 							<button class="ui red tiny button inline text-thin delete-button {{if .IncludesAllRepositories}}disabled{{end}}" data-url="{{$.Link}}/team/delete" data-id="{{.ID}}">
-									{{$.i18n.Tr "repo.settings.delete_collaborator"}}
+									{{$.locale.Tr "repo.settings.delete_collaborator"}}
 							</button>
 						</div>
 					{{end}}
@@ -96,15 +96,15 @@
 					<div class="inline field ui left">
 						<div id="search-team-box" class="ui search" data-org="{{.OrgName}}">
 							<div class="ui input">
-								<input class="prompt" name="team" placeholder="{{$.i18n.Tr "repo.settings.search_team"}}" autocomplete="off" autofocus required>
+								<input class="prompt" name="team" placeholder="{{$.locale.Tr "repo.settings.search_team"}}" autocomplete="off" autofocus required>
 							</div>
 						</div>
 					</div>
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.add_team"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.add_team"}}</button>
 				</form>
 			{{else}}
 				<div class="item">
-					{{$.i18n.Tr "repo.settings.change_team_access_not_allowed"}}
+					{{$.locale.Tr "repo.settings.change_team_access_not_allowed"}}
 				</div>
 			{{end}}
 		</div>
@@ -115,10 +115,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.settings.collaborator_deletion"}}
+		{{.locale.Tr "repo.settings.collaborator_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.settings.collaborator_deletion_desc"}}</p>
+		<p>{{.locale.Tr "repo.settings.collaborator_deletion_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/repo/settings/deploy_keys.tmpl
+++ b/templates/repo/settings/deploy_keys.tmpl
@@ -5,12 +5,12 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.deploy_keys"}}
+			{{.locale.Tr "repo.settings.deploy_keys"}}
 			<div class="ui right">
 			{{if not .DisableSSH}}
-				<div class="ui primary tiny show-panel button" data-panel="#add-deploy-key-panel">{{.i18n.Tr "repo.settings.add_deploy_key"}}</div>
+				<div class="ui primary tiny show-panel button" data-panel="#add-deploy-key-panel">{{.locale.Tr "repo.settings.add_deploy_key"}}</div>
 			{{else}}
-				<div class="ui primary tiny button disabled">{{.i18n.Tr "settings.ssh_disabled"}}</div>
+				<div class="ui primary tiny button disabled">{{.locale.Tr "settings.ssh_disabled"}}</div>
 			{{end}}
 			</div>
 		</h4>
@@ -19,30 +19,30 @@
 				<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<div class="field">
-						{{.i18n.Tr "repo.settings.deploy_key_desc"}}
+						{{.locale.Tr "repo.settings.deploy_key_desc"}}
 					</div>
 					<div class="field {{if .Err_Title}}error{{end}}">
-						<label for="title">{{.i18n.Tr "repo.settings.title"}}</label>
+						<label for="title">{{.locale.Tr "repo.settings.title"}}</label>
 						<input id="ssh-key-title" name="title" value="{{.title}}" autofocus required>
 					</div>
 					<div class="field {{if .Err_Content}}error{{end}}">
-						<label for="content">{{.i18n.Tr "repo.settings.deploy_key_content"}}</label>
-						<textarea id="ssh-key-content" name="content" placeholder="{{.i18n.Tr "settings.key_content_ssh_placeholder"}}" required>{{.content}}</textarea>
+						<label for="content">{{.locale.Tr "repo.settings.deploy_key_content"}}</label>
+						<textarea id="ssh-key-content" name="content" placeholder="{{.locale.Tr "settings.key_content_ssh_placeholder"}}" required>{{.content}}</textarea>
 					</div>
 					<div class="field">
 						<div class="ui checkbox {{if .Err_IsWritable}}error{{end}}">
 							<input id="ssh-key-is-writable" name="is_writable" class="hidden" type="checkbox" value="1">
 							<label for="is_writable">
-								{{.i18n.Tr "repo.settings.is_writable"}}
+								{{.locale.Tr "repo.settings.is_writable"}}
 							</label>
-							<small style="padding-left: 26px;">{{$.i18n.Tr "repo.settings.is_writable_info" | Str2html}}</small>
+							<small style="padding-left: 26px;">{{$.locale.Tr "repo.settings.is_writable_info" | Str2html}}</small>
 						</div>
 					</div>
 					<button class="ui green button">
-						{{.i18n.Tr "repo.settings.add_deploy_key"}}
+						{{.locale.Tr "repo.settings.add_deploy_key"}}
 					</button>
 					<button class="ui hide-panel button" data-panel="#add-deploy-key-panel">
-						{{.i18n.Tr "cancel"}}
+						{{.locale.Tr "cancel"}}
 					</button>
 				</form>
 			</div>
@@ -52,11 +52,11 @@
 						<div class="item">
 							<div class="right floated content">
 								<button class="ui red tiny button delete-button" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
-									{{$.i18n.Tr "settings.delete_key"}}
+									{{$.locale.Tr "settings.delete_key"}}
 								</button>
 							</div>
 							<div class="left floated content">
-								<i class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted"{{end}}>{{svg "octicon-key" 32}}</i>
+								<i class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.locale.Tr "settings.key_state_desc"}}" data-variation="inverted"{{end}}>{{svg "octicon-key" 32}}</i>
 							</div>
 							<div class="content">
 								<strong>{{.Name}}</strong>
@@ -64,14 +64,14 @@
 									{{.Fingerprint}}
 								</div>
 								<div class="activity meta">
-									<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info"}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}} - <span>{{$.i18n.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.i18n.Tr "settings.can_write_info"}} {{end}}</span></i>
+									<i>{{$.locale.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info"}} {{if .HasUsed}}{{$.locale.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.locale.Tr "settings.no_activity"}}{{end}} - <span>{{$.locale.Tr "settings.can_read_info"}}{{if not .IsReadOnly}} / {{$.locale.Tr "settings.can_write_info"}} {{end}}</span></i>
 								</div>
 							</div>
 						</div>
 					{{end}}
 				</div>
 			{{else}}
-				{{.i18n.Tr "repo.settings.no_deploy_keys"}}
+				{{.locale.Tr "repo.settings.no_deploy_keys"}}
 			{{end}}
 		</div>
 	</div>
@@ -80,19 +80,19 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.settings.deploy_key_deletion"}}
+		{{.locale.Tr "repo.settings.deploy_key_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.settings.deploy_key_deletion_desc"}}</p>
+		<p>{{.locale.Tr "repo.settings.deploy_key_deletion_desc"}}</p>
 	</div>
 	<div class="actions">
 		<div class="ui red basic inverted cancel button">
 			<i class="remove icon"></i>
-			{{.i18n.Tr "modal.no"}}
+			{{.locale.Tr "modal.no"}}
 		</div>
 		<div class="ui green basic inverted ok button">
 			<i class="checkmark icon"></i>
-			{{.i18n.Tr "modal.yes"}}
+			{{.locale.Tr "modal.yes"}}
 		</div>
 	</div>
 </div>

--- a/templates/repo/settings/githook_edit.tmpl
+++ b/templates/repo/settings/githook_edit.tmpl
@@ -5,24 +5,24 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.githooks"}}
+			{{.locale.Tr "repo.settings.githooks"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "repo.settings.githook_edit_desc"}}</p>
+			<p>{{.locale.Tr "repo.settings.githook_edit_desc"}}</p>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				{{with .Hook}}
 					<div class="inline field">
-						<label>{{$.i18n.Tr "repo.settings.githook_name"}}</label>
+						<label>{{$.locale.Tr "repo.settings.githook_name"}}</label>
 						<span class="hook-filename">{{.Name}}</span>
 					</div>
 					<div class="field">
-						<label for="content">{{$.i18n.Tr "repo.settings.githook_content"}}</label>
+						<label for="content">{{$.locale.Tr "repo.settings.githook_content"}}</label>
 						<textarea id="content" name="content" class="hide">{{if .IsActive}}{{.Content}}{{else}}{{.Sample}}{{end}}</textarea>
 						<div class="editor-loading is-loading"></div>
 					</div>
 					<div class="inline field">
-						<button class="ui green button">{{$.i18n.Tr "repo.settings.update_githook"}}</button>
+						<button class="ui green button">{{$.locale.Tr "repo.settings.update_githook"}}</button>
 					</div>
 				{{end}}
 			</form>

--- a/templates/repo/settings/githooks.tmpl
+++ b/templates/repo/settings/githooks.tmpl
@@ -5,12 +5,12 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.githooks"}}
+			{{.locale.Tr "repo.settings.githooks"}}
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui list">
 				<div class="item">
-					{{.i18n.Tr "repo.settings.githooks_desc" | Str2html}}
+					{{.locale.Tr "repo.settings.githooks_desc" | Str2html}}
 				</div>
 				{{range .Hooks}}
 					<div class="item">

--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -5,10 +5,10 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.lfs_filelist"}} ({{.i18n.Tr "admin.total" .Total}})
+			{{.locale.Tr "repo.settings.lfs_filelist"}} ({{.locale.Tr "admin.total" .Total}})
 			<div class="ui right">
-				<a class="ui tiny show-panel button" href="{{.Link}}/locks">{{.i18n.Tr "repo.settings.lfs_locks"}}</a>
-				<a class="ui primary tiny show-panel button" href="{{.Link}}/pointers">&nbsp;{{.i18n.Tr "repo.settings.lfs_findpointerfiles"}}</a>
+				<a class="ui tiny show-panel button" href="{{.Link}}/locks">{{.locale.Tr "repo.settings.lfs_locks"}}</a>
+				<a class="ui primary tiny show-panel button" href="{{.Link}}/pointers">&nbsp;{{.locale.Tr "repo.settings.lfs_findpointerfiles"}}</a>
 			</div>
 		</h4>
 		<table id="lfs-files-table" class="ui attached segment single line table">
@@ -23,17 +23,17 @@
 							</span>
 						</td>
 						<td>{{FileSize .Size}}</td>
-						<td>{{TimeSince .CreatedUnix.AsTime $.i18n}}</td>
+						<td>{{TimeSince .CreatedUnix.AsTime $.locale}}</td>
 						<td class="right aligned">
-							<a class="ui primary show-panel button" href="{{$.Link}}/find?oid={{.Oid}}&size={{.Size}}">{{$.i18n.Tr "repo.settings.lfs_findcommits"}}</a>
+							<a class="ui primary show-panel button" href="{{$.Link}}/find?oid={{.Oid}}&size={{.Size}}">{{$.locale.Tr "repo.settings.lfs_findcommits"}}</a>
 							<button class="ui basic show-modal icon button" data-modal="#delete-{{.Oid}}">
-								<span class="btn-octicon btn-octicon-danger tooltip"  data-content="{{$.i18n.Tr "repo.editor.delete_this_file"}}" data-position="bottom center">{{svg "octicon-trash"}}</span>
+								<span class="btn-octicon btn-octicon-danger tooltip"  data-content="{{$.locale.Tr "repo.editor.delete_this_file"}}" data-position="bottom center">{{svg "octicon-trash"}}</span>
 							</button>
 						</td>
 					</tr>
 				{{else}}
 					<tr>
-						<td colspan="4">{{.i18n.Tr "repo.settings.lfs_no_lfs_files"}}</td>
+						<td colspan="4">{{.locale.Tr "repo.settings.lfs_no_lfs_files"}}</td>
 					</tr>
 				{{end}}
 			</tbody>
@@ -42,17 +42,17 @@
 		{{range .LFSFiles}}
 			<div class="ui basic modal" id="delete-{{.Oid}}">
 				<div class="ui icon header">
-					{{$.i18n.Tr "repo.settings.lfs_delete" .Oid}}
+					{{$.locale.Tr "repo.settings.lfs_delete" .Oid}}
 				</div>
 				<div class="content center">
 					<p>
-						{{$.i18n.Tr "repo.settings.lfs_delete_warning"}}
+						{{$.locale.Tr "repo.settings.lfs_delete_warning"}}
 					</p>
 					<form class="ui form" action="{{$.Link}}/delete/{{.Oid}}" method="post">
 						{{$.CsrfTokenHtml}}
 						<div class="center actions">
-							<div class="ui basic cancel inverted button">{{$.i18n.Tr "settings.cancel"}}</div>
-							<button class="ui basic inverted yellow button">{{$.i18n.Tr "modal.yes"}}</button>
+							<div class="ui basic cancel inverted button">{{$.locale.Tr "settings.cancel"}}</div>
+							<button class="ui basic inverted yellow button">{{$.locale.Tr "modal.yes"}}</button>
 						</div>
 					</form>
 				</div>

--- a/templates/repo/settings/lfs_file.tmpl
+++ b/templates/repo/settings/lfs_file.tmpl
@@ -6,13 +6,13 @@
 		{{template "base/alert" .}}
 		<div class="tab-size-8 non-diff-file-content">
 			<h4 class="ui top attached header">
-				<a href="{{.LFSFilesLink}}">{{.i18n.Tr "repo.settings.lfs"}}</a> / <span class="truncate sha">{{.LFSFile.Oid}}</span>
+				<a href="{{.LFSFilesLink}}">{{.locale.Tr "repo.settings.lfs"}}</a> / <span class="truncate sha">{{.LFSFile.Oid}}</span>
 				<div class="ui right">
 					{{if .EscapeStatus.Escaped}}
-						<a class="ui mini basic button unescape-button" style="display: none;">{{.i18n.Tr "repo.unescape_control_characters"}}</a>
-						<a class="ui mini basic button escape-button">{{.i18n.Tr "repo.escape_control_characters"}}</a>
+						<a class="ui mini basic button unescape-button" style="display: none;">{{.locale.Tr "repo.unescape_control_characters"}}</a>
+						<a class="ui mini basic button escape-button">{{.locale.Tr "repo.escape_control_characters"}}</a>
 					{{end}}
-					<a class="ui primary show-panel button" href="{{.LFSFilesLink}}/find?oid={{.LFSFile.Oid}}&size={{.LFSFile.Size}}">{{$.i18n.Tr "repo.settings.lfs_findcommits"}}</a>
+					<a class="ui primary show-panel button" href="{{.LFSFilesLink}}/find?oid={{.LFSFile.Oid}}&size={{.LFSFile.Size}}">{{$.locale.Tr "repo.settings.lfs_findcommits"}}</a>
 				</div>
 			</h4>
 			<div class="ui attached table unstackable segment">
@@ -28,16 +28,16 @@
 								<img src="{{$.RawFileLink}}">
 							{{else if .IsVideoFile}}
 								<video controls src="{{$.RawFileLink}}">
-									<strong>{{.i18n.Tr "repo.video_not_supported_in_browser"}}</strong>
+									<strong>{{.locale.Tr "repo.video_not_supported_in_browser"}}</strong>
 								</video>
 							{{else if .IsAudioFile}}
 								<audio controls src="{{$.RawFileLink}}">
-									<strong>{{.i18n.Tr "repo.audio_not_supported_in_browser"}}</strong>
+									<strong>{{.locale.Tr "repo.audio_not_supported_in_browser"}}</strong>
 								</audio>
 							{{else if .IsPDFFile}}
 								<iframe width="100%" height="600px" src="{{AppSubUrl}}/vendor/plugins/pdfjs/web/viewer.html?file={{$.RawFileLink}}"></iframe>
 							{{else}}
-								<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{.i18n.Tr "repo.file_view_raw"}}</a>
+								<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{.locale.Tr "repo.file_view_raw"}}</a>
 							{{end}}
 						</div>
 					{{else if .FileSize}}
@@ -45,7 +45,7 @@
 							<tbody>
 								<tr>
 								{{if .IsFileTooLarge}}
-									<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td>
+									<td><strong>{{.locale.Tr "repo.file_too_large"}}</strong></td>
 								{{else}}
 									<td class="lines-num">{{.LineNums}}</td>
 									<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.FileContent}}</ol></code></pre></td>

--- a/templates/repo/settings/lfs_file_find.tmpl
+++ b/templates/repo/settings/lfs_file_find.tmpl
@@ -6,7 +6,7 @@
 		{{template "base/alert" .}}
 		<div class="tab-size-8 non-diff-file-content">
 			<h4 class="ui top attached header">
-				<a href="{{.LFSFilesLink}}">{{.i18n.Tr "repo.settings.lfs"}}</a> / <span class="truncate sha">{{.Oid}}</span>
+				<a href="{{.LFSFilesLink}}">{{.locale.Tr "repo.settings.lfs"}}</a> / <span class="truncate sha">{{.Oid}}</span>
 			</h4>
 			<table id="lfs-files-find-table" class="ui attached segment single line table">
 				<tbody>
@@ -28,20 +28,20 @@
 							</td>
 							<td>
 								{{if .ParentHashes}}
-									{{$.i18n.Tr "repo.diff.parent"}}
+									{{$.locale.Tr "repo.diff.parent"}}
 									{{range .ParentHashes}}
 										<a class="ui primary sha label" href="{{$.RepoLink}}/commit/{{.String}}">{{ShortSha .String}}</a>
 									{{end}}
 								{{end}}
 								<div class="mobile-only"></div>
-								{{$.i18n.Tr "repo.diff.commit"}}
+								{{$.locale.Tr "repo.diff.commit"}}
 								<a class="ui primary sha label" href="{{$.RepoLink}}/commit/{{.SHA}}">{{ShortSha .SHA}}</a>
 							</td>
-							<td>{{TimeSince .When $.i18n}}</td>
+							<td>{{TimeSince .When $.locale}}</td>
 						</tr>
 					{{else}}
 						<tr>
-							<td colspan="5">{{.i18n.Tr "repo.settings.lfs_lfs_file_no_commits"}}</td>
+							<td colspan="5">{{.locale.Tr "repo.settings.lfs_lfs_file_no_commits"}}</td>
 						</tr>
 					{{end}}
 				</tbody>

--- a/templates/repo/settings/lfs_locks.tmpl
+++ b/templates/repo/settings/lfs_locks.tmpl
@@ -6,14 +6,14 @@
 		{{template "base/alert" .}}
 		<div class="tab-size-8 non-diff-file-content">
 			<h4 class="ui top attached header">
-				<a href="{{.LFSFilesLink}}">{{.i18n.Tr "repo.settings.lfs"}}</a> / {{.i18n.Tr "repo.settings.lfs_locks"}} ({{.i18n.Tr "admin.total" .Total}})
+				<a href="{{.LFSFilesLink}}">{{.locale.Tr "repo.settings.lfs"}}</a> / {{.locale.Tr "repo.settings.lfs_locks"}} ({{.locale.Tr "admin.total" .Total}})
 			</h4>
 			<div class="ui attached segment">
 				<form class="ui form ignore-dirty" method="POST">
 					{{$.CsrfTokenHtml}}
 					<div class="ui fluid action input">
-						<input name="path" value="" placeholder="{{.i18n.Tr "repo.settings.lfs_lock_path"}}" autofocus>
-						<button class="ui primary button">{{.i18n.Tr "repo.settings.lfs_lock"}}</button>
+						<input name="path" value="" placeholder="{{.locale.Tr "repo.settings.lfs_lock_path"}}" autofocus>
+						<button class="ui primary button">{{.locale.Tr "repo.settings.lfs_lock"}}</button>
 					</div>
 				</form>
 			</div>
@@ -27,10 +27,10 @@
 								<a href="{{$.RepoLink}}/src/branch/{{PathEscapeSegments $.Repository.DefaultBranch}}/{{PathEscapeSegments $lock.Path}}" title="{{$lock.Path}}">{{$lock.Path}}</a>
 								{{else}}
 									{{svg "octicon-diff"}}
-								<span class="tooltip" title="{{$.i18n.Tr "repo.settings.lfs_lock_file_no_exist"}}">{{$lock.Path}}</span>
+								<span class="tooltip" title="{{$.locale.Tr "repo.settings.lfs_lock_file_no_exist"}}">{{$lock.Path}}</span>
 								{{end}}
 								{{if not (index $.Lockables $index)}}
-									<span class="tooltip" title="{{$.i18n.Tr "repo.settings.lfs_noattribute"}}">{{svg "octicon-alert"}}</span>
+									<span class="tooltip" title="{{$.locale.Tr "repo.settings.lfs_noattribute"}}">{{svg "octicon-alert"}}</span>
 								{{end}}
 							</td>
 							<td>
@@ -39,17 +39,17 @@
 									{{$.Owner.DisplayName}}
 								</a>
 							</td>
-							<td>{{TimeSince .Created $.i18n}}</td>
+							<td>{{TimeSince .Created $.locale}}</td>
 							<td class="right aligned">
 								<form action="{{$.LFSFilesLink}}/locks/{{$lock.ID}}/unlock" method="POST">
 									{{$.CsrfTokenHtml}}
-									<button class="ui primary button"><span class="btn-octicon">{{svg "octicon-lock"}}</span>{{$.i18n.Tr "repo.settings.lfs_force_unlock"}}</button>
+									<button class="ui primary button"><span class="btn-octicon">{{svg "octicon-lock"}}</span>{{$.locale.Tr "repo.settings.lfs_force_unlock"}}</button>
 								</form>
 							</td>
 						</tr>
 					{{else}}
 						<tr>
-							<td colspan="4">{{.i18n.Tr "repo.settings.lfs_locks_no_locks"}}</td>
+							<td colspan="4">{{.locale.Tr "repo.settings.lfs_locks_no_locks"}}</td>
 						</tr>
 					{{end}}
 				</tbody>

--- a/templates/repo/settings/lfs_pointers.tmpl
+++ b/templates/repo/settings/lfs_pointers.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.lfs_pointers.found" .NumPointers .NumAssociated .NumNotAssociated .NumNoExist }}
+			{{.locale.Tr "repo.settings.lfs_pointers.found" .NumPointers .NumAssociated .NumNotAssociated .NumNoExist }}
 			{{if gt .NumAssociatable 0}}
 				<div class="ui right">
 					<form class="ui form" method="post" action="{{$.Link}}/associate">
@@ -15,7 +15,7 @@
 								<input type="hidden" name="oid" value="{{.Oid}} {{.Size}}"/>
 							{{end}}
 						{{end}}
-						<button class="ui green button">{{$.i18n.Tr "repo.settings.lfs_pointers.associateAccessible" $.NumAssociatable}}</button>
+						<button class="ui green button">{{$.locale.Tr "repo.settings.lfs_pointers.associateAccessible" $.NumAssociatable}}</button>
 					</form>
 				</div>
 			{{end}}
@@ -24,12 +24,12 @@
 			<table id="lfs-files-table" class="ui fixed single line table">
 				<thead>
 					<tr>
-						<th class="three wide">{{.i18n.Tr "repo.settings.lfs_pointers.sha"}}</th>
-						<th class="four wide">{{.i18n.Tr "repo.settings.lfs_pointers.oid"}}</th>
+						<th class="three wide">{{.locale.Tr "repo.settings.lfs_pointers.sha"}}</th>
+						<th class="four wide">{{.locale.Tr "repo.settings.lfs_pointers.oid"}}</th>
 						<th class="three wide"></th>
-						<th class="two wide">{{.i18n.Tr "repo.settings.lfs_pointers.inRepo"}}</th>
-						<th class="two wide">{{.i18n.Tr "repo.settings.lfs_pointers.exists"}}</th>
-						<th class="two wide">{{.i18n.Tr "repo.settings.lfs_pointers.accessible"}}</th>
+						<th class="two wide">{{.locale.Tr "repo.settings.lfs_pointers.inRepo"}}</th>
+						<th class="two wide">{{.locale.Tr "repo.settings.lfs_pointers.exists"}}</th>
+						<th class="two wide">{{.locale.Tr "repo.settings.lfs_pointers.accessible"}}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -56,7 +56,7 @@
 								</span>
 							</td>
 							<td>
-								<a class="ui primary show-panel button" href="{{$.LFSFilesLink}}/find?oid={{.Oid}}&size={{.Size}}&sha={{.SHA}}">{{$.i18n.Tr "repo.settings.lfs_findcommits"}}</a>
+								<a class="ui primary show-panel button" href="{{$.LFSFilesLink}}/find?oid={{.Oid}}&size={{.Size}}&sha={{.SHA}}">{{$.locale.Tr "repo.settings.lfs_findcommits"}}</a>
 							</td>
 							<td>{{if .InRepo}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>
 							<td>{{if .Exists}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</td>

--- a/templates/repo/settings/nav.tmpl
+++ b/templates/repo/settings/nav.tmpl
@@ -1,18 +1,18 @@
 <div id="setting-menu" class="grid-1-5 panel panel-radius left">
-	<p class="panel-header"><strong>{{.i18n.Tr "repo.settings"}}</strong></p>
+	<p class="panel-header"><strong>{{.locale.Tr "repo.settings"}}</strong></p>
 	<div class="panel-body">
 		<ul class="menu menu-vertical switching-list grid-1-5 left">
-			<li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="{{.RepoLink}}/settings">{{.i18n.Tr "repo.settings.options"}}</a></li>
-			<li {{if .PageIsSettingsCollaboration}}class="current"{{end}}><a href="{{.RepoLink}}/settings/collaboration">{{.i18n.Tr "repo.settings.collaboration"}}</a></li>
-			<li {{if .PageIsSettingsBranches}}class="current"{{end}}><a href="{{.RepoLink}}/settings/branches">{{.i18n.Tr "repo.settings.branches"}}</a></li>
-			<li {{if .PageIsSettingsTags}}class="current"{{end}}><a href="{{.RepoLink}}/settings/tags">{{.i18n.Tr "repo.settings.tags"}}</a></li>
+			<li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="{{.RepoLink}}/settings">{{.locale.Tr "repo.settings.options"}}</a></li>
+			<li {{if .PageIsSettingsCollaboration}}class="current"{{end}}><a href="{{.RepoLink}}/settings/collaboration">{{.locale.Tr "repo.settings.collaboration"}}</a></li>
+			<li {{if .PageIsSettingsBranches}}class="current"{{end}}><a href="{{.RepoLink}}/settings/branches">{{.locale.Tr "repo.settings.branches"}}</a></li>
+			<li {{if .PageIsSettingsTags}}class="current"{{end}}><a href="{{.RepoLink}}/settings/tags">{{.locale.Tr "repo.settings.tags"}}</a></li>
 			{{if not DisableWebhooks}}
-			<li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks">{{.i18n.Tr "repo.settings.hooks"}}</a></li>
+			<li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks">{{.locale.Tr "repo.settings.hooks"}}</a></li>
 			{{end}}
 			{{if or .SignedUser.AllowGitHook .SignedUser.IsAdmin}}
-				<li {{if .PageIsSettingsGitHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks/git">{{.i18n.Tr "repo.settings.githooks"}}</a></li>
+				<li {{if .PageIsSettingsGitHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks/git">{{.locale.Tr "repo.settings.githooks"}}</a></li>
 			{{end}}
-			<li {{if .PageIsSettingsKeys}}class="current"{{end}}><a href="{{.RepoLink}}/settings/keys">{{.i18n.Tr "repo.settings.deploy_keys"}}</a></li>
+			<li {{if .PageIsSettingsKeys}}class="current"{{end}}><a href="{{.RepoLink}}/settings/keys">{{.locale.Tr "repo.settings.deploy_keys"}}</a></li>
 		</ul>
 	</div>
 </div>

--- a/templates/repo/settings/navbar.tmpl
+++ b/templates/repo/settings/navbar.tmpl
@@ -1,35 +1,35 @@
 <div class="ui secondary pointing tabular top attached borderless menu stackable new-menu navbar shadow-body">
 	<div class="new-menu-inner">
 		<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.RepoLink}}/settings">
-			{{.i18n.Tr "repo.settings.options"}}
+			{{.locale.Tr "repo.settings.options"}}
 		</a>
 		<a class="{{if .PageIsSettingsCollaboration}}active{{end}} item" href="{{.RepoLink}}/settings/collaboration">
-			{{.i18n.Tr "repo.settings.collaboration"}}
+			{{.locale.Tr "repo.settings.collaboration"}}
 		</a>
 		{{if not .Repository.IsEmpty}}
 			<a class="{{if .PageIsSettingsBranches}}active{{end}} item" href="{{.RepoLink}}/settings/branches">
-				{{.i18n.Tr "repo.settings.branches"}}
+				{{.locale.Tr "repo.settings.branches"}}
 			</a>
 		{{end}}
 		<a class="{{if .PageIsSettingsTags}}active{{end}} item" href="{{.RepoLink}}/settings/tags">
-			{{.i18n.Tr "repo.settings.tags"}}
+			{{.locale.Tr "repo.settings.tags"}}
 		</a>
 		{{if not DisableWebhooks}}
 			<a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.RepoLink}}/settings/hooks">
-				{{.i18n.Tr "repo.settings.hooks"}}
+				{{.locale.Tr "repo.settings.hooks"}}
 			</a>
 		{{end}}
 		{{if .SignedUser.CanEditGitHook}}
 			<a class="{{if .PageIsSettingsGitHooks}}active{{end}} item" href="{{.RepoLink}}/settings/hooks/git">
-				{{.i18n.Tr "repo.settings.githooks"}}
+				{{.locale.Tr "repo.settings.githooks"}}
 			</a>
 		{{end}}
 		<a class="{{if .PageIsSettingsKeys}}active{{end}} item" href="{{.RepoLink}}/settings/keys">
-			{{.i18n.Tr "repo.settings.deploy_keys"}}
+			{{.locale.Tr "repo.settings.deploy_keys"}}
 		</a>
 		{{if .LFSStartServer}}
 			<a class="{{if .PageIsSettingsLFS}}active{{end}} item" href="{{.RepoLink}}/settings/lfs">
-				{{.i18n.Tr "repo.settings.lfs"}}
+				{{.locale.Tr "repo.settings.lfs"}}
 			</a>
 		{{end}}
 	</div>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.basic_settings"}}
+			{{.locale.Tr "repo.settings.basic_settings"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -13,44 +13,44 @@
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="update">
 				<div class="required field {{if .Err_RepoName}}error{{end}}">
-					<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+					<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 					<input id="repo_name" name="repo_name" value="{{.Repository.Name}}" data-repo-name="{{.Repository.Name}}" autofocus required>
 				</div>
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.repo_size"}}</label>
+					<label>{{.locale.Tr "repo.repo_size"}}</label>
 					<span>{{FileSize .Repository.Size}}</span>
 				</div>
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.template"}}</label>
+					<label>{{.locale.Tr "repo.template"}}</label>
 					<div class="ui checkbox">
 						<input name="template" type="checkbox" {{if .Repository.IsTemplate}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.template_helper"}}</label>
+						<label>{{.locale.Tr "repo.template_helper"}}</label>
 					</div>
 				</div>
 				{{if not .Repository.IsFork}}
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.visibility"}}</label>
+						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
 							{{if .IsAdmin}}
 							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}>
 							{{else}}
 							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if and $.ForcePrivate .Repository.IsPrivate}} readonly{{end}}>
 							{{end}}
-							<label>{{.i18n.Tr "repo.visibility_helper" | Safe}} {{if .Repository.NumForks}}<span class="text red">{{.i18n.Tr "repo.visibility_fork_helper"}}</span>{{end}}</label>
+							<label>{{.locale.Tr "repo.visibility_helper" | Safe}} {{if .Repository.NumForks}}<span class="text red">{{.locale.Tr "repo.visibility_fork_helper"}}</span>{{end}}</label>
 						</div>
 					</div>
 				{{end}}
 				<div class="field {{if .Err_Description}}error{{end}}">
-					<label for="description">{{$.i18n.Tr "repo.repo_desc"}}</label>
+					<label for="description">{{$.locale.Tr "repo.repo_desc"}}</label>
 					<textarea id="description" name="description" rows="2">{{.Repository.Description}}</textarea>
 				</div>
 				<div class="field {{if .Err_Website}}error{{end}}">
-					<label for="website">{{.i18n.Tr "repo.settings.site"}}</label>
+					<label for="website">{{.locale.Tr "repo.settings.site"}}</label>
 					<input id="website" name="website" type="url" value="{{.Repository.Website}}">
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 
@@ -59,13 +59,13 @@
 			<form class="ui form" action="{{.Link}}/avatar" method="post" enctype="multipart/form-data">
 				{{.CsrfTokenHtml}}
 				<div class="inline field">
-					<label for="avatar">{{.i18n.Tr "settings.choose_new_avatar"}}</label>
+					<label for="avatar">{{.locale.Tr "settings.choose_new_avatar"}}</label>
 					<input name="avatar" type="file" >
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_avatar"}}</button>
-					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.i18n.Tr "settings.delete_current_avatar"}}</a>
+					<button class="ui green button">{{$.locale.Tr "settings.update_avatar"}}</button>
+					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.locale.Tr "settings.delete_current_avatar"}}</a>
 				</div>
 			</form>
 
@@ -73,17 +73,17 @@
 
 		{{if .MirrorsEnabled}}
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.settings.mirror_settings"}}
+				{{.locale.Tr "repo.settings.mirror_settings"}}
 			</h4>
 			<div class="ui attached segment">
-				{{$.i18n.Tr "repo.settings.mirror_settings.docs" | Safe}}
+				{{$.locale.Tr "repo.settings.mirror_settings.docs" | Safe}}
 				<table class="ui table">
 					{{if or .Repository.IsMirror .PushMirrors}}
 					<thead>
 						<tr>
-							<th style="width:40%">{{$.i18n.Tr "repo.settings.mirror_settings.mirrored_repository"}}</th>
-							<th>{{$.i18n.Tr "repo.settings.mirror_settings.direction"}}</th>
-							<th>{{$.i18n.Tr "repo.settings.mirror_settings.last_update"}}</th>
+							<th style="width:40%">{{$.locale.Tr "repo.settings.mirror_settings.mirrored_repository"}}</th>
+							<th>{{$.locale.Tr "repo.settings.mirror_settings.direction"}}</th>
+							<th>{{$.locale.Tr "repo.settings.mirror_settings.last_update"}}</th>
 							<th></th>
 						</tr>
 					</thead>
@@ -92,13 +92,13 @@
 					<tbody>
 						<tr>
 							<td>{{(MirrorRemoteAddress $.Context .Repository .Mirror.GetRemoteName).Address}}</td>
-							<td>{{$.i18n.Tr "repo.settings.mirror_settings.direction.pull"}}</td>
+							<td>{{$.locale.Tr "repo.settings.mirror_settings.direction.pull"}}</td>
 							<td>{{.Mirror.UpdatedUnix.AsTime}}</td>
 							<td class="right aligned">
 								<form method="post" style="display: inline-block">
 									{{.CsrfTokenHtml}}
 									<input type="hidden" name="action" value="mirror-sync">
-									<button class="ui primary tiny button inline text-thin">{{$.i18n.Tr "repo.settings.sync_mirror"}}</button>
+									<button class="ui primary tiny button inline text-thin">{{$.locale.Tr "repo.settings.sync_mirror"}}</button>
 								</form>
 							</td>
 						</tr>
@@ -109,55 +109,55 @@
 									{{.CsrfTokenHtml}}
 									<input type="hidden" name="action" value="mirror">
 									<div class="inline field {{if .Err_EnablePrune}}error{{end}}">
-										<label>{{.i18n.Tr "repo.mirror_prune"}}</label>
+										<label>{{.locale.Tr "repo.mirror_prune"}}</label>
 										<div class="ui checkbox">
 									<input id="enable_prune" name="enable_prune" type="checkbox" {{if .MirrorEnablePrune}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.mirror_prune_desc"}}</label>
+									<label>{{.locale.Tr "repo.mirror_prune_desc"}}</label>
 										</div>
 									</div>
 									<div class="inline field {{if .Err_Interval}}error{{end}}">
-										<label for="interval">{{.i18n.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
+										<label for="interval">{{.locale.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
 										<input id="interval" name="interval" value="{{.MirrorInterval}}">
 									</div>
 									{{$address := MirrorRemoteAddress $.Context .Repository .Mirror.GetRemoteName}}
 									<div class="field {{if .Err_MirrorAddress}}error{{end}}">
-										<label for="mirror_address">{{.i18n.Tr "repo.mirror_address"}}</label>
+										<label for="mirror_address">{{.locale.Tr "repo.mirror_address"}}</label>
 										<input id="mirror_address" name="mirror_address" value="{{$address.Address}}" required>
-										<p class="help">{{.i18n.Tr "repo.mirror_address_desc"}}</p>
+										<p class="help">{{.locale.Tr "repo.mirror_address_desc"}}</p>
 									</div>
 									<details class="ui optional field" {{if or .Err_Auth $address.Username}}open{{end}}>
 										<summary class="p-2">
-											{{.i18n.Tr "repo.need_auth"}}
+											{{.locale.Tr "repo.need_auth"}}
 										</summary>
 										<div class="p-2">
 											<div class="inline field {{if .Err_Auth}}error{{end}}">
-												<label for="mirror_username">{{.i18n.Tr "username"}}</label>
+												<label for="mirror_username">{{.locale.Tr "username"}}</label>
 												<input id="mirror_username" name="mirror_username" value="{{$address.Username}}" {{if not .mirror_username}}data-need-clear="true"{{end}}>
 											</div>
 											<div class="inline field {{if .Err_Auth}}error{{end}}">
-												<label for="mirror_password">{{.i18n.Tr "password"}}</label>
-												<input id="mirror_password" name="mirror_password" type="password" placeholder="{{if $address.Password}}{{.i18n.Tr "repo.mirror_password_placeholder"}}{{else}}{{.i18n.Tr "repo.mirror_password_blank_placeholder"}}{{end}}" value="" {{if not .mirror_password}}data-need-clear="true"{{end}} autocomplete="off">
+												<label for="mirror_password">{{.locale.Tr "password"}}</label>
+												<input id="mirror_password" name="mirror_password" type="password" placeholder="{{if $address.Password}}{{.locale.Tr "repo.mirror_password_placeholder"}}{{else}}{{.locale.Tr "repo.mirror_password_blank_placeholder"}}{{end}}" value="" {{if not .mirror_password}}data-need-clear="true"{{end}} autocomplete="off">
 											</div>
-											<p class="help">{{.i18n.Tr "repo.mirror_password_help"}}</p>
+											<p class="help">{{.locale.Tr "repo.mirror_password_help"}}</p>
 										</div>
 									</details>
 
 									{{if .LFSStartServer}}
 									<div class="inline field">
-										<label>{{.i18n.Tr "repo.mirror_lfs"}}</label>
+										<label>{{.locale.Tr "repo.mirror_lfs"}}</label>
 										<div class="ui checkbox">
 											<input id="mirror_lfs" name="mirror_lfs" type="checkbox" {{if .Mirror.LFS}}checked{{end}}>
-											<label>{{.i18n.Tr "repo.mirror_lfs_desc"}}</label>
+											<label>{{.locale.Tr "repo.mirror_lfs_desc"}}</label>
 										</div>
 									</div>
 									<div class="field {{if .Err_LFSEndpoint}}error{{end}}">
-										<label for="mirror_lfs_endpoint">{{.i18n.Tr "repo.mirror_lfs_endpoint"}}</label>
-										<input id="mirror_lfs_endpoint" name="mirror_lfs_endpoint" value="{{.Mirror.LFSEndpoint}}" placeholder="{{.i18n.Tr "repo.migrate_options_lfs_endpoint.placeholder"}}">
-										<p class="help">{{.i18n.Tr "repo.mirror_lfs_endpoint_desc" "https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md#server-discovery" | Str2html}}</p>
+										<label for="mirror_lfs_endpoint">{{.locale.Tr "repo.mirror_lfs_endpoint"}}</label>
+										<input id="mirror_lfs_endpoint" name="mirror_lfs_endpoint" value="{{.Mirror.LFSEndpoint}}" placeholder="{{.locale.Tr "repo.migrate_options_lfs_endpoint.placeholder"}}">
+										<p class="help">{{.locale.Tr "repo.mirror_lfs_endpoint_desc" "https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md#server-discovery" | Str2html}}</p>
 									</div>
 									{{end}}
 									<div class="field">
-										<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+										<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 									</div>
 								</form>
 							</td>
@@ -170,26 +170,26 @@
 						<tr>
 							{{$address := MirrorRemoteAddress $.Context $.Repository .GetRemoteName}}
 							<td>{{$address.Address}}</td>
-							<td>{{$.i18n.Tr "repo.settings.mirror_settings.direction.push"}}</td>
-							<td>{{if .LastUpdateUnix}}{{.LastUpdateUnix.AsTime}}{{else}}{{$.i18n.Tr "never"}}{{end}} {{if .LastError}}<div class="ui red label tooltip" data-content="{{.LastError}}">{{$.i18n.Tr "error"}}</div>{{end}}</td>
+							<td>{{$.locale.Tr "repo.settings.mirror_settings.direction.push"}}</td>
+							<td>{{if .LastUpdateUnix}}{{.LastUpdateUnix.AsTime}}{{else}}{{$.locale.Tr "never"}}{{end}} {{if .LastError}}<div class="ui red label tooltip" data-content="{{.LastError}}">{{$.locale.Tr "error"}}</div>{{end}}</td>
 							<td class="right aligned">
 								<form method="post" style="display: inline-block">
 									{{$.CsrfTokenHtml}}
 									<input type="hidden" name="action" value="push-mirror-remove">
 									<input type="hidden" name="push_mirror_id" value="{{.ID}}">
-									<button class="ui basic red tiny button inline text-thin">{{$.i18n.Tr "remove"}}</button>
+									<button class="ui basic red tiny button inline text-thin">{{$.locale.Tr "remove"}}</button>
 								</form>
 								<form method="post" style="display: inline-block">
 									{{$.CsrfTokenHtml}}
 									<input type="hidden" name="action" value="push-mirror-sync">
 									<input type="hidden" name="push_mirror_id" value="{{.ID}}">
-									<button class="ui primary tiny button inline text-thin">{{$.i18n.Tr "repo.settings.sync_mirror"}}</button>
+									<button class="ui primary tiny button inline text-thin">{{$.locale.Tr "repo.settings.sync_mirror"}}</button>
 								</form>
 							</td>
 						</tr>
 						{{else}}
 						<tr>
-							<td>{{$.i18n.Tr "repo.settings.mirror_settings.push_mirror.none"}}</td>
+							<td>{{$.locale.Tr "repo.settings.mirror_settings.push_mirror.none"}}</td>
 						</tr>
 						{{end}}
 						{{if (not .DisableNewPushMirrors)}}
@@ -200,31 +200,31 @@
 										{{.CsrfTokenHtml}}
 										<input type="hidden" name="action" value="push-mirror-add">
 										<div class="field {{if .Err_PushMirrorAddress}}error{{end}}">
-											<label for="push_mirror_address">{{.i18n.Tr "repo.settings.mirror_settings.push_mirror.remote_url"}}</label>
+											<label for="push_mirror_address">{{.locale.Tr "repo.settings.mirror_settings.push_mirror.remote_url"}}</label>
 											<input id="push_mirror_address" name="push_mirror_address" value="{{.push_mirror_address}}" required>
-											<p class="help">{{.i18n.Tr "repo.mirror_address_desc"}}</p>
+											<p class="help">{{.locale.Tr "repo.mirror_address_desc"}}</p>
 										</div>
 										<details class="ui optional field" {{if or .Err_PushMirrorAuth .push_mirror_username}}open{{end}}>
 											<summary class="p-2">
-												{{.i18n.Tr "repo.need_auth"}}
+												{{.locale.Tr "repo.need_auth"}}
 											</summary>
 											<div class="p-2">
 												<div class="inline field {{if .Err_PushMirrorAuth}}error{{end}}">
-													<label for="push_mirror_username">{{.i18n.Tr "username"}}</label>
+													<label for="push_mirror_username">{{.locale.Tr "username"}}</label>
 													<input id="push_mirror_username" name="push_mirror_username" value="{{.push_mirror_username}}">
 												</div>
 												<div class="inline field {{if .Err_PushMirrorAuth}}error{{end}}">
-													<label for="push_mirror_password">{{.i18n.Tr "password"}}</label>
+													<label for="push_mirror_password">{{.locale.Tr "password"}}</label>
 													<input id="push_mirror_password" name="push_mirror_password" type="password" value="{{.push_mirror_password}}" autocomplete="off">
 												</div>
 											</div>
 										</details>
 										<div class="inline field {{if .Err_PushMirrorInterval}}error{{end}}">
-											<label for="push_mirror_interval">{{.i18n.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
+											<label for="push_mirror_interval">{{.locale.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
 											<input id="push_mirror_interval" name="push_mirror_interval" value="{{if .push_mirror_interval}}{{.push_mirror_interval}}{{else}}{{.DefaultMirrorInterval}}{{end}}">
 										</div>
 										<div class="field">
-											<button class="ui green button">{{$.i18n.Tr "repo.settings.mirror_settings.push_mirror.add"}}</button>
+											<button class="ui green button">{{$.locale.Tr "repo.settings.mirror_settings.push_mirror.add"}}</button>
 										</div>
 									</form>
 								</td>
@@ -236,7 +236,7 @@
 		{{end}}
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.advanced_settings"}}
+			{{.locale.Tr "repo.settings.advanced_settings"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" method="post">
@@ -245,41 +245,41 @@
 
 				{{$isWikiEnabled := or (.Repository.UnitEnabled $.UnitTypeWiki) (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.wiki"}}</label>
+					<label>{{.locale.Tr "repo.wiki"}}</label>
 					{{if and (.UnitTypeWiki.UnitGlobalDisabled) (.UnitTypeExternalWiki.UnitGlobalDisabled)}}
-					<div class="ui checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+					<div class="ui checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 					{{else}}
 					<div class="ui checkbox">
 					{{end}}
 						<input class="enable-system" name="enable_wiki" type="checkbox" data-target="#wiki_box" {{if $isWikiEnabled}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.wiki_desc"}}</label>
+						<label>{{.locale.Tr "repo.settings.wiki_desc"}}</label>
 					</div>
 				</div>
 				<div class="field {{if not $isWikiEnabled}}disabled{{end}}" id="wiki_box">
 					<div class="field">
 						{{if .UnitTypeWiki.UnitGlobalDisabled}}
-						<div class="ui radio checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+						<div class="ui radio checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
 							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}checked{{end}}/>
-							<label>{{.i18n.Tr "repo.settings.use_internal_wiki"}}</label>
+							<label>{{.locale.Tr "repo.settings.use_internal_wiki"}}</label>
 						</div>
 					</div>
 					<div class="field">
 						{{if .UnitTypeExternalWiki.UnitGlobalDisabled}}
-						<div class="ui radio checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+						<div class="ui radio checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
 							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.UnitEnabled $.UnitTypeExternalWiki}}checked{{end}}/>
-							<label>{{.i18n.Tr "repo.settings.use_external_wiki"}}</label>
+							<label>{{.locale.Tr "repo.settings.use_external_wiki"}}</label>
 						</div>
 					</div>
 					<div class="field {{if not (.Repository.UnitEnabled $.UnitTypeExternalWiki)}}disabled{{end}}" id="external_wiki_box">
-						<label for="external_wiki_url">{{.i18n.Tr "repo.settings.external_wiki_url"}}</label>
+						<label for="external_wiki_url">{{.locale.Tr "repo.settings.external_wiki_url"}}</label>
 						<input id="external_wiki_url" name="external_wiki_url" type="url" value="{{(.Repository.MustGetUnit $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}">
-						<p class="help">{{.i18n.Tr "repo.settings.external_wiki_url_desc"}}</p>
+						<p class="help">{{.locale.Tr "repo.settings.external_wiki_url_desc"}}</p>
 					</div>
 				</div>
 
@@ -287,25 +287,25 @@
 
 				{{$isIssuesEnabled := or (.Repository.UnitEnabled $.UnitTypeIssues) (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.issues"}}</label>
+					<label>{{.locale.Tr "repo.issues"}}</label>
 					{{if and (.UnitTypeIssues.UnitGlobalDisabled) (.UnitTypeExternalTracker.UnitGlobalDisabled)}}
-					<div class="ui checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+					<div class="ui checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 					{{else}}
 					<div class="ui checkbox">
 					{{end}}
 						<input class="enable-system" name="enable_issues" type="checkbox" data-target="#issue_box" {{if $isIssuesEnabled}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.issues_desc"}}</label>
+						<label>{{.locale.Tr "repo.settings.issues_desc"}}</label>
 					</div>
 				</div>
 				<div class="field {{if not $isIssuesEnabled}}disabled{{end}}" id="issue_box">
 					<div class="field">
 						{{if .UnitTypeIssues.UnitGlobalDisabled}}
-						<div class="ui radio checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+						<div class="ui radio checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
 							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="false" data-context="#internal_issue_box" data-target="#external_issue_box" {{if not (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}checked{{end}}/>
-							<label>{{.i18n.Tr "repo.settings.use_internal_issue_tracker"}}</label>
+							<label>{{.locale.Tr "repo.settings.use_internal_issue_tracker"}}</label>
 						</div>
 					</div>
 					<div class="field {{if (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}disabled{{end}}" id="internal_issue_box">
@@ -313,75 +313,75 @@
 							<div class="field">
 								<div class="ui checkbox">
 									<input name="enable_timetracker" class="enable-system" data-target="#only_contributors" type="checkbox" {{if .Repository.IsTimetrackerEnabled}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.settings.enable_timetracker"}}</label>
+									<label>{{.locale.Tr "repo.settings.enable_timetracker"}}</label>
 								</div>
 							</div>
 							<div class="field {{if not .Repository.IsTimetrackerEnabled}}disabled{{end}}" id="only_contributors">
 								<div class="ui checkbox">
 									<input name="allow_only_contributors_to_track_time" type="checkbox" {{if .Repository.AllowOnlyContributorsToTrackTime}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.settings.allow_only_contributors_to_track_time"}}</label>
+									<label>{{.locale.Tr "repo.settings.allow_only_contributors_to_track_time"}}</label>
 								</div>
 							</div>
 						{{end}}
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="enable_issue_dependencies" type="checkbox" {{if (.Repository.IsDependenciesEnabled)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.issues.dependency.setting"}}</label>
+								<label>{{.locale.Tr "repo.issues.dependency.setting"}}</label>
 							</div>
 						</div>
 						<div class="ui checkbox">
 							<input name="enable_close_issues_via_commit_in_any_branch" type="checkbox" {{ if .Repository.CloseIssuesViaCommitInAnyBranch }}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.admin_enable_close_issues_via_commit_in_any_branch"}}</label>
+							<label>{{.locale.Tr "repo.settings.admin_enable_close_issues_via_commit_in_any_branch"}}</label>
 						</div>
 					</div>
 					<div class="field">
 						{{if .UnitTypeExternalTracker.UnitGlobalDisabled}}
-						<div class="ui radio checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+						<div class="ui radio checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
 							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="true" data-context="#internal_issue_box" data-target="#external_issue_box" {{if .Repository.UnitEnabled $.UnitTypeExternalTracker}}checked{{end}}/>
-							<label>{{.i18n.Tr "repo.settings.use_external_issue_tracker"}}</label>
+							<label>{{.locale.Tr "repo.settings.use_external_issue_tracker"}}</label>
 						</div>
 					</div>
 					<div class="field {{if not (.Repository.UnitEnabled $.UnitTypeExternalTracker)}}disabled{{end}}" id="external_issue_box">
 						<div class="field">
-							<label for="external_tracker_url">{{.i18n.Tr "repo.settings.external_tracker_url"}}</label>
+							<label for="external_tracker_url">{{.locale.Tr "repo.settings.external_tracker_url"}}</label>
 							<input id="external_tracker_url" name="external_tracker_url" type="url" value="{{(.Repository.MustGetUnit $.UnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerURL}}">
-							<p class="help">{{.i18n.Tr "repo.settings.external_tracker_url_desc"}}</p>
+							<p class="help">{{.locale.Tr "repo.settings.external_tracker_url_desc"}}</p>
 						</div>
 						<div class="field">
-							<label for="tracker_url_format">{{.i18n.Tr "repo.settings.tracker_url_format"}}</label>
+							<label for="tracker_url_format">{{.locale.Tr "repo.settings.tracker_url_format"}}</label>
 							<input id="tracker_url_format" name="tracker_url_format" type="url" value="{{(.Repository.MustGetUnit $.UnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerFormat}}" placeholder="e.g. https://github.com/{user}/{repo}/issues/{index}">
-							<p class="help">{{.i18n.Tr "repo.settings.tracker_url_format_desc" | Str2html}}</p>
+							<p class="help">{{.locale.Tr "repo.settings.tracker_url_format_desc" | Str2html}}</p>
 						</div>
 						<div class="inline fields">
-							<label for="issue_style">{{.i18n.Tr "repo.settings.tracker_issue_style"}}</label>
+							<label for="issue_style">{{.locale.Tr "repo.settings.tracker_issue_style"}}</label>
 							<div class="field">
 								<div class="ui radio checkbox">
 								{{$externalTracker := (.Repository.MustGetUnit $.UnitTypeExternalTracker)}}
 								{{$externalTrackerStyle := $externalTracker.ExternalTrackerConfig.ExternalTrackerStyle}}
 									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="numeric" {{if eq $externalTrackerStyle "numeric"}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.settings.tracker_issue_style.numeric"}} <span class="ui light grey text">#1234</span></label>
+									<label>{{.locale.Tr "repo.settings.tracker_issue_style.numeric"}} <span class="ui light grey text">#1234</span></label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
 									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="alphanumeric" {{if eq $externalTrackerStyle "alphanumeric"}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.settings.tracker_issue_style.alphanumeric"}} <span class="ui light grey text">ABC-123 , DEFG-234</span></label>
+									<label>{{.locale.Tr "repo.settings.tracker_issue_style.alphanumeric"}} <span class="ui light grey text">ABC-123 , DEFG-234</span></label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
 									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="regexp" {{if eq $externalTrackerStyle "regexp"}}checked{{end}}>
-									<label>{{.i18n.Tr "repo.settings.tracker_issue_style.regexp"}} <span class="ui light grey text">(ISSUE-\d+) , ISSUE-(\d+)</span></label>
+									<label>{{.locale.Tr "repo.settings.tracker_issue_style.regexp"}} <span class="ui light grey text">(ISSUE-\d+) , ISSUE-(\d+)</span></label>
 								</div>
 							</div>
 						</div>
 						<div class="field {{if ne $externalTrackerStyle "regexp"}}disabled{{end}}" id="tracker-issue-style-regex-box">
-							<label for="external_tracker_regexp_pattern">{{.i18n.Tr "repo.settings.tracker_issue_style.regexp_pattern"}}</label>
+							<label for="external_tracker_regexp_pattern">{{.locale.Tr "repo.settings.tracker_issue_style.regexp_pattern"}}</label>
 							<input id="external_tracker_regexp_pattern" name="external_tracker_regexp_pattern" value="{{(.Repository.MustGetUnit $.UnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerRegexpPattern}}">
-							<p class="help">{{.i18n.Tr "repo.settings.tracker_issue_style.regexp_pattern_desc" | Str2html}}</p>
+							<p class="help">{{.locale.Tr "repo.settings.tracker_issue_style.regexp_pattern_desc" | Str2html}}</p>
 						</div>
 					</div>
 				</div>
@@ -390,27 +390,27 @@
 
 				{{$isProjectsEnabled := .Repository.UnitEnabled $.UnitTypeProjects}}
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.project_board"}}</label>
+					<label>{{.locale.Tr "repo.project_board"}}</label>
 					{{if .UnitTypeProjects.UnitGlobalDisabled}}
-					<div class="ui checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+					<div class="ui checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 					{{else}}
 					<div class="ui checkbox">
 					{{end}}
 						<input class="enable-system" name="enable_projects" type="checkbox" {{if $isProjectsEnabled}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.projects_desc"}}</label>
+						<label>{{.locale.Tr "repo.settings.projects_desc"}}</label>
 					</div>
 				</div>
 
 				{{$isPackagesEnabled := .Repository.UnitEnabled $.UnitTypePackages}}
 				<div class="inline field">
-					<label>{{.i18n.Tr "repo.packages"}}</label>
+					<label>{{.locale.Tr "repo.packages"}}</label>
 					{{if .UnitTypePackages.UnitGlobalDisabled}}
-					<div class="ui checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+					<div class="ui checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 					{{else}}
 					<div class="ui checkbox">
 					{{end}}
 						<input class="enable-system" name="enable_packages" type="checkbox" {{if $isPackagesEnabled}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.packages_desc"}}</label>
+						<label>{{.locale.Tr "repo.settings.packages_desc"}}</label>
 					</div>
 				</div>
 
@@ -419,101 +419,101 @@
 					{{$pullRequestEnabled := .Repository.UnitEnabled $.UnitTypePullRequests}}
 					{{$prUnit := .Repository.MustGetUnit $.UnitTypePullRequests}}
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.pulls"}}</label>
+						<label>{{.locale.Tr "repo.pulls"}}</label>
 						{{if .UnitTypePullRequests.UnitGlobalDisabled}}
-						<div class="ui checkbox tooltip disabled" data-content="{{.i18n.Tr "repo.unit_disabled"}}">
+						<div class="ui checkbox tooltip disabled" data-content="{{.locale.Tr "repo.unit_disabled"}}">
 						{{else}}
 						<div class="ui checkbox">
 						{{end}}
 							<input class="enable-system" name="enable_pulls" type="checkbox" data-target="#pull_box" {{if $pullRequestEnabled}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.pulls_desc"}}</label>
+							<label>{{.locale.Tr "repo.settings.pulls_desc"}}</label>
 						</div>
 					</div>
 					<div class="field{{if not $pullRequestEnabled}} disabled{{end}}" id="pull_box">
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_ignore_whitespace" type="checkbox" {{if and $pullRequestEnabled ($prUnit.PullRequestsConfig.IgnoreWhitespaceConflicts)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.ignore_whitespace"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.ignore_whitespace"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowMerge)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_merge_commits"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_merge_commits"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_rebase" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebase)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_rebase_merge"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_rebase_merge"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_rebase_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebaseMerge)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_rebase_merge_commit"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_rebase_merge_commit"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_squash" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowSquash)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_squash_commits"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_squash_commits"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_manual_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowManualMerge)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_manual_merge"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_manual_merge"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="enable_autodetect_manual_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AutodetectManualMerge)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.enable_autodetect_manual_merge"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.enable_autodetect_manual_merge"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="pulls_allow_rebase_update" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebaseUpdate)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.allow_rebase_update"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.allow_rebase_update"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
 								<input name="default_delete_branch_after_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.DefaultDeleteBranchAfterMerge)}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls.default_delete_branch_after_merge"}}</label>
+								<label>{{.locale.Tr "repo.settings.pulls.default_delete_branch_after_merge"}}</label>
 							</div>
 						</div>
 						<div class="field">
 							<p>
-								{{.i18n.Tr "repo.settings.default_merge_style_desc"}}
+								{{.locale.Tr "repo.settings.default_merge_style_desc"}}
 							</p>
 							<div class="ui dropdown selection" tabindex="0">
 								<select name="pulls_default_merge_style">
-									<option value="merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "merge")}}selected{{end}}>{{.i18n.Tr "repo.pulls.merge_pull_request"}}</option>
-									<option value="rebase" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase")}}selected{{end}}>{{.i18n.Tr "repo.pulls.rebase_merge_pull_request"}}</option>
-									<option value="rebase-merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase-merge")}}selected{{end}}>{{.i18n.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</option>
-									<option value="squash" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "squash")}}selected{{end}}>{{.i18n.Tr "repo.pulls.squash_merge_pull_request"}}</option>
+									<option value="merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "merge")}}selected{{end}}>{{.locale.Tr "repo.pulls.merge_pull_request"}}</option>
+									<option value="rebase" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase")}}selected{{end}}>{{.locale.Tr "repo.pulls.rebase_merge_pull_request"}}</option>
+									<option value="rebase-merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase-merge")}}selected{{end}}>{{.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</option>
+									<option value="squash" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "squash")}}selected{{end}}>{{.locale.Tr "repo.pulls.squash_merge_pull_request"}}</option>
 								</select>{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 								<div class="default text">
 									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "merge")}}
-										{{.i18n.Tr "repo.pulls.merge_pull_request"}}
+										{{.locale.Tr "repo.pulls.merge_pull_request"}}
 									{{end}}
 									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase")}}
-										{{.i18n.Tr "repo.pulls.rebase_merge_pull_request"}}
+										{{.locale.Tr "repo.pulls.rebase_merge_pull_request"}}
 									{{end}}
 									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase-merge")}}
-										{{.i18n.Tr "repo.pulls.rebase_merge_commit_pull_request"}}
+										{{.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}
 									{{end}}
 									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "squash")}}
-										{{.i18n.Tr "repo.pulls.squash_merge_pull_request"}}
+										{{.locale.Tr "repo.pulls.squash_merge_pull_request"}}
 									{{end}}
 								</div>
 								<div class="menu transition hidden" tabindex="-1" style="display: block !important;">
-									<div class="item" data-value="merge">{{.i18n.Tr "repo.pulls.merge_pull_request"}}</div>
-									<div class="item" data-value="rebase">{{.i18n.Tr "repo.pulls.rebase_merge_pull_request"}}</div>
-									<div class="item" data-value="rebase-merge">{{.i18n.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</div>
-									<div class="item" data-value="squash">{{.i18n.Tr "repo.pulls.squash_merge_pull_request"}}</div>
+									<div class="item" data-value="merge">{{.locale.Tr "repo.pulls.merge_pull_request"}}</div>
+									<div class="item" data-value="rebase">{{.locale.Tr "repo.pulls.rebase_merge_pull_request"}}</div>
+									<div class="item" data-value="rebase-merge">{{.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</div>
+									<div class="item" data-value="squash">{{.locale.Tr "repo.pulls.squash_merge_pull_request"}}</div>
 								</div>
 							</div>
 						</div>
@@ -522,60 +522,60 @@
 
 				<div class="ui divider"></div>
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.signing_settings"}}
+			{{.locale.Tr "repo.settings.signing_settings"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" method="post">
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="signing">
 				<div class="field">
-					<label>{{.i18n.Tr "repo.settings.trust_model"}}</label><br>
+					<label>{{.locale.Tr "repo.settings.trust_model"}}</label><br>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input type="radio" id="trust_model_default" name="trust_model" {{if eq .Repository.TrustModel.String "default"}}checked="checked"{{end}} value="default">
-							<label for="trust_model_default">{{.i18n.Tr "repo.settings.trust_model.default"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.trust_model.default.desc"}}</p>
+							<label for="trust_model_default">{{.locale.Tr "repo.settings.trust_model.default"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.trust_model.default.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input type="radio" id="trust_model_collaborator" name="trust_model" {{if eq .Repository.TrustModel.String "collaborator"}}checked="checked"{{end}} value="collaborator">
-							<label for="trust_model_collaborator">{{.i18n.Tr "repo.settings.trust_model.collaborator.long"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.trust_model.collaborator.desc"}}</p>
+							<label for="trust_model_collaborator">{{.locale.Tr "repo.settings.trust_model.collaborator.long"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.trust_model.collaborator.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input type="radio" name="trust_model" id="trust_model_committer" {{if eq .Repository.TrustModel.String "committer"}}checked="checked"{{end}} value="committer">
-							<label for="trust_model_committer">{{.i18n.Tr "repo.settings.trust_model.committer.long"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.trust_model.committer.desc"}}</p>
+							<label for="trust_model_committer">{{.locale.Tr "repo.settings.trust_model.committer.long"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.trust_model.committer.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input type="radio" name="trust_model" id="trust_model_collaboratorcommitter" {{if eq .Repository.TrustModel.String "collaboratorcommitter"}}checked="checked"{{end}} value="collaboratorcommitter">
-							<label for="trust_model_collaboratorcommitter">{{.i18n.Tr "repo.settings.trust_model.collaboratorcommitter.long"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.trust_model.collaboratorcommitter.desc"}}</p>
+							<label for="trust_model_collaboratorcommitter">{{.locale.Tr "repo.settings.trust_model.collaboratorcommitter.long"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.trust_model.collaboratorcommitter.desc"}}</p>
 						</div>
 					</div>
 				</div>
 
 				<div class="ui divider"></div>
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 		</div>
 
 		{{if .IsAdmin}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.admin_settings"}}
+			{{.locale.Tr "repo.settings.admin_settings"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" method="post">
@@ -584,12 +584,12 @@
 				<div class="field">
 					<div class="ui checkbox">
 						<input name="enable_health_check" type="checkbox" {{if .Repository.IsFsckEnabled}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.admin_enable_health_check"}}</label>
+						<label>{{.locale.Tr "repo.settings.admin_enable_health_check"}}</label>
 					</div>
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 
@@ -598,37 +598,37 @@
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="admin_index">
 				{{if .CodeIndexerEnabled}}
-					<h4 class="ui header">{{.i18n.Tr "repo.settings.admin_code_indexer"}}</h4>
+					<h4 class="ui header">{{.locale.Tr "repo.settings.admin_code_indexer"}}</h4>
 					<div class="inline fields">
-						<label>{{.i18n.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+						<label>{{.locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
 						<span class="field">
 							{{if .CodeIndexerStatus}}
 								<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.CodeIndexerStatus.CommitSha}}">
 									<span class="shortsha">{{ShortSha .CodeIndexerStatus.CommitSha}}</span>
 								</a>
 							{{else}}
-									<span>{{.i18n.Tr "repo.settings.admin_indexer_unindexed"}}</span>
+									<span>{{.locale.Tr "repo.settings.admin_indexer_unindexed"}}</span>
 							{{end}}
 						</span>
 						<div class="field">
-							<button class="ui green button" name="request_reindex_type" value="code">{{$.i18n.Tr "repo.settings.reindex_button"}}</button>
+							<button class="ui green button" name="request_reindex_type" value="code">{{$.locale.Tr "repo.settings.reindex_button"}}</button>
 						</div>
 					</div>
 				{{end}}
-				<h4 class="ui header">{{.i18n.Tr "repo.settings.admin_stats_indexer"}}</h4>
+				<h4 class="ui header">{{.locale.Tr "repo.settings.admin_stats_indexer"}}</h4>
 				<div class="inline fields">
-					<label>{{.i18n.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+					<label>{{.locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
 					<span class="field">
 						{{if .StatsIndexerStatus}}
 							<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.StatsIndexerStatus.CommitSha}}">
 								<span class="shortsha">{{ShortSha .StatsIndexerStatus.CommitSha}}</span>
 							</a>
 						{{else}}
-							<span>{{.i18n.Tr "repo.settings.admin_indexer_unindexed"}}</span>
+							<span>{{.locale.Tr "repo.settings.admin_indexer_unindexed"}}</span>
 						{{end}}
 					</span>
 					<div class="field">
-						<button class="ui green button" name="request_reindex_type" value="stats">{{$.i18n.Tr "repo.settings.reindex_button"}}</button>
+						<button class="ui green button" name="request_reindex_type" value="stats">{{$.locale.Tr "repo.settings.reindex_button"}}</button>
 					</div>
 				</div>
 			</form>
@@ -637,17 +637,17 @@
 
 		{{if .Permission.IsOwner}}
 		<h4 class="ui top attached error header">
-			{{.i18n.Tr "repo.settings.danger_zone"}}
+			{{.locale.Tr "repo.settings.danger_zone"}}
 		</h4>
 		<div class="ui attached error table danger segment">
 			{{if .Repository.IsMirror}}
 				<div class="item">
 					<div class="ui right">
-						<button class="ui basic red show-modal button" data-modal="#convert-mirror-repo-modal">{{.i18n.Tr "repo.settings.convert"}}</button>
+						<button class="ui basic red show-modal button" data-modal="#convert-mirror-repo-modal">{{.locale.Tr "repo.settings.convert"}}</button>
 					</div>
 					<div>
-						<h5>{{.i18n.Tr "repo.settings.convert"}}</h5>
-						<p>{{.i18n.Tr "repo.settings.convert_desc"}}</p>
+						<h5>{{.locale.Tr "repo.settings.convert"}}</h5>
+						<p>{{.locale.Tr "repo.settings.convert_desc"}}</p>
 					</div>
 				</div>
 				<div class="ui divider"></div>
@@ -655,11 +655,11 @@
 			{{if and .Repository.IsFork .Repository.Owner.CanCreateRepo}}
 				<div class="item">
 					<div class="ui right">
-						<button class="ui basic red show-modal button" data-modal="#convert-fork-repo-modal">{{.i18n.Tr "repo.settings.convert_fork"}}</button>
+						<button class="ui basic red show-modal button" data-modal="#convert-fork-repo-modal">{{.locale.Tr "repo.settings.convert_fork"}}</button>
 					</div>
 					<div>
-						<h5>{{.i18n.Tr "repo.settings.convert_fork"}}</h5>
-						<p>{{.i18n.Tr "repo.settings.convert_fork_desc"}}</p>
+						<h5>{{.locale.Tr "repo.settings.convert_fork"}}</h5>
+						<p>{{.locale.Tr "repo.settings.convert_fork_desc"}}</p>
 					</div>
 				</div>
 				<div class="ui divider"></div>
@@ -670,18 +670,18 @@
 						<form class="ui form" action="{{.Link}}" method="post">
 							{{.CsrfTokenHtml}}
 							<input type="hidden" name="action" value="cancel_transfer">
-							<button class="ui red button">{{.i18n.Tr "repo.settings.transfer_abort"}}</button>
+							<button class="ui red button">{{.locale.Tr "repo.settings.transfer_abort"}}</button>
 						</form>
 					{{ else }}
-						<button class="ui basic red show-modal button" data-modal="#transfer-repo-modal">{{.i18n.Tr "repo.settings.transfer"}}</button>
+						<button class="ui basic red show-modal button" data-modal="#transfer-repo-modal">{{.locale.Tr "repo.settings.transfer"}}</button>
 					{{ end }}
 				</div>
 				<div>
-					<h5>{{.i18n.Tr "repo.settings.transfer"}}</h5>
+					<h5>{{.locale.Tr "repo.settings.transfer"}}</h5>
 					{{if .RepoTransfer}}
-						<p>{{.i18n.Tr "repo.settings.transfer_started" .RepoTransfer.Recipient.DisplayName}}</p>
+						<p>{{.locale.Tr "repo.settings.transfer_started" .RepoTransfer.Recipient.DisplayName}}</p>
 					{{else}}
-						<p>{{.i18n.Tr "repo.settings.transfer_desc"}}</p>
+						<p>{{.locale.Tr "repo.settings.transfer_desc"}}</p>
 					{{end}}
 				</div>
 			</div>
@@ -691,11 +691,11 @@
 
 				<div class="item">
 					<div class="ui right">
-						<button class="ui basic red show-modal button" data-modal="#delete-wiki-modal">{{.i18n.Tr "repo.settings.wiki_delete"}}</button>
+						<button class="ui basic red show-modal button" data-modal="#delete-wiki-modal">{{.locale.Tr "repo.settings.wiki_delete"}}</button>
 					</div>
 					<div>
-						<h5>{{.i18n.Tr "repo.settings.wiki_delete"}}</h5>
-						<p>{{.i18n.Tr "repo.settings.wiki_delete_desc"}}</p>
+						<h5>{{.locale.Tr "repo.settings.wiki_delete"}}</h5>
+						<p>{{.locale.Tr "repo.settings.wiki_delete_desc"}}</p>
 					</div>
 				</div>
 			{{end}}
@@ -704,11 +704,11 @@
 
 			<div class="item">
 				<div class="ui right">
-					<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{.i18n.Tr "repo.settings.delete"}}</button>
+					<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{.locale.Tr "repo.settings.delete"}}</button>
 				</div>
 				<div>
-					<h5>{{.i18n.Tr "repo.settings.delete"}}</h5>
-					<p>{{.i18n.Tr "repo.settings.delete_desc"}}</p>
+					<h5>{{.locale.Tr "repo.settings.delete"}}</h5>
+					<p>{{.locale.Tr "repo.settings.delete_desc"}}</p>
 				</div>
 			</div>
 
@@ -719,19 +719,19 @@
 					<div class="ui right">
 						<button class="ui basic red show-modal button" data-modal="#archive-repo-modal">
 							{{if .Repository.IsArchived}}
-								{{.i18n.Tr "repo.settings.unarchive.button"}}
+								{{.locale.Tr "repo.settings.unarchive.button"}}
 							{{else}}
-								{{.i18n.Tr "repo.settings.archive.button"}}
+								{{.locale.Tr "repo.settings.archive.button"}}
 							{{end}}
 						</button>
 					</div>
 					<div>
 						{{if .Repository.IsArchived}}
-							<h5>{{.i18n.Tr "repo.settings.unarchive.header"}}</h5>
-							<p>{{.i18n.Tr "repo.settings.unarchive.text"}}</p>
+							<h5>{{.locale.Tr "repo.settings.unarchive.header"}}</h5>
+							<p>{{.locale.Tr "repo.settings.unarchive.text"}}</p>
 						{{else}}
-							<h5>{{.i18n.Tr "repo.settings.archive.header"}}</h5>
-							<p>{{.i18n.Tr "repo.settings.archive.text"}}</p>
+							<h5>{{.locale.Tr "repo.settings.archive.header"}}</h5>
+							<p>{{.locale.Tr "repo.settings.archive.text"}}</p>
 						{{end}}
 					</div>
 				</div>
@@ -745,29 +745,29 @@
 	{{if .Repository.IsMirror}}
 		<div class="ui small modal" id="convert-mirror-repo-modal">
 			<div class="header">
-				{{.i18n.Tr "repo.settings.convert"}}
+				{{.locale.Tr "repo.settings.convert"}}
 			</div>
 			<div class="content">
 				<div class="ui warning message text left">
-					{{.i18n.Tr "repo.settings.convert_notices_1"}}
+					{{.locale.Tr "repo.settings.convert_notices_1"}}
 				</div>
 				<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<input type="hidden" name="action" value="convert">
 					<div class="field">
 						<label>
-							{{.i18n.Tr "repo.settings.transfer_form_title"}}
+							{{.locale.Tr "repo.settings.transfer_form_title"}}
 							<span class="text red">{{.Repository.Name}}</span>
 						</label>
 					</div>
 					<div class="required field">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" required>
 					</div>
 
 					<div class="text right actions">
-						<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-						<button class="ui red button">{{.i18n.Tr "repo.settings.convert_confirm"}}</button>
+						<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+						<button class="ui red button">{{.locale.Tr "repo.settings.convert_confirm"}}</button>
 					</div>
 				</form>
 			</div>
@@ -776,29 +776,29 @@
 	{{if and .Repository.IsFork .Repository.Owner.CanCreateRepo}}
 		<div class="ui small modal" id="convert-fork-repo-modal">
 			<div class="header">
-				{{.i18n.Tr "repo.settings.convert_fork"}}
+				{{.locale.Tr "repo.settings.convert_fork"}}
 			</div>
 			<div class="content">
 				<div class="ui warning message text left">
-					{{.i18n.Tr "repo.settings.convert_fork_notices_1"}}
+					{{.locale.Tr "repo.settings.convert_fork_notices_1"}}
 				</div>
 				<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<input type="hidden" name="action" value="convert_fork">
 					<div class="field">
 						<label>
-							{{.i18n.Tr "repo.settings.transfer_form_title"}}
+							{{.locale.Tr "repo.settings.transfer_form_title"}}
 							<span class="text red">{{.Repository.Name}}</span>
 						</label>
 					</div>
 					<div class="required field">
-						<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+						<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 						<input id="repo_name" name="repo_name" required>
 					</div>
 
 					<div class="text right actions">
-						<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-						<button class="ui red button">{{.i18n.Tr "repo.settings.convert_fork_confirm"}}</button>
+						<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+						<button class="ui red button">{{.locale.Tr "repo.settings.convert_fork_confirm"}}</button>
 					</div>
 				</form>
 			</div>
@@ -806,35 +806,35 @@
 	{{end}}
 	<div class="ui small modal" id="transfer-repo-modal">
 		<div class="header">
-			{{.i18n.Tr "repo.settings.transfer"}}
+			{{.locale.Tr "repo.settings.transfer"}}
 		</div>
 		<div class="content">
 			<div class="ui warning message text left">
-				{{.i18n.Tr "repo.settings.transfer_notices_1"}} <br>
-				{{.i18n.Tr "repo.settings.transfer_notices_2"}} <br>
-				{{.i18n.Tr "repo.settings.transfer_notices_3"}}
+				{{.locale.Tr "repo.settings.transfer_notices_1"}} <br>
+				{{.locale.Tr "repo.settings.transfer_notices_2"}} <br>
+				{{.locale.Tr "repo.settings.transfer_notices_3"}}
 			</div>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="transfer">
 				<div class="field">
 					<label>
-						{{.i18n.Tr "repo.settings.transfer_form_title"}}
+						{{.locale.Tr "repo.settings.transfer_form_title"}}
 						<span class="text red">{{.Repository.Name}}</span>
 					</label>
 				</div>
 				<div class="required field">
-					<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+					<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 					<input id="repo_name" name="repo_name" required>
 				</div>
 				<div class="required field">
-					<label for="new_owner_name">{{.i18n.Tr "repo.settings.transfer_owner"}}</label>
+					<label for="new_owner_name">{{.locale.Tr "repo.settings.transfer_owner"}}</label>
 					<input id="new_owner_name" name="new_owner_name" required>
 				</div>
 
 				<div class="text right actions">
-					<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-					<button class="ui red button">{{.i18n.Tr "repo.settings.transfer_perform"}}</button>
+					<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+					<button class="ui red button">{{.locale.Tr "repo.settings.transfer_perform"}}</button>
 				</div>
 			</form>
 		</div>
@@ -842,14 +842,14 @@
 
 	<div class="ui small modal" id="delete-repo-modal">
 		<div class="header">
-			{{.i18n.Tr "repo.settings.delete"}}
+			{{.locale.Tr "repo.settings.delete"}}
 		</div>
 		<div class="content">
 			<div class="ui warning message text left">
-				{{.i18n.Tr "repo.settings.delete_notices_1" | Safe}}<br>
-				{{.i18n.Tr "repo.settings.delete_notices_2" .Repository.FullName | Safe}}
+				{{.locale.Tr "repo.settings.delete_notices_1" | Safe}}<br>
+				{{.locale.Tr "repo.settings.delete_notices_2" .Repository.FullName | Safe}}
 				{{if .Repository.NumForks}}<br>
-				{{.i18n.Tr "repo.settings.delete_notices_fork_1"}}
+				{{.locale.Tr "repo.settings.delete_notices_fork_1"}}
 				{{end}}
 			</div>
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -857,18 +857,18 @@
 				<input type="hidden" name="action" value="delete">
 				<div class="field">
 					<label>
-						{{.i18n.Tr "repo.settings.transfer_form_title"}}
+						{{.locale.Tr "repo.settings.transfer_form_title"}}
 						<span class="text red">{{.Repository.Name}}</span>
 					</label>
 				</div>
 				<div class="required field">
-					<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+					<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 					<input id="repo_name" name="repo_name" required>
 				</div>
 
 				<div class="text right actions">
-					<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-					<button class="ui red button">{{.i18n.Tr "repo.settings.confirm_delete"}}</button>
+					<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+					<button class="ui red button">{{.locale.Tr "repo.settings.confirm_delete"}}</button>
 				</div>
 			</form>
 		</div>
@@ -877,30 +877,30 @@
 	{{if .Repository.UnitEnabled $.UnitTypeWiki}}
 	<div class="ui small modal" id="delete-wiki-modal">
 		<div class="header">
-			{{.i18n.Tr "repo.settings.wiki_delete"}}
+			{{.locale.Tr "repo.settings.wiki_delete"}}
 		</div>
 		<div class="content">
 			<div class="ui warning message text left">
-				{{.i18n.Tr "repo.settings.delete_notices_1" | Safe}}<br>
-				{{.i18n.Tr "repo.settings.wiki_delete_notices_1" .Repository.Name | Safe}}
+				{{.locale.Tr "repo.settings.delete_notices_1" | Safe}}<br>
+				{{.locale.Tr "repo.settings.wiki_delete_notices_1" .Repository.Name | Safe}}
 			</div>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<input type="hidden" name="action" value="delete-wiki">
 				<div class="field">
 					<label>
-						{{.i18n.Tr "repo.settings.transfer_form_title"}}
+						{{.locale.Tr "repo.settings.transfer_form_title"}}
 						<span class="text red">{{.Repository.Name}}</span>
 					</label>
 				</div>
 				<div class="required field">
-					<label for="repo_name">{{.i18n.Tr "repo.repo_name"}}</label>
+					<label for="repo_name">{{.locale.Tr "repo.repo_name"}}</label>
 					<input id="repo_name" name="repo_name" required>
 				</div>
 
 				<div class="text right actions">
-					<div class="ui cancel button">{{.i18n.Tr "settings.cancel"}}</div>
-					<button class="ui red button">{{.i18n.Tr "repo.settings.confirm_wiki_delete"}}</button>
+					<div class="ui cancel button">{{.locale.Tr "settings.cancel"}}</div>
+					<button class="ui red button">{{.locale.Tr "repo.settings.confirm_wiki_delete"}}</button>
 				</div>
 			</form>
 		</div>
@@ -911,17 +911,17 @@
 		<div class="ui basic modal" id="archive-repo-modal">
 			<div class="ui icon header">
 				{{if .Repository.IsArchived}}
-					{{.i18n.Tr "repo.settings.unarchive.header"}}
+					{{.locale.Tr "repo.settings.unarchive.header"}}
 				{{else}}
-					{{.i18n.Tr "repo.settings.archive.header"}}
+					{{.locale.Tr "repo.settings.archive.header"}}
 				{{end}}
 			</div>
 			<div class="content center">
 				<p>
 					{{if .Repository.IsArchived}}
-						{{.i18n.Tr "repo.settings.unarchive.text"}}
+						{{.locale.Tr "repo.settings.unarchive.text"}}
 					{{else}}
-						{{.i18n.Tr "repo.settings.archive.text"}}
+						{{.locale.Tr "repo.settings.archive.text"}}
 					{{end}}
 				</p>
 			</div>
@@ -930,8 +930,8 @@
 				<input type="hidden" name="action" value="{{if .Repository.IsArchived}}unarchive{{else}}archive{{end}}">
 				<input type="hidden" name="repo_id" value="{{.Repository.ID}}">
 				<div class="center actions">
-					<div class="ui basic cancel inverted button">{{.i18n.Tr "settings.cancel"}}</div>
-					<button class="ui basic inverted yellow button">{{.i18n.Tr "modal.yes"}}</button>
+					<div class="ui basic cancel inverted button">{{.locale.Tr "settings.cancel"}}</div>
+					<button class="ui basic inverted yellow button">{{.locale.Tr "modal.yes"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "repo.settings.branch_protection" (.Branch.BranchName|Escape) | Str2html}}
+			{{.locale.Tr "repo.settings.branch_protection" (.Branch.BranchName|Escape) | Str2html}}
 		</h4>
 		<div class="ui attached segment branch-protection">
 			<form class="ui form" action="{{.Link}}" method="post">
@@ -13,38 +13,38 @@
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input class="enable-protection" name="protected" type="checkbox" data-target="#protection_box" {{if .Branch.IsProtected}}checked{{end}}>
-						<label>{{.i18n.Tr "repo.settings.protect_this_branch"}}</label>
-						<p class="help">{{.i18n.Tr "repo.settings.protect_this_branch_desc"}}</p>
+						<label>{{.locale.Tr "repo.settings.protect_this_branch"}}</label>
+						<p class="help">{{.locale.Tr "repo.settings.protect_this_branch_desc"}}</p>
 					</div>
 				</div>
 				<div id="protection_box" class="fields {{if not .Branch.IsProtected}}disabled{{end}}">
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input name="enable_push" type="radio" value="none" class="disable-whitelist" data-target="#whitelist_box" {{if not .Branch.CanPush}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_disable_push"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_disable_push_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_disable_push"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_disable_push_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input name="enable_push" type="radio" value="all" class="disable-whitelist" data-target="#whitelist_box" {{if and (.Branch.CanPush) (not .Branch.EnableWhitelist)}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_enable_push"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_enable_push_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_enable_push"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_enable_push_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
 							<input name="enable_push" type="radio" value="whitelist" class="enable-whitelist" data-target="#whitelist_box" {{if and (.Branch.CanPush) (.Branch.EnableWhitelist)}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_whitelist_committers"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_whitelist_committers_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_whitelist_committers"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_whitelist_committers_desc"}}</p>
 						</div>
 					</div>
 					<div id="whitelist_box" class="fields {{if not .Branch.EnableWhitelist}}disabled{{end}}">
 						<div class="whitelist field">
-							<label>{{.i18n.Tr "repo.settings.protect_whitelist_users"}}</label>
+							<label>{{.locale.Tr "repo.settings.protect_whitelist_users"}}</label>
 							<div class="ui multiple search selection dropdown">
 								<input type="hidden" name="whitelist_users" value="{{.whitelist_users}}">
-								<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_users"}}</div>
+								<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_users"}}</div>
 								<div class="menu">
 									{{range .Users}}
 										<div class="item" data-value="{{.ID}}">
@@ -58,10 +58,10 @@
 						{{if .Owner.IsOrganization}}
 							<br>
 							<div class="whitelist field">
-								<label>{{.i18n.Tr "repo.settings.protect_whitelist_teams"}}</label>
+								<label>{{.locale.Tr "repo.settings.protect_whitelist_teams"}}</label>
 								<div class="ui multiple search selection dropdown">
 									<input type="hidden" name="whitelist_teams" value="{{.whitelist_teams}}">
-									<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
+									<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
 									<div class="menu">
 										{{range .Teams}}
 											<div class="item" data-value="{{.ID}}">
@@ -77,7 +77,7 @@
 						<div class="whitelist field">
 							<div class="ui checkbox">
 								<input type="checkbox" name="whitelist_deploy_keys" {{if .Branch.WhitelistDeployKeys}}checked{{end}}>
-								<label for="whitelist_deploy_keys">{{.i18n.Tr "repo.settings.protect_whitelist_deploy_keys"}}</label>
+								<label for="whitelist_deploy_keys">{{.locale.Tr "repo.settings.protect_whitelist_deploy_keys"}}</label>
 							</div>
 						</div>
 					</div>
@@ -85,16 +85,16 @@
 					<div class="field">
 						<div class="ui checkbox">
 							<input class="enable-whitelist" name="enable_merge_whitelist" type="checkbox" data-target="#merge_whitelist_box" {{if .Branch.EnableMergeWhitelist}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_merge_whitelist_committers"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_merge_whitelist_committers_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_merge_whitelist_committers"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_merge_whitelist_committers_desc"}}</p>
 						</div>
 					</div>
 					<div id="merge_whitelist_box" class="fields {{if not .Branch.EnableMergeWhitelist}}disabled{{end}}">
 						<div class="whitelist field">
-							<label>{{.i18n.Tr "repo.settings.protect_merge_whitelist_users"}}</label>
+							<label>{{.locale.Tr "repo.settings.protect_merge_whitelist_users"}}</label>
 							<div class="ui multiple search selection dropdown">
 								<input type="hidden" name="merge_whitelist_users" value="{{.merge_whitelist_users}}">
-								<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_users"}}</div>
+								<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_users"}}</div>
 								<div class="menu">
 								{{range .Users}}
 									<div class="item" data-value="{{.ID}}">
@@ -108,10 +108,10 @@
 					{{if .Owner.IsOrganization}}
 						<br>
 						<div class="whitelist field">
-							<label>{{.i18n.Tr "repo.settings.protect_merge_whitelist_teams"}}</label>
+							<label>{{.locale.Tr "repo.settings.protect_merge_whitelist_teams"}}</label>
 							<div class="ui multiple search selection dropdown">
 								<input type="hidden" name="merge_whitelist_teams" value="{{.merge_whitelist_teams}}">
-								<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
+								<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
 								<div class="menu">
 								{{range .Teams}}
 									<div class="item" data-value="{{.ID}}">
@@ -128,8 +128,8 @@
 					<div class="field">
 						<div class="ui checkbox">
 							<input class="enable-statuscheck" name="enable_status_check" type="checkbox" data-target="#statuscheck_contexts_box" {{if eq (len .branch_status_check_contexts) 0}}disabled{{end}} {{if .Branch.EnableStatusCheck}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_check_status_contexts"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_check_status_contexts_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_check_status_contexts"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_check_status_contexts_desc"}}</p>
 						</div>
 					</div>
 
@@ -138,7 +138,7 @@
 							<table class="ui celled table six column">
 								<thead>
 									<tr><th>
-										{{.i18n.Tr "repo.settings.protect_check_status_contexts_list"}}
+										{{.locale.Tr "repo.settings.protect_check_status_contexts_list"}}
 									</th>
 									</tr>
 								</thead>
@@ -158,23 +158,23 @@
 					</div>
 
 					<div class="field">
-						<label for="required-approvals">{{.i18n.Tr "repo.settings.protect_required_approvals"}}</label>
+						<label for="required-approvals">{{.locale.Tr "repo.settings.protect_required_approvals"}}</label>
 						<input name="required_approvals" id="required-approvals" type="number" value="{{.Branch.RequiredApprovals}}">
-						<p class="help">{{.i18n.Tr "repo.settings.protect_required_approvals_desc"}}</p>
+						<p class="help">{{.locale.Tr "repo.settings.protect_required_approvals_desc"}}</p>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
 							<input class="enable-whitelist" name="enable_approvals_whitelist" type="checkbox" data-target="#approvals_whitelist_box" {{if .Branch.EnableApprovalsWhitelist}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.settings.protect_approvals_whitelist_enabled"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.protect_approvals_whitelist_enabled_desc"}}</p>
+							<label>{{.locale.Tr "repo.settings.protect_approvals_whitelist_enabled"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.protect_approvals_whitelist_enabled_desc"}}</p>
 						</div>
 					</div>
 					<div id="approvals_whitelist_box" class="fields {{if not .Branch.EnableApprovalsWhitelist}}disabled{{end}}">
 						<div class="whitelist field">
-							<label>{{.i18n.Tr "repo.settings.protect_approvals_whitelist_users"}}</label>
+							<label>{{.locale.Tr "repo.settings.protect_approvals_whitelist_users"}}</label>
 							<div class="ui multiple search selection dropdown">
 								<input type="hidden" name="approvals_whitelist_users" value="{{.approvals_whitelist_users}}">
-								<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_users"}}</div>
+								<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_users"}}</div>
 								<div class="menu">
 								{{range .Users}}
 									<div class="item" data-value="{{.ID}}">
@@ -188,10 +188,10 @@
 						{{if .Owner.IsOrganization}}
 							<br>
 							<div class="whitelist field">
-								<label>{{.i18n.Tr "repo.settings.protect_approvals_whitelist_teams"}}</label>
+								<label>{{.locale.Tr "repo.settings.protect_approvals_whitelist_teams"}}</label>
 								<div class="ui multiple search selection dropdown">
 									<input type="hidden" name="approvals_whitelist_teams" value="{{.approvals_whitelist_teams}}">
-									<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
+									<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
 									<div class="menu">
 									{{range .Teams}}
 										<div class="item" data-value="{{.ID}}">
@@ -207,47 +207,47 @@
 					<div class="field">
 						<div class="ui checkbox">
 							<input name="block_on_rejected_reviews" type="checkbox" {{if .Branch.BlockOnRejectedReviews}}checked{{end}}>
-							<label for="block_on_rejected_reviews">{{.i18n.Tr "repo.settings.block_rejected_reviews"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.block_rejected_reviews_desc"}}</p>
+							<label for="block_on_rejected_reviews">{{.locale.Tr "repo.settings.block_rejected_reviews"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.block_rejected_reviews_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
 							<input name="block_on_official_review_requests" type="checkbox" {{if .Branch.BlockOnOfficialReviewRequests}}checked{{end}}>
-							<label for="block_on_official_review_requests">{{.i18n.Tr "repo.settings.block_on_official_review_requests"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.block_on_official_review_requests_desc"}}</p>
+							<label for="block_on_official_review_requests">{{.locale.Tr "repo.settings.block_on_official_review_requests"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.block_on_official_review_requests_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
 							<input name="dismiss_stale_approvals" type="checkbox" {{if .Branch.DismissStaleApprovals}}checked{{end}}>
-							<label for="dismiss_stale_approvals">{{.i18n.Tr "repo.settings.dismiss_stale_approvals"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.dismiss_stale_approvals_desc"}}</p>
+							<label for="dismiss_stale_approvals">{{.locale.Tr "repo.settings.dismiss_stale_approvals"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.dismiss_stale_approvals_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
 							<input name="require_signed_commits" type="checkbox" {{if .Branch.RequireSignedCommits}}checked{{end}}>
-							<label for="require_signed_commits">{{.i18n.Tr "repo.settings.require_signed_commits"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.require_signed_commits_desc"}}</p>
+							<label for="require_signed_commits">{{.locale.Tr "repo.settings.require_signed_commits"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.require_signed_commits_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
 							<input name="block_on_outdated_branch" type="checkbox" {{if .Branch.BlockOnOutdatedBranch}}checked{{end}}>
-							<label for="block_on_outdated_branch">{{.i18n.Tr "repo.settings.block_outdated_branch"}}</label>
-							<p class="help">{{.i18n.Tr "repo.settings.block_outdated_branch_desc"}}</p>
+							<label for="block_on_outdated_branch">{{.locale.Tr "repo.settings.block_outdated_branch"}}</label>
+							<p class="help">{{.locale.Tr "repo.settings.block_outdated_branch_desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
-						<label for="protected_file_patterns">{{.i18n.Tr "repo.settings.protect_protected_file_patterns"}}</label>
+						<label for="protected_file_patterns">{{.locale.Tr "repo.settings.protect_protected_file_patterns"}}</label>
 						<input name="protected_file_patterns" id="protected_file_patterns" type="text" value="{{.Branch.ProtectedFilePatterns}}">
-						<p class="help">{{.i18n.Tr "repo.settings.protect_protected_file_patterns_desc" | Safe}}</p>
+						<p class="help">{{.locale.Tr "repo.settings.protect_protected_file_patterns_desc" | Safe}}</p>
 					</div>
 					<div class="field">
-						<label for="unprotected_file_patterns">{{.i18n.Tr "repo.settings.protect_unprotected_file_patterns"}}</label>
+						<label for="unprotected_file_patterns">{{.locale.Tr "repo.settings.protect_unprotected_file_patterns"}}</label>
 						<input name="unprotected_file_patterns" id="unprotected_file_patterns" type="text" value="{{.Branch.UnprotectedFilePatterns}}">
-						<p class="help">{{.i18n.Tr "repo.settings.protect_unprotected_file_patterns_desc" | Safe}}</p>
+						<p class="help">{{.locale.Tr "repo.settings.protect_unprotected_file_patterns_desc" | Safe}}</p>
 					</div>
 
 				</div>
@@ -255,7 +255,7 @@
 				<div class="ui divider"></div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "repo.settings.update_settings"}}</button>
+					<button class="ui green button">{{$.locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/repo/settings/tags.tmpl
+++ b/templates/repo/settings/tags.tmpl
@@ -6,11 +6,11 @@
 		{{template "base/alert" .}}
 		{{if .Repository.IsArchived}}
 			<div class="ui warning message">
-				{{.i18n.Tr "repo.settings.archive.tagsettings_unavailable"}}
+				{{.locale.Tr "repo.settings.archive.tagsettings_unavailable"}}
 			</div>
 		{{else}}
 			<h4 class="ui top attached header">
-				{{.i18n.Tr "repo.settings.tags.protection"}}
+				{{.locale.Tr "repo.settings.tags.protection"}}
 			</h4>
 
 			<div class="ui attached segment">
@@ -20,19 +20,19 @@
 							<form class="ui form" action="{{.Link}}" method="post">
 								{{.CsrfTokenHtml}}
 								<div class="field">
-									<label>{{.i18n.Tr "repo.settings.tags.protection.pattern"}}</label>
+									<label>{{.locale.Tr "repo.settings.tags.protection.pattern"}}</label>
 									<div id="search-tag-box" class="ui search">
 										<div class="ui input">
 											<input class="prompt" name="name_pattern" autocomplete="off" value="{{.name_pattern}}" placeholder="v*" autofocus required>
 										</div>
-										<div class="help">{{.i18n.Tr "repo.settings.tags.protection.pattern.description" | Safe}}</div>
+										<div class="help">{{.locale.Tr "repo.settings.tags.protection.pattern.description" | Safe}}</div>
 									</div>
 								</div>
 								<div class="whitelist field">
-									<label>{{.i18n.Tr "repo.settings.tags.protection.allowed.users"}}</label>
+									<label>{{.locale.Tr "repo.settings.tags.protection.allowed.users"}}</label>
 									<div class="ui multiple search selection dropdown">
 										<input type="hidden" name="allowlist_users" value="{{.allowlist_users}}">
-										<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_users"}}</div>
+										<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_users"}}</div>
 										<div class="menu">
 											{{range .Users}}
 												<div class="item" data-value="{{.ID}}">
@@ -45,10 +45,10 @@
 								</div>
 								{{if .Owner.IsOrganization}}
 									<div class="whitelist field">
-										<label>{{.i18n.Tr "repo.settings.tags.protection.allowed.teams"}}</label>
+										<label>{{.locale.Tr "repo.settings.tags.protection.allowed.teams"}}</label>
 										<div class="ui multiple search selection dropdown">
 											<input type="hidden" name="allowlist_teams" value="{{.allowlist_teams}}">
-											<div class="default text">{{.i18n.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
+											<div class="default text">{{.locale.Tr "repo.settings.protect_whitelist_search_teams"}}</div>
 											<div class="menu">
 												{{range .Teams}}
 													<div class="item" data-value="{{.ID}}">
@@ -63,14 +63,14 @@
 								<div class="field">
 									{{if .PageIsEditProtectedTag}}
 									<button class="ui green button">
-										{{$.i18n.Tr "save"}}
+										{{$.locale.Tr "save"}}
 									</button>
 									<a class="ui primary button" href="{{$.RepoLink}}/settings/tags">
-										{{$.i18n.Tr "cancel"}}
+										{{$.locale.Tr "cancel"}}
 									</a>
 									{{else}}
 									<button class="ui green button">
-										{{$.i18n.Tr "repo.settings.tags.protection.create"}}
+										{{$.locale.Tr "repo.settings.tags.protection.create"}}
 									</button>
 									{{end}}
 								</div>
@@ -81,8 +81,8 @@
 					<div class="sixteen wide column">
 						<table class="ui single line table">
 							<thead>
-								<th>{{.i18n.Tr "repo.settings.tags.protection.pattern"}}</th>
-								<th>{{.i18n.Tr "repo.settings.tags.protection.allowed"}}</th>
+								<th>{{.locale.Tr "repo.settings.tags.protection.pattern"}}</th>
+								<th>{{.locale.Tr "repo.settings.tags.protection.allowed"}}</th>
 								<th></th>
 							</thead>
 							<tbody>
@@ -106,20 +106,20 @@
 													{{end}}
 												{{end}}
 											{{else}}
-												{{$.i18n.Tr "repo.settings.tags.protection.allowed.noone"}}
+												{{$.locale.Tr "repo.settings.tags.protection.allowed.noone"}}
 											{{end}}
 										</td>
 										<td class="right aligned">
-											<a class="ui tiny primary button" href="{{$.RepoLink}}/settings/tags/{{.ID}}">{{$.i18n.Tr "edit"}}</a>
+											<a class="ui tiny primary button" href="{{$.RepoLink}}/settings/tags/{{.ID}}">{{$.locale.Tr "edit"}}</a>
 											<form class="dib" action="{{$.RepoLink}}/settings/tags/delete" method="post">
 												{{$.CsrfTokenHtml}}
 												<input type="hidden" name="id" value="{{.ID}}" />
-												<button class="ui tiny red button">{{$.i18n.Tr "remove"}}</button>
+												<button class="ui tiny red button">{{$.locale.Tr "remove"}}</button>
 											</form>
 										</td>
 									</tr>
 								{{else}}
-									<tr class="center aligned"><td colspan="3">{{.i18n.Tr "repo.settings.tags.protection.none"}}</td></tr>
+									<tr class="center aligned"><td colspan="3">{{.locale.Tr "repo.settings.tags.protection.none"}}</td></tr>
 								{{end}}
 							</tbody>
 						</table>

--- a/templates/repo/settings/webhook/base_list.tmpl
+++ b/templates/repo/settings/webhook/base_list.tmpl
@@ -2,40 +2,40 @@
 	{{.Title}}
 	<div class="ui right">
 		<div class="ui floating1 jump dropdown">
-			<div class="ui primary tiny button">{{.i18n.Tr "repo.settings.add_webhook"}}</div>
+			<div class="ui primary tiny button">{{.locale.Tr "repo.settings.add_webhook"}}</div>
 			<div class="menu">
 				<a class="item" href="{{.BaseLinkNew}}/gitea/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gitea.svg">{{.i18n.Tr "repo.settings.web_hook_name_gitea"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gitea.svg">{{.locale.Tr "repo.settings.web_hook_name_gitea"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/gogs/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gogs.ico">{{.i18n.Tr "repo.settings.web_hook_name_gogs"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gogs.ico">{{.locale.Tr "repo.settings.web_hook_name_gogs"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/slack/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/slack.png">{{.i18n.Tr "repo.settings.web_hook_name_slack"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/slack.png">{{.locale.Tr "repo.settings.web_hook_name_slack"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/discord/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/discord.png">{{.i18n.Tr "repo.settings.web_hook_name_discord"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/discord.png">{{.locale.Tr "repo.settings.web_hook_name_discord"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/dingtalk/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/dingtalk.ico">{{.i18n.Tr "repo.settings.web_hook_name_dingtalk"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/dingtalk.ico">{{.locale.Tr "repo.settings.web_hook_name_dingtalk"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/telegram/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/telegram.png">{{.i18n.Tr "repo.settings.web_hook_name_telegram"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/telegram.png">{{.locale.Tr "repo.settings.web_hook_name_telegram"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/msteams/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/msteams.png">{{.i18n.Tr "repo.settings.web_hook_name_msteams"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/msteams.png">{{.locale.Tr "repo.settings.web_hook_name_msteams"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/feishu/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/feishu.png">{{.i18n.Tr "repo.settings.web_hook_name_feishu_or_larksuite"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/feishu.png">{{.locale.Tr "repo.settings.web_hook_name_feishu_or_larksuite"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/matrix/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/matrix.svg">{{.i18n.Tr "repo.settings.web_hook_name_matrix"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/matrix.svg">{{.locale.Tr "repo.settings.web_hook_name_matrix"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/wechatwork/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/wechatwork.png">{{.i18n.Tr "repo.settings.web_hook_name_wechatwork"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/wechatwork.png">{{.locale.Tr "repo.settings.web_hook_name_wechatwork"}}
 				</a>
 				<a class="item" href="{{.BaseLinkNew}}/packagist/new">
-					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/packagist.png">{{.i18n.Tr "repo.settings.web_hook_name_packagist"}}
+					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/packagist.png">{{.locale.Tr "repo.settings.web_hook_name_packagist"}}
 				</a>
 			</div>
 		</div>

--- a/templates/repo/settings/webhook/delete_modal.tmpl
+++ b/templates/repo/settings/webhook/delete_modal.tmpl
@@ -1,19 +1,19 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.settings.webhook_deletion"}}
+		{{.locale.Tr "repo.settings.webhook_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.settings.webhook_deletion_desc"}}</p>
+		<p>{{.locale.Tr "repo.settings.webhook_deletion_desc"}}</p>
 	</div>
 	<div class="actions">
 		<div class="ui red basic inverted cancel button">
 			<i class="remove icon"></i>
-			{{.i18n.Tr "modal.no"}}
+			{{.locale.Tr "modal.no"}}
 		</div>
 		<div class="ui green basic inverted ok button">
 			<i class="checkmark icon"></i>
-			{{.i18n.Tr "modal.yes"}}
+			{{.locale.Tr "modal.yes"}}
 		</div>
 	</div>
 </div>

--- a/templates/repo/settings/webhook/dingtalk.tmpl
+++ b/templates/repo/settings/webhook/dingtalk.tmpl
@@ -1,9 +1,9 @@
 {{if eq .HookType "dingtalk"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://dingtalk.com" (.i18n.Tr "repo.settings.web_hook_name_dingtalk") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://dingtalk.com" (.locale.Tr "repo.settings.web_hook_name_dingtalk") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/dingtalk/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/discord.tmpl
+++ b/templates/repo/settings/webhook/discord.tmpl
@@ -1,17 +1,17 @@
 {{if eq .HookType "discord"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://discord.com" (.i18n.Tr "repo.settings.web_hook_name_discord") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://discord.com" (.locale.Tr "repo.settings.web_hook_name_discord") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/discord/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		<div class="field">
-			<label for="username">{{.i18n.Tr "repo.settings.discord_username"}}</label>
+			<label for="username">{{.locale.Tr "repo.settings.discord_username"}}</label>
 			<input id="username" name="username" value="{{.DiscordHook.Username}}" placeholder="e.g. Gitea">
 		</div>
 		<div class="field">
-			<label for="icon_url">{{.i18n.Tr "repo.settings.discord_icon_url"}}</label>
+			<label for="icon_url">{{.locale.Tr "repo.settings.discord_icon_url"}}</label>
 			<input id="icon_url" name="icon_url" value="{{.DiscordHook.IconURL}}" placeholder="e.g. https://example.com/assets/img/logo.svg">
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/feishu.tmpl
+++ b/templates/repo/settings/webhook/feishu.tmpl
@@ -1,10 +1,10 @@
 {{if eq .HookType "feishu"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://feishu.cn" (.i18n.Tr "repo.settings.web_hook_name_feishu") | Str2html}}</p>
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://larksuite.com" (.i18n.Tr "repo.settings.web_hook_name_larksuite") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://feishu.cn" (.locale.Tr "repo.settings.web_hook_name_feishu") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://larksuite.com" (.locale.Tr "repo.settings.web_hook_name_larksuite") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/feishu/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/gitea.tmpl
+++ b/templates/repo/settings/webhook/gitea.tmpl
@@ -1,14 +1,14 @@
 {{if eq .HookType "gitea"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.i18n.Tr "repo.settings.web_hook_name_gitea") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.locale.Tr "repo.settings.web_hook_name_gitea") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/gitea/{{or .Webhook.ID "new"}}" method="post">
 		{{template "base/disable_form_autofill"}}
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "repo.settings.http_method"}}</label>
+			<label>{{.locale.Tr "repo.settings.http_method"}}</label>
 			<div class="ui selection dropdown">
 				<input type="hidden" id="http_method" name="http_method" value="{{if .Webhook.HTTPMethod}}{{.Webhook.HTTPMethod}}{{else}}POST{{end}}">
 				<div class="default text"></div>
@@ -20,7 +20,7 @@
 			</div>
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "repo.settings.content_type"}}</label>
+			<label>{{.locale.Tr "repo.settings.content_type"}}</label>
 			<div class="ui selection dropdown">
 				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}1{{end}}">
 				<div class="default text"></div>
@@ -32,7 +32,7 @@
 			</div>
 		</div>
 		<div class="field {{if .Err_Secret}}error{{end}}">
-			<label for="secret">{{.i18n.Tr "repo.settings.secret"}}</label>
+			<label for="secret">{{.locale.Tr "repo.settings.secret"}}</label>
 			<input id="secret" name="secret" type="password" value="{{.Webhook.Secret}}" autocomplete="off">
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/gogs.tmpl
+++ b/templates/repo/settings/webhook/gogs.tmpl
@@ -1,14 +1,14 @@
 {{if eq .HookType "gogs"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.i18n.Tr "repo.settings.web_hook_name_gogs") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://docs.gitea.io/en-us/webhooks/" (.locale.Tr "repo.settings.web_hook_name_gogs") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/gogs/{{or .Webhook.ID "new"}}" method="post">
 		{{template "base/disable_form_autofill"}}
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "repo.settings.content_type"}}</label>
+			<label>{{.locale.Tr "repo.settings.content_type"}}</label>
 			<div class="ui selection dropdown">
 				<input type="hidden" id="content_type" name="content_type" value="{{if .Webhook.ContentType}}{{.Webhook.ContentType}}{{else}}1{{end}}">
 				<div class="default text"></div>
@@ -20,7 +20,7 @@
 			</div>
 		</div>
 		<div class="field {{if .Err_Secret}}error{{end}}">
-			<label for="secret">{{.i18n.Tr "repo.settings.secret"}}</label>
+			<label for="secret">{{.locale.Tr "repo.settings.secret"}}</label>
 			<input id="secret" name="secret" type="password" value="{{.Webhook.Secret}}" autocomplete="off">
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -1,10 +1,10 @@
 {{if .PageIsSettingsHooksEdit}}
 	<h4 class="ui top attached header">
-		{{.i18n.Tr "repo.settings.recent_deliveries"}}
+		{{.locale.Tr "repo.settings.recent_deliveries"}}
 		{{if .Permission.IsAdmin}}
 			<div class="ui right">
 				<button class="ui teal tiny button tooltip" id="test-delivery" data-content=
-				"{{.i18n.Tr "repo.settings.webhook.test_delivery_desc"}}" data-link="{{.Link}}/test" data-redirect="{{.Link}}">{{.i18n.Tr "repo.settings.webhook.test_delivery"}}</button>
+				"{{.locale.Tr "repo.settings.webhook.test_delivery_desc"}}" data-link="{{.Link}}/test" data-redirect="{{.Link}}">{{.locale.Tr "repo.settings.webhook.test_delivery"}}</button>
 			</div>
 		{{end}}
 	</h4>
@@ -27,9 +27,9 @@
 					</div>
 					<div class="info hide" id="info-{{.ID}}">
 						<div class="ui top attached tabular menu">
-							<a class="item active" data-tab="request-{{.ID}}">{{$.i18n.Tr "repo.settings.webhook.request"}}</a>
+							<a class="item active" data-tab="request-{{.ID}}">{{$.locale.Tr "repo.settings.webhook.request"}}</a>
 							<a class="item" data-tab="response-{{.ID}}">
-								{{$.i18n.Tr "repo.settings.webhook.response"}}
+								{{$.locale.Tr "repo.settings.webhook.response"}}
 								{{if .ResponseInfo}}
 									{{if .IsSucceed}}
 										<span class="ui green label">{{.ResponseInfo.Status}}</span>
@@ -44,19 +44,19 @@
 							<div class="right menu">
 								<form class="item" action="{{$.Link}}/replay/{{.UUID}}" method="post">
 									{{$.CsrfTokenHtml}}
-									<button class="ui tiny button tooltip" data-content="{{$.i18n.Tr "repo.settings.webhook.replay.description"}}" data-variation="inverted tiny">{{svg "octicon-sync"}}</button>
+									<button class="ui tiny button tooltip" data-content="{{$.locale.Tr "repo.settings.webhook.replay.description"}}" data-variation="inverted tiny">{{svg "octicon-sync"}}</button>
 								</form>
 							</div>
 							{{end}}
 						</div>
 						<div class="ui bottom attached tab segment active" data-tab="request-{{.ID}}">
 							{{if .RequestInfo}}
-								<h5>{{$.i18n.Tr "repo.settings.webhook.headers"}}</h5>
+								<h5>{{$.locale.Tr "repo.settings.webhook.headers"}}</h5>
 								<pre class="webhook-info"><strong>Request URL:</strong> {{.RequestInfo.URL}}
 <strong>Request method:</strong> {{if .RequestInfo.HTTPMethod}}{{.RequestInfo.HTTPMethod}}{{else}}POST{{end}}
 {{ range $key, $val := .RequestInfo.Headers }}<strong>{{$key}}:</strong> {{$val}}
 {{end}}</pre>
-								<h5>{{$.i18n.Tr "repo.settings.webhook.payload"}}</h5>
+								<h5>{{$.locale.Tr "repo.settings.webhook.payload"}}</h5>
 								<pre class="webhook-info"><code class="json">{{.PayloadContent}}</code></pre>
 							{{else}}
 								N/A
@@ -64,10 +64,10 @@
 						</div>
 						<div class="ui bottom attached tab segment" data-tab="response-{{.ID}}">
 							{{if .ResponseInfo}}
-								<h5>{{$.i18n.Tr "repo.settings.webhook.headers"}}</h5>
+								<h5>{{$.locale.Tr "repo.settings.webhook.headers"}}</h5>
 								<pre class="webhook-info">{{ range $key, $val := .ResponseInfo.Headers }}<strong>{{$key}}:</strong> {{$val}}
 {{end}}</pre>
-								<h5>{{$.i18n.Tr "repo.settings.webhook.body"}}</h5>
+								<h5>{{$.locale.Tr "repo.settings.webhook.body"}}</h5>
 								<pre class="webhook-info"><code>{{.ResponseInfo.Body}}</code></pre>
 							{{else}}
 								N/A

--- a/templates/repo/settings/webhook/matrix.tmpl
+++ b/templates/repo/settings/webhook/matrix.tmpl
@@ -1,21 +1,21 @@
 {{if eq .HookType "matrix"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://matrix.org/" (.i18n.Tr "repo.settings.web_hook_name_matrix") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://matrix.org/" (.locale.Tr "repo.settings.web_hook_name_matrix") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/matrix/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_HomeserverURL}}error{{end}}">
-			<label for="homeserver_url">{{.i18n.Tr "repo.settings.matrix.homeserver_url"}}</label>
+			<label for="homeserver_url">{{.locale.Tr "repo.settings.matrix.homeserver_url"}}</label>
 			<input id="homeserver_url" name="homeserver_url" type="url" value="{{.MatrixHook.HomeserverURL}}" autofocus required>
 		</div>
 		<div class="required field {{if .Err_Room}}error{{end}}">
-			<label for="room_id">{{.i18n.Tr "repo.settings.matrix.room_id"}}</label>
+			<label for="room_id">{{.locale.Tr "repo.settings.matrix.room_id"}}</label>
 			<input id="room_id" name="room_id" type="text" value="{{.MatrixHook.Room}}" required>
 		</div>
 		<div class="required field {{if .Err_AccessToken}}error{{end}}">
-			<label for="access_token">{{.i18n.Tr "repo.settings.matrix.access_token"}}</label>
+			<label for="access_token">{{.locale.Tr "repo.settings.matrix.access_token"}}</label>
 			<input id="access_token" name="access_token" type="text" value="{{.MatrixHook.AccessToken}}" required>
 		</div>
 		<div class="field">
-			<label>{{.i18n.Tr "repo.settings.matrix.message_type"}}</label>
+			<label>{{.locale.Tr "repo.settings.matrix.message_type"}}</label>
 				<div class="ui selection dropdown">
 				<input type="hidden" id="message_type" name="message_type" value="{{if .MatrixHook.MessageType}}{{.MatrixHook.MessageType}}{{else}}1{{end}}">
 				<div class="default text"></div>

--- a/templates/repo/settings/webhook/msteams.tmpl
+++ b/templates/repo/settings/webhook/msteams.tmpl
@@ -1,9 +1,9 @@
 {{if eq .HookType "msteams"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://teams.microsoft.com" (.i18n.Tr "repo.settings.web_hook_name_msteams") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://teams.microsoft.com" (.locale.Tr "repo.settings.web_hook_name_msteams") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/msteams/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/new.tmpl
+++ b/templates/repo/settings/webhook/new.tmpl
@@ -5,7 +5,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{if .PageIsSettingsHooksNew}}{{.i18n.Tr "repo.settings.add_webhook"}}{{else}}{{.i18n.Tr "repo.settings.update_webhook"}}{{end}}
+			{{if .PageIsSettingsHooksNew}}{{.locale.Tr "repo.settings.add_webhook"}}{{else}}{{.locale.Tr "repo.settings.update_webhook"}}{{end}}
 			<div class="ui right">
 				{{if eq .HookType "gitea"}}
 					<img width="26" height="26" src="{{AssetUrlPrefix}}/img/gitea.svg">

--- a/templates/repo/settings/webhook/packagist.tmpl
+++ b/templates/repo/settings/webhook/packagist.tmpl
@@ -1,17 +1,17 @@
 {{if eq .HookType "packagist"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://packagist.org" (.i18n.Tr "repo.settings.web_hook_name_packagist") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://packagist.org" (.locale.Tr "repo.settings.web_hook_name_packagist") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/packagist/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_Username}}error{{end}}">
-			<label for="username">{{.i18n.Tr "repo.settings.packagist_username"}}</label>
+			<label for="username">{{.locale.Tr "repo.settings.packagist_username"}}</label>
 			<input id="username" name="username" value="{{.PackagistHook.Username}}" placeholder="e.g. Gitea" autofocus required>
 		</div>
 		<div class="required field {{if .Err_APIToken}}error{{end}}">
-			<label for="api_token">{{.i18n.Tr "repo.settings.packagist_api_token"}}</label>
+			<label for="api_token">{{.locale.Tr "repo.settings.packagist_api_token"}}</label>
 			<input id="api_token" name="api_token" value="{{.PackagistHook.APIToken}}" placeholder="e.g. X5F_tZ-Wj3c1vqaU2Rky" required>
 		</div>
 		<div class="required field {{if .Err_PackageURL}}error{{end}}">
-			<label for="package_url">{{.i18n.Tr "repo.settings.packagist_package_url"}}</label>
+			<label for="package_url">{{.locale.Tr "repo.settings.packagist_package_url"}}</label>
 			<input id="package_url" name="package_url" value="{{.PackagistHook.PackageURL}}" placeholder="e.g. https://packagist.org/packages/laravel/framework" required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/settings.tmpl
+++ b/templates/repo/settings/webhook/settings.tmpl
@@ -1,23 +1,23 @@
 {{$isNew:=or .PageIsSettingsHooksNew .PageIsAdminDefaultHooksNew .PageIsAdminSystemHooksNew}}
 <div class="field">
-	<h4>{{.i18n.Tr "repo.settings.event_desc"}}</h4>
+	<h4>{{.locale.Tr "repo.settings.event_desc"}}</h4>
 	<div class="grouped event type fields">
 		<div class="field">
 			<div class="ui radio non-events checkbox">
 				<input class="hidden" name="events" type="radio" value="push_only" {{if or $isNew .Webhook.PushOnly}}checked{{end}}>
-				<label>{{.i18n.Tr "repo.settings.event_push_only" | Str2html}}</label>
+				<label>{{.locale.Tr "repo.settings.event_push_only" | Str2html}}</label>
 			</div>
 		</div>
 		<div class="field">
 			<div class="ui radio non-events checkbox">
 				<input class="hidden" name="events" type="radio" value="send_everything" {{if .Webhook.SendEverything}}checked{{end}}>
-				<label>{{.i18n.Tr "repo.settings.event_send_everything" | Str2html}}</label>
+				<label>{{.locale.Tr "repo.settings.event_send_everything" | Str2html}}</label>
 			</div>
 		</div>
 		<div class="field">
 			<div class="ui radio events checkbox">
 				<input class="hidden" name="events" type="radio" value="choose_events" {{if .Webhook.ChooseEvents}}checked{{end}}>
-				<label>{{.i18n.Tr "repo.settings.event_choose" | Str2html}}</label>
+				<label>{{.locale.Tr "repo.settings.event_choose" | Str2html}}</label>
 			</div>
 		</div>
 	</div>
@@ -25,15 +25,15 @@
 	<div class="events fields ui grid" {{if not .Webhook.ChooseEvents}}style="display:none"{{end}}>
 		<!-- Repository Events -->
 		<div class="fourteen wide column">
-			<label>{{.i18n.Tr "repo.settings.event_header_repository"}}</label>
+			<label>{{.locale.Tr "repo.settings.event_header_repository"}}</label>
 		</div>
 		<!-- Create -->
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="create" type="checkbox" tabindex="0" {{if .Webhook.Create}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_create"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_create_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_create"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_create_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -42,8 +42,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="delete" type="checkbox" tabindex="0" {{if .Webhook.Delete}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_delete"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_delete_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_delete"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_delete_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -52,8 +52,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="fork" type="checkbox" tabindex="0" {{if .Webhook.Fork}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_fork"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_fork_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_fork"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_fork_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -62,8 +62,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="push" type="checkbox" tabindex="0" {{if .Webhook.Push}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_push"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_push_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_push"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_push_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -72,8 +72,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="repository" type="checkbox" tabindex="0" {{if .Webhook.Repository}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_repository"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_repository_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_repository"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_repository_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -82,8 +82,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="release" type="checkbox" tabindex="0" {{if .Webhook.Release}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_release"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_release_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_release"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_release_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -92,23 +92,23 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="package" type="checkbox" tabindex="0" {{if .Webhook.Package}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_package"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_package_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_package"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_package_desc"}}</span>
 				</div>
 			</div>
 		</div>
 
 		<!-- Issue Events -->
 		<div class="fourteen wide column">
-			<label>{{.i18n.Tr "repo.settings.event_header_issue"}}</label>
+			<label>{{.locale.Tr "repo.settings.event_header_issue"}}</label>
 		</div>
 		<!-- Issues -->
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="issues" type="checkbox" tabindex="0" {{if .Webhook.Issues}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_issues"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_issues_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_issues"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_issues_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -117,8 +117,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="issue_assign" type="checkbox" tabindex="0" {{if .Webhook.IssueAssign}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_issue_assign"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_issue_assign_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_issue_assign"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_issue_assign_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -127,8 +127,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="issue_label" type="checkbox" tabindex="0" {{if .Webhook.IssueLabel}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_issue_label"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_issue_label_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_issue_label"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_issue_label_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -137,8 +137,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="issue_milestone" type="checkbox" tabindex="0" {{if .Webhook.IssueMilestone}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_issue_milestone"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_issue_milestone_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_issue_milestone"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_issue_milestone_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -147,23 +147,23 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="issue_comment" type="checkbox" tabindex="0" {{if .Webhook.IssueComment}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_issue_comment"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_issue_comment_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_issue_comment"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_issue_comment_desc"}}</span>
 				</div>
 			</div>
 		</div>
 
 		<!-- Pull Request Events -->
 		<div class="fourteen wide column">
-			<label>{{.i18n.Tr "repo.settings.event_header_pull_request"}}</label>
+			<label>{{.locale.Tr "repo.settings.event_header_pull_request"}}</label>
 		</div>
 		<!-- Pull Request -->
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request" type="checkbox" tabindex="0" {{if .Webhook.PullRequest}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -172,8 +172,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_assign" type="checkbox" tabindex="0" {{if .Webhook.PullRequestAssign}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_assign"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_assign_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_assign"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_assign_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -182,8 +182,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_label" type="checkbox" tabindex="0" {{if .Webhook.PullRequestLabel}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_label"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_label_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_label"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_label_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -192,8 +192,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_milestone" type="checkbox" tabindex="0" {{if .Webhook.PullRequestMilestone}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_milestone"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_milestone_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_milestone"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_milestone_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -202,8 +202,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_comment" type="checkbox" tabindex="0" {{if .Webhook.PullRequestComment}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_comment"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_comment_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_comment"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_comment_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -212,8 +212,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_review" type="checkbox" tabindex="0" {{if .Webhook.PullRequestReview}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_review"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_review_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_review"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_review_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -222,8 +222,8 @@
 			<div class="field">
 				<div class="ui checkbox">
 					<input class="hidden" name="pull_request_sync" type="checkbox" tabindex="0" {{if .Webhook.PullRequestSync}}checked{{end}}>
-					<label>{{.i18n.Tr "repo.settings.event_pull_request_sync"}}</label>
-					<span class="help">{{.i18n.Tr "repo.settings.event_pull_request_sync_desc"}}</span>
+					<label>{{.locale.Tr "repo.settings.event_pull_request_sync"}}</label>
+					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_sync_desc"}}</span>
 				</div>
 			</div>
 		</div>
@@ -232,9 +232,9 @@
 
 <!-- Branch filter -->
 <div class="field">
-	<label for="branch_filter">{{.i18n.Tr "repo.settings.branch_filter"}}</label>
+	<label for="branch_filter">{{.locale.Tr "repo.settings.branch_filter"}}</label>
 	<input name="branch_filter" type="text" tabindex="0" value="{{or .Webhook.BranchFilter "*"}}">
-	<span class="help">{{.i18n.Tr "repo.settings.branch_filter_desc" | Str2html}}</span>
+	<span class="help">{{.locale.Tr "repo.settings.branch_filter_desc" | Str2html}}</span>
 </div>
 
 <div class="ui divider"></div>
@@ -242,16 +242,16 @@
 <div class="inline field">
 	<div class="ui checkbox">
 		<input class="hidden" name="active" type="checkbox" tabindex="0" {{if or $isNew .Webhook.IsActive}}checked{{end}}>
-		<label>{{.i18n.Tr "repo.settings.active"}}</label>
-		<span class="help">{{.i18n.Tr "repo.settings.active_helper"}}</span>
+		<label>{{.locale.Tr "repo.settings.active"}}</label>
+		<span class="help">{{.locale.Tr "repo.settings.active_helper"}}</span>
 	</div>
 </div>
 <div class="field">
 	{{if $isNew}}
-		<button class="ui green button">{{.i18n.Tr "repo.settings.add_webhook"}}</button>
+		<button class="ui green button">{{.locale.Tr "repo.settings.add_webhook"}}</button>
 	{{else}}
-		<button class="ui green button">{{.i18n.Tr "repo.settings.update_webhook"}}</button>
-		<a class="ui red delete-button button" data-url="{{.BaseLink}}/delete" data-id="{{.Webhook.ID}}">{{.i18n.Tr "repo.settings.delete_webhook"}}</a>
+		<button class="ui green button">{{.locale.Tr "repo.settings.update_webhook"}}</button>
+		<a class="ui red delete-button button" data-url="{{.BaseLink}}/delete" data-id="{{.Webhook.ID}}">{{.locale.Tr "repo.settings.delete_webhook"}}</a>
 	{{end}}
 </div>
 

--- a/templates/repo/settings/webhook/slack.tmpl
+++ b/templates/repo/settings/webhook/slack.tmpl
@@ -1,26 +1,26 @@
 {{if eq .HookType "slack"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://slack.com" (.i18n.Tr "repo.settings.web_hook_name_slack") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://slack.com" (.locale.Tr "repo.settings.web_hook_name_slack") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/slack/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		<div class="required field {{if .Err_Channel}}error{{end}}">
-			<label for="channel">{{.i18n.Tr "repo.settings.slack_channel"}}</label>
+			<label for="channel">{{.locale.Tr "repo.settings.slack_channel"}}</label>
 			<input id="channel" name="channel" value="{{.SlackHook.Channel}}" placeholder="e.g. #general" required>
 		</div>
 
 		<div class="field">
-			<label for="username">{{.i18n.Tr "repo.settings.slack_username"}}</label>
+			<label for="username">{{.locale.Tr "repo.settings.slack_username"}}</label>
 			<input id="username" name="username" value="{{.SlackHook.Username}}" placeholder="e.g. Gitea">
 		</div>
 		<div class="field">
-			<label for="icon_url">{{.i18n.Tr "repo.settings.slack_icon_url"}}</label>
+			<label for="icon_url">{{.locale.Tr "repo.settings.slack_icon_url"}}</label>
 			<input id="icon_url" name="icon_url" value="{{.SlackHook.IconURL}}" placeholder="e.g. https://example.com/img/favicon.png">
 		</div>
 		<div class="field">
-			<label for="color">{{.i18n.Tr "repo.settings.slack_color"}}</label>
+			<label for="color">{{.locale.Tr "repo.settings.slack_color"}}</label>
 			<input id="color" name="color" value="{{.SlackHook.Color}}" placeholder="e.g. #dd4b39, good, warning, danger">
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/telegram.tmpl
+++ b/templates/repo/settings/webhook/telegram.tmpl
@@ -1,13 +1,13 @@
 {{if eq .HookType "telegram"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://core.telegram.org/bots" (.i18n.Tr "repo.settings.web_hook_name_telegram") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://core.telegram.org/bots" (.locale.Tr "repo.settings.web_hook_name_telegram") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/telegram/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_BotToken}}error{{end}}">
-			<label for="bot_token">{{.i18n.Tr "repo.settings.bot_token"}}</label>
+			<label for="bot_token">{{.locale.Tr "repo.settings.bot_token"}}</label>
 			<input id="bot_token" name="bot_token" type="text" value="{{.TelegramHook.BotToken}}" autofocus required>
 		</div>
 		<div class="required field {{if .Err_ChatID}}error{{end}}">
-			<label for="chat_id">{{.i18n.Tr "repo.settings.chat_id"}}</label>
+			<label for="chat_id">{{.locale.Tr "repo.settings.chat_id"}}</label>
 			<input id="chat_id" name="chat_id" type="text" value="{{.TelegramHook.ChatID}}" required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/settings/webhook/wechatwork.tmpl
+++ b/templates/repo/settings/webhook/wechatwork.tmpl
@@ -1,9 +1,9 @@
 {{if eq .HookType "wechatwork"}}
-	<p>{{.i18n.Tr "repo.settings.add_web_hook_desc" "https://work.weixin.qq.com" (.i18n.Tr "repo.settings.web_hook_name_wechatwork") | Str2html}}</p>
+	<p>{{.locale.Tr "repo.settings.add_web_hook_desc" "https://work.weixin.qq.com" (.locale.Tr "repo.settings.web_hook_name_wechatwork") | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/wechatwork/{{or .Webhook.ID "new"}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">
-			<label for="payload_url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+			<label for="payload_url">{{.locale.Tr "repo.settings.payload_url"}}</label>
 			<input id="payload_url" name="payload_url" type="url" value="{{.Webhook.URL}}" autofocus required>
 		</div>
 		{{template "repo/settings/webhook/settings" .}}

--- a/templates/repo/shabox_badge.tmpl
+++ b/templates/repo/shabox_badge.tmpl
@@ -1,15 +1,15 @@
 <div class="ui detail icon button">
 	{{if .verification.Verified}}
-		<div title="{{if eq .verification.TrustStatus "trusted"}}{{else if eq .verification.TrustStatus "untrusted"}}{{$.root.i18n.Tr "repo.commits.signed_by_untrusted_user"}}: {{else}}{{$.root.i18n.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}: {{end}}{{.verification.Reason}}">
+		<div title="{{if eq .verification.TrustStatus "trusted"}}{{else if eq .verification.TrustStatus "untrusted"}}{{$.root.locale.Tr "repo.commits.signed_by_untrusted_user"}}: {{else}}{{$.root.locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}: {{end}}{{.verification.Reason}}">
 		{{if ne .verification.SigningUser.ID 0}}
 			{{svg "gitea-lock"}}
 			{{avatar .verification.SigningUser 28 "signature"}}
 		{{else}}
-			<span title="{{$.root.i18n.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog"}}</span>
+			<span title="{{$.root.locale.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog"}}</span>
 			{{avatarByEmail .verification.SigningEmail "" 28 "signature"}}
 		{{end}}
 		</div>
 	{{else}}
-		<span title="{{$.root.i18n.Tr .verification.Reason}}">{{svg "gitea-unlock"}}</span>
+		<span title="{{$.root.locale.Tr .verification.Reason}}">{{svg "gitea-unlock"}}</span>
 	{{end}}
 </div>

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -3,14 +3,14 @@
 		<div class="ui two horizontal center link list">
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo)}}
 				<div class="item{{if .PageIsCommits}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}">{{svg "octicon-history"}} <b>{{.CommitsCount}}</b> {{.i18n.TrN .CommitsCount "repo.commit" "repo.commits"}}</a>
+					<a class="ui" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}">{{svg "octicon-history"}} <b>{{.CommitsCount}}</b> {{.locale.TrN .CommitsCount "repo.commit" "repo.commits"}}</a>
 				</div>
 				<div class="item{{if .PageIsBranches}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/branches">{{svg "octicon-git-branch"}} <b>{{.BranchesCount}}</b> {{.i18n.TrN .BranchesCount "repo.branch" "repo.branches"}}</a>
+					<a class="ui" href="{{.RepoLink}}/branches">{{svg "octicon-git-branch"}} <b>{{.BranchesCount}}</b> {{.locale.TrN .BranchesCount "repo.branch" "repo.branches"}}</a>
 				</div>
 				{{if $.Permission.CanRead $.UnitTypeCode}}
 					<div class="item">
-						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{.NumTags}}</b> {{.i18n.TrN .NumTags "repo.tag" "repo.tags"}}</a>
+						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{.NumTags}}</b> {{.locale.TrN .NumTags "repo.tag" "repo.tags"}}</a>
 					</div>
 				{{end}}
 				<div class="item">
@@ -27,7 +27,7 @@
 				<i class="color-icon mr-3" style="background-color: {{ .Color }}"></i>
 				<span class="bold mr-3">
 					{{if eq .Language "other" }}
-						{{ $.i18n.Tr "repo.language_other" }}
+						{{ $.locale.Tr "repo.language_other" }}
 					{{else}}
 						{{ .Language }}
 					{{end}}

--- a/templates/repo/unicode_escape_prompt.tmpl
+++ b/templates/repo/unicode_escape_prompt.tmpl
@@ -3,17 +3,17 @@
 		<div class="ui error message unicode-escape-prompt tl">
 			<span class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</span>
 			<div class="header">
-				{{$.root.i18n.Tr "repo.bidi_bad_header"}}
+				{{$.root.locale.Tr "repo.bidi_bad_header"}}
 			</div>
-			<p>{{$.root.i18n.Tr "repo.bidi_bad_description" | Str2html}}</p>
+			<p>{{$.root.locale.Tr "repo.bidi_bad_description" | Str2html}}</p>
 		</div>
 	{{else if .EscapeStatus.HasBIDI}}
 		<div class="ui warning message unicode-escape-prompt tl">
 			<span class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</span>
 			<div class="header">
-				{{$.root.i18n.Tr "repo.unicode_header"}}
+				{{$.root.locale.Tr "repo.unicode_header"}}
 			</div>
-			<p>{{$.root.i18n.Tr "repo.unicode_description" | Str2html}}</p>
+			<p>{{$.root.locale.Tr "repo.unicode_description" | Str2html}}</p>
 		</div>
 	{{end}}
 {{end}}

--- a/templates/repo/upload.tmpl
+++ b/templates/repo/upload.tmpl
@@ -6,10 +6,10 @@
 	data-accepts="{{.UploadAccepts}}"
 	data-max-file="{{.UploadMaxFiles}}"
 	data-max-size="{{.UploadMaxSize}}"
-	data-default-message="{{.i18n.Tr "dropzone.default_message"}}"
-	data-invalid-input-type="{{.i18n.Tr "dropzone.invalid_input_type"}}"
-	data-file-too-big="{{.i18n.Tr "dropzone.file_too_big"}}"
-	data-remove-file="{{.i18n.Tr "dropzone.remove_file"}}"
+	data-default-message="{{.locale.Tr "dropzone.default_message"}}"
+	data-invalid-input-type="{{.locale.Tr "dropzone.invalid_input_type"}}"
+	data-file-too-big="{{.locale.Tr "dropzone.file_too_big"}}"
+	data-remove-file="{{.locale.Tr "dropzone.remove_file"}}"
 >
 	<div class="files"></div>
 </div>

--- a/templates/repo/user_cards.tmpl
+++ b/templates/repo/user_cards.tmpl
@@ -18,7 +18,7 @@
 					{{else if .Location}}
 						{{svg "octicon-location"}} {{.Location}}
 					{{else}}
-						{{svg "octicon-clock"}} {{$.i18n.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
+						{{svg "octicon-clock"}} {{$.locale.Tr "user.join_on"}} {{.CreatedUnix.FormatShort}}
 					{{end}}
 				</div>
 			</li>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -8,17 +8,17 @@
 				<div class="file-info text grey normal mono">
 					{{if .FileIsSymlink}}
 						<div class="file-info-entry">
-							{{.i18n.Tr "repo.symbolic_link"}}
+							{{.locale.Tr "repo.symbolic_link"}}
 						</div>
 					{{end}}
 					{{if .NumLinesSet}}
 						<div class="file-info-entry">
-							{{.NumLines}} {{.i18n.TrN .NumLines "repo.line" "repo.lines"}}
+							{{.NumLines}} {{.locale.TrN .NumLines "repo.line" "repo.lines"}}
 						</div>
 					{{end}}
 					{{if .FileSize}}
 						<div class="file-info-entry">
-							{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.i18n.Tr "repo.stored_lfs"}}){{end}}
+							{{FileSize .FileSize}}{{if .IsLFSFile}} ({{.locale.Tr "repo.stored_lfs"}}){{end}}
 						</div>
 					{{end}}
 					{{if .LFSLock}}
@@ -33,26 +33,26 @@
 		<div class="file-header-right file-actions df ac">
 			{{if .HasSourceRenderedToggle}}
 				<div class="ui compact icon buttons two-toggle-buttons">
-					<a href="{{$.Link}}?display=source" class="ui mini basic button tooltip {{if .IsDisplayingSource}}active{{end}}" data-content="{{.i18n.Tr "repo.file_view_source"}}" data-position="bottom center">{{svg "octicon-code" 15}}</a>
-					<a href="{{$.Link}}" class="ui mini basic button tooltip {{if .IsDisplayingRendered}}active{{end}}" data-content="{{.i18n.Tr "repo.file_view_rendered"}}" data-position="bottom center">{{svg "octicon-file" 15}}</a>
+					<a href="{{$.Link}}?display=source" class="ui mini basic button tooltip {{if .IsDisplayingSource}}active{{end}}" data-content="{{.locale.Tr "repo.file_view_source"}}" data-position="bottom center">{{svg "octicon-code" 15}}</a>
+					<a href="{{$.Link}}" class="ui mini basic button tooltip {{if .IsDisplayingRendered}}active{{end}}" data-content="{{.locale.Tr "repo.file_view_rendered"}}" data-position="bottom center">{{svg "octicon-file" 15}}</a>
 				</div>
 			{{end}}
 			{{if not .ReadmeInList}}
 				<div class="ui buttons mr-2">
-					<a class="ui mini basic button" href="{{$.RawFileLink}}">{{.i18n.Tr "repo.file_raw"}}</a>
+					<a class="ui mini basic button" href="{{$.RawFileLink}}">{{.locale.Tr "repo.file_raw"}}</a>
 					{{if not .IsViewCommit}}
-						<a class="ui mini basic button" href="{{.RepoLink}}/src/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}">{{.i18n.Tr "repo.file_permalink"}}</a>
+						<a class="ui mini basic button" href="{{.RepoLink}}/src/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}">{{.locale.Tr "repo.file_permalink"}}</a>
 					{{end}}
 					{{if .IsRepresentableAsText}}
-						<a class="ui mini basic button" href="{{.RepoLink}}/blame/{{.BranchNameSubURL}}/{{PathEscapeSegments .TreePath}}">{{.i18n.Tr "repo.blame"}}</a>
+						<a class="ui mini basic button" href="{{.RepoLink}}/blame/{{.BranchNameSubURL}}/{{PathEscapeSegments .TreePath}}">{{.locale.Tr "repo.blame"}}</a>
 					{{end}}
-					<a class="ui mini basic button" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/{{PathEscapeSegments .TreePath}}">{{.i18n.Tr "repo.file_history"}}</a>
+					<a class="ui mini basic button" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}/{{PathEscapeSegments .TreePath}}">{{.locale.Tr "repo.file_history"}}</a>
 					{{if .EscapeStatus.Escaped}}
-						<a class="ui mini basic button unescape-button" style="display: none;">{{.i18n.Tr "repo.unescape_control_characters"}}</a>
-						<a class="ui mini basic button escape-button">{{.i18n.Tr "repo.escape_control_characters"}}</a>
+						<a class="ui mini basic button unescape-button" style="display: none;">{{.locale.Tr "repo.unescape_control_characters"}}</a>
+						<a class="ui mini basic button escape-button">{{.locale.Tr "repo.escape_control_characters"}}</a>
 					{{end}}
 				</div>
-				<a download href="{{$.RawFileLink}}"><span class="btn-octicon tooltip" data-content="{{.i18n.Tr "repo.download_file"}}" data-position="bottom center">{{svg "octicon-download"}}</span></a>
+				<a download href="{{$.RawFileLink}}"><span class="btn-octicon tooltip" data-content="{{.locale.Tr "repo.download_file"}}" data-position="bottom center">{{svg "octicon-download"}}</span></a>
 				{{if .Repository.CanEnableEditor}}
 					{{if .CanEditFile}}
 						<a href="{{.RepoLink}}/_edit/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .TreePath}}"><span class="btn-octicon tooltip" data-content="{{.EditFileTooltip}}" data-position="bottom center">{{svg "octicon-pencil"}}</span></a>
@@ -66,8 +66,8 @@
 					{{end}}
 				{{end}}
 			{{else if .EscapeStatus.Escaped}}
-				<a class="ui mini basic button unescape-button mr-2" style="display: none;">{{.i18n.Tr "repo.unescape_control_characters"}}</a>
-				<a class="ui mini basic button escape-button mr-2">{{.i18n.Tr "repo.escape_control_characters"}}</a>
+				<a class="ui mini basic button unescape-button mr-2" style="display: none;">{{.locale.Tr "repo.unescape_control_characters"}}</a>
+				<a class="ui mini basic button escape-button mr-2">{{.locale.Tr "repo.escape_control_characters"}}</a>
 			{{end}}
 		</div>
 	</h4>
@@ -84,16 +84,16 @@
 						<img src="{{$.RawFileLink}}">
 					{{else if .IsVideoFile}}
 						<video controls src="{{$.RawFileLink}}">
-							<strong>{{.i18n.Tr "repo.video_not_supported_in_browser"}}</strong>
+							<strong>{{.locale.Tr "repo.video_not_supported_in_browser"}}</strong>
 						</video>
 					{{else if .IsAudioFile}}
 						<audio controls src="{{$.RawFileLink}}">
-							<strong>{{.i18n.Tr "repo.audio_not_supported_in_browser"}}</strong>
+							<strong>{{.locale.Tr "repo.audio_not_supported_in_browser"}}</strong>
 						</audio>
 					{{else if .IsPDFFile}}
 						<iframe width="100%" height="600px" src="{{AssetUrlPrefix}}/vendor/plugins/pdfjs/web/viewer.html?file={{$.RawFileLink}}"></iframe>
 					{{else}}
-						<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{.i18n.Tr "repo.file_view_raw"}}</a>
+						<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{.locale.Tr "repo.file_view_raw"}}</a>
 					{{end}}
 				</div>
 			{{else if .FileSize}}
@@ -101,7 +101,7 @@
 				<table>
 					<tbody>
 						<tr>
-							<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td>
+							<td><strong>{{.locale.Tr "repo.file_too_large"}}</strong></td>
 						</tr>
 					</tbody>
 				</table>
@@ -113,7 +113,7 @@
 						<tr>
 							<td id="L{{$line}}" class="lines-num"><span id="L{{$line}}" data-line-number="{{$line}}"></span></td>
 							{{if $.EscapeStatus.Escaped}}
-								<td class="lines-escape">{{if (index $.LineEscapeStatus $idx).Escaped}}<a href="" class="toggle-escape-button" title="{{$.i18n.Tr "repo.line_unicode"}}"></a>{{end}}</td>
+								<td class="lines-escape">{{if (index $.LineEscapeStatus $idx).Escaped}}<a href="" class="toggle-escape-button" title="{{$.locale.Tr "repo.line_unicode"}}"></a>{{end}}</td>
 							{{end}}
 							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$code | Safe}}</code></td>
 						</tr>
@@ -125,14 +125,14 @@
 						<div class="column">
 							{{if $.Permission.CanRead $.UnitTypeIssues}}
 								<div class="ui link list">
-									<a class="item ref-in-new-issue" href="{{.RepoLink}}/issues/new?body={{.Repository.HTMLURL}}{{printf "/src/commit/" }}{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}" rel="nofollow noindex">{{.i18n.Tr "repo.issues.context.reference_issue"}}</a>
+									<a class="item ref-in-new-issue" href="{{.RepoLink}}/issues/new?body={{.Repository.HTMLURL}}{{printf "/src/commit/" }}{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}" rel="nofollow noindex">{{.locale.Tr "repo.issues.context.reference_issue"}}</a>
 								</div>
 							{{end}}
 							<div class="ui link list">
-								<a class="item view_git_blame" href="{{.Repository.HTMLURL}}/blame/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}">{{.i18n.Tr "repo.view_git_blame"}}</a>
+								<a class="item view_git_blame" href="{{.Repository.HTMLURL}}/blame/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}">{{.locale.Tr "repo.view_git_blame"}}</a>
 							</div>
 							<div class="ui link list">
-								<a data-clipboard-text="{{.Repository.HTMLURL}}/src/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}" class="item copy-line-permalink">{{.i18n.Tr "repo.file_copy_permalink"}}</a>
+								<a data-clipboard-text="{{.Repository.HTMLURL}}/src/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}" class="item copy-line-permalink">{{.locale.Tr "repo.file_copy_permalink"}}</a>
 							</div>
 						</div>
 					</div>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -34,7 +34,7 @@
 					</span>
 				{{end}}
 			</th>
-			<th class="text grey right age">{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.i18n}}{{end}}{{end}}</th>
+			<th class="text grey right age">{{if .LatestCommit}}{{if .LatestCommit.Committer}}{{TimeSince .LatestCommit.Committer.When $.locale}}{{end}}{{end}}</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -87,7 +87,7 @@
 						{{end}}
 					</span>
 				</td>
-				<td class="text right age three wide">{{if $commit}}{{TimeSince $commit.Committer.When $.i18n}}{{end}}</td>
+				<td class="text right age three wide">{{if $commit}}{{TimeSince $commit.Committer.When $.locale}}{{end}}</td>
 			</tr>
 		{{end}}
 	</tbody>

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -4,10 +4,10 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<div class="ui header">
-			{{.i18n.Tr "repo.wiki.new_page"}}
+			{{.locale.Tr "repo.wiki.new_page"}}
 			{{if .PageIsWikiEdit}}
 				<div class="ui right">
-					<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+					<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.locale.Tr "repo.wiki.new_page_button"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -17,23 +17,23 @@
 				<input name="title" value="{{.title}}" autofocus required>
 			</div>
 			<div class="help">
-				{{.i18n.Tr "repo.wiki.page_name_desc"}}
+				{{.locale.Tr "repo.wiki.page_name_desc"}}
 			</div>
 			<div class="ui top attached tabular menu previewtabs" data-write="write" data-preview="preview">
-				<a class="active item" data-tab="write">{{.i18n.Tr "write"}}</a>
-				<a class="item" data-tab="preview" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "preview"}}</a>
+				<a class="active item" data-tab="write">{{.locale.Tr "write"}}</a>
+				<a class="item" data-tab="preview" data-url="{{$.Repository.HTMLURL}}/markdown" data-context="{{$.RepoLink}}">{{$.locale.Tr "preview"}}</a>
 			</div>
-			<div class="field content" data-loading="{{.i18n.Tr "loading"}}">
+			<div class="field content" data-loading="{{.locale.Tr "loading"}}">
 				<div class="ui bottom active tab" data-tab="write">
-					<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}">{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.i18n.Tr "repo.wiki.welcome"}}{{end}}</textarea>
+					<textarea class="js-quick-submit" id="edit_area" name="content" data-id="wiki-{{.title}}" data-url="{{.Repository.HTMLURL}}/markdown" data-context="{{.RepoLink}}">{{if .PageIsWikiEdit}}{{.content}}{{else}}{{.locale.Tr "repo.wiki.welcome"}}{{end}}</textarea>
 				</div>
 			</div>
 			<div class="field">
-				<input name="message" placeholder="{{.i18n.Tr "repo.wiki.default_commit_message"}}">
+				<input name="message" placeholder="{{.locale.Tr "repo.wiki.default_commit_message"}}">
 			</div>
 			<div class="text right">
 				<button class="ui green button">
-					{{.i18n.Tr "repo.wiki.save_page"}}
+					{{.locale.Tr "repo.wiki.save_page"}}
 				</button>
 			</div>
 		</form>

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -4,11 +4,11 @@
 	<div class="ui container">
 		<h2 class="ui header df ac sb">
 			<div>
-				{{.i18n.Tr "repo.wiki.pages"}}
+				{{.locale.Tr "repo.wiki.pages"}}
 			</div>
 			<div>
 				{{if and .CanWriteWiki (not .IsRepositoryMirror)}}
-					<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
+					<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.locale.Tr "repo.wiki.new_page_button"}}</a>
 				{{end}}
 			</div>
 		</h2>
@@ -20,8 +20,8 @@
 							{{svg "octicon-file"}}
 							<a href="{{$.RepoLink}}/wiki/{{.SubURL}}">{{.Name}}</a>
 						</td>
-						{{$timeSince := TimeSinceUnix .UpdatedUnix $.i18n}}
-						<td class="text right grey">{{$.i18n.Tr "repo.wiki.last_updated" $timeSince | Safe}}</td>
+						{{$timeSince := TimeSinceUnix .UpdatedUnix $.locale}}
+						<td class="text right grey">{{$.locale.Tr "repo.wiki.last_updated" $timeSince | Safe}}</td>
 					</tr>
 				{{end}}
 			</tbody>

--- a/templates/repo/wiki/revision.tmpl
+++ b/templates/repo/wiki/revision.tmpl
@@ -10,20 +10,20 @@
 				</div>
 			</div>
 			<div class="ui header eight wide column">
-				<a class="file-revisions-btn ui basic button" title="{{.i18n.Tr "repo.wiki.back_to_wiki"}}" href="{{.RepoLink}}/wiki/{{.PageURL}}" ><span>{{.revision}}</span> {{svg "octicon-home"}}</a>
+				<a class="file-revisions-btn ui basic button" title="{{.locale.Tr "repo.wiki.back_to_wiki"}}" href="{{.RepoLink}}/wiki/{{.PageURL}}" ><span>{{.revision}}</span> {{svg "octicon-home"}}</a>
 				{{$title}}
 				<div class="ui sub header word-break">
-					{{$timeSince := TimeSince .Author.When $.i18n}}
-					{{.i18n.Tr "repo.wiki.last_commit_info" .Author.Name $timeSince | Safe}}
+					{{$timeSince := TimeSince .Author.When $.locale}}
+					{{.locale.Tr "repo.wiki.last_commit_info" .Author.Name $timeSince | Safe}}
 				</div>
 			</div>
 		</div>
-		<h2 class="ui top header">{{.i18n.Tr "repo.wiki.wiki_page_revisions"}}</h2>
+		<h2 class="ui top header">{{.locale.Tr "repo.wiki.wiki_page_revisions"}}</h2>
 		<div class="ui" style="margin-top: 1rem;">
 			<h4 class="ui top attached header">
 				<div class="ui stackable grid">
 					<div class="sixteen wide column">
-						{{.CommitCount}} {{.i18n.Tr "repo.commits.commits"}}
+						{{.CommitCount}} {{.locale.Tr "repo.commits.commits"}}
 					</div>
 				</div>
 			</h4>

--- a/templates/repo/wiki/start.tmpl
+++ b/templates/repo/wiki/start.tmpl
@@ -4,10 +4,10 @@
 	<div class="ui container">
 		<div class="ui center segment">
 			{{svg "octicon-book" 32}}
-			<h2>{{.i18n.Tr "repo.wiki.welcome"}}</h2>
-			<p>{{.i18n.Tr "repo.wiki.welcome_desc"}}</p>
+			<h2>{{.locale.Tr "repo.wiki.welcome"}}</h2>
+			<p>{{.locale.Tr "repo.wiki.welcome_desc"}}</p>
 			{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-				<a class="ui green button" href="{{.RepoLink}}/wiki?action=_new">{{.i18n.Tr "repo.wiki.create_first_page"}}</a>
+				<a class="ui green button" href="{{.RepoLink}}/wiki?action=_new">{{.locale.Tr "repo.wiki.create_first_page"}}</a>
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -6,10 +6,10 @@
 		<div class="ui stackable secondary menu mobile--margin-between-items mobile--no-negative-margins no-vertical-tabs">
 			<div class="fitted item">
 				<div class="choose page">
-					<div class="ui floating filter dropdown" data-no-results="{{.i18n.Tr "repo.pulls.no_results"}}">
+					<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
 						<div class="ui basic small button">
 							<span class="text">
-								{{.i18n.Tr "repo.wiki.page"}}:
+								{{.locale.Tr "repo.wiki.page"}}:
 								<strong>{{$title}}</strong>
 							</span>
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -17,7 +17,7 @@
 						<div class="menu">
 							<div class="ui icon search input">
 								<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
-								<input name="search" placeholder="{{.i18n.Tr "repo.wiki.filter_page"}}...">
+								<input name="search" placeholder="{{.locale.Tr "repo.wiki.filter_page"}}...">
 							</div>
 							<div class="scrolling menu">
 								{{range .Pages}}
@@ -37,23 +37,23 @@
 		<div class="ui dividing header">
 			<div class="ui stackable grid">
 				<div class="eight wide column">
-					<a class="file-revisions-btn ui basic button" title="{{.i18n.Tr "repo.wiki.file_revision"}}" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_revision" ><span>{{.CommitCount}}</span> {{svg "octicon-history"}}</a>
+					<a class="file-revisions-btn ui basic button" title="{{.locale.Tr "repo.wiki.file_revision"}}" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_revision" ><span>{{.CommitCount}}</span> {{svg "octicon-history"}}</a>
 					{{$title}}
 					<div class="ui sub header">
-						{{$timeSince := TimeSince .Author.When $.i18n}}
-						{{.i18n.Tr "repo.wiki.last_commit_info" .Author.Name $timeSince | Safe}}
+						{{$timeSince := TimeSince .Author.When $.locale}}
+						{{.locale.Tr "repo.wiki.last_commit_info" .Author.Name $timeSince | Safe}}
 					</div>
 				</div>
 				<div class="eight wide right aligned column">
 					{{if .EscapeStatus.Escaped}}
-						<a class="ui small button unescape-button" style="display: none;">{{.i18n.Tr "repo.unescape_control_characters"}}</a>
-						<a class="ui small button escape-button">{{.i18n.Tr "repo.escape_control_characters"}}</a>
+						<a class="ui small button unescape-button" style="display: none;">{{.locale.Tr "repo.unescape_control_characters"}}</a>
+						<a class="ui small button escape-button">{{.locale.Tr "repo.escape_control_characters"}}</a>
 					{{end}}
 					{{if and .CanWriteWiki (not .Repository.IsMirror)}}
 						<div class="ui right">
-							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
-							<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
-							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}?action=_delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
+							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_edit">{{.locale.Tr "repo.wiki.edit_page_button"}}</a>
+							<a class="ui green small button" href="{{.RepoLink}}/wiki?action=_new">{{.locale.Tr "repo.wiki.new_page_button"}}</a>
+							<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}?action=_delete" data-id="{{.PageURL}}">{{.locale.Tr "repo.wiki.delete_page_button"}}</a>
 						</div>
 					{{end}}
 				</div>
@@ -75,7 +75,7 @@
 					<div class="ui segment wiki-content-toc">
 						<details open>
 							<summary>
-								<div class="ui header">{{.i18n.Tr "toc"}}</div>
+								<div class="ui header">{{.locale.Tr "toc"}}</div>
 							</summary>
 							{{$level := 0}}
 							{{range .toc}}
@@ -91,7 +91,7 @@
 				{{if .sidebarPresent}}
 					<div class="ui segment wiki-content-sidebar">
 						{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-							<a class="ui right floated muted" href="{{.RepoLink}}/wiki/_Sidebar?action=_edit" aria-label="{{.i18n.Tr "repo.wiki.edit_page_button"}}">{{svg "octicon-pencil"}}</a>
+							<a class="ui right floated muted" href="{{.RepoLink}}/wiki/_Sidebar?action=_edit" aria-label="{{.locale.Tr "repo.wiki.edit_page_button"}}">{{svg "octicon-pencil"}}</a>
 						{{end}}
 						{{template "repo/unicode_escape_prompt" dict "EscapeStatus" .sidebarEscapeStatus "root" $}}
 						{{.sidebarContent | Safe}}
@@ -103,7 +103,7 @@
 		{{if .footerPresent}}
 		<div class="ui segment wiki-content-footer">
 			{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-				<a class="ui right floated muted" href="{{.RepoLink}}/wiki/_Footer?action=_edit" aria-label="{{.i18n.Tr "repo.wiki.edit_page_button"}}">{{svg "octicon-pencil"}}</a>
+				<a class="ui right floated muted" href="{{.RepoLink}}/wiki/_Footer?action=_edit" aria-label="{{.locale.Tr "repo.wiki.edit_page_button"}}">{{svg "octicon-pencil"}}</a>
 			{{end}}
 			{{template "repo/unicode_escape_prompt" dict "footerEscapeStatus" .sidebarEscapeStatus "root" $}}
 			{{.footerContent | Safe}}
@@ -115,10 +115,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "repo.wiki.delete_page_button"}}
+		{{.locale.Tr "repo.wiki.delete_page_button"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.wiki.delete_page_notice_1" ($title|Escape) | Safe}}</p>
+		<p>{{.locale.Tr "repo.wiki.delete_page_notice_1" ($title|Escape) | Safe}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -51,13 +51,13 @@
 							#{{.Index}}
 						{{end}}
 					</a>
-					{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.i18n }}
+					{{ $timeStr := TimeSinceUnix .GetLastEventTimestamp $.locale }}
 					{{if .OriginalAuthor }}
-						{{$.i18n.Tr .GetLastEventLabelFake $timeStr (.OriginalAuthor|Escape) | Safe}}
+						{{$.locale.Tr .GetLastEventLabelFake $timeStr (.OriginalAuthor|Escape) | Safe}}
 					{{else if gt .Poster.ID 0}}
-						{{$.i18n.Tr .GetLastEventLabel $timeStr (.Poster.HomeLink|Escape) (.Poster.GetDisplayName | Escape) | Safe}}
+						{{$.locale.Tr .GetLastEventLabel $timeStr (.Poster.HomeLink|Escape) (.Poster.GetDisplayName | Escape) | Safe}}
 					{{else}}
-						{{$.i18n.Tr .GetLastEventLabelFake $timeStr (.Poster.GetDisplayName | Escape) | Safe}}
+						{{$.locale.Tr .GetLastEventLabelFake $timeStr (.Poster.GetDisplayName | Escape) | Safe}}
 					{{end}}
 					{{if .IsPull}}
 						<div class="branches">
@@ -99,7 +99,7 @@
 						</span>
 					{{end}}
 					{{if ne .DeadlineUnix 0}}
-						<span class="due-date tooltip" data-content="{{$.i18n.Tr "repo.issues.due_date"}}" data-position="right center">
+						<span class="due-date tooltip" data-content="{{$.locale.Tr "repo.issues.due_date"}}" data-position="right center">
 							<span{{if .IsOverdue}} class="overdue"{{end}}>
 								{{svg "octicon-calendar" 14 "mr-2"}}
 								{{.DeadlineUnix.FormatShort}}
@@ -113,25 +113,25 @@
 						{{if gt $approveOfficial 0}}
 							<span class="approvals df ac">
 								{{svg "octicon-check" 14 "mr-1"}}
-								{{$.i18n.TrN $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n" $approveOfficial}}
+								{{$.locale.TrN $approveOfficial "repo.pulls.approve_count_1" "repo.pulls.approve_count_n" $approveOfficial}}
 							</span>
 						{{end}}
 						{{if gt $rejectOfficial 0}}
 							<span class="rejects df ac">
 								{{svg "octicon-diff" 14 "mr-2"}}
-								{{$.i18n.TrN $rejectOfficial "repo.pulls.reject_count_1" "repo.pulls.reject_count_n" $rejectOfficial}}
+								{{$.locale.TrN $rejectOfficial "repo.pulls.reject_count_1" "repo.pulls.reject_count_n" $rejectOfficial}}
 							</span>
 						{{end}}
 						{{if gt $waitingOfficial 0}}
 							<span class="waiting df ac">
 								{{svg "octicon-eye" 14 "mr-2"}}
-								{{$.i18n.TrN $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n" $waitingOfficial}}
+								{{$.locale.TrN $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n" $waitingOfficial}}
 							</span>
 						{{end}}
 						{{if and (not .PullRequest.HasMerged) (gt (len .PullRequest.ConflictedFiles) 0)}}
 							<span class="conflicting df ac">
 								{{svg "octicon-x" 14}}
-								{{$.i18n.TrN (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n" (len .PullRequest.ConflictedFiles)}}
+								{{$.locale.TrN (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n" (len .PullRequest.ConflictedFiles)}}
 							</span>
 						{{end}}
 					{{end}}
@@ -163,7 +163,7 @@
 	{{end}}
 	{{if .IssueIndexerUnavailable}}
 		<div class="ui error message">
-			<p>{{$.i18n.Tr "repo.issues.keyword_search_unavailable"}}</p>
+			<p>{{$.locale.Tr "repo.issues.keyword_search_unavailable"}}</p>
 		</div>
 	{{end}}
 </div>

--- a/templates/shared/searchbottom.tmpl
+++ b/templates/shared/searchbottom.tmpl
@@ -6,7 +6,7 @@
 		</div>
 		<div class="mr-4">
 			{{if not .result.UpdatedUnix.IsZero}}
-					<span class="ui grey text">{{.root.i18n.Tr "explore.code_last_indexed_at" (TimeSinceUnix .result.UpdatedUnix .root.i18n) | Safe}}</span>
+					<span class="ui grey text">{{.root.locale.Tr "explore.code_last_indexed_at" (TimeSinceUnix .result.UpdatedUnix .root.locale) | Safe}}</span>
 			{{end}}
 		</div>
 </div>

--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -5,8 +5,8 @@
 		<p style="margin-top: 100px"><img class="ui centered image" src="{{AssetUrlPrefix}}/img/404.png" alt="404"/></p>
 		<div class="ui divider"></div>
 		<br>
-		<p>{{.i18n.Tr "error404" | Safe}}
-		{{if .ShowFooterVersion}}<p>{{.i18n.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
+		<p>{{.locale.Tr "error404" | Safe}}
+		{{if .ShowFooterVersion}}<p>{{.locale.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
 	</div>
 </div>
 {{template "base/footer" .}}

--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -4,10 +4,10 @@
 	<div class="ui divider"></div>
 	<br>
 	{{if .ErrorMsg}}
-		<p>{{.i18n.Tr "error.occurred"}}:</p>
+		<p>{{.locale.Tr "error.occurred"}}:</p>
 		<pre style="text-align: left">{{.ErrorMsg}}</pre>
 	{{end}}
-	{{if .ShowFooterVersion}}<p>{{.i18n.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
-	{{if .IsAdmin}}<p>{{.i18n.Tr "error.report_message"  | Safe}}</p>{{end}}
+	{{if .ShowFooterVersion}}<p>{{.locale.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
+	{{if .IsAdmin}}<p>{{.locale.Tr "error.report_message"  | Safe}}</p>{{end}}
 </div>
 {{template "base/footer" .}}

--- a/templates/swagger/ui.tmpl
+++ b/templates/swagger/ui.tmpl
@@ -6,7 +6,7 @@
 		<link href="{{AssetUrlPrefix}}/css/swagger.css?v={{MD5 AppVer}}" rel="stylesheet">
 	</head>
 	<body>
-		<a class="swagger-back-link" href="{{AppUrl}}">{{svg "octicon-reply"}}{{.i18n.Tr "return_to_gitea"}}</a>
+		<a class="swagger-back-link" href="{{AppUrl}}">{{svg "octicon-reply"}}{{.locale.Tr "return_to_gitea"}}</a>
 		<div id="swagger-ui" data-source="{{AppUrl}}swagger.{{.APIJSONVersion}}.json"></div>
 		<script src="{{AssetUrlPrefix}}/js/swagger.js?v={{MD5 AppVer}}"></script>
 	</body>

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -5,40 +5,40 @@
 			<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/activate" method="post">
 				{{.CsrfTokenHtml}}
 				<h2 class="ui top attached header">
-					{{.i18n.Tr "auth.active_your_account"}}
+					{{.locale.Tr "auth.active_your_account"}}
 				</h2>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					{{if .IsActivatePage}}
 						{{if .ServiceNotEnabled}}
-							<p class="center">{{.i18n.Tr "auth.disable_register_mail"}}</p>
+							<p class="center">{{.locale.Tr "auth.disable_register_mail"}}</p>
 						{{else if .ResendLimited}}
-							<p class="center">{{.i18n.Tr "auth.resent_limit_prompt"}}</p>
+							<p class="center">{{.locale.Tr "auth.resent_limit_prompt"}}</p>
 						{{else}}
-							<p>{{.i18n.Tr "auth.confirmation_mail_sent_prompt" (.SignedUser.Email|Escape) .ActiveCodeLives | Str2html}}</p>
+							<p>{{.locale.Tr "auth.confirmation_mail_sent_prompt" (.SignedUser.Email|Escape) .ActiveCodeLives | Str2html}}</p>
 						{{end}}
 					{{else}}
 						{{if .NeedsPassword}}
 							<div class="required inline field">
-								<label for="password">{{.i18n.Tr "password"}}</label>
+								<label for="password">{{.locale.Tr "password"}}</label>
 								<input id="password" name="password" type="password" autocomplete="off" required>
 							</div>
 							<div class="inline field">
 								<label></label>
-								<button class="ui green button">{{.i18n.Tr "install.confirm_password"}}</button>
+								<button class="ui green button">{{.locale.Tr "install.confirm_password"}}</button>
 							</div>
 							<input id="code" name="code" type="hidden" value="{{.Code}}">
 						{{else if .IsSendRegisterMail}}
-							<p>{{.i18n.Tr "auth.confirmation_mail_sent_prompt" (.Email|Escape) .ActiveCodeLives | Str2html}}</p>
+							<p>{{.locale.Tr "auth.confirmation_mail_sent_prompt" (.Email|Escape) .ActiveCodeLives | Str2html}}</p>
 						{{else if .IsActivateFailed}}
-							<p>{{.i18n.Tr "auth.invalid_code"}}</p>
+							<p>{{.locale.Tr "auth.invalid_code"}}</p>
 						{{else if .ManualActivationOnly}}
-							<p class="center">{{.i18n.Tr "auth.manual_activation_only"}}</p>
+							<p class="center">{{.locale.Tr "auth.manual_activation_only"}}</p>
 						{{else}}
-							<p>{{.i18n.Tr "auth.has_unconfirmed_mail" (.SignedUser.Name|Escape) (.SignedUser.Email|Escape) | Str2html}}</p>
+							<p>{{.locale.Tr "auth.has_unconfirmed_mail" (.SignedUser.Name|Escape) (.SignedUser.Email|Escape) | Str2html}}</p>
 							<div class="ui divider"></div>
 							<div class="text right">
-								<button class="ui primary button">{{.i18n.Tr "auth.resend_mail"}}</button>
+								<button class="ui primary button">{{.locale.Tr "auth.resend_mail"}}</button>
 							</div>
 						{{end}}
 					{{end}}

--- a/templates/user/auth/change_passwd_inner.tmpl
+++ b/templates/user/auth/change_passwd_inner.tmpl
@@ -2,25 +2,25 @@
 		{{template "base/alert" .}}
 		{{end}}
 		<h4 class="ui top attached header center">
-			{{.i18n.Tr "settings.change_password"}}
+			{{.locale.Tr "settings.change_password"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.ChangePasscodeLink}}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
-				<label for="password">{{.i18n.Tr "password"}}</label>
+				<label for="password">{{.locale.Tr "password"}}</label>
 				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="new-password" required>
 			</div>
 
 
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
-				<label for="retype">{{.i18n.Tr "re_type"}}</label>
+				<label for="retype">{{.locale.Tr "re_type"}}</label>
 				<input id="retype" name="retype" type="password" autocomplete="new-password" required>
 			</div>
 
 			<div class="inline field">
 				<label></label>
-				<button class="ui green button">{{.i18n.Tr "settings.change_password" }}</button>
+				<button class="ui green button">{{.locale.Tr "settings.change_password" }}</button>
 			</div>
 			</form>
 		</div>

--- a/templates/user/auth/finalize_openid.tmpl
+++ b/templates/user/auth/finalize_openid.tmpl
@@ -6,36 +6,36 @@
 			<div class="twelve wide column content">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "auth.login_userpass"}}
+					{{.locale.Tr "auth.login_userpass"}}
 				</h4>
 				<div class="ui attached segment">
 					<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
-						<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
+						<label for="user_name">{{.locale.Tr "home.uname_holder"}}</label>
 						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Password}}error{{end}}">
-						<label for="password">{{.i18n.Tr "password"}}</label>
+						<label for="password">{{.locale.Tr "password"}}</label>
 						<input id="password" name="password" type="password" value="{{.password}}" autocomplete="off" required>
 					</div>
 					<div class="inline field">
 						<label></label>
 						<div class="ui checkbox">
-							<label>{{.i18n.Tr "auth.remember_me"}}</label>
+							<label>{{.locale.Tr "auth.remember_me"}}</label>
 							<input name="remember" type="checkbox">
 						</div>
 					</div>
 
 					<div class="inline field">
 						<label></label>
-						<button class="ui green button">{{.i18n.Tr "sign_in"}}</button>
-						<a href="{{AppSubUrl}}/user/forget_password">{{.i18n.Tr "auth.forget_password"}}</a>
+						<button class="ui green button">{{.locale.Tr "sign_in"}}</button>
+						<a href="{{AppSubUrl}}/user/forget_password">{{.locale.Tr "auth.forget_password"}}</a>
 					</div>
 					{{if .ShowRegistrationButton}}
 						<div class="inline field">
 							<label></label>
-							<a href="{{AppSubUrl}}/user/sign_up">{{.i18n.Tr "auth.sign_up_now" | Str2html}}</a>
+							<a href="{{AppSubUrl}}/user/sign_up">{{.locale.Tr "auth.sign_up_now" | Str2html}}</a>
 						</div>
 					{{end}}
 					</form>

--- a/templates/user/auth/forgot_passwd.tmpl
+++ b/templates/user/auth/forgot_passwd.tmpl
@@ -5,32 +5,32 @@
 			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h2 class="ui top attached header">
-					{{.i18n.Tr "auth.forgot_password_title"}}
+					{{.locale.Tr "auth.forgot_password_title"}}
 				</h2>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					{{if .IsResetSent}}
-						<p>{{.i18n.Tr "auth.reset_password_mail_sent_prompt" (Escape .Email) .ResetPwdCodeLives | Str2html}}</p>
+						<p>{{.locale.Tr "auth.reset_password_mail_sent_prompt" (Escape .Email) .ResetPwdCodeLives | Str2html}}</p>
 					{{else if .IsResetRequest}}
 						<div class="required inline field {{if .Err_Email}}error{{end}}">
-							<label for="email">{{.i18n.Tr "email"}}</label>
+							<label for="email">{{.locale.Tr "email"}}</label>
 							<input id="email" name="email" type="email"  value="{{.Email}}" autofocus required>
 						</div>
 						<div class="ui divider"></div>
 						<div class="inline field">
 							<label></label>
-							<button class="ui primary button">{{.i18n.Tr "auth.send_reset_mail"}}</button>
+							<button class="ui primary button">{{.locale.Tr "auth.send_reset_mail"}}</button>
 						</div>
 					{{else if .IsResetDisable}}
 						<p class="center">
 							{{if $.IsAdmin}}
-								{{.i18n.Tr "auth.disable_forgot_password_mail_admin"}}
+								{{.locale.Tr "auth.disable_forgot_password_mail_admin"}}
 							{{else}}
-								{{.i18n.Tr "auth.disable_forgot_password_mail"}}
+								{{.locale.Tr "auth.disable_forgot_password_mail"}}
 							{{end}}
 						</p>
 					{{else if .ResendLimited}}
-						<p class="center">{{.i18n.Tr "auth.resent_limit_prompt"}}</p>
+						<p class="center">{{.locale.Tr "auth.resent_limit_prompt"}}</p>
 					{{end}}
 				</div>
 			</form>

--- a/templates/user/auth/grant.tmpl
+++ b/templates/user/auth/grant.tmpl
@@ -3,17 +3,17 @@
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">
 			<h3 class="ui top attached header">
-				{{.i18n.Tr "auth.authorize_title" .Application.Name}}
+				{{.locale.Tr "auth.authorize_title" .Application.Name}}
 			</h3>
 			<div class="ui attached segment">
 				{{template "base/alert" .}}
 				<p>
-					<b>{{.i18n.Tr "auth.authorize_application_description"}}</b><br/>
-					{{.i18n.Tr "auth.authorize_application_created_by" .ApplicationUserLinkHTML | Str2html}}
+					<b>{{.locale.Tr "auth.authorize_application_description"}}</b><br/>
+					{{.locale.Tr "auth.authorize_application_created_by" .ApplicationUserLinkHTML | Str2html}}
 				</p>
 			</div>
 			<div class="ui attached segment">
-				<p>{{.i18n.Tr "auth.authorize_redirect_notice" .ApplicationRedirectDomainHTML | Str2html}}</p>
+				<p>{{.locale.Tr "auth.authorize_redirect_notice" .ApplicationRedirectDomainHTML | Str2html}}</p>
 			</div>
 			<div class="ui attached segment">
 				<form method="post" action="{{AppSubUrl}}/login/oauth/grant">
@@ -23,7 +23,7 @@
 					<input type="hidden" name="scope" value="{{.Scope}}">
 					<input type="hidden" name="nonce" value="{{.Nonce}}">
 					<input type="hidden" name="redirect_uri" value="{{.RedirectURI}}">
-					<input type="submit" id="authorize-app" value="{{.i18n.Tr "auth.authorize_application"}}" class="ui red inline button"/>
+					<input type="submit" id="authorize-app" value="{{.locale.Tr "auth.authorize_application"}}" class="ui red inline button"/>
 					<a href="{{.RedirectURI}}" class="ui basic primary inline button">Cancel</a>
 				</form>
 			</div>

--- a/templates/user/auth/grant_error.tmpl
+++ b/templates/user/auth/grant_error.tmpl
@@ -4,11 +4,11 @@
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">
 			<h1 class="ui top attached header">
-				{{.i18n.Tr "auth.authorization_failed" }}
+				{{.locale.Tr "auth.authorization_failed" }}
 			</h1>
 			<h3 class="ui attached segment">{{.Error.ErrorDescription}}</h3>
 			<div class="ui attached segment">
-				<p>{{.i18n.Tr "auth.authorization_failed_desc"}}</p>
+				<p>{{.locale.Tr "auth.authorization_failed_desc"}}</p>
 			</div>
 		</div>
 	</div>

--- a/templates/user/auth/link_account.tmpl
+++ b/templates/user/auth/link_account.tmpl
@@ -6,12 +6,12 @@
 			{{if not .AllowOnlyInternalRegistration}}
 				<a class="item {{if not .user_exists}}active{{end}}"
 					data-tab="auth-link-signup-tab">
-					{{.i18n.Tr "auth.oauth_signup_tab"}}
+					{{.locale.Tr "auth.oauth_signup_tab"}}
 				</a>
 			{{end}}
 			<a class="item {{if .user_exists}}active{{end}}"
 				data-tab="auth-link-signin-tab">
-				{{.i18n.Tr "auth.oauth_signin_tab"}}
+				{{.locale.Tr "auth.oauth_signin_tab"}}
 			</a>
 		</div>
 	</div>

--- a/templates/user/auth/prohibit_login.tmpl
+++ b/templates/user/auth/prohibit_login.tmpl
@@ -4,10 +4,10 @@
 		<div class="column">
 			<form class="ui form">
 				<h2 class="ui top attached header">
-					{{.i18n.Tr "auth.prohibit_login"}}
+					{{.locale.Tr "auth.prohibit_login"}}
 				</h2>
 				<div class="ui attached segment">
-					<p>{{.i18n.Tr "auth.prohibit_login_desc"}}</p>
+					<p>{{.locale.Tr "auth.prohibit_login_desc"}}</p>
 				</div>
 			</form>
 		</div>

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -6,44 +6,44 @@
 				{{.CsrfTokenHtml}}
 				<input name="code" type="hidden" value="{{.Code}}">
 				<h2 class="ui top attached header">
-					{{.i18n.Tr "auth.reset_password"}}
+					{{.locale.Tr "auth.reset_password"}}
 				</h2>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					{{if .user_email }}
 						<div class="inline field">
-							<label for="user_name">{{.i18n.Tr "email"}}</label>
+							<label for="user_name">{{.locale.Tr "email"}}</label>
 							<input id="user_name" type="text" value="{{ .user_email }}" disabled>
 						</div>
 					{{end}}
 					{{if .IsResetForm}}
 						<div class="required inline field {{if .Err_Password}}error{{end}}">
-							<label for="password">{{.i18n.Tr "settings.new_password"}}</label>
+							<label for="password">{{.locale.Tr "settings.new_password"}}</label>
 							<input id="password" name="password" type="password"  value="{{.password}}" autocomplete="new-password" autofocus required>
 						</div>
 						{{if not .user_signed_in}}
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
-								<label>{{.i18n.Tr "auth.remember_me"}}</label>
+								<label>{{.locale.Tr "auth.remember_me"}}</label>
 								<input name="remember" type="checkbox">
 							</div>
 						</div>
 						{{end}}
 						{{if .has_two_factor}}
 						<h4 class="ui dividing header">
-							{{.i18n.Tr "twofa"}}
+							{{.locale.Tr "twofa"}}
 						</h4>
-						<div class="ui warning visible message">{{.i18n.Tr "settings.twofa_is_enrolled" | Str2html }}</div>
+						<div class="ui warning visible message">{{.locale.Tr "settings.twofa_is_enrolled" | Str2html }}</div>
 						{{if .scratch_code}}
 						<div class="required inline field {{if .Err_Token}}error{{end}}">
-							<label for="token">{{.i18n.Tr "auth.scratch_code"}}</label>
+							<label for="token">{{.locale.Tr "auth.scratch_code"}}</label>
 							<input id="token" name="token" type="text" autocomplete="off" autofocus required>
 						</div>
 						<input type="hidden" name="scratch_code" value="true">
 						{{else}}
 						<div class="required inline field {{if .Err_Passcode}}error{{end}}">
-							<label for="passcode">{{.i18n.Tr "passcode"}}</label>
+							<label for="passcode">{{.locale.Tr "passcode"}}</label>
 							<input id="passcode" name="passcode" type="number" autocomplete="off" autofocus required>
 						</div>
 						{{end}}
@@ -51,13 +51,13 @@
 						<div class="ui divider"></div>
 						<div class="inline field">
 							<label></label>
-							<button class="ui primary button">{{.i18n.Tr "auth.reset_password_helper"}}</button>
+							<button class="ui primary button">{{.locale.Tr "auth.reset_password_helper"}}</button>
 							{{if and .has_two_factor (not .scratch_code)}}
-								<a href="{{.Link}}?code={{.Code}}&amp;scratch_code=true">{{.i18n.Tr "auth.use_scratch_code" | Str2html}}</a>
+								<a href="{{.Link}}?code={{.Code}}&amp;scratch_code=true">{{.locale.Tr "auth.use_scratch_code" | Str2html}}</a>
 							{{end}}
 						</div>
 					{{else}}
-						<p class="center">{{.i18n.Tr "auth.invalid_code"}}</p>
+						<p class="center">{{.locale.Tr "auth.invalid_code"}}</p>
 					{{end}}
 				</div>
 			</form>

--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -3,21 +3,21 @@
 		{{end}}
 		<h4 class="ui top attached header center">
 			{{if .LinkAccountMode}}
-				{{.i18n.Tr "auth.oauth_signin_title"}}
+				{{.locale.Tr "auth.oauth_signin_title"}}
 			{{else}}
-				{{.i18n.Tr "auth.login_userpass"}}
+				{{.locale.Tr "auth.login_userpass"}}
 			{{end}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.SignInLink}}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="required inline field {{if and (.Err_UserName) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
-				<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
+				<label for="user_name">{{.locale.Tr "home.uname_holder"}}</label>
 				<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 			</div>
 			{{if or (not .DisablePassword) .LinkAccountMode}}
 			<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
-				<label for="password">{{.i18n.Tr "password"}}</label>
+				<label for="password">{{.locale.Tr "password"}}</label>
 				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="current-password" required>
 			</div>
 			{{end}}
@@ -25,7 +25,7 @@
 			<div class="inline field">
 				<label></label>
 				<div class="ui checkbox">
-					<label>{{.i18n.Tr "auth.remember_me"}}</label>
+					<label>{{.locale.Tr "auth.remember_me"}}</label>
 					<input name="remember" type="checkbox">
 				</div>
 			</div>
@@ -35,18 +35,18 @@
 				<label></label>
 				<button class="ui green button">
 					{{if .LinkAccountMode}}
-						{{.i18n.Tr "auth.oauth_signin_submit"}}
+						{{.locale.Tr "auth.oauth_signin_submit"}}
 					{{else}}
-						{{.i18n.Tr "sign_in"}}
+						{{.locale.Tr "sign_in"}}
 					{{end}}
 				</button>
-				<a href="{{AppSubUrl}}/user/forgot_password">{{.i18n.Tr "auth.forgot_password"}}</a>
+				<a href="{{AppSubUrl}}/user/forgot_password">{{.locale.Tr "auth.forgot_password"}}</a>
 			</div>
 
 			{{if .ShowRegistrationButton}}
 				<div class="inline field">
 					<label></label>
-					<a href="{{AppSubUrl}}/user/sign_up">{{.i18n.Tr "auth.sign_up_now" | Str2html}}</a>
+					<a href="{{AppSubUrl}}/user/sign_up">{{.locale.Tr "auth.sign_up_now" | Str2html}}</a>
 				</div>
 			{{end}}
 
@@ -56,7 +56,7 @@
 					<div id="oauth2-login-loader" class="ui disabled centered loader"></div>
 					<div>
 						<div id="oauth2-login-navigator">
-							<p>{{.i18n.Tr "sign_in_with"}}</p>
+							<p>{{.locale.Tr "sign_in_with"}}</p>
 							{{range $key := .OrderedOAuth2Names}}
 								{{$provider := index $.OAuth2Providers $key}}
 								<a href="{{AppSubUrl}}/user/oauth2/{{$key}}">

--- a/templates/user/auth/signin_navbar.tmpl
+++ b/templates/user/auth/signin_navbar.tmpl
@@ -2,7 +2,7 @@
 <div class="ui secondary pointing tabular top attached borderless menu new-menu navbar">
 	<div class="new-menu-inner">
 		<a class="{{if .PageIsLogin}}active{{end}} item" rel="nofollow" href="{{AppSubUrl}}/user/login">
-			{{.i18n.Tr "auth.login_userpass"}}
+			{{.locale.Tr "auth.login_userpass"}}
 		</a>
 		{{if .EnableOpenIDSignIn}}
 		<a class="{{if .PageIsLoginOpenID}}active{{end}} item" rel="nofollow" href="{{AppSubUrl}}/user/login/openid">

--- a/templates/user/auth/signin_openid.tmpl
+++ b/templates/user/auth/signin_openid.tmpl
@@ -11,7 +11,7 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="inline field">
-				{{.i18n.Tr "auth.openid_signin_desc"}}
+				{{.locale.Tr "auth.openid_signin_desc"}}
 			</div>
 			<div class="required inline field {{if .Err_OpenID}}error{{end}}">
 				<label for="openid">
@@ -23,13 +23,13 @@
 			<div class="inline field">
 				<label></label>
 				<div class="ui checkbox">
-					<label>{{.i18n.Tr "auth.remember_me"}}</label>
+					<label>{{.locale.Tr "auth.remember_me"}}</label>
 					<input name="remember" type="checkbox">
 				</div>
 			</div>
 			<div class="inline field">
 				<label></label>
-				<button class="ui green button">{{.i18n.Tr "sign_in"}}</button>
+				<button class="ui green button">{{.locale.Tr "sign_in"}}</button>
 			</div>
 			</form>
 		</div>

--- a/templates/user/auth/signup_inner.tmpl
+++ b/templates/user/auth/signup_inner.tmpl
@@ -1,9 +1,9 @@
 <div class="ui container column fluid{{if .LinkAccountMode}} icon{{end}}">
 	<h4 class="ui top attached header center">
 		{{if .LinkAccountMode}}
-			{{.i18n.Tr "auth.oauth_signup_title"}}
+			{{.locale.Tr "auth.oauth_signup_title"}}
 		{{else}}
-			{{.i18n.Tr "sign_up"}}
+			{{.locale.Tr "sign_up"}}
 		{{end}}
 	</h4>
 	<div class="ui attached segment">
@@ -13,24 +13,24 @@
 			{{template "base/alert" .}}
 			{{end}}
 			{{if .DisableRegistration}}
-				<p>{{.i18n.Tr "auth.disable_register_prompt"}}</p>
+				<p>{{.locale.Tr "auth.disable_register_prompt"}}</p>
 			{{else}}
 				<div class="required inline field {{if and (.Err_UserName) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
-					<label for="user_name">{{.i18n.Tr "username"}}</label>
+					<label for="user_name">{{.locale.Tr "username"}}</label>
 					<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 				</div>
 				<div class="required inline field {{if .Err_Email}}error{{end}}">
-					<label for="email">{{.i18n.Tr "email"}}</label>
+					<label for="email">{{.locale.Tr "email"}}</label>
 					<input id="email" name="email" type="email" value="{{.email}}" required>
 				</div>
 
 				{{if not .DisablePassword}}
 					<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
-						<label for="password">{{.i18n.Tr "password"}}</label>
+						<label for="password">{{.locale.Tr "password"}}</label>
 						<input id="password" name="password" type="password" value="{{.password}}" autocomplete="new-password" required>
 					</div>
 					<div class="required inline field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeRegister))}}error{{end}}">
-						<label for="retype">{{.i18n.Tr "re_type"}}</label>
+						<label for="retype">{{.locale.Tr "re_type"}}</label>
 						<input id="retype" name="retype" type="password" value="{{.retype}}" autocomplete="new-password" required>
 					</div>
 				{{end}}
@@ -40,7 +40,7 @@
 						{{.Captcha.CreateHTML}}
 					</div>
 					<div class="required inline field {{if .Err_Captcha}}error{{end}}">
-						<label for="captcha">{{.i18n.Tr "captcha"}}</label>
+						<label for="captcha">{{.locale.Tr "captcha"}}</label>
 						<input id="captcha" name="captcha" value="{{.captcha}}" autocomplete="off">
 					</div>
 				{{end}}
@@ -59,9 +59,9 @@
 					<label></label>
 					<button class="ui green button">
 						{{if .LinkAccountMode}}
-							{{.i18n.Tr "auth.oauth_signup_submit"}}
+							{{.locale.Tr "auth.oauth_signup_submit"}}
 						{{else}}
-							{{.i18n.Tr "auth.create_new_account"}}
+							{{.locale.Tr "auth.create_new_account"}}
 						{{end}}
 					</button>
 				</div>
@@ -69,7 +69,7 @@
 				{{if not .LinkAccountMode}}
 				<div class="inline field">
 					<label></label>
-					<a href="{{AppSubUrl}}/user/login">{{.i18n.Tr "auth.register_helper_msg"}}</a>
+					<a href="{{AppSubUrl}}/user/login">{{.locale.Tr "auth.register_helper_msg"}}</a>
 				</div>
 				{{end}}
 			{{end}}

--- a/templates/user/auth/signup_openid_connect.tmpl
+++ b/templates/user/auth/signup_openid_connect.tmpl
@@ -4,20 +4,20 @@
 	<div class="ui container">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "auth.openid_connect_title"}}
+					{{.locale.Tr "auth.openid_connect_title"}}
 				</h4>
 				<div class="ui attached segment">
 					<p>
-						{{.i18n.Tr "auth.openid_connect_desc"}}
+						{{.locale.Tr "auth.openid_connect_desc"}}
 					</p>
 					<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
-						<label for="user_name">{{.i18n.Tr "home.uname_holder"}}</label>
+						<label for="user_name">{{.locale.Tr "home.uname_holder"}}</label>
 						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Password}}error{{end}}">
-						<label for="password">{{.i18n.Tr "password"}}</label>
+						<label for="password">{{.locale.Tr "password"}}</label>
 						<input id="password" name="password" type="password" value="{{.password}}" autocomplete="off" required>
 					</div>
 					<div class="inline field">
@@ -26,8 +26,8 @@
 					</div>
 					<div class="inline field">
 						<label></label>
-						<button class="ui green button">{{.i18n.Tr "auth.openid_connect_submit"}}</button>
-						<a href="{{AppSubUrl}}/user/forgot_password">{{.i18n.Tr "auth.forgot_password"}}</a>
+						<button class="ui green button">{{.locale.Tr "auth.openid_connect_submit"}}</button>
+						<a href="{{AppSubUrl}}/user/forgot_password">{{.locale.Tr "auth.forgot_password"}}</a>
 					</div>
 					</form>
 				</div>

--- a/templates/user/auth/signup_openid_navbar.tmpl
+++ b/templates/user/auth/signup_openid_navbar.tmpl
@@ -1,11 +1,11 @@
 <div class="ui secondary pointing tabular top attached borderless menu stackable new-menu navbar">
 	<div class="new-menu-inner">
 		<a class="{{if .PageIsOpenIDConnect}}active{{end}} item" href="{{AppSubUrl}}/user/openid/connect">
-			{{.i18n.Tr "auth.openid_connect_title"}}
+			{{.locale.Tr "auth.openid_connect_title"}}
 		</a>
 		{{if and .EnableOpenIDSignUp (not .AllowOnlyInternalRegistration)}}
 			<a class="{{if .PageIsOpenIDRegister}}active{{end}} item" href="{{AppSubUrl}}/user/openid/register">
-				{{.i18n.Tr "auth.openid_register_title"}}
+				{{.locale.Tr "auth.openid_register_title"}}
 			</a>
 		{{end}}
 	</div>

--- a/templates/user/auth/signup_openid_register.tmpl
+++ b/templates/user/auth/signup_openid_register.tmpl
@@ -4,20 +4,20 @@
 	<div class="ui container">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "auth.openid_register_title"}}
+					{{.locale.Tr "auth.openid_register_title"}}
 				</h4>
 				<div class="ui attached segment">
 					<p>
-						{{.i18n.Tr "auth.openid_register_desc"}}
+						{{.locale.Tr "auth.openid_register_desc"}}
 					</p>
 					<form class="ui form" action="{{.Link}}" method="post">
 					{{.CsrfTokenHtml}}
 					<div class="required inline field {{if .Err_UserName}}error{{end}}">
-						<label for="user_name">{{.i18n.Tr "username"}}</label>
+						<label for="user_name">{{.locale.Tr "username"}}</label>
 						<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
 					</div>
 					<div class="required inline field {{if .Err_Email}}error{{end}}">
-						<label for="email">{{.i18n.Tr "email"}}</label>
+						<label for="email">{{.locale.Tr "email"}}</label>
 						<input id="email" name="email" type="email" value="{{.email}}" required>
 					</div>
 					{{if and .EnableCaptcha (eq .CaptchaType "image")}}
@@ -26,7 +26,7 @@
 							{{.Captcha.CreateHTML}}
 						</div>
 						<div class="required inline field {{if .Err_Captcha}}error{{end}}">
-							<label for="captcha">{{.i18n.Tr "captcha"}}</label>
+							<label for="captcha">{{.locale.Tr "captcha"}}</label>
 							<input id="captcha" name="captcha" value="{{.captcha}}" autocomplete="off">
 						</div>
 					{{end}}
@@ -46,7 +46,7 @@
 					</div>
 					<div class="inline field">
 						<label></label>
-						<button class="ui green button">{{.i18n.Tr "auth.create_new_account"}}</button>
+						<button class="ui green button">{{.locale.Tr "auth.create_new_account"}}</button>
 					</div>
 					</form>
 				</div>

--- a/templates/user/auth/twofa.tmpl
+++ b/templates/user/auth/twofa.tmpl
@@ -5,19 +5,19 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "twofa"}}
+					{{.locale.Tr "twofa"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="required inline field">
-						<label for="passcode">{{.i18n.Tr "passcode"}}</label>
+						<label for="passcode">{{.locale.Tr "passcode"}}</label>
 						<input id="passcode" name="passcode" type="text" autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*" autofocus required>
 					</div>
 
 					<div class="inline field">
 						<label></label>
-						<button class="ui green button">{{.i18n.Tr "auth.verify"}}</button>
-						<a href="{{AppSubUrl}}/user/two_factor/scratch">{{.i18n.Tr "auth.use_scratch_code" | Str2html}}</a>
+						<button class="ui green button">{{.locale.Tr "auth.verify"}}</button>
+						<a href="{{AppSubUrl}}/user/two_factor/scratch">{{.locale.Tr "auth.use_scratch_code" | Str2html}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/user/auth/twofa_scratch.tmpl
+++ b/templates/user/auth/twofa_scratch.tmpl
@@ -5,18 +5,18 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "twofa_scratch"}}
+					{{.locale.Tr "twofa_scratch"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="required inline field">
-						<label for="token">{{.i18n.Tr "auth.scratch_code"}}</label>
+						<label for="token">{{.locale.Tr "auth.scratch_code"}}</label>
 						<input id="token" name="token" type="text" autocomplete="off" autofocus required>
 					</div>
 
 					<div class="inline field">
 						<label></label>
-						<button class="ui green button">{{.i18n.Tr "auth.verify"}}</button>
+						<button class="ui green button">{{.locale.Tr "auth.verify"}}</button>
 					</div>
 				</div>
 			</form>

--- a/templates/user/auth/webauthn.tmpl
+++ b/templates/user/auth/webauthn.tmpl
@@ -3,17 +3,17 @@
 	<div class="ui middle centered very relaxed page grid">
 		<div class="column">
 				<h3 class="ui top attached header">
-				{{.i18n.Tr "twofa"}}
+				{{.locale.Tr "twofa"}}
 				</h3>
 				<div class="ui attached segment">
 					<i class="huge key icon"></i>
-					<h3>{{.i18n.Tr "webauthn_insert_key"}}</h3>
+					<h3>{{.locale.Tr "webauthn_insert_key"}}</h3>
 					{{template "base/alert" .}}
-					<p>{{.i18n.Tr "webauthn_sign_in"}}</p>
+					<p>{{.locale.Tr "webauthn_sign_in"}}</p>
 				</div>
-				<div class="ui attached segment"><div class="ui active indeterminate inline loader"></div> {{.i18n.Tr "webauthn_press_button"}} </div>
+				<div class="ui attached segment"><div class="ui active indeterminate inline loader"></div> {{.locale.Tr "webauthn_press_button"}} </div>
 				<div class="ui attached segment">
-					<a href="{{AppSubUrl}}/user/two_factor">{{.i18n.Tr "webauthn_use_twofa"}}</a>
+					<a href="{{AppSubUrl}}/user/two_factor">{{.locale.Tr "webauthn_use_twofa"}}</a>
 				</div>
 		</div>
 	</div>

--- a/templates/user/auth/webauthn_error.tmpl
+++ b/templates/user/auth/webauthn_error.tmpl
@@ -1,22 +1,22 @@
 <div class="ui small modal" id="webauthn-error">
-	<div class="header">{{.i18n.Tr "webauthn_error"}}</div>
+	<div class="header">{{.locale.Tr "webauthn_error"}}</div>
 	<div class="content">
 		<div class="ui negative message">
 			<div class="header">
-			{{.i18n.Tr "webauthn_error"}}
+			{{.locale.Tr "webauthn_error"}}
 			</div>
-			<div class="hide" data-webauthn-error-msg="browser"><p>{{.i18n.Tr "webauthn_unsupported_browser"}}</div>
-			<div class="hide" data-webauthn-error-msg="unknown"><p>{{.i18n.Tr "webauthn_error_unknown"}}</div>
-			<div class="hide" data-webauthn-error-msg="insecure"><p>{{.i18n.Tr "webauthn_error_insecure"}}</div>
-			<div class="hide" data-webauthn-error-msg="unable-to-process"><p>{{.i18n.Tr "webauthn_error_unable_to_process"}}</div>
-			<div class="hide" data-webauthn-error-msg="duplicated"><p>{{.i18n.Tr "webauthn_error_duplicated"}}</div>
-			<div class="hide" data-webauthn-error-msg="empty"><p>{{.i18n.Tr "webauthn_error_empty"}}</div>
-			<div class="hide" data-webauthn-error-msg="timeout"><p>{{.i18n.Tr "webauthn_error_timeout"}}</div>
+			<div class="hide" data-webauthn-error-msg="browser"><p>{{.locale.Tr "webauthn_unsupported_browser"}}</div>
+			<div class="hide" data-webauthn-error-msg="unknown"><p>{{.locale.Tr "webauthn_error_unknown"}}</div>
+			<div class="hide" data-webauthn-error-msg="insecure"><p>{{.locale.Tr "webauthn_error_insecure"}}</div>
+			<div class="hide" data-webauthn-error-msg="unable-to-process"><p>{{.locale.Tr "webauthn_error_unable_to_process"}}</div>
+			<div class="hide" data-webauthn-error-msg="duplicated"><p>{{.locale.Tr "webauthn_error_duplicated"}}</div>
+			<div class="hide" data-webauthn-error-msg="empty"><p>{{.locale.Tr "webauthn_error_empty"}}</div>
+			<div class="hide" data-webauthn-error-msg="timeout"><p>{{.locale.Tr "webauthn_error_timeout"}}</div>
 			<div class="hide" data-webauthn-error-msg="general"></div>
 		</div>
 	</div>
 	<div class="actions">
-		<button onclick="window.location.reload()" class="success ui button hide webauthn_error_timeout">{{.i18n.Tr "webauthn_reload"}}</button>
-		<div class="ui cancel button">{{.i18n.Tr "cancel"}}</div>
+		<button onclick="window.location.reload()" class="success ui button hide webauthn_error_timeout">{{.locale.Tr "webauthn_reload"}}</button>
+		<div class="ui cancel button">{{.locale.Tr "cancel"}}</div>
 	</div>
 </div>

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -13,71 +13,71 @@
 							{{.ShortActUserName}}
 						{{end}}
 						{{if eq .GetOpType 1}}
-							{{$.i18n.Tr "action.create_repo" (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.create_repo" (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 2}}
-							{{$.i18n.Tr "action.rename_repo" (.GetContent|Escape) (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.rename_repo" (.GetContent|Escape) (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 5}}
 							{{if .Content}}
-								{{$.i18n.Tr "action.commit_repo" (.GetRepoLink|Escape) (.GetRefLink|Escape) (Escape .GetBranch) (.ShortRepoPath|Escape) | Str2html}}
+								{{$.locale.Tr "action.commit_repo" (.GetRepoLink|Escape) (.GetRefLink|Escape) (Escape .GetBranch) (.ShortRepoPath|Escape) | Str2html}}
 							{{else}}
-								{{$.i18n.Tr "action.create_branch" (.GetRepoLink|Escape) (.GetRefLink|Escape) (Escape .GetBranch) (.ShortRepoPath|Escape) | Str2html}}
+								{{$.locale.Tr "action.create_branch" (.GetRepoLink|Escape) (.GetRefLink|Escape) (Escape .GetBranch) (.ShortRepoPath|Escape) | Str2html}}
 							{{end}}
 						{{else if eq .GetOpType 6}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.create_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.create_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 7}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.create_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.create_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 8}}
-							{{$.i18n.Tr "action.transfer_repo" .GetContent (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.transfer_repo" .GetContent (.GetRepoLink|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 9}}
-							{{$.i18n.Tr "action.push_tag" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetTag|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.push_tag" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetTag|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 10}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.comment_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.comment_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 11}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.merge_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.merge_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 12}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.close_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.close_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 13}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.reopen_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.reopen_issue" ((printf "%s/issues/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 14}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.close_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.close_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 15}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.reopen_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.reopen_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 16}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.delete_tag" (.GetRepoLink|Escape) (.GetTag|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.delete_tag" (.GetRepoLink|Escape) (.GetTag|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 17}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.delete_branch" (.GetRepoLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.delete_branch" (.GetRepoLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 18}}
-							{{$.i18n.Tr "action.mirror_sync_push" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.mirror_sync_push" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 19}}
-							{{$.i18n.Tr "action.mirror_sync_create" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.mirror_sync_create" (.GetRepoLink|Escape) (.GetRefLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 20}}
-							{{$.i18n.Tr "action.mirror_sync_delete" (.GetRepoLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.mirror_sync_delete" (.GetRepoLink|Escape) (.GetBranch|Escape) (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 21}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.approve_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.approve_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 22}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.reject_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.reject_pull_request" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 23}}
 							{{ $index := index .GetIssueInfos 0}}
-							{{$.i18n.Tr "action.comment_pull" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
+							{{$.locale.Tr "action.comment_pull" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) | Str2html}}
 						{{else if eq .GetOpType 24}}
 							{{ $linkText := .Content | RenderEmoji }}
-							{{$.i18n.Tr "action.publish_release" (.GetRepoLink|Escape) ((printf "%s/releases/tag/%s" .GetRepoLink .GetTag)|Escape) (.ShortRepoPath|Escape) $linkText | Str2html}}
+							{{$.locale.Tr "action.publish_release" (.GetRepoLink|Escape) ((printf "%s/releases/tag/%s" .GetRepoLink .GetTag)|Escape) (.ShortRepoPath|Escape) $linkText | Str2html}}
 						{{else if eq .GetOpType 25}}
 							{{ $index := index .GetIssueInfos 0}}
 							{{ $reviewer := index .GetIssueInfos 1}}
-							{{$.i18n.Tr "action.review_dismissed" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) $reviewer | Str2html}}
+							{{$.locale.Tr "action.review_dismissed" ((printf "%s/pulls/%s" .GetRepoLink $index) |Escape) $index (.ShortRepoPath|Escape) $reviewer | Str2html}}
 						{{end}}
 					</p>
 					{{if or (eq .GetOpType 5) (eq .GetOpType 18)}}
@@ -95,7 +95,7 @@
 										</span>
 									</li>
 								{{end}}
-								{{if and (gt $push.Len 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.i18n.Tr "action.compare_commits" $push.Len}} »</a></li>{{end}}
+								{{if and (gt $push.Len 1) $push.CompareURL}}<li><a href="{{AppSubUrl}}/{{$push.CompareURL}}">{{$.locale.Tr "action.compare_commits" $push.Len}} »</a></li>{{end}}
 							</ul>
 						</div>
 					{{else if eq .GetOpType 6}}
@@ -111,10 +111,10 @@
 					{{else if or (eq .GetOpType 12) (eq .GetOpType 13) (eq .GetOpType 14) (eq .GetOpType 15)}}
 						<span class="text truncate issue title">{{.GetIssueTitle | RenderEmoji}}</span>
 					{{else if eq .GetOpType 25}}
-					<p class="text light grey">{{$.i18n.Tr "action.review_dismissed_reason"}}</p>
+					<p class="text light grey">{{$.locale.Tr "action.review_dismissed_reason"}}</p>
 						<p class="text light grey">{{index .GetIssueInfos 2 | RenderEmoji}}</p>
 					{{end}}
-					<p class="text italic light grey">{{TimeSince .GetCreate $.i18n}}</p>
+					<p class="text italic light grey">{{TimeSince .GetCreate $.locale}}</p>
 				</div>
 			</div>
 			<div class="ui two wide right aligned column">

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -6,24 +6,24 @@
 			<div class="four wide column">
 				<div class="ui secondary vertical filter menu">
 					<a class="{{if eq .ViewType "your_repositories"}}ui basic primary button{{end}} item" href="{{.Link}}?type=your_repositories&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
-						{{.i18n.Tr "home.issues.in_your_repos"}}
+						{{.locale.Tr "home.issues.in_your_repos"}}
 						<strong class="ui right">{{CountFmt .IssueStats.YourRepositoriesCount}}</strong>
 					</a>
 					<a class="{{if eq .ViewType "assigned"}}ui basic primary button{{end}} item" href="{{.Link}}?type=assigned&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
-						{{.i18n.Tr "repo.issues.filter_type.assigned_to_you"}}
+						{{.locale.Tr "repo.issues.filter_type.assigned_to_you"}}
 						<strong class="ui right">{{CountFmt .IssueStats.AssignCount}}</strong>
 					</a>
 					<a class="{{if eq .ViewType "created_by"}}ui basic primary button{{end}} item" href="{{.Link}}?type=created_by&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
-						{{.i18n.Tr "repo.issues.filter_type.created_by_you"}}
+						{{.locale.Tr "repo.issues.filter_type.created_by_you"}}
 						<strong class="ui right">{{CountFmt .IssueStats.CreateCount}}</strong>
 					</a>
 					<a class="{{if eq .ViewType "mentioned"}}ui basic primary button{{end}} item" href="{{.Link}}?type=mentioned&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
-						{{.i18n.Tr "repo.issues.filter_type.mentioning_you"}}
+						{{.locale.Tr "repo.issues.filter_type.mentioning_you"}}
 						<strong class="ui right">{{CountFmt .IssueStats.MentionCount}}</strong>
 					</a>
 					{{if .PageIsPulls}}
 						<a class="{{if eq .ViewType "review_requested"}}ui basic primary button{{end}} item" href="{{.Link}}?type=review_requested&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state={{.State}}">
-							{{.i18n.Tr "repo.issues.filter_type.review_requested"}}
+							{{.locale.Tr "repo.issues.filter_type.review_requested"}}
 							<strong class="ui right">{{CountFmt .IssueStats.ReviewRequestedCount}}</strong>
 						</a>
 					{{end}}
@@ -61,11 +61,11 @@
 						<div class="ui compact tiny menu">
 							<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open&q={{$.Keyword}}">
 								{{svg "octicon-issue-opened" 16 "mr-3"}}
-								{{JsPrettyNumber .IssueStats.OpenCount}}&nbsp;{{.i18n.Tr "repo.issues.open_title"}}
+								{{JsPrettyNumber .IssueStats.OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 							</a>
 							<a class="item{{if .IsShowClosed}} active{{end}}" href="{{.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed&q={{$.Keyword}}">
 								{{svg "octicon-issue-closed" 16 "mr-3"}}
-								{{JsPrettyNumber .IssueStats.ClosedCount}}&nbsp;{{.i18n.Tr "repo.issues.closed_title"}}
+								{{JsPrettyNumber .IssueStats.ClosedCount}}&nbsp;{{.locale.Tr "repo.issues.closed_title"}}
 							</a>
 						</div>
 					</div>
@@ -76,8 +76,8 @@
 								<input type="hidden" name="repos" value="[{{range $.RepoIDs}}{{.}}%2C{{end}}]"/>
 								<input type="hidden" name="sort" value="{{$.SortType}}"/>
 								<input type="hidden" name="state" value="{{$.State}}"/>
-								<input name="q" value="{{$.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}...">
-								<button class="ui primary button" type="submit">{{.i18n.Tr "explore.search"}}</button>
+								<input name="q" value="{{$.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}...">
+								<button class="ui primary button" type="submit">{{.locale.Tr "explore.search"}}</button>
 							</div>
 						</form>
 					</div>
@@ -85,18 +85,18 @@
 						<!-- Sort -->
 						<div class="ui dropdown type jump item">
 							<span class="text">
-								{{.i18n.Tr "repo.issues.filter_sort"}}
+								{{.locale.Tr "repo.issues.filter_sort"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							</span>
 							<div class="menu">
-								<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=latest&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.latest"}}</a>
-								<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=oldest&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.oldest"}}</a>
-								<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=recentupdate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.recentupdate"}}</a>
-								<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastupdate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastupdate"}}</a>
-								<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostcomment&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.mostcomment"}}</a>
-								<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastcomment&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.leastcomment"}}</a>
-								<a class="{{if eq .SortType "nearduedate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=nearduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.nearduedate"}}</a>
-								<a class="{{if eq .SortType "farduedate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=farduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.issues.filter_sort.farduedate"}}</a>
+								<a class="{{if or (eq .SortType "latest") (not .SortType)}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=latest&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.latest"}}</a>
+								<a class="{{if eq .SortType "oldest"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=oldest&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.oldest"}}</a>
+								<a class="{{if eq .SortType "recentupdate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=recentupdate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.recentupdate"}}</a>
+								<a class="{{if eq .SortType "leastupdate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastupdate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.leastupdate"}}</a>
+								<a class="{{if eq .SortType "mostcomment"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostcomment&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.mostcomment"}}</a>
+								<a class="{{if eq .SortType "leastcomment"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastcomment&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.leastcomment"}}</a>
+								<a class="{{if eq .SortType "nearduedate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=nearduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.nearduedate"}}</a>
+								<a class="{{if eq .SortType "farduedate"}}active{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=farduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.issues.filter_sort.farduedate"}}</a>
 							</div>
 						</div>
 					</div>

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -6,7 +6,7 @@
 			<div class="four wide column">
 				<div class="ui secondary vertical filter menu">
 					<a class="item" href="{{.Link}}?type=your_repositories&sort={{$.SortType}}&state={{.State}}&q={{$.Keyword}}">
-						{{.i18n.Tr "home.issues.in_your_repos"}}
+						{{.locale.Tr "home.issues.in_your_repos"}}
 						<strong class="ui right">{{.Total}}</strong>
 					</a>
 					<div class="ui divider"></div>
@@ -39,11 +39,11 @@
 						<div class="ui compact tiny menu">
 							<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=open&q={{$.Keyword}}">
 								{{svg "octicon-milestone" 16 "mr-3"}}
-								{{JsPrettyNumber .MilestoneStats.OpenCount}}&nbsp;{{.i18n.Tr "repo.issues.open_title"}}
+								{{JsPrettyNumber .MilestoneStats.OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 							</a>
 							<a class="item{{if .IsShowClosed}} active{{end}}" href="{{.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort={{$.SortType}}&state=closed&q={{$.Keyword}}">
 								{{svg "octicon-check" 16 "mr-3"}}
-								{{JsPrettyNumber .MilestoneStats.ClosedCount}}&nbsp;{{.i18n.Tr "repo.issues.closed_title"}}
+								{{JsPrettyNumber .MilestoneStats.ClosedCount}}&nbsp;{{.locale.Tr "repo.issues.closed_title"}}
 							</a>
 						</div>
 					</div>
@@ -54,8 +54,8 @@
 								<input type="hidden" name="repos" value="[{{range $.RepoIDs}}{{.}},{{end}}]"/>
 								<input type="hidden" name="sort" value="{{$.SortType}}"/>
 								<input type="hidden" name="state" value="{{$.State}}"/>
-								<input name="q" value="{{$.Keyword}}" placeholder="{{.i18n.Tr "explore.search"}}...">
-								<button class="ui primary button" type="submit">{{.i18n.Tr "explore.search"}}</button>
+								<input name="q" value="{{$.Keyword}}" placeholder="{{.locale.Tr "explore.search"}}...">
+								<button class="ui primary button" type="submit">{{.locale.Tr "explore.search"}}</button>
 							</div>
 						</form>
 					</div>
@@ -63,16 +63,16 @@
 						<!-- Sort -->
 						<div class="ui dropdown type jump item">
 							<span class="text">
-								{{.i18n.Tr "repo.issues.filter_sort"}}
+								{{.locale.Tr "repo.issues.filter_sort"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 							</span>
 							<div class="menu">
-								<a class="{{if or (eq .SortType "closestduedate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=closestduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.closest_due_date"}}</a>
-								<a class="{{if eq .SortType "furthestduedate"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=furthestduedate&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.furthest_due_date"}}</a>
-								<a class="{{if eq .SortType "leastcomplete"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastcomplete&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.least_complete"}}</a>
-								<a class="{{if eq .SortType "mostcomplete"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostcomplete&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.most_complete"}}</a>
-								<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostissues&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.most_issues"}}</a>
-								<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastissues&state={{$.State}}&q={{$.Keyword}}">{{.i18n.Tr "repo.milestones.filter_sort.least_issues"}}</a>
+								<a class="{{if or (eq .SortType "closestduedate") (not .SortType)}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=closestduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.closest_due_date"}}</a>
+								<a class="{{if eq .SortType "furthestduedate"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=furthestduedate&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.furthest_due_date"}}</a>
+								<a class="{{if eq .SortType "leastcomplete"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastcomplete&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.least_complete"}}</a>
+								<a class="{{if eq .SortType "mostcomplete"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostcomplete&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.most_complete"}}</a>
+								<a class="{{if eq .SortType "mostissues"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=mostissues&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.most_issues"}}</a>
+								<a class="{{if eq .SortType "leastissues"}}active{{end}} item" href="{{$.Link}}?repos=[{{range $.RepoIDs}}{{.}}%2C{{end}}]&sort=leastissues&state={{$.State}}&q={{$.Keyword}}">{{.locale.Tr "repo.milestones.filter_sort.least_issues"}}</a>
 							</div>
 						</div>
 					</div>
@@ -91,22 +91,22 @@
 								</div>
 							</div>
 							<div class="meta">
-								{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.i18n }}
+								{{ $closedDate:= TimeSinceUnix .ClosedDateUnix $.locale }}
 								{{if .IsClosed}}
-									{{svg "octicon-clock"}} {{$.i18n.Tr "repo.milestones.closed" $closedDate|Str2html}}
+									{{svg "octicon-clock"}} {{$.locale.Tr "repo.milestones.closed" $closedDate|Str2html}}
 								{{else}}
 									{{svg "octicon-calendar"}}
 									{{if .DeadlineString}}
 										<span {{if .IsOverdue}}class="overdue"{{end}}>{{.DeadlineString}}</span>
 									{{else}}
-										{{$.i18n.Tr "repo.milestones.no_due_date"}}
+										{{$.locale.Tr "repo.milestones.no_due_date"}}
 									{{end}}
 								{{end}}
 								<span class="issue-stats">
 									{{svg "octicon-issue-opened" 16 "mr-3"}}
-									{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.i18n.Tr "repo.issues.open_title"}}
+									{{JsPrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
 									{{svg "octicon-check" 16 "mr-3"}}
-									{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.i18n.Tr "repo.issues.closed_title"}}
+									{{JsPrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
 									{{if .TotalTrackedTime}}
 										{{svg "octicon-clock"}} {{.TotalTrackedTime|Sec2Time}}
 									{{end}}
@@ -114,13 +114,13 @@
 							</div>
 							{{if and (or $.CanWriteIssues $.CanWritePulls) (not $.Repository.IsArchived)}}
 								<div class="ui right operate">
-									<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil"}} {{$.i18n.Tr "repo.issues.label_edit"}}</a>
+									<a href="{{$.Link}}/{{.ID}}/edit" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-pencil"}} {{$.locale.Tr "repo.issues.label_edit"}}</a>
 									{{if .IsClosed}}
-										<a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check"}} {{$.i18n.Tr "repo.milestones.open"}}</a>
+										<a href="{{$.Link}}/{{.ID}}/open" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-check"}} {{$.locale.Tr "repo.milestones.open"}}</a>
 									{{else}}
-										<a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x"}} {{$.i18n.Tr "repo.milestones.close"}}</a>
+										<a href="{{$.Link}}/{{.ID}}/close" data-id={{.ID}} data-title={{.Name}}>{{svg "octicon-x"}} {{$.locale.Tr "repo.milestones.close"}}</a>
 									{{end}}
-									<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.i18n.Tr "repo.issues.label_delete"}}</a>
+									<a class="delete-button" href="#" data-url="{{$.RepoLink}}/milestones/delete" data-id="{{.ID}}">{{svg "octicon-trash"}} {{$.locale.Tr "repo.issues.label_delete"}}</a>
 								</div>
 							{{end}}
 							{{if .Content}}

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -7,15 +7,15 @@
 					<span class="truncated-item-name">{{.ContextUser.ShortName 40}}</span>
 					{{if .ContextUser.IsOrganization}}
 						<span class="org-visibility">
-							{{if .ContextUser.Visibility.IsLimited}}<div class="ui orange tiny horizontal label">{{.i18n.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-							{{if .ContextUser.Visibility.IsPrivate}}<div class="ui red tiny horizontal label">{{.i18n.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+							{{if .ContextUser.Visibility.IsLimited}}<div class="ui orange tiny horizontal label">{{.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+							{{if .ContextUser.Visibility.IsPrivate}}<div class="ui red tiny horizontal label">{{.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 						</span>
 					{{end}}
 					{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 				</span>
 				<div class="context user overflow menu" tabindex="-1">
 					<div class="ui header">
-						{{.i18n.Tr "home.switch_dashboard_context"}}
+						{{.locale.Tr "home.switch_dashboard_context"}}
 					</div>
 					<div class="scrolling menu items">
 						<a class="{{if eq .ContextUser.ID .SignedUser.ID}}active selected{{end}} item truncated-item-container" href="{{AppSubUrl}}/{{if .PageIsIssues}}issues{{else if .PageIsPulls}}pulls{{else if .PageIsMilestonesDashboard}}milestones{{end}}">
@@ -27,15 +27,15 @@
 								{{avatar .}}
 								<span class="truncated-item-name">{{.ShortName 40}}</span>
 								<span class="org-visibility">
-									{{if .Visibility.IsLimited}}<div class="ui orange tiny horizontal label">{{$.i18n.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-									{{if .Visibility.IsPrivate}}<div class="ui red tiny horizontal label">{{$.i18n.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+									{{if .Visibility.IsLimited}}<div class="ui orange tiny horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+									{{if .Visibility.IsPrivate}}<div class="ui red tiny horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 								</span>
 							</a>
 						{{end}}
 					</div>
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
-						{{svg "octicon-plus"}}&nbsp;&nbsp;&nbsp;{{.i18n.Tr "new_org"}}
+						{{svg "octicon-plus"}}&nbsp;&nbsp;&nbsp;{{.locale.Tr "new_org"}}
 					</a>
 					{{end}}
 				</div>
@@ -49,17 +49,17 @@
 						{{if .Team}}
 							{{.Team.Name}}
 						{{else}}
-							{{.i18n.Tr "org.teams"}}
+							{{.locale.Tr "org.teams"}}
 						{{end}}
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 					</span>
 					<div class="context user overflow menu" tabindex="-1">
 						<div class="ui header">
-							{{.i18n.Tr "home.filter_by_team_repositories"}}
+							{{.locale.Tr "home.filter_by_team_repositories"}}
 						</div>
 						<div class="scrolling menu items">
-							<a class="{{if not $.Team}}active selected{{end}} item" title="{{.i18n.Tr "all"}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}">
-								{{.i18n.Tr "all"}}
+							<a class="{{if not $.Team}}active selected{{end}} item" title="{{.locale.Tr "all"}}" href="{{$.Org.OrganisationLink}}/{{if $.PageIsIssues}}issues{{else if $.PageIsPulls}}pulls{{else if $.PageIsMilestonesDashboard}}milestones{{else}}dashboard{{end}}">
+								{{.locale.Tr "all"}}
 							</a>
 							{{range .Teams}}
 								{{if not .IncludesAllRepositories}}
@@ -77,26 +77,26 @@
 	{{if .ContextUser.IsOrganization}}
 		<div class="right stackable menu">
 			<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{.ContextUser.DashboardLink}}{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
+				{{svg "octicon-rss"}}&nbsp;{{.locale.Tr "activities"}}
 			</a>
 			{{if not .UnitIssuesGlobalDisabled}}
 			<a class="{{if .PageIsIssues}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/issues{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
+				{{svg "octicon-issue-opened"}}&nbsp;{{.locale.Tr "issues"}}
 			</a>
 			{{end}}
 			{{if not .UnitPullsGlobalDisabled}}
 			<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
+				{{svg "octicon-git-pull-request"}}&nbsp;{{.locale.Tr "pull_requests"}}
 			</a>
 			{{end}}
 			{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
 			<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/milestones{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
+				{{svg "octicon-milestone"}}&nbsp;{{.locale.Tr "milestones"}}
 			</a>
 			{{end}}
 			<div class="item">
-				<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
-					{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 40)}}
+				<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.locale.Tr "home.view_home" .ContextUser.Name}}'>
+					{{.locale.Tr "home.view_home" (.ContextUser.ShortName 40)}}
 				</a>
 			</div>
 		</div>

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -22,73 +22,73 @@
 	>
 	<div>
 		<div v-if="!isOrganization" class="ui two item tabable menu">
-			<a :class="{item: true, active: tab === 'repos'}" @click="changeTab('repos')">{{.i18n.Tr "repository"}}</a>
-			<a :class="{item: true, active: tab === 'organizations'}" @click="changeTab('organizations')">{{.i18n.Tr "organization"}}</a>
+			<a :class="{item: true, active: tab === 'repos'}" @click="changeTab('repos')">{{.locale.Tr "repository"}}</a>
+			<a :class="{item: true, active: tab === 'organizations'}" @click="changeTab('organizations')">{{.locale.Tr "organization"}}</a>
 		</div>
 		<div v-show="tab === 'repos'" class="ui tab active list dashboard-repos">
 			<h4 class="ui top attached header df ac">
 				<div class="f1 df ac">
-					{{.i18n.Tr "home.my_repos"}}
+					{{.locale.Tr "home.my_repos"}}
 					<span class="ui grey label ml-3">${reposTotalCount}</span>
 				</div>
-				<a class="tooltip" :href="subUrl + '/repo/create'" data-content="{{.i18n.Tr "new_repo"}}" data-position="left center">
+				<a class="tooltip" :href="subUrl + '/repo/create'" data-content="{{.locale.Tr "new_repo"}}" data-position="left center">
 					{{svg "octicon-plus"}}
-					<span class="sr-only">{{.i18n.Tr "new_repo"}}</span>
+					<span class="sr-only">{{.locale.Tr "new_repo"}}</span>
 				</a>
 			</h4>
 			<div class="ui attached segment repos-search">
 				<div class="ui fluid right action left icon input" :class="{loading: isLoading}">
-					<input @input="changeReposFilter(reposFilter)" v-model="searchQuery" ref="search" placeholder="{{.i18n.Tr "home.search_repos"}}">
+					<input @input="changeReposFilter(reposFilter)" v-model="searchQuery" ref="search" placeholder="{{.locale.Tr "home.search_repos"}}">
 					<i class="icon df ac jc">{{svg "octicon-search" 16}}</i>
-					<div class="ui dropdown icon button" title="{{.i18n.Tr "home.filter"}}">
+					<div class="ui dropdown icon button" title="{{.locale.Tr "home.filter"}}">
 						<i class="icon df ac jc m-0">{{svg "octicon-filter" 16}}</i>
 						<div class="menu">
 							<div class="item">
 								<a @click="toggleArchivedFilter()">
-									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.i18n.Tr "home.show_both_archived_unarchived"}}" v-if="archivedFilter === 'both'">
+									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.locale.Tr "home.show_both_archived_unarchived"}}" v-if="archivedFilter === 'both'">
 										<input type="checkbox">
 										<label>
 											{{svg "octicon-archive" 16 "mr-2"}}
-											{{.i18n.Tr "home.show_archived"}}
+											{{.locale.Tr "home.show_archived"}}
 										</label>
 									</div>
-									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.i18n.Tr "home.show_only_unarchived"}}" v-if="archivedFilter === 'unarchived'">
+									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.locale.Tr "home.show_only_unarchived"}}" v-if="archivedFilter === 'unarchived'">
 										<input type="checkbox">
 										<label>
 											{{svg "octicon-archive" 16 "mr-2"}}
-											{{.i18n.Tr "home.show_archived"}}
+											{{.locale.Tr "home.show_archived"}}
 										</label>
 									</div>
-									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.i18n.Tr "home.show_only_archived"}}" v-if="archivedFilter === 'archived'">
+									<div class="ui checkbox" id="archivedFilterCheckbox" title="{{.locale.Tr "home.show_only_archived"}}" v-if="archivedFilter === 'archived'">
 										<input type="checkbox">
 										<label>
 											{{svg "octicon-archive" 16 "mr-2"}}
-											{{.i18n.Tr "home.show_archived"}}
+											{{.locale.Tr "home.show_archived"}}
 										</label>
 									</div>
 								</a>
 							</div>
 							<div class="item">
 								<a @click="togglePrivateFilter()">
-									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.i18n.Tr "home.show_both_private_public"}}" v-if="privateFilter === 'both'">
+									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.locale.Tr "home.show_both_private_public"}}" v-if="privateFilter === 'both'">
 										<input type="checkbox">
 										<label>
 											{{svg "octicon-lock" 16 "mr-2"}}
-											{{.i18n.Tr "home.show_private"}}
+											{{.locale.Tr "home.show_private"}}
 										</label>
 									</div>
-									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.i18n.Tr "home.show_only_public"}}" v-if="privateFilter === 'public'">
+									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.locale.Tr "home.show_only_public"}}" v-if="privateFilter === 'public'">
 										<input type="checkbox">
 										<label>
 											{{svg "octicon-lock" 16 "mr-2"}}
-											{{.i18n.Tr "home.show_private"}}
+											{{.locale.Tr "home.show_private"}}
 										</label>
 									</div>
-									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.i18n.Tr "home.show_only_private"}}" v-if="privateFilter === 'private'">
+									<div class="ui checkbox" id="privateFilterCheckbox" title="{{.locale.Tr "home.show_only_private"}}" v-if="privateFilter === 'private'">
 										<input type="checkbox">
 											<label>
 												{{svg "octicon-lock" 16 "mr-2"}}
-												{{.i18n.Tr "home.show_private"}}
+												{{.locale.Tr "home.show_private"}}
 											</label>
 									</div>
 								</a>
@@ -98,25 +98,25 @@
 				</div>
 				<div class="ui secondary tiny pointing borderless menu center grid repos-filter">
 					<a class="item" :class="{active: reposFilter === 'all'}" @click="changeReposFilter('all')">
-						{{.i18n.Tr "all"}}
+						{{.locale.Tr "all"}}
 						<div v-show="reposFilter === 'all'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
 					<a class="item" :class="{active: reposFilter === 'sources'}" @click="changeReposFilter('sources')">
-						{{.i18n.Tr "sources"}}
+						{{.locale.Tr "sources"}}
 						<div v-show="reposFilter === 'sources'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
 					<a class="item" :class="{active: reposFilter === 'forks'}" @click="changeReposFilter('forks')">
-						{{.i18n.Tr "forks"}}
+						{{.locale.Tr "forks"}}
 						<div v-show="reposFilter === 'forks'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
 					{{if .MirrorsEnabled}}
 					<a class="item" :class="{active: reposFilter === 'mirrors'}" @click="changeReposFilter('mirrors')">
-						{{.i18n.Tr "mirrors"}}
+						{{.locale.Tr "mirrors"}}
 						<div v-show="reposFilter === 'mirrors'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
 					{{end}}
 					<a class="item" :class="{active: reposFilter === 'collaborative'}" @click="changeReposFilter('collaborative')">
-						{{.i18n.Tr "collaborative"}}
+						{{.locale.Tr "collaborative"}}
 						<div v-show="reposFilter === 'collaborative'" class="ui circular mini grey label">${repoTypeCount}</div>
 					</a>
 				</div>
@@ -144,20 +144,20 @@
 				<div v-if="showMoreReposLink" class="center py-3 border-secondary-top">
 					<div class="ui borderless pagination menu narrow">
 						<a class="item navigation py-2" :class="{'disabled': page === 1}"
-							@click="changePage(1)" title="{{$.i18n.Tr "admin.first_page"}}">
+							@click="changePage(1)" title="{{$.locale.Tr "admin.first_page"}}">
 							{{svg "gitea-double-chevron-left" 16 "mr-2"}}
 						</a>
 						<a class="item navigation py-2" :class="{'disabled': page === 1}"
-							@click="changePage(page - 1)" title="{{$.i18n.Tr "repo.issues.previous"}}">
+							@click="changePage(page - 1)" title="{{$.locale.Tr "repo.issues.previous"}}">
 							{{svg "octicon-chevron-left" 16 "mr-2"}}
 						</a>
 						<a class="active item py-2">${page}</a>
 						<a class="item navigation" :class="{'disabled': page === finalPage}"
-							@click="changePage(page + 1)" title="{{$.i18n.Tr "repo.issues.next"}}">
+							@click="changePage(page + 1)" title="{{$.locale.Tr "repo.issues.next"}}">
 							{{svg "octicon-chevron-right" 16 "ml-2"}}
 						</a>
 						<a class="item navigation py-2" :class="{'disabled': page === finalPage}"
-							@click="changePage(finalPage)" title="{{$.i18n.Tr "admin.last_page"}}">
+							@click="changePage(finalPage)" title="{{$.locale.Tr "admin.last_page"}}">
 							{{svg "gitea-double-chevron-right" 16 "ml-2"}}
 						</a>
 					</div>
@@ -167,12 +167,12 @@
 		<div v-if="!isOrganization" v-show="tab === 'organizations'" class="ui tab active list dashboard-orgs">
 			<h4 class="ui top attached header df ac">
 				<div class="f1 df ac">
-					{{.i18n.Tr "home.my_orgs"}}
+					{{.locale.Tr "home.my_orgs"}}
 					<span class="ui grey label ml-3">${organizationsTotalCount}</span>
 				</div>
-				<a v-if="canCreateOrganization" class="tooltip" :href="subUrl + '/org/create'" data-content="{{.i18n.Tr "new_org"}}" data-position="left center">
+				<a v-if="canCreateOrganization" class="tooltip" :href="subUrl + '/org/create'" data-content="{{.locale.Tr "new_org"}}" data-position="left center">
 					{{svg "octicon-plus"}}
-					<span class="sr-only">{{.i18n.Tr "new_org"}}</span>
+					<span class="sr-only">{{.locale.Tr "new_org"}}</span>
 				</a>
 			</h4>
 			<div v-if="organizations.length" class="ui attached table segment rounded-bottom">

--- a/templates/user/heatmap.tmpl
+++ b/templates/user/heatmap.tmpl
@@ -1,7 +1,7 @@
 {{if .HeatmapData}}
 	<div id="user-heatmap" data-heatmap-data="{{Json .HeatmapData}}">
 		<div slot="loading">
-			<div class="ui active centered inline indeterminate text loader" id="loading-heatmap">{{.i18n.Tr "user.heatmap.loading"}}</div>
+			<div class="ui active centered inline indeterminate text loader" id="loading-heatmap">{{.locale.Tr "user.heatmap.loading"}}</div>
 		</div>
 	</div>
 	<div class="ui divider"></div>

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -1,20 +1,20 @@
 <div class="page-content user notification" id="notification_div" data-params="{{.Page.GetParams}}" data-sequence-number="{{.SequenceNumber}}">
 	<div class="ui container">
-		<h1 class="ui dividing header">{{.i18n.Tr "notification.notifications"}}</h1>
+		<h1 class="ui dividing header">{{.locale.Tr "notification.notifications"}}</h1>
 		<div class="ui top attached tabular menu">
 			{{ $notificationUnreadCount := call .NotificationUnreadCount}}
 			<a href="{{AppSubUrl}}/notifications?q=unread" class="{{if eq .Status 1}}active{{end}} item">
-				{{.i18n.Tr "notification.unread"}}
+				{{.locale.Tr "notification.unread"}}
 				<div class="ui label {{if not $notificationUnreadCount}}hidden{{end}}">{{$notificationUnreadCount}}</div>
 			</a>
 			<a href="{{AppSubUrl}}/notifications?q=read" class="{{if eq .Status 2}}active{{end}} item">
-				{{.i18n.Tr "notification.read"}}
+				{{.locale.Tr "notification.read"}}
 			</a>
 			{{if and (eq .Status 1)}}
 				<form action="{{AppSubUrl}}/notifications/purge" method="POST" style="margin-left: auto;">
 					{{$.CsrfTokenHtml}}
 					<div class="{{if not $notificationUnreadCount}}hide{{end}}">
-						<button class="ui mini button primary" title='{{$.i18n.Tr "notification.mark_all_as_read"}}'>
+						<button class="ui mini button primary" title='{{$.locale.Tr "notification.mark_all_as_read"}}'>
 							{{svg "octicon-checklist"}}
 						</button>
 					</div>
@@ -24,9 +24,9 @@
 		<div class="ui bottom attached active tab segment">
 			{{if eq (len .Notifications) 0}}
 				{{if eq .Status 1}}
-					{{.i18n.Tr "notification.no_unread"}}
+					{{.locale.Tr "notification.no_unread"}}
 				{{else}}
-					{{.i18n.Tr "notification.no_read"}}
+					{{.locale.Tr "notification.no_read"}}
 				{{end}}
 			{{else}}
 				<table class="ui unstackable striped very compact small selectable table" id="notification_table">
@@ -79,7 +79,7 @@
 											{{$.CsrfTokenHtml}}
 											<input type="hidden" name="notification_id" value="{{.ID}}" />
 											<input type="hidden" name="status" value="pinned" />
-											<button class="ui mini button" title='{{$.i18n.Tr "notification.pin"}}'
+											<button class="ui mini button" title='{{$.locale.Tr "notification.pin"}}'
 												data-url="{{AppSubUrl}}/notifications/status"
 												data-status="pinned"
 												data-page="{{$.Page.Paginater.Current}}"
@@ -97,7 +97,7 @@
 											<input type="hidden" name="notification_id" value="{{.ID}}" />
 											<input type="hidden" name="status" value="read" />
 											<input type="hidden" name="page" value="{{$.Page.Paginater.Current}}" />
-											<button class="ui mini button" title='{{$.i18n.Tr "notification.mark_as_read"}}'
+											<button class="ui mini button" title='{{$.locale.Tr "notification.mark_as_read"}}'
 												data-url="{{AppSubUrl}}/notifications/status"
 												data-status="read"
 												data-page="{{$.Page.Paginater.Current}}"
@@ -112,7 +112,7 @@
 											<input type="hidden" name="notification_id" value="{{.ID}}" />
 											<input type="hidden" name="status" value="unread" />
 											<input type="hidden" name="page" value="{{$.Page.Paginater.Current}}" />
-											<button class="ui mini button" title='{{$.i18n.Tr "notification.mark_as_unread"}}'
+											<button class="ui mini button" title='{{$.locale.Tr "notification.mark_as_unread"}}'
 												data-url="{{AppSubUrl}}/notifications/status"
 												data-status="unread"
 												data-page="{{$.Page.Paginater.Current}}"

--- a/templates/user/overview/header.tmpl
+++ b/templates/user/overview/header.tmpl
@@ -12,11 +12,11 @@
 	<div class="ui tabs container">
 		<div class="ui tabular stackable menu navbar">
 			<a class="item" href="{{.ContextUser.HomeLink}}">
-				{{svg "octicon-repo"}} {{.i18n.Tr "user.repositories"}}
+				{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 			</a>
 			{{if (not .UnitPackagesGlobalDisabled)}}
 				<a href="{{.ContextUser.HTMLURL}}/-/packages" class="{{if .IsPackagesPage}}active{{end}} item">
-					{{svg "octicon-package"}} {{.i18n.Tr "packages.title"}}
+					{{svg "octicon-package"}} {{.locale.Tr "packages.title"}}
 				</a>
 			{{end}}
 		</div>

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -6,7 +6,7 @@
 				<div class="ui card">
 					<div id="profile-avatar" class="content df"/>
 					{{if eq .SignedUserName .Owner.Name}}
-						<a class="image tooltip" href="{{AppSubUrl}}/user/settings" data-content="{{.i18n.Tr "user.change_avatar"}}" data-position="bottom center">
+						<a class="image tooltip" href="{{AppSubUrl}}/user/settings" data-content="{{.locale.Tr "user.change_avatar"}}" data-position="bottom center">
 							{{avatar .Owner 290}}
 						</a>
 					{{else}}
@@ -18,9 +18,9 @@
 					<div class="content word-break profile-avatar-name">
 						{{if .Owner.FullName}}<span class="header text center">{{.Owner.FullName}}</span>{{end}}
 						<span class="username text center">{{.Owner.Name}}</span>
-						<a href="{{.Owner.HomeLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{.i18n.Tr "rss_feed"}}" data-position="bottom center">{{svg "octicon-rss" 18}}</i></a>
+						<a href="{{.Owner.HomeLink}}.rss"><i class="ui grey icon tooltip ml-3" data-content="{{.locale.Tr "rss_feed"}}" data-position="bottom center">{{svg "octicon-rss" 18}}</i></a>
 						<div class="mt-3">
-							<a class="muted" href="{{.Owner.HomeLink}}?tab=followers">{{svg "octicon-person" 18 "mr-2"}}{{.Owner.NumFollowers}} {{.i18n.Tr "user.followers"}}</a> · <a class="muted" href="{{.Owner.HomeLink}}?tab=following">{{.Owner.NumFollowing}} {{.i18n.Tr "user.following"}}</a>
+							<a class="muted" href="{{.Owner.HomeLink}}?tab=followers">{{svg "octicon-person" 18 "mr-2"}}{{.Owner.NumFollowers}} {{.locale.Tr "user.followers"}}</a> · <a class="muted" href="{{.Owner.HomeLink}}?tab=following">{{.Owner.NumFollowing}} {{.locale.Tr "user.following"}}</a>
 						</div>
 					</div>
 					<div class="extra content word-break">
@@ -53,7 +53,7 @@
 									</li>
 								{{end}}
 							{{end}}
-							<li>{{svg "octicon-clock"}} {{.i18n.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
+							<li>{{svg "octicon-clock"}} {{.locale.Tr "user.join_on"}} {{.Owner.CreatedUnix.FormatShort}}</li>
 							{{if and .Orgs .HasOrgsVisible}}
 							<li>
 								<ul class="user-orgs">
@@ -74,12 +74,12 @@
 								{{if $.IsFollowing}}
 									<form method="post" action="{{.Link}}?action=unfollow&redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic red button">{{svg "octicon-person"}} {{.i18n.Tr "user.unfollow"}}</button>
+										<button type="submit" class="ui basic red button">{{svg "octicon-person"}} {{.locale.Tr "user.unfollow"}}</button>
 									</form>
 								{{else}}
 									<form method="post" action="{{.Link}}?action=follow&redirect_to={{$.Link}}">
 										{{$.CsrfTokenHtml}}
-										<button type="submit" class="ui basic green button">{{svg "octicon-person"}} {{.i18n.Tr "user.follow"}}</button>
+										<button type="submit" class="ui basic green button">{{svg "octicon-person"}} {{.locale.Tr "user.follow"}}</button>
 									</form>
 								{{end}}
 							</li>
@@ -91,26 +91,26 @@
 			<div class="ui eleven wide column">
 				<div class="ui secondary stackable pointing tight menu">
 					<a class='{{if and (ne .TabName "activity") (ne .TabName "following") (ne .TabName "followers") (ne .TabName "stars") (ne .TabName "watching") (ne .TabName "projects")}}active{{end}} item' href="{{.Owner.HomeLink}}">
-						{{svg "octicon-repo"}} {{.i18n.Tr "user.repositories"}}
+						{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 					</a>
 					{{if .IsPackageEnabled}}
 					<a class='{{if eq .TabName "packages"}}active{{end}} item' href="{{.Owner.HomeLink}}/-/packages">
-						{{svg "octicon-package"}} {{.i18n.Tr "packages.title"}}
+						{{svg "octicon-package"}} {{.locale.Tr "packages.title"}}
 					</a>
 					{{end}}
 					<a class='{{if eq .TabName "activity"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=activity">
-						{{svg "octicon-rss"}} {{.i18n.Tr "user.activity"}}
+						{{svg "octicon-rss"}} {{.locale.Tr "user.activity"}}
 					</a>
 					{{if not .DisableStars}}
 						<a class='{{if eq .TabName "stars"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=stars">
-							{{svg "octicon-star"}} {{.i18n.Tr "user.starred"}}
+							{{svg "octicon-star"}} {{.locale.Tr "user.starred"}}
 							{{if .Owner.NumStars}}
 								<div class="ui primary label">{{.Owner.NumStars}}</div>
 							{{end}}
 						</a>
 					{{else}}
 						<a class='{{if eq .TabName "watching"}}active{{end}} item' href="{{.Owner.HomeLink}}?tab=watching">
-							{{svg "octicon-eye"}} {{.i18n.Tr "user.watched"}}
+							{{svg "octicon-eye"}} {{.locale.Tr "user.watched"}}
 						</a>
 					{{end}}
 				</div>
@@ -118,7 +118,7 @@
 				{{if eq .TabName "activity"}}
 					{{if .Owner.KeepActivityPrivate}}
 						<div class="ui info message">
-							<p>{{.i18n.Tr "user.disabled_public_activity"}}</p>
+							<p>{{.locale.Tr "user.disabled_public_activity"}}</p>
 						</div>
 					{{end}}
 					{{template "user/heatmap" .}}

--- a/templates/user/project.tmpl
+++ b/templates/user/project.tmpl
@@ -5,12 +5,12 @@
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<h3 class="ui top attached header">
-					{{.i18n.Tr "new_project"}}
+					{{.locale.Tr "new_project"}}
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
 					<div class="inline required field {{if .Err_Owner}}error{{end}}">
-						<label>{{.i18n.Tr "repo.owner"}}</label>
+						<label>{{.locale.Tr "repo.owner"}}</label>
 						<div class="ui selection owner dropdown">
 							<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
 							<span class="text truncated-item-container" title="{{.ContextUser.Name}}">
@@ -34,22 +34,22 @@
 					</div>
 
 					<div class="inline field {{if .Err_Title}}error{{end}}">
-						<label>{{.i18n.Tr "repo.projects.title"}}</label>
-						<input name="title" placeholder="{{.i18n.Tr "repo.projects.title"}}" value="{{.title}}" autofocus required>
+						<label>{{.locale.Tr "repo.projects.title"}}</label>
+						<input name="title" placeholder="{{.locale.Tr "repo.projects.title"}}" value="{{.title}}" autofocus required>
 					</div>
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.projects.desc"}}</label>
+						<label>{{.locale.Tr "repo.projects.desc"}}</label>
 						<textarea name="content">{{.content}}</textarea>
 					</div>
 
 					<div class="inline field">
-						<label>{{.i18n.Tr "repo.projects.template.desc"}}</label>
+						<label>{{.locale.Tr "repo.projects.template.desc"}}</label>
 						<div class="ui selection dropdown">
 							<input type="hidden" name="board_type" value="{{.type}}">
-							<div class="default text">{{.i18n.Tr "repo.projects.template.desc_helper"}}</div>
+							<div class="default text">{{.locale.Tr "repo.projects.template.desc_helper"}}</div>
 							<div class="menu">
 								{{range $element := .ProjectTypes}}
-								<div class="item" data-id="{{$element.BoardType}}" data-value="{{$element.BoardType}}">{{$.i18n.Tr $element.Translation}}</div>
+								<div class="item" data-id="{{$element.BoardType}}" data-value="{{$element.BoardType}}">{{$.locale.Tr $element.Translation}}</div>
 								{{end}}
 							</div>
 						</div>
@@ -58,9 +58,9 @@
 					<div class="inline field">
 						<label></label>
 						<button class="ui green button">
-							{{.i18n.Tr "repo.projects.create" }}
+							{{.locale.Tr "repo.projects.create" }}
 						</button>
-						<a class="ui button" href="{{AppSubUrl}}/">{{.i18n.Tr "cancel"}}</a>
+						<a class="ui button" href="{{AppSubUrl}}/">{{.locale.Tr "cancel"}}</a>
 					</div>
 				</div>
 			</form>

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.password"}}
+			{{.locale.Tr "settings.password"}}
 		</h4>
 		<div class="ui attached segment">
 			{{if or (.SignedUser.IsLocal) (.SignedUser.IsOAuth2)}}
@@ -13,42 +13,42 @@
 				{{.CsrfTokenHtml}}
 				{{if .SignedUser.IsPasswordSet}}
 				<div class="required field {{if .Err_OldPassword}}error{{end}}">
-					<label for="old_password">{{.i18n.Tr "settings.old_password"}}</label>
+					<label for="old_password">{{.locale.Tr "settings.old_password"}}</label>
 					<input id="old_password" name="old_password" type="password" autocomplete="current-password" autofocus required>
 				</div>
 				{{end}}
 				<div class="required field {{if .Err_Password}}error{{end}}">
-					<label for="password">{{.i18n.Tr "settings.new_password"}}</label>
+					<label for="password">{{.locale.Tr "settings.new_password"}}</label>
 					<input id="password" name="password" type="password" autocomplete="new-password" required>
 				</div>
 				<div class="required field {{if .Err_Password}}error{{end}}">
-					<label for="retype">{{.i18n.Tr "settings.retype_new_password"}}</label>
+					<label for="retype">{{.locale.Tr "settings.retype_new_password"}}</label>
 					<input id="retype" name="retype" type="password" autocomplete="new-password" required>
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.change_password"}}</button>
-					<a href="{{AppSubUrl}}/user/forgot_password?email={{.Email}}">{{.i18n.Tr "auth.forgot_password"}}</a>
+					<button class="ui green button">{{$.locale.Tr "settings.change_password"}}</button>
+					<a href="{{AppSubUrl}}/user/forgot_password?email={{.Email}}">{{.locale.Tr "auth.forgot_password"}}</a>
 				</div>
 			</form>
 			{{else}}
 			<div class="ui info message">
-				<p class="text left">{{$.i18n.Tr "settings.password_change_disabled"}}</p>
+				<p class="text left">{{$.locale.Tr "settings.password_change_disabled"}}</p>
 			</div>
 			{{end}}
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.manage_emails"}}
+			{{.locale.Tr "settings.manage_emails"}}
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui email list">
 				<div class="item">
 					<form action="{{AppSubUrl}}/user/settings/account/email" class="ui form" method="post">
-						{{.i18n.Tr "settings.email_desc"}}
+						{{.locale.Tr "settings.email_desc"}}
 						<div class="right floated content">
 							<div class="field">
-								<button class="ui green button">{{$.i18n.Tr "settings.email_notifications.submit"}}</button>
+								<button class="ui green button">{{$.locale.Tr "settings.email_notifications.submit"}}</button>
 							</div>
 						</div>
 						<div class="right floated content">
@@ -58,11 +58,11 @@
 								<div class="ui selection dropdown" tabindex="0">
 									<input name="preference" type="hidden" value="{{.EmailNotificationsPreference}}">
 									{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-									<div class="text">{{$.i18n.Tr "settings.email_notifications"}}</div>
+									<div class="text">{{$.locale.Tr "settings.email_notifications"}}</div>
 									<div class="menu">
-										<div data-value="enabled" class="{{if eq .EmailNotificationsPreference "enabled"}}active selected {{end}}item">{{$.i18n.Tr "settings.email_notifications.enable"}}</div>
-										<div data-value="onmention" class="{{if eq .EmailNotificationsPreference "onmention"}}active selected {{end}}item">{{$.i18n.Tr "settings.email_notifications.onmention"}}</div>
-										<div data-value="disabled" class="{{if eq .EmailNotificationsPreference "disabled"}}active selected {{end}}item">{{$.i18n.Tr "settings.email_notifications.disable"}}</div>
+										<div data-value="enabled" class="{{if eq .EmailNotificationsPreference "enabled"}}active selected {{end}}item">{{$.locale.Tr "settings.email_notifications.enable"}}</div>
+										<div data-value="onmention" class="{{if eq .EmailNotificationsPreference "onmention"}}active selected {{end}}item">{{$.locale.Tr "settings.email_notifications.onmention"}}</div>
+										<div data-value="disabled" class="{{if eq .EmailNotificationsPreference "disabled"}}active selected {{end}}item">{{$.locale.Tr "settings.email_notifications.disable"}}</div>
 									</div>
 								</div>
 							</div>
@@ -74,7 +74,7 @@
 						{{if not .IsPrimary}}
 							<div class="right floated content">
 								<button class="ui red tiny button delete-button" data-modal-id="delete-email" data-url="{{AppSubUrl}}/user/settings/account/email/delete" data-id="{{.ID}}">
-									{{$.i18n.Tr "settings.delete_email"}}
+									{{$.locale.Tr "settings.delete_email"}}
 								</button>
 							</div>
 							{{if .CanBePrimary}}
@@ -83,7 +83,7 @@
 										{{$.CsrfTokenHtml}}
 										<input name="_method" type="hidden" value="PRIMARY">
 										<input name="id" type="hidden" value="{{.ID}}">
-										<button class="ui primary tiny button">{{$.i18n.Tr "settings.primary_email"}}</button>
+										<button class="ui primary tiny button">{{$.locale.Tr "settings.primary_email"}}</button>
 									</form>
 								</div>
 							{{end}}
@@ -95,9 +95,9 @@
 									<input name="_method" type="hidden" value="SENDACTIVATION">
 									<input name="id" type="hidden" value="{{.ID}}">
 									{{if $.ActivationsPending}}
-										<button disabled class="ui primary tiny button">{{$.i18n.Tr "settings.activations_pending"}}</button>
+										<button disabled class="ui primary tiny button">{{$.locale.Tr "settings.activations_pending"}}</button>
 									{{else}}
-										<button class="ui primary tiny button">{{$.i18n.Tr "settings.activate_email"}}</button>
+										<button class="ui primary tiny button">{{$.locale.Tr "settings.activate_email"}}</button>
 									{{end}}
 								</form>
 							</div>
@@ -105,12 +105,12 @@
 						<div class="content">
 							<strong>{{.Email}}</strong>
 							{{if .IsPrimary}}
-								<div class="ui primary label">{{$.i18n.Tr "settings.primary"}}</div>
+								<div class="ui primary label">{{$.locale.Tr "settings.primary"}}</div>
 							{{end}}
 							{{if .IsActivated}}
-								<div class="ui green label">{{$.i18n.Tr "settings.activated"}}</div>
+								<div class="ui green label">{{$.locale.Tr "settings.activated"}}</div>
 							{{else}}
-								<div class="ui label">{{$.i18n.Tr "settings.requires_activation"}}</div>
+								<div class="ui label">{{$.locale.Tr "settings.requires_activation"}}</div>
 							{{end}}
 						</div>
 					</div>
@@ -121,37 +121,37 @@
 			<form class="ui form" action="{{AppSubUrl}}/user/settings/account/email" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="required field {{if .Err_Email}}error{{end}}">
-					<label for="email">{{.i18n.Tr "settings.add_new_email"}}</label>
+					<label for="email">{{.locale.Tr "settings.add_new_email"}}</label>
 					<input id="email" name="email" type="email" required {{if not .CanAddEmails}}disabled{{end}}>
 				</div>
 				<button class="ui green button" {{if not .CanAddEmails}}disabled{{end}}>
-					{{.i18n.Tr "settings.add_email"}}
+					{{.locale.Tr "settings.add_email"}}
 				</button>
 			</form>
 		</div>
 
 		<h4 class="ui top attached error header">
-			{{.i18n.Tr "settings.delete_account"}}
+			{{.locale.Tr "settings.delete_account"}}
 		</h4>
 		<div class="ui attached error segment">
 			<div class="ui red message">
-				<p class="text left">{{svg "octicon-alert"}} {{.i18n.Tr "settings.delete_prompt" | Str2html}}</p>
+				<p class="text left">{{svg "octicon-alert"}} {{.locale.Tr "settings.delete_prompt" | Str2html}}</p>
 				{{ if .UserDeleteWithComments }}
-				<p class="text left" style="font-weight: bold;">{{.i18n.Tr "settings.delete_with_all_comments" .UserDeleteWithCommentsMaxTime | Str2html}}</p>
+				<p class="text left" style="font-weight: bold;">{{.locale.Tr "settings.delete_with_all_comments" .UserDeleteWithCommentsMaxTime | Str2html}}</p>
 				{{ end }}
 			</div>
 			<form class="ui form ignore-dirty" id="delete-form" action="{{AppSubUrl}}/user/settings/account/delete" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
 				<div class="required field {{if .Err_Password}}error{{end}}">
-					<label for="password-confirmation">{{.i18n.Tr "password"}}</label>
+					<label for="password-confirmation">{{.locale.Tr "password"}}</label>
 					<input id="password-confirmation" name="password" type="password" autocomplete="off" required>
 				</div>
 				<div class="field">
 					<div class="ui red button delete-button" data-modal-id="delete-account" data-type="form" data-form="#delete-form">
-						{{.i18n.Tr "settings.confirm_delete_account"}}
+						{{.locale.Tr "settings.confirm_delete_account"}}
 					</div>
-					<a href="{{AppSubUrl}}/user/forgot_password?email={{.Email}}">{{.i18n.Tr "auth.forgot_password"}}</a>
+					<a href="{{AppSubUrl}}/user/forgot_password?email={{.Email}}">{{.locale.Tr "auth.forgot_password"}}</a>
 				</div>
 			</form>
 		</div>
@@ -161,10 +161,10 @@
 <div class="ui small basic delete modal" id="delete-email">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.email_deletion"}}
+		{{.locale.Tr "settings.email_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.email_deletion_desc"}}</p>
+		<p>{{.locale.Tr "settings.email_deletion_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>
@@ -172,10 +172,10 @@
 <div class="ui small basic delete modal" id="delete-account">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.delete_account_title"}}
+		{{.locale.Tr "settings.delete_account_title"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.delete_account_desc"}}</p>
+		<p>{{.locale.Tr "settings.delete_account_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -6,18 +6,18 @@
 
 		<!-- Theme -->
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.manage_themes"}}
+			{{.locale.Tr "settings.manage_themes"}}
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui email list">
 				<div class="item">
-					{{.i18n.Tr "settings.theme_desc"}}
+					{{.locale.Tr "settings.theme_desc"}}
 				</div>
 
 			<form class="ui form" action="{{.Link}}/theme" method="post">
 				{{.CsrfTokenHtml}}
 					<div class="field">
-						<label for="ui">{{.i18n.Tr "settings.ui"}}</label>
+						<label for="ui">{{.locale.Tr "settings.ui"}}</label>
 						<div class="ui selection dropdown" id="ui">
 							<input name="theme" type="hidden" value="{{.SignedUser.Theme}}">
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -38,7 +38,7 @@
 					</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_theme"}}</button>
+					<button class="ui green button">{{$.locale.Tr "settings.update_theme"}}</button>
 				</div>
 			</form>
 			</div>
@@ -46,7 +46,7 @@
 
 		<!-- Language -->
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.language"}}
+			{{.locale.Tr "settings.language"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}/language" method="post">
@@ -64,14 +64,14 @@
 					</div>
 				</div>
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_language"}}</button>
+					<button class="ui green button">{{$.locale.Tr "settings.update_language"}}</button>
 				</div>
 			</form>
 		</div>
 
 		<!-- Shown comment event types -->
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.hidden_comment_types"}}
+			{{.locale.Tr "settings.hidden_comment_types"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}/hidden_comments" method="post">
@@ -79,90 +79,90 @@
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="reference" type="checkbox" {{if(call .IsCommentTypeGroupChecked "reference")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_reference"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_reference"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="label" type="checkbox" {{if (call .IsCommentTypeGroupChecked "label")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_label"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_label"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="milestone" type="checkbox" {{if (call .IsCommentTypeGroupChecked "milestone")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_milestone"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_milestone"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="assignee" type="checkbox" {{if (call .IsCommentTypeGroupChecked "assignee")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_assignee"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_assignee"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="title" type="checkbox" {{if (call .IsCommentTypeGroupChecked "title")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_title"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_title"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="branch" type="checkbox" {{if (call .IsCommentTypeGroupChecked "branch")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_branch"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_branch"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="time_tracking" type="checkbox" {{if (call .IsCommentTypeGroupChecked "time_tracking")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_time_tracking"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_time_tracking"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="deadline" type="checkbox" {{if (call .IsCommentTypeGroupChecked "deadline")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_deadline"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_deadline"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="dependency" type="checkbox" {{if (call .IsCommentTypeGroupChecked "dependency")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_dependency"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_dependency"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="lock" type="checkbox" {{if (call .IsCommentTypeGroupChecked "lock")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_lock"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_lock"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="review_request" type="checkbox" {{if (call .IsCommentTypeGroupChecked "review_request")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_review_request"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_review_request"}}</label>
 					</div>
 				</div>
 
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="pull_request_push" type="checkbox" {{if (call .IsCommentTypeGroupChecked "pull_request_push")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_pull_request_push"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_pull_request_push"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="project" type="checkbox" {{if (call .IsCommentTypeGroupChecked "project")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_project"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_project"}}</label>
 					</div>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="issue_ref" type="checkbox" {{if (call .IsCommentTypeGroupChecked "issue_ref")}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.comment_type_group_issue_ref"}}</label>
+						<label>{{.locale.Tr "settings.comment_type_group_issue_ref"}}</label>
 					</div>
 				</div>
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "save"}}</button>
+					<button class="ui green button">{{$.locale.Tr "save"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -4,26 +4,26 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.manage_access_token"}}
+			{{.locale.Tr "settings.manage_access_token"}}
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui key list">
 				<div class="item">
-					{{.i18n.Tr "settings.tokens_desc"}}
+					{{.locale.Tr "settings.tokens_desc"}}
 				</div>
 				{{range .Tokens}}
 					<div class="item">
 						<div class="right floated content">
 								<button class="ui red tiny button delete-button" data-modal-id="delete-token" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
 									{{svg "octicon-trash" 16 "mr-2"}}
-									{{$.i18n.Tr "settings.delete_token"}}
+									{{$.locale.Tr "settings.delete_token"}}
 								</button>
 						</div>
-						<i class="big send icon {{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.token_state_desc"}}" data-variation="inverted tiny"{{end}}></i>
+						<i class="big send icon {{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.locale.Tr "settings.token_state_desc"}}" data-variation="inverted tiny"{{end}}></i>
 						<div class="content">
 							<strong>{{.Name}}</strong>
 							<div class="activity meta">
-								<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> — {{svg "octicon-info"}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
+								<i>{{$.locale.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> — {{svg "octicon-info"}} {{if .HasUsed}}{{$.locale.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.locale.Tr "settings.no_activity"}}{{end}}</i>
 							</div>
 						</div>
 					</div>
@@ -32,17 +32,17 @@
 		</div>
 		<div class="ui attached bottom segment">
 			<h5 class="ui top header">
-				{{.i18n.Tr "settings.generate_new_token"}}
+				{{.locale.Tr "settings.generate_new_token"}}
 			</h5>
-			<p>{{.i18n.Tr "settings.new_token_desc"}}</p>
+			<p>{{.locale.Tr "settings.new_token_desc"}}</p>
 			<form class="ui form ignore-dirty" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="field {{if .Err_Name}}error{{end}}">
-					<label for="name">{{.i18n.Tr "settings.token_name"}}</label>
+					<label for="name">{{.locale.Tr "settings.token_name"}}</label>
 					<input id="name" name="name" value="{{.name}}" autofocus required>
 				</div>
 				<button class="ui green button">
-					{{.i18n.Tr "settings.generate_token"}}
+					{{.locale.Tr "settings.generate_token"}}
 				</button>
 			</form>
 		</div>
@@ -57,19 +57,19 @@
 <div class="ui small basic delete modal" id="delete-token">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.access_token_deletion"}}
+		{{.locale.Tr "settings.access_token_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.access_token_deletion_desc"}}</p>
+		<p>{{.locale.Tr "settings.access_token_deletion_desc"}}</p>
 	</div>
 	<div class="actions">
 		<div class="ui cancel button">
 			<i class="remove icon"></i>
-			{{.i18n.Tr "settings.access_token_deletion_cancel_action"}}
+			{{.locale.Tr "settings.access_token_deletion_cancel_action"}}
 		</div>
 		<div class="ui red basic inverted ok button">
 			<i class="checkmark icon"></i>
-			{{.i18n.Tr "settings.access_token_deletion_confirm_action"}}
+			{{.locale.Tr "settings.access_token_deletion_confirm_action"}}
 		</div>
 	</div>
 </div>

--- a/templates/user/settings/applications_oauth2.tmpl
+++ b/templates/user/settings/applications_oauth2.tmpl
@@ -1,23 +1,23 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.manage_oauth2_applications"}}
+	{{.locale.Tr "settings.manage_oauth2_applications"}}
 </h4>
 <div class="ui attached segment">
 	<div class="ui key list">
 		<div class="item">
-			{{.i18n.Tr "settings.oauth2_application_create_description"}}
+			{{.locale.Tr "settings.oauth2_application_create_description"}}
 		</div>
 		{{range $app := .Applications}}
 			<div class="item">
 				<div class="right floated content">
 					<a href="{{$.Link}}/oauth2/{{$app.ID}}" class="ui primary tiny button">
 						{{svg "octicon-pencil" 16 "mr-2"}}
-						{{$.i18n.Tr "settings.oauth2_application_edit"}}
+						{{$.locale.Tr "settings.oauth2_application_edit"}}
 					</a>
 					<button class="ui red tiny button delete-button" data-modal-id="remove-gitea-oauth2-application"
 							data-url="{{AppSubUrl}}/user/settings/applications/oauth2/delete"
 							data-id="{{$app.ID}}">
 						{{svg "octicon-trash" 16 "mr-2"}}
-						{{$.i18n.Tr "settings.delete_key"}}
+						{{$.locale.Tr "settings.delete_key"}}
 					</button>
 				</div>
 				<div class="content">
@@ -29,20 +29,20 @@
 </div>
 <div class="ui attached bottom segment">
 	<h5 class="ui top header">
-		{{.i18n.Tr "settings.create_oauth2_application" }}
+		{{.locale.Tr "settings.create_oauth2_application" }}
 	</h5>
 	<form class="ui form ignore-dirty" action="{{.Link}}/oauth2" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="field {{if .Err_AppName}}error{{end}}">
-			<label for="application-name">{{.i18n.Tr "settings.oauth2_application_name"}}</label>
+			<label for="application-name">{{.locale.Tr "settings.oauth2_application_name"}}</label>
 			<input id="application-name" name="application_name" value="{{.application_name}}" required>
 		</div>
 		<div class="field {{if .Err_RedirectURI}}error{{end}}">
-			<label for="redirect-uri">{{.i18n.Tr "settings.oauth2_redirect_uri"}}</label>
+			<label for="redirect-uri">{{.locale.Tr "settings.oauth2_redirect_uri"}}</label>
 			<input type="url" name="redirect_uri" id="redirect-uri">
 		</div>
 		<button class="ui green button">
-			{{.i18n.Tr "settings.create_oauth2_application_button"}}
+			{{.locale.Tr "settings.create_oauth2_application_button"}}
 		</button>
 	</form>
 </div>
@@ -50,10 +50,10 @@
 <div class="ui small basic delete modal" id="remove-gitea-oauth2-application">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.remove_oauth2_application"}}
+		{{.locale.Tr "settings.remove_oauth2_application"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.oauth2_application_remove_description"}}</p>
+		<p>{{.locale.Tr "settings.oauth2_application_remove_description"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/applications_oauth2_edit.tmpl
+++ b/templates/user/settings/applications_oauth2_edit.tmpl
@@ -4,34 +4,34 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.edit_oauth2_application"}}
+			{{.locale.Tr "settings.edit_oauth2_application"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "settings.oauth2_application_create_description"}}</p>
+			<p>{{.locale.Tr "settings.oauth2_application_create_description"}}</p>
 		</div>
 		<div class="ui attached segment form ignore-dirty">
 			{{.CsrfTokenHtml}}
 			<div class="field">
-				<label for="client-id">{{.i18n.Tr "settings.oauth2_client_id"}}</label>
+				<label for="client-id">{{.locale.Tr "settings.oauth2_client_id"}}</label>
 				<input id="client-id" readonly value="{{.App.ClientID}}">
 			</div>
 			{{if .ClientSecret}}
 				<div class="field">
-					<label for="client-secret">{{.i18n.Tr "settings.oauth2_client_secret"}}</label>
+					<label for="client-secret">{{.locale.Tr "settings.oauth2_client_secret"}}</label>
 					<input id="client-secret" type="text" readonly value="{{.ClientSecret}}">
 				</div>
 			{{else}}
 				<div class="field">
-					<label for="client-secret">{{.i18n.Tr "settings.oauth2_client_secret"}}</label>
+					<label for="client-secret">{{.locale.Tr "settings.oauth2_client_secret"}}</label>
 					<input id="client-secret" type="password" readonly value="averysecuresecret">
 				</div>
 			{{end}}
 			<div class="item">
 				<!-- TODO add regenerate secret functionality */ -->
-				{{.i18n.Tr "settings.oauth2_regenerate_secret_hint"}}
+				{{.locale.Tr "settings.oauth2_regenerate_secret_hint"}}
 				<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/settings/applications/oauth2/{{.App.ID}}/regenerate_secret" method="post">
 					{{.CsrfTokenHtml}}
-					<a href="#" onclick="event.target.parentNode.submit()">{{.i18n.Tr "settings.oauth2_regenerate_secret"}}</a>
+					<a href="#" onclick="event.target.parentNode.submit()">{{.locale.Tr "settings.oauth2_regenerate_secret"}}</a>
 				</form>
 			</div>
 		</div>
@@ -39,15 +39,15 @@
 			<form class="ui form ignore-dirty" action="{{AppSubUrl}}/user/settings/applications/oauth2/{{.App.ID}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="field {{if .Err_AppName}}error{{end}}">
-					<label for="application-name">{{.i18n.Tr "settings.oauth2_application_name"}}</label>
+					<label for="application-name">{{.locale.Tr "settings.oauth2_application_name"}}</label>
 					<input id="application-name" value="{{.App.Name}}" name="application_name" required>
 				</div>
 				<div class="field {{if .Err_RedirectURI}}error{{end}}">
-					<label for="redirect-uri">{{.i18n.Tr "settings.oauth2_redirect_uri"}}</label>
+					<label for="redirect-uri">{{.locale.Tr "settings.oauth2_redirect_uri"}}</label>
 					<input type="url" name="redirect_uri" value="{{.App.PrimaryRedirectURI}}" id="redirect-uri">
 				</div>
 				<button class="ui green button">
-					{{.i18n.Tr "settings.save_application"}}
+					{{.locale.Tr "settings.save_application"}}
 				</button>
 			</form>
 		</div>
@@ -57,10 +57,10 @@
 <div class="ui small basic delete modal" id="delete-oauth2-application">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.remove_oauth2_application"}}
+		{{.locale.Tr "settings.remove_oauth2_application"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.remove_oauth2_application_desc"}}</p>
+		<p>{{.locale.Tr "settings.remove_oauth2_application_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/grants_oauth2.tmpl
+++ b/templates/user/settings/grants_oauth2.tmpl
@@ -1,10 +1,10 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.authorized_oauth2_applications"}}
+	{{.locale.Tr "settings.authorized_oauth2_applications"}}
 </h4>
 <div class="ui attached segment">
 	<div class="ui key list">
 		<div class="item">
-			{{.i18n.Tr "settings.authorized_oauth2_applications_description"}}
+			{{.locale.Tr "settings.authorized_oauth2_applications_description"}}
 		</div>
 		{{range $grant := .Grants}}
 			<div class="item">
@@ -12,7 +12,7 @@
 					<button class="ui red tiny button delete-button" data-modal-id="revoke-gitea-oauth2-grant"
 							data-url="{{AppSubUrl}}/user/settings/applications/oauth2/revoke"
 							data-id="{{$grant.ID}}">
-						{{$.i18n.Tr "settings.revoke_key"}}
+						{{$.locale.Tr "settings.revoke_key"}}
 					</button>
 				</div>
 				<div class="left floated content">
@@ -21,7 +21,7 @@
 				<div class="content">
 					<strong>{{$grant.Application.Name}}</strong>
 					<div class="activity meta">
-						<i>{{$.i18n.Tr "settings.add_on"}} <span>{{$grant.CreatedUnix.FormatShort}}</span></i>
+						<i>{{$.locale.Tr "settings.add_on"}} <span>{{$grant.CreatedUnix.FormatShort}}</span></i>
 					</div>
 				</div>
 			</div>
@@ -32,10 +32,10 @@
 <div class="ui small basic delete modal" id="revoke-gitea-oauth2-grant">
 	<div class="ui icon header">
 		{{svg "octicon-shield" 16 "mr-2"}}
-		{{.i18n.Tr "settings.revoke_oauth2_grant"}}
+		{{.locale.Tr "settings.revoke_oauth2_grant"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.revoke_oauth2_grant_description"}}</p>
+		<p>{{.locale.Tr "settings.revoke_oauth2_grant_description"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -1,7 +1,7 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.manage_gpg_keys"}}
+	{{.locale.Tr "settings.manage_gpg_keys"}}
 	<div class="ui right">
-		<div class="ui primary tiny show-panel button" data-panel="#add-gpg-key-panel">{{.i18n.Tr "settings.add_key"}}</div>
+		<div class="ui primary tiny show-panel button" data-panel="#add-gpg-key-panel">{{.locale.Tr "settings.add_key"}}</div>
 	</div>
 </h4>
 <div class="ui attached segment">
@@ -10,47 +10,47 @@
 			{{.CsrfTokenHtml}}
 			<input type="hidden" name="title" value="none">
 			<div class="field {{if .Err_Content}}error{{end}}">
-				<label for="content">{{.i18n.Tr "settings.key_content"}}</label>
-				<textarea id="gpg-key-content" name="content" placeholder="{{.i18n.Tr "settings.key_content_gpg_placeholder"}}" required>{{.content}}</textarea>
+				<label for="content">{{.locale.Tr "settings.key_content"}}</label>
+				<textarea id="gpg-key-content" name="content" placeholder="{{.locale.Tr "settings.key_content_gpg_placeholder"}}" required>{{.content}}</textarea>
 			</div>
 			{{if .Err_Signature}}
 				<div class="ui error message">
-					<p>{{.i18n.Tr "settings.gpg_token_required"}}</p>
+					<p>{{.locale.Tr "settings.gpg_token_required"}}</p>
 				</div>
 				<div class="field">
-					<label for="token">{{.i18n.Tr "setting.gpg_token"}}
+					<label for="token">{{.locale.Tr "setting.gpg_token"}}
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
-						<p>{{.i18n.Tr "settings.gpg_token_help"}}</p>
-						<p><code>{{$.i18n.Tr "settings.gpg_token_code" .TokenToSign .KeyID}}</code></p>
+						<p>{{.locale.Tr "settings.gpg_token_help"}}</p>
+						<p><code>{{$.locale.Tr "settings.gpg_token_code" .TokenToSign .KeyID}}</code></p>
 					</div>
 				</div>
 				<div class="field">
-					<label for="signature">{{.i18n.Tr "settings.gpg_token_signature"}}</label>
-					<textarea id="gpg-key-signature" name="signature" placeholder="{{.i18n.Tr "settings.key_signature_gpg_placeholder"}}" required>{{.signature}}</textarea>
+					<label for="signature">{{.locale.Tr "settings.gpg_token_signature"}}</label>
+					<textarea id="gpg-key-signature" name="signature" placeholder="{{.locale.Tr "settings.key_signature_gpg_placeholder"}}" required>{{.signature}}</textarea>
 				</div>
 			{{end}}
 			<input name="type" type="hidden" value="gpg">
 			<button class="ui green button">
-				{{.i18n.Tr "settings.add_key"}}
+				{{.locale.Tr "settings.add_key"}}
 			</button>
 			<button class="ui hide-panel button" data-panel="#add-gpg-key-panel">
-				{{.i18n.Tr "cancel"}}
+				{{.locale.Tr "cancel"}}
 			</button>
 		</form>
 	</div>
 	<div class="ui key list mt-0">
 		<div class="item">
-			{{.i18n.Tr "settings.gpg_desc"}}
+			{{.locale.Tr "settings.gpg_desc"}}
 		</div>
 		{{range .GPGKeys}}
 			<div class="item">
 				<div class="right floated content">
 					<button class="ui red tiny button delete-button" data-modal-id="delete-gpg" data-url="{{$.Link}}/delete?type=gpg" data-id="{{.ID}}">
-						{{$.i18n.Tr "settings.delete_key"}}
+						{{$.locale.Tr "settings.delete_key"}}
 					</button>
 					{{if and (not .Verified) (ne $.VerifyingID .KeyID)}}
-						<a class="ui primary tiny show-panel button" href="{{$.Link}}?verify_gpg={{.KeyID}}">{{$.i18n.Tr "settings.gpg_key_verify"}}</a>
+						<a class="ui primary tiny show-panel button" href="{{$.Link}}?verify_gpg={{.KeyID}}">{{$.locale.Tr "settings.gpg_key_verify"}}</a>
 					{{end}}
 				</div>
 				<div class="left floated content">
@@ -58,49 +58,49 @@
 				</div>
 				<div class="content">
 					{{if .Verified}}
-						<span class="tooltip" data-content="{{$.i18n.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-shield-check"}} <strong>{{$.i18n.Tr "settings.gpg_key_verified"}}</strong></span>
+						<span class="tooltip" data-content="{{$.locale.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-shield-check"}} <strong>{{$.locale.Tr "settings.gpg_key_verified"}}</strong></span>
 					{{end}}
 					{{if gt (len .Emails) 0}}
-						<span class="tooltip" data-content="{{$.i18n.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{$.i18n.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
+						<span class="tooltip" data-content="{{$.locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{$.locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
 					{{end}}
 					<div class="print meta">
-						<b>{{$.i18n.Tr "settings.key_id"}}:</b> {{.KeyID}}
-						<b>{{$.i18n.Tr "settings.subkeys"}}:</b> {{range .SubsKey}} {{.KeyID}} {{end}}
+						<b>{{$.locale.Tr "settings.key_id"}}:</b> {{.KeyID}}
+						<b>{{$.locale.Tr "settings.subkeys"}}:</b> {{range .SubsKey}} {{.KeyID}} {{end}}
 					</div>
 					<div class="activity meta">
-						<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.AddedUnix.FormatShort}}</span></i>
+						<i>{{$.locale.Tr "settings.add_on"}} <span>{{.AddedUnix.FormatShort}}</span></i>
 						-
-						<i>{{if not .ExpiredUnix.IsZero}}{{$.i18n.Tr "settings.valid_until"}} <span>{{.ExpiredUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.valid_forever"}}{{end}}</i>
+						<i>{{if not .ExpiredUnix.IsZero}}{{$.locale.Tr "settings.valid_until"}} <span>{{.ExpiredUnix.FormatShort}}</span>{{else}}{{$.locale.Tr "settings.valid_forever"}}{{end}}</i>
 					</div>
 				</div>
 			</div>
 			{{if and (not .Verified) (eq $.VerifyingID .KeyID)}}
 				<div class="ui  segment">
-					<h4>{{$.i18n.Tr "settings.gpg_token_required"}}</h4>
+					<h4>{{$.locale.Tr "settings.gpg_token_required"}}</h4>
 					<form class="ui form{{if $.HasGPGVerifyError}} error{{end}}" action="{{$.Link}}" method="post">
 						{{$.CsrfTokenHtml}}
 						<input type="hidden" name="title" value="none">
 						<input type="hidden" name="content" value="{{.KeyID}}">
 						<input type="hidden" name="key_id" value="{{.KeyID}}">
 						<div class="field">
-							<label for="token">{{$.i18n.Tr "settings.gpg_token"}}</label>
+							<label for="token">{{$.locale.Tr "settings.gpg_token"}}</label>
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
-								<p>{{$.i18n.Tr "settings.gpg_token_help"}}</p>
-								<p><code>{{$.i18n.Tr "settings.gpg_token_code" $.TokenToSign .KeyID}}</code></p>
+								<p>{{$.locale.Tr "settings.gpg_token_help"}}</p>
+								<p><code>{{$.locale.Tr "settings.gpg_token_code" $.TokenToSign .KeyID}}</code></p>
 							</div>
 							<br>
 						</div>
 						<div class="field">
-							<label for="signature">{{$.i18n.Tr "settings.gpg_token_signature"}}</label>
-							<textarea id="gpg-key-signature" name="signature" placeholder="{{$.i18n.Tr "settings.key_signature_gpg_placeholder"}}" required>{{$.signature}}</textarea>
+							<label for="signature">{{$.locale.Tr "settings.gpg_token_signature"}}</label>
+							<textarea id="gpg-key-signature" name="signature" placeholder="{{$.locale.Tr "settings.key_signature_gpg_placeholder"}}" required>{{$.signature}}</textarea>
 						</div>
 						<input name="type" type="hidden" value="verify_gpg">
 						<button class="ui green button">
-							{{$.i18n.Tr "settings.gpg_key_verify"}}
+							{{$.locale.Tr "settings.gpg_key_verify"}}
 						</button>
 						<a class="ui red button" href="{{$.Link}}">
-							{{$.i18n.Tr "settings.cancel"}}
+							{{$.locale.Tr "settings.cancel"}}
 						</a>
 					</form>
 				</div>
@@ -109,15 +109,15 @@
 	</div>
 </div>
 <br>
-<p>{{.i18n.Tr "settings.gpg_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/about-commit-signature-verification#gpg-commit-signature-verification" | Str2html}}</p>
+<p>{{.locale.Tr "settings.gpg_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/about-commit-signature-verification#gpg-commit-signature-verification" | Str2html}}</p>
 
 <div class="ui small basic delete modal" id="delete-gpg">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.gpg_key_deletion"}}
+		{{.locale.Tr "settings.gpg_key_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.gpg_key_deletion_desc"}}</p>
+		<p>{{.locale.Tr "settings.gpg_key_deletion_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/keys_principal.tmpl
+++ b/templates/user/settings/keys_principal.tmpl
@@ -1,31 +1,31 @@
 {{if .AllowPrincipals}}
 	<h4 class="ui top attached header">
-		{{.i18n.Tr "settings.manage_ssh_principals"}}
+		{{.locale.Tr "settings.manage_ssh_principals"}}
 		<div class="ui right">
 		{{if not .DisableSSH}}
-			<div class="ui primary tiny show-panel button" data-panel="#add-ssh-principal-panel">{{.i18n.Tr "settings.add_new_principal"}}</div>
+			<div class="ui primary tiny show-panel button" data-panel="#add-ssh-principal-panel">{{.locale.Tr "settings.add_new_principal"}}</div>
 		{{else}}
-			<div class="ui primary tiny button disabled">{{.i18n.Tr "settings.ssh_disabled"}}</div>
+			<div class="ui primary tiny button disabled">{{.locale.Tr "settings.ssh_disabled"}}</div>
 		{{end}}
 		</div>
 	</h4>
 	<div class="ui attached segment">
 		<div class="ui key list">
 			<div class="item">
-				{{.i18n.Tr "settings.principal_desc"}}
+				{{.locale.Tr "settings.principal_desc"}}
 			</div>
 			{{range .Principals}}
 				<div class="item">
 					<div class="right floated content">
 						<button class="ui red tiny button delete-button" data-modal-id="delete-principal" data-url="{{$.Link}}/delete?type=principal" data-id="{{.ID}}">
-							{{$.i18n.Tr "settings.delete_key"}}
+							{{$.locale.Tr "settings.delete_key"}}
 						</button>
 					</div>
-					<i class="big send icon {{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.principal_state_desc"}}" data-variation="inverted tiny"{{end}}></i>
+					<i class="big send icon {{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.locale.Tr "settings.principal_state_desc"}}" data-variation="inverted tiny"{{end}}></i>
 					<div class="content">
 						<strong>{{.Name}}</strong>
 						<div class="activity meta">
-							<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
+							<i>{{$.locale.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —  {{svg "octicon-info" 16}} {{if .HasUsed}}{{$.locale.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.locale.Tr "settings.no_activity"}}{{end}}</i>
 						</div>
 					</div>
 				</div>
@@ -36,19 +36,19 @@
 
 	<div {{if not .HasPrincipalError}}class="hide"{{end}} id="add-ssh-principal-panel">
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.add_new_principal"}}
+			{{.locale.Tr "settings.add_new_principal"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="field {{if .Err_Content}}error{{end}}">
-					<label for="content">{{.i18n.Tr "settings.principal_content"}}</label>
+					<label for="content">{{.locale.Tr "settings.principal_content"}}</label>
 					<input id="ssh-principal-content" name="content" value="{{.content}}" autofocus required>
 				</div>
 				<input name="title" type="hidden" value="principal">
 				<input name="type" type="hidden" value="principal">
 				<button class="ui green button">
-					{{.i18n.Tr "settings.add_new_principal"}}
+					{{.locale.Tr "settings.add_new_principal"}}
 				</button>
 			</form>
 		</div>
@@ -57,10 +57,10 @@
 	<div class="ui small basic delete modal" id="delete-principal">
 		<div class="ui icon header">
 			{{svg "octicon-trash"}}
-			{{.i18n.Tr "settings.ssh_principal_deletion"}}
+			{{.locale.Tr "settings.ssh_principal_deletion"}}
 		</div>
 		<div class="content">
-			<p>{{.i18n.Tr "settings.ssh_principal_deletion_desc"}}</p>
+			<p>{{.locale.Tr "settings.ssh_principal_deletion_desc"}}</p>
 		</div>
 		{{template "base/delete_modal_actions" .}}
 	</div>

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -1,12 +1,12 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.manage_ssh_keys"}}
+	{{.locale.Tr "settings.manage_ssh_keys"}}
 	<div class="ui right">
 		{{if not .DisableSSH }}
 			<div id="add-ssh-button" class="ui primary tiny show-panel button" data-panel="#add-ssh-key-panel">
-				{{.i18n.Tr "settings.add_key"}}
+				{{.locale.Tr "settings.add_key"}}
 			</div>
 		{{else}}
-			<div class="ui primary tiny button disabled">{{.i18n.Tr "settings.ssh_disabled"}}</div>
+			<div class="ui primary tiny button disabled">{{.locale.Tr "settings.ssh_disabled"}}</div>
 		{{end}}
 	</div>
 </h4>
@@ -15,80 +15,80 @@
 		<form class="ui form" action="{{.Link}}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="field {{if .Err_Title}}error{{end}}">
-				<label for="title">{{.i18n.Tr "settings.key_name"}}</label>
+				<label for="title">{{.locale.Tr "settings.key_name"}}</label>
 				<input id="ssh-key-title" name="title" value="{{.title}}" autofocus required>
 			</div>
 			<div class="field {{if .Err_Content}}error{{end}}">
-				<label for="content">{{.i18n.Tr "settings.key_content"}}</label>
-				<textarea id="ssh-key-content" name="content" class="js-quick-submit" placeholder="{{.i18n.Tr "settings.key_content_ssh_placeholder"}}" required>{{.content}}</textarea>
+				<label for="content">{{.locale.Tr "settings.key_content"}}</label>
+				<textarea id="ssh-key-content" name="content" class="js-quick-submit" placeholder="{{.locale.Tr "settings.key_content_ssh_placeholder"}}" required>{{.content}}</textarea>
 			</div>
 			<input name="type" type="hidden" value="ssh">
 			<button class="ui green button">
-				{{.i18n.Tr "settings.add_key"}}
+				{{.locale.Tr "settings.add_key"}}
 			</button>
 			<button id="cancel-ssh-button" class="ui hide-panel button" data-panel="#add-ssh-key-panel">
-				{{.i18n.Tr "cancel"}}
+				{{.locale.Tr "cancel"}}
 			</button>
 		</form>
 	</div>
 	<div class="ui key list mt-0">
 		<div class="item">
-			{{.i18n.Tr "settings.ssh_desc"}}
+			{{.locale.Tr "settings.ssh_desc"}}
 		</div>
 		{{range $index, $key := .Keys}}
 			<div class="item">
 				<div class="right floated content">
-					<button class="ui red tiny button delete-button{{if index $.ExternalKeys $index}} disabled{{end}}" data-modal-id="delete-ssh" data-url="{{$.Link}}/delete?type=ssh" data-id="{{.ID}}"{{if index $.ExternalKeys $index}} title="{{$.i18n.Tr "settings.ssh_externally_managed"}}"{{end}}>
-						{{$.i18n.Tr "settings.delete_key"}}
+					<button class="ui red tiny button delete-button{{if index $.ExternalKeys $index}} disabled{{end}}" data-modal-id="delete-ssh" data-url="{{$.Link}}/delete?type=ssh" data-id="{{.ID}}"{{if index $.ExternalKeys $index}} title="{{$.locale.Tr "settings.ssh_externally_managed"}}"{{end}}>
+						{{$.locale.Tr "settings.delete_key"}}
 					</button>
 					{{if and (not .Verified) (ne $.VerifyingFingerprint .Fingerprint)}}
-						<a class="ui primary tiny show-panel button" href="{{$.Link}}?verify_ssh={{.Fingerprint}}">{{$.i18n.Tr "settings.ssh_key_verify"}}</a>
+						<a class="ui primary tiny show-panel button" href="{{$.Link}}?verify_ssh={{.Fingerprint}}">{{$.locale.Tr "settings.ssh_key_verify"}}</a>
 					{{end}}
 
 				</div>
 				<div class="left floated content">
-					<span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.i18n.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32}}</span>
+					<span class="{{if .HasRecentActivity}}green{{end}}" {{if .HasRecentActivity}}data-content="{{$.locale.Tr "settings.key_state_desc"}}" data-variation="inverted tiny"{{end}}>{{svg "octicon-key" 32}}</span>
 				</div>
 				<div class="content">
 						{{if .Verified}}
-							<span class="tooltip" data-content="{{$.i18n.Tr "settings.ssh_key_verified_long"}}">{{svg "octicon-shield-check"}} <strong>{{$.i18n.Tr "settings.ssh_key_verified"}}</strong></span>
+							<span class="tooltip" data-content="{{$.locale.Tr "settings.ssh_key_verified_long"}}">{{svg "octicon-shield-check"}} <strong>{{$.locale.Tr "settings.ssh_key_verified"}}</strong></span>
 						{{end}}
 						<strong>{{.Name}}</strong>
 						<div class="print meta">
 								{{.Fingerprint}}
 						</div>
 						<div class="activity meta">
-								<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —	{{svg "octicon-info"}} {{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i>
+								<i>{{$.locale.Tr "settings.add_on"}} <span>{{.CreatedUnix.FormatShort}}</span> —	{{svg "octicon-info"}} {{if .HasUsed}}{{$.locale.Tr "settings.last_used"}} <span {{if .HasRecentActivity}}class="green"{{end}}>{{.UpdatedUnix.FormatShort}}</span>{{else}}{{$.locale.Tr "settings.no_activity"}}{{end}}</i>
 						</div>
 				</div>
 			</div>
 			{{if and (not .Verified) (eq $.VerifyingFingerprint .Fingerprint)}}
 				<div class="ui segment">
-					<h4>{{$.i18n.Tr "settings.ssh_token_required"}}</h4>
+					<h4>{{$.locale.Tr "settings.ssh_token_required"}}</h4>
 					<form class="ui form{{if $.HasSSHVerifyError}} error{{end}}" action="{{$.Link}}" method="post">
 						{{$.CsrfTokenHtml}}
 						<input type="hidden" name="title" value="none">
 						<input type="hidden" name="content" value="{{.Content}}">
 						<input type="hidden" name="fingerprint" value="{{.Fingerprint}}">
 						<div class="field">
-							<label for="token">{{$.i18n.Tr "settings.ssh_token"}}</label>
+							<label for="token">{{$.locale.Tr "settings.ssh_token"}}</label>
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
-								<p>{{$.i18n.Tr "settings.ssh_token_help"}}</p>
+								<p>{{$.locale.Tr "settings.ssh_token_help"}}</p>
 								<p><code>{{printf "echo -n '%s' | ssh-keygen -Y sign -n gitea -f /path_to_your_privkey" $.TokenToSign}}</code></p>
 							</div>
 							<br>
 						</div>
 						<div class="field">
-							<label for="signature">{{$.i18n.Tr "settings.ssh_token_signature"}}</label>
-							<textarea id="ssh-key-signature" name="signature" class="js-quick-submit" placeholder="{{$.i18n.Tr "settings.key_signature_ssh_placeholder"}}" required>{{$.signature}}</textarea>
+							<label for="signature">{{$.locale.Tr "settings.ssh_token_signature"}}</label>
+							<textarea id="ssh-key-signature" name="signature" class="js-quick-submit" placeholder="{{$.locale.Tr "settings.key_signature_ssh_placeholder"}}" required>{{$.signature}}</textarea>
 						</div>
 						<input name="type" type="hidden" value="verify_ssh">
 						<button class="ui green button">
-							{{$.i18n.Tr "settings.ssh_key_verify"}}
+							{{$.locale.Tr "settings.ssh_key_verify"}}
 						</button>
 						<a class="ui red button" href="{{$.Link}}">
-							{{$.i18n.Tr "settings.cancel"}}
+							{{$.locale.Tr "settings.cancel"}}
 						</a>
 					</form>
 				</div>
@@ -97,15 +97,15 @@
 	</div>
 </div>
 <br>
-<p>{{.i18n.Tr "settings.ssh_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/connecting-to-github-with-ssh" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/troubleshooting-ssh" | Str2html}}</p>
+<p>{{.locale.Tr "settings.ssh_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/connecting-to-github-with-ssh" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/troubleshooting-ssh" | Str2html}}</p>
 
 <div class="ui small basic delete modal" id="delete-ssh">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.ssh_key_deletion"}}
+		{{.locale.Tr "settings.ssh_key_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.ssh_key_deletion_desc"}}</p>
+		<p>{{.locale.Tr "settings.ssh_key_deletion_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -1,28 +1,28 @@
 <div class="ui secondary pointing tabular top attached borderless menu stackable new-menu navbar">
 	<div class="new-menu-inner">
 		<a class="{{if .PageIsSettingsProfile}}active{{end}} item" href="{{AppSubUrl}}/user/settings">
-			{{.i18n.Tr "settings.profile"}}
+			{{.locale.Tr "settings.profile"}}
 		</a>
 		<a class="{{if .PageIsSettingsAccount}}active{{end}} item" href="{{AppSubUrl}}/user/settings/account">
-			{{.i18n.Tr "settings.account"}}
+			{{.locale.Tr "settings.account"}}
 		</a>
 		<a class="{{if .PageIsSettingsAppearance}}active{{end}} item" href="{{AppSubUrl}}/user/settings/appearance">
-			{{.i18n.Tr "settings.appearance"}}
+			{{.locale.Tr "settings.appearance"}}
 		</a>
 		<a class="{{if .PageIsSettingsSecurity}}active{{end}} item" href="{{AppSubUrl}}/user/settings/security">
-			{{.i18n.Tr "settings.security"}}
+			{{.locale.Tr "settings.security"}}
 		</a>
 		<a class="{{if .PageIsSettingsApplications}}active{{end}} item" href="{{AppSubUrl}}/user/settings/applications">
-			{{.i18n.Tr "settings.applications"}}
+			{{.locale.Tr "settings.applications"}}
 		</a>
 		<a class="{{if .PageIsSettingsKeys}}active{{end}} item" href="{{AppSubUrl}}/user/settings/keys">
-			{{.i18n.Tr "settings.ssh_gpg_keys"}}
+			{{.locale.Tr "settings.ssh_gpg_keys"}}
 		</a>
 		<a class="{{if .PageIsSettingsOrganization}}active{{end}} item" href="{{AppSubUrl}}/user/settings/organization">
-			{{.i18n.Tr "settings.organization"}}
+			{{.locale.Tr "settings.organization"}}
 		</a>
 		<a class="{{if .PageIsSettingsRepos}}active{{end}} item" href="{{AppSubUrl}}/user/settings/repos">
-			{{.i18n.Tr "settings.repos"}}
+			{{.locale.Tr "settings.repos"}}
 		</a>
 	</div>
 </div>

--- a/templates/user/settings/organization.tmpl
+++ b/templates/user/settings/organization.tmpl
@@ -4,10 +4,10 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.orgs"}}
+			{{.locale.Tr "settings.orgs"}}
 			{{if .SignedUser.CanCreateOrganization}}
 			<div class="ui right">
-				<a class="ui primary tiny button" href="{{AppSubUrl}}/org/create">{{.i18n.Tr "admin.orgs.new_orga"}}</a>
+				<a class="ui primary tiny button" href="{{AppSubUrl}}/org/create">{{.locale.Tr "admin.orgs.new_orga"}}</a>
 			</div>
 			{{end}}
 		</h4>
@@ -19,7 +19,7 @@
 						<div class="right floated content">
 							<form method="post" action="{{.OrganisationLink}}/members/action/leave">
 								{{$.CsrfTokenHtml}}
-								<button type="submit" class="ui primary small button" name="uid" value="{{.ID}}">{{$.i18n.Tr "org.members.leave"}}</button>
+								<button type="submit" class="ui primary small button" name="uid" value="{{.ID}}">{{$.locale.Tr "org.members.leave"}}</button>
 							</form>
 						</div>
 						{{avatar . 28 "mini"}}
@@ -31,7 +31,7 @@
 				</div>
 				{{template "base/paginate" .}}
 			{{else}}
-				{{.i18n.Tr "settings.orgs_none"}}
+				{{.locale.Tr "settings.orgs_none"}}
 			{{end}}
 		</div>
 	</div>

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -4,46 +4,46 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.public_profile"}}
+			{{.locale.Tr "settings.public_profile"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "settings.profile_desc"}}</p>
+			<p>{{.locale.Tr "settings.profile_desc"}}</p>
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="required field {{if .Err_Name}}error{{end}}">
-					<label for="username">{{.i18n.Tr "username"}}
-						<span class="text red hide" id="name-change-prompt"> {{.i18n.Tr "settings.change_username_prompt"}}</span>
-						<span class="text red hide" id="name-change-redirect-prompt"> {{.i18n.Tr "settings.change_username_redirect_prompt"}}</span>
+					<label for="username">{{.locale.Tr "username"}}
+						<span class="text red hide" id="name-change-prompt"> {{.locale.Tr "settings.change_username_prompt"}}</span>
+						<span class="text red hide" id="name-change-redirect-prompt"> {{.locale.Tr "settings.change_username_redirect_prompt"}}</span>
 					</label>
 					<input id="username" name="name" value="{{.SignedUser.Name}}" data-name="{{.SignedUser.Name}}" autofocus required {{if or (not .SignedUser.IsLocal) .IsReverseProxy}}disabled{{end}}>
 					{{if or (not .SignedUser.IsLocal) .IsReverseProxy}}
-					<p class="help text blue">{{$.i18n.Tr "settings.password_username_disabled"}}</p>
+					<p class="help text blue">{{$.locale.Tr "settings.password_username_disabled"}}</p>
 					{{end}}
 				</div>
 				<div class="field {{if .Err_FullName}}error{{end}}">
-					<label for="full_name">{{.i18n.Tr "settings.full_name"}}</label>
+					<label for="full_name">{{.locale.Tr "settings.full_name"}}</label>
 					<input id="full_name" name="full_name" value="{{.SignedUser.FullName}}">
 				</div>
 				<div class="field {{if .Err_Email}}error{{end}}">
-					<label for="email">{{.i18n.Tr "email"}}</label>
+					<label for="email">{{.locale.Tr "email"}}</label>
 					<p>{{.SignedUser.Email}}</p>
 				</div>
 				<div class="inline field">
 					<div class="ui checkbox" id="keep-email-private">
-						<label class="tooltip" data-content="{{.i18n.Tr "settings.keep_email_private_popup"}}"><strong>{{.i18n.Tr "settings.keep_email_private"}}</strong></label>
+						<label class="tooltip" data-content="{{.locale.Tr "settings.keep_email_private_popup"}}"><strong>{{.locale.Tr "settings.keep_email_private"}}</strong></label>
 						<input name="keep_email_private" type="checkbox" {{if .SignedUser.KeepEmailPrivate}}checked{{end}}>
 					</div>
 				</div>
 				<div class="field {{if .Err_Description}}error{{end}}">
-					<label for="description">{{$.i18n.Tr "user.user_bio"}}</label>
-					<textarea id="description" name="description" rows="2" placeholder="{{.i18n.Tr "settings.biography_placeholder"}}">{{.SignedUser.Description}}</textarea>
+					<label for="description">{{$.locale.Tr "user.user_bio"}}</label>
+					<textarea id="description" name="description" rows="2" placeholder="{{.locale.Tr "settings.biography_placeholder"}}">{{.SignedUser.Description}}</textarea>
 				</div>
 				<div class="field {{if .Err_Website}}error{{end}}">
-					<label for="website">{{.i18n.Tr "settings.website"}}</label>
+					<label for="website">{{.locale.Tr "settings.website"}}</label>
 					<input id="website" name="website" type="url" value="{{.SignedUser.Website}}">
 				</div>
 				<div class="field">
-					<label for="location">{{.i18n.Tr "settings.location"}}</label>
+					<label for="location">{{.locale.Tr "settings.location"}}</label>
 					<input id="location" name="location"  value="{{.SignedUser.Location}}">
 				</div>
 
@@ -51,29 +51,29 @@
 				<!-- private block -->
 
 				<div class="field">
-					<label for="security-private"><strong>{{.i18n.Tr "settings.privacy"}}</strong></label>
+					<label for="security-private"><strong>{{.locale.Tr "settings.privacy"}}</strong></label>
 				</div>
 
 				<div class="inline field {{if .Err_Visibility}}error{{end}}">
-					<span class="inline required field"><label for="visibility">{{.i18n.Tr "settings.visibility"}}</label></span>
+					<span class="inline required field"><label for="visibility">{{.locale.Tr "settings.visibility"}}</label></span>
 					<div class="ui selection type dropdown">
 						{{if .SignedUser.Visibility.IsPublic}}<input type="hidden" id="visibility" name="visibility" value="0">{{end}}
 						{{if .SignedUser.Visibility.IsLimited}}<input type="hidden" id="visibility" name="visibility" value="1">{{end}}
 						{{if .SignedUser.Visibility.IsPrivate}}<input type="hidden" id="visibility" name="visibility" value="2">{{end}}
 						<div class="text">
-							{{if .SignedUser.Visibility.IsPublic}}{{.i18n.Tr "settings.visibility.public"}}{{end}}
-							{{if .SignedUser.Visibility.IsLimited}}{{.i18n.Tr "settings.visibility.limited"}}{{end}}
-							{{if .SignedUser.Visibility.IsPrivate}}{{.i18n.Tr "settings.visibility.private"}}{{end}}
+							{{if .SignedUser.Visibility.IsPublic}}{{.locale.Tr "settings.visibility.public"}}{{end}}
+							{{if .SignedUser.Visibility.IsLimited}}{{.locale.Tr "settings.visibility.limited"}}{{end}}
+							{{if .SignedUser.Visibility.IsPrivate}}{{.locale.Tr "settings.visibility.private"}}{{end}}
 						</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 						<div class="menu">
 							{{range $mode := .AllowedUserVisibilityModes}}
 								{{if $mode.IsPublic}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.i18n.Tr "settings.visibility.public"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.public_tooltip"}}" data-value="0">{{$.locale.Tr "settings.visibility.public"}}</div>
 								{{else if $mode.IsLimited}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.i18n.Tr "settings.visibility.limited"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.limited_tooltip"}}" data-value="1">{{$.locale.Tr "settings.visibility.limited"}}</div>
 								{{else if $mode.IsPrivate}}
-									<div class="item tooltip" data-content="{{$.i18n.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.i18n.Tr "settings.visibility.private"}}</div>
+									<div class="item tooltip" data-content="{{$.locale.Tr "settings.visibility.private_tooltip"}}" data-value="2">{{$.locale.Tr "settings.visibility.private"}}</div>
 								{{end}}
 							{{end}}
 						</div>
@@ -82,7 +82,7 @@
 
 				<div class="field">
 					<div class="ui checkbox" id="keep-activity-private">
-						<label class="tooltip" data-content="{{.i18n.Tr "settings.keep_activity_private_popup"}}"><strong>{{.i18n.Tr "settings.keep_activity_private"}}</strong></label>
+						<label class="tooltip" data-content="{{.locale.Tr "settings.keep_activity_private_popup"}}"><strong>{{.locale.Tr "settings.keep_activity_private"}}</strong></label>
 						<input name="keep_activity_private" type="checkbox" {{if .SignedUser.KeepActivityPrivate}}checked{{end}}>
 					</div>
 				</div>
@@ -90,13 +90,13 @@
 				<div class="ui divider"></div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_profile"}}</button>
+					<button class="ui green button">{{$.locale.Tr "settings.update_profile"}}</button>
 				</div>
 			</form>
 		</div>
 
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.avatar"}}
+			{{.locale.Tr "settings.avatar"}}
 		</h4>
 		<div class="ui attached segment">
 			<form class="ui form" action="{{.Link}}/avatar" method="post" enctype="multipart/form-data">
@@ -105,11 +105,11 @@
 				<div class="inline field">
 					<div class="ui radio checkbox">
 						<input name="source" value="lookup" type="radio" {{if not .SignedUser.UseCustomAvatar}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.lookup_avatar_by_mail"}}</label>
+						<label>{{.locale.Tr "settings.lookup_avatar_by_mail"}}</label>
 					</div>
 				</div>
 				<div class="field {{if .Err_Gravatar}}error{{end}}">
-					<label for="gravatar">Avatar {{.i18n.Tr "email"}}</label>
+					<label for="gravatar">Avatar {{.locale.Tr "email"}}</label>
 					<input id="gravatar" name="gravatar" value="{{.SignedUser.AvatarEmail}}" />
 				</div>
 				{{end}}
@@ -117,18 +117,18 @@
 				<div class="inline field">
 					<div class="ui radio checkbox">
 						<input name="source" value="local" type="radio" {{if .SignedUser.UseCustomAvatar}}checked{{end}}>
-						<label>{{.i18n.Tr "settings.enable_custom_avatar"}}</label>
+						<label>{{.locale.Tr "settings.enable_custom_avatar"}}</label>
 					</div>
 				</div>
 
 				<div class="inline field">
-					<label for="avatar">{{.i18n.Tr "settings.choose_new_avatar"}}</label>
+					<label for="avatar">{{.locale.Tr "settings.choose_new_avatar"}}</label>
 					<input name="avatar" type="file" >
 				</div>
 
 				<div class="field">
-					<button class="ui green button">{{$.i18n.Tr "settings.update_avatar"}}</button>
-					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.i18n.Tr "settings.delete_current_avatar"}}</a>
+					<button class="ui green button">{{$.locale.Tr "settings.update_avatar"}}</button>
+					<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.locale.Tr "settings.delete_current_avatar"}}</a>
 				</div>
 			</form>
 		</div>

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.repos"}}
+			{{.locale.Tr "settings.repos"}}
 		</h4>
 		<div class="ui attached segment">
 			{{if or .allowAdopt .allowDelete}}
@@ -29,7 +29,7 @@
 										<a class="name" href="{{$repo.Link}}">{{$repo.OwnerName}}/{{$repo.Name}}</a>
 										<span>{{FileSize $repo.Size}}</span>
 										{{if $repo.IsFork}}
-											{{$.i18n.Tr "repo.forked_from"}}
+											{{$.locale.Tr "repo.forked_from"}}
 											<span><a href="{{$repo.BaseRepo.Link}}">{{$repo.BaseRepo.OwnerName}}/{{$repo.BaseRepo.Name}}</a></span>
 										{{end}}
 									{{else}}
@@ -37,14 +37,14 @@
 										<span class="name">{{$.Owner.Name}}/{{$dir}}</span>
 										<div class="right floated content">
 											{{if $.allowAdopt}}
-												<button class="ui button submit tiny green adopt show-modal" data-modal="#adopt-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-plus"}}</span><span class="label">{{$.i18n.Tr "repo.adopt_preexisting_label"}}</span></button>
+												<button class="ui button submit tiny green adopt show-modal" data-modal="#adopt-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-plus"}}</span><span class="label">{{$.locale.Tr "repo.adopt_preexisting_label"}}</span></button>
 												<div class="ui basic modal" id="adopt-unadopted-modal-{{$dirI}}">
 													{{svg "octicon-x" 16 "close inside"}}
 													<div class="header">
-														<span class="label">{{$.i18n.Tr "repo.adopt_preexisting"}}</span>
+														<span class="label">{{$.locale.Tr "repo.adopt_preexisting"}}</span>
 													</div>
 													<div class="content">
-														<p>{{$.i18n.Tr "repo.adopt_preexisting_content" $dir}}</p>
+														<p>{{$.locale.Tr "repo.adopt_preexisting_content" $dir}}</p>
 													</div>
 													<form class="ui form" method="POST" action="{{AppSubUrl}}/user/settings/repos/unadopted">
 														{{$.CsrfTokenHtml}}
@@ -53,25 +53,25 @@
 														<div class="actions">
 															<div class="ui red basic inverted cancel button">
 																<i class="remove icon"></i>
-																{{$.i18n.Tr "modal.no"}}
+																{{$.locale.Tr "modal.no"}}
 															</div>
 															<button class="ui green basic inverted ok button">
 																<i class="checkmark icon"></i>
-																{{$.i18n.Tr "modal.yes"}}
+																{{$.locale.Tr "modal.yes"}}
 															</button>
 														</div>
 													</form>
 												</div>
 											{{end}}
 											{{if $.allowDelete}}
-												<button class="ui button submit tiny red delete show-modal" data-modal="#delete-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-x"}}</span><span class="label">{{$.i18n.Tr "repo.delete_preexisting_label"}}</span></button>
+												<button class="ui button submit tiny red delete show-modal" data-modal="#delete-unadopted-modal-{{$dirI}}"><span class="icon">{{svg "octicon-x"}}</span><span class="label">{{$.locale.Tr "repo.delete_preexisting_label"}}</span></button>
 												<div class="ui basic modal" id="delete-unadopted-modal-{{$dirI}}">
 													{{svg "octicon-x" 16 "close inside"}}
 													<div class="header">
-														<span class="label">{{$.i18n.Tr "repo.delete_preexisting"}}</span>
+														<span class="label">{{$.locale.Tr "repo.delete_preexisting"}}</span>
 													</div>
 													<div class="content">
-														<p>{{$.i18n.Tr "repo.delete_preexisting_content" $dir}}</p>
+														<p>{{$.locale.Tr "repo.delete_preexisting_content" $dir}}</p>
 													</div>
 													<form class="ui form" method="POST" action="{{AppSubUrl}}/user/settings/repos/unadopted">
 														{{$.CsrfTokenHtml}}
@@ -80,11 +80,11 @@
 														<div class="actions">
 															<div class="ui red basic inverted cancel button">
 																<i class="remove icon"></i>
-																{{$.i18n.Tr "modal.no"}}
+																{{$.locale.Tr "modal.no"}}
 															</div>
 															<button class="ui green basic inverted ok button">
 																<i class="checkmark icon"></i>
-																{{$.i18n.Tr "modal.yes"}}
+																{{$.locale.Tr "modal.yes"}}
 															</button>
 														</div>
 													</form>
@@ -99,7 +99,7 @@
 					{{template "base/paginate" .}}
 				{{else}}
 					<div class="item">
-						{{.i18n.Tr "settings.repos_none"}}
+						{{.locale.Tr "settings.repos_none"}}
 					</div>
 				{{end}}
 			{{else}}
@@ -122,7 +122,7 @@
 									<a class="name" href="{{.Link}}">{{.OwnerName}}/{{.Name}}</a>
 									<span>{{FileSize .Size}}</span>
 									{{if .IsFork}}
-										{{$.i18n.Tr "repo.forked_from"}}
+										{{$.locale.Tr "repo.forked_from"}}
 										<span><a href="{{.BaseRepo.Link}}">{{.BaseRepo.OwnerName}}/{{.BaseRepo.Name}}</a></span>
 									{{end}}
 								</div>
@@ -132,7 +132,7 @@
 					{{template "base/paginate" .}}
 				{{else}}
 					<div class="item">
-						{{.i18n.Tr "settings.repos_none"}}
+						{{.locale.Tr "settings.repos_none"}}
 					</div>
 				{{end}}
 			{{end}}
@@ -143,10 +143,10 @@
 <div class="ui small basic delete modal">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.remove_account_link"}}
+		{{.locale.Tr "settings.remove_account_link"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.remove_account_link_desc"}}</p>
+		<p>{{.locale.Tr "settings.remove_account_link_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/security/accountlinks.tmpl
+++ b/templates/user/settings/security/accountlinks.tmpl
@@ -1,9 +1,9 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.manage_account_links"}}
+	{{.locale.Tr "settings.manage_account_links"}}
 	{{if .OrderedOAuth2Names}}
 		<div class="ui right">
 			<div class="ui dropdown">
-				<div class="ui primary tiny button">{{.i18n.Tr "settings.link_account"}}</div>
+				<div class="ui primary tiny button">{{.locale.Tr "settings.link_account"}}</div>
 				<div class="menu">
 					{{range $key := .OrderedOAuth2Names}}
 						{{$provider := index $.OAuth2Providers $key}}
@@ -21,19 +21,19 @@
 <div class="ui attached segment">
 	<div class="ui key list">
 		<div class="item">
-			{{.i18n.Tr "settings.manage_account_links_desc"}}
+			{{.locale.Tr "settings.manage_account_links_desc"}}
 		</div>
 		{{if .AccountLinks}}
 			{{range $loginSource, $provider := .AccountLinks}}
 				<div class="item">
 					<div class="right floated content">
 							<button class="ui red tiny button delete-button" data-modal-id="delete-account-link" data-url="{{AppSubUrl}}/user/settings/security/account_link" data-id="{{$loginSource.ID}}">
-								{{$.i18n.Tr "settings.delete_key"}}
+								{{$.locale.Tr "settings.delete_key"}}
 							</button>
 					</div>
 					<div class="content">
 						<strong>{{$provider}}</strong>
-						{{if $loginSource.IsActive}}<span class="text red">{{$.i18n.Tr "settings.active"}}</span>{{end}}
+						{{if $loginSource.IsActive}}<span class="text red">{{$.locale.Tr "settings.active"}}</span>{{end}}
 					</div>
 				</div>
 			{{end}}
@@ -44,10 +44,10 @@
 <div class="ui small basic delete modal" id="delete-account-link">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.remove_account_link"}}
+		{{.locale.Tr "settings.remove_account_link"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.remove_account_link_desc"}}</p>
+		<p>{{.locale.Tr "settings.remove_account_link_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/security/openid.tmpl
+++ b/templates/user/settings/security/openid.tmpl
@@ -1,16 +1,16 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.manage_openid"}}
+	{{.locale.Tr "settings.manage_openid"}}
 </h4>
 <div class="ui attached segment">
 	<div class="ui openid list">
 		<div class="item">
-			{{.i18n.Tr "settings.openid_desc"}}
+			{{.locale.Tr "settings.openid_desc"}}
 		</div>
 		{{range .OpenIDs}}
 			<div class="item">
 				<div class="right floated content">
 						<button class="ui red tiny button delete-button" data-modal-id="delete-openid" data-url="{{AppSubUrl}}/user/settings/security/openid/delete" data-id="{{.ID}}">
-							{{$.i18n.Tr "settings.delete_key"}}
+							{{$.locale.Tr "settings.delete_key"}}
 						</button>
 				</div>
 					<div class="right floated content">
@@ -20,12 +20,12 @@
 						{{if .Show}}
 							<button class="ui tiny button">
 							{{svg "octicon-eye" 16 "icon"}}
-							{{$.i18n.Tr "settings.hide_openid"}}
+							{{$.locale.Tr "settings.hide_openid"}}
 							</button>
 						{{else}}
 							<button class="ui tiny button">
 							{{svg "octicon-eye-closed" 16 "icon"}}
-							{{$.i18n.Tr "settings.show_openid"}}
+							{{$.locale.Tr "settings.show_openid"}}
 							</button>
 						{{end}}
 						</button>
@@ -42,11 +42,11 @@
 	<form class="ui form" action="{{AppSubUrl}}/user/settings/security/openid" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_OpenID}}error{{end}}">
-			<label for="openid">{{.i18n.Tr "settings.add_new_openid"}}</label>
+			<label for="openid">{{.locale.Tr "settings.add_new_openid"}}</label>
 			<input id="openid" name="openid" type="text" required>
 		</div>
 		<button class="ui green button">
-			{{.i18n.Tr "settings.add_openid"}}
+			{{.locale.Tr "settings.add_openid"}}
 		</button>
 	</form>
 </div>
@@ -54,10 +54,10 @@
 <div class="ui small basic delete modal" id="delete-openid">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.openid_deletion"}}
+		{{.locale.Tr "settings.openid_deletion"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.openid_deletion_desc"}}</p>
+		<p>{{.locale.Tr "settings.openid_deletion_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/security/twofa.tmpl
+++ b/templates/user/settings/security/twofa.tmpl
@@ -1,24 +1,24 @@
 <h4 class="ui top attached header">
-	{{.i18n.Tr "settings.twofa"}}
+	{{.locale.Tr "settings.twofa"}}
 </h4>
 <div class="ui attached segment">
-	<p>{{.i18n.Tr "settings.twofa_desc"}}</p>
+	<p>{{.locale.Tr "settings.twofa_desc"}}</p>
 	{{if .TOTPEnrolled}}
-	<p>{{$.i18n.Tr "settings.twofa_is_enrolled" | Str2html }}</p>
+	<p>{{$.locale.Tr "settings.twofa_is_enrolled" | Str2html }}</p>
 	<form class="ui form" action="{{AppSubUrl}}/user/settings/security/two_factor/regenerate_scratch" method="post" enctype="multipart/form-data">
 		{{.CsrfTokenHtml}}
-		<p>{{.i18n.Tr "settings.regenerate_scratch_token_desc"}}</p>
-		<button class="ui primary button">{{$.i18n.Tr "settings.twofa_scratch_token_regenerate"}}</button>
+		<p>{{.locale.Tr "settings.regenerate_scratch_token_desc"}}</p>
+		<button class="ui primary button">{{$.locale.Tr "settings.twofa_scratch_token_regenerate"}}</button>
 	</form>
 	<form class="ui form" action="{{AppSubUrl}}/user/settings/security/two_factor/disable" method="post" enctype="multipart/form-data" id="disable-form">
 		{{.CsrfTokenHtml}}
-		<p>{{.i18n.Tr "settings.twofa_disable_note"}}</p>
-		<div class="ui red button delete-button" data-modal-id="disable-twofa" data-type="form" data-form="#disable-form">{{$.i18n.Tr "settings.twofa_disable"}}</div>
+		<p>{{.locale.Tr "settings.twofa_disable_note"}}</p>
+		<div class="ui red button delete-button" data-modal-id="disable-twofa" data-type="form" data-form="#disable-form">{{$.locale.Tr "settings.twofa_disable"}}</div>
 	</form>
 	{{else}}
-	<p>{{.i18n.Tr "settings.twofa_not_enrolled"}}</p>
+	<p>{{.locale.Tr "settings.twofa_not_enrolled"}}</p>
 	<div class="inline field">
-		<a class="ui green button" href="{{AppSubUrl}}/user/settings/security/two_factor/enroll">{{$.i18n.Tr "settings.twofa_enroll"}}</a>
+		<a class="ui green button" href="{{AppSubUrl}}/user/settings/security/two_factor/enroll">{{$.locale.Tr "settings.twofa_enroll"}}</a>
 	</div>
 	{{end}}
 </div>
@@ -26,10 +26,10 @@
 <div class="ui small basic delete modal" id="disable-twofa">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-		{{.i18n.Tr "settings.twofa_disable"}}
+		{{.locale.Tr "settings.twofa_disable"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.twofa_disable_desc"}}</p>
+		<p>{{.locale.Tr "settings.twofa_disable_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>

--- a/templates/user/settings/security/twofa_enroll.tmpl
+++ b/templates/user/settings/security/twofa_enroll.tmpl
@@ -4,22 +4,22 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		<h4 class="ui top attached header">
-			{{.i18n.Tr "settings.twofa_enroll"}}
+			{{.locale.Tr "settings.twofa_enroll"}}
 		</h4>
 		<div class="ui attached segment">
-			<p>{{.i18n.Tr "settings.scan_this_image"}}</p>
+			<p>{{.locale.Tr "settings.scan_this_image"}}</p>
 			<img src="{{.QrUri}}" alt="{{.TwofaSecret}}">
-			<p>{{.i18n.Tr "settings.or_enter_secret" .TwofaSecret}}
-			<p>{{.i18n.Tr "settings.then_enter_passcode"}}
+			<p>{{.locale.Tr "settings.or_enter_secret" .TwofaSecret}}
+			<p>{{.locale.Tr "settings.then_enter_passcode"}}
 			<form class="ui form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div class="inline required field {{if .Err_Passcode}}error{{end}}">
-					<label for="passcode">{{.i18n.Tr "passcode"}}</label>
+					<label for="passcode">{{.locale.Tr "passcode"}}</label>
 					<input id="passcode" name="passcode" autofocus required>
 				</div>
 				<div class="inline field">
 					<label></label>
-					<button class="ui green button">{{.i18n.Tr "auth.verify"}}</button>
+					<button class="ui green button">{{.locale.Tr "auth.verify"}}</button>
 				</div>
 			</form>
 		</div>

--- a/templates/user/settings/security/webauthn.tmpl
+++ b/templates/user/settings/security/webauthn.tmpl
@@ -1,30 +1,30 @@
 <h4 class="ui top attached header">
-{{.i18n.Tr "settings.webauthn"}}
+{{.locale.Tr "settings.webauthn"}}
 </h4>
 <div class="ui attached segment">
-	<p>{{.i18n.Tr "settings.webauthn_desc" | Str2html}}</p>
+	<p>{{.locale.Tr "settings.webauthn_desc" | Str2html}}</p>
 	<div class="ui key list">
 		{{range .WebAuthnCredentials}}
 			<div class="item">
 				<div class="right floated content">
 					<button class="ui red tiny button delete-button" data-modal-id="delete-registration" data-url="{{$.Link}}/webauthn/delete" data-id="{{.ID}}">
-					{{$.i18n.Tr "settings.delete_key"}}
+					{{$.locale.Tr "settings.delete_key"}}
 					</button>
 				</div>
 				<div class="content">
 					<strong>{{.Name}}</strong>
 				</div>
-				<span class="time">{{TimeSinceUnix .CreatedUnix $.i18n}}</span>
+				<span class="time">{{TimeSinceUnix .CreatedUnix $.locale}}</span>
 			</div>
 		{{end}}
 	</div>
 	<div class="ui form">
 		{{.CsrfTokenHtml}}
 		<div class="required field">
-			<label for="nickname">{{.i18n.Tr "settings.webauthn_nickname"}}</label>
+			<label for="nickname">{{.locale.Tr "settings.webauthn_nickname"}}</label>
 			<input id="nickname" name="nickname" type="text" required>
 		</div>
-		<button id="register-webauthn" class="ui green button">{{svg "octicon-key"}} {{.i18n.Tr "settings.webauthn_register_key"}}</button>
+		<button id="register-webauthn" class="ui green button">{{svg "octicon-key"}} {{.locale.Tr "settings.webauthn_register_key"}}</button>
 	</div>
 </div>
 
@@ -33,10 +33,10 @@
 <div class="ui small basic delete modal" id="delete-registration">
 	<div class="ui icon header">
 		{{svg "octicon-trash"}}
-	{{.i18n.Tr "settings.webauthn_delete_key"}}
+	{{.locale.Tr "settings.webauthn_delete_key"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "settings.webauthn_delete_key_desc"}}</p>
+		<p>{{.locale.Tr "settings.webauthn_delete_key_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>


### PR DESCRIPTION
- Currently we're using the `i18n` variable naming for the `locale` struct. This contains locale's specific information and cannot be used for general i18n purpose, therefore refactoring it to `locale` makes more sense.
- Ref: https://github.com/go-gitea/gitea/pull/20096#discussion_r906699200

## :warning: BREAKING :warning:

Users who have custom templates needs to replace `.i18n` occurrences with `.locale`.