### PR TITLE
Upgrade snap to node 20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
     source: .
     stage-packages: [ git, sqlite3, openssh-client ]
     build-packages: [ git, libpam0g-dev, libsqlite3-dev, build-essential]
-    build-snaps: [ go, node/18/stable ]
+    build-snaps: [ go, node/20/stable ]
     build-environment:
       - LDFLAGS: ""
     override-pull: |


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/pull/24524. Now there is a [node 20 snap](https://snapcraft.io/node), so let's upgrade to it.