### PR TITLE
Quote table `release` in sql queries (#27205)

### DIFF
--- a/models/activities/repo_activity.go
+++ b/models/activities/repo_activity.go
@@ -342,7 +342,7 @@ func (stats *ActivityStats) FillReleases(repoID int64, fromTime time.Time) error
 
 	// Published releases list
 	sess := releasesForActivityStatement(repoID, fromTime)
-	sess.OrderBy("release.created_unix DESC")
+	sess.OrderBy("`release`.created_unix DESC")
 	stats.PublishedReleases = make([]*repo_model.Release, 0)
 	if err = sess.Find(&stats.PublishedReleases); err != nil {
 		return err
@@ -350,7 +350,7 @@ func (stats *ActivityStats) FillReleases(repoID int64, fromTime time.Time) error
 
 	// Published releases authors
 	sess = releasesForActivityStatement(repoID, fromTime)
-	if _, err = sess.Select("count(distinct release.publisher_id) as `count`").Table("release").Get(&count); err != nil {
+	if _, err = sess.Select("count(distinct `release`.publisher_id) as `count`").Table("release").Get(&count); err != nil {
 		return err
 	}
 	stats.PublishedReleaseAuthorCount = count
@@ -359,7 +359,7 @@ func (stats *ActivityStats) FillReleases(repoID int64, fromTime time.Time) error
 }
 
 func releasesForActivityStatement(repoID int64, fromTime time.Time) *xorm.Session {
-	return db.GetEngine(db.DefaultContext).Where("release.repo_id = ?", repoID).
-		And("release.is_draft = ?", false).
-		And("release.created_unix >= ?", fromTime.Unix())
+	return db.GetEngine(db.DefaultContext).Where("`release`.repo_id = ?", repoID).
+		And("`release`.is_draft = ?", false).
+		And("`release`.created_unix >= ?", fromTime.Unix())
 }

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -101,7 +101,7 @@ func checkDBConsistency(ctx context.Context, logger log.Logger, autofix bool) er
 		},
 		// find releases without existing repository
 		genericOrphanCheck("Orphaned Releases without existing repository",
-			"release", "repository", "release.repo_id=repository.id"),
+			"release", "repository", "`release`.repo_id=repository.id"),
 		// find pulls without existing issues
 		genericOrphanCheck("Orphaned PullRequests without existing issue",
 			"pull_request", "issue", "pull_request.issue_id=issue.id"),


### PR DESCRIPTION
Backport of #27205

Fixes #27174

`release` is a reserved keyword in MySql. I can't reproduce the issue on my setup and we have a test for that code but it seems there can be setups where it fails.
