### PR TITLE
add `test-frontend` back to actions

### DIFF
--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -96,6 +96,7 @@ jobs:
       - run: make deps-frontend
       - run: make lint-frontend
       - run: make checks-frontend
+      - run: make test-frontend
       - run: make frontend
 
   backend:


### PR DESCRIPTION
Apparently we were not running `test-frontend` on actions, this adds it back.