### PR TITLE
Always show usernames in reaction tooltips

### DIFF
--- a/models/issues/reaction.go
+++ b/models/issues/reaction.go
@@ -377,7 +377,7 @@ func (list ReactionList) GetFirstUsers() string {
 		if buffer.Len() > 0 {
 			buffer.WriteString(", ")
 		}
-		buffer.WriteString(reaction.User.DisplayName())
+		buffer.WriteString(reaction.User.Name)
 		if rem--; rem == 0 {
 			break
 		}

--- a/models/issues/reaction_test.go
+++ b/models/issues/reaction_test.go
@@ -109,7 +109,7 @@ func TestIssueReactionCount(t *testing.T) {
 	reactions := reactionsList.GroupByType()
 	assert.Len(t, reactions["heart"], 4)
 	assert.Equal(t, 2, reactions["heart"].GetMoreUserCount())
-	assert.Equal(t, user1.DisplayName()+", "+user2.DisplayName(), reactions["heart"].GetFirstUsers())
+	assert.Equal(t, user1.Name+", "+user2.Name, reactions["heart"].GetFirstUsers())
 	assert.True(t, reactions["heart"].HasUser(1))
 	assert.False(t, reactions["heart"].HasUser(5))
 	assert.False(t, reactions["heart"].HasUser(0))


### PR DESCRIPTION
Even if GetDisplayName() is normally preferred elsewhere, this change
provides more consistency, as usernames are also always being shown
when participating in a conversation taking place in an issue or
a pull request. This change makes conversations easier to follow, as
you would not have to have a mental association between someone's
username and someone's real name in order to follow what is happening.

This behavior matches GitHub's. Optimally, both the username and the
full name (if applicable) could be shown, but such an effort is a
much bigger task that needs to be thought out well.