### PR TITLE
Fix awesome-gitea link in 1.19

### DIFF
--- a/docs/content/page/index.en-us.md
+++ b/docs/content/page/index.en-us.md
@@ -301,4 +301,4 @@ You can try it out using [the online demo](https://try.gitea.io/).
 
 ## Integrated support
 
- Please visit [AWESOME GITEA] (https://gitea.com/gitea/awesome-gitea/) to get more third-party integrated support
+ Please visit [Awesome Gitea](https://gitea.com/gitea/awesome-gitea/) to get more third-party integrated support


### PR DESCRIPTION
As title, we still pull the docs for `1.19`.