### PR TITLE
Use native error checking with `exec.ErrDot`

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -6,6 +6,7 @@ package setting
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -466,8 +467,7 @@ func getAppPath() (string, error) {
 	}
 
 	if err != nil {
-		// FIXME: Once we switch to go 1.19 use !errors.Is(err, exec.ErrDot)
-		if !strings.Contains(err.Error(), "cannot run executable found relative to current directory") {
+		if !errors.Is(err, exec.ErrDot) {
 			return "", err
 		}
 		appPath, err = filepath.Abs(os.Args[0])


### PR DESCRIPTION
This was meant to land in #22073 but was blocked until #22732 was merged