### PR TITLE
Fix incorrect run order of action jobs

### DIFF
--- a/models/actions/task.go
+++ b/models/actions/task.go
@@ -234,7 +234,7 @@ func CreateTaskForRunner(ctx context.Context, runner *ActionRunner) (*ActionTask
 	}
 
 	var jobs []*ActionRunJob
-	if err := e.Where("task_id=? AND status=?", 0, StatusWaiting).And(jobCond).Asc("id").Find(&jobs); err != nil {
+	if err := e.Where("task_id=? AND status=?", 0, StatusWaiting).And(jobCond).Asc("updated", "id").Find(&jobs); err != nil {
 		return nil, false, err
 	}
 


### PR DESCRIPTION
When we pick up a job, all waiting jobs should firstly be ordered by update time, 
otherwise when there's a running job, if I rerun an older job, the older job will run first, as it's id is smaller.