### PR TITLE
fix install 500 error

### DIFF
--- a/models/system/setting.go
+++ b/models/system/setting.go
@@ -89,6 +89,10 @@ func GetSetting(key string) (*Setting, error) {
 
 // GetSettings returns specific settings
 func GetSettings(keys []string) (map[string]*Setting, error) {
+	if db.DefaultContext == nil {
+		return map[string]*Setting{}, nil
+	}
+
 	for i := 0; i < len(keys); i++ {
 		keys[i] = strings.ToLower(keys[i])
 	}

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -385,7 +385,6 @@ func SubmitInstall(ctx *context.Context) {
 		ctx.RenderWithErr(ctx.Tr("install.invalid_db_setting", err), tplInstall, &form)
 		return
 	}
-	db.UnsetDefaultEngine()
 
 	// Save settings.
 	cfg := ini.Empty()


### PR DESCRIPTION
- can't get specific settings from database before
  install becaucse of no database
- should not ``db.UnsetDefaultEngine()`` in ``SubmitInstall``
  because it will be used soon.

- related with: https://github.com/go-gitea/gitea/pull/18058