### PR TITLE
Polyfill the window.customElements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
         "@primer/octicons": "18.2.0",
         "@vue/compiler-sfc": "3.2.47",
+        "@webcomponents/custom-elements": "1.5.1",
         "add-asset-webpack-plugin": "2.0.1",
         "ansi-to-html": "0.7.2",
         "asciinema-player": "3.2.0",
@@ -1914,6 +1915,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webcomponents/custom-elements": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.5.1.tgz",
+      "integrity": "sha512-6T/XT3S1UHDlRWFSxRXdeSoYWczEl78sygNPS7jDyHVrfZcF/pUtWGYgxF4uviH59iPVw1eOWbhubm8CqO0MpA=="
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
     "@primer/octicons": "18.2.0",
     "@vue/compiler-sfc": "3.2.47",
+    "@webcomponents/custom-elements": "1.5.1",
     "add-asset-webpack-plugin": "2.0.1",
     "ansi-to-html": "0.7.2",
     "asciinema-player": "3.2.0",

--- a/web_src/js/webcomponents/GiteaOriginUrl.js
+++ b/web_src/js/webcomponents/GiteaOriginUrl.js
@@ -1,4 +1,4 @@
-import '@webcomponents/custom-elements';
+import '@webcomponents/custom-elements'; // automatically adds custom elements for older browsers that don't support it
 
 // this is a Gitea's private HTML component, it converts an absolute or relative URL to an absolute URL with the current origin
 window.customElements.define('gitea-origin-url', class extends HTMLElement {

--- a/web_src/js/webcomponents/GiteaOriginUrl.js
+++ b/web_src/js/webcomponents/GiteaOriginUrl.js
@@ -1,3 +1,5 @@
+import '@webcomponents/custom-elements';
+
 // this is a Gitea's private HTML component, it converts an absolute or relative URL to an absolute URL with the current origin
 window.customElements.define('gitea-origin-url', class extends HTMLElement {
   connectedCallback() {


### PR DESCRIPTION
Related: #23590

Reference: https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs

It seems that some browsers don't support customElements.

The Custom Elements would help a lot for Gitea's UI problems, including:

* `<span class="js-pretty-number">`
* `<time data-format>`

So it's worth get polyfill.