### PR TITLE
Apply min-height in wiki only on preview pane

### DIFF
--- a/web_src/css/repo/wiki.css
+++ b/web_src/css/repo/wiki.css
@@ -13,7 +13,10 @@
 
 .repository.wiki .markup {
   overflow: visible;
-  min-height: 340px;
+}
+
+.repository.wiki .markup[data-tab-panel="markdown-previewer"] {
+  min-height: 340px; /* This height matches the markdown editor's height */
 }
 
 .repository.wiki .wiki-content-parts .markup {


### PR DESCRIPTION
In the commit 5a56f9699c (3.) the min-height was applied to all wiki elements. This resulted in huge blank spaces when viewing the wiki.

This fixes this by only applying the min-height to the preview when editing.

Refs: https://codeberg.org/forgejo/forgejo/pulls/2080

(cherry picked from commit 8f0baefe5dadc929fe7456c36c8b205e96f228f0)
