### PR TITLE
Fix release URL in webhooks

### DIFF
--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -170,7 +170,7 @@ func (d *DingtalkPayload) Repository(p *api.RepositoryPayload) (api.Payloader, e
 func (d *DingtalkPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 	text, _ := getReleasePayloadInfo(p, noneLinkFormatter, true)
 
-	return createDingtalkPayload(text, text, "view release", p.Release.URL), nil
+	return createDingtalkPayload(text, text, "view release", p.Release.HTMLURL), nil
 }
 
 func createDingtalkPayload(title, text, singleTitle, singleURL string) *DingtalkPayload {

--- a/services/webhook/dingtalk_test.go
+++ b/services/webhook/dingtalk_test.go
@@ -238,7 +238,7 @@ func TestDingTalkPayload(t *testing.T) {
 		assert.Equal(t, "[test/repo] Release created: v1.0 by user1", pl.(*DingtalkPayload).ActionCard.Text)
 		assert.Equal(t, "[test/repo] Release created: v1.0 by user1", pl.(*DingtalkPayload).ActionCard.Title)
 		assert.Equal(t, "view release", pl.(*DingtalkPayload).ActionCard.SingleTitle)
-		assert.Equal(t, "http://localhost:3000/api/v1/repos/test/repo/releases/2", parseRealSingleURL(pl.(*DingtalkPayload).ActionCard.SingleURL))
+		assert.Equal(t, "http://localhost:3000/test/repo/releases/tag/v1.0", parseRealSingleURL(pl.(*DingtalkPayload).ActionCard.SingleURL))
 	})
 }
 

--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -253,7 +253,7 @@ func (d *DiscordPayload) Wiki(p *api.WikiPayload) (api.Payloader, error) {
 func (d *DiscordPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 	text, color := getReleasePayloadInfo(p, noneLinkFormatter, false)
 
-	return d.createPayload(p.Sender, text, p.Release.Note, p.Release.URL, color), nil
+	return d.createPayload(p.Sender, text, p.Release.Note, p.Release.HTMLURL, color), nil
 }
 
 // GetDiscordPayload converts a discord webhook into a DiscordPayload

--- a/services/webhook/discord_test.go
+++ b/services/webhook/discord_test.go
@@ -270,7 +270,7 @@ func TestDiscordPayload(t *testing.T) {
 		assert.Len(t, pl.(*DiscordPayload).Embeds, 1)
 		assert.Equal(t, "[test/repo] Release created: v1.0", pl.(*DiscordPayload).Embeds[0].Title)
 		assert.Equal(t, "Note of first stable release", pl.(*DiscordPayload).Embeds[0].Description)
-		assert.Equal(t, "http://localhost:3000/api/v1/repos/test/repo/releases/2", pl.(*DiscordPayload).Embeds[0].URL)
+		assert.Equal(t, "http://localhost:3000/test/repo/releases/tag/v1.0", pl.(*DiscordPayload).Embeds[0].URL)
 		assert.Equal(t, p.Sender.UserName, pl.(*DiscordPayload).Embeds[0].Author.Name)
 		assert.Equal(t, setting.AppURL+p.Sender.UserName, pl.(*DiscordPayload).Embeds[0].Author.URL)
 		assert.Equal(t, p.Sender.AvatarURL, pl.(*DiscordPayload).Embeds[0].Author.IconURL)

--- a/services/webhook/general_test.go
+++ b/services/webhook/general_test.go
@@ -240,7 +240,7 @@ func pullReleaseTestPayload() *api.ReleasePayload {
 			Target:  "master",
 			Title:   "First stable release",
 			Note:    "Note of first stable release",
-			URL:     "http://localhost:3000/api/v1/repos/test/repo/releases/2",
+			URL:     "http://localhost:3000/test/repo/releases/tag/v1.0",
 		},
 	}
 }

--- a/services/webhook/general_test.go
+++ b/services/webhook/general_test.go
@@ -240,7 +240,7 @@ func pullReleaseTestPayload() *api.ReleasePayload {
 			Target:  "master",
 			Title:   "First stable release",
 			Note:    "Note of first stable release",
-			URL:     "http://localhost:3000/test/repo/releases/tag/v1.0",
+			HTMLURL: "http://localhost:3000/test/repo/releases/tag/v1.0",
 		},
 	}
 }

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -177,7 +177,7 @@ func (m *MatrixPayload) PullRequest(p *api.PullRequestPayload) (api.Payloader, e
 func (m *MatrixPayload) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (api.Payloader, error) {
 	senderLink := MatrixLinkFormatter(setting.AppURL+url.PathEscape(p.Sender.UserName), p.Sender.UserName)
 	title := fmt.Sprintf("#%d %s", p.Index, p.PullRequest.Title)
-	titleLink := MatrixLinkFormatter(p.PullRequest.URL, title)
+	titleLink := MatrixLinkFormatter(p.PullRequest.HTMLURL, title)
 	repoLink := MatrixLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 	var text string
 

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -290,7 +290,7 @@ func (m *MSTeamsPayload) Release(p *api.ReleasePayload) (api.Payloader, error) {
 		p.Sender,
 		title,
 		"",
-		p.Release.URL,
+		p.Release.HTMLURL,
 		color,
 		&MSTeamsFact{"Tag:", p.Release.TagName},
 	), nil

--- a/services/webhook/msteams_test.go
+++ b/services/webhook/msteams_test.go
@@ -429,7 +429,7 @@ func TestMSTeamsPayload(t *testing.T) {
 		}
 		assert.Len(t, pl.(*MSTeamsPayload).PotentialAction, 1)
 		assert.Len(t, pl.(*MSTeamsPayload).PotentialAction[0].Targets, 1)
-		assert.Equal(t, "http://localhost:3000/api/v1/repos/test/repo/releases/2", pl.(*MSTeamsPayload).PotentialAction[0].Targets[0].URI)
+		assert.Equal(t, "http://localhost:3000/test/repo/releases/tag/v1.0", pl.(*MSTeamsPayload).PotentialAction[0].Targets[0].URI)
 	})
 }
 

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -223,7 +223,7 @@ func (s *SlackPayload) PullRequest(p *api.PullRequestPayload) (api.Payloader, er
 		attachments = append(attachments, SlackAttachment{
 			Color:     fmt.Sprintf("%x", color),
 			Title:     issueTitle,
-			TitleLink: p.PullRequest.URL,
+			TitleLink: p.PullRequest.HTMLURL,
 			Text:      attachmentText,
 		})
 	}


### PR DESCRIPTION
Resolves #27180

`URL` points to the API URL, `HTMLURL` points to the web page.

Notably, however, for PRs they are the same URL. I switched them to use HTMLURL to match the rest of the codebase terminology.
