### PR TITLE
fix: text decorator on issue sidebar menu label

### DIFF
--- a/templates/repo/issue/labels/label.tmpl
+++ b/templates/repo/issue/labels/label.tmpl
@@ -1,5 +1,5 @@
 <a
-	class="item {{if not .label.IsChecked}}gt-hidden{{end}}"
+	class="item gt-dib {{if not .label.IsChecked}}gt-hidden{{end}}"
 	id="label_{{.label.ID}}"
 	href="{{.root.RepoLink}}/{{if or .root.IsPull .root.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.label.ID}}"{{/* FIXME: use .root.Issue.Link or create .root.Link */}}
 >

--- a/templates/repo/issue/labels/label.tmpl
+++ b/templates/repo/issue/labels/label.tmpl
@@ -1,7 +1,7 @@
 <a
-	class="item gt-dib {{if not .label.IsChecked}}gt-hidden{{end}}"
+	class="item {{if not .label.IsChecked}}gt-hidden{{end}}"
 	id="label_{{.label.ID}}"
 	href="{{.root.RepoLink}}/{{if or .root.IsPull .root.Issue.IsPull}}pulls{{else}}issues{{end}}?labels={{.label.ID}}"{{/* FIXME: use .root.Issue.Link or create .root.Link */}}
 >
-	{{RenderLabel $.Context .label}}
+	{{- RenderLabel $.Context .label -}}
 </a>


### PR DESCRIPTION
fix underline for label on issue sidebar

Ex: https://try.gitea.io/jaqra/ConfuserEx/issues/1

![image](https://github.com/go-gitea/gitea/assets/29250154/4d5beec6-34c5-4360-92b1-383738dcd74d)
