### PR TITLE
Add configurable for PR approver token

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1059,6 +1059,9 @@ ROUTER = console
 ;;
 ;; In addition to testing patches using the three-way merge method, re-test conflicting patches with git apply
 ;TEST_CONFLICTING_PATCHES_WITH_GIT_APPLY = false
+;;
+;; In default merge message all approvers are annotated using git trailers with a token of this value. The colon is inserted automatically.
+;APPROVER_TRAILER_TOKEN = Reviewed-by
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -137,6 +137,7 @@ In addition there is _`StaticRootPath`_ which can be set as a built-in at build 
 - `POPULATE_SQUASH_COMMENT_WITH_COMMIT_MESSAGES`: **false**: In default squash-merge messages include the commit message of all commits comprising the pull request.
 - `ADD_CO_COMMITTER_TRAILERS`: **true**: Add co-authored-by and co-committed-by trailers to merge commit messages if committer does not match author.
 - `TEST_CONFLICTING_PATCHES_WITH_GIT_APPLY`: **false**: PR patches are tested using a three-way merge method to discover if there are conflicts. If this setting is set to **true**, conflicting patches will be retested using `git apply` - This was the previous behaviour in 1.18 (and earlier) but is somewhat inefficient. Please report if you find that this setting is required.
+- `APPROVER_TRAILER_TOKEN`: **Reviewed-by**: Trailer token used to annotate approvers on generated commit messages as git trailers. When using the default merge message, each approve included in the message will be listed in the trailer as `APPROVER_TRAILER_TOKEN: User Name <email>`.
 
 ### Repository - Issue (`repository.issue`)
 

--- a/models/issues/pull.go
+++ b/models/issues/pull.go
@@ -414,13 +414,10 @@ func (pr *PullRequest) getReviewedByLines(writer io.Writer) error {
 		} else if review.Reviewer == nil {
 			continue
 		}
-		if _, err := writer.Write([]byte("Reviewed-by: ")); err != nil {
-			return err
-		}
-		if _, err := writer.Write([]byte(review.Reviewer.NewGitSig().String())); err != nil {
-			return err
-		}
-		if _, err := writer.Write([]byte{'\n'}); err != nil {
+
+		reviewerSignature := review.Reviewer.NewGitSig().String()
+		trailer := fmt.Sprintf("%s: %s\n", setting.Repository.PullRequest.ApproverTrailerToken, reviewerSignature)
+		if _, err := writer.Write([]byte(trailer)); err != nil {
 			return err
 		}
 		reviewersWritten++

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -85,6 +85,7 @@ var (
 			PopulateSquashCommentWithCommitMessages  bool
 			AddCoCommitterTrailers                   bool
 			TestConflictingPatchesWithGitApply       bool
+			ApproverTrailerToken                     string
 		} `ini:"repository.pull-request"`
 
 		// Issue Setting
@@ -208,6 +209,7 @@ var (
 			PopulateSquashCommentWithCommitMessages  bool
 			AddCoCommitterTrailers                   bool
 			TestConflictingPatchesWithGitApply       bool
+			ApproverTrailerToken                     string
 		}{
 			WorkInProgressPrefixes: []string{"WIP:", "[WIP]"},
 			// Same as GitHub. See
@@ -222,6 +224,7 @@ var (
 			DefaultMergeMessageOfficialApproversOnly: true,
 			PopulateSquashCommentWithCommitMessages:  false,
 			AddCoCommitterTrailers:                   true,
+			ApproverTrailerToken:                     "Reviewed-by",
 		},
 
 		// Issue settings


### PR DESCRIPTION
Allow customization of the git trailer token used to annotate approvers when generating the default merge message for pull requests. Also  simplify the logic that writes the trailer string for each reviewer.

fixes #24797 

With default ini
![image](https://github.com/go-gitea/gitea/assets/2796559/deb0befa-d5ee-46fb-b680-6c1d71a477ad)


With custom APPROVER_TRAILER_TOKEN in ini
![image](https://github.com/go-gitea/gitea/assets/2796559/9d3cfca4-5e73-44cd-ac3a-6fa0eec1f2a4)

