### PR TITLE
Do not allow Ghost access to limited visible user/org

### DIFF
--- a/models/organization/org.go
+++ b/models/organization/org.go
@@ -458,8 +458,9 @@ func CountOrgs(opts FindOrgOptions) (int64, error) {
 
 // HasOrgOrUserVisible tells if the given user can see the given org or user
 func HasOrgOrUserVisible(ctx context.Context, orgOrUser, user *user_model.User) bool {
-	// Not SignedUser
-	if user == nil {
+	// If user is nil, it's an anonymous user/request.
+	// The Ghost user is handled like an anonymous user.
+	if user == nil || user.IsGhost() {
 		return orgOrUser.Visibility == structs.VisibleTypePublic
 	}
 


### PR DESCRIPTION
The Ghost user should not be allowed to have access to a limited visible user/org.