### PR TITLE
EasyMDE: enable autosave

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -190,6 +190,10 @@ class ComboMarkdownEditor {
     // EasyMDE's CSS should be loaded via webpack config, otherwise our own styles can not overwrite the default styles.
     const {default: EasyMDE} = await import(/* webpackChunkName: "easymde" */'easymde');
     const easyMDEOpt = {
+      autosave: {
+        enabled: true,
+        uniqueId: this.textarea.id
+      },
       autoDownloadFontAwesome: false,
       element: this.textarea,
       forceSync: true,


### PR DESCRIPTION
Enable autosave editor by default. It is annoying that you can lose whole text when you accidentally close a window or you do some miss click.

The easy markdown editor has options for this behavior.

https://github.com/Ionaru/easy-markdown-editor#options-list