### PR TITLE
Do not prepare oauth2 config if it is not enabled, do not write config in some sub-commands (#25567)

### DIFF
--- a/cmd/embedded.go
+++ b/cmd/embedded.go
@@ -22,9 +22,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Cmdembedded represents the available extract sub-command.
+// CmdEmbedded represents the available extract sub-command.
 var (
-	Cmdembedded = cli.Command{
+	CmdEmbedded = cli.Command{
 		Name:        "embedded",
 		Usage:       "Extract embedded resources",
 		Description: "A command for extracting embedded resources, like templates and images",

--- a/main.go
+++ b/main.go
@@ -87,25 +87,31 @@ func main() {
 	app.Description = `By default, Gitea will start serving using the web-server with no argument, which can alternatively be run by running the subcommand "web".`
 	app.Version = Version + formatBuiltWith()
 	app.EnableBashCompletion = true
-	app.Commands = []cli.Command{
+
+	// these sub-commands need to use config file
+	subCmdWithIni := []cli.Command{
 		cmd.CmdWeb,
 		cmd.CmdServ,
 		cmd.CmdHook,
 		cmd.CmdDump,
-		cmd.CmdCert,
 		cmd.CmdAdmin,
-		cmd.CmdGenerate,
 		cmd.CmdMigrate,
 		cmd.CmdKeys,
 		cmd.CmdConvert,
 		cmd.CmdDoctor,
 		cmd.CmdManager,
-		cmd.Cmdembedded,
+		cmd.CmdEmbedded,
 		cmd.CmdMigrateStorage,
-		cmd.CmdDocs,
 		cmd.CmdDumpRepository,
 		cmd.CmdRestoreRepository,
 		cmd.CmdActions,
+		cmdHelp, // TODO: the "help" sub-command was used to show the more information for "work path" and "custom config", in the future, it should avoid doing so
+	}
+	// these sub-commands do not need the config file, and they do not depend on any path or environment variable.
+	subCmdStandalone := []cli.Command{
+		cmd.CmdCert,
+		cmd.CmdGenerate,
+		cmd.CmdDocs,
 	}
 
 	// shared configuration flags, they are for global and for each sub-command at the same time
@@ -134,10 +140,11 @@ func main() {
 	app.Action = prepareWorkPathAndCustomConf(cmd.CmdWeb.Action)
 	app.HideHelp = true // use our own help action to show helps (with more information like default config)
 	app.Before = cmd.PrepareConsoleLoggerLevel(log.INFO)
-	app.Commands = append(app.Commands, cmdHelp)
-	for i := range app.Commands {
-		prepareSubcommands(&app.Commands[i], globalFlags)
+	for i := range subCmdWithIni {
+		prepareSubcommands(&subCmdWithIni[i], globalFlags)
 	}
+	app.Commands = append(app.Commands, subCmdWithIni...)
+	app.Commands = append(app.Commands, subCmdStandalone...)
 
 	err := app.Run(os.Args)
 	if err != nil {

--- a/modules/setting/oauth2.go
+++ b/modules/setting/oauth2.go
@@ -116,6 +116,10 @@ func loadOAuth2From(rootCfg ConfigProvider) {
 		return
 	}
 
+	if !OAuth2.Enable {
+		return
+	}
+
 	if !filepath.IsAbs(OAuth2.JWTSigningPrivateKeyFile) {
 		OAuth2.JWTSigningPrivateKeyFile = filepath.Join(AppDataPath, OAuth2.JWTSigningPrivateKeyFile)
 	}


### PR DESCRIPTION
Backport #25567

Ref:

* https://github.com/go-gitea/gitea/issues/25377#issuecomment-1609757289

And some sub-commands like "generate" / "docs", they do not need to use the ini config
