### PR TITLE
Fix user labels are invisible

### DIFF
--- a/web_src/js/modules/fomantic.js
+++ b/web_src/js/modules/fomantic.js
@@ -38,7 +38,7 @@ export function initGiteaFomantic() {
     const isScale = arg?.animation?.includes('scale');
 
     let ret;
-    if (arg === 'show' || isIn || isScale) {
+    if (arg === 'show' || isIn) {
       arg?.onStart?.(this);
       ret = this.each((_, el) => {
         el.classList.remove('hidden');
@@ -58,8 +58,22 @@ export function initGiteaFomantic() {
         arg?.onHidden?.(this);
       });
       arg?.onComplete?.(this);
+    } else if (isScale) {
+      arg?.onStart?.(this);
+      ret = this.each((_, el) => {
+        if (el.classList.contains('hidden')) {
+          el.classList.remove('hidden');
+          el.classList.add('visible');
+          arg?.onShow?.(this);
+        } else if (el.classList.contains('visible')) {
+          el.classList.remove('visible');
+          el.classList.add('hidden');
+          el.style.removeProperty('display');
+          arg?.onHidden?.(this);
+        }
+      });
+      arg.onComplete?.(this);
     }
-
     return ret;
   };
 

--- a/web_src/js/modules/fomantic.js
+++ b/web_src/js/modules/fomantic.js
@@ -35,9 +35,10 @@ export function initGiteaFomantic() {
 
     const isIn = arg?.animation?.endsWith(' in');
     const isOut = arg?.animation?.endsWith(' out');
+    const isScale = arg?.animation?.includes('scale');
 
     let ret;
-    if (arg === 'show' || isIn) {
+    if (arg === 'show' || isIn || isScale) {
       arg?.onStart?.(this);
       ret = this.each((_, el) => {
         el.classList.remove('hidden');


### PR DESCRIPTION
Currently, when editing whitelists of protected branch rules in the repo setting, the user labels are invisible.
![ksnip_20230926-174106](https://github.com/go-gitea/gitea/assets/70063547/209aa4af-e294-4480-a665-7a4b7c02645a)
That's because the transition module is removed and couldn't handle "transition: scale".
This PR adds the code logic to handle this case and fix the bug.
![ksnip_20230926-171411](https://github.com/go-gitea/gitea/assets/70063547/4c43c91d-4449-4ef8-a34a-1da8a18ce524)
