### PR TITLE
Remove `modules/context` from SSPI

### DIFF
--- a/modules/web/middleware/request.go
+++ b/modules/web/middleware/request.go
@@ -12,3 +12,7 @@ import (
 func IsAPIPath(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, "/api/")
 }
+
+func IsLoginPath(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, "/user/login")
+}

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -418,7 +418,7 @@ authorize_application_description = If you grant the access, it will be able to 
 authorize_title = Authorize "%s" to access your account?
 authorization_failed = Authorization failed
 authorization_failed_desc = The authorization failed because we detected an invalid request. Please contact the maintainer of the app you have tried to authorize.
-sspi_auth_failed = SSPI authentication failed
+authorization.error = Authorization failed. If this error persists, please contact the site administrator.
 password_pwned = The password you chose is on a <a target="_blank" rel="noopener noreferrer" href="https://haveibeenpwned.com/Passwords">list of stolen passwords</a> previously exposed in public data breaches. Please try again with a different password and consider changing this password elsewhere too.
 password_pwned_err = Could not complete request to HaveIBeenPwned
 

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -163,7 +163,7 @@ func SignIn(ctx *context.Context) {
 		context.SetCaptchaData(ctx)
 	}
 
-	ctx.HTML(http.StatusOK, tplSignIn)
+	ctx.HTML(http.StatusUnauthorized, tplSignIn)
 }
 
 // SignInPost response for sign in request
@@ -184,7 +184,7 @@ func SignInPost(ctx *context.Context) {
 	ctx.Data["EnableSSPI"] = auth.IsSSPIEnabled()
 
 	if ctx.HasError() {
-		ctx.HTML(http.StatusOK, tplSignIn)
+		ctx.HTML(http.StatusUnauthorized, tplSignIn)
 		return
 	}
 

--- a/services/auth/middleware.go
+++ b/services/auth/middleware.go
@@ -21,7 +21,13 @@ func Auth(authMethod Method) func(*context.Context) {
 		ar, err := authShared(ctx.Base, ctx.Session, authMethod)
 		if err != nil {
 			log.Error("Failed to verify user: %v", err)
-			ctx.Error(http.StatusUnauthorized, "Verify")
+
+			// If the error occurs on the login page, fallthrough and render the login form again with a generic error message.
+			if middleware.IsLoginPath(ctx.Req) {
+				ctx.Flash.Error(ctx.Locale.Tr("auth.authorization.error"), true)
+			} else {
+				ctx.Error(http.StatusUnauthorized, "Verify")
+			}
 			return
 		}
 		ctx.Doer = ar.Doer

--- a/services/auth/sspi_windows.go
+++ b/services/auth/sspi_windows.go
@@ -14,7 +14,6 @@ import (
 	"code.gitea.io/gitea/models/avatars"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/log"
-	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/services/auth/source/sspi"
@@ -133,7 +132,8 @@ func (s *SSPI) shouldAuthenticate(req *http.Request) (shouldAuth bool) {
 		if req.FormValue("user_name") != "" && req.FormValue("password") != "" {
 			return false
 		}
-		return strconv.ParseBool(req.FormValue("auth_with_sspi"))
+		b, _ := strconv.ParseBool(req.FormValue("auth_with_sspi"))
+		return b
 	}
 	return middleware.IsAPIPath(req) || isAttachmentDownload(req)
 }


### PR DESCRIPTION
Related #27028

Extracted from another PR I'm working on.

This PR removes the dependency of `modules/context` from SSPI.
SSPI does not work nicely with our current auth design because it needs a specific workflow (request-response challenge). The old code renders a (bugged version) of the login page and needs `modules/context` to do that.

The new code renders the login page now for every failed auth method and shows a generic error to hide possible secrets in the message. This happens only if the error occured on the login page. For all other routes the old behaviour is active. SSPI needs a 401 Unauthorized response code. This can't be set in the auth handler because `ctx.Written` blocks the processing of other handlers. Therefore the login page now renders with the 401 status code. For a normal web browser user this is not noticeable.