### PR TITLE
Remove hacky patch for "safari emoji glitch fix" 

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -2199,19 +2199,6 @@ table th[data-sortt-desc] .svg {
   vertical-align: -0.075em;
 }
 
-@supports (-webkit-hyphens:none) {
-  body:not(.safari-above125) .emoji,
-  body:not(.safari-above125) .reaction {
-    font-size: inherit;
-    vertical-align: inherit;
-  }
-  body:not(.safari-above125) .emoji img,
-  body:not(.safari-above125) .reaction img {
-    font-size: 1.25em;
-    vertical-align: -0.225em !important;
-  }
-}
-
 .emoji img,
 .reaction img {
   border-width: 0 !important;

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import 'jquery.are-you-sure';
-import {mqBinarySearch} from '../utils.js';
 import {createDropzone} from './dropzone.js';
 import {initCompColorPicker} from './comp/ColorPicker.js';
 import {showGlobalErrorMessage} from '../bootstrap.js';
@@ -62,19 +61,6 @@ export function initGlobalButtonClickOnEnter() {
 }
 
 export function initGlobalCommon() {
-  // Undo Safari emoji glitch fix at high enough zoom levels
-  if (navigator.userAgent.match('Safari')) {
-    $(window).on('resize', () => {
-      const px = mqBinarySearch('width', 0, 4096, 1, 'px');
-      const em = mqBinarySearch('width', 0, 1024, 0.01, 'em');
-      if (em * 16 * 1.25 - px <= -1) {
-        $('body').addClass('safari-above125');
-      } else {
-        $('body').removeClass('safari-above125');
-      }
-    });
-  }
-
   // Semantic UI modules.
   const $uiDropdowns = $('.ui.dropdown');
 

--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -37,19 +37,6 @@ export function stripTags(text) {
   return text.replace(/<[^>]*>?/g, '');
 }
 
-// searches the inclusive range [minValue, maxValue].
-// credits: https://matthiasott.com/notes/write-your-media-queries-in-pixels-not-ems
-export function mqBinarySearch(feature, minValue, maxValue, step, unit) {
-  if (maxValue - minValue < step) {
-    return minValue;
-  }
-  const mid = Math.ceil((minValue + maxValue) / 2 / step) * step;
-  if (matchMedia(`screen and (min-${feature}:${mid}${unit})`).matches) {
-    return mqBinarySearch(feature, mid, maxValue, step, unit); // feature is >= mid
-  }
-  return mqBinarySearch(feature, minValue, mid - step, step, unit); // feature is < mid
-}
-
 export function parseIssueHref(href) {
   const path = (href || '').replace(/[#?].*$/, '');
   const [_, owner, repo, type, index] = /([^/]+)\/([^/]+)\/(issues|pulls)\/([0-9]+)/.exec(path) || [];


### PR DESCRIPTION
According to my test, the UI (emoji) is fine in Safari

And actually the code is just dead code, because the "resize" event is never fired on page loading. So for most cases users just view the pages without this hacky patch, nobody ever complains.
