### PR TITLE
Show placeholder email in privacy popup

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -729,7 +729,7 @@ add_email_success = The new email address has been added.
 email_preference_set_success = Email preference has been set successfully.
 add_openid_success = The new OpenID address has been added.
 keep_email_private = Hide Email Address
-keep_email_private_popup = This will hide your email address from your profile, as well as when you make a pull request or edit a file using the web interface. Pushed commits will not be modified.
+keep_email_private_popup = This will hide your email address from your profile, as well as when you make a pull request or edit a file using the web interface. Pushed commits will not be modified. Use %s in commits to associate them with your account.
 openid_desc = OpenID lets you delegate authentication to an external provider.
 
 manage_ssh_keys = Manage SSH Keys

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -73,7 +73,7 @@
 
 				<div class="field">
 					<div class="ui checkbox">
-						<label data-tooltip-content="{{ctx.Locale.Tr "settings.keep_email_private_popup"}}"><strong>{{ctx.Locale.Tr "settings.keep_email_private"}}</strong></label>
+						<label data-tooltip-content="{{ctx.Locale.Tr "settings.keep_email_private_popup" .SignedUser.GetPlaceholderEmail}}"><strong>{{ctx.Locale.Tr "settings.keep_email_private"}}</strong></label>
 						<input name="keep_email_private" type="checkbox" {{if .SignedUser.KeepEmailPrivate}}checked{{end}}>
 					</div>
 				</div>


### PR DESCRIPTION
This PR will show the _noreply_ address in the privacy popup _keep_email_private_popup_.

I had to look into the source code to figure out which E-Mail Adress I had to use on gitea.com to hide it from public access.

According to the contribution guidelines I only updated the en-US translation file.