### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/doc/administration/mail-templates.en-us.md
+++ b/docs/content/doc/administration/mail-templates.en-us.md
@@ -39,7 +39,7 @@ Currently, the following notification events make use of templates:
 | `approve`   | The head comment of a approving review for a pull request.                                                   |
 | `reject`    | The head comment of a review requesting changes for a pull request.                                          |
 | `code`      | A single comment on the code of a pull request.                                                              |
-| `assigned`  | Used was assigned to an issue or pull request.                                                               |
+| `assigned`  | User was assigned to an issue or pull request.                                                               |
 | `default`   | Any action not included in the above categories, or when the corresponding category template is not present. |
 
 The path for the template of a particular message type is:


### PR DESCRIPTION
fixes a minor typo in the email templates page