### PR TITLE
Fix issue that `sync_on_commit` is not set

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -221,7 +221,7 @@
 										</details>
 										<div class="field">
 											<div class="ui checkbox">
-												<input id="push_mirror_sync_on_commit" name="push_mirror_sync_on_commit" type="checkbox">
+												<input id="push_mirror_sync_on_commit" name="push_mirror_sync_on_commit" type="checkbox" {{if .push_mirror_sync_on_commit}}checked{{end}}>
 												<label for="push_mirror_sync_on_commit">{{.locale.Tr "repo.mirror_sync_on_commit"}}</label>
 											</div>
 										</div>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -221,7 +221,7 @@
 										</details>
 										<div class="field">
 											<div class="ui checkbox">
-												<input id="push_mirror_sync_on_commit" name="push_mirror_sync_on_commit" type="checkbox" value="{{.push_mirror_sync_on_commit}}">
+												<input id="push_mirror_sync_on_commit" name="push_mirror_sync_on_commit" type="checkbox">
 												<label for="push_mirror_sync_on_commit">{{.locale.Tr "repo.mirror_sync_on_commit"}}</label>
 											</div>
 										</div>


### PR DESCRIPTION
<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
Fixes #21308.

With the original frontend template `templates/repo/settings/options.tmpl`, the field `push_mirror_sync_on_commit` is always empty even when checkbox is checked. Removing `value` from the input tag seems to solve the issue, and will set `push_mirror_sync_on_commit: on` when the checkbox is checked.

(I'm not familiar with the frontend logics Gitea is using, so I don't really understand the cause of it)
