### PR TITLE
Ensure that drone tags 1.16.x and 1.16 on push to v1.16.x tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -904,6 +904,9 @@ steps:
     settings:
       auto_tag: false
       auto_tag_suffix: linux-amd64
+      tags:
+        - ${DRONE_TAG##v}-linux-amd64
+        - ${DRONE_TAG:1:4}-linux-amd64
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -922,6 +925,9 @@ steps:
       dockerfile: Dockerfile.rootless
       auto_tag: false
       auto_tag_suffix: linux-amd64-rootless
+      tags:
+        - ${DRONE_TAG##v}-linux-amd64-rootless
+        - ${DRONE_TAG:1:4}-linux-amd64-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1128,6 +1134,9 @@ steps:
     settings:
       auto_tag: false
       auto_tag_suffix: linux-arm64
+      tags:
+        - ${DRONE_TAG##v}-linux-arm64
+        - ${DRONE_TAG:1:4}-linux-arm64
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1146,6 +1155,9 @@ steps:
       dockerfile: Dockerfile.rootless
       auto_tag: false
       auto_tag_suffix: linux-arm64-rootless
+      tags:
+        - ${DRONE_TAG##v}-linux-arm64-rootless
+        - ${DRONE_TAG:1:4}-linux-arm64-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io


### PR DESCRIPTION
We need pushes to v1.16.9 to create tags to 1.16.9 and 1.16 but not 1 or latest.

We have previously adjusted the manifest to remove the latest tag, and have removed
auto_tags so that 1 does not get tagged but in doing so we also stopped 1.16 being
tagged. So here we just state the that we tag x.yy in addition to x.yyz*.

Signed-off-by: Andrew Thornton <art27@cantab.net>
