### PR TITLE
Adjust max-widths for the repository file table (#20243)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -352,11 +352,31 @@
         overflow: initial;
 
         &.name {
-          max-width: 150px;
+          @media @mediaXl {
+            max-width: 150px;
+          }
+          @media @mediaLg {
+            max-width: 200px;
+          }
+          @media @mediaMd {
+            max-width: 300px;
+          }
+          width: 33%;
+
+          max-width: calc(100vw - 140px);
         }
 
         &.message {
-          max-width: 400px;
+          @media @mediaXl {
+            max-width: 400px;
+          }
+          @media @mediaLg {
+            max-width: 350px;
+          }
+          @media @mediaMd {
+            max-width: 250px;
+          }
+          width: 66%;
         }
 
         &.age {


### PR DESCRIPTION
Backport #20243

Adjust the max-widths for the repository file table to allow for nicer
resizing of the names and commit messages.

Fix #20040

Signed-off-by: Andrew Thornton <art27@cantab.net>

 ## Screenshots

 ## MediaXL
![Screenshot from 2022-07-05 10-22-12](https://user-images.githubusercontent.com/1824502/177295867-7ba8cf60-8f61-4227-892f-e5a0477e4146.png)

 ## MediaLg
![Screenshot from 2022-07-05 10-24-37](https://user-images.githubusercontent.com/1824502/177296301-e066e206-10f7-4a15-a68b-0f772a95f369.png)

 ## MediaMd
![Screenshot from 2022-07-05 10-23-03](https://user-images.githubusercontent.com/1824502/177295965-69397649-16ca-456a-bc0c-ed507fcb7f44.png)

 ## MediaSm
![Screenshot from 2022-07-05 10-26-44](https://user-images.githubusercontent.com/1824502/177296700-ca2a853b-c47b-4592-baf4-4bc08a7e1c9c.png)

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
