### PR TITLE
Adjust line-height on dashboard sidebar

### DIFF
--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -33,7 +33,7 @@
 					</a>
 					<div class="divider"></div>
 					<a class="{{if not $.RepoIDs}}active{{end}} repo name item" href="{{$.Link}}?type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&q={{$.Keyword}}">
-						<span class="text truncate">All</span>
+						<span class="text truncate">{{.locale.Tr "all"}}</span>
 						<span>{{CountFmt .TotalIssueCount}}</span>
 					</a>
 					{{range .Repos}}

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -21,7 +21,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  line-height: 1.3; /* avoid cut-off letters because of too little line-height from fomantic */
+  line-height: 1.3; /* avoid cut-off letters because fomantic line-height and overflow hidden via ellipsis */
   padding-top: 8.9px; /* adjust for increased line-height */
   padding-bottom: 8.9px; /* adjust for increased line-height */
 }

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -22,8 +22,8 @@
   align-items: center;
   justify-content: space-between;
   line-height: 1.3; /* avoid cut-off letters because of too little line-height from fomantic */
-  padding-top: 8.9px;
-  padding-bottom: 8.9px;
+  padding-top: 8.9px; /* adjust for increased line-height */
+  padding-bottom: 8.9px; /* adjust for increased line-height */
 }
 
 .dashboard.feeds .filter.menu .item .text.truncate,

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -21,6 +21,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  line-height: 1.3; /* avoid cut-off letters because of too little line-height from fomantic */
+  padding-top: 8.9px;
+  padding-bottom: 8.9px;
 }
 
 .dashboard.feeds .filter.menu .item .text.truncate,


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/25597

This is caused by some unintended interaction between our `overflow: hidden` for ellipsis and fomantic setting `line-height: 1` and this is the best I could come up with. Element height is unchanged after this via careful padding adjustment.

Also, I found some untranslated text.

<img width="313" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/41158e4c-2705-4fb2-a127-73d5dbb1cb0b">
