### PR TITLE
Fix citation error when the file size is larger than 1024 bytes

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -716,14 +716,11 @@ func checkCitationFile(ctx *context.Context, entry *git.TreeEntry) {
 				return
 			}
 			defer dataRc.Close()
-			buf := make([]byte, 1024)
-			n, err := util.ReadAtMost(dataRc, buf)
+			ctx.PageData["citationFileContent"], err = blob.GetBlobContent(setting.UI.MaxDisplayFileSize)
 			if err != nil {
-				ctx.ServerError("ReadAtMost", err)
+				ctx.ServerError("GetBlobContent", err)
 				return
 			}
-			buf = buf[:n]
-			ctx.PageData["citationFileContent"] = string(buf)
 			break
 		}
 	}


### PR DESCRIPTION
Mentioned in: https://github.com/go-gitea/gitea/pull/27931#issuecomment-1798016960

Same to #25131, so use the same method to fix this problem.