### PR TITLE
Fix incorrect last online time in runner_edit.tmpl

### DIFF
--- a/templates/shared/actions/runner_edit.tmpl
+++ b/templates/shared/actions/runner_edit.tmpl
@@ -13,7 +13,7 @@
 				</div>
 				<div class="field gt-dib gt-mr-4 disabled">
 					<label>{{.locale.Tr "actions.runners.last_online"}}</label>
-					<span>{{TimeSinceUnix .Runner.LastOnline $.locale}}</span>
+					<span>{{if .LastOnline}}{{TimeSinceUnix .LastOnline $.locale}}{{else}}{{$.locale.Tr "never"}}{{end}}</span>
 				</div>
 				<div class="field gt-dib gt-mr-4 disabled">
 					<label>{{.locale.Tr "actions.runners.agent_labels"}}</label>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/18380374/234772748-7f4b416f-4056-4a5e-89f0-727d2fa14a41.png)

After:
![image](https://user-images.githubusercontent.com/18380374/234772682-8b076054-d0be-4f5f-892d-8d0427275493.png)
