### PR TITLE
Enable Monaco automaticLayout

### DIFF
--- a/web_src/js/features/codeeditor.js
+++ b/web_src/js/features/codeeditor.js
@@ -17,6 +17,7 @@ const baseOptions = {
   rulers: false,
   scrollbar: {horizontalScrollbarSize: 6, verticalScrollbarSize: 6},
   scrollBeyondLastLine: false,
+  automaticLayout: true,
 };
 
 function getEditorconfig(input) {


### PR DESCRIPTION
Enable [`automaticLayout`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IDiffEditorOptions.html#automaticLayout) for monaco so it can reflow itself.

Fixes: https://github.com/go-gitea/gitea/issues/21508