### PR TITLE
Fix `dump-repo` git init, fix wrong error type for NullDownloader

### DIFF
--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/convert"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	base "code.gitea.io/gitea/modules/migration"
 	"code.gitea.io/gitea/modules/setting"
@@ -80,6 +81,11 @@ func runDumpRepository(ctx *cli.Context) error {
 	defer cancel()
 
 	if err := initDB(stdCtx); err != nil {
+		return err
+	}
+
+	// migrations.GiteaLocalUploader depends on git module
+	if err := git.InitSimple(context.Background()); err != nil {
 		return err
 	}
 

--- a/modules/indexer/code/elastic_search.go
+++ b/modules/indexer/code/elastic_search.go
@@ -284,7 +284,7 @@ func (b *ElasticSearchIndexer) Index(ctx context.Context, repo *repo_model.Repos
 	reqs := make([]elastic.BulkableRequest, 0)
 	if len(changes.Updates) > 0 {
 		// Now because of some insanity with git cat-file not immediately failing if not run in a valid git directory we need to run git rev-parse first!
-		if err := git.EnsureValidGitRepository(git.DefaultContext, repo.RepoPath()); err != nil {
+		if err := git.EnsureValidGitRepository(ctx, repo.RepoPath()); err != nil {
 			log.Error("Unable to open git repo: %s for %-v: %v", repo.RepoPath(), repo, err)
 			return err
 		}

--- a/modules/migration/null_downloader.go
+++ b/modules/migration/null_downloader.go
@@ -19,52 +19,52 @@ func (n NullDownloader) SetContext(_ context.Context) {}
 
 // GetRepoInfo returns a repository information
 func (n NullDownloader) GetRepoInfo() (*Repository, error) {
-	return nil, &ErrNotSupported{Entity: "RepoInfo"}
+	return nil, ErrNotSupported{Entity: "RepoInfo"}
 }
 
 // GetTopics return repository topics
 func (n NullDownloader) GetTopics() ([]string, error) {
-	return nil, &ErrNotSupported{Entity: "Topics"}
+	return nil, ErrNotSupported{Entity: "Topics"}
 }
 
 // GetMilestones returns milestones
 func (n NullDownloader) GetMilestones() ([]*Milestone, error) {
-	return nil, &ErrNotSupported{Entity: "Milestones"}
+	return nil, ErrNotSupported{Entity: "Milestones"}
 }
 
 // GetReleases returns releases
 func (n NullDownloader) GetReleases() ([]*Release, error) {
-	return nil, &ErrNotSupported{Entity: "Releases"}
+	return nil, ErrNotSupported{Entity: "Releases"}
 }
 
 // GetLabels returns labels
 func (n NullDownloader) GetLabels() ([]*Label, error) {
-	return nil, &ErrNotSupported{Entity: "Labels"}
+	return nil, ErrNotSupported{Entity: "Labels"}
 }
 
 // GetIssues returns issues according start and limit
 func (n NullDownloader) GetIssues(page, perPage int) ([]*Issue, bool, error) {
-	return nil, false, &ErrNotSupported{Entity: "Issues"}
+	return nil, false, ErrNotSupported{Entity: "Issues"}
 }
 
 // GetComments returns comments of an issue or PR
 func (n NullDownloader) GetComments(commentable Commentable) ([]*Comment, bool, error) {
-	return nil, false, &ErrNotSupported{Entity: "Comments"}
+	return nil, false, ErrNotSupported{Entity: "Comments"}
 }
 
 // GetAllComments returns paginated comments
 func (n NullDownloader) GetAllComments(page, perPage int) ([]*Comment, bool, error) {
-	return nil, false, &ErrNotSupported{Entity: "AllComments"}
+	return nil, false, ErrNotSupported{Entity: "AllComments"}
 }
 
 // GetPullRequests returns pull requests according page and perPage
 func (n NullDownloader) GetPullRequests(page, perPage int) ([]*PullRequest, bool, error) {
-	return nil, false, &ErrNotSupported{Entity: "PullRequests"}
+	return nil, false, ErrNotSupported{Entity: "PullRequests"}
 }
 
 // GetReviews returns pull requests review
 func (n NullDownloader) GetReviews(reviewable Reviewable) ([]*Review, error) {
-	return nil, &ErrNotSupported{Entity: "Reviews"}
+	return nil, ErrNotSupported{Entity: "Reviews"}
 }
 
 // FormatCloneURL add authentication into remote URLs


### PR DESCRIPTION
Found a new dependency of git module.

The `dump-repo` sub-command should initialize the git module before calling git commands.

And NullDownloader returned wrong error type, which stops dump-repo command, it's fixed together.

ps: keeping the `var git.DefaultContext = nil` is by purpose, it will help to find all uninitialized calls to git module.