### PR TITLE
Set errwriter for urfave/cli v1

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,6 +150,8 @@ func main() {
 		log.GetManager().Close()
 		os.Exit(code)
 	}
+	app.ErrWriter = os.Stderr
+
 	_ = cmd.RunMainApp(app, os.Args...) // all errors should have been handled by the RunMainApp
 	log.GetManager().Close()
 }


### PR DESCRIPTION
Should resolve #26615

urfave/cli v1 doesn't set an errwriter https://github.com/urfave/cli/blob/ed683a717c7f2a15b9a631a8f8170b7bfa247708/app.go#L127
Instead it defers to the package-level errwriter, which _is_ set to `os.Stderr`, but it only does this for internal error messages, so when we use it explicitly it's still `nil`

This likely works fine in 1.21+ because we updated to urfave/cli v2 which sets an errwriter https://github.com/urfave/cli/blob/v2.25.7/app.go#L156