### PR TITLE
Display total blob size of a package version

### DIFF
--- a/templates/package/view.tmpl
+++ b/templates/package/view.tmpl
@@ -52,6 +52,7 @@
 							{{template "package/metadata/pub" .}}
 							{{template "package/metadata/pypi" .}}
 							{{template "package/metadata/rubygems" .}}
+							<div class="item">{{svg "octicon-database" 16 "mr-3"}} {{FileSize .PackageDescriptor.CalculateBlobSize}}</div>
 						</div>
 						{{if not (eq .PackageDescriptor.Package.Type "container")}}
 							<div class="ui divider"></div>


### PR DESCRIPTION
fixes #20909

Looks like this for a container package:
![grafik](https://user-images.githubusercontent.com/1666336/186179826-be4a6c15-3e16-4d66-adab-ae08c8fd7916.png)

For package types with versions which only contain a single file, this info is redundant but I think that's not a problem.