### PR TITLE
Refactor `setting.Database.UseXXX` to methods

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -35,7 +35,7 @@ func runConvert(ctx *cli.Context) error {
 	log.Info("Log path: %s", setting.Log.RootPath)
 	log.Info("Configuration file: %s", setting.CustomConf)
 
-	if !setting.Database.UseMySQL {
+	if !setting.Database.Type.IsMySQL() {
 		fmt.Println("This command can only be used with a MySQL database")
 		return nil
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -279,7 +279,7 @@ func runDump(ctx *cli.Context) error {
 	}()
 
 	targetDBType := ctx.String("database")
-	if len(targetDBType) > 0 && targetDBType != setting.Database.Type {
+	if len(targetDBType) > 0 && targetDBType != setting.Database.Type.String() {
 		log.Info("Dumping database %s => %s...", setting.Database.Type, targetDBType)
 	} else {
 		log.Info("Dumping database...")

--- a/models/activities/action.go
+++ b/models/activities/action.go
@@ -99,7 +99,7 @@ func (a *Action) TableIndices() []*schemas.Index {
 	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
 
 	indices := []*schemas.Index{actUserIndex, repoIndex}
-	if setting.Database.UsePostgreSQL {
+	if setting.Database.Type.IsPostgreSQL() {
 		cudIndex := schemas.NewIndex("c_u_d", schemas.IndexType)
 		cudIndex.AddColumn("created_unix", "user_id", "is_deleted")
 		indices = append(indices, cudIndex)
@@ -640,7 +640,7 @@ func DeleteIssueActions(ctx context.Context, repoID, issueID int64) error {
 
 // CountActionCreatedUnixString count actions where created_unix is an empty string
 func CountActionCreatedUnixString(ctx context.Context) (int64, error) {
-	if setting.Database.UseSQLite3 {
+	if setting.Database.Type.IsSQLite3() {
 		return db.GetEngine(ctx).Where(`created_unix = ""`).Count(new(Action))
 	}
 	return 0, nil
@@ -648,7 +648,7 @@ func CountActionCreatedUnixString(ctx context.Context) (int64, error) {
 
 // FixActionCreatedUnixString set created_unix to zero if it is an empty string
 func FixActionCreatedUnixString(ctx context.Context) (int64, error) {
-	if setting.Database.UseSQLite3 {
+	if setting.Database.Type.IsSQLite3() {
 		res, err := db.GetEngine(ctx).Exec(`UPDATE action SET created_unix = 0 WHERE created_unix = ""`)
 		if err != nil {
 			return 0, err

--- a/models/activities/action_test.go
+++ b/models/activities/action_test.go
@@ -243,7 +243,7 @@ func TestGetFeedsCorrupted(t *testing.T) {
 }
 
 func TestConsistencyUpdateAction(t *testing.T) {
-	if !setting.Database.UseSQLite3 {
+	if !setting.Database.Type.IsSQLite3() {
 		t.Skip("Test is only for SQLite database.")
 	}
 	assert.NoError(t, unittest.PrepareTestDatabase())

--- a/models/activities/user_heatmap.go
+++ b/models/activities/user_heatmap.go
@@ -39,9 +39,9 @@ func getUserHeatmapData(user *user_model.User, team *organization.Team, doer *us
 	groupBy := "created_unix / 900 * 900"
 	groupByName := "timestamp" // We need this extra case because mssql doesn't allow grouping by alias
 	switch {
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		groupBy = "created_unix DIV 900 * 900"
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		groupByName = groupBy
 	}
 

--- a/models/db/common.go
+++ b/models/db/common.go
@@ -15,7 +15,7 @@ import (
 // BuildCaseInsensitiveLike returns a condition to check if the given value is like the given key case-insensitively.
 // Handles especially SQLite correctly as UPPER there only transforms ASCII letters.
 func BuildCaseInsensitiveLike(key, value string) builder.Cond {
-	if setting.Database.UseSQLite3 {
+	if setting.Database.Type.IsSQLite3() {
 		return builder.Like{"UPPER(" + key + ")", util.ToUpperASCII(value)}
 	}
 	return builder.Like{"UPPER(" + key + ")", strings.ToUpper(value)}

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -101,12 +101,12 @@ func newXORMEngine() (*xorm.Engine, error) {
 
 	var engine *xorm.Engine
 
-	if setting.Database.UsePostgreSQL && len(setting.Database.Schema) > 0 {
+	if setting.Database.Type.IsPostgreSQL() && len(setting.Database.Schema) > 0 {
 		// OK whilst we sort out our schema issues - create a schema aware postgres
 		registerPostgresSchemaDriver()
 		engine, err = xorm.NewEngine("postgresschema", connStr)
 	} else {
-		engine, err = xorm.NewEngine(setting.Database.Type, connStr)
+		engine, err = xorm.NewEngine(setting.Database.Type.String(), connStr)
 	}
 
 	if err != nil {

--- a/models/db/index.go
+++ b/models/db/index.go
@@ -73,7 +73,7 @@ func postgresGetNextResourceIndex(ctx context.Context, tableName string, groupID
 
 // GetNextResourceIndex generates a resource index, it must run in the same transaction where the resource is created
 func GetNextResourceIndex(ctx context.Context, tableName string, groupID int64) (int64, error) {
-	if setting.Database.UsePostgreSQL {
+	if setting.Database.Type.IsPostgreSQL() {
 		return postgresGetNextResourceIndex(ctx, tableName, groupID)
 	}
 

--- a/models/db/sequence.go
+++ b/models/db/sequence.go
@@ -13,7 +13,7 @@ import (
 
 // CountBadSequences looks for broken sequences from recreate-table mistakes
 func CountBadSequences(_ context.Context) (int64, error) {
-	if !setting.Database.UsePostgreSQL {
+	if !setting.Database.Type.IsPostgreSQL() {
 		return 0, nil
 	}
 
@@ -34,7 +34,7 @@ func CountBadSequences(_ context.Context) (int64, error) {
 
 // FixBadSequences fixes for broken sequences from recreate-table mistakes
 func FixBadSequences(_ context.Context) error {
-	if !setting.Database.UsePostgreSQL {
+	if !setting.Database.Type.IsPostgreSQL() {
 		return nil
 	}
 

--- a/models/git/commit_status.go
+++ b/models/git/commit_status.go
@@ -65,7 +65,7 @@ func postgresGetCommitStatusIndex(ctx context.Context, repoID int64, sha string)
 
 // GetNextCommitStatusIndex retried 3 times to generate a resource index
 func GetNextCommitStatusIndex(ctx context.Context, repoID int64, sha string) (int64, error) {
-	if setting.Database.UsePostgreSQL {
+	if setting.Database.Type.IsPostgreSQL() {
 		return postgresGetCommitStatusIndex(ctx, repoID, sha)
 	}
 

--- a/models/migrations/v1_12/v139.go
+++ b/models/migrations/v1_12/v139.go
@@ -13,9 +13,9 @@ func PrependRefsHeadsToIssueRefs(x *xorm.Engine) error {
 	var query string
 
 	switch {
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		query = "UPDATE `issue` SET `ref` = 'refs/heads/' + `ref` WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%'"
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		query = "UPDATE `issue` SET `ref` = CONCAT('refs/heads/', `ref`) WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%';"
 	default:
 		query = "UPDATE `issue` SET `ref` = 'refs/heads/' || `ref` WHERE `ref` IS NOT NULL AND `ref` <> '' AND `ref` NOT LIKE 'refs/%'"

--- a/models/migrations/v1_13/v140.go
+++ b/models/migrations/v1_13/v140.go
@@ -41,7 +41,7 @@ func FixLanguageStatsToSaveSize(x *xorm.Engine) error {
 
 	// Delete language stat statuses
 	truncExpr := "TRUNCATE TABLE"
-	if setting.Database.UseSQLite3 {
+	if setting.Database.Type.IsSQLite3() {
 		truncExpr = "DELETE FROM"
 	}
 

--- a/models/migrations/v1_13/v145.go
+++ b/models/migrations/v1_13/v145.go
@@ -21,7 +21,7 @@ func IncreaseLanguageField(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseSQLite3 {
+	if setting.Database.Type.IsSQLite3() {
 		// SQLite maps VARCHAR to TEXT without size so we're done
 		return nil
 	}
@@ -41,11 +41,11 @@ func IncreaseLanguageField(x *xorm.Engine) error {
 	}
 
 	switch {
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat MODIFY COLUMN language %s", sqlType)); err != nil {
 			return err
 		}
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		// Yet again MSSQL just has to be awkward.
 		// Here we have to drop the constraints first and then rebuild them
 		constraints := make([]string, 0)
@@ -71,7 +71,7 @@ func IncreaseLanguageField(x *xorm.Engine) error {
 		if err := sess.CreateUniques(new(LanguageStat)); err != nil {
 			return err
 		}
-	case setting.Database.UsePostgreSQL:
+	case setting.Database.Type.IsPostgreSQL():
 		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE language_stat ALTER COLUMN language TYPE %s", sqlType)); err != nil {
 			return err
 		}

--- a/models/migrations/v1_13/v151.go
+++ b/models/migrations/v1_13/v151.go
@@ -17,13 +17,13 @@ import (
 
 func SetDefaultPasswordToArgon2(x *xorm.Engine) error {
 	switch {
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		_, err := x.Exec("ALTER TABLE `user` ALTER passwd_hash_algo SET DEFAULT 'argon2';")
 		return err
-	case setting.Database.UsePostgreSQL:
+	case setting.Database.Type.IsPostgreSQL():
 		_, err := x.Exec("ALTER TABLE `user` ALTER COLUMN passwd_hash_algo SET DEFAULT 'argon2';")
 		return err
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		// need to find the constraint and drop it, then recreate it.
 		sess := x.NewSession()
 		defer sess.Close()
@@ -53,7 +53,7 @@ func SetDefaultPasswordToArgon2(x *xorm.Engine) error {
 		}
 		return sess.Commit()
 
-	case setting.Database.UseSQLite3:
+	case setting.Database.Type.IsSQLite3():
 		// drop through
 	default:
 		log.Fatal("Unrecognized DB")

--- a/models/migrations/v1_14/v158.go
+++ b/models/migrations/v1_14/v158.go
@@ -62,7 +62,7 @@ func UpdateCodeCommentReplies(x *xorm.Engine) error {
 			return err
 		}
 
-		if setting.Database.UseMSSQL {
+		if setting.Database.Type.IsMSSQL() {
 			if _, err := sess.Exec(sqlSelect + " INTO #temp_comments" + sqlTail); err != nil {
 				log.Error("unable to create temporary table")
 				return err
@@ -72,13 +72,13 @@ func UpdateCodeCommentReplies(x *xorm.Engine) error {
 		comments := make([]*Comment, 0, batchSize)
 
 		switch {
-		case setting.Database.UseMySQL:
+		case setting.Database.Type.IsMySQL():
 			sqlCmd = sqlSelect + sqlTail + " LIMIT " + strconv.Itoa(batchSize) + ", " + strconv.Itoa(start)
-		case setting.Database.UsePostgreSQL:
+		case setting.Database.Type.IsPostgreSQL():
 			fallthrough
-		case setting.Database.UseSQLite3:
+		case setting.Database.Type.IsSQLite3():
 			sqlCmd = sqlSelect + sqlTail + " LIMIT " + strconv.Itoa(batchSize) + " OFFSET " + strconv.Itoa(start)
-		case setting.Database.UseMSSQL:
+		case setting.Database.Type.IsMSSQL():
 			sqlCmd = "SELECT TOP " + strconv.Itoa(batchSize) + " * FROM #temp_comments WHERE " +
 				"(id NOT IN ( SELECT TOP " + strconv.Itoa(start) + " id FROM #temp_comments ORDER BY id )) ORDER BY id"
 		default:

--- a/models/migrations/v1_14/v175.go
+++ b/models/migrations/v1_14/v175.go
@@ -14,7 +14,7 @@ import (
 )
 
 func FixPostgresIDSequences(x *xorm.Engine) error {
-	if !setting.Database.UsePostgreSQL {
+	if !setting.Database.Type.IsPostgreSQL() {
 		return nil
 	}
 

--- a/models/migrations/v1_15/v184.go
+++ b/models/migrations/v1_15/v184.go
@@ -54,11 +54,11 @@ func RenameTaskErrorsToMessage(x *xorm.Engine) error {
 	}
 
 	switch {
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		if _, err := sess.Exec("ALTER TABLE `task` CHANGE errors message text"); err != nil {
 			return err
 		}
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		if _, err := sess.Exec("sp_rename 'task.errors', 'message', 'COLUMN'"); err != nil {
 			return err
 		}

--- a/models/migrations/v1_16/v191.go
+++ b/models/migrations/v1_16/v191.go
@@ -16,7 +16,7 @@ func AlterIssueAndCommentTextFieldsToLongText(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseMySQL {
+	if setting.Database.Type.IsMySQL() {
 		if _, err := sess.Exec("ALTER TABLE `issue` CHANGE `content` `content` LONGTEXT"); err != nil {
 			return err
 		}

--- a/models/migrations/v1_17/v217.go
+++ b/models/migrations/v1_17/v217.go
@@ -16,7 +16,7 @@ func AlterHookTaskTextFieldsToLongText(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseMySQL {
+	if setting.Database.Type.IsMySQL() {
 		if _, err := sess.Exec("ALTER TABLE `hook_task` CHANGE `payload_content` `payload_content` LONGTEXT, CHANGE `request_content` `request_content` LONGTEXT, change `response_content` `response_content` LONGTEXT"); err != nil {
 			return err
 		}

--- a/models/migrations/v1_17/v218.go
+++ b/models/migrations/v1_17/v218.go
@@ -38,7 +38,7 @@ func (*improveActionTableIndicesAction) TableIndices() []*schemas.Index {
 	actUserIndex := schemas.NewIndex("au_r_c_u_d", schemas.IndexType)
 	actUserIndex.AddColumn("act_user_id", "repo_id", "created_unix", "user_id", "is_deleted")
 	indices := []*schemas.Index{actUserIndex, repoIndex}
-	if setting.Database.UsePostgreSQL {
+	if setting.Database.Type.IsPostgreSQL() {
 		cudIndex := schemas.NewIndex("c_u_d", schemas.IndexType)
 		cudIndex.AddColumn("created_unix", "user_id", "is_deleted")
 		indices = append(indices, cudIndex)

--- a/models/migrations/v1_17/v223.go
+++ b/models/migrations/v1_17/v223.go
@@ -65,11 +65,11 @@ func RenameCredentialIDBytes(x *xorm.Engine) error {
 		}
 
 		switch {
-		case setting.Database.UseMySQL:
+		case setting.Database.Type.IsMySQL():
 			if _, err := sess.Exec("ALTER TABLE `webauthn_credential` CHANGE credential_id_bytes credential_id VARBINARY(1024)"); err != nil {
 				return err
 			}
-		case setting.Database.UseMSSQL:
+		case setting.Database.Type.IsMSSQL():
 			if _, err := sess.Exec("sp_rename 'webauthn_credential.credential_id_bytes', 'credential_id', 'COLUMN'"); err != nil {
 				return err
 			}

--- a/models/migrations/v1_18/v225.go
+++ b/models/migrations/v1_18/v225.go
@@ -16,7 +16,7 @@ func AlterPublicGPGKeyContentFieldsToMediumText(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseMySQL {
+	if setting.Database.Type.IsMySQL() {
 		if _, err := sess.Exec("ALTER TABLE `gpg_key` CHANGE `content` `content` MEDIUMTEXT"); err != nil {
 			return err
 		}

--- a/models/migrations/v1_19/v232.go
+++ b/models/migrations/v1_19/v232.go
@@ -16,7 +16,7 @@ func AlterPackageVersionMetadataToLongText(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseMySQL {
+	if setting.Database.Type.IsMySQL() {
 		if _, err := sess.Exec("ALTER TABLE `package_version` MODIFY COLUMN `metadata_json` LONGTEXT"); err != nil {
 			return err
 		}

--- a/models/migrations/v1_19/v242.go
+++ b/models/migrations/v1_19/v242.go
@@ -17,7 +17,7 @@ func AlterPublicGPGKeyImportContentFieldToMediumText(x *xorm.Engine) error {
 		return err
 	}
 
-	if setting.Database.UseMySQL {
+	if setting.Database.Type.IsMySQL() {
 		if _, err := sess.Exec("ALTER TABLE `gpg_key_import` CHANGE `content` `content` MEDIUMTEXT"); err != nil {
 			return err
 		}

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -409,7 +409,7 @@ func DeleteProjectByID(ctx context.Context, id int64) error {
 
 func DeleteProjectByRepoID(ctx context.Context, repoID int64) error {
 	switch {
-	case setting.Database.UseSQLite3:
+	case setting.Database.Type.IsSQLite3():
 		if _, err := db.GetEngine(ctx).Exec("DELETE FROM project_issue WHERE project_issue.id IN (SELECT project_issue.id FROM project_issue INNER JOIN project WHERE project.id = project_issue.project_id AND project.repo_id = ?)", repoID); err != nil {
 			return err
 		}
@@ -419,7 +419,7 @@ func DeleteProjectByRepoID(ctx context.Context, repoID int64) error {
 		if _, err := db.GetEngine(ctx).Table("project").Where("repo_id = ? ", repoID).Delete(&Project{}); err != nil {
 			return err
 		}
-	case setting.Database.UsePostgreSQL:
+	case setting.Database.Type.IsPostgreSQL():
 		if _, err := db.GetEngine(ctx).Exec("DELETE FROM project_issue USING project WHERE project.id = project_issue.project_id AND project.repo_id = ? ", repoID); err != nil {
 			return err
 		}

--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -498,7 +498,7 @@ func SearchRepositoryCondition(opts *SearchRepoOptions) builder.Cond {
 		subQueryCond := builder.NewCond()
 
 		// Topic checking. Topics are present.
-		if setting.Database.UsePostgreSQL { // postgres stores the topics as json and not as text
+		if setting.Database.Type.IsPostgreSQL() { // postgres stores the topics as json and not as text
 			subQueryCond = subQueryCond.Or(builder.And(builder.NotNull{"topics"}, builder.Neq{"(topics)::text": "[]"}))
 		} else {
 			subQueryCond = subQueryCond.Or(builder.And(builder.Neq{"topics": "null"}, builder.Neq{"topics": "[]"}))

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -76,7 +76,7 @@ func MainTest(m *testing.M, testOpts *TestOptions) {
 	setting.SSH.BuiltinServerUser = "builtinuser"
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
-	setting.Database.UseSQLite3 = true
+	setting.Database.Type = setting.ToDatabaseType("sqlite3")
 	setting.Repository.DefaultBranch = "master" // many test code still assume that default branch is called "master"
 	repoRootPath, err := os.MkdirTemp(os.TempDir(), "repos")
 	if err != nil {

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -76,7 +76,7 @@ func MainTest(m *testing.M, testOpts *TestOptions) {
 	setting.SSH.BuiltinServerUser = "builtinuser"
 	setting.SSH.Port = 3000
 	setting.SSH.Domain = "try.gitea.io"
-	setting.Database.Type = setting.ToDatabaseType("sqlite3")
+	setting.Database.Type = "sqlite3"
 	setting.Repository.DefaultBranch = "master" // many test code still assume that default branch is called "master"
 	repoRootPath, err := os.MkdirTemp(os.TempDir(), "repos")
 	if err != nil {

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -155,7 +155,7 @@ func checkDBConsistency(ctx context.Context, logger log.Logger, autofix bool) er
 
 	// TODO: function to recalc all counters
 
-	if setting.Database.UsePostgreSQL {
+	if setting.Database.Type.IsPostgreSQL() {
 		consistencyChecks = append(consistencyChecks, consistencyCheck{
 			Name:         "Sequence values",
 			Counter:      db.CountBadSequences,

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -27,7 +27,7 @@ var (
 
 	// Database holds the database settings
 	Database = struct {
-		Type              string
+		Type              databaseType
 		Host              string
 		Name              string
 		User              string
@@ -39,10 +39,6 @@ var (
 		Charset           string
 		Timeout           int // seconds
 		SQLiteJournalMode string
-		UseSQLite3        bool
-		UseMySQL          bool
-		UseMSSQL          bool
-		UsePostgreSQL     bool
 		DBConnectRetries  int
 		DBConnectBackoff  time.Duration
 		MaxIdleConns      int
@@ -59,24 +55,13 @@ var (
 // LoadDBSetting loads the database settings
 func LoadDBSetting() {
 	sec := CfgProvider.Section("database")
-	Database.Type = sec.Key("DB_TYPE").String()
+	Database.Type = ToDatabaseType(sec.Key("DB_TYPE").String())
 	defaultCharset := "utf8"
-	Database.UseMySQL = false
-	Database.UseSQLite3 = false
-	Database.UsePostgreSQL = false
-	Database.UseMSSQL = false
 
-	switch Database.Type {
-	case "sqlite3":
-		Database.UseSQLite3 = true
-	case "mysql":
-		Database.UseMySQL = true
+	if Database.Type.IsMySQL() {
 		defaultCharset = "utf8mb4"
-	case "postgres":
-		Database.UsePostgreSQL = true
-	case "mssql":
-		Database.UseMSSQL = true
 	}
+
 	Database.Host = sec.Key("HOST").String()
 	Database.Name = sec.Key("NAME").String()
 	Database.User = sec.Key("USER").String()
@@ -86,7 +71,7 @@ func LoadDBSetting() {
 	Database.Schema = sec.Key("SCHEMA").String()
 	Database.SSLMode = sec.Key("SSL_MODE").MustString("disable")
 	Database.Charset = sec.Key("CHARSET").In(defaultCharset, []string{"utf8", "utf8mb4"})
-	if Database.UseMySQL && defaultCharset != "utf8mb4" {
+	if Database.Type.IsMySQL() && defaultCharset != "utf8mb4" {
 		log.Error("Deprecated database mysql charset utf8 support, please use utf8mb4 or convert utf8 to utf8mb4.")
 	}
 
@@ -95,7 +80,7 @@ func LoadDBSetting() {
 	Database.SQLiteJournalMode = sec.Key("SQLITE_JOURNAL_MODE").MustString("")
 
 	Database.MaxIdleConns = sec.Key("MAX_IDLE_CONNS").MustInt(2)
-	if Database.UseMySQL {
+	if Database.Type.IsMySQL() {
 		Database.ConnMaxLifetime = sec.Key("CONN_MAX_LIFETIME").MustDuration(3 * time.Second)
 	} else {
 		Database.ConnMaxLifetime = sec.Key("CONN_MAX_LIFETIME").MustDuration(0)
@@ -206,4 +191,30 @@ func ParseMSSQLHostPort(info string) (string, string) {
 		port = "0"
 	}
 	return host, port
+}
+
+type databaseType string
+
+func ToDatabaseType(s string) databaseType {
+	return databaseType(s)
+}
+
+func (t databaseType) String() string {
+	return string(t)
+}
+
+func (t databaseType) IsSQLite3() bool {
+	return t == "sqlite3"
+}
+
+func (t databaseType) IsMySQL() bool {
+	return t == "mysql"
+}
+
+func (t databaseType) IsMSSQL() bool {
+	return t == "mssql"
+}
+
+func (t databaseType) IsPostgreSQL() bool {
+	return t == "postgres"
 }

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -27,7 +27,7 @@ var (
 
 	// Database holds the database settings
 	Database = struct {
-		Type              databaseType
+		Type              DatabaseType
 		Host              string
 		Name              string
 		User              string
@@ -55,7 +55,7 @@ var (
 // LoadDBSetting loads the database settings
 func LoadDBSetting() {
 	sec := CfgProvider.Section("database")
-	Database.Type = ToDatabaseType(sec.Key("DB_TYPE").String())
+	Database.Type = DatabaseType(sec.Key("DB_TYPE").String())
 	defaultCharset := "utf8"
 
 	if Database.Type.IsMySQL() {
@@ -193,28 +193,24 @@ func ParseMSSQLHostPort(info string) (string, string) {
 	return host, port
 }
 
-type databaseType string
+type DatabaseType string
 
-func ToDatabaseType(s string) databaseType {
-	return databaseType(s)
-}
-
-func (t databaseType) String() string {
+func (t DatabaseType) String() string {
 	return string(t)
 }
 
-func (t databaseType) IsSQLite3() bool {
+func (t DatabaseType) IsSQLite3() bool {
 	return t == "sqlite3"
 }
 
-func (t databaseType) IsMySQL() bool {
+func (t DatabaseType) IsMySQL() bool {
 	return t == "mysql"
 }
 
-func (t databaseType) IsMSSQL() bool {
+func (t DatabaseType) IsMSSQL() bool {
 	return t == "mssql"
 }
 
-func (t databaseType) IsPostgreSQL() bool {
+func (t DatabaseType) IsPostgreSQL() bool {
 	return t == "postgres"
 }

--- a/routers/init.go
+++ b/routers/init.go
@@ -141,7 +141,7 @@ func GlobalInitInstalled(ctx context.Context) {
 
 	if setting.EnableSQLite3 {
 		log.Info("SQLite3 support is enabled")
-	} else if setting.Database.UseSQLite3 {
+	} else if setting.Database.Type.IsSQLite3() {
 		log.Fatal("SQLite3 support is disabled, but it is used for database setting. Please get or build a Gitea release with SQLite3 support.")
 	}
 

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -104,7 +104,7 @@ func Install(ctx *context.Context) {
 	form.DbSchema = setting.Database.Schema
 	form.Charset = setting.Database.Charset
 
-	curDBType := setting.Database.Type
+	curDBType := setting.Database.Type.String()
 	var isCurDBTypeSupported bool
 	for _, dbType := range setting.SupportedDatabaseTypes {
 		if dbType == curDBType {
@@ -272,7 +272,7 @@ func SubmitInstall(ctx *context.Context) {
 	// ---- Basic checks are passed, now test configuration.
 
 	// Test database setting.
-	setting.Database.Type = form.DbType
+	setting.Database.Type = setting.ToDatabaseType(form.DbType)
 	setting.Database.Host = form.DbHost
 	setting.Database.User = form.DbUser
 	setting.Database.Passwd = form.DbPasswd
@@ -392,7 +392,7 @@ func SubmitInstall(ctx *context.Context) {
 			log.Error("Failed to load custom conf '%s': %v", setting.CustomConf, err)
 		}
 	}
-	cfg.Section("database").Key("DB_TYPE").SetValue(setting.Database.Type)
+	cfg.Section("database").Key("DB_TYPE").SetValue(setting.Database.Type.String())
 	cfg.Section("database").Key("HOST").SetValue(setting.Database.Host)
 	cfg.Section("database").Key("NAME").SetValue(setting.Database.Name)
 	cfg.Section("database").Key("USER").SetValue(setting.Database.User)

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -272,7 +272,7 @@ func SubmitInstall(ctx *context.Context) {
 	// ---- Basic checks are passed, now test configuration.
 
 	// Test database setting.
-	setting.Database.Type = setting.ToDatabaseType(form.DbType)
+	setting.Database.Type = setting.DatabaseType(form.DbType)
 	setting.Database.Host = form.DbHost
 	setting.Database.User = form.DbUser
 	setting.Database.Passwd = form.DbPasswd

--- a/routers/web/healthcheck/check.go
+++ b/routers/web/healthcheck/check.go
@@ -100,7 +100,7 @@ func checkDatabase(checks checks) status {
 		st.Time = getCheckTime()
 	}
 
-	if setting.Database.UseSQLite3 && st.Status == pass {
+	if setting.Database.Type.IsSQLite3() && st.Status == pass {
 		if !setting.EnableSQLite3 {
 			st.Status = fail
 			st.Time = getCheckTime()

--- a/tests/integration/markup_external_test.go
+++ b/tests/integration/markup_external_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestExternalMarkupRenderer(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
-	if !setting.Database.UseSQLite3 {
+	if !setting.Database.Type.IsSQLite3() {
 		t.Skip()
 		return
 	}

--- a/tests/integration/migration-test/migration_test.go
+++ b/tests/integration/migration-test/migration_test.go
@@ -94,7 +94,7 @@ func availableVersions() ([]string, error) {
 		return nil, err
 	}
 	defer migrationsDir.Close()
-	versionRE, err := regexp.Compile("gitea-v(?P<version>.+)\\." + regexp.QuoteMeta(setting.Database.Type) + "\\.sql.gz")
+	versionRE, err := regexp.Compile("gitea-v(?P<version>.+)\\." + regexp.QuoteMeta(setting.Database.Type.String()) + "\\.sql.gz")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/migration-test/migration_test.go
+++ b/tests/integration/migration-test/migration_test.go
@@ -149,7 +149,7 @@ func restoreOldDB(t *testing.T, version string) bool {
 	}
 
 	switch {
-	case setting.Database.UseSQLite3:
+	case setting.Database.Type.IsSQLite3():
 		util.Remove(setting.Database.Path)
 		err := os.MkdirAll(path.Dir(setting.Database.Path), os.ModePerm)
 		assert.NoError(t, err)
@@ -162,7 +162,7 @@ func restoreOldDB(t *testing.T, version string) bool {
 		assert.NoError(t, err)
 		db.Close()
 
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/",
 			setting.Database.User, setting.Database.Passwd, setting.Database.Host))
 		assert.NoError(t, err)
@@ -184,7 +184,7 @@ func restoreOldDB(t *testing.T, version string) bool {
 		assert.NoError(t, err)
 		db.Close()
 
-	case setting.Database.UsePostgreSQL:
+	case setting.Database.Type.IsPostgreSQL():
 		var db *sql.DB
 		var err error
 		if setting.Database.Host[0] == '/' {
@@ -252,7 +252,7 @@ func restoreOldDB(t *testing.T, version string) bool {
 		assert.NoError(t, err)
 		db.Close()
 
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		host, port := setting.ParseMSSQLHostPort(setting.Database.Host)
 		db, err := sql.Open("mssql", fmt.Sprintf("server=%s; port=%s; database=%s; user id=%s; password=%s;",
 			host, port, "master", setting.Database.User, setting.Database.Passwd))

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -74,7 +74,7 @@ func InitTest(requireGitea bool) {
 	}
 
 	switch {
-	case setting.Database.UseMySQL:
+	case setting.Database.Type.IsMySQL():
 		connType := "tcp"
 		if len(setting.Database.Host) > 0 && setting.Database.Host[0] == '/' { // looks like a unix socket
 			connType = "unix"
@@ -89,7 +89,7 @@ func InitTest(requireGitea bool) {
 		if _, err = db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", setting.Database.Name)); err != nil {
 			log.Fatal("db.Exec: %v", err)
 		}
-	case setting.Database.UsePostgreSQL:
+	case setting.Database.Type.IsPostgreSQL():
 		var db *sql.DB
 		var err error
 		if setting.Database.Host[0] == '/' {
@@ -146,7 +146,7 @@ func InitTest(requireGitea bool) {
 			}
 		}
 
-	case setting.Database.UseMSSQL:
+	case setting.Database.Type.IsMSSQL():
 		host, port := setting.ParseMSSQLHostPort(setting.Database.Host)
 		db, err := sql.Open("mssql", fmt.Sprintf("server=%s; port=%s; database=%s; user id=%s; password=%s;",
 			host, port, "master", setting.Database.User, setting.Database.Passwd))


### PR DESCRIPTION
Replace #23350.

Refactor `setting.Database.UseMySQL` to `setting.Database.Type.IsMySQL()`.

To avoid mismatching between `Type` and `UseXXX`.

This refactor can fix the bug mentioned in #23350, so it should be backported.