### PR TITLE
Show error toast when file size exceeds the limits

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -247,6 +247,10 @@ export function initGlobalDropzone() {
             });
           }
         });
+        this.on('error', function (file, message) {
+          showErrorToast(message);
+          this.removeFile(file);
+        });
       },
     });
   }


### PR DESCRIPTION
As title.
Before that, there was no alert at all.
After:
![error_toast](https://github.com/go-gitea/gitea/assets/70063547/c54ffeed-76f8-4c3a-b5dc-b9b3e0f8fc76)
