### PR TITLE
Change use of Walk to WalkDir to improve disk performance

### DIFF
--- a/build/generate-bindata.go
+++ b/build/generate-bindata.go
@@ -32,11 +32,15 @@ func needsUpdate(dir, filename string) (bool, []byte) {
 
 	hasher := sha1.New()
 
-	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		_, _ = hasher.Write([]byte(info.Name()))
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		_, _ = hasher.Write([]byte(d.Name()))
 		_, _ = hasher.Write([]byte(info.ModTime().String()))
 		_, _ = hasher.Write([]byte(strconv.FormatInt(info.Size(), 16)))
 		return nil

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -232,7 +232,12 @@ func (log *FileLogger) deleteOldLog() {
 			}
 		}()
 
-		if !d.IsDir() {
+    if err != nil {
+         return err
+    }
+		if d.IsDir() {
+		    return nil
+		}
 			info, err := d.Info()
 			if err != nil {
 				return err

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -232,8 +232,8 @@ func (log *FileLogger) deleteOldLog() {
 			}
 		}()
 
-		if returnErr != nil {
-			return returnErr
+		if err != nil {
+			return err
 		}
 		if d.IsDir() {
 		    return nil

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -225,17 +225,23 @@ func compressOldLogFile(fname string, compressionLevel int) error {
 
 func (log *FileLogger) deleteOldLog() {
 	dir := filepath.Dir(log.Filename)
-	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) (returnErr error) {
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) (returnErr error) {
 		defer func() {
 			if r := recover(); r != nil {
 				returnErr = fmt.Errorf("Unable to delete old log '%s', error: %+v", path, r)
 			}
 		}()
 
-		if !info.IsDir() && info.ModTime().Unix() < (time.Now().Unix()-60*60*24*log.Maxdays) {
-			if strings.HasPrefix(filepath.Base(path), filepath.Base(log.Filename)) {
-				if err := util.Remove(path); err != nil {
-					returnErr = fmt.Errorf("Failed to remove %s: %w", path, err)
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if info.ModTime().Unix() < (time.Now().Unix() - 60*60*24*log.Maxdays) {
+				if strings.HasPrefix(filepath.Base(path), filepath.Base(log.Filename)) {
+					if err := util.Remove(path); err != nil {
+						returnErr = fmt.Errorf("Failed to remove %s: %w", path, err)
+					}
 				}
 			}
 		}

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -232,21 +232,20 @@ func (log *FileLogger) deleteOldLog() {
 			}
 		}()
 
-    if err != nil {
-         return err
-    }
+		if returnErr != nil {
+			return returnErr
+		}
 		if d.IsDir() {
 		    return nil
 		}
-			info, err := d.Info()
-			if err != nil {
-				return err
-			}
-			if info.ModTime().Unix() < (time.Now().Unix() - 60*60*24*log.Maxdays) {
-				if strings.HasPrefix(filepath.Base(path), filepath.Base(log.Filename)) {
-					if err := util.Remove(path); err != nil {
-						returnErr = fmt.Errorf("Failed to remove %s: %w", path, err)
-					}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.ModTime().Unix() < (time.Now().Unix() - 60*60*24*log.Maxdays) {
+			if strings.HasPrefix(filepath.Base(path), filepath.Base(log.Filename)) {
+				if err := util.Remove(path); err != nil {
+					returnErr = fmt.Errorf("Failed to remove %s: %w", path, err)
 				}
 			}
 		}

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -233,10 +233,10 @@ func (log *FileLogger) deleteOldLog() {
 		}()
 
 		if err != nil {
-		    return err
+			return err
 		}
 		if d.IsDir() {
-		    return nil
+			return nil
 		}
 		info, err := d.Info()
 		if err != nil {

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -233,7 +233,7 @@ func (log *FileLogger) deleteOldLog() {
 		}()
 
 		if err != nil {
-			return err
+		    return err
 		}
 		if d.IsDir() {
 		    return nil

--- a/modules/repository/generate.go
+++ b/modules/repository/generate.go
@@ -173,12 +173,12 @@ func generateRepoCommit(ctx context.Context, repo, templateRepo, generateRepo *r
 		// Avoid walking tree if there are no globs
 		if len(gt.Globs()) > 0 {
 			tmpDirSlash := strings.TrimSuffix(filepath.ToSlash(tmpDir), "/") + "/"
-			if err := filepath.Walk(tmpDirSlash, func(path string, info os.FileInfo, walkErr error) error {
+			if err := filepath.WalkDir(tmpDirSlash, func(path string, d os.DirEntry, walkErr error) error {
 				if walkErr != nil {
 					return walkErr
 				}
 
-				if info.IsDir() {
+				if d.IsDir() {
 					return nil
 				}
 

--- a/modules/storage/local.go
+++ b/modules/storage/local.go
@@ -129,7 +129,7 @@ func (l *LocalStorage) URL(path, name string) (*url.URL, error) {
 
 // IterateObjects iterates across the objects in the local storage
 func (l *LocalStorage) IterateObjects(fn func(path string, obj Object) error) error {
-	return filepath.Walk(l.dir, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(l.dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (l *LocalStorage) IterateObjects(fn func(path string, obj Object) error) er
 		if path == l.dir {
 			return nil
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		relPath, err := filepath.Rel(l.dir, path)

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -280,17 +280,17 @@ func Repos(ctx *context.Context) {
 		repos := map[string]*repo_model.Repository{}
 		// We're going to iterate by pagesize.
 		root := user_model.UserPath(ctxUser.Name)
-		if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil
 				}
 				return err
 			}
-			if !info.IsDir() || path == root {
+			if !d.IsDir() || path == root {
 				return nil
 			}
-			name := info.Name()
+			name := d.Name()
 			if !strings.HasSuffix(name, ".git") {
 				return filepath.SkipDir
 			}
@@ -304,7 +304,7 @@ func Repos(ctx *context.Context) {
 			count++
 			return filepath.SkipDir
 		}); err != nil {
-			ctx.ServerError("filepath.Walk", err)
+			ctx.ServerError("filepath.WalkDir", err)
 			return
 		}
 

--- a/services/repository/adopt.go
+++ b/services/repository/adopt.go
@@ -303,13 +303,15 @@ func ListUnadoptedRepositories(query string, opts *db.ListOptions) ([]string, in
 
 	// We're going to iterate by pagesize.
 	root := filepath.Clean(setting.RepoRootPath)
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() || path == root {
+		if !d.IsDir() || path == root {
 			return nil
 		}
+
+		name := d.Name()
 
 		if !strings.ContainsRune(path[len(root)+1:], filepath.Separator) {
 			// Got a new user
@@ -318,15 +320,13 @@ func ListUnadoptedRepositories(query string, opts *db.ListOptions) ([]string, in
 			}
 			repoNamesToCheck = repoNamesToCheck[:0]
 
-			if !globUser.Match(info.Name()) {
+			if !globUser.Match(name) {
 				return filepath.SkipDir
 			}
 
-			userName = info.Name()
+			userName = name
 			return nil
 		}
-
-		name := info.Name()
 
 		if !strings.HasSuffix(name, ".git") {
 			return filepath.SkipDir


### PR DESCRIPTION
As suggest by Go developers, use `filepath.WalkDir` instead of `filepath.Walk` because [*Walk is less efficient than WalkDir, introduced in Go 1.16, which avoids calling `os.Lstat` on every file or directory visited](https://pkg.go.dev/path/filepath#Walk).

Contributed by @Forgejo.

This proposition address that, in a similar way as https://github.com/go-gitea/gitea/pull/22392 did.
<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
