### PR TITLE
Add link to repository code language badges to direct to repo list with lang filter #24993

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -871,6 +871,7 @@ func renderLanguageStats(ctx *context.Context) {
 	}
 
 	ctx.Data["LanguageStats"] = langs
+	ctx.Data["HomeLink"] = ctx.ContextUser.HomeLink()
 }
 
 func renderRepoTopics(ctx *context.Context) {

--- a/templates/repo/sub_menu.tmpl
+++ b/templates/repo/sub_menu.tmpl
@@ -28,13 +28,13 @@
 			{{range .LanguageStats}}
 			<div class="item gt-df gt-ac gt-jc">
 				<i class="color-icon gt-mr-3" style="background-color: {{.Color}}"></i>
-				<span class="gt-font-semibold gt-mr-3">
+				<a class="gt-font-semibold gt-mr-3" href="{{$.HomeLink}}?q=&sort=recentupdate&language={{.Language}}">
 					{{if eq .Language "other"}}
 						{{$.locale.Tr "repo.language_other"}}
 					{{else}}
 						{{.Language}}
 					{{end}}
-				</span>
+				</a>
 				{{.Percentage}}%
 			</div>
 			{{end}}


### PR DESCRIPTION
Add a link to the code language badge to direct to repo list with lang filter. (Same functionality on the repo list where you can click the code language to show only repos with same primary code language)

![image](https://github.com/go-gitea/gitea/assets/72307968/f3116407-fe0d-461f-98ba-f62c7f93a172)

closes #24993