### PR TITLE
Remember to attach the parent tree when converting TreeEntry() -> Tree()

### DIFF
--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -101,12 +101,13 @@ func (te *TreeEntry) FollowLinks() (*TreeEntry, error) {
 	return entry, nil
 }
 
-// returns the subtree, or nil if this is not a tree
+// returns the Tree pointed to by this TreeEntry, or nil if this is not a tree
 func (te *TreeEntry) Tree() *Tree {
 	t, err := te.ptree.repo.getTree(te.ID)
 	if err != nil {
 		return nil
 	}
+	t.ptree = te.ptree
 	return t
 }
 


### PR DESCRIPTION
!fixup https://github.com/go-gitea/gitea/pull/22177

The only place this function is used so far is in findReadmeFileInEntries(), so the only visible effect of this oversight was in an obscure README-related corner: if the README was in a subfolder and was a symlink that pointed up, as in .github/README.md -> ../docs/old/setup.md, the README would fail to render when FollowLinks() hit the nil ptree. This makes the ptree non-nil and thus repairs it.