### PR TITLE
Display project's name in pages which are related to issues by using project.Name instead of project.Title 

### DIFF
--- a/models/issues/issue_list.go
+++ b/models/issues/issue_list.go
@@ -229,6 +229,15 @@ func (issues IssueList) loadMilestones(ctx context.Context) error {
 	return nil
 }
 
+func (issues IssueList) GetProjects() (pl project_model.ProjectList) {
+	for _, issue := range issues {
+		if issue.Project != nil {
+			pl = append(pl, issue.Project)
+		}
+	}
+	return pl
+}
+
 func (issues IssueList) getProjectIDs() []int64 {
 	ids := make(container.Set[int64], len(issues))
 	for _, issue := range issues {

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -36,7 +36,7 @@ type (
 	Type uint8
 
 	// ProjectList defines a list of projects
-	ProjectList []*Project
+	ProjectList []*Project //nolint
 )
 
 const (

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -144,6 +144,25 @@ func (p *Project) Link() string {
 	return ""
 }
 
+// Name return the project's name which is combined with owner/repo/project's name
+func (p *Project) Name() string {
+	if p.OwnerID > 0 {
+		if err := p.LoadOwner(db.DefaultContext); err != nil {
+			log.Error("LoadOwner: %v", err)
+			return ""
+		}
+		return fmt.Sprintf("%s/-/%s", p.Owner.Name, p.Title)
+	}
+	if p.RepoID > 0 {
+		if err := p.LoadRepo(db.DefaultContext); err != nil {
+			log.Error("LoadRepo: %v", err)
+			return ""
+		}
+		return fmt.Sprintf("%s/%s/%s", p.Repo.OwnerName, p.Repo.Name, p.Title)
+	}
+	return ""
+}
+
 func (p *Project) IsOrganizationProject() bool {
 	return p.Type == TypeOrganization
 }

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -200,20 +200,16 @@ func IsTypeValid(p Type) bool {
 
 // SearchOptions are options for GetProjects
 type SearchOptions struct {
-	ProjectID int64
-	OwnerID   int64
-	RepoID    int64
-	Page      int
-	IsClosed  util.OptionalBool
-	SortType  string
-	Type      Type
+	OwnerID  int64
+	RepoID   int64
+	Page     int
+	IsClosed util.OptionalBool
+	SortType string
+	Type     Type
 }
 
 func (opts *SearchOptions) toConds() builder.Cond {
 	cond := builder.NewCond()
-	if opts.ProjectID > 0 {
-		cond = cond.And(builder.Eq{"project.id": opts.ProjectID})
-	}
 	if opts.RepoID > 0 {
 		cond = cond.And(builder.Eq{"project.repo_id": opts.RepoID})
 	}

--- a/models/user/list.go
+++ b/models/user/list.go
@@ -81,3 +81,9 @@ func GetUsersByIDs(ids []int64) (UserList, error) {
 		Find(&ous)
 	return ous, err
 }
+
+// GetUsersMapByIDs returns all resolved users from a list of Ids.
+func GetUsersMapByIDs(ids []int64) (map[int64]*User, error) {
+	usm := make(map[int64]*User, len(ids))
+	return usm, db.GetEngine(db.DefaultContext).In("id", ids).Find(&usm)
+}

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -485,51 +485,51 @@ func RetrieveRepoMilestonesAndAssignees(ctx *context.Context, repo *repo_model.R
 
 func retrieveProjects(ctx *context.Context, repo *repo_model.Repository) {
 	var err error
-	projects, _, err := project_model.FindProjects(ctx, project_model.SearchOptions{
+	ptdl, _, err := project_model.GetProjectsTmplData(ctx, project_model.SearchOptions{
 		RepoID:   repo.ID,
 		Page:     -1,
 		IsClosed: util.OptionalBoolFalse,
 		Type:     project_model.TypeRepository,
 	})
 	if err != nil {
-		ctx.ServerError("GetProjects", err)
+		ctx.ServerError("GetProjectsTmplData", err)
 		return
 	}
-	projects2, _, err := project_model.FindProjects(ctx, project_model.SearchOptions{
+	ptdl2, _, err := project_model.GetProjectsTmplData(ctx, project_model.SearchOptions{
 		OwnerID:  repo.OwnerID,
 		Page:     -1,
 		IsClosed: util.OptionalBoolFalse,
 		Type:     project_model.TypeOrganization,
 	})
 	if err != nil {
-		ctx.ServerError("GetProjects", err)
+		ctx.ServerError("GetProjectsTmplData", err)
 		return
 	}
 
-	ctx.Data["OpenProjects"] = append(projects, projects2...)
+	ctx.Data["OpenProjectsTmplData"] = append(ptdl, ptdl2...)
 
-	projects, _, err = project_model.FindProjects(ctx, project_model.SearchOptions{
+	ptdl, _, err = project_model.GetProjectsTmplData(ctx, project_model.SearchOptions{
 		RepoID:   repo.ID,
 		Page:     -1,
 		IsClosed: util.OptionalBoolTrue,
 		Type:     project_model.TypeRepository,
 	})
 	if err != nil {
-		ctx.ServerError("GetProjects", err)
+		ctx.ServerError("GetProjectsTmplData", err)
 		return
 	}
-	projects2, _, err = project_model.FindProjects(ctx, project_model.SearchOptions{
+	ptdl2, _, err = project_model.GetProjectsTmplData(ctx, project_model.SearchOptions{
 		OwnerID:  repo.OwnerID,
 		Page:     -1,
 		IsClosed: util.OptionalBoolTrue,
 		Type:     project_model.TypeOrganization,
 	})
 	if err != nil {
-		ctx.ServerError("GetProjects", err)
+		ctx.ServerError("GetProjectsTmplData", err)
 		return
 	}
 
-	ctx.Data["ClosedProjects"] = append(projects, projects2...)
+	ctx.Data["ClosedProjectsTmplData"] = append(ptdl, ptdl2...)
 }
 
 // repoReviewerSelection items to bee shown

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -18,6 +18,7 @@ import (
 	"code.gitea.io/gitea/models/db"
 	issues_model "code.gitea.io/gitea/models/issues"
 	"code.gitea.io/gitea/models/organization"
+	project_model "code.gitea.io/gitea/models/project"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
@@ -608,6 +609,13 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 	ctx.Data["IssueRefEndNames"], ctx.Data["IssueRefURLs"] = issue_service.GetRefEndNamesAndURLs(issues, ctx.FormString("RepoLink"))
 
 	ctx.Data["Issues"] = issues
+
+	projects := issues_model.IssueList(issues).GetProjects()
+	ctx.Data["ProjectTmplData"], err = project_model.GetProjectTmplData(projects)
+	if err != nil {
+		ctx.ServerError("GetProjectTmplData", err)
+		return
+	}
 
 	approvalCounts, err := issues_model.IssueList(issues).GetApprovalCounts(ctx)
 	if err != nil {

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -249,7 +249,7 @@
 							</div>
 							{{range .Milestones}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/milestone">
-									{{$.ProjectTmplData.RenderFullTitle .}}
+									{{.Name}}
 								</div>
 							{{end}}
 						</div>

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -81,7 +81,7 @@
 					</div>
 
 					<!-- Project -->
-					<div class="ui{{if not (or .OpenProjectsTmplData .ClosedProjectsTmplData)}} disabled{{end}} dropdown jump item">
+					<div class="ui{{if not (or .OpenProjects .ClosedProjects)}} disabled{{end}} dropdown jump item">
 						<span class="text">
 							{{.locale.Tr "repo.issues.filter_project"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -93,27 +93,27 @@
 							</div>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">{{.locale.Tr "repo.issues.filter_project_all"}}</a>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&project=-1&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">{{.locale.Tr "repo.issues.filter_project_none"}}</a>
-							{{if .OpenProjectsTmplData}}
+							{{if .OpenProjects}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.open_projects"}}
 								</div>
-								{{range .OpenProjectsTmplData}}
-									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.Project.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
-										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.GetFullTitle}}
+								{{range .OpenProjects}}
+									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
+										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{$.ProjectTmplData.RenderFullTitle .}}
 									</a>
 								{{end}}
 							{{end}}
-							{{if .ClosedProjectsTmplData}}
+							{{if .ClosedProjects}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.closed_projects"}}
 								</div>
-								{{range .ClosedProjectsTmplData}}
-									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.Project.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
-										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.GetFullTitle}}
+								{{range .ClosedProjects}}
+									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
+										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{$.ProjectTmplData.RenderFullTitle .}}
 									</a>
 								{{end}}
 							{{end}}
@@ -249,14 +249,14 @@
 							</div>
 							{{range .Milestones}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/milestone">
-									{{.GetFullTitle}}
+									{{$.ProjectTmplData.RenderFullTitle .}}
 								</div>
 							{{end}}
 						</div>
 					</div>
 
 					<!-- Projects -->
-					<div class="ui{{if not (or .OpenProjectsTmplData .ClosedProjectsTmplData)}} disabled{{end}} dropdown jump item">
+					<div class="ui{{if not (or .OpenProjects .ClosedProjects)}} disabled{{end}} dropdown jump item">
 						<span class="text">
 							{{.locale.Tr "repo.project_board"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -265,27 +265,27 @@
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/projects">
 							{{.locale.Tr "repo.issues.new.clear_projects"}}
 							</div>
-							{{if .OpenProjectsTmplData}}
+							{{if .OpenProjects}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.open_projects"}}
 								</div>
-								{{range .OpenProjectsTmplData}}
-									<div class="item issue-action" data-element-id="{{.Project.ID}}" data-url="{{$.RepoLink}}/issues/projects">
-										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.GetFullTitle}}
+								{{range .OpenProjects}}
+									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
+										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{$.ProjectTmplData.RenderFullTitle .}}
 									</div>
 								{{end}}
 							{{end}}
-							{{if .ClosedProjectsTmplData}}
+							{{if .ClosedProjects}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.closed_projects"}}
 								</div>
-								{{range .ClosedProjectsTmplData}}
-									<div class="item issue-action" data-element-id="{{.Project.ID}}" data-url="{{$.RepoLink}}/issues/projects">
-										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.GetFullTitle}}
+								{{range .ClosedProjects}}
+									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
+										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{$.ProjectTmplData.RenderFullTitle .}}
 									</div>
 								{{end}}
 							{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -101,7 +101,7 @@
 								{{range .OpenProjects}}
 									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
 										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Title}}
+										{{.Name}}
 									</a>
 								{{end}}
 							{{end}}
@@ -113,7 +113,7 @@
 								{{range .ClosedProjects}}
 									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
 										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Title}}
+										{{.Name}}
 									</a>
 								{{end}}
 							{{end}}
@@ -273,7 +273,7 @@
 								{{range .OpenProjects}}
 									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
 										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Title}}
+										{{.Name}}
 									</div>
 								{{end}}
 							{{end}}
@@ -285,7 +285,7 @@
 								{{range .ClosedProjects}}
 									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
 										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Title}}
+										{{.Name}}
 									</div>
 								{{end}}
 							{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -81,7 +81,7 @@
 					</div>
 
 					<!-- Project -->
-					<div class="ui{{if not (or .OpenProjects .ClosedProjects)}} disabled{{end}} dropdown jump item">
+					<div class="ui{{if not (or .OpenProjectsTmplData .ClosedProjectsTmplData)}} disabled{{end}} dropdown jump item">
 						<span class="text">
 							{{.locale.Tr "repo.issues.filter_project"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -93,27 +93,27 @@
 							</div>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">{{.locale.Tr "repo.issues.filter_project_all"}}</a>
 							<a class="item" href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.SelectLabels}}&project=-1&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">{{.locale.Tr "repo.issues.filter_project_none"}}</a>
-							{{if .OpenProjects}}
+							{{if .OpenProjectsTmplData}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.open_projects"}}
 								</div>
-								{{range .OpenProjects}}
-									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
-										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Name}}
+								{{range .OpenProjectsTmplData}}
+									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.Project.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
+										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{.GetFullTitle}}
 									</a>
 								{{end}}
 							{{end}}
-							{{if .ClosedProjects}}
+							{{if .ClosedProjectsTmplData}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.closed_projects"}}
 								</div>
-								{{range .ClosedProjects}}
-									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
-										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Name}}
+								{{range .ClosedProjectsTmplData}}
+									<a class="{{if $.ProjectID}}{{if eq $.ProjectID .ID}}active selected{{end}}{{end}} item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{$.SelectLabels}}&milestone={{$.MilestoneID}}&project={{.Project.ID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}">
+										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{.GetFullTitle}}
 									</a>
 								{{end}}
 							{{end}}
@@ -249,14 +249,14 @@
 							</div>
 							{{range .Milestones}}
 								<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/milestone">
-									{{.Name}}
+									{{.GetFullTitle}}
 								</div>
 							{{end}}
 						</div>
 					</div>
 
 					<!-- Projects -->
-					<div class="ui{{if not (or .OpenProjects .ClosedProjects)}} disabled{{end}} dropdown jump item">
+					<div class="ui{{if not (or .OpenProjectsTmplData .ClosedProjectsTmplData)}} disabled{{end}} dropdown jump item">
 						<span class="text">
 							{{.locale.Tr "repo.project_board"}}
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
@@ -265,27 +265,27 @@
 							<div class="item issue-action" data-element-id="0" data-url="{{$.Link}}/projects">
 							{{.locale.Tr "repo.issues.new.clear_projects"}}
 							</div>
-							{{if .OpenProjects}}
+							{{if .OpenProjectsTmplData}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.open_projects"}}
 								</div>
-								{{range .OpenProjects}}
-									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
-										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Name}}
+								{{range .OpenProjectsTmplData}}
+									<div class="item issue-action" data-element-id="{{.Project.ID}}" data-url="{{$.RepoLink}}/issues/projects">
+										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{.GetFullTitle}}
 									</div>
 								{{end}}
 							{{end}}
-							{{if .ClosedProjects}}
+							{{if .ClosedProjectsTmplData}}
 								<div class="divider"></div>
 								<div class="header">
 									{{.locale.Tr "repo.issues.new.closed_projects"}}
 								</div>
-								{{range .ClosedProjects}}
-									<div class="item issue-action" data-element-id="{{.ID}}" data-url="{{$.RepoLink}}/issues/projects">
-										{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-										{{.Name}}
+								{{range .ClosedProjectsTmplData}}
+									<div class="item issue-action" data-element-id="{{.Project.ID}}" data-url="{{$.RepoLink}}/issues/projects">
+										{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+										{{.GetFullTitle}}
 									</div>
 								{{end}}
 							{{end}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -158,39 +158,39 @@
 				</span>
 				<div class="menu">
 					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_project_title"}}</div>
-					{{if or .OpenProjects .ClosedProjects}}
+					{{if or .OpenProjectsTmplData .ClosedProjectsTmplData}}
 					<div class="ui icon search input">
 						<i class="icon gt-df gt-ac gt-jc">{{svg "octicon-search" 16}}</i>
 						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_projects"}}">
 					</div>
 					{{end}}
 					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
-					{{if and (not .OpenProjects) (not .ClosedProjects)}}
+					{{if and (not .OpenProjectsTmplData) (not .ClosedProjectsTmplData)}}
 						<div class="header" style="text-transform: none;font-size:14px;">
 							{{.locale.Tr "repo.issues.new.no_items"}}
 						</div>
 					{{else}}
-						{{if .OpenProjects}}
+						{{if .OpenProjectsTmplData}}
 							<div class="divider"></div>
 							<div class="header">
 								{{.locale.Tr "repo.issues.new.open_projects"}}
 							</div>
-							{{range .OpenProjects}}
-								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
+							{{range .OpenProjectsTmplData}}
+								<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{$.RepoLink}}/projects/{{.Project.ID}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.Name}}
+									{{.GetFullTitle}}
 								</a>
 							{{end}}
 						{{end}}
-						{{if .ClosedProjects}}
+						{{if .ClosedProjectsTmplData}}
 							<div class="divider"></div>
 							<div class="header">
 								{{.locale.Tr "repo.issues.new.closed_projects"}}
 							</div>
-							{{range .ClosedProjects}}
-								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
+							{{range .ClosedProjectsTmplData}}
+								<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{$.RepoLink}}/projects/{{.Project.ID}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.Name}}
+									{{.GetFullTitle}}
 								</a>
 							{{end}}
 						{{end}}
@@ -203,7 +203,7 @@
 					{{if .Project}}
 						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/projects/{{.Project.ID}}">
 							{{svg "octicon-project" 18 "gt-mr-3"}}
-							{{.Project.Name}}
+							{{.Project.Title}}
 						</a>
 					{{end}}
 				</div>

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -158,39 +158,39 @@
 				</span>
 				<div class="menu">
 					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_project_title"}}</div>
-					{{if or .OpenProjectsTmplData .ClosedProjectsTmplData}}
+					{{if or .OpenProjects .ClosedProjects}}
 					<div class="ui icon search input">
 						<i class="icon gt-df gt-ac gt-jc">{{svg "octicon-search" 16}}</i>
 						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_projects"}}">
 					</div>
 					{{end}}
 					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
-					{{if and (not .OpenProjectsTmplData) (not .ClosedProjectsTmplData)}}
+					{{if and (not .OpenProjects) (not .ClosedProjects)}}
 						<div class="header" style="text-transform: none;font-size:14px;">
 							{{.locale.Tr "repo.issues.new.no_items"}}
 						</div>
 					{{else}}
-						{{if .OpenProjectsTmplData}}
+						{{if .OpenProjects}}
 							<div class="divider"></div>
 							<div class="header">
 								{{.locale.Tr "repo.issues.new.open_projects"}}
 							</div>
-							{{range .OpenProjectsTmplData}}
-								<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{$.RepoLink}}/projects/{{.Project.ID}}">
+							{{range .OpenProjects}}
+								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.Link}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.GetFullTitle}}
+									{{$.ProjectTmplData.RenderFullTitle .}}
 								</a>
 							{{end}}
 						{{end}}
-						{{if .ClosedProjectsTmplData}}
+						{{if .ClosedProjects}}
 							<div class="divider"></div>
 							<div class="header">
 								{{.locale.Tr "repo.issues.new.closed_projects"}}
 							</div>
-							{{range .ClosedProjectsTmplData}}
-								<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{$.RepoLink}}/projects/{{.Project.ID}}">
+							{{range .ClosedProjects}}
+								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.Link}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.GetFullTitle}}
+									{{$.ProjectTmplData.RenderFullTitle .}}
 								</a>
 							{{end}}
 						{{end}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -178,7 +178,7 @@
 							{{range .OpenProjects}}
 								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.Title}}
+									{{.Name}}
 								</a>
 							{{end}}
 						{{end}}
@@ -190,7 +190,7 @@
 							{{range .ClosedProjects}}
 								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
 									{{svg "octicon-project" 18 "gt-mr-3"}}
-									{{.Title}}
+									{{.Name}}
 								</a>
 							{{end}}
 						{{end}}
@@ -203,7 +203,7 @@
 					{{if .Project}}
 						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/projects/{{.Project.ID}}">
 							{{svg "octicon-project" 18 "gt-mr-3"}}
-							{{.Project.Title}}
+							{{.Project.Name}}
 						</a>
 					{{end}}
 				</div>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -720,12 +720,12 @@
 					{{template "shared/user/authorlink" .Poster}}
 					{{if gt .OldProjectID 0}}
 						{{if gt .ProjectID 0}}
-							{{$.locale.Tr "repo.issues.change_project_at" (.OldProject.Title|Escape) (.Project.Title|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.change_project_at" (.OldProject.Name|Escape) (.Project.Name|Escape) $createdStr | Safe}}
 						{{else}}
-							{{$.locale.Tr "repo.issues.remove_project_at" (.OldProject.Title|Escape) $createdStr | Safe}}
+							{{$.locale.Tr "repo.issues.remove_project_at" (.OldProject.Name|Escape) $createdStr | Safe}}
 						{{end}}
 					{{else if gt .ProjectID 0}}
-						{{$.locale.Tr "repo.issues.add_project_at" (.Project.Title|Escape) $createdStr | Safe}}
+						{{$.locale.Tr "repo.issues.add_project_at" (.Project.Name|Escape) $createdStr | Safe}}
 					{{end}}
 				</span>
 			</div>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -240,7 +240,7 @@
 						{{range .OpenProjects}}
 							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
 								{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.Title}}
+								{{.Name}}
 							</a>
 						{{end}}
 					{{end}}
@@ -252,7 +252,7 @@
 						{{range .ClosedProjects}}
 							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
 								{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.Title}}
+								{{.Name}}
 							</a>
 						{{end}}
 					{{end}}
@@ -264,7 +264,7 @@
 					{{if .Issue.ProjectID}}
 						<a class="item muted sidebar-item-link" href="{{.Issue.Project.Link}}">
 							{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-							{{.Issue.Project.Title}}
+							{{.Issue.Project.Name}}
 						</a>
 					{{end}}
 				</div>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -225,34 +225,34 @@
 				</a>
 				<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/projects">
 					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_project_title"}}</div>
-					{{if or .OpenProjects .ClosedProjects}}
+					{{if or .OpenProjectsTmplData .ClosedProjectsTmplData}}
 					<div class="ui icon search input">
 						<i class="icon gt-df gt-ac gt-jc">{{svg "octicon-search" 16}}</i>
 						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_projects"}}">
 					</div>
 					{{end}}
 					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
-					{{if .OpenProjects}}
+					{{if .OpenProjectsTmplData}}
 						<div class="divider"></div>
 						<div class="header">
 							{{.locale.Tr "repo.issues.new.open_projects"}}
 						</div>
-						{{range .OpenProjects}}
-							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
-								{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.Name}}
+						{{range .OpenProjectsTmplData}}
+							<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{.Project.Link}}">
+								{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+								{{.GetFullTitle}}
 							</a>
 						{{end}}
 					{{end}}
-					{{if .ClosedProjects}}
+					{{if .ClosedProjectsTmplData}}
 						<div class="divider"></div>
 						<div class="header">
 							{{.locale.Tr "repo.issues.new.closed_projects"}}
 						</div>
-						{{range .ClosedProjects}}
-							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
-								{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.Name}}
+						{{range .ClosedProjectsTmplData}}
+							<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{.Project.Link}}">
+								{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+								{{.GetFullTitle}}
 							</a>
 						{{end}}
 					{{end}}

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -225,34 +225,34 @@
 				</a>
 				<div class="menu" data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/projects">
 					<div class="header" style="text-transform: none;font-size:16px;">{{.locale.Tr "repo.issues.new.add_project_title"}}</div>
-					{{if or .OpenProjectsTmplData .ClosedProjectsTmplData}}
+					{{if or .OpenProjects .ClosedProjects}}
 					<div class="ui icon search input">
 						<i class="icon gt-df gt-ac gt-jc">{{svg "octicon-search" 16}}</i>
 						<input type="text" placeholder="{{.locale.Tr "repo.issues.filter_projects"}}">
 					</div>
 					{{end}}
 					<div class="no-select item">{{.locale.Tr "repo.issues.new.clear_projects"}}</div>
-					{{if .OpenProjectsTmplData}}
+					{{if .OpenProjects}}
 						<div class="divider"></div>
 						<div class="header">
 							{{.locale.Tr "repo.issues.new.open_projects"}}
 						</div>
-						{{range .OpenProjectsTmplData}}
-							<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{.Project.Link}}">
-								{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.GetFullTitle}}
+						{{range .OpenProjects}}
+							<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
+								{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+								{{$.ProjectTmplData.RenderFullTitle .}}
 							</a>
 						{{end}}
 					{{end}}
-					{{if .ClosedProjectsTmplData}}
+					{{if .ClosedProjects}}
 						<div class="divider"></div>
 						<div class="header">
 							{{.locale.Tr "repo.issues.new.closed_projects"}}
 						</div>
-						{{range .ClosedProjectsTmplData}}
+						{{range .ClosedProjects}}
 							<a class="item muted sidebar-item-link" data-id="{{.Project.ID}}" data-href="{{.Project.Link}}">
 								{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-								{{.GetFullTitle}}
+								{{$.ProjectTmplData.RenderFullTitle .}}
 							</a>
 						{{end}}
 					{{end}}
@@ -263,8 +263,8 @@
 				<div class="selected">
 					{{if .Issue.ProjectID}}
 						<a class="item muted sidebar-item-link" href="{{.Issue.Project.Link}}">
-							{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
-							{{.Issue.Project.Name}}
+							{{if .Issue.Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
+							{{$.ProjectTmplData.RenderFullTitle .Issue.Project}}
 						</a>
 					{{end}}
 				</div>

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -87,8 +87,8 @@
 						</a>
 					{{end}}
 					{{if .Project}}
-						<a class="project" {{if $.RepoLink}}href="{{$.RepoLink}}/projects/{{.Project.ID}}"{{else}}href="{{.Repo.Link}}/projects/{{.Project.ID}}"{{end}}>
-							{{svg "octicon-project" 14 "gt-mr-2"}}{{.Project.Name}}
+						<a class="project" href="{{.Project.Link}}">
+							{{svg "octicon-project" 14 "gt-mr-2"}}{{$.ProjectTmplData.RenderFullTitle .Project}}
 						</a>
 					{{end}}
 					{{if .Ref}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -88,7 +88,7 @@
 					{{end}}
 					{{if .Project}}
 						<a class="project" {{if $.RepoLink}}href="{{$.RepoLink}}/projects/{{.Project.ID}}"{{else}}href="{{.Repo.Link}}/projects/{{.Project.ID}}"{{end}}>
-							{{svg "octicon-project" 14 "gt-mr-2"}}{{.Project.Title}}
+							{{svg "octicon-project" 14 "gt-mr-2"}}{{.Project.Name}}
 						</a>
 					{{end}}
 					{{if .Ref}}


### PR DESCRIPTION
This PR is a part of https://github.com/go-gitea/gitea/pull/22865/

Although we have different icons between repo project and user project,
(in some places they have same icons, I will fix them later)
but it is still hard to know which one is a repo's project if they have the same title.

Before:
![image](https://user-images.githubusercontent.com/18380374/220284056-1eeb7b8e-c8fc-4ee7-ad53-fc8d07e1aae0.png)
After:
![image](https://user-images.githubusercontent.com/18380374/220284426-8c1be38d-e334-4e9e-888d-82fe0e07a9c8.png)

Maybe we can remove `-`?