### PR TITLE
Add tooltip to issue reference

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -577,8 +577,8 @@
 
 		<div class="ui divider"></div>
 		<div class="ui equal width compact grid">
-			<div class="row gt-ac">
-				{{$issueReferenceLink := printf "%s#%d" .Issue.Repo.FullName .Issue.Index}}
+			{{$issueReferenceLink := printf "%s#%d" .Issue.Repo.FullName .Issue.Index}}
+			<div class="row gt-ac tooltip" data-content="{{$issueReferenceLink}}">
 				<span class="text column truncate">{{.locale.Tr "repo.issues.reference_link" $issueReferenceLink}}</span>
 				<button class="ui two wide button column gt-p-3" data-clipboard-text="{{$issueReferenceLink}}">{{svg "octicon-copy" 14}}</button>
 			</div>


### PR DESCRIPTION
Previously, you had no idea what you are copying with the issue reference button for either long repo names, user names, or issue indexes.
Now, it is simply a bit redundant for short references but a lot easier for long references.

## Before
![image](https://user-images.githubusercontent.com/51889757/218995943-3b609ee9-4138-49ce-99b1-73fb1ea80280.png)

## After
![image](https://user-images.githubusercontent.com/51889757/218996119-4b6bf6c1-abfa-4618-81ca-a72914e73eb8.png)


<!--

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
3. Describe what your pull request does and which issue you're targeting (if any)

-->  
