### PR TITLE
Revert "packages: Calculate package size quota using package creator ID instead of owner ID (#28007)"

### DIFF
--- a/models/packages/package_file.go
+++ b/models/packages/package_file.go
@@ -230,15 +230,3 @@ func CalculateFileSize(ctx context.Context, opts *PackageFileSearchOptions) (int
 		Join("INNER", "package_blob", "package_blob.id = package_file.blob_id").
 		SumInt(new(PackageBlob), "size")
 }
-
-// CalculateCreatorPackageQuota sums up all blob sizes related to package
-// version creator id.
-// It does NOT respect the deduplication of blobs.
-func CalculateCreatorPackageQuota(ctx context.Context, creatorID int64) (int64, error) {
-	return db.GetEngine(ctx).
-		Table("package_version").
-		Where(builder.Eq{"creator_id": creatorID}).
-		Join("INNER", "package_file", "package_version.id = package_file.version_id").
-		Join("INNER", "package_blob", "package_blob.id = package_file.blob_id").
-		SumInt(new(PackageBlob), "size")
-}

--- a/services/packages/packages.go
+++ b/services/packages/packages.go
@@ -401,7 +401,9 @@ func CheckSizeQuotaExceeded(ctx context.Context, doer, owner *user_model.User, p
 	}
 
 	if setting.Packages.LimitTotalOwnerSize > -1 {
-		totalSize, err := packages_model.CalculateCreatorPackageQuota(ctx, doer.ID)
+		totalSize, err := packages_model.CalculateFileSize(ctx, &packages_model.PackageFileSearchOptions{
+			OwnerID: owner.ID,
+		})
 		if err != nil {
 			log.Error("CalculateFileSize failed: %v", err)
 			return err


### PR DESCRIPTION
This reverts commit #28007 60522fc96f1fa4675e95010e4b1535e0eac21910.
