### PR TITLE
Fix "build from source" document to clarify the `bindata` tag is required.

### DIFF
--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -94,7 +94,7 @@ are provided to keep the build process as simple as possible.
 
 Depending on requirements, the following build tags can be included.
 
-- `bindata`: Build a single monolithic binary, with all assets included.
+- `bindata`: Build a single monolithic binary, with all assets included. Required for production build.
 - `sqlite sqlite_unlock_notify`: Enable support for a
   [SQLite3](https://sqlite.org/) database. Suggested only for tiny
   installations.
@@ -103,11 +103,10 @@ Depending on requirements, the following build tags can be included.
   available to PAM.
 - `gogit`: (EXPERIMENTAL) Use go-git variants of Git commands.
 
-Bundling assets into the binary using the `bindata` build tag is recommended for
-production deployments. It is possible to serve the static assets directly via a reverse proxy,
-but in most cases it is not necessary, and assets should still be bundled in the binary.
-You may want to exclude bindata while developing/testing Gitea.
-To include assets, add the `bindata` tag:
+Bundling all assets (JS/CSS/templates, etc) into the binary. Using the `bindata` build tag is required for
+production deployments. You could exclude `bindata` when you are developing/testing Gitea or able to separate the assets correctly.
+
+To include all assets, use the `bindata` tag:
 
 ```bash
 TAGS="bindata" make build


### PR DESCRIPTION
Related: #21845

I have seen many users not using `bindata` and asking "why my Gitea build doesn't work".

For almost 100% users, the `bindata` tag is required for the production build, the `bindata` contains not only the JS/CSS files, but also other essential backend data like templates.

Without `bindata`, Gitea is unlikely to run correctly in a production deployment.

If some advanced users want to fine tune the build, they should look into source code and other documents to separate bindata files carefully and manually.
