### PR TITLE
Fix EasyMDE toolbar

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -311,7 +311,7 @@ class ComboMarkdownEditor {
           this.userPreferredEditor = 'textarea';
           this.switchToTextarea();
         },
-        icon: svg('octicon-file'),
+        icon: svg('octicon-arrow-switch'),
         title: 'Revert to simple textarea',
       },
       'gitea-code-inline': {

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -203,7 +203,7 @@ class ComboMarkdownEditor {
     });
   }
 
-  prepareEasyMDEToolbarActions(EasyMDE) {
+  prepareEasyMDEToolbarActions(EasyMDE, isWiki) {
     this.easyMDEToolbarDefault = [
       {
         name: 'heading',
@@ -236,6 +236,7 @@ class ComboMarkdownEditor {
         icon: svg('octicon-quote'),
         title: 'Quote',
       },
+      isWiki && 'gitea-code-inline',
       {
         name: 'code',
         action: EasyMDE.toggleCodeBlock,
@@ -283,9 +284,28 @@ class ComboMarkdownEditor {
         icon: svg('octicon-horizontal-rule'),
         title: 'Horizontal Rule',
       },
+      isWiki && '|',
+      isWiki && {
+        name: 'preview',
+        action: EasyMDE.togglePreview,
+        icon: svg('octicon-eye'),
+        title: 'Preview',
+      },
+      isWiki && {
+        name: 'fullscreen',
+        action: EasyMDE.toggleFullScreen,
+        icon: svg('octicon-screen-full'),
+        title: 'Fullscreen',
+      },
+      isWiki && {
+        name: 'side-by-side',
+        action: EasyMDE.toggleSideBySide,
+        icon: svg('octicon-columns'),
+        title: 'Side by Side',
+      },
       '|',
       'gitea-switch-to-textarea',
-    ];
+    ].filter(Boolean);
 
     this.easyMDEToolbarActions = {
       'gitea-checkbox-empty': {
@@ -357,7 +377,7 @@ class ComboMarkdownEditor {
     // EasyMDE's CSS should be loaded via webpack config, otherwise our own styles can not overwrite the default styles.
     const {default: EasyMDE} = await import(/* webpackChunkName: "easymde" */'easymde');
 
-    this.prepareEasyMDEToolbarActions(EasyMDE);
+    this.prepareEasyMDEToolbarActions(EasyMDE, this.options.easyMDEOptions.isWiki);
 
     const easyMDEOpt = {
       autoDownloadFontAwesome: false,

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -207,10 +207,10 @@ class ComboMarkdownEditor {
 
   prepareEasyMDEToolbarActions() {
     this.easyMDEToolbarDefault = [
-      'bold', 'italic', 'strikethrough', '|', 'heading-1', 'heading-2', 'heading-3', '|',
-      'code', 'quote', '|', 'gitea-checkbox-empty', 'gitea-checkbox-checked', '|',
-      'unordered-list', 'ordered-list', '|', 'link', 'image', 'table', 'horizontal-rule', '|',
-      'gitea-switch-to-textarea',
+      'bold', 'italic', 'strikethrough', '|', 'heading-1', 'heading-2', 'heading-3',
+      'heading-bigger', 'heading-smaller', '|', 'code', 'quote', '|', 'gitea-checkbox-empty',
+      'gitea-checkbox-checked', '|', 'unordered-list', 'ordered-list', '|', 'link', 'image',
+      'table', 'horizontal-rule', '|', 'gitea-switch-to-textarea',
     ];
   }
 

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -8,7 +8,6 @@ import {handleGlobalEnterQuickSubmit} from './QuickSubmit.js';
 import {emojiString} from '../emoji.js';
 import {renderPreviewPanelContent} from '../repo-editor.js';
 import {matchEmoji, matchMention} from '../../utils/match.js';
-import {svg} from '../../svg.js';
 import {easyMDEToolbarActions} from './EasyMDEToolbarActions.js';
 
 let elementIdCounter = 0;

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -42,7 +42,6 @@ class ComboMarkdownEditor {
   }
 
   async init() {
-    this.prepareEasyMDEToolbarActions();
     this.setupTab();
     this.setupDropzone();
     this.setupTextarea();
@@ -204,11 +203,87 @@ class ComboMarkdownEditor {
     });
   }
 
-  prepareEasyMDEToolbarActions() {
+  prepareEasyMDEToolbarActions(EasyMDE) {
     this.easyMDEToolbarDefault = [
-      'bold', 'italic', 'strikethrough', '|', 'heading-1', 'heading-2', 'heading-3', 'heading-bigger', 'heading-smaller', '|',
-      'code', 'quote', '|', 'gitea-checkbox-empty', 'gitea-checkbox-checked', '|',
-      'unordered-list', 'ordered-list', '|', 'link', 'image', 'table', 'horizontal-rule', '|', 'clean-block', '|',
+      {
+        name: 'heading',
+        action: EasyMDE.toggleHeading3,
+        icon: svg('octicon-heading'),
+        title: 'Heading',
+      },
+      {
+        name: 'bold',
+        action: EasyMDE.toggleBold,
+        icon: svg('octicon-bold'),
+        title: 'Bold',
+      },
+      {
+        name: 'italic',
+        action: EasyMDE.toggleItalic,
+        icon: svg('octicon-italic'),
+        title: 'Italic',
+      },
+      {
+        name: 'strikethrough',
+        action: EasyMDE.toggleStrikethrough,
+        icon: svg('octicon-strikethrough'),
+        title: 'Strikethrough',
+      },
+      '|',
+      {
+        name: 'quote',
+        action: EasyMDE.toggleBlockquote,
+        icon: svg('octicon-quote'),
+        title: 'Quote',
+      },
+      {
+        name: 'code',
+        action: EasyMDE.toggleCodeBlock,
+        icon: svg('octicon-code'),
+        title: 'Code',
+      },
+      {
+        name: 'link',
+        action: EasyMDE.drawLink,
+        icon: svg('octicon-link'),
+        title: 'Link',
+      },
+      '|',
+      {
+        name: 'unordered-list',
+        action: EasyMDE.toggleUnorderedList,
+        icon: svg('octicon-list-unordered'),
+        title: 'Unordered List',
+      },
+      {
+        name: 'ordered-list',
+        action: EasyMDE.toggleOrderedList,
+        icon: svg('octicon-list-ordered'),
+        title: 'Ordered List',
+      },
+      '|',
+      'gitea-checkbox-empty',
+      'gitea-checkbox-checked',
+      '|',
+      {
+        name: 'image',
+        action: EasyMDE.drawImage,
+        icon: svg('octicon-image'),
+        title: 'Image',
+      },
+      {
+        name: 'table',
+        action: EasyMDE.drawTable,
+        icon: svg('octicon-table'),
+        title: 'Table',
+      },
+      {
+        name: 'horizontal-rule',
+        action: EasyMDE.drawHorizontalRule,
+        icon: svg('octicon-horizontal-rule'),
+        title: 'Horizontal Rule',
+      },
+      '|',
       'gitea-switch-to-textarea',
     ];
 
@@ -259,7 +334,7 @@ class ComboMarkdownEditor {
   parseEasyMDEToolbar(actions) {
     const processed = [];
     for (const action of actions) {
-      if (action.startsWith('gitea-')) {
+      if (typeof action === 'string' && action.startsWith('gitea-')) {
         const giteaAction = this.easyMDEToolbarActions[action];
         if (!giteaAction) throw new Error(`Unknown EasyMDE toolbar action ${action}`);
         processed.push(giteaAction);
@@ -281,6 +356,9 @@ class ComboMarkdownEditor {
   async switchToEasyMDE() {
     // EasyMDE's CSS should be loaded via webpack config, otherwise our own styles can not overwrite the default styles.
     const {default: EasyMDE} = await import(/* webpackChunkName: "easymde" */'easymde');
+
+    this.prepareEasyMDEToolbarActions(EasyMDE);
+
     const easyMDEOpt = {
       autoDownloadFontAwesome: false,
       element: this.textarea,

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -206,11 +206,24 @@ class ComboMarkdownEditor {
   prepareEasyMDEToolbarActions(EasyMDE, isWiki) {
     this.easyMDEToolbarDefault = [
       {
-        name: 'heading',
+        name: 'heading-1',
+        action: EasyMDE.toggleHeading1,
+        icon: svg('octicon-heading'),
+        title: 'Heading',
+      },
+      {
+        name: 'heading-2',
+        action: EasyMDE.toggleHeading2,
+        icon: svg('octicon-heading'),
+        title: 'Heading',
+      },
+      {
+        name: 'heading-3',
         action: EasyMDE.toggleHeading3,
         icon: svg('octicon-heading'),
         title: 'Heading',
       },
+      '|',
       {
         name: 'bold',
         action: EasyMDE.toggleBold,

--- a/web_src/js/features/comp/EasyMDEToolbarActions.js
+++ b/web_src/js/features/comp/EasyMDEToolbarActions.js
@@ -18,6 +18,16 @@ export function easyMDEToolbarActions(EasyMDE, editor) {
       icon: svg('octicon-heading'),
       title: 'Heading',
     },
+    'heading-smaller': {
+      action: EasyMDE.toggleHeadingSmaller,
+      icon: svg('octicon-heading'),
+      title: 'Decrease Heading',
+    },
+    'heading-bigger': {
+      action: EasyMDE.toggleHeadingBigger,
+      icon: svg('octicon-heading'),
+      title: 'Increase Heading',
+    },
     'bold': {
       action: EasyMDE.toggleBold,
       icon: svg('octicon-bold'),

--- a/web_src/js/features/comp/EasyMDEToolbarActions.js
+++ b/web_src/js/features/comp/EasyMDEToolbarActions.js
@@ -141,10 +141,12 @@ export function easyMDEToolbarActions(EasyMDE, editor) {
       title: 'Add Inline Code',
     }
   };
-  for (const action in actions) {
-    if (action !== '|') {
-      actions[action].name = action;
+
+  for (const [key, value] of Object.entries(actions)) {
+    if (typeof value !== 'string') {
+      value.name = key;
     }
   }
+
   return actions;
 }

--- a/web_src/js/features/comp/EasyMDEToolbarActions.js
+++ b/web_src/js/features/comp/EasyMDEToolbarActions.js
@@ -1,0 +1,140 @@
+import {svg} from '../../svg.js';
+
+export function easyMDEToolbarActions(EasyMDE, editor) {
+  const actions = {
+    '|': '|',
+    'heading-1': {
+      action: EasyMDE.toggleHeading1,
+      icon: svg('octicon-heading'),
+      title: 'Heading',
+    },
+    'heading-2': {
+      action: EasyMDE.toggleHeading2,
+      icon: svg('octicon-heading'),
+      title: 'Heading',
+    },
+    'heading-3': {
+      action: EasyMDE.toggleHeading3,
+      icon: svg('octicon-heading'),
+      title: 'Heading',
+    },
+    'bold': {
+      action: EasyMDE.toggleBold,
+      icon: svg('octicon-bold'),
+      title: 'Bold',
+    },
+    'italic': {
+      action: EasyMDE.toggleItalic,
+      icon: svg('octicon-italic'),
+      title: 'Italic',
+    },
+    'strikethrough': {
+      action: EasyMDE.toggleStrikethrough,
+      icon: svg('octicon-strikethrough'),
+      title: 'Strikethrough',
+    },
+    'quote': {
+      action: EasyMDE.toggleBlockquote,
+      icon: svg('octicon-quote'),
+      title: 'Quote',
+    },
+    'code': {
+      action: EasyMDE.toggleCodeBlock,
+      icon: svg('octicon-code'),
+      title: 'Code',
+    },
+    'link': {
+      action: EasyMDE.drawLink,
+      icon: svg('octicon-link'),
+      title: 'Link',
+    },
+    'unordered-list': {
+      action: EasyMDE.toggleUnorderedList,
+      icon: svg('octicon-list-unordered'),
+      title: 'Unordered List',
+    },
+    'ordered-list': {
+      action: EasyMDE.toggleOrderedList,
+      icon: svg('octicon-list-ordered'),
+      title: 'Ordered List',
+    },
+    'image': {
+      action: EasyMDE.drawImage,
+      icon: svg('octicon-image'),
+      title: 'Image',
+    },
+    'table': {
+      action: EasyMDE.drawTable,
+      icon: svg('octicon-table'),
+      title: 'Table',
+    },
+    'horizontal-rule': {
+      action: EasyMDE.drawHorizontalRule,
+      icon: svg('octicon-horizontal-rule'),
+      title: 'Horizontal Rule',
+    },
+    'preview': {
+      action: EasyMDE.togglePreview,
+      icon: svg('octicon-eye'),
+      title: 'Preview',
+    },
+    'fullscreen': {
+      action: EasyMDE.toggleFullScreen,
+      icon: svg('octicon-screen-full'),
+      title: 'Fullscreen',
+    },
+    'side-by-side': {
+      action: EasyMDE.toggleSideBySide,
+      icon: svg('octicon-columns'),
+      title: 'Side by Side',
+    },
+
+    // gitea's custom actions
+    'gitea-checkbox-empty': {
+      action(e) {
+        const cm = e.codemirror;
+        cm.replaceSelection(`\n- [ ] ${cm.getSelection()}`);
+        cm.focus();
+      },
+      icon: svg('gitea-empty-checkbox'),
+      title: 'Add Checkbox (empty)',
+    },
+    'gitea-checkbox-checked': {
+      action(e) {
+        const cm = e.codemirror;
+        cm.replaceSelection(`\n- [x] ${cm.getSelection()}`);
+        cm.focus();
+      },
+      icon: svg('octicon-checkbox'),
+      title: 'Add Checkbox (checked)',
+    },
+    'gitea-switch-to-textarea': {
+      action: () => {
+        editor.userPreferredEditor = 'textarea';
+        editor.switchToTextarea();
+      },
+      icon: svg('octicon-arrow-switch'),
+      title: 'Revert to simple textarea',
+    },
+    'gitea-code-inline': {
+      action(e) {
+        const cm = e.codemirror;
+        const selection = cm.getSelection();
+        cm.replaceSelection(`\`${selection}\``);
+        if (!selection) {
+          const cursorPos = cm.getCursor();
+          cm.setCursor(cursorPos.line, cursorPos.ch - 1);
+        }
+        cm.focus();
+      },
+      icon: svg('octicon-chevron-right'),
+      title: 'Add Inline Code',
+    }
+  };
+  for (const action in actions) {
+    if (action !== '|') {
+      actions[action].name = action;
+    }
+  }
+  return actions;
+}

--- a/web_src/js/features/comp/EasyMDEToolbarActions.js
+++ b/web_src/js/features/comp/EasyMDEToolbarActions.js
@@ -6,17 +6,17 @@ export function easyMDEToolbarActions(EasyMDE, editor) {
     'heading-1': {
       action: EasyMDE.toggleHeading1,
       icon: svg('octicon-heading'),
-      title: 'Heading',
+      title: 'Heading 1',
     },
     'heading-2': {
       action: EasyMDE.toggleHeading2,
       icon: svg('octicon-heading'),
-      title: 'Heading',
+      title: 'Heading 2',
     },
     'heading-3': {
       action: EasyMDE.toggleHeading3,
       icon: svg('octicon-heading'),
-      title: 'Heading',
+      title: 'Heading 3',
     },
     'heading-smaller': {
       action: EasyMDE.toggleHeadingSmaller,

--- a/web_src/js/features/repo-wiki.js
+++ b/web_src/js/features/repo-wiki.js
@@ -54,7 +54,7 @@ async function initRepoWikiFormEditor() {
     easyMDEOptions: {
       previewRender: (_content, previewTarget) => previewTarget.innerHTML, // disable builtin preview render
       toolbar: ['bold', 'italic', 'strikethrough', '|',
-        'heading-1', 'heading-2', 'heading-3', '|',
+        'heading-1', 'heading-2', 'heading-3', 'heading-bigger', 'heading-smaller', '|',
         'gitea-code-inline', 'code', 'quote', '|', 'gitea-checkbox-empty', 'gitea-checkbox-checked', '|',
         'unordered-list', 'ordered-list', '|',
         'link', 'image', 'table', 'horizontal-rule', '|',

--- a/web_src/js/features/repo-wiki.js
+++ b/web_src/js/features/repo-wiki.js
@@ -53,7 +53,13 @@ async function initRepoWikiFormEditor() {
     previewWiki: true,
     easyMDEOptions: {
       previewRender: (_content, previewTarget) => previewTarget.innerHTML, // disable builtin preview render
-      isWiki: true,
+      toolbar: ['bold', 'italic', 'strikethrough', '|',
+        'heading-1', 'heading-2', 'heading-3', '|',
+        'gitea-code-inline', 'code', 'quote', '|', 'gitea-checkbox-empty', 'gitea-checkbox-checked', '|',
+        'unordered-list', 'ordered-list', '|',
+        'link', 'image', 'table', 'horizontal-rule', '|',
+        'preview', 'fullscreen', 'side-by-side', '|', 'gitea-switch-to-textarea'
+      ],
     },
   });
 

--- a/web_src/js/features/repo-wiki.js
+++ b/web_src/js/features/repo-wiki.js
@@ -53,13 +53,7 @@ async function initRepoWikiFormEditor() {
     previewWiki: true,
     easyMDEOptions: {
       previewRender: (_content, previewTarget) => previewTarget.innerHTML, // disable builtin preview render
-      toolbar: ['bold', 'italic', 'strikethrough', '|',
-        'heading-1', 'heading-2', 'heading-3', 'heading-bigger', 'heading-smaller', '|',
-        'gitea-code-inline', 'code', 'quote', '|', 'gitea-checkbox-empty', 'gitea-checkbox-checked', '|',
-        'unordered-list', 'ordered-list', '|',
-        'link', 'image', 'table', 'horizontal-rule', '|',
-        'clean-block', 'preview', 'fullscreen', 'side-by-side', '|', 'gitea-switch-to-textarea'
-      ],
+      isWiki: true,
     },
   });
 

--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -1,7 +1,17 @@
 import {h} from 'vue';
+import giteaDoubleChevronLeft from '../../public/img/svg/gitea-double-chevron-left.svg';
+import giteaDoubleChevronRight from '../../public/img/svg/gitea-double-chevron-right.svg';
+import giteaEmptyCheckbox from '../../public/img/svg/gitea-empty-checkbox.svg';
+import octiconArchive from '../../public/img/svg/octicon-archive.svg';
+import octiconBlocked from '../../public/img/svg/octicon-blocked.svg';
+import octiconBold from '../../public/img/svg/octicon-bold.svg';
+import octiconCheckbox from '../../public/img/svg/octicon-checkbox.svg';
+import octiconCheckCircleFill from '../../public/img/svg/octicon-check-circle-fill.svg';
 import octiconChevronDown from '../../public/img/svg/octicon-chevron-down.svg';
+import octiconChevronLeft from '../../public/img/svg/octicon-chevron-left.svg';
 import octiconChevronRight from '../../public/img/svg/octicon-chevron-right.svg';
 import octiconClock from '../../public/img/svg/octicon-clock.svg';
+import octiconCode from '../../public/img/svg/octicon-code.svg';
 import octiconCopy from '../../public/img/svg/octicon-copy.svg';
 import octiconDiffAdded from '../../public/img/svg/octicon-diff-added.svg';
 import octiconDiffModified from '../../public/img/svg/octicon-diff-modified.svg';
@@ -9,72 +19,81 @@ import octiconDiffRemoved from '../../public/img/svg/octicon-diff-removed.svg';
 import octiconDiffRenamed from '../../public/img/svg/octicon-diff-renamed.svg';
 import octiconFile from '../../public/img/svg/octicon-file.svg';
 import octiconFileDirectoryFill from '../../public/img/svg/octicon-file-directory-fill.svg';
+import octiconFilter from '../../public/img/svg/octicon-filter.svg';
+import octiconGitBranch from '../../public/img/svg/octicon-git-branch.svg';
 import octiconGitMerge from '../../public/img/svg/octicon-git-merge.svg';
 import octiconGitPullRequest from '../../public/img/svg/octicon-git-pull-request.svg';
+import octiconHeading from '../../public/img/svg/octicon-heading.svg';
+import octiconHorizontalRule from '../../public/img/svg/octicon-horizontal-rule.svg';
+import octiconImage from '../../public/img/svg/octicon-image.svg';
 import octiconIssueClosed from '../../public/img/svg/octicon-issue-closed.svg';
 import octiconIssueOpened from '../../public/img/svg/octicon-issue-opened.svg';
+import octiconItalic from '../../public/img/svg/octicon-italic.svg';
 import octiconKebabHorizontal from '../../public/img/svg/octicon-kebab-horizontal.svg';
 import octiconLink from '../../public/img/svg/octicon-link.svg';
+import octiconListOrdered from '../../public/img/svg/octicon-list-ordered.svg';
+import octiconListUnordered from '../../public/img/svg/octicon-list-unordered.svg';
 import octiconLock from '../../public/img/svg/octicon-lock.svg';
+import octiconMeter from '../../public/img/svg/octicon-meter.svg';
 import octiconMilestone from '../../public/img/svg/octicon-milestone.svg';
 import octiconMirror from '../../public/img/svg/octicon-mirror.svg';
+import octiconOrganization from '../../public/img/svg/octicon-organization.svg';
 import octiconPlay from '../../public/img/svg/octicon-play.svg';
+import octiconPlus from '../../public/img/svg/octicon-plus.svg';
 import octiconProject from '../../public/img/svg/octicon-project.svg';
+import octiconQuote from '../../public/img/svg/octicon-quote.svg';
 import octiconRepo from '../../public/img/svg/octicon-repo.svg';
 import octiconRepoForked from '../../public/img/svg/octicon-repo-forked.svg';
 import octiconRepoTemplate from '../../public/img/svg/octicon-repo-template.svg';
+import octiconRss from '../../public/img/svg/octicon-rss.svg';
+import octiconSearch from '../../public/img/svg/octicon-search.svg';
 import octiconSidebarCollapse from '../../public/img/svg/octicon-sidebar-collapse.svg';
 import octiconSidebarExpand from '../../public/img/svg/octicon-sidebar-expand.svg';
+import octiconSkip from '../../public/img/svg/octicon-skip.svg';
+import octiconStar from '../../public/img/svg/octicon-star.svg';
+import octiconStrikethrough from '../../public/img/svg/octicon-strikethrough.svg';
+import octiconSync from '../../public/img/svg/octicon-sync.svg';
+import octiconTable from '../../public/img/svg/octicon-table.svg';
+import octiconTag from '../../public/img/svg/octicon-tag.svg';
 import octiconTriangleDown from '../../public/img/svg/octicon-triangle-down.svg';
 import octiconX from '../../public/img/svg/octicon-x.svg';
-import octiconCheckCircleFill from '../../public/img/svg/octicon-check-circle-fill.svg';
 import octiconXCircleFill from '../../public/img/svg/octicon-x-circle-fill.svg';
-import octiconSkip from '../../public/img/svg/octicon-skip.svg';
-import octiconMeter from '../../public/img/svg/octicon-meter.svg';
-import octiconBlocked from '../../public/img/svg/octicon-blocked.svg';
-import octiconSync from '../../public/img/svg/octicon-sync.svg';
-import octiconFilter from '../../public/img/svg/octicon-filter.svg';
-import octiconPlus from '../../public/img/svg/octicon-plus.svg';
-import octiconSearch from '../../public/img/svg/octicon-search.svg';
-import octiconArchive from '../../public/img/svg/octicon-archive.svg';
-import octiconStar from '../../public/img/svg/octicon-star.svg';
-import giteaDoubleChevronLeft from '../../public/img/svg/gitea-double-chevron-left.svg';
-import giteaDoubleChevronRight from '../../public/img/svg/gitea-double-chevron-right.svg';
-import octiconChevronLeft from '../../public/img/svg/octicon-chevron-left.svg';
-import octiconOrganization from '../../public/img/svg/octicon-organization.svg';
-import octiconTag from '../../public/img/svg/octicon-tag.svg';
-import octiconGitBranch from '../../public/img/svg/octicon-git-branch.svg';
-import octiconRss from '../../public/img/svg/octicon-rss.svg';
-import octiconCheckbox from '../../public/img/svg/octicon-checkbox.svg';
-import giteaEmptyCheckbox from '../../public/img/svg/gitea-empty-checkbox.svg';
 
 const svgs = {
+  'gitea-double-chevron-left': giteaDoubleChevronLeft,
+  'gitea-double-chevron-right': giteaDoubleChevronRight,
+  'gitea-empty-checkbox': giteaEmptyCheckbox,
   'octicon-archive': octiconArchive,
   'octicon-blocked': octiconBlocked,
-  'octicon-checkbox': octiconCheckbox,
+  'octicon-bold': octiconBold,
   'octicon-check-circle-fill': octiconCheckCircleFill,
+  'octicon-checkbox': octiconCheckbox,
   'octicon-chevron-down': octiconChevronDown,
   'octicon-chevron-left': octiconChevronLeft,
   'octicon-chevron-right': octiconChevronRight,
   'octicon-clock': octiconClock,
+  'octicon-code': octiconCode,
   'octicon-copy': octiconCopy,
   'octicon-diff-added': octiconDiffAdded,
   'octicon-diff-modified': octiconDiffModified,
   'octicon-diff-removed': octiconDiffRemoved,
   'octicon-diff-renamed': octiconDiffRenamed,
-  'gitea-double-chevron-left': giteaDoubleChevronLeft,
-  'gitea-double-chevron-right': giteaDoubleChevronRight,
-  'gitea-empty-checkbox': giteaEmptyCheckbox,
   'octicon-file': octiconFile,
   'octicon-file-directory-fill': octiconFileDirectoryFill,
   'octicon-filter': octiconFilter,
   'octicon-git-branch': octiconGitBranch,
   'octicon-git-merge': octiconGitMerge,
   'octicon-git-pull-request': octiconGitPullRequest,
+  'octicon-heading': octiconHeading,
+  'octicon-horizontal-rule': octiconHorizontalRule,
+  'octicon-image': octiconImage,
   'octicon-issue-closed': octiconIssueClosed,
   'octicon-issue-opened': octiconIssueOpened,
+  'octicon-italic': octiconItalic,
   'octicon-kebab-horizontal': octiconKebabHorizontal,
   'octicon-link': octiconLink,
+  'octicon-list-ordered': octiconListOrdered,
+  'octicon-list-unordered': octiconListUnordered,
   'octicon-lock': octiconLock,
   'octicon-meter': octiconMeter,
   'octicon-milestone': octiconMilestone,
@@ -83,6 +102,7 @@ const svgs = {
   'octicon-play': octiconPlay,
   'octicon-plus': octiconPlus,
   'octicon-project': octiconProject,
+  'octicon-quote': octiconQuote,
   'octicon-repo': octiconRepo,
   'octicon-repo-forked': octiconRepoForked,
   'octicon-repo-template': octiconRepoTemplate,
@@ -92,7 +112,9 @@ const svgs = {
   'octicon-sidebar-expand': octiconSidebarExpand,
   'octicon-skip': octiconSkip,
   'octicon-star': octiconStar,
+  'octicon-strikethrough': octiconStrikethrough,
   'octicon-sync': octiconSync,
+  'octicon-table': octiconTable,
   'octicon-tag': octiconTag,
   'octicon-triangle-down': octiconTriangleDown,
   'octicon-x': octiconX,

--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -3,6 +3,7 @@ import giteaDoubleChevronLeft from '../../public/img/svg/gitea-double-chevron-le
 import giteaDoubleChevronRight from '../../public/img/svg/gitea-double-chevron-right.svg';
 import giteaEmptyCheckbox from '../../public/img/svg/gitea-empty-checkbox.svg';
 import octiconArchive from '../../public/img/svg/octicon-archive.svg';
+import octiconArrowSwitch from '../../public/img/svg/octicon-arrow-switch.svg';
 import octiconBlocked from '../../public/img/svg/octicon-blocked.svg';
 import octiconBold from '../../public/img/svg/octicon-bold.svg';
 import octiconCheckbox from '../../public/img/svg/octicon-checkbox.svg';
@@ -64,6 +65,7 @@ const svgs = {
   'gitea-double-chevron-right': giteaDoubleChevronRight,
   'gitea-empty-checkbox': giteaEmptyCheckbox,
   'octicon-archive': octiconArchive,
+  'octicon-arrow-switch': octiconArrowSwitch,
   'octicon-blocked': octiconBlocked,
   'octicon-bold': octiconBold,
   'octicon-check-circle-fill': octiconCheckCircleFill,

--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -13,11 +13,13 @@ import octiconChevronLeft from '../../public/img/svg/octicon-chevron-left.svg';
 import octiconChevronRight from '../../public/img/svg/octicon-chevron-right.svg';
 import octiconClock from '../../public/img/svg/octicon-clock.svg';
 import octiconCode from '../../public/img/svg/octicon-code.svg';
+import octiconColumns from '../../public/img/svg/octicon-columns.svg';
 import octiconCopy from '../../public/img/svg/octicon-copy.svg';
 import octiconDiffAdded from '../../public/img/svg/octicon-diff-added.svg';
 import octiconDiffModified from '../../public/img/svg/octicon-diff-modified.svg';
 import octiconDiffRemoved from '../../public/img/svg/octicon-diff-removed.svg';
 import octiconDiffRenamed from '../../public/img/svg/octicon-diff-renamed.svg';
+import octiconEye from '../../public/img/svg/octicon-eye.svg';
 import octiconFile from '../../public/img/svg/octicon-file.svg';
 import octiconFileDirectoryFill from '../../public/img/svg/octicon-file-directory-fill.svg';
 import octiconFilter from '../../public/img/svg/octicon-filter.svg';
@@ -47,6 +49,7 @@ import octiconRepo from '../../public/img/svg/octicon-repo.svg';
 import octiconRepoForked from '../../public/img/svg/octicon-repo-forked.svg';
 import octiconRepoTemplate from '../../public/img/svg/octicon-repo-template.svg';
 import octiconRss from '../../public/img/svg/octicon-rss.svg';
+import octiconScreenFull from '../../public/img/svg/octicon-screen-full.svg';
 import octiconSearch from '../../public/img/svg/octicon-search.svg';
 import octiconSidebarCollapse from '../../public/img/svg/octicon-sidebar-collapse.svg';
 import octiconSidebarExpand from '../../public/img/svg/octicon-sidebar-expand.svg';
@@ -75,11 +78,13 @@ const svgs = {
   'octicon-chevron-right': octiconChevronRight,
   'octicon-clock': octiconClock,
   'octicon-code': octiconCode,
+  'octicon-columns': octiconColumns,
   'octicon-copy': octiconCopy,
   'octicon-diff-added': octiconDiffAdded,
   'octicon-diff-modified': octiconDiffModified,
   'octicon-diff-removed': octiconDiffRemoved,
   'octicon-diff-renamed': octiconDiffRenamed,
+  'octicon-eye': octiconEye,
   'octicon-file': octiconFile,
   'octicon-file-directory-fill': octiconFileDirectoryFill,
   'octicon-filter': octiconFilter,
@@ -109,6 +114,7 @@ const svgs = {
   'octicon-repo-forked': octiconRepoForked,
   'octicon-repo-template': octiconRepoTemplate,
   'octicon-rss': octiconRss,
+  'octicon-screen-full': octiconScreenFull,
   'octicon-search': octiconSearch,
   'octicon-sidebar-collapse': octiconSidebarCollapse,
   'octicon-sidebar-expand': octiconSidebarExpand,


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/24486

The "clean block" button is gone because I could not find a matching octicon. Order of buttons is roughly equal to textarea.

<img width="824" alt="Screenshot 2023-05-02 at 21 10 00" src="https://user-images.githubusercontent.com/115237/235762593-ceccb260-e665-4932-ac8a-ef6fe8406a3c.png">




