### PR TITLE
Fix duplicate project board when hitting `enter` key

### DIFF
--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -193,20 +193,6 @@ export function initRepoProject() {
     const url = $(this).data('url');
     createNewColumn(url, columnTitle, projectColorInput);
   });
-
-  $('.new-project-column').on('input keyup', (e) => {
-    const columnTitle = $('#new_project_column');
-    const projectColorInput = $('#new_project_column_color_picker');
-    if (!columnTitle.val()) {
-      $('#new_project_column_submit').addClass('disabled');
-      return;
-    }
-    $('#new_project_column_submit').removeClass('disabled');
-    if (e.key === 'Enter') {
-      const url = $(this).data('url');
-      createNewColumn(url, columnTitle, projectColorInput);
-    }
-  });
 }
 
 function setLabelColor(label, color) {


### PR DESCRIPTION
When hitting the `enter` key to create a new project column, the request is sent twice because the `submit` event and `key up` event are both triggered.
Probably a better solution is to rewrite these parts of the code to avoid using native jQuery but reuse the `form-fetch-action` class. But it's beyond my ability.