### PR TITLE
Replace fmt.Sprintf with hex.EncodeToString

### DIFF
--- a/models/auth/twofactor.go
+++ b/models/auth/twofactor.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	"code.gitea.io/gitea/models/db"
@@ -78,7 +79,7 @@ func (t *TwoFactor) GenerateScratchToken() (string, error) {
 // HashToken return the hashable salt
 func HashToken(token, salt string) string {
 	tempHash := pbkdf2.Key([]byte(token), []byte(salt), 10000, 50, sha256.New)
-	return fmt.Sprintf("%x", tempHash)
+	return hex.EncodeToString(tempHash)
 }
 
 // VerifyScratchToken verifies if the specified scratch token is valid.

--- a/models/migrations/base/hash.go
+++ b/models/migrations/base/hash.go
@@ -5,12 +5,12 @@ package base
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 
 	"golang.org/x/crypto/pbkdf2"
 )
 
 func HashToken(token, salt string) string {
 	tempHash := pbkdf2.Key([]byte(token), []byte(salt), 10000, 50, sha256.New)
-	return fmt.Sprintf("%x", tempHash)
+	return hex.EncodeToString(tempHash)
 }

--- a/models/migrations/v1_14/v166.go
+++ b/models/migrations/v1_14/v166.go
@@ -5,7 +5,7 @@ package v1_14 //nolint
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/bcrypt"
@@ -53,7 +53,7 @@ func RecalculateUserEmptyPWD(x *xorm.Engine) (err error) {
 			tempPasswd = pbkdf2.Key([]byte(passwd), []byte(salt), 10000, 50, sha256.New)
 		}
 
-		return fmt.Sprintf("%x", tempPasswd)
+		return hex.EncodeToString(tempPasswd)
 	}
 
 	// ValidatePassword checks if given password matches the one belongs to the user.

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -401,7 +401,7 @@ func hashPassword(passwd, salt, algo string) (string, error) {
 		tempPasswd = pbkdf2.Key([]byte(passwd), saltBytes, 10000, 50, sha256.New)
 	}
 
-	return fmt.Sprintf("%x", tempPasswd), nil
+	return hex.EncodeToString(tempPasswd), nil
 }
 
 // SetPassword hashes a password using the algorithm defined in the config value of PASSWORD_HASH_ALGO

--- a/modules/packages/hashed_buffer_test.go
+++ b/modules/packages/hashed_buffer_test.go
@@ -4,7 +4,7 @@
 package packages
 
 import (
-	"fmt"
+	"encoding/hex"
 	"io"
 	"strings"
 	"testing"
@@ -36,10 +36,10 @@ func TestHashedBuffer(t *testing.T) {
 		assert.Equal(t, c.Data, string(data))
 
 		hashMD5, hashSHA1, hashSHA256, hashSHA512 := buf.Sums()
-		assert.Equal(t, c.HashMD5, fmt.Sprintf("%x", hashMD5))
-		assert.Equal(t, c.HashSHA1, fmt.Sprintf("%x", hashSHA1))
-		assert.Equal(t, c.HashSHA256, fmt.Sprintf("%x", hashSHA256))
-		assert.Equal(t, c.HashSHA512, fmt.Sprintf("%x", hashSHA512))
+		assert.Equal(t, c.HashMD5, hex.EncodeToString(hashMD5))
+		assert.Equal(t, c.HashSHA1, hex.EncodeToString(hashSHA1))
+		assert.Equal(t, c.HashSHA256, hex.EncodeToString(hashSHA256))
+		assert.Equal(t, c.HashSHA512, hex.EncodeToString(hashSHA512))
 
 		assert.NoError(t, buf.Close())
 	}

--- a/modules/packages/multi_hasher_test.go
+++ b/modules/packages/multi_hasher_test.go
@@ -4,7 +4,7 @@
 package packages
 
 import (
-	"fmt"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,10 +24,10 @@ func TestMultiHasherSums(t *testing.T) {
 
 		hashMD5, hashSHA1, hashSHA256, hashSHA512 := h.Sums()
 
-		assert.Equal(t, expectedMD5, fmt.Sprintf("%x", hashMD5))
-		assert.Equal(t, expectedSHA1, fmt.Sprintf("%x", hashSHA1))
-		assert.Equal(t, expectedSHA256, fmt.Sprintf("%x", hashSHA256))
-		assert.Equal(t, expectedSHA512, fmt.Sprintf("%x", hashSHA512))
+		assert.Equal(t, expectedMD5, hex.EncodeToString(hashMD5))
+		assert.Equal(t, expectedSHA1, hex.EncodeToString(hashSHA1))
+		assert.Equal(t, expectedSHA256, hex.EncodeToString(hashSHA256))
+		assert.Equal(t, expectedSHA512, hex.EncodeToString(hashSHA512))
 	})
 
 	t.Run("State", func(t *testing.T) {
@@ -45,9 +45,9 @@ func TestMultiHasherSums(t *testing.T) {
 
 		hashMD5, hashSHA1, hashSHA256, hashSHA512 := h2.Sums()
 
-		assert.Equal(t, expectedMD5, fmt.Sprintf("%x", hashMD5))
-		assert.Equal(t, expectedSHA1, fmt.Sprintf("%x", hashSHA1))
-		assert.Equal(t, expectedSHA256, fmt.Sprintf("%x", hashSHA256))
-		assert.Equal(t, expectedSHA512, fmt.Sprintf("%x", hashSHA512))
+		assert.Equal(t, expectedMD5, hex.EncodeToString(hashMD5))
+		assert.Equal(t, expectedSHA1, hex.EncodeToString(hashSHA1))
+		assert.Equal(t, expectedSHA256, hex.EncodeToString(hashSHA256))
+		assert.Equal(t, expectedSHA512, hex.EncodeToString(hashSHA512))
 	})
 }

--- a/routers/api/packages/maven/maven.go
+++ b/routers/api/packages/maven/maven.go
@@ -8,9 +8,9 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -128,7 +128,7 @@ func serveMavenMetadata(ctx *context.Context, params parameters) {
 			tmp := sha512.Sum512(xmlMetadataWithHeader)
 			hash = tmp[:]
 		}
-		ctx.PlainText(http.StatusOK, fmt.Sprintf("%x", hash))
+		ctx.PlainText(http.StatusOK, hex.EncodeToString(hash))
 		return
 	}
 

--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -4,7 +4,7 @@
 package pypi
 
 import (
-	"fmt"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"regexp"
@@ -118,7 +118,7 @@ func UploadPackageFile(ctx *context.Context) {
 
 	_, _, hashSHA256, _ := buf.Sums()
 
-	if !strings.EqualFold(ctx.Req.FormValue("sha256_digest"), fmt.Sprintf("%x", hashSHA256)) {
+	if !strings.EqualFold(ctx.Req.FormValue("sha256_digest"), hex.EncodeToString(hashSHA256)) {
 		apiError(ctx, http.StatusBadRequest, "hash mismatch")
 		return
 	}

--- a/services/packages/packages.go
+++ b/services/packages/packages.go
@@ -5,6 +5,7 @@ package packages
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -229,10 +230,10 @@ func NewPackageBlob(hsr packages_module.HashedSizeReader) *packages_model.Packag
 
 	return &packages_model.PackageBlob{
 		Size:       hsr.Size(),
-		HashMD5:    fmt.Sprintf("%x", hashMD5),
-		HashSHA1:   fmt.Sprintf("%x", hashSHA1),
-		HashSHA256: fmt.Sprintf("%x", hashSHA256),
-		HashSHA512: fmt.Sprintf("%x", hashSHA512),
+		HashMD5:    hex.EncodeToString(hashMD5),
+		HashSHA1:   hex.EncodeToString(hashSHA1),
+		HashSHA256: hex.EncodeToString(hashSHA256),
+		HashSHA512: hex.EncodeToString(hashSHA512),
 	}
 }
 


### PR DESCRIPTION
`hex.EncodeToString` has better performance than `fmt.Sprintf("%x", []byte)`, we should use it as much as possible.

I'm not an extreme fan of performance, so I think there are some exceptions:

- `fmt.Sprintf("%x", func(...)[N]byte())`
  - We can't slice the function return value directly, and it's not worth adding lines.
    ```diff
    func A()[20]byte { ... }
    - a := fmt.Sprintf("%x", A())
    - a := hex.EncodeToString(A()[:]) // invalid
    + tmp := A()
    + a := hex.EncodeToString(tmp[:])
    ```
- `fmt.Sprintf("%X", []byte)`
  - `strings.ToUpper(hex.EncodeToString(bytes))` has even worse performance.