### PR TITLE
Fix broken code editor diff preview

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -474,7 +474,7 @@ func ParsePatch(maxLines, maxLineCharacters, maxFiles int, reader io.Reader, ski
 	sb := strings.Builder{}
 
 	// OK let's set a reasonable buffer size.
-	// This should be let's say at least the size of maxLineCharacters or 4096 whichever is larger.
+	// This should be at least the size of maxLineCharacters or 4096 whichever is larger.
 	readerSize := maxLineCharacters
 	if readerSize < 4096 {
 		readerSize = 4096

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -1,9 +1,9 @@
 {{$file := .file}}
 {{range $j, $section := $file.Sections}}
 	{{range $k, $line := $section.Lines}}
-		{{if or $.root.AfterCommitID (ne .GetType 4)}}
-			<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
-				{{if eq .GetType 4}}
+		<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
+			{{if eq .GetType 4}}
+				{{if $.root.AfterCommitID}}
 					<td colspan="2" class="lines-num">
 						{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5)}}
 							<a role="button" class="blob-excerpt" data-url="{{$.root.RepoLink}}/blob_excerpt/{{PathEscape $.root.AfterCommitID}}" data-query="{{$line.GetBlobExcerptQuery}}&style=unified&direction=down&wiki={{$.root.PageIsWiki}}" data-anchor="diff-{{$file.NameHash}}K{{$line.SectionInfo.RightIdx}}">
@@ -22,35 +22,38 @@
 						{{end}}
 					</td>
 				{{else}}
-					<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$file.NameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
-					<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$file.NameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
+					{{/* for code file preview page or comment diffs on pull comment pages, do not show the expansion arrows */}}
+					<td colspan="2" class="lines-num"></td>
 				{{end}}
-				{{$inlineDiff := $section.GetComputedInlineDiffFor $line $.root.locale -}}
-				<td class="lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></a>{{end}}</td>
-				<td class="lines-type-marker"><span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
-				{{if eq .GetType 4}}
-					<td class="chroma lines-code blob-hunk">{{/*
-						*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
-					*/}}</td>
-				{{else}}
-					<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*
-						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
-							*/}}<a class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">{{/*
-								*/}}{{svg "octicon-plus"}}{{/*
-							*/}}</a>{{/*
-						*/}}{{end}}{{/*
-						*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
-					*/}}</td>
-				{{end}}
-			</tr>
-			{{if gt (len $line.Comments) 0}}
-				<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
-					<td colspan="3" class="lines-num"></td>
-					<td class="add-comment-left add-comment-right" colspan="5">
-						{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
-					</td>
-				</tr>
+			{{else}}
+				<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$file.NameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
+				<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$file.NameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
 			{{end}}
+			{{$inlineDiff := $section.GetComputedInlineDiffFor $line $.root.locale -}}
+			<td class="lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<a href="" class="toggle-escape-button" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></a>{{end}}</td>
+			<td class="lines-type-marker"><span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
+			{{if eq .GetType 4}}
+				<td class="chroma lines-code blob-hunk">{{/*
+					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+				*/}}</td>
+			{{else}}
+				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*
+					*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
+						*/}}<a class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">{{/*
+							*/}}{{svg "octicon-plus"}}{{/*
+						*/}}</a>{{/*
+					*/}}{{end}}{{/*
+					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+				*/}}</td>
+			{{end}}
+		</tr>
+		{{if gt (len $line.Comments) 0}}
+			<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+				<td colspan="3" class="lines-num"></td>
+				<td class="add-comment-left add-comment-right" colspan="5">
+					{{template "repo/diff/conversation" mergeinto $.root "comments" $line.Comments}}
+				</td>
+			</tr>
 		{{end}}
 	{{end}}
 {{end}}

--- a/templates/repo/editor/diff_preview.tmpl
+++ b/templates/repo/editor/diff_preview.tmpl
@@ -1,6 +1,6 @@
 <div class="diff-file-box">
 	<div class="ui attached table segment">
-		<div class="file-body file-code code-view code-diff-unified unicode-escaped">
+		<div class="file-body file-code code-diff code-diff-unified unicode-escaped">
 			<table>
 				<tbody>
 					{{template "repo/diff/section_unified" dict "file" .File "root" $}}


### PR DESCRIPTION
Close #23265, the code editor diff preview has been broken for long time.

* Fix the regression for `data-line-num`
    * `.code-diff` is necessary to show the line number
* Fix the regression for #12434
    * The diff: [12434](https://github.com/go-gitea/gitea/pull/12434/files?diff=unified&w=1)
    * It hides the Type(4) (aka HunkHeader)  for unexpected cases.


Diff with ignoring whitespaces: https://github.com/go-gitea/gitea/pull/23307/files?diff=unified&w=1

Before: see the issue #23265

After:

![image](https://user-images.githubusercontent.com/2114189/222942810-286dc9af-0b39-4e9d-8585-8c299b881241.png)
