### PR TITLE
Remove semver compatible flag and change pypi to an array of test cases

### DIFF
--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -21,9 +21,9 @@ import (
 	packages_service "code.gitea.io/gitea/services/packages"
 )
 
-// https://www.python.org/dev/peps/pep-0503/#normalized-names
+// https://peps.python.org/pep-0426/#name
 var normalizer = strings.NewReplacer(".", "-", "_", "-")
-var nameMatcher = regexp.MustCompile(`\A[a-zA-Z0-9\.\-_]+\z`)
+var nameMatcher = regexp.MustCompile(`\A(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])\z`)
 
 // https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 var versionMatcher = regexp.MustCompile(`\Av?` +
@@ -128,7 +128,7 @@ func UploadPackageFile(ctx *context.Context) {
 
 	packageName := normalizer.Replace(ctx.Req.FormValue("name"))
 	packageVersion := ctx.Req.FormValue("version")
-	if !nameMatcher.MatchString(packageName) || !versionMatcher.MatchString(packageVersion) {
+	if hasInvalidMetadata(packageName, packageVersion) {
 		apiError(ctx, http.StatusBadRequest, "invalid name or version")
 		return
 	}
@@ -146,7 +146,7 @@ func UploadPackageFile(ctx *context.Context) {
 				Name:        packageName,
 				Version:     packageVersion,
 			},
-			SemverCompatible: true,
+			SemverCompatible: false,
 			Creator:          ctx.Doer,
 			Metadata: &pypi_module.Metadata{
 				Author:          ctx.Req.FormValue("author"),
@@ -176,4 +176,8 @@ func UploadPackageFile(ctx *context.Context) {
 	}
 
 	ctx.Status(http.StatusCreated)
+}
+
+func hasInvalidMetadata(packageName, packageVersion string) bool {
+	return !nameMatcher.MatchString(packageName) || !versionMatcher.MatchString(packageVersion)
 }

--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -128,7 +128,7 @@ func UploadPackageFile(ctx *context.Context) {
 
 	packageName := normalizer.Replace(ctx.Req.FormValue("name"))
 	packageVersion := ctx.Req.FormValue("version")
-	if hasInvalidMetadata(packageName, packageVersion) {
+	if !isValidNameAndVersion(packageName, packageVersion) {
 		apiError(ctx, http.StatusBadRequest, "invalid name or version")
 		return
 	}
@@ -178,6 +178,6 @@ func UploadPackageFile(ctx *context.Context) {
 	ctx.Status(http.StatusCreated)
 }
 
-func hasInvalidMetadata(packageName, packageVersion string) bool {
-	return !nameMatcher.MatchString(packageName) || !versionMatcher.MatchString(packageVersion)
+func isValidNameAndVersion(packageName, packageVersion string) bool {
+	return nameMatcher.MatchString(packageName) && versionMatcher.MatchString(packageVersion)
 }

--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -23,7 +23,7 @@ import (
 
 // https://peps.python.org/pep-0426/#name
 var normalizer = strings.NewReplacer(".", "-", "_", "-")
-var nameMatcher = regexp.MustCompile(`\A(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])\z`)
+var nameMatcher = regexp.MustCompile(`\A(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\.\-_]*[a-zA-Z0-9])\z`)
 
 // https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 var versionMatcher = regexp.MustCompile(`\Av?` +

--- a/routers/api/packages/pypi/pypi_test.go
+++ b/routers/api/packages/pypi/pypi_test.go
@@ -10,28 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHasInvalidMetadata(t *testing.T) {
+func TestIsValidNameAndVersion(t *testing.T) {
 	// The test cases below were created from the following Python PEPs:
 	// https://peps.python.org/pep-0426/#name
 	// https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 
 	// Valid Cases
-	assert.False(t, hasInvalidMetadata("A", "1.0.1"))
-	assert.False(t, hasInvalidMetadata("Test.Name.1234", "1.0.1"))
-	assert.False(t, hasInvalidMetadata("test_name", "1.0.1"))
-	assert.False(t, hasInvalidMetadata("test-name", "1.0.1"))
-	assert.False(t, hasInvalidMetadata("test-name", "v1.0.1"))
-	assert.False(t, hasInvalidMetadata("test-name", "2012.4"))
-	assert.False(t, hasInvalidMetadata("test-name", "1.0.1-alpha"))
-	assert.False(t, hasInvalidMetadata("test-name", "1.0.1a1"))
-	assert.False(t, hasInvalidMetadata("test-name", "1.0b2.r345.dev456"))
-	assert.False(t, hasInvalidMetadata("test-name", "1!1.0.1"))
-	assert.False(t, hasInvalidMetadata("test-name", "1.0.1+local.1"))
+	assert.True(t, isValidNameAndVersion("A", "1.0.1"))
+	assert.True(t, isValidNameAndVersion("Test.Name.1234", "1.0.1"))
+	assert.True(t, isValidNameAndVersion("test_name", "1.0.1"))
+	assert.True(t, isValidNameAndVersion("test-name", "1.0.1"))
+	assert.True(t, isValidNameAndVersion("test-name", "v1.0.1"))
+	assert.True(t, isValidNameAndVersion("test-name", "2012.4"))
+	assert.True(t, isValidNameAndVersion("test-name", "1.0.1-alpha"))
+	assert.True(t, isValidNameAndVersion("test-name", "1.0.1a1"))
+	assert.True(t, isValidNameAndVersion("test-name", "1.0b2.r345.dev456"))
+	assert.True(t, isValidNameAndVersion("test-name", "1!1.0.1"))
+	assert.True(t, isValidNameAndVersion("test-name", "1.0.1+local.1"))
 
 	// Invalid Cases
-	assert.True(t, hasInvalidMetadata(".test-name", "1.0.1"))
-	assert.True(t, hasInvalidMetadata("test!name", "1.0.1"))
-	assert.True(t, hasInvalidMetadata("test-name", "a1.0.1"))
-	assert.True(t, hasInvalidMetadata("test-name", "1.0.1aa"))
-	assert.True(t, hasInvalidMetadata("test-name", "1.0.0-alpha.beta"))
+	assert.False(t, isValidNameAndVersion(".test-name", "1.0.1"))
+	assert.False(t, isValidNameAndVersion("test!name", "1.0.1"))
+	assert.False(t, isValidNameAndVersion("test-name", "a1.0.1"))
+	assert.False(t, isValidNameAndVersion("test-name", "1.0.1aa"))
+	assert.False(t, isValidNameAndVersion("test-name", "1.0.0-alpha.beta"))
 }

--- a/routers/api/packages/pypi/pypi_test.go
+++ b/routers/api/packages/pypi/pypi_test.go
@@ -31,6 +31,8 @@ func TestIsValidNameAndVersion(t *testing.T) {
 	// Invalid Cases
 	assert.False(t, isValidNameAndVersion(".test-name", "1.0.1"))
 	assert.False(t, isValidNameAndVersion("test!name", "1.0.1"))
+	assert.False(t, isValidNameAndVersion("-test-name", "1.0.1"))
+	assert.False(t, isValidNameAndVersion("test-name-", "1.0.1"))
 	assert.False(t, isValidNameAndVersion("test-name", "a1.0.1"))
 	assert.False(t, isValidNameAndVersion("test-name", "1.0.1aa"))
 	assert.False(t, isValidNameAndVersion("test-name", "1.0.0-alpha.beta"))

--- a/routers/api/packages/pypi/pypi_test.go
+++ b/routers/api/packages/pypi/pypi_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package pypi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasInvalidMetadata(t *testing.T) {
+	// The test cases below were created from the following Python PEPs:
+	// https://peps.python.org/pep-0426/#name
+	// https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
+
+	// Valid Cases
+	assert.False(t, hasInvalidMetadata("Test.Name.1234", "1.0.1"))
+	assert.False(t, hasInvalidMetadata("test_name", "1.0.1"))
+	assert.False(t, hasInvalidMetadata("test-name", "1.0.1"))
+	assert.False(t, hasInvalidMetadata("test-name", "v1.0.1"))
+	assert.False(t, hasInvalidMetadata("test-name", "2012.4"))
+	assert.False(t, hasInvalidMetadata("test-name", "1.0.1-alpha"))
+	assert.False(t, hasInvalidMetadata("test-name", "1.0.1a1"))
+	assert.False(t, hasInvalidMetadata("test-name", "1.0b2.r345.dev456"))
+	assert.False(t, hasInvalidMetadata("test-name", "1!1.0.1"))
+	assert.False(t, hasInvalidMetadata("test-name", "1.0.1+local.1"))
+
+	// Invalid Cases
+	assert.True(t, hasInvalidMetadata(".test-name", "1.0.1"))
+	assert.True(t, hasInvalidMetadata("test!name", "1.0.1"))
+	assert.True(t, hasInvalidMetadata("test-name", "a1.0.1"))
+	assert.True(t, hasInvalidMetadata("test-name", "1.0.1aa"))
+	assert.True(t, hasInvalidMetadata("test-name", "1.0.0-alpha.beta"))
+}

--- a/routers/api/packages/pypi/pypi_test.go
+++ b/routers/api/packages/pypi/pypi_test.go
@@ -16,6 +16,7 @@ func TestHasInvalidMetadata(t *testing.T) {
 	// https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 
 	// Valid Cases
+	assert.False(t, hasInvalidMetadata("A", "1.0.1"))
 	assert.False(t, hasInvalidMetadata("Test.Name.1234", "1.0.1"))
 	assert.False(t, hasInvalidMetadata("test_name", "1.0.1"))
 	assert.False(t, hasInvalidMetadata("test-name", "1.0.1"))

--- a/tests/integration/api_packages_pypi_test.go
+++ b/tests/integration/api_packages_pypi_test.go
@@ -29,7 +29,7 @@ func TestPackagePyPI(t *testing.T) {
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 
 	packageName := "test-package"
-	packageVersion := "1.0.1+r1234"
+	packageVersion := "1!1.0.1+r1234"
 	packageAuthor := "KN4CK3R"
 	packageDescription := "Test Description"
 
@@ -72,7 +72,7 @@ func TestPackagePyPI(t *testing.T) {
 
 		pd, err := packages.GetPackageDescriptor(db.DefaultContext, pvs[0])
 		assert.NoError(t, err)
-		assert.NotNil(t, pd.SemVer)
+		assert.Nil(t, pd.SemVer)
 		assert.IsType(t, &pypi.Metadata{}, pd.Metadata)
 		assert.Equal(t, packageName, pd.Package.Name)
 		assert.Equal(t, packageVersion, pd.Version.Version)
@@ -100,7 +100,7 @@ func TestPackagePyPI(t *testing.T) {
 
 		pd, err := packages.GetPackageDescriptor(db.DefaultContext, pvs[0])
 		assert.NoError(t, err)
-		assert.NotNil(t, pd.SemVer)
+		assert.Nil(t, pd.SemVer)
 		assert.IsType(t, &pypi.Metadata{}, pd.Metadata)
 		assert.Equal(t, packageName, pd.Package.Name)
 		assert.Equal(t, packageVersion, pd.Version.Version)


### PR DESCRIPTION
This addresses #21707 and adds a second package test case for a non-semver compatible version (this might be overkill though since you could also edit the old package version to have an epoch in front and see the error, this just seemed more flexible for the future).
