### PR TITLE
Hide `show more` btn in file-tree list if no more data

### DIFF
--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -147,6 +147,7 @@ export default {
         this.isLoadingNewData = false;
         const {pageData} = window.config;
         this.diffEnd = pageData.diffFileInfo.diffEnd;
+        this.isIncomplete = pageData.diffFileInfo.isIncomplete;
       });
     },
   },

--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -7,7 +7,7 @@
     <div class="ui list">
       <DiffFileTreeItem v-for="item in fileTree" :key="item.name" :item="item"/>
     </div>
-    <div v-if="hasMore" id="diff-too-many-files-stats" class="gt-pt-2">
+    <div v-if="isIncomplete" id="diff-too-many-files-stats" class="gt-pt-2">
       <span class="gt-mr-2">{{ tooManyFilesMessage }}</span><a :class="['ui', 'basic', 'tiny', 'button', isLoadingNewData === true ? 'disabled' : '']" id="diff-show-more-files-stats" @click.stop="loadMoreData">{{ showMoreMessage }}</a>
     </div>
   </div>
@@ -34,14 +34,6 @@ export default {
     };
   },
   computed: {
-    hasMore: {
-      get() {
-        return this.isIncomplete;
-      },
-      set(newValue) {
-        this.isIncomplete = newValue;
-      }
-    },
     fileTree() {
       const result = [];
       for (const file of this.files) {
@@ -156,6 +148,7 @@ export default {
         this.isLoadingNewData = false;
         const {pageData} = window.config;
         this.diffEnd = pageData.diffFileInfo.diffEnd;
+        this.isIncomplete = pageData.diffFileInfo.isIncomplete;
       });
     },
   },

--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -7,7 +7,7 @@
     <div class="ui list">
       <DiffFileTreeItem v-for="item in fileTree" :key="item.name" :item="item"/>
     </div>
-    <div v-if="isIncomplete" id="diff-too-many-files-stats" class="gt-pt-2">
+    <div v-if="hasMore" id="diff-too-many-files-stats" class="gt-pt-2">
       <span class="gt-mr-2">{{ tooManyFilesMessage }}</span><a :class="['ui', 'basic', 'tiny', 'button', isLoadingNewData === true ? 'disabled' : '']" id="diff-show-more-files-stats" @click.stop="loadMoreData">{{ showMoreMessage }}</a>
     </div>
   </div>
@@ -34,6 +34,14 @@ export default {
     };
   },
   computed: {
+    hasMore: {
+      get() {
+        return this.isIncomplete;
+      },
+      set(newValue) {
+        this.isIncomplete = newValue;
+      }
+    },
     fileTree() {
       const result = [];
       for (const file of this.files) {
@@ -148,7 +156,6 @@ export default {
         this.isLoadingNewData = false;
         const {pageData} = window.config;
         this.diffEnd = pageData.diffFileInfo.diffEnd;
-        this.isIncomplete = pageData.diffFileInfo.isIncomplete;
       });
     },
   },

--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -94,6 +94,7 @@ export default {
       // Merge folders with just a folder as children in order to
       // reduce the depth of our tree.
       mergeChildIfOnlyOneDir(result);
+      this.isIncomplete = pageData.diffFileInfo.isIncomplete;
       return result;
     }
   },


### PR DESCRIPTION
fix #24938
Click `show more` btn in file-tree list:

https://github.com/go-gitea/gitea/assets/33891828/3d192313-59e9-4dd6-ad59-12fb83c6aed7

Click `show more` btn in file list:

https://github.com/go-gitea/gitea/assets/33891828/68e5b2e0-43de-40a1-9c06-16e94ded6eec



