### PR TITLE
Remove unnecessary length check for repo's Description & Website

### DIFF
--- a/modules/repository/create.go
+++ b/modules/repository/create.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"unicode/utf8"
 
 	"code.gitea.io/gitea/models"
 	activities_model "code.gitea.io/gitea/models/activities"
@@ -336,13 +335,6 @@ func CheckDaemonExportOK(ctx context.Context, repo *repo_model.Repository) error
 // UpdateRepository updates a repository with db context
 func UpdateRepository(ctx context.Context, repo *repo_model.Repository, visibilityChanged bool) (err error) {
 	repo.LowerName = strings.ToLower(repo.Name)
-
-	if utf8.RuneCountInString(repo.Description) > 255 {
-		repo.Description = string([]rune(repo.Description)[:255])
-	}
-	if utf8.RuneCountInString(repo.Website) > 255 {
-		repo.Website = string([]rune(repo.Website)[:255])
-	}
 
 	e := db.GetEngine(ctx)
 


### PR DESCRIPTION
Follows #21119
* #21119


The manual length check was as old as year 2014 

https://github.com/go-gitea/gitea/commit/59ffdbf6#diff-1851799b06733db4df3ec74385c1e8850ee5aedee70b8b55366910d22725eea8R374-R384


It doesn't make sense nowadays:
1. The length check is already done by form's `binding:MaxSize` (then the manual check is unnecessary)
2. The CreateRepository doesn't have such check (then the manual check is inconsistent)

So this PR removes these manual length checks.