### PR TITLE
Improve wiki user title test

### DIFF
--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -34,6 +34,9 @@ func TestUserTitleToWebPath(t *testing.T) {
 		UserTitle string
 	}
 	for _, test := range []test{
+		{"unnamed", ""},
+		{"unnamed", "."},
+		{"unnamed", ".."},
 		{"wiki-name", "wiki name"},
 		{"title.md.-", "title.md"},
 		{"wiki-name.-", "wiki-name"},
@@ -118,7 +121,7 @@ func TestUserWebGitPathConsistency(t *testing.T) {
 		}
 
 		userTitle := strings.TrimSpace(string(b[:l]))
-		if userTitle == "" || userTitle == "." {
+		if userTitle == "" || userTitle == "." || userTitle == ".." {
 			continue
 		}
 		webPath := UserTitleToWebPath("", userTitle)


### PR DESCRIPTION
The `..` should be covered by TestUserTitleToWebPath.

Otherwise, if the random string is "..", it causes unnecessary failure in TestUserWebGitPathConsistency

----

CI failure is unrelated, Go has new version with security fix ....