### PR TITLE
Add build/backport.sh

### DIFF
--- a/build/backport.sh
+++ b/build/backport.sh
@@ -9,7 +9,7 @@ backport() {
   git checkout "release/v$VER" || git checkout -b "release/v$VER"
   git fetch origin "release/v$VER"
   git reset --hard "origin/release/v$VER"
-  git branch -D "backport-$PR-$VER"
+  git branch -D "backport-$PR-$VER" &>/dev/null || true
   git checkout -b "backport-$PR-$VER"
   HASH="$(curl -sH "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/go-gitea/gitea/pulls/$PR" | jq -r .merge_commit_sha)"
   git cherry-pick "$HASH"

--- a/build/backport.sh
+++ b/build/backport.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+backport() {
+  if [ $# -eq 0 ]; then; echo "backport PR VERSION"; exit 1; fi
+  PR="$1"
+  VER="$2"
+
+  git checkout "release/v$VER" || git checkout -b "release/v$VER"
+  git fetch origin "release/v$VER"
+  git reset --hard "origin/release/v$VER"
+  git branch -D "backport-$PR-$VER"
+  git checkout -b "backport-$PR-$VER"
+  HASH="$(curl -sH "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/go-gitea/gitea/pulls/$PR" | jq -r .merge_commit_sha)"
+  git cherry-pick "$HASH"
+}


### PR DESCRIPTION
[contrib/backport](https://github.com/go-gitea/gitea/blob/main/contrib/backport) seems [broken](https://github.com/GiteaBot/gitea-backporter/issues/110#issuecomment-1751995115), I don't want to debug it. Add this simple script that will work for my backporting needs.