### PR TITLE
Use the total issue count for UI (#20785)

### DIFF
--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -607,10 +607,8 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 	var shownIssues int
 	if !isShowClosed {
 		shownIssues = int(issueStats.OpenCount)
-		ctx.Data["TotalIssueCount"] = shownIssues
 	} else {
 		shownIssues = int(issueStats.ClosedCount)
-		ctx.Data["TotalIssueCount"] = shownIssues
 	}
 	if len(repoIDs) != 0 {
 		shownIssues = 0
@@ -618,6 +616,12 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 			shownIssues += int(issueCountByRepo[repoID])
 		}
 	}
+
+	var allIssueCount int64
+	for _, issueCount := range issueCountByRepo {
+		allIssueCount += issueCount
+	}
+	ctx.Data["TotalIssueCount"] = allIssueCount
 
 	ctx.Data["IsShowClosed"] = isShowClosed
 


### PR DESCRIPTION
Backport #20785

This fixes a problem where the "All" line item on the Issues or Pull Requests page was only showing the count of the selected repos instead of the total of all issues/prs in all repos.

The "total number of shown issues" number is now stashed in a different context variable in case it wants to be used by the frontend later. It's currently not being used.

Fixes #20574