### PR TITLE
Replace a few fontawesome icons with svg

### DIFF
--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -77,7 +77,7 @@
 
 <div class="ui small basic addall modal">
 	<div class="ui icon header">
-		<i class="globe icon"></i>
+		{{svg "octicon-globe"}}
 		{{.locale.Tr "org.teams.add_all_repos_title"}}
 	</div>
 	<div class="content">

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -58,7 +58,7 @@
 
 	<div class="ui small basic modal" id="edit-empty-content-modal">
 		<div class="ui icon header">
-			<i class="file icon"></i>
+			{{svg "octicon-file"}}
 			{{.locale.Tr "repo.editor.commit_empty_file_header"}}
 		</div>
 		<div class="center content">
@@ -66,11 +66,11 @@
 		</div>
 		<div class="actions">
 			<button class="ui red basic cancel inverted button">
-				<i class="remove icon"></i>
+				{{svg "octicon-x"}}
 				{{.locale.Tr "repo.editor.cancel"}}
 			</button>
 			<button class="ui green basic ok inverted button">
-				<i class="save icon"></i>
+				{{svg "fontawesome-save"}}
 				{{.locale.Tr "repo.editor.commit_changes"}}
 			</button>
 		</div>

--- a/templates/repo/editor/patch.tmpl
+++ b/templates/repo/editor/patch.tmpl
@@ -38,7 +38,7 @@
 
 	<div class="ui small basic modal" id="edit-empty-content-modal">
 		<div class="ui icon header">
-			<i class="file icon"></i>
+			{{svg "octicon-file"}}
 			{{.locale.Tr "repo.editor.commit_empty_file_header"}}
 		</div>
 		<div class="center content">

--- a/templates/user/auth/webauthn.tmpl
+++ b/templates/user/auth/webauthn.tmpl
@@ -6,7 +6,7 @@
 				{{.locale.Tr "twofa"}}
 				</h3>
 				<div class="ui attached segment">
-					<i class="huge key icon"></i>
+					{{svg "octicon-key" 56}}
 					<h3>{{.locale.Tr "webauthn_insert_key"}}</h3>
 					{{template "base/alert" .}}
 					<p>{{.locale.Tr "webauthn_sign_in"}}</p>


### PR DESCRIPTION
Replaced a few icons with SVG. The only ones left are some in actions (idk why new code introduces legacy icons) and a few dropdown icons.

<img width="746" alt="Screenshot 2023-03-21 at 00 52 36" src="https://user-images.githubusercontent.com/115237/226490028-f99d7314-3145-477f-a634-af243b1101fd.png">
<img width="270" alt="Screenshot 2023-03-21 at 00 47 03" src="https://user-images.githubusercontent.com/115237/226490045-bf161214-9d68-4338-ad9a-46dc80e225cd.png">
<img width="227" alt="Screenshot 2023-03-21 at 00 33 47" src="https://user-images.githubusercontent.com/115237/226490049-10d61f1a-da3a-4632-942d-85ca82a03ff5.png">
