### PR TITLE
Alter package_version.metadata_json to LONGTEXT

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -433,6 +433,8 @@ var migrations = []Migration{
 	NewMigration("Add ConfidentialClient column (default true) to OAuth2Application table", v1_18.AddConfidentialClientColumnToOAuth2ApplicationTable),
 	// v231 -> v232
 	NewMigration("Add index for hook_task", v1_19.AddIndexForHookTask),
+	// v232 -> v233
+	NewMigration("Alter package_version.metadata_json to LONGTEXT", v1_19.AlterPackageVersionMetadataToLongText),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v1_19/v232.go
+++ b/models/migrations/v1_19/v232.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package v1_19 // nolint
+
+import (
+	"code.gitea.io/gitea/modules/setting"
+
+	"xorm.io/xorm"
+)
+
+func AlterPackageVersionMetadataToLongText(x *xorm.Engine) error {
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	if setting.Database.UseMySQL {
+		if _, err := sess.Exec("ALTER TABLE `package_version` MODIFY COLUMN `metadata_json` LONGTEXT"); err != nil {
+			return err
+		}
+	}
+	return sess.Commit()
+}

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -33,7 +33,7 @@ type PackageVersion struct {
 	LowerVersion  string             `xorm:"UNIQUE(s) INDEX NOT NULL"`
 	CreatedUnix   timeutil.TimeStamp `xorm:"created INDEX NOT NULL"`
 	IsInternal    bool               `xorm:"INDEX NOT NULL DEFAULT false"`
-	MetadataJSON  string             `xorm:"metadata_json TEXT"`
+	MetadataJSON  string             `xorm:"metadata_json LONGTEXT"`
 	DownloadCount int64              `xorm:"NOT NULL DEFAULT 0"`
 }
 


### PR DESCRIPTION
Fixes #21664

How do we get this migration into 1.18 and 1.17.x?
