### PR TITLE
Improve file history UI and fix URL escaping bug

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -6,7 +6,7 @@
 					<th class="two wide sha">SHA1</th>
 					<th class="eight wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
 					<th class="two wide right aligned">{{ctx.Locale.Tr "repo.commits.date"}}</th>
-					<th class="one wide right aligned"></th>
+					<th class="one wide"></th>
 				</tr>
 			</thead>
 			<tbody class="commit-list">
@@ -25,7 +25,7 @@
 								{{$userName}}
 							{{end}}
 						</td>
-						<td class="sha gt-df">
+						<td class="sha">
 							{{$class := "ui sha label"}}
 							{{if .Signature}}
 								{{$class = (print $class " isSigned")}}
@@ -76,11 +76,11 @@
 						{{else}}
 							<td class="text right aligned">{{TimeSince .Author.When ctx.Locale}}</td>
 						{{end}}
-						<td class="gt-pt-0 gt-pb-0">
-							<div class="gt-df gt-je">
-								<button class="btn interact-bg gt-p-3" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
-								{{if $.FileName}}<a class="btn interact-bg gt-p-3" data-tooltip-content="{{ctx.Locale.Tr "repo.commits.view_path"}}" href="{{printf "%s/src/commit/%s/%s" $commitRepoLink (PathEscape .ID.String) $.FileName}}">{{svg "octicon-file-code"}}</a>{{end}}
-							</div>
+						<td class="text right aligned gt-py-0">
+							<button class="btn interact-bg gt-p-3" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
+							{{if $.FileName}}
+								<a class="btn interact-bg gt-p-3" data-tooltip-content="{{ctx.Locale.Tr "repo.commits.view_path"}}" href="{{printf "%s/src/commit/%s/%s" $commitRepoLink (PathEscape .ID.String) (PathEscapeSegments $.FileName)}}">{{svg "octicon-file-code"}}</a>
+							{{end}}
 						</td>
 					</tr>
 				{{end}}


### PR DESCRIPTION
Follow #27354

Major changes:

1. The `right aligned` in `<th class="one wide right aligned">` is a no-op because it doesn't have any content
2. The `gt-df` in `<td class="sha gt-df">` was wrong, it causes UI misalignment, a table cell shouldn't be "flex"
3. Use `gt-py-0` for `gt-pt-0 gt-pb-0`
4. Simplify the layout for buttons, because the `text right aligned` is widely used and good enough, it doesn't make sense to introduce the `<div class="gt-df gt-je">`
5. Escape the `$.FileName` correctly


Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/eb2ced3f-1dad-4149-9ed2-aee4c0663621)

After:

![image](https://github.com/go-gitea/gitea/assets/2114189/08244b61-416b-4279-b495-029bc0a96f67)