### PR TITLE
Fix blame view missing lines

### DIFF
--- a/modules/git/blame_test.go
+++ b/modules/git/blame_test.go
@@ -28,7 +28,7 @@ func TestReadingBlameOutput(t *testing.T) {
 		},
 		{
 			"f32b0a9dfd09a60f616f29158f772cedd89942d2",
-			[]string{},
+			[]string{"", "Do not make any changes to this repo it is used for unit testing"},
 		},
 	}
 


### PR DESCRIPTION
Creating a new buffered reader for every part of the blame can miss lines, as it will read and buffer bytes that the next buffered reader will not get.