### PR TITLE
Fix flakey test in logger test

### DIFF
--- a/modules/log/logger_test.go
+++ b/modules/log/logger_test.go
@@ -94,6 +94,7 @@ func TestLoggerPause(t *testing.T) {
 	logger.AddWriters(w1)
 
 	GetManager().PauseAll()
+	time.Sleep(50 * time.Millisecond)
 
 	logger.Info("info-level")
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Fix #24882

The goroutines are all asynchronized. So it needs a little "sleep" to make sure the writer's goroutine has been paused before sending messages to it.



