### PR TITLE
Make table column branch.name case sensitive

### DIFF
--- a/docs/content/help/faq.en-us.md
+++ b/docs/content/help/faq.en-us.md
@@ -387,7 +387,7 @@ the `utf8` charset, and connections which use the `utf8` charset will not use th
 
 Please run `gitea doctor convert`, or run `ALTER DATABASE database_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`
 for the database_name and run `ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`
-for each table in the database.
+for tables which are not using `utf8mb4` in the database.
 
 ## Why are Emoji displaying only as placeholders or in monochrome
 

--- a/docs/content/help/faq.zh-cn.md
+++ b/docs/content/help/faq.zh-cn.md
@@ -390,9 +390,7 @@ SET GLOBAL innodb_large_prefix=1;
 utf8 字符集的表和连接将不会使用它。
 
 请运行 `gitea doctor convert` 或对数据库运行 `ALTER DATABASE database_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`
-并对每个表运行 `ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`。
-
-您还需要将`app.ini`文件中的数据库字符集设置为`CHARSET=utf8mb4`。
+并对不是 `utf8mb4` 的表运行 `ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`。
 
 ## 为什么 Emoji 只显示占位符或单色图像
 

--- a/models/db/convert.go
+++ b/models/db/convert.go
@@ -6,6 +6,7 @@ package db
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -34,6 +35,10 @@ func ConvertUtf8ToUtf8mb4() error {
 			return err
 		}
 
+		if strings.HasPrefix(table.Collation, "utf8mb4") {
+			fmt.Printf("skip table %q because it is already using utf8mb4\n", table.Name)
+			continue
+		}
 		if _, err := x.Exec(fmt.Sprintf("ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;", table.Name)); err != nil {
 			return err
 		}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -552,6 +552,8 @@ var migrations = []Migration{
 	NewMigration("Add Index to pull_auto_merge.doer_id", v1_22.AddIndexToPullAutoMergeDoerID),
 	// v283 -> v284
 	NewMigration("Add combined Index to issue_user.uid and issue_id", v1_22.AddCombinedIndexToIssueUser),
+	// v284 -> v285
+	NewMigration("Alter branch name collation to be case-sensitive", v1_22.AlterBranchNameCollation),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v1_22/v283_test.go
+++ b/models/migrations/v1_22/v283_test.go
@@ -7,22 +7,22 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/migrations/base"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_AddCombinedIndexToIssueUser(t *testing.T) {
 	type IssueUser struct {
-		UID     int64 `xorm:"INDEX unique(uid_to_issue)"` // User ID.
-		IssueID int64 `xorm:"INDEX unique(uid_to_issue)"`
+		ID          int64 `xorm:"pk autoincr"`
+		UID         int64 `xorm:"INDEX"` // User ID.
+		IssueID     int64 `xorm:"INDEX"`
+		IsRead      bool
+		IsMentioned bool
 	}
 
 	// Prepare and load the testing database
 	x, deferable := base.PrepareTestEnv(t, 0, new(IssueUser))
 	defer deferable()
-	if x == nil || t.Failed() {
-		return
-	}
 
-	if err := AddCombinedIndexToIssueUser(x); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, AddCombinedIndexToIssueUser(x))
 }

--- a/models/migrations/v1_22/v284.go
+++ b/models/migrations/v1_22/v284.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_22 //nolint
+
+import (
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+
+	"xorm.io/xorm"
+)
+
+func AlterBranchNameCollation(x *xorm.Engine) error {
+	if setting.Database.Type.IsMySQL() {
+		_, err := x.Exec("ALTER TABLE branch MODIFY COLUMN `name` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL")
+		return err
+	} else if setting.Database.Type.IsMSSQL() {
+		if _, err := x.Exec("DROP INDEX UQE_branch_s ON branch"); err != nil {
+			log.Error("Failed to drop index UQE_branch_s on branch: %v", err) // ignore this error, in case the index has been dropped in previous migration
+		}
+		if _, err := x.Exec("ALTER TABLE branch ALTER COLUMN [name] nvarchar(255) COLLATE Latin1_General_CS_AS NOT NULL"); err != nil {
+			return err
+		}
+		if _, err := x.Exec("CREATE UNIQUE NONCLUSTERED INDEX UQE_branch_s ON branch (repo_id ASC, [name] ASC)"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/models/migrations/v1_22/v284_test.go
+++ b/models/migrations/v1_22/v284_test.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_22 //nolint
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/migrations/base"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlterBranchNameCollation(t *testing.T) {
+	type Branch struct {
+		ID     int64
+		RepoID int64  `xorm:"UNIQUE(s)"`
+		Name   string `xorm:"UNIQUE(s) NOT NULL"`
+	}
+
+	x, deferable := base.PrepareTestEnv(t, 0, new(Branch))
+	defer deferable()
+
+	assert.NoError(t, AlterBranchNameCollation(x))
+}

--- a/tests/integration/api_branch_test.go
+++ b/tests/integration/api_branch_test.go
@@ -142,6 +142,18 @@ func testAPICreateBranches(t *testing.T, giteaURL *url.URL) {
 			NewBranch:          "branch_2",
 			ExpectedHTTPStatus: http.StatusCreated,
 		},
+		// Trying to create a case-sensitive branch name
+		{
+			OldBranch:          "new_branch_from_master_1",
+			NewBranch:          "Branch_2",
+			ExpectedHTTPStatus: http.StatusCreated,
+		},
+		// Trying to create a branch with UTF8
+		{
+			OldBranch:          "master",
+			NewBranch:          "test-👀",
+			ExpectedHTTPStatus: http.StatusCreated,
+		},
 		// Trying to create from a branch which does not exist
 		{
 			OldBranch:          "does_not_exist",


### PR DESCRIPTION
The bug was introduced by  #22743 , because some databases are default to "case-insensitive"

Fix #28131
Fix #25909
and more

This PR is only a quick fix, it only fixes the "branch" case-insensitive bug. It is not a complete fix for the database collation problem.

To fix various potential "case" bugs in the future, it's better to make all database collation case-sensitive (mainly MySQL/MSSQL)