### PR TITLE
Make i18n live-reload work for default language and write-lock-free if no change

### DIFF
--- a/modules/translation/i18n/i18n.go
+++ b/modules/translation/i18n/i18n.go
@@ -157,6 +157,8 @@ func (l *locale) tryTr(trKey string, trArgs ...interface{}) (msg string, found b
 				} else {
 					log.Error("unable to live-reload the locale file %q, err: %v", l.sourceFileName, err)
 				}
+			} else if err != nil {
+				log.Error("unable to stat the locale file %q, err: %v", l.sourceFileName, err)
 			}
 			l.store.reloadMu.Unlock() // release the write-lock
 			l.store.reloadMu.RLock()  // and re-acquire the read-lock, which was managed by outer Tr function

--- a/modules/translation/i18n/i18n.go
+++ b/modules/translation/i18n/i18n.go
@@ -147,10 +147,11 @@ func (l *locale) tryTr(trKey string, trArgs ...interface{}) (msg string, found b
 	if l.store.reloadMu != nil {
 		now := time.Now()
 		if now.Sub(l.lastReloadCheckTime) >= time.Second && l.sourceFileInfo != nil && l.sourceFileName != "" {
+			sourceFileInfo, err := os.Stat(l.sourceFileName)
 			l.store.reloadMu.RUnlock() // if the locale file should be reloaded, then we release the read-lock
 			l.store.reloadMu.Lock()    // and acquire the write-lock
 			l.lastReloadCheckTime = now
-			if sourceFileInfo, err := os.Stat(l.sourceFileName); err == nil && !sourceFileInfo.ModTime().Equal(l.sourceFileInfo.ModTime()) {
+			if err == nil && !sourceFileInfo.ModTime().Equal(l.sourceFileInfo.ModTime()) {
 				if err = l.store.reloadLocaleByIni(l.langName, l.sourceFileName); err == nil {
 					l.sourceFileInfo = sourceFileInfo
 				} else {

--- a/modules/translation/i18n/i18n.go
+++ b/modules/translation/i18n/i18n.go
@@ -138,6 +138,13 @@ func (l *locale) Tr(trKey string, trArgs ...interface{}) string {
 	if l.store.reloadMu != nil {
 		l.store.reloadMu.Lock()
 		defer l.store.reloadMu.Unlock()
+	}
+	msg, _ := l.tryTr(trKey, trArgs...)
+	return msg
+}
+
+func (l *locale) tryTr(trKey string, trArgs ...interface{}) (msg string, found bool) {
+	if l.store.reloadMu != nil {
 		now := time.Now()
 		if now.Sub(l.lastReloadCheckTime) >= time.Second && l.sourceFileInfo != nil && l.sourceFileName != "" {
 			l.lastReloadCheckTime = now
@@ -150,11 +157,6 @@ func (l *locale) Tr(trKey string, trArgs ...interface{}) string {
 			}
 		}
 	}
-	msg, _ := l.tryTr(trKey, trArgs...)
-	return msg
-}
-
-func (l *locale) tryTr(trKey string, trArgs ...interface{}) (msg string, found bool) {
 	trMsg := trKey
 	textIdx, ok := l.store.textIdxMap[trKey]
 	if ok {


### PR DESCRIPTION
In #20096, I was going to make the live-reload for for fallback default language. But at that time I forgot this detail.

This PR fixes it, makes i18n live-reload work for the fallback default language.

Relation (difference) between #20159:

* #20159 uses a more complex approach (more mutexes and more code +100 lines) to lock everything. ~~It makes the concurrency better in development mode~~ update: it seems no difference now.

* This PR uses a shared mutex to lock everything. No data-race problem, and it's very simple to be maintained in future. In development mode, there is no need for many mutexes, a shared RWMutex should work and in most time there is no write-lock, then no concurrency performance problem, so it's not worth to make code too complex.

These two PRs should have no performance difference for production mode. And they all behave the same in development mode for concurrency accesses.


Personally I usually consider about Return on Investment (ROI) and like simple approaches, so I just put the fix here, let community to choose a preferred approach. Feel free to edit on it / replace it / close it.

----

Update: This PR describes whether one mutex works, so the variable names are not refactored. The renaming in #20159 (eg: `textMap` => `idxToMsgMap`) is more clear than before
