### PR TITLE
File header tweaks

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -409,10 +409,6 @@
           font-size: .5em;
         }
 
-        .file-info {
-          font-size: 13px;
-        }
-
         .file-actions {
           .btn-octicon {
             line-height: 1;
@@ -3051,7 +3047,8 @@ td.blob-excerpt {
   display: flex;
   justify-content: space-between;
   overflow-x: auto;
-  padding: 8px 12px !important;
+  padding: 6px 12px !important;
+  font-size: 13px !important;
 }
 
 .file-info {


### PR DESCRIPTION
- Remove non-matching selector
- Set font-size on parent so `.mono` can correctly reduce it

Before (font subjectively too big):
<img width="1270" alt="Screenshot 2022-09-15 at 19 03 56" src="https://user-images.githubusercontent.com/115237/190466867-283e9c23-cbfa-457e-8dbe-94902e886cc7.png">

After:
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/115237/190467290-eb392007-5db2-4ab0-a5be-e7cfe4618dcc.png">

