### PR TITLE
Update packages overview page

### DIFF
--- a/docs/content/doc/usage/packages/overview.en-us.md
+++ b/docs/content/doc/usage/packages/overview.en-us.md
@@ -36,6 +36,7 @@ The following package managers are currently supported:
 | [Container]({{< relref "doc/usage/packages/container.en-us.md" >}}) | - | any OCI compliant client |
 | [Debian]({{< relref "doc/usage/packages/debian.en-us.md" >}}) | - | `apt` |
 | [Generic]({{< relref "doc/usage/packages/generic.en-us.md" >}}) | - | any HTTP client |
+| [Go]({{< relref "doc/usage/packages/go.en-us.md" >}}) | Go | `go` |
 | [Helm]({{< relref "doc/usage/packages/helm.en-us.md" >}}) | - | any HTTP client, `cm-push` |
 | [Maven]({{< relref "doc/usage/packages/maven.en-us.md" >}}) | Java | `mvn`, `gradle` |
 | [npm]({{< relref "doc/usage/packages/npm.en-us.md" >}}) | JavaScript | `npm`, `yarn`, `pnpm` |


### PR DESCRIPTION
Add missed Go package reference to packages overview page