### PR TITLE
WIP: Replaced Sec2Time with Sec2Hours for better timesheets reporting.

### DIFF
--- a/models/issues/stopwatch.go
+++ b/models/issues/stopwatch.go
@@ -62,7 +62,7 @@ func (s Stopwatch) Seconds() int64 {
 
 // Duration returns a human-readable duration string based on local server time
 func (s Stopwatch) Duration() string {
-	return util.SecToTime(s.Seconds())
+	return util.SecToHours(s.Seconds())
 }
 
 func getStopwatch(ctx context.Context, userID, issueID int64) (sw *Stopwatch, exists bool, err error) {
@@ -215,7 +215,7 @@ func FinishIssueStopwatch(ctx context.Context, user *user_model.User, issue *Iss
 		Doer:    user,
 		Issue:   issue,
 		Repo:    issue.Repo,
-		Content: util.SecToTime(timediff),
+		Content: util.SecToHours(timediff),
 		Type:    CommentTypeStopTracking,
 		TimeID:  tt.ID,
 	}); err != nil {

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -67,7 +67,7 @@ func NewFuncMap() template.FuncMap {
 		"TimeSince":     timeutil.TimeSince,
 		"TimeSinceUnix": timeutil.TimeSinceUnix,
 		"DateTime":      timeutil.DateTime,
-		"Sec2Time":      util.SecToTime,
+		"Sec2Hours":     util.SecToHours,
 		"LoadTimes": func(startTime time.Time) string {
 			return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"
 		},

--- a/modules/util/sec_to_time.go
+++ b/modules/util/sec_to_time.go
@@ -66,6 +66,25 @@ func SecToTime(durationVal any) string {
 	return strings.TrimRight(formattedTime, " ")
 }
 
+// SecToHours converts an amount of seconds to a human-readable hours string.
+// This is sutable for planning and managing timesheets.
+func SecToHours(durationVal any) string {
+	duration, _ := ToInt64(durationVal)
+
+	formattedTime := ""
+
+	// The following three variables are calculated without depending
+	// on the previous calculated variables.
+	hours := (duration / 3600)
+	minutes := (duration / 60) % 60
+
+	formattedTime = formatTime(hours, "hour", formattedTime)
+	formattedTime = formatTime(minutes, "minute", formattedTime)
+
+	// The formatTime() function always appends a space at the end. This will be trimmed
+	return strings.TrimRight(formattedTime, " ")
+}
+
 // formatTime appends the given value to the existing forammattedTime. E.g:
 // formattedTime = "1 year"
 // input: value = 3, name = "month"

--- a/modules/util/sec_to_time_test.go
+++ b/modules/util/sec_to_time_test.go
@@ -28,3 +28,16 @@ func TestSecToTime(t *testing.T) {
 	assert.Equal(t, "11 months", SecToTime(year-25*day))
 	assert.Equal(t, "1 year 5 months", SecToTime(year+163*day+10*hour+11*minute+5*second))
 }
+
+func TestSecToHours(t *testing.T) {
+	second := int64(1)
+	minute := 60 * second
+	hour := 60 * minute
+	day := 24 * hour
+
+	assert.Equal(t, "1 minute", SecToHours(minute+6*second))
+	assert.Equal(t, "1 hour", SecToHours(hour))
+	assert.Equal(t, "1 hour", SecToHours(hour+second))
+	assert.Equal(t, "14 hours 33 minutes", SecToHours(14*hour+33*minute+30*second))
+	assert.Equal(t, "156 hours 30 minutes", SecToHours(6*day+12*hour+30*minute+18*second))
+}

--- a/routers/web/repo/issue_timetrack.go
+++ b/routers/web/repo/issue_timetrack.go
@@ -82,6 +82,6 @@ func DeleteTime(c *context.Context) {
 		return
 	}
 
-	c.Flash.Success(c.Tr("repo.issues.del_time_history", util.SecToTime(t.Time)))
+	c.Flash.Success(c.Tr("repo.issues.del_time_history", util.SecToHours(t.Time)))
 	c.Redirect(issue.Link())
 }

--- a/services/convert/issue_comment.go
+++ b/services/convert/issue_comment.go
@@ -74,7 +74,7 @@ func ToTimelineComment(ctx context.Context, repo *repo_model.Repository, c *issu
 			c.Content[0] == '|' {
 			// TimeTracking Comments from v1.21 on store the seconds instead of an formated string
 			// so we check for the "|" delimeter and convert new to legacy format on demand
-			c.Content = util.SecToTime(c.Content[1:])
+			c.Content = util.SecToHours(c.Content[1:])
 		}
 	}
 

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -88,7 +88,7 @@
 						{{svg "octicon-issue-opened" 16 "gt-mr-3"}}
 						<span class="stopwatch-issue">{{.ActiveStopwatch.RepoSlug}}#{{.ActiveStopwatch.IssueIndex}}</span>
 						<span class="ui primary label stopwatch-time gt-my-0 gt-mx-4" data-seconds="{{.ActiveStopwatch.Seconds}}">
-							{{if .ActiveStopwatch}}{{Sec2Time .ActiveStopwatch.Seconds}}{{end}}
+							{{if .ActiveStopwatch}}{{Sec2Hours .ActiveStopwatch.Seconds}}{{end}}
 						</span>
 					</a>
 					<form class="stopwatch-commit" method="post" action="{{.ActiveStopwatch.IssueLink}}/times/stopwatch/toggle">

--- a/templates/repo/issue/filters.tmpl
+++ b/templates/repo/issue/filters.tmpl
@@ -9,7 +9,7 @@
 			<div class="ui compact tiny secondary menu">
 				<span class="item" data-tooltip-content='{{ctx.Locale.Tr "tracked_time_summary"}}'>
 					{{svg "octicon-clock"}}
-					{{.TotalTrackedTime | Sec2Time}}
+					{{.TotalTrackedTime | Sec2Hours}}
 				</span>
 			</div>
 		{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -39,7 +39,7 @@
 					<div class="ui compact tiny secondary menu">
 						<span class="item" data-tooltip-content='{{ctx.Locale.Tr "tracked_time_summary"}}'>
 							{{svg "octicon-clock"}}
-							{{.TotalTrackedTime | Sec2Time}}
+							{{.TotalTrackedTime | Sec2Hours}}
 						</span>
 					</div>
 				{{end}}

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -49,7 +49,7 @@
 				{{if .TotalTrackedTime}}
 					<div data-tooltip-content='{{ctx.Locale.Tr "tracked_time_summary"}}'>
 						{{svg "octicon-clock"}}
-						{{.TotalTrackedTime | Sec2Time}}
+						{{.TotalTrackedTime | Sec2Hours}}
 					</div>
 				{{end}}
 			</div>

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -41,7 +41,7 @@
 							{{if .TotalTrackedTime}}
 								<div class="flex-text-block">
 									{{svg "octicon-clock"}}
-									{{.TotalTrackedTime|Sec2Time}}
+									{{.TotalTrackedTime|Sec2Hours}}
 								</div>
 							{{end}}
 							{{if .UpdatedUnix}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -252,7 +252,7 @@
 						{{/* compatibility with time comments made before v1.21 */}}
 						<span class="text grey muted-links">{{.RenderedContent}}</span>
 					{{else}}
-						<span class="text grey muted-links">{{.Content|Sec2Time}}</span>
+						<span class="text grey muted-links">{{.Content|Sec2Hours}}</span>
 					{{end}}
 				</div>
 			</div>
@@ -271,7 +271,7 @@
 						{{/* compatibility with time comments made before v1.21 */}}
 						<span class="text grey muted-links">{{.RenderedContent}}</span>
 					{{else}}
-						<span class="text grey muted-links">{{.Content|Sec2Time}}</span>
+						<span class="text grey muted-links">{{.Content|Sec2Hours}}</span>
 					{{end}}
 				</div>
 			</div>
@@ -647,7 +647,7 @@
 						{{/* compatibility with time comments made before v1.21 */}}
 						<span class="text grey muted-links">{{.RenderedContent}}</span>
 					{{else}}
-						<span class="text grey muted-links">- {{.Content|Sec2Time}}</span>
+						<span class="text grey muted-links">- {{.Content|Sec2Hours}}</span>
 					{{end}}
 				</div>
 			</div>

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -342,7 +342,7 @@
 		{{if gt (len .WorkingUsers) 0}}
 			<div class="divider"></div>
 			<div class="ui comments">
-				<span class="text"><strong>{{ctx.Locale.Tr "repo.issues.time_spent_from_all_authors" ($.Issue.TotalTrackedTime | Sec2Time) | Safe}}</strong></span>
+				<span class="text"><strong>{{ctx.Locale.Tr "repo.issues.time_spent_from_all_authors" ($.Issue.TotalTrackedTime | Sec2Hours) | Safe}}</strong></span>
 				<div>
 					{{range $user, $trackedtime := .WorkingUsers}}
 						<div class="comment gt-mt-3">
@@ -352,7 +352,7 @@
 							<div class="content">
 								{{template "shared/user/authorlink" $user}}
 								<div class="text">
-									{{$trackedtime|Sec2Time}}
+									{{$trackedtime|Sec2Hours}}
 								</div>
 							</div>
 						</div>

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -30,7 +30,7 @@
 						{{if .TotalTrackedTime}}
 						<div class="text grey flex-text-block">
 								{{svg "octicon-clock" 16}}
-								{{.TotalTrackedTime | Sec2Time}}
+								{{.TotalTrackedTime | Sec2Hours}}
 						</div>
 						{{end}}
 						{{if .Assignees}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -100,7 +100,7 @@
 									{{if .TotalTrackedTime}}
 										<div class="flex-text-block">
 											{{svg "octicon-clock"}}
-											{{.TotalTrackedTime|Sec2Time}}
+											{{.TotalTrackedTime|Sec2Hours}}
 										</div>
 									{{end}}
 									{{if .UpdatedUnix}}


### PR DESCRIPTION
Current situation.
Tracked time informations is displayed in years, monthes, days, hours, minutes. This is not suitable for timesheets reporting. For example work day is 8 hours, work week often has 5 work days.
What is changed.
Added function Sec2Hours which shows tracked time in hours and minutes which is more convenient while reporting timesheets to management.
