### PR TITLE
Add cancel button to wiki

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1882,6 +1882,7 @@ wiki.page_title = Page title
 wiki.page_content = Page content
 wiki.default_commit_message = Write a note about this page update (optional).
 wiki.save_page = Save Page
+wiki.cancel = Cancel
 wiki.last_commit_info = %s edited this page %s
 wiki.edit_page_button = Edit
 wiki.new_page_button = New Page

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -39,6 +39,7 @@
 				<button class="ui primary button">
 					{{ctx.Locale.Tr "repo.wiki.save_page"}}
 				</button>
+				<a class="ui button red" href="{{.Link}}">{{ctx.Locale.Tr "repo.wiki.cancel"}}</a>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
- Add a cancel button to the Edit and New wiki pages.
- Resolves https://codeberg.org/forgejo/forgejo/issues/705

(cherry picked from commit 9f8bf83b0e7845a44ca91bc8497356dbab059374)
