### PR TITLE
Use GhostUser if needed for TrackedTimes (#22021)

### DIFF
--- a/models/issues/tracked_time.go
+++ b/models/issues/tracked_time.go
@@ -6,6 +6,7 @@ package issues
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"code.gitea.io/gitea/models/db"
@@ -47,33 +48,42 @@ func (t *TrackedTime) LoadAttributes() (err error) {
 }
 
 func (t *TrackedTime) loadAttributes(ctx context.Context) (err error) {
+	// Load the issue
 	if t.Issue == nil {
 		t.Issue, err = GetIssueByID(ctx, t.IssueID)
-		if err != nil {
-			return
-		}
-		err = t.Issue.LoadRepo(ctx)
-		if err != nil {
-			return
-		}
-	}
-	if t.User == nil {
-		t.User, err = user_model.GetUserByIDCtx(ctx, t.UserID)
-		if err != nil {
-			return
-		}
-	}
-	return err
-}
 
-// LoadAttributes load Issue, User
-func (tl TrackedTimeList) LoadAttributes() (err error) {
-	for _, t := range tl {
-		if err = t.LoadAttributes(); err != nil {
+		if err != nil && !errors.Is(err, util.ErrNotExist) {
 			return err
 		}
 	}
-	return err
+	// Now load the repo for the issue (which we may have just loaded)
+	if t.Issue != nil {
+		err = t.Issue.LoadRepo(ctx)
+		if err != nil && !errors.Is(err, util.ErrNotExist) {
+			return err
+		}
+	}
+	// Load the user
+	if t.User == nil {
+		t.User, err = user_model.GetUserByIDCtx(ctx, t.UserID)
+		if err != nil {
+			if !errors.Is(err, util.ErrNotExist) {
+				return err
+			}
+			t.User = user_model.NewGhostUser()
+		}
+	}
+	return nil
+}
+
+// LoadAttributes load Issue, User
+func (tl TrackedTimeList) LoadAttributes() error {
+	for _, t := range tl {
+		if err := t.LoadAttributes(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // FindTrackedTimesOptions represent the filters for tracked times. If an ID is 0 it will be ignored.

--- a/modules/convert/issue.go
+++ b/modules/convert/issue.go
@@ -110,12 +110,11 @@ func ToAPIIssueList(il issues_model.IssueList) []*api.Issue {
 // ToTrackedTime converts TrackedTime to API format
 func ToTrackedTime(t *issues_model.TrackedTime) (apiT *api.TrackedTime) {
 	apiT = &api.TrackedTime{
-		ID:       t.ID,
-		IssueID:  t.IssueID,
-		UserID:   t.UserID,
-		UserName: t.User.Name,
-		Time:     t.Time,
-		Created:  t.Created,
+		ID:      t.ID,
+		IssueID: t.IssueID,
+		UserID:  t.UserID,
+		Time:    t.Time,
+		Created: t.Created,
 	}
 	if t.Issue != nil {
 		apiT.Issue = ToAPIIssue(t.Issue)


### PR DESCRIPTION
Backport #22021

When getting tracked times out of the db and loading their attributes handle not exist errors in a nicer way. (Also prevent an NPE.)

Fix #22006

Signed-off-by: Andrew Thornton <art27@cantab.net>