### PR TITLE
Fix review comment context menu clipped bug

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -161,7 +161,8 @@
 									{{end}}
 								</div>
 								{{if $showFileViewToggle}}
-									<div id="diff-rendered-{{$file.NameHash}}" class="file-body file-code {{if $.IsSplitStyle}} code-diff-split{{else}} code-diff-unified{{end}}">
+									{{/* for image or CSV, it can have a horizontal scroll bar, there won't be review comment context menu (position absolute) which would be clipped by "overflow" */}}
+									<div id="diff-rendered-{{$file.NameHash}}" class="file-body file-code {{if $.IsSplitStyle}}code-diff-split{{else}}code-diff-unified{{end}} gt-overflow-x-scroll">
 										<table class="chroma gt-w-100">
 											{{if $isImage}}
 												{{template "repo/diff/image_diff" dict "file" . "root" $ "blobBase" $blobBase "blobHead" $blobHead}}

--- a/web_src/css/helpers.css
+++ b/web_src/css/helpers.css
@@ -22,6 +22,7 @@
 /* below class names match Tailwind CSS */
 .gt-pointer-events-none { pointer-events: none !important; }
 .gt-relative { position: relative !important; }
+.gt-overflow-x-scroll { overflow-x: scroll !important; }
 
 .gt-mono {
   font-family: var(--fonts-monospace) !important;

--- a/web_src/css/repository.css
+++ b/web_src/css/repository.css
@@ -3337,10 +3337,6 @@ td.blob-excerpt {
   min-width: 100px;
 }
 
-.diff-file-body {
-  overflow-x: scroll;
-}
-
 .diff-stats-bar {
   display: inline-block;
   background-color: var(--color-red);


### PR DESCRIPTION
This is another regression of #22959 (the first regression has been fixed by the Image Diff fix)

Close #23517

This is a quick fix. Luckily, there is no "dropdown menu" for image/csv view, so we could only add the "overflow-x: scroll" to the image/csv view.

After fix:

![image](https://user-images.githubusercontent.com/2114189/225643575-9e964b4f-5543-4a69-86c2-2ffc8e40d9a6.png)

![image](https://user-images.githubusercontent.com/2114189/225643670-f0e575d0-f4af-41f4-b023-2d9ddb6462e9.png)
