### PR TITLE
Add missing deps to files-changed, downgrade `markdownlint-cli`

### DIFF
--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -64,6 +64,8 @@ jobs:
               - "**/*.md"
               - "docs/**"
               - ".markdownlint.yaml"
+              - "package.json"
+              - "package-lock.json"
 
             actions:
               - ".github/workflows/*"
@@ -90,3 +92,5 @@ jobs:
               - "**/*.yml"
               - "**/*.yaml"
               - ".yamllint.yaml"
+              - "pyproject.toml"
+              - "poetry.lock"

--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -69,6 +69,7 @@ jobs:
 
             actions:
               - ".github/workflows/*"
+              - "Makefile"
 
             templates:
               - "templates/**/*.tmpl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "eslint-plugin-vue-scoped-css": "2.5.0",
         "eslint-plugin-wc": "1.5.0",
         "jsdom": "22.1.0",
-        "markdownlint-cli": "0.36.0",
+        "markdownlint-cli": "0.35.0",
         "postcss-html": "1.5.0",
         "stylelint": "15.10.3",
         "stylelint-declaration-block-no-ignored-properties": "2.7.0",
@@ -6046,12 +6046,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==",
       "dev": true,
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/internal-slot": {
@@ -7188,33 +7188,33 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.30.0.tgz",
-      "integrity": "sha512-nInuFvI/rEzanAOArW5490Ez4EYpB5ODqVM0mcDYCPx9DKJWCQqCgejjiCvbSeE7sjbDscVtZmwr665qpF5xGA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
+      "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
       "dev": true,
       "dependencies": {
         "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.7"
+        "markdownlint-micromark": "0.1.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.36.0.tgz",
-      "integrity": "sha512-h4WdqOam3+QOVOcJSOQuG8KvvN8dlS0OiJhbPwYWBk7VMZR40UtSSMIOpSP5B4EHPHg3W3ILSQUvqg1HNpTCxA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.35.0.tgz",
+      "integrity": "sha512-lVIIIV1MrUtjoocgDqXLxUCxlRbn7Ve8rsWppfwciUNwLlNS28AhNiyQ3PU7jjj4Qvj+rWTTvwkqg7AcdG988g==",
       "dev": true,
       "dependencies": {
         "commander": "~11.0.0",
         "get-stdin": "~9.0.0",
-        "glob": "~10.3.4",
+        "glob": "~10.2.7",
         "ignore": "~5.2.4",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "~3.2.0",
-        "markdownlint": "~0.30.0",
-        "minimatch": "~9.0.3",
-        "run-con": "~1.3.2"
+        "markdownlint": "~0.29.0",
+        "minimatch": "~9.0.1",
+        "run-con": "~1.2.11"
       },
       "bin": {
         "markdownlint": "markdownlint.js"
@@ -7233,16 +7233,16 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/glob": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
-      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
+      "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -7261,9 +7261,9 @@
       "dev": true
     },
     "node_modules/markdownlint-micromark": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
-      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
+      "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -7994,9 +7994,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9349,13 +9349,13 @@
       "dev": true
     },
     "node_modules/run-con": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
-      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.12.tgz",
+      "integrity": "sha512-5257ILMYIF4RztL9uoZ7V9Q97zHtNHn5bN3NobeAnzB1P3ASLgg8qocM2u+R18ttp+VEM78N2LK8XcNVtnSRrg==",
       "dev": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
-        "ini": "~4.1.0",
+        "ini": "~3.0.0",
         "minimist": "^1.2.8",
         "strip-json-comments": "~3.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-vue-scoped-css": "2.5.0",
     "eslint-plugin-wc": "1.5.0",
     "jsdom": "22.1.0",
-    "markdownlint-cli": "0.36.0",
+    "markdownlint-cli": "0.35.0",
     "postcss-html": "1.5.0",
     "stylelint": "15.10.3",
     "stylelint-declaration-block-no-ignored-properties": "2.7.0",


### PR DESCRIPTION
The `docs` and `yaml` actions categories need to run when the dependencies `markdownlin-cli` or `yamllint` change, so add those to the list of dependencies for these actions.