### PR TITLE
docs: add swagger.json file location to FAQ

### DIFF
--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -136,7 +136,8 @@ All Gitea instances have the built-in API and there is no way to disable it comp
 You can, however, disable showing its documentation by setting `ENABLE_SWAGGER` to `false` in the `api` section of your `app.ini`.
 For more information, refer to Gitea's [API docs]({{< relref "doc/developers/api-usage.en-us.md" >}}).
 
-You can see the latest API (for example) on <https://try.gitea.io/api/swagger>.
+You can see the latest API (for example) on <https://try.gitea.io/api/swagger>.  
+You can also see an example of the `swagger.json` file at <https://try.gitea.io/swagger.v1.json>.
 
 ## Adjusting your server for public/private use
 

--- a/docs/content/doc/help/faq.en-us.md
+++ b/docs/content/doc/help/faq.en-us.md
@@ -136,7 +136,8 @@ All Gitea instances have the built-in API and there is no way to disable it comp
 You can, however, disable showing its documentation by setting `ENABLE_SWAGGER` to `false` in the `api` section of your `app.ini`.
 For more information, refer to Gitea's [API docs]({{< relref "doc/developers/api-usage.en-us.md" >}}).
 
-You can see the latest API (for example) on <https://try.gitea.io/api/swagger>.  
+You can see the latest API (for example) on <https://try.gitea.io/api/swagger>.
+
 You can also see an example of the `swagger.json` file at <https://try.gitea.io/swagger.v1.json>.
 
 ## Adjusting your server for public/private use


### PR DESCRIPTION
This just adds a mention on how to get the `swagger.json` for an instance.