### PR TITLE
Use async await to fix empty quote reply at first time (#23168) 

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -417,6 +417,22 @@ function assignMenuAttributes(menu) {
   return id;
 }
 
+export async function handleReply($el) {
+  hideElem($el);
+  const form = $el.closest('.comment-code-cloud').find('.comment-form');
+  form.removeClass('gt-hidden');
+  const $textarea = form.find('textarea');
+  let easyMDE = getAttachedEasyMDE($textarea);
+  if (!easyMDE) {
+    await attachTribute($textarea.get(), {mentions: true, emoji: true});
+    easyMDE = await createCommentEasyMDE($textarea);
+  }
+  $textarea.focus();
+  easyMDE.codemirror.focus();
+  assignMenuAttributes(form.find('.menu'));
+  return easyMDE;
+}
+
 export function initRepoPullRequestReview() {
   if (window.location.hash && window.location.hash.startsWith('#issuecomment-')) {
     const commentDiv = $(window.location.hash);
@@ -454,19 +470,7 @@ export function initRepoPullRequestReview() {
 
   $(document).on('click', 'button.comment-form-reply', async function (e) {
     e.preventDefault();
-
-    $(this).hide();
-    const form = $(this).closest('.comment-code-cloud').find('.comment-form');
-    form.removeClass('hide');
-    const $textarea = form.find('textarea');
-    let easyMDE = getAttachedEasyMDE($textarea);
-    if (!easyMDE) {
-      await attachTribute($textarea.get(), {mentions: true, emoji: true});
-      easyMDE = await createCommentEasyMDE($textarea);
-    }
-    $textarea.focus();
-    easyMDE.codemirror.focus();
-    assignMenuAttributes(form.find('.menu'));
+    await handleReply($(this));
   });
 
   const $reviewBox = $('.review-box');

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -9,7 +9,7 @@ import {
   initRepoIssueReferenceIssue, initRepoIssueStatusButton,
   initRepoIssueTitleEdit,
   initRepoIssueWipToggle, initRepoPullRequestUpdate,
-  updateIssuesMeta,
+  updateIssuesMeta, handleReply
 } from './repo-issue.js';
 import {initUnicodeEscapeButton} from './repo-unicode-escape.js';
 import {svg} from '../svg.js';
@@ -567,16 +567,15 @@ function initRepoIssueCommentEdit() {
   $(document).on('click', '.edit-content', onEditContent);
 
   // Quote reply
-  $(document).on('click', '.quote-reply', function (event) {
-    $(this).closest('.dropdown').find('.menu').toggle('visible');
+  $(document).on('click', '.quote-reply', async function (event) {
+    event.preventDefault();
     const target = $(this).data('target');
     const quote = $(`#comment-${target}`).text().replace(/\n/g, '\n> ');
     const content = `> ${quote}\n\n`;
     let easyMDE;
     if ($(this).hasClass('quote-reply-diff')) {
-      const $parent = $(this).closest('.comment-code-cloud');
-      $parent.find('button.comment-form-reply').trigger('click');
-      easyMDE = getAttachedEasyMDE($parent.find('[name="content"]'));
+      const $replyBtn = $(this).closest('.comment-code-cloud').find('button.comment-form-reply');
+      easyMDE = await handleReply($replyBtn);
     } else {
       // for normal issue/comment page
       easyMDE = getAttachedEasyMDE($('#comment-form .edit_area'));
@@ -592,6 +591,5 @@ function initRepoIssueCommentEdit() {
         easyMDE.codemirror.setCursor(easyMDE.codemirror.lineCount(), 0);
       });
     }
-    event.preventDefault();
   });
 }


### PR DESCRIPTION
Backport #23168 

The reason why quote reply is empty is when quote reply is clicked, it triggers the click function on `.comment-form-reply` button, and when the first time this function is triggered, easyMDE for the reply has not yet initialized, so that click handler of `.quote-reply` button in `repo-legacy.js` got an `undefined` as easyMDE, and the following lines which put quoted reply into the easyMDE is not executed. The workaround in this PR is to pass the replied content to '.comment-form-reply' button if easyMDE is not yet initialized (quote reply first clicked) and put the replied content into it the after easyMDE is created.
Now quote reply on first click:

https://user-images.githubusercontent.com/17645053/221452823-fc699d50-1649-4af1-952e-f04fc8d2978e.mov

<br />

Update:
The above change is not appropriate as stated in the [comment](https://github.com/go-gitea/gitea/pull/23168#issuecomment-1445562284) Use await instead

Close #22075.
Close #23247.

