### PR TITLE
Refactor commit status for Actions jobs

### DIFF
--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -149,10 +149,7 @@ func (s *Service) UpdateTask(
 		return nil, status.Errorf(codes.Internal, "load job: %v", err)
 	}
 
-	if err := actions_service.CreateCommitStatus(ctx, task.Job); err != nil {
-		log.Error("Update commit status for job %v failed: %v", task.Job.ID, err)
-		// go on
-	}
+	actions_service.CreateCommitStatus(ctx, task.Job)
 
 	if req.Msg.State.Result != runnerv1.Result_RESULT_UNSPECIFIED {
 		if err := actions_service.EmitJobsIfReady(task.Job.RunID); err != nil {

--- a/routers/api/actions/runner/utils.go
+++ b/routers/api/actions/runner/utils.go
@@ -13,6 +13,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	secret_module "code.gitea.io/gitea/modules/secret"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/services/actions"
 
 	runnerv1 "code.gitea.io/actions-proto-go/runner/v1"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -25,6 +26,11 @@ func pickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 	}
 	if !ok {
 		return nil, false, nil
+	}
+
+	if err := actions.CreateCommitStatus(ctx, t.Job); err != nil {
+		log.Error("Update commit status for job %v failed: %v", t.Job.ID, err)
+		// go on
 	}
 
 	task := &runnerv1.Task{

--- a/routers/api/actions/runner/utils.go
+++ b/routers/api/actions/runner/utils.go
@@ -28,10 +28,7 @@ func pickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 		return nil, false, nil
 	}
 
-	if err := actions.CreateCommitStatus(ctx, t.Job); err != nil {
-		log.Error("Update commit status for job %v failed: %v", t.Job.ID, err)
-		// go on
-	}
+	actions.CreateCommitStatus(ctx, t.Job)
 
 	task := &runnerv1.Task{
 		Id:              t.ID,

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -349,6 +349,13 @@ func Approve(ctx *context_module.Context) {
 		return
 	}
 
+	for _, job := range jobs {
+		if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
+			log.Error("Update commit status for job %v failed: %v", job.ID, err)
+			// go on
+		}
+	}
+
 	ctx.JSON(http.StatusOK, struct{}{})
 }
 

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -16,7 +16,6 @@ import (
 	"code.gitea.io/gitea/modules/actions"
 	"code.gitea.io/gitea/modules/base"
 	context_module "code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
@@ -264,10 +263,7 @@ func Rerun(ctx *context_module.Context) {
 		return
 	}
 
-	if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
-		log.Error("Update commit status for job %v failed: %v", job.ID, err)
-		// go on
-	}
+	actions_service.CreateCommitStatus(ctx, job)
 
 	ctx.JSON(http.StatusOK, struct{}{})
 }
@@ -308,12 +304,7 @@ func Cancel(ctx *context_module.Context) {
 		return
 	}
 
-	for _, job := range jobs {
-		if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
-			log.Error("Update commit status for job %v failed: %v", job.ID, err)
-			// go on
-		}
-	}
+	actions_service.CreateCommitStatus(ctx, jobs...)
 
 	ctx.JSON(http.StatusOK, struct{}{})
 }
@@ -349,12 +340,7 @@ func Approve(ctx *context_module.Context) {
 		return
 	}
 
-	for _, job := range jobs {
-		if err := actions_service.CreateCommitStatus(ctx, job); err != nil {
-			log.Error("Update commit status for job %v failed: %v", job.ID, err)
-			// go on
-		}
-	}
+	actions_service.CreateCommitStatus(ctx, jobs...)
 
 	ctx.JSON(http.StatusOK, struct{}{})
 }

--- a/services/actions/clear_tasks.go
+++ b/services/actions/clear_tasks.go
@@ -64,12 +64,7 @@ func stopTasks(ctx context.Context, opts actions_model.FindTaskOptions) error {
 		}
 	}
 
-	for _, job := range jobs {
-		if err := CreateCommitStatus(ctx, job); err != nil {
-			log.Error("Update commit status for job %v failed: %v", job.ID, err)
-			// go on
-		}
-	}
+	CreateCommitStatus(ctx, jobs...)
 
 	return nil
 }
@@ -96,10 +91,7 @@ func CancelAbandonedJobs(ctx context.Context) error {
 			log.Warn("cancel abandoned job %v: %v", job.ID, err)
 			// go on
 		}
-		if err := CreateCommitStatus(ctx, job); err != nil {
-			log.Error("Update commit status for job %v failed: %v", job.ID, err)
-			// go on
-		}
+		CreateCommitStatus(ctx, job)
 	}
 
 	return nil

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -109,9 +109,9 @@ func CreateCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 
 func toCommitStatus(status actions_model.Status) api.CommitStatusState {
 	switch status {
-	case actions_model.StatusSuccess:
+	case actions_model.StatusSuccess, actions_model.StatusSkipped:
 		return api.CommitStatusSuccess
-	case actions_model.StatusFailure, actions_model.StatusCancelled, actions_model.StatusSkipped:
+	case actions_model.StatusFailure, actions_model.StatusCancelled:
 		return api.CommitStatusFailure
 	case actions_model.StatusWaiting, actions_model.StatusBlocked:
 		return api.CommitStatusPending

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -79,7 +79,7 @@ func CreateCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 	}
 
 	description := ""
-	switch run.Status {
+	switch job.Status {
 	// TODO: if we want support description in different languages, we need to support i18n placeholders in it
 	case actions_model.StatusSuccess:
 		description = fmt.Sprintf("Successful in %s", job.Duration())

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -11,7 +11,6 @@ import (
 	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/graceful"
-	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/queue"
 
 	"xorm.io/builder"
@@ -71,12 +70,7 @@ func checkJobsOfRun(ctx context.Context, runID int64) error {
 	}); err != nil {
 		return err
 	}
-	for _, job := range jobs {
-		if err := CreateCommitStatus(ctx, job); err != nil {
-			log.Error("Update commit status for job %v failed: %v", job.ID, err)
-			// go on
-		}
-	}
+	CreateCommitStatus(ctx, jobs...)
 	return nil
 }
 

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -185,12 +185,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 		if jobs, _, err := actions_model.FindRunJobs(ctx, actions_model.FindRunJobOptions{RunID: run.ID}); err != nil {
 			log.Error("FindRunJobs: %v", err)
 		} else {
-			for _, job := range jobs {
-				if err := CreateCommitStatus(ctx, job); err != nil {
-					log.Error("Update commit status for job %v failed: %v", job.ID, err)
-					// go on
-				}
-			}
+			CreateCommitStatus(ctx, jobs...)
 		}
 
 	}


### PR DESCRIPTION
Before:
<img width="353" alt="xnip_230329_163852" src="https://user-images.githubusercontent.com/9418365/228479807-424452df-10fa-45cf-ae4b-09939c0ed54c.png">
After:
<img width="508" alt="xnip_230329_163358" src="https://user-images.githubusercontent.com/9418365/228479923-537b54fe-9564-4105-a068-bcc75fa2a7ea.png">

Highlights:
- Treat `StatusSkipped` as `CommitStatusSuccess` instead of `CommitStatusFailure`, so it fixed #23599.
- Use the bot user `gitea-actions` instead of the trigger as the creator of commit status.
- New format `<run_name> / <job_name> / (<event>)` for the context of commit status to avoid conflicts.
- Add descriptions for commit status.
- Add the missing calls to `CreateCommitStatus`.
- Refactor `CreateCommitStatus` to make it easier to use.


