### PR TITLE
Fixed incorrect locale references

### DIFF
--- a/templates/repo/settings/navbar.tmpl
+++ b/templates/repo/settings/navbar.tmpl
@@ -1,6 +1,6 @@
 <div class="four wide column">
 	<div class="ui fluid vertical menu">
-		<div class="header item">{{.locale.Tr "org.settings"}}</div>
+		<div class="header item">{{.locale.Tr "repo.settings"}}</div>
 		<a class="{{if .PageIsSettingsOptions}}active {{end}}item" href="{{.RepoLink}}/settings">
 			{{.locale.Tr "repo.settings.options"}}
 		</a>

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -1,6 +1,6 @@
 <div class="four wide column">
 	<div class="ui fluid vertical menu">
-		<div class="header item">{{.locale.Tr "org.settings"}}</div>
+		<div class="header item">{{.locale.Tr "settings"}}</div>
 		<a class="{{if .PageIsSettingsProfile}}active {{end}}item" href="{{AppSubUrl}}/user/settings">
 			{{.locale.Tr "settings.profile"}}
 		</a>


### PR DESCRIPTION
Fixed two incorrect headers for setting the page navigation bar:
* User settings page, should not use the title "`org.settings`"
* Repo settings page, should not use the title "`org.settings`"