### PR TITLE
Use globally shared HTMLRender

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -677,7 +677,7 @@ func getCsrfOpts() CsrfOptions {
 
 // Contexter initializes a classic context for a request.
 func Contexter(ctx context.Context) func(next http.Handler) http.Handler {
-	_, rnd := templates.HTMLRenderer(ctx)
+	rnd := templates.HTMLRenderer()
 	csrfOpts := getCsrfOpts()
 	if !setting.IsProd {
 		CsrfTokenRegenerationInterval = 5 * time.Second // in dev, re-generate the tokens more aggressively for debug purpose

--- a/modules/context/package.go
+++ b/modules/context/package.go
@@ -131,7 +131,7 @@ func determineAccessMode(ctx *Context) (perm.AccessMode, error) {
 
 // PackageContexter initializes a package context for a request.
 func PackageContexter(ctx gocontext.Context) func(next http.Handler) http.Handler {
-	_, rnd := templates.HTMLRenderer(ctx)
+	rnd := templates.HTMLRenderer()
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			ctx := Context{

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -10,7 +10,6 @@ import (
 	"html"
 	"html/template"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -26,12 +25,9 @@ import (
 	"code.gitea.io/gitea/services/gitdiff"
 )
 
-// Used from static.go && dynamic.go
-var mailSubjectSplit = regexp.MustCompile(`(?m)^-{3,}[\s]*$`)
-
 // NewFuncMap returns functions for injecting to templates
-func NewFuncMap() []template.FuncMap {
-	return []template.FuncMap{map[string]interface{}{
+func NewFuncMap() template.FuncMap {
+	return map[string]interface{}{
 		"DumpVar": dumpVar,
 
 		// -----------------------------------------------------------------
@@ -192,7 +188,7 @@ func NewFuncMap() []template.FuncMap {
 
 		"FilenameIsImage": FilenameIsImage,
 		"TabSizeClass":    TabSizeClass,
-	}}
+	}
 }
 
 // Safe render raw as HTML

--- a/modules/templates/htmlrenderer.go
+++ b/modules/templates/htmlrenderer.go
@@ -32,8 +32,10 @@ type HTMLRender struct {
 	templates atomic.Pointer[scopedtmpl.ScopedTemplate]
 }
 
-var htmlRender *HTMLRender
-var htmlRenderOnce sync.Once
+var (
+	htmlRender     *HTMLRender
+	htmlRenderOnce sync.Once
+)
 
 var ErrTemplateNotInitialized = errors.New("template system is not initialized, check your log for errors")
 

--- a/modules/templates/htmlrenderer.go
+++ b/modules/templates/htmlrenderer.go
@@ -6,7 +6,6 @@ package templates
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -15,23 +14,26 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	texttemplate "text/template"
 
 	"code.gitea.io/gitea/modules/assetfs"
+	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates/scopedtmpl"
 	"code.gitea.io/gitea/modules/util"
 )
 
-var rendererKey interface{} = "templatesHtmlRenderer"
-
 type TemplateExecutor scopedtmpl.TemplateExecutor
 
 type HTMLRender struct {
 	templates atomic.Pointer[scopedtmpl.ScopedTemplate]
 }
+
+var htmlRender *HTMLRender
+var htmlRenderOnce sync.Once
 
 var ErrTemplateNotInitialized = errors.New("template system is not initialized, check your log for errors")
 
@@ -55,14 +57,14 @@ func (h *HTMLRender) TemplateLookup(name string) (TemplateExecutor, error) {
 		return nil, ErrTemplateNotInitialized
 	}
 
-	return tmpls.Executor(name, NewFuncMap()[0])
+	return tmpls.Executor(name, NewFuncMap())
 }
 
 func (h *HTMLRender) CompileTemplates() error {
 	assets := AssetFS()
 	extSuffix := ".tmpl"
 	tmpls := scopedtmpl.NewScopedTemplate()
-	tmpls.Funcs(NewFuncMap()[0])
+	tmpls.Funcs(NewFuncMap())
 	files, err := ListWebTemplateAssetNames(assets)
 	if err != nil {
 		return nil
@@ -86,20 +88,21 @@ func (h *HTMLRender) CompileTemplates() error {
 	return nil
 }
 
-// HTMLRenderer returns the current html renderer for the context or creates and stores one within the context for future use
-func HTMLRenderer(ctx context.Context) (context.Context, *HTMLRender) {
-	if renderer, ok := ctx.Value(rendererKey).(*HTMLRender); ok {
-		return ctx, renderer
-	}
+// HTMLRenderer returns the globally shared html renderer
+func HTMLRenderer() *HTMLRender {
+	htmlRenderOnce.Do(initHTMLRenderer)
+	return htmlRender
+}
 
+func initHTMLRenderer() {
 	rendererType := "static"
 	if !setting.IsProd {
 		rendererType = "auto-reloading"
 	}
-	log.Log(1, log.DEBUG, "Creating "+rendererType+" HTML Renderer")
+	log.Debug("Creating %s HTML Renderer", rendererType)
 
-	renderer := &HTMLRender{}
-	if err := renderer.CompileTemplates(); err != nil {
+	htmlRender = &HTMLRender{}
+	if err := htmlRender.CompileTemplates(); err != nil {
 		p := &templateErrorPrettier{assets: AssetFS()}
 		wrapFatal(p.handleFuncNotDefinedError(err))
 		wrapFatal(p.handleUnexpectedOperandError(err))
@@ -107,14 +110,14 @@ func HTMLRenderer(ctx context.Context) (context.Context, *HTMLRender) {
 		wrapFatal(p.handleGenericTemplateError(err))
 		log.Fatal("HTMLRenderer CompileTemplates error: %v", err)
 	}
+
 	if !setting.IsProd {
-		go AssetFS().WatchLocalChanges(ctx, func() {
-			if err := renderer.CompileTemplates(); err != nil {
+		go AssetFS().WatchLocalChanges(graceful.GetManager().ShutdownContext(), func() {
+			if err := htmlRender.CompileTemplates(); err != nil {
 				log.Error("Template error: %v\n%s", err, log.Stack(2))
 			}
 		})
 	}
-	return context.WithValue(ctx, rendererKey, renderer), renderer
 }
 
 func wrapFatal(msg string) {

--- a/modules/templates/htmlrenderer.go
+++ b/modules/templates/htmlrenderer.go
@@ -88,7 +88,7 @@ func (h *HTMLRender) CompileTemplates() error {
 	return nil
 }
 
-// HTMLRenderer returns the globally shared html renderer
+// HTMLRenderer init once and returns the globally shared html renderer
 func HTMLRenderer() *HTMLRender {
 	htmlRenderOnce.Do(initHTMLRenderer)
 	return htmlRender

--- a/modules/templates/mailer.go
+++ b/modules/templates/mailer.go
@@ -6,6 +6,7 @@ package templates
 import (
 	"context"
 	"html/template"
+	"regexp"
 	"strings"
 	texttmpl "text/template"
 
@@ -13,6 +14,8 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 )
+
+var mailSubjectSplit = regexp.MustCompile(`(?m)^-{3,}\s*$`)
 
 // mailSubjectTextFuncMap returns functions for injecting to text templates, it's only used for mail subject
 func mailSubjectTextFuncMap() texttmpl.FuncMap {
@@ -55,9 +58,7 @@ func Mailer(ctx context.Context) (*texttmpl.Template, *template.Template) {
 	bodyTemplates := template.New("")
 
 	subjectTemplates.Funcs(mailSubjectTextFuncMap())
-	for _, funcs := range NewFuncMap() {
-		bodyTemplates.Funcs(funcs)
-	}
+	bodyTemplates.Funcs(NewFuncMap())
 
 	assetFS := AssetFS()
 	refreshTemplates := func() {

--- a/routers/api/v1/misc/markup_test.go
+++ b/routers/api/v1/misc/markup_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 func createContext(req *http.Request) (*context.Context, *httptest.ResponseRecorder) {
-	_, rnd := templates.HTMLRenderer(req.Context())
+	rnd := templates.HTMLRenderer()
 	resp := httptest.NewRecorder()
 	c := &context.Context{
 		Req:    req,

--- a/routers/init.go
+++ b/routers/init.go
@@ -175,7 +175,7 @@ func GlobalInitInstalled(ctx context.Context) {
 
 // NormalRoutes represents non install routes
 func NormalRoutes(ctx context.Context) *web.Route {
-	ctx, _ = templates.HTMLRenderer(ctx)
+	_ = templates.HTMLRenderer()
 	r := web.NewRoute()
 	r.Use(common.ProtocolMiddlewares()...)
 

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -55,7 +55,7 @@ func getSupportedDbTypeNames() (dbTypeNames []map[string]string) {
 
 // Init prepare for rendering installation page
 func Init(ctx goctx.Context) func(next http.Handler) http.Handler {
-	_, rnd := templates.HTMLRenderer(ctx)
+	rnd := templates.HTMLRenderer()
 	dbTypeNames := getSupportedDbTypeNames()
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {

--- a/routers/install/routes.go
+++ b/routers/install/routes.go
@@ -66,7 +66,7 @@ func installRecovery(ctx goctx.Context) func(next http.Handler) http.Handler {
 					if !setting.IsProd {
 						store["ErrorMsg"] = combinedErr
 					}
-					_, rnd := templates.HTMLRenderer(ctx)
+					rnd := templates.HTMLRenderer()
 					err = rnd.HTML(w, http.StatusInternalServerError, "status/500", templates.BaseVars().Merge(store))
 					if err != nil {
 						log.Error("%v", err)

--- a/routers/web/base.go
+++ b/routers/web/base.go
@@ -120,7 +120,7 @@ func (d *dataStore) GetData() map[string]interface{} {
 // RecoveryWith500Page returns a middleware that recovers from any panics and writes a 500 and a log if so.
 // This error will be created with the gitea 500 page.
 func RecoveryWith500Page(ctx goctx.Context) func(next http.Handler) http.Handler {
-	_, rnd := templates.HTMLRenderer(ctx)
+	rnd := templates.HTMLRenderer()
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			defer func() {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -114,7 +114,8 @@ func Routes(ctx gocontext.Context) *web.Route {
 	routes.RouteMethods("/apple-touch-icon.png", "GET, HEAD", misc.StaticRedirect("/assets/img/apple-touch-icon.png"))
 	routes.RouteMethods("/favicon.ico", "GET, HEAD", misc.StaticRedirect("/assets/img/favicon.png"))
 
-	ctx, _ = templates.HTMLRenderer(ctx)
+	_ = templates.HTMLRenderer()
+
 	common := []any{
 		common.Sessioner(),
 		RecoveryWith500Page(ctx),


### PR DESCRIPTION
The old `HTMLRender` is not ideal.

1. It shouldn't be initialized multiple times, it consumes a lot of memory and is slow.
2. It shouldn't depend on short-lived requests, the `WatchLocalChanges` needs a long-running context.
3. It doesn't make sense to use FuncsMap slice.


HTMLRender was designed to only work for GItea's specialized 400+ templates, so it's good to make it a global shared instance.
