### PR TITLE
Fix slight bug in katex

### DIFF
--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -7,6 +7,7 @@ package markup_test
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -32,6 +33,7 @@ func TestMain(m *testing.M) {
 	if err := git.InitSimple(context.Background()); err != nil {
 		log.Fatal("git init failed, err: %v", err)
 	}
+	os.Exit(m.Run())
 }
 
 func TestRender_Commits(t *testing.T) {
@@ -336,7 +338,7 @@ func TestRender_emoji(t *testing.T) {
 		`<p>Some text with <span class="emoji" aria-label="grinning face with smiling eyes">😄</span><span class="emoji" aria-label="grinning face with smiling eyes">😄</span> 2 emoji next to each other</p>`)
 	test(
 		"😎🤪🔐🤑❓",
-		`<p><span class="emoji" aria-label="smiling face with sunglasses">😎</span><span class="emoji" aria-label="zany face">🤪</span><span class="emoji" aria-label="locked with key">🔐</span><span class="emoji" aria-label="money-mouth face">🤑</span><span class="emoji" aria-label="question mark">❓</span></p>`)
+		`<p><span class="emoji" aria-label="smiling face with sunglasses">😎</span><span class="emoji" aria-label="zany face">🤪</span><span class="emoji" aria-label="locked with key">🔐</span><span class="emoji" aria-label="money-mouth face">🤑</span><span class="emoji" aria-label="red question mark">❓</span></p>`)
 
 	// should match nothing
 	test(

--- a/modules/markup/markdown/math/inline_parser.go
+++ b/modules/markup/markdown/math/inline_parser.go
@@ -37,7 +37,7 @@ func NewInlineBracketParser() parser.InlineParser {
 	return defaultInlineBracketParser
 }
 
-// Trigger returns nil
+// Trigger triggers this parser on $ or \
 func (parser *inlineParser) Trigger() []byte {
 	return parser.start[0:1]
 }

--- a/modules/markup/markdown/meta.go
+++ b/modules/markup/markdown/meta.go
@@ -88,7 +88,9 @@ func ExtractMetadataBytes(contents []byte, out interface{}) ([]byte, error) {
 		line := contents[start:end]
 		if isYAMLSeparator(line) {
 			front = contents[frontMatterStart:start]
-			body = contents[end+1:]
+			if end+1 < len(contents) {
+				body = contents[end+1:]
+			}
 			break
 		}
 	}

--- a/modules/markup/markdown/meta_test.go
+++ b/modules/markup/markdown/meta_test.go
@@ -61,7 +61,7 @@ func TestExtractMetadataBytes(t *testing.T) {
 		var meta structs.IssueTemplate
 		body, err := ExtractMetadataBytes([]byte(fmt.Sprintf("%s\n%s\n%s\n%s", sepTest, frontTest, sepTest, bodyTest)), &meta)
 		assert.NoError(t, err)
-		assert.Equal(t, bodyTest, body)
+		assert.Equal(t, bodyTest, string(body))
 		assert.Equal(t, metaTest, meta)
 		assert.True(t, validateMetadata(meta))
 	})
@@ -82,7 +82,7 @@ func TestExtractMetadataBytes(t *testing.T) {
 		var meta structs.IssueTemplate
 		body, err := ExtractMetadataBytes([]byte(fmt.Sprintf("%s\n%s\n%s", sepTest, frontTest, sepTest)), &meta)
 		assert.NoError(t, err)
-		assert.Equal(t, "", body)
+		assert.Equal(t, "", string(body))
 		assert.Equal(t, metaTest, meta)
 		assert.True(t, validateMetadata(meta))
 	})

--- a/modules/markup/markdown/renderconfig.go
+++ b/modules/markup/markdown/renderconfig.go
@@ -5,9 +5,8 @@
 package markdown
 
 import (
+	"fmt"
 	"strings"
-
-	"code.gitea.io/gitea/modules/log"
 
 	"github.com/yuin/goldmark/ast"
 	"gopkg.in/yaml.v3"
@@ -33,17 +32,13 @@ func (rc *RenderConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 	rc.yamlNode = value
 
-	type basicRenderConfig struct {
-		Gitea *yaml.Node `yaml:"gitea"`
-		TOC   bool       `yaml:"include_toc"`
-		Lang  string     `yaml:"lang"`
+	type commonRenderConfig struct {
+		TOC  bool   `yaml:"include_toc"`
+		Lang string `yaml:"lang"`
 	}
-
-	var basic basicRenderConfig
-
-	err := value.Decode(&basic)
-	if err != nil {
-		return err
+	var basic commonRenderConfig
+	if err := value.Decode(&basic); err != nil {
+		return fmt.Errorf("unable to decode into basicRenderConfig %w", err)
 	}
 
 	if basic.Lang != "" {
@@ -51,14 +46,48 @@ func (rc *RenderConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	rc.TOC = basic.TOC
-	if basic.Gitea == nil {
+
+	type controlStringRenderConfig struct {
+		Gitea string `yaml:"gitea"`
+	}
+
+	var stringBasic controlStringRenderConfig
+
+	if err := value.Decode(&stringBasic); err == nil {
+		if stringBasic.Gitea != "" {
+			switch strings.TrimSpace(strings.ToLower(stringBasic.Gitea)) {
+			case "none":
+				rc.Meta = "none"
+			case "table":
+				rc.Meta = "table"
+			default: // "details"
+				rc.Meta = "details"
+			}
+		}
 		return nil
 	}
 
-	var control *string
-	if err := basic.Gitea.Decode(&control); err == nil && control != nil {
-		log.Info("control %v", control)
-		switch strings.TrimSpace(strings.ToLower(*control)) {
+	type giteaControl struct {
+		Meta *string `yaml:"meta"`
+		Icon *string `yaml:"details_icon"`
+		TOC  *bool   `yaml:"include_toc"`
+		Lang *string `yaml:"lang"`
+	}
+
+	type complexGiteaConfig struct {
+		Gitea *giteaControl `yaml:"gitea"`
+	}
+	var complex complexGiteaConfig
+	if err := value.Decode(&complex); err != nil {
+		return fmt.Errorf("unable to decode into complexRenderConfig %w", err)
+	}
+
+	if complex.Gitea == nil {
+		return nil
+	}
+
+	if complex.Gitea.Meta != nil {
+		switch strings.TrimSpace(strings.ToLower(*complex.Gitea.Meta)) {
 		case "none":
 			rc.Meta = "none"
 		case "table":
@@ -66,39 +95,18 @@ func (rc *RenderConfig) UnmarshalYAML(value *yaml.Node) error {
 		default: // "details"
 			rc.Meta = "details"
 		}
-		return nil
 	}
 
-	type giteaControl struct {
-		Meta string     `yaml:"meta"`
-		Icon string     `yaml:"details_icon"`
-		TOC  *yaml.Node `yaml:"include_toc"`
-		Lang string     `yaml:"lang"`
+	if complex.Gitea.Icon != nil {
+		rc.Icon = strings.TrimSpace(strings.ToLower(*complex.Gitea.Icon))
 	}
 
-	var controlStruct *giteaControl
-	if err := basic.Gitea.Decode(controlStruct); err != nil || controlStruct == nil {
-		return err
+	if complex.Gitea.Lang != nil && *complex.Gitea.Lang != "" {
+		rc.Lang = *complex.Gitea.Lang
 	}
 
-	switch strings.TrimSpace(strings.ToLower(controlStruct.Meta)) {
-	case "none":
-		rc.Meta = "none"
-	case "table":
-		rc.Meta = "table"
-	default: // "details"
-		rc.Meta = "details"
-	}
-
-	rc.Icon = strings.TrimSpace(strings.ToLower(controlStruct.Icon))
-
-	if controlStruct.Lang != "" {
-		rc.Lang = controlStruct.Lang
-	}
-
-	var toc bool
-	if err := controlStruct.TOC.Decode(&toc); err == nil {
-		rc.TOC = toc
+	if complex.Gitea.TOC != nil {
+		rc.TOC = *complex.Gitea.TOC
 	}
 
 	return nil

--- a/modules/markup/markdown/renderconfig.go
+++ b/modules/markup/markdown/renderconfig.go
@@ -38,7 +38,7 @@ func (rc *RenderConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 	var basic commonRenderConfig
 	if err := value.Decode(&basic); err != nil {
-		return fmt.Errorf("unable to decode into basicRenderConfig %w", err)
+		return fmt.Errorf("unable to decode into commonRenderConfig %w", err)
 	}
 
 	if basic.Lang != "" {

--- a/modules/markup/markdown/renderconfig_test.go
+++ b/modules/markup/markdown/renderconfig_test.go
@@ -5,8 +5,10 @@
 package markdown
 
 import (
+	"strings"
 	"testing"
 
+	"code.gitea.io/gitea/modules/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -80,20 +82,20 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				TOC:  true,
 				Lang: "testlang",
-			}, `
-	include_toc: true
-	lang: testlang
-`,
+			}, util.Dedent(`
+				include_toc: true
+				lang: testlang
+				`),
 		},
 		{
 			"complexlang", &RenderConfig{
 				Meta: "table",
 				Icon: "table",
 				Lang: "testlang",
-			}, `
-	gitea:
-		lang: testlang
-`,
+			}, util.Dedent(`
+				gitea:
+					lang: testlang
+				`),
 		},
 		{
 			"complexlang2", &RenderConfig{
@@ -140,8 +142,8 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				Lang: "",
 			}
-			if err := yaml.Unmarshal([]byte(tt.args), got); err != nil {
-				t.Errorf("RenderConfig.UnmarshalYAML() error = %v", err)
+			if err := yaml.Unmarshal([]byte(strings.ReplaceAll(tt.args, "\t", "        ")), got); err != nil {
+				t.Errorf("RenderConfig.UnmarshalYAML() error = %v\n%q", err, tt.args)
 				return
 			}
 

--- a/modules/markup/markdown/renderconfig_test.go
+++ b/modules/markup/markdown/renderconfig_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"code.gitea.io/gitea/modules/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -82,20 +81,20 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				TOC:  true,
 				Lang: "testlang",
-			}, util.Dedent(`
+			}, `
 				include_toc: true
 				lang: testlang
-				`),
+				`,
 		},
 		{
 			"complexlang", &RenderConfig{
 				Meta: "table",
 				Icon: "table",
 				Lang: "testlang",
-			}, util.Dedent(`
+			}, `
 				gitea:
 					lang: testlang
-				`),
+				`,
 		},
 		{
 			"complexlang2", &RenderConfig{
@@ -142,7 +141,7 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				Lang: "",
 			}
-			if err := yaml.Unmarshal([]byte(strings.ReplaceAll(tt.args, "\t", "        ")), got); err != nil {
+			if err := yaml.Unmarshal([]byte(strings.ReplaceAll(tt.args, "\t", "    ")), got); err != nil {
 				t.Errorf("RenderConfig.UnmarshalYAML() error = %v\n%q", err, tt.args)
 				return
 			}


### PR DESCRIPTION
There is a small bug in #20571 whereby `$a a$b b$` will not be correctly detected as a math inline block of `a a$b b`. This PR fixes this.

Signed-off-by: Andrew Thornton <art27@cantab.net>
