### PR TITLE
Prevent 500 is head repo does not have PullRequest unit in IsUserAllowedToUpdate (#20839)

### DIFF
--- a/services/pull/update.go
+++ b/services/pull/update.go
@@ -87,6 +87,9 @@ func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, 
 	}
 	headRepoPerm, err := access_model.GetUserRepoPermission(ctx, pull.HeadRepo, user)
 	if err != nil {
+		if repo_model.IsErrUnitTypeNotExist(err) {
+			return false, false, nil
+		}
 		return false, false, err
 	}
 


### PR DESCRIPTION
Backport #20839 

Some repositories do not have the PullRequest unit present in their configuration
and unfortunately the way that IsUserAllowedToUpdate currently works assumes
that this is an error instead of just returning false.

This PR simply swallows this error allowing the function to return false.

Fix #20621

Signed-off-by: Andrew Thornton <art27@cantab.net>

Signed-off-by: Andrew Thornton <art27@cantab.net>
