### PR TITLE
Add ui.EDITOR_EOL, default to saving files with LF again

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1243,7 +1243,7 @@ LEVEL = Info
 ;; Default is "recentupdate", but you also have "alphabetically", "reverselastlogin", "newest", "oldest".
 ;EXPLORE_PAGING_DEFAULT_SORT = recentupdate
 ;;
-;; Default line ending format for the web editor. Either "LF" or "CRLF". Can be overridden with .editorconfig.
+;; Newline format for the web editor. Either "LF" or "CRLF". Can be overridden per-file with .editorconfig.
 ;EDITOR_EOL = LF
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1243,7 +1243,7 @@ LEVEL = Info
 ;; Default is "recentupdate", but you also have "alphabetically", "reverselastlogin", "newest", "oldest".
 ;EXPLORE_PAGING_DEFAULT_SORT = recentupdate
 ;;
-;; Default line ending format for the web editor. Either `LF` or `CRLF`. Can be overridden with .editorconfig.
+;; Default line ending format for the web editor. Either "LF" or "CRLF". Can be overridden with .editorconfig.
 ;EDITOR_EOL = LF
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1242,6 +1242,9 @@ LEVEL = Info
 ;; Change the sort type of the explore pages.
 ;; Default is "recentupdate", but you also have "alphabetically", "reverselastlogin", "newest", "oldest".
 ;EXPLORE_PAGING_DEFAULT_SORT = recentupdate
+;;
+;; Default line ending format for the web editor. Either `LF` or `CRLF`. Can be overridden with .editorconfig.
+;EDITOR_EOL = LF
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -232,7 +232,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `ONLY_SHOW_RELEVANT_REPOS`: **false**: Whether to only show relevant repos on the explore page when no keyword is specified and default sorting is used.
     A repo is considered irrelevant if it's a fork or if it has no metadata (no description, no icon, no topic).
 - `EXPLORE_PAGING_DEFAULT_SORT`: **recentupdate**: Change the sort type of the explore pages. Valid values are "recentupdate", "alphabetically", "reverselastlogin", "newest" and "oldest"
-- `EDITOR_EOL`: **LF**: Default line ending format for the web editor. Either "LF" or "CRLF". Can be overridden with .editorconfig.
+- `EDITOR_EOL`: **LF**: Newline format for the web editor. Either "LF" or "CRLF". Can be overridden per-file with .editorconfig.
 
 ### UI - Admin (`ui.admin`)
 

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -232,6 +232,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `ONLY_SHOW_RELEVANT_REPOS`: **false**: Whether to only show relevant repos on the explore page when no keyword is specified and default sorting is used.
     A repo is considered irrelevant if it's a fork or if it has no metadata (no description, no icon, no topic).
 - `EXPLORE_PAGING_DEFAULT_SORT`: **recentupdate**: Change the sort type of the explore pages. Valid values are "recentupdate", "alphabetically", "reverselastlogin", "newest" and "oldest"
+- `EDITOR_EOL`: **LF**: Default line ending format for the web editor. Either `LF` or `CRLF`. Can be overridden with .editorconfig.
 
 ### UI - Admin (`ui.admin`)
 

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -232,7 +232,7 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `ONLY_SHOW_RELEVANT_REPOS`: **false**: Whether to only show relevant repos on the explore page when no keyword is specified and default sorting is used.
     A repo is considered irrelevant if it's a fork or if it has no metadata (no description, no icon, no topic).
 - `EXPLORE_PAGING_DEFAULT_SORT`: **recentupdate**: Change the sort type of the explore pages. Valid values are "recentupdate", "alphabetically", "reverselastlogin", "newest" and "oldest"
-- `EDITOR_EOL`: **LF**: Default line ending format for the web editor. Either `LF` or `CRLF`. Can be overridden with .editorconfig.
+- `EDITOR_EOL`: **LF**: Default line ending format for the web editor. Either "LF" or "CRLF". Can be overridden with .editorconfig.
 
 ### UI - Admin (`ui.admin`)
 

--- a/modules/setting/ui.go
+++ b/modules/setting/ui.go
@@ -34,6 +34,7 @@ var UI = struct {
 	SearchRepoDescription bool
 	OnlyShowRelevantRepos bool
 	ExploreDefaultSort    string `ini:"EXPLORE_PAGING_DEFAULT_SORT"`
+	EditorEol             string `ini:"EDITOR_EOL"`
 
 	Notification struct {
 		MinTimeout            time.Duration
@@ -82,6 +83,7 @@ var UI = struct {
 	Reactions:           []string{`+1`, `-1`, `laugh`, `hooray`, `confused`, `heart`, `rocket`, `eyes`},
 	CustomEmojis:        []string{`git`, `gitea`, `codeberg`, `gitlab`, `github`, `gogs`},
 	CustomEmojisMap:     map[string]string{"git": ":git:", "gitea": ":gitea:", "codeberg": ":codeberg:", "gitlab": ":gitlab:", "github": ":github:", "gogs": ":gogs:"},
+	EditorEol:           `LF`,
 	Notification: struct {
 		MinTimeout            time.Duration
 		TimeoutStep           time.Duration

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -149,6 +149,9 @@ func NewFuncMap() template.FuncMap {
 		"MermaidMaxSourceCharacters": func() int {
 			return setting.MermaidMaxSourceCharacters
 		},
+		"EditorEol": func() string {
+			return setting.UI.EditorEol
+		},
 
 		// -----------------------------------------------------------------
 		// render

--- a/modules/util/string.go
+++ b/modules/util/string.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"strings"
+
 	"github.com/yuin/goldmark/util"
 )
 

--- a/modules/util/string.go
+++ b/modules/util/string.go
@@ -3,7 +3,10 @@
 
 package util
 
-import "github.com/yuin/goldmark/util"
+import (
+	"strings"
+	"github.com/yuin/goldmark/util"
+)
 
 func isSnakeCaseUpper(c byte) bool {
 	return 'A' <= c && c <= 'Z'
@@ -84,4 +87,12 @@ func ToSnakeCase(input string) string {
 		}
 	}
 	return util.BytesToReadOnlyString(res)
+}
+
+func ConvertToLF(str string) string {
+	return strings.ReplaceAll(str, "\r", "")
+}
+
+func ConvertToCRLF(str string) string {
+	return strings.ReplaceAll(ConvertToLF(str), "\n", "\r\n")
 }

--- a/modules/util/string.go
+++ b/modules/util/string.go
@@ -90,10 +90,12 @@ func ToSnakeCase(input string) string {
 	return util.BytesToReadOnlyString(res)
 }
 
-func ConvertToLF(str string) string {
+// convert all newlines in string to \n
+func ToLF(str string) string {
 	return strings.ReplaceAll(str, "\r", "")
 }
 
-func ConvertToCRLF(str string) string {
-	return strings.ReplaceAll(ConvertToLF(str), "\n", "\r\n")
+// convert all newlines in string to \r\n
+func ToCRLF(str string) string {
+	return strings.ReplaceAll(ToLF(str), "\n", "\r\n")
 }

--- a/modules/util/string_test.go
+++ b/modules/util/string_test.go
@@ -45,3 +45,11 @@ func TestToSnakeCase(t *testing.T) {
 		assert.Equal(t, expected, ToSnakeCase(input))
 	}
 }
+
+func TestConvertToLF(t *testing.T) {
+	assert.Equal(t, "\na\nbc\n\n", ConvertToLF("\r\na\r\nb\rc\n\n"))
+}
+
+func TestConvertToCRLF(t *testing.T) {
+	assert.Equal(t, "\r\na\r\nbc\r\n\r\n", ConvertToCRLF("\r\na\r\nb\rc\n\n"))
+}

--- a/modules/util/string_test.go
+++ b/modules/util/string_test.go
@@ -46,10 +46,10 @@ func TestToSnakeCase(t *testing.T) {
 	}
 }
 
-func TestConvertToLF(t *testing.T) {
-	assert.Equal(t, "\na\nbc\n\n", ConvertToLF("\r\na\r\nb\rc\n\n"))
+func TestToLF(t *testing.T) {
+	assert.Equal(t, "\na\nbc\n\n", ToLF("\r\na\r\nb\rc\n\n"))
 }
 
-func TestConvertToCRLF(t *testing.T) {
-	assert.Equal(t, "\r\na\r\nbc\r\n\r\n", ConvertToCRLF("\r\na\r\nb\rc\n\n"))
+func TestToCRLF(t *testing.T) {
+	assert.Equal(t, "\r\na\r\nbc\r\n\r\n", ToCRLF("\r\na\r\nb\rc\n\n"))
 }

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -278,23 +278,19 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 	}
 
 	eol := setting.UI.EditorEol
-	editorconfigEol := ""
 	ec, _, err := ctx.Repo.GetEditorconfig()
 	if err == nil {
 		def, err := ec.GetDefinitionForFilename(form.TreePath)
 		if err == nil {
-			editorconfigEol = strings.ToUpper(def.EndOfLine)
-			if editorconfigEol != "" {
-				eol = editorconfigEol
-			}
+			eol = strings.ToUpper(def.EndOfLine)
 		}
 	}
 
 	content := form.Content
 	if eol == "CRLF" {
-		content = util.ConvertToCRLF(content)
-	} else {
-		content = util.ConvertToLF(content)
+		content = util.ToCRLF(content)
+	} else { // convert to LF, this was hardcoded before 1.21
+		content = util.ToLF(content)
 	}
 
 	if _, err := files_service.ChangeRepoFiles(ctx, ctx.Repo.Repository, ctx.Doer, &files_service.ChangeRepoFilesOptions{

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -281,7 +281,7 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 	if setting.UI.EditorEol == "CRLF" {
 		content = util.ConvertToCRLF(content)
 	} else {
-		content = utils.ConvertToLF(content)
+		content = util.ConvertToLF(content)
 	}
 
 	if _, err := files_service.ChangeRepoFiles(ctx, ctx.Repo.Repository, ctx.Doer, &files_service.ChangeRepoFilesOptions{

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -277,8 +277,21 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 		operation = "create"
 	}
 
+	eol := setting.UI.EditorEol
+	editorconfigEol := ""
+	ec, _, err := ctx.Repo.GetEditorconfig()
+	if err == nil {
+		def, err := ec.GetDefinitionForFilename(form.TreePath)
+		if err == nil {
+			editorconfigEol = strings.ToUpper(def.EndOfLine)
+			if editorconfigEol != "" {
+				eol = editorconfigEol
+			}
+		}
+	}
+
 	content := form.Content
-	if setting.UI.EditorEol == "CRLF" {
+	if eol == "CRLF" {
 		content = util.ConvertToCRLF(content)
 	} else {
 		content = util.ConvertToLF(content)

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -277,6 +277,13 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 		operation = "create"
 	}
 
+	content := form.Content
+	if setting.UI.EditorEol == "CRLF" {
+		content = util.ConvertToCRLF(content)
+	} else {
+		content = utils.ConvertToLF(content)
+	}
+
 	if _, err := files_service.ChangeRepoFiles(ctx, ctx.Repo.Repository, ctx.Doer, &files_service.ChangeRepoFilesOptions{
 		LastCommitID: form.LastCommit,
 		OldBranch:    ctx.Repo.BranchName,
@@ -287,7 +294,7 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 				Operation:     operation,
 				FromTreePath:  ctx.Repo.TreePath,
 				TreePath:      form.TreePath,
-				ContentReader: strings.NewReader(form.Content),
+				ContentReader: strings.NewReader(content),
 			},
 		},
 		Signoff: form.Signoff,

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -42,6 +42,7 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 			modal_confirm: {{ctx.Locale.Tr "modal.confirm"}},
 			modal_cancel: {{ctx.Locale.Tr "modal.cancel"}},
 		},
+		editorEol: '{{EditorEol}}',
 	};
 	{{/* in case some pages don't render the pageData, we make sure it is an object to prevent null access */}}
 	window.config.pageData = window.config.pageData || {};

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -42,7 +42,6 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 			modal_confirm: {{ctx.Locale.Tr "modal.confirm"}},
 			modal_cancel: {{ctx.Locale.Tr "modal.cancel"}},
 		},
-		editorEol: '{{EditorEol}}',
 	};
 	{{/* in case some pages don't render the pageData, we make sure it is an object to prevent null access */}}
 	window.config.pageData = window.config.pageData || {};

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -40,7 +40,8 @@
 						data-context="{{.RepoLink}}"
 						data-previewable-extensions="{{.PreviewableExtensions}}"
 						data-line-wrap-extensions="{{.LineWrapExtensions}}"
-						data-initial-value="{{JsonUtils.EncodeToString .FileContent}}"></textarea>
+						data-initial-value="{{JsonUtils.EncodeToString .FileContent}}"
+						data-editor-eol="{{EditorEol}}"></textarea>
 					<div class="editor-loading is-loading"></div>
 				</div>
 				<div class="ui bottom attached tab segment markup" data-tab="preview">

--- a/web_src/js/features/codeeditor.js
+++ b/web_src/js/features/codeeditor.js
@@ -4,6 +4,7 @@ import {onInputDebounce} from '../utils/dom.js';
 
 const languagesByFilename = {};
 const languagesByExt = {};
+const {editorEol} = window.config;
 
 const baseOptions = {
   fontFamily: 'var(--fonts-monospace)',
@@ -62,7 +63,7 @@ export async function createMonaco(textarea, filename, editorOpts) {
   const monaco = await import(/* webpackChunkName: "monaco" */'monaco-editor');
 
   initLanguages(monaco);
-  let {language, eol, ...other} = editorOpts;
+  let {language, eol: editorConfigEol, ...other} = editorOpts;
   if (!language) language = getLanguage(filename);
 
   const container = document.createElement('div');
@@ -121,8 +122,8 @@ export async function createMonaco(textarea, filename, editorOpts) {
 
   const model = editor.getModel();
 
-  // Monaco performs auto-detection of dominant EOL in the file, biased towards LF for
-  // empty files. If there is an editorconfig value, override this detected value.
+  // Use eol format from editorconfig if present, otherwise fall back to ui.EDITOR_EOL
+  const eol = editorConfigEol ?? editorEol;
   if (eol in monaco.editor.EndOfLineSequence) {
     model.setEOL(monaco.editor.EndOfLineSequence[eol]);
   }

--- a/web_src/js/features/codeeditor.js
+++ b/web_src/js/features/codeeditor.js
@@ -4,7 +4,6 @@ import {onInputDebounce} from '../utils/dom.js';
 
 const languagesByFilename = {};
 const languagesByExt = {};
-const {editorEol} = window.config;
 
 const baseOptions = {
   fontFamily: 'var(--fonts-monospace)',
@@ -123,7 +122,8 @@ export async function createMonaco(textarea, filename, editorOpts) {
   const model = editor.getModel();
 
   // Use eol format from editorconfig if present, otherwise fall back to ui.EDITOR_EOL
-  const eol = editorConfigEol ?? editorEol;
+  const editorEol = textarea.getAttribute('data-editor-eol');
+  const eol = editorConfigEol || editorEol || "LF";
   if (eol in monaco.editor.EndOfLineSequence) {
     model.setEOL(monaco.editor.EndOfLineSequence[eol]);
   }


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/28097
Replaces: https://github.com/go-gitea/gitea/pull/28101

Assuming we consider it a bug that people on Windows get CRLF endings without a editorconfig, we should backport this to 1.21.