### PR TITLE
Ensure delete user deletes all comments

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -103,7 +103,7 @@ func DeleteUser(ctx context.Context, u *user_model.User, purge bool) (err error)
 		// Delete Comments
 		const batchSize = 50
 		for {
-			comments := make([]*issues_model.Comment, 0, 50)
+			comments := make([]*issues_model.Comment, 0, batchSize)
 			if err = e.Where("type=? AND poster_id=?", issues_model.CommentTypeComment, u.ID).Limit(batchSize, 0).Find(&comments); err != nil {
 				return err
 			}

--- a/models/user.go
+++ b/models/user.go
@@ -102,9 +102,9 @@ func DeleteUser(ctx context.Context, u *user_model.User, purge bool) (err error)
 
 		// Delete Comments
 		const batchSize = 50
-		for start := 0; ; start += batchSize {
-			comments := make([]*issues_model.Comment, 0, batchSize)
-			if err = e.Where("type=? AND poster_id=?", issues_model.CommentTypeComment, u.ID).Limit(batchSize, start).Find(&comments); err != nil {
+		for {
+			comments := make([]*issues_model.Comment, 0, 50)
+			if err = e.Where("type=? AND poster_id=?", issues_model.CommentTypeComment, u.ID).Limit(batchSize, 0).Find(&comments); err != nil {
 				return err
 			}
 			if len(comments) == 0 {
@@ -202,7 +202,7 @@ func DeleteUser(ctx context.Context, u *user_model.User, purge bool) (err error)
 	// ***** END: ExternalLoginUser *****
 
 	if _, err = e.ID(u.ID).Delete(new(user_model.User)); err != nil {
-		return fmt.Errorf("Delete: %v", err)
+		return fmt.Errorf("delete: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
There is a mistake in the batched delete comments part of DeleteUser which causes some comments to not be deleted

The code incorrectly updates the `start` of the limit clause resulting in most comments not being deleted.

```go
			if err = e.Where("type=? AND poster_id=?", issues_model.CommentTypeComment, u.ID).Limit(batchSize, start).Find(&comments); err != nil {
```

should be:

```go
			if err = e.Where("type=? AND poster_id=?", issues_model.CommentTypeComment, u.ID).Limit(batchSize, 0).Find(&comments); err != nil {
```
