### PR TITLE
fix wording in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Please **DO NOT** file a public issue, instead send your report privately to `se
 
 ## Protecting Security Information
 
-Due to the sensitive nature of security information, you can use below GPG public key encrypt your mail body.
+Due to the sensitive nature of security information, you can use the below GPG public key encrypt to your mail body.
 
 The PGP key is valid until June 24, 2024.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Please **DO NOT** file a public issue, instead send your report privately to `se
 
 ## Protecting Security Information
 
-Due to the sensitive nature of security information, you can use the below GPG public key encrypt to your mail body.
+Due to the sensitive nature of security information, you can use the below GPG public key to encrypt your mail body.
 
 The PGP key is valid until June 24, 2024.
 


### PR DESCRIPTION
This pull request only makes two slight changes in the wording introducing the GPG public key:

"Due to the sensitive nature of security information, you can use **the** below GPG public key **to** encrypt your mail body."

No code is affected.