### PR TITLE
Fix SyncOnCommit always return false in API of push_mirrors

### DIFF
--- a/services/convert/mirror.go
+++ b/services/convert/mirror.go
@@ -24,6 +24,7 @@ func ToPushMirror(pm *repo_model.PushMirror) (*api.PushMirror, error) {
 		LastUpdateUnix: pm.LastUpdateUnix.FormatLong(),
 		LastError:      pm.LastError,
 		Interval:       pm.Interval.String(),
+		SyncOnCommit:   pm.SyncOnCommit,
 	}, nil
 }
 


### PR DESCRIPTION
Fix: #22990

---
Before, the return value of the api is always false,regrardless of whether the entry of `sync_on_commit` is true or false.
I have confirmed that the value of `sync_on_commit` dropped into the database is correct.
So, I think it is enough to make some small changes.
