### PR TITLE
Unify doc links to use paths relative to doc folder (#24979)

### DIFF
--- a/docs/content/doc/development/hacking-on-gitea.en-us.md
+++ b/docs/content/doc/development/hacking-on-gitea.en-us.md
@@ -121,9 +121,8 @@ to the Gitea sources. Otherwise, changes can't be pushed.
 ## Building Gitea (Basic)
 
 Take a look at our
-<a href='{{< relref "doc/installation/from-source.en-us.md" >}}'>instructions</a>
-for <a href='{{< relref "doc/installation/from-source.en-us.md" >}}'>building
-from source</a>.
+[instructions]({{< relref "doc/installation/from-source.en-us.md" >}})
+for [building from source]({{< relref "doc/installation/from-source.en-us.md" >}}).
 
 The simplest recommended way to build from source is:
 
@@ -264,7 +263,7 @@ OpenAPI 3 documentation.
 When creating new configuration options, it is not enough to add them to the
 `modules/setting` files. You should add information to `custom/conf/app.ini`
 and to the
-<a href='{{< relref "doc/administration/config-cheat-sheet.en-us.md" >}}'>configuration cheat sheet</a>
+[configuration cheat sheet]({{< relref "doc/administration/config-cheat-sheet.en-us.md" >}})
 found in `docs/content/doc/administer/config-cheat-sheet.en-us.md`
 
 ### Changing the logo

--- a/docs/content/doc/development/hacking-on-gitea.zh-cn.md
+++ b/docs/content/doc/development/hacking-on-gitea.zh-cn.md
@@ -113,8 +113,8 @@ git fetch --all --prune
 ## 构建 Gitea（基本）
 
 看看我们的
-<a href='{{ < relref "doc/installation/from-source.en-us.md" > }}'>说明</a>
-关于如何 <a href='{{ < relref "doc/installation/from-source.en-us.md" > }}'>从源代码构建</a> 。
+[说明]({{< relref "doc/installation/from-source.zh-cn.md" >}})
+关于如何[从源代码构建]({{< relref "doc/installation/from-source.zh-cn.md" >}}) 。
 
 从源代码构建的最简单推荐方法是：
 
@@ -247,8 +247,8 @@ make swagger-check
 ### 创建新的配置选项
 
 创建新的配置选项时，将它们添加到 `modules/setting` 的对应文件。您应该将信息添加到 `custom/conf/app.ini`
-并到 <a href = '{{ < relref "doc/administration/config-cheat-sheet.en-us.md" > }}'>配置备忘单</a>
-在 `docs/content/doc/advanced/config-cheat-sheet.en-us.md` 中找到
+并到[配置备忘单]({{< relref "doc/administration/config-cheat-sheet.zh-cn.md" >}})
+在 `docs/content/doc/advanced/config-cheat-sheet.zh-cn.md` 中找到
 
 ### 更改Logo
 

--- a/docs/content/doc/development/hacking-on-gitea.zh-cn.md
+++ b/docs/content/doc/development/hacking-on-gitea.zh-cn.md
@@ -248,7 +248,7 @@ make swagger-check
 
 创建新的配置选项时，将它们添加到 `modules/setting` 的对应文件。您应该将信息添加到 `custom/conf/app.ini`
 并到[配置备忘单]({{< relref "doc/administration/config-cheat-sheet.zh-cn.md" >}})
-在 `docs/content/doc/advanced/config-cheat-sheet.zh-cn.md` 中找到
+在 `docs/content/doc/advanced/config-cheat-sheet.en-us.md` 中找到
 
 ### 更改Logo
 

--- a/docs/content/doc/installation/from-binary.en-us.md
+++ b/docs/content/doc/installation/from-binary.en-us.md
@@ -186,7 +186,7 @@ Older Linux distributions (such as Debian 7 and CentOS 6) may not be able to loa
 Gitea binary, usually producing an error such as `./gitea: /lib/x86_64-linux-gnu/libc.so.6:
 version 'GLIBC\_2.14' not found (required by ./gitea)`. This is due to the integrated
 SQLite support in the binaries provided by dl.gitea.com. In this situation, it is usually
-possible to [install from source]({{< relref "from-source.en-us.md" >}}), without including
+possible to [install from source]({{< relref "doc/installation/from-source.en-us.md" >}}), without including
 SQLite support.
 
 ### Running Gitea on another port

--- a/docs/content/doc/installation/from-binary.fr-fr.md
+++ b/docs/content/doc/installation/from-binary.fr-fr.md
@@ -34,7 +34,7 @@ Après avoir suivi les étapes ci-dessus, vous aurez un binaire `gitea` dans vot
 
 ### Anciennes version de glibc
 
-Les anciennes distributions Linux (comme Debian 7 ou CentOS 6) peuvent ne pas être capable d'exécuter le binaire Gitea, résultant généralement une erreur du type ```./gitea: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found (required by ./gitea)```. Cette erreur est due au driver SQLite que nous intégrons dans le binaire Gitea. Dans le futur, nous fournirons des binaires sans la dépendance pour la bibliothèque glibc. En attendant, vous pouvez mettre à jour votre distribution ou installer Gitea depuis le [code source]({{< relref "from-source.fr-fr.md" >}}).
+Les anciennes distributions Linux (comme Debian 7 ou CentOS 6) peuvent ne pas être capable d'exécuter le binaire Gitea, résultant généralement une erreur du type ```./gitea: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found (required by ./gitea)```. Cette erreur est due au driver SQLite que nous intégrons dans le binaire Gitea. Dans le futur, nous fournirons des binaires sans la dépendance pour la bibliothèque glibc. En attendant, vous pouvez mettre à jour votre distribution ou installer Gitea depuis le [code source]({{< relref "doc/installation/from-source.fr-fr.md" >}}).
 
 ### Exécuter Gitea avec un autre port
 

--- a/docs/content/doc/installation/from-binary.zh-cn.md
+++ b/docs/content/doc/installation/from-binary.zh-cn.md
@@ -129,7 +129,7 @@ cp gitea /usr/local/bin/gitea
 
 ### 1. 创建服务自动启动 Gitea（推荐）
 
-学习创建 [Linux 服务]({{< relref "run-as-service-in-ubuntu.zh-cn.md" >}})
+学习创建 [Linux 服务]({{< relref "doc/installation/run-as-service-in-ubuntu.zh-cn.md" >}})
 
 ### 2. 通过命令行终端运行
 
@@ -161,4 +161,4 @@ GITEA_WORK_DIR=/var/lib/gitea/ /usr/local/bin/gitea web -c /etc/gitea/app.ini
 
 > 更多经验总结，请参考英文版 [Troubleshooting](/en-us/install-from-binary/#troubleshooting)
 
-如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "doc/help/seek-help.zh-cn.md" >}})

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -77,7 +77,7 @@ Or follow the [deployment from binary]({{< relref "doc/installation/from-binary.
 ## macOS
 
 Currently, the only supported method of installation on MacOS is [Homebrew](http://brew.sh/).
-Following the [deployment from binary]({{< relref "from-binary.en-us.md" >}}) guide may work,
+Following the [deployment from binary]({{< relref "doc/installation/from-binary.en-us.md" >}}) guide may work,
 but is not supported. To install Gitea via `brew`:
 
 ```

--- a/docs/content/doc/installation/from-package.en-us.md
+++ b/docs/content/doc/installation/from-package.en-us.md
@@ -72,7 +72,7 @@ There is a [Gitea](https://chocolatey.org/packages/gitea) package for Windows by
 choco install gitea
 ```
 
-Or follow the [deployment from binary]({{< relref "from-binary.en-us.md" >}}) guide.
+Or follow the [deployment from binary]({{< relref "doc/installation/from-binary.en-us.md" >}}) guide.
 
 ## macOS
 

--- a/docs/content/doc/installation/from-package.fr-fr.md
+++ b/docs/content/doc/installation/from-package.fr-fr.md
@@ -17,15 +17,15 @@ menu:
 
 ## Linux
 
-Nous n'avons pas encore publié de paquet pour Linux, nous allons mettre à jour cette page directement lorsque nous commencerons à publier des paquets pour toutes distributions Linux. En attendant, vous devriez suivre les [instructions d'installation]({{< relref "from-binary.fr-fr.md" >}}) avec le binaire pré-compilé.
+Nous n'avons pas encore publié de paquet pour Linux, nous allons mettre à jour cette page directement lorsque nous commencerons à publier des paquets pour toutes distributions Linux. En attendant, vous devriez suivre les [instructions d'installation]({{< relref "doc/installation/from-binary.fr-fr.md" >}}) avec le binaire pré-compilé.
 
 ## Windows
 
-Nous n'avons pas encore publié de paquet pour Windows, nous allons mettre à jour cette page directement lorsque nous commencerons à publier des paquets sous la forme de fichiers `MSI` ou via [Chocolatey](https://chocolatey.org/). En attendant, vous devriez suivre les [instructions d'installation]({{< relref "from-binary.fr-fr.md" >}}) avec le binaire pré-compilé.
+Nous n'avons pas encore publié de paquet pour Windows, nous allons mettre à jour cette page directement lorsque nous commencerons à publier des paquets sous la forme de fichiers `MSI` ou via [Chocolatey](https://chocolatey.org/). En attendant, vous devriez suivre les [instructions d'installation]({{< relref "doc/installation/from-binary.fr-fr.md" >}}) avec le binaire pré-compilé.
 
 ## macOS
 
-Actuellement, nous ne supportons que l'installation via `brew` pour macOS. Si vous n'utilisez pas [Homebrew](http://brew.sh/), vous pouvez suivre les [instructions d'installation]({{< relref "from-binary.fr-fr.md" >}}) avec le binaire pré-compilé. Pour installer Gitea depuis `brew`, utilisez les commandes suivantes :
+Actuellement, nous ne supportons que l'installation via `brew` pour macOS. Si vous n'utilisez pas [Homebrew](http://brew.sh/), vous pouvez suivre les [instructions d'installation]({{< relref "doc/installation/from-binary.fr-fr.md" >}}) avec le binaire pré-compilé. Pour installer Gitea depuis `brew`, utilisez les commandes suivantes :
 
 ```
 brew tap go-gitea/gitea

--- a/docs/content/doc/installation/from-package.zh-cn.md
+++ b/docs/content/doc/installation/from-package.zh-cn.md
@@ -68,7 +68,7 @@ choco install gitea
 
 ## macOS
 
-macOS 平台下当前我们仅支持通过 `brew` 来安装。如果你没有安装 [Homebrew](http://brew.sh/)，你也可以查看 [从二进制安装]({{< relref "from-binary.zh-cn.md" >}})。在你安装了 `brew` 之后， 你可以执行以下命令：
+macOS 平台下当前我们仅支持通过 `brew` 来安装。如果你没有安装 [Homebrew](http://brew.sh/)，你也可以查看 [从二进制安装]({{< relref "doc/installation/from-binary.zh-cn.md" >}})。在你安装了 `brew` 之后， 你可以执行以下命令：
 
 ```
 brew tap gitea/tap https://gitea.com/gitea/homebrew-gitea

--- a/docs/content/doc/installation/from-package.zh-cn.md
+++ b/docs/content/doc/installation/from-package.zh-cn.md
@@ -64,7 +64,7 @@ OpenSUSE 构建服务为 [openSUSE 和 SLE](https://software.opensuse.org/downlo
 choco install gitea
 ```
 
-你也可以 [从二进制安装]({{< relref "from-binary.zh-cn.md" >}}) 。
+你也可以 [从二进制安装]({{< relref "doc/installation/from-binary.zh-cn.md" >}}) 。
 
 ## macOS
 

--- a/docs/content/doc/installation/from-package.zh-tw.md
+++ b/docs/content/doc/installation/from-package.zh-tw.md
@@ -17,7 +17,7 @@ menu:
 
 ## Linux
 
-目前尚未發佈任何 Linux 套件，如果我們發佈了，會直接更新此網頁。在這之前請先參考[執行檔安裝]({{< relref "from-binary.zh-tw.md" >}})方式。
+目前尚未發佈任何 Linux 套件，如果我們發佈了，會直接更新此網頁。在這之前請先參考[執行檔安裝]({{< relref "doc/installation/from-binary.zh-tw.md" >}})方式。
 
 ## Windows
 
@@ -27,11 +27,11 @@ menu:
 choco install gitea
 ```
 
-也可以參考[執行檔安裝]({{< relref "from-binary.zh-tw.md" >}})方式。
+也可以參考[執行檔安裝]({{< relref "doc/installation/from-binary.zh-tw.md" >}})方式。
 
 ## macOS
 
-目前我們只支援透過 `brew` 來安裝套件。假如您尚未使用 [Homebrew](http://brew.sh/)，您就必須參考[執行檔安裝]({{< relref "from-binary.zh-tw.md" >}})方式。透過 `brew` 安裝 Gitea，您只需要執行底下指令:
+目前我們只支援透過 `brew` 來安裝套件。假如您尚未使用 [Homebrew](http://brew.sh/)，您就必須參考[執行檔安裝]({{< relref "doc/installation/from-binary.zh-tw.md" >}})方式。透過 `brew` 安裝 Gitea，您只需要執行底下指令:
 
 ```
 brew tap go-gitea/gitea

--- a/docs/content/doc/installation/from-source.en-us.md
+++ b/docs/content/doc/installation/from-source.en-us.md
@@ -33,8 +33,7 @@ executable path, you will have to manage this yourself.
 
 **Note 2**: Go version {{< min-go-version >}} or higher is required. However, it is recommended to
 obtain the same version as our continuous integration, see the advice given in
-<a href='{{< relref "doc/development/hacking-on-gitea.en-us.md" >}}'>Hacking on
-Gitea</a>
+[Hacking on Gitea]({{< relref "doc/development/hacking-on-gitea.en-us.md" >}})
 
 **Table of Contents**
 


### PR DESCRIPTION
Backport #24979 

Changes:

1. Use uniform links types relative to doc folder (start with `doc/`)
2. According to [docusaurus links](https://docusaurus.io/docs/markdown-features/links), if `<a>` is used, the `href` is resolved as URL location, but not file location.  So need to use `[text]({{< relref "path" >}})` instead.