### PR TITLE
Silently ignore the obsolete `sudo` token scope

### DIFF
--- a/models/auth/token_scope.go
+++ b/models/auth/token_scope.go
@@ -250,7 +250,7 @@ func (s AccessTokenScope) parse() (accessTokenScopeBitmap, error) {
 			remainingScopes = remainingScopes[i+1:]
 		}
 		singleScope := AccessTokenScope(v)
-		if singleScope == "" {
+		if singleScope == "" || singleScope == "sudo" {
 			continue
 		}
 		if singleScope == AccessTokenScopeAll {

--- a/models/auth/token_scope.go
+++ b/models/auth/token_scope.go
@@ -250,7 +250,7 @@ func (s AccessTokenScope) parse() (accessTokenScopeBitmap, error) {
 			remainingScopes = remainingScopes[i+1:]
 		}
 		singleScope := AccessTokenScope(v)
-		if singleScope == "" || singleScope == "sudo" {
+		if singleScope == "" || singleScope == "sudo" { // sudo was recognized previously but isn't anymore
 			continue
 		}
 		if singleScope == AccessTokenScopeAll {

--- a/models/auth/token_scope_test.go
+++ b/models/auth/token_scope_test.go
@@ -20,7 +20,7 @@ func TestAccessTokenScope_Normalize(t *testing.T) {
 	tests := []scopeTestNormalize{
 		{"", "", nil},
 		{"write:misc,write:notification,read:package,write:notification,public-only", "public-only,write:misc,write:notification,read:package", nil},
-		{"all", "all", nil},
+		{"all,sudo", "all", nil},
 		{"write:activitypub,write:admin,write:misc,write:notification,write:organization,write:package,write:issue,write:repository,write:user", "all", nil},
 		{"write:activitypub,write:admin,write:misc,write:notification,write:organization,write:package,write:issue,write:repository,write:user,public-only", "public-only,all", nil},
 	}


### PR DESCRIPTION
Fixes: https://codeberg.org/forgejo/forgejo/issues/820
