### PR TITLE
fix: omit avatar_url in discord payload when empty

### DIFF
--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -55,7 +55,7 @@ type (
 		Wait      bool           `json:"wait"`
 		Content   string         `json:"content"`
 		Username  string         `json:"username"`
-		AvatarURL string         `json:"avatar_url"`
+		AvatarURL string         `json:"avatar_url,omitempty"`
 		TTS       bool           `json:"tts"`
 		Embeds    []DiscordEmbed `json:"embeds"`
 	}


### PR DESCRIPTION
Fixes #22391

This field is optional for Discord, however when it exists in the payload it is now validated. 
Omitting it entirely just makes Discord use the default for that webhook, which is set on the Discord side.