### PR TITLE
Use `gitea/test_env` image instead of `golang`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
       - make deps-frontend
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -92,7 +92,7 @@ steps:
     depends_on: [deps-frontend]
 
   - name: checks-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     commands:
       - make --always-make checks-backend # ensure the 'go-licenses' make target runs
     depends_on: [deps-backend]
@@ -113,7 +113,7 @@ steps:
     depends_on: [deps-frontend]
 
   - name: build-backend-no-gcc
-    image: golang:1.19 # this step is kept as the lowest version of golang that we support
+    image: gitea/test_env:linux-1.19-amd64 # this step is kept as the lowest version of golang that we support
     pull: always
     environment:
       GOPROXY: https://goproxy.io
@@ -125,7 +125,7 @@ steps:
         path: /go
 
   - name: build-backend-arm64
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     environment:
       GOPROXY: https://goproxy.io
       GOOS: linux
@@ -140,7 +140,7 @@ steps:
         path: /go
 
   - name: build-backend-windows
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     environment:
       GOPROXY: https://goproxy.io
       GOOS: windows
@@ -154,7 +154,7 @@ steps:
         path: /go
 
   - name: build-backend-386
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     environment:
       GOPROXY: https://goproxy.io
       GOOS: linux
@@ -217,7 +217,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -225,7 +224,7 @@ steps:
           - pull_request
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -319,7 +318,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -327,7 +325,7 @@ steps:
           - pull_request
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -405,7 +403,7 @@ steps:
         path: /go
 
   - name: generate-coverage
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     commands:
       - make coverage
     environment:
@@ -473,7 +471,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -481,7 +478,7 @@ steps:
           - pull_request
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -563,7 +560,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -571,7 +567,7 @@ steps:
           - pull_request
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -643,7 +639,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
     when:
       event:
@@ -651,7 +646,7 @@ steps:
           - pull_request
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-arm64
     pull: always
     commands:
       - make deps-backend
@@ -733,7 +728,7 @@ steps:
     depends_on: [deps-frontend]
 
   - name: deps-backend
-    image: golang:1.18
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -842,7 +837,7 @@ trigger:
 
 steps:
   - name: download
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - timeout -s ABRT 40m make generate-license generate-gitignore
@@ -902,7 +897,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: deps-frontend
@@ -912,7 +906,7 @@ steps:
       - make deps-frontend
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -1038,7 +1032,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: deps-frontend
@@ -1048,7 +1041,7 @@ steps:
       - make deps-frontend
 
   - name: deps-backend
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     pull: always
     commands:
       - make deps-backend
@@ -1148,7 +1141,7 @@ trigger:
 
 steps:
   - name: build-docs
-    image: golang:1.20
+    image: gitea/test_env:linux-1.20-amd64
     commands:
       - cd docs
       - make trans-copy clean build
@@ -1202,7 +1195,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1280,7 +1272,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1353,7 +1344,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1427,7 +1417,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1545,7 +1534,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1623,7 +1611,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1699,7 +1686,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish
@@ -1773,7 +1759,6 @@ steps:
     image: docker:git
     pull: always
     commands:
-      - git config --global --add safe.directory /drone/src
       - git fetch --tags --force
 
   - name: publish


### PR DESCRIPTION
The `safe.directory` setting was not executed for pull requests, which made subsequent `deps-backend` target fail at `go mod download`. To fix it, split thep and perform the git config unconditionally.

Example: https://drone.gitea.io/go-gitea/gitea/69477/4/3