### PR TITLE
maintain aspect ratio for auth icons

### DIFF
--- a/services/auth/source/oauth2/providers.go
+++ b/services/auth/source/oauth2/providers.go
@@ -56,7 +56,7 @@ func (p *AuthSourceProvider) DisplayName() string {
 
 func (p *AuthSourceProvider) IconHTML() template.HTML {
 	if p.iconURL != "" {
-		img := fmt.Sprintf(`<img class="gt-mr-3" width="20" height="20" src="%s" alt="%s">`,
+		img := fmt.Sprintf(`<img class="gt-mr-3 oauth-provider-icon" src="%s" alt="%s">`,
 			html.EscapeString(p.iconURL), html.EscapeString(p.DisplayName()),
 		)
 		return template.HTML(img)

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -2289,3 +2289,8 @@ table th[data-sortt-desc] .svg {
   flex-wrap: wrap;
   gap: .25rem;
 }
+
+.oauth-provider-icon {
+  max-height: 20px;
+  max-width: 20px;
+}


### PR DESCRIPTION
- When specifying an icon URL for a authentication source, it's forced to be an width and height of 20px. However this didn't take into account that icons could have an different aspect ratio of 1:1.
- This patch fixes that by instead using `max-width` and `max-height` which will respect other aspect ratios.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1234

Refs: https://codeberg.org/forgejo/forgejo/pulls/1241

(cherry picked from commit bd915b867057c1aaae1b4a33a83a5703cabda462)
