### PR TITLE
Update curl usage in API docs

### DIFF
--- a/docs/content/doc/developers/api-usage.en-us.md
+++ b/docs/content/doc/developers/api-usage.en-us.md
@@ -49,7 +49,7 @@ Note that `/users/:name/tokens` is a special endpoint and requires you
 to authenticate using `BasicAuth` and a password, as follows:
 
 ```sh
-$ curl -XPOST -H "Content-Type: application/json"  -k -d '{"name":"test"}' -u username:password https://gitea.your.host/api/v1/users/<username>/tokens
+$ curl -H "Content-Type: application/json" -k -d '{"name":"test"}' -u username:password https://gitea.your.host/api/v1/users/<username>/tokens
 {"id":1,"name":"test","sha1":"9fcb1158165773dd010fca5f0cf7174316c3e37d","token_last_eight":"16c3e37d"}
 ```
 
@@ -58,7 +58,7 @@ plain-text.  It will not be displayed when listing tokens with a `GET`
 request; e.g.
 
 ```sh
-$ curl --request GET --url https://yourusername:password@gitea.your.host/api/v1/users/<username>/tokens
+$ curl --url https://yourusername:password@gitea.your.host/api/v1/users/<username>/tokens
 [{"name":"test","sha1":"","token_last_eight:"........":},{"name":"dev","sha1":"","token_last_eight":"........"}]
 ```
 
@@ -70,7 +70,7 @@ is where you'd place the code from your authenticator.
 Here is how the request would look like in curl:
 
 ```sh
-$ curl -H "X-Gitea-OTP: 123456" --request GET --url https://yourusername:yourpassword@gitea.your.host/api/v1/users/yourusername/tokens
+$ curl -H "X-Gitea-OTP: 123456" --url https://yourusername:yourpassword@gitea.your.host/api/v1/users/yourusername/tokens
 ```
 
 You can also create an API key token via your Gitea installation's web
@@ -96,7 +96,7 @@ Authorization: token 65eaa9c8ef52460d22a93307fe0aee76289dc675
 In a `curl` command, for instance, this would look like:
 
 ```sh
-curl -X POST "http://localhost:4000/api/v1/repos/test1/test1/issues" \
+curl "http://localhost:4000/api/v1/repos/test1/test1/issues" \
     -H "accept: application/json" \
     -H "Authorization: token 65eaa9c8ef52460d22a93307fe0aee76289dc675" \
     -H "Content-Type: application/json" -d "{ \"body\": \"testing\", \"title\": \"test 20\"}" -i

--- a/docs/content/doc/developers/api-usage.zh-cn.md
+++ b/docs/content/doc/developers/api-usage.zh-cn.md
@@ -46,7 +46,7 @@ Authorization: token 65eaa9c8ef52460d22a93307fe0aee76289dc675
 以 `curl` 命令为例，它会以如下形式携带在请求中：
 
 ```
-curl -X POST "http://localhost:4000/api/v1/repos/test1/test1/issues" \
+curl "http://localhost:4000/api/v1/repos/test1/test1/issues" \
     -H "accept: application/json" \
     -H "Authorization: token 65eaa9c8ef52460d22a93307fe0aee76289dc675" \
     -H "Content-Type: application/json" -d "{ \"body\": \"testing\", \"title\": \"test 20\"}" -i
@@ -62,7 +62,7 @@ curl -X POST "http://localhost:4000/api/v1/repos/test1/test1/issues" \
 ### 使用 Basic authentication 认证：
 
 ```
-$ curl --request GET --url https://yourusername:yourpassword@gitea.your.host/api/v1/users/yourusername/tokens
+$ curl --url https://yourusername:yourpassword@gitea.your.host/api/v1/users/yourusername/tokens
 [{"name":"test","sha1":"..."},{"name":"dev","sha1":"..."}]
 ```
 


### PR DESCRIPTION
Closes #21066

I believe I have this correct, as sending any data `-d` automatically assumes a `POST` request and likewise not specifying a verb should default to `GET`.