### PR TITLE
Enable Wire 2 for Internal SSH Server (#20616)

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -75,11 +75,21 @@ func sessionHandler(session ssh.Session) {
 	ctx, cancel := context.WithCancel(session.Context())
 	defer cancel()
 
+	gitProtocol := ""
+	for _, env := range session.Environ() {
+		if strings.HasPrefix(env, "GIT_PROTOCOL=") {
+			// The value would be version=2, so using normal split doesn't work here.
+			gitProtocol = strings.SplitN(env, "=", 2)[1]
+			break
+		}
+	}
+
 	cmd := exec.CommandContext(ctx, setting.AppPath, args...)
 	cmd.Env = append(
 		os.Environ(),
 		"SSH_ORIGINAL_COMMAND="+command,
 		"SKIP_MINWINSVC=1",
+		"GIT_PROTOCOL="+gitProtocol,
 	)
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
- Backport of #20616
  - Git only decides to use the Wire 2 protocol when `git {receive,upload}-pack` receive the `GIT_PROTOCOL` environment with as value `version=2`. Currently the internal SSH Server wasn't passing this environment through. The `gitea serv` code already passed all received environments to the git command, so no code changes there.
  - This is mentioned in Git manual, https://git-scm.com/docs/git#Documentation/git.txt-codeGITPROTOCOLcode

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
