### PR TITLE
SessionUser protection against nil pointer dereference

### DIFF
--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Gitea Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Gitea Authors. All rights reserved.
+// Copyright 2022 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -39,6 +39,10 @@ func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataSto
 
 // SessionUser returns the user object corresponding to the "uid" session variable.
 func SessionUser(sess SessionStore) *user_model.User {
+	if sess == nil {
+		return nil
+	}
+
 	// Get user ID
 	uid := sess.Get("uid")
 	if uid == nil {


### PR DESCRIPTION
`SessionUser` should be protected against passing `sess` = `nil` to avoid

```
PANIC: runtime error: invalid memory address or nil pointer dereference
```

in

https://github.com/go-gitea/gitea/pull/18452/files#diff-a215b82aadeb8b4c4632fcf31215dd421f804eb1c0137ec6721b980136e4442aR69

after upgrade from gitea v1.16 to v1.17.

Related: https://github.com/go-gitea/gitea/pull/18452
Author-Change-Id: IB#1126459

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
