### PR TITLE
[WIP] Add SMTP logger (log event writer)

### DIFF
--- a/modules/log/event_writer_smtp.go
+++ b/modules/log/event_writer_smtp.go
@@ -1,0 +1,63 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package log
+
+import (
+	"net/smtp"
+	"strings"
+)
+
+type WriterSMTPOption struct {
+	Username           string
+	Password           string
+	Host               string
+	Subject            string
+	RecipientAddresses []string
+}
+
+type eventWriterSMTP struct {
+	*EventWriterBaseImpl
+	smtpWriter smtpWriter
+}
+
+var _ EventWriter = (*eventWriterSMTP)(nil)
+
+func NewEventWriterSMTP(writerName string, writerMode WriterMode) EventWriter {
+	w := &eventWriterSMTP{EventWriterBaseImpl: NewEventWriterBase(writerName, "smtp", writerMode)}
+	w.smtpWriter = smtpWriter{
+		opt:        writerMode.WriterOption.(WriterSMTPOption),
+		sendMailFn: smtp.SendMail,
+	}
+	w.OutputWriteCloser = &w.smtpWriter
+	return w
+}
+
+func init() {
+	RegisterEventWriter("smtp", NewEventWriterSMTP)
+}
+
+type smtpWriter struct {
+	opt        WriterSMTPOption
+	sendMailFn func(string, smtp.Auth, string, []string, []byte) error
+}
+
+func (s *smtpWriter) Close() error {
+	return nil
+}
+
+// below is copied from old code
+
+func (s *smtpWriter) Write(p []byte) (int, error) {
+	hp := strings.Split(s.opt.Host, ":")
+	auth := smtp.PlainAuth("", s.opt.Username, s.opt.Password, hp[0])
+	mailMsg := []byte("To: " + strings.Join(s.opt.RecipientAddresses, ";") + "\r\n" +
+		"From: " + s.opt.Username + "<" + s.opt.Username + ">" + "\r\n" +
+		"Subject: " + s.opt.Subject + "\r\n" +
+		"Content-Type: text/plain; charset=UTF-8" + "\r\n" +
+		"\r\n",
+	)
+	mailMsg = append(mailMsg, p...)
+	return len(p), s.sendMailFn(s.opt.Host, auth, s.opt.Username, s.opt.RecipientAddresses, mailMsg)
+}

--- a/modules/log/event_writer_smtp_test.go
+++ b/modules/log/event_writer_smtp_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package log
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSMTPLogger(t *testing.T) {
+	opt := WriterSMTPOption{
+		Username:           "user",
+		Password:           "pass",
+		Host:               "host",
+		Subject:            "subject",
+		RecipientAddresses: []string{"u@h.com"},
+	}
+	w := NewEventWriterSMTP("test", WriterMode{WriterOption: opt})
+	s := w.(*eventWriterSMTP)
+
+	var envToHost string
+	var envFrom string
+	var envTo []string
+	var envMsg []byte
+	s.smtpWriter.sendMailFn = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		envToHost = addr
+		envFrom = from
+		envTo = to
+		envMsg = msg
+		return nil
+	}
+
+	_, err := s.smtpWriter.Write([]byte("test msg"))
+	assert.NoError(t, err)
+	assert.Equal(t, opt.Host, envToHost)
+	assert.Equal(t, opt.Username, envFrom)
+	assert.Equal(t, opt.RecipientAddresses, envTo)
+	assert.Contains(t, string(envMsg), "test msg")
+}

--- a/modules/setting/log.go
+++ b/modules/setting/log.go
@@ -163,6 +163,14 @@ func loadLogModeByName(rootCfg ConfigProvider, loggerName, modeName string) (wri
 		writerOption.Protocol = ConfigInheritedKey(sec, "PROTOCOL").In("tcp", []string{"tcp", "unix", "udp"})
 		writerOption.Addr = ConfigInheritedKey(sec, "ADDR").MustString(":7020")
 		writerMode.WriterOption = writerOption
+	case "smtp":
+		writerOption := log.WriterSMTPOption{}
+		writerOption.Subject = ConfigInheritedKey(sec, "SUBJECT").MustString("Diagnostic message from server")
+		writerOption.Host = ConfigInheritedKey(sec, "HOST").String()
+		writerOption.Username = ConfigInheritedKey(sec, "USER").String()
+		writerOption.Password = ConfigInheritedKey(sec, "PASSWD").String()
+		writerOption.RecipientAddresses = ConfigInheritedKey(sec, "RECEIVERS").Strings(",")
+		writerMode.WriterOption = writerOption
 	default:
 		if !log.HasEventWriter(writerType) {
 			return "", "", writerMode, fmt.Errorf("invalid log writer type (mode): %s", writerType)


### PR DESCRIPTION
Some people worry a lot about "removing the SMTP logger", this PR is to make people not worry.

I am pretty sure the SMTP logger should not be added back, and I would expect this PR never gets merged, so just put it into WIP.

I guess few people ever thought about this problem carefully.


1. Does a modern app need a SMTP logger?

I believe the answer is no. There could be a lot of "ERROR" level messages for a Gitea instance, it doesn't make sense to get a lot of emails for these error logs.

Otherwise, please help to show real examples about how modern web applications use SMTP as logger.


2. Why there was a SMTP logger and how it came?

The history of Gitea's "SMTP logger" is as old as year 2014, from the first commits of Gogs. No maintenance since then. I do not think it is a well-designed or serious feature.

It is just a toy, only basic SMTP auth, no TLS, etc.


3. Is the new logger system on the right way?

I think so. Adding a log event writer it pretty easy, and the test code is clearer and simpler than [before](https://github.com/go-gitea/gitea/blob/release/v1.19/modules/log/smtp_test.go).
