### PR TITLE
fix: update libcurl in docs pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -931,7 +931,7 @@ steps:
     image: plugins/hugo:latest
     pull: always
     commands:
-      - apk add --no-cache make bash curl
+      - apk add --no-cache make bash curl curl-dev
       - cd docs
       - make trans-copy clean build
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -931,7 +931,7 @@ steps:
     image: plugins/hugo:latest
     pull: always
     commands:
-      # avoid curl/libcurl mismatch by upgrading libcurl first
+      # https://github.com/drone-plugins/drone-hugo/issues/36
       - apk upgrade --no-cache libcurl && apk add --no-cache make bash curl
       - cd docs
       - make trans-copy clean build

--- a/.drone.yml
+++ b/.drone.yml
@@ -931,7 +931,8 @@ steps:
     image: plugins/hugo:latest
     pull: always
     commands:
-      - apk add --no-cache make bash curl curl-dev
+      # avoid curl/libcurl mismatch by upgrading libcurl first
+      - apk upgrade --no-cache libcurl && apk add --no-cache make bash curl
       - cd docs
       - make trans-copy clean build
 


### PR DESCRIPTION
Our docs pipeline has been failing recently, and running the image locally without `-s` shows 

![libcurl](https://user-images.githubusercontent.com/42128690/208976692-8f91b3e7-1d34-4ca7-b0a5-92d349f51947.png)

Adding `curl-dev` appears to fix the issue.

![hugo-curl](https://user-images.githubusercontent.com/42128690/208976740-2c1899b8-3c1e-40bc-8ef6-8e7718d95afa.png)

-----

Per @silverwind instead we can just update `libcurl` to make them match.