### PR TITLE
Add step start time to `ViewStepLog`

### DIFF
--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -106,9 +106,10 @@ type ViewJobStep struct {
 }
 
 type ViewStepLog struct {
-	Step   int                `json:"step"`
-	Cursor int64              `json:"cursor"`
-	Lines  []*ViewStepLogLine `json:"lines"`
+	Step    int                `json:"step"`
+	Cursor  int64              `json:"cursor"`
+	Lines   []*ViewStepLogLine `json:"lines"`
+	Started int64              `json:"started"`
 }
 
 type ViewStepLogLine struct {
@@ -241,9 +242,10 @@ func ViewPost(ctx *context_module.Context) {
 			}
 
 			resp.Logs.StepsLog = append(resp.Logs.StepsLog, &ViewStepLog{
-				Step:   cursor.Step,
-				Cursor: cursor.Cursor + int64(len(logLines)),
-				Lines:  logLines,
+				Step:    cursor.Step,
+				Cursor:  cursor.Cursor + int64(len(logLines)),
+				Lines:   logLines,
+				Started: int64(step.Started),
 			})
 		}
 	}


### PR DESCRIPTION
Part of #24876

According to https://github.com/go-gitea/gitea/pull/24876#discussion_r1205565622 , we need the start time of the step to get the log time offset.