### PR TITLE
Improve AppUrl/ROOT_URL checking

### DIFF
--- a/web_src/js/features/admin/common.js
+++ b/web_src/js/features/admin/common.js
@@ -1,11 +1,16 @@
 import $ from 'jquery';
+import {checkAppUrl} from '../common-global.js';
 
 const {csrfToken} = window.config;
 
 export function initAdminCommon() {
-  if ($('.admin').length === 0) {
+  if ($('.page-content.admin').length === 0) {
     return;
   }
+
+  // check whether appUrl(ROOT_URL) is correct, if not, show an error message
+  // only admin pages need this check because most templates are using relative URLs now
+  checkAppUrl();
 
   // New user
   if ($('.admin.new.user').length > 0 || $('.admin.edit.user').length > 0) {

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -381,9 +381,6 @@ export function checkAppUrl() {
   if (curUrl.startsWith(appUrl) || `${curUrl}/` === appUrl) {
     return;
   }
-  if (document.querySelector('.page-content.install')) {
-    return; // no need to show the message on the installation page
-  }
-  showGlobalErrorMessage(`Your ROOT_URL in app.ini is ${appUrl} but you are visiting ${curUrl}
-You should set ROOT_URL correctly, otherwise the web may not work correctly.`);
+  showGlobalErrorMessage(`Your ROOT_URL in app.ini is "${appUrl}", it's unlikely matching the site you are visiting.
+Mismatched ROOT_URL config causes wrong URL links for web UI/mail content/webhook notification.`);
 }

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -48,7 +48,6 @@ import {
   initCommitStatuses,
 } from './features/repo-commit.js';
 import {
-  checkAppUrl,
   initFootLanguageMenu,
   initGlobalButtonClickOnEnter,
   initGlobalButtons,
@@ -199,5 +198,4 @@ $(document).ready(() => {
   initUserAuthWebAuthnRegister();
   initUserSettings();
   initViewedCheckboxListenerFor();
-  checkAppUrl();
 });


### PR DESCRIPTION
After some PRs:
* #21986
* #22795
* #22808
* #22831
* #22839

Users won't be affected by the ROOT_URL problem in most cases. Close #19345

This PR improves AppUrl/ROOT_URL checking, only check it on the admin page, and the message is also updated.

Feel free to suggest about more English-native messages.


![image](https://user-images.githubusercontent.com/2114189/217811809-7d44ddb7-2c4a-46d0-a5db-8ae6ee65f8c3.png)
