### PR TITLE
When updating by rebase we need to set the environment for head repo (#22535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 ## [1.18.2](https://github.com/go-gitea/gitea/releases/tag/v1.18.2) - 2023-01-19
 
 * BUGFIXES
-  * When updating by rebase we need to set the environment for head repo (#22535)
+  * When updating by rebase we need to set the environment for head repo (#22535) (#22536)
   * Fix issue not auto-closing when it includes a reference to a branch (#22514) (#22521)
   * Fix invalid issue branch reference if not specified in template (#22513) (#22520)
   * Fix 500 error viewing pull request when fork has pull requests disabled (#22512) (#22515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ been added to each release, please refer to the [blog](https://blog.gitea.io).
 ## [1.18.2](https://github.com/go-gitea/gitea/releases/tag/v1.18.2) - 2023-01-19
 
 * BUGFIXES
+  * When updating by rebase we need to set the environment for head repo (#22535)
   * Fix issue not auto-closing when it includes a reference to a branch (#22514) (#22521)
   * Fix invalid issue branch reference if not specified in template (#22513) (#22520)
   * Fix 500 error viewing pull request when fork has pull requests disabled (#22512) (#22515)

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -584,19 +584,25 @@ func rawMerge(ctx context.Context, pr *issues_model.PullRequest, doer *user_mode
 		headUser = pr.HeadRepo.Owner
 	}
 
-	env = repo_module.FullPushingEnvironment(
-		headUser,
-		doer,
-		pr.BaseRepo,
-		pr.BaseRepo.Name,
-		pr.ID,
-	)
-
 	var pushCmd *git.Command
 	if mergeStyle == repo_model.MergeStyleRebaseUpdate {
 		// force push the rebase result to head branch
+		env = repo_module.FullPushingEnvironment(
+			headUser,
+			doer,
+			pr.HeadRepo,
+			pr.HeadRepo.Name,
+			pr.ID,
+		)
 		pushCmd = git.NewCommand(ctx, "push", "-f", "head_repo").AddDynamicArguments(stagingBranch + ":" + git.BranchPrefix + pr.HeadBranch)
 	} else {
+		env = repo_module.FullPushingEnvironment(
+			headUser,
+			doer,
+			pr.BaseRepo,
+			pr.BaseRepo.Name,
+			pr.ID,
+		)
 		pushCmd = git.NewCommand(ctx, "push", "origin").AddDynamicArguments(baseBranch + ":" + git.BranchPrefix + pr.BaseBranch)
 	}
 

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -104,6 +104,8 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 	var pusher *user_model.User
 
 	for _, opts := range optsList {
+		log.Trace("pushUpdates: %-v %s %s %s", repo, opts.OldCommitID, opts.NewCommitID, opts.RefFullName)
+
 		if opts.IsNewRef() && opts.IsDelRef() {
 			return fmt.Errorf("old and new revisions are both %s", git.EmptySHA)
 		}
@@ -129,7 +131,7 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 			} else { // is new tag
 				newCommit, err := gitRepo.GetCommit(opts.NewCommitID)
 				if err != nil {
-					return fmt.Errorf("gitRepo.GetCommit: %w", err)
+					return fmt.Errorf("gitRepo.GetCommit(%s) in %s/%s[%d]: %w", opts.NewCommitID, repo.OwnerName, repo.Name, repo.ID, err)
 				}
 
 				commits := repo_module.NewPushCommits()
@@ -162,7 +164,7 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 
 				newCommit, err := gitRepo.GetCommit(opts.NewCommitID)
 				if err != nil {
-					return fmt.Errorf("gitRepo.GetCommit: %w", err)
+					return fmt.Errorf("gitRepo.GetCommit(%s) in %s/%s[%d]: %w", opts.NewCommitID, repo.OwnerName, repo.Name, repo.ID, err)
 				}
 
 				refName := opts.RefName()


### PR DESCRIPTION
Backport #22535

The update by rebase code reuses the merge code but shortcircuits and pushes back up to the head. However, it doesn't set the correct pushing environment - and just uses the same environment as the base repo. This leads to the push update failing and thence the PR becomes out-of-sync with the head.

This PR fixes this and adjusts the trace logging elsewhere to help make this clearer.

Fix #18802

Signed-off-by: Andrew Thornton <art27@cantab.net>
