### PR TITLE
Prevent context deadline error propagation in GetCommitsInfo (#20346)

### DIFF
--- a/modules/git/log_name_status.go
+++ b/modules/git/log_name_status.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"path"
 	"sort"
@@ -62,9 +63,10 @@ func LogNameStatusRepo(ctx context.Context, repository, head, treepath string, p
 		})
 		if err != nil {
 			_ = stdoutWriter.CloseWithError(ConcatenateError(err, (&stderr).String()))
-		} else {
-			_ = stdoutWriter.Close()
+			return
 		}
+
+		_ = stdoutWriter.Close()
 	}()
 
 	// For simplicities sake we'll us a buffered reader to read from the cat-file --batch
@@ -354,7 +356,7 @@ heaploop:
 		}
 		current, err := g.Next(treepath, path2idx, changed, maxpathlen)
 		if err != nil {
-			if err == context.DeadlineExceeded {
+			if errors.Is(err, context.DeadlineExceeded) {
 				break heaploop
 			}
 			g.Close()


### PR DESCRIPTION
Backport #20346

Although `WalkGitLog` tries to test for `context.DeadlineExceededErr`
there is a small chance that the error will propagate to the reader
before it is recognised. This will cause the error to propagate up to
`renderDirectoryFiles` and cause a http status 500.

Here we check that the error passed is a `DeadlineExceededErr` via errors.Is

Fix #20329

Signed-off-by: Andrew Thornton <art27@cantab.net>