### PR TITLE
Add missing return for when topic isn't found (#20351)

### DIFF
--- a/routers/api/v1/repo/topic.go
+++ b/routers/api/v1/repo/topic.go
@@ -240,6 +240,7 @@ func DeleteTopic(ctx *context.APIContext) {
 
 	if topic == nil {
 		ctx.NotFound()
+		return
 	}
 
 	ctx.Status(http.StatusNoContent)


### PR DESCRIPTION
Backport #20351

Add missing return to DeleteTopic API when the topic is not found.
