### PR TITLE
Enable fluid page layout on medium size viewports

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -737,6 +737,13 @@ a.ui.card:hover,
   padding-bottom: 80px;
 }
 
+/* enable fluid page widths for medium size viewports */
+@media @mediaMdAndUp and @mediaLgAndDown {
+  .ui.ui.ui.container:not(.fluid) {
+    width: calc(100vw - 3em);
+  }
+}
+
 .following.bar {
   z-index: 900;
   left: 0;


### PR DESCRIPTION
Fomantic has abrupt breakpoints at 991px and 768px which leads to variable amounts of wasted screen space below those breakpoints. Instead, enable fluid width for all viewport sizes below 1200px.

Before:
<img width="895" alt="Screen Shot 2022-09-15 at 22 53 05" src="https://user-images.githubusercontent.com/115237/190507305-3e53e712-0e0b-47e1-99f6-fd343e58537e.png">

After
<img width="895" alt="Screen Shot 2022-09-15 at 22 53 50" src="https://user-images.githubusercontent.com/115237/190507334-bf15354a-2bf1-4096-aff8-d6d50bec2574.png">
