### PR TITLE
cleanup locale function usage

### DIFF
--- a/templates/admin/base/search.tmpl
+++ b/templates/admin/base/search.tmpl
@@ -1,7 +1,7 @@
 <div class="ui secondary filter menu gt-ac gt-mx-0">
 	<form class="ui form ignore-dirty gt-f1">
 		<div class="ui fluid action input">
-			{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+			{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 			<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 		</div>
 	</form>

--- a/templates/admin/emails/list.tmpl
+++ b/templates/admin/emails/list.tmpl
@@ -7,7 +7,7 @@
 			<div class="ui secondary filter menu gt-ac gt-mx-0">
 				<form class="ui form ignore-dirty gt-f1">
 					<div class="ui fluid action input">
-						{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+						{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 						<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 					</div>
 				</form>

--- a/templates/admin/packages/list.tmpl
+++ b/templates/admin/packages/list.tmpl
@@ -14,7 +14,7 @@
 		<div class="ui attached segment">
 			<form class="ui form ignore-dirty">
 				<div class="ui fluid action input">
-					{{template "shared/searchinput" dict "locale" .locale "Value" .Query "AutoFocus" true}}
+					{{template "shared/searchinput" dict "Value" .Query "AutoFocus" true}}
 					<select class="ui dropdown" name="type">
 						<option value="">{{.locale.Tr "packages.filter.type"}}</option>
 						<option value="all">{{.locale.Tr "packages.filter.type.all"}}</option>

--- a/templates/admin/repo/search.tmpl
+++ b/templates/admin/repo/search.tmpl
@@ -1,7 +1,7 @@
 <div class="ui secondary filter menu gt-ac gt-mx-0">
 	<form class="ui form ignore-dirty gt-f1">
 		<div class="ui fluid action input">
-			{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+			{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 			<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 		</div>
 	</form>

--- a/templates/admin/repo/unadopted.tmpl
+++ b/templates/admin/repo/unadopted.tmpl
@@ -37,7 +37,7 @@
 											<input type="hidden" name="action" value="adopt">
 											<input type="hidden" name="q" value="{{$.Keyword}}">
 											<input type="hidden" name="page" value="{{$.CurrentPage}}">
-											{{template "base/modal_actions_confirm" (dict "locale" $.locale)}}
+											{{template "base/modal_actions_confirm" .}}
 										</form>
 									</div>
 									<button class="ui button red show-modal gt-p-3" data-modal="#delete-unadopted-modal-{{$dirI}}">{{svg "octicon-x"}} {{$.locale.Tr "repo.delete_preexisting_label"}}</button>
@@ -54,7 +54,7 @@
 											<input type="hidden" name="action" value="delete">
 											<input type="hidden" name="q" value="{{$.Keyword}}">
 											<input type="hidden" name="page" value="{{$.CurrentPage}}">
-											{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonColors" "yellow")}}
+											{{template "base/modal_actions_confirm" (dict "ModalButtonColors" "yellow")}}
 										</form>
 									</div>
 								</div>

--- a/templates/admin/repo/unadopted.tmpl
+++ b/templates/admin/repo/unadopted.tmpl
@@ -37,7 +37,7 @@
 											<input type="hidden" name="action" value="adopt">
 											<input type="hidden" name="q" value="{{$.Keyword}}">
 											<input type="hidden" name="page" value="{{$.CurrentPage}}">
-											{{template "base/modal_actions_confirm" .}}
+											{{template "base/modal_actions_confirm"}}
 										</form>
 									</div>
 									<button class="ui button red show-modal gt-p-3" data-modal="#delete-unadopted-modal-{{$dirI}}">{{svg "octicon-x"}} {{$.locale.Tr "repo.delete_preexisting_label"}}</button>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -54,7 +54,7 @@
 
 				<!-- Search Text -->
 				<div class="ui fluid action input">
-					{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+					{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 					<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 				</div>
 			</form>

--- a/templates/base/modal_actions_confirm.tmpl
+++ b/templates/base/modal_actions_confirm.tmpl
@@ -1,7 +1,4 @@
 {{/*
-Template Attributes:
-* locale
-
 Two buttons (negative, positive):
 * ModalButtonTypes: "yes" (default) or "confirm"
 * ModalButtonColors: "primary" (default) / "blue" / "yellow"
@@ -17,11 +14,11 @@ The ".ok.button" and ".cancel.button" selectors are also used by Fomantic Modal 
 	{{if .ModalButtonDangerText}}
 		<button class="ui danger red ok button">{{.ModalButtonDangerText}}</button>
 	{{else}}
-		{{$textNegitive := .locale.Tr "modal.no"}}
-		{{$textPositive := .locale.Tr "modal.yes"}}
+		{{$textNegitive := ctx.Locale.Tr "modal.no"}}
+		{{$textPositive := ctx.Locale.Tr "modal.yes"}}
 		{{if eq .ModalButtonTypes "confirm"}}
-			{{$textNegitive = .locale.Tr "modal.cancel"}}
-			{{$textPositive = .locale.Tr "modal.confirm"}}
+			{{$textNegitive = ctx.Locale.Tr "modal.cancel"}}
+			{{$textPositive = ctx.Locale.Tr "modal.confirm"}}
 		{{end}}
 		{{if .ModalButtonCancelText}}{{$textNegitive = .ModalButtonCancelText}}{{end}}
 		{{if .ModalButtonOkText}}{{$textPositive = .ModalButtonOkText}}{{end}}

--- a/templates/code/searchform.tmpl
+++ b/templates/code/searchform.tmpl
@@ -1,6 +1,6 @@
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
-		{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true "Disabled" .CodeIndexerUnavailable}}
+		{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true "Disabled" .CodeIndexerUnavailable}}
 		<div class="ui dropdown selection {{if .CodeIndexerUnavailable}} disabled{{end}}" data-tooltip-content="{{.locale.Tr "explore.search.type.tooltip"}}">
 			<input name="t" type="hidden" value="{{.queryType}}"{{if .CodeIndexerUnavailable}} disabled{{end}}>{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 			<div class="text">{{.locale.Tr (printf "explore.search.%s" (or .queryType "fuzzy"))}}</div>

--- a/templates/devtest/fomantic-modal.tmpl
+++ b/templates/devtest/fomantic-modal.tmpl
@@ -45,7 +45,7 @@
 		<div class="content">
 			very long aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 		</div>
-		{{template "base/modal_actions_confirm" .}}
+		{{template "base/modal_actions_confirm"}}
 	</div>
 
 	<div class="ui g-modal-confirm modal" id="test-modal-confirm">

--- a/templates/devtest/fomantic-modal.tmpl
+++ b/templates/devtest/fomantic-modal.tmpl
@@ -6,7 +6,7 @@
 		<div class="header">Form dialog (layout 1)</div>
 		<form class="content" method="post">
 			<div class="ui input gt-w-100"><input name="user_input"></div>
-			{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+			{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 		</form>
 	</div>
 
@@ -15,7 +15,7 @@
 		<form method="post">
 			<div class="content">
 				<div class="ui input gt-w-100"><input name="user_input"></div>
-				{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+				{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 			</div>
 		</form>
 	</div>
@@ -26,7 +26,7 @@
 			<div class="content">
 				<div class="ui input gt-w-100"><input name="user_input"></div>
 			</div>
-			{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+			{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 		</form>
 	</div>
 
@@ -36,7 +36,7 @@
 			<div class="ui input gt-w-100"><input name="user_input"></div>
 		</div>
 		<form method="post">
-			{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+			{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 		</form>
 	</div>
 
@@ -45,25 +45,25 @@
 		<div class="content">
 			very long aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 		</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale)}}
+		{{template "base/modal_actions_confirm" .}}
 	</div>
 
 	<div class="ui g-modal-confirm modal" id="test-modal-confirm">
 		<div class="header">Confirm dialog</div>
 		<div class="content">hello, this is the modal dialog content</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 	</div>
 
 	<div class="ui g-modal-confirm modal" id="test-modal-blue">
 		<div class="header">Blue dialog</div>
 		<div class="content">hello, this is the modal dialog content</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonColors" "blue")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonColors" "blue")}}
 	</div>
 
 	<div class="ui g-modal-confirm modal" id="test-modal-yellow">
 		<div class="header">yellow dialog</div>
 		<div class="content">hello, this is the modal dialog content</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonColors" "yellow")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonColors" "yellow")}}
 	</div>
 
 	<div class="ui g-modal-confirm modal" id="test-modal-danger">

--- a/templates/explore/repo_search.tmpl
+++ b/templates/explore/repo_search.tmpl
@@ -3,7 +3,7 @@
 		<input type="hidden" name="sort" value="{{$.SortType}}">
 		<input type="hidden" name="language" value="{{$.Language}}">
 		<div class="ui fluid action input">
-			{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+			{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 			{{if .PageIsExploreRepositories}}
 				<input type="hidden" name="only_show_relevant" value="{{.OnlyShowRelevant}}">
 			{{else}}

--- a/templates/explore/search.tmpl
+++ b/templates/explore/search.tmpl
@@ -1,7 +1,7 @@
 <div class="ui secondary filter menu gt-ac gt-mx-0">
 	<form class="ui form ignore-dirty gt-f1">
 		<div class="ui fluid action input">
-			{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+			{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 			<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 		</div>
 	</form>

--- a/templates/package/shared/list.tmpl
+++ b/templates/package/shared/list.tmpl
@@ -1,7 +1,7 @@
 {{template "base/alert" .}}
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
-		{{template "shared/searchinput" dict "locale" .locale "Value" .Query "AutoFocus" true}}
+		{{template "shared/searchinput" dict "Value" .Query "AutoFocus" true}}
 		<select class="ui dropdown" name="type">
 			<option value="">{{.locale.Tr "packages.filter.type"}}</option>
 			<option value="all">{{.locale.Tr "packages.filter.type.all"}}</option>

--- a/templates/package/shared/versionlist.tmpl
+++ b/templates/package/shared/versionlist.tmpl
@@ -1,7 +1,7 @@
 <p><a href="{{.PackageDescriptor.PackageWebLink}}">{{.PackageDescriptor.Package.Name}}</a> / <strong>{{.locale.Tr "packages.versions"}}</strong></p>
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
-		{{template "shared/searchinput" dict "locale" .locale "Value" .Query "AutoFocus" true}}
+		{{template "shared/searchinput" dict "Value" .Query "AutoFocus" true}}
 		<select class="ui dropdown" name="sort">
 			<option value="version_asc"{{if eq .Sort "version_asc"}} selected="selected"{{end}}>{{.locale.Tr "filter.string.asc"}}</option>
 			<option value="version_desc"{{if eq .Sort "version_desc"}} selected="selected"{{end}}>{{.locale.Tr "filter.string.desc"}}</option>

--- a/templates/projects/list.tmpl
+++ b/templates/projects/list.tmpl
@@ -23,7 +23,7 @@
 	<form class="list-header-search ui form ignore-dirty">
 		<div class="ui small search fluid action input">
 			<input type="hidden" name="state" value="{{$.State}}">
-			{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword}}
+			{{template "shared/searchinput" dict "Value" .Keyword}}
 			<button class="ui small icon button" type="submit" aria-label="{{.locale.Tr "explore.search"}}">
 				{{svg "octicon-search"}}
 			</button>

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -142,7 +142,7 @@
 									<div class="content">
 										<label id="default-project-column-content"></label>
 									</div>
-									{{template "base/modal_actions_confirm" (dict "locale" ctx.Locale "ModalButtonTypes" "confirm")}}
+									{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 								</div>
 
 								<div class="ui g-modal-confirm modal" id="delete-project-column-modal-{{.ID}}">
@@ -154,7 +154,7 @@
 											{{ctx.Locale.Tr "repo.projects.column.deletion_desc"}}
 										</label>
 									</div>
-									{{template "base/modal_actions_confirm" (dict "locale" ctx.Locale "ModalButtonTypes" "confirm")}}
+									{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 								</div>
 							</div>
 						</div>

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -8,7 +8,7 @@
 	{{range .Runs}}
 		<div class="flex-item gt-ac">
 			<div class="flex-item-leading">
-				{{template "repo/actions/status" (dict "status" .Status.String "locale" $.locale)}}
+				{{template "repo/actions/status" (dict "status" .Status.String)}}
 			</div>
 			<div class="flex-item-main">
 				<a class="flex-item-title" title="{{.Title}}" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">

--- a/templates/repo/actions/status.tmpl
+++ b/templates/repo/actions/status.tmpl
@@ -12,7 +12,7 @@
 {{- $className = .className -}}
 {{- end -}}
 
-<span class="gt-df gt-ac" data-tooltip-content="{{.locale.Tr (printf "actions.status.%s" .status)}}">
+<span class="gt-df gt-ac" data-tooltip-content="{{ctx.Locale.Tr (printf "actions.status.%s" .status)}}">
 {{if eq .status "success"}}
 	{{svg "octicon-check-circle-fill" $size (printf "text green %s" $className)}}
 {{else if eq .status "skipped"}}

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -64,7 +64,7 @@
 							{{if $.EscapeStatus.Escaped}}
 								<td class="lines-escape">
 									{{if $row.EscapeStatus.Escaped}}
-										<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $row "locale" $.locale}}"></button>
+										<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $row}}"></button>
 									{{end}}
 								</td>
 							{{end}}

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -236,7 +236,7 @@
 				<input id="new_branch_name" name="new_branch_name" required>
 			</div>
 		</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 	</form>
 </div>
 
@@ -258,7 +258,7 @@
 				<input name="to" required>
 			</div>
 		</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 	</form>
 </div>
 {{template "base/footer" .}}

--- a/templates/repo/commit_statuses.tmpl
+++ b/templates/repo/commit_statuses.tmpl
@@ -14,7 +14,7 @@
 				{{template "repo/commit_status" .}}
 				<span class="ui gt-ml-3 gt-f1">{{.Context}} <span class="text grey">{{.Description}}</span></span>
 				{{if .TargetURL}}
-					<a class="gt-ml-3" href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{$.root.locale.Tr "repo.pulls.status_checks_details"}}</a>
+					<a class="gt-ml-3" href="{{.TargetURL}}" target="_blank" rel="noopener noreferrer">{{ctx.Locale.Tr "repo.pulls.status_checks_details"}}</a>
 				{{end}}
 			</div>
 		{{end}}

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -22,22 +22,22 @@
 				</div>
 			</td>
 			<td colspan="7" class="lines-code lines-code-old ">{{$inlineDiff := $.section.GetComputedInlineDiffFor $line $.locale}}{{/*
-				*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.locale}}</td>
+				*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}</td>
 		{{else}}
 			{{$inlineDiff := $.section.GetComputedInlineDiffFor $line $.locale}}
 			<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$.FileNameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
-			<td class="blob-excerpt lines-escape lines-escape-old">{{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.locale}}"></button>{{end}}</td>
+			<td class="blob-excerpt lines-escape lines-escape-old">{{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}</td>
 			<td class="blob-excerpt lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="gt-mono" data-type-marker=""></span>{{end}}</td>
 			<td class="blob-excerpt lines-code lines-code-old">{{/*
-				*/}}{{if $line.LeftIdx}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.locale}}{{else}}{{/*
+				*/}}{{if $line.LeftIdx}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{else}}{{/*
 					*/}}<code class="code-inner"></code>{{/*
 				*/}}{{end}}{{/*
 			*/}}</td>
 			<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$.FileNameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
-			<td class="blob-excerpt lines-escape lines-escape-new">{{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.locale}}"></button>{{end}}</td>
+			<td class="blob-excerpt lines-escape lines-escape-new">{{if and $line.RightIdx $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}</td>
 			<td class="blob-excerpt lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="gt-mono" data-type-marker=""></span>{{end}}</td>
 			<td class="blob-excerpt lines-code lines-code-new">{{/*
-				*/}}{{if $line.RightIdx}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.locale}}{{else}}{{/*
+				*/}}{{if $line.RightIdx}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{else}}{{/*
 					*/}}<code class="code-inner"></code>{{/*
 				*/}}{{end}}{{/*
 			*/}}</td>
@@ -72,9 +72,9 @@
 			<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$.FileNameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
 		{{end}}
 		{{$inlineDiff := $.section.GetComputedInlineDiffFor $line $.locale}}
-		<td class="blob-excerpt lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.locale}}"></button>{{end}}</td>
+		<td class="blob-excerpt lines-escape">{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}</td>
 		<td class="blob-excerpt lines-type-marker"><span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
-		<td class="blob-excerpt lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}"><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.locale}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
+		<td class="blob-excerpt lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}"><code {{if $inlineDiff.EscapeStatus.Escaped}}class="code-inner has-escaped" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"{{else}}class="code-inner"{{end}}>{{$inlineDiff.Content}}</code></td>
 	</tr>
 	{{end}}
 {{end}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -225,7 +225,6 @@
 		<template id="issue-comment-editor-template">
 			<div class="ui comment form">
 				{{template "shared/combomarkdowneditor" (dict
-					"locale" $.locale
 					"MarkdownPreviewUrl" (print $.Repository.Link "/markup")
 					"MarkdownPreviewContext" $.RepoLink
 					"TextareaName" "content"

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -11,7 +11,6 @@
 		<input type="hidden" name="diff_base_cid">
 
 		{{template "shared/combomarkdowneditor" (dict
-			"locale" $.root.locale
 			"MarkdownPreviewUrl" (print $.root.Repository.Link "/markup")
 			"MarkdownPreviewContext" $.root.RepoLink
 			"TextareaName" "content"
@@ -21,22 +20,22 @@
 		)}}
 
 		<div class="field footer gt-mx-3">
-			<span class="markup-info">{{svg "octicon-markup"}} {{$.root.locale.Tr "repo.diff.comment.markdown_info"}}</span>
+			<span class="markup-info">{{svg "octicon-markup"}} {{ctx.Locale.Tr "repo.diff.comment.markdown_info"}}</span>
 			<div class="gt-text-right">
 				{{if $.reply}}
-					<button class="ui submit primary tiny button btn-reply" type="submit">{{$.root.locale.Tr "repo.diff.comment.reply"}}</button>
+					<button class="ui submit primary tiny button btn-reply" type="submit">{{ctx.Locale.Tr "repo.diff.comment.reply"}}</button>
 					<input type="hidden" name="reply" value="{{$.reply}}">
 					<input type="hidden" name="single_review" value="true">
 				{{else}}
 					{{if $.root.CurrentReview}}
-						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-add-comment">{{$.root.locale.Tr "repo.diff.comment.add_review_comment"}}</button>
+						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-add-comment">{{ctx.Locale.Tr "repo.diff.comment.add_review_comment"}}</button>
 					{{else}}
-						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-start-review">{{$.root.locale.Tr "repo.diff.comment.start_review"}}</button>
-						<button name="single_review" value="true" type="submit" class="ui submit tiny basic button btn-add-single">{{$.root.locale.Tr "repo.diff.comment.add_single_comment"}}</button>
+						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-start-review">{{ctx.Locale.Tr "repo.diff.comment.start_review"}}</button>
+						<button name="single_review" value="true" type="submit" class="ui submit tiny basic button btn-add-single">{{ctx.Locale.Tr "repo.diff.comment.add_single_comment"}}</button>
 					{{end}}
 				{{end}}
 				{{if or (not $.HasComments) $.hidden}}
-					<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{$.root.locale.Tr "cancel"}}</button>
+					<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{ctx.Locale.Tr "cancel"}}</button>
 				{{end}}
 			</div>
 		</div>

--- a/templates/repo/diff/comments.tmpl
+++ b/templates/repo/diff/comments.tmpl
@@ -16,35 +16,35 @@
 						{{.OriginalAuthor}}
 					</span>
 					<span class="text grey muted-links">
-						{{$.root.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
+						{{ctx.Locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
 					</span>
 					<span class="text migrate">
 						{{if $.root.Repository.OriginalURL}}
-							({{$.root.locale.Tr "repo.migrated_from" ($.root.Repository.OriginalURL | Escape) ($.root.Repository.GetOriginalURLHostname | Escape) | Safe}})
+							({{ctx.Locale.Tr "repo.migrated_from" ($.root.Repository.OriginalURL | Escape) ($.root.Repository.GetOriginalURLHostname | Escape) | Safe}})
 						{{end}}
 					</span>
 				{{else}}
 					<span class="text grey muted-links">
 						{{template "shared/user/namelink" .Poster}}
-						{{$.root.locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
+						{{ctx.Locale.Tr "repo.issues.commented_at" (.HashTag|Escape) $createdStr | Safe}}
 					</span>
 				{{end}}
 			</div>
 			<div class="comment-header-right actions gt-df gt-ac">
 				{{if .Invalidated}}
 					{{$referenceUrl := printf "%s#%s" $.root.Issue.Link .HashTag}}
-					<a href="{{AppSubUrl}}{{$referenceUrl}}" class="ui label basic small" data-tooltip-content="{{$.root.locale.Tr "repo.issues.review.outdated_description"}}">
-						{{$.root.locale.Tr "repo.issues.review.outdated"}}
+					<a href="{{AppSubUrl}}{{$referenceUrl}}" class="ui label basic small" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.review.outdated_description"}}">
+						{{ctx.Locale.Tr "repo.issues.review.outdated"}}
 					</a>
 				{{end}}
 				{{if and .Review}}
 					{{if eq .Review.Type 0}}
-						<div class="ui label basic small yellow pending-label" data-tooltip-content="{{$.root.locale.Tr "repo.issues.review.pending.tooltip" ($.root.locale.Tr "repo.diff.review") ($.root.locale.Tr "repo.diff.review.approve") ($.root.locale.Tr "repo.diff.review.comment") ($.root.locale.Tr "repo.diff.review.reject")}}">
-						{{$.root.locale.Tr "repo.issues.review.pending"}}
+						<div class="ui label basic small yellow pending-label" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.review.pending.tooltip" (ctx.Locale.Tr "repo.diff.review") (ctx.Locale.Tr "repo.diff.review.approve") (ctx.Locale.Tr "repo.diff.review.comment") (ctx.Locale.Tr "repo.diff.review.reject")}}">
+						{{ctx.Locale.Tr "repo.issues.review.pending"}}
 						</div>
 					{{else}}
 						<div class="ui label basic small">
-						{{$.root.locale.Tr "repo.issues.review.review"}}
+						{{ctx.Locale.Tr "repo.issues.review.review"}}
 						</div>
 					{{end}}
 				{{end}}
@@ -57,7 +57,7 @@
 			{{if .RenderedContent}}
 				{{.RenderedContent|Str2html}}
 			{{else}}
-				<span class="no-content">{{$.root.locale.Tr "repo.issues.no_content"}}</span>
+				<span class="no-content">{{ctx.Locale.Tr "repo.issues.no_content"}}</span>
 			{{end}}
 			</div>
 			<div id="issuecomment-{{.ID}}-raw" class="raw-content gt-hidden">{{.Content}}</div>

--- a/templates/repo/diff/escape_title.tmpl
+++ b/templates/repo/diff/escape_title.tmpl
@@ -1,2 +1,2 @@
-{{if .diff.EscapeStatus.HasInvisible}}{{.locale.Tr "repo.invisible_runes_line"}} {{end}}{{/*
-*/}}{{if .diff.EscapeStatus.HasAmbiguous}}{{.locale.Tr "repo.ambiguous_runes_line"}}{{end}}
+{{if .diff.EscapeStatus.HasInvisible}}{{ctx.Locale.Tr "repo.invisible_runes_line"}} {{end}}{{/*
+*/}}{{if .diff.EscapeStatus.HasAmbiguous}}{{ctx.Locale.Tr "repo.ambiguous_runes_line"}}{{end}}

--- a/templates/repo/diff/new_review.tmpl
+++ b/templates/repo/diff/new_review.tmpl
@@ -16,7 +16,6 @@
 				</div>
 				<div class="field">
 					{{template "shared/combomarkdowneditor" (dict
-						"locale" $.locale
 						"MarkdownPreviewUrl" (print .Repository.Link "/markup")
 						"MarkdownPreviewContext" .RepoLink
 						"TextareaName" "content"

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -34,40 +34,40 @@
 						{{end}}
 						</div>
 					</td>{{$inlineDiff := $section.GetComputedInlineDiffFor $line $.root.locale}}
-					<td class="lines-escape lines-escape-old">{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></button>{{end}}</td>
+					<td class="lines-escape lines-escape-old">{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}</td>
 					<td colspan="6" class="lines-code lines-code-old ">{{/*
-						*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+						*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{/*
 					*/}}</td>
 				{{else if and (eq .GetType 3) $hasmatch}}{{/* DEL */}}
 					{{$match := index $section.Lines $line.Match}}
 					{{- $leftDiff := ""}}{{if $line.LeftIdx}}{{$leftDiff = $section.GetComputedInlineDiffFor $line $.root.locale}}{{end}}
 					{{- $rightDiff := ""}}{{if $match.RightIdx}}{{$rightDiff = $section.GetComputedInlineDiffFor $match $.root.locale}}{{end}}
 					<td class="lines-num lines-num-old del-code" data-line-num="{{$line.LeftIdx}}"><span rel="diff-{{$file.NameHash}}L{{$line.LeftIdx}}"></span></td>
-					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{if $leftDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $leftDiff "locale" $.root.locale}}"></button>{{end}}{{end}}</td>
+					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{if $leftDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $leftDiff}}"></button>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old del-code">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
-							*/}}<button type="button" aria-label="{{$.root.locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{/*
+							*/}}<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{/*
 								*/}}{{svg "octicon-plus"}}{{/*
 							*/}}</button>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.LeftIdx}}{{/*
-							*/}}{{template "repo/diff/section_code" dict "diff" $leftDiff "locale" $.root.locale}}{{/*
+							*/}}{{template "repo/diff/section_code" dict "diff" $leftDiff}}{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
 					*/}}</td>
 					<td class="lines-num lines-num-new add-code" data-line-num="{{if $match.RightIdx}}{{$match.RightIdx}}{{end}}"><span rel="{{if $match.RightIdx}}diff-{{$file.NameHash}}R{{$match.RightIdx}}{{end}}"></span></td>
-					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{if $rightDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $rightDiff "locale" $.root.locale}}"></button>{{end}}{{end}}</td>
+					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{if $rightDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $rightDiff}}"></button>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="gt-mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new add-code">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
-							*/}}<button type="button" aria-label="{{$.root.locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} gt-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">{{/*
+							*/}}<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} gt-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">{{/*
 								*/}}{{svg "octicon-plus"}}{{/*
 							*/}}</button>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $match.RightIdx}}{{/*
-							*/}}{{template "repo/diff/section_code" dict "diff" $rightDiff "locale" $.root.locale}}{{/*
+							*/}}{{template "repo/diff/section_code" dict "diff" $rightDiff}}{{/*
 						*/}}{{else}}{{/*
 							*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
@@ -75,31 +75,31 @@
 				{{else}}
 					{{$inlineDiff := $section.GetComputedInlineDiffFor $line $.root.locale}}
 					<td class="lines-num lines-num-old" data-line-num="{{if $line.LeftIdx}}{{$line.LeftIdx}}{{end}}"><span rel="{{if $line.LeftIdx}}diff-{{$file.NameHash}}L{{$line.LeftIdx}}{{end}}"></span></td>
-					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></button>{{end}}{{end}}</td>
+					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2))}}{{/*
-							*/}}<button type="button" aria-label="{{$.root.locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{/*
+							*/}}<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">{{/*
 								*/}}{{svg "octicon-plus"}}{{/*
 							*/}}</button>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.LeftIdx}}{{/*
-							*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+							*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*
 					*/}}</td>
 					<td class="lines-num lines-num-new" data-line-num="{{if $line.RightIdx}}{{$line.RightIdx}}{{end}}"><span rel="{{if $line.RightIdx}}diff-{{$file.NameHash}}R{{$line.RightIdx}}{{end}}"></span></td>
-					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></button>{{end}}{{end}}</td>
+					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{if $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new">{{/*
 						*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3))}}{{/*
-							*/}}<button type="button" aria-label="{{$.root.locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">{{/*
+							*/}}<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">{{/*
 								*/}}{{svg "octicon-plus"}}{{/*
 							*/}}</button>{{/*
 						*/}}{{end}}{{/*
 						*/}}{{if $line.RightIdx}}{{/*
-							*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+							*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{/*
 						*/}}{{else}}{{/*
 						*/}}<code class="code-inner"></code>{{/*
 						*/}}{{end}}{{/*

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -41,22 +41,22 @@
 			{{$inlineDiff := $section.GetComputedInlineDiffFor $line $.root.locale -}}
 			<td class="lines-escape">
 				{{- if $inlineDiff.EscapeStatus.Escaped -}}
-					<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff "locale" $.root.locale}}"></button>
+					<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>
 				{{- end -}}
 			</td>
 			<td class="lines-type-marker"><span class="gt-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 			{{if eq .GetType 4}}
 				<td class="chroma lines-code blob-hunk">{{/*
-					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{/*
 				*/}}</td>
 			{{else}}
 				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">{{/*
 					*/}}{{if and $.root.SignedUserID $.root.PageIsPullFiles}}{{/*
-						*/}}<button type="button" aria-label="{{$.root.locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">{{/*
+						*/}}<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} gt-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">{{/*
 							*/}}{{svg "octicon-plus"}}{{/*
 						*/}}</button>{{/*
 					*/}}{{end}}{{/*
-					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff "locale" $.root.locale}}{{/*
+					*/}}{{template "repo/diff/section_code" dict "diff" $inlineDiff}}{{/*
 				*/}}</td>
 			{{end}}
 		</tr>

--- a/templates/repo/issue/comment_tab.tmpl
+++ b/templates/repo/issue/comment_tab.tmpl
@@ -5,7 +5,6 @@
 
 <div class="field">
 	{{template "shared/combomarkdowneditor" (dict
-		"locale" $.locale
 		"MarkdownPreviewUrl" (print .Repository.Link "/markup")
 		"MarkdownPreviewContext" .RepoLink
 		"TextareaName" "content"

--- a/templates/repo/issue/fields/textarea.tmpl
+++ b/templates/repo/issue/fields/textarea.tmpl
@@ -7,7 +7,6 @@
 
 	{{if $useMarkdownEditor}}
 		{{template "shared/combomarkdowneditor" (dict
-			"locale" .root.locale
 			"ContainerClasses" "gt-hidden"
 			"MarkdownPreviewUrl" (print .root.RepoLink "/markup")
 			"MarkdownPreviewContext" .root.RepoLink

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -26,7 +26,7 @@
 			<form class="list-header-search ui form ignore-dirty">
 				<div class="ui small search fluid action input">
 					<input type="hidden" name="state" value="{{$.State}}">
-					{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword}}
+					{{template "shared/searchinput" dict "Value" .Keyword}}
 					<button class="ui small icon button" type="submit" aria-label="{{.locale.Tr "explore.search"}}">
 						{{svg "octicon-search"}}
 					</button>

--- a/templates/repo/issue/search.tmpl
+++ b/templates/repo/issue/search.tmpl
@@ -7,7 +7,7 @@
 		<input type="hidden" name="project" value="{{$.ProjectID}}">
 		<input type="hidden" name="assignee" value="{{$.AssigneeID}}">
 		<input type="hidden" name="poster" value="{{$.PosterID}}">
-		{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword}}
+		{{template "shared/searchinput" dict "Value" .Keyword}}
 		{{if .PageIsIssueList}}
 			<button id="issue-list-quick-goto" class="ui small icon button gt-hidden" data-tooltip-content="{{.locale.Tr "explore.go_to"}}" data-repo-link="{{.RepoLink}}">{{svg "octicon-hash"}}</button>
 		{{end}}

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -147,7 +147,6 @@
 	<div class="ui comment form">
 		<div class="field">
 			{{template "shared/combomarkdowneditor" (dict
-				"locale" $.locale
 				"MarkdownPreviewUrl" (print .Repository.Link "/markup")
 				"MarkdownPreviewContext" .RepoLink
 				"TextareaName" "content"

--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -7,7 +7,7 @@
 						{{.ctxData.CsrfTokenHtml}}
 					</form>
 					<div class="header">{{.ctxData.locale.Tr "repo.issues.del_time"}}</div>
-					{{template "base/modal_actions_confirm" (dict "locale" .ctxData.locale)}}
+					{{template "base/modal_actions_confirm" .}}
 				</div>
 				<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{.ctxData.locale.Tr "repo.issues.del_time"}}">
 					{{svg "octicon-trash"}}

--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -7,7 +7,7 @@
 						{{.ctxData.CsrfTokenHtml}}
 					</form>
 					<div class="header">{{.ctxData.locale.Tr "repo.issues.del_time"}}</div>
-					{{template "base/modal_actions_confirm" .}}
+					{{template "base/modal_actions_confirm"}}
 				</div>
 				<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{.ctxData.locale.Tr "repo.issues.del_time"}}">
 					{{svg "octicon-trash"}}

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -373,7 +373,7 @@
 			{{end}}
 
 			{{if and .ShowMergeInstructions .Issue.PullRequest.HeadRepo (not .Issue.PullRequest.HasMerged) (not .Issue.IsClosed)}}
-				{{template "repo/issue/view_content/pull_merge_instruction" .}}
+				{{template "repo/issue/view_content/pull_merge_instruction" .Issue.PullRequest}}
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -373,7 +373,7 @@
 			{{end}}
 
 			{{if and .ShowMergeInstructions .Issue.PullRequest.HeadRepo (not .Issue.PullRequest.HasMerged) (not .Issue.IsClosed)}}
-				{{template "repo/issue/view_content/pull_merge_instruction" (dict "locale" .locale "Issue" .Issue)}}
+				{{template "repo/issue/view_content/pull_merge_instruction" .}}
 			{{end}}
 		</div>
 	</div>

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -3,17 +3,17 @@
 <div class="instruct-content gt-mt-3 gt-hidden">
 	<div><h3 class="gt-dib">{{ctx.Locale.Tr "step1"}}</h3> {{ctx.Locale.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
 	<div class="ui secondary segment">
-		{{if eq .PullRequest.Flow 0}}
-		<div>git checkout -b {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}{{.PullRequest.HeadRepo.OwnerName}}-{{end}}{{.PullRequest.HeadBranch}} {{.PullRequest.BaseBranch}}</div>
-		<div>git pull {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}<gitea-origin-url data-url="{{.PullRequest.HeadRepo.Link}}"></gitea-origin-url>{{else}}origin{{end}} {{.PullRequest.HeadBranch}}</div>
+		{{if eq .Flow 0}}
+		<div>git checkout -b {{if ne .HeadRepo.ID .BaseRepo.ID}}{{.HeadRepo.OwnerName}}-{{end}}{{.HeadBranch}} {{.BaseBranch}}</div>
+		<div>git pull {{if ne .HeadRepo.ID .BaseRepo.ID}}<gitea-origin-url data-url="{{.HeadRepo.Link}}"></gitea-origin-url>{{else}}origin{{end}} {{.HeadBranch}}</div>
 		{{else}}
-		<div>git fetch origin {{.PullRequest.GetGitRefName}}:{{.PullRequest.HeadBranch}}</div>
+		<div>git fetch origin {{.GetGitRefName}}:{{.HeadBranch}}</div>
 		{{end}}
 	</div>
 	<div><h3 class="gt-dib">{{ctx.Locale.Tr "step2"}}</h3> {{ctx.Locale.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
 	<div class="ui secondary segment">
-		<div>git checkout {{.PullRequest.BaseBranch}}</div>
-		<div>git merge --no-ff {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}{{.PullRequest.HeadRepo.OwnerName}}-{{end}}{{.PullRequest.HeadBranch}}</div>
-		<div>git push origin {{.PullRequest.BaseBranch}}</div>
+		<div>git checkout {{.BaseBranch}}</div>
+		<div>git merge --no-ff {{if ne .HeadRepo.ID .BaseRepo.ID}}{{.HeadRepo.OwnerName}}-{{end}}{{.HeadBranch}}</div>
+		<div>git push origin {{.BaseBranch}}</div>
 	</div>
 </div>

--- a/templates/repo/issue/view_content/pull_merge_instruction.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_instruction.tmpl
@@ -1,19 +1,19 @@
 <div class="divider"></div>
-<div class="instruct-toggle"> {{$.locale.Tr "repo.pulls.merge_instruction_hint" | Safe}} </div>
+<div class="instruct-toggle"> {{ctx.Locale.Tr "repo.pulls.merge_instruction_hint" | Safe}} </div>
 <div class="instruct-content gt-mt-3 gt-hidden">
-	<div><h3 class="gt-dib">{{$.locale.Tr "step1"}}</h3> {{$.locale.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
+	<div><h3 class="gt-dib">{{ctx.Locale.Tr "step1"}}</h3> {{ctx.Locale.Tr "repo.pulls.merge_instruction_step1_desc"}}</div>
 	<div class="ui secondary segment">
-		{{if eq $.Issue.PullRequest.Flow 0}}
-		<div>git checkout -b {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}} {{$.Issue.PullRequest.BaseBranch}}</div>
-		<div>git pull {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}<gitea-origin-url data-url="{{$.Issue.PullRequest.HeadRepo.Link}}"></gitea-origin-url>{{else}}origin{{end}} {{$.Issue.PullRequest.HeadBranch}}</div>
+		{{if eq .PullRequest.Flow 0}}
+		<div>git checkout -b {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}{{.PullRequest.HeadRepo.OwnerName}}-{{end}}{{.PullRequest.HeadBranch}} {{.PullRequest.BaseBranch}}</div>
+		<div>git pull {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}<gitea-origin-url data-url="{{.PullRequest.HeadRepo.Link}}"></gitea-origin-url>{{else}}origin{{end}} {{.PullRequest.HeadBranch}}</div>
 		{{else}}
-		<div>git fetch origin {{$.Issue.PullRequest.GetGitRefName}}:{{$.Issue.PullRequest.HeadBranch}}</div>
+		<div>git fetch origin {{.PullRequest.GetGitRefName}}:{{.PullRequest.HeadBranch}}</div>
 		{{end}}
 	</div>
-	<div><h3 class="gt-dib">{{$.locale.Tr "step2"}}</h3> {{$.locale.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
+	<div><h3 class="gt-dib">{{ctx.Locale.Tr "step2"}}</h3> {{ctx.Locale.Tr "repo.pulls.merge_instruction_step2_desc"}}</div>
 	<div class="ui secondary segment">
-		<div>git checkout {{$.Issue.PullRequest.BaseBranch}}</div>
-		<div>git merge --no-ff {{if ne $.Issue.PullRequest.HeadRepo.ID $.Issue.PullRequest.BaseRepo.ID}}{{$.Issue.PullRequest.HeadRepo.OwnerName}}-{{end}}{{$.Issue.PullRequest.HeadBranch}}</div>
-		<div>git push origin {{$.Issue.PullRequest.BaseBranch}}</div>
+		<div>git checkout {{.PullRequest.BaseBranch}}</div>
+		<div>git merge --no-ff {{if ne .PullRequest.HeadRepo.ID .PullRequest.BaseRepo.ID}}{{.PullRequest.HeadRepo.OwnerName}}-{{end}}{{.PullRequest.HeadBranch}}</div>
+		<div>git push origin {{.PullRequest.BaseBranch}}</div>
 	</div>
 </div>

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -50,7 +50,6 @@
 				</div>
 				<div class="field">
 					{{template "shared/combomarkdowneditor" (dict
-						"locale" $.locale
 						"MarkdownPreviewUrl" (print .Repository.Link "/markup")
 						"MarkdownPreviewContext" .RepoLink
 						"TextareaName" "content"

--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -44,7 +44,7 @@
 					</p>
 					<form class="ui form" action="{{$.Link}}/delete/{{.Oid}}" method="post">
 						{{$.CsrfTokenHtml}}
-						{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonColors" "yellow")}}
+						{{template "base/modal_actions_confirm" (dict "ModalButtonColors" "yellow")}}
 					</form>
 				</div>
 			</div>

--- a/templates/repo/shabox_badge.tmpl
+++ b/templates/repo/shabox_badge.tmpl
@@ -1,15 +1,15 @@
 <div class="ui detail icon button">
 	{{if .verification.Verified}}
-		<div title="{{if eq .verification.TrustStatus "trusted"}}{{else if eq .verification.TrustStatus "untrusted"}}{{$.root.locale.Tr "repo.commits.signed_by_untrusted_user"}}: {{else}}{{$.root.locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}: {{end}}{{.verification.Reason}}">
+		<div title="{{if eq .verification.TrustStatus "trusted"}}{{else if eq .verification.TrustStatus "untrusted"}}{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user"}}: {{else}}{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}: {{end}}{{.verification.Reason}}">
 		{{if ne .verification.SigningUser.ID 0}}
 			{{svg "gitea-lock"}}
 			{{ctx.AvatarUtils.Avatar .verification.SigningUser 28 "signature"}}
 		{{else}}
-			<span title="{{$.root.locale.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog"}}</span>
+			<span title="{{ctx.Locale.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog"}}</span>
 			{{ctx.AvatarUtils.AvatarByEmail .verification.SigningEmail "" 28 "signature"}}
 		{{end}}
 		</div>
 	{{else}}
-		<span title="{{$.root.locale.Tr .verification.Reason}}">{{svg "gitea-unlock"}}</span>
+		<span title="{{ctx.Locale.Tr .verification.Reason}}">{{svg "gitea-unlock"}}</span>
 	{{end}}
 </div>

--- a/templates/repo/unicode_escape_prompt.tmpl
+++ b/templates/repo/unicode_escape_prompt.tmpl
@@ -3,20 +3,20 @@
 		<div class="ui warning message unicode-escape-prompt gt-text-left">
 			<button class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
 			<div class="header">
-				{{$.root.locale.Tr "repo.invisible_runes_header"}}
+				{{ctx.Locale.Tr "repo.invisible_runes_header"}}
 			</div>
-			<p>{{$.root.locale.Tr "repo.invisible_runes_description" | Str2html}}</p>
+			<p>{{ctx.Locale.Tr "repo.invisible_runes_description" | Str2html}}</p>
 			{{if .EscapeStatus.HasAmbiguous}}
-				<p>{{$.root.locale.Tr "repo.ambiguous_runes_description" | Str2html}}</p>
+				<p>{{ctx.Locale.Tr "repo.ambiguous_runes_description" | Str2html}}</p>
 			{{end}}
 		</div>
 	{{else if .EscapeStatus.HasAmbiguous}}
 		<div class="ui warning message unicode-escape-prompt gt-text-left">
 			<button class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
 			<div class="header">
-				{{$.root.locale.Tr "repo.ambiguous_runes_header"}}
+				{{ctx.Locale.Tr "repo.ambiguous_runes_header"}}
 			</div>
-			<p>{{$.root.locale.Tr "repo.ambiguous_runes_description" | Str2html}}</p>
+			<p>{{ctx.Locale.Tr "repo.ambiguous_runes_description" | Str2html}}</p>
 		</div>
 	{{end}}
 {{end}}

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -23,7 +23,6 @@
 				{{$content = .locale.Tr "repo.wiki.welcome"}}
 			{{end}}
 			{{template "shared/combomarkdowneditor" (dict
-				"locale" $.locale
 				"MarkdownPreviewUrl" (print .Repository.Link "/markup")
 				"MarkdownPreviewContext" .RepoLink
 				"TextareaName" "content"

--- a/templates/shared/actions/runner_list.tmpl
+++ b/templates/shared/actions/runner_list.tmpl
@@ -36,7 +36,7 @@
 		<form class="ui form ignore-dirty" id="user-list-search-form" action="{{$.Link}}">
 			<!-- Search Text -->
 			<div class="ui fluid action input">
-				{{template "shared/searchinput" dict "locale" .locale "Value" .Keyword "AutoFocus" true}}
+				{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 				<button class="ui primary button">{{.locale.Tr "explore.search"}}</button>
 			</div>
 		</form>

--- a/templates/shared/combomarkdowneditor.tmpl
+++ b/templates/shared/combomarkdowneditor.tmpl
@@ -1,6 +1,5 @@
 {{/*
 Template Attributes:
-* locale: passed through for localization
 * ContainerId: id attribute for the container element
 * ContainerClasses: additional classes for the container element
 * MarkdownPreviewUrl: preview url for the preview tab
@@ -15,34 +14,34 @@ Template Attributes:
 <div {{if .ContainerId}}id="{{.ContainerId}}"{{end}} class="combo-markdown-editor {{.ContainerClasses}}" data-dropzone-parent-container="{{.DropzoneParentContainer}}">
 	{{if .MarkdownPreviewUrl}}
 	<div class="ui top tabular menu">
-		<a class="active item" data-tab-for="markdown-writer">{{.locale.Tr "write"}}</a>
-		<a class="item" data-tab-for="markdown-previewer" data-preview-url="{{.MarkdownPreviewUrl}}" data-preview-context="{{.MarkdownPreviewContext}}">{{.locale.Tr "preview"}}</a>
+		<a class="active item" data-tab-for="markdown-writer">{{ctx.Locale.Tr "write"}}</a>
+		<a class="item" data-tab-for="markdown-previewer" data-preview-url="{{.MarkdownPreviewUrl}}" data-preview-context="{{.MarkdownPreviewContext}}">{{ctx.Locale.Tr "preview"}}</a>
 	</div>
 	{{end}}
 	<div class="ui tab active" data-tab-panel="markdown-writer">
 		<markdown-toolbar>
 			<div class="markdown-toolbar-group">
-				<md-header class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.heading.tooltip"}}">{{svg "octicon-heading"}}</md-header>
-				<md-bold class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.bold.tooltip"}}">{{svg "octicon-bold"}}</md-bold>
-				<md-italic class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.italic.tooltip"}}">{{svg "octicon-italic"}}</md-italic>
+				<md-header class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.heading.tooltip"}}">{{svg "octicon-heading"}}</md-header>
+				<md-bold class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.bold.tooltip"}}">{{svg "octicon-bold"}}</md-bold>
+				<md-italic class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.italic.tooltip"}}">{{svg "octicon-italic"}}</md-italic>
 			</div>
 			<div class="markdown-toolbar-group">
-				<md-quote class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.quote.tooltip"}}">{{svg "octicon-quote"}}</md-quote>
-				<md-code class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.code.tooltip"}}">{{svg "octicon-code"}}</md-code>
-				<md-link class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.link.tooltip"}}">{{svg "octicon-link"}}</md-link>
+				<md-quote class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.quote.tooltip"}}">{{svg "octicon-quote"}}</md-quote>
+				<md-code class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.code.tooltip"}}">{{svg "octicon-code"}}</md-code>
+				<md-link class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.link.tooltip"}}">{{svg "octicon-link"}}</md-link>
 			</div>
 			<div class="markdown-toolbar-group">
-				<md-unordered-list class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.list.unordered.tooltip"}}">{{svg "octicon-list-unordered"}}</md-unordered-list>
-				<md-ordered-list class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.list.ordered.tooltip"}}">{{svg "octicon-list-ordered"}}</md-ordered-list>
-				<md-task-list class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.list.task.tooltip"}}">{{svg "octicon-tasklist"}}</md-task-list>
+				<md-unordered-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.unordered.tooltip"}}">{{svg "octicon-list-unordered"}}</md-unordered-list>
+				<md-ordered-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.ordered.tooltip"}}">{{svg "octicon-list-ordered"}}</md-ordered-list>
+				<md-task-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.task.tooltip"}}">{{svg "octicon-tasklist"}}</md-task-list>
 			</div>
 			<div class="markdown-toolbar-group">
-				<md-mention class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.mention.tooltip"}}">{{svg "octicon-mention"}}</md-mention>
-				<md-ref class="markdown-toolbar-button" data-tooltip-content="{{.locale.Tr "editor.buttons.ref.tooltip"}}">{{svg "octicon-cross-reference"}}</md-ref>
+				<md-mention class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.mention.tooltip"}}">{{svg "octicon-mention"}}</md-mention>
+				<md-ref class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.ref.tooltip"}}">{{svg "octicon-cross-reference"}}</md-ref>
 			</div>
 			<div class="markdown-toolbar-group">
-				<button class="markdown-toolbar-button markdown-switch-monospace" role="switch" data-enable-text="{{.locale.Tr "editor.buttons.enable_monospace_font"}}" data-disable-text="{{.locale.Tr "editor.buttons.disable_monospace_font"}}">{{svg "octicon-typography"}}</button>
-				<button class="markdown-toolbar-button markdown-switch-easymde" data-tooltip-content="{{.locale.Tr "editor.buttons.switch_to_legacy.tooltip"}}">{{svg "octicon-arrow-switch"}}</button>
+				<button class="markdown-toolbar-button markdown-switch-monospace" role="switch" data-enable-text="{{ctx.Locale.Tr "editor.buttons.enable_monospace_font"}}" data-disable-text="{{ctx.Locale.Tr "editor.buttons.disable_monospace_font"}}">{{svg "octicon-typography"}}</button>
+				<button class="markdown-toolbar-button markdown-switch-easymde" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.switch_to_legacy.tooltip"}}">{{svg "octicon-arrow-switch"}}</button>
 			</div>
 		</markdown-toolbar>
 		<text-expander keys=": @" suffix="">
@@ -55,6 +54,6 @@ Template Attributes:
 		</script>
 	</div>
 	<div class="ui tab markup" data-tab-panel="markdown-previewer">
-		{{.locale.Tr "loading"}}
+		{{ctx.Locale.Tr "loading"}}
 	</div>
 </div>

--- a/templates/shared/searchinput.tmpl
+++ b/templates/shared/searchinput.tmpl
@@ -1,1 +1,1 @@
-<input type="search" spellcheck="false" name="q" maxlength="255" placeholder="{{.locale.Tr "explore.search"}}…"{{if .Value}} value="{{.Value}}"{{end}}{{if .AutoFocus}} autofocus{{end}}{{if .Disabled}} disabled{{end}}>
+<input type="search" spellcheck="false" name="q" maxlength="255" placeholder="{{ctx.Locale.Tr "explore.search"}}…"{{if .Value}} value="{{.Value}}"{{end}}{{if .AutoFocus}} autofocus{{end}}{{if .Disabled}} disabled{{end}}>

--- a/templates/shared/secrets/add_list.tmpl
+++ b/templates/shared/secrets/add_list.tmpl
@@ -76,6 +76,6 @@
 				></textarea>
 			</div>
 		</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 	</form>
 </div>

--- a/templates/shared/variables/variable_list.tmpl
+++ b/templates/shared/variables/variable_list.tmpl
@@ -86,7 +86,7 @@
 				></textarea>
 			</div>
 		</div>
-		{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonTypes" "confirm")}}
+		{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
 	</form>
 </div>
 

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -77,7 +77,7 @@
 							<input type="hidden" name="repos" value="[{{range $.RepoIDs}}{{.}},{{end}}]">
 							<input type="hidden" name="sort" value="{{$.SortType}}">
 							<input type="hidden" name="state" value="{{$.State}}">
-							{{template "shared/searchinput" dict "locale" .locale "Value" $.Keyword}}
+							{{template "shared/searchinput" dict "Value" $.Keyword}}
 							<button id="issue-list-quick-goto" class="ui small icon button gt-hidden" data-tooltip-content="{{.locale.Tr "explore.go_to"}}">{{svg "octicon-hash"}}</button>
 							<button class="ui small icon button" aria-label="{{.locale.Tr "explore.search"}}">{{svg "octicon-search"}}</button>
 						</div>

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -51,7 +51,7 @@
 							<input type="hidden" name="repos" value="[{{range $.RepoIDs}}{{.}},{{end}}]">
 							<input type="hidden" name="sort" value="{{$.SortType}}">
 							<input type="hidden" name="state" value="{{$.State}}">
-							{{template "shared/searchinput" dict "locale" .locale "Value" $.Keyword}}
+							{{template "shared/searchinput" dict "Value" $.Keyword}}
 							<button class="ui small icon button" type="submit" aria-label="{{.locale.Tr "explore.search"}}">{{svg "octicon-search"}}</button>
 						</div>
 					</form>

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -109,7 +109,7 @@
 	<div class="content">
 		<p>{{.locale.Tr "settings.access_token_deletion_desc"}}</p>
 	</div>
-	{{template "base/modal_actions_confirm" (dict "locale" $.locale "ModalButtonColors" "yellow")}}
+	{{template "base/modal_actions_confirm" (dict "ModalButtonColors" "yellow")}}
 </div>
 
 {{template "user/settings/layout_footer" .}}


### PR DESCRIPTION
Throughout the Gitea codebase, you can meet some weird constructions to make `locale.Tr` work in subtemplates.
Since we now have `ctx.Locale.Tr` which solves that problem, clean up various templates which pass `locale` through `dict` or use some weird constructions like `$.root.locale`

Going on, it would be great to replace every case of `$.locale.Tr` and `.locale.Tr` with `ctx.Locale.Tr`, but that needs to be done with patience.