### PR TITLE
Use different SVG for pending and running actions

### DIFF
--- a/templates/repo/commit_status.tmpl
+++ b/templates/repo/commit_status.tmpl
@@ -1,5 +1,5 @@
 {{if eq .State "pending"}}
-	{{svg "octicon-dot-fill" 18 "commit-status icon text yellow"}}
+	{{svg "octicon-dot-fill" 18 "commit-status icon text grey"}}
 {{end}}
 {{if eq .State "running"}}
 	{{svg "octicon-dot-fill" 18 "commit-status icon text yellow"}}

--- a/tests/integration/repo_commits_test.go
+++ b/tests/integration/repo_commits_test.go
@@ -110,7 +110,7 @@ func testRepoCommitsWithStatus(t *testing.T, resp, respOne *httptest.ResponseRec
 }
 
 func TestRepoCommitsWithStatusPending(t *testing.T) {
-	doTestRepoCommitWithStatus(t, "pending", "octicon-dot-fill", "yellow")
+	doTestRepoCommitWithStatus(t, "pending", "octicon-dot-fill", "grey")
 }
 
 func TestRepoCommitsWithStatusSuccess(t *testing.T) {
@@ -127,6 +127,10 @@ func TestRepoCommitsWithStatusFailure(t *testing.T) {
 
 func TestRepoCommitsWithStatusWarning(t *testing.T) {
 	doTestRepoCommitWithStatus(t, "warning", "gitea-exclamation", "yellow")
+}
+
+func TestRepoCommitsWithStatusRunning(t *testing.T) {
+	doTestRepoCommitWithStatus(t, "running", "octicon-dot-fill", "yellow")
 }
 
 func TestRepoCommitsStatusParallel(t *testing.T) {


### PR DESCRIPTION
Before:
<img width="641" alt="截屏2023-03-31 11 12 17" src="https://user-images.githubusercontent.com/17645053/229013472-237701db-2c30-4477-a7b5-d40640361b14.png">
<img width="576" alt="截屏2023-03-31 11 10 48" src="https://user-images.githubusercontent.com/17645053/229013535-571aa8be-8e58-4d93-8641-9b8b5fd90108.png">


After:
<img width="709" alt="截屏2023-03-31 11 05 44" src="https://user-images.githubusercontent.com/17645053/229012963-ccd1e9a7-8bea-4197-aa36-865eafbf8858.png">
<img width="528" alt="截屏2023-03-31 11 06 56" src="https://user-images.githubusercontent.com/17645053/229012971-a7313eb6-ecd2-4da3-89a7-c20be33f4611.png">

