### PR TITLE
Support uploading file to empty repo by API

### DIFF
--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -458,6 +458,11 @@ func CreateOrUpdateRepoFile(ctx context.Context, repo *repo_model.Repository, do
 	if err != nil {
 		return nil, err
 	}
+
+	if repo.IsEmpty {
+		_ = repo_model.UpdateRepositoryCols(ctx, &repo_model.Repository{ID: repo.ID, IsEmpty: false}, "is_empty")
+	}
+
 	return file, nil
 }
 

--- a/tests/integration/empty_repo_test.go
+++ b/tests/integration/empty_repo_test.go
@@ -5,17 +5,21 @@ package integration
 
 import (
 	"bytes"
+	"encoding/base64"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"testing"
 
+	auth_model "code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/setting"
+	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/tests"
 
@@ -104,4 +108,33 @@ func TestEmptyRepoUploadFile(t *testing.T) {
 	req = NewRequest(t, "GET", redirect)
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), "uploaded-file.txt")
+}
+
+func TestEmptyRepoAddFileByAPI(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	err := user_model.UpdateUserCols(db.DefaultContext, &user_model.User{ID: 30, ProhibitLogin: false}, "prohibit_login")
+	assert.NoError(t, err)
+
+	session := loginUser(t, "user30")
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeRepo)
+
+	url := fmt.Sprintf("/api/v1/repos/user30/empty/contents/new-file.txt?token=%s", token)
+	req := NewRequestWithJSON(t, "POST", url, &api.CreateFileOptions{
+		FileOptions: api.FileOptions{
+			NewBranchName: "new_branch",
+			Message:       "init",
+		},
+		Content: base64.StdEncoding.EncodeToString([]byte("newly-added-api-file")),
+	})
+
+	resp := MakeRequest(t, req, http.StatusCreated)
+	var fileResponse api.FileResponse
+	DecodeJSON(t, resp, &fileResponse)
+	expectedHTMLURL := setting.AppURL + "user30/empty/src/branch/new_branch/new-file.txt"
+	assert.EqualValues(t, expectedHTMLURL, *fileResponse.Content.HTMLURL)
+
+	req = NewRequest(t, "GET", "/user30/empty/src/branch/new_branch/new-file.txt")
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), "newly-added-api-file")
 }


### PR DESCRIPTION
The uploading API already works (the only nit is the the IsEmpty flag is out-of-sync, this PR also fixes it)

Close #14633