### PR TITLE
Format date range in in activity page according to locale

### DIFF
--- a/options/locale/TRANSLATORS
+++ b/options/locale/TRANSLATORS
@@ -75,5 +75,6 @@ Viktor Sperl <viktike32 AT gmail DOT com>
 Vladimir Jigulin mogaika AT yandex DOT ru
 Vladimir Vissoultchev <wqweto AT gmail DOT com>
 Yaşar Çiv <yasarciv67 AT gmail DOT com>
+Yarden Shoham <hrsi88 AT gmail DOT com>
 YJSoft <yjsoft AT yjsoft DOT pe DOT kr>
 Łukasz Jan Niemier <lukasz AT niemier DOT pl>

--- a/options/locale/locale_bg-BG.ini
+++ b/options/locale/locale_bg-BG.ini
@@ -70,7 +70,19 @@ loading=Зареждане…
 
 error404=Страницата, която се опитвате да достъпите, <strong>не съществува</strong> или <strong>не сте оторизирани</strong> да я достъпите.
 
-
+[dates]
+months.january=Януари
+months.february=Февруари
+months.march=Март
+months.april=Април
+months.may=Май
+months.june=Юни
+months.july=Юли
+months.august=Август
+months.september=Септември
+months.october=Октомври
+months.november=Ноември
+months.december=Декември
 
 [error]
 

--- a/options/locale/locale_cs-CZ.ini
+++ b/options/locale/locale_cs-CZ.ini
@@ -106,6 +106,20 @@ never=Nikdy
 
 rss_feed=RSS kanál
 
+[dates]
+months.january=Leden
+months.february=Únor
+months.march=Březen
+months.april=Duben
+months.may=Květen
+months.june=Červen
+months.july=Červenec
+months.august=Srpen
+months.september=Září
+months.october=Říjen
+months.november=Listopad
+months.december=Prosinec
+
 [error]
 occurred=Došlo k chybě
 report_message=Pokud jste si jisti, že se jedná o chybu Gitea, prosím vyhledejte problém na <a href="https://github.com/go-gitea/gitea/issues">GitHub</a> a v případě potřeby otevřete nový problém.

--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -106,6 +106,20 @@ never=Niemals
 
 rss_feed=RSS Feed
 
+[dates]
+months.january=Januar
+months.february=Februar
+months.march=März
+months.april=April
+months.may=Mai
+months.june=Juni
+months.july=Juli
+months.august=August
+months.september=September
+months.october=Oktober
+months.november=November
+months.december=Dezember
+
 [error]
 occurred=Ein Fehler ist aufgetreten
 report_message=Wenn du dir sicher bist, dass dies ein Fehler von Gitea ist, suche bitte auf <a href="https://github.com/go-gitea/gitea/issues">GitHub</a> nach diesem Fehler und erstelle gegebenenfalls ein neues Issue.

--- a/options/locale/locale_el-GR.ini
+++ b/options/locale/locale_el-GR.ini
@@ -106,6 +106,20 @@ never=Ποτέ
 
 rss_feed=Ροή RSS
 
+[dates]
+months.january=Ιανουάριος
+months.february=Φεβρουάριος
+months.march=Μάρτιος
+months.april=Απρίλιος
+months.may=Μάιος
+months.june=Ιούνιος
+months.july=Ιούλιος
+months.august=Αύγουστος
+months.september=Σεπτέμβριος
+months.october=Οκτώβριος
+months.november=Νοέμβριος
+months.december=Δεκέμβριος
+
 [error]
 occurred=Παρουσιάστηκε ένα σφάλμα
 report_message=Αν είστε σίγουροι ότι πρόκειται για ένα πρόβλημα στο Gitea, παρακαλώ αναζητήστε στα ζητήματα στο <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> ή ανοίξτε ένα νέο ζήτημα εάν είναι απαραίτητο.

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -106,6 +106,20 @@ never = Never
 
 rss_feed = RSS Feed
 
+[dates]
+months.january = January
+months.february = February
+months.march = March
+months.april = April
+months.may = May
+months.june = June
+months.july = July
+months.august = August
+months.september = September
+months.october = October
+months.november = November
+months.december = December
+
 [error]
 occurred = An error occurred
 report_message = If you are sure this is a Gitea bug, please search for issues on <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> or open a new issue if necessary.

--- a/options/locale/locale_es-ES.ini
+++ b/options/locale/locale_es-ES.ini
@@ -106,6 +106,20 @@ never=Nunca
 
 rss_feed=Fuentes RSS
 
+[dates]
+months.january=Enero
+months.february=Febrero
+months.march=Marzo
+months.april=Abril
+months.may=Mayo
+months.june=Junio
+months.july=Julio
+months.august=Agosto
+months.september=Septiembre
+months.october=Octubre
+months.november=Noviembre
+months.december=Diciembre
+
 [error]
 occurred=Ha ocurrido un error
 report_message=Si estás seguro de que este es un error de Gitea, por favor busca un problema en <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> y abre un nuevo problema si es necesario.

--- a/options/locale/locale_fa-IR.ini
+++ b/options/locale/locale_fa-IR.ini
@@ -90,6 +90,19 @@ error404=صفحه موردنظر شما یا <strong>وجود ندارد</strong
 
 never=هرگز
 
+[dates]
+months.january=ژانویه
+months.february=فوریه
+months.march=مارس
+months.april=آوریل
+months.may=مه
+months.june=ژوئن
+months.july=ژوئیه
+months.august=اوت
+months.september=سپتامبر
+months.october=اکتبر
+months.november=نوامبر
+months.december=دسامبر
 
 [error]
 missing_csrf=درخواست بد: بلیط CSRF ندارد

--- a/options/locale/locale_fi-FI.ini
+++ b/options/locale/locale_fi-FI.ini
@@ -104,6 +104,20 @@ never=Ei koskaan
 
 rss_feed=RSS-syöte
 
+[dates]
+months.january=Tammikuu
+months.february=Helmikuu
+months.march=Maaliskuu
+months.april=Huhtikuu
+months.may=Toukokuu
+months.june=Kesäkuu
+months.july=Heinäkuu
+months.august=Elokuu
+months.september=Syyskuu
+months.october=Lokakuu
+months.november=Marraskuu
+months.december=Joulukuu
+
 [error]
 occurred=Virhe tapahtui
 report_message=Jos olet varma, että tämä on ongelma Giteassa, etsi ongelmaa <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHubista</a> tai avaa uusi ongelma tarvittaessa.

--- a/options/locale/locale_fr-FR.ini
+++ b/options/locale/locale_fr-FR.ini
@@ -106,6 +106,20 @@ never=Jamais
 
 rss_feed=Flux RSS
 
+[dates]
+months.january=Janvier
+months.february=Février
+months.march=Mars
+months.april=Avril
+months.may=Mai
+months.june=Juin
+months.july=Juillet
+months.august=Août
+months.september=Septembre
+months.october=Octobre
+months.november=Novembre
+months.december=Décembre
+
 [error]
 occurred=Une erreur s’est produite
 report_message=Si vous êtes sûr qu'il s'agit d'un bug de Gitea, cherchez s’il existe des tickets sur <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> ou ouvrez-en un nouveau si nécessaire.

--- a/options/locale/locale_hu-HU.ini
+++ b/options/locale/locale_hu-HU.ini
@@ -78,7 +78,19 @@ step2=2. lépés:
 
 error404=Az elérni kívánt oldal vagy <strong>nem létezik</strong>, vagy <strong>nincs jogosultsága</strong> a megtekintéséhez.
 
-
+[dates]
+months.january=Január
+months.february=Február
+months.march=Március
+months.april=Április
+months.may=Május
+months.june=Június
+months.july=Július
+months.august=Augusztus
+months.september=Szeptember
+months.october=Október
+months.november=November
+months.december=December
 
 [error]
 

--- a/options/locale/locale_it-IT.ini
+++ b/options/locale/locale_it-IT.ini
@@ -106,6 +106,20 @@ never=Mai
 
 rss_feed=Feed RSS
 
+[dates]
+months.january=Gennaio
+months.february=Febbraio
+months.march=Marzo
+months.april=Aprile
+months.may=Maggio
+months.june=Giugno
+months.july=Luglio
+months.august=Agosto
+months.september=Settembre
+months.october=Ottobre
+months.november=Novembre
+months.december=Dicembre
+
 [error]
 occurred=Si è verificato un errore
 report_message=Se sei sicuro che questo sia un bug Gitea, cerca i problemi su <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> o apri un nuovo problema se necessario.

--- a/options/locale/locale_nl-NL.ini
+++ b/options/locale/locale_nl-NL.ini
@@ -106,6 +106,20 @@ never=Nooit
 
 rss_feed=RSS Feed
 
+[dates]
+months.january=Januari
+months.february=Februari
+months.march=Maart
+months.april=April
+months.may=Mei
+months.june=Juni
+months.july=Juli
+months.august=Augustus
+months.september=September
+months.october=Oktober
+months.november=November
+months.december=December
+
 [error]
 occurred=Er is een fout opgetreden
 report_message=Als je zeker weet dat dit een Gitea bug is, zoek dan naar problemen op <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> of open een nieuw probleem indien nodig.

--- a/options/locale/locale_pt-BR.ini
+++ b/options/locale/locale_pt-BR.ini
@@ -106,6 +106,19 @@ never=Nunca
 
 rss_feed=Feed RSS
 
+[dates]
+months.january=Janeiro
+months.february=Fevereiro
+months.march=Março
+months.april=Abril
+months.may=Maio
+months.june=Junho
+months.july=Julho
+months.august=Agosto
+months.september=Setembro
+months.october=Outubro
+months.november=Novembro
+
 [error]
 occurred=Ocorreu um erro
 report_message=Se você tem certeza de que é um bug do Gitea, procure por issues no <a href="https://github.com/go-gitea/gitea/issues" target="_blank">GitHub</a> ou abra uma nova issue, se necessário.

--- a/options/locale/locale_pt-PT.ini
+++ b/options/locale/locale_pt-PT.ini
@@ -106,6 +106,19 @@ never=Nunca
 
 rss_feed=Fonte RSS
 
+[dates]
+months.january=Janeiro
+months.february=Fevereiro
+months.march=Março
+months.april=Abril
+months.may=Maio
+months.june=Junho
+months.july=Julho
+months.august=Agosto
+months.september=Setembro
+months.october=Outubro
+months.november=Novembro
+
 [error]
 occurred=Ocorreu um erro
 report_message=Se tiver certeza de que se trata de um erro do Gitea, procure, por favor, questões relacionadas no <a href="https://github.com/go-gitea/gitea/issues">GitHub</a> ou abra uma nova questão, se necessário.

--- a/options/locale/locale_ru-RU.ini
+++ b/options/locale/locale_ru-RU.ini
@@ -106,6 +106,20 @@ never=Никогда
 
 rss_feed=RSS-лента
 
+[dates]
+months.january=Январь
+months.february=Февраль
+months.march=Март
+months.april=Апрель
+months.may=Май
+months.june=Июнь
+months.july=Июль
+months.august=Август
+months.september=Сентябрь
+months.october=Октябрь
+months.november=Ноябрь
+months.december=Декабрь
+
 [error]
 occurred=Произошла ошибка
 missing_csrf=Некорректный запрос: CSRF токен отсутствует

--- a/options/locale/locale_uk-UA.ini
+++ b/options/locale/locale_uk-UA.ini
@@ -91,6 +91,19 @@ error404=Сторінка, до якої ви намагаєтеся зверн�
 
 never=Ніколи
 
+[dates]
+months.january=Січень
+months.february=Лютий
+months.march=Березень
+months.april=Квітень
+months.may=Травень
+months.june=Червень
+months.july=Липень
+months.august=Серпень
+months.september=Вересень
+months.october=Жовтень
+months.november=Листопад
+months.december=Грудень
 
 [error]
 occurred=Сталася помилка

--- a/routers/web/repo/activity.go
+++ b/routers/web/repo/activity.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Gitea Authors. All rights reserved.
+// Copyright 2022 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package repo
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	activities_model "code.gitea.io/gitea/models/activities"
@@ -47,8 +48,8 @@ func Activity(ctx *context.Context) {
 		ctx.Data["Period"] = "weekly"
 		timeFrom = timeUntil.Add(-time.Hour * 168)
 	}
-	ctx.Data["DateFrom"] = timeFrom.Format("January 2, 2006")
-	ctx.Data["DateUntil"] = timeUntil.Format("January 2, 2006")
+	ctx.Data["DateFrom"] = formatDate(ctx, &timeFrom)
+	ctx.Data["DateUntil"] = formatDate(ctx, &timeUntil)
 	ctx.Data["PeriodText"] = ctx.Tr("repo.activity.period." + ctx.Data["Period"].(string))
 
 	var err error
@@ -101,4 +102,21 @@ func ActivityAuthors(ctx *context.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, authors)
+}
+
+func formatDate(ctx *context.Context, t *time.Time) string {
+	r := strings.NewReplacer(
+		"January", ctx.Tr("dates.months.january"),
+		"February", ctx.Tr("dates.months.february"),
+		"March", ctx.Tr("dates.months.march"),
+		"April", ctx.Tr("dates.months.april"),
+		"May", ctx.Tr("dates.months.may"),
+		"June", ctx.Tr("dates.months.june"),
+		"July", ctx.Tr("dates.months.july"),
+		"August", ctx.Tr("dates.months.august"),
+		"September", ctx.Tr("dates.months.september"),
+		"October", ctx.Tr("dates.months.october"),
+		"November", ctx.Tr("dates.months.november"),
+		"December", ctx.Tr("dates.months.december"))
+	return r.Replace(t.Format("January 2, 2006"))
 }


### PR DESCRIPTION
Fixes #21380

Before this PR, the date range on the activity page was hardcoded in English. This PR adds functionality so that the date range would respect the chosen locale.

For example:
![image](https://user-images.githubusercontent.com/20454870/194743615-724e6172-6f32-4daf-a784-148b40b52186.png)
