### PR TITLE
Add releases/latest{file} route

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -870,6 +870,7 @@ func registerRoutes(m *web.Route) {
 
 	// ***** Release Attachment Download without Signin
 	m.Get("/{username}/{reponame}/releases/download/{vTag}/{fileName}", ignSignIn, context.RepoAssignment, repo.MustBeNotEmpty, repo.RedirectDownload)
+	m.Get("/{username}/{reponame}/releases/download-latest/{fileName}", ignSignIn, context.RepoAssignment, repo.MustBeNotEmpty, repo.RedirectDownloadLatest)
 
 	m.Group("/{username}/{reponame}", func() {
 		m.Group("/settings", func() {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -870,7 +870,8 @@ func registerRoutes(m *web.Route) {
 
 	// ***** Release Attachment Download without Signin
 	m.Get("/{username}/{reponame}/releases/download/{vTag}/{fileName}", ignSignIn, context.RepoAssignment, repo.MustBeNotEmpty, repo.RedirectDownload)
-	m.Get("/{username}/{reponame}/releases/download-latest/{fileName}", ignSignIn, context.RepoAssignment, repo.MustBeNotEmpty, repo.RedirectDownloadLatest)
+	// **** Latest release Attachment Download without Signin
+	m.Get("/{username}/{reponame}/releases/latest/{fileName}", ignSignIn, context.RepoAssignment, repo.MustBeNotEmpty, repo.RedirectDownloadLatest)
 
 	m.Group("/{username}/{reponame}", func() {
 		m.Group("/settings", func() {


### PR DESCRIPTION
Possible partial fix (the "download url for latest release" part) for https://github.com/go-gitea/gitea/issues/3712
Draft PR posted for comment, tests currently missing.

