### PR TITLE
Do not block the database(sqlite) during archive creation

### DIFF
--- a/services/repository/archiver/archiver.go
+++ b/services/repository/archiver/archiver.go
@@ -266,6 +266,13 @@ func doArchive(r *ArchiveRequest) (*repo_model.RepoArchiver, error) {
 	// TODO: add lfs data to zip
 	// TODO: add submodule data to zip
 
+	// Commit and close here to avoid blocking the database for the entirety of the archive generation process
+	err = committer.Commit()
+	if err != nil {
+		return nil, err
+	}
+	committer.Close()
+
 	if _, err := storage.RepoArchives.Save(rPath, rd, -1); err != nil {
 		return nil, fmt.Errorf("unable to write archive: %w", err)
 	}
@@ -274,6 +281,14 @@ func doArchive(r *ArchiveRequest) (*repo_model.RepoArchiver, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	txCtx, committer, err = db.TxContext(db.DefaultContext)
+	if err != nil {
+		return nil, err
+	}
+	defer committer.Close()
+	ctx, _, finished = process.GetManager().AddContext(txCtx, fmt.Sprintf("ArchiveRequest[%d]: %s", r.RepoID, r.GetArchiveName()))
+	defer finished()
 
 	if archiver.Status == repo_model.ArchiverGenerating {
 		archiver.Status = repo_model.ArchiverReady


### PR DESCRIPTION
The database transaction in `doArchive` is currently held open for the entirety of the archive generation process. For larger repositories this could be a long time. If the database is sqlite3 (others not tested) then this can block other processes from using the database, which e.g. leads to long load times for the web UI route of all repositories on the gitea server, among other things. This patch finishes the transaction right before generating the archive and starts a new one to update the database afterwards.

You can reproduce the issue with the following steps:
1. create a git repository with a large file (e.g. 1GB seems sufficient to see the issue)
2. commit the file and push to a gitea instance using a sqlite database
3. from the web UI start a .tar.gz (or .zip) download
4. try to navigate to the same or another repository
5. observe a long loading time until the archive is created (i.e. the download starts)

---

I am new to Go and therefore not sure if this is the most idiomatic way to fix this. I essentially just copied the way the transaction is created in the beginning to after the archive is created and `.Commit` and `.Close`d before that. Specifically I am not sure if I would have to propagate the err from `.Close` as well, since that is deferred in the beginning which would silence the error as well, right? Is this "double `.Close`" from the defer and the explicit call OK to do?