### PR TITLE
Add another index for Action table on postgres (#21033)

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -98,7 +98,14 @@ func (a *Action) TableIndices() []*schemas.Index {
 	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
 	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
 
-	return []*schemas.Index{actUserIndex, repoIndex}
+	indices := []*schemas.Index{actUserIndex, repoIndex}
+	if setting.Database.UsePostgreSQL {
+		cudIndex := schemas.NewIndex("c_u_d", schemas.IndexType)
+		cudIndex.AddColumn("created_unix", "user_id", "is_deleted")
+		indices = append(indices, cudIndex)
+	}
+
+	return indices
 }
 
 // GetOpType gets the ActionType of this action.

--- a/models/migrations/v218.go
+++ b/models/migrations/v218.go
@@ -5,6 +5,7 @@
 package migrations
 
 import (
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
 
 	"xorm.io/xorm"
@@ -37,8 +38,14 @@ func (*improveActionTableIndicesAction) TableIndices() []*schemas.Index {
 
 	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
 	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
+	indices := []*schemas.Index{actUserIndex, repoIndex}
+	if setting.Database.UsePostgreSQL {
+		cudIndex := schemas.NewIndex("c_u_d", schemas.IndexType)
+		cudIndex.AddColumn("created_unix", "user_id", "is_deleted")
+		indices = append(indices, cudIndex)
+	}
 
-	return []*schemas.Index{actUserIndex, repoIndex}
+	return indices
 }
 
 func improveActionTableIndices(x *xorm.Engine) error {


### PR DESCRIPTION
Backport #21033

In #21031 we have discovered that on very big tables postgres will use a
search involving the sort term in preference to the restrictive index.

Therefore we add another index for postgres and update the original migration.

Fix #21031

Signed-off-by: Andrew Thornton <art27@cantab.net>
