### PR TITLE
Use secure cookie for HTTPS sites (#26999)

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1724,8 +1724,8 @@ LEVEL = Info
 ;; Session cookie name
 ;COOKIE_NAME = i_like_gitea
 ;;
-;; If you use session in https only, default is false
-;COOKIE_SECURE = false
+;; If you use session in https only: true or false. If not set, it defaults to `true` if the ROOT_URL is an HTTPS URL.
+;COOKIE_SECURE =
 ;;
 ;; Session GC time interval in seconds, default is 86400 (1 day)
 ;GC_INTERVAL_TIME = 86400

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -772,7 +772,7 @@ and
 
 - `PROVIDER`: **memory**: Session engine provider \[memory, file, redis, redis-cluster, db, mysql, couchbase, memcache, postgres\]. Setting `db` will reuse the configuration in `[database]`
 - `PROVIDER_CONFIG`: **data/sessions**: For file, the root path; for db, empty (database config will be used); for others, the connection string. Relative paths will be made absolute against _`AppWorkPath`_.
-- `COOKIE_SECURE`: **false**: Enable this to force using HTTPS for all session access.
+- `COOKIE_SECURE`:**_empty_**: `true` or `false`. Enable this to force using HTTPS for all session access. If not set, it defaults to `true` if the ROOT_URL is an HTTPS URL.
 - `COOKIE_NAME`: **i\_like\_gitea**: The name of the cookie used for the session ID.
 - `GC_INTERVAL_TIME`: **86400**: GC interval in seconds.
 - `SESSION_LIFE_TIME`: **86400**: Session life time in seconds, default is 86400 (1 day)

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -200,7 +200,7 @@ menu:
 
 - `PROVIDER`: Session 内容存储方式，可选 `memory`, `file`, `redis` 或 `mysql`。
 - `PROVIDER_CONFIG`: 如果是文件，那么这里填根目录；其他的要填主机地址和端口。
-- `COOKIE_SECURE`: 强制使用 HTTPS 作为session访问。
+- `COOKIE_SECURE`: **_empty_**：`true` 或 `false`。启用此选项以强制在所有会话访问中使用 HTTPS。如果没有设置，当 ROOT_URL 是 https 链接的时候默认设置为 true。
 - `GC_INTERVAL_TIME`: Session失效时间。
 
 ## Picture (`picture`)

--- a/modules/setting/session.go
+++ b/modules/setting/session.go
@@ -50,7 +50,7 @@ func loadSessionFrom(rootCfg ConfigProvider) {
 	}
 	SessionConfig.CookieName = sec.Key("COOKIE_NAME").MustString("i_like_gitea")
 	SessionConfig.CookiePath = AppSubURL + "/" // there was a bug, old code only set CookePath=AppSubURL, no trailing slash
-	SessionConfig.Secure = sec.Key("COOKIE_SECURE").MustBool(false)
+	SessionConfig.Secure = sec.Key("COOKIE_SECURE").MustBool(strings.HasPrefix(strings.ToLower(AppURL), "https://"))
 	SessionConfig.Gclifetime = sec.Key("GC_INTERVAL_TIME").MustInt64(86400)
 	SessionConfig.Maxlifetime = sec.Key("SESSION_LIFE_TIME").MustInt64(86400)
 	SessionConfig.Domain = sec.Key("DOMAIN").String()


### PR DESCRIPTION
Backport #26999

If the AppURL(ROOT_URL) is an HTTPS URL, then the COOKIE_SECURE's default value should be true.

And, if a user visits an "http" site with "https" AppURL, they won't be able to login, and they should have been warned. The only problem is that the "language" can't be set either in such case, while I think it is not a serious problem, and it could be fixed easily if needed.