### PR TITLE
Fix mirror address setting not working (#20850)

### DIFF
--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -227,14 +227,17 @@ func SettingsPost(ctx *context.Context) {
 			form.MirrorPassword, _ = u.User.Password()
 		}
 
-		err = migrations.IsMigrateURLAllowed(u.String(), ctx.Doer)
+		address, err := forms.ParseRemoteAddr(form.MirrorAddress, form.MirrorUsername, form.MirrorPassword)
+		if err == nil {
+			err = migrations.IsMigrateURLAllowed(address, ctx.Doer)
+		}
 		if err != nil {
 			ctx.Data["Err_MirrorAddress"] = true
 			handleSettingRemoteAddrError(ctx, err, form)
 			return
 		}
 
-		if err := mirror_service.UpdateAddress(ctx, ctx.Repo.Mirror, u.String()); err != nil {
+		if err := mirror_service.UpdateAddress(ctx, ctx.Repo.Mirror, address); err != nil {
 			ctx.ServerError("UpdateAddress", err)
 			return
 		}


### PR DESCRIPTION
Backport #20850

This patch fixes the issue that the mirror address field is ignored from the repo setting form.
