### PR TITLE
Fix open redirect check for more cases (#25143)

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -197,9 +197,9 @@ func (ctx *Context) RedirectToFirst(location ...string) {
 			continue
 		}
 
-		// Unfortunately browsers consider a redirect Location with preceding "//" and "/\" as meaning redirect to "http(s)://REST_OF_PATH"
+		// Unfortunately browsers consider a redirect Location with preceding "//", "\\" and "/\" as meaning redirect to "http(s)://REST_OF_PATH"
 		// Therefore we should ignore these redirect locations to prevent open redirects
-		if len(loc) > 1 && loc[0] == '/' && (loc[1] == '/' || loc[1] == '\\') {
+		if len(loc) > 1 && (loc[0] == '/' || loc[0] == '\\') && (loc[1] == '/' || loc[1] == '\\') {
 			continue
 		}
 


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/25143

If redirect_to parameter has set value starting with \\example.com redirect will be created with header Location: /\\example.com that will redirect to example.com domain.