### PR TITLE
Make pushUpdate error verbose

### DIFF
--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -35,7 +35,9 @@ var pushQueue *queue.WorkerPoolQueue[[]*repo_module.PushUpdateOptions]
 func handler(items ...[]*repo_module.PushUpdateOptions) [][]*repo_module.PushUpdateOptions {
 	for _, opts := range items {
 		if err := pushUpdates(opts); err != nil {
-			log.Error("pushUpdate failed: %v", err)
+			// Username and repository stays the same between items in opts.
+			pushUpdate := opts[0]
+			log.Error("pushUpdate[%s/%s] failed: %v", pushUpdate.RepoUserName, pushUpdate.RepoName, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Push commits updates are run in a queue and updates can come from less traceable places such as Git over SSH, therefor add more information about on which repository the pushUpdate failed.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1723

(cherry picked from commit 37ab9460394800678d2208fed718e719d7a5d96f)
