### PR TITLE
Lock go to 1.21 on CI

### DIFF
--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make generate-license generate-gitignore
         timeout-minutes: 40

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-backend
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-go-windows lint-go-vet
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-go
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make --always-make checks-backend # ensure the "go-licenses" make target runs
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       # no frontend build here as backend should be able to build
       # even without any frontend files

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 pgsql ldap minio" | sudo tee -a /etc/hosts'
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - run: make deps-backend
       - run: make backend
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch meilisearch smtpimap" | sudo tee -a /etc/hosts'
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql8" | sudo tee -a /etc/hosts'
@@ -244,7 +244,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mssql" | sudo tee -a /etc/hosts'

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -14,7 +14,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.20"
+          go-version: "~1.21"
           check-latest: true
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
To prevent unwanted surprises with new minor versions of go, lock the version to minor version using [semver tilde syntax](https://github.com/npm/node-semver#tilde-ranges-123-12-1). We were already getting 1.21.0 since yesterday, so use that version now as minimum.