### PR TITLE
Mark `models/fixtures` as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto eol=lf
 *.tmpl linguist-language=Handlebars
 /assets/*.json linguist-generated
+/models/fixtures/** linguist-generated
 /public/img/svg/*.svg linguist-generated
 /public/vendor/** -text -eol linguist-vendored
 /templates/swagger/v1_json.tmpl linguist-generated


### PR DESCRIPTION
Makes diffs like https://github.com/go-gitea/gitea/pull/24676/files more readable. I'm not sure if those are actually generated, but they are good to collapse in diffs anyways.