### PR TITLE
Fix panic when an invalid oauth2 name is passed (#20820)

### DIFF
--- a/models/auth/oauth2.go
+++ b/models/auth/oauth2.go
@@ -512,8 +512,12 @@ func GetActiveOAuth2ProviderSources() ([]*Source, error) {
 func GetActiveOAuth2SourceByName(name string) (*Source, error) {
 	authSource := new(Source)
 	has, err := db.GetEngine(db.DefaultContext).Where("name = ? and type = ? and is_active = ?", name, OAuth2, true).Get(authSource)
-	if !has || err != nil {
+	if err != nil {
 		return nil, err
+	}
+
+	if !has {
+		return nil, fmt.Errorf("oauth2 source not found, name: %q", name)
 	}
 
 	return authSource, nil


### PR DESCRIPTION
Backport #20820

When trying to access an invalid oauth2 link, we get an internal server error and can see a panic stack-trace in logs

Example:
Try to go to this url for a gitea installation
https://<gitea_url>/user/oauth2/DoesNotExist?redirect_to=

It causes an internal server error

Stack trace in log

```
2022/08/17 01:26:50 routers/web/base.go:134:1() [E] [62fc43da] PANIC: runtime error: invalid memory address or nil pointer dereference
        /usr/local/go/src/runtime/panic.go:220 (0x453095)
        /usr/local/go/src/runtime/signal_unix.go:818 (0x453065)
        /source/routers/web/auth/oauth.go:1100 (0x20f6ef7)
        /source/routers/web/auth/oauth.go:785 (0x20f4684)
        /source/modules/web/wrap_convert.go:47 (0x1f45196)
        /source/modules/web/wrap.go:41 (0x1f433c9)
        /usr/local/go/src/net/http/server.go:2084 (0x93cace)
       <clipped>
```

Root cause:

In this [line](https://github.com/go-gitea/gitea/blob/a4e91c4197483c94f13e623c962b6b011494e949/models/auth/oauth2.go#L516) here, err is nil. The caller assumes no error and tries to access a `nil *Source`

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
