### PR TITLE
Fix dashboard navbar dropdown overflow

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -1,5 +1,5 @@
 <div class="dashboard-navbar">
-	<div class="ui secondary stackable menu">
+	<div class="ui secondary stackable menu no-vertical-tabs">
 		<div class="item">
 			<div class="ui floating dropdown link jump">
 				<span class="text truncated-item-container">


### PR DESCRIPTION
Fixes #20039.

<details>
<summary>Preview</summary>

User dashboard:
![user dashboard preview image](https://user-images.githubusercontent.com/7695608/179345204-481aca23-40f4-445b-8ff4-a7e5170a69d1.png)

Organization dashboard:
![organization dashboard preview image](https://user-images.githubusercontent.com/7695608/179345212-3ab9561c-b6f2-49b5-8eb0-420a4a0bf5fd.png)

</details>

I guess it's ok to use `no-vertical-tabs` here for now, as the vertical layout was already broken in the organization dashboard:
<details>
<summary>View current broken org vertical tabs</summary>

![Screen Shot 2022-07-16 at 04 37 20](https://user-images.githubusercontent.com/7695608/179345337-76ccb6e2-471f-47ea-864a-1dad248d8a13.png)

</details>
