### PR TITLE
Fix alignment of truncated text in tables

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1219,6 +1219,10 @@ img.ui.avatar,
   display: inline-block;
 }
 
+.ui td .text.truncate {
+  vertical-align: top;
+}
+
 .ui .text.thin {
   font-weight: var(--font-weight-normal);
 }


### PR DESCRIPTION
Before:
<img width="918" alt="Screenshot 2023-07-18 at 02 23 48" src="https://github.com/go-gitea/gitea/assets/115237/1c45739d-68fa-4db2-854f-ce50ab28ae2a">

After:
<img width="922" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/3c301c84-8497-41f6-b94b-4345c58b860c">

