### PR TITLE
Fix delete user account modal

### DIFF
--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -197,17 +197,17 @@
 		{{svg "octicon-trash"}}
 		{{.locale.Tr "settings.delete_account_title"}}
 	</div>
-	<div class="content">
-		<p>{{.locale.Tr "settings.delete_account_desc"}}</p>
-	</div>
 	<form class="ui form" method="POST" action="{{.Link}}/delete">
-		{{$.CsrfTokenHtml}}
-		<div class="field">
-			<div class="ui checkbox">
-				<label for="purge">{{.locale.Tr "admin.users.purge"}}</label>
-				<input name="purge" type="checkbox">
+		<div class="content">
+			<p>{{.locale.Tr "settings.delete_account_desc"}}</p>
+			{{$.CsrfTokenHtml}}
+			<div class="field">
+				<div class="ui checkbox">
+					<label for="purge">{{.locale.Tr "admin.users.purge"}}</label>
+					<input name="purge" type="checkbox">
+				</div>
+				<p class="help">{{.locale.Tr "admin.users.purge_help"}}</p>
 			</div>
-			<p class="help">{{.locale.Tr "admin.users.purge_help"}}</p>
 		</div>
 		{{template "base/modal_actions_confirm" .}}
 	</form>


### PR DESCRIPTION
Before:

<img width="953" alt="Screen Shot 2023-05-30 at 17 08 57" src="https://github.com/go-gitea/gitea/assets/17645053/f379b2c9-7d9a-492e-b0e4-5a8be1c3a025">

After:

<img width="875" alt="Screen Shot 2023-05-30 at 17 06 17" src="https://github.com/go-gitea/gitea/assets/17645053/75d3c9b5-201b-4001-a27e-64c932e2e34a">
