### PR TITLE
Fix height for sticky head on large screen on PR page

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3271,15 +3271,7 @@ td.blob-excerpt {
     position: sticky;
     top: 77px;
     z-index: 7;
-
-    @media @mediaMd {
-      top: 77px;
-    }
-
-    @media @mediaSm {
-      top: 77px;
-    }
-
+    
     @media (max-width: 480px) {
       position: static;
     }

--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3269,7 +3269,7 @@ td.blob-excerpt {
 .ui.attached.header.diff-file-header {
   &.sticky-2nd-row {
     position: sticky;
-    top: 46px;
+    top: 77px;
     z-index: 7;
 
     @media @mediaMd {


### PR DESCRIPTION
Right now on the PR 'File Change' Tab, the file title header sticky to the top on large screens has wrong height, resulting in wrong ui behavior when scrolling down. This PR is to fix this.

Before:

<img width="964" alt="截屏2023-02-24 17 12 29" src="https://user-images.githubusercontent.com/17645053/221140409-025c4a84-6bbe-4b5b-a13f-bd2b79063522.png">

After:
<img width="1430" alt="截屏2023-02-24 21 10 12" src="https://user-images.githubusercontent.com/17645053/221186750-0344d652-4610-4a90-a4c0-7f6269f950d6.png">



