### PR TITLE
Fix commits table regression

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -1,5 +1,5 @@
 <div class="ui attached table segment commit-table">
-		<table class="ui very basic striped table unstackable fixed" id="commits-table">
+		<table class="ui very basic striped table unstackable" id="commits-table">
 			<thead>
 				<tr>
 					<th class="three wide">{{.locale.Tr "repo.commits.author"}}</th>

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -1,5 +1,5 @@
 <div class="ui attached table segment commit-table">
-		<table class="ui very basic striped table unstackable" id="commits-table">
+		<table class="ui very basic striped table unstackable fixed" id="commits-table">
 			<thead>
 				<tr>
 					<th class="three wide">{{.locale.Tr "repo.commits.author"}}</th>

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1314,7 +1314,6 @@
 }
 
 .repository #commits-table {
-  display: block;
   white-space: nowrap;
 }
 

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1313,8 +1313,9 @@
   padding: 5px 10px;
 }
 
-.repository #commits-table thead th:first-of-type {
-  padding-left: 15px;
+.repository #commits-table {
+  display: block;
+  white-space: nowrap;
 }
 
 .repository #commits-table thead .sha {
@@ -1331,6 +1332,7 @@
 
 .repository #commits-table td.message {
   text-overflow: unset;
+  white-space: normal;
 }
 
 .repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n) {
@@ -3243,17 +3245,6 @@ tbody.commit-list {
   .commit-table td.sha,
   .commit-table th.sha {
     display: none !important;
-  }
-  .commit-table .commit-list span.message-wrapper {
-    max-width: none;
-  }
-  .commit-table .commit-list tr td:first-child,
-  .commit-table .commit-list tr td:last-child {
-    white-space: nowrap;
-  }
-  .commit-table .commit-list td.author {
-    display: block;
-    width: calc(100% + 0.5rem);
   }
   .commit-table .commit-list .copy-commit-sha {
     display: none !important;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2683,6 +2683,7 @@ tbody.commit-list {
 /* in the commit list, messages can wrap so we can use inline */
 .commit-list .message-wrapper {
   display: inline;
+  overflow-wrap: anywhere;
 }
 
 /* but in the repo-files-table we cannot */

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1313,10 +1313,9 @@
   padding: 5px 10px;
 }
 
-.repository #commits-table {
+.repository #commits-table td:not(.message) {
   white-space: nowrap;
 }
-
 .repository #commits-table thead .sha {
   width: 200px;
 }
@@ -1331,7 +1330,6 @@
 
 .repository #commits-table td.message {
   text-overflow: unset;
-  white-space: normal;
 }
 
 .repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n) {


### PR DESCRIPTION
Fixes #25693

The commits table appearance fix in #25634 was incomplete and caused a regression. This PR fixes that issue and removes some unneeded CSS classes because of the proper fix.

<details>
<summary>Before</summary>

![Bildschirmfoto vom 2023-07-05 19-37-04](https://github.com/go-gitea/gitea/assets/47871822/4f680878-9612-443b-a0a3-b331369c912b)
![Bildschirmfoto vom 2023-07-05 19-38-56](https://github.com/go-gitea/gitea/assets/47871822/8826f246-6bde-4c33-9d10-172d11619908)

</details>

<details>
<summary>After</summary>

![Bildschirmfoto vom 2023-07-05 19-37-44](https://github.com/go-gitea/gitea/assets/47871822/0fe2d2cb-f706-41e0-b341-d1827a64b21a)
![Bildschirmfoto vom 2023-07-05 19-38-08](https://github.com/go-gitea/gitea/assets/47871822/2f29271c-7da5-44d7-bd9a-38a4bfdde219)

</details>
