### PR TITLE
Fix typo in rename branch dialog

### DIFF
--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -232,7 +232,7 @@
 		<div class="content">
 			{{.CsrfTokenHtml}}
 			<div class="field default-branch-warning">
-				<span class="text red">{{.locale.Tr "repo.branch.warning_raname_default_branch"}}</span>
+				<span class="text red">{{.locale.Tr "repo.branch.warning_rename_default_branch"}}</span>
 			</div>
 			<div class="field">
 				<span class="text" data-rename-branch-to="{{.locale.Tr "repo.branch.rename_branch_to"}}"></span>


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/pull/24512#discussion_r1185664695