### PR TITLE
Add gap between diff boxes

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2734,6 +2734,9 @@ tbody.commit-list {
 #diff-file-boxes {
   flex: 1;
   max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 #diff-file-tree {


### PR DESCRIPTION
Before (almost no gap between files):
<img width="1240" alt="Screenshot 2023-10-24 at 19 43 32" src="https://github.com/go-gitea/gitea/assets/115237/30cdbdbc-d102-479c-89ce-3f68837ae0cd">

After (with 8px gap):
<img width="1241" alt="Screenshot 2023-10-24 at 19 43 22" src="https://github.com/go-gitea/gitea/assets/115237/72b26a30-8730-4a36-8de9-be143b684b98">
