### PR TITLE
Fix the full-height problem for all pages

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -268,6 +268,11 @@ export function initRepositoryActionView() {
   const el = document.getElementById('repo-action-view');
   if (!el) return;
 
+  // TODO: the parent element's full height doesn't work well now,
+  // but we can not pollute the global style at the moment, only fix the height problem for pages with this component
+  const parentFullHeight = document.querySelector('body > div.full.height');
+  if (parentFullHeight) parentFullHeight.style.paddingBottom = '0';
+
   const view = createApp(sfc, {
     runIndex: el.getAttribute('data-run-index'),
     jobIndex: el.getAttribute('data-job-index'),
@@ -411,11 +416,6 @@ export function initRepositoryActionView() {
 
 <style lang="less">
 // some elements are not managed by vue, so we need to use global style
-
-// TODO: the parent element's full height doesn't work well now
-body > div.full.height {
-  padding-bottom: 0;
-}
 
 .job-status-rotate {
   animation: job-status-rotate-keyframes 1s linear infinite;


### PR DESCRIPTION
Really fix #22883, close #22901

I made a mistake that the global styles in RepoActionView.vue could still pollute global styles (I forgot that the code of this component is still loaded on every page, instead of loaded on demand)

This PR makes a complete fix: only change the page's full-height behavior if the component is used.

Screenshot after the fix:

<details>

![image](https://user-images.githubusercontent.com/2114189/218664776-0dbcd469-2c36-4e17-972f-e44fa3b81ba6.png)

</details>
