### PR TITLE
Link issue and pull requests status change in UI notifications directly to their event in the timelined view. (#22627)

### DIFF
--- a/modules/notification/ui/ui.go
+++ b/modules/notification/ui/ui.go
@@ -96,6 +96,7 @@ func (ns *notificationService) NotifyIssueChangeStatus(doer *user_model.User, is
 	_ = ns.issueQueue.Push(issueNotificationOpts{
 		IssueID:              issue.ID,
 		NotificationAuthorID: doer.ID,
+		CommentID:            actionComment.ID,
 	})
 }
 


### PR DESCRIPTION
Backport #22627

Adding the related comment to the issue and pull request status change in the UI notifications allows to navigate directly to the specific event in its dedicated view, easing the reading of last comments and to the editor for additional comments if desired. 

<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
