### PR TITLE
Add missing public user visibility in user details page

### DIFF
--- a/templates/admin/user/view_details.tmpl
+++ b/templates/admin/user/view_details.tmpl
@@ -36,6 +36,7 @@
 			</div>
 			<div class="flex-item-body">
 				<b>{{ctx.Locale.Tr "settings.visibility"}}:</b>
+				{{if .User.Visibility.IsPublic}}{{ctx.Locale.Tr "settings.visibility.public"}}{{end}}
 				{{if .User.Visibility.IsLimited}}{{ctx.Locale.Tr "settings.visibility.limited"}}{{end}}
 				{{if .User.Visibility.IsPrivate}}{{ctx.Locale.Tr "settings.visibility.private"}}{{end}}
 			</div>


### PR DESCRIPTION
It seems that `Public` user visibility is missing in the template.

Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/a8e7f3e0-1b77-41a0-921a-10adba90211e)

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/b0bffe13-0ca6-453e-95d7-0794528d5733)
