### PR TITLE
make filename accessible in dropzone

### DIFF
--- a/web_src/css/features/dropzone.css
+++ b/web_src/css/features/dropzone.css
@@ -51,3 +51,12 @@
 .dropzone .dz-preview:hover .dz-image img {
   filter: opacity(0.5) !important;
 }
+
+.dropzone .dz-preview.dz-image-preview .dz-filename {
+  /* Don't use margin or padding, as that will mess with the dimensions
+   * of the details div and thereby making the 'Cancel upload' button
+   * inaccessible to use.
+  */
+  position: relative;
+  top: 2em;
+}


### PR DESCRIPTION
- In Forgejo you can upload files by drag n dropping them in selective 'zones', these are handled by
[dropzone](https://github.com/dropzone/dropzone). While waiting for it to finish uploading, you can see the file's size and name.
- The name was conviently placed under the progress bar, so as an file is uploading you couldn't see the filename anymore.
- This patch fixes that by simply moving the filename a few pixels down.
- Resolves https://codeberg.org/Codeberg/Community/issues/1104

Refs: https://codeberg.org/forgejo/forgejo/pulls/1242

(cherry picked from commit 58d500aafdd2dd5756427376763132cdcc5b608c)
