### PR TITLE
Link to existing PR when trying to open a new PR on the same branches

### DIFF
--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -192,7 +192,7 @@
 		{{if .HasPullRequest}}
 			<div class="ui segment grid title">
 				<div class="twelve wide column issue-title">
-					{{.locale.Tr "repo.pulls.has_pull_request" (Escape $.RepoLink) (Escape $.RepoRelPath) .PullRequest.Index | Safe}}
+					{{.locale.Tr "repo.pulls.has_pull_request" (print (Escape $.RepoLink) "/pulls/" .PullRequest.Issue.Index) (Escape $.RepoRelPath) .PullRequest.Index | Safe}}
 					<h1>
 						<span id="issue-title">{{RenderIssueTitle $.Context .PullRequest.Issue.Title $.RepoLink $.Repository.ComposeMetas}}</span>
 						<span class="index">#{{.PullRequest.Issue.Index}}</span>


### PR DESCRIPTION
when trying to create a PR for an existing PRs branch combination link to the PR directly and not just to the repo.

Before:
![image](https://github.com/go-gitea/gitea/assets/1135157/b6c71323-29c8-4024-afa5-420eed145e91)

After:
![image](https://github.com/go-gitea/gitea/assets/1135157/837665f5-7459-46c6-86d4-c2dbedabc262)

