### PR TITLE
Fix branches presentation on PR's list

### DIFF
--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -66,17 +66,17 @@
 					{{if .IsPull}}
 						<div class="branches df ac">
 							<div class="branch">
-								<a href="{{.PullRequest.BaseRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.BaseBranch}}">
+								<a class="bold dif" href="{{.PullRequest.BaseRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.BaseBranch}}">
 									{{/* inline to remove the spaces between spans */}}
-									{{if ne .RepoID .PullRequest.BaseRepoID}}<span class="truncated-name">{{.PullRequest.BaseRepo.OwnerName}}</span>:{{end}}<span class="truncated-name">{{.PullRequest.BaseBranch}}</span>
+									{{if ne .RepoID .PullRequest.BaseRepoID}}<span class="truncated-name dib vb">{{.PullRequest.BaseRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib vb">{{.PullRequest.BaseBranch}}</span>
 								</a>
 							</div>
 							{{svg "gitea-double-chevron-left" 12 "mx-1"}}
 							{{if .PullRequest.HeadRepo}}
 							<div class="branch">
-								<a href="{{.PullRequest.HeadRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.HeadBranch}}">
+								<a class="bold dif" href="{{.PullRequest.HeadRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.HeadBranch}}">
 									{{/* inline to remove the spaces between spans */}}
-									{{if ne .RepoID .PullRequest.HeadRepoID}}<span class="truncated-name">{{.PullRequest.HeadRepo.OwnerName}}</span>:{{end}}<span class="truncated-name">{{.PullRequest.HeadBranch}}</span>
+									{{if ne .RepoID .PullRequest.HeadRepoID}}<span class="truncated-name dib vb">{{.PullRequest.HeadRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib vb">{{.PullRequest.HeadBranch}}</span>
 								</a>
 							</div>
 							{{end}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -68,7 +68,7 @@
 							<div class="branch">
 								<a class="bold dif" href="{{.PullRequest.BaseRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.BaseBranch}}">
 									{{/* inline to remove the spaces between spans */}}
-									{{if ne .RepoID .PullRequest.BaseRepoID}}<span class="truncated-name dib vb">{{.PullRequest.BaseRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib vb">{{.PullRequest.BaseBranch}}</span>
+									{{if ne .RepoID .PullRequest.BaseRepoID}}<span class="truncated-name dib">{{.PullRequest.BaseRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib">{{.PullRequest.BaseBranch}}</span>
 								</a>
 							</div>
 							{{svg "gitea-double-chevron-left" 12 "mx-1"}}
@@ -76,7 +76,7 @@
 							<div class="branch">
 								<a class="bold dif" href="{{.PullRequest.HeadRepo.HTMLURL}}/src/branch/{{PathEscapeSegments .PullRequest.HeadBranch}}">
 									{{/* inline to remove the spaces between spans */}}
-									{{if ne .RepoID .PullRequest.HeadRepoID}}<span class="truncated-name dib vb">{{.PullRequest.HeadRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib vb">{{.PullRequest.HeadBranch}}</span>
+									{{if ne .RepoID .PullRequest.HeadRepoID}}<span class="truncated-name dib">{{.PullRequest.HeadRepo.OwnerName}}</span>:{{end}}<span class="truncated-name dib">{{.PullRequest.HeadBranch}}</span>
 								</a>
 							</div>
 							{{end}}


### PR DESCRIPTION
This is a hotfix for UI presentation of branches on PR's list (implemented in #19747)

Current representation (before fix)
![before_fix](https://user-images.githubusercontent.com/101557941/186205531-22333bcd-567d-4f0e-804e-8ec2e8672be5.png)

New representation
![after_fix](https://user-images.githubusercontent.com/101557941/186205732-c18c1f8b-26f9-49ef-b5f3-a8ca600224dd.png)


**Please include/backport (if possible) to v1.17.2 for example**
