### PR TITLE
Differentiate better between user settings and admin settings

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -604,6 +604,7 @@ disabled_public_activity = This user has disabled the public visibility of the a
 email_visibility.limited = Your email address is visible to all authenticated users
 email_visibility.private = Your email address is only visible to you and administrators
 show_on_map = Show this place on a map
+settings = User Settings
 
 form.name_reserved = The username "%s" is reserved.
 form.name_pattern_not_allowed = The pattern "%s" is not allowed in a username.
@@ -2667,6 +2668,7 @@ monitor = Monitoring
 first_page = First
 last_page = Last
 total = Total: %d
+settings = Admin Settings
 
 dashboard.new_version_hint = Gitea %s is now available, you are running %s. Check <a target="_blank" rel="noreferrer" href="https://blog.gitea.io">the blog</a> for more details.
 dashboard.statistic = Summary

--- a/templates/admin/navbar.tmpl
+++ b/templates/admin/navbar.tmpl
@@ -1,6 +1,6 @@
 <div class="flex-container-nav">
 	<div class="ui fluid vertical menu">
-		<div class="header item">{{.locale.Tr "settings"}}</div>
+		<div class="header item">{{.locale.Tr "admin.settings"}}</div>
 		<a class="{{if .PageIsAdminDashboard}}active {{end}}item" href="{{AppSubUrl}}/admin">
 			{{.locale.Tr "admin.dashboard"}}
 		</a>

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -1,6 +1,6 @@
 <div class="flex-container-nav">
 	<div class="ui fluid vertical menu">
-		<div class="header item">{{.locale.Tr "settings"}}</div>
+		<div class="header item">{{.locale.Tr "user.settings"}}</div>
 		<a class="{{if .PageIsSettingsProfile}}active {{end}}item" href="{{AppSubUrl}}/user/settings">
 			{{.locale.Tr "settings.profile"}}
 		</a>


### PR DESCRIPTION
User settings page and admin settings page are too similar. I thinlk this will be better of using `User Settings` and `Admin Settings` as the navbar's title.

Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/68db06f3-918b-41bc-b4d3-522b1057eb57)
![image](https://github.com/go-gitea/gitea/assets/18380374/24f53d91-54e1-410c-ad9b-438bb2c8069f)

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/6600a872-d630-4ea6-a58f-d9ded7d38067)
![image](https://github.com/go-gitea/gitea/assets/18380374/501cde5d-9868-4cba-829d-ff8bafce695d)
