### PR TITLE
actions/setup-go use go-version-file

### DIFF
--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make generate-license generate-gitignore
         timeout-minutes: 40

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -176,4 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          check-latest: true
       - run: make lint-actions

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-backend
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-go-windows lint-go-vet
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make lint-go
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make deps-backend deps-tools
       - run: make --always-make checks-backend # ensure the "go-licenses" make target runs
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       # no frontend build here as backend should be able to build
       # even without any frontend files

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 pgsql ldap minio" | sudo tee -a /etc/hosts'
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - run: make deps-backend
       - run: make backend
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch meilisearch smtpimap" | sudo tee -a /etc/hosts'
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mssql" | sudo tee -a /etc/hosts'

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: actions/setup-node@v3
         with:
@@ -66,7 +66,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
@@ -103,7 +103,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -19,7 +19,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -21,7 +21,7 @@ jobs:
       - run: git fetch --unshallow --quiet --tags --force
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.21"
+          go-version-file: go.mod
           check-latest: true
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
These changes will allow not to specify the version of go in every pipeline.