### PR TITLE
Add link for repositories README file

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -1,4 +1,4 @@
-<div class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
+<div {{if .ReadmeInList}}id="readme"{{end}} class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
 	{{- if .FileError}}
 		<div class="ui error message">
 			<div class="text left gt-whitespace-pre">{{.FileError}}</div>
@@ -13,7 +13,7 @@
 		<div class="file-header-left gt-df gt-ac gt-py-3 gt-pr-4">
 			{{if .ReadmeInList}}
 				{{svg "octicon-book" 16 "gt-mr-3"}}
-				<strong>{{.FileName}}</strong>
+				<strong><a class="default-link muted" href="#readme">{{.FileName}}</a></strong>
 			{{else}}
 				{{template "repo/file_info" .}}
 			{{end}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -1,4 +1,4 @@
-<div {{if .ReadmeInList}}id="readme"{{end}} class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
+<div {{if .ReadmeInList}}id="readme" {{end}}class="{{TabSizeClass .Editorconfig .FileName}} non-diff-file-content">
 	{{- if .FileError}}
 		<div class="ui error message">
 			<div class="text left gt-whitespace-pre">{{.FileError}}</div>


### PR DESCRIPTION
this allows to deep link to the readme section of a repository.

fixes #27641

Screenshots:

No changes on initial display:
![image](https://github.com/go-gitea/gitea/assets/1135157/efbef50e-c24b-4cca-b19f-9092e70b5a5f)

On hover the link is shown:
![image](https://github.com/go-gitea/gitea/assets/1135157/c8dff2b8-31dc-4b7b-96d0-27642318483d)
