### PR TITLE
Remove useless comment in #23114 (#23173)

### DIFF
--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -33,7 +33,6 @@ type RepoSearchOptions struct {
 
 // RenderRepoSearch render repositories search page
 // This function is also used to render the Admin Repository Management page.
-// The isAdmin param should be set to true when rendering the Admin page.
 func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	// Sitemap index for sitemap paths
 	page := int(ctx.ParamsInt64("idx"))


### PR DESCRIPTION
Backport #23173

The `isAdmin` param is no longer used so the comment should be removed.

https://github.com/go-gitea/gitea/blob/d27d36f2f4dd389050e613967ad2a5d02d250acc/routers/web/explore/repo.go#L36-L37