### PR TITLE
Follow improve code quality

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -40,7 +40,7 @@ type Command struct {
 	parentContext    context.Context
 	desc             string
 	globalArgsLength int
-	broken           bool
+	brokenArgs       []string
 }
 
 func (c *Command) String() string {
@@ -105,9 +105,11 @@ func (c *Command) AddArguments(args ...string) *Command {
 func (c *Command) AddDynamicArguments(args ...string) *Command {
 	for _, arg := range args {
 		if arg != "" && arg[0] == '-' {
-			c.broken = true
-			return c
+			c.brokenArgs = append(c.brokenArgs, arg)
 		}
+	}
+	if len(c.brokenArgs) != 0 {
+		return c
 	}
 	c.args = append(c.args, args...)
 	return c
@@ -160,8 +162,8 @@ var ErrBrokenCommand = errors.New("git command is command")
 
 // Run runs the command with the RunOpts
 func (c *Command) Run(opts *RunOpts) error {
-	if c.broken {
-		log.Error("git command is broken: %s", c.String())
+	if len(c.brokenArgs) != 0 {
+		log.Error("git command is broken: %s, broken args: %s", c.String(), strings.Join(c.brokenArgs, " "))
 		return ErrBrokenCommand
 	}
 	if opts == nil {

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -90,7 +90,7 @@ func (c *Command) SetDescription(desc string) *Command {
 	return c
 }
 
-// AddArguments adds new argument(s) to the command. Each argument must be safe trusted.
+// AddArguments adds new argument(s) to the command. Each argument must be safe to be trusted.
 func (c *Command) AddArguments(args ...string) *Command {
 	c.args = append(c.args, args...)
 	return c

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -158,7 +158,7 @@ func CommonCmdServEnvs() []string {
 	return commonBaseEnvs()
 }
 
-var ErrBrokenCommand = errors.New("git command is command")
+var ErrBrokenCommand = errors.New("git command is broken")
 
 // Run runs the command with the RunOpts
 func (c *Command) Run(opts *RunOpts) error {

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -51,6 +51,7 @@ func (c *Command) String() string {
 }
 
 // NewCommand creates and returns a new Git Command based on given command and arguments.
+// Each argument should be safe to be trusted. User-provided arguments should be passed to AddDynamicArguments instead.
 func NewCommand(ctx context.Context, args ...string) *Command {
 	// Make an explicit copy of globalCommandArgs, otherwise append might overwrite it
 	cargs := make([]string, len(globalCommandArgs))
@@ -64,11 +65,13 @@ func NewCommand(ctx context.Context, args ...string) *Command {
 }
 
 // NewCommandNoGlobals creates and returns a new Git Command based on given command and arguments only with the specify args and don't care global command args
+// Each argument should be safe to be trusted. User-provided arguments should be passed to AddDynamicArguments instead.
 func NewCommandNoGlobals(args ...string) *Command {
 	return NewCommandContextNoGlobals(DefaultContext, args...)
 }
 
 // NewCommandContextNoGlobals creates and returns a new Git Command based on given command and arguments only with the specify args and don't care global command args
+// Each argument should be safe to be trusted. User-provided arguments should be passed to AddDynamicArguments instead.
 func NewCommandContextNoGlobals(ctx context.Context, args ...string) *Command {
 	return &Command{
 		name:          GitExecutable,
@@ -91,6 +94,7 @@ func (c *Command) SetDescription(desc string) *Command {
 }
 
 // AddArguments adds new argument(s) to the command. Each argument must be safe to be trusted.
+// User-provided arguments should be passed to AddDynamicArguments instead.
 func (c *Command) AddArguments(args ...string) *Command {
 	c.args = append(c.args, args...)
 	return c

--- a/modules/git/command_test.go
+++ b/modules/git/command_test.go
@@ -27,15 +27,13 @@ func TestRunWithContextStd(t *testing.T) {
 		assert.Empty(t, stdout)
 	}
 
-	assert.Panics(t, func() {
-		cmd = NewCommand(context.Background())
-		cmd.AddDynamicArguments("-test")
-	})
+	cmd = NewCommand(context.Background())
+	cmd.AddDynamicArguments("-test")
+	assert.ErrorIs(t, cmd.Run(&RunOpts{}), ErrBrokenCommand)
 
-	assert.Panics(t, func() {
-		cmd = NewCommand(context.Background())
-		cmd.AddDynamicArguments("--test")
-	})
+	cmd = NewCommand(context.Background())
+	cmd.AddDynamicArguments("--test")
+	assert.ErrorIs(t, cmd.Run(&RunOpts{}), ErrBrokenCommand)
 
 	subCmd := "version"
 	cmd = NewCommand(context.Background()).AddDynamicArguments(subCmd) // for test purpose only, the sub-command should never be dynamic for production


### PR DESCRIPTION
After some discussion, introduce a new slice `brokenArgs` to make `gitCmd.Run()` return errors if any dynamic argument is invalid.