### PR TITLE
Remove delete button for review comment

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -437,7 +437,7 @@
 									{{end}}
 									{{if not $.Repository.IsArchived}}
 											{{template "repo/issue/view_content/add_reaction" Dict "ctx" $ "ActionURL" (Printf "%s/comments/%d/reactions" $.RepoLink .ID)}}
-											{{template "repo/issue/view_content/context_menu" Dict "ctx" $ "item" . "delete" true "issue" true "diff" false "IsCommentPoster" (and $.IsSigned (eq $.SignedUserID .PosterID))}}
+											{{template "repo/issue/view_content/context_menu" Dict "ctx" $ "item" . "delete" false "issue" true "diff" false "IsCommentPoster" (and $.IsSigned (eq $.SignedUserID .PosterID))}}
 									{{end}}
 							</div>
 						</div>


### PR DESCRIPTION
Fix #23031.

Currently, only comments with type `CommentTypeComment` or `CommentTypeCode` can be deleted. If user create a review comment, the type of the comment will be `CommentTypeReview` so the comment cannot be deleted.

https://github.com/go-gitea/gitea/blob/e7be610d5773e69abbfb98d19e23112dfad6dfcc/routers/web/repo/issue.go#L2860-L2868

And in Github, user also cannot delete a review comment. There isn't a delete button in the menu.

<img src="https://user-images.githubusercontent.com/15528715/220275166-5ae2dc10-4003-4857-b14e-d7b02644345f.png" width="640px" />

So we should remove the delete button from the menu when the comment's type is `CommentTypeReview`.



