### PR TITLE
Add missing volume to test-e2e

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -569,6 +569,9 @@ steps:
       TEST_PGSQL_DBNAME: 'testgitea-e2e'
       DEBIAN_FRONTEND: noninteractive
     depends_on: [build-frontend, deps-backend]
+    volumes:
+      - name: deps
+        path: /go
 
 ---
 kind: pipeline


### PR DESCRIPTION
Without it, the deps-backend step before is useless as `go test` will not see the files in GOPATH and re-download them.