### PR TITLE
Differentiate between `push` and `pull` `mirror sync in progress`

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2009,8 +2009,8 @@ settings.mirror_settings.push_mirror.add = Add Push Mirror
 settings.mirror_settings.push_mirror.edit_sync_time = Edit mirror sync interval
 
 settings.sync_mirror = Synchronize Now
-settings.pull_mirror_sync_in_progress = Syncing changes from the remote %s is currently in progress.
-settings.push_mirror_sync_in_progress = Pushing changes to the push mirror %s at the moment.
+settings.pull_mirror_sync_in_progress = Pulling changes from the remote %s at the moment.
+settings.push_mirror_sync_in_progress = Pushing changes to the remote %s at the moment.
 settings.site = Website
 settings.update_settings = Update Settings
 settings.update_mirror_settings = Update Mirror Settings

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2009,7 +2009,8 @@ settings.mirror_settings.push_mirror.add = Add Push Mirror
 settings.mirror_settings.push_mirror.edit_sync_time = Edit mirror sync interval
 
 settings.sync_mirror = Synchronize Now
-settings.mirror_sync_in_progress = Mirror synchronization is in progress. Check back in a minute.
+settings.pull_mirror_sync_in_progress = Syncing changes from the remote %s is currently in progress.
+settings.push_mirror_sync_in_progress = Pushing changes to the push mirror %s at the moment.
 settings.site = Website
 settings.update_settings = Update Settings
 settings.update_mirror_settings = Update Mirror Settings

--- a/routers/web/repo/setting/setting.go
+++ b/routers/web/repo/setting/setting.go
@@ -285,7 +285,7 @@ func SettingsPost(ctx *context.Context) {
 
 		mirror_service.AddPullMirrorToQueue(repo.ID)
 
-		ctx.Flash.Info(ctx.Tr("repo.settings.mirror_sync_in_progress"))
+		ctx.Flash.Info(ctx.Tr("repo.settings.pull_mirror_sync_in_progress", repo.OriginalURL))
 		ctx.Redirect(repo.Link() + "/settings")
 
 	case "push-mirror-sync":
@@ -302,7 +302,7 @@ func SettingsPost(ctx *context.Context) {
 
 		mirror_service.AddPushMirrorToQueue(m.ID)
 
-		ctx.Flash.Info(ctx.Tr("repo.settings.mirror_sync_in_progress"))
+		ctx.Flash.Info(ctx.Tr("repo.settings.push_mirror_sync_in_progress", m.RemoteAddress))
 		ctx.Redirect(repo.Link() + "/settings")
 
 	case "push-mirror-update":

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -592,7 +592,7 @@ func checkAndUpdateEmptyRepository(m *repo_model.Mirror, gitRepo *git.Repository
 		if err := gitRepo.SetDefaultBranch(m.Repo.DefaultBranch); err != nil {
 			if !git.IsErrUnsupportedVersion(err) {
 				log.Error("Failed to update default branch of underlying git repository %-v. Error: %v", m.Repo, err)
-				desc := fmt.Sprintf("Failed to uupdate default branch of underlying git repository '%s': %v", m.Repo.RepoPath(), err)
+				desc := fmt.Sprintf("Failed to update default branch of underlying git repository '%s': %v", m.Repo.RepoPath(), err)
 				if err = system_model.CreateRepositoryNotice(desc); err != nil {
 					log.Error("CreateRepositoryNotice: %v", err)
 				}
@@ -603,7 +603,7 @@ func checkAndUpdateEmptyRepository(m *repo_model.Mirror, gitRepo *git.Repository
 		// Update the is empty and default_branch columns
 		if err := repo_model.UpdateRepositoryCols(db.DefaultContext, m.Repo, "default_branch", "is_empty"); err != nil {
 			log.Error("Failed to update default branch of repository %-v. Error: %v", m.Repo, err)
-			desc := fmt.Sprintf("Failed to uupdate default branch of repository '%s': %v", m.Repo.RepoPath(), err)
+			desc := fmt.Sprintf("Failed to update default branch of repository '%s': %v", m.Repo.RepoPath(), err)
 			if err = system_model.CreateRepositoryNotice(desc); err != nil {
 				log.Error("CreateRepositoryNotice: %v", err)
 			}


### PR DESCRIPTION
Previously, if you had both a push and a pull mirror, the message did not clarify if you've accidentally synchronized the wrong one.
Additionally fixed two typos that were encountered while debugging.

## Screenshots
![grafik](https://github.com/go-gitea/gitea/assets/51889757/06543198-431f-4086-8d3c-48510f860ec1)
![grafik](https://github.com/go-gitea/gitea/assets/51889757/bd0b2de8-dc6f-4683-8ebd-7afa207435e9)
