### PR TITLE
Simplify template helper functions

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -179,7 +179,6 @@ func NewFuncMap() template.FuncMap {
 
 		// -----------------------------------------------------------------
 		// misc
-		"DiffLineTypeToStr":        DiffLineTypeToStr,
 		"ShortSha":                 base.ShortSha,
 		"ActionContent2Commits":    ActionContent2Commits,
 		"IsMultilineCommitMessage": IsMultilineCommitMessage,

--- a/modules/templates/util_misc.go
+++ b/modules/templates/util_misc.go
@@ -122,19 +122,6 @@ func ActionContent2Commits(act Actioner) *repository.PushCommits {
 	return push
 }
 
-// DiffLineTypeToStr returns diff line type name
-func DiffLineTypeToStr(diffType int) string {
-	switch diffType {
-	case 2:
-		return "add"
-	case 3:
-		return "del"
-	case 4:
-		return "tag"
-	}
-	return "same"
-}
-
 // MigrationIcon returns a SVG name matching the service an issue/comment was migrated from
 func MigrationIcon(hostname string) string {
 	switch hostname {

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -104,6 +104,19 @@ func (d *DiffLine) GetType() int {
 	return int(d.Type)
 }
 
+// GetHTMLDiffLineType returns the diff line type name for HTML
+func (d *DiffLine) GetHTMLDiffLineType() string {
+	switch d.Type {
+	case DiffLineAdd:
+		return "add"
+	case DiffLineDel:
+		return "del"
+	case DiffLineSection:
+		return "tag"
+	}
+	return "same"
+}
+
 // CanComment returns whether a line can get commented
 func (d *DiffLine) CanComment() bool {
 	return len(d.Comments) == 0 && d.Type != DiffLineSection

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -1,6 +1,6 @@
 {{if $.IsSplitStyle}}
 	{{range $k, $line := $.section.Lines}}
-	<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
+	<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}}">
 		{{if eq .GetType 4}}
 			<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}">
 				{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5)}}
@@ -44,7 +44,7 @@
 	{{end}}
 {{else}}
 	{{range $k, $line := $.section.Lines}}
-	<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}">
+	<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}}">
 		{{if eq .GetType 4}}
 			<td colspan="2" class="lines-num">
 				{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5)}}

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -13,7 +13,7 @@
 	{{range $k, $line := $section.Lines}}
 		{{$hasmatch := ne $line.Match -1}}
 		{{if or (ne .GetType 2) (not $hasmatch)}}
-			<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
+			<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{.GetHTMLDiffLineType}}">
 				{{if eq .GetType 4}}
 					<td class="lines-num lines-num-old">
 						{{if or (eq $line.GetExpandDirection 3) (eq $line.GetExpandDirection 5)}}
@@ -107,7 +107,7 @@
 			{{if and (eq .GetType 3) $hasmatch}}
 				{{$match := index $section.Lines $line.Match}}
 				{{if or (gt (len $line.Comments) 0) (gt (len $match.Comments) 0)}}
-					<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+					<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 						<td class="add-comment-left" colspan="4">
 							{{if gt (len $line.Comments) 0}}
 								{{if eq $line.GetCommentSide "previous"}}
@@ -133,7 +133,7 @@
 					</tr>
 				{{end}}
 			{{else if gt (len $line.Comments) 0}}
-				<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+				<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 					<td class="add-comment-left" colspan="4">
 						{{if gt (len $line.Comments) 0}}
 							{{if eq $line.GetCommentSide "previous"}}

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -8,7 +8,7 @@
 </colgroup>
 {{range $j, $section := $file.Sections}}
 	{{range $k, $line := $section.Lines}}
-		<tr class="{{DiffLineTypeToStr .GetType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{DiffLineTypeToStr .GetType}}">
+		<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}}" data-line-type="{{.GetHTMLDiffLineType}}">
 			{{if eq .GetType 4}}
 				{{if $.root.AfterCommitID}}
 					<td colspan="2" class="lines-num">
@@ -55,7 +55,7 @@
 			{{end}}
 		</tr>
 		{{if gt (len $line.Comments) 0}}
-			<tr class="add-comment" data-line-type="{{DiffLineTypeToStr .GetType}}">
+			<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 				<td class="add-comment-left add-comment-right" colspan="5">
 					{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 				</td>


### PR DESCRIPTION
To avoid bloating the template helper functions, some functions could be provided by type methods.

And the new code `data-line-type="{{.GetHTMLDiffLineType}}"` reads better than `data-line-type="{{DiffLineTypeToStr .GetType}}"`


After the fix, screenshots (the same as before):

<details>

![image](https://user-images.githubusercontent.com/2114189/236657918-20ce01e0-1192-443e-aeb4-6b3fe1aa2102.png)

![image](https://user-images.githubusercontent.com/2114189/236657950-ee19727f-a1fc-4133-afc7-e5d1a8c1783f.png)

</details>