### PR TITLE
Use StaticCacheTime for avatars again

### DIFF
--- a/routers/web/user/avatar.go
+++ b/routers/web/user/avatar.go
@@ -6,19 +6,16 @@ package user
 
 import (
 	"strings"
-	"time"
 
 	"code.gitea.io/gitea/models/avatars"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/httpcache"
+	"code.gitea.io/gitea/modules/setting"
 )
 
 func cacheableRedirect(ctx *context.Context, location string) {
-	// here we should not use `setting.StaticCacheTime`, it is pretty long (default: 6 hours)
-	// we must make sure the redirection cache time is short enough, otherwise a user won't see the updated avatar in 6 hours
-	// it's OK to make the cache time short, it is only a redirection, and doesn't cost much to make a new request
-	httpcache.AddCacheControlToHeader(ctx.Resp.Header(), 5*time.Minute)
+	httpcache.AddCacheControlToHeader(ctx.Resp.Header(), setting.StaticCacheTime)
 	ctx.Redirect(location)
 }
 


### PR DESCRIPTION
https://github.com/go-gitea/gitea/commit/f0ba87fda88c7bb601eee17f3e3a72bea8a71521 had added a hardcoded 5 minute cache duration for avatars, but it's actually not necessary for local avatars to have such a short duration because when a users uploads a new avatar, the file hash will change so the new avatar will be on a new and uncached URL, so local avatar changes take effect immediately.

On external services like Gravatar, URL will not change so it will take up to 6 hours there for an update to take effect, but I think it's still acceptable for those, for the sake of performance.