### PR TITLE
Use appSubUrl for OAuth2 callback URL tip

### DIFF
--- a/web_src/js/features/admin/common.js
+++ b/web_src/js/features/admin/common.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import {checkAppUrl} from '../common-global.js';
 import {hideElem, showElem, toggleElem} from '../../utils/dom.js';
 
-const {csrfToken} = window.config;
+const {csrfToken, appSubUrl} = window.config;
 
 export function initAdminCommon() {
   if ($('.page-content.admin').length === 0) {
@@ -172,7 +172,8 @@ export function initAdminCommon() {
 
   if ($('.admin.authentication').length > 0) {
     $('#auth_name').on('input', function () {
-      $('#oauth2-callback-url').text(`${window.location.origin}/user/oauth2/${encodeURIComponent($(this).val())}/callback`);
+      // appSubUrl is either empty or is a path that starts with `/` and doesn't have a trailing slash.
+      $('#oauth2-callback-url').text(`${window.location.origin}${appSubUrl}/user/oauth2/${encodeURIComponent($(this).val())}/callback`);
     }).trigger('input');
   }
 


### PR DESCRIPTION
- When crafting the OAuth2 callbackURL take into account `appSubUrl`, which is quite safe given that its strictly formatted.
- No integration testing as this is all done in Javascript.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1795

(cherry picked from commit 27cb6b7956136f87aa78067d9adb5a4c4ce28a24)
