### PR TITLE
Docs: Replace deprecated IS_TLS_ENABLED mailer setting in email setup

### DIFF
--- a/docs/content/administration/email-setup.en-us.md
+++ b/docs/content/administration/email-setup.en-us.md
@@ -61,7 +61,7 @@ Please note: authentication is only supported when the SMTP server communication
 
 - STARTTLS (also known as Opportunistic TLS) via port 587. Initial connection is done over cleartext, but then be upgraded over TLS if the server supports it.
 - SMTPS connection (SMTP over TLS) via the default port 465. Connection to the server use TLS from the beginning.
-- Forced SMTPS connection with `PROTOCOL=SMTPS`. (These are both known as Implicit TLS.)
+- Forced SMTPS connection with `PROTOCOL=smtps`. (These are both known as Implicit TLS.)
 This is due to protections imposed by the Go internal libraries against STRIPTLS attacks.
 
 Note that Implicit TLS is recommended by [RFC8314](https://tools.ietf.org/html/rfc8314#section-3) since 2018.

--- a/docs/content/administration/email-setup.en-us.md
+++ b/docs/content/administration/email-setup.en-us.md
@@ -61,7 +61,7 @@ Please note: authentication is only supported when the SMTP server communication
 
 - STARTTLS (also known as Opportunistic TLS) via port 587. Initial connection is done over cleartext, but then be upgraded over TLS if the server supports it.
 - SMTPS connection (SMTP over TLS) via the default port 465. Connection to the server use TLS from the beginning.
-- Forced SMTPS connection with `IS_TLS_ENABLED=true`. (These are both known as Implicit TLS.)
+- Forced SMTPS connection with `PROTOCOL=SMTPS`. (These are both known as Implicit TLS.)
 This is due to protections imposed by the Go internal libraries against STRIPTLS attacks.
 
 Note that Implicit TLS is recommended by [RFC8314](https://tools.ietf.org/html/rfc8314#section-3) since 2018.

--- a/docs/content/administration/email-setup.zh-cn.md
+++ b/docs/content/administration/email-setup.zh-cn.md
@@ -61,7 +61,7 @@ PASSWD         = `password`
 
 - 通过端口 587 的 STARTTLS（也称为 Opportunistic TLS）。初始连接是明文的，但如果服务器支持，则可以升级为 TLS。
 - 通过默认端口 465 的 SMTPS 连接。连接到服务器从一开始就使用 TLS。
-- 使用 `IS_TLS_ENABLED=true` 进行强制的 SMTPS 连接。（这两种方式都被称为 Implicit TLS）
+- 使用 `PROTOCOL=smtps` 进行强制的 SMTPS 连接。（这两种方式都被称为 Implicit TLS）
 这是由于 Go 内部库对 STRIPTLS 攻击的保护机制。
 
 请注意，自2018年起，[RFC8314](https://tools.ietf.org/html/rfc8314#section-3) 推荐使用 Implicit TLS。


### PR DESCRIPTION
In the [docs for email setup](https://docs.gitea.com/administration/email-setup) `mailer.IS_TLS_ENABLED` is mentioned which was replaced by `mailer.PROTOCOL` in release 1.18.0 according to https://blog.gitea.com/release-of-1.18.0/ . This change wasn't reflected in the docs for email setup. I just replaced the deprecated mailer setting. 
