### PR TITLE
Improve display of Webauthn keys' creation time

### DIFF
--- a/templates/user/settings/security/webauthn.tmpl
+++ b/templates/user/settings/security/webauthn.tmpl
@@ -10,7 +10,7 @@
 				</div>
 				<div class="flex-item-main">
 					<div class="flex-item-title">{{.Name}}</div>
-					<span class="flex-item-body time">{{TimeSinceUnix .CreatedUnix ctx.Locale}}</span>
+					<i class="flex-item-body">{{ctx.Locale.Tr "settings.added_on" (DateTime "short" .CreatedUnix) | Safe}}</i>
 				</div>
 				<div class="flex-item-trailing">
 					<button class="ui red tiny button delete-button" data-modal-id="delete-registration" data-url="{{$.Link}}/webauthn/delete" data-id="{{.ID}}">


### PR DESCRIPTION
- Unify how the creation time of webauthn keys are shown with GPG and SSH keys.
- Instead of using the time since, show the date that the key was created.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1794

(cherry picked from commit 0a2db6215cb10a6bfcb558f5afabc7fba208e3f8)
