### PR TITLE
cleanup repo details icons/labels

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1030,10 +1030,8 @@ transfer.no_permission_to_reject = You do not have permission to reject this tra
 
 desc.private = Private
 desc.public = Public
-desc.private_template = Private template
-desc.public_template = Template
+desc.template = Template
 desc.internal = Internal
-desc.internal_template = Internal template
 desc.archived = Archived
 
 template.items = Template Items

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -55,29 +55,22 @@
 							<td>
 								<a href="{{.Link}}">{{.Name}}</a>
 								{{if .IsArchived}}
-									<span class="ui basic mini label">{{ctx.Locale.Tr "repo.desc.archived"}}</span>
+									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.archived"}}</span>
+								{{end}}
+								{{if .IsPrivate}}
+									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
+								{{else}}
+									{{if .Owner.Visibility.IsPrivate}}
+										<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
+									{{end}}
 								{{end}}
 								{{if .IsTemplate}}
-									{{if .IsPrivate}}
-										<span class="ui basic mini label">{{ctx.Locale.Tr "repo.desc.private_template"}}</span>
-									{{else}}
-										{{if .Owner.Visibility.IsPrivate}}
-											<span class="ui basic mini label">{{ctx.Locale.Tr "repo.desc.internal_template"}}</span>
-										{{end}}
-									{{end}}
-								{{else}}
-									{{if .IsPrivate}}
-										<span class="ui basic mini label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
-									{{else}}
-										{{if .Owner.Visibility.IsPrivate}}
-											<span class="ui basic mini label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
-										{{end}}
-									{{end}}
+									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.template"}}</span>
 								{{end}}
-								{{if .IsFork}}
-									{{svg "octicon-repo-forked"}}
-								{{else if .IsMirror}}
+								{{if .IsMirror}}
 									{{svg "octicon-mirror"}}
+								{{else if .IsFork}}
+									{{svg "octicon-repo-forked"}}
 								{{end}}
 							</td>
 							<td>{{.NumWatches}}</td>

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -14,29 +14,17 @@
 							{{if .IsArchived}}
 								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.archived"}}</span>
 							{{end}}
-							{{if .IsTemplate}}
-								{{if .IsPrivate}}
-									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private_template"}}</span>
-								{{else}}
-									{{if .Owner.Visibility.IsPrivate}}
-										<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal_template"}}</span>
-									{{end}}
-								{{end}}
+							{{if .IsPrivate}}
+								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
 							{{else}}
-								{{if .IsPrivate}}
-									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
-								{{else}}
-									{{if .Owner.Visibility.IsPrivate}}
-										<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
-									{{end}}
+								{{if .Owner.Visibility.IsPrivate}}
+									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
 								{{end}}
 							{{end}}
+							{{if .IsTemplate}}
+								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.template"}}</span>
+							{{end}}
 						</span>
-						{{if .IsFork}}
-							<span data-tooltip-content="{{ctx.Locale.Tr "repo.fork"}}">{{svg "octicon-repo-forked"}}</span>
-						{{else if .IsMirror}}
-							<span data-tooltip-content="{{ctx.Locale.Tr "mirror"}}">{{svg "octicon-mirror"}}</span>
-						{{end}}
 					</div>
 					<div class="flex-item-trailing">
 						{{if .PrimaryLanguage}}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -11,25 +11,18 @@
 					<div class="gt-mx-2">/</div>
 					<a href="{{$.RepoLink}}">{{.Name}}</a>
 					<div class="labels gt-df gt-ac gt-fw">
-						{{if .IsTemplate}}
-							{{if .IsPrivate}}
-								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private_template"}}</span>
-							{{else}}
-								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal_template"}}</span>
-								{{end}}
-							{{end}}
-						{{else}}
-							{{if .IsPrivate}}
-								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
-							{{else}}
-								{{if .Owner.Visibility.IsPrivate}}
-									<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
-								{{end}}
-							{{end}}
-						{{end}}
 						{{if .IsArchived}}
 							<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.archived"}}</span>
+						{{end}}
+						{{if .IsPrivate}}
+							<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
+						{{else}}
+							{{if .Owner.Visibility.IsPrivate}}
+								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.internal"}}</span>
+							{{end}}
+						{{end}}
+						{{if .IsTemplate}}
+							<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.template"}}</span>
 						{{end}}
 					</div>
 					{{if $.EnableFeed}}

--- a/templates/repo/icon.tmpl
+++ b/templates/repo/icon.tmpl
@@ -1,10 +1,6 @@
 {{$avatarLink := (.RelAvatarLink ctx)}}
 {{if $avatarLink}}
 	<img class="ui avatar gt-vm" src="{{$avatarLink}}" width="32" height="32" alt="{{.FullName}}">
-{{else if $.IsTemplate}}
-	{{svg "octicon-repo-template" 32}}
-{{else if $.IsPrivate}}
-	{{svg "octicon-lock" 32}}
 {{else if $.IsMirror}}
 	{{svg "octicon-mirror" 32}}
 {{else if $.IsFork}}


### PR DESCRIPTION
Fix #27596 

Change confusing behavior when showing information about a repo via labels and icons. Implement changes proposed by @lng2020 in https://github.com/go-gitea/gitea/pull/27627#pullrequestreview-1678787673.