### PR TITLE
Improve profile readme rendering

### DIFF
--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -232,7 +232,11 @@ func prepareUserProfileTabData(ctx *context.Context, showPrivate bool, profileGi
 		if bytes, err := profileReadme.GetBlobContent(setting.UI.MaxDisplayFileSize); err != nil {
 			log.Error("failed to GetBlobContent: %v", err)
 		} else {
-			if profileContent, err := markdown.RenderString(&markup.RenderContext{Ctx: ctx, GitRepo: profileGitRepo}, bytes); err != nil {
+			if profileContent, err := markdown.RenderString(&markup.RenderContext{
+				Ctx:     ctx,
+				GitRepo: profileGitRepo,
+				Metas:   map[string]string{"mode": "document"},
+			}, bytes); err != nil {
 				log.Error("failed to RenderString: %v", err)
 			} else {
 				ctx.Data["ProfileReadme"] = profileContent

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -122,7 +122,7 @@
 }
 
 #readme_profile {
-  padding: 10px;
+  padding: 1em 2em;
   border-radius: 0.28571429rem;
   background: var(--color-card);
   border: 1px solid var(--color-secondary);


### PR DESCRIPTION
- Tell the renderer to use the `document` mode, so it's consistent with other renderers.
- Use the same padding as `.file-view.markup`, so it's consistent with other containers that contain markup rendering.
- Resolves https://codeberg.org/forgejo/forgejo/issues/833
