### PR TITLE
Fix git.Init for doctor sub-command

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -14,7 +14,6 @@ import (
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/migrations"
 	"code.gitea.io/gitea/modules/doctor"
-	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -127,11 +126,6 @@ func runRecreateTable(ctx *cli.Context) error {
 func runDoctor(ctx *cli.Context) error {
 	stdCtx, cancel := installSignals()
 	defer cancel()
-
-	// some doctor sub-commands need to use git command
-	if err := git.InitFull(stdCtx); err != nil {
-		return err
-	}
 
 	// Silence the default loggers
 	log.DelNamedLogger("console")

--- a/modules/doctor/doctor.go
+++ b/modules/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
@@ -49,7 +50,11 @@ func initDBDisableConsole(ctx context.Context, disableConsole bool) error {
 
 	setting.NewXORMLogService(disableConsole)
 	if err := db.InitEngine(ctx); err != nil {
-		return fmt.Errorf("models.SetEngine: %v", err)
+		return fmt.Errorf("db.InitEngine: %w", err)
+	}
+	// some doctor sub-commands need to use git command
+	if err := git.InitFull(ctx); err != nil {
+		return fmt.Errorf("git.InitFull: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
A bug was introduced by https://github.com/go-gitea/gitea/pull/20376
* https://github.com/go-gitea/gitea/pull/20376

Some doctor sub-commands need the git module.

Although putting the `git.InitFull` in `initDBDisableConsole` (which is controlled by `SkipDatabaseInitialization`) is not ideal, that's the only fix I can do at the moment. In the future the doctor sub-commands need some refactorings.

Sorry for that I didn't test the `doctor` sub-command carefully that time. 

For this PR, I have tested `make build && ./gitea doctor --all` and it works.

```
~/work/gitea$ ./gitea doctor --all
[1] Check paths and basic configuration
...
[17] Check if users have a valid username
 - [I] All users have a valid username.
OK
```

Reported by #20771, backport is #20783