### PR TITLE
[Update options.tmpl] The text at the bottom of `Mirror Settings` is directly translated strings, not converted to html

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -80,7 +80,7 @@
 			</h4>
 			<div class="ui attached segment">
 				{{if $newMirrorsEntirelyEnabled}}
-					{{$.locale.Tr "repo.settings.mirror_settings.docs"}}
+					{{$.locale.Tr "repo.settings.mirror_settings.docs" | Str2html}}
 					<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/repo-mirror/#pushing-to<ing-to-a-remote-repository">{{$.locale.Tr "repo.settings.mirror_settings.docs.doc_link_title"}}</a><br><br>
 					{{$.locale.Tr "repo.settings.mirror_settings.docs.pull_mirror_instructions"}}
 					<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/usage/repo-mirror/#pulling-from-a-remote-repository">{{$.locale.Tr "repo.settings.mirror_settings.docs.doc_link_pull_section"}}</a><br>


### PR DESCRIPTION
## Bug🐛:
```
将你的项目设置成自动从其它仓库推送或拉取变更。分支、标签以及提交将会自动同步。<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io/en-us/repo-mirror/">如何镜像仓库?</a>
```

Repository Settings ➝ `Mirror Settings`. The text at the bottom of `Mirror Settings` is directly translated strings, not converted to html



## Solution✅:
templates/repo/settings/options.tmpl

```diff
- {{$.locale.Tr "repo.settings.mirror_settings.docs"}}
+ {{$.locale.Tr "repo.settings.mirror_settings.docs" | Str2html}}
```

<!-- start tips --> 
Please check the following:
1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for backports.
2. Make sure you have read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md .
3. Describe what your pull request does and which issue you're targeting (if any).
4. It is recommended to enable "Allow edits by maintainers", so maintainers can help more easily.
5. Your input here will be included in the commit message when this PR has been merged. If you don't want some content to be included, please separate them with a line like `---`.
6. Delete all these tips before posting.
<!-- end tips -->
