### PR TITLE
Avoid writing config file if not installed

### DIFF
--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -58,7 +58,7 @@ func loadLFSFrom(rootCfg ConfigProvider) error {
 	LFS.JWTSecretBytes = make([]byte, 32)
 	n, err := base64.RawURLEncoding.Decode(LFS.JWTSecretBytes, []byte(LFS.JWTSecretBase64))
 
-	if err != nil || n != 32 {
+	if (err != nil || n != 32) && InstallLock {
 		LFS.JWTSecretBase64, err = generate.NewJwtSecretBase64()
 		if err != nil {
 			return fmt.Errorf("error generating JWT Secret for custom config: %v", err)


### PR DESCRIPTION
Just like others (oauth2 secret, internal token, etc), do not generate if no install lock