### PR TITLE
Improve profile readme rendering (#25988)

### DIFF
--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -115,6 +115,7 @@ func Profile(ctx *context.Context) {
 			profileContent, err := markdown.RenderString(&markup.RenderContext{
 				Ctx:     ctx,
 				GitRepo: gitRepo,
+				Metas:   map[string]string{"mode": "document"},
 			}, bytes)
 			if err != nil {
 				ctx.ServerError("RenderString", err)

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -122,7 +122,7 @@
 }
 
 #readme_profile {
-  padding: 10px;
+  padding: 1em 2em;
   border-radius: 0.28571429rem;
   background: var(--color-card);
   border: 1px solid var(--color-secondary);


### PR DESCRIPTION
manual backport of #25988 to v1.20

- Tell the renderer to use the `document` mode, so it's consistent with other renderers.
- Use the same padding as `.file-view.markup`, so it's consistent with other containers that contain markup rendering.
- Resolves https://codeberg.org/forgejo/forgejo/issues/833