### PR TITLE
Set uploadpack.allowFilter etc on gitea serv to enable partial clones with ssh (#20902)

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -287,7 +287,20 @@ func syncGitConfig() (err error) {
 		}
 	}
 
-	return nil
+	// By default partial clones are disabled, enable them from git v2.22
+	if !setting.Git.DisablePartialClone && CheckGitVersionAtLeast("2.22") == nil {
+		if err = configSet("uploadpack.allowfilter", "true"); err != nil {
+			return err
+		}
+		err = configSet("uploadpack.allowAnySHA1InWant", "true")
+	} else {
+		if err = configUnsetAll("uploadpack.allowfilter", "true"); err != nil {
+			return err
+		}
+		err = configUnsetAll("uploadpack.allowAnySHA1InWant", "true")
+	}
+
+	return err
 }
 
 // CheckGitVersionAtLeast check git version is at least the constraint version


### PR DESCRIPTION
Backport #20902

When setting.Git.DisablePartialClone is set to false then the web server will add filter support to web http. It does this by using`-c` command arguments but this will not work on gitea serv as the upload-pack and receive-pack commands do not support this.

Instead we move these options into the .gitconfig instead.

Fix #20400

Signed-off-by: Andrew Thornton <art27@cantab.net>
