### PR TITLE
Remove unnecessary space on link

### DIFF
--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -7,7 +7,7 @@
 			<div class="issue-item-main gt-f1 gt-fc gt-df">
 				<div class="issue-item-top-row">
 					<a class="index gt-ml-0 gt-mr-2" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
-						{{.Title}}
+						{{- .Title -}}
 					</a>
 					<span class="ui label">
 						{{if .RefLink}}


### PR DESCRIPTION
The action run title has a blank. This PR removes it.