### PR TITLE
Revert "Fix missed table name on iterate lfs meta objects"

### DIFF
--- a/models/git/lfs.go
+++ b/models/git/lfs.go
@@ -390,7 +390,7 @@ func IterateLFSMetaObjectsForRepo(ctx context.Context, repoID int64, f func(cont
 
 	for {
 		beans := make([]*CountLFSMetaObject, 0, batchSize)
-		sess := engine.Table("lfs_meta_object").Select("`lfs_meta_object`.*, COUNT(`l1`.oid) AS `count`").
+		sess := engine.Select("`lfs_meta_object`.*, COUNT(`l1`.oid) AS `count`").
 			Join("INNER", "`lfs_meta_object` AS l1", "`lfs_meta_object`.oid = `l1`.oid").
 			Where("`lfs_meta_object`.repository_id = ?", repoID)
 		if !opts.OlderThan.IsZero() {


### PR DESCRIPTION
This reverts commit 3364092013aa4d5d27ad02806b0f47967c04de18.

It was accidentally pushed to `main` without a review.