### PR TITLE
Rename the swagger /markdown/raw `operationId` from `renderMarkdownRaw` to `renderRawMarkdown`

### DIFF
--- a/routers/api/v1/misc/markup.go
+++ b/routers/api/v1/misc/markup.go
@@ -81,7 +81,7 @@ func Markdown(ctx *context.APIContext) {
 
 // MarkdownRaw render raw markdown HTML
 func MarkdownRaw(ctx *context.APIContext) {
-	// swagger:operation POST /markdown/raw miscellaneous renderMarkdownRaw
+	// swagger:operation POST /markdown/raw miscellaneous renderRawMarkdown
 	// ---
 	// summary: Render raw markdown as HTML
 	// parameters:

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1019,7 +1019,7 @@
           "miscellaneous"
         ],
         "summary": "Render raw markdown as HTML",
-        "operationId": "renderMarkdownRaw",
+        "operationId": "renderRawMarkdown",
         "parameters": [
           {
             "description": "Request body to render",


### PR DESCRIPTION
- Fixes #19025

To allow for code generation. See https://github.com/OpenAPITools/openapi-generator/issues/11827 for the reason a method ends with `Raw` breaks code generation.

## :warning: BREAKING :warning:

Previously generated API clients that used `renderMarkdownRaw` will break unless they regenerate and use `renderRawMarkdown`