### PR TITLE
Return 404 when user is not found on avatar (#21476)

### DIFF
--- a/routers/web/user/avatar.go
+++ b/routers/web/user/avatar.go
@@ -31,6 +31,10 @@ func AvatarByUserName(ctx *context.Context) {
 	if strings.ToLower(userName) != "ghost" {
 		var err error
 		if user, err = user_model.GetUserByName(ctx, userName); err != nil {
+			if user_model.IsErrUserNotExist(err) {
+				ctx.NotFound("GetUserByName", err)
+				return
+			}
 			ctx.ServerError("Invalid user: "+userName, err)
 			return
 		}


### PR DESCRIPTION
- Backport #21476
  - Instead of returning a 500 Internal Server when the user wasn't found, return 404 Not found.

