### PR TITLE
Remove `feature` label from `feature request` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Got an idea for a feature that Gitea doesn't have currently?  Submit your idea here!
-labels: ["kind/feature", "kind/proposal"]
+labels: ["kind/proposal"]
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
We need a feature request process, so when a user submit a feature proposal, it should not be marked as feature before it has been accept.