### PR TITLE
Fix linked account translation

### DIFF
--- a/templates/user/settings/security/accountlinks.tmpl
+++ b/templates/user/settings/security/accountlinks.tmpl
@@ -33,7 +33,7 @@
 					</div>
 					<div class="content">
 						<strong>{{$provider}}</strong>
-						{{if $loginSource.IsActive}}<span class="text red">{{$.locale.Tr "settings.active"}}</span>{{end}}
+						{{if $loginSource.IsActive}}<span class="text red">{{$.locale.Tr "repo.settings.active"}}</span>{{end}}
 					</div>
 				</div>
 			{{end}}


### PR DESCRIPTION
Fixes #21318 

Going back, I couldn't find a previous value that matches this, my guess is it was simply overlooked. Our previous `i18n` code would have set this to the final key, which is `active`

Lo and behold, 
![image](https://user-images.githubusercontent.com/42128690/193733143-57c9788c-be78-4666-b88e-c5e39fb1a605.png)

The above is from codeberg, but I can confirm on my own instance as well.

-----

Now, I've gone and used `repo.settings.active`, which is arguably for webhooks. 
https://github.com/go-gitea/gitea/blob/274523baf43ce588e18c2f557d1b82afefbe8dd4/options/locale/locale_en-US.ini#L1998-L1999
Given it's a single word, I think it's fine to re-use, but I'm open to making a new key if that's preferred.