### PR TITLE
Support importing comment types

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -175,6 +175,15 @@ func (t CommentType) String() string {
 	return commentStrings[t]
 }
 
+func AsCommentType(typeName string) CommentType {
+	for index, name := range commentStrings {
+		if typeName == name {
+			return CommentType(index)
+		}
+	}
+	return CommentTypeUnknown
+}
+
 // RoleDescriptor defines comment tag type
 type RoleDescriptor int
 

--- a/models/issues/comment_test.go
+++ b/models/issues/comment_test.go
@@ -62,3 +62,10 @@ func TestFetchCodeComments(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 }
+
+func TestAsCommentType(t *testing.T) {
+	assert.Equal(t, issues_model.CommentTypeUnknown, issues_model.AsCommentType(""))
+	assert.Equal(t, issues_model.CommentTypeUnknown, issues_model.AsCommentType("nonsense"))
+	assert.Equal(t, issues_model.CommentTypeComment, issues_model.AsCommentType("comment"))
+	assert.Equal(t, issues_model.CommentTypePRUnScheduledToAutoMerge, issues_model.AsCommentType("pull_cancel_scheduled_merge"))
+}

--- a/modules/migration/comment.go
+++ b/modules/migration/comment.go
@@ -17,6 +17,7 @@ type Commentable interface {
 type Comment struct {
 	IssueIndex  int64 `yaml:"issue_index"`
 	Index       int64
+	CommentType string `yaml:"comment_type"` // see `commentStrings` in models/issues/comment.go
 	PosterID    int64  `yaml:"poster_id"`
 	PosterName  string `yaml:"poster_name"`
 	PosterEmail string `yaml:"poster_email"`
@@ -24,6 +25,7 @@ type Comment struct {
 	Updated     time.Time
 	Content     string
 	Reactions   []*Reaction
+	Meta        map[string]interface{} `yaml:"meta,omitempty"` // see models/issues/comment.go for fields in Comment struct
 }
 
 // GetExternalName ExternalUserMigrated interface


### PR DESCRIPTION
This commit adds support for specifying comment types when importing with `gitea restore-repo`. It makes it possible to import issue changes, such as "title changed" or "assigned user changed".

An earlier version of this pull request was made by Matti Ranta, in https://future.projects.blender.org/blender-migration/gitea-bf/pulls/3

There are two changes with regard to Matti's original code:

1. The comment type was an `int64` in Matti's code, and is now using a string. This makes it possible to use `comment_type: title`, which is more reliable and future-proof than an index into an internal list in the Gitea Go code.

2. Matti's code also had support for including labels, but in a way that would require knowing the database ID of the labels before the import even starts, which is impossible. This can be solved by using label names instead of IDs; for simplicity I I left that out of this PR.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
