### PR TITLE
Fix `make watch` for generated files

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,4 +7,4 @@ bin = "gitea"
 include_ext = ["go", "tmpl"]
 exclude_dir = ["modules/git/tests", "services/gitdiff/testdata", "modules/avatar/testdata"]
 include_dir = ["cmd", "models", "modules", "options", "routers", "services", "templates"]
-exclude_regex = ["_test.go$"]
+exclude_regex = ["_test.go$", "_gen.go$"]


### PR DESCRIPTION
- Don't rebuild the binary when generated files are updated, which is the case by-default when running `make watch`.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
