### PR TITLE
Use native inputs in whitespace dropdown

### DIFF
--- a/templates/repo/diff/whitespace_dropdown.tmpl
+++ b/templates/repo/diff/whitespace_dropdown.tmpl
@@ -3,20 +3,20 @@
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu">
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=show-all">
-			<i class="circle {{if eq .WhitespaceBehavior "show-all"}}dot{{else}}outline{{end}} icon"></i>
-			{{.locale.Tr "repo.diff.whitespace_show_everything"}}
+			<input id="whitespace-show-all" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "show-all"}} checked{{end}}>
+			<label for="whitespace-show-all" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_show_everything"}}</label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-all">
-			<i class="circle {{if eq .WhitespaceBehavior "ignore-all"}}dot{{else}}outline{{end}} icon"></i>
-			{{.locale.Tr "repo.diff.whitespace_ignore_all_whitespace"}}
+			<input id="whitespace-ignore-all" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-all"}} checked{{end}}>
+			<label for="whitespace-ignore-all" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_ignore_all_whitespace"}}<label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-change">
-			<i class="circle {{if eq .WhitespaceBehavior "ignore-change"}}dot{{else}}outline{{end}} icon"></i>
-			{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}
+			<input id="whitespace-ignore-change" class="mr-3 pen" type="radio"{{if eq .WhitespaceBehavior "ignore-change"}} checked{{end}}>
+			<label for="whitespace-ignore-change" class="pen">{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}</label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-eol">
-			<i class="circle {{if eq .WhitespaceBehavior "ignore-eol"}}dot{{else}}outline{{end}} icon"></i>
-			{{.locale.Tr "repo.diff.whitespace_ignore_at_eol"}}
+			<input id="whitespace-ignore-eol" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-eol"}} checked{{end}}>
+			<label for="whitespace-ignore-eol" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_ignore_at_eol"}}</label>
 		</a>
 	</div>
 </div>

--- a/templates/repo/diff/whitespace_dropdown.tmpl
+++ b/templates/repo/diff/whitespace_dropdown.tmpl
@@ -15,8 +15,8 @@
 				<label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-change">
-			<label class="pen">
-				<input class="mr-3 pen" type="radio"{{if eq .WhitespaceBehavior "ignore-change"}} checked{{end}}>
+			<label class="pointer-events-none">
+				<input class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-change"}} checked{{end}}>
 				{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}
 			</label>
 		</a>

--- a/templates/repo/diff/whitespace_dropdown.tmpl
+++ b/templates/repo/diff/whitespace_dropdown.tmpl
@@ -3,20 +3,28 @@
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu">
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=show-all">
-			<input id="whitespace-show-all" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "show-all"}} checked{{end}}>
-			<label for="whitespace-show-all" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_show_everything"}}</label>
+			<label class="pointer-events-none">
+				<input class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "show-all"}} checked{{end}}>
+				{{.locale.Tr "repo.diff.whitespace_show_everything"}}
+			</label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-all">
-			<input id="whitespace-ignore-all" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-all"}} checked{{end}}>
-			<label for="whitespace-ignore-all" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_ignore_all_whitespace"}}<label>
+			<label class="pointer-events-none">
+				<input class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-all"}} checked{{end}}>
+				{{.locale.Tr "repo.diff.whitespace_ignore_all_whitespace"}}
+				<label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-change">
-			<input id="whitespace-ignore-change" class="mr-3 pen" type="radio"{{if eq .WhitespaceBehavior "ignore-change"}} checked{{end}}>
-			<label for="whitespace-ignore-change" class="pen">{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}</label>
+			<label class="pen">
+				<input class="mr-3 pen" type="radio"{{if eq .WhitespaceBehavior "ignore-change"}} checked{{end}}>
+				{{.locale.Tr "repo.diff.whitespace_ignore_amount_changes"}}
+			</label>
 		</a>
 		<a class="item" href="?style={{if .IsSplitStyle}}split{{else}}unified{{end}}&whitespace=ignore-eol">
-			<input id="whitespace-ignore-eol" class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-eol"}} checked{{end}}>
-			<label for="whitespace-ignore-eol" class="pointer-events-none">{{.locale.Tr "repo.diff.whitespace_ignore_at_eol"}}</label>
+			<label class="pointer-events-none">
+				<input class="mr-3 pointer-events-none" type="radio"{{if eq .WhitespaceBehavior "ignore-eol"}} checked{{end}}>
+				{{.locale.Tr "repo.diff.whitespace_ignore_at_eol"}}
+			</label>
 		</a>
 	</div>
 </div>

--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -19,6 +19,9 @@
 .h-100 { height: 100% !important; }
 .br-0 { border-radius: 0 !important; }
 
+/* below class names match tailwind.css */
+.pointer-events-none { pointer-events: none !important; }
+
 .mono {
   font-family: var(--fonts-monospace) !important;
   font-size: .9em !important; /* compensate for monospace fonts being usually slightly larger */

--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -19,7 +19,7 @@
 .h-100 { height: 100% !important; }
 .br-0 { border-radius: 0 !important; }
 
-/* below class names match tailwind.css */
+/* below class names match Tailwind CSS */
 .pointer-events-none { pointer-events: none !important; }
 
 .mono {


### PR DESCRIPTION
Use native `<input type="radio">` instead of fake icon font. The `pointer-events: none` is necessary so the link click always takes effect. Tested in Firefox, Safari and Chrome.

Before:
<img width="305" alt="Screen Shot 2022-08-27 at 20 42 11" src="https://user-images.githubusercontent.com/115237/187044786-6655c766-c3fb-4672-9e3e-219b3ec4896c.png">

After:
<img width="298" alt="Screen Shot 2022-08-27 at 21 10 05" src="https://user-images.githubusercontent.com/115237/187044790-33f87741-062e-4744-80b1-d3bd3fd725e3.png">
<img width="302" alt="image" src="https://user-images.githubusercontent.com/115237/187044872-6c133cea-65ee-4ebd-b18a-a8b38c791565.png">

