### PR TITLE
Fix typo in sidebar

### DIFF
--- a/docs/content/doc/packages/storage.en-us.md
+++ b/docs/content/doc/packages/storage.en-us.md
@@ -7,7 +7,7 @@ toc: false
 menu:
   sidebar:
     parent: "packages"
-    name: "storage"
+    name: "Storage"
     weight: 5
     identifier: "storage"
 ---


### PR DESCRIPTION
Same as #21922 
I used the npm file as template which was a bad idea to spot these casing errors...