### PR TITLE
Add `actions/labeler`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@ kind/build:
   - Makefile
   - Dockerfile
   - Dockerfile.rootless
+  - docker/**
   - webpack.config.js
 
 kind/lint:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+kind/docs:
+  - docs/**/*
+
+kind/ui:
+  - web_src/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@ kind/build:
   - Dockerfile.*
   - webpack.config.js
 
-kind/dependencies:
+dependencies:
   - go.mod
   - go.sum
   - package.json

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ kind/api:
 kind/build:
   - Makefile
   - Dockerfile
-  - Dockerfile.*
+  - Dockerfile.rootless
   - webpack.config.js
 
 dependencies:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,14 +14,6 @@ kind/build:
   - Dockerfile.rootless
   - webpack.config.js
 
-dependencies:
-  - go.mod
-  - go.sum
-  - package.json
-  - package-lock.json
-  - pyproject.toml
-  - poetry.lock
-
 kind/lint:
   - .eslintrc.yaml
   - .golangci.yml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,9 @@
-kind/ui:
-  - web_src/**/*
-
 kind/docs:
   - docs/**/*
+
+kind/ui:
+  - web_src/**/*
+  - all: ["templates/**/*", "!templates/swagger/v1_json.tmpl"]
+
+kind/api:
+  - templates/swagger/v1_json.tmpl

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,24 @@ kind/ui:
 
 kind/api:
   - templates/swagger/v1_json.tmpl
+
+kind/build:
+  - Makefile
+  - Dockerfile
+  - Dockerfile.*
+  - webpack.config.js
+
+kind/dependencies:
+  - go.mod
+  - go.sum
+  - package.json
+  - package-lock.json
+  - pyproject.toml
+  - poetry.lock
+
+kind/lint:
+  - .eslintrc.yaml
+  - .golangci.yml
+  - .markdownlint.yaml
+  - .spectral.yaml
+  - .stylelintrc.yaml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 kind/docs:
+  - **/*.md
   - docs/**/*
 
 kind/ui:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-kind/docs:
-  - docs/**/*
-
 kind/ui:
   - web_src/**/*
+
+kind/docs:
+  - docs/**/*

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -2,6 +2,7 @@ name: labeler
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -1,7 +1,7 @@
-name: pull-labeler
+name: labeler
 
 on:
-  - pull_request_target
+  pull_request_target:
 
 jobs:
   label:

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -1,0 +1,16 @@
+name: pull-labeler
+
+on:
+  - pull_request_target
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          dot: true
+          sync-labels: true

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -1,7 +1,7 @@
 name: labeler
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   label:

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -1,7 +1,7 @@
 name: labeler
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   label:

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -3,6 +3,10 @@ name: labeler
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Gitea: Docs
 
+edit!
+
 [![Join the chat at https://img.shields.io/discord/322538954119184384.svg](https://img.shields.io/discord/322538954119184384.svg)](https://discord.gg/Gitea)
 [![](https://images.microbadger.com/badges/image/gitea/docs.svg)](http://microbadger.com/images/gitea/docs "Get your own image badge on microbadger.com")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # Gitea: Docs
 
-edit!
-
 [![Join the chat at https://img.shields.io/discord/322538954119184384.svg](https://img.shields.io/discord/322538954119184384.svg)](https://discord.gg/Gitea)
 [![](https://images.microbadger.com/badges/image/gitea/docs.svg)](http://microbadger.com/images/gitea/docs "Get your own image badge on microbadger.com")
 


### PR DESCRIPTION
Implements https://github.com/GiteaBot/gitea-backporter/issues/93 using [`actions/labeler`](https://github.com/actions/labeler). Very basic configuration, can be extended later.