### PR TITLE
Fix actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   labels:
     - actuated-4cpu-8gb
     - actuated-4cpu-16gb
+    - nscloud


### PR DESCRIPTION
`make lint-actions` is currently failing because of undeclared runner name.