### PR TITLE
Make cross-reference issue links work in markdown documents again

### DIFF
--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -852,11 +852,14 @@ func fullIssuePatternProcessor(ctx *RenderContext, node *html.Node) {
 }
 
 func issueIndexPatternProcessor(ctx *RenderContext, node *html.Node) {
-	// FIXME: the use of "mode" is quite dirty and hacky, for example: what is a "document"? how should it be rendered?
-	// The "mode" approach should be refactored to some other more clear&reliable way.
-	if ctx.Metas == nil || (ctx.Metas["mode"] == "document" && !ctx.IsWiki) {
+	if ctx.Metas == nil {
 		return
 	}
+
+	// FIXME: the use of "mode" is quite dirty and hacky, for example: what is a "document"? how should it be rendered?
+	// The "mode" approach should be refactored to some other more clear&reliable way.
+	crossLinkOnly := (ctx.Metas["mode"] == "document" && !ctx.IsWiki)
+
 	var (
 		found bool
 		ref   *references.RenderizableReference
@@ -870,7 +873,7 @@ func issueIndexPatternProcessor(ctx *RenderContext, node *html.Node) {
 		// Repos with external issue trackers might still need to reference local PRs
 		// We need to concern with the first one that shows up in the text, whichever it is
 		isNumericStyle := ctx.Metas["style"] == "" || ctx.Metas["style"] == IssueNameStyleNumeric
-		foundNumeric, refNumeric := references.FindRenderizableReferenceNumeric(node.Data, hasExtTrackFormat && !isNumericStyle)
+		foundNumeric, refNumeric := references.FindRenderizableReferenceNumeric(node.Data, hasExtTrackFormat && !isNumericStyle, crossLinkOnly)
 
 		switch ctx.Metas["style"] {
 		case "", IssueNameStyleNumeric:

--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -561,10 +561,15 @@ func TestPostProcess_RenderDocument(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(res.String()))
 	}
 
-	// Issue index shouldn't be post processing in an document.
+	// Issue index shouldn't be post processing in a document.
 	test(
 		"#1",
 		"#1")
+
+	// But cross-referenced issue index should work.
+	test(
+		"go-gitea/gitea#12345",
+		`<a href="`+util.URLJoin(markup.TestAppURL, "go-gitea", "gitea", "issues", "12345")+`" class="ref-issue">go-gitea/gitea#12345</a>`)
 
 	// Test that other post processing still works.
 	test(

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -331,8 +331,11 @@ func FindAllIssueReferences(content string) []IssueReference {
 }
 
 // FindRenderizableReferenceNumeric returns the first unvalidated reference found in a string.
-func FindRenderizableReferenceNumeric(content string, prOnly bool) (bool, *RenderizableReference) {
-	match := issueNumericPattern.FindStringSubmatchIndex(content)
+func FindRenderizableReferenceNumeric(content string, prOnly, crossLinkOnly bool) (bool, *RenderizableReference) {
+	var match []int
+	if !crossLinkOnly {
+		match = issueNumericPattern.FindStringSubmatchIndex(content)
+	}
 	if match == nil {
 		if match = crossReferenceIssueNumericPattern.FindStringSubmatchIndex(content); match == nil {
 			return false, nil


### PR DESCRIPTION
In #26365 issue references were disabled entirely for documents, intending to match GitHub behavior. However cross-references do appear to work in documents on GitHub.

This is useful for example to write release notes in a markdown document and reference issues. While the simpler syntax may create links when not intended, hopefully the cross-reference syntax is unique enough to avoid it.