### PR TITLE
Update eslints for Vue 3

### DIFF
--- a/web_src/js/components/.eslintrc.yaml
+++ b/web_src/js/components/.eslintrc.yaml
@@ -3,7 +3,7 @@ plugins:
 
 extends:
   - ../../../.eslintrc.yaml
-  - plugin:vue/recommended
+  - plugin:vue/vue3-recommended
 
 env:
   browser: true


### PR DESCRIPTION
I found that some lint warnings in my editor are conflicting, and I believe the root cause is using lints designed for Vue 2 instead of Vue 3.  We moved to Vue 3 in #20044.

I verified that the explicitly disabled rules in the changed file are still part of the `vue/vue3-recommended` set.

See [Available rules - eslint-plugin-vue](https://eslint.vuejs.org/rules/) for a full list of lints.