### PR TITLE
refactor: make db iterate context aware

### DIFF
--- a/models/db/iterate.go
+++ b/models/db/iterate.go
@@ -17,21 +17,26 @@ func Iterate[Bean any](ctx context.Context, cond builder.Cond, f func(ctx contex
 	batchSize := setting.Database.IterateBufferSize
 	sess := GetEngine(ctx)
 	for {
-		beans := make([]*Bean, 0, batchSize)
-		if cond != nil {
-			sess = sess.Where(cond)
-		}
-		if err := sess.Limit(batchSize, start).Find(&beans); err != nil {
-			return err
-		}
-		if len(beans) == 0 {
-			return nil
-		}
-		start += len(beans)
-
-		for _, bean := range beans {
-			if err := f(ctx, bean); err != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			beans := make([]*Bean, 0, batchSize)
+			if cond != nil {
+				sess = sess.Where(cond)
+			}
+			if err := sess.Limit(batchSize, start).Find(&beans); err != nil {
 				return err
+			}
+			if len(beans) == 0 {
+				return nil
+			}
+			start += len(beans)
+
+			for _, bean := range beans {
+				if err := f(ctx, bean); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
the iteration will run until finished atm.

this changes it by checking if if the context got canceled before each run of a loop sequence is executed

[View this pull with now whitespace](https://github.com/go-gitea/gitea/pull/27710/files?diff=unified&w=1)