### PR TITLE
Unification of registration fields order

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -322,6 +322,10 @@
 							<label for="admin_name">{{.locale.Tr "install.admin_name"}}</label>
 							<input id="admin_name" name="admin_name" value="{{.admin_name}}">
 						</div>
+						<div class="inline field {{if .Err_AdminEmail}}error{{end}}">
+							<label for="admin_email">{{.locale.Tr "install.admin_email"}}</label>
+							<input id="admin_email" name="admin_email" type="email" value="{{.admin_email}}">
+						</div>
 						<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
 							<label for="admin_passwd">{{.locale.Tr "install.admin_password"}}</label>
 							<input id="admin_passwd" name="admin_passwd" type="password" autocomplete="new-password" value="{{.admin_passwd}}">
@@ -329,10 +333,6 @@
 						<div class="inline field {{if .Err_AdminPasswd}}error{{end}}">
 							<label for="admin_confirm_passwd">{{.locale.Tr "install.confirm_password"}}</label>
 							<input id="admin_confirm_passwd" name="admin_confirm_passwd" autocomplete="new-password" type="password" value="{{.admin_confirm_passwd}}">
-						</div>
-						<div class="inline field {{if .Err_AdminEmail}}error{{end}}">
-							<label for="admin_email">{{.locale.Tr "install.admin_email"}}</label>
-							<input id="admin_email" name="admin_email" type="email" value="{{.admin_email}}">
 						</div>
 					</details>
 


### PR DESCRIPTION
Place email filed in same order on all user creation pages.

Registration on installation page (before):
![image](https://github.com/go-gitea/gitea/assets/1969460/b0e6c8e5-4f6f-4225-b365-946036aa6490)

Registration on main page:
![image](https://github.com/go-gitea/gitea/assets/1969460/8bd43ab7-e706-4088-8f64-a61ca5c90d1b)

Create user account on site administration page:  
![image](https://github.com/go-gitea/gitea/assets/1969460/ab0a90c4-748d-43aa-b267-432d529888f0)

Registration on installation page (after):
![image](https://github.com/go-gitea/gitea/assets/1969460/1f5e29c2-988c-46d2-960b-11b12789d7a7)


