### PR TITLE
Make environment-to-ini work with INSTALL_LOCK=true

### DIFF
--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -75,6 +75,8 @@ func main() {
 }
 
 func runEnvironmentToIni(c *cli.Context) error {
+	// the config system may change the environment variables, so get a copy first, to be used later
+	env := append([]string{}, os.Environ()...)
 	setting.InitWorkPathAndCfgProvider(os.Getenv, setting.ArgWorkPathAndCustomConf{
 		WorkPath:   c.String("work-path"),
 		CustomPath: c.String("custom-path"),
@@ -86,7 +88,7 @@ func runEnvironmentToIni(c *cli.Context) error {
 		log.Fatal("Failed to load custom conf '%s': %v", setting.CustomConf, err)
 	}
 
-	changed := setting.EnvironmentToConfig(cfg, os.Environ())
+	changed := setting.EnvironmentToConfig(cfg, env)
 
 	// try to save the config file
 	destination := c.String("out")


### PR DESCRIPTION
Regression of #25648, fix #25924

Test:

```bash
rm -f /tmp/example.ini /tmp/out.ini && \
echo "[security]" > /tmp/example.ini && \
echo "INSTALL_LOCK = true" >> /tmp/example.ini && \
GITEA__foo__bar=1 go run contrib/environment-to-ini/environment-to-ini.go --config=/tmp/example.ini --out=/tmp/out.ini && \
echo "==== example:" && \
cat /tmp/example.ini && \
echo "==== out:" && \
cat /tmp/out.ini
```

Output:

```
2023/07/17 17:40:51 ...nvironment-to-ini.go:99:runEnvironmentToIni() [I] Settings saved to: "/tmp/out.ini"
==== example:
[security]
INSTALL_LOCK = true
==== out:
[security]
INSTALL_LOCK = true

[foo]
bar = 1

```
