### PR TITLE
Change style to improve whitespaces trimming inside inline markdown code (#23093)

### DIFF
--- a/web_src/less/markup/content.less
+++ b/web_src/less/markup/content.less
@@ -415,6 +415,7 @@
     padding: .2em .4em;
     margin: 0;
     font-size: 85%;
+    white-space: break-spaces;
     background-color: var(--color-markup-code-block);
     border-radius: 4px;
   }


### PR DESCRIPTION
Backport #23093 to 1.19.

Given mardown source
```
x ` a` y
x `a ` y
x ` a ` y
```

Render

<img width="1421" alt="2023-02-23 15 33 14"
src="https://user-images.githubusercontent.com/17645053/220844280-a304c788-ac79-4a26-a55a-0db00f2fb3f3.png">

Fixes #23080.