### PR TITLE
Reduce margin/padding on flex-list items and divider

### DIFF
--- a/web_src/css/modules/divider.css
+++ b/web_src/css/modules/divider.css
@@ -1,5 +1,5 @@
 .divider {
-  margin: 1rem 0;
+  margin: 10px 0;
   height: 0;
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;

--- a/web_src/css/modules/divider.css
+++ b/web_src/css/modules/divider.css
@@ -15,7 +15,7 @@
 .divider.divider-text {
   display: flex;
   align-items: center;
-  padding: 7px 0;
+  padding: 5px 0;
 }
 
 .divider.divider-text::before,

--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -6,7 +6,7 @@
   display: flex;
   gap: 8px;
   align-items: flex-start;
-  padding: 1em 0;
+  padding: 10px 0;
 }
 
 .flex-item .flex-item-leading {


### PR DESCRIPTION
Small CSS tweak, reduces margin/padding from 14px to 10px, which I think looks better:

Before and after:
<img width="406" alt="Screenshot 2023-11-02 at 01 07 14" src="https://github.com/go-gitea/gitea/assets/115237/c89413d8-9536-492f-b477-ea4c9e9d94be">
<img width="404" alt="Screenshot 2023-11-02 at 01 08 00" src="https://github.com/go-gitea/gitea/assets/115237/bfdb2e8d-bae6-439b-81d3-e4309216cd3b">
