### PR TITLE
When squashing commits in web UI, only compare emails

### DIFF
--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -64,6 +64,7 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
+        // RFC 1035 - host is case-insensitive, local part is case-sensitive
 	if setting.Repository.PullRequest.AddCoCommitterTrailers &&
            strings.EqualFold(strings.SplitAfter(ctx.committer.Email, "@")[1], strings.SplitAfter(sig.Email, "@")[1]) &&
            (strings.SplitAfter(ctx.committer.Email, "@")[0] != strings.SplitAfter(sig.Email, "@")[0]) {

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -5,6 +5,7 @@ package pull
 
 import (
 	"fmt"
+        "strings"
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
@@ -63,7 +64,7 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
-	if setting.Repository.PullRequest.AddCoCommitterTrailers && ctx.committer.Email != sig.Email {
+	if setting.Repository.PullRequest.AddCoCommitterTrailers && strings.EqualFold(ctx.committer.Email, sig.Email) {
 		// add trailer if email of user and email of committer don't match
 		message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 	}

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -64,7 +64,9 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
-	if setting.Repository.PullRequest.AddCoCommitterTrailers && strings.EqualFold(ctx.committer.Email, sig.Email) {
+	if setting.Repository.PullRequest.AddCoCommitterTrailers &&
+           strings.EqualFold(strings.SplitAfter(ctx.committer.Email, "@")[1], strings.SplitAfter(sig.Email, "@")[1]) &&
+           (strings.SplitAfter(ctx.committer.Email, "@")[0] != strings.SplitAfter(sig.Email, "@")[0]) {
 		// add trailer if email of user and email of committer don't match
 		message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 	}

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -63,8 +63,8 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
-	if setting.Repository.PullRequest.AddCoCommitterTrailers && ctx.committer.String() != sig.String() {
-		// add trailer
+	if setting.Repository.PullRequest.AddCoCommitterTrailers && ctx.committer.Email != sig.Email {
+		// add trailer if email of user and email of committer don't match
 		message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 	}
 	cmdCommit := git.NewCommand(ctx, "commit").

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -64,7 +64,6 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
-	// RFC 1035 - host is case-insensitive, local part is case-sensitive
 	if setting.Repository.PullRequest.AddCoCommitterTrailers &&
 		strings.EqualFold(ctx.committer.Email, sig.Email) {
 		// add trailer if email of user and email of committer don't match

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -66,8 +66,7 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 
 	// RFC 1035 - host is case-insensitive, local part is case-sensitive
 	if setting.Repository.PullRequest.AddCoCommitterTrailers &&
-		strings.EqualFold(strings.SplitAfter(ctx.committer.Email, "@")[1], strings.SplitAfter(sig.Email, "@")[1]) &&
-		(strings.SplitAfter(ctx.committer.Email, "@")[0] != strings.SplitAfter(sig.Email, "@")[0]) {
+		strings.EqualFold(ctx.committer.Email, sig.Email) {
 		// add trailer if email of user and email of committer don't match
 		message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 	}

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -5,7 +5,7 @@ package pull
 
 import (
 	"fmt"
-        "strings"
+	"strings"
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
@@ -64,10 +64,10 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 		return err
 	}
 
-        // RFC 1035 - host is case-insensitive, local part is case-sensitive
+	// RFC 1035 - host is case-insensitive, local part is case-sensitive
 	if setting.Repository.PullRequest.AddCoCommitterTrailers &&
-           strings.EqualFold(strings.SplitAfter(ctx.committer.Email, "@")[1], strings.SplitAfter(sig.Email, "@")[1]) &&
-           (strings.SplitAfter(ctx.committer.Email, "@")[0] != strings.SplitAfter(sig.Email, "@")[0]) {
+		strings.EqualFold(strings.SplitAfter(ctx.committer.Email, "@")[1], strings.SplitAfter(sig.Email, "@")[1]) &&
+		(strings.SplitAfter(ctx.committer.Email, "@")[0] != strings.SplitAfter(sig.Email, "@")[0]) {
 		// add trailer if email of user and email of committer don't match
 		message += fmt.Sprintf("\nCo-authored-by: %s\nCo-committed-by: %s\n", sig.String(), sig.String())
 	}


### PR DESCRIPTION
When squashing commits in web UI, only compare emails
    
Say that a user uses the email address "user@example.com" in their
local Git configuration, as well as their Gitea profile. Right now,
if they use a different name for their profile than the one that
they use in their local Git configuration (e.g. they make commits
using their full name, but their profile contains a different
for a display name pseudonym, then the UI will act as if there
are two separate identities, even if they use the same email address.
    
This doesn't fix the underlying problem completely (user accounts
can contain multiple email addresses), but it improves it.