### PR TITLE
Add accessibility to the menu on the navbar (#23059)

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -18,9 +18,9 @@
 				</span>
 			</a>
 			{{end}}
-			<div class="ui icon button mobile-only" id="navbar-expand-toggle">
+			<button class="ui icon button mobile-only" id="navbar-expand-toggle">
 				{{svg "octicon-three-bars"}}
-			</div>
+			</button>
 		</div>
 	</div>
 


### PR DESCRIPTION
Backport #23059

This PR is trying to add accessibility to the menu as mentioned in #23053 so the menu can be accessed using keyboard (A quick demo is added below), with a reference to
[PR2612](https://github.com/go-gitea/gitea/pull/22612). The goal is to make the menu accessible merely using keyboard like shown below. And this PR might need confirmation from developers using screen readers.
