### PR TITLE
Remove `git.FileBlame`

### DIFF
--- a/modules/git/repo_blame.go
+++ b/modules/git/repo_blame.go
@@ -7,12 +7,6 @@ import (
 	"fmt"
 )
 
-// FileBlame return the Blame object of file
-func (repo *Repository) FileBlame(revision, path, file string) ([]byte, error) {
-	stdout, _, err := NewCommand(repo.Ctx, "blame", "--root").AddDashesAndList(file).RunStdBytes(&RunOpts{Dir: path})
-	return stdout, err
-}
-
 // LineBlame returns the latest commit at the given line
 func (repo *Repository) LineBlame(revision, path, file string, line uint) (*Commit, error) {
 	res, _, err := NewCommand(repo.Ctx, "blame").


### PR DESCRIPTION
The `FileBlame` function looks strange, it has `revision` as argument but doesn't use it.

Since the function never be used, I think we could just remove it.

If anyone thinks it should be kept, please help fix `revision`.