### PR TITLE
Fix 500 error when select `No assignee` filter in issue list page

### DIFF
--- a/models/issues/issue_stats.go
+++ b/models/issues/issue_stats.go
@@ -141,7 +141,7 @@ func getIssueStatsChunk(opts *IssuesOptions, issueIDs []int64) (*IssueStats, err
 		if opts.AssigneeID > 0 {
 			applyAssigneeCondition(sess, opts.AssigneeID)
 		} else if opts.AssigneeID == db.NoConditionID {
-			sess.Where("id NOT IN (SELECT issue_id FROM issue_assignees)")
+			sess.Where("issue.id NOT IN (SELECT issue_id FROM issue_assignees)")
 		}
 
 		if opts.PosterID > 0 {


### PR DESCRIPTION
Access the issue list page and select `No assignee`, you will get 500 error:
![image](https://github.com/go-gitea/gitea/assets/18380374/a7435fd3-c3d5-4801-894e-9353a8ddc1af)

You can see this page in try.gitea.io:
https://try.gitea.io/yp05327/testrepo/issues?q=&type=all&sort=&state=open&labels=&milestone=0&project=0&assignee=-1&poster=0

Caused by https://github.com/go-gitea/gitea/pull/24707/files#diff-d7c7dc2da4fcfdc09997648e11a018414dc116472054350b5590ab407adcd44dR1748