### PR TITLE
Add backport migration support

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -610,20 +610,19 @@ Please try upgrading to a lower version first (suggested v1.6.4), then upgrade t
 
 	// Migrate
 	for i, m := range migrations[v-minDBVersion:] {
-		// Skip migrated backport migration
 		if migratedBackportVersions.Contains(v + int64(i)) {
 			log.Info("Skip Migration[%d]: %s, as it is migrated in backport.", v+int64(i), m.Description())
 			// remove db record
 			if _, err = x.Delete(&BackportVersion{Version: v + int64(i)}); err != nil {
 				return err
 			}
-			continue
-		}
-		log.Info("Migration[%d]: %s", v+int64(i), m.Description())
-		// Reset the mapper between each migration - migrations are not supposed to depend on each other
-		x.SetMapper(names.GonicMapper{})
-		if err = m.Migrate(x); err != nil {
-			return fmt.Errorf("migration[%d]: %s failed: %w", v+int64(i), m.Description(), err)
+		} else {
+			log.Info("Migration[%d]: %s", v+int64(i), m.Description())
+			// Reset the mapper between each migration - migrations are not supposed to depend on each other
+			x.SetMapper(names.GonicMapper{})
+			if err = m.Migrate(x); err != nil {
+				return fmt.Errorf("migration[%d]: %s failed: %w", v+int64(i), m.Description(), err)
+			}
 		}
 		currentVersion.Version = v + int64(i) + 1
 		if _, err = x.ID(1).Update(currentVersion); err != nil {

--- a/models/migrations/v1_20/v247.go
+++ b/models/migrations/v1_20/v247.go
@@ -1,0 +1,17 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_20 //nolint
+
+import (
+	"xorm.io/xorm"
+)
+
+func AddBackportVersion(x *xorm.Engine) error {
+	type BackportVersion struct {
+		ID      int64 `xorm:"pk autoincr"`
+		Version int64
+	}
+
+	return x.Sync(new(BackportVersion))
+}


### PR DESCRIPTION
Changes:
Use `BackportVersion` table to store migrated versions in newer versions.
When users upgrade gitea version, we can skip the migrations recorded in `BackportVersion` table.

I have no idea about testing now.
So it may have bugs now.