### PR TITLE
Redirect to package after version deletion (#25594)

### DIFF
--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -420,7 +420,13 @@ func PackageSettingsPost(ctx *context.Context) {
 			ctx.Flash.Success(ctx.Tr("packages.settings.delete.success"))
 		}
 
-		ctx.Redirect(ctx.Package.Owner.HomeLink() + "/-/packages")
+		redirectURL := ctx.Package.Owner.HomeLink() + "/-/packages"
+		// redirect to the package if there are still versions available
+		if has, _ := packages_model.ExistVersion(ctx, &packages_model.PackageSearchOptions{PackageID: ctx.Package.Descriptor.Package.ID}); has {
+			redirectURL = ctx.Package.Descriptor.PackageWebLink()
+		}
+
+		ctx.Redirect(redirectURL)
 		return
 	}
 }

--- a/templates/package/view.tmpl
+++ b/templates/package/view.tmpl
@@ -84,19 +84,17 @@
 					{{end}}
 					</div>
 				{{end}}
-				{{if .LatestVersions}}
-					<div class="ui divider"></div>
-					<strong>{{.locale.Tr "packages.versions"}} ({{.TotalVersionCount}})</strong>
-					<a class="ui right" href="{{$.PackageDescriptor.PackageWebLink}}/versions">{{.locale.Tr "packages.versions.view_all"}}</a>
-					<div class="ui relaxed list">
-					{{range .LatestVersions}}
-						<div class="item gt-df">
-							<a class="gt-f1" href="{{$.PackageDescriptor.PackageWebLink}}/{{PathEscape .LowerVersion}}">{{.Version}}</a>
-							<span class="text small">{{DateTime "short" .CreatedUnix}}</span>
-						</div>
-					{{end}}
+				<div class="ui divider"></div>
+				<strong>{{.locale.Tr "packages.versions"}} ({{.TotalVersionCount}})</strong>
+				<a class="ui right" href="{{$.PackageDescriptor.PackageWebLink}}/versions">{{.locale.Tr "packages.versions.view_all"}}</a>
+				<div class="ui relaxed list">
+				{{range .LatestVersions}}
+					<div class="item gt-df">
+						<a class="gt-f1" href="{{$.PackageDescriptor.PackageWebLink}}/{{PathEscape .LowerVersion}}">{{.Version}}</a>
+						<span class="text small">{{DateTime "short" .CreatedUnix}}</span>
 					</div>
 				{{end}}
+				</div>
 				{{if or .CanWritePackages .HasRepositoryAccess}}
 					<div class="ui divider"></div>
 					<div class="ui relaxed list">


### PR DESCRIPTION
Related #25559

Current behaviour:
1. Deletion of a package version
2. Redirect to the owners package list

New behaviour:
1. Deletion of a package version
2.1. If there are more versions available, redirect to the package again
2.2. If there are no versions available, redirect to the owners package list