### PR TITLE
Add .livemd as a markdown extension

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -992,7 +992,7 @@ ROUTER = console
 ;;
 ;; List of file extensions for which lines should be wrapped in the Monaco editor
 ;; Separate extensions with a comma. To line wrap files without an extension, just put a comma
-;LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,
+;LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,.livemd,
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1334,7 +1334,7 @@ ROUTER = console
 ;;
 ;; List of file extensions that should be rendered/edited as Markdown
 ;; Separate the extensions with a comma. To render files without any extension as markdown, just put a comma
-;FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
+;FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd,.livemd
 ;;
 ;; Enables math inline and block detection
 ;ENABLE_MATH = true

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -117,7 +117,7 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
 
 ### Repository - Editor (`repository.editor`)
 
-- `LINE_WRAP_EXTENSIONS`: **.txt,.md,.markdown,.mdown,.mkd,**: List of file extensions for which lines should be wrapped in the Monaco editor. Separate extensions with a comma. To line wrap files without an extension, just put a comma
+- `LINE_WRAP_EXTENSIONS`: **.txt,.md,.markdown,.mdown,.mkd,.livemd,**: List of file extensions for which lines should be wrapped in the Monaco editor. Separate extensions with a comma. To line wrap files without an extension, just put a comma
 - `PREVIEWABLE_FILE_MODES`: **markdown**: Valid file modes that have a preview API associated with them, such as `api/v1/markdown`. Separate the values by commas. The preview tab in edit mode won't be displayed if the file extension doesn't match.
 
 ### Repository - Pull Request (`repository.pull-request`)
@@ -277,6 +277,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed
+- `FILE_EXTENSIONS`: **.md,.markdown,.mdown,.mkd,.livemd**: List of file extensions that should be rendered/edited as Markdown. Separate the extensions with a comma. To render files without any extension as markdown, just put a comma.
 - `ENABLE_MATH`: **true**: Enables detection of `\(...\)`, `\[...\]`, `$...$` and `$$...$$` blocks as math blocks.
 
 ## Server (`server`)

--- a/modules/setting/markup.go
+++ b/modules/setting/markup.go
@@ -33,7 +33,7 @@ var Markdown = struct {
 }{
 	EnableHardLineBreakInComments:  true,
 	EnableHardLineBreakInDocuments: false,
-	FileExtensions:                 strings.Split(".md,.markdown,.mdown,.mkd,.livemd,", ","),
+	FileExtensions:                 strings.Split(".md,.markdown,.mdown,.mkd,.livemd", ","),
 	EnableMath:                     true,
 }
 

--- a/modules/setting/markup.go
+++ b/modules/setting/markup.go
@@ -33,7 +33,7 @@ var Markdown = struct {
 }{
 	EnableHardLineBreakInComments:  true,
 	EnableHardLineBreakInDocuments: false,
-	FileExtensions:                 strings.Split(".md,.markdown,.mdown,.mkd", ","),
+	FileExtensions:                 strings.Split(".md,.markdown,.mdown,.mkd,.livemd,", ","),
 	EnableMath:                     true,
 }
 

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -168,7 +168,7 @@ var (
 		Editor: struct {
 			LineWrapExtensions []string
 		}{
-			LineWrapExtensions: strings.Split(".txt,.md,.markdown,.mdown,.mkd,", ","),
+			LineWrapExtensions: strings.Split(".txt,.md,.markdown,.mdown,.mkd,.livemd,", ","),
 		},
 
 		// Repository upload settings


### PR DESCRIPTION
## Needs and benefits
[Livebook](https://livebook.dev/) notebooks are used for code documentation and for deep dives and note-taking in the elixir ecosystem. Rendering these in these as Markdown on frogejo has many benefits, since livemd is a subset of markdown. Some of the benefits are:
- New users of elixir and livebook are scared by unformated .livemd files, but are shown what they expect
- Sharing a notebook is as easy as sharing a link, no need to install the software in order to see the results.

[goldmark-meraid ](https://github.com/abhinav/goldmark-mermaid) is a mermaid-js parser already included in gitea. This makes the .livemd rendering integration feature complete. With this PR class diagrams, ER Diagrams, flow charts and much more will be rendered perfectly.

With the additional functionality gitea will be an ideal tool for sharing resources with fellow software engineers working in the elixir ecosystem. Allowing the git forge to be used without needing to install any software.

## Feature Description
This issue requests the .livemd extension to be added as a Markdown language extension.

- `.livemd` is the extension of Livebook which is an Elixir version of Jupyter Notebook.
- `.livemd` is` a subset of Markdown.

This would require the .livemd to be recognized as a markdown file. The Goldmark the markdown parser should handle the parsing and rendering automatically.

Here is the corresponding commit for GitHub linguist:
https://github.com/github/linguist/pull/5672

Here is a sample page of a livemd file:
https://github.com/github/linguist/blob/master/samples/Markdown/livebook.livemd

## Screenshots

The first screenshot shows how github shows the sample .livemd in the browser.
The second screenshot shows how mermaid js, renders my development notebook and its corresponding ER Diagram. The source code can be found here: https://codeberg.org/lgh/Termi/src/commit/79615f74281789a1f2967b57bad0c67c356cef1f/termiNotes.livemd

## Testing
I just changed the file extension from `.livemd`to `.md`and the document already renders perfectly on codeberg. Check you can it out [here](https://codeberg.org/lgh/Termi/src/branch/livemd2md/termiNotes.md)


