### PR TITLE
Fix links in docs

### DIFF
--- a/docs/content/administration/email-setup.zh-cn.md
+++ b/docs/content/administration/email-setup.zh-cn.md
@@ -55,7 +55,7 @@ PASSWD         = `password`
 
 要发送测试邮件以验证设置，请转到 Gitea > 站点管理 > 配置 > SMTP 邮件配置。
 
-有关所有选项的完整列表，请查看[配置速查表](doc/administration/config-cheat-sheet.md)。
+有关所有选项的完整列表，请查看[配置速查表](administration/config-cheat-sheet.md)。
 
 请注意：只有在使用 TLS 或 `HOST=localhost` 加密 SMTP 服务器通信时才支持身份验证。TLS 加密可以通过以下方式进行：
 

--- a/docs/content/usage/actions/act-runner.en-us.md
+++ b/docs/content/usage/actions/act-runner.en-us.md
@@ -114,7 +114,7 @@ If you cannot see the settings page, please make sure that you have the right pe
 
 The format of the registration token is a random string `D0gvfu2iHfUjNqCYVljVyRV14fISpJxxxxxxxxxx`.
 
-A registration token can also be obtained from the gitea [command-line interface](../../administration/command-line.md#actions-generate-runner-token):
+A registration token can also be obtained from the gitea [command-line interface](administration/command-line.md#actions-generate-runner-token):
 
 ```
 gitea --config /etc/gitea/app.ini actions generate-runner-token

--- a/docs/content/usage/actions/act-runner.zh-cn.md
+++ b/docs/content/usage/actions/act-runner.zh-cn.md
@@ -113,7 +113,7 @@ Runner级别决定了从哪里获取注册令牌。
 
 注册令牌的格式是一个随机字符串 `D0gvfu2iHfUjNqCYVljVyRV14fISpJxxxxxxxxxx`。
 
-注册令牌也可以通过 Gitea 的 [命令行](../../administration/command-line.md#actions-generate-runner-token) 获得:
+注册令牌也可以通过 Gitea 的 [命令行](administration/command-line.md#actions-generate-runner-token) 获得:
 
 ### 注册Runner
 


### PR DESCRIPTION
Follow #28191

Changes:
- `(doc/administration/config-cheat-sheet.md` is incorrect:
![image](https://github.com/go-gitea/gitea/assets/18380374/1c417dd7-61a0-49ba-8d50-871fd4c9bf20)
- remove `../../`