### PR TITLE
Raise golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
 
 run:
   go: 1.18
-  timeout: 10m
+  timeout: 20m
   skip-dirs:
     - node_modules
     - public
@@ -40,7 +40,7 @@ linters-settings:
   stylecheck:
     checks: ["all", "-ST1005", "-ST1003"]
   nakedret:
-    max-func-lines: 0 
+    max-func-lines: 0
   gocritic:
     disabled-checks:
       - ifElseChain


### PR DESCRIPTION
Some [recent failures](https://drone.gitea.io/go-gitea/gitea/57909/1/5) on CI with timeout, let's raise it a bit.