### PR TITLE
Fix DBConsistency checks on MSSQL

### DIFF
--- a/models/issues/label.go
+++ b/models/issues/label.go
@@ -778,7 +778,7 @@ func CountOrphanedLabels(ctx context.Context) (int64, error) {
 	norepo, err := db.GetEngine(ctx).Table("label").
 		Where(builder.And(
 			builder.Gt{"repo_id": 0},
-			builder.NotIn("repo_id", builder.Select("id").From("repository")),
+			builder.NotIn("repo_id", builder.Select("id").From("`repository`")),
 		)).
 		Count()
 	if err != nil {
@@ -788,7 +788,7 @@ func CountOrphanedLabels(ctx context.Context) (int64, error) {
 	noorg, err := db.GetEngine(ctx).Table("label").
 		Where(builder.And(
 			builder.Gt{"org_id": 0},
-			builder.NotIn("org_id", builder.Select("id").From("user")),
+			builder.NotIn("org_id", builder.Select("id").From("`user`")),
 		)).
 		Count()
 	if err != nil {
@@ -809,7 +809,7 @@ func DeleteOrphanedLabels(ctx context.Context) error {
 	if _, err := db.GetEngine(ctx).
 		Where(builder.And(
 			builder.Gt{"repo_id": 0},
-			builder.NotIn("repo_id", builder.Select("id").From("repository")),
+			builder.NotIn("repo_id", builder.Select("id").From("`repository`")),
 		)).
 		Delete(Label{}); err != nil {
 		return err
@@ -819,7 +819,7 @@ func DeleteOrphanedLabels(ctx context.Context) error {
 	if _, err := db.GetEngine(ctx).
 		Where(builder.And(
 			builder.Gt{"org_id": 0},
-			builder.NotIn("org_id", builder.Select("id").From("user")),
+			builder.NotIn("org_id", builder.Select("id").From("`user`")),
 		)).
 		Delete(Label{}); err != nil {
 		return err


### PR DESCRIPTION
Unfortunately xorm's `builder.Select(...).From(...)` does not escape the table names. This is mostly not a problem but is a problem with the `user` table.

This PR simply escapes the user table. No other uses of `From("user")` where found in the codebase so I think this should be all that is needed.

Fix #23064
