### PR TITLE
Ensure "ref" parameter is not ignored in function RepoRefForAPI

### DIFF
--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -342,6 +342,7 @@ func RepoRefForAPI(next http.Handler) http.Handler {
 				return
 			}
 			ctx.Repo.Commit = commit
+			ctx.Repo.CommitID = ctx.Repo.Commit.ID.String()
 			ctx.Repo.TreePath = ctx.Params("*")
 			return
 		}

--- a/modules/context/api.go
+++ b/modules/context/api.go
@@ -322,10 +322,8 @@ func ReferencesGitRepo(allowEmpty ...bool) func(ctx *APIContext) (cancel context
 }
 
 // RepoRefForAPI handles repository reference names when the ref name is not explicitly given
-func RepoRefForAPI(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ctx := GetAPIContext(req)
-
+func RepoRefForAPI(ctx *APIContext) {
+	{
 		if ctx.Repo.GitRepo == nil {
 			ctx.InternalServerError(fmt.Errorf("no open git repo"))
 			return
@@ -375,7 +373,5 @@ func RepoRefForAPI(next http.Handler) http.Handler {
 			ctx.NotFound(fmt.Errorf("not exist: '%s'", ctx.Params("*")))
 			return
 		}
-
-		next.ServeHTTP(w, req)
-	})
+	}
 }


### PR DESCRIPTION
## before
- work
  - `http://localhost:3000/api/v1/repos/test/aaa/raw/.woodpecker.yml`
  - `http://localhost:3000/api/v1/repos/test/aaa/raw/500c8e1f4c3d33c1d6990c5498db0f0a02136cc5/.woodpecker.yml`
- broken
  - `http://localhost:3000/api/v1/repos/test/aaa/raw/.woodpecker.yml?ref=500c8e1f4c3d33c1d6990c5498db0f0a02136cc5`
## after all work