### PR TITLE
Add missing translation for `actions.runners.reset_registration_token_success` (#23732)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3344,6 +3344,7 @@ runners.status.unspecified = Unknown
 runners.status.idle = Idle
 runners.status.active = Active
 runners.status.offline = Offline
+runners.reset_registration_token_success = Runner registration token reset successfully
 
 runs.all_workflows = All Workflows
 runs.open_tab = %d Open


### PR DESCRIPTION
Backport #23732.

Used at

https://github.com/go-gitea/gitea/blob/4011821c946e8db032be86266dd9364ccb204118/routers/web/shared/actions/runners.go#L157

