### PR TITLE
Improve dropdown button alignment and fix hover bug

### DIFF
--- a/templates/devtest/gitea-ui.tmpl
+++ b/templates/devtest/gitea-ui.tmpl
@@ -250,6 +250,15 @@
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 			</div>
 		</div>
+
+		<div>
+			<hr>
+			<div class="ui tiny button">Button align with ...</div>
+			<div class="ui dropdown tiny button">
+				<span class="text">... Dropdown Button</span>
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+			</div>
+		</div>
 	</div>
 
 	<div>

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1952,7 +1952,7 @@ table th[data-sortt-desc] .svg {
   height: 15px;
 }
 
-.ui.dropdown {
+.ui.dropdown:not(.button) {
   line-height: var(--line-height-default); /* the dropdown doesn't have default line-height, use this to make the dropdown icon align with plain dropdown */
 }
 

--- a/web_src/css/modules/button.css
+++ b/web_src/css/modules/button.css
@@ -128,11 +128,13 @@ It needs some tricks to tweak the left/right borders with active state */
 .ui.primary.button:focus,
 .ui.primary.buttons .button:focus {
   background: var(--color-primary);
+  color: var(--color-primary-contrast);
 }
 
 .ui.primary.button:hover,
 .ui.primary.buttons .button:hover {
   background: var(--color-primary-hover);
+  color: var(--color-primary-contrast);
 }
 
 .ui.primary.button:active,


### PR DESCRIPTION
1. fix #27631 , and add samples to devtest page
2. fix incorrect color for "ui dropdown button" when hover

<details>

### Before:

![image](https://github.com/go-gitea/gitea/assets/2114189/fa17b703-8eb4-458c-828a-e079cbd6cd76)


### After:


![image](https://github.com/go-gitea/gitea/assets/2114189/81ebbe05-2563-4ecc-86f6-9e2a36bbe216)

</details>