### PR TITLE
fix: Backport of Alpine 3.19 to release/v1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Build stage
-FROM docker.io/library/golang:1.20-alpine3.17 AS build-env
+FROM docker.io/library/golang:1.20-alpine3.19 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -23,7 +23,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM docker.io/library/alpine:3.17
+FROM docker.io/library/alpine:3.19
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 22 3000

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,5 +1,5 @@
 #Build stage
-FROM docker.io/library/golang:1.20-alpine3.17 AS build-env
+FROM docker.io/library/golang:1.20-alpine3.19 AS build-env
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY:-direct}
@@ -23,7 +23,7 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
-FROM docker.io/library/alpine:3.17
+FROM docker.io/library/alpine:3.19
 LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 2222 3000

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/markbates/goth v1.76.0
 	github.com/mattn/go-isatty v0.0.17
-	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/microcosm-cc/bluemonday v1.0.21
 	github.com/minio/minio-go/v7 v7.0.46

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
-github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
+github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mholt/acmez v1.0.4 h1:N3cE4Pek+dSolbsofIkAYz6H1d3pE+2G0os7QHslf80=


### PR DESCRIPTION
We're currently using `gitea:1.19.x` and our security scanners have detected the Critical [CVE-2023-38545](https://avd.aquasec.com/nvd/cve-2023-38545) found in the base `alpine:3.17` image.

This CVE has been fixed in the `main` branch via #28594. 

This PR backports the fixes to the  `release/v1.19` branches.

This PR also bumps `github.com/mattn/go-sqlite3` to `v1.14.9` due to a build break which was fixed by [`go-sqlite3`](https://github.com/mattn/go-sqlite3/issues/1164), a similar bump is introduced in `main` via #28518 

For testing, issuing a `make test` passes and running a `trivy image docker.io/gitea/gitea:latest` shows the Critical CVEs are no longer present with `alpine:3.19` as of writingthis PR.

We'd like to request the release of a new `gitea:1.19.x` release on the successful merge of this PR.