### PR TITLE
Update environment-to-ini flag parsing

### DIFF
--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -47,28 +47,28 @@ func main() {
 	on the configuration cheat sheet.`
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:  "custom-path",
+			Name:    "custom-path",
 			Aliases: []string{"C"},
-			Value: setting.CustomPath,
-			Usage: "Custom path file path",
+			Value:   setting.CustomPath,
+			Usage:   "Custom path file path",
 		},
 		&cli.StringFlag{
-			Name:  "config",
+			Name:    "config",
 			Aliases: []string{"c"},
-			Value: setting.CustomConf,
-			Usage: "Custom configuration file path",
+			Value:   setting.CustomConf,
+			Usage:   "Custom configuration file path",
 		},
 		&cli.StringFlag{
-			Name:  "work-path",
+			Name:    "work-path",
 			Aliases: []string{"w"},
-			Value: setting.AppWorkPath,
-			Usage: "Set the gitea working path",
+			Value:   setting.AppWorkPath,
+			Usage:   "Set the gitea working path",
 		},
 		&cli.StringFlag{
-			Name:  "out",
+			Name:    "out",
 			Aliases: []string{"o"},
-			Value: "",
-			Usage: "Destination file to write to",
+			Value:   "",
+			Usage:   "Destination file to write to",
 		},
 	}
 	app.Action = runEnvironmentToIni

--- a/contrib/environment-to-ini/environment-to-ini.go
+++ b/contrib/environment-to-ini/environment-to-ini.go
@@ -47,22 +47,26 @@ func main() {
 	on the configuration cheat sheet.`
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:  "custom-path, C",
+			Name:  "custom-path",
+			Aliases: []string{"C"},
 			Value: setting.CustomPath,
 			Usage: "Custom path file path",
 		},
 		&cli.StringFlag{
-			Name:  "config, c",
+			Name:  "config",
+			Aliases: []string{"c"},
 			Value: setting.CustomConf,
 			Usage: "Custom configuration file path",
 		},
 		&cli.StringFlag{
-			Name:  "work-path, w",
+			Name:  "work-path",
+			Aliases: []string{"w"},
 			Value: setting.AppWorkPath,
 			Usage: "Set the gitea working path",
 		},
 		&cli.StringFlag{
-			Name:  "out, o",
+			Name:  "out",
+			Aliases: []string{"o"},
 			Value: "",
 			Usage: "Destination file to write to",
 		},


### PR DESCRIPTION
This Fixes #27913 

This commit updates `environment-to-ini` to be compatible with update  urfave/cli/v2 

Doc: <https://cli.urfave.org/v2/examples/combining-short-options/>

