### PR TITLE
Do not send "registration success email" for external auth sources

### DIFF
--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -13,7 +13,6 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web/middleware"
-	"code.gitea.io/gitea/services/mailer"
 
 	gouuid "github.com/google/uuid"
 )
@@ -171,8 +170,6 @@ func (r *ReverseProxy) newUser(req *http.Request) *user_model.User {
 		log.Error("CreateUser: %v", err)
 		return nil
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	return user
 }

--- a/services/auth/source/ldap/source_authenticate.go
+++ b/services/auth/source/ldap/source_authenticate.go
@@ -14,7 +14,6 @@ import (
 	auth_module "code.gitea.io/gitea/modules/auth"
 	"code.gitea.io/gitea/modules/util"
 	source_service "code.gitea.io/gitea/services/auth/source"
-	"code.gitea.io/gitea/services/mailer"
 	user_service "code.gitea.io/gitea/services/user"
 )
 
@@ -99,8 +98,6 @@ func (source *Source) Authenticate(user *user_model.User, userName, password str
 		if err != nil {
 			return user, err
 		}
-
-		mailer.SendRegisterNotifyMail(user)
 
 		if isAttributeSSHPublicKeySet && asymkey_model.AddPublicKeysBySource(user, source.authSource, sr.SSHPublicKey) {
 			if err := asymkey_model.RewriteAllPublicKeys(); err != nil {

--- a/services/auth/source/pam/source_authenticate.go
+++ b/services/auth/source/pam/source_authenticate.go
@@ -12,7 +12,6 @@ import (
 	"code.gitea.io/gitea/modules/auth/pam"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
-	"code.gitea.io/gitea/services/mailer"
 
 	"github.com/google/uuid"
 )
@@ -66,8 +65,6 @@ func (source *Source) Authenticate(user *user_model.User, userName, password str
 	if err := user_model.CreateUser(user, overwriteDefault); err != nil {
 		return user, err
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	return user, nil
 }

--- a/services/auth/source/smtp/source_authenticate.go
+++ b/services/auth/source/smtp/source_authenticate.go
@@ -12,7 +12,6 @@ import (
 	auth_model "code.gitea.io/gitea/models/auth"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/util"
-	"code.gitea.io/gitea/services/mailer"
 )
 
 // Authenticate queries if the provided login/password is authenticates against the SMTP server
@@ -81,8 +80,6 @@ func (source *Source) Authenticate(user *user_model.User, userName, password str
 	if err := user_model.CreateUser(user, overwriteDefault); err != nil {
 		return user, err
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	return user, nil
 }

--- a/services/auth/sspi_windows.go
+++ b/services/auth/sspi_windows.go
@@ -19,7 +19,6 @@ import (
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/services/auth/source/sspi"
-	"code.gitea.io/gitea/services/mailer"
 
 	gouuid "github.com/google/uuid"
 	"github.com/quasoft/websspi"
@@ -190,8 +189,6 @@ func (s *SSPI) newUser(username string, cfg *sspi.Source) (*user_model.User, err
 	if err := user_model.CreateUser(user, overwriteDefault); err != nil {
 		return nil, err
 	}
-
-	mailer.SendRegisterNotifyMail(user)
 
 	return user, nil
 }


### PR DESCRIPTION
Co-author: @pboguslawski 


"registration success email" is only used for notifying a user that "you have a new account now" when the account is created by admin manually.

When a user uses external auth source, they already knows that they has the account, so do not send such email.