### PR TITLE
Install poetry dependencies with --no-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -875,7 +875,7 @@ node_modules: package-lock.json
 	@touch node_modules
 
 .venv: poetry.lock
-	poetry install
+	poetry install --no-root
 	@touch .venv
 
 .PHONY: update


### PR DESCRIPTION
Poetry 1.7.0 or higher will print a warning otherwise, see discussions:

https://github.com/python-poetry/poetry/pull/8369
https://github.com/python-poetry/poetry/issues/1132

> --no-root              Do not install the root package (the current project).