### PR TITLE
Fix content-type header for non-text-file attachments

### DIFF
--- a/modules/typesniffer/typesniffer.go
+++ b/modules/typesniffer/typesniffer.go
@@ -20,6 +20,8 @@ const sniffLen = 1024
 const (
 	// SvgMimeType MIME type of SVG images.
 	SvgMimeType = "image/svg+xml"
+	// PdfMimeType MIME type of PDF images.
+	PdfMimeType = "application/pdf"
 	// ApplicationOctetStream MIME type of binary files.
 	ApplicationOctetStream = "application/octet-stream"
 )

--- a/routers/common/repo.go
+++ b/routers/common/repo.go
@@ -93,12 +93,12 @@ func ServeData(ctx *context.Context, name string, size int64, reader io.Reader) 
 			}
 		}
 		ctx.Resp.Header().Set("Content-Type", mimeType)
+		ctx.Resp.Header().Set("X-Content-Type-Options", "nosniff")
 
 		ctx.Resp.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 		if (st.IsImage() || st.IsPDF()) && (setting.UI.SVG.Enabled || !st.IsSvgImage()) {
 			ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, name))
 			ctx.Resp.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
-			ctx.Resp.Header().Set("X-Content-Type-Options", "nosniff")
 		} else {
 			ctx.Resp.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
 		}


### PR DESCRIPTION
The previous logic was only setting content-type for SVG.  All other types did not consider the user's configured mime type mapping. Fix that by allowing all mappings to take effect. Also, added a default PDF mimetype as there is no harm in doing that.