### PR TITLE
Fix typo when updating email address

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2856,7 +2856,7 @@ emails.updated = Email updated
 emails.not_updated = Failed to update the requested email address: %v
 emails.duplicate_active = This email address is already active for a different user.
 emails.change_email_header = Update Email Properties
-emails.change_email_text = Are your sure you want to update this email address?
+emails.change_email_text = Are you sure you want to update this email address?
 
 orgs.org_manage_panel = Organization Management
 orgs.name = Name


### PR DESCRIPTION
- correct text that is shown when attempting to change an email address
