### PR TITLE
fix(docs): Update default database value

### DIFF
--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -422,7 +422,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 
 ## Database (`database`)
 
-- `DB_TYPE`: **mysql**: The database type in use \[mysql, postgres, mssql, sqlite3\].
+- `DB_TYPE`: **sqlite3**: The database type in use \[mysql, postgres, mssql, sqlite3\].
 - `HOST`: **127.0.0.1:3306**: Database host address and port or absolute path for unix socket \[mysql, postgres\] (ex: /var/run/mysqld/mysqld.sock).
 - `NAME`: **gitea**: Database name.
 - `USER`: **root**: Database username.

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -414,7 +414,7 @@ menu:
 
 ## 数据库 (`database`)
 
-- `DB_TYPE`: **mysql**：数据库类型 \[mysql, postgres, mssql, sqlite3\]。
+- `DB_TYPE`: **sqlite3**：数据库类型 \[mysql, postgres, mssql, sqlite3\]。
 - `HOST`: **127.0.0.1:3306**：数据库主机地址和端口或unix套接字的绝对路径 \[mysql, postgres\]（例如：/var/run/mysqld/mysqld.sock）。
 - `NAME`: **gitea**：数据库名称。
 - `USER`: **root**：数据库用户名。


### PR DESCRIPTION
When I read [Basics installation with Docker](https://docs.gitea.com/installation/install-with-docker#basics) I understand `SQLite` is used [by default](https://github.com/go-gitea/gitea/blob/72c68177ab78d026d25a0a440c35cdbc9723cd98/docker/root/etc/s6/gitea/setup#L45) but when I read [Configuration Cheat Sheet](https://docs.gitea.com/administration/config-cheat-sheet#database-database) I see `mysql` on DB_TYPE default value. It's only for Docker ?

So with this commit, I would like restore the truth 😇
