### PR TITLE
Gitea version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 ifneq ($(GITHUB_REF_TYPE),branch)
 	VERSION ?= $(subst v,,$(GITHUB_REF_NAME))
-	GITEA_VERSION ?= $(GITHUB_REF_NAME)
+	GITEA_VERSION ?= $(VERSION)
 else
 	ifneq ($(GITHUB_REF_NAME),)
 		VERSION ?= $(subst release/v,,$(GITHUB_REF_NAME))


### PR DESCRIPTION
As title, this is how it was inferred before
https://github.com/go-gitea/gitea/blob/e24f651c86a5168da8181f2c75f5f99b56561224/Makefile#L83-L84

We moved to actions, however `GITEA_VERSION` should still work to use `VERSION`