### PR TITLE
Fix adding of empty class name

### DIFF
--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -80,7 +80,8 @@ export function svg(name, size = 16, className = '') {
   const svgNode = document.firstChild;
   if (size !== 16) svgNode.setAttribute('width', String(size));
   if (size !== 16) svgNode.setAttribute('height', String(size));
-  if (className) svgNode.classList.add(...className.split(/\s+/));
+  // filter array to remove empty string
+  if (className) svgNode.classList.add(...className.split(/\s+/).filter(item => item));
   return serializer.serializeToString(svgNode);
 }
 

--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -81,7 +81,7 @@ export function svg(name, size = 16, className = '') {
   if (size !== 16) svgNode.setAttribute('width', String(size));
   if (size !== 16) svgNode.setAttribute('height', String(size));
   // filter array to remove empty string
-  if (className) svgNode.classList.add(...className.split(/\s+/).filter(item => item));
+  if (className) svgNode.classList.add(...className.split(/\s+/).filter(Boolean));
   return serializer.serializeToString(svgNode);
 }
 


### PR DESCRIPTION
This PR is to fix the error shown below. The reason is because [`class-name` prop](https://github.com/go-gitea/gitea/blob/main/web_src/js/components/ActionRunStatus.vue#L6) given to `svg` component has a space, and classList cannot add empty string. 


https://user-images.githubusercontent.com/17645053/223346720-c7f9de43-5e69-4ecf-93c0-90bf04090693.mov

