### PR TITLE
Use default values when provided values are empty

### DIFF
--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -179,6 +179,7 @@ func getPostgreSQLConnectionString(dbHost, dbUser, dbPasswd, dbName, dbParam, db
 
 // ParseMSSQLHostPort splits the host into host and port
 func ParseMSSQLHostPort(info string) (string, string) {
+	// the default port "0" might be related to MSSQL's dynamic port, maybe it should be double-confirmed in the future
 	host, port := "127.0.0.1", "0"
 	if strings.Contains(info, ":") {
 		host = strings.Split(info, ":")[0]

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -156,6 +156,12 @@ func parsePostgreSQLHostPort(info string) (string, string) {
 	} else if len(info) > 0 {
 		host = info
 	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port == "" {
+		port = "5432"
+	}
 	return host, port
 }
 
@@ -182,6 +188,12 @@ func ParseMSSQLHostPort(info string) (string, string) {
 		port = strings.TrimSpace(strings.Split(info, ",")[1])
 	} else if len(info) > 0 {
 		host = info
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port == "" {
+		port = "0"
 	}
 	return host, port
 }


### PR DESCRIPTION
- When provided values are empty like `:3000` would imply that host is empty, use the default value.
- Resolves #20316

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
