### PR TITLE
Fix error on account activation with wrong passwd

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -322,6 +322,7 @@ email_not_associate = The email address is not associated with any account.
 send_reset_mail = Send Account Recovery Email
 reset_password = Account Recovery
 invalid_code = Your confirmation code is invalid or has expired.
+invalid_password = Your password does not match the password that was used to create the account.
 reset_password_helper = Recover Account
 reset_password_wrong_user = You are signed in as %s, but the account recovery link is for %s
 password_too_short = Password length cannot be less than %d characters.

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -633,7 +633,7 @@ func Activate(ctx *context.Context) {
 	user := user_model.VerifyUserActiveCode(code)
 	// if code is wrong
 	if user == nil {
-		ctx.Data["IsActivateFailed"] = true
+		ctx.Data["IsCodeInvalid"] = true
 		ctx.HTML(http.StatusOK, TplActivate)
 		return
 	}
@@ -660,7 +660,7 @@ func ActivatePost(ctx *context.Context) {
 	user := user_model.VerifyUserActiveCode(code)
 	// if code is wrong
 	if user == nil {
-		ctx.Data["IsActivateFailed"] = true
+		ctx.Data["IsCodeInvalid"] = true
 		ctx.HTML(http.StatusOK, TplActivate)
 		return
 	}
@@ -675,7 +675,7 @@ func ActivatePost(ctx *context.Context) {
 			return
 		}
 		if !user.ValidatePassword(password) {
-			ctx.Data["IsActivateFailed"] = true
+			ctx.Data["IsPasswordInvalid"] = true
 			ctx.HTML(http.StatusOK, TplActivate)
 			return
 		}

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -30,8 +30,10 @@
 							<input id="code" name="code" type="hidden" value="{{.Code}}">
 						{{else if .IsSendRegisterMail}}
 							<p>{{.locale.Tr "auth.confirmation_mail_sent_prompt" (.Email|Escape) .ActiveCodeLives | Str2html}}</p>
-						{{else if .IsActivateFailed}}
+						{{else if .IsCodeInvalid}}
 							<p>{{.locale.Tr "auth.invalid_code"}}</p>
+						{{else if .IsPasswordInvalid}}
+							<p>{{.locale.Tr "auth.invalid_password"}}</p>
 						{{else if .ManualActivationOnly}}
 							<p class="center">{{.locale.Tr "auth.manual_activation_only"}}</p>
 						{{else}}


### PR DESCRIPTION
On activating local accounts, the error message didn't differentiate between using a wrong or expired token, or a wrong password. The result could already be obtained from the behaviour (different screens were presented), but the error message was misleading and lead to confusion for new users on Codeberg with Forgejo.

Now, entering a wrong password for a valid token prints a different error message.

The problem was introduced in 0f14f69e6070c9aca09f57c419e7d6007d0e520b.