### PR TITLE
feat(API): update and delete secret for managing organization secrets

### DIFF
--- a/models/secret/secret.go
+++ b/models/secret/secret.go
@@ -95,8 +95,8 @@ func CountSecrets(ctx context.Context, opts *FindSecretsOptions) (int64, error) 
 	return db.GetEngine(ctx).Where(opts.toConds()).Count(new(Secret))
 }
 
-// ChangeSecret changes org or user reop secret.
-func ChangeSecret(ctx context.Context, orgID, repoID int64, name, data string) error {
+// UpdateSecret changes org or user reop secret.
+func UpdateSecret(ctx context.Context, orgID, repoID int64, name, data string) error {
 	sc := new(Secret)
 	has, err := db.GetEngine(ctx).
 		Where("owner_id=?", orgID).

--- a/modules/structs/secret.go
+++ b/modules/structs/secret.go
@@ -29,7 +29,7 @@ type CreateSecretOption struct {
 // UpdateSecretOption options when updating secret
 // swagger:model
 type UpdateSecretOption struct {
-	// Data of the secret to create
+	// Data of the secret to update
 	//
 	// required: true
 	Data string `json:"data" binding:"Required"`

--- a/modules/structs/secret.go
+++ b/modules/structs/secret.go
@@ -25,3 +25,12 @@ type CreateSecretOption struct {
 	// Data of the secret to create
 	Data string `json:"data" binding:"Required"`
 }
+
+// UpdateSecretOption options when updating secret
+// swagger:model
+type UpdateSecretOption struct {
+	// Data of the secret to create
+	//
+	// required: true
+	Data string `json:"data" binding:"Required"`
+}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1301,6 +1301,9 @@ func Routes() *web.Route {
 			m.Group("/actions/secrets", func() {
 				m.Get("", reqToken(), reqOrgOwnership(), org.ListActionsSecrets)
 				m.Post("", reqToken(), reqOrgOwnership(), bind(api.CreateSecretOption{}), org.CreateOrgSecret)
+				m.Combo("/{secretname}").
+					Put(reqToken(), reqOrgOwnership(), bind(api.UpdateSecretOption{}), org.UpdateOrgSecret).
+					Delete(reqToken(), reqOrgOwnership(), org.DeleteOrgSecret)
 			})
 			m.Group("/public_members", func() {
 				m.Get("", org.ListPublicMembers)

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -103,6 +103,10 @@ func CreateOrgSecret(ctx *context.APIContext) {
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
 	opt := web.GetForm(ctx).(*api.CreateSecretOption)
+	if err := actions.NameRegexMatch(opt.Name); err != nil {
+		ctx.Error(http.StatusBadRequest, "CreateOrgSecret", err)
+		return
+	}
 	s, err := secret_model.InsertEncryptedSecret(
 		ctx, ctx.Org.Organization.ID, 0, opt.Name, actions.ReserveLineBreakForTextarea(opt.Data),
 	)

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -145,7 +145,7 @@ func UpdateOrgSecret(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 	secretName := ctx.Params(":secretname")
 	opt := web.GetForm(ctx).(*api.UpdateSecretOption)
-	err := secret_model.ChangeSecret(
+	err := secret_model.UpdateSecret(
 		ctx, ctx.Org.Organization.ID, 0, secretName, opt.Data,
 	)
 	if err != nil {

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -140,7 +140,7 @@ func UpdateOrgSecret(ctx *context.APIContext) {
 	//     "$ref": "#/definitions/UpdateSecretOption"
 	// responses:
 	//   "204":
-	//     description: membership publicized
+	//     description: update one secret of the organization
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
 	secretName := ctx.Params(":secretname")
@@ -178,7 +178,7 @@ func DeleteOrgSecret(ctx *context.APIContext) {
 	//   required: true
 	// responses:
 	//   "204":
-	//     description: membership publicized
+	//     description: delete one secret of the organization
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
 	secretName := ctx.Params(":secretname")

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -118,7 +118,7 @@ func CreateOrgSecret(ctx *context.APIContext) {
 func UpdateOrgSecret(ctx *context.APIContext) {
 	// swagger:operation PUT /orgs/{org}/actions/secrets/{secretname} organization updateOrgSecret
 	// ---
-	// summary: Update a secret in an organization
+	// summary: Update a secret value in an organization
 	// consumes:
 	// - application/json
 	// produces:

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -148,8 +148,12 @@ func UpdateOrgSecret(ctx *context.APIContext) {
 	err := secret_model.UpdateSecret(
 		ctx, ctx.Org.Organization.ID, 0, secretName, opt.Data,
 	)
+	if secret_model.IsErrSecretNotFound(err) {
+		ctx.NotFound(err)
+		return
+	}
 	if err != nil {
-		ctx.Error(http.StatusInternalServerError, "ChangeSecret", err)
+		ctx.Error(http.StatusInternalServerError, "UpdateSecret", err)
 		return
 	}
 
@@ -185,6 +189,10 @@ func DeleteOrgSecret(ctx *context.APIContext) {
 	err := secret_model.DeleteSecret(
 		ctx, ctx.Org.Organization.ID, 0, secretName,
 	)
+	if secret_model.IsErrSecretNotFound(err) {
+		ctx.NotFound(err)
+		return
+	}
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "DeleteSecret", err)
 		return

--- a/routers/api/v1/org/action.go
+++ b/routers/api/v1/org/action.go
@@ -113,3 +113,82 @@ func CreateOrgSecret(ctx *context.APIContext) {
 
 	ctx.JSON(http.StatusCreated, convert.ToSecret(s))
 }
+
+// UpdateOrgSecret update one secret of the organization
+func UpdateOrgSecret(ctx *context.APIContext) {
+	// swagger:operation PUT /orgs/{org}/actions/secrets/{secretname} organization updateOrgSecret
+	// ---
+	// summary: Update a secret in an organization
+	// consumes:
+	// - application/json
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: org
+	//   in: path
+	//   description: name of organization
+	//   type: string
+	//   required: true
+	// - name: secretname
+	//   in: path
+	//   description: name of the secret
+	//   type: string
+	//   required: true
+	// - name: body
+	//   in: body
+	//   schema:
+	//     "$ref": "#/definitions/UpdateSecretOption"
+	// responses:
+	//   "204":
+	//     description: membership publicized
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	secretName := ctx.Params(":secretname")
+	opt := web.GetForm(ctx).(*api.UpdateSecretOption)
+	err := secret_model.ChangeSecret(
+		ctx, ctx.Org.Organization.ID, 0, secretName, opt.Data,
+	)
+	if err != nil {
+		ctx.Error(http.StatusInternalServerError, "ChangeSecret", err)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// DeleteOrgSecret delete one secret of the organization
+func DeleteOrgSecret(ctx *context.APIContext) {
+	// swagger:operation DELETE /orgs/{org}/actions/secrets/{secretname} organization deleteOrgSecret
+	// ---
+	// summary: Delete a secret in an organization
+	// consumes:
+	// - application/json
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: org
+	//   in: path
+	//   description: name of organization
+	//   type: string
+	//   required: true
+	// - name: secretname
+	//   in: path
+	//   description: name of the secret
+	//   type: string
+	//   required: true
+	// responses:
+	//   "204":
+	//     description: membership publicized
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	secretName := ctx.Params(":secretname")
+	err := secret_model.DeleteSecret(
+		ctx, ctx.Org.Organization.ID, 0, secretName,
+	)
+	if err != nil {
+		ctx.Error(http.StatusInternalServerError, "DeleteSecret", err)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}

--- a/routers/api/v1/swagger/options.go
+++ b/routers/api/v1/swagger/options.go
@@ -190,4 +190,7 @@ type swaggerParameterBodies struct {
 
 	// in:body
 	CreateSecretOption api.CreateSecretOption
+
+	// in:body
+	UpdateSecretOption api.UpdateSecretOption
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1642,7 +1642,7 @@
         "tags": [
           "organization"
         ],
-        "summary": "Update a secret in an organization",
+        "summary": "Update a secret value in an organization",
         "operationId": "updateOrgSecret",
         "parameters": [
           {
@@ -1669,7 +1669,7 @@
         ],
         "responses": {
           "204": {
-            "description": "membership publicized"
+            "description": "update one secret of the organization"
           },
           "403": {
             "$ref": "#/responses/forbidden"
@@ -1706,7 +1706,7 @@
         ],
         "responses": {
           "204": {
-            "description": "membership publicized"
+            "description": "delete one secret of the organization"
           },
           "403": {
             "$ref": "#/responses/forbidden"
@@ -21982,7 +21982,7 @@
       ],
       "properties": {
         "data": {
-          "description": "Data of the secret to create",
+          "description": "Data of the secret to update",
           "type": "string",
           "x-go-name": "Data"
         }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1631,6 +1631,89 @@
         }
       }
     },
+    "/orgs/{org}/actions/secrets/{secretname}": {
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Update a secret in an organization",
+        "operationId": "updateOrgSecret",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "name of organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the secret",
+            "name": "secretname",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateSecretOption"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "membership publicized"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          }
+        }
+      },
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Delete a secret in an organization",
+        "operationId": "deleteOrgSecret",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "name of organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the secret",
+            "name": "secretname",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "membership publicized"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          }
+        }
+      }
+    },
     "/orgs/{org}/activities/feeds": {
       "get": {
         "produces": [
@@ -21891,6 +21974,21 @@
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
+    "UpdateSecretOption": {
+      "description": "UpdateSecretOption options when updating secret",
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "description": "Data of the secret to create",
+          "type": "string",
+          "x-go-name": "Data"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
     "UpdateUserAvatarOption": {
       "description": "UpdateUserAvatarUserOption options when updating the user avatar",
       "type": "object",
@@ -23207,7 +23305,7 @@
     "parameterBodies": {
       "description": "parameterBodies",
       "schema": {
-        "$ref": "#/definitions/CreateSecretOption"
+        "$ref": "#/definitions/UpdateSecretOption"
       }
     },
     "redirect": {


### PR DESCRIPTION
- Add `UpdateSecret` function to modify org or user repo secret
- Add `DeleteSecret` function to delete secret from an organization
- Add `UpdateSecretOption` struct for updating secret options
- Add `UpdateOrgSecret` function to update a secret in an organization
- Add `DeleteOrgSecret` function to delete a secret in an organization

GitHub API

1. Update Org Secret: https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
2. Delete Org Secret: https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#delete-an-organization-secret
