### PR TITLE
Fix incorrect aggregated status of commit statuses

### DIFF
--- a/modules/structs/commit_status.go
+++ b/modules/structs/commit_status.go
@@ -24,18 +24,15 @@ const (
 
 // NoBetterThan returns true if this State is no better than the given State
 func (css CommitStatusState) NoBetterThan(css2 CommitStatusState) bool {
-	switch css {
-	case CommitStatusError:
-		return true
-	case CommitStatusFailure:
-		return css2 != CommitStatusError
-	case CommitStatusWarning:
-		return css2 != CommitStatusError && css2 != CommitStatusFailure
-	case CommitStatusPending:
-		return css2 != CommitStatusError && css2 != CommitStatusFailure && css2 != CommitStatusWarning
-	default:
-		return css2 != CommitStatusError && css2 != CommitStatusFailure && css2 != CommitStatusWarning && css2 != CommitStatusPending
+	commitStatusPriorities := map[CommitStatusState]int{
+		CommitStatusError:   0,
+		CommitStatusFailure: 1,
+		CommitStatusWarning: 2,
+		CommitStatusPending: 3,
+		CommitStatusRunning: 4,
+		CommitStatusSuccess: 5,
 	}
+	return commitStatusPriorities[css] <= commitStatusPriorities[css2]
 }
 
 // IsPending represents if commit status state is pending


### PR DESCRIPTION
I checked the commit history and found that in the last modification to `modules/structs/commit_status.go`, a status `running` was added, but it was not handled in time for the `NoBetterThan` function, which led to issue #25776. So I made a simple change to `NoBetterThan`.
This PR will close #25776