### PR TITLE
Load reviewer before sending notification (#27063)

### DIFF
--- a/modules/notification/mail/mail.go
+++ b/modules/notification/mail/mail.go
@@ -177,6 +177,9 @@ func (m *mailNotifier) NotifyPullRequestPushCommits(ctx context.Context, doer *u
 }
 
 func (m *mailNotifier) NotifyPullReviewDismiss(ctx context.Context, doer *user_model.User, review *issues_model.Review, comment *issues_model.Comment) {
+	if err := comment.Review.LoadReviewer(ctx); err != nil {
+		log.Error("Error in PullReviewDismiss while loading reviewer for issue[%d], review[%d] and reviewer[%d]: %v", review.Issue.ID, comment.Review.ID, comment.Review.ReviewerID, err)
+	}
 	if err := mailer.MailParticipantsComment(ctx, comment, activities_model.ActionPullReviewDismissed, review.Issue, nil); err != nil {
 		log.Error("MailParticipantsComment: %v", err)
 	}


### PR DESCRIPTION
Backport #27063

The
[template](https://github.com/go-gitea/gitea/blob/main/templates/mail/issue/default.tmpl#L51) uses the Reviewer.Name property - this was not loaded.

Fixes #27035
