### PR TITLE
Fix INI parsing for value with trailing slash

### DIFF
--- a/modules/setting/config_provider.go
+++ b/modules/setting/config_provider.go
@@ -174,9 +174,16 @@ func (s *iniConfigSection) ChildSections() (sections []ConfigSection) {
 	return sections
 }
 
+func configProviderLoadOptions() ini.LoadOptions {
+	return ini.LoadOptions{
+		KeyValueDelimiterOnWrite: " = ",
+		IgnoreContinuation:       true,
+	}
+}
+
 // NewConfigProviderFromData this function is mainly for testing purpose
 func NewConfigProviderFromData(configContent string) (ConfigProvider, error) {
-	cfg, err := ini.Load(strings.NewReader(configContent))
+	cfg, err := ini.LoadSources(configProviderLoadOptions(), strings.NewReader(configContent))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,7 @@ func NewConfigProviderFromData(configContent string) (ConfigProvider, error) {
 // NewConfigProviderFromFile load configuration from file.
 // NOTE: do not print any log except error.
 func NewConfigProviderFromFile(file string, extraConfigs ...string) (ConfigProvider, error) {
-	cfg := ini.Empty(ini.LoadOptions{KeyValueDelimiterOnWrite: " = "})
+	cfg := ini.Empty(configProviderLoadOptions())
 	loadedFromEmpty := true
 
 	if file != "" {
@@ -339,6 +346,7 @@ func NewConfigProviderForLocale(source any, others ...any) (ConfigProvider, erro
 	iniFile, err := ini.LoadSources(ini.LoadOptions{
 		IgnoreInlineComment:         true,
 		UnescapeValueCommentSymbols: true,
+		IgnoreContinuation:          true,
 	}, source, others...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load locale ini: %w", err)

--- a/modules/setting/config_provider_test.go
+++ b/modules/setting/config_provider_test.go
@@ -30,6 +30,16 @@ key = 123
 		secSub := cfg.Section("foo.bar.xxx")
 		assert.Equal(t, "123", secSub.Key("key").String())
 	})
+	t.Run("TrailingSlash", func(t *testing.T) {
+		cfg, _ := NewConfigProviderFromData(`
+[foo]
+key = E:\
+xxx = yyy
+`)
+		sec := cfg.Section("foo")
+		assert.Equal(t, "E:\\", sec.Key("key").String())
+		assert.Equal(t, "yyy", sec.Key("xxx").String())
+	})
 }
 
 func TestConfigProviderHelper(t *testing.T) {


### PR DESCRIPTION
Fix #26977 (a temp fix)