### PR TITLE
Avoid panic caused by broken payload when creating commit status

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -119,29 +119,13 @@ func (run *ActionRun) Duration() time.Duration {
 
 func (run *ActionRun) GetPushEventPayload() (*api.PushPayload, error) {
 	if run.Event == webhook_module.HookEventPush {
-		return nil, fmt.Errorf("event %s is not a push event", run.Event)
+		var payload api.PushPayload
+		if err := json.Unmarshal([]byte(run.EventPayload), &payload); err != nil {
+			return nil, err
+		}
+		return &payload, nil
 	}
-
-	payload := &api.PushPayload{}
-	if err := json.Unmarshal([]byte(run.EventPayload), payload); err != nil {
-		return nil, err
-	}
-
-	// Since it comes from json unmarshal, we should check if it's broken
-	if payload.HeadCommit == nil {
-		return nil, fmt.Errorf("nil HeadCommit")
-	}
-	if payload.Repo == nil {
-		return nil, fmt.Errorf("nil Repo")
-	}
-	if payload.Pusher == nil {
-		return nil, fmt.Errorf("nil Pusher")
-	}
-	if payload.Sender == nil {
-		return nil, fmt.Errorf("nil Sender")
-	}
-
-	return payload, nil
+	return nil, fmt.Errorf("event %s is not a push event", run.Event)
 }
 
 func updateRepoRunsNumbers(ctx context.Context, repo *repo_model.Repository) error {

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -119,13 +119,29 @@ func (run *ActionRun) Duration() time.Duration {
 
 func (run *ActionRun) GetPushEventPayload() (*api.PushPayload, error) {
 	if run.Event == webhook_module.HookEventPush {
-		var payload api.PushPayload
-		if err := json.Unmarshal([]byte(run.EventPayload), &payload); err != nil {
-			return nil, err
-		}
-		return &payload, nil
+		return nil, fmt.Errorf("event %s is not a push event", run.Event)
 	}
-	return nil, fmt.Errorf("event %s is not a push event", run.Event)
+
+	payload := &api.PushPayload{}
+	if err := json.Unmarshal([]byte(run.EventPayload), payload); err != nil {
+		return nil, err
+	}
+
+	// Since it comes from json unmarshal, we should check if it's broken
+	if payload.HeadCommit == nil {
+		return nil, fmt.Errorf("nil HeadCommit")
+	}
+	if payload.Repo == nil {
+		return nil, fmt.Errorf("nil Repo")
+	}
+	if payload.Pusher == nil {
+		return nil, fmt.Errorf("nil Pusher")
+	}
+	if payload.Sender == nil {
+		return nil, fmt.Errorf("nil Sender")
+	}
+
+	return payload, nil
 }
 
 func updateRepoRunsNumbers(ctx context.Context, repo *repo_model.Repository) error {

--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -150,7 +150,7 @@ func (s *Service) UpdateTask(
 	}
 
 	if err := actions_service.CreateCommitStatus(ctx, task.Job); err != nil {
-		log.Error("Update commit status failed: %v", err)
+		log.Error("Update commit status for job %v failed: %v", task.Job.ID, err)
 		// go on
 	}
 

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -15,6 +15,7 @@ import (
 	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/modules/actions"
 	context_module "code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
@@ -212,13 +213,16 @@ func Rerun(ctx *context_module.Context) {
 	job.Stopped = 0
 
 	if err := db.WithTx(ctx, func(ctx context.Context) error {
-		if _, err := actions_model.UpdateRunJob(ctx, job, builder.Eq{"status": status}, "task_id", "status", "started", "stopped"); err != nil {
-			return err
-		}
-		return actions_service.CreateCommitStatus(ctx, job)
+		_, err := actions_model.UpdateRunJob(ctx, job, builder.Eq{"status": status}, "task_id", "status", "started", "stopped")
+		return err
 	}); err != nil {
 		ctx.Error(http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
+		log.Error("Update commit status for job %v failed: %v", job.ID, err)
+		// go on
 	}
 
 	ctx.JSON(http.StatusOK, struct{}{})
@@ -253,14 +257,18 @@ func Cancel(ctx *context_module.Context) {
 			if err := actions_model.StopTask(ctx, job.TaskID, actions_model.StatusCancelled); err != nil {
 				return err
 			}
-			if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
-				return err
-			}
 		}
 		return nil
 	}); err != nil {
 		ctx.Error(http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	for _, job := range jobs {
+		if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
+			log.Error("Update commit status for job %v failed: %v", job.ID, err)
+			// go on
+		}
 	}
 
 	ctx.JSON(http.StatusOK, struct{}{})

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -33,11 +33,11 @@ func CreateCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 	// Since the payload comes from json data, we should check if it's broken, or it will cause panic
 	switch {
 	case payload.Repo == nil:
-		return fmt.Errorf("miss Repo in event payload")
+		return fmt.Errorf("repo is missing in event payload")
 	case payload.Pusher == nil:
-		return fmt.Errorf("miss Pusher in event payload")
+		return fmt.Errorf("pusher is missing in event payload")
 	case payload.HeadCommit == nil:
-		return fmt.Errorf("miss HeadCommit in event payload")
+		return fmt.Errorf("head commit is missing in event payload")
 	}
 
 	creator, err := user_model.GetUserByID(ctx, payload.Pusher.ID)

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -30,6 +30,16 @@ func CreateCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 		return fmt.Errorf("GetPushEventPayload: %w", err)
 	}
 
+	// Since the payload comes from json data, we should check if it's broken, or it will cause panic
+	switch {
+	case payload.Repo == nil:
+		return fmt.Errorf("miss Repo in event payload")
+	case payload.Pusher == nil:
+		return fmt.Errorf("miss Pusher in event payload")
+	case payload.HeadCommit == nil:
+		return fmt.Errorf("miss HeadCommit in event payload")
+	}
+
 	creator, err := user_model.GetUserByID(ctx, payload.Pusher.ID)
 	if err != nil {
 		return fmt.Errorf("GetUserByID: %w", err)

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -187,7 +187,8 @@ func notify(ctx context.Context, input *notifyInput) error {
 		} else {
 			for _, job := range jobs {
 				if err := CreateCommitStatus(ctx, job); err != nil {
-					log.Error("CreateCommitStatus: %v", err)
+					log.Error("Update commit status for job %v failed: %v", job.ID, err)
+					// go on
 				}
 			}
 		}


### PR DESCRIPTION
When creating commit status for Actons jobs, a payload with nil `HeadCommit` will cause panic.

Reported at: https://gitea.com/gitea/act_runner/issues/28#issuecomment-732166

Although the `HeadCommit` probably can not be nil after #23215, `CreateCommitStatus` should protect itself, to avoid being broken in the future.

In addition, it's enough to print error log instead of returning err when `CreateCommitStatus` failed.


