### PR TITLE
Reorder documentation sidebar for better discoverability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,12 +30,11 @@ make server
 When you are done with your changes just create a pull request, after merging
 the pull request the website will be updated automatically.
 
-
 ### Tips
 
-- Instead of adding things to the FAQ, try to consolidate information with existing pages or create a new section if enough once content is available.
+* Instead of adding things to the FAQ, try to consolidate information with existing pages or create a new section if enough once content is available.
 
-- For new pages, select a good location in the sidebar using the `menu.sidebar.weight` and `menu.sidebar.parent` metadata attributes
+* For new pages, select a good location in the sidebar using the `menu.sidebar.weight` and `menu.sidebar.parent` metadata attributes
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,13 @@ make server
 When you are done with your changes just create a pull request, after merging
 the pull request the website will be updated automatically.
 
+
+### Tips
+
+- Instead of adding things to the FAQ, try to consolidate information with existing pages or create a new section if enough once content is available.
+
+- For new pages, select a good location in the sidebar using the `menu.sidebar.weight` and `menu.sidebar.parent` metadata attributes
+
 ## Contributing
 
 Fork -> Patch -> Push -> Pull Request

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -9,7 +9,7 @@ menu:
   sidebar:
     parent: "advanced"
     name: "Config Cheat Sheet"
-    weight: 20
+    weight: 1
     identifier: "config-cheat-sheet"
 ---
 

--- a/docs/content/doc/developers/integrations.en-us.md
+++ b/docs/content/doc/developers/integrations.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-04-15T17:29:00+08:00"
-title: "Integrations"
+title: "Web UI API"
 slug: "integrations"
 weight: 40
 toc: false
@@ -8,22 +8,12 @@ draft: false
 menu:
   sidebar:
     parent: "developers"
-    name: "Integrations"
+    name: "Web UI API"
     weight: 65
     identifier: "integrations"
 ---
 
-# Integrations
-
-Gitea has a wonderful community of third-party integrations, as well as first-class support in various other
-projects.
-
-We are curating a list over at [awesome-gitea](https://gitea.com/gitea/awesome-gitea) to track these!
-
-If you are looking for [CI/CD](https://gitea.com/gitea/awesome-gitea#user-content-devops),
-an [SDK](https://gitea.com/gitea/awesome-gitea#user-content-sdk),
-or even some extra [themes](https://gitea.com/gitea/awesome-gitea#user-content-themes),
-you can find them listed in the [awesome-gitea](https://gitea.com/gitea/awesome-gitea) repository!
+# Web UI API
 
 ## Pre-Fill New File name and contents
 

--- a/docs/content/doc/features/integrations.en-us.md
+++ b/docs/content/doc/features/integrations.en-us.md
@@ -1,0 +1,25 @@
+---
+date: "2019-04-15T17:29:00+08:00"
+title: "Integrations"
+slug: "thirdparty"
+toc: false
+draft: false
+menu:
+  sidebar:
+    parent: "features"
+    name: "3rd-party Integrations"
+    weight: 65
+    identifier: "thirdparty"
+---
+
+# Integrations
+
+Gitea has a wonderful community of third-party integrations, as well as first-class support in various other
+projects.
+
+We are curating a list over at [awesome-gitea](https://gitea.com/gitea/awesome-gitea) to track these!
+
+If you are looking for [CI/CD](https://gitea.com/gitea/awesome-gitea#user-content-devops),
+an [SDK](https://gitea.com/gitea/awesome-gitea#user-content-sdk),
+or even some extra [themes](https://gitea.com/gitea/awesome-gitea#user-content-themes),
+you can find them listed in the [awesome-gitea](https://gitea.com/gitea/awesome-gitea) repository!

--- a/docs/content/doc/features/integrations.zh-tw.md
+++ b/docs/content/doc/features/integrations.zh-tw.md
@@ -1,13 +1,13 @@
 ---
 date: "2019-04-15T17:29:00+08:00"
 title: "整合"
-slug: "integrations"
+slug: "thirdparty"
 weight: 40
 toc: false
 draft: false
 menu:
   sidebar:
-    parent: "developers"
+    parent: "features"
     name: "整合"
     weight: 65
     identifier: "integrations"

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -210,9 +210,7 @@ Which makes all other paths non-writeable to Gitea.
 
 ## Translation is incorrect/how to add more translations
 
-Our translations are currently crowd-sourced on our [Crowdin project](https://crowdin.com/project/gitea)
-
-Whether you want to change a translation or add a new one, it will need to be there as all translations are overwritten in our CI via the Crowdin integration.
+Check the [localization section]({{< relref "doc/translation/localization.en-us.md" >}}) on how to add or change translations.
 
 ## Hooks aren't running
 

--- a/docs/content/doc/translation/localization.en-us.md
+++ b/docs/content/doc/translation/localization.en-us.md
@@ -7,7 +7,7 @@ toc: false
 draft: false
 menu:
   sidebar:
-    parent: "features"
+    parent: "translation"
     name: "Localization"
     weight: 20
     identifier: "localization"
@@ -21,6 +21,12 @@ For changes to an **English** translation, a pull request can be made that chang
 the [english locale](https://github.com/go-gitea/gitea/blob/master/options/locale/locale_en-US.ini).
 
 For changes to a **non-English** translation, refer to the Crowdin project above.
+Please don't submit non-English translation updates via GitHub pull requests, as they will be overwritten with the translations in Crowdin.
+
+## Adding a new translation
+
+If you want to add an entirely new translation, please [contact us]({{< relref "doc/help/seek-help" >}}) so we can set that up in Crowdin.
+Please understand that we only add new translations, if there is a volunteer for maintaining this translation with future changes.
 
 ## Supported Languages
 

--- a/docs/content/doc/translation/localization.zh-cn.md
+++ b/docs/content/doc/translation/localization.zh-cn.md
@@ -7,7 +7,7 @@ toc: false
 draft: false
 menu:
   sidebar:
-    parent: "features"
+    parent: "translation"
     name: "本地化"
     weight: 20
     identifier: "localization"

--- a/docs/content/doc/translation/localization.zh-tw.md
+++ b/docs/content/doc/translation/localization.zh-tw.md
@@ -7,7 +7,7 @@ toc: false
 draft: false
 menu:
   sidebar:
-    parent: "features"
+    parent: "translation"
     name: "在地化"
     weight: 20
     identifier: "localization"

--- a/docs/content/page/index.en-us.md
+++ b/docs/content/page/index.en-us.md
@@ -298,6 +298,3 @@ You can try it out using [the online demo](https://try.gitea.io/).
   - [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)
   - [github.com/denisenkom/go-mssqldb](https://github.com/denisenkom/go-mssqldb)
 
-## Software and Service Support
-
-- [Drone](https://github.com/drone/drone) (CI)

--- a/docs/content/page/index.en-us.md
+++ b/docs/content/page/index.en-us.md
@@ -297,4 +297,3 @@ You can try it out using [the online demo](https://try.gitea.io/).
   - [github.com/lib/pq](https://github.com/lib/pq)
   - [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)
   - [github.com/denisenkom/go-mssqldb](https://github.com/denisenkom/go-mssqldb)
-


### PR DESCRIPTION
Apart from reordering some pages, this cleans up invalid page metadata and adds some guidance to the README.

- [ ] add new `overview`, `configuration` categories
- [ ] dissolve `upgrade` category (move `upgrade from gogs` to `installation`)
- [ ] dissolve `features` category (?)
  - [x] localization: →translation
  - [ ] comparison: →overview
  - [ ] authentication: →usage
  - [ ] webhooks: →usage
- [x] integrations: developers→`overview`
- [ ] (clean up `usage` category (plenty of pages that should be in `configuration`))
- [ ] (clean up `advanced` category (plentry of pages that should be in `usage` or `configuration`))


This revives my stale PR #16392, but I'll split changes over several PRs so they can be easily reviewed & merged.