### PR TITLE
Speed up nightly builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - actuated-4cpu-8gb
+    - actuated-4cpu-16gb

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main, release/v* ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   nightly-binary:
     runs-on: actuated-4cpu-8gb

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -51,7 +51,7 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: dist/release
           DEST_DIR: gitea/${{ steps.clean_name.outputs.branch }}
-  nightly-docker:
+  nightly-docker-rootful:
     runs-on: actuated-4cpu-8gb
     steps:
       - uses: actions/checkout@v3
@@ -75,6 +75,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: fetch go modules
+        run: make vendor
       - name: build rootful docker image
         uses: docker/build-push-action@v4
         with:
@@ -82,6 +84,32 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: gitea/gitea:${{ steps.clean_name.outputs.branch }}
+  nightly-docker-rootless:
+    runs-on: actuated-4cpu-8gb
+    steps:
+      - uses: actions/checkout@v3
+      # fetch all commits instead of only the last as some branches are long lived and could have many between versions
+      # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
+      - run: git fetch --unshallow --quiet --tags --force
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          # if main then say nightly otherwise cleanup name
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "branch=nightly" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          echo "branch=${REF_NAME}-nightly" >> "$GITHUB_OUTPUT"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: fetch go modules
+          run: make vendor
       - name: build rootless docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -113,7 +113,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: fetch go modules
-          run: make vendor
+        run: make vendor
       - name: build rootless docker image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
* Rootless/ful docker images build separately
* Vendor go modules outside docker to speed up the build

Thanks to Alex Ellis for these suggestions (and actuated runner build time)