### PR TITLE
Fix auth check bug

### DIFF
--- a/services/lfs/server.go
+++ b/services/lfs/server.go
@@ -86,11 +86,6 @@ func DownloadHandler(ctx *context.Context) {
 		return
 	}
 
-	repository := getAuthenticatedRepository(ctx, rc, true)
-	if repository == nil {
-		return
-	}
-
 	// Support resume download using Range header
 	var fromByte, toByte int64
 	toByte = meta.Size - 1
@@ -362,11 +357,6 @@ func VerifyHandler(ctx *context.Context) {
 
 	meta := getAuthenticatedMeta(ctx, rc, p, true)
 	if meta == nil {
-		return
-	}
-
-	repository := getAuthenticatedRepository(ctx, rc, true)
-	if repository == nil {
 		return
 	}
 

--- a/tests/integration/lfs_getobject_test.go
+++ b/tests/integration/lfs_getobject_test.go
@@ -119,7 +119,7 @@ func TestGetLFSSmallToken(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	content := []byte("A very small file\n")
 
-	resp := storeAndGetLfsToken(t, auth.AccessTokenScope(auth.AccessTokenScopePublicRepo), &content, nil, http.StatusOK)
+	resp := storeAndGetLfsToken(t, auth.AccessTokenScopePublicRepo, &content, nil, http.StatusOK)
 	checkResponseTestContentEncoding(t, &content, resp, false)
 }
 
@@ -127,7 +127,7 @@ func TestGetLFSSmallTokenFail(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	content := []byte("A very small file\n")
 
-	storeAndGetLfsToken(t, auth.AccessTokenScope(auth.AccessTokenScopeNotification), &content, nil, http.StatusForbidden)
+	storeAndGetLfsToken(t, auth.AccessTokenScopeNotification, &content, nil, http.StatusForbidden)
 }
 
 func TestGetLFSLarge(t *testing.T) {

--- a/tests/integration/lfs_getobject_test.go
+++ b/tests/integration/lfs_getobject_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -38,6 +39,30 @@ func storeObjectInRepo(t *testing.T, repositoryID int64, content *[]byte) string
 		assert.NoError(t, err)
 	}
 	return pointer.Oid
+}
+
+func storeAndGetLfsToken(t *testing.T, content *[]byte, extraHeader *http.Header, expectedStatus int) *httptest.ResponseRecorder {
+	repo, err := repo_model.GetRepositoryByOwnerAndName(db.DefaultContext, "user2", "repo1")
+	assert.NoError(t, err)
+	oid := storeObjectInRepo(t, repo.ID, content)
+	defer git_model.RemoveLFSMetaObjectByOid(db.DefaultContext, repo.ID, oid)
+
+	token := getUserToken(t, "user2", auth.AccessTokenScope(auth.AccessTokenScopePublicRepo))
+
+	// Request OID
+	req := NewRequest(t, "GET", "/user2/repo1.git/info/lfs/objects/"+oid+"/test?token="+token)
+	req.Header.Set("Accept-Encoding", "gzip")
+	if extraHeader != nil {
+		for key, values := range *extraHeader {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
+
+	resp := MakeRequest(t, req, expectedStatus)
+
+	return resp
 }
 
 func storeAndGetLfs(t *testing.T, content *[]byte, extraHeader *http.Header, expectedStatus int) *httptest.ResponseRecorder {
@@ -86,6 +111,14 @@ func TestGetLFSSmall(t *testing.T) {
 	content := []byte("A very small file\n")
 
 	resp := storeAndGetLfs(t, &content, nil, http.StatusOK)
+	checkResponseTestContentEncoding(t, &content, resp, false)
+}
+
+func TestGetLFSSmallToken(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	content := []byte("A very small file\n")
+
+	resp := storeAndGetLfsToken(t, &content, nil, http.StatusOK)
 	checkResponseTestContentEncoding(t, &content, resp, false)
 }
 


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/pull/24362/files#r1179095324

`getAuthenticatedMeta` has checked them, these code are duplicated one. And the first invokation has a wrong permission check. `DownloadHandle` should require read permission but not write.