### PR TITLE
Remove incorrect element ID on "post-install" page

### DIFF
--- a/templates/post-install.tmpl
+++ b/templates/post-install.tmpl
@@ -5,9 +5,9 @@
 			<div class="sixteen wide column content">
 				<div class="home">
 					<div class="ui stackable middle very relaxed page grid">
-						<div id="repo_migrating" class="sixteen wide center aligned centered column">
+						<div class="sixteen wide center aligned centered column">
 							<div>
-								<img src="{{AssetUrlPrefix}}/img/loading.png">
+								<img src="{{AssetUrlPrefix}}/img/loading.png" alt="{{.locale.Tr "loading"}}">
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
That ID is a "copy&paste" error, it conflicts with the `initRepoMigrationStatusChecker` logic, which is the right function for a real `#repo_migrating` element. That wrong ID causes incorrect page navigation after installation.