### PR TITLE
Split default gitpod view to include all tasks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,10 +7,6 @@ tasks:
     command: |
       gp sync-done setup
       exit 0
-  - name: Run frontend
-    command: |
-      gp sync-await setup
-      make watch-frontend
   - name: Run backend
     command: |
       gp sync-await setup
@@ -19,7 +15,11 @@ tasks:
       echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
-    openMode: split-left
+  - name: Run frontend
+    command: |
+      gp sync-await setup
+      make watch-frontend
+    openMode: split-right
   - name: Run docs
     before: sudo bash -c "$(grep 'https://github.com/gohugoio/hugo/releases/download' Makefile | tr -d '\')" # install hugo
     command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,9 +19,11 @@ tasks:
       echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
+    openMode: split-right
   - name: Run docs
     before: sudo bash -c "$(grep 'https://github.com/gohugoio/hugo/releases/download' Makefile | tr -d '\')" # install hugo
     command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
+    openMode: split-right
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
       echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
-    openMode: split-right
+    openMode: split-left
   - name: Run docs
     before: sudo bash -c "$(grep 'https://github.com/gohugoio/hugo/releases/download' Makefile | tr -d '\')" # install hugo
     command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0


### PR DESCRIPTION
It was showing only the `docs` process

### Before
![image](https://user-images.githubusercontent.com/20454870/213759014-c573f8ea-c631-471a-8e0c-4af8d897600b.png)
### After
![image](https://user-images.githubusercontent.com/20454870/213785129-5256c019-620c-46ed-8988-ac697e280f10.png)

