### PR TITLE
fix broken insecureskipverify handling in rediss connection uris (#20967)

### DIFF
--- a/modules/nosql/manager_redis.go
+++ b/modules/nosql/manager_redis.go
@@ -245,7 +245,7 @@ func getRedisTLSOptions(uri *url.URL) *tls.Config {
 
 	if len(skipverify) > 0 {
 		skipverify, err := strconv.ParseBool(skipverify)
-		if err != nil {
+		if err == nil {
 			tlsConfig.InsecureSkipVerify = skipverify
 		}
 	}
@@ -254,7 +254,7 @@ func getRedisTLSOptions(uri *url.URL) *tls.Config {
 
 	if len(insecureskipverify) > 0 {
 		insecureskipverify, err := strconv.ParseBool(insecureskipverify)
-		if err != nil {
+		if err == nil {
 			tlsConfig.InsecureSkipVerify = insecureskipverify
 		}
 	}

--- a/modules/nosql/manager_redis_test.go
+++ b/modules/nosql/manager_redis_test.go
@@ -27,6 +27,24 @@ func TestRedisPasswordOpt(t *testing.T) {
 	}
 }
 
+func TestSkipVerifyOpt(t *testing.T) {
+	uri, _ := url.Parse("rediss://myredis/0?skipverify=true")
+	tlsConfig := getRedisTLSOptions(uri)
+
+	if !tlsConfig.InsecureSkipVerify {
+		t.Fail()
+	}
+}
+
+func TestInsecureSkipVerifyOpt(t *testing.T) {
+	uri, _ := url.Parse("rediss://myredis/0?insecureskipverify=true")
+	tlsConfig := getRedisTLSOptions(uri)
+
+	if !tlsConfig.InsecureSkipVerify {
+		t.Fail()
+	}
+}
+
 func TestRedisSentinelUsernameOpt(t *testing.T) {
 	uri, _ := url.Parse("redis+sentinel://redis:password@myredis/0?sentinelusername=suser&sentinelpassword=spass")
 	opts := getRedisOptions(uri).Failover()


### PR DESCRIPTION
Backport #20967

Currently, it's impossible to connect to self-signed TLS encrypted redis instances. The problem lies in inproper error handling, when building redis tls options - only invalid booleans are allowed to be used in `tlsConfig` builder. The problem is, when `strconv.ParseBool(...)` returns error, it always defaults to false - meaning it's impossible to set `tlsOptions.InsecureSkipVerify` to true.

Fixes #19213
