### PR TITLE
Fix bad method call when deleting user secrets via API

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -961,7 +961,7 @@ func Routes() *web.Route {
 			m.Group("/actions/secrets", func() {
 				m.Combo("/{secretname}").
 					Put(bind(api.CreateOrUpdateSecretOption{}), user.CreateOrUpdateSecret).
-					Delete(repo.DeleteSecret)
+					Delete(user.DeleteSecret)
 			})
 
 			m.Get("/followers", user.ListMyFollowers)


### PR DESCRIPTION
Fixed a little mistake when you deleting user secrets via the API. Found it when working on #27725.
It should be backported to 1.21 I think.