### PR TITLE
Fix `environment-to-ini` inherited key bug

### DIFF
--- a/modules/setting/config_env.go
+++ b/modules/setting/config_env.go
@@ -149,8 +149,9 @@ func EnvironmentToConfig(cfg ConfigProvider, envs []string) (changed bool) {
 				continue
 			}
 		}
-		key := section.Key(keyName)
+		key := ConfigSectionKey(section, keyName)
 		if key == nil {
+			changed = true
 			key, err = section.NewKey(keyName, keyValue)
 			if err != nil {
 				log.Error("Error creating key: %s in section: %s with value: %s : %v", keyName, sectionName, keyValue, err)


### PR DESCRIPTION
Fix  #27541

The INI package has a quirk: by default, the keys are inherited.
When maintaining the keys, the newly added sub key should not be affected by the parent key.