### PR TITLE
Fix tooltip of variable edit button

### DIFF
--- a/templates/shared/variables/variable_list.tmpl
+++ b/templates/shared/variables/variable_list.tmpl
@@ -33,7 +33,7 @@
 					{{ctx.Locale.Tr "settings.added_on" (DateTime "short" .CreatedUnix) | Safe}}
 				</span>
 				<button class="btn interact-bg gt-p-3 show-modal"
-					data-tooltip-content="{{ctx.Locale.Tr "variables.edit"}}"
+					data-tooltip-content="{{ctx.Locale.Tr "actions.variables.edit"}}"
 					data-modal="#edit-variable-modal"
 					data-modal-form.action="{{$.Link}}/{{.ID}}/edit"
 					data-modal-header="{{ctx.Locale.Tr "actions.variables.edit"}}"


### PR DESCRIPTION
The `variables.edit` key does not exist.
![image](https://github.com/go-gitea/gitea/assets/29505620/462a1c6c-775c-466a-8398-37115b2af47a)
