### PR TITLE
Use correct selector for hiding RSS icon link in the branch selector dropdown

### DIFF
--- a/web_src/js/components/RepoBranchTagSelector.vue
+++ b/web_src/js/components/RepoBranchTagSelector.vue
@@ -296,10 +296,10 @@ export default sfc; // activate IDE's Vue plugin
 </script>
 
 <style scoped>
-.menu .item a {
+.menu .item .rss-icon {
   display: none; /* only show RSS icon on hover */
 }
-.menu .item:hover a {
+.menu .item:hover .rss-icon {
   display: inline-block;
 }
 </style>


### PR DESCRIPTION
Fix  #25079

![image](https://github.com/go-gitea/gitea/assets/2114189/5d3f2f49-018a-4b75-8c90-ffafd898697a)

![image](https://github.com/go-gitea/gitea/assets/2114189/3e9dcf2e-eca7-4e96-be79-3b26f222cdb9)

![image](https://github.com/go-gitea/gitea/assets/2114189/855fffa4-0220-4ca2-a5e0-58c376fdc378)

![image](https://github.com/go-gitea/gitea/assets/2114189/f5ffa7e6-a974-4698-a45d-e38091903be1)
