### PR TITLE
Use Get/Set instead of Rename when Regenerate session id

### DIFF
--- a/modules/session/redis.go
+++ b/modules/session/redis.go
@@ -183,16 +183,21 @@ func (p *RedisProvider) Regenerate(oldsid, sid string) (_ session.RawStore, err 
 		}
 	}
 
-	if err = p.c.Rename(graceful.GetManager().HammerContext(), poldsid, psid).Err(); err != nil {
-		return nil, err
-	}
-
-	var kv map[interface{}]interface{}
-	kvs, err := p.c.Get(graceful.GetManager().HammerContext(), psid).Result()
+	// do not use Rename here, because the old sid and new sid may be in different redis cluster slot.
+	kvs, err := p.c.Get(graceful.GetManager().HammerContext(), poldsid).Result()
 	if err != nil {
 		return nil, err
 	}
 
+	if err = p.c.Del(graceful.GetManager().HammerContext(), poldsid).Err(); err != nil {
+		return nil, err
+	}
+
+	if err = p.c.Set(graceful.GetManager().HammerContext(), psid, kvs, p.duration).Err(); err != nil {
+		return nil, err
+	}
+
+	var kv map[interface{}]interface{}
 	if len(kvs) == 0 {
 		kv = make(map[interface{}]interface{})
 	} else {


### PR DESCRIPTION
Do not use Rename here, because the old sid and new sid may be in different redis cluster slot.

Fix #23869