### PR TITLE
avoid hard-coding height in language dropdown menu

### DIFF
--- a/web_src/css/home.css
+++ b/web_src/css/home.css
@@ -74,8 +74,7 @@
 }
 
 .page-footer .ui.dropdown.language .menu {
-  height: 500px;
-  max-height: calc(100vh - 60px);
+  max-height: min(500px, calc(100vh - 60px));
   overflow-y: auto;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
This commit removes the hard-coded height of 500px, using that as a max-height instead. The height of items in the dropdown menu, assuming a default font size of 16px, is 36px, so the old CSS would cause overly large dropdown menus in instances where less than 14 languages are offered.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1000
