### PR TITLE
Do not publish docker release images on `-dev` tags

### DIFF
--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,7 +1,7 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}-rootless
 {{#if build.tags}}
-{{#unless (contains "-rc" tag)}}
-{{#unless (contains "-dev" tag)}}
+{{#unless (contains "-rc" build.tag)}}
+{{#unless (contains "-dev" build.tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}-rootless

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,6 +1,6 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}-rootless
 {{#if build.tags}}
-{{#unless (contains "-rc" build.tag)}}
+{{#unless (or (contains "-rc" build.tag) (contains "-dev" build.tag))}}
 tags:
 {{#each build.tags}}
   - {{this}}-rootless

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,11 +1,13 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}-rootless
 {{#if build.tags}}
-{{#unless (or (contains "-rc" build.tag) (contains "-dev" build.tag))}}
+{{#unless (contains "-rc" tag)}}
+{{#unless (contains "-dev" tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}-rootless
 {{/each}}
   - "latest-rootless"
+{{/unless}}
 {{/unless}}
 {{/if}}
 manifests:

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,7 +1,7 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}
 {{#if build.tags}}
-{{#unless (contains "-rc" tag)}}
-{{#unless (contains "-dev" tag)}}
+{{#unless (contains "-rc" build.tag)}}
+{{#unless (contains "-dev" build.tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,6 +1,6 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}
 {{#if build.tags}}
-{{#unless (contains "-rc" build.tag)}}
+{{#unless (or (contains "-rc" build.tag) (contains "-dev" build.tag))}}
 tags:
 {{#each build.tags}}
   - {{this}}

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,11 +1,13 @@
 image: gitea/gitea:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{#if (hasPrefix "refs/heads/release/v" build.ref)}}{{trimPrefix "refs/heads/release/v" build.ref}}-{{/if}}nightly{{/if}}
 {{#if build.tags}}
-{{#unless (or (contains "-rc" build.tag) (contains "-dev" build.tag))}}
+{{#unless (contains "-rc" tag)}}
+{{#unless (contains "-dev" tag)}}
 tags:
 {{#each build.tags}}
   - {{this}}
 {{/each}}
   - "latest"
+{{/unless}}
 {{/unless}}
 {{/if}}
 manifests:


### PR DESCRIPTION
Try to prevent what happened with tag `v1.21.0-dev` as outlined in #25193.
Unfortunately, we cannot really test if it works as intended as we would need to release a new `dev` tag for that.
Fixes #25193 (or at least attempts to).