### PR TITLE
Enable markdownlint `no-duplicate-header`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -6,7 +6,6 @@ line-length: {code_blocks: false, tables: false, stern: true, line_length: -1}
 no-alt-text: false
 no-bare-urls: false
 no-blanks-blockquote: false
-no-duplicate-header: {allow_different_nesting: true}
 no-emphasis-as-header: false
 no-empty-links: false
 no-hard-tabs: {code_blocks: false}

--- a/docs/content/administration/cmd-embedded.en-us.md
+++ b/docs/content/administration/cmd-embedded.en-us.md
@@ -50,7 +50,7 @@ a special meaning for your command shell.
 
 If no pattern is provided, all files are listed.
 
-### Example
+### Example: Listing all embedded files
 
 Listing all embedded files with `openid` in their path:
 
@@ -101,7 +101,7 @@ When Gitea is upgraded to a new version (by replacing the executable), many of t
 embedded files will suffer changes. Gitea will honor and use any files found
 in the `custom` directory, even if they are old and incompatible.
 
-### Example
+### Example: Extracting mail templates
 
 Extracting mail templates to a temporary directory:
 

--- a/docs/content/administration/cmd-embedded.zh-cn.md
+++ b/docs/content/administration/cmd-embedded.zh-cn.md
@@ -43,7 +43,7 @@ gitea embedded list [--include-vendored] [patterns...]
 
 如果未提供模式，则列出所有文件。
 
-### 示例
+### 示例：列出所有嵌入文件
 
 列出所有路径中包含 `openid` 的嵌入文件：
 
@@ -83,7 +83,7 @@ gitea [--config {file}] embedded extract [--destination {dir}|--custom] [--overw
 
 请确保**只提取需要自定义的文件**。位于 `custom` 目录中的文件不会受到 Gitea 的升级过程的影响。当 Gitea 升级到新版本（通过替换可执行文件）时，许多嵌入文件将发生变化。Gitea 将尊重并使用在 `custom` 目录中找到的任何文件，即使这些文件是旧的和不兼容的。
 
-### 示例
+### 示例：提取邮件模板
 
 将邮件模板提取到临时目录：
 

--- a/docs/content/installation/database-preparation.en-us.md
+++ b/docs/content/installation/database-preparation.en-us.md
@@ -184,7 +184,7 @@ If the communication between Gitea and your database instance is performed throu
 - On the database server certificate, one of `Subject Alternative Name` or `Common Name` entries must be the fully-qualified domain name (FQDN) of the database instance (e.g. `db.example.com`). On the database client certificate, one of the entries mentioned above must contain the database username that Gitea will be using to connect.
 - You need domain name mappings of both Gitea and database servers to their respective IP addresses. Either set up DNS records for them or add local mappings to `/etc/hosts` (`%WINDIR%\System32\drivers\etc\hosts` in Windows) on each system. This allows the database connections to be performed by domain name instead of IP address. See documentation of your system for details.
 
-### PostgreSQL
+### PostgreSQL TLS
 
 The PostgreSQL driver used by Gitea supports two-way TLS. In two-way TLS, both database client and server authenticate each other by sending their respective certificates to their respective opposite for validation. In other words, the server verifies client certificate, and the client verifies server certificate.
 
@@ -252,7 +252,7 @@ The PostgreSQL driver used by Gitea supports two-way TLS. In two-way TLS, both d
 
     You should be prompted to enter password for the database user, and then be connected to the database.
 
-### MySQL
+### MySQL/MariaDB TLS
 
 While the MySQL driver used by Gitea also supports two-way TLS, Gitea currently supports only one-way TLS. See issue #10828 for details.
 

--- a/docs/content/installation/database-preparation.zh-cn.md
+++ b/docs/content/installation/database-preparation.zh-cn.md
@@ -23,7 +23,7 @@ menu:
 
 注意：以下所有步骤要求您的选择的数据库引擎已安装在您的系统上。对于远程数据库设置，请在数据库实例上安装服务器应用程序，在 Gitea 服务器上安装客户端程序。客户端程序用于测试 Gitea 服务器与数据库之间的连接，而 Gitea 本身使用 Go 提供的数据库驱动程序完成相同的任务。此外，请确保服务器和客户端使用相同的引擎版本，以使某些引擎功能正常工作。出于安全原因，请使用安全密码保护 `root`（MySQL）或 `postgres`（PostgreSQL）数据库超级用户。以下步骤假设您在数据库和 Gitea 服务器上都使用 Linux。
 
-## MySQL
+## MySQL/MariaDB
 
 1. 对于远程数据库设置，您需要让 MySQL 监听您的 IP 地址。编辑数据库实例上的 `/etc/mysql/my.cnf` 文件中的 `bind-address` 选项为：
 
@@ -182,7 +182,7 @@ menu:
 - 在数据库服务器证书中，`Subject Alternative Name` 或 `Common Name` 条目之一必须是数据库实例的完全限定域名（FQDN）（例如 `db.example.com`）。在数据库客户端证书中，上述提到的条目之一必须包含 Gitea 将用于连接的数据库用户名。
 - 您需要将 Gitea 和数据库服务器的域名映射到它们各自的 IP 地址。可以为它们设置 DNS 记录，也可以在每个系统上的 `/etc/hosts`（Windows 中的 `%WINDIR%\System32\drivers\etc\hosts`）中添加本地映射。这样可以通过域名而不是 IP 地址进行数据库连接。有关详细信息，请参阅您系统的文档。
 
-### PostgreSQL
+### PostgreSQL TLS
 
 Gitea 使用的 PostgreSQL 驱动程序支持双向 TLS。在双向 TLS 中，数据库客户端和服务器通过将各自的证书发送给对方进行验证来相互认证。换句话说，服务器验证客户端证书，客户端验证服务器证书。
 
@@ -250,7 +250,7 @@ Gitea 使用的 PostgreSQL 驱动程序支持双向 TLS。在双向 TLS 中，�
 
     您将被提示输入数据库用户的密码，然后连接到数据库。
 
-### MySQL
+### MySQL/MariaDB TLS
 
 虽然 Gitea 使用的MySQL驱动程序也支持双向 TLS，但目前 Gitea 仅支持单向 TLS。有关详细信息，请参见工单＃10828。
 


### PR DESCRIPTION
Duplicate headers in a single Markdown document are problemlematic because the auto-generated links won't be stable. Enable this rule with no exceptions which is also the default of `markdownlint`. For example:

```md
# A
## Example
# B
## Example
```
Docasaurus will generated `example` and `example-1` links for this. If the first heading is altered, the link `example` will unexpectedly move to the second example heading.

Ref: https://github.com/go-gitea/gitea/pull/27461#discussion_r1347987659