### PR TITLE
Forbid HTML string tooltips

### DIFF
--- a/web_src/js/modules/tippy.js
+++ b/web_src/js/modules/tippy.js
@@ -5,7 +5,7 @@ export function createTippy(target, opts = {}) {
     appendTo: document.body,
     placement: 'top-start',
     animation: false,
-    allowHTML: true,
+    allowHTML: false,
     maxWidth: 500, // increase over default 350px
     arrow: `<svg width="16" height="7"><path d="m0 7 8-7 8 7Z" class="tippy-svg-arrow-outer"/><path d="m0 8 8-7 8 7Z" class="tippy-svg-arrow-inner"/></svg>`,
     ...(opts?.role && {theme: opts.role}),


### PR DESCRIPTION
Tippy [allows HTML strings](https://atomiks.github.io/tippyjs/v6/html-content/#string) to be passed as `content` but we do not use this feature (we do pass HTML only as `Element`), so it's better to disable it for increased security.

Edit: Turns out the fix is just a bool flip, as `allowHTML: false` still allows `Element` content.