### PR TITLE
add skip ci functionality

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1017,7 +1017,7 @@ LEVEL = Info
 ;ALLOWED_TYPES =
 ;;
 ;; Max size of each file in megabytes. Defaults to 50MB
-;FILE_MAX_SIZE = 50 
+;FILE_MAX_SIZE = 50
 ;;
 ;; Max number of files per upload. Defaults to 5
 ;MAX_FILES = 5
@@ -2583,6 +2583,8 @@ LEVEL = Info
 ;ENDLESS_TASK_TIMEOUT = 3h
 ;; Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
 ;ABANDONED_JOB_TIMEOUT = 24h
+;; Strings committers can place inside a commit message to skip executing the corresponding actions workflow
+;SKIP_WORKFLOW_STRINGS = "[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2584,7 +2584,7 @@ LEVEL = Info
 ;; Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
 ;ABANDONED_JOB_TIMEOUT = 24h
 ;; Strings committers can place inside a commit message to skip executing the corresponding actions workflow
-;SKIP_WORKFLOW_STRINGS = "[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"
+;SKIP_WORKFLOW_STRINGS = [skip ci],[ci skip],[no ci],[skip actions],[actions skip]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1396,7 +1396,7 @@ PROXY_HOSTS = *.github.com
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
-- `SKIP_WORKFLOW_STRINGS`: **"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
+- `SKIP_WORKFLOW_STRINGS`: **[skip ci],[ci skip],[no ci],[skip actions],[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
 For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1396,7 +1396,7 @@ PROXY_HOSTS = *.github.com
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
-- `SKIP_WORKFLOW_STRINGS`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
+- `SKIP_WORKFLOW_STRINGS`: **"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
 For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1396,7 +1396,7 @@ PROXY_HOSTS = *.github.com
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
-- `SKIP_RUN_PREFIX`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Prefixes committers can place inside a commit message to skip executing the workflow
+- `SKIP_RUN_STRINGS`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
 For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1396,6 +1396,7 @@ PROXY_HOSTS = *.github.com
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
+- `SKIP_RUN_PREFIX`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Prefixes committers can place inside a commit message to skip executing the workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
 For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1396,7 +1396,7 @@ PROXY_HOSTS = *.github.com
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time
-- `SKIP_RUN_STRINGS`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
+- `SKIP_WORKFLOW_STRINGS`: **[skip ci]**, **[ci skip]**, **[no ci]**, **[skip actions]**, **[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
 For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -22,11 +22,11 @@ var (
 		ZombieTaskTimeout     time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
 		EndlessTaskTimeout    time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
 		AbandonedJobTimeout   time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`
-		SkipRunPrefix         []string          `ìni:"SKIP_RUN_PREFIX"`
+		SkipRunStrings        []string          `ìni:"SKIP_RUN_STRINGS"`
 	}{
 		Enabled:           true,
 		DefaultActionsURL: defaultActionsURLGitHub,
-		SkipRunPrefix:     []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
+		SkipRunStrings:    []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
 	}
 )
 

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -22,9 +22,11 @@ var (
 		ZombieTaskTimeout     time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
 		EndlessTaskTimeout    time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
 		AbandonedJobTimeout   time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`
+		SkipRunPrefix         []string          `ìni:"SKIP_RUN_PREFIX"`
 	}{
 		Enabled:           true,
 		DefaultActionsURL: defaultActionsURLGitHub,
+		SkipRunPrefix:     []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
 	}
 )
 

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -22,11 +22,11 @@ var (
 		ZombieTaskTimeout     time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
 		EndlessTaskTimeout    time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
 		AbandonedJobTimeout   time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`
-		SkipRunStrings        []string          `ìni:"SKIP_RUN_STRINGS"`
+		SkipWorkflowStrings   []string          `ìni:"SKIP_WORKFLOW_STRINGS"`
 	}{
-		Enabled:           true,
-		DefaultActionsURL: defaultActionsURLGitHub,
-		SkipRunStrings:    []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
+		Enabled:             true,
+		DefaultActionsURL:   defaultActionsURLGitHub,
+		SkipWorkflowStrings: []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
 	}
 )
 

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -146,11 +146,11 @@ func notify(ctx context.Context, input *notifyInput) error {
 	}
 
 	if input.Event == webhook_module.HookEventPush || input.Event == webhook_module.HookEventPullRequest {
-		// skip runs with skip ci prefix in commit message if the event is push or pull_request
+		// skip runs with a configured skip-ci string in commit message if the event is push or pull_request
 		// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-		for _, prefix := range setting.Actions.SkipRunPrefix {
-			if strings.HasPrefix(commit.CommitMessage, prefix) {
-				log.Debug("repo %s with commit %s: skipped run because of %s prefix", input.Repo.RepoPath(), commit.ID, prefix)
+		for _, s := range setting.Actions.SkipRunStrings {
+			if strings.Contains(commit.CommitMessage, s) {
+				log.Debug("repo %s with commit %s: skipped run because of %s string", input.Repo.RepoPath(), commit.ID, s)
 				return nil
 			}
 		}

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -202,15 +202,15 @@ func notify(ctx context.Context, input *notifyInput) error {
 }
 
 func skipWorkflowsForCommit(input *notifyInput, commit *git.Commit) bool {
-	// skip runs with a configured skip-ci string in commit message if the event is push or pull_request(_sync)
+	// skip workflow runs with a configured skip-ci string in commit message if the event is push or pull_request(_sync)
 	// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-	skipRunEvents := []webhook_module.HookEventType{
+	skipWorkflowEvents := []webhook_module.HookEventType{
 		webhook_module.HookEventPush,
 		webhook_module.HookEventPullRequest,
 		webhook_module.HookEventPullRequestSync,
 	}
-	if slices.Contains(skipRunEvents, input.Event) {
-		for _, s := range setting.Actions.SkipRunStrings {
+	if slices.Contains(skipWorkflowEvents, input.Event) {
+		for _, s := range setting.Actions.SkipWorkflowStrings {
 			if strings.Contains(commit.CommitMessage, s) {
 				log.Debug("repo %s with commit %s: skipped run because of %s string", input.Repo.RepoPath(), commit.ID, s)
 				return true

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -146,7 +146,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 		return fmt.Errorf("gitRepo.GetCommit: %w", err)
 	}
 
-	if skipped := skipCIRuns(input, commit); skipped {
+	if skipped := skipWorkflowsForCommit(input, commit); skipped {
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 	return handleWorkflows(ctx, detectedWorkflows, commit, input, ref)
 }
 
-func skipCIRuns(input *notifyInput, commit *git.Commit) bool {
+func skipWorkflowsForCommit(input *notifyInput, commit *git.Commit) bool {
 	// skip runs with a configured skip-ci string in commit message if the event is push or pull_request(_sync)
 	// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
 	skipRunEvents := []webhook_module.HookEventType{

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	actions_model "code.gitea.io/gitea/models/actions"
@@ -145,7 +146,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 		return fmt.Errorf("gitRepo.GetCommit: %w", err)
 	}
 
-	if input.Event == webhook_module.HookEventPush || input.Event == webhook_module.HookEventPullRequest {
+	if slices.Contains([]webhook_module.HookEventType{webhook_module.HookEventPush, webhook_module.HookEventPullRequest, webhook_module.HookEventPullRequestSync}, input.Event) {
 		// skip runs with a configured skip-ci string in commit message if the event is push or pull_request
 		// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
 		for _, s := range setting.Actions.SkipRunStrings {

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -20,6 +20,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	webhook_module "code.gitea.io/gitea/modules/webhook"
 	"code.gitea.io/gitea/services/convert"
@@ -147,7 +148,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 	if input.Event == webhook_module.HookEventPush || input.Event == webhook_module.HookEventPullRequest {
 		// skip runs with skip ci prefix in commit message if the event is push or pull_request
 		// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-		for _, prefix := range []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"} {
+		for _, prefix := range setting.Actions.SkipRunPrefix {
 			if strings.HasPrefix(commit.CommitMessage, prefix) {
 				log.Debug("repo %s with commit %s: skipped run because of %s prefix", input.Repo.RepoPath(), commit.ID, prefix)
 				return nil

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -146,8 +146,13 @@ func notify(ctx context.Context, input *notifyInput) error {
 		return fmt.Errorf("gitRepo.GetCommit: %w", err)
 	}
 
-	if slices.Contains([]webhook_module.HookEventType{webhook_module.HookEventPush, webhook_module.HookEventPullRequest, webhook_module.HookEventPullRequestSync}, input.Event) {
-		// skip runs with a configured skip-ci string in commit message if the event is push or pull_request
+	skipRunEvents := []webhook_module.HookEventType{
+		webhook_module.HookEventPush,
+		webhook_module.HookEventPullRequest,
+		webhook_module.HookEventPullRequestSync,
+	}
+	if slices.Contains(skipRunEvents, input.Event) {
+		// skip runs with a configured skip-ci string in commit message if the event is push or pull_request(_sync)
 		// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
 		for _, s := range setting.Actions.SkipRunStrings {
 			if strings.Contains(commit.CommitMessage, s) {

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -146,7 +146,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 		return fmt.Errorf("gitRepo.GetCommit: %w", err)
 	}
 
-	if skipped := skipWorkflowsForCommit(input, commit); skipped {
+	if skipWorkflowsForCommit(input, commit) {
 		return nil
 	}
 

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -203,7 +203,7 @@ func TestSkipCI(t *testing.T) {
 
 		// create the repo
 		repo, err := repo_service.CreateRepository(db.DefaultContext, user2, user2, repo_service.CreateRepoOptions{
-			Name:          "skip-ci-prefix",
+			Name:          "skip-ci",
 			Description:   "test skip ci functionality",
 			AutoInit:      true,
 			Gitignores:    "Go",
@@ -253,7 +253,7 @@ func TestSkipCI(t *testing.T) {
 		// a run has been created
 		assert.Equal(t, 1, unittest.GetCount(t, &actions_model.ActionRun{RepoID: repo.ID}))
 
-		// add a file with [skip ci] prefix in commit message
+		// add a file with a configured skip-ci string in commit message
 		addFileResp, err := files_service.ChangeRepoFiles(git.DefaultContext, repo, user2, &files_service.ChangeRepoFilesOptions{
 			Files: []*files_service.ChangeRepoFile{
 				{
@@ -262,7 +262,7 @@ func TestSkipCI(t *testing.T) {
 					ContentReader: strings.NewReader("bar"),
 				},
 			},
-			Message:   fmt.Sprintf("%s add bar", setting.Actions.SkipRunPrefix[0]),
+			Message:   fmt.Sprintf("%s add bar", setting.Actions.SkipRunStrings[0]),
 			OldBranch: "main",
 			NewBranch: "main",
 			Author: &files_service.IdentityOptions{
@@ -281,7 +281,7 @@ func TestSkipCI(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, addFileResp)
 
-		// the commit message contains a [skip ci] prefix, so there is still only 1 record
+		// the commit message contains a configured skip-ci string, so there is still only 1 record
 		assert.Equal(t, 1, unittest.GetCount(t, &actions_model.ActionRun{RepoID: repo.ID}))
 	})
 }

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -262,7 +262,7 @@ func TestSkipCI(t *testing.T) {
 					ContentReader: strings.NewReader("bar"),
 				},
 			},
-			Message:   fmt.Sprintf("%s add bar", setting.Actions.SkipRunStrings[0]),
+			Message:   fmt.Sprintf("%s add bar", setting.Actions.SkipWorkflowStrings[0]),
 			OldBranch: "main",
 			NewBranch: "main",
 			Author: &files_service.IdentityOptions{

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	user_model "code.gitea.io/gitea/models/user"
 	actions_module "code.gitea.io/gitea/modules/actions"
 	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/setting"
 	pull_service "code.gitea.io/gitea/services/pull"
 	repo_service "code.gitea.io/gitea/services/repository"
 	files_service "code.gitea.io/gitea/services/repository/files"
@@ -260,7 +262,7 @@ func TestSkipCI(t *testing.T) {
 					ContentReader: strings.NewReader("bar"),
 				},
 			},
-			Message:   "[skip ci] add bar",
+			Message:   fmt.Sprintf("%s add bar", setting.Actions.SkipRunPrefix[0]),
 			OldBranch: "main",
 			NewBranch: "main",
 			Author: &files_service.IdentityOptions{


### PR DESCRIPTION
Adds the possibility to skip workflow execution if the commit message contains a string like [skip ci] or similar.

The default strings are the same as on GitHub, users can also set custom ones in app.ini

Reference: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

Close #28020 
