### PR TITLE
Ignore issue template with a special name

### DIFF
--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -163,7 +163,7 @@ const (
 
 // Type returns the type of IssueTemplate, can be "md", "yaml" or empty for known
 func (it IssueTemplate) Type() IssueTemplateType {
-	if it.Name == "config.yaml" || it.Name == "config.yml" {
+	if base := filepath.Base(it.FileName); base == "config.yaml" || base == "config.yml" {
 		// ignore config.yaml which is a special configuration file
 		return ""
 	}

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -5,7 +5,7 @@
 package structs
 
 import (
-	"path/filepath"
+	"path"
 	"time"
 )
 
@@ -163,11 +163,11 @@ const (
 
 // Type returns the type of IssueTemplate, can be "md", "yaml" or empty for known
 func (it IssueTemplate) Type() IssueTemplateType {
-	if base := filepath.Base(it.FileName); base == "config.yaml" || base == "config.yml" {
+	if base := path.Base(it.FileName); base == "config.yaml" || base == "config.yml" {
 		// ignore config.yaml which is a special configuration file
 		return ""
 	}
-	if ext := filepath.Ext(it.FileName); ext == ".md" {
+	if ext := path.Ext(it.FileName); ext == ".md" {
 		return IssueTemplateTypeMarkdown
 	} else if ext == ".yaml" || ext == ".yml" {
 		return IssueTemplateTypeYaml

--- a/modules/structs/issue_test.go
+++ b/modules/structs/issue_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIssueTemplate_Type(t *testing.T) {
+	tests := []struct {
+		fileName string
+		want     IssueTemplateType
+	}{
+		{
+			fileName: ".gitea/ISSUE_TEMPLATE/bug_report.yaml",
+			want:     IssueTemplateTypeYaml,
+		},
+		{
+			fileName: ".gitea/ISSUE_TEMPLATE/bug_report.md",
+			want:     IssueTemplateTypeMarkdown,
+		},
+		{
+			fileName: ".gitea/ISSUE_TEMPLATE/bug_report.txt",
+			want:     "",
+		},
+		{
+			fileName: ".gitea/ISSUE_TEMPLATE/config.yaml",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fileName, func(t *testing.T) {
+			it := IssueTemplate{
+				FileName: tt.fileName,
+			}
+			assert.Equal(t, tt.want, it.Type())
+		})
+	}
+}


### PR DESCRIPTION
A file in `ISSUE_TEMPLATE` with the name `config.yml` shouldn't be treated as a YAML template, it's for [configuring the template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).

The old code tried to ignore the file, but it didn't work, caused by #20987. That's why the warning is displayed:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/9418365/202094067-804c42fe-0e9e-4fc5-bf01-d95fa336f54f.png">

Note that this PR is not an implementation of `config.yml`, there will be another one to do it.
