### PR TITLE
Fix wrong scopes of locale.PrettyNumber

### DIFF
--- a/templates/repo/projects/list.tmpl
+++ b/templates/repo/projects/list.tmpl
@@ -48,9 +48,9 @@
 						{{end}}
 						<span class="issue-stats">
 							{{svg "octicon-issue-opened" 16 "gt-mr-3"}}
-							{{.locale.PrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
+							{{$.locale.PrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
 							{{svg "octicon-check" 16 "gt-mr-3"}}
-							{{.locale.PrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
+							{{$.locale.PrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
 						</span>
 					</div>
 					{{if and $.CanWriteProjects (not $.Repository.IsArchived)}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -104,9 +104,9 @@
 								{{end}}
 								<span class="issue-stats">
 									{{svg "octicon-issue-opened" 16 "gt-mr-3"}}
-									{{.locale.PrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
+									{{$.locale.PrettyNumber .NumOpenIssues}}&nbsp;{{$.locale.Tr "repo.issues.open_title"}}
 									{{svg "octicon-check" 16 "gt-mr-3"}}
-									{{.locale.PrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
+									{{$.locale.PrettyNumber .NumClosedIssues}}&nbsp;{{$.locale.Tr "repo.issues.closed_title"}}
 									{{if .TotalTrackedTime}}
 										{{svg "octicon-clock"}} {{.TotalTrackedTime|Sec2Time}}
 									{{end}}


### PR DESCRIPTION
Fix the scopes for `locale.PrettyNumber` on repo project list and user dashboard milestone list. Regression from #24134

<img width="986" alt="截屏2023-04-18 15 50 33" src="https://user-images.githubusercontent.com/17645053/232709386-aff1f793-0ff9-44fb-83de-e8216eb519d8.png">

<img width="970" alt="截屏2023-04-18 15 46 14" src="https://user-images.githubusercontent.com/17645053/232709369-cd1fdaf9-d84c-4de6-a6e3-6edb7e10a023.png">

