### PR TITLE
Various CSS tweaks

### DIFF
--- a/web_src/fomantic/theme.config.less
+++ b/web_src/fomantic/theme.config.less
@@ -50,7 +50,6 @@
 @table      : 'default';
 
 /* Modules */
-@accordion  : 'default';
 @calendar   : 'default';
 @checkbox   : 'default';
 @dimmer     : 'default';

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -135,7 +135,7 @@
   --color-light: #00000006;
   --color-light-mimic-enabled: rgba(0, 0, 0, calc(6 / 255 * 222 / 255 / var(--opacity-disabled)));
   --color-light-border: #0000001d;
-  --color-hover: #0000000f;
+  --color-hover: #0000000c;
   --color-active: #00000014;
   --color-menu: #ffffff;
   --color-card: #ffffff;
@@ -157,6 +157,7 @@
   --color-reaction-active-bg: var(--color-primary-alpha-20);
   --color-tooltip-bg: #000000f0;
   --color-tooltip-text: #ffffff;
+  --color-header-bar: #ffffff;
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
@@ -294,6 +295,29 @@ a.commit-statuses-trigger {
   text-decoration: none !important;
 }
 
+.ui.search > .results {
+  background: var(--color-body);
+  border-color: var(--color-secondary);
+}
+
+.ui.search > .results .result {
+  background: var(--color-body);
+}
+
+.ui.search > .results .result .title {
+  color: var(--color-text-dark);
+}
+
+.ui.search > .results .result .image {
+  width: auto;
+  height: auto;
+}
+
+.ui.search > .results .result:hover,
+.ui.category.search > .results .category .result:hover {
+  background: var(--color-hover);
+}
+
 .unselectable {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -316,6 +340,11 @@ a.commit-statuses-trigger {
 
 .ui.breadcrumb .divider {
   color: var(--color-text-light-2);
+}
+
+.ui.divider:not(.vertical,.horizontal) {
+  border-top-color: var(--color-secondary) !important;
+  border-bottom: none !important;
 }
 
 .page-content {
@@ -447,6 +476,11 @@ a.commit-statuses-trigger {
 
 .ui.dropdown .menu > .message:not(.ui) {
   color: var(--color-text-light-2);
+}
+
+.ui.list .list > .item > .content,
+.ui.list > .item > .content {
+  color: var(--color-text);
 }
 
 .ui.secondary.menu .dropdown.item:hover,
@@ -656,8 +690,18 @@ a.ui.card:hover,
 
 .ui.table {
   color: var(--color-text);
-  background: var(--color-body);
+  background: var(--color-box-body);
   border-color: var(--color-secondary);
+}
+
+.ui.table th,
+.ui.table td {
+  transition: none;
+}
+
+.ui.table > tr > td,
+.ui.table > tbody > tr > td {
+  border-top-color: var(--color-secondary-alpha-50);
 }
 
 .ui.ui.selectable.table > tbody > tr:hover,
@@ -669,6 +713,11 @@ a.ui.card:hover,
 .ui.ui.ui.ui.table tr.grey:not(.marked),
 .ui.ui.table td.grey:not(.marked) {
   background: var(--color-body);
+  color: var(--color-text);
+}
+
+.ui.table > thead > tr > th {
+  background: var(--color-box-header);
   color: var(--color-text);
 }
 
@@ -750,7 +799,7 @@ a.ui.card:hover,
   margin: 0 !important;
 
   &.light {
-    background: var(--color-body);
+    background: var(--color-header-bar);
     border-bottom: 1px solid var(--color-secondary);
   }
 

--- a/web_src/less/_form.less
+++ b/web_src/less/_form.less
@@ -134,7 +134,7 @@ textarea:focus,
 
 .form {
   .help {
-    color: #999999;
+    color: var(--color-secondary-dark-5);
     padding-bottom: .6em;
     display: inline-block;
   }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -384,7 +384,7 @@
       }
 
       tr:hover {
-        background-color: #ffffee;
+        background-color: var(--color-hover);
       }
 
       tr.has-parent a {
@@ -3013,9 +3013,9 @@ tbody.commit-list {
 }
 
 .tag-code,
-.tag-code td {
-  background-color: #f0f9ff;
-  border-color: #f1f8ff !important;
+.tag-code td,
+.tag-code .blob-excerpt {
+  background-color: var(--color-box-body-highlight);
   vertical-align: middle;
 }
 
@@ -3031,7 +3031,7 @@ tbody.commit-list {
 }
 
 td.blob-excerpt {
-  background-color: #fafafa;
+  background-color: var(--color-secondary-alpha-30);
 }
 
 .issue-keyword {

--- a/web_src/less/themes/theme-arc-green.less
+++ b/web_src/less/themes/theme-arc-green.less
@@ -94,7 +94,7 @@
   /* target-based colors */
   --color-body: #383c4a;
   --color-box-header: #404652;
-  --color-box-body: #303440;
+  --color-box-body: #2a2e3a;
   --color-box-body-highlight: #353945;
   --color-text-dark: #dbe0ea;
   --color-text: #bbc0ca;
@@ -105,7 +105,7 @@
   --color-footer: #2e323e;
   --color-timeline: #4c525e;
   --color-input-text: #d5dbe6;
-  --color-input-background: #292d39;
+  --color-input-background: #232933;
   --color-input-border: #454a57;
   --color-input-border-hover: #505667;
   --color-navbar: #2a2e3a;
@@ -132,23 +132,11 @@
   --color-caret: var(--color-text); /* should ideally be --color-text-dark, see #15651 */
   --color-reaction-bg: #ffffff12;
   --color-reaction-active-bg: var(--color-primary-alpha-40);
+  --color-header-bar: #2e323e;
 }
 
 ::-webkit-calendar-picker-indicator {
   filter: invert(.8);
-}
-
-.ui.horizontal.segments > .segment {
-  background-color: #383c4a;
-}
-
-.following.bar.light {
-  background: #2e323e;
-  border-color: var(--color-secondary-alpha-40);
-}
-
-.following.bar .top.menu a.item:hover {
-  color: #fff;
 }
 
 .ui.red.label,
@@ -161,10 +149,6 @@
 .ui.yellow.labels .label {
   border-color: #664d02 !important;
   background-color: #936e00 !important;
-}
-
-.ui.accordion .title:not(.ui) {
-  color: #dbdbdb;
 }
 
 .ui.green.label,
@@ -181,19 +165,6 @@ a.ui.basic.green.label:hover {
   background-color: #3d794b !important;
   border-color: #3d794b !important;
   color: #fff !important;
-}
-
-.ui.divider:not(.vertical,.horizontal) {
-  border-bottom-color: var(--color-secondary);
-  border-top-color: transparent;
-}
-
-.form .help {
-  color: #7f8699;
-}
-
-.ui .text.light.grey {
-  color: #7f8699 !important;
 }
 
 .ui.form .fields.error .field textarea,
@@ -257,45 +228,6 @@ a.ui.basic.green.label:hover {
   background-color: #a0cc75;
 }
 
-.ui.search > .results {
-  background: #383c4a;
-  border-color: var(--color-secondary);
-}
-
-.ui.search > .results .result:hover,
-.ui.category.search > .results .category .result:hover {
-  background: var(--color-secondary);
-}
-
-.ui.search > .results .result .title {
-  color: #dbdbdb;
-}
-
-.ui.table > thead > tr > th {
-  background: var(--color-secondary);
-  color: #dbdbdb !important;
-}
-
-.repository.file.list #repo-files-table tr {
-  background: #2a2e3a;
-}
-
-.repository.file.list #repo-files-table tr:hover {
-  background-color: #393d4a !important;
-}
-
-.overflow.menu .items .item {
-  color: #9d9d9d;
-}
-
-.overflow.menu .items .item:hover {
-  color: #dbdbdb;
-}
-
-.ui.list > .item > .content {
-  color: var(--color-secondary-dark-6) !important;
-}
-
 .repository .navbar .active.item,
 .repository .navbar .active.item:hover {
   border-color: transparent !important;
@@ -303,20 +235,6 @@ a.ui.basic.green.label:hover {
 
 .repository .diff-stats li {
   border-color: var(--color-secondary);
-}
-
-.tag-code,
-.tag-code td {
-  background: #353945 !important;
-
-}
-.tag-code td.lines-num {
-  background-color: #3a3e4c !important;
-}
-
-.tag-code td.lines-type-marker,
-td.blob-hunk {
-  color: #dbdbdb !important;
 }
 
 .ui.red.button,
@@ -342,10 +260,6 @@ td.blob-hunk {
 .lines-num {
   color: var(--color-secondary-dark-6) !important;
   border-color: var(--color-secondary) !important;
-}
-
-td.blob-excerpt {
-  background-color: rgba(0, 0, 0, .15);
 }
 
 .lines-code.active,


### PR DESCRIPTION
- Remove arc-green specific rules and instead fix the colors in the base rules.
- Make file table row border visible on arc-green.
- Remove remnants of fomantic accordeon module that was removed.

This introduces 1 new CSS var, which is breaking for theme authors.

<img width="414" alt="Screen Shot 2022-09-22 at 22 15 39" src="https://user-images.githubusercontent.com/115237/191852063-437698e9-0f6a-47f4-86e7-9b9206d64144.png">
<img width="549" alt="Screen Shot 2022-09-22 at 23 11 07" src="https://user-images.githubusercontent.com/115237/191852081-81a8b35e-1f0b-46b1-9dda-35dfa91d92bf.png">
<img width="689" alt="Screen Shot 2022-09-22 at 23 11 40" src="https://user-images.githubusercontent.com/115237/191852101-741b1914-e97f-44ad-8a1e-43a2ca455aa6.png">
