### PR TITLE
Do not emit ambiguous character warning on rendered pages

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -58,7 +58,9 @@
 		</div>
 	</h4>
 	<div class="ui attached table unstackable segment">
-		{{template "repo/unicode_escape_prompt" dict "EscapeStatus" .EscapeStatus "root" $}}
+		{{if not (or .IsMarkup .IsRenderedHTML)}}
+			{{template "repo/unicode_escape_prompt" dict "EscapeStatus" .EscapeStatus "root" $}}
+		{{end}}
 		<div class="file-view{{if .IsMarkup}} markup {{.MarkupType}}{{else if .IsRenderedHTML}} plain-text{{else if .IsTextSource}} code-view{{end}}">
 			{{if .IsMarkup}}
 				{{if .FileContent}}{{.FileContent | Safe}}{{end}}


### PR DESCRIPTION
The real sensitivity of ambiguous characters is in source code - therefore warning about them in rendered pages causes too many warnings. Therefore simply remove the warning on rendered pages.

The escape button will remain available and it is present on the view source page.

Fix #20999

Signed-off-by: Andrew Thornton <art27@cantab.net>
