### PR TITLE
Fix Bug in Explore when Repo has no Owner

### DIFF
--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -84,7 +84,11 @@ func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
 		return fmt.Errorf("find users: %w", err)
 	}
 	for i := range repos {
-		repos[i].Owner = users[repos[i].OwnerID]
+		if users[repos[i].OwnerID] != nil {
+			repos[i].Owner = users[repos[i].OwnerID]
+		} else {
+			repos[i].Owner = user_model.NewGhostUser()
+		}
 	}
 
 	// Load primary language.

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -7,9 +7,15 @@
 					{{if $avatar}}
 						{{$avatar}}
 					{{end}}
-					<a class="name" href="{{.Link}}">
-						{{if or $.PageIsExplore $.PageIsProfileStarList}}{{if .Owner}}{{.Owner.Name}} / {{end}}{{end}}{{.Name}}
-					</a>
+					{{if not .Owner.IsGhost}}
+						<a class="name" href="{{.Link}}">
+							{{if or $.PageIsExplore $.PageIsProfileStarList}}{{if .Owner}}{{.Owner.Name}} / {{end}}{{end}}{{.Name}}
+						</a>
+					{{else}}
+						<span class="name">
+							{{if or $.PageIsExplore $.PageIsProfileStarList}}{{if .Owner}}{{.Owner.Name}} / {{end}}{{end}}{{.Name}}
+						</span>
+					{{end}}
 					<div class="labels gt-df gt-ac gt-fw gt-mr-3">
 						{{if .IsArchived}}
 							<span class="ui basic label">{{$.locale.Tr "repo.desc.archived"}}</span>


### PR DESCRIPTION
Fixes #24857

Do be clear, I don't know how this could happen. It should normally not possible to Delete a User and has his Repos left. I needed to change the Owner ID in the Database to test this Code. But I think it's nice to have a Fallback in case something goes wrong like in the reported Bug.