### PR TITLE
Remove ReverseProxy authentication from the API (#22219)

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -232,13 +232,10 @@ func reqExploreSignIn() func(ctx *context.APIContext) {
 	}
 }
 
-func reqBasicOrRevProxyAuth() func(ctx *context.APIContext) {
+func reqBasicAuth() func(ctx *context.APIContext) {
 	return func(ctx *context.APIContext) {
-		if ctx.IsSigned && setting.Service.EnableReverseProxyAuth && ctx.Data["AuthedMethod"].(string) == auth.ReverseProxyMethodName {
-			return
-		}
 		if !ctx.Context.IsBasicAuth {
-			ctx.Error(http.StatusUnauthorized, "reqBasicOrRevProxyAuth", "auth required")
+			ctx.Error(http.StatusUnauthorized, "reqBasicAuth", "auth required")
 			return
 		}
 		ctx.CheckForOTP()
@@ -597,9 +594,6 @@ func buildAuthGroup() *auth.Group {
 		&auth.HTTPSign{},
 		&auth.Basic{}, // FIXME: this should be removed once we don't allow basic auth in API
 	)
-	if setting.Service.EnableReverseProxyAuth {
-		group.Add(&auth.ReverseProxy{})
-	}
 	specialAdd(group)
 
 	return group
@@ -689,7 +683,7 @@ func Routes(ctx gocontext.Context) *web.Route {
 					m.Combo("").Get(user.ListAccessTokens).
 						Post(bind(api.CreateAccessTokenOption{}), user.CreateAccessToken)
 					m.Combo("/{id}").Delete(user.DeleteAccessToken)
-				}, reqBasicOrRevProxyAuth())
+				}, reqBasicAuth())
 			}, context_service.UserAssignmentAPI())
 		})
 


### PR DESCRIPTION
backport from #22219

Since we changed the /api/v1/ routes to disallow session authentication we also removed their reliance on CSRF. However, we left the ReverseProxy authentication here - but this means that POSTs to the API are no longer protected by CSRF.

Now, ReverseProxy authentication is a kind of session authentication, and is therefore inconsistent with the removal of session from the API.

This PR proposes that we simply remove the ReverseProxy authentication from the API and therefore users of the API must explicitly use tokens or basic authentication.

Replace #22077
Close #22221 
Close #22077 

Signed-off-by: Andrew Thornton <art27@cantab.net>