### PR TITLE
Use full width for PR comparison

### DIFF
--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -2,7 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content repository diff {{if .PageIsComparePull}}compare pull{{end}}">
 	{{template "repo/header" .}}
 	{{$showDiffBox := false}}
-	<div class="ui container">
+	<div class="ui container fluid padded">
 	<h2 class="ui header">
 		{{if and $.PageIsComparePull $.IsSigned (not .Repository.IsArchived)}}
 			{{ctx.Locale.Tr "repo.pulls.compare_changes"}}
@@ -235,7 +235,7 @@
 	</div>
 
 	{{if $showDiffBox}}
-	<div class="ui container">
+	<div class="ui container fluid padded">
 		{{template "repo/commits_table" .}}
 		{{template "repo/diff/box" .}}
 	</div>


### PR DESCRIPTION
Follow-up #22844 
close #28142 
Before 
![ksnip_20231123-183906](https://github.com/go-gitea/gitea/assets/70063547/78428a22-b0a0-45f9-9458-7fd5ec73aa29)
After
![full](https://github.com/go-gitea/gitea/assets/70063547/047242cf-9d6c-4b3a-9f92-54102740c27e)
