### PR TITLE
Fix label filter between `all` and `no`

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -177,7 +177,8 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption uti
 		ctx.Data["AllLabels"] = true
 	} else if selectLabels == "0" {
 		ctx.Data["NoLabel"] = true
-	} else if len(selectLabels) > 0 {
+	}
+	if len(selectLabels) > 0 {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectLabels, ","))
 		if err != nil {
 			ctx.ServerError("StringsToInt64s", err)


### PR DESCRIPTION
Regression of https://github.com/go-gitea/gitea/pull/25886.
# Description 
For `labelIDs`:
https://github.com/go-gitea/gitea/blob/9afcb0e0461aa48a4fbda7740d4c5424911e35ef/routers/web/repo/issue.go#L171-L174
 - `nil` mean no filter
 - `[0]` mean `no label` filter

When `selectLabels == "0"`, labelIDs should be `[0]` rather than `nil`
 # Before:
 

https://github.com/go-gitea/gitea/assets/50507092/3dac5075-6da0-4769-ba20-48a56f4063c0


#  After:

https://github.com/go-gitea/gitea/assets/50507092/ff79fd4c-b02e-4dfb-9309-ae7851f4dcdb

