### PR TITLE
Fix wrong default value for update checker on app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2147,7 +2147,7 @@ ROUTER = console
 ;[cron.update_checker]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;ENABLED = false
+;ENABLED = true
 ;RUN_AT_START = false
 ;ENABLE_SUCCESS_NOTICE = false
 ;SCHEDULE = @every 168h

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -1005,7 +1005,7 @@ Default templates for project boards:
 
 #### Cron -  Check for new Gitea versions ('cron.update_checker')
 
-- `ENABLED`: **false**: Enable service.
+- `ENABLED`: **true**: Enable service.
 - `RUN_AT_START`: **false**: Run tasks at start up time (if ENABLED).
 - `ENABLE_SUCCESS_NOTICE`: **true**: Set to false to switch off success notices.
 - `SCHEDULE`: **@every 168h**: Cron syntax for scheduling a work, e.g. `@every 168h`.


### PR DESCRIPTION
Fix #22078 

Note from @jolheiser: this **is not** breaking, but deserves a note in the changelog/blog to let users know. 🙂 
The label can be removed after the note has been added.