### PR TITLE
Add `/public/assets` to `.ignore`

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -5,4 +5,5 @@
 /modules/public/bindata.go
 /modules/templates/bindata.go
 /vendor
+/public/assets
 node_modules


### PR DESCRIPTION
Ignore compiled assets when searching via ripgrep and similar search tools.