### PR TITLE
Fix label render containing invalid HTML

### DIFF
--- a/modules/templates/util_render.go
+++ b/modules/templates/util_render.go
@@ -179,7 +179,7 @@ func RenderLabel(ctx context.Context, label *issues_model.Label) template.HTML {
 
 	s := fmt.Sprintf("<span class='ui label scope-parent' title='%s'>"+
 		"<div class='ui label scope-left' style='color: %s !important; background-color: %s !important'>%s</div>"+
-		"<div class='ui label scope-right' style='color: %s !important; background-color: %s !important''>%s</div>"+
+		"<div class='ui label scope-right' style='color: %s !important; background-color: %s !important'>%s</div>"+
 		"</span>",
 		description,
 		textColor, scopeColor, scopeText,


### PR DESCRIPTION
- The label HTML contained a quote that wasn't being closed.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1651

(cherry picked from commit e2bc2c9a1fff482c49dbeb3a51e4e1c698bf506c)
