### PR TITLE
Fix some files are recognized as SVG incorrectly, make the diff UI unable to work

### DIFF
--- a/modules/typesniffer/typesniffer.go
+++ b/modules/typesniffer/typesniffer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"code.gitea.io/gitea/modules/util"
@@ -21,11 +20,6 @@ const (
 	SvgMimeType = "image/svg+xml"
 	// ApplicationOctetStream MIME type of binary files.
 	ApplicationOctetStream = "application/octet-stream"
-)
-
-var (
-	svgTagRegex      = regexp.MustCompile(`(?si)\A\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg([\s:]+.*?>|>))\s*)*<svg[\s>\/]`)
-	svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg([\s:]+.*?>|>))\s*)*<svg[\s>\/]`)
 )
 
 // SniffedType contains information about a blobs type.
@@ -89,12 +83,6 @@ func DetectContentType(data []byte) SniffedType {
 
 	if len(data) > sniffLen {
 		data = data[:sniffLen]
-	}
-
-	if (strings.Contains(ct, "text/plain") || strings.Contains(ct, "text/html")) && svgTagRegex.Match(data) ||
-		strings.Contains(ct, "text/xml") && svgTagInXMLRegex.Match(data) {
-		// SVG is unsupported. https://github.com/golang/go/issues/15888
-		ct = SvgMimeType
 	}
 
 	return SniffedType{ct}

--- a/modules/typesniffer/typesniffer_test.go
+++ b/modules/typesniffer/typesniffer_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestDetectContentTypeLongerThanSniffLen(t *testing.T) {
-	// Pre-condition: Shorter than sniffLen detects SVG.
-	assert.Equal(t, "image/svg+xml", DetectContentType([]byte(`<!-- Comment --><svg></svg>`)).contentType)
 	// Longer than sniffLen detects something else.
 	assert.NotEqual(t, "image/svg+xml", DetectContentType([]byte(`<!-- `+strings.Repeat("x", sniffLen)+` --><svg></svg>`)).contentType)
 }
@@ -22,52 +20,6 @@ func TestDetectContentTypeLongerThanSniffLen(t *testing.T) {
 func TestIsTextFile(t *testing.T) {
 	assert.True(t, DetectContentType([]byte{}).IsText())
 	assert.True(t, DetectContentType([]byte("lorem ipsum")).IsText())
-}
-
-func TestIsSvgImage(t *testing.T) {
-	assert.True(t, DetectContentType([]byte("<svg></svg>")).IsSvgImage())
-	assert.True(t, DetectContentType([]byte("    <svg></svg>")).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<svg width="100"></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte("<svg/>")).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?><svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<!-- Comment -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<!-- Multiple -->
-	<!-- Comments -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<!-- Multiline
-	Comment -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Basic//EN"
-	"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-basic.dtd">
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<!-- Comment -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<!-- Multiple -->
-	<!-- Comments -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<!-- Multline
-	Comment -->
-	<svg></svg>`)).IsSvgImage())
-	assert.True(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-	<!-- Multline
-	Comment -->
-	<svg></svg>`)).IsSvgImage())
-	assert.False(t, DetectContentType([]byte{}).IsSvgImage())
-	assert.False(t, DetectContentType([]byte("svg")).IsSvgImage())
-	assert.False(t, DetectContentType([]byte("<svgfoo></svgfoo>")).IsSvgImage())
-	assert.False(t, DetectContentType([]byte("text<svg></svg>")).IsSvgImage())
-	assert.False(t, DetectContentType([]byte("<html><body><svg></svg></body></html>")).IsSvgImage())
-	assert.False(t, DetectContentType([]byte(`<script>"<svg></svg>"</script>`)).IsSvgImage())
-	assert.False(t, DetectContentType([]byte(`<!-- <svg></svg> inside comment -->
-	<foo></foo>`)).IsSvgImage())
-	assert.False(t, DetectContentType([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<!-- <svg></svg> inside comment -->
-	<foo></foo>`)).IsSvgImage())
 }
 
 func TestIsPDF(t *testing.T) {


### PR DESCRIPTION
SVG file displaying is broken, meanwhile also breaks other diff files (such as php html templates) from displaying in the diff ui

Every commit here does not display SVGs, and also showcaases broken php html template display
https://try.gitea.io/stuzer05/test-preview/commits/branch/master

So I removed "smart" svg detection at all

Closes #19733