### PR TITLE
Check for valid user token in integration tests

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -260,9 +261,12 @@ func loginUserWithPassword(t testing.TB, userName, password string) *TestSession
 
 // token has to be unique this counter take care of
 var tokenCounter int64
+var tokenCounterMutex sync.Mutex
 
 func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	t.Helper()
+	tokenCounterMutex.Lock()
+	defer tokenCounterMutex.Unlock()
 	tokenCounter++
 	req := NewRequest(t, "GET", "/user/settings/applications")
 	resp := session.MakeRequest(t, req, http.StatusOK)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"hash"
 	"hash/fnv"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -259,9 +258,12 @@ func loginUserWithPassword(t testing.TB, userName, password string) *TestSession
 	return session
 }
 
+// token has to be unique this counter take care of
+var tokenCounter int64
+
 func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	t.Helper()
-	tokenCounter := rand.Int()
+	tokenCounter++
 	req := NewRequest(t, "GET", "/user/settings/applications")
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	doc := NewHTMLParser(t, resp.Body)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -266,6 +266,7 @@ func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	tokenCounter++
 	req := NewRequest(t, "GET", "/user/settings/applications")
 	resp := session.MakeRequest(t, req, http.StatusOK)
+	assert.EqualValues(t, resp.Result().StatusCode, 200)
 	doc := NewHTMLParser(t, resp.Body)
 	req = NewRequestWithValues(t, "POST", "/user/settings/applications", map[string]string{
 		"_csrf": doc.GetCSRF(),
@@ -274,8 +275,10 @@ func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	session.MakeRequest(t, req, http.StatusSeeOther)
 	req = NewRequest(t, "GET", "/user/settings/applications")
 	resp = session.MakeRequest(t, req, http.StatusOK)
+	assert.EqualValues(t, resp.Result().StatusCode, 200)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	token := htmlDoc.doc.Find(".ui.info p").Text()
+	assert.NotEmpty(t, token)
 	return token
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -258,12 +259,9 @@ func loginUserWithPassword(t testing.TB, userName, password string) *TestSession
 	return session
 }
 
-// token has to be unique this counter take care of
-var tokenCounter int64
-
 func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	t.Helper()
-	tokenCounter++
+	tokenCounter := rand.Int()
 	req := NewRequest(t, "GET", "/user/settings/applications")
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	doc := NewHTMLParser(t, resp.Body)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -266,7 +266,6 @@ func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	tokenCounter++
 	req := NewRequest(t, "GET", "/user/settings/applications")
 	resp := session.MakeRequest(t, req, http.StatusOK)
-	assert.EqualValues(t, resp.Result().StatusCode, 200)
 	doc := NewHTMLParser(t, resp.Body)
 	req = NewRequestWithValues(t, "POST", "/user/settings/applications", map[string]string{
 		"_csrf": doc.GetCSRF(),
@@ -275,7 +274,6 @@ func getTokenForLoggedInUser(t testing.TB, session *TestSession) string {
 	session.MakeRequest(t, req, http.StatusSeeOther)
 	req = NewRequest(t, "GET", "/user/settings/applications")
 	resp = session.MakeRequest(t, req, http.StatusOK)
-	assert.EqualValues(t, resp.Result().StatusCode, 200)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	token := htmlDoc.doc.Find(".ui.info p").Text()
 	assert.NotEmpty(t, token)


### PR DESCRIPTION
Added checks for logged user token.

Some builds fail at unrelated tests, due to missing token.

Example:
https://drone.gitea.io/go-gitea/gitea/62011/2/14