### PR TITLE
record previous create org operation info when return to error page

### DIFF
--- a/routers/web/org/org.go
+++ b/routers/web/org/org.go
@@ -28,7 +28,7 @@ const (
 func Create(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("new_org")
 	ctx.Data["DefaultOrgVisibilityMode"] = setting.Service.DefaultOrgVisibilityMode
-	ctx.Data["RepoAdminChangeTeamAccess"] = true
+	ctx.Data["DefaultRepoAdminChangeTeamAccess"] = true
 	if !ctx.Doer.CanCreateOrganization() {
 		ctx.ServerError("Not allowed", errors.New(ctx.Tr("org.form.create_org_not_allowed")))
 		return

--- a/routers/web/org/org.go
+++ b/routers/web/org/org.go
@@ -28,6 +28,7 @@ const (
 func Create(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("new_org")
 	ctx.Data["DefaultOrgVisibilityMode"] = setting.Service.DefaultOrgVisibilityMode
+	ctx.Data["RepoAdminChangeTeamAccess"] = true
 	if !ctx.Doer.CanCreateOrganization() {
 		ctx.ServerError("Not allowed", errors.New(ctx.Tr("org.form.create_org_not_allowed")))
 		return
@@ -60,6 +61,8 @@ func CreatePost(ctx *context.Context) {
 
 	if err := organization.CreateOrganization(org, ctx.Doer); err != nil {
 		ctx.Data["Err_OrgName"] = true
+		ctx.Data["DefaultOrgVisibilityMode"] = form.Visibility
+		ctx.Data["DefaultRepoAdminChangeTeamAccess"] = form.RepoAdminChangeTeamAccess
 		switch {
 		case user_model.IsErrUserAlreadyExist(err):
 			ctx.RenderWithErr(ctx.Tr("form.org_name_been_taken"), tplCreateOrg, &form)

--- a/routers/web/org/org.go
+++ b/routers/web/org/org.go
@@ -28,7 +28,6 @@ const (
 func Create(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("new_org")
 	ctx.Data["DefaultOrgVisibilityMode"] = setting.Service.DefaultOrgVisibilityMode
-	ctx.Data["DefaultRepoAdminChangeTeamAccess"] = true
 	if !ctx.Doer.CanCreateOrganization() {
 		ctx.ServerError("Not allowed", errors.New(ctx.Tr("org.form.create_org_not_allowed")))
 		return
@@ -61,8 +60,6 @@ func CreatePost(ctx *context.Context) {
 
 	if err := organization.CreateOrganization(org, ctx.Doer); err != nil {
 		ctx.Data["Err_OrgName"] = true
-		ctx.Data["DefaultOrgVisibilityMode"] = form.Visibility
-		ctx.Data["DefaultRepoAdminChangeTeamAccess"] = form.RepoAdminChangeTeamAccess
 		switch {
 		case user_model.IsErrUserAlreadyExist(err):
 			ctx.RenderWithErr(ctx.Tr("form.org_name_been_taken"), tplCreateOrg, &form)

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -19,15 +19,15 @@
 						<span class="inline required field"><label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label></span>
 						<div class="inline-grouped-list">
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if or .DefaultOrgVisibilityMode.IsPublic (and .Err_OrgName .__form.Visibility.IsPublic)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if or .DefaultOrgVisibilityMode.IsLimited (and .Err_OrgName .__form.Visibility.IsLimited)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if or .DefaultOrgVisibilityMode.IsPrivate (and .Err_OrgName .__form.Visibility.IsPrivate)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 							</div>
 						</div>
@@ -37,7 +37,7 @@
 						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
-								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if .DefaultRepoAdminChangeTeamAccess}}checked{{end}}/>
+								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if or (not .Err_OrgName) .__form.RepoAdminChangeTeamAccess}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -37,7 +37,7 @@
 						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
-								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" checked/>
+								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if .DefaultRepoAdminChangeTeamAccess}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -37,7 +37,7 @@
 						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
-								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if or (not .Err_OrgName) .repo_admin_change_team_access}}checked{{end}}/>
+								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if not (eq .repo_admin_change_team_access false)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -19,15 +19,15 @@
 						<span class="inline required field"><label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label></span>
 						<div class="inline-grouped-list">
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if or .DefaultOrgVisibilityMode.IsPublic (and .Err_OrgName .visibility.IsPublic)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if or .DefaultOrgVisibilityMode.IsPublic .visibility.IsPublic}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if or .DefaultOrgVisibilityMode.IsLimited (and .Err_OrgName .visibility.IsLimited)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if or .DefaultOrgVisibilityMode.IsLimited .visibility.IsLimited}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if or .DefaultOrgVisibilityMode.IsPrivate (and .Err_OrgName .visibility.IsPrivate)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if or .DefaultOrgVisibilityMode.IsPrivate .visibility.IsPrivate}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 							</div>
 						</div>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -19,15 +19,15 @@
 						<span class="inline required field"><label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label></span>
 						<div class="inline-grouped-list">
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if or .DefaultOrgVisibilityMode.IsPublic (and .Err_OrgName .__form.Visibility.IsPublic)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if or .DefaultOrgVisibilityMode.IsPublic (and .Err_OrgName .visibility.IsPublic)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if or .DefaultOrgVisibilityMode.IsLimited (and .Err_OrgName .__form.Visibility.IsLimited)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if or .DefaultOrgVisibilityMode.IsLimited (and .Err_OrgName .visibility.IsLimited)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if or .DefaultOrgVisibilityMode.IsPrivate (and .Err_OrgName .__form.Visibility.IsPrivate)}}checked{{end}}/>
+								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if or .DefaultOrgVisibilityMode.IsPrivate (and .Err_OrgName .visibility.IsPrivate)}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 							</div>
 						</div>
@@ -37,7 +37,7 @@
 						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
-								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if or (not .Err_OrgName) .__form.RepoAdminChangeTeamAccess}}checked{{end}}/>
+								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if or (not .Err_OrgName) .repo_admin_change_team_access}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>


### PR DESCRIPTION
Fixes: #22833 
Put user's previous operation params into context, for the page can get these params when re-rendering