### PR TITLE
Use line-height: normal by default

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -10,7 +10,7 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   /* line-height: use the default value as "modules/normalize.css" */
-  --line-height-default: 1.15;
+  --line-height-default: normal;
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
@@ -521,8 +521,6 @@ a.label,
   color: var(--color-text);
   user-select: auto;
   line-height: var(--line-height-default); /* fomantic uses "1" which causes overflow problems because "1" doesn't consider the descent part */
-  padding-top: 11px; /* counteract line-height change */
-  padding-bottom: 11px; /* counteract line-height change */
 }
 
 .ui.menu .item > .svg {
@@ -669,8 +667,6 @@ a.label,
 .ui.secondary.menu .item {
   margin-left: 0;
   margin-right: 0;
-  padding-top: 10px; /* counteract line-height change */
-  padding-bottom: 10px; /* counteract line-height change */
 }
 
 .ui.secondary.menu .dropdown.item:hover,

--- a/web_src/css/modules/normalize.css
+++ b/web_src/css/modules/normalize.css
@@ -25,7 +25,7 @@ Use a better box model (opinionated).
 }
 
 html {
-  line-height: 1.15; /* 1. Correct the line height in all browsers. */
+  line-height: normal; /* 1. (not following the "modern-normalize") Do not change the browser's default line-height, the default value is font-dependent and roughly 1.2 */
   -webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
 }
 


### PR DESCRIPTION
Fix #26537 again because 1.15 is too small for some fonts.
 
I do not see how the "padding-top/padding-bottom" affects the UI, and I do not think the pixel-level fine-tuning is a stable approach, so remove these fine-tunes.
