### PR TITLE
Improve error descriptions for unauthorized_client

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -645,7 +645,7 @@ func handleRefreshToken(ctx *context.Context, form forms.AccessTokenForm, server
 	if err != nil {
 		handleAccessTokenError(ctx, AccessTokenError{
 			ErrorCode:        AccessTokenErrorCodeUnauthorizedClient,
-			ErrorDescription: "client is not authorized",
+			ErrorDescription: "unable to parse refresh token",
 		})
 		return
 	}
@@ -688,14 +688,14 @@ func handleAuthorizationCode(ctx *context.Context, form forms.AccessTokenForm, s
 	if !app.ValidateClientSecret([]byte(form.ClientSecret)) {
 		handleAccessTokenError(ctx, AccessTokenError{
 			ErrorCode:        AccessTokenErrorCodeUnauthorizedClient,
-			ErrorDescription: "client is not authorized",
+			ErrorDescription: "invalid client secret",
 		})
 		return
 	}
 	if form.RedirectURI != "" && !app.ContainsRedirectURI(form.RedirectURI) {
 		handleAccessTokenError(ctx, AccessTokenError{
 			ErrorCode:        AccessTokenErrorCodeUnauthorizedClient,
-			ErrorDescription: "client is not authorized",
+			ErrorDescription: "unexpected redirect URI",
 		})
 		return
 	}
@@ -711,7 +711,7 @@ func handleAuthorizationCode(ctx *context.Context, form forms.AccessTokenForm, s
 	if !authorizationCode.ValidateCodeChallenge(form.CodeVerifier) {
 		handleAccessTokenError(ctx, AccessTokenError{
 			ErrorCode:        AccessTokenErrorCodeUnauthorizedClient,
-			ErrorDescription: "client is not authorized",
+			ErrorDescription: "failed PKCE code challenge",
 		})
 		return
 	}


### PR DESCRIPTION
Fixes #21282


As suggested by the [OAuth RFC](https://www.rfc-editor.org/rfc/rfc6749) (quoted below), it's helpful to give more detail in the description

> error_description
         OPTIONAL.  Human-readable ASCII [[USASCII](https://www.rfc-editor.org/rfc/rfc6749#ref-USASCII)] text providing         **additional information, used to assist the client developer in         understanding the error that occurred.**
         Values for the "error_description" parameter MUST NOT include         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
