### PR TITLE
Fix wrong xorm Delete usage(backport for 1.20)

### DIFF
--- a/models/auth/source.go
+++ b/models/auth/source.go
@@ -232,7 +232,7 @@ func CreateSource(source *Source) error {
 	err = registerableSource.RegisterSource()
 	if err != nil {
 		// remove the AuthSource in case of errors while registering configuration
-		if _, err := db.GetEngine(db.DefaultContext).Delete(source); err != nil {
+		if _, err := db.GetEngine(db.DefaultContext).ID(source.ID).Delete(new(Source)); err != nil {
 			log.Error("CreateSource: Error while wrapOpenIDConnectInitializeError: %v", err)
 		}
 	}


### PR DESCRIPTION
manually backport for https://github.com/go-gitea/gitea/pull/27995
The conflict is `ctx` and `db.Defaultctx`.
