### PR TITLE
Fix Drone pushing commits with wrong author info

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -619,13 +619,15 @@ steps:
     image: appleboy/drone-git-push
     pull: always
     settings:
-      author_email: "teabot@gitea.io"
-      author_name: GiteaBot
+      author_email: &author_email "teabot@gitea.io"
+      author_name: &author_name GiteaBot
       branch: main
       commit: true
       commit_message: "[skip ci] Updated translations via Crowdin"
       remote: "git@github.com:go-gitea/gitea.git"
     environment:
+      DRONE_COMMIT_AUTHOR_EMAIL: *author_email
+      DRONE_COMMIT_AUTHOR: *author_name
       GIT_PUSH_SSH_KEY:
         from_secret: git_push_ssh_key
 
@@ -669,13 +671,15 @@ steps:
     image: appleboy/drone-git-push
     pull: always
     settings:
-      author_email: "teabot@gitea.io"
-      author_name: GiteaBot
+      author_email: *author_email
+      author_name: *author_name
       branch: main
       commit: true
-      commit_message: "[skip ci] Updated licenses and gitignores "
+      commit_message: "[skip ci] Updated licenses and gitignores"
       remote: "git@github.com:go-gitea/gitea.git"
     environment:
+      DRONE_COMMIT_AUTHOR_EMAIL: *author_email
+      DRONE_COMMIT_AUTHOR: *author_name
       GIT_PUSH_SSH_KEY:
         from_secret: git_push_ssh_key
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -619,15 +619,15 @@ steps:
     image: appleboy/drone-git-push
     pull: always
     settings:
-      author_email: &author_email "teabot@gitea.io"
-      author_name: &author_name GiteaBot
+      author_email: "teabot@gitea.io"
+      author_name: GiteaBot
       branch: main
       commit: true
       commit_message: "[skip ci] Updated translations via Crowdin"
       remote: "git@github.com:go-gitea/gitea.git"
     environment:
-      DRONE_COMMIT_AUTHOR_EMAIL: *author_email
-      DRONE_COMMIT_AUTHOR: *author_name
+      DRONE_COMMIT_AUTHOR_EMAIL: "teabot@gitea.io"
+      DRONE_COMMIT_AUTHOR: GiteaBot
       GIT_PUSH_SSH_KEY:
         from_secret: git_push_ssh_key
 
@@ -671,15 +671,15 @@ steps:
     image: appleboy/drone-git-push
     pull: always
     settings:
-      author_email: *author_email
-      author_name: *author_name
+      author_email: "teabot@gitea.io"
+      author_name: "GiteaBot"
       branch: main
       commit: true
       commit_message: "[skip ci] Updated licenses and gitignores"
       remote: "git@github.com:go-gitea/gitea.git"
     environment:
-      DRONE_COMMIT_AUTHOR_EMAIL: *author_email
-      DRONE_COMMIT_AUTHOR: *author_name
+      DRONE_COMMIT_AUTHOR_EMAIL: "teabot@gitea.io"
+      DRONE_COMMIT_AUTHOR: "GiteaBot"
       GIT_PUSH_SSH_KEY:
         from_secret: git_push_ssh_key
 


### PR DESCRIPTION
I don't know how to test this so I'll explain my thought process:

After a discussion with @techknowlogick in https://github.com/go-gitea/gitea/commit/cda2c38f4a61ef7f448be3efab5420d9974c8474 I saw the CI config has this block:
https://github.com/go-gitea/gitea/blob/cda2c38f4a61ef7f448be3efab5420d9974c8474/.drone.yml#L618-L630

I don't know much about Drone but after looking at [appleboy/drone-git-push](https://github.com/appleboy/drone-git-push)'s source code, I think each setting becomes an environment variable (e.g. `remote` to `PLUGIN_REMOTE`, `commit_message` to `PLUGIN_COMMIT_MESSAGE` etc...). Take a look at the code block loading the author info:
https://github.com/appleboy/drone-git-push/blob/a69878c00665277c53fb38d6c5980221cb687935/main.go#L32-L42

Two environment variables are listed for each setting. This PR forces both to have the same value.