### PR TITLE
Fix loading `LFS_JWT_SECRET` from wrong section

### DIFF
--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -53,7 +53,7 @@ func loadLFSFrom(rootCfg ConfigProvider) error {
 		return nil
 	}
 
-	LFS.JWTSecretBase64 = loadSecret(rootCfg.Section("lfs"), "LFS_JWT_SECRET_URI", "LFS_JWT_SECRET")
+	LFS.JWTSecretBase64 = loadSecret(rootCfg.Section("server"), "LFS_JWT_SECRET_URI", "LFS_JWT_SECRET")
 
 	LFS.JWTSecretBytes = make([]byte, 32)
 	n, err := base64.RawURLEncoding.Decode(LFS.JWTSecretBytes, []byte(LFS.JWTSecretBase64))


### PR DESCRIPTION
Regression of #25408.

`LFS_JWT_SECRET_URI` and `LFS_JWT_SECRET` are under the `server` section, not `lfs`.

So each time gitea restarts, it resets `LFS_JWT_SECRET`.

<img width="1378" alt="image" src="https://github.com/go-gitea/gitea/assets/9418365/527ec9b9-eea2-4334-a274-6d1471456edd">
