### PR TITLE
Avoid too long names for actions (#23162)

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -194,6 +194,7 @@ func InsertRun(ctx context.Context, run *ActionRun, jobs []*jobparser.SingleWork
 		if len(needs) > 0 {
 			status = StatusBlocked
 		}
+		job.Name, _ = util.SplitStringAtByteN(job.Name, 255)
 		runJobs = append(runJobs, &ActionRunJob{
 			RunID:             run.ID,
 			RepoID:            run.RepoID,

--- a/models/actions/task.go
+++ b/models/actions/task.go
@@ -298,8 +298,9 @@ func CreateTaskForRunner(ctx context.Context, runner *ActionRunner) (*ActionTask
 	if len(workflowJob.Steps) > 0 {
 		steps := make([]*ActionTaskStep, len(workflowJob.Steps))
 		for i, v := range workflowJob.Steps {
+			name, _ := util.SplitStringAtByteN(v.String(), 255)
 			steps[i] = &ActionTaskStep{
-				Name:   v.String(),
+				Name:   name,
 				TaskID: task.ID,
 				Index:  int64(i),
 				RepoID: task.RepoID,

--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/actions"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/util"
 	actions_service "code.gitea.io/gitea/services/actions"
 
 	runnerv1 "code.gitea.io/actions-proto-go/runner/v1"
@@ -55,9 +56,10 @@ func (s *Service) Register(
 	}
 
 	// create new runner
+	name, _ := util.SplitStringAtByteN(req.Msg.Name, 255)
 	runner := &actions_model.ActionRunner{
 		UUID:         gouuid.New().String(),
-		Name:         req.Msg.Name,
+		Name:         name,
 		OwnerID:      runnerToken.OwnerID,
 		RepoID:       runnerToken.RepoID,
 		AgentLabels:  req.Msg.AgentLabels,


### PR DESCRIPTION
Backport #23162

The name of the job or step comes from the workflow file, while the name of the runner comes from its registration. If the strings used for these names are too long, they could cause db issues.