### PR TITLE
Allow empty Conan files

### DIFF
--- a/routers/api/packages/conan/conan.go
+++ b/routers/api/packages/conan/conan.go
@@ -326,13 +326,8 @@ func uploadFile(ctx *context.Context, fileFilter container.Set[string], fileKey 
 	}
 	defer buf.Close()
 
-	if buf.Size() == 0 {
-		// ignore empty uploads, second request contains content
-		jsonResponse(ctx, http.StatusOK, nil)
-		return
-	}
-
 	isConanfileFile := filename == conanfileFile
+	isConaninfoFile := filename == conaninfoFile
 
 	pci := &packages_service.PackageCreationInfo{
 		PackageInfo: packages_service.PackageInfo{
@@ -364,7 +359,7 @@ func uploadFile(ctx *context.Context, fileFilter container.Set[string], fileKey 
 		pfci.Properties[conan_module.PropertyPackageRevision] = pref.RevisionOrDefault()
 	}
 
-	if isConanfileFile || filename == conaninfoFile {
+	if isConanfileFile || isConaninfoFile {
 		if isConanfileFile {
 			metadata, err := conan_module.ParseConanfile(buf)
 			if err != nil {


### PR DESCRIPTION
Fixes #27090

Looks like the Conan upload process has changed since last year. The empty uploads don't occur anymore.