### PR TITLE
Deal with markdown template without metadata

### DIFF
--- a/modules/issue/template/unmarshal.go
+++ b/modules/issue/template/unmarshal.go
@@ -100,8 +100,8 @@ func unmarshal(filename string, content []byte) (*api.IssueTemplate, error) {
 			it.Content = string(content)
 			it.Name = filepath.Base(it.FileName)
 			it.About = it.Content
-			if max := 80; len(it.About) > max {
-				it.About = it.About[:max] + "..."
+			if max, runes := 80, []rune(it.About); len(runes) > max {
+				it.About = string(runes[:max]) + "..."
 			}
 		} else {
 			it.Content = templateBody

--- a/modules/issue/template/unmarshal.go
+++ b/modules/issue/template/unmarshal.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 
 	"gopkg.in/yaml.v2"
 )
@@ -96,13 +97,20 @@ func unmarshal(filename string, content []byte) (*api.IssueTemplate, error) {
 
 	if typ := it.Type(); typ == api.IssueTemplateTypeMarkdown {
 		if templateBody, err := markdown.ExtractMetadata(string(content), it); err != nil {
-			// can't extract metadata, so it could be a pure markdown.
+			// The only thing we know here is that we can't extract metadata from the content,
+			// it's hard to tell if metadata doesn't exist or metadata isn't valid.
+			// There's an example template:
+			//
+			//    ---
+			//    # Title
+			//    ---
+			//    Content
+			//
+			// It could be a valid markdown with two horizontal lines, or an invalid markdown with wrong metadata.
+
 			it.Content = string(content)
 			it.Name = filepath.Base(it.FileName)
-			it.About = it.Content
-			if max, runes := 80, []rune(it.About); len(runes) > max {
-				it.About = string(runes[:max]) + "..."
-			}
+			it.About, _ = util.SplitStringAtByteN(it.Content, 80)
 		} else {
 			it.Content = templateBody
 			if it.About == "" {

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -170,7 +170,7 @@ func (it IssueTemplate) Type() IssueTemplateType {
 	if ext := filepath.Ext(it.FileName); ext == ".md" {
 		return IssueTemplateTypeMarkdown
 	} else if ext == ".yaml" || ext == ".yml" {
-		return "yaml"
+		return IssueTemplateTypeYaml
 	}
-	return IssueTemplateTypeYaml
+	return ""
 }


### PR DESCRIPTION
Fixed #21636.

Related to #20987.

A markdown template without metadata should not be treated as an invalid template.

And this PR fixed another bug that non-template files(neither .md nor .yaml) are treated as yaml files.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/9418365/198968668-40082fa1-4f25-4d3e-9b73-1dbf6d1a7521.png">

