### PR TITLE
Fix enabling partial clones on 1.17

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -190,11 +190,6 @@ func InitOnceWithSync(ctx context.Context) (err error) {
 			globalCommandArgs = append(globalCommandArgs, "-c", "protocol.version=2")
 		}
 
-		// By default partial clones are disabled, enable them from git v2.22
-		if !setting.Git.DisablePartialClone && CheckGitVersionAtLeast("2.22") == nil {
-			globalCommandArgs = append(globalCommandArgs, "-c", "uploadpack.allowfilter=true", "-c", "uploadpack.allowAnySHA1InWant=true")
-		}
-
 		// Explicitly disable credential helper, otherwise Git credentials might leak
 		if CheckGitVersionAtLeast("2.9") == nil {
 			globalCommandArgs = append(globalCommandArgs, "-c", "credential.helper=")


### PR DESCRIPTION
When backporting #20902 in #21058 there was a slight misbackport. It was missed that we needed to remove the global command option before setting the settings.

Fix #21805

Signed-off-by: Andrew Thornton <art27@cantab.net>

