### PR TITLE
Remove "inverted" class on creating new label and cancel buttons

### DIFF
--- a/templates/repo/issue/labels/label_new.tmpl
+++ b/templates/repo/issue/labels/label_new.tmpl
@@ -38,11 +38,11 @@
 	</div>
 
 	<div class="actions">
-		<button class="ui red basic inverted cancel button">
+		<button class="ui red basic cancel button">
 			{{svg "octicon-x"}}
 			{{.locale.Tr "cancel"}}
 		</button>
-		<button class="ui green basic inverted ok button">
+		<button class="ui green basic ok button">
 			{{svg "octicon-check"}}
 			{{.locale.Tr "repo.issues.create_label"}}
 		</button>


### PR DESCRIPTION
"inverted" class might not be needed because background of these two buttons is light color. 

inverted related rule from `semantic.css`:
```css
.ui.inverted.green.basic.buttons .button,
.ui.inverted.green.buttons .basic.button,
.ui.inverted.green.basic.button {
  background-color: transparent;
  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5) inset;
  color: #FFFFFF;
}
```

Before:
<img width="771" alt="截屏2023-04-10 17 21 22" src="https://user-images.githubusercontent.com/17645053/230873878-cc64b3d6-ffa9-4cae-9280-07b06f7829b2.png">

After:
<img width="765" alt="截屏2023-04-10 17 22 14" src="https://user-images.githubusercontent.com/17645053/230873956-9412054f-b739-4878-9ee9-57ff65eb7910.png">
