### PR TITLE
fix: read:org scope

### DIFF
--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -80,8 +80,8 @@
 						</div>
 						<div class="field">
 							<div class="ui checkbox">
-								<input class="enable-system" type="checkbox" name="scope" value="read:public_key">
-								<label>read:public_key</label>
+								<input class="enable-system" type="checkbox" name="scope" value="read:org">
+								<label>read:org</label>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Hard to see in the diff, but this was duplicated in the wrong section.

![read-org](https://user-images.githubusercontent.com/42128690/213774506-9b47ce23-d2e5-4dfd-af49-6ae4947ac724.png)
