### PR TITLE
Check for v prefix on tags for release clean name

### DIFF
--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Get cleaned branch name
         id: clean_name
         run: |
-          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
           echo "Cleaned name is ${REF_NAME}"
           echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: configure aws

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get cleaned branch name
         id: clean_name
         run: |
-          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
           echo "Cleaned name is ${REF_NAME}"
           echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: configure aws


### PR DESCRIPTION
As title, this will strip the `v` prefix when getting a "clean" name for a tag.

From the last run:
https://github.com/go-gitea/gitea/actions/runs/7015365494/job/19084572109
`REF_NAME=$(echo "refs/tags/v1.20.6" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')` \
It strips `ref/tags/` and just needs to strip the additional `v`.