### PR TITLE
Fix typo in backup documentation (pgdump->pg_dump)

### DIFF
--- a/docs/content/doc/usage/backup-and-restore.en-us.md
+++ b/docs/content/doc/usage/backup-and-restore.en-us.md
@@ -62,7 +62,7 @@ The SQL dump created by `gitea dump` uses XORM and Gitea admins may prefer to us
 # mysql
 mysqldump -u$USER -p$PASS --database $DATABASE > gitea-db.sql
 # postgres
-pgdump -U $USER $DATABASE > gitea-db.sql
+pg_dump -U $USER $DATABASE > gitea-db.sql
 ```
 
 ### Using Docker (`dump`)


### PR DESCRIPTION
This PR fixes a small typo in the backup documentation: `pgdump` command is wrong, the correct name for the backup software in PostgreSQL is `pg_dump`