### PR TITLE
Add down key check has tribute container (#21016)

### DIFF
--- a/web_src/js/features/comp/EasyMDE.js
+++ b/web_src/js/features/comp/EasyMDE.js
@@ -90,6 +90,18 @@ export async function createCommentEasyMDE(textarea, easyMDEOptions = {}) {
       }
       cm.execCommand('delCharBefore');
     },
+    Up: (cm) => {
+      const tributeContainer = document.querySelector('.tribute-container');
+      if (!tributeContainer || tributeContainer.style.display === 'none') {
+        return cm.execCommand('goLineUp');
+      }
+    },
+    Down: (cm) => {
+      const tributeContainer = document.querySelector('.tribute-container');
+      if (!tributeContainer || tributeContainer.style.display === 'none') {
+        return cm.execCommand('goLineDown');
+      }
+    },
   });
   attachTribute(inputField, {mentions: true, emoji: true});
   attachEasyMDEToElements(easyMDE);


### PR DESCRIPTION
Backport #21016

Fixes an issue where users would not be able to select by pressing the down arrow when using @TAG above a message

Bug videos:

https://user-images.githubusercontent.com/1255041/188095999-c4ccde18-e53b-4251-8a14-d90c4042d768.mp4


