### PR TITLE
fixed duplicate attachments on dump on windows

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -452,7 +452,7 @@ func addRecursiveExclude(w archiver.Writer, insidePath, absPath string, excludeA
 		return err
 	}
 	for _, file := range files {
-		currentAbsPath := path.Join(absPath, file.Name())
+		currentAbsPath := filepath.Join(absPath, file.Name())
 		currentInsidePath := path.Join(insidePath, file.Name())
 		if file.IsDir() {
 			if !util.SliceContainsString(excludeAbsPath, currentAbsPath) {


### PR DESCRIPTION
Hi,

This PR fixes #27988. The use of `path.join`(which uses `/` as the file separator) to construct paths and comparing them with paths constructed using `filepath.join`(which uses platform specific file separator) is the root cause of this issue. 

The desired behavior is to ignore attachments when dumping data directory. Due to the what's mentioned above, the function `addRecursiveExclude` is not actually ignoring the attachments directory and is being written to the archive. The attachment directory is again added to the archive (with different file separator as mentioned in the issue) causing a duplicate entry on windows.

The solution is to use `filepath.join` in `addResursiveExclude` to construct `currentAbsPath`.
