### PR TITLE
Fix condition for is_internal (#22095)

### DIFF
--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -289,7 +289,7 @@ func SearchLatestVersions(ctx context.Context, opts *PackageSearchOptions) ([]*P
 
 	sess := db.GetEngine(ctx).
 		Table("package_version").
-		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))").
+		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND pv2.is_internal = ? AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))", false).
 		Join("INNER", "package", "package.id = package_version.package_id").
 		Where(cond)
 


### PR DESCRIPTION
Backport of #22095

I changed it to a static condition because it needs a new version of xorm which is only available in 1.19. This change is valid because `SearchLatestVersions` is never called to list internal versions and there will no change to this behaviour in <1.19.