### PR TITLE
Hide `last indexed SHA` when a repo could not be indexed yet

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -680,7 +680,9 @@
 				{{end}}
 				<h4 class="ui header">{{.locale.Tr "repo.settings.admin_stats_indexer"}}</h4>
 				<div class="inline fields">
-					<label>{{.locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+					{{if and .StatsIndexerStatus .StatsIndexerStatus.CommitSha}}
+						<label>{{.locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+					{{end}}
 					<span class="field">
 						{{if and .StatsIndexerStatus .StatsIndexerStatus.CommitSha}}
 							<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.StatsIndexerStatus.CommitSha}}">

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -682,7 +682,7 @@
 				<div class="inline fields">
 					<label>{{.locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
 					<span class="field">
-						{{if .StatsIndexerStatus}}
+						{{if and .StatsIndexerStatus .StatsIndexerStatus.CommitSha}}
 							<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.StatsIndexerStatus.CommitSha}}">
 								<span class="shortsha">{{ShortSha .StatsIndexerStatus.CommitSha}}</span>
 							</a>


### PR DESCRIPTION
Now,  for a new repo without any commit, the Last indexed SHA field looks like this:
Before:
![image](https://github.com/go-gitea/gitea/assets/50507092/cecc6e24-3366-4093-ae07-c361ea34b373)
After: 
![image](https://github.com/go-gitea/gitea/assets/50507092/9b6ba703-b0d5-4648-ad6b-9a2341dd60f9)


fix #26336