### PR TITLE
Make "install page" respect environment config (#25648)

### DIFF
--- a/docs/content/doc/installation/with-docker-rootless.en-us.md
+++ b/docs/content/doc/installation/with-docker-rootless.en-us.md
@@ -288,7 +288,7 @@ docker-compose up -d
 
 In addition to the environment variables above, any settings in `app.ini` can be set
 or overridden with an environment variable of the form: `GITEA__SECTION_NAME__KEY_NAME`.
-These settings are applied each time the docker container starts.
+These settings are applied each time the docker container starts, and won't be passed into Gitea's sub-processes.
 Full information [here](https://github.com/go-gitea/gitea/tree/main/contrib/environment-to-ini).
 
 These environment variables can be passed to the docker container in `docker-compose.yml`.

--- a/docs/content/doc/installation/with-docker.en-us.md
+++ b/docs/content/doc/installation/with-docker.en-us.md
@@ -289,7 +289,7 @@ docker-compose up -d
 
 In addition to the environment variables above, any settings in `app.ini` can be set
 or overridden with an environment variable of the form: `GITEA__SECTION_NAME__KEY_NAME`.
-These settings are applied each time the docker container starts.
+These settings are applied each time the docker container starts, and won't be passed into Gitea's sub-processes.
 Full information [here](https://github.com/go-gitea/gitea/tree/master/contrib/environment-to-ini).
 
 These environment variables can be passed to the docker container in `docker-compose.yml`.

--- a/modules/assetfs/layered.go
+++ b/modules/assetfs/layered.go
@@ -215,6 +215,7 @@ func (l *LayeredFS) WatchLocalChanges(ctx context.Context, callback func()) {
 			log.Error("Unable to list directories for asset local file-system %q: %v", layer.localPath, err)
 			continue
 		}
+		layerDirs = append(layerDirs, ".")
 		for _, dir := range layerDirs {
 			if err = watcher.Add(util.FilePathJoinAbs(layer.localPath, dir)); err != nil {
 				log.Error("Unable to watch directory %s: %v", dir, err)

--- a/modules/setting/config_env_test.go
+++ b/modules/setting/config_env_test.go
@@ -72,7 +72,7 @@ func TestDecodeEnvironmentKey(t *testing.T) {
 func TestEnvironmentToConfig(t *testing.T) {
 	cfg, _ := NewConfigProviderFromData("")
 
-	changed := EnvironmentToConfig(cfg, "GITEA__", "__FILE", nil)
+	changed := EnvironmentToConfig(cfg, nil)
 	assert.False(t, changed)
 
 	cfg, err := NewConfigProviderFromData(`
@@ -81,16 +81,16 @@ key = old
 `)
 	assert.NoError(t, err)
 
-	changed = EnvironmentToConfig(cfg, "GITEA__", "__FILE", []string{"GITEA__sec__key=new"})
+	changed = EnvironmentToConfig(cfg, []string{"GITEA__sec__key=new"})
 	assert.True(t, changed)
 	assert.Equal(t, "new", cfg.Section("sec").Key("key").String())
 
-	changed = EnvironmentToConfig(cfg, "GITEA__", "__FILE", []string{"GITEA__sec__key=new"})
+	changed = EnvironmentToConfig(cfg, []string{"GITEA__sec__key=new"})
 	assert.False(t, changed)
 
 	tmpFile := t.TempDir() + "/the-file"
 	_ = os.WriteFile(tmpFile, []byte("value-from-file"), 0o644)
-	changed = EnvironmentToConfig(cfg, "GITEA__", "__FILE", []string{"GITEA__sec__key__FILE=" + tmpFile})
+	changed = EnvironmentToConfig(cfg, []string{"GITEA__sec__key__FILE=" + tmpFile})
 	assert.True(t, changed)
 	assert.Equal(t, "value-from-file", cfg.Section("sec").Key("key").String())
 }

--- a/modules/setting/path.go
+++ b/modules/setting/path.go
@@ -171,6 +171,9 @@ func InitWorkPathAndCfgProvider(getEnvFn func(name string) string, args ArgWorkP
 
 	// only read the config but do not load/init anything more, because the AppWorkPath and CustomPath are not ready
 	InitCfgProvider(tmpCustomConf.Value)
+	if HasInstallLock(CfgProvider) {
+		ClearEnvConfigKeys() // if the instance has been installed, do not pass the environment variables to sub-processes
+	}
 	configWorkPath := ConfigSectionKeyString(CfgProvider.Section(""), "WORK_PATH")
 	if configWorkPath != "" {
 		if !filepath.IsAbs(configWorkPath) {

--- a/modules/setting/security.go
+++ b/modules/setting/security.go
@@ -102,7 +102,7 @@ func generateSaveInternalToken(rootCfg ConfigProvider) {
 
 func loadSecurityFrom(rootCfg ConfigProvider) {
 	sec := rootCfg.Section("security")
-	InstallLock = sec.Key("INSTALL_LOCK").MustBool(false)
+	InstallLock = HasInstallLock(rootCfg)
 	LogInRememberDays = sec.Key("LOGIN_REMEMBER_DAYS").MustInt(7)
 	CookieUserName = sec.Key("COOKIE_USERNAME").MustString("gitea_awesome")
 	SecretKey = loadSecret(sec, "SECRET_KEY_URI", "SECRET_KEY")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -183,10 +183,14 @@ func loadRunModeFrom(rootCfg ConfigProvider) {
 	}
 }
 
+// HasInstallLock checks the install-lock in ConfigProvider directly, because sometimes the config file is not loaded into setting variables yet.
+func HasInstallLock(rootCfg ConfigProvider) bool {
+	return rootCfg.Section("security").Key("INSTALL_LOCK").MustBool(false)
+}
+
 func mustCurrentRunUserMatch(rootCfg ConfigProvider) {
 	// Does not check run user when the "InstallLock" is off.
-	installLock := rootCfg.Section("security").Key("INSTALL_LOCK").MustBool(false)
-	if installLock {
+	if HasInstallLock(rootCfg) {
 		currentUser, match := IsRunUserMatchCurrentUser(RunUser)
 		if !match {
 			log.Fatal("Expect user '%s' but current user is: %s", RunUser, currentUser)

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -290,6 +290,8 @@ invalid_password_algorithm = Invalid password hash algorithm
 password_algorithm_helper = Set the password hashing algorithm. Algorithms have differing requirements and strength. The argon2 algorithm is rather secure but uses a lot of memory and may be inappropriate for small systems.
 enable_update_checker = Enable Update Checker
 enable_update_checker_helper = Checks for new version releases periodically by connecting to gitea.io.
+env_config_keys = Environment Configuration
+env_config_keys_prompt = The following environment variables will also be applied to your configuration file:
 
 [home]
 uname_holder = Username or Email Address

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -1,6 +1,6 @@
 {{template "base/head" .}}
 <div role="main" aria-label="{{.Title}}" class="page-content install">
-	<div class="ui middle very relaxed page grid">
+	<div class="ui grid install-config-container">
 		<div class="sixteen wide center aligned centered column">
 			<h3 class="ui top attached header">
 				{{.locale.Tr "install.title"}}
@@ -149,7 +149,7 @@
 					</div>
 					<div class="inline field">
 						<div class="ui checkbox">
-							<label for="enable_update_checker">{{.locale.Tr "install.enable_update_checker"}}</label>
+							<label>{{.locale.Tr "install.enable_update_checker"}}</label>
 							<input name="enable_update_checker" type="checkbox">
 						</div>
 						<span class="help">{{.locale.Tr "install.enable_update_checker_helper"}}</span>
@@ -161,7 +161,7 @@
 
 					<!-- Email -->
 					<details class="optional field">
-						<summary class="title gt-py-3{{if .Err_SMTP}} text red{{end}}">
+						<summary class="right-content gt-py-3{{if .Err_SMTP}} text red{{end}}">
 							{{.locale.Tr "install.email_title"}}
 						</summary>
 						<div class="inline field">
@@ -201,7 +201,7 @@
 
 					<!-- Server and other services -->
 					<details class="optional field">
-						<summary class="title gt-py-3{{if .Err_Services}} text red{{end}}">
+						<summary class="right-content gt-py-3{{if .Err_Services}} text red{{end}}">
 							{{.locale.Tr "install.server_service_title"}}
 						</summary>
 						<div class="inline field">
@@ -299,7 +299,7 @@
 
 					<!-- Admin -->
 					<details class="optional field">
-						<summary class="title gt-py-3{{if .Err_Admin}} text red{{end}}">
+						<summary class="right-content gt-py-3{{if .Err_Admin}} text red{{end}}">
 							{{.locale.Tr "install.admin_title"}}
 						</summary>
 						<p class="center">{{.locale.Tr "install.admin_setting_desc"}}</p>
@@ -321,10 +321,30 @@
 						</div>
 					</details>
 
-					<div class="ui divider"></div>
+					{{if .EnvConfigKeys}}
+					<!-- Environment Config -->
+					<h4 class="ui dividing header">{{.locale.Tr "install.env_config_keys"}}</h4>
 					<div class="inline field">
 						<label></label>
 						<button class="ui primary button">{{.locale.Tr "install.install_btn_confirm"}}</button>
+						<div class="right-content">
+							{{.locale.Tr "install.env_config_keys_prompt"}}
+						</div>
+						<div class="right-content gt-mt-3">
+							{{range .EnvConfigKeys}}<span class="ui label">{{.}}</span>{{end}}
+						</div>
+					</div>
+					{{end}}
+
+					<div class="ui divider"></div>
+
+					<div class="inline field">
+						<div class="right-content">
+							These configuration options will be written into: {{.CustomConfFile}}
+						</div>
+						<div class="right-content gt-mt-3">
+							<button class="ui primary button">{{.locale.Tr "install.install_btn_confirm"}}</button>
+						</div>
 					</div>
 				</form>
 			</div>

--- a/web_src/css/install.css
+++ b/web_src/css/install.css
@@ -1,5 +1,6 @@
-.page-content.install {
-  padding-top: 45px;
+.page-content.install .install-config-container {
+  max-width: 900px;
+  margin: auto;
 }
 
 .page-content.install form.ui.form .inline.field > label {
@@ -9,18 +10,12 @@
   margin-right: 0;
 }
 
-.page-content.install form.ui.form .inline.field > .ui.checkbox:first-child {
+.page-content.install .ui.form .field > .help,
+.page-content.install .ui.form .field > .ui.checkbox:first-child,
+.page-content.install .ui.form .field > .right-content {
   margin-left: 30%;
   padding-left: 5px;
-}
-
-.page-content.install form.ui.form .inline.field > .ui.checkbox:first-child label {
   width: auto;
-}
-
-.page-content.install form.ui.form .title {
-  margin-left: 30%;
-  padding-left: 5px;
 }
 
 .page-content.install form.ui.form input {
@@ -28,7 +23,7 @@
 }
 
 .page-content.install form.ui.form details.optional.field[open] {
-  border-bottom: 1px solid var(--color-secondary);
+  border-bottom: 1px dashed var(--color-secondary);
   padding-bottom: 10px;
 }
 
@@ -42,12 +37,6 @@
 
 .page-content.install form.ui.form .field {
   text-align: left;
-}
-
-.page-content.install form.ui.form .field .help {
-  margin-left: 30%;
-  padding-left: 5px;
-  width: 60%;
 }
 
 .page-content.install .ui .reinstall-message {


### PR DESCRIPTION
Backport #25648

Replace #25580

Fix #19453

The problem was: when users set "GITEA__XXX__YYY" , the "install page" doesn't respect it.

So, to make the result consistent and avoid surprising end users, now the "install page" also writes the environment variables to the config file.

And, to make things clear, there are enough messages on the UI to tell users what will happen.

There are some necessary/related changes to `environment-to-ini.go`:

* The "--clear" flag is removed and it was incorrectly written there. The "clear" operation should be done if INSTALL_LOCK=true
* The "--prefix" flag is removed because it's never used, never documented and it only causes inconsistent behavior.

The only conflict during backport is "ui divider" in templates/install.tmpl
