### PR TITLE
Enable clone URL override

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -325,6 +325,11 @@ LFS_JWT_SECRET =
 ;;
 ;; Static resources, includes resources on custom/, public/ and all uploaded avatars web browser cache time. Note that this cache is disabled when RUN_MODE is "dev". Default is 6h
 ;STATIC_CACHE_TIME = 6h
+;;
+;; Allows the user to override the appearance of the clone URL to the user. It has no effect beyond that. Must be fully-formed (i.e. including schema and port etc).
+;; If defined, will supersede all other settings that might otherwise influence the display of clone URLs in that context (e.g. USE_COMPAT_SSH_URI, SSH_USER etc).
+;CLONE_URL_OVERRIDE_SSH =
+;CLONE_URL_OVERRIDE_HTTP =
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -415,6 +415,8 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `ALLOW_GRACEFUL_RESTARTS`: **true**: Perform a graceful restart on SIGHUP
 - `GRACEFUL_HAMMER_TIME`: **60s**: After a restart the parent process will stop accepting new connections and will allow requests to finish before stopping. Shutdown will be forced if it takes longer than this time.
 - `STARTUP_TIMEOUT`: **0**: Shutsdown the server if startup takes longer than the provided time. On Windows setting this sends a waithint to the SVC host to tell the SVC host startup may take some time. Please note startup is determined by the opening of the listeners - HTTP/HTTPS/SSH. Indexers may take longer to startup and can have their own timeouts.
+- `CLONE_URL_OVERRIDE_HTTP`: **\<empty\>**: Display this string as-is for the portion of the HTTP clone URL ahead of `/[user]/[repo].git`. Will supersede all other settings that might otherwise influence the display of the HTTP clone URL. E.g. a value of 'https://example.org' here would result in an HTTP clone URL of 'https://example.org/[user]/[repo].git'
+- `CLONE_URL_OVERRIDE_SSH`: **\<empty\>**: Display this string as-is for the portion of the SSH clone URL ahead of `/[user]/[repo].git`. Will supersede all other settings that might otherwise influence the display of the SSH clone URL. E.g. a value of 'ssh://git@example.org' here would result in an SSH clone URL of 'ssh://git@example.org/[user]/[repo].git'
 
 ## Database (`database`)
 

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -537,7 +537,13 @@ type CloneLink struct {
 
 // ComposeHTTPSCloneURL returns HTTPS clone URL based on given owner and repository name.
 func ComposeHTTPSCloneURL(owner, repo string) string {
-	return fmt.Sprintf("%s%s/%s.git", setting.AppURL, url.PathEscape(owner), url.PathEscape(repo))
+	cloneURL := setting.AppURL
+
+	if setting.CloneURLOverrideHTTP != "" {
+		cloneURL = setting.CloneURLOverrideHTTP + "/"
+	}
+
+	return fmt.Sprintf("%s%s/%s.git", cloneURL, url.PathEscape(owner), url.PathEscape(repo))
 }
 
 func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
@@ -558,7 +564,9 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 		sshDomain = "[" + setting.SSH.Domain + "]"
 	}
 
-	if setting.SSH.Port != 22 {
+	if setting.CloneURLOverrideSSH != "" {
+		cl.SSH = fmt.Sprintf("%s/%s/%s.git", setting.CloneURLOverrideSSH, url.PathEscape(repo.OwnerName), url.PathEscape(repoName))
+	} else if setting.SSH.Port != 22 {
 		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", sshUser, net.JoinHostPort(setting.SSH.Domain, strconv.Itoa(setting.SSH.Port)), url.PathEscape(repo.OwnerName), url.PathEscape(repoName))
 	} else if setting.Repository.UseCompatSSHURI {
 		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", sshUser, sshDomain, url.PathEscape(repo.OwnerName), url.PathEscape(repoName))

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -138,6 +138,8 @@ var (
 	PerWritePerKbTimeout       = 10 * time.Second
 	StaticURLPrefix            string
 	AbsoluteAssetURL           string
+	CloneURLOverrideHTTP       string
+	CloneURLOverrideSSH        string
 
 	SSH = struct {
 		Disabled                              bool               `ini:"DISABLE_SSH"`
@@ -822,6 +824,8 @@ func loadFromConf(allowEmpty bool, extraConfig string) {
 		log.Info("The provided APP_DATA_PATH: %s is not absolute - it will be made absolute against the work path: %s", AppDataPath, AppWorkPath)
 		AppDataPath = filepath.ToSlash(filepath.Join(AppWorkPath, AppDataPath))
 	}
+	CloneURLOverrideHTTP = strings.TrimSuffix(sec.Key("CLONE_URL_OVERRIDE_HTTP").MustString(""), "/")
+	CloneURLOverrideSSH = strings.TrimSuffix(sec.Key("CLONE_URL_OVERRIDE_SSH").MustString(""), "/")
 
 	EnableGzip = sec.Key("ENABLE_GZIP").MustBool()
 	EnablePprof = sec.Key("ENABLE_PPROF").MustBool(false)


### PR DESCRIPTION
Add two settings that allow the admin to override what's displayed as the clone URLs for SSH and HTTP for those with any particularly strange proxy/OAuth/zero trust setups.


![image](https://user-images.githubusercontent.com/4531887/217128018-db2d71a6-b8a7-437d-8477-79d623dcb1b6.png)
