### PR TITLE
Make webhook Response Body detailed when webhook is inactive

### DIFF
--- a/services/webhook/deliver.go
+++ b/services/webhook/deliver.go
@@ -207,6 +207,7 @@ func Deliver(ctx context.Context, t *webhook_model.HookTask) error {
 
 	if !w.IsActive {
 		log.Trace("Webhook %s in Webhook Task[%d] is not active", w.URL, t.ID)
+		t.ResponseInfo.Body = "Hook delivery skipped as webhook is inactive."
 		return nil
 	}
 


### PR DESCRIPTION
Currently, when user click `Test Delivery` for an inactivate webhook, Gitea will refuse to send the webhook. However, the `Response` or anywhere else (except log on server) doesn't describe the reason, and may make user think that the webhook server is crashed.
This PR writes error message `Hook delivery skipped as webhook is inactive.` to Response Body, so that user can know the status clearly.

## Comparison
### Current behavior
![Current page when webhook is inactivate, showing empty Response Headers and Response Body](https://github.com/go-gitea/gitea/assets/51789698/66baec35-fd4f-4bd5-8152-cf469113a62e)
### Expected behavior
![Page displayed after this PR, Response Body is set as above](https://github.com/go-gitea/gitea/assets/51789698/1f42dbd1-649b-41a7-a13f-de13a5dfca1b)

Closes #26824 
