### PR TITLE
Fix cocurrent upload package

### DIFF
--- a/models/packages/package.go
+++ b/models/packages/package.go
@@ -128,7 +128,7 @@ func TryInsertPackage(ctx context.Context, p *Package) (*Package, error) {
 		LowerName: p.LowerName,
 	}
 
-	has, err := e.Get(key)
+	has, err := e.Exist(key)
 	if err != nil {
 		return nil, err
 	}
@@ -136,6 +136,13 @@ func TryInsertPackage(ctx context.Context, p *Package) (*Package, error) {
 		return key, ErrDuplicatePackage
 	}
 	if _, err = e.Insert(p); err != nil {
+		has, err := e.Exist(key)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			return key, ErrDuplicatePackage
+		}
 		return nil, err
 	}
 	return p, nil

--- a/models/packages/package_blob.go
+++ b/models/packages/package_blob.go
@@ -35,7 +35,7 @@ type PackageBlob struct {
 func GetOrInsertBlob(ctx context.Context, pb *PackageBlob) (*PackageBlob, bool, error) {
 	e := db.GetEngine(ctx)
 
-	has, err := e.Get(pb)
+	has, err := e.Exist(pb)
 	if err != nil {
 		return nil, false, err
 	}
@@ -43,6 +43,13 @@ func GetOrInsertBlob(ctx context.Context, pb *PackageBlob) (*PackageBlob, bool, 
 		return pb, true, nil
 	}
 	if _, err = e.Insert(pb); err != nil {
+		has, err := e.Exist(pb)
+		if err != nil {
+			return nil, false, err
+		}
+		if has {
+			return pb, true, nil
+		}
 		return nil, false, err
 	}
 	return pb, false, nil

--- a/models/packages/package_file.go
+++ b/models/packages/package_file.go
@@ -53,7 +53,7 @@ func TryInsertFile(ctx context.Context, pf *PackageFile) (*PackageFile, error) {
 		CompositeKey: pf.CompositeKey,
 	}
 
-	has, err := e.Get(key)
+	has, err := e.Exist(key)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +61,13 @@ func TryInsertFile(ctx context.Context, pf *PackageFile) (*PackageFile, error) {
 		return pf, ErrDuplicatePackageFile
 	}
 	if _, err = e.Insert(pf); err != nil {
+		has, err := e.Exist(key)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			return pf, ErrDuplicatePackageFile
+		}
 		return nil, err
 	}
 	return pf, nil

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -46,7 +46,7 @@ func GetOrInsertVersion(ctx context.Context, pv *PackageVersion) (*PackageVersio
 		LowerVersion: pv.LowerVersion,
 	}
 
-	has, err := e.Get(key)
+	has, err := e.Exist(key)
 	if err != nil {
 		return nil, err
 	}
@@ -54,6 +54,13 @@ func GetOrInsertVersion(ctx context.Context, pv *PackageVersion) (*PackageVersio
 		return key, ErrDuplicatePackageVersion
 	}
 	if _, err = e.Insert(pv); err != nil {
+		has, err := e.Exist(key)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			return key, ErrDuplicatePackageVersion
+		}
 		return nil, err
 	}
 	return pv, nil

--- a/routers/api/packages/container/blob.go
+++ b/routers/api/packages/container/blob.go
@@ -38,12 +38,11 @@ func saveAsPackageBlob(hsr packages_module.HashedSizeReader, pi *packages_servic
 		}
 		var err error
 		if p, err = packages_model.TryInsertPackage(ctx, p); err != nil {
-			if err == packages_model.ErrDuplicatePackage {
-				created = false
-			} else {
+			if err != packages_model.ErrDuplicatePackage {
 				log.Error("Error inserting package: %v", err)
 				return err
 			}
+			created = false
 		}
 
 		if created {


### PR DESCRIPTION
When inserting failed, then check if the record does exist, if yes, then just return the record duplicated.