### PR TITLE
Remove duplicate CSS import for chroma/base.css

### DIFF
--- a/web_src/css/themes/theme-arc-green.css
+++ b/web_src/css/themes/theme-arc-green.css
@@ -1,4 +1,3 @@
-@import "../chroma/base.css";
 @import "../chroma/dark.css";
 @import "../codemirror/dark.css";
 


### PR DESCRIPTION
The file is [already imported](https://github.com/go-gitea/gitea/blob/27e4ac3e40265722abf9f99d519cb5985eebd1c7/web_src/css/index.css#L34) in index.css, so there is no reason to import it again in the theme. It actually caused duplicate CSS to be loaded.