### PR TITLE
Fix content holes in Actions task logs file

### DIFF
--- a/models/actions/task.go
+++ b/models/actions/task.go
@@ -344,6 +344,9 @@ func UpdateTask(ctx context.Context, task *ActionTask, cols ...string) error {
 	return err
 }
 
+// UpdateTaskByState updates the task by the state.
+// It will always update the task if the state is not final, even there is no change.
+// So it will update ActionTask.Updated to avoid the task being judged as a zombie task.
 func UpdateTaskByState(ctx context.Context, state *runnerv1.TaskState) (*ActionTask, error) {
 	stepStates := map[int64]*runnerv1.StepState{}
 	for _, v := range state.Steps {
@@ -382,6 +385,12 @@ func UpdateTaskByState(ctx context.Context, state *runnerv1.TaskState) (*ActionT
 			Status:  task.Status,
 			Stopped: task.Stopped,
 		}, nil); err != nil {
+			return nil, err
+		}
+	} else {
+		// Force update ActionTask.Updated to avoid the task being judged as a zombie task
+		task.Updated = timeutil.TimeStampNow()
+		if err := UpdateTask(ctx, task, "updated"); err != nil {
 			return nil, err
 		}
 	}

--- a/models/dbfs/dbfs.go
+++ b/models/dbfs/dbfs.go
@@ -5,7 +5,10 @@ package dbfs
 
 import (
 	"context"
+	"io/fs"
 	"os"
+	"path"
+	"time"
 
 	"code.gitea.io/gitea/models/db"
 )
@@ -99,4 +102,30 @@ func Remove(ctx context.Context, name string) error {
 	}
 	defer f.Close()
 	return f.delete()
+}
+
+var _ fs.FileInfo = (*dbfsMeta)(nil)
+
+func (m *dbfsMeta) Name() string {
+	return path.Base(m.FullPath)
+}
+
+func (m *dbfsMeta) Size() int64 {
+	return m.FileSize
+}
+
+func (m *dbfsMeta) Mode() fs.FileMode {
+	return os.ModePerm
+}
+
+func (m *dbfsMeta) ModTime() time.Time {
+	return fileTimestampToTime(m.ModifyTimestamp)
+}
+
+func (m *dbfsMeta) IsDir() bool {
+	return false
+}
+
+func (m *dbfsMeta) Sys() any {
+	return nil
 }

--- a/models/dbfs/dbfs_test.go
+++ b/models/dbfs/dbfs_test.go
@@ -111,6 +111,19 @@ func TestDbfsBasic(t *testing.T) {
 
 	_, err = OpenFile(db.DefaultContext, "test2.txt", os.O_RDONLY)
 	assert.Error(t, err)
+
+	// test stat
+	f, err = OpenFile(db.DefaultContext, "test/test.txt", os.O_RDWR|os.O_CREATE)
+	assert.NoError(t, err)
+	stat, err := f.Stat()
+	assert.NoError(t, err)
+	assert.EqualValues(t, "test.txt", stat.Name())
+	assert.EqualValues(t, 0, stat.Size())
+	_, err = f.Write([]byte("0123456789"))
+	assert.NoError(t, err)
+	stat, err = f.Stat()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, stat.Size())
 }
 
 func TestDbfsReadWrite(t *testing.T) {

--- a/modules/actions/log.go
+++ b/modules/actions/log.go
@@ -29,8 +29,13 @@ const (
 )
 
 func WriteLogs(ctx context.Context, filename string, offset int64, rows []*runnerv1.LogRow) ([]int, error) {
+	flag := os.O_WRONLY
+	if offset == 0 {
+		// Create file only if offset is 0, or it could result in a file with content holes if the file doesn't exist.
+		flag |= os.O_CREATE
+	}
 	name := DBFSPrefix + filename
-	f, err := dbfs.OpenFile(ctx, name, os.O_WRONLY|os.O_CREATE)
+	f, err := dbfs.OpenFile(ctx, name, flag)
 	if err != nil {
 		return nil, fmt.Errorf("dbfs OpenFile %q: %w", name, err)
 	}

--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -210,20 +210,17 @@ func (s *Service) UpdateLog(
 
 	task, err := actions_model.GetTaskByID(ctx, req.Msg.TaskId)
 	if err != nil {
-		if errors.Is(err, util.ErrNotExist) {
-			return nil, status.Errorf(codes.NotFound, "task %d not found", req.Msg.TaskId)
-		}
 		return nil, status.Errorf(codes.Internal, "get task: %v", err)
 	}
-	if task.Status.IsDone() {
-		return nil, status.Errorf(codes.FailedPrecondition, "task %d is done", req.Msg.TaskId)
-	}
-
 	ack := task.LogLength
 
 	if len(req.Msg.Rows) == 0 || req.Msg.Index > ack || int64(len(req.Msg.Rows))+req.Msg.Index <= ack {
 		res.Msg.AckIndex = ack
 		return res, nil
+	}
+
+	if task.LogInStorage {
+		return nil, status.Errorf(codes.AlreadyExists, "log file has been archived")
 	}
 
 	rows := req.Msg.Rows[ack-req.Msg.Index:]


### PR DESCRIPTION
Fix #25451.

Bugfixes:
- When stopping the zombie or endless tasks, set `LogInStorage` to true after transferring the file to storage. It was missing, it could write to a nonexistent file in DBFS because `LogInStorage` was false.
- Always update `ActionTask.Updated` when there's a new state reported by the runner, even if there's no change. This is to avoid the task being judged as a zombie task.

Enhancement:
- Support `Stat()` for DBFS file.
- `WriteLogs` refuses to write if it could result in content holes.

