### PR TITLE
Add endpoint for not implemented Docker auth

### DIFF
--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -603,7 +603,10 @@ func ContainerRoutes() *web.Route {
 	})
 
 	r.Get("", container.ReqContainerAccess, container.DetermineSupport)
-	r.Get("/token", container.Authenticate)
+	r.Group("/token", func() {
+		r.Get("", container.Authenticate)
+		r.Post("", container.AuthenticateNotImplemented)
+	})
 	r.Get("/_catalog", container.ReqContainerAccess, container.GetRepositoryList)
 	r.Group("/{username}", func() {
 		r.Group("/{image}", func() {

--- a/routers/api/packages/container/container.go
+++ b/routers/api/packages/container/container.go
@@ -156,6 +156,17 @@ func Authenticate(ctx *context.Context) {
 	})
 }
 
+// https://distribution.github.io/distribution/spec/auth/oauth/
+func AuthenticateNotImplemented(ctx *context.Context) {
+	// This optional endpoint can be used to authenticate a client.
+	// It must implement the specification described in:
+	// https://datatracker.ietf.org/doc/html/rfc6749
+	// https://distribution.github.io/distribution/spec/auth/oauth/
+	// Purpose of this stub is to respond with 404 Not Found instead of 405 Method Not Allowed.
+
+	ctx.Status(http.StatusNotFound)
+}
+
 // https://docs.docker.com/registry/spec/api/#listing-repositories
 func GetRepositoryList(ctx *context.Context) {
 	n := ctx.FormInt("n")


### PR DESCRIPTION
Recently Docker started to use the optional `POST /v2/token` endpoint which should respond with a `404 Not Found` status code instead of the current `405 Method Not Allowed`.

> Note: Not all token servers implement oauth2. If the request to the endpoint returns 404 using the HTTP POST method, refer to Token Documentation for using the HTTP GET method supported by all token servers.