### PR TITLE
Fix various typos

### DIFF
--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -62,7 +62,7 @@ ENV GITEA_CUSTOM /var/lib/gitea/custom
 ENV GITEA_TEMP /tmp/gitea
 ENV TMPDIR /tmp/gitea
 
-#TODO add to docs the ability to define the ini to load (usefull to test and revert a config)
+#TODO add to docs the ability to define the ini to load (useful to test and revert a config)
 ENV GITEA_APP_INI /etc/gitea/app.ini
 ENV HOME "/var/lib/gitea/git"
 VOLUME ["/var/lib/gitea", "/etc/gitea"]

--- a/Makefile
+++ b/Makefile
@@ -771,7 +771,7 @@ generate-manpage:
 	@mkdir -p man/man1/ man/man5
 	@./gitea docs --man > man/man1/gitea.1
 	@gzip -9 man/man1/gitea.1 && echo man/man1/gitea.1.gz created
-	@#TODO A small script which formats config-cheat-sheet.en-us.md nicely to suit as config man page
+	@#TODO A small script that formats config-cheat-sheet.en-us.md nicely for use as a config man page
 
 .PHONY: pr\#%
 pr\#%: clean-all

--- a/Makefile
+++ b/Makefile
@@ -771,7 +771,7 @@ generate-manpage:
 	@mkdir -p man/man1/ man/man5
 	@./gitea docs --man > man/man1/gitea.1
 	@gzip -9 man/man1/gitea.1 && echo man/man1/gitea.1.gz created
-	@#TODO A smal script witch format config-cheat-sheet.en-us.md nicely to suit as config man page
+	@#TODO A small script which formats config-cheat-sheet.en-us.md nicely to suit as config man page
 
 .PHONY: pr\#%
 pr\#%: clean-all

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ NOTES:
 
 Translations are done through Crowdin. If you want to translate to a new language ask one of the managers in the Crowdin project to add a new language there. 
 
-You can also just create an issue for adding a language or ask on discord on the #translation channel. If you need context or find some translation issues, you can leave a comment on the string or ask on Discord. For general translation questions there is a section in the docs. Currently a bit empty but we hope fo fill it as questions pop up.
+You can also just create an issue for adding a language or ask on discord on the #translation channel. If you need context or find some translation issues, you can leave a comment on the string or ask on Discord. For general translation questions there is a section in the docs. Currently a bit empty but we hope to fill it as questions pop up.
 
 https://docs.gitea.io/en-us/translation-guidelines/
 

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -82,7 +82,7 @@ var (
 			},
 			cli.BoolFlag{
 				Name:  "no-system",
-				Usage: "Do not show system proceses",
+				Usage: "Do not show system processes",
 			},
 			cli.BoolFlag{
 				Name:  "stacktraces",

--- a/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.zh-cn.md
@@ -346,7 +346,7 @@ ALLOW_DATA_URI_IMAGES = true
 - `ALLOW_DATA_URI_IMAGES`: **false** 允许 data uri 图片 (`<img src="data:image/png;base64,..."/>`)。
 
 多个净化规则可以被同时定义，只要section名称最后一位不重复即可。如： `[markup.sanitizer.TeX-2]`。
-为了针对一种渲染类型进行一个特殊的净化策略，必须使用形如 `[markup.sanitizer.asciidoc.rule-1]` 的方式来命名 seciton。
+为了针对一种渲染类型进行一个特殊的净化策略，必须使用形如 `[markup.sanitizer.asciidoc.rule-1]` 的方式来命名 section。
 如果此规则没有匹配到任何渲染类型，它将会被应用到所有的渲染类型。
 
 ## Time (`time`)

--- a/docs/content/doc/packages/nuget.en-us.md
+++ b/docs/content/doc/packages/nuget.en-us.md
@@ -23,7 +23,7 @@ Publish [NuGet](https://www.nuget.org/) packages for your user or organization. 
 ## Requirements
 
 To work with the NuGet package registry, you can use command-line interface tools as well as NuGet features in various IDEs like Visual Studio.
-More informations about NuGet clients can be found in [the official documentation](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools).
+More information about NuGet clients can be found in [the official documentation](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools).
 The following examples use the `dotnet nuget` tool.
 
 ## Configuring the package registry

--- a/integrations/dump_restore_test.go
+++ b/integrations/dump_restore_test.go
@@ -201,7 +201,7 @@ func (c *compareDump) assertEquals(repoBefore, repoAfter *repo_model.Repository)
 		"Assignees": {ignore: true}, // not implemented yet
 		"Head":      {nested: comparePullRequestBranch},
 		"Base":      {nested: comparePullRequestBranch},
-		"Labels":    {ignore: true}, // because org labels are not handled propery
+		"Labels":    {ignore: true}, // because org labels are not handled properly
 	}).([]*base.PullRequest)
 	assert.True(c.t, ok)
 	assert.GreaterOrEqual(c.t, len(prs), 1)

--- a/models/db/context.go
+++ b/models/db/context.go
@@ -100,7 +100,7 @@ func TxContext() (*Context, Committer, error) {
 }
 
 // WithTx represents executing database operations on a transaction
-// you can optionally change the context to a parrent one
+// you can optionally change the context to a parent one
 func WithTx(f func(ctx context.Context) error, stdCtx ...context.Context) error {
 	parentCtx := DefaultContext
 	if len(stdCtx) != 0 && stdCtx[0] != nil {

--- a/models/issues/pull_list.go
+++ b/models/issues/pull_list.go
@@ -62,7 +62,7 @@ func GetUnmergedPullRequestsByHeadInfo(repoID int64, branch string) ([]*PullRequ
 		Find(&prs)
 }
 
-// CanMaintainerWriteToBranch check whether user is a matainer and could write to the branch
+// CanMaintainerWriteToBranch check whether user is a maintainer and could write to the branch
 func CanMaintainerWriteToBranch(p access_model.Permission, branch string, user *user_model.User) bool {
 	if p.CanWrite(unit.TypeCode) {
 		return true

--- a/models/organization/team_repo.go
+++ b/models/organization/team_repo.go
@@ -55,7 +55,7 @@ func GetTeamRepositories(ctx context.Context, opts *SearchTeamRepoOptions) ([]*r
 		Find(&repos)
 }
 
-// AddTeamRepo addes a repo for an organization's team
+// AddTeamRepo adds a repo for an organization's team
 func AddTeamRepo(ctx context.Context, orgID, teamID, repoID int64) error {
 	_, err := db.GetEngine(ctx).Insert(&TeamRepo{
 		OrgID:  orgID,

--- a/modules/charset/charset.go
+++ b/modules/charset/charset.go
@@ -23,7 +23,7 @@ import (
 // UTF8BOM is the utf-8 byte-order marker
 var UTF8BOM = []byte{'\xef', '\xbb', '\xbf'}
 
-// ToUTF8WithFallbackReader detects the encoding of content and coverts to UTF-8 reader if possible
+// ToUTF8WithFallbackReader detects the encoding of content and converts to UTF-8 reader if possible
 func ToUTF8WithFallbackReader(rd io.Reader) io.Reader {
 	buf := make([]byte, 2048)
 	n, err := util.ReadAtMost(rd, buf)
@@ -76,7 +76,7 @@ func ToUTF8WithErr(content []byte) (string, error) {
 	return string(result), err
 }
 
-// ToUTF8WithFallback detects the encoding of content and coverts to UTF-8 if possible
+// ToUTF8WithFallback detects the encoding of content and converts to UTF-8 if possible
 func ToUTF8WithFallback(content []byte) []byte {
 	bs, _ := io.ReadAll(ToUTF8WithFallbackReader(bytes.NewReader(content)))
 	return bs
@@ -191,7 +191,7 @@ func DetectEncoding(content []byte) (string, error) {
 			break
 		}
 
-		// Otherwise check if this results is earlier in the DetectedCharsetOrder than our current top guesss
+		// Otherwise check if this results is earlier in the DetectedCharsetOrder than our current top guess
 		resultPriority, resultHas := setting.Repository.DetectedCharsetScore[strings.ToLower(strings.TrimSpace(result.Charset))]
 		if resultHas && (!has || resultPriority < priority) {
 			topResult = result

--- a/modules/doctor/breaking.go
+++ b/modules/doctor/breaking.go
@@ -32,8 +32,8 @@ func iterateUserAccounts(ctx context.Context, each func(*user.User) error) error
 // Ref: https://github.com/go-gitea/gitea/pull/19085 & https://github.com/go-gitea/gitea/pull/17688
 func checkUserEmail(ctx context.Context, logger log.Logger, _ bool) error {
 	// We could use quirky SQL to get all users that start without a [a-zA-Z0-9], but that would mean
-	// DB provider-specific SQL and only works _now_. So instead we iterate trough all user accounts and
-	// use the user.ValidateEmail function to be future-proof.
+	// DB provider-specific SQL and only works _now_. So instead we iterate through all user accounts
+	// and use the user.ValidateEmail function to be future-proof.
 	var invalidUserCount int64
 	if err := iterateUserAccounts(ctx, func(u *user.User) error {
 		// Only check for users, skip

--- a/modules/nosql/manager_leveldb.go
+++ b/modules/nosql/manager_leveldb.go
@@ -103,7 +103,7 @@ func (m *Manager) getLevelDB(connection string) (*leveldb.DB, error) {
 	db, ok = m.LevelDBConnections[dataDir]
 	if ok {
 		db.count++
-		log.Warn("Duplicate connnection to level db: %s with different connection strings. Initial connection: %s. This connection: %s", dataDir, db.name[0], connection)
+		log.Warn("Duplicate connection to level db: %s with different connection strings. Initial connection: %s. This connection: %s", dataDir, db.name[0], connection)
 		db.name = append(db.name, connection)
 		m.LevelDBConnections[connection] = db
 		return db.db, nil

--- a/modules/web/middleware/locale.go
+++ b/modules/web/middleware/locale.go
@@ -60,7 +60,7 @@ func SetLocaleCookie(resp http.ResponseWriter, lang string, expiry int) {
 }
 
 // DeleteLocaleCookie convenience function to delete the locale cookie consistently
-// Setting the lang cookie will trigger the middleware to reset the language ot previous state.
+// Setting the lang cookie will trigger the middleware to reset the language to previous state.
 func DeleteLocaleCookie(resp http.ResponseWriter) {
 	SetCookie(resp, "lang", "",
 		-1,

--- a/modules/web/routing/context.go
+++ b/modules/web/routing/context.go
@@ -25,7 +25,7 @@ func UpdateFuncInfo(ctx context.Context, funcInfo *FuncInfo) {
 	record.lock.Unlock()
 }
 
-// MarkLongPolling marks the reuqest is a long-polling request, and the logger may output different message for it
+// MarkLongPolling marks the request is a long-polling request, and the logger may output different message for it
 func MarkLongPolling(resp http.ResponseWriter, req *http.Request) {
 	record, ok := req.Context().Value(contextKey).(*requestRecord)
 	if !ok {

--- a/options/gitignore/Bazel
+++ b/options/gitignore/Bazel
@@ -6,7 +6,7 @@
 /bazel-*
 
 # Directories for the Bazel IntelliJ plugin containing the generated
-# IntelliJ project files and plugin configuration. Seperate directories are
+# IntelliJ project files and plugin configuration. Separate directories are
 # for the IntelliJ, Android Studio and CLion versions of the plugin.
 /.ijwb/
 /.aswb/

--- a/routers/api/packages/composer/api.go
+++ b/routers/api/packages/composer/api.go
@@ -76,7 +76,7 @@ type PackageVersionMetadata struct {
 	Dist    Dist      `json:"dist"`
 }
 
-// Dist contains package download informations
+// Dist contains package download information
 type Dist struct {
 	Type     string `json:"type"`
 	URL      string `json:"url"`

--- a/routers/api/packages/conan/conan.go
+++ b/routers/api/packages/conan/conan.go
@@ -429,14 +429,14 @@ func uploadFile(ctx *context.Context, fileFilter stringSet, fileKey string) {
 	ctx.Status(http.StatusCreated)
 }
 
-// DownloadRecipeFile serves the conent of the requested recipe file
+// DownloadRecipeFile serves the content of the requested recipe file
 func DownloadRecipeFile(ctx *context.Context) {
 	rref := ctx.Data[recipeReferenceKey].(*conan_module.RecipeReference)
 
 	downloadFile(ctx, recipeFileList, rref.AsKey())
 }
 
-// DownloadPackageFile serves the conent of the requested package file
+// DownloadPackageFile serves the content of the requested package file
 func DownloadPackageFile(ctx *context.Context) {
 	pref := ctx.Data[packageReferenceKey].(*conan_module.PackageReference)
 

--- a/routers/api/packages/rubygems/rubygems.go
+++ b/routers/api/packages/rubygems/rubygems.go
@@ -37,7 +37,7 @@ func EnumeratePackages(ctx *context.Context) {
 	enumeratePackages(ctx, "specs.4.8", packages)
 }
 
-// EnumeratePackagesLatest serves the list of the lastest version of every package
+// EnumeratePackagesLatest serves the list of the latest version of every package
 func EnumeratePackagesLatest(ctx *context.Context) {
 	pvs, _, err := packages_model.SearchLatestVersions(ctx, &packages_model.PackageSearchOptions{
 		OwnerID: ctx.Package.Owner.ID,

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1440,7 +1440,7 @@ func UpdatePullRequestTarget(ctx *context.Context) {
 			err := err.(issues_model.ErrPullRequestAlreadyExists)
 
 			RepoRelPath := ctx.Repo.Owner.Name + "/" + ctx.Repo.Repository.Name
-			errorMessage := ctx.Tr("repo.pulls.has_pull_request", html.EscapeString(ctx.Repo.RepoLink+"/pulls/"+strconv.FormatInt(err.IssueID, 10)), html.EscapeString(RepoRelPath), err.IssueID) // FIXME: Creates url insidde locale string
+			errorMessage := ctx.Tr("repo.pulls.has_pull_request", html.EscapeString(ctx.Repo.RepoLink+"/pulls/"+strconv.FormatInt(err.IssueID, 10)), html.EscapeString(RepoRelPath), err.IssueID) // FIXME: Creates url inside locale string
 
 			ctx.Flash.Error(errorMessage)
 			ctx.JSON(http.StatusConflict, map[string]interface{}{

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -98,8 +98,8 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 		listOptions.PageSize = setting.API.MaxResponseItems
 	}
 
-	// TODO(20073) tags are used for compare feature witch needs all tags
-	// filtering is doen at the client side atm
+	// TODO(20073) tags are used for compare feature which needs all tags
+	// filtering is done on the client-side atm
 	tagListStart, tagListEnd := 0, 0
 	if isTagList {
 		tagListStart, tagListEnd = listOptions.GetStartEnd()
@@ -514,12 +514,12 @@ func EditReleasePost(ctx *context.Context) {
 	ctx.Redirect(ctx.Repo.RepoLink + "/releases")
 }
 
-// DeleteRelease delete a release
+// DeleteRelease deletes a release
 func DeleteRelease(ctx *context.Context) {
 	deleteReleaseOrTag(ctx, false)
 }
 
-// DeleteTag delete a tag
+// DeleteTag deletes a tag
 func DeleteTag(ctx *context.Context) {
 	deleteReleaseOrTag(ctx, true)
 }

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -85,7 +85,7 @@ func CorsHandler() func(next http.Handler) http.Handler {
 // for users that have already signed in.
 func buildAuthGroup() *auth_service.Group {
 	group := auth_service.NewGroup(
-		&auth_service.OAuth2{}, // FIXME: this should be removed and only applied in download and oauth realted routers
+		&auth_service.OAuth2{}, // FIXME: this should be removed and only applied in download and oauth related routers
 		&auth_service.Basic{},  // FIXME: this should be removed and only applied in download and git/lfs routers
 		&auth_service.Session{},
 	)

--- a/routers/web/webfinger.go
+++ b/routers/web/webfinger.go
@@ -33,7 +33,7 @@ type webfingerLink struct {
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
-// WebfingerQuery returns informations about a resource
+// WebfingerQuery returns information about a resource
 // https://datatracker.ietf.org/doc/html/rfc7565
 func WebfingerQuery(ctx *context.Context) {
 	appURL, _ := url.Parse(setting.AppURL)

--- a/services/auth/source/oauth2/providers.go
+++ b/services/auth/source/oauth2/providers.go
@@ -35,7 +35,7 @@ type GothProvider interface {
 	GothProviderCreator
 }
 
-// ImagedProvider provide an overrided image setting for the provider
+// ImagedProvider provide an overridden image setting for the provider
 type ImagedProvider struct {
 	GothProvider
 	image string

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -254,7 +254,7 @@
 
 				{{$notAllOverridableChecksOk := or .IsBlockedByApprovals .IsBlockedByRejection .IsBlockedByOfficialReviewRequests .IsBlockedByOutdatedBranch .IsBlockedByChangedProtectedFiles (and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess))}}
 
-				{{/* admin can merge without checks, writer can merge when checkes succeed */}}
+				{{/* admin can merge without checks, writer can merge when checks succeed */}}
 				{{$canMergeNow := and (or $.IsRepoAdmin (not $notAllOverridableChecksOk)) (or (not .AllowMerge) (not .RequireSigned) .WillSign)}}
 				{{/* admin and writer both can make an auto merge schedule */}}
 

--- a/web_src/fomantic/build/semantic.css
+++ b/web_src/fomantic/build/semantic.css
@@ -30873,7 +30873,7 @@ ol.ui.suffixed.list li:before,
      List
 ---------------*/
 
-/* Menu divider shouldn't apply */
+/* Menu divider shouldnt apply */
 
 .ui.menu .list .item:before {
   background: none !important;
@@ -31802,7 +31802,7 @@ Floated Menu / Item
   opacity: 1;
 }
 
-/* Icon Glyph */
+/* Icon Gylph */
 
 .ui.icon.menu i.icon:before {
   opacity: 1;

--- a/web_src/fomantic/build/semantic.css
+++ b/web_src/fomantic/build/semantic.css
@@ -30873,7 +30873,7 @@ ol.ui.suffixed.list li:before,
      List
 ---------------*/
 
-/* Menu divider shouldnt apply */
+/* Menu divider shouldn't apply */
 
 .ui.menu .list .item:before {
   background: none !important;
@@ -31802,7 +31802,7 @@ Floated Menu / Item
   opacity: 1;
 }
 
-/* Icon Gylph */
+/* Icon Glyph */
 
 .ui.icon.menu i.icon:before {
   opacity: 1;

--- a/web_src/fomantic/build/semantic.js
+++ b/web_src/fomantic/build/semantic.js
@@ -142,7 +142,7 @@ $.api = $.fn.api = function(parameters) {
                response = JSON.parse(response);
               }
               catch(e) {
-                // isn't json string
+                // isnt json string
               }
             }
             return response;
@@ -2220,7 +2220,7 @@ $.fn.dimmer = function(parameters) {
 
         event: {
           click: function(event) {
-            module.verbose('Determining if event occurred on dimmer', event);
+            module.verbose('Determining if event occured on dimmer', event);
             if( $dimmer.find(event.target).length === 0 || $(event.target).is(selector.content) ) {
               module.hide();
               event.stopImmediatePropagation();
@@ -3368,7 +3368,7 @@ $.fn.dropdown = function(parameters) {
             if(settings.onHide.call(element) !== false) {
               module.animate.hide(function() {
                 module.remove.visible();
-                // hiding search focus
+                // hidding search focus
                 if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }
@@ -16003,7 +16003,7 @@ $.fn.transition.settings = {
 
   // possible errors
   error: {
-    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
+    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production.',
     repeated    : 'That animation is already occurring, cancelling repeated animation',
     method      : 'The method you called is not defined',
     support     : 'This browser does not support CSS animations'

--- a/web_src/fomantic/build/semantic.js
+++ b/web_src/fomantic/build/semantic.js
@@ -142,7 +142,7 @@ $.api = $.fn.api = function(parameters) {
                response = JSON.parse(response);
               }
               catch(e) {
-                // isnt json string
+                // isn't json string
               }
             }
             return response;
@@ -2220,7 +2220,7 @@ $.fn.dimmer = function(parameters) {
 
         event: {
           click: function(event) {
-            module.verbose('Determining if event occured on dimmer', event);
+            module.verbose('Determining if event occurred on dimmer', event);
             if( $dimmer.find(event.target).length === 0 || $(event.target).is(selector.content) ) {
               module.hide();
               event.stopImmediatePropagation();
@@ -3368,7 +3368,7 @@ $.fn.dropdown = function(parameters) {
             if(settings.onHide.call(element) !== false) {
               module.animate.hide(function() {
                 module.remove.visible();
-                // hidding search focus
+                // hiding search focus
                 if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }
@@ -16003,7 +16003,7 @@ $.fn.transition.settings = {
 
   // possible errors
   error: {
-    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production.',
+    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
     repeated    : 'That animation is already occurring, cancelling repeated animation',
     method      : 'The method you called is not defined',
     support     : 'This browser does not support CSS animations'

--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -192,7 +192,7 @@ function setLabelColor(label, color) {
 }
 
 /**
- * Inspired by W3C recommandation https://www.w3.org/TR/WCAG20/#relativeluminancedef
+ * Inspired by W3C recommendation https://www.w3.org/TR/WCAG20/#relativeluminancedef
  */
 function getRelativeColor(color) {
   color /= 255;

--- a/web_src/less/_dashboard.less
+++ b/web_src/less/_dashboard.less
@@ -68,7 +68,7 @@
 
   .dashboard-repos,
   .dashboard-orgs {
-    margin: 0 1px; /* Accomodate for Semantic's 1px hacks on .attached elements */
+    margin: 0 1px; /* Accommodate for Semantic's 1px hacks on .attached elements */
   }
 
   .dashboard-navbar {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./options/locale,./options/license,./public/vendor -L actived,allways,attachements,ba,befores,commiter,pullrequest,pullrequests,readby,splitted,te,unknwon`