### PR TITLE
Fix issue not auto-closing when it includes a reference to a branch

### DIFF
--- a/services/issue/commit.go
+++ b/services/issue/commit.go
@@ -18,6 +18,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/container"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/references"
 	"code.gitea.io/gitea/modules/repository"
@@ -175,7 +176,8 @@ func UpdateIssuesCommit(doer *user_model.User, repo *repo_model.Repository, comm
 			if !repo.CloseIssuesViaCommitInAnyBranch {
 				// If the issue was specified to be in a particular branch, don't allow commits in other branches to close it
 				if refIssue.Ref != "" {
-					if branchName != refIssue.Ref {
+					issueBranchName := strings.TrimPrefix(refIssue.Ref, git.BranchPrefix)
+					if branchName != issueBranchName {
 						continue
 					}
 					// Otherwise, only process commits to the default branch


### PR DESCRIPTION
Ensure branch prefix is stripped away for both when comparing the branch name.

