### PR TITLE
Fix: treat tab "overview" as "repositories" in user profiles without readme

### DIFF
--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -77,8 +77,9 @@ func userProfile(ctx *context.Context) {
 
 func prepareUserProfileTabData(ctx *context.Context, showPrivate bool, profileGitRepo *git.Repository, profileReadme *git.Blob) {
 	// if there is a profile readme, default to "overview" page, otherwise, default to "repositories" page
+	// if there is not a profile readme, the overview tab should be treated as the repositories tab
 	tab := ctx.FormString("tab")
-	if tab == "" {
+	if tab == "" || tab == "overview" {
 		if profileReadme != nil {
 			tab = "overview"
 		} else {


### PR DESCRIPTION
Beginning since 2af30f715e64dbb0a3900168e3768ffb36c06392, Gitea has a 500 error when visiting a user profile with `?tab=overview` in the URL when the user doesn't have a `.profile/README.md`, because the backend code assumes that if the tab is overview a profile repository must exist, and checks that the repository is nil aren't done.

In this PR I treat `?tab=overview` the same as if no tab is set in the URL, which corrects this behaviour- Now, when visiting `?tab=overview`, if `.profile/README.md` exists on that user's profile it'll show that as it should, otherwise it'll show the repositories tab.