### PR TITLE
Remove `cancel-in-progress` on release-nightly

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,12 +1,8 @@
-name: release-nightly-assets
+name: release-nightly
 
 on:
   push:
     branches: [ main, release/v* ]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   nightly-binary:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main, release/v* ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   nightly-binary:
     runs-on: actuated-4cpu-16gb


### PR DESCRIPTION
The `release-nightly` tasks take 45+ minutes to complete, if there is another push before this, the build will cancel, which may not desirable here. For example:

https://github.com/go-gitea/gitea/actions/runs/6292064738/job/17081091584

Note there is another issue with this pipeline where a build took more than 6 hours and I think some mechanism cancelled it after that time. I think that worker must have been crashed mid-build or something. For example:

https://github.com/go-gitea/gitea/actions/runs/6284981295/job/17066890382