### PR TITLE
Downgrade @github/combobox-nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -995,11 +995,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@github/combobox-nav": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.3.0.tgz",
-      "integrity": "sha512-5CX03DbsLZ41dX5hKHyQKtg133U6lruX4TD9G0Zs4W8BpWy7lN8DJ6TYaeZN/V7x8K34coaqNYk/Y5ic7stfkg=="
-    },
     "node_modules/@github/markdown-toolbar-element": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.2.1.tgz",
@@ -1017,6 +1012,11 @@
       "dependencies": {
         "@github/combobox-nav": "^2.0.2"
       }
+    },
+    "node_modules/@github/text-expander-element/node_modules/@github/combobox-nav": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.2.0.tgz",
+      "integrity": "sha512-28kJUfzzPDYNyYsFCP/be8aXvEpjcEuciVENZlopcaUynS/4Pt9ll88Kl9l1D1Vy6a9+k+Km/YGJQ1e+gzG7SQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
     "vite-string-plugin": "1.1.2",
     "vitest": "0.34.6"
   },
+  "overrides": {
+    "@github/combobox-nav": "2.2.0"
+  },
   "browserslist": [
     "defaults",
     "not ie > 0",


### PR DESCRIPTION
- The v2.3.0 update caused to always scroll to the suggestion menu, where it previously wouldn't work at all or only scroll when it wasn't in the viewport.
- Ref: https://github.com/github/text-expander-element/issues/50
- Ref: https://github.com/github/combobox-nav/pull/75
- Resolves https://codeberg.org/forgejo/forgejo/issues/1990

(cherry picked from commit 27145be211ff782afe0910adbe200f126961f150)
