### PR TITLE
Fixes #20625 - Puts wiki header links on the right

### DIFF
--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -24,7 +24,7 @@ export function initMarkupAnchors() {
     a.classList.add('anchor');
     a.setAttribute('href', `#${encodeURIComponent(originalId)}`);
     a.innerHTML = svg('octicon-link');
-    heading.prepend(a);
+    heading.append(a);
   }
 
   scrollToAnchor();

--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -30,8 +30,7 @@
   }
 
   .anchor {
-    padding-right: 4px;
-    margin-left: -20px;
+    margin-left: 4px;
     line-height: 1;
     color: inherit;
   }


### PR DESCRIPTION
Moves header links to the right hand side of the text.

Before:

![image](https://user-images.githubusercontent.com/96976531/182367763-1e3c2da4-7746-45bf-8698-7e6a256243f5.png)

After:

![image](https://user-images.githubusercontent.com/96976531/182368077-9764ba45-dfa4-4d56-9a8a-68c915f5eff5.png)


Fixes #20625 