### PR TITLE
Improve error report when user passes a private key

### DIFF
--- a/models/asymkey/error.go
+++ b/models/asymkey/error.go
@@ -24,6 +24,9 @@ func (err ErrKeyUnableVerify) Error() string {
 	return fmt.Sprintf("Unable to verify key content [result: %s]", err.Result)
 }
 
+// ErrKeyIsPrivate is returned when the provided key is a private key not a public key
+var ErrKeyIsPrivate = util.NewSilentWrapErrorf(util.ErrInvalidArgument, "the provided key is a private key")
+
 // ErrKeyNotExist represents a "KeyNotExist" kind of error.
 type ErrKeyNotExist struct {
 	ID int64

--- a/models/asymkey/ssh_key_parse.go
+++ b/models/asymkey/ssh_key_parse.go
@@ -96,6 +96,9 @@ func parseKeyString(content string) (string, error) {
 			if block == nil {
 				return "", fmt.Errorf("failed to parse PEM block containing the public key")
 			}
+			if strings.Contains(block.Type, "PRIVATE") {
+				return "", ErrKeyIsPrivate
+			}
 
 			pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 			if err != nil {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -518,6 +518,7 @@ organization_leave_success = You have successfully left the organization %s.
 invalid_ssh_key = Cannot verify your SSH key: %s
 invalid_gpg_key = Cannot verify your GPG key: %s
 invalid_ssh_principal = Invalid principal: %s
+must_use_public_key = The provided key is a private key you must use a public key.
 unable_verify_ssh_key = "Cannot verify the SSH key; double-check it for mistakes."
 auth_failed = Authentication failed: %v
 

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -518,7 +518,7 @@ organization_leave_success = You have successfully left the organization %s.
 invalid_ssh_key = Cannot verify your SSH key: %s
 invalid_gpg_key = Cannot verify your GPG key: %s
 invalid_ssh_principal = Invalid principal: %s
-must_use_public_key = The provided key is a private key you must use a public key.
+must_use_public_key = The key you provided is a private key. Please do not upload your private key anywhere. Use your public key instead.
 unable_verify_ssh_key = "Cannot verify the SSH key; double-check it for mistakes."
 auth_failed = Authentication failed: %v
 

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -1158,6 +1158,10 @@ func DeployKeysPost(ctx *context.Context) {
 			ctx.Flash.Info(ctx.Tr("settings.ssh_disabled"))
 		} else if asymkey_model.IsErrKeyUnableVerify(err) {
 			ctx.Flash.Info(ctx.Tr("form.unable_verify_ssh_key"))
+		} else if err == asymkey_model.ErrKeyIsPrivate {
+			ctx.Data["HasError"] = true
+			ctx.Data["Err_Content"] = true
+			ctx.Flash.Error(ctx.Tr("form.must_use_public_key"))
 		} else {
 			ctx.Data["HasError"] = true
 			ctx.Data["Err_Content"] = true

--- a/routers/web/user/setting/keys.go
+++ b/routers/web/user/setting/keys.go
@@ -159,6 +159,8 @@ func KeysPost(ctx *context.Context) {
 				ctx.Flash.Info(ctx.Tr("settings.ssh_disabled"))
 			} else if asymkey_model.IsErrKeyUnableVerify(err) {
 				ctx.Flash.Info(ctx.Tr("form.unable_verify_ssh_key"))
+			} else if err == asymkey_model.ErrKeyIsPrivate {
+				ctx.Flash.Error(ctx.Tr("form.must_use_public_key"))
 			} else {
 				ctx.Flash.Error(ctx.Tr("form.invalid_ssh_key", err.Error()))
 			}


### PR DESCRIPTION
The error reported when a user passes a private ssh key as their ssh public key is not very nice.

This PR improves this slightly.

Ref #22693

Signed-off-by: Andrew Thornton <art27@cantab.net>
