### PR TITLE
Fix docs links in v1.19

### DIFF
--- a/docs/content/usage/labels.en-us.md
+++ b/docs/content/usage/labels.en-us.md
@@ -25,7 +25,7 @@ For organizations, you can define organization-wide labels that are shared with 
 
 Labels have a mandatory name, a mandatory color, an optional description, and must either be exclusive or not (see `Scoped Labels` below).
 
-When you create a repository, you can ensure certain labels exist by using the `Issue Labels` option. This option lists a number of available label sets that are [configured globally on your instance](administration/customizing-gitea.md/#labels). Its contained labels will all be created as well while creating the repository.
+When you create a repository, you can ensure certain labels exist by using the `Issue Labels` option. This option lists a number of available label sets that are [configured globally on your instance](administration/customizing-gitea.md#labels). Its contained labels will all be created as well while creating the repository.
 
 ## Scoped Labels
 


### PR DESCRIPTION
I'm sorry for the mistake in #28415
![image](https://github.com/go-gitea/gitea/assets/18380374/792eb1fa-7df7-4f13-a04b-4b705554b653)
https://gitea.com/gitea/gitea-docusaurus/actions/runs/764#jobstep-9-69

ps: it is `../administration/customizing-gitea/#labels` in current version. Which is better?