### PR TITLE
Return `repository` in npm package metadata endpoint

### DIFF
--- a/modules/packages/npm/creator.go
+++ b/modules/packages/npm/creator.go
@@ -223,6 +223,7 @@ func ParsePackage(r io.Reader) (*Package, error) {
 				OptionalDependencies:    meta.OptionalDependencies,
 				Bin:                     meta.Bin,
 				Readme:                  meta.Readme,
+				Repository:              meta.Repository,
 			},
 		}
 

--- a/modules/packages/npm/creator_test.go
+++ b/modules/packages/npm/creator_test.go
@@ -26,6 +26,10 @@ func TestParsePackage(t *testing.T) {
 	packageDescription := "Test Description"
 	data := "H4sIAAAAAAAA/ytITM5OTE/VL4DQelnF+XkMVAYGBgZmJiYK2MRBwNDcSIHB2NTMwNDQzMwAqA7IMDUxA9LUdgg2UFpcklgEdAql5kD8ogCnhwio5lJQUMpLzE1VslJQcihOzi9I1S9JLS7RhSYIJR2QgrLUouLM/DyQGkM9Az1D3YIiqExKanFyUWZBCVQ2BKhVwQVJDKwosbQkI78IJO/tZ+LsbRykxFXLNdA+HwWjYBSMgpENACgAbtAACAAA"
 	integrity := "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg=="
+	repository := Repository{
+		Type: "gitea",
+		URL:  "http://localhost:3000/gitea/test.git",
+	}
 
 	t.Run("InvalidUpload", func(t *testing.T) {
 		p, err := ParsePackage(bytes.NewReader([]byte{0}))
@@ -242,6 +246,7 @@ func TestParsePackage(t *testing.T) {
 						Dist: PackageDistribution{
 							Integrity: integrity,
 						},
+						Repository: repository,
 					},
 				},
 			},
@@ -272,5 +277,7 @@ func TestParsePackage(t *testing.T) {
 		assert.Equal(t, "https://gitea.io/", p.Metadata.ProjectURL)
 		assert.Contains(t, p.Metadata.Dependencies, "package")
 		assert.Equal(t, "1.2.0", p.Metadata.Dependencies["package"])
+		assert.Equal(t, repository.Type, p.Metadata.Repository.Type)
+		assert.Equal(t, repository.URL, p.Metadata.Repository.URL)
 	})
 }

--- a/modules/packages/npm/metadata.go
+++ b/modules/packages/npm/metadata.go
@@ -21,4 +21,5 @@ type Metadata struct {
 	OptionalDependencies    map[string]string `json:"optional_dependencies,omitempty"`
 	Bin                     map[string]string `json:"bin,omitempty"`
 	Readme                  string            `json:"readme,omitempty"`
+	Repository              Repository        `json:"repository,omitempty"`
 }

--- a/routers/api/packages/npm/api.go
+++ b/routers/api/packages/npm/api.go
@@ -45,6 +45,7 @@ func createPackageMetadataResponse(registryURL string, pds []*packages_model.Pac
 		Author:      npm_module.User{Name: metadata.Author},
 		License:     metadata.License,
 		Versions:    versions,
+		Repository:  metadata.Repository,
 	}
 }
 

--- a/tests/integration/api_packages_npm_test.go
+++ b/tests/integration/api_packages_npm_test.go
@@ -37,6 +37,8 @@ func TestPackageNpm(t *testing.T) {
 	packageDescription := "Test Description"
 	packageBinName := "cli"
 	packageBinPath := "./cli.sh"
+	repoType := "gitea"
+	repoURL := "http://localhost:3000/gitea/test.git"
 
 	data := "H4sIAAAAAAAA/ytITM5OTE/VL4DQelnF+XkMVAYGBgZmJiYK2MRBwNDcSIHB2NTMwNDQzMwAqA7IMDUxA9LUdgg2UFpcklgEdAql5kD8ogCnhwio5lJQUMpLzE1VslJQcihOzi9I1S9JLS7RhSYIJR2QgrLUouLM/DyQGkM9Az1D3YIiqExKanFyUWZBCVQ2BKhVwQVJDKwosbQkI78IJO/tZ+LsbRykxFXLNdA+HwWjYBSMgpENACgAbtAACAAA"
 
@@ -62,6 +64,10 @@ func TestPackageNpm(t *testing.T) {
 				"dist": {
 				  "integrity": "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg==",
 				  "shasum": "aaa7eaf852a948b0aa05afeda35b1badca155d90"
+				},
+				"repository": {
+					"type": "` + repoType + `",
+					"url": "` + repoURL + `"
 				}
 			  }
 			},
@@ -169,6 +175,8 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, "sha512-yA4FJsVhetynGfOC1jFf79BuS+jrHbm0fhh+aHzCQkOaOBXKf9oBnC4a6DnLLnEsHQDRLYd00cwj8sCXpC+wIg==", pmv.Dist.Integrity)
 		assert.Equal(t, "aaa7eaf852a948b0aa05afeda35b1badca155d90", pmv.Dist.Shasum)
 		assert.Equal(t, fmt.Sprintf("%s%s/-/%s/%s", setting.AppURL, root[1:], packageVersion, filename), pmv.Dist.Tarball)
+		assert.Equal(t, repoType, result.Repository.Type)
+		assert.Equal(t, repoURL, result.Repository.URL)
 	})
 
 	t.Run("AddTag", func(t *testing.T) {


### PR DESCRIPTION
Close #23444 

Add `Repository` to npm package `Metadata` struct so the `repository` in `package.json` can be stored and be returned in the endpoint.
