### PR TITLE
Close the temp file when dumping database to make the temp file can be deleted on Windows

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -272,6 +272,7 @@ func runDump(ctx *cli.Context) error {
 		fatal("Failed to create tmp file: %v", err)
 	}
 	defer func() {
+		_ = dbDump.Close()
 		if err := util.Remove(dbDump.Name()); err != nil {
 			log.Warn("Unable to remove temporary file: %s: Error: %v", dbDump.Name(), err)
 		}


### PR DESCRIPTION
There was no `dbDump.Close()` before, Windows doesn't like to delete opened files.