### PR TITLE
Make buttons in a modal form have proper type. (#25446)

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -345,6 +345,8 @@ export function initGlobalButtons() {
     if (colorPickers.length > 0) {
       initCompColorPicker();
     }
+    // all non-"ok" buttons which do not have "type" should not submit the form, should not be triggered by "Enter"
+    $($(this).attr('data-modal')).find('form button:not(.ok):not([type])').attr('type', 'button');
   });
 
   $('.delete-post.button').on('click', function (e) {


### PR DESCRIPTION
Backport #25446 by @wxiaoguang 

Fix  #25438

All non-"ok" buttons which do not have "type" should not submit the form, should not be triggered by "Enter".
