### PR TITLE
Fix incorrect project links and use symlink icon for org-wide projects

### DIFF
--- a/templates/org/menu.tmpl
+++ b/templates/org/menu.tmpl
@@ -4,7 +4,7 @@
 			{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 		</a>
 		<a class="{{if .PageIsViewProjects}}active {{end}}item" href="{{$.Org.HomeLink}}/-/projects">
-			{{svg "octicon-project"}} {{.locale.Tr "user.projects"}}
+			{{svg "octicon-project-symlink"}} {{.locale.Tr "user.projects"}}
 		</a>
 		{{if .IsPackageEnabled}}
 		<a class="item" href="{{$.Org.HomeLink}}/-/packages">

--- a/templates/projects/list.tmpl
+++ b/templates/projects/list.tmpl
@@ -12,7 +12,7 @@
 		{{template "base/alert" .}}
 		<div class="ui compact tiny menu">
 			<a class="item{{if not .IsShowClosed}} active{{end}}" href="{{$.Link}}?state=open">
-				{{svg "octicon-project" 16 "gt-mr-3"}}
+				{{svg "octicon-project-symlink" 16 "gt-mr-3"}}
 				{{JsPrettyNumber .OpenCount}}&nbsp;{{.locale.Tr "repo.issues.open_title"}}
 			</a>
 			<a class="item{{if .IsShowClosed}} active{{end}}" href="{{$.Link}}?state=closed">
@@ -38,7 +38,7 @@
 		<div class="milestone list">
 			{{range .Projects}}
 				<li class="item">
-					{{svg "octicon-project"}} <a href="{{$.Link}}/{{.ID}}">{{.Title}}</a>
+					{{svg "octicon-project-symlink"}} <a href="{{.Link}}">{{.Title}}</a>
 					<div class="meta">
 						{{$closedDate:= TimeSinceUnix .ClosedDateUnix $.locale}}
 						{{if .IsClosed}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -176,8 +176,8 @@
 								{{.locale.Tr "repo.issues.new.open_projects"}}
 							</div>
 							{{range .OpenProjects}}
-								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
-									{{svg "octicon-project" 18 "gt-mr-3"}}
+								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
+									{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
 									{{.Title}}
 								</a>
 							{{end}}
@@ -188,8 +188,8 @@
 								{{.locale.Tr "repo.issues.new.closed_projects"}}
 							</div>
 							{{range .ClosedProjects}}
-								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{$.RepoLink}}/projects/{{.ID}}">
-									{{svg "octicon-project" 18 "gt-mr-3"}}
+								<a class="item muted sidebar-item-link" data-id="{{.ID}}" data-href="{{.Link}}">
+									{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
 									{{.Title}}
 								</a>
 							{{end}}
@@ -201,8 +201,8 @@
 				<span class="no-select item {{if .Project}}gt-hidden{{end}}">{{.locale.Tr "repo.issues.new.no_projects"}}</span>
 				<div class="selected">
 					{{if .Project}}
-						<a class="item muted sidebar-item-link" href="{{.RepoLink}}/projects/{{.Project.ID}}">
-							{{svg "octicon-project" 18 "gt-mr-3"}}
+						<a class="item muted sidebar-item-link" href="{{.Project.Link}}">
+							{{if .IsOrganizationProject}}{{svg "octicon-project-symlink" 18 "gt-mr-3"}}{{else}}{{svg "octicon-project" 18 "gt-mr-3"}}{{end}}
 							{{.Project.Title}}
 						</a>
 					{{end}}

--- a/templates/repo/projects/list.tmpl
+++ b/templates/repo/projects/list.tmpl
@@ -40,7 +40,7 @@
 		<div class="milestone list">
 			{{range .Projects}}
 				<li class="item">
-					{{svg "octicon-project"}} <a href="{{$.RepoLink}}/projects/{{.ID}}">{{.Title}}</a>
+					{{svg "octicon-project"}} <a href="{{.Link}}">{{.Title}}</a>
 					<div class="meta">
 						{{$closedDate:= TimeSinceUnix .ClosedDateUnix $.locale}}
 						{{if .IsClosed}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -87,7 +87,7 @@
 						</a>
 					{{end}}
 					{{if .Project}}
-						<a class="project" {{if $.RepoLink}}href="{{$.RepoLink}}/projects/{{.Project.ID}}"{{else}}href="{{.Repo.Link}}/projects/{{.Project.ID}}"{{end}}>
+						<a class="project" href="{{.Project.Link}}">
 							{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 14 "gt-mr-2"}}{{else}}{{svg "octicon-project" 14 "gt-mr-2"}}{{end}}{{.Project.Title}}
 						</a>
 					{{end}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -88,7 +88,7 @@
 					{{end}}
 					{{if .Project}}
 						<a class="project" {{if $.RepoLink}}href="{{$.RepoLink}}/projects/{{.Project.ID}}"{{else}}href="{{.Repo.Link}}/projects/{{.Project.ID}}"{{end}}>
-							{{svg "octicon-project" 14 "gt-mr-2"}}{{.Project.Title}}
+							{{if .Project.IsOrganizationProject}}{{svg "octicon-project-symlink" 14 "gt-mr-2"}}{{else}}{{svg "octicon-project" 14 "gt-mr-2"}}{{end}}{{.Project.Title}}
 						</a>
 					{{end}}
 					{{if .Ref}}

--- a/templates/user/overview/header.tmpl
+++ b/templates/user/overview/header.tmpl
@@ -23,7 +23,7 @@
 				{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 			</a>
 			<a href="{{.ContextUser.HomeLink}}/-/projects" class="{{if .PageIsViewProjects}}active {{end}}item">
-				{{svg "octicon-project"}} {{.locale.Tr "user.projects"}}
+				{{svg "octicon-project-symlink"}} {{.locale.Tr "user.projects"}}
 			</a>
 			{{if (not .UnitPackagesGlobalDisabled)}}
 				<a href="{{.ContextUser.HomeLink}}/-/packages" class="{{if .IsPackagesPage}}active {{end}}item">

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -107,7 +107,7 @@
 						{{svg "octicon-repo"}} {{.locale.Tr "user.repositories"}}
 					</a>
 					<a href="{{.Owner.HomeLink}}/-/projects" class="{{if eq .TabName "projects"}}active {{end}}item">
-						{{svg "octicon-project"}} {{.locale.Tr "user.projects"}}
+						{{svg "octicon-project-symlink"}} {{.locale.Tr "user.projects"}}
 					</a>
 					{{if .IsPackageEnabled}}
 					<a class='{{if eq .TabName "packages"}}active {{end}}item' href="{{.Owner.HomeLink}}/-/packages">


### PR DESCRIPTION
Fix displaying same projects icons between user/repo projects.
And fix incorrect projects links.
A part of https://github.com/go-gitea/gitea/pull/22865.

![image](https://user-images.githubusercontent.com/18380374/223044279-7b620ff1-d88a-4146-97e6-531bbf269761.png)
![image](https://user-images.githubusercontent.com/18380374/223044390-42911e3f-1f6b-439f-8441-4f3ebf99ea13.png)
![image](https://user-images.githubusercontent.com/18380374/223044437-5cad5391-0f95-4c8b-b0a3-32e263e2854f.png)
