### PR TITLE
Update go dev dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,28 @@
 linters:
   enable:
-    - gosimple
-    - deadcode
-    - typecheck
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - structcheck
-    - varcheck
-    - dupl
-    #- gocyclo # The cyclomatic complexety of a lot of functions is too high, we should refactor those another time.
-    - gofmt
-    - gocritic
     - bidichk
-    - ineffassign
-    - revive
-    - gofumpt
+    # - deadcode # deprecated - https://github.com/golangci/golangci-lint/issues/1841
     - depguard
+    - dupl
+    - errcheck
+    - gocritic
+    # - gocyclo # The cyclomatic complexety of a lot of functions is too high, we should refactor those another time.
+    - gofmt
+    - gofumpt
+    - gosimple
+    - govet
+    - ineffassign
     - nakedret
-    - unconvert
-    - wastedassign
     - nolintlint
+    - revive
+    - staticcheck
+    # - structcheck # deprecated - https://github.com/golangci/golangci-lint/issues/1841
     - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    # - varcheck # deprecated - https://github.com/golangci/golangci-lint/issues/1841
+    # - wastedassign # disabled - https://github.com/golangci/golangci-lint/issues/2649
   enable-all: false
   disable-all: true
   fast: false

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ COMMA := ,
 XGO_VERSION := go-1.19.x
 
 AIR_PACKAGE ?= github.com/cosmtrek/air@v1.40.4
-EDITORCONFIG_CHECKER_PACKAGE ?= github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@2.5.0
-ERRCHECK_PACKAGE ?= github.com/kisielk/errcheck@v1.6.1
-GOFUMPT_PACKAGE ?= mvdan.cc/gofumpt@v0.3.1
-GOLANGCI_LINT_PACKAGE ?= github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.0
+EDITORCONFIG_CHECKER_PACKAGE ?= github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@2.6.0
+ERRCHECK_PACKAGE ?= github.com/kisielk/errcheck@v1.6.2
+GOFUMPT_PACKAGE ?= mvdan.cc/gofumpt@v0.4.0
+GOLANGCI_LINT_PACKAGE ?= github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 GXZ_PAGAGE ?= github.com/ulikunitz/xz/cmd/gxz@v0.5.10
 MISSPELL_PACKAGE ?= github.com/client9/misspell/cmd/misspell@v0.3.4
-SWAGGER_PACKAGE ?= github.com/go-swagger/go-swagger/cmd/swagger@v0.30.0
+SWAGGER_PACKAGE ?= github.com/go-swagger/go-swagger/cmd/swagger@v0.30.3
 XGO_PACKAGE ?= src.techknowlogick.com/xgo@latest
-GO_LICENSES_PACKAGE ?= github.com/google/go-licenses@v1.3.0
+GO_LICENSES_PACKAGE ?= github.com/google/go-licenses@v1.5.0
 GOVULNCHECK_PACKAGE ?= golang.org/x/vuln/cmd/govulncheck@latest
 
 DOCKER_IMAGE ?= gitea/gitea

--- a/models/db/context.go
+++ b/models/db/context.go
@@ -21,8 +21,10 @@ type contextKey struct {
 }
 
 // enginedContextKey is a context key. It is used with context.Value() to get the current Engined for the context
-var enginedContextKey = &contextKey{"engined"}
-var _ Engined = &Context{}
+var (
+	enginedContextKey         = &contextKey{"engined"}
+	_                 Engined = &Context{}
+)
 
 // Context represents a db context
 type Context struct {

--- a/models/migrations/v1_17/main_test.go
+++ b/models/migrations/v1_17/main_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"testing"

--- a/models/migrations/v1_17/v211.go
+++ b/models/migrations/v1_17/v211.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_17/v212.go
+++ b/models/migrations/v1_17/v212.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/timeutil"

--- a/models/migrations/v1_17/v213.go
+++ b/models/migrations/v1_17/v213.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_17/v214.go
+++ b/models/migrations/v1_17/v214.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_17/v215.go
+++ b/models/migrations/v1_17/v215.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"code.gitea.io/gitea/models/pull"

--- a/models/migrations/v1_17/v216.go
+++ b/models/migrations/v1_17/v216.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 // This migration added non-ideal indices to the action table which on larger datasets slowed things down
 // it has been superceded by v218.go

--- a/models/migrations/v1_17/v217.go
+++ b/models/migrations/v1_17/v217.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/setting"

--- a/models/migrations/v1_17/v218.go
+++ b/models/migrations/v1_17/v218.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/setting"

--- a/models/migrations/v1_17/v219.go
+++ b/models/migrations/v1_17/v219.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"time"

--- a/models/migrations/v1_17/v220.go
+++ b/models/migrations/v1_17/v220.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	packages_model "code.gitea.io/gitea/models/packages"

--- a/models/migrations/v1_17/v221.go
+++ b/models/migrations/v1_17/v221.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"encoding/base32"

--- a/models/migrations/v1_17/v221_test.go
+++ b/models/migrations/v1_17/v221_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"encoding/base32"

--- a/models/migrations/v1_17/v222.go
+++ b/models/migrations/v1_17/v222.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"context"

--- a/models/migrations/v1_17/v223.go
+++ b/models/migrations/v1_17/v223.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_17 // nolint
+package v1_17 //nolint
 
 import (
 	"context"

--- a/models/migrations/v1_18/main_test.go
+++ b/models/migrations/v1_18/main_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"testing"

--- a/models/migrations/v1_18/v224.go
+++ b/models/migrations/v1_18/v224.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_18/v225.go
+++ b/models/migrations/v1_18/v225.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/setting"

--- a/models/migrations/v1_18/v226.go
+++ b/models/migrations/v1_18/v226.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"xorm.io/builder"

--- a/models/migrations/v1_18/v227.go
+++ b/models/migrations/v1_18/v227.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_18/v228.go
+++ b/models/migrations/v1_18/v228.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/timeutil"

--- a/models/migrations/v1_18/v230.go
+++ b/models/migrations/v1_18/v230.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_18 // nolint
+package v1_18 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_19/main_test.go
+++ b/models/migrations/v1_19/main_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_19 // nolint
+package v1_19 //nolint
 
 import (
 	"testing"

--- a/models/migrations/v1_19/v232.go
+++ b/models/migrations/v1_19/v232.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_19 // nolint
+package v1_19 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/setting"

--- a/models/migrations/v1_6/v70.go
+++ b/models/migrations/v1_6/v70.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_6 // nolint
+package v1_6 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_6/v71.go
+++ b/models/migrations/v1_6/v71.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_6 // nolint
+package v1_6 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_6/v72.go
+++ b/models/migrations/v1_6/v72.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_6 // nolint
+package v1_6 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_7/v73.go
+++ b/models/migrations/v1_7/v73.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_7 // nolint
+package v1_7 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_7/v74.go
+++ b/models/migrations/v1_7/v74.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_7 // nolint
+package v1_7 //nolint
 
 import "xorm.io/xorm"
 

--- a/models/migrations/v1_7/v75.go
+++ b/models/migrations/v1_7/v75.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_7 // nolint
+package v1_7 //nolint
 
 import (
 	"xorm.io/builder"

--- a/models/migrations/v1_8/v76.go
+++ b/models/migrations/v1_8/v76.go
@@ -1,7 +1,7 @@
 // Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_8/v77.go
+++ b/models/migrations/v1_8/v77.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import (
 	"xorm.io/xorm"

--- a/models/migrations/v1_8/v78.go
+++ b/models/migrations/v1_8/v78.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import (
 	"code.gitea.io/gitea/models/migrations/base"

--- a/models/migrations/v1_8/v79.go
+++ b/models/migrations/v1_8/v79.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import (
 	"code.gitea.io/gitea/modules/setting"

--- a/models/migrations/v1_8/v80.go
+++ b/models/migrations/v1_8/v80.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import "xorm.io/xorm"
 

--- a/models/migrations/v1_8/v81.go
+++ b/models/migrations/v1_8/v81.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_8 // nolint
+package v1_8 //nolint
 
 import (
 	"fmt"

--- a/models/migrations/v1_9/v82.go
+++ b/models/migrations/v1_9/v82.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_9 // nolint
+package v1_9 //nolint
 
 import (
 	"fmt"

--- a/modules/charset/escape_stream.go
+++ b/modules/charset/escape_stream.go
@@ -239,7 +239,7 @@ func (counts runeCountType) needsEscape() bool {
 type runeType int
 
 const (
-	basicASCIIRuneType runeType = iota //nolint // <- This is technically deadcode but its self-documenting so it should stay
+	basicASCIIRuneType runeType = iota // <- This is technically deadcode but its self-documenting so it should stay
 	brokenRuneType
 	nonBasicASCIIRuneType
 	ambiguousRuneType

--- a/modules/log/groutinelabel.go
+++ b/modules/log/groutinelabel.go
@@ -6,7 +6,7 @@ package log
 import "unsafe"
 
 //go:linkname runtime_getProfLabel runtime/pprof.runtime_getProfLabel
-func runtime_getProfLabel() unsafe.Pointer // nolint
+func runtime_getProfLabel() unsafe.Pointer //nolint
 
 type labelMap map[string]string
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -941,7 +941,7 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	if SecretKey == "" {
 		// FIXME: https://github.com/go-gitea/gitea/issues/16832
 		// Until it supports rotating an existing secret key, we shouldn't move users off of the widely used default value
-		SecretKey = "!#@FDEWREWR&*(" // nolint:gosec
+		SecretKey = "!#@FDEWREWR&*(" //nolint:gosec
 	}
 
 	CookieRememberName = sec.Key("COOKIE_REMEMBER_NAME").MustString("gitea_incredible")

--- a/routers/api/packages/pypi/pypi.go
+++ b/routers/api/packages/pypi/pypi.go
@@ -21,8 +21,10 @@ import (
 )
 
 // https://peps.python.org/pep-0426/#name
-var normalizer = strings.NewReplacer(".", "-", "_", "-")
-var nameMatcher = regexp.MustCompile(`\A(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\.\-_]*[a-zA-Z0-9])\z`)
+var (
+	normalizer  = strings.NewReplacer(".", "-", "_", "-")
+	nameMatcher = regexp.MustCompile(`\A(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\.\-_]*[a-zA-Z0-9])\z`)
+)
 
 // https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 var versionMatcher = regexp.MustCompile(`\Av?` +


### PR DESCRIPTION
`golangci-lint` [deprecated](https://github.com/golangci/golangci-lint/issues/1841) a bunch of linters, removed them.