### PR TITLE
Hide internal package versions

### DIFF
--- a/integrations/api_packages_container_test.go
+++ b/integrations/api_packages_container_test.go
@@ -20,6 +20,7 @@ import (
 	container_module "code.gitea.io/gitea/modules/packages/container"
 	"code.gitea.io/gitea/modules/packages/container/oci"
 	"code.gitea.io/gitea/modules/setting"
+	api "code.gitea.io/gitea/modules/structs"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -487,6 +488,13 @@ func TestPackageContainer(t *testing.T) {
 					assert.Equal(t, c.ExpectedTags, tagList.Tags)
 					assert.Equal(t, c.ExpectedLink, resp.Header().Get("Link"))
 				}
+
+				req := NewRequest(t, "GET", fmt.Sprintf("/api/v1/packages/%s?type=container&q=%s", user.Name, image))
+				resp := MakeRequest(t, req, http.StatusOK)
+
+				var apiPackages []*api.Package
+				DecodeJSON(t, resp, &apiPackages)
+				assert.Len(t, apiPackages, 4) // "latest", "main", "multi", "sha256:..."
 			})
 
 			t.Run("Delete", func(t *testing.T) {

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -122,8 +122,9 @@ func getVersionByNameAndVersion(ctx context.Context, ownerID int64, packageType 
 // GetVersionsByPackageType gets all versions of a specific type
 func GetVersionsByPackageType(ctx context.Context, ownerID int64, packageType Type) ([]*PackageVersion, error) {
 	pvs, _, err := SearchVersions(ctx, &PackageSearchOptions{
-		OwnerID: ownerID,
-		Type:    packageType,
+		OwnerID:    ownerID,
+		Type:       packageType,
+		IsInternal: util.OptionalBoolFalse,
 	})
 	return pvs, err
 }
@@ -137,6 +138,7 @@ func GetVersionsByPackageName(ctx context.Context, ownerID int64, packageType Ty
 			ExactMatch: true,
 			Value:      name,
 		},
+		IsInternal: util.OptionalBoolFalse,
 	})
 	return pvs, err
 }

--- a/routers/api/packages/composer/composer.go
+++ b/routers/api/packages/composer/composer.go
@@ -19,6 +19,7 @@ import (
 	packages_module "code.gitea.io/gitea/modules/packages"
 	composer_module "code.gitea.io/gitea/modules/packages/composer"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
 
@@ -62,10 +63,11 @@ func SearchPackages(ctx *context.Context) {
 	}
 
 	opts := &packages_model.PackageSearchOptions{
-		OwnerID:   ctx.Package.Owner.ID,
-		Type:      packages_model.TypeComposer,
-		Name:      packages_model.SearchValue{Value: ctx.FormTrim("q")},
-		Paginator: &paginator,
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeComposer,
+		Name:       packages_model.SearchValue{Value: ctx.FormTrim("q")},
+		IsInternal: util.OptionalBoolFalse,
+		Paginator:  &paginator,
 	}
 	if ctx.FormTrim("type") != "" {
 		opts.Properties = map[string]string{

--- a/routers/api/packages/helm/helm.go
+++ b/routers/api/packages/helm/helm.go
@@ -19,6 +19,7 @@ import (
 	packages_module "code.gitea.io/gitea/modules/packages"
 	helm_module "code.gitea.io/gitea/modules/packages/helm"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
 
@@ -39,8 +40,9 @@ func apiError(ctx *context.Context, status int, obj interface{}) {
 // Index generates the Helm charts index
 func Index(ctx *context.Context) {
 	pvs, _, err := packages_model.SearchVersions(ctx, &packages_model.PackageSearchOptions{
-		OwnerID: ctx.Package.Owner.ID,
-		Type:    packages_model.TypeHelm,
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeHelm,
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)
@@ -108,6 +110,7 @@ func DownloadPackageFile(ctx *context.Context) {
 			Value:      ctx.Params("package"),
 		},
 		HasFileWithName: filename,
+		IsInternal:      util.OptionalBoolFalse,
 	})
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -18,6 +18,7 @@ import (
 	packages_module "code.gitea.io/gitea/modules/packages"
 	npm_module "code.gitea.io/gitea/modules/packages/npm"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
 
@@ -261,6 +262,7 @@ func setPackageTag(tag string, pv *packages_model.PackageVersion, deleteOnly boo
 		Properties: map[string]string{
 			npm_module.TagProperty: tag,
 		},
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		return err

--- a/routers/api/packages/nuget/nuget.go
+++ b/routers/api/packages/nuget/nuget.go
@@ -17,6 +17,7 @@ import (
 	packages_module "code.gitea.io/gitea/modules/packages"
 	nuget_module "code.gitea.io/gitea/modules/packages/nuget"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -39,9 +40,10 @@ func ServiceIndex(ctx *context.Context) {
 // SearchService https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
 func SearchService(ctx *context.Context) {
 	pvs, count, err := packages_model.SearchVersions(ctx, &packages_model.PackageSearchOptions{
-		OwnerID: ctx.Package.Owner.ID,
-		Type:    packages_model.TypeNuGet,
-		Name:    packages_model.SearchValue{Value: ctx.FormTrim("q")},
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeNuGet,
+		Name:       packages_model.SearchValue{Value: ctx.FormTrim("q")},
+		IsInternal: util.OptionalBoolFalse,
 		Paginator: db.NewAbsoluteListOptions(
 			ctx.FormInt("skip"),
 			ctx.FormInt("take"),

--- a/routers/api/packages/rubygems/rubygems.go
+++ b/routers/api/packages/rubygems/rubygems.go
@@ -16,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	packages_module "code.gitea.io/gitea/modules/packages"
 	rubygems_module "code.gitea.io/gitea/modules/packages/rubygems"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -40,8 +41,9 @@ func EnumeratePackages(ctx *context.Context) {
 // EnumeratePackagesLatest serves the list of the latest version of every package
 func EnumeratePackagesLatest(ctx *context.Context) {
 	pvs, _, err := packages_model.SearchLatestVersions(ctx, &packages_model.PackageSearchOptions{
-		OwnerID: ctx.Package.Owner.ID,
-		Type:    packages_model.TypeRubyGems,
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeRubyGems,
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)
@@ -289,6 +291,7 @@ func getVersionsByFilename(ctx *context.Context, filename string) ([]*packages_m
 		OwnerID:         ctx.Package.Owner.ID,
 		Type:            packages_model.TypeRubyGems,
 		HasFileWithName: filename,
+		IsInternal:      util.OptionalBoolFalse,
 	})
 	return pvs, err
 }

--- a/routers/api/v1/packages/package.go
+++ b/routers/api/v1/packages/package.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/convert"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/v1/utils"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -55,10 +56,11 @@ func ListPackages(ctx *context.APIContext) {
 	query := ctx.FormTrim("q")
 
 	pvs, count, err := packages.SearchVersions(ctx, &packages.PackageSearchOptions{
-		OwnerID:   ctx.Package.Owner.ID,
-		Type:      packages.Type(packageType),
-		Name:      packages.SearchValue{Value: query},
-		Paginator: &listOptions,
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages.Type(packageType),
+		Name:       packages.SearchValue{Value: query},
+		IsInternal: util.OptionalBoolFalse,
+		Paginator:  &listOptions,
 	})
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "SearchVersions", err)

--- a/routers/web/admin/packages.go
+++ b/routers/web/admin/packages.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
 
@@ -31,9 +32,10 @@ func Packages(ctx *context.Context) {
 	sort := ctx.FormTrim("sort")
 
 	pvs, total, err := packages_model.SearchVersions(ctx, &packages_model.PackageSearchOptions{
-		Type: packages_model.Type(packageType),
-		Name: packages_model.SearchValue{Value: query},
-		Sort: sort,
+		Type:       packages_model.Type(packageType),
+		Name:       packages_model.SearchValue{Value: query},
+		Sort:       sort,
+		IsInternal: util.OptionalBoolFalse,
 		Paginator: &db.ListOptions{
 			PageSize: setting.UI.PackagesPagingNum,
 			Page:     page,

--- a/routers/web/repo/packages.go
+++ b/routers/web/repo/packages.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 )
 
 const (
@@ -32,10 +33,11 @@ func Packages(ctx *context.Context) {
 			PageSize: setting.UI.PackagesPagingNum,
 			Page:     page,
 		},
-		OwnerID: ctx.ContextUser.ID,
-		RepoID:  ctx.Repo.Repository.ID,
-		Type:    packages.Type(packageType),
-		Name:    packages.SearchValue{Value: query},
+		OwnerID:    ctx.ContextUser.ID,
+		RepoID:     ctx.Repo.Repository.ID,
+		Type:       packages.Type(packageType),
+		Name:       packages.SearchValue{Value: query},
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		ctx.ServerError("SearchLatestVersions", err)

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -17,6 +17,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 	packages_service "code.gitea.io/gitea/services/packages"
@@ -43,9 +44,10 @@ func ListPackages(ctx *context.Context) {
 			PageSize: setting.UI.PackagesPagingNum,
 			Page:     page,
 		},
-		OwnerID: ctx.ContextUser.ID,
-		Type:    packages_model.Type(packageType),
-		Name:    packages_model.SearchValue{Value: query},
+		OwnerID:    ctx.ContextUser.ID,
+		Type:       packages_model.Type(packageType),
+		Name:       packages_model.SearchValue{Value: query},
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		ctx.ServerError("SearchLatestVersions", err)
@@ -112,7 +114,8 @@ func RedirectToLastVersion(ctx *context.Context) {
 	}
 
 	pvs, _, err := packages_model.SearchLatestVersions(ctx, &packages_model.PackageSearchOptions{
-		PackageID: p.ID,
+		PackageID:  p.ID,
+		IsInternal: util.OptionalBoolFalse,
 	})
 	if err != nil {
 		ctx.ServerError("GetPackageByName", err)
@@ -157,8 +160,9 @@ func ViewPackageVersion(ctx *context.Context) {
 		})
 	default:
 		pvs, total, err = packages_model.SearchVersions(ctx, &packages_model.PackageSearchOptions{
-			Paginator: db.NewAbsoluteListOptions(0, 5),
-			PackageID: pd.Package.ID,
+			Paginator:  db.NewAbsoluteListOptions(0, 5),
+			PackageID:  pd.Package.ID,
+			IsInternal: util.OptionalBoolFalse,
 		})
 		if err != nil {
 			ctx.ServerError("SearchVersions", err)
@@ -254,6 +258,7 @@ func ListPackageVersions(ctx *context.Context) {
 				ExactMatch: false,
 				Value:      query,
 			},
+			IsInternal: util.OptionalBoolFalse,
 		})
 		if err != nil {
 			ctx.ServerError("SearchVersions", err)

--- a/services/packages/packages.go
+++ b/services/packages/packages.go
@@ -19,6 +19,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/notification"
 	packages_module "code.gitea.io/gitea/modules/packages"
+	"code.gitea.io/gitea/modules/util"
 	container_service "code.gitea.io/gitea/services/packages/container"
 )
 
@@ -462,7 +463,8 @@ func RemoveAllPackages(ctx context.Context, userID int64) (int, error) {
 				PageSize: repo_model.RepositoryListDefaultPageSize,
 				Page:     1,
 			},
-			OwnerID: userID,
+			OwnerID:    userID,
+			IsInternal: util.OptionalBoolNone,
 		})
 		if err != nil {
 			return count, fmt.Errorf("GetOwnedPackages[%d]: %w", userID, err)


### PR DESCRIPTION
fixes #20491 

At the moment only the container packages use internal versions so I forgot to restrict the api to display these versions. This PR simply restricts all searches.

#18064 made the `IsInternal` optional which resulted in the wrong API result.