### PR TITLE
Localize numbers server-side (maintainers' opinion requested)

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -47,10 +47,10 @@ import (
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/services/gitdiff"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 // Used from static.go && dynamic.go

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -47,6 +47,8 @@ import (
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/services/gitdiff"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
 )
@@ -170,6 +172,7 @@ func NewFuncMap() []template.FuncMap {
 		"RenderEmojiPlain":               emoji.ReplaceAliases,
 		"ReactionToEmoji":                ReactionToEmoji,
 		"RenderNote":                     RenderNote,
+		"RenderNumber":                   RenderNumber,
 		"RenderMarkdownToHtml": func(input string) template.HTML {
 			output, err := markdown.RenderString(&markup.RenderContext{
 				URLPrefix: setting.AppSubURL,
@@ -780,6 +783,13 @@ var codeMatcher = regexp.MustCompile("`([^`]+)`")
 func RenderCodeBlock(htmlEscapedTextToRender template.HTML) template.HTML {
 	htmlWithCodeTags := codeMatcher.ReplaceAllString(string(htmlEscapedTextToRender), "<code>$1</code>") // replace with HTML <code> tags
 	return template.HTML(htmlWithCodeTags)
+}
+
+// RenderNumber render any number according to the given language code (e.g. 1234 -> 1,234)
+// Should RenderNumber, JsPrettyNumber, and CountFmt coexist on this codebase? RenderNumber is server-rendered and localized
+func RenderNumber(number int64, languageCode string) template.HTML {
+	formatter := message.NewPrinter(language.MustParse(languageCode))
+	return template.HTML(formatter.Sprintf("%d", number))
 }
 
 // RenderIssueTitle renders issue/pull title with defined post processors

--- a/templates/code/searchresults.tmpl
+++ b/templates/code/searchresults.tmpl
@@ -3,7 +3,7 @@
 	<a class="ui text-label df ac mr-1 my-1 {{if eq $.Language $term.Language}}primary {{end}}basic label" href="{{AppSubUrl}}{{if $.ContextUser}}/{{$.ContextUser.Name}}/-/code{{else}}/explore/code{{end}}?q={{$.Keyword}}{{if ne $.Language $term.Language}}&l={{$term.Language}}{{end}}{{if ne $.queryType ""}}&t={{$.queryType}}{{end}}">
 		<i class="color-icon mr-3" style="background-color: {{$term.Color}}"></i>
 		{{$term.Language}}
-		<div class="detail">{{$term.Count}}</div>
+		<div class="detail">{{RenderNumber $term.Count $.locale.Language}}</div>
 	</a>
 	{{end}}
 </div>

--- a/templates/package/view.tmpl
+++ b/templates/package/view.tmpl
@@ -41,7 +41,7 @@
 							<div class="item">{{svg "octicon-repo" 16 "mr-3"}} <a href="{{.PackageDescriptor.Repository.HTMLURL}}">{{.PackageDescriptor.Repository.FullName}}</a></div>
 							{{end}}
 							<div class="item">{{svg "octicon-calendar" 16 "mr-3"}} {{TimeSinceUnix .PackageDescriptor.Version.CreatedUnix $.locale}}</div>
-							<div class="item">{{svg "octicon-download" 16 "mr-3"}} {{.PackageDescriptor.Version.DownloadCount}}</div>
+							<div class="item">{{svg "octicon-download" 16 "mr-3"}} {{RenderNumber .PackageDescriptor.Version.DownloadCount $.locale.Language}}</div>
 							{{template "package/metadata/composer" .}}
 							{{template "package/metadata/conan" .}}
 							{{template "package/metadata/container" .}}

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -63,21 +63,21 @@
 		<div class="ui attached segment horizontal segments">
 			{{if .Permission.CanRead $.UnitTypePullRequests}}
 				<a href="#merged-pull-requests" class="ui attached segment text center">
-					<span class="text purple">{{svg "octicon-git-pull-request"}}</span> <strong>{{.Activity.MergedPRCount}}</strong><br>
+					<span class="text purple">{{svg "octicon-git-pull-request"}}</span> <strong>{{RenderNumber .Activity.MergedPRCount $.locale.Language}}</strong><br>
 					{{.locale.TrN .Activity.MergedPRCount "repo.activity.merged_prs_count_1" "repo.activity.merged_prs_count_n"}}
 				</a>
 				<a href="#proposed-pull-requests" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-git-branch"}}</span> <strong>{{.Activity.OpenedPRCount}}</strong><br>
+					<span class="text green">{{svg "octicon-git-branch"}}</span> <strong>{{RenderNumber .Activity.OpenedPRCount $.locale.Language}}</strong><br>
 					{{.locale.TrN .Activity.OpenedPRCount "repo.activity.opened_prs_count_1" "repo.activity.opened_prs_count_n"}}
 				</a>
 			{{end}}
 			{{if .Permission.CanRead $.UnitTypeIssues}}
 				<a href="#closed-issues" class="ui attached segment text center">
-					<span class="text red">{{svg "octicon-issue-closed"}}</span> <strong>{{.Activity.ClosedIssueCount}}</strong><br>
+					<span class="text red">{{svg "octicon-issue-closed"}}</span> <strong>{{RenderNumber .Activity.ClosedIssueCount $.locale.Language}}</strong><br>
 					{{.locale.TrN .Activity.ClosedIssueCount "repo.activity.closed_issues_count_1" "repo.activity.closed_issues_count_n"}}
 				</a>
 				<a href="#new-issues" class="ui attached segment text center">
-					<span class="text green">{{svg "octicon-issue-opened"}}</span> <strong>{{.Activity.OpenedIssueCount}}</strong><br>
+					<span class="text green">{{svg "octicon-issue-opened"}}</span> <strong>{{RenderNumber .Activity.OpenedIssueCount $.locale.Language}}</strong><br>
 					{{.locale.TrN .Activity.OpenedIssueCount "repo.activity.new_issues_count_1" "repo.activity.new_issues_count_n"}}
 				</a>
 			{{end}}

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -1,7 +1,7 @@
 <h4 class="ui top attached header commits-table df ac sb">
 	<div class="commits-table-left df ac">
 		{{if or .PageIsCommits (gt .CommitCount 0)}}
-			{{.CommitCount}} {{.locale.Tr "repo.commits.commits"}} {{if .RefName}}({{.RefName}}){{end}}
+			{{RenderNumber .CommitCount .locale.Language}} {{.locale.Tr "repo.commits.commits"}} {{if .RefName}}({{.RefName}}){{end}}
 		{{else if .IsNothingToCompare}}
 			{{.locale.Tr "repo.commits.nothing_to_compare"}} {{if .RefName}}({{.RefName}}){{end}}
 		{{else}}

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -4,14 +4,14 @@
 		<div class="ui two horizontal center link list">
 			{{if and (.Permission.CanRead $.UnitTypeCode) (not .IsEmptyRepo)}}
 				<div class="item{{if .PageIsCommits}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}">{{svg "octicon-history"}} <b>{{.CommitsCount}}</b> {{.locale.TrN .CommitsCount "repo.commit" "repo.commits"}}</a>
+					<a class="ui" href="{{.RepoLink}}/commits/{{.BranchNameSubURL}}">{{svg "octicon-history"}} <b>{{RenderNumber .CommitsCount .locale.Language}}</b> {{.locale.TrN .CommitsCount "repo.commit" "repo.commits"}}</a>
 				</div>
 				<div class="item{{if .PageIsBranches}} active{{end}}">
-					<a class="ui" href="{{.RepoLink}}/branches">{{svg "octicon-git-branch"}} <b>{{.BranchesCount}}</b> {{.locale.TrN .BranchesCount "repo.branch" "repo.branches"}}</a>
+					<a class="ui" href="{{.RepoLink}}/branches">{{svg "octicon-git-branch"}} <b>{{RenderNumber .BranchesCount .locale.Language}}</b> {{.locale.TrN .BranchesCount "repo.branch" "repo.branches"}}</a>
 				</div>
 				{{if $.Permission.CanRead $.UnitTypeCode}}
 					<div class="item">
-						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{.NumTags}}</b> {{.locale.TrN .NumTags "repo.tag" "repo.tags"}}</a>
+						<a class="ui" href="{{.RepoLink}}/tags">{{svg "octicon-tag"}} <b>{{RenderNumber .NumTags .locale.Language}}</b> {{.locale.TrN .NumTags "repo.tag" "repo.tags"}}</a>
 					</div>
 				{{end}}
 				<div class="item">


### PR DESCRIPTION
This one started when I encountered #12637. I wrote `RenderNumber` in https://github.com/go-gitea/gitea/commit/b9319f9a46d2b1a6fe549ec12971fa38315bfea6 to format the number of commits, then I thought "Why not format all other numbers in a nice way?". So I did it in https://github.com/go-gitea/gitea/commit/c929ad212f962204fd6ac2b690bae58047a0d5f0.

While running a search for numbers in templates I encountered `JsPrettyNumber` and `CountFmt`. `JsPrettyNumber` seems to localize the numbers client-side (therefore with a "flash of unstyled content") and `CountFmt` does it server-side disregarding the user's locale. So this PR can go a few ways:
1. Land `RenderNumber` + use it in the places of https://github.com/go-gitea/gitea/commit/c929ad212f962204fd6ac2b690bae58047a0d5f0 (current PR state)
2. Do 1 + refactor the codebase to use only `RenderNumber` and drop `JsPrettyNumber` and `CountFmt`
3. Drop everything I did and just use `JsPrettyNumber` for number of commits

What do you prefer?