### PR TITLE
Left-align review comments

### DIFF
--- a/web_src/css/review.css
+++ b/web_src/css/review.css
@@ -61,8 +61,7 @@
 .comment-code-cloud {
   padding: 0.5rem 1rem !important;
   position: relative;
-  margin: 0 auto;
-  max-width: 1000px;
+  max-width: 820px;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Small extract from https://github.com/go-gitea/gitea/pull/23553 for 1.19:

Before:
<img width="1190" alt="Screenshot 2023-04-05 at 21 47 55" src="https://user-images.githubusercontent.com/115237/230190330-3cee8904-8558-43ea-b9d3-424d807d0b73.png">

After:
<img width="1181" alt="Screenshot 2023-04-05 at 21 47 38" src="https://user-images.githubusercontent.com/115237/230190315-c1c3cae5-1bc3-4c2d-bd3d-c119fa01be82.png">
