### PR TITLE
Fix cancel button in the page of project edit not work (#23655)

### DIFF
--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -232,9 +232,11 @@ func EditProject(ctx *context.Context) {
 		return
 	}
 
+	ctx.Data["projectID"] = p.ID
 	ctx.Data["title"] = p.Title
 	ctx.Data["content"] = p.Description
 	ctx.Data["redirect"] = ctx.FormString("redirect")
+	ctx.Data["HomeLink"] = ctx.ContextUser.HomeLink()
 
 	ctx.HTML(http.StatusOK, tplProjectsNew)
 }

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -232,6 +232,7 @@ func EditProject(ctx *context.Context) {
 		return
 	}
 
+	ctx.Data["projectID"] = p.ID
 	ctx.Data["title"] = p.Title
 	ctx.Data["content"] = p.Description
 	ctx.Data["card_type"] = p.CardType

--- a/templates/projects/new.tmpl
+++ b/templates/projects/new.tmpl
@@ -48,7 +48,7 @@
 				<div class="ui divider"></div>
 				<div class="ui left">
 					{{if .PageIsEditProjects}}
-					<a class="ui primary basic button" href="{{.RepoLink}}/projects">
+					<a class="ui primary basic button" href="{{$.HomeLink}}/-/projects{{if eq .redirect "project"}}/{{.projectID}}{{end}}">
 						{{.locale.Tr "repo.milestones.cancel"}}
 					</a>
 					<button class="ui green button">

--- a/templates/repo/projects/new.tmpl
+++ b/templates/repo/projects/new.tmpl
@@ -72,7 +72,7 @@
 				<div class="ui divider"></div>
 				<div class="ui left">
 					{{if .PageIsEditProjects}}
-					<a class="ui primary basic button" href="{{.RepoLink}}/projects">
+					<a class="ui primary basic button" href="{{.RepoLink}}/projects{{if eq .redirect "project"}}/{{.projectID}}{{end}}">
 						{{.locale.Tr "repo.milestones.cancel"}}
 					</a>
 					<button class="ui green button">

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -314,15 +314,7 @@ export function initGlobalLinkActions() {
 }
 
 export function initGlobalButtons() {
-  // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
-  // However, Gitea misuses the modal dialog and put the cancel buttons inside forms, so we must prevent the form submission.
-  // There are a few cancel buttons in non-modal forms, and there are some dynamically created forms (eg: the "Edit Issue Content")
-  $(document).on('click', 'form button.ui.cancel.button', (e) => {
-    e.preventDefault();
-  });
-
-  $('.show-panel.button').on('click', function (e) {
-    e.preventDefault();
+  $('.show-panel.button').on('click', function () {
     showElem($(this).data('panel'));
   });
 

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -314,7 +314,15 @@ export function initGlobalLinkActions() {
 }
 
 export function initGlobalButtons() {
-  $('.show-panel.button').on('click', function () {
+  // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
+  // However, Gitea misuses the modal dialog and put the cancel buttons inside forms, so we must prevent the form submission.
+  // There are a few cancel buttons in non-modal forms, and there are some dynamically created forms (eg: the "Edit Issue Content")
+  $(document).on('click', 'form button.ui.cancel.button', (e) => {
+    e.preventDefault();
+  });
+
+  $('.show-panel.button').on('click', function (e) {
+    e.preventDefault();
     showElem($(this).data('panel'));
   });
 


### PR DESCRIPTION
Backport #23655

Before, in project edit page, the cancel button is not work.

https://user-images.githubusercontent.com/33891828/227182731-6478e29f-0e52-48c4-beb0-6a7d1dda6a1d.mov

1. The wrong classname `cancel` was added to the `<a>` tag. That classname caused the default click event of `<a>` tag to be cancelled. Because we have the following settings in the global. So I remove the classname `cancel`.

https://github.com/go-gitea/gitea/blob/9be90a58754061171bbd5025d85d2b891364efd3/web_src/js/features/common-global.js#L325-L327

2. Another change is that page will redirect to the previous page.

https://user-images.githubusercontent.com/33891828/227187326-c653c6d6-9715-440f-a732-ba0a6f012c81.mov
