### PR TITLE
Fix secrets overview page missing from docs sidebar (#23143)

### DIFF
--- a/docs/content/doc/packages/overview.en-us.md
+++ b/docs/content/doc/packages/overview.en-us.md
@@ -9,7 +9,7 @@ menu:
     parent: "packages"
     name: "Overview"
     weight: 1
-    identifier: "overview"
+    identifier: "packages-overview"
 ---
 
 # Package Registry

--- a/docs/content/doc/secrets/overview.en-us.md
+++ b/docs/content/doc/secrets/overview.en-us.md
@@ -9,7 +9,7 @@ menu:
     parent: "secrets"
     name: "Overview"
     weight: 1
-    identifier: "overview"
+    identifier: "secrets-overview"
 ---
 
 # Secrets


### PR DESCRIPTION
Backport #23143

There was a warning while building the docs: `Building sites … WARN 2023/02/25 08:56:37 "/workspace/gitea/docs/content/doc/secrets/overview.en-us.md:1:1": duplicate menu entry with identifier "overview" in menu "sidebar"`.

### Before
![image](https://user-images.githubusercontent.com/20454870/221348741-55cef254-f2ac-4507-9a66-818b406c668f.png)

### After
![image](https://user-images.githubusercontent.com/20454870/221348757-42066303-e1b7-43fe-9c4f-e05182fbabdd.png)
