### PR TITLE
Add missing exclusive in advanced label options

### DIFF
--- a/options/label/Advanced.yaml
+++ b/options/label/Advanced.yaml
@@ -14,12 +14,12 @@ labels:
   - name: "Kind/Testing"
     color: 795548
     description: Issue or pull request related to testing
-  - name: "Kind/Breaking"
-    color: c62828
-    description: Breaking change that won't be backward compatible
   - name: "Kind/Documentation"
     color: 37474f
     description: Documentation changes
+  - name: "Compat/Breaking"
+    color: c62828
+    description: Breaking change that won't be backward compatible
   - name: "Reviewed/Duplicate"
     exclusive: true
     color: 616161


### PR DESCRIPTION
Hi, I think these changes could be useful for default labels when creating new repos.

The PR includes the following changes:
 - Add missing exclusive flag for Kind/ scope in labels.
 - Move Breaking label into new Compat/ scope.
