### PR TITLE
Check Mirror exists before linking its Repo (#20840)

### DIFF
--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -153,7 +153,9 @@ func (repos MirrorRepositoryList) loadAttributes(ctx context.Context) error {
 	}
 	for i := range repos {
 		repos[i].Mirror = set[repos[i].ID]
-		repos[i].Mirror.Repo = repos[i]
+		if repos[i].Mirror != nil {
+			repos[i].Mirror.Repo = repos[i]
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
backport #20840 and fix #20804

In MirrorRepositoryList.loadAttributes there is some code to load the Mirror entries
from the database. This assumes that every Repository which has IsMirror set has
a Mirror associated in the DB. This association is incorrect in the case of
Mirror repository under creation when there is no Mirror entry in the DB until
completion.

Unfortunately LoadAttributes makes this incorrect assumption and presumes that a
Mirror will always be loaded. This then causes a panic.

This PR simply double checks if there a Mirror before attempting to link back to
its Repo. Unfortunately it should be expected that there may be other cases where
this incorrect assumption causes further problems.

Fix #20804

Signed-off-by: Andrew Thornton <art27@cantab.net>

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>