### PR TITLE
Suppress `ExternalLoginUserNotExist` error

### DIFF
--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -6,6 +6,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"code.gitea.io/gitea/modules/session"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/routers/utils"

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -619,7 +619,7 @@ func handleUserCreated(ctx *context.Context, u *user_model.User, gothUser *goth.
 	// update external user information
 	if gothUser != nil {
 		if err := externalaccount.UpdateExternalUser(u, *gothUser); err != nil {
-			if !user_model.IsErrExternalLoginUserNotExist(err) {
+			if !errors.Is(err, util.ErrNotExist) {
 				log.Error("UpdateExternalUser failed: %v", err)
 			}
 		}

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -619,7 +619,9 @@ func handleUserCreated(ctx *context.Context, u *user_model.User, gothUser *goth.
 	// update external user information
 	if gothUser != nil {
 		if err := externalaccount.UpdateExternalUser(u, *gothUser); err != nil {
-			log.Error("UpdateExternalUser failed: %v", err)
+			if !user_model.IsErrExternalLoginUserNotExist(err) {
+				log.Error("UpdateExternalUser failed: %v", err)
+			}
 		}
 	}
 

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1068,7 +1068,7 @@ func handleOAuth2SignIn(ctx *context.Context, source *auth.Source, u *user_model
 
 		// update external user information
 		if err := externalaccount.UpdateExternalUser(u, gothUser); err != nil {
-			if !user_model.IsErrExternalLoginUserNotExist(err) {
+			if !errors.Is(err, util.ErrNotExist) {
 				log.Error("UpdateExternalUser failed: %v", err)
 			}
 		}

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1068,7 +1068,9 @@ func handleOAuth2SignIn(ctx *context.Context, source *auth.Source, u *user_model
 
 		// update external user information
 		if err := externalaccount.UpdateExternalUser(u, gothUser); err != nil {
-			log.Error("UpdateExternalUser failed: %v", err)
+			if !user_model.IsErrExternalLoginUserNotExist(err) {
+				log.Error("UpdateExternalUser failed: %v", err)
+			}
 		}
 
 		if err := resetLocale(ctx, u); err != nil {


### PR DESCRIPTION
Fixes #21202
Closes #21276

An `ExternalLoginUser` is not mandatory if the current user account was created with/by the external login source.