### PR TITLE
Ignore VSCode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ cpu.out
 /VERSION
 /.air
 /.go-licenses
-/vscode/*
+/.vscode
 
 # Snapcraft
 snap/.snapcraft/

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ cpu.out
 /VERSION
 /.air
 /.go-licenses
+/vscode/*
 
 # Snapcraft
 snap/.snapcraft/


### PR DESCRIPTION
The reason for this PR is that gitpod copies the vscode config into root and you need to be careful not to commit it, as well as some users may wish to customize it per their preferences.