### PR TITLE
Allow setting `redirect_to` cookie on OAuth login

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -847,6 +847,11 @@ func SignInOAuth(ctx *context.Context) {
 		return
 	}
 
+	redirectTo := ctx.FormString("redirect_to")
+	if len(redirectTo) > 0 {
+		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
+	}
+
 	// try to do a direct callback flow, so we don't authenticate the user again but use the valid accesstoken to get the user
 	user, gothUser, err := oAuth2UserLoginCallback(authSource, ctx.Req, ctx.Resp)
 	if err == nil && user != nil {


### PR DESCRIPTION
The regular login flow can use a `redirect_to` cookie to ensure the user ends their authentication flow on the same page as where they started it.

This commit adds the same functionality to the OAuth login URLs, so that you can use URLs like these to directly use a specific OAuth provider:

`/user/oauth2/{provider}?redirect_to={post-login path}`

Only the `auth.SignInOAuth()` function needed a change for this, as the rest of the login flow is aware of this cookie and uses it properly already.

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
