### PR TITLE
Fix condition for is_internal (#22095)

### DIFF
--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -303,14 +303,9 @@ func SearchLatestVersions(ctx context.Context, opts *PackageSearchOptions) ([]*P
 	cond := opts.toConds().
 		And(builder.Expr("pv2.id IS NULL"))
 
-	joinCond := builder.Expr("package_version.package_id = pv2.package_id AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))")
-	if !opts.IsInternal.IsNone() {
-		joinCond = joinCond.And(builder.Eq{"pv2.is_internal": opts.IsInternal.IsTrue()})
-	}
-
 	sess := db.GetEngine(ctx).
 		Table("package_version").
-		Join("LEFT", "package_version pv2", joinCond).
+		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND pv2.is_internal = false AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))").
 		Join("INNER", "package", "package.id = package_version.package_id").
 		Where(cond)
 

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -303,9 +303,14 @@ func SearchLatestVersions(ctx context.Context, opts *PackageSearchOptions) ([]*P
 	cond := opts.toConds().
 		And(builder.Expr("pv2.id IS NULL"))
 
+	joinCond := builder.Expr("package_version.package_id = pv2.package_id AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))")
+	if !opts.IsInternal.IsNone() {
+		joinCond = joinCond.And(builder.Eq{"pv2.is_internal": opts.IsInternal.IsTrue()})
+	}
+
 	sess := db.GetEngine(ctx).
 		Table("package_version").
-		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))").
+		Join("LEFT", "package_version pv2", joinCond).
 		Join("INNER", "package", "package.id = package_version.package_id").
 		Where(cond)
 

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -305,7 +305,7 @@ func SearchLatestVersions(ctx context.Context, opts *PackageSearchOptions) ([]*P
 
 	sess := db.GetEngine(ctx).
 		Table("package_version").
-		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND pv2.is_internal = false AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))").
+		Join("LEFT", "package_version pv2", "package_version.package_id = pv2.package_id AND pv2.is_internal = ? AND (package_version.created_unix < pv2.created_unix OR (package_version.created_unix = pv2.created_unix AND package_version.id < pv2.id))", false).
 		Join("INNER", "package", "package.id = package_version.package_id").
 		Where(cond)
 

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -402,8 +402,9 @@ func setPackageTag(tag string, pv *packages_model.PackageVersion, deleteOnly boo
 
 func PackageSearch(ctx *context.Context) {
 	pvs, total, err := packages_model.SearchLatestVersions(ctx, &packages_model.PackageSearchOptions{
-		OwnerID: ctx.Package.Owner.ID,
-		Type:    packages_model.TypeNpm,
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeNpm,
+		IsInternal: util.OptionalBoolFalse,
 		Name: packages_model.SearchValue{
 			ExactMatch: false,
 			Value:      ctx.FormTrim("text"),


### PR DESCRIPTION
Backport of #22095

I changed it to a static condition because it needs a new version of xorm which is only available in 1.19. This change is valid because `SearchLatestVersions` is never called to list internal versions and there will no change to this behaviour in <1.19.