### PR TITLE
Fix 500 on PR files API (#21602)

### DIFF
--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1443,7 +1443,11 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 		end = totalNumberOfFiles
 	}
 
-	apiFiles := make([]*api.ChangedFile, 0, end-start)
+	lenFiles := end - start
+	if lenFiles < 0 {
+		lenFiles = 0
+	}
+	apiFiles := make([]*api.ChangedFile, 0, lenFiles)
 	for i := start; i < end; i++ {
 		apiFiles = append(apiFiles, convert.ToChangedFile(diff.Files[i], pr.HeadRepo, endCommitID))
 	}


### PR DESCRIPTION
Fixes an 500 error/panic if using the changed PR files API with pages that should return empty lists because there are no items anymore. `start-end` is then < 0 which ends in panic.

Backport https://github.com/go-gitea/gitea/pull/21602

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
