### PR TITLE
Increase Content field size of gpg_key and public_key to MEDIUMTEXT (#20896)

### DIFF
--- a/models/asymkey/gpg_key.go
+++ b/models/asymkey/gpg_key.go
@@ -33,7 +33,7 @@ type GPGKey struct {
 	OwnerID           int64              `xorm:"INDEX NOT NULL"`
 	KeyID             string             `xorm:"INDEX CHAR(16) NOT NULL"`
 	PrimaryKeyID      string             `xorm:"CHAR(16)"`
-	Content           string             `xorm:"TEXT NOT NULL"`
+	Content           string             `xorm:"MEDIUMTEXT NOT NULL"`
 	CreatedUnix       timeutil.TimeStamp `xorm:"created"`
 	ExpiredUnix       timeutil.TimeStamp
 	AddedUnix         timeutil.TimeStamp

--- a/models/asymkey/ssh_key.go
+++ b/models/asymkey/ssh_key.go
@@ -41,7 +41,7 @@ type PublicKey struct {
 	OwnerID       int64           `xorm:"INDEX NOT NULL"`
 	Name          string          `xorm:"NOT NULL"`
 	Fingerprint   string          `xorm:"INDEX NOT NULL"`
-	Content       string          `xorm:"TEXT NOT NULL"`
+	Content       string          `xorm:"MEDIUMTEXT NOT NULL"`
 	Mode          perm.AccessMode `xorm:"NOT NULL DEFAULT 2"`
 	Type          KeyType         `xorm:"NOT NULL DEFAULT 1"`
 	LoginSourceID int64           `xorm:"NOT NULL DEFAULT 0"`


### PR DESCRIPTION
Backport #20896

Unfortunately some keys are too big to fix within the 65535 limit of TEXT on MySQL
this causes issues with these large keys.

Therefore increase these fields to MEDIUMTEXT.

Fix #20894

Signed-off-by: Andrew Thornton <art27@cantab.net>

## :warning: BREAKING :warning: 

Technically this PR should contain a migration but the migration in #20896 cannot be backported to 1.17.
Affected users will have to use `gitea doctor recreate-table gpg_key public_key`

Only MySQL users will need to do this.

