### PR TITLE
Add missing translation for queue flush workers

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2895,6 +2895,7 @@ monitor.queue.nopool.title = No Worker Pool
 monitor.queue.nopool.desc = This queue wraps other queues and does not itself have a worker pool.
 monitor.queue.wrapped.desc = A wrapped queue wraps a slow starting queue, buffering queued requests in a channel. It does not have a worker pool itself.
 monitor.queue.persistable-channel.desc = A persistable-channel wraps two queues, a channel queue that has its own worker pool and a level queue for persisted requests from previous shutdowns. It does not have a worker pool itself.
+monitor.queue.flush = Flush worker
 monitor.queue.pool.timeout = Timeout
 monitor.queue.pool.addworkers.title = Add Workers
 monitor.queue.pool.addworkers.submit = Add Workers


### PR DESCRIPTION
- Add a missing translation key and value for the flush worker indication
- Resolves #20770

I haven't tested this PR as for some reason adding flush workers will just immediately disappear again even if I force a fixed number of fake queue items.
