### PR TITLE
Hide 2FA status from other members in organization members list (#22999)

### DIFF
--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -39,6 +39,7 @@
 							</div>
 						</div>
 						<div class="ui two wide column center">
+							{{if $.IsOrganizationOwner}}
 							<div class="meta">
 								{{$.locale.Tr "admin.users.2fa"}}
 							</div>
@@ -51,6 +52,7 @@
 									{{end}}
 								</strong>
 							</div>
+							{{end}}
 						</div>
 					{{end}}
 					<div class="ui three wide column">


### PR DESCRIPTION
Backport #22999

This is rather private information that should not be given to all members in the same organization. Only show it to organization owners.