### PR TITLE
Skip known flaky `queue` tests on CI environment

### DIFF
--- a/modules/queue/queue_channel_test.go
+++ b/modules/queue/queue_channel_test.go
@@ -4,6 +4,7 @@
 package queue
 
 import (
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -101,7 +102,9 @@ func TestChannelQueue_Batch(t *testing.T) {
 }
 
 func TestChannelQueue_Pause(t *testing.T) {
-	t.Skip("Skipping because test is flaky on CI")
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping because test is flaky on CI")
+	}
 	lock := sync.Mutex{}
 	var queue Queue
 	var err error

--- a/modules/queue/queue_channel_test.go
+++ b/modules/queue/queue_channel_test.go
@@ -101,6 +101,7 @@ func TestChannelQueue_Batch(t *testing.T) {
 }
 
 func TestChannelQueue_Pause(t *testing.T) {
+	t.Skip("Skipping because test is flaky on CI")
 	lock := sync.Mutex{}
 	var queue Queue
 	var err error

--- a/modules/queue/unique_queue_disk_channel_test.go
+++ b/modules/queue/unique_queue_disk_channel_test.go
@@ -4,6 +4,7 @@
 package queue
 
 import (
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -15,7 +16,9 @@ import (
 )
 
 func TestPersistableChannelUniqueQueue(t *testing.T) {
-	t.Skip("Skipping because test is flaky on CI")
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping because test is flaky on CI")
+	}
 
 	tmpDir := t.TempDir()
 	_ = log.NewLogger(1000, "console", "console", `{"level":"warn","stacktracelevel":"NONE","stderr":true}`)

--- a/modules/queue/unique_queue_disk_channel_test.go
+++ b/modules/queue/unique_queue_disk_channel_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestPersistableChannelUniqueQueue(t *testing.T) {
+	t.Skip("Skipping because test is flaky on CI")
+
 	tmpDir := t.TempDir()
 	_ = log.NewLogger(1000, "console", "console", `{"level":"warn","stacktracelevel":"NONE","stderr":true}`)
 


### PR DESCRIPTION
Random CI failures are annoying. It's better to just skip the affected tests so maintainers can use their valuable time for more productive topics.

Related: https://github.com/go-gitea/gitea/issues/23608
Related: https://github.com/go-gitea/gitea/issues/23977
Related: https://github.com/go-gitea/gitea/issues/18703