### PR TITLE
EscapeFilter the group dn membership (#20200)

### DIFF
--- a/services/auth/source/ldap/source_search.go
+++ b/services/auth/source/ldap/source_search.go
@@ -199,7 +199,7 @@ func checkRestricted(l *ldap.Conn, ls *Source, userDN string) bool {
 // List all group memberships of a user
 func (ls *Source) listLdapGroupMemberships(l *ldap.Conn, uid string) []string {
 	var ldapGroups []string
-	groupFilter := fmt.Sprintf("(%s=%s)", ls.GroupMemberUID, uid)
+	groupFilter := fmt.Sprintf("(%s=%s)", ls.GroupMemberUID, ldap.EscapeFilter(uid))
 	result, err := l.Search(ldap.NewSearchRequest(
 		ls.GroupDN,
 		ldap.ScopeWholeSubtree,


### PR DESCRIPTION
Backport #20200

The uid provided to the group filter must be properly escaped using the provided
ldap.EscapeFilter function.

Fix #20181

Signed-off-by: Andrew Thornton <art27@cantab.net>
