### PR TITLE
Executable check always returns true for windows (#20637)

### DIFF
--- a/modules/repository/hooks.go
+++ b/modules/repository/hooks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
@@ -153,6 +154,10 @@ func createDelegateHooks(repoPath string) (err error) {
 }
 
 func checkExecutable(filename string) bool {
+	// windows has no concept of a executable bit
+	if runtime.GOOS == "windows" {
+		return true
+	}
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
 		return false


### PR DESCRIPTION
Backport #20637

Windows doesn't have the concept of "executable" POSIX bits so for now always return true to minimise doctor and logging noise. Addresses #20636

Co-authored-by: silverwind <me@silverwind.io>
