### PR TITLE
Automatically set cookie `secure` attribute, remove COOKIE_SECURE option

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1744,9 +1744,6 @@ LEVEL = Info
 ;; Session cookie name
 ;COOKIE_NAME = i_like_gitea
 ;;
-;; If you use session in https only, default is false
-;COOKIE_SECURE = false
-;;
 ;; Session GC time interval in seconds, default is 86400 (1 day)
 ;GC_INTERVAL_TIME = 86400
 ;;

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -776,7 +776,6 @@ and
 
 - `PROVIDER`: **memory**: Session engine provider \[memory, file, redis, redis-cluster, db, mysql, couchbase, memcache, postgres\]. Setting `db` will reuse the configuration in `[database]`
 - `PROVIDER_CONFIG`: **data/sessions**: For file, the root path; for db, empty (database config will be used); for others, the connection string. Relative paths will be made absolute against _`AppWorkPath`_.
-- `COOKIE_SECURE`: **false**: Enable this to force using HTTPS for all session access.
 - `COOKIE_NAME`: **i\_like\_gitea**: The name of the cookie used for the session ID.
 - `GC_INTERVAL_TIME`: **86400**: GC interval in seconds.
 - `SESSION_LIFE_TIME`: **86400**: Session life time in seconds, default is 86400 (1 day)

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -742,7 +742,6 @@ Gitea 创建以下非唯一队列：
 
 - `PROVIDER`: **memory**：会话存储引擎 \[memory, file, redis, redis-cluster, db, mysql, couchbase, memcache, postgres\]。设置为 `db` 将会重用 `[database]` 的配置信息。
 - `PROVIDER_CONFIG`: **data/sessions**：对于文件，为根路径；对于 db，为空（将使用数据库配置）；对于其他引擎，为连接字符串。相对路径将根据 _`AppWorkPath`_ 绝对化。
-- `COOKIE_SECURE`: **false**：启用此选项以强制在所有会话访问中使用 HTTPS。
 - `COOKIE_NAME`: **i\_like\_gitea**：用于会话 ID 的 cookie 名称。
 - `GC_INTERVAL_TIME`: **86400**：GC 间隔时间，以秒为单位。
 - `SESSION_LIFE_TIME`: **86400**：会话生命周期，以秒为单位，默认为 86400（1 天）。

--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -160,10 +160,10 @@ func Contexter() func(next http.Handler) http.Handler {
 				Cookie:         setting.CSRFCookieName,
 				SetCookie:      true,
 				Secure:         middleware.GetCookieSecure(ctx.Req),
+				CookieHTTPOnly: setting.CSRFCookieHTTPOnly,
 				Header:         "X-Csrf-Token",
 				CookieDomain:   setting.SessionConfig.Domain,
 				CookiePath:     setting.SessionConfig.CookiePath,
-				CookieHTTPOnly: setting.CSRFCookieHTTPOnly,
 				SameSite:       setting.SessionConfig.SameSite,
 			}
 			ctx.Csrf = PrepareCSRFProtector(csrfOpts, ctx)

--- a/modules/context/context_cookie.go
+++ b/modules/context/context_cookie.go
@@ -32,13 +32,13 @@ func removeSessionCookieHeader(w http.ResponseWriter) {
 // SetSiteCookie convenience function to set most cookies consistently
 // CSRF and a few others are the exception here
 func (ctx *Context) SetSiteCookie(name, value string, maxAge int) {
-	middleware.SetSiteCookie(ctx.Resp, name, value, maxAge)
+	middleware.SetSiteCookie(ctx.Resp, ctx.Req, name, value, maxAge)
 }
 
 // DeleteSiteCookie convenience function to delete most cookies consistently
 // CSRF and a few others are the exception here
 func (ctx *Context) DeleteSiteCookie(name string) {
-	middleware.SetSiteCookie(ctx.Resp, name, "", -1)
+	middleware.SetSiteCookie(ctx.Resp, ctx.Req, name, "", -1)
 }
 
 // GetSiteCookie returns given cookie value from request header.

--- a/modules/setting/session.go
+++ b/modules/setting/session.go
@@ -27,8 +27,6 @@ var SessionConfig = struct {
 	Gclifetime int64
 	// Max life time in seconds. Default is whatever GC interval time is.
 	Maxlifetime int64
-	// Use HTTPS only. Default is false.
-	Secure bool
 	// Cookie domain name. Default is empty.
 	Domain string
 	// SameSite declares if your cookie should be restricted to a first-party or same-site context. Valid strings are "none", "lax", "strict". Default is "lax"
@@ -50,7 +48,6 @@ func loadSessionFrom(rootCfg ConfigProvider) {
 	}
 	SessionConfig.CookieName = sec.Key("COOKIE_NAME").MustString("i_like_gitea")
 	SessionConfig.CookiePath = AppSubURL + "/" // there was a bug, old code only set CookePath=AppSubURL, no trailing slash
-	SessionConfig.Secure = sec.Key("COOKIE_SECURE").MustBool(false)
 	SessionConfig.Gclifetime = sec.Key("GC_INTERVAL_TIME").MustInt64(86400)
 	SessionConfig.Maxlifetime = sec.Key("SESSION_LIFE_TIME").MustInt64(86400)
 	SessionConfig.Domain = sec.Key("DOMAIN").String()

--- a/modules/web/middleware/cookie.go
+++ b/modules/web/middleware/cookie.go
@@ -34,7 +34,7 @@ func GetSiteCookie(req *http.Request, name string) string {
 
 // GetCookieSecure returns whether the "Secure" attribute on a cookie should be set
 func GetCookieSecure(req *http.Request) bool {
-	forwardedProto := req.Header.Get("x-forwarded-proto")
+	forwardedProto := strings.ToLower(req.Header.Get("x-forwarded-proto"))
 	if forwardedProto != "" {
 		return forwardedProto == "https" || forwardedProto == "wss"
 	}

--- a/modules/web/middleware/cookie.go
+++ b/modules/web/middleware/cookie.go
@@ -37,9 +37,8 @@ func GetCookieSecure(req *http.Request) bool {
 	forwardedProto := req.Header.Get("x-forwarded-proto")
 	if forwardedProto != "" {
 		return forwardedProto == "https"
-	} else {
-		return req.TLS != nil
 	}
+	return req.TLS != nil
 }
 
 // SetSiteCookie returns given cookie value from request header.

--- a/modules/web/middleware/cookie.go
+++ b/modules/web/middleware/cookie.go
@@ -43,7 +43,6 @@ func GetCookieSecure(req *http.Request) bool {
 
 // SetSiteCookie returns given cookie value from request header.
 func SetSiteCookie(resp http.ResponseWriter, req *http.Request, name, value string, maxAge int) {
-
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    url.QueryEscape(value),

--- a/modules/web/middleware/cookie.go
+++ b/modules/web/middleware/cookie.go
@@ -36,7 +36,7 @@ func GetSiteCookie(req *http.Request, name string) string {
 func GetCookieSecure(req *http.Request) bool {
 	forwardedProto := req.Header.Get("x-forwarded-proto")
 	if forwardedProto != "" {
-		return forwardedProto == "https"
+		return forwardedProto == "https" || forwardedProto == "wss"
 	}
 	return req.TLS != nil
 }

--- a/modules/web/middleware/locale.go
+++ b/modules/web/middleware/locale.go
@@ -41,19 +41,19 @@ func Locale(resp http.ResponseWriter, req *http.Request) translation.Locale {
 	}
 
 	if changeLang {
-		SetLocaleCookie(resp, lang, 1<<31-1)
+		SetLocaleCookie(resp, req, lang, 1<<31-1)
 	}
 
 	return translation.NewLocale(lang)
 }
 
 // SetLocaleCookie convenience function to set the locale cookie consistently
-func SetLocaleCookie(resp http.ResponseWriter, lang string, maxAge int) {
-	SetSiteCookie(resp, "lang", lang, maxAge)
+func SetLocaleCookie(resp http.ResponseWriter, req *http.Request, lang string, maxAge int) {
+	SetSiteCookie(resp, req, "lang", lang, maxAge)
 }
 
 // DeleteLocaleCookie convenience function to delete the locale cookie consistently
 // Setting the lang cookie will trigger the middleware to reset the language to previous state.
-func DeleteLocaleCookie(resp http.ResponseWriter) {
-	SetSiteCookie(resp, "lang", "", -1)
+func DeleteLocaleCookie(resp http.ResponseWriter, req *http.Request) {
+	SetSiteCookie(resp, req, "lang", "", -1)
 }

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3109,7 +3109,6 @@ config.provider_config = Provider Config
 config.cookie_name = Cookie Name
 config.gc_interval_time = GC Interval Time
 config.session_life_time = Session Life Time
-config.https_only = HTTPS Only
 config.cookie_life_time = Cookie Life Time
 
 config.picture_config = Picture and Avatar Configuration

--- a/routers/common/middleware.go
+++ b/routers/common/middleware.go
@@ -101,15 +101,20 @@ func stripSlashesMiddleware(next http.Handler) http.Handler {
 }
 
 func Sessioner() func(next http.Handler) http.Handler {
-	return session.Sessioner(session.Options{
-		Provider:       setting.SessionConfig.Provider,
-		ProviderConfig: setting.SessionConfig.ProviderConfig,
-		CookieName:     setting.SessionConfig.CookieName,
-		CookiePath:     setting.SessionConfig.CookiePath,
-		Gclifetime:     setting.SessionConfig.Gclifetime,
-		Maxlifetime:    setting.SessionConfig.Maxlifetime,
-		Secure:         setting.SessionConfig.Secure,
-		SameSite:       setting.SessionConfig.SameSite,
-		Domain:         setting.SessionConfig.Domain,
-	})
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			handler := session.Sessioner(session.Options{
+				Provider:       setting.SessionConfig.Provider,
+				ProviderConfig: setting.SessionConfig.ProviderConfig,
+				CookieName:     setting.SessionConfig.CookieName,
+				CookiePath:     setting.SessionConfig.CookiePath,
+				Gclifetime:     setting.SessionConfig.Gclifetime,
+				Maxlifetime:    setting.SessionConfig.Maxlifetime,
+				Secure:         middleware.GetCookieSecure(req),
+				SameSite:       setting.SessionConfig.SameSite,
+				Domain:         setting.SessionConfig.Domain,
+			})
+			handler.ServeHTTP(resp, req) // handler.ServeHTTP undefined
+		})
+	}
 }

--- a/routers/common/middleware.go
+++ b/routers/common/middleware.go
@@ -114,7 +114,7 @@ func Sessioner() func(next http.Handler) http.Handler {
 				SameSite:       setting.SessionConfig.SameSite,
 				Domain:         setting.SessionConfig.Domain,
 			})
-			handler.ServeHTTP(resp, req) // handler.ServeHTTP undefined
+			handler(next).ServeHTTP(resp, req)
 		})
 	}
 }

--- a/routers/web/admin/config.go
+++ b/routers/web/admin/config.go
@@ -159,7 +159,6 @@ func Config(ctx *context.Context) {
 		sessionCfg.CookiePath = realSession.CookiePath
 		sessionCfg.Gclifetime = realSession.Gclifetime
 		sessionCfg.Maxlifetime = realSession.Maxlifetime
-		sessionCfg.Secure = realSession.Secure
 		sessionCfg.Domain = realSession.Domain
 	}
 	sessionCfg.ProviderConfig = shadowPassword(sessionCfg.Provider, sessionCfg.ProviderConfig)

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -104,7 +104,7 @@ func resetLocale(ctx *context.Context, u *user_model.User) error {
 		}
 	}
 
-	middleware.SetLocaleCookie(ctx.Resp, u.Language, 0)
+	middleware.SetLocaleCookie(ctx.Resp, ctx.Req, u.Language, 0)
 
 	if ctx.Locale.Language() != u.Language {
 		ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
@@ -123,13 +123,13 @@ func checkAutoLogin(ctx *context.Context) bool {
 
 	redirectTo := ctx.FormString("redirect_to")
 	if len(redirectTo) > 0 {
-		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
+		middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, redirectTo)
 	} else {
 		redirectTo = ctx.GetSiteCookie("redirect_to")
 	}
 
 	if isSucceed {
-		middleware.DeleteRedirectToCookie(ctx.Resp)
+		middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 		ctx.RedirectToFirst(redirectTo, setting.AppSubURL+string(setting.LandingPageURL))
 		return true
 	}
@@ -323,7 +323,7 @@ func handleSignInFull(ctx *context.Context, u *user_model.User, remember, obeyRe
 		}
 	}
 
-	middleware.SetLocaleCookie(ctx.Resp, u.Language, 0)
+	middleware.SetLocaleCookie(ctx.Resp, ctx.Req, u.Language, 0)
 
 	if ctx.Locale.Language() != u.Language {
 		ctx.Locale = middleware.Locale(ctx.Resp, ctx.Req)
@@ -340,7 +340,7 @@ func handleSignInFull(ctx *context.Context, u *user_model.User, remember, obeyRe
 	}
 
 	if redirectTo := ctx.GetSiteCookie("redirect_to"); len(redirectTo) > 0 && !utils.IsExternalURL(redirectTo) {
-		middleware.DeleteRedirectToCookie(ctx.Resp)
+		middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 		if obeyRedirect {
 			ctx.RedirectToFirst(redirectTo)
 		}
@@ -371,7 +371,7 @@ func HandleSignOut(ctx *context.Context) {
 	ctx.DeleteSiteCookie(setting.CookieUserName)
 	ctx.DeleteSiteCookie(setting.CookieRememberName)
 	ctx.Csrf.DeleteCookie(ctx)
-	middleware.DeleteRedirectToCookie(ctx.Resp)
+	middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 }
 
 // SignOut sign out from login status
@@ -400,7 +400,7 @@ func SignUp(ctx *context.Context) {
 
 	redirectTo := ctx.FormString("redirect_to")
 	if len(redirectTo) > 0 {
-		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
+		middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, redirectTo)
 	}
 
 	ctx.HTML(http.StatusOK, tplSignUp)
@@ -735,7 +735,7 @@ func handleAccountActivation(ctx *context.Context, user *user_model.User) {
 
 	ctx.Flash.Success(ctx.Tr("auth.account_activated"))
 	if redirectTo := ctx.GetSiteCookie("redirect_to"); len(redirectTo) > 0 {
-		middleware.DeleteRedirectToCookie(ctx.Resp)
+		middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 		ctx.RedirectToFirst(redirectTo)
 		return
 	}

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -855,7 +855,7 @@ func SignInOAuth(ctx *context.Context) {
 
 	redirectTo := ctx.FormString("redirect_to")
 	if len(redirectTo) > 0 {
-		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
+		middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, redirectTo)
 	}
 
 	// try to do a direct callback flow, so we don't authenticate the user again but use the valid accesstoken to get the user
@@ -1163,7 +1163,7 @@ func handleOAuth2SignIn(ctx *context.Context, source *auth.Source, u *user_model
 		}
 
 		if redirectTo := ctx.GetSiteCookie("redirect_to"); len(redirectTo) > 0 {
-			middleware.DeleteRedirectToCookie(ctx.Resp)
+			middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 			ctx.RedirectToFirst(redirectTo)
 			return
 		}

--- a/routers/web/auth/openid.go
+++ b/routers/web/auth/openid.go
@@ -45,13 +45,13 @@ func SignInOpenID(ctx *context.Context) {
 
 	redirectTo := ctx.FormString("redirect_to")
 	if len(redirectTo) > 0 {
-		middleware.SetRedirectToCookie(ctx.Resp, redirectTo)
+		middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, redirectTo)
 	} else {
 		redirectTo = ctx.GetSiteCookie("redirect_to")
 	}
 
 	if isSucceed {
-		middleware.DeleteRedirectToCookie(ctx.Resp)
+		middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 		ctx.RedirectToFirst(redirectTo)
 		return
 	}

--- a/routers/web/auth/password.go
+++ b/routers/web/auth/password.go
@@ -338,7 +338,7 @@ func MustChangePasswordPost(ctx *context.Context) {
 	log.Trace("User updated password: %s", u.Name)
 
 	if redirectTo := ctx.GetSiteCookie("redirect_to"); len(redirectTo) > 0 && !utils.IsExternalURL(redirectTo) {
-		middleware.DeleteRedirectToCookie(ctx.Resp)
+		middleware.DeleteRedirectToCookie(ctx.Resp, ctx.Req)
 		ctx.RedirectToFirst(redirectTo)
 		return
 	}

--- a/routers/web/home.go
+++ b/routers/web/home.go
@@ -41,7 +41,7 @@ func Home(ctx *context.Context) {
 		} else if ctx.Doer.MustChangePassword {
 			ctx.Data["Title"] = ctx.Tr("auth.must_change_password")
 			ctx.Data["ChangePasscodeLink"] = setting.AppSubURL + "/user/change_password"
-			middleware.SetRedirectToCookie(ctx.Resp, setting.AppSubURL+ctx.Req.URL.RequestURI())
+			middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, setting.AppSubURL+ctx.Req.URL.RequestURI())
 			ctx.Redirect(setting.AppSubURL + "/user/settings/change_password")
 		} else {
 			user.Dashboard(ctx)

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -407,7 +407,7 @@ func UpdateUserLang(ctx *context.Context) {
 	}
 
 	// Update the language to the one we just set
-	middleware.SetLocaleCookie(ctx.Resp, ctx.Doer.Language, 0)
+	middleware.SetLocaleCookie(ctx.Resp, ctx.Req, ctx.Doer.Language, 0)
 
 	log.Trace("User settings updated: %s", ctx.Doer.Name)
 	ctx.Flash.Success(translation.NewLocale(ctx.Doer.Language).Tr("settings.update_language_success"))

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -89,7 +89,7 @@ func handleSignIn(resp http.ResponseWriter, req *http.Request, sess SessionStore
 		}
 	}
 
-	middleware.SetLocaleCookie(resp, user.Language, 0)
+	middleware.SetLocaleCookie(resp, req, user.Language, 0)
 
 	// Clear whatever CSRF has right now, force to generate a new one
 	if ctx := gitea_context.GetWebContext(req); ctx != nil {

--- a/services/auth/middleware.go
+++ b/services/auth/middleware.go
@@ -108,7 +108,7 @@ func VerifyAuthWithOptions(options *VerifyOptions) func(ctx *context.Context) {
 					ctx.Data["Title"] = ctx.Tr("auth.must_change_password")
 					ctx.Data["ChangePasscodeLink"] = setting.AppSubURL + "/user/change_password"
 					if ctx.Req.URL.Path != "/user/events" {
-						middleware.SetRedirectToCookie(ctx.Resp, setting.AppSubURL+ctx.Req.URL.RequestURI())
+						middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, setting.AppSubURL+ctx.Req.URL.RequestURI())
 					}
 					ctx.Redirect(setting.AppSubURL + "/user/settings/change_password")
 					return
@@ -136,7 +136,7 @@ func VerifyAuthWithOptions(options *VerifyOptions) func(ctx *context.Context) {
 		if options.SignInRequired {
 			if !ctx.IsSigned {
 				if ctx.Req.URL.Path != "/user/events" {
-					middleware.SetRedirectToCookie(ctx.Resp, setting.AppSubURL+ctx.Req.URL.RequestURI())
+					middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, setting.AppSubURL+ctx.Req.URL.RequestURI())
 				}
 				ctx.Redirect(setting.AppSubURL + "/user/login")
 				return
@@ -151,7 +151,7 @@ func VerifyAuthWithOptions(options *VerifyOptions) func(ctx *context.Context) {
 		if !options.SignOutRequired && !ctx.IsSigned &&
 			len(ctx.GetSiteCookie(setting.CookieUserName)) > 0 {
 			if ctx.Req.URL.Path != "/user/events" {
-				middleware.SetRedirectToCookie(ctx.Resp, setting.AppSubURL+ctx.Req.URL.RequestURI())
+				middleware.SetRedirectToCookie(ctx.Resp, ctx.Req, setting.AppSubURL+ctx.Req.URL.RequestURI())
 			}
 			ctx.Redirect(setting.AppSubURL + "/user/login")
 			return

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -280,8 +280,6 @@
 				<dd>{{.SessionConfig.Gclifetime}} {{.locale.Tr "tool.raw_seconds"}}</dd>
 				<dt>{{.locale.Tr "admin.config.session_life_time"}}</dt>
 				<dd>{{.SessionConfig.Maxlifetime}} {{.locale.Tr "tool.raw_seconds"}}</dd>
-				<dt>{{.locale.Tr "admin.config.https_only"}}</dt>
-				<dd>{{if .SessionConfig.Secure}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 			</dl>
 		</div>
 


### PR DESCRIPTION
The idea is to automatically set cookie `Secure` flag based on proxy headers or the connection, making it unnecessary to configure it by hand via previous `COOKIE_SECURE` option.

## :warning: BREAKING :warning:

Gitea now requires a properly configured `X-Forwarded-Proto` header from reverse proxies, which should be set at the first user-facing reverse proxy and not be changed by any additional proxies in the chain.