### PR TITLE
Replace Placeholders in Licenses

### DIFF
--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -11,9 +11,9 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -284,7 +284,7 @@ func prepareRepoCommit(ctx context.Context, repo *repo_model.Repository, tmpDir,
 	if len(opts.License) > 0 {
 		data, err = GetRepoInitFile("license", opts.License)
 
-		// Replace placeholders in License
+		// Replace Placeholders in License
 		data = bytes.ReplaceAll(data, []byte("<program>"), []byte(repo.Name))
 		data = bytes.ReplaceAll(data, []byte("<owner>"), []byte(repo.OwnerName))
 		data = bytes.ReplaceAll(data, []byte("<name of author>"), []byte(repo.OwnerName))

--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -286,10 +286,13 @@ func prepareRepoCommit(ctx context.Context, repo *repo_model.Repository, tmpDir,
 
 		// Replace Placeholders in License
 		data = bytes.ReplaceAll(data, []byte("<program>"), []byte(repo.Name))
+		data = bytes.ReplaceAll(data, []byte("[NAME]"), []byte(repo.OwnerName))
 		data = bytes.ReplaceAll(data, []byte("<owner>"), []byte(repo.OwnerName))
 		data = bytes.ReplaceAll(data, []byte("<name of author>"), []byte(repo.OwnerName))
 		data = bytes.ReplaceAll(data, []byte("<copyright holders>"), []byte(repo.OwnerName))
 		data = bytes.ReplaceAll(data, []byte("<year>"), []byte(strconv.Itoa(time.Now().Year())))
+		data = bytes.ReplaceAll(data, []byte("[YEAR]"), []byte(strconv.Itoa(time.Now().Year())))
+		data = bytes.ReplaceAll(data, []byte("{YEAR}"), []byte(strconv.Itoa(time.Now().Year())))
 		data = bytes.ReplaceAll(data, []byte("<one line to give the program's name and a brief idea of what it does.>"), []byte(repo.Description))
 
 		if err != nil {

--- a/modules/repository/init.go
+++ b/modules/repository/init.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"strconv"
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -282,6 +283,15 @@ func prepareRepoCommit(ctx context.Context, repo *repo_model.Repository, tmpDir,
 	// LICENSE
 	if len(opts.License) > 0 {
 		data, err = GetRepoInitFile("license", opts.License)
+
+		// Replace placeholders in License
+		data = bytes.ReplaceAll(data, []byte("<program>"), []byte(repo.Name))
+		data = bytes.ReplaceAll(data, []byte("<owner>"), []byte(repo.OwnerName))
+		data = bytes.ReplaceAll(data, []byte("<name of author>"), []byte(repo.OwnerName))
+		data = bytes.ReplaceAll(data, []byte("<copyright holders>"), []byte(repo.OwnerName))
+		data = bytes.ReplaceAll(data, []byte("<year>"), []byte(strconv.Itoa(time.Now().Year())))
+		data = bytes.ReplaceAll(data, []byte("<one line to give the program's name and a brief idea of what it does.>"), []byte(repo.Description))
+
 		if err != nil {
 			return fmt.Errorf("GetRepoInitFile[%s]: %w", opts.License, err)
 		}


### PR DESCRIPTION
Some Licenses have Placeholders e.g. the BSD Licenses start with this line:
```
Copyright (c) <year> <owner>. 
```
This PR replaces the placeholders with the correct value, when creating a new Repo. Tested with the BSD, GPL, AGPL and MIT Licenses, which are the most used.