### PR TITLE
webview: Fix overflowing diff body

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3187,6 +3187,7 @@ td.blob-excerpt {
 }
 #diff-file-boxes {
   flex: 1;
+  max-width: 100%;
 }
 
 #diff-file-tree {
@@ -3293,6 +3294,10 @@ td.blob-excerpt {
       position: static;
     }
   }
+}
+
+.diff-file-body {
+  overflow-x: scroll;
 }
 
 .diff-stats-bar {


### PR DESCRIPTION
If the content is quite large the diff body overflows the container and can not be read.
This is fixed by setting the diff body maximum width to 100% and enable overflow scrollbars:

before | after
---|---
![Screenshot_20230217_184716](https://user-images.githubusercontent.com/1855448/219733934-75bec38c-7cfe-47bb-b001-b090c02b769e.png) | ![Screenshot_20230217_184655](https://user-images.githubusercontent.com/1855448/219733971-4db092d1-ffcb-4298-a640-f740a3ac430b.png)
