### PR TITLE
Decrease issue font size in project template

### DIFF
--- a/web_src/css/repo/issue-card.css
+++ b/web_src/css/repo/issue-card.css
@@ -16,6 +16,6 @@
 
 .issue-card-title {
   flex: 1;
-  font-size: 18px;
+  font-size: 14px;
   margin-left: 4px;
 }


### PR DESCRIPTION
I propose to decrease font size. 18 is too big and looks ugly, on windows. 14 is on par with other elements and save a bit of space. 
![image](https://github.com/go-gitea/gitea/assets/13328513/bc41f65d-8f48-4fd9-8e3b-d7a73967b0aa)
![image](https://github.com/go-gitea/gitea/assets/13328513/70e78919-9b9b-4f57-a491-d746ea59c048)
