### PR TITLE
Add a new parameter for load configuration function to allow or not exist file

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -146,7 +146,7 @@ func serveInstall(ctx *cli.Context) error {
 }
 
 func serveInstalled(ctx *cli.Context) error {
-	setting.InitCfgProvider(setting.CustomConf)
+	setting.InitCfgProvider(setting.CustomConf, false)
 	setting.LoadCommonSettings()
 	setting.MustInstalled()
 

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -43,12 +43,12 @@ func fatalTestError(fmtStr string, args ...any) {
 }
 
 // InitSettings initializes config provider and load common settings for tests
-func InitSettings(extraConfigs ...string) {
+func InitSettings() {
 	if setting.CustomConf == "" {
 		setting.CustomConf = filepath.Join(setting.CustomPath, "conf/app-unittest-tmp.ini")
 		_ = os.Remove(setting.CustomConf)
 	}
-	setting.InitCfgProvider(setting.CustomConf, strings.Join(extraConfigs, "\n"))
+	setting.InitCfgProvider(setting.CustomConf, true)
 	setting.LoadCommonSettings()
 
 	if err := setting.PrepareAppDataPath(); err != nil {

--- a/modules/setting/path.go
+++ b/modules/setting/path.go
@@ -170,7 +170,7 @@ func InitWorkPathAndCfgProvider(getEnvFn func(name string) string, args ArgWorkP
 	}
 
 	// only read the config but do not load/init anything more, because the AppWorkPath and CustomPath are not ready
-	InitCfgProvider(tmpCustomConf.Value)
+	InitCfgProvider(tmpCustomConf.Value, false)
 	if HasInstallLock(CfgProvider) {
 		ClearEnvConfigKeys() // if the instance has been installed, do not pass the environment variables to sub-processes
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -90,9 +90,9 @@ func PrepareAppDataPath() error {
 	return nil
 }
 
-func InitCfgProvider(file string, extraConfigs ...string) {
+func InitCfgProvider(file string, allowNotExist bool) {
 	var err error
-	if CfgProvider, err = NewConfigProviderFromFile(file, extraConfigs...); err != nil {
+	if CfgProvider, err = NewConfigProviderFromFile(file, allowNotExist); err != nil {
 		log.Fatal("Unable to init config provider from %q: %v", file, err)
 	}
 	CfgProvider.DisableSaving() // do not allow saving the CfgProvider into file, it will be polluted by the "MustXxx" calls

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -373,7 +373,7 @@ func SubmitInstall(ctx *context.Context) {
 	}
 
 	// Save settings.
-	cfg, err := setting.NewConfigProviderFromFile(setting.CustomConf)
+	cfg, err := setting.NewConfigProviderFromFile(setting.CustomConf, true)
 	if err != nil {
 		log.Error("Failed to load custom conf '%s': %v", setting.CustomConf, err)
 	}
@@ -519,7 +519,7 @@ func SubmitInstall(ctx *context.Context) {
 	// ---- All checks are passed
 
 	// Reload settings (and re-initialize database connection)
-	setting.InitCfgProvider(setting.CustomConf)
+	setting.InitCfgProvider(setting.CustomConf, false)
 	setting.LoadCommonSettings()
 	setting.MustInstalled()
 	setting.LoadDBSetting()


### PR DESCRIPTION
We should ensure the configuration file does exist in some situation but not ignore it. Otherwise, it may result in unknow result. i.e. when it saves back to disk, all old configuration items maybe missed.