### PR TITLE
Improve 404 screen on mobile

### DIFF
--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -1,8 +1,8 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content ui container center gt-w-screen {{if .IsRepo}}repository{{end}}">
+<div role="main" aria-label="{{.Title}}" class="page-content ui center gt-w-screen {{if .IsRepo}}repository{{end}}">
 	{{if .IsRepo}}{{template "repo/header" .}}{{end}}
 	<div class="ui container center">
-		<p style="margin-top: 100px"><img src="{{AssetUrlPrefix}}/img/404.png" alt="404"></p>
+		<p style="margin-top: 100px"><img src="{{AssetUrlPrefix}}/img/404.png" alt="404" style="max-width: 100%"></p>
 		<p>{{if .NotFoundPrompt}}{{.NotFoundPrompt}}{{else}}{{ctx.Locale.Tr "error404" | Safe}}{{end}}</p>
 		{{if .NotFoundGoBackURL}}<a class="ui button green" href="{{.NotFoundGoBackURL}}">{{ctx.Locale.Tr "go_back"}}</a>{{end}}
 


### PR DESCRIPTION
- Remove `container` to remove unnecessary margins being added to the whole page.
- Specify max width for the 404 image to avoid overflow of the image.

Refs: https://codeberg.org/forgejo/forgejo/pulls/2101

(cherry picked from commit 2235c227402c7b1b6e2d4c77215fa15d636f25c7)
