### PR TITLE
Load GitRepo in API before deleting issue (#21720)

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -890,7 +890,7 @@ func Routes() *web.Route {
 					m.Group("/{index}", func() {
 						m.Combo("").Get(repo.GetIssue).
 							Patch(reqToken(), bind(api.EditIssueOption{}), repo.EditIssue).
-							Delete(reqToken(), reqAdmin(), repo.DeleteIssue)
+							Delete(reqToken(), reqAdmin(), context.ReferencesGitRepo(), repo.DeleteIssue)
 						m.Group("/comments", func() {
 							m.Combo("").Get(repo.ListIssueComments).
 								Post(reqToken(), mustNotBeArchived, bind(api.CreateIssueCommentOption{}), repo.CreateIssueComment)


### PR DESCRIPTION
Backport #21720.

Fix #20921.

The `ctx.Repo.GitRepo` has been used in deleting issues when the issue is a PR.

Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>
Co-authored-by: Lauris BH <lauris@nix.lv>