### PR TITLE
[docs] Fix Gmail configuration

### DIFF
--- a/docs/content/administration/email-setup.en-us.md
+++ b/docs/content/administration/email-setup.en-us.md
@@ -79,8 +79,9 @@ SMTP_PORT      = 465
 FROM           = example.user@gmail.com
 USER           = example.user
 PASSWD         = `***`
-PROTOCOL       = smtp
-IS_TLS_ENABLED = true
+PROTOCOL       = smtps ; Gitea >= 1.19.0
+; PROTOCOL       = smtp  ; Gitea < 1.19.0
+; IS_TLS_ENABLED = true  ; Gitea < 1.19.0
 ```
 
 Note that you'll need to create and use an [App password](https://support.google.com/accounts/answer/185833?hl=en) by enabling 2FA on your Google


### PR DESCRIPTION
The previous configuration did not work in v1.20.2, and warnings in the UI indicated these configuration options changed in v1.19.0.

Left configuration for older versions, but commented out.

A fix was merged into main with #26302. However, v1.20 docs are currently incorrect, so it might be worth backporting.