### PR TITLE
Make app.ini read-only message more prominent

### DIFF
--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -97,12 +97,12 @@ chown root:git /etc/gitea
 chmod 770 /etc/gitea
 ```
 
-**NOTE:** `/etc/gitea` is temporarily set with write permissions for user `git` so that the web installer can write the configuration file. After the installation is finished, it is recommended to set permissions to read-only using:
-
-```sh
-chmod 750 /etc/gitea
-chmod 640 /etc/gitea/app.ini
-```
+> **NOTE:** `/etc/gitea` is temporarily set with write permissions for user `git` so that the web installer can write the configuration file. After the installation is finished, it is recommended to set permissions to read-only using:
+>
+> ```sh
+> chmod 750 /etc/gitea
+> chmod 640 /etc/gitea/app.ini
+> ```
 
 If you don't want the web installer to be able to write to the config file, it is possible to make the config file read-only for the Gitea user (owner/group `root:git`, mode `0640`) however you will need to edit your config file manually to:
 


### PR DESCRIPTION
Something that has come up a few times when I've watched/interacted with people following our installation tutorial, is that by the third or fourth shell command snippet they start to copy/paste while skimming.

Unfortunately this sometimes leads to making a read-only config and the web installer getting mad at them.

This just block-quotes the "FYI do this after installation" blurb, which hopefully makes it stick out a bit more.

![install-docs](https://user-images.githubusercontent.com/42128690/193437671-f2ea1f8d-f6be-4e97-ab81-6154a6055493.png)
