### PR TITLE
Update Arch linux URL from community to extra

### DIFF
--- a/docs/content/installation/from-package.en-us.md
+++ b/docs/content/installation/from-package.en-us.md
@@ -40,7 +40,7 @@ apk add gitea
 
 ## Arch Linux
 
-The rolling release distribution has [Gitea](https://www.archlinux.org/packages/extra/x86_64/gitea/) in their official community repository and package updates are provided with new Gitea releases.
+The rolling release distribution has [Gitea](https://www.archlinux.org/packages/extra/x86_64/gitea/) in their official extra repository and package updates are provided with new Gitea releases.
 
 ```sh
 pacman -S gitea

--- a/docs/content/installation/from-package.en-us.md
+++ b/docs/content/installation/from-package.en-us.md
@@ -40,7 +40,7 @@ apk add gitea
 
 ## Arch Linux
 
-The rolling release distribution has [Gitea](https://www.archlinux.org/packages/community/x86_64/gitea/) in their official community repository and package updates are provided with new Gitea releases.
+The rolling release distribution has [Gitea](https://www.archlinux.org/packages/extra/x86_64/gitea/) in their official community repository and package updates are provided with new Gitea releases.
 
 ```sh
 pacman -S gitea


### PR DESCRIPTION
Arch linux package link has changed from the community repo to the extra repo. The link has been updated

