### PR TITLE
Use "Title Case" for text "Reference in new issue"

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1361,7 +1361,7 @@ issues.commented_at = `commented <a href="#%s">%s</a>`
 issues.delete_comment_confirm = Are you sure you want to delete this comment?
 issues.context.copy_link = Copy Link
 issues.context.quote_reply = Quote Reply
-issues.context.reference_issue = Reference in new issue
+issues.context.reference_issue = Reference in New Issue
 issues.context.edit = Edit
 issues.context.delete = Delete
 issues.no_content = There is no content yet.


### PR DESCRIPTION
The "Reference in new issue" option shows up in a menu when looking at pull requests. All the other options there follow the "Title case":

* Copy Link
* Quote Reply
* Edit

This patch makes sure this option also follow the Title case.

Screenshot of how it looks without this patch:

![image](https://user-images.githubusercontent.com/843498/219346003-728d07c1-d150-41a5-b084-faef118228b1.png)
