### PR TITLE
Add a tooltip to the job rerun button

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -36,7 +36,7 @@
                 <span class="ui text gt-mx-3">{{ job.name }}</span>
               </a>
               <span class="step-summary-duration">{{ job.duration }}</span>
-              <button class="job-brief-rerun" @click="rerunJob(index)" v-if="job.canRerun">
+              <button :data-tooltip-content="locale.rerun" class="job-brief-rerun" @click="rerunJob(index)" v-if="job.canRerun">
                 <SvgIcon name="octicon-sync" class="ui text black"/>
               </button>
             </div>


### PR DESCRIPTION
This one doesn't look very good as a real button (at least not in the ways I tried), so I've opted to simply add a tooltip for it.
# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/05afe362-b914-42ce-9db3-e3471bc6ec4b)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/c99c88d4-bf43-46b0-911e-9ea17ff6977e)
