### PR TITLE
Add missing `reqToken()` to notifications endpoints

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -776,11 +776,11 @@ func Routes() *web.Route {
 		// Notifications (requires 'notifications' scope)
 		m.Group("/notifications", func() {
 			m.Combo("").
-				Get(notify.ListNotifications).
+				Get(reqToken(), notify.ListNotifications).
 				Put(reqToken(), notify.ReadNotifications)
-			m.Get("/new", notify.NewAvailable)
+			m.Get("/new", reqToken(), notify.NewAvailable)
 			m.Combo("/threads/{id}").
-				Get(notify.GetThread).
+				Get(reqToken(), notify.GetThread).
 				Patch(reqToken(), notify.ReadThread)
 		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryNotification))
 

--- a/tests/integration/api_notification_test.go
+++ b/tests/integration/api_notification_test.go
@@ -30,6 +30,8 @@ func TestAPINotification(t *testing.T) {
 	session := loginUser(t, user2.Name)
 	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteNotification, auth_model.AccessTokenScopeWriteRepository)
 
+	MakeRequest(t, NewRequest(t, "GET", "/api/v1/notifications"), http.StatusUnauthorized)
+
 	// -- GET /notifications --
 	// test filter
 	since := "2000-01-01T00%3A50%3A01%2B00%3A00" // 946687801
@@ -80,6 +82,8 @@ func TestAPINotification(t *testing.T) {
 	assert.False(t, apiNL[1].Unread)
 	assert.True(t, apiNL[1].Pinned)
 
+	MakeRequest(t, NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications/threads/%d", 1)), http.StatusUnauthorized)
+
 	// -- GET /notifications/threads/{id} --
 	// get forbidden
 	req = NewRequest(t, "GET", fmt.Sprintf("/api/v1/notifications/threads/%d?token=%s", 1, token))
@@ -98,6 +102,8 @@ func TestAPINotification(t *testing.T) {
 	assert.EqualValues(t, "Issue", apiN.Subject.Type)
 	assert.EqualValues(t, thread5.Issue.APIURL(), apiN.Subject.URL)
 	assert.EqualValues(t, thread5.Repository.HTMLURL(), apiN.Repository.HTMLURL)
+
+	MakeRequest(t, NewRequest(t, "GET", "/api/v1/notifications/new"), http.StatusUnauthorized)
 
 	new := struct {
 		New int64 `json:"new"`


### PR DESCRIPTION
They currently throw a Internal Server Error when you use them without a token. Now they correctly return a `token is required` error.

This is no security issue. If you use this endpoints with a token that don't have the correct permission, you get the correct error. This is not affected by this PR.