### PR TITLE
Fix GetAffectedFiles failed when encountering a null old commit

### DIFF
--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -273,8 +273,8 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 // GetAffectedFiles returns the affected files between two commits
 func GetAffectedFiles(repo *Repository, oldCommitID, newCommitID string, env []string) ([]string, error) {
 	// If the old commit is the null commit, then we need to use the empty tree
-	if oldCommitID == "0000000000000000000000000000000000000000" {
-		oldCommitID = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	if oldCommitID == EmptySHA {
+		oldCommitID = EmptyTreeSHA
 	}
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {

--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -273,8 +273,9 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 // GetAffectedFiles returns the affected files between two commits
 func GetAffectedFiles(repo *Repository, oldCommitID, newCommitID string, env []string) ([]string, error) {
 	// If the old commit is the null commit, then we need to use the empty tree
-	if oldCommitID == "0000000000000000000000000000000000000000" {
-		oldCommitID = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	if oldCommitID == EmptySHA {
+		oldCommitID = EmptyTreeSHA
+	}
 	}
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {

--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -272,6 +272,10 @@ func CutDiffAroundLine(originalDiff io.Reader, line int64, old bool, numbersOfLi
 
 // GetAffectedFiles returns the affected files between two commits
 func GetAffectedFiles(repo *Repository, oldCommitID, newCommitID string, env []string) ([]string, error) {
+	// If the old commit is the null commit, then we need to use the empty tree
+	if oldCommitID == "0000000000000000000000000000000000000000" {
+		oldCommitID = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	}
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		log.Error("Unable to create os.Pipe for %s", repo.Path)


### PR DESCRIPTION
When using protected/unprotected file patterns, `git push --set-upstream xxx xxx` will cause an internal server error.
![6D9IB}`MLNADEJ%QV`QD(0V](https://github.com/go-gitea/gitea/assets/70063547/012087ba-402b-46e2-9092-6b46e796cb5b)
This bug is because when `git push --set-upstream`, a null commit is passed to function GetAffectedFiles as oldCommitID, but git diff cannot compare null commits. So when `oldCommit` is null, we should modify the `oldCommitID` to empty tree commit("4b825dc642cb6eb9a060e54bf8d69288fbee4904") to use `git diff`.
