### PR TITLE
Refactor "editorconfig"

### DIFF
--- a/modules/templates/util_misc.go
+++ b/modules/templates/util_misc.go
@@ -5,10 +5,10 @@ package templates
 
 import (
 	"context"
-	"fmt"
 	"html/template"
 	"mime"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -174,23 +174,12 @@ func FilenameIsImage(filename string) bool {
 	return strings.HasPrefix(mimeType, "image/")
 }
 
-func TabSizeClass(ec any, filename string) string {
-	var (
-		value *editorconfig.Editorconfig
-		ok    bool
-	)
+func TabSizeClass(ec *editorconfig.Editorconfig, filename string) string {
 	if ec != nil {
-		if value, ok = ec.(*editorconfig.Editorconfig); !ok || value == nil {
-			return "tab-size-8"
-		}
-		def, err := value.GetDefinitionForFilename(filename)
-		if err != nil {
-			log.Error("tab size class: getting definition for filename: %v", err)
-			return "tab-size-8"
-		}
-		if def.TabWidth > 0 {
-			return fmt.Sprintf("tab-size-%d", def.TabWidth)
+		def, err := ec.GetDefinitionForFilename(filename)
+		if err == nil && def.TabWidth >= 1 && def.TabWidth <= 16 {
+			return "tab-size-" + strconv.Itoa(def.TabWidth)
 		}
 	}
-	return "tab-size-8"
+	return "tab-size-4"
 }

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -191,7 +191,7 @@ func editFile(ctx *context.Context, isNewFile bool) {
 	ctx.Data["last_commit"] = ctx.Repo.CommitID
 	ctx.Data["PreviewableExtensions"] = strings.Join(markup.PreviewableExtensions(), ",")
 	ctx.Data["LineWrapExtensions"] = strings.Join(setting.Repository.Editor.LineWrapExtensions, ",")
-	ctx.Data["Editorconfig"] = GetEditorConfig(ctx, treePath)
+	ctx.Data["EditorconfigJson"] = GetEditorConfig(ctx, treePath)
 
 	ctx.HTML(http.StatusOK, tplEditFile)
 }
@@ -242,7 +242,7 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 	ctx.Data["last_commit"] = ctx.Repo.CommitID
 	ctx.Data["PreviewableExtensions"] = strings.Join(markup.PreviewableExtensions(), ",")
 	ctx.Data["LineWrapExtensions"] = strings.Join(setting.Repository.Editor.LineWrapExtensions, ",")
-	ctx.Data["Editorconfig"] = GetEditorConfig(ctx, form.TreePath)
+	ctx.Data["EditorconfigJson"] = GetEditorConfig(ctx, form.TreePath)
 
 	if ctx.HasError() {
 		ctx.HTML(http.StatusOK, tplEditFile)

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -15,7 +15,7 @@
 					{{range $i, $v := .TreeNames}}
 						<div class="divider"> / </div>
 						{{if eq $i $l}}
-							<input id="file-name" value="{{$v}}" placeholder="{{$.locale.Tr "repo.editor.name_your_file"}}" data-editorconfig="{{$.Editorconfig}}" required autofocus>
+							<input id="file-name" value="{{$v}}" placeholder="{{$.locale.Tr "repo.editor.name_your_file"}}" data-editorconfig="{{$.EditorconfigJson}}" required autofocus>
 							<span data-tooltip-content="{{$.locale.Tr "repo.editor.filename_help"}}">{{svg "octicon-info"}}</span>
 						{{else}}
 							<span class="section"><a href="{{$.BranchLink}}/{{index $.TreePaths $i | PathEscapeSegments}}">{{$v}}</a></span>


### PR DESCRIPTION
There are 2 kinds of ".Editorconfig" in code, one is `JSON string` for the web edtior, another is `*editorconfig.Editorconfig` for the file rendering (used by `TabSizeClass`)

This PR distinguish them with different names.

And by the way, change the default tab size from 8 to 4, I think few people would like to use 8-size tabs nowadays.
