### PR TITLE
Fix cli command restore-repo: "units" should be parsed as cli.String

### DIFF
--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -128,7 +128,9 @@ func runDumpRepository(ctx *cli.Context) error {
 	} else {
 		units := strings.Split(ctx.String("units"), ",")
 		for _, unit := range units {
-			switch strings.ToLower(unit) {
+			switch strings.ToLower(strings.TrimSpace(unit)) {
+			case "":
+				continue
 			case "wiki":
 				opts.Wiki = true
 			case "issues":
@@ -145,6 +147,8 @@ func runDumpRepository(ctx *cli.Context) error {
 				opts.Comments = true
 			case "pull_requests":
 				opts.PullRequests = true
+			default:
+				return errors.New("invalid unit: " + unit)
 			}
 		}
 	}

--- a/cmd/restore_repo.go
+++ b/cmd/restore_repo.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/private"
@@ -37,10 +38,10 @@ var CmdRestoreRepository = cli.Command{
 			Value: "",
 			Usage: "Restore destination repository name",
 		},
-		cli.StringSliceFlag{
+		cli.StringFlag{
 			Name:  "units",
-			Value: nil,
-			Usage: `Which items will be restored, one or more units should be repeated with this flag.
+			Value: "",
+			Usage: `Which items will be restored, one or more units should be separated as comma.
 wiki, issues, labels, releases, release_assets, milestones, pull_requests, comments are allowed. Empty means all units.`,
 		},
 		cli.BoolFlag{
@@ -55,13 +56,16 @@ func runRestoreRepository(c *cli.Context) error {
 	defer cancel()
 
 	setting.LoadFromExisting()
-
+	var units []string
+	if s := c.String("units"); s != "" {
+		units = strings.Split(s, ",")
+	}
 	statusCode, errStr := private.RestoreRepo(
 		ctx,
 		c.String("repo_dir"),
 		c.String("owner_name"),
 		c.String("repo_name"),
-		c.StringSlice("units"),
+		units,
 		c.Bool("validation"),
 	)
 	if statusCode == http.StatusOK {

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -590,7 +590,7 @@ func updateOptionsUnits(opts *base.MigrateOptions, units []string) error {
 		opts.ReleaseAssets = true
 	} else {
 		for _, unit := range units {
-			switch strings.ToLower(unit) {
+			switch strings.ToLower(strings.TrimSpace(unit)) {
 			case "":
 				continue
 			case "wiki":


### PR DESCRIPTION
The "units" should be splitted to string slice, to match the old behavior and match the `dump-repo`'s behavior https://github.com/go-gitea/gitea/blob/main/cmd/dump_repo.go#L129-L130

Before, the #19953 was misled by #19935 (sorry that I didn't find the problem at that time, just followed these 3 LGTMs).

This PR should make everything correct and consistent, and more stable by trimming / checking
