### PR TITLE
Disable test for incoming email

### DIFF
--- a/tests/mysql.ini.tmpl
+++ b/tests/mysql.ini.tmpl
@@ -126,7 +126,7 @@ INTERNAL_TOKEN = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0OTU1NTE2MTh9.h
 ENABLED = true
 
 [email.incoming]
-ENABLED = true
+ENABLED = false
 HOST = smtpimap
 PORT = 993
 USERNAME = debug@localdomain.test


### PR DESCRIPTION
Disable this test for the moment because the used imap container image seems unstable which results in many failed CI builds.