### PR TITLE
oauth: Increase the max size of Provider to 255

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -552,6 +552,8 @@ var migrations = []Migration{
 	NewMigration("Add Index to pull_auto_merge.doer_id", v1_22.AddIndexToPullAutoMergeDoerID),
 	// v283 -> v284
 	NewMigration("Add combined Index to issue_user.uid and issue_id", v1_22.AddCombinedIndexToIssueUser),
+	// v284 -> v285
+	NewMigration("Incrase external_login_user.provider size to 255", v1_22.UpdateExternalLoginUserProvider),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v1_22/v284.go
+++ b/models/migrations/v1_22/v284.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_22 //nolint
+
+import (
+	"xorm.io/xorm"
+)
+
+func UpdateExternalLoginUserProvider(x *xorm.Engine) error {
+	type ExternalLoginUser struct {
+		Provider string `xorm:"index VARCHAR(255)"`
+	}
+
+	return x.Sync(new(ExternalLoginUser))
+}

--- a/models/user/external_login_user.go
+++ b/models/user/external_login_user.go
@@ -61,7 +61,7 @@ type ExternalLoginUser struct {
 	UserID            int64          `xorm:"INDEX NOT NULL"`
 	LoginSourceID     int64          `xorm:"pk NOT NULL"`
 	RawData           map[string]any `xorm:"TEXT JSON"`
-	Provider          string         `xorm:"index VARCHAR(25)"`
+	Provider          string         `xorm:"index VARCHAR(255)"`
 	Email             string
 	Name              string
 	FirstName         string

--- a/services/forms/auth_form.go
+++ b/services/forms/auth_form.go
@@ -16,7 +16,7 @@ import (
 type AuthenticationForm struct {
 	ID                            int64
 	Type                          int    `binding:"Range(2,7)"`
-	Name                          string `binding:"Required;MaxSize(30)"`
+	Name                          string `binding:"Required;MaxSize(255)"`
 	Host                          string
 	Port                          int
 	BindDN                        string


### PR DESCRIPTION
There are legit reasons why a Provider ("Authentication Name") can be longer than 25 characters, so lets increase that limit substantially to 255.

To do so, we need a migration too, and `AuthenticationForm` needs to have the maximum size of its `Name` field increased similarly.

Fixes #24891, at least for the Provider case.