### PR TITLE
Return 404 instead of 403 if user can not access the repo (#23155)

### DIFF
--- a/routers/web/repo/http.go
+++ b/routers/web/repo/http.go
@@ -228,7 +228,7 @@ func httpBase(ctx *context.Context) (h *serviceHandler) {
 				}
 
 				if !p.CanAccess(accessMode, unitType) {
-					ctx.PlainText(http.StatusForbidden, "User permission denied")
+					ctx.PlainText(http.StatusNotFound, "Repository not found")
 					return
 				}
 			}


### PR DESCRIPTION
Backport #23155

Fixes https://github.com/go-gitea/gitea/issues/23150

Before:
![image](https://user-images.githubusercontent.com/18380374/221390802-2317c6bc-d163-4def-b68b-6bb297143fe2.png)

After:
![image](https://user-images.githubusercontent.com/18380374/221390823-87490351-39c3-4a40-b1d2-11fc5b85fa24.png)