### PR TITLE
Update Gmail mailer configuration

### DIFF
--- a/docs/content/doc/usage/email-setup.en-us.md
+++ b/docs/content/doc/usage/email-setup.en-us.md
@@ -76,12 +76,15 @@ The following configuration should work with GMail's SMTP server:
 ```ini
 [mailer]
 ENABLED        = true
+HOST           = smtp.gmail.com:465
 SMTP_ADDR      = smtp.gmail.com
 SMTP_PORT      = 465
-FROM           = example@gmail.com
-USER           = example@gmail.com
+FROM           = example.user@gmail.com
+USER           = example.user
 PASSWD         = ***
 MAILER_TYPE    = smtp
 IS_TLS_ENABLED = true
-HELO_HOSTNAME  = example.com
 ```
+
+Note that you'll need to create and use an [App password](https://support.google.com/accounts/answer/185833?hl=en) by enabling 2FA on your Google
+account. You won't be able to use your Google account password directly.

--- a/docs/content/doc/usage/email-setup.en-us.md
+++ b/docs/content/doc/usage/email-setup.en-us.md
@@ -76,7 +76,7 @@ The following configuration should work with GMail's SMTP server:
 ```ini
 [mailer]
 ENABLED        = true
-HOST           = smtp.gmail.com:465
+HOST           = smtp.gmail.com:465 ; Remove this line for Gitea >= 1.18.0
 SMTP_ADDR      = smtp.gmail.com
 SMTP_PORT      = 465
 FROM           = example.user@gmail.com


### PR DESCRIPTION
This PR updates the `[mailer]` configuration snippet for Gmail:

- The `HELO_HOSTNAME` isn't required.
- The `USER` must not include the @gmail domain.
- `HOST` needs to be supplied, and the SMTP port number needs to be appended to the URL.

I also added a note about the requirement to use App passwords instead of your Google account password directly.