### PR TITLE
Fix git 2.11 error when checking IsEmpty (again)

### DIFF
--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -86,7 +86,7 @@ func (repo *Repository) IsEmpty() (bool, error) {
 			Stdout: &output,
 			Stderr: &errbuf,
 		}); err != nil {
-		if (err.Error() == "exit status 1" || err.Error() == "exit status 129") && strings.TrimSpace(errbuf.String()) == "" {
+		if (err.Error() == "exit status 1" && strings.TrimSpace(errbuf.String()) == "") || err.Error() == "exit status 129" {
 			// git 2.11 exits with 129 if the repo is empty
 			return true, nil
 		}


### PR DESCRIPTION
Follow  #27393

Sorry that I made a mistake in  #27393. The `errbuf` is not empty when the err is `exit status 129`.