### PR TITLE
Fix compile docs

### DIFF
--- a/.github/workflows/pull-compliance-docsignore.yml
+++ b/.github/workflows/pull-compliance-docsignore.yml
@@ -7,11 +7,6 @@ on:
       - "*.md"
 
 jobs:
-  compliance-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No build required"
-
   lint-backend:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/pull/24530#issuecomment-1557669210

This PR fix a bug that when a PR includes docs, the compile docs workflow will not run.