### PR TITLE
Improve diff tree spacing

### DIFF
--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -126,7 +126,7 @@ export default {
 };
 </script>
 <template>
-  <div v-if="store.fileTreeIsVisible" class="gt-mr-3">
+  <div v-if="store.fileTreeIsVisible" class="gt-mr-3 diff-file-tree-items">
     <!-- only render the tree if we're visible. in many cases this is something that doesn't change very often -->
     <DiffFileTreeItem v-for="item in fileTree" :key="item.name" :item="item"/>
     <div v-if="store.isIncomplete" class="gt-pt-2">
@@ -134,3 +134,10 @@ export default {
     </div>
   </div>
 </template>
+<style scoped>
+.diff-file-tree-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+</style>

--- a/web_src/js/components/DiffFileTree.vue
+++ b/web_src/js/components/DiffFileTree.vue
@@ -126,7 +126,7 @@ export default {
 };
 </script>
 <template>
-  <div v-if="store.fileTreeIsVisible" class="gt-mr-3 diff-file-tree-items">
+  <div v-if="store.fileTreeIsVisible" class="diff-file-tree-items">
     <!-- only render the tree if we're visible. in many cases this is something that doesn't change very often -->
     <DiffFileTreeItem v-for="item in fileTree" :key="item.name" :item="item"/>
     <div v-if="store.isIncomplete" class="gt-pt-2">
@@ -139,5 +139,6 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  margin-right: .5rem;
 }
 </style>

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -58,11 +58,14 @@ a, a:hover {
 }
 
 .sub-items {
-  padding-left: 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding-left: 7px;
 }
 
-.item-file + .item-file {
-  margin-top: 2px;
+.sub-items .item-file {
+  padding-left: 24px;
 }
 
 .item-file.selected {

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -61,7 +61,7 @@ a, a:hover {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding-left: 7px;
+  padding-left: 8px;
 }
 
 .sub-items .item-file {

--- a/web_src/js/components/DiffFileTreeItem.vue
+++ b/web_src/js/components/DiffFileTreeItem.vue
@@ -61,8 +61,8 @@ a, a:hover {
   padding-left: 9px;
 }
 
-.item-file {
-  margin-left: 20px;
+.item-file + .item-file {
+  margin-top: 2px;
 }
 
 .item-file.selected {
@@ -80,7 +80,7 @@ a, a:hover {
   display: flex;
   align-items: center;
   gap: 0.25em;
-  padding: 2px;
+  padding: 3px 6px;
 }
 
 .item-file:hover,


### PR DESCRIPTION
1. Un-indent top-level items, matching GitHub rendering
2. Increase item padding and add 1px gap between items

Before and After:

<img width="247" alt="Screenshot 2023-10-20 at 18 37 32" src="https://github.com/go-gitea/gitea/assets/115237/43c1ce86-1814-4a8a-9dd2-0c4a82a2be7c">
<img width="241" alt="Screenshot 2023-10-20 at 18 40 46" src="https://github.com/go-gitea/gitea/assets/115237/b541b85b-c428-4903-becd-773ae5807495">

