### PR TITLE
Dropzone: Add "Copy link" button for new uploads

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -167,20 +167,20 @@ export function initGlobalDropzone() {
           file.uuid = data.uuid;
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           $dropzone.find('.files').append(input);
-          // Create a "Copy Link" element, to conveniently copy the image 
-          // or file link as Markdown to the clipboard 
-          let newNode = document.createElement('a');
-          newNode.className = 'dz-remove';
-          newNode.href = '#';
-          newNode.innerHTML = '<i class="fa fa-copy"></i> Copy link';
-          newNode.onclick = (e) => {
+          // Create a "Copy Link" element, to conveniently copy the image
+          // or file link as Markdown to the clipboard
+          const copyLinkElement = document.createElement('a');
+          copyLinkElement.className = 'dz-remove';
+          copyLinkElement.href = '#';
+          copyLinkElement.innerHTML = '<i class="fa fa-copy"></i> Copy link';
+          copyLinkElement.addEventListener('click', (e) => {
             e.preventDefault();
             let fileMarkdown = `[${file.name}](/attachments/${file.uuid})`;
             if (file.type.startsWith('image/')) {
               fileMarkdown = `!${fileMarkdown}`;
             }
             navigator.clipboard.writeText(fileMarkdown);
-          }
+          });
           file.previewTemplate.appendChild(newNode);
         });
         this.on('removedfile', (file) => {

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -167,6 +167,21 @@ export function initGlobalDropzone() {
           file.uuid = data.uuid;
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           $dropzone.find('.files').append(input);
+          // Create a "Copy Link" element, to conveniently copy the image 
+          // or file link as Markdown to the clipboard 
+          let newNode = document.createElement('a');
+          newNode.className = 'dz-remove';
+          newNode.href = '#';
+          newNode.innerHTML = '<i class="fa fa-copy"></i> Copy link';
+          newNode.onclick = (e) => {
+            e.preventDefault();
+            let fileMarkdown = `[${file.name}](/attachments/${file.uuid})`;
+            if (file.type.startsWith('image/')) {
+              fileMarkdown = `!${fileMarkdown}`;
+            }
+            navigator.clipboard.writeText(fileMarkdown);
+          }
+          file.previewTemplate.appendChild(newNode);
         });
         this.on('removedfile', (file) => {
           $(`#${file.uuid}`).remove();

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -181,7 +181,7 @@ export function initGlobalDropzone() {
             }
             navigator.clipboard.writeText(fileMarkdown);
           });
-          file.previewTemplate.appendChild(newNode);
+          file.previewTemplate.appendChild(copyLinkElement);
         });
         this.on('removedfile', (file) => {
           $(`#${file.uuid}`).remove();


### PR DESCRIPTION
Once an attachment is successfully uploaded via Dropzone, display a "Copy link" under the "Remove file" button.
Once the button is clicked, depending if the attachment is an image or a file, the appropriate markup is written to the clipboard, so it can be conveniently pasted in the description.