### PR TITLE
Configure update checker on installation page

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -238,8 +238,8 @@ no_reply_address = Hidden Email Domain
 no_reply_address_helper = Domain name for users with a hidden email address. For example, the username 'joe' will be logged in Git as 'joe@noreply.example.org' if the hidden email domain is set to 'noreply.example.org'.
 password_algorithm = Password Hash Algorithm
 password_algorithm_helper = Set the password hashing algorithm. Algorithms have differing requirements and strength. `argon2` whilst having good characteristics uses a lot of memory and may be inappropriate for small systems.
-enable_update_checker = Enable the update checker
-enable_update_checker_popup = Checks for new version releases periodically by connecting to gitea.io
+enable_update_checker = Enable Update Checker
+enable_update_checker_helper = Checks for new version releases periodically by connecting to gitea.io.
 
 [home]
 uname_holder = Username or Email Address

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -238,6 +238,8 @@ no_reply_address = Hidden Email Domain
 no_reply_address_helper = Domain name for users with a hidden email address. For example, the username 'joe' will be logged in Git as 'joe@noreply.example.org' if the hidden email domain is set to 'noreply.example.org'.
 password_algorithm = Password Hash Algorithm
 password_algorithm_helper = Set the password hashing algorithm. Algorithms have differing requirements and strength. `argon2` whilst having good characteristics uses a lot of memory and may be inappropriate for small systems.
+enable_update_checker = Enable the update checker
+enable_update_checker_helper = Checks for new version releases periodically by connecting to gitea.io
 
 [home]
 uname_holder = Username or Email Address

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -239,7 +239,7 @@ no_reply_address_helper = Domain name for users with a hidden email address. For
 password_algorithm = Password Hash Algorithm
 password_algorithm_helper = Set the password hashing algorithm. Algorithms have differing requirements and strength. `argon2` whilst having good characteristics uses a lot of memory and may be inappropriate for small systems.
 enable_update_checker = Enable the update checker
-enable_update_checker_helper = Checks for new version releases periodically by connecting to gitea.io
+enable_update_checker_popup = Checks for new version releases periodically by connecting to gitea.io
 
 [home]
 uname_holder = Username or Email Address

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -457,6 +457,7 @@ func SubmitInstall(ctx *context.Context) {
 	cfg.Section("service").Key("DEFAULT_ALLOW_CREATE_ORGANIZATION").SetValue(fmt.Sprint(form.DefaultAllowCreateOrganization))
 	cfg.Section("service").Key("DEFAULT_ENABLE_TIMETRACKING").SetValue(fmt.Sprint(form.DefaultEnableTimetracking))
 	cfg.Section("service").Key("NO_REPLY_ADDRESS").SetValue(fmt.Sprint(form.NoReplyAddress))
+	cfg.Section("cron.update_checker").Key("ENABLED").SetValue(fmt.Sprint(form.EnableUpdateChecker))
 
 	cfg.Section("").Key("RUN_MODE").SetValue("prod")
 

--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -151,7 +151,7 @@ func registerUpdateGiteaChecker() {
 	}
 	RegisterTaskFatal("update_checker", &UpdateCheckerConfig{
 		BaseConfig: BaseConfig{
-			Enabled:    true,
+			Enabled:    false,
 			RunAtStart: false,
 			Schedule:   "@every 168h",
 		},

--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -151,7 +151,7 @@ func registerUpdateGiteaChecker() {
 	}
 	RegisterTaskFatal("update_checker", &UpdateCheckerConfig{
 		BaseConfig: BaseConfig{
-			Enabled:    false,
+			Enabled:    true,
 			RunAtStart: false,
 			Schedule:   "@every 168h",
 		},

--- a/services/forms/user_form.go
+++ b/services/forms/user_form.go
@@ -60,6 +60,7 @@ type InstallForm struct {
 	DefaultKeepEmailPrivate        bool
 	DefaultAllowCreateOrganization bool
 	DefaultEnableTimetracking      bool
+	EnableUpdateChecker            bool
 	NoReplyAddress                 string
 
 	PasswordAlgorithm string

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -163,6 +163,7 @@
 						<span class="help">{{.locale.Tr "install.log_root_path_helper"}}</span>
 					</div>
 
+
 					<!-- Optional Settings -->
 					<h4 class="ui dividing header">{{.locale.Tr "install.optional_title"}}</h4>
 

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -285,7 +285,7 @@
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.locale.Tr "install.enable_update_checker_helper"}}"><strong>{{.locale.Tr "install.enable_update_checker"}}</strong></label>
+								<label class="tooltip" data-content="{{.locale.Tr "install.enable_update_checker_popup"}}"><strong>{{.locale.Tr "install.enable_update_checker"}}</strong></label>
 								<input name="enable_update_checker" type="checkbox" {{if .enable_update_checker}}checked{{end}}>
 							</div>
 						</div>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -165,7 +165,7 @@
 					<div class="inline field">
 						<label for="enable_update_checker">{{.locale.Tr "install.enable_update_checker"}}</label>
 						<div class="ui checkbox">
-							<input name="enable_update_checker" type="checkbox" {{if .enable_update_checker}}checked{{end}}>
+							<input name="enable_update_checker" type="checkbox">
 						</div>
 						<span class="help">{{.locale.Tr "install.enable_update_checker_helper"}}</span>
 					</div>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -163,7 +163,6 @@
 						<span class="help">{{.locale.Tr "install.log_root_path_helper"}}</span>
 					</div>
 
-
 					<!-- Optional Settings -->
 					<h4 class="ui dividing header">{{.locale.Tr "install.optional_title"}}</h4>
 
@@ -282,6 +281,12 @@
 							<div class="ui checkbox">
 								<label class="tooltip" data-content="{{.locale.Tr "install.default_enable_timetracking_popup"}}"><strong>{{.locale.Tr "install.default_enable_timetracking"}}</strong></label>
 								<input name="default_enable_timetracking" type="checkbox" {{if .default_enable_timetracking}}checked{{end}}>
+							</div>
+						</div>
+						<div class="inline field">
+							<div class="ui checkbox">
+								<label class="tooltip" data-content="{{.locale.Tr "install.enable_update_checker_helper"}}"><strong>{{.locale.Tr "install.enable_update_checker"}}</strong></label>
+								<input name="enable_update_checker" type="checkbox" {{if .enable_update_checker}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -162,6 +162,13 @@
 						<input id="log_root_path" name="log_root_path" value="{{.log_root_path}}" placeholder="log" required>
 						<span class="help">{{.locale.Tr "install.log_root_path_helper"}}</span>
 					</div>
+					<div class="inline field">
+						<label for="enable_update_checker">{{.locale.Tr "install.enable_update_checker"}}</label>
+						<div class="ui checkbox">
+							<input name="enable_update_checker" type="checkbox" {{if .enable_update_checker}}checked{{end}}>
+						</div>
+						<span class="help">{{.locale.Tr "install.enable_update_checker_helper"}}</span>
+					</div>
 
 
 					<!-- Optional Settings -->
@@ -282,12 +289,6 @@
 							<div class="ui checkbox">
 								<label class="tooltip" data-content="{{.locale.Tr "install.default_enable_timetracking_popup"}}"><strong>{{.locale.Tr "install.default_enable_timetracking"}}</strong></label>
 								<input name="default_enable_timetracking" type="checkbox" {{if .default_enable_timetracking}}checked{{end}}>
-							</div>
-						</div>
-						<div class="inline field">
-							<div class="ui checkbox">
-								<label class="tooltip" data-content="{{.locale.Tr "install.enable_update_checker_popup"}}"><strong>{{.locale.Tr "install.enable_update_checker"}}</strong></label>
-								<input name="enable_update_checker" type="checkbox" {{if .enable_update_checker}}checked{{end}}>
 							</div>
 						</div>
 						<div class="inline field">


### PR DESCRIPTION
- I recently became aware that this was enabled by-default, I don't necessary agree with that and this should rather be configured by the user(this patch does that on the installation page) as it connects to a homeserver, which I'd prefer to avoid on my instance.

![image](https://user-images.githubusercontent.com/25481501/199260613-a77a1b10-347a-4542-8982-9b9b24dad28c.png)

