### PR TITLE
Wrap unless-check in docker manifests (#23079)

### DIFF
--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,6 +1,6 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}-rootless
 {{#if build.tags}}
-{{#unless contains "-rc" build.tag}}
+{{#unless (contains "-rc" build.tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}-rootless

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,6 +1,6 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}dev{{/if}}
 {{#if build.tags}}
-{{#unless contains "-rc" build.tag }}
+{{#unless (contains "-rc" build.tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}


### PR DESCRIPTION
Backport #23079

Should fix the following:
> failed to render template: Evaluation error: Helper 'unless' called with wrong number of arguments, needed 2 but got 3

https://go.dev/play/p/h7bt7MWKTcv