### PR TITLE
Fix commit status color on dashboard repolist

### DIFF
--- a/web_src/js/components/DashboardRepoList.vue
+++ b/web_src/js/components/DashboardRepoList.vue
@@ -153,7 +153,7 @@ import {SvgIcon} from '../svg.js';
 const {appSubUrl, assetUrlPrefix, pageData} = window.config;
 
 const commitStatus = {
-  pending: {name: 'octicon-dot-fill', color: 'grey'},
+  pending: {name: 'octicon-dot-fill', color: 'yellow'},
   running: {name: 'octicon-dot-fill', color: 'yellow'},
   success: {name: 'octicon-check', color: 'green'},
   error: {name: 'gitea-exclamation', color: 'red'},


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/pull/25935 which has missed to change the icon on the repolist because the logic is not shared with templates.