### PR TITLE
Try to fix labeler for UI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ kind/docs:
 
 kind/ui:
   - "web_src/**/*"
-  - all: ["templates/**", "!templates/swagger/v1_json.tmpl"]
+  - any: ["templates/**", "!templates/swagger/v1_json.tmpl"]
 
 kind/api:
   - "templates/swagger/v1_json.tmpl"


### PR DESCRIPTION
At the Moment PRs will not get the `kind/ui` label when they change something the `templates` directory and also change  `templates/swagger/v1_json.tmpl`. Wha we want is, that PRs get the `kind/ui` when they change any file in the tmeplates direcory, but ignore `templates/swagger/v1_json.tmpl`. According to the documentation we should use `any` instead of `all` to archive this, but I haven't tested it.