### PR TITLE
fix a nit error output in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 
 EXTRA_GOFLAGS ?=
 
-MAKE_VERSION := $(shell "$(MAKE)" -v | head -n 1)
+MAKE_VERSION := $(shell "$(MAKE)" -v | cat | head -n 1)
 MAKE_EVIDENCE_DIR := .make_evidence
 
 ifeq ($(RACE_ENABLED),true)


### PR DESCRIPTION
fix ``make: write error: stdout``

ref: https://stackoverflow.com/questions/70671525/write-error-stdout-when-calling-make-from-makefile
