### PR TITLE
Prevent multiple `To` recipients (#22566)

### DIFF
--- a/routers/private/mail.go
+++ b/routers/private/mail.go
@@ -81,7 +81,7 @@ func SendEmail(ctx *context.PrivateContext) {
 
 func sendEmail(ctx *context.PrivateContext, subject, message string, to []string) {
 	for _, email := range to {
-		msg := mailer.NewMessage([]string{email}, subject, message)
+		msg := mailer.NewMessage(email, subject, message)
 		mailer.SendAsync(msg)
 	}
 

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -61,7 +61,7 @@ func SendTestMail(email string) error {
 		// No mail service configured
 		return nil
 	}
-	return gomail.Send(Sender, NewMessage([]string{email}, "Gitea Test Email!", "Gitea Test Email!").ToMessage())
+	return gomail.Send(Sender, NewMessage(email, "Gitea Test Email!", "Gitea Test Email!").ToMessage())
 }
 
 // sendUserMail sends a mail to the user
@@ -86,7 +86,7 @@ func sendUserMail(language string, u *user_model.User, tpl base.TplName, code, s
 		return
 	}
 
-	msg := NewMessage([]string{u.Email}, subject, content.String())
+	msg := NewMessage(u.Email, subject, content.String())
 	msg.Info = fmt.Sprintf("UID: %d, %s", u.ID, info)
 
 	SendAsync(msg)
@@ -137,7 +137,7 @@ func SendActivateEmailMail(u *user_model.User, email *user_model.EmailAddress) {
 		return
 	}
 
-	msg := NewMessage([]string{email.Email}, locale.Tr("mail.activate_email"), content.String())
+	msg := NewMessage(email.Email, locale.Tr("mail.activate_email"), content.String())
 	msg.Info = fmt.Sprintf("UID: %d, activate email", u.ID)
 
 	SendAsync(msg)
@@ -168,7 +168,7 @@ func SendRegisterNotifyMail(u *user_model.User) {
 		return
 	}
 
-	msg := NewMessage([]string{u.Email}, locale.Tr("mail.register_notify"), content.String())
+	msg := NewMessage(u.Email, locale.Tr("mail.register_notify"), content.String())
 	msg.Info = fmt.Sprintf("UID: %d, registration notify", u.ID)
 
 	SendAsync(msg)
@@ -202,7 +202,7 @@ func SendCollaboratorMail(u, doer *user_model.User, repo *repo_model.Repository)
 		return
 	}
 
-	msg := NewMessage([]string{u.Email}, subject, content.String())
+	msg := NewMessage(u.Email, subject, content.String())
 	msg.Info = fmt.Sprintf("UID: %d, add collaborator", u.ID)
 
 	SendAsync(msg)
@@ -306,7 +306,7 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipient
 
 	msgs := make([]*Message, 0, len(recipients))
 	for _, recipient := range recipients {
-		msg := NewMessageFrom([]string{recipient.Email}, ctx.Doer.DisplayName(), setting.MailService.FromEmail, subject, mailBody.String())
+		msg := NewMessageFrom(recipient.Email, ctx.Doer.DisplayName(), setting.MailService.FromEmail, subject, mailBody.String())
 		msg.Info = fmt.Sprintf("Subject: %s, %s", subject, info)
 
 		msg.SetHeader("Message-ID", "<"+msgID+">")

--- a/services/mailer/mail_release.go
+++ b/services/mailer/mail_release.go
@@ -90,7 +90,7 @@ func mailNewRelease(ctx context.Context, lang string, tos []string, rel *repo_mo
 	publisherName := rel.Publisher.DisplayName()
 	relURL := "<" + rel.HTMLURL() + ">"
 	for _, to := range tos {
-		msg := NewMessageFrom([]string{to}, publisherName, setting.MailService.FromEmail, subject, mailBody.String())
+		msg := NewMessageFrom(to, publisherName, setting.MailService.FromEmail, subject, mailBody.String())
 		msg.Info = subject
 		msg.SetHeader("Message-ID", relURL)
 		msgs = append(msgs, msg)

--- a/services/mailer/mail_repo.go
+++ b/services/mailer/mail_repo.go
@@ -83,9 +83,12 @@ func sendRepoTransferNotifyMailPerLang(lang string, newOwner, doer *user_model.U
 		return err
 	}
 
-	msg := NewMessage(emails, subject, content.String())
-	msg.Info = fmt.Sprintf("UID: %d, repository pending transfer notification", newOwner.ID)
+	for _, to := range emails {
+		msg := NewMessage(to, subject, content.String())
+		msg.Info = fmt.Sprintf("UID: %d, repository pending transfer notification", newOwner.ID)
 
-	SendAsync(msg)
+		SendAsync(msg)
+	}
+
 	return nil
 }

--- a/services/mailer/mail_team_invite.go
+++ b/services/mailer/mail_team_invite.go
@@ -53,7 +53,7 @@ func MailTeamInvite(ctx context.Context, inviter *user_model.User, team *org_mod
 		return err
 	}
 
-	msg := NewMessage([]string{invite.Email}, subject, mailBody.String())
+	msg := NewMessage(invite.Email, subject, mailBody.String())
 	msg.Info = subject
 
 	SendAsync(msg)

--- a/services/mailer/mailer.go
+++ b/services/mailer/mailer.go
@@ -36,7 +36,7 @@ type Message struct {
 	Info            string // Message information for log purpose.
 	FromAddress     string
 	FromDisplayName string
-	To              []string
+	To              string // Use only one recipient to prevent leaking of addresses
 	Subject         string
 	Date            time.Time
 	Body            string
@@ -47,7 +47,7 @@ type Message struct {
 func (m *Message) ToMessage() *gomail.Message {
 	msg := gomail.NewMessage()
 	msg.SetAddressHeader("From", m.FromAddress, m.FromDisplayName)
-	msg.SetHeader("To", m.To...)
+	msg.SetHeader("To", m.To)
 	for header := range m.Headers {
 		msg.SetHeader(header, m.Headers[header]...)
 	}
@@ -86,7 +86,7 @@ func (m *Message) generateAutoMessageID() string {
 	dateMs := m.Date.UnixNano() / 1e6
 	h := fnv.New64()
 	if len(m.To) > 0 {
-		_, _ = h.Write([]byte(m.To[0]))
+		_, _ = h.Write([]byte(m.To))
 	}
 	_, _ = h.Write([]byte(m.Subject))
 	_, _ = h.Write([]byte(m.Body))
@@ -94,7 +94,7 @@ func (m *Message) generateAutoMessageID() string {
 }
 
 // NewMessageFrom creates new mail message object with custom From header.
-func NewMessageFrom(to []string, fromDisplayName, fromAddress, subject, body string) *Message {
+func NewMessageFrom(to, fromDisplayName, fromAddress, subject, body string) *Message {
 	log.Trace("NewMessageFrom (body):\n%s", body)
 
 	return &Message{
@@ -109,7 +109,7 @@ func NewMessageFrom(to []string, fromDisplayName, fromAddress, subject, body str
 }
 
 // NewMessage creates new mail message object with default From header.
-func NewMessage(to []string, subject, body string) *Message {
+func NewMessage(to, subject, body string) *Message {
 	return NewMessageFrom(to, setting.MailService.FromName, setting.MailService.FromEmail, subject, body)
 }
 

--- a/services/mailer/mailer_test.go
+++ b/services/mailer/mailer_test.go
@@ -22,17 +22,17 @@ func TestGenerateMessageID(t *testing.T) {
 	setting.Domain = "localhost"
 
 	date := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
-	m := NewMessageFrom(nil, "display-name", "from-address", "subject", "body")
+	m := NewMessageFrom("", "display-name", "from-address", "subject", "body")
 	m.Date = date
 	gm := m.ToMessage()
 	assert.Equal(t, "<autogen-946782245000-41e8fc54a8ad3a3f@localhost>", gm.GetHeader("Message-ID")[0])
 
-	m = NewMessageFrom([]string{"a@b.com"}, "display-name", "from-address", "subject", "body")
+	m = NewMessageFrom("a@b.com", "display-name", "from-address", "subject", "body")
 	m.Date = date
 	gm = m.ToMessage()
 	assert.Equal(t, "<autogen-946782245000-cc88ce3cfe9bd04f@localhost>", gm.GetHeader("Message-ID")[0])
 
-	m = NewMessageFrom([]string{"a@b.com"}, "display-name", "from-address", "subject", "body")
+	m = NewMessageFrom("a@b.com", "display-name", "from-address", "subject", "body")
 	m.SetHeader("Message-ID", "<msg-d@domain.com>")
 	gm = m.ToMessage()
 	assert.Equal(t, "<msg-d@domain.com>", gm.GetHeader("Message-ID")[0])


### PR DESCRIPTION
Backport #22566

Change the mailer interface to prevent the leaking of possible hidden email addresses when sending to multiple recipients.