### PR TITLE
Close all hashed buffers

### DIFF
--- a/modules/packages/hashed_buffer.go
+++ b/modules/packages/hashed_buffer.go
@@ -32,7 +32,7 @@ func NewHashedBuffer() (*HashedBuffer, error) {
 	return NewHashedBufferWithSize(DefaultMemorySize)
 }
 
-// NewHashedBuffer creates a hashed buffer with a specific memory size
+// NewHashedBufferWithSize creates a hashed buffer with a specific memory size
 func NewHashedBufferWithSize(maxMemorySize int) (*HashedBuffer, error) {
 	b, err := filebuffer.New(maxMemorySize)
 	if err != nil {

--- a/services/packages/alpine/repository.go
+++ b/services/packages/alpine/repository.go
@@ -238,6 +238,8 @@ func buildPackagesIndex(ctx context.Context, ownerID int64, repoVersion *package
 	}
 
 	unsignedIndexContent, _ := packages_module.NewHashedBuffer()
+	defer unsignedIndexContent.Close()
+
 	h := sha1.New()
 
 	if err := writeGzipStream(io.MultiWriter(unsignedIndexContent, h), "APKINDEX", buf.Bytes(), true); err != nil {
@@ -275,6 +277,7 @@ func buildPackagesIndex(ctx context.Context, ownerID int64, repoVersion *package
 	}
 
 	signedIndexContent, _ := packages_module.NewHashedBuffer()
+	defer signedIndexContent.Close()
 
 	if err := writeGzipStream(
 		signedIndexContent,

--- a/services/packages/debian/repository.go
+++ b/services/packages/debian/repository.go
@@ -196,11 +196,16 @@ func buildPackagesIndices(ctx context.Context, ownerID int64, repoVersion *packa
 	}
 
 	packagesContent, _ := packages_module.NewHashedBuffer()
+	defer packagesContent.Close()
 
 	packagesGzipContent, _ := packages_module.NewHashedBuffer()
+	defer packagesGzipContent.Close()
+
 	gzw := gzip.NewWriter(packagesGzipContent)
 
 	packagesXzContent, _ := packages_module.NewHashedBuffer()
+	defer packagesXzContent.Close()
+
 	xzw, _ := xz.NewWriter(packagesXzContent)
 
 	w := io.MultiWriter(packagesContent, gzw, xzw)
@@ -323,6 +328,8 @@ func buildReleaseFiles(ctx context.Context, ownerID int64, repoVersion *packages
 	}
 
 	inReleaseContent, _ := packages_module.NewHashedBuffer()
+	defer inReleaseContent.Close()
+
 	sw, err := clearsign.Encode(inReleaseContent, e.PrivateKey, nil)
 	if err != nil {
 		return err
@@ -367,11 +374,14 @@ func buildReleaseFiles(ctx context.Context, ownerID int64, repoVersion *packages
 	sw.Close()
 
 	releaseGpgContent, _ := packages_module.NewHashedBuffer()
+	defer releaseGpgContent.Close()
+
 	if err := openpgp.ArmoredDetachSign(releaseGpgContent, e, bytes.NewReader(buf.Bytes()), nil); err != nil {
 		return err
 	}
 
 	releaseContent, _ := packages_module.CreateHashedBufferFromReader(&buf)
+	defer releaseContent.Close()
 
 	for _, file := range []struct {
 		Name string

--- a/services/packages/rpm/repository.go
+++ b/services/packages/rpm/repository.go
@@ -551,6 +551,8 @@ func (wc *writtenCounter) Written() int64 {
 
 func addDataAsFileToRepo(ctx context.Context, pv *packages_model.PackageVersion, filetype string, obj any) (*repoData, error) {
 	content, _ := packages_module.NewHashedBuffer()
+	defer content.Close()
+
 	gzw := gzip.NewWriter(content)
 	wc := &writtenCounter{}
 	h := sha256.New()

--- a/services/packages/rpm/repository.go
+++ b/services/packages/rpm/repository.go
@@ -258,11 +258,14 @@ func buildRepomd(ctx context.Context, pv *packages_model.PackageVersion, ownerID
 	}
 
 	repomdAscContent, _ := packages_module.NewHashedBuffer()
+	defer repomdAscContent.Close()
+
 	if err := openpgp.ArmoredDetachSign(repomdAscContent, e, bytes.NewReader(buf.Bytes()), nil); err != nil {
 		return err
 	}
 
 	repomdContent, _ := packages_module.CreateHashedBufferFromReader(&buf)
+	defer repomdContent.Close()
 
 	for _, file := range []struct {
 		Name string


### PR DESCRIPTION
Add missing `.Close()` calls. The current code does not delete the temporary files if the data grows over 32mb.
