### PR TITLE
Send SIGKILL instead of SIGTERM in watch.sh

### DIFF
--- a/build/watch.sh
+++ b/build/watch.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 make watch-frontend &
 make watch-backend &
 
-trap 'kill $(jobs -p)' EXIT
+trap 'kill -9 $(jobs -p)' EXIT
 wait


### PR DESCRIPTION
Should fix the issue mentioned in https://github.com/go-gitea/gitea/issues/24845#issuecomment-1556645692.