### PR TITLE
 Revert unrelated changes for SMTP auth (#21767)

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -413,9 +413,9 @@ var (
 			Usage: "SMTP Authentication Type (PLAIN/LOGIN/CRAM-MD5) default PLAIN",
 		},
 		cli.StringFlag{
-			Name:  "addr",
+			Name:  "host",
 			Value: "",
-			Usage: "SMTP Addr",
+			Usage: "SMTP Host",
 		},
 		cli.IntFlag{
 			Name:  "port",
@@ -955,8 +955,8 @@ func parseSMTPConfig(c *cli.Context, conf *smtp.Source) error {
 		}
 		conf.Auth = c.String("auth-type")
 	}
-	if c.IsSet("addr") {
-		conf.Addr = c.String("addr")
+	if c.IsSet("host") {
+		conf.Host = c.String("host")
 	}
 	if c.IsSet("port") {
 		conf.Port = c.Int("port")

--- a/routers/web/admin/auths.go
+++ b/routers/web/admin/auths.go
@@ -159,7 +159,7 @@ func parseLDAPConfig(form forms.AuthenticationForm) *ldap.Source {
 func parseSMTPConfig(form forms.AuthenticationForm) *smtp.Source {
 	return &smtp.Source{
 		Auth:           form.SMTPAuth,
-		Addr:           form.SMTPAddr,
+		Host:           form.SMTPHost,
 		Port:           form.SMTPPort,
 		AllowedDomains: form.AllowedDomains,
 		ForceSMTPS:     form.ForceSMTPS,

--- a/services/auth/source/smtp/auth.go
+++ b/services/auth/source/smtp/auth.go
@@ -58,10 +58,10 @@ var ErrUnsupportedLoginType = errors.New("Login source is unknown")
 func Authenticate(a smtp.Auth, source *Source) error {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: source.SkipVerify,
-		ServerName:         source.Addr,
+		ServerName:         source.Host,
 	}
 
-	conn, err := net.Dial("tcp", net.JoinHostPort(source.Addr, strconv.Itoa(source.Port)))
+	conn, err := net.Dial("tcp", net.JoinHostPort(source.Host, strconv.Itoa(source.Port)))
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func Authenticate(a smtp.Auth, source *Source) error {
 		conn = tls.Client(conn, tlsConfig)
 	}
 
-	client, err := smtp.NewClient(conn, source.Addr)
+	client, err := smtp.NewClient(conn, source.Host)
 	if err != nil {
 		return fmt.Errorf("failed to create NewClient: %w", err)
 	}

--- a/services/auth/source/smtp/source.go
+++ b/services/auth/source/smtp/source.go
@@ -19,7 +19,7 @@ import (
 // Source holds configuration for the SMTP login source.
 type Source struct {
 	Auth           string
-	Addr           string
+	Host           string
 	Port           int
 	AllowedDomains string `xorm:"TEXT"`
 	ForceSMTPS     bool

--- a/services/auth/source/smtp/source_authenticate.go
+++ b/services/auth/source/smtp/source_authenticate.go
@@ -32,7 +32,7 @@ func (source *Source) Authenticate(user *user_model.User, userName, password str
 	var auth smtp.Auth
 	switch source.Auth {
 	case PlainAuthentication:
-		auth = smtp.PlainAuth("", userName, password, source.Addr)
+		auth = smtp.PlainAuth("", userName, password, source.Host)
 	case LoginAuthentication:
 		auth = &loginAuthenticator{userName, password}
 	case CRAMMD5Authentication:

--- a/services/forms/auth_form.go
+++ b/services/forms/auth_form.go
@@ -45,7 +45,7 @@ type AuthenticationForm struct {
 	IsActive                      bool
 	IsSyncEnabled                 bool
 	SMTPAuth                      string
-	SMTPAddr                      string
+	SMTPHost                      string
 	SMTPPort                      int
 	AllowedDomains                string
 	SecurityProtocol              int `binding:"Range(0,2)"`


### PR DESCRIPTION
Backport #21767

The purpose of #18982 is to improve the SMTP mailer, but there were some unrelated changes made to the SMTP auth in https://github.com/go-gitea/gitea/pull/18982/commits/d60c43869420f5fc43ad19b454c9ae50dad65964

This PR reverts these unrelated changes, fix #21744