### PR TITLE
Fix NPE when using non-numeric (#20277)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -841,9 +841,10 @@ func issueIndexPatternProcessor(ctx *RenderContext, node *html.Node) {
 
 		// Repos with external issue trackers might still need to reference local PRs
 		// We need to concern with the first one that shows up in the text, whichever it is
-		if hasExtTrackFormat && !isNumericStyle {
+		if hasExtTrackFormat && !isNumericStyle && refNumeric != nil {
 			// If numeric (PR) was found, and it was BEFORE the non-numeric pattern, use that
-			if foundNumeric && refNumeric.RefLocation.Start < ref.RefLocation.Start {
+			// Allow a free-pass when non-numeric pattern wasn't found.
+			if found && (ref == nil || refNumeric.RefLocation.Start < ref.RefLocation.Start) {
 				found = foundNumeric
 				ref = refNumeric
 			}


### PR DESCRIPTION
- Backport (#20277
  - This code is only valid when `refNumeric` exist(otherwise we didn't find such numeric PR and can skip that check) and give a free-pas to the  "BEFORE" check when `ref` is nil.
  - Resolves #20109

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
