### PR TITLE
Refix indices on actions table (#20158)

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -92,11 +92,11 @@ func init() {
 
 // TableIndices implements xorm's TableIndices interface
 func (a *Action) TableIndices() []*schemas.Index {
+	repoIndex := schemas.NewIndex("r_u_d", schemas.IndexType)
+	repoIndex.AddColumn("repo_id", "user_id", "is_deleted")
+
 	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
 	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
-
-	repoIndex := schemas.NewIndex("r_c_u_d", schemas.IndexType)
-	repoIndex.AddColumn("repo_id", "created_unix", "user_id", "is_deleted")
 
 	return []*schemas.Index{actUserIndex, repoIndex}
 }

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -56,6 +56,9 @@ type Version struct {
 	Version int64
 }
 
+// Use noopMigration when there is a migration that has been no-oped
+var noopMigration = func(_ *xorm.Engine) error { return nil }
+
 // This is a sequence of migrations. Add new migrations to the bottom of the list.
 // If you want to "retire" a migration, remove it from the top of the list and
 // update minDBVersion accordingly
@@ -351,7 +354,7 @@ var migrations = []Migration{
 	// v198 -> v199
 	NewMigration("Add issue content history table", addTableIssueContentHistory),
 	// v199 -> v200
-	NewMigration("No-op (remote version is using AppState now)", addRemoteVersionTableNoop),
+	NewMigration("No-op (remote version is using AppState now)", noopMigration),
 	// v200 -> v201
 	NewMigration("Add table app_state", addTableAppState),
 	// v201 -> v202
@@ -388,9 +391,11 @@ var migrations = []Migration{
 	// v215 -> v216
 	NewMigration("allow to view files in PRs", addReviewViewedFiles),
 	// v216 -> v217
-	NewMigration("Improve Action table indices", improveActionTableIndices),
+	NewMigration("No-op (Improve Action table indices v1)", noopMigration),
 	// v217 -> v218
 	NewMigration("Alter hook_task table TEXT fields to LONGTEXT", alterHookTaskTextFieldsToLongText),
+	// v218 -> v219
+	NewMigration("Improve Action table indices v2", improveActionTableIndices),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v199.go
+++ b/models/migrations/v199.go
@@ -4,11 +4,4 @@
 
 package migrations
 
-import (
-	"xorm.io/xorm"
-)
-
-func addRemoteVersionTableNoop(x *xorm.Engine) error {
-	// we used to use a table `remote_version` to store information for updater, now we use `AppState`, so this migration task is a no-op now.
-	return nil
-}
+// We used to use a table `remote_version` to store information for updater, now we use `AppState`, so this migration task is a no-op now.

--- a/models/migrations/v216.go
+++ b/models/migrations/v216.go
@@ -4,43 +4,5 @@
 
 package migrations
 
-import (
-	"code.gitea.io/gitea/modules/timeutil"
-
-	"xorm.io/xorm"
-	"xorm.io/xorm/schemas"
-)
-
-type improveActionTableIndicesAction struct {
-	ID          int64 `xorm:"pk autoincr"`
-	UserID      int64 // Receiver user id.
-	OpType      int
-	ActUserID   int64 // Action user id.
-	RepoID      int64
-	CommentID   int64 `xorm:"INDEX"`
-	IsDeleted   bool  `xorm:"NOT NULL DEFAULT false"`
-	RefName     string
-	IsPrivate   bool               `xorm:"NOT NULL DEFAULT false"`
-	Content     string             `xorm:"TEXT"`
-	CreatedUnix timeutil.TimeStamp `xorm:"created"`
-}
-
-// TableName sets the name of this table
-func (a *improveActionTableIndicesAction) TableName() string {
-	return "action"
-}
-
-// TableIndices implements xorm's TableIndices interface
-func (a *improveActionTableIndicesAction) TableIndices() []*schemas.Index {
-	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
-	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
-
-	repoIndex := schemas.NewIndex("r_c_u_d", schemas.IndexType)
-	repoIndex.AddColumn("repo_id", "created_unix", "user_id", "is_deleted")
-
-	return []*schemas.Index{actUserIndex, repoIndex}
-}
-
-func improveActionTableIndices(x *xorm.Engine) error {
-	return x.Sync2(&improveActionTableIndicesAction{})
-}
+// This migration added non-ideal indices to the action table which on larger datasets slowed things down
+// it has been superceded by v218.go

--- a/models/migrations/v218.go
+++ b/models/migrations/v218.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"code.gitea.io/gitea/modules/timeutil"
+
+	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
+)
+
+type improveActionTableIndicesAction struct {
+	ID          int64 `xorm:"pk autoincr"`
+	UserID      int64 // Receiver user id.
+	OpType      int
+	ActUserID   int64 // Action user id.
+	RepoID      int64
+	CommentID   int64 `xorm:"INDEX"`
+	IsDeleted   bool  `xorm:"NOT NULL DEFAULT false"`
+	RefName     string
+	IsPrivate   bool               `xorm:"NOT NULL DEFAULT false"`
+	Content     string             `xorm:"TEXT"`
+	CreatedUnix timeutil.TimeStamp `xorm:"created"`
+}
+
+// TableName sets the name of this table
+func (*improveActionTableIndicesAction) TableName() string {
+	return "action"
+}
+
+// TableIndices implements xorm's TableIndices interface
+func (*improveActionTableIndicesAction) TableIndices() []*schemas.Index {
+	repoIndex := schemas.NewIndex("r_u_d", schemas.IndexType)
+	repoIndex.AddColumn("repo_id", "user_id", "is_deleted")
+
+	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
+	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
+
+	return []*schemas.Index{actUserIndex, repoIndex}
+}
+
+func improveActionTableIndices(x *xorm.Engine) error {
+	return x.Sync2(&improveActionTableIndicesAction{})
+}


### PR DESCRIPTION
Backport #20158

Unforunately the previous PR #20035 created indices that were not helpful
for SQLite. This PR adjusts these after testing using the try.gitea.io db.

Fix #20129

Signed-off-by: Andrew Thornton <art27@cantab.net>
