### PR TITLE
Fix reaction of issues (#21185)

### DIFF
--- a/models/issues/reaction.go
+++ b/models/issues/reaction.go
@@ -181,6 +181,10 @@ func createReaction(ctx context.Context, opts *ReactionOptions) (*Reaction, erro
 		Reaction:  opts.Type,
 		UserID:    opts.DoerID,
 	}
+	if findOpts.CommentID == 0 {
+		// explicit search of Issue Reactions where CommentID = 0
+		findOpts.CommentID = -1
+	}
 
 	existingR, _, err := FindReactions(ctx, findOpts)
 	if err != nil {
@@ -256,16 +260,23 @@ func DeleteReaction(ctx context.Context, opts *ReactionOptions) error {
 		CommentID: opts.CommentID,
 	}
 
-	_, err := db.GetEngine(ctx).Where("original_author_id = 0").Delete(reaction)
+	sess := db.GetEngine(ctx).Where("original_author_id = 0")
+	if opts.CommentID == -1 {
+		reaction.CommentID = 0
+		sess.MustCols("comment_id")
+	}
+
+	_, err := sess.Delete(reaction)
 	return err
 }
 
 // DeleteIssueReaction deletes a reaction on issue.
 func DeleteIssueReaction(doerID, issueID int64, content string) error {
 	return DeleteReaction(db.DefaultContext, &ReactionOptions{
-		Type:    content,
-		DoerID:  doerID,
-		IssueID: issueID,
+		Type:      content,
+		DoerID:    doerID,
+		IssueID:   issueID,
+		CommentID: -1,
 	})
 }
 


### PR DESCRIPTION
Backport #21185.

Fix #20860.

`CommentID` in `FindReactionsOptions` should be -1 to search reactions with zero comment id.


https://github.com/go-gitea/gitea/blob/8351172b6e5221290dc5b2c81e159e2eec0b43c8/models/issues/reaction.go#L108-L121

