### PR TITLE
Fixing redirection issue for logged-in users

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -374,12 +374,10 @@ func registerRoutes(m *web.Route) {
 	m.Get("/milestones", reqSignIn, reqMilestonesDashboardPageEnabled, user.Milestones)
 
 	// ***** START: User *****
-	// Group without signOut required to allow logged-in users to access this route for redirection purposes
+	// "user/login" doesn't need signOut, then logged-in users can still access this route for redirection purposes by "/user/login?redirec_to=..."
+	m.Get("/user/login", auth.SignIn)
 	m.Group("/user", func() {
-		m.Get("/login", auth.SignIn)
 		m.Post("/login", web.Bind(forms.SignInForm{}), auth.SignInPost)
-	})
-	m.Group("/user", func() {
 		m.Group("", func() {
 			m.Combo("/login/openid").
 				Get(auth.SignInOpenID).

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -374,9 +374,12 @@ func registerRoutes(m *web.Route) {
 	m.Get("/milestones", reqSignIn, reqMilestonesDashboardPageEnabled, user.Milestones)
 
 	// ***** START: User *****
+	// Group without signOut required to allow logged-in users to access this route for redirection purposes
 	m.Group("/user", func() {
 		m.Get("/login", auth.SignIn)
 		m.Post("/login", web.Bind(forms.SignInForm{}), auth.SignInPost)
+	})
+	m.Group("/user", func() {
 		m.Group("", func() {
 			m.Combo("/login/openid").
 				Get(auth.SignInOpenID).


### PR DESCRIPTION
This PR addresses an issue where logged-in users get redirected to the homepage when trying to access a URL with the redirect_to parameter. The issue was traced back to a middleware function in services/auth/middleware.go that redirects logged-in users to the homepage. This function didn't account the redirect_to parameter.

The fix modifies the middleware function to check for this case and redirect the user to the specified URL instead of the homepage.

Closes: #26005 

