### PR TITLE
Improve External Wiki in Repo Header

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -222,7 +222,7 @@
 				{{end}}
 
 				{{if .Permission.CanRead $.UnitTypeExternalWiki}}
-					<a class="{{if .PageIsWiki}}active {{end}}item" href="{{(.Repository.MustGetUnit $.Context $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}" target="_blank" rel="noopener noreferrer">
+					<a class="item" href="{{(.Repository.MustGetUnit $.Context $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}" target="_blank" rel="noopener noreferrer">
 						{{svg "octicon-link-external"}} {{.locale.Tr "repo.wiki"}}
 					</a>
 				{{end}}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -215,9 +215,15 @@
 				</a>
 				{{end}}
 
-				{{if or (.Permission.CanRead $.UnitTypeWiki) (.Permission.CanRead $.UnitTypeExternalWiki)}}
-					<a class="{{if .PageIsWiki}}active {{end}}item" href="{{.RepoLink}}/wiki" {{if and (.Permission.CanRead $.UnitTypeExternalWiki) (not (StringUtils.HasPrefix ((.Repository.MustGetUnit $.Context $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL) (.Repository.Link)))}} target="_blank" rel="noopener noreferrer" {{end}}>
+				{{if .Permission.CanRead $.UnitTypeWiki}}
+					<a class="{{if .PageIsWiki}}active {{end}}item" href="{{.RepoLink}}/wiki">
 						{{svg "octicon-book"}} {{.locale.Tr "repo.wiki"}}
+					</a>
+				{{end}}
+
+				{{if .Permission.CanRead $.UnitTypeExternalWiki}}
+					<a class="{{if .PageIsWiki}}active {{end}}item" href="{{(.Repository.MustGetUnit $.Context $.UnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}" target="_blank" rel="noopener noreferrer">
+						{{svg "octicon-link-external"}} {{.locale.Tr "repo.wiki"}}
 					</a>
 				{{end}}
 


### PR DESCRIPTION
If you use a External Wiki, with Gitea, it brings currently 2 Problems in the Header:

1. It always uses the Wiki Icon. When you use e.g. a External Issue Tracker, it shows the External Link icon to Indicate, that the User will send to a External Side. This helps preventing fishing.
2. If you use a External Wiki, the Link in the Header still goes to `{repo}/wiki` which will redirect the user to the External Wiki. That means, that if the users hovers with the Cursor over the link, it shows  `{repo}/wiki`, so the User does not know, where he will land.

This PR fixes both.

![grafik](https://user-images.githubusercontent.com/15185051/233964455-dbca9bbe-a224-44c5-b351-5649fd9b15fc.png)

