### PR TITLE
Avoid warning for system setting when start up (#23054)

### DIFF
--- a/models/avatars/avatar.go
+++ b/models/avatars/avatar.go
@@ -153,7 +153,7 @@ func generateEmailAvatarLink(ctx context.Context, email string, size int, final 
 		return DefaultAvatarLink()
 	}
 
-	enableFederatedAvatar := system_model.GetSettingBool(ctx, system_model.KeyPictureEnableFederatedAvatar)
+	enableFederatedAvatar := system_model.GetSettingWithCacheBool(ctx, system_model.KeyPictureEnableFederatedAvatar)
 
 	var err error
 	if enableFederatedAvatar && system_model.LibravatarService != nil {
@@ -174,7 +174,7 @@ func generateEmailAvatarLink(ctx context.Context, email string, size int, final 
 		return urlStr
 	}
 
-	disableGravatar := system_model.GetSettingBool(ctx, system_model.KeyPictureDisableGravatar)
+	disableGravatar := system_model.GetSettingWithCacheBool(ctx, system_model.KeyPictureDisableGravatar)
 	if !disableGravatar {
 		// copy GravatarSourceURL, because we will modify its Path.
 		avatarURLCopy := *system_model.GravatarSourceURL

--- a/models/avatars/avatar_test.go
+++ b/models/avatars/avatar_test.go
@@ -28,7 +28,7 @@ func enableGravatar(t *testing.T) {
 	err := system_model.SetSettingNoVersion(db.DefaultContext, system_model.KeyPictureDisableGravatar, "false")
 	assert.NoError(t, err)
 	setting.GravatarSource = gravatarSource
-	err = system_model.Init()
+	err = system_model.Init(db.DefaultContext)
 	assert.NoError(t, err)
 }
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -39,9 +39,9 @@ import (
 var ItemsPerPage = 40
 
 // Init initialize model
-func Init() error {
+func Init(ctx context.Context) error {
 	unit.LoadUnitConfig()
-	return system_model.Init()
+	return system_model.Init(ctx)
 }
 
 // DeleteRepository deletes a repository for a user or organization.

--- a/models/system/setting_test.go
+++ b/models/system/setting_test.go
@@ -40,10 +40,10 @@ func TestSettings(t *testing.T) {
 
 	value, err := system.GetSetting(db.DefaultContext, keyName)
 	assert.NoError(t, err)
-	assert.EqualValues(t, updatedSetting.SettingValue, value)
+	assert.EqualValues(t, updatedSetting.SettingValue, value.SettingValue)
 
 	// get all settings
-	settings, err = system.GetAllSettings()
+	settings, err = system.GetAllSettings(db.DefaultContext)
 	assert.NoError(t, err)
 	assert.Len(t, settings, 3)
 	assert.EqualValues(t, updatedSetting.SettingValue, settings[strings.ToLower(updatedSetting.SettingKey)].SettingValue)
@@ -51,7 +51,7 @@ func TestSettings(t *testing.T) {
 	// delete setting
 	err = system.DeleteSetting(db.DefaultContext, &system.Setting{SettingKey: strings.ToLower(keyName)})
 	assert.NoError(t, err)
-	settings, err = system.GetAllSettings()
+	settings, err = system.GetAllSettings(db.DefaultContext)
 	assert.NoError(t, err)
 	assert.Len(t, settings, 2)
 }

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -113,7 +113,7 @@ func MainTest(m *testing.M, testOpts *TestOptions) {
 	if err = storage.Init(); err != nil {
 		fatalTestError("storage.Init: %v\n", err)
 	}
-	if err = system_model.Init(); err != nil {
+	if err = system_model.Init(db.DefaultContext); err != nil {
 		fatalTestError("models.Init: %v\n", err)
 	}
 

--- a/models/user/avatar.go
+++ b/models/user/avatar.go
@@ -67,7 +67,7 @@ func (u *User) AvatarLinkWithSize(ctx context.Context, size int) string {
 	useLocalAvatar := false
 	autoGenerateAvatar := false
 
-	disableGravatar := system_model.GetSettingBool(ctx, system_model.KeyPictureDisableGravatar)
+	disableGravatar := system_model.GetSettingWithCacheBool(ctx, system_model.KeyPictureDisableGravatar)
 
 	switch {
 	case u.UseCustomAvatar:

--- a/modules/repository/commits_test.go
+++ b/modules/repository/commits_test.go
@@ -106,7 +106,7 @@ func enableGravatar(t *testing.T) {
 	err := system_model.SetSettingNoVersion(db.DefaultContext, system_model.KeyPictureDisableGravatar, "false")
 	assert.NoError(t, err)
 	setting.GravatarSource = "https://secure.gravatar.com/avatar"
-	err = system_model.Init()
+	err = system_model.Init(db.DefaultContext)
 	assert.NoError(t, err)
 }
 

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -92,7 +92,7 @@ func NewFuncMap() []template.FuncMap {
 			return setting.AssetVersion
 		},
 		"DisableGravatar": func(ctx context.Context) bool {
-			return system_model.GetSettingBool(ctx, system_model.KeyPictureDisableGravatar)
+			return system_model.GetSettingWithCacheBool(ctx, system_model.KeyPictureDisableGravatar)
 		},
 		"DefaultShowFullName": func() bool {
 			return setting.UI.DefaultShowFullName

--- a/routers/init.go
+++ b/routers/init.go
@@ -150,7 +150,7 @@ func GlobalInitInstalled(ctx context.Context) {
 	mustInit(system.Init)
 	mustInit(oauth2.Init)
 
-	mustInit(models.Init)
+	mustInitCtx(ctx, models.Init)
 	mustInit(repo_service.Init)
 
 	// Booting long running goroutines.

--- a/routers/web/admin/config.go
+++ b/routers/web/admin/config.go
@@ -103,7 +103,7 @@ func Config(ctx *context.Context) {
 	ctx.Data["PageIsAdmin"] = true
 	ctx.Data["PageIsAdminConfig"] = true
 
-	systemSettings, err := system_model.GetAllSettings()
+	systemSettings, err := system_model.GetAllSettings(ctx)
 	if err != nil {
 		ctx.ServerError("system_model.GetAllSettings", err)
 		return


### PR DESCRIPTION
Backport #23054

Partially fix #23050

After #22294 merged, it always has a warning log like `cannot get context cache` when starting up. This should not affect any real life but it's annoying. This PR will fix the problem. That means when starting up, getting the system settings will not try from the cache but will read from the database directly.

