### PR TITLE
[docs] Add note that PROTOCOL config is case-sensitive

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -60,6 +60,7 @@ RUN_USER = ; git
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; The protocol the server listens on. One of 'http', 'https', 'http+unix', 'fcgi' or 'fcgi+unix'. Defaults to 'http'
+;; Note: Value must be lowercase.
 ;PROTOCOL = http
 ;;
 ;; Expect PROXY protocol headers on connections

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -281,6 +281,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 
 - `APP_DATA_PATH`: **_`AppWorkPath`_/data**: This is the default root path for storing data.
 - `PROTOCOL`: **http**: \[http, https, fcgi, http+unix, fcgi+unix\]
+  - Note: Value is case-sensitive (must be in lowercase). For example, if you write `PROTOCOL=HTTPS`, you may get a SSL_ERROR_RX_RECORD_TOO_LONG error on Firefox or ERR_SSL_PROTOCOL_ERROR on Chrome and Edge.
 - `USE_PROXY_PROTOCOL`: **false**: Expect PROXY protocol headers on connections
 - `PROXY_PROTOCOL_TLS_BRIDGING`: **false**: When protocol is https, expect PROXY protocol headers after TLS negotiation.
 - `PROXY_PROTOCOL_HEADER_TIMEOUT`: **5s**: Timeout to wait for PROXY protocol header (set to 0 to have no timeout)

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -281,7 +281,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 
 - `APP_DATA_PATH`: **_`AppWorkPath`_/data**: This is the default root path for storing data.
 - `PROTOCOL`: **http**: \[http, https, fcgi, http+unix, fcgi+unix\]
-  - Note: Value is case-sensitive (must be in lowercase). For example, if you write `PROTOCOL=HTTPS`, you may get a SSL_ERROR_RX_RECORD_TOO_LONG error on Firefox or ERR_SSL_PROTOCOL_ERROR on Chrome and Edge.
+  - Note: Value must be lowercase.
 - `USE_PROXY_PROTOCOL`: **false**: Expect PROXY protocol headers on connections
 - `PROXY_PROTOCOL_TLS_BRIDGING`: **false**: When protocol is https, expect PROXY protocol headers after TLS negotiation.
 - `PROXY_PROTOCOL_HEADER_TIMEOUT`: **5s**: Timeout to wait for PROXY protocol header (set to 0 to have no timeout)


### PR DESCRIPTION
See [issue on gitea.com](https://gitea.com/gitea/gitea-docusaurus/issues/38), copied below for convenience: 
> Hello, may I first confirm that the app.ini PROTOCOL config is case sensitive (must be lowercase)?
> 
> If so, I'd like to suggest for it to be highlighted in the [HTTPS Setup](https://docs.gitea.com/administration/https-setup#using-the-built-in-server) page.
> Perhaps something like:
> For the PROTOCOL=https field, make sure https is lowercase. Writing PROTOCOL=HTTPS may result in a SSL_ERROR_RX_RECORD_TOO_LONG error on Firefox or ERR_SSL_PROTOCOL_ERROR on Chrome and Edge.
> 
> Background
> At first I carelessly wrote PROTOCOL=HTTPS in my app.ini, and Firefox didn't allow me to connect because:
> Secure Connection Failed
> An error occurred during a connection to gitea.local.lan. SSL received a record that exceeded the maximum permissible length.
> Error code: SSL_ERROR_RX_RECORD_TOO_LONG
> I spent maybe half an hour troubleshooting my certs, ports, and other configs before backtracking to the start and realizing the capitalization difference there 😅. When I changed that config to lowercase, it worked.

For this PR I added the note in the Config Cheat Sheet page and fixed the links to it from the HTTPS Setup page.

Was originally thinking to put the note in the HTTPS Setup page itself, but since there are 2 sections referencing the PROTOCOL config, I was thinking it'd be neater and more concise to put it in the Config Cheat Sheet page instead. Especially since both sections already link to it, and I actually tried to check that link quite early on in my troubleshooting (but didn't pay much attention to it since the link was broken).

## Before/After screenshots as per [this repo's docs](https://github.com/go-gitea/gitea/tree/main/docs)

Before - links
![image](https://github.com/go-gitea/gitea/assets/135522693/e0745077-f6a9-4178-aa78-2155ccb58fd6)
Note: For this the links weren't broken, the links fix is because they were broken on gitea.com's docs (see below).

After - links
![image](https://github.com/go-gitea/gitea/assets/135522693/748b3759-aa13-4ad0-9811-c6664b6cdd35)

Before - config cheat sheet
![image](https://github.com/go-gitea/gitea/assets/135522693/4ff2e4e6-3528-4cea-a7a6-64a75854eb99)

After - config cheat sheet
![image](https://github.com/go-gitea/gitea/assets/135522693/c8e07ab6-5a26-4582-a4d0-b83d1f11a30e)


## Before/After screenshots as per [gitea.com's docs](https://gitea.com/gitea/gitea-docusaurus)

Before - links
![image](https://github.com/go-gitea/gitea/assets/135522693/4d26ea67-b987-4b91-810b-c53852a13078)

After - links
![image](https://github.com/go-gitea/gitea/assets/135522693/24d02907-7f9e-4228-a190-7696623c00f7)

Before - config cheat sheet
![image](https://github.com/go-gitea/gitea/assets/135522693/978eedfd-ce05-488d-ab54-9d7f3c9f233d)

After - config cheat sheet
![image](https://github.com/go-gitea/gitea/assets/135522693/12d22566-a2b0-45ec-8302-a88eae9365d8)
