### PR TITLE
Fix repeated actions on repository feed (#20738)

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -361,6 +361,13 @@ func GetFeeds(ctx context.Context, opts GetFeedsOptions) (ActionList, error) {
 
 	actions := make([]*Action, 0, opts.PageSize)
 
+	// De-duplicate any action that has the same created unix, as actions are stored for each user
+	// who can see that action. This probably (though there is no guarantee) means that they were the same
+	// action.
+	if opts.RequestedRepo != nil {
+		sess = sess.GroupBy("`action`.created_unix")
+	}
+
 	if err := sess.Desc("`action`.created_unix").Find(&actions); err != nil {
 		return nil, fmt.Errorf("Find: %v", err)
 	}

--- a/models/action.go
+++ b/models/action.go
@@ -365,7 +365,7 @@ func GetFeeds(ctx context.Context, opts GetFeedsOptions) (ActionList, error) {
 	// who can see that action. This probably (though there is no guarantee) means that they were the same
 	// action.
 	if opts.RequestedRepo != nil {
-		sess = sess.GroupBy("`action`.created_unix")
+		sess = sess.GroupBy("`action`.created_unix, `action`.op_type, `action`.act_user_id")
 	}
 
 	if err := sess.Desc("`action`.created_unix").Find(&actions); err != nil {

--- a/models/action_test.go
+++ b/models/action_test.go
@@ -68,6 +68,7 @@ func TestGetFeedsForRepos(t *testing.T) {
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
 	privRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2}).(*repo_model.Repository)
 	pubRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 8}).(*repo_model.Repository)
+	repoWithActions := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1}).(*repo_model.Repository)
 
 	// private repo & no login
 	actions, err := GetFeeds(db.DefaultContext, GetFeedsOptions{
@@ -102,6 +103,16 @@ func TestGetFeedsForRepos(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
+
+	// Check repository with four actions, all of them were created
+	// at the same time, but two of them are comments(one should be de-duped)
+	// the other one is closing a issue and the last one is also comment but by a different user.
+	// So in told there are 3 de-deduped actions.
+	actions, err = GetFeeds(db.DefaultContext, GetFeedsOptions{
+		RequestedRepo: repoWithActions,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, actions, 3)
 }
 
 func TestGetFeeds2(t *testing.T) {

--- a/models/fixtures/action.yml
+++ b/models/fixtures/action.yml
@@ -64,3 +64,38 @@
   repo_id: 1700 # dangling intentional
   is_private: false
   created_unix: 1603011541
+
+- id: 9
+  user_id: 10
+  op_type: 10
+  act_user_id: 10
+  repo_id: 1
+  content: HelloWorld
+  is_private: false
+  created_unix: 1603011301 # same as 10, 11, 12
+
+- id: 10
+  user_id: 9
+  op_type: 10
+  act_user_id: 10
+  repo_id: 1
+  content: HelloWorld
+  is_private: false
+  created_unix: 1603011301 # same as id 9, 11, 12
+
+- id: 11
+  user_id: 9
+  op_type: 12 # differ op_type
+  act_user_id: 10
+  repo_id: 1
+  is_private: false
+  created_unix: 1603011301 # same as id 9, 10, 12
+
+- id: 12
+  user_id: 9
+  op_type: 10
+  act_user_id: 9 # differ act_user_id
+  repo_id: 1
+  content: HelloWorld
+  is_private: false
+  created_unix: 1603011301 # same as id 9, 10, 11

--- a/models/user_heatmap_test.go
+++ b/models/user_heatmap_test.go
@@ -52,7 +52,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		},
 		{
 			"multiple actions performed with two grouped together",
-			10, 10, 3, `[{"timestamp":1603009800,"contributions":1},{"timestamp":1603010700,"contributions":2}]`,
+			10, 10, 4, `[{"timestamp":1603009800,"contributions":1},{"timestamp":1603010700,"contributions":2}]`,
 		},
 	}
 	// Prepare


### PR DESCRIPTION
- Backport #20738
  - Before understanding why this patch is here. The actions table stores the actions, this includes commenting on a issue, merging a pull request and pushing a tag etc. However, due to historical (and likely performance) reason, each action(e.g. commenting on a issue) is duplicated for each user(such as the poster, watcher of that issue and repository etc.).
  - This means, if you only specify the `repo_id` you will end up with a lot of duplicated actions. We fix this by de-duplicating the actions by their `created_unix`. While this isn't a perfect way of solving this problem, it will do the job for 99%. Only problems will arise for highly active repositories in which actions are being taken on the same second.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
