### PR TITLE
Remove `title` from elements on Org mode

### DIFF
--- a/modules/markup/orgmode/orgmode.go
+++ b/modules/markup/orgmode/orgmode.go
@@ -158,7 +158,7 @@ func (r *Writer) WriteRegularLink(l org.RegularLink) {
 	case "image":
 		if l.Description == nil {
 			imageSrc := getMediaURL(link)
-			fmt.Fprintf(r, `<img src="%s" alt="%s" title="%s" />`, imageSrc, link, link)
+			fmt.Fprintf(r, `<img src="%s" alt="%s" />`, imageSrc, link)
 		} else {
 			description := strings.TrimPrefix(org.String(l.Description...), "file:")
 			imageSrc := getMediaURL([]byte(description))
@@ -167,18 +167,18 @@ func (r *Writer) WriteRegularLink(l org.RegularLink) {
 	case "video":
 		if l.Description == nil {
 			imageSrc := getMediaURL(link)
-			fmt.Fprintf(r, `<video src="%s" title="%s">%s</video>`, imageSrc, link, link)
+			fmt.Fprintf(r, `<video src="%s">%s</video>`, imageSrc, link)
 		} else {
 			description := strings.TrimPrefix(org.String(l.Description...), "file:")
 			videoSrc := getMediaURL([]byte(description))
-			fmt.Fprintf(r, `<a href="%s"><video src="%s" title="%s"></video></a>`, link, videoSrc, videoSrc)
+			fmt.Fprintf(r, `<a href="%s"><video src="%s">%s</video></a>`, link, videoSrc, videoSrc)
 		}
 	default:
 		description := string(link)
 		if l.Description != nil {
 			description = r.WriteNodesAsString(l.Description...)
 		}
-		fmt.Fprintf(r, `<a href="%s" title="%s">%s</a>`, link, description, description)
+		fmt.Fprintf(r, `<a href="%s">%s</a>`, link, description)
 	}
 }
 

--- a/modules/markup/orgmode/orgmode_test.go
+++ b/modules/markup/orgmode/orgmode_test.go
@@ -34,12 +34,12 @@ func TestRender_StandardLinks(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(buffer))
 	}
 
-	googleRendered := "<p><a href=\"https://google.com/\" title=\"https://google.com/\">https://google.com/</a></p>"
-	test("[[https://google.com/]]", googleRendered)
+	test("[[https://google.com/]]",
+		`<p><a href="https://google.com/">https://google.com/</a></p>`)
 
 	lnk := util.URLJoin(AppSubURL, "WikiPage")
 	test("[[WikiPage][WikiPage]]",
-		"<p><a href=\""+lnk+"\" title=\"WikiPage\">WikiPage</a></p>")
+		`<p><a href="`+lnk+`">WikiPage</a></p>`)
 }
 
 func TestRender_Media(t *testing.T) {
@@ -59,19 +59,23 @@ func TestRender_Media(t *testing.T) {
 	result := util.URLJoin(AppSubURL, url)
 
 	test("[[file:"+url+"]]",
-		"<p><img src=\""+result+"\" alt=\""+result+"\" title=\""+result+"\" /></p>")
+		`<p><img src="`+result+`" alt="`+result+`" /></p>`)
 
 	// With description.
 	test("[[https://example.com][https://example.com/example.svg]]",
 		`<p><a href="https://example.com"><img src="https://example.com/example.svg" alt="https://example.com/example.svg" /></a></p>`)
+	test("[[https://example.com][pre https://example.com/example.svg post]]",
+		`<p><a href="https://example.com">pre <img src="https://example.com/example.svg" alt="https://example.com/example.svg" /> post</a></p>`)
 	test("[[https://example.com][https://example.com/example.mp4]]",
-		`<p><a href="https://example.com"><video src="https://example.com/example.mp4" title="https://example.com/example.mp4"></video></a></p>`)
+		`<p><a href="https://example.com"><video src="https://example.com/example.mp4">https://example.com/example.mp4</video></a></p>`)
+	test("[[https://example.com][pre https://example.com/example.mp4 post]]",
+		`<p><a href="https://example.com">pre <video src="https://example.com/example.mp4">https://example.com/example.mp4</video> post</a></p>`)
 
 	// Without description.
 	test("[[https://example.com/example.svg]]",
-		`<p><img src="https://example.com/example.svg" alt="https://example.com/example.svg" title="https://example.com/example.svg" /></p>`)
+		`<p><img src="https://example.com/example.svg" alt="https://example.com/example.svg" /></p>`)
 	test("[[https://example.com/example.mp4]]",
-		`<p><video src="https://example.com/example.mp4" title="https://example.com/example.mp4">https://example.com/example.mp4</video></p>`)
+		`<p><video src="https://example.com/example.mp4">https://example.com/example.mp4</video></p>`)
 }
 
 func TestRender_Source(t *testing.T) {


### PR DESCRIPTION
The Org mode rendering has some problems:
1.  `[[https://example.com][pre https://example.com/example.mp4 post]]`
 renders as
 `<p><a href="https://example.com" title="pre <video src="https://example.com/example.mp4" title="https://example.com/example.mp4">https://example.com/example.mp4</video> post">pre <video src="https://example.com/example.mp4" title="https://example.com/example.mp4">https://example.com/example.mp4</video> post</a></p>`
 As you can see, the `title` attribute contains the inner html in unescaped form. I removed the `title` attribute because it is of little value.
3. The `title` attribute on `img` and `video` is of little value.
4. The inner elements of `video` are different depending on the `if`.