### PR TITLE
Fix CSV diff panic if the file was deleted from both branches

### DIFF
--- a/services/gitdiff/csv.go
+++ b/services/gitdiff/csv.go
@@ -119,8 +119,12 @@ func CreateCsvDiff(diffFile *DiffFile, baseReader, headReader *csv.Reader) ([]*T
 
 	if baseReader != nil {
 		return createCsvDiffSingle(baseReader, TableDiffCellDel)
+	} else if headReader != nil {
+		return createCsvDiffSingle(headReader, TableDiffCellAdd)
 	}
-	return createCsvDiffSingle(headReader, TableDiffCellAdd)
+	// If a CSV file was deleted from both branches, then baseReader and headReader are nil, no need to "diff" them
+	// The UI will show a "deleted" change correctly.
+	return nil, nil
 }
 
 // createCsvDiffSingle creates a tabular diff based on a single CSV reader. All cells are added or deleted.


### PR DESCRIPTION
Close  #22946

If a CSV file was deleted from both branches, then baseReader and headReader are nil, no need to "diff" them.
The UI will show a "deleted" change correctly.

ps: This is a quick fix. If you want to see the "deleted content", it needs more work to fine tune. I think it's good enough for a fix, since the file has been deleted from both side already.


![image](https://user-images.githubusercontent.com/2114189/219542309-d706caaf-5947-4f6f-b0b1-b5335908068a.png)