### PR TITLE
Fix dark theme highlight for "NameNamespace"

### DIFF
--- a/web_src/css/chroma/dark.css
+++ b/web_src/css/chroma/dark.css
@@ -45,7 +45,7 @@
 .chroma .nf { color: #fabd2f; } /* NameFunction */
 .chroma .ni { color: #fabd2f; } /* NameEntity */
 .chroma .nl { color: #ff7540; } /* NameLabel */
-.chroma .nn { color: #ffaa10; } /* NameNamespace */
+.chroma .nn { color: #c9d1d9; } /* NameNamespace */
 .chroma .no { color: #649bc4; } /* NameConstant */
 .chroma .nt { color: #ff7540; } /* NameTag */
 .chroma .nv { color: #ebdbb2; } /* NameVariable */


### PR DESCRIPTION
The color is taken from "Name"

Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/b94d7521-770c-4e14-a63b-f30c44fe883f)


After:

![image](https://github.com/go-gitea/gitea/assets/2114189/d99c1f13-a0c0-4dc8-82ab-bfdd451e46ec)
