### PR TITLE
Add missing close bracket in imagediff (#22710)

### DIFF
--- a/web_src/js/features/imagediff.js
+++ b/web_src/js/features/imagediff.js
@@ -263,7 +263,7 @@ export default function initImageDiff() {
         height: sizes.max.height * factor + 4
       });
 
-      const $range = $container.find("input[type='range'");
+      const $range = $container.find("input[type='range']");
       const onInput = () => sizes.image1.parent().css({
         opacity: $range.val() / 100
       });


### PR DESCRIPTION
Backport #22710

There was a missing `]` in imagediff.js:

```
const $range = $container.find("input[type='range'"); 
```

This PR simply adds this.

Fix #22702 
