### PR TITLE
Fix the new-line copy-paste for rendered code

### DIFF
--- a/modules/highlight/highlight_test.go
+++ b/modules/highlight/highlight_test.go
@@ -43,18 +43,29 @@ func TestFile(t *testing.T) {
 					- go test -v -race -coverprofile=coverage.txt -covermode=atomic
 			`),
 			want: util.Dedent(`
-				<span class="line"><span class="cl"><span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l">pipeline</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">default</span>
-				</span></span><span class="line"><span class="cl">
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">steps</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span>- <span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">test</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">golang:1.13</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">environment</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="w">		</span><span class="nt">GOPROXY</span><span class="p">:</span><span class="w"> </span><span class="l">https://goproxy.cn</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">commands</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="w">	</span>- <span class="l">go get -u</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go build -v</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go test -v -race -coverprofile=coverage.txt -covermode=atomic</span></span></span>
+				<span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l">pipeline</span><span class="w">
+				</span>
+				<span class="w"></span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">default</span><span class="w">
+				</span>
+				<span class="w">
+				</span>
+				<span class="w"></span><span class="nt">steps</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span>- <span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">test</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">golang:1.13</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">environment</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span><span class="w">		</span><span class="nt">GOPROXY</span><span class="p">:</span><span class="w"> </span><span class="l">https://goproxy.cn</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">commands</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span><span class="w">	</span>- <span class="l">go get -u</span><span class="w">
+				</span>
+				<span class="w">	</span>- <span class="l">go build -v</span><span class="w">
+				</span>
+				<span class="w">	</span>- <span class="l">go test -v -race -coverprofile=coverage.txt -covermode=atomic</span>
 			`),
 		},
 		{
@@ -76,19 +87,30 @@ func TestFile(t *testing.T) {
 					- go test -v -race -coverprofile=coverage.txt -covermode=atomic
 			`)+"\n", "name: default", "name: default  ", 1),
 			want: util.Dedent(`
-				<span class="line"><span class="cl"><span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l">pipeline</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">default  </span>
-				</span></span><span class="line"><span class="cl">
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">steps</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span>- <span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">test</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">golang:1.13</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">environment</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="w">		</span><span class="nt">GOPROXY</span><span class="p">:</span><span class="w"> </span><span class="l">https://goproxy.cn</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span><span class="nt">commands</span><span class="p">:</span>
-				</span></span><span class="line"><span class="cl"><span class="w"></span><span class="w">	</span>- <span class="l">go get -u</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go build -v</span>
-				</span></span><span class="line"><span class="cl"><span class="w">	</span>- <span class="l">go test -v -race -coverprofile=coverage.txt -covermode=atomic</span>
-				</span></span>
+				<span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l">pipeline</span><span class="w">
+				</span>
+				<span class="w"></span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">default  </span><span class="w">
+				</span>
+				<span class="w">
+				</span>
+				<span class="w"></span><span class="nt">steps</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span>- <span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l">test</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">golang:1.13</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">environment</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span><span class="w">		</span><span class="nt">GOPROXY</span><span class="p">:</span><span class="w"> </span><span class="l">https://goproxy.cn</span><span class="w">
+				</span>
+				<span class="w">	</span><span class="nt">commands</span><span class="p">:</span><span class="w">
+				</span>
+				<span class="w"></span><span class="w">	</span>- <span class="l">go get -u</span><span class="w">
+				</span>
+				<span class="w">	</span>- <span class="l">go build -v</span><span class="w">
+				</span>
+				<span class="w">	</span>- <span class="l">go test -v -race -coverprofile=coverage.txt -covermode=atomic</span><span class="w">
+				</span>
 				<span class="w">
 				</span>
 			`),


### PR DESCRIPTION
Credits to zeripath.

> The code for detection of lines in highlight.go is somewhat too complex and doesn't take account of how Chroma is actually splitting things into lines for us.

Backport for #19967  (only backport the fix, not the refactoring)
* #19967

Fix:
* https://github.com/go-gitea/gitea/issues/19331

Remove both the `.line` and `.cl` classes from Chroma's HTML which made the old conditional work again. This fixed Copy of YAML files for me while also reducing the amount of rendered HTML nodes.
