### PR TITLE
Optimize actions list by removing an unnecessary `git` call

### DIFF
--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -61,12 +61,7 @@ func List(ctx *context.Context) {
 		ctx.Error(http.StatusInternalServerError, err.Error())
 		return
 	} else if !empty {
-		defaultBranch, err := ctx.Repo.GitRepo.GetDefaultBranch()
-		if err != nil {
-			ctx.Error(http.StatusInternalServerError, err.Error())
-			return
-		}
-		commit, err := ctx.Repo.GitRepo.GetBranchCommit(defaultBranch)
+		commit, err := ctx.Repo.GitRepo.GetBranchCommit(ctx.Repo.Repository.DefaultBranch)
 		if err != nil {
 			ctx.Error(http.StatusInternalServerError, err.Error())
 			return


### PR DESCRIPTION
We already have the default branch so we don't need to make a `git` call to get it.
