### PR TITLE
Remove outdated paragraphs when comparing Gitea Actions to GitHub Actions

### DIFF
--- a/docs/content/usage/actions/comparison.en-us.md
+++ b/docs/content/usage/actions/comparison.en-us.md
@@ -114,15 +114,17 @@ Pre and Post steps don't have their own section in the job log user interface.
 
 ### Downloading actions
 
-When `[actions].DEFAULT_ACTIONS_URL` keep default value `github`, Gitea will download relative paths actions from https://github.com, that means
-if you use `uses: actions/checkout@v3`, it will download the checkout repository from https://github.com/actions/checkout.git .
-If you want to download an actions from another git service sites, you can just use an absolute URL `uses: https://gitea.com/actions/checkout@v3`.
+Previously (Pre 1.21.0), `[actions].DEFAULT_ACTIONS_URL` defaulted to `https://gitea.com`.
+We have since restricted this option to only allow two values (`github` and `self`).
+When set to `github`, the new default, Gitea will download non-fully-qualified actions from <https://github.com>.
+For example, if you use `uses: actions/checkout@v3`, it will download the checkout repository from <https://github.com/actions/checkout.git>.
 
-If your Gitea instance is in an intranet without internet connection or a restricted area. You can use absolute URL in workflows.
-You can also set `[actions].DEFAULT_ACTIONS_URL = self`, then all relative actions will not be downloaded from github like before,
-but will be download from your Gitea instance. That means if your workflow have the syntax `uses: actions/checkout@v3`, it will be downloaded from `[server].ROOT_URL`/actions/checkout.git .
+If you want to download an action from another git hoster, you can use an absolute URL, e.g. `uses: https://gitea.com/actions/checkout@v3`.
 
-More detail configurations about `[actions].DEFAULT_ACTIONS_URL` could be found at [Configuration Cheat Sheet](administration/config-cheat-sheet.md#actions-actions)。
+If your Gitea instance is in an intranet or a restricted area, you can set the URL to `self` to only download actions from your own instance by default.
+Of course, you can still use absolute URLs in workflows.
+
+More details about the `[actions].DEFAULT_ACTIONS_URL` configuration can be found in the [Configuration Cheat Sheet](administration/config-cheat-sheet.md#actions-actions)。
 
 ### Context availability
 

--- a/docs/content/usage/actions/comparison.en-us.md
+++ b/docs/content/usage/actions/comparison.en-us.md
@@ -91,12 +91,6 @@ As a workaround, you can use [go-hashfiles](https://gitea.com/actions/go-hashfil
 
 ## Missing features
 
-### Variables
-
-See [Variables](https://docs.github.com/en/actions/learn-github-actions/variables).
-
-It's under development.
-
 ### Problem Matchers
 
 Problem Matchers are a way to scan the output of actions for a specified regex pattern and surface that information prominently in the UI.
@@ -117,18 +111,6 @@ It's ignored by Gitea Actions now.
 Pre and Post steps don't have their own section in the job log user interface.
 
 ## Different behavior
-
-### Downloading actions
-
-Gitea Actions doesn't download actions from GitHub by default.
-"By default" means that you don't specify the host in the `uses` field, like `uses: actions/checkout@v3`.
-As a contrast, `uses: https://github.com/actions/checkout@v3` has specified host.
-
-The missing host will be filled with `https://gitea.com` if you don't configure it.
-That means `uses: actions/checkout@v3` will download the action from [gitea.com/actions/checkout](https://gitea.com/actions/checkout), instead of [github.com/actions/checkout](https://github.com/actions/checkout).
-
-As mentioned, it's configurable.
-If you want your runners to download actions from GitHub or your own Gitea instance by default, you can configure it by setting `[actions].DEFAULT_ACTIONS_URL`. See [Configuration Cheat Sheet](administration/config-cheat-sheet.md#actions-actions).
 
 ### Context availability
 

--- a/docs/content/usage/actions/comparison.en-us.md
+++ b/docs/content/usage/actions/comparison.en-us.md
@@ -112,6 +112,18 @@ Pre and Post steps don't have their own section in the job log user interface.
 
 ## Different behavior
 
+### Downloading actions
+
+When `[actions].DEFAULT_ACTIONS_URL` keep default value `github`, Gitea will download relative paths actions from https://github.com, that means
+if you use `uses: actions/checkout@v3`, it will download the checkout repository from https://github.com/actions/checkout.git .
+If you want to download an actions from another git service sites, you can just use an absolute URL `uses: https://gitea.com/actions/checkout@v3`.
+
+If your Gitea instance is in an intranet without internet connection or a restricted area. You can use absolute URL in workflows.
+You can also set `[actions].DEFAULT_ACTIONS_URL = self`, then all relative actions will not be downloaded from github like before,
+but will be download from your Gitea instance. That means if your workflow have the syntax `uses: actions/checkout@v3`, it will be downloaded from `[server].ROOT_URL`/actions/checkout.git .
+
+More detail configurations about `[actions].DEFAULT_ACTIONS_URL` could be found at [Configuration Cheat Sheet](administration/config-cheat-sheet.md#actions-actions)。
+
 ### Context availability
 
 Context availability is not checked, so you can use the env context on more places.

--- a/docs/content/usage/actions/comparison.zh-cn.md
+++ b/docs/content/usage/actions/comparison.zh-cn.md
@@ -120,15 +120,13 @@ Gitea Actions目前不支持此功能。
 
 ### 下载Actions
 
-Gitea Actions默认不从GitHub下载Actions。
-"默认" 意味着您在`uses` 字段中不指定主机，如`uses: actions/checkout@v3`。
-相反，`uses: https://github.com/actions/checkout@v3`是有指定主机的。
+当 `[actions].DEFAULT_ACTIONS_URL` 保持默认值为 `github` 时，Gitea将会从 https://github.com 下载相对路径的actions。比如：
+如果你使用 `uses: actions/checkout@v3`，Gitea将会从 https://github.com/actions/checkout.git 下载这个 actions 项目。
+如果你想要从另外一个 Git服务下载actions，你只需要使用绝对URL `uses: https://gitea.com/actions/checkout@v3` 来下载。
 
-如果您不进行配置，缺失的主机将填充为`https://gitea.com`。
-这意味着`uses: actions/checkout@v3`将从[gitea.com/actions/checkout](https://gitea.com/actions/checkout)下载该Action，而不是[github.com/actions/checkout](https://github.com/actions/checkout)。
+如果你的 Gitea 实例是部署在一个互联网限制的网络中，有可以使用绝对地址来下载 actions。你也可以讲配置项修改为 `[actions].DEFAULT_ACTIONS_URL = self`。这样所有的相对路径的actions引用，将不再会从 github.com 去下载，而会从这个 Gitea 实例自己的仓库中去下载。例如： `uses: actions/checkout@v3` 将会从 `[server].ROOT_URL`/actions/checkout.git 这个地址去下载 actions。
 
-正如前面提到的，这是可配置的。
-如果您希望您的运行程序默认从GitHub或您自己的Gitea实例下载动作，您可以通过设置`[actions].DEFAULT_ACTIONS_URL`进行配置。请参阅[配置备忘单](administration/config-cheat-sheet.md#actions-actions)。
+设置`[actions].DEFAULT_ACTIONS_URL`进行配置。请参阅[配置备忘单](administration/config-cheat-sheet.md#actions-actions)。
 
 ### 上下文可用性
 


### PR DESCRIPTION
No backport needed as this new state only applies to 1.21+