### PR TITLE
Make CORS work for oauth2 handlers

### DIFF
--- a/modules/web/route.go
+++ b/modules/web/route.go
@@ -136,6 +136,10 @@ func (r *Route) Get(pattern string, h ...any) {
 	r.Methods("GET", pattern, h...)
 }
 
+func (r *Route) Options(pattern string, h ...any) {
+	r.Methods("OPTIONS", pattern, h...)
+}
+
 // GetOptions delegate get and options method
 func (r *Route) GetOptions(pattern string, h ...any) {
 	r.Methods("GET,OPTIONS", pattern, h...)

--- a/routers/web/misc/misc.go
+++ b/routers/web/misc/misc.go
@@ -33,6 +33,10 @@ func DummyOK(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func DummyBadRequest(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusBadRequest)
+}
+
 func RobotsTxt(w http.ResponseWriter, req *http.Request) {
 	robotsTxt := util.FilePathJoinAbs(setting.CustomPath, "public/robots.txt")
 	if ok, _ := util.IsExist(robotsTxt); !ok {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -533,8 +533,10 @@ func registerRoutes(m *web.Route) {
 		m.Post("/authorize", web.Bind(forms.AuthorizationForm{}), auth.AuthorizeOAuth)
 	}, ignSignInAndCsrf, reqSignIn)
 	m.Get("/login/oauth/userinfo", ignSignInAndCsrf, auth.InfoOAuth)
+	m.Options("/login/oauth/access_token", CorsHandler(), misc.DummyBadRequest)
 	m.Post("/login/oauth/access_token", CorsHandler(), web.Bind(forms.AccessTokenForm{}), ignSignInAndCsrf, auth.AccessTokenOAuth)
 	m.Get("/login/oauth/keys", ignSignInAndCsrf, auth.OIDCKeys)
+	m.Options("/login/oauth/introspect", CorsHandler(), misc.DummyBadRequest)
 	m.Post("/login/oauth/introspect", CorsHandler(), web.Bind(forms.IntrospectTokenForm{}), ignSignInAndCsrf, auth.IntrospectOAuth)
 
 	m.Group("/user/settings", func() {


### PR DESCRIPTION
Fix #25473

Although there was `m.Post("/login/oauth/access_token", CorsHandler() ...` ,it never really worked, because it still lacks the "OPTIONS" handler.

After the fix:

```
$ curl -v -X OPTIONS --header "Access-Control-Request-Method: POST" http://localhost:3000/login/oauth/access_token
*   Trying 127.0.0.1:3000...
> OPTIONS /login/oauth/access_token HTTP/1.1
> Accept: */*
> Access-Control-Request-Method: POST
>
< HTTP/1.1 200 OK
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< X-Frame-Options: SAMEORIGIN
< X-Gitea-Debug: RUN_MODE=dev
< Date: Thu, 23 Nov 2023 11:45:36 GMT
< Content-Length: 0



$ curl -v -X OPTIONS http://localhost:3000/login/oauth/access_token
> OPTIONS /login/oauth/access_token HTTP/1.1
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Vary: Origin
< X-Frame-Options: SAMEORIGIN
< X-Gitea-Debug: RUN_MODE=dev
< Date: Thu, 23 Nov 2023 11:45:32 GMT
< Content-Length: 0

```

ps: I haven't fully tested the "oauth2 cors client", we can make further fixes if there are still problems.
