### PR TITLE
Return empty url for submodule tree entries

### DIFF
--- a/services/repository/files/tree.go
+++ b/services/repository/files/tree.go
@@ -86,6 +86,9 @@ func GetTreeBySHA(ctx context.Context, repo *repo_model.Repository, gitRepo *git
 			copy(treeURL[copyPos:], entries[e].ID.String())
 			tree.Entries[i].URL = string(treeURL)
 		} else if entries[e].IsSubModule() {
+			// In Github Rest API Version=2022-11-28, if a tree entry is a submodule,
+			// its url will be returned as an empty string.
+			// So the URL will be set to "" here.
 			tree.Entries[i].URL = ""
 		} else {
 			copy(blobURL[copyPos:], entries[e].ID.String())

--- a/services/repository/files/tree.go
+++ b/services/repository/files/tree.go
@@ -85,6 +85,8 @@ func GetTreeBySHA(ctx context.Context, repo *repo_model.Repository, gitRepo *git
 		if entries[e].IsDir() {
 			copy(treeURL[copyPos:], entries[e].ID.String())
 			tree.Entries[i].URL = string(treeURL)
+		} else if entries[e].IsSubModule() {
+			tree.Entries[i].URL = ""
 		} else {
 			copy(blobURL[copyPos:], entries[e].ID.String())
 			tree.Entries[i].URL = string(blobURL)


### PR DESCRIPTION
Close #22614.

Refer to [Github's API](https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#get-a-tree), if a tree entry is a submodule, its url will be an empty string.