### PR TITLE
Rename actions to operations on UI

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1018,7 +1018,7 @@ unstar = Unstar
 star = Star
 fork = Fork
 download_archive = Download Repository
-more_actions = More Actions
+more_operations = More Operations
 
 no_desc = No Description
 quick_guide = Quick Guide
@@ -1173,7 +1173,7 @@ commits.signed_by_untrusted_user_unmatched = Signed by untrusted user who does n
 commits.gpg_key_id = GPG Key ID
 commits.ssh_key_fingerprint = SSH Key Fingerprint
 
-commit.actions = Actions
+commit.operations = Operations
 commit.revert = Revert
 commit.revert-header = Revert: %s
 commit.revert-content = Select branch to revert onto:
@@ -2989,7 +2989,7 @@ monitor.queue.pool.cancel_desc = Leaving a queue without any worker groups may c
 
 notices.system_notice_list = System Notices
 notices.view_detail_header = View Notice Details
-notices.actions = Actions
+notices.operations = Operations
 notices.select_all = Select All
 notices.deselect_all = Deselect All
 notices.inverse_selection = Inverse Selection

--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -46,7 +46,7 @@
 										</form>
 									</div>
 									<div class="ui floating upward dropdown small button">
-										<span class="text">{{.locale.Tr "admin.notices.actions"}}</span>
+										<span class="text">{{.locale.Tr "admin.notices.operations"}}</span>
 										<div class="menu">
 											<div class="item select action" data-action="select-all">
 												{{.locale.Tr "admin.notices.select_all"}}

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -26,10 +26,10 @@
 							{{.locale.Tr "repo.diff.browse_source"}}
 						</a>
 						{{if and ($.Permission.CanWrite $.UnitTypeCode) (not $.Repository.IsArchived) (not .IsDeleted)}}{{- /* */ -}}
-							<div class="ui primary tiny floating dropdown icon button">{{.locale.Tr "repo.commit.actions"}}
+							<div class="ui primary tiny floating dropdown icon button">{{.locale.Tr "repo.commit.operations"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 								<div class="menu">
-									<div class="ui header">{{.locale.Tr "repo.commit.actions"}}</div>
+									<div class="ui header">{{.locale.Tr "repo.commit.operations"}}</div>
 									<div class="divider"></div>
 									<div class="item show-create-branch-modal"
 										data-content="{{$.locale.Tr "repo.branch.new_branch_from" (.CommitID)}}"

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -117,7 +117,7 @@
 				{{if eq $n 0}}
 					<div class="ui action tiny input" id="clone-panel">
 						{{template "repo/clone_buttons" .}}
-						<button id="more-btn" class="ui basic small compact jump dropdown icon button tooltip" data-content="{{.locale.Tr "repo.more_actions"}}" data-position="top right">
+						<button id="more-btn" class="ui basic small compact jump dropdown icon button tooltip" data-content="{{.locale.Tr "repo.more_operations"}}" data-position="top right">
 							{{svg "octicon-kebab-horizontal"}}
 							<div class="menu">
 								{{if not $.DisableDownloadSourceArchives}}


### PR DESCRIPTION
Use "operations" to indicate "some something can be done", to prevent users from confusing it with CICD.

Releated to: #13539.

Snapshots:

<img width="389" alt="image" src="https://user-images.githubusercontent.com/9418365/206409797-a99bac25-2d38-4066-b9ab-27a4f6fe67e7.png">
<img width="398" alt="image" src="https://user-images.githubusercontent.com/9418365/206410099-bbd258a9-54d9-4664-8d95-31d29cb35209.png">
<img width="442" alt="image" src="https://user-images.githubusercontent.com/9418365/206410218-009a3103-a9b9-4d0c-86b6-540dda5bce89.png">

I'm not a native English speaker, but I think "operations" may be good enough, and Gitea already uses this word:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9418365/206410671-4a718b14-0603-40cb-bdcb-f6f84d1f5e24.png">

