### PR TITLE
Nest metadata in refactoring docs

### DIFF
--- a/docs/content/doc/developers/guidelines-refactoring.en-us.md
+++ b/docs/content/doc/developers/guidelines-refactoring.en-us.md
@@ -6,11 +6,11 @@ weight: 20
 toc: false
 draft: false
 menu:
-sidebar:
-parent: "developers"
-name: "Guidelines for Refactoring"
-weight: 20
-identifier: "guidelines-refactoring"
+  sidebar:
+    parent: "developers"
+    name: "Guidelines for Refactoring"
+    weight: 20
+    identifier: "guidelines-refactoring"
 ---
 
 # Guidelines for Refactoring


### PR DESCRIPTION
Whitespace was missing from refactoring docs metadata.

backport label applied so it is included in versioned docs.