### PR TITLE
Use case-insensitive regex for all webpack assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,12 +117,12 @@ export default {
   module: {
     rules: [
       {
-        test: /\.vue$/,
+        test: /\.vue$/i,
         exclude: /node_modules/,
         loader: 'vue-loader',
       },
       {
-        test: /\.js$/,
+        test: /\.js$/i,
         exclude: /node_modules/,
         use: [
           {
@@ -151,12 +151,12 @@ export default {
         ],
       },
       {
-        test: /\.svg$/,
+        test: /\.svg$/i,
         include: fileURLToPath(new URL('public/assets/img/svg', import.meta.url)),
         type: 'asset/source',
       },
       {
-        test: /\.(ttf|woff2?)$/,
+        test: /\.(ttf|woff2?)$/i,
         type: 'asset/resource',
         generator: {
           filename: 'fonts/[name].[contenthash:8][ext]',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,10 +41,10 @@ const filterCssImport = (url, ...args) => {
 
   if (cssFile.includes('fomantic')) {
     if (/brand-icons/.test(importedFile)) return false;
-    if (/(eot|ttf|otf|woff|svg)$/.test(importedFile)) return false;
+    if (/(eot|ttf|otf|woff|svg)$/i.test(importedFile)) return false;
   }
 
-  if (cssFile.includes('katex') && /(ttf|woff)$/.test(importedFile)) {
+  if (cssFile.includes('katex') && /(ttf|woff)$/i.test(importedFile)) {
     return false;
   }
 


### PR DESCRIPTION
Previously, only some of these regex had the `i` flag and while we can likely ensure case for our files, these regexes are also used for third-party files, so it's better to always match insensitively.