### PR TITLE
Allow text selection in actions step header

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -740,7 +740,6 @@ export function initRepositoryActionView() {
   padding: 5px 10px;
   display: flex;
   align-items: center;
-  user-select: none;
   border-radius: var(--border-radius);
 }
 


### PR DESCRIPTION
It's useful being able to select text there:

<img width="888" alt="Screenshot 2023-08-18 at 19 02 34" src="https://github.com/go-gitea/gitea/assets/115237/7491ee19-819f-4206-9da0-96c954333a38">
