### PR TITLE
Fix invalid issue branch reference if not specified in template

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -784,7 +784,8 @@ func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleFiles 
 			}
 
 		}
-		if !strings.HasPrefix(template.Ref, "refs/") { // Assume that the ref intended is always a branch - for tags users should use refs/tags/<ref>
+
+		if template.Ref != "" && !strings.HasPrefix(template.Ref, "refs/") { // Assume that the ref intended is always a branch - for tags users should use refs/tags/<ref>
 			template.Ref = git.BranchPrefix + template.Ref
 		}
 		ctx.Data["HasSelectedLabel"] = len(labelIDs) > 0


### PR DESCRIPTION
When an issue template does not contain a ref, it would end up with an invalid `ref/heads/` value instead of having no branch referenced .