### PR TITLE
Respect user's locale when rendering the date range in the repo activity page

### DIFF
--- a/routers/web/repo/activity.go
+++ b/routers/web/repo/activity.go
@@ -47,8 +47,8 @@ func Activity(ctx *context.Context) {
 		ctx.Data["Period"] = "weekly"
 		timeFrom = timeUntil.Add(-time.Hour * 168)
 	}
-	ctx.Data["DateFrom"] = timeFrom.Format("2006-01-02")
-	ctx.Data["DateUntil"] = timeUntil.Format("2006-01-02")
+	ctx.Data["DateFrom"] = timeFrom.UTC().Format(time.RFC3339)
+	ctx.Data["DateUntil"] = timeUntil.UTC().Format(time.RFC3339)
 	ctx.Data["PeriodText"] = ctx.Tr("repo.activity.period." + ctx.Data["Period"].(string))
 
 	var err error

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -2,7 +2,7 @@
 <div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
-		<h2 class="ui header"><time data-format-text-according-to-datetime datetime="{{.DateFrom}}"></time> - <time data-format-text-according-to-datetime datetime="{{.DateUntil}}"></time>
+		<h2 class="ui header"><time data-date-format datetime="{{.DateFrom}}"></time> - <time data-date-format datetime="{{.DateUntil}}"></time>
 			<div class="ui right">
 				<!-- Period -->
 				<div class="ui floating dropdown jump filter">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -2,7 +2,7 @@
 <div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
-		<h2 class="ui header"><time data-format="date" datetime="{{.DateFrom}}"></time> - <time data-format="date" datetime="{{.DateUntil}}"></time>
+		<h2 class="ui header"><time data-format="date" datetime="{{.DateFrom}}">{{.DateFrom}}</time> - <time data-format="date" datetime="{{.DateUntil}}">{{.DateUntil}}</time>
 			<div class="ui right">
 				<!-- Period -->
 				<div class="ui floating dropdown jump filter">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -2,7 +2,7 @@
 <div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
-		<h2 class="ui header">{{.DateFrom}} - {{.DateUntil}}
+		<h2 class="ui header"><time data-format-text-according-to-datetime datetime="{{.DateFrom}}"></time> - <time data-format-text-according-to-datetime datetime="{{.DateUntil}}"></time>
 			<div class="ui right">
 				<!-- Period -->
 				<div class="ui floating dropdown jump filter">

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -2,7 +2,7 @@
 <div class="page-content repository commits">
 	{{template "repo/header" .}}
 	<div class="ui container">
-		<h2 class="ui header"><time data-date-format datetime="{{.DateFrom}}"></time> - <time data-date-format datetime="{{.DateUntil}}"></time>
+		<h2 class="ui header"><time data-format="date" datetime="{{.DateFrom}}"></time> - <time data-format="date" datetime="{{.DateUntil}}"></time>
 			<div class="ui right">
 				<!-- Period -->
 				<div class="ui floating dropdown jump filter">

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -11,4 +11,14 @@ export function initFormattingReplacements() {
       el.textContent = formatted;
     }
   }
+
+  // for each <time></time> tag, if it has the data-format-text-according-to-datetime, format
+  // the text according to the user's chosen locale
+  const locale = document.getElementsByTagName('html')[0].lang;
+  const formatter = new Intl.DateTimeFormat(locale, {year: 'numeric', month: 'long', day: 'numeric'});
+  for (const timeElement of document.getElementsByTagName('time')) {
+    if (timeElement.hasAttribute('data-format-text-according-to-datetime')) {
+      timeElement.innerText = formatter.format(new Date(timeElement.dateTime));
+    }
+  }
 }

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -12,13 +12,10 @@ export function initFormattingReplacements() {
     }
   }
 
-  // for each <time></time> tag, if it has the data-date-format, format
+  // for each <time></time> tag, if it has the data-format="date" attribute, format
   // the text according to the user's chosen locale
-  const {lang} = document.documentElement;
   const formatter = new Intl.DateTimeFormat(lang, {year: 'numeric', month: 'long', day: 'numeric'});
-  for (const timeElement of document.getElementsByTagName('time')) {
-    if (timeElement.hasAttribute('data-date-format')) {
-      timeElement.innerText = formatter.format(new Date(timeElement.dateTime));
-    }
+  for (const timeElement of document.querySelectorAll('time[data-format="date"]')) {
+    timeElement.innerText = formatter.format(new Date(timeElement.dateTime));
   }
 }

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -1,6 +1,7 @@
 import {prettyNumber} from '../utils.js';
 
 const {lang} = document.documentElement;
+const dateFormatter = new Intl.DateTimeFormat(lang, {year: 'numeric', month: 'long', day: 'numeric'});
 
 export function initFormattingReplacements() {
   // replace english formatted numbers with locale-specific separators
@@ -14,8 +15,7 @@ export function initFormattingReplacements() {
 
   // for each <time></time> tag, if it has the data-format="date" attribute, format
   // the text according to the user's chosen locale
-  const formatter = new Intl.DateTimeFormat(lang, {year: 'numeric', month: 'long', day: 'numeric'});
   for (const timeElement of document.querySelectorAll('time[data-format="date"]')) {
-    timeElement.innerText = formatter.format(new Date(timeElement.dateTime));
+    timeElement.innerText = dateFormatter.format(new Date(timeElement.dateTime));
   }
 }

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -12,12 +12,12 @@ export function initFormattingReplacements() {
     }
   }
 
-  // for each <time></time> tag, if it has the data-format-text-according-to-datetime, format
+  // for each <time></time> tag, if it has the data-date-format, format
   // the text according to the user's chosen locale
   const locale = document.getElementsByTagName('html')[0].lang;
   const formatter = new Intl.DateTimeFormat(locale, {year: 'numeric', month: 'long', day: 'numeric'});
   for (const timeElement of document.getElementsByTagName('time')) {
-    if (timeElement.hasAttribute('data-format-text-according-to-datetime')) {
+    if (timeElement.hasAttribute('data-date-format')) {
       timeElement.innerText = formatter.format(new Date(timeElement.dateTime));
     }
   }

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -16,6 +16,6 @@ export function initFormattingReplacements() {
   // for each <time></time> tag, if it has the data-format="date" attribute, format
   // the text according to the user's chosen locale
   for (const timeElement of document.querySelectorAll('time[data-format="date"]')) {
-    timeElement.innerText = dateFormatter.format(new Date(timeElement.dateTime));
+    timeElement.textContent = dateFormatter.format(new Date(timeElement.dateTime));
   }
 }

--- a/web_src/js/features/formatting.js
+++ b/web_src/js/features/formatting.js
@@ -14,8 +14,8 @@ export function initFormattingReplacements() {
 
   // for each <time></time> tag, if it has the data-date-format, format
   // the text according to the user's chosen locale
-  const locale = document.getElementsByTagName('html')[0].lang;
-  const formatter = new Intl.DateTimeFormat(locale, {year: 'numeric', month: 'long', day: 'numeric'});
+  const {lang} = document.documentElement;
+  const formatter = new Intl.DateTimeFormat(lang, {year: 'numeric', month: 'long', day: 'numeric'});
   for (const timeElement of document.getElementsByTagName('time')) {
     if (timeElement.hasAttribute('data-date-format')) {
       timeElement.innerText = formatter.format(new Date(timeElement.dateTime));


### PR DESCRIPTION
# Description
Previously, to make the date range understood by all, we used the format "2006-01-02" for the dates as it's locale-generic.

This commit changes the rendering logic. Instead of rendering the date on the server, we send a formatted computer-readable timestamp. The client's javascript then renders it according to the user's locale.

This approach is reusable across the codebase, any `<time></time>` tag with the data-format="date" attribute would get rendered according to the user's chosen locale.

## Previous View
![image](https://user-images.githubusercontent.com/20454870/195099143-e1c5df86-282a-42f1-898f-a36bb5fe7c2f.png)

## New View

### English
![image](https://user-images.githubusercontent.com/20454870/195099301-5cda4eab-4012-49d5-97e5-b1f9cada9c06.png)

### French
![image](https://user-images.githubusercontent.com/20454870/195099434-ce23e394-8d65-4c4c-8ac8-8b96bc9044f3.png)

### Portuguese
![image](https://user-images.githubusercontent.com/20454870/195099559-9a7aed28-944a-45ec-bedb-64403e3faede.png)

### Italian
![image](https://user-images.githubusercontent.com/20454870/195099661-17758d55-3fe0-4797-879b-d45de0ee8ba3.png)

# References
* #21380 
* #21387
* #21396

Inspiration:

        I think either differentiating by class, or probably better by a custom attribute such as `data-format` or similar, is the best course of action.

_Originally posted by @delvh in https://github.com/go-gitea/gitea/issues/21396#issuecomment-1274424788_
      


Resolves #21380 