### PR TITLE
Fix incorrect default value of `[attachment].MAX_SIZE`

### DIFF
--- a/modules/setting/attachment.go
+++ b/modules/setting/attachment.go
@@ -26,7 +26,7 @@ func loadAttachmentFrom(rootCfg ConfigProvider) (err error) {
 	}
 
 	Attachment.AllowedTypes = sec.Key("ALLOWED_TYPES").MustString(".csv,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.xls,.xlsx,.zip")
-	Attachment.MaxSize = sec.Key("MAX_SIZE").MustInt64(4)
+	Attachment.MaxSize = sec.Key("MAX_SIZE").MustInt64(2048)
 	Attachment.MaxFiles = sec.Key("MAX_FILES").MustInt(5)
 	Attachment.Enabled = sec.Key("ENABLED").MustBool(true)
 


### PR DESCRIPTION
In the documents, the `[attachment] MAX_SIZE` default value should be 4.

Reference the source code `modules/setting/attachment.go` line 29.