### PR TITLE
Fix markdown typo of an extra backtick in docs

### DIFF
--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -145,7 +145,7 @@ launched manually from command line, it can be killed by pressing `Ctrl + C`.
 
 Gitea will search for a number of things from the _`CustomPath`_. By default this is
 the `custom/` directory in the current working directory when running Gitea. It will also
-look for its configuration file _`CustomConf`_ in _`CustomPath`_/conf/app.ini`, and will use the
+look for its configuration file _`CustomConf`_ in _`CustomPath_/conf/app.ini`, and will use the
 current working directory as the relative base path _`AppWorkPath`_ for a number configurable
 values. Finally the static files will be served from _`StaticRootPath`_ which defaults to the _`AppWorkPath`_.
 

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -145,7 +145,7 @@ launched manually from command line, it can be killed by pressing `Ctrl + C`.
 
 Gitea will search for a number of things from the _`CustomPath`_. By default this is
 the `custom/` directory in the current working directory when running Gitea. It will also
-look for its configuration file _`CustomConf`_ in _`CustomPath_/conf/app.ini`, and will use the
+look for its configuration file _`CustomConf`_ in `$(CustomPath)/conf/app.ini`, and will use the
 current working directory as the relative base path _`AppWorkPath`_ for a number configurable
 values. Finally the static files will be served from _`StaticRootPath`_ which defaults to the _`AppWorkPath`_.
 


### PR DESCRIPTION
This pull request fixes a visual bug in docs which is caused by a typo of an extra backtick.

### Screenshot:
![firefox_PkeHeUkKtN](https://user-images.githubusercontent.com/28637006/207453327-db8b75d4-eb29-4549-b64b-3af6c60797f1.png)

**Page Link:** https://docs.gitea.io/en-us/install-from-source/