### PR TITLE
Fix rerun icon on action view component

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -590,6 +590,7 @@ export function initRepositoryActionView() {
 .job-brief-item .job-brief-link {
   display: flex;
   width: 100%;
+  min-width: 0;
 }
 
 .job-brief-item .job-brief-link span {

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -611,6 +611,7 @@ export function initRepositoryActionView() {
   display: flex;
   align-items: center;
   width: 55px;
+  min-width: fit-content;
 }
 
 /* ================ */

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -38,8 +38,8 @@
                 <span class="job-brief-name gt-mx-3 gt-ellipsis">{{ job.name }}</span>
               </a>
               <span class="job-brief-info">
-                <span class="step-summary-duration">{{ job.duration }}</span>
                 <SvgIcon name="octicon-sync" role="button" :data-tooltip-content="locale.rerun" class="job-brief-rerun gt-mx-3" @click="rerunJob(index)" v-if="job.canRerun && onHoverRerunIndex === job.id"/>
+                <span class="step-summary-duration">{{ job.duration }}</span>
               </span>
             </div>
           </div>
@@ -610,8 +610,7 @@ export function initRepositoryActionView() {
 .job-brief-item .job-brief-info {
   display: flex;
   align-items: center;
-  width: 55px;
-  min-width: fit-content;
+  width: fit-content;
 }
 
 /* ================ */

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -611,7 +611,6 @@ export function initRepositoryActionView() {
 .job-brief-item .job-brief-info {
   display: flex;
   align-items: center;
-  width: fit-content;
 }
 
 /* ================ */


### PR DESCRIPTION
Right now rerun icon on action view component will not be seen when duration text length is long, because the wrapper `job-brief-info` has a fixed width, and the svg is squeezed. The way to fix this in this PR is to remove width and exchange position of duration text and rerun svg, and add `min-width` to job title

Before (rerun svg not shown on hover):

<img width="1401" alt="Screen Shot 2023-06-27 at 12 53 41" src="https://github.com/go-gitea/gitea/assets/17645053/bb3f62ec-8c56-4dbc-96f1-718b50426d91">

After:

<img width="1409" alt="Screen Shot 2023-06-27 at 12 50 59" src="https://github.com/go-gitea/gitea/assets/17645053/620aa02c-2326-408d-a763-453f48f42c40">


