### PR TITLE
Delete unreferenced packages when deleting a package version (#20977)

### DIFF
--- a/models/packages/package.go
+++ b/models/packages/package.go
@@ -214,9 +214,16 @@ func FindUnreferencedPackages(ctx context.Context) ([]*Package, error) {
 		Find(&ps)
 }
 
-// HasOwnerPackages tests if a user/org has packages
+// HasOwnerPackages tests if a user/org has accessible packages
 func HasOwnerPackages(ctx context.Context, ownerID int64) (bool, error) {
-	return db.GetEngine(ctx).Where("owner_id = ?", ownerID).Exist(&Package{})
+	return db.GetEngine(ctx).
+		Table("package_version").
+		Join("INNER", "package", "package.id = package_version.package_id").
+		Where(builder.Eq{
+			"package_version.is_internal": false,
+			"package.owner_id":            ownerID,
+		}).
+		Exist(&PackageVersion{})
 }
 
 // HasRepositoryPackages tests if a repository has packages

--- a/models/packages/package_test.go
+++ b/models/packages/package_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package packages_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"code.gitea.io/gitea/models/db"
+	packages_model "code.gitea.io/gitea/models/packages"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+
+	_ "code.gitea.io/gitea/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m, &unittest.TestOptions{
+		GiteaRootPath: filepath.Join("..", ".."),
+	})
+}
+
+func TestHasOwnerPackages(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+
+	p, err := packages_model.TryInsertPackage(db.DefaultContext, &packages_model.Package{
+		OwnerID:   owner.ID,
+		LowerName: "package",
+	})
+	assert.NotNil(t, p)
+	assert.NoError(t, err)
+
+	// A package without package versions gets automatically cleaned up and should return false
+	has, err := packages_model.HasOwnerPackages(db.DefaultContext, owner.ID)
+	assert.False(t, has)
+	assert.NoError(t, err)
+
+	pv, err := packages_model.GetOrInsertVersion(db.DefaultContext, &packages_model.PackageVersion{
+		PackageID:    p.ID,
+		LowerVersion: "internal",
+		IsInternal:   true,
+	})
+	assert.NotNil(t, pv)
+	assert.NoError(t, err)
+
+	// A package with an internal package version gets automaticaly cleaned up and should return false
+	has, err = packages_model.HasOwnerPackages(db.DefaultContext, owner.ID)
+	assert.False(t, has)
+	assert.NoError(t, err)
+
+	pv, err = packages_model.GetOrInsertVersion(db.DefaultContext, &packages_model.PackageVersion{
+		PackageID:    p.ID,
+		LowerVersion: "normal",
+		IsInternal:   false,
+	})
+	assert.NotNil(t, pv)
+	assert.NoError(t, err)
+
+	// A package with a normal package version should return true
+	has, err = packages_model.HasOwnerPackages(db.DefaultContext, owner.ID)
+	assert.True(t, has)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Backport #20977

Delete a package if its last version got deleted. Otherwise removing the owner works only after the clean up job ran.

Fix #20969
