### PR TITLE
Fix 500 error of searching commits

### DIFF
--- a/templates/code/searchresults.tmpl
+++ b/templates/code/searchresults.tmpl
@@ -31,7 +31,7 @@
 										<a href="{{$repo.Link}}/src/commit/{{$result.CommitID | PathEscape}}/{{$result.Filename | PathEscapeSegments}}#L{{.}}"><span>{{.}}</span></a>
 									{{end}}
 								</td>
-								<td class="lines-code chroma"><code class="code-inner">{{.FormattedLines | Safe}}</code></td>
+								<td class="lines-code chroma"><code class="code-inner">{{.FormattedLines}}</code></td>
 							</tr>
 						</tbody>
 					</table>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -53,7 +53,7 @@
 														<a href="{{$.SourcePath}}/src/commit/{{PathEscape $result.CommitID}}/{{PathEscapeSegments $result.Filename}}#L{{.}}"><span>{{.}}</span></a>
 													{{end}}
 												</td>
-												<td class="lines-code chroma"><code class="code-inner">{{.FormattedLines | Safe}}</code></td>
+												<td class="lines-code chroma"><code class="code-inner">{{.FormattedLines}}</code></td>
 											</tr>
 										</tbody>
 									</table>


### PR DESCRIPTION
Regression of #28454 . Now the string is escaped HTML, so it doesn't need `| Safe`.

Fix #28575