### PR TITLE
Fix webpack license warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -228,7 +228,8 @@ export default {
       override: {
         'jquery.are-you-sure@*': {licenseName: 'MIT'},
       },
-      allow: '(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT OR ISC)',
+      emitError: true,
+      allow: '(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT OR ISC OR CPAL-1.0 OR AGPL-1.0)',
       ignore: [
         'font-awesome',
       ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -229,7 +229,7 @@ export default {
         'jquery.are-you-sure@*': {licenseName: 'MIT'},
       },
       emitError: true,
-      allow: '(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT OR ISC OR CPAL-1.0 OR AGPL-1.0)',
+      allow: '(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT OR ISC OR CPAL-1.0)',
       ignore: [
         'font-awesome',
       ],


### PR DESCRIPTION
#19999 introduced a indirect dependency with a license that was not on our allowlist yet which produced this warning during webpack:

````
WARNING in License: citeproc@2.4.62 has disallowed license CPAL-1.0 OR AGPL-1.0
````

I've added both licenses to the allowed list and made it so webpack will now abort on such license errors so that we don't miss those next time.