### PR TITLE
Fixed colour transparency regex matching in project board sorting (#22092)

### DIFF
--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -200,7 +200,7 @@ function getRelativeColor(color) {
 }
 
 function rgbToHex(rgb) {
-  rgb = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+  rgb = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+).*\)$/);
   return `#${hex(rgb[1])}${hex(rgb[2])}${hex(rgb[3])}`;
 }
 


### PR DESCRIPTION
Backport #22092

As described in the linked issue (#22091), semi-transparent UI elements would result in JS errors due to the fact that the CSS `backgroundColor` element was being matched by the pattern
`^rgb\((\d+),\s*(\d+),\s*(\d+)\)$`, which does not take the alpha channel into account.

I changed the pattern to `^rgba?\((\d+),\s*(\d+),\s*(\d+).*\)$`. This new pattern accepts both `rgb` and `rgba` tuples, and ignores the alpha channel (that little `.*` at the end) from the sorting criteria. The reason why I chose to ignore alpha is because when it comes to kanban colour sorting, only the hue is important; the order of the panels should stay the same, even if some of them are transparent.

Alternative solutions were discussed in the bug report and are included here for completeness:
1. Change the regex from ^rgb\((\d+),\s*(\d+),\s*(\d+)\)$ to ^rgba?\((\d+),\s*(\d+),\s*(\d+)(,\s*(\d+(\.\d+)?))?\)$ (alpha channel is a float or NaN on 5th group) and include the alpha channel in the sorting criteria.
2. Rethink on why you're reading colours out of the CSS in the first place, then reformat this sorting procedure.

Fix #22091

Co-authored-by: Lauris BH <lauris@nix.lv>
Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>
Co-authored-by: techknowlogick <techknowlogick@gitea.io>
