### PR TITLE
Improve actions docs related to `pull_request` event

### DIFF
--- a/docs/content/usage/actions/faq.en-us.md
+++ b/docs/content/usage/actions/faq.en-us.md
@@ -180,3 +180,6 @@ For events supported only by GitHub, see GitHub's [documentation](https://docs.g
 | pull_request_review_comment | `created`, `edited`                                                                                                      |
 | release                     | `published`, `edited`                                                                                                    |
 | registry_package            | `published`                                                                                                              |
+
+> For `pull_request` events, in Github, the `ref` is `refs/pull/:prNumber/merge`. However, Gitea has no such reference.
+> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head` which points to the head of pull request rather than the merge commit.

--- a/docs/content/usage/actions/faq.en-us.md
+++ b/docs/content/usage/actions/faq.en-us.md
@@ -181,5 +181,5 @@ For events supported only by GitHub, see GitHub's [documentation](https://docs.g
 | release                     | `published`, `edited`                                                                                                    |
 | registry_package            | `published`                                                                                                              |
 
-> For `pull_request` events, in [GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `ref` is `refs/pull/:prNumber/merge`, which is a reference to the merge commit preview.
-> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head`, which points to the head of the pull request rather than the preview of the merge commit.
+> For `pull_request` events, in [GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `ref` is `refs/pull/:prNumber/merge`, which is a reference to the merge commit preview. However, Gitea has no such reference.
+> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head`, which points to the head of  pull request rather than the preview of the merge commit.

--- a/docs/content/usage/actions/faq.en-us.md
+++ b/docs/content/usage/actions/faq.en-us.md
@@ -181,5 +181,5 @@ For events supported only by GitHub, see GitHub's [documentation](https://docs.g
 | release                     | `published`, `edited`                                                                                                    |
 | registry_package            | `published`                                                                                                              |
 
-> For `pull_request` events, in Github, the `ref` is `refs/pull/:prNumber/merge`. However, Gitea has no such reference.
-> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head` which points to the head of pull request rather than the merge commit.
+> For `pull_request` events, in [GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `ref` is `refs/pull/:prNumber/merge`, which is a reference to the merge commit preview.
+> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head`, which points to the head of the pull request rather than the preview of the merge commit.

--- a/docs/content/usage/actions/faq.en-us.md
+++ b/docs/content/usage/actions/faq.en-us.md
@@ -182,4 +182,4 @@ For events supported only by GitHub, see GitHub's [documentation](https://docs.g
 | registry_package            | `published`                                                                                                              |
 
 > For `pull_request` events, in [GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `ref` is `refs/pull/:prNumber/merge`, which is a reference to the merge commit preview. However, Gitea has no such reference.
-> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head`, which points to the head of  pull request rather than the preview of the merge commit.
+> Therefore, the `ref` in Gitea Actions is `refs/pull/:prNumber/head`, which points to the head of pull request rather than the preview of the merge commit.

--- a/docs/content/usage/actions/faq.zh-cn.md
+++ b/docs/content/usage/actions/faq.zh-cn.md
@@ -180,3 +180,6 @@ defaults:
 | pull_request_review_comment | `created`, `edited`                                                                                                      |
 | release                     | `published`, `edited`                                                                                                    |
 | registry_package            | `published`                                                                                                              |
+
+> 对于 `pull_request` 事件，在 [GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) 中 `ref` 是 `refs/pull/:prNumber/merge`，它指向这个拉取请求合并提交的一个预览。但是 Gitea 没有这种 reference。
+> 因此，Gitea Actions 中 `ref` 是 `refs/pull/:prNumber/head`，它指向这个拉取请求的头分支而不是合并提交的预览。


### PR DESCRIPTION
Related to #27039

The `ref` property in Gitea Actions is different from GitHub Actions. This PR improves the documentation to explain the difference.