### PR TITLE
Update repo's default branch when adding new files in an empty one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cpu.out
 
 *.db
 *.log
+*.log.*.gz
 
 /gitea
 /gitea-vet

--- a/tests/integration/empty_repo_test.go
+++ b/tests/integration/empty_repo_test.go
@@ -137,4 +137,10 @@ func TestEmptyRepoAddFileByAPI(t *testing.T) {
 	req = NewRequest(t, "GET", "/user30/empty/src/branch/new_branch/new-file.txt")
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), "newly-added-api-file")
+
+	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/repos/user30/empty?token=%s", token))
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	var apiRepo api.Repository
+	DecodeJSON(t, resp, &apiRepo)
+	assert.Equal(t, "new_branch", apiRepo.DefaultBranch)
 }


### PR DESCRIPTION
Fix #25014

Only API needs this fix. On the Web UI, users could only add new file on the default branch.