### PR TITLE
Fix incorrect replacement in markdown image links

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -409,7 +409,7 @@ func visitNode(ctx *RenderContext, procs, textProcs []processor, node *html.Node
 					if ctx.IsWiki {
 						prefix = util.URLJoin(prefix, "wiki", "raw")
 					}
-					prefix = strings.Replace(prefix, "/src/", "/media/", 1)
+					prefix = strings.Replace(prefix, "/src/branch/", "/media/branch/", 1)
 
 					attr.Val = util.URLJoin(prefix, attr.Val)
 				}

--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -91,7 +91,7 @@ func (g *ASTTransformer) Transform(node *ast.Document, reader text.Reader, pc pa
 				if pc.Get(isWikiKey).(bool) {
 					prefix = giteautil.URLJoin(prefix, "wiki", "raw")
 				}
-				prefix = strings.Replace(prefix, "/src/", "/media/", 1)
+				prefix = strings.Replace(prefix, "/src/branch/", "/media/branch/", 1)
 
 				lnk := strings.TrimLeft(string(link), "/")
 

--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -174,7 +174,7 @@ func getMediaURL(l []byte) string {
 
 	// Check if link is valid
 	if len(srcURL) > 0 && !markup.IsLink(l) {
-		srcURL = strings.Replace(srcURL, "/src/", "/media/", 1)
+		srcURL = strings.Replace(srcURL, "/src/branch/", "/media/branch/", 1)
 	}
 
 	return srcURL


### PR DESCRIPTION
Fix #26548
When the repo name is `src`:
-  `/<user>/src/src/branch/` => `/<user>/media/src/branch/` 

it should be: 
-  `/<user>/src/src/branch/` => `/<user>/src/media/branch/` 