### PR TITLE
Do not display search box when there's no packages yet

### DIFF
--- a/templates/package/shared/list.tmpl
+++ b/templates/package/shared/list.tmpl
@@ -1,4 +1,5 @@
 {{template "base/alert" .}}
+{{if .HasPackages}}
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
 		{{template "shared/searchinput" dict "Value" .Query}}
@@ -12,6 +13,7 @@
 		<button class="ui primary button">{{ctx.Locale.Tr "explore.search"}}</button>
 	</div>
 </form>
+{{end}}
 <div>
 	{{range .PackageDescriptors}}
 	<div class="flex-list">


### PR DESCRIPTION
Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/3012f544-7ff5-4ccb-ac80-ce24d50abe97)

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/4084312a-9ac0-4103-8c93-ea178ae24493)
![image](https://github.com/go-gitea/gitea/assets/18380374/3c47d175-0735-476d-8979-da2bc0a4fc95)
![image](https://github.com/go-gitea/gitea/assets/18380374/033c6a81-d1f7-4426-8063-5793d0b47462)
