### PR TITLE
Skip GitHub migration tests if the API token is undefined

### DIFF
--- a/services/migrations/github_test.go
+++ b/services/migrations/github_test.go
@@ -18,7 +18,11 @@ import (
 
 func TestGitHubDownloadRepo(t *testing.T) {
 	GithubLimitRateRemaining = 3 // Wait at 3 remaining since we could have 3 CI in //
-	downloader := NewGithubDownloaderV3(context.Background(), "https://github.com", "", "", os.Getenv("GITHUB_READ_TOKEN"), "go-gitea", "test_repo")
+	token := os.Getenv("GITHUB_READ_TOKEN")
+	if token == "" {
+		t.Skip("Skipping GitHub migration test because GITHUB_READ_TOKEN is empty")
+	}
+	downloader := NewGithubDownloaderV3(context.Background(), "https://github.com", "", "", token, "go-gitea", "test_repo")
 	err := downloader.RefreshRate()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
GitHub migration tests will be skipped if the secret for the GitHub API token hasn't been set.

This change should make all tests pass (or skip in the case of this one) for anyone running the pipeline on their own infrastructure without further action on their part.

Resolves https://github.com/go-gitea/gitea/issues/21739