### PR TITLE
Prevent panic on looking at api "git" endpoints for empty repos

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1061,7 +1061,7 @@ func Routes(ctx gocontext.Context) *web.Route {
 					m.Get("/blobs/{sha}", repo.GetBlob)
 					m.Get("/tags/{sha}", repo.GetAnnotatedTag)
 					m.Get("/notes/{sha}", repo.GetNote)
-				}, context.ReferencesGitRepo(), reqRepoReader(unit.TypeCode))
+				}, context.ReferencesGitRepo(true), reqRepoReader(unit.TypeCode))
 				m.Post("/diffpatch", reqRepoWriter(unit.TypeCode), reqToken(), bind(api.ApplyDiffPatchFileOptions{}), repo.ApplyDiffPatch)
 				m.Group("/contents", func() {
 					m.Get("", repo.GetContentsList)


### PR DESCRIPTION
The API endpoints for "git" can panic if they are called on an empty repo. We can simply allow empty repos for these endpoints without worry as they should just work.

Fix #22452

Signed-off-by: Andrew Thornton <art27@cantab.net>
