### PR TITLE
NoOp DB Migrations to allow for DB backports

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -463,6 +463,23 @@ var migrations = []Migration{
 	NewMigration("Add exclusive label", v1_19.AddExclusiveLabel),
 
 	// Gitea 1.19.0 ends at v244
+
+	// v244 -> v259
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
+	NewMigration("Noop DB Migration to allow for DB backports", v1_20.NoopDBMigrations),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -19,6 +19,7 @@ import (
 	"code.gitea.io/gitea/models/migrations/v1_17"
 	"code.gitea.io/gitea/models/migrations/v1_18"
 	"code.gitea.io/gitea/models/migrations/v1_19"
+	"code.gitea.io/gitea/models/migrations/v1_20"
 	"code.gitea.io/gitea/models/migrations/v1_6"
 	"code.gitea.io/gitea/models/migrations/v1_7"
 	"code.gitea.io/gitea/models/migrations/v1_8"

--- a/models/migrations/v1_20/v244.go
+++ b/models/migrations/v1_20/v244.go
@@ -1,0 +1,12 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_19 //nolint
+
+import (
+	"xorm.io/xorm"
+)
+
+func NoopDBMigrations(x *xorm.Engine) error {
+	return nil
+}

--- a/models/migrations/v1_20/v244.go
+++ b/models/migrations/v1_20/v244.go
@@ -1,7 +1,7 @@
 // Copyright 2023 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package v1_19 //nolint
+package v1_20 //nolint
 
 import (
 	"xorm.io/xorm"


### PR DESCRIPTION
Due to our migrations table only keeping a count of the highest migration that has been run, this means that PRs with migrations cannot be backported as then the migration count would conflict if the administrator ever tries to upgrade to a newer major release.

The purpose of this PR is to add several (15 in this case) no-op migrations, so that the count would be artificially inflated to allow for migration backports.

Pretend Example:
v1.A - max migration = 100
v1.B - migrations start at 101 + 15 noops
An index is added to a large table in v1.B to improve speed of queries, as there are 15 noops this can become migration 101 in v1.A (as when upgrading to v1.B migration 101 would be skipped)

Note: This has a failure case of when a migration may attempted to be run twice on upgrade (the migration that is backported would have a different number, and so on upgrade it would be attempted to be run again), as well as a few others. There are some good suggestions below on improvements to this PR of tracking all migrations that are run to ensure they aren't run in duplicate, as well as a few others.

Alternative: #10625
