### PR TITLE
Set no-tags in git fetch on compare (#20893)

### DIFF
--- a/modules/git/repo_compare.go
+++ b/modules/git/repo_compare.go
@@ -40,7 +40,7 @@ func (repo *Repository) GetMergeBase(tmpRemote, base, head string) (string, stri
 	if tmpRemote != "origin" {
 		tmpBaseName := RemotePrefix + tmpRemote + "/tmp_" + base
 		// Fetch commit into a temporary branch in order to be able to handle commits and tags
-		_, _, err := NewCommand(repo.Ctx, "fetch", tmpRemote, base+":"+tmpBaseName).RunStdString(&RunOpts{Dir: repo.Path})
+		_, _, err := NewCommand(repo.Ctx, "fetch", "--no-tags", tmpRemote, "--", base+":"+tmpBaseName).RunStdString(&RunOpts{Dir: repo.Path})
 		if err == nil {
 			base = tmpBaseName
 		}


### PR DESCRIPTION
Backport #20893

In the compare endpoint the git fetch is restricted to a certain branch however,
this does not completely prevent tag acquisition/pollution as git fetch will collect
any tags on that branch.

This causes pollution of the tag namespace and could cause confusion by users.

This PR adds `--no-tags` to the `git fetch` call.

Signed-off-by: Andrew Thornton <art27@cantab.net>
