### PR TITLE
Fix PR file tree folders no longer collapsing

### DIFF
--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -10,7 +10,7 @@
       />
       <a
         v-if="item.isFile"
-        class="file ellipsis"
+        class="file ellipsis" :class="[getFileClassForDiffType(item.file.Type)]"
         :href="item.isFile ? '#diff-' + item.file.NameHash : ''"
       >{{ item.name }}</a>
       <SvgIcon
@@ -75,6 +75,16 @@ export default {
       };
       return diffTypes[pType];
     },
+    getFileClassForDiffType(pType) {
+      const diffTypes = {
+        1: 'file-diff-added',
+        2: 'file-diff-modified',
+        3: 'file-diff-removed',
+        4: 'file-diff-renamed',
+        5: 'file-diff-copied',
+      };
+      return diffTypes[pType];
+    }
   },
 };
 </script>
@@ -117,6 +127,26 @@ span.svg-icon.octicon-diff-renamed {
   color: var(--color-text);
   background: var(--color-hover);
   border-radius: 4px;
+}
+
+.file.file-diff-added {
+  color: var(--color-green);
+}
+
+.file.file-diff-modified {
+  color: var(--color-yellow);
+}
+
+.file.file-diff-removed {
+  color: var(--color-red);
+}
+
+.file.file-diff-renamed {
+  color: var(--color-yellow);
+}
+
+.file.file-diff-copied {
+  color: var(--color-yellow);
 }
 
 div.directory {

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -10,7 +10,7 @@
       />
       <a
         v-if="item.isFile"
-        class="file ellipsis"
+        class="file ellipsis muted"
         :href="item.isFile ? '#diff-' + item.file.NameHash : ''"
       >{{ item.name }}</a>
       <SvgIcon
@@ -86,10 +86,6 @@ span.svg-icon.status {
 
 span.svg-icon.file {
   color: var(--color-secondary-dark-7);
-}
-
-a.file {
-  color: var(--color-text);
 }
 
 span.svg-icon.directory {

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -10,7 +10,7 @@
       />
       <a
         v-if="item.isFile"
-        class="file ellipsis" :class="[getFileClassForDiffType(item.file.Type)]"
+        class="file ellipsis"
         :href="item.isFile ? '#diff-' + item.file.NameHash : ''"
       >{{ item.name }}</a>
       <SvgIcon
@@ -75,16 +75,6 @@ export default {
       };
       return diffTypes[pType];
     },
-    getFileClassForDiffType(pType) {
-      const diffTypes = {
-        1: 'file-diff-added',
-        2: 'file-diff-modified',
-        3: 'file-diff-removed',
-        4: 'file-diff-renamed',
-        5: 'file-diff-copied',
-      };
-      return diffTypes[pType];
-    }
   },
 };
 </script>
@@ -93,8 +83,13 @@ export default {
 span.svg-icon.status {
   float: right;
 }
+
 span.svg-icon.file {
   color: var(--color-secondary-dark-7);
+}
+
+a.file {
+  color: var(--color-text);
 }
 
 span.svg-icon.directory {
@@ -127,26 +122,6 @@ span.svg-icon.octicon-diff-renamed {
   color: var(--color-text);
   background: var(--color-hover);
   border-radius: 4px;
-}
-
-.file.file-diff-added {
-  color: var(--color-green);
-}
-
-.file.file-diff-modified {
-  color: var(--color-yellow);
-}
-
-.file.file-diff-removed {
-  color: var(--color-red);
-}
-
-.file.file-diff-renamed {
-  color: var(--color-yellow);
-}
-
-.file.file-diff-copied {
-  color: var(--color-yellow);
 }
 
 div.directory {

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -63,7 +63,7 @@ export default {
       if (itemIsFile) {
         return;
       }
-      this.$set(this, 'collapsed', !this.collapsed);
+      this.collapsed = !this.collapsed;
     },
     getIconForDiffType(pType) {
       const diffTypes = {
@@ -122,6 +122,8 @@ span.svg-icon.octicon-diff-renamed {
 div.directory {
   display: grid;
   grid-template-columns: 18px 20px auto;
+  user-select: none;
+  cursor: pointer;
 }
 
 div.directory:hover {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1614,6 +1614,18 @@
       margin-right: .25rem;
     }
 
+    .diff-detail-stats strong:nth-of-type(1) {
+      color: var(--color-yellow)
+    }
+
+    .diff-detail-stats strong:nth-of-type(2) {
+      color: var(--color-green)
+    }
+
+    .diff-detail-stats strong:nth-of-type(3) {
+      color: var(--color-red)
+    }
+
     .diff-detail-stats {
       @media (max-width: 480px) {
         font-size: 0;

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1615,15 +1615,15 @@
     }
 
     .diff-detail-stats strong:nth-of-type(1) {
-      color: var(--color-yellow)
+      color: var(--color-yellow);
     }
 
     .diff-detail-stats strong:nth-of-type(2) {
-      color: var(--color-green)
+      color: var(--color-green);
     }
 
     .diff-detail-stats strong:nth-of-type(3) {
-      color: var(--color-red)
+      color: var(--color-red);
     }
 
     .diff-detail-stats {

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -1614,6 +1614,8 @@
       margin-right: .25rem;
     }
 
+    // Because the translations contain the <strong> we need to style with nth-of-type
+
     .diff-detail-stats strong:nth-of-type(1) {
       color: var(--color-yellow);
     }


### PR DESCRIPTION
Collapsing folders currently just throws a console error

```
index.js?v=1.19.0~dev-403-gb6b8feb3d:10 TypeError: this.$set is not a function
    at Proxy.handleClick (index.js?v=1.19.0~dev-403-gb6b8feb3d:58:7159)
    at index.js?v=1.19.0~dev-403-gb6b8feb3d:58:6466
    at index.js?v=1.19.0~dev-403-gb6b8feb3d:10:93922
    at ce (index.js?v=1.19.0~dev-403-gb6b8feb3d:10:1472)
    at Q (index.js?v=1.19.0~dev-403-gb6b8feb3d:10:1567)
    at HTMLDivElement.$e (index.js?v=1.19.0~dev-403-gb6b8feb3d:10:79198)
```

This PR fixes this and allows folders to be collapsed again.

Also:
- better cursor interaction with folders
- added some color to the diff detail stats
- remove green link color from all the file names

Screenshots:
![image](https://user-images.githubusercontent.com/9765622/218269712-2f3dda55-6d70-407f-8d34-2a5d9c8df548.png)
![image](https://user-images.githubusercontent.com/9765622/218269714-6ce8a954-daea-4ed6-9eea-8b2323db4d8f.png)

