### PR TITLE
Fix sticky header in diff view

### DIFF
--- a/web_src/css/repository.css
+++ b/web_src/css/repository.css
@@ -1611,12 +1611,14 @@
   padding: 7px 0;
   background: var(--color-body);
   line-height: 30px;
+  height: 47px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
 }
 
 @media (max-width: 991px) {
   .repository .diff-detail-box {
     flex-direction: column;
     align-items: flex-start;
+    height: 77px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
   }
 }
 
@@ -1635,13 +1637,6 @@
   padding-right: 2px;
   margin-left: -1px;
   margin-right: -1px;
-  height: 47px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
-}
-
-@media (max-width: 991px) {
-  .repository .diff-detail-box.sticky {
-    height: 77px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
-  }
 }
 
 .repository .diff-detail-box > div::after {
@@ -3325,14 +3320,14 @@ td.blob-excerpt {
 
 .ui.attached.header.diff-file-header.sticky-2nd-row {
   position: sticky;
-  top: 47px; /* match .repository .diff-detail-box.sticky */
+  top: 47px; /* match .repository .diff-detail-box */
   z-index: 7;
   box-shadow: 0 -1px 0 1px var(--color-body); /* hide gap behind border-radius */
 }
 
 @media (max-width: 991px) {
   .ui.attached.header.diff-file-header.sticky-2nd-row {
-    top: 77px; /* match .repository .diff-detail-box.sticky */
+    top: 77px; /* match .repository .diff-detail-box */
   }
 }
 

--- a/web_src/css/repository.css
+++ b/web_src/css/repository.css
@@ -1635,6 +1635,13 @@
   padding-right: 2px;
   margin-left: -1px;
   margin-right: -1px;
+  height: 47px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
+}
+
+@media (max-width: 991px) {
+  .repository .diff-detail-box.sticky {
+    height: 77px; /* match .ui.attached.header.diff-file-header.sticky-2nd-row */
+  }
 }
 
 .repository .diff-detail-box > div::after {
@@ -3318,14 +3325,14 @@ td.blob-excerpt {
 
 .ui.attached.header.diff-file-header.sticky-2nd-row {
   position: sticky;
-  top: 46.5px;
+  top: 47px; /* match .repository .diff-detail-box.sticky */
   z-index: 7;
-  box-shadow: 0 -1px 0 1px var(--color-body); /* hide sub-pixel gap on top */
+  box-shadow: 0 -1px 0 1px var(--color-body); /* hide gap behind border-radius */
 }
 
 @media (max-width: 991px) {
   .ui.attached.header.diff-file-header.sticky-2nd-row {
-    top: 76.5px;
+    top: 77px; /* match .repository .diff-detail-box.sticky */
   }
 }
 

--- a/web_src/css/repository.css
+++ b/web_src/css/repository.css
@@ -1630,7 +1630,7 @@
   position: sticky;
   top: 0;
   z-index: 8;
-  border-bottom: 1px solid var(--color-secondary);
+  border-bottom: none;
   padding-left: 2px;
   padding-right: 2px;
   margin-left: -1px;
@@ -3318,8 +3318,15 @@ td.blob-excerpt {
 
 .ui.attached.header.diff-file-header.sticky-2nd-row {
   position: sticky;
-  top: 77px;
+  top: 46.5px;
   z-index: 7;
+  box-shadow: 0 -1px 0 1px var(--color-body); /* hide sub-pixel gap on top */
+}
+
+@media (max-width: 991px) {
+  .ui.attached.header.diff-file-header.sticky-2nd-row {
+    top: 76.5px;
+  }
 }
 
 @media (max-width: 480px) {

--- a/web_src/css/repository.css
+++ b/web_src/css/repository.css
@@ -3322,7 +3322,6 @@ td.blob-excerpt {
   position: sticky;
   top: 47px; /* match .repository .diff-detail-box */
   z-index: 7;
-  box-shadow: 0 -1px 0 1px var(--color-body); /* hide gap behind border-radius */
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
Fix regression https://github.com/go-gitea/gitea/pull/23513#issuecomment-1474356817 from https://github.com/go-gitea/gitea/pull/23271. The previous sticky CSS did assume the content is always 2 rows, but since that PR, it's single-row above 993px width. Adjust the sticky offset to match and add a small tweak that hides content behind the border-radius.

Single row:
<img width="1264" alt="Screenshot 2023-03-17 at 21 33 05" src="https://user-images.githubusercontent.com/115237/226034050-a04b131d-fd3f-45c0-bc72-413738a59825.png">

Double row:
<img width="1243" alt="Screenshot 2023-03-17 at 21 32 53" src="https://user-images.githubusercontent.com/115237/226034163-2f1c6aa9-fc72-432f-bc46-9a7119da8677.png">

