### PR TITLE
Remove manual rollback for failed generated repositories (#20639)

### DIFF
--- a/services/repository/template.go
+++ b/services/repository/template.go
@@ -7,12 +7,10 @@ package repository
 import (
 	"context"
 
-	"code.gitea.io/gitea/models"
 	"code.gitea.io/gitea/models/db"
 	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/notification"
 	repo_module "code.gitea.io/gitea/modules/repository"
 )
@@ -95,11 +93,6 @@ func GenerateRepository(doer, owner *user_model.User, templateRepo *repo_model.R
 
 		return nil
 	}); err != nil {
-		if generateRepo != nil && generateRepo.ID > 0 {
-			if errDelete := models.DeleteRepository(doer, owner.ID, generateRepo.ID); errDelete != nil {
-				log.Error("Rollback deleteRepository: %v", errDelete)
-			}
-		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Backport #20639

Generating repositories from a template is done inside a transaction.
Manual rollback on error is not needed and it always results in error
"repository does not exist".
