### PR TITLE
Fix issue/PR numbers (#22037)

### DIFF
--- a/models/issues/issue.go
+++ b/models/issues/issue.go
@@ -1010,12 +1010,7 @@ func NewIssueWithIndex(ctx context.Context, doer *user_model.User, opts NewIssue
 		}
 	}
 
-	if opts.IsPull {
-		_, err = e.Exec("UPDATE `repository` SET num_pulls = num_pulls + 1 WHERE id = ?", opts.Issue.RepoID)
-	} else {
-		_, err = e.Exec("UPDATE `repository` SET num_issues = num_issues + 1 WHERE id = ?", opts.Issue.RepoID)
-	}
-	if err != nil {
+	if err := repo_model.UpdateRepoIssueNumbers(ctx, opts.Issue.RepoID, opts.IsPull, false); err != nil {
 		return err
 	}
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -444,7 +444,7 @@ func CheckRepoStats(ctx context.Context) error {
 		},
 		// Repository.NumIssues
 		{
-			statsQuery("SELECT repo.id FROM `repository` repo WHERE repo.num_issues!=(SELECT COUNT(*) FROM `issue` WHERE repo_id=repo.id AND is_closed=? AND is_pull=?)", false, false),
+			statsQuery("SELECT repo.id FROM `repository` repo WHERE repo.num_issues!=(SELECT COUNT(*) FROM `issue` WHERE repo_id=repo.id AND is_pull=?)", false),
 			repoStatsCorrectNumIssues,
 			"repository count 'num_issues'",
 		},
@@ -456,7 +456,7 @@ func CheckRepoStats(ctx context.Context) error {
 		},
 		// Repository.NumPulls
 		{
-			statsQuery("SELECT repo.id FROM `repository` repo WHERE repo.num_pulls!=(SELECT COUNT(*) FROM `issue` WHERE repo_id=repo.id AND is_closed=? AND is_pull=?)", false, true),
+			statsQuery("SELECT repo.id FROM `repository` repo WHERE repo.num_pulls!=(SELECT COUNT(*) FROM `issue` WHERE repo_id=repo.id AND is_pull=?)", true),
 			repoStatsCorrectNumPulls,
 			"repository count 'num_pulls'",
 		},

--- a/services/issue/issue.go
+++ b/services/issue/issue.go
@@ -220,8 +220,15 @@ func deleteIssue(issue *issues_model.Issue) error {
 		return err
 	}
 
-	if err := repo_model.UpdateRepoIssueNumbers(ctx, issue.RepoID, issue.IsPull, issue.IsClosed); err != nil {
+	// update the total issue numbers
+	if err := repo_model.UpdateRepoIssueNumbers(ctx, issue.RepoID, issue.IsPull, false); err != nil {
 		return err
+	}
+	// if the issue is closed, update the closed issue numbers
+	if issue.IsClosed {
+		if err := repo_model.UpdateRepoIssueNumbers(ctx, issue.RepoID, issue.IsPull, true); err != nil {
+			return err
+		}
 	}
 
 	if err := issues_model.UpdateMilestoneCounters(ctx, issue.MilestoneID); err != nil {


### PR DESCRIPTION
Backport #22037.

When deleting a closed issue, we should update both `NumIssues`and `NumClosedIssues`, or `NumOpenIssues`(`= NumIssues -NumClosedIssues`) will be wrong. It's the same for pull requests.

Releated to #21557.

Alse fixed two harmless problems:

- The SQL to check issue/PR total numbers is wrong, that means it will update the numbers even if they are correct.
- Replace legacy `num_issues = num_issues + 1` operations with `UpdateRepoIssueNumbers`.
