### PR TITLE
Fix 0x00 postgres

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -1274,6 +1274,7 @@ func InsertIssueComments(ctx context.Context, comments []*Comment) error {
 	}
 	defer committer.Close()
 	for _, comment := range comments {
+		comment.Content = replaceNullByte(comment.Content)
 		if _, err := db.GetEngine(ctx).NoAutoTime().Insert(comment); err != nil {
 			return err
 		}


### PR DESCRIPTION
When migrating https://gitea.com/xorm/xorm into a gitea instance with postgres, it will report a postgres text column cannot include `0x00` char error.

This PR will replace all issue title/content and comment content `0x00` as empty before migrating.