### PR TITLE
Make gitea work using cmd.exe again (#22073)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -465,6 +465,13 @@ func getAppPath() (string, error) {
 	}
 
 	if err != nil {
+		// FIXME: Once we switch to go 1.19 use !errors.Is(err, exec.ErrDot)
+		if !strings.Contains(err.Error(), "cannot run executable found relative to current directory") {
+			return "", err
+		}
+		appPath, err = filepath.Abs(os.Args[0])
+	}
+	if err != nil {
 		return "", err
 	}
 	appPath, err = filepath.Abs(appPath)


### PR DESCRIPTION
Backport #22073

Gitea will attempt to lookup its location using LookPath however, this fails on cmd.exe if gitea is in the current working directory.

exec.LookPath will return an exec.ErrDot error which we can test for and then simply using filepath.Abs(os.Args[0]) to absolute gitea against the current working directory.

Fix #22063

Signed-off-by: Andrew Thornton <art27@cantab.net>
