### PR TITLE
Fix Actions being enabled accidentally

### DIFF
--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -306,11 +306,11 @@ func loadRepositoryFrom(rootCfg ConfigProvider) {
 		log.Fatal("Failed to map Repository.PullRequest settings: %v", err)
 	}
 
-	if !rootCfg.Section("packages").Key("ENABLED").MustBool(true) {
+	if !rootCfg.Section("packages").Key("ENABLED").MustBool(Packages.Enabled) {
 		Repository.DisabledRepoUnits = append(Repository.DisabledRepoUnits, "repo.packages")
 	}
 
-	if !rootCfg.Section("actions").Key("ENABLED").MustBool(false) {
+	if !rootCfg.Section("actions").Key("ENABLED").MustBool(Actions.Enabled) {
 		Repository.DisabledRepoUnits = append(Repository.DisabledRepoUnits, "repo.actions")
 	}
 

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -310,7 +310,7 @@ func loadRepositoryFrom(rootCfg ConfigProvider) {
 		Repository.DisabledRepoUnits = append(Repository.DisabledRepoUnits, "repo.packages")
 	}
 
-	if !rootCfg.Section("actions").Key("ENABLED").MustBool(true) {
+	if !rootCfg.Section("actions").Key("ENABLED").MustBool(false) {
 		Repository.DisabledRepoUnits = append(Repository.DisabledRepoUnits, "repo.actions")
 	}
 


### PR DESCRIPTION
Regression of #24536. If the user doesn't explicitly disable Actions, it will be enabled.

1. Gitea will call `loadRepositoryFrom` before `loadActionsFrom`.
https://github.com/go-gitea/gitea/blob/25d4f95df25dae5226e96e813dde87b071d9155e/modules/setting/setting.go#L234-L237
2. In `loadRepositoryFrom`, `rootCfg.Section("actions").Key("ENABLED").MustBool(true)` will set `actions.ENABLED` with `true`. 
https://github.com/go-gitea/gitea/blob/25d4f95df25dae5226e96e813dde87b071d9155e/modules/setting/repository.go#L313-L315
3. In `loadActionsFrom`, `rootCfg.Section("actions")` will get a section with Actions enabled.
https://github.com/go-gitea/gitea/blob/25d4f95df25dae5226e96e813dde87b071d9155e/modules/setting/actions.go#L23-L26


Although the cause of the problem was using `true` by copy-paste mistake, it also surprised me that **`rootCfg.Section("actions").Key("ENABLED").MustBool(true)` doesn't only read, but also write.**

