### PR TITLE
Makes wiki ToC sticky

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3109,6 +3109,8 @@ td.blob-excerpt {
 }
 
 .wiki-content-toc {
+  position: sticky !important;
+  top: 14px;
   > ul > li {
     margin-bottom: 4px;
   }


### PR DESCRIPTION
Makes ToC follows viewport on wiki pages to ease navigation.

Top of page

![image](https://user-images.githubusercontent.com/96976531/182386700-ec3bde45-1826-4ec8-b619-99debdd2e1d5.png)

Scrolled

![image](https://user-images.githubusercontent.com/96976531/182386670-0b107b7c-efd7-4218-ae99-6385a9503664.png)
