### PR TITLE
Skip TestExportUserGPGKeys

### DIFF
--- a/tests/integration/user_test.go
+++ b/tests/integration/user_test.go
@@ -140,6 +140,8 @@ func TestRenameReservedUsername(t *testing.T) {
 }
 
 func TestExportUserGPGKeys(t *testing.T) {
+	t.Skip("Test is flaky, see https://github.com/go-gitea/gitea/issues/19961")
+
 	defer tests.PrepareTestEnv(t)()
 	// Export empty key list
 	testExportUserGPGKeys(t, "user1", `-----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/tests/integration/user_test.go
+++ b/tests/integration/user_test.go
@@ -140,7 +140,9 @@ func TestRenameReservedUsername(t *testing.T) {
 }
 
 func TestExportUserGPGKeys(t *testing.T) {
-	t.Skip("Test is flaky, see https://github.com/go-gitea/gitea/issues/19961")
+	if os.Getenv("CI") != "" {
+		t.Skip("Test is flaky, see https://github.com/go-gitea/gitea/issues/19961")
+	}
 
 	defer tests.PrepareTestEnv(t)()
 	// Export empty key list

--- a/tests/integration/user_test.go
+++ b/tests/integration/user_test.go
@@ -6,6 +6,7 @@ package integration
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	issues_model "code.gitea.io/gitea/models/issues"


### PR DESCRIPTION
This test is causing a lot of failures on CI and I'm not really motived to look into, so just skip it to make CI results more accurate.

Related: https://github.com/go-gitea/gitea/issues/19961