### PR TITLE
Add default commit messages to PR for squash merge (#20618)

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -510,6 +510,8 @@ func PrepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git.C
 			return nil
 		}
 		ctx.Data["GetCommitMessages"] = pull_service.GetSquashMergeCommitMessages(ctx, pull)
+	} else {
+		ctx.Data["GetCommitMessages"] = ""
 	}
 
 	sha, err := baseGitRepo.GetRefCommitID(pull.GetGitRefName())

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -396,7 +396,7 @@
 										'allowed': {{$prUnit.PullRequestsConfig.AllowSquash}},
 										'textDoMerge': {{$.i18n.Tr "repo.pulls.squash_merge_pull_request"}},
 										'mergeTitleFieldText': defaultSquashMergeTitle,
-										'mergeMessageFieldText': defaultMergeMessage,
+										'mergeMessageFieldText': {{.GetCommitMessages}} + defaultMergeMessage,
 										'hideAutoMerge': generalHideAutoMerge,
 									},
 									{


### PR DESCRIPTION
Backport #20618

Keep the same behavior as 1.16