### PR TITLE
Fix dashboard feed icon color

### DIFF
--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -120,7 +120,7 @@
 				<div class="flex-item-body">{{TimeSince .GetCreate $.locale}}</div>
 			</div>
 			<div class="flex-item-trailing">
-				{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 32}}
+				{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 32 "text grey"}}
 			</div>
 		</div>
 	{{end}}


### PR DESCRIPTION
https://github.com/go-gitea/gitea/pull/25790 had [changed](https://github.com/go-gitea/gitea/pull/25790/files#diff-bc170be40002f926441aa2ebb2e6e119a03e50acfbbecad5d2070c824150aa82L121) this icon color to body text color, revert it to previous shade. Before and after:

<img width="60" alt="Screenshot 2023-08-17 at 02 02 35" src="https://github.com/go-gitea/gitea/assets/115237/f67c399c-1539-4e8a-81be-a2f4c875a5b4">
<img width="58" alt="Screenshot 2023-08-17 at 02 02 41" src="https://github.com/go-gitea/gitea/assets/115237/98117c98-99fb-4c16-a8ef-6259d41a56d7">
