### PR TITLE
Modify milestone search keywords to be case insensitive

### DIFF
--- a/models/issues/milestone.go
+++ b/models/issues/milestone.go
@@ -361,7 +361,7 @@ func (opts GetMilestonesOption) toCond() builder.Cond {
 	}
 
 	if len(opts.Name) != 0 {
-		cond = cond.And(builder.Like{"name", opts.Name})
+		cond = cond.And(builder.Like{"UPPER(name)", strings.ToUpper(opts.Name)})
 	}
 
 	return cond


### PR DESCRIPTION
Milestone search keywords are now sensitive, this modification is changed to insensitive