### PR TITLE
[WIP] Optimize: allow to submit the status of the checkbox directly without button

### DIFF
--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -602,37 +602,32 @@
 					<label>{{ctx.Locale.Tr "repo.settings.trust_model"}}</label><br>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input type="radio" id="trust_model_default" name="trust_model" {{if eq .Repository.TrustModel.String "default"}}checked="checked"{{end}} value="default">
+							<input class="signing-verification" type="radio" id="trust_model_default" name="trust_model" {{if eq .Repository.TrustModel.String "default"}}checked="checked"{{end}} value="default">
 							<label for="trust_model_default">{{ctx.Locale.Tr "repo.settings.trust_model.default"}}</label>
 							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.default.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input type="radio" id="trust_model_collaborator" name="trust_model" {{if eq .Repository.TrustModel.String "collaborator"}}checked="checked"{{end}} value="collaborator">
+							<input class="signing-verification" type="radio" id="trust_model_collaborator" name="trust_model" {{if eq .Repository.TrustModel.String "collaborator"}}checked="checked"{{end}} value="collaborator">
 							<label for="trust_model_collaborator">{{ctx.Locale.Tr "repo.settings.trust_model.collaborator.long"}}</label>
 							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.collaborator.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input type="radio" name="trust_model" id="trust_model_committer" {{if eq .Repository.TrustModel.String "committer"}}checked="checked"{{end}} value="committer">
+							<input class="signing-verification" type="radio" name="trust_model" id="trust_model_committer" {{if eq .Repository.TrustModel.String "committer"}}checked="checked"{{end}} value="committer">
 							<label for="trust_model_committer">{{ctx.Locale.Tr "repo.settings.trust_model.committer.long"}}</label>
 							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.committer.desc"}}</p>
 						</div>
 					</div>
 					<div class="field">
 						<div class="ui radio checkbox">
-							<input type="radio" name="trust_model" id="trust_model_collaboratorcommitter" {{if eq .Repository.TrustModel.String "collaboratorcommitter"}}checked="checked"{{end}} value="collaboratorcommitter">
+							<input class="signing-verification" type="radio" name="trust_model" id="trust_model_collaboratorcommitter" {{if eq .Repository.TrustModel.String "collaboratorcommitter"}}checked="checked"{{end}} value="collaboratorcommitter">
 							<label for="trust_model_collaboratorcommitter">{{ctx.Locale.Tr "repo.settings.trust_model.collaboratorcommitter.long"}}</label>
 							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.collaboratorcommitter.desc"}}</p>
 						</div>
 					</div>
-				</div>
-
-				<div class="divider"></div>
-				<div class="field">
-					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 		</div>
@@ -647,13 +642,9 @@
 				<input type="hidden" name="action" value="admin">
 				<div class="field">
 					<div class="ui checkbox">
-						<input name="enable_health_check" type="checkbox" {{if .Repository.IsFsckEnabled}}checked{{end}}>
+						<input class="admin-settings" name="enable_health_check" type="checkbox" {{if .Repository.IsFsckEnabled}}checked{{end}}>
 						<label>{{ctx.Locale.Tr "repo.settings.admin_enable_health_check"}}</label>
 					</div>
-				</div>
-
-				<div class="field">
-					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
 				</div>
 			</form>
 

--- a/web_src/js/features/repo-settings.js
+++ b/web_src/js/features/repo-settings.js
@@ -106,3 +106,17 @@ export function initRepoSettingBranches() {
   markMatchedStatusChecks();
   document.getElementById('status_check_contexts').addEventListener('input', onInputDebounce(markMatchedStatusChecks));
 }
+
+export function initRepoSettingRepository() {
+  // allow the user to submit the form directly after changing the status of the checkbox
+  initSigningVerificationForm();
+}
+
+function initSigningVerificationForm() {
+  $('input.signing-verification').on('change', function() {
+    $(this).closest('form').trigger('submit');
+  });
+  $('input.admin-settings').on('change', function() {
+    $(this).closest('form').trigger('submit');
+  });
+}

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -60,6 +60,7 @@ import {initRepoArchiveLinks} from './features/repo-common.js';
 import {initRepoMigrationStatusChecker} from './features/repo-migrate.js';
 import {
   initRepoSettingGitHook,
+  initRepoSettingRepository,
   initRepoSettingsCollaboration,
   initRepoSettingSearchTeamBox,
 } from './features/repo-settings.js';
@@ -172,6 +173,7 @@ onDomReady(() => {
   initRepoWikiForm();
   initRepository();
   initRepositoryActionView();
+  initRepoSettingRepository();
 
   initCommitStatuses();
   initCaptcha();


### PR DESCRIPTION
fix: https://github.com/go-gitea/gitea/issues/27660

branch: main

before: There are too many Update Settings buttons
<img width="767" alt="image" src="https://github.com/go-gitea/gitea/assets/45022150/0c1cbd2b-cfb4-41d8-8af7-d9293a43b6fd">

after: Removed two buttons and allowed the user to update the status of the checkboxes directly by changing their state
<img width="746" alt="image" src="https://github.com/go-gitea/gitea/assets/45022150/617a96ba-9fbc-4fa7-9dd5-dbceadc96a4f">

desc: Since gitea's `form` tag is currently designed for synchronous commits and the backend uses a structure (services/forms/repo_form.go:119) to accept all parameters.

The current options for reducing the update button are:
a. **This PR cuts down to two buttons and allows direct submission by modifying the radio box flags (but multiple choice boxes obviously don't work with this logic)**
b. Consolidating the chunks of logic on this page into a single update button submit (but with some bloat)
c. Asynchronously submit each change, removing all update buttons from the current page (the scope of the change may be large)

