### PR TITLE
Protect against ReferenceError when creating SharedWorker

### DIFF
--- a/web_src/js/features/eventsource.sharedworker.js
+++ b/web_src/js/features/eventsource.sharedworker.js
@@ -93,10 +93,18 @@ self.addEventListener('connect', (e) => {
           }
         }
         // Create a new Source
-        source = new Source(url);
-        source.register(port);
-        sourcesByUrl[url] = source;
-        sourcesByPort[port] = source;
+        try {
+          source = new Source(url);
+          source.register(port);
+          sourcesByUrl[url] = source;
+          sourcesByPort[port] = source;
+        } catch (error) {
+          port.postMessage({
+            type: 'error',
+            message: `unable to create Source: ${error}`,
+          });
+          port.close();
+        }
       } else if (event.data.type === 'listen') {
         const source = sourcesByPort[port];
         source.listen(event.data.eventType);


### PR DESCRIPTION
Some browsers do not have EventSource within the SharedWorker context even though
it is available in the normal context. This leads to a global error percolating
up to the main page.

Here we simply wrap the new Source in a try/catch and catch the error falling back
to a poller if so.

Fix #20572

Signed-off-by: Andrew Thornton <art27@cantab.net>
