### PR TITLE
Remove broken translations

### DIFF
--- a/options/locale/locale_cs-CZ.ini
+++ b/options/locale/locale_cs-CZ.ini
@@ -2915,74 +2915,59 @@ versions.view_all=Zobrazit všechny
 dependency.id=ID
 dependency.version=Verze
 cargo.install=Chcete-li nainstalovat balíček pomocí Cargo, spusťte následující příkaz:
-cargo.documentation=Další informace o registru Cargo naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">dokumentaci</a>.
 cargo.details.repository_site=Stránka repositáře
 cargo.details.documentation_site=Stránka dokumentace
 chef.registry=Nastavit tento registr v souboru <code>~/.chef/config.rb</code>:
 chef.install=Pro instalaci balíčku spusťte následující příkaz:
-chef.documentation=Další informace o registru Chef naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">dokumentaci</a>.
 composer.registry=Nastavit tento registr v souboru <code>~/.composer/config.json</code>:
 composer.install=Pro instalaci balíčku pomocí Compposer spusťte následující příkaz:
-composer.documentation=Další informace o registru Composer naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">dokumentaci</a>.
 composer.dependencies=Závislosti
 composer.dependencies.development=Vývojové závislosti
 conan.details.repository=Repozitář
 conan.registry=Nastavte tento registr z příkazového řádku:
 conan.install=Pro instalaci balíčku pomocí Conan spusťte následující příkaz:
-conan.documentation=Další informace o registru Conan naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">dokumentaci</a>.
 conda.registry=Nastavte tento registr jako Conda repozitář ve vašem <code>.condarc</code>:
 conda.install=Pro instalaci balíčku pomocí Conda spusťte následující příkaz:
-conda.documentation=Další informace o registru Conda naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">dokumentaci</a>.
 conda.details.repository_site=Stránka repositáře
 conda.details.documentation_site=Stránka dokumentace
 container.details.type=Typ obrazu
 container.details.platform=Platforma
 container.pull=Stáhněte obraz z příkazové řádky:
 container.digest=Výběr:
-container.documentation=Další informace o registru Container naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">dokumentaci</a>.
 container.multi_arch=OS/architektura
 container.layers=Vrstvy obrazů
 container.labels=Štítky
 container.labels.key=Klíč
 container.labels.value=Hodnota
 generic.download=Stáhnout balíček z příkazové řádky:
-generic.documentation=Další informace o obecném registru naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">dokumentaci</a>.
 helm.registry=Nastavte tento registr z příkazového řádku:
 helm.install=Pro instalaci balíčku spusťte následující příkaz:
-helm.documentation=Další informace o Helm registru naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">dokumentaci</a>.
 maven.registry=Nastavte tento registr ve vašem projektu <code>pom.xml</code> souboru:
 maven.install=Pro použití balíčku uveďte následující v bloku <code>dependencies</code> v souboru <code>pom.xml</code>:
 maven.install2=Spustit pomocí příkazové řádky:
 maven.download=Chcete-li stáhnout závislost, spusťte přes příkazový řádek:
-maven.documentation=Další informace o registru Maven naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">dokumentaci</a>.
 nuget.registry=Nastavte tento registr z příkazového řádku:
 nuget.install=Chcete-li nainstalovat balíček pomocí NuGet, spusťte následující příkaz:
-nuget.documentation=Další informace o registru NuGet naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">dokumentaci</a>.
 nuget.dependency.framework=Cílový Framework
 npm.registry=Nastavte tento registr ve vašem projektu v souboru <code>.npmrc</code>:
 npm.install=Pro instalaci balíčku pomocí npm spusťte následující příkaz:
 npm.install2=nebo ho přidejte do souboru package.json:
-npm.documentation=Další informace o npm registru naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">dokumentaci</a>.
 npm.dependencies=Závislosti
 npm.dependencies.development=Vývojové závislosti
 npm.dependencies.peer=Vzájemné závislosti
 npm.dependencies.optional=Volitelné závislosti
 npm.details.tag=Značka
 pub.install=Chcete-li nainstalovat balíček pomocí Dart, spusťte následující příkaz:
-pub.documentation=Další informace o registru Pub naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">dokumentaci</a>.
 pypi.requires=Vyžaduje Python
 pypi.install=Pro instalaci balíčku pomocí pip spusťte následující příkaz:
-pypi.documentation=Další informace o registru PyPI naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">dokumentaci</a>.
 rubygems.install=Pro instalaci balíčku pomocí gem spusťte následující příkaz:
 rubygems.install2=nebo ho přidejte do Gemfie:
 rubygems.dependencies.runtime=Běhové závislosti
 rubygems.dependencies.development=Vývojové závislosti
 rubygems.required.ruby=Vyžaduje verzi Ruby
 rubygems.required.rubygems=Vyžaduje verzi RubyGem
-rubygems.documentation=Další informace o registru RubyGems naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">dokumentaci</a>.
 swift.registry=Nastavte tento registr z příkazového řádku:
 vagrant.install=Pro přidání Vagrant box spusťte následující příkaz:
-vagrant.documentation=Další informace o registru Vagrant naleznete v <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">dokumentaci</a>.
 settings.link=Propojit tento balíček s repozitářem
 settings.link.description=Pokud propojíte balíček s repozitářem, je tento balíček uveden v seznamu balíčků repozitáře.
 settings.link.select=Vybrat repozitář

--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -2881,60 +2881,48 @@ dependency.version=Version
 chef.install=Nutze folgenden Befehl, um das Paket zu installieren:
 composer.registry=Setze diese Paketverwaltung in deiner <code>~/.composer/config.json</code> Datei auf:
 composer.install=Nutze folgenden Befehl, um das Paket mit Composer zu installieren:
-composer.documentation=Weitere Informationen zur Composer-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">Dokumentation</a>.
 composer.dependencies=Abhängigkeiten
 composer.dependencies.development=Entwicklungsabhängigkeiten
 conan.details.repository=Repository
 conan.registry=Diese Registry über die Kommandozeile einrichten:
 conan.install=Um das Paket mit Conan zu installieren, führe den folgenden Befehl aus:
-conan.documentation=Weitere Informationen zur Conan-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">Dokumentation</a>.
 container.details.type=Container-Image Typ
 container.details.platform=Plattform
 container.pull=Downloade das Container-Image aus der Kommandozeile:
-container.documentation=Weitere Informationen zur Container-Imageverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">Dokumentation</a>.
 container.multi_arch=Betriebsystem / Architektur
 container.layers=Container-Image Ebenen
 container.labels=Labels
 container.labels.key=Schlüssel
 container.labels.value=Wert
 generic.download=Downloade das Paket aus der Kommandozeile:
-generic.documentation=Weitere Informationen zur generischen Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">Dokumentation</a>.
 helm.registry=Diese Paketverwaltung über die Kommandozeile einrichten:
 helm.install=Nutze folgenden Befehl, um das Paket zu installieren:
-helm.documentation=Weitere Informationen zur Helm-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">Dokumentation</a>.
 maven.registry=Setze diese Paketverwaltung in der <code>pom.xml</code> deines Projektes auf:
 maven.install=Nimm Folgendes in den <code>dependencies</code> deiner <code>pom.xml</code> auf, um das Paket zu installieren:
 maven.install2=Über die Kommandozeile ausführen:
 maven.download=Nutze folgendes Kommando, um die Dependency herunterzuladen:
-maven.documentation=Weitere Informationen zur Maven-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">Dokumentation</a>.
 nuget.registry=Diese Registry über die Kommandozeile einrichten:
 nuget.install=Um das Paket mit NuGet zu installieren, führe den folgenden Befehl aus:
-nuget.documentation=Weitere Informationen zur NuGet-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">Dokumentation</a>.
 nuget.dependency.framework=Zielframework
 npm.registry=Setze diese Paketverwaltung in der <code>.npmrc</code> deines Projektes auf:
 npm.install=Um das Paket mit npm zu installieren, führe den folgenden Befehl aus:
 npm.install2=oder füge es zur package.json-Datei hinzu:
-npm.documentation=Weitere Informationen zur npm-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">Dokumentation</a>.
 npm.dependencies=Abhängigkeiten
 npm.dependencies.development=Entwicklungsabhängigkeiten
 npm.dependencies.peer=Peer Abhängigkeiten
 npm.dependencies.optional=Optionale Abhängigkeiten
 npm.details.tag=Tag
 pub.install=Um das Paket mit Dart zu installieren, führe den folgenden Befehl aus:
-pub.documentation=Weitere Informationen zur pub-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">Dokumentation</a>.
 pypi.requires=Erfordert Python
 pypi.install=Nutze folgenden Befehl, um das Paket mit pip zu installieren:
-pypi.documentation=Weitere Informationen zur PyPI-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">Dokumentation</a>.
 rubygems.install=Um das Paket mit gem zu installieren, führe den folgenden Befehl aus:
 rubygems.install2=oder füg es zum Gemfile hinzu:
 rubygems.dependencies.runtime=Laufzeitabhängigkeiten
 rubygems.dependencies.development=Entwicklungsabhängigkeiten
 rubygems.required.ruby=Benötigt Ruby Version
 rubygems.required.rubygems=Benötigt RubyGem Version
-rubygems.documentation=Weitere Informationen zur RubyGems-Paketverwaltung findest du in der <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">Dokumentation</a>.
 swift.registry=Diese Registry über die Kommandozeile einrichten:
 vagrant.install=Um eine Vagrant-Box hinzuzufügen, führen Sie folgenden Befehl aus:
-vagrant.documentation=Für weitere Informationen zur Vagrant-Registry, siehe <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">Dokumentation</a>.
 settings.link=Dieses Paket einem Repository zuweisen
 settings.link.description=Wenn du ein Paket mit einem Repository verknüpfst, wird es in der Paketliste des Repositories angezeigt.
 settings.link.select=Repository auswählen

--- a/options/locale/locale_el-GR.ini
+++ b/options/locale/locale_el-GR.ini
@@ -3077,7 +3077,6 @@ error.unit_not_allowed=Δεν σας επιτρέπεται να έχετε πρ
 title=Πακέτα
 desc=Διαχείριση πακέτων μητρώου.
 empty=Δεν υπάρχουν πακέτα ακόμα.
-empty.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο πακέτων, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">στην τεκμηρίωση</a>.
 empty.repo=Μήπως ανεβάσατε ένα πακέτο, αλλά δεν εμφανίζεται εδώ; Πηγαίνετε στις <a href="%[1]s">ρυθμίσεις πακέτων</a> και συνδέστε το σε αυτό το αποθετήριο.
 filter.type=Τύπος
 filter.type.all=Όλα
@@ -3104,77 +3103,61 @@ dependency.id=ID
 dependency.version=Έκδοση
 cargo.registry=Ρυθμίστε αυτό το μητρώο στις ρυθμίσεις του Cargo (για παράδειγμα <code>~/.cargo/config.toml</code>):
 cargo.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το Cargo, εκτελέστε την ακόλουθη εντολή:
-cargo.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Cargo, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">στην τεκμηρίωση</a>.
 cargo.details.repository_site=Ιστοσελίδα Αποθετηρίου
 cargo.details.documentation_site=Ιστοσελίδα Τεκμηρίωσης
 chef.registry=Ρυθμίστε αυτό το μητρώο στο αρχείο <code>~/.chef/config.rb</code>:
 chef.install=Για να εγκαταστήσετε το πακέτο, εκτελέστε την ακόλουθη εντολή:
-chef.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Chef, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">στην τεκμηρίωση</a>.
 composer.registry=Ρυθμίστε αυτό το μητρώο στο αρχείο <code>~/.composer/config.json</code>:
 composer.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το Composer, εκτελέστε την ακόλουθη εντολή:
-composer.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Composer, διαβάστε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">τη τεκμηρίωση</a>.
 composer.dependencies=Εξαρτήσεις
 composer.dependencies.development=Εξαρτήσεις Ανάπτυξης
 conan.details.repository=Αποθετήριο
 conan.registry=Ρυθμίστε αυτό το μητρώο από τη γραμμή εντολών:
 conan.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το Conan, εκτελέστε την ακόλουθη εντολή:
-conan.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Conan, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">στην τεκμηρίωση</a>.
 conda.registry=Ρυθμίστε αυτό το μητρώο ως αποθετήριο Conda στο αρχείο <code>.condarc</code>:
 conda.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το Conda, εκτελέστε την ακόλουθη εντολή:
-conda.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Conda, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">στην τεκμηρίωση</a>.
 conda.details.repository_site=Ιστοσελίδα Αποθετηρίου
 conda.details.documentation_site=Ιστοσελίδα Τεκμηρίωσης
 container.details.type=Τύπος Εικόνας
 container.details.platform=Πλατφόρμα
 container.pull=Κατεβάστε την εικόνα από τη γραμμή εντολών:
 container.digest=Σύνοψη:
-container.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο για Container, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">στην τεκμηρίωση</a>.
 container.multi_arch=ΛΣ / Αρχιτεκτονική
 container.layers=Στρώματα Εικόνας
 container.labels=Ετικέτες
 container.labels.key=Κλειδί
 container.labels.value=Τιμή
 generic.download=Λήψη πακέτου από τη γραμμή εντολών:
-generic.documentation=Για περισσότερες πληροφορίες σχετικά με το γενικό μητρώο, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">στην τεκμηρίωση</a>.
 helm.registry=Ρυθμίστε αυτό το μητρώο από τη γραμμή εντολών:
 helm.install=Για να εγκαταστήσετε το πακέτο, εκτελέστε την ακόλουθη εντολή:
-helm.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Helm, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">στην τεκμηρίωση</a>.
 maven.registry=Ρυθμίστε αυτό το μητρώο στο αρχείο <code>pom.xml</code> του έργου σας:
 maven.install=Για να χρησιμοποιήσετε το πακέτο, συμπεριλάβετε τα ακόλουθα στη περιοχή <code>dependencies</code> στο αρχείο <code>pom.xml</code>:
 maven.install2=Εκτέλεση μέσω γραμμής εντολών:
 maven.download=Για να κατεβάσετε την εξάρτηση, εκτελέστε μέσω της γραμμής εντολών:
-maven.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Maven, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">στην τεκμηρίωση</a>.
 nuget.registry=Ρυθμίστε αυτό το μητρώο από τη γραμμή εντολών:
 nuget.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το NuGet, εκτελέστε την ακόλουθη εντολή:
-nuget.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο NuGet δείτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">την τεκμηρίωση</a>.
 nuget.dependency.framework=Πλαίσιο Ανάπτυξης
 npm.registry=Ρυθμίστε αυτό το μητρώο στο αρχείο <code>.npmrc</code> του έργου σας:
 npm.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας npm, εκτελέστε την ακόλουθη εντολή:
 npm.install2=ή προσθέστε το στο αρχείο package.json:
-npm.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο npm, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">στην τεκμηρίωση</a>.
 npm.dependencies=Εξαρτήσεις
 npm.dependencies.development=Εξαρτήσεις Ανάπτυξης
 npm.dependencies.peer=Εξαρτήσεις Ομότιμου
 npm.dependencies.optional=Προαιρετικές Εξαρτήσεις
 npm.details.tag=Σήμανση
 pub.install=Για να εγκαταστήσετε το πακέτο μέσω του Dart, εκτελέστε την ακόλουθη εντολή:
-pub.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Pub, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">στην τεκμηρίωση</a>.
 pypi.requires=Απαιτεί Python
 pypi.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το pip, εκτελέστε την ακόλουθη εντολή:
-pypi.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο PyPI, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">στην τεκμηρίωση</a>.
 rubygems.install=Για να εγκαταστήσετε το πακέτο χρησιμοποιώντας το gem, εκτελέστε την ακόλουθη εντολή:
 rubygems.install2=ή προσθέστε το στο Gemfile:
 rubygems.dependencies.runtime=Εξαρτήσεις Εκτέλεσης
 rubygems.dependencies.development=Εξαρτήσεις Ανάπτυξης
 rubygems.required.ruby=Απαιτεί την έκδοση Ruby
 rubygems.required.rubygems=Απαιτεί έκδοση RubyGem
-rubygems.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο RubyGems, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">στην τεκμηρίωση</a>.
 swift.registry=Ρυθμίστε αυτό το μητρώο από τη γραμμή εντολών:
 swift.install=Προσθέστε το πακέτο στο αρχείο <code>Package.swift</code>:
 swift.install2=και εκτελέστε την ακόλουθη εντολή:
-swift.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο Swift, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">στην τεκμηρίωση</a>.
 vagrant.install=Για προσθήκη ενός κυτίου Vagrant, εκτελέστε την ακόλουθη εντολή:
-vagrant.documentation=Για περισσότερες πληροφορίες σχετικά με το μητρώο του Vagrant, ανατρέξτε <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">στην τεκμηρίωση</a>.
 settings.link=Σύνδεση αυτού του πακέτου με ένα αποθετήριο
 settings.link.description=Εάν συνδέσετε ένα πακέτο με ένα αποθετήριο, το πακέτο περιλαμβάνεται στη λίστα πακέτων του αποθετηρίου.
 settings.link.select=Επιλογή Αποθετηρίου

--- a/options/locale/locale_es-ES.ini
+++ b/options/locale/locale_es-ES.ini
@@ -2877,61 +2877,49 @@ dependency.version=Versión
 chef.install=Para instalar el paquete, ejecute el siguiente comando:
 composer.registry=Configura este registro en el archivo <code>~/.composer/config.json</code>:
 composer.install=Para instalar el paquete usando Composer, ejecute el siguiente comando:
-composer.documentation=Para más información sobre el registro de Composer, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">la documentación</a>.
 composer.dependencies=Dependencias
 composer.dependencies.development=Dependencias de desarrollo
 conan.details.repository=Repositorio
 conan.registry=Configurar este registro desde la línea de comandos:
 conan.install=Para instalar el paquete usando Conan, ejecuta el siguiente comando:
-conan.documentation=Para más información sobre el registro de Conan, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">la documentación</a>.
 container.details.type=Tipo de imagen
 container.details.platform=Plataforma
 container.pull=Arrastra la imagen desde la línea de comandos:
 container.digest=Resumen:
-container.documentation=Para más información sobre el registro de Container, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">la documentación</a>.
 container.multi_arch=SO / Arquitectura
 container.layers=Capas de imagen
 container.labels=Etiquetas
 container.labels.key=Clave
 container.labels.value=Valor
 generic.download=Descargar paquete desde la línea de comandos:
-generic.documentation=Para más información sobre el registro genérico, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">la documentación</a>.
 helm.registry=Configurar este registro desde la línea de comandos:
 helm.install=Para instalar el paquete, ejecute el siguiente comando:
-helm.documentation=Para obtener más información sobre el registro de Helm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">la documentación</a>.
 maven.registry=Configure este registro en su proyecto <code>pom.xml</code> archivo:
 maven.install=Para usar el paquete incluya lo siguiente en el bloque <code>dependencias</code> en el archivo <code>pom.xml</code>:
 maven.install2=Ejecutar vía línea de comandos:
 maven.download=Para descargar la dependencia, ejecute vía línea de comandos:
-maven.documentation=Para obtener más información sobre el registro de Maven, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">la documentación</a>.
 nuget.registry=Configurar este registro desde la línea de comandos:
 nuget.install=Para instalar el paquete usando NuGet, ejecute el siguiente comando:
-nuget.documentation=Para obtener más información sobre el registro de NuGet consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">la documentación</a>.
 nuget.dependency.framework=Marco de destino
 npm.registry=Configura este registro en tu proyecto <code>.npmrc</code> archivo:
 npm.install=Para instalar el paquete usando npm, ejecute el siguiente comando:
 npm.install2=o añádelo al archivo package.json:
-npm.documentation=Para más información sobre el registro de npm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">la documentación</a>.
 npm.dependencies=Dependencias
 npm.dependencies.development=Dependencias de desarrollo
 npm.dependencies.peer=Dependencias de pares
 npm.dependencies.optional=Dependencias opcionales
 npm.details.tag=Etiqueta
 pub.install=Para instalar el paquete usando Dart, ejecute el siguiente comando:
-pub.documentation=Para obtener más información sobre el registro de Pub, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">la documentación</a>.
 pypi.requires=Requiere Python
 pypi.install=Para instalar el paquete usando pip, ejecute el siguiente comando:
-pypi.documentation=Para obtener más información sobre el registro PyPI, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">la documentación</a>.
 rubygems.install=Para instalar el paquete usando gem, ejecute el siguiente comando:
 rubygems.install2=o añádelo al archivo Gemfile:
 rubygems.dependencies.runtime=Dependencias en tiempo de ejecución
 rubygems.dependencies.development=Dependencias de desarrollo
 rubygems.required.ruby=Requiere versión Ruby
 rubygems.required.rubygems=Requiere la versión de RubyGem
-rubygems.documentation=Para obtener más información sobre el registro de RubyGems, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">la documentación</a>.
 swift.registry=Configurar este registro desde la línea de comandos:
 vagrant.install=Para añadir un paquete Vagrant, ejecuta el siguiente comando:
-vagrant.documentation=Para más información sobre el registro de paquetes Vagrant, revisa la <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">documentación</a>.
 settings.link=Vincular este paquete a un repositorio
 settings.link.description=Si enlaza un paquete con un repositorio, el paquete se enumera en la lista de paquetes del repositorio.
 settings.link.select=Seleccionar repositorio

--- a/options/locale/locale_fi-FI.ini
+++ b/options/locale/locale_fi-FI.ini
@@ -1624,17 +1624,7 @@ filter.type.all=Kaikki
 filter.no_result=Suodattimesi ei tuottanut tuloksia.
 installation=Asennus
 details.author=Tekijä
-composer.documentation=Lisätietoa Composer-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">dokumentaatiosta</a>.
 conan.details.repository=Repo
-conan.documentation=Lisätietoa Conan-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">dokumentaatiosta</a>.
-container.documentation=Lisätietoa Container-rekisteristä löydät<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">dokumentaatiosta</a>.
-generic.documentation=Lisätietoa yleisestä pakettirekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">dokumentaatiosta</a>.
-helm.documentation=Lisätietoa Helm-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">dokumentaatiosta</a>.
-maven.documentation=Lisätietoa Maven-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">dokumentaatiosta</a>.
-nuget.documentation=Lisätietoa NuGet-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">dokumentaatiosta</a>.
-npm.documentation=Lisätietoa npm-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">dokumentaatiosta</a>.
-pypi.documentation=Lisätietoa PyPI-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">dokumentaatiosta</a>.
-rubygems.documentation=Lisätietoa RubyGems-rekisteristä löydät <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">dokumentaatiosta</a>.
 owner.settings.cleanuprules.enabled=Käytössä
 alpine.repository.branches=Haarat
 alpine.repository.repositories=Repot

--- a/options/locale/locale_fr-FR.ini
+++ b/options/locale/locale_fr-FR.ini
@@ -3069,7 +3069,6 @@ error.unit_not_allowed=Vous n'êtes pas autorisé à accéder à cette section d
 title=Paquets
 desc=Gérer les paquets du dépôt.
 empty=Il n'y pas de paquet pour le moment.
-empty.documentation=Pour plus d'informations sur le registre de paquets, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">la documentation</a>.
 empty.repo=Avez-vous téléchargé un paquet, mais il n'est pas affiché ici? Allez dans les <a href="%[1]s">paramètres du paquet</a> et liez le à ce dépôt.
 filter.type=Type
 filter.type.all=Tous
@@ -3095,71 +3094,55 @@ versions.view_all=Voir tout
 dependency.id=ID
 dependency.version=Version
 cargo.install=Pour installer le paquet en utilisant Cargo, exécutez la commande suivante :
-cargo.documentation=Pour plus d'informations sur le registre Cargo, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/cargo/">la documentation</a>.
 cargo.details.repository_site=Site du dépôt
 cargo.details.documentation_site=Site de documentation
 chef.registry=Configurer ce registre dans votre fichier <code>~/.chef/config.rb</code>:
 chef.install=Pour installer le paquet, exécutez la commande suivante :
-chef.documentation=Pour plus d'informations sur le registre Chef, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/chef/">la documentation</a>.
 composer.registry=Configurez ce registre dans votre fichier <code>~/.composer/config.json</code> :
 composer.install=Pour installer le paquet en utilisant Composer, exécutez la commande suivante :
-composer.documentation=Pour plus d'informations sur le registre Composer voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/composer/">la documentation</a>.
 composer.dependencies=Dépendances
 composer.dependencies.development=Dépendances de développement
 conan.details.repository=Dépôt
 conan.registry=Configurez ce registre à partir d'un terminal :
 conan.install=Pour installer le paquet en utilisant Conan, exécutez la commande suivante :
-conan.documentation=Pour plus d'informations sur le registre Conan, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/conan/">la documentation</a>.
-conda.documentation=Pour plus d'informations sur le registre Conda, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/conda/">la documentation</a>.
 conda.details.repository_site=Site du dépôt
 conda.details.documentation_site=Site de documentation
 container.details.type=Type d'image
 container.details.platform=Plateforme
 container.pull=Tirez l'image depuis un terminal :
 container.digest=Empreinte :
-container.documentation=Pour plus d'informations sur le registre Container, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/container/">la documentation</a>.
 container.multi_arch=SE / Arch
 container.layers=Calques d'image
 container.labels=Étiquettes
 container.labels.key=Clé
 container.labels.value=Valeur
 generic.download=Télécharger le paquet depuis un terminal :
-generic.documentation=Pour plus d'informations sur le registre générique, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/generic/">la documentation</a>.
 helm.registry=Configurer ce registre à partir d'un terminal :
 helm.install=Pour installer le paquet, exécutez la commande suivante :
-helm.documentation=Pour plus d'informations sur le registre Helm, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/helm/">la documentation</a>.
 maven.install2=Exécuter dans un terminal :
-maven.documentation=Pour plus d'informations sur le registre Maven, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/maven/">la documentation</a>.
 nuget.registry=Configurer ce registre à partir d'un terminal :
-nuget.documentation=Pour plus d'informations sur le registre NuGet, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/nuget/">la documentation</a>.
 nuget.dependency.framework=Cadriciel cible
 npm.registry=Configurez ce registre dans le fichier <code>.npmrc</code> de votre projet :
 npm.install=Pour installer le paquet en utilisant npm, exécutez la commande suivante :
 npm.install2=ou ajoutez-le au fichier package.json :
-npm.documentation=Pour plus d'informations sur le registre npm, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/npm/">la documentation</a>.
 npm.dependencies=Dépendances
 npm.dependencies.development=Dépendances de développement
 npm.dependencies.peer=Dépendances de pairs
 npm.dependencies.optional=Dépendances optionnelles
 npm.details.tag=Balise
 pub.install=Pour installer le paquet en utilisant Dart, exécutez la commande suivante :
-pub.documentation=Pour davantage d'informations sur le registre Pub, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/pub/">la documentation</a>.
 pypi.requires=Nécessite Python
 pypi.install=Pour installer le paquet en utilisant pip, exécutez la commande suivante :
-pypi.documentation=Pour plus d'informations sur le registre PyPI, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/pypi/">la documentation</a>.
 rubygems.install=Pour installer le paquet en utilisant gem, exécutez la commande suivante :
 rubygems.install2=ou ajoutez-le au Gemfile :
 rubygems.dependencies.runtime=Dépendances d'exécution
 rubygems.dependencies.development=Dépendances de développement
 rubygems.required.ruby=Nécessite la version de Ruby
 rubygems.required.rubygems=Nécessite la version de RubyGem
-rubygems.documentation=Pour plus d'informations sur le registre RubyGems, consulter <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/rubygems/">la documentation</a>.
 swift.registry=Configurez ce registre à partir d'un terminal :
 swift.install=Ajoutez le paquet dans votre fichier <code>Package.swift</code>:
 swift.install2=et exécutez la commande suivante :
-swift.documentation=Pour plus d'informations sur le registre Swift, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/swift/">la documentation</a>.
 vagrant.install=Pour ajouter une machine Vagrant, exécutez la commande suivante :
-vagrant.documentation=Pour plus d'informations sur le registre Vagrant, voir <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/vagrant/">la documentation</a>.
 settings.link=Lier ce paquet à un dépôt
 settings.link.description=Si vous liez un paquet à dépôt, le paquet sera inclus dans sa liste des paquets.
 settings.link.select=Sélectionner un dépôt

--- a/options/locale/locale_is-IS.ini
+++ b/options/locale/locale_is-IS.ini
@@ -1224,22 +1224,13 @@ versions=Útgáfur
 versions.view_all=Sjá allar
 dependency.id=Auðkenni
 dependency.version=Útgáfa
-composer.documentation=Frekari upplýsingar um Composer skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">hér</a>.
 conan.details.repository=Hugbúnaðarsafn
-conan.documentation=Frekari upplýsingar um Conan skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">hér</a>.
 container.details.platform=Vettvangur
-container.documentation=Frekari upplýsingar um Container skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">hér</a>.
 container.labels=Lýsingar
 container.labels.key=Lykill
 container.labels.value=Gildi
-generic.documentation=Frekari upplýsingar um almennu skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">hér</a>.
-maven.documentation=Frekari upplýsingar um Maven skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">hér</a>.
-nuget.documentation=Frekari upplýsingar um NuGet skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">hér</a>.
-npm.documentation=Frekari upplýsingar um npm skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">hér</a>.
 npm.details.tag=Merki
 pypi.requires=Þarfnast Python
-pypi.documentation=Frekari upplýsingar um PyPI skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">hér</a>.
-rubygems.documentation=Frekari upplýsingar um RubyGems skrána er hægt að finna <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">hér</a>.
 alpine.repository.branches=Greinar
 alpine.repository.repositories=Hugbúnaðarsöfn
 

--- a/options/locale/locale_it-IT.ini
+++ b/options/locale/locale_it-IT.ini
@@ -2844,57 +2844,46 @@ dependency.version=Versione
 chef.install=Per installare il pacchetto, eseguire il seguente comando:
 composer.registry=Imposta questo registro nel tuo file <code>~/.composer/config.json</code>:
 composer.install=Per installare il pacchetto utilizzando Composer, eseguire il seguente comando:
-composer.documentation=Per ulteriori informazioni sul registro dei compositori, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">la documentazione</a>.
 composer.dependencies=Dipendenze
 composer.dependencies.development=Dipendenze Di Sviluppo
 conan.details.repository=Repository
 conan.registry=Configura questo registro dalla riga di comando:
 conan.install=Per installare il pacchetto usando Conan, eseguire il seguente comando:
-conan.documentation=Per ulteriori informazioni sul registro di Conan, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">la documentazione</a>.
 container.details.type=Tipo Immagine
 container.details.platform=Piattaforma
 container.pull=Tirare l'immagine dalla riga di comando:
-container.documentation=Per ulteriori informazioni sul registro Container, vedere <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">la documentazione</a>.
 container.multi_arch=OS / Arch
 container.layers=Livelli Immagine
 container.labels=Etichette
 container.labels.key=Chiave
 container.labels.value=Valore
 generic.download=Scarica il pacchetto dalla riga di comando:
-generic.documentation=Per ulteriori informazioni sul registro generico, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">la documentazione</a>.
 helm.registry=Configura questo registro dalla riga di comando:
 helm.install=Per installare il pacchetto, eseguire il seguente comando:
-helm.documentation=Per ulteriori informazioni sul registro Helm, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">la documentazione</a>.
 maven.registry=Configura questo registro nel file <code>pom.xml</code> del tuo progetto:
 maven.install=Per utilizzare il pacchetto includere i seguenti nel blocco <code>dipendenze</code> nel file <code>pom.xml</code>:
 maven.install2=Esegui tramite riga di comando:
 maven.download=Per scaricare la dipendenza, eseguire tramite riga di comando:
-maven.documentation=Per ulteriori informazioni sul registro Maven, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">la documentazione</a>.
 nuget.registry=Configura questo registro dalla riga di comando:
 nuget.install=Per installare il pacchetto utilizzando NuGet, eseguire il seguente comando:
-nuget.documentation=Per ulteriori informazioni sul registro di NuGest, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">la documentazione</a>.
 nuget.dependency.framework=Target Framework
 npm.registry=Impostare questo registro nel file del progetto <code>.npmrc</code>:
 npm.install=Per installare il pacchetto usando npm, eseguire il seguente comando:
 npm.install2=o aggiungerlo al file package.json:
-npm.documentation=Per ulteriori informazioni sul registro npm, vedere <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">la documentazione</a>.
 npm.dependencies=Dipendenze
 npm.dependencies.development=Dipendenze Di Sviluppo
 npm.dependencies.peer=Dipendenze Peer
 npm.dependencies.optional=Dipendenze Opzionali
 npm.details.tag=Tag
 pub.install=Per installare il pacchetto utilizzando NuGet, eseguire il seguente comando:
-pub.documentation=Per ulteriori informazioni sul registro Pub, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">la documentazione</a>.
 pypi.requires=Richiede Python
 pypi.install=Per installare il pacchetto usando pip, eseguire il seguente comando:
-pypi.documentation=Per ulteriori informazioni sul registro PyPI, consultare <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">la documentazione</a>.
 rubygems.install=Per installare il pacchetto usando gem, eseguire il seguente comando:
 rubygems.install2=o aggiungerlo al file Gem:
 rubygems.dependencies.runtime=Dipendenze Runtime
 rubygems.dependencies.development=Dipendenze Di Sviluppo
 rubygems.required.ruby=Richiede la versione di Ruby
 rubygems.required.rubygems=Richiede la versione RubyGem
-rubygems.documentation=Per ulteriori informazioni sul registro di RubyGems, vedere <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">la documentazione</a>.
 swift.registry=Configura questo registro dalla riga di comando:
 settings.link=Collega questo pacchetto a un repository
 settings.link.description=Se si collega un pacchetto a un repository, il pacchetto è elencato nell'elenco dei pacchetti del repository.

--- a/options/locale/locale_ja-JP.ini
+++ b/options/locale/locale_ja-JP.ini
@@ -3148,7 +3148,6 @@ error.unit_not_allowed=このセクションへのアクセスが許可されて
 title=パッケージ
 desc=リポジトリ パッケージを管理します。
 empty=パッケージはまだありません。
-empty.documentation=パッケージレジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">ドキュメント</a> を参照してください。
 empty.repo=パッケージはアップロードしたけども、ここに表示されない？ <a href="%[1]s">パッケージ設定</a>を開いて、パッケージをこのリポジトリにリンクしてください。
 filter.type=タイプ
 filter.type.all=すべて
@@ -3175,77 +3174,61 @@ dependency.id=ID
 dependency.version=バージョン
 cargo.registry=Cargo 設定ファイルでこのレジストリをセットアップします。(例 <code>~/.cargo/config.toml</code>):
 cargo.install=Cargo を使用してパッケージをインストールするには、次のコマンドを実行します:
-cargo.documentation=Cargoレジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">ドキュメント</a> を参照してください。
 cargo.details.repository_site=リポジトリサイト
 cargo.details.documentation_site=ドキュメンテーションサイト
 chef.registry=あなたの <code>~/.chef/config.rb</code> ファイルに、このレジストリをセットアップします:
 chef.install=パッケージをインストールするには、次のコマンドを実行します:
-chef.documentation=Chefレジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">ドキュメント</a> を参照してください。
 composer.registry=あなたの <code>~/.composer/config.json</code> ファイルに、このレジストリをセットアップします:
 composer.install=Composer を使用してパッケージをインストールするには、次のコマンドを実行します:
-composer.documentation=Composer レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">ドキュメント</a> を参照してください。
 composer.dependencies=依存関係
 composer.dependencies.development=開発用依存関係
 conan.details.repository=リポジトリ
 conan.registry=このレジストリをコマンドラインからセットアップします:
 conan.install=Conan を使用してパッケージをインストールするには、次のコマンドを実行します:
-conan.documentation=Conan レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">ドキュメント</a> を参照してください。
 conda.registry=あなたの <code>.condarc</code> ファイルに、このレジストリを Conda リポジトリとしてセットアップします:
 conda.install=Conda を使用してパッケージをインストールするには、次のコマンドを実行します:
-conda.documentation=Condaレジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">ドキュメント</a> を参照してください。
 conda.details.repository_site=リポジトリサイト
 conda.details.documentation_site=ドキュメンテーションサイト
 container.details.type=イメージタイプ
 container.details.platform=プラットフォーム
 container.pull=コマンドラインでイメージを取得します:
 container.digest=ダイジェスト:
-container.documentation=Container レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">ドキュメント</a> を参照してください。
 container.multi_arch=OS / アーキテクチャ
 container.layers=イメージレイヤー
 container.labels=ラベル
 container.labels.key=キー
 container.labels.value=値
 generic.download=コマンドラインでパッケージをダウンロードします:
-generic.documentation=汎用 レジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">ドキュメント</a> を参照してください。
 helm.registry=このレジストリをコマンドラインからセットアップします:
 helm.install=パッケージをインストールするには、次のコマンドを実行します:
-helm.documentation=Helm レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">ドキュメント</a> を参照してください。
 maven.registry=あなたのプロジェクトの <code>pom.xml</code> ファイルに、このレジストリをセットアップします:
 maven.install=パッケージを使用するため <code>pom.xml</code> ファイル内の <code>dependencies</code> ブロックに以下を含めます:
 maven.install2=コマンドラインで実行します:
 maven.download=依存関係をダウンロードするには、コマンドラインでこれを実行します:
-maven.documentation=Mavenレジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">ドキュメント</a> を参照してください。
 nuget.registry=このレジストリをコマンドラインからセットアップします:
 nuget.install=NuGet を使用してパッケージをインストールするには、次のコマンドを実行します:
-nuget.documentation=NuGetレジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">ドキュメント</a> を参照してください。
 nuget.dependency.framework=ターゲットフレームワーク
 npm.registry=あなたのプロジェクトの <code>.npmrc</code> ファイルに、このレジストリをセットアップします:
 npm.install=npm を使用してパッケージをインストールするには、次のコマンドを実行します:
 npm.install2=または package.json ファイルに追加します:
-npm.documentation=Npm レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">ドキュメント</a> を参照してください。
 npm.dependencies=依存関係
 npm.dependencies.development=開発用依存関係
 npm.dependencies.peer=Peer依存関係
 npm.dependencies.optional=オプションの依存関係
 npm.details.tag=タグ
 pub.install=Dart を使用してパッケージをインストールするには、次のコマンドを実行します:
-pub.documentation=Pub レジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">ドキュメント</a> を参照してください。
 pypi.requires=必要なPython
 pypi.install=pip を使用してパッケージをインストールするには、次のコマンドを実行します:
-pypi.documentation=PyPI レジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">ドキュメント</a> を参照してください。
 rubygems.install=gem を使用してパッケージをインストールするには、次のコマンドを実行します:
 rubygems.install2=または Gemfile に追加します:
 rubygems.dependencies.runtime=実行用依存関係
 rubygems.dependencies.development=開発用依存関係
 rubygems.required.ruby=必要なRubyバージョン
 rubygems.required.rubygems=必要なRubyGemバージョン
-rubygems.documentation=RubyGemsレジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">ドキュメント</a> を参照してください。
 swift.registry=このレジストリをコマンドラインからセットアップします:
 swift.install=あなたの <code>Package.swift</code> ファイルにパッケージを追加します:
 swift.install2=そして次のコマンドを実行します:
-swift.documentation=Swift レジストリの詳細については、 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">ドキュメント</a> を参照してください。
 vagrant.install=Vagrant ボックスを追加するには、次のコマンドを実行します。
-vagrant.documentation=Vagrantレジストリの詳細については <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">ドキュメント</a>を参照してください。
 settings.link=このパッケージをリポジトリにリンク
 settings.link.description=パッケージをリポジトリにリンクすると、リポジトリのパッケージリストに表示されるようになります。
 settings.link.select=リポジトリを選択
@@ -3300,7 +3283,6 @@ alpine.repository.repositories=Repositories
 alpine.repository.architectures=Architectures
 cran.registry=あなたの <code>Rprofile.site</code> ファイルに、このレジストリをセットアップします:
 cran.install=パッケージをインストールするには、次のコマンドを実行します:
-cran.documentation=CRAN レジストリの詳細については、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cran/">ドキュメント</a> を参照してください。
 debian.registry=このレジストリをコマンドラインからセットアップします:
 debian.registry.info=$distribution と $component は下にあるリストから選んでください。
 debian.install=パッケージをインストールするには、次のコマンドを実行します:

--- a/options/locale/locale_lv-LV.ini
+++ b/options/locale/locale_lv-LV.ini
@@ -2948,74 +2948,59 @@ dependency.id=ID
 dependency.version=Versija
 cargo.registry=Uzstādiet šo reģistru Cargo konfigurācijas failā, piemēram, <code>~/.cargo/config.toml</code>:
 cargo.install=Lai instalētu Cargo pakotni, izpildiet sekojošu komandu:
-cargo.documentation=Papildus informācija par Cargo reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">dokumentācijā</a>.
 cargo.details.repository_site=Repozitorija lapa
 cargo.details.documentation_site=Dokumentācijas lapa
 chef.registry=Uzstādiet šo reģistru failā <code>~/.chef/config.rb</code>:
 chef.install=Lai instalētu pakotni, nepieciešams izpildīt sekojošu komandu:
-chef.documentation=Papildus informācija par Chef reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">dokumentācijā</a>.
 composer.registry=Pievienojiet šo reģistru savā <code>~/.composer/config.json</code> failā:
 composer.install=Lai instalētu Composer pakotni, izpildiet sekojošu komandu:
-composer.documentation=Papildus informācija par Composer reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">dokumentācijā</a>.
 composer.dependencies=Atkarības
 composer.dependencies.development=Izstrādes atkarības
 conan.details.repository=Repozitorijs
 conan.registry=Konfigurējiet šo reģistru no komandrindas:
 conan.install=Lai instalētu Conan pakotni, izpildiet sekojošu komandu:
-conan.documentation=Papildus informācija par Conan reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">dokumentācijā</a>.
 conda.registry=Uzstādiet šo reģistru kā Conda repozitoriju failā <code>.condarc</code>:
 conda.install=Lai instalētu Conda pakotni, izpildiet sekojošu komandu:
-conda.documentation=Papildus informācija par Conda reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">dokumentācijā</a>.
 conda.details.repository_site=Repozitorija lapa
 conda.details.documentation_site=Dokumentācijas lapa
 container.details.type=Attēla formāts
 container.details.platform=Platforma
 container.pull=Atgādājiet šo attēlu no komandrindas:
 container.digest=Īssavilkums:
-container.documentation=Papildus informācija par konteineru reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">dokumentācijā</a>.
 container.multi_arch=OS / arhitektūra
 container.layers=Attēla slāņi
 container.labels=Etiķetes
 container.labels.key=Atslēga
 container.labels.value=Vērtība
 generic.download=Lejupielādēt pakotni, izmantojot, komandrindu:
-generic.documentation=Papildus informācija par ģenerisku pakotņu reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">dokumentācijā</a>.
 helm.registry=Konfigurējiet šo reģistru no komandrindas:
 helm.install=Lai instalētu pakotni, nepieciešams izpildīt sekojošu komandu:
-helm.documentation=Papildus informācija par Helm reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">dokumentācijā</a>.
 maven.registry=Konfigurējiet šo reģistru sava projekta <code>pom.xml</code> failā:
 maven.install=Lai izmantotu pakotni, sadaļā <code>dependencies</code> failā <code>pom.xml</code> ievietojiet sekojošas rindas:
 maven.install2=Izpildiet no komandrindas:
 maven.download=Izpildiet no komandrindas, lai lejupielādētu šo atkarību:
-maven.documentation=Papildus informācija par Maven reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">dokumentācijā</a>.
 nuget.registry=Konfigurējiet šo reģistru no komandrindas:
 nuget.install=Lai instalētu NuGet pakotni, izpildiet sekojošu komandu:
-nuget.documentation=Papildus informācija par NuGet reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">dokumentācijā</a>.
 nuget.dependency.framework=Mērķa ietvars
 npm.registry=Konfigurējiet šo reģistru sava projekta <code>.npmrc</code> failā:
 npm.install=Lai instalētu npm pakotni, izpildiet sekojošu komandu:
 npm.install2=vai pievienojiet failā package.json sekojošas rindas:
-npm.documentation=Papildus informācija par npm reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">dokumentācijā</a>.
 npm.dependencies=Atkarības
 npm.dependencies.development=Izstrādes atkarības
 npm.dependencies.peer=Netiešās atkarības
 npm.dependencies.optional=Neobligātās atkarības
 npm.details.tag=Tags
 pub.install=Lai instalētu Dart pakotni, izpildiet sekojošu komandu:
-pub.documentation=Papildus informācija par Pub reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">dokumentācijā</a>.
 pypi.requires=Nepieciešams Python
 pypi.install=Lai instalētu pip pakotni, izpildiet sekojošu komandu:
-pypi.documentation=Papildus informācija par PyPI reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">dokumentācijā</a>.
 rubygems.install=Lai instalētu gem pakotni, izpildiet sekojošu komandu:
 rubygems.install2=vai pievienojiet Gemfile:
 rubygems.dependencies.runtime=Izpildlaika atkarības
 rubygems.dependencies.development=Izstrādes atkarības
 rubygems.required.ruby=Nepieciešamā Ruby versija
 rubygems.required.rubygems=Nepieciešamā RubyGem versija
-rubygems.documentation=Papildus informācija par RubyGems reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">dokumentācijā</a>.
 swift.registry=Konfigurējiet šo reģistru no komandrindas:
 vagrant.install=Lai pievienotu Vagrant kasti, izpildiet sekojošu komandu:
-vagrant.documentation=Papildus informācija par Vagrant reģistru pieejama <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">dokumentācijā</a>.
 settings.link=Piesaistīt pakotni šim repozitorijam
 settings.link.description=Sasaistot pakotni ar repozitoriju, tā tiks attēlota repozitorija pakotņu sarakstā.
 settings.link.select=Norādiet repozitoriju

--- a/options/locale/locale_pt-BR.ini
+++ b/options/locale/locale_pt-BR.ini
@@ -3092,77 +3092,61 @@ dependency.id=ID
 dependency.version=Versão
 cargo.registry=Configurar este registro no arquivo de configuração de Cargo (por exemplo <code>~/.cargo/config.toml</code>):
 cargo.install=Para instalar o pacote usando Cargo, execute o seguinte comando:
-cargo.documentation=Para obter mais informações sobre o registro Cargo, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">a documentação</a>.
 cargo.details.repository_site=Site do Repositório
 cargo.details.documentation_site=Site da Documentação
 chef.registry=Configure este registro em seu arquivo <code>~/.chef/config.rb</code>:
 chef.install=Para instalar o pacote, execute o seguinte comando:
-chef.documentation=Para obter mais informações sobre o registro Chef, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">a documentação</a>.
 composer.registry=Configure este registro em seu arquivo <code>~/.composer/config.json</code>:
 composer.install=Para instalar o pacote usando o Composer, execute o seguinte comando:
-composer.documentation=Para obter mais informações sobre o registro do Composer, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">a documentação</a>.
 composer.dependencies=Dependências
 composer.dependencies.development=Dependências de Desenvolvimento
 conan.details.repository=Repositório
 conan.registry=Configure este registro pela linha de comando:
 conan.install=Para instalar o pacote usando o Conan, execute o seguinte comando:
-conan.documentation=Para obter mais informações sobre o registro Conan, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">a documentação</a>.
 conda.registry=Configure este registro como um repositório Conda no arquivo <code>.condarc</code>:
 conda.install=Para instalar o pacote usando o Conda, execute o seguinte comando:
-conda.documentation=Para obter mais informações sobre o registro Conda, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">a documentação</a>.
 conda.details.repository_site=Site do Repositório
 conda.details.documentation_site=Site da Documentação
 container.details.type=Tipo de Imagem
 container.details.platform=Plataforma
 container.pull=Puxe a imagem pela linha de comando:
 container.digest=Digest:
-container.documentation=Para obter mais informações sobre o registro de Container, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">a documentação</a>.
 container.multi_arch=S.O. / Arquitetura
 container.layers=Camadas da Imagem
 container.labels=Rótulos
 container.labels.key=Chave
 container.labels.value=Valor
 generic.download=Baixar pacote pela linha de comando:
-generic.documentation=Para obter mais informações sobre o registro genérico, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">a documentação</a>.
 helm.registry=Configurar este registro pela linha de comando:
 helm.install=Para instalar o pacote, execute o seguinte comando:
-helm.documentation=Para obter mais informações sobre o registro Helm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">a documentação</a>.
 maven.registry=Configure este registro no arquivo <code>pom.xml</code> do seu projeto:
 maven.install=Para usar o pacote inclua o seguinte no bloco de <code>dependencies</code> no arquivo <code>pom.xml</code>:
 maven.install2=Executar via linha de comando:
 maven.download=Para baixar a dependência, execute via linha de comando:
-maven.documentation=Para obter mais informações sobre o registro Maven, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">a documentação</a>.
 nuget.registry=Configurar este registro pela linha de comando:
 nuget.install=Para instalar o pacote usando NuGet, execute o seguinte comando:
-nuget.documentation=Para obter mais informações sobre o registro Nuget, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">a documentação</a>.
 nuget.dependency.framework=Estrutura Alvo
 npm.registry=Configure este registro no arquivo <code>.npmrc</code> do seu projeto:
 npm.install=Para instalar o pacote usando o npm, execute o seguinte comando:
 npm.install2=ou adicione-o ao arquivo package.json:
-npm.documentation=Para obter mais informações sobre o registro npm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">a documentação</a>.
 npm.dependencies=Dependências
 npm.dependencies.development=Dependências de Desenvolvimento
 npm.dependencies.peer=Dependências Peer
 npm.dependencies.optional=Dependências Opcionais
 npm.details.tag=Tag
 pub.install=Para instalar o pacote usando Dart, execute o seguinte comando:
-pub.documentation=Para obter mais informações sobre o registro Pub, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">a documentação</a>.
 pypi.requires=Requer Python
 pypi.install=Para instalar o pacote usando pip, execute o seguinte comando:
-pypi.documentation=Para obter mais informações sobre o registro PyPI, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">a documentação</a>.
 rubygems.install=Para instalar o pacote usando gem, execute o seguinte comando:
 rubygems.install2=ou adicione-o ao Gemfile:
 rubygems.dependencies.runtime=Dependências de Execução
 rubygems.dependencies.development=Dependências de Desenvolvimento
 rubygems.required.ruby=Requer o Ruby versão
 rubygems.required.rubygems=Requer o RubyGem versão
-rubygems.documentation=Para obter mais informações sobre o registro do RubyGems, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">a documentação</a>.
 swift.registry=Configure este registro pela linha de comando:
 swift.install=Adicione o pacote em seu arquivo <code>Package.swift</code>:
 swift.install2=e execute o seguinte comando:
-swift.documentation=Para obter mais informações sobre o registro Swift, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">a documentação</a>.
 vagrant.install=Para adicionar uma Vagrant box, execute o seguinte comando:
-vagrant.documentation=Para obter mais informações sobre o registro do Vagrant, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">a documentação</a>.
 settings.link=Vincular este pacote a um repositório
 settings.link.description=Se você vincular um pacote a um repositório, o pacote será listado na lista de pacotes do repositório.
 settings.link.select=Selecionar Repositório

--- a/options/locale/locale_pt-PT.ini
+++ b/options/locale/locale_pt-PT.ini
@@ -3148,7 +3148,6 @@ error.unit_not_allowed=Não tem permissão para aceder a esta parte do repositó
 title=Pacotes
 desc=Gerir pacotes do repositório.
 empty=Ainda não há pacotes.
-empty.documentation=Para obter mais informação sobre o registo de pacotes, veja <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">a documentação</a>.
 empty.repo=Carregou um pacote mas este não é apresentado aqui? Vá às <a href="%[1]s">configurações do pacote</a> e ligue-o a este repositório.
 filter.type=Tipo
 filter.type.all=Todos
@@ -3175,77 +3174,61 @@ dependency.id=ID
 dependency.version=Versão
 cargo.registry=Configurar este registo no ficheiro de configuração do Cargo (por exemplo: <code>~/.cargo/config.toml</code>):
 cargo.install=Para instalar o pacote usando o Cargo, execute o seguinte comando:
-cargo.documentation=Para obter mais informações sobre o registo do Cargo, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">a documentação</a>.
 cargo.details.repository_site=Página web do repositório
 cargo.details.documentation_site=Página web da documentação
 chef.registry=Configure este registo no seu ficheiro <code>~/.chef/config.rb</code>:
 chef.install=Para instalar o pacote, execute o seguinte comando:
-chef.documentation=Para obter mais informações sobre o registo do Chef, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">a documentação</a>.
 composer.registry=Configure este registo no seu ficheiro <code>~/.composer/config.json</code>:
 composer.install=Para instalar o pacote usando o Composer, execute o seguinte comando:
-composer.documentation=Para obter mais informações sobre o registo do Composer, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">a documentação</a>.
 composer.dependencies=Dependências
 composer.dependencies.development=Dependências de desenvolvimento
 conan.details.repository=Repositório
 conan.registry=Configurar este registo usando a linha de comandos:
 conan.install=Para instalar o pacote usando o Conan, execute o seguinte comando:
-conan.documentation=Para obter mais informações sobre o registo do Conan, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">a documentação</a>.
 conda.registry=Configure este registo como um repositório Conda no seu ficheiro <code>.condarc</code>:
 conda.install=Para instalar o pacote usando o Conda, execute o seguinte comando:
-conda.documentation=Para obter mais informações sobre o registo do Conda, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">a documentação</a>.
 conda.details.repository_site=Página web do repositório
 conda.details.documentation_site=Página web da documentação
 container.details.type=Tipo de imagem
 container.details.platform=Plataforma
 container.pull=Puxar a imagem usando a linha de comandos:
 container.digest=Resumo:
-container.documentation=Para obter mais informações sobre o registo do Container, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">a documentação</a>.
 container.multi_arch=S.O. / Arquit.
 container.layers=Camadas de imagem
 container.labels=Rótulos
 container.labels.key=Chave
 container.labels.value=Valor
 generic.download=Descarregar pacote usando a linha de comandos:
-generic.documentation=Para obter mais informações sobre o registo genérico, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">a documentação</a>.
 helm.registry=Configurar este registo usando a linha de comandos:
 helm.install=Para instalar o pacote, execute o seguinte comando:
-helm.documentation=Para obter mais informações sobre o registo do Helm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">a documentação</a>.
 maven.registry=Configure este registo no seu ficheiro <code>pom.xml</code> do projecto:
 maven.install=Para usar este pacote, inclua no bloco <code>dependencies</code> do ficheiro <code>pom.xml</code> o seguinte:
 maven.install2=Executar usando a linha de comandos:
 maven.download=Para descarregar a dependência, execute na linha de comandos:
-maven.documentation=Para obter mais informações sobre o registo do Maven, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">a documentação</a>.
 nuget.registry=Configurar este registo usando a linha de comandos:
 nuget.install=Para instalar o pacote usando NuGet, execute o seguinte comando:
-nuget.documentation=Para obter mais informações sobre o registo do Nuget, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">a documentação</a>.
 nuget.dependency.framework=Estrutura alvo
 npm.registry=Configure este registo no seu ficheiro <code>.npmrc</code> do projecto:
 npm.install=Para instalar o pacote usando o npm, execute o seguinte comando:
 npm.install2=ou adicione-o ao ficheiro <code>package.json</code>:
-npm.documentation=Para obter mais informações sobre o registo do npm, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">a documentação</a>.
 npm.dependencies=Dependências
 npm.dependencies.development=Dependências de desenvolvimento
 npm.dependencies.peer=Dependências de pares
 npm.dependencies.optional=Dependências opcionais
 npm.details.tag=Etiqueta
 pub.install=Para instalar o pacote usando o Dart, execute o seguinte comando:
-pub.documentation=Para obter mais informações sobre o registo Pub, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">a documentação</a>.
 pypi.requires=Requer Python
 pypi.install=Para instalar o pacote usando o pip, execute o seguinte comando:
-pypi.documentation=Para obter mais informações sobre o registo do PyPI, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">a documentação</a>.
 rubygems.install=Para instalar o pacote usando o gem, execute o seguinte comando:
 rubygems.install2=ou adicione-o ao ficheiro <code>Gemfile</code>:
 rubygems.dependencies.runtime=Dependências do tempo de execução (runtime)
 rubygems.dependencies.development=Dependências de desenvolvimento
 rubygems.required.ruby=Requer a versão do Ruby
 rubygems.required.rubygems=Requer a versão do RubyGem
-rubygems.documentation=Para obter mais informações sobre o registo do RubyGems, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">a documentação</a>.
 swift.registry=Configurar este registo usando a linha de comandos:
 swift.install=Adicione o pacote no seu ficheiro <code>Package.swift</code>:
 swift.install2=e execute o seguinte comando:
-swift.documentation=Para obter mais informações sobre o registo do Swift, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">a documentação</a>.
 vagrant.install=Para adicionar uma máquina virtual Vagrant, execute o seguinte comando:
-vagrant.documentation=Para obter mais informações sobre o registo do Vagrant, consulte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">a documentação</a>.
 settings.link=Vincular este pacote a um repositório
 settings.link.description=Se você vincular um pacote a um repositório, o pacote será listado na lista de pacotes do repositório.
 settings.link.select=Escolha o repositório
@@ -3300,7 +3283,6 @@ alpine.repository.repositories=Repositórios
 alpine.repository.architectures=Arquitecturas
 cran.registry=Configure este registo no seu ficheiro <code>Rprofile.site</code>:
 cran.install=Para instalar o pacote, execute o seguinte comando:
-cran.documentation=Para mais informação sobre o registo CRAN, veja <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cran/">a documentação</a>.
 debian.registry=Configurar este registo usando a linha de comandos:
 debian.registry.info=Escolha $distribution e $component da lista abaixo.
 debian.install=Para instalar o pacote, execute o seguinte comando:

--- a/options/locale/locale_ru-RU.ini
+++ b/options/locale/locale_ru-RU.ini
@@ -3288,7 +3288,6 @@ alpine.repository.repositories=Репозитории
 alpine.repository.architectures=Архитектуры
 cran.registry=Настройте этот реестр в файле <code>Rprofile.site</code>:
 cran.install=Чтобы установить пакет, выполните следующую команду:
-cran.documentation=Для получения дополнительной информации о реестре CRAN смотрите <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cran/">документацию</a>.
 debian.registry=Настроить реестр из командной строки:
 debian.registry.info=Выберите $distribution и $component из списка ниже.
 debian.install=Чтобы установить пакет, выполните следующую команду:

--- a/options/locale/locale_tr-TR.ini
+++ b/options/locale/locale_tr-TR.ini
@@ -3073,7 +3073,6 @@ error.unit_not_allowed=Bu depo bölümüne erişme izniniz yok.
 title=Paketler
 desc=Depo paketlerini yönet.
 empty=Henüz hiçbir paket yok.
-empty.documentation=Paket kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">belgeye</a> bakabilirsiniz.
 empty.repo=Bir paket yüklediniz ama burada gösterilmiyor mu? <a href="%[1]s">Paket ayarları</a>na gidin ve bu depoya bağlantı verin.
 filter.type=Tür
 filter.type.all=Tümü
@@ -3100,77 +3099,61 @@ dependency.id=Kimlik
 dependency.version=Sürüm
 cargo.registry=Bu kütüğü Cargo yapılandırma dosyasına (örneğin <code>~/.cargo/config.toml</code>) ayarlayın:
 cargo.install=Paketi Cargo kullanarak kurmak için, şu komutu çalıştırın:
-cargo.documentation=Cargo kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">belgeye</a> bakabilirsiniz.
 cargo.details.repository_site=Depo Sitesi
 cargo.details.documentation_site=Belge Sitesi
 chef.registry=Bu kütüğü <code>~/.chef/config.rb</code> dosyasında ayarlayın:
 chef.install=Paketi kurmak için, aşağıdaki komutu çalıştırın:
-chef.documentation=Chef kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">belgeye</a> bakabilirsiniz.
 composer.registry=Bu kütüğü <code>~/.composer/config.json</code> dosyasında ayarlayın:
 composer.install=Paketi Composer ile kurmak için, şu komutu çalıştırın:
-composer.documentation=Composer kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">belgeye</a> bakabilirsiniz.
 composer.dependencies=Bağımlılıklar
 composer.dependencies.development=Geliştirme Bağımlılıkları
 conan.details.repository=Depo
 conan.registry=Bu kütüğü komut satırını kullanarak kurun:
 conan.install=Conan ile paket kurmak için aşağıdaki komutu çalıştırın:
-conan.documentation=Conan kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">belgeye</a> bakabilirsiniz.
 conda.registry=Bu kütüğü <code>.condarc</code> dosyasında bir Conda deposu olarak ayarlayın:
 conda.install=Conda ile paket kurmak için aşağıdaki komutu çalıştırın:
-conda.documentation=Conda kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">belgeye</a> bakabilirsiniz.
 conda.details.repository_site=Depo Sitesi
 conda.details.documentation_site=Belge Sitesi
 container.details.type=Görüntü Türü
 container.details.platform=Platform
 container.pull=Görüntüyü komut satırını kullanarak çekin:
 container.digest=Özet:
-container.documentation=Taşıyıcı kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">belgeye</a> bakabilirsiniz.
 container.multi_arch=İşletim Sistemi / Mimari
 container.layers=Görüntü Katmanları
 container.labels=Etiketler
 container.labels.key=Anahtar
 container.labels.value=Değer
 generic.download=Paketi komut satırında indirin:
-generic.documentation=Genel kütük hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">belgeye</a> bakabilirsiniz.
 helm.registry=Bu kütüğü komut satırını kullanarak kurun:
 helm.install=Paketi kurmak için, aşağıdaki komutu çalıştırın:
-helm.documentation=Helm kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">belgeye</a> bakabilirsiniz.
 maven.registry=Bu kütüğü projenizdeki <code>pom.xml</code> dosyasında ayarlayın:
 maven.install=Paketi kullanmak için aşağıdaki <code>dependencies</code> parçasını <code>pom.xml</code> dosyasınıza ekleyin:
 maven.install2=Komut satırında çalıştırın:
 maven.download=Bağımlılığı indirmek için, komut satırında çalıştırın:
-maven.documentation=Maven kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">belgeye</a> bakabilirsiniz.
 nuget.registry=Bu kütüğü komut satırını kullanarak kurun:
 nuget.install=Paketi NuGet ile kurmak için, şu komutu çalıştırın:
-nuget.documentation=NuGet kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">belgeye</a> bakabilirsiniz.
 nuget.dependency.framework=Hedef Çerçeve
 npm.registry=Bu kütüğü projenizdeki <code>.npmrc</code> dosyasında ayarlayın:
 npm.install=Paketi npm ile kurmak için, şu komutu çalıştırın:
 npm.install2=veya paketi package.json dosyasına ekleyin:
-npm.documentation=Npm kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">belgeye</a> bakabilirsiniz.
 npm.dependencies=Bağımlılıklar
 npm.dependencies.development=Geliştirme Bağımlılıkları
 npm.dependencies.peer=Eş Bağımlılıkları
 npm.dependencies.optional=İsteğe Bağlı Bağımlılıklar
 npm.details.tag=Etiket
 pub.install=Paketi Dart ile kurmak için, şu komutu çalıştırın:
-pub.documentation=Pub kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">belgeye</a> bakabilirsiniz.
 pypi.requires=Gereken Python
 pypi.install=Paketi pip ile kurmak için, şu komutu çalıştırın:
-pypi.documentation=PyPI kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">belgeye</a> bakabilirsiniz.
 rubygems.install=Paketi gem ile kurmak için, şu komutu çalıştırın:
 rubygems.install2=veya paketi Gemfile dosyasına ekleyin:
 rubygems.dependencies.runtime=Çalışma Zamanı Bağımlılıkları
 rubygems.dependencies.development=Geliştirme Bağımlılıkları
 rubygems.required.ruby=Gereken Ruby sürümü
 rubygems.required.rubygems=Gereken RubyGem sürümü
-rubygems.documentation=RubyGems kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">belgeye</a> bakabilirsiniz.
 swift.registry=Bu kütüğü komut satırını kullanarak kurun:
 swift.install=Paketi <code>Package.swift</code> dosyanıza ekleyin:
 swift.install2=ve şu komutu çalıştırın:
-swift.documentation=Swift kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">belgeye</a> bakabilirsiniz.
 vagrant.install=Vagrant paketi eklemek için aşağıdaki komutu çalıştırın:
-vagrant.documentation=Vagrant kütüğü hakkında daha fazla bilgi için, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">belgeye</a> bakabilirsiniz.
 settings.link=Bu paketi bir depoya bağlayın
 settings.link.description=Eğer bir paketi bir depoya bağlarsanız, paket deponun paket listesinde listelenecektir.
 settings.link.select=Depo Seç

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -3076,7 +3076,6 @@ error.unit_not_allowed=您没有权限访问此仓库单元
 title=软件包
 desc=管理仓库软件包。
 empty=还没有软件包。
-empty.documentation=关于软件包注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/overview"> 文档 </a>。
 empty.repo=您上传了一个包，但没有显示在这里吗？转到 <a href="%[1]s">包设置</a> 并将其链接到这个仓库中。
 filter.type=类型
 filter.type.all=所有
@@ -3103,77 +3102,61 @@ dependency.id=ID
 dependency.version=版本
 cargo.registry=在 Cargo 配置文件中设置此注册中心(例如：<code>~/.cargo/config.toml</code>)：
 cargo.install=要使用 Cargo 安装软件包，请运行以下命令：
-cargo.documentation=关于 Cargo 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">文档</a>。
 cargo.details.repository_site=仓库站点
 cargo.details.documentation_site=文档站点
 chef.registry=在您的 <code>~/.chef/config.rb</code> 文件中设置此注册中心：
 chef.install=要安装包，请运行以下命令：
-chef.documentation=关于 Chef 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">文档</a>。
 composer.registry=在您的 <code>~/.composer/config.json</code> 文件中设置此注册中心：
 composer.install=要使用 Composer 安装软件包，请运行以下命令：
-composer.documentation=关于 Composer 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/"> 文档 </a>。
 composer.dependencies=依赖
 composer.dependencies.development=开发依赖
 conan.details.repository=仓库
 conan.registry=从命令行设置此注册中心：
 conan.install=要使用 Conan 安装软件包，请运行以下命令：
-conan.documentation=关于 Conan 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">文档</a>。
 conda.registry=在您的 <code>.condarc</code> 文件中将此注册中心设置为 Conda 仓库：
 conda.install=要使用 Conda 安装软件包，请运行以下命令：
-conda.documentation=关于 Conda 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">文档</a>。
 conda.details.repository_site=仓库站点
 conda.details.documentation_site=文档站点
 container.details.type=镜像类型
 container.details.platform=平台
 container.pull=从命令行拉取镜像：
 container.digest=摘要：
-container.documentation=关于 Container 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">文档</a>。
 container.multi_arch=OS / Arch
 container.layers=镜像层
 container.labels=标签
 container.labels.key=键
 container.labels.value=值
 generic.download=从命令行下载软件包：
-generic.documentation=关于通用注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">文档</a>。
 helm.registry=从命令行设置此注册中心：
 helm.install=要安装包，请运行以下命令：
-helm.documentation=关于 Helm 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">文档</a>。
 maven.registry=在您项目的 <code>pom.xml</code> 文件中设置此注册中心：
 maven.install=要使用这个软件包，在 <code>pom.xml</code> 文件中的 <code>依赖项</code> 块中包含以下内容：
 maven.install2=通过命令行运行：
 maven.download=要下载依赖项，请通过命令行运行：
-maven.documentation=关于 Maven 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">文档</a>。
 nuget.registry=从命令行设置此注册中心：
 nuget.install=要使用 Nuget 安装软件包，请运行以下命令：
-nuget.documentation=关于 Nuget 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">文档</a>。
 nuget.dependency.framework=目标框架
 npm.registry=在您项目的 <code>.npmrc</code> 文件中设置此注册中心：
 npm.install=要使用 npm 安装软件包，请运行以下命令：
 npm.install2=或将其添加到 package.json 文件：
-npm.documentation=关于 npm 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">文档</a>。
 npm.dependencies=依赖项
 npm.dependencies.development=开发依赖
 npm.dependencies.peer=Peer 依赖
 npm.dependencies.optional=可选依赖
 npm.details.tag=标签
 pub.install=要使用 Dart 安装软件包，请运行以下命令：
-pub.documentation=关于 Pub 注册中心的信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">文档</a>。
 pypi.requires=需要 Python
 pypi.install=要使用 pip 安装软件包，请运行以下命令：
-pypi.documentation=关于 PyPI 注册中心的信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">文档</a>。
 rubygems.install=要使用 gem 安装软件包，请运行以下命令：
 rubygems.install2=或将它添加到 Gemfile：
 rubygems.dependencies.runtime=运行时依赖
 rubygems.dependencies.development=开发依赖
 rubygems.required.ruby=需要 Ruby 版本
 rubygems.required.rubygems=需要 RubyGem 版本
-rubygems.documentation=关于 RubyGems 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">文档</a>。
 swift.registry=从命令行设置此注册中心：
 swift.install=在你的 <code>Package.swift</code>文件中添加该包：
 swift.install2=并运行以下命令：
-swift.documentation=关于 Swift 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">文档</a>。
 vagrant.install=若要添加一个 Vagrant box，请运行以下命令：
-vagrant.documentation=关于 Vagrant 注册中心的更多信息，请参阅 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">文档</a>。
 settings.link=将此软件包链接到仓库
 settings.link.description=如果您将一个软件包与一个代码库链接起来，软件包将显示在代码库的软件包列表中。
 settings.link.select=选择仓库

--- a/options/locale/locale_zh-TW.ini
+++ b/options/locale/locale_zh-TW.ini
@@ -3050,7 +3050,6 @@ error.unit_not_allowed=您未被允許訪問此儲存庫區域
 title=套件
 desc=管理儲存庫套件。
 empty=目前還沒有套件。
-empty.documentation=關於套件註冊中心的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/packages/overview/">說明文件</a>。
 empty.repo=已經上傳了一個套件，但是沒有顯示在這裡嗎？打開<a href="%[1]s">套件設定</a>並將其連結到這個儲存庫。
 filter.type=類型
 filter.type.all=所有
@@ -3077,77 +3076,61 @@ dependency.id=ID
 dependency.version=版本
 cargo.registry=在 Cargo 組態檔設定此註冊中心 (例如: <code>~/.cargo/config.toml</code>):
 cargo.install=執行下列命令以使用 Cargo 安裝此套件:
-cargo.documentation=關於 Cargo registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cargo/">說明文件</a>。
 cargo.details.repository_site=儲存庫網站
 cargo.details.documentation_site=文件網站
 chef.registry=在您的 <code>~/.chef/config.rb</code> 檔設定此註冊中心:
 chef.install=執行下列命令安裝此套件:
-chef.documentation=關於 Chef registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/chef/">說明文件</a>。
 composer.registry=在您的 <code>~/.composer/config.json</code> 檔設定此註冊中心:
 composer.install=執行下列命令以使用 Composer 安裝此套件:
-composer.documentation=關於 Composer registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/composer/">說明文件</a>。
 composer.dependencies=相依性
 composer.dependencies.development=開發相依性
 conan.details.repository=儲存庫
 conan.registry=透過下列命令設定此註冊中心:
 conan.install=執行下列命令以使用 Conan 安裝此套件:
-conan.documentation=關於 Conan registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conan/">說明文件</a>。
 conda.registry=在您的 <code>.condarc</code> 檔設定此註冊中心為 Conda 存儲庫:
 conda.install=執行下列命令以使用 Conda 安裝此套件:
-conda.documentation=關於 Conda registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/conda/">說明文件</a>。
 conda.details.repository_site=儲存庫網站
 conda.details.documentation_site=文件網站
 container.details.type=映像檔類型
 container.details.platform=平台
 container.pull=透過下列命令拉取映像檔:
 container.digest=摘要:
-container.documentation=關於 Container registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/container/">說明文件</a>。
 container.multi_arch=作業系統 / 架構
 container.layers=映像檔 Layers
 container.labels=標籤
 container.labels.key=鍵
 container.labels.value=值
 generic.download=透過下列命令下載套件:
-generic.documentation=關於通用 registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/generic">說明文件</a>。
 helm.registry=透過下列命令設定此註冊中心:
 helm.install=執行下列命令安裝此套件:
-helm.documentation=關於 Helm registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/helm/">說明文件</a>。
 maven.registry=在您專案的 <code>pom.xml</code> 檔設定此註冊中心:
 maven.install=若要使用此套件，請在您 <code>pom.xml</code> 檔的 <code>dependencies</code> 段落加入下列內容:
 maven.install2=透過下列命令執行:
 maven.download=透過下列命令下載相依性:
-maven.documentation=關於 Maven registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/maven/">說明文件</a>。
 nuget.registry=透過下列命令設定此註冊中心:
 nuget.install=執行下列命令以使用 NuGet 安裝此套件:
-nuget.documentation=關於 NuGet registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/nuget/">說明文件</a>。
 nuget.dependency.framework=目標框架
 npm.registry=在您專案的 <code>.npmrc</code> 檔設定此註冊中心:
 npm.install=執行下列命令以使用 npm 安裝此套件:
 npm.install2=或將它加到 package.json 檔:
-npm.documentation=關於 npm registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/npm/">說明文件</a>。
 npm.dependencies=相依性
 npm.dependencies.development=開發相依性
 npm.dependencies.peer=Peer 相依性
 npm.dependencies.optional=選用相依性
 npm.details.tag=標籤
 pub.install=執行下列命令以使用 Dart 安裝此套件:
-pub.documentation=關於 Pub registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pub/">說明文件</a>。
 pypi.requires=需要 Python
 pypi.install=執行下列命令以使用 pip 安裝此套件:
-pypi.documentation=關於 PyPI registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/pypi/">說明文件</a>。
 rubygems.install=執行下列命令以使用 gem 安裝此套件:
 rubygems.install2=或將它加到 Gemfile:
 rubygems.dependencies.runtime=執行階段相依性
 rubygems.dependencies.development=開發相依性
 rubygems.required.ruby=需要的 Ruby 版本
 rubygems.required.rubygems=需要的 RubyGem 版本
-rubygems.documentation=關於 RubyGems registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/rubygems/">說明文件</a>。
 swift.registry=透過下列命令設定此註冊中心:
 swift.install=將此套件加入您的 <code>Package.swift</code> 檔:
 swift.install2=並執行下列命令:
-swift.documentation=關於 Swift registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/swift/">說明文件</a>。
 vagrant.install=執行下列命令以新增 Vagrant box:
-vagrant.documentation=關於 Vagrant registry 的詳情請參閱<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/vagrant/">說明文件</a>。
 settings.link=連結此套件到儲存庫
 settings.link.description=如果您將套件連結到儲存庫，該套件會顯示在儲存庫的套件清單。
 settings.link.select=選擇儲存庫


### PR DESCRIPTION
Some translations were just copied&pasted and they duplicated a lot.

Now, they are broken .....

To avoid blocking 1.20 release, as a quick fix, remove all of them, only keep the en-US texts.