### PR TITLE
Fix margin and alignment in dashboard repolist (#22120)

### DIFF
--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -128,9 +128,9 @@
 				<ul class="repo-owner-name-list">
 					<li v-for="repo in repos" :class="{'private': repo.private || repo.internal}">
 						<a class="repo-list-link df ac sb" :href="repo.html_url">
-							<div class="text truncate item-name df ac f1">
+							<div class="item-name df ac f1 mr-2">
 								<component v-bind:is="repoIcon(repo)" size="16" class="mr-2"></component>
-								<strong class="ml-1">${repo.full_name}</strong>
+								<div class="text bold truncate ml-1">${repo.full_name}</div>
 								<span v-if="repo.archived">
 									{{svg "octicon-archive" 16 "ml-2"}}
 								</span>

--- a/templates/user/dashboard/repolist.tmpl
+++ b/templates/user/dashboard/repolist.tmpl
@@ -128,9 +128,9 @@
 				<ul class="repo-owner-name-list">
 					<li v-for="repo in repos" :class="{'private': repo.private || repo.internal}">
 						<a class="repo-list-link df ac sb" :href="repo.html_url">
-							<div class="text truncate item-name f1">
-								<component v-bind:is="repoIcon(repo)" size="16"></component>
-								<strong>${repo.full_name}</strong>
+							<div class="text truncate item-name df ac f1">
+								<component v-bind:is="repoIcon(repo)" size="16" class="mr-2"></component>
+								<strong class="ml-1">${repo.full_name}</strong>
 								<span v-if="repo.archived">
 									{{svg "octicon-archive" 16 "ml-2"}}
 								</span>

--- a/web_src/less/_dashboard.less
+++ b/web_src/less/_dashboard.less
@@ -188,7 +188,11 @@
     }
 
     .repo-owner-name-list .item-name {
-      max-width: 70%;
+      min-width: 0;
+    }
+
+    .repo-owner-name-list .item-name svg {
+      min-width: 16px;
     }
   }
 }


### PR DESCRIPTION
Backport #22120 to 1.18. Seems this has recently regressed, previously, there was a significant whitespace between icon and text, but it seems to be gone, so I added the margin.