### PR TITLE
Allow change line of admin-dl-horizontal dt (#25508)

### DIFF
--- a/web_src/css/admin.css
+++ b/web_src/css/admin.css
@@ -35,9 +35,6 @@
   font-weight: var(--font-weight-semibold);
   width: 220px;
   margin-right: 5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
As https://github.com/go-gitea/gitea/pull/25515#issuecomment-1606626886 says, still need this backport

Close #25389

After:

<img width="915" alt="Screen Shot 2023-06-26 at 11 00 12" src="https://github.com/go-gitea/gitea/assets/17645053/45026447-cf50-4603-ade3-7b80a9023c20">


admin/dashboard:

<img width="957" alt="Screen Shot 2023-06-26 at 10 59 51" src="https://github.com/go-gitea/gitea/assets/17645053/f4f95bbe-f747-46f1-8fbd-5778a19ebef7">

