### PR TITLE
Add orphaned topic consistency check

### DIFF
--- a/models/repo/topic.go
+++ b/models/repo/topic.go
@@ -377,3 +377,13 @@ func syncTopicsInRepository(sess db.Engine, repoID int64) error {
 	}
 	return nil
 }
+
+// CountOrphanedAttachments returns the number of topics that don't belong to any repository.
+func CountOrphanedTopics(ctx context.Context) (int64, error) {
+	return db.GetEngine(ctx).Where("repo_count = 0").Count(new(Topic))
+}
+
+// DeleteOrphanedAttachments delete all topics that don't belong to any repository.
+func DeleteOrphanedTopics(ctx context.Context) (int64, error) {
+	return db.GetEngine(ctx).Where("repo_count = 0").Delete(new(Topic))
+}

--- a/modules/doctor/dbconsistency.go
+++ b/modules/doctor/dbconsistency.go
@@ -158,6 +158,12 @@ func checkDBConsistency(ctx context.Context, logger log.Logger, autofix bool) er
 			Fixer:        actions_model.FixRunnersWithoutBelongingOwner,
 			FixedMessage: "Removed",
 		},
+		{
+			Name:         "Topics with empty repository count",
+			Counter:      repo_model.CountOrphanedTopics,
+			Fixer:        repo_model.DeleteOrphanedTopics,
+			FixedMessage: "Removed",
+		},
 	}
 
 	// TODO: function to recalc all counters


### PR DESCRIPTION
- If a topic has zero repository count, it means that none of the repositories are using that topic, that would make them 'useless' to keep. One caveat is that if that topic is going to be used in the future, it will be added again to the database, but simply with a new ID.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1964
