### PR TITLE
Sync git hooks when config file path changed (#21619)

### DIFF
--- a/modules/system/item_runtime.go
+++ b/modules/system/item_runtime.go
@@ -6,7 +6,8 @@ package system
 
 // RuntimeState contains app state for runtime, and we can save remote version for update checker here in future
 type RuntimeState struct {
-	LastAppPath string `json:"last_app_path"`
+	LastAppPath    string `json:"last_app_path"`
+	LastCustomConf string `json:"last_custom_conf"`
 }
 
 // Name returns the item name

--- a/routers/init.go
+++ b/routers/init.go
@@ -76,21 +76,31 @@ func InitGitServices() {
 	mustInit(repo_service.Init)
 }
 
-func syncAppPathForGit(ctx context.Context) error {
+func syncAppConfForGit(ctx context.Context) error {
 	runtimeState := new(system.RuntimeState)
 	if err := system.AppState.Get(runtimeState); err != nil {
 		return err
 	}
+
+	updated := false
 	if runtimeState.LastAppPath != setting.AppPath {
 		log.Info("AppPath changed from '%s' to '%s'", runtimeState.LastAppPath, setting.AppPath)
+		runtimeState.LastAppPath = setting.AppPath
+		updated = true
+	}
+	if runtimeState.LastCustomConf != setting.CustomConf {
+		log.Info("CustomConf changed from '%s' to '%s'", runtimeState.LastCustomConf, setting.CustomConf)
+		runtimeState.LastCustomConf = setting.CustomConf
+		updated = true
+	}
 
+	if updated {
 		log.Info("re-sync repository hooks ...")
 		mustInitCtx(ctx, repo_service.SyncRepositoryHooks)
 
 		log.Info("re-write ssh public keys ...")
 		mustInit(asymkey_model.RewriteAllPublicKeys)
 
-		runtimeState.LastAppPath = setting.AppPath
 		return system.AppState.Set(runtimeState)
 	}
 	return nil
@@ -153,7 +163,7 @@ func GlobalInitInstalled(ctx context.Context) {
 	mustInit(repo_migrations.Init)
 	eventsource.GetManager().Init()
 
-	mustInitCtx(ctx, syncAppPathForGit)
+	mustInitCtx(ctx, syncAppConfForGit)
 
 	mustInit(ssh.Init)
 


### PR DESCRIPTION
Backport #21619 .

A patch to #17335.

Just like AppPath, Gitea writes its own CustomConf into git hook scripts too. If Gitea's CustomConf changes, then the git push may fail.

Co-authored-by: techknowlogick <techknowlogick@gitea.io>

