### PR TITLE
Filter inactive auth sources

### DIFF
--- a/routers/web/user/setting/security/security.go
+++ b/routers/web/user/setting/security/security.go
@@ -82,7 +82,7 @@ func loadSecurityData(ctx *context.Context) {
 	// map the provider display name with the AuthSource
 	sources := make(map[*auth_model.Source]string)
 	for _, externalAccount := range accountLinks {
-		if authSource, err := auth_model.GetSourceByID(ctx, externalAccount.LoginSourceID); err == nil {
+		if authSource, err := auth_model.GetSourceByID(ctx, externalAccount.LoginSourceID); err == nil && authSource.IsActive {
 			var providerDisplayName string
 
 			type DisplayNamed interface {


### PR DESCRIPTION
Fix nil access for inactive auth sources.

> Render failed, failed to render template: user/settings/security/security, error: template error: builtin(static):user/settings/security/accountlinks:32:20 : executing "user/settings/security/accountlinks" at <$providerData.IconHTML>: nil pointer evaluating oauth2.Provider.IconHTML

Code tries to access the auth source of an `ExternalLoginUser` but the list contains only the active auth sources.