### PR TITLE
Improve notification and stopwatch styles

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -3,22 +3,24 @@
 	{{if .IsSigned}}
 		{{if .NotificationUnreadCount}}{{$notificationUnreadCount = call .NotificationUnreadCount}}{{end}}
 	{{end}}
-	<div class="item brand" style="justify-content: space-between;">
+	<div class="item brand sb">
 		<a href="{{AppSubUrl}}/" aria-label="{{if .IsSigned}}{{.locale.Tr "dashboard"}}{{else}}{{.locale.Tr "home"}}{{end}}">
 			<img width="30" height="30" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{.locale.Tr "logo"}}" aria-hidden="true">
 		</a>
-		{{if .IsSigned}}
-		<a href="{{AppSubUrl}}/notifications" class="tooltip mobile-only" data-content='{{.locale.Tr "notifications"}}'>
-			<span class="text black">
-				<span class="fitted">{{svg "octicon-bell"}}</span>
-				<span class="ui red label mini{{if not $notificationUnreadCount}} hidden{{end}} notification_count">
-					{{$notificationUnreadCount}}
+		<div class="df ac">
+			{{if .IsSigned}}
+			<a href="{{AppSubUrl}}/notifications" class="tooltip mobile-only mr-4 mt-3" data-content="{{.locale.Tr "notifications"}}" aria-label="{{.locale.Tr "notifications"}}">
+				<span class="fitted item">
+					{{svg "octicon-bell"}}
+					<span class="notification_count{{if not $notificationUnreadCount}} hidden{{end}}">
+						{{$notificationUnreadCount}}
+					</span>
 				</span>
-			</span>
-		</a>
-		{{end}}
-		<div class="ui basic icon button mobile-only" id="navbar-expand-toggle">
-			<i class="sidebar icon"></i>
+			</a>
+			{{end}}
+			<div class="ui icon button mobile-only" id="navbar-expand-toggle">
+				{{svg "octicon-three-bars"}}
+			</div>
 		</div>
 	</div>
 
@@ -77,12 +79,10 @@
 		</div>
 	{{else if .IsSigned}}
 		<div class="right stackable menu">
-			<a class="active-stopwatch-trigger item ui label {{if not .ActiveStopwatch}}hidden{{end}}" href="{{.ActiveStopwatch.IssueLink}}">
-				<span class="text">
-					<span class="fitted item">
-						{{svg "octicon-stopwatch"}}
-						<span class="red" style="position:absolute; right:-0.6em; top:-0.6em;">{{svg "octicon-dot-fill"}}</span>
-					</span>
+			<a class="active-stopwatch-trigger item ui mx-0{{if not .ActiveStopwatch}} hidden{{end}}" href="{{.ActiveStopwatch.IssueLink}}">
+				<span class="fitted relative">
+					{{svg "octicon-stopwatch"}}
+					<span class="header-stopwatch-dot"></span>
 					<span class="sr-mobile-only">{{.locale.Tr "active_stopwatch"}}</span>
 				</span>
 			</a>
@@ -116,16 +116,16 @@
 				</div>
 			</div>
 
-			<a href="{{AppSubUrl}}/notifications" class="item tooltip not-mobile" data-content="{{.locale.Tr "notifications"}}" aria-label="{{.locale.Tr "notifications"}}">
-				<span class="text">
-					<span class="fitted">{{svg "octicon-bell"}}</span>
-					<span class="ui red label {{if not $notificationUnreadCount}}hidden{{end}} notification_count">
+			<a href="{{AppSubUrl}}/notifications" class="item tooltip not-mobile mx-0" data-content="{{.locale.Tr "notifications"}}" aria-label="{{.locale.Tr "notifications"}}">
+				<span class="fitted item">
+					{{svg "octicon-bell"}}
+					<span class="notification_count{{if not $notificationUnreadCount}} hidden{{end}}">
 						{{$notificationUnreadCount}}
 					</span>
 				</span>
 			</a>
 
-			<div class="ui dropdown jump item tooltip" data-content="{{.locale.Tr "create_new"}}">
+			<div class="ui dropdown jump item tooltip mx-0" data-content="{{.locale.Tr "create_new"}}">
 				<span class="text">
 					<span class="fitted">{{svg "octicon-plus"}}</span>
 					<span class="sr-mobile-only">{{.locale.Tr "create_new"}}</span>
@@ -148,7 +148,7 @@
 				</div><!-- end content create new menu -->
 			</div><!-- end dropdown menu create new -->
 
-			<div class="ui dropdown jump item tooltip" tabindex="-1" data-content="{{.locale.Tr "user_profile_and_more"}}">
+			<div class="ui dropdown jump item tooltip mx-0" tabindex="-1" data-content="{{.locale.Tr "user_profile_and_more"}}">
 				<span class="text">
 					{{avatar .SignedUser 24 "tiny"}}
 					<span class="sr-only">{{.locale.Tr "user_profile_and_more"}}</span>

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2430,10 +2430,10 @@ a.ui.basic.label:hover {
 
 .header-stopwatch-dot {
   position: absolute;
-  left: 7px;
+  left: 8px;
   top: -8px;
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
   background: var(--color-primary);
   border: 2px solid var(--color-header-bar);
   border-radius: 100%;

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1364,6 +1364,7 @@ a.ui.card:hover,
   visibility: hidden;
 }
 
+.text.primary { color: var(--color-primary) !important; }
 .text.red { color: var(--color-red) !important; }
 .text.orange { color: var(--color-orange) !important; }
 .text.yellow { color: var(--color-yellow) !important; }
@@ -2425,6 +2426,33 @@ a.ui.basic.label:hover {
 /* https://github.com/go-gitea/gitea/issues/10210 */
 .ui.attached.segment ~ .ui.top.attached.header {
   margin-top: 1rem;
+}
+
+.header-stopwatch-dot {
+  position: absolute;
+  left: 7px;
+  top: -8px;
+  width: 14px;
+  height: 14px;
+  background: var(--color-primary);
+  border: 2px solid var(--color-header-bar);
+  border-radius: 100%;
+}
+
+.notification_count {
+  position: absolute;
+  left: 5px;
+  top: -8px;
+  min-width: 1.5em;
+  text-align: center;
+  background: var(--color-primary);
+  border: 2px solid var(--color-header-bar);
+  color: var(--color-header-bar);
+  padding: 2px;
+  border-radius: 1em;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: .7;
 }
 
 table th[data-sortt-asc],

--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -21,6 +21,7 @@
 
 /* below class names match Tailwind CSS */
 .pointer-events-none { pointer-events: none !important; }
+.relative { position: relative !important; }
 
 .mono {
   font-family: var(--fonts-monospace) !important;


### PR DESCRIPTION
- Add dot-style indicators to notification and time tracker
- Slightly reduce whitespace between right-aligned icons
- Move notification icon to right on mobile
- Switch menu icon to SVG

<img width="270" alt="Screenshot 2022-12-19 at 19 40 32" src="https://user-images.githubusercontent.com/115237/208496795-ce8734a0-f109-47b7-8eb8-96931e867b23.png">
<img width="607" alt="Screenshot 2022-12-19 at 19 41 04" src="https://user-images.githubusercontent.com/115237/208496797-2ff68197-f520-4174-927e-ead15addd63e.png">

