### PR TITLE
Fix wrong due date rendering in issue list page

### DIFF
--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -114,7 +114,7 @@
 						<span class="due-date flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.due_date"}}">
 							<span{{if .IsOverdue}} class="text red"{{end}}>
 								{{svg "octicon-calendar" 14}}
-								{{DateTime "short" .DeadlineUnix}}
+								{{DateTime "short" (.DeadlineUnix.Format "2006-01-02")}}
 							</span>
 						</span>
 					{{end}}


### PR DESCRIPTION
It included the hours, minutes, and seconds. By removing these, the date renders correctly.

- Same fix as https://github.com/go-gitea/gitea/pull/26268
- Fixes https://github.com/go-gitea/gitea/issues/28567

The due date in the following example is 2024-01-01:
![image](https://github.com/go-gitea/gitea/assets/20454870/bf4c825a-d2e8-48d8-96c4-445ed848a369)

# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/4ede079c-43f7-4d2e-8d9c-d7c573613d36)
![image](https://github.com/go-gitea/gitea/assets/20454870/cd8be83d-43a9-440e-b800-94daca535f1e)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/bb69968d-97f8-45d4-8d84-95353f5636bc)
![image](https://github.com/go-gitea/gitea/assets/20454870/a126bfcc-9dce-4b90-92a6-ac3fe40f7353)
