### PR TITLE
Disable auto tag to prepare next 1.17 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -902,7 +902,7 @@ steps:
     image: techknowlogick/drone-docker:latest
     pull: always
     settings:
-      auto_tag: true
+      auto_tag: false
       auto_tag_suffix: linux-amd64
       repo: gitea/gitea
       build_args:
@@ -920,7 +920,7 @@ steps:
     image: techknowlogick/drone-docker:latest
     settings:
       dockerfile: Dockerfile.rootless
-      auto_tag: true
+      auto_tag: false
       auto_tag_suffix: linux-amd64-rootless
       repo: gitea/gitea
       build_args:
@@ -1126,7 +1126,7 @@ steps:
     image: techknowlogick/drone-docker:latest
     pull: always
     settings:
-      auto_tag: true
+      auto_tag: false
       auto_tag_suffix: linux-arm64
       repo: gitea/gitea
       build_args:
@@ -1144,7 +1144,7 @@ steps:
     image: techknowlogick/drone-docker:latest
     settings:
       dockerfile: Dockerfile.rootless
-      auto_tag: true
+      auto_tag: false
       auto_tag_suffix: linux-arm64-rootless
       repo: gitea/gitea
       build_args:
@@ -1299,7 +1299,7 @@ steps:
     image: plugins/manifest
     pull: always
     settings:
-      auto_tag: true
+      auto_tag: false
       ignore_missing: true
       spec: docker/manifest.rootless.tmpl
       password:
@@ -1310,7 +1310,7 @@ steps:
   - name: manifest
     image: plugins/manifest
     settings:
-      auto_tag: true
+      auto_tag: false
       ignore_missing: true
       spec: docker/manifest.tmpl
       password:

--- a/.drone.yml
+++ b/.drone.yml
@@ -904,6 +904,9 @@ steps:
     settings:
       auto_tag: false
       auto_tag_suffix: linux-amd64
+      tags:
+        - ${DRONE_TAG##v}-linux-amd64
+        - ${DRONE_TAG:1:4}-linux-amd64
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -922,6 +925,9 @@ steps:
       dockerfile: Dockerfile.rootless
       auto_tag: false
       auto_tag_suffix: linux-amd64-rootless
+      tags:
+        - ${DRONE_TAG##v}-linux-amd64-rootless
+        - ${DRONE_TAG:1:4}-linux-amd64-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1128,6 +1134,9 @@ steps:
     settings:
       auto_tag: false
       auto_tag_suffix: linux-arm64
+      tags:
+        - ${DRONE_TAG##v}-linux-arm64
+        - ${DRONE_TAG:1:4}-linux-arm64
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io
@@ -1146,6 +1155,9 @@ steps:
       dockerfile: Dockerfile.rootless
       auto_tag: false
       auto_tag_suffix: linux-arm64-rootless
+      tags:
+        - ${DRONE_TAG##v}-linux-arm64-rootless
+        - ${DRONE_TAG:1:4}-linux-arm64-rootless
       repo: gitea/gitea
       build_args:
         - GOPROXY=https://goproxy.io


### PR DESCRIPTION
Disable auto tag so that 1.17 release will not tag `:1`.