### PR TITLE
Use GitLab's squash_commit_sha when available

### DIFF
--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -566,6 +566,11 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 			closeTime = pr.UpdatedAt
 		}
 
+		mergeCommitSHA := pr.MergeCommitSHA
+		if mergeCommitSHA == "" {
+			mergeCommitSHA = pr.SquashCommitSHA
+		}
+
 		var locked bool
 		if pr.State == "locked" {
 			locked = true
@@ -608,7 +613,7 @@ func (g *GitlabDownloader) GetPullRequests(page, perPage int) ([]*base.PullReque
 			Closed:         closeTime,
 			Labels:         labels,
 			Merged:         merged,
-			MergeCommitSHA: pr.MergeCommitSHA,
+			MergeCommitSHA: mergeCommitSHA,
 			MergedTime:     mergeTime,
 			IsLocked:       locked,
 			Reactions:      g.awardsToReactions(reactions),


### PR DESCRIPTION
Before this PR, the PR migration code populates Gitea's MergedCommitID field by using GitLab's merge_commit_sha field. However, that field is only populated when the PR was merged using a merge strategy. When a squash strategy is used, squash_commit_sha is populated instead.

Given that Gitea does not keep track of merge and squash commits separately, this PR simply populates Gitea's MergedCommitID by using whichever field is present in the GitLab API response.

ref: https://docs.gitlab.com/ee/api/merge_requests.html#response