### PR TITLE
Add more packages to denylist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,13 +76,14 @@ linters-settings:
     extra-rules: true
     lang-version: "1.19"
   depguard:
-    # TODO: use depguard to replace import checks in gitea-vet
     list-type: denylist
     # Check the list against standard lib.
     include-go-root: true
     packages-with-error-message:
       - encoding/json: "use gitea's modules/json instead of encoding/json"
       - github.com/unknwon/com: "use gitea's util and replacements"
+      - io/ioutil: "use os or io instead"
+      - golang.org/x/exp: "it's experimental and unreliable."
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
After this, we can remove [`denylist_imports`](https://gitea.com/gitea/gitea-vet/src/branch/master/checks/denylisted-imports.go#L13) in gitea-vet ([gitea-vet/pulls/23](https://gitea.com/gitea/gitea-vet/pulls/23)).

```go
deniedImports   = []string{"io/ioutil", "encoding/json", "gitea.com/gitea/go-crypto"}
```

However, we needn't keep `gitea.com/gitea/go-crypto` any longer, it's gone and can't be imported again.