### PR TITLE
Fix update by rebase being wrongly disabled by protected base branch

### DIFF
--- a/services/pull/update.go
+++ b/services/pull/update.go
@@ -106,7 +106,7 @@ func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, 
 		BaseBranch: pull.HeadBranch,
 	}
 
-	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pull.BaseRepoID, pull.BaseBranch)
+	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pull.HeadRepoID, pull.HeadBranch)
 	if err != nil {
 		return false, false, err
 	}

--- a/services/pull/update.go
+++ b/services/pull/update.go
@@ -106,7 +106,7 @@ func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, 
 		BaseBranch: pull.HeadBranch,
 	}
 
-	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pull.HeadRepoID, pull.HeadBranch)
+	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pr.BaseRepoID, pr.BaseBranch)
 	if err != nil {
 		return false, false, err
 	}


### PR DESCRIPTION
The branch this is force pushing to is the head branch in the head repo, so it should be checking if that is protected, not the base.