### PR TITLE
Move web/api context related testing function into a separate package

### DIFF
--- a/modules/contexttest/context_tests.go
+++ b/modules/contexttest/context_tests.go
@@ -1,7 +1,8 @@
 // Copyright 2017 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-package test
+// Package contexttest provides utilities for testing Web/API contexts with models.
+package contexttest
 
 import (
 	gocontext "context"
@@ -22,7 +23,7 @@ import (
 	"code.gitea.io/gitea/modules/translation"
 	"code.gitea.io/gitea/modules/web/middleware"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +41,6 @@ func mockRequest(t *testing.T, reqPath string) *http.Request {
 }
 
 // MockContext mock context for unit tests
-// TODO: move this function to other packages, because it depends on "models" package
 func MockContext(t *testing.T, reqPath string) (*context.Context, *httptest.ResponseRecorder) {
 	resp := httptest.NewRecorder()
 	req := mockRequest(t, reqPath)
@@ -58,7 +58,6 @@ func MockContext(t *testing.T, reqPath string) (*context.Context, *httptest.Resp
 }
 
 // MockAPIContext mock context for unit tests
-// TODO: move this function to other packages, because it depends on "models" package
 func MockAPIContext(t *testing.T, reqPath string) (*context.APIContext, *httptest.ResponseRecorder) {
 	resp := httptest.NewRecorder()
 	req := mockRequest(t, reqPath)
@@ -123,7 +122,7 @@ func LoadRepoCommit(t *testing.T, ctx gocontext.Context) {
 	}
 }
 
-// LoadUser load a user into a test context.
+// LoadUser load a user into a test context
 func LoadUser(t *testing.T, ctx gocontext.Context, userID int64) {
 	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: userID})
 	switch ctx := ctx.(type) {

--- a/routers/api/v1/misc/markup_test.go
+++ b/routers/api/v1/misc/markup_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +34,7 @@ func testRenderMarkup(t *testing.T, mode, filePath, text, responseBody string, r
 		Wiki:     true,
 		FilePath: filePath,
 	}
-	ctx, resp := test.MockAPIContext(t, "POST /api/v1/markup")
+	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markup")
 	web.SetForm(ctx, &options)
 	Markup(ctx)
 	assert.Equal(t, responseBody, resp.Body.String())
@@ -50,7 +50,7 @@ func testRenderMarkdown(t *testing.T, mode, text, responseBody string, responseC
 		Context: Repo,
 		Wiki:    true,
 	}
-	ctx, resp := test.MockAPIContext(t, "POST /api/v1/markdown")
+	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markdown")
 	web.SetForm(ctx, &options)
 	Markdown(ctx)
 	assert.Equal(t, responseBody, resp.Body.String())
@@ -162,7 +162,7 @@ func TestAPI_RenderSimple(t *testing.T) {
 		Text:    "",
 		Context: Repo,
 	}
-	ctx, resp := test.MockAPIContext(t, "POST /api/v1/markdown")
+	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markdown")
 	for i := 0; i < len(simpleCases); i += 2 {
 		options.Text = simpleCases[i]
 		web.SetForm(ctx, &options)
@@ -174,7 +174,7 @@ func TestAPI_RenderSimple(t *testing.T) {
 
 func TestAPI_RenderRaw(t *testing.T) {
 	setting.AppURL = AppURL
-	ctx, resp := test.MockAPIContext(t, "POST /api/v1/markdown")
+	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markdown")
 	for i := 0; i < len(simpleCases); i += 2 {
 		ctx.Req.Body = io.NopCloser(strings.NewReader(simpleCases[i]))
 		MarkdownRaw(ctx)

--- a/routers/api/v1/repo/hook_test.go
+++ b/routers/api/v1/repo/hook_test.go
@@ -9,7 +9,7 @@ import (
 
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/models/webhook"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,11 +17,11 @@ import (
 func TestTestHook(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockAPIContext(t, "user2/repo1/wiki/_pages")
+	ctx, _ := contexttest.MockAPIContext(t, "user2/repo1/wiki/_pages")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
 	TestHook(ctx)
 	assert.EqualValues(t, http.StatusNoContent, ctx.Resp.Status())
 

--- a/routers/api/v1/repo/repo_test.go
+++ b/routers/api/v1/repo/repo_test.go
@@ -9,8 +9,8 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 
 	"github.com/stretchr/testify/assert"
@@ -19,9 +19,9 @@ import (
 func TestRepoEdit(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockAPIContext(t, "user2/repo1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockAPIContext(t, "user2/repo1")
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.Repo.Owner = ctx.Doer
 	description := "new description"
 	website := "http://wwww.newwebsite.com"
@@ -65,9 +65,9 @@ func TestRepoEdit(t *testing.T) {
 func TestRepoEditNameChange(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockAPIContext(t, "user2/repo1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockAPIContext(t, "user2/repo1")
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.Repo.Owner = ctx.Doer
 	name := "newname"
 	opts := api.EditRepoOption{

--- a/routers/web/admin/users_test.go
+++ b/routers/web/admin/users_test.go
@@ -8,9 +8,9 @@ import (
 
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 
@@ -19,7 +19,7 @@ import (
 
 func TestNewUserPost_MustChangePassword(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "admin/users/new")
+	ctx, _ := contexttest.MockContext(t, "admin/users/new")
 
 	u := unittest.AssertExistsAndLoadBean(t, &user_model.User{
 		IsAdmin: true,
@@ -56,7 +56,7 @@ func TestNewUserPost_MustChangePassword(t *testing.T) {
 
 func TestNewUserPost_MustChangePasswordFalse(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "admin/users/new")
+	ctx, _ := contexttest.MockContext(t, "admin/users/new")
 
 	u := unittest.AssertExistsAndLoadBean(t, &user_model.User{
 		IsAdmin: true,
@@ -93,7 +93,7 @@ func TestNewUserPost_MustChangePasswordFalse(t *testing.T) {
 
 func TestNewUserPost_InvalidEmail(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "admin/users/new")
+	ctx, _ := contexttest.MockContext(t, "admin/users/new")
 
 	u := unittest.AssertExistsAndLoadBean(t, &user_model.User{
 		IsAdmin: true,
@@ -123,7 +123,7 @@ func TestNewUserPost_InvalidEmail(t *testing.T) {
 
 func TestNewUserPost_VisibilityDefaultPublic(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "admin/users/new")
+	ctx, _ := contexttest.MockContext(t, "admin/users/new")
 
 	u := unittest.AssertExistsAndLoadBean(t, &user_model.User{
 		IsAdmin: true,
@@ -161,7 +161,7 @@ func TestNewUserPost_VisibilityDefaultPublic(t *testing.T) {
 
 func TestNewUserPost_VisibilityPrivate(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "admin/users/new")
+	ctx, _ := contexttest.MockContext(t, "admin/users/new")
 
 	u := unittest.AssertExistsAndLoadBean(t, &user_model.User{
 		IsAdmin: true,

--- a/routers/web/org/projects_test.go
+++ b/routers/web/org/projects_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/routers/web/org"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +15,8 @@ import (
 
 func TestCheckProjectBoardChangePermissions(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/-/projects/4/4")
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "user2/-/projects/4/4")
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.ContextUser = ctx.Doer // user2
 	ctx.SetParams(":id", "4")
 	ctx.SetParams(":boardID", "4")

--- a/routers/web/repo/editor_test.go
+++ b/routers/web/repo/editor_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/git"
-	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -41,12 +41,12 @@ func TestCleanUploadName(t *testing.T) {
 
 func TestGetUniquePatchBranchName(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	expectedBranchName := "user2-patch-1"
@@ -56,12 +56,12 @@ func TestGetUniquePatchBranchName(t *testing.T) {
 
 func TestGetClosestParentWithFiles(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository

--- a/routers/web/repo/issue_label_test.go
+++ b/routers/web/repo/issue_label_test.go
@@ -10,6 +10,7 @@ import (
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/repository"
 	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
@@ -32,9 +33,9 @@ func int64SliceToCommaSeparated(a []int64) string {
 func TestInitializeLabels(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 	assert.NoError(t, repository.LoadRepoConfig())
-	ctx, _ := test.MockContext(t, "user2/repo1/labels/initialize")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/labels/initialize")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 2)
 	web.SetForm(ctx, &forms.InitializeLabelsForm{TemplateName: "Default"})
 	InitializeLabels(ctx)
 	assert.EqualValues(t, http.StatusSeeOther, ctx.Resp.Status())
@@ -57,9 +58,9 @@ func TestRetrieveLabels(t *testing.T) {
 		{1, "leastissues", []int64{2, 1}},
 		{2, "", []int64{}},
 	} {
-		ctx, _ := test.MockContext(t, "user/repo/issues")
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, testCase.RepoID)
+		ctx, _ := contexttest.MockContext(t, "user/repo/issues")
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, testCase.RepoID)
 		ctx.Req.Form.Set("sort", testCase.Sort)
 		RetrieveLabels(ctx)
 		assert.False(t, ctx.Written())
@@ -75,9 +76,9 @@ func TestRetrieveLabels(t *testing.T) {
 
 func TestNewLabel(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/labels/edit")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/labels/edit")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	web.SetForm(ctx, &forms.CreateLabelForm{
 		Title: "newlabel",
 		Color: "#abcdef",
@@ -93,9 +94,9 @@ func TestNewLabel(t *testing.T) {
 
 func TestUpdateLabel(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/labels/edit")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/labels/edit")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	web.SetForm(ctx, &forms.CreateLabelForm{
 		ID:         2,
 		Title:      "newnameforlabel",
@@ -114,9 +115,9 @@ func TestUpdateLabel(t *testing.T) {
 
 func TestDeleteLabel(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/labels/delete")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/labels/delete")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	ctx.Req.Form.Set("id", "2")
 	DeleteLabel(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
@@ -127,9 +128,9 @@ func TestDeleteLabel(t *testing.T) {
 
 func TestUpdateIssueLabel_Clear(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	ctx.Req.Form.Set("issue_ids", "1,3")
 	ctx.Req.Form.Set("action", "clear")
 	UpdateIssueLabel(ctx)
@@ -152,9 +153,9 @@ func TestUpdateIssueLabel_Toggle(t *testing.T) {
 		{"toggle", []int64{1, 2}, 2, true},
 	} {
 		unittest.PrepareTestEnv(t)
-		ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, 1)
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
 		ctx.Req.Form.Set("issue_ids", int64SliceToCommaSeparated(testCase.IssueIDs))
 		ctx.Req.Form.Set("action", testCase.Action)
 		ctx.Req.Form.Set("id", strconv.Itoa(int(testCase.LabelID)))

--- a/routers/web/repo/projects_test.go
+++ b/routers/web/repo/projects_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckProjectBoardChangePermissions(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/projects/1/2")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/projects/1/2")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	ctx.SetParams(":id", "1")
 	ctx.SetParams(":boardID", "2")
 

--- a/routers/web/repo/release_test.go
+++ b/routers/web/repo/release_test.go
@@ -8,7 +8,7 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 
@@ -47,10 +47,10 @@ func TestNewReleasePost(t *testing.T) {
 	} {
 		unittest.PrepareTestEnv(t)
 
-		ctx, _ := test.MockContext(t, "user2/repo1/releases/new")
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, 1)
-		test.LoadGitRepo(t, ctx)
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/releases/new")
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadGitRepo(t, ctx)
 		web.SetForm(ctx, &testCase.Form)
 		NewReleasePost(ctx)
 		unittest.AssertExistsAndLoadBean(t, &repo_model.Release{
@@ -67,10 +67,10 @@ func TestNewReleasePost(t *testing.T) {
 
 func TestNewReleasesList(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo-release/releases")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 57)
-	test.LoadGitRepo(t, ctx)
+	ctx, _ := contexttest.MockContext(t, "user2/repo-release/releases")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 57)
+	contexttest.LoadGitRepo(t, ctx)
 	t.Cleanup(func() { ctx.Repo.GitRepo.Close() })
 
 	Releases(ctx)

--- a/routers/web/repo/setting/settings_test.go
+++ b/routers/web/repo/setting/settings_test.go
@@ -15,8 +15,8 @@ import (
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 
@@ -42,10 +42,10 @@ func TestAddReadOnlyDeployKey(t *testing.T) {
 	}
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/settings/keys")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/settings/keys")
 
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 2)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 2)
 
 	addKeyForm := forms.AddKeyForm{
 		Title:   "read-only",
@@ -71,10 +71,10 @@ func TestAddReadWriteOnlyDeployKey(t *testing.T) {
 
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/settings/keys")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/settings/keys")
 
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 2)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 2)
 
 	addKeyForm := forms.AddKeyForm{
 		Title:      "read-write",
@@ -94,10 +94,10 @@ func TestAddReadWriteOnlyDeployKey(t *testing.T) {
 
 func TestCollaborationPost(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-	test.LoadUser(t, ctx, 2)
-	test.LoadUser(t, ctx, 4)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadUser(t, ctx, 4)
+	contexttest.LoadRepo(t, ctx, 1)
 
 	ctx.Req.Form.Set("collaborator", "user4")
 
@@ -129,10 +129,10 @@ func TestCollaborationPost(t *testing.T) {
 
 func TestCollaborationPost_InactiveUser(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-	test.LoadUser(t, ctx, 2)
-	test.LoadUser(t, ctx, 9)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadUser(t, ctx, 9)
+	contexttest.LoadRepo(t, ctx, 1)
 
 	ctx.Req.Form.Set("collaborator", "user9")
 
@@ -152,10 +152,10 @@ func TestCollaborationPost_InactiveUser(t *testing.T) {
 
 func TestCollaborationPost_AddCollaboratorTwice(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-	test.LoadUser(t, ctx, 2)
-	test.LoadUser(t, ctx, 4)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadUser(t, ctx, 4)
+	contexttest.LoadRepo(t, ctx, 1)
 
 	ctx.Req.Form.Set("collaborator", "user4")
 
@@ -193,9 +193,9 @@ func TestCollaborationPost_AddCollaboratorTwice(t *testing.T) {
 
 func TestCollaborationPost_NonExistentUser(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1/issues/labels")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/issues/labels")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 
 	ctx.Req.Form.Set("collaborator", "user34")
 
@@ -215,7 +215,7 @@ func TestCollaborationPost_NonExistentUser(t *testing.T) {
 
 func TestAddTeamPost(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "org26/repo43")
+	ctx, _ := contexttest.MockContext(t, "org26/repo43")
 
 	ctx.Req.Form.Set("team", "team11")
 
@@ -255,7 +255,7 @@ func TestAddTeamPost(t *testing.T) {
 
 func TestAddTeamPost_NotAllowed(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "org26/repo43")
+	ctx, _ := contexttest.MockContext(t, "org26/repo43")
 
 	ctx.Req.Form.Set("team", "team11")
 
@@ -295,7 +295,7 @@ func TestAddTeamPost_NotAllowed(t *testing.T) {
 
 func TestAddTeamPost_AddTeamTwice(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "org26/repo43")
+	ctx, _ := contexttest.MockContext(t, "org26/repo43")
 
 	ctx.Req.Form.Set("team", "team11")
 
@@ -336,7 +336,7 @@ func TestAddTeamPost_AddTeamTwice(t *testing.T) {
 
 func TestAddTeamPost_NonExistentTeam(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "org26/repo43")
+	ctx, _ := contexttest.MockContext(t, "org26/repo43")
 
 	ctx.Req.Form.Set("team", "team-non-existent")
 
@@ -369,7 +369,7 @@ func TestAddTeamPost_NonExistentTeam(t *testing.T) {
 
 func TestDeleteTeam(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "org3/team1/repo3")
+	ctx, _ := contexttest.MockContext(t, "org3/team1/repo3")
 
 	ctx.Req.Form.Set("id", "2")
 

--- a/routers/web/repo/wiki_test.go
+++ b/routers/web/repo/wiki_test.go
@@ -11,8 +11,8 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/git"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 	wiki_service "code.gitea.io/gitea/services/wiki"
@@ -78,9 +78,9 @@ func assertPagesMetas(t *testing.T, expectedNames []string, metas any) {
 func TestWiki(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/?action=_pages")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_pages")
 	ctx.SetParams("*", "Home")
-	test.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepo(t, ctx, 1)
 	Wiki(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assert.EqualValues(t, "Home", ctx.Data["Title"])
@@ -90,8 +90,8 @@ func TestWiki(t *testing.T) {
 func TestWikiPages(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/?action=_pages")
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_pages")
+	contexttest.LoadRepo(t, ctx, 1)
 	WikiPages(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["Pages"])
@@ -100,9 +100,9 @@ func TestWikiPages(t *testing.T) {
 func TestNewWiki(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/?action=_new")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	NewWiki(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assert.EqualValues(t, ctx.Tr("repo.wiki.new_page"), ctx.Data["Title"])
@@ -115,9 +115,9 @@ func TestNewWikiPost(t *testing.T) {
 	} {
 		unittest.PrepareTestEnv(t)
 
-		ctx, _ := test.MockContext(t, "user2/repo1/wiki/?action=_new")
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, 1)
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
 		web.SetForm(ctx, &forms.NewWikiForm{
 			Title:   title,
 			Content: content,
@@ -133,9 +133,9 @@ func TestNewWikiPost(t *testing.T) {
 func TestNewWikiPost_ReservedName(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/?action=_new")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	web.SetForm(ctx, &forms.NewWikiForm{
 		Title:   "_edit",
 		Content: content,
@@ -150,10 +150,10 @@ func TestNewWikiPost_ReservedName(t *testing.T) {
 func TestEditWiki(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/Home?action=_edit")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_edit")
 	ctx.SetParams("*", "Home")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	EditWiki(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assert.EqualValues(t, "Home", ctx.Data["Title"])
@@ -166,10 +166,10 @@ func TestEditWikiPost(t *testing.T) {
 		"New/<page>",
 	} {
 		unittest.PrepareTestEnv(t)
-		ctx, _ := test.MockContext(t, "user2/repo1/wiki/Home?action=_new")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_new")
 		ctx.SetParams("*", "Home")
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, 1)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
 		web.SetForm(ctx, &forms.NewWikiForm{
 			Title:   title,
 			Content: content,
@@ -188,9 +188,9 @@ func TestEditWikiPost(t *testing.T) {
 func TestDeleteWikiPagePost(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := test.MockContext(t, "user2/repo1/wiki/Home?action=_delete")
-	test.LoadUser(t, ctx, 2)
-	test.LoadRepo(t, ctx, 1)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_delete")
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadRepo(t, ctx, 1)
 	DeleteWikiPagePost(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 	assertWikiNotExists(t, ctx.Repo.Repository, "Home")
@@ -207,10 +207,10 @@ func TestWikiRaw(t *testing.T) {
 	} {
 		unittest.PrepareTestEnv(t)
 
-		ctx, _ := test.MockContext(t, "user2/repo1/wiki/raw/"+url.PathEscape(filepath))
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/raw/"+url.PathEscape(filepath))
 		ctx.SetParams("*", filepath)
-		test.LoadUser(t, ctx, 2)
-		test.LoadRepo(t, ctx, 1)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
 		WikiRaw(ctx)
 		if filetype == "" {
 			assert.EqualValues(t, http.StatusNotFound, ctx.Resp.Status(), "filepath: %s", filepath)

--- a/routers/web/user/home_test.go
+++ b/routers/web/user/home_test.go
@@ -9,8 +9,8 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,8 +20,8 @@ func TestArchivedIssues(t *testing.T) {
 	setting.UI.IssuePagingNum = 1
 	assert.NoError(t, unittest.LoadFixtures())
 
-	ctx, _ := test.MockContext(t, "issues")
-	test.LoadUser(t, ctx, 30)
+	ctx, _ := contexttest.MockContext(t, "issues")
+	contexttest.LoadUser(t, ctx, 30)
 	ctx.Req.Form.Set("state", "open")
 
 	// Assume: User 30 has access to two Repos with Issues, one of the Repos being archived.
@@ -53,8 +53,8 @@ func TestIssues(t *testing.T) {
 	setting.UI.IssuePagingNum = 1
 	assert.NoError(t, unittest.LoadFixtures())
 
-	ctx, _ := test.MockContext(t, "issues")
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "issues")
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.Req.Form.Set("state", "closed")
 	Issues(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
@@ -69,8 +69,8 @@ func TestPulls(t *testing.T) {
 	setting.UI.IssuePagingNum = 20
 	assert.NoError(t, unittest.LoadFixtures())
 
-	ctx, _ := test.MockContext(t, "pulls")
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "pulls")
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.Req.Form.Set("state", "open")
 	Pulls(ctx)
 	assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
@@ -82,8 +82,8 @@ func TestMilestones(t *testing.T) {
 	setting.UI.IssuePagingNum = 1
 	assert.NoError(t, unittest.LoadFixtures())
 
-	ctx, _ := test.MockContext(t, "milestones")
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "milestones")
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.SetParams("sort", "issues")
 	ctx.Req.Form.Set("state", "closed")
 	ctx.Req.Form.Set("sort", "furthestduedate")
@@ -101,8 +101,8 @@ func TestMilestonesForSpecificRepo(t *testing.T) {
 	setting.UI.IssuePagingNum = 1
 	assert.NoError(t, unittest.LoadFixtures())
 
-	ctx, _ := test.MockContext(t, "milestones")
-	test.LoadUser(t, ctx, 2)
+	ctx, _ := contexttest.MockContext(t, "milestones")
+	contexttest.LoadUser(t, ctx, 2)
 	ctx.SetParams("sort", "issues")
 	ctx.SetParams("repo", "1")
 	ctx.Req.Form.Set("state", "closed")

--- a/routers/web/user/setting/account_test.go
+++ b/routers/web/user/setting/account_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
 
@@ -83,9 +83,9 @@ func TestChangePassword(t *testing.T) {
 		t.Run(req.OldPassword+"__"+req.NewPassword, func(t *testing.T) {
 			unittest.PrepareTestEnv(t)
 			setting.PasswordComplexity = req.PasswordComplexity
-			ctx, _ := test.MockContext(t, "user/settings/security")
-			test.LoadUser(t, ctx, 2)
-			test.LoadRepo(t, ctx, 1)
+			ctx, _ := contexttest.MockContext(t, "user/settings/security")
+			contexttest.LoadUser(t, ctx, 2)
+			contexttest.LoadRepo(t, ctx, 1)
 
 			web.SetForm(ctx, &forms.ChangePasswordForm{
 				OldPassword: req.OldPassword,

--- a/services/markup/processorhelper_test.go
+++ b/services/markup/processorhelper_test.go
@@ -13,7 +13,7 @@ import (
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/models/user"
 	gitea_context "code.gitea.io/gitea/modules/context"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -42,7 +42,7 @@ func TestProcessorHelper(t *testing.T) {
 	assert.NoError(t, err)
 	base, baseCleanUp := gitea_context.NewBaseContext(httptest.NewRecorder(), req)
 	defer baseCleanUp()
-	giteaCtx := gitea_context.NewWebContext(base, &test.MockRender{}, nil)
+	giteaCtx := gitea_context.NewWebContext(base, &contexttest.MockRender{}, nil)
 
 	assert.True(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPublic))
 	assert.False(t, ProcessorHelper().IsUsernameMentionable(giteaCtx, userPrivate))

--- a/services/repository/archiver/archiver_test.go
+++ b/services/repository/archiver/archiver_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/models/unittest"
-	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/modules/contexttest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,11 +24,11 @@ func TestMain(m *testing.M) {
 func TestArchive_Basic(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
-	ctx, _ := test.MockContext(t, "user27/repo49")
+	ctx, _ := contexttest.MockContext(t, "user27/repo49")
 	firstCommit, secondCommit := "51f84af23134", "aacbdfe9e1c4"
 
-	test.LoadRepo(t, ctx, 49)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 49)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	bogusReq, err := NewRequest(ctx.Repo.Repository.ID, ctx.Repo.GitRepo, firstCommit+".zip")

--- a/services/repository/files/content_test.go
+++ b/services/repository/files/content_test.go
@@ -9,9 +9,9 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/git"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -54,12 +54,12 @@ func getExpectedReadmeContentsResponse() *api.ContentsResponse {
 
 func TestGetContents(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	treePath := "README.md"
@@ -82,12 +82,12 @@ func TestGetContents(t *testing.T) {
 
 func TestGetContentsOrListForDir(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	treePath := "" // root dir
@@ -117,12 +117,12 @@ func TestGetContentsOrListForDir(t *testing.T) {
 
 func TestGetContentsOrListForFile(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	treePath := "README.md"
@@ -145,12 +145,12 @@ func TestGetContentsOrListForFile(t *testing.T) {
 
 func TestGetContentsErrors(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository
@@ -176,12 +176,12 @@ func TestGetContentsErrors(t *testing.T) {
 
 func TestGetContentsOrListErrors(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository
@@ -207,11 +207,11 @@ func TestGetContentsOrListErrors(t *testing.T) {
 
 func TestGetContentsOrListOfEmptyRepos(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user30/empty")
+	ctx, _ := contexttest.MockContext(t, "user30/empty")
 	ctx.SetParams(":id", "52")
-	test.LoadRepo(t, ctx, 52)
-	test.LoadUser(t, ctx, 30)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 52)
+	contexttest.LoadUser(t, ctx, 30)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository
@@ -225,11 +225,11 @@ func TestGetContentsOrListOfEmptyRepos(t *testing.T) {
 
 func TestGetBlobBySHA(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	sha := "65f1bf27bc3bf70f64657658635e66094edbcb4d"

--- a/services/repository/files/diff_test.go
+++ b/services/repository/files/diff_test.go
@@ -8,8 +8,8 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/json"
-	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/services/gitdiff"
 
 	"github.com/stretchr/testify/assert"
@@ -17,12 +17,12 @@ import (
 
 func TestGetDiffPreview(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	branch := ctx.Repo.Repository.DefaultBranch
@@ -139,12 +139,12 @@ func TestGetDiffPreview(t *testing.T) {
 
 func TestGetDiffPreviewErrors(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	branch := ctx.Repo.Repository.DefaultBranch

--- a/services/repository/files/file_test.go
+++ b/services/repository/files/file_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -98,12 +98,12 @@ func getExpectedFileResponse() *api.FileResponse {
 
 func TestGetFileResponseFromCommit(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository

--- a/services/repository/files/tree_test.go
+++ b/services/repository/files/tree_test.go
@@ -7,19 +7,19 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTreeBySHA(t *testing.T) {
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	sha := ctx.Repo.Repository.DefaultBranch

--- a/tests/integration/repofiles_change_test.go
+++ b/tests/integration/repofiles_change_test.go
@@ -12,10 +12,10 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/contexttest"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
-	"code.gitea.io/gitea/modules/test"
 	files_service "code.gitea.io/gitea/services/repository/files"
 
 	"github.com/stretchr/testify/assert"
@@ -245,12 +245,12 @@ func getExpectedFileResponseForRepofilesUpdate(commitID, filename, lastCommitSHA
 func TestChangeRepoFilesForCreate(t *testing.T) {
 	// setup
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		ctx, _ := test.MockContext(t, "user2/repo1")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
-		test.LoadRepo(t, ctx, 1)
-		test.LoadRepoCommit(t, ctx)
-		test.LoadUser(t, ctx, 2)
-		test.LoadGitRepo(t, ctx)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadRepoCommit(t, ctx)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadGitRepo(t, ctx)
 		defer ctx.Repo.GitRepo.Close()
 
 		repo := ctx.Repo.Repository
@@ -282,12 +282,12 @@ func TestChangeRepoFilesForCreate(t *testing.T) {
 func TestChangeRepoFilesForUpdate(t *testing.T) {
 	// setup
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		ctx, _ := test.MockContext(t, "user2/repo1")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
-		test.LoadRepo(t, ctx, 1)
-		test.LoadRepoCommit(t, ctx)
-		test.LoadUser(t, ctx, 2)
-		test.LoadGitRepo(t, ctx)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadRepoCommit(t, ctx)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadGitRepo(t, ctx)
 		defer ctx.Repo.GitRepo.Close()
 
 		repo := ctx.Repo.Repository
@@ -316,12 +316,12 @@ func TestChangeRepoFilesForUpdate(t *testing.T) {
 func TestChangeRepoFilesForUpdateWithFileMove(t *testing.T) {
 	// setup
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		ctx, _ := test.MockContext(t, "user2/repo1")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
-		test.LoadRepo(t, ctx, 1)
-		test.LoadRepoCommit(t, ctx)
-		test.LoadUser(t, ctx, 2)
-		test.LoadGitRepo(t, ctx)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadRepoCommit(t, ctx)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadGitRepo(t, ctx)
 		defer ctx.Repo.GitRepo.Close()
 
 		repo := ctx.Repo.Repository
@@ -367,12 +367,12 @@ func TestChangeRepoFilesForUpdateWithFileMove(t *testing.T) {
 func TestChangeRepoFilesWithoutBranchNames(t *testing.T) {
 	// setup
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		ctx, _ := test.MockContext(t, "user2/repo1")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
-		test.LoadRepo(t, ctx, 1)
-		test.LoadRepoCommit(t, ctx)
-		test.LoadUser(t, ctx, 2)
-		test.LoadGitRepo(t, ctx)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadRepoCommit(t, ctx)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadGitRepo(t, ctx)
 		defer ctx.Repo.GitRepo.Close()
 
 		repo := ctx.Repo.Repository
@@ -403,12 +403,12 @@ func TestChangeRepoFilesForDelete(t *testing.T) {
 func testDeleteRepoFiles(t *testing.T, u *url.URL) {
 	// setup
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 	repo := ctx.Repo.Repository
 	doer := ctx.Doer
@@ -442,12 +442,12 @@ func TestChangeRepoFilesForDeleteWithoutBranchNames(t *testing.T) {
 func testDeleteRepoFilesWithoutBranchNames(t *testing.T, u *url.URL) {
 	// setup
 	unittest.PrepareTestEnv(t)
-	ctx, _ := test.MockContext(t, "user2/repo1")
+	ctx, _ := contexttest.MockContext(t, "user2/repo1")
 	ctx.SetParams(":id", "1")
-	test.LoadRepo(t, ctx, 1)
-	test.LoadRepoCommit(t, ctx)
-	test.LoadUser(t, ctx, 2)
-	test.LoadGitRepo(t, ctx)
+	contexttest.LoadRepo(t, ctx, 1)
+	contexttest.LoadRepoCommit(t, ctx)
+	contexttest.LoadUser(t, ctx, 2)
+	contexttest.LoadGitRepo(t, ctx)
 	defer ctx.Repo.GitRepo.Close()
 
 	repo := ctx.Repo.Repository
@@ -472,12 +472,12 @@ func testDeleteRepoFilesWithoutBranchNames(t *testing.T, u *url.URL) {
 func TestChangeRepoFilesErrors(t *testing.T) {
 	// setup
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		ctx, _ := test.MockContext(t, "user2/repo1")
+		ctx, _ := contexttest.MockContext(t, "user2/repo1")
 		ctx.SetParams(":id", "1")
-		test.LoadRepo(t, ctx, 1)
-		test.LoadRepoCommit(t, ctx)
-		test.LoadUser(t, ctx, 2)
-		test.LoadGitRepo(t, ctx)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.LoadRepoCommit(t, ctx)
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadGitRepo(t, ctx)
 		defer ctx.Repo.GitRepo.Close()
 
 		repo := ctx.Repo.Repository


### PR DESCRIPTION
Just like `models/unittest`, the testing helper functions should be in a separate package: `contexttest`

And complete the TODO:

> // TODO: move this function to other packages, because it depends on "models" package