### PR TITLE
enable system users for comment.LoadPoster

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -350,7 +350,7 @@ func (c *Comment) AfterLoad(session *xorm.Session) {
 
 // LoadPoster loads comment poster
 func (c *Comment) LoadPoster(ctx context.Context) (err error) {
-	if c.PosterID <= 0 || c.Poster != nil {
+	if c.Poster != nil {
 		return nil
 	}
 


### PR DESCRIPTION
System users (Ghost, ActionsUser, etc) have a negative id and may be the author of a comment, either because it was created by a now deleted user or via an action using a transient token.

The GetPossibleUserByID function has special cases related to system users and will not fail if given a negative id.

Refs: https://codeberg.org/forgejo/forgejo/issues/1425 

(cherry picked from commit 6a2d2fa24390116d31ae2507c0a93d423f690b7b)
