### PR TITLE
Improve update-locales script and fix locale processing bug

### DIFF
--- a/build/update-locales.sh
+++ b/build/update-locales.sh
@@ -28,7 +28,7 @@ mv ./options/locale/locale_en-US.ini ./options/
 
 # this script helps to unquote the crowdin outputs for the quirky ini library
 # * find all `key="...\"..."` lines
-# * remote the leading quote
+# * remove the leading quote
 # * remove the trailing quote
 # * unescape the quotes
 # * eg: key="...\"..." => key=..."...

--- a/build/update-locales.sh
+++ b/build/update-locales.sh
@@ -1,13 +1,48 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
+
+SED=sed
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # for macOS developers, use "brew install gnu-sed"
+  SED=gsed
+fi
+
+if [ ! -f ./options/locale/locale_en-US.ini ]; then
+  echo "please run this script in the root directory of the project"
+  exit 1
+fi
 
 mv ./options/locale/locale_en-US.ini ./options/
 
-# Make sure to only change lines that have the translation enclosed between quotes
-sed -i -r -e '/^[a-zA-Z0-9_.-]+[ ]*=[ ]*".*"$/ {
-	s/^([a-zA-Z0-9_.-]+)[ ]*="/\1=/
-	s/\\"/"/g
+# the "ini" library for locale has many quirks
+#  * `a="xx"` gets `xx` (no quote)
+#  * `a=x\"y` gets `x\"y` (no unescaping)
+#  * `a="x\"y"` gets `"x\"y"` (no unescaping, the quotes are still there)
+#  * `a='x\"y'` gets `x\"y` (no unescaping, no quote)
+#  * `a="foo` gets `"foo` (although the quote is not closed)
+#  * 'a=`foo`' works like single-quote
+# crowdin needs the strings to be quoted correctly and doesn't like incomplete quotes
+# crowdin always outputs quoted strings
+
+# this script helps to unquote the crowdin outputs for the quirky ini library
+# * find all `key="...\"..."` lines
+# * remote the leading quote
+# * remove the trailing quote
+# * unescape the quotes
+# * eg: key="...\"..." => key=..."...
+$SED -i -r -e '/^[-.A-Za-z0-9_]+[ ]*=[ ]*".*"$/ {
+	s/^([-.A-Za-z0-9_]+)[ ]*=[ ]*"/\1=/
 	s/"$//
+	s/\\"/"/g
 	}' ./options/locale/*.ini
+
+# * if the escaped line is incomplete like `key="...` or `key=..."`, quote it with backticks
+# * eg: key="... => key=`"...`
+# * eg: key=..." => key=`..."`
+$SED -i -r -e 's/^([-.A-Za-z0-9_]+)[ ]*=[ ]*(".*[^"])$/\1=`\2`/' ./options/locale/*.ini
+$SED -i -r -e 's/^([-.A-Za-z0-9_]+)[ ]*=[ ]*([^"].*")$/\1=`\2`/' ./options/locale/*.ini
 
 # Remove translation under 25% of en_us
 baselines=$(wc -l "./options/locale_en-US.ini" | cut -d" " -f1)

--- a/build/update-locales.sh
+++ b/build/update-locales.sh
@@ -24,7 +24,7 @@ mv ./options/locale/locale_en-US.ini ./options/
 #  * `a="foo` gets `"foo` (although the quote is not closed)
 #  * 'a=`foo`' works like single-quote
 # crowdin needs the strings to be quoted correctly and doesn't like incomplete quotes
-# crowdin always outputs quoted strings
+# crowdin always outputs quoted strings if there are quotes in the strings.
 
 # this script helps to unquote the crowdin outputs for the quirky ini library
 # * find all `key="...\"..."` lines

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -57,6 +57,7 @@ new_mirror=创建新的镜像
 new_fork=新的仓库Fork
 new_org=创建组织
 new_project=创建项目
+new_project_column=创建列
 manage_org=管理我的组织
 admin_panel=管理后台
 account_settings=帐户设置
@@ -90,9 +91,11 @@ disabled=禁用
 
 copy=复制
 copy_url=复制网址
+copy_content=复制内容
 copy_branch=复制分支名
 copy_success=复制成功！
 copy_error=复制失败
+copy_type_unsupported=无法复制此类型的文件内容
 
 write=撰写
 preview=预览
@@ -109,6 +112,10 @@ never=从不
 rss_feed=RSS 订阅源
 
 [aria]
+navbar=导航栏
+footer=页脚
+footer.software=关于软件
+footer.links=链接
 
 [filter]
 string.asc=A - Z
@@ -258,16 +265,40 @@ view_home=访问 %s
 search_repos=查找仓库…
 filter=其他过滤器
 filter_by_team_repositories=按团队仓库筛选
-feed_of=%s" 的源
+feed_of=`"%s"的源`
 
+show_archived=已归档
+show_both_archived_unarchived=显示已归档和未归档的
+show_only_archived=只显示已归档的
+show_only_unarchived=只显示未归档的
 
 show_private=私有库
+show_both_private_public=同时显示公开的和私有的
+show_only_private=只显示私有的
+show_only_public=只显示公开的
 
+issues.in_your_repos=在您的仓库中
 
 [explore]
 repos=仓库管理
+users=用户
 organizations=组织管理
+search=搜索
 code=代码
+search.type.tooltip=搜索类型
+search.fuzzy=模糊
+search.fuzzy.tooltip=包含近似匹配搜索词的结果
+search.match=匹配
+search.match.tooltip=仅包含精确匹配搜索词的结果
+code_search_unavailable=目前代码搜索不可用。请与网站管理员联系。
+repo_no_results=未找到匹配的仓库。
+user_no_results=未找到匹配的用户。
+org_no_results=未找到匹配的组织。
+code_no_results=未找到与搜索字词匹配的源代码。
+code_search_results=“%s” 的搜索结果
+code_last_indexed_at=最后索引于 %s
+relevant_repositories_tooltip=派生的仓库，以及缺少主题、图标和描述的仓库将被隐藏。
+relevant_repositories=只显示相关的仓库， <a href="%s">显示未过滤结果</a>。
 
 
 [auth]
@@ -297,6 +328,7 @@ email_not_associate=您输入的邮箱地址未被关联到任何帐号！
 send_reset_mail=发送账户恢复邮件
 reset_password=账户恢复
 invalid_code=此确认密钥无效或已过期。
+invalid_password=您的密码与用于创建账户的密码不匹配。
 reset_password_helper=恢复账户
 reset_password_wrong_user=您已作为 %s 登录，无法使用链接恢复 %s 的账户。
 password_too_short=密码长度不能少于 %d 位。
@@ -340,6 +372,7 @@ password_pwned_err=无法完成对 HaveIBeenPwned 的请求
 
 [mail]
 view_it_on=在 %s 上查看
+reply=或直接回复此邮件
 link_not_working_do_paste=不起作用？尝试复制并粘贴到您的浏览器。
 hi_user_x=<b>%s</b> 您好，
 
@@ -443,6 +476,8 @@ url_error=`'%s' 不是一个有效的 URL。`
 include_error=`必须包含子字符串 '%s'。`
 glob_pattern_error=`匹配模式无效：%s.`
 regex_pattern_error=`正则表达式无效：%s.`
+username_error=` 只能包含字母数字字符('0-9','a-z','A-Z'), 破折号 ('-'), 下划线 ('_') 和点 ('.'). 不能以非字母数字字符开头或结尾，并且不允许连续的非字母数字字符。`
+invalid_group_team_map_error=`映射无效： %s`
 unknown_error=未知错误：
 captcha_incorrect=验证码不正确。
 password_not_match=密码不匹配。
@@ -479,10 +514,12 @@ team_not_exist=团队不存在
 last_org_owner=您不能从 "所有者" 团队中删除最后一个用户。组织中必须至少有一个所有者。
 cannot_add_org_to_team=组织不能被加入到团队中。
 duplicate_invite_to_team=此用户已被邀请为团队成员。
+organization_leave_success=您已成功离开组织 %s。
 
 invalid_ssh_key=无法验证您的 SSH 密钥: %s
 invalid_gpg_key=无法验证您的 GPG 密钥: %s
 invalid_ssh_principal=无效的规则： %s
+must_use_public_key=您提供的密钥是私钥。不要在任何地方上传您的私钥，请改用您的公钥。
 unable_verify_ssh_key=无法验证SSH密钥，再次检查是否有误。
 auth_failed=授权验证失败：%v
 
@@ -719,6 +756,8 @@ access_token_deletion_cancel_action=取消
 access_token_deletion_confirm_action=刪除
 access_token_deletion_desc=删除令牌将撤销程序对您账户的访问权限。此操作无法撤消。是否继续？
 delete_token_success=令牌已经被删除。使用该令牌的应用将不再能够访问你的账号。
+select_scopes=选择范围
+scopes_list=范围：
 
 manage_oauth2_applications=管理 OAuth2 应用程序
 edit_oauth2_application=编辑 OAuth2 应用程序
@@ -893,9 +932,9 @@ delete_preexisting_success=删除 %s 中未收录的文件
 blame_prior=查看此更改前的 blame
 
 transfer.accept=接受转移
-transfer.accept_desc=转移到 "%s"
+transfer.accept_desc=`转移到 "%s"`
 transfer.reject=拒绝转移
-transfer.reject_desc=取消转移到 "%s"
+transfer.reject_desc=`取消转移到 "%s"`
 transfer.no_permission_to_accept=您没有接受的权限
 transfer.no_permission_to_reject=您没有拒绝的权限
 
@@ -991,10 +1030,12 @@ unstar=取消点赞
 star=点赞
 fork=派生
 download_archive=下载此仓库
+more_operations=更多操作
 
 no_desc=暂无描述
 quick_guide=快速帮助
 clone_this_repo=克隆当前仓库
+cite_this_repo=引用此仓库
 create_new_repo_command=从命令行创建一个新的仓库
 push_exist_repo=从命令行推送已经创建的仓库
 empty_message=这个家伙很懒，什么都没有推送。
@@ -1093,6 +1134,7 @@ editor.commit_directly_to_this_branch=直接提交至 <strong class="branch-name
 editor.create_new_branch=为此提交创建一个 <strong>新的分支</strong> 并发起合并请求。
 editor.create_new_branch_np=为此提交创建 <strong>新分支</strong>。
 editor.propose_file_change=提议文件更改
+editor.new_branch_name=为这次提交的新分支命名
 editor.new_branch_name_desc=新的分支名称...
 editor.cancel=取消
 editor.filename_cannot_be_empty=文件名不能为空。
@@ -1144,6 +1186,7 @@ commits.signed_by_untrusted_user_unmatched=由与提交者不匹配的未授信�
 commits.gpg_key_id=GPG 密钥 ID
 commits.ssh_key_fingerprint=SSH 密钥指纹
 
+commit.operations=操作
 commit.revert=还原
 commit.revert-header=还原： %s
 commit.revert-content=选择要还原的分支：
@@ -1176,11 +1219,22 @@ projects.type.bug_triage=Bug分类看板
 projects.template.desc=项目模板
 projects.template.desc_helper=选择一个项目模板以开始
 projects.type.uncategorized=未分类
+projects.column.edit=编辑列
 projects.column.edit_title=名称
 projects.column.new_title=名称
+projects.column.new_submit=创建列
+projects.column.new=创建列
+projects.column.set_default=设为默认
+projects.column.set_default_desc=Set this column as default for uncategorized issues and pulls
+projects.column.delete=删除列
+projects.column.deletion_desc=删除项目列会将所有相关问题移到“未分类”。是否继续？
 projects.column.color=彩色
 projects.open=开启
 projects.close=关闭
+projects.column.assigned_to=指派给
+projects.card_type.desc=卡片预览
+projects.card_type.images_and_text=图标和文字
+projects.card_type.text_only=仅文本
 
 issues.desc=组织 bug 报告、任务和里程碑。
 issues.filter_assignees=筛选指派人
@@ -1257,6 +1311,7 @@ issues.filter_label_no_select=所有标签
 issues.filter_milestone=里程碑筛选
 issues.filter_milestone_no_select=所有里程碑
 issues.filter_project=项目
+issues.filter_project_all=所有项目
 issues.filter_project_none=暂无项目
 issues.filter_assignee=指派人筛选
 issues.filter_assginee_no_select=所有指派成员
@@ -1268,6 +1323,7 @@ issues.filter_type.assigned_to_you=指派给您的
 issues.filter_type.created_by_you=由您创建的
 issues.filter_type.mentioning_you=提及您的
 issues.filter_type.review_requested=已请求评审
+issues.filter_type.reviewed_by_you=您评审过的
 issues.filter_sort=排序
 issues.filter_sort.latest=最新创建
 issues.filter_sort.oldest=最早创建
@@ -1289,6 +1345,8 @@ issues.action_milestone=里程碑
 issues.action_milestone_no_select=无里程碑
 issues.action_assignee=指派人筛选
 issues.action_assignee_no_select=未指派
+issues.action_check=选中/取消选中
+issues.action_check_all=选中/取消选中所有项目
 issues.opened_by=由 <a href="%[2]s">%[3]s</a> 于 %[1]s创建
 pulls.merged_by=由 <a href="%[2]s">%[3]s</a> 创建，被合并于 %[1]s
 pulls.merged_by_fake=由 %[2]s 创建，被合并于 %[1]s
@@ -1342,6 +1400,9 @@ issues.save=保存
 issues.label_title=标签名称
 issues.label_description=标签描述
 issues.label_color=标签颜色
+issues.label_exclusive=独有
+issues.label_exclusive_desc=命名标签为 <code>scope/item</code> 以使其与其他以 <code>scope/</code> 开头的标签互斥。
+issues.label_exclusive_warning=在编辑工单或合并请求的标签时，任何冲突的范围标签都将被删除。
 issues.label_count=%d 个标签
 issues.label_open_issues=%d 个开启的工单
 issues.label_edit=编辑
@@ -1409,6 +1470,7 @@ issues.error_removing_due_date=删除到期时间失败。
 issues.push_commit_1=于 %[2]s 推送了 %[1]d 个提交
 issues.push_commits_n=于 %[2]s 推送了 %[1]d 个提交
 issues.force_push_codes=`于 %[6]s 强制推送 %[1]s，从 <a class="ui sha" href="%[3]s"><code>%[2]s</code></a>，至 <a class="ui sha" href="%[5]s"><code>%[4]s</code></a>`
+issues.force_push_compare=比较
 issues.due_date_form=yyyy年mm月dd日
 issues.due_date_form_add=设置到期时间
 issues.due_date_form_edit=编辑
@@ -1595,6 +1657,8 @@ pulls.reopened_at=`重新打开此合并请求 <a id="%[1]s" href="#%[1]s">%[2]s
 pulls.merge_instruction_hint=`你也可以查看 <a class="show-instruction">命令行指令</a>`
 pulls.merge_instruction_step1_desc=从你的仓库中签出一个新的分支并测试变更。
 pulls.merge_instruction_step2_desc=合并变更并更新到 Gitea 上
+pulls.clear_merge_message=清除合并信息
+pulls.clear_merge_message_hint=Clearing the merge message will only remove the commit message content and keep generated git trailers such as "Co-Authored-By …".
 
 pulls.auto_merge_button_when_succeed=(当检查成功时)
 pulls.auto_merge_when_succeed=在所有检查成功后自动合并
@@ -1786,6 +1850,7 @@ settings.mirror_sync_in_progress=镜像同步正在进行中，请稍后再试�
 settings.site=网站
 settings.update_settings=更新仓库设置
 settings.branches.update_default_branch=更新默认分支
+settings.branches.add_new_rule=添加新规则
 settings.advanced_settings=高级设置
 settings.wiki_desc=启用仓库百科
 settings.use_internal_wiki=使用内置百科
@@ -1815,8 +1880,11 @@ settings.pulls.ignore_whitespace=忽略空白冲突
 settings.pulls.enable_autodetect_manual_merge=启用自动检测手动合并 (注意：在某些特殊情况下可能发生错误判断)
 settings.pulls.allow_rebase_update=允许通过变基更新拉取请求分支
 settings.pulls.default_delete_branch_after_merge=默认合并后删除合并请求分支
+settings.pulls.default_allow_edits_from_maintainers=默认开启允许维护者编辑
+settings.releases_desc=启用发布
 settings.packages_desc=启用仓库软件包注册中心
 settings.projects_desc=启用仓库项目
+settings.actions_desc=启用 Actions
 settings.admin_settings=管理员设置
 settings.admin_enable_health_check=启用仓库健康检查 (git fsck)
 settings.admin_code_indexer=代码索引器
@@ -2026,6 +2094,8 @@ settings.deploy_key_deletion_desc=删除部署密钥将取消此密钥对此仓�
 settings.deploy_key_deletion_success=部署密钥已删除。
 settings.branches=分支
 settings.protected_branch=分支保护
+settings.protected_branch.save_rule=保存规则
+settings.protected_branch.delete_rule=删除规则
 settings.protected_branch_can_push=允许推吗？
 settings.protected_branch_can_push_yes=你可以推
 settings.protected_branch_can_push_no=你不能推
@@ -2060,6 +2130,7 @@ settings.dismiss_stale_approvals=取消过时的批准
 settings.dismiss_stale_approvals_desc=当新的提交更改合并请求内容被推送到分支时，旧的批准将被撤销。
 settings.require_signed_commits=需要签名提交
 settings.require_signed_commits_desc=拒绝推送未签名或无法验证的提交到分支
+settings.protect_branch_name_pattern=受保护的分支名称模式
 settings.protect_protected_file_patterns=受保护的文件模式(使用分号分隔)
 settings.protect_protected_file_patterns_desc=即使用户有权在此分支中添加、编辑或删除文件，也不允许直接更改受保护文件。 可以使用分号分隔多个模式 ('\;')。语法文档见 <a href="https://pkg.go.dev/github.com/gobwas/glob#Compile">github.com/gobwas/glob</a>。示例：<code>.drone.yml</code>，<code>/docs/**/*.txt</code>。
 settings.protect_unprotected_file_patterns=不受保护的文件模式 (使用分号 '\;' 分隔)：
@@ -2068,6 +2139,7 @@ settings.add_protected_branch=启用保护
 settings.delete_protected_branch=禁用保护
 settings.update_protect_branch_success=分支 "%s" 的分支保护已更新。
 settings.remove_protected_branch_success=分支 "%s" 的分支保护已被禁用。
+settings.remove_protected_branch_failed=删除分支保护规则 '%s' 失败。
 settings.protected_branch_deletion=禁用分支保护
 settings.protected_branch_deletion_desc=禁用分支保护允许具有写入权限的用户推送提交到此分支。继续？
 settings.block_rejected_reviews=拒绝审核阻止了此合并
@@ -2077,10 +2149,13 @@ settings.block_on_official_review_requests_desc=处于评审状态时，即使�
 settings.block_outdated_branch=如果拉取请求已经过时，阻止合并
 settings.block_outdated_branch_desc=当头部分支落后基础分支时，不能合并。
 settings.default_branch_desc=请选择一个默认的分支用于合并请求和提交：
+settings.merge_style_desc=合并方式
 settings.default_merge_style_desc=合并请求的默认合并样式：
 settings.choose_branch=选择一个分支...
 settings.no_protected_branch=没有受保护的分支
 settings.edit_protected_branch=编辑
+settings.protected_branch_required_rule_name=必须填写规则名称
+settings.protected_branch_duplicate_rule_name=规则名称已存在
 settings.protected_branch_required_approvals_min=所需的审批数不能为负数。
 settings.tags=标签
 settings.tags.protection=Git标签保护
@@ -2236,6 +2311,8 @@ release.downloads=下载附件
 release.download_count=下载：%s
 release.add_tag_msg=使用发布的标题和内容作为标签消息。
 release.add_tag=仅创建标签
+release.releases_for=%s 的版本发布
+release.tags_for=%s 的标签
 
 branch.name=分支名称
 branch.search=搜索分支
@@ -2503,6 +2580,10 @@ dashboard.delete_old_actions=从数据库中删除所有旧操作记录
 dashboard.delete_old_actions.started=已开始从数据库中删除所有旧操作记录。
 dashboard.update_checker=更新检查器
 dashboard.delete_old_system_notices=从数据库中删除所有旧系统通知
+dashboard.gc_lfs=垃圾回收 LFS 元数据
+dashboard.stop_zombie_tasks=停止僵尸任务
+dashboard.stop_endless_tasks=停止永不停止的任务
+dashboard.cancel_abandoned_jobs=取消丢弃的任务
 
 users.user_manage_panel=用户帐户管理
 users.new_account=创建新帐户
@@ -2591,6 +2672,7 @@ repos.size=大小
 
 packages.package_manage_panel=软件包管理
 packages.total_size=总大小：%s
+packages.unreferenced_size=未引用大小： %s
 packages.owner=所有者
 packages.creator=创建者
 packages.name=名称
@@ -2684,6 +2766,8 @@ auths.oauth2_required_claim_value_helper=设置此值，只有拥有对应的声
 auths.oauth2_group_claim_name=用于提供用户组名称的 Claim 声明名称。(可选)
 auths.oauth2_admin_group=管理员用户组的 Claim 声明值。(可选 - 需要上面的声明名称)
 auths.oauth2_restricted_group=受限用户组的 Claim 声明值。(可选 - 需要上面的声明名称)
+auths.oauth2_map_group_to_team=Map claimed groups to Organization teams. (Optional - requires claim name above)
+auths.oauth2_map_group_to_team_removal=如果用户不属于相应的组，从已同步团队中移除用户
 auths.enable_auto_register=允许用户自动注册
 auths.sspi_auto_create_users=自动创建用户
 auths.sspi_auto_create_users_helper=允许 SSPI 认证在用户第一次登录时自动创建新账号
@@ -2699,10 +2783,10 @@ auths.tips=帮助提示
 auths.tips.oauth2.general=OAuth2 认证
 auths.tips.oauth2.general.tip=当注册一个新的 OAuth2 认证，回调/重定向 URL 应该是： <host>/user/oauth2/<Authentication Name>/callback
 auths.tip.oauth2_provider=OAuth2 提供程序
-auths.tip.bitbucket=在 https://bitbucket.org/account/user/<your username>/oauth-consumers/new 注册新的 OAuth 消费者同时添加权限"帐户"-"读"
+auths.tip.bitbucket=`在 https://bitbucket.org/account/user/<your username>/oauth-consumers/new 注册新的 OAuth 消费者同时添加权限"帐户"-"读"`
 auths.tip.nextcloud=使用下面的菜单“设置（Settings） -> 安全（Security） -> OAuth 2.0 client”在您的实例上注册一个新的 OAuth 客户端。
 auths.tip.dropbox=在 https://www.dropbox.com/developers/apps 上创建一个新的应用程序
-auths.tip.facebook=在 https://developers.facebook.com/apps 注册一个新的应用，并添加产品"Facebook 登录"
+auths.tip.facebook=`在 https://developers.facebook.com/apps 注册一个新的应用，并添加产品"Facebook 登录"`
 auths.tip.github=在 https://github.com/settings/applications/new 注册一个 OAuth 应用程序
 auths.tip.gitlab=在 https://gitlab.com/profile/applications 上注册新应用程序
 auths.tip.google_plus=从谷歌 API 控制台 (https://console.developers.google.com/) 获得 OAuth2 客户端凭据
@@ -2946,6 +3030,7 @@ monitor.queue.pool.cancel_desc=没有工作者组的队列将会引起请求永�
 
 notices.system_notice_list=系统提示管理
 notices.view_detail_header=查看提示详情
+notices.operations=操作
 notices.select_all=选中全部
 notices.deselect_all=取消全选
 notices.inverse_selection=反向选中
@@ -3079,9 +3164,14 @@ versions.on=于
 versions.view_all=查看全部
 dependency.id=ID
 dependency.version=版本
+cargo.registry=在 Cargo 配置文件中设置此注册中心(例如：<code>~/.cargo/config.toml</code>)：
+cargo.install=要使用 Cargo 安装软件包，请运行以下命令：
+cargo.documentation=关于 Cargo 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">文档</a>。
 cargo.details.repository_site=仓库站点
 cargo.details.documentation_site=文档站点
+chef.registry=在您的 <code>~/.chef/config.rb</code> 文件中设置此注册中心：
 chef.install=要安装包，请运行以下命令：
+chef.documentation=关于 Chef 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">文档</a>。
 composer.registry=在您的 <code>~/.composer/config.json</code> 文件中设置此注册中心：
 composer.install=要使用 Composer 安装软件包，请运行以下命令：
 composer.documentation=关于 Composer 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/"> 文档 </a>。
@@ -3091,6 +3181,9 @@ conan.details.repository=仓库
 conan.registry=从命令行设置此注册中心：
 conan.install=要使用 Conan 安装软件包，请运行以下命令：
 conan.documentation=关于 Conan 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">文档</a>。
+conda.registry=在您的 <code>.condarc</code> 文件中将此注册中心设置为 Conda 仓库：
+conda.install=要使用 Conda 安装软件包，请运行以下命令：
+conda.documentation=关于 Conda 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">文档</a>。
 conda.details.repository_site=仓库站点
 conda.details.documentation_site=文档站点
 container.details.type=镜像类型
@@ -3151,26 +3244,110 @@ settings.delete.description=删除软件包是永久性的，无法撤消。
 settings.delete.notice=您将要删除 %s (%s)。此操作是不可逆的，您确定吗？
 settings.delete.success=软件包已被删除。
 settings.delete.error=删除软件包失败。
+owner.settings.cargo.title=Cargo 注册中心索引
+owner.settings.cargo.initialize=初始化索引
+owner.settings.cargo.initialize.description=To use the Cargo registry a special index git repository is needed. Here you can (re)create it with the required config.
+owner.settings.cargo.initialize.error=初始化Cargo索引失败： %v
+owner.settings.cargo.initialize.success=Cargo索引已经成功创建。
+owner.settings.cargo.rebuild=重建索引
+owner.settings.cargo.rebuild.description=If the index is out of sync with the cargo packages stored you can rebuild it here.
+owner.settings.cargo.rebuild.error=无法重建 Cargo 索引: %v
+owner.settings.cargo.rebuild.success=Cargo 索引已成功重建。
+owner.settings.cleanuprules.title=管理清理规则
+owner.settings.cleanuprules.add=添加清理规则
+owner.settings.cleanuprules.edit=编辑清理规则
+owner.settings.cleanuprules.none=没有可用的清理规则。请阅读文档了解更多信息。
+owner.settings.cleanuprules.preview=清理规则预览
+owner.settings.cleanuprules.preview.overview=%d 个软件包计划被删除。
+owner.settings.cleanuprules.preview.none=清理规则与任何软件包都不匹配。
 owner.settings.cleanuprules.enabled=启用
+owner.settings.cleanuprules.pattern_full_match=Apply pattern to full package name
+owner.settings.cleanuprules.keep.title=Versions that match these rules are kept, even if they match a removal rule below.
+owner.settings.cleanuprules.keep.count=保留最新的
+owner.settings.cleanuprules.keep.count.1=每个软件包1个版本
+owner.settings.cleanuprules.keep.count.n=每个软件包 %d 个版本
+owner.settings.cleanuprules.keep.pattern=保持版本匹配
+owner.settings.cleanuprules.keep.pattern.container=The <code>latest</code> version is always kept for Container packages.
+owner.settings.cleanuprules.remove.title=与这些规则相匹配的版本将被删除，除非其中存在某个保留它们的规则。
+owner.settings.cleanuprules.remove.days=移除旧于天数的版本
+owner.settings.cleanuprules.remove.pattern=删除匹配的版本
+owner.settings.cleanuprules.success.update=清理规则已更新。
+owner.settings.cleanuprules.success.delete=清理规则已删除。
+owner.settings.chef.title=Chef 注册中心
+owner.settings.chef.keypair=生成密钥对
+owner.settings.chef.keypair.description=生成用于验证Chef 注册中心的密钥对。之前的密钥不能在以后使用。
 
 [secrets]
+secrets=密钥
+description=Secrets will be passed to certain actions and cannot be read otherwise.
+none=还没有密钥。
 value=值
 name=名称
+creation=添加密钥
+creation.name_placeholder=不区分大小写，字母数字或下划线不能以GITEA_ 或 GITHUB_ 开头。
+creation.value_placeholder=输入任何内容，开头和结尾的空白都会被省略
+creation.success=您的密钥 '%s' 添加成功。
+creation.failed=添加密钥失败。
+deletion=删除密钥
+deletion.description=删除密钥是永久性的，无法撤消。继续吗？
+deletion.success=此Secret已被删除。
+deletion.failed=删除密钥失败。
 
 [actions]
+actions=Actions
 
+unit.desc=管理Actions
 
+status.unknown=未知
+status.waiting=等待中
+status.running=正在运行
+status.success=成功
+status.failure=失败
+status.cancelled=已取消
+status.skipped=已忽略
+status.blocked=阻塞中
 
+runners=Runners
+runners.runner_manage_panel=Runners管理
+runners.new=创建 Runner
+runners.new_notice=如何启动一个运行器
+runners.status=状态
 runners.id=ID
 runners.name=名称
 runners.owner_type=类型
 runners.description=组织描述
 runners.labels=标签
+runners.last_online=上次在线时间
+runners.agent_labels=代理标签
+runners.custom_labels=自定义标签
+runners.custom_labels_helper=自定义标签是由管理员手动添加的标签。标签之间用逗号分隔，每个标签的开头和结尾的空白被忽略。
+runners.runner_title=Runner
+runners.task_list=最近在此runner上的任务
 runners.task_list.run=执行
+runners.task_list.status=状态
 runners.task_list.repository=仓库
 runners.task_list.commit=提交
+runners.task_list.done_at=完成于
+runners.edit_runner=编辑运行器
+runners.update_runner=更新更改
+runners.update_runner_success=运行器更新成功
+runners.update_runner_failed=更新运行器失败
+runners.delete_runner=删除运行器
+runners.delete_runner_success=运行器删除成功
+runners.delete_runner_failed=删除运行器失败
+runners.delete_runner_header=确认要删除此运行器
+runners.delete_runner_notice=如果一个任务正在运行在此运行器上，它将被终止并标记为失败。它可能会打断正在构建的工作流。
+runners.none=无可用的 Runner
+runners.status.unspecified=未知
+runners.status.idle=空闲
 runners.status.active=激活
+runners.status.offline=离线
 
+runs.all_workflows=所有工作流
+runs.open_tab=%d 开启中
+runs.closed_tab=%d 已关闭
 runs.commit=提交
+runs.pushed_by=推送者
 
+need_approval_desc=该工作流由派生仓库的合并请求所触发，需要批准方可运行。
 


### PR DESCRIPTION
The locales of Gitea has been broken for long time, till now, it's still not fully fixed.

One of the root problems is that the `ini` library is quite quirky and the `update-locales` script doesn't work well for all cases.


This PR fixes the  `update-locales` script to make it satisfy `ini` library and the crowdin.

See the comments for more details.

The `locale_zh-CN.ini` is an example, it comes from crowdin and is processed by the new `update-locales.sh`. Especially see the `feed_of`: https://github.com/go-gitea/gitea/pull/23240/files#diff-321f6ca4eae1096eba230e93c4740f9903708afe8d79cf2e57f4299786c4528bR268
