### PR TITLE
Bump xgo to go-1.21.x and node to 20 in release-version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,11 +41,10 @@ steps:
         path: /go
 
   - name: static
-    image: techknowlogick/xgo:go-1.20.x
+    image: techknowlogick/xgo:go-1.21.x
     pull: always
     commands:
-      # Upgrade to node 20 once https://github.com/techknowlogick/xgo/issues/163 is resolved
-      - curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get -qqy install nodejs
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash - && apt-get -qqy install nodejs
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:


### PR DESCRIPTION
Now that https://github.com/techknowlogick/xgo/issues/163 is resolved, we can bump these.

It seems there is no way to dry-run this, so we may only notice issues next release, but I don't expect any.