### PR TITLE
Use "small-loading-icon" insead of "btn-octicon is-loading"

### DIFF
--- a/web_src/css/modules/animations.css
+++ b/web_src/css/modules/animations.css
@@ -58,13 +58,6 @@ form.single-button-form.is-loading .button {
 }
 
 /* TODO: not needed, use "is-loading small-loading-icon" instead */
-.btn-octicon.is-loading::after {
-  border-width: 2px;
-  height: 1.25rem;
-  width: 1.25rem;
-}
-
-/* TODO: not needed, use "is-loading small-loading-icon" instead */
 code.language-math.is-loading::after {
   padding: 0;
   border-width: 2px;

--- a/web_src/js/features/copycontent.js
+++ b/web_src/js/features/copycontent.js
@@ -18,7 +18,7 @@ export function initCopyContent() {
     // the text to copy is not in the DOM or it is an image which should be
     // fetched to copy in full resolution
     if (link) {
-      btn.classList.add('is-loading');
+      btn.classList.add('is-loading', 'small-loading-icon');
       try {
         const res = await fetch(link, {credentials: 'include', redirect: 'follow'});
         const contentType = res.headers.get('content-type');
@@ -32,7 +32,7 @@ export function initCopyContent() {
       } catch {
         return showTemporaryTooltip(btn, i18n.copy_error);
       } finally {
-        btn.classList.remove('is-loading');
+        btn.classList.remove('is-loading', 'small-loading-icon');
       }
     } else { // text, read from DOM
       const lineEls = document.querySelectorAll('.file-view .lines-code');


### PR DESCRIPTION
The "btn-octicon is-loading" was introduced by #21842 , it is only used by the "Copy Content" button, but the "btn-octicon" selector would affect too many uncertain elements.

Now there is a general "small-loading-icon" class, so the "btn-octicon is-loading" could be removed.

Before:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/9c599762-0569-43dd-affb-e0db06ea61d7)

</details>

After: 

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/c34b1e9e-59c4-482d-9029-52b780aa0328)

</details>
