### PR TITLE
Fix template bugs in recently_pushed_new_branches.tmpl

### DIFF
--- a/templates/repo/code/recently_pushed_new_branches.tmpl
+++ b/templates/repo/code/recently_pushed_new_branches.tmpl
@@ -2,9 +2,9 @@
 	<div class="ui positive message gt-df gt-ac">
 		<div class="gt-f1">
 			{{$timeSince := TimeSince .CommitTime.AsTime $.locale}}
-			{{$.locale.Tr "repo.pulls.recently_pushed_new_branches" (PathEscapeSegments .Name) $timeSince | Safe}}
+			{{$.locale.Tr "repo.pulls.recently_pushed_new_branches" (Escape .Name) $timeSince | Safe}}
 		</div>
-		<a aria-role="button" class="ui compact positive button gt-m-0" href="{{$.Repository.ComposeBranchCompareURL $.Repository.BaseRepo (PathEscapeSegments .Name)}}">
+		<a role="button" class="ui compact positive button gt-m-0" href="{{$.Repository.ComposeBranchCompareURL $.Repository.BaseRepo .Name}}">
 			{{$.locale.Tr "repo.pulls.compare_changes"}}
 		</a>
 	</div>


### PR DESCRIPTION
Fix some bugs from #25715, fix #25830

1. `$.locale.Tr ... Safe` needs `Escape`, but not `PathEscapeSegments`
2. The attribute should be `role`
3. The `ComposeBranchCompareURL` already does escaping correctly
