### PR TITLE
Swap highlighting  between tags and branches

### DIFF
--- a/web_src/js/components/RepoBranchTagSelector.vue
+++ b/web_src/js/components/RepoBranchTagSelector.vue
@@ -21,13 +21,13 @@
           <div class="ui grid">
             <div class="two column row">
               <a class="reference column" href="#" @click="handleTabSwitch('branches')">
-                <span class="text" :class="{black: mode === 'branches'}">
+                <span class="text" :class="{black: mode !== 'branches'}">
                   <svg-icon name="octicon-git-branch" :size="16" class-name="gt-mr-2"/>{{ textBranches }}
                 </span>
               </a>
               <template v-if="!noTag">
                 <a class="reference column" href="#" @click="handleTabSwitch('tags')">
-                  <span class="text" :class="{black: mode === 'tags'}">
+                  <span class="text" :class="{black: mode !== 'tags'}">
                     <svg-icon name="octicon-tag" :size="16" class-name="gt-mr-2"/>{{ textTags }}
                   </span>
                 </a>


### PR DESCRIPTION
In the dropdown box, the color when selected is `black` instead of highlighted, which seems a bit strange.
- Before:
<img src="https://github.com/go-gitea/gitea/assets/50507092/0ccb37d9-bfd2-475b-85db-040f205978d4" width="150px">

- After:
<img src="https://github.com/go-gitea/gitea/assets/50507092/b86e29e4-b5ac-42f2-9c3f-e03297de2d3a" width="150px">

