### PR TITLE
Add custom subject for all kinds of mail templates

### DIFF
--- a/services/mailer/mail.go
+++ b/services/mailer/mail.go
@@ -296,6 +296,8 @@ func composeIssueCommentMessages(ctx *mailCommentContext, lang string, recipient
 	subjectFromTemplate := subjectFromTemplate(tplName, mailMeta)
 	if subjectFromTemplate != "" {
 		subject = subjectFromTemplate
+	} else {
+		subject = fallback
 	}
 
 	mailMeta["Subject"] = subject

--- a/services/mailer/mail_release.go
+++ b/services/mailer/mail_release.go
@@ -74,6 +74,11 @@ func mailNewRelease(ctx context.Context, lang string, tos []string, rel *repo_mo
 		"Language": locale.Language(),
 	}
 
+	subjectFromTemplate := subjectFromTemplate(string(tplNewReleaseMail), mailMeta)
+	if subjectFromTemplate != "" {
+		subject = subjectFromTemplate
+	}
+
 	var mailBody bytes.Buffer
 
 	if err := bodyTemplates.ExecuteTemplate(&mailBody, string(tplNewReleaseMail), mailMeta); err != nil {

--- a/services/mailer/mail_repo.go
+++ b/services/mailer/mail_repo.go
@@ -74,6 +74,11 @@ func sendRepoTransferNotifyMailPerLang(lang string, newOwner, doer *user_model.U
 		"Destination": destination,
 	}
 
+	subjectFromTemplate := subjectFromTemplate(string(mailRepoTransferNotify), data)
+	if subjectFromTemplate != "" {
+		subject = subjectFromTemplate
+	}
+
 	if err := bodyTemplates.ExecuteTemplate(&content, string(mailRepoTransferNotify), data); err != nil {
 		return err
 	}

--- a/services/mailer/mail_team_invite.go
+++ b/services/mailer/mail_team_invite.go
@@ -61,6 +61,13 @@ func MailTeamInvite(ctx context.Context, inviter *user_model.User, team *org_mod
 		"InviteURL":    inviteURL,
 	}
 
+	subjectFromTemplate := subjectFromTemplate(string(tplTeamInviteMail), mailMeta)
+	if subjectFromTemplate != "" {
+		subject = subjectFromTemplate
+	}
+
+	mailMeta["Subject"] = subject
+
 	var mailBody bytes.Buffer
 	if err := bodyTemplates.ExecuteTemplate(&mailBody, string(tplTeamInviteMail), mailMeta); err != nil {
 		log.Error("ExecuteTemplate [%s]: %v", string(tplTeamInviteMail)+"/body", err)


### PR DESCRIPTION
Apply template subject to all mail types (activate account, reset password, etc.).
Follow https://github.com/go-gitea/gitea/pull/8329 (it's in the future enhancement list of that PR but it got forgotten for 4 years)
Fix #27793 