### PR TITLE
Fix show more for image on diff page

### DIFF
--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -4,6 +4,7 @@ import {initRepoIssueContentHistory} from './repo-issue-content.js';
 import {initDiffFileTree} from './repo-diff-filetree.js';
 import {validateTextareaNonEmpty} from './comp/ComboMarkdownEditor.js';
 import {initViewedCheckboxListenerFor, countAndUpdateViewedFiles, initExpandAndCollapseFilesButton} from './pull-view-file.js';
+import {initImageDiff} from './imagediff.js';
 
 const {csrfToken, pageData} = window.config;
 
@@ -117,6 +118,7 @@ function onShowMoreFiles() {
   initRepoIssueContentHistory();
   initViewedCheckboxListenerFor();
   countAndUpdateViewedFiles();
+  initImageDiff();
 }
 
 export function loadMoreFiles(url) {


### PR DESCRIPTION
Right now when clicking on loadmore on files change page, if the loaded content is image, it will be always in load status:

https://github.com/go-gitea/gitea/assets/17645053/39e449b6-067a-474c-9443-9dd98d5bbfe2

This PR fixes this by adding `initImageDiff ` to `onShowMoreFiles `

After:

https://github.com/go-gitea/gitea/assets/17645053/87bbb13e-0064-4a6e-a7ad-0f0060eb8bff

