### PR TITLE
Remove EasyMDE focus outline on text

### DIFF
--- a/web_src/css/codemirror/base.css
+++ b/web_src/css/codemirror/base.css
@@ -45,5 +45,5 @@
 }
 
 .CodeMirror :focus {
-  outline: none
+  outline: none;
 }

--- a/web_src/css/codemirror/base.css
+++ b/web_src/css/codemirror/base.css
@@ -43,3 +43,7 @@
 .CodeMirror-focused {
   border-color: var(--color-primary) !important;
 }
+
+.CodeMirror :focus {
+  outline: none
+}


### PR DESCRIPTION
EasyMDE in Firefox currently shows a ugly outline in the fake textarea the CodeMirror uses. Hide it.

Before:

<img width="845" alt="Screenshot 2023-06-18 at 02 54 09" src="https://github.com/go-gitea/gitea/assets/115237/dc406166-9ad5-4a9b-9581-002b5cdcc6df">

After:

<img width="870" alt="Screenshot 2023-06-18 at 02 54 24" src="https://github.com/go-gitea/gitea/assets/115237/ddd78759-2cf2-4385-b863-7576fec25c34">

