### PR TITLE
Feature: Case-insensitive "find files in repo"

### DIFF
--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -64,8 +64,9 @@ export function parseIssueHref(href) {
 export function strSubMatch(full, sub) {
   const res = [''];
   let i = 0, j = 0;
-  while (i < sub.length && j < full.length) {
-    if (sub[i].toLowerCase() === full[j].toLowerCase()) {
+  const subLower = sub.toLowerCase(), fullLower = full.toLowerCase();
+  while (i < subLower.length && j < fullLower.length) {
+    if (subLower[i] === fullLower[j]) {
       if (res.length % 2 !== 0) res.push('');
       res[res.length - 1] += full[j];
       j++;

--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -65,18 +65,15 @@ export function strSubMatch(full, sub) {
   const res = [''];
   let i = 0, j = 0;
   while (i < sub.length && j < full.length) {
-    while (j < full.length) {
-      if (sub[i]?.toLowerCase() === full[j]?.toLowerCase()) {
-        if (res.length % 2 !== 0) res.push('');
-        res[res.length - 1] += full[j];
-        j++;
-        i++;
-      } else {
-        if (res.length % 2 === 0) res.push('');
-        res[res.length - 1] += full[j];
-        j++;
-        break;
-      }
+    if (sub[i].toLowerCase() === full[j].toLowerCase()) {
+      if (res.length % 2 !== 0) res.push('');
+      res[res.length - 1] += full[j];
+      j++;
+      i++;
+    } else {
+      if (res.length % 2 === 0) res.push('');
+      res[res.length - 1] += full[j];
+      j++;
     }
   }
   if (i !== sub.length) {

--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -66,7 +66,7 @@ export function strSubMatch(full, sub) {
   let i = 0, j = 0;
   while (i < sub.length && j < full.length) {
     while (j < full.length) {
-      if (sub[i] === full[j]) {
+      if (typeof sub[i] !== 'undefined' && typeof full[j] !== 'undefined' && sub[i].toLowerCase() === full[j].toLowerCase()) {
         if (res.length % 2 !== 0) res.push('');
         res[res.length - 1] += full[j];
         j++;

--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -66,7 +66,7 @@ export function strSubMatch(full, sub) {
   let i = 0, j = 0;
   while (i < sub.length && j < full.length) {
     while (j < full.length) {
-      if (typeof sub[i] !== 'undefined' && typeof full[j] !== 'undefined' && sub[i].toLowerCase() === full[j].toLowerCase()) {
+      if (sub[i]?.toLowerCase() === full[j]?.toLowerCase()) {
         if (res.length % 2 !== 0) res.push('');
         res[res.length - 1] += full[j];
         j++;

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -95,6 +95,9 @@ test('strSubMatch', () => {
   expect(strSubMatch('abc', 'z')).toEqual(['abc']);
   expect(strSubMatch('abc', 'az')).toEqual(['abc']);
 
+  expect(strSubMatch('abc', 'aC')).toEqual(['', 'a', 'b', 'c']);
+  expect(strSubMatch('abC', 'ac')).toEqual(['', 'a', 'b', 'C']);
+
   expect(strSubMatch('aabbcc', 'abc')).toEqual(['', 'a', 'a', 'b', 'b', 'c', 'c']);
   expect(strSubMatch('the/directory', 'hedir')).toEqual(['t', 'he', '/', 'dir', 'ectory']);
 });


### PR DESCRIPTION
This (short) PR builds upon #15028 and makes the file search case-insensitive.

Previously, having a file named `TestFile.cs` would not be shown if `test` was typed in the search box.  
This now changes the matching function to be case-insensitive (without affecting the UI).

The matching function, `strSubMatch`, is only used for this feature (it has been introduced by #15028), meaning that this PR does not affect the behaviour of any unrelated functionality of Gitea.