### PR TITLE
Correctly handle draft releases without a tag (#20314)

### DIFF
--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -7,7 +7,6 @@ package migrations
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -268,7 +267,7 @@ func (g *GiteaLocalUploader) CreateReleases(releases ...*base.Release) error {
 		// calc NumCommits if possible
 		if rel.TagName != "" {
 			commit, err := g.gitRepo.GetTagCommit(rel.TagName)
-			if !errors.Is(err, git.ErrNotExist{}) {
+			if !git.IsErrNotExist(err) {
 				if err != nil {
 					return fmt.Errorf("GetTagCommit[%v]: %v", rel.TagName, err)
 				}


### PR DESCRIPTION
Backport #20314

`errors.Is(err, git.ErrNotExist{})` is not working

Fixes #20313
