### PR TITLE
Fix code wrap for unbroken lines

### DIFF
--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2121,8 +2121,9 @@ a.ui.label:hover {
   font: 12px var(--fonts-monospace);
   white-space: pre-wrap;
   word-break: break-all;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  /* stylelint-disable-next-line declaration-property-value-no-unknown */
+  word-wrap: anywhere; // Firefox respects word-wrap more than overflow-wrap
 }
 
 .blame .code-inner {

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -2122,8 +2122,6 @@ a.ui.label:hover {
   white-space: pre-wrap;
   word-break: break-all;
   overflow-wrap: anywhere;
-  /* stylelint-disable-next-line declaration-property-value-no-unknown */
-  word-wrap: anywhere; // Firefox respects word-wrap more than overflow-wrap
 }
 
 .blame .code-inner {


### PR DESCRIPTION
## The Problem

`overflow-wrap: break-word` doesn't work well for unbroken lines. Use `overflow-wrap: anywhere` instead, and remove legacy alias `word-wrap`

## Before

![image](https://user-images.githubusercontent.com/2114189/222743939-5f38d9e4-18d8-4ae0-8078-4b3a59195a30.png)

## After

![image](https://user-images.githubusercontent.com/2114189/222743833-0e0cfdbb-7b2e-420d-99f9-b1b45dde521a.png)