### PR TITLE
Remove highlight in repo list

### DIFF
--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -171,10 +171,6 @@
   border-bottom: 1px solid var(--color-secondary);
 }
 
-.feeds .list ul li.private {
-  background-color: var(--color-box-body-highlight);
-}
-
 .feeds .list ul li .repo-list-link {
   padding: 6px 1em;
   display: block;

--- a/web_src/js/components/DashboardRepoList.vue
+++ b/web_src/js/components/DashboardRepoList.vue
@@ -70,7 +70,7 @@
       </div>
       <div v-if="repos.length" class="ui attached table segment gt-rounded-bottom">
         <ul class="repo-owner-name-list">
-          <li v-for="repo in repos" :class="{'private': repo.private || repo.internal}" :key="repo.id">
+          <li v-for="repo in repos" :key="repo.id">
             <a class="repo-list-link gt-df gt-ac gt-sb" :href="repo.link">
               <div class="item-name gt-df gt-ac gt-f1">
                 <svg-icon :name="repoIcon(repo)" :size="16" class-name="gt-mr-2"/>


### PR DESCRIPTION
Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/aa5e9f1f-48ff-4e9f-a693-23a34e390760)
After:
![image](https://github.com/go-gitea/gitea/assets/18380374/a4b58a6c-4ea3-4ded-80df-2e650d39a1d3)

private or internal repos have `lock` icon, no need to add highlights to them.