### PR TITLE
Add `updated_at` field to PullReview API object

### DIFF
--- a/modules/convert/pull_review.go
+++ b/modules/convert/pull_review.go
@@ -39,6 +39,7 @@ func ToPullReview(ctx context.Context, r *issues_model.Review, doer *user_model.
 		Dismissed:         r.Dismissed,
 		CodeCommentsCount: r.GetCodeCommentsCount(),
 		Submitted:         r.CreatedUnix.AsTime(),
+		Updated:           r.UpdatedUnix.AsTime(),
 		HTMLURL:           r.HTMLURL(),
 		HTMLPullURL:       r.Issue.HTMLURL(),
 	}

--- a/modules/structs/pull_review.go
+++ b/modules/structs/pull_review.go
@@ -40,6 +40,8 @@ type PullReview struct {
 	CodeCommentsCount int             `json:"comments_count"`
 	// swagger:strfmt date-time
 	Submitted time.Time `json:"submitted_at"`
+	// swagger:strfmt date-time
+	Updated time.Time `json:"updated_at"`
 
 	HTMLURL     string `json:"html_url"`
 	HTMLPullURL string `json:"pull_request_url"`

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -17888,6 +17888,11 @@
           "format": "date-time",
           "x-go-name": "Submitted"
         },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
+        },
         "team": {
           "$ref": "#/definitions/Team"
         },

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -17888,13 +17888,13 @@
           "format": "date-time",
           "x-go-name": "Submitted"
         },
+        "team": {
+          "$ref": "#/definitions/Team"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time",
           "x-go-name": "Updated"
-        },
-        "team": {
-          "$ref": "#/definitions/Team"
         },
         "user": {
           "$ref": "#/definitions/User"


### PR DESCRIPTION
* Closes #19997

Adds an `updated_at` time field to the `PullReview` API object to specify when the pull request review's state changed.