### PR TITLE
Fix the mode of custom dir to 0700 in docker-rootless

### DIFF
--- a/docker/rootless/usr/local/bin/docker-setup.sh
+++ b/docker/rootless/usr/local/bin/docker-setup.sh
@@ -5,7 +5,7 @@ mkdir -p ${HOME} && chmod 0700 ${HOME}
 if [ ! -w ${HOME} ]; then echo "${HOME} is not writable"; exit 1; fi
 
 # Prepare custom folder
-mkdir -p ${GITEA_CUSTOM} && chmod 0500 ${GITEA_CUSTOM}
+mkdir -p ${GITEA_CUSTOM} && chmod 0700 ${GITEA_CUSTOM}
 
 # Prepare temp folder
 mkdir -p ${GITEA_TEMP} && chmod 0700 ${GITEA_TEMP}


### PR DESCRIPTION
The 0500 came from #10154, more than 2 years ago. Maybe at that time people think that this directory wouldn't be changed anymore and make it secure. However, more and more directories may be added during Gitea's development.
* #10154


Close #20570
* #20570

Some things that I still do not fully understand:
* Is there any other purpose for the 0500?
* Since 1.17 has been released for a long time, why there is only a few (one?) issues reporting about it.
