### PR TITLE
Move licenses.txt to /assets directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ cpu.out
 /public/assets/js
 /public/assets/css
 /public/assets/fonts
+/public/assets/licenses.txt
 /public/assets/img/webpack
 /vendor
 /web_src/fomantic/node_modules

--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -23,7 +23,7 @@
 				{{end}}
 			</div>
 		</div>
-		<a href="{{AssetUrlPrefix}}/js/licenses.txt">{{.locale.Tr "licenses"}}</a>
+		<a href="{{AssetUrlPrefix}}/licenses.txt">{{.locale.Tr "licenses"}}</a>
 		{{if .EnableSwagger}}<a href="{{AppSubUrl}}/api/swagger">API</a>{{end}}
 		{{template "custom/extra_links_footer" .}}
 	</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,7 +188,7 @@ export default {
       filename: 'js/monaco-[name].[contenthash:8].worker.js',
     }),
     isProduction ? new LicenseCheckerWebpackPlugin({
-      outputFilename: 'js/licenses.txt',
+      outputFilename: 'licenses.txt',
       outputWriter: ({dependencies}) => {
         const line = '-'.repeat(80);
         const goJson = readFileSync('assets/go-licenses.json', 'utf8');
@@ -211,7 +211,7 @@ export default {
       },
       emitError: true,
       allow: '(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT OR ISC OR CPAL-1.0 OR Unlicense OR EPL-1.0 OR EPL-2.0)',
-    }) : new AddAssetPlugin('js/licenses.txt', `Licenses are disabled during development`),
+    }) : new AddAssetPlugin('licenses.txt', `Licenses are disabled during development`),
   ],
   performance: {
     hints: false,
@@ -239,7 +239,7 @@ export default {
     entrypoints: false,
     excludeAssets: [
       /^js\/monaco-language-.+\.js$/,
-      !isProduction && /^js\/licenses.txt$/,
+      !isProduction && /^licenses.txt$/,
     ].filter(Boolean),
     groupAssetsByChunk: false,
     groupAssetsByEmitStatus: false,


### PR DESCRIPTION
Now that we have the `/assets` directory, we can put`licenses.txt` directly into it instead of incorrect `/js` path which was previously only done to avoid reserving a username.