### PR TITLE
Increase "version" when update the setting value to a same value as before

### DIFF
--- a/models/system/setting.go
+++ b/models/system/setting.go
@@ -81,7 +81,7 @@ func SetSettings(ctx context.Context, settings map[string]string) error {
 			return err
 		}
 		for k, v := range settings {
-			res, err := e.Exec("UPDATE system_setting SET setting_value=? WHERE setting_key=?", v, k)
+			res, err := e.Exec("UPDATE system_setting SET version=version+1, setting_value=? WHERE setting_key=?", v, k)
 			if err != nil {
 				return err
 			}

--- a/models/system/setting_test.go
+++ b/models/system/setting_test.go
@@ -39,4 +39,16 @@ func TestSettings(t *testing.T) {
 	assert.EqualValues(t, 3, rev)
 	assert.Len(t, settings, 2)
 	assert.EqualValues(t, "false", settings[keyName])
+
+	// setting the same value should not trigger DuplicateKey error, and the "version" should be increased
+	setting := &system.Setting{SettingKey: keyName}
+	_, err = db.GetByBean(db.DefaultContext, setting)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, setting.Version)
+	err = system.SetSettings(db.DefaultContext, map[string]string{keyName: "false"})
+	assert.NoError(t, err)
+	setting = &system.Setting{SettingKey: keyName}
+	_, err = db.GetByBean(db.DefaultContext, setting)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, setting.Version)
 }


### PR DESCRIPTION
Setting the same value should not trigger DuplicateKey error, and the "version" should be increased

Fix #28242 