### PR TITLE
Refresh button when branch changes

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3046,6 +3046,7 @@ title = Packages
 desc = Manage repository packages.
 empty = There are no packages yet.
 empty.documentation = For more information on the package registry, see <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/overview">the documentation</a>.
+empty.repo = Did you upload a package, but it's not shown here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
 filter.type = Type
 filter.type.all = All
 filter.no_result = Your filter produced no results.

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1615,6 +1615,8 @@ pulls.auto_merge_canceled_schedule_comment = `canceled auto merging this pull re
 pulls.delete.title = Delete this pull request?
 pulls.delete.text = Do you really want to delete this pull request? (This will permanently remove all content. Consider closing it instead, if you intend to keep it archived)
 
+pulls.refresh = Refresh
+
 milestones.new = New Milestone
 milestones.closed = Closed %s
 milestones.update_ago = Updated %s ago
@@ -3044,7 +3046,6 @@ title = Packages
 desc = Manage repository packages.
 empty = There are no packages yet.
 empty.documentation = For more information on the package registry, see <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/overview">the documentation</a>.
-empty.repo = Did you upload a package, but it's not shown here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
 filter.type = Type
 filter.type.all = All
 filter.no_result = Your filter produced no results.

--- a/routers/private/event.go
+++ b/routers/private/event.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// Package private includes all internal routes. The package name internal is ideal but Golang is not allowed, so we use private as package name instead.
+package private
+
+import (
+	access_model "code.gitea.io/gitea/models/perm/access"
+	user_model "code.gitea.io/gitea/models/user"
+	gitea_context "code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/eventsource"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/private"
+	"code.gitea.io/gitea/modules/web"
+)
+
+type BranchUpdateEvent struct {
+	CommitID      string
+	Branch        string
+	BranchDeleted bool
+	Owner         string
+	RefFullName   string
+	Repository    string
+}
+
+func SendBranchUpdateEvent(readers []*user_model.User, commitID, branchName, repoName, refFullName, ownerName string) {
+	manager := eventsource.GetManager()
+
+	for _, reader := range readers {
+		manager.SendMessage(reader.ID, &eventsource.Event{
+			Name: "branch-update",
+			Data: BranchUpdateEvent{
+				CommitID:      commitID,
+				Branch:        branchName,
+				BranchDeleted: commitID == git.EmptySHA,
+				Repository:    repoName,
+				RefFullName:   refFullName,
+				Owner:         ownerName,
+			},
+		})
+	}
+}
+
+func SendContextBranchUpdateEvents(ctx *gitea_context.PrivateContext) error {
+	opts := web.GetForm(ctx).(*private.HookOptions)
+
+	ownerName := ctx.Params(":owner")
+	repoName := ctx.Params(":repo")
+
+	repo := loadRepository(ctx, ownerName, repoName)
+
+	readers, err := access_model.GetRepoReaders(repo)
+	if err != nil {
+		return err
+	}
+
+	for i := range opts.OldCommitIDs {
+		branch := git.RefEndName(opts.RefFullNames[i])
+		commitID := opts.NewCommitIDs[i]
+		refFullName := opts.RefFullNames[i]
+
+		SendBranchUpdateEvent(readers, commitID, branch, repoName, refFullName, ownerName)
+	}
+
+	return nil
+}

--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -233,6 +233,19 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 			}
 		}
 	}
+
+	// Notify users with read access via eventsource that a change
+	// has been made
+	if err := SendContextBranchUpdateEvents(ctx); err != nil {
+		log.Error("Failed to Get Repo Readers: %s/%s Error: %v", ownerName, repoName, err)
+
+		ctx.JSON(http.StatusInternalServerError, private.HookPostReceiveResult{
+			Err: fmt.Sprintf("Failed to Get Repo Readers: %s/%s Error: %v", ownerName, repoName, err),
+		})
+
+		return
+	}
+
 	ctx.JSON(http.StatusOK, private.HookPostReceiveResult{
 		Results:      results,
 		RepoWasEmpty: wasEmpty,

--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -237,10 +237,10 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 	// Notify users with read access via eventsource that a change
 	// has been made
 	if err := SendContextBranchUpdateEvents(ctx); err != nil {
-		log.Error("Failed to Get Repo Readers: %s/%s Error: %v", ownerName, repoName, err)
+		log.Error("Failed to Send Branch Update Events: %s/%s Error: %v", ownerName, repoName, err)
 
 		ctx.JSON(http.StatusInternalServerError, private.HookPostReceiveResult{
-			Err: fmt.Sprintf("Failed to Get Repo Readers: %s/%s Error: %v", ownerName, repoName, err),
+			Err: fmt.Sprintf("Failed to Send Branch Update Events: %s/%s Error: %v", ownerName, repoName, err),
 		})
 
 		return

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1171,6 +1171,7 @@ func ViewIssue(ctx *context.Context) {
 		}
 		ctx.Data["PageIsPullList"] = true
 		ctx.Data["PageIsPullConversation"] = true
+		ctx.Data["Reponame"] = ctx.Repo.Repository.Name
 	} else {
 		MustEnableIssues(ctx)
 		if ctx.Written() {

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -5,6 +5,9 @@
 				<div id="edit-title" class="ui basic secondary not-in-edit button">{{.locale.Tr "repo.issues.edit"}}</div>
 			</div>
 		{{end}}
+		<div class="edit-button not-in-edit refresh-pull-request" data-base-target="{{$.BaseTarget}}" data-head-target="{{$.HeadTarget}}" data-owner-name="{{$.Username}}" data-repository-name="{{$.Reponame}}">
+			<button class="ui inverted orange button">{{.locale.Tr "repo.pulls.refresh"}}</button>
+		</div>
 		<h1>
 			<span id="issue-title">{{RenderIssueTitle $.Context .Issue.Title $.RepoLink $.Repository.ComposeMetas}}</span>
 			<span class="index">#{{.Issue.Index}}</span>

--- a/web_src/js/features/eventsource.sharedworker.js
+++ b/web_src/js/features/eventsource.sharedworker.js
@@ -13,6 +13,7 @@ class Source {
     this.listen('notification-count');
     this.listen('stopwatches');
     this.listen('error');
+    this.listen('branch-update');
   }
 
   register(port) {

--- a/web_src/js/features/notification.js
+++ b/web_src/js/features/notification.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import worker from './shared-worker.js';
+import getMemoizedSharedWorker from './shared-worker.js';
 
 const {appSubUrl, csrfToken, notificationSettings} = window.config;
 let notificationSequenceNumber = 0;
@@ -50,7 +50,9 @@ export function initNotificationCount() {
     return;
   }
 
-  if (notificationSettings.EventSourceUpdateTime > 0 && !!window.EventSource && window.SharedWorker) {
+  let worker;
+
+  if (notificationSettings.EventSourceUpdateTime > 0 && (worker = getMemoizedSharedWorker())) {
     // Try to connect to the event source via the shared worker first
     worker.port.addEventListener('message', (event) => {
       if (!event.data || !event.data.type) {

--- a/web_src/js/features/repo-refresh-pr.js
+++ b/web_src/js/features/repo-refresh-pr.js
@@ -6,23 +6,23 @@ async function receiveBranchUpdated(event) {
   try {
     const data = JSON.parse(event.data);
 
-    const staleBranchAlert = document.querySelector('.refresh-pull-request');
+    const refreshPullRequest = document.querySelector('.refresh-pull-request');
 
-    if (!staleBranchAlert) {
+    if (!refreshPullRequest) {
       return;
     }
 
-    const baseTarget = $(staleBranchAlert).data('baseTarget');
-    const headTarget = $(staleBranchAlert).data('headTarget');
-    const ownerName = $(staleBranchAlert).data('ownerName');
-    const repositoryName = $(staleBranchAlert).data('repositoryName');
+    const baseTarget = $(refreshPullRequest).data('baseTarget');
+    const headTarget = $(refreshPullRequest).data('headTarget');
+    const ownerName = $(refreshPullRequest).data('ownerName');
+    const repositoryName = $(refreshPullRequest).data('repositoryName');
 
     if (
       [baseTarget, headTarget].includes(data.Branch) &&
       data.Owner === ownerName &&
       data.Repository === repositoryName
     ) {
-      staleBranchAlert.classList.add('active');
+      refreshPullRequest.classList.add('active');
     }
   } catch (error) {
     console.error(error, event);

--- a/web_src/js/features/repo-refresh-pr.js
+++ b/web_src/js/features/repo-refresh-pr.js
@@ -6,9 +6,6 @@ async function receiveBranchUpdated(event) {
   try {
     const data = JSON.parse(event.data);
 
-    // eslint-disable-next-line no-console
-    console.log('Received data', data);
-
     const staleBranchAlert = document.querySelector('.refresh-pull-request');
 
     if (!staleBranchAlert) {
@@ -19,11 +16,6 @@ async function receiveBranchUpdated(event) {
     const headTarget = $(staleBranchAlert).data('headTarget');
     const ownerName = $(staleBranchAlert).data('ownerName');
     const repositoryName = $(staleBranchAlert).data('repositoryName');
-
-    // eslint-disable-next-line no-console
-    console.log($(staleBranchAlert).data());
-    // eslint-disable-next-line no-console
-    console.log(data);
 
     if (
       [baseTarget, headTarget].includes(data.Branch) &&
@@ -64,8 +56,6 @@ export function initRepoRefreshPullRequest() {
       url: `${window.location.origin}${appSubUrl}/user/events`,
     });
     worker.port.addEventListener('message', (event) => {
-      // eslint-disable-next-line no-console
-      console.log('received message', event);
       if (!event.data || !event.data.type) {
         console.error(event);
         return;

--- a/web_src/js/features/repo-refresh-pr.js
+++ b/web_src/js/features/repo-refresh-pr.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
-
-const {appSubUrl} = window.config;
+import worker from './shared-worker.js';
 
 async function receiveBranchUpdated(event) {
   try {
@@ -41,54 +40,13 @@ export function initRepoRefreshPullRequest() {
   });
 
   if (!!window.EventSource && window.SharedWorker) {
-    const worker = new SharedWorker(
-      `${__webpack_public_path__}js/eventsource.sharedworker.js`,
-      'notification-worker'
-    );
-    worker.addEventListener('error', (event) => {
-      console.error(event);
-    });
-    worker.port.addEventListener('messageerror', () => {
-      console.error('Unable to deserialize message');
-    });
-    worker.port.postMessage({
-      type: 'start',
-      url: `${window.location.origin}${appSubUrl}/user/events`,
-    });
     worker.port.addEventListener('message', (event) => {
       if (!event.data || !event.data.type) {
-        console.error(event);
         return;
       }
       if (event.data.type === 'branch-update') {
-        const _promise = receiveBranchUpdated(event.data);
-      } else if (event.data.type === 'error') {
-        console.error(event.data);
-      } else if (event.data.type === 'logout') {
-        if (event.data.data !== 'here') {
-          return;
-        }
-        worker.port.postMessage({
-          type: 'close',
-        });
-        worker.port.close();
-        window.location.href = appSubUrl;
-      } else if (event.data.type === 'close') {
-        worker.port.postMessage({
-          type: 'close',
-        });
-        worker.port.close();
+        receiveBranchUpdated(event.data);
       }
-    });
-    worker.port.addEventListener('error', (e) => {
-      console.error(e);
-    });
-    worker.port.start();
-    window.addEventListener('beforeunload', () => {
-      worker.port.postMessage({
-        type: 'close',
-      });
-      worker.port.close();
     });
   } else {
     console.error('Service workers not available');

--- a/web_src/js/features/repo-refresh-pr.js
+++ b/web_src/js/features/repo-refresh-pr.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import worker from './shared-worker.js';
+import getMemoizedSharedWorker from './shared-worker.js';
 
 async function receiveBranchUpdated(event) {
   try {
@@ -39,7 +39,9 @@ export function initRepoRefreshPullRequest() {
     window.location.reload();
   });
 
-  if (!!window.EventSource && window.SharedWorker) {
+  const worker = getMemoizedSharedWorker();
+
+  if (worker) {
     worker.port.addEventListener('message', (event) => {
       if (!event.data || !event.data.type) {
         return;

--- a/web_src/js/features/repo-refresh-pr.js
+++ b/web_src/js/features/repo-refresh-pr.js
@@ -1,0 +1,106 @@
+import $ from 'jquery';
+
+const {appSubUrl} = window.config;
+
+async function receiveBranchUpdated(event) {
+  try {
+    const data = JSON.parse(event.data);
+
+    // eslint-disable-next-line no-console
+    console.log('Received data', data);
+
+    const staleBranchAlert = document.querySelector('.refresh-pull-request');
+
+    if (!staleBranchAlert) {
+      return;
+    }
+
+    const baseTarget = $(staleBranchAlert).data('baseTarget');
+    const headTarget = $(staleBranchAlert).data('headTarget');
+    const ownerName = $(staleBranchAlert).data('ownerName');
+    const repositoryName = $(staleBranchAlert).data('repositoryName');
+
+    // eslint-disable-next-line no-console
+    console.log($(staleBranchAlert).data());
+    // eslint-disable-next-line no-console
+    console.log(data);
+
+    if (
+      [baseTarget, headTarget].includes(data.Branch) &&
+      data.Owner === ownerName &&
+      data.Repository === repositoryName
+    ) {
+      staleBranchAlert.classList.add('active');
+    }
+  } catch (error) {
+    console.error(error, event);
+  }
+}
+
+export function initRepoRefreshPullRequest() {
+  const staleBranchAlert = $('.refresh-pull-request');
+
+  if (!staleBranchAlert.length) {
+    return;
+  }
+
+  $(staleBranchAlert).on('click', () => {
+    window.location.reload();
+  });
+
+  if (!!window.EventSource && window.SharedWorker) {
+    const worker = new SharedWorker(
+      `${__webpack_public_path__}js/eventsource.sharedworker.js`,
+      'notification-worker'
+    );
+    worker.addEventListener('error', (event) => {
+      console.error(event);
+    });
+    worker.port.addEventListener('messageerror', () => {
+      console.error('Unable to deserialize message');
+    });
+    worker.port.postMessage({
+      type: 'start',
+      url: `${window.location.origin}${appSubUrl}/user/events`,
+    });
+    worker.port.addEventListener('message', (event) => {
+      // eslint-disable-next-line no-console
+      console.log('received message', event);
+      if (!event.data || !event.data.type) {
+        console.error(event);
+        return;
+      }
+      if (event.data.type === 'branch-update') {
+        const _promise = receiveBranchUpdated(event.data);
+      } else if (event.data.type === 'error') {
+        console.error(event.data);
+      } else if (event.data.type === 'logout') {
+        if (event.data.data !== 'here') {
+          return;
+        }
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
+        window.location.href = appSubUrl;
+      } else if (event.data.type === 'close') {
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
+      }
+    });
+    worker.port.addEventListener('error', (e) => {
+      console.error(e);
+    });
+    worker.port.start();
+    window.addEventListener('beforeunload', () => {
+      worker.port.postMessage({
+        type: 'close',
+      });
+      worker.port.close();
+    });
+  } else {
+    console.error('Service workers not available');
+  }
+}

--- a/web_src/js/features/shared-worker.js
+++ b/web_src/js/features/shared-worker.js
@@ -8,8 +8,6 @@ function getMemoizedSharedWorker() {
   }
 
   if (!worker) {
-    // eslint-disable-next-line no-console
-    console.log('Starting worker');
     worker = new SharedWorker(
       `${__webpack_public_path__}js/eventsource.sharedworker.js`,
       'notification-worker'

--- a/web_src/js/features/shared-worker.js
+++ b/web_src/js/features/shared-worker.js
@@ -1,0 +1,58 @@
+const {appSubUrl} = window.config;
+
+const worker = new SharedWorker(
+  `${__webpack_public_path__}js/eventsource.sharedworker.js`,
+  'notification-worker'
+);
+
+worker.addEventListener('error', (event) => {
+  console.error(event);
+});
+
+worker.port.addEventListener('messageerror', () => {
+  console.error('Unable to deserialize message');
+});
+
+worker.port.postMessage({
+  type: 'start',
+  url: `${window.location.origin}${appSubUrl}/user/events`,
+});
+
+worker.port.addEventListener('message', (event) => {
+  if (!event.data || !event.data.type) {
+    console.error(event);
+    return;
+  }
+  if (event.data.type === 'error') {
+    console.error(event.data);
+  } else if (event.data.type === 'logout') {
+    if (event.data.data !== 'here') {
+      return;
+    }
+    worker.port.postMessage({
+      type: 'close',
+    });
+    worker.port.close();
+    window.location.href = appSubUrl;
+  } else if (event.data.type === 'close') {
+    worker.port.postMessage({
+      type: 'close',
+    });
+    worker.port.close();
+  }
+});
+
+worker.port.addEventListener('error', (e) => {
+  console.error(e);
+});
+
+worker.port.start();
+
+window.addEventListener('beforeunload', () => {
+  worker.port.postMessage({
+    type: 'close',
+  });
+  worker.port.close();
+});
+
+export default worker;

--- a/web_src/js/features/shared-worker.js
+++ b/web_src/js/features/shared-worker.js
@@ -1,58 +1,72 @@
 const {appSubUrl} = window.config;
 
-const worker = new SharedWorker(
-  `${__webpack_public_path__}js/eventsource.sharedworker.js`,
-  'notification-worker'
-);
+let worker;
 
-worker.addEventListener('error', (event) => {
-  console.error(event);
-});
-
-worker.port.addEventListener('messageerror', () => {
-  console.error('Unable to deserialize message');
-});
-
-worker.port.postMessage({
-  type: 'start',
-  url: `${window.location.origin}${appSubUrl}/user/events`,
-});
-
-worker.port.addEventListener('message', (event) => {
-  if (!event.data || !event.data.type) {
-    console.error(event);
-    return;
+function getMemoizedSharedWorker() {
+  if (!window.EventSource || !window.SharedWorker) {
+    return null;
   }
-  if (event.data.type === 'error') {
-    console.error(event.data);
-  } else if (event.data.type === 'logout') {
-    if (event.data.data !== 'here') {
-      return;
-    }
-    worker.port.postMessage({
-      type: 'close',
+
+  if (!worker) {
+    // eslint-disable-next-line no-console
+    console.log('Starting worker');
+    worker = new SharedWorker(
+      `${__webpack_public_path__}js/eventsource.sharedworker.js`,
+      'notification-worker'
+    );
+
+    worker.addEventListener('error', (event) => {
+      console.error(event);
     });
-    worker.port.close();
-    window.location.href = appSubUrl;
-  } else if (event.data.type === 'close') {
-    worker.port.postMessage({
-      type: 'close',
+
+    worker.port.addEventListener('messageerror', () => {
+      console.error('Unable to deserialize message');
     });
-    worker.port.close();
+
+    worker.port.postMessage({
+      type: 'start',
+      url: `${window.location.origin}${appSubUrl}/user/events`,
+    });
+
+    worker.port.addEventListener('message', (event) => {
+      if (!event.data || !event.data.type) {
+        console.error(event);
+        return;
+      }
+      if (event.data.type === 'error') {
+        console.error(event.data);
+      } else if (event.data.type === 'logout') {
+        if (event.data.data !== 'here') {
+          return;
+        }
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
+        window.location.href = appSubUrl;
+      } else if (event.data.type === 'close') {
+        worker.port.postMessage({
+          type: 'close',
+        });
+        worker.port.close();
+      }
+    });
+
+    worker.port.addEventListener('error', (e) => {
+      console.error(e);
+    });
+
+    worker.port.start();
+
+    window.addEventListener('beforeunload', () => {
+      worker.port.postMessage({
+        type: 'close',
+      });
+      worker.port.close();
+    });
   }
-});
 
-worker.port.addEventListener('error', (e) => {
-  console.error(e);
-});
+  return worker;
+}
 
-worker.port.start();
-
-window.addEventListener('beforeunload', () => {
-  worker.port.postMessage({
-    type: 'close',
-  });
-  worker.port.close();
-});
-
-export default worker;
+export default getMemoizedSharedWorker;

--- a/web_src/js/features/stopwatch.js
+++ b/web_src/js/features/stopwatch.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import prettyMilliseconds from 'pretty-ms';
-import worker from './shared-worker.js';
+import getMemoizedSharedWorker from './shared-worker.js';
 
 const {appSubUrl, csrfToken, notificationSettings, enableTimeTracking} = window.config;
 let updateTimeInterval = null; // holds setInterval id when active
@@ -27,7 +27,9 @@ export function initStopwatch() {
     $(this).parent().trigger('submit');
   });
 
-  if (notificationSettings.EventSourceUpdateTime > 0 && !!window.EventSource && window.SharedWorker) {
+  let worker;
+
+  if (notificationSettings.EventSourceUpdateTime > 0 && (worker = getMemoizedSharedWorker())) {
     // Try to connect to the event source via the shared worker first
     worker.port.addEventListener('message', (event) => {
       if (!event.data || !event.data.type) {

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -82,6 +82,7 @@ import {initInstall} from './features/install.js';
 import {initCompWebHookEditor} from './features/comp/WebHookEditor.js';
 import {initCommonIssue} from './features/common-issue.js';
 import {initRepoBranchButton} from './features/repo-branch.js';
+import {initRepoRefreshPullRequest} from './features/repo-refresh-pr.js';
 import {initCommonOrganization} from './features/common-organization.js';
 import {initRepoWikiForm} from './features/repo-wiki.js';
 import {initRepoCommentForm, initRepository} from './features/repo-legacy.js';
@@ -176,6 +177,7 @@ $(document).ready(() => {
   initRepoSettingGitHook();
   initRepoSettingSearchTeamBox();
   initRepoSettingsCollaboration();
+  initRepoRefreshPullRequest();
   initRepoTemplateSearch();
   initRepoTopicBar();
   initRepoWikiForm();

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2572,6 +2572,14 @@
   display: none;
 }
 
+.refresh-pull-request {
+  display: none;
+
+  &.active {
+    display: inherit;
+  }
+}
+
 .ui.menu .item > img:not(.ui) {
   width: auto;
 }


### PR DESCRIPTION
Fixes #18427 

Had a quick go at the problem. Events are sent at the end of `hook_post_receive.go`, to all users returned by `access_model.GetRepoReaders()` for the updated repo. The FE event handler filters incoming events by owner, repo and branch. Both changes to the base and head target triggers the reveal of the refresh button.

Working good as far as I can tell, some more polish might be needed.

Questions:
* Should there be a polling fallback for this behavior if EventSource is not available in the browser?
* What color and position should be used for the button?
* Is the behavior displayed exactly the one discussed in the original issue, or did I miss something?
* Are all service workers supposed to use `notification-worker` for their name? Seemed to be the case in both the currently existing ones, so I followed that example... not sure if it makes sense or not.

Please give me your feedback!

EDIT: Removed WIP label