### PR TITLE
environment-to-ini fails if run as root

### DIFF
--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -48,11 +48,11 @@ if [ ! -f ${GITEA_CUSTOM}/conf/app.ini ]; then
     chown ${USER}:git ${GITEA_CUSTOM}/conf/app.ini
 fi
 
-# Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
-environment-to-ini --config ${GITEA_CUSTOM}/conf/app.ini
-
 # only chown if current owner is not already the gitea ${USER}. No recursive check to save time
 if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/gitea; fi
 if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi
 if ! [[ $(ls -ld /data/git   | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/git;   fi
 chmod 0755 /data/gitea /app/gitea /data/git
+
+# Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
+su $USER -c "environment-to-ini --config ${GITEA_CUSTOM}/conf/app.ini"


### PR DESCRIPTION
Refs: https://codeberg.org/forgejo/forgejo/pulls/924
