### PR TITLE
fix(config): remove context on config template

### DIFF
--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -177,7 +177,7 @@
 					<dt>{{.locale.Tr "admin.config.default_enable_timetracking"}}</dt>
 					<dd>{{if .Service.DefaultEnableTimetracking}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 					<dt>{{.locale.Tr "admin.config.default_allow_only_contributors_to_track_time"}}</dt>
-					<dd>{{if .Service.DefaultAllowOnlyContributorsToTrackTime $.Context}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
+					<dd>{{if .Service.DefaultAllowOnlyContributorsToTrackTime}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				{{end}}
 				<dt>{{.locale.Tr "admin.config.default_visibility_organization"}}</dt>
 				<dd>{{.Service.DefaultOrgVisibility}}</dd>


### PR DESCRIPTION
👋 Hey
I'm new around here, so I may have done some mistakes, sorry! 

---

## Context
On a fresh Gitea install, when I go to the [config admin page](http://localhost:3000/admin/config) I had a 500 error page.
The logs:
```
2022/12/10 20:08:47 ...s/context/context.go:232:HTML() [E] [6394d93f] Render failed: template: admin/config:180:22: executing "admin/config" at <.Service.DefaultAllowOnlyContributorsToTrackTime>: DefaultAllowOnlyContributorsToTrackTime has arguments but cannot be invoked as function
2022/12/10 20:08:47 [6394d93f] router: completed GET /admin/config for [::1]:43800, 500 Internal Server Error in 5.1ms @ admin/config.go:99(admin.Config)
```

## The fix

I removed the `$.Context` on the `.Service.DefaultAllowOnlyContributorsToTrackTime` to fix the 500 error page happening. It could be a mistake, and I don't fully understand what I've done!

Signed-off-by: Restray <contact@restray.org>