### PR TITLE
Add missing translation for queue flush workers (#20791)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2886,6 +2886,7 @@ monitor.queue.nopool.title = No Worker Pool
 monitor.queue.nopool.desc = This queue wraps other queues and does not itself have a worker pool.
 monitor.queue.wrapped.desc = A wrapped queue wraps a slow starting queue, buffering queued requests in a channel. It does not have a worker pool itself.
 monitor.queue.persistable-channel.desc = A persistable-channel wraps two queues, a channel queue that has its own worker pool and a level queue for persisted requests from previous shutdowns. It does not have a worker pool itself.
+monitor.queue.flush = Flush worker
 monitor.queue.pool.timeout = Timeout
 monitor.queue.pool.addworkers.title = Add Workers
 monitor.queue.pool.addworkers.submit = Add Workers


### PR DESCRIPTION
- Backport #20791
  - Add a missing translation key and value for the flush worker indication
  - Resolves #20770

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
