### PR TITLE
Truncate commit summary on repo files table. (#22551)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2845,6 +2845,11 @@ tbody.commit-list {
   display: inline;
 }
 
+// but in the repo-files-table we cannot
+#repo-files-table .commit-list .message-wrapper {
+  display: inline-block;
+}
+
 @media @mediaSm {
   tr.commit-list {
     width: 100%;


### PR DESCRIPTION
Backport #22551
There was an unintended regression in #21124 which assumed that .commits-list .message-wrapper would only match the commit summaries on /{owner}/{name}/commits/*. This assumption is incorrect as the directory/file view also uses a .commits-list wrapper.

Rather than completely restructure this page this PR simply adjusts the styling to again use display: inline-block; for #repo-files-table .commit-list .message-wrapper

Fix #22360
