### PR TITLE
Add pagination for dashboard and user activity feeds

### DIFF
--- a/models/activities/action_test.go
+++ b/models/activities/action_test.go
@@ -44,7 +44,7 @@ func TestGetFeeds(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 
-	actions, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedUser:   user,
 		Actor:           user,
 		IncludePrivate:  true,
@@ -56,8 +56,9 @@ func TestGetFeeds(t *testing.T) {
 		assert.EqualValues(t, 1, actions[0].ID)
 		assert.EqualValues(t, user.ID, actions[0].UserID)
 	}
+	assert.Equal(t, int64(1), count)
 
-	actions, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedUser:   user,
 		Actor:           user,
 		IncludePrivate:  false,
@@ -65,6 +66,7 @@ func TestGetFeeds(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
+	assert.Equal(t, int64(0), count)
 }
 
 func TestGetFeedsForRepos(t *testing.T) {
@@ -74,38 +76,42 @@ func TestGetFeedsForRepos(t *testing.T) {
 	pubRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 8})
 
 	// private repo & no login
-	actions, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedRepo:  privRepo,
 		IncludePrivate: true,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
+	assert.Equal(t, int64(0), count)
 
 	// public repo & no login
-	actions, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedRepo:  pubRepo,
 		IncludePrivate: true,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
+	assert.Equal(t, int64(1), count)
 
 	// private repo and login
-	actions, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedRepo:  privRepo,
 		IncludePrivate: true,
 		Actor:          user,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
+	assert.Equal(t, int64(1), count)
 
 	// public repo & login
-	actions, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedRepo:  pubRepo,
 		IncludePrivate: true,
 		Actor:          user,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 1)
+	assert.Equal(t, int64(1), count)
 }
 
 func TestGetFeeds2(t *testing.T) {
@@ -114,7 +120,7 @@ func TestGetFeeds2(t *testing.T) {
 	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3})
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 
-	actions, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedUser:   org,
 		Actor:           user,
 		IncludePrivate:  true,
@@ -127,8 +133,9 @@ func TestGetFeeds2(t *testing.T) {
 		assert.EqualValues(t, 2, actions[0].ID)
 		assert.EqualValues(t, org.ID, actions[0].UserID)
 	}
+	assert.Equal(t, int64(1), count)
 
-	actions, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err = activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedUser:   org,
 		Actor:           user,
 		IncludePrivate:  false,
@@ -137,6 +144,7 @@ func TestGetFeeds2(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
+	assert.Equal(t, int64(0), count)
 }
 
 func TestActivityReadable(t *testing.T) {
@@ -224,13 +232,14 @@ func TestGetFeedsCorrupted(t *testing.T) {
 		RepoID: 1700,
 	})
 
-	actions, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+	actions, count, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 		RequestedUser:  user,
 		Actor:          user,
 		IncludePrivate: true,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
+	assert.Equal(t, int64(0), count)
 }
 
 func TestConsistencyUpdateAction(t *testing.T) {

--- a/models/activities/user_heatmap_test.go
+++ b/models/activities/user_heatmap_test.go
@@ -73,7 +73,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		}
 
 		// get the action for comparison
-		actions, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
+		actions, count, err := activities_model.GetFeeds(db.DefaultContext, activities_model.GetFeedsOptions{
 			RequestedUser:   user,
 			Actor:           doer,
 			IncludePrivate:  true,
@@ -90,6 +90,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		}
 		assert.NoError(t, err)
 		assert.Len(t, actions, contributions, "invalid action count: did the test data became too old?")
+		assert.Equal(t, count, int64(contributions))
 		assert.Equal(t, tc.CountResult, contributions, fmt.Sprintf("testcase '%s'", tc.desc))
 
 		// Test JSON rendering

--- a/routers/web/feed/profile.go
+++ b/routers/web/feed/profile.go
@@ -26,7 +26,7 @@ func ShowUserFeedAtom(ctx *context.Context) {
 func showUserFeed(ctx *context.Context, formatType string) {
 	includePrivate := ctx.IsSigned && (ctx.Doer.IsAdmin || ctx.Doer.ID == ctx.ContextUser.ID)
 
-	actions, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
+	actions, _, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
 		RequestedUser:   ctx.ContextUser,
 		Actor:           ctx.Doer,
 		IncludePrivate:  includePrivate,

--- a/routers/web/feed/repo.go
+++ b/routers/web/feed/repo.go
@@ -15,7 +15,7 @@ import (
 
 // ShowRepoFeed shows user activity on the repo as RSS / Atom feed
 func ShowRepoFeed(ctx *context.Context, repo *repo_model.Repository, formatType string) {
-	actions, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
+	actions, _, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
 		RequestedRepo:  repo,
 		Actor:          ctx.Doer,
 		IncludePrivate: true,

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -187,19 +187,25 @@ func Profile(ctx *context.Context) {
 
 		total = int(count)
 	case "activity":
-		ctx.Data["Feeds"], err = activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
+		items, count, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
 			RequestedUser:   ctx.ContextUser,
 			Actor:           ctx.Doer,
 			IncludePrivate:  showPrivate,
 			OnlyPerformedBy: true,
 			IncludeDeleted:  false,
 			Date:            ctx.FormString("date"),
-			ListOptions:     db.ListOptions{PageSize: setting.UI.FeedPagingNum},
+			ListOptions: db.ListOptions{
+				PageSize: setting.UI.FeedPagingNum,
+				Page:     page,
+			},
 		})
 		if err != nil {
 			ctx.ServerError("GetFeeds", err)
 			return
 		}
+		ctx.Data["Feeds"] = items
+
+		total = int(count)
 	case "stars":
 		ctx.Data["PageIsProfileStarList"] = true
 		repos, count, err = repo_model.SearchRepository(ctx, &repo_model.SearchRepoOptions{

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -119,6 +119,11 @@ func Profile(ctx *context.Context) {
 		page = 1
 	}
 
+	pagingNum := setting.UI.User.RepoPagingNum
+	if tab == "activity" {
+		pagingNum = setting.UI.FeedPagingNum
+	}
+
 	topicOnly := ctx.FormBool("topic")
 
 	var (
@@ -164,7 +169,7 @@ func Profile(ctx *context.Context) {
 	switch tab {
 	case "followers":
 		items, count, err := user_model.GetUserFollowers(ctx, ctx.ContextUser, ctx.Doer, db.ListOptions{
-			PageSize: setting.UI.User.RepoPagingNum,
+			PageSize: pagingNum,
 			Page:     page,
 		})
 		if err != nil {
@@ -176,7 +181,7 @@ func Profile(ctx *context.Context) {
 		total = int(count)
 	case "following":
 		items, count, err := user_model.GetUserFollowing(ctx, ctx.ContextUser, ctx.Doer, db.ListOptions{
-			PageSize: setting.UI.User.RepoPagingNum,
+			PageSize: pagingNum,
 			Page:     page,
 		})
 		if err != nil {
@@ -187,15 +192,16 @@ func Profile(ctx *context.Context) {
 
 		total = int(count)
 	case "activity":
+		date := ctx.FormString("date")
 		items, count, err := activities_model.GetFeeds(ctx, activities_model.GetFeedsOptions{
 			RequestedUser:   ctx.ContextUser,
 			Actor:           ctx.Doer,
 			IncludePrivate:  showPrivate,
 			OnlyPerformedBy: true,
 			IncludeDeleted:  false,
-			Date:            ctx.FormString("date"),
+			Date:            date,
 			ListOptions: db.ListOptions{
-				PageSize: setting.UI.FeedPagingNum,
+				PageSize: pagingNum,
 				Page:     page,
 			},
 		})
@@ -204,13 +210,14 @@ func Profile(ctx *context.Context) {
 			return
 		}
 		ctx.Data["Feeds"] = items
+		ctx.Data["Date"] = date
 
 		total = int(count)
 	case "stars":
 		ctx.Data["PageIsProfileStarList"] = true
 		repos, count, err = repo_model.SearchRepository(ctx, &repo_model.SearchRepoOptions{
 			ListOptions: db.ListOptions{
-				PageSize: setting.UI.User.RepoPagingNum,
+				PageSize: pagingNum,
 				Page:     page,
 			},
 			Actor:              ctx.Doer,
@@ -242,7 +249,7 @@ func Profile(ctx *context.Context) {
 	case "watching":
 		repos, count, err = repo_model.SearchRepository(ctx, &repo_model.SearchRepoOptions{
 			ListOptions: db.ListOptions{
-				PageSize: setting.UI.User.RepoPagingNum,
+				PageSize: pagingNum,
 				Page:     page,
 			},
 			Actor:              ctx.Doer,
@@ -264,7 +271,7 @@ func Profile(ctx *context.Context) {
 	default:
 		repos, count, err = repo_model.SearchRepository(ctx, &repo_model.SearchRepoOptions{
 			ListOptions: db.ListOptions{
-				PageSize: setting.UI.User.RepoPagingNum,
+				PageSize: pagingNum,
 				Page:     page,
 			},
 			Actor:              ctx.Doer,
@@ -287,11 +294,14 @@ func Profile(ctx *context.Context) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["Total"] = total
 
-	pager := context.NewPagination(total, setting.UI.User.RepoPagingNum, page, 5)
+	pager := context.NewPagination(total, pagingNum, page, 5)
 	pager.SetDefaultParams(ctx)
 	pager.AddParam(ctx, "tab", "TabName")
 	if tab != "followers" && tab != "following" && tab != "activity" && tab != "projects" {
 		pager.AddParam(ctx, "language", "Language")
+	}
+	if tab == "activity" {
+		pager.AddParam(ctx, "date", "Date")
 	}
 	ctx.Data["Page"] = pager
 	ctx.Data["IsPackageEnabled"] = setting.Packages.Enabled

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -124,3 +124,5 @@
 		<div class="ui divider"></div>
 	</div>
 {{end}}
+
+{{template "base/paginate" .}}

--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -70,6 +70,8 @@ export default {
         params.set('date', clickedDate);
       }
 
+      params.delete('page');
+
       const newSearch = params.toString();
       window.location.search = newSearch.length ? `?${newSearch}` : '';
     }


### PR DESCRIPTION
Previously only the last few activities where available. This works for all activity and for activity on a date chosen on the heatmap.