### PR TITLE
Fix wechatwork webhook sends empty content in PR review (#21762)

### DIFF
--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -139,7 +139,7 @@ func (f *WechatworkPayload) PullRequest(p *api.PullRequestPayload) (api.Payloade
 func (f *WechatworkPayload) Review(p *api.PullRequestPayload, event webhook_model.HookEventType) (api.Payloader, error) {
 	var text, title string
 	switch p.Action {
-	case api.HookIssueSynchronized:
+	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Backport #21762

Wechatwork webhook is sending the following string for pull request reviews:

``` markdown
>
```

This commit fixes this problem.

