### PR TITLE
Check for zero time instant in TimeStamp.IsZero() (#22171)

### DIFF
--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -13,8 +13,13 @@ import (
 // TimeStamp defines a timestamp
 type TimeStamp int64
 
-// mock is NOT concurrency-safe!!
-var mock time.Time
+var (
+	// mock is NOT concurrency-safe!!
+	mock time.Time
+
+	// Used for IsZero, to check if timestamp is the zero time instant.
+	timeZeroUnix = time.Time{}.Unix()
+)
 
 // Set sets the time to a mocked time.Time
 func Set(now time.Time) {
@@ -103,5 +108,5 @@ func (ts TimeStamp) FormatDate() string {
 
 // IsZero is zero time
 func (ts TimeStamp) IsZero() bool {
-	return int64(ts) == 0
+	return int64(ts) == 0 || int64(ts) == timeZeroUnix
 }


### PR DESCRIPTION
- Backport of #22171
  - Currently, the 'IsZero' function for 'TimeStamp' just checks if the unix time is zero, which is not the behavior of 'Time.IsZero()', but Gitea is using this method in accordance with the behavior of 'Time.IsZero()'.
  - Adds a new condition to check for the zero time instant.
  - Fixes a bug where non-expiring GPG keys where shown as they expired on Jan 01, 0001.
  - Related https://codeberg.org/Codeberg/Community/issues/791

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
