### PR TITLE
Add Fuzz Driver for getPostgreSQLConnectionString API (Issue #20316)

### DIFF
--- a/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
+++ b/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
@@ -1,16 +1,11 @@
-package setting
+package fuzz
 
 import (
-	 "secsys/gout-transformation/pkg/transstruct"
-)
-import (
-	 "os"
-)
-import (
-	 "github.com/stretchr/testify/assert"
-)
-import (
-	 "testing"
+	"os"
+	"testing"
+
+	"secsys/gout-transformation/pkg/transstruct"
+	"github.com/stretchr/testify/assert"
 )
 
 func FuzzTest_getPostgreSQLConnectionString(XVl []byte) int {

--- a/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
+++ b/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
@@ -1,0 +1,67 @@
+package setting
+
+import (
+	 "secsys/gout-transformation/pkg/transstruct"
+)
+import (
+	 "os"
+)
+import (
+	 "github.com/stretchr/testify/assert"
+)
+import (
+	 "testing"
+)
+
+func FuzzTest_getPostgreSQLConnectionString(XVl []byte) int {
+	t := &testing.T{}
+	_ = t
+	var skippingTableDriven bool
+	_, skippingTableDriven = os.LookupEnv("SKIPPING_TABLE_DRIVEN")
+	_ = skippingTableDriven
+	transstruct.SetFuzzData(XVl)
+	FDG_FuzzGlobal()
+
+	tests := []struct {
+		Host	string
+		Port	string
+		User	string
+		Passwd	string
+		Name	string
+		Param	string
+		SSLMode	string
+		Output	string
+	}{
+		{
+			Host:		transstruct.GetString("/tmp/pg.sock"),
+			Port:		"4321",
+			User:		transstruct.GetString("testuser"),
+			Passwd:		transstruct.GetString("space space !#$%^^%^```-=?="),
+			Name:		transstruct.GetString("gitea"),
+			Param:		transstruct.GetString(""),
+			SSLMode:	transstruct.GetString("false"),
+			Output:		"postgres://testuser:space%20space%20%21%23$%25%5E%5E%25%5E%60%60%60-=%3F=@:5432/giteasslmode=false&host=/tmp/pg.sock",
+		},
+		{
+			Host:		transstruct.GetString("localhost"),
+			Port:		"1234",
+			User:		transstruct.GetString("pgsqlusername"),
+			Passwd:		transstruct.GetString("I love Gitea!"),
+			Name:		transstruct.GetString("gitea"),
+			Param:		transstruct.GetString(""),
+			SSLMode:	transstruct.GetString("true"),
+			Output:		"postgres://pgsqlusername:I%20love%20Gitea%21@localhost:5432/giteasslmode=true",
+		},
+	}
+
+	for _, test := range tests {
+		connStr := getPostgreSQLConnectionString(test.Host, test.User, test.Passwd, test.Name, test.Param, test.SSLMode)
+		assert.Equal(t, test.Output, connStr)
+	}
+
+	return 1
+}
+
+func FDG_FuzzGlobal() {
+
+}

--- a/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
+++ b/tests/fuzz/database_test.go_Test_getPostgreSQLConnectionString.go
@@ -1,3 +1,6 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
 package fuzz
 
 import (


### PR DESCRIPTION
## Overview

This pull request introduces a fuzz driver that addresses issue #20316. The purpose of this fuzz driver is to rigorously test the getPostgreSQLConnectionString API by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

## Details

The fuzz driver has been designed to thoroughly exercise the getPostgreSQLConnectionString API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we can identify potential vulnerabilities and edge cases that might otherwise go unnoticed.
## Additional Information

We want to highlight that we have already developed numerous fuzz drivers, each serving as a valuable addition to our testing suite. If this PR is well-received, we are eager to contribute more fuzz drivers to further bolster our testing capabilities.

Thus, we are eager for your feedback and guidance on the process of adding fuzz drivers. Specifically, we would appreciate insights on the following:

- Deployment: How should we handle the deployment of these fuzz drivers within the project's testing infrastructure?
- Testing Metrics: Are there specific testing metrics or criteria that you consider essential for evaluating the effectiveness of these fuzz drivers?
- Any Other Concerns: Please let us know if you have any other concerns or preferences related to the inclusion of fuzz drivers in the project.

Thank you for considering this contribution, and we look forward to your feedback.