### PR TITLE
Delete run feature

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -306,7 +306,7 @@ func InsertRun(ctx context.Context, run *ActionRun, jobs []*jobparser.SingleWork
 }
 
 func DeleteRunJobs(ctx context.Context, jobs []*ActionRunJob) error {
-	return db.DeleteBeans(ctx, jobs...)
+	return db.DeleteBeans(ctx, jobs)
 }
 
 func DeleteRun(ctx context.Context, run *ActionRun) error {

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -305,8 +305,21 @@ func InsertRun(ctx context.Context, run *ActionRun, jobs []*jobparser.SingleWork
 	return commiter.Commit()
 }
 
-func DeleteRunJobs(ctx context.Context, jobs []*ActionRunJob) error {
-	return db.DeleteBeans(ctx, jobs)
+func DeleteTaskSteps(ctx context.Context, steps []*ActionTaskStep) error {
+	for _, step := range steps {
+		if err := db.DeleteBeans(ctx, step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DeleteTask(ctx context.Context, actionTask *ActionTask) error {
+	return db.DeleteBeans(ctx, actionTask)
+}
+
+func DeleteRunJob(ctx context.Context, job *ActionRunJob) error {
+	return db.DeleteBeans(ctx, job)
 }
 
 func DeleteRun(ctx context.Context, run *ActionRun) error {
@@ -322,11 +335,7 @@ func DeleteRun(ctx context.Context, run *ActionRun) error {
 		return err
 	}
 
-	if err := updateRepoRunsNumbers(ctx, run.Repo); err != nil {
-		return err
-	}
-
-	return nil
+	return updateRepoRunsNumbers(ctx, run.Repo)
 }
 
 func GetRunByID(ctx context.Context, id int64) (*ActionRun, error) {

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -306,12 +306,7 @@ func InsertRun(ctx context.Context, run *ActionRun, jobs []*jobparser.SingleWork
 }
 
 func DeleteRunJobs(ctx context.Context, jobs []*ActionRunJob) error {
-	for _, job := range jobs {
-		if err := db.DeleteBeans(ctx, job); err != nil {
-			return err
-		}
-	}
-	return nil
+	return db.DeleteBeans(ctx, jobs...)
 }
 
 func DeleteRun(ctx context.Context, run *ActionRun) error {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1212,6 +1212,7 @@ func registerRoutes(m *web.Route) {
 				m.Post("/artifacts", actions.ArtifactsView)
 				m.Get("/artifacts/{artifact_name}", actions.ArtifactsDownloadView)
 				m.Post("/rerun", reqRepoActionsWriter, actions.RerunAll)
+				m.Post("/delete", reqRepoActionsWriter, actions.Delete)
 			})
 		}, reqRepoActionsReader, actions.MustEnableActions)
 


### PR DESCRIPTION
Target Issue:  #26219

This PR has the aim of add a delete single workflow run feature to Gitea. It does that by:
1. Adding in web.go a new delete endpoint for the action that calls `action.Delete`. 
2. In the Delete function it gets the respective `ActionRun`  and `ActionRunJob` objects by run ID, starts a transaction and calls 2  lower-level functions at `models/actions/run.go`: `DeleteRun` and `DeleteRunJobs`.
3. These lower-level functions will be responsible to do the DB operations to delete it.

This work is still in progress and I'm aware it needs more operations to really erase every remnant of the deleted Run. Also it needs to be integrated with the frontend. 

