### PR TITLE
Pull Requests: show command line instructions closer to chosen merge style

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1630,6 +1630,7 @@ pulls.update_not_allowed = You are not allowed to update branch
 pulls.outdated_with_base_branch = This branch is out-of-date with the base branch
 pulls.closed_at = `closed this pull request <a id="%[1]s" href="#%[1]s">%[2]s</a>`
 pulls.reopened_at = `reopened this pull request <a id="%[1]s" href="#%[1]s">%[2]s</a>`
+pulls.rebase_add_message_hint = `The pull request # will be automatically added to the message of the last commit in the stack, if missing.`
 pulls.merge_instruction_hint = `You can also view <a class="show-instruction">command line instructions</a>.`
 pulls.merge_instruction_step1_desc = From your project repository, check out a new branch and test the changes.
 pulls.merge_instruction_step2_desc = Merge the changes and update on Gitea.

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1664,6 +1664,14 @@ func ViewIssue(ctx *context.Context) {
 
 		ctx.Data["MergeStyle"] = mergeStyle
 
+		if mergeStyle == repo_model.MergeStyleRebase {
+			ctx.Data["MergeInstructionsCommand"] = "merge --ff-only"
+		} else if mergeStyle == repo_model.MergeStyleSquash {
+			ctx.Data["MergeInstructionsCommand"] = "merge --squash"
+		} else {
+			ctx.Data["MergeInstructionsCommand"] = "merge --no-ff"
+		}
+
 		defaultMergeMessage, defaultMergeBody, err := pull_service.GetDefaultMergeMessage(ctx, ctx.Repo.GitRepo, pull, mergeStyle)
 		if err != nil {
 			ctx.ServerError("GetDefaultMergeMessage", err)

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1663,9 +1663,11 @@ func ViewIssue(ctx *context.Context) {
 		}
 
 		ctx.Data["MergeStyle"] = mergeStyle
+		ctx.Data["ShowRebaseAddMessageHint"] = false
 
 		if mergeStyle == repo_model.MergeStyleRebase {
 			ctx.Data["MergeInstructionsCommand"] = "merge --ff-only"
+			ctx.Data["ShowRebaseAddMessageHint"] = true
 		} else if mergeStyle == repo_model.MergeStyleSquash {
 			ctx.Data["MergeInstructionsCommand"] = "merge --squash"
 		} else {

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -511,18 +511,18 @@ func rawMerge(ctx context.Context, pr *issues_model.PullRequest, doer *user_mode
 			}
 		} else if mergeStyle == repo_model.MergeStyleRebase {
 			// Append Pull Request #123 to commit message
-			var existing_message strings.Builder
-			cmd_show := git.NewCommand(ctx, "show", "--format=%B", "-s")
-			if err := cmd_show.Run(&git.RunOpts{Dir: tmpBasePath, Stdout: &existing_message}); err != nil {
+			var existingMessage strings.Builder
+			cmdShow := git.NewCommand(ctx, "show", "--format=%B", "-s")
+			if err := cmdShow.Run(&git.RunOpts{Dir: tmpBasePath, Stdout: &existingMessage}); err != nil {
 				log.Error("Failed to get commit message for Pull Request #%d: %v", pr.Index, err)
 				return "", err
 			}
 
-			new_message := strings.TrimSpace(existing_message.String())
-			if match, _ := regexp.MatchString(fmt.Sprintf("#\\b%d\\b", pr.Index), new_message); !match {
-				new_message = new_message + fmt.Sprintf("\n\nPull Request #%d", pr.Index)
-				cmd_amend := git.NewCommand(ctx, "commit", "--amend", "-m").AddDynamicArguments(new_message)
-				if err := cmd_amend.Run(&git.RunOpts{Dir: tmpBasePath}); err != nil {
+			newMessage := strings.TrimSpace(existingMessage.String())
+			if match, _ := regexp.MatchString(fmt.Sprintf("#\\b%d\\b", pr.Index), newMessage); !match {
+				newMessage += fmt.Sprintf("\n\nPull Request #%d", pr.Index)
+				cmdAmend := git.NewCommand(ctx, "commit", "--amend", "-m").AddDynamicArguments(newMessage)
+				if err := cmdAmend.Run(&git.RunOpts{Dir: tmpBasePath}); err != nil {
 					log.Error("Failed to amend commit message with Pull Request #%d: %v", pr.Index, err)
 					return "", err
 				}

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -419,6 +419,9 @@
 						{{if .ShowMergeInstructions}}
 							{{template "repo/issue/view_content/pull_merge_instruction" (dict "locale" .locale "Issue" .Issue "MergeCommand" .MergeInstructionsCommand)}}
 						{{end}}
+						{{if .ShowRebaseAddMessageHint}}
+							<div class="mt-3"> {{$.locale.Tr "repo.pulls.rebase_add_message_hint" | Safe}} </div>
+						{{end}}
 					{{else}}
 						{{/* no merge style was set in repo setting: not or ($prUnit.PullRequestsConfig.AllowMerge ...) */}}
 						<div class="ui divider"></div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -417,7 +417,7 @@
 						<div id="pull-request-merge-form"></div>
 
 						{{if .ShowMergeInstructions}}
-							{{template "repo/issue/view_content/pull_merge_instruction" (dict "locale" .locale "Issue" .Issue)}}
+							{{template "repo/issue/view_content/pull_merge_instruction" (dict "locale" .locale "Issue" .Issue "MergeCommand" .MergeInstructionsCommand)}}
 						{{end}}
 					{{else}}
 						{{/* no merge style was set in repo setting: not or ($prUnit.PullRequestsConfig.AllowMerge ...) */}}

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -13,7 +13,7 @@
 	<div><h3 class="di">{{$.locale.Tr "step2"}} </h3>{{$.locale.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
 	<div class="ui secondary segment">
 		<div>git checkout {{$.Issue.PullRequest.BaseBranch}}</div>
-		<div>git merge --no-ff {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}}</div>
+		<div>git {{$.MergeCommand}} {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}}</div>
 		<div>git push origin {{$.Issue.PullRequest.BaseBranch}}</div>
 	</div>
 </div>


### PR DESCRIPTION
Pull Requests: show command line instructions closer to chosen merge style

Only matches the default command though, does not manually update if you switch.
But for Blender we will likely have only one option anyway.

If the # is not already mentioned somewhere in the commit message, the
following is added at the end of the commit message:

```
Pull Request https://github.com/go-gitea/gitea/issues/123
```

To be upstreamable, this should at least be made optional behavior if it is
considered a good feature to have at all. It also only changes the last commit
in the stack which is not ideal.

Code by: @brechtvl
