### PR TITLE
Fix tooltip init after review

### DIFF
--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -44,21 +44,22 @@ export function initRepoDiffConversationForm() {
   $(document).on('submit', '.conversation-holder form', async (e) => {
     e.preventDefault();
 
-    const form = $(e.target);
-    const $textArea = form.find('textarea');
+    const $form = $(e.target);
+    const $textArea = $form.find('textarea');
     if (!validateTextareaNonEmpty($textArea)) {
       return;
     }
 
-    const $newConversationHolder = $(await $.post(form.attr('action'), form.serialize()));
+    const formDataString = String(new URLSearchParams(new FormData($form[0])));
+    const $newConversationHolder = $(await $.post($form.attr('action'), formDataString));
     const {path, side, idx} = $newConversationHolder.data();
 
     $newConversationHolder.find('.tooltip').each(function () {
       initTooltip(this);
     });
 
-    form.closest('.conversation-holder').replaceWith($newConversationHolder);
-    if (form.closest('tr').data('line-type') === 'same') {
+    $form.closest('.conversation-holder').replaceWith($newConversationHolder);
+    if ($form.closest('tr').data('line-type') === 'same') {
       $(`[data-path="${path}"] a.add-code-comment[data-idx="${idx}"]`).addClass('invisible');
     } else {
       $(`[data-path="${path}"] a.add-code-comment[data-side="${side}"][data-idx="${idx}"]`).addClass('invisible');

--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -50,18 +50,21 @@ export function initRepoDiffConversationForm() {
       return;
     }
 
-    const newConversationHolder = $(await $.post(form.attr('action'), form.serialize()));
-    const {path, side, idx} = newConversationHolder.data();
+    const $newConversationHolder = $(await $.post(form.attr('action'), form.serialize()));
+    const {path, side, idx} = $newConversationHolder.data();
 
-    initTooltip(newConversationHolder.find('.tooltip'));
-    form.closest('.conversation-holder').replaceWith(newConversationHolder);
+    $newConversationHolder.find('.tooltip').each(function () {
+      initTooltip(this);
+    });
+
+    form.closest('.conversation-holder').replaceWith($newConversationHolder);
     if (form.closest('tr').data('line-type') === 'same') {
       $(`[data-path="${path}"] a.add-code-comment[data-idx="${idx}"]`).addClass('invisible');
     } else {
       $(`[data-path="${path}"] a.add-code-comment[data-side="${side}"][data-idx="${idx}"]`).addClass('invisible');
     }
-    newConversationHolder.find('.dropdown').dropdown();
-    initCompReactionSelector(newConversationHolder);
+    $newConversationHolder.find('.dropdown').dropdown();
+    initCompReactionSelector($newConversationHolder);
   });
 
 


### PR DESCRIPTION
Previous code passed a jQuery collection which `initTooltip` couldn't handle. Instead, iterate the individial matched elements and add a dollar to the variable name to make it clear it's jQuery.

Fixes: https://github.com/go-gitea/gitea/issues/20809