### PR TITLE
Add label next to size number in repo submenu

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1084,6 +1084,7 @@ filter_branch_and_tag = Filter branch or tag
 find_tag = Find tag
 branches = Branches
 tags = Tags
+space_used = used
 issues = Issues
 pulls = Pull Requests
 project_board = Projects

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -15,7 +15,7 @@
 					</div>
 				{{end}}
 				<div class="item">
-					<span>{{svg "octicon-database"}}<b>{{FileSize .Repository.Size}}</b> {{$.locale.Tr "repo.space_used"}}</span>
+					<span>{{svg "octicon-database"}}<b> {{FileSize .Repository.Size}}</b> {{$.locale.Tr "repo.space_used"}}</span>
 				</div>
 			{{end}}
 		</div>

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -15,7 +15,7 @@
 					</div>
 				{{end}}
 				<div class="item">
-					<span>{{svg "octicon-database"}}<b> {{FileSize .Repository.Size}}</b> {{$.locale.Tr "repo.space_used"}}</span>
+					<span>{{svg "octicon-database"}} <b>{{FileSize .Repository.Size}}</b> {{$.locale.Tr "repo.space_used"}}</span>
 				</div>
 			{{end}}
 		</div>

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -15,7 +15,7 @@
 					</div>
 				{{end}}
 				<div class="item">
-					<span>{{svg "octicon-database"}} <b>{{FileSize .Repository.Size}}</b></span>
+					<span>{{svg "octicon-database"}}<b>{{FileSize .Repository.Size}}</b> {{$.locale.Tr "repo.space_used"}}</span>
 				</div>
 			{{end}}
 		</div>


### PR DESCRIPTION
Every other label in that submenu has a clear indicator as to what it
does.

Even if the size is described using the format "12 MiB", the meaning
of the label doesn't seem to immediately register with the user
because the developer that worked on this feature may have thought
that this would have been superfluous, as "MiB" is a unit used to
describe the size of digital files.

The word "used" (example: "212 MiB used") was chosen over "Size:"
(example: "Size: 212 MiB") so as to preserve consistency. I also
thought about using the adjective "large", but it seemed way too
implicit.