### PR TITLE
Fix regression with action button height with icon

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -506,6 +506,13 @@ a.label,
   border-right-color: var(--color-primary);
 }
 
+/* fix button enlarged vertically by svg icon */
+/* TODO: change to just `.small.button:has(svg)` but may have global side effects */
+.ui.action.input .small.button:has(svg) {
+  padding-top: 7px !important;
+  padding-bottom: 7px !important;
+}
+
 .ui.menu,
 .ui.vertical.menu {
   background: var(--color-menu);


### PR DESCRIPTION
One of the recent changes seems to have removed this needed CSS rule,  resulting in this regression where the input element is stretched too high because of the SVG:

Before (search bar too high):
<img width="932" alt="Screenshot 2023-08-31 at 23 13 22" src="https://github.com/go-gitea/gitea/assets/115237/ec99a962-5a18-46bd-bbf6-406d3cd6f53b">

After (search roughly equal in height to buttons on left):
<img width="942" alt="Screenshot 2023-08-31 at 23 13 31" src="https://github.com/go-gitea/gitea/assets/115237/8087cb7f-e532-4b3b-b6ba-de9dffe6fe38">
