### PR TITLE
Add templates to customize text when creating and migrating repositories

### DIFF
--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -9,10 +9,7 @@
 				</h3>
 				<div class="ui attached segment">
 					{{template "base/alert" .}}
-
-					{{if not $.DisableMigrations}}
-						<p class="ui center">{{.locale.Tr "repo.new_repo_helper" ((printf "%s%s" AppSubUrl "/repo/migrate")|Escape) | Safe}}</p>
-					{{end}}
+					{{template "repo/create_helper" .}}
 
 					{{if not .CanCreateRepo}}
 						<div class="ui negative message">

--- a/templates/repo/create_helper.tmpl
+++ b/templates/repo/create_helper.tmpl
@@ -1,0 +1,3 @@
+{{if not $.DisableMigrations}}
+	<p class="ui center">{{.locale.Tr "repo.new_repo_helper" ((printf "%s%s" AppSubUrl "/repo/migrate")|Escape) | Safe}}</p>
+{{end}}

--- a/templates/repo/migrate/migrate.tmpl
+++ b/templates/repo/migrate/migrate.tmpl
@@ -2,6 +2,7 @@
 <div class="page-content repository new migrate">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
+			{{template "repo/migrate/helper" .}}
 			<div class="ui three stackable cards">
 				{{range .Services}}
 					<a class="ui card df ac" href="{{AppSubUrl}}/repo/migrate?service_type={{.}}&org={{$.Org}}&mirror={{$.Mirror}}">


### PR DESCRIPTION
These can be used to explain which types of repositories a Gitea instance is willing to host, or other rules for creating repositories.