### PR TITLE
Restore air delay of 1000ms

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,6 +4,7 @@ tmp_dir = ".air"
 [build]
 cmd = "make backend"
 bin = "gitea"
+delay = 1000
 include_ext = ["go", "tmpl"]
 include_file = ["main.go"]
 include_dir = ["cmd", "models", "modules", "options", "routers", "services"]


### PR DESCRIPTION
https://github.com/cosmtrek/air/pull/343 has changed air's default `delay` from 1000 to 0 and since then, while switching git branches, I notice air starting off multiple parallel build, essentially overloading my machine. Restore previous value of 1000.

````
building...
routers/web/org/setting_secrets.go has changed
routers/web/org/teams.go has changed
building...
routers/web/org/teams.go has changed
routers/web/repo/setting_secrets.go has changed
building...
routers/web/org/setting_secrets.go has changed
routers/web/repo/setting_secrets.go has changed
building...
routers/web/shared/secrets/secrets.go has changed
routers/web/repo/view.go has changed
building...
routers/web/repo/view.go has changed
routers/web/user/setting/secrets.go has changed
building...
routers/web/shared/secrets/secrets.go has changed
routers/web/user/setting/secrets.go has changed
building...
routers/web/web.go has changed
routers/web/web.go has changed
building...
services/wiki/wiki_path.go has changed
services/wiki/wiki_path.go has changed
building...
...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
Running go generate...
```