### PR TITLE
Prevent dangling user redirects

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -89,6 +89,7 @@ func DeleteUser(ctx context.Context, u *user_model.User, purge bool) (err error)
 		&user_model.UserBadge{UserID: u.ID},
 		&pull_model.AutoMerge{DoerID: u.ID},
 		&pull_model.ReviewState{UserID: u.ID},
+		&user_model.Redirect{RedirectUserID: u.ID},
 	); err != nil {
 		return fmt.Errorf("deleteBeans: %w", err)
 	}

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -205,6 +205,9 @@ func checkDBConsistency(ctx context.Context, logger log.Logger, autofix bool) er
 		// find stopwatches without existing issue
 		genericOrphanCheck("Orphaned Stopwatches without existing Issue",
 			"stopwatch", "issue", "stopwatch.issue_id=`issue`.id"),
+		// find redirects without existing user.
+		genericOrphanCheck("Orphaned Redirects without existing redirect user",
+			"user_redirect", "user", "user_redirect.redirect_user_id=`user`.id"),
 	)
 
 	for _, c := range consistencyChecks {


### PR DESCRIPTION
- It's possible that the `user_redirect` table contains a user id that no longer exists.
- Delete a user redirect upon deleting the user.
- Add a check for these dangling user redirects to check-db-consistency.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
