### PR TITLE
Introduce pull request commit view files page

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -758,7 +758,7 @@ func ViewPullCommitFiles(ctx *context.Context) {
 		return
 	}
 
-	var index int = -1
+	index := -1
 	for i, commit := range prInfo.Commits {
 		if commit.ID.String() == ctx.Params("sha") {
 			index = i

--- a/routers/web/repo/pull_review.go
+++ b/routers/web/repo/pull_review.go
@@ -160,7 +160,7 @@ func UpdateResolveConversation(ctx *context.Context) {
 }
 
 func renderConversation(ctx *context.Context, comment *issues_model.Comment) {
-	comments, err := issues_model.FetchCodeCommentsByLine(ctx, comment.Issue, ctx.Doer, comment.TreePath, comment.Line, ctx.Data["ShowOutdatedComments"].(bool))
+	comments, err := issues_model.FetchCodeCommentsByLine(ctx, comment.Issue, ctx.Doer, comment.TreePath, comment.Line, showOutdatedComments(ctx))
 	if err != nil {
 		ctx.ServerError("FetchCodeCommentsByLine", err)
 		return

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1280,6 +1280,7 @@ func registerRoutes(m *web.Route) {
 			m.Get(".diff", repo.DownloadPullDiff)
 			m.Get(".patch", repo.DownloadPullPatch)
 			m.Get("/commits", context.RepoRef(), repo.SetWhitespaceBehavior, repo.GetPullDiffStats, repo.ViewPullCommits)
+			m.Get("/commits/{sha}", context.RepoRef(), repo.SetWhitespaceBehavior, repo.GetPullDiffStats, repo.ViewPullCommitFiles)
 			m.Post("/merge", context.RepoMustNotBeArchived(), web.Bind(forms.MergePullRequestForm{}), repo.MergePullRequest)
 			m.Post("/cancel_auto_merge", context.RepoMustNotBeArchived(), repo.CancelAutoMergePullRequest)
 			m.Post("/update", repo.UpdatePullRequest)

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -43,6 +43,8 @@
 							{{end}}
 							{{if $.PageIsWiki}}
 								<a href="{{$commitRepoLink}}/wiki/commit/{{.ID}}" rel="nofollow" class="{{$class}}">
+							{{else if $.PageIsPullCommits}}
+								<a href="{{$commitRepoLink}}/pulls/{{$.Issue.Index}}/commits/{{.ID}}" rel="nofollow" class="{{$class}}">
 							{{else if $.Reponame}}
 								<a href="{{$commitRepoLink}}/commit/{{.ID}}" rel="nofollow" class="{{$class}}">
 							{{else}}


### PR DESCRIPTION
This PR introduce a new page for view commit changes in a pull request. Before this PR, when click some commit in the commits list page of a pull request, it will jump to a commit view page. But now it will show in this pull request like GH did.

related to #25528
Before:

<img width="1893" alt="图片" src="https://github.com/go-gitea/gitea/assets/81045/709973cd-ecc4-4073-bceb-f38b08b0941a">


After:

<img width="1891" alt="图片" src="https://github.com/go-gitea/gitea/assets/81045/eacd8d66-55f0-4886-9b68-c33e722986dc">

This also avoids pull request commits have blank branches and tags listed.

<img width="321" alt="图片" src="https://github.com/go-gitea/gitea/assets/81045/7cc8d0ce-bd06-49d4-aa94-7699d6dc369d">
