### PR TITLE
Fix stylesheet HTML snippet for external renderers documentation

### DIFF
--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -192,5 +192,5 @@ And so you could write some CSS:
 Add your stylesheet to your custom directory e.g `custom/public/css/my-style-XXXXX.css` and import it using a custom header file `custom/templates/custom/header.tmpl`:
 
 ```html
-<link rel="stylesheet" type="text/css" href="{{AppSubUrl}}/assets/css/my-style-XXXXX.css" />
+<link rel="stylesheet" href="{{AppSubUrl}}/assets/css/my-style-XXXXX.css" />
 ```

--- a/docs/content/doc/advanced/external-renderers.en-us.md
+++ b/docs/content/doc/advanced/external-renderers.en-us.md
@@ -192,5 +192,5 @@ And so you could write some CSS:
 Add your stylesheet to your custom directory e.g `custom/public/css/my-style-XXXXX.css` and import it using a custom header file `custom/templates/custom/header.tmpl`:
 
 ```html
-<link type="text/css" href="{{AppSubUrl}}/assets/css/my-style-XXXXX.css" />
+<link rel="stylesheet" type="text/css" href="{{AppSubUrl}}/assets/css/my-style-XXXXX.css" />
 ```


### PR DESCRIPTION
The documentation is missing the rel attribute. Neither Firefox nor Chrome did use the linked file as CSS if rel="stylesheet" is not set.

The problem is described in issue #22434.