### PR TITLE
speed up loading access levels

### DIFF
--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -99,7 +99,6 @@ func (repos RepositoryList) loadAttributes(ctx context.Context) error {
 }
 
 func (repos RepositoryList) LoadOwners(ctx context.Context) error {
-
 	set := make(container.Set[int64])
 	for i := range repos {
 		set.Add(repos[i].OwnerID)


### PR DESCRIPTION
Our renovatebot gitea user has access to a lot of repositories. It takes a relatively long time to load all repositories, via api/v1/repo/search. This fixes this.
