### PR TITLE
Prevent dangling user redirects (#21856)

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -87,6 +87,7 @@ func DeleteUser(ctx context.Context, u *user_model.User) (err error) {
 		&user_model.Setting{UserID: u.ID},
 		&pull_model.AutoMerge{DoerID: u.ID},
 		&pull_model.ReviewState{UserID: u.ID},
+		&user_model.Redirect{RedirectUserID: u.ID},
 	); err != nil {
 		return fmt.Errorf("deleteBeans: %v", err)
 	}

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -205,6 +205,9 @@ func checkDBConsistency(ctx context.Context, logger log.Logger, autofix bool) er
 		// find stopwatches without existing issue
 		genericOrphanCheck("Orphaned Stopwatches without existing Issue",
 			"stopwatch", "issue", "stopwatch.issue_id=`issue`.id"),
+		// find redirects without existing user.
+		genericOrphanCheck("Orphaned Redirects without existing redirect user",
+			"user_redirect", "user", "user_redirect.redirect_user_id=`user`.id"),
 	)
 
 	for _, c := range consistencyChecks {


### PR DESCRIPTION
- Backport #21856
  - It's possible that the `user_redirect` table contains a user id that no longer exists.
  - Delete a user redirect upon deleting the user.
  - Add a check for these dangling user redirects to check-db-consistency.
