### PR TITLE
Speed up CI: only reset fixture repositories when they have been changed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/yuin/goldmark v1.5.3
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20220924101305-151362477c87
 	github.com/yuin/goldmark-meta v1.1.0
+	go.uber.org/atomic v1.10.0
 	golang.org/x/crypto v0.4.0
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.3.0
@@ -267,7 +268,6 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.1 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,6 @@ require (
 	github.com/yuin/goldmark v1.5.3
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20220924101305-151362477c87
 	github.com/yuin/goldmark-meta v1.1.0
-	go.uber.org/atomic v1.10.0
 	golang.org/x/crypto v0.4.0
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.3.0
@@ -268,6 +267,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.1 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect

--- a/modules/watcher/watcher.go
+++ b/modules/watcher/watcher.go
@@ -95,7 +95,7 @@ func run(ctx context.Context, desc string, opts *CreateWatcherOpts) {
 			return
 		}
 		if err := opts.PathsCallback(func(path, _ string, _ fs.DirEntry, err error) error {
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				return err
 			}
 			_ = watcher.Add(path)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -123,6 +123,11 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Error initializing test database: %v\n", err)
 		os.Exit(1)
 	}
+	if err := util.RemoveAll(setting.RepoRootPath); err != nil {
+		fmt.Printf("Error removing old repo store: %v\n", err)
+		os.Exit(1)
+	}
+
 	exitCode := m.Run()
 
 	tests.WriterCloser.Reset()

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func InitTest(requireGitea bool) {

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -25,10 +25,10 @@ import (
 	"code.gitea.io/gitea/modules/storage"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers"
-	"go.uber.org/atomic"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 )
 
 func InitTest(requireGitea bool) {


### PR DESCRIPTION
This PR creates a watcher that will watch the setting.RepoRootPath for changes during the integration test, and only if there is changes will the repo fixtures be recreated.

This should save substantial time when running CI.

This PR could be further improved by only resetting the repos that need to be reset but that would be a lot more complicated.
