### PR TITLE
Fix double border and adjust width for user profile page

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -2,7 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content user profile">
 	<div class="ui container">
 		<div class="ui stackable grid">
-			<div class="ui five wide column">
+			<div class="ui four wide column">
 				<div class="ui card">
 					<div id="profile-avatar" class="content gt-df">
 					{{if eq .SignedUserID .ContextUser.ID}}
@@ -120,8 +120,8 @@
 					</div>
 				</div>
 			</div>
-			<div class="ui eleven wide column">
-				<div class="ui secondary stackable pointing tight menu">
+			<div class="ui twelve wide column">
+				<div class="gt-mb-4 gt-df">
 					{{template "user/overview/header" .}}
 				</div>
 


### PR DESCRIPTION
Close #24848 

After:

<img width="1434" alt="Screen Shot 2023-05-23 at 12 34 11" src="https://github.com/go-gitea/gitea/assets/17645053/3b54c821-86a4-4360-b6b5-af0228470ecb">

<img width="1434" alt="Screen Shot 2023-05-23 at 12 34 18" src="https://github.com/go-gitea/gitea/assets/17645053/6cb99083-d69d-463a-af98-dcd411f38c1b">


<img width="1431" alt="Screen Shot 2023-05-23 at 12 34 25" src="https://github.com/go-gitea/gitea/assets/17645053/d6b54bbc-b7ab-414b-9a94-ac70be3c1072">

