### PR TITLE
Add new workflow in `Add File` list

### DIFF
--- a/modules/context/repo.go
+++ b/modules/context/repo.go
@@ -559,6 +559,7 @@ func RepoAssignment(ctx *Context) context.CancelFunc {
 	ctx.Data["CanWriteCode"] = ctx.Repo.CanWrite(unit_model.TypeCode)
 	ctx.Data["CanWriteIssues"] = ctx.Repo.CanWrite(unit_model.TypeIssues)
 	ctx.Data["CanWritePulls"] = ctx.Repo.CanWrite(unit_model.TypePullRequests)
+	ctx.Data["CanWriteActions"] = ctx.Repo.CanWrite(unit_model.TypeActions)
 
 	canSignedUserFork, err := repo_module.CanUserForkRepo(ctx.Doer, ctx.Repo.Repository)
 	if err != nil {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1185,6 +1185,7 @@ from_comment = (comment)
 
 editor.add_file = Add File
 editor.new_file = New File
+editor.new_workflow = New Workflow
 editor.upload_file = Upload File
 editor.edit_file = Edit File
 editor.preview_changes = Preview Changes

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -92,6 +92,20 @@
 							<a class="item" href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
 								{{.locale.Tr "repo.editor.new_file"}}
 							</a>
+							{{if and .EnableActions (not .UnitActionsGlobalDisabled) .CanWriteActions}}
+							<div class="item">
+								<i class="dropdown icon"></i>
+								<span class="text">{{.locale.Tr "repo.editor.new_workflow"}}</span>
+								<div class="menu">
+									<a class="item" href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/.gitea/workflows/{{.TreePath | PathEscapeSegments}}">
+										Gitea
+									</a>
+									<a class="item" href="{{.RepoLink}}/_new/{{.BranchName | PathEscapeSegments}}/.github/workflows/{{.TreePath | PathEscapeSegments}}">
+										GitHub
+									</a>
+								</div>
+							</div>
+							{{end}}
 							{{if .RepositoryUploadEnabled}}
 							<a class="item" href="{{.RepoLink}}/_upload/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">
 								{{.locale.Tr "repo.editor.upload_file"}}


### PR DESCRIPTION
Close #26145

`New workflow` will display when user have write permission and action is enabled in the repo.
![image](https://github.com/go-gitea/gitea/assets/18380374/03de11f8-01db-4982-90c3-33e0e88a0b88)

ps: it seems that we have lost some fonts? The content `\f0da` is displayed as a box.