### PR TITLE
Fix required error for token name

### DIFF
--- a/services/forms/user_form.go
+++ b/services/forms/user_form.go
@@ -365,7 +365,7 @@ func (f *EditVariableForm) Validate(req *http.Request, errs binding.Errors) bind
 
 // NewAccessTokenForm form for creating access token
 type NewAccessTokenForm struct {
-	Name  string `binding:"Required;MaxSize(255)"`
+	Name  string `binding:"Required;MaxSize(255)" locale:"settings.token_name"`
 	Scope []string
 }
 


### PR DESCRIPTION
- Say to the binding middleware which locale should be used for the required error.
- Resolves https://codeberg.org/forgejo/forgejo/issues/1683

(cherry picked from commit 5a2d7966127b5639332038e9925d858ab54fc360)
