### PR TITLE
recognize OGG as an audio format

### DIFF
--- a/modules/typesniffer/typesniffer.go
+++ b/modules/typesniffer/typesniffer.go
@@ -62,7 +62,7 @@ func (ct SniffedType) IsVideo() bool {
 
 // IsAudio detects if data is an video format
 func (ct SniffedType) IsAudio() bool {
-	return strings.Contains(ct.contentType, "audio/")
+	return strings.Contains(ct.contentType, "audio/") || strings.Contains(ct.contentType, "application/ogg")
 }
 
 // IsRepresentableAsText returns true if file content can be represented as

--- a/modules/typesniffer/typesniffer_test.go
+++ b/modules/typesniffer/typesniffer_test.go
@@ -113,6 +113,8 @@ func TestIsAudio(t *testing.T) {
 	assert.True(t, DetectContentType([]byte("ID3Toy\000")).IsAudio())
 	assert.True(t, DetectContentType([]byte("ID3Toy\n====\t* hi 🌞, ...")).IsText())          // test ID3 tag for plain text
 	assert.True(t, DetectContentType([]byte("ID3Toy\n====\t* hi 🌞, ..."+"🌛"[0:2])).IsText()) // test ID3 tag with incomplete UTF8 char
+
+	assert.True(t, DetectContentType([]byte("OggS\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x7e\x46\x00\x00\x00\x00\x00\x00\x1f\xf6\xb4\xfc\x01\x1e\x01\x76\x6f\x72")).IsAudio()) // application/ogg
 }
 
 func TestDetectContentTypeFromReader(t *testing.T) {


### PR DESCRIPTION
- OGG is officially an container format and is therefor classified as `application/ogg` in RFC3534. While `audio/ogg` exists, as defined in RFC5334, it doesn't have a different magic number and thus purely informative, it can only be determined by parsing the file and checking if it only contains audio data.
- A quick search on Wikimedia Commons yields that the OGG container is by far more used for audio than for video, so it's safe to classify this as audio, as OGG files that only contain video would now falsy be classified as an audio file (previously it would've shown just a link to the 'View Raw' link).
- Added unit tests.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1091

(cherry picked from commit f5fa1a245236527dd41af4e71b5486c1a39e898a)