### PR TITLE
Add the local identifier to the pypi version regex

### DIFF
--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -26,7 +26,7 @@ var normalizer = strings.NewReplacer(".", "-", "_", "-")
 var nameMatcher = regexp.MustCompile(`\A[a-zA-Z0-9\.\-_]+\z`)
 
 // https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
-var versionMatcher = regexp.MustCompile(`^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$`)
+var versionMatcher = regexp.MustCompile(`^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?(\+[a-z0-9]+([-_\.][a-z0-9]+)*)?$`)
 
 func apiError(ctx *context.Context, status int, obj interface{}) {
 	helper.LogAndProcessError(ctx, status, obj, func(message string) {


### PR DESCRIPTION
This PR addresses #21683 allowing for [local version identifiers](https://peps.python.org/pep-0440/#local-version-identifiers) as described by PEP-0440.

![image](https://user-images.githubusercontent.com/3977569/200022381-e2a0afc9-f7f3-4879-bcbb-45894c5977cf.png)

(Let me know if more testing is needed, I based this largely off of the changes I saw made here: https://github.com/go-gitea/gitea/pull/21095)