### PR TITLE
Double slash in URL makes git clone fail

### DIFF
--- a/routers/common/middleware.go
+++ b/routers/common/middleware.go
@@ -60,7 +60,6 @@ func Middlewares() []func(http.Handler) http.Handler {
 			} else {
 				path = req.URL.Path
 			}
-			fmt.Println(strings.HasPrefix(path, "//"))
 			if len(path) > 1 && strings.HasPrefix(path, "//") {
 				newPath := path[1:]
 				if rctx == nil {

--- a/routers/common/middleware.go
+++ b/routers/common/middleware.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
 	"net/http"
 	"strings"
 
@@ -17,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/web/routing"
 
 	"github.com/chi-middleware/proxy"
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
 


### PR DESCRIPTION
Allow urls prefixes with double slashes be valid

e.g. `http://localhost:3000//stuzer05/test_rights.git`

Closes #20462
