### PR TITLE
Suggest to use Type=simple for systemd service

### DIFF
--- a/contrib/systemd/gitea.service
+++ b/contrib/systemd/gitea.service
@@ -52,7 +52,7 @@ After=network.target
 # Uncomment the next line if you have repos with lots of files and get a HTTP 500 error because of that
 # LimitNOFILE=524288:524288
 RestartSec=2s
-Type=notify
+Type=simple
 User=git
 Group=git
 WorkingDirectory=/var/lib/gitea/
@@ -62,7 +62,6 @@ WorkingDirectory=/var/lib/gitea/
 ExecStart=/usr/local/bin/gitea web --config /etc/gitea/app.ini
 Restart=always
 Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/var/lib/gitea
-WatchdogSec=30s
 # If you install Git to directory prefix other than default PATH (which happens
 # for example if you install other versions of Git side-to-side with
 # distribution version), uncomment below line and add that prefix to PATH

--- a/modules/graceful/manager_common.go
+++ b/modules/graceful/manager_common.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// FIXME: it seems that there is a bug when using systemd Type=notify: the "Install Page" (INSTALL_LOCK=false) doesn't notify properly.
+// At the moment, no idea whether it also affects Windows Service, or whether it's a regression bug. It needs to be investigated later.
+
 type systemdNotifyMsg string
 
 const (


### PR DESCRIPTION
Although the systemd notify support was added, it seems that there are some problems (#28553, for the "non-installed" instance)

At the moment, I didn't see real benefit of using Type=notify, nor I have enough time to fix or improve.

So I think it could just suggest users to use Type=simple, as the old behavior, to avoid confuse end users.