### PR TITLE
Fix SQL Query for `SearchTeam` (#20844)

### DIFF
--- a/integrations/api_team_test.go
+++ b/integrations/api_team_test.go
@@ -223,7 +223,7 @@ func TestAPITeamSearch(t *testing.T) {
 	defer prepareTestEnv(t)()
 
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
-	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)
+	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 17}).(*user_model.User)
 
 	var results TeamSearchResults
 

--- a/integrations/api_user_orgs_test.go
+++ b/integrations/api_user_orgs_test.go
@@ -26,8 +26,19 @@ func TestUserOrgs(t *testing.T) {
 	orgs := getUserOrgs(t, adminUsername, normalUsername)
 
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user3"}).(*user_model.User)
+	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"})
 
 	assert.Equal(t, []*api.Organization{
+		{
+			ID:          17,
+			UserName:    user17.Name,
+			FullName:    user17.FullName,
+			AvatarURL:   user17.AvatarLink(),
+			Description: "",
+			Website:     "",
+			Location:    "",
+			Visibility:  "public",
+		},
 		{
 			ID:          3,
 			UserName:    user3.Name,
@@ -82,8 +93,19 @@ func TestMyOrgs(t *testing.T) {
 	var orgs []*api.Organization
 	DecodeJSON(t, resp, &orgs)
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user3"}).(*user_model.User)
+	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"})
 
 	assert.Equal(t, []*api.Organization{
+		{
+			ID:          17,
+			UserName:    user17.Name,
+			FullName:    user17.FullName,
+			AvatarURL:   user17.AvatarLink(),
+			Description: "",
+			Website:     "",
+			Location:    "",
+			Visibility:  "public",
+		},
 		{
 			ID:          3,
 			UserName:    user3.Name,

--- a/integrations/api_user_orgs_test.go
+++ b/integrations/api_user_orgs_test.go
@@ -26,7 +26,7 @@ func TestUserOrgs(t *testing.T) {
 	orgs := getUserOrgs(t, adminUsername, normalUsername)
 
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user3"}).(*user_model.User)
-	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"})
+	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"}).(*user_model.User)
 
 	assert.Equal(t, []*api.Organization{
 		{
@@ -93,7 +93,7 @@ func TestMyOrgs(t *testing.T) {
 	var orgs []*api.Organization
 	DecodeJSON(t, resp, &orgs)
 	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user3"}).(*user_model.User)
-	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"})
+	user17 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user17"}).(*user_model.User)
 
 	assert.Equal(t, []*api.Organization{
 		{

--- a/integrations/org_test.go
+++ b/integrations/org_test.go
@@ -179,8 +179,8 @@ func TestOrgRestrictedUser(t *testing.T) {
 func TestTeamSearch(t *testing.T) {
 	defer prepareTestEnv(t)()
 
-	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}).(*user_model.User)
-	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3}).(*user_model.User)
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 15}).(*user_model.User)
+	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 17}).(*user_model.User)
 
 	var results TeamSearchResults
 
@@ -190,9 +190,9 @@ func TestTeamSearch(t *testing.T) {
 	req.Header.Add("X-Csrf-Token", csrf)
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &results)
-	assert.NotEmpty(t, results.Data)
-	assert.Len(t, results.Data, 1)
-	assert.Equal(t, "test_team", results.Data[0].Name)
+	assert.Len(t, results.Data, 2)
+	assert.Equal(t, "review_team", results.Data[0].Name)
+	assert.Equal(t, "test_team", results.Data[1].Name)
 
 	// no access if not organization member
 	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5}).(*user_model.User)

--- a/models/fixtures/org_user.yml
+++ b/models/fixtures/org_user.yml
@@ -63,3 +63,9 @@
   uid: 29
   org_id: 17
   is_public: true
+
+-
+  id: 12
+  uid: 2
+  org_id: 17
+  is_public: true

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -309,7 +309,7 @@
   avatar_email: user17@example.com
   num_repos: 2
   is_active: true
-  num_members: 3
+  num_members: 4
   num_teams: 3
 
 -

--- a/routers/web/org/teams.go
+++ b/routers/web/org/teams.go
@@ -339,7 +339,7 @@ func SearchTeam(ctx *context.Context) {
 	}
 
 	opts := &organization.SearchTeamOptions{
-		UserID:      ctx.Doer.ID,
+		// UserID is not set because the router already requires the doer to be an org admin. Thus, we don't need to restrict to teams that the user belongs in
 		Keyword:     ctx.FormTrim("q"),
 		OrgID:       ctx.Org.Organization.ID,
 		IncludeDesc: ctx.FormString("include_desc") == "" || ctx.FormBool("include_desc"),


### PR DESCRIPTION
- Backport of #20844
  - Currently the function takes in the UserID option, but isn't being used within the SQL query. This patch fixes that by checking that only teams are being returned that the user belongs to.
  - Resolves #20829

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
