### PR TITLE
Prevent NPE if trying to restore an already restored deleted branch

### DIFF
--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -126,6 +126,10 @@ func RestoreBranchPost(ctx *context.Context) {
 		log.Error("GetDeletedBranchByID: %v", err)
 		ctx.Flash.Error(ctx.Tr("repo.branch.restore_failed", branchName))
 		return
+	} else if deletedBranch == nil {
+		log.Debug("RestoreBranch: Can't restore branch[%d] '%s', as it does not exist", branchID, branchName)
+		ctx.Flash.Error(ctx.Tr("repo.branch.restore_failed", branchName))
+		return
 	}
 
 	if err := git.Push(ctx, ctx.Repo.Repository.RepoPath(), git.PushOptions{

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -260,6 +260,7 @@ export function initGlobalLinkActions() {
     e.preventDefault();
     const $this = $(this);
     const redirect = $this.data('redirect');
+    $this.prop('disabled', true);
     $.post($this.data('url'), {
       _csrf: csrfToken
     }).done((data) => {
@@ -270,6 +271,8 @@ export function initGlobalLinkActions() {
       } else {
         window.location.reload();
       }
+    }).always(() => {
+      $this.prop('disabled', false);
     });
   }
 
@@ -283,11 +286,14 @@ export function initGlobalLinkActions() {
   // FIXME: this is only used once, and should be replace with `link-action` instead
   $('.undo-button').on('click', function () {
     const $this = $(this);
+    $this.prop('disabled', true);
     $.post($this.data('url'), {
       _csrf: csrfToken,
       id: $this.data('id')
     }).done((data) => {
       window.location.href = data.redirect;
+    }).always(() => {
+      $this.prop('disabled', false);
     });
   });
 }


### PR DESCRIPTION
If a deleted-branch has already been restored, a request to restore it again will cause a NPE. This PR adds detection for this case, but also disables buttons when they're clicked in order to help prevent accidental repeat requests.

Fix #21930

Signed-off-by: Andrew Thornton <art27@cantab.net>
