### PR TITLE
Increase table cell padding, use icons in admin table headers

### DIFF
--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -19,21 +19,25 @@
 							{{.locale.Tr "admin.repos.name"}}
 							{{SortArrow "alphabetically" "reversealphabetically" $.SortType false}}
 						</th>
-						<th>{{.locale.Tr "admin.repos.watches"}}</th>
-						<th  data-sortt-asc="moststars" data-sortt-desc="feweststars">
-							{{.locale.Tr "admin.repos.stars"}}
+						<th data-tooltip-content="{{.locale.Tr "admin.repos.watches"}}">
+							{{svg "octicon-eye"}}
+						</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.repos.stars"}}" data-sortt-asc="moststars" data-sortt-desc="feweststars">
+							{{svg "octicon-star"}}
 							{{SortArrow "moststars" "feweststars" $.SortType false}}
 						</th>
-						<th  data-sortt-asc="mostforks" data-sortt-desc="fewestforks">
-							{{.locale.Tr "admin.repos.forks"}}
+						<th data-tooltip-content="{{.locale.Tr "admin.repos.forks"}}" data-sortt-asc="mostforks" data-sortt-desc="fewestforks">
+							{{svg "octicon-repo-forked"}}
 							{{SortArrow "mostforks" "fewestforks" $.SortType false}}
 						</th>
-						<th>{{.locale.Tr "admin.repos.issues"}}</th>
-						<th  data-sortt-asc="gitsize" data-sortt-desc="reversegitsize">
+						<th data-tooltip-content="{{.locale.Tr "admin.repos.issues"}}">
+							{{svg "octicon-issue-opened"}}
+						</th>
+						<th data-sortt-asc="gitsize" data-sortt-desc="reversegitsize">
 							{{.locale.Tr "admin.repos.size"}}
 							{{SortArrow "gitsize" "reversegitsize" $.SortType false}}
 						</th>
-						<th  data-sortt-asc="lfssize" data-sortt-desc="reverselfssize">
+						<th data-sortt-asc="lfssize" data-sortt-desc="reverselfssize">
 							{{.locale.Tr "admin.repos.lfs_size"}}
 							{{SortArrow "lfssize" "reverselfssize" $.SortType false}}
 						</th>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -67,11 +67,21 @@
 							{{SortArrow "alphabetically" "reversealphabetically" $.SortType true}}
 						</th>
 						<th>{{.locale.Tr "email"}}</th>
-						<th>{{.locale.Tr "admin.users.activated"}}</th>
-						<th>{{.locale.Tr "admin.users.admin"}}</th>
-						<th>{{.locale.Tr "admin.users.restricted"}}</th>
-						<th>{{.locale.Tr "admin.users.2fa"}}</th>
-						<th>{{.locale.Tr "admin.users.repos"}}</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.users.activated"}}">
+							{{svg "octicon-check-circle"}}
+						</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.users.admin"}}">
+							{{svg "octicon-gear"}}
+						</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.users.restricted"}}">
+							{{svg "octicon-skip"}}
+						</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.users.2fa"}}">
+							{{svg "octicon-key"}}
+						</th>
+						<th data-tooltip-content="{{.locale.Tr "admin.users.repos"}}">
+							{{svg "octicon-repo"}}
+						</th>
 						<th>{{.locale.Tr "admin.users.created"}}</th>
 						<th data-sortt-asc="lastlogin" data-sortt-desc="reverselastlogin">
 							{{.locale.Tr "admin.users.last_login"}}

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -883,7 +883,7 @@ a.label,
 .ui.table > thead > tr > th,
 .ui.table > tbody > tr > td,
 .ui.table > tr > td {
-  padding: 6px 3px;
+  padding: 6px;
 }
 /* use more horizontal padding on first and last items for visuals */
 .ui.table > thead > tr > th:first-of-type,

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -883,7 +883,7 @@ a.label,
 .ui.table > thead > tr > th,
 .ui.table > tbody > tr > td,
 .ui.table > tr > td {
-  padding: 6px;
+  padding: 6px 5px;
 }
 /* use more horizontal padding on first and last items for visuals */
 .ui.table > thead > tr > th:first-of-type,


### PR DESCRIPTION
- Increase table cell horizonzal padding from 3px to 5px
- Add icons to user and repo list in admin tables

Fixes: https://github.com/go-gitea/gitea/issues/25939

<img width="972" alt="Screenshot 2023-07-21 at 18 29 09" src="https://github.com/go-gitea/gitea/assets/115237/f49336bb-7662-4a7c-87f0-dff1dc2bace4">
<img width="979" alt="Screenshot 2023-07-21 at 18 29 16" src="https://github.com/go-gitea/gitea/assets/115237/ac453971-d8e4-4019-8bb2-a4d66446b20d">

Each icon has a tooltip:

<img width="121" alt="Screenshot 2023-07-21 at 18 30 48" src="https://github.com/go-gitea/gitea/assets/115237/8080f2aa-6636-486b-aeab-6c440c6a03ec">

Sorting works as usual:

<img width="179" alt="Screenshot 2023-07-21 at 18 31 31" src="https://github.com/go-gitea/gitea/assets/115237/5d89dd2a-fbc8-4c95-b954-0eee21dcbf77">

Could be backported. Open for better ideas for icons.