### PR TITLE
Fix pull request API field `closed_at` always being `null` (#22482)

### DIFF
--- a/modules/convert/pull.go
+++ b/modules/convert/pull.go
@@ -89,6 +89,10 @@ func ToAPIPullRequest(ctx context.Context, pr *issues_model.PullRequest, doer *u
 		},
 	}
 
+	if pr.Issue.ClosedUnix != 0 {
+		apiPullRequest.Closed = pr.Issue.ClosedUnix.AsTimePtr()
+	}
+
 	gitRepo, err := git.OpenRepository(ctx, pr.BaseRepo.RepoPath())
 	if err != nil {
 		log.Error("OpenRepository[%s]: %v", pr.BaseRepo.RepoPath(), err)


### PR DESCRIPTION
Backport #22482
Fix #22480
