### PR TITLE
Fix custom mailer template on Windows

### DIFF
--- a/modules/templates/mailer.go
+++ b/modules/templates/mailer.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	texttmpl "text/template"
 
@@ -65,6 +66,7 @@ func Mailer(ctx context.Context) (*texttmpl.Template, *template.Template) {
 			}
 
 			assetName := strings.TrimSuffix(name, ".tmpl")
+			assetName = filepath.ToSlash(assetName)
 			log.Trace("Adding mailer template for %s from %q", assetName, path)
 			buildSubjectBodyTemplate(subjectTemplates,
 				bodyTemplates,

--- a/modules/templates/mailer.go
+++ b/modules/templates/mailer.go
@@ -8,12 +8,12 @@ import (
 	"html/template"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	texttmpl "text/template"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/watcher"
 )
 
@@ -66,7 +66,7 @@ func Mailer(ctx context.Context) (*texttmpl.Template, *template.Template) {
 			}
 
 			assetName := strings.TrimSuffix(name, ".tmpl")
-			assetName = filepath.ToSlash(assetName)
+			assetName = util.PathJoinRelX(assetName)
 			log.Trace("Adding mailer template for %s from %q", assetName, path)
 			buildSubjectBodyTemplate(subjectTemplates,
 				bodyTemplates,


### PR DESCRIPTION
Fix #24075
Fix #23873

From the log:

```
2023/04/02 19:41:46 .../templates/mailer.go:68:1() [T] Adding mailer template for \issue\default from "C:\gitea\custom\templates\mail\issue\default.tmpl"
```

That `assetName ` on Windows is wrong. Gitea only uses slash `/`.

1.20 doesn't have such bug, because the asset system has been refactored.