### PR TITLE
SessionUser protection against nil pointer dereference

### DIFF
--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -30,10 +30,6 @@ func (s *Session) Name() string {
 // object for that uid.
 // Returns nil if there is no user uid stored in the session.
 func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
-	if sess == nil {
-		return nil
-	}
-
 	user := SessionUser(sess)
 	if user != nil {
 		return user
@@ -43,6 +39,10 @@ func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataSto
 
 // SessionUser returns the user object corresponding to the "uid" session variable.
 func SessionUser(sess SessionStore) *user_model.User {
+	if sess == nil {
+		return nil
+	}
+
 	// Get user ID
 	uid := sess.Get("uid")
 	if uid == nil {

--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Gitea Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Gitea Authors. All rights reserved.
+// Copyright 2022 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -30,6 +30,10 @@ func (s *Session) Name() string {
 // object for that uid.
 // Returns nil if there is no user uid stored in the session.
 func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
+	if sess == nil {
+		return nil
+	}
+
 	user := SessionUser(sess)
 	if user != nil {
 		return user


### PR DESCRIPTION
Backport #21358 

`SessionUser` should be protected against passing `sess` = `nil` to avoid

```
PANIC: runtime error: invalid memory address or nil pointer dereference
```

in

https://github.com/go-gitea/gitea/pull/18452/files#diff-a215b82aadeb8b4c4632fcf31215dd421f804eb1c0137ec6721b980136e4442aR69

after upgrade from gitea v1.16 to v1.17.

Related: https://github.com/go-gitea/gitea/pull/18452

