### PR TITLE
Fix `Timestamp.IsZero` (#21593)

### DIFF
--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -103,5 +103,5 @@ func (ts TimeStamp) FormatDate() string {
 
 // IsZero is zero time
 func (ts TimeStamp) IsZero() bool {
-	return ts.AsTimeInLocation(time.Local).IsZero()
+	return int64(ts) == 0
 }


### PR DESCRIPTION
Backport of #21593