### PR TITLE
MinIO > 2021 interprets a / prefix differently

### DIFF
--- a/modules/storage/minio.go
+++ b/modules/storage/minio.go
@@ -219,7 +219,7 @@ func (m *MinioStorage) IterateObjects(dirName string, fn func(path string, obj O
 	defer cancel()
 
 	basePath := m.basePath
-	if dirName != "" {
+	if dirName != "" && dirName != "/" {
 		// ending slash is required for avoiding matching like "foo/" and "foobar/" with prefix "foo"
 		basePath = m.buildMinioPath(dirName) + "/"
 	}


### PR DESCRIPTION
```
$ minio --version
minio version RELEASE.2023-08-23T10-07-06Z (commit-id=af564b8ba07a7805a578b5f6f2b3827490f74ccd)
$ make CI=true GOTESTFLAGS='-v -count=1' GO_TEST_PACKAGES=code.gitea.io/gitea/modules/storage FLAGS= 'test#TestMinioStorageIterator'
Running go test with -tags 'sqlite sqlite_unlock_notify'...
=== RUN   TestMinioStorageIterator
2023/08/31 14:09:28 ...les/storage/minio.go:81:NewMinioStorage() [I] Creating Minio storage at 127.0.0.1:9000:gitea with base path
    storage_test.go:49:
        	Error Trace:	/home/earl-warren/software/forgejo/modules/storage/storage_test.go:49
        	            				/home/earl-warren/software/forgejo/modules/storage/minio_test.go:18
        	Error:      	"[a/1.txt b/1.txt b/2.txt b/3.txt b/x 4.txt ab/1.txt]" should have 0 item(s), but has 6
        	Test:       	TestMinioStorageIterator
--- FAIL: TestMinioStorageIterator (0.30s)
FAIL
FAIL	code.gitea.io/gitea/modules/storage	0.306s
FAIL
make: *** [Makefile:470: test#TestMinioStorageIterator] Error 1
```