### PR TITLE
Fix wrong xorm get usage on migration

### DIFF
--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -160,7 +160,7 @@ func migratePushMirrors(x *xorm.Engine) error {
 	return sess.Commit()
 }
 
-func getRemoteAddress(sess *xorm.Session, repoID int64, ownerName, repoName, remoteName string) (string, error) {
+func getRemoteAddress(ownerName, repoName, remoteName string) (string, error) {
 	repoPath := filepath.Join(setting.RepoRootPath, strings.ToLower(ownerName), strings.ToLower(repoName)+".git")
 
 	remoteURL, err := git.GetRemoteAddress(context.Background(), repoPath, remoteName)

--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -5,6 +5,7 @@ package v1_21 //nolint
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -165,7 +166,7 @@ func getRemoteAddress(ownerName, repoName, remoteName string) (string, error) {
 
 	remoteURL, err := git.GetRemoteAddress(context.Background(), repoPath, remoteName)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get remote %s's address of %s/%s failed: %v", remoteName, ownerName, repoName, err)
 	}
 
 	u, err := giturl.Parse(remoteURL)

--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -72,7 +72,7 @@ func migratePullMirrors(x *xorm.Engine) error {
 		start += len(mirrors)
 
 		for _, m := range mirrors {
-			remoteAddress, err := getRemoteAddress(sess, m.RepoID, m.RepoOwner, m.RepoName, "origin")
+			remoteAddress, err := getRemoteAddress(m.RepoOwner, m.RepoName, "origin")
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ func migratePushMirrors(x *xorm.Engine) error {
 		start += len(mirrors)
 
 		for _, m := range mirrors {
-			remoteAddress, err := getRemoteAddress(sess, m.RepoID, m.RepoOwner, m.RepoName, m.RemoteName)
+			remoteAddress, err := getRemoteAddress(m.RepoOwner, m.RepoName, m.RemoteName)
 			if err != nil {
 				return err
 			}

--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -5,7 +5,6 @@ package v1_21 //nolint
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -41,6 +40,8 @@ func migratePullMirrors(x *xorm.Engine) error {
 		ID            int64  `xorm:"pk autoincr"`
 		RepoID        int64  `xorm:"INDEX"`
 		RemoteAddress string `xorm:"VARCHAR(2048)"`
+		RepoOwner     string
+		RepoName      string
 	}
 
 	sess := x.NewSession()
@@ -59,7 +60,9 @@ func migratePullMirrors(x *xorm.Engine) error {
 
 	for {
 		var mirrors []Mirror
-		if err := sess.Limit(limit, start).Find(&mirrors); err != nil {
+		if err := sess.Select("mirror.id, mirror.repo_id, mirror.remote_address, repository.owner_name as repo_owner, repository.name as repo_name").
+			Join("INNER", "repository", "repository.id = mirror.repo_id").
+			Limit(limit, start).Find(&mirrors); err != nil {
 			return err
 		}
 
@@ -69,7 +72,7 @@ func migratePullMirrors(x *xorm.Engine) error {
 		start += len(mirrors)
 
 		for _, m := range mirrors {
-			remoteAddress, err := getRemoteAddress(sess, m.RepoID, "origin")
+			remoteAddress, err := getRemoteAddress(sess, m.RepoID, m.RepoOwner, m.RepoName, "origin")
 			if err != nil {
 				return err
 			}
@@ -100,6 +103,8 @@ func migratePushMirrors(x *xorm.Engine) error {
 		RepoID        int64 `xorm:"INDEX"`
 		RemoteName    string
 		RemoteAddress string `xorm:"VARCHAR(2048)"`
+		RepoOwner     string
+		RepoName      string
 	}
 
 	sess := x.NewSession()
@@ -118,7 +123,9 @@ func migratePushMirrors(x *xorm.Engine) error {
 
 	for {
 		var mirrors []PushMirror
-		if err := sess.Limit(limit, start).Find(&mirrors); err != nil {
+		if err := sess.Select("push_mirror.id, push_mirror.repo_id, push_mirror.remote_name, push_mirror.remote_address, repository.owner_name as repo_owner, repository.name as repo_name").
+			Join("INNER", "repository", "repository.id = push_mirror.repo_id").
+			Limit(limit, start).Find(&mirrors); err != nil {
 			return err
 		}
 
@@ -128,7 +135,7 @@ func migratePushMirrors(x *xorm.Engine) error {
 		start += len(mirrors)
 
 		for _, m := range mirrors {
-			remoteAddress, err := getRemoteAddress(sess, m.RepoID, m.RemoteName)
+			remoteAddress, err := getRemoteAddress(sess, m.RepoID, m.RepoOwner, m.RepoName, m.RemoteName)
 			if err != nil {
 				return err
 			}
@@ -153,20 +160,7 @@ func migratePushMirrors(x *xorm.Engine) error {
 	return sess.Commit()
 }
 
-func getRemoteAddress(sess *xorm.Session, repoID int64, remoteName string) (string, error) {
-	var ownerName string
-	var repoName string
-	has, err := sess.
-		Table("repository").
-		Cols("owner_name", "lower_name").
-		Where("id=?", repoID).
-		Get(&ownerName, &repoName)
-	if err != nil {
-		return "", err
-	} else if !has {
-		return "", fmt.Errorf("repository [%v] not found", repoID)
-	}
-
+func getRemoteAddress(sess *xorm.Session, repoID int64, ownerName, repoName, remoteName string) (string, error) {
 	repoPath := filepath.Join(setting.RepoRootPath, strings.ToLower(ownerName), strings.ToLower(repoName)+".git")
 
 	remoteURL, err := git.GetRemoteAddress(context.Background(), repoPath, remoteName)


### PR DESCRIPTION
Fix the bug on try.gitea.io

```log
2023/09/18 01:48:41 ...ations/migrations.go:635:Migrate() [I] Migration[276]: Add RemoteAddress to mirrors
2023/09/18 01:48:41 routers/common/db.go:34:InitDBEngine() [E] ORM engine initialization attempt #7/10 failed. Error: migrate: migration[276]: Add RemoteAddress to mirrors failed: exit status 128 - fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
 - fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

Caused by #26952 