### PR TITLE
Support external renderers to PDF (#17635)

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -158,6 +158,35 @@ RENDER_COMMAND = "jupyter-nbconvert --stdin --stdout --to html --template basic"
 ALLOW_DATA_URI_IMAGES = true
 ```
 
+### Example: Office PPTX
+
+Convert Office PPTX files to PDF using
+[LibreOffice CLI](https://help.libreoffice.org/latest/en-US/text/shared/guide/start_parameters.html):
+
+```ini
+[markup.pptx]
+ENABLED = true
+FILE_EXTENSIONS = .pptx
+IS_INPUT_FILE = true
+RENDER_COMMAND = ./convert-pptx.sh
+RENDER_CONTENT_MODE = pdf
+```
+
+The script `convert-pptx.sh`:
+
+```sh
+#!/usr/bin/env sh
+set -eu
+file="$1"
+dir=`mktemp -d`
+libreoffice --convert-to pdf "$file" --outdir "$dir"
+cat "$dir/$(basename $file .pptx).pdf"
+rm -rf "$dir"
+```
+
+Using `RENDER_CONTENT_MODE = pdf` makes Gitea to embed files into a PDF viewer.
+It is mutually exclusive with post-processing and sanitization.
+
 ## Customizing CSS
 
 The external renderer is specified in the .ini in the format `[markup.XXXXX]` and the HTML supplied by your external renderer will be wrapped in a `<div>` with classes `markup` and `XXXXX`. The `markup` class provides out of the box styling (as does `markdown` if `XXXXX` is `markdown`). Otherwise you can use these classes to specifically target the contents of your rendered HTML.

--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -61,12 +61,18 @@ func (p *Renderer) SanitizerRules() []setting.MarkupSanitizerRule {
 
 // SanitizerDisabled disabled sanitize if return true
 func (p *Renderer) SanitizerDisabled() bool {
-	return p.RenderContentMode == setting.RenderContentModeNoSanitizer || p.RenderContentMode == setting.RenderContentModeIframe
+	return p.RenderContentMode == setting.RenderContentModeNoSanitizer ||
+		p.RenderContentMode == setting.RenderContentModeIframe ||
+		p.RenderContentMode == setting.RenderContentModePDF
 }
 
 // DisplayInIFrame represents whether render the content with an iframe
 func (p *Renderer) DisplayInIFrame() bool {
 	return p.RenderContentMode == setting.RenderContentModeIframe
+}
+
+func (p *Renderer) DisplayAsPDF() bool {
+	return p.RenderContentMode == setting.RenderContentModePDF
 }
 
 func envMark(envName string) string {

--- a/modules/setting/markup.go
+++ b/modules/setting/markup.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/log"
-
 	"gopkg.in/ini.v1"
 )
 
@@ -24,6 +23,7 @@ const (
 	RenderContentModeSanitized   = "sanitized"
 	RenderContentModeNoSanitizer = "no-sanitizer"
 	RenderContentModeIframe      = "iframe"
+	RenderContentModePDF         = "pdf"
 )
 
 // MarkupRenderer defines the external parser configured in ini
@@ -160,9 +160,18 @@ func newMarkupRenderer(name string, sec *ini.Section) {
 	}
 	if renderContentMode != RenderContentModeSanitized &&
 		renderContentMode != RenderContentModeNoSanitizer &&
-		renderContentMode != RenderContentModeIframe {
+		renderContentMode != RenderContentModeIframe &&
+		renderContentMode != RenderContentModePDF {
 		log.Error("invalid RENDER_CONTENT_MODE: %q, default to %q", renderContentMode, RenderContentModeSanitized)
 		renderContentMode = RenderContentModeSanitized
+	}
+
+	needPostProcessDefault := renderContentMode != RenderContentModePDF
+	needPostProcess := sec.Key("NEED_POSTPROCESS").MustBool(needPostProcessDefault)
+	if needPostProcess && renderContentMode == RenderContentModePDF {
+		log.Error("NEED_POSTPROCESS: %q is incompatible with RENDER_CONTENT_MODE: %q, default to %q",
+			needPostProcess, renderContentMode, false)
+		needPostProcess = false
 	}
 
 	ExternalMarkupRenderers = append(ExternalMarkupRenderers, &MarkupRenderer{
@@ -171,7 +180,7 @@ func newMarkupRenderer(name string, sec *ini.Section) {
 		FileExtensions:    exts,
 		Command:           command,
 		IsInputFile:       sec.Key("IS_INPUT_FILE").MustBool(false),
-		NeedPostProcess:   sec.Key("NEED_POSTPROCESS").MustBool(true),
+		NeedPostProcess:   needPostProcess,
 		RenderContentMode: renderContentMode,
 	})
 }

--- a/routers/web/repo/render.go
+++ b/routers/web/repo/render.go
@@ -44,7 +44,10 @@ func RenderFile(ctx *context.Context) {
 	st := typesniffer.DetectContentType(buf)
 	isTextFile := st.IsText()
 
-	rd := charset.ToUTF8WithFallbackReader(io.MultiReader(bytes.NewReader(buf), dataRc))
+	rd := io.MultiReader(bytes.NewReader(buf), dataRc)
+	if isTextFile {
+		rd = charset.ToUTF8WithFallbackReader(rd)
+	}
 
 	if markupType := markup.Type(blob.Name()); markupType == "" {
 		if isTextFile {

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -462,6 +462,9 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 		ctx.Data["EditFileTooltip"] = ctx.Tr("repo.editor.cannot_edit_non_text_files")
 	}
 
+	metas := ctx.Repo.Repository.ComposeDocumentMetas()
+	metas["BranchNameSubURL"] = ctx.Repo.BranchNameSubURL()
+
 	switch {
 	case isRepresentableAsText:
 		if st.IsSvgImage() {
@@ -498,8 +501,6 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			if !detected {
 				markupType = ""
 			}
-			metas := ctx.Repo.Repository.ComposeDocumentMetas()
-			metas["BranchNameSubURL"] = ctx.Repo.BranchNameSubURL()
 			ctx.Data["EscapeStatus"], ctx.Data["FileContent"], err = markupRender(ctx, &markup.RenderContext{
 				Ctx:          ctx,
 				Type:         markupType,
@@ -613,7 +614,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 				Ctx:          ctx,
 				RelativePath: ctx.Repo.TreePath,
 				URLPrefix:    path.Dir(treeLink),
-				Metas:        ctx.Repo.Repository.ComposeDocumentMetas(),
+				Metas:        metas,
 				GitRepo:      ctx.Repo.GitRepo,
 			}, rd)
 			if err != nil {


### PR DESCRIPTION
For some formats, conversion to HTML is unavailable or lossy, while quality conversion of printing to PDF is available.
Examples include Office PPTX slides and TeX papers.

Add new option value markup.XXX.RENDER_CONTENT_MODE = "pdf".
It requires markup.XXX.NEED_POSTPROCESS = false.
In this mode, external renderer is only invoked for the standalone page.
Embedded rendering outputs a PDF.js widget with a link to that page.

The first commit is a required fix for this PR, although not limited to it.