### PR TITLE
Fix migration from GitBucket (#22477)

### DIFF
--- a/services/migrations/gitbucket.go
+++ b/services/migrations/gitbucket.go
@@ -35,6 +35,9 @@ func (f *GitBucketDownloaderFactory) New(ctx context.Context, opts base.MigrateO
 	}
 
 	fields := strings.Split(u.Path, "/")
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("invalid path: %s", u.Path)
+	}
 	baseURL := u.Scheme + "://" + u.Host + strings.TrimSuffix(strings.Join(fields[:len(fields)-2], "/"), "/git")
 
 	oldOwner := fields[len(fields)-2]

--- a/services/migrations/gitbucket.go
+++ b/services/migrations/gitbucket.go
@@ -34,10 +34,11 @@ func (f *GitBucketDownloaderFactory) New(ctx context.Context, opts base.MigrateO
 		return nil, err
 	}
 
-	baseURL := u.Scheme + "://" + u.Host
 	fields := strings.Split(u.Path, "/")
-	oldOwner := fields[1]
-	oldName := strings.TrimSuffix(fields[2], ".git")
+	baseURL := u.Scheme + "://" + u.Host + strings.TrimSuffix(strings.Join(fields[:len(fields)-2], "/"), "/git")
+
+	oldOwner := fields[len(fields)-2]
+	oldName := strings.TrimSuffix(fields[len(fields)-1], ".git")
 
 	log.Trace("Create GitBucket downloader. BaseURL: %s RepoOwner: %s RepoName: %s", baseURL, oldOwner, oldName)
 	return NewGitBucketDownloader(ctx, baseURL, opts.AuthUsername, opts.AuthPassword, opts.AuthToken, oldOwner, oldName), nil
@@ -72,6 +73,7 @@ func (g *GitBucketDownloader) ColorFormat(s fmt.State) {
 func NewGitBucketDownloader(ctx context.Context, baseURL, userName, password, token, repoOwner, repoName string) *GitBucketDownloader {
 	githubDownloader := NewGithubDownloaderV3(ctx, baseURL, userName, password, token, repoOwner, repoName)
 	githubDownloader.SkipReactions = true
+	githubDownloader.SkipReviews = true
 	return &GitBucketDownloader{
 		githubDownloader,
 	}

--- a/services/migrations/github.go
+++ b/services/migrations/github.go
@@ -76,6 +76,7 @@ type GithubDownloaderV3 struct {
 	curClientIdx  int
 	maxPerPage    int
 	SkipReactions bool
+	SkipReviews   bool
 }
 
 // NewGithubDownloaderV3 creates a github Downloader via github v3 API
@@ -805,6 +806,9 @@ func (g *GithubDownloaderV3) convertGithubReviewComments(cs []*github.PullReques
 // GetReviews returns pull requests review
 func (g *GithubDownloaderV3) GetReviews(reviewable base.Reviewable) ([]*base.Review, error) {
 	allReviews := make([]*base.Review, 0, g.maxPerPage)
+	if g.SkipReviews {
+		return allReviews, nil
+	}
 	opt := &github.ListOptions{
 		PerPage: g.maxPerPage,
 	}


### PR DESCRIPTION
Backport #22477 

Migration from GitBucket does not work due to a access for "Reviews" API on GitBucket that makes 404 response.
This PR has following changes.
1. Made to stop access for Reviews API while migrating from GitBucket.
2. Added support for custom URL (e.g. `http://example.com/gitbucket/owner/repository`)
3. Made to accept for git checkout URL (`http://example.com/git/owner/repository.git`)
