### PR TITLE
Fix push publish docs workflow

### DIFF
--- a/.github/workflows/push-publish_docs.yml
+++ b/.github/workflows/push-publish_docs.yml
@@ -4,8 +4,8 @@ on:
   push:
     paths:
       - "docs/**"
-  branch:
-    - main
+    branches:
+      - main
 
 jobs:
   compliance-docs:


### PR DESCRIPTION
I received too many GitHub Actions error emails.
It seems that there's a mistake in the workflow file.
![image](https://user-images.githubusercontent.com/18380374/235388181-9497a55b-b30e-41a2-8ad8-6a5f173e3914.png)

Document:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore