### PR TITLE
Reduce verbosity of dev commands

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = ".air"
 
 [build]
-cmd = "make backend"
+cmd = "make --no-print-directory backend"
 bin = "gitea"
 delay = 1000
 include_ext = ["go", "tmpl"]

--- a/Makefile
+++ b/Makefile
@@ -936,7 +936,7 @@ fomantic:
 webpack: $(WEBPACK_DEST)
 
 $(WEBPACK_DEST): $(WEBPACK_SOURCES) $(WEBPACK_CONFIGS) package-lock.json
-	@$(MAKE) -s node-check node_modules
+	@$(MAKE) --no-print-directory -s node-check node_modules
 	rm -rf $(WEBPACK_DEST_ENTRIES)
 	npx webpack
 	@touch $(WEBPACK_DEST)

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ watch:
 
 .PHONY: watch-frontend
 watch-frontend: node-check node_modules
-	rm -rf $(WEBPACK_DEST_ENTRIES)
+	@rm -rf $(WEBPACK_DEST_ENTRIES)
 	NODE_ENV=development npx webpack --watch --progress
 
 .PHONY: watch-backend

--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ lint-editorconfig:
 
 .PHONY: watch
 watch:
-	bash build/watch.sh
+	@bash build/watch.sh
 
 .PHONY: watch-frontend
 watch-frontend: node-check node_modules

--- a/Makefile
+++ b/Makefile
@@ -936,7 +936,7 @@ fomantic:
 webpack: $(WEBPACK_DEST)
 
 $(WEBPACK_DEST): $(WEBPACK_SOURCES) $(WEBPACK_CONFIGS) package-lock.json
-	@$(MAKE) --no-print-directory -s node-check node_modules
+	@$(MAKE) -s node-check node_modules
 	rm -rf $(WEBPACK_DEST_ENTRIES)
 	npx webpack
 	@touch $(WEBPACK_DEST)

--- a/build/watch.sh
+++ b/build/watch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-make watch-frontend &
-make watch-backend &
+make --no-print-directory watch-frontend &
+make --no-print-directory watch-backend &
 
 trap 'kill $(jobs -p)' EXIT
 wait


### PR DESCRIPTION
### Before
```
$ make watch
bash build/watch.sh
make[1]: Entering directory '/Users/silverwind/git/gitea'
make[1]: Entering directory '/Users/silverwind/git/gitea'
GITEA_RUN_MODE=dev go run github.com/cosmtrek/air@v1.43.0 -c .air.toml
rm -rf public/js public/css public/fonts public/img/webpack public/serviceworker.js
NODE_ENV=development npx webpack --watch --progress
```
### After
```
$ make watch
GITEA_RUN_MODE=dev go run github.com/cosmtrek/air@v1.43.0 -c .air.toml
NODE_ENV=development npx webpack --watch --progress
```