### PR TITLE
Make language stats available without JavaScript

### DIFF
--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -20,7 +20,12 @@
 		</div>
 	</div>
 	{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo) .LanguageStats }}
-	<div class="ui segment sub-menu language-stats-details" style="display: none">
+	<div class="ui segment language-stats">
+		{{range .LanguageStats}}
+		<div class="bar" style="width: {{ .Percentage }}%; background-color: {{ .Color }}">&nbsp;</div>
+		{{end}}
+	</div>
+	<div class="ui segment sub-menu language-stats-details">
 		<div class="ui horizontal center link list">
 			{{range .LanguageStats}}
 			<div class="item df ac jc">
@@ -37,10 +42,5 @@
 			{{end}}
 		</div>
 	</div>
-	<a class="ui segment language-stats">
-		{{range .LanguageStats}}
-		<div class="bar" style="width: {{ .Percentage }}%; background-color: {{ .Color }}">&nbsp;</div>
-		{{end}}
-	</a>
 	{{end}}
 </div>

--- a/web_src/js/features/repo-common.js
+++ b/web_src/js/features/repo-common.js
@@ -96,13 +96,3 @@ export function initRepoCommonFilterSearchDropdown(selector) {
     message: {noResults: $dropdown.attr('data-no-results')},
   });
 }
-
-export function initRepoCommonLanguageStats() {
-  // Language stats
-  if ($('.language-stats').length > 0) {
-    $('.language-stats').on('click', (e) => {
-      e.preventDefault();
-      $('.language-stats-details, .repository-menu').slideToggle();
-    });
-  }
-}

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -19,7 +19,6 @@ import {
   initRepoCloneLink,
   initRepoCommonBranchOrTagDropdown,
   initRepoCommonFilterSearchDropdown,
-  initRepoCommonLanguageStats,
 } from './repo-common.js';
 import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {initRepoDiffConversationNav} from './repo-diff.js';
@@ -500,7 +499,6 @@ export function initRepository() {
   }
 
   initRepoCloneLink();
-  initRepoCommonLanguageStats();
   initRepoSettingBranches();
 
   // Issues

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3164,7 +3164,7 @@ td.blob-excerpt {
 
 /* prevent page shaking on language bar click */
 .repository-summary-language-stats {
-  height: 48px;
+  height: 84px;
   overflow: hidden;
 
   @media @mediaSm {


### PR DESCRIPTION
Fixes #20947.

This PR makes a repository's language stats available to users who have disabled JavaScript. The language names and respective shares are now always shown below the colored bar, rather than faded in when clicked (see screenshot below).

![Bildschirmfoto 2022-08-24 um 20 41 09](https://user-images.githubusercontent.com/38211057/186501982-fdb9700a-4b6b-4ec3-97da-8e45c8e53b19.png)

This has the additional advantage that these stats are now also visible in the mobile/responsive version, even though the bar is not visible there (perhaps this is another issue).

![Bildschirmfoto 2022-08-24 um 20 41 19](https://user-images.githubusercontent.com/38211057/186502041-660fd48b-6880-49c7-b5a0-aca75948a1e5.png)

Since this is my first contribution to Gitea, I am not 100% sure if the removed code breaks other functionality or there are things to be removed that I didn't see.