### PR TITLE
Remove fluid on compare diff page

### DIFF
--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -237,8 +237,6 @@
 	{{if $showDiffBox}}
 	<div class="ui container">
 		{{template "repo/commits_table" .}}
-	</div>
-	<div class="ui container">
 		{{template "repo/diff/box" .}}
 	</div>
 	{{end}}

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -238,7 +238,7 @@
 	<div class="ui container">
 		{{template "repo/commits_table" .}}
 	</div>
-	<div class="ui container fluid padded">
+	<div class="ui container">
 		{{template "repo/diff/box" .}}
 	</div>
 	{{end}}


### PR DESCRIPTION
As discuessed in https://github.com/go-gitea/gitea/pull/24598/files#r1189290462

After:

Diff Page
<img width="1426" alt="Screen Shot 2023-05-10 at 10 44 48" src="https://github.com/go-gitea/gitea/assets/17645053/bc1a5f78-ec17-4ac2-8390-081a5fc059d1">

New PR Page
<img width="1428" alt="Screen Shot 2023-05-10 at 10 45 17" src="https://github.com/go-gitea/gitea/assets/17645053/ce94a28e-39d5-4534-9e78-c0edd4c7a339">

<img width="1432" alt="Screen Shot 2023-05-10 at 10 45 27" src="https://github.com/go-gitea/gitea/assets/17645053/047809e1-abb2-4c16-ae62-63b71094c1c7">

