### PR TITLE
Revert Fixing redirection issue for logged-in users #26105

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -487,9 +487,8 @@ func registerRoutes(m *web.Route) {
 	m.Get("/milestones", reqSignIn, reqMilestonesDashboardPageEnabled, user.Milestones)
 
 	// ***** START: User *****
-	// "user/login" doesn't need signOut, then logged-in users can still access this route for redirection purposes by "/user/login?redirec_to=..."
-	m.Get("/user/login", auth.SignIn)
 	m.Group("/user", func() {
+		m.Get("/login", auth.SignIn)
 		m.Post("/login", web.Bind(forms.SignInForm{}), auth.SignInPost)
 		m.Group("", func() {
 			m.Combo("/login/openid").


### PR DESCRIPTION
IMO the fix in #26105 is not good enough.
And I see that in #27028, we have already support check `redirect_to` in `verifyAuthWithOptions`.
![image](https://github.com/go-gitea/gitea/assets/18380374/e94b4557-21ee-40a3-8ceb-04440fcf2514)

Ttested in my local pc, #26005 will not disappear again after revert the patch from #26105.
So I think we can revert it now.