### PR TITLE
 Init git module before database migration (#21764)

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -511,6 +512,13 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 		_, _ = fmt.Fprintln(os.Stderr, msg)
 		log.Fatal(msg)
 		return nil
+	}
+
+	// Some migration tasks depend on the git command
+	if git.DefaultContext == nil {
+		if err = git.InitSimple(context.Background()); err != nil {
+			return err
+		}
 	}
 
 	// Migrate


### PR DESCRIPTION
Backport #21764

Some database migrations depend on the git module.
