### PR TITLE
Fix "from" branch not being shown in swedish translation

### DIFF
--- a/options/locale/locale_sv-SE.ini
+++ b/options/locale/locale_sv-SE.ini
@@ -1122,7 +1122,7 @@ pulls.filter_branch=Filtrera gren
 pulls.no_results=Inga resultat hittades.
 pulls.nothing_to_compare=Dessa brancher är ekvivalenta. Det finns ingen anledning att skapa en pull-request.
 pulls.create=Skapa Pullförfrågan
-pulls.title_desc=vill sammanfoga %[1]d incheckningar från <code>s[2]s</code> in i <code id="branch_target">%[3]s</code>
+pulls.title_desc=vill sammanfoga %[1]d incheckningar från <code>%[2]s</code> in i <code id="branch_target">%[3]s</code>
 pulls.merged_title_desc=sammanfogade %[1]d incheckningar från <code>%[2]s</code> in i <code>%[3]s</code> %[4]s
 pulls.change_target_branch_at=`ändrade mål-branch från <b>%s</b> till <b>%s</b>%s`
 pulls.tab_conversation=Konversation


### PR DESCRIPTION
A typo in the format string kept the "from" branch from being shown in the UI.
