### PR TITLE
Use dedicated draft PR icon when possible

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1303,6 +1303,7 @@ issues.previous = Previous
 issues.next = Next
 issues.open_title = Open
 issues.closed_title = Closed
+issues.draft_title = Draft
 issues.num_comments = %d comments
 issues.commented_at = `commented <a href="#%s">%s</a>`
 issues.delete_comment_confirm = Are you sure you want to delete this comment?

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -24,7 +24,11 @@
 	{{else if .Issue.IsClosed}}
 		<div class="ui red large label">{{if .Issue.IsPull}}{{svg "octicon-git-pull-request"}}{{else}}{{svg "octicon-issue-closed"}}{{end}} {{.locale.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
-		<div class="ui green large label">{{svg "octicon-git-pull-request"}} {{.locale.Tr "repo.issues.open_title"}}</div>
+		{{if .IsPullWorkInProgress}}
+			<div class="ui grey large label">{{svg "octicon-git-pull-request-draft"}} {{.locale.Tr "repo.issues.open_title"}}</div>
+		{{else}}
+			<div class="ui green large label">{{svg "octicon-git-pull-request"}} {{.locale.Tr "repo.issues.open_title"}}</div>
+		{{end}}
 	{{else}}
 		<div class="ui green large label">{{svg "octicon-issue-opened"}} {{.locale.Tr "repo.issues.open_title"}}</div>
 	{{end}}

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -25,7 +25,7 @@
 		<div class="ui red large label">{{if .Issue.IsPull}}{{svg "octicon-git-pull-request"}}{{else}}{{svg "octicon-issue-closed"}}{{end}} {{.locale.Tr "repo.issues.closed_title"}}</div>
 	{{else if .Issue.IsPull}}
 		{{if .IsPullWorkInProgress}}
-			<div class="ui grey large label">{{svg "octicon-git-pull-request-draft"}} {{.locale.Tr "repo.issues.open_title"}}</div>
+			<div class="ui grey large label">{{svg "octicon-git-pull-request-draft"}} {{.locale.Tr "repo.issues.draft_title"}}</div>
 		{{else}}
 			<div class="ui green large label">{{svg "octicon-git-pull-request"}} {{.locale.Tr "repo.issues.open_title"}}</div>
 		{{end}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -17,7 +17,11 @@
 							{{if .IsClosed}}
 								{{svg "octicon-git-pull-request" 16 "text red"}}
 							{{else}}
-								{{svg "octicon-git-pull-request" 16 "text green"}}
+								{{if .PullRequest.IsWorkInProgress}}
+									{{svg "octicon-git-pull-request-draft" 16 "text grey"}}
+								{{else}}
+									{{svg "octicon-git-pull-request" 16 "text green"}}
+								{{end}}
 							{{end}}
 						{{end}}
 					{{else}}


### PR DESCRIPTION
- Currently the generic pull-request icon is used for draft PR's. This patch changes that by using the dedicated icon for this.
- Resolves #20296

Before:
![image](https://user-images.githubusercontent.com/25481501/178116092-484e7f33-fb37-4885-9945-40b8018ae813.png)
![image](https://user-images.githubusercontent.com/25481501/178116100-f528091b-0bd9-4f4a-a832-d933c1d00823.png)

After:
![image](https://user-images.githubusercontent.com/25481501/178116057-cc7a7bdd-45d4-4811-9032-1c7535128148.png)
![image](https://user-images.githubusercontent.com/25481501/178116063-6f094657-b3e9-4e09-970a-961ff3389667.png)

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
