### PR TITLE
Fix strange UI behavior of cancelling dismiss review modal

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -58,10 +58,10 @@
 						</div>
 						<div class="gt-df gt-ac gt-gap-3">
 							{{if (and $.Permission.IsAdmin (or (eq .Review.Type 1) (eq .Review.Type 3)) (not $.Issue.IsClosed))}}
-								<a href="#" class="ui muted icon gt-df gt-ac dismiss-review-btn" data-review-id="dismiss-review-{{.Review.ID}}" data-tooltip-content="{{$.locale.Tr "repo.issues.dismiss_review"}}">
+								<a href="#" class="ui muted icon gt-df gt-ac show-modal" data-review-id="dismiss-review-{{.Review.ID}}" data-tooltip-content="{{$.locale.Tr "repo.issues.dismiss_review"}}" data-modal="#dismiss-review-modal">
 									{{svg "octicon-x" 20}}
 								</a>
-								<div class="ui small modal" id="dismiss-review-modal">
+								<div class="ui small modal dismiss-review-modal" id="dismiss-review-modal">
 									<div class="header">
 										{{$.locale.Tr "repo.issues.dismiss_review"}}
 									</div>

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -358,13 +358,6 @@ export function initRepoIssueComments() {
     ).then(() => window.location.reload());
   });
 
-  $('.dismiss-review-btn').on('click', function (e) {
-    e.preventDefault();
-    const $this = $(this);
-    const $dismissReviewModal = $this.next();
-    $dismissReviewModal.modal('show');
-  });
-
   $(document).on('click', (event) => {
     const urlTarget = $(':target');
     if (urlTarget.length === 0) return;


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/25130

The old code uses `$(this).next()` to get `dismiss-review-modal`.
At first, it will get `$(#dismiss-review-modal)`, but the next time it will get `$(#dismiss-review-modal).next();`
and then `$(#dismiss-review-modal).next().next();`.
Because div `dismiss-review-modal` will be removed when `dismiss-review-btn` clicked.

Maybe the right usage is adding `show-modal` class and `data-modal` attribute.