### PR TITLE
Reliable selection of admin user

### DIFF
--- a/models/user/user.go
+++ b/models/user/user.go
@@ -1235,7 +1235,7 @@ func GetAdminUser() (*User, error) {
 	var admin User
 	has, err := db.GetEngine(db.DefaultContext).
 		Where("is_admin=?", true).
-		OrderBy("id asc"). // Reliably get the admin with the lowest ID.
+		Asc("id"). // Reliably get the admin with the lowest ID.
 		Get(&admin)
 	if err != nil {
 		return nil, err

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -1233,7 +1233,10 @@ func GetUserByOpenID(uri string) (*User, error) {
 // GetAdminUser returns the first administrator
 func GetAdminUser() (*User, error) {
 	var admin User
-	has, err := db.GetEngine(db.DefaultContext).Where("is_admin=?", true).Get(&admin)
+	has, err := db.GetEngine(db.DefaultContext).
+		Where("is_admin=?", true).
+		OrderBy("id asc"). // Reliably get the admin with the lowest ID.
+		Get(&admin)
 	if err != nil {
 		return nil, err
 	} else if !has {


### PR DESCRIPTION
When importing a repository via `gitea restore-repo`, external users will get remapped to an admin user. This admin user is obtained via `users.GetAdminUser()`, which unfortunately picks a more-or-less random admin to return.

This makes it hard to predict which admin user will get assigned. This patch orders the admin by ascending ID before choosing the first one, i.e. it picks the admin with the lowest ID.

Even though it would be nicer to have full control over which user is chosen, this at least gives us a predictable result.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
