### PR TITLE
Hide branch/tag icon if branches/tags are empty

### DIFF
--- a/web_src/js/features/repo-diff-commit.js
+++ b/web_src/js/features/repo-diff-commit.js
@@ -16,7 +16,7 @@ async function loadBranchesAndTags(area, loadingButton) {
 
 function addTags(area, tags) {
   const tagArea = area.querySelector('.tag-area');
-  toggleElem(tagArea, tags.length > 0);
+  toggleElem(tagArea.parentElement, tags.length > 0);
   for (const tag of tags) {
     addLink(tagArea, tag.web_link, tag.name);
   }
@@ -25,7 +25,7 @@ function addTags(area, tags) {
 function addBranches(area, branches, defaultBranch) {
   const defaultBranchTooltip = area.getAttribute('data-text-default-branch-tooltip');
   const branchArea = area.querySelector('.branch-area');
-  toggleElem(branchArea, branches.length > 0);
+  toggleElem(branchArea.parentElement, branches.length > 0);
   for (const branch of branches) {
     const tooltip = defaultBranch === branch.name ? defaultBranchTooltip : null;
     addLink(branchArea, branch.web_link, branch.name, tooltip);


### PR DESCRIPTION
A bug was introduced by me in #25180 when iterating the layout for different preferences .....

The branch/tag isn't hidden correctly if there is no branch/tag.

This PR fixes it.


Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/748b42c5-adb6-4cd4-8485-a22b5198d443)

After:

![image](https://github.com/go-gitea/gitea/assets/2114189/e42ae3b8-2352-4f4d-9366-d3c5b6aae11e)