### PR TITLE
Local storage should not store files as executable

### DIFF
--- a/modules/storage/local.go
+++ b/modules/storage/local.go
@@ -102,7 +102,8 @@ func (l *LocalStorage) Save(path string, r io.Reader, size int64) (int64, error)
 		return 0, err
 	}
 	// Golang's tmp file (os.CreateTemp) always have 0o600 mode, so we need to change the file to follow the umask (as what Create/MkDir does)
-	if err := util.ApplyUmask(p, os.ModePerm); err != nil {
+	// but we don't want to make these files executable - so ensure that we mask out the executable bits
+	if err := util.ApplyUmask(p, os.ModePerm&0o666); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
The PR #21198 introduced a probable security vulnerability which resulted in making all storage files be marked as executable.

This PR ensures that these are forcibly marked as non-executable.

Fix #22161

Signed-off-by: Andrew Thornton <art27@cantab.net>
