### PR TITLE
Show migration validation error

### DIFF
--- a/modules/migration/file_format.go
+++ b/modules/migration/file_format.go
@@ -76,7 +76,7 @@ func validate(bs []byte, datatype interface{}, isJSON bool) error {
 	}
 	err = sch.Validate(v)
 	if err != nil {
-		log.Error("migration validation with %s failed for\n%s", schemaFilename, string(bs))
+		log.Error("migration validation with %s failed:\n%#v", schemaFilename, err)
 	}
 	return err
 }


### PR DESCRIPTION
Discord request: https://discord.com/channels/322538954119184384/322910365237248000/1067083214096703488

If there is a json schema validation error the full file content gets dumped into the log. That does not help and may be a lot of data. This PR prints the schema validation error message instead.