### PR TITLE
Remove .exe suffix when cross-compiling on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 ifeq ($(GOOS),windows)
 	IS_WINDOWS := yes
-else ifeq ($(findstring Windows,$(OS)),Windows)
+else ifeq ($(patsubst Windows%,Windows,$(OS)),Windows)
 	ifeq ($(GOOS),)
 		IS_WINDOWS := yes
 	endif

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,14 @@ ifeq ($(HAS_GO), yes)
 	CGO_CFLAGS ?= $(shell $(GO) env CGO_CFLAGS) $(CGO_EXTRA_CFLAGS)
 endif
 
-ifeq ($(OS), Windows_NT)
-	GOFLAGS := -v -buildmode=exe
-	EXECUTABLE ?= gitea.exe
-else ifeq ($(OS), Windows)
+ifeq ($(GOOS),windows)
+	IS_WINDOWS := yes
+else ifeq ($(findstring Windows,$(OS)),Windows)
+	ifeq ($(GOOS),)
+		IS_WINDOWS := yes
+	endif
+endif
+ifeq ($(IS_WINDOWS),yes)
 	GOFLAGS := -v -buildmode=exe
 	EXECUTABLE ?= gitea.exe
 else


### PR DESCRIPTION
When compiling GItea for Linux on Windows, you get a `gitea.exe` file as output, but because it's a Linux executable, the `.exe` extension is unnecessary.

This PR adds a check for `GOOS` environment variable in addition to `OS`.
