### PR TITLE
Remove unused code

### DIFF
--- a/models/organization/org.go
+++ b/models/organization/org.go
@@ -532,27 +532,6 @@ func GetOrgsCanCreateRepoByUserID(userID int64) ([]*Organization, error) {
 		Find(&orgs)
 }
 
-// GetOrgUsersByUserID returns all organization-user relations by user ID.
-func GetOrgUsersByUserID(uid int64, opts *SearchOrganizationsOptions) ([]*OrgUser, error) {
-	ous := make([]*OrgUser, 0, 10)
-	sess := db.GetEngine(db.DefaultContext).
-		Join("LEFT", "`user`", "`org_user`.org_id=`user`.id").
-		Where("`org_user`.uid=?", uid)
-	if !opts.All {
-		// Only show public organizations
-		sess.And("is_public=?", true)
-	}
-
-	if opts.PageSize != 0 {
-		sess = db.SetSessionPagination(sess, opts)
-	}
-
-	err := sess.
-		Asc("`user`.name").
-		Find(&ous)
-	return ous, err
-}
-
 // GetOrgUsersByOrgID returns all organization-user relations by organization ID.
 func GetOrgUsersByOrgID(ctx context.Context, opts *FindOrgMembersOpts) ([]*OrgUser, error) {
 	sess := db.GetEngine(ctx).Where("org_id=?", opts.OrgID)

--- a/models/organization/org_test.go
+++ b/models/organization/org_test.go
@@ -207,42 +207,6 @@ func TestFindOrgs(t *testing.T) {
 	assert.EqualValues(t, 1, total)
 }
 
-func TestGetOrgUsersByUserID(t *testing.T) {
-	assert.NoError(t, unittest.PrepareTestDatabase())
-
-	orgUsers, err := organization.GetOrgUsersByUserID(5, &organization.SearchOrganizationsOptions{All: true})
-	assert.NoError(t, err)
-	if assert.Len(t, orgUsers, 3) {
-		assert.Equal(t, organization.OrgUser{
-			ID:       orgUsers[0].ID,
-			OrgID:    23,
-			UID:      5,
-			IsPublic: false,
-		}, *orgUsers[0])
-		assert.Equal(t, organization.OrgUser{
-			ID:       orgUsers[1].ID,
-			OrgID:    6,
-			UID:      5,
-			IsPublic: true,
-		}, *orgUsers[1])
-		assert.Equal(t, organization.OrgUser{
-			ID:       orgUsers[2].ID,
-			OrgID:    7,
-			UID:      5,
-			IsPublic: false,
-		}, *orgUsers[2])
-	}
-
-	publicOrgUsers, err := organization.GetOrgUsersByUserID(5, &organization.SearchOrganizationsOptions{All: false})
-	assert.NoError(t, err)
-	assert.Len(t, publicOrgUsers, 1)
-	assert.Equal(t, *orgUsers[1], *publicOrgUsers[0])
-
-	orgUsers, err = organization.GetOrgUsersByUserID(1, &organization.SearchOrganizationsOptions{All: true})
-	assert.NoError(t, err)
-	assert.Len(t, orgUsers, 0)
-}
-
 func TestGetOrgUsersByOrgID(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 


### PR DESCRIPTION
The method is only used in the test. Found it because I changed the fixtures and had a hard time fixing this test. My revenge is deleting it.