### PR TITLE
Remove last newline from config file

### DIFF
--- a/modules/setting/config_env.go
+++ b/modules/setting/config_env.go
@@ -4,6 +4,7 @@
 package setting
 
 import (
+	"bytes"
 	"os"
 	"regexp"
 	"strconv"
@@ -130,6 +131,11 @@ func EnvironmentToConfig(cfg ConfigProvider, envs []string) (changed bool) {
 			if err != nil {
 				log.Error("Error reading file for %s : %v", envKey, envValue, err)
 				continue
+			}
+			if bytes.HasSuffix(fileContent, []byte("\r\n")) {
+				fileContent = fileContent[:len(fileContent)-2]
+			} else if bytes.HasSuffix(fileContent, []byte("\n")) {
+				fileContent = fileContent[:len(fileContent)-1]
 			}
 			keyValue = string(fileContent)
 		}

--- a/modules/setting/config_env_test.go
+++ b/modules/setting/config_env_test.go
@@ -99,4 +99,19 @@ key = old
 	changed = EnvironmentToConfig(cfg, []string{"GITEA__sec__key__FILE=" + tmpFile})
 	assert.True(t, changed)
 	assert.Equal(t, "value-from-file", cfg.Section("sec").Key("key").String())
+
+	cfg, _ = NewConfigProviderFromData("")
+	_ = os.WriteFile(tmpFile, []byte("value-from-file\n"), 0o644)
+	EnvironmentToConfig(cfg, []string{"GITEA__sec__key__FILE=" + tmpFile})
+	assert.Equal(t, "value-from-file", cfg.Section("sec").Key("key").String())
+
+	cfg, _ = NewConfigProviderFromData("")
+	_ = os.WriteFile(tmpFile, []byte("value-from-file\r\n"), 0o644)
+	EnvironmentToConfig(cfg, []string{"GITEA__sec__key__FILE=" + tmpFile})
+	assert.Equal(t, "value-from-file", cfg.Section("sec").Key("key").String())
+
+	cfg, _ = NewConfigProviderFromData("")
+	_ = os.WriteFile(tmpFile, []byte("value-from-file\n\n"), 0o644)
+	EnvironmentToConfig(cfg, []string{"GITEA__sec__key__FILE=" + tmpFile})
+	assert.Equal(t, "value-from-file\n", cfg.Section("sec").Key("key").String())
 }


### PR DESCRIPTION
When users put the secrets into a file (GITEA__sec__KEY__FILE), the newline sometimes is different to avoid (eg: echo/vim/...)

So the last newline could be removed when reading, it makes the users easier to maintain the secret files.
