### PR TITLE
Deal with markdown template without metadata (#21639)

### DIFF
--- a/modules/issue/template/unmarshal.go
+++ b/modules/issue/template/unmarshal.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 
 	"gopkg.in/yaml.v2"
 )
@@ -95,14 +96,27 @@ func unmarshal(filename string, content []byte) (*api.IssueTemplate, error) {
 	}{}
 
 	if typ := it.Type(); typ == api.IssueTemplateTypeMarkdown {
-		templateBody, err := markdown.ExtractMetadata(string(content), it)
-		if err != nil {
-			return nil, err
-		}
-		it.Content = templateBody
-		if it.About == "" {
-			if _, err := markdown.ExtractMetadata(string(content), compatibleTemplate); err == nil && compatibleTemplate.About != "" {
-				it.About = compatibleTemplate.About
+		if templateBody, err := markdown.ExtractMetadata(string(content), it); err != nil {
+			// The only thing we know here is that we can't extract metadata from the content,
+			// it's hard to tell if metadata doesn't exist or metadata isn't valid.
+			// There's an example template:
+			//
+			//    ---
+			//    # Title
+			//    ---
+			//    Content
+			//
+			// It could be a valid markdown with two horizontal lines, or an invalid markdown with wrong metadata.
+
+			it.Content = string(content)
+			it.Name = filepath.Base(it.FileName)
+			it.About, _ = util.SplitStringAtByteN(it.Content, 80)
+		} else {
+			it.Content = templateBody
+			if it.About == "" {
+				if _, err := markdown.ExtractMetadata(string(content), compatibleTemplate); err == nil && compatibleTemplate.About != "" {
+					it.About = compatibleTemplate.About
+				}
 			}
 		}
 	} else if typ == api.IssueTemplateTypeYaml {

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -170,7 +170,7 @@ func (it IssueTemplate) Type() IssueTemplateType {
 	if ext := filepath.Ext(it.FileName); ext == ".md" {
 		return IssueTemplateTypeMarkdown
 	} else if ext == ".yaml" || ext == ".yml" {
-		return "yaml"
+		return IssueTemplateTypeYaml
 	}
-	return IssueTemplateTypeYaml
+	return ""
 }


### PR DESCRIPTION
Backport #21639 .

Fixed #21636.

Related to #20987.

A markdown template without metadata should not be treated as an invalid template.

And this PR fixed another bug that non-template files(neither .md nor .yaml) are treated as yaml files.

<img width="504" alt="image"
src="https://user-images.githubusercontent.com/9418365/198968668-40082fa1-4f25-4d3e-9b73-1dbf6d1a7521.png">
