### PR TITLE
 Don't open new page for ext wiki on same repository (#20725)

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -574,6 +574,7 @@ func NewTextFuncMap() []texttmpl.FuncMap {
 			return sum
 		},
 		"QueryEscape": url.QueryEscape,
+		"HasPrefix": strings.HasPrefix,
 	}}
 }
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -574,7 +574,7 @@ func NewTextFuncMap() []texttmpl.FuncMap {
 			return sum
 		},
 		"QueryEscape": url.QueryEscape,
-		"HasPrefix": strings.HasPrefix,
+		"HasPrefix":   strings.HasPrefix,
 	}}
 }
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -454,6 +454,7 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return items
 		},
+		"HasPrefix": strings.HasPrefix,
 	}}
 }
 
@@ -574,7 +575,6 @@ func NewTextFuncMap() []texttmpl.FuncMap {
 			return sum
 		},
 		"QueryEscape": url.QueryEscape,
-		"HasPrefix":   strings.HasPrefix,
 	}}
 }
 

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -206,7 +206,7 @@
 				{{end}}
 
 				{{if or (.Permission.CanRead $.UnitTypeWiki) (.Permission.CanRead $.UnitTypeExternalWiki)}}
-					<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki" {{if (.Permission.CanRead $.UnitTypeExternalWiki)}} target="_blank" rel="noopener noreferrer" {{end}}>
+					<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki" {{if and (.Permission.CanRead $.UnitTypeExternalWiki) (not (HasPrefix ((.Repository.MustGetUnit $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL) (.Repository.HTMLURL)))}} target="_blank" rel="noopener noreferrer" {{end}}>
 						{{svg "octicon-book"}} {{.i18n.Tr "repo.wiki"}}
 					</a>
 				{{end}}


### PR DESCRIPTION
- Backport #20725
  - When the external wiki has been set to a file on the repository, don't open the page on a tab.

Fix #20657
