### PR TITLE
Shouldn't return error if IsErrUserNotExist

### DIFF
--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -113,8 +113,9 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 	if err != nil {
 		if !user_model.IsErrUserNotExist(err) {
 			log.Error("UserSignIn: %v", err)
+			return nil, err
 		}
-		return nil, err
+		return nil, nil
 	}
 
 	if skipper, ok := source.Cfg.(LocalTwoFASkipper); ok && skipper.IsSkipLocalTwoFA() {

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -123,8 +123,9 @@ func (o *OAuth2) Verify(req *http.Request, w http.ResponseWriter, store DataStor
 	if err != nil {
 		if !user_model.IsErrUserNotExist(err) {
 			log.Error("GetUserByName: %v", err)
+			return nil, err
 		}
-		return nil, err
+		return nil, nil
 	}
 
 	log.Trace("OAuth2 Authorization: Logged in user %-v", user)

--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -60,9 +60,12 @@ func (r *ReverseProxy) getUserFromAuthUser(req *http.Request) (*user_model.User,
 
 	user, err := user_model.GetUserByName(req.Context(), username)
 	if err != nil {
-		if !user_model.IsErrUserNotExist(err) || !r.isAutoRegisterAllowed() {
+		if !user_model.IsErrUserNotExist(err) {
 			log.Error("GetUserByName: %v", err)
 			return nil, err
+		}
+		if !r.isAutoRegisterAllowed() {
+			return nil, nil
 		}
 		user = r.newUser(req)
 	}


### PR DESCRIPTION
Shouldn't return an error and stop verifing if the error IsErrUserNotExist.

Related to #22119.
