### PR TITLE
Revert "Do not send notifications for draft releases (#21451)"

### DIFF
--- a/services/release/release.go
+++ b/services/release/release.go
@@ -271,12 +271,13 @@ func UpdateRelease(doer *user_model.User, gitRepo *git.Repository, rel *repo_mod
 		}
 	}
 
+	if !isCreated {
+		notification.NotifyUpdateRelease(doer, rel)
+		return
+	}
+
 	if !rel.IsDraft {
-		if isCreated {
-			notification.NotifyNewRelease(rel)
-		} else {
-			notification.NotifyUpdateRelease(doer, rel)
-		}
+		notification.NotifyNewRelease(rel)
 	}
 
 	return err
@@ -352,9 +353,7 @@ func DeleteReleaseByID(ctx context.Context, id int64, doer *user_model.User, del
 		}
 	}
 
-	if !rel.IsDraft {
-		notification.NotifyDeleteRelease(doer, rel)
-	}
+	notification.NotifyDeleteRelease(doer, rel)
 
 	return nil
 }


### PR DESCRIPTION
This reverts commit a37e8b275d19c0daf160cc540d981ec4f3025a5a / #21451

Temporarily revert this PR to be able to continue discussion, and potentially get it into 1.19.0