### PR TITLE
Add instructions how to add service dependencies

### DIFF
--- a/docs/content/doc/installation/windows-service.en-us.md
+++ b/docs/content/doc/installation/windows-service.en-us.md
@@ -49,6 +49,16 @@ Open "Windows Services", search for the service named "gitea", right-click it an
 "Run". If everything is OK, Gitea will be reachable on `http://localhost:3000` (or the port
 that was configured).
 
+## Adding startup dependancies
+
+To add a startup dependancy to the Gitea Windows service (eg Mysql, Mariadb), as an Administrator, then run the following command:
+
+```
+sc.exe config gitea depend= mariadb
+```
+
+This will ensure that when the Windows machine restarts, the automatic starting of Gitea is postponed until the database is ready and thus mitigate failed startups.
+
 ## Unregister as a service
 
 To unregister Gitea as a service, open a command prompt (cmd) as an Administrator and run:


### PR DESCRIPTION
It is advantageous to ensure the Windows service has the correct dependencies to ensure that once the host machine is rebooted that the Gitea service will only start once the database is ready.
