### PR TITLE
Fix nil context in RenderMarkdownToHtml (#23092)

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -174,8 +174,9 @@ func NewFuncMap() []template.FuncMap {
 		"RenderEmojiPlain":               emoji.ReplaceAliases,
 		"ReactionToEmoji":                ReactionToEmoji,
 		"RenderNote":                     RenderNote,
-		"RenderMarkdownToHtml": func(input string) template.HTML {
+		"RenderMarkdownToHtml": func(ctx context.Context, input string) template.HTML {
 			output, err := markdown.RenderString(&markup.RenderContext{
+				Ctx:       ctx,
 				URLPrefix: setting.AppSubURL,
 			}, input)
 			if err != nil {

--- a/templates/package/content/cargo.tmpl
+++ b/templates/package/content/cargo.tmpl
@@ -26,7 +26,7 @@ git-fetch-with-cli = true</code></pre></div>
 	{{if or .PackageDescriptor.Metadata.Description .PackageDescriptor.Metadata.Readme}}
 		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		{{if .PackageDescriptor.Metadata.Description}}<div class="ui attached segment">{{.PackageDescriptor.Metadata.Description}}</div>{{end}}
-		{{if .PackageDescriptor.Metadata.Readme}}<div class="ui attached segment">{{RenderMarkdownToHtml .PackageDescriptor.Metadata.Readme}}</div>{{end}}
+		{{if .PackageDescriptor.Metadata.Readme}}<div class="ui attached segment">{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.Readme}}</div>{{end}}
 	{{end}}
 
 	{{if .PackageDescriptor.Metadata.Dependencies}}

--- a/templates/package/content/chef.tmpl
+++ b/templates/package/content/chef.tmpl
@@ -20,7 +20,7 @@
 		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		<div class="ui attached segment">
 			{{if .PackageDescriptor.Metadata.Description}}<p>{{.PackageDescriptor.Metadata.Description}}</p>{{end}}
-			{{if .PackageDescriptor.Metadata.LongDescription}}{{RenderMarkdownToHtml .PackageDescriptor.Metadata.LongDescription}}{{end}}
+			{{if .PackageDescriptor.Metadata.LongDescription}}{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.LongDescription}}{{end}}
 		</div>
 	{{end}}
 

--- a/templates/package/content/npm.tmpl
+++ b/templates/package/content/npm.tmpl
@@ -25,7 +25,7 @@
 		<div class="ui attached segment">
 			{{if .PackageDescriptor.Metadata.Readme}}
 			<div class="markup markdown">
-				{{RenderMarkdownToHtml .PackageDescriptor.Metadata.Readme}}
+				{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.Readme}}
 			</div>
 			{{else if .PackageDescriptor.Metadata.Description}}
 				{{.PackageDescriptor.Metadata.Description}}

--- a/templates/package/content/pub.tmpl
+++ b/templates/package/content/pub.tmpl
@@ -14,6 +14,6 @@
 	{{if or .PackageDescriptor.Metadata.Description .PackageDescriptor.Metadata.Readme}}
 		<h4 class="ui top attached header">{{.locale.Tr "packages.about"}}</h4>
 		{{if .PackageDescriptor.Metadata.Description}}<div class="ui attached segment">{{.PackageDescriptor.Metadata.Description}}</div>{{end}}
-		{{if .PackageDescriptor.Metadata.Readme}}<div class="ui attached segment">{{RenderMarkdownToHtml .PackageDescriptor.Metadata.Readme}}</div>{{end}}
+		{{if .PackageDescriptor.Metadata.Readme}}<div class="ui attached segment">{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.Readme}}</div>{{end}}
 	{{end}}
 {{end}}

--- a/templates/package/content/pypi.tmpl
+++ b/templates/package/content/pypi.tmpl
@@ -16,9 +16,9 @@
 		<div class="ui attached segment">
 			<p>{{if .PackageDescriptor.Metadata.Summary}}{{.PackageDescriptor.Metadata.Summary}}{{end}}</p>
 			{{if .PackageDescriptor.Metadata.LongDescription}}
-				{{RenderMarkdownToHtml .PackageDescriptor.Metadata.LongDescription}}
+				{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.LongDescription}}
 			{{else if .PackageDescriptor.Metadata.Description}}
-				{{RenderMarkdownToHtml .PackageDescriptor.Metadata.Description}}
+				{{RenderMarkdownToHtml $.Context .PackageDescriptor.Metadata.Description}}
 			{{end}}
 		</div>
 	{{end}}

--- a/templates/repo/issue/comment_tab.tmpl
+++ b/templates/repo/issue/comment_tab.tmpl
@@ -2,15 +2,15 @@
 	<input type="hidden" name="template-file" value="{{.TemplateFile}}">
 	{{range .Fields}}
 		{{if eq .Type "input"}}
-			{{template "repo/issue/fields/input" .}}
+			{{template "repo/issue/fields/input" Dict "Context" $.Context "item" .}}
 		{{else if eq .Type "markdown"}}
-			{{template "repo/issue/fields/markdown" .}}
+			{{template "repo/issue/fields/markdown" Dict "Context" $.Context "item" .}}
 		{{else if eq .Type "textarea"}}
-			{{template "repo/issue/fields/textarea" .}}
+			{{template "repo/issue/fields/textarea" Dict "Context" $.Context "item" .}}
 		{{else if eq .Type "dropdown"}}
-			{{template "repo/issue/fields/dropdown" .}}
+			{{template "repo/issue/fields/dropdown" Dict "Context" $.Context "item" .}}
 		{{else if eq .Type "checkboxes"}}
-			{{template "repo/issue/fields/checkboxes" .}}
+			{{template "repo/issue/fields/checkboxes" Dict "Context" $.Context "item" .}}
 		{{end}}
 	{{end}}
 {{else}}

--- a/templates/repo/issue/fields/checkboxes.tmpl
+++ b/templates/repo/issue/fields/checkboxes.tmpl
@@ -1,7 +1,7 @@
 <div class="field">
 	{{template "repo/issue/fields/header" .}}
 	{{$field := .}}
-	{{range $i, $opt := .Attributes.options}}
+	{{range $i, $opt := .item.Attributes.options}}
 		<div class="field">
 			<div class="ui checkbox">
 				<input type="checkbox" name="form-field-{{$field.ID}}-{{$i}}" {{if $opt.required}}readonly checked{{end}}>

--- a/templates/repo/issue/fields/dropdown.tmpl
+++ b/templates/repo/issue/fields/dropdown.tmpl
@@ -1,12 +1,12 @@
 <div class="field">
 	{{template "repo/issue/fields/header" .}}
 	{{/* FIXME: required validation */}}
-	<div class="ui fluid selection dropdown {{if .Attributes.multiple}}multiple clearable{{end}}">
-		<input type="hidden" name="form-field-{{.ID}}" value="0">
+	<div class="ui fluid selection dropdown {{if .item.Attributes.multiple}}multiple clearable{{end}}">
+		<input type="hidden" name="form-field-{{.item.ID}}" value="0">
 		<i class="dropdown icon"></i>
 		<div class="default text"></div>
 		<div class="menu">
-			{{range $i, $opt := .Attributes.options}}
+			{{range $i, $opt := .item.Attributes.options}}
 				<div class="item" data-value="{{$i}}">{{$opt}}</div>
 			{{end}}
 		</div>

--- a/templates/repo/issue/fields/header.tmpl
+++ b/templates/repo/issue/fields/header.tmpl
@@ -1,6 +1,6 @@
-{{if .Attributes.label}}
-	<h3>{{.Attributes.label}}{{if .Validations.required}}<label class="required"></label>{{end}}</h3>
+{{if .item.Attributes.label}}
+	<h3>{{.item.Attributes.label}}{{if .item.Validations.required}}<label class="required"></label>{{end}}</h3>
 {{end}}
-{{if .Attributes.description}}
-	<span class="help">{{RenderMarkdownToHtml .Attributes.description}}</span>
+{{if .item.Attributes.description}}
+	<span class="help">{{RenderMarkdownToHtml .Context .item.Attributes.description}}</span>
 {{end}}

--- a/templates/repo/issue/fields/input.tmpl
+++ b/templates/repo/issue/fields/input.tmpl
@@ -1,4 +1,4 @@
 <div class="field">
 	{{template "repo/issue/fields/header" .}}
-	<input type="{{if .Validations.is_number}}number{{else}}text{{end}}" name="form-field-{{.ID}}" placeholder="{{.Attributes.placeholder}}" value="{{.Attributes.value}}" {{if .Validations.required}}required{{end}} {{if .Validations.regex}}pattern="{{.Validations.regex}}" title="{{.Validations.regex}}"{{end}}>
+	<input type="{{if .item.Validations.is_number}}number{{else}}text{{end}}" name="form-field-{{.item.ID}}" placeholder="{{.item.Attributes.placeholder}}" value="{{.item.Attributes.value}}" {{if .item.Validations.required}}required{{end}} {{if .item.Validations.regex}}pattern="{{.item.Validations.regex}}" title="{{.item.Validations.regex}}"{{end}}>
 </div>

--- a/templates/repo/issue/fields/markdown.tmpl
+++ b/templates/repo/issue/fields/markdown.tmpl
@@ -1,3 +1,3 @@
 <div class="field">
-	<div>{{RenderMarkdownToHtml .Attributes.value}}</div>
+	<div>{{RenderMarkdownToHtml .Context .item.Attributes.value}}</div>
 </div>

--- a/templates/repo/issue/fields/textarea.tmpl
+++ b/templates/repo/issue/fields/textarea.tmpl
@@ -2,5 +2,5 @@
 	{{template "repo/issue/fields/header" .}}
 	{{/* FIXME: preview markdown result */}}
 	{{/* FIXME: required validation for markdown editor */}}
-	<textarea name="form-field-{{.ID}}" placeholder="{{.Attributes.placeholder}}" class="edit_area {{if .Attributes.render}}no-easymde{{end}}" {{if and .Validations.required .Attributes.render}}required{{end}}>{{.Attributes.value}}</textarea>
+	<textarea name="form-field-{{.item.ID}}" placeholder="{{.item.Attributes.placeholder}}" class="edit_area {{if .item.Attributes.render}}no-easymde{{end}}" {{if and .item.Validations.required .item.Attributes.render}}required{{end}}>{{.item.Attributes.value}}</textarea>
 </div>


### PR DESCRIPTION
Backport #23092

Fix #23082.

This bug is caused by a nil context in https://github.com/go-gitea/gitea/issues/23082#issuecomment-1441276546 .