### PR TITLE
Disable the 'Add File' button when not able to edit repo

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -77,7 +77,7 @@
 					<a href="{{.Repository.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button tooltip" data-content="{{.locale.Tr "repo.find_file.go_to_file"}}">{{svg "octicon-file-moved" 15}}</a>
 				{{end}}
 				{{if or .CanAddFile .CanUploadFile}}
-					<button class="ui basic small compact dropdown jump icon button mr-2"{{if not .Repository.CanEnableEditor}} disabled="disabled"{{end}}>
+					<button class="ui basic small compact dropdown jump icon button mr-2"{{if not .Repository.CanEnableEditor}} disabled{{end}}>
 						<span class="text">{{.locale.Tr "repo.editor.add_file"}}</span>
 						<div class="menu">
 							{{if .CanAddFile}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -77,25 +77,23 @@
 					<a href="{{.Repository.Link}}/find/{{.BranchNameSubURL}}" class="ui compact basic button tooltip" data-content="{{.locale.Tr "repo.find_file.go_to_file"}}">{{svg "octicon-file-moved" 15}}</a>
 				{{end}}
 				{{if or .CanAddFile .CanUploadFile}}
-					<button class="ui basic small compact dropdown jump icon button mr-2">
+					<button class="ui basic small compact dropdown jump icon button mr-2"{{if not .Repository.CanEnableEditor}} disabled="disabled"{{end}}>
 						<span class="text">{{.locale.Tr "repo.editor.add_file"}}</span>
 						<div class="menu">
-							{{if .Repository.CanEnableEditor}}
-								{{if .CanAddFile}}
-									<a class="item" href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
-										{{.locale.Tr "repo.editor.new_file"}}
-									</a>
-								{{end}}
-								{{if .CanUploadFile}}
-									<a class="item" href="{{.RepoLink}}/_upload/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
-										{{.locale.Tr "repo.editor.upload_file"}}
-									</a>
-								{{end}}
-								{{if .CanAddFile}}
-									<a class="item" href="{{.RepoLink}}/_diffpatch/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
-										{{.locale.Tr "repo.editor.patch"}}
-									</a>
-								{{end}}
+							{{if .CanAddFile}}
+								<a class="item" href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
+									{{.locale.Tr "repo.editor.new_file"}}
+								</a>
+							{{end}}
+							{{if .CanUploadFile}}
+								<a class="item" href="{{.RepoLink}}/_upload/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
+									{{.locale.Tr "repo.editor.upload_file"}}
+								</a>
+							{{end}}
+							{{if .CanAddFile}}
+								<a class="item" href="{{.RepoLink}}/_diffpatch/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
+									{{.locale.Tr "repo.editor.patch"}}
+								</a>
 							{{end}}
 						</div>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}


### PR DESCRIPTION
Previously, the button would render a dropdown with zero items when `.CanEnableEditor` was false (for example on a mirror repo). Now it disables the button instead which is better UX.

<img width="310" alt="image" src="https://user-images.githubusercontent.com/115237/196546655-7262070d-dd8f-4fbe-ad5c-ecb443a9caef.png">
<img width="292" alt="image" src="https://user-images.githubusercontent.com/115237/196546694-51ef5792-16d4-463d-aae8-7ef22dba6bb4.png">
