### PR TITLE
Correctly handle moved files in apply patch

### DIFF
--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -54,6 +54,7 @@ var patchErrorSuffices = []string{
 	": already exists in working directory",
 	"unrecognized input",
 	": No such file or directory",
+	": does not exist in index",
 }
 
 // TestPatch will test whether a simple patch will apply

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -53,6 +53,7 @@ var patchErrorSuffices = []string{
 	": patch does not apply",
 	": already exists in working directory",
 	"unrecognized input",
+	": No such file or directory",
 }
 
 // TestPatch will test whether a simple patch will apply

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -417,6 +417,7 @@ func checkConflicts(ctx context.Context, pr *issues_model.PullRequest, gitRepo *
 				scanner := bufio.NewScanner(stderrReader)
 				for scanner.Scan() {
 					line := scanner.Text()
+					log.Trace("PullRequest[%d].testPatch: stderr: %s", pr.ID, line)
 					if strings.HasPrefix(line, prefix) {
 						conflict = true
 						filepath := strings.TrimSpace(strings.Split(line[len(prefix):], ":")[0])


### PR DESCRIPTION
Moved files in a patch will result in git apply returning:

```
error: {filename}: No such file or directory
```

This wasn't handled by the git apply patch code. This PR adds handling for this.

Fix #22083

Signed-off-by: Andrew Thornton <art27@cantab.net>
