### PR TITLE
fix pagination for followers and following

### DIFF
--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -157,10 +157,10 @@ func prepareUserProfileTabData(ctx *context.Context, showPrivate bool, profileGi
 	switch tab {
 	case "followers":
 		ctx.Data["Cards"] = followers
-		total = int(count)
+		total = int(numFollowers)
 	case "following":
 		ctx.Data["Cards"] = following
-		total = int(count)
+		total = int(numFollowing)
 	case "activity":
 		date := ctx.FormString("date")
 		pagingNum = setting.UI.FeedPagingNum


### PR DESCRIPTION
- Use the correct total amount for pagination. Thereby correctly show the pagination bare when there's more than one page of followers/followings.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1477

(cherry picked from commit c1a136318be3bf72511bed108f2d67f2cf34e1b8)
