### PR TITLE
Avoid new stack context for task list items (#20377)

### DIFF
--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -159,12 +159,12 @@
   .task-list-item {
     list-style-type: none;
     line-height: 1.5rem;
+    margin-right: -1.6em;
     min-height: 1.5rem; // to render a checkbox list without content `- [ ]`, we need this min-height to make sure the <li> can be visible
 
     input[type="checkbox"] {
-      position: absolute;
-      left: 1.4em;
-      top: 3.8em;
+      top: -.1em;
+      margin-right: calc(1.6em - 14px);
     }
 
     p {

--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -158,14 +158,13 @@
 
   .task-list-item {
     list-style-type: none;
-    position: relative;
     line-height: 1.5rem;
     min-height: 1.5rem; // to render a checkbox list without content `- [ ]`, we need this min-height to make sure the <li> can be visible
 
     input[type="checkbox"] {
       position: absolute;
-      top: .25em;
-      left: -1.6em;
+      left: 1.4em;
+      top: 3.8em;
     }
 
     p {


### PR DESCRIPTION
- Backport #20377
  - Avoid creating a new stack context on a task list item, this PR does that by removing the `position: relative` which causes a new stack context to be created on that element. And thereby solving that popups weren't able to utilize their z-index and weren't able to show properly.

  Before:
  ![image](https://user-images.githubusercontent.com/25481501/179135078-63805ccc-17bc-4e11-8393-cdb6f1916cdd.png)

  After:
  ![image](https://user-images.githubusercontent.com/25481501/179135105-09996426-85da-40d7-8777-46a16a9413fe.png)

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
