### PR TITLE
The repository list page, pading top and bottom is too small compared as v1.20, increase them so make it looks like before

### DIFF
--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -9,7 +9,7 @@
 }
 
 .flex-item:not(:last-child) {
-  padding-bottom: 8px;
+  padding-bottom: 1rem;
 }
 
 .flex-item-baseline {
@@ -92,5 +92,5 @@
 
 .flex-list > .flex-item + .flex-item {
   border-top: 1px solid var(--color-secondary);
-  padding-top: 8px;
+  padding-top: 1rem;
 }


### PR DESCRIPTION
Before

<img width="1309" alt="图片" src="https://github.com/go-gitea/gitea/assets/81045/cd03dd7e-5eca-4865-9744-b523b4433f94">

After

<img width="1312" alt="图片" src="https://github.com/go-gitea/gitea/assets/81045/68471259-4a2b-465f-b9b9-5d94b7cbc3f2">
