### PR TITLE
Fix whitespace being matched on commit cross-referencing

### DIFF
--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -39,7 +39,7 @@ var (
 	crossReferenceIssueNumericPattern = regexp.MustCompile(`(?:\s|^|\(|\[)([0-9a-zA-Z-_\.]+/[0-9a-zA-Z-_\.]+[#!][0-9]+)(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)`)
 	// crossReferenceCommitPattern matches a string that references a commit in a different repository
 	// e.g. go-gitea/gitea@d8a994ef, go-gitea/gitea@d8a994ef243349f321568f9e36d5c3f444b99cae (7-40 characters)
-	crossReferenceCommitPattern = regexp.MustCompile(`(?:\s|^|\(|\[)([0-9a-zA-Z-_\.]+)/([0-9a-zA-Z-_\.]+)@([0-9a-f]{7,40})(?:\s|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)`)
+	crossReferenceCommitPattern = regexp.MustCompile(`(?:|^|\(|\[)([0-9a-zA-Z-_\.]+)/([0-9a-zA-Z-_\.]+)@([0-9a-f]{7,40})(?:|$|\)|\]|[:;,.?!]\s|[:;,.?!]$)`)
 	// spaceTrimmedPattern let's us find the trailing space
 	spaceTrimmedPattern = regexp.MustCompile(`(?:.*[0-9a-zA-Z-_])\s`)
 	// timeLogPattern matches string for time tracking

--- a/modules/references/references_test.go
+++ b/modules/references/references_test.go
@@ -352,7 +352,7 @@ func TestFindRenderizableCommitCrossReference(t *testing.T) {
 				Owner:       "go-gitea",
 				Name:        "gitea",
 				CommitSha:   "abcd1234",
-				RefLocation: &RefSpan{Start: 4, End: 29},
+				RefLocation: &RefSpan{Start: 5, End: 28},
 			},
 		},
 	}


### PR DESCRIPTION
Changed the regex so it won't match whitespace

## Screenshots
Source:
```
hi abc/fed@12d90af2cfe5500ec947bdefd237f2a8b6464b95 bye
```
### Before
![image](https://user-images.githubusercontent.com/20454870/215597449-1a13af88-3410-498e-9522-1ec7b1b89058.png)
### After
![image](https://user-images.githubusercontent.com/20454870/215597685-19d7fd48-3f45-4dfa-94bd-ca5dab9ba3d3.png)


Fixes #22666 
