### PR TITLE
Return 404 NotFound if requested attachment does not exist (#20886)

### DIFF
--- a/routers/api/v1/repo/release_attachment.go
+++ b/routers/api/v1/repo/release_attachment.go
@@ -57,6 +57,10 @@ func GetReleaseAttachment(ctx *context.APIContext) {
 	attachID := ctx.ParamsInt64(":asset")
 	attach, err := repo_model.GetAttachmentByID(ctx, attachID)
 	if err != nil {
+		if repo_model.IsErrAttachmentNotExist(err) {
+			ctx.NotFound()
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetAttachmentByID", err)
 		return
 	}
@@ -100,6 +104,10 @@ func ListReleaseAttachments(ctx *context.APIContext) {
 	releaseID := ctx.ParamsInt64(":id")
 	release, err := models.GetReleaseByID(ctx, releaseID)
 	if err != nil {
+		if models.IsErrReleaseNotExist(err) {
+			ctx.NotFound()
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetReleaseByID", err)
 		return
 	}
@@ -166,6 +174,10 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 	releaseID := ctx.ParamsInt64(":id")
 	release, err := models.GetReleaseByID(ctx, releaseID)
 	if err != nil {
+		if models.IsErrReleaseNotExist(err) {
+			ctx.NotFound()
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetReleaseByID", err)
 		return
 	}
@@ -244,6 +256,10 @@ func EditReleaseAttachment(ctx *context.APIContext) {
 	attachID := ctx.ParamsInt64(":asset")
 	attach, err := repo_model.GetAttachmentByID(ctx, attachID)
 	if err != nil {
+		if repo_model.IsErrAttachmentNotExist(err) {
+			ctx.NotFound()
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetAttachmentByID", err)
 		return
 	}
@@ -302,6 +318,10 @@ func DeleteReleaseAttachment(ctx *context.APIContext) {
 	attachID := ctx.ParamsInt64(":asset")
 	attach, err := repo_model.GetAttachmentByID(ctx, attachID)
 	if err != nil {
+		if repo_model.IsErrAttachmentNotExist(err) {
+			ctx.NotFound()
+			return
+		}
 		ctx.Error(http.StatusInternalServerError, "GetAttachmentByID", err)
 		return
 	}


### PR DESCRIPTION
Backport #20886

Add code to test if GetAttachmentByID returns an ErrAttachmentNotExist error
and return NotFound instead of InternalServerError

Fix #20884

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>
