### PR TITLE
Fix team members API endpoint pagination

### DIFF
--- a/models/organization/team_user.go
+++ b/models/organization/team_user.go
@@ -63,8 +63,8 @@ func GetTeamMembers(ctx context.Context, opts *SearchMembersOptions) ([]*user_mo
 				Where(builder.Eq{"team_id": opts.TeamID}),
 		)
 	}
-	if opts.PageSize > 0 && opts.Page > -1 {
-		sess = sess.Limit(opts.PageSize, opts.Page*opts.PageSize)
+	if opts.PageSize > 0 && opts.Page > 0 {
+		sess = sess.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize)
 	}
 	if err := sess.OrderBy("full_name, name").Find(&members); err != nil {
 		return nil, err


### PR DESCRIPTION
Now it's 1-based instead of 0-based

- Fixes #24747

### Before
![image](https://github.com/go-gitea/gitea/assets/20454870/9b58ecfa-666c-4b78-bd0f-93233efeecbd)

### After
![image](https://github.com/go-gitea/gitea/assets/20454870/103b767a-e02e-4473-9f9f-5a676a61c174)

## :warning: BREAKING :warning:
Previous API consumers may have relied on the 0-based pagination of this endpoint. The page numbering now starts at 1, as documented.