### PR TITLE
Log STDERR of external renderer when it fails

### DIFF
--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -4,6 +4,7 @@
 package external
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -132,11 +133,13 @@ func (p *Renderer) Render(ctx *markup.RenderContext, input io.Reader, output io.
 	if !p.IsInputFile {
 		cmd.Stdin = input
 	}
+	var stderr bytes.Buffer
 	cmd.Stdout = output
+	cmd.Stderr = &stderr
 	process.SetSysProcAttribute(cmd)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s render run command %s %v failed: %w", p.Name(), commands[0], args, err)
+		return fmt.Errorf("%s render run command %s %v failed: %w\nStderr: %s", p.Name(), commands[0], args, err, stderr.String())
 	}
 	return nil
 }


### PR DESCRIPTION
When using an external renderer, STDOUT is expected to be HTML.  But anything written to STDERR is currently ignored.  In cases where the renderer fails, I would like to log any error messages that the external program outputs to STDERR.