### PR TITLE
Move dropzone progress bar to bottom to show filename when uploading

### DIFF
--- a/web_src/css/features/dropzone.css
+++ b/web_src/css/features/dropzone.css
@@ -51,3 +51,9 @@
 .dropzone .dz-preview:hover .dz-image img {
   filter: opacity(0.5) !important;
 }
+
+.ui .field .dropzone .dz-preview .dz-progress {
+  /* by default the progress-bar is vertically centered (top: 50%), it's better to put it after the "details (size, filename)",
+  then the layout from top to bottom is: size, filename, progress */
+  top: 7em;
+}


### PR DESCRIPTION
1. Make the "filename" visible
2. Avoiding UI flicker when the uploading is completing

Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/836f249a-2850-4202-b4e5-d52aa5c66e98)


After:

![image](https://github.com/go-gitea/gitea/assets/2114189/a14f47a9-0dd6-4ff5-bdda-05fda07dbb35)

