### PR TITLE
Refactor Gitpod configuration to improve quick spin up of automated dev environments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,3 @@
-image: gitpod/workspace-full:latest
-
 tasks:
   - name: Setup
     init: |
@@ -16,10 +14,13 @@ tasks:
     command: |
       gp sync-await setup
       mkdir -p custom/conf/
-      echo -e "[server]\nROOT_URL=https://3000-$GITPOD_WORKSPACE_ID.${GITPOD_WORKSPACE_CLUSTER_HOST}/" > custom/conf/app.ini
+      echo -e "[server]\nROOT_URL=$(gp url 3000)/" > custom/conf/app.ini
       echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = /workspace/gitea/data/gitea.db" >> custom/conf/app.ini
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
+  - name: Run docs
+    before: sudo bash -c "$(grep 'https://github.com/gohugoio/hugo/releases/download' Makefile | tr -d '\')" # install hugo
+    command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
 
 vscode:
   extensions:
@@ -28,7 +29,11 @@ vscode:
     - golang.go
     - stylelint.vscode-stylelint
     - DavidAnson.vscode-markdownlint
+    - johnsoncodehk.volar
+    - ms-azuretools.vscode-docker
 
 ports:
   - name: Gitea
     port: 3000
+  - name: Docs
+    port: 1313

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,7 @@ tasks:
       gp sync-await setup
       mkdir -p custom/conf/
       echo -e "[server]\nROOT_URL=$(gp url 3000)/" > custom/conf/app.ini
-      echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = /workspace/gitea/data/gitea.db" >> custom/conf/app.ini
+      echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
   - name: Run docs

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
   <a href="https://opensource.org/licenses/MIT" title="License: MIT">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg">
   </a>
+  <a href="https://gitpod.io/#https://github.com/go-gitea/gitea">
+  <img
+    src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod"
+    alt="Contribute with Gitpod"
+  />
+  </a>
   <a href="https://crowdin.com/project/gitea" title="Crowdin">
     <img src="https://badges.crowdin.net/gitea/localized.svg">
   </a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -33,6 +33,12 @@
   <a href="https://opensource.org/licenses/MIT" title="License: MIT">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg">
   </a>
+  <a href="https://gitpod.io/#https://github.com/go-gitea/gitea">
+  <img
+    src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod"
+    alt="Contribute with Gitpod"
+  />
+  </a>
   <a href="https://crowdin.com/project/gitea" title="Crowdin">
     <img src="https://badges.crowdin.net/gitea/localized.svg">
   </a>

--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -19,6 +19,12 @@ menu:
 
 {{< toc >}}
 
+## Quickstart
+
+To get a quick working development environment you may use Gitpod.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/go-gitea/gitea)
+
 ## Installing go
 
 You should [install go](https://golang.org/doc/install) and set up your go

--- a/docs/content/doc/developers/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/developers/hacking-on-gitea.en-us.md
@@ -21,7 +21,7 @@ menu:
 
 ## Quickstart
 
-To get a quick working development environment you may use Gitpod.
+To get a quick working development environment you could use Gitpod.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/go-gitea/gitea)
 


### PR DESCRIPTION
This commit instructs Gitpod to run `docs` in watch mode in fresh development environments so any dev could start hacking in seconds.

Also included some vscode extensions for Vue, Go, and Docker.


Try it here:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/yardenshoham/gitea/tree/gitpod)
