### PR TITLE
Skip push update when tag reference to blob/tree

### DIFF
--- a/modules/git/error.go
+++ b/modules/git/error.go
@@ -46,6 +46,22 @@ func (err ErrNotExist) Unwrap() error {
 	return util.ErrNotExist
 }
 
+// ErrWrongType git object with wrong type
+type ErrWrongType struct {
+	ID   string
+	Type string
+}
+
+// IsErrWrongType if some error is ErrWrongType
+func IsErrWrongType(err error) bool {
+	_, ok := err.(ErrWrongType)
+	return ok
+}
+
+func (err ErrWrongType) Error() string {
+	return fmt.Sprintf("git object type is invalid [id: %s, type: %s]", err.ID, err.Type)
+}
+
 // ErrBadLink entry.FollowLink error
 type ErrBadLink struct {
 	Name    string

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -119,6 +119,15 @@ func (repo *Repository) getCommitFromBatchReader(rd *bufio.Reader, id SHA1) (*Co
 		}
 
 		return commit, nil
+	case "blob", "tree":
+		_, err = rd.Discard(int(size) + 1)
+		if err != nil {
+			return nil, err
+		}
+		return nil, ErrWrongType{
+			ID:   id.String(),
+			Type: typ,
+		}
 	default:
 		log.Debug("Unknown typ: %s", typ)
 		_, err = rd.Discard(int(size) + 1)

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -135,6 +135,10 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 			} else { // is new tag
 				newCommit, err := gitRepo.GetCommit(opts.NewCommitID)
 				if err != nil {
+					if git.IsErrWrongType(err) {
+						log.Info("ignore special ref push update: %v", err)
+						continue
+					}
 					return fmt.Errorf("gitRepo.GetCommit(%s) in %s/%s[%d]: %w", opts.NewCommitID, repo.OwnerName, repo.Name, repo.ID, err)
 				}
 


### PR DESCRIPTION
Because git ref may reference to blob/tree, but
push update logic will treate the object as a commit.

Therefore, an error occurred when parsing the commit object, resulting in the loss of the webhook notification of this ref and other refs.

So we ignore the wrong type error here to let other common refs can do webhook normally.

Hope to fix #23213.

