### PR TITLE
Pad GPG Key ID with preceding zeroes (#20878)

### DIFF
--- a/models/asymkey/gpg_key.go
+++ b/models/asymkey/gpg_key.go
@@ -63,6 +63,15 @@ func (key *GPGKey) AfterLoad(session *xorm.Session) {
 	}
 }
 
+// PaddedKeyID show KeyID padded to 16 characters
+func (key *GPGKey) PaddedKeyID() string {
+	if len(key.KeyID) > 15 {
+		return key.KeyID
+	}
+	zeros := "0000000000000000"
+	return zeros[0:16-len(key.KeyID)] + key.KeyID
+}
+
 // ListGPGKeys returns a list of public keys belongs to given user.
 func ListGPGKeys(ctx context.Context, uid int64, listOptions db.ListOptions) ([]*GPGKey, error) {
 	sess := db.GetEngine(ctx).Table(&GPGKey{}).Where("owner_id=? AND primary_key_id=''", uid)

--- a/routers/api/v1/user/gpg_key.go
+++ b/routers/api/v1/user/gpg_key.go
@@ -7,6 +7,7 @@ package user
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	asymkey_model "code.gitea.io/gitea/models/asymkey"
 	"code.gitea.io/gitea/models/db"
@@ -176,6 +177,12 @@ func VerifyUserGPGKey(ctx *context.APIContext) {
 	form := web.GetForm(ctx).(*api.VerifyGPGKeyOption)
 	token := asymkey_model.VerificationToken(ctx.Doer, 1)
 	lastToken := asymkey_model.VerificationToken(ctx.Doer, 0)
+
+	form.KeyID = strings.TrimLeft(form.KeyID, "0")
+	if form.KeyID == "" {
+		ctx.NotFound()
+		return
+	}
 
 	_, err := asymkey_model.VerifyGPGKey(ctx.Doer.ID, form.KeyID, token, form.Signature)
 	if err != nil && asymkey_model.IsErrGPGInvalidTokenSignature(err) {

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -222,7 +222,7 @@
 								{{.Verification.SigningSSHKey.Fingerprint}}
 							{{else}}
 								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.KeyID}}
+								{{.Verification.SigningKey.PaddedKeyID}}
 							{{end}}
 						{{else}}
 							{{svg "octicon-shield-lock" 16 "mr-3"}}
@@ -231,7 +231,7 @@
 								{{.Verification.SigningSSHKey.Fingerprint}}
 							{{else}}
 								<span class="ui text mr-3 tooltip" data-content="{{.i18n.Tr "gpg.default_key"}}">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.KeyID}}
+								{{.Verification.SigningKey.PaddedKeyID}}
 							{{end}}
 						{{end}}
 					{{else if .Verification.Warning}}
@@ -241,14 +241,14 @@
 							{{.Verification.SigningSSHKey.Fingerprint}}
 						{{else}}
 							<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
-							{{.Verification.SigningKey.KeyID}}
+							{{.Verification.SigningKey.PaddedKeyID}}
 						{{end}}
 					{{else}}
 						{{if .Verification.SigningKey}}
 							{{if ne .Verification.SigningKey.KeyID ""}}
 								{{svg "octicon-shield" 16 "mr-3"}}
 								<span class="ui text mr-3">{{.i18n.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.KeyID}}
+								{{.Verification.SigningKey.PaddedKeyID}}
 							{{end}}
 						{{end}}
 						{{if .Verification.SigningSSHKey}}

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -22,7 +22,7 @@
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
 						<p>{{.i18n.Tr "settings.gpg_token_help"}}</p>
-						<p><code>{{$.i18n.Tr "settings.gpg_token_code" .TokenToSign .KeyID}}</code></p>
+						<p><code>{{$.i18n.Tr "settings.gpg_token_code" .TokenToSign .PaddedKeyID}}</code></p>
 					</div>
 				</div>
 				<div class="field">
@@ -64,8 +64,8 @@
 						<span class="tooltip" data-content="{{$.i18n.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{$.i18n.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
 					{{end}}
 					<div class="print meta">
-						<b>{{$.i18n.Tr "settings.key_id"}}:</b> {{.KeyID}}
-						<b>{{$.i18n.Tr "settings.subkeys"}}:</b> {{range .SubsKey}} {{.KeyID}} {{end}}
+						<b>{{$.i18n.Tr "settings.key_id"}}:</b> {{.PaddedKeyID}}
+						<b>{{$.i18n.Tr "settings.subkeys"}}:</b> {{range .SubsKey}} {{.PaddedKeyID}} {{end}}
 					</div>
 					<div class="activity meta">
 						<i>{{$.i18n.Tr "settings.add_on"}} <span>{{.AddedUnix.FormatShort}}</span></i>
@@ -87,7 +87,7 @@
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
 								<p>{{$.i18n.Tr "settings.gpg_token_help"}}</p>
-								<p><code>{{$.i18n.Tr "settings.gpg_token_code" $.TokenToSign .KeyID}}</code></p>
+								<p><code>{{$.i18n.Tr "settings.gpg_token_code" $.TokenToSign .PaddedKeyID}}</code></p>
 							</div>
 							<br>
 						</div>


### PR DESCRIPTION
Backport #20878

The go crypto library does not pad keyIDs to 16 characters with preceding zeroes. This
is a somewhat confusing thing for most users who expect these to have preceding zeroes.

This PR prefixes any sub 16 length KeyID with preceding zeroes and removes preceding
zeroes from KeyIDs inputted on the API.

Fix #20876

Signed-off-by: Andrew Thornton <art27@cantab.net>

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
