### PR TITLE
Sync git hooks when config file path changed (#21619)

### DIFF
--- a/modules/appstate/item_runtime.go
+++ b/modules/appstate/item_runtime.go
@@ -6,7 +6,8 @@ package appstate
 
 // RuntimeState contains app state for runtime, and we can save remote version for update checker here in future
 type RuntimeState struct {
-	LastAppPath string `json:"last_app_path"`
+	LastAppPath    string `json:"last_app_path"`
+	LastCustomConf string `json:"last_custom_conf"`
 }
 
 // Name returns the item name


### PR DESCRIPTION
Backport #21619 .

A patch to #17335.

Just like AppPath, Gitea writes its own CustomConf into git hook scripts too. If Gitea's CustomConf changes, then the git push may fail.

Co-authored-by: techknowlogick <techknowlogick@gitea.io>