### PR TITLE
Fix incorrect CurrentUser check for docker rootless

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -282,6 +282,9 @@ func loadCommonSettingsFrom(cfg ConfigProvider) {
 	loadLogFrom(cfg)
 	loadServerFrom(cfg)
 	loadSSHFrom(cfg)
+
+	mustCurrentRunUserMatch(cfg) // it depends on the SSH config, only non-builtin SSH server requires this check
+
 	loadOAuth2From(cfg)
 	loadSecurityFrom(cfg)
 	loadAttachmentFrom(cfg)
@@ -314,14 +317,6 @@ func loadRunModeFrom(rootCfg ConfigProvider) {
 		RunMode = rootSec.Key("RUN_MODE").MustString("prod")
 	}
 	IsProd = strings.EqualFold(RunMode, "prod")
-	// Does not check run user when the install lock is off.
-	installLock := rootCfg.Section("security").Key("INSTALL_LOCK").MustBool(false)
-	if installLock {
-		currentUser, match := IsRunUserMatchCurrentUser(RunUser)
-		if !match {
-			log.Fatal("Expect user '%s' but current user is: %s", RunUser, currentUser)
-		}
-	}
 
 	// check if we run as root
 	if os.Getuid() == 0 {
@@ -330,6 +325,17 @@ func loadRunModeFrom(rootCfg ConfigProvider) {
 			log.Fatal("Gitea is not supposed to be run as root. Sorry. If you need to use privileged TCP ports please instead use setcap and the `cap_net_bind_service` permission")
 		}
 		log.Critical("You are running Gitea using the root user, and have purposely chosen to skip built-in protections around this. You have been warned against this.")
+	}
+}
+
+func mustCurrentRunUserMatch(rootCfg ConfigProvider) {
+	// Does not check run user when the "InstallLock" is off.
+	installLock := rootCfg.Section("security").Key("INSTALL_LOCK").MustBool(false)
+	if installLock {
+		currentUser, match := IsRunUserMatchCurrentUser(RunUser)
+		if !match {
+			log.Fatal("Expect user '%s' but current user is: %s", RunUser, currentUser)
+		}
 	}
 }
 


### PR DESCRIPTION
Many users report that 1.19 has a regression bug: the rootless image can't start if the UID is not 1000.

https://github.com/go-gitea/gitea/issues/23632#issuecomment-1524589213

https://discourse.gitea.io/t/gitea-doesnt-start-after-update-to-1-19/6920/9


The problem is that the IsRunUserMatchCurrentUser logic is fragile, the "SSH" config is not ready when it executes.

This PR is just a quick fix for 1.19. For 1.20, we need a clear and stable solution.

