### PR TITLE
Improve commit graph page UI alignment (#23751)

### DIFF
--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -28,10 +28,10 @@
 							{{- end -}}
 						</a>
 					</span>
-					<span class="message gt-dib gt-ellipsis gt-mr-2">
+					<span class="message gt-dib gt-ellipsis gt-mr-3">
 						<span>{{RenderCommitMessage $.Context $commit.Subject $.RepoLink $.Repository.ComposeMetas}}</span>
 					</span>
-					<span class="tags gt-df gt-ac">
+					<span class="tags gt-df gt-ac gt-mr-2">
 						{{range $commit.Refs}}
 							{{$refGroup := .RefGroup}}
 							{{if eq $refGroup "pull"}}
@@ -54,20 +54,20 @@
 									{{svg "octicon-git-branch" 16 "gt-mr-2"}}{{.ShortName}}
 								</a>
 							{{else}}
-								<!-- Unknown ref type {{.Name}} -->
+								<!-- Unknown ref type .Name -->
 							{{end}}
 						{{end}}
 					</span>
-					<span class="author gt-df gt-ac gt-mr-2">
+					<span class="author gt-df gt-ac gt-mr-3">
 						{{$userName := $commit.Commit.Author.Name}}
 						{{if $commit.User}}
 							{{if $commit.User.FullName}}
 								{{$userName = $commit.User.FullName}}
 							{{end}}
-							{{avatar $.Context $commit.User}}
+							<span class="gt-mr-2">{{avatar $.Context $commit.User}}</span>
 							<a href="{{$commit.User.HomeLink}}">{{$userName}}</a>
 						{{else}}
-							{{avatarByEmail $.Context $commit.Commit.Author.Email $userName}}
+							<span class="gt-mr-2">{{avatarByEmail $.Context $commit.Commit.Author.Email $userName}}</span>
 							{{$userName}}
 						{{end}}
 					</span>


### PR DESCRIPTION
Backport #23751

Fix the UI alignment by the way (adding some `gt-mr-xx`)

Before:

![image](https://user-images.githubusercontent.com/2114189/228034794-7a6ac8d6-01fa-4dd2-97d4-0df0368f8ee0.png)

After:

![image](https://user-images.githubusercontent.com/2114189/228034938-64edeadf-7c99-4e74-b658-0ca62b72d596.png)

