### PR TITLE
Add `HEAD` support for rpm repo files

### DIFF
--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -520,7 +520,10 @@ func CommonRoutes() *web.Route {
 				r.Get("", rpm.DownloadPackageFile)
 				r.Delete("", reqPackageAccess(perm.AccessModeWrite), rpm.DeletePackageFile)
 			})
-			r.Get("/repodata/{filename}", rpm.GetRepositoryFile)
+			r.Group("/repodata/{filename}", func() {
+				r.Head("", rpm.CheckRepositoryFileExistence)
+				r.Get("", rpm.GetRepositoryFile)
+			})
 		}, reqPackageAccess(perm.AccessModeRead))
 		r.Group("/rubygems", func() {
 			r.Get("/specs.4.8.gz", rubygems.EnumeratePackages)

--- a/tests/integration/api_packages_rpm_test.go
+++ b/tests/integration/api_packages_rpm_test.go
@@ -149,11 +149,17 @@ gpgkey=%sapi/packages/%s/rpm/repository.key`, user.Name, user.Name, setting.AppN
 
 		url := rootURL + "/repodata"
 
-		req := NewRequest(t, "GET", url+"/dummy.xml")
+		req := NewRequest(t, "HEAD", url+"/dummy.xml")
+		MakeRequest(t, req, http.StatusNotFound)
+
+		req = NewRequest(t, "GET", url+"/dummy.xml")
 		MakeRequest(t, req, http.StatusNotFound)
 
 		t.Run("repomd.xml", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
+
+			req = NewRequest(t, "HEAD", url+"/repomd.xml")
+			MakeRequest(t, req, http.StatusOK)
 
 			req = NewRequest(t, "GET", url+"/repomd.xml")
 			resp := MakeRequest(t, req, http.StatusOK)


### PR DESCRIPTION
Fixes https://codeberg.org/forgejo/forgejo/issues/1810

zypper uses HEAD requests to check file existence.

https://github.com/openSUSE/libzypp/blob/HEAD/zypp/RepoManager.cc#L2549
https://github.com/openSUSE/libzypp/blob/HEAD/zypp-curl/ng/network/private/downloaderstates/basicdownloader_p.cc#L116

@ExplodingDragon fyi