### PR TITLE
Meilisearch: require all query terms to be matched

### DIFF
--- a/modules/indexer/issues/meilisearch/meilisearch.go
+++ b/modules/indexer/issues/meilisearch/meilisearch.go
@@ -211,10 +211,11 @@ func (b *Indexer) Search(ctx context.Context, options *internal.SearchOptions) (
 	skip, limit := indexer_internal.ParsePaginator(options.Paginator, maxTotalHits)
 
 	searchRes, err := b.inner.Client.Index(b.inner.VersionedIndexName()).Search(options.Keyword, &meilisearch.SearchRequest{
-		Filter: query.Statement(),
-		Limit:  int64(limit),
-		Offset: int64(skip),
-		Sort:   sortBy,
+		Filter:           query.Statement(),
+		Limit:            int64(limit),
+		Offset:           int64(skip),
+		Sort:             sortBy,
+		MatchingStrategy: "all",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously only the first term had to be matched. That default Meilisearch behavior makes sense for e.g. some kind of autocomplete to find and select a single result. But for filtering issues it means you can't narrow down results by adding more terms.

This is also more consistent with other indexers and GitHub.

---

Reference:
https://www.meilisearch.com/docs/reference/api/search#matching-strategy