### PR TITLE
Fix: Search organization results prompt error

### DIFF
--- a/routers/web/explore/org.go
+++ b/routers/web/explore/org.go
@@ -6,9 +6,15 @@ package explore
 import (
 	"code.gitea.io/gitea/models/db"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/structs"
+)
+
+const (
+	// tplExploreUsers explore org page template
+	tplExploreOrgs base.TplName = "explore/orgs"
 )
 
 // Organizations render explore organizations page
@@ -33,5 +39,5 @@ func Organizations(ctx *context.Context) {
 		Type:        user_model.UserTypeOrganization,
 		ListOptions: db.ListOptions{PageSize: setting.UI.ExplorePagingNum},
 		Visible:     visibleTypes,
-	}, tplExploreUsers)
+	}, tplExploreOrgs)
 }

--- a/templates/explore/org_list.tmpl
+++ b/templates/explore/org_list.tmpl
@@ -1,0 +1,31 @@
+<div class="flex-list">
+	{{range .Users}}
+		<div class="flex-item gt-ac">
+			<div class="flex-item-leading">
+				{{ctx.AvatarUtils.Avatar . 48}}
+			</div>
+			<div class="flex-item-main">
+				<div class="flex-item-title">
+					{{template "shared/user/name" .}}
+					{{if .Visibility.IsPrivate}}
+						<span class="ui basic tiny label">{{ctx.Locale.Tr "repo.desc.private"}}</span>
+					{{end}}
+				</div>
+				<div class="flex-item-body">
+					{{if .Location}}
+						<span class="flex-text-inline">{{svg "octicon-location"}}{{.Location}}</span>
+					{{end}}
+					{{if and .Email (or (and $.ShowUserEmail $.IsSigned (not .KeepEmailPrivate)) $.PageIsAdminUsers)}}
+						<span class="flex-text-inline">
+							{{svg "octicon-mail"}}
+							<a href="mailto:{{.Email}}">{{.Email}}</a>
+						</span>
+					{{end}}
+					<span class="flex-text-inline">{{svg "octicon-calendar"}}{{ctx.Locale.Tr "user.joined_on" (DateTime "short" .CreatedUnix) | Safe}}</span>
+				</div>
+			</div>
+		</div>
+	{{else}}
+		<div class="flex-item">{{ctx.Locale.Tr "explore.org_no_results"}}</div>
+	{{end}}
+</div>

--- a/templates/explore/orgs.tmpl
+++ b/templates/explore/orgs.tmpl
@@ -1,0 +1,12 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content explore users">
+	{{template "explore/navbar" .}}
+	<div class="ui container">
+		{{template "explore/search" .}}
+
+		{{template "explore/org_list" .}}
+
+		{{template "base/paginate" .}}
+	</div>
+</div>
+{{template "base/footer" .}}


### PR DESCRIPTION

Bug: When the organization cannot be searched, the error prompt displays an error
![image](https://github.com/go-gitea/gitea/assets/17313832/1fe78bce-0e05-4489-b36d-85f1dabde6e1)

Fixed this issue
![image](https://github.com/go-gitea/gitea/assets/17313832/37901944-c7f0-4c3a-b859-a4c4924229e3)
