### PR TITLE
Make the 500 page load themes

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -20,7 +20,6 @@
 {{end}}
 	<link rel="icon" href="{{AssetUrlPrefix}}/img/favicon.svg" type="image/svg+xml">
 	<link rel="alternate icon" href="{{AssetUrlPrefix}}/img/favicon.png" type="image/png">
-	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/index.css?v={{AssetVersion}}">
 	{{template "base/head_script" .}}
 	<noscript>
 		<style>
@@ -63,15 +62,9 @@
 	<meta property="og:url" content="{{AppUrl}}">
 	<meta property="og:description" content="{{MetaDescription}}">
 {{end}}
-<meta property="og:site_name" content="{{AppName}}">
-{{if .IsSigned}}
-	{{if ne .SignedUser.Theme "gitea"}}
-		<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{.SignedUser.Theme | PathEscape}}.css?v={{AssetVersion}}">
-	{{end}}
-{{else if ne DefaultTheme "gitea"}}
-	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{DefaultTheme | PathEscape}}.css?v={{AssetVersion}}">
-{{end}}
-{{template "custom/header" .}}
+	<meta property="og:site_name" content="{{AppName}}">
+	{{template "base/stylesheets" .}}
+	{{template "custom/header" .}}
 </head>
 <body>
 	{{template "custom/body_outer_pre" .}}

--- a/templates/base/stylesheets.tmpl
+++ b/templates/base/stylesheets.tmpl
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/index.css?v={{AssetVersion}}">
+{{if .IsSigned}}
+	{{if ne .SignedUser.Theme "gitea"}}
+		<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{.SignedUser.Theme | PathEscape}}.css?v={{AssetVersion}}">
+	{{end}}
+{{else if ne DefaultTheme "gitea"}}
+	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/theme-{{DefaultTheme | PathEscape}}.css?v={{AssetVersion}}">
+{{end}}

--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -11,7 +11,7 @@
 	<title>Internal Server Error - {{AppName}}</title>
 	<link rel="icon" href="{{AssetUrlPrefix}}/img/favicon.svg" type="image/svg+xml">
 	<link rel="alternate icon" href="{{AssetUrlPrefix}}/img/favicon.png" type="image/png">
-	<link rel="stylesheet" href="{{AssetUrlPrefix}}/css/index.css?v={{AssetVersion}}">
+	{{template "base/stylesheets" .}}
 </head>
 <body>
 	<div class="full height">


### PR DESCRIPTION
The 500 page was not loading theme CSS, so always appeared in light theme. This extracts the stylesheets into a shared template used by all pages.

<img width="1262" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/72222b8d-a523-40d0-aa91-b9db32e5625d">

Small related rant: I think there should only be one `<head>` in all of the templates, but I see it was deliberatly done that the 500 page has its own `<head>` because "it should only depend the minimal template functions", but I disagree because we are missing a lot of things that are in the regular `<head>`.