### PR TITLE
Continue GCing other repos on error in one repo

### DIFF
--- a/services/repository/check.go
+++ b/services/repository/check.go
@@ -73,7 +73,9 @@ func GitGcRepos(ctx context.Context, timeout time.Duration, args ...git.CmdArg) 
 				return db.ErrCancelledf("before GC of %s", repo.FullName())
 			default:
 			}
-			return GitGcRepo(ctx, repo, timeout, args)
+			// we can ignore the error here because it will be logged in GitGCRepo
+			_ = GitGcRepo(ctx, repo, timeout, args)
+			return nil
 		},
 	); err != nil {
 		return err
@@ -93,7 +95,7 @@ func GitGcRepo(ctx context.Context, repo *repo_model.Repository, timeout time.Du
 	stdout, _, err = command.RunStdString(&git.RunOpts{Timeout: timeout, Dir: repo.RepoPath()})
 
 	if err != nil {
-		log.Error("Repository garbage collection failed for %v. Stdout: %s\nError: %v", repo, stdout, err)
+		log.Error("Repository garbage collection failed for %-v. Stdout: %s\nError: %v", repo, stdout, err)
 		desc := fmt.Sprintf("Repository garbage collection failed for %s. Stdout: %s\nError: %v", repo.RepoPath(), stdout, err)
 		if err := system_model.CreateRepositoryNotice(desc); err != nil {
 			log.Error("CreateRepositoryNotice: %v", err)
@@ -165,7 +167,7 @@ func DeleteMissingRepositories(ctx context.Context, doer *user_model.User) error
 		}
 		log.Trace("Deleting %d/%d...", repo.OwnerID, repo.ID)
 		if err := models.DeleteRepository(doer, repo.OwnerID, repo.ID); err != nil {
-			log.Error("Failed to DeleteRepository %s [%d]: Error: %v", repo.FullName(), repo.ID, err)
+			log.Error("Failed to DeleteRepository %-v: Error: %v", repo, err)
 			if err2 := system_model.CreateRepositoryNotice("Failed to DeleteRepository %s [%d]: Error: %v", repo.FullName(), repo.ID, err); err2 != nil {
 				log.Error("CreateRepositoryNotice: %v", err)
 			}


### PR DESCRIPTION
The current code propagates all errors up to the iteration step meaning that a single malformed repo will prevent GC of other repos.

This PR simply stops that propagation.

Fix #21605

Signed-off-by: Andrew Thornton <art27@cantab.net>
