### PR TITLE
Clean some functions about project issue

### DIFF
--- a/models/issues/issue_project.go
+++ b/models/issues/issue_project.go
@@ -51,7 +51,7 @@ func (issue *Issue) ProjectBoardID(ctx context.Context) int64 {
 func LoadIssuesFromBoard(ctx context.Context, b *project_model.Board) (IssueList, error) {
 	issueList := make(IssueList, 0, 10)
 
-	if b.ID != 0 {
+	if b.ID > 0 {
 		issues, err := Issues(ctx, &IssuesOptions{
 			ProjectBoardID: b.ID,
 			ProjectID:      b.ProjectID,
@@ -65,7 +65,7 @@ func LoadIssuesFromBoard(ctx context.Context, b *project_model.Board) (IssueList
 
 	if b.Default {
 		issues, err := Issues(ctx, &IssuesOptions{
-			ProjectBoardID: -1, // Issues without ProjectBoardID
+			ProjectBoardID: db.NoConditionID,
 			ProjectID:      b.ProjectID,
 			SortType:       "project-column-sorting",
 		})
@@ -149,31 +149,4 @@ func addUpdateIssueProject(ctx context.Context, issue *Issue, doer *user_model.U
 		IssueID:   issue.ID,
 		ProjectID: newProjectID,
 	})
-}
-
-// MoveIssueAcrossProjectBoards move a card from one board to another
-func MoveIssueAcrossProjectBoards(ctx context.Context, issue *Issue, board *project_model.Board) error {
-	ctx, committer, err := db.TxContext(ctx)
-	if err != nil {
-		return err
-	}
-	defer committer.Close()
-	sess := db.GetEngine(ctx)
-
-	var pis project_model.ProjectIssue
-	has, err := sess.Where("issue_id=?", issue.ID).Get(&pis)
-	if err != nil {
-		return err
-	}
-
-	if !has {
-		return fmt.Errorf("issue has to be added to a project first")
-	}
-
-	pis.ProjectBoardID = board.ID
-	if _, err := sess.ID(pis.ID).Cols("project_board_id").Update(&pis); err != nil {
-		return err
-	}
-
-	return committer.Commit()
 }

--- a/modules/indexer/issues/db/options.go
+++ b/modules/indexer/issues/db/options.go
@@ -96,7 +96,6 @@ func ToDBOptions(ctx context.Context, options *internal.SearchOptions) (*issue_m
 		}
 
 		if len(options.IncludedLabelIDs) == 0 && len(options.IncludedAnyLabelIDs) > 0 {
-			_ = ctx // issue_model.GetLabelsByIDs should be called with ctx, this line can be removed when it's done.
 			labels, err := issue_model.GetLabelsByIDs(ctx, options.IncludedAnyLabelIDs, "name")
 			if err != nil {
 				return nil, fmt.Errorf("GetLabelsByIDs: %v", err)


### PR DESCRIPTION
1. remove unused function `MoveIssueAcrossProjectBoards`
2. extract the project board condition into a function
3. use db.NoCondition instead of -1. (BTW, the usage of db.NoCondition is too confusing. Is there any way to avoid that?)
4. remove the unnecessary comment since the ctx refactor is completed.
5. Change `b.ID != 0` to `b.ID > 0`. It's more intuitive but I think they're the same since board ID can't be negative.