### PR TITLE
Refactor template empty checks

### DIFF
--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -1,5 +1,5 @@
 <div class="flex-list">
-	{{if eq (len .Runs) 0}}
+	{{if not .Runs}}
 	<div class="empty-placeholder">
 		{{svg "octicon-no-entry" 48}}
 		<h2>{{if $.IsFiltered}}{{ctx.Locale.Tr "actions.runs.no_results"}}{{else}}{{ctx.Locale.Tr "actions.runs.no_runs"}}{{end}}</h2>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -108,25 +108,27 @@
 			</tr>
 			{{if and (eq .GetType 3) $hasmatch}}
 				{{$match := index $section.Lines $line.Match}}
-				{{if or (gt (len $line.Comments) 0) (gt (len $match.Comments) 0)}}
+				{{if or $line.Comments $match.Comments}}
 					<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 						<td class="add-comment-left" colspan="4">
-							{{if gt (len $line.Comments) 0}}
+							{{if $line.Comments}}
 								{{if eq $line.GetCommentSide "previous"}}
 									{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 								{{end}}
 							{{end}}
-							{{if gt (len $match.Comments) 0}}
+							{{if $match.Comments}}
 								{{if eq $match.GetCommentSide "previous"}}
 									{{template "repo/diff/conversation" dict "." $.root "comments" $match.Comments}}
 								{{end}}
 							{{end}}
 						</td>
 						<td class="add-comment-right" colspan="4">
-							{{if eq $line.GetCommentSide "proposed"}}
-								{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
+							{{if $line.Comments}}
+								{{if eq $line.GetCommentSide "proposed"}}
+									{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
+								{{end}}
 							{{end}}
-							{{if gt (len $match.Comments) 0}}
+							{{if $match.Comments}}
 								{{if eq $match.GetCommentSide "proposed"}}
 									{{template "repo/diff/conversation" dict "." $.root "comments" $match.Comments}}
 								{{end}}
@@ -134,13 +136,11 @@
 						</td>
 					</tr>
 				{{end}}
-			{{else if gt (len $line.Comments) 0}}
+			{{else if $line.Comments}}
 				<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 					<td class="add-comment-left" colspan="4">
-						{{if gt (len $line.Comments) 0}}
-							{{if eq $line.GetCommentSide "previous"}}
-								{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
-							{{end}}
+						{{if eq $line.GetCommentSide "previous"}}
+							{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 						{{end}}
 					</td>
 					<td class="add-comment-right" colspan="4">

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -60,7 +60,7 @@
 				*/}}</td>
 			{{end}}
 		</tr>
-		{{if gt (len $line.Comments) 0}}
+		{{if $line.Comments}}
 			<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 				<td class="add-comment-left add-comment-right" colspan="5">
 					{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -81,12 +81,12 @@
 					{{end}}
 					{{if and (not .IsEmpty) ($.Permission.CanRead $.UnitTypeCode)}}
 						<div class="ui labeled button
-							{{if or (not $.IsSigned) (and (not $.CanSignedUserFork) (eq (len $.UserAndOrgForks) 0))}}
+							{{if or (not $.IsSigned) (and (not $.CanSignedUserFork) (not $.UserAndOrgForks))}}
 								disabled
 							{{end}}"
 							{{if not $.IsSigned}}
 								data-tooltip-content="{{ctx.Locale.Tr "repo.fork_guest_user"}}"
-							{{else if and (not $.CanSignedUserFork) (eq (len $.UserAndOrgForks) 0)}}
+							{{else if and (not $.CanSignedUserFork) (not $.UserAndOrgForks)}}
 								data-tooltip-content="{{ctx.Locale.Tr "repo.fork_from_self"}}"
 							{{end}}
 						>
@@ -98,7 +98,7 @@
 										href="{{AppSubUrl}}/{{(index $.UserAndOrgForks 0).FullName}}"
 									{{/*else is not required here, because the button shouldn't link to any site if you can't create a fork*/}}
 									{{end}}
-								{{else if eq (len $.UserAndOrgForks) 0}}
+								{{else if not $.UserAndOrgForks}}
 									href="{{AppSubUrl}}/repo/fork/{{.ID}}"
 								{{else}}
 									data-modal="#fork-repo-modal"

--- a/templates/repo/issue/filters.tmpl
+++ b/templates/repo/issue/filters.tmpl
@@ -1,6 +1,6 @@
 <div id="issue-filters" class="issue-list-toolbar">
 	<div class="issue-list-toolbar-left">
-		{{if and ($.CanWriteIssuesOrPulls) (gt (len .Issues) 0)}}
+		{{if and $.CanWriteIssuesOrPulls .Issues}}
 			<input type="checkbox" autocomplete="off" class="issue-checkbox-all gt-mr-4" title="{{ctx.Locale.Tr "repo.issues.action_check_all"}}">
 		{{end}}
 		{{template "repo/issue/openclose" .}}

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -339,7 +339,7 @@
 				</div>
 			</div>
 		{{end}}
-		{{if gt (len .WorkingUsers) 0}}
+		{{if .WorkingUsers}}
 			<div class="divider"></div>
 			<div class="ui comments">
 				<span class="text"><strong>{{ctx.Locale.Tr "repo.issues.time_spent_from_all_authors" ($.Issue.TotalTrackedTime | Sec2Time) | Safe}}</strong></span>

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -140,7 +140,7 @@
 								{{ctx.Locale.TrN $waitingOfficial "repo.pulls.waiting_count_1" "repo.pulls.waiting_count_n" $waitingOfficial}}
 							</span>
 						{{end}}
-						{{if and (not .PullRequest.HasMerged) (gt (len .PullRequest.ConflictedFiles) 0)}}
+						{{if and (not .PullRequest.HasMerged) .PullRequest.ConflictedFiles}}
 							<span class="conflicting flex-text-inline">
 								{{svg "octicon-x" 14}}
 								{{ctx.Locale.TrN (len .PullRequest.ConflictedFiles) "repo.pulls.num_conflicting_files_1" "repo.pulls.num_conflicting_files_n" (len .PullRequest.ConflictedFiles)}}

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -106,7 +106,7 @@
 				{{else if .GetOpType.InActions "comment_issue" "approve_pull_request" "reject_pull_request" "comment_pull"}}
 					<a href="{{.GetCommentLink ctx}}" class="text truncate issue title">{{(.GetIssueTitle ctx) | RenderEmoji $.Context | RenderCodeBlock}}</a>
 					{{$comment := index .GetIssueInfos 1}}
-					{{if gt (len $comment) 0}}
+					{{if $comment}}
 						<div class="markup gt-font-14">{{RenderMarkdownToHtml ctx $comment}}</div>
 					{{end}}
 				{{else if .GetOpType.InActions "merge_pull_request"}}

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -24,7 +24,7 @@
 		</div>
 		<div class="gt-p-0">
 			<div id="notification_table">
-				{{if eq (len .Notifications) 0}}
+				{{if not .Notifications}}
 					<div class="gt-df gt-ac gt-fc gt-p-4">
 						{{svg "octicon-inbox" 56 "gt-mb-4"}}
 						{{if eq .Status 1}}

--- a/templates/user/notification/notification_subscriptions.tmpl
+++ b/templates/user/notification/notification_subscriptions.tmpl
@@ -63,7 +63,7 @@
 					</div>
 				</div>
 				<div class="divider"></div>
-				{{if eq (len .Issues) 0}}
+				{{if not .Issues}}
 					{{ctx.Locale.Tr "notification.no_subscriptions"}}
 				{{else}}
 					{{template "shared/issuelist" dict "." . "listType" "dashboard"}}

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -55,7 +55,7 @@
 					{{if .Verified}}
 						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-verified"}} <strong>{{ctx.Locale.Tr "settings.gpg_key_verified"}}</strong></span>
 					{{end}}
-					{{if gt (len .Emails) 0}}
+					{{if .Emails}}
 						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
 					{{end}}
 					<div class="flex-item-body">


### PR DESCRIPTION
Fix #28347

As there is no info how to reproduce it, I can't test it.
Fix may be `section_split.tmpl @ 126/130`.

Other changes are "empty check" refactorings.