### PR TITLE
Fix assignment to `cm.AssigneeID` when importing comments

### DIFF
--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -468,7 +468,9 @@ func (g *GiteaLocalUploader) CreateComments(comments ...*base.Comment) error {
 
 		switch cm.Type {
 		case issues_model.CommentTypeAssignees:
-			cm.AssigneeID = comment.Meta["AssigneeID"].(int64)
+			if assigneeID, ok := comment.Meta["AssigneeID"].(int); ok {
+				cm.AssigneeID = int64(assigneeID)
+			}
 			if comment.Meta["RemovedAssigneeID"] != nil {
 				cm.RemovedAssignee = true
 			}


### PR DESCRIPTION
This is a fix for https://github.com/go-gitea/gitea/pull/22510

The code assumed that the `AssigneeID` from the comment YAML was an `int64`, but it is actually an `int`, causing a panic. It also had no check on whether the type cast was actually valid, so badly formatted YAML could also cause a panic.

Both these issues have been fixed.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
