### PR TITLE
Add minimum polyfill to support "relative-time-element" in PaleMoon

### DIFF
--- a/web_src/js/webcomponents/polyfill.js
+++ b/web_src/js/webcomponents/polyfill.js
@@ -1,0 +1,17 @@
+try {
+  // some browsers like PaleMoon don't have full support for Intl.NumberFormat, so do the minimum polyfill to support "relative-time-element"
+  // https://repo.palemoon.org/MoonchildProductions/UXP/issues/2289
+  new Intl.NumberFormat('en', {style: 'unit', unit: 'minute'}).format(1);
+} catch {
+  const intlNumberFormat = Intl.NumberFormat;
+  Intl.NumberFormat = function(locales, options) {
+    if (options.style === 'unit') {
+      return {
+        format(value) {
+          return ` ${value} ${options.unit}`;
+        }
+      };
+    }
+    return intlNumberFormat(locales, options);
+  };
+}

--- a/web_src/js/webcomponents/webcomponents.js
+++ b/web_src/js/webcomponents/webcomponents.js
@@ -1,3 +1,5 @@
 import '@webcomponents/custom-elements'; // polyfill for some browsers like Pale Moon
+import './polyfill.js';
+
 import '@github/relative-time-element';
 import './GiteaOriginUrl.js';


### PR DESCRIPTION
Close #26525

Q&A:

* Why not fully polyfill?
    * The full polyfill would be quite big because it needs different locale resources.
* Why not use something like `https://polyfill.io/v3/`?
    * It needs to access external sites
    * Actually "polyfill.io" doesn't polyfill the incomplete `Intl.NumberFormat` because it considers there is already `Intl.NumberFormat` support .....
