### PR TITLE
Check webhooks slice length before calling xorm (#20642)

### DIFF
--- a/models/webhook/webhook.go
+++ b/models/webhook/webhook.go
@@ -399,6 +399,10 @@ func CreateWebhook(ctx context.Context, w *Webhook) error {
 
 // CreateWebhooks creates multiple web hooks
 func CreateWebhooks(ctx context.Context, ws []*Webhook) error {
+	// xorm returns err "no element on slice when insert" for empty slices.
+	if len(ws) == 0 {
+		return nil
+	}
 	for i := 0; i < len(ws); i++ {
 		ws[i].Type = strings.TrimSpace(ws[i].Type)
 	}


### PR DESCRIPTION
backport from #20642

xorm.db.Insert errors for empty slices. Fixes: #20641

Co-authored-by: Lauris BH <lauris@nix.lv>
Co-authored-by: John Olheiser <john.olheiser@gmail.com>
Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>

