### PR TITLE
Update LDAP filters to include both username and email address

### DIFF
--- a/docs/content/doc/administration/command-line.en-us.md
+++ b/docs/content/doc/administration/command-line.en-us.md
@@ -225,7 +225,7 @@ Admin operations:
         - `--synchronize-users`: Enable user synchronization.
         - `--page-size value`: Search page size.
       - Examples:
-        - `gitea admin auth add-ldap --name ldap --security-protocol unencrypted --host mydomain.org --port 389 --user-search-base "ou=Users,dc=mydomain,dc=org" --user-filter "(&(objectClass=posixAccount)(uid=%s))" --email-attribute mail`
+        - `gitea admin auth add-ldap --name ldap --security-protocol unencrypted --host mydomain.org --port 389 --user-search-base "ou=Users,dc=mydomain,dc=org" --user-filter "(&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))" --email-attribute mail`
     - `update-ldap`: Update existing LDAP (via Bind DN) authentication source
       - Options:
         - `--id value`: ID of authentication source. Required.

--- a/docs/content/doc/usage/authentication.en-us.md
+++ b/docs/content/doc/usage/authentication.en-us.md
@@ -100,9 +100,9 @@ Adds the following fields:
 
 - User Filter **(required)**
   - An LDAP filter declaring how to find the user record that is attempting to
-    authenticate. The `%s` matching parameter will be substituted with login
+    authenticate. The `%[1]s` matching parameter will be substituted with login
     name given on sign-in form.
-  - Example: `(&(objectClass=posixAccount)(uid=%s))`
+  - Example: `(&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))`
   - Example for Microsoft Active Directory (AD): `(&(objectCategory=Person)(memberOf=CN=user-group,OU=example,DC=example,DC=org)(sAMAccountName=%s)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))`
   - To substitute more than once, `%[1]s` should be used instead, e.g. when
     matching supplied login name against multiple attributes such as user
@@ -137,11 +137,11 @@ Adds the following fields:
   - Example: `ou=Users,dc=mydomain,dc=com`
 
 - User Filter **(required)**
-  - An LDAP filter declaring when a user should be allowed to log in. The `%s`
+  - An LDAP filter declaring when a user should be allowed to log in. The `%[1]s`
     matching parameter will be substituted with login name given on sign-in
     form.
-  - Example: `(&(objectClass=posixAccount)(cn=%s))`
-  - Example: `(&(objectClass=posixAccount)(uid=%s))`
+  - Example: `(&(objectClass=posixAccount)(|(cn=%[1]s)(mail=%[1]s)))`
+  - Example: `(&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))`
 
 ### Verify group membership in LDAP
 

--- a/services/auth/source/ldap/README.md
+++ b/services/auth/source/ldap/README.md
@@ -81,9 +81,9 @@ share the following fields:
 
 * User Filter **(required)**
   * An LDAP filter declaring how to find the user record that is attempting to
-      authenticate. The '%s' matching parameter will be substituted with the
+      authenticate. The '%[1]s' matching parameter will be substituted with the
       user's username.
-  * Example: (&(objectClass=posixAccount)(uid=%s))
+  * Example: (&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))
 
 **LDAP using simple auth** adds the following fields:
 
@@ -98,10 +98,10 @@ share the following fields:
   * Example: ou=Users,dc=mydomain,dc=com
 
 * User Filter **(required)**
-  * An LDAP filter declaring when a user should be allowed to log in. The `%s`
+  * An LDAP filter declaring when a user should be allowed to log in. The `%[1]s`
       matching parameter will be substituted with the user's username.
-  * Example: (&(objectClass=posixAccount)(cn=%s))
-  * Example: (&(objectClass=posixAccount)(uid=%s))
+  * Example: (&(objectClass=posixAccount)(|(cn=%[1]s)(mail=%[1]s)))
+  * Example: (&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))
 
 **Verify group membership in LDAP** uses the following fields:
 

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -70,7 +70,7 @@
 					{{end}}
 					<div class="required field">
 						<label for="filter">{{.locale.Tr "admin.auths.filter"}}</label>
-						<input id="filter" name="filter" value="{{$cfg.Filter}}" placeholder="e.g. (&(objectClass=posixAccount)(uid=%s))" required>
+						<input id="filter" name="filter" value="{{$cfg.Filter}}" placeholder="e.g. (&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))" required>
 					</div>
 					<div class="field">
 						<label for="admin_filter">{{.locale.Tr "admin.auths.admin_filter"}}</label>

--- a/templates/admin/auth/source/ldap.tmpl
+++ b/templates/admin/auth/source/ldap.tmpl
@@ -44,7 +44,7 @@
 	</div>
 	<div class="required field">
 		<label for="filter">{{.locale.Tr "admin.auths.filter"}}</label>
-		<input id="filter" name="filter" value="{{.filter}}" placeholder="e.g. (&(objectClass=posixAccount)(uid=%s))">
+		<input id="filter" name="filter" value="{{.filter}}" placeholder="e.g. (&(objectClass=posixAccount)(|(uid=%[1]s)(mail=%[1]s)))">
 	</div>
 	<div class="field">
 		<label for="admin_filter">{{.locale.Tr "admin.auths.admin_filter"}}</label>


### PR DESCRIPTION
Since the login form label for user_name unconditionally displays `Username or Email Address` for the `user_name` field, bring matching LDAP filters to more prominence in the documentation/placeholders.

---

I thought I was a super megamind for coming up with this, and then coming to make this PR I find it's documented in a lot of places just not the ones I looked haha :sob: 