### PR TITLE
show manual cron run's last time

### DIFF
--- a/services/cron/cron.go
+++ b/services/cron/cron.go
@@ -106,6 +106,12 @@ func ListTasks() TaskTable {
 			next = e.NextRun()
 			prev = e.PreviousRun()
 		}
+
+		// If the manual run is after the cron run, use that instead.
+		if prev.Before(task.LastRun) {
+			prev = task.LastRun
+		}
+
 		task.lock.Lock()
 		tTable = append(tTable, &TaskTableRow{
 			Name:        task.Name,

--- a/tests/integration/api_admin_test.go
+++ b/tests/integration/api_admin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	asymkey_model "code.gitea.io/gitea/models/asymkey"
 	auth_model "code.gitea.io/gitea/models/auth"
@@ -281,4 +282,54 @@ func TestAPIRenameUser(t *testing.T) {
 		"new_name": "user2",
 	})
 	MakeRequest(t, req, http.StatusOK)
+}
+
+func TestAPICron(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	// user1 is an admin user
+	session := loginUser(t, "user1")
+
+	t.Run("List", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadAdmin)
+		urlStr := fmt.Sprintf("/api/v1/admin/cron?token=%s", token)
+		req := NewRequest(t, "GET", urlStr)
+		resp := MakeRequest(t, req, http.StatusOK)
+
+		assert.Equal(t, "26", resp.Header().Get("X-Total-Count"))
+
+		var crons []api.Cron
+		DecodeJSON(t, resp, &crons)
+		assert.Len(t, crons, 26)
+	})
+
+	t.Run("Execute", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		now := time.Now()
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteAdmin)
+		/// Archive cleanup is harmless, because in the text environment there are none
+		/// and is thus an NOOP operation and therefore doesn't interfere with any other
+		/// tests.
+		urlStr := fmt.Sprintf("/api/v1/admin/cron/archive_cleanup?token=%s", token)
+		req := NewRequest(t, "POST", urlStr)
+		MakeRequest(t, req, http.StatusNoContent)
+
+		// Check for the latest run time for this cron, to ensure it
+		// has been run.
+		urlStr = fmt.Sprintf("/api/v1/admin/cron?token=%s", token)
+		req = NewRequest(t, "GET", urlStr)
+		resp := MakeRequest(t, req, http.StatusOK)
+
+		var crons []api.Cron
+		DecodeJSON(t, resp, &crons)
+
+		for _, cron := range crons {
+			if cron.Name == "archive_cleanup" {
+				assert.True(t, now.Before(cron.Prev))
+			}
+		}
+	})
 }


### PR DESCRIPTION
- Currently in the cron tasks, the 'Previous Time' only displays the previous time of when the cron library executes the function, but not any of the manual executions of the task.
- Store the last run's time in memory in the Task struct and use that, when that time is later than time that the cron library has executed this task.
- This ensures that if an instance admin manually starts a task, there's feedback that this task is/has been run, because the task might be run that quick, that the status icon already has been changed to an checkmark,
- Tasks that are executed at startup now reflect this as well, as the time of the execution of that task on startup is now being shown as 'Previous Time'.
- Added integration tests for the API part, which is easier to test because querying the HTML table of cron tasks is non-trivial.
- Resolves https://codeberg.org/forgejo/forgejo/issues/949

(cherry picked from commit cdaa9615f4f4b6563c383e691aaa57b3df308cf0)
