### PR TITLE
Rename `Sync2` -> `Sync`

### DIFF
--- a/docs/content/administration/command-line.en-us.md
+++ b/docs/content/administration/command-line.en-us.md
@@ -403,7 +403,7 @@ Sometimes when there are migrations the old columns and default values may be le
 unchanged in the database schema. This may lead to warning such as:
 
 ```
-2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync2() [W] Table user Column keep_activity_private db default is , struct default is 0
+2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync() [W] Table user Column keep_activity_private db default is , struct default is 0
 ```
 
 You can cause Gitea to recreate these tables and copy the old data into the new table

--- a/docs/content/administration/command-line.zh-cn.md
+++ b/docs/content/administration/command-line.zh-cn.md
@@ -375,7 +375,7 @@ AuthorizedKeysCommand /path/to/gitea keys -e git -u %u -t %t -k %k
 有时，在迁移时，旧的列和默认值可能会在数据库模式中保持不变。这可能会导致警告，如下所示:
 
 ```
-2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync2() [W] Table user Column keep_activity_private db default is , struct default is 0
+2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync() [W] Table user Column keep_activity_private db default is , struct default is 0
 ```
 
 您可以通过以下方式让 Gitea 重新创建这些表，并将旧数据复制到新表中，并适当设置默认值：

--- a/docs/content/help/faq.en-us.md
+++ b/docs/content/help/faq.en-us.md
@@ -410,7 +410,7 @@ Sometimes when there are migrations the old columns and default values may be le
 unchanged in the database schema. This may lead to warning such as:
 
 ```
-2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync2() [W] Table user Column keep_activity_private db default is , struct default is 0
+2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync() [W] Table user Column keep_activity_private db default is , struct default is 0
 ```
 
 These can safely be ignored, but you are able to stop these warnings by getting Gitea to recreate these tables using:

--- a/docs/content/help/faq.zh-cn.md
+++ b/docs/content/help/faq.zh-cn.md
@@ -424,7 +424,7 @@ SystemD 上的标准输出默认会写入日志记录中。您可以尝试使用
 这可能会导致警告，例如：
 
 ```
-2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync2() [W] Table user Column keep_activity_private db default is , struct default is 0
+2020/08/02 11:32:29 ...rm/session_schema.go:360:Sync() [W] Table user Column keep_activity_private db default is , struct default is 0
 ```
 
 可以安全地忽略这些警告，但您可以通过让 Gitea 重新创建这些表来停止这些警告，使用以下命令：

--- a/models/db/engine.go
+++ b/models/db/engine.go
@@ -55,7 +55,7 @@ type Engine interface {
 	Limit(limit int, start ...int) *xorm.Session
 	NoAutoTime() *xorm.Session
 	SumInt(bean any, columnName string) (res int64, err error)
-	Sync2(...any) error
+	Sync(...any) error
 	Select(string) *xorm.Session
 	NotIn(string, ...any) *xorm.Session
 	OrderBy(any, ...any) *xorm.Session
@@ -172,7 +172,7 @@ func UnsetDefaultEngine() {
 }
 
 // InitEngineWithMigration initializes a new xorm.Engine and sets it as the db.DefaultContext
-// This function must never call .Sync2() if the provided migration function fails.
+// This function must never call .Sync() if the provided migration function fails.
 // When called from the "doctor" command, the migration function is a version check
 // that prevents the doctor from fixing anything in the database if the migration level
 // is different from the expected value.

--- a/models/db/engine_test.go
+++ b/models/db/engine_test.go
@@ -26,7 +26,7 @@ func TestDumpDatabase(t *testing.T) {
 		ID      int64 `xorm:"pk autoincr"`
 		Version int64
 	}
-	assert.NoError(t, db.GetEngine(db.DefaultContext).Sync2(new(Version)))
+	assert.NoError(t, db.GetEngine(db.DefaultContext).Sync(new(Version)))
 
 	for _, dbType := range setting.SupportedDatabaseTypes {
 		assert.NoError(t, db.DumpDatabase(filepath.Join(dir, dbType+".sql"), dbType))

--- a/models/issues/content_history_test.go
+++ b/models/issues/content_history_test.go
@@ -46,7 +46,7 @@ func TestContentHistory(t *testing.T) {
 		Name     string
 		FullName string
 	}
-	_ = db.GetEngine(dbCtx).Sync2(&User{})
+	_ = db.GetEngine(dbCtx).Sync(&User{})
 
 	list1, _ := issues_model.FetchIssueContentHistoryList(dbCtx, 10, 0)
 	assert.Len(t, list1, 3)

--- a/models/migrations/base/db_test.go
+++ b/models/migrations/base/db_test.go
@@ -38,7 +38,7 @@ func Test_DropTableColumns(t *testing.T) {
 
 	for i := range columns {
 		x.SetMapper(names.GonicMapper{})
-		if err := x.Sync2(new(DropTest)); err != nil {
+		if err := x.Sync(new(DropTest)); err != nil {
 			t.Errorf("unable to create DropTest table: %v", err)
 			return
 		}
@@ -65,7 +65,7 @@ func Test_DropTableColumns(t *testing.T) {
 		}
 		for j := range columns[i+1:] {
 			x.SetMapper(names.GonicMapper{})
-			if err := x.Sync2(new(DropTest)); err != nil {
+			if err := x.Sync(new(DropTest)); err != nil {
 				t.Errorf("unable to create DropTest table: %v", err)
 				return
 			}

--- a/models/migrations/base/tests.go
+++ b/models/migrations/base/tests.go
@@ -81,7 +81,7 @@ func PrepareTestEnv(t *testing.T, skip int, syncModels ...any) (*xorm.Engine, fu
 	}
 
 	if len(syncModels) > 0 {
-		if err := x.Sync2(syncModels...); err != nil {
+		if err := x.Sync(syncModels...); err != nil {
 			t.Errorf("error during sync: %v", err)
 			return x, deferFn
 		}

--- a/models/migrations/v1_10/v100.go
+++ b/models/migrations/v1_10/v100.go
@@ -18,7 +18,7 @@ func UpdateMigrationServiceTypes(x *xorm.Engine) error {
 		OriginalURL         string `xorm:"VARCHAR(2048)"`
 	}
 
-	if err := x.Sync2(new(Repository)); err != nil {
+	if err := x.Sync(new(Repository)); err != nil {
 		return err
 	}
 
@@ -78,5 +78,5 @@ func UpdateMigrationServiceTypes(x *xorm.Engine) error {
 		ExpiresAt         time.Time
 	}
 
-	return x.Sync2(new(ExternalLoginUser))
+	return x.Sync(new(ExternalLoginUser))
 }

--- a/models/migrations/v1_10/v101.go
+++ b/models/migrations/v1_10/v101.go
@@ -14,5 +14,5 @@ func ChangeSomeColumnsLengthOfExternalLoginUser(x *xorm.Engine) error {
 		RefreshToken      string `xorm:"TEXT"`
 	}
 
-	return x.Sync2(new(ExternalLoginUser))
+	return x.Sync(new(ExternalLoginUser))
 }

--- a/models/migrations/v1_10/v88.go
+++ b/models/migrations/v1_10/v88.go
@@ -21,7 +21,7 @@ func AddCommitStatusContext(x *xorm.Engine) error {
 		Context     string `xorm:"TEXT"`
 	}
 
-	if err := x.Sync2(new(CommitStatus)); err != nil {
+	if err := x.Sync(new(CommitStatus)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_10/v89.go
+++ b/models/migrations/v1_10/v89.go
@@ -12,7 +12,7 @@ func AddOriginalMigrationInfo(x *xorm.Engine) error {
 		OriginalAuthorID int64
 	}
 
-	if err := x.Sync2(new(Issue)); err != nil {
+	if err := x.Sync(new(Issue)); err != nil {
 		return err
 	}
 
@@ -22,7 +22,7 @@ func AddOriginalMigrationInfo(x *xorm.Engine) error {
 		OriginalAuthorID int64
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
+	if err := x.Sync(new(Comment)); err != nil {
 		return err
 	}
 
@@ -31,5 +31,5 @@ func AddOriginalMigrationInfo(x *xorm.Engine) error {
 		OriginalURL string
 	}
 
-	return x.Sync2(new(Repository))
+	return x.Sync(new(Repository))
 }

--- a/models/migrations/v1_10/v90.go
+++ b/models/migrations/v1_10/v90.go
@@ -13,5 +13,5 @@ func ChangeSomeColumnsLengthOfRepo(x *xorm.Engine) error {
 		OriginalURL string `xorm:"VARCHAR(2048)"`
 	}
 
-	return x.Sync2(new(Repository))
+	return x.Sync(new(Repository))
 }

--- a/models/migrations/v1_10/v91.go
+++ b/models/migrations/v1_10/v91.go
@@ -11,7 +11,7 @@ func AddIndexOnRepositoryAndComment(x *xorm.Engine) error {
 		OwnerID int64 `xorm:"index"`
 	}
 
-	if err := x.Sync2(new(Repository)); err != nil {
+	if err := x.Sync(new(Repository)); err != nil {
 		return err
 	}
 
@@ -21,5 +21,5 @@ func AddIndexOnRepositoryAndComment(x *xorm.Engine) error {
 		ReviewID int64 `xorm:"index"`
 	}
 
-	return x.Sync2(new(Comment))
+	return x.Sync(new(Comment))
 }

--- a/models/migrations/v1_10/v93.go
+++ b/models/migrations/v1_10/v93.go
@@ -11,5 +11,5 @@ func AddEmailNotificationEnabledToUser(x *xorm.Engine) error {
 		EmailNotificationsPreference string `xorm:"VARCHAR(20) NOT NULL DEFAULT 'enabled'"`
 	}
 
-	return x.Sync2(new(User))
+	return x.Sync(new(User))
 }

--- a/models/migrations/v1_10/v94.go
+++ b/models/migrations/v1_10/v94.go
@@ -11,7 +11,7 @@ func AddStatusCheckColumnsForProtectedBranches(x *xorm.Engine) error {
 		StatusCheckContexts []string `xorm:"JSON TEXT"`
 	}
 
-	if err := x.Sync2(new(ProtectedBranch)); err != nil {
+	if err := x.Sync(new(ProtectedBranch)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_10/v95.go
+++ b/models/migrations/v1_10/v95.go
@@ -15,5 +15,5 @@ func AddCrossReferenceColumns(x *xorm.Engine) error {
 		RefIsPull    bool
 	}
 
-	return x.Sync2(new(Comment))
+	return x.Sync(new(Comment))
 }

--- a/models/migrations/v1_10/v97.go
+++ b/models/migrations/v1_10/v97.go
@@ -10,5 +10,5 @@ func AddRepoAdminChangeTeamAccessColumnForUser(x *xorm.Engine) error {
 		RepoAdminChangeTeamAccess bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(User))
+	return x.Sync(new(User))
 }

--- a/models/migrations/v1_10/v98.go
+++ b/models/migrations/v1_10/v98.go
@@ -12,5 +12,5 @@ func AddOriginalAuthorOnMigratedReleases(x *xorm.Engine) error {
 		OriginalAuthorID int64 `xorm:"index"`
 	}
 
-	return x.Sync2(new(Release))
+	return x.Sync(new(Release))
 }

--- a/models/migrations/v1_10/v99.go
+++ b/models/migrations/v1_10/v99.go
@@ -34,5 +34,5 @@ func AddTaskTable(x *xorm.Engine) error {
 		Status int `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	return x.Sync2(new(Task), new(Repository))
+	return x.Sync(new(Task), new(Repository))
 }

--- a/models/migrations/v1_11/v103.go
+++ b/models/migrations/v1_11/v103.go
@@ -13,5 +13,5 @@ func AddWhitelistDeployKeysToBranches(x *xorm.Engine) error {
 		WhitelistDeployKeys bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_11/v104.go
+++ b/models/migrations/v1_11/v104.go
@@ -15,7 +15,7 @@ func RemoveLabelUneededCols(x *xorm.Engine) error {
 		QueryString string
 		IsSelected  bool
 	}
-	if err := x.Sync2(new(Label)); err != nil {
+	if err := x.Sync(new(Label)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_11/v105.go
+++ b/models/migrations/v1_11/v105.go
@@ -13,7 +13,7 @@ func AddTeamIncludesAllRepositories(x *xorm.Engine) error {
 		IncludesAllRepositories bool  `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(Team)); err != nil {
+	if err := x.Sync(new(Team)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_11/v106.go
+++ b/models/migrations/v1_11/v106.go
@@ -17,7 +17,7 @@ type Watch struct {
 }
 
 func AddModeColumnToWatch(x *xorm.Engine) error {
-	if err := x.Sync2(new(Watch)); err != nil {
+	if err := x.Sync(new(Watch)); err != nil {
 		return err
 	}
 	_, err := x.Exec("UPDATE `watch` SET `mode` = 1")

--- a/models/migrations/v1_11/v107.go
+++ b/models/migrations/v1_11/v107.go
@@ -13,5 +13,5 @@ func AddTemplateToRepo(x *xorm.Engine) error {
 		TemplateID int64 `xorm:"INDEX"`
 	}
 
-	return x.Sync2(new(Repository))
+	return x.Sync(new(Repository))
 }

--- a/models/migrations/v1_11/v108.go
+++ b/models/migrations/v1_11/v108.go
@@ -13,5 +13,5 @@ func AddCommentIDOnNotification(x *xorm.Engine) error {
 		CommentID int64
 	}
 
-	return x.Sync2(new(Notification))
+	return x.Sync(new(Notification))
 }

--- a/models/migrations/v1_11/v109.go
+++ b/models/migrations/v1_11/v109.go
@@ -12,5 +12,5 @@ func AddCanCreateOrgRepoColumnForTeam(x *xorm.Engine) error {
 		CanCreateOrgRepo bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(Team))
+	return x.Sync(new(Team))
 }

--- a/models/migrations/v1_11/v111.go
+++ b/models/migrations/v1_11/v111.go
@@ -36,11 +36,11 @@ func AddBranchProtectionCanPushAndEnableWhitelist(x *xorm.Engine) error {
 		IssueID    int64 `xorm:"index"`
 	}
 
-	if err := x.Sync2(new(ProtectedBranch)); err != nil {
+	if err := x.Sync(new(ProtectedBranch)); err != nil {
 		return err
 	}
 
-	if err := x.Sync2(new(Review)); err != nil {
+	if err := x.Sync(new(Review)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_11/v113.go
+++ b/models/migrations/v1_11/v113.go
@@ -15,8 +15,8 @@ func FeatureChangeTargetBranch(x *xorm.Engine) error {
 		NewRef string
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Comment)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_11/v116.go
+++ b/models/migrations/v1_11/v116.go
@@ -24,7 +24,7 @@ func ExtendTrackedTimes(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(TrackedTime)); err != nil {
+	if err := sess.Sync(new(TrackedTime)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_12/v117.go
+++ b/models/migrations/v1_12/v117.go
@@ -12,5 +12,5 @@ func AddBlockOnRejectedReviews(x *xorm.Engine) error {
 		BlockOnRejectedReviews bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_12/v118.go
+++ b/models/migrations/v1_12/v118.go
@@ -18,8 +18,8 @@ func AddReviewCommitAndStale(x *xorm.Engine) error {
 	}
 
 	// Old reviews will have commit ID set to "" and not stale
-	if err := x.Sync2(new(Review)); err != nil {
+	if err := x.Sync(new(Review)); err != nil {
 		return err
 	}
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_12/v120.go
+++ b/models/migrations/v1_12/v120.go
@@ -11,7 +11,7 @@ func AddOwnerNameOnRepository(x *xorm.Engine) error {
 	type Repository struct {
 		OwnerName string
 	}
-	if err := x.Sync2(new(Repository)); err != nil {
+	if err := x.Sync(new(Repository)); err != nil {
 		return err
 	}
 	_, err := x.Exec("UPDATE repository SET owner_name = (SELECT name FROM `user` WHERE `user`.id = repository.owner_id)")

--- a/models/migrations/v1_12/v121.go
+++ b/models/migrations/v1_12/v121.go
@@ -12,5 +12,5 @@ func AddIsRestricted(x *xorm.Engine) error {
 		IsRestricted bool  `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(User))
+	return x.Sync(new(User))
 }

--- a/models/migrations/v1_12/v122.go
+++ b/models/migrations/v1_12/v122.go
@@ -12,5 +12,5 @@ func AddRequireSignedCommits(x *xorm.Engine) error {
 		RequireSignedCommits bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_12/v123.go
+++ b/models/migrations/v1_12/v123.go
@@ -13,5 +13,5 @@ func AddReactionOriginals(x *xorm.Engine) error {
 		OriginalAuthor   string
 	}
 
-	return x.Sync2(new(Reaction))
+	return x.Sync(new(Reaction))
 }

--- a/models/migrations/v1_12/v124.go
+++ b/models/migrations/v1_12/v124.go
@@ -19,5 +19,5 @@ func AddUserRepoMissingColumns(x *xorm.Engine) error {
 		Topics     []string `xorm:"TEXT JSON"`
 	}
 
-	return x.Sync2(new(User), new(Repository))
+	return x.Sync(new(User), new(Repository))
 }

--- a/models/migrations/v1_12/v125.go
+++ b/models/migrations/v1_12/v125.go
@@ -15,8 +15,8 @@ func AddReviewMigrateInfo(x *xorm.Engine) error {
 		OriginalAuthorID int64
 	}
 
-	if err := x.Sync2(new(Review)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Review)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_12/v127.go
+++ b/models/migrations/v1_12/v127.go
@@ -34,11 +34,11 @@ func AddLanguageStats(x *xorm.Engine) error {
 		IndexerType RepoIndexerType `xorm:"INDEX(s) NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(LanguageStat)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(LanguageStat)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
-	if err := x.Sync2(new(RepoIndexerStatus)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(RepoIndexerStatus)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_12/v131.go
+++ b/models/migrations/v1_12/v131.go
@@ -14,8 +14,8 @@ func AddSystemWebhookColumn(x *xorm.Engine) error {
 		IsSystemWebhook bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(Webhook)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Webhook)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_12/v132.go
+++ b/models/migrations/v1_12/v132.go
@@ -14,8 +14,8 @@ func AddBranchProtectionProtectedFilesColumn(x *xorm.Engine) error {
 		ProtectedFilePatterns string `xorm:"TEXT"`
 	}
 
-	if err := x.Sync2(new(ProtectedBranch)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(ProtectedBranch)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_12/v133.go
+++ b/models/migrations/v1_12/v133.go
@@ -11,5 +11,5 @@ func AddEmailHashTable(x *xorm.Engine) error {
 		Hash  string `xorm:"pk varchar(32)"`
 		Email string `xorm:"UNIQUE NOT NULL"`
 	}
-	return x.Sync2(new(EmailHash))
+	return x.Sync(new(EmailHash))
 }

--- a/models/migrations/v1_12/v135.go
+++ b/models/migrations/v1_12/v135.go
@@ -14,8 +14,8 @@ func AddOrgIDLabelColumn(x *xorm.Engine) error {
 		OrgID int64 `xorm:"INDEX"`
 	}
 
-	if err := x.Sync2(new(Label)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Label)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_12/v136.go
+++ b/models/migrations/v1_12/v136.go
@@ -42,8 +42,8 @@ func AddCommitDivergenceToPulls(x *xorm.Engine) error {
 		MergedCommitID string `xorm:"VARCHAR(40)"`
 	}
 
-	if err := x.Sync2(new(PullRequest)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(PullRequest)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	last := 0

--- a/models/migrations/v1_12/v137.go
+++ b/models/migrations/v1_12/v137.go
@@ -11,5 +11,5 @@ func AddBlockOnOutdatedBranch(x *xorm.Engine) error {
 	type ProtectedBranch struct {
 		BlockOnOutdatedBranch bool `xorm:"NOT NULL DEFAULT false"`
 	}
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_12/v138.go
+++ b/models/migrations/v1_12/v138.go
@@ -14,8 +14,8 @@ func AddResolveDoerIDCommentColumn(x *xorm.Engine) error {
 		ResolveDoerID int64
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Comment)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_13/v140.go
+++ b/models/migrations/v1_13/v140.go
@@ -33,8 +33,8 @@ func FixLanguageStatsToSaveSize(x *xorm.Engine) error {
 		IndexerType RepoIndexerType `xorm:"INDEX(s) NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(LanguageStat)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(LanguageStat)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	x.Delete(&RepoIndexerStatus{IndexerType: RepoIndexerTypeStats})

--- a/models/migrations/v1_13/v141.go
+++ b/models/migrations/v1_13/v141.go
@@ -14,8 +14,8 @@ func AddKeepActivityPrivateUserColumn(x *xorm.Engine) error {
 		KeepActivityPrivate bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(User)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(User)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_13/v145.go
+++ b/models/migrations/v1_13/v145.go
@@ -17,7 +17,7 @@ func IncreaseLanguageField(x *xorm.Engine) error {
 		Language string `xorm:"VARCHAR(50) UNIQUE(s) INDEX NOT NULL"`
 	}
 
-	if err := x.Sync2(new(LanguageStat)); err != nil {
+	if err := x.Sync(new(LanguageStat)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_13/v146.go
+++ b/models/migrations/v1_13/v146.go
@@ -32,7 +32,7 @@ func AddProjectsInfo(x *xorm.Engine) error {
 		UpdatedUnix    timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	if err := x.Sync2(new(Project)); err != nil {
+	if err := x.Sync(new(Project)); err != nil {
 		return err
 	}
 
@@ -41,7 +41,7 @@ func AddProjectsInfo(x *xorm.Engine) error {
 		ProjectID    int64
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
+	if err := x.Sync(new(Comment)); err != nil {
 		return err
 	}
 
@@ -51,7 +51,7 @@ func AddProjectsInfo(x *xorm.Engine) error {
 		NumClosedProjects int `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(Repository)); err != nil {
+	if err := x.Sync(new(Repository)); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func AddProjectsInfo(x *xorm.Engine) error {
 		ProjectBoardID int64 `xorm:"INDEX"`
 	}
 
-	if err := x.Sync2(new(ProjectIssue)); err != nil {
+	if err := x.Sync(new(ProjectIssue)); err != nil {
 		return err
 	}
 
@@ -79,5 +79,5 @@ func AddProjectsInfo(x *xorm.Engine) error {
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	return x.Sync2(new(ProjectBoard))
+	return x.Sync(new(ProjectBoard))
 }

--- a/models/migrations/v1_13/v147.go
+++ b/models/migrations/v1_13/v147.go
@@ -78,7 +78,7 @@ func CreateReviewsForCodeComments(x *xorm.Engine) error {
 		RefIsPull    bool
 	}
 
-	if err := x.Sync2(new(Review), new(Comment)); err != nil {
+	if err := x.Sync(new(Review), new(Comment)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_13/v149.go
+++ b/models/migrations/v1_13/v149.go
@@ -17,8 +17,8 @@ func AddCreatedAndUpdatedToMilestones(x *xorm.Engine) error {
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	if err := x.Sync2(new(Milestone)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Milestone)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_13/v151.go
+++ b/models/migrations/v1_13/v151.go
@@ -77,14 +77,14 @@ func SetDefaultPasswordToArgon2(x *xorm.Engine) error {
 		type User struct {
 			PasswdHashAlgo string `xorm:"NOT NULL DEFAULT 'argon2'"`
 		}
-		return x.Sync2(new(User))
+		return x.Sync(new(User))
 	}
 	column := table.GetColumn("passwd_hash_algo")
 	if column == nil {
 		type User struct {
 			PasswdHashAlgo string `xorm:"NOT NULL DEFAULT 'argon2'"`
 		}
-		return x.Sync2(new(User))
+		return x.Sync(new(User))
 	}
 
 	tempTableName := "tmp_recreate__user"

--- a/models/migrations/v1_13/v152.go
+++ b/models/migrations/v1_13/v152.go
@@ -9,5 +9,5 @@ func AddTrustModelToRepository(x *xorm.Engine) error {
 	type Repository struct {
 		TrustModel int
 	}
-	return x.Sync2(new(Repository))
+	return x.Sync(new(Repository))
 }

--- a/models/migrations/v1_13/v153.go
+++ b/models/migrations/v1_13/v153.go
@@ -16,9 +16,9 @@ func AddTeamReviewRequestSupport(x *xorm.Engine) error {
 		AssigneeTeamID int64 `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(Review)); err != nil {
+	if err := x.Sync(new(Review)); err != nil {
 		return err
 	}
 
-	return x.Sync2(new(Comment))
+	return x.Sync(new(Comment))
 }

--- a/models/migrations/v1_13/v154.go
+++ b/models/migrations/v1_13/v154.go
@@ -16,7 +16,7 @@ func AddTimeStamps(x *xorm.Engine) error {
 	type Star struct {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 	}
-	if err := x.Sync2(new(Star)); err != nil {
+	if err := x.Sync(new(Star)); err != nil {
 		return err
 	}
 
@@ -25,7 +25,7 @@ func AddTimeStamps(x *xorm.Engine) error {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	if err := x.Sync2(new(Label)); err != nil {
+	if err := x.Sync(new(Label)); err != nil {
 		return err
 	}
 
@@ -33,7 +33,7 @@ func AddTimeStamps(x *xorm.Engine) error {
 	type Follow struct {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 	}
-	if err := x.Sync2(new(Follow)); err != nil {
+	if err := x.Sync(new(Follow)); err != nil {
 		return err
 	}
 
@@ -42,7 +42,7 @@ func AddTimeStamps(x *xorm.Engine) error {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	if err := x.Sync2(new(Watch)); err != nil {
+	if err := x.Sync(new(Watch)); err != nil {
 		return err
 	}
 
@@ -51,5 +51,5 @@ func AddTimeStamps(x *xorm.Engine) error {
 		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	return x.Sync2(new(Collaboration))
+	return x.Sync(new(Collaboration))
 }

--- a/models/migrations/v1_14/v155.go
+++ b/models/migrations/v1_14/v155.go
@@ -14,8 +14,8 @@ func AddChangedProtectedFilesPullRequestColumn(x *xorm.Engine) error {
 		ChangedProtectedFiles []string `xorm:"TEXT JSON"`
 	}
 
-	if err := x.Sync2(new(PullRequest)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(PullRequest)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v158.go
+++ b/models/migrations/v1_14/v158.go
@@ -27,7 +27,7 @@ func UpdateCodeCommentReplies(x *xorm.Engine) error {
 		ReviewID int64 `xorm:"index"`
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
+	if err := x.Sync(new(Comment)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_14/v160.go
+++ b/models/migrations/v1_14/v160.go
@@ -12,5 +12,5 @@ func AddBlockOnOfficialReviewRequests(x *xorm.Engine) error {
 		BlockOnOfficialReviewRequests bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_14/v161.go
+++ b/models/migrations/v1_14/v161.go
@@ -41,7 +41,7 @@ func ConvertTaskTypeToString(x *xorm.Engine) error {
 	type HookTask struct {
 		Typ string `xorm:"VARCHAR(16) index"`
 	}
-	if err := x.Sync2(new(HookTask)); err != nil {
+	if err := x.Sync(new(HookTask)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_14/v162.go
+++ b/models/migrations/v1_14/v162.go
@@ -39,7 +39,7 @@ func ConvertWebhookTaskTypeToString(x *xorm.Engine) error {
 	type Webhook struct {
 		Type string `xorm:"char(16) index"`
 	}
-	if err := x.Sync2(new(Webhook)); err != nil {
+	if err := x.Sync(new(Webhook)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_14/v163.go
+++ b/models/migrations/v1_14/v163.go
@@ -18,7 +18,7 @@ func ConvertTopicNameFrom25To50(x *xorm.Engine) error {
 		UpdatedUnix int64 `xorm:"INDEX updated"`
 	}
 
-	if err := x.Sync2(new(Topic)); err != nil {
+	if err := x.Sync(new(Topic)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_14/v164.go
+++ b/models/migrations/v1_14/v164.go
@@ -30,8 +30,8 @@ func (grant *OAuth2Grant) TableName() string {
 }
 
 func AddScopeAndNonceColumnsToOAuth2Grant(x *xorm.Engine) error {
-	if err := x.Sync2(new(OAuth2Grant)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(OAuth2Grant)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v167.go
+++ b/models/migrations/v1_14/v167.go
@@ -16,8 +16,8 @@ func AddUserRedirect(x *xorm.Engine) (err error) {
 		RedirectUserID int64
 	}
 
-	if err := x.Sync2(new(UserRedirect)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(UserRedirect)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v170.go
+++ b/models/migrations/v1_14/v170.go
@@ -14,8 +14,8 @@ func AddDismissedReviewColumn(x *xorm.Engine) error {
 		Dismissed bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(Review)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Review)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v171.go
+++ b/models/migrations/v1_14/v171.go
@@ -14,8 +14,8 @@ func AddSortingColToProjectBoard(x *xorm.Engine) error {
 		Sorting int8 `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(ProjectBoard)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(ProjectBoard)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v172.go
+++ b/models/migrations/v1_14/v172.go
@@ -15,5 +15,5 @@ func AddSessionTable(x *xorm.Engine) error {
 		Data   []byte `xorm:"BLOB"`
 		Expiry timeutil.TimeStamp
 	}
-	return x.Sync2(new(Session))
+	return x.Sync(new(Session))
 }

--- a/models/migrations/v1_14/v173.go
+++ b/models/migrations/v1_14/v173.go
@@ -14,8 +14,8 @@ func AddTimeIDCommentColumn(x *xorm.Engine) error {
 		TimeID int64
 	}
 
-	if err := x.Sync2(new(Comment)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Comment)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_14/v174.go
+++ b/models/migrations/v1_14/v174.go
@@ -26,8 +26,8 @@ func AddRepoTransfer(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(RepoTransfer)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(RepoTransfer)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	return sess.Commit()

--- a/models/migrations/v1_14/v176.go
+++ b/models/migrations/v1_14/v176.go
@@ -42,7 +42,7 @@ func RemoveInvalidLabels(x *xorm.Engine) error {
 		LabelID int64 `xorm:"UNIQUE(s)"`
 	}
 
-	if err := x.Sync2(new(Comment), new(Issue), new(Repository), new(Label), new(IssueLabel)); err != nil {
+	if err := x.Sync(new(Comment), new(Issue), new(Repository), new(Label), new(IssueLabel)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_14/v177.go
+++ b/models/migrations/v1_14/v177.go
@@ -23,8 +23,8 @@ func DeleteOrphanedIssueLabels(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(IssueLabel)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(IssueLabel)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	if _, err := sess.Exec(`DELETE FROM issue_label WHERE issue_label.id IN (

--- a/models/migrations/v1_15/v178.go
+++ b/models/migrations/v1_15/v178.go
@@ -13,5 +13,5 @@ func AddLFSMirrorColumns(x *xorm.Engine) error {
 		LFSEndpoint string `xorm:"lfs_endpoint TEXT"`
 	}
 
-	return x.Sync2(new(Mirror))
+	return x.Sync(new(Mirror))
 }

--- a/models/migrations/v1_15/v181.go
+++ b/models/migrations/v1_15/v181.go
@@ -26,7 +26,7 @@ func AddPrimaryEmail2EmailAddress(x *xorm.Engine) error {
 	}
 
 	// Add lower_email and is_primary columns
-	if err := x.Table("email_address").Sync2(new(EmailAddress1)); err != nil {
+	if err := x.Table("email_address").Sync(new(EmailAddress1)); err != nil {
 		return err
 	}
 
@@ -44,7 +44,7 @@ func AddPrimaryEmail2EmailAddress(x *xorm.Engine) error {
 	}
 
 	// change lower_email as unique
-	if err := x.Sync2(new(EmailAddress)); err != nil {
+	if err := x.Sync(new(EmailAddress)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_15/v182.go
+++ b/models/migrations/v1_15/v182.go
@@ -20,7 +20,7 @@ func AddIssueResourceIndexTable(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Table("issue_index").Sync2(new(ResourceIndex)); err != nil {
+	if err := sess.Table("issue_index").Sync(new(ResourceIndex)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_15/v183.go
+++ b/models/migrations/v1_15/v183.go
@@ -30,8 +30,8 @@ func CreatePushMirrorTable(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(PushMirror)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(PushMirror)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	return sess.Commit()

--- a/models/migrations/v1_15/v184.go
+++ b/models/migrations/v1_15/v184.go
@@ -42,8 +42,8 @@ func RenameTaskErrorsToMessage(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(Task)); err != nil {
-		return fmt.Errorf("error on Sync2: %w", err)
+	if err := sess.Sync(new(Task)); err != nil {
+		return fmt.Errorf("error on Sync: %w", err)
 	}
 
 	if messageExist {

--- a/models/migrations/v1_15/v185.go
+++ b/models/migrations/v1_15/v185.go
@@ -17,5 +17,5 @@ func AddRepoArchiver(x *xorm.Engine) error {
 		CommitID    string `xorm:"VARCHAR(40) unique(s)"`
 		CreatedUnix int64  `xorm:"INDEX NOT NULL created"`
 	}
-	return x.Sync2(new(RepoArchiver))
+	return x.Sync(new(RepoArchiver))
 }

--- a/models/migrations/v1_15/v186.go
+++ b/models/migrations/v1_15/v186.go
@@ -21,5 +21,5 @@ func CreateProtectedTagTable(x *xorm.Engine) error {
 		UpdatedUnix timeutil.TimeStamp `xorm:"updated"`
 	}
 
-	return x.Sync2(new(ProtectedTag))
+	return x.Sync(new(ProtectedTag))
 }

--- a/models/migrations/v1_15/v187.go
+++ b/models/migrations/v1_15/v187.go
@@ -15,7 +15,7 @@ func DropWebhookColumns(x *xorm.Engine) error {
 		Signature string `xorm:"TEXT"`
 		IsSSL     bool   `xorm:"is_ssl"`
 	}
-	if err := x.Sync2(new(Webhook)); err != nil {
+	if err := x.Sync(new(Webhook)); err != nil {
 		return err
 	}
 
@@ -27,7 +27,7 @@ func DropWebhookColumns(x *xorm.Engine) error {
 		ContentType int
 		IsSSL       bool
 	}
-	if err := x.Sync2(new(HookTask)); err != nil {
+	if err := x.Sync(new(HookTask)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_16/v189.go
+++ b/models/migrations/v1_16/v189.go
@@ -58,7 +58,7 @@ func UnwrapLDAPSourceCfg(x *xorm.Engine) error {
 	}
 
 	// change lower_email as unique
-	if err := x.Sync2(new(LoginSource)); err != nil {
+	if err := x.Sync(new(LoginSource)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_16/v190.go
+++ b/models/migrations/v1_16/v190.go
@@ -16,7 +16,7 @@ func AddAgitFlowPullRequest(x *xorm.Engine) error {
 		Flow PullRequestFlow `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(PullRequest)); err != nil {
+	if err := x.Sync(new(PullRequest)); err != nil {
 		return fmt.Errorf("sync2: %w", err)
 	}
 	return nil

--- a/models/migrations/v1_16/v193.go
+++ b/models/migrations/v1_16/v193.go
@@ -16,7 +16,7 @@ func AddRepoIDForAttachment(x *xorm.Engine) error {
 		ReleaseID  int64  `xorm:"INDEX"` // maybe zero when creating
 		UploaderID int64  `xorm:"INDEX DEFAULT 0"`
 	}
-	if err := x.Sync2(new(Attachment)); err != nil {
+	if err := x.Sync(new(Attachment)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_16/v194.go
+++ b/models/migrations/v1_16/v194.go
@@ -14,8 +14,8 @@ func AddBranchProtectionUnprotectedFilesColumn(x *xorm.Engine) error {
 		UnprotectedFilePatterns string `xorm:"TEXT"`
 	}
 
-	if err := x.Sync2(new(ProtectedBranch)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(ProtectedBranch)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_16/v195.go
+++ b/models/migrations/v1_16/v195.go
@@ -18,8 +18,8 @@ func AddTableCommitStatusIndex(x *xorm.Engine) error {
 		MaxIndex int64  `xorm:"index"`
 	}
 
-	if err := x.Sync2(new(CommitStatusIndex)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(CommitStatusIndex)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	sess := x.NewSession()

--- a/models/migrations/v1_16/v196.go
+++ b/models/migrations/v1_16/v196.go
@@ -14,8 +14,8 @@ func AddColorColToProjectBoard(x *xorm.Engine) error {
 		Color string `xorm:"VARCHAR(7)"`
 	}
 
-	if err := x.Sync2(new(ProjectBoard)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(ProjectBoard)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_16/v197.go
+++ b/models/migrations/v1_16/v197.go
@@ -15,5 +15,5 @@ func AddRenamedBranchTable(x *xorm.Engine) error {
 		To          string
 		CreatedUnix int64 `xorm:"created"`
 	}
-	return x.Sync2(new(RenamedBranch))
+	return x.Sync(new(RenamedBranch))
 }

--- a/models/migrations/v1_16/v198.go
+++ b/models/migrations/v1_16/v198.go
@@ -25,8 +25,8 @@ func AddTableIssueContentHistory(x *xorm.Engine) error {
 
 	sess := x.NewSession()
 	defer sess.Close()
-	if err := sess.Sync2(new(IssueContentHistory)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(IssueContentHistory)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return sess.Commit()
 }

--- a/models/migrations/v1_16/v200.go
+++ b/models/migrations/v1_16/v200.go
@@ -15,8 +15,8 @@ func AddTableAppState(x *xorm.Engine) error {
 		Revision int64
 		Content  string `xorm:"LONGTEXT"`
 	}
-	if err := x.Sync2(new(AppState)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(AppState)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_16/v202.go
+++ b/models/migrations/v1_16/v202.go
@@ -16,7 +16,7 @@ func CreateUserSettingsTable(x *xorm.Engine) error {
 		SettingKey   string `xorm:"varchar(255) index unique(key_userid)"` // ensure key is always lowercase
 		SettingValue string `xorm:"text"`
 	}
-	if err := x.Sync2(new(UserSetting)); err != nil {
+	if err := x.Sync(new(UserSetting)); err != nil {
 		return fmt.Errorf("sync2: %w", err)
 	}
 	return nil

--- a/models/migrations/v1_16/v203.go
+++ b/models/migrations/v1_16/v203.go
@@ -13,5 +13,5 @@ func AddProjectIssueSorting(x *xorm.Engine) error {
 		Sorting int64 `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	return x.Sync2(new(ProjectIssue))
+	return x.Sync(new(ProjectIssue))
 }

--- a/models/migrations/v1_16/v204.go
+++ b/models/migrations/v1_16/v204.go
@@ -10,5 +10,5 @@ func AddSSHKeyIsVerified(x *xorm.Engine) error {
 		Verified bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(PublicKey))
+	return x.Sync(new(PublicKey))
 }

--- a/models/migrations/v1_16/v206.go
+++ b/models/migrations/v1_16/v206.go
@@ -18,7 +18,7 @@ func AddAuthorizeColForTeamUnit(x *xorm.Engine) error {
 		AccessMode int
 	}
 
-	if err := x.Sync2(new(TeamUnit)); err != nil {
+	if err := x.Sync(new(TeamUnit)); err != nil {
 		return fmt.Errorf("sync2: %w", err)
 	}
 

--- a/models/migrations/v1_16/v210.go
+++ b/models/migrations/v1_16/v210.go
@@ -34,7 +34,7 @@ func RemigrateU2FCredentials(x *xorm.Engine) error {
 		CreatedUnix     timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix     timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	if err := x.Sync2(&webauthnCredential{}); err != nil {
+	if err := x.Sync(&webauthnCredential{}); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_17/v212.go
+++ b/models/migrations/v1_17/v212.go
@@ -20,7 +20,7 @@ func AddPackageTables(x *xorm.Engine) error {
 		SemverCompatible bool   `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(Package)); err != nil {
+	if err := x.Sync(new(Package)); err != nil {
 		return err
 	}
 
@@ -36,7 +36,7 @@ func AddPackageTables(x *xorm.Engine) error {
 		DownloadCount int64              `xorm:"NOT NULL DEFAULT 0"`
 	}
 
-	if err := x.Sync2(new(PackageVersion)); err != nil {
+	if err := x.Sync(new(PackageVersion)); err != nil {
 		return err
 	}
 
@@ -48,7 +48,7 @@ func AddPackageTables(x *xorm.Engine) error {
 		Value   string `xorm:"TEXT NOT NULL"`
 	}
 
-	if err := x.Sync2(new(PackageProperty)); err != nil {
+	if err := x.Sync(new(PackageProperty)); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func AddPackageTables(x *xorm.Engine) error {
 		CreatedUnix  timeutil.TimeStamp `xorm:"created INDEX NOT NULL"`
 	}
 
-	if err := x.Sync2(new(PackageFile)); err != nil {
+	if err := x.Sync(new(PackageFile)); err != nil {
 		return err
 	}
 
@@ -77,7 +77,7 @@ func AddPackageTables(x *xorm.Engine) error {
 		CreatedUnix timeutil.TimeStamp `xorm:"created INDEX NOT NULL"`
 	}
 
-	if err := x.Sync2(new(PackageBlob)); err != nil {
+	if err := x.Sync(new(PackageBlob)); err != nil {
 		return err
 	}
 
@@ -89,5 +89,5 @@ func AddPackageTables(x *xorm.Engine) error {
 		UpdatedUnix    timeutil.TimeStamp `xorm:"updated INDEX NOT NULL"`
 	}
 
-	return x.Sync2(new(PackageBlobUpload))
+	return x.Sync(new(PackageBlobUpload))
 }

--- a/models/migrations/v1_17/v213.go
+++ b/models/migrations/v1_17/v213.go
@@ -13,5 +13,5 @@ func AddAllowMaintainerEdit(x *xorm.Engine) error {
 		AllowMaintainerEdit bool `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(PullRequest))
+	return x.Sync(new(PullRequest))
 }

--- a/models/migrations/v1_17/v214.go
+++ b/models/migrations/v1_17/v214.go
@@ -18,5 +18,5 @@ func AddAutoMergeTable(x *xorm.Engine) error {
 		CreatedUnix int64      `xorm:"created"`
 	}
 
-	return x.Sync2(&PullAutoMerge{})
+	return x.Sync(&PullAutoMerge{})
 }

--- a/models/migrations/v1_17/v215.go
+++ b/models/migrations/v1_17/v215.go
@@ -20,5 +20,5 @@ func AddReviewViewedFiles(x *xorm.Engine) error {
 		UpdatedUnix  timeutil.TimeStamp          `xorm:"updated"`
 	}
 
-	return x.Sync2(new(ReviewState))
+	return x.Sync(new(ReviewState))
 }

--- a/models/migrations/v1_17/v218.go
+++ b/models/migrations/v1_17/v218.go
@@ -48,5 +48,5 @@ func (*improveActionTableIndicesAction) TableIndices() []*schemas.Index {
 }
 
 func ImproveActionTableIndices(x *xorm.Engine) error {
-	return x.Sync2(&improveActionTableIndicesAction{})
+	return x.Sync(&improveActionTableIndicesAction{})
 }

--- a/models/migrations/v1_17/v219.go
+++ b/models/migrations/v1_17/v219.go
@@ -26,5 +26,5 @@ func AddSyncOnCommitColForPushMirror(x *xorm.Engine) error {
 		LastError      string             `xorm:"text"`
 	}
 
-	return x.Sync2(new(PushMirror))
+	return x.Sync(new(PushMirror))
 }

--- a/models/migrations/v1_17/v221.go
+++ b/models/migrations/v1_17/v221.go
@@ -30,7 +30,7 @@ func StoreWebauthnCredentialIDAsBytes(x *xorm.Engine) error {
 		CreatedUnix       timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix       timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	if err := x.Sync2(&webauthnCredential{}); err != nil {
+	if err := x.Sync(&webauthnCredential{}); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_17/v222.go
+++ b/models/migrations/v1_17/v222.go
@@ -49,7 +49,7 @@ func DropOldCredentialIDColumn(x *xorm.Engine) error {
 		CreatedUnix       timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix       timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	if err := x.Sync2(&webauthnCredential{}); err != nil {
+	if err := x.Sync(&webauthnCredential{}); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_17/v223.go
+++ b/models/migrations/v1_17/v223.go
@@ -53,8 +53,8 @@ func RenameCredentialIDBytes(x *xorm.Engine) error {
 			return err
 		}
 
-		if err := sess.Sync2(new(webauthnCredential)); err != nil {
-			return fmt.Errorf("error on Sync2: %w", err)
+		if err := sess.Sync(new(webauthnCredential)); err != nil {
+			return fmt.Errorf("error on Sync: %w", err)
 		}
 
 		if credentialIDExist {
@@ -99,5 +99,5 @@ func RenameCredentialIDBytes(x *xorm.Engine) error {
 		CreatedUnix     timeutil.TimeStamp `xorm:"INDEX created"`
 		UpdatedUnix     timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
-	return x.Sync2(&webauthnCredential{})
+	return x.Sync(&webauthnCredential{})
 }

--- a/models/migrations/v1_18/v224.go
+++ b/models/migrations/v1_18/v224.go
@@ -20,8 +20,8 @@ func CreateUserBadgesTable(x *xorm.Engine) error {
 		UserID  int64 `xorm:"INDEX"`
 	}
 
-	if err := x.Sync2(new(Badge)); err != nil {
+	if err := x.Sync(new(Badge)); err != nil {
 		return err
 	}
-	return x.Sync2(new(userBadge))
+	return x.Sync(new(userBadge))
 }

--- a/models/migrations/v1_18/v227.go
+++ b/models/migrations/v1_18/v227.go
@@ -43,7 +43,7 @@ func insertSettingsIfNotExist(x *xorm.Engine, sysSettings []*SystemSetting) erro
 }
 
 func CreateSystemSettingsTable(x *xorm.Engine) error {
-	if err := x.Sync2(new(SystemSetting)); err != nil {
+	if err := x.Sync(new(SystemSetting)); err != nil {
 		return fmt.Errorf("sync2: %w", err)
 	}
 

--- a/models/migrations/v1_18/v228.go
+++ b/models/migrations/v1_18/v228.go
@@ -21,5 +21,5 @@ func AddTeamInviteTable(x *xorm.Engine) error {
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	return x.Sync2(new(TeamInvite))
+	return x.Sync(new(TeamInvite))
 }

--- a/models/migrations/v1_19/v234.go
+++ b/models/migrations/v1_19/v234.go
@@ -24,5 +24,5 @@ func CreatePackageCleanupRuleTable(x *xorm.Engine) error {
 		UpdatedUnix   timeutil.TimeStamp `xorm:"updated NOT NULL DEFAULT 0"`
 	}
 
-	return x.Sync2(new(PackageCleanupRule))
+	return x.Sync(new(PackageCleanupRule))
 }

--- a/models/migrations/v1_20/v245.go
+++ b/models/migrations/v1_20/v245.go
@@ -40,7 +40,7 @@ func RenameWebhookOrgToOwner(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(Webhook)); err != nil {
+	if err := sess.Sync(new(Webhook)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_21/v263.go
+++ b/models/migrations/v1_21/v263.go
@@ -23,8 +23,8 @@ func AddGitSizeAndLFSSizeToRepositoryTable(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(Repository)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(Repository)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	_, err := sess.Exec(`UPDATE repository SET lfs_size=(SELECT SUM(size) FROM lfs_meta_object WHERE lfs_meta_object.repository_id=repository.ID) WHERE EXISTS (SELECT 1 FROM lfs_meta_object WHERE lfs_meta_object.repository_id=repository.ID)`)

--- a/models/migrations/v1_6/v71.go
+++ b/models/migrations/v1_6/v71.go
@@ -27,8 +27,8 @@ func AddScratchHash(x *xorm.Engine) error {
 		UpdatedUnix      timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	if err := x.Sync2(new(TwoFactor)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(TwoFactor)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	sess := x.NewSession()

--- a/models/migrations/v1_6/v72.go
+++ b/models/migrations/v1_6/v72.go
@@ -23,8 +23,8 @@ func AddReview(x *xorm.Engine) error {
 		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
 	}
 
-	if err := x.Sync2(new(Review)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := x.Sync(new(Review)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return nil
 }

--- a/models/migrations/v1_7/v73.go
+++ b/models/migrations/v1_7/v73.go
@@ -14,5 +14,5 @@ func AddMustChangePassword(x *xorm.Engine) error {
 		MustChangePassword bool  `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(User))
+	return x.Sync(new(User))
 }

--- a/models/migrations/v1_7/v74.go
+++ b/models/migrations/v1_7/v74.go
@@ -11,5 +11,5 @@ func AddApprovalWhitelistsToProtectedBranches(x *xorm.Engine) error {
 		ApprovalsWhitelistTeamIDs []int64 `xorm:"JSON TEXT"`
 		RequiredApprovals         int64   `xorm:"NOT NULL DEFAULT 0"`
 	}
-	return x.Sync2(new(ProtectedBranch))
+	return x.Sync(new(ProtectedBranch))
 }

--- a/models/migrations/v1_8/v77.go
+++ b/models/migrations/v1_8/v77.go
@@ -12,5 +12,5 @@ func AddUserDefaultTheme(x *xorm.Engine) error {
 		Theme string `xorm:"VARCHAR(30) NOT NULL DEFAULT ''"`
 	}
 
-	return x.Sync2(new(User))
+	return x.Sync(new(User))
 }

--- a/models/migrations/v1_8/v78.go
+++ b/models/migrations/v1_8/v78.go
@@ -22,7 +22,7 @@ func RenameRepoIsBareToIsEmpty(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(Repository)); err != nil {
+	if err := sess.Sync(new(Repository)); err != nil {
 		return err
 	}
 	if _, err := sess.Exec("UPDATE repository SET is_empty = is_bare;"); err != nil {

--- a/models/migrations/v1_8/v79.go
+++ b/models/migrations/v1_8/v79.go
@@ -15,7 +15,7 @@ func AddCanCloseIssuesViaCommitInAnyBranch(x *xorm.Engine) error {
 		CloseIssuesViaCommitInAnyBranch bool  `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	if err := x.Sync2(new(Repository)); err != nil {
+	if err := x.Sync(new(Repository)); err != nil {
 		return err
 	}
 

--- a/models/migrations/v1_8/v80.go
+++ b/models/migrations/v1_8/v80.go
@@ -12,5 +12,5 @@ func AddIsLockedToIssues(x *xorm.Engine) error {
 		IsLocked bool  `xorm:"NOT NULL DEFAULT false"`
 	}
 
-	return x.Sync2(new(Issue))
+	return x.Sync(new(Issue))
 }

--- a/models/migrations/v1_9/v83.go
+++ b/models/migrations/v1_9/v83.go
@@ -23,5 +23,5 @@ func AddUploaderIDForAttachment(x *xorm.Engine) error {
 		CreatedUnix   timeutil.TimeStamp `xorm:"created"`
 	}
 
-	return x.Sync2(new(Attachment))
+	return x.Sync(new(Attachment))
 }

--- a/models/migrations/v1_9/v84.go
+++ b/models/migrations/v1_9/v84.go
@@ -13,5 +13,5 @@ func AddGPGKeyImport(x *xorm.Engine) error {
 		Content string `xorm:"TEXT NOT NULL"`
 	}
 
-	return x.Sync2(new(GPGKeyImport))
+	return x.Sync(new(GPGKeyImport))
 }

--- a/models/migrations/v1_9/v85.go
+++ b/models/migrations/v1_9/v85.go
@@ -40,8 +40,8 @@ func HashAppToken(x *xorm.Engine) error {
 		return err
 	}
 
-	if err := sess.Sync2(new(AccessToken)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(AccessToken)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 
 	if err := sess.Commit(); err != nil {
@@ -112,8 +112,8 @@ func resyncHashAppTokenWithUniqueHash(x *xorm.Engine) error {
 	if err := sess.Begin(); err != nil {
 		return err
 	}
-	if err := sess.Sync2(new(AccessToken)); err != nil {
-		return fmt.Errorf("Sync2: %w", err)
+	if err := sess.Sync(new(AccessToken)); err != nil {
+		return fmt.Errorf("Sync: %w", err)
 	}
 	return sess.Commit()
 }

--- a/models/migrations/v1_9/v86.go
+++ b/models/migrations/v1_9/v86.go
@@ -12,5 +12,5 @@ func AddHTTPMethodToWebhook(x *xorm.Engine) error {
 		HTTPMethod string `xorm:"http_method DEFAULT 'POST'"`
 	}
 
-	return x.Sync2(new(Webhook))
+	return x.Sync(new(Webhook))
 }

--- a/models/migrations/v1_9/v87.go
+++ b/models/migrations/v1_9/v87.go
@@ -13,5 +13,5 @@ func AddAvatarFieldToRepository(x *xorm.Engine) error {
 		Avatar string `xorm:"VARCHAR(64)"`
 	}
 
-	return x.Sync2(new(Repository))
+	return x.Sync(new(Repository))
 }


### PR DESCRIPTION
The xorm `Sync2` has already been deprecated in favor of `Sync`,
so let's do the same inside the Gitea codebase.

Command used to replace everything:
```sh
for i in $(ag Sync2 --files-with-matches); do vim $i -c ':%sno/Sync2/Sync/g' -c ':wq'; done
```