### PR TITLE
set user visibility class to basic

### DIFF
--- a/templates/user/overview/header.tmpl
+++ b/templates/user/overview/header.tmpl
@@ -8,8 +8,8 @@
 						{{avatar . 100}}
 						<span class="text thin grey"><a href="{{.HomeLink}}">{{.DisplayName}}</a></span>
 						<span class="org-visibility">
-							{{if .Visibility.IsLimited}}<div class="ui medium orange horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
-							{{if .Visibility.IsPrivate}}<div class="ui medium red horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
+							{{if .Visibility.IsLimited}}<div class="ui medium basic horizontal label">{{$.locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
+							{{if .Visibility.IsPrivate}}<div class="ui medium basic horizontal label">{{$.locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 						</span>
 					</div>
 				</div>


### PR DESCRIPTION
Same to https://github.com/go-gitea/gitea/pull/22605

![user package](https://user-images.githubusercontent.com/18380374/215669905-71fe01c3-c011-4867-97a6-3df5f940a6bf.PNG)
![user projects](https://user-images.githubusercontent.com/18380374/215669909-1a4f74f1-bbde-4913-9ba5-51c44cc63862.PNG)

These two page are both used at user and org, so if i fixed the org page, the user page will be also be fixed.