### PR TITLE
Use line-height: normal by default (#26635)

### DIFF
--- a/web_src/css/admin.css
+++ b/web_src/css/admin.css
@@ -45,7 +45,7 @@
 
 .admin dl.admin-dl-horizontal dt,
 .admin dl.admin-dl-horizontal dd {
-  line-height: 1;
+  line-height: var(--line-height-default);
   padding: 5px 0;
 }
 

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -10,7 +10,7 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   /* line-height: use the default value as "modules/normalize.css" */
-  --line-height-default: 1.15;
+  --line-height-default: normal;
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
@@ -512,8 +512,6 @@ a.label,
   color: var(--color-text);
   user-select: auto;
   line-height: var(--line-height-default); /* fomantic uses "1" which causes overflow problems because "1" doesn't consider the descent part */
-  padding-top: 11px; /* counteract line-height change */
-  padding-bottom: 11px; /* counteract line-height change */
 }
 
 .ui.menu .item > .svg {

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -9,6 +9,8 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  /* line-height: use the default value as "modules/normalize.css" */
+  --line-height-default: 1.15;
   /* backgrounds */
   --checkbox-mask-checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>');
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
@@ -509,6 +511,9 @@ a.label,
 .ui.menu .item {
   color: var(--color-text);
   user-select: auto;
+  line-height: var(--line-height-default); /* fomantic uses "1" which causes overflow problems because "1" doesn't consider the descent part */
+  padding-top: 11px; /* counteract line-height change */
+  padding-bottom: 11px; /* counteract line-height change */
 }
 
 .ui.menu .item > .svg {
@@ -1517,7 +1522,7 @@ img.ui.avatar,
   height: 3em;
   float: none;
   display: block;
-  line-height: 1;
+  line-height: var(--line-height-default);
   padding: 0;
   margin: 0 auto 0.5rem;
   opacity: 1;
@@ -2170,7 +2175,7 @@ table th[data-sortt-desc] .svg {
 .emoji,
 .reaction {
   font-size: 1.25em;
-  line-height: 1;
+  line-height: var(--line-height-default);
   font-style: normal !important;
   font-weight: var(--font-weight-normal) !important;
   vertical-align: -0.075em;
@@ -2294,7 +2299,7 @@ table th[data-sortt-desc] .svg {
 }
 
 .ui.dropdown {
-  line-height: 1em; /* the dropdown doesn't have default line-height, use this to make the dropdown icon align with plain dropdown */
+  line-height: var(--line-height-default); /* the dropdown doesn't have default line-height, use this to make the dropdown icon align with plain dropdown */
 }
 
 /* dropdown has some kinds of icons:

--- a/web_src/css/modules/normalize.css
+++ b/web_src/css/modules/normalize.css
@@ -25,7 +25,7 @@ Use a better box model (opinionated).
 }
 
 html {
-  line-height: 1.15; /* 1. Correct the line height in all browsers. */
+  line-height: normal; /* 1. (not following the "modern-normalize") Do not change the browser's default line-height, the default value is font-dependent and roughly 1.2 */
   -webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
 }
 

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -403,8 +403,8 @@
 }
 
 .repository.file.list .non-diff-file-content .header .file-actions .btn-octicon {
-  line-height: 1;
-  padding: 10px 8px;
+  line-height: var(--line-height-default);
+  padding: 8px;
   vertical-align: middle;
   color: var(--color-text);
 }


### PR DESCRIPTION
Backport the `line-height: normal`, because #26520 was backported