### PR TITLE
Set last login when activating account

### DIFF
--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -783,6 +783,13 @@ func handleAccountActivation(ctx *context.Context, user *user_model.User) {
 		return
 	}
 
+	// Register last login
+	user.SetLastLogin()
+	if err := user_model.UpdateUserCols(ctx, user, "last_login_unix"); err != nil {
+		ctx.ServerError("UpdateUserCols", err)
+		return
+	}
+
 	ctx.Flash.Success(ctx.Tr("auth.account_activated"))
 	ctx.Redirect(setting.AppSubURL + "/")
 }


### PR DESCRIPTION
Fix #21698.

Set the last login time to the current time when activating the user successfully.
