### PR TITLE
Ensure `setting.Database.UseXXX` has been set to the right value when installing

### DIFF
--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -61,22 +61,12 @@ func LoadDBSetting() {
 	sec := CfgProvider.Section("database")
 	Database.Type = sec.Key("DB_TYPE").String()
 	defaultCharset := "utf8"
-	Database.UseMySQL = false
-	Database.UseSQLite3 = false
-	Database.UsePostgreSQL = false
-	Database.UseMSSQL = false
 
-	switch Database.Type {
-	case "sqlite3":
-		Database.UseSQLite3 = true
-	case "mysql":
-		Database.UseMySQL = true
+	EnsureDBType()
+	if Database.UseMySQL {
 		defaultCharset = "utf8mb4"
-	case "postgres":
-		Database.UsePostgreSQL = true
-	case "mssql":
-		Database.UseMSSQL = true
 	}
+
 	Database.Host = sec.Key("HOST").String()
 	Database.Name = sec.Key("NAME").String()
 	Database.User = sec.Key("USER").String()
@@ -107,6 +97,25 @@ func LoadDBSetting() {
 	Database.DBConnectRetries = sec.Key("DB_RETRIES").MustInt(10)
 	Database.DBConnectBackoff = sec.Key("DB_RETRY_BACKOFF").MustDuration(3 * time.Second)
 	Database.AutoMigration = sec.Key("AUTO_MIGRATION").MustBool(true)
+}
+
+// EnsureDBType ensures Database.UseXXX has been set to the right value
+func EnsureDBType() {
+	Database.UseMySQL = false
+	Database.UseSQLite3 = false
+	Database.UsePostgreSQL = false
+	Database.UseMSSQL = false
+
+	switch Database.Type {
+	case "sqlite3":
+		Database.UseSQLite3 = true
+	case "mysql":
+		Database.UseMySQL = true
+	case "postgres":
+		Database.UsePostgreSQL = true
+	case "mssql":
+		Database.UseMSSQL = true
+	}
 }
 
 // DBConnStr returns database connection string

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -273,6 +273,7 @@ func SubmitInstall(ctx *context.Context) {
 
 	// Test database setting.
 	setting.Database.Type = form.DbType
+	setting.EnsureDBType()
 	setting.Database.Host = form.DbHost
 	setting.Database.User = form.DbUser
 	setting.Database.Passwd = form.DbPasswd


### PR DESCRIPTION
`setting.Database.Type` has been modified, but `setting.Database.UseXXX` hasn't.

https://github.com/go-gitea/gitea/blob/84a299310d9a8f6387f18a1711485b7f33e6f6b5/routers/install/install.go#L274-L276

So `registerPostgresSchemaDriver` will be missed when initing DB engine.

https://github.com/go-gitea/gitea/blob/84a299310d9a8f6387f18a1711485b7f33e6f6b5/models/db/engine.go#L104-L110

---

BTW, I think it will be a good idea to refactor `setting.Database.UseXXX` to methods.

Update: #23354