### PR TITLE
Fix more HTMLURL in templates

### DIFF
--- a/models/issues/issue_xref.go
+++ b/models/issues/issue_xref.go
@@ -277,26 +277,26 @@ func CommentTypeIsRef(t CommentType) bool {
 	return t == CommentTypeCommentRef || t == CommentTypePullRef || t == CommentTypeIssueRef
 }
 
-// RefCommentHTMLURL returns the HTML URL for the comment that created this reference
-func (c *Comment) RefCommentHTMLURL() string {
+// RefCommentLink returns the relative URL for the comment that created this reference
+func (c *Comment) RefCommentLink() string {
 	// Edge case for when the reference is inside the title or the description of the referring issue
 	if c.RefCommentID == 0 {
-		return c.RefIssueHTMLURL()
+		return c.RefIssueLink()
 	}
 	if err := c.LoadRefComment(); err != nil { // Silently dropping errors :unamused:
 		log.Error("LoadRefComment(%d): %v", c.RefCommentID, err)
 		return ""
 	}
-	return c.RefComment.HTMLURL()
+	return c.RefComment.Link()
 }
 
-// RefIssueHTMLURL returns the HTML URL of the issue where this reference was created
-func (c *Comment) RefIssueHTMLURL() string {
+// RefIssueLink returns the relative URL of the issue where this reference was created
+func (c *Comment) RefIssueLink() string {
 	if err := c.LoadRefIssue(); err != nil { // Silently dropping errors :unamused:
 		log.Error("LoadRefIssue(%d): %v", c.RefCommentID, err)
 		return ""
 	}
-	return c.RefIssue.HTMLURL()
+	return c.RefIssue.Link()
 }
 
 // RefIssueTitle returns the title of the issue where this reference was created

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -72,6 +72,10 @@ func NewFuncMap() []template.FuncMap {
 			return setting.StaticURLPrefix + "/assets"
 		},
 		"AppUrl": func() string {
+			// The usage of AppUrl should be avoided as much as possible,
+			// because the AppURL(ROOT_URL) may not match user's visiting site and the ROOT_URL in app.ini may be incorrect.
+			// And it's difficult for Gitea to guess absolute URL correctly with zero configuration,
+			// because Gitea doesn't know whether the scheme is HTTP or HTTPS unless the reverse proxy could tell Gitea.
 			return setting.AppURL
 		},
 		"AppVer": func() string {

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -238,7 +238,7 @@
 							{{end}}
 							<div class="right floated">
 								{{range .Assignees}}
-									<a class="tooltip" target="_blank" href="{{.HTMLURL}}" data-content="{{$.locale.Tr "repo.projects.board.assigned_to"}} {{.Name}}">{{avatar . 28 "mini mr-3"}}</a>
+									<a class="tooltip" target="_blank" href="{{.HomeLink}}" data-content="{{$.locale.Tr "repo.projects.board.assigned_to"}} {{.Name}}">{{avatar . 28 "mini mr-3"}}</a>
 								{{end}}
 							</div>
 						</div>

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -6,7 +6,7 @@
 			</div>
 			<div class="issue-item-main f1 fc df">
 				<div class="issue-item-top-row">
-					<a class="index ml-0 mr-2" href="{{if .HTMLURL}}{{.HTMLURL}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
+					<a class="index ml-0 mr-2" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
 						{{.Title}}
 					</a>
 					<span class="ui label">

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -151,12 +151,12 @@
 				{{if eq .RefAction 3}}<del>{{end}}
 				<span class="text grey muted-links">
 					{{template "shared/user/authorlink" .Poster}}
-					{{$.locale.Tr $refTr (.EventTag|Escape) $createdStr (.RefCommentHTMLURL|Escape) $refFrom | Safe}}
+					{{$.locale.Tr $refTr (.EventTag|Escape) $createdStr (.RefCommentLink|Escape) $refFrom | Safe}}
 				</span>
 				{{if eq .RefAction 3}}</del>{{end}}
 
 				<div class="detail">
-					<span class="text grey muted-links"><a href="{{.RefIssueHTMLURL}}"><b>{{.RefIssueTitle}}</b> {{.RefIssueIdent}}</a></span>
+					<span class="text grey muted-links"><a href="{{.RefIssueLink}}"><b>{{.RefIssueTitle}}</b> {{.RefIssueIdent}}</a></span>
 				</div>
 			</div>
 		{{else if eq .Type 4}}

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -303,79 +303,78 @@
 							{{$hasPendingPullRequestMergeTip = $.locale.Tr "repo.pulls.auto_merge_has_pending_schedule" .PendingPullRequestMerge.Doer.Name $createdPRMergeStr}}
 						{{end}}
 						<div class="ui divider"></div>
-						<script>
-							(() => {
-								const defaultMergeTitle = {{.DefaultMergeMessage}};
-								const defaultSquashMergeTitle = {{.DefaultSquashMergeMessage}};
-								const defaultMergeMessage = {{if .DefaultMergeBody}}{{.DefaultMergeBody}}{{else}}'Reviewed-on: ' + {{$.Issue.HTMLURL}} + '\n' + {{$approvers}}{{end}};
-								const defaultSquashMergeMessage = {{if .DefaultSquashMergeBody}}{{.DefaultSquashMergeBody}}{{else}}'Reviewed-on: ' + {{$.Issue.HTMLURL}} + '\n' + {{$approvers}}{{end}};
-								const mergeForm = {
-									'baseLink': {{.Link}},
-									'textCancel': {{$.locale.Tr "cancel"}},
-									'textDeleteBranch': {{$.locale.Tr "repo.branch.delete" .HeadTarget}},
-									'textAutoMergeButtonWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
-									'textAutoMergeWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_when_succeed"}},
-									'textAutoMergeCancelSchedule': {{$.locale.Tr "repo.pulls.auto_merge_cancel_schedule"}},
-									'textClearMergeMessage': {{$.locale.Tr "repo.pulls.clear_merge_message"}},
-									'textClearMergeMessageHint': {{$.locale.Tr "repo.pulls.clear_merge_message_hint"}},
+						<script type="module">
+							const issueUrl = `${window.location.origin}${window.config.appSubUrl}` + {{$.Issue.Link}};
+							const defaultMergeTitle = {{.DefaultMergeMessage}};
+							const defaultSquashMergeTitle = {{.DefaultSquashMergeMessage}};
+							const defaultMergeMessage = {{if .DefaultMergeBody}}{{.DefaultMergeBody}}{{else}}`Reviewed-on: ${issueUrl}\n` + {{$approvers}}{{end}};
+							const defaultSquashMergeMessage = {{if .DefaultSquashMergeBody}}{{.DefaultSquashMergeBody}}{{else}}`Reviewed-on: ${issueUrl}\n` + {{$approvers}}{{end}};
+							const mergeForm = {
+								'baseLink': {{.Link}},
+								'textCancel': {{$.locale.Tr "cancel"}},
+								'textDeleteBranch': {{$.locale.Tr "repo.branch.delete" .HeadTarget}},
+								'textAutoMergeButtonWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
+								'textAutoMergeWhenSucceed': {{$.locale.Tr "repo.pulls.auto_merge_when_succeed"}},
+								'textAutoMergeCancelSchedule': {{$.locale.Tr "repo.pulls.auto_merge_cancel_schedule"}},
+								'textClearMergeMessage': {{$.locale.Tr "repo.pulls.clear_merge_message"}},
+								'textClearMergeMessageHint': {{$.locale.Tr "repo.pulls.clear_merge_message_hint"}},
 
-									'canMergeNow': {{$canMergeNow}},
-									'allOverridableChecksOk': {{not $notAllOverridableChecksOk}},
-									'emptyCommit': {{.Issue.PullRequest.IsEmpty}},
-									'pullHeadCommitID': {{.PullHeadCommitID}},
-									'isPullBranchDeletable': {{.IsPullBranchDeletable}},
-									'defaultMergeStyle': {{.MergeStyle}},
-									'defaultDeleteBranchAfterMerge': {{$prUnit.PullRequestsConfig.DefaultDeleteBranchAfterMerge}},
-									'mergeMessageFieldPlaceHolder': {{$.locale.Tr "repo.editor.commit_message_desc"}},
-									'defaultMergeMessage': defaultMergeMessage,
+								'canMergeNow': {{$canMergeNow}},
+								'allOverridableChecksOk': {{not $notAllOverridableChecksOk}},
+								'emptyCommit': {{.Issue.PullRequest.IsEmpty}},
+								'pullHeadCommitID': {{.PullHeadCommitID}},
+								'isPullBranchDeletable': {{.IsPullBranchDeletable}},
+								'defaultMergeStyle': {{.MergeStyle}},
+								'defaultDeleteBranchAfterMerge': {{$prUnit.PullRequestsConfig.DefaultDeleteBranchAfterMerge}},
+								'mergeMessageFieldPlaceHolder': {{$.locale.Tr "repo.editor.commit_message_desc"}},
+								'defaultMergeMessage': defaultMergeMessage,
 
-									'hasPendingPullRequestMerge': {{.HasPendingPullRequestMerge}},
-									'hasPendingPullRequestMergeTip': {{$hasPendingPullRequestMergeTip}},
-								};
+								'hasPendingPullRequestMerge': {{.HasPendingPullRequestMerge}},
+								'hasPendingPullRequestMergeTip': {{$hasPendingPullRequestMergeTip}},
+							};
 
-								const generalHideAutoMerge = mergeForm.canMergeNow && mergeForm.allOverridableChecksOk; // if this PR can be merged now, then hide the auto merge
-								mergeForm['mergeStyles'] = [
-									{
-										'name': 'merge',
-										'allowed': {{$prUnit.PullRequestsConfig.AllowMerge}},
-										'textDoMerge': {{$.locale.Tr "repo.pulls.merge_pull_request"}},
-										'mergeTitleFieldText': defaultMergeTitle,
-										'mergeMessageFieldText': defaultMergeMessage,
-										'hideAutoMerge': generalHideAutoMerge,
-									},
-									{
-										'name': 'rebase',
-										'allowed': {{$prUnit.PullRequestsConfig.AllowRebase}},
-										'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_pull_request"}},
-										'hideMergeMessageTexts': true,
-										'hideAutoMerge': generalHideAutoMerge,
-									},
-									{
-										'name': 'rebase-merge',
-										'allowed': {{$prUnit.PullRequestsConfig.AllowRebaseMerge}},
-										'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}},
-										'mergeTitleFieldText': defaultMergeTitle,
-										'mergeMessageFieldText': defaultMergeMessage,
-										'hideAutoMerge': generalHideAutoMerge,
-									},
-									{
-										'name': 'squash',
-										'allowed': {{$prUnit.PullRequestsConfig.AllowSquash}},
-										'textDoMerge': {{$.locale.Tr "repo.pulls.squash_merge_pull_request"}},
-										'mergeTitleFieldText': defaultSquashMergeTitle,
-										'mergeMessageFieldText': {{.GetCommitMessages}} + defaultSquashMergeMessage,
-										'hideAutoMerge': generalHideAutoMerge,
-									},
-									{
-										'name': 'manually-merged',
-										'allowed': {{and $prUnit.PullRequestsConfig.AllowManualMerge $.IsRepoAdmin}},
-										'textDoMerge': {{$.locale.Tr "repo.pulls.merge_manually"}},
-										'hideMergeMessageTexts': true,
-										'hideAutoMerge': true,
-									}
-								];
-								window.config.pageData.pullRequestMergeForm = mergeForm;
-							})();
+							const generalHideAutoMerge = mergeForm.canMergeNow && mergeForm.allOverridableChecksOk; // if this PR can be merged now, then hide the auto merge
+							mergeForm['mergeStyles'] = [
+								{
+									'name': 'merge',
+									'allowed': {{$prUnit.PullRequestsConfig.AllowMerge}},
+									'textDoMerge': {{$.locale.Tr "repo.pulls.merge_pull_request"}},
+									'mergeTitleFieldText': defaultMergeTitle,
+									'mergeMessageFieldText': defaultMergeMessage,
+									'hideAutoMerge': generalHideAutoMerge,
+								},
+								{
+									'name': 'rebase',
+									'allowed': {{$prUnit.PullRequestsConfig.AllowRebase}},
+									'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_pull_request"}},
+									'hideMergeMessageTexts': true,
+									'hideAutoMerge': generalHideAutoMerge,
+								},
+								{
+									'name': 'rebase-merge',
+									'allowed': {{$prUnit.PullRequestsConfig.AllowRebaseMerge}},
+									'textDoMerge': {{$.locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}},
+									'mergeTitleFieldText': defaultMergeTitle,
+									'mergeMessageFieldText': defaultMergeMessage,
+									'hideAutoMerge': generalHideAutoMerge,
+								},
+								{
+									'name': 'squash',
+									'allowed': {{$prUnit.PullRequestsConfig.AllowSquash}},
+									'textDoMerge': {{$.locale.Tr "repo.pulls.squash_merge_pull_request"}},
+									'mergeTitleFieldText': defaultSquashMergeTitle,
+									'mergeMessageFieldText': {{.GetCommitMessages}} + defaultSquashMergeMessage,
+									'hideAutoMerge': generalHideAutoMerge,
+								},
+								{
+									'name': 'manually-merged',
+									'allowed': {{and $prUnit.PullRequestsConfig.AllowManualMerge $.IsRepoAdmin}},
+									'textDoMerge': {{$.locale.Tr "repo.pulls.merge_manually"}},
+									'hideMergeMessageTexts': true,
+									'hideAutoMerge': true,
+								}
+							];
+							window.config.pageData.pullRequestMergeForm = mergeForm;
 						</script>
 
 						<div id="pull-request-merge-form"></div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -304,7 +304,7 @@
 						{{end}}
 						<div class="ui divider"></div>
 						<script type="module">
-							const issueUrl = `${window.location.origin}${window.config.appSubUrl}` + {{$.Issue.Link}};
+							const issueUrl = window.location.origin + {{$.Issue.Link}};
 							const defaultMergeTitle = {{.DefaultMergeMessage}};
 							const defaultSquashMergeTitle = {{.DefaultSquashMergeMessage}};
 							const defaultMergeMessage = {{if .DefaultMergeBody}}{{.DefaultMergeBody}}{{else}}`Reviewed-on: ${issueUrl}\n` + {{$approvers}}{{end}};

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -5,6 +5,7 @@
 	<div class="ui secondary segment">
 		{{if eq $.Issue.PullRequest.Flow 0}}
 		<div>git checkout -b {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}} {{$.Issue.PullRequest.BaseBranch}}</div>
+		{{/* the only legacy HTMLURL used in template, which doesn't affect users too much and is very diffcult to fix */}}
 		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.HTMLURL}}{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
 		{{else}}
 		<div>git fetch origin {{$.Issue.PullRequest.GetGitRefName}}:{{$.Issue.PullRequest.HeadBranch}}</div>

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -5,7 +5,8 @@
 	<div class="ui secondary segment">
 		{{if eq $.Issue.PullRequest.Flow 0}}
 		<div>git checkout -b {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}} {{$.Issue.PullRequest.BaseBranch}}</div>
-		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{URLJoin AppUrl $.Issue.PullRequest.HeadRepo.Link}}{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
+		{{/* the only legacy HTMLURL used in template, which doesn't affect users too much and is very diffcult to fix, it should be fixed together with other AppUrl usages*/}}
+		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.HTMLURL}}{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
 		{{else}}
 		<div>git fetch origin {{$.Issue.PullRequest.GetGitRefName}}:{{$.Issue.PullRequest.HeadBranch}}</div>
 		{{end}}

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -5,8 +5,7 @@
 	<div class="ui secondary segment">
 		{{if eq $.Issue.PullRequest.Flow 0}}
 		<div>git checkout -b {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}} {{$.Issue.PullRequest.BaseBranch}}</div>
-		{{/* the only legacy HTMLURL used in template, which doesn't affect users too much and is very diffcult to fix */}}
-		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.HTMLURL}}{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
+		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{URLJoin AppUrl $.Issue.PullRequest.HeadRepo.Link}}{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
 		{{else}}
 		<div>git fetch origin {{$.Issue.PullRequest.GetGitRefName}}:{{$.Issue.PullRequest.HeadBranch}}</div>
 		{{end}}


### PR DESCRIPTION
I haven't tested `runs_list.tmpl` but I think it could be right.

After this PR, besides the `<meta .. HTMLURL>` in html head, the only explicit HTMLURL usage is in `pull_merge_instruction.tmpl`, which doesn't affect users too much and it's difficult to fix at the moment. 

There are still many usages of `AppUrl` in the templates (eg: the package help manual), they are similar problems as the HTMLURL in pull_merge_instruction,  and they might be fixed together in the future.

Diff without space: https://github.com/go-gitea/gitea/pull/22831/files?diff=unified&w=1