### PR TITLE
Preconfigure OAuth Git credential helpers

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -544,6 +544,9 @@ ENABLE = true
 ;;
 ;; Maximum length of oauth2 token/cookie stored on server
 ;MAX_TOKEN_LENGTH = 32767
+;;
+;; Register OAuth applications for Git credential helpers
+;GIT_CREDENTIAL_HELPERS = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1099,6 +1099,7 @@ This section only does "set" config, a removed config key from this section won'
 - `JWT_SECRET_URI`: **_empty_**: Instead of defining JWT_SECRET in the configuration, this configuration option can be used to give Gitea a path to a file that contains the secret (example value: `file:/etc/gitea/oauth2_jwt_secret`)
 - `JWT_SIGNING_PRIVATE_KEY_FILE`: **jwt/private.pem**: Private key file path used to sign OAuth2 tokens. The path is relative to `APP_DATA_PATH`. This setting is only needed if `JWT_SIGNING_ALGORITHM` is set to `RS256`, `RS384`, `RS512`, `ES256`, `ES384` or `ES512`. The file must contain a RSA or ECDSA private key in the PKCS8 format. If no key exists a 4096 bit key will be created for you.
 - `MAX_TOKEN_LENGTH`: **32767**: Maximum length of token/cookie to accept from OAuth2 provider
+- `GIT_CREDENTIAL_HELPERS`: **true**: Register OAuth applications for Git credential helpers at startup.
 
 ## i18n (`i18n`)
 

--- a/models/auth/oauth2.go
+++ b/models/auth/oauth2.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
 
@@ -44,6 +45,26 @@ func init() {
 	db.RegisterModel(new(OAuth2Application))
 	db.RegisterModel(new(OAuth2AuthorizationCode))
 	db.RegisterModel(new(OAuth2Grant))
+}
+
+func Init(ctx context.Context) error {
+	if setting.OAuth2.GitCredentialHelpers {
+		// the following Git credential helpers are universally useful
+		// https://git-scm.com/doc/credential-helpers
+		_ = db.Insert(ctx, []OAuth2Application{
+			{
+				Name:         "git-credential-oauth",
+				ClientID:     "a4792ccc-144e-407e-86c9-5e7d8d9c3269",
+				RedirectURIs: []string{"http://127.0.0.1", "https://127.0.0.1"},
+			},
+			{
+				Name:         "Git Credential Manager",
+				ClientID:     "e90ee53c-94e2-48ac-9358-a874fb9e0662",
+				RedirectURIs: []string{"http://127.0.0.1", "https://127.0.0.1"},
+			},
+		})
+	}
+	return nil
 }
 
 // TableName sets the table name to `oauth2_application`

--- a/modules/setting/oauth2.go
+++ b/modules/setting/oauth2.go
@@ -100,6 +100,7 @@ var OAuth2 = struct {
 	JWTSecretBase64            string `ini:"JWT_SECRET"`
 	JWTSigningPrivateKeyFile   string `ini:"JWT_SIGNING_PRIVATE_KEY_FILE"`
 	MaxTokenLength             int
+	GitCredentialHelpers       bool
 }{
 	Enable:                     true,
 	AccessTokenExpirationTime:  3600,
@@ -108,6 +109,7 @@ var OAuth2 = struct {
 	JWTSigningAlgorithm:        "RS256",
 	JWTSigningPrivateKeyFile:   "jwt/private.pem",
 	MaxTokenLength:             math.MaxInt16,
+	GitCredentialHelpers:       true,
 }
 
 func loadOAuth2From(rootCfg ConfigProvider) {

--- a/routers/init.go
+++ b/routers/init.go
@@ -10,6 +10,7 @@ import (
 
 	"code.gitea.io/gitea/models"
 	asymkey_model "code.gitea.io/gitea/models/asymkey"
+	authmodel "code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/modules/cache"
 	"code.gitea.io/gitea/modules/eventsource"
 	"code.gitea.io/gitea/modules/git"
@@ -138,6 +139,7 @@ func InitWebInstalled(ctx context.Context) {
 	mustInit(oauth2.Init)
 
 	mustInitCtx(ctx, models.Init)
+	mustInitCtx(ctx, authmodel.Init)
 	mustInit(repo_service.Init)
 
 	// Booting long running goroutines.

--- a/routers/web/repo/http.go
+++ b/routers/web/repo/http.go
@@ -147,7 +147,7 @@ func httpBase(ctx *context.Context) *serviceHandler {
 		// rely on the results of Contexter
 		if !ctx.IsSigned {
 			// TODO: support digit auth - which would be Authorization header with digit
-			ctx.Resp.Header().Set("WWW-Authenticate", "Basic realm=\".\"")
+			ctx.Resp.Header().Set("WWW-Authenticate", `Basic realm="Gitea"`)
 			ctx.Error(http.StatusUnauthorized)
 			return nil
 		}


### PR DESCRIPTION
OAuth Git credential helpers are universally useful so preregister on every instance. https://git-scm.com/doc/credential-helpers

Fixes #25189
