### PR TITLE
Use ISO date format instead of hard-coded English date format for date range in repo activity page

### DIFF
--- a/routers/web/repo/activity.go
+++ b/routers/web/repo/activity.go
@@ -47,8 +47,8 @@ func Activity(ctx *context.Context) {
 		ctx.Data["Period"] = "weekly"
 		timeFrom = timeUntil.Add(-time.Hour * 168)
 	}
-	ctx.Data["DateFrom"] = timeFrom.Format("January 2, 2006")
-	ctx.Data["DateUntil"] = timeUntil.Format("January 2, 2006")
+	ctx.Data["DateFrom"] = timeFrom.Format("2006-01-02")
+	ctx.Data["DateUntil"] = timeUntil.Format("2006-01-02")
 	ctx.Data["PeriodText"] = ctx.Tr("repo.activity.period." + ctx.Data["Period"].(string))
 
 	var err error


### PR DESCRIPTION
January 2, 2006 -> 2006-01-02

See:
* #21380 
* #21387

![image](https://user-images.githubusercontent.com/20454870/195061592-fbb51a7b-a717-4639-8493-f452bbc2204c.png)

