### PR TITLE
Fix grammar issues on the repository Actions page (en-US)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3532,8 +3532,8 @@ runs.actors_no_select = All actors
 runs.status_no_select = All status
 runs.no_results = No results matched.
 runs.no_workflows = There are no workflows yet.
-runs.no_workflows.quick_start = Don't know how to start with Gitea Action? See <a target="_blank" rel="noopener noreferrer" href="%s">the quick start guide</a>.
-runs.no_workflows.documentation = For more information on the Gitea Action, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
+runs.no_workflows.quick_start = Don't know how to start with Gitea Actions? See <a target="_blank" rel="noopener noreferrer" href="%s">the quick start guide</a>.
+runs.no_workflows.documentation = For more information on Gitea Actions, see <a target="_blank" rel="noopener noreferrer" href="%s">the documentation</a>.
 runs.no_runs = The workflow has no runs yet.
 runs.empty_commit_message = (empty commit message)
 


### PR DESCRIPTION
Fixes a few grammar issues in the en-US localization of the repository Actions page.