### PR TITLE
Wrap labels list in issue overview

### DIFF
--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -35,6 +35,7 @@
 
 #issue-list .flex-item-title .labels-list {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.25em;
 }
 


### PR DESCRIPTION
- Allow the labels list to be wrapped, so it doesn't overflow.

Refs: https://codeberg.org/forgejo/forgejo/pulls/1977

(cherry picked from commit 26feb781a8991eda881acc1335c3bde241cebf8e)

