### PR TITLE
Do not list active repositories as unadopted (#22034)

### DIFF
--- a/services/repository/adopt.go
+++ b/services/repository/adopt.go
@@ -340,7 +340,7 @@ func ListUnadoptedRepositories(query string, opts *db.ListOptions) ([]string, in
 		}
 
 		repoNamesToCheck = append(repoNamesToCheck, name)
-		if len(repoNamesToCheck) > setting.Database.IterateBufferSize {
+		if len(repoNamesToCheck) >= setting.Database.IterateBufferSize {
 			if err = checkUnadoptedRepositories(userName, repoNamesToCheck, unadopted); err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport #22034

This fixes a bug where, when searching unadopted repositories, active repositories will be listed as well. This is because the size of the array of repository names to check is larger by one than the `IterateBufferSize`.

For an `IterateBufferSize` of 50, the original code will pass 51 repository names but set the query to `LIMIT 50`. If all repositories in the query are active (i.e. not unadopted) one of them will be omitted from the result. Due to the `ORDER BY` clause it will be the oldest (or least recently modified) one.