### PR TITLE
Remove vitest globals

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -35,9 +35,6 @@ overrides:
     rules:
       import/no-unresolved: [0]
       import/no-extraneous-dependencies: [0]
-  - files: ["*.test.js"]
-    env:
-      jest: true
   - files: ["*.config.js"]
     rules:
       import/no-unused-modules: [0]

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -24,7 +24,6 @@ export default defineConfig({
     open: false,
     allowOnly: true,
     passWithNoTests: true,
-    globals: true,
     watch: false,
   },
   plugins: [

--- a/web_src/js/features/repo-findfile.test.js
+++ b/web_src/js/features/repo-findfile.test.js
@@ -1,3 +1,4 @@
+import {describe, expect, test} from 'vitest';
 import {strSubMatch, calcMatchedWeight, filterRepoFilesWeighted} from './repo-findfile.js';
 
 describe('Repo Find Files', () => {

--- a/web_src/js/svg.test.js
+++ b/web_src/js/svg.test.js
@@ -1,3 +1,4 @@
+import {expect, test} from 'vitest';
 import {svg} from './svg.js';
 
 test('svg', () => {

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -1,3 +1,4 @@
+import {expect, test} from 'vitest';
 import {
   basename, extname, isObject, uniq, stripTags, joinPaths, parseIssueHref,
   prettyNumber, parseUrl,


### PR DESCRIPTION
Explicitly import them instead which is cleaner and enables better editor integration.