### PR TITLE
Remove useless `appVer` from JS `window.config`

### DIFF
--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -6,7 +6,6 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 <script>
 	window.addEventListener('error', function(e) {window._globalHandlerErrors=window._globalHandlerErrors||[]; window._globalHandlerErrors.push(e);});
 	window.config = {
-		appVer: '{{AppVer}}',
 		appUrl: '{{AppUrl}}',
 		appSubUrl: '{{AppSubUrl}}',
 		assetVersionEncoded: encodeURIComponent('{{AssetVersion}}'), // will be used in URL construction directly

--- a/web_src/js/features/serviceworker.js
+++ b/web_src/js/features/serviceworker.js
@@ -1,6 +1,6 @@
 import {joinPaths, parseUrl} from '../utils.js';
 
-const {useServiceWorker, assetUrlPrefix, appVer, assetVersionEncoded} = window.config;
+const {useServiceWorker, assetUrlPrefix, assetVersionEncoded} = window.config;
 const cachePrefix = 'static-cache-v'; // actual version is set in the service worker script
 const workerUrl = `${joinPaths(assetUrlPrefix, 'serviceworker.js')}?v=${assetVersionEncoded}`;
 
@@ -25,7 +25,7 @@ async function invalidateCache() {
 }
 
 async function checkCacheValidity() {
-  const cacheKey = appVer;
+  const cacheKey = assetVersionEncoded;
   const storedCacheKey = localStorage.getItem('staticCacheKey');
 
   // invalidate cache if it belongs to a different gitea version


### PR DESCRIPTION
The only usage of `appVer` was in serviceworker.js, while indeed it needs the asset version.