### PR TITLE
Handle "comment form combo editor init" more gracefully

### DIFF
--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -54,9 +54,10 @@ export function initRepoCommentForm() {
   }
 
   if ($commentForm.find('.field.combo-editor-dropzone').length) {
-    // at the moment, if a form has multiple combo-markdown-editors, it must be a issue template form
+    // at the moment, if a form has multiple combo-markdown-editors, it must be an issue template form
     initIssueTemplateCommentEditors($commentForm);
-  } else {
+  } else if ($commentForm.find('.combo-markdown-editor').length) {
+    // it's quite unclear about the "comment form" elements, sometimes it's for issue comment, sometimes it's for file editor/uploader message
     initSingleCommentEditor($commentForm);
   }
 


### PR DESCRIPTION
Now Gitea exposes unhandled promise rejection messages as error message on the UI.

The "comment form" was quite unclear before, so it should be handled more gracefully to avoid such error.

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/7275ff1f-f64f-476f-8c8b-92df3c1502b1)

</details>
