### PR TITLE
fix: release page for empty or non-existing target

### DIFF
--- a/models/fixtures/release.yml
+++ b/models/fixtures/release.yml
@@ -108,3 +108,31 @@
   is_prerelease: false
   is_tag: false
   created_unix: 946684803
+
+- id: 9
+  repo_id: 57
+  publisher_id: 2
+  tag_name: "non-existing-target-branch"
+  lower_tag_name: "non-existing-target-branch"
+  target: "non-existing"
+  title: "non-existing-target-branch"
+  sha1: "cef06e48f2642cd0dc9597b4bea09f4b3f74aad6"
+  num_commits: 5
+  is_draft: false
+  is_prerelease: false
+  is_tag: false
+  created_unix: 946684803
+
+- id: 10
+  repo_id: 57
+  publisher_id: 2
+  tag_name: "empty-target-branch"
+  lower_tag_name: "empty-target-branch"
+  target: ""
+  title: "empty-target-branch"
+  sha1: "cef06e48f2642cd0dc9597b4bea09f4b3f74aad6"
+  num_commits: 5
+  is_draft: false
+  is_prerelease: false
+  is_tag: false
+  created_unix: 946684803

--- a/models/repo/release.go
+++ b/models/repo/release.go
@@ -71,6 +71,7 @@ type Release struct {
 	OriginalAuthorID int64 `xorm:"index"`
 	LowerTagName     string
 	Target           string
+	TargetBehind     string `xorm:"-"` // to handle non-existing or empty target
 	Title            string
 	Sha1             string `xorm:"VARCHAR(40)"`
 	NumCommits       int64

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -47,7 +47,7 @@
 								{{end}}
 								|
 								{{end}}
-								<span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}{{if .Target}}...{{.Target | PathEscapeSegments}}{{end}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" $.DefaultBranch}}</span>
+								<span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}...{{.TargetBehind | PathEscapeSegments}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" .TargetBehind}}</span>
 							</p>
 							<div class="download">
 							{{if $.Permission.CanRead $.UnitTypeCode}}
@@ -96,7 +96,7 @@
 									<span class="time">{{TimeSinceUnix .CreatedUnix $.locale}}</span>
 								{{end}}
 								{{if not .IsDraft}}
-									| <span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}...{{.Target | PathEscapeSegments}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" .Target}}</span>
+									| <span class="ahead"><a href="{{$.RepoLink}}/compare/{{.TagName | PathEscapeSegments}}...{{.TargetBehind | PathEscapeSegments}}">{{$.locale.Tr "repo.release.ahead.commits" .NumCommitsBehind | Str2html}}</a> {{$.locale.Tr "repo.release.ahead.target" .TargetBehind}}</span>
 								{{end}}
 							</p>
 							<div class="markup desc">

--- a/tests/integration/release_test.go
+++ b/tests/integration/release_test.go
@@ -143,10 +143,10 @@ func TestViewReleaseListNoLogin(t *testing.T) {
 
 	htmlDoc := NewHTMLParser(t, rsp.Body)
 	releases := htmlDoc.Find("#release-list li.ui.grid")
-	assert.Equal(t, 3, releases.Length())
+	assert.Equal(t, 5, releases.Length())
 
-	links := make([]string, 0, 3)
-	commitsToMain := make([]string, 0, 3)
+	links := make([]string, 0, 5)
+	commitsToMain := make([]string, 0, 5)
 	releases.Each(func(i int, s *goquery.Selection) {
 		link, exist := s.Find(".release-list-title a").Attr("href")
 		if !exist {
@@ -158,11 +158,15 @@ func TestViewReleaseListNoLogin(t *testing.T) {
 	})
 
 	assert.EqualValues(t, []string{
+		"/user2/repo-release/releases/tag/empty-target-branch",
+		"/user2/repo-release/releases/tag/non-existing-target-branch",
 		"/user2/repo-release/releases/tag/v2.0",
 		"/user2/repo-release/releases/tag/v1.1",
 		"/user2/repo-release/releases/tag/v1.0",
 	}, links)
 	assert.EqualValues(t, []string{
+		"1 commits", // like v1.1
+		"1 commits", // like v1.1
 		"0 commits",
 		"1 commits", // should be 3 commits ahead and 2 commits behind, but not implemented yet
 		"3 commits",


### PR DESCRIPTION
Backport #24470

Fixes #24145

---

To solve the bug, I added a "computed" `TargetBehind` field to the `Release` model, which indicates the target branch of a release. This is particularly useful if the target branch was deleted in the meantime (or is empty).

I also did a micro-optimization in `calReleaseNumCommitsBehind`. Instead of checking that a branch exists and then call `GetBranchCommit`, I immediately call `GetBranchCommit` and handle the `git.ErrNotExist` error.

This optimization is covered by the added unit test.

_contributed in the context of @forgejo_
