### PR TITLE
Make db.ErrNotExist reusable

### DIFF
--- a/models/db/error.go
+++ b/models/db/error.go
@@ -48,9 +48,15 @@ type ErrNotExist struct {
 	ID int64
 }
 
+type errNotExist interface {
+	isErrNotExist()
+}
+
+func (err ErrNotExist) isErrNotExist() {}
+
 // IsErrNotExist checks if an error is an ErrNotExist
 func IsErrNotExist(err error) bool {
-	_, ok := err.(ErrNotExist)
+	_, ok := err.(errNotExist)
 	return ok
 }
 


### PR DESCRIPTION
This is a proposal.

There are lots of `ErrXXXNotExist` in models, like

```go
// ErrUserNotExist represents a "UserNotExist" kind of error.
type ErrUserNotExist struct {
	UID   int64
	Name  string
	KeyID int64
}

// IsErrUserNotExist checks if an error is a ErrUserNotExist.
func IsErrUserNotExist(err error) bool {
	_, ok := err.(ErrUserNotExist)
	return ok
}
```

But sometimes I don't care what kind of "NotExist" the error is, I just want to know if it is "NotExist".

If this PR had been merged, I could do that like this:

```go
type ErrUserNotExist struct {
	db.ErrNotExist
	// ...
}

var err error = ErrUserNotExist{}
IsErrUserNotExist(err) // true
db.IsErrNotExist(err) // true
IsErrRepoNotExist(err) // false
```

