### PR TITLE
Fix the display of orgs listed in user profile

### DIFF
--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -96,7 +96,6 @@
   display: flex;
   border-bottom: 0 !important;
   padding: 3px !important;
-  width: 20%;
   max-width: 60px;
 }
 


### PR DESCRIPTION
Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/55759aad-cbf7-4d91-8559-b7781d184911)
After:
![image](https://github.com/go-gitea/gitea/assets/18380374/9de5136b-d0a0-4756-9426-125fd4b603d3)

In #26214, we changed each row's display into `flex` which caused this problem.
![image](https://github.com/go-gitea/gitea/assets/18380374/66546e7e-a224-45e7-9008-224f0f2952c6)
![image](https://github.com/go-gitea/gitea/assets/18380374/e5190f88-e561-4361-894a-86c5fe88837e)
In old version:
![image](https://github.com/go-gitea/gitea/assets/18380374/36e58e98-7d75-4a63-844a-2beee460997a)

Maybe we can add paddings here?
![image](https://github.com/go-gitea/gitea/assets/18380374/dc61acd2-8995-46d4-b606-eb10c77dd877)
In old version;
![image](https://github.com/go-gitea/gitea/assets/18380374/478acba7-0bbc-4852-b208-3ae43fcea976)
