### PR TITLE
Show Release Notification in the UI

### DIFF
--- a/models/activities/notification.go
+++ b/models/activities/notification.go
@@ -347,6 +347,7 @@ func GetIssueNotification(ctx context.Context, userID, issueID int64) (*Notifica
 
 // CreateOrUpdateIssueNotifications creates an release notification
 // for each watcher, or updates it if already exists
+// this function called from a queue, so we can't pass a context
 func CreateOrUpdateReleaseNotifications(releaseID, receiverID int64) error {
 	ctx, committer, err := db.TxContext(db.DefaultContext)
 	if err != nil {

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -532,6 +532,8 @@ var migrations = []Migration{
 	NewMigration("Add Actions artifacts expiration date", v1_21.AddExpiredUnixColumnInActionArtifactTable),
 	// v275 -> v276
 	NewMigration("Add ScheduleID for ActionRun", v1_21.AddScheduleIDForActionRun),
+	// v276 -> v277
+	NewMigration("Add ReleaseID to Notification", v1_21.AddReleaseIDToNotification),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -1,0 +1,15 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_21 //nolint
+
+import (
+	"xorm.io/xorm"
+)
+
+func AddReleaseIDToNotification(x *xorm.Engine) error {
+	type Notification struct {
+		ReleaseID int64 `xorm:"INDEX"`
+	}
+	return x.Sync(new(Notification))
+}

--- a/modules/structs/notifications.go
+++ b/modules/structs/notifications.go
@@ -46,4 +46,6 @@ const (
 	NotifySubjectCommit NotifySubjectType = "Commit"
 	// NotifySubjectRepository an repository is subject of an notification
 	NotifySubjectRepository NotifySubjectType = "Repository"
+	// NotifySubjectRelease an release is subject of an notification
+	NotifySubjectRelease NotifySubjectType = "Release"
 )

--- a/routers/api/v1/notify/notifications.go
+++ b/routers/api/v1/notify/notifications.go
@@ -60,6 +60,8 @@ func subjectToSource(value []string) (result []activities_model.NotificationSour
 			result = append(result, activities_model.NotificationSourceCommit)
 		case "repository":
 			result = append(result, activities_model.NotificationSourceRepository)
+		case "release":
+			result = append(result, activities_model.NotificationSourceRelease)
 		}
 	}
 	return result

--- a/routers/api/v1/notify/repo.go
+++ b/routers/api/v1/notify/repo.go
@@ -80,7 +80,7 @@ func ListRepoNotifications(ctx *context.APIContext) {
 	//   collectionFormat: multi
 	//   items:
 	//     type: string
-	//     enum: [issue,pull,commit,repository]
+	//     enum: [issue,pull,commit,repository,release]
 	// - name: since
 	//   in: query
 	//   description: Only show notifications updated after the given time. This is a timestamp in RFC 3339 format

--- a/routers/api/v1/notify/user.go
+++ b/routers/api/v1/notify/user.go
@@ -41,7 +41,7 @@ func ListNotifications(ctx *context.APIContext) {
 	//   collectionFormat: multi
 	//   items:
 	//     type: string
-	//     enum: [issue,pull,commit,repository]
+	//     enum: [issue,pull,commit,repository,release]
 	// - name: since
 	//   in: query
 	//   description: Only show notifications updated after the given time. This is a timestamp in RFC 3339 format

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/models"
+	activities_model "code.gitea.io/gitea/models/activities"
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
@@ -289,6 +290,14 @@ func SingleRelease(ctx *context.Context) {
 	if err != nil {
 		ctx.ServerError("RenderString", err)
 		return
+	}
+
+	if ctx.IsSigned && !release.IsTag {
+		err = activities_model.SetReleaseReadBy(ctx, release.ID, ctx.Doer.ID)
+		if err != nil {
+			ctx.ServerError("SetReleaseReadBy", err)
+			return
+		}
 	}
 
 	ctx.Data["Releases"] = []*repo_model.Release{release}

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -139,6 +139,14 @@ func getNotifications(ctx *context.Context) {
 	notifications = notifications.Without(failures)
 	failCount += len(failures)
 
+	failures, err = notifications.LoadReleases(ctx)
+	if err != nil {
+		ctx.ServerError("LoadReleases", err)
+		return
+	}
+	notifications = notifications.Without(failures)
+	failCount += len(failures)
+
 	if failCount > 0 {
 		ctx.Flash.Error(fmt.Sprintf("ERROR: %d notifications were removed due to missing parts - check the logs", failCount))
 	}

--- a/services/convert/notification.go
+++ b/services/convert/notification.go
@@ -82,6 +82,13 @@ func ToNotificationThread(n *activities_model.Notification) *api.NotificationThr
 			URL:     n.Repository.Link(),
 			HTMLURL: n.Repository.HTMLURL(),
 		}
+	case activities_model.NotificationSourceRelease:
+		result.Subject = &api.NotificationSubject{Type: api.NotifySubjectRelease}
+		if n.Release != nil {
+			result.Subject.Title = n.Release.Title
+			result.Subject.URL = n.Release.APIURL()
+			result.Subject.HTMLURL = n.Release.HTMLURL()
+		}
 	}
 
 	return result

--- a/services/uinotification/notify.go
+++ b/services/uinotification/notify.go
@@ -309,7 +309,7 @@ func (ns *notificationService) NewRelease(ctx context.Context, rel *repo_model.R
 		if watcher != rel.PublisherID {
 			err = ns.notificationQueue.Push(notificationOpts{QueueType: NotificationQueueRelease, ReleaseID: rel.ID, ReceiverID: watcher})
 			if err != nil {
-				log.Error("NotificationQueuePushRelease %v", err)
+				log.Error("NotificationQueuePushRelease: %v", err)
 			}
 		}
 	}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -1176,7 +1176,8 @@
                 "issue",
                 "pull",
                 "commit",
-                "repository"
+                "repository",
+                "release"
               ],
               "type": "string"
             },
@@ -9962,7 +9963,8 @@
                 "issue",
                 "pull",
                 "commit",
-                "repository"
+                "repository",
+                "release"
               ],
               "type": "string"
             },

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -40,6 +40,8 @@
 							<div class="notifications-icon gt-ml-3 gt-mr-2 gt-self-start gt-mt-2">
 								{{if .Issue}}
 									{{template "shared/issueicon" .Issue}}
+								{{else if .Release}}
+									{{svg "octicon-tag" 16 "text grey"}}
 								{{else}}
 									{{svg "octicon-repo" 16 "text grey"}}
 								{{end}}
@@ -55,6 +57,8 @@
 									<span class="issue-title">
 										{{if .Issue}}
 											{{.Issue.Title | RenderEmoji $.Context | RenderCodeBlock}}
+										{{else if .Release}}
+											{{.Release.Title}}
 										{{else}}
 											{{.Repository.FullName}}
 										{{end}}
@@ -64,6 +68,8 @@
 							<div class="notifications-updated gt-ac gt-mr-3">
 								{{if .Issue}}
 									{{TimeSinceUnix .Issue.UpdatedUnix $locale}}
+								{{else if .Release}}
+									{{TimeSinceUnix .Release.CreatedUnix $locale}}
 								{{else}}
 									{{TimeSinceUnix .UpdatedUnix $locale}}
 								{{end}}


### PR DESCRIPTION
If a repo that you are watching creates a new Release, you get a Mail but it is not shown in the UI. This PR changed this. Now the Release Notification is shown in the UI!

The Migration will be added after the Code is reviewed.

![grafik](https://github.com/go-gitea/gitea/assets/15185051/10d843b3-3e68-49ff-aef3-a0f04ed175a6)
