### PR TITLE
Fix incorrect redirect link of delete org project

### DIFF
--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -205,7 +205,7 @@ func DeleteProject(ctx *context.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, map[string]interface{}{
-		"redirect": ctx.Repo.RepoLink + "/projects",
+		"redirect": ctx.ContextUser.HomeLink() + "/-/projects",
 	})
 }
 


### PR DESCRIPTION
A part of https://github.com/go-gitea/gitea/pull/22865/commits

The old code will cause 500 error.
