### PR TITLE
Make large code blocks and quotes scrollable

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -574,8 +574,24 @@
 
   @comment-avatar-width: 3em;
 
-  .comment textarea {
-    max-height: none !important;
+  .comment {
+    textarea {
+      max-height: none !important;
+    }
+
+    blockquote,
+    pre {
+      max-height: 405px;
+      overflow: auto;
+    }
+
+    blockquote,
+    details {
+      blockquote,
+      pre {
+        max-height: none;
+      }
+    }
   }
 
   &.new.issue {


### PR DESCRIPTION
This commit introduces a max-height to both blockquote and preformatted elements along with automatic scroll behavior so that large blocks do not interrupt the visual flow of an issue thread. When nested within a details or another blockquote element, the max-height is unset as the parent element already has some control of the resulting height. (max-height applied by this commit for blockquotes, and collapsible contents for details)

This change is inspired [by a similar change implemented in Refined Github years ago](https://github.com/refined-github/refined-github/pull/1146) (the feature's current styles [exist in a self-contained file](https://github.com/refined-github/refined-github/blob/2d35b21a17f8462729bc4a818e5259a12fd0b893/source/features/scrollable-code-and-blockquote.css) today) which I've used and enjoyed for some time, and felt would be appreciated in Gitea as well. I chose `405px` as the max-height value as it appears to result in the last line of text being partially cut off by the bottom of the container, helping to make clear visually that there is more text to be read upon scrolling.

|       Element       | Before (cropped to max. 1000px) | After |
|:---------------------:|:------------------------------------------------:|:-------:|
| `<pre>`               | ![Screen Shot 2022-12-28 at 06 03 12_vertical-crop](https://user-images.githubusercontent.com/2199511/209765959-ba415fdb-7b66-486b-a310-1c1a60e4b360.png) | ![Screenshot 2022-12-28 at 06-00-28 Add more vim defaults](https://user-images.githubusercontent.com/2199511/209765835-dcc0198a-38db-4829-9f04-bd4b33aec294.png) |
| `<blockquote>` | ![Screenshot 2022-12-28 at 06-01-21 Add more vim defaults](https://user-images.githubusercontent.com/2199511/209765990-70d4d37f-2d13-48a1-ae69-fab40ef6932b.png) | ![Screenshot 2022-12-28 at 06-00-35 Add more vim defaults](https://user-images.githubusercontent.com/2199511/209765983-cf279e5d-eddf-4cb2-8f9d-c083c3880972.png) |