### PR TITLE
Add FORCE_VISIBILITY config value to force new repos to be public or private

### DIFF
--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -83,7 +83,7 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
    but some users report that only `sh` is available.
 - `DETECTED_CHARSETS_ORDER`: **UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr**: Tie-break order of detected charsets - if the detected charsets have equal confidence, charsets earlier in the list will be chosen in preference to those later. Adding `defaults` will place the unnamed charsets at that point.
 - `ANSI_CHARSET`: **\<empty\>**: Default ANSI charset to override non-UTF-8 charsets to.
-- `FORCE_PRIVATE`: **false**: Force every new repository to be private or public.
+- `FORCE_PRIVATE`: **off**: Force every new repository to be private or public.
    \[off, private, public\]
 - `DEFAULT_PRIVATE`: **last**: Default private when creating a new repository.
    \[last, private, public\]

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -83,7 +83,8 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
    but some users report that only `sh` is available.
 - `DETECTED_CHARSETS_ORDER`: **UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr**: Tie-break order of detected charsets - if the detected charsets have equal confidence, charsets earlier in the list will be chosen in preference to those later. Adding `defaults` will place the unnamed charsets at that point.
 - `ANSI_CHARSET`: **\<empty\>**: Default ANSI charset to override non-UTF-8 charsets to.
-- `FORCE_PRIVATE`: **false**: Force every new repository to be private.
+- `FORCE_PRIVATE`: **false**: Force every new repository to be private or public.
+   \[off, private, public\]
 - `DEFAULT_PRIVATE`: **last**: Default private when creating a new repository.
    \[last, private, public\]
 - `DEFAULT_PUSH_CREATE_PRIVATE`: **true**: Default private when creating a new repository with push-to-create.

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -83,6 +83,7 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
    but some users report that only `sh` is available.
 - `DETECTED_CHARSETS_ORDER`: **UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr**: Tie-break order of detected charsets - if the detected charsets have equal confidence, charsets earlier in the list will be chosen in preference to those later. Adding `defaults` will place the unnamed charsets at that point.
 - `ANSI_CHARSET`: **\<empty\>**: Default ANSI charset to override non-UTF-8 charsets to.
+- `FORCE_PRIVATE`: **false**: Force every new repository to be private. **DEPRECATED** set `FORCE_VISIBILITY` to private.
 - `FORCE_VISIBILITY`: **off**: Force every new repository to be private or public.
    \[off, private, public\]
 - `DEFAULT_PRIVATE`: **last**: Default private when creating a new repository.

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -83,7 +83,7 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
    but some users report that only `sh` is available.
 - `DETECTED_CHARSETS_ORDER`: **UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE, ISO-8859, windows-1252, ISO-8859, windows-1250, ISO-8859, ISO-8859, ISO-8859, windows-1253, ISO-8859, windows-1255, ISO-8859, windows-1251, windows-1256, KOI8-R, ISO-8859, windows-1254, Shift_JIS, GB18030, EUC-JP, EUC-KR, Big5, ISO-2022, ISO-2022, ISO-2022, IBM424_rtl, IBM424_ltr, IBM420_rtl, IBM420_ltr**: Tie-break order of detected charsets - if the detected charsets have equal confidence, charsets earlier in the list will be chosen in preference to those later. Adding `defaults` will place the unnamed charsets at that point.
 - `ANSI_CHARSET`: **\<empty\>**: Default ANSI charset to override non-UTF-8 charsets to.
-- `FORCE_PRIVATE`: **off**: Force every new repository to be private or public.
+- `FORCE_VISIBILITY`: **off**: Force every new repository to be private or public.
    \[off, private, public\]
 - `DEFAULT_PRIVATE`: **last**: Default private when creating a new repository.
    \[last, private, public\]

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -28,7 +28,7 @@ var (
 		DetectedCharsetsOrder                   []string
 		DetectedCharsetScore                    map[string]int `ini:"-"`
 		AnsiCharset                             string
-		ForcePrivate                            bool
+		ForcePrivate                            string
 		DefaultPrivate                          string
 		DefaultPushCreatePrivate                bool
 		MaxCreationLimit                        int
@@ -146,7 +146,7 @@ var (
 		},
 		DetectedCharsetScore:                    map[string]int{},
 		AnsiCharset:                             "",
-		ForcePrivate:                            false,
+		ForcePrivate:                            "off",
 		DefaultPrivate:                          RepoCreatingLastUserVisibility,
 		DefaultPushCreatePrivate:                true,
 		MaxCreationLimit:                        -1,

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -28,7 +28,7 @@ var (
 		DetectedCharsetsOrder                   []string
 		DetectedCharsetScore                    map[string]int `ini:"-"`
 		AnsiCharset                             string
-		ForcePrivate                            string
+		ForceVisibility                         string
 		DefaultPrivate                          string
 		DefaultPushCreatePrivate                bool
 		MaxCreationLimit                        int
@@ -146,7 +146,7 @@ var (
 		},
 		DetectedCharsetScore:                    map[string]int{},
 		AnsiCharset:                             "",
-		ForcePrivate:                            "off",
+		ForceVisibility:                         "off",
 		DefaultPrivate:                          RepoCreatingLastUserVisibility,
 		DefaultPushCreatePrivate:                true,
 		MaxCreationLimit:                        -1,

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -316,6 +316,12 @@ func loadRepositoryFrom(rootCfg ConfigProvider) {
 		Repository.DisabledRepoUnits = append(Repository.DisabledRepoUnits, "repo.actions")
 	}
 
+	// for compatibility with force private
+	if sec.Key("FORCE_PRIVATE").MustBool(false) && sec.Key("FORCE_VISIBILITY").MustString("off") == "off" {
+		Repository.ForceVisibility = "private"
+		log.Error("FORCE_PRIVATE is deprecated! Please set FORCE_VISIBILITY to private.")
+	}
+
 	// Handle default trustmodel settings
 	Repository.Signing.DefaultTrustModel = strings.ToLower(strings.TrimSpace(Repository.Signing.DefaultTrustModel))
 	if Repository.Signing.DefaultTrustModel == "default" {

--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -457,7 +457,8 @@ lang_select_error=Wähle eine Sprache aus der Liste aus.
 username_been_taken=Der Benutzername ist bereits vergeben.
 username_change_not_local_user=Nicht-lokale Benutzer dürfen ihren Nutzernamen nicht ändern.
 repo_name_been_taken=Der Repository-Name wird schon verwendet.
-repository_force_private=Privat erzwingen ist aktiviert: Private Repositorys können nicht veröffentlicht werden.
+repository_force_private=Privat erzwingen ist auf privat gesetzt: Private Repositorys können nicht veröffentlicht werden.
+repository_force_public=Privat erzwingen ist auf öffentlich gesetzt: Öffentliche Repositorys können nicht privatisiert werden.
 repository_files_already_exist=Dateien für dieses Repository sind bereits vorhanden. Kontaktiere den Systemadministrator.
 repository_files_already_exist.adopt=Dateien für dieses Repository existieren bereits und können nur übernommen werden.
 repository_files_already_exist.delete=Dateien für dieses Repository sind bereits vorhanden. Du must sie löschen.
@@ -806,6 +807,7 @@ visibility=Sichtbarkeit
 visibility_description=Nur der Besitzer oder Organisationsmitglieder mit entsprechender Berechtigung, werden in der Lage sein, es zu sehen.
 visibility_helper=In privates Repository umwandeln
 visibility_helper_forced=Auf dieser Gitea-Instanz können nur private Repositories angelegt werden.
+visibility_helper_forced_public=Es können nur öffentliche Repositories angelegt werden.
 visibility_fork_helper=(Eine Änderung dieses Wertes wirkt sich auf alle Forks aus)
 clone_helper=Benötigst du Hilfe beim Klonen? Öffne die <a target="_blank" rel="noopener noreferrer" href="%s">Hilfe</a>.
 fork_repo=Repository forken

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -530,7 +530,8 @@ username_been_taken = The username is already taken.
 username_change_not_local_user = Non-local users are not allowed to change their username.
 username_has_not_been_changed = Username has not been changed
 repo_name_been_taken = The repository name is already used.
-repository_force_private = Force Private is enabled: private repositories cannot be made public.
+repository_force_private = Force Private is set to private: private repositories cannot be made public.
+repository_force_public = Force Private is set to public: public repositories cannot be made private.
 repository_files_already_exist = Files already exist for this repository. Contact the system administrator.
 repository_files_already_exist.adopt = Files already exist for this repository and can only be Adopted.
 repository_files_already_exist.delete = Files already exist for this repository. You must delete them.
@@ -913,6 +914,7 @@ visibility = Visibility
 visibility_description = Only the owner or the organization members if they have rights, will be able to see it.
 visibility_helper = Make Repository Private
 visibility_helper_forced = Your site administrator forces new repositories to be private.
+visibility_helper_forced_public = Your site administrator forces new repositories to be public.
 visibility_fork_helper = (Changing this will affect all forks.)
 clone_helper = Need help cloning? Visit <a target="_blank" rel="noopener noreferrer" href="%s">Help</a>.
 fork_repo = Fork Repository

--- a/routers/api/v1/repo/migrate.go
+++ b/routers/api/v1/repo/migrate.go
@@ -143,7 +143,7 @@ func Migrate(ctx *context.APIContext) {
 		CloneAddr:      remoteAddr,
 		RepoName:       form.RepoName,
 		Description:    form.Description,
-		Private:        form.Private || setting.Repository.ForcePrivate,
+		Private:        getPrivate(form.Private),
 		Mirror:         form.Mirror,
 		LFS:            form.LFS,
 		LFSEndpoint:    form.LFSEndpoint,
@@ -269,5 +269,15 @@ func handleRemoteAddrError(ctx *context.APIContext, err error) {
 		}
 	} else {
 		ctx.Error(http.StatusInternalServerError, "ParseRemoteAddr", err)
+	}
+}
+
+func getPrivate(private bool) bool {
+	if (setting.Repository.ForcePrivate == "private" ){
+		return true
+	} else if (setting.Repository.ForcePrivate == "public" ){
+		return false
+	} else {
+		return private
 	}
 }

--- a/routers/api/v1/repo/migrate.go
+++ b/routers/api/v1/repo/migrate.go
@@ -273,9 +273,9 @@ func handleRemoteAddrError(ctx *context.APIContext, err error) {
 }
 
 func getPrivate(private bool) bool {
-	if (setting.Repository.ForcePrivate == "private" ){
+	if setting.Repository.ForcePrivate == "private" {
 		return true
-	} else if (setting.Repository.ForcePrivate == "public" ){
+	} else if setting.Repository.ForcePrivate == "public" {
 		return false
 	} else {
 		return private

--- a/routers/api/v1/repo/migrate.go
+++ b/routers/api/v1/repo/migrate.go
@@ -273,9 +273,9 @@ func handleRemoteAddrError(ctx *context.APIContext, err error) {
 }
 
 func getPrivate(private bool) bool {
-	if setting.Repository.ForcePrivate == "private" {
+	if setting.Repository.ForceVisibility == "private" {
 		return true
-	} else if setting.Repository.ForcePrivate == "public" {
+	} else if setting.Repository.ForceVisibility == "public" {
 		return false
 	} else {
 		return private

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -691,10 +691,17 @@ func updateBasicProperties(ctx *context.APIContext, opts api.EditRepoOption) err
 		}
 
 		visibilityChanged = repo.IsPrivate != *opts.Private
-		// when ForcePrivate enabled, you could change public repo to private, but only admin users can change private to public
-		if visibilityChanged && setting.Repository.ForcePrivate && !*opts.Private && !ctx.Doer.IsAdmin {
+		// when ForcePrivate is set to private, you could change public repo to private, but only admin users can change private to public
+		if visibilityChanged && setting.Repository.ForcePrivate == "private" && !*opts.Private && !ctx.Doer.IsAdmin {
 			err := fmt.Errorf("cannot change private repository to public")
-			ctx.Error(http.StatusUnprocessableEntity, "Force Private enabled", err)
+			ctx.Error(http.StatusUnprocessableEntity, "Force Private is set to private", err)
+			return err
+		}
+
+		// when ForcePrivate is set to public, you could change private repo to public, but only admin users can change public to private
+		if visibilityChanged && setting.Repository.ForcePrivate == "public" && *opts.Private && !ctx.Doer.IsAdmin {
+			err := fmt.Errorf("cannot change public repository to private")
+			ctx.Error(http.StatusUnprocessableEntity, "Force Private is set to public", err)
 			return err
 		}
 

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -691,15 +691,15 @@ func updateBasicProperties(ctx *context.APIContext, opts api.EditRepoOption) err
 		}
 
 		visibilityChanged = repo.IsPrivate != *opts.Private
-		// when ForcePrivate is set to private, you could change public repo to private, but only admin users can change private to public
-		if visibilityChanged && setting.Repository.ForcePrivate == "private" && !*opts.Private && !ctx.Doer.IsAdmin {
+		// when ForceVisibility is set to private, you could change public repo to private, but only admin users can change private to public
+		if visibilityChanged && setting.Repository.ForceVisibility == "private" && !*opts.Private && !ctx.Doer.IsAdmin {
 			err := fmt.Errorf("cannot change private repository to public")
 			ctx.Error(http.StatusUnprocessableEntity, "Force Private is set to private", err)
 			return err
 		}
 
-		// when ForcePrivate is set to public, you could change private repo to public, but only admin users can change public to private
-		if visibilityChanged && setting.Repository.ForcePrivate == "public" && *opts.Private && !ctx.Doer.IsAdmin {
+		// when ForceVisibility is set to public, you could change private repo to public, but only admin users can change public to private
+		if visibilityChanged && setting.Repository.ForceVisibility == "public" && *opts.Private && !ctx.Doer.IsAdmin {
 			err := fmt.Errorf("cannot change public repository to private")
 			ctx.Error(http.StatusUnprocessableEntity, "Force Private is set to public", err)
 			return err

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -277,9 +277,9 @@ func MigrateCancelPost(ctx *context.Context) {
 }
 
 func getPrivate(private bool) bool {
-	if (setting.Repository.ForcePrivate == "private" ){
+	if setting.Repository.ForcePrivate == "private" {
 		return true
-	} else if (setting.Repository.ForcePrivate == "public" ){
+	} else if setting.Repository.ForcePrivate == "public" {
 		return false
 	} else {
 		return private

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -208,7 +208,7 @@ func MigratePost(ctx *context.Context) {
 		CloneAddr:      remoteAddr,
 		RepoName:       form.RepoName,
 		Description:    form.Description,
-		Private:        form.Private || setting.Repository.ForcePrivate,
+		Private:        getPrivate(form.Private),
 		Mirror:         form.Mirror,
 		LFS:            form.LFS,
 		LFSEndpoint:    form.LFSEndpoint,
@@ -251,7 +251,7 @@ func setMigrationContextData(ctx *context.Context, serviceType structs.GitServic
 	ctx.Data["Title"] = ctx.Tr("new_migrate")
 
 	ctx.Data["LFSActive"] = setting.LFS.StartServer
-	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["DisableNewPullMirrors"] = setting.Mirror.DisableNewPull
 
 	// Plain git should be first
@@ -274,4 +274,14 @@ func MigrateCancelPost(ctx *context.Context) {
 		}
 	}
 	ctx.Redirect(ctx.Repo.Repository.Link())
+}
+
+func getPrivate(private bool) bool {
+	if (setting.Repository.ForcePrivate == "private" ){
+		return true
+	} else if (setting.Repository.ForcePrivate == "public" ){
+		return false
+	} else {
+		return private
+	}
 }

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -251,7 +251,7 @@ func setMigrationContextData(ctx *context.Context, serviceType structs.GitServic
 	ctx.Data["Title"] = ctx.Tr("new_migrate")
 
 	ctx.Data["LFSActive"] = setting.LFS.StartServer
-	ctx.Data["ForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForceVisibility"] = setting.Repository.ForceVisibility
 	ctx.Data["DisableNewPullMirrors"] = setting.Mirror.DisableNewPull
 
 	// Plain git should be first
@@ -277,9 +277,9 @@ func MigrateCancelPost(ctx *context.Context) {
 }
 
 func getPrivate(private bool) bool {
-	if setting.Repository.ForcePrivate == "private" {
+	if setting.Repository.ForceVisibility == "private" {
 		return true
-	} else if setting.Repository.ForcePrivate == "public" {
+	} else if setting.Repository.ForceVisibility == "public" {
 		return false
 	} else {
 		return private

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -156,7 +156,7 @@ func Create(ctx *context.Context) {
 	ctx.Data["Readmes"] = repo_module.Readmes
 	ctx.Data["readme"] = "Default"
 	ctx.Data["private"] = getRepoPrivate(ctx)
-	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["default_branch"] = setting.Repository.DefaultBranch
 
 	ctxUser := checkContextUser(ctx, ctx.FormInt64("org"))
@@ -281,7 +281,7 @@ func CreatePost(ctx *context.Context) {
 			IssueLabels:   form.IssueLabels,
 			License:       form.License,
 			Readme:        form.Readme,
-			IsPrivate:     form.Private || setting.Repository.ForcePrivate,
+			IsPrivate:     false,
 			DefaultBranch: form.DefaultBranch,
 			AutoInit:      form.AutoInit,
 			IsTemplate:    form.Template,

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -281,7 +281,7 @@ func CreatePost(ctx *context.Context) {
 			IssueLabels:   form.IssueLabels,
 			License:       form.License,
 			Readme:        form.Readme,
-			IsPrivate:     false,
+			IsPrivate:     getPrivate(form.Private),
 			DefaultBranch: form.DefaultBranch,
 			AutoInit:      form.AutoInit,
 			IsTemplate:    form.Template,

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -156,7 +156,7 @@ func Create(ctx *context.Context) {
 	ctx.Data["Readmes"] = repo_module.Readmes
 	ctx.Data["readme"] = "Default"
 	ctx.Data["private"] = getRepoPrivate(ctx)
-	ctx.Data["ForcedPrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForceVisibility"] = setting.Repository.ForceVisibility
 	ctx.Data["default_branch"] = setting.Repository.DefaultBranch
 
 	ctxUser := checkContextUser(ctx, ctx.FormInt64("org"))

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -178,9 +178,15 @@ func SettingsPost(ctx *context.Context) {
 		}
 
 		visibilityChanged := repo.IsPrivate != form.Private
-		// when ForcePrivate enabled, you could change public repo to private, but only admin users can change private to public
-		if visibilityChanged && setting.Repository.ForcePrivate && !form.Private && !ctx.Doer.IsAdmin {
+		// when ForcePrivate is set to private, you could change public repo to private, but only admin users can change private to public
+		if visibilityChanged && setting.Repository.ForcePrivate == "private" && !form.Private && !ctx.Doer.IsAdmin {
 			ctx.RenderWithErr(ctx.Tr("form.repository_force_private"), tplSettingsOptions, form)
+			return
+		}
+
+		// when ForcePrivate is set to public, you could change private repo to public, but only admin users can change public to private
+		if visibilityChanged && setting.Repository.ForcePrivate == "public" && form.Private && !ctx.Doer.IsAdmin {
+			ctx.RenderWithErr(ctx.Tr("form.repository_force_public"), tplSettingsOptions, form)
 			return
 		}
 

--- a/routers/web/repo/setting.go
+++ b/routers/web/repo/setting.go
@@ -62,7 +62,7 @@ const (
 func SettingsCtxData(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.settings.options")
 	ctx.Data["PageIsSettingsOptions"] = true
-	ctx.Data["ForcePrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForceVisibility"] = setting.Repository.ForceVisibility
 	ctx.Data["MirrorsEnabled"] = setting.Mirror.Enabled
 	ctx.Data["DisableNewPullMirrors"] = setting.Mirror.DisableNewPull
 	ctx.Data["DisableNewPushMirrors"] = setting.Mirror.DisableNewPush
@@ -107,7 +107,7 @@ func Settings(ctx *context.Context) {
 func SettingsPost(ctx *context.Context) {
 	form := web.GetForm(ctx).(*forms.RepoSettingForm)
 
-	ctx.Data["ForcePrivate"] = setting.Repository.ForcePrivate
+	ctx.Data["ForceVisibility"] = setting.Repository.ForceVisibility
 	ctx.Data["MirrorsEnabled"] = setting.Mirror.Enabled
 	ctx.Data["DisableNewPullMirrors"] = setting.Mirror.DisableNewPull
 	ctx.Data["DisableNewPushMirrors"] = setting.Mirror.DisableNewPush
@@ -178,14 +178,14 @@ func SettingsPost(ctx *context.Context) {
 		}
 
 		visibilityChanged := repo.IsPrivate != form.Private
-		// when ForcePrivate is set to private, you could change public repo to private, but only admin users can change private to public
-		if visibilityChanged && setting.Repository.ForcePrivate == "private" && !form.Private && !ctx.Doer.IsAdmin {
+		// when ForceVisibility is set to private, you could change public repo to private, but only admin users can change private to public
+		if visibilityChanged && setting.Repository.ForceVisibility == "private" && !form.Private && !ctx.Doer.IsAdmin {
 			ctx.RenderWithErr(ctx.Tr("form.repository_force_private"), tplSettingsOptions, form)
 			return
 		}
 
-		// when ForcePrivate is set to public, you could change private repo to public, but only admin users can change public to private
-		if visibilityChanged && setting.Repository.ForcePrivate == "public" && form.Private && !ctx.Doer.IsAdmin {
+		// when ForceVisibility is set to public, you could change private repo to public, but only admin users can change public to private
+		if visibilityChanged && setting.Repository.ForceVisibility == "public" && form.Private && !ctx.Doer.IsAdmin {
 			ctx.RenderWithErr(ctx.Tr("form.repository_force_public"), tplSettingsOptions, form)
 			return
 		}

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -49,9 +49,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -49,10 +49,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -88,10 +88,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -88,9 +88,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -62,9 +62,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -62,10 +62,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -104,10 +104,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -104,9 +104,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -100,10 +100,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -100,11 +100,14 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
-								<input name="private" type="checkbox" {{if .private}} checked{{end}}>
+								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -102,9 +102,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -102,10 +102,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -99,10 +99,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -99,9 +99,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/migrate/gogs.tmpl
+++ b/templates/repo/migrate/gogs.tmpl
@@ -102,11 +102,14 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
-								<input name="private" type="checkbox" {{if .private}} checked{{end}}>
+								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 							{{end}}
 						</div>

--- a/templates/repo/migrate/gogs.tmpl
+++ b/templates/repo/migrate/gogs.tmpl
@@ -102,10 +102,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/onedev.tmpl
+++ b/templates/repo/migrate/onedev.tmpl
@@ -88,10 +88,10 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if eq .ForcedPrivate "private"}}
+							{{if eq .ForceVisibility "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
-							{{else if eq .ForcedPrivate "public"}}
+							{{else if eq .ForceVisibility "public"}}
 								<input name="private" type="checkbox" readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}

--- a/templates/repo/migrate/onedev.tmpl
+++ b/templates/repo/migrate/onedev.tmpl
@@ -88,9 +88,12 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui checkbox">
-							{{if .IsForcedPrivate}}
+							{{if eq .ForcedPrivate "private"}}
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.locale.Tr "repo.visibility_helper_forced" | Safe}}</label>
+							{{else if eq .ForcedPrivate "public"}}
+								<input name="private" type="checkbox" readonly>
+								<label>{{.locale.Tr "repo.visibility_helper_forced_public" | Safe}}</label>
 							{{else}}
 								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
 								<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -30,7 +30,7 @@
 							{{if .IsAdmin}}
 							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}>
 							{{else}}
-							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if or (and (eq $.ForcePrivate "private") (.Repository.IsPrivate)) (and (eq $.ForcePrivate "public") (not .Repository.IsPrivate))}} readonly{{end}}>
+							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if or (and (eq $.ForceVisibility "private") (.Repository.IsPrivate)) (and (eq $.ForceVisibility "public") (not .Repository.IsPrivate))}} readonly{{end}}>
 							{{end}}
 							<label>{{.locale.Tr "repo.visibility_helper" | Safe}} {{if .Repository.NumForks}}<span class="text red">{{.locale.Tr "repo.visibility_fork_helper"}}</span>{{end}}</label>
 						</div>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -30,7 +30,7 @@
 							{{if .IsAdmin}}
 							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}>
 							{{else}}
-							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if and $.ForcePrivate .Repository.IsPrivate}} readonly{{end}}>
+							<input name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}}{{if or (and (eq $.ForcePrivate "private") (.Repository.IsPrivate)) (and (eq $.ForcePrivate "public") (not .Repository.IsPrivate))}} readonly{{end}}>
 							{{end}}
 							<label>{{.locale.Tr "repo.visibility_helper" | Safe}} {{if .Repository.NumForks}}<span class="text red">{{.locale.Tr "repo.visibility_fork_helper"}}</span>{{end}}</label>
 						</div>


### PR DESCRIPTION
This PR adds the feature to configure repositories as force public like force private. See #24059
The value `FORCE_VISIBILITY`has been added. The key type is a string, that is used similar to `DEFAULT_PRIVATE`.

`FORCE_VISIBILITY` can  take the following values:
**public** - new repos must be public and existing ones cannot be switched to private
**private** - new repos must be private similar to previous `FORCE_PRIVATE=true`
**off** - new repos can be private or public

For compatibility reasons `ForceVisibility = private` is set if `FORCE_PRIVATE=true` is configured. `FORCE_PRIVATE` was marked as deprecated.

- closes #24059