### PR TITLE
Use Actions git context instead of dynamically created buildkit one

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -78,12 +78,14 @@ jobs:
       - name: build rootful docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: gitea/gitea:${{ steps.clean_name.outputs.branch }}
       - name: build rootless docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.rootless

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ endif
 STORED_VERSION_FILE := VERSION
 HUGO_VERSION ?= 0.111.3
 
+GITHUB_REF_TYPE ?= branch
+GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
+
 ifneq ($(GITHUB_REF_TYPE),branch)
 	VERSION ?= $(subst v,,$(GITHUB_REF_NAME))
 	GITEA_VERSION ?= $(GITHUB_REF_NAME)
@@ -1010,10 +1013,6 @@ generate-manpage:
 docker:
 	docker build --disable-content-trust=false -t $(DOCKER_REF) .
 # support also build args docker build --build-arg GITEA_VERSION=v1.2.3 --build-arg TAGS="bindata sqlite sqlite_unlock_notify"  .
-
-.PHONY: docker-build
-docker-build:
-	docker run -ti --rm -v "$(CURDIR):/srv/app/src/code.gitea.io/gitea" -w /srv/app/src/code.gitea.io/gitea -e TAGS="bindata $(TAGS)" LDFLAGS="$(LDFLAGS)" CGO_EXTRA_CFLAGS="$(CGO_EXTRA_CFLAGS)" webhippie/golang:edge make clean build
 
 # This endif closes the if at the top of the file
 endif


### PR DESCRIPTION
The [docker/build-push-action@v2 action](https://github.com/docker/build-push-action) by default ignores the checkout created using the actions/checkout@v2 action. When you pass a git build context to docker build, it wouldn't include the .git directory.

By passing `context: .` to the build step then it'll use the Actions git context which includes the git fetch from the earlier step.
