### PR TITLE
Fix ref to trigger Actions

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -6,11 +6,13 @@ package actions
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/json"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -61,6 +63,27 @@ func (run *ActionRun) Link() string {
 		return ""
 	}
 	return fmt.Sprintf("%s/actions/runs/%d", run.Repo.Link(), run.Index)
+}
+
+func (run *ActionRun) RefLink() string {
+	refName := git.RefName(run.Ref)
+	switch refName.RefGroup() {
+	case "heads":
+		return run.Repo.Link() + "/src/branch/" + refName.ShortName()
+	case "tags":
+		return run.Repo.Link() + "/src/tag/" + refName.ShortName()
+	case "pull":
+		return run.Repo.Link() + "/pulls/" + refName.ShortName()
+	}
+	return ""
+}
+
+func (run *ActionRun) PrettyRef() string {
+	refName := git.RefName(run.Ref)
+	if refName.RefGroup() == "pull" {
+		return "#" + strings.TrimSuffix(strings.TrimPrefix(run.Ref, git.PullPrefix), "/head")
+	}
+	return refName.ShortName()
 }
 
 // LoadAttributes load Repo TriggerUser if not loaded

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -67,15 +67,10 @@ func (run *ActionRun) Link() string {
 
 func (run *ActionRun) RefLink() string {
 	refName := git.RefName(run.Ref)
-	switch refName.RefGroup() {
-	case "heads":
-		return run.Repo.Link() + "/src/branch/" + refName.ShortName()
-	case "tags":
-		return run.Repo.Link() + "/src/tag/" + refName.ShortName()
-	case "pull":
+	if refName.RefGroup() == "pull" {
 		return run.Repo.Link() + "/pulls/" + refName.ShortName()
 	}
-	return ""
+	return git.RefURL(run.Repo.Link(), run.Ref)
 }
 
 func (run *ActionRun) PrettyRef() string {

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -65,6 +65,7 @@ func (run *ActionRun) Link() string {
 	return fmt.Sprintf("%s/actions/runs/%d", run.Repo.Link(), run.Index)
 }
 
+// RefLink return the url of run's ref
 func (run *ActionRun) RefLink() string {
 	refName := git.RefName(run.Ref)
 	if refName.RefGroup() == "pull" {
@@ -73,6 +74,7 @@ func (run *ActionRun) RefLink() string {
 	return git.RefURL(run.Repo.Link(), run.Ref)
 }
 
+// PrettyRef return #id for pull ref or ShortName for others
 func (run *ActionRun) PrettyRef() string {
 	refName := git.RefName(run.Ref)
 	if refName.RefGroup() == "pull" {

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -90,7 +90,7 @@ func (input *notifyInput) WithPayload(payload api.Payloader) *notifyInput {
 func (input *notifyInput) WithPullRequest(pr *issues_model.PullRequest) *notifyInput {
 	input.PullRequest = pr
 	if input.Ref == "" {
-		input.Ref = fmt.Sprintf("pull/%d/head", pr.Index)
+		input.Ref = pr.GetGitRefName()
 	}
 	return input
 }

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -67,7 +67,6 @@ type notifyInput struct {
 func newNotifyInput(repo *repo_model.Repository, doer *user_model.User, event webhook_module.HookEventType) *notifyInput {
 	return &notifyInput{
 		Repo:  repo,
-		Ref:   repo.DefaultBranch,
 		Doer:  doer,
 		Event: event,
 	}
@@ -90,6 +89,9 @@ func (input *notifyInput) WithPayload(payload api.Payloader) *notifyInput {
 
 func (input *notifyInput) WithPullRequest(pr *issues_model.PullRequest) *notifyInput {
 	input.PullRequest = pr
+	if input.Ref == "" {
+		input.Ref = fmt.Sprintf("pull/%d/head", pr.Index)
+	}
 	return input
 }
 
@@ -124,8 +126,13 @@ func notify(ctx context.Context, input *notifyInput) error {
 	}
 	defer gitRepo.Close()
 
+	ref := input.Ref
+	if ref == "" {
+		ref = input.Repo.DefaultBranch
+	}
+
 	// Get the commit object for the ref
-	commit, err := gitRepo.GetCommit(input.Ref)
+	commit, err := gitRepo.GetCommit(ref)
 	if err != nil {
 		return fmt.Errorf("gitRepo.GetCommit: %w", err)
 	}
@@ -152,7 +159,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 			OwnerID:           input.Repo.OwnerID,
 			WorkflowID:        id,
 			TriggerUserID:     input.Doer.ID,
-			Ref:               input.Ref,
+			Ref:               ref,
 			CommitSHA:         commit.ID.String(),
 			IsForkPullRequest: input.PullRequest != nil && input.PullRequest.IsFromFork(),
 			Event:             input.Event,

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -7,8 +7,15 @@
 			<div class="issue-item-main f1 fc df">
 				<div class="issue-item-top-row">
 					<a class="index ml-0 mr-2" href="{{if .HTMLURL}}{{.HTMLURL}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
-						{{.Title}} <span class="ui label">{{RefShortName .Ref}}</span>
+						{{.Title}}
 					</a>
+					<span class="ui label">
+						{{if .RefLink}}
+							<a href="{{.RefLink}}">{{.PrettyRef}}</a>
+						{{else}}
+							{{.PrettyRef}}
+						{{end}}
+					</span>
 				</div>
 				<div class="desc issue-item-bottom-row df ac fw my-1">
 					<b>{{if not $.CurWorkflow}}{{.WorkflowID}} {{end}}#{{.Index}}</b>: {{$.locale.Tr "actions.runs.commit"}}


### PR DESCRIPTION
If triggered by PR, the ref should be `pull/<index>/head` instead of `repo.DefaultBranch`.

And improve UI:

<img width="493" alt="image" src="https://user-images.githubusercontent.com/9418365/215731280-312564f2-2450-45d0-b986-1accb0670976.png">


Related to #21937.