### PR TITLE
Don't display `select all issues` checkbox when no issues are available

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -83,7 +83,7 @@
 		</div>
 		<div id="issue-filters" class="issue-list-toolbar">
 			<div class="issue-list-toolbar-left">
-				{{if $.CanWriteIssuesOrPulls}}
+				{{if and ($.CanWriteIssuesOrPulls) (gt (len .Issues) 0)}}
 					<input type="checkbox" autocomplete="off" class="issue-checkbox-all gt-mr-4" title="{{.locale.Tr "repo.issues.action_check_all"}}">
 				{{end}}
 				{{template "repo/issue/openclose" .}}


### PR DESCRIPTION
Before:
![image](https://github.com/go-gitea/gitea/assets/1969460/8830c077-89d4-4897-a6e0-f5dba6830ff7)

After:
![image](https://github.com/go-gitea/gitea/assets/1969460/8fa06878-496b-4f65-87eb-04e1f94d4a3c)
