### PR TITLE
Fix system config cache expiration timing

### DIFF
--- a/models/system/setting.go
+++ b/models/system/setting.go
@@ -119,20 +119,20 @@ func (d *dbConfigCachedGetter) GetRevision(ctx context.Context) int {
 	if time.Since(d.cacheTime) < time.Second {
 		return d.revision
 	}
+	d.mu.RUnlock()
+	d.mu.Lock()
 	if GetRevision(ctx) != d.revision {
-		d.mu.RUnlock()
-		d.mu.Lock()
 		rev, set, err := GetAllSettings(ctx)
 		if err != nil {
 			log.Error("Unable to get all settings: %v", err)
 		} else {
-			d.cacheTime = time.Now()
 			d.revision = rev
 			d.settings = set
 		}
-		d.mu.Unlock()
-		d.mu.RLock()
 	}
+	d.cacheTime = time.Now()
+	d.mu.Unlock()
+	d.mu.RLock()
 	return d.revision
 }
 


### PR DESCRIPTION
To avoid unnecessary database access, the `cacheTime` should always be set if the revision has been checked.

Fix #28057