### PR TITLE
Show `bot` label next to username when rendering autor link if the user is a bot

### DIFF
--- a/models/user/user.go
+++ b/models/user/user.go
@@ -406,6 +406,11 @@ func (u *User) IsIndividual() bool {
 	return u.Type == UserTypeIndividual
 }
 
+// IsBot returns whether or not the user is of type bot
+func (u *User) IsBot() bool {
+	return u.Type == UserTypeBot
+}
+
 // DisplayName returns full name if it's not empty,
 // returns username otherwise.
 func (u *User) DisplayName() string {

--- a/templates/shared/user/authorlink.tmpl
+++ b/templates/shared/user/authorlink.tmpl
@@ -1,1 +1,1 @@
-<a class="author text black gt-font-semibold muted"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>
+<a class="author text black gt-font-semibold muted"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>{{if .IsBot}}<span class="ui label">bot</span>{{end}}

--- a/templates/shared/user/authorlink.tmpl
+++ b/templates/shared/user/authorlink.tmpl
@@ -1,1 +1,1 @@
-<a class="author text black gt-font-semibold muted"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>{{if .IsBot}}<span class="ui label">bot</span>{{end}}
+<a class="author text black gt-font-semibold muted"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>{{if .IsBot}}<span class="ui basic label gt-p-2">bot</span>{{end}}


### PR DESCRIPTION
If the user is a bot, we'll add a label next to the author link that says `bot`. I didn't localize `bot` because passing `locale` into the `autorlink` template would require changing all calls.

# Example
`yardenshoham` is a bot.
## Before
![image](https://github.com/go-gitea/gitea/assets/20454870/77390780-b763-4f0f-b358-bbccdbf17a5d)

## After
![image](https://github.com/go-gitea/gitea/assets/20454870/72af342f-ee76-4337-95ad-4ecaba853fed)
