### PR TITLE
Use qwtel.sqlite-viewer instead of alexcvzz.vscode-sqlite

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
         "Vue.volar",
         "ms-azuretools.vscode-docker",
         "zixuanchen.vitest-explorer",
-        "alexcvzz.vscode-sqlite"
+        "qwtel.sqlite-viewer"
       ]
     }
   },

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -34,7 +34,7 @@ vscode:
     - Vue.volar
     - ms-azuretools.vscode-docker
     - zixuanchen.vitest-explorer
-    - alexcvzz.vscode-sqlite
+    - qwtel.sqlite-viewer
 
 ports:
   - name: Gitea


### PR DESCRIPTION
`alexcvzz.vscode-sqlite` doesn't work well in devcontainer.
![image](https://github.com/go-gitea/gitea/assets/18380374/8c13710c-c69f-4c72-aaa7-aa5cd514ce52)

qwtel.sqlite-viewer works well, maybe we can use this one instead.
![image](https://github.com/go-gitea/gitea/assets/18380374/e7d1cda0-077c-4c5d-b6a0-9822a6563be9)
![image](https://github.com/go-gitea/gitea/assets/18380374/b34f1bab-f666-4c84-a377-f537734226e6)

ps: don't know how to create an env in gitpod, so didn't test it in gitpod.