### PR TITLE
In PushMirrorsIterate and MirrorsIterate if limit is negative do not set it (#20837)

### DIFF
--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -108,12 +108,14 @@ func DeleteMirrorByRepoID(repoID int64) error {
 
 // MirrorsIterate iterates all mirror repositories.
 func MirrorsIterate(limit int, f func(idx int, bean interface{}) error) error {
-	return db.GetEngine(db.DefaultContext).
+	sess := db.GetEngine(db.DefaultContext).
 		Where("next_update_unix<=?", time.Now().Unix()).
 		And("next_update_unix!=0").
-		OrderBy("updated_unix ASC").
-		Limit(limit).
-		Iterate(new(Mirror), f)
+		OrderBy("updated_unix ASC")
+	if limit > 0 {
+		sess = sess.Limit(limit)
+	}
+	return sess.Iterate(new(Mirror), f)
 }
 
 // InsertMirror inserts a mirror to database

--- a/models/repo/pushmirror.go
+++ b/models/repo/pushmirror.go
@@ -95,10 +95,12 @@ func GetPushMirrorsByRepoID(repoID int64) ([]*PushMirror, error) {
 
 // PushMirrorsIterate iterates all push-mirror repositories.
 func PushMirrorsIterate(limit int, f func(idx int, bean interface{}) error) error {
-	return db.GetEngine(db.DefaultContext).
+	sess := db.GetEngine(db.DefaultContext).
 		Where("last_update + (`interval` / ?) <= ?", time.Second, time.Now().Unix()).
 		And("`interval` != 0").
-		OrderBy("last_update ASC").
-		Limit(limit).
-		Iterate(new(PushMirror), f)
+		OrderBy("last_update ASC")
+	if limit > 0 {
+		sess = sess.Limit(limit)
+	}
+	return sess.Iterate(new(PushMirror), f)
 }


### PR DESCRIPTION
Backport #20837

The documentation allows the mirror update queue to add all potential mirrors to
the queue by setting the limits negative. Unfortunately a change to the iterator code
has missed this subtly and resulted in passing negative numbers to the LIMIT SQL
statement. This causes bugs on some DB systems.

Fix #20667

Signed-off-by: Andrew Thornton <art27@cantab.net>
