### PR TITLE
Remove dashes between organization member avatars on hover

### DIFF
--- a/web_src/less/_organization.less
+++ b/web_src/less/_organization.less
@@ -93,6 +93,10 @@
   &.teams,
   &.profile {
     .members {
+      a:hover {
+        text-decoration: none;
+      }
+
       .ui.avatar {
         width: 48px;
         height: 48px;


### PR DESCRIPTION
On the home page of an organization, there are unexpected dashes between the avatars of the members when hovering over the avatars, as shown in below:

<img width="376" alt="截屏2023-02-21 14 46 02" src="https://user-images.githubusercontent.com/17645053/220271470-4f49e16f-87eb-4ffa-b38e-23feae1ff92d.png">

<img width="349" alt="截屏2023-02-21 14 58 14" src="https://user-images.githubusercontent.com/17645053/220271512-e4a67685-6b72-4742-a34f-e01ed248c1de.png">

This is because in `fomantic/build/semantic.css` there is a rule`text-decoration: underline;` when `<a>` tag is hovered. And here `<a>` tag has width and height because of  the avatar image inside, leading to the unexpected underlines. 

<img width="1360" alt="截屏2023-02-21 14 47 36" src="https://user-images.githubusercontent.com/17645053/220271867-def3d0ee-e7bc-45c4-9a8d-9763d5866952.png">

This PR is to override the `a:hover` rule so the underline does not exist any more.
