### PR TITLE
Show empty repos in Admin Repository Management page (#23114)

### DIFF
--- a/routers/web/admin/repos.go
+++ b/routers/web/admin/repos.go
@@ -34,9 +34,10 @@ func Repos(ctx *context.Context) {
 	ctx.Data["PageIsAdminRepositories"] = true
 
 	explore.RenderRepoSearch(ctx, &explore.RepoSearchOptions{
-		Private:  true,
-		PageSize: setting.UI.Admin.RepoPagingNum,
-		TplName:  tplRepos,
+		Private:          true,
+		PageSize:         setting.UI.Admin.RepoPagingNum,
+		TplName:          tplRepos,
+		OnlyShowRelevant: false,
 	})
 }
 

--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -23,14 +23,17 @@ const (
 
 // RepoSearchOptions when calling search repositories
 type RepoSearchOptions struct {
-	OwnerID    int64
-	Private    bool
-	Restricted bool
-	PageSize   int
-	TplName    base.TplName
+	OwnerID          int64
+	Private          bool
+	Restricted       bool
+	PageSize         int
+	OnlyShowRelevant bool
+	TplName          base.TplName
 }
 
 // RenderRepoSearch render repositories search page
+// This function is also used to render the Admin Repository Management page.
+// The isAdmin param should be set to true when rendering the Admin page.
 func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	// Sitemap index for sitemap paths
 	page := int(ctx.ParamsInt64("idx"))
@@ -48,11 +51,10 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	}
 
 	var (
-		repos            []*repo_model.Repository
-		count            int64
-		err              error
-		orderBy          db.SearchOrderBy
-		onlyShowRelevant bool
+		repos   []*repo_model.Repository
+		count   int64
+		err     error
+		orderBy db.SearchOrderBy
 	)
 
 	ctx.Data["SortType"] = ctx.FormString("sort")
@@ -90,7 +92,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		onlyShowRelevant = false
 	}
 
-	ctx.Data["OnlyShowRelevant"] = onlyShowRelevant
+	ctx.Data["OnlyShowRelevant"] = opts.OnlyShowRelevant
 
 	topicOnly := ctx.FormBool("topic")
 	ctx.Data["TopicOnly"] = topicOnly
@@ -113,7 +115,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 		TopicOnly:          topicOnly,
 		Language:           language,
 		IncludeDescription: setting.UI.SearchRepoDescription,
-		OnlyShowRelevant:   onlyShowRelevant,
+		OnlyShowRelevant:   opts.OnlyShowRelevant,
 	})
 	if err != nil {
 		ctx.ServerError("SearchRepository", err)
@@ -160,9 +162,10 @@ func Repos(ctx *context.Context) {
 	}
 
 	RenderRepoSearch(ctx, &RepoSearchOptions{
-		PageSize: setting.UI.ExplorePagingNum,
-		OwnerID:  ownerID,
-		Private:  ctx.Doer != nil,
-		TplName:  tplExploreRepos,
+		PageSize:         setting.UI.ExplorePagingNum,
+		OwnerID:          ownerID,
+		Private:          ctx.Doer != nil,
+		TplName:          tplExploreRepos,
+		OnlyShowRelevant: !ctx.FormBool(relevantReposOnlyParam),
 	})
 }


### PR DESCRIPTION
Backport #23114

The **Admin Repository Management** page and the **Explore Repository** page both use the `RenderRepoSearch` function. In this function, the `OnlyShowRelevant` search option is `true` when querying repositories for admin page.

https://github.com/go-gitea/gitea/blob/edf98a2dc30956c8e04b778bb7f1ce55c14ba963/routers/web/explore/repo.go#L99-L115

Refer to [#19361](https://github.com/go-gitea/gitea/pull/19361/files#diff-8058dfb85557010e0592d586675ec62ce406af7068e6311f39c160deac37f149R497), the repositories with `is_empty=true` will be hidden if `OnlyShowRelevant` is `true`.

Administrators should be able to see all repositories. So `OnlyShowRelevant` shouldn't be set to `true` .