### PR TITLE
Should also support upper-case README files

### DIFF
--- a/modules/markup/renderer.go
+++ b/modules/markup/renderer.go
@@ -328,11 +328,13 @@ func IsReadmeFile(name string) bool {
 // the length of the provided extension list.
 // Note that the '.' should be provided in ext, e.g ".md"
 func IsReadmeFileExtension(name string, ext ...string) (int, bool) {
+	name = strings.ToLower(name)
 	if len(name) < 6 || name[:6] != "readme" {
 		return 0, false
 	}
 
 	for i, extension := range ext {
+		extension = strings.ToLower(extension)
 		if name[6:] == extension {
 			return i, true
 		}

--- a/modules/markup/renderer_test.go
+++ b/modules/markup/renderer_test.go
@@ -59,6 +59,16 @@ func TestMisc_IsReadmeFile(t *testing.T) {
 			idx:      0,
 		},
 		{
+			name:     "README.md",
+			expected: true,
+			idx:      0,
+		},
+		{
+			name:     "ReAdMe.Md",
+			expected: true,
+			idx:      0,
+		},
+		{
 			name:     "readme.txt",
 			expected: true,
 			idx:      1,


### PR DESCRIPTION
Address the issue introduced in https://github.com/go-gitea/gitea/pull/20508 (https://github.com/go-gitea/gitea/pull/20508/commits/79741dd1816c26404ef36b216049e9f3b4b72f5d), also added some case in existing test that cover this issue.

`IsReadmeFileExtension` only match the lower-case `readme` file, and also require the extensions use the same caption case as the provided ones, so `README.md` and `readme.MD` will no longer be supported. After this patch, it will be once again become supported.