### PR TITLE
Fix 500 on time tracking in timeline API

### DIFF
--- a/modules/convert/issue_comment.go
+++ b/modules/convert/issue_comment.go
@@ -101,6 +101,12 @@ func ToTimelineComment(c *issues_model.Comment, doer *user_model.User) *api.Time
 	}
 
 	if c.Time != nil {
+		err = c.Time.LoadAttributes()
+		if err != nil {
+			log.Error("Time.LoadAttributes: %v", err)
+			return nil
+		}
+
 		comment.TrackedTime = ToTrackedTime(c.Time)
 	}
 


### PR DESCRIPTION
Before converting a `TrackedTime` for the API we need to load its attributes - otherwise we get an NPE.

Fix #21041