### PR TITLE
Fix: Hide divider when labels are hidden

### DIFF
--- a/templates/repo/issue/filters.tmpl
+++ b/templates/repo/issue/filters.tmpl
@@ -38,7 +38,9 @@
 					{{range .Labels}}
 						{{$exclusiveScope := .ExclusiveScope}}
 						{{if and (ne $previousExclusiveScope $exclusiveScope)}}
-							<div class="divider"></div>
+							{{if or (not .IsArchived) (and .IsArchived $.ShowArchivedLabels)}}
+								<div class="divider"></div>
+							{{end}}
 						{{end}}
 						{{$previousExclusiveScope = $exclusiveScope}}
 						<a class="item label-filter-item gt-df gt-ac" {{if .IsArchived}}data-is-archived{{end}} href="{{$.Link}}?q={{$.Keyword}}&type={{$.ViewType}}&sort={{$.SortType}}&state={{$.State}}&labels={{.QueryString}}&milestone={{$.MilestoneID}}&project={{$.ProjectID}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}" data-label-id="{{.ID}}">


### PR DESCRIPTION
# Summary

Empty dividers are shown with no enclosed labels when the archived labels are hidden from list

# Before fix

The dividers will show on the list even if the enclosed labels are hidden

<img width="1728" alt="with_bug" src="https://github.com/go-gitea/gitea/assets/47709856/d1c445f0-64db-40ed-8318-90c850e2e8da">

# After the fix

The divider has been conditionally hidden when the label is not shown in the list


- With archived labels hidden

<img width="1725" alt="fixed_view" src="https://github.com/go-gitea/gitea/assets/47709856/10ea1b41-ca12-4715-b22d-65899db9a403">


- With archived labels shown

<img width="1725" alt="showing archived" src="https://github.com/go-gitea/gitea/assets/47709856/7d69d831-3117-43a4-974a-9c83f14c3ca3">


Fixed #27466
