### PR TITLE
docs: make the required backticks in email password more explicit

### DIFF
--- a/docs/content/doc/administration/email-setup.en-us.md
+++ b/docs/content/doc/administration/email-setup.en-us.md
@@ -81,7 +81,7 @@ SMTP_ADDR      = smtp.gmail.com
 SMTP_PORT      = 465
 FROM           = example.user@gmail.com
 USER           = example.user
-PASSWD         = ***
+PASSWD         = `***`
 MAILER_TYPE    = smtp
 IS_TLS_ENABLED = true
 ```


### PR DESCRIPTION
updated the example config to make the needed backticks around the password more obvious 