### PR TITLE
 Ensure that graceful start-up is informed of unused SSH listener (#20877)

### DIFF
--- a/modules/graceful/manager_windows.go
+++ b/modules/graceful/manager_windows.go
@@ -114,9 +114,9 @@ func (g *Manager) start() {
 // Execute makes Manager implement svc.Handler
 func (g *Manager) Execute(args []string, changes <-chan svc.ChangeRequest, status chan<- svc.Status) (svcSpecificEC bool, exitCode uint32) {
 	if setting.StartupTimeout > 0 {
-		status <- svc.Status{State: svc.StartPending}
-	} else {
 		status <- svc.Status{State: svc.StartPending, WaitHint: uint32(setting.StartupTimeout / time.Millisecond)}
+	} else {
+		status <- svc.Status{State: svc.StartPending}
 	}
 
 	log.Trace("Awaiting server start-up")

--- a/modules/ssh/init.go
+++ b/modules/ssh/init.go
@@ -18,6 +18,7 @@ import (
 
 func Init() error {
 	if setting.SSH.Disabled {
+		builtinUnused()
 		return nil
 	}
 


### PR DESCRIPTION
Backport #20877 

The graceful manager waits for 4 listeners to be created or to be told that they are not needed. If it is not told about them it will indefinitely and timeout. 

This leads to SVC hosts not being told of being in the readyState but on Unix would lead to the termination of the process.

There was an unfortunate regression in #20299 which missed this subtly and in the case whereby SSH is disabled the `builtinUnused()` is not called.

This PR adds a call to `builtinUnused()` when not using the builtin ssh to allow `createServerWaitGroup.Done()` to be called. 

In addition it was noted that the if/else clauses for timeout informing of the SVC host were in the wrong order. These have been swapped.

Fix #20609