### PR TITLE
Ignore error when retrieving changed PR review files (#21487)

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1505,8 +1505,13 @@ func SyncAndGetUserSpecificDiff(ctx context.Context, userID int64, pull *issues_
 	}
 
 	changedFiles, err := gitRepo.GetFilesChangedBetween(review.CommitSHA, latestCommit)
+	// There are way too many possible errors.
+	// Examples are various git errors such as the commit the review was based on was gc'ed and hence doesn't exist anymore as well as unrecoverable errors where we should serve a 500 response
+	// Due to the current architecture and physical limitation of needing to compare explicit error messages, we can only choose one approach without the code getting ugly
+	// For SOME of the errors such as the gc'ed commit, it would be best to mark all files as changed
+	// But as that does not work for all potential errors, we simply mark all files as unchanged and drop the error which always works, even if not as good as possible
 	if err != nil {
-		return diff, err
+		log.Error("Could not get changed files between %s and %s for pull request %d in repo with path %s. Assuming no changes. Error: %w", review.CommitSHA, latestCommit, pull.Index, gitRepo.Path, err)
 	}
 
 	filesChangedSinceLastDiff := make(map[string]pull_model.ViewedState)


### PR DESCRIPTION
When a PR reviewer reviewed a file on a commit that was later gc'ed, they would always get a `500` response from then on when loading the PR. This PR simply ignores that error and instead marks all files as unchanged.
This approach was chosen as the only feasible option without diving into **a lot** of error handling.

Fixes #21392
Backport of #21487