### PR TITLE
Set issue labels based on conditions in issue form

### DIFF
--- a/modules/issue/template/template.go
+++ b/modules/issue/template/template.go
@@ -458,7 +458,6 @@ func (o *valuedOption) getDropdownLabels() map[string][]string {
 			continue
 		}
 
-		fmt.Printf("Hello %s\n", key)
 		stringSlice := reflect.ValueOf(value)
 		for i := 0; i < stringSlice.Len(); i++ {
 			str, ok := stringSlice.Index(i).Interface().(string)

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -1209,6 +1209,17 @@ func NewIssuePost(ctx *context.Context) {
 	if filename := ctx.Req.Form.Get("template-file"); filename != "" {
 		if template, err := issue_template.UnmarshalFromRepo(ctx.Repo.GitRepo, ctx.Repo.Repository.DefaultBranch, filename); err == nil {
 			content = issue_template.RenderToMarkdown(template, ctx.Req.Form)
+
+			templateLabels, err := issue_template.GetTemplateFieldLabels(ctx, template, ctx.Req.Form, repo.ID)
+			if err != nil {
+				ctx.ServerError("GetTemplateFieldLabels", err)
+			}
+
+			for _, labelID := range templateLabels {
+				if !slices.Contains(labelIDs, labelID) {
+					labelIDs = append(labelIDs, labelID)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR allows issue forms to set labels, based on what the user selects. Take for example this form:
```yaml
name: Bug Report
about: File a bug report
body:
  - type: dropdown
    id: os
    attributes:
      label: Operating System
      description: What OS are you using?
      options:
        - Windows
        - macOS
        - Linux
      options_labels:
        Windows: ["OS/Windows"]
        macOS: ["OS/Mac"]
        Linux: ["OS/Linux"]
  - type: checkboxes
    id: lts
    attributes:
      label: LTS
      options:
        - label: This Bug also affects the LTS version
          labels: [LTS]
```
If Windows is selected, the issue gets the `OS/Windows` label, with macOS it gets the `OS/Mac` label and with Linux the `OS/Linux` label. When the checkbox is checked, the issue gets the `LTS` label. This can save some work.

This is missing.
- [ ] Validation
- [ ] Tests
- [ ] Documentation

I first want some feed back of this new feature before tackling any of this.