### PR TITLE
Render code blocks in repo description

### DIFF
--- a/modules/templates/util_render.go
+++ b/modules/templates/util_render.go
@@ -111,7 +111,7 @@ var codeMatcher = regexp.MustCompile("`([^`]+)`")
 // RenderCodeBlock renders "`…`" as highlighted "<code>" block.
 // Intended for issue and PR titles, these containers should have styles for "<code>" elements
 func RenderCodeBlock(htmlEscapedTextToRender template.HTML) template.HTML {
-	htmlWithCodeTags := codeMatcher.ReplaceAllString(string(htmlEscapedTextToRender), "<code>$1</code>") // replace with HTML <code> tags
+	htmlWithCodeTags := codeMatcher.ReplaceAllString(string(htmlEscapedTextToRender), `<code class="inline-code-block">$1</code>`) // replace with HTML <code> tags
 	return template.HTML(htmlWithCodeTags)
 }
 

--- a/modules/templates/util_render.go
+++ b/modules/templates/util_render.go
@@ -108,8 +108,7 @@ func RenderCommitBody(ctx context.Context, msg, urlPrefix string, metas map[stri
 // Match text that is between back ticks.
 var codeMatcher = regexp.MustCompile("`([^`]+)`")
 
-// RenderCodeBlock renders "`…`" as highlighted "<code>" block.
-// Intended for issue and PR titles, these containers should have styles for "<code>" elements
+// RenderCodeBlock renders "`…`" as highlighted "<code>" block, intended for issue and PR titles
 func RenderCodeBlock(htmlEscapedTextToRender template.HTML) template.HTML {
 	htmlWithCodeTags := codeMatcher.ReplaceAllString(string(htmlEscapedTextToRender), `<code class="inline-code-block">$1</code>`) // replace with HTML <code> tags
 	return template.HTML(htmlWithCodeTags)

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -8,7 +8,7 @@
 		<div class="ui repo-description">
 			<div id="repo-desc">
 				{{$description := .Repository.DescriptionHTML $.Context}}
-				{{if $description}}<span class="description">{{$description}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}
+				{{if $description}}<span class="description">{{$description | RenderCodeBlock}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}
 				<a class="link" href="{{.Repository.Website}}">{{.Repository.Website}}</a>
 			</div>
 			{{if .RepoSearchEnabled}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -6,7 +6,7 @@
 		{{template "repo/code/recently_pushed_new_branches" .}}
 		{{if and (not .HideRepoInfo) (not .IsBlame)}}
 		<div class="ui repo-description">
-			<div id="repo-desc">
+			<div id="repo-desc" class="gt-font-16">
 				{{$description := .Repository.DescriptionHTML $.Context}}
 				{{if $description}}<span class="description">{{$description | RenderCodeBlock}}</span>{{else if .IsRepositoryAdmin}}<span class="no-description text-italic">{{.locale.Tr "repo.no_desc"}}</span>{{end}}
 				<a class="link" href="{{.Repository.Website}}">{{.Repository.Website}}</a>

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -454,7 +454,7 @@ a.label,
   background: var(--color-hover);
 }
 
-.issue-title code {
+.inline-code-block {
   padding: 2px 4px;
   border-radius: var(--border-radius-medium);
   background-color: var(--color-markup-code-block);

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -236,10 +236,6 @@
   }
 }
 
-#repo-desc {
-  font-size: 16px;
-}
-
 .repository.file.list .repo-path {
   word-break: break-word;
 }

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -236,8 +236,8 @@
   }
 }
 
-.repository.file.list #repo-desc {
-  font-size: 1.2em;
+#repo-desc {
+  font-size: 16px;
 }
 
 .repository.file.list .repo-path {


### PR DESCRIPTION
Backtick syntax now works in repo description too. Also, I replaced the CSS for this was a new single class, making it more flexible and not dependent on a parent. Also, very slightly reduced font size from 16.8px to 16px.

<img width="163" alt="Screenshot 2023-08-31 at 00 47 52" src="https://github.com/go-gitea/gitea/assets/115237/26645713-042b-420b-a28a-8929f0db2987">

