### PR TITLE
Refactor timeutil package

### DIFF
--- a/models/activities/user_heatmap_test.go
+++ b/models/activities/user_heatmap_test.go
@@ -59,8 +59,8 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
 	// Mock time
-	timeutil.Set(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
-	defer timeutil.Unset()
+	timeutil.MockSet(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer timeutil.MockUnset()
 
 	for _, tc := range testCases {
 		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: tc.userID})

--- a/models/asymkey/gpg_key_verify.go
+++ b/models/asymkey/gpg_key_verify.go
@@ -107,8 +107,9 @@ func VerifyGPGKey(ctx context.Context, ownerID int64, keyID, token, signature st
 // VerificationToken returns token for the user that will be valid in minutes (time)
 func VerificationToken(user *user_model.User, minutes int) string {
 	return base.EncodeSha256(
-		time.Now().Truncate(1*time.Minute).Add(time.Duration(minutes)*time.Minute).Format(time.RFC1123Z) + ":" +
-			user.CreatedUnix.FormatLong() + ":" +
+		time.Now().Truncate(1*time.Minute).Add(time.Duration(minutes)*time.Minute).Format(
+			time.RFC1123Z) + ":" +
+			user.CreatedUnix.Format(time.RFC1123Z) + ":" +
 			user.Name + ":" +
 			user.Email + ":" +
 			strconv.FormatInt(user.ID, 10))

--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -899,15 +899,15 @@ func createDeadlineComment(ctx context.Context, doer *user_model.User, issue *Is
 	// newDeadline = 0 means deleting
 	if newDeadlineUnix == 0 {
 		commentType = CommentTypeRemovedDeadline
-		content = issue.DeadlineUnix.Format("2006-01-02")
+		content = issue.DeadlineUnix.FormatDate()
 	} else if issue.DeadlineUnix == 0 {
 		// Check if the new date was added or modified
 		// If the actual deadline is 0 => deadline added
 		commentType = CommentTypeAddedDeadline
-		content = newDeadlineUnix.Format("2006-01-02")
+		content = newDeadlineUnix.FormatDate()
 	} else { // Otherwise modified
 		commentType = CommentTypeModifiedDeadline
-		content = newDeadlineUnix.Format("2006-01-02") + "|" + issue.DeadlineUnix.Format("2006-01-02")
+		content = newDeadlineUnix.FormatDate() + "|" + issue.DeadlineUnix.FormatDate()
 	}
 
 	if err := issue.LoadRepo(ctx); err != nil {

--- a/models/issues/milestone.go
+++ b/models/issues/milestone.go
@@ -86,7 +86,7 @@ func (m *Milestone) AfterLoad() {
 		return
 	}
 
-	m.DeadlineString = m.DeadlineUnix.Format("2006-01-02")
+	m.DeadlineString = m.DeadlineUnix.FormatDate()
 	if m.IsClosed {
 		m.IsOverdue = m.ClosedDateUnix >= m.DeadlineUnix
 	} else {

--- a/modules/timeutil/timestamp.go
+++ b/modules/timeutil/timestamp.go
@@ -13,27 +13,27 @@ import (
 type TimeStamp int64
 
 var (
-	// mock is NOT concurrency-safe!!
-	mock time.Time
+	// mockNow is NOT concurrency-safe!!
+	mockNow time.Time
 
 	// Used for IsZero, to check if timestamp is the zero time instant.
 	timeZeroUnix = time.Time{}.Unix()
 )
 
-// Set sets the time to a mocked time.Time
-func Set(now time.Time) {
-	mock = now
+// MockSet sets the time to a mocked time.Time
+func MockSet(now time.Time) {
+	mockNow = now
 }
 
-// Unset will unset the mocked time.Time
-func Unset() {
-	mock = time.Time{}
+// MockUnset will unset the mocked time.Time
+func MockUnset() {
+	mockNow = time.Time{}
 }
 
 // TimeStampNow returns now int64
 func TimeStampNow() TimeStamp {
-	if !mock.IsZero() {
-		return TimeStamp(mock.Unix())
+	if !mockNow.IsZero() {
+		return TimeStamp(mockNow.Unix())
 	}
 	return TimeStamp(time.Now().Unix())
 }
@@ -89,19 +89,9 @@ func (ts TimeStamp) FormatInLocation(f string, loc *time.Location) string {
 	return ts.AsTimeInLocation(loc).Format(f)
 }
 
-// FormatLong formats as RFC1123Z
-func (ts TimeStamp) FormatLong() string {
-	return ts.Format(time.RFC1123Z)
-}
-
-// FormatShort formats as short
-func (ts TimeStamp) FormatShort() string {
-	return ts.Format("Jan 02, 2006")
-}
-
-// FormatDate formats a date in YYYY-MM-DD server time zone
+// FormatDate formats a date in YYYY-MM-DD
 func (ts TimeStamp) FormatDate() string {
-	return time.Unix(int64(ts), 0).String()[:10]
+	return ts.Format("2006-01-02")
 }
 
 // IsZero is zero time

--- a/services/auth/auth_token_test.go
+++ b/services/auth/auth_token_test.go
@@ -37,14 +37,14 @@ func TestCheckAuthToken(t *testing.T) {
 	})
 
 	t.Run("Expired", func(t *testing.T) {
-		timeutil.Set(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+		timeutil.MockSet(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 
 		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
 		assert.NoError(t, err)
 		assert.NotNil(t, at)
 		assert.NotEmpty(t, token)
 
-		timeutil.Unset()
+		timeutil.MockUnset()
 
 		at2, err := CheckAuthToken(db.DefaultContext, at.ID+":"+token)
 		assert.ErrorIs(t, err, ErrAuthTokenExpired)
@@ -83,15 +83,15 @@ func TestCheckAuthToken(t *testing.T) {
 func TestRegenerateAuthToken(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
-	timeutil.Set(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
-	defer timeutil.Unset()
+	timeutil.MockSet(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer timeutil.MockUnset()
 
 	at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
 	assert.NoError(t, err)
 	assert.NotNil(t, at)
 	assert.NotEmpty(t, token)
 
-	timeutil.Set(time.Date(2023, 1, 1, 0, 0, 1, 0, time.UTC))
+	timeutil.MockSet(time.Date(2023, 1, 1, 0, 0, 1, 0, time.UTC))
 
 	at2, token2, err := RegenerateAuthToken(db.DefaultContext, at)
 	assert.NoError(t, err)

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -392,7 +392,7 @@
 			<div {{if ne .Issue.DeadlineUnix 0}} class="gt-hidden"{{end}} id="deadlineForm">
 				<form class="ui fluid action input issue-due-form" action="{{AppSubUrl}}/{{PathEscape .Repository.Owner.Name}}/{{PathEscape .Repository.Name}}/issues/{{.Issue.Index}}/deadline" method="post" id="update-issue-deadline-form">
 					{{$.CsrfTokenHtml}}
-					<input required placeholder="{{ctx.Locale.Tr "repo.issues.due_date_form"}}" {{if gt .Issue.DeadlineUnix 0}}value="{{.Issue.DeadlineUnix.Format "2006-01-02"}}"{{end}} type="date" name="deadlineDate" id="deadlineDate">
+					<input required placeholder="{{ctx.Locale.Tr "repo.issues.due_date_form"}}" {{if gt .Issue.DeadlineUnix 0}}value="{{.Issue.DeadlineUnix.FormatDate}}"{{end}} type="date" name="deadlineDate" id="deadlineDate">
 					<button class="ui icon button">
 						{{if ne .Issue.DeadlineUnix 0}}
 							{{svg "octicon-pencil"}}

--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -114,7 +114,7 @@
 						<span class="due-date flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.due_date"}}">
 							<span{{if .IsOverdue}} class="text red"{{end}}>
 								{{svg "octicon-calendar" 14}}
-								{{DateTime "short" (.DeadlineUnix.Format "2006-01-02")}}
+								{{DateTime "short" (.DeadlineUnix.FormatDate)}}
 							</span>
 						</span>
 					{{end}}

--- a/tests/integration/api_user_heatmap_test.go
+++ b/tests/integration/api_user_heatmap_test.go
@@ -24,8 +24,8 @@ func TestUserHeatmap(t *testing.T) {
 	token := getUserToken(t, adminUsername, auth_model.AccessTokenScopeReadUser)
 
 	fakeNow := time.Date(2011, 10, 20, 0, 0, 0, 0, time.Local)
-	timeutil.Set(fakeNow)
-	defer timeutil.Unset()
+	timeutil.MockSet(fakeNow)
+	defer timeutil.MockUnset()
 
 	req := NewRequest(t, "GET", fmt.Sprintf("/api/v1/users/%s/heatmap", normalUsername)).
 		AddTokenAuth(token)


### PR DESCRIPTION
1. make names more readable
2. remove unused FormatLong/FormatShort
3. use `FormatDate` instead of `Format "2006-01-02"`