### PR TITLE
Restore auto_tag for 1.16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -902,11 +902,12 @@ steps:
     image: techknowlogick/drone-docker:latest
     pull: always
     settings:
-      auto_tag: false
+      auto_tag: true
       auto_tag_suffix: linux-amd64
       tags:
         - ${DRONE_TAG##v}-linux-amd64
         - ${DRONE_TAG:1:4}-linux-amd64
+        - ${DRONE_TAG:1:4}
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -923,11 +924,12 @@ steps:
     image: techknowlogick/drone-docker:latest
     settings:
       dockerfile: Dockerfile.rootless
-      auto_tag: false
+      auto_tag: true
       auto_tag_suffix: linux-amd64-rootless
       tags:
         - ${DRONE_TAG##v}-linux-amd64-rootless
         - ${DRONE_TAG:1:4}-linux-amd64-rootless
+        - ${DRONE_TAG:1:4}-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1132,11 +1134,8 @@ steps:
     image: techknowlogick/drone-docker:latest
     pull: always
     settings:
-      auto_tag: false
+      auto_tag: true
       auto_tag_suffix: linux-arm64
-      tags:
-        - ${DRONE_TAG##v}-linux-arm64
-        - ${DRONE_TAG:1:4}-linux-arm64
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1153,11 +1152,8 @@ steps:
     image: techknowlogick/drone-docker:latest
     settings:
       dockerfile: Dockerfile.rootless
-      auto_tag: false
+      auto_tag: true
       auto_tag_suffix: linux-arm64-rootless
-      tags:
-        - ${DRONE_TAG##v}-linux-arm64-rootless
-        - ${DRONE_TAG:1:4}-linux-arm64-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1311,7 +1307,7 @@ steps:
     image: plugins/manifest
     pull: always
     settings:
-      auto_tag: false
+      auto_tag: true
       ignore_missing: true
       spec: docker/manifest.rootless.tmpl
       password:
@@ -1322,7 +1318,7 @@ steps:
   - name: manifest
     image: plugins/manifest
     settings:
-      auto_tag: false
+      auto_tag: true
       ignore_missing: true
       spec: docker/manifest.tmpl
       password:


### PR DESCRIPTION
Whilst trying to avoid causing a downgrade it appears that we've managed
to break the tagging of docker builds.

As the 1.17-rc1 doesn't appear to have hit the 1 tag we should restore
the auto_tag version of 1.16's .drone.yml. Once 1.17 is released we
should change the .drone.yml of 1.16 to set the tags (but include the
1.16 tagging.)

Signed-off-by: Andrew Thornton <art27@cantab.net>
