### PR TITLE
Fix Operator does not exist bug on explore page with ONLY_SHOW_RELEVANT_REPOS (#22454)

### DIFF
--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -15,6 +15,7 @@ import (
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/container"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 
@@ -498,8 +499,12 @@ func SearchRepositoryCondition(opts *SearchRepoOptions) builder.Cond {
 		// Only show a repo that either has a topic or description.
 		subQueryCond := builder.NewCond()
 
-		// Topic checking. Topics is non-null.
-		subQueryCond = subQueryCond.Or(builder.And(builder.Neq{"topics": "null"}, builder.Neq{"topics": "[]"}))
+		// Topic checking. Topics are present.
+		if setting.Database.UsePostgreSQL { // postgres stores the topics as json and not as text
+			subQueryCond = subQueryCond.Or(builder.And(builder.NotNull{"topics"}, builder.Neq{"(topics)::text": "[]"}))
+		} else {
+			subQueryCond = subQueryCond.Or(builder.And(builder.Neq{"topics": "null"}, builder.Neq{"topics": "[]"}))
+		}
 
 		// Description checking. Description not empty.
 		subQueryCond = subQueryCond.Or(builder.Neq{"description": ""})


### PR DESCRIPTION
Backport #22454

There is a mistake in the code for SearchRepositoryCondition where it tests topics as a string. This is incorrect for postgres where topics is cast and stored as json. topics needs to be cast to text for this to work. (For some reason JSON_ARRAY_LENGTH does not work, so I have taken the simplest solution of casting to text and doing a string comparison.)

Ref https://github.com/go-gitea/gitea/pull/21962#issuecomment-1379584057

Signed-off-by: Andrew Thornton <art27@cantab.net>
Co-authored-by: delvh <dev.lh@web.de>
