### PR TITLE
Remove redundant `len` check around loop

### DIFF
--- a/modules/git/repo_commit.go
+++ b/modules/git/repo_commit.go
@@ -116,17 +116,13 @@ func (repo *Repository) searchCommits(id SHA1, opts SearchCommitsOptions) ([]*Co
 		c.AddArguments("-i")
 
 		// add authors if present in search query
-		if len(opts.Authors) > 0 {
-			for _, v := range opts.Authors {
-				c.AddOptionFormat("--author=%s", v)
-			}
+		for _, v := range opts.Authors {
+			c.AddOptionFormat("--author=%s", v)
 		}
 
 		// add committers if present in search query
-		if len(opts.Committers) > 0 {
-			for _, v := range opts.Committers {
-				c.AddOptionFormat("--committer=%s", v)
-			}
+		for _, v := range opts.Committers {
+			c.AddOptionFormat("--committer=%s", v)
 		}
 
 		// add time constraints if present in search query
@@ -150,10 +146,8 @@ func (repo *Repository) searchCommits(id SHA1, opts SearchCommitsOptions) ([]*Co
 
 	// add remaining keywords from search string
 	// note this is done only for command created above
-	if len(opts.Keywords) > 0 {
-		for _, v := range opts.Keywords {
-			cmd.AddOptionFormat("--grep=%s", v)
-		}
+	for _, v := range opts.Keywords {
+		cmd.AddOptionFormat("--grep=%s", v)
 	}
 
 	// search for commits matching given constraints and keywords in commit msg
@@ -168,25 +162,23 @@ func (repo *Repository) searchCommits(id SHA1, opts SearchCommitsOptions) ([]*Co
 
 	// if there are any keywords (ie not committer:, author:, time:)
 	// then let's iterate over them
-	if len(opts.Keywords) > 0 {
-		for _, v := range opts.Keywords {
-			// ignore anything not matching a valid sha pattern
-			if IsValidSHAPattern(v) {
-				// create new git log command with 1 commit limit
-				hashCmd := NewCommand(repo.Ctx, "log", "-1", prettyLogFormat)
-				// add previous arguments except for --grep and --all
-				addCommonSearchArgs(hashCmd)
-				// add keyword as <commit>
-				hashCmd.AddDynamicArguments(v)
+	for _, v := range opts.Keywords {
+		// ignore anything not matching a valid sha pattern
+		if IsValidSHAPattern(v) {
+			// create new git log command with 1 commit limit
+			hashCmd := NewCommand(repo.Ctx, "log", "-1", prettyLogFormat)
+			// add previous arguments except for --grep and --all
+			addCommonSearchArgs(hashCmd)
+			// add keyword as <commit>
+			hashCmd.AddDynamicArguments(v)
 
-				// search with given constraints for commit matching sha hash of v
-				hashMatching, _, err := hashCmd.RunStdBytes(&RunOpts{Dir: repo.Path})
-				if err != nil || bytes.Contains(stdout, hashMatching) {
-					continue
-				}
-				stdout = append(stdout, hashMatching...)
-				stdout = append(stdout, '\n')
+			// search with given constraints for commit matching sha hash of v
+			hashMatching, _, err := hashCmd.RunStdBytes(&RunOpts{Dir: repo.Path})
+			if err != nil || bytes.Contains(stdout, hashMatching) {
+				continue
 			}
+			stdout = append(stdout, hashMatching...)
+			stdout = append(stdout, '\n')
 		}
 	}
 

--- a/modules/setting/config_provider.go
+++ b/modules/setting/config_provider.go
@@ -213,11 +213,9 @@ func NewConfigProviderFromFile(file string, extraConfigs ...string) (ConfigProvi
 		}
 	}
 
-	if len(extraConfigs) > 0 {
-		for _, s := range extraConfigs {
-			if err := cfg.Append([]byte(s)); err != nil {
-				return nil, fmt.Errorf("unable to append more config: %v", err)
-			}
+	for _, s := range extraConfigs {
+		if err := cfg.Append([]byte(s)); err != nil {
+			return nil, fmt.Errorf("unable to append more config: %v", err)
 		}
 	}
 

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -965,10 +965,8 @@ func NewIssue(ctx *context.Context) {
 
 	_, templateErrs := issue_service.GetTemplatesFromDefaultBranch(ctx.Repo.Repository, ctx.Repo.GitRepo)
 	templateLoaded, errs := setTemplateIfExists(ctx, issueTemplateKey, IssueTemplateCandidates)
-	if len(errs) > 0 {
-		for k, v := range errs {
-			templateErrs[k] = v
-		}
+	for k, v := range errs {
+		templateErrs[k] = v
 	}
 	if ctx.Written() {
 		return

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -152,14 +152,12 @@ func NewPullRequest(ctx context.Context, repo *repo_model.Repository, issue *iss
 	if issue.Milestone != nil {
 		notify_service.IssueChangeMilestone(ctx, issue.Poster, issue, 0)
 	}
-	if len(assigneeIDs) > 0 {
-		for _, assigneeID := range assigneeIDs {
-			assignee, err := user_model.GetUserByID(ctx, assigneeID)
-			if err != nil {
-				return ErrDependenciesLeft
-			}
-			notify_service.IssueChangeAssignee(ctx, issue.Poster, issue, assignee, false, assigneeCommentMap[assigneeID])
+	for _, assigneeID := range assigneeIDs {
+		assignee, err := user_model.GetUserByID(ctx, assigneeID)
+		if err != nil {
+			return ErrDependenciesLeft
 		}
+		notify_service.IssueChangeAssignee(ctx, issue.Poster, issue, assignee, false, assigneeCommentMap[assigneeID])
 	}
 
 	return nil


### PR DESCRIPTION
This pull request is a minor code cleanup.

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the slice or map is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

---

At the time of writing this pull request, there wasn't a lint rule that catches these issues. The closest I could find is https://staticcheck.dev/docs/checks/#S103