### PR TITLE
Remove `In your repositories` link in milestones dashboard

### DIFF
--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -5,10 +5,10 @@
 		<div class="ui stackable grid">
 			<div class="four wide column">
 				<div class="ui secondary vertical filter menu gt-bg-transparent">
-					<a class="item" href="{{.Link}}?type=your_repositories&sort={{$.SortType}}&state={{.State}}&q={{$.Keyword}}">
+					<div class="item">
 						{{.locale.Tr "home.issues.in_your_repos"}}
 						<strong class="ui right">{{.Total}}</strong>
-					</a>
+					</div>
 					<div class="ui divider"></div>
 					{{range .Repos}}
 						{{with $Repo := .}}


### PR DESCRIPTION
It is unnecessary to it.