### PR TITLE
Add Profile Readme for Organisations

### DIFF
--- a/docs/content/usage/profile-readme.en-us.md
+++ b/docs/content/usage/profile-readme.en-us.md
@@ -15,7 +15,7 @@ menu:
 
 # Profile READMEs
 
-To display a Markdown file in your Gitea user / organization profile page, simply create a repository named `.profile` and add a new file called `README.md`.
+To display a Markdown file in your Gitea user or organization profile page, create a repository named `.profile` and add a new file named `README.md` to it.
 Gitea will automatically display the contents of the file on your profile, in a new "Overview" above your repositories.
 
 Making the `.profile` repository private will hide the Profile README.

--- a/docs/content/usage/profile-readme.en-us.md
+++ b/docs/content/usage/profile-readme.en-us.md
@@ -15,6 +15,7 @@ menu:
 
 # Profile READMEs
 
-To display a Markdown file in your Gitea profile page, simply create a repository named `.profile` and add a new file called `README.md`. Gitea will automatically display the contents of the file on your profile, above your repositories.
+To display a Markdown file in your Gitea user / organization profile page, simply create a repository named `.profile` and add a new file called `README.md`.
+Gitea will automatically display the contents of the file on your profile, in a new "Overview" above your repositories.
 
 Making the `.profile` repository private will hide the Profile README.

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -166,7 +166,6 @@ func Home(ctx *context.Context) {
 
 func prepareOrgProfileReadme(ctx *context.Context, profileGitRepo *git.Repository, profileReadme *git.Blob) {
 	if profileGitRepo == nil || profileReadme == nil {
-		ctx.Data["HasProfileReadme"] = false
 		return
 	}
 
@@ -181,7 +180,6 @@ func prepareOrgProfileReadme(ctx *context.Context, profileGitRepo *git.Repositor
 			log.Error("failed to RenderString: %v", err)
 		} else {
 			ctx.Data["ProfileReadme"] = profileContent
-			ctx.Data["HasProfileReadme"] = true
 		}
 	}
 }

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -159,12 +159,12 @@ func Home(ctx *context.Context) {
 
 	profileGitRepo, profileReadmeBlob, profileClose := shared_user.FindUserProfileReadme(ctx)
 	defer profileClose()
-	calcOrgProfileReadme(ctx, profileGitRepo, profileReadmeBlob)
+	prepareOrgProfileReadme(ctx, profileGitRepo, profileReadmeBlob)
 
 	ctx.HTML(http.StatusOK, tplOrgHome)
 }
 
-func calcOrgProfileReadme(ctx *context.Context, profileGitRepo *git.Repository, profileReadme *git.Blob) {
+func prepareOrgProfileReadme(ctx *context.Context, profileGitRepo *git.Repository, profileReadme *git.Blob) {
 	if profileGitRepo == nil || profileReadme == nil {
 		ctx.Data["HasProfileReadme"] = false
 		return

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -13,6 +13,8 @@ import (
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
@@ -155,5 +157,31 @@ func Home(ctx *context.Context) {
 
 	ctx.Data["ShowMemberAndTeamTab"] = ctx.Org.IsMember || len(members) > 0
 
+	profileGitRepo, profileReadmeBlob, profileClose := shared_user.FindUserProfileReadme(ctx)
+	defer profileClose()
+	calcOrgProfileReadme(ctx, profileGitRepo, profileReadmeBlob)
+
 	ctx.HTML(http.StatusOK, tplOrgHome)
+}
+
+func calcOrgProfileReadme(ctx *context.Context, profileGitRepo *git.Repository, profileReadme *git.Blob) {
+	if profileGitRepo == nil || profileReadme == nil {
+		ctx.Data["HasProfileReadme"] = false
+		return
+	}
+
+	if bytes, err := profileReadme.GetBlobContent(setting.UI.MaxDisplayFileSize); err != nil {
+		log.Error("failed to GetBlobContent: %v", err)
+	} else {
+		if profileContent, err := markdown.RenderString(&markup.RenderContext{
+			Ctx:     ctx,
+			GitRepo: profileGitRepo,
+			Metas:   map[string]string{"mode": "document"},
+		}, bytes); err != nil {
+			log.Error("failed to RenderString: %v", err)
+		} else {
+			ctx.Data["ProfileReadme"] = profileContent
+			ctx.Data["HasProfileReadme"] = true
+		}
+	}
 }

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -38,6 +38,10 @@
 	<div class="ui container">
 		<div class="ui mobile reversed stackable grid">
 			<div class="ui {{if .ShowMemberAndTeamTab}}eleven wide{{end}} column">
+				{{if .HasProfileReadme}}
+					<div id="readme_profile" class="markup">{{.ProfileReadme | Str2html}}</div>
+				{{end}}
+
 				{{template "explore/repo_search" .}}
 				{{template "explore/repo_list" .}}
 				{{template "base/paginate" .}}

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -41,7 +41,6 @@
 				{{if .ProfileReadme}}
 					<div id="readme_profile" class="markup">{{.ProfileReadme | Str2html}}</div>
 				{{end}}
-
 				{{template "explore/repo_search" .}}
 				{{template "explore/repo_list" .}}
 				{{template "base/paginate" .}}

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -38,7 +38,7 @@
 	<div class="ui container">
 		<div class="ui mobile reversed stackable grid">
 			<div class="ui {{if .ShowMemberAndTeamTab}}eleven wide{{end}} column">
-				{{if .HasProfileReadme}}
+				{{if .ProfileReadme}}
 					<div id="readme_profile" class="markup">{{.ProfileReadme | Str2html}}</div>
 				{{end}}
 


### PR DESCRIPTION
https://blog.gitea.com/release-of-1.20.0/#-user-profile-readme-23260 (#23260) did introduce Profile Readme for Users.

This makes it usable for Organisations:

![image](https://github.com/go-gitea/gitea/assets/24977596/464ab58b-a952-414b-8a34-6deaeb4f7d35)

---
*Sponsored by Kithara Software GmbH*