### PR TITLE
Increase default LFS auth timeout from 20m to 24h

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -303,7 +303,7 @@ RUN_MODE = ; prod
 LFS_JWT_SECRET =
 ;;
 ;; LFS authentication validity period (in time.Duration), pushes taking longer than this may fail.
-;LFS_HTTP_AUTH_EXPIRY = 20m
+;LFS_HTTP_AUTH_EXPIRY = 24h
 ;;
 ;; Maximum allowed LFS file size in bytes (Set to 0 for no limit).
 ;LFS_MAX_FILE_SIZE = 0

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -364,7 +364,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `LFS_START_SERVER`: **false**: Enables Git LFS support.
 - `LFS_CONTENT_PATH`: **%(APP_DATA_PATH)s/lfs**: Default LFS content path. (if it is on local storage.) **DEPRECATED** use settings in `[lfs]`.
 - `LFS_JWT_SECRET`: **\<empty\>**: LFS authentication secret, change this a unique string.
-- `LFS_HTTP_AUTH_EXPIRY`: **20m**: LFS authentication validity period in time.Duration, pushes taking longer than this may fail.
+- `LFS_HTTP_AUTH_EXPIRY`: **24h**: LFS authentication validity period in time.Duration, pushes taking longer than this may fail.
 - `LFS_MAX_FILE_SIZE`: **0**: Maximum allowed LFS file size in bytes (Set to 0 for no limit).
 - `LFS_LOCKS_PAGING_NUM`: **50**: Maximum number of LFS Locks returned per page.
 

--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -45,7 +45,7 @@ func loadLFSFrom(rootCfg ConfigProvider) {
 		LFS.LocksPagingNum = 50
 	}
 
-	LFS.HTTPAuthExpiry = sec.Key("LFS_HTTP_AUTH_EXPIRY").MustDuration(20 * time.Minute)
+	LFS.HTTPAuthExpiry = sec.Key("LFS_HTTP_AUTH_EXPIRY").MustDuration(24 * time.Hour)
 
 	if LFS.StartServer {
 		LFS.JWTSecretBytes = make([]byte, 32)


### PR DESCRIPTION
According to the discussion with DanielGibson, the default "20m" seems too short. It would make LFS fail if the file is large / network is slow.


I think relaxing this timeout doesn't have side affect. So change the default value to 24h, IMO that should be long enough.

## :warning: BREAKING

If admins want the previous timeout, they should set the setting `[server].LFS_HTTP_AUTH_EXPIRY`.