### PR TITLE
use drone secrets for s3 config (#22770)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -769,10 +769,16 @@ steps:
     image: woodpeckerci/plugin-s3:latest
     pull: always
     settings:
-      acl: public-read
-      bucket: gitea-artifacts
-      endpoint: https://ams3.digitaloceanspaces.com
-      path_style: true
+      acl:
+        from_secret: aws_s3_acl
+      region:
+        from_secret: aws_s3_region
+      bucket:
+        from_secret: aws_s3_bucket
+      endpoint:
+        from_secret: aws_s3_endpoint
+      path_style:
+        from_secret: aws_s3_path_style
       source: "dist/release/*"
       strip_prefix: dist/release/
       target: "/gitea/${DRONE_BRANCH##release/v}"
@@ -790,10 +796,16 @@ steps:
   - name: release-main
     image: woodpeckerci/plugin-s3:latest
     settings:
-      acl: public-read
-      bucket: gitea-artifacts
-      endpoint: https://ams3.digitaloceanspaces.com
-      path_style: true
+      acl:
+        from_secret: aws_s3_acl
+      region:
+        from_secret: aws_s3_region
+      bucket:
+        from_secret: aws_s3_bucket
+      endpoint:
+        from_secret: aws_s3_endpoint
+      path_style:
+        from_secret: aws_s3_path_style
       source: "dist/release/*"
       strip_prefix: dist/release/
       target: /gitea/main
@@ -892,10 +904,16 @@ steps:
     image: woodpeckerci/plugin-s3:latest
     pull: always
     settings:
-      acl: public-read
-      bucket: gitea-artifacts
-      endpoint: https://ams3.digitaloceanspaces.com
-      path_style: true
+      acl:
+        from_secret: aws_s3_acl
+      region:
+        from_secret: aws_s3_region
+      bucket:
+        from_secret: aws_s3_bucket
+      endpoint:
+        from_secret: aws_s3_endpoint
+      path_style:
+        from_secret: aws_s3_path_style
       source: "dist/release/*"
       strip_prefix: dist/release/
       target: "/gitea/${DRONE_TAG##v}"


### PR DESCRIPTION
Backport #22770

to allow for updating without having to git commit updates to drone yaml