### PR TITLE
Fix broken translations for package documantion

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3232,6 +3232,7 @@ desc = Manage repository packages.
 empty = There are no packages yet.
 empty.documentation = For more information on the package registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 empty.repo = Did you upload a package, but it's not shown here? Go to <a href="%[1]s">package settings</a> and link it to this repo.
+registry.documentation = For more information on the %s registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 filter.type = Type
 filter.type.all = All
 filter.no_result = Your filter produced no results.
@@ -3259,38 +3260,31 @@ alpine.registry = Setup this registry by adding the url in your <code>/etc/apk/r
 alpine.registry.key = Download the registry public RSA key into the <code>/etc/apk/keys/</code> folder to verify the index signature:
 alpine.registry.info = Choose $branch and $repository from the list below.
 alpine.install = To install the package, run the following command:
-alpine.documentation = For more information on the Alpine registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 alpine.repository = Repository Info
 alpine.repository.branches = Branches
 alpine.repository.repositories = Repositories
 alpine.repository.architectures = Architectures
 cargo.registry = Setup this registry in the Cargo configuration file (for example <code>~/.cargo/config.toml</code>):
 cargo.install = To install the package using Cargo, run the following command:
-cargo.documentation = For more information on the Cargo registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 cargo.details.repository_site = Repository Site
 cargo.details.documentation_site = Documentation Site
 chef.registry = Setup this registry in your <code>~/.chef/config.rb</code> file:
 chef.install = To install the package, run the following command:
-chef.documentation = For more information on the Chef registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 composer.registry = Setup this registry in your <code>~/.composer/config.json</code> file:
 composer.install = To install the package using Composer, run the following command:
-composer.documentation = For more information on the Composer registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 composer.dependencies = Dependencies
 composer.dependencies.development = Development Dependencies
 conan.details.repository = Repository
 conan.registry = Setup this registry from the command line:
 conan.install = To install the package using Conan, run the following command:
-conan.documentation = For more information on the Conan registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 conda.registry = Setup this registry as a Conda repository in your <code>.condarc</code> file:
 conda.install = To install the package using Conda, run the following command:
-conda.documentation = For more information on the Conda registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 conda.details.repository_site = Repository Site
 conda.details.documentation_site = Documentation Site
 container.details.type = Image Type
 container.details.platform = Platform
 container.pull = Pull the image from the command line:
 container.digest = Digest:
-container.documentation = For more information on the Container registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 container.multi_arch = OS / Arch
 container.layers = Image Layers
 container.labels = Labels
@@ -3298,61 +3292,47 @@ container.labels.key = Key
 container.labels.value = Value
 cran.registry = Setup this registry in your <code>Rprofile.site</code> file:
 cran.install = To install the package, run the following command:
-cran.documentation = For more information on the CRAN registry, see <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/packages/cran/">the documentation</a>.
 debian.registry = Setup this registry from the command line:
 debian.registry.info = Choose $distribution and $component from the list below.
 debian.install = To install the package, run the following command:
-debian.documentation = For more information on the Debian registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 debian.repository = Repository Info
 debian.repository.distributions = Distributions
 debian.repository.components = Components
 debian.repository.architectures = Architectures
 generic.download = Download package from the command line:
-generic.documentation = For more information on the generic registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 go.install = Install the package from the command line:
-go.documentation = For more information on the Go registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 helm.registry = Setup this registry from the command line:
 helm.install = To install the package, run the following command:
-helm.documentation = For more information on the Helm registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 maven.registry = Setup this registry in your project <code>pom.xml</code> file:
 maven.install = To use the package include the following in the <code>dependencies</code> block in the <code>pom.xml</code> file:
 maven.install2 = Run via command line:
 maven.download = To download the dependency, run via command line:
-maven.documentation = For more information on the Maven registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 nuget.registry = Setup this registry from the command line:
 nuget.install = To install the package using NuGet, run the following command:
-nuget.documentation = For more information on the NuGet registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 nuget.dependency.framework = Target Framework
 npm.registry = Setup this registry in your project <code>.npmrc</code> file:
 npm.install = To install the package using npm, run the following command:
 npm.install2 = or add it to the package.json file:
-npm.documentation = For more information on the npm registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 npm.dependencies = Dependencies
 npm.dependencies.development = Development Dependencies
 npm.dependencies.peer = Peer Dependencies
 npm.dependencies.optional = Optional Dependencies
 npm.details.tag = Tag
 pub.install = To install the package using Dart, run the following command:
-pub.documentation = For more information on the Pub registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 pypi.requires = Requires Python
 pypi.install = To install the package using pip, run the following command:
-pypi.documentation = For more information on the PyPI registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 rpm.registry = Setup this registry from the command line:
 rpm.install = To install the package, run the following command:
-rpm.documentation = For more information on the RPM registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 rubygems.install = To install the package using gem, run the following command:
 rubygems.install2 = or add it to the Gemfile:
 rubygems.dependencies.runtime = Runtime Dependencies
 rubygems.dependencies.development = Development Dependencies
 rubygems.required.ruby = Requires Ruby version
 rubygems.required.rubygems = Requires RubyGem version
-rubygems.documentation = For more information on the RubyGems registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 swift.registry = Setup this registry from the command line:
 swift.install = Add the package in your <code>Package.swift</code> file:
 swift.install2 = and run the following command:
-swift.documentation = For more information on the Swift registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 vagrant.install = To add a Vagrant box, run the following command:
-vagrant.documentation = For more information on the Vagrant registry, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 settings.link = Link this package to a repository
 settings.link.description = If you link a package with a repository, the package is listed in the repository's package list.
 settings.link.select = Select Repository

--- a/templates/package/content/alpine.tmpl
+++ b/templates/package/content/alpine.tmpl
@@ -18,7 +18,7 @@
 				</div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.alpine.documentation" "https://docs.gitea.io/en-us/packages/alpine/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Alpine" "https://docs.gitea.io/en-us/usage/packages/alpine/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/cargo.tmpl
+++ b/templates/package/content/cargo.tmpl
@@ -18,7 +18,7 @@ git-fetch-with-cli = true</code></pre></div>
 				<div class="markup"><pre class="code-block"><code>cargo add {{.PackageDescriptor.Package.Name}}@{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.cargo.documentation" "https://docs.gitea.io/en-us/usage/packages/cargo/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Cargo" "https://docs.gitea.io/en-us/usage/packages/cargo/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/chef.tmpl
+++ b/templates/package/content/chef.tmpl
@@ -11,7 +11,7 @@
 				<div class="markup"><pre class="code-block"><code>knife supermarket install {{.PackageDescriptor.Package.Name}} {{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.chef.documentation" "https://docs.gitea.io/en-us/usage/packages/chef/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Chef" "https://docs.gitea.io/en-us/usage/packages/chef/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/composer.tmpl
+++ b/templates/package/content/composer.tmpl
@@ -17,7 +17,7 @@
 				<div class="markup"><pre class="code-block"><code>composer require {{.PackageDescriptor.Package.Name}}:{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.composer.documentation" "https://docs.gitea.io/en-us/usage/packages/composer/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Composer" "https://docs.gitea.io/en-us/usage/packages/composer/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/conan.tmpl
+++ b/templates/package/content/conan.tmpl
@@ -11,7 +11,7 @@
 				<div class="markup"><pre class="code-block"><code>conan install --remote=gitea {{.PackageDescriptor.Package.Name}}/{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.conan.documentation" "https://docs.gitea.io/en-us/usage/packages/conan/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Conan" "https://docs.gitea.io/en-us/usage/packages/conan/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/conda.tmpl
+++ b/templates/package/content/conda.tmpl
@@ -16,7 +16,7 @@ default_channels:
 				<div class="markup"><pre class="code-block"><code>conda install{{if $channel}} -c {{$channel}}{{end}} {{.PackageDescriptor.PackageProperties.GetByName "conda.name"}}={{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.conda.documentation" "https://docs.gitea.io/en-us/usage/packages/conda/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Conda" "https://docs.gitea.io/en-us/usage/packages/conda/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/container.tmpl
+++ b/templates/package/content/container.tmpl
@@ -19,7 +19,7 @@
 				<div class="markup"><pre class="code-block"><code>{{range .PackageDescriptor.Files}}{{if eq .File.LowerName "manifest.json"}}{{.Properties.GetByName "container.digest"}}{{end}}{{end}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.container.documentation" "https://docs.gitea.io/en-us/usage/packages/container/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Container" "https://docs.gitea.io/en-us/usage/packages/container/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/cran.tmpl
+++ b/templates/package/content/cran.tmpl
@@ -11,7 +11,7 @@
 				<div class="markup"><pre class="code-block"><code>install.packages("{{.PackageDescriptor.Package.Name}}")</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.cran.documentation" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "CRAN" "https://docs.gitea.io/en-us/usage/packages/container/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/debian.tmpl
+++ b/templates/package/content/debian.tmpl
@@ -16,7 +16,7 @@ sudo apt update</code></pre></div>
 				</div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.debian.documentation" "https://docs.gitea.io/en-us/packages/debian/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Debian" "https://docs.gitea.io/en-us/usage/packages/debian/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/generic.tmpl
+++ b/templates/package/content/generic.tmpl
@@ -11,7 +11,7 @@ curl <gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{$.PackageDescripto
 				</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.generic.documentation" "https://docs.gitea.io/en-us/usage/packages/generic" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Generic" "https://docs.gitea.io/en-us/usage/packages/generic" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/go.tmpl
+++ b/templates/package/content/go.tmpl
@@ -7,7 +7,7 @@
 				<div class="markup"><pre class="code-block"><code>GOPROXY=<gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{$.PackageDescriptor.Owner.Name}}/go"></gitea-origin-url> go install {{$.PackageDescriptor.Package.Name}}@{{$.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.go.documentation" "https://docs.gitea.io/en-us/usage/packages/go" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Go" "https://docs.gitea.io/en-us/usage/packages/go" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/helm.tmpl
+++ b/templates/package/content/helm.tmpl
@@ -12,7 +12,7 @@ helm repo update</code></pre></div>
 				<div class="markup"><pre class="code-block"><code>helm install {{.PackageDescriptor.Package.Name}} {{AppDomain}}/{{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.helm.documentation" "https://docs.gitea.io/en-us/usage/packages/helm/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Helm" "https://docs.gitea.io/en-us/usage/packages/helm/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/maven.tmpl
+++ b/templates/package/content/maven.tmpl
@@ -40,7 +40,7 @@
 				<div class="markup"><pre class="code-block"><code>mvn dependency:get -DremoteRepositories=<gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{.PackageDescriptor.Owner.Name}}/maven"></gitea-origin-url> -Dartifact={{.PackageDescriptor.Metadata.GroupID}}:{{.PackageDescriptor.Metadata.ArtifactID}}:{{.PackageDescriptor.Version.Version}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.maven.documentation" "https://docs.gitea.io/en-us/usage/packages/maven/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Maven" "https://docs.gitea.io/en-us/usage/packages/maven/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/npm.tmpl
+++ b/templates/package/content/npm.tmpl
@@ -15,7 +15,7 @@
 				<div class="markup"><pre class="code-block"><code>&quot;{{.PackageDescriptor.Package.Name}}&quot;: &quot;{{.PackageDescriptor.Version.Version}}&quot;</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.npm.documentation" "https://docs.gitea.io/en-us/usage/packages/npm/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "npm" "https://docs.gitea.io/en-us/usage/packages/npm/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/nuget.tmpl
+++ b/templates/package/content/nuget.tmpl
@@ -11,7 +11,7 @@
 				<div class="markup"><pre class="code-block"><code>dotnet add package --source {{.PackageDescriptor.Owner.Name}} --version {{.PackageDescriptor.Version.Version}} {{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.nuget.documentation" "https://docs.gitea.io/en-us/usage/packages/nuget/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "NuGet" "https://docs.gitea.io/en-us/usage/packages/nuget/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/pub.tmpl
+++ b/templates/package/content/pub.tmpl
@@ -7,7 +7,7 @@
 				<div class="markup"><pre class="code-block"><code>dart pub add {{.PackageDescriptor.Package.Name}}:{{.PackageDescriptor.Version.Version}} --hosted-url=<gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{.PackageDescriptor.Owner.Name}}/pub/"></gitea-origin-url></code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.pub.documentation" "https://docs.gitea.io/en-us/usage/packages/pub/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Pub" "https://docs.gitea.io/en-us/usage/packages/pub/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/pypi.tmpl
+++ b/templates/package/content/pypi.tmpl
@@ -7,7 +7,7 @@
 				<div class="markup"><pre class="code-block"><code>pip install --index-url <gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{.PackageDescriptor.Owner.Name}}/pypi/simple/"></gitea-origin-url> {{.PackageDescriptor.Package.Name}}</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.pypi.documentation" "https://docs.gitea.io/en-us/usage/packages/pypi/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "PyPI" "https://docs.gitea.io/en-us/usage/packages/pypi/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/rpm.tmpl
+++ b/templates/package/content/rpm.tmpl
@@ -13,7 +13,7 @@
 				</div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.rpm.documentation" "https://docs.gitea.io/en-us/usage/packages/rpm/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "RPM" "https://docs.gitea.io/en-us/usage/packages/rpm/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/rubygems.tmpl
+++ b/templates/package/content/rubygems.tmpl
@@ -13,7 +13,7 @@
 end</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.rubygems.documentation" "https://docs.gitea.io/en-us/usage/packages/rubygems/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "RubyGems" "https://docs.gitea.io/en-us/usage/packages/rubygems/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/swift.tmpl
+++ b/templates/package/content/swift.tmpl
@@ -17,7 +17,7 @@
 				<div class="markup"><pre class="code-block"><code>swift package resolve</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.swift.documentation" "https://docs.gitea.io/en-us/usage/packages/swift/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Swift" "https://docs.gitea.io/en-us/usage/packages/swift/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/content/vagrant.tmpl
+++ b/templates/package/content/vagrant.tmpl
@@ -7,7 +7,7 @@
 				<div class="markup"><pre class="code-block"><code>vagrant box add --box-version {{.PackageDescriptor.Version.Version}} "<gitea-origin-url data-url="{{AppSubUrl}}/api/packages/{{.PackageDescriptor.Owner.Name}}/vagrant/{{.PackageDescriptor.Package.Name}}"></gitea-origin-url>"</code></pre></div>
 			</div>
 			<div class="field">
-				<label>{{.locale.Tr "packages.vagrant.documentation" "https://docs.gitea.io/en-us/usage/packages/vagrant/" | Safe}}</label>
+				<label>{{.locale.Tr "packages.registry.documentation" "Vagrant" "https://docs.gitea.io/en-us/usage/packages/vagrant/" | Safe}}</label>
 			</div>
 		</div>
 	</div>

--- a/templates/package/shared/cargo.tmpl
+++ b/templates/package/shared/cargo.tmpl
@@ -18,7 +18,7 @@
 			<button class="ui green button">{{$.locale.Tr "packages.owner.settings.cargo.rebuild"}}</button>
 		</form>
 		<div class="field">
-			<label>{{.locale.Tr "packages.cargo.documentation" "https://docs.gitea.io/en-us/usage/packages/cargo/" | Safe}}</label>
+			<label>{{.locale.Tr "packages.registry.documentation" "Cargo" "https://docs.gitea.io/en-us/usage/packages/cargo/" | Safe}}</label>
 		</div>
 	</div>
 </div>

--- a/templates/user/settings/packages.tmpl
+++ b/templates/user/settings/packages.tmpl
@@ -16,7 +16,7 @@
 					<button class="ui green button">{{$.locale.Tr "packages.owner.settings.chef.keypair"}}</button>
 				</form>
 				<div class="field">
-					<label>{{.locale.Tr "packages.chef.documentation" "https://docs.gitea.io/en-us/usage/packages/chef/" | Safe}}</label>
+					<label>{{.locale.Tr "packages.registry.documentation" "Chef" "https://docs.gitea.io/en-us/usage/packages/chef/" | Safe}}</label>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The code was just copied&pasted, it causes problems now.

There are a lot (for every package) broken translations. eg:

```
# en-US
conda.documentation = For more information on the Conda registry, see 
<a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.

# fr-FR (and many languages)
conda.documentation=Pour plus d'informations sur le registre Conda, voir 
<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/fr-fr/packages/conda/">la documentation</a>.
```


To resolve the problem fundamentally, use a general string, and trigger the re-translating on Crowdin side.


And, it should really really really avoid introducing too much copied&pasted code .......

