### PR TITLE
Use correct tab value for repo search

### DIFF
--- a/templates/explore/repo_search.tmpl
+++ b/templates/explore/repo_search.tmpl
@@ -6,8 +6,8 @@
 			{{template "shared/searchinput" dict "Value" .Keyword "AutoFocus" true}}
 			{{if .PageIsExploreRepositories}}
 				<input type="hidden" name="only_show_relevant" value="{{.OnlyShowRelevant}}">
-			{{else}}
-				<input type="hidden" name="tab" value="repositories">
+			{{else if .tab}}
+				<input type="hidden" name="tab" value="{{.tab}}">
 			{{end}}
 			<button class="ui primary button">{{ctx.Locale.Tr "explore.search"}}</button>
 		</div>

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -20,7 +20,7 @@
 					{{template "user/dashboard/feeds" .}}
 				{{else if eq .TabName "stars"}}
 					<div class="stars">
-						{{template "explore/repo_search" .}}
+						{{template "explore/repo_search" (dict "." . "tab" "stars")}}
 						{{template "explore/repo_list" .}}
 						{{template "base/paginate" .}}
 					</div>
@@ -31,7 +31,7 @@
 				{{else if eq .TabName "overview"}}
 					<div id="readme_profile" class="markup">{{.ProfileReadme | Str2html}}</div>
 				{{else}}
-					{{template "explore/repo_search" .}}
+					{{template "explore/repo_search" (dict "ctxData" . "tab" "repositories")}}
 					{{template "explore/repo_list" .}}
 					{{template "base/paginate" .}}
 				{{end}}


### PR DESCRIPTION
- Use the correct tab value for repo search by letting the templates pass the right value.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1516

(cherry picked from commit 477c4ca47725796064c4cbc90c9ee07b4b780b3b)
