### PR TITLE
Add more package registry paths to the labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,9 @@ kind/build:
 
 theme/package-registry:
   - "modules/packages/**"
+  - "services/packages/**"
+  - "routers/api/packages/**"
+  - "routers/web/shared/packages/**"
 
 kind/cli:
   - "cmd/**"


### PR DESCRIPTION
Found this while working on #26960 