### PR TITLE
Add missing test case and fix typo in tests

### DIFF
--- a/models/organization/org_test.go
+++ b/models/organization/org_test.go
@@ -269,7 +269,7 @@ func TestGetOrgUsersByOrgID(t *testing.T) {
 			ID:       orgUsers[2].ID,
 			OrgID:    3,
 			UID:      28,
-			IsPublic: false,
+			IsPublic: true,
 		}, *orgUsers[2])
 	}
 

--- a/models/organization/org_test.go
+++ b/models/organization/org_test.go
@@ -265,6 +265,12 @@ func TestGetOrgUsersByOrgID(t *testing.T) {
 			UID:      4,
 			IsPublic: false,
 		}, *orgUsers[1])
+		assert.Equal(t, organization.OrgUser{
+			ID:       orgUsers[2].ID,
+			OrgID:    3,
+			UID:      28,
+			IsPublic: false,
+		}, *orgUsers[2])
 	}
 
 	orgUsers, err = organization.GetOrgUsersByOrgID(db.DefaultContext, &organization.FindOrgMembersOpts{

--- a/models/organization/org_user_test.go
+++ b/models/organization/org_user_test.go
@@ -85,7 +85,7 @@ func TestUserListIsPublicMember(t *testing.T) {
 		{22, map[int64]bool{}},
 	}
 	for _, v := range tt {
-		t.Run(fmt.Sprintf("IsPublicMemberOfOrdIg%d", v.orgid), func(t *testing.T) {
+		t.Run(fmt.Sprintf("IsPublicMemberOfOrgId%d", v.orgid), func(t *testing.T) {
 			testUserListIsPublicMember(t, v.orgid, v.expected)
 		})
 	}
@@ -112,7 +112,7 @@ func TestUserListIsUserOrgOwner(t *testing.T) {
 		{22, map[int64]bool{}},          // No member
 	}
 	for _, v := range tt {
-		t.Run(fmt.Sprintf("IsUserOrgOwnerOfOrdIg%d", v.orgid), func(t *testing.T) {
+		t.Run(fmt.Sprintf("IsUserOrgOwnerOfOrgId%d", v.orgid), func(t *testing.T) {
 			testUserListIsUserOrgOwner(t, v.orgid, v.expected)
 		})
 	}


### PR DESCRIPTION
This PR adds a missing assertion in the `TestGetOrgUsersByOrgID` function. It also incidentally fixes a small typo.
