### PR TITLE
Fix being unable to use a repo that prohibits accepting PRs as a PR source.

### DIFF
--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -460,7 +460,7 @@ func ParseCompareInfo(ctx *context.Context) *CompareInfo {
 		rootRepo.ID != ci.HeadRepo.ID &&
 		rootRepo.ID != baseRepo.ID {
 		canRead := access_model.CheckRepoUnitUser(ctx, rootRepo, ctx.Doer, unit.TypeCode)
-		if canRead && rootRepo.AllowsPulls() {
+		if canRead {
 			ctx.Data["RootRepo"] = rootRepo
 			if !fileOnly {
 				branches, tags, err := getBranchesAndTagsForRepo(ctx, rootRepo)

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -77,7 +77,7 @@
 							<div class="item" data-url="{{$.OwnForkRepo.Link}}/compare/{{PathEscapeSegments .}}{{$.CompareSeparator}}{{PathEscape $.HeadUser.Name}}/{{PathEscape $.HeadRepo.Name}}:{{PathEscapeSegments $.HeadBranch}}">{{$OwnForkCompareName}}:{{.}}</div>
 						{{end}}
 					{{end}}
-					{{if .RootRepo}}
+					{{if and .RootRepo .RootRepo.AllowsPulls}}
 						{{range .RootRepoBranches}}
 							<div class="item" data-url="{{$.RootRepo.Link}}/compare/{{PathEscapeSegments .}}{{$.CompareSeparator}}{{PathEscape $.HeadUser.Name}}/{{PathEscape $.HeadRepo.Name}}:{{PathEscapeSegments $.HeadBranch}}">{{$RootRepoCompareName}}:{{.}}</div>
 						{{end}}


### PR DESCRIPTION
## Description 
Sometimes, we need to use an upstream mirror repository to update the current development repository, but mirror repositories are prohibited from PR. It should not appear in `merge to,` but it can appear in `pull from.`
Fix #24585 
Fix #26193 
Fix #26781
Related #24183

Many thanks to @apnote  for assisting me in reproducing this bug!

## ScreenShot
---
### Before

<img src="https://github.com/go-gitea/gitea/assets/50507092/3d76c376-1f54-45b9-80c9-6ba8319d6a9a" width="400px">

<img src="https://github.com/go-gitea/gitea/assets/50507092/fbfd9f7f-421f-4a2e-9a3e-f2958bbf3312" width="400px">

### After

<img src="https://github.com/go-gitea/gitea/assets/50507092/e6984524-4f61-4310-b795-4d8598bd8963" width="400px">

<img src="https://github.com/go-gitea/gitea/assets/50507092/04065b44-78d7-4721-bf31-0f1674150727" width="400px">


