### PR TITLE
Fix dashboard switching on Mobile (#20238)

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -75,30 +75,32 @@
 		{{end}}
 
 	{{if .ContextUser.IsOrganization}}
-		<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{.ContextUser.DashboardLink}}{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-			{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
-		</a>
-		{{if not .UnitIssuesGlobalDisabled}}
-		<a class="{{if .PageIsIssues}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/issues{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-			{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
-		</a>
-		{{end}}
-			{{if not .UnitPullsGlobalDisabled}}
-		<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-			{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
-		</a>
-		{{end}}
-		{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
-		<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/milestones{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-			{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
-		</a>
-		{{end}}
-		<div class="item">
-			<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
-				{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 40)}}
+		<div class="right stackable menu">
+			<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{.ContextUser.DashboardLink}}{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+				{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
 			</a>
+			{{if not .UnitIssuesGlobalDisabled}}
+			<a class="{{if .PageIsIssues}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/issues{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+				{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
+			</a>
+			{{end}}
+			{{if not .UnitPullsGlobalDisabled}}
+			<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+				{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
+			</a>
+			{{end}}
+			{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
+			<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/milestones{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+				{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
+			</a>
+			{{end}}
+			<div class="item">
+				<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
+					{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 40)}}
+				</a>
 			</div>
-		{{end}}
+		</div>
+	{{end}}
 	</div>
 </div>
 <div class="ui divider"></div>

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -75,32 +75,30 @@
 		{{end}}
 
 	{{if .ContextUser.IsOrganization}}
-		<div class="right stackable menu">
-			<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{.ContextUser.DashboardLink}}{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
-			</a>
-			{{if not .UnitIssuesGlobalDisabled}}
-			<a class="{{if .PageIsIssues}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/issues{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
-			</a>
-			{{end}}
+		<a class="{{if .PageIsNews}}active{{end}} item" style="margin-left: auto" href="{{.ContextUser.DashboardLink}}{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+			{{svg "octicon-rss"}}&nbsp;{{.i18n.Tr "activities"}}
+		</a>
+		{{if not .UnitIssuesGlobalDisabled}}
+		<a class="{{if .PageIsIssues}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/issues{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+			{{svg "octicon-issue-opened"}}&nbsp;{{.i18n.Tr "issues"}}
+		</a>
+		{{end}}
 			{{if not .UnitPullsGlobalDisabled}}
-			<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
+		<a class="{{if .PageIsPulls}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/pulls{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+			{{svg "octicon-git-pull-request"}}&nbsp;{{.i18n.Tr "pull_requests"}}
+		</a>
+		{{end}}
+		{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
+		<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/milestones{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
+			{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
+		</a>
+		{{end}}
+		<div class="item">
+			<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
+				{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 40)}}
 			</a>
-			{{end}}
-			{{if and .ShowMilestonesDashboardPage (not (and .UnitIssuesGlobalDisabled .UnitPullsGlobalDisabled))}}
-			<a class="{{if .PageIsMilestonesDashboard}}active{{end}} item" href="{{.ContextUser.OrganisationLink}}/milestones{{if .Team}}/{{PathEscape .Team.Name}}{{end}}">
-				{{svg "octicon-milestone"}}&nbsp;{{.i18n.Tr "milestones"}}
-			</a>
-			{{end}}
-			<div class="item">
-				<a class="ui primary basic button" href="{{.ContextUser.HomeLink}}" title='{{.i18n.Tr "home.view_home" .ContextUser.Name}}'>
-					{{.i18n.Tr "home.view_home" (.ContextUser.ShortName 40)}}
-				</a>
 			</div>
-		</div>
-	{{end}}
+		{{end}}
 	</div>
 </div>
 <div class="ui divider"></div>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2194,7 +2194,7 @@ table th[data-sortt-desc] {
   .ui.stackable.menu:not(.no-vertical-tabs) {
     overflow-y: hidden;
     overflow-x: auto;
-    flex-direction: row !important;
+    flex-direction: row;
     flex-wrap: nowrap !important;
 
     .item {
@@ -2203,6 +2203,10 @@ table th[data-sortt-desc] {
 
     > .dropdown.item {
       position: initial;
+    }
+
+    .menu {
+      flex-direction: row;
     }
   }
 }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2194,7 +2194,7 @@ table th[data-sortt-desc] {
   .ui.stackable.menu:not(.no-vertical-tabs) {
     overflow-y: hidden;
     overflow-x: auto;
-    flex-direction: row;
+    flex-direction: row !important;
     flex-wrap: nowrap !important;
 
     .item {

--- a/web_src/less/_dashboard.less
+++ b/web_src/less/_dashboard.less
@@ -83,8 +83,8 @@
       max-width: 100%;
 
       @media @mediaSm {
-        > .menu:not(.hidden) {
-          position: inherit;
+        > .menu {
+          position: static;
         }
       }
     }

--- a/web_src/less/_dashboard.less
+++ b/web_src/less/_dashboard.less
@@ -81,6 +81,12 @@
 
     .ui.dropdown {
       max-width: 100%;
+
+      @media @mediaSm {
+        > .menu:not(.hidden) {
+          position: inherit;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Backport #20238
  - This is a regression of improving mobile experience on Gitea, currently organization dashboard aren't readable and the popup won't show up when you want to switch between users/organization(as we saw in #19978).
  - This patch fixes that, by allowing the popup to allocate the required pixels(for some absurd reason, z-index doesn't work on the popup, so it's not able to render over the existing elements, we can investigate later of why this is). And also remove the additional dropdown menu for the pages link, so it's one unified list which then can be displayed as rows.
  - See original PR for screenshots.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
