### PR TITLE
Improve milestone title

### DIFF
--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -62,9 +62,9 @@
 			{{range .Milestones}}
 				<li class="item">
 					<div class="df ac sb">
-						<h2 class="df ac m-0 fw">
+						<div class="df ac title">
 							{{svg "octicon-milestone" 16 "mr-3"}}<a class="muted" href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
-						</h2>
+						</div>
 						<div class="df ac">
 							<span class="mr-3">{{.Completeness}}%</span>
 							<progress value="{{.Completeness}}" max="100"></progress>

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1235,6 +1235,11 @@
         height: 16px;
       }
 
+      .title {
+        font-size: 16px;
+        font-weight: 600;
+      }
+
       .meta {
         color: var(--color-text-light-2);
         padding-top: 5px;


### PR DESCRIPTION
- Don't use `h2` for the title, instead use `font-size` and `font-weight` to make the title look better.
- Forgejo issue: https://codeberg.org/forgejo/forgejo/issues/348

Pulled from:
https://github.com/go-gitea/gitea/blob/affdd40296960a08a4223330ccbd1fb88c96ea1a/web_src/less/shared/issuelist.less#L30-L32

Before:
![image](https://user-images.githubusercontent.com/25481501/218122759-a176e8c8-1009-41b9-80b3-9f4ab833aa1d.png)

After:
![image](https://user-images.githubusercontent.com/25481501/218122708-659c196d-6bc8-4077-8ade-62e1aa84b3f6.png)
