### PR TITLE
Fix error when calculate the repository size (#22392)

### DIFF
--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -24,7 +24,7 @@
   fork_id: 0
   is_template: false
   template_id: 0
-  size: 0
+  size: 6708
   is_fsck_enabled: true
   close_issues_via_commit_in_any_branch: false
 

--- a/models/repo/update.go
+++ b/models/repo/update.go
@@ -185,7 +185,7 @@ func ChangeRepositoryName(doer *user_model.User, repo *Repository, newRepoName s
 	return committer.Commit()
 }
 
-// UpdateRepoSize updates the repository size, calculating it using util.GetDirectorySize
+// UpdateRepoSize updates the repository size, calculating it using getDirectorySize
 func UpdateRepoSize(ctx context.Context, repoID, size int64) error {
 	_, err := db.GetEngine(ctx).ID(repoID).Cols("size").NoAutoTime().Update(&Repository{
 		Size: size,

--- a/modules/repository/create.go
+++ b/modules/repository/create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"code.gitea.io/gitea/models"
@@ -286,9 +287,36 @@ func CreateRepository(doer, u *user_model.User, opts CreateRepoOptions) (*repo_m
 	return repo, nil
 }
 
-// UpdateRepoSize updates the repository size, calculating it using util.GetDirectorySize
+const notRegularFileMode = os.ModeSymlink | os.ModeNamedPipe | os.ModeSocket | os.ModeDevice | os.ModeCharDevice | os.ModeIrregular
+
+// getDirectorySize returns the disk consumption for a given path
+func getDirectorySize(path string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(path, func(_ string, info os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) { // ignore the error because the file maybe deleted during traversing.
+				return nil
+			}
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		f, err := info.Info()
+		if err != nil {
+			return err
+		}
+		if (f.Mode() & notRegularFileMode) == 0 {
+			size += f.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
+// UpdateRepoSize updates the repository size, calculating it using getDirectorySize
 func UpdateRepoSize(ctx context.Context, repo *repo_model.Repository) error {
-	size, err := util.GetDirectorySize(repo.RepoPath())
+	size, err := getDirectorySize(repo.RepoPath())
 	if err != nil {
 		return fmt.Errorf("updateSize: %w", err)
 	}

--- a/modules/repository/create_test.go
+++ b/modules/repository/create_test.go
@@ -172,7 +172,7 @@ func TestUpdateRepositoryVisibilityChanged(t *testing.T) {
 
 func TestGetDirectorySize(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
-	repo, err := repo_model.GetRepositoryByID(db.DefaultContext, 1)
+	repo, err := repo_model.GetRepositoryByID(1)
 	assert.NoError(t, err)
 
 	size, err := getDirectorySize(repo.RepoPath())

--- a/modules/repository/create_test.go
+++ b/modules/repository/create_test.go
@@ -169,3 +169,13 @@ func TestUpdateRepositoryVisibilityChanged(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, act.IsPrivate)
 }
+
+func TestGetDirectorySize(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	repo, err := repo_model.GetRepositoryByID(db.DefaultContext, 1)
+	assert.NoError(t, err)
+
+	size, err := getDirectorySize(repo.RepoPath())
+	assert.NoError(t, err)
+	assert.EqualValues(t, size, repo.Size)
+}

--- a/modules/util/path.go
+++ b/modules/util/path.go
@@ -23,20 +23,6 @@ func EnsureAbsolutePath(path, absoluteBase string) string {
 	return filepath.Join(absoluteBase, path)
 }
 
-const notRegularFileMode os.FileMode = os.ModeSymlink | os.ModeNamedPipe | os.ModeSocket | os.ModeDevice | os.ModeCharDevice | os.ModeIrregular
-
-// GetDirectorySize returns the disk consumption for a given path
-func GetDirectorySize(path string) (int64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if info != nil && (info.Mode()&notRegularFileMode) == 0 {
-			size += info.Size()
-		}
-		return err
-	})
-	return size, err
-}
-
 // IsDir returns true if given path is a directory,
 // or returns false when it's a file or does not exist.
 func IsDir(dir string) (bool, error) {


### PR DESCRIPTION
Backport #22392

Fix #22386

`GetDirectorySize` moved as `getDirectorySize` because it becomes a special function which should not be put in `util`.

Co-authored-by: Jason Song <i@wolfogre.com>
