### PR TITLE
Add missing default value for some Bool cli flags

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -298,10 +298,12 @@ var (
 		&cli.BoolFlag{
 			Name:  "force-smtps",
 			Usage: "SMTPS is always used on port 465. Set this to force SMTPS on other ports.",
+			Value: true,
 		},
 		&cli.BoolFlag{
 			Name:  "skip-verify",
 			Usage: "Skip TLS verify.",
+			Value: true,
 		},
 		&cli.StringFlag{
 			Name:  "helo-hostname",
@@ -311,6 +313,7 @@ var (
 		&cli.BoolFlag{
 			Name:  "disable-helo",
 			Usage: "Disable SMTP helo.",
+			Value: true,
 		},
 		&cli.StringFlag{
 			Name:  "allowed-domains",
@@ -320,10 +323,12 @@ var (
 		&cli.BoolFlag{
 			Name:  "skip-local-2fa",
 			Usage: "Skip 2FA to log on.",
+			Value: true,
 		},
 		&cli.BoolFlag{
 			Name:  "active",
 			Usage: "This Authentication Source is Activated.",
+			Value: true,
 		},
 	}
 

--- a/cmd/manager_logging.go
+++ b/cmd/manager_logging.go
@@ -117,6 +117,7 @@ var (
 								Name:    "rotate",
 								Aliases: []string{"r"},
 								Usage:   "Rotate logs",
+								Value:   true,
 							},
 							&cli.Int64Flag{
 								Name:    "max-size",
@@ -127,6 +128,7 @@ var (
 								Name:    "daily",
 								Aliases: []string{"d"},
 								Usage:   "Rotate logs daily",
+								Value:   true,
 							},
 							&cli.IntFlag{
 								Name:    "max-days",
@@ -137,6 +139,7 @@ var (
 								Name:    "compress",
 								Aliases: []string{"z"},
 								Usage:   "Compress rotated logs",
+								Value:   true,
 							},
 							&cli.IntFlag{
 								Name:    "compression-level",


### PR DESCRIPTION
In #25959 I forgot to add default values to some Bool flags (which were BoolT in cli/v1, BoolT means default to be true)

This PR adds the default "Value" for them.

```
./cmd/manager_logging.go:							}, cli.BoolTFlag{
./cmd/manager_logging.go-								Name:  "rotate, r",
./cmd/manager_logging.go-								Usage: "Rotate logs",
--
./cmd/manager_logging.go:							}, cli.BoolTFlag{
./cmd/manager_logging.go-								Name:  "daily, d",
./cmd/manager_logging.go-								Usage: "Rotate logs daily",
--
./cmd/manager_logging.go:							}, cli.BoolTFlag{
./cmd/manager_logging.go-								Name:  "compress, z",
./cmd/manager_logging.go-								Usage: "Compress rotated logs",
--
./cmd/admin.go:		cli.BoolTFlag{
./cmd/admin.go-			Name:  "force-smtps",
./cmd/admin.go-			Usage: "SMTPS is always used on port 465. Set this to force SMTPS on other ports.",
--
./cmd/admin.go:		cli.BoolTFlag{
./cmd/admin.go-			Name:  "skip-verify",
./cmd/admin.go-			Usage: "Skip TLS verify.",
--
./cmd/admin.go:		cli.BoolTFlag{
./cmd/admin.go-			Name:  "disable-helo",
./cmd/admin.go-			Usage: "Disable SMTP helo.",
--
./cmd/admin.go:		cli.BoolTFlag{
./cmd/admin.go-			Name:  "skip-local-2fa",
./cmd/admin.go-			Usage: "Skip 2FA to log on.",
--
./cmd/admin.go:		cli.BoolTFlag{
./cmd/admin.go-			Name:  "active",
./cmd/admin.go-			Usage: "This Authentication Source is Activated.",
```