### PR TITLE
Fix doubled box-shadow in branch dropdown menu

### DIFF
--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -67,7 +67,7 @@
 
 <div class="js-branch-tag-selector {{if .ContainerClasses}}{{.ContainerClasses}}{{end}}">
 	{{/* show dummy elements before Vue componment is mounted, this code must match the code in BranchTagSelector.vue */}}
-	<div class="ui floating filter dropdown custom">
+	<div class="ui dropdown custom">
 		<button class="branch-dropdown-button gt-ellipsis ui basic small compact button gt-df gt-m-0">
 			<span class="text gt-df gt-ac gt-mr-2">
 				{{if .release}}

--- a/web_src/js/components/RepoBranchTagSelector.vue
+++ b/web_src/js/components/RepoBranchTagSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ui floating filter dropdown custom">
+  <div class="ui dropdown custom">
     <button class="branch-dropdown-button gt-ellipsis ui basic small compact button gt-df gt-m-0" @click="menuVisible = !menuVisible" @keyup.enter="menuVisible = !menuVisible">
       <span class="text gt-df gt-ac gt-mr-2">
         <template v-if="release">{{ textReleaseCompare }}</template>


### PR DESCRIPTION
Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/897bcb05-7df0-4d01-a84d-6f4ec1e173d4)


After:

![image](https://github.com/go-gitea/gitea/assets/2114189/bfde9448-af92-425b-9cdb-8c80a1ad11c8)
