### PR TITLE
Team invite url fix when registration disabled

### DIFF
--- a/services/mailer/mail_team_invite.go
+++ b/services/mailer/mail_team_invite.go
@@ -46,7 +46,7 @@ func MailTeamInvite(ctx context.Context, inviter *user_model.User, team *org_mod
 	inviteRedirect := url.QueryEscape(fmt.Sprintf("/org/invite/%s", invite.Token))
 	inviteURL := fmt.Sprintf("%suser/sign_up?redirect_to=%s", setting.AppURL, inviteRedirect)
 
-	if (err == nil && user != nil) || setting.Service.AllowOnlyExternalRegistration {
+	if (err == nil && user != nil) || setting.Service.DisableRegistration || setting.Service.AllowOnlyExternalRegistration {
 		// user account exists or registration disabled
 		inviteURL = fmt.Sprintf("%suser/login?redirect_to=%s", setting.AppURL, inviteRedirect)
 	}

--- a/services/mailer/mail_team_invite.go
+++ b/services/mailer/mail_team_invite.go
@@ -46,8 +46,8 @@ func MailTeamInvite(ctx context.Context, inviter *user_model.User, team *org_mod
 	inviteRedirect := url.QueryEscape(fmt.Sprintf("/org/invite/%s", invite.Token))
 	inviteURL := fmt.Sprintf("%suser/sign_up?redirect_to=%s", setting.AppURL, inviteRedirect)
 
-	if err == nil && user != nil {
-		// user account exists
+	if (err == nil && user != nil) || setting.Service.AllowOnlyExternalRegistration {
+		// user account exists or registration disabled
 		inviteURL = fmt.Sprintf("%suser/login?redirect_to=%s", setting.AppURL, inviteRedirect)
 	}
 


### PR DESCRIPTION
This is a follow-on to https://github.com/go-gitea/gitea/pull/26550 and fixes the case where the team invite links to the registration page if it is disabled in settings.
