### PR TITLE
Fix doc for 1.19 backend guideline

### DIFF
--- a/docs/content/doc/contributing/guidelines-backend.en-us.md
+++ b/docs/content/doc/contributing/guidelines-backend.en-us.md
@@ -35,7 +35,7 @@ To maintain understandable code and avoid circular dependencies it is important 
 - `cmd`: All Gitea actual sub commands includes web, doctor, serv, hooks, admin and etc. `web` will start the web service. `serv` and `hooks` will be invoked by Git or OpenSSH. Other sub commands could help to maintain Gitea.
 - `tests`: Common test utility functions
   - `tests/integration`: Integration tests, to test back-end regressions
-  - `tests/e2e`: E2e tests, to test test front-end <> back-end compatibility and visual regressions.
+  - `tests/e2e`: E2e tests, to test front-end and back-end compatibility and visual regressions.
 - `models`: Contains the data structures used by xorm to construct database tables. It also contains functions to query and update the database. Dependencies to other Gitea code should be avoided. You can make exceptions in cases such as logging.
   - `models/db`: Basic database operations. All other `models/xxx` packages should depend on this package. The `GetEngine` function should only be invoked from `models/`.
   - `models/fixtures`: Sample data used in unit tests and integration tests. One `yml` file means one table which will be loaded into database when beginning the tests.
@@ -70,7 +70,6 @@ So services must be allowed to create a database transaction. Here is some examp
 // services/repository/repository.go
 func CreateXXXX() error {
     return db.WithTx(func(ctx context.Context) error {
-        e := db.GetEngine(ctx)
         // do something, if err is returned, it will rollback automatically
         if err := issues.UpdateIssue(ctx, repoID); err != nil {
             // ...


### PR DESCRIPTION
Port the file change in https://github.com/go-gitea/gitea/pull/24925/files from `main` to `v1.19` to fix docs