### PR TITLE
Remove go versions from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
   fast: false
 
 run:
-  go: "1.21"
   timeout: 10m
   skip-dirs:
     - node_modules
@@ -75,7 +74,6 @@ linters-settings:
       - name: modifies-value-receiver
   gofumpt:
     extra-rules: true
-    lang-version: "1.21"
   depguard:
     rules:
       main:


### PR DESCRIPTION
1. `linter.lang-version` is deprecated in favor of `run.go`
2. `run.go` defaults to the version in `go.mod` as per [docs](https://golangci-lint.run/usage/configuration/#run-configuration):

```yaml
  # Define the Go version limit.
  # Mainly related to generics support since go1.18.
  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
  go: '1.19'
```

So in summary, we don't need these versions in the file as long as we keep the version in go.mod bumped.