### PR TITLE
CSS Font stack cleanup and enhancements

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -30,3 +30,4 @@ rules:
   shorthand-property-no-redundant-values: true
   string-quotes: null
   value-no-vendor-prefix: null
+  value-keyword-case: [lower, ignoreProperties: /^--/]

--- a/web_src/fomantic/_site/globals/site.variables
+++ b/web_src/fomantic/_site/globals/site.variables
@@ -1,7 +1,7 @@
 /* https://github.com/fomantic/Fomantic-UI/blob/develop/src/themes/default/globals/site.variables */
 
-@headerFont: var(--fonts-regular);
-@pageFont: var(--fonts-regular);
+@headerFont: var(--fonts-proportional);
+@pageFont: var(--fonts-proportional);
 @bold: 500;
 @useCustomScrollbars: false;
 @disabledOpacity: var(--opacity-disabled);

--- a/web_src/fomantic/build/semantic.css
+++ b/web_src/fomantic/build/semantic.css
@@ -176,7 +176,7 @@
   vertical-align: baseline;
   background: #E0E1E2 none;
   color: rgba(0, 0, 0, 0.6);
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   margin: 0 0.25em 0 0;
   padding: 0.78571429em 1.5em 0.78571429em;
   text-transform: none;
@@ -4932,7 +4932,7 @@
 .ui.card > .content > .header {
   display: block;
   margin: '';
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   color: rgba(0, 0, 0, 0.85);
 }
 
@@ -7372,7 +7372,7 @@ a.inverted.ui.card:hover,
 /* Text Container */
 
 .ui.text.container {
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   max-width: 700px;
   line-height: 1.5;
   font-size: 1.14285714rem;
@@ -10460,7 +10460,7 @@ select.ui.dropdown {
 .ui.form input[type="text"],
 .ui.form input[type="file"],
 .ui.form input[type="url"] {
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   margin: 0;
   outline: none;
   -webkit-appearance: none;
@@ -10492,7 +10492,7 @@ select.ui.dropdown {
   box-shadow: 0 0 0 0 transparent inset;
   transition: color 0.1s ease, border-color 0.1s ease;
   font-size: 1em;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   line-height: 1.2857;
   resize: vertical;
 }
@@ -14521,7 +14521,7 @@ select.ui.dropdown {
   border: none;
   margin: calc(2rem - 0.1428571428571429em) 0 1rem;
   padding: 0 0;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-weight: 500;
   line-height: 1.28571429em;
   text-transform: none;
@@ -24381,7 +24381,7 @@ i.icon.youtube.play:before {
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   text-align: left;
   line-height: 1.21428571em;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   padding: 0.67857143em 1em;
   background: #FFFFFF;
   border: 1px solid rgba(34, 36, 38, 0.15);
@@ -25263,7 +25263,7 @@ i.icon.youtube.play:before {
 .ui.items > .item > .content > .header {
   display: inline-block;
   margin: -0.21425em 0 0;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-weight: 500;
   color: rgba(0, 0, 0, 0.85);
 }
@@ -28300,7 +28300,7 @@ ol.ui.list ol li,
 .ui.list > .item .header {
   display: block;
   margin: 0;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-weight: 500;
   color: rgba(0, 0, 0, 0.87);
 }
@@ -30174,7 +30174,7 @@ ol.ui.suffixed.list li:before,
 .ui.menu {
   display: flex;
   margin: 1rem 0;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   background: #FFFFFF;
   font-weight: normal;
   border: 1px solid rgba(34, 36, 38, 0.15);
@@ -32627,7 +32627,7 @@ Floated Menu / Item
 
 .ui.message .header {
   display: block;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-weight: 500;
   margin: -0.14285714em 0 0 0;
 }
@@ -33353,7 +33353,7 @@ Floated Menu / Item
 
 .ui.modal > .header {
   display: block;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   background: #FFFFFF;
   margin: 0;
   padding: 1.25rem 1.5rem;
@@ -34649,7 +34649,7 @@ template {
 
 .ui.search > .results .result .title {
   margin: -0.14285714em 0 0;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-weight: 500;
   font-size: 1em;
   color: rgba(0, 0, 0, 0.85);
@@ -34675,7 +34675,7 @@ template {
 }
 
 .ui.search > .results > .message .header {
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-size: 1rem;
   font-weight: 500;
   color: rgba(0, 0, 0, 0.87);
@@ -34883,7 +34883,7 @@ template {
   width: 100px;
   white-space: nowrap;
   background: transparent;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-size: 1em;
   padding: 0.4em 1em;
   font-weight: 500;
@@ -36032,7 +36032,7 @@ body {
   overflow-x: hidden;
   min-width: 320px;
   background: #FFFFFF;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   font-size: 14px;
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
@@ -36047,7 +36047,7 @@ h2,
 h3,
 h4,
 h5 {
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   line-height: 1.28571429em;
   margin: calc(2rem - 0.1428571428571429em) 0 1rem;
   font-weight: 500;

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1,7 +1,7 @@
 :root {
   /* fonts */
-  --fonts-proportional: -apple-system, "Segoe UI", system-ui, "Roboto", "Helvetica Neue", "Arial";
-  --fonts-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace, var(--fonts-emoji);
+  --fonts-proportional: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, var(--fonts-emoji);
+  --fonts-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace, var(--fonts-emoji);
   --fonts-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji Mozilla";
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
@@ -168,12 +168,9 @@
   --color-active-line: #fffbdd;
 }
 
-:root * {
-  --fonts-regular: var(--fonts-override, var(--fonts-proportional)), "Noto Sans", "Liberation Sans", sans-serif, var(--fonts-emoji);
-}
-
+/* There is a rule that sets --fonts-proportional on body in Fomantic UI */
 textarea {
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
 }
 
 pre,
@@ -1775,7 +1772,7 @@ a.ui.label:hover {
 
     .blame-data {
       display: flex;
-      font-family: var(--fonts-regular);
+      font-family: var(--fonts-proportional);
 
       .blame-message {
         flex-grow: 2;

--- a/web_src/less/_font_i18n.less
+++ b/web_src/less/_font_i18n.less
@@ -1,35 +1,35 @@
 /* global */
 :root[lang^="ja"] {
-  --fonts-proportional: var(--fonts-default-override-ja), var(--fonts-emoji);
+  --fonts-proportional: var(--fonts-default-override-ja), sans-serif, var(--fonts-emoji);
 }
 :root[lang^="ko"] {
-  --fonts-proportional: var(--fonts-default-override-ko), var(--fonts-emoji);
+  --fonts-proportional: var(--fonts-default-override-ko), sans-serif, var(--fonts-emoji);
 }
 :root[lang="zh-CN"] {
-  --fonts-proportional: var(--fonts-default-override-zh-cn), var(--fonts-emoji);
+  --fonts-proportional: var(--fonts-default-override-zh-cn), sans-serif, var(--fonts-emoji);
 }
 :root[lang="zh-TW"] {
-  --fonts-proportional: var(--fonts-default-override-zh-tw), var(--fonts-emoji);
+  --fonts-proportional: var(--fonts-default-override-zh-tw), sans-serif, var(--fonts-emoji);
 }
 :root[lang="zh-HK"] {
-  --fonts-proportional: var(--fonts-default-override-zh-hk), var(--fonts-emoji);
+  --fonts-proportional: var(--fonts-default-override-zh-hk), sans-serif, var(--fonts-emoji);
 }
 
 /* element-specific */
 :lang(ja) {
-  font-family: var(--fonts-default-override-ja), var(--fonts-emoji);
+  font-family: var(--fonts-default-override-ja), sans-serif, var(--fonts-emoji);
 }
 :lang(ko) {
-  font-family: var(--fonts-default-override-ko), var(--fonts-emoji);
+  font-family: var(--fonts-default-override-ko), sans-serif, var(--fonts-emoji);
 }
 :lang(zh-CN) {
-  font-family: var(--fonts-default-override-zh-cn), var(--fonts-emoji);
+  font-family: var(--fonts-default-override-zh-cn), sans-serif, var(--fonts-emoji);
 }
 :lang(zh-TW) {
-  font-family: var(--fonts-default-override-zh-tw), var(--fonts-emoji);
+  font-family: var(--fonts-default-override-zh-tw), sans-serif, var(--fonts-emoji);
 }
 :lang(zh-HK) {
-  font-family: var(--fonts-default-override-zh-hk), var(--fonts-emoji);
+  font-family: var(--fonts-default-override-zh-hk), sans-serif, var(--fonts-emoji);
 }
 
 each(@fonts, {

--- a/web_src/less/_font_i18n.less
+++ b/web_src/less/_font_i18n.less
@@ -1,25 +1,35 @@
-/* font i18n */
-:root {
-  /* customizable localized variables */
-  :lang(ja) {
-    --fonts-override: var(--fonts-default-override-ja);
-  }
-  :lang(zh-CN) {
-    --fonts-override: var(--fonts-default-override-zh-cn);
-  }
-  :lang(zh-TW) {
-    --fonts-override: var(--fonts-default-override-zh-tw);
-  }
-  :lang(zh-HK) {
-    --fonts-override: var(--fonts-default-override-zh-hk);
-  }
-  :lang(ko) {
-    --fonts-override: var(--fonts-default-override-ko);
-  }
+/* global */
+:root[lang^="ja"] {
+  --fonts-proportional: var(--fonts-default-override-ja), var(--fonts-emoji);
+}
+:root[lang^="ko"] {
+  --fonts-proportional: var(--fonts-default-override-ko), var(--fonts-emoji);
+}
+:root[lang="zh-CN"] {
+  --fonts-proportional: var(--fonts-default-override-zh-cn), var(--fonts-emoji);
+}
+:root[lang="zh-TW"] {
+  --fonts-proportional: var(--fonts-default-override-zh-tw), var(--fonts-emoji);
+}
+:root[lang="zh-HK"] {
+  --fonts-proportional: var(--fonts-default-override-zh-hk), var(--fonts-emoji);
 }
 
-[lang] {
-  font-family: var(--fonts-regular);
+/* element-specific */
+:lang(ja) {
+  font-family: var(--fonts-default-override-ja), var(--fonts-emoji);
+}
+:lang(ko) {
+  font-family: var(--fonts-default-override-ko), var(--fonts-emoji);
+}
+:lang(zh-CN) {
+  font-family: var(--fonts-default-override-zh-cn), var(--fonts-emoji);
+}
+:lang(zh-TW) {
+  font-family: var(--fonts-default-override-zh-tw), var(--fonts-emoji);
+}
+:lang(zh-HK) {
+  font-family: var(--fonts-default-override-zh-hk), var(--fonts-emoji);
 }
 
 each(@fonts, {

--- a/web_src/less/code/linebutton.less
+++ b/web_src/less/code/linebutton.less
@@ -13,7 +13,7 @@
   border-radius: var(--border-radius);
   padding: 1px 10px;
   position: absolute;
-  font-family: var(--fonts-regular);
+  font-family: var(--fonts-proportional);
   left: 0;
   transform: translateX(-70%);
   cursor: pointer;


### PR DESCRIPTION
- Update system font stack to latest from Bootstrap
- Eliminate confusing `--fonts-regular`, remove associated wildcard selector
- Set language-specifc fonts directly on root tag and elements with `lang` attribute

Everything should work as before, but now it's easier for themes to override fonts because everything is defined on `:root`.

Note: I'm pretty sure a lot of stuff in `web_src/less/_font_i18n.less` may be over-complicated/obsolete but I don't really understand enough of asian browsers to be able to touch it.