### PR TITLE
fix incorrect role labels for migrated issues and comments (#22914)

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -1549,3 +1549,8 @@ func FixCommentTypeLabelWithOutsideLabels() (int64, error) {
 
 	return res.RowsAffected()
 }
+
+// HasOriginalAuthor returns if a comment was migrated and has an original author.
+func (c *Comment) HasOriginalAuthor() bool {
+	return c.OriginalAuthor != "" && c.OriginalAuthorID != 0
+}

--- a/models/issues/issue.go
+++ b/models/issues/issue.go
@@ -2466,3 +2466,8 @@ func DeleteOrphanedIssues() error {
 	}
 	return nil
 }
+
+// HasOriginalAuthor returns if an issue was migrated and has an original author.
+func (issue *Issue) HasOriginalAuthor() bool {
+	return issue.OriginalAuthor != "" && issue.OriginalAuthorID != 0
+}


### PR DESCRIPTION
Backport #22914

Fix #22797.

## Reason
If a comment was migrated from other platforms, this comment may have an original author and its poster is always not the original author. When the `roleDescriptor` func get the poster's role descriptor for a comment, it does not check if the comment has an original author. So the migrated comments' original authors might be marked as incorrect roles.
