### PR TITLE
Set target on create release with existing tag

### DIFF
--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -224,6 +224,7 @@ func CreateRelease(ctx *context.APIContext) {
 		rel.IsTag = false
 		rel.Repo = ctx.Repo.Repository
 		rel.Publisher = ctx.Doer
+		rel.Target = form.Target
 
 		if err = release_service.UpdateRelease(ctx.Doer, ctx.Repo.GitRepo, rel, nil, nil, nil); err != nil {
 			ctx.Error(http.StatusInternalServerError, "UpdateRelease", err)


### PR DESCRIPTION
- When you create a new release(e.g. via Tea) and specify a tag that already exists on the repository, Gitea will instead use the `UpdateRelease` functionality. However it currently doesn't set the Target field. This PR fixes that.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
