### PR TITLE
Fix tooltip of commit select button

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -718,7 +718,6 @@ func GetPullCommits(ctx *context.Context) {
 	// Get the needed locale
 	resp.Locale = map[string]string{
 		"lang":                                ctx.Locale.Language(),
-		"filter_changes_by_commit":            ctx.Tr("repo.pulls.filter_changes_by_commit"),
 		"show_all_commits":                    ctx.Tr("repo.pulls.show_all_commits"),
 		"stats_num_commits":                   ctx.TrN(len(commits), "repo.activity.git_stats_commit_1", "repo.activity.git_stats_commit_n", len(commits)),
 		"show_changes_since_your_last_review": ctx.Tr("repo.pulls.show_changes_since_your_last_review"),

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -32,7 +32,7 @@
 			{{template "repo/diff/whitespace_dropdown" .}}
 			{{template "repo/diff/options_dropdown" .}}
 			{{if .PageIsPullFiles}}
-				<div id="diff-commit-select" data-issuelink="{{$.Issue.Link}}" data-queryparams="?style={{if $.IsSplitStyle}}split{{else}}unified{{end}}&whitespace={{$.WhitespaceBehavior}}&show-outdated={{$.ShowOutdatedComments}}">
+				<div id="diff-commit-select" data-issuelink="{{$.Issue.Link}}" data-queryparams="?style={{if $.IsSplitStyle}}split{{else}}unified{{end}}&whitespace={{$.WhitespaceBehavior}}&show-outdated={{$.ShowOutdatedComments}}" data-filter_changes_by_commit="{{.locale.Tr "repo.pulls.filter_changes_by_commit"}}">
 					{{/*
 						the following will be replaced by vue component
 						but this avoids any loading artifacts till the vue component is initialized

--- a/web_src/js/components/DiffCommitSelector.vue
+++ b/web_src/js/components/DiffCommitSelector.vue
@@ -77,10 +77,13 @@ import {SvgIcon} from '../svg.js';
 export default {
   components: {SvgIcon},
   data: () => {
+    const el = document.getElementById('diff-commit-select');
     return {
       menuVisible: false,
       isLoading: false,
-      locale: {},
+      locale: {
+        filter_changes_by_commit: el.getAttribute('data-filter_changes_by_commit'),
+      },
       commits: [],
       hoverActivated: false,
       lastReviewCommitSha: null


### PR DESCRIPTION
<img width="156" alt="Screenshot 2023-08-12 at 23 55 49" src="https://github.com/go-gitea/gitea/assets/115237/2d56218d-8e5f-47ef-96bd-47e4f1e1e5a6">

Previously, the tooltip for this button was only shown after opening and closing it once because it was only set after the server response, now it shows before opening it.