### PR TITLE
Add validations.required check to dropdown field

### DIFF
--- a/templates/repo/issue/fields/dropdown.tmpl
+++ b/templates/repo/issue/fields/dropdown.tmpl
@@ -4,7 +4,9 @@
 	<div class="ui fluid selection dropdown {{if .item.Attributes.multiple}}multiple clearable{{end}}">
 		<input type="hidden" name="form-field-{{.item.ID}}" value="0">
 		{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+		{{if not .item.Validations.required}}
 		{{svg "octicon-x" 14 "remove icon"}}
+		{{end}}
 		<div class="default text"></div>
 		<div class="menu">
 			{{range $i, $opt := .item.Attributes.options}}


### PR DESCRIPTION
If dropdown is marked as required, we should not provide the `remove` button.
This will cause user may post empty value which seems like a bug.

Definition:
![image](https://github.com/go-gitea/gitea/assets/18380374/cf48b478-244e-44e0-9a0e-7a0f02bc471a)
Post request form:
![image](https://github.com/go-gitea/gitea/assets/18380374/31d6f823-835f-422a-879c-3b1e18950ac8)
Result:
![image](https://github.com/go-gitea/gitea/assets/18380374/a9944fe9-24d0-4776-9eec-d31b70144eb4)

