### PR TITLE
Fix archived unix time when archiving the label

### DIFF
--- a/models/issues/label.go
+++ b/models/issues/label.go
@@ -113,10 +113,11 @@ func (l *Label) CalOpenIssues() {
 
 // SetArchived set the label as archived
 func (l *Label) SetArchived(isArchived bool) {
-	if isArchived && l.ArchivedUnix.IsZero() {
-		l.ArchivedUnix = timeutil.TimeStampNow()
-	} else {
+	if !isArchived {
 		l.ArchivedUnix = timeutil.TimeStamp(0)
+	} else if isArchived && l.ArchivedUnix.IsZero() {
+		// Only change the date when it is newly archived.
+		l.ArchivedUnix = timeutil.TimeStampNow()
 	}
 }
 


### PR DESCRIPTION
Small Fix :-`ArchivedUnix` column changed only change the date when it is newly archived.

Followup  https://github.com/go-gitea/gitea/pull/26478

Part of https://github.com/go-gitea/gitea/issues/25237