### PR TITLE
Display error log when a modified template has an error so that it could recovery when the error fixed (#22261)

### DIFF
--- a/modules/templates/htmlrenderer.go
+++ b/modules/templates/htmlrenderer.go
@@ -76,8 +76,15 @@ func HTMLRenderer(ctx context.Context) (context.Context, *render.Render) {
 	compilingTemplates = false
 	if !setting.IsProd {
 		watcher.CreateWatcher(ctx, "HTML Templates", &watcher.CreateWatcherOpts{
-			PathsCallback:   walkTemplateFiles,
-			BetweenCallback: renderer.CompileTemplates,
+			PathsCallback: walkTemplateFiles,
+			BetweenCallback: func() {
+				defer func() {
+					if err := recover(); err != nil {
+						log.Error("PANIC: %v\n%s", err, log.Stack(2))
+					}
+				}()
+				renderer.CompileTemplates()
+			},
 		})
 	}
 	return context.WithValue(ctx, rendererKey, renderer), renderer


### PR DESCRIPTION
backport #22261 

A drawback is the previous generated template has been cached, so you cannot get error in the UI but only from log

Co-authored-by: KN4CK3R <admin@oldschoolhack.me>
Co-authored-by: delvh <dev.lh@web.de>
