### PR TITLE
Change status code on package registry

### DIFF
--- a/routers/api/packages/nuget/nuget.go
+++ b/routers/api/packages/nuget/nuget.go
@@ -217,7 +217,7 @@ func UploadPackage(ctx *context.Context) {
 	)
 	if err != nil {
 		if err == packages_model.ErrDuplicatePackageVersion {
-			apiError(ctx, http.StatusBadRequest, err)
+			apiError(ctx, http.StatusConflict, err)
 			return
 		}
 		apiError(ctx, http.StatusInternalServerError, err)


### PR DESCRIPTION
This pr should fix #20624.

Based on the api documentation of the registry, the status code should be 409:
* Nuget: https://docs.microsoft.com/en-us/nuget/api/overview


Not changed:
* Composer: https://packagist.com/docs/api#/Package/createPackage (400 is documented)

I couldn't find any other documentation for other registries. I don't want to touch it if it works.