### PR TITLE
Fix panic when getting notes by ref

### DIFF
--- a/routers/api/v1/repo/notes.go
+++ b/routers/api/v1/repo/notes.go
@@ -60,7 +60,11 @@ func getNote(ctx *context.APIContext, identifier string) {
 
 	commitSHA, err := ctx.Repo.GitRepo.ConvertToSHA1(identifier)
 	if err != nil {
-		ctx.NotFound(err)
+		if git.IsErrNotExist(err) {
+			ctx.NotFound(err)
+		} else {
+			ctx.Error(http.StatusInternalServerError, "ConvertToSHA1", err)
+		}
 		return
 	}
 

--- a/routers/api/v1/repo/notes.go
+++ b/routers/api/v1/repo/notes.go
@@ -58,8 +58,14 @@ func getNote(ctx *context.APIContext, identifier string) {
 		return
 	}
 
+	commitSHA, err := ctx.Repo.GitRepo.ConvertToSHA1(identifier)
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+
 	var note git.Note
-	if err := git.GetNote(ctx, ctx.Repo.GitRepo, identifier, &note); err != nil {
+	if err := git.GetNote(ctx, ctx.Repo.GitRepo, commitSHA.String(), &note); err != nil {
 		if git.IsErrNotExist(err) {
 			ctx.NotFound(identifier)
 			return


### PR DESCRIPTION
Fix #23357 .

Now the `/repos/{owner}/{repo}/git/notes/{sha}` API supports getting notes by a ref or sha (https://try.gitea.io/api/swagger#/repository/repoGetNote). But the `GetNote` func can only accept commit ID.
https://github.com/go-gitea/gitea/blob/a12f5757372f751d25f9e5ca1f168f6920ded894/modules/git/notes_nogogit.go#L18

So we need to convert the query parameter to commit ID before calling `GetNote`.

