### PR TITLE
Add word-break to sidebar-item-link (#23146)

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -3210,8 +3210,8 @@ td.blob-excerpt {
 }
 
 .sidebar-item-link {
-  display: inline-flex;
   align-items: center;
+  word-break: break-all;
 }
 
 .diff-file-box[data-folded="true"] .diff-file-body {


### PR DESCRIPTION
Backport #23146

Fixes https://github.com/go-gitea/gitea/issues/22953
![image](https://user-images.githubusercontent.com/18380374/221351117-1e4b8922-04ca-4717-8e3b-c338a61bc062.png)
