### PR TITLE
Handle empty author names (#21902)

### DIFF
--- a/modules/git/signature_gogit.go
+++ b/modules/git/signature_gogit.go
@@ -10,6 +10,7 @@ package git
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -30,7 +31,9 @@ type Signature = object.Signature
 func newSignatureFromCommitline(line []byte) (_ *Signature, err error) {
 	sig := new(Signature)
 	emailStart := bytes.IndexByte(line, '<')
-	sig.Name = string(line[:emailStart-1])
+	if emailStart > 0 { // Empty name has already occurred, even if it shouldn't
+		sig.Name = strings.TrimSpace(string(line[:emailStart-1]))
+	}
 	emailEnd := bytes.IndexByte(line, '>')
 	sig.Email = string(line[emailStart+1 : emailEnd])
 

--- a/modules/git/signature_nogogit.go
+++ b/modules/git/signature_nogogit.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -51,7 +52,9 @@ func newSignatureFromCommitline(line []byte) (sig *Signature, err error) {
 		return
 	}
 
-	sig.Name = string(line[:emailStart-1])
+	if emailStart > 0 { // Empty name has already occurred, even if it shouldn't
+		sig.Name = strings.TrimSpace(string(line[:emailStart-1]))
+	}
 	sig.Email = string(line[emailStart+1 : emailEnd])
 
 	hasTime := emailEnd+2 < len(line)


### PR DESCRIPTION
Backport #21902

Although git does expect that author names should be of the form: `NAME <EMAIL>` some users have been able to create commits with: `<EMAIL>`

Fix #21900

Signed-off-by: Andrew Thornton <art27@cantab.net>

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
