### PR TITLE
Order pull request conflict checking by recently updated, for each push

### DIFF
--- a/models/issues/pull_list.go
+++ b/models/issues/pull_list.go
@@ -111,6 +111,7 @@ func GetUnmergedPullRequestsByBaseInfo(repoID int64, branch string) ([]*PullRequ
 	return prs, db.GetEngine(db.DefaultContext).
 		Where("base_repo_id=? AND base_branch=? AND has_merged=? AND issue.is_closed=?",
 			repoID, branch, false, false).
+		OrderBy("issue.updated_unix DESC").
 		Join("INNER", "issue", "issue.id=pull_request.issue_id").
 		Find(&prs)
 }


### PR DESCRIPTION
When a change is pushed to the default branch and many pull requests are open for that branch, conflict checking can take some time.

Previously it would go from oldest to newest pull request. Now prioritize pull requests that are likely being actively worked on or prepared for merging.

This only changes the order within one push to one repository, but the change is trivial and can already be quite helpful for smaller Gitea instances where a few repositories have most pull requests. A global order would require deeper changes to queues.