### PR TITLE
Add missing translation for `actions.runners.reset_registration_token_success`

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3358,6 +3358,7 @@ runners.status.idle = Idle
 runners.status.active = Active
 runners.status.offline = Offline
 runners.version = Version
+runners.reset_registration_token_success = Runner registration token reset successfully
 
 runs.all_workflows = All Workflows
 runs.open_tab = %d Open


### PR DESCRIPTION
Used at
https://github.com/go-gitea/gitea/blob/4011821c946e8db032be86266dd9364ccb204118/routers/web/shared/actions/runners.go#L157