### PR TITLE
Fix incorrect redirection in new issue using references

### DIFF
--- a/templates/repo/issue/view_content/reference_issue_dialog.tmpl
+++ b/templates/repo/issue/view_content/reference_issue_dialog.tmpl
@@ -3,7 +3,7 @@
 		{{.locale.Tr "repo.issues.context.reference_issue"}}
 	</div>
 	<div class="content" style="text-align:left">
-		<form class="ui form" action="{{printf "%s/issues/new" .Repository.Link}}" method="post">
+		<form class="ui form form-fetch-action" action="{{printf "%s/issues/new" .Repository.Link}}" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="ui segment content">
 				<div class="field">


### PR DESCRIPTION
fix #26427
related https://github.com/go-gitea/gitea/pull/25258

---

Before:
![gitea](https://github.com/go-gitea/gitea/assets/50507092/ed8d3a17-1f63-42f2-a698-3b684e70dc91)

--- 

After:
![After](https://github.com/go-gitea/gitea/assets/50507092/b8e1338f-c520-4abc-b0df-b812c021ac7e)
