### PR TITLE
Cleanup the output from the gitea internal hooks

### DIFF
--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -43,7 +43,7 @@ var Git = struct {
 	MaxGitDiffFiles:           100,
 	CommitsRangeSize:          50,
 	BranchesRangeSize:         20,
-	VerbosePush:               true,
+	VerbosePush:               false,
 	VerbosePushDelay:          5 * time.Second,
 	GCArgs:                    []string{},
 	EnableAutoGitWireProtocol: true,


### PR DESCRIPTION
Some gitea hook output "Processing 2 references" is a little noisy, so let's cleanup them.

v1. 
Remove all hook output logic.

v2.
Just turn off VerbosePush setting to suppress output.


Want to fix #23364
