### PR TITLE
Demo for making backend code know browser's locale and timezone

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -698,6 +698,9 @@ func Contexter(ctx context.Context) func(next http.Handler) http.Handler {
 			ctx.Req = WithContext(req, &ctx)
 			ctx.csrf = PrepareCSRFProtector(csrfOpts, &ctx)
 
+			browserSyncJson := ctx.GetCookie("_gitea_bsj")
+			ctx.PageData["browserSyncJson"] = browserSyncJson
+
 			// Get flash.
 			flashCookie := ctx.GetCookie("macaron_flash")
 			vals, _ := url.ParseQuery(flashCookie)

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -47,3 +47,12 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 	{{/* in case some pages don't render the pageData, we make sure it is an object to prevent null access */}}
 	window.config.pageData = window.config.pageData || {};
 </script>
+
+<script type="module">
+	const browserSyncJson = JSON.stringify({lc: window.navigator.language, tz: new Date().getTimezoneOffset()});
+	if (window.config.pageData.browserSyncJson != null && window.config.pageData.browserSyncJson !== browserSyncJson) {
+		document.cookie = '_gitea_bsj=' + encodeURIComponent(browserSyncJson) + '; path=/'; // tell the backend about locale and timezone
+		document.body.style.setProperty('display', 'none', 'important'); // hide the page to prevent flash during reload
+		setTimeout(() => window.location.reload(), 1000); // use a setTimeout to simulate a slow network
+	}
+</script>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -1,4 +1,7 @@
 {{template "base/head" .}}
+<div>
+	Backend has the user browser's locale and timezone offset now: {{.PageData.browserSyncJson}}
+</div>
 <div class="page-content home">
 	<div class="ui stackable middle very relaxed page grid">
 		<div class="sixteen wide center aligned centered column">


### PR DESCRIPTION
A demo for 
* https://github.com/go-gitea/gitea/pull/21429#issuecomment-1277818095

Then backend code can render contents with correct locale and timezone, there will be no UI flicker on frontend.

Try it in a private window.

----

Some backgrounds and discussions: https://github.com/go-gitea/gitea/pull/21429

In short, at the moment, backend code doesn't know user's timezone, so rendered date/time would be in wrong timezone. 

There could be 2 approaches:

1. Re-render the date/time by JS again, which may cause some flickers on UI, to avoid flicker the code would be somewhat hacky and IMO not stable  (PR #21429).
2. Make backend know the browser's timezone (This PR, for demo), which will make a second request for user's first visit. Or we can choose to only render correct timezone for later visits.

Which way should we go?
