### PR TITLE
Fix bugs related to notification endpoints

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -777,11 +777,11 @@ func Routes() *web.Route {
 		m.Group("/notifications", func() {
 			m.Combo("").
 				Get(notify.ListNotifications).
-				Put(notify.ReadNotifications, reqToken())
+				Put(reqToken(), notify.ReadNotifications)
 			m.Get("/new", notify.NewAvailable)
 			m.Combo("/threads/{id}").
 				Get(notify.GetThread).
-				Patch(notify.ReadThread, reqToken())
+				Patch(reqToken(), notify.ReadThread)
 		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryNotification))
 
 		// Users (requires user scope)

--- a/routers/api/v1/notify/repo.go
+++ b/routers/api/v1/notify/repo.go
@@ -183,7 +183,7 @@ func ReadRepoNotifications(ctx *context.APIContext) {
 	if len(qLastRead) > 0 {
 		tmpLastRead, err := time.Parse(time.RFC3339, qLastRead)
 		if err != nil {
-			ctx.InternalServerError(err)
+			ctx.Error(http.StatusBadRequest, "Parse", err)
 			return
 		}
 		if !tmpLastRead.IsZero() {

--- a/routers/api/v1/notify/user.go
+++ b/routers/api/v1/notify/user.go
@@ -132,7 +132,7 @@ func ReadNotifications(ctx *context.APIContext) {
 	if len(qLastRead) > 0 {
 		tmpLastRead, err := time.Parse(time.RFC3339, qLastRead)
 		if err != nil {
-			ctx.InternalServerError(err)
+			ctx.Error(http.StatusBadRequest, "Parse", err)
 			return
 		}
 		if !tmpLastRead.IsZero() {


### PR DESCRIPTION
This PR
- fixes #25545
- fixes two incorrect `reqToken()` in `/notifications` endpoints (caused by #24767)