### PR TITLE
Fix scroll over mermaid frame

### DIFF
--- a/web_src/js/markup/mermaid.js
+++ b/web_src/js/markup/mermaid.js
@@ -3,7 +3,7 @@ const {mermaidMaxSourceCharacters} = window.config;
 
 const iframeCss = `
   :root {color-scheme: normal}
-  body {margin: 0; padding: 0}
+  body {margin: 0; padding: 0; overflow: hidden}
   #mermaid {display: block; margin: 0 auto}
 `;
 


### PR DESCRIPTION
Backport #21925. When starting a scroll while the mouse is over a mermaid diagram, the scroll sometimes propagates to the iframe, preventing the parent page from scrolling. Fix this by disabling scroll inside the iframe. This is not a problem because those frames are never meant to scroll. Bug seems to affect Firefox only.

![scroll](https://user-images.githubusercontent.com/115237/203847655-48b6903e-01a3-4005-bb33-9d623e4dfab0.gif)
