### PR TITLE
Fix issues.ref_closing_from in Russian

### DIFF
--- a/options/locale/locale_ru-RU.ini
+++ b/options/locale/locale_ru-RU.ini
@@ -1282,7 +1282,7 @@ issues.reopened_at=`переоткрыл(а) эту проблему <a id="%[1]
 issues.commit_ref_at=`упомянул эту задачу в коммите <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_issue_from=`<a href="%[3]s">ссылка на эту проблему %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_pull_from=`<a href="%[3]s">ссылается на этот запрос на слияние %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
-issues.ref_closing_from=`<a href="%[3]s">ссылается на запрос на слияние %[4], который закроет эту задачу</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+issues.ref_closing_from=`<a href="%[3]s">ссылается на запрос на слияние %[4]s, который закроет эту задачу</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_reopening_from=`<a href="%[3]s">ссылается на запрос на слияние %[4]s, который вновь откроет эту задачу</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_closed_from=`<a href="%[3]s">закрыл этот запрос %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 issues.ref_reopened_from=`<a href="%[3]s">переоткрыл эту задачу %[4]s</a> <a id="%[1]s" href="#%[1]s">%[2]s</a>`


### PR DESCRIPTION
This fix a translation for issues.ref_closing_from.

I already did this in [Crowdin](https://crowdin.com/translate/gitea/68/enus-ru?filter=basic&value=0#74642) and @zeripath adviced me to do PR to backport tihs change to the 1.17 branch.
