### PR TITLE
Fix the show/hide methods for string selector

### DIFF
--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -19,7 +19,7 @@ function assertShown(el, expectShown) {
 }
 
 function elementsCall(el, func, ...args) {
-  if (el instanceof String) {
+  if (typeof el === 'string' || el instanceof String) {
     el = document.querySelectorAll(el);
   }
   if (el instanceof Node) {
@@ -34,6 +34,10 @@ function elementsCall(el, func, ...args) {
   }
 }
 
+/**
+ * @param el string (selector), Node, NodeList, HTMLCollection, Array or jQuery
+ * @param force force=true to show or force=false to hide, undefined to toggle
+ */
 function toggleShown(el, force) {
   if (force === true) {
     el.classList.remove('gt-hidden');


### PR DESCRIPTION
At that moment I made a mistake (failed to detect a JS variable type correctly)

Close #23040


Screenshot for the fix:

<details>

![image](https://user-images.githubusercontent.com/2114189/220320341-74673c9f-f3d8-4430-9950-61892ade7aa3.png)

</details>
