### PR TITLE
Exclude default branch from pushed branch hint

### DIFF
--- a/models/git/branch.go
+++ b/models/git/branch.go
@@ -391,12 +391,10 @@ func FindRecentlyPushedNewBranches(ctx context.Context, repoID, userID int64, ex
 			"pull_request.head_repo_id": repoID,
 			"issue.is_closed":           false,
 		})
-	sess := db.GetEngine(ctx).
-		Where("pusher_id=? AND is_deleted=?", userID, false)
-	if excludeBranchName != "" {
-		sess.And("name <> ?", excludeBranchName)
-	}
-	err := sess.And("updated_unix >= ?", time.Now().Add(-time.Hour*6).Unix()).
+	err := db.GetEngine(ctx).
+		Where("pusher_id=? AND is_deleted=?", userID, false).
+		And("name <> ?", excludeBranchName).
+		And("updated_unix >= ?", time.Now().Add(-time.Hour*6).Unix()).
 		NotIn("name", subQuery).
 		OrderBy("branch.updated_unix DESC").
 		Limit(2).

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -982,7 +982,7 @@ func renderCode(ctx *context.Context) {
 			ctx.ServerError("GetBaseRepo", err)
 			return
 		}
-		ctx.Data["RecentlyPushedNewBranches"], err = git_model.FindRecentlyPushedNewBranches(ctx, ctx.Repo.Repository.ID, ctx.Doer.ID)
+		ctx.Data["RecentlyPushedNewBranches"], err = git_model.FindRecentlyPushedNewBranches(ctx, ctx.Repo.Repository.ID, ctx.Doer.ID, ctx.Repo.Repository.DefaultBranch)
 		if err != nil {
 			ctx.ServerError("GetRecentlyPushedBranches", err)
 			return


### PR DESCRIPTION
When pushing to default branch, no pushing hint should be prompt.
Fix #25778 