### PR TITLE
ensure go/bin path exists when copying hugo bin into it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -823,7 +823,7 @@ docs: deps-docs
 .PHONY: deps-docs
 deps-docs:
 	@hash hugo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		curl -sL https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxf - -C /tmp && mv /tmp/hugo ~/go/bin/hugo && chmod +x ~/go/bin/hugo; \
+		curl -sL https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxf - -C /tmp && mkdir -p ~/go/bin && mv /tmp/hugo ~/go/bin/hugo && chmod +x ~/go/bin/hugo; \
 	fi
 
 .PHONY: deps


### PR DESCRIPTION
follow up of https://github.com/go-gitea/gitea/pull/23686

path does not exist during static pipeline, and fails out (example: https://drone.gitea.io/go-gitea/gitea/70587/1/5 )