### PR TITLE
Chroma color tweaks

### DIFF
--- a/web_src/css/chroma/dark.css
+++ b/web_src/css/chroma/dark.css
@@ -1,3 +1,4 @@
+/* https://github.com/alecthomas/chroma/blob/6428fb4e65f3c1493491571c8a6a8f1add1da822/types.go#L208 */
 .chroma .bp { color: #fabd2f; } /* NameBuiltinPseudo */
 .chroma .c { color: #777e94; } /* Comment */
 .chroma .c1 { color: #777e94; } /* CommentSingle */
@@ -37,7 +38,7 @@
 .chroma .mi { color: #649bc4; } /* LiteralNumberInteger */
 .chroma .mo { color: #649bc4; } /* LiteralNumberOct */
 .chroma .n { color: #c9d1d9; } /* Name */
-.chroma .na { color: #b8bb26; } /* NameAttribute */
+.chroma .na { color: #fabd2f; } /* NameAttribute */
 .chroma .nb { color: #fabd2f; } /* NameBuiltin */
 .chroma .nc { color: #ffaa10; } /* NameClass */
 .chroma .nd { color: #8ec07c; } /* NameDecorator */
@@ -57,18 +58,19 @@
 .chroma .s { color: #b8bb26; } /* LiteralString */
 .chroma .s1 { color: #b8bb26; } /* LiteralStringSingle */
 .chroma .s2 { color: #b8bb26; } /* LiteralStringDouble */
-.chroma .sa { color: #649bc4; } /* LiteralStringAffix */
+.chroma .sa { color: #ffaa10; } /* LiteralStringAffix */
 .chroma .sb { color: #b8bb26; } /* LiteralStringBacktick */
-.chroma .sc { color: #649bc4; } /* LiteralStringChar */
-.chroma .sd { color: #777e94; } /* LiteralStringDoc */
-.chroma .se { color: #ff7540; } /* LiteralStringEscape */
-.chroma .sh { color: #649bc4; } /* LiteralStringHeredoc */
+.chroma .sc { color: #ffaa10; } /* LiteralStringChar */
+.chroma .sd { color: #b8bb26; } /* LiteralStringDoc */
+.chroma .se { color: #ff8540; } /* LiteralStringEscape */
+.chroma .sh { color: #b8bb26; } /* LiteralStringHeredoc */
 .chroma .si { color: #ffaa10; } /* LiteralStringInterpol */
 .chroma .sr { color: #9075cd; } /* LiteralStringRegex */
-.chroma .ss { color: #ff7540; } /* LiteralStringSymbol */
+.chroma .ss { color: #ff8540; } /* LiteralStringSymbol */
 .chroma .sx { color: #ffaa10; } /* LiteralStringOther */
-.chroma .vc { color: #ff7540; } /* NameVariableClass */
-.chroma .vg { color: #ffaa10; } /* NameVariableGlobal */
-.chroma .vi { color: #ffaa10; } /* NameVariableInstance */
+.chroma .vc { color: #649bee; } /* NameVariableClass */
+.chroma .vg { color: #649bee; } /* NameVariableGlobal */
+.chroma .vi { color: #649bee; } /* NameVariableInstance */
 .chroma .vm {} /* NameVariableMagic */
 .chroma .w { color: #7f8699; } /* TextWhitespace */
+.chroma .err {/* not styled because Chroma uses it on too many things like JSX */} /* Error */

--- a/web_src/css/chroma/light.css
+++ b/web_src/css/chroma/light.css
@@ -1,3 +1,4 @@
+/* https://github.com/alecthomas/chroma/blob/6428fb4e65f3c1493491571c8a6a8f1add1da822/types.go#L208 */
 .chroma .bp { color: #999999; } /* NameBuiltinPseudo */
 .chroma .c { color: #6a737d; } /* Comment */
 .chroma .c1 { color: #6a737d; } /* CommentSingle */
@@ -55,20 +56,21 @@
 .chroma .p {} /* Punctuation */
 .chroma .py {} /* NameProperty */
 .chroma .s { color: #106303; } /* LiteralString */
-.chroma .s1 { color: #cc7a00; } /* LiteralStringSingle */
+.chroma .s1 { color: #106303; } /* LiteralStringSingle */
 .chroma .s2 { color: #106303; } /* LiteralStringDouble */
-.chroma .sa { color: #106303; } /* LiteralStringAffix */
+.chroma .sa { color: #cc7a00; } /* LiteralStringAffix */
 .chroma .sb { color: #106303; } /* LiteralStringBacktick */
-.chroma .sc { color: #106303; } /* LiteralStringChar */
+.chroma .sc { color: #cc7a00; } /* LiteralStringChar */
 .chroma .sd { color: #106303; } /* LiteralStringDoc */
-.chroma .se { color: #106303; } /* LiteralStringEscape */
+.chroma .se { color: #994400; } /* LiteralStringEscape */
 .chroma .sh { color: #106303; } /* LiteralStringHeredoc */
-.chroma .si { color: #106303; } /* LiteralStringInterpol */
-.chroma .sr { color: #22863a; } /* LiteralStringRegex */
-.chroma .ss { color: #106303; } /* LiteralStringSymbol */
+.chroma .si { color: #cc7a00; } /* LiteralStringInterpol */
+.chroma .sr { color: #4c4dbc; } /* LiteralStringRegex */
+.chroma .ss { color: #994400; } /* LiteralStringSymbol */
 .chroma .sx { color: #106303; } /* LiteralStringOther */
 .chroma .vc { color: #008080; } /* NameVariableClass */
 .chroma .vg { color: #008080; } /* NameVariableGlobal */
 .chroma .vi { color: #008080; } /* NameVariableInstance */
 .chroma .vm {} /* NameVariableMagic */
 .chroma .w { color: #bbbbbb; } /* TextWhitespace */
+.chroma .err {/* not styled because Chroma uses it on too many things like JSX */} /* Error */


### PR DESCRIPTION
Before and after each:

1. don't highlight yaml multiline string like comments in dark theme:

<img width="551" alt="Screenshot 2023-09-08 at 17 12 53" src="https://github.com/go-gitea/gitea/assets/115237/0c358c27-c47e-4b65-861a-f3ba887ea2b1">
<img width="568" alt="Screenshot 2023-09-08 at 17 13 32" src="https://github.com/go-gitea/gitea/assets/115237/987e5fa9-27fa-420a-bf32-0f595074d608">

2. highlight `LiteralStringInterpol` in light theme

<img width="411" alt="Screenshot 2023-09-08 at 17 19 08" src="https://github.com/go-gitea/gitea/assets/115237/126c0571-aa03-4f81-868d-20533f8e9fcd">
<img width="412" alt="Screenshot 2023-09-08 at 17 19 23" src="https://github.com/go-gitea/gitea/assets/115237/e49c9bd5-3480-4f8b-ac95-bc204ce68b13">

3. Use non-string color in `NameAttribute` in dark theme:

<img width="189" alt="Screenshot 2023-09-08 at 17 24 41" src="https://github.com/go-gitea/gitea/assets/115237/22f3f712-5ad2-4c0c-83ad-83037c59bca6">
<img width="180" alt="Screenshot 2023-09-08 at 17 24 26" src="https://github.com/go-gitea/gitea/assets/115237/05d2ba45-3c9a-4c1e-b1d4-990add87d2b1">

4. Bring various colors in `LiteralString` and `NameVariable` into sync between the themes. I was not able to reproduce all tokens, but I guess it should not look too bad.