### PR TITLE
Render access log template as text instead of HTML (#23013)

### DIFF
--- a/modules/context/access_log.go
+++ b/modules/context/access_log.go
@@ -7,8 +7,8 @@ package context
 import (
 	"bytes"
 	"context"
-	"html/template"
 	"net/http"
+	"text/template"
 	"time"
 
 	"code.gitea.io/gitea/modules/log"


### PR DESCRIPTION
Backport #23013

Fix https://github.com/go-gitea/gitea/pull/22906#discussion_r1112106675