### PR TITLE
Fix JS error when changing PR's target branch

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -645,8 +645,6 @@ export function initRepoIssueTitleEdit() {
       $.post(update_url, {
         _csrf: csrfToken,
         target_branch: targetBranch
-      }).done((data) => {
-        $branchTarget.text(data.base_branch);
       }).always(() => {
         window.location.reload();
       });


### PR DESCRIPTION
Caught by @justusbunsi 

An old bug from #6488

In `pullrequest_targetbranch_change`, the `data` might be empty, because `UpdatePullRequestTarget` may respond `http.StatusNoContent`.

And the old code's `$branchTarget.text(data.base_branch);` doesn't make sense, because in the end, the page will be always reloaded.

So, just remove the `$branchTarget.text(data.base_branch);`, everything should be fine.

