### PR TITLE
Refactor `og:description` to limit the max length

### DIFF
--- a/modules/templates/util_string.go
+++ b/modules/templates/util_string.go
@@ -33,6 +33,11 @@ func (su *StringUtils) Join(a []string, sep string) string {
 	return strings.Join(a, sep)
 }
 
+func (su *StringUtils) Cut(s, sep string) []any {
+	before, after, found := strings.Cut(s, sep)
+	return []any{before, after, found}
+}
+
 func (su *StringUtils) EllipsisString(s string, max int) string {
 	return base.EllipsisString(s, max)
 }

--- a/templates/base/head_opengraph.tmpl
+++ b/templates/base/head_opengraph.tmpl
@@ -1,29 +1,34 @@
+{{- /* og:description - a one to two sentence description of your object, maybe it only needs at most 300 bytes */ -}}
 {{if .PageIsUserProfile}}
 	<meta property="og:title" content="{{.ContextUser.DisplayName}}">
 	<meta property="og:type" content="profile">
 	<meta property="og:image" content="{{.ContextUser.AvatarLink ctx}}">
 	<meta property="og:url" content="{{.ContextUser.HTMLURL}}">
 	{{if .ContextUser.Description}}
-		<meta property="og:description" content="{{.ContextUser.Description}}">
+		<meta property="og:description" content="{{StringUtils.EllipsisString .ContextUser.Description 300}}">
 	{{end}}
 {{else if .Repository}}
 	{{if .Issue}}
 		<meta property="og:title" content="{{.Issue.Title}}">
 		<meta property="og:url" content="{{.Issue.HTMLURL}}">
 		{{if .Issue.Content}}
-			<meta property="og:description" content="{{.Issue.Content}}">
+			<meta property="og:description" content="{{StringUtils.EllipsisString .Issue.Content 300}}">
 		{{end}}
 	{{else if or .PageIsDiff .IsViewFile}}
 		<meta property="og:title" content="{{.Title}}">
 		<meta property="og:url" content="{{AppUrl}}{{.Link}}">
-		{{if and .PageIsDiff (IsMultilineCommitMessage .Commit.Message)}}
-			<meta property="og:description" content="{{RenderCommitBody $.Context .Commit.Message $.RepoLink $.Repository.ComposeMetas}}">
+		{{if .PageIsDiff}}
+			{{- $commitMessageParts := StringUtils.Cut .Commit.Message "\n" -}}
+			{{- $commitMessageBody := index $commitMessageParts 1 -}}
+			{{- if $commitMessageBody -}}
+				<meta property="og:description" content="{{StringUtils.EllipsisString $commitMessageBody 300}}">
+			{{- end -}}
 		{{end}}
 	{{else}}
 		<meta property="og:title" content="{{.Repository.Name}}">
 		<meta property="og:url" content="{{.Repository.HTMLURL}}">
 		{{if .Repository.Description}}
-			<meta property="og:description" content="{{.Repository.Description}}">
+			<meta property="og:description" content="{{StringUtils.EllipsisString .Repository.Description 300}}">
 		{{end}}
 	{{end}}
 	<meta property="og:type" content="object">


### PR DESCRIPTION
1. The `og:description` should be "a one to two sentence description of your object"
    * It shouldn't output all the user inputted content -- it would be pretty huge.
    * Maybe it only needs at most 300 bytes.
2. Do not render commit message as HTML