### PR TITLE
Fix display for context menu

### DIFF
--- a/templates/repo/issue/view_content/context_menu.tmpl
+++ b/templates/repo/issue/view_content/context_menu.tmpl
@@ -10,16 +10,16 @@
 		{{else}}
 			{{$referenceUrl = Printf "%s/files#%s" .ctxData.Issue.Link .item.HashTag}}
 		{{end}}
-		<a class="item context" data-clipboard-text-type="url" data-clipboard-text="{{AppSubUrl}}{{$referenceUrl}}">{{.ctxData.locale.Tr "repo.issues.context.copy_link"}}</a>
-		<a class="item context quote-reply {{if .diff}}quote-reply-diff{{end}}" data-target="{{.item.HashTag}}-raw">{{.ctxData.locale.Tr "repo.issues.context.quote_reply"}}</a>
+		<a class="item context gt-db" data-clipboard-text-type="url" data-clipboard-text="{{AppSubUrl}}{{$referenceUrl}}">{{.ctxData.locale.Tr "repo.issues.context.copy_link"}}</a>
+		<a class="item context gt-db quote-reply {{if .diff}}quote-reply-diff{{end}}" data-target="{{.item.HashTag}}-raw">{{.ctxData.locale.Tr "repo.issues.context.quote_reply"}}</a>
 		{{if not .ctxData.UnitIssuesGlobalDisabled}}
-			<a class="item context reference-issue" data-target="{{.item.HashTag}}-raw" data-modal="#reference-issue-modal" data-poster="{{.item.Poster.GetDisplayName}}" data-poster-username="{{.item.Poster.Name}}" data-reference="{{$referenceUrl}}">{{.ctxData.locale.Tr "repo.issues.context.reference_issue"}}</a>
+			<a class="item context gt-db reference-issue" data-target="{{.item.HashTag}}-raw" data-modal="#reference-issue-modal" data-poster="{{.item.Poster.GetDisplayName}}" data-poster-username="{{.item.Poster.Name}}" data-reference="{{$referenceUrl}}">{{.ctxData.locale.Tr "repo.issues.context.reference_issue"}}</a>
 		{{end}}
 		{{if or .ctxData.Permission.IsAdmin .IsCommentPoster .ctxData.HasIssuesOrPullsWritePermission}}
 			<div class="divider"></div>
-			<a class="item context edit-content">{{.ctxData.locale.Tr "repo.issues.context.edit"}}</a>
+			<a class="item context gt-db edit-content">{{.ctxData.locale.Tr "repo.issues.context.edit"}}</a>
 			{{if .delete}}
-				<a class="item context delete-comment" data-comment-id={{.item.HashTag}} data-url="{{.ctxData.RepoLink}}/comments/{{.item.ID}}/delete" data-locale="{{.ctxData.locale.Tr "repo.issues.delete_comment_confirm"}}">{{.ctxData.locale.Tr "repo.issues.context.delete"}}</a>
+				<a class="item context gt-db delete-comment" data-comment-id={{.item.HashTag}} data-url="{{.ctxData.RepoLink}}/comments/{{.item.ID}}/delete" data-locale="{{.ctxData.locale.Tr "repo.issues.delete_comment_confirm"}}">{{.ctxData.locale.Tr "repo.issues.context.delete"}}</a>
 			{{end}}
 		{{end}}
 	</div>

--- a/web_src/less/helpers.less
+++ b/web_src/less/helpers.less
@@ -1,6 +1,7 @@
 .gt-df { display: flex !important; }
 .gt-di { display: inline !important; }
 .gt-dif { display: inline-flex !important; }
+.gt-db { display: block !important; }
 .gt-dib { display: inline-block !important; }
 .gt-ac { align-items: center !important; }
 .gt-tc { text-align: center !important; }


### PR DESCRIPTION
This PR is to fix the wrong display for context menu. The reason this occurs is because `display` was overwitten by style of fomantic component, specifically the following rule
```css
.ui.comments .comment .actions a {
    cursor: pointer;
    display: inline-block; // should be block
    margin: 0 0.75em 0 0;
    color: rgba(0, 0, 0, 0.4);
}
```

Before:
<img width="777" alt="截屏2023-03-07 08 54 28" src="https://user-images.githubusercontent.com/17645053/223291079-6e2f5445-ce87-4725-af6c-e20244404a58.png">

After:
 
<img width="921" alt="截屏2023-03-07 08 50 45" src="https://user-images.githubusercontent.com/17645053/223291098-930c844c-ae7a-4284-963a-e860b004caeb.png">
