### PR TITLE
Update codemirror to 5.65.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.4",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.4.tgz",
-      "integrity": "sha512-tytrSm5Rh52b6j36cbDXN+FHwHCl9aroY4BrDZB2NFFL3Wjfq9nuYVLFFhaOYOczKAg3JXTr8BuT8LcE5QY4Iw=="
+      "version": "5.65.8",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.8.tgz",
+      "integrity": "sha512-TNGkSkkoAsmZSf6W6g35LMVQJBHKasc2CKwhr/fTxSYun7cn6J+CbtyNjV/MYlFVkNTsqZoviegyCZimWhoMMA=="
     },
     "node_modules/codemirror-spell-checker": {
       "version": "1.1.2",
@@ -12911,9 +12911,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.65.4",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.4.tgz",
-      "integrity": "sha512-tytrSm5Rh52b6j36cbDXN+FHwHCl9aroY4BrDZB2NFFL3Wjfq9nuYVLFFhaOYOczKAg3JXTr8BuT8LcE5QY4Iw=="
+      "version": "5.65.8",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.8.tgz",
+      "integrity": "sha512-TNGkSkkoAsmZSf6W6g35LMVQJBHKasc2CKwhr/fTxSYun7cn6J+CbtyNjV/MYlFVkNTsqZoviegyCZimWhoMMA=="
     },
     "codemirror-spell-checker": {
       "version": "1.1.2",


### PR DESCRIPTION
For 1.17 branch. Includes fix for https://github.com/codemirror/codemirror5/issues/6893. Main branch will update separately later.