### PR TITLE
Ensure that Chinese punctuation is not ambiguous when locale is Chinese

### DIFF
--- a/modules/charset/ambiguous.go
+++ b/modules/charset/ambiguous.go
@@ -28,7 +28,7 @@ func AmbiguousTablesForLocale(locale translation.Locale) []*AmbiguousTable {
 			key = key[:idx]
 		}
 	}
-	if table == nil && (locale.Language() == "zh-CN" || locale.Language() == "zh_CN")  {
+	if table == nil && (locale.Language() == "zh-CN" || locale.Language() == "zh_CN") {
 		table = AmbiguousCharacters["zh-hans"]
 	}
 	if table == nil && strings.HasPrefix(locale.Language(), "zh") {

--- a/modules/charset/ambiguous.go
+++ b/modules/charset/ambiguous.go
@@ -28,6 +28,12 @@ func AmbiguousTablesForLocale(locale translation.Locale) []*AmbiguousTable {
 			key = key[:idx]
 		}
 	}
+	if table == nil && (locale.Language() == "zh-CN" || locale.Language() == "zh_CN")  {
+		table = AmbiguousCharacters["zh-hans"]
+	}
+	if table == nil && strings.HasPrefix(locale.Language(), "zh") {
+		table = AmbiguousCharacters["zh-hant"]
+	}
 	if table == nil {
 		table = AmbiguousCharacters["_default"]
 	}


### PR DESCRIPTION
Although there are per-locale fallbacks for ambiguity the locale names for Chinese do not quite match our locales. This PR simply maps zh-CN on to zh-hans and other zh variants on to zh-hant.

Ref #20999

Signed-off-by: Andrew Thornton <art27@cantab.net>

