### PR TITLE
Fix milestone title font problem

### DIFF
--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -62,9 +62,9 @@
 			{{range .Milestones}}
 				<li class="item">
 					<div class="df ac sb">
-						<h2 class="df ac m-0 fw">
+						<h3 class="df ac m-0 fw">
 							{{svg "octicon-milestone" 16 "mr-3"}}<a class="muted" href="{{$.RepoLink}}/milestone/{{.ID}}">{{.Name}}</a>
-						</h2>
+						</h3>
 						<div class="df ac">
 							<span class="mr-3">{{.Completeness}}%</span>
 							<progress value="{{.Completeness}}" max="100"></progress>

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -81,10 +81,10 @@
 					{{range .Milestones}}
 						<li class="item">
 							<div class="df ac sb">
-								<h2 class="df ac m-0 fw">
+								<h3 class="df ac m-0 fw">
 									<span class="ui large label">{{.Repo.FullName}}</span>
 									{{svg "octicon-milestone" 16 "mr-3"}}<a class="muted" href="{{.Repo.Link}}/milestone/{{.ID}}">{{.Name}}</a>
-								</h2>
+								</h3>
 								<div class="df ac">
 									<span class="mr-3">{{.Completeness}}%</span>
 									<progress value="{{.Completeness}}" max="100"></progress>


### PR DESCRIPTION
Replace #22853 since it's closed, and actually there are 2 places need to be fixed.

~~Follow @fsologureng 's suggestion to keep the `<hX>` tags.~~ 

Update: from fsologureng: this doesn't change anything from a11y's point of view. So I think this PR could be fine to fix the UI looking problems as a quick patch, then defer the a11y problems to new PRs together.

Before: the font-size is too large.

After: it seems better.

![image](https://user-images.githubusercontent.com/2114189/218266257-fc2d5872-9e96-4c6a-87ea-f27531ac15c0.png)


![image](https://user-images.githubusercontent.com/2114189/218266247-efc09d83-405f-4495-967a-30d9744134ce.png)
