### PR TITLE
Check for v prefix on tags for release clean branch name (#28257) (#28270)

### DIFF
--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get cleaned branch name
         id: clean_name
         run: |
-          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
           echo "Cleaned name is ${REF_NAME}"
           echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: configure aws


### PR DESCRIPTION
Partial backport #28257 for `v1.20`