### PR TITLE
Fix the runs will not be displayed bug when the main branch have no workflows but other branches have

### DIFF
--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -200,6 +200,7 @@ func List(ctx *context.Context) {
 	pager.AddParamString("actor", fmt.Sprint(actorID))
 	pager.AddParamString("status", fmt.Sprint(status))
 	ctx.Data["Page"] = pager
+	ctx.Data["HasWorkflowsOrRuns"] = len(workflows) > 0 || len(runs) > 0
 
 	ctx.HTML(http.StatusOK, tplListActions)
 }

--- a/templates/repo/actions/list.tmpl
+++ b/templates/repo/actions/list.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 
-		{{if .workflows}}
+		{{if .HasWorkflowsOrRuns}}
 		<div class="ui stackable grid">
 			<div class="four wide column">
 				<div class="ui fluid vertical menu">


### PR DESCRIPTION
The left menu will only display the default branch's workflows but the right side will display the runs triggered by all branches' workflows. So we cannot hide right side if default branch has no workflows.

Fix #28332 
Replace #28333 