### PR TITLE
Support disabling database auto migration

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -403,6 +403,9 @@ LOG_SQL = false ; if unset defaults to true
 ;;
 ;; Database maximum number of open connections, default is 0 meaning no maximum
 ;MAX_OPEN_CONNS = 0
+;;
+;; Whether execute database models migrations automatically
+;AUTO_MIGRATION = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -444,6 +444,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `MAX_OPEN_CONNS` **0**: Database maximum open connections - default is 0, meaning there is no limit.
 - `MAX_IDLE_CONNS` **2**: Max idle database connections on connection pool, default is 2 - this will be capped to `MAX_OPEN_CONNS`.
 - `CONN_MAX_LIFETIME` **0 or 3s**: Sets the maximum amount of time a DB connection may be reused - default is 0, meaning there is no limit (except on MySQL where it is 3s - see #6804 & #7071).
+- `AUTO_MIGRATION` **true**: Whether execute database models migrations automatically.
 
 Please see #8540 & #8273 for further discussion of the appropriate values for `MAX_OPEN_CONNS`, `MAX_IDLE_CONNS` & `CONN_MAX_LIFETIME` and their
 relation to port exhaustion.

--- a/modules/doctor/dbversion.go
+++ b/modules/doctor/dbversion.go
@@ -12,6 +12,7 @@ import (
 )
 
 func checkDBVersion(ctx context.Context, logger log.Logger, autofix bool) error {
+	logger.Info("Expected database version: %d", migrations.ExpectedVersion())
 	if err := db.InitEngineWithMigration(ctx, migrations.EnsureUpToDate); err != nil {
 		if !autofix {
 			logger.Critical("Error: %v during ensure up to date", err)

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -49,6 +49,7 @@ var (
 		MaxOpenConns      int
 		ConnMaxLifetime   time.Duration
 		IterateBufferSize int
+		AutoMigration     bool
 	}{
 		Timeout:           500,
 		IterateBufferSize: 50,
@@ -105,6 +106,7 @@ func InitDBConfig() {
 	Database.LogSQL = sec.Key("LOG_SQL").MustBool(true)
 	Database.DBConnectRetries = sec.Key("DB_RETRIES").MustInt(10)
 	Database.DBConnectBackoff = sec.Key("DB_RETRY_BACKOFF").MustDuration(3 * time.Second)
+	Database.AutoMigration = sec.Key("AUTO_MIGRATION").MustBool(true)
 }
 
 // DBConnStr returns database connection string


### PR DESCRIPTION
Gitea will migrate the database model version automatically, but it should be able to be disabled and keep Gitea shutdown if the version is not matched.

An operator of a Gitea instance should have a choice to turn it off to avoid unexpected database changes, and when he finds the instance can't be started after upgrading Gitea to a new version, he can decide whether to migrate manually or undo the upgrade. It will be a strong reminder to backup database, we know the migrations can't be rolled back yet.

<img width="930" alt="image" src="https://user-images.githubusercontent.com/9418365/206106237-c8ec4f73-44d1-4c69-a5e1-e5f1576b47b4.png">
