### PR TITLE
Make first section on home page full width

### DIFF
--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -1,6 +1,6 @@
 {{template "base/head" .}}
 <div role="main" aria-label="{{if .IsSigned}}{{.locale.Tr "dashboard"}}{{else}}{{.locale.Tr "home"}}{{end}}" class="page-content home">
-	<div class="ui stackable middle very relaxed page grid">
+	<div class="ui middle very relaxed page gt-mb-5">
 		<div class="sixteen wide center aligned centered column">
 			<div>
 				<img class="logo" width="220" height="220" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{.locale.Tr "logo"}}">


### PR DESCRIPTION
Before:
<img width="1272" alt="Screenshot 2023-03-31 at 19 56 16" src="https://user-images.githubusercontent.com/115237/229195611-4570453c-26bf-4663-865b-7e7eb9115060.png">

After:
<img width="1270" alt="Screenshot 2023-03-31 at 20 00 14" src="https://user-images.githubusercontent.com/115237/229195639-23841b62-38d8-4e43-8ee5-3f70cba5de6e.png">
