### PR TITLE
Use context cache in most queue handlers to avoid warning logs

### DIFF
--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -10,6 +10,7 @@ import (
 
 	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/queue"
 
@@ -34,6 +35,7 @@ func EmitJobsIfReady(runID int64) error {
 
 func jobEmitterQueueHandle(data ...queue.Data) []queue.Data {
 	ctx := graceful.GetManager().ShutdownContext()
+	ctx = cache.WithCacheContext(ctx)
 	var ret []queue.Data
 	for _, d := range data {
 		update := d.(*jobUpdate)

--- a/services/automerge/automerge.go
+++ b/services/automerge/automerge.go
@@ -16,6 +16,7 @@ import (
 	pull_model "code.gitea.io/gitea/models/pull"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -166,6 +167,7 @@ func handlePull(pullID int64, sha string) {
 	ctx, _, finished := process.GetManager().AddContext(graceful.GetManager().HammerContext(),
 		fmt.Sprintf("Handle AutoMerge of PR[%d] with sha[%s]", pullID, sha))
 	defer finished()
+	ctx = cache.WithCacheContext(ctx)
 
 	pr, err := issues_model.GetPullRequestByID(ctx, pullID)
 	if err != nil {

--- a/services/mirror/mirror.go
+++ b/services/mirror/mirror.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
 	mirror_module "code.gitea.io/gitea/modules/mirror"
@@ -123,7 +124,7 @@ func Update(ctx context.Context, pullLimit, pushLimit int) error {
 func queueHandle(data ...queue.Data) []queue.Data {
 	for _, datum := range data {
 		req := datum.(*mirror_module.SyncRequest)
-		doMirrorSync(graceful.GetManager().ShutdownContext(), req)
+		doMirrorSync(cache.WithCacheContext(graceful.GetManager().ShutdownContext()), req)
 	}
 	return nil
 }

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -19,6 +19,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -340,6 +341,7 @@ func testPR(id int64) {
 	defer pullWorkingPool.CheckOut(fmt.Sprint(id))
 	ctx, _, finished := process.GetManager().AddContext(graceful.GetManager().HammerContext(), fmt.Sprintf("Test PR[%d] from patch checking queue", id))
 	defer finished()
+	ctx = cache.WithCacheContext(ctx)
 
 	pr, err := issues_model.GetPullRequestByID(ctx, id)
 	if err != nil {

--- a/services/repository/archiver/archiver.go
+++ b/services/repository/archiver/archiver.go
@@ -15,6 +15,7 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -180,6 +181,7 @@ func doArchive(r *ArchiveRequest) (*repo_model.RepoArchiver, error) {
 	defer committer.Close()
 	ctx, _, finished := process.GetManager().AddContext(txCtx, fmt.Sprintf("ArchiveRequest[%d]: %s", r.RepoID, r.GetArchiveName()))
 	defer finished()
+	ctx = cache.WithCacheContext(ctx)
 
 	archiver, err := repo_model.GetRepoArchiver(ctx, r.RepoID, r.Type, r.CommitID)
 	if err != nil {

--- a/services/task/migrate.go
+++ b/services/task/migrate.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
@@ -102,6 +103,7 @@ func runMigrateTask(t *admin_model.Task) (err error) {
 	pm := process.GetManager()
 	ctx, _, finished := pm.AddContext(graceful.GetManager().ShutdownContext(), fmt.Sprintf("MigrateTask: %s/%s", t.Owner.Name, opts.RepoName))
 	defer finished()
+	ctx = cache.WithCacheContext(ctx)
 
 	t.StartTime = timeutil.TimeStampNow()
 	t.Status = structs.TaskStatusRunning

--- a/services/webhook/webhook.go
+++ b/services/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
 	webhook_model "code.gitea.io/gitea/models/webhook"
+	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -107,6 +108,7 @@ type EventSource struct {
 // handle delivers hook tasks
 func handle(data ...queue.Data) []queue.Data {
 	ctx := graceful.GetManager().HammerContext()
+	ctx = cache.WithCacheContext(ctx)
 
 	for _, taskID := range data {
 		task, err := webhook_model.GetHookTaskByID(ctx, taskID.(int64))


### PR DESCRIPTION
Follow: #23186 #23054

Related to: #22294

The point is that the context cache is not only "HTTP request level cache", but also "queue handling level cache". And there are so many queues...
