### PR TITLE
Add missing variable in tag list

### DIFF
--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -174,6 +174,7 @@ func TagsList(ctx *context.Context) {
 	// Disable the showCreateNewBranch form in the dropdown on this page.
 	ctx.Data["CanCreateBranch"] = false
 	ctx.Data["HideBranchesInDropdown"] = true
+	ctx.Data["CanCreateRelease"] = ctx.Repo.CanWrite(unit.TypeReleases) && !ctx.Repo.Repository.IsArchived
 
 	listOptions := db.ListOptions{
 		Page:     ctx.FormInt("page"),


### PR DESCRIPTION
This fixes a regression from #25859

If a tag has no Release, Gitea will show a Link to create a Release for the Tag if the User has the Permission to do this, but the variable to indicate that is no longer set.

Used here:
https://github.com/go-gitea/gitea/blob/1bfcdeef4cca0f5509476358e5931c13d37ed1ca/templates/repo/tag/list.tmpl#L39-L41