### PR TITLE
Fix Ruby spec parsing

### DIFF
--- a/modules/packages/rubygems/metadata.go
+++ b/modules/packages/rubygems/metadata.go
@@ -80,7 +80,6 @@ type gemspec struct {
 		VersionRequirements requirement `yaml:"version_requirements"`
 	} `yaml:"dependencies"`
 	Description    string        `yaml:"description"`
-	Email          string        `yaml:"email"`
 	Executables    []string      `yaml:"executables"`
 	Extensions     []interface{} `yaml:"extensions"`
 	ExtraRdocFiles []string      `yaml:"extra_rdoc_files"`


### PR DESCRIPTION
fixes #19837

Problem is the `email` field which can be [a string or an array of strings](https://guides.rubygems.org/specification-reference/#email). The yaml parser does not support (?) the parsing of a single string into an array so I just removed the field as it is not used.