### PR TITLE
Align label with checkbox

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -162,7 +162,7 @@
 						<input id="log_root_path" name="log_root_path" value="{{.log_root_path}}" placeholder="log" required>
 						<span class="help">{{.locale.Tr "install.log_root_path_helper"}}</span>
 					</div>
-					<div class="inline field">
+					<div class="inline field left-label">
 						<label for="enable_update_checker">{{.locale.Tr "install.enable_update_checker"}}</label>
 						<div class="ui checkbox">
 							<input name="enable_update_checker" type="checkbox">

--- a/web_src/less/_install.less
+++ b/web_src/less/_install.less
@@ -20,6 +20,11 @@
         margin-left: @input-padding+15px;
       }
 
+      &.left-label label {
+        vertical-align: top;
+        line-height: 17px;
+      }
+
       &.optional {
         .title {
           margin-left: 38%;


### PR DESCRIPTION
- Follow up from https://github.com/go-gitea/gitea/pull/21655#issuecomment-1299428018
- Use vertical-align and line-height to get it to align exactly with the checkbox.

![image](https://user-images.githubusercontent.com/25481501/199441356-84014561-8a6f-4a82-989d-72ea54cb4393.png)

