### PR TITLE
Avoiding accessing undefined mentionValues

### DIFF
--- a/web_src/js/features/tribute.js
+++ b/web_src/js/features/tribute.js
@@ -31,7 +31,7 @@ function makeCollections({mentions, emoji}) {
 
   if (mentions) {
     collections.push({
-      values: window.config.mentionValues,
+      values: window.config.mentionValues ?? [],
       requireLeadingSpace: true,
       menuItemTemplate: (item) => {
         return `

--- a/web_src/js/utils/match.js
+++ b/web_src/js/utils/match.js
@@ -32,7 +32,7 @@ export function matchMention(queryText) {
 
   // results is a map of weights, lower is better
   const results = new Map();
-  for (const obj of window.config.mentionValues) {
+  for (const obj of window.config.mentionValues ?? []) {
     const index = obj.key.toLowerCase().indexOf(query);
     if (index === -1) continue;
     const existing = results.get(obj);


### PR DESCRIPTION
The `window.config.mentionValues` might be undefined: 

```
{{if or .Participants .Assignees .MentionableTeams}}
    mentionValues: ...
{{end}}
```