### PR TITLE
Remove unnecessary prefix usage

### DIFF
--- a/docs/content/doc/administration/backup-and-restore.en-us.md
+++ b/docs/content/doc/administration/backup-and-restore.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2017-01-01T16:00:00+02:00"
-title: "Usage: Backup and Restore"
+title: "Backup and Restore"
 slug: "backup-and-restore"
 weight: 11
 toc: false

--- a/docs/content/doc/administration/backup-and-restore.zh-cn.md
+++ b/docs/content/doc/administration/backup-and-restore.zh-cn.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-06-06T09:33:00+08:00"
-title: "使用：备份与恢复"
+title: "备份与恢复"
 slug: "backup-and-restore"
 weight: 11
 toc: false

--- a/docs/content/doc/administration/command-line.en-us.md
+++ b/docs/content/doc/administration/command-line.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2017-01-01T16:00:00+02:00"
-title: "Usage: Command Line"
+title: "Command Line"
 slug: "command-line"
 weight: 1
 toc: false

--- a/docs/content/doc/administration/email-setup.en-us.md
+++ b/docs/content/doc/administration/email-setup.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-10-15T10:10:00+05:00"
-title: "Usage: Email setup"
+title: "Email setup"
 slug: "email-setup"
 weight: 12
 toc: false

--- a/docs/content/doc/administration/fail2ban-setup.en-us.md
+++ b/docs/content/doc/administration/fail2ban-setup.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-05-11T11:00:00+02:00"
-title: "Usage: Setup fail2ban"
+title: "Setup fail2ban"
 slug: "fail2ban-setup"
 weight: 16
 toc: false

--- a/docs/content/doc/administration/git-lfs-support.en-us.md
+++ b/docs/content/doc/administration/git-lfs-support.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-10-06T08:00:00+05:00"
-title: "Usage: Git LFS setup"
+title: "Git LFS setup"
 slug: "git-lfs-setup"
 weight: 12
 toc: false

--- a/docs/content/doc/administration/https-support.en-us.md
+++ b/docs/content/doc/administration/https-support.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-06-02T11:00:00+02:00"
-title: "Usage: HTTPS setup"
+title: "HTTPS setup"
 slug: "https-setup"
 weight: 12
 toc: false

--- a/docs/content/doc/administration/logging-documentation.en-us.md
+++ b/docs/content/doc/administration/logging-documentation.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-04-02T17:06:00+01:00"
-title: "Advanced: Logging Configuration"
+title: "Logging Configuration"
 slug: "logging-configuration"
 weight: 40
 toc: false

--- a/docs/content/doc/administration/reverse-proxies.en-us.md
+++ b/docs/content/doc/administration/reverse-proxies.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-05-22T11:00:00+00:00"
-title: "Usage: Reverse Proxies"
+title: "Reverse Proxies"
 slug: "reverse-proxies"
 weight: 16
 toc: false

--- a/docs/content/doc/administration/reverse-proxies.zh-cn.md
+++ b/docs/content/doc/administration/reverse-proxies.zh-cn.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-05-22T11:00:00+00:00"
-title: "使用：反向代理"
+title: "反向代理"
 slug: "reverse-proxies"
 weight: 16
 toc: false

--- a/docs/content/doc/administration/search-engines-indexation.en-us.md
+++ b/docs/content/doc/administration/search-engines-indexation.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-12-31T13:55:00+05:00"
-title: "Advanced: Search Engines Indexation"
+title: "Search Engines Indexation"
 slug: "search-engines-indexation"
 weight: 60
 toc: false

--- a/docs/content/doc/usage/agit-support.en-us.md
+++ b/docs/content/doc/usage/agit-support.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "	2022-09-01T20:50:42+0000"
-title: "Usage: Agit Setup"
+title: "Agit Setup"
 slug: "agit-setup"
 weight: 12
 toc: false

--- a/docs/content/doc/usage/issue-pull-request-templates.en-us.md
+++ b/docs/content/doc/usage/issue-pull-request-templates.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-05-10T16:00:00+02:00"
-title: "Usage: Issue and Pull Request templates"
+title: "Issue and Pull Request templates"
 slug: "issue-pull-request-templates"
 weight: 15
 toc: false

--- a/docs/content/doc/usage/issue-pull-request-templates.zh-cn.md
+++ b/docs/content/doc/usage/issue-pull-request-templates.zh-cn.md
@@ -1,6 +1,6 @@
 ---
 date: "2022-09-07T16:00:00+08:00"
-title: "使用：从模板创建工单与合并请求"
+title: "从模板创建工单与合并请求"
 slug: "issue-pull-request-templates"
 weight: 15
 toc: true

--- a/docs/content/doc/usage/labels.en-us.md
+++ b/docs/content/doc/usage/labels.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2023-03-04T19:00:00+00:00"
-title: "Usage: Labels"
+title: "Labels"
 slug: "labels"
 weight: 13
 toc: false

--- a/docs/content/doc/usage/linked-references.en-us.md
+++ b/docs/content/doc/usage/linked-references.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2019-11-21T17:00:00-03:00"
-title: "Usage: Automatically Linked References"
+title: "Automatically Linked References"
 slug: "automatically-linked-references"
 weight: 15
 toc: false

--- a/docs/content/doc/usage/merge-message-templates.en-us.md
+++ b/docs/content/doc/usage/merge-message-templates.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2022-08-31T17:35:40+08:00"
-title: "Usage: Merge Message templates"
+title: "Merge Message templates"
 slug: "merge-message-templates"
 weight: 15
 toc: false

--- a/docs/content/doc/usage/pull-request.en-us.md
+++ b/docs/content/doc/usage/pull-request.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-06-01T19:00:00+02:00"
-title: "Usage: Pull Request"
+title: "Pull Request"
 slug: "pull-request"
 weight: 13
 toc: false

--- a/docs/content/doc/usage/pull-request.zh-cn.md
+++ b/docs/content/doc/usage/pull-request.zh-cn.md
@@ -1,6 +1,6 @@
 ---
 date: "2018-06-01T19:00:00+02:00"
-title: "使用：Pull Request"
+title: "合并请求"
 slug: "pull-request"
 weight: 13
 toc: false
@@ -8,14 +8,14 @@ draft: false
 menu:
   sidebar:
     parent: "usage"
-    name: "Pull Request"
+    name: "合并请求"
     weight: 13
     identifier: "pull-request"
 ---
 
-# Pull Request
+# 合并请求
 
-## 在 pull requests 使用“Work In Progress”标记
+## 在合并请求中使用“Work In Progress”标记
 
 您可以通过在一个进行中的 pull request 的标题上添加前缀 `WIP:` 或者 `[WIP]`（此处大小写敏感）来防止它被意外合并，具体的前缀设置可以在配置文件 `app.ini` 中找到：
 
@@ -26,6 +26,6 @@ WORK_IN_PROGRESS_PREFIXES=WIP:,[WIP]
 
 列表的第一个值将用于 helpers 程序。
 
-## Pull Request 模板
+## 合并请求模板
 
-有关 pull request 模板的更多信息请您移步 : [Issue and Pull Request templates](../issue-pull-request-templates)
+有关合并请求模板的更多信息请您移步 : [工单和合并请求模板](issue-pull-request-templates)

--- a/docs/content/doc/usage/push.en-us.md
+++ b/docs/content/doc/usage/push.en-us.md
@@ -1,6 +1,6 @@
 ---
 date: "2020-07-06T16:00:00+02:00"
-title: "Usage: Push"
+title: "Push"
 slug: "push"
 weight: 15
 toc: false


### PR DESCRIPTION
Since now all articles have a class, the `Usage:` is unnecessary. This PR will remove them.