### PR TITLE
Use correct minio error

### DIFF
--- a/modules/storage/minio.go
+++ b/modules/storage/minio.go
@@ -91,8 +91,8 @@ func NewMinioStorage(ctx context.Context, cfg *setting.Storage) (ObjectStorage, 
 	}
 
 	// Check to see if we already own this bucket
-	exists, errBucketExists := minioClient.BucketExists(ctx, config.Bucket)
-	if errBucketExists != nil {
+	exists, err := minioClient.BucketExists(ctx, config.Bucket)
+	if err != nil {
 		return nil, convertMinioErr(err)
 	}
 


### PR DESCRIPTION
Previously, `err` was defined above, checked for `err == nil` and used nowhere else.
Hence, the result of `convertMinioErr` would always be `nil`.
This leads to a NPE further down the line.
That is not intentional, it should convert the error of the most recent operation, not one of its predecessors.

Found through https://discord.com/channels/322538954119184384/322538954119184384/1143185780206993550.