### PR TITLE
Remove duplicated functions when deleting a branch

### DIFF
--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -17,7 +17,6 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/notification"
 	repo_module "code.gitea.io/gitea/modules/repository"
-	pull_service "code.gitea.io/gitea/services/pull"
 )
 
 // CreateNewBranch creates a new repository branch
@@ -181,10 +180,6 @@ func DeleteBranch(ctx context.Context, doer *user_model.User, repo *repo_model.R
 		return err
 	}
 
-	if err := pull_service.CloseBranchPulls(doer, repo.ID, branchName); err != nil {
-		return err
-	}
-
 	// Don't return error below this
 	if err := PushUpdate(
 		&repo_module.PushUpdateOptions{
@@ -197,10 +192,6 @@ func DeleteBranch(ctx context.Context, doer *user_model.User, repo *repo_model.R
 			RepoName:     repo.Name,
 		}); err != nil {
 		log.Error("Update: %v", err)
-	}
-
-	if err := git_model.AddDeletedBranch(ctx, repo.ID, branchName, commit.ID.String(), doer.ID); err != nil {
-		log.Warn("AddDeletedBranch: %v", err)
 	}
 
 	return nil

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -273,6 +273,9 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 					// close all related pulls
 					log.Error("close related pull request failed: %v", err)
 				}
+				if err := git_model.AddDeletedBranch(db.DefaultContext, repo.ID, branch, opts.OldCommitID, pusher.ID); err != nil {
+					log.Warn("AddDeletedBranch: %v", err)
+				}
 			}
 
 			// Even if user delete a branch on a repository which he didn't watch, he will be watch that.


### PR DESCRIPTION
Extract from #22743

`DeleteBranch` will trigger a push update event, so that `pull_service.CloseBranchPulls` has been invoked twice and `AddDeletedBranch` is better to be moved to push update then even user delete a branch via git command, it will also be triggered.