### PR TITLE
Fixing the issue-filter layout in milestone issue pages for mobile view

### DIFF
--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -11,12 +11,12 @@
 							<a class="ui green basic button link-action" href data-url="{{$.RepoLink}}/milestones/{{.MilestoneID}}/open">{{$.locale.Tr "repo.milestones.open"}}
 							</a>
 						{{else}}
-							<a class="ui red basic button link-action" href data-url="{{$.RepoLink}}/milestones/{{.MilestoneID}}/close">{{$.locale.Tr "repo.milestones.close"}}
+							<a class="ui compact small red basic button link-action" href data-url="{{$.RepoLink}}/milestones/{{.MilestoneID}}/close">{{$.locale.Tr "repo.milestones.close"}}
 							</a>
 						{{end}}
-						<a class="ui button" href="{{.RepoLink}}/milestones/{{.MilestoneID}}/edit">{{.locale.Tr "repo.milestones.edit"}}</a>
+						<a class="ui compact small button basic" href="{{.RepoLink}}/milestones/{{.MilestoneID}}/edit">{{.locale.Tr "repo.milestones.edit"}}</a>
 					{{end}}
-					<a class="ui primary button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}?milestone={{.MilestoneID}}">{{.locale.Tr "repo.issues.new"}}</a>
+					<a class="ui compact small primary button" href="{{.RepoLink}}/issues/new{{if .NewIssueChooseTemplate}}/choose{{end}}?milestone={{.MilestoneID}}">{{.locale.Tr "repo.issues.new"}}</a>
 				</div>
 			{{end}}
 		</div>
@@ -50,7 +50,7 @@
 		</div>
 		<div class="divider"></div>
 
-		<div id="issue-filters" class="issue-list-toolbar">
+		<div id="issue-filters" class="issue-list-toolbar milestone">
 			<div class="issue-list-toolbar-left">
 				{{template "repo/issue/openclose" .}}
 			</div>

--- a/web_src/css/shared/milestone.css
+++ b/web_src/css/shared/milestone.css
@@ -59,4 +59,15 @@
     flex-direction: column;
     gap: 8px;
   }
+
+  .issue-list-toolbar.milestone {
+    flex-direction: column;
+  }
+
+  .milestone > .issue-list-toolbar-right > .labels > .item {
+    flex-direction: row;
+    display: flex;
+    flex-wrap: wrap;
+    max-width: fit-content;
+  }
 }


### PR DESCRIPTION
Fixing the issue-filter layout in milestone issue pages

<details>
  <summary>Screen shots [Mobile view]</summary>
  
 Before
![image](https://github.com/go-gitea/gitea/assets/80308335/c91a1c08-9ce0-45fd-bbab-f2d8cb3f8343)

After: 
![image](https://github.com/go-gitea/gitea/assets/80308335/07cc1bcc-3a88-4c27-bdfd-93e3acd0f68a)

![image](https://github.com/go-gitea/gitea/assets/80308335/d656fafb-fe89-469f-96a0-4f32a72cfda9)

</details>


