### PR TITLE
Log STDERR of external renderer when it fails (#22442)

### DIFF
--- a/modules/markup/external/external.go
+++ b/modules/markup/external/external.go
@@ -5,6 +5,7 @@
 package external
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -133,11 +134,13 @@ func (p *Renderer) Render(ctx *markup.RenderContext, input io.Reader, output io.
 	if !p.IsInputFile {
 		cmd.Stdin = input
 	}
+	var stderr bytes.Buffer
 	cmd.Stdout = output
+	cmd.Stderr = &stderr
 	process.SetSysProcAttribute(cmd)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s render run command %s %v failed: %w", p.Name(), commands[0], args, err)
+		return fmt.Errorf("%s render run command %s %v failed: %w\nStderr: %s", p.Name(), commands[0], args, err, stderr.String())
 	}
 	return nil
 }


### PR DESCRIPTION
Backport #22442.