### PR TITLE
Show `🚫` on the last line when a file does not end with `\n`

### DIFF
--- a/modules/highlight/highlight_test.go
+++ b/modules/highlight/highlight_test.go
@@ -4,6 +4,7 @@
 package highlight
 
 import (
+	"html/template"
 	"strings"
 	"testing"
 
@@ -12,6 +13,16 @@ import (
 
 func lines(s string) []string {
 	return strings.Split(strings.ReplaceAll(strings.TrimSpace(s), `\n`, "\n"), "\n")
+}
+
+func join(lines []template.HTML, sep string) (s string) {
+	for i, line := range lines {
+		s += string(line)
+		if i != len(lines)-1 {
+			s += sep
+		}
+	}
+	return s
 }
 
 func TestFile(t *testing.T) {
@@ -97,13 +108,13 @@ c=2
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, lexerName, err := File(tt.name, "", []byte(tt.code))
+			out, err := File(tt.name, "", []byte(tt.code))
 			assert.NoError(t, err)
 			expected := strings.Join(tt.want, "\n")
-			actual := strings.Join(out, "\n")
+			actual := join(out.HTMLLines, "\n")
 			assert.Equal(t, strings.Count(actual, "<span"), strings.Count(actual, "</span>"))
 			assert.EqualValues(t, expected, actual)
-			assert.Equal(t, tt.lexerName, lexerName)
+			assert.Equal(t, tt.lexerName, out.LexerName)
 		})
 	}
 }
@@ -166,7 +177,7 @@ c=2`),
 		t.Run(tt.name, func(t *testing.T) {
 			out := PlainText([]byte(tt.code))
 			expected := strings.Join(tt.want, "\n")
-			actual := strings.Join(out, "\n")
+			actual := join(out.HTMLLines, "\n")
 			assert.EqualValues(t, expected, actual)
 		})
 	}

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -114,6 +114,7 @@ step2 = Step 2:
 error = Error
 error404 = The page you are trying to reach either <strong>does not exist</strong> or <strong>you are not authorized</strong> to view it.
 go_back = Go Back
+file_missing_final_newline = No newline at end of file
 
 never = Never
 unknown = Unknown

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -535,7 +535,8 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 			//   empty: 0 lines; "a": 1 incomplete-line; "a\n": 1 line; "a\nb": 1 line, 1 incomplete-line;
 			// Gitea uses the definition (like most modern editors):
 			//   empty: 0 lines; "a": 1 line; "a\n": 2 lines (only 1 line is rendered); "a\nb": 2 lines;
-			//   When rendering, the last empty line is not rendered on UI, there is an icon mark to indicate that there is no trailing EOL
+			//   When rendering, the last empty line is not rendered on UI, so "a\n" will be only rendered as one line on the UI.
+			//   If the content doesn't end with an EOL, there will be an icon mark at the end of last line to distinguish from the case above.
 			// This NumLines is only used for the display purpose on the UI: "xxx lines"
 			if len(buf) == 0 {
 				ctx.Data["NumLines"] = 0

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -110,7 +110,7 @@
 								<td class="lines-escape">{{if (index $.LineEscapeStatus $idx).Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{if (index $.LineEscapeStatus $idx).HasInvisible}}{{ctx.Locale.Tr "repo.invisible_runes_line"}} {{end}}{{if (index $.LineEscapeStatus $idx).HasAmbiguous}}{{ctx.Locale.Tr "repo.ambiguous_runes_line"}}{{end}}"></button>{{end}}</td>
 							{{end}}
 							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$codeHTML}}</code>
-								{{- if $.FileContentLines.ShouldShowIncompleteMark $idx -}}<span class="text red unselectable gt-ml-2">🚫</span>{{- end -}}
+								{{- if $.FileContentLines.ShouldShowIncompleteMark $idx -}}<span class="text red gt-ml-2" data-tooltip-content="{{ctx.Locale.Tr "file_missing_final_newline"}}">{{svg "octicon-no-entry" 14}}</span>{{- end -}}
 							</td>
 						</tr>
 						{{end}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -109,7 +109,9 @@
 							{{if $.EscapeStatus.Escaped}}
 								<td class="lines-escape">{{if (index $.LineEscapeStatus $idx).Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{if (index $.LineEscapeStatus $idx).HasInvisible}}{{ctx.Locale.Tr "repo.invisible_runes_line"}} {{end}}{{if (index $.LineEscapeStatus $idx).HasAmbiguous}}{{ctx.Locale.Tr "repo.ambiguous_runes_line"}}{{end}}"></button>{{end}}</td>
 							{{end}}
-							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$codeHTML}}</code>{{if $.FileContentLines.ShouldShowIncompleteMark $idx}}<span class="text red unselectable gt-ml-2">🚫</span>{{end}}</td>
+							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$codeHTML}}</code>
+								{{- if $.FileContentLines.ShouldShowIncompleteMark $idx -}}<span class="text red unselectable gt-ml-2">🚫</span>{{- end -}}
+							</td>
 						</tr>
 						{{end}}
 					</tbody>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -102,14 +102,14 @@
 				{{else}}
 				<table>
 					<tbody>
-						{{range $idx, $code := .FileContent}}
+						{{range $idx, $codeHTML := .FileContentLines.HTMLLines}}
 						{{$line := Eval $idx "+" 1}}
 						<tr>
 							<td id="L{{$line}}" class="lines-num"><span id="L{{$line}}" data-line-number="{{$line}}"></span></td>
 							{{if $.EscapeStatus.Escaped}}
 								<td class="lines-escape">{{if (index $.LineEscapeStatus $idx).Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{if (index $.LineEscapeStatus $idx).HasInvisible}}{{ctx.Locale.Tr "repo.invisible_runes_line"}} {{end}}{{if (index $.LineEscapeStatus $idx).HasAmbiguous}}{{ctx.Locale.Tr "repo.ambiguous_runes_line"}}{{end}}"></button>{{end}}</td>
 							{{end}}
-							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$code | Safe}}</code></td>
+							<td rel="L{{$line}}" class="lines-code chroma"><code class="code-inner">{{$codeHTML}}</code>{{if $.FileContentLines.ShouldShowIncompleteMark $idx}}<span class="text red unselectable gt-ml-2">🚫</span>{{end}}</td>
 						</tr>
 						{{end}}
 					</tbody>

--- a/web_src/js/features/copycontent.js
+++ b/web_src/js/features/copycontent.js
@@ -36,7 +36,7 @@ export function initCopyContent() {
         btn.classList.remove('is-loading', 'small-loading-icon');
       }
     } else { // text, read from DOM
-      const lineEls = document.querySelectorAll('.file-view .lines-code');
+      const lineEls = document.querySelectorAll('.file-view .lines-code .code-inner');
       content = Array.from(lineEls, (el) => el.textContent).join('');
     }
 


### PR DESCRIPTION
Follow my comment https://github.com/go-gitea/gitea/pull/19967#issuecomment-1184115968 

> If users want to hide the last empty line or show a block emoji (🚫) for no-newline when rendering, the new code is easier to do so in the future.

Changed the line-counting behavior to not count the last empty line on the UI. And add the "no EOL" mark to the last line.

```
// Gitea uses the definition (like most modern editors):
//   empty: 0 lines; "a": 1 line; "a\n": 2 lines (only 1 line is rendered); "a\nb": 2 lines;
//   When rendering, the last empty line is not rendered on UI, so "a\n" will be only rendered as one line on the UI.
//   If the content doesn't end with an EOL, there will be an icon mark at the end of last line to distinguish from the case above.
```

![image](https://github.com/go-gitea/gitea/assets/2114189/46bcfe12-9874-4e32-b9cf-1340a3ed7d8a)