### PR TITLE
Use 1.18's aria role for dropdown menus

### DIFF
--- a/web_src/js/modules/aria/dropdown.js
+++ b/web_src/js/modules/aria/dropdown.js
@@ -148,8 +148,8 @@ function attachInit($dropdown) {
   // Since #19861 we have prepared the "combobox" solution, but didn't get enough time to put it into practice and test before.
   const isComboBox = $dropdown.find('input').length > 0;
 
-  dropdown[ariaPatchKey].focusableRole = isComboBox ? 'combobox' : 'button';
-  dropdown[ariaPatchKey].listPopupRole = isComboBox ? 'listbox' : 'menu';
+  dropdown[ariaPatchKey].focusableRole = isComboBox ? 'combobox' : 'menu';
+  dropdown[ariaPatchKey].listPopupRole = isComboBox ? 'listbox' : '';
   dropdown[ariaPatchKey].listItemRole = isComboBox ? 'option' : 'menuitem';
 
   attachDomEvents($dropdown, $focusable, $menu);


### PR DESCRIPTION
According to erion's feedback, the 1.18 approach works with Safari (`role=menu` on the parent container), while the 1.19's approach doesn't work well with Safari+VoiceOver (although I tested it worked with Chrome a little better).

I have tested this 1.18 approach could work for all Safari/Chrome+VoiceOver and Chrome+Talkback.

Let's try to make it on try.gitea.io to see whether it helps Safari users.