### PR TITLE
Kd/fix redis unit test

### DIFF
--- a/.github/workflows/pull-db_test.yml
+++ b/.github/workflows/pull-db_test.yml
@@ -110,6 +110,16 @@ jobs:
           - "143:143"
           - "587:587"
           - "993:993"
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+        ports:
+          - 6379:6379
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/modules/queue/base_redis_test.go
+++ b/modules/queue/base_redis_test.go
@@ -56,7 +56,7 @@ func TestBaseRedis(t *testing.T) {
 	}()
 	if !waitRedisReady("redis://127.0.0.1:6379/0", 0) {
 		redisServer = redisServerCmd(t)
-		if redisServer == nil && os.Getenv("CI") != "" {
+		if redisServer == nil && os.Getenv("CI") == "" {
 			t.Skip("redis-server not found")
 			return
 		}


### PR DESCRIPTION
Replaces https://github.com/go-gitea/gitea/pull/24641

Currently, unit tests fail when run locally (unless users have minio instance running). This PR only requires redis unit tests if in CI. 

- Only run redis unit tests when `CI` env variable is set
- Add minio as a service in unit tests actions