### PR TITLE
Use absolute slug for packages documentations

### DIFF
--- a/docs/content/doc/packages.en-us.md
+++ b/docs/content/doc/packages.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2016-12-27T16:00:00+02:00"
 title: "Packages"
-slug: "packages"
+slug: "usage/packages"
 weight: 35
 toc: false
 draft: false

--- a/docs/content/doc/packages/cargo.en-us.md
+++ b/docs/content/doc/packages/cargo.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-11-20T00:00:00+00:00"
 title: "Cargo Packages Repository"
-slug: "usage/packages/cargo"
+slug: "/usage/packages/cargo"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/cargo.en-us.md
+++ b/docs/content/doc/packages/cargo.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-11-20T00:00:00+00:00"
 title: "Cargo Packages Repository"
-slug: "/usage/packages/cargo"
+slug: "cargo"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/chef.en-us.md
+++ b/docs/content/doc/packages/chef.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2023-01-20T00:00:00+00:00"
 title: "Chef Packages Repository"
-slug: "usage/packages/chef"
+slug: "/usage/packages/chef"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/chef.en-us.md
+++ b/docs/content/doc/packages/chef.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2023-01-20T00:00:00+00:00"
 title: "Chef Packages Repository"
-slug: "/usage/packages/chef"
+slug: "chef"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/composer.en-us.md
+++ b/docs/content/doc/packages/composer.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Composer Packages Repository"
-slug: "/usage/packages/composer"
+slug: "composer"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/composer.en-us.md
+++ b/docs/content/doc/packages/composer.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Composer Packages Repository"
-slug: "usage/packages/composer"
+slug: "/usage/packages/composer"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/conan.en-us.md
+++ b/docs/content/doc/packages/conan.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Conan Packages Repository"
-slug: "/usage/packages/conan"
+slug: "conan"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/conan.en-us.md
+++ b/docs/content/doc/packages/conan.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Conan Packages Repository"
-slug: "usage/packages/conan"
+slug: "/usage/packages/conan"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/conda.en-us.md
+++ b/docs/content/doc/packages/conda.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-12-28T00:00:00+00:00"
 title: "Conda Packages Repository"
-slug: "usage/packages/conda"
+slug: "/usage/packages/conda"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/conda.en-us.md
+++ b/docs/content/doc/packages/conda.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-12-28T00:00:00+00:00"
 title: "Conda Packages Repository"
-slug: "/usage/packages/conda"
+slug: "conda"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/container.en-us.md
+++ b/docs/content/doc/packages/container.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Container Registry"
-slug: "/usage/packages/container"
+slug: "container"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/container.en-us.md
+++ b/docs/content/doc/packages/container.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Container Registry"
-slug: "usage/packages/container"
+slug: "/usage/packages/container"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/generic.en-us.md
+++ b/docs/content/doc/packages/generic.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Generic Packages Repository"
-slug: "usage/packages/generic"
+slug: "/usage/packages/generic"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/generic.en-us.md
+++ b/docs/content/doc/packages/generic.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Generic Packages Repository"
-slug: "/usage/packages/generic"
+slug: "generic"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/helm.en-us.md
+++ b/docs/content/doc/packages/helm.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-04-14T00:00:00+00:00"
 title: "Helm Chart Registry"
-slug: "usage/packages/helm"
+slug: "/usage/packages/helm"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/helm.en-us.md
+++ b/docs/content/doc/packages/helm.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-04-14T00:00:00+00:00"
 title: "Helm Chart Registry"
-slug: "/usage/packages/helm"
+slug: "helm"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/maven.en-us.md
+++ b/docs/content/doc/packages/maven.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Maven Packages Repository"
-slug: "/usage/packages/maven"
+slug: "maven"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/maven.en-us.md
+++ b/docs/content/doc/packages/maven.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Maven Packages Repository"
-slug: "usage/packages/maven"
+slug: "/usage/packages/maven"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/npm.en-us.md
+++ b/docs/content/doc/packages/npm.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "npm Packages Repository"
-slug: "usage/packages/npm"
+slug: "/usage/packages/npm"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/npm.en-us.md
+++ b/docs/content/doc/packages/npm.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "npm Packages Repository"
-slug: "/usage/packages/npm"
+slug: "npm"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/nuget.en-us.md
+++ b/docs/content/doc/packages/nuget.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "NuGet Packages Repository"
-slug: "usage/packages/nuget"
+slug: "/usage/packages/nuget"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/nuget.en-us.md
+++ b/docs/content/doc/packages/nuget.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "NuGet Packages Repository"
-slug: "/usage/packages/nuget"
+slug: "nuget"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/overview.en-us.md
+++ b/docs/content/doc/packages/overview.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Package Registry"
-slug: "usage/packages/overview"
+slug: "/usage/packages/overview"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/overview.en-us.md
+++ b/docs/content/doc/packages/overview.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "Package Registry"
-slug: "/usage/packages/overview"
+slug: "overview"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/pub.en-us.md
+++ b/docs/content/doc/packages/pub.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-07-31T00:00:00+00:00"
 title: "Pub Packages Repository"
-slug: "/usage/packages/pub"
+slug: "pub"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/pub.en-us.md
+++ b/docs/content/doc/packages/pub.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-07-31T00:00:00+00:00"
 title: "Pub Packages Repository"
-slug: "usage/packages/pub"
+slug: "/usage/packages/pub"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/pypi.en-us.md
+++ b/docs/content/doc/packages/pypi.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "PyPI Packages Repository"
-slug: "/usage/packages/pypi"
+slug: "pypi"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/pypi.en-us.md
+++ b/docs/content/doc/packages/pypi.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "PyPI Packages Repository"
-slug: "usage/packages/pypi"
+slug: "/usage/packages/pypi"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/rubygems.en-us.md
+++ b/docs/content/doc/packages/rubygems.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "RubyGems Packages Repository"
-slug: "usage/packages/rubygems"
+slug: "/usage/packages/rubygems"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/rubygems.en-us.md
+++ b/docs/content/doc/packages/rubygems.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2021-07-20T00:00:00+00:00"
 title: "RubyGems Packages Repository"
-slug: "/usage/packages/rubygems"
+slug: "rubygems"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/storage.en-us.md
+++ b/docs/content/doc/packages/storage.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-11-01T00:00:00+00:00"
 title: "Storage"
-slug: "/usage/packages/storage"
+slug: "storage"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/storage.en-us.md
+++ b/docs/content/doc/packages/storage.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-11-01T00:00:00+00:00"
 title: "Storage"
-slug: "usage/packages/storage"
+slug: "/usage/packages/storage"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/swift.en-us.md
+++ b/docs/content/doc/packages/swift.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2023-01-10T00:00:00+00:00"
 title: "Swift Packages Repository"
-slug: "usage/packages/swift"
+slug: "/usage/packages/swift"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/swift.en-us.md
+++ b/docs/content/doc/packages/swift.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2023-01-10T00:00:00+00:00"
 title: "Swift Packages Repository"
-slug: "/usage/packages/swift"
+slug: "swift"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/vagrant.en-us.md
+++ b/docs/content/doc/packages/vagrant.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-08-23T00:00:00+00:00"
 title: "Vagrant Packages Repository"
-slug: "usage/packages/vagrant"
+slug: "/usage/packages/vagrant"
 draft: false
 toc: false
 menu:

--- a/docs/content/doc/packages/vagrant.en-us.md
+++ b/docs/content/doc/packages/vagrant.en-us.md
@@ -1,7 +1,7 @@
 ---
 date: "2022-08-23T00:00:00+00:00"
 title: "Vagrant Packages Repository"
-slug: "/usage/packages/vagrant"
+slug: "vagrant"
 draft: false
 toc: false
 menu:


### PR DESCRIPTION
Look like there is a duplicated `packages` in https://docs.gitea.com/packages/usage/packages/cargo , It maybe caused by the relative slug in packages documentations.