### PR TITLE
Update gitea-vet to check FSFE REUSE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module code.gitea.io/gitea
 go 1.18
 
 require (
-	code.gitea.io/gitea-vet v0.2.2-0.20220122151748-48ebc902541b
+	code.gitea.io/gitea-vet v0.2.2
 	code.gitea.io/sdk/gitea v0.15.1
 	codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570
 	gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 code.gitea.io/gitea-vet v0.2.1/go.mod h1:zcNbT/aJEmivCAhfmkHOlT645KNOf9W2KnkLgFjGGfE=
-code.gitea.io/gitea-vet v0.2.2-0.20220122151748-48ebc902541b h1:uv9a8eGSdQ8Dr4HyUcuHFfDsk/QuwO+wf+Y99RYdxY0=
-code.gitea.io/gitea-vet v0.2.2-0.20220122151748-48ebc902541b/go.mod h1:zcNbT/aJEmivCAhfmkHOlT645KNOf9W2KnkLgFjGGfE=
+code.gitea.io/gitea-vet v0.2.2 h1:TEOV/Glf38iGmKzKP0EB++Z5OSL4zGg3RrAvlwaMuvk=
+code.gitea.io/gitea-vet v0.2.2/go.mod h1:zcNbT/aJEmivCAhfmkHOlT645KNOf9W2KnkLgFjGGfE=
 code.gitea.io/sdk/gitea v0.11.3/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUrR6JDY=
 code.gitea.io/sdk/gitea v0.15.1 h1:WJreC7YYuxbn0UDaPuWIe/mtiNKTvLN8MLkaw71yx/M=
 code.gitea.io/sdk/gitea v0.15.1/go.mod h1:klY2LVI3s3NChzIk/MzMn7G1FHrfU7qd63iSMVoHRBA=

--- a/models/migrations/v1_19/v234.go
+++ b/models/migrations/v1_19/v234.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package v1_19 //nolint
 

--- a/models/migrations/v1_19/v235.go
+++ b/models/migrations/v1_19/v235.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package v1_19 //nolint
 

--- a/models/packages/package_cleanup_rule.go
+++ b/models/packages/package_cleanup_rule.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package packages
 

--- a/modules/context/csrf.go
+++ b/modules/context/csrf.go
@@ -13,6 +13,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // a middleware that generates and validates CSRF tokens.
 

--- a/modules/context/xsrf.go
+++ b/modules/context/xsrf.go
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package context
 

--- a/modules/context/xsrf_test.go
+++ b/modules/context/xsrf_test.go
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package context
 

--- a/modules/json/json.go
+++ b/modules/json/json.go
@@ -1,6 +1,5 @@
 // Copyright 2020 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: MIT
 
 package json
 

--- a/modules/json/json.go
+++ b/modules/json/json.go
@@ -1,5 +1,6 @@
 // Copyright 2020 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
+// SPDX-License-Identifier: BSD-3-Clause
 
 package json
 

--- a/modules/paginator/paginator.go
+++ b/modules/paginator/paginator.go
@@ -1,5 +1,6 @@
 // Copyright 2022 The Gitea Authors.
 // Copyright 2015 https://github.com/unknwon. Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: Apache-2.0
 
 package paginator
 

--- a/modules/paginator/paginator_test.go
+++ b/modules/paginator/paginator_test.go
@@ -1,5 +1,6 @@
 // Copyright 2022 The Gitea Authors.
 // Copyright 2015 https://github.com/unknwon. Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: Apache-2.0
 
 package paginator
 

--- a/modules/session/redis.go
+++ b/modules/session/redis.go
@@ -13,6 +13,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package session
 

--- a/routers/web/org/setting_packages.go
+++ b/routers/web/org/setting_packages.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package org
 

--- a/routers/web/shared/packages/packages.go
+++ b/routers/web/shared/packages/packages.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package packages
 

--- a/routers/web/user/setting/packages.go
+++ b/routers/web/user/setting/packages.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package setting
 

--- a/services/forms/package_form.go
+++ b/services/forms/package_form.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package forms
 

--- a/services/packages/container/common.go
+++ b/services/packages/container/common.go
@@ -1,6 +1,5 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
 
 package container
 


### PR DESCRIPTION
Related to:
- #21840
- https://gitea.com/gitea/gitea-vet/pulls/21

What it looks like when it's working: https://drone.gitea.io/go-gitea/gitea/64040/1/5

All available SPDX license identifiers: [SPDX License List](https://spdx.org/licenses/).