### PR TITLE
Prevent duplicate labels when importing more than 99

### DIFF
--- a/services/migrations/migrate.go
+++ b/services/migrations/migrate.go
@@ -281,7 +281,7 @@ func migrateRepository(doer *user_model.User, downloader base.Downloader, upload
 				lbBatchSize = len(labels)
 			}
 
-			if err := uploader.CreateLabels(labels...); err != nil {
+			if err := uploader.CreateLabels(labels[:lbBatchSize]...); err != nil {
 				return err
 			}
 			labels = labels[lbBatchSize:]


### PR DESCRIPTION
Importing labels (via `gitea restore-repo`) did not split them up into batches properly. The first "batch" would create all labels, the second "batch" would create all labels except those in the first "batch", etc. This meant that when importing more than 99 labels (the batch size) there would always be duplicate ones.

This is solved by actually passing `labels[:lbBatchSize]` to the `CreateLabels()` function, instead of the entire list `labels`.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
