### PR TITLE
Fix docs  links in v1.19

### DIFF
--- a/docs/content/administration/external-renderers.en-us.md
+++ b/docs/content/administration/external-renderers.en-us.md
@@ -22,7 +22,7 @@ it is just a matter of:
 - add some configuration to your `app.ini` file
 - restart your Gitea instance
 
-This supports rendering of whole files. If you want to render code blocks in markdown you would need to do something with javascript. See some examples on the [Customizing Gitea](../customizing-gitea) page.
+This supports rendering of whole files. If you want to render code blocks in markdown you would need to do something with javascript. See some examples on the [Customizing Gitea](administration/customizing-gitea.md) page.
 
 ## Installing external binaries
 

--- a/docs/content/administration/https-support.en-us.md
+++ b/docs/content/administration/https-support.en-us.md
@@ -34,7 +34,7 @@ KEY_FILE  = key.pem
 ```
 
 Note that if your certificate is signed by a third party certificate authority (i.e. not self-signed), then cert.pem should contain the certificate chain. The server certificate must be the first entry in cert.pem, followed by the intermediaries in order (if any). The root certificate does not have to be included because the connecting client must already have it in order to estalbish the trust relationship.
-To learn more about the config values, please checkout the [Config Cheat Sheet](../config-cheat-sheet#server-server).
+To learn more about the config values, please checkout the [Config Cheat Sheet](administration/config-cheat-sheet.md#server-server).
 
 For the `CERT_FILE` or `KEY_FILE` field, the file path is relative to the `GITEA_CUSTOM` environment variable when it is a relative path. It can be an absolute path as well.
 
@@ -83,11 +83,11 @@ ACME_DIRECTORY=https
 ACME_EMAIL=email@example.com
 ```
 
-To learn more about the config values, please checkout the [Config Cheat Sheet](../config-cheat-sheet#server-server).
+To learn more about the config values, please checkout the [Config Cheat Sheet](administration/config-cheat-sheet.md#server-server).
 
 ## Using a reverse proxy
 
-Setup up your reverse proxy as shown in the [reverse proxy guide](../reverse-proxies).
+Setup up your reverse proxy as shown in the [reverse proxy guide](administration/reverse-proxies.md).
 
 After that, enable HTTPS by following one of these guides:
 

--- a/docs/content/usage/labels.en-us.md
+++ b/docs/content/usage/labels.en-us.md
@@ -25,7 +25,7 @@ For organizations, you can define organization-wide labels that are shared with 
 
 Labels have a mandatory name, a mandatory color, an optional description, and must either be exclusive or not (see `Scoped Labels` below).
 
-When you create a repository, you can ensure certain labels exist by using the `Issue Labels` option. This option lists a number of available label sets that are [configured globally on your instance](./customizing-gitea/#labels). Its contained labels will all be created as well while creating the repository.
+When you create a repository, you can ensure certain labels exist by using the `Issue Labels` option. This option lists a number of available label sets that are [configured globally on your instance](administration/customizing-gitea.md/#labels). Its contained labels will all be created as well while creating the repository.
 
 ## Scoped Labels
 


### PR DESCRIPTION
Fix:
https://gitea.com/gitea/gitea-docusaurus/actions/runs/761/jobs/0
![image](https://github.com/go-gitea/gitea/assets/18380374/d2b8c6e9-a318-4ff7-a293-769eaaa7d8b2)

awesome is not related.

ps: #28302 should be backported.