### PR TITLE
Fix `Init` of db indexer

### DIFF
--- a/modules/indexer/internal/db/indexer.go
+++ b/modules/indexer/internal/db/indexer.go
@@ -16,8 +16,9 @@ type Indexer struct{}
 
 // Init initializes the indexer
 func (i *Indexer) Init(_ context.Context) (bool, error) {
-	// nothing to do
-	return false, nil
+	// Return true to indicate that the index was opened/existed.
+	// So that the indexer will not try to populate the index, the data is already there.
+	return true, nil
 }
 
 // Ping checks if the indexer is available


### PR DESCRIPTION
Fix regression of #25174.

The `Init` of the db indexer should return true to indicate that the index was opened/existed, or the indexer will try to populate the index (not really populate, just fill the queue, `Index` method of the db indexer is a dummy).