### PR TITLE
Add vitest tests to Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,6 +31,7 @@ vscode:
     - DavidAnson.vscode-markdownlint
     - johnsoncodehk.volar
     - ms-azuretools.vscode-docker
+    - zixuanchen.vitest-explorer
 
 ports:
   - name: Gitea


### PR DESCRIPTION
The vitest PR is merged, we can now add vitest to Gitpod's testing pane
* #21444

We couldn't use jest in the same manner because we had to customize `NODE_OPTIONS`.

Screenshot (look at all the cool stuff circled in red):
![image](https://user-images.githubusercontent.com/20454870/195728971-9a2eaa80-8d91-4e4f-899b-a068edb9ff30.png)


