### PR TITLE
Allow issue templates to not render title

### DIFF
--- a/modules/issue/template/template.go
+++ b/modules/issue/template/template.go
@@ -259,7 +259,9 @@ func (f *valuedField) WriteTo(builder *strings.Builder) {
 	}
 
 	// write label
-	_, _ = fmt.Fprintf(builder, "### %s\n\n", f.Label())
+	if !f.HideLabel() {
+		_, _ = fmt.Fprintf(builder, "### %s\n\n", f.Label())
+	}
 
 	blankPlaceholder := "_No response_\n"
 
@@ -309,6 +311,13 @@ func (f *valuedField) Label() string {
 		return label
 	}
 	return ""
+}
+
+func (f *valuedField) HideLabel() bool {
+	if label, ok := f.Attributes["hide_label"].(bool); ok {
+		return label
+	}
+	return false
 }
 
 func (f *valuedField) Render() string {

--- a/modules/issue/template/template_test.go
+++ b/modules/issue/template/template_test.go
@@ -640,6 +640,7 @@ body:
       description: Description of input
       placeholder: Placeholder of input
       value: Value of input
+	  hide_label: true
     validations:
       required: true
       is_number: true
@@ -680,8 +681,6 @@ body:
 			want: `### Label of textarea
 
 ` + "```bash\nValue of id2\n```" + `
-
-### Label of input
 
 Value of id3
 

--- a/modules/issue/template/template_test.go
+++ b/modules/issue/template/template_test.go
@@ -640,7 +640,7 @@ body:
       description: Description of input
       placeholder: Placeholder of input
       value: Value of input
-	  hide_label: true
+      hide_label: true
     validations:
       required: true
       is_number: true


### PR DESCRIPTION
This adds a yaml attribute that will allow the option for when markdown is rendered that the title will be not included in the output

Based on work from @brechtvl

