### PR TITLE
Use `hidden` over `clip` for text truncation

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1235,7 +1235,7 @@ img.ui.avatar,
 }
 
 .ui .text.truncate {
-  overflow-x: clip;
+  overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   display: inline-block;


### PR DESCRIPTION
Avoid browser bugs:

- Firefox not cutting off - https://github.com/go-gitea/gitea/pull/26354#issuecomment-1678456052
- Safari not showing ellipsis - https://github.com/go-gitea/gitea/pull/26354#issuecomment-1678812801