### PR TITLE
Fix DownloadFunc when migrating releases

### DIFF
--- a/services/migrations/gitea_downloader.go
+++ b/services/migrations/gitea_downloader.go
@@ -283,6 +283,7 @@ func (g *GiteaDownloader) convertGiteaRelease(rel *gitea_sdk.Release) *base.Rele
 
 	for _, asset := range rel.Attachments {
 		assetID := asset.ID // Don't optimize this, for closure we need a local variable
+		assetDownloadURL := asset.DownloadURL
 		size := int(asset.Size)
 		dlCount := int(asset.DownloadCount)
 		r.Assets = append(r.Assets, &base.ReleaseAsset{
@@ -298,13 +299,13 @@ func (g *GiteaDownloader) convertGiteaRelease(rel *gitea_sdk.Release) *base.Rele
 					return nil, err
 				}
 
-				if !hasBaseURL(asset.DownloadURL, g.baseURL) {
-					WarnAndNotice("Unexpected AssetURL for assetID[%d] in %s: %s", asset.ID, g, asset.DownloadURL)
+				if !hasBaseURL(assetDownloadURL, g.baseURL) {
+					WarnAndNotice("Unexpected AssetURL for assetID[%d] in %s: %s", assetID, g, assetDownloadURL)
 					return io.NopCloser(strings.NewReader(asset.DownloadURL)), nil
 				}
 
 				// FIXME: for a private download?
-				req, err := http.NewRequest("GET", asset.DownloadURL, nil)
+				req, err := http.NewRequest("GET", assetDownloadURL, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/services/migrations/gitea_downloader.go
+++ b/services/migrations/gitea_downloader.go
@@ -282,6 +282,7 @@ func (g *GiteaDownloader) convertGiteaRelease(rel *gitea_sdk.Release) *base.Rele
 	httpClient := NewMigrationHTTPClient()
 
 	for _, asset := range rel.Attachments {
+		assetID := asset.ID // Don't optimize this, for closure we need a local variable
 		size := int(asset.Size)
 		dlCount := int(asset.DownloadCount)
 		r.Assets = append(r.Assets, &base.ReleaseAsset{
@@ -292,7 +293,7 @@ func (g *GiteaDownloader) convertGiteaRelease(rel *gitea_sdk.Release) *base.Rele
 			Created:       asset.Created,
 			DownloadURL:   &asset.DownloadURL,
 			DownloadFunc: func() (io.ReadCloser, error) {
-				asset, _, err := g.client.GetReleaseAttachment(g.repoOwner, g.repoName, rel.ID, asset.ID)
+				asset, _, err := g.client.GetReleaseAttachment(g.repoOwner, g.repoName, rel.ID, assetID)
 				if err != nil {
 					return nil, err
 				}

--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -310,6 +310,7 @@ func (g *GitlabDownloader) convertGitlabRelease(rel *gitlab.Release) *base.Relea
 	httpClient := NewMigrationHTTPClient()
 
 	for k, asset := range rel.Assets.Links {
+		assetID := asset.ID // Don't optimize this, for closure we need a local variable
 		r.Assets = append(r.Assets, &base.ReleaseAsset{
 			ID:            int64(asset.ID),
 			Name:          asset.Name,
@@ -317,7 +318,7 @@ func (g *GitlabDownloader) convertGitlabRelease(rel *gitlab.Release) *base.Relea
 			Size:          &zero,
 			DownloadCount: &zero,
 			DownloadFunc: func() (io.ReadCloser, error) {
-				link, _, err := g.client.ReleaseLinks.GetReleaseLink(g.repoID, rel.TagName, asset.ID, gitlab.WithContext(g.ctx))
+				link, _, err := g.client.ReleaseLinks.GetReleaseLink(g.repoID, rel.TagName, assetID, gitlab.WithContext(g.ctx))
 				if err != nil {
 					return nil, err
 				}

--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -324,7 +324,7 @@ func (g *GitlabDownloader) convertGitlabRelease(rel *gitlab.Release) *base.Relea
 				}
 
 				if !hasBaseURL(link.URL, g.baseURL) {
-					WarnAndNotice("Unexpected AssetURL for assetID[%d] in %s: %s", asset.ID, g, link.URL)
+					WarnAndNotice("Unexpected AssetURL for assetID[%d] in %s: %s", assetID, g, link.URL)
 					return io.NopCloser(strings.NewReader(link.URL)), nil
 				}
 


### PR DESCRIPTION
We should not use `asset.ID` in DownloadFunc because DownloadFunc is a closure.
https://github.com/go-gitea/gitea/blob/1bf5527eac6b947010c8faf408f6747de2a2384f/services/migrations/gitea_downloader.go#L284-L295

A similar bug when migrating from GitHub has been fixed in #14703. This PR fixes the bug when migrating from Gitea and GitLab.