### PR TITLE
Prevent mobile safari zooming in on repo search input

### DIFF
--- a/web_src/js/components/DashboardRepoList.vue
+++ b/web_src/js/components/DashboardRepoList.vue
@@ -17,7 +17,7 @@
       </h4>
       <div class="ui attached segment repos-search">
         <div class="ui fluid right action left icon input" :class="{loading: isLoading}">
-          <input @input="changeReposFilter(reposFilter)" v-model="searchQuery" ref="search" @keydown="reposFilterKeyControl" :placeholder="textSearchRepos">
+          <input class="repos-search-input" @input="changeReposFilter(reposFilter)" v-model="searchQuery" ref="search" @keydown="reposFilterKeyControl" :placeholder="textSearchRepos">
           <i class="icon gt-df gt-ac gt-jc"><svg-icon name="octicon-search" :size="16"/></i>
           <div class="ui dropdown icon button" :title="textFilter">
             <i class="icon gt-df gt-ac gt-jc gt-m-0"><svg-icon name="octicon-filter" :size="16"/></i>
@@ -521,5 +521,14 @@ ul li:not(:last-child) {
 
 .repo-owner-name-list li.active {
   background: var(--color-hover);
+}
+
+/* prevent mobile safari zoom in on <input> by setting 16px font size */
+/* https://stackoverflow.com/questions/2989263 */
+/* https://stackoverflow.com/questions/30102792 */
+@supports (-webkit-touch-callout: none) {
+  .repos-search-input {
+    font-size: 16px;
+  }
 }
 </style>


### PR DESCRIPTION
Mobile Safari will zoom to any input file whose font size is less than 16px, which is a bit annoying on the frontpage. Detect it specifically and set font size to 16px to prevent this zoom. The other solutions around like via `viewport` have drawbacks in that they may disable pinch-zooming, so I think this is an acceptable workaround.

Before, just after loading frontpage and autofocus taking effect:

<img width="322" alt="Screenshot 2023-06-05 at 22 47 24" src="https://github.com/go-gitea/gitea/assets/115237/33033acb-f76b-4a76-9a8c-aba3f23032de">

After:

<img width="326" alt="Screenshot 2023-06-05 at 22 47 03" src="https://github.com/go-gitea/gitea/assets/115237/23e9a77c-63f8-462c-9a24-ac46b1e69f55">