### PR TITLE
Fix checks for `needs` in Actions (#23789)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -285,7 +285,7 @@ replace github.com/shurcooL/vfsgen => github.com/lunny/vfsgen v0.0.0-20220105142
 
 replace github.com/blevesearch/zapx/v15 v15.3.6 => github.com/zeripath/zapx/v15 v15.3.6-alignment-fix
 
-replace github.com/nektos/act => gitea.com/gitea/act v0.243.1
+replace github.com/nektos/act => gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab
 
 exclude github.com/gofrs/uuid v3.2.0+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570/go.mod h1:IIAjsi
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20220703122237-02e73435a078 h1:cliQ4HHsCo6xi2oWZYKWW4bly/Ory9FuTpFPRxj/mAg=
 git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20220703122237-02e73435a078/go.mod h1:g/V2Hjas6Z1UHUp4yIx6bATpNzJ7DYtD0FG3+xARWxs=
-gitea.com/gitea/act v0.243.1 h1:zIVlhGOLE4SHFPW++u3+5Y/jX5mub3QIhB13oNf6rtA=
-gitea.com/gitea/act v0.243.1/go.mod h1:iLHCXqOPUElA2nSyHo4wtxSmvdkym3WU7CkP3AxF39Q=
+gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab h1:HDImhO/XpMJrw2PJcADI/wgur9Gro/pegLFaRt8Wpg0=
+gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab/go.mod h1:mabw6AZAiDgxGlK83orWLrNERSPvgBJzEUS3S7u2bHI=
 gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681 h1:MMSPgnVULVwV9kEBgvyEUhC9v/uviZ55hPJEMjpbNR4=
 gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681/go.mod h1:77TZu701zMXWJFvB8gvTbQ92zQ3DQq/H7l5wAEjQRKc=
 gitea.com/go-chi/cache v0.0.0-20210110083709-82c4c9ce2d5e/go.mod h1:k2V/gPDEtXGjjMGuBJiapffAXTv76H4snSmlJRLUhH0=

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -199,7 +199,9 @@ func InsertRun(ctx context.Context, run *ActionRun, jobs []*jobparser.SingleWork
 	for _, v := range jobs {
 		id, job := v.Job()
 		needs := job.Needs()
-		job.EraseNeeds()
+		if err := v.SetJob(id, job.EraseNeeds()); err != nil {
+			return err
+		}
 		payload, _ := v.Marshal()
 		status := StatusWaiting
 		if len(needs) > 0 {

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -106,8 +106,8 @@ func detectMatched(commit *git.Commit, triggedEvent webhook_module.HookEventType
 		webhook_module.HookEventRepository,
 		webhook_module.HookEventRelease,
 		webhook_module.HookEventPackage:
-		if len(evt.Acts) != 0 {
-			log.Warn("Ignore unsupported %s event arguments %q", triggedEvent, evt.Acts)
+		if len(evt.Acts()) != 0 {
+			log.Warn("Ignore unsupported %s event arguments %v", triggedEvent, evt.Acts())
 		}
 		// no special filter parameters for these events, just return true if name matched
 		return true
@@ -132,7 +132,7 @@ func detectMatched(commit *git.Commit, triggedEvent webhook_module.HookEventType
 
 func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobparser.Event) bool {
 	// with no special filter parameters
-	if len(evt.Acts) == 0 {
+	if len(evt.Acts()) == 0 {
 		return true
 	}
 
@@ -141,7 +141,7 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 	hasTagFilter := false
 	refName := git.RefName(pushPayload.Ref)
 	// all acts conditions should be satisfied
-	for cond, vals := range evt.Acts {
+	for cond, vals := range evt.Acts() {
 		switch cond {
 		case "branches":
 			hasBranchFilter = true
@@ -225,18 +225,18 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 	if hasBranchFilter && hasTagFilter {
 		matchTimes++
 	}
-	return matchTimes == len(evt.Acts)
+	return matchTimes == len(evt.Acts())
 }
 
 func matchIssuesEvent(commit *git.Commit, issuePayload *api.IssuePayload, evt *jobparser.Event) bool {
 	// with no special filter parameters
-	if len(evt.Acts) == 0 {
+	if len(evt.Acts()) == 0 {
 		return true
 	}
 
 	matchTimes := 0
 	// all acts conditions should be satisfied
-	for cond, vals := range evt.Acts {
+	for cond, vals := range evt.Acts() {
 		switch cond {
 		case "types":
 			for _, val := range vals {
@@ -249,19 +249,19 @@ func matchIssuesEvent(commit *git.Commit, issuePayload *api.IssuePayload, evt *j
 			log.Warn("issue event unsupported condition %q", cond)
 		}
 	}
-	return matchTimes == len(evt.Acts)
+	return matchTimes == len(evt.Acts())
 }
 
 func matchPullRequestEvent(commit *git.Commit, prPayload *api.PullRequestPayload, evt *jobparser.Event) bool {
 	// with no special filter parameters
-	if len(evt.Acts) == 0 {
+	if len(evt.Acts()) == 0 {
 		// defaultly, only pull request opened and synchronized will trigger workflow
 		return prPayload.Action == api.HookIssueSynchronized || prPayload.Action == api.HookIssueOpened
 	}
 
 	matchTimes := 0
 	// all acts conditions should be satisfied
-	for cond, vals := range evt.Acts {
+	for cond, vals := range evt.Acts() {
 		switch cond {
 		case "types":
 			action := prPayload.Action
@@ -323,18 +323,18 @@ func matchPullRequestEvent(commit *git.Commit, prPayload *api.PullRequestPayload
 			log.Warn("pull request event unsupported condition %q", cond)
 		}
 	}
-	return matchTimes == len(evt.Acts)
+	return matchTimes == len(evt.Acts())
 }
 
 func matchIssueCommentEvent(commit *git.Commit, issueCommentPayload *api.IssueCommentPayload, evt *jobparser.Event) bool {
 	// with no special filter parameters
-	if len(evt.Acts) == 0 {
+	if len(evt.Acts()) == 0 {
 		return true
 	}
 
 	matchTimes := 0
 	// all acts conditions should be satisfied
-	for cond, vals := range evt.Acts {
+	for cond, vals := range evt.Acts() {
 		switch cond {
 		case "types":
 			for _, val := range vals {
@@ -347,5 +347,5 @@ func matchIssueCommentEvent(commit *git.Commit, issueCommentPayload *api.IssueCo
 			log.Warn("issue comment unsupported condition %q", cond)
 		}
 	}
-	return matchTimes == len(evt.Acts)
+	return matchTimes == len(evt.Acts())
 }


### PR DESCRIPTION
Backport #23789.

Fix:
- https://gitea.com/gitea/act_runner/issues/77
- https://gitea.com/gitea/act_runner/issues/81

Before:
<img width="1489" alt="image"
src="https://user-images.githubusercontent.com/9418365/228501567-f752cf87-a7ed-42c6-8f3d-ba741795c1fe.png">

Highlights:
- Upgrade act to make things doable, related to
  - https://gitea.com/gitea/act/pulls/32
  - https://gitea.com/gitea/act/pulls/33
  - https://gitea.com/gitea/act/pulls/35
- Make `needs` works
- Sort jobs in the original order in the workflow files

