### PR TITLE
Enable production source maps for index.js, fix CSS sourcemaps

### DIFF
--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -261,7 +261,7 @@ make build
 
 ## Source Maps
 
-By default, gitea generated reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
+By default, gitea generates reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
 
 - `SOURCEMAPS=full` generates all source maps
 - `SOURCEMAPS=reduced` generates limited source maps, the default for production builds

--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -264,5 +264,5 @@ make build
 By default, gitea generated reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
 
 - `SOURCEMAPS=full` generates all source maps
-- `SOURCEMAPS=reduced` generates limited source maps, the default
-- `SOURCEMAPS=none` generates no source maps
+- `SOURCEMAPS=reduced` generates limited source maps, the default for production builds
+- `SOURCEMAPS=none` generates no source maps, the default for development builds

--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -128,7 +128,7 @@ If pre-built frontend files are present it is possible to only build the backend
 TAGS="bindata" make backend
 ```
 
-Webpack source maps are by default enabled in development builds and disabled in production builds. They can be enabled by setting the `ENABLE_SOURCEMAP=true` environment variable.
+Webpack source maps are limited by default to conserve space. When `ENABLE_SOURCEMAP=true` is set, the webpack build will generate all source maps.
 
 ## Test
 

--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -263,6 +263,6 @@ make build
 
 By default, gitea generates reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
 
-- `SOURCEMAPS=full` generates all source maps
+- `SOURCEMAPS=full` generates all source maps, the default for development builds
 - `SOURCEMAPS=reduced` generates limited source maps, the default for production builds
-- `SOURCEMAPS=none` generates no source maps, the default for development builds
+- `SOURCEMAPS=none` generates no source maps

--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -261,8 +261,8 @@ make build
 
 ## Source Maps
 
-By default, gitea generates reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
+By default, gitea generates reduced source maps for frontend files to conserve space. This can be controlled with the `ENABLE_SOURCEMAP` environment variable:
 
-- `SOURCEMAPS=full` generates all source maps, the default for development builds
-- `SOURCEMAPS=reduced` generates limited source maps, the default for production builds
-- `SOURCEMAPS=none` generates no source maps
+- `ENABLE_SOURCEMAP=true` generates all source maps, the default for development builds
+- `ENABLE_SOURCEMAP=reduced` generates limited source maps, the default for production builds
+- `ENABLE_SOURCEMAP=false` generates no source maps

--- a/docs/content/installation/from-source.en-us.md
+++ b/docs/content/installation/from-source.en-us.md
@@ -128,8 +128,6 @@ If pre-built frontend files are present it is possible to only build the backend
 TAGS="bindata" make backend
 ```
 
-Webpack source maps are limited by default to conserve space. When `ENABLE_SOURCEMAP=true` is set, the webpack build will generate all source maps.
-
 ## Test
 
 After following the steps above, a `gitea` binary will be available in the working directory.
@@ -260,3 +258,11 @@ GOARCH=amd64 \
 TAGS="bindata sqlite sqlite_unlock_notify" \
 make build
 ```
+
+## Source Maps
+
+By default, gitea generated reduced source maps for frontend files to conserve space. This can be controlled with the `SOURCEMAPS` environment variable:
+
+- `SOURCEMAPS=full` generates all source maps
+- `SOURCEMAPS=reduced` generates limited source maps, the default
+- `SOURCEMAPS=none` generates no source maps

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -222,8 +222,8 @@ make build
 
 ## 源映射
 
-默认情况下，gitea 会为前端文件生成精简的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
+默认情况下，gitea 会为前端文件生成精简的源映射以节省空间。 这可以通过“ENABLE_SOURCEMAP”环境变量进行控制：
 
-- `SOURCEMAPS=full` 生成所有源映射，这是开发版本的默认设置
-- `SOURCEMAPS=reduced` 生成有限的源映射，这是生产版本的默认设置
-- `SOURCEMAPS=none` 不生成源映射
+- `ENABLE_SOURCEMAP=true` 生成所有源映射，这是开发版本的默认设置
+- `ENABLE_SOURCEMAP=reduced` 生成有限的源映射，这是生产版本的默认设置
+- `ENABLE_SOURCEMAP=false` 不生成源映射

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -100,8 +100,6 @@ TAGS="bindata sqlite sqlite_unlock_notify" make build
 TAGS="bindata" make backend
 ```
 
-默认情况下，Webpack 源映射受到限制以节省空间。 当设置`ENABLE_SOURCEMAP=true`时，webpack 构建将生成所有源映射。
-
 ## 测试
 
 按照上述步骤完成后，工作目录中将会有一个`gitea`二进制文件。可以从该目录进行测试，或将其移动到带有测试数据的目录中。当手动从命令行启动 Gitea 时，可以通过按下`Ctrl + C`来停止程序。
@@ -221,3 +219,11 @@ GOARCH=amd64 \
 TAGS="bindata sqlite sqlite_unlock_notify" \
 make build
 ```
+
+## 源映射
+
+默认情况下，gitea 为前端文件生成缩减的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
+
+- `SOURCEMAPS=full` 生成所有源映射
+- `SOURCEMAPS=reduced` 生成有限的源映射，默认值
+- `SOURCEMAPS=none` 不生成源映射

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -225,5 +225,5 @@ make build
 默认情况下，gitea 为前端文件生成缩减的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
 
 - `SOURCEMAPS=full` 生成所有源映射
-- `SOURCEMAPS=reduced` 生成有限的源映射，默认值
-- `SOURCEMAPS=none` 不生成源映射
+- `SOURCEMAPS=reduced` 生成有限的源映射，这是生产版本的默认设置
+- `SOURCEMAPS=none` 不生成源映射，这是开发版本的默认设置

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -100,7 +100,7 @@ TAGS="bindata sqlite sqlite_unlock_notify" make build
 TAGS="bindata" make backend
 ```
 
-在开发构建中，默认启用 Webpack 源映射，在生产构建中禁用。可以通过设置`ENABLE_SOURCEMAP=true`环境变量来启用它们。
+默认情况下，Webpack 源映射受到限制以节省空间。 当设置`ENABLE_SOURCEMAP=true`时，webpack 构建将生成所有源映射。
 
 ## 测试
 

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -224,6 +224,6 @@ make build
 
 默认情况下，gitea 会为前端文件生成精简的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
 
-- `SOURCEMAPS=full` 生成所有源映射
+- `SOURCEMAPS=full` 生成所有源映射，这是开发版本的默认设置
 - `SOURCEMAPS=reduced` 生成有限的源映射，这是生产版本的默认设置
-- `SOURCEMAPS=none` 不生成源映射，这是开发版本的默认设置
+- `SOURCEMAPS=none` 不生成源映射

--- a/docs/content/installation/from-source.zh-cn.md
+++ b/docs/content/installation/from-source.zh-cn.md
@@ -222,7 +222,7 @@ make build
 
 ## 源映射
 
-默认情况下，gitea 为前端文件生成缩减的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
+默认情况下，gitea 会为前端文件生成精简的源映射以节省空间。 这可以通过“SOURCEMAPS”环境变量进行控制：
 
 - `SOURCEMAPS=full` 生成所有源映射
 - `SOURCEMAPS=reduced` 生成有限的源映射，这是生产版本的默认设置

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,15 +28,15 @@ for (const path of glob('web_src/css/themes/*.css')) {
 
 const isProduction = env.NODE_ENV !== 'development';
 
-// SOURCEMAPS accepts the following values:
-// "full" - all enabled, the default in development
+// ENABLE_SOURCEMAP accepts the following values:
+// "true" - all enabled, the default in development
 // "reduced" - minimal sourcemaps, the default in production
-// "none" - all disabled
+// "false" - all disabled
 let sourceMaps;
-if ('SOURCEMAPS' in env) {
-  sourceMaps = ['none', 'full'].includes(env.SOURCEMAPS) ? env.SOURCEMAPS : 'reduced';
+if ('ENABLE_SOURCEMAP' in env) {
+  sourceMaps = ['true', 'false'].includes(env.ENABLE_SOURCEMAP) ? env.ENABLE_SOURCEMAP : 'reduced';
 } else {
-  sourceMaps = isProduction ? 'reduced' : 'full';
+  sourceMaps = isProduction ? 'reduced' : 'true';
 }
 
 const filterCssImport = (url, ...args) => {
@@ -110,7 +110,7 @@ export default {
         legalComments: 'none',
       }),
       LightningCssMinifyPlugin && new LightningCssMinifyPlugin({
-        sourceMap: sourceMaps === 'full',
+        sourceMap: sourceMaps === 'true',
       }),
     ],
     splitChunks: {
@@ -149,7 +149,7 @@ export default {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: sourceMaps === 'full',
+              sourceMap: sourceMaps === 'true',
               url: {filter: filterCssImport},
               import: {filter: filterCssImport},
             },
@@ -187,7 +187,7 @@ export default {
       filename: 'css/[name].css',
       chunkFilename: 'css/[name].[contenthash:8].css',
     }),
-    sourceMaps !== 'none' && new SourceMapDevToolPlugin({
+    sourceMaps !== 'false' && new SourceMapDevToolPlugin({
       filename: '[file].[contenthash:8].map',
       ...(sourceMaps === 'reduced' && {include: /^js\/index\.js$/}),
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,8 @@ for (const path of glob('web_src/css/themes/*.css')) {
 const isProduction = env.NODE_ENV !== 'development';
 
 // SOURCEMAPS accepts the following values:
-// "reduced" - minimal sourcemaps, the default in production
 // "full" - all enabled, the default in development
+// "reduced" - minimal sourcemaps, the default in production
 // "none" - all disabled
 let sourceMaps;
 if ('SOURCEMAPS' in env) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,9 +29,9 @@ for (const path of glob('web_src/css/themes/*.css')) {
 const isProduction = env.NODE_ENV !== 'development';
 
 // SOURCEMAPS accepts the following values:
-// "none" - all disabled
 // "reduced" - minimal sourcemaps, the default in production
 // "full" - all enabled, the default in development
+// "none" - all disabled
 let sourceMaps;
 if ('SOURCEMAPS' in env) {
   sourceMaps = ['none', 'full'].includes(env.SOURCEMAPS) ? env.SOURCEMAPS : 'reduced';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,9 +29,9 @@ for (const path of glob('web_src/css/themes/*.css')) {
 const isProduction = env.NODE_ENV !== 'development';
 
 // ENABLE_SOURCEMAP accepts the following values:
-// "true" - all enabled, the default in development
-// "reduced" - minimal sourcemaps, the default in production
-// "false" - all disabled
+// true - all enabled, the default in development
+// reduced - minimal sourcemaps, the default in production
+// false - all disabled
 let sourceMaps;
 if ('ENABLE_SOURCEMAP' in env) {
   sourceMaps = ['true', 'false'].includes(env.ENABLE_SOURCEMAP) ? env.ENABLE_SOURCEMAP : 'reduced';


### PR DESCRIPTION
Previously, the production build never output sourcemaps. Now we emit one file for `index.js` because it is the most likely one where we need to be able to better debug reported issues like https://github.com/go-gitea/gitea/issues/27213. This will currently increase the binary size of gitea by around 700kB which is what the gzipped source map file has.

Also, I fixed the CSS sourcemap generation which was broken since the introduction of lightningcss.

The chinese docs are machine-translated, please correct accordingly.