### PR TITLE
Fill the specified ref in webhook test payload (#20961)

### DIFF
--- a/routers/web/repo/webhook.go
+++ b/routers/web/repo/webhook.go
@@ -1271,10 +1271,12 @@ func TestWebhook(ctx *context.Context) {
 		},
 	}
 
+	commitID := commit.ID.String()
 	p := &api.PushPayload{
 		Ref:        git.BranchPrefix + ctx.Repo.Repository.DefaultBranch,
-		Before:     commit.ID.String(),
-		After:      commit.ID.String(),
+		Before:     commitID,
+		After:      commitID,
+		CompareURL: setting.AppURL + ctx.Repo.Repository.ComposeCompareURL(commitID, commitID),
 		Commits:    []*api.PayloadCommit{apiCommit},
 		HeadCommit: apiCommit,
 		Repo:       convert.ToRepo(ctx.Repo.Repository, perm.AccessModeNone),

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -4614,7 +4614,7 @@
           },
           {
             "type": "string",
-            "description": "The name of the commit/branch/tag. Default the repository’s default branch (usually master)",
+            "description": "The name of the commit/branch/tag, indicates which commit will be loaded to the webhook payload.",
             "name": "ref",
             "in": "query"
           }


### PR DESCRIPTION
Backport #20961

The webhook payload should use the right ref when it‘s specified in the testing request.

The compare URL should not be empty, a URL like `compare/A...A` seems useless in most cases but is helpful when testing.
