### PR TITLE
Fix 2-dot direct compare to use the right base commit

### DIFF
--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -551,7 +551,11 @@ func ParseCompareInfo(ctx *context.Context) *CompareInfo {
 		ctx.ServerError("GetCompareInfo", err)
 		return nil
 	}
-	ctx.Data["BeforeCommitID"] = ci.CompareInfo.MergeBase
+	if ci.DirectComparison {
+		ctx.Data["BeforeCommitID"] = ci.CompareInfo.BaseCommitID
+	} else {
+		ctx.Data["BeforeCommitID"] = ci.CompareInfo.MergeBase
+	}
 
 	return ci
 }


### PR DESCRIPTION
For 2-dot direct compare, we should use the base commit in the title and templates, as is used elsewhere, not the common ancestor which is used for 3-dot compare.  I believe that this change should have been included in #22949.