### PR TITLE
Created a new templates for email messages

### DIFF
--- a/modules/templates/util_string.go
+++ b/modules/templates/util_string.go
@@ -36,3 +36,11 @@ func (su *StringUtils) Join(a []string, sep string) string {
 func (su *StringUtils) EllipsisString(s string, max int) string {
 	return base.EllipsisString(s, max)
 }
+
+func (su *StringUtils) ReplaceAll(s string, old string, new string) string {
+	return strings.ReplaceAll(s, old, new)
+}
+
+func (su *StringUtils) TrimPrefix(s string, prefix string) string {
+	return strings.TrimPrefix(s, prefix)
+}

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -473,6 +473,21 @@ func (diff *Diff) LoadComments(ctx context.Context, issue *issues_model.Issue, c
 	return nil
 }
 
+func (diff *Diff) Lines() []*DiffLine {
+	if diff == nil {
+		return nil
+	}
+
+	resultLines := make([]*DiffLine, 0, diff.TotalAddition+diff.TotalDeletion)
+	for _, file := range diff.Files {
+		for _, section := range file.Sections {
+			resultLines = append(resultLines, section.Lines...)
+		}
+	}
+
+	return resultLines
+}
+
 const cmdDiffHead = "diff --git "
 
 // ParsePatch builds a Diff object from a io.Reader and some parameters.

--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -260,6 +260,7 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipient
 
 	mailMeta := map[string]interface{}{
 		"FallbackSubject": fallback,
+		"Context":         ctx,
 		"Body":            body,
 		"Link":            link,
 		"Issue":           ctx.Issue,

--- a/templates/mail/pull/default.tmpl
+++ b/templates/mail/pull/default.tmpl
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Browser</title>
+</head>
+
+<body style="font-family: wf_segoe-ui_normal, 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif, serif, EmojiFont;">
+<table class="container" style="
+		background-color: #F4F5F7;
+		width: 100%;
+		margin: auto;
+		border: 1px solid #DFE1E6;
+		border-collapse: collapse;
+		box-shadow: 0 0 0 1px #DFE1E6;
+		border-radius: 5px;"
+>
+	<tr>
+		<td>
+			{{template "v2/header" .}}
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<table style="
+							background-color: #FFFFFF;
+							margin: auto;
+							width: 100%;
+							padding: 10px 50px;"
+			>
+				<tr>
+					<td>
+						{{if eq .ActionName "close"}}
+							{{.locale.Tr "mail.issue.action.close" (Escape .Doer.Name) .Issue.Index | Str2html}}
+						{{else if eq .ActionName "reopen"}}
+							{{.locale.Tr "mail.issue.action.reopen" (Escape .Doer.Name) .Issue.Index | Str2html}}
+						{{else if eq .ActionName "merge"}}
+							{{.locale.Tr "mail.issue.action.merge" (Escape .Doer.Name) .Issue.Index (Escape .Issue.PullRequest.BaseBranch) | Str2html}}
+						{{else if eq .ActionName "approve"}}
+							{{.locale.Tr "mail.issue.action.approve" (Escape .Doer.Name) | Str2html}}
+						{{else if eq .ActionName "reject"}}
+							{{.locale.Tr "mail.issue.action.reject" (Escape .Doer.Name) | Str2html}}
+						{{else if eq .ActionName "review"}}
+							{{.locale.Tr "mail.issue.action.review" (Escape .Doer.Name) | Str2html}}
+						<!--TODO No found locale for comment, only for review-->
+						{{else if eq .ActionName "comment"}}
+							{{.locale.Tr "mail.issue.action.review" (Escape .Doer.Name) | Str2html}}
+						{{else if eq .ActionName "review_dismissed"}}
+							{{.locale.Tr "mail.issue.action.review_dismissed" (Escape .Doer.Name) (Escape .Comment.Review.Reviewer.Name) | Str2html}}
+						{{else if eq .ActionName "ready_for_review"}}
+							{{.locale.Tr "mail.issue.action.ready_for_review" (Escape .Doer.Name) | Str2html}}
+						{{end}}
+					</td>
+				</tr>
+				{{ if .Comment.Content }}
+				<tr>
+					<td>
+						{{ template "v2/comment" . }}
+					</td>
+				</tr>
+				{{ end }}
+				{{ if .Comment.Review }}
+				<tr>
+					<td>
+						{{ template "v2/review" . }}
+					</td>
+				</tr>
+				{{ end }}
+				<tr>
+					<td>
+						<table style="
+									background-color: #F2F2F2;
+									border-spacing: 0;
+									border-radius: 5px;
+									border: 1px solid #0000001d;
+									padding: 10px 15px;
+									margin-top: 30px;">
+							<tr>
+								<td>
+									<a href="{{ .Issue.HTMLURL }}" class="view-button" style="
+											cursor: pointer;
+											font-size: 14px;
+											text-decoration: none;
+											color: black;"
+									>
+										{{.locale.Tr "mail.view_it_on" AppName}}
+									</a>
+								</td>
+							</tr>
+						</table>
+
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+</body>
+
+</html>

--- a/templates/mail/v2/comment.tmpl
+++ b/templates/mail/v2/comment.tmpl
@@ -1,0 +1,48 @@
+<table class="block" style="
+				width: 100%;
+				border-spacing: 0;
+				margin-top: 20px;"
+>
+	{{ if .Comment.TreePath }}
+		<tr class="diff-header">
+			<td style="background-color: #F4F5F7;padding: 5px 20px;font-family: inherit">
+				<span style="font-family: inherit">{{ .Comment.TreePath }}</span>
+			</td>
+		</tr>
+	{{ end }}
+	<tr class="comment-line">
+		<td>
+			<table class="comment-block" style="
+							padding: 10px;
+							width: 100%;
+							border: 1px solid #DFE1E6;
+							border-radius: 5px;
+							border-spacing: 0;"
+			>
+				<tr>
+					<td style="width: 0;padding: 10px;vertical-align: top;">
+						<img src="{{ .Comment.Poster.AvatarLink $.Context }}" width="48" height="48" alt="avatar" style="margin: 5px;"/>
+					</td>
+					<td style="margin: 5px;">
+						<table>
+							<tr>
+								<td>
+									<span style="font-weight: bold;margin: 5px;font-family: inherit;">
+										{{ .Comment.Poster.Name }}
+									</span>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<span class="text" style="font-family: inherit">
+										{{ RenderMarkdownToHtml $.Context .Comment.Content }}
+									</span>
+								</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>

--- a/templates/mail/v2/header.tmpl
+++ b/templates/mail/v2/header.tmpl
@@ -1,0 +1,126 @@
+<table class="header" style="
+			background-color: #F4F5F7;
+			border-radius: 5px;
+			border-spacing: 5px;
+			padding: 10px 20px;"
+>
+	<tr>
+		<td style="vertical-align: middle; text-align: center; padding: 0 5px;">
+			{{ $avatarLink := .Issue.Repo.AvatarLink $.Context }}
+			{{ if $avatarLink }}
+			<img src="{{ $avatarLink }}" alt="repo icon" width="36" height="36" style="margin: auto;">
+			{{ end }}
+		</td>
+		<td style="padding-right: 20px;">
+			<h1 style="
+					font-size: 20px;
+					font-weight: normal;
+					font-family: inherit;
+					margin: auto;
+					display: flex;
+					flex-direction: row;"
+			>
+				<a href="{{ .Issue.HTMLURL }}" style="text-decoration: none;color: black;"
+				>
+					{{ .Issue.Title }}
+				</a>
+			</h1>
+		</td>
+		<td>
+			{{ if .Issue.IsClosed }}
+			<table style="
+								font-family: inherit;
+								background-color: #CA402D;
+								padding: 2px 10px;
+								border-radius: 5px;
+								font-weight: bold;"
+			>
+				<tr>
+					<td style="text-align: center">{{svg "octicon-issue-closed"}}</td>
+					<td style="text-align: center">
+						<span style="margin-left: 10px;color: white;">{{$.locale.Tr "repo.issues.closed_title"}}</span>
+					</td>
+				</tr>
+			</table>
+			{{ else if .Issue.IsPull }}
+				{{ if .Issue.PullRequest.HasMerged }}
+					<table style="
+										font-family: inherit;
+										background-color: #9742C4;
+										padding: 2px 10px;
+										border-radius: 5px;
+										font-weight: bold;"
+					>
+						<tr>
+							<td style="text-align: center">{{svg "octicon-git-merge" 16}}</td>
+							<td style="text-align: center">
+								<span style="margin-left: 10px;color: white;">
+									{{if eq .Issue.PullRequest.Status 3}}{{$.locale.Tr "repo.pulls.manually_merged"}}{{else}}{{$.locale.Tr "repo.pulls.merged"}}{{end}}
+								</span>
+							</td>
+						</tr>
+					</table>
+				{{ else if .Issue.PullRequest.IsWorkInProgress }}
+					<table style="
+										font-family: inherit;
+										background-color: #707070;
+										padding: 2px 10px;
+										border-radius: 5px;
+										font-weight: bold;"
+					>
+						<tr>
+							<td style="text-align: center">{{svg "octicon-git-pull-request-draft"}}</td>
+							<td style="text-align: center">
+								<span style="margin-left: 10px;color: white;">{{$.locale.Tr "repo.issues.draft_title"}}</span>
+							</td>
+						</tr>
+					</table>
+				{{ else }}
+					<table style="
+									font-family: inherit;
+									background-color: #57B64F;
+									padding: 2px 10px;
+									border-radius: 5px;
+									font-weight: bold;"
+					>
+						<tr>
+							<td style="text-align: center">{{svg "octicon-git-pull-request"}}</td>
+							<td style="text-align: center">
+								<span style="margin-left: 10px;color: white;">{{$.locale.Tr "repo.issues.open_title"}}</span>
+							</td>
+						</tr>
+					</table>
+				{{ end }}
+			{{ else }}
+			<table style="
+							font-family: inherit;
+							background-color: #57B64F;
+							padding: 2px 10px;
+							border-radius: 5px;
+							font-weight: bold;"
+			>
+				<tr>
+					<td style="text-align: center">{{svg "octicon-issue-opened"}}</td>
+					<td style="text-align: center">
+						<span style="margin-left: 10px;color: white;">{{$.locale.Tr "repo.issues.open_title"}}</span>
+					</td>
+				</tr>
+			</table>
+			{{ end }}
+		</td>
+	</tr>
+	<tr>
+		<td colspan="3">
+			<h1 style="
+					margin: 5px 20px;
+					font-family: inherit;
+					font-size: 20px;
+					font-weight: normal;"
+			>
+				<a href="{{ .Issue.Repo.HTMLURL }}" style="text-decoration: none;color: black;">
+					{{ .Issue.Repo.FullName }}
+				</a>
+			</h1>
+		</td>
+	</tr>
+</table>

--- a/templates/mail/v2/review.tmpl
+++ b/templates/mail/v2/review.tmpl
@@ -1,0 +1,115 @@
+{{ range $file_path, $commentsMap := .Comment.Review.CodeComments }}
+	{{ range $_, $comments := $commentsMap }}
+		<table class="block" style="
+						width: 100%;
+						border-radius: 5px;
+						border-spacing: 0;
+						border: 1px solid #DFE1E6;
+						margin-top: 20px;"
+		>
+			<tr class="diff-header">
+				<td colspan="4"
+						style="
+							background-color: #F4F5F7;
+							padding: 5px 20px;
+							font-family: inherit"
+				>
+					<span style="font-family: inherit">{{ $file_path }}</span>
+				</td>
+			</tr>
+			{{ range $_, $comment := $comments }}
+				{{ $patchDiff := CommentMustAsDiff $comment }}
+				{{ $patchLines := $patchDiff.Lines }}
+				{{ range $_, $patchLine := $patchLines }}
+					{{ if eq $patchLine.Type 4 }}  {{ continue }} {{ end }}
+					<tr class="diff"
+							style="
+								font-family: inherit;
+								background-color: {{if eq $patchLine.Type 2 }}#EAFEEE{{ else if eq $patchLine.Type 3 }}#FCEFF0{{else}}#FFFFFF{{ end }};"
+					>
+						<td class="line-number"
+								style="
+									font-family: inherit;
+									padding: 5px;
+									margin: 0;
+									text-align: center;
+									width: 50px;"
+						>
+							{{ if gt $patchLine.LeftIdx 0 }}{{ $patchLine.LeftIdx }}{{end}}
+						</td>
+						<td class="line-number"
+								style="
+									font-family: inherit;
+									padding: 5px;
+									margin: 0;
+									text-align: center;
+									width: 50px;"
+						>
+							{{ if gt $patchLine.RightIdx 0 }}{{ $patchLine.RightIdx }}{{end}}
+						</td>
+						<td class="lines-type-marker"
+								style="
+									font-family: inherit;
+									padding: 5px;
+									margin: 0;
+									text-align: center;
+									width: 20px;"
+						>
+							{{if eq $patchLine.Type 2 }}+{{ else if eq $patchLine.Type 3 }}-{{ end }}
+						</td>
+						<td style="
+									font-family: inherit;
+									padding: 5px;
+									display: grid;
+									margin: 0;"
+						>
+							<span style="margin: 0;overflow:hidden;text-overflow: ellipsis;white-space: nowrap;">
+								{{ $content := StringUtils.ReplaceAll $patchLine.Content "\t" "&emsp;&emsp;" }}
+								{{ if eq $patchLine.Type 2 }}
+									{{ StringUtils.TrimPrefix $content "+" | Str2html }}
+								{{ else if eq $patchLine.Type 3 }}
+									{{ StringUtils.TrimPrefix $content "-" | Str2html }}
+								{{ end }}
+							</span>
+						</td>
+					</tr>
+				{{ end }}
+				<tr class="comment-line">
+					<td colspan="4">
+						<table class="comment-block" style="
+							padding: 10px;
+							width: 100%;
+							border-radius: 5px;
+							border-spacing: 0;
+							border-collapse: collapse;"
+						>
+							<tr>
+								<td style="width: 0;padding: 5px;vertical-align: top;border-radius: 5px;">
+									<img src="{{ $comment.Poster.AvatarLink $.Context }}" width="48" height="48" alt="avatar" style="margin: 5px;"/>
+								</td>
+								<td style="margin: 5px;">
+									<table>
+										<tr>
+											<td>
+									<span style="font-weight: bold;font-family: inherit;">
+										{{ $comment.Poster.Name }}
+									</span>
+											</td>
+										</tr>
+										<tr>
+											<td>
+									<span class="text" style="font-family: inherit">
+										{{ RenderMarkdownToHtml $.Context $comment.Content }}
+									</span>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+			{{end}}
+		</table>
+	{{ end }}
+{{ end }}


### PR DESCRIPTION
Signed-off-by: Aleksandr Tulskiy <alex.tulski@gmail.com>

---
#24219
I have made new templates for notifications in the mail. When choosing a design, I was inspired by Bitbucket.
At the moment, templates are ready only for actions from Pull requests and issues.

In issue, it was proposed to do it using mjml, but this is a js framework, and in go it has [low performance](https://github.com/Boostport/mjml-go#benchmarks).
I tried to make the templates as simple as possible so that they are displayed correctly on different email clients. I used a tabular layout with inline styles for this. I tested the template on gmail, yandex, outlook.

Below is an example for comparison

Before:
![image_2023-05-03_21-32-19](https://github.com/go-gitea/gitea/assets/62292054/8c499b8a-7367-4d2a-9116-17436bb64bd8)
After:
![image_2023-05-11_21-05-15](https://github.com/go-gitea/gitea/assets/62292054/639fe4ce-ce08-48d1-9435-08aeaadc96fe)
