### PR TITLE
Set uploadpack.allowFilter etc on gitea serv to enable partial clones with SSH

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -326,6 +326,11 @@ func runServ(c *cli.Context) error {
 	// it could be re-considered whether to use the same git.CommonGitCmdEnvs() as "git" command later.
 	gitcmd.Env = append(gitcmd.Env, git.CommonCmdServEnvs()...)
 
+	// By default partial clones are disabled, enable them from git v2.22
+	if !setting.Git.DisablePartialClone && git.CheckGitVersionAtLeast("2.22") == nil {
+		gitcmd.Env = append(gitcmd.Env, "-c", "uploadpack.allowfilter=true", "-c", "uploadpack.allowAnySHA1InWant=true")
+	}
+
 	if err = gitcmd.Run(); err != nil {
 		return fail("Internal error", "Failed to execute git command: %v", err)
 	}


### PR DESCRIPTION
When setting.Git.DisablePartialClone is set to false then the
web server will add filter support to web http. The ssh serv
wrapper is missing this code and therefore we need to add it.

Fix #20400

Signed-off-by: Andrew Thornton <art27@cantab.net>
