### PR TITLE
Disabled registration notification e-mail in ldap + reverse proxy mode

### DIFF
--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -14,7 +14,6 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web/middleware"
-	"code.gitea.io/gitea/services/mailer"
 
 	gouuid "github.com/google/uuid"
 )

--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -1,5 +1,5 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
-// Copyright 2019 The Gitea Authors. All rights reserved.
+// Copyright 2022 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -119,8 +119,6 @@ func (r *ReverseProxy) newUser(req *http.Request) *user_model.User {
 		log.Error("CreateUser: %v", err)
 		return nil
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	return user
 }

--- a/services/auth/source/ldap/source_authenticate.go
+++ b/services/auth/source/ldap/source_authenticate.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Gitea Authors. All rights reserved.
+// Copyright 2022 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -14,7 +14,6 @@ import (
 	"code.gitea.io/gitea/models/organization"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/util"
-	"code.gitea.io/gitea/services/mailer"
 	user_service "code.gitea.io/gitea/services/user"
 )
 
@@ -104,8 +103,6 @@ func (source *Source) Authenticate(user *user_model.User, userName, password str
 	if err != nil {
 		return user, err
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	if isAttributeSSHPublicKeySet && asymkey_model.AddPublicKeysBySource(user, source.authSource, sr.SSHPublicKey) {
 		err = asymkey_model.RewriteAllPublicKeys()


### PR DESCRIPTION
Disabled registration notification e-mail in ldap + reverse proxy mode to avoid
spamming user with invalid instructions (such accounts are created by admin
in LDAP not during self registration and no gitea passwords are used for auth).

Related: https://github.com/go-gitea/gitea/pull/18601
Author-Change-Id: IB#1122610