### PR TITLE
do not use deprecatedSettingFatal for cosmetic reasons

### DIFF
--- a/modules/setting/config_provider.go
+++ b/modules/setting/config_provider.go
@@ -322,12 +322,6 @@ func deprecatedSetting(rootCfg ConfigProvider, oldSection, oldKey, newSection, n
 	}
 }
 
-func deprecatedSettingFatal(rootCfg ConfigProvider, oldSection, oldKey, newSection, newKey, version string) {
-	if rootCfg.Section(oldSection).HasKey(oldKey) {
-		log.Fatal("Deprecated fallback `[%s]` `%s` present. Use `[%s]` `%s` instead. This fallback will be/has been removed in %s. Shutting down", oldSection, oldKey, newSection, newKey, version)
-	}
-}
-
 // deprecatedSettingDB add a hint that the configuration has been moved to database but still kept in app.ini
 func deprecatedSettingDB(rootCfg ConfigProvider, oldSection, oldKey string) {
 	if rootCfg.Section(oldSection).HasKey(oldKey) {

--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -34,7 +34,14 @@ func loadLFSFrom(rootCfg ConfigProvider) error {
 	// Specifically default PATH to LFS_CONTENT_PATH
 	// DEPRECATED should not be removed because users maybe upgrade from lower version to the latest version
 	// if these are removed, the warning will not be shown
-	deprecatedSettingFatal(rootCfg, "server", "LFS_CONTENT_PATH", "lfs", "PATH", "v1.19.0")
+	deprecatedSetting(rootCfg, "server", "LFS_CONTENT_PATH", "lfs", "PATH", "v1.19.0")
+
+	if val := sec.Key("LFS_CONTENT_PATH").String(); val != "" {
+		if lfsSec == nil {
+			lfsSec = rootCfg.Section("lfs")
+		}
+		lfsSec.Key("PATH").MustString(val)
+	}
 
 	var err error
 	LFS.Storage, err = getStorage(rootCfg, "lfs", "", lfsSec)

--- a/modules/setting/lfs_test.go
+++ b/modules/setting/lfs_test.go
@@ -22,6 +22,30 @@ func Test_getStorageInheritNameSectionTypeForLFS(t *testing.T) {
 	assert.EqualValues(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
 
 	iniStr = `
+[server]
+LFS_CONTENT_PATH = path_ignored
+[lfs]
+PATH = path_used
+`
+	cfg, err = NewConfigProviderFromData(iniStr)
+	assert.NoError(t, err)
+	assert.NoError(t, loadLFSFrom(cfg))
+
+	assert.EqualValues(t, "local", LFS.Storage.Type)
+	assert.Contains(t, LFS.Storage.Path, "path_used")
+
+	iniStr = `
+[server]
+LFS_CONTENT_PATH = deprecatedpath
+`
+	cfg, err = NewConfigProviderFromData(iniStr)
+	assert.NoError(t, err)
+	assert.NoError(t, loadLFSFrom(cfg))
+
+	assert.EqualValues(t, "local", LFS.Storage.Type)
+	assert.Contains(t, LFS.Storage.Path, "deprecatedpath")
+
+	iniStr = `
 [storage.lfs]
 STORAGE_TYPE = minio
 `


### PR DESCRIPTION
It breaks existing instances that would otherwise work perfectly fine. Failing to start an instance should only happen when there is a compelling reason to do so, for instance if the `app.ini` could not be modified in a way that is backward compatible. If the only motivation is to remove the setting for cosmetic reason, it must not be fatal.
