### PR TITLE
Adjust class for mobile has the problem of double small bells

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -114,7 +114,7 @@
 				</div>
 			</div>
 
-			<a href="{{AppSubUrl}}/notifications" class="m-4 ac text black tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
+			<a href="{{AppSubUrl}}/notifications" class="m-4 text black tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
 				<span class="text">
 					<span class="fitted">{{svg "octicon-bell"}}</span>
 					<span class="ui red label {{if not $notificationUnreadCount}}hidden{{end}} notification_count">

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -114,7 +114,7 @@
 				</div>
 			</div>
 
-			<a href="{{AppSubUrl}}/notifications" class="item tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
+			<a href="{{AppSubUrl}}/notifications" class="m-4 ac text black tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
 				<span class="text">
 					<span class="fitted">{{svg "octicon-bell"}}</span>
 					<span class="ui red label {{if not $notificationUnreadCount}}hidden{{end}} notification_count">


### PR DESCRIPTION
Sorry, I didn't notice that the item class has a display property, and I will see two small bells on the phone
for #20069 improve

Before:
![image](https://user-images.githubusercontent.com/1255041/177232998-66ee31eb-6446-48b7-a4db-43262dbd5605.png)

After:
![image](https://user-images.githubusercontent.com/1255041/177233191-3c490a57-1de5-4c3d-be41-688adae14390.png)


