### PR TITLE
Add "X-Gitea-Object-Type" header for GET `/raw/` & `/media/` API

### DIFF
--- a/integrations/api_repo_raw_test.go
+++ b/integrations/api_repo_raw_test.go
@@ -28,10 +28,10 @@ func TestAPIReposRaw(t *testing.T) {
 	} {
 		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/raw/%s/README.md?token="+token, user.Name, ref)
 		resp := session.MakeRequest(t, req, http.StatusOK)
-		assert.EqualValues(t, "file", resp.Header().Get("X-Gitea-Content-Type"))
+		assert.EqualValues(t, "file", resp.Header().Get("x-gitea-object-type"))
 	}
 	// Test default branch
 	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/raw/README.md?token="+token, user.Name)
 	resp := session.MakeRequest(t, req, http.StatusOK)
-	assert.EqualValues(t, "file", resp.Header().Get("X-Gitea-Content-Type"))
+	assert.EqualValues(t, "file", resp.Header().Get("x-gitea-object-type"))
 }

--- a/integrations/api_repo_raw_test.go
+++ b/integrations/api_repo_raw_test.go
@@ -10,6 +10,8 @@ import (
 
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIReposRaw(t *testing.T) {
@@ -25,9 +27,11 @@ func TestAPIReposRaw(t *testing.T) {
 		"65f1bf27bc3bf70f64657658635e66094edbcb4d", // Commit
 	} {
 		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/raw/%s/README.md?token="+token, user.Name, ref)
-		session.MakeRequest(t, req, http.StatusOK)
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		assert.EqualValues(t, "file", resp.Header().Get("X-Gitea-Content-Type"))
 	}
 	// Test default branch
 	req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/raw/README.md?token="+token, user.Name)
-	session.MakeRequest(t, req, http.StatusOK)
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	assert.EqualValues(t, "file", resp.Header().Get("X-Gitea-Content-Type"))
 }

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -82,7 +82,7 @@ func GetRawFile(ctx *context.APIContext) {
 	}
 
 	ctx.RespHeader().Set(giteaObjectTypeHeader,
-		string(files_service.GetContentTypeFromTreeEntry(entry)))
+		string(files_service.GetObjectTypeFromTreeEntry(entry)))
 
 	if err := common.ServeBlob(ctx.Context, blob, lastModified); err != nil {
 		ctx.Error(http.StatusInternalServerError, "ServeBlob", err)
@@ -132,7 +132,7 @@ func GetRawFileOrLFS(ctx *context.APIContext) {
 	}
 
 	ctx.RespHeader().Set(giteaObjectTypeHeader,
-		string(files_service.GetContentTypeFromTreeEntry(entry)))
+		string(files_service.GetObjectTypeFromTreeEntry(entry)))
 
 	// LFS Pointer files are at most 1024 bytes - so any blob greater than 1024 bytes cannot be an LFS file
 	if blob.Size() > 1024 {

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -33,9 +33,7 @@ import (
 	files_service "code.gitea.io/gitea/services/repository/files"
 )
 
-const (
-	giteaObjectTypeHeader = "X-Gitea-Object-Type"
-)
+const giteaObjectTypeHeader = "X-Gitea-Object-Type"
 
 // GetRawFile get a file by path on a repository
 func GetRawFile(ctx *context.APIContext) {
@@ -81,8 +79,7 @@ func GetRawFile(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.RespHeader().Set(giteaObjectTypeHeader,
-		string(files_service.GetObjectTypeFromTreeEntry(entry)))
+	ctx.RespHeader().Set(giteaObjectTypeHeader, string(files_service.GetObjectTypeFromTreeEntry(entry)))
 
 	if err := common.ServeBlob(ctx.Context, blob, lastModified); err != nil {
 		ctx.Error(http.StatusInternalServerError, "ServeBlob", err)
@@ -131,8 +128,7 @@ func GetRawFileOrLFS(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.RespHeader().Set(giteaObjectTypeHeader,
-		string(files_service.GetObjectTypeFromTreeEntry(entry)))
+	ctx.RespHeader().Set(giteaObjectTypeHeader, string(files_service.GetObjectTypeFromTreeEntry(entry)))
 
 	// LFS Pointer files are at most 1024 bytes - so any blob greater than 1024 bytes cannot be an LFS file
 	if blob.Size() > 1024 {

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	giteaContentTypeHeader = "X-Gitea-Content-Type"
+	giteaObjectTypeHeader = "X-Gitea-Object-Type"
 )
 
 // GetRawFile get a file by path on a repository
@@ -81,7 +81,7 @@ func GetRawFile(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.RespHeader().Set(giteaContentTypeHeader,
+	ctx.RespHeader().Set(giteaObjectTypeHeader,
 		string(files_service.GetContentTypeFromTreeEntry(entry)))
 
 	if err := common.ServeBlob(ctx.Context, blob, lastModified); err != nil {
@@ -131,7 +131,7 @@ func GetRawFileOrLFS(ctx *context.APIContext) {
 		return
 	}
 
-	ctx.RespHeader().Set(giteaContentTypeHeader,
+	ctx.RespHeader().Set(giteaObjectTypeHeader,
 		string(files_service.GetContentTypeFromTreeEntry(entry)))
 
 	// LFS Pointer files are at most 1024 bytes - so any blob greater than 1024 bytes cannot be an LFS file

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -101,6 +101,22 @@ func GetContentsOrList(ctx context.Context, repo *repo_model.Repository, treePat
 	return fileList, nil
 }
 
+// GetContentTypeFromTreeEntry check what content is behind it
+func GetContentTypeFromTreeEntry(entry *git.TreeEntry) ContentType {
+	switch {
+	case entry.IsDir():
+		return ContentTypeDir
+	case entry.IsSubModule():
+		return ContentTypeSubmodule
+	case entry.IsExecutable(), entry.IsRegular():
+		return ContentTypeRegular
+	case entry.IsLink():
+		return ContentTypeLink
+	default:
+		return ""
+	}
+}
+
 // GetContents gets the meta data on a file's contents. Ref can be a branch, commit or tag
 func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref string, forList bool) (*api.ContentsResponse, error) {
 	if ref == "" {

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -101,8 +101,8 @@ func GetContentsOrList(ctx context.Context, repo *repo_model.Repository, treePat
 	return fileList, nil
 }
 
-// GetContentTypeFromTreeEntry check what content is behind it
-func GetContentTypeFromTreeEntry(entry *git.TreeEntry) ContentType {
+// GetObjectTypeFromTreeEntry check what content is behind it
+func GetObjectTypeFromTreeEntry(entry *git.TreeEntry) ContentType {
 	switch {
 	case entry.IsDir():
 		return ContentTypeDir


### PR DESCRIPTION
example header response:
```
cache-control: public,max-age=86400
content-length: 4
content-type: text/plain; charset=utf-8
date: Thu,21 Jul 2022 15:54:23 GMT
etag: "1a010b1c0f081b2e8901d55307a15c29ff30af0e"
last-modified: Thu,21 Jul 2022 15:27:16 GMT
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-gitea-object-type: symlink
x-gitea-debug: RUN_MODE=dev,CacheControl=no-store
```

this make it possible to handle symlinks ...