### PR TITLE
Prevent multiple codecomments to be submitted

### DIFF
--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -45,6 +45,9 @@ function initRepoDiffConversationForm() {
     e.preventDefault();
 
     const $form = $(e.target);
+    if ($form.hasClass('is-loading')) return;
+    $form.addClass('is-loading');
+
     const $textArea = $form.find('textarea');
     if (!validateTextareaNonEmpty($textArea)) {
       return;


### PR DESCRIPTION
- Utilize the existing `is-loading` class to prevent the submit code from running twice or more.
- The `is-loading` class gives us a nice loading indicator when added to the form.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1476

(cherry picked from commit 85048c96608004988f57a57358c9cda91f095e23)
