### PR TITLE
Use git.HOME_PATH for Git HOME directory (#20114)

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -617,7 +617,10 @@ ROUTER = console
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; The path of git executable. If empty, Gitea searches through the PATH environment.
-PATH =
+;PATH =
+;;
+;; The HOME directory for Git
+;HOME_PATH = %(APP_DATA_PATH)/home
 ;;
 ;; Disables highlight of added and removed changes
 ;DISABLE_DIFF_HIGHLIGHT = false

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -947,6 +947,8 @@ Default templates for project boards:
 ## Git (`git`)
 
 - `PATH`: **""**: The path of Git executable. If empty, Gitea searches through the PATH environment.
+- `HOME_PATH`: **%(APP_DATA_PATH)/home**: The HOME directory for Git.
+	  This directory will be used to contain the `.gitconfig` and possible `.gnupg` directories that Gitea's git calls will use. If you can confirm Gitea is the only application running in this environment, you can set it to the normal home directory for Gitea user.
 - `DISABLE_DIFF_HIGHLIGHT`: **false**: Disables highlight of added and removed changes.
 - `MAX_GIT_DIFF_LINES`: **1000**: Max number of lines allowed of a single file in diff view.
 - `MAX_GIT_DIFF_LINE_CHARACTERS`: **5000**: Max character count per line highlighted in diff view.

--- a/docs/content/doc/advanced/signing.en-us.md
+++ b/docs/content/doc/advanced/signing.en-us.md
@@ -97,10 +97,11 @@ repositories, `SIGNING_KEY=default` could be used to provide different
 signing keys on a per-repository basis. However, this is clearly not an
 ideal UI and therefore subject to change.
 
-**Since 1.17**, Gitea runs git in its own home directory `[repository].ROOT` and uses its own config `{[repository].ROOT}/.gitconfig`.
+**Since 1.17**, Gitea runs git in its own home directory `[git].HOME_PATH` (default to `%(APP_DATA_PATH)/home`)
+and uses its own config `{[git].HOME_PATH}/.gitconfig`.
 If you have your own customized git config for Gitea, you should set these configs in system git config (aka `/etc/gitconfig`)
-or the Gitea internal git config `{[repository].ROOT}/.gitconfig`. 
-Related home files for git command (like `.gnupg`) should also be put in Gitea's git home directory `[repository].ROOT`. 
+or the Gitea internal git config `{[git].HOME_PATH}/.gitconfig`. 
+Related home files for git command (like `.gnupg`) should also be put in Gitea's git home directory `[git].HOME_PATH`. 
 
 
 ### `INITIAL_COMMIT`

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -107,6 +107,8 @@ func MainTest(m *testing.M, testOpts *TestOptions) {
 
 	setting.Packages.Storage.Path = filepath.Join(setting.AppDataPath, "packages")
 
+	setting.Git.HomePath = filepath.Join(setting.AppDataPath, "home")
+
 	if err = storage.Init(); err != nil {
 		fatalTestError("storage.Init: %v\n", err)
 	}

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -19,7 +20,6 @@ import (
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
-
 	"github.com/hashicorp/go-version"
 )
 
@@ -126,8 +126,8 @@ func VersionInfo() string {
 }
 
 func checkInit() error {
-	if setting.RepoRootPath == "" {
-		return errors.New("can not init Git's HomeDir (RepoRootPath is empty), the setting and git modules are not initialized correctly")
+	if setting.Git.HomePath == "" {
+		return errors.New("unable to init Git's HomeDir, incorrect initialization of the setting and git modules")
 	}
 	if DefaultContext != nil {
 		log.Warn("git module has been initialized already, duplicate init should be fixed")
@@ -137,14 +137,14 @@ func checkInit() error {
 
 // HomeDir is the home dir for git to store the global config file used by Gitea internally
 func HomeDir() string {
-	if setting.RepoRootPath == "" {
+	if setting.Git.HomePath == "" {
 		// strict check, make sure the git module is initialized correctly.
 		// attention: when the git module is called in gitea sub-command (serv/hook), the log module is not able to show messages to users.
 		// for example: if there is gitea git hook code calling git.NewCommand before git.InitXxx, the integration test won't show the real failure reasons.
-		log.Fatal("can not get Git's HomeDir (RepoRootPath is empty), the setting and git modules are not initialized correctly")
+		log.Fatal("Unable to init Git's HomeDir, incorrect initialization of the setting and git modules")
 		return ""
 	}
-	return setting.RepoRootPath
+	return setting.Git.HomePath
 }
 
 // InitSimple initializes git module with a very simple step, no config changes, no global command arguments.
@@ -175,9 +175,13 @@ func InitOnceWithSync(ctx context.Context) (err error) {
 	}
 
 	initOnce.Do(func() {
-		err = InitSimple(ctx)
-		if err != nil {
+		if err = InitSimple(ctx); err != nil {
 			return
+		}
+
+		// when git works with gnupg (commit signing), there should be a stable home for gnupg commands
+		if _, ok := os.LookupEnv("GNUPGHOME"); !ok {
+			_ = os.Setenv("GNUPGHOME", filepath.Join(HomeDir(), ".gnupg"))
 		}
 
 		// Since git wire protocol has been released from git v2.18
@@ -206,7 +210,7 @@ func InitOnceWithSync(ctx context.Context) (err error) {
 // syncGitConfig only modifies gitconfig, won't change global variables (otherwise there will be data-race problem)
 func syncGitConfig() (err error) {
 	if err = os.MkdirAll(HomeDir(), os.ModePerm); err != nil {
-		return fmt.Errorf("unable to create directory %s, err: %w", setting.RepoRootPath, err)
+		return fmt.Errorf("unable to prepare git home directory %s, err: %w", HomeDir(), err)
 	}
 
 	// Git requires setting user.name and user.email in order to commit changes - old comment: "if they're not set just add some defaults"

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -21,12 +21,12 @@ import (
 func testRun(m *testing.M) error {
 	_ = log.NewLogger(1000, "console", "console", `{"level":"trace","stacktracelevel":"NONE","stderr":true}`)
 
-	repoRootPath, err := os.MkdirTemp(os.TempDir(), "repos")
+	gitHomePath, err := os.MkdirTemp(os.TempDir(), "git-home")
 	if err != nil {
 		return fmt.Errorf("unable to create temp dir: %w", err)
 	}
-	defer util.RemoveAll(repoRootPath)
-	setting.RepoRootPath = repoRootPath
+	defer util.RemoveAll(gitHomePath)
+	setting.Git.HomePath = gitHomePath
 
 	if err = InitOnceWithSync(context.Background()); err != nil {
 		return fmt.Errorf("failed to call Init: %w", err)

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -5,6 +5,7 @@
 package setting
 
 import (
+	"path/filepath"
 	"time"
 
 	"code.gitea.io/gitea/modules/log"
@@ -13,6 +14,7 @@ import (
 // Git settings
 var Git = struct {
 	Path                      string
+	HomePath                  string
 	DisableDiffHighlight      bool
 	MaxGitDiffLines           int
 	MaxGitDiffLineCharacters  int
@@ -67,7 +69,16 @@ var Git = struct {
 }
 
 func newGit() {
-	if err := Cfg.Section("git").MapTo(&Git); err != nil {
+	sec := Cfg.Section("git")
+
+	if err := sec.MapTo(&Git); err != nil {
 		log.Fatal("Failed to map Git settings: %v", err)
+	}
+
+	Git.HomePath = sec.Key("HOME_PATH").MustString("home")
+	if !filepath.IsAbs(Git.HomePath) {
+		Git.HomePath = filepath.Join(AppDataPath, Git.HomePath)
+	} else {
+		Git.HomePath = filepath.Clean(Git.HomePath)
 	}
 }


### PR DESCRIPTION
Backport #20114

Before, in #19732, the old home directory is not correct.
This PR introduces a new config option for git home: git.HOME_PATH,
which is default to %(APP_DATA_PATH)/home.

And pass env GNUPGHOME to git command, force Gitea to use a stable GNUPGHOME directory.