### PR TITLE
Ignore temporary files for directory size

### DIFF
--- a/modules/repository/create.go
+++ b/modules/repository/create.go
@@ -167,7 +167,11 @@ func getDirectorySize(path string) (int64, error) {
 			}
 			return err
 		}
-		if info.IsDir() {
+
+		fileName := info.Name()
+		// Ignore temporary Git files as they will like be missing once info.Info is
+		// called and cause a disrupt to the whole operation.
+		if info.IsDir() || strings.HasSuffix(fileName, ".lock") || strings.HasPrefix(filepath.Base(fileName), "tmp_graph") {
 			return nil
 		}
 		f, err := info.Info()


### PR DESCRIPTION
- While looking trough the logs for unrelated things I noticed errors for directory size calculations in `pushUpdates` that were being caused by a race condition in which git was making temporary file, `filepath.WalkDir` noticed that but by the time the second lstat came(`info.Info()`) it was already gone and it would error.
- Ignore temporary files created by Git.
- There are other cases but much much more rarer and not trivial to detect.

Examples:

...s/repository/push.go:96:pushUpdates() [E] Failed to update size for repository: updateSize: lstat [...]/objects/info/commit-graphs/tmp_graph_Wcy9kR: no such file or directory
...s/repository/push.go:96:pushUpdates() [E] Failed to update size for repository: updateSize: lstat [...]/packed-refs.lock: no such file or directory

Refs: https://codeberg.org/forgejo/forgejo/pulls/1748

(cherry picked from commit c3aebcf16a7181192432730b827e369728196968)

