### PR TITLE
Fix Docker meta action for releases

### DIFF
--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -78,6 +78,8 @@ jobs:
         id: meta
         with:
           images: gitea/gitea
+          flavor: |
+            latest=false
           # 1.2.3-rc0
           tags: |
             type=semver,pattern={{version}}
@@ -109,6 +111,7 @@ jobs:
           images: gitea/gitea
           # each tag below will have the suffix of -rootless
           flavor: |
+            latest=false
             suffix=-rootless
           # 1.2.3-rc0
           tags: |

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -86,7 +86,6 @@ jobs:
           # 1.2
           # 1.2.3
           tags: |
-            type=raw,value=latest
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{version}}
@@ -118,14 +117,13 @@ jobs:
           images: gitea/gitea
           # each tag below will have the suffix of -rootless
           flavor: |
-            suffix=-rootless
+            suffix=-rootless,onlatest=true
           # this will generate tags in the following format (with -rootless suffix added):
           # latest
           # 1
           # 1.2
           # 1.2.3
           tags: |
-            type=raw,value=latest
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{version}}


### PR DESCRIPTION
Should fix #28229 and #28230 for next release.

Assuming I'm reading the docs correctly for the docker meta action:

https://github.com/docker/metadata-action#flavor-input
https://github.com/docker/metadata-action#latest-tag

1. We want `latest=false` for the RCs.
2. `latest` should happen already due to `auto` mode, however there's an extra option for the `suffix` flavor.

This PR is ready, but leaving it as draft to make sure someone double-checks my sleuth-work.