### PR TITLE
Fix heatmap first color being unused

### DIFF
--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -53,7 +53,7 @@ export default {
   },
   mounted() {
     // work around issue with first legend color being rendered twice and legend cut off
-    const legend = document.querySelector('#user-heatmap .vch__external-legend-wrapper');
+    const legend = document.querySelector('.vch__external-legend-wrapper');
     legend.setAttribute('viewBox', '12 0 80 10');
     legend.style.marginRight = '-12px';
   },

--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -51,6 +51,12 @@ export default {
       return s;
     }
   },
+  mounted() {
+    // work around issue with first legend color being rendered twice and legend cut off
+    const legend = document.querySelector('#user-heatmap .vch__external-legend-wrapper');
+    legend.setAttribute('viewBox', '12 0 80 10');
+    legend.style.marginRight = '-12px';
+  },
   methods: {
     handleDayClick(e) {
       // Reset filter if same date is clicked

--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -29,6 +29,7 @@ export default {
   data: () => ({
     colorRange: [
       'var(--color-secondary-alpha-70)',
+      'var(--color-secondary-alpha-70)',
       'var(--color-primary-light-4)',
       'var(--color-primary-light-2)',
       'var(--color-primary)',


### PR DESCRIPTION
Backport #22157. vue3-calendar-heatmap has the behaviour that the first and second colors are mapped to values null and 0, meaning the second color was not used as intended for values > 0. I think this is a behaviour change from previous vue2 version that was missed during the upgrade.

This change makes first and second values the same, so the heatmap can now use one additional color for meaningful values.