### PR TITLE
Fix duplicate tooltip hiding

### DIFF
--- a/web_src/js/modules/tippy.js
+++ b/web_src/js/modules/tippy.js
@@ -20,7 +20,7 @@ export function createTippy(target, opts = {}) {
     onShow: (instance) => {
       // hide other tooltip instances so only one tooltip shows at a time
       for (const visibleInstance of visibleInstances) {
-        if (visibleInstance.role === 'tooltip') {
+        if (visibleInstance.props.role === 'tooltip') {
           visibleInstance.hide();
         }
       }


### PR DESCRIPTION
A tippy instance's role is actually on `props.role`. This makes duplicate tooltip hiding work again after https://github.com/go-gitea/gitea/pull/24688.