### PR TITLE
Remove duplicate "Actions" label in mobile view (#21974)

### DIFF
--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -27,7 +27,7 @@
 						</a>
 						{{if and ($.Permission.CanWrite $.UnitTypeCode) (not $.Repository.IsArchived) (not .IsDeleted)}}{{- /* */ -}}
 							<div class="ui primary tiny floating dropdown icon button">{{.locale.Tr "repo.commit.actions"}}
-								{{svg "octicon-triangle-down" 14 "dropdown icon"}}<span class="sr-mobile-only">{{.locale.Tr "repo.commit.actions"}}</span>
+								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 								<div class="menu">
 									<div class="ui header">{{.locale.Tr "repo.commit.actions"}}</div>
 									<div class="divider"></div>


### PR DESCRIPTION
Backport #21974

Closes #21973.

The "Actions" button on the commit view page is labelled twice in mobile view. No other buttons on the page have a `mobile-only` extra label, so this PR removes it.

Before:

![before](https://user-images.githubusercontent.com/6496999/204540002-75baa08a-6c06-4b39-847b-34272e09d71e.PNG)

After:

![after](https://user-images.githubusercontent.com/6496999/204539991-a0607765-d5e2-4b1a-84c9-a3e16cbc674e.PNG)

Co-authored-by: Lunny Xiao <xiaolunwen@gmail.com>
