### PR TITLE
fix: omit avatar_url in discord payload when empty (#22393)

### DIFF
--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -55,7 +55,7 @@ type (
 		Wait      bool           `json:"wait"`
 		Content   string         `json:"content"`
 		Username  string         `json:"username"`
-		AvatarURL string         `json:"avatar_url"`
+		AvatarURL string         `json:"avatar_url,omitempty"`
 		TTS       bool           `json:"tts"`
 		Embeds    []DiscordEmbed `json:"embeds"`
 	}


### PR DESCRIPTION
Backport #22393 