### PR TITLE
Allow enable LDAP source and disable user sync via CLI

### DIFF
--- a/cmd/admin_auth_ldap.go
+++ b/cmd/admin_auth_ldap.go
@@ -34,6 +34,10 @@ var (
 			Name:  "not-active",
 			Usage: "Deactivate the authentication source.",
 		},
+		cli.BoolFlag{
+			Name:  "active",
+			Usage: "Activate the authentication source.",
+		},
 		cli.StringFlag{
 			Name:  "security-protocol",
 			Usage: "Security protocol name.",
@@ -117,6 +121,10 @@ var (
 			Name:  "synchronize-users",
 			Usage: "Enable user synchronization.",
 		},
+		cli.BoolFlag{
+			Name:  "disable-synchronize-users",
+			Usage: "Disable user synchronization.",
+		},
 		cli.UintFlag{
 			Name:  "page-size",
 			Usage: "Search page size.",
@@ -183,8 +191,14 @@ func parseAuthSource(c *cli.Context, authSource *auth.Source) {
 	if c.IsSet("not-active") {
 		authSource.IsActive = !c.Bool("not-active")
 	}
+	if c.IsSet("active") {
+		authSource.IsActive = c.Bool("active")
+	}
 	if c.IsSet("synchronize-users") {
 		authSource.IsSyncEnabled = c.Bool("synchronize-users")
+	}
+	if c.IsSet("disable-synchronize-users") {
+		authSource.IsSyncEnabled = !c.Bool("disable-synchronize-users")
 	}
 }
 

--- a/cmd/admin_auth_ldap_test.go
+++ b/cmd/admin_auth_ldap_test.go
@@ -858,6 +858,36 @@ func TestUpdateLdapBindDn(t *testing.T) {
 			},
 			errMsg: "Invalid authentication type. expected: LDAP (via BindDN), actual: OAuth2",
 		},
+		// case 24
+		{
+			args: []string{
+				"ldap-test",
+				"--id", "24",
+				"--name", "ldap (via Bind DN) flip 'active' and 'user sync' attributes",
+				"--active",
+				"--disable-synchronize-users",
+			},
+			id: 24,
+			existingAuthSource: &auth.Source{
+				Type:          auth.LDAP,
+				IsActive:      false,
+				IsSyncEnabled: true,
+				Cfg: &ldap.Source{
+					Name:    "ldap (via Bind DN) flip 'active' and 'user sync' attributes",
+					Enabled: true,
+				},
+			},
+			authSource: &auth.Source{
+				Type:          auth.LDAP,
+				Name:          "ldap (via Bind DN) flip 'active' and 'user sync' attributes",
+				IsActive:      true,
+				IsSyncEnabled: false,
+				Cfg: &ldap.Source{
+					Name:    "ldap (via Bind DN) flip 'active' and 'user sync' attributes",
+					Enabled: true,
+				},
+			},
+		},
 	}
 
 	for n, c := range cases {
@@ -1220,6 +1250,33 @@ func TestUpdateLdapSimpleAuth(t *testing.T) {
 				Cfg:  &ldap.Source{},
 			},
 			errMsg: "Invalid authentication type. expected: LDAP (simple auth), actual: PAM",
+		},
+		// case 20
+		{
+			args: []string{
+				"ldap-test",
+				"--id", "20",
+				"--name", "ldap (simple auth) flip 'active' attribute",
+				"--active",
+			},
+			id: 20,
+			existingAuthSource: &auth.Source{
+				Type:          auth.DLDAP,
+				IsActive:      false,
+				Cfg: &ldap.Source{
+					Name:    "ldap (simple auth) flip 'active' attribute",
+					Enabled: true,
+				},
+			},
+			authSource: &auth.Source{
+				Type:          auth.DLDAP,
+				Name:          "ldap (simple auth) flip 'active' attribute",
+				IsActive:      true,
+				Cfg: &ldap.Source{
+					Name:    "ldap (simple auth) flip 'active' attribute",
+					Enabled: true,
+				},
+			},
 		},
 	}
 

--- a/cmd/admin_auth_ldap_test.go
+++ b/cmd/admin_auth_ldap_test.go
@@ -1261,17 +1261,17 @@ func TestUpdateLdapSimpleAuth(t *testing.T) {
 			},
 			id: 20,
 			existingAuthSource: &auth.Source{
-				Type:          auth.DLDAP,
-				IsActive:      false,
+				Type:     auth.DLDAP,
+				IsActive: false,
 				Cfg: &ldap.Source{
 					Name:    "ldap (simple auth) flip 'active' attribute",
 					Enabled: true,
 				},
 			},
 			authSource: &auth.Source{
-				Type:          auth.DLDAP,
-				Name:          "ldap (simple auth) flip 'active' attribute",
-				IsActive:      true,
+				Type:     auth.DLDAP,
+				Name:     "ldap (simple auth) flip 'active' attribute",
+				IsActive: true,
 				Cfg: &ldap.Source{
 					Name:    "ldap (simple auth) flip 'active' attribute",
 					Enabled: true,


### PR DESCRIPTION
The current `admin auth` CLI for managing authentication source of type
LDAP via BindDN and Simple LDAP does not allow enabling the respective
source, once disabled via `--not-active`.
The same applies to `--synchronize-users` specifially for LDAP via
BindDN.

These changes add two new flags to LDAP related CLI commands:

- `--active` for both LDAP authentication source types
- `--disable-synchronize-users` for LDAP via BindDN

Signed-off-by: justusbunsi <61625851+justusbunsi@users.noreply.github.com>
