### PR TITLE
Focus editor on "Write" tab click

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -135,6 +135,12 @@ class ComboMarkdownEditor {
     $panelPreviewer.attr('data-tab', `markdown-previewer-${elementIdCounter}`);
     elementIdCounter++;
 
+    $tabEditor[0].addEventListener('click', () => {
+      requestAnimationFrame(() => {
+        this.focus();
+      });
+    });
+
     $tabs.tab();
 
     this.previewUrl = $tabPreviewer.attr('data-preview-url');


### PR DESCRIPTION
Focus the editor when clicking the "Write" tab. Works for both Textarea and EasyMDE. Does for some reason not work without the `requestAnimationFrame`.

![](https://github.com/go-gitea/gitea/assets/115237/d2d4cf9a-b5ed-4899-a300-16b97b7af591)
