### PR TITLE
discarded, wrong branch, (backport Fix `dump-repo` git init)

### DIFF
--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/convert"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	base "code.gitea.io/gitea/modules/migration"
 	"code.gitea.io/gitea/modules/setting"
@@ -80,6 +81,11 @@ func runDumpRepository(ctx *cli.Context) error {
 	defer cancel()
 
 	if err := initDB(stdCtx); err != nil {
+		return err
+	}
+
+	// migrations.GiteaLocalUploader depends on git module
+	if err := git.InitSimple(context.Background()); err != nil {
 		return err
 	}
 

--- a/modules/indexer/code/elastic_search.go
+++ b/modules/indexer/code/elastic_search.go
@@ -284,7 +284,7 @@ func (b *ElasticSearchIndexer) Index(ctx context.Context, repo *repo_model.Repos
 	reqs := make([]elastic.BulkableRequest, 0)
 	if len(changes.Updates) > 0 {
 		// Now because of some insanity with git cat-file not immediately failing if not run in a valid git directory we need to run git rev-parse first!
-		if err := git.EnsureValidGitRepository(git.DefaultContext, repo.RepoPath()); err != nil {
+		if err := git.EnsureValidGitRepository(ctx, repo.RepoPath()); err != nil {
 			log.Error("Unable to open git repo: %s for %-v: %v", repo.RepoPath(), repo, err)
 			return err
 		}


### PR DESCRIPTION
Backport #20182

The dump-repo sub-command should initialize the git module before calling git commands.