### PR TITLE
Upgrade hugo to 0.82

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ THEME := themes/gitea
 PUBLIC := public
 ARCHIVE := https://dl.gitea.io/theme/master.tar.gz
 
-HUGO_PACKAGE := github.com/gohugoio/hugo@v0.81.0
+HUGO_PACKAGE := github.com/gohugoio/hugo@v0.82.0
 
 .PHONY: all
 all: build


### PR DESCRIPTION
See https://github.com/go-gitea/gitea/pull/22206#issuecomment-1362523796. Apparently hugo 0.81.0 is a broken release in regards to checksums. 

https://github.com/gohugoio/hugo/releases/tag/v0.82.0