### PR TITLE
Fix dropdown icon misalignment when using fomantic icon (#23558)

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -2544,10 +2544,10 @@ table th[data-sortt-desc] .svg {
   height: auto; /* reset the ".ui.dropdown > .dropdown.icon {height}", otherwise the icon would be too small */
 }
 
-.ui.selection.dropdown > .search.icon,
-.ui.selection.dropdown > .delete.icon,
-.ui.selection.dropdown > .dropdown.icon {
-  top: 0 !important;
+.ui.selection.dropdown > .svg.search.icon,
+.ui.selection.dropdown > .svg.delete.icon,
+.ui.selection.dropdown > .svg.dropdown.icon {
+  top: 0 !important; /* reset the ".ui.selection.dropdown > .xxx.icon {top}" if the icon is svg instead of the fomantic icon */
 }
 
 .ui.dropdown.no-text > .dropdown.icon {


### PR DESCRIPTION
Backport #23558

There are still many dropdowns using fomantic icon. For example: new issue with issue template.

Avoid polluting the fomantic styles.