### PR TITLE
Users with hidden emails will see a noreply email on their profile

### DIFF
--- a/routers/web/shared/user/header.go
+++ b/routers/web/shared/user/header.go
@@ -44,7 +44,7 @@ func PrepareContextForProfileBigAvatar(ctx *context.Context) {
 	if userViewsOwnProfile && !ctx.ContextUser.KeepEmailPrivate {
 		ctx.Data["DisplayedEmail"] = ctx.ContextUser.Email
 	} else {
-		ctx.Data["DisplayedEmail"] = ctx.ContextUser.Name + "@" + setting.Service.NoReplyAddress
+		ctx.Data["DisplayedEmail"] = ctx.ContextUser.GetPlaceholderEmail()
 	}
 
 	// Show OpenID URIs

--- a/templates/shared/user/profile_big_avatar.tmpl
+++ b/templates/shared/user/profile_big_avatar.tmpl
@@ -42,7 +42,8 @@
 			{{if (eq .SignedUserID .ContextUser.ID)}}
 				<li>
 					{{svg "octicon-mail"}}
-					<a class="gt-f1" href="mailto:{{.ContextUser.Email}}" rel="nofollow">{{.ContextUser.Email}}</a>
+					{{/* If the email is private, DisplayedEmail will be a noreply address instead. */}}
+					<a class="gt-f1" {{if not (.ShowUserNoreply)}}href="mailto:{{.DisplayedEmail}}" rel="nofollow"{{end}}>{{.DisplayedEmail}}</a>
 					<a href="{{AppSubUrl}}/user/settings#privacy-user-settings">
 						{{if .ShowUserEmail}}
 							<i data-tooltip-content="{{ctx.Locale.Tr "user.email_visibility.limited"}}">

--- a/tests/integration/setting_test.go
+++ b/tests/integration/setting_test.go
@@ -44,13 +44,13 @@ func TestSettingShowUserEmailExplore(t *testing.T) {
 func TestSettingShowUserEmailProfile(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
+	// note: in this scenario, user2's email will always be private
+	// this setting only controls the email visibility of user1
+	// user1: keep_email_private = false, user2: keep_email_private = true
 	showUserEmail := setting.UI.ShowUserEmail
 
-	// user1: keep_email_private = false, user2: keep_email_private = true
-
-	setting.UI.ShowUserEmail = true
-
 	// user1 can see own visible email
+	setting.UI.ShowUserEmail = true
 	session := loginUser(t, "user1")
 	req := NewRequest(t, "GET", "/user1")
 	resp := session.MakeRequest(t, req, http.StatusOK)
@@ -58,11 +58,10 @@ func TestSettingShowUserEmailProfile(t *testing.T) {
 	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@noreply.example.org")
 	assert.Contains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@example.com")
 
-	// user1 can not see user2's hidden email (or their corresponding noreply email)
+	// user1 can not see user2's placeholder / hidden, primary email
 	req = NewRequest(t, "GET", "/user2")
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc = NewHTMLParser(t, resp.Body)
-	// Should only contain if the user visits their own profile page
 	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user2@noreply.example.org")
 	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user2@example.com")
 
@@ -74,7 +73,7 @@ func TestSettingShowUserEmailProfile(t *testing.T) {
 	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@noreply.example.org")
 	assert.Contains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@example.com")
 
-	// user2 cannot see own hidden email, but a noreply email
+	// user2's profile only shows a placeholder email
 	session = loginUser(t, "user2")
 	req = NewRequest(t, "GET", "/user2")
 	resp = session.MakeRequest(t, req, http.StatusOK)
@@ -82,9 +81,9 @@ func TestSettingShowUserEmailProfile(t *testing.T) {
 	assert.Contains(t, htmlDoc.doc.Find(".user.profile").Text(), "user2@noreply.example.org")
 	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user2@example.com")
 
+	// now that user1's email is hidden, user1 should only be
+	// able to see the placeholder email on their profile
 	setting.UI.ShowUserEmail = false
-
-	// user1 can see own noreply email (email hidden)
 	session = loginUser(t, "user1")
 	req = NewRequest(t, "GET", "/user1")
 	resp = session.MakeRequest(t, req, http.StatusOK)

--- a/tests/integration/setting_test.go
+++ b/tests/integration/setting_test.go
@@ -89,7 +89,7 @@ func TestSettingShowUserEmailProfile(t *testing.T) {
 	req = NewRequest(t, "GET", "/user1")
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc = NewHTMLParser(t, resp.Body)
-	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user2@noreply.example.org")
+	assert.NotContains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@noreply.example.org")
 	assert.Contains(t, htmlDoc.doc.Find(".user.profile").Text(), "user1@example.com")
 
 	setting.UI.ShowUserEmail = showUserEmail


### PR DESCRIPTION
Gitea, unlike GitLab and GitHub, would show the user's email address on their profile and gave some users something close to a heart attack.

This is obviously not healthy, so I built a new feature that would add an icon showing a padlock next to it, to show whether the email would be visible to other users or not. Such an indicator is important, because hiding your email address will mean that a "noreply@..." email address will be used for Git web operations, and this can mess the metadata of a repository if you just don't want your address to be shown on your profile, but still use it for commits.

If you're one of those people, it is very likely that you may not want that if you do livestreams, screencasts or just showing your screen to someone else somehow.

For that reason, the "noreply" email address will now be shown on the user's profile. This should show people that the noreply address will be used for every single Git-related thing that they do on the platform. It's probably less misleading this way, too.

Fixes https://codeberg.org/forgejo/forgejo/issues/1950