### PR TITLE
Fix README TOC links (#22577)

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -358,10 +358,17 @@ func postProcess(ctx *RenderContext, procs []processor, input io.Reader, output 
 }
 
 func visitNode(ctx *RenderContext, procs, textProcs []processor, node *html.Node) {
-	// Add user-content- to IDs if they don't already have them
+	// Add user-content- to IDs and "#" links if they don't already have them
 	for idx, attr := range node.Attr {
-		if attr.Key == "id" && !(strings.HasPrefix(attr.Val, "user-content-") || blackfridayExtRegex.MatchString(attr.Val)) {
+		val := strings.TrimPrefix(attr.Val, "#")
+		notHasPrefix := !(strings.HasPrefix(val, "user-content-") || blackfridayExtRegex.MatchString(val))
+
+		if attr.Key == "id" && notHasPrefix {
 			node.Attr[idx].Val = "user-content-" + attr.Val
+		}
+
+		if attr.Key == "href" && strings.HasPrefix(attr.Val, "#") && notHasPrefix {
+			node.Attr[idx].Val = "#user-content-" + val
 		}
 
 		if attr.Key == "class" && attr.Val == "emoji" {


### PR DESCRIPTION
Backport #22577 

Fixes anchored markup links by adding `user-content-` (which is prepended to IDs)

Closes https://codeberg.org/Codeberg/Community/issues/894