### PR TITLE
Remove unnecessary debug log

### DIFF
--- a/modules/markup/markdown/meta.go
+++ b/modules/markup/markdown/meta.go
@@ -10,8 +10,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"code.gitea.io/gitea/modules/log"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -98,8 +96,6 @@ func ExtractMetadataBytes(contents []byte, out interface{}) ([]byte, error) {
 	if len(front) == 0 {
 		return contents, errors.New("could not determine metadata")
 	}
-
-	log.Info("%s", string(front))
 
 	if err := yaml.Unmarshal(front, out); err != nil {
 		return contents, err


### PR DESCRIPTION
It distractingly shows up on unit tests

* Looks like a leftover from #20571

![image](https://user-images.githubusercontent.com/20454870/197263223-bd205fe9-f48a-45e6-ad29-5df0edf41c67.png)
