### PR TITLE
Clarify the reason why the user can't add a new email if there is a pending activation

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -696,6 +696,7 @@ requires_activation = Requires activation
 primary_email = Make Primary
 activate_email = Send Activation
 activations_pending = Activations Pending
+can_not_add_email_activations_pending = There is a pending activation, try again in a few minutes if you want to add a new email.
 delete_email = Remove
 email_deletion = Remove Email Address
 email_deletion_desc = The email address and related information will be removed from your account. Git commits by this email address will remain unchanged. Continue?

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -128,6 +128,10 @@
 					{{.locale.Tr "settings.add_email"}}
 				</button>
 			</form>
+			{{/* if ActivationsPending is false, then CanAddEmails must be true, so if CanAddEmails is false, ActivationsPending must be true */}}
+			{{if not .CanAddEmails}}
+				<div class="ui warning message">{{.locale.Tr "settings.can_not_add_email_activations_pending"}}</div>
+			{{end}}
 		</div>
 
 		<h4 class="ui top attached error header">


### PR DESCRIPTION
![image](https://github.com/go-gitea/gitea/assets/2114189/cff20df0-ad0c-4140-b8e2-5782cad8a53a)
