### PR TITLE
Add invlid value check to DISABLED_REPO_UNITS and fix incorrect slice combine

### DIFF
--- a/models/unit/unit.go
+++ b/models/unit/unit.go
@@ -151,16 +151,13 @@ func validateDefaultRepoUnits(defaultUnits, settingDefaultUnits []Type) []Type {
 
 // LoadUnitConfig load units from settings
 func LoadUnitConfig() {
-	DisabledRepoUnits = FindUnitTypes(setting.Repository.DisabledRepoUnits...)
+	disabledRepoUnits := FindUnitTypes(setting.Repository.DisabledRepoUnits...)
 	// Check that must units are not disabled
-	for i, disabledU := range DisabledRepoUnits {
+	DisabledRepoUnits = disabledRepoUnits[:0]
+	for _, disabledU := range disabledRepoUnits {
 		if !disabledU.CanDisable() || disabledU.IsInvalid() {
 			log.Warn("Not allowed to global disable unit %s", disabledU.String())
-			if i == 0 {
-				DisabledRepoUnits = DisabledRepoUnits[i:]
-			} else {
-				DisabledRepoUnits = append(DisabledRepoUnits[:i], DisabledRepoUnits[i+1:]...)
-			}
+			DisabledRepoUnits = append(DisabledRepoUnits, disabledU)
 		}
 	}
 

--- a/models/unit/unit.go
+++ b/models/unit/unit.go
@@ -157,6 +157,7 @@ func LoadUnitConfig() {
 	for _, disabledU := range disabledRepoUnits {
 		if !disabledU.CanDisable() || disabledU.IsInvalid() {
 			log.Warn("Not allowed to global disable unit %s", disabledU.String())
+		} else {
 			DisabledRepoUnits = append(DisabledRepoUnits, disabledU)
 		}
 	}

--- a/models/unit/unit.go
+++ b/models/unit/unit.go
@@ -154,7 +154,7 @@ func LoadUnitConfig() {
 	DisabledRepoUnits = FindUnitTypes(setting.Repository.DisabledRepoUnits...)
 	// Check that must units are not disabled
 	for i, disabledU := range DisabledRepoUnits {
-		if !disabledU.CanDisable() {
+		if !disabledU.CanDisable() || disabledU.IsInvalid() {
 			log.Warn("Not allowed to global disable unit %s", disabledU.String())
 			DisabledRepoUnits = append(DisabledRepoUnits[:i], DisabledRepoUnits[i+1:]...)
 		}
@@ -174,6 +174,11 @@ func (u Type) UnitGlobalDisabled() bool {
 		}
 	}
 	return false
+}
+
+// IsInvalid checks if this unit type is invalid.
+func (u *Type) IsInvalid() bool {
+	return *u == TypeInvalid
 }
 
 // CanDisable checks if this unit type can be disabled.

--- a/models/unit/unit.go
+++ b/models/unit/unit.go
@@ -156,7 +156,11 @@ func LoadUnitConfig() {
 	for i, disabledU := range DisabledRepoUnits {
 		if !disabledU.CanDisable() || disabledU.IsInvalid() {
 			log.Warn("Not allowed to global disable unit %s", disabledU.String())
-			DisabledRepoUnits = append(DisabledRepoUnits[:i], DisabledRepoUnits[i+1:]...)
+			if i == 0 {
+				DisabledRepoUnits = DisabledRepoUnits[i:]
+			} else {
+				DisabledRepoUnits = append(DisabledRepoUnits[:i], DisabledRepoUnits[i+1:]...)
+			}
 		}
 	}
 


### PR DESCRIPTION
If user set incorrect vaule to DISABLED_REPO_UNITS, all invaild items in `DisabledRepoUnits` will be `Unknown Type 0`, and there's no process to check the invaild value in this function.

![image](https://user-images.githubusercontent.com/18380374/220220985-c75dde4e-f4a6-4852-8ac4-e82de1405e88.png)

After:
![image](https://user-images.githubusercontent.com/18380374/220222728-f208089e-8ed3-428f-8727-dad03fd140d8.png)