### PR TITLE
Revert "Make buttons in a modal form have proper type. (#25446)"

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -395,8 +395,6 @@ function initGlobalShowModal() {
     if (colorPickers.length > 0) {
       initCompColorPicker(); // FIXME: this might cause duplicate init
     }
-    // all non-"ok" buttons which do not have "type" should not submit the form, should not be triggered by "Enter"
-    $modal.find('form button:not(.ok):not([type])').attr('type', 'button');
     $modal.modal('setting', {
       onApprove: () => {
         // "form-fetch-action" can handle network errors gracefully,


### PR DESCRIPTION
There is a side effect because some modal doesn't have a proper "ok" button.

This reverts commit a954c93a68072042aa7dad717b6fa002c83a58fb.
