### PR TITLE
Reenable creating default webhooks.

### DIFF
--- a/routers/web/repo/webhook.go
+++ b/routers/web/repo/webhook.go
@@ -99,7 +99,7 @@ func getOwnerRepoCtx(ctx *context.Context) (*ownerRepoCtx, error) {
 			IsAdmin:         true,
 			IsSystemWebhook: ctx.Params(":configType") == "system-hooks",
 			Link:            path.Join(setting.AppSubURL, "/admin/hooks"),
-			LinkNew:         "/admin/" + ctx.Params(":configType"),
+			LinkNew:         path.Join(setting.AppSubURL, "/admin/", ctx.Params(":configType")),
 			NewTemplate:     tplAdminHookNew,
 		}, nil
 	}

--- a/routers/web/repo/webhook.go
+++ b/routers/web/repo/webhook.go
@@ -99,7 +99,7 @@ func getOwnerRepoCtx(ctx *context.Context) (*ownerRepoCtx, error) {
 			IsAdmin:         true,
 			IsSystemWebhook: ctx.Params(":configType") == "system-hooks",
 			Link:            path.Join(setting.AppSubURL, "/admin/hooks"),
-			LinkNew:         path.Join(setting.AppSubURL, "/admin/system-hooks"),
+			LinkNew:         "/admin/" + ctx.Params(":configType"),
 			NewTemplate:     tplAdminHookNew,
 		}, nil
 	}


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/24624

This seems to have been broken in https://github.com/go-gitea/gitea/pull/21563

Previously, this code read

```
                // Are we looking at default webhooks?
                if ctx.Params(":configType") == "default-hooks" {
                        return &orgRepoCtx{
                                IsAdmin:     true,
                                Link:        path.Join(setting.AppSubURL, "/admin/hooks"),
                                LinkNew:     path.Join(setting.AppSubURL, "/admin/default-hooks"),
                                NewTemplate: tplAdminHookNew,
                        }, nil
                }

                // Must be system webhooks instead
                return &orgRepoCtx{
                        IsAdmin:         true,
                        IsSystemWebhook: true,
                        Link:            path.Join(setting.AppSubURL, "/admin/hooks"),
                        LinkNew:         path.Join(setting.AppSubURL, "/admin/system-hooks"),
                        NewTemplate:     tplAdminHookNew,
                }, nil
```

but was simplified to

```
                return &ownerRepoCtx{
                        IsAdmin:         true,
                        IsSystemWebhook: ctx.Params(":configType") == "system-hooks",
                        Link:            path.Join(setting.AppSubURL, "/admin/hooks"),
                        LinkNew:         path.Join(setting.AppSubURL, "/admin/system-hooks"),
                        NewTemplate:     tplAdminHookNew,
                }, nil
```

In other words, combining the `IsSystemWebhook` check into a one-liner and forgetting that `LinkNew` also depended on it. This meant the rendered `<form>` always POSTed to `/admin/system-hooks`, even when you had GETed `/admin/default-hooks/gitea/new`.