### PR TITLE
Fix incorrect URL for "Reference in New Issue"

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -4,6 +4,7 @@ import {showTemporaryTooltip, createTippy} from '../modules/tippy.js';
 import {hideElem, showElem, toggleElem} from '../utils/dom.js';
 import {setFileFolding} from './file-fold.js';
 import {getComboMarkdownEditor, initComboMarkdownEditor} from './comp/ComboMarkdownEditor.js';
+import {toAbsoluteUrl} from '../utils.js';
 
 const {appSubUrl, csrfToken} = window.config;
 
@@ -526,7 +527,7 @@ export function initRepoIssueReferenceIssue() {
     const $this = $(this);
     const content = $(`#${$this.data('target')}`).text();
     const poster = $this.data('poster-username');
-    const reference = $this.data('reference');
+    const reference = toAbsoluteUrl($this.data('reference'));
     const $modal = $($this.data('modal'));
     $modal.find('textarea[name="content"]').val(`${content}\n\n_Originally posted by @${poster} in ${reference}_`);
     $modal.modal('show');


### PR DESCRIPTION
Gitea prefers to use relative URLs in code (to make multiple domain work for some users)

So it needs to use `toAbsoluteUrl` to generate a full URL when click "Reference in New Issues"

And add some comments in the test code

For the main issue:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/7c085598-e227-4118-b51d-9237d8f70049)

</details>

For the issue comment:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/37d844d8-734b-4f87-92d9-109aa923c27e)


</details>
