### PR TITLE
Add GET and DELETE endpoints for Docker blob uploads

### DIFF
--- a/routers/api/packages/container/container.go
+++ b/routers/api/packages/container/container.go
@@ -248,6 +248,27 @@ func InitiateUploadBlob(ctx *context.Context) {
 	})
 }
 
+// https://docs.docker.com/registry/spec/api/#get-blob-upload
+func GetUploadBlob(ctx *context.Context) {
+	uuid := ctx.Params("uuid")
+
+	upload, err := packages_model.GetBlobUploadByID(ctx, uuid)
+	if err != nil {
+		if err == packages_model.ErrPackageBlobUploadNotExist {
+			apiErrorDefined(ctx, errBlobUploadUnknown)
+		} else {
+			apiError(ctx, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	setResponseHeaders(ctx.Resp, &containerHeaders{
+		Range:      fmt.Sprintf("0-%d", upload.BytesReceived),
+		UploadUUID: upload.ID,
+		Status:     http.StatusNoContent,
+	})
+}
+
 // https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-a-blob-in-chunks
 func UploadBlob(ctx *context.Context) {
 	image := ctx.Params("image")
@@ -351,6 +372,30 @@ func EndUploadBlob(ctx *context.Context) {
 		Location:      fmt.Sprintf("/v2/%s/%s/blobs/%s", ctx.Package.Owner.LowerName, image, digest),
 		ContentDigest: digest,
 		Status:        http.StatusCreated,
+	})
+}
+
+// https://docs.docker.com/registry/spec/api/#delete-blob-upload
+func CancelUploadBlob(ctx *context.Context) {
+	uuid := ctx.Params("uuid")
+
+	_, err := packages_model.GetBlobUploadByID(ctx, uuid)
+	if err != nil {
+		if err == packages_model.ErrPackageBlobUploadNotExist {
+			apiErrorDefined(ctx, errBlobUploadUnknown)
+		} else {
+			apiError(ctx, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if err := container_service.RemoveBlobUploadByID(ctx, uuid); err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	setResponseHeaders(ctx.Resp, &containerHeaders{
+		Status: http.StatusNoContent,
 	})
 }
 

--- a/tests/integration/api_packages_container_test.go
+++ b/tests/integration/api_packages_container_test.go
@@ -227,11 +227,11 @@ func TestPackageContainer(t *testing.T) {
 
 				t.Run("Cancel", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
-	
+
 					req := NewRequest(t, "POST", fmt.Sprintf("%s/blobs/uploads", url))
 					addTokenAuthHeader(req, userToken)
 					resp := MakeRequest(t, req, http.StatusAccepted)
-	
+
 					uuid := resp.Header().Get("Docker-Upload-Uuid")
 					assert.NotEmpty(t, uuid)
 

--- a/tests/integration/api_packages_container_test.go
+++ b/tests/integration/api_packages_container_test.go
@@ -205,11 +205,18 @@ func TestPackageContainer(t *testing.T) {
 				assert.Equal(t, uuid, resp.Header().Get("Docker-Upload-Uuid"))
 				assert.Equal(t, contentRange, resp.Header().Get("Range"))
 
+				uploadURL = resp.Header().Get("Location")
+
+				req = NewRequest(t, "GET", setting.AppURL+uploadURL[1:])
+				addTokenAuthHeader(req, userToken)
+				resp = MakeRequest(t, req, http.StatusNoContent)
+
+				assert.Equal(t, uuid, resp.Header().Get("Docker-Upload-Uuid"))
+				assert.Equal(t, fmt.Sprintf("0-%d", len(blobContent)), resp.Header().Get("Range"))
+
 				pbu, err = packages_model.GetBlobUploadByID(db.DefaultContext, uuid)
 				assert.NoError(t, err)
 				assert.EqualValues(t, len(blobContent), pbu.BytesReceived)
-
-				uploadURL = resp.Header().Get("Location")
 
 				req = NewRequest(t, "PUT", fmt.Sprintf("%s?digest=%s", setting.AppURL+uploadURL[1:], blobDigest))
 				addTokenAuthHeader(req, userToken)
@@ -217,6 +224,35 @@ func TestPackageContainer(t *testing.T) {
 
 				assert.Equal(t, fmt.Sprintf("/v2/%s/%s/blobs/%s", user.Name, image, blobDigest), resp.Header().Get("Location"))
 				assert.Equal(t, blobDigest, resp.Header().Get("Docker-Content-Digest"))
+
+				t.Run("Cancel", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+	
+					req := NewRequest(t, "POST", fmt.Sprintf("%s/blobs/uploads", url))
+					addTokenAuthHeader(req, userToken)
+					resp := MakeRequest(t, req, http.StatusAccepted)
+	
+					uuid := resp.Header().Get("Docker-Upload-Uuid")
+					assert.NotEmpty(t, uuid)
+
+					uploadURL := resp.Header().Get("Location")
+					assert.NotEmpty(t, uploadURL)
+
+					req = NewRequest(t, "GET", setting.AppURL+uploadURL[1:])
+					addTokenAuthHeader(req, userToken)
+					resp = MakeRequest(t, req, http.StatusNoContent)
+
+					assert.Equal(t, uuid, resp.Header().Get("Docker-Upload-Uuid"))
+					assert.Equal(t, "0-0", resp.Header().Get("Range"))
+
+					req = NewRequest(t, "DELETE", setting.AppURL+uploadURL[1:])
+					addTokenAuthHeader(req, userToken)
+					MakeRequest(t, req, http.StatusNoContent)
+
+					req = NewRequest(t, "GET", setting.AppURL+uploadURL[1:])
+					addTokenAuthHeader(req, userToken)
+					MakeRequest(t, req, http.StatusNotFound)
+				})
 			})
 
 			for _, tag := range tags {


### PR DESCRIPTION
This PR adds support for
https://docs.docker.com/registry/spec/api/#get-blob-upload
https://docs.docker.com/registry/spec/api/#delete-blob-upload

Both are not required by the OCI spec but some clients call these endpoints.