### PR TITLE
Add `deps-docs` command to makefile

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,8 +24,11 @@ tasks:
       make watch-frontend
     openMode: split-right
   - name: Run docs
-    before: sudo make deps-docs
-    command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
+    command: |
+      gp sync-await setup
+      cd docs
+      make clean update
+      hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
     openMode: split-right
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,7 +24,7 @@ tasks:
       make watch-frontend
     openMode: split-right
   - name: Run docs
-    before: sudo bash -c "$(grep 'https://github.com/gohugoio/hugo/releases/download' Makefile | tr -d '\')" # install hugo
+    before: sudo make deps-docs
     command: cd docs && make clean update && hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
     openMode: split-right
 

--- a/Makefile
+++ b/Makefile
@@ -820,14 +820,14 @@ release-docs: | $(DIST_DIRS) docs
 docs: deps-docs
 	cd docs; make trans-copy clean build-offline;
 
-.PHONY: deps-docs # TODO: find a way to install hugo without needing sudo permissions and add deps-docs to deps (the next block)
+.PHONY: deps-docs
 deps-docs:
 	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		curl -sL https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxf - -C /tmp && mv /tmp/hugo /usr/bin/hugo && chmod +x /usr/bin/hugo; \
+		curl -sL https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxf - -C /tmp && mv /tmp/hugo ~/go/bin/hugo && chmod +x ~/go/bin/hugo; \
 	fi
 
 .PHONY: deps
-deps: deps-frontend deps-backend deps-tools
+deps: deps-frontend deps-backend deps-tools deps-docs
 
 .PHONY: deps-frontend
 deps-frontend: node_modules

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ help:
 	@echo " - clean                            delete backend and integration files"
 	@echo " - clean-all                        delete backend, frontend and integration files"
 	@echo " - deps                             install dependencies"
+	@echo " - deps-docs                        install docs dependencies"
 	@echo " - deps-frontend                    install frontend dependencies"
 	@echo " - deps-backend                     install backend dependencies"
 	@echo " - deps-tools                       install tool dependencies"
@@ -816,11 +817,14 @@ release-docs: | $(DIST_DIRS) docs
 	tar -czf $(DIST)/release/gitea-docs-$(VERSION).tar.gz -C ./docs/public .
 
 .PHONY: docs
-docs:
+docs: deps-docs
+	cd docs; make trans-copy clean build-offline;
+
+.PHONY: deps-docs # TODO: find a way to install hugo without needing sudo permissions and add deps-docs to deps (the next block)
+deps-docs:
 	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		curl -sL https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxf - -C /tmp && mv /tmp/hugo /usr/bin/hugo && chmod +x /usr/bin/hugo; \
 	fi
-	cd docs; make trans-copy clean build-offline;
 
 .PHONY: deps
 deps: deps-frontend deps-backend deps-tools


### PR DESCRIPTION
Refactored `deps-docs` out of `docs` because #23629 broke Gitpod's docs setup (which grepped to get the hugo install command).

Now `make deps` really installs everything to develop (includes `docs`).