### PR TITLE
Improve confusable character string

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1131,7 +1131,7 @@ ambiguous_runes_header = `This file contains ambiguous Unicode characters!`
 ambiguous_runes_description = `This file contains ambiguous Unicode characters that may be confused with others in your current locale. If your use case is intentional and legitimate, you can safely ignore this warning. Use the Escape button to highlight these characters.`
 invisible_runes_line = `This line has invisible unicode characters`
 ambiguous_runes_line = `This line has ambiguous unicode characters`
-ambiguous_character = `%[1]c [U+%04[1]X] is confusable with %[2]c [U+%04[2]X]`
+ambiguous_character = `%[1]c [U+%04[1]X] can be confused with %[2]c [U+%04[2]X]`
 
 escape_control_characters = Escape
 unescape_control_characters = Unescape


### PR DESCRIPTION
Very small UX change, "confusable" is a word that is indeed valid, but when you look it up online, it doesn't take long for this adjective to appear in [its technical Unicode-related context](https://util.unicode.org/UnicodeJsps/confusables.jsp). I think that it throws me off as a person that doesn't speak English natively.

I think that this could be replaced with "can be confused with". As the change is very small and purely a matter of preference, if you (the maintainer) believe that this shouldn't be included, feel free to close this without any further discussion, as your time would probably be better used elsewhere.