### PR TITLE
Add team and collaborators permission adjustment logs

### DIFF
--- a/models/admin/notice.go
+++ b/models/admin/notice.go
@@ -24,6 +24,8 @@ const (
 	NoticeRepository NoticeType = iota + 1
 	// NoticeTask type
 	NoticeTask
+	// Permission type
+	NoticePermission
 )
 
 // Notice represents a system notice for admin.
@@ -59,6 +61,13 @@ func CreateNotice(ctx context.Context, tp NoticeType, desc string, args ...inter
 func CreateRepositoryNotice(desc string, args ...interface{}) error {
 	// Note we use the db.DefaultContext here rather than passing in a context as the context may be cancelled
 	return CreateNotice(db.DefaultContext, NoticeRepository, desc, args...)
+}
+
+// CreatePermissionNotice creates new notice with type NoticePermission.
+func CreatePermissionNotice(desc string, args ...interface{}) {
+	if err := CreateNotice(db.DefaultContext, NoticePermission, desc, args...); err != nil {
+		log.Error("CreatePermissionNotice: %v", err)
+	}
 }
 
 // RemoveAllWithNotice removes all directories in given path and

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2955,6 +2955,17 @@ notices.type_2 = Task
 notices.desc = Description
 notices.op = Op.
 notices.delete_success = The system notices have been deleted.
+notices.addusertoteam = %s added user %s to %s/%s team
+notices.removeuserfromteam = %s removed user %s from %s/%s team
+notices.addteamtorepo = %s added team %s to %s/%s repository
+notices.removeteamfromrepo = %s removed team %s from %s/%s repository
+notices.addusertorepo = %s added user %s to %s/%s
+notices.removeuserfromrepo = %s removed user %s from %s/%s
+notices.addrepototeam = %s added repository %s/%s to %s
+notices.removerepofromteam = %s removed repository %s/%s from %s
+notices.addallrepostoteam = %s added all repository to %s/%s
+notices.removeallreposfromteam = %s removed all repository from %s/%s
+notices.adjustteampermissions = %s adjust team %s/%s permissions %v
 
 [action]
 create_repo = created repository <a href="%s">%s</a>

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -926,8 +926,9 @@ func CollaborationPost(ctx *context.Context) {
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.add_collaborator_success"))
 
-	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addusertorepo"), ctx.Doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
-
+	if doer := ctx.Doer; doer != nil {
+		admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addusertorepo"), doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	}
 	ctx.Redirect(setting.AppSubURL + ctx.Req.URL.EscapedPath())
 }
 
@@ -950,8 +951,9 @@ func DeleteCollaboration(ctx *context.Context) {
 	}
 
 	u, _ := user_model.GetUserByID(ctx.FormInt64("id"))
-	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeuserfromrepo"), ctx.Doer.GetDisplayName(), u.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
-
+	if doer := ctx.Doer; doer != nil {
+		admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeuserfromrepo"), doer.GetDisplayName(), u.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	}
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"redirect": ctx.Repo.RepoLink + "/settings/collaboration",
 	})
@@ -1029,7 +1031,9 @@ func DeleteTeam(ctx *context.Context) {
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.remove_team_success"))
 
-	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeteamfromrepo"), ctx.Doer.GetDisplayName(), team.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	if doer := ctx.Doer; doer != nil {
+		admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeteamfromrepo"), doer.GetDisplayName(), team.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	}
 
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"redirect": ctx.Repo.RepoLink + "/settings/collaboration",

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	admin_model "code.gitea.io/gitea/models/admin"
+
 	"code.gitea.io/gitea/models"
 	asymkey_model "code.gitea.io/gitea/models/asymkey"
 	"code.gitea.io/gitea/models/db"
@@ -923,6 +925,9 @@ func CollaborationPost(ctx *context.Context) {
 	}
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.add_collaborator_success"))
+
+	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addusertorepo"), ctx.Doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+
 	ctx.Redirect(setting.AppSubURL + ctx.Req.URL.EscapedPath())
 }
 
@@ -943,6 +948,9 @@ func DeleteCollaboration(ctx *context.Context) {
 	} else {
 		ctx.Flash.Success(ctx.Tr("repo.settings.remove_collaborator_success"))
 	}
+
+	u, _ := user_model.GetUserByID(ctx.FormInt64("id"))
+	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeuserfromrepo"), ctx.Doer.GetDisplayName(), u.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"redirect": ctx.Repo.RepoLink + "/settings/collaboration",
@@ -992,6 +1000,9 @@ func AddTeamPost(ctx *context.Context) {
 	}
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.add_team_success"))
+
+	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addteamtorepo"), ctx.Doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+
 	ctx.Redirect(ctx.Repo.RepoLink + "/settings/collaboration")
 }
 
@@ -1015,6 +1026,9 @@ func DeleteTeam(ctx *context.Context) {
 	}
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.remove_team_success"))
+
+	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.removeteamfromrepo"), ctx.Doer.GetDisplayName(), team.Name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"redirect": ctx.Repo.RepoLink + "/settings/collaboration",
 	})

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -1001,7 +1001,9 @@ func AddTeamPost(ctx *context.Context) {
 
 	ctx.Flash.Success(ctx.Tr("repo.settings.add_team_success"))
 
-	admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addteamtorepo"), ctx.Doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	if doer := ctx.Doer; doer != nil {
+		admin_model.CreatePermissionNotice(ctx.Tr("admin.notices.addteamtorepo"), doer.GetDisplayName(), name, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
+	}
 
 	ctx.Redirect(ctx.Repo.RepoLink + "/settings/collaboration")
 }


### PR DESCRIPTION
You can view the record of who operated the increase or decrease of repository collaborators from the management interface notice