### PR TITLE
Fix due date rendering the wrong date in issue

### DIFF
--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -374,7 +374,7 @@
 				<div class="gt-df gt-sb gt-ac">
 					<div class="due-date {{if .Issue.IsOverdue}}text red{{end}}" {{if .Issue.IsOverdue}}data-tooltip-content="{{.locale.Tr "repo.issues.due_date_overdue"}}"{{end}}>
 						{{svg "octicon-calendar" 16 "gt-mr-3"}}
-						{{DateTime "long" .Issue.DeadlineUnix}}
+						{{DateTime "long" .Issue.DeadlineUnix.FormatDate}}
 					</div>
 					<div>
 						{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}


### PR DESCRIPTION
Closes #26263

We have to pass the date without the time.

# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/6b6cb43d-2b1c-4679-951d-20f48c94bfdd)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/50441baf-2c52-452b-bb0d-6034a407abde)

