### PR TITLE
Add `fmt-check` to `make checks-backend` for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ checks: checks-frontend checks-backend
 checks-frontend: lockfile-check svg-check
 
 .PHONY: checks-backend
-checks-backend: tidy-check swagger-check swagger-validate
+checks-backend: tidy-check swagger-check swagger-validate fmt-check
 
 .PHONY: lint
 lint: lint-frontend lint-backend


### PR DESCRIPTION
* Following #21437 I realized the build system isn't actually checking that the code is formatted
