### PR TITLE
Link mentioned user in markdown only if they are visible to viewer

### DIFF
--- a/services/markup/processorhelper.go
+++ b/services/markup/processorhelper.go
@@ -8,8 +8,7 @@ import (
 	"context"
 
 	"code.gitea.io/gitea/models/user"
-	module_context "code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/log"
+	gitea_context "code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/markup"
 )
 
@@ -21,13 +20,14 @@ func ProcessorHelper() *markup.ProcessorHelper {
 				return false
 			}
 
-			moduleCtx, ok := ctx.(*module_context.Context)
+			giteaCtx, ok := ctx.(*gitea_context.Context)
 			if !ok {
-				log.Warn("couldn't cast context, assuming user should be visible based on their visibility")
+				// when using general context, use user's visibility to check
 				return mentionedUser.Visibility.IsPublic()
 			}
 
-			return user.IsUserVisibleToViewer(moduleCtx, mentionedUser, moduleCtx.Doer)
+			// when using gitea context (web context), use user's visibility and user's permission to check
+			return user.IsUserVisibleToViewer(giteaCtx, mentionedUser, giteaCtx.Doer)
 		},
 	}
 }

--- a/services/markup/processorhelper.go
+++ b/services/markup/processorhelper.go
@@ -9,6 +9,7 @@ import (
 
 	"code.gitea.io/gitea/models/user"
 	module_context "code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 )
 
@@ -22,7 +23,8 @@ func ProcessorHelper() *markup.ProcessorHelper {
 
 			moduleCtx, ok := ctx.(*module_context.Context)
 			if !ok {
-				return false
+				log.Error("couldn't cast context, assuming user should be visible based on their visibility")
+				return mentionedUser.Visibility.IsPublic()
 			}
 
 			return user.IsUserVisibleToViewer(moduleCtx, mentionedUser, moduleCtx.Doer)

--- a/services/markup/processorhelper.go
+++ b/services/markup/processorhelper.go
@@ -8,22 +8,24 @@ import (
 	"context"
 
 	"code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/log"
+	module_context "code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/markup"
 )
 
 func ProcessorHelper() *markup.ProcessorHelper {
 	return &markup.ProcessorHelper{
 		IsUsernameMentionable: func(ctx context.Context, username string) bool {
-			// TODO: cast ctx to modules/context.Context and use IsUserVisibleToViewer
-
-			// Only link if the user actually exists
-			userExists, err := user.IsUserExist(ctx, 0, username)
+			mentionedUser, err := user.GetUserByName(ctx, username)
 			if err != nil {
-				log.Error("Failed to validate user in mention %q exists, assuming it does", username)
-				userExists = true
+				return false
 			}
-			return userExists
+
+			moduleCtx, ok := ctx.(*module_context.Context)
+			if !ok {
+				return false
+			}
+
+			return user.IsUserVisibleToViewer(moduleCtx, mentionedUser, moduleCtx.Doer)
 		},
 	}
 }

--- a/services/markup/processorhelper.go
+++ b/services/markup/processorhelper.go
@@ -23,7 +23,7 @@ func ProcessorHelper() *markup.ProcessorHelper {
 
 			moduleCtx, ok := ctx.(*module_context.Context)
 			if !ok {
-				log.Error("couldn't cast context, assuming user should be visible based on their visibility")
+				log.Warn("couldn't cast context, assuming user should be visible based on their visibility")
 				return mentionedUser.Visibility.IsPublic()
 			}
 

--- a/services/markup/processorhelper_test.go
+++ b/services/markup/processorhelper_test.go
@@ -5,16 +5,16 @@
 package markup
 
 import (
+	"context"
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
-	"code.gitea.io/gitea/modules/context"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessorHelper(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
-	assert.True(t, ProcessorHelper().IsUsernameMentionable(&context.Context{}, "user10"))
-	assert.False(t, ProcessorHelper().IsUsernameMentionable(&context.Context{}, "no-such-user"))
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "user10"))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "no-such-user"))
 }

--- a/services/markup/processorhelper_test.go
+++ b/services/markup/processorhelper_test.go
@@ -6,15 +6,48 @@ package markup
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/models/user"
+	gitea_context "code.gitea.io/gitea/modules/context"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessorHelper(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
-	assert.True(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "user10"))
-	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "no-such-user"))
+
+	userPublic := "user1"
+	userPrivate := "user31"
+	userLimited := "user33"
+	userNoSuch := "no-such-user"
+
+	unittest.AssertCount(t, &user.User{Name: userPublic}, 1)
+	unittest.AssertCount(t, &user.User{Name: userPrivate}, 1)
+	unittest.AssertCount(t, &user.User{Name: userLimited}, 1)
+	unittest.AssertCount(t, &user.User{Name: userNoSuch}, 0)
+
+	// when using general context, use user's visibility to check
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userPublic))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userLimited))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userPrivate))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userNoSuch))
+
+	// when using web context, use user's visibility to check
+	var err error
+	giteaCtx := &gitea_context.Context{}
+	giteaCtx.Req, err = http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+
+	giteaCtx.Doer = nil
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPublic))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPrivate))
+
+	giteaCtx.Doer, err = user.GetUserByName(db.DefaultContext, userPrivate)
+	assert.NoError(t, err)
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPublic))
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPrivate))
 }

--- a/services/markup/processorhelper_test.go
+++ b/services/markup/processorhelper_test.go
@@ -5,16 +5,16 @@
 package markup
 
 import (
-	"context"
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/context"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessorHelper(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
-	assert.True(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "user10"))
-	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), "no-such-user"))
+	assert.True(t, ProcessorHelper().IsUsernameMentionable(&context.Context{}, "user10"))
+	assert.False(t, ProcessorHelper().IsUsernameMentionable(&context.Context{}, "no-such-user"))
 }

--- a/services/markup/processorhelper_test.go
+++ b/services/markup/processorhelper_test.go
@@ -36,7 +36,7 @@ func TestProcessorHelper(t *testing.T) {
 	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userPrivate))
 	assert.False(t, ProcessorHelper().IsUsernameMentionable(context.Background(), userNoSuch))
 
-	// when using web context, use user's visibility to check
+	// when using web context, use user.IsUserVisibleToViewer to check
 	var err error
 	giteaCtx := &gitea_context.Context{}
 	giteaCtx.Req, err = http.NewRequest("GET", "/", nil)


### PR DESCRIPTION
We need to make sure a user can't confirm the existence of a user with private visibility

* Follow up on #21533 

### Before

<details>

#### User
![image](https://user-images.githubusercontent.com/20454870/197357580-340911d7-1659-4fc9-a9f6-7ed6bc3476b4.png)

#### Admin
![image](https://user-images.githubusercontent.com/20454870/197357676-a8f0ae63-8f80-4221-a9b5-b6311552910a.png)

</details>

### After

#### User
![image](https://user-images.githubusercontent.com/20454870/197357536-05616edb-7821-469d-8e51-6f8cb84c1362.png)

#### Admin
![image](https://user-images.githubusercontent.com/20454870/197357703-071fe984-de79-43aa-a77c-a85b046292a4.png)
