### PR TITLE
Fix switched citation format

### DIFF
--- a/web_src/js/features/citation.js
+++ b/web_src/js/features/citation.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 
 const {pageData} = window.config;
 
-const initInputCitationValue = async ($citationCopyBibtex, $citationCopyApa) => {
+const initInputCitationValue = async ($citationCopyApa, $citationCopyBibtex) => {
   const [{Cite, plugins}] = await Promise.all([
     import(/* webpackChunkName: "citation-js-core" */'@citation-js/core'),
     import(/* webpackChunkName: "citation-js-formats" */'@citation-js/plugin-software-formats'),


### PR DESCRIPTION
Due to switched input parameters, the citation texts for Bibtex and Apa were switched.
This pull request fixes #23244
