### PR TITLE
Switch to `vite-string-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "3.2.1",
         "@playwright/test": "1.35.1",
-        "@rollup/pluginutils": "5.0.2",
         "@stoplight/spectral-cli": "6.8.0",
         "@vitejs/plugin-vue": "4.2.3",
         "eslint": "8.43.0",
@@ -80,6 +79,7 @@
         "stylelint-stylistic": "0.4.2",
         "svgo": "3.0.2",
         "updates": "14.2.8",
+        "vite-string-plugin": "1.1.0",
         "vitest": "0.32.2"
       },
       "engines": {
@@ -1293,28 +1293,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@stoplight/better-ajv-errors": {
       "version": "1.0.3",
@@ -10741,6 +10719,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-string-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-string-plugin/-/vite-string-plugin-1.1.0.tgz",
+      "integrity": "sha512-RMxstCLl6Zyyz4tkzzHDFrrVvom1GAxjo2lTmgfus5CZYOnFNcJ2iQiDaFpc4KAOHSNkBNtkj5YauSs+f1gqCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/vite/node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "3.2.1",
     "@playwright/test": "1.35.1",
-    "@rollup/pluginutils": "5.0.2",
     "@stoplight/spectral-cli": "6.8.0",
     "@vitejs/plugin-vue": "4.2.3",
     "eslint": "8.43.0",
@@ -79,6 +78,7 @@
     "stylelint-stylistic": "0.4.2",
     "svgo": "3.0.2",
     "updates": "14.2.8",
+    "vite-string-plugin": "1.1.0",
     "vitest": "0.32.2"
   },
   "browserslist": [

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,20 +1,6 @@
 import {defineConfig} from 'vitest/dist/config.js';
-import {readFile} from 'node:fs/promises';
-import {dataToEsm} from '@rollup/pluginutils';
-import {extname} from 'node:path';
 import vue from '@vitejs/plugin-vue';
-
-function stringPlugin() {
-  return {
-    name: 'string-plugin',
-    enforce: 'pre',
-    async load(id) {
-      const path = id.split('?')[0];
-      if (extname(path) !== '.svg') return null;
-      return dataToEsm(await readFile(path, 'utf8'));
-    }
-  };
-}
+import {stringPlugin} from 'vite-string-plugin';
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Switch to [`vite-string-plugin`](https://github.com/silverwind/vite-string-plugin) to load SVGs as string during tests. The plugin will also be useful once we switch to vite.