### PR TITLE
Do not create empty ".ssh" directory when loading config (#20289)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -862,9 +862,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	SSH.AuthorizedPrincipalsAllow, SSH.AuthorizedPrincipalsEnabled = parseAuthorizedPrincipalsAllow(sec.Key("SSH_AUTHORIZED_PRINCIPALS_ALLOW").Strings(","))
 
 	if !SSH.Disabled && !SSH.StartBuiltinServer {
-		if err := os.MkdirAll(SSH.RootPath, 0o700); err != nil {
-			log.Fatal("Failed to create '%s': %v", SSH.RootPath, err)
-		} else if err = os.MkdirAll(SSH.KeyTestPath, 0o644); err != nil {
+		if err = os.MkdirAll(SSH.KeyTestPath, 0o644); err != nil {
 			log.Fatal("Failed to create '%s': %v", SSH.KeyTestPath, err)
 		}
 


### PR DESCRIPTION
Backport #20289

The code is as old as back to 2016, creating the directory automatically is not correct IMO.

In other places for ssh key writing (RewriteAllPrincipalKeys / appendAuthorizedKeysToFile, etc), the directory will still be created when updating the keys.

This PR will resolve the confusing and annoying problem: the dummy and empty ".ssh" directory in new git home


----

Update: wait for https://github.com/go-gitea/gitea/pull/20299