### PR TITLE
Fix fullscreen for action 

### DIFF
--- a/templates/repo/actions/view.tmpl
+++ b/templates/repo/actions/view.tmpl
@@ -1,4 +1,5 @@
 {{template "base/head" .}}
+
 <div class="page-content repository">
 	{{template "repo/header" .}}
 	<div id="repo-action-view"

--- a/templates/repo/actions/view.tmpl
+++ b/templates/repo/actions/view.tmpl
@@ -1,6 +1,6 @@
 {{template "base/head" .}}
-
-<div class="page-content repository">
+<!-- actions-content is used in RepoActionView.vue as a selector -->
+<div class="page-content repository actions" id="actions-content">
 	{{template "repo/header" .}}
 	<div id="repo-action-view"
 		data-run-index="{{.RunIndex}}"

--- a/templates/repo/actions/view.tmpl
+++ b/templates/repo/actions/view.tmpl
@@ -1,6 +1,5 @@
 {{template "base/head" .}}
-<!-- actions-content is used in RepoActionView.vue as a selector -->
-<div class="page-content repository actions" id="actions-content">
+<div class="page-content repository">
 	{{template "repo/header" .}}
 	<div id="repo-action-view"
 		data-run-index="{{.RunIndex}}"

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -415,7 +415,7 @@ const sfc = {
       const fullScreenEl = document.querySelector('.action-view-right');
       const outerEl = document.querySelector('.full.height');
       const actionBodyEl = document.querySelector('.action-view-body');
-      const headerEl = document.querySelector('.ui.main.menu');
+      const headerEl = document.querySelector('#navbar');
       const contentEl = document.querySelector('.page-content.repository');
       const footerEl = document.querySelector('.page-footer');
       toggleElem(headerEl, !this.isFullScreen);

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -416,7 +416,7 @@ const sfc = {
       const outerEl = document.querySelector('.full.height');
       const actionBodyEl = document.querySelector('.action-view-body');
       const headerEl = document.querySelector('#navbar');
-      const contentEl = document.querySelector('.page-content.repository');
+      const contentEl = document.querySelector('#actions-content');
       const footerEl = document.querySelector('.page-footer');
       toggleElem(headerEl, !this.isFullScreen);
       toggleElem(contentEl, !this.isFullScreen);

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -416,7 +416,7 @@ const sfc = {
       const outerEl = document.querySelector('.full.height');
       const actionBodyEl = document.querySelector('.action-view-body');
       const headerEl = document.querySelector('#navbar');
-      const contentEl = document.querySelector('#actions-content');
+      const contentEl = document.querySelector('.page-content.repository');
       const footerEl = document.querySelector('.page-footer');
       toggleElem(headerEl, !this.isFullScreen);
       toggleElem(contentEl, !this.isFullScreen);


### PR DESCRIPTION
An error occurs when clicking on `show full screen` on action page.

<img width="1440" alt="Screen Shot 2023-06-12 at 13 06 52" src="https://github.com/go-gitea/gitea/assets/17645053/1d4ded3c-fb77-4dd8-9201-24d0696f96eb">


class name has changed in #25134, so the selector is not working. 
Enhance the selectors to fix this.

