### PR TITLE
Tweak repo topics bar

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -5,7 +5,7 @@
 		{{template "base/alert" .}}
 		{{template "repo/code/recently_pushed_new_branches" .}}
 		{{if and (not .HideRepoInfo) (not .IsBlame)}}
-		<div class="ui repo-description">
+		<div class="ui repo-description gt-my-2">
 			<div id="repo-desc">
 				{{$description := .Repository.DescriptionHTML $.Context}}
 				{{if $description}}<span class="description">{{$description}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}
@@ -29,9 +29,9 @@
 				</div>
 			{{end}}
 		</div>
-		<div class="gt-df gt-ac gt-fw gt-mt-3" id="repo-topics">
-			{{range .Topics}}<a class="ui repo-topic large label topic" href="{{AppSubUrl}}/explore/repos?q={{.Name}}&topic=1">{{.Name}}</a>{{end}}
-			{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}<button id="manage_topic" class="btn interact-fg gt-ml-2 gt-font-12">{{.locale.Tr "repo.topic.manage_topics"}}</button>{{end}}
+		<div class="gt-df gt-ac gt-fw gt-gap-2" id="repo-topics">
+			{{range .Topics}}<a class="ui repo-topic large label topic gt-m-0" href="{{AppSubUrl}}/explore/repos?q={{.Name}}&topic=1">{{.Name}}</a>{{end}}
+			{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}<button id="manage_topic" class="btn interact-fg gt-font-12">{{.locale.Tr "repo.topic.manage_topics"}}</button>{{end}}
 		</div>
 		{{end}}
 		{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -5,7 +5,7 @@
 		{{template "base/alert" .}}
 		{{template "repo/code/recently_pushed_new_branches" .}}
 		{{if and (not .HideRepoInfo) (not .IsBlame)}}
-		<div class="ui repo-description gt-my-2">
+		<div class="ui repo-description">
 			<div id="repo-desc">
 				{{$description := .Repository.DescriptionHTML $.Context}}
 				{{if $description}}<span class="description">{{$description}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -231,6 +231,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 6px;
 }
 
 @media (max-width: 767.68px) {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2777,7 +2777,6 @@ tbody.commit-list {
 #repo-topics .repo-topic {
   font-weight: var(--font-weight-normal);
   cursor: pointer;
-  margin: 2px;
 }
 
 #new-dependency-drop-list.ui.selection.dropdown {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -231,7 +231,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
+  margin-bottom: 5px;
 }
 
 @media (max-width: 767.68px) {


### PR DESCRIPTION
Minor tweaks to repo topics:

- Use gap instead of margin to align "Manage Topics" when no topics present
- Add margin to description instead

Before:

<img width="1232" alt="Screenshot 2023-07-08 at 13 08 15" src="https://github.com/go-gitea/gitea/assets/115237/a5d3586c-6cbf-4b74-8137-11d91f2cbb45">
<img width="1233" alt="Screenshot 2023-07-08 at 13 08 05" src="https://github.com/go-gitea/gitea/assets/115237/59b18d93-e4cb-4f2b-9bc2-d6aa63f93827">

After:

<img width="1232" alt="Screenshot 2023-07-08 at 13 08 42" src="https://github.com/go-gitea/gitea/assets/115237/470d42ad-3f7e-40f9-b0a1-203b4af77eb9">
<img width="1231" alt="Screenshot 2023-07-08 at 13 08 32" src="https://github.com/go-gitea/gitea/assets/115237/42d18048-748c-4a3f-ab89-3403866cef34">