### PR TITLE
Add customizable emoji aliases in app.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1295,6 +1295,19 @@ ROUTER = console
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[ui.emoji_aliases]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Add self-defined emoji aliases into this section, for example,
+;thumbs_up = thumbsup
+;; will map the self-defined alias "thumbs_up" to gitea defined alias "thumbsup".
+;; Add as many mapping pairs as you need. Please note that self-defined aliases are in priority.
+;; Beware that self-defined emoji aliases might conflict with the Unicode standard emoji
+;; names (aliases), which might cause incompatibility problems when migrating repositories.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;[markdown]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -240,6 +240,12 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `NOTICE_PAGING_NUM`: **25**: Number of notices that are shown in one page.
 - `ORG_PAGING_NUM`: **50**: Number of organizations that are shown in one page.
 
+### UI - Custom Emoji Aliases (`ui.emoji_aliases`)
+
+Add self-defined emoji aliases into this section, for example,
+**thumbs_up = thumbsup**
+will map the self-defined alias "thumbs_up" to gitea defined alias "thumbsup". Add as many mapping pairs as you need. Please note that self-defined aliases are in priority. Beware that self-defined emoji aliases might conflict with the Unicode standard emoji names (aliases), which might cause incompatibility problems when migrating repositories.
+
 ### UI - User (`ui.user`)
 
 - `REPO_PAGING_NUM`: **15**: Number of repos that are shown in one page.

--- a/modules/emoji/emoji.go
+++ b/modules/emoji/emoji.go
@@ -30,6 +30,9 @@ var (
 	// aliasMap provides a map of the alias to its emoji data.
 	aliasMap map[string]int
 
+	// customAliasMap maps custom emoji alias to defined emoji alias.
+	customAliasMap map[string]string
+
 	// emptyReplacer is the string replacer for emoji codes.
 	emptyReplacer *strings.Replacer
 
@@ -47,6 +50,7 @@ func loadMap() {
 		// initialize
 		codeMap = make(map[string]int, len(GemojiData))
 		aliasMap = make(map[string]int, len(GemojiData))
+		customAliasMap = make(map[string]string)
 
 		// process emoji codes and aliases
 		codePairs := make([]string, 0)
@@ -106,7 +110,10 @@ func FromAlias(alias string) *Emoji {
 	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
 		alias = alias[1 : len(alias)-1]
 	}
-
+	customAlias, ok := customAliasMap[alias]
+	if ok {
+		alias = customAlias
+	}
 	i, ok := aliasMap[alias]
 	if !ok {
 		return nil
@@ -183,4 +190,10 @@ func FindEmojiSubmatchIndex(s string) []int {
 	}
 
 	return []int{secondWriteWriter.idx, secondWriteWriter.end}
+}
+
+// AddCustomAliasMap sets up map from custom alias to predefined alias
+func AddCustomAliasMap(c, a string) {
+	loadMap()
+	customAliasMap[c] = a
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/container"
+	"code.gitea.io/gitea/modules/emoji"
 	"code.gitea.io/gitea/modules/generate"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
@@ -1137,6 +1138,10 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 	UI.CustomEmojisMap = make(map[string]string)
 	for _, emoji := range UI.CustomEmojis {
 		UI.CustomEmojisMap[emoji] = ":" + emoji + ":"
+	}
+	customAliases := Cfg.Section("ui.emoji_aliases")
+	for _, i := range customAliases.KeyStrings() {
+		emoji.AddCustomAliasMap(i, customAliases.Key(i).String())
 	}
 }
 


### PR DESCRIPTION
This patch provides customizable emoji aliases
Add [ui.emoji_aliases] section in app.ini to customize emoji aliases without rebuilding the server.

The core idea is, to search for the emoji from the alias (emoji.FromAlias()), searching customized mapping first, when finding a customized alias, map it into a predefined emoji alias, then get the emoji index from the predefined alias name.

Fix #22153