### PR TITLE
Remove Fomantic-UI's `.hidden` CSS class for checkbox elements

### DIFF
--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -19,15 +19,15 @@
 						<span class="inline required field"><label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label></span>
 						<div class="inline-grouped-list">
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
+								<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if .DefaultOrgVisibilityMode.IsPublic}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
+								<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if .DefaultOrgVisibilityMode.IsLimited}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 							</div>
 							<div class="ui radio checkbox">
-								<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
+								<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if .DefaultOrgVisibilityMode.IsPrivate}}checked{{end}}/>
 								<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 							</div>
 						</div>
@@ -37,7 +37,7 @@
 						<label>{{.locale.Tr "org.settings.permission"}}</label>
 						<div class="inline-grouped-list">
 							<div class="ui checkbox">
-								<input class="hidden" type="checkbox" name="repo_admin_change_team_access" checked/>
+								<input type="checkbox" name="repo_admin_change_team_access" checked/>
 								<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 							</div>
 						</div>

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -41,19 +41,19 @@
 							<label for="visibility">{{.locale.Tr "org.settings.visibility"}}</label>
 							<div class="field">
 								<div class="ui radio checkbox">
-									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if eq .CurrentVisibility 0}}checked{{end}}/>
+									<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="0" {{if eq .CurrentVisibility 0}}checked{{end}}/>
 									<label>{{.locale.Tr "org.settings.visibility.public"}}</label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
-									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if eq .CurrentVisibility 1}}checked{{end}}/>
+									<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="1" {{if eq .CurrentVisibility 1}}checked{{end}}/>
 									<label>{{.locale.Tr "org.settings.visibility.limited"}}</label>
 								</div>
 							</div>
 							<div class="field">
 								<div class="ui radio checkbox">
-									<input class="hidden enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if eq .CurrentVisibility 2}}checked{{end}}/>
+									<input class="enable-system-radio" tabindex="0" name="visibility" type="radio" value="2" {{if eq .CurrentVisibility 2}}checked{{end}}/>
 									<label>{{.locale.Tr "org.settings.visibility.private"}}</label>
 								</div>
 							</div>
@@ -63,7 +63,7 @@
 							<label>{{.locale.Tr "org.settings.permission"}}</label>
 							<div class="field">
 								<div class="ui checkbox">
-									<input class="hidden" type="checkbox" name="repo_admin_change_team_access" {{if .RepoAdminChangeTeamAccess}}checked{{end}}/>
+									<input type="checkbox" name="repo_admin_change_team_access" {{if .RepoAdminChangeTeamAccess}}checked{{end}}/>
 									<label>{{.locale.Tr "org.settings.repoadminchangeteam"}}</label>
 								</div>
 							</div>

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -99,17 +99,17 @@
 													</td>
 													<td class="center aligned">
 														<div class="ui radio checkbox">
-															<input type="radio" class="hidden" name="unit_{{$unit.Type.Value}}" value="0"{{if or ($unit.Type.UnitGlobalDisabled) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 0)}} checked{{end}} title="{{$.locale.Tr "org.teams.none_access"}}">
+															<input type="radio" name="unit_{{$unit.Type.Value}}" value="0"{{if or ($unit.Type.UnitGlobalDisabled) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 0)}} checked{{end}} title="{{$.locale.Tr "org.teams.none_access"}}">
 														</div>
 													</td>
 													<td class="center aligned">
 														<div class="ui radio checkbox">
-															<input type="radio" class="hidden" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{$.locale.Tr "org.teams.read_access"}}">
+															<input type="radio" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{$.locale.Tr "org.teams.read_access"}}">
 														</div>
 													</td>
 													<td class="center aligned">
 														<div class="ui radio checkbox">
-															<input type="radio" class="hidden" name="unit_{{$unit.Type.Value}}" value="2"{{if (eq ($.Team.UnitAccessMode $.Context $unit.Type) 2)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{$.locale.Tr "org.teams.write_access"}}">
+															<input type="radio" name="unit_{{$unit.Type.Value}}" value="2"{{if (eq ($.Team.UnitAccessMode $.Context $unit.Type) 2)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{$.locale.Tr "org.teams.write_access"}}">
 														</div>
 													</td>
 												</tr>
@@ -121,7 +121,7 @@
 									{{if lt $unit.MaxPerm 2}}
 										<div {{if $unit.Type.UnitGlobalDisabled}}class="field tooltip" data-content="{{$.locale.Tr "repo.unit_disabled"}}"{{else}}class="field"{{end}}>
 											<div class="ui checkbox">
-												<input type="checkbox" class="hidden" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}}>
+												<input type="checkbox" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode $.Context $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}}>
 												<label>{{$.locale.Tr $unit.NameKey}}{{if $unit.Type.UnitGlobalDisabled}} {{$.locale.Tr "org.team_unit_disabled"}}{{end}}</label>
 												<span class="help">{{$.locale.Tr $unit.DescKey}}</span>
 											</div>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -77,33 +77,33 @@
 						<div class="inline field">
 							<label>{{.locale.Tr "repo.template.items"}}</label>
 							<div class="ui checkbox">
-								<input class="hidden" name="git_content" type="checkbox" tabindex="0" {{if .git_content}}checked{{end}}>
+								<input name="git_content" type="checkbox" tabindex="0" {{if .git_content}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.git_content"}}</label>
 							</div>
 							<div class="ui checkbox{{if not .SignedUser.CanEditGitHook}} tooltip{{end}}"{{if not .SignedUser.CanEditGitHook}} data-content="{{.locale.Tr "repo.template.git_hooks_tooltip"}}"{{end}}>
-								<input class="hidden" name="git_hooks" type="checkbox" tabindex="0" {{if .git_hooks}}checked{{end}}>
+								<input name="git_hooks" type="checkbox" tabindex="0" {{if .git_hooks}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.git_hooks"}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
-								<input class="hidden" name="webhooks" type="checkbox" tabindex="0" {{if .webhooks}}checked{{end}}>
+								<input name="webhooks" type="checkbox" tabindex="0" {{if .webhooks}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.webhooks"}}</label>
 							</div>
 							<div class="ui checkbox">
-								<input class="hidden" name="topics" type="checkbox" tabindex="0" {{if .topics}}checked{{end}}>
+								<input name="topics" type="checkbox" tabindex="0" {{if .topics}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.topics"}}</label>
 							</div>
 						</div>
 						<div class="inline field">
 							<label></label>
 							<div class="ui checkbox">
-								<input class="hidden" name="avatar" type="checkbox" tabindex="0" {{if .avatar}}checked{{end}}>
+								<input name="avatar" type="checkbox" tabindex="0" {{if .avatar}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.avatar"}}</label>
 							</div>
 							<div class="ui checkbox">
-								<input class="hidden" name="labels" type="checkbox" tabindex="0" {{if .labels}}checked{{end}}>
+								<input name="labels" type="checkbox" tabindex="0" {{if .labels}}checked{{end}}>
 								<label>{{.locale.Tr "repo.template.issue_labels"}}</label>
 							</div>
 						</div>
@@ -169,7 +169,7 @@
 						</div>
 						<div class="inline field">
 							<div class="ui checkbox" id="auto-init">
-								<input class="hidden" name="auto_init" type="checkbox" tabindex="0" {{if .auto_init}}checked{{end}}>
+								<input name="auto_init" type="checkbox" tabindex="0" {{if .auto_init}}checked{{end}}>
 								<label>{{.locale.Tr "repo.auto_init"}}</label>
 							</div>
 						</div>
@@ -204,7 +204,7 @@
 						<div class="inline field">
 							<label>{{.locale.Tr "repo.template"}}</label>
 							<div class="ui checkbox">
-								<input class="hidden" name="template" type="checkbox" tabindex="0">
+								<input name="template" type="checkbox" tabindex="0">
 								<label>{{.locale.Tr "repo.template_helper"}}</label>
 							</div>
 						</div>

--- a/templates/repo/editor/commit_form.tmpl
+++ b/templates/repo/editor/commit_form.tmpl
@@ -16,7 +16,7 @@
 		</div>
 		<div class="inline field">
 			<div class="ui checkbox">
-				<input name="signoff" type="checkbox" tabindex="0" class="hidden">
+				<input name="signoff" type="checkbox" tabindex="0">
 				<label>{{.locale.Tr "repo.editor.signoff_desc"}}</label>
 			</div>
 		</div>

--- a/templates/repo/settings/deploy_keys.tmpl
+++ b/templates/repo/settings/deploy_keys.tmpl
@@ -31,7 +31,7 @@
 					</div>
 					<div class="field">
 						<div class="ui checkbox {{if .Err_IsWritable}}error{{end}}">
-							<input id="ssh-key-is-writable" name="is_writable" class="hidden" type="checkbox" value="1">
+							<input id="ssh-key-is-writable" name="is_writable" type="checkbox" value="1">
 							<label for="is_writable">
 								{{.locale.Tr "repo.settings.is_writable"}}
 							</label>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -281,7 +281,7 @@
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.UnitEnabled $.Context $.UnitTypeExternalWiki)}}checked{{end}}/>
+							<input class="enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="false" data-target="#external_wiki_box" {{if not (.Repository.UnitEnabled $.Context $.UnitTypeExternalWiki)}}checked{{end}}/>
 							<label>{{.locale.Tr "repo.settings.use_internal_wiki"}}</label>
 						</div>
 					</div>
@@ -291,7 +291,7 @@
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.UnitEnabled $.Context $.UnitTypeExternalWiki}}checked{{end}}/>
+							<input class="enable-system-radio" tabindex="0" name="enable_external_wiki" type="radio" value="true" data-target="#external_wiki_box" {{if .Repository.UnitEnabled $.Context $.UnitTypeExternalWiki}}checked{{end}}/>
 							<label>{{.locale.Tr "repo.settings.use_external_wiki"}}</label>
 						</div>
 					</div>
@@ -323,7 +323,7 @@
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="false" data-context="#internal_issue_box" data-target="#external_issue_box" {{if not (.Repository.UnitEnabled $.Context $.UnitTypeExternalTracker)}}checked{{end}}/>
+							<input class="enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="false" data-context="#internal_issue_box" data-target="#external_issue_box" {{if not (.Repository.UnitEnabled $.Context $.UnitTypeExternalTracker)}}checked{{end}}/>
 							<label>{{.locale.Tr "repo.settings.use_internal_issue_tracker"}}</label>
 						</div>
 					</div>
@@ -359,7 +359,7 @@
 						{{else}}
 						<div class="ui radio checkbox">
 						{{end}}
-							<input class="hidden enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="true" data-context="#internal_issue_box" data-target="#external_issue_box" {{if .Repository.UnitEnabled $.Context $.UnitTypeExternalTracker}}checked{{end}}/>
+							<input class="enable-system-radio" tabindex="0" name="enable_external_tracker" type="radio" value="true" data-context="#internal_issue_box" data-target="#external_issue_box" {{if .Repository.UnitEnabled $.Context $.UnitTypeExternalTracker}}checked{{end}}/>
 							<label>{{.locale.Tr "repo.settings.use_external_issue_tracker"}}</label>
 						</div>
 					</div>

--- a/templates/repo/settings/webhook/settings.tmpl
+++ b/templates/repo/settings/webhook/settings.tmpl
@@ -4,19 +4,19 @@
 	<div class="grouped event type fields">
 		<div class="field">
 			<div class="ui radio non-events checkbox">
-				<input class="hidden" name="events" type="radio" value="push_only" {{if or $isNew .Webhook.PushOnly}}checked{{end}}>
+				<input name="events" type="radio" value="push_only" {{if or $isNew .Webhook.PushOnly}}checked{{end}}>
 				<label>{{.locale.Tr "repo.settings.event_push_only" | Str2html}}</label>
 			</div>
 		</div>
 		<div class="field">
 			<div class="ui radio non-events checkbox">
-				<input class="hidden" name="events" type="radio" value="send_everything" {{if .Webhook.SendEverything}}checked{{end}}>
+				<input name="events" type="radio" value="send_everything" {{if .Webhook.SendEverything}}checked{{end}}>
 				<label>{{.locale.Tr "repo.settings.event_send_everything" | Str2html}}</label>
 			</div>
 		</div>
 		<div class="field">
 			<div class="ui radio events checkbox">
-				<input class="hidden" name="events" type="radio" value="choose_events" {{if .Webhook.ChooseEvents}}checked{{end}}>
+				<input name="events" type="radio" value="choose_events" {{if .Webhook.ChooseEvents}}checked{{end}}>
 				<label>{{.locale.Tr "repo.settings.event_choose" | Str2html}}</label>
 			</div>
 		</div>
@@ -31,7 +31,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="create" type="checkbox" tabindex="0" {{if .Webhook.Create}}checked{{end}}>
+					<input name="create" type="checkbox" tabindex="0" {{if .Webhook.Create}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_create"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_create_desc"}}</span>
 				</div>
@@ -41,7 +41,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="delete" type="checkbox" tabindex="0" {{if .Webhook.Delete}}checked{{end}}>
+					<input name="delete" type="checkbox" tabindex="0" {{if .Webhook.Delete}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_delete"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_delete_desc"}}</span>
 				</div>
@@ -51,7 +51,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="fork" type="checkbox" tabindex="0" {{if .Webhook.Fork}}checked{{end}}>
+					<input name="fork" type="checkbox" tabindex="0" {{if .Webhook.Fork}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_fork"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_fork_desc"}}</span>
 				</div>
@@ -61,7 +61,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="push" type="checkbox" tabindex="0" {{if .Webhook.Push}}checked{{end}}>
+					<input name="push" type="checkbox" tabindex="0" {{if .Webhook.Push}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_push"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_push_desc"}}</span>
 				</div>
@@ -71,7 +71,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="repository" type="checkbox" tabindex="0" {{if .Webhook.Repository}}checked{{end}}>
+					<input name="repository" type="checkbox" tabindex="0" {{if .Webhook.Repository}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_repository"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_repository_desc"}}</span>
 				</div>
@@ -81,7 +81,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="release" type="checkbox" tabindex="0" {{if .Webhook.Release}}checked{{end}}>
+					<input name="release" type="checkbox" tabindex="0" {{if .Webhook.Release}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_release"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_release_desc"}}</span>
 				</div>
@@ -91,7 +91,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="package" type="checkbox" tabindex="0" {{if .Webhook.Package}}checked{{end}}>
+					<input name="package" type="checkbox" tabindex="0" {{if .Webhook.Package}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_package"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_package_desc"}}</span>
 				</div>
@@ -102,7 +102,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="wiki" type="checkbox" tabindex="0" {{if .Webhook.Wiki}}checked{{end}}>
+					<input name="wiki" type="checkbox" tabindex="0" {{if .Webhook.Wiki}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_wiki"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_wiki_desc"}}</span>
 				</div>
@@ -117,7 +117,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="issues" type="checkbox" tabindex="0" {{if .Webhook.Issues}}checked{{end}}>
+					<input name="issues" type="checkbox" tabindex="0" {{if .Webhook.Issues}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_issues"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_issues_desc"}}</span>
 				</div>
@@ -127,7 +127,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="issue_assign" type="checkbox" tabindex="0" {{if .Webhook.IssueAssign}}checked{{end}}>
+					<input name="issue_assign" type="checkbox" tabindex="0" {{if .Webhook.IssueAssign}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_issue_assign"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_issue_assign_desc"}}</span>
 				</div>
@@ -137,7 +137,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="issue_label" type="checkbox" tabindex="0" {{if .Webhook.IssueLabel}}checked{{end}}>
+					<input name="issue_label" type="checkbox" tabindex="0" {{if .Webhook.IssueLabel}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_issue_label"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_issue_label_desc"}}</span>
 				</div>
@@ -147,7 +147,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="issue_milestone" type="checkbox" tabindex="0" {{if .Webhook.IssueMilestone}}checked{{end}}>
+					<input name="issue_milestone" type="checkbox" tabindex="0" {{if .Webhook.IssueMilestone}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_issue_milestone"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_issue_milestone_desc"}}</span>
 				</div>
@@ -157,7 +157,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="issue_comment" type="checkbox" tabindex="0" {{if .Webhook.IssueComment}}checked{{end}}>
+					<input name="issue_comment" type="checkbox" tabindex="0" {{if .Webhook.IssueComment}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_issue_comment"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_issue_comment_desc"}}</span>
 				</div>
@@ -172,7 +172,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request" type="checkbox" tabindex="0" {{if .Webhook.PullRequest}}checked{{end}}>
+					<input name="pull_request" type="checkbox" tabindex="0" {{if .Webhook.PullRequest}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_desc"}}</span>
 				</div>
@@ -182,7 +182,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_assign" type="checkbox" tabindex="0" {{if .Webhook.PullRequestAssign}}checked{{end}}>
+					<input name="pull_request_assign" type="checkbox" tabindex="0" {{if .Webhook.PullRequestAssign}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_assign"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_assign_desc"}}</span>
 				</div>
@@ -192,7 +192,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_label" type="checkbox" tabindex="0" {{if .Webhook.PullRequestLabel}}checked{{end}}>
+					<input name="pull_request_label" type="checkbox" tabindex="0" {{if .Webhook.PullRequestLabel}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_label"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_label_desc"}}</span>
 				</div>
@@ -202,7 +202,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_milestone" type="checkbox" tabindex="0" {{if .Webhook.PullRequestMilestone}}checked{{end}}>
+					<input name="pull_request_milestone" type="checkbox" tabindex="0" {{if .Webhook.PullRequestMilestone}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_milestone"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_milestone_desc"}}</span>
 				</div>
@@ -212,7 +212,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_comment" type="checkbox" tabindex="0" {{if .Webhook.PullRequestComment}}checked{{end}}>
+					<input name="pull_request_comment" type="checkbox" tabindex="0" {{if .Webhook.PullRequestComment}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_comment"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_comment_desc"}}</span>
 				</div>
@@ -222,7 +222,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_review" type="checkbox" tabindex="0" {{if .Webhook.PullRequestReview}}checked{{end}}>
+					<input name="pull_request_review" type="checkbox" tabindex="0" {{if .Webhook.PullRequestReview}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_review"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_review_desc"}}</span>
 				</div>
@@ -232,7 +232,7 @@
 		<div class="seven wide column">
 			<div class="field">
 				<div class="ui checkbox">
-					<input class="hidden" name="pull_request_sync" type="checkbox" tabindex="0" {{if .Webhook.PullRequestSync}}checked{{end}}>
+					<input name="pull_request_sync" type="checkbox" tabindex="0" {{if .Webhook.PullRequestSync}}checked{{end}}>
 					<label>{{.locale.Tr "repo.settings.event_pull_request_sync"}}</label>
 					<span class="help">{{.locale.Tr "repo.settings.event_pull_request_sync_desc"}}</span>
 				</div>
@@ -261,7 +261,7 @@
 
 <div class="inline field">
 	<div class="ui checkbox">
-		<input class="hidden" name="active" type="checkbox" tabindex="0" {{if or $isNew .Webhook.IsActive}}checked{{end}}>
+		<input name="active" type="checkbox" tabindex="0" {{if or $isNew .Webhook.IsActive}}checked{{end}}>
 		<label>{{.locale.Tr "repo.settings.active"}}</label>
 		<span class="help">{{.locale.Tr "repo.settings.active_helper"}}</span>
 	</div>


### PR DESCRIPTION
Fomantic-UI's `.hidden` CSS class is badly designed.

* Checkbox elements do not need it in HTML, so this PR removes it (JS adds the `.hidden` class back by `$('.ui.checkbox').checkbox()`)
* `menu transaction hidden` is still needed, and it should be the only usage for the `.hidden` from now on (until they get refactored properly)
