### PR TITLE
Fix line spacing for plaintext previews (#22699)

### DIFF
--- a/modules/charset/escape.go
+++ b/modules/charset/escape.go
@@ -45,7 +45,7 @@ func EscapeControlReader(reader io.Reader, writer io.Writer, locale translation.
 	return streamer.escaped, err
 }
 
-// EscapeControlStringReader escapes the unicode control sequences in a provided reader of string content and writer in a locale and returns the findings as an EscapeStatus and the escaped []byte
+// EscapeControlStringReader escapes the unicode control sequences in a provided reader of string content and writer in a locale and returns the findings as an EscapeStatus and the escaped []byte. HTML line breaks are not inserted after every newline by this method.
 func EscapeControlStringReader(reader io.Reader, writer io.Writer, locale translation.Locale, allowed ...rune) (escaped *EscapeStatus, err error) {
 	bufRd := bufio.NewReader(reader)
 	outputStream := &HTMLStreamerWriter{Writer: writer}

--- a/modules/charset/escape.go
+++ b/modules/charset/escape.go
@@ -66,10 +66,6 @@ func EscapeControlStringReader(reader io.Reader, writer io.Writer, locale transl
 			}
 			break
 		}
-		if err := streamer.SelfClosingTag("br"); err != nil {
-			streamer.escaped.HasError = true
-			return streamer.escaped, err
-		}
 	}
 	return streamer.escaped, err
 }


### PR DESCRIPTION
Backport #22699

Adding `<br>` between each line is not necessary since the entire file is rendered inside a `<pre>`

fixes https://codeberg.org/Codeberg/Community/issues/915