### PR TITLE
Fix typo of issue template name

### DIFF
--- a/docs/content/doc/usage/issue-pull-request-templates.en-us.md
+++ b/docs/content/doc/usage/issue-pull-request-templates.en-us.md
@@ -42,7 +42,7 @@ Possible file names for issue templates:
 - `.gitea/ISSUE_TEMPLATE.yml`
 - `.gitea/issue_template.md`
 - `.gitea/issue_template.yaml`
-- `.gitea/issue_template.md`
+- `.gitea/issue_template.yml`
 - `.github/ISSUE_TEMPLATE.md`
 - `.github/ISSUE_TEMPLATE.yaml`
 - `.github/ISSUE_TEMPLATE.yml`

--- a/docs/content/doc/usage/issue-pull-request-templates.zh-cn.md
+++ b/docs/content/doc/usage/issue-pull-request-templates.zh-cn.md
@@ -62,7 +62,7 @@ Gitea 支持两种格式的模板：Markdown 和 YAML。
 - `.gitea/ISSUE_TEMPLATE.yml`
 - `.gitea/issue_template.md`
 - `.gitea/issue_template.yaml`
-- `.gitea/issue_template.md`
+- `.gitea/issue_template.yml`
 - `.github/ISSUE_TEMPLATE.md`
 - `.github/ISSUE_TEMPLATE.yaml`
 - `.github/ISSUE_TEMPLATE.yml`

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -81,7 +81,7 @@ var IssueTemplateCandidates = []string{
 	".gitea/ISSUE_TEMPLATE.yml",
 	".gitea/issue_template.md",
 	".gitea/issue_template.yaml",
-	".gitea/issue_template.md",
+	".gitea/issue_template.yml",
 	".github/ISSUE_TEMPLATE.md",
 	".github/ISSUE_TEMPLATE.yaml",
 	".github/ISSUE_TEMPLATE.yml",


### PR DESCRIPTION
Should be

- .gitea/issue_template.md
- .gitea/issue_template.yaml
- .gitea/issue_template.~~md~~yml

Related to #20987, #21030.