### PR TITLE
Fix various line-height styles

### DIFF
--- a/web_src/css/admin.css
+++ b/web_src/css/admin.css
@@ -13,7 +13,7 @@
 
 .admin dl.admin-dl-horizontal dt,
 .admin dl.admin-dl-horizontal dd {
-  line-height: 1;
+  line-height: var(--line-height-default);
   padding: 5px 0;
 }
 

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -9,6 +9,8 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  /* line-height: use the default value as "modules/normalize.css" */
+  --line-height-default: 1.15;
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
@@ -518,6 +520,7 @@ a.label,
 .ui.menu .item {
   color: var(--color-text);
   user-select: auto;
+  line-height: var(--line-height-default); /* fomantic uses "1" which causes overflow problems because "1" doesn't consider the descent part */
 }
 
 .ui.menu .item > .svg {
@@ -1476,7 +1479,7 @@ img.ui.avatar,
   height: 3em;
   float: none;
   display: block;
-  line-height: 1;
+  line-height: var(--line-height-default);
   padding: 0;
   margin: 0 auto 0.5rem;
   opacity: 1;
@@ -2124,7 +2127,7 @@ table th[data-sortt-desc] .svg {
 .emoji,
 .reaction {
   font-size: 1.25em;
-  line-height: 1;
+  line-height: var(--line-height-default);
   font-style: normal !important;
   font-weight: var(--font-weight-normal) !important;
   vertical-align: -0.075em;
@@ -2247,7 +2250,7 @@ table th[data-sortt-desc] .svg {
 }
 
 .ui.dropdown {
-  line-height: 1; /* the dropdown doesn't have default line-height, use this to make the dropdown icon align with plain dropdown */
+  line-height: var(--line-height-default); /* the dropdown doesn't have default line-height, use this to make the dropdown icon align with plain dropdown */
 }
 
 /* dropdown has some kinds of icons:

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -521,6 +521,8 @@ a.label,
   color: var(--color-text);
   user-select: auto;
   line-height: var(--line-height-default); /* fomantic uses "1" which causes overflow problems because "1" doesn't consider the descent part */
+  padding-top: 11px; /* counteract line-height change */
+  padding-bottom: 11px; /* counteract line-height change */
 }
 
 .ui.menu .item > .svg {
@@ -667,6 +669,8 @@ a.label,
 .ui.secondary.menu .item {
   margin-left: 0;
   margin-right: 0;
+  padding-top: 10px; /* counteract line-height change */
+  padding-bottom: 10px; /* counteract line-height change */
 }
 
 .ui.secondary.menu .dropdown.item:hover,

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -390,7 +390,7 @@
 }
 
 .repository.file.list .non-diff-file-content .header .file-actions .btn-octicon {
-  line-height: 1;
+  line-height: var(--line-height-default);
   padding: 10px 8px;
   vertical-align: middle;
   color: var(--color-text);

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -391,7 +391,7 @@
 
 .repository.file.list .non-diff-file-content .header .file-actions .btn-octicon {
   line-height: var(--line-height-default);
-  padding: 10px 8px;
+  padding: 8px;
   vertical-align: middle;
   color: var(--color-text);
 }


### PR DESCRIPTION
Fix #26537

Use the same default line-height as "normalize.css" instead of "1". "1" is not right because it doesn't work with descent part and causes overflow problems.

![image](https://github.com/go-gitea/gitea/assets/2114189/3f2e8fb5-b326-4889-bfff-c79c75f1b7f4)
