### PR TITLE
Add branch prefix to mirror synced push results

### DIFF
--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -143,7 +143,7 @@ func parseRemoteUpdateOutput(output string) []*mirrorSyncResult {
 				continue
 			}
 			results = append(results, &mirrorSyncResult{
-				refName:     refName,
+				refName:     git.BranchPrefix + refName,
 				oldCommitID: shas[0],
 				newCommitID: shas[1],
 			})


### PR DESCRIPTION
Possible fix for https://github.com/go-gitea/gitea/issues/24926