### PR TITLE
Remove -v from vulncheck (#23953)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,7 +751,7 @@ generate-go: $(TAGS_PREREQ)
 
 .PHONY: security-check
 security-check:
-	go run $(GOVULNCHECK_PACKAGE) -v ./...
+	go run $(GOVULNCHECK_PACKAGE) ./...
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
 	CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/23953 to 1.19 to fix the branch build:

https://drone.gitea.io/go-gitea/gitea/75155/1/9