### PR TITLE
Add oauth sign-in to registration page

### DIFF
--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -390,6 +390,13 @@ func SignOut(ctx *context.Context) {
 func SignUp(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("sign_up")
 
+	orderedOAuth2Names, oauth2Providers, err := oauth2.GetActiveOAuth2Providers()
+	if err != nil {
+		ctx.ServerError("SignUp", err)
+		return
+	}
+	ctx.Data["OrderedOAuth2Names"] = orderedOAuth2Names
+	ctx.Data["OAuth2Providers"] = oauth2Providers
 	ctx.Data["SignUpLink"] = setting.AppSubURL + "/user/sign_up"
 
 	context.SetCaptchaData(ctx)
@@ -411,6 +418,13 @@ func SignUpPost(ctx *context.Context) {
 	form := web.GetForm(ctx).(*forms.RegisterForm)
 	ctx.Data["Title"] = ctx.Tr("sign_up")
 
+	orderedOAuth2Names, oauth2Providers, err := oauth2.GetActiveOAuth2Providers()
+	if err != nil {
+		ctx.ServerError("SignUpPost", err)
+		return
+	}
+	ctx.Data["OrderedOAuth2Names"] = orderedOAuth2Names
+	ctx.Data["OAuth2Providers"] = oauth2Providers
 	ctx.Data["SignUpLink"] = setting.AppSubURL + "/user/sign_up"
 
 	context.SetCaptchaData(ctx)

--- a/templates/user/auth/signup_inner.tmpl
+++ b/templates/user/auth/signup_inner.tmpl
@@ -54,6 +54,25 @@
 					<a href="{{AppSubUrl}}/user/login">{{.locale.Tr "auth.register_helper_msg"}}</a>
 				</div>
 				{{end}}
+
+				{{if and .OrderedOAuth2Names .OAuth2Providers}}
+					<div class="divider divider-text">
+						{{.locale.Tr "sign_in_or"}}
+					</div>
+					<div id="oauth2-login-navigator" class="gt-py-2">
+						<div class="gt-df gt-fc gt-jc">
+							<div id="oauth2-login-navigator-inner" class="gt-df gt-fc gt-fw gt-ac gt-gap-3">
+								{{range $key := .OrderedOAuth2Names}}
+									{{$provider := index $.OAuth2Providers $key}}
+									<a class="{{$provider.Name}} ui button gt-df gt-ac gt-jc gt-py-3 oauth-login-link" href="{{AppSubUrl}}/user/oauth2/{{$key}}">
+										{{$provider.IconHTML}}
+										{{$.locale.Tr "sign_in_with_provider" $provider.DisplayName}}
+									</a>
+								{{end}}
+							</div>
+						</div>
+					</div>
+				{{end}}
 			{{end}}
 		</form>
 	</div>


### PR DESCRIPTION
This is a follow-on to https://github.com/go-gitea/gitea/pull/26550 and includes oauth signin on the registration page. 

This is particularly important for invitations by email. A user without an account may be invited to join a team and will receive an activation link that first navigates to the registration page. However, this will be a confusing flow if they intend to use an external auth provider.

<img width="1230" alt="Screen Shot 2023-09-06 at 12 55 49 PM" src="https://github.com/go-gitea/gitea/assets/23248839/35c47fd9-564b-469a-a9ef-fc1b7fab959f">
