### PR TITLE
Make disk clean action a bit more robust

### DIFF
--- a/.github/workflows/disk-clean.yml
+++ b/.github/workflows/disk-clean.yml
@@ -21,6 +21,8 @@ jobs:
           sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri || true
           sudo apt-get autoremove -y
           sudo apt-get clean
+        env:
+          DEBIAN_FRONTEND: noninteractive
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/disk-clean.yml
+++ b/.github/workflows/disk-clean.yml
@@ -12,12 +12,13 @@ jobs:
       - name: same as 'large-packages' but without 'google-cloud-sdk'
         shell: bash
         run: |
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y '^mongodb-.*'
-          sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get update
+          sudo apt-get remove -y '^dotnet-.*' || true
+          sudo apt-get remove -y '^llvm-.*' || true
+          sudo apt-get remove -y 'php.*' || true
+          sudo apt-get remove -y '^mongodb-.*' || true
+          sudo apt-get remove -y '^mysql-.*' || true
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri || true
           sudo apt-get autoremove -y
           sudo apt-get clean
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
Try to address [this](https://github.com/go-gitea/gitea/actions/runs/6488542420/job/17621185506). I think it's good practice to always run `apt-get update` before any other apt actions. Also I added `|| true` to the removal steps so that it won't fail in the future when a package is not present. Finally I added `DEBIAN_FRONTEND` for good measure.