### PR TITLE
Support storage base path as prefix

### DIFF
--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -250,13 +250,16 @@ func getStorageForMinio(targetSec, overrideSec ConfigSection, tp targetSecType, 
 		return nil, fmt.Errorf("map minio config failed: %v", err)
 	}
 
-	defaultPath := name + "/"
+	var defaultPath string
 	if storage.MinioConfig.BasePath != "" {
 		if tp == targetSecIsStorage || tp == targetSecIsDefault {
-			defaultPath = strings.TrimSuffix(storage.MinioConfig.BasePath, "/") + "/" + defaultPath
+			defaultPath = strings.TrimSuffix(storage.MinioConfig.BasePath, "/") + "/" + name + "/"
 		} else {
 			defaultPath = storage.MinioConfig.BasePath
 		}
+	}
+	if defaultPath == "" {
+		defaultPath = name + "/"
 	}
 
 	if overrideSec != nil {

--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -250,8 +250,6 @@ func getStorageForMinio(targetSec, overrideSec ConfigSection, tp targetSecType, 
 		return nil, fmt.Errorf("map minio config failed: %v", err)
 	}
 
-	fmt.Println("111", targetSec.Name(), storage.MinioConfig.BasePath)
-
 	defaultPath := name + "/"
 	if storage.MinioConfig.BasePath != "" {
 		if tp == targetSecIsStorage || tp == targetSecIsDefault {
@@ -262,7 +260,6 @@ func getStorageForMinio(targetSec, overrideSec ConfigSection, tp targetSecType, 
 	}
 
 	if overrideSec != nil {
-		fmt.Println("222", overrideSec.Name())
 		storage.MinioConfig.ServeDirect = ConfigSectionKeyBool(overrideSec, "SERVE_DIRECT", storage.MinioConfig.ServeDirect)
 		storage.MinioConfig.BasePath = ConfigSectionKeyString(overrideSec, "MINIO_BASE_PATH", defaultPath)
 		storage.MinioConfig.Bucket = ConfigSectionKeyString(overrideSec, "MINIO_BUCKET", storage.MinioConfig.Bucket)

--- a/modules/setting/storage.go
+++ b/modules/setting/storage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // StorageType is a type of Storage
@@ -249,14 +250,24 @@ func getStorageForMinio(targetSec, overrideSec ConfigSection, tp targetSecType, 
 		return nil, fmt.Errorf("map minio config failed: %v", err)
 	}
 
-	if storage.MinioConfig.BasePath == "" {
-		storage.MinioConfig.BasePath = name + "/"
+	fmt.Println("111", targetSec.Name(), storage.MinioConfig.BasePath)
+
+	defaultPath := name + "/"
+	if storage.MinioConfig.BasePath != "" {
+		if tp == targetSecIsStorage || tp == targetSecIsDefault {
+			defaultPath = strings.TrimSuffix(storage.MinioConfig.BasePath, "/") + "/" + defaultPath
+		} else {
+			defaultPath = storage.MinioConfig.BasePath
+		}
 	}
 
 	if overrideSec != nil {
+		fmt.Println("222", overrideSec.Name())
 		storage.MinioConfig.ServeDirect = ConfigSectionKeyBool(overrideSec, "SERVE_DIRECT", storage.MinioConfig.ServeDirect)
-		storage.MinioConfig.BasePath = ConfigSectionKeyString(overrideSec, "MINIO_BASE_PATH", storage.MinioConfig.BasePath)
+		storage.MinioConfig.BasePath = ConfigSectionKeyString(overrideSec, "MINIO_BASE_PATH", defaultPath)
 		storage.MinioConfig.Bucket = ConfigSectionKeyString(overrideSec, "MINIO_BUCKET", storage.MinioConfig.Bucket)
+	} else {
+		storage.MinioConfig.BasePath = defaultPath
 	}
 	return &storage, nil
 }

--- a/modules/setting/storage_test.go
+++ b/modules/setting/storage_test.go
@@ -428,4 +428,40 @@ MINIO_BASE_PATH = /prefix
 	assert.EqualValues(t, "my_secret_key", RepoArchive.Storage.MinioConfig.SecretAccessKey)
 	assert.EqualValues(t, true, RepoArchive.Storage.MinioConfig.UseSSL)
 	assert.EqualValues(t, "/prefix/repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
+
+	cfg, err = NewConfigProviderFromData(`
+[storage]
+STORAGE_TYPE = minio
+MINIO_ACCESS_KEY_ID = my_access_key
+MINIO_SECRET_ACCESS_KEY = my_secret_key
+MINIO_USE_SSL = true
+MINIO_BASE_PATH = /prefix
+
+[lfs]
+MINIO_BASE_PATH = /lfs
+`)
+	assert.NoError(t, err)
+	assert.NoError(t, loadLFSFrom(cfg))
+	assert.EqualValues(t, "my_access_key", LFS.Storage.MinioConfig.AccessKeyID)
+	assert.EqualValues(t, "my_secret_key", LFS.Storage.MinioConfig.SecretAccessKey)
+	assert.EqualValues(t, true, LFS.Storage.MinioConfig.UseSSL)
+	assert.EqualValues(t, "/lfs", LFS.Storage.MinioConfig.BasePath)
+
+	cfg, err = NewConfigProviderFromData(`
+[storage]
+STORAGE_TYPE = minio
+MINIO_ACCESS_KEY_ID = my_access_key
+MINIO_SECRET_ACCESS_KEY = my_secret_key
+MINIO_USE_SSL = true
+MINIO_BASE_PATH = /prefix
+
+[storage.lfs]
+MINIO_BASE_PATH = /lfs
+`)
+	assert.NoError(t, err)
+	assert.NoError(t, loadLFSFrom(cfg))
+	assert.EqualValues(t, "my_access_key", LFS.Storage.MinioConfig.AccessKeyID)
+	assert.EqualValues(t, "my_secret_key", LFS.Storage.MinioConfig.SecretAccessKey)
+	assert.EqualValues(t, true, LFS.Storage.MinioConfig.UseSSL)
+	assert.EqualValues(t, "/lfs", LFS.Storage.MinioConfig.BasePath)
 }

--- a/modules/setting/storage_test.go
+++ b/modules/setting/storage_test.go
@@ -412,3 +412,20 @@ MINIO_USE_SSL = true
 	assert.EqualValues(t, true, RepoArchive.Storage.MinioConfig.UseSSL)
 	assert.EqualValues(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
 }
+
+func Test_getStorageConfiguration28(t *testing.T) {
+	cfg, err := NewConfigProviderFromData(`
+[storage]
+STORAGE_TYPE = minio
+MINIO_ACCESS_KEY_ID = my_access_key
+MINIO_SECRET_ACCESS_KEY = my_secret_key
+MINIO_USE_SSL = true
+MINIO_BASE_PATH = /prefix
+`)
+	assert.NoError(t, err)
+	assert.NoError(t, loadRepoArchiveFrom(cfg))
+	assert.EqualValues(t, "my_access_key", RepoArchive.Storage.MinioConfig.AccessKeyID)
+	assert.EqualValues(t, "my_secret_key", RepoArchive.Storage.MinioConfig.SecretAccessKey)
+	assert.EqualValues(t, true, RepoArchive.Storage.MinioConfig.UseSSL)
+	assert.EqualValues(t, "/prefix/repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
+}


### PR DESCRIPTION
This PR adds a prefix path for all minio storage and override base path will override the path.
The previous behavior is undefined officially, so it will be marked as breaking.

Breakage:

This PR will affect all configurations having `base_path` on `storage` section but having no `base_path` on derived storage configuration sections. The `base_path` on `storage` will become a prefix for them but not share the same base_path.