### PR TITLE
Migrate Releases from GitLab without Token

### DIFF
--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -32,6 +32,10 @@
 							<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
 							<label>{{.locale.Tr "repo.migrate_items_wiki" | Safe}}</label>
 						</div>
+						<div class="ui checkbox">
+								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
+								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
+						</div>
 					</div>
 					<div id="migrate_items">
 						<span class="help">{{.locale.Tr "repo.migrate.migrate_items_options"}}</span>
@@ -45,20 +49,10 @@
 								<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
 								<label>{{.locale.Tr "repo.migrate_items_issues" | Safe}}</label>
 							</div>
-						</div>
-						<div class="inline field">
-							<label></label>
 							<div class="ui checkbox">
 								<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
 								<label>{{.locale.Tr "repo.migrate_items_merge_requests" | Safe}}</label>
 							</div>
-							<div class="ui checkbox">
-								<input name="releases" type="checkbox" {{if .releases}}checked{{end}}>
-								<label>{{.locale.Tr "repo.migrate_items_releases" | Safe}}</label>
-							</div>
-						</div>
-						<div class="inline field">
-							<label></label>
 							<div class="ui checkbox">
 								<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
 								<label>{{.locale.Tr "repo.migrate_items_milestones" | Safe}}</label>


### PR DESCRIPTION
You don't need a token when you want to migrate Releases from GitLab. To test it, migrate any Repository from gitlab.com or another GitLab instance e.g. gitlab.gnome.org and you will see that it will migrate all Releases even without a Token.

I also reordered the Checkboxes a little bit.

![grafik](https://user-images.githubusercontent.com/15185051/186355224-b202cbf1-dd4d-4938-8fd9-be6a8447b471.png)

