### PR TITLE
Respect SSH.KeygenPath option when calculating ssh key fingerprints

### DIFF
--- a/models/asymkey/ssh_key_fingerprint.go
+++ b/models/asymkey/ssh_key_fingerprint.go
@@ -81,7 +81,7 @@ func CalcFingerprint(publicKeyContent string) (string, error) {
 		fnName, fp string
 		err        error
 	)
-	if setting.SSH.StartBuiltinServer {
+	if len(setting.SSH.KeygenPath) == 0 {
 		fnName = "calcFingerprintNative"
 		fp, err = calcFingerprintNative(publicKeyContent)
 	} else {


### PR DESCRIPTION
Fixes #27535 
