### PR TITLE
Fix org members bug

### DIFF
--- a/integrations/org_test.go
+++ b/integrations/org_test.go
@@ -116,6 +116,24 @@ func TestPrivateOrg(t *testing.T) {
 	session.MakeRequest(t, req, http.StatusOK)
 }
 
+func TestOrgMembers(t *testing.T) {
+	defer prepareTestEnv(t)()
+
+	// not logged in user
+	req := NewRequest(t, "GET", "/org/org25/members")
+	MakeRequest(t, req, http.StatusOK)
+
+	// org member
+	session := loginUser(t, "user24")
+	req = NewRequest(t, "GET", "/org/org25/members")
+	session.MakeRequest(t, req, http.StatusOK)
+
+	// site admin
+	session = loginUser(t, "user1")
+	req = NewRequest(t, "GET", "/org/org25/members")
+	session.MakeRequest(t, req, http.StatusOK)
+}
+
 func TestOrgRestrictedUser(t *testing.T) {
 	defer prepareTestEnv(t)()
 

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -29,7 +29,7 @@
 							{{end}}
 						</div>
 					</div>
-					{{if not .PublicOnly}}
+					{{if not $.PublicOnly}}
 						<div class="ui three wide column center">
 							<div class="meta">
 								{{$.locale.Tr "org.members.member_role"}}


### PR DESCRIPTION
Fixed 500 error on organization members page.
Bug was introduced in d6779c7ad3639d6af0c4454a9c22abf21d608922
Only non empy orgs are affected.

Expanded org unit test to cover this problem.
