### PR TITLE
escape filename when assemble URL

### DIFF
--- a/modules/lfs/endpoint.go
+++ b/modules/lfs/endpoint.go
@@ -4,7 +4,6 @@
 package lfs
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // DetermineEndpoint determines an endpoint from the clone url or uses the specified LFS url.
@@ -95,7 +95,7 @@ func endpointFromLocalPath(path string) *url.URL {
 		return nil
 	}
 
-	path = fmt.Sprintf("file://%s%s", slash, filepath.ToSlash(path))
+	path = "file://" + slash + util.PathEscapeSegments(filepath.ToSlash(path))
 
 	u, _ := url.Parse(path)
 

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -159,7 +159,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		return nil, fmt.Errorf("no commit found for the ref [ref: %s]", ref)
 	}
 
-	selfURL, err := url.Parse(fmt.Sprintf("%s/contents/%s?ref=%s", repo.APIURL(), util.PathEscapeSegments(treePath), origRef))
+	selfURL, err := url.Parse(repo.APIURL() + "/contents/" + util.PathEscapeSegments(treePath) + "?ref=" + url.QueryEscape(origRef))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 	}
 	// Handle links
 	if entry.IsRegular() || entry.IsLink() {
-		downloadURL, err := url.Parse(fmt.Sprintf("%s/raw/%s/%s/%s", repo.HTMLURL(), refType, ref, util.PathEscapeSegments(treePath)))
+		downloadURL, err := url.Parse(repo.HTMLURL() + "/raw/" + url.PathEscape(string(refType)) + "/" + util.PathEscapeSegments(ref) + "/" + util.PathEscapeSegments(treePath))
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +226,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		contentsResponse.DownloadURL = &downloadURLString
 	}
 	if !entry.IsSubModule() {
-		htmlURL, err := url.Parse(fmt.Sprintf("%s/src/%s/%s/%s", repo.HTMLURL(), refType, ref, util.PathEscapeSegments(treePath)))
+		htmlURL, err := url.Parse(repo.HTMLURL() + "/src/" + url.PathEscape(string(refType)) + "/" + util.PathEscapeSegments(ref) + "/" + util.PathEscapeSegments(treePath))
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +234,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		contentsResponse.HTMLURL = &htmlURLString
 		contentsResponse.Links.HTMLURL = &htmlURLString
 
-		gitURL, err := url.Parse(fmt.Sprintf("%s/git/blobs/%s", repo.APIURL(), entry.ID.String()))
+		gitURL, err := url.Parse(repo.APIURL() + "/git/blobs/" + url.PathEscape(entry.ID.String()))
 		if err != nil {
 			return nil, err
 		}

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -15,6 +15,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // ContentType repo content type
@@ -158,7 +159,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		return nil, fmt.Errorf("no commit found for the ref [ref: %s]", ref)
 	}
 
-	selfURL, err := url.Parse(fmt.Sprintf("%s/contents/%s?ref=%s", repo.APIURL(), url.PathEscape(treePath), origRef))
+	selfURL, err := url.Parse(fmt.Sprintf("%s/contents/%s?ref=%s", repo.APIURL(), util.PathEscapeSegments(treePath), origRef))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +218,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 	}
 	// Handle links
 	if entry.IsRegular() || entry.IsLink() {
-		downloadURL, err := url.Parse(fmt.Sprintf("%s/raw/%s/%s/%s", repo.HTMLURL(), refType, ref, url.PathEscape(treePath)))
+		downloadURL, err := url.Parse(fmt.Sprintf("%s/raw/%s/%s/%s", repo.HTMLURL(), refType, ref, util.PathEscapeSegments(treePath)))
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +226,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		contentsResponse.DownloadURL = &downloadURLString
 	}
 	if !entry.IsSubModule() {
-		htmlURL, err := url.Parse(fmt.Sprintf("%s/src/%s/%s/%s", repo.HTMLURL(), refType, ref, url.PathEscape(treePath)))
+		htmlURL, err := url.Parse(fmt.Sprintf("%s/src/%s/%s/%s", repo.HTMLURL(), refType, ref, util.PathEscapeSegments(treePath)))
 		if err != nil {
 			return nil, err
 		}

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -158,7 +158,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		return nil, fmt.Errorf("no commit found for the ref [ref: %s]", ref)
 	}
 
-	selfURL, err := url.Parse(fmt.Sprintf("%s/contents/%s?ref=%s", repo.APIURL(), treePath, origRef))
+	selfURL, err := url.Parse(fmt.Sprintf("%s/contents/%s?ref=%s", repo.APIURL(), url.PathEscape(treePath), origRef))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 	}
 	// Handle links
 	if entry.IsRegular() || entry.IsLink() {
-		downloadURL, err := url.Parse(fmt.Sprintf("%s/raw/%s/%s/%s", repo.HTMLURL(), refType, ref, treePath))
+		downloadURL, err := url.Parse(fmt.Sprintf("%s/raw/%s/%s/%s", repo.HTMLURL(), refType, ref, url.PathEscape(treePath)))
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +225,7 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		contentsResponse.DownloadURL = &downloadURLString
 	}
 	if !entry.IsSubModule() {
-		htmlURL, err := url.Parse(fmt.Sprintf("%s/src/%s/%s/%s", repo.HTMLURL(), refType, ref, treePath))
+		htmlURL, err := url.Parse(fmt.Sprintf("%s/src/%s/%s/%s", repo.HTMLURL(), refType, ref, url.PathEscape(treePath)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes: #22843 

### Cause:
https://github.com/go-gitea/gitea/blob/affdd40296960a08a4223330ccbd1fb88c96ea1a/services/repository/files/content.go#L161

Previously,  we did not escape the **"%"** that might be in "treePath" when call "url.parse()". 

![image](https://user-images.githubusercontent.com/33891828/218066318-5a909e50-2a17-46e6-b32f-684b2aa4b91f.png)

This function will check whether "%" is the beginning of an escape character. Obviously, the "%" in the example (hello%mother.txt) is not that. So, the function will return a error.

### Solution:
We can escape "treePath" by call "url.PathEscape()" function firstly.

### Screenshot:
![image](https://user-images.githubusercontent.com/33891828/218069781-1a030f8b-18d0-4804-b0f8-73997849ef43.png)

