### PR TITLE
Remove Pull Request button on repo homepage

### DIFF
--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -21,7 +21,7 @@ func testPullCreate(t *testing.T, session *TestSession, user, repo, branch, titl
 
 	// Click the PR button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
-	link, exists := htmlDoc.doc.Find("#new-pull-request").Parent().Attr("href")
+	link, exists := htmlDoc.doc.Find("#new-pull-request").Attr("href")
 	assert.True(t, exists, "The template has changed")
 	if branch != "master" {
 		link = strings.Replace(link, ":master", ":"+branch, 1)

--- a/integrations/pull_create_test.go
+++ b/integrations/pull_create_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func testPullCreate(t *testing.T, session *TestSession, user, repo, branch, title string) *httptest.ResponseRecorder {
-	req := NewRequest(t, "GET", path.Join(user, repo))
+	req := NewRequest(t, "GET", path.Join(user, repo, "pulls"))
 	resp := session.MakeRequest(t, req, http.StatusOK)
 
 	// Click the PR button to create a pull

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -64,15 +64,8 @@
 			{{template "repo/branch_dropdown" dict "root" .}}
 			{{ $n := len .TreeNames}}
 			{{ $l := Subtract $n 1}}
-			<!-- If home page, show new PR. If not, show breadcrumb -->
+			<!-- If home page, show actions. If not, show breadcrumb -->
 			{{if eq $n 0}}
-				{{if and .CanCompareOrPull .IsViewBranch (not .Repository.IsArchived)}}
-					<div class="fitted item mx-0">
-						<a href="{{.BaseRepo.Link}}/compare/{{PathEscapeSegments .BaseRepo.DefaultBranch}}...{{if ne .Repository.Owner.Name .BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}{{if .BaseRepo.IsFork}}/{{PathEscape .Repository.Name}}{{end}}:{{end}}{{PathEscapeSegments .BranchName}}">
-							<button id="new-pull-request" class="ui compact basic button">{{if .PullRequestCtx.Allowed}}{{.locale.Tr "repo.pulls.compare_changes"}}{{else}}{{.locale.Tr "action.compare_branch"}}{{end}}</button>
-						</a>
-					</div>
-				{{end}}
 				<div class="fitted item mx-0">
 					<a href="{{.Repository.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button">
 						{{.locale.Tr "repo.find_file.go_to_file"}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -14,7 +14,7 @@
 					{{if .PageIsIssueList}}
 						<a class="ui green button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}">{{.locale.Tr "repo.issues.new"}}</a>
 					{{else}}
-						<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.Repository.Link}}/compare/{{.Repository.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{.locale.Tr "repo.pulls.new"}}</a>
+						<a id="new-pull-request" class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.Repository.Link}}/compare/{{.Repository.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{.locale.Tr "repo.pulls.new"}}</a>
 					{{end}}
 				</div>
 			{{else}}


### PR DESCRIPTION
We have too many buttons on the repo homepage and the "New PR" button seems like a obvious candidate to remove as it already exists in the Pull Requests tab where it makes more sense.

FWIW, GitHub also no longer shows the button on a repo home page but they do have the recent-pushes flash feature which we lack.

Before:

<img width="1156" alt="Screen Shot 2022-07-14 at 19 24 56" src="https://user-images.githubusercontent.com/115237/179046014-62f87eff-e161-459b-94a6-feea3b333d3b.png">

After:

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/115237/179046090-a17b4a75-02f1-4f14-9acb-33508839ca8c.png">