### PR TITLE
Avoid Hugo from adding quote to actions url

### DIFF
--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -1336,7 +1336,7 @@ PROXY_HOSTS = *.github.com
 ## Actions (`actions`)
 
 - `ENABLED`: **false**: Enable/Disable actions capabilities
-- `DEFAULT_ACTIONS_URL`: **https://gitea.com**: Default address to get action plugins, e.g. the default value means downloading from "https://gitea.com/actions/checkout" for "uses: actions/checkout@v3"
+- `DEFAULT_ACTIONS_URL`: **https://gitea.com**: Default address to get action plugins, e.g. the default value means downloading from "[https://gitea.com/actions/checkout](https://gitea.com/actions/checkout)" for "uses: actions/checkout@v3"
 
 `DEFAULT_ACTIONS_URL` indicates where should we find the relative path action plugin. i.e. when use an action in a workflow file like
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -1336,7 +1336,7 @@ PROXY_HOSTS = *.github.com
 ## Actions (`actions`)
 
 - `ENABLED`: **false**: Enable/Disable actions capabilities
-- `DEFAULT_ACTIONS_URL`: **https://gitea.com**: Default address to get action plugins, e.g. the default value means downloading from "[https://gitea.com/actions/checkout](https://gitea.com/actions/checkout)" for "uses: actions/checkout@v3"
+- `DEFAULT_ACTIONS_URL`: **https://gitea.com**: Default address to get action plugins, e.g. the default value means downloading from "<https://gitea.com/actions/checkout>" for "uses: actions/checkout@v3"
 
 `DEFAULT_ACTIONS_URL` indicates where should we find the relative path action plugin. i.e. when use an action in a workflow file like
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25549100/220970789-8bad64b9-5f92-447b-887c-8270a4c2212e.png)

Hugo added a `"` to the url, I put it in a url block to avoid this.
