### PR TITLE
Prevent primary key update on migration

### DIFF
--- a/models/migrations/v1_20/v250.go
+++ b/models/migrations/v1_20/v250.go
@@ -20,7 +20,7 @@ func ChangeContainerMetadataMultiArch(x *xorm.Engine) error {
 	}
 
 	type PackageVersion struct {
-		ID           int64  `xorm:"pk"`
+		ID           int64  `xorm:"pk autoincr"`
 		MetadataJSON string `xorm:"metadata_json"`
 	}
 


### PR DESCRIPTION
Fixes #25918

The migration fails on MSSQL because xorm tries to update the primary key column. xorm prevents this if the column is marked as auto increment:
https://gitea.com/xorm/xorm/src/commit/c622cdaf893fbfe3f40a6b79f6bc17ee10f53865/internal/statements/update.go#L38-L40

I think it would be better if xorm would check for primary key columns here because updating such columns is bad practice. It looks like if that auto increment check should do the same.

fyi @lunny