### PR TITLE
Fix markdown anchor re-clicking

### DIFF
--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -3,7 +3,7 @@ import {svg} from '../svg.js';
 const headingSelector = '.markup h1, .markup h2, .markup h3, .markup h4, .markup h5, .markup h6';
 
 function scrollToAnchor(hash, initial) {
-  // abort on page load if the browser has already scrolled to another anchor
+  // abort if the browser has already scrolled to another anchor during page load
   if (initial && document.querySelector(':target')) return;
   if (hash?.length <= 1) return;
   const id = decodeURIComponent(hash.substring(1));

--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -2,8 +2,9 @@ import {svg} from '../svg.js';
 
 const headingSelector = '.markup h1, .markup h2, .markup h3, .markup h4, .markup h5, .markup h6';
 
-function scrollToAnchor(hash) {
-  if (document.querySelector(':target')) return; // something else on the page matches
+function scrollToAnchor(hash, initial) {
+  // abort on page load if the browser has already scrolled to another anchor
+  if (initial && document.querySelector(':target')) return;
   if (hash?.length <= 1) return;
   const id = decodeURIComponent(hash.substring(1));
   const el = document.getElementById(`user-content-${id}`);
@@ -30,5 +31,5 @@ export function initMarkupAnchors() {
     heading.prepend(a);
   }
 
-  scrollToAnchor(window.location.hash);
+  scrollToAnchor(window.location.hash, true);
 }

--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -26,7 +26,7 @@ export function initMarkupAnchors() {
     a.setAttribute('href', `#${encodeURIComponent(originalId)}`);
     a.innerHTML = svg('octicon-link');
     a.addEventListener('click', (e) => {
-      scrollToAnchor(e.currentTarget.getAttribute('href'));
+      scrollToAnchor(e.currentTarget.getAttribute('href'), false);
     });
     heading.prepend(a);
   }

--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -2,10 +2,10 @@ import {svg} from '../svg.js';
 
 const headingSelector = '.markup h1, .markup h2, .markup h3, .markup h4, .markup h5, .markup h6';
 
-function scrollToAnchor() {
-  if (document.querySelector(':target')) return;
-  if (!window.location.hash || window.location.hash.length <= 1) return;
-  const id = decodeURIComponent(window.location.hash.substring(1));
+function scrollToAnchor(hash) {
+  if (document.querySelector(':target')) return; // something else on the page matches
+  if (hash?.length <= 1) return;
+  const id = decodeURIComponent(hash.substring(1));
   const el = document.getElementById(`user-content-${id}`);
   if (el) {
     el.scrollIntoView();
@@ -24,9 +24,11 @@ export function initMarkupAnchors() {
     a.classList.add('anchor');
     a.setAttribute('href', `#${encodeURIComponent(originalId)}`);
     a.innerHTML = svg('octicon-link');
+    a.addEventListener('click', (e) => {
+      scrollToAnchor(e.currentTarget.getAttribute('href'));
+    });
     heading.prepend(a);
   }
 
-  scrollToAnchor();
-  window.addEventListener('hashchange', scrollToAnchor);
+  scrollToAnchor(window.location.hash);
 }


### PR DESCRIPTION
The hashchange event did not fire on re-click of a active anchor. Instead, use the click event which always fires.

Fixes: https://github.com/go-gitea/gitea/issues/21680