### PR TITLE
Fix grammar in error message

### DIFF
--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -52,7 +52,7 @@ func (s *Service) Register(
 	}
 
 	if runnerToken.IsActive {
-		return nil, errors.New("runner token has already activated")
+		return nil, errors.New("runner token has already been activated")
 	}
 
 	// create new runner


### PR DESCRIPTION
Fixes the grammar in the error message in case a runner token has already been activated