### PR TITLE
Write Gitpod `app.ini` only once

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ tasks:
   - name: Run backend
     command: |
       gp sync-await setup
-      if [[ ! -f custom/conf/app.ini ]]
+      if [ ! -f custom/conf/app.ini ]
       then
         mkdir -p custom/conf/
         echo -e "[server]\nROOT_URL=$(gp url 3000)/" > custom/conf/app.ini

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,12 @@ tasks:
   - name: Run backend
     command: |
       gp sync-await setup
-      mkdir -p custom/conf/
-      echo -e "[server]\nROOT_URL=$(gp url 3000)/" > custom/conf/app.ini
-      echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
+      if [[ ! -f custom/conf/app.ini ]]
+      then
+        mkdir -p custom/conf/
+        echo -e "[server]\nROOT_URL=$(gp url 3000)/" > custom/conf/app.ini
+        echo -e "\n[database]\nDB_TYPE = sqlite3\nPATH = $GITPOD_REPO_ROOT/data/gitea.db" >> custom/conf/app.ini
+      fi
       export TAGS="sqlite sqlite_unlock_notify"
       make watch-backend
   - name: Run frontend


### PR DESCRIPTION
Before this change, the `app.ini` would get overwritten on each workspace start, confusing Gitea. It asked for reinstallation each time. This makes sure the file is written only once by checking it does not exist before creating it.

---
[Review without whitespace diff](https://github.com/go-gitea/gitea/pull/23192/files?w=1)