### PR TITLE
fix duplicated icon in repolist

### DIFF
--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -32,10 +32,12 @@
 								{{end}}
 							{{end}}
 						</span>
-						{{if .IsFork}}
-							<span data-tooltip-content="{{ctx.Locale.Tr "repo.fork"}}">{{svg "octicon-repo-forked"}}</span>
-						{{else if .IsMirror}}
-							<span data-tooltip-content="{{ctx.Locale.Tr "mirror"}}">{{svg "octicon-mirror"}}</span>
+						{{if or (.RelAvatarLink ctx) .IsTemplate .IsPrivate}}
+							{{if .IsFork}}
+								<span data-tooltip-content="{{ctx.Locale.Tr "repo.fork"}}">{{svg "octicon-repo-forked"}}</span>
+							{{else if .IsMirror}}
+								<span data-tooltip-content="{{ctx.Locale.Tr "mirror"}}">{{svg "octicon-mirror"}}</span>
+							{{end}}
 						{{end}}
 					</div>
 					<div class="flex-item-trailing">


### PR DESCRIPTION
Fix #27596 

Only show fork/mirror icon in title if the main icon is something else.