### PR TITLE
set org visibility class to basic in header

### DIFF
--- a/templates/org/header.tmpl
+++ b/templates/org/header.tmpl
@@ -6,8 +6,8 @@
 					{{avatar . 100}}
 					<span class="text thin grey"><a href="{{.HomeLink}}">{{.DisplayName}}</a></span>
 					<span class="org-visibility">
-						{{if .Visibility.IsLimited}}<div class="ui medium orange horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-						{{if .Visibility.IsPrivate}}<div class="ui medium red horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+						{{if .Visibility.IsLimited}}<div class="ui medium basic horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+						{{if .Visibility.IsPrivate}}<div class="ui medium basic horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 					</span>
 				</div>
 			</div>


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/22601

At people and team page, we have red private tag or orange limited tag, but at repo page, it is gray (basic).
I think it is better to set them into same color (basic).