### PR TITLE
Remove unnecessary syncbranchToDB with tests

### DIFF
--- a/tests/integration/branches_test.go
+++ b/tests/integration/branches_test.go
@@ -73,5 +73,3 @@ func branchAction(t *testing.T, button string) (*HTMLDoc, string) {
 
 	return NewHTMLParser(t, resp.Body), url.Query().Get("name")
 }
-
-

--- a/tests/integration/branches_test.go
+++ b/tests/integration/branches_test.go
@@ -73,3 +73,5 @@ func branchAction(t *testing.T, button string) (*HTMLDoc, string) {
 
 	return NewHTMLParser(t, resp.Body), url.Query().Get("name")
 }
+
+


### PR DESCRIPTION
#28361 introduced `syncBranchToDB` in `CreateNewBranchFromCommit`. This PR will revert the change because it's unnecessary. Every push will already be checked by `syncBranchToDB`. 
This PR also created a test to ensure it's right.