### PR TITLE
WIP: Fix reaction already exists

### DIFF
--- a/models/issues/reaction.go
+++ b/models/issues/reaction.go
@@ -116,7 +116,7 @@ func (opts *FindReactionsOptions) toConds() builder.Cond {
 	// If it is -1 it explicit search of Issue Reactions where CommentID = 0
 	if opts.CommentID > 0 {
 		cond = cond.And(builder.Eq{"reaction.comment_id": opts.CommentID})
-	} else if opts.CommentID == -1 {
+	} else if opts.CommentID <= 0 {
 		cond = cond.And(builder.Eq{"reaction.comment_id": 0})
 	}
 	if opts.UserID > 0 {


### PR DESCRIPTION
If someone else has already clicked the icon, there will be an error when clicking the icon from the upper right corner, In gitea.log display below log

`2022/08/19 13:39:43 ...rs/web/repo/issue.go:2815:ChangeIssueReaction() [I] [62ff221e] CreateIssueReaction: reaction 'eyes' already exists`
