### PR TITLE
Fix branch selector on release page in 1.19

### DIFF
--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -486,12 +486,7 @@ export function initRepository() {
     return;
   }
 
-
-  // File list and commits
-  if ($('.repository.file.list').length > 0 || $('.branch-dropdown').length > 0 ||
-    $('.repository.commits').length > 0 || $('.repository.release').length > 0) {
-    initRepoBranchTagDropdown('.choose.reference .dropdown');
-  }
+  initRepoBranchTagDropdown('.choose.reference .dropdown');
 
   // Wiki
   if ($('.repository.wiki.view').length > 0) {


### PR DESCRIPTION
Fix #25705

Regression of #24369

There is no problem in 1.20 because there is #24459