### PR TITLE
Fix Uint8Array comparisons and update vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "svgo": "3.0.2",
         "updates": "14.4.0",
         "vite-string-plugin": "1.1.2",
-        "vitest": "0.34.2"
+        "vitest": "0.34.3"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -2043,13 +2043,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.2.tgz",
-      "integrity": "sha512-EZm2dMNlLyIfDMha17QHSQcg2KjeAZaXd65fpPzXY5bvnfx10Lcaz3N55uEe8PhF+w4pw+hmrlHLLlRn9vkBJg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.3.tgz",
+      "integrity": "sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.34.2",
-        "@vitest/utils": "0.34.2",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "chai": "^4.3.7"
       },
       "funding": {
@@ -2057,12 +2057,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.2.tgz",
-      "integrity": "sha512-8ydGPACVX5tK3Dl0SUwxfdg02h+togDNeQX3iXVFYgzF5odxvaou7HnquALFZkyVuYskoaHUOqOyOLpOEj5XTA==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.3.tgz",
+      "integrity": "sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.34.2",
+        "@vitest/utils": "0.34.3",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       },
@@ -2098,9 +2098,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.2.tgz",
-      "integrity": "sha512-qhQ+xy3u4mwwLxltS4Pd4SR+XHv4EajiTPNY3jkIBLUApE6/ce72neJPSUQZ7bL3EBuKI+NhvzhGj3n5baRQUQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.3.tgz",
+      "integrity": "sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.1",
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.2.tgz",
-      "integrity": "sha512-yd4L9OhfH6l0Av7iK3sPb3MykhtcRN5c5K5vm1nTbuN7gYn+yvUVVsyvzpHrjqS7EWqn9WsPJb7+0c3iuY60tA==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.3.tgz",
+      "integrity": "sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.2.tgz",
-      "integrity": "sha512-Lzw+kAsTPubhoQDp1uVAOP6DhNia1GMDsI9jgB0yMn+/nDaPieYQ88lKqz/gGjSHL4zwOItvpehec9OY+rS73w==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.3.tgz",
+      "integrity": "sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -10735,9 +10735,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.2.tgz",
-      "integrity": "sha512-JtW249Zm3FB+F7pQfH56uWSdlltCo1IOkZW5oHBzeQo0iX4jtC7o1t9aILMGd9kVekXBP2lfJBEQt9rBh07ebA==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.3.tgz",
+      "integrity": "sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -11172,19 +11172,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.2.tgz",
-      "integrity": "sha512-WgaIvBbjsSYMq/oiMlXUI7KflELmzM43BEvkdC/8b5CAod4ryAiY2z8uR6Crbi5Pjnu5oOmhKa9sy7uk6paBxQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.3.tgz",
+      "integrity": "sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.34.2",
-        "@vitest/runner": "0.34.2",
-        "@vitest/snapshot": "0.34.2",
-        "@vitest/spy": "0.34.2",
-        "@vitest/utils": "0.34.2",
+        "@vitest/expect": "0.34.3",
+        "@vitest/runner": "0.34.3",
+        "@vitest/snapshot": "0.34.3",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -11199,7 +11199,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.7.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.34.2",
+        "vite-node": "0.34.3",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "svgo": "3.0.2",
     "updates": "14.4.0",
     "vite-string-plugin": "1.1.2",
-    "vitest": "0.34.2"
+    "vitest": "0.34.3"
   },
   "browserslist": [
     "defaults",

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -135,7 +135,7 @@ test('toAbsoluteUrl', () => {
 
 test('encodeURLEncodedBase64, decodeURLEncodedBase64', () => {
   // TextEncoder is Node.js API while Uint8Array is jsdom API and their outputs are not
-  // structurally comparable, so we convert to array to compare. The conversation
+  // structurally comparable, so we convert to array to compare. The conversion
   // can be removed once https://github.com/jsdom/jsdom/issues/2524 is resolved.
   const encoder = new TextEncoder();
   const uint8array = encoder.encode.bind(encoder);

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -135,8 +135,8 @@ test('toAbsoluteUrl', () => {
 
 test('encodeURLEncodedBase64, decodeURLEncodedBase64', () => {
   // TextEncoder is Node.js API while Uint8Array is jsdom API and their outputs are not
-  // structurally comparable, so we convert to array to compare. The conversion
-  // can be removed once https://github.com/jsdom/jsdom/issues/2524 is resolved.
+  // structurally comparable, so we convert to array to compare. The conversion can be
+  // removed once https://github.com/jsdom/jsdom/issues/2524 is resolved.
   const encoder = new TextEncoder();
   const uint8array = encoder.encode.bind(encoder);
 

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -133,17 +133,22 @@ test('toAbsoluteUrl', () => {
   expect(() => toAbsoluteUrl('path')).toThrowError('unsupported');
 });
 
-const uint8array = (s) => new TextEncoder().encode(s);
 test('encodeURLEncodedBase64, decodeURLEncodedBase64', () => {
+  // TextEncoder is Node.js API while Uint8Array is jsdom API and their outputs are not
+  // structurally comparable, so we convert to array to compare. The conversation
+  // can be removed once https://github.com/jsdom/jsdom/issues/2524 is resolved.
+  const encoder = new TextEncoder();
+  const uint8array = encoder.encode.bind(encoder);
+
   expect(encodeURLEncodedBase64(uint8array('AA?'))).toEqual('QUE_'); // standard base64: "QUE/"
   expect(encodeURLEncodedBase64(uint8array('AA~'))).toEqual('QUF-'); // standard base64: "QUF+"
 
-  expect(decodeURLEncodedBase64('QUE/')).toEqual(uint8array('AA?'));
-  expect(decodeURLEncodedBase64('QUF+')).toEqual(uint8array('AA~'));
-  expect(decodeURLEncodedBase64('QUE_')).toEqual(uint8array('AA?'));
-  expect(decodeURLEncodedBase64('QUF-')).toEqual(uint8array('AA~'));
+  expect(Array.from(decodeURLEncodedBase64('QUE/'))).toEqual(Array.from(uint8array('AA?')));
+  expect(Array.from(decodeURLEncodedBase64('QUF+'))).toEqual(Array.from(uint8array('AA~')));
+  expect(Array.from(decodeURLEncodedBase64('QUE_'))).toEqual(Array.from(uint8array('AA?')));
+  expect(Array.from(decodeURLEncodedBase64('QUF-'))).toEqual(Array.from(uint8array('AA~')));
 
   expect(encodeURLEncodedBase64(uint8array('a'))).toEqual('YQ'); // standard base64: "YQ=="
-  expect(decodeURLEncodedBase64('YQ')).toEqual(uint8array('a'));
-  expect(decodeURLEncodedBase64('YQ==')).toEqual(uint8array('a'));
+  expect(Array.from(decodeURLEncodedBase64('YQ'))).toEqual(Array.from(uint8array('a')));
+  expect(Array.from(decodeURLEncodedBase64('YQ=='))).toEqual(Array.from(uint8array('a')));
 });


### PR DESCRIPTION
Compare those `Uint8Array` via conversion to Array which are properly comparable, so that we don't have to worry about whether `TextEncoder` and `UInt8Array` from the environment are compatible or not.