### PR TITLE
Fix typos

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -218,9 +218,9 @@ Gitea or set your environment appropriately.`, "")
 		}
 	}
 
-	supportProcRecive := false
+	supportProcReceive := false
 	if git.CheckGitVersionAtLeast("2.29") == nil {
-		supportProcRecive = true
+		supportProcReceive = true
 	}
 
 	for scanner.Scan() {
@@ -241,9 +241,9 @@ Gitea or set your environment appropriately.`, "")
 		lastline++
 
 		// If the ref is a branch or tag, check if it's protected
-		// if supportProcRecive all ref should be checked because
+		// if supportProcReceive all ref should be checked because
 		// permission check was delayed
-		if supportProcRecive || strings.HasPrefix(refFullName, git.BranchPrefix) || strings.HasPrefix(refFullName, git.TagPrefix) {
+		if supportProcReceive || strings.HasPrefix(refFullName, git.BranchPrefix) || strings.HasPrefix(refFullName, git.TagPrefix) {
 			oldCommitIDs[count] = oldCommitID
 			newCommitIDs[count] = newCommitID
 			refFullNames[count] = refFullName

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -43,7 +43,7 @@ func EncodeSha1(str string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// EncodeSha256 string to sha1 hex value.
+// EncodeSha256 string to sha256 hex value.
 func EncodeSha256(str string) string {
 	h := sha256.New()
 	_, _ = h.Write([]byte(str))


### PR DESCRIPTION
Two typos

The `recieve` typo is also present in a translation.
https://github.com/go-gitea/gitea/blob/5f38acd9a08958024e8bbf47bcc482c79d844e44/options/locale/locale_sv-SE.ini#L1760
Someone with a Crowdin account should fix that.

... and in a license file but I don't think we can change that because that's the official text.
https://github.com/go-gitea/gitea/blob/5f38acd9a08958024e8bbf47bcc482c79d844e44/options/license/xinetd#L21