### PR TITLE
Remove the mirror repo URL from edit form since it can't be changed

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -210,7 +210,6 @@
 									data-tooltip-content="{{ctx.Locale.Tr "repo.settings.mirror_settings.push_mirror.edit_sync_time"}}"
 									data-modal-push-mirror-edit-id="{{.ID}}"
 									data-modal-push-mirror-edit-interval="{{.Interval}}"
-									data-modal-push-mirror-edit-address="{{.RemoteAddress}}"
 								>
 									{{svg "octicon-pencil" 14}}
 								</button>

--- a/templates/repo/settings/push_mirror_sync_modal.tmpl
+++ b/templates/repo/settings/push_mirror_sync_modal.tmpl
@@ -8,12 +8,6 @@
 			<input type="hidden" name="action" value="push-mirror-update">
 			<input type="hidden" name="push_mirror_id" id="push-mirror-edit-id">
 			<div class="field">
-				<label for="name">{{ctx.Locale.Tr "repo.settings.mirror_settings.mirrored_repository"}}</label>
-				<div class="ui small input">
-					<input id="push-mirror-edit-address" readonly>
-				</div>
-			</div>
-			<div class="inline field">
 				<label for="push-mirror-edit-interval">{{ctx.Locale.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
 				<input id="push-mirror-edit-interval" name="push_mirror_interval" autofocus>
 			</div>


### PR DESCRIPTION
Before: 
<img width="380" alt="image" src="https://github.com/go-gitea/gitea/assets/70063547/bdb2c717-3518-4f8b-8378-17276f73b52d">
After:
<img width="385" alt="image" src="https://github.com/go-gitea/gitea/assets/70063547/262de0a4-9084-43a0-8d93-37c612859ac7">

Or just change the background color of the input box 🤔 ?
