### PR TITLE
Remove deprecated query condition in ListReleases

### DIFF
--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -133,11 +133,6 @@ func ListReleases(ctx *context.APIContext) {
 	//   in: query
 	//   description: filter (exclude / include) pre-releases
 	//   type: boolean
-	// - name: per_page
-	//   in: query
-	//   description: page size of results, deprecated - use limit
-	//   type: integer
-	//   deprecated: true
 	// - name: page
 	//   in: query
 	//   description: page number of results to return (1-based)
@@ -152,9 +147,6 @@ func ListReleases(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 	listOptions := utils.GetListOptions(ctx)
-	if listOptions.PageSize == 0 && ctx.FormInt("per_page") != 0 {
-		listOptions.PageSize = ctx.FormInt("per_page")
-	}
 
 	opts := repo_model.FindReleasesOptions{
 		ListOptions:   listOptions,

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -11730,12 +11730,6 @@
           },
           {
             "type": "integer",
-            "description": "page size of results, deprecated - use limit",
-            "name": "per_page",
-            "in": "query"
-          },
-          {
-            "type": "integer",
             "description": "page number of results to return (1-based)",
             "name": "page",
             "in": "query"


### PR DESCRIPTION
close #24057 
call stack: 
https://github.com/go-gitea/gitea/blob/25faee3c5f5be23c99b3b7e50418fc0dbad7a41b/routers/api/v1/repo/release.go#L154
https://github.com/go-gitea/gitea/blob/ec1feedbf582b05b6a5e8c59fb2457f25d053ba2/routers/api/v1/utils/page.go#L13-L18
https://github.com/go-gitea/gitea/blob/ec1feedbf582b05b6a5e8c59fb2457f25d053ba2/services/convert/utils.go#L15-L22

## :warning: Breaking   :warning: (though it's not caused by this PR)
Do not use `per_page` to specify pagination; use `limit` instead
