### PR TITLE
npm package registry support for `bin`

### DIFF
--- a/modules/packages/npm/creator.go
+++ b/modules/packages/npm/creator.go
@@ -66,7 +66,8 @@ type PackageMetadata struct {
 	License        string                             `json:"license,omitempty"`
 }
 
-// PackageMetadataVersion https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#version
+// PackageMetadataVersion documentation: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#version
+// PackageMetadataVersion response: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object
 type PackageMetadataVersion struct {
 	ID                   string              `json:"_id"`
 	Name                 string              `json:"name"`
@@ -80,6 +81,7 @@ type PackageMetadataVersion struct {
 	Dependencies         map[string]string   `json:"dependencies,omitempty"`
 	DevDependencies      map[string]string   `json:"devDependencies,omitempty"`
 	PeerDependencies     map[string]string   `json:"peerDependencies,omitempty"`
+	Bin                  map[string]string   `json:"bin,omitempty"`
 	OptionalDependencies map[string]string   `json:"optionalDependencies,omitempty"`
 	Readme               string              `json:"readme,omitempty"`
 	Dist                 PackageDistribution `json:"dist"`
@@ -220,6 +222,7 @@ func ParsePackage(r io.Reader) (*Package, error) {
 				DevelopmentDependencies: meta.DevDependencies,
 				PeerDependencies:        meta.PeerDependencies,
 				OptionalDependencies:    meta.OptionalDependencies,
+				Bin:                     meta.Bin,
 				Readme:                  meta.Readme,
 			},
 		}

--- a/modules/packages/npm/creator_test.go
+++ b/modules/packages/npm/creator_test.go
@@ -23,6 +23,7 @@ func TestParsePackage(t *testing.T) {
 	packageVersion := "1.0.1-pre"
 	packageTag := "latest"
 	packageAuthor := "KN4CK3R"
+	packageBin := "gitea"
 	packageDescription := "Test Description"
 	data := "H4sIAAAAAAAA/ytITM5OTE/VL4DQelnF+XkMVAYGBgZmJiYK2MRBwNDcSIHB2NTMwNDQzMwAqA7IMDUxA9LUdgg2UFpcklgEdAql5kD8ogCnhwio5lJQUMpLzE1VslJQcihOzi9I1S9JLS7RhSYIJR2QgrLUouLM/DyQGkM9Az1D3YIiqExKanFyUWZBCVQ2BKhVwQVJDKwosbQkI78IJO/tZ+LsbRykxFXLNdA+HwWjYBSMgpENACgAbtAACAAA"
 	integrity := "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg=="
@@ -236,6 +237,9 @@ func TestParsePackage(t *testing.T) {
 						Dependencies: map[string]string{
 							"package": "1.2.0",
 						},
+						Bin: map[string]string{
+							"bin": packageBin,
+						},
 						Dist: PackageDistribution{
 							Integrity: integrity,
 						},
@@ -264,6 +268,7 @@ func TestParsePackage(t *testing.T) {
 		assert.Equal(t, packageDescription, p.Metadata.Description)
 		assert.Equal(t, packageDescription, p.Metadata.Readme)
 		assert.Equal(t, packageAuthor, p.Metadata.Author)
+		assert.Equal(t, packageBin, p.Metadata.Bin["bin"])
 		assert.Equal(t, "MIT", p.Metadata.License)
 		assert.Equal(t, "https://gitea.io/", p.Metadata.ProjectURL)
 		assert.Contains(t, p.Metadata.Dependencies, "package")

--- a/modules/packages/npm/metadata.go
+++ b/modules/packages/npm/metadata.go
@@ -20,5 +20,6 @@ type Metadata struct {
 	DevelopmentDependencies map[string]string `json:"development_dependencies,omitempty"`
 	PeerDependencies        map[string]string `json:"peer_dependencies,omitempty"`
 	OptionalDependencies    map[string]string `json:"optional_dependencies,omitempty"`
+	Bin                     map[string]string `json:"bin,omitempty"`
 	Readme                  string            `json:"readme,omitempty"`
 }

--- a/routers/api/packages/npm/api.go
+++ b/routers/api/packages/npm/api.go
@@ -67,6 +67,7 @@ func createPackageMetadataVersion(registryURL string, pd *packages_model.Package
 		PeerDependencies:     metadata.PeerDependencies,
 		OptionalDependencies: metadata.OptionalDependencies,
 		Readme:               metadata.Readme,
+		Bin:                  metadata.Bin,
 		Dist: npm_module.PackageDistribution{
 			Shasum:    pd.Files[0].Blob.HashSHA1,
 			Integrity: "sha512-" + base64.StdEncoding.EncodeToString(hashBytes),

--- a/tests/integration/api_packages_npm_test.go
+++ b/tests/integration/api_packages_npm_test.go
@@ -36,7 +36,7 @@ func TestPackageNpm(t *testing.T) {
 	packageAuthor := "KN4CK3R"
 	packageDescription := "Test Description"
 	packageBinName := "cli"
-	packageBinPath := "cli.sh"
+	packageBinPath := "./cli.sh"
 
 	data := "H4sIAAAAAAAA/ytITM5OTE/VL4DQelnF+XkMVAYGBgZmJiYK2MRBwNDcSIHB2NTMwNDQzMwAqA7IMDUxA9LUdgg2UFpcklgEdAql5kD8ogCnhwio5lJQUMpLzE1VslJQcihOzi9I1S9JLS7RhSYIJR2QgrLUouLM/DyQGkM9Az1D3YIiqExKanFyUWZBCVQ2BKhVwQVJDKwosbQkI78IJO/tZ+LsbRykxFXLNdA+HwWjYBSMgpENACgAbtAACAAA"
 

--- a/tests/integration/api_packages_npm_test.go
+++ b/tests/integration/api_packages_npm_test.go
@@ -35,6 +35,8 @@ func TestPackageNpm(t *testing.T) {
 	packageTag2 := "release"
 	packageAuthor := "KN4CK3R"
 	packageDescription := "Test Description"
+	packageBinName := "cli"
+	packageBinPath := "cli.sh"
 
 	data := "H4sIAAAAAAAA/ytITM5OTE/VL4DQelnF+XkMVAYGBgZmJiYK2MRBwNDcSIHB2NTMwNDQzMwAqA7IMDUxA9LUdgg2UFpcklgEdAql5kD8ogCnhwio5lJQUMpLzE1VslJQcihOzi9I1S9JLS7RhSYIJR2QgrLUouLM/DyQGkM9Az1D3YIiqExKanFyUWZBCVQ2BKhVwQVJDKwosbQkI78IJO/tZ+LsbRykxFXLNdA+HwWjYBSMgpENACgAbtAACAAA"
 
@@ -54,6 +56,9 @@ func TestPackageNpm(t *testing.T) {
 				"author": {
 				  "name": "` + packageAuthor + `"
 				},
+        "bin": {
+          "` + packageBinName + `": "` + packageBinPath + `"
+        },
 				"dist": {
 				  "integrity": "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg==",
 				  "shasum": "aaa7eaf852a948b0aa05afeda35b1badca155d90"
@@ -154,6 +159,7 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, packageName, pmv.Name)
 		assert.Equal(t, packageDescription, pmv.Description)
 		assert.Equal(t, packageAuthor, pmv.Author.Name)
+		assert.Equal(t, packageBinPath, pmv.Bin[packageBinName])
 		assert.Equal(t, "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg==", pmv.Dist.Integrity)
 		assert.Equal(t, "aaa7eaf852a948b0aa05afeda35b1badca155d90", pmv.Dist.Shasum)
 		assert.Equal(t, fmt.Sprintf("%s%s/-/%s/%s", setting.AppURL, root[1:], packageVersion, filename), pmv.Dist.Tarball)


### PR DESCRIPTION
npm package.json supports binary packaging:
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bin

the npm registry documents that the binary references will be attached to the abbreviated version object:
https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object

unfortunately their api documentation leaves this out: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-objectdoc

which is likely to be the reason this was left out in gitea's initial implementation

this response is critical for npm to install the binary in the `.bin` folder so as to be included on the users default bin path, resulting in immediate access to any binaries provided by the package

i have tested upload and installing through npm and can confirm the npm registry now responds with `bin` in the version metadata and results in the binary being available after install.

this fixes #21303 