### PR TITLE
feat: bump `dessant/lock-threads` and `actions/setup-go` to use nodejs20 runtime

### DIFF
--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'go-gitea/gitea'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/cron-lock.yml
+++ b/.github/workflows/cron-lock.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'go-gitea/gitea'
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5
         with:
           issue-inactive-days: 45

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -39,7 +39,7 @@ jobs:
           - "9000:9000"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -115,7 +115,7 @@ jobs:
           - "9000:9000"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -165,7 +165,7 @@ jobs:
           - "993:993"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -198,7 +198,7 @@ jobs:
           - "1433:1433"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -18,7 +18,7 @@ jobs:
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
       # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
       - run: git fetch --unshallow --quiet --tags --force
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -64,7 +64,7 @@ jobs:
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
       # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
       - run: git fetch --unshallow --quiet --tags --force
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true
@@ -101,7 +101,7 @@ jobs:
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
       # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
       - run: git fetch --unshallow --quiet --tags --force
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -17,7 +17,7 @@ jobs:
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
       # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
       - run: git fetch --unshallow --quiet --tags --force
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -19,7 +19,7 @@ jobs:
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
       # fetch all tags to ensure that "git describe" reports expected Gitea version, eg. v1.21.0-dev-1-g1234567
       - run: git fetch --unshallow --quiet --tags --force
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1399,8 +1399,8 @@ PROXY_HOSTS = *.github.com
 - `SKIP_WORKFLOW_STRINGS`: **[skip ci],[ci skip],[no ci],[skip actions],[actions skip]**: Strings committers can place inside a commit message to skip executing the corresponding actions workflow
 
 `DEFAULT_ACTIONS_URL` indicates where the Gitea Actions runners should find the actions with relative path.
-For example, `uses: actions/checkout@v3` means `https://github.com/actions/checkout@v3` since the value of `DEFAULT_ACTIONS_URL` is `github`.
-And it can be changed to `self` to make it `root_url_of_your_gitea/actions/checkout@v3`.
+For example, `uses: actions/checkout@v4` means `https://github.com/actions/checkout@v4` since the value of `DEFAULT_ACTIONS_URL` is `github`.
+And it can be changed to `self` to make it `root_url_of_your_gitea/actions/checkout@v4`.
 
 Please note that using `self` is not recommended for most cases, as it could make names globally ambiguous.
 Additionally, it requires you to mirror all the actions you need to your Gitea instance, which may not be worth it.
@@ -1409,7 +1409,7 @@ Therefore, please use `self` only if you understand what you are doing.
 In earlier versions (`<= 1.19`), `DEFAULT_ACTIONS_URL` could be set to any custom URLs like `https://gitea.com` or `http://your-git-server,https://gitea.com`, and the default value was `https://gitea.com`.
 However, later updates removed those options, and now the only options are `github` and `self`, with the default value being `github`.
 However, if you want to use actions from other git server, you can use a complete URL in `uses` field, it's supported by Gitea (but not GitHub).
-Like `uses: https://gitea.com/actions/checkout@v3` or `uses: http://your-git-server/actions/checkout@v3`.
+Like `uses: https://gitea.com/actions/checkout@v4` or `uses: http://your-git-server/actions/checkout@v4`.
 
 ## Other (`other`)
 

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -1335,8 +1335,8 @@ PROXY_HOSTS = *.github.com
 - `MINIO_BASE_PATH`: **actions_log/**：Minio存储桶上的基本路径，仅在`STORAGE_TYPE`为`minio`时可用。
 
 `DEFAULT_ACTIONS_URL` 指示 Gitea 操作运行程序应该在哪里找到带有相对路径的操作。
-例如，`uses: actions/checkout@v3` 表示 `https://github.com/actions/checkout@v3`，因为 `DEFAULT_ACTIONS_URL` 的值为 `github`。
-它可以更改为 `self`，以使其成为 `root_url_of_your_gitea/actions/checkout@v3`。
+例如，`uses: actions/checkout@v4` 表示 `https://github.com/actions/checkout@v4`，因为 `DEFAULT_ACTIONS_URL` 的值为 `github`。
+它可以更改为 `self`，以使其成为 `root_url_of_your_gitea/actions/checkout@v4`。
 
 请注意，对于大多数情况，不建议使用 `self`，因为它可能使名称在全局范围内产生歧义。
 此外，它要求您将所有所需的操作镜像到您的 Gitea 实例，这可能不值得。
@@ -1345,7 +1345,7 @@ PROXY_HOSTS = *.github.com
 在早期版本（`<= 1.19`）中，`DEFAULT_ACTIONS_URL` 可以设置为任何自定义 URL，例如 `https://gitea.com` 或 `http://your-git-server,https://gitea.com`，默认值为 `https://gitea.com`。
 然而，后来的更新删除了这些选项，现在唯一的选项是 `github` 和 `self`，默认值为 `github`。
 但是，如果您想要使用其他 Git 服务器中的操作，您可以在 `uses` 字段中使用完整的 URL，Gitea 支持此功能（GitHub 不支持）。
-例如 `uses: https://gitea.com/actions/checkout@v3` 或 `uses: http://your-git-server/actions/checkout@v3`。
+例如 `uses: https://gitea.com/actions/checkout@v4` 或 `uses: http://your-git-server/actions/checkout@v4`。
 
 ## 其他 (`other`)
 

--- a/docs/content/usage/actions/comparison.en-us.md
+++ b/docs/content/usage/actions/comparison.en-us.md
@@ -22,7 +22,7 @@ Even though Gitea Actions is designed to be compatible with GitHub Actions, ther
 ### Absolute action URLs
 
 Gitea Actions supports defining actions via absolute URL, which means that you can use actions from any git repository.
-Like `uses: https://github.com/actions/checkout@v3` or `uses: http://your_gitea.com/owner/repo@branch`.
+Like `uses: https://github.com/actions/checkout@v4` or `uses: http://your_gitea.com/owner/repo@branch`.
 
 ### Actions written in Go
 
@@ -125,9 +125,9 @@ Services steps don't have their own section in the job log user interface.
 Previously (Pre 1.21.0), `[actions].DEFAULT_ACTIONS_URL` defaulted to `https://gitea.com`.
 We have since restricted this option to only allow two values (`github` and `self`).
 When set to `github`, the new default, Gitea will download non-fully-qualified actions from `https://github.com`.
-For example, if you use `uses: actions/checkout@v3`, it will download the checkout repository from `https://github.com/actions/checkout.git`.
+For example, if you use `uses: actions/checkout@v4`, it will download the checkout repository from `https://github.com/actions/checkout.git`.
 
-If you want to download an action from another git hoster, you can use an absolute URL, e.g. `uses: https://gitea.com/actions/checkout@v3`.
+If you want to download an action from another git hoster, you can use an absolute URL, e.g. `uses: https://gitea.com/actions/checkout@v4`.
 
 If your Gitea instance is in an intranet or a restricted area, you can set the URL to `self` to only download actions from your own instance by default.
 Of course, you can still use absolute URLs in workflows.

--- a/docs/content/usage/actions/comparison.zh-cn.md
+++ b/docs/content/usage/actions/comparison.zh-cn.md
@@ -22,7 +22,7 @@ menu:
 ### Action URL绝对路径
 
 Gitea Actions支持通过URL绝对路径定义actions，这意味着您可以使用来自任何Git存储库的Actions。
-例如，`uses: https://github.com/actions/checkout@v3`或`uses: http://your_gitea.com/owner/repo@branch`。
+例如，`uses: https://github.com/actions/checkout@v4`或`uses: http://your_gitea.com/owner/repo@branch`。
 
 ### 使用Go编写Actions
 
@@ -129,10 +129,10 @@ Gitea Actions目前不支持此功能。
 ### 下载Actions
 
 当 `[actions].DEFAULT_ACTIONS_URL` 保持默认值为 `github` 时，Gitea将会从 https://github.com 下载相对路径的actions。比如：
-如果你使用 `uses: actions/checkout@v3`，Gitea将会从 https://github.com/actions/checkout.git 下载这个 actions 项目。
-如果你想要从另外一个 Git服务下载actions，你只需要使用绝对URL `uses: https://gitea.com/actions/checkout@v3` 来下载。
+如果你使用 `uses: actions/checkout@v4`，Gitea将会从 https://github.com/actions/checkout.git 下载这个 actions 项目。
+如果你想要从另外一个 Git服务下载actions，你只需要使用绝对URL `uses: https://gitea.com/actions/checkout@v4` 来下载。
 
-如果你的 Gitea 实例是部署在一个互联网限制的网络中，有可以使用绝对地址来下载 actions。你也可以讲配置项修改为 `[actions].DEFAULT_ACTIONS_URL = self`。这样所有的相对路径的actions引用，将不再会从 github.com 去下载，而会从这个 Gitea 实例自己的仓库中去下载。例如： `uses: actions/checkout@v3` 将会从 `[server].ROOT_URL`/actions/checkout.git 这个地址去下载 actions。
+如果你的 Gitea 实例是部署在一个互联网限制的网络中，有可以使用绝对地址来下载 actions。你也可以讲配置项修改为 `[actions].DEFAULT_ACTIONS_URL = self`。这样所有的相对路径的actions引用，将不再会从 github.com 去下载，而会从这个 Gitea 实例自己的仓库中去下载。例如： `uses: actions/checkout@v4` 将会从 `[server].ROOT_URL`/actions/checkout.git 这个地址去下载 actions。
 
 设置`[actions].DEFAULT_ACTIONS_URL`进行配置。请参阅[配置备忘单](administration/config-cheat-sheet.md#actions-actions)。
 

--- a/docs/content/usage/actions/design.en-us.md
+++ b/docs/content/usage/actions/design.en-us.md
@@ -116,7 +116,7 @@ And [Gitea Container Registry](usage/packages/container.md) can be used as a Doc
 
 ### Connection 4, job containers to internet
 
-When using actions such as `actions/setup-go@v4`, it may be necessary to download resources from the internet to set up the Go language environment in job containers.
+When using actions such as `actions/setup-go@v5`, it may be necessary to download resources from the internet to set up the Go language environment in job containers.
 Therefore, access to the internet is required for the successful completion of these actions.
 
 However, it is optional as well.

--- a/docs/content/usage/actions/design.en-us.md
+++ b/docs/content/usage/actions/design.en-us.md
@@ -95,7 +95,7 @@ The act runner must be able to connect to Gitea to receive tasks and send back t
 ### Connection 2, job containers to Gitea instance
 
 The job containers have different network namespaces than the runner, even if they are on the same machine.
-They need to connect to Gitea to fetch codes if there is `actions/checkout@v3` in the workflow, for example.
+They need to connect to Gitea to fetch codes if there is `actions/checkout@v4` in the workflow, for example.
 Fetching code is not always necessary to run some jobs, but it is required in most cases.
 
 If you use a loopback address to register a runner, the runner can connect to Gitea when it is on the same machine.
@@ -103,7 +103,7 @@ However, if a job container tries to fetch code from localhost, it will fail bec
 
 ### Connection 3, act runner to internet
 
-When you use some actions like `actions/checkout@v3`, the act runner downloads the scripts, not the job containers.
+When you use some actions like `actions/checkout@v4`, the act runner downloads the scripts, not the job containers.
 By default, it downloads from [gitea.com](http://gitea.com/), so it requires access to the internet.
 It also downloads some docker images from Docker Hub by default, which also requires internet access.
 

--- a/docs/content/usage/actions/design.zh-cn.md
+++ b/docs/content/usage/actions/design.zh-cn.md
@@ -96,7 +96,7 @@ act runner 必须能够连接到Gitea以接收任务并发送执行结果回来�
 ### 连接 2，Job容器到Gitea实例
 
 即使Job容器位于同一台机器上，它们的网络命名空间与Runner不同。
-举个例子，如果工作流中包含 `actions/checkout@v3`，Job容器需要连接到Gitea来获取代码。
+举个例子，如果工作流中包含 `actions/checkout@v4`，Job容器需要连接到Gitea来获取代码。
 获取代码并不总是运行某些Job所必需的，但在大多数情况下是必需的。
 
 如果您使用回环地址注册Runner，当Runner与Gitea在同一台机器上时，Runner可以连接到Gitea。
@@ -104,7 +104,7 @@ act runner 必须能够连接到Gitea以接收任务并发送执行结果回来�
 
 ### 连接 3，act runner到互联网
 
-当您使用诸如 `actions/checkout@v3` 的一些Actions时，act runner下载的是脚本，而不是Job容器。
+当您使用诸如 `actions/checkout@v4` 的一些Actions时，act runner下载的是脚本，而不是Job容器。
 默认情况下，它从[gitea.com](http://gitea.com/)下载，因此需要访问互联网。
 它还默认从Docker Hub下载一些Docker镜像，这也需要互联网访问。
 

--- a/docs/content/usage/actions/design.zh-cn.md
+++ b/docs/content/usage/actions/design.zh-cn.md
@@ -117,7 +117,7 @@ act runner 必须能够连接到Gitea以接收任务并发送执行结果回来�
 
 ### 连接 4，Job容器到互联网
 
-当使用诸如`actions/setup-go@v4`的Actions时，可能需要从互联网下载资源，以设置Job容器中的Go语言环境。
+当使用诸如`actions/setup-go@v5`的Actions时，可能需要从互联网下载资源，以设置Job容器中的Go语言环境。
 因此，成功完成这些Actions需要访问互联网。
 
 然而，这也是可选的。

--- a/docs/content/usage/actions/faq.en-us.md
+++ b/docs/content/usage/actions/faq.en-us.md
@@ -43,10 +43,10 @@ Still, this is completely optional since both options have the same effect at th
 Not yet.
 It is technically possible to implement, but we need to discuss whether it is necessary.
 
-## Where will the runner download scripts when using actions such as `actions/checkout@v3`?
+## Where will the runner download scripts when using actions such as `actions/checkout@v4`?
 
 You may be aware that there are tens of thousands of [marketplace actions](https://github.com/marketplace?type=actions) in GitHub.
-However, when you write `uses: actions/checkout@v3`, it actually downloads the scripts from [gitea.com/actions/checkout](http://gitea.com/actions/checkout) by default (not GitHub).
+However, when you write `uses: actions/checkout@v4`, it actually downloads the scripts from [gitea.com/actions/checkout](http://gitea.com/actions/checkout) by default (not GitHub).
 This is a mirror of [github.com/actions/checkout](http://github.com/actions/checkout), but it's impossible to mirror all of them.
 That's why you may encounter failures when trying to use some actions that haven't been mirrored.
 

--- a/docs/content/usage/actions/faq.zh-cn.md
+++ b/docs/content/usage/actions/faq.zh-cn.md
@@ -43,10 +43,10 @@ DEFAULT_REPO_UNITS = ...,repo.actions
 目前还不可以。
 从技术上讲是可以实现的，但我们需要讨论是否有必要。
 
-## 使用`actions/checkout@v3`等Actions时，Job容器会从何处下载脚本？
+## 使用`actions/checkout@v4`等Actions时，Job容器会从何处下载脚本？
 
 您可能知道GitHub上有成千上万个[Actions市场](https://github.com/marketplace?type=actions)。
-然而，当您编写`uses: actions/checkout@v3`时，它实际上默认从[gitea.com/actions/checkout](http://gitea.com/actions/checkout)下载脚本（而不是从GitHub下载）。
+然而，当您编写`uses: actions/checkout@v4`时，它实际上默认从[gitea.com/actions/checkout](http://gitea.com/actions/checkout)下载脚本（而不是从GitHub下载）。
 这是[github.com/actions/checkout](http://github.com/actions/checkout)的镜像，但无法将它们全部镜像。
 这就是为什么在尝试使用尚未镜像的某些Actions时可能会遇到失败的原因。
 

--- a/docs/content/usage/actions/overview.en-us.md
+++ b/docs/content/usage/actions/overview.en-us.md
@@ -25,7 +25,7 @@ To avoid confusion, we have clarified the spelling here:
 - "Gitea Actions" (with an "s", both words capitalized) is the name of the Gitea feature.
 - "GitHub Actions" is the name of the GitHub feature.
 - "Actions" could refer to either of the above, depending on the context. So it refers to "Gitea Actions" in this document.
-- "action" or "actions" refer to some scripts/plugins to be used, like "actions/checkout@v3" or "actions/cache@v3".
+- "action" or "actions" refer to some scripts/plugins to be used, like "actions/checkout@v4" or "actions/cache@v3".
 
 ## Runners
 

--- a/docs/content/usage/actions/overview.zh-cn.md
+++ b/docs/content/usage/actions/overview.zh-cn.md
@@ -25,7 +25,7 @@ Gitea Actions与[GitHub Actions](https://github.com/features/actions)相似且�
 - "Gitea Actions"（两个单词都大写且带有"s"）是Gitea功能的名称。
 - "GitHub Actions"是GitHub功能的名称。
 - "Actions"根据上下文的不同可以指代以上任意一个。在本文档中指代的是"Gitea Actions"。
-- "action"或"actions"指代一些要使用的脚本/插件，比如"actions/checkout@v3"或"actions/cache@v3"。
+- "action"或"actions"指代一些要使用的脚本/插件，比如"actions/checkout@v4"或"actions/cache@v3"。
 
 ## Runner
 

--- a/docs/content/usage/actions/quickstart.en-us.md
+++ b/docs/content/usage/actions/quickstart.en-us.md
@@ -113,7 +113,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by Gitea!"
       - run: echo "🔎 The name of your branch is ${{ gitea.ref }} and your repository is ${{ gitea.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: echo "💡 The ${{ gitea.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository

--- a/docs/content/usage/actions/quickstart.zh-cn.md
+++ b/docs/content/usage/actions/quickstart.zh-cn.md
@@ -112,7 +112,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by Gitea!"
       - run: echo "🔎 The name of your branch is ${{ gitea.ref }} and your repository is ${{ gitea.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: echo "💡 The ${{ gitea.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository


### PR DESCRIPTION
Update more actions to use nodejs20 runtime and also update the docs for checkout action usage.

similar to:
- #27836
- #27096


