### PR TITLE
Store read access in access for team repositories (#20275)

### DIFF
--- a/models/perm/access/access.go
+++ b/models/perm/access/access.go
@@ -86,7 +86,13 @@ func updateUserAccess(accessMap map[int64]*userAccess, user *user_model.User, mo
 // FIXME: do cross-comparison so reduce deletions and additions to the minimum?
 func refreshAccesses(ctx context.Context, repo *repo_model.Repository, accessMap map[int64]*userAccess) (err error) {
 	minMode := perm.AccessModeRead
-	if !repo.IsPrivate {
+	if err := repo.GetOwner(ctx); err != nil {
+		return fmt.Errorf("GetOwner: %v", err)
+	}
+
+	// If the repo isn't private and isn't owned by a organization,
+	// increase the minMode to Write.
+	if !repo.IsPrivate && !repo.Owner.IsOrganization() {
 		minMode = perm.AccessModeWrite
 	}
 


### PR DESCRIPTION
- Backport #20275
  - Currently when a Team has read access to a organization's non-private repository, their access(in the `access` table) won't be stored in the database. This cause issues for code that rely on read access being stored, like retrieving all users who have read permission to that repository(even though this is confusing as this doesn't include all registered users). So from now-on if we see that the repository is owned by a organization don't increase the `minMode` to write permission.
  - Resolves #20083

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
