### PR TITLE
Do not select line numbers when selecting text from the action run logs

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -530,6 +530,7 @@ export function ansiLogToHTML(line) {
   width: 48px;
   color: var(--color-grey-light);
   text-align: right;
+  user-select: none;
 }
 
 .job-step-section .job-step-logs .job-log-line .log-time {


### PR DESCRIPTION
- Fixes #24578

# Before
![image](https://user-images.githubusercontent.com/20454870/236873942-26e97f28-6595-4be9-88fa-158870eda253.png)

# After
![image](https://user-images.githubusercontent.com/20454870/236874171-8f0182a5-e953-4740-b875-f3542dee8325.png)
