### PR TITLE
test demonstrating orphaned process are not killed with their parent

### DIFF
--- a/modules/process/manager_exec_test.go
+++ b/modules/process/manager_exec_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func retry(t *testing.T, fun func() error, tries int) {
+	var err interface{}
+	for i := 0; i < tries; i++ {
+		err = fun()
+		if err == nil {
+			return
+		}
+		<-time.After(1 * time.Second)
+	}
+	assert.Fail(t, fmt.Sprintf("Retry: failed \n%v", err))
+}
+
+func TestManagerKillGrandChildren(t *testing.T) {
+	tmp := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pm := &Manager{
+		processMap: make(map[IDType]*process),
+		next:       1,
+	}
+
+	go func() {
+		// blocks forever because of the firewall at 4.4.4.4
+		_, _, _ = pm.ExecDir(ctx, -1, tmp, "GIT description", "git", "clone", "https://4.4.4.4", "something")
+	}()
+
+	// the git clone process forks a grand child git-remote-https, wait for it
+	pattern := "git-remote-https origin https://4.4.4.4"
+	ps := func() string {
+		cmd := exec.Command("ps", "-x", "-o", "pid,ppid,pgid,args")
+		output, err := cmd.CombinedOutput()
+		assert.NoError(t, err)
+		return string(output)
+	}
+
+	retry(t, func() error {
+		out := ps()
+		if !strings.Contains(out, pattern) {
+			return fmt.Errorf(out + "Does not contain " + pattern)
+		}
+		return nil
+	}, 5)
+
+	// canceling the parent context will cause the child process to be killed
+	cancel()
+	<-ctx.Done()
+
+	// wait for the git-remote-https grand child process to terminate
+	retry(t, func() error {
+		out := ps()
+		if strings.Contains(out, pattern) {
+			return fmt.Errorf(out + "Contains " + pattern)
+		}
+		return nil
+	}, 5)
+}


### PR DESCRIPTION
This test fails and demonstrates that when Gitea kills one of its children (for instance when mirroring a repository timesout), the grand children are not killed and become orphaned that linger and will eventually become zombies.

This is explained in detail in these blog posts:

* https://hostea.org/blog/zombies/
* https://hostea.org/blog/zombies-part-2/

I'd be happy to work on implementing a bug fix for Gitea.

```bash
...
[unit-test:115]         	            	  16511       1   16494 /usr/libexec/git-core/git remote-https origin https://4.4.4.4
[unit-test:116]         	            	  16513   16511   16494 /usr/libexec/git-core/git-remote-https origin https://4.4.4.4
...
[unit-test:120]         	            	  17165   16486       1 ps -x -o pid,ppid,pgid,args
[unit-test:121]         	            	Contains git-remote-https origin https://4.4.4.4
[unit-test:122]         	Test:       	TestManagerKillGrandChildren
[unit-test:123] FAIL
[unit-test:124] coverage: 35.5% of statements
[unit-test:125] FAIL	code.gitea.io/gitea/modules/process	6.518s
```

This [test fails and demonstrates](https://drone.gitea.io/go-gitea/gitea/57147/2/12) that when...

---
This PR is from [@dachary](https://lab.forgefriends.org/dachary) of the [forgefriends project](https://forgefriends.org). Please see [here](https://lab.forgefriends.org/forgefriends/forgefriends/-/merge_requests/54) for origin.
