### PR TITLE
Skip initing LFS storage if disabled

### DIFF
--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -174,6 +174,10 @@ func initAttachments() (err error) {
 }
 
 func initLFS() (err error) {
+	if !setting.LFS.StartServer {
+		LFS = discardStorage("LFS isn't enabled")
+		return nil
+	}
 	log.Info("Initialising LFS storage with type: %s", setting.LFS.Storage.Type)
 	LFS, err = NewStorage(setting.LFS.Storage.Type, &setting.LFS.Storage)
 	return err


### PR DESCRIPTION
A complement to #21985.

I overlooked it because the name of the switch is `StartServer`, not `Enabled`. I believe the weird name is a legacy, but renaming is out of scope.
