### PR TITLE
Fix "custom URL scheme" support and fix tests

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1306,7 +1306,7 @@ LEVEL = Info
 ;; Comma separated list of custom URL-Schemes that are allowed as links when rendering Markdown
 ;; for example git,magnet,ftp (more at https://en.wikipedia.org/wiki/List_of_URI_schemes)
 ;; URLs starting with http and https are always displayed, whatever is put in this entry.
-;; If this entry is empty, all URL schemes are allowed.
+;; Keep in mind that some URL schemes like 'javascript' could cause security problems.
 ;CUSTOM_URL_SCHEMES =
 ;;
 ;; List of file extensions that should be rendered/edited as Markdown

--- a/docs/content/doc/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/administration/config-cheat-sheet.en-us.md
@@ -275,7 +275,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
   trailing whitespace to paragraphs is not necessary to force a line break.
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
-  always displayed. If this entry is empty, all URL schemes are allowed
+  always displayed. Keep in mind that some URL schemes like 'javascript' could cause security problems.
 - `FILE_EXTENSIONS`: **.md,.markdown,.mdown,.mkd,.livemd**: List of file extensions that should be rendered/edited as Markdown. Separate the extensions with a comma. To render files without any extension as markdown, just put a comma.
 - `ENABLE_MATH`: **true**: Enables detection of `\(...\)`, `\[...\]`, `$...$` and `$$...$$` blocks as math blocks.
 

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -224,6 +224,15 @@ func TestRender_links(t *testing.T) {
 	test(
 		"ftps://gitea.com",
 		`<p>ftps://gitea.com</p>`)
+	test(
+		"[a](http://domain)",
+		`<p><a href="http://domain" rel="nofollow">a</a></p>`)
+	test(
+		"[a](https://domain)",
+		`<p><a href="https://domain" rel="nofollow">a</a></p>`)
+	test(
+		"[a](javascript:foo)",
+		`<p>a</p>`)
 
 	// Restore previous settings
 	setting.Markdown.CustomURLSchemes = defaultCustom

--- a/modules/markup/sanitizer.go
+++ b/modules/markup/sanitizer.go
@@ -22,10 +22,7 @@ type Sanitizer struct {
 	init             sync.Once
 }
 
-var (
-	sanitizer     = &Sanitizer{}
-	allowAllRegex = regexp.MustCompile(".+")
-)
+var sanitizer = &Sanitizer{}
 
 // NewSanitizer initializes sanitizer with allowed attributes based on settings.
 // Multiple calls to this function will only create one instance of Sanitizer during
@@ -77,8 +74,6 @@ func createDefaultPolicy() *bluemonday.Policy {
 	// Custom URL-Schemes
 	if len(setting.Markdown.CustomURLSchemes) > 0 {
 		policy.AllowURLSchemes(setting.Markdown.CustomURLSchemes...)
-	} else {
-		policy.AllowURLSchemesMatching(allowAllRegex)
 	}
 
 	// Allow classes for anchors

--- a/modules/markup/sanitizer_test.go
+++ b/modules/markup/sanitizer_test.go
@@ -52,10 +52,6 @@ func Test_Sanitizer(t *testing.T) {
 		`<span style="bad-color: red">Hello World</span>`, `<span>Hello World</span>`,
 		`<p style="bad-color: red">Hello World</p>`, `<p>Hello World</p>`,
 		`<code style="bad-color: red">Hello World</code>`, `<code>Hello World</code>`,
-
-		// URLs
-		`[my custom URL scheme](cbthunderlink://somebase64string)`, `[my custom URL scheme](cbthunderlink://somebase64string)`,
-		`[my custom URL scheme](matrix:roomid/psumPMeAfzgAeQpXMG:feneas.org?action=join)`, `[my custom URL scheme](matrix:roomid/psumPMeAfzgAeQpXMG:feneas.org?action=join)`,
 	}
 
 	for i := 0; i < len(testCases); i += 2 {


### PR DESCRIPTION
I made a mistake for  #24805

And the tests cases didn't work because the "custom schemes" affect "render" but not "sanitizer"

This PR reverts to the old behavior, add more comments, and fix the tests.