### PR TITLE
[FIX] resolve confusing colors in languages stats by insert a gap

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2050,6 +2050,7 @@
 
 .repository .repository-summary .segment.language-stats {
   display: flex;
+  gap: 2px;
   padding: 0;
   height: 10px;
   white-space: nowrap;


### PR DESCRIPTION
The current language stats are too obsessed with color matching. Similar colors are always next to each other. It is a bit troublesome to find the place where the color matching is generated, so just follow the example of github and add a gap.

## before

<img width="883" alt="image" src="https://github.com/go-gitea/gitea/assets/12915306/cf54430c-616c-4b37-b561-5a37c20b2d94">

## after

<img width="877" alt="image" src="https://github.com/go-gitea/gitea/assets/12915306/e518ea36-2b8f-4f11-a867-a58dc393db85">

