### PR TITLE
Fix wrapping of label list

### DIFF
--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -35,6 +35,7 @@
 
 #issue-list .flex-item-title .labels-list {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.25em;
 }
 


### PR DESCRIPTION
Before:
![grafik](https://github.com/go-gitea/gitea/assets/47871822/2fbd7ef2-22ad-4515-9c66-81c29bfbb7a3)

After:
![grafik](https://github.com/go-gitea/gitea/assets/47871822/df86d1ae-03db-4543-834c-761859c367be)
