### PR TITLE
Do not highlight `#number` in documents

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -852,7 +852,7 @@ func fullIssuePatternProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 func issueIndexPatternProcessor(ctx *RenderContext, node *html.Node) {
-	if ctx.Metas == nil {
+	if ctx.Metas == nil || ctx.Metas["mode"] == "document" {
 		return
 	}
 	var (

--- a/modules/markup/html_internal_test.go
+++ b/modules/markup/html_internal_test.go
@@ -262,6 +262,30 @@ func TestRender_IssueIndexPattern5(t *testing.T) {
 	})
 }
 
+func TestRender_IssueIndexPattern_Document(t *testing.T) {
+	setting.AppURL = TestAppURL
+	metas := map[string]string{
+		"format": "https://someurl.com/{user}/{repo}/{index}",
+		"user":   "someUser",
+		"repo":   "someRepo",
+		"style":  IssueNameStyleNumeric,
+		"mode":   "document",
+	}
+
+	testRenderIssueIndexPattern(t, "#1", "#1", &RenderContext{
+		Ctx:   git.DefaultContext,
+		Metas: metas,
+	})
+	testRenderIssueIndexPattern(t, "#1312", "#1312", &RenderContext{
+		Ctx:   git.DefaultContext,
+		Metas: metas,
+	})
+	testRenderIssueIndexPattern(t, "!1", "!1", &RenderContext{
+		Ctx:   git.DefaultContext,
+		Metas: metas,
+	})
+}
+
 func testRenderIssueIndexPattern(t *testing.T, input, expected string, ctx *RenderContext) {
 	if ctx.URLPrefix == "" {
 		ctx.URLPrefix = TestAppURL

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -529,6 +529,42 @@ func Test_ParseClusterFuzz(t *testing.T) {
 	assert.NotContains(t, res.String(), "<html")
 }
 
+func TestPostProcess_RenderDocument(t *testing.T) {
+	setting.AppURL = TestAppURL
+
+	localMetas := map[string]string{
+		"user": "go-gitea",
+		"repo": "gitea",
+		"mode": "document",
+	}
+
+	test := func(input, expected string) {
+		var res strings.Builder
+		err := PostProcess(&RenderContext{
+			Ctx:       git.DefaultContext,
+			URLPrefix: "https://example.com",
+			Metas:     localMetas,
+		}, strings.NewReader(input), &res)
+		assert.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(res.String()))
+	}
+
+	// Issue index shouldn't be post processing in an document.
+	test(
+		"#1",
+		"#1")
+
+	// Test that other post processing still works.
+	test(
+		":gitea:",
+		`<span class="emoji" aria-label="gitea"><img alt=":gitea:" src="`+setting.StaticURLPrefix+`/assets/img/emoji/gitea.png"/></span>`)
+	test(
+		"Some text with 😄 in the middle",
+		`Some text with <span class="emoji" aria-label="grinning face with smiling eyes">😄</span> in the middle`)
+	test("http://localhost:3000/person/repo/issues/4#issuecomment-1234",
+		`<a href="http://localhost:3000/person/repo/issues/4#issuecomment-1234" class="ref-issue">person/repo#4 (comment)</a>`)
+}
+
 func TestIssue16020(t *testing.T) {
 	setting.AppURL = TestAppURL
 


### PR DESCRIPTION
- Currently the post processing will transform all issue indexes (such as  `#6`) into an clickable link.
- This makes sense in an situation like issues or PRs, where referencing to other issues is quite common and only referencing to their issue indexing is an handy and efficient way to do it.
- Currently this is also run for documents (which is the user profile and viewing rendered files), but in those situations it's less common to reference issues by their index and instead could mean something else.
- This patch disables this post processing for issue index for documents. Which matches Github's behavior.
- Added unit tests.
- Resolves https://codeberg.org/Codeberg/Community/issues/1120
