### PR TITLE
Improve text in Security settings

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -626,11 +626,11 @@ applications = Applications
 orgs = Manage Organizations
 repos = Repositories
 delete = Delete Account
-twofa = Two-Factor Authentication
+twofa = Two-Factor Authentication (TOTP)
 account_link = Linked Accounts
 organization = Organizations
 uid = UID
-webauthn = Security Keys
+webauthn = Two-Factor Authentication (Security Keys)
 
 public_profile = Public Profile
 biography_placeholder = Tell us a little bit about yourself! (You can use Markdown)
@@ -864,22 +864,23 @@ revoke_oauth2_grant = Revoke Access
 revoke_oauth2_grant_description = Revoking access for this third party application will prevent this application from accessing your data. Are you sure?
 revoke_oauth2_grant_success = Access revoked successfully.
 
-twofa_desc = Two-factor authentication enhances the security of your account.
+twofa_desc = To protect your account against password theft, you can use a smartphone or another device for receiving time-based one-time passwords ("TOTP").
+twofa_recovery_tip = If you lose your device, you will be able to use a single-use recovery key to regain access to your account.
 twofa_is_enrolled = Your account is currently <strong>enrolled</strong> in two-factor authentication.
 twofa_not_enrolled = Your account is not currently enrolled in two-factor authentication.
 twofa_disable = Disable Two-Factor Authentication
-twofa_scratch_token_regenerate = Regenerate Scratch Token
-twofa_scratch_token_regenerated = Your scratch token is now %s. Store it in a safe place, it will never be shown again.
+twofa_scratch_token_regenerate = Regenerate Single-Use Recovery Key
+twofa_scratch_token_regenerated = Your single-use recovery key is now %s. Store it in a safe place, as it will not be shown again.
 twofa_enroll = Enroll into Two-Factor Authentication
 twofa_disable_note = You can disable two-factor authentication if needed.
 twofa_disable_desc = Disabling two-factor authentication will make your account less secure. Continue?
-regenerate_scratch_token_desc = If you misplaced your scratch token or have already used it to sign in you can reset it here.
+regenerate_scratch_token_desc = If you misplaced your recovery key or have already used it to sign in, you can reset it here.
 twofa_disabled = Two-factor authentication has been disabled.
 scan_this_image = Scan this image with your authentication application:
 or_enter_secret = Or enter the secret: %s
 then_enter_passcode = And enter the passcode shown in the application:
 passcode_invalid = The passcode is incorrect. Try again.
-twofa_enrolled = Your account has been enrolled into two-factor authentication. Store your scratch token (%s) in a safe place as it is only shown once!
+twofa_enrolled = Your account has been enrolled into two-factor authentication. Store your single-use recovery key (%s) in a safe place, as it will not be shown again.
 twofa_failed_get_secret = Failed to get secret.
 
 webauthn_desc = Security keys are hardware devices containing cryptographic keys. They can be used for two-factor authentication. Security keys must support the <a rel="noreferrer" target="_blank" href="https://w3c.github.io/webauthn/#webauthn-authenticator">WebAuthn Authenticator</a> standard.
@@ -887,6 +888,8 @@ webauthn_register_key = Add Security Key
 webauthn_nickname = Nickname
 webauthn_delete_key = Remove Security Key
 webauthn_delete_key_desc = If you remove a security key you can no longer sign in with it. Continue?
+webauthn_key_loss_warning = If you lose your security keys, you will lose access to your account.
+webauthn_alternative_tip = You may want to configure an additional authentication method.
 
 manage_account_links = Manage Linked Accounts
 manage_account_links_desc = These external accounts are linked to your Gitea account.

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -880,7 +880,7 @@ scan_this_image = Scan this image with your authentication application:
 or_enter_secret = Or enter the secret: %s
 then_enter_passcode = And enter the passcode shown in the application:
 passcode_invalid = The passcode is incorrect. Try again.
-twofa_enrolled = Your account has been enrolled into two-factor authentication. Store your single-use recovery key (%s) in a safe place, as it will not be shown again.
+twofa_enrolled = Your account has been successfully enrolled. Store your single-use recovery key (%s) in a safe place, as it will not be shown again.
 twofa_failed_get_secret = Failed to get secret.
 
 webauthn_desc = Security keys are hardware devices containing cryptographic keys. They can be used for two-factor authentication. Security keys must support the <a rel="noreferrer" target="_blank" href="https://w3c.github.io/webauthn/#webauthn-authenticator">WebAuthn Authenticator</a> standard.

--- a/templates/user/settings/security/twofa.tmpl
+++ b/templates/user/settings/security/twofa.tmpl
@@ -16,6 +16,8 @@
 		<button class="ui red button delete-button" data-modal-id="disable-twofa" data-type="form" data-form="#disable-form">{{ctx.Locale.Tr "settings.twofa_disable"}}</button>
 	</form>
 	{{else}}
+	{{/* The recovery tip is there as a means of encouraging a user to enroll */}}
+	<p>{{ctx.Locale.Tr "settings.twofa_recovery_tip"}}</p>
 	<p>{{ctx.Locale.Tr "settings.twofa_not_enrolled"}}</p>
 	<div class="inline field">
 		<a class="ui primary button" href="{{AppSubUrl}}/user/settings/security/two_factor/enroll">{{ctx.Locale.Tr "settings.twofa_enroll"}}</a>

--- a/templates/user/settings/security/webauthn.tmpl
+++ b/templates/user/settings/security/webauthn.tmpl
@@ -1,6 +1,7 @@
 <h4 class="ui top attached header">{{ctx.Locale.Tr "settings.webauthn"}}</h4>
 <div class="ui attached segment">
 	<p>{{ctx.Locale.Tr "settings.webauthn_desc" | Str2html}}</p>
+	<p>{{ctx.Locale.Tr "settings.webauthn_key_loss_warning"}} {{ctx.Locale.Tr "settings.webauthn_alternative_tip" | Str2html}}</p>
 	{{template "user/auth/webauthn_error" .}}
 	<div class="flex-list">
 		{{range .WebAuthnCredentials}}

--- a/templates/user/settings/security/webauthn.tmpl
+++ b/templates/user/settings/security/webauthn.tmpl
@@ -1,7 +1,7 @@
 <h4 class="ui top attached header">{{ctx.Locale.Tr "settings.webauthn"}}</h4>
 <div class="ui attached segment">
 	<p>{{ctx.Locale.Tr "settings.webauthn_desc" | Str2html}}</p>
-	<p>{{ctx.Locale.Tr "settings.webauthn_key_loss_warning"}} {{ctx.Locale.Tr "settings.webauthn_alternative_tip" | Str2html}}</p>
+	<p>{{ctx.Locale.Tr "settings.webauthn_key_loss_warning"}} {{ctx.Locale.Tr "settings.webauthn_alternative_tip"}}</p>
 	{{template "user/auth/webauthn_error" .}}
 	<div class="flex-list">
 		{{range .WebAuthnCredentials}}


### PR DESCRIPTION
- en-US: Rename "Scratch Tokens" to "single-use recovery keys".
  Longer, but clearer.
- Improve titles
- TOTP: Improve description
- TOTP: Inform user about Scratch Tokens to encourage TOTP usage
- WebAuthn: Add loss of access warning