### PR TITLE
Replace `N/A` with `-` everywhere

### DIFF
--- a/docs/content/doc/usage/linked-references.en-us.md
+++ b/docs/content/doc/usage/linked-references.en-us.md
@@ -178,28 +178,28 @@ In the examples, `User1/Repo1` refers to the repository where the reference is u
 
 | Reference in User1/Repo1    | Repo1 issues are external | RepoZ issues are external | Should render                                           |
 | --------------------------- | :-----------------------: | :-----------------------: | ------------------------------------------------------- |
-| `#1234`                     |            no             |            N/A            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `!1234`                     |            no             |            N/A            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `#1234`                     |            yes            |            N/A            | A link to _external issue_ 1234 for `User1/Repo1`       |
-| `!1234`                     |            yes            |            N/A            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `User1/Repo1#1234`          |            no             |            N/A            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `User1/Repo1!1234`          |            no             |            N/A            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `User1/Repo1#1234`          |            yes            |            N/A            | A link to _external issue_ 1234 for `User1/Repo1`       |
-| `User1/Repo1!1234`          |            yes            |            N/A            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `UserZ/RepoZ#1234`          |            N/A            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
-| `UserZ/RepoZ!1234`          |            N/A            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
-| `UserZ/RepoZ#1234`          |            N/A            |            yes            | A link to _external issue_ 1234 for `UserZ/RepoZ`       |
-| `UserZ/RepoZ!1234`          |            N/A            |            yes            | A link to _PR_ 1234 for `UserZ/RepoZ`                   |
+| `#1234`                     |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
+| `!1234`                     |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
+| `#1234`                     |            yes            |            -            | A link to _external issue_ 1234 for `User1/Repo1`       |
+| `!1234`                     |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `User1/Repo1#1234`          |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
+| `User1/Repo1!1234`          |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
+| `User1/Repo1#1234`          |            yes            |            -            | A link to _external issue_ 1234 for `User1/Repo1`       |
+| `User1/Repo1!1234`          |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `UserZ/RepoZ#1234`          |            -            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
+| `UserZ/RepoZ!1234`          |            -            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
+| `UserZ/RepoZ#1234`          |            -            |            yes            | A link to _external issue_ 1234 for `UserZ/RepoZ`       |
+| `UserZ/RepoZ!1234`          |            -            |            yes            | A link to _PR_ 1234 for `UserZ/RepoZ`                   |
 | **Alphanumeric issue IDs:** |             -             |             -             | -                                                       |
-| `AAA-1234`                  |            yes            |            N/A            | A link to _external issue_ `AAA-1234` for `User1/Repo1` |
-| `!1234`                     |            yes            |            N/A            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `User1/Repo1!1234`          |            yes            |            N/A            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| _Not supported_             |            N/A            |            yes            | A link to _external issue_ `AAA-1234` for `UserZ/RepoZ` |
-| `UserZ/RepoZ!1234`          |            N/A            |            yes            | A link to _PR_ 1234 in `UserZ/RepoZ`                    |
+| `AAA-1234`                  |            yes            |            -            | A link to _external issue_ `AAA-1234` for `User1/Repo1` |
+| `!1234`                     |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `User1/Repo1!1234`          |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
+| _Not supported_             |            -            |            yes            | A link to _external issue_ `AAA-1234` for `UserZ/RepoZ` |
+| `UserZ/RepoZ!1234`          |            -            |            yes            | A link to _PR_ 1234 in `UserZ/RepoZ`                    |
 
 _The last section is for repositories with external issue trackers that use alphanumeric format._
 
-_**N/A**: not applicable._
+_**-**: not applicable._
 
 Note: automatic references between repositories with different types of issues (external vs. internal) are not fully supported
 and may render invalid links.

--- a/docs/content/doc/usage/linked-references.en-us.md
+++ b/docs/content/doc/usage/linked-references.en-us.md
@@ -178,24 +178,24 @@ In the examples, `User1/Repo1` refers to the repository where the reference is u
 
 | Reference in User1/Repo1    | Repo1 issues are external | RepoZ issues are external | Should render                                           |
 | --------------------------- | :-----------------------: | :-----------------------: | ------------------------------------------------------- |
-| `#1234`                     |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `!1234`                     |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `#1234`                     |            yes            |            -            | A link to _external issue_ 1234 for `User1/Repo1`       |
-| `!1234`                     |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `User1/Repo1#1234`          |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `User1/Repo1!1234`          |            no             |            -            | A link to issue/pull 1234 in `User1/Repo1`              |
-| `User1/Repo1#1234`          |            yes            |            -            | A link to _external issue_ 1234 for `User1/Repo1`       |
-| `User1/Repo1!1234`          |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `UserZ/RepoZ#1234`          |            -            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
-| `UserZ/RepoZ!1234`          |            -            |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
-| `UserZ/RepoZ#1234`          |            -            |            yes            | A link to _external issue_ 1234 for `UserZ/RepoZ`       |
-| `UserZ/RepoZ!1234`          |            -            |            yes            | A link to _PR_ 1234 for `UserZ/RepoZ`                   |
+| `#1234`                     |            no             |            -              | A link to issue/pull 1234 in `User1/Repo1`              |
+| `!1234`                     |            no             |            -              | A link to issue/pull 1234 in `User1/Repo1`              |
+| `#1234`                     |            yes            |            -              | A link to _external issue_ 1234 for `User1/Repo1`       |
+| `!1234`                     |            yes            |            -              | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `User1/Repo1#1234`          |            no             |            -              | A link to issue/pull 1234 in `User1/Repo1`              |
+| `User1/Repo1!1234`          |            no             |            -              | A link to issue/pull 1234 in `User1/Repo1`              |
+| `User1/Repo1#1234`          |            yes            |            -              | A link to _external issue_ 1234 for `User1/Repo1`       |
+| `User1/Repo1!1234`          |            yes            |            -              | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `UserZ/RepoZ#1234`          |            -              |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
+| `UserZ/RepoZ!1234`          |            -              |            no             | A link to issue/pull 1234 in `UserZ/RepoZ`              |
+| `UserZ/RepoZ#1234`          |            -              |            yes            | A link to _external issue_ 1234 for `UserZ/RepoZ`       |
+| `UserZ/RepoZ!1234`          |            -              |            yes            | A link to _PR_ 1234 for `UserZ/RepoZ`                   |
 | **Alphanumeric issue IDs:** |             -             |             -             | -                                                       |
-| `AAA-1234`                  |            yes            |            -            | A link to _external issue_ `AAA-1234` for `User1/Repo1` |
-| `!1234`                     |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| `User1/Repo1!1234`          |            yes            |            -            | A link to _PR_ 1234 for `User1/Repo1`                   |
-| _Not supported_             |            -            |            yes            | A link to _external issue_ `AAA-1234` for `UserZ/RepoZ` |
-| `UserZ/RepoZ!1234`          |            -            |            yes            | A link to _PR_ 1234 in `UserZ/RepoZ`                    |
+| `AAA-1234`                  |            yes            |            -              | A link to _external issue_ `AAA-1234` for `User1/Repo1` |
+| `!1234`                     |            yes            |            -              | A link to _PR_ 1234 for `User1/Repo1`                   |
+| `User1/Repo1!1234`          |            yes            |            -              | A link to _PR_ 1234 for `User1/Repo1`                   |
+| _Not supported_             |            -              |            yes            | A link to _external issue_ `AAA-1234` for `UserZ/RepoZ` |
+| `UserZ/RepoZ!1234`          |            -              |            yes            | A link to _PR_ 1234 in `UserZ/RepoZ`                    |
 
 _The last section is for repositories with external issue trackers that use alphanumeric format._
 

--- a/modules/timeutil/datetime.go
+++ b/modules/timeutil/datetime.go
@@ -30,13 +30,13 @@ func DateTime(format string, datetime any) template.HTML {
 	var datetimeEscaped, textEscaped string
 	switch v := datetime.(type) {
 	case nil:
-		return "N/A"
+		return "-"
 	case string:
 		datetimeEscaped = html.EscapeString(v)
 		textEscaped = datetimeEscaped
 	case time.Time:
 		if v.IsZero() || v.Unix() == 0 {
-			return "N/A"
+			return "-"
 		}
 		datetimeEscaped = html.EscapeString(v.Format(time.RFC3339))
 		if format == "full" {

--- a/modules/timeutil/datetime_test.go
+++ b/modules/timeutil/datetime_test.go
@@ -23,10 +23,10 @@ func TestDateTime(t *testing.T) {
 	refTime, _ := time.Parse(time.RFC3339, refTimeStr)
 	refTimeStamp := TimeStamp(refTime.Unix())
 
-	assert.EqualValues(t, "N/A", DateTime("short", nil))
-	assert.EqualValues(t, "N/A", DateTime("short", 0))
-	assert.EqualValues(t, "N/A", DateTime("short", time.Time{}))
-	assert.EqualValues(t, "N/A", DateTime("short", TimeStamp(0)))
+	assert.EqualValues(t, "-", DateTime("short", nil))
+	assert.EqualValues(t, "-", DateTime("short", 0))
+	assert.EqualValues(t, "-", DateTime("short", time.Time{}))
+	assert.EqualValues(t, "-", DateTime("short", TimeStamp(0)))
 
 	actual := DateTime("short", "invalid")
 	assert.EqualValues(t, `<relative-time format="datetime" year="numeric" month="short" day="numeric" weekday="" datetime="invalid">invalid</relative-time>`, actual)

--- a/templates/admin/cron.tmpl
+++ b/templates/admin/cron.tmpl
@@ -22,7 +22,7 @@
 						<td>{{$.locale.Tr (printf "admin.dashboard.%s" .Name)}}</td>
 						<td>{{.Spec}}</td>
 						<td>{{DateTime "full" .Next}}</td>
-						<td>{{if gt .Prev.Year 1}}{{DateTime "full" .Prev}}{{else}}N/A{{end}}</td>
+						<td>{{if gt .Prev.Year 1}}{{DateTime "full" .Prev}}{{else}}-{{end}}</td>
 						<td>{{.ExecTimes}}</td>
 						<td {{if ne .Status ""}}data-tooltip-content="{{.FormatLastMessage $.locale}}"{{end}} >{{if eq .Status ""}}—{{else if eq .Status "finished"}}{{svg "octicon-check" 16}}{{else}}{{svg "octicon-x" 16}}{{end}}</td>
 					</tr>

--- a/templates/repo/pulls/tab_menu.tmpl
+++ b/templates/repo/pulls/tab_menu.tmpl
@@ -7,11 +7,11 @@
 	<a class="item {{if .PageIsPullCommits}}active{{end}}" {{if .NumCommits}}href="{{.Issue.Link}}/commits"{{end}}>
 		{{svg "octicon-git-commit"}}
 		{{$.locale.Tr "repo.pulls.tab_commits"}}
-		<span class="ui small label">{{if .NumCommits}}{{.NumCommits}}{{else}}N/A{{end}}</span>
+		<span class="ui small label">{{if .NumCommits}}{{.NumCommits}}{{else}}-{{end}}</span>
 	</a>
 	<a class="item {{if .PageIsPullFiles}}active{{end}}" {{if .NumFiles}}href="{{.Issue.Link}}/files"{{end}}>
 		{{svg "octicon-diff"}}
 		{{$.locale.Tr "repo.pulls.tab_files"}}
-		<span class="ui small label">{{if .NumFiles}}{{.NumFiles}}{{else}}N/A{{end}}</span>
+		<span class="ui small label">{{if .NumFiles}}{{.NumFiles}}{{else}}-{{end}}</span>
 	</a>
 </div>

--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -174,7 +174,7 @@
 									</td>
 								</tr>
 							{{else}}
-								<tr><td>N/A</td></tr>
+								<tr><td>-</td></tr>
 							{{end}}
 							</tbody>
 						</table>

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -37,7 +37,7 @@
 										<span class="ui red label">{{.ResponseInfo.Status}}</span>
 									{{end}}
 								{{else}}
-									<span class="ui label">N/A</span>
+									<span class="ui label">-</span>
 								{{end}}
 							</a>
 							{{if or $.Permission.IsAdmin $.IsOrganizationOwner $.PageIsAdmin $.PageIsUserSettings}}
@@ -59,7 +59,7 @@
 								<h5>{{$.locale.Tr "repo.settings.webhook.payload"}}</h5>
 								<pre class="webhook-info"><code class="json">{{.PayloadContent}}</code></pre>
 							{{else}}
-								N/A
+								-
 							{{end}}
 						</div>
 						<div class="ui bottom attached tab segment" data-tab="response-{{.ID}}">
@@ -70,7 +70,7 @@
 								<h5>{{$.locale.Tr "repo.settings.webhook.body"}}</h5>
 								<pre class="webhook-info"><code>{{.ResponseInfo.Body}}</code></pre>
 							{{else}}
-								N/A
+								-
 							{{end}}
 						</div>
 					</div>

--- a/web_src/js/features/repo-settings.js
+++ b/web_src/js/features/repo-settings.js
@@ -32,7 +32,7 @@ export function initRepoSettingsCollaboration() {
           if ($item) {
             $dropdown.dropdown('set selected', $dropdown.attr('data-last-value'));
           } else {
-            $text.text('(N/A)'); // prevent from misleading users when the access mode is undefined
+            $text.text('(none)'); // prevent from misleading users when the access mode is undefined
           }
         }, 0);
       }


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/pull/24427.

Reasoning is that `N/A` is specific to english while `-` is language-neutral and does not need translation.

Before:
<img width="891" alt="Screenshot 2023-05-01 at 20 58 20" src="https://user-images.githubusercontent.com/115237/235511592-8a36d0f2-34ff-4dbe-b642-67c0ade644fe.png">

After:
<img width="901" alt="Screenshot 2023-05-01 at 20 59 59" src="https://user-images.githubusercontent.com/115237/235511594-d49f6d09-92e8-4e99-be7b-2a37f5d24129.png">
