### PR TITLE
add "xrpc" to reserved username list

### DIFF
--- a/models/user/user.go
+++ b/models/user/user.go
@@ -529,6 +529,7 @@ var (
 		"explore",
 		"favicon.ico",
 		"ghost",
+		"gitea-actions",
 		"issues",
 		"login",
 		"manifest.json",
@@ -548,7 +549,7 @@ var (
 		"swagger.v1.json",
 		"user",
 		"v2",
-		"gitea-actions",
+		"xrpc",
 	}
 
 	// DON'T ADD ANY NEW STUFF, WE SOLVE THIS WITH `/user/{obj}` PATHS!


### PR DESCRIPTION
`xrpc` is a "well-known" endpoint for bluesky to validate domains.

documented at `at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3juuaipn3q424` (you'll need a valid AT proto client to view)

## :warning: Breaking

Exisiting users with the name `xrpc` need to be renamed prior to the upgrade.