### PR TITLE
Refix notification bell placement

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -114,7 +114,7 @@
 				</div>
 			</div>
 
-			<a href="{{AppSubUrl}}/notifications" class="m-4 text black tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
+			<a href="{{AppSubUrl}}/notifications" class="item tooltip not-mobile" data-content='{{.locale.Tr "notifications"}}'>
 				<span class="text">
 					<span class="fitted">{{svg "octicon-bell"}}</span>
 					<span class="ui red label {{if not $notificationUnreadCount}}hidden{{end}} notification_count">

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1329,7 +1329,7 @@ footer {
 @media @mediaMdAndUp {
   .mobile-only,
   .ui.button.mobile-only {
-    display: none;
+    display: none !important;
   }
 
   // has the same behaviour of sr-only, hiding the content for
@@ -1341,7 +1341,7 @@ footer {
 
 @media @mediaSm {
   .not-mobile {
-    display: none;
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
The use of `m-4 text black` for the notification bell results in this
icon being shifted upwards. Instead we should use the `item` class but
adjust `not-mobile` and `mobile-only` to make their `display: none`
settings `!important`.

(As an aside: This is probably one of the only times we should use
`!important` in our less files and the rest should be avoided or
removed.)

Ref #20069
Revert #20236
Fix #20245

Signed-off-by: Andrew Thornton <art27@cantab.net>
