### PR TITLE
Add `white-space: nowrap` to ui.button

### DIFF
--- a/web_src/css/modules/button.css
+++ b/web_src/css/modules/button.css
@@ -5,6 +5,7 @@
   background: var(--color-button);
   border: 1px solid var(--color-light-border);
   color: var(--color-text);
+  white-space: nowrap;
 }
 
 .ui.button:hover {


### PR DESCRIPTION
Try to fix #26617

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/9078da43-6395-408c-9907-6e1e6c75de01)
![image](https://github.com/go-gitea/gitea/assets/18380374/1812bb8f-4edd-48b9-b402-a3b93de06745)
