### PR TITLE
Fix notification list bugs

### DIFF
--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -186,7 +186,7 @@ func NotificationStatusPost(ctx *context.Context) {
 	if ctx.Written() {
 		return
 	}
-	ctx.Data["Link"] = setting.AppURL + "notifications"
+	ctx.Data["Link"] = setting.AppSubURL + "/notifications"
 	ctx.Data["SequenceNumber"] = ctx.Req.PostFormValue("sequence-number")
 
 	ctx.HTML(http.StatusOK, tplNotificationDiv)

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -1,4 +1,4 @@
-<div role="main" aria-label="{{.Title}}" class="page-content user notification" id="notification_div" data-params="{{.Page.GetParams}}" data-sequence-number="{{.SequenceNumber}}">
+<div role="main" aria-label="{{.Title}}" class="page-content user notification" id="notification_div" data-sequence-number="{{.SequenceNumber}}">
 	<div class="ui container">
 		{{$notificationUnreadCount := call .NotificationUnreadCount}}
 		<div class="gt-df gt-ac gt-sb gt-mb-4">

--- a/templates/user/notification/notification_subscriptions.tmpl
+++ b/templates/user/notification/notification_subscriptions.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content user notification" id="notification_subscriptions" data-params="{{.Page.GetParams}}" data-sequence-number="{{.SequenceNumber}}">
+<div role="main" aria-label="{{.Title}}" class="page-content user notification">
 	<div class="ui container">
 		<div class="ui top attached tabular menu">
 			<a href="{{AppSubUrl}}/notifications/subscriptions" class="{{if eq .Status 1}}active {{end}}item">

--- a/web_src/js/features/notification.js
+++ b/web_src/js/features/notification.js
@@ -165,7 +165,7 @@ async function updateNotificationTable() {
   if (notificationDiv.length > 0) {
     const data = await $.ajax({
       type: 'GET',
-      url: `${appSubUrl}/notifications?${notificationDiv.data('params')}`,
+      url: `${appSubUrl}/notifications${window.location.search}`,
       data: {
         'div-only': true,
         'sequence-number': ++notificationSequenceNumber,


### PR DESCRIPTION
Fix #25627

1. `ctx.Data["Link"]` should use relative URL but not AppURL
2. The `data-params` is incorrect because it doesn't contain "page". JS can simply use "window.location.search" to construct the AJAX URL
3. The `data-xxx` and `id` in notification_subscriptions.tmpl were copied&pasted, they don't have affect.