### PR TITLE
Show hint to link package to repo when viewing empty repo package list

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3044,7 +3044,7 @@ title = Packages
 desc = Manage repository packages.
 empty = There are no packages yet.
 empty.documentation = For more information on the package registry, see <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/overview">the documentation</a>.
-empty.repo = Uploaded a package, but it's not showing here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
+empty.repo = Did you upload a package, but it's not shown here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
 filter.type = Type
 filter.type.all = All
 filter.no_result = Your filter produced no results.

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3044,6 +3044,7 @@ title = Packages
 desc = Manage repository packages.
 empty = There are no packages yet.
 empty.documentation = For more information on the package registry, see <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/overview">the documentation</a>.
+empty.repo = Uploaded a package, but it's not showing here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
 filter.type = Type
 filter.type.all = All
 filter.no_result = Your filter produced no results.

--- a/routers/web/repo/packages.go
+++ b/routers/web/repo/packages.go
@@ -9,6 +9,7 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/packages"
+	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
@@ -62,6 +63,9 @@ func Packages(ctx *context.Context) {
 	ctx.Data["Query"] = query
 	ctx.Data["PackageType"] = packageType
 	ctx.Data["HasPackages"] = hasPackages
+	if ctx.Repo != nil {
+		ctx.Data["CanWritePackages"] = ctx.IsUserRepoWriter([]unit.Type{unit.TypePackages}) || ctx.IsUserSiteAdmin()
+	}
 	ctx.Data["PackageDescriptors"] = pds
 	ctx.Data["Total"] = total
 	ctx.Data["RepositoryAccessMap"] = map[int64]bool{ctx.Repo.Repository.ID: true} // There is only the current repository

--- a/templates/package/shared/list.tmpl
+++ b/templates/package/shared/list.tmpl
@@ -47,6 +47,10 @@
 				<div class="empty center">
 					{{svg "octicon-package" 32}}
 					<h2>{{.locale.Tr "packages.empty"}}</h2>
+					{{if and .Repository .CanWritePackages}}
+						{{$packagesUrl := URLJoin .Owner.HTMLURL "-" "packages" }}
+						<p>{{.locale.Tr "packages.empty.repo" $packagesUrl | Safe}}</p>
+					{{end}}
 					<p>{{.locale.Tr "packages.empty.documentation" | Safe}}</p>
 				</div>
 			{{else}}


### PR DESCRIPTION
This might reduce the amount of questions regarding packages not showing up on the repo page. Should probably be backported

fixes #20483 

![image](https://user-images.githubusercontent.com/7880552/181212854-5f9b3f5a-312d-4aca-bdc6-533b6c8962cb.png)
