### PR TITLE
Skip DB tests duplicate runs on push to branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,16 +9,10 @@ platform:
 
 trigger:
   event:
-    - push
-    - tag
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -184,15 +178,10 @@ depends_on:
 
 trigger:
   event:
-    - push
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -292,15 +281,10 @@ depends_on:
 
 trigger:
   event:
-    - push
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -459,15 +443,10 @@ depends_on:
 
 trigger:
   event:
-    - push  
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -551,15 +530,10 @@ depends_on:
 
 trigger:
   event:
-    - push
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -643,15 +617,10 @@ depends_on:
 
 trigger:
   event:
-    - push
     - pull_request
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -733,10 +702,6 @@ trigger:
   paths:
     exclude:
       - docs/**
-  branch:
-    exclude:
-      - main
-      - release/*
 
 volumes:
   - name: deps
@@ -1500,7 +1465,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: docker-linux-amd64-dry-run
+name: docker-linux-arm64-dry-run
 
 platform:
   os: linux
@@ -1510,8 +1475,8 @@ depends_on:
   - compliance
 
 trigger:
-  ref:
-  - "refs/pull/**"
+  event:
+    - pull_request
   paths:
     exclude:
       - docs/**

--- a/.drone.yml
+++ b/.drone.yml
@@ -181,7 +181,6 @@ depends_on:
 trigger:
   event:
     - push
-    - tag
     - pull_request
   paths:
     exclude:
@@ -290,7 +289,6 @@ depends_on:
 trigger:
   event:
     - push
-    - tag
     - pull_request
   paths:
     exclude:
@@ -457,8 +455,7 @@ depends_on:
 
 trigger:
   event:
-    - push
-    - tag
+    - push  
     - pull_request
   paths:
     exclude:
@@ -551,7 +548,6 @@ depends_on:
 trigger:
   event:
     - push
-    - tag
     - pull_request
   paths:
     exclude:
@@ -644,7 +640,6 @@ depends_on:
 trigger:
   event:
     - push
-    - tag
     - pull_request
   paths:
     exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -186,6 +186,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps
@@ -291,6 +295,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps
@@ -455,6 +463,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps
@@ -544,6 +556,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps
@@ -633,6 +649,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps
@@ -714,6 +734,10 @@ trigger:
   paths:
     exclude:
       - docs/**
+  branch:
+    exclude:
+      - main
+      - release/*
 
 volumes:
   - name: deps


### PR DESCRIPTION
This skips all testing-* pipelines on push to main or release/* branches. This decreases the total build time on those, as in theory they should already be run for PRs before merging.

Fixes https://github.com/go-gitea/gitea/issues/22011