### PR TITLE
Fix object does not exist error when checking citation file

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -711,11 +711,12 @@ func checkCitationFile(ctx *context.Context, entry *git.TreeEntry) {
 	}
 	for _, entry := range allEntries {
 		if entry.Name() == "CITATION.cff" || entry.Name() == "CITATION.bib" {
-			ctx.Data["CitiationExist"] = true
 			// Read Citation file contents
-			ctx.PageData["citationFileContent"], err = entry.Blob().GetBlobContent(setting.UI.MaxDisplayFileSize)
-			if err != nil {
+			if content, err := entry.Blob().GetBlobContent(setting.UI.MaxDisplayFileSize); err != nil {
 				log.Error("checkCitationFile: GetBlobContent: %v", err)
+			} else {
+				ctx.Data["CitiationExist"] = true
+				ctx.PageData["citationFileContent"] = content
 			}
 			break
 		}

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -717,8 +717,8 @@ func checkCitationFile(ctx *context.Context, entry *git.TreeEntry) {
 			} else {
 				ctx.Data["CitiationExist"] = true
 				ctx.PageData["citationFileContent"] = content
+				break
 			}
-			break
 		}
 	}
 }

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -713,14 +713,7 @@ func checkCitationFile(ctx *context.Context, entry *git.TreeEntry) {
 		if entry.Name() == "CITATION.cff" || entry.Name() == "CITATION.bib" {
 			ctx.Data["CitiationExist"] = true
 			// Read Citation file contents
-			blob := entry.Blob()
-			dataRc, err := blob.DataAsync()
-			if err != nil {
-				ctx.ServerError("DataAsync", err)
-				return
-			}
-			defer dataRc.Close()
-			ctx.PageData["citationFileContent"], err = blob.GetBlobContent(setting.UI.MaxDisplayFileSize)
+			ctx.PageData["citationFileContent"], err = entry.Blob().GetBlobContent(setting.UI.MaxDisplayFileSize)
 			if err != nil {
 				ctx.ServerError("GetBlobContent", err)
 				return

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -715,8 +715,7 @@ func checkCitationFile(ctx *context.Context, entry *git.TreeEntry) {
 			// Read Citation file contents
 			ctx.PageData["citationFileContent"], err = entry.Blob().GetBlobContent(setting.UI.MaxDisplayFileSize)
 			if err != nil {
-				ctx.ServerError("GetBlobContent", err)
-				return
+				log.Error("checkCitationFile: GetBlobContent: %v", err)
 			}
 			break
 		}


### PR DESCRIPTION
Fix #28264

`DataAsync()` will be called twice.
Caused by https://github.com/go-gitea/gitea/pull/27958.
I'm sorry, I didn't completely remove all unnecessary codes.