### PR TITLE
Support estimated count with multiple schemas

### DIFF
--- a/models/db/context.go
+++ b/models/db/context.go
@@ -188,7 +188,9 @@ func EstimateCount(ctx context.Context, bean interface{}) (int64, error) {
 	case schemas.MYSQL:
 		_, err = e.Context(ctx).SQL("SELECT table_rows FROM information_schema.tables WHERE tables.table_name = ? AND tables.table_schema = ?;", tablename, x.Dialect().URI().DBName).Get(&rows)
 	case schemas.POSTGRES:
-		_, err = e.Context(ctx).SQL("SELECT reltuples AS estimate FROM pg_class WHERE relname = ?;", tablename).Get(&rows)
+		// the table can live in multiple schemas of a postgres database
+		tablename = x.TableName(bean, true)
+		_, err = e.Context(ctx).SQL("SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = ?::regclass;", tablename).Get(&rows)
 	case schemas.MSSQL:
 		_, err = e.Context(ctx).SQL("sp_spaceused ?;", tablename).Get(&rows)
 	default:

--- a/models/db/context.go
+++ b/models/db/context.go
@@ -189,6 +189,7 @@ func EstimateCount(ctx context.Context, bean interface{}) (int64, error) {
 		_, err = e.Context(ctx).SQL("SELECT table_rows FROM information_schema.tables WHERE tables.table_name = ? AND tables.table_schema = ?;", tablename, x.Dialect().URI().DBName).Get(&rows)
 	case schemas.POSTGRES:
 		// the table can live in multiple schemas of a postgres database
+		// See https://wiki.postgresql.org/wiki/Count_estimate
 		tablename = x.TableName(bean, true)
 		_, err = e.Context(ctx).SQL("SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = ?::regclass;", tablename).Get(&rows)
 	case schemas.MSSQL:


### PR DESCRIPTION
The `EstimateCount` could be incorrect when the table lives in multiple schemas. Related to #19775.

See https://wiki.postgresql.org/wiki/Count_estimate:

> If you don't need an exact count, the current statistic from the catalog table pg_class might be good enough and is much faster to retrieve for big tables.
> `SELECT reltuples AS estimate FROM pg_class WHERE relname = 'table_name';`
> Tables named "table_name" can live in multiple schemas of a database, in which case you get multiple rows for this query. To overcome ambiguity:
> `SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = 'schema_name.table_name'::regclass;`

And it happened to me:

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/9418365/210040291-732b9814-a5ea-4d8a-82ba-91b5bd969531.png">


I don't think it's a bug, because it's correct in most cases. So I labeled this PR with `kind/enhancement`.

