### PR TITLE
Remove `href="javascript:;"` in "save topics (Done)" button

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -47,7 +47,7 @@
 				</div>
 			</div>
 			<div class="two wide column">
-				<a class="ui button primary" href="javascript:;" id="save_topic"
+				<a class="ui button primary" role="button" tabindex="0" id="save_topic"
 				data-link="{{.RepoLink}}/topics">{{.locale.Tr "repo.topic.done"}}</a>
 			</div>
 		</div>


### PR DESCRIPTION
To use an anchor tag as a button and have it be accessible I added `role="button" tabindex="0"`, [reference](https://stackoverflow.com/a/10510353/7414734).

* Closes #19912
