### PR TITLE
Fixed lint warnings in Grafana raised by Mixtool

### DIFF
--- a/contrib/gitea-monitoring-mixin/dashboards/overview.libsonnet
+++ b/contrib/gitea-monitoring-mixin/dashboards/overview.libsonnet
@@ -29,7 +29,7 @@ local addIssueLabelsOverrides(labels) =
 
   grafanaDashboards+:: {
 
-    local giteaSelector = 'job="$job", instance="$instance"',
+    local giteaSelector = 'job=~"$job", instance=~"$instance"',
     local giteaStatsPanel =
       grafana.statPanel.new(
         'Gitea stats',
@@ -399,25 +399,31 @@ local addIssueLabelsOverrides(labels) =
       .addTemplate(
         {
           hide: 0,
-          label: null,
+          label: 'job',
           name: 'job',
           options: [],
+          datasource: '$datasource',
           query: 'label_values(gitea_organizations, job)',
           refresh: 1,
           regex: '',
           type: 'query',
+          multi: true,
+          allValue: '.+'
         },
       )
       .addTemplate(
         {
           hide: 0,
-          label: null,
+          label: 'instance',
           name: 'instance',
           options: [],
+          datasource: '$datasource',
           query: 'label_values(gitea_organizations{job="$job"}, instance)',
           refresh: 1,
           regex: '',
           type: 'query',
+          multi: true,
+          allValue: '.+'
         },
       )
       .addTemplate(


### PR DESCRIPTION
### What this PR does / why we need it:
This PR introduces a few minor changes to the gitea-monitoring-mixin, specifically linting issues raised by [Mixtool](https://github.com/monitoring-mixins/mixtool): 
- Query selectors using `job` and `instance` have been update to allow multi-select
- Added missing attributes to `job` and `instance` template

As this change is very minor I haven't created an issue, but please let me know if you'd like me to do so. According to the guidelines, it seemed to only be for larger designs :)