### PR TITLE
Fix setup-go actions

### DIFF
--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -10,9 +10,10 @@ jobs:
     if: github.repository == 'go-gitea/gitea'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.1"
+          go-version: ">=1.20"
+          check-latest: true
       - run: make generate-license generate-gitignore
         timeout-minutes: 40
       - name: push translations to repo

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -41,7 +41,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 pgsql ldap minio" | sudo tee -a /etc/hosts'
       - run: make deps-backend
@@ -65,7 +66,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - run: make deps-backend
       - run: make backend
         env:
@@ -123,7 +125,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
@@ -172,7 +175,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
@@ -203,7 +207,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql8" | sudo tee -a /etc/hosts'
       - run: make deps-backend
@@ -233,7 +238,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20.0"
+          go-version: ">=1.20"
+          check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mssql" | sudo tee -a /etc/hosts'
       - run: make deps-backend

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -1,4 +1,5 @@
 {{template "base/head" .}}
+
 <div role="main" aria-label="{{if .IsSigned}}{{.locale.Tr "dashboard"}}{{else}}{{.locale.Tr "home"}}{{end}}" class="page-content home">
 	<div class="gt-mb-5 gt-px-5">
 		<div class="center">

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -1,5 +1,4 @@
 {{template "base/head" .}}
-
 <div role="main" aria-label="{{if .IsSigned}}{{.locale.Tr "dashboard"}}{{else}}{{.locale.Tr "home"}}{{end}}" class="page-content home">
 	<div class="gt-mb-5 gt-px-5">
 		<div class="center">


### PR DESCRIPTION
The `setup-go` actions did not all have `check-latest` which means they use some cached version of go that currently still resolves to go1.20.4, as seen in a number of recent runs that currently fail at govulncheck because of it:

````
Run actions/setup-go@v4
Setup go version spec >=1.20
Attempting to resolve the latest version from the manifest...
matching >=1.20...
Resolved as '1.20.4'
````

Add the [check-latest](https://github.com/actions/setup-go#check-latest-version) option which should guarantee that this cache is skipped.