### PR TITLE
Deduplicate findReadmeFile()

### DIFF
--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -101,6 +101,15 @@ func (te *TreeEntry) FollowLinks() (*TreeEntry, error) {
 	return entry, nil
 }
 
+// returns the subtree, or nil if this is not a tree
+func (te *TreeEntry) Tree() *Tree {
+	t, err := te.ptree.repo.getTree(te.ID)
+	if err != nil {
+		return nil
+	}
+	return t
+}
+
 // GetSubJumpablePathName return the full path of subdirectory jumpable ( contains only one directory )
 func (te *TreeEntry) GetSubJumpablePathName() string {
 	if te.IsSubModule() || !te.IsDir() {


### PR DESCRIPTION
This code was copy-pasted at some point. Revisit it to reunify it.

~~Doing that then encouraged simplifying the types of a couple of related functions.~~

~~As a follow-up, move two helper functions, `isReadmeFile()` and `isReadmeFileExtension()`, intimately tied to `findReadmeFile()`, in as package-private.~~