### PR TITLE
Ignore "non-existing" errors when getDirectorySize calculates the size (#28276)

### DIFF
--- a/modules/repository/create.go
+++ b/modules/repository/create.go
@@ -160,24 +160,25 @@ const notRegularFileMode = os.ModeSymlink | os.ModeNamedPipe | os.ModeSocket | o
 // getDirectorySize returns the disk consumption for a given path
 func getDirectorySize(path string) (int64, error) {
 	var size int64
-	err := filepath.WalkDir(path, func(_ string, info os.DirEntry, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) { // ignore the error because the file maybe deleted during traversing.
-				return nil
-			}
+	err := filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
+		if os.IsNotExist(err) { // ignore the error because some files (like temp/lock file) may be deleted during traversing.
+			return nil
+		} else if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if entry.IsDir() {
 			return nil
 		}
-		f, err := info.Info()
-		if err != nil {
+		info, err := entry.Info()
+		if os.IsNotExist(err) { // ignore the error as above
+			return nil
+		} else if err != nil {
 			return err
 		}
-		if (f.Mode() & notRegularFileMode) == 0 {
-			size += f.Size()
+		if (info.Mode() & notRegularFileMode) == 0 {
+			size += info.Size()
 		}
-		return err
+		return nil
 	})
 	return size, err
 }


### PR DESCRIPTION
Backport #28276

The git command may operate the git directory (add/remove) files in any time.

So when the code iterates the directory, some files may disappear during the "walk". All "IsNotExist" errors should be ignored.