### PR TITLE
Fix commit status icon when in subdirectory

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -856,7 +856,7 @@ func renderDirectoryFiles(ctx *context.Context, timeout time.Duration) git.Entri
 		ctx.Data["LatestCommitUser"] = user_model.ValidateCommitWithEmail(latestCommit)
 	}
 
-	statuses, _, err := git_model.GetLatestCommitStatus(ctx, ctx.Repo.Repository.ID, ctx.Repo.Commit.ID.String(), db.ListOptions{})
+	statuses, _, err := git_model.GetLatestCommitStatus(ctx, ctx.Repo.Repository.ID, latestCommit.ID.String(), db.ListOptions{})
 	if err != nil {
 		log.Error("GetLatestCommitStatus: %v", err)
 	}


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/20285 to 1.17.