### PR TITLE
handle repository.size column being NULL in migration v263

### DIFF
--- a/models/migrations/v1_21/v263.go
+++ b/models/migrations/v1_21/v263.go
@@ -32,7 +32,7 @@ func AddGitSizeAndLFSSizeToRepositoryTable(x *xorm.Engine) error {
 		return err
 	}
 
-	_, err = sess.Exec(`UPDATE repository SET git_size = size - lfs_size`)
+	_, err = sess.Exec(`UPDATE repository SET git_size = size - lfs_size WHERE size IS NOT NULL`)
 	if err != nil {
 		return err
 	}

--- a/models/migrations/v1_21/v263.go
+++ b/models/migrations/v1_21/v263.go
@@ -32,7 +32,7 @@ func AddGitSizeAndLFSSizeToRepositoryTable(x *xorm.Engine) error {
 		return err
 	}
 
-	, err = sess.Exec(`UPDATE repository SET size = 0 WHERE size IS NULL`)
+	_, err = sess.Exec(`UPDATE repository SET size = 0 WHERE size IS NULL`)
 	if err != nil {
 		return err
 	}

--- a/models/migrations/v1_21/v263.go
+++ b/models/migrations/v1_21/v263.go
@@ -32,7 +32,12 @@ func AddGitSizeAndLFSSizeToRepositoryTable(x *xorm.Engine) error {
 		return err
 	}
 
-	_, err = sess.Exec(`UPDATE repository SET git_size = size - lfs_size WHERE size IS NOT NULL`)
+	, err = sess.Exec(`UPDATE repository SET size = 0 WHERE size IS NULL`)
+	if err != nil {
+		return err
+	}
+
+	_, err = sess.Exec(`UPDATE repository SET git_size = size - lfs_size WHERE size > lfs_size`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This resolves a problem I encountered while updating gitea from 1.20.4 to 1.21. For some reason (correct or otherwise) there are some values in `repository.size` that are NULL in my gitea database which cause this migration to fail due to the NOT NULL constraints.

Log snippet (excuse the escape characters)
```
ESC[36mgitea                |ESC[0m 2023-12-04T03:52:28.573122395Z 2023/12/04 03:52:28 ...ations/migrations.go:641:Migrate() [I] Migration[263]: Add git_size and lfs_size columns to repository table
ESC[36mgitea                |ESC[0m 2023-12-04T03:52:28.608705544Z 2023/12/04 03:52:28 routers/common/db.go:36:InitDBEngine() [E] ORM engine initialization attempt #3/10 failed. Error: migrate: migration[263]: Add git_size and lfs_size columns to repository table failed: NOT NULL constraint failed: repository.git_size
```

I assume this should be reasonably safe since `repository.git_size` has a default value of 0 but I don't know if that value being 0 in the odd situation where `repository.size == NULL` has any problematic consequences.