### PR TITLE
Fix missing yes/no in delete time log modal

### DIFF
--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -7,7 +7,7 @@
 						{{.ctxData.CsrfTokenHtml}}
 					</form>
 					<div class="header">{{.ctxData.locale.Tr "repo.issues.del_time"}}</div>
-					{{template "base/modal_actions_confirm" .}}
+					{{template "base/modal_actions_confirm" (dict "locale" .ctxData.locale)}}
 				</div>
 				<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{.ctxData.locale.Tr "repo.issues.del_time"}}">
 					{{svg "octicon-trash"}}


### PR DESCRIPTION
Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/bcbcddcc-b328-4751-92fe-6e55b7a84671)

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/571ef27a-2411-472e-819d-f694e7be3697)

