### PR TITLE
Display attachments of review comment when comment content is blank (#23035)

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -399,7 +399,7 @@
 						{{end}}
 					</span>
 				</div>
-				{{if .Content}}
+				{{if or .Content .Attachments}}
 				<div class="timeline-item comment" id="{{.HashTag}}">
 					<div class="content comment-container">
 						<div class="ui top attached header comment-header df ac sb">


### PR DESCRIPTION
Backport #23035
