### PR TITLE
fix grab cursor on default column

### DIFF
--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -167,7 +167,7 @@
 
 				<div class="divider"></div>
 
-				<div class="ui cards {{if and $canWriteProject (ne .ID 0)}}gt-cursor-grab{{end}}" data-url="{{$.Link}}/{{.ID}}" data-project="{{$.Project.ID}}" data-board="{{.ID}}" id="board_{{.ID}}">
+				<div class="ui cards {{if and $canWriteProject (ne .ID 0)}}{{/* ID 0 is default column which cannot be moved */}}gt-cursor-grab{{end}}" data-url="{{$.Link}}/{{.ID}}" data-project="{{$.Project.ID}}" data-board="{{.ID}}" id="board_{{.ID}}">
 					{{range (index $.IssuesMap .ID)}}
 						<div class="issue-card gt-word-break {{if $canWriteProject}}gt-cursor-grab{{end}}" data-issue="{{.ID}}">
 							{{template "repo/issue/card" (dict "Issue" . "Page" $)}}

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -167,9 +167,9 @@
 
 				<div class="divider"></div>
 
-				<div class="ui cards {{if $.CanWriteProjects}}gt-cursor-grab{{end}}" data-url="{{$.Link}}/{{.ID}}" data-project="{{$.Project.ID}}" data-board="{{.ID}}" id="board_{{.ID}}">
+				<div class="ui cards {{if and $canWriteProject (ne .ID 0)}}gt-cursor-grab{{end}}" data-url="{{$.Link}}/{{.ID}}" data-project="{{$.Project.ID}}" data-board="{{.ID}}" id="board_{{.ID}}">
 					{{range (index $.IssuesMap .ID)}}
-						<div class="issue-card gt-word-break" data-issue="{{.ID}}">
+						<div class="issue-card gt-word-break {{if $canWriteProject}}gt-cursor-grab{{end}}" data-issue="{{.ID}}">
 							{{template "repo/issue/card" (dict "Issue" . "Page" $)}}
 						</div>
 					{{end}}


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/pull/26448#issuecomment-1676194200

I accidentally set grab cursor for project columns instead of issue cards, which actually turned out not to be a problem - with proper check for the default column, which can't be moved.
