### PR TITLE
remove unnecessary explore org template

### DIFF
--- a/routers/web/explore/org.go
+++ b/routers/web/explore/org.go
@@ -6,15 +6,9 @@ package explore
 import (
 	"code.gitea.io/gitea/models/db"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
-)
-
-const (
-	// tplExploreOrganizations explore organizations page template
-	tplExploreOrganizations base.TplName = "explore/organizations"
 )
 
 // Organizations render explore organizations page
@@ -39,5 +33,5 @@ func Organizations(ctx *context.Context) {
 		Type:        user_model.UserTypeOrganization,
 		ListOptions: db.ListOptions{PageSize: setting.UI.ExplorePagingNum},
 		Visible:     visibleTypes,
-	}, tplExploreOrganizations)
+	}, tplExploreUsers)
 }

--- a/templates/explore/organizations.tmpl
+++ b/templates/explore/organizations.tmpl
@@ -1,1 +1,0 @@
-{{template "explore/users" .}}


### PR DESCRIPTION
As title. The template became obsolete when we merged user and org explore templates together in #25790 
