### PR TITLE
Add MD5 back to template helper functions to avoid breaking

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -154,6 +154,7 @@ func NewFuncMap() []template.FuncMap {
 		"DiffTypeToStr":                  DiffTypeToStr,
 		"DiffLineTypeToStr":              DiffLineTypeToStr,
 		"ShortSha":                       base.ShortSha,
+		"MD5":                            base.EncodeMD5,
 		"ActionContent2Commits":          ActionContent2Commits,
 		"PathEscape":                     url.PathEscape,
 		"PathEscapeSegments":             util.PathEscapeSegments,


### PR DESCRIPTION
In #20932 the MD5 helper function was removed from template context, it breaks user's customized templates.

This PR just adds the MD5 helper function back, and will help users in #21099.

Feel free to edit/take it, or discard/close if it's not necessary.