### PR TITLE
Fix key signature error page (#22229)

### DIFF
--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -18,11 +18,11 @@
 					<p>{{.i18n.Tr "settings.gpg_token_required"}}</p>
 				</div>
 				<div class="field">
-					<label for="token">{{.i18n.Tr "setting.gpg_token"}}
+					<label for="token">{{.i18n.Tr "settings.gpg_token"}}
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
 						<p>{{.i18n.Tr "settings.gpg_token_help"}}</p>
-						<p><code>{{$.i18n.Tr "settings.gpg_token_code" .TokenToSign .PaddedKeyID}}</code></p>
+						<p><code>{{$.i18n.Tr "settings.gpg_token_code" .TokenToSign .KeyID}}</code></p>
 					</div>
 				</div>
 				<div class="field">


### PR DESCRIPTION
- Backport of #22229
  - When the GPG key contains an error, such as an invalid signature or an email address that does not match the user.A page will be shown that says you must provide a signature for the token.
  - This page had two errors: one had the wrong translation key and the other tried to use an undefined variable [`.PaddedKeyID`](https://github.com/go-gitea/gitea/blob/e81ccc406bf723a5a58d685e7782f281736affd4/models/asymkey/gpg_key.go#L65-L72), which is a function implemented on the `GPGKey` struct, given that we don't have that, we use [`KeyID`](https://github.com/go-gitea/gitea/blob/e81ccc406bf723a5a58d685e7782f281736affd4/routers/web/user/setting/keys.go#L102) which is [the fingerprint of the publickey](https://pkg.go.dev/golang.org/x/crypto/openpgp/packet#PublicKey.KeyIdString) and is a valid way for opengpg to refer to a key.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
