### PR TITLE
Add a link to OpenID Issuer URL in WebFinger response

### DIFF
--- a/routers/web/webfinger.go
+++ b/routers/web/webfinger.go
@@ -106,6 +106,10 @@ func WebfingerQuery(ctx *context.Context) {
 			Type: "application/activity+json",
 			Href: appURL.String() + "api/v1/activitypub/user-id/" + fmt.Sprint(u.ID),
 		},
+		{
+			Rel:  "http://openid.net/specs/connect/1.0/issuer",
+			Href: appURL.String(),
+		},
 	}
 
 	ctx.Resp.Header().Add("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
This change adds an entry to the `links` field of the `/.well-known/webfinger` response. The new entry points to the `appURL` as an OpenID issuer. This is consistent with the output of `/.well-known/openid-configuration`, which also uses the value of `appURL`.

This change is required for Tailscale SSO to work, as it uses the OpenID Issuer URL when querying the Tailscale user email during signup/login ([docs](https://tailscale.com/kb/1240/sso-custom-oidc/#webfinger-setup)).
