### PR TITLE
Fix `delete_repo` in template

### DIFF
--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -165,7 +165,7 @@
 					</div>
 					<div class="field">
 						<div class="ui checkbox">
-							<input class="enable-system" type="checkbox" name="scope" value="delete:repo">
+							<input class="enable-system" type="checkbox" name="scope" value="delete_repo">
 							<label>delete_repo</label>
 						</div>
 					</div>


### PR DESCRIPTION
Currently the value doesn't match the model, so selecting it results in a 500.
https://github.com/go-gitea/gitea/blob/e8ac6a9aeacf0adf21982abc51baa8938e5dd6bb/models/auth/token_scope.go#L42

---

I also feel like this should be moved up nearer the other repo scopes.  
Would anyone be opposed to a follow-up PR for that? (or I can do it in this one yet)