### PR TITLE
Fix successful return value for `SyncAndGetUserSpecificDiff`

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1302,6 +1302,7 @@ func SyncAndGetUserSpecificDiff(ctx context.Context, userID int64, pull *issues_
 	// But as that does not work for all potential errors, we simply mark all files as unchanged and drop the error which always works, even if not as good as possible
 	if err != nil {
 		log.Error("Could not get changed files between %s and %s for pull request %d in repo with path %s. Assuming no changes. Error: %w", review.CommitSHA, latestCommit, pull.Index, gitRepo.Path, err)
+		err = nil
 	}
 
 	filesChangedSinceLastDiff := make(map[string]pull_model.ViewedState)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1302,7 +1302,6 @@ func SyncAndGetUserSpecificDiff(ctx context.Context, userID int64, pull *issues_
 	// But as that does not work for all potential errors, we simply mark all files as unchanged and drop the error which always works, even if not as good as possible
 	if err != nil {
 		log.Error("Could not get changed files between %s and %s for pull request %d in repo with path %s. Assuming no changes. Error: %w", review.CommitSHA, latestCommit, pull.Index, gitRepo.Path, err)
-		err = nil
 	}
 
 	filesChangedSinceLastDiff := make(map[string]pull_model.ViewedState)
@@ -1344,7 +1343,7 @@ outer:
 		}
 	}
 
-	return diff, err
+	return diff, nil
 }
 
 // CommentAsDiff returns c.Patch as *Diff


### PR DESCRIPTION
A function should not return an error when it is successful.
Otherwise, things like https://discord.com/channels/322538954119184384/322538954119184384/1153705341620600833 happen…