### PR TITLE
Improve comment header for mobile (#20781)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3428,4 +3428,16 @@ td.blob-excerpt {
       }
     }
   }
+
+  .comment-header {
+    flex-wrap: wrap;
+
+    .comment-header-left {
+      flex-wrap: wrap;
+    }
+
+    .comment-header-right {
+      margin-left: auto;
+    }
+  }
 }


### PR DESCRIPTION
- Backport #20781
  - Since b9e8fa5 the avatar will be inlined into the comment header, so there's more room for the actual comment container(thus more text per line in the comment body). However this didn't take into consideration that the flex didn't allow any wrapping and thus was shrinking the avatar. Well this isn't a perfect solution, as you ideally all want these elements to be individually wrapped(such that comment-header-right can be on the same line as comment-header-left, which now causes a new line in certain situations). It's a better solution than the current CSS and to not mess with the desktop CSS/HTML.