### PR TITLE
Prevent "empty" scrollbars on Firefox (#20294)

### DIFF
--- a/web_src/less/_admin.less
+++ b/web_src/less/_admin.less
@@ -12,7 +12,7 @@
   .table.segment {
     padding: 0;
     font-size: 13px;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     &:not(.striped) {
       thead {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3352,7 +3352,7 @@ td.blob-excerpt {
   .commit-header-row {
     .ui.horizontal.list {
       width: 100%;
-      overflow-x: scroll;
+      overflow-x: auto;
       margin-top: 2px;
 
       .item {
@@ -3401,7 +3401,7 @@ td.blob-excerpt {
   }
 
   .commit-table {
-    overflow-x: scroll;
+    overflow-x: auto;
 
     td.sha,
     th.sha {

--- a/web_src/less/_user.less
+++ b/web_src/less/_user.less
@@ -170,5 +170,5 @@
 }
 
 #notification_div .tab.segment {
-  overflow-x: scroll;
+  overflow-x: auto;
 }

--- a/web_src/less/features/gitgraph.less
+++ b/web_src/less/features/gitgraph.less
@@ -1,5 +1,5 @@
 #git-graph-container {
-  overflow-x: scroll;
+  overflow-x: auto;
   width: 100%;
   min-height: 350px;
 


### PR DESCRIPTION
Backport of #20294

Addition to: Show scrollbar when necessary #20142
Fixes the "empty" scrollbars with Firefox by changing some scroll to auto on some UI elements.