### PR TITLE
Make testlogger output "TestLogger" prefix

### DIFF
--- a/modules/testlogger/testlogger.go
+++ b/modules/testlogger/testlogger.go
@@ -58,7 +58,9 @@ func (w *testLoggerWriterCloser) Write(p []byte) (int, error) {
 	}
 
 	if t == nil || *t == nil {
-		return fmt.Fprintf(os.Stdout, "??? [Unknown Test] %s\n", p)
+		// if there is no running test, the log message should be outputted to console, to avoid losing important information.
+		// the "???" prefix is used to match the "===" and "+++" in PrintCurrentTest
+		return fmt.Fprintf(os.Stdout, "??? [TestLogger] %s\n", p)
 	}
 
 	defer func() {


### PR DESCRIPTION
Make testlogger output "TestLogger" prefix instead of "Unknown Test" when there is no running test case.