### PR TITLE
Skip unuseful error message in dev mode when watching local filesystem

### DIFF
--- a/modules/assetfs/layered.go
+++ b/modules/assetfs/layered.go
@@ -217,7 +217,7 @@ func (l *LayeredFS) WatchLocalChanges(ctx context.Context, callback func()) {
 		}
 		layerDirs = append(layerDirs, ".")
 		for _, dir := range layerDirs {
-			if err = watcher.Add(util.FilePathJoinAbs(layer.localPath, dir)); err != nil {
+			if err = watcher.Add(util.FilePathJoinAbs(layer.localPath, dir)); err != nil && !os.IsNotExist(err) {
 				log.Error("Unable to watch directory %s: %v", dir, err)
 			}
 		}


### PR DESCRIPTION
Before, in dev mode, there might be some error logs like:

```
2023/07/17 13:54:51 ...s/assetfs/layered.go:221:WatchLocalChanges() [E] Unable to watch directory .: lstat /data/work/gitea/custom/templates: no such file or directory

```

Because there is no "custom/templates" directory.

After: ignore such error, no such error message anymore.