### PR TITLE
Show explanation if user cannot add new email

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -688,6 +688,7 @@ emails = Email Addresses
 manage_emails = Manage Email Addresses
 manage_themes = Select default theme
 manage_openid = Manage OpenID Addresses
+email_cant_add = You cannot add any new email addresses at this time. Please try again later.
 email_desc = Your primary email address will be used for notifications and other operations.
 theme_desc = This will be your default theme across the site.
 primary = Primary

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -40,6 +40,11 @@
 		</h4>
 		<div class="ui attached segment">
 			<div class="ui email list">
+				{{if not .CanAddEmails}}
+				<div class="item">
+					<p>{{.locale.Tr "settings.email_cant_add"}}</p>
+				</div>
+				{{end}}
 				{{if $.EnableNotifyMail}}
 				<div class="item">
 					<form action="{{AppSubUrl}}/user/settings/account/email" class="ui form" method="post">


### PR DESCRIPTION
This change concerns the "Manage Email Addresses" submenu
in the Account settings.