### PR TITLE
Fix documented redis connection string

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1721,7 +1721,7 @@ ROUTER = console
 ;INTERVAL = 60
 ;;
 ;; For "redis" and "memcache", connection host address
-;; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
+;; redis: `redis://:macaron@127.0.0.1:6379/0?pool_size=100&idle_timeout=180s`
 ;; memcache: `127.0.0.1:11211`
 ;; twoqueue: `{"size":50000,"recent_ratio":0.25,"ghost_ratio":0.5}` or `50000`
 ;HOST =


### PR DESCRIPTION
Make it match the config cheat sheet

Fix #22571 
