### PR TITLE
Display human-readable text instead of cryptic filemodes

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3509,11 +3509,7 @@ type-3.display_name = Organization Project
 [git.filemode]
 # Ordered by git filemode value, ascending. E.g. directory has "040000", normal file has "100644", …
 directory = Directory
-normal_file_rw0_000_000 = Normal file (Permissions rw-------)
-normal_file_rw0_r00_000 = Normal file (Permissions rw-r-----)
 normal_file = Normal file
-executable_file_rwx_000_000 = Executable file (Permissions rwxr-----)
-executable_file_rwx_r0x_000 = Executable file (Permissions rwxr-x---)
 executable_file = Executable file
 symbolic_link = Symbolic link
 submodule = Submodule

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3507,6 +3507,7 @@ type-2.display_name = Repository Project
 type-3.display_name = Organization Project
 
 [git.filemode]
+changed_filemode = %[1]s → %[2]s
 # Ordered by git filemode value, ascending. E.g. directory has "040000", normal file has "100644", …
 directory = Directory
 normal_file = Normal file

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3505,3 +3505,15 @@ variables.update.success = The variable has been edited.
 type-1.display_name = Individual Project
 type-2.display_name = Repository Project
 type-3.display_name = Organization Project
+
+[git.filemode]
+# Ordered by git filemode value, ascending. E.g. directory has "040000", normal file has "100644", …
+directory = Directory
+normal_file_rw0_000_000 = Normal file (Permissions rw-------)
+normal_file_rw0_r00_000 = Normal file (Permissions rw-r-----)
+normal_file = Normal file
+executable_file_rwx_000_000 = Executable file (Permissions rwxr-----)
+executable_file_rwx_r0x_000 = Executable file (Permissions rwxr-x---)
+executable_file = Executable file
+symbolic_link = Symbolic link
+submodule = Submodule

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -431,16 +431,8 @@ func (diffFile *DiffFile) ModeTranslationKey(mode string) string {
 	switch mode {
 	case "040000":
 		return "git.filemode.directory"
-	case "100600":
-		return "git.filemode.normal_file_rw0_000_000"
-	case "100640":
-		return "git.filemode.normal_file_rw0_r00_000"
 	case "100644":
 		return "git.filemode.normal_file"
-	case "100700":
-		return "git.filemode.executable_file_rwx_000_000"
-	case "100750":
-		return "git.filemode.executable_file_rwx_r0x_000"
 	case "100755":
 		return "git.filemode.executable_file"
 	case "120000":

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -427,6 +427,31 @@ func (diffFile *DiffFile) ShouldBeHidden() bool {
 	return diffFile.IsGenerated || diffFile.IsViewed
 }
 
+func (diffFile *DiffFile) ModeTranslationKey(mode string) string {
+	switch mode {
+	case "040000":
+		return "git.filemode.directory"
+	case "100600":
+		return "git.filemode.normal_file_rw0_000_000"
+	case "100640":
+		return "git.filemode.normal_file_rw0_r00_000"
+	case "100644":
+		return "git.filemode.normal_file"
+	case "100700":
+		return "git.filemode.executable_file_rwx_000_000"
+	case "100750":
+		return "git.filemode.executable_file_rwx_r0x_000"
+	case "100755":
+		return "git.filemode.executable_file"
+	case "120000":
+		return "git.filemode.symbolic_link"
+	case "160000":
+		return "git.filemode.submodule"
+	default:
+		return mode
+	}
+}
+
 func getCommitFileLineCount(commit *git.Commit, filePath string) int {
 	blob, err := commit.GetBlobByPath(filePath)
 	if err != nil {

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -130,7 +130,9 @@
 									<span class="ui label">{{$.locale.Tr "repo.diff.vendored"}}</span>
 								{{end}}
 								{{if and $file.Mode $file.OldMode}}
-									<span class="gt-ml-4 gt-mono">{{$.locale.Tr ($file.ModeTranslationKey $file.OldMode)}} → {{$.locale.Tr ($file.ModeTranslationKey $file.Mode)}}</span>
+									{{$old := $.locale.Tr ($file.ModeTranslationKey $file.OldMode)}}
+									{{$new := $.locale.Tr ($file.ModeTranslationKey $file.Mode)}}
+									<span class="gt-ml-4 gt-mono">{{$.locale.Tr "git.filemode.changed_filemode" $old $new}}</span>
 								{{else if $file.Mode}}
 									<span class="gt-ml-4 gt-mono">{{$.locale.Tr ($file.ModeTranslationKey $file.Mode)}}</span>
 								{{end}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -130,9 +130,9 @@
 									<span class="ui label">{{$.locale.Tr "repo.diff.vendored"}}</span>
 								{{end}}
 								{{if and $file.Mode $file.OldMode}}
-									<span class="gt-ml-4 gt-mono">{{$file.OldMode}} → {{$file.Mode}}</span>
+									<span class="gt-ml-4 gt-mono">{{$.locale.Tr ($file.ModeTranslationKey $file.OldMode)}} → {{$.locale.Tr ($file.ModeTranslationKey $file.Mode)}}</span>
 								{{else if $file.Mode}}
-									<span class="gt-ml-4 gt-mono">{{$file.Mode}}</span>
+									<span class="gt-ml-4 gt-mono">{{$.locale.Tr ($file.ModeTranslationKey $file.Mode)}}</span>
 								{{end}}
 							</div>
 							<div class="diff-file-header-actions gt-df gt-ac gt-gap-2 gt-fw">


### PR DESCRIPTION
Now, you don't need to be a git expert anymore to know what these numbers mean.

## Before
![grafik](https://github.com/go-gitea/gitea/assets/51889757/9a964bf6-10fd-40a6-aeb2-ac8f437f8c32)

## After
![grafik](https://github.com/go-gitea/gitea/assets/51889757/84573cb9-55b6-4dde-9866-95f71b657554)
or when the mode actually changed:
![grafik](https://github.com/go-gitea/gitea/assets/51889757/0f327538-ebdc-40e7-8c99-f9e21b67f638)
