### PR TITLE
docs: rootless docker ssh's default port is 2222

### DIFF
--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -119,7 +119,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "3000:3000"
-      - "222:22"
+      - "2222:2222"
 +    depends_on:
 +      - db
 +


### PR DESCRIPTION
---

according `docker/rootless/usr/local/bin/docker-setup.sh` , in rootless docker setup, ssh port is 2222.
and mysql database case should port same as PostgreSQL port