### PR TITLE
Add shutting down notice

### DIFF
--- a/modules/setting/config_provider.go
+++ b/modules/setting/config_provider.go
@@ -324,7 +324,7 @@ func deprecatedSetting(rootCfg ConfigProvider, oldSection, oldKey, newSection, n
 
 func deprecatedSettingFatal(rootCfg ConfigProvider, oldSection, oldKey, newSection, newKey, version string) {
 	if rootCfg.Section(oldSection).HasKey(oldKey) {
-		log.Fatal("Deprecated fallback `[%s]` `%s` present. Use `[%s]` `%s` instead. This fallback will be/has been removed in %s", oldSection, oldKey, newSection, newKey, version)
+		log.Fatal("Deprecated fallback `[%s]` `%s` present. Use `[%s]` `%s` instead. This fallback will be/has been removed in %s. Shutting down", oldSection, oldKey, newSection, newKey, version)
 	}
 }
 


### PR DESCRIPTION
Got the same problem as #25915 when updating an instance. The `log.Fatal` should have been marked as breaking in #23911.

This PR adds a notice that the system is shutting down because of the deprecated setting.