### PR TITLE
Fix filename for .spectral.yaml

### DIFF
--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -81,4 +81,4 @@ jobs:
               - "Makefile"
               - "package.json"
               - "package-lock.json"
-              - ".spectral.yml"
+              - ".spectral.yaml"


### PR DESCRIPTION
Mixed up yml vs. yaml previously.