### PR TITLE
Stop logging CheckPath returns error: context canceled (#21064)

### DIFF
--- a/modules/git/repo_attribute.go
+++ b/modules/git/repo_attribute.go
@@ -191,8 +191,8 @@ func (c *CheckAttributeReader) Run() error {
 // CheckPath check attr for given path
 func (c *CheckAttributeReader) CheckPath(path string) (rs map[string]string, err error) {
 	defer func() {
-		if err != nil {
-			log.Error("CheckPath returns error: %v", err)
+		if err != nil && err != c.ctx.Err() {
+			log.Error("Unexpected error when checking path %s in %s. Error: %v", path, c.Repo.Path, err)
 		}
 	}()
 

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1448,8 +1448,6 @@ func GetDiff(gitRepo *git.Repository, opts *DiffOptions, files ...string) (*Diff
 				} else if language, has := attrs["gitlab-language"]; has && language != "unspecified" && language != "" {
 					diffFile.Language = language
 				}
-			} else {
-				log.Error("Unexpected error: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Backport #21064

We should only log CheckPath errors if they are not simply due to context cancellation - and we should add a little more context to the error message.

Fix #20709

Signed-off-by: Andrew Thornton <art27@cantab.net>
