### PR TITLE
Remove label color from global issue filters

### DIFF
--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -30,7 +30,7 @@
 					<div class="ui divider"></div>
 					<a class="{{if not $.RepoIDs}}ui basic primary button{{end}} repo name item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&q={{$.Keyword}}">
 						<span class="text truncate">All</span>
-						<div class="ui {{if $.IsShowClosed}}red{{else}}green{{end}} label">{{CountFmt .TotalIssueCount}}</div>
+						<span class="ui ">{{CountFmt .TotalIssueCount}}</span>
 					</a>
 					{{range .Repos}}
 						{{with $Repo := .}}
@@ -49,7 +49,7 @@
 									{{- end -}}
 									]&sort={{$.SortType}}&state={{$.State}}&q={{$.Keyword}}" title="{{.FullName}}">
 								<span class="text truncate">{{$Repo.FullName}}</span>
-								<div class="ui {{if $.IsShowClosed}}red{{else}}green{{end}} label">{{CountFmt (index $.Counts $Repo.ID)}}</div>
+								<span class="ui">{{CountFmt (index $.Counts $Repo.ID)}}</span>
 							</a>
 						{{end}}
 					{{end}}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -30,7 +30,7 @@
 					<div class="ui divider"></div>
 					<a class="{{if not $.RepoIDs}}ui basic primary button{{end}} repo name item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&q={{$.Keyword}}">
 						<span class="text truncate">All</span>
-						<span class="ui ">{{CountFmt .TotalIssueCount}}</span>
+						<span class="ui">{{CountFmt .TotalIssueCount}}</span>
 					</a>
 					{{range .Repos}}
 						{{with $Repo := .}}


### PR DESCRIPTION
The use of ui colors (red, green, etc) should be limited to actionable or dismissable entries. Before this commit, a green/red label was used to display issues count on each repository. This did not add any meaningful information to the list.

Removing the label reduces ambiguity and makes the list easier to scan visually.

![label_compare](https://user-images.githubusercontent.com/451841/215360696-a881b765-207d-4ffa-8bec-398f8e5dab1e.jpg)
