### PR TITLE
Do not crash when parsing an invalid workflow file 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -289,7 +289,7 @@ replace github.com/shurcooL/vfsgen => github.com/lunny/vfsgen v0.0.0-20220105142
 
 replace github.com/blevesearch/zapx/v15 v15.3.6 => github.com/zeripath/zapx/v15 v15.3.6-alignment-fix
 
-replace github.com/nektos/act => gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab
+replace github.com/nektos/act => gitea.com/gitea/act v0.243.3-0.20230407083103-5c4a96bcb797
 
 exclude github.com/gofrs/uuid v3.2.0+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570/go.mod h1:IIAjsi
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20220703122237-02e73435a078 h1:cliQ4HHsCo6xi2oWZYKWW4bly/Ory9FuTpFPRxj/mAg=
 git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20220703122237-02e73435a078/go.mod h1:g/V2Hjas6Z1UHUp4yIx6bATpNzJ7DYtD0FG3+xARWxs=
-gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab h1:HDImhO/XpMJrw2PJcADI/wgur9Gro/pegLFaRt8Wpg0=
-gitea.com/gitea/act v0.243.2-0.20230329055922-5e76853b55ab/go.mod h1:mabw6AZAiDgxGlK83orWLrNERSPvgBJzEUS3S7u2bHI=
+gitea.com/gitea/act v0.243.3-0.20230407083103-5c4a96bcb797 h1:QdQ+pHxpbIi2qsgZbYVxqYV7trfW3P5M/T4AfpoM7iw=
+gitea.com/gitea/act v0.243.3-0.20230407083103-5c4a96bcb797/go.mod h1:mabw6AZAiDgxGlK83orWLrNERSPvgBJzEUS3S7u2bHI=
 gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681 h1:MMSPgnVULVwV9kEBgvyEUhC9v/uviZ55hPJEMjpbNR4=
 gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681/go.mod h1:77TZu701zMXWJFvB8gvTbQ92zQ3DQq/H7l5wAEjQRKc=
 gitea.com/go-chi/cache v0.0.0-20210110083709-82c4c9ce2d5e/go.mod h1:k2V/gPDEtXGjjMGuBJiapffAXTv76H4snSmlJRLUhH0=

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -23,8 +23,8 @@ import (
 func init() {
 	model.OnDecodeNodeError = func(node yaml.Node, out interface{}, err error) {
 		// Log the error instead of panic or fatal.
-		// It will be a big job to refactor act/pkg/model return decode error,
-		// so we just log the error and continue, and improve it later.
+		// It will be a big job to refactor act/pkg/model to return decode error,
+		// so we just log the error and return empty value, and improve it later.
 		log.Error("Failed to decode node %v into %T: %v", node, out, err)
 	}
 }

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -17,7 +17,17 @@ import (
 	"github.com/nektos/act/pkg/jobparser"
 	"github.com/nektos/act/pkg/model"
 	"github.com/nektos/act/pkg/workflowpattern"
+	"gopkg.in/yaml.v3"
 )
+
+func init() {
+	model.OnDecodeNodeError = func(node yaml.Node, out interface{}, err error) {
+		// Log the error instead of panic or fatal.
+		// It will be a big job to refactor act/pkg/model return decode error,
+		// so we just log the error and continue, and improve it later.
+		log.Error("Failed to decode node %v into %T: %v", node, out, err)
+	}
+}
 
 func ListWorkflows(commit *git.Commit) (git.Entries, error) {
 	tree, err := commit.SubTree(".gitea/workflows")


### PR DESCRIPTION
Fix #23658.

Related to https://gitea.com/gitea/act/pulls/39
