### PR TITLE
Remove cancel button from branch protection form

### DIFF
--- a/templates/repo/settings/protected_branch.tmpl
+++ b/templates/repo/settings/protected_branch.tmpl
@@ -256,7 +256,6 @@
 
 				<div class="field">
 					<button class="ui green button">{{$.locale.Tr "repo.settings.protected_branch.save_rule"}}</button>
-					<button class="ui gray button">{{$.locale.Tr "cancel"}}</button>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
It caused bugs. To cancel, just navigate away.

- Follows #21381 and #21872
- Resolves #25038 

## Before
![image](https://github.com/go-gitea/gitea/assets/20454870/068c8d96-fc50-4725-8af2-d953e9f39024)

## After
![image](https://github.com/go-gitea/gitea/assets/20454870/105d5c50-e490-456a-a253-269b174c09ab)
