### PR TITLE
Fix various typos

### DIFF
--- a/docs/content/doc/installation/windows-service.en-us.md
+++ b/docs/content/doc/installation/windows-service.en-us.md
@@ -49,9 +49,9 @@ Open "Windows Services", search for the service named "gitea", right-click it an
 "Run". If everything is OK, Gitea will be reachable on `http://localhost:3000` (or the port
 that was configured).
 
-## Adding startup dependancies
+## Adding startup dependencies
 
-To add a startup dependancy to the Gitea Windows service (eg Mysql, Mariadb), as an Administrator, then run the following command:
+To add a startup dependency to the Gitea Windows service (eg Mysql, Mariadb), as an Administrator, then run the following command:
 
 ```
 sc.exe config gitea depend= mariadb

--- a/models/activities/repo_activity.go
+++ b/models/activities/repo_activity.go
@@ -28,7 +28,7 @@ type ActivityAuthorData struct {
 	Commits    int64  `json:"commits"`
 }
 
-// ActivityStats represets issue and pull request information.
+// ActivityStats represents issue and pull request information.
 type ActivityStats struct {
 	OpenedPRs                   issues_model.PullRequestList
 	OpenedPRAuthorCount         int64

--- a/models/packages/package_test.go
+++ b/models/packages/package_test.go
@@ -49,7 +49,7 @@ func TestHasOwnerPackages(t *testing.T) {
 	assert.NotNil(t, pv)
 	assert.NoError(t, err)
 
-	// A package with an internal package version gets automaticaly cleaned up and should return false
+	// A package with an internal package version gets automatically cleaned up and should return false
 	has, err = packages_model.HasOwnerPackages(db.DefaultContext, owner.ID)
 	assert.False(t, has)
 	assert.NoError(t, err)

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -27,7 +27,7 @@ import (
 	"xorm.io/builder"
 )
 
-// ErrUserDoesNotHaveAccessToRepo represets an error where the user doesn't has access to a given repo.
+// ErrUserDoesNotHaveAccessToRepo represents an error where the user doesn't has access to a given repo.
 type ErrUserDoesNotHaveAccessToRepo struct {
 	UserID   int64
 	RepoName string

--- a/modules/packages/vagrant/metadata.go
+++ b/modules/packages/vagrant/metadata.go
@@ -26,7 +26,7 @@ type Metadata struct {
 	RepositoryURL string `json:"repository_url,omitempty"`
 }
 
-// ParseMetadataFromBox parses the metdata of a box file
+// ParseMetadataFromBox parses the metadata of a box file
 func ParseMetadataFromBox(r io.Reader) (*Metadata, error) {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {

--- a/options/gitignore/Bazel
+++ b/options/gitignore/Bazel
@@ -6,7 +6,7 @@
 /bazel-*
 
 # Directories for the Bazel IntelliJ plugin containing the generated
-# IntelliJ project files and plugin configuration. Seperate directories are
+# IntelliJ project files and plugin configuration. Separate directories are
 # for the IntelliJ, Android Studio and CLion versions of the plugin.
 /.ijwb/
 /.aswb/

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -136,7 +136,7 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 }
 
 // localizedExtensions prepends the provided language code with and without a
-// regional identifier to the provided extenstion.
+// regional identifier to the provided extension.
 // Note: the language code will always be lower-cased, if a region is present it must be separated with a `-`
 // Note: ext should be prefixed with a `.`
 func localizedExtensions(ext, languageCode string) (localizedExts []string) {

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -13,7 +13,7 @@
 	</h2>
 	{{if .Flash.WarningMsg}}
 		{{/*
-			There's alreay a importing of alert.tmpl in new_form.tmpl,
+			There's already an importing of alert.tmpl in new_form.tmpl,
 			but only the negative message will be displayed within forms for some reasons, see semantic.css:10659.
 			To avoid repeated negative messages, the importing here if for .Flash.WarningMsg only.
 		*/}}

--- a/templates/repo/issue/new.tmpl
+++ b/templates/repo/issue/new.tmpl
@@ -8,7 +8,7 @@
 		<div class="ui divider"></div>
 		{{if .Flash.WarningMsg}}
 			{{/*
-			There's alreay a importing of alert.tmpl in new_form.tmpl,
+			There's already an importing of alert.tmpl in new_form.tmpl,
 			but only the negative message will be displayed within forms for some reasons, see semantic.css:10659.
 			To avoid repeated negative messages, the importing here if for .Flash.WarningMsg only.
 			 */}}

--- a/tests/integration/pull_status_test.go
+++ b/tests/integration/pull_status_test.go
@@ -107,7 +107,7 @@ func doAPICreateCommitStatus(ctx APITestContext, commitID string, status api.Com
 
 func TestPullCreate_EmptyChangesWithDifferentCommits(t *testing.T) {
 	// Merge must continue if commits SHA are different, even if content is same
-	// Reason: gitflow and merging master back into develop, where is high possiblity, there are no changes
+	// Reason: gitflow and merging master back into develop, where is high possibility, there are no changes
 	// but just commit saying "Merge branch". And this meta commit can be also tagged,
 	// so we need to have this meta commit also in develop branch.
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./options/locale,./options/license,./public/vendor,./web_src/fomantic -L actived,allways,attachements,ba,befores,commiter,pullrequest,pullrequests,readby,splitted,te,unknwon`