### PR TITLE
Use `[git.config]` for reflog cleaning up

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -694,16 +694,12 @@ LEVEL = Info
 ;GC = 60
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Git Reflog timeout in days
-;[git.reflog]
-;ENABLED = true
-;EXPIRATION = 90
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Git config options
 ;; This section only does "set" config, a removed config key from this section won't be removed from git config automatically. The format is `some.configKey = value`.
 ;[git.config]
 ;diff.algorithm = histogram
+;core.logAllRefUpdates = true
+;gc.reflogExpire = 90
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -1065,17 +1065,14 @@ Default templates for project boards:
 - `PULL`: **300**: Git pull from internal repositories timeout seconds.
 - `GC`: **60**: Git repository GC timeout seconds.
 
-### Git - Reflog settings (`git.reflog`)
-
-- `ENABLED`: **true** Set to true to enable Git to write changes to reflogs in each repo.
-- `EXPIRATION`: **90** Reflog entry lifetime, in days. Entries are removed opportunistically by Git.
-
 ### Git - Config options (`git.config`)
 
 The key/value pairs in this section will be used as git config.
 This section only does "set" config, a removed config key from this section won't be removed from git config automatically. The format is `some.configKey = value`.
 
 - `diff.algorithm`: **histogram**
+- `core.logAllRefUpdates`: **true**
+- `gc.reflogExpire`: **90**
 
 ## Metrics (`metrics`)
 

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -201,23 +201,6 @@ func InitFull(ctx context.Context) (err error) {
 	return syncGitConfig()
 }
 
-func enableReflogs() error {
-	if err := configSet("core.logAllRefUpdates", "true"); err != nil {
-		return err
-	}
-	err := configSet("gc.reflogExpire", fmt.Sprintf("%d", setting.Git.Reflog.Expiration))
-	return err
-}
-
-func disableReflogs() error {
-	if err := configUnsetAll("core.logAllRefUpdates", "true"); err != nil {
-		return err
-	} else if err := configUnsetAll("gc.reflogExpire", ""); err != nil {
-		return err
-	}
-	return nil
-}
-
 // syncGitConfig only modifies gitconfig, won't change global variables (otherwise there will be data-race problem)
 func syncGitConfig() (err error) {
 	if err = os.MkdirAll(HomeDir(), os.ModePerm); err != nil {
@@ -247,16 +230,6 @@ func syncGitConfig() (err error) {
 	// Set git some configurations - these must be set to these values for gitea to work correctly
 	if err := configSet("core.quotePath", "false"); err != nil {
 		return err
-	}
-
-	if setting.Git.Reflog.Enabled {
-		if err := enableReflogs(); err != nil {
-			return err
-		}
-	} else {
-		if err := disableReflogs(); err != nil {
-			return err
-		}
 	}
 
 	if CheckGitVersionAtLeast("2.10") == nil {

--- a/modules/setting/git_test.go
+++ b/modules/setting/git_test.go
@@ -43,7 +43,7 @@ func TestGitReflog(t *testing.T) {
 		GitConfig = oldGitConfig
 	}()
 
-	// default legacy reflog config
+	// default reflog config without legacy options
 	cfg, err := NewConfigProviderFromData(``)
 	assert.NoError(t, err)
 	loadGitFrom(cfg)
@@ -51,7 +51,7 @@ func TestGitReflog(t *testing.T) {
 	assert.EqualValues(t, "true", GitConfig.GetOption("core.logAllRefUpdates"))
 	assert.EqualValues(t, "90", GitConfig.GetOption("gc.reflogExpire"))
 
-	// custom reflog config
+	// custom reflog config by legacy options
 	cfg, err = NewConfigProviderFromData(`
 [git.reflog]
 ENABLED = false

--- a/modules/setting/git_test.go
+++ b/modules/setting/git_test.go
@@ -23,8 +23,6 @@ a.b = 1
 `)
 	assert.NoError(t, err)
 	loadGitFrom(cfg)
-
-	assert.Len(t, GitConfig.Options, 2)
 	assert.EqualValues(t, "1", GitConfig.Options["a.b"])
 	assert.EqualValues(t, "histogram", GitConfig.Options["diff.algorithm"])
 
@@ -34,7 +32,34 @@ diff.algorithm = other
 `)
 	assert.NoError(t, err)
 	loadGitFrom(cfg)
-
-	assert.Len(t, GitConfig.Options, 1)
 	assert.EqualValues(t, "other", GitConfig.Options["diff.algorithm"])
+}
+
+func TestGitReflog(t *testing.T) {
+	oldGit := Git
+	oldGitConfig := GitConfig
+	defer func() {
+		Git = oldGit
+		GitConfig = oldGitConfig
+	}()
+
+	// default legacy reflog config
+	cfg, err := NewConfigProviderFromData(``)
+	assert.NoError(t, err)
+	loadGitFrom(cfg)
+
+	assert.EqualValues(t, "true", GitConfig.GetOption("core.logAllRefUpdates"))
+	assert.EqualValues(t, "90", GitConfig.GetOption("gc.reflogExpire"))
+
+	// custom reflog config
+	cfg, err = NewConfigProviderFromData(`
+[git.reflog]
+ENABLED = false
+EXPIRATION = 123
+`)
+	assert.NoError(t, err)
+	loadGitFrom(cfg)
+
+	assert.EqualValues(t, "false", GitConfig.GetOption("core.logAllRefUpdates"))
+	assert.EqualValues(t, "123", GitConfig.GetOption("gc.reflogExpire"))
 }


### PR DESCRIPTION
Follow https://github.com/go-gitea/gitea/pull/24860#discussion_r1200589651

Use `[git.config]` for reflog cleaning up, the new options are more flexible.

* https://git-scm.com/docs/git-config#Documentation/git-config.txt-corelogAllRefUpdates
* https://git-scm.com/docs/git-config#Documentation/git-config.txt-gcreflogExpire

## :warning: BREAKING

The section `[git.reflog]` is now obsolete and its keys have been moved to the following replacements:
- `[git.reflog].ENABLED` → `[git.config].core.logAllRefUpdates`
- `[git.reflog].EXPIRATION` → `[git.config].gc.reflogExpire`