### PR TITLE
Fix .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
   fast: false
 
 run:
-  go: 1.20
+  go: "1.20"
   timeout: 10m
   skip-dirs:
     - node_modules

--- a/models/db/sql_postgres_with_schema.go
+++ b/models/db/sql_postgres_with_schema.go
@@ -37,7 +37,9 @@ func (d *postgresSchemaDriver) Open(name string) (driver.Conn, error) {
 	}
 	schemaValue, _ := driver.String.ConvertValue(setting.Database.Schema)
 
-	if execer, ok := conn.(driver.Execer); ok {
+	// golangci lint is incorrect here - there is no benefit to using driver.ExecerContext here
+	// and in any case pq does not implement it
+	if execer, ok := conn.(driver.Execer); ok { //nolint
 		_, err := execer.Exec(`SELECT set_config(
 			'search_path',
 			$1 || ',' || current_setting('search_path'),
@@ -61,7 +63,8 @@ func (d *postgresSchemaDriver) Open(name string) (driver.Conn, error) {
 
 	// driver.String.ConvertValue will never return err for string
 
-	_, err = stmt.Exec([]driver.Value{schemaValue})
+	// golangci lint is incorrect here - there is no benefit to using stmt.ExecWithContext here
+	_, err = stmt.Exec([]driver.Value{schemaValue}) //nolint
 	if err != nil {
 		_ = conn.Close()
 		return nil, err


### PR DESCRIPTION
When we updated the .golangci.yml for 1.20 we should have used a string as 1.20 is not a valid number.

In doing so we need to restore the nolint markings within the pq driver.

Signed-off-by: Andrew Thornton <art27@cantab.net>