### PR TITLE
Redirect if user does not exist on admin pages (#20981)

### DIFF
--- a/routers/web/admin/users.go
+++ b/routers/web/admin/users.go
@@ -209,7 +209,11 @@ func NewUserPost(ctx *context.Context) {
 func prepareUserInfo(ctx *context.Context) *user_model.User {
 	u, err := user_model.GetUserByID(ctx.ParamsInt64(":userid"))
 	if err != nil {
-		ctx.ServerError("GetUserByID", err)
+		if user_model.IsErrUserNotExist(err) {
+			ctx.Redirect(setting.AppSubURL + "/admin/users")
+		} else {
+			ctx.ServerError("GetUserByID", err)
+		}
 		return nil
 	}
 	ctx.Data["User"] = u


### PR DESCRIPTION
Backport #20981

When on /admin/users/ endpoints if the user is no longer in the DB,
redirect instead of causing a http 500.
