### PR TITLE
Fix accidental overwriting of LDAP team memberships

### DIFF
--- a/services/auth/source/source_group_sync.go
+++ b/services/auth/source/source_group_sync.go
@@ -52,11 +52,11 @@ func resolveMappedMemberships(sourceUserGroups container.Set[string], sourceGrou
 		isUserInGroup := sourceUserGroups.Contains(group)
 		if isUserInGroup {
 			for org, teams := range memberships {
-				membershipsToAdd[org] = teams
+				membershipsToAdd[org] = append(membershipsToAdd[org], teams...)
 			}
 		} else {
 			for org, teams := range memberships {
-				membershipsToRemove[org] = teams
+				membershipsToRemove[org] = append(membershipsToRemove[org], teams...)
 			}
 		}
 	}


### PR DESCRIPTION
In the `for` loop, the value of `membershipsToAdd[org]` and `membershipsToRemove[org]` is a slice that should be appended instead of overwritten.
Due to the current overwrite, the LDAP group sync only matches the last group at the moment.

## Example reproduction
- an LDAP user is both a member of `cn=admin_staff,ou=people,dc=planetexpress,dc=com` and `cn=ship_crew,ou=people,dc=planetexpress,dc=com`.
- configuration of `Map LDAP groups to Organization teams ` in `Authentication Sources`:
```json
{
    "cn=admin_staff,ou=people,dc=planetexpress,dc=com":{
        "test_organization":[
            "admin_staff",
            "test_add"
        ]
    },
    "cn=ship_crew,ou=people,dc=planetexpress,dc=com":{
        "test_organization":[
            "ship_crew"
        ]
}
```
- start `Synchronize external user data` task in the `Dashboard`.
- the user was only added for the team `test_organization.ship_crew`