### PR TITLE
read-only checkboxes don't appear and don't entirely act the way one might expect

### DIFF
--- a/templates/repo/pulls/fork.tmpl
+++ b/templates/repo/pulls/fork.tmpl
@@ -46,7 +46,7 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui read-only checkbox">
-							<input type="checkbox" disabled="disabled" {{if .IsPrivate}}checked{{end}}>
+							<input type="checkbox" disabled {{if .IsPrivate}}checked{{end}}>
 							<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 						</div>
 						<span class="help">{{.locale.Tr "repo.fork_visibility_helper"}}</span>

--- a/templates/repo/pulls/fork.tmpl
+++ b/templates/repo/pulls/fork.tmpl
@@ -46,7 +46,7 @@
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
 						<div class="ui read-only checkbox">
-							<input type="checkbox" {{if .IsPrivate}}checked{{end}}>
+							<input type="checkbox" disabled="disabled" {{if .IsPrivate}}checked{{end}}>
 							<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 						</div>
 						<span class="help">{{.locale.Tr "repo.fork_visibility_helper"}}</span>

--- a/templates/repo/pulls/fork.tmpl
+++ b/templates/repo/pulls/fork.tmpl
@@ -45,7 +45,7 @@
 					</div>
 					<div class="inline field">
 						<label>{{.locale.Tr "repo.visibility"}}</label>
-						<div class="ui read-only checkbox">
+						<div class="ui disabled checkbox">
 							<input type="checkbox" disabled {{if .IsPrivate}}checked{{end}}>
 							<label>{{.locale.Tr "repo.visibility_helper" | Safe}}</label>
 						</div>

--- a/web_src/css/form.css
+++ b/web_src/css/form.css
@@ -41,6 +41,11 @@ textarea,
   color: var(--color-input-text);
 }
 
+.ui.read-only.checkbox label::before,
+.ui.read-only.checkbox input:checked ~ label::before {
+  opacity: var(--opacity-disabled);
+}
+
 input:hover,
 textarea:hover,
 .ui.input input:hover,
@@ -96,6 +101,11 @@ textarea:focus,
   color: var(--color-input-text);
 }
 
+.ui.read-only.checkbox input:focus ~ label::before,
+.ui.read-only.checkbox input:checked:focus ~ label::before {
+  border-color: var(--color-input-border);
+}
+
 .ui.form .field > label,
 .ui.form .inline.fields > label,
 .ui.form .inline.fields .field > label,
@@ -130,6 +140,10 @@ textarea:focus,
 .ui.disabled.checkbox label,
 .ui.checkbox input[disabled] ~ label {
   color: var(--color-input-text);
+}
+
+.ui.read-only.checkbox input:checked ~ label::after {
+  opacity: var(--opacity-disabled);
 }
 
 .ui.radio.checkbox input:focus ~ label::after,

--- a/web_src/css/form.css
+++ b/web_src/css/form.css
@@ -41,11 +41,6 @@ textarea,
   color: var(--color-input-text);
 }
 
-.ui.read-only.checkbox label::before,
-.ui.read-only.checkbox input:checked ~ label::before {
-  opacity: var(--opacity-disabled);
-}
-
 input:hover,
 textarea:hover,
 .ui.input input:hover,
@@ -101,11 +96,6 @@ textarea:focus,
   color: var(--color-input-text);
 }
 
-.ui.read-only.checkbox input:focus ~ label::before,
-.ui.read-only.checkbox input:checked:focus ~ label::before {
-  border-color: var(--color-input-border);
-}
-
 .ui.form .field > label,
 .ui.form .inline.fields > label,
 .ui.form .inline.fields .field > label,
@@ -140,10 +130,6 @@ textarea:focus,
 .ui.disabled.checkbox label,
 .ui.checkbox input[disabled] ~ label {
   color: var(--color-input-text);
-}
-
-.ui.read-only.checkbox input:checked ~ label::after {
-  opacity: var(--opacity-disabled);
 }
 
 .ui.radio.checkbox input:focus ~ label::after,


### PR DESCRIPTION
This pull request fades read-only checkboxes and checkmark, and it makes the checkboxes act more read-only/disabled by not changing the border-color when clicked.

Examples using light mode:
 
| Before | After |
| - | - |
| ![Kapture 2023-06-28 at 00 20 45](https://github.com/go-gitea/gitea/assets/63764270/0899fd5c-18a9-4290-9ba9-d3cf71033cf8) | ![Kapture 2023-06-28 at 00 23 12](https://github.com/go-gitea/gitea/assets/63764270/0db9be14-e16c-42ed-8fb1-999928fd1d25) |
| ![Kapture 2023-06-28 at 00 25 22](https://github.com/go-gitea/gitea/assets/63764270/65c6c380-b928-4e6c-b403-3655d3565896) | ![Kapture 2023-06-28 at 00 27 28](https://github.com/go-gitea/gitea/assets/63764270/d8c2a019-e07c-43a1-a7fa-93c0d4e01900) |
| | read-only checkboxes and checkmark are faded<br>and the checkboxes act more read-only/disabled |

Fixes/Closes/Resolves #25076
