### PR TITLE
Add cardtype to org/user level project on creation, edit and view

### DIFF
--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -13,6 +13,7 @@ import (
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	project_model "code.gitea.io/gitea/models/project"
+	attachment_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
@@ -128,6 +129,7 @@ func canWriteProjects(ctx *context.Context) bool {
 func NewProject(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.projects.new")
 	ctx.Data["BoardTypes"] = project_model.GetBoardConfig()
+	ctx.Data["CardTypes"] = project_model.GetCardConfig()
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)
 	ctx.Data["PageIsViewProjects"] = true
 	ctx.Data["HomeLink"] = ctx.ContextUser.HomeLink()
@@ -145,6 +147,7 @@ func NewProjectPost(ctx *context.Context) {
 		ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)
 		ctx.Data["PageIsViewProjects"] = true
 		ctx.Data["BoardTypes"] = project_model.GetBoardConfig()
+		ctx.Data["CardTypes"] = project_model.GetCardConfig()
 		ctx.HTML(http.StatusOK, tplProjectsNew)
 		return
 	}
@@ -155,6 +158,7 @@ func NewProjectPost(ctx *context.Context) {
 		Description: form.Content,
 		CreatorID:   ctx.Doer.ID,
 		BoardType:   form.BoardType,
+		CardType:    form.CardType,
 	}
 
 	if ctx.ContextUser.IsOrganization() {
@@ -229,6 +233,8 @@ func EditProject(ctx *context.Context) {
 	ctx.Data["PageIsEditProjects"] = true
 	ctx.Data["PageIsViewProjects"] = true
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)
+	ctx.Data["CardTypes"] = project_model.GetCardConfig()
+
 	shared_user.RenderUserHeader(ctx)
 
 	p, err := project_model.GetProjectByID(ctx, ctx.ParamsInt64(":id"))
@@ -250,6 +256,7 @@ func EditProject(ctx *context.Context) {
 	ctx.Data["content"] = p.Description
 	ctx.Data["redirect"] = ctx.FormString("redirect")
 	ctx.Data["HomeLink"] = ctx.ContextUser.HomeLink()
+	ctx.Data["card_type"] = p.CardType
 
 	ctx.HTML(http.StatusOK, tplProjectsNew)
 }
@@ -261,6 +268,8 @@ func EditProjectPost(ctx *context.Context) {
 	ctx.Data["PageIsEditProjects"] = true
 	ctx.Data["PageIsViewProjects"] = true
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)
+	ctx.Data["CardTypes"] = project_model.GetCardConfig()
+
 	shared_user.RenderUserHeader(ctx)
 
 	if ctx.HasError() {
@@ -284,6 +293,7 @@ func EditProjectPost(ctx *context.Context) {
 
 	p.Title = form.Title
 	p.Description = form.Content
+	p.CardType = form.CardType
 	if err = project_model.UpdateProject(ctx, p); err != nil {
 		ctx.ServerError("UpdateProjects", err)
 		return
@@ -327,6 +337,18 @@ func ViewProject(ctx *context.Context) {
 	if err != nil {
 		ctx.ServerError("LoadIssuesOfBoards", err)
 		return
+	}
+
+	if project.CardType != project_model.CardTypeTextOnly {
+		issuesAttachmentMap := make(map[int64][]*attachment_model.Attachment)
+		for _, issuesList := range issuesMap {
+			for _, issue := range issuesList {
+				if issueAttachment, err := attachment_model.GetAttachmentsByIssueIDImagesLatest(ctx, issue.ID); err == nil {
+					issuesAttachmentMap[issue.ID] = issueAttachment
+				}
+			}
+		}
+		ctx.Data["issuesAttachmentMap"] = issuesAttachmentMap
 	}
 
 	linkedPrsMap := make(map[int64][]*issues_model.Issue)

--- a/templates/projects/new.tmpl
+++ b/templates/projects/new.tmpl
@@ -45,6 +45,24 @@
 						</div>
 					</div>
 				{{end}}
+
+				<div class="field">
+					<label>{{.locale.Tr "repo.projects.card_type.desc"}}</label>
+					<div class="ui selection dropdown">
+						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+						{{range $element := .CardTypes}}
+							{{if or (eq $.card_type $element.CardType) (and (not $.PageIsEditProjects) (eq $element.CardType 1))}}
+								<input type="hidden" name="card_type" value="{{$element.CardType}}">
+								<div class="default text">{{$.locale.Tr $element.Translation}}</div>
+							{{end}}
+						{{end}}
+						<div class="menu">
+							{{range $element := .CardTypes}}
+								<div class="item" data-id="{{$element.CardType}}" data-value="{{$element.CardType}}">{{$.locale.Tr $element.Translation}}</div>
+							{{end}}
+						</div>
+					</div>
+				</div>
 			</div>
 			<div class="ui container">
 				<div class="ui divider"></div>

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -175,6 +175,13 @@
 
 					<!-- start issue card -->
 					<div class="card board-card" data-issue="{{.ID}}">
+						{{if eq $.Project.CardType 1}}{{/* Images and Text*/}}
+							<div class="card-attachment-images">
+								{{range (index $.issuesAttachmentMap .ID)}}
+									<img src="{{.DownloadURL}}" alt="{{.Name}}" />
+								{{end}}
+							</div>
+						{{end}}
 						<div class="content gt-p-0">
 							<div class="header">
 								<span class="gt-dif gt-ac gt-vm {{if .IsClosed}}red{{else}}green{{end}}">


### PR DESCRIPTION
Part of #23318

The way to fix the missing cardtype for user/org level projects in this PR is to port the cardtype related part from #22112 to org/user level projects' template and router functions.

Before:
<img width="1135" alt="截屏2023-04-11 13 55 49" src="https://user-images.githubusercontent.com/17645053/231069068-ba897129-ae90-4aa0-9b0f-468bf5c65375.png">

<img width="1131" alt="截屏2023-04-11 13 55 59" src="https://user-images.githubusercontent.com/17645053/231069084-279f6681-5a10-42da-b5a8-2b0ba47c7078.png">


After:
Create
<img width="835" alt="截屏2023-04-11 13 27 16" src="https://user-images.githubusercontent.com/17645053/231064445-0d6e12bd-5725-48db-a102-80e7472757c2.png">

Edit
<img width="852" alt="截屏2023-04-11 13 27 05" src="https://user-images.githubusercontent.com/17645053/231064503-c70525cd-1038-43ec-8d93-8b8d95d183d4.png">

View
<img width="1329" alt="截屏2023-04-11 13 26 56" src="https://user-images.githubusercontent.com/17645053/231064529-26023c85-698b-4b2e-af02-45f9820c77ec.png">

