### PR TITLE
Fix bug of DisableGravatar default value

### DIFF
--- a/models/system/setting.go
+++ b/models/system/setting.go
@@ -266,7 +266,7 @@ func Init() error {
 		enableFederatedAvatar = false
 	}
 
-	if disableGravatar || !enableFederatedAvatar {
+	if enableFederatedAvatar || !disableGravatar {
 		var err error
 		GravatarSourceURL, err = url.Parse(setting.GravatarSource)
 		if err != nil {

--- a/modules/setting/picture.go
+++ b/modules/setting/picture.go
@@ -68,7 +68,7 @@ func newPictureService() {
 }
 
 func GetDefaultDisableGravatar() bool {
-	return !OfflineMode
+	return OfflineMode
 }
 
 func GetDefaultEnableFederatedAvatar(disableGravatar bool) bool {


### PR DESCRIPTION
#18058 made a mistake. The disableGravatar's default value depends on `OfflineMode`. If it's `true`, then `disableGravatar` is true, otherwise it's `false`. But not opposite.