### PR TITLE
Hiding Secrets options when Actions feature is disabled

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -479,7 +479,7 @@ func RegisterRoutes(m *web.Route) {
 			m.Get("", user_setting.Secrets)
 			m.Post("", web.Bind(forms.AddSecretForm{}), user_setting.SecretsPost)
 			m.Post("/delete", user_setting.SecretsDelete)
-		})
+		}, actions.MustEnableActions)
 		m.Get("/organization", user_setting.Organization)
 		m.Get("/repos", user_setting.Repos)
 		m.Post("/repos/unadopted", user_setting.AdoptOrDeleteRepository)
@@ -853,7 +853,7 @@ func RegisterRoutes(m *web.Route) {
 					m.Get("", org.Secrets)
 					m.Post("", web.Bind(forms.AddSecretForm{}), org.SecretsPost)
 					m.Post("/delete", org.SecretsDelete)
-				})
+				}, actions.MustEnableActions)
 
 				m.Route("/delete", "GET,POST", org.SettingsDelete)
 
@@ -1044,7 +1044,7 @@ func RegisterRoutes(m *web.Route) {
 				m.Get("", repo.Secrets)
 				m.Post("", web.Bind(forms.AddSecretForm{}), repo.SecretsPost)
 				m.Post("/delete", repo.DeleteSecret)
-			})
+			}, actions.MustEnableActions)
 
 			m.Group("/lfs", func() {
 				m.Get("/", repo.LFSFiles)

--- a/templates/org/settings/navbar.tmpl
+++ b/templates/org/settings/navbar.tmpl
@@ -12,9 +12,11 @@
 		<a class="{{if .PageIsOrgSettingsLabels}}active {{end}}item" href="{{.OrgLink}}/settings/labels">
 			{{.locale.Tr "repo.labels"}}
 		</a>
+		{{if .EnableActions}}
 		<a class="{{if .PageIsOrgSettingsSecrets}}active {{end}}item" href="{{.OrgLink}}/settings/secrets">
 			{{.locale.Tr "secrets.secrets"}}
 		</a>
+		{{end}}
 		{{if .EnableOAuth2}}
 		<a class="{{if .PageIsSettingsApplications}}active {{end}}item" href="{{.OrgLink}}/settings/applications">
 			{{.locale.Tr "settings.applications"}}

--- a/templates/repo/settings/nav.tmpl
+++ b/templates/repo/settings/nav.tmpl
@@ -13,7 +13,9 @@
 				<li {{if .PageIsSettingsGitHooks}}class="current"{{end}}><a href="{{.RepoLink}}/settings/hooks/git">{{.locale.Tr "repo.settings.githooks"}}</a></li>
 			{{end}}
 			<li {{if .PageIsSettingsKeys}}class="current"{{end}}><a href="{{.RepoLink}}/settings/keys">{{.locale.Tr "repo.settings.deploy_keys"}}</a></li>
+			{{if .EnableActions}}
 			<li {{if .PageIsSettingsSecrets}}class="current"{{end}}><a href="{{.RepoLink}}/settings/secrets">{{.locale.Tr "secrets.secrets"}}</a></li>
+			{{end}}
 		</ul>
 	</div>
 </div>

--- a/templates/repo/settings/navbar.tmpl
+++ b/templates/repo/settings/navbar.tmpl
@@ -27,9 +27,11 @@
 		<a class="{{if .PageIsSettingsKeys}}active {{end}}item" href="{{.RepoLink}}/settings/keys">
 			{{.locale.Tr "repo.settings.deploy_keys"}}
 		</a>
+		{{if .EnableActions}}
 		<a class="{{if .PageIsSettingsSecrets}}active {{end}}item" href="{{.RepoLink}}/settings/secrets">
 			{{.locale.Tr "secrets.secrets"}}
 		</a>
+		{{end}}
 		{{if .LFSStartServer}}
 			<a class="{{if .PageIsSettingsLFS}}active {{end}}item" href="{{.RepoLink}}/settings/lfs">
 				{{.locale.Tr "repo.settings.lfs"}}

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -18,9 +18,11 @@
 		<a class="{{if .PageIsSettingsKeys}}active {{end}}item" href="{{AppSubUrl}}/user/settings/keys">
 			{{.locale.Tr "settings.ssh_gpg_keys"}}
 		</a>
+		{{if .EnableActions}}
 		<a class="{{if .PageIsSettingsSecrets}}active {{end}}item" href="{{AppSubUrl}}/user/settings/secrets">
 			{{.locale.Tr "secrets.secrets"}}
 		</a>
+		{{end}}
 		{{if .EnablePackages}}
 		<a class="{{if .PageIsSettingsPackages}}active {{end}}item" href="{{AppSubUrl}}/user/settings/packages">
 			{{.locale.Tr "packages.title"}}


### PR DESCRIPTION
`Secrets` options should be hidden if `Actions` feature is disabled.

This fixes in release/v1.19. In main probably fixed in 63a401ac40ce2cc19c7d0341d11d434b568653fc (didn't check).

Fixes: 659055138b6d32492b20c9f4d1d5a3cdaa47188d
Author-Change-Id: IB#1134011

