### PR TITLE
Remove docs from automatically building in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,13 +23,6 @@ tasks:
       gp sync-await setup
       make watch-frontend
     openMode: split-right
-  - name: Run docs
-    command: |
-      gp sync-await setup
-      cd docs
-      make clean update
-      hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
-    openMode: split-right
 
 vscode:
   extensions:
@@ -46,5 +39,3 @@ vscode:
 ports:
   - name: Gitea
     port: 3000
-  - name: Docs
-    port: 1313


### PR DESCRIPTION
I couldn't find a way to build the docs without `trans-copy` and spinning up a dev environment that generates files untracked by git on startup is not a good development experience