### PR TITLE
Use yellow if an approved review is stale

### DIFF
--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -194,9 +194,8 @@ func (r *Review) HTMLTypeColorName() string {
 	case ReviewTypeApprove:
 		if r.Stale {
 			return "yellow"
-		} else {
-			return "green"
 		}
+		return "green"
 	case ReviewTypeComment:
 		return "grey"
 	case ReviewTypeReject:

--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -192,7 +192,11 @@ func (r *Review) LoadAttributes(ctx context.Context) (err error) {
 func (r *Review) HTMLTypeColorName() string {
 	switch r.Type {
 	case ReviewTypeApprove:
-		return "green"
+		if r.Stale {
+			return "yellow"
+		} else {
+			return "green"
+		}
 	case ReviewTypeComment:
 		return "grey"
 	case ReviewTypeReject:


### PR DESCRIPTION
By using a different color it's clear that the review isn't pointing to the latest commit.

**Screenshots:**
Not stale review:
![image](https://github.com/go-gitea/gitea/assets/1135157/2901ad69-e0d8-4041-b760-277d02dafd45)
Stale review:
![image](https://github.com/go-gitea/gitea/assets/1135157/500b306e-a994-42d4-a2fd-1174774ba5ee)

fixes #26306 
