### PR TITLE
Tag list should include draft releases with existing tags (#21263)

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -170,6 +170,7 @@ type FindReleasesOptions struct {
 	IsPreRelease  util.OptionalBool
 	IsDraft       util.OptionalBool
 	TagNames      []string
+	HasSha1       util.OptionalBool // useful to find draft releases which are created with existing tags
 }
 
 func (opts *FindReleasesOptions) toConds(repoID int64) builder.Cond {
@@ -190,6 +191,13 @@ func (opts *FindReleasesOptions) toConds(repoID int64) builder.Cond {
 	}
 	if !opts.IsDraft.IsNone() {
 		cond = cond.And(builder.Eq{"is_draft": opts.IsDraft.IsTrue()})
+	}
+	if !opts.HasSha1.IsNone() {
+		if opts.HasSha1.IsTrue() {
+			cond = cond.And(builder.Neq{"sha1": ""})
+		} else {
+			cond = cond.And(builder.Eq{"sha1": ""})
+		}
 	}
 	return cond
 }

--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -524,7 +524,9 @@ func RepoAssignment(ctx *Context) (cancel context.CancelFunc) {
 	}
 
 	ctx.Data["NumTags"], err = models.GetReleaseCountByRepoID(ctx.Repo.Repository.ID, models.FindReleasesOptions{
-		IncludeTags: true,
+		IncludeDrafts: true,
+		IncludeTags:   true,
+		HasSha1:       util.OptionalBoolTrue, // only draft releases which are created with existing tags
 	})
 	if err != nil {
 		ctx.ServerError("GetReleaseCountByRepoID", err)

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -116,9 +116,17 @@ func releasesOrTags(ctx *context.Context, isTagList bool) {
 	ctx.Data["CanCreateRelease"] = writeAccess && !ctx.Repo.Repository.IsArchived
 
 	opts := models.FindReleasesOptions{
-		ListOptions:   listOptions,
-		IncludeDrafts: writeAccess && !isTagList,
-		IncludeTags:   isTagList,
+		ListOptions: listOptions,
+	}
+	if isTagList {
+		// for the tags list page, show all releases with real tags (having real commit-id),
+		// the drafts should also be included because a real tag might be used as a draft.
+		opts.IncludeDrafts = true
+		opts.IncludeTags = true
+		opts.HasSha1 = util.OptionalBoolTrue
+	} else {
+		// only show draft releases for users who can write, read-only users shouldn't see draft releases.
+		opts.IncludeDrafts = writeAccess
 	}
 
 	releases, err := models.GetReleasesByRepoID(ctx.Repo.Repository.ID, opts)

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -77,14 +77,12 @@
 								<span class="ui green label">{{$.i18n.Tr "repo.release.stable"}}</span>
 							{{end}}
 							<span class="tag text blue">
-								<a class="df ac je" href="{{if .IsDraft}}#{{else}}{{$.RepoLink}}/src/tag/{{.TagName | PathEscapeSegments}}{{end}}" rel="nofollow">{{svg "octicon-tag" 16 "mr-2"}}{{.TagName}}</a>
+								<a class="df ac je" href="{{if not .Sha1}}#{{else}}{{$.RepoLink}}/src/tag/{{.TagName | PathEscapeSegments}}{{end}}" rel="nofollow">{{svg "octicon-tag" 16 "mr-2"}}{{.TagName}}</a>
 							</span>
-							{{if not .IsDraft}}
+							{{if .Sha1}}
 								<span class="commit">
 									<a class="mono" href="{{$.RepoLink}}/src/commit/{{.Sha1}}" rel="nofollow">{{svg "octicon-git-commit" 16 "mr-2"}}{{ShortSha .Sha1}}</a>
 								</span>
-							{{end}}
-							{{if .Sha1 }}
 								{{template "repo/branch_dropdown" dict "root" $ "release" .}}
 							{{end}}
 						{{end}}


### PR DESCRIPTION
Backport #21263.

Before, a tag for a draft release disappeared in the tag list, fix #21262.


