### PR TITLE
Add pull request review request webhook event

### DIFF
--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -131,6 +131,10 @@ func getPullRequestPayloadInfo(p *api.PullRequestPayload, linkFormatter linkForm
 	case api.HookIssueReviewed:
 		text = fmt.Sprintf("[%s] Pull request reviewed: %s", repoLink, titleLink)
 		attachmentText = p.Review.Content
+	case api.HookIssueReviewRequested:
+		text = fmt.Sprintf("[%s] Pull request review requested: %s", repoLink, titleLink)
+	case api.HookIssueReviewRequestRemoved:
+		text = fmt.Sprintf("[%s] Pull request review request removed: %s", repoLink, titleLink)
 	}
 	if withSender {
 		text += fmt.Sprintf(" by %s", linkFormatter(setting.AppURL+p.Sender.UserName, p.Sender.UserName))


### PR DESCRIPTION
Add webhook events for pull request review requests

- Fixes #26371
- Added support for the "Pull request review requested" and "Pull request review request removed" webhook events.
- Updated the `getPullRequestPayloadInfo` function in `general.go` to handle these new webhook events.

# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/bd942971-fb1d-40f3-8961-46638e3588fa)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/216e9c7d-0a4d-49f9-8492-2d14c88bbf4e)
