### PR TITLE
Proof of concept: Template context function

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -30,6 +30,10 @@ func NewFuncMap() template.FuncMap {
 	return map[string]interface{}{
 		"DumpVar": dumpVar,
 
+		// ctx func
+		"CtxLocale":   func(v ...any) any { panic("not implemented") },
+		"CtxDateTime": func(v ...any) any { panic("not implemented") },
+
 		// -----------------------------------------------------------------
 		// html/template related functions
 		"dict":        dict, // it's lowercase because this name has been widely used. Our other functions should have uppercase names.

--- a/templates/devtest/ctxfunc.tmpl
+++ b/templates/devtest/ctxfunc.tmpl
@@ -1,0 +1,2 @@
+Locale: {{CtxLocale "home"}}<br>
+DateTime: {{CtxDateTime "full" "2001-02-03"}}<br>


### PR DESCRIPTION
cc @yardenshoham for #24342

This is a proof of concept of the "template context function".

Now in templates we only need to do:

```
Locale: {{CtxLocale "home"}}<br>
DateTime: {{CtxDateTime "full" "2001-02-03"}}<br>
```


TODO:

1. Refactor the 500 page rendering
2. Design better name/struct for `CtxFunc`

![image](https://user-images.githubusercontent.com/2114189/235402816-3e6b5b11-b58f-46d2-b377-624adfdd9121.png)