### PR TITLE
packages/generic: Do not restrict package versions to SemVer (#20414)

### DIFF
--- a/docs/content/doc/packages/generic.en-us.md
+++ b/docs/content/doc/packages/generic.en-us.md
@@ -37,7 +37,7 @@ PUT https://gitea.example.com/api/packages/{owner}/generic/{package_name}/{packa
 | ----------------- | ----------- |
 | `owner`           | The owner of the package. |
 | `package_name`    | The package name. It can contain only lowercase letters (`a-z`), uppercase letter (`A-Z`), numbers (`0-9`), dots (`.`), hyphens (`-`), or underscores (`_`). |
-| `package_version` | The package version as described in the [SemVer](https://semver.org/) spec. |
+| `package_version` | The package version, a non-empty string. |
 | `file_name`       | The filename. It can contain only lowercase letters (`a-z`), uppercase letter (`A-Z`), numbers (`0-9`), dots (`.`), hyphens (`-`), or underscores (`_`). |
 
 Example request using HTTP Basic authentication:

--- a/integrations/api_packages_generic_test.go
+++ b/integrations/api_packages_generic_test.go
@@ -42,7 +42,6 @@ func TestPackageGeneric(t *testing.T) {
 
 		pd, err := packages.GetPackageDescriptor(db.DefaultContext, pvs[0])
 		assert.NoError(t, err)
-		assert.NotNil(t, pd.SemVer)
 		assert.Nil(t, pd.Metadata)
 		assert.Equal(t, packageName, pd.Package.Name)
 		assert.Equal(t, packageVersion, pd.Version.Version)

--- a/routers/api/packages/generic/generic.go
+++ b/routers/api/packages/generic/generic.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"strings"
 
 	packages_model "code.gitea.io/gitea/models/packages"
 	"code.gitea.io/gitea/modules/context"
@@ -15,8 +16,6 @@ import (
 	packages_module "code.gitea.io/gitea/modules/packages"
 	"code.gitea.io/gitea/routers/api/packages/helper"
 	packages_service "code.gitea.io/gitea/services/packages"
-
-	"github.com/hashicorp/go-version"
 )
 
 var (
@@ -97,8 +96,7 @@ func UploadPackage(ctx *context.Context) {
 				Name:        packageName,
 				Version:     packageVersion,
 			},
-			SemverCompatible: true,
-			Creator:          ctx.Doer,
+			Creator: ctx.Doer,
 		},
 		&packages_service.PackageFileCreationInfo{
 			PackageFileInfo: packages_service.PackageFileInfo{
@@ -157,10 +155,10 @@ func sanitizeParameters(ctx *context.Context) (string, string, string, error) {
 		return "", "", "", errors.New("Invalid package name or filename")
 	}
 
-	v, err := version.NewSemver(ctx.Params("packageversion"))
-	if err != nil {
-		return "", "", "", err
+	packageVersion := strings.TrimSpace(ctx.Params("packageversion"))
+	if packageVersion == "" {
+		return "", "", "", errors.New("Invalid package version")
 	}
 
-	return packageName, v.String(), filename, nil
+	return packageName, packageVersion, filename, nil
 }


### PR DESCRIPTION
backport #20414

There are existing packages out there whose version do not conform to SemVer, yet, one would like to have them available in a generic package repository. To this end, remove the SemVer restriction on package versions when using the Generic package registry, and replace it with a check that simply makes sure the version isn't empty.

Signed-off-by: Gergely Nagy <me@gergo.csillger.hu>
Co-authored-by: KN4CK3R <admin@oldschoolhack.me>
Co-authored-by: 6543 <6543@obermui.de>