### PR TITLE
Remove joinPaths function

### DIFF
--- a/web_src/js/bootstrap.js
+++ b/web_src/js/bootstrap.js
@@ -1,11 +1,9 @@
-import {joinPaths} from './utils.js';
-
 // DO NOT IMPORT window.config HERE!
 // to make sure the error handler always works, we should never import `window.config`, because some user's custom template breaks it.
 
 // This sets up the URL prefix used in webpack's chunk loading.
 // This file must be imported before any lazy-loading is being attempted.
-__webpack_public_path__ = joinPaths(window?.config?.assetUrlPrefix ?? '/', '/');
+__webpack_public_path__ = `${window.config?.assetUrlPrefix ?? '/assets'}/`;
 
 export function showGlobalErrorMessage(msg) {
   const pageContent = document.querySelector('.page-content');

--- a/web_src/js/utils.js
+++ b/web_src/js/utils.js
@@ -11,16 +11,6 @@ export function extname(path = '') {
   return ext || '';
 }
 
-// join a list of path segments with slashes, ensuring no double slashes
-export function joinPaths(...parts) {
-  let str = '';
-  for (const part of parts) {
-    if (!part) continue;
-    str = !str ? part : `${str.replace(/\/$/, '')}/${part.replace(/^\//, '')}`;
-  }
-  return str;
-}
-
 // test whether a variable is an object
 export function isObject(obj) {
   return Object.prototype.toString.call(obj) === '[object Object]';

--- a/web_src/js/utils.test.js
+++ b/web_src/js/utils.test.js
@@ -1,6 +1,6 @@
 import {expect, test} from 'vitest';
 import {
-  basename, extname, isObject, stripTags, joinPaths, parseIssueHref,
+  basename, extname, isObject, stripTags, parseIssueHref,
   parseUrl, translateMonth, translateDay, blobToDataURI,
   toAbsoluteUrl, encodeURLEncodedBase64, decodeURLEncodedBase64,
 } from './utils.js';
@@ -16,45 +16,6 @@ test('extname', () => {
   expect(extname('/path/')).toEqual('');
   expect(extname('/path')).toEqual('');
   expect(extname('file.js')).toEqual('.js');
-});
-
-test('joinPaths', () => {
-  expect(joinPaths('', '')).toEqual('');
-  expect(joinPaths('', 'b')).toEqual('b');
-  expect(joinPaths('', '/b')).toEqual('/b');
-  expect(joinPaths('', '/b/')).toEqual('/b/');
-  expect(joinPaths('a', '')).toEqual('a');
-  expect(joinPaths('/a', '')).toEqual('/a');
-  expect(joinPaths('/a/', '')).toEqual('/a/');
-  expect(joinPaths('a', 'b')).toEqual('a/b');
-  expect(joinPaths('a', '/b')).toEqual('a/b');
-  expect(joinPaths('/a', '/b')).toEqual('/a/b');
-  expect(joinPaths('/a', '/b')).toEqual('/a/b');
-  expect(joinPaths('/a/', '/b')).toEqual('/a/b');
-  expect(joinPaths('/a', '/b/')).toEqual('/a/b/');
-  expect(joinPaths('/a/', '/b/')).toEqual('/a/b/');
-
-  expect(joinPaths('', '', '')).toEqual('');
-  expect(joinPaths('', 'b', '')).toEqual('b');
-  expect(joinPaths('', 'b', 'c')).toEqual('b/c');
-  expect(joinPaths('', '', 'c')).toEqual('c');
-  expect(joinPaths('', '/b', '/c')).toEqual('/b/c');
-  expect(joinPaths('/a', '', '/c')).toEqual('/a/c');
-  expect(joinPaths('/a', '/b', '')).toEqual('/a/b');
-
-  expect(joinPaths('', '/')).toEqual('/');
-  expect(joinPaths('a', '/')).toEqual('a/');
-  expect(joinPaths('', '/', '/')).toEqual('/');
-  expect(joinPaths('/', '/')).toEqual('/');
-  expect(joinPaths('/', '')).toEqual('/');
-  expect(joinPaths('/', 'b')).toEqual('/b');
-  expect(joinPaths('/', 'b/')).toEqual('/b/');
-  expect(joinPaths('/', '', '/')).toEqual('/');
-  expect(joinPaths('/', 'b', '/')).toEqual('/b/');
-  expect(joinPaths('/', 'b/', '/')).toEqual('/b/');
-  expect(joinPaths('a', '/', '/')).toEqual('a/');
-  expect(joinPaths('/', '/', 'c')).toEqual('/c');
-  expect(joinPaths('/', '/', 'c/')).toEqual('/c/');
 });
 
 test('isObject', () => {


### PR DESCRIPTION
Extract from https://github.com/go-gitea/gitea/pull/25940.

`assetUrlPrefix` is guaranteed to not contain trailing slashes, making this function unneeded.