### PR TITLE
Remove redundant "RouteMethods" method

### DIFF
--- a/modules/web/route.go
+++ b/modules/web/route.go
@@ -101,7 +101,7 @@ func (r *Route) wrapMiddlewareAndHandler(h []any) ([]func(http.Handler) http.Han
 	return middlewares, handlerFunc
 }
 
-func (r *Route) Methods(method, pattern string, h []any) {
+func (r *Route) Methods(method, pattern string, h ...any) {
 	middlewares, handlerFunc := r.wrapMiddlewareAndHandler(h)
 	fullPattern := r.getPattern(pattern)
 	if strings.Contains(method, ",") {
@@ -126,49 +126,44 @@ func (r *Route) Any(pattern string, h ...any) {
 	r.R.With(middlewares...).HandleFunc(r.getPattern(pattern), handlerFunc)
 }
 
-// RouteMethods delegate special methods, it is an alias of "Methods", while the "pattern" is the first parameter
-func (r *Route) RouteMethods(pattern, methods string, h ...any) {
-	r.Methods(methods, pattern, h)
-}
-
 // Delete delegate delete method
 func (r *Route) Delete(pattern string, h ...any) {
-	r.Methods("DELETE", pattern, h)
+	r.Methods("DELETE", pattern, h...)
 }
 
 // Get delegate get method
 func (r *Route) Get(pattern string, h ...any) {
-	r.Methods("GET", pattern, h)
+	r.Methods("GET", pattern, h...)
 }
 
 // GetOptions delegate get and options method
 func (r *Route) GetOptions(pattern string, h ...any) {
-	r.Methods("GET,OPTIONS", pattern, h)
+	r.Methods("GET,OPTIONS", pattern, h...)
 }
 
 // PostOptions delegate post and options method
 func (r *Route) PostOptions(pattern string, h ...any) {
-	r.Methods("POST,OPTIONS", pattern, h)
+	r.Methods("POST,OPTIONS", pattern, h...)
 }
 
 // Head delegate head method
 func (r *Route) Head(pattern string, h ...any) {
-	r.Methods("HEAD", pattern, h)
+	r.Methods("HEAD", pattern, h...)
 }
 
 // Post delegate post method
 func (r *Route) Post(pattern string, h ...any) {
-	r.Methods("POST", pattern, h)
+	r.Methods("POST", pattern, h...)
 }
 
 // Put delegate put method
 func (r *Route) Put(pattern string, h ...any) {
-	r.Methods("PUT", pattern, h)
+	r.Methods("PUT", pattern, h...)
 }
 
 // Patch delegate patch method
 func (r *Route) Patch(pattern string, h ...any) {
-	r.Methods("PATCH", pattern, h)
+	r.Methods("PATCH", pattern, h...)
 }
 
 // ServeHTTP implements http.Handler

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -634,7 +634,7 @@ func ContainerRoutes() *web.Route {
 		)
 
 		// Manual mapping of routes because {image} can contain slashes which chi does not support
-		r.RouteMethods("/*", "HEAD,GET,POST,PUT,PATCH,DELETE", func(ctx *context.Context) {
+		r.Methods("HEAD,GET,POST,PUT,PATCH,DELETE", "/*", func(ctx *context.Context) {
 			path := ctx.Params("*")
 			isHead := ctx.Req.Method == "HEAD"
 			isGet := ctx.Req.Method == "GET"

--- a/routers/install/routes.go
+++ b/routers/install/routes.go
@@ -20,7 +20,7 @@ import (
 func Routes() *web.Route {
 	base := web.NewRoute()
 	base.Use(common.ProtocolMiddlewares()...)
-	base.RouteMethods("/assets/*", "GET, HEAD", public.AssetsHandlerFunc("/assets/"))
+	base.Methods("GET, HEAD", "/assets/*", public.AssetsHandlerFunc("/assets/"))
 
 	r := web.NewRoute()
 	r.Use(common.Sessioner(), Contexter())

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -108,12 +108,12 @@ func Routes() *web.Route {
 	routes := web.NewRoute()
 
 	routes.Head("/", misc.DummyOK) // for health check - doesn't need to be passed through gzip handler
-	routes.RouteMethods("/assets/*", "GET, HEAD", CorsHandler(), public.AssetsHandlerFunc("/assets/"))
-	routes.RouteMethods("/avatars/*", "GET, HEAD", storageHandler(setting.Avatar.Storage, "avatars", storage.Avatars))
-	routes.RouteMethods("/repo-avatars/*", "GET, HEAD", storageHandler(setting.RepoAvatar.Storage, "repo-avatars", storage.RepoAvatars))
-	routes.RouteMethods("/apple-touch-icon.png", "GET, HEAD", misc.StaticRedirect("/assets/img/apple-touch-icon.png"))
-	routes.RouteMethods("/apple-touch-icon-precomposed.png", "GET, HEAD", misc.StaticRedirect("/assets/img/apple-touch-icon.png"))
-	routes.RouteMethods("/favicon.ico", "GET, HEAD", misc.StaticRedirect("/assets/img/favicon.png"))
+	routes.Methods("GET, HEAD", "/assets/*", CorsHandler(), public.AssetsHandlerFunc("/assets/"))
+	routes.Methods("GET, HEAD", "/avatars/*", storageHandler(setting.Avatar.Storage, "avatars", storage.Avatars))
+	routes.Methods("GET, HEAD", "/repo-avatars/*", storageHandler(setting.RepoAvatar.Storage, "repo-avatars", storage.RepoAvatars))
+	routes.Methods("GET, HEAD", "/apple-touch-icon.png", misc.StaticRedirect("/assets/img/apple-touch-icon.png"))
+	routes.Methods("GET, HEAD", "/apple-touch-icon-precomposed.png", misc.StaticRedirect("/assets/img/apple-touch-icon.png"))
+	routes.Methods("GET, HEAD", "/favicon.ico", misc.StaticRedirect("/assets/img/favicon.png"))
 
 	_ = templates.HTMLRenderer()
 
@@ -129,7 +129,7 @@ func Routes() *web.Route {
 
 	if setting.Service.EnableCaptcha {
 		// The captcha http.Handler should only fire on /captcha/* so we can just mount this on that url
-		routes.RouteMethods("/captcha/*", "GET,HEAD", append(mid, captcha.Captchaer(context.GetImageCaptcha()))...)
+		routes.Methods("GET,HEAD", "/captcha/*", append(mid, captcha.Captchaer(context.GetImageCaptcha()))...)
 	}
 
 	if setting.HasRobotsTxt {
@@ -773,7 +773,7 @@ func registerRoutes(m *web.Route) {
 					addSettingVariablesRoutes()
 				}, actions.MustEnableActions)
 
-				m.RouteMethods("/delete", "GET,POST", org.SettingsDelete)
+				m.Methods("GET,POST", "/delete", org.SettingsDelete)
 
 				m.Group("/packages", func() {
 					m.Get("", org.Packages)


### PR DESCRIPTION
The `RouteMethods` is mainly an alias for `Methods` with different argument order.

Remove it to keep the "route.go" code clear