### PR TITLE
Fix incorrect test code for error handling

### DIFF
--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -168,7 +168,9 @@ func TestRepository_AddWikiPage(t *testing.T) {
 			assert.NoError(t, AddWikiPage(git.DefaultContext, doer, repo, webPath, wikiContent, commitMsg))
 			// Now need to show that the page has been added:
 			gitRepo, err := git.OpenRepository(git.DefaultContext, repo.WikiPath())
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 			defer gitRepo.Close()
 			masterTree, err := gitRepo.GetTree(DefaultBranch)
 			assert.NoError(t, err)
@@ -238,7 +240,9 @@ func TestRepository_DeleteWikiPage(t *testing.T) {
 
 	// Now need to show that the page has been added:
 	gitRepo, err := git.OpenRepository(git.DefaultContext, repo.WikiPath())
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer gitRepo.Close()
 	masterTree, err := gitRepo.GetTree(DefaultBranch)
 	assert.NoError(t, err)
@@ -251,7 +255,9 @@ func TestPrepareWikiFileName(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 	gitRepo, err := git.OpenRepository(git.DefaultContext, repo.WikiPath())
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer gitRepo.Close()
 
 	tests := []struct {
@@ -303,7 +309,9 @@ func TestPrepareWikiFileName_FirstPage(t *testing.T) {
 	assert.NoError(t, err)
 
 	gitRepo, err := git.OpenRepository(git.DefaultContext, tmpDir)
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer gitRepo.Close()
 
 	existence, newWikiPath, err := prepareGitPath(gitRepo, "Home")


### PR DESCRIPTION
If `assert.NoError` fails, it should return. Otherwise the code could still execute even if the error occurs.