### PR TITLE
MySQL case sensitivty fix

### DIFF
--- a/cmd/doctor_convert.go
+++ b/cmd/doctor_convert.go
@@ -37,11 +37,16 @@ func runDoctorConvert(ctx *cli.Context) error {
 
 	switch {
 	case setting.Database.Type.IsMySQL():
-		if err := db.ConvertUtf8ToUtf8mb4(); err != nil {
-			log.Fatal("Failed to convert database from utf8 to utf8mb4: %v", err)
+		charset, collation, err := db.GetDesiredCharsetAndCollation()
+		if err != nil {
+			log.Fatal("Failed to determine the desired database charset or collation: %v", err)
 			return err
 		}
-		fmt.Println("Converted successfully, please confirm your database's character set is now utf8mb4")
+		if err := db.ConvertCharsetAndCollation(charset, collation); err != nil {
+			log.Fatal("Failed to convert database from utf8 to %s: %v", charset, err)
+			return err
+		}
+		fmt.Printf("Converted successfully, please confirm your database's character set is now %s, and collation is set to %s\n", charset, collation)
 	case setting.Database.Type.IsMSSQL():
 		if err := db.ConvertVarcharToNVarchar(); err != nil {
 			log.Fatal("Failed to convert database from varchar to nvarchar: %v", err)

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -15,6 +15,7 @@ import (
 
 	_ "net/http/pprof" // Used for debugging if enabled and a web server is running
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -192,6 +193,10 @@ func serveInstalled(ctx *cli.Context) error {
 	}
 
 	routers.InitWebInstalled(graceful.GetManager().HammerContext())
+
+	if err := db.SanityCheck(); err != nil {
+		log.Warn("database sanity check warning: %s", err)
+	}
 
 	// We check that AppDataPath exists here (it should have been created during installation)
 	// We can't check it in `InitWebInstalled`, because some integration tests

--- a/docs/content/help/faq.en-us.md
+++ b/docs/content/help/faq.en-us.md
@@ -385,9 +385,11 @@ Unfortunately MySQL's `utf8` charset does not completely allow all possible UTF-
 They created a new charset and collation called `utf8mb4` that allows for emoji to be stored but tables which use
 the `utf8` charset, and connections which use the `utf8` charset will not use this.
 
-Please run `gitea doctor convert`, or run `ALTER DATABASE database_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`
-for the database_name and run `ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`
+Please run `gitea doctor convert`, or run `ALTER DATABASE database_name CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;`
+for the database_name and run `ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;`
 for each table in the database.
+
+The most appropriate collate function depends on your variant of the database: for MySQL, it is `utf8mb4_0900_as_cs`, for MariaDB, it is `uca1400_as_cs`. Both of them support `utf8mb4_bin`, so that's the common ground. `gitea doctor convert` will choose the best one for you automatically.
 
 ## Why are Emoji displaying only as placeholders or in monochrome
 

--- a/docs/content/installation/database-preparation.en-us.md
+++ b/docs/content/installation/database-preparation.en-us.md
@@ -61,13 +61,13 @@ Note: All steps below requires that the database engine of your choice is instal
 
     Replace username and password above as appropriate.
 
-4. Create database with UTF-8 charset and collation. Make sure to use `utf8mb4` charset instead of `utf8` as the former supports all Unicode characters (including emojis) beyond _Basic Multilingual Plane_. Also, collation chosen depending on your expected content. When in doubt, use either `unicode_ci` or `general_ci`.
+4. Create database with UTF-8 charset and collation. Make sure to use `utf8mb4` charset instead of `utf8` as the former supports all Unicode characters (including emojis) beyond _Basic Multilingual Plane_. Also, collation chosen depending on your expected content (such as `utf8mb4_0900_as_cs` for MySQL, or `uca1400_as_cs` for MariaDB, or `utf8mb4_bin` that works for both). When in doubt, leave it unset, and Gitea will adjust the database to use the most fitting one.
 
     ```sql
-    CREATE DATABASE giteadb CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+    CREATE DATABASE giteadb CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin';
     ```
 
-    Replace database name as appropriate.
+    Replace database name and the collate function as appropriate.
 
 5. Grant all privileges on the database to database user created above.
 

--- a/models/db/convert.go
+++ b/models/db/convert.go
@@ -15,12 +15,12 @@ import (
 )
 
 // ConvertUtf8ToUtf8mb4 converts database and tables from utf8 to utf8mb4 if it's mysql and set ROW_FORMAT=dynamic
-func ConvertUtf8ToUtf8mb4() error {
+func ConvertCharsetAndCollation(charset, collation string) error {
 	if x.Dialect().URI().DBType != schemas.MYSQL {
 		return nil
 	}
 
-	_, err := x.Exec(fmt.Sprintf("ALTER DATABASE `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci", setting.Database.Name))
+	_, err := x.Exec(fmt.Sprintf("ALTER DATABASE `%s` CHARACTER SET `%s` COLLATE `%s`", setting.Database.Name, charset, collation))
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func ConvertUtf8ToUtf8mb4() error {
 			return err
 		}
 
-		if _, err := x.Exec(fmt.Sprintf("ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;", table.Name)); err != nil {
+		if _, err := x.Exec(fmt.Sprintf("ALTER TABLE `%s` CONVERT TO CHARACTER SET `%s` COLLATE `%s`", table.Name, charset, collation)); err != nil {
 			return err
 		}
 	}

--- a/models/git/branch.go
+++ b/models/git/branch.go
@@ -103,7 +103,7 @@ func (err ErrBranchesEqual) Unwrap() error {
 type Branch struct {
 	ID            int64
 	RepoID        int64  `xorm:"UNIQUE(s)"`
-	Name          string `xorm:"UNIQUE(s) NOT NULL"` // git's ref-name is case-sensitive internally, however, in some databases (mssql, mysql, by default), it's case-insensitive at the moment
+	Name          string `xorm:"UNIQUE(s) NOT NULL"`
 	CommitID      string
 	CommitMessage string `xorm:"TEXT"` // it only stores the message summary (the first line)
 	PusherID      int64

--- a/tests/integration/collate_test.go
+++ b/tests/integration/collate_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/setting"
+	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMySQLCollate(t *testing.T) {
+	// This test is only for MySQL, return early for any other engine.
+	if !setting.Database.Type.IsMySQL() {
+		t.Skip()
+	}
+
+	defer tests.PrepareTestEnv(t)()
+
+	// Helpers
+	loadProps := func() (*repo_model.Repository, *user_model.User, string) {
+		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
+		owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
+		session := loginUser(t, owner.Name)
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteIssue)
+
+		return repo, owner, token
+	}
+
+	breakCollation := func() {
+		err := db.ConvertCharsetAndCollation("utf8mb4", "utf8mb4_general_ci")
+		assert.NoError(t, err)
+	}
+	fixCollation := func() {
+		charset, collation, err := db.GetDesiredCharsetAndCollation()
+		assert.NoError(t, err)
+		err = db.ConvertCharsetAndCollation(charset, collation)
+		assert.NoError(t, err)
+	}
+
+	t.Run("Collation fixing", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		// Ensure that the database uses the wrong collation
+		breakCollation()
+
+		// With the wrong collation, sanity checking fails
+		err := db.SanityCheck()
+		assert.Error(t, err)
+
+		// Try updating the collation
+		fixCollation()
+
+		// Sanity checking works after the collation update
+		err = db.SanityCheck()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Case sensitive issue search by label", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		assert.NoError(t, unittest.LoadFixtures())
+
+		// Helpers
+		createLabel := func(name string) int64 {
+			repo, owner, token := loadProps()
+			urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/labels", owner.Name, repo.Name)
+
+			// CreateLabel
+			req := NewRequestWithJSON(t, "POST", urlStr, &api.CreateLabelOption{
+				Name:        name,
+				Color:       "abcdef",
+				Description: "test label",
+			}).AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusCreated)
+			apiLabel := new(api.Label)
+			DecodeJSON(t, resp, &apiLabel)
+			return apiLabel.ID
+		}
+
+		createIssue := func(title string, labelID int64) {
+			repo, owner, token := loadProps()
+			urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues", owner.Name, repo.Name)
+
+			// CreateIssue
+			req := NewRequestWithJSON(t, "POST", urlStr, &api.CreateIssueOption{
+				Title:  title,
+				Labels: []int64{labelID},
+			}).AddTokenAuth(token)
+			MakeRequest(t, req, http.StatusCreated)
+		}
+
+		searchIssues := func(label string) []*api.Issue {
+			_, _, token := loadProps()
+			var apiIssues []*api.Issue
+
+			urlStr := fmt.Sprintf("/api/v1/repos/issues/search?labels=%s", label)
+			req := NewRequest(t, "GET", urlStr).AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusOK)
+
+			DecodeJSON(t, resp, &apiIssues)
+			return apiIssues
+		}
+
+		// Ensure that the database uses the wrong collation
+		breakCollation()
+
+		// Create two labels that differ in case only
+		labelID1 := createLabel("case-sens")
+		labelID2 := createLabel("Case-Sens")
+
+		// Create two issues, one with each of the labels above
+		createIssue("case-sens 1", labelID1)
+		createIssue("case-sens 2", labelID2)
+
+		// Search for 'label1', and expect two results (`label1` and `Label1`)
+		issues := searchIssues("case-sens")
+		assert.Len(t, issues, 2)
+
+		// Update the collation
+		fixCollation()
+
+		// Search for 'label1', and expect only one result now.
+		issues = searchIssues("case-sens")
+		assert.Len(t, issues, 1)
+	})
+}


### PR DESCRIPTION
This is a... complicated pull request, and does a number of things:

- It adds `setting.Database.DefaultCharset` and `setting.Database.DefaultCollation`, and removes `setting.Database.MysqlCharset`.
- Refactors `db.ConvertUtf8ToUtf8mb4()` into `db.ConvertCharsetAndCollation()`, a function that can convert a database to the desired charset + collation, rather than hardcoding either of them.
- Adds `db.findCaseSensitiveCollation()` to auto-detect the most fitting collate, and `db.GetDesiredCharsetAndCollation()` to return either the charset/collation set in the config, or (if either is empty) the auto-detected default.
- With the above changes, `gitea doctor convert` will convert the db to the desired charset + collation combo, rather than hardcoded values.
- When starting the web server, Gitea will now perform a sanity check on the database: this currently checks the charset & collation on the database and each table, and warns if there's a mismatch (it does not stop the process, merely warns)
- In `InitDBWithMigrations`, if it sees an empty MySQL database, it will `ALTER DATABASE` it to have the correct charset & collate.
- Documentation is updated to mention the case sensitive collations, and recommend using `gitea doctor convert` more strongly.

The reason for the `setting.Database.MysqlCharset` removal, and the `InitDBWithMigrations` change is to let `CREATE TABLE` calls *inherit* the charset and the collate function from the database. If we don't remove `MysqlCharset` from the connection string, `xorm` will add `CHARSET <foo>` to each `CREATE TABLE` call, which in turn will *implicitly* set the collate function to the *charset's default*, rather than the database's. If we remove the charset from the connection string, `xorm` will not add `CHARSET <foo>` to the `CREATE TABLE` calls, and they will correctly inherit both charset & collate.

A better solution for this would be to teach `xorm` to let us set a database-level default collate, and add that to each `CREATE TABLE` call. If it did that, we could remove the `ALTER TABLE` from `InitDBWithMigration`. This is something that is worth doing longer term, and I'm more than willing to do that and submit a PR against `xorm`, and once that's updated - if such a change is accepted - submit an update to Gitea aswell. Meanwhile, I think this is the best we can do.

By the way, the `ALTER TABLE` thing (and the `xorm`-based fix later on) will both help new installations when the database was automatically created with the wrong collate, such as when using a dockerized MySQL/MariaDB. Existing installs will have to use `gitea doctor convert`.

This PR does *not* address the problem for MSSQL, however. I don't have the resources to make a fix for that, but I'm reasonably sure something similar could be accomplished there, too.