### PR TITLE
Purge API comment

### DIFF
--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -305,6 +305,10 @@ func DeleteUser(ctx *context.APIContext) {
 	//   description: username of user to delete
 	//   type: string
 	//   required: true
+	// - name: purge
+	//   in: query
+	//   description: purge the user from the system completely
+	//   type: bool
 	// responses:
 	//   "204":
 	//     "$ref": "#/responses/empty"

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -308,7 +308,7 @@ func DeleteUser(ctx *context.APIContext) {
 	// - name: purge
 	//   in: query
 	//   description: purge the user from the system completely
-	//   type: bool
+	//   type: boolean
 	// responses:
 	//   "204":
 	//     "$ref": "#/responses/empty"

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -495,7 +495,7 @@
             "required": true
           },
           {
-            "type": "bool",
+            "type": "boolean",
             "description": "purge the user from the system completely",
             "name": "purge",
             "in": "query"

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -493,6 +493,12 @@
             "name": "username",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "bool",
+            "description": "purge the user from the system completely",
+            "name": "purge",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR just adds the `purge` query parameter to the swagger docs for admin user delete.

I considered using the same verbiage we have in the UI, but that seemed more verbose than descriptions we use elsewhere in swagger. I'm fine if that's preferred, though, just let me know. 🙂 