### PR TITLE
Use browser's default application open handler for non-dangerous MIME types

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -348,8 +348,13 @@ func (ctx *Context) RespHeader() http.Header {
 // SetServeHeaders sets necessary content serve headers
 func (ctx *Context) SetServeHeaders(filename string) {
 	ctx.Resp.Header().Set("Content-Description", "File Transfer")
-	ctx.Resp.Header().Set("Content-Type", "application/octet-stream")
-	ctx.Resp.Header().Set("Content-Disposition", "attachment; filename="+filename)
+	if strings.HasSuffix(filename, ".pdf") {
+		ctx.Resp.Header().Set("Content-Disposition", "inline; filename=\""+filename+"\"")
+		ctx.Resp.Header().Set("Content-Type", "application/pdf")
+	} else {
+		ctx.Resp.Header().Set("Content-Type", "application/octet-stream")
+		ctx.Resp.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	}
 	ctx.Resp.Header().Set("Content-Transfer-Encoding", "binary")
 	ctx.Resp.Header().Set("Expires", "0")
 	ctx.Resp.Header().Set("Cache-Control", "must-revalidate")


### PR DESCRIPTION
This changes PDF downloads to not be displayed inline in the browser (or preferred application) rather than being saved as a download. The current implementation requires multiple clicks to open PDFs included in `generic` packages.

There is no existing issue for this, and I have not created one.

Notably, this is **not** the way GitHub behaves, but is the way I **wish** GitHub behaved.

Additionally, this adds quotes to the filename parameter per [MSDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#syntax): 
> Warning: The string following filename should always be put into quotes; but, for compatibility reasons, many browsers try to parse unquoted names that contain spaces.

I have not tested this code or checked if this change has any (security?) consequences for usages of this function outside of serving `generic`-type package files. A MIME-type check (as opposed to this implementation's file extension check) may or may not be necessary.
