### PR TITLE
Set disable_gravatar/enable_federated_avatar when offline mode is true (#22479)

### DIFF
--- a/models/system/setting.go
+++ b/models/system/setting.go
@@ -269,6 +269,16 @@ func Init() error {
 	if setting_module.OfflineMode {
 		disableGravatar = true
 		enableFederatedAvatar = false
+		if !GetSettingBool(KeyPictureDisableGravatar) {
+			if err := SetSettingNoVersion(KeyPictureDisableGravatar, "true"); err != nil {
+				return fmt.Errorf("Failed to set setting %q: %w", KeyPictureDisableGravatar, err)
+			}
+		}
+		if GetSettingBool(KeyPictureEnableFederatedAvatar) {
+			if err := SetSettingNoVersion(KeyPictureEnableFederatedAvatar, "false"); err != nil {
+				return fmt.Errorf("Failed to set setting %q: %w", KeyPictureEnableFederatedAvatar, err)
+			}
+		}
 	}
 
 	if enableFederatedAvatar || !disableGravatar {

--- a/routers/web/admin/config.go
+++ b/routers/web/admin/config.go
@@ -6,9 +6,11 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	system_model "code.gitea.io/gitea/models/system"
@@ -202,6 +204,16 @@ func ChangeConfig(ctx *context.Context) {
 	value := ctx.FormString("value")
 	version := ctx.FormInt("version")
 
+	if check, ok := changeConfigChecks[key]; ok {
+		if err := check(ctx, value); err != nil {
+			log.Warn("refused to set setting: %v", err)
+			ctx.JSON(http.StatusOK, map[string]string{
+				"err": ctx.Tr("admin.config.set_setting_failed", key),
+			})
+			return
+		}
+	}
+
 	if err := system_model.SetSetting(&system_model.Setting{
 		SettingKey:   key,
 		SettingValue: value,
@@ -217,4 +229,19 @@ func ChangeConfig(ctx *context.Context) {
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"version": version + 1,
 	})
+}
+
+var changeConfigChecks = map[string]func(ctx *context.Context, newValue string) error{
+	system_model.KeyPictureDisableGravatar: func(_ *context.Context, newValue string) error {
+		if v, _ := strconv.ParseBool(newValue); setting.OfflineMode && !v {
+			return fmt.Errorf("%q should be true when OFFLINE_MODE is true", system_model.KeyPictureDisableGravatar)
+		}
+		return nil
+	},
+	system_model.KeyPictureEnableFederatedAvatar: func(_ *context.Context, newValue string) error {
+		if v, _ := strconv.ParseBool(newValue); setting.OfflineMode && v {
+			return fmt.Errorf("%q cannot be false when OFFLINE_MODE is true", system_model.KeyPictureEnableFederatedAvatar)
+		}
+		return nil
+	},
 }


### PR DESCRIPTION
Backport #22479.

When offline mode is true, we should set `disable_gravatar` to `true` and `enable_federated_avatar` to `false` in system settings.
