### PR TITLE
Fix no ActionTaskOutput table waring

### DIFF
--- a/models/actions/task_output.go
+++ b/models/actions/task_output.go
@@ -20,6 +20,10 @@ type ActionTaskOutput struct {
 	OutputValue string `xorm:"MEDIUMTEXT"`
 }
 
+func init() {
+	db.RegisterModel(new(ActionTaskOutput))
+}
+
 // FindTaskOutputByTaskID returns the outputs of the task.
 func FindTaskOutputByTaskID(ctx context.Context, taskID int64) ([]*ActionTaskOutput, error) {
 	var outputs []*ActionTaskOutput


### PR DESCRIPTION
Reproduce:
- Create a new Gitea instance
- Register a runner
- Create a repo and add a workflow
- Check the log, you will see warnings:
![image](https://github.com/go-gitea/gitea/assets/18380374/5f1278e0-114b-48bc-8113-8ba1404d9975)
It comes from:
![image](https://github.com/go-gitea/gitea/assets/18380374/c2807831-e137-4229-9536-87f6114c8a5b)

The reason is that we forgot registering `ActionTaskOutput` model.
So `action_table_output` table will be missing in your db.