### PR TITLE
Improve checkIfPRContentChanged

### DIFF
--- a/modules/util/io.go
+++ b/modules/util/io.go
@@ -22,8 +22,8 @@ func ReadAtMost(r io.Reader, buf []byte) (n int, err error) {
 // ErrNotEmpty is an error reported when there is a non-empty reader
 var ErrNotEmpty = errors.New("not-empty")
 
-// EmptyReader reads a reader and ensures it is empty
-func EmptyReader(r io.Reader) (err error) {
+// IsEmptyReader reads a reader and ensures it is empty
+func IsEmptyReader(r io.Reader) (err error) {
 	var buf [1024]byte
 
 	for {

--- a/modules/util/io.go
+++ b/modules/util/io.go
@@ -24,7 +24,7 @@ var ErrNotEmpty = errors.New("not-empty")
 
 // IsEmptyReader reads a reader and ensures it is empty
 func IsEmptyReader(r io.Reader) (err error) {
-	var buf [1024]byte
+	var buf [1]byte
 
 	for {
 		n, err := r.Read(buf[:])

--- a/modules/util/io.go
+++ b/modules/util/io.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"errors"
 	"io"
 )
 
@@ -16,4 +17,25 @@ func ReadAtMost(r io.Reader, buf []byte) (n int, err error) {
 		err = nil
 	}
 	return n, err
+}
+
+// ErrNotEmpty is an error reported when there is a non-empty reader
+var ErrNotEmpty = errors.New("not-empty")
+
+// EmptyReader reads a reader and ensures it is empty
+func EmptyReader(r io.Reader) (err error) {
+	var buf [1024]byte
+
+	for {
+		n, err := r.Read(buf[:])
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if n > 0 {
+			return ErrNotEmpty
+		}
+	}
 }

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -4,7 +4,6 @@
 package pull
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -28,6 +27,7 @@ import (
 	repo_module "code.gitea.io/gitea/modules/repository"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/sync"
+	"code.gitea.io/gitea/modules/util"
 	issue_service "code.gitea.io/gitea/services/issue"
 )
 
@@ -389,21 +389,7 @@ func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, 
 			defer func() {
 				_ = stdoutReader.Close()
 			}()
-			buf := make([]byte, 1024)
-			for {
-				n, err := stdoutReader.Read(buf)
-				if err != nil {
-					if err == io.EOF {
-						return nil
-					}
-					return err
-				}
-
-				ts := bytes.TrimSpace(buf[:n])
-				if len(ts) > 0 {
-					return changedErr
-				}
-			}
+			return util.EmptyReader(stdoutReader)
 		},
 	}); err != nil {
 		if err == changedErr {

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -352,7 +352,7 @@ func AddTestPullRequestTask(doer *user_model.User, repoID int64, branch string, 
 func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, oldCommitID, newCommitID string) (hasChanged bool, err error) {
 	tmpBasePath, err := createTemporaryRepo(ctx, pr)
 	if err != nil {
-		log.Error("CreateTemporaryPath: %v", err)
+		log.Error("CreateTemporaryRepo: %v", err)
 		return false, err
 	}
 	defer func() {

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -399,10 +399,7 @@ func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, 
 			pr.ID, pr.BaseRepo.FullName(), pr.BaseBranch, pr.HeadRepo.FullName(), pr.HeadBranch,
 			err)
 
-		return false, fmt.Errorf("Unable to run diff on %s %s %s in tempRepo for PR[%d]%s/%s...%s/%s: %w",
-			newCommitID, oldCommitID, base,
-			pr.ID, pr.BaseRepo.FullName(), pr.BaseBranch, pr.HeadRepo.FullName(), pr.HeadBranch,
-			err)
+		return false, fmt.Errorf("Unable to run git diff --name-only -z %s %s %s: %w", newCommitID, oldCommitID, base, err)
 	}
 
 	return false, nil

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -388,7 +388,7 @@ func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, 
 			err)
 	}
 
-	return strings.TrimSpace(stdout) == "", nil
+	return strings.TrimSpace(stdout) != "", nil
 }
 
 // PushToBaseRepo pushes commits from branches of head repository to


### PR DESCRIPTION
The code for checking if a commit has caused a change in a PR is extremely inefficient and affects the head repository instead of using a temporary repository.

This PR therefore makes several significant improvements:

* A temporary repo like that used in merging.
* The diff code is then significant improved to use a three-way diff instead of comparing diffs (possibly binary) line-by-line - in memory...

Ref #22578

Signed-off-by: Andrew Thornton <art27@cantab.net>
