### PR TITLE
Move the captcha script loader to the template which really needs it

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -13,18 +13,6 @@
 
 	{{template "base/footer_content" .}}
 
-<!-- Third-party libraries -->
-{{if .EnableCaptcha}}
-	{{if eq .CaptchaType "recaptcha"}}
-		<script src='{{URLJoin .RecaptchaURL "api.js"}}'></script>
-	{{end}}
-	{{if eq .CaptchaType "hcaptcha"}}
-		<script src='https://hcaptcha.com/1/api.js'></script>
-	{{end}}
-	{{if eq .CaptchaType "cfturnstile"}}
-		<script src='https://challenges.cloudflare.com/turnstile/v0/api.js'></script>
-	{{end}}
-{{end}}
 	<script src="{{AssetUrlPrefix}}/js/index.js?v={{AssetVersion}}" onerror="alert('Failed to load asset files from ' + this.src + '. Please make sure the asset files can be accessed.')"></script>
 
 	{{template "custom/footer" .}}

--- a/templates/user/auth/captcha.tmpl
+++ b/templates/user/auth/captcha.tmpl
@@ -11,10 +11,12 @@
 	<div class="inline field required">
 		<div id="captcha" data-captcha-type="g-recaptcha" class="g-recaptcha-style" data-sitekey="{{.RecaptchaSitekey}}"></div>
 	</div>
+	<script src='{{URLJoin .RecaptchaURL "api.js"}}'></script>
 {{else if eq .CaptchaType "hcaptcha"}}
 	<div class="inline field required">
 		<div id="captcha" data-captcha-type="h-captcha" class="h-captcha-style" data-sitekey="{{.HcaptchaSitekey}}"></div>
 	</div>
+	<script src='https://hcaptcha.com/1/api.js'></script>
 {{else if eq .CaptchaType "mcaptcha"}}
 	<div class="inline field">
 		<label></label>
@@ -25,4 +27,5 @@
 	<div class="inline field gt-text-center">
 		<div id="captcha" data-captcha-type="cf-turnstile" data-sitekey="{{.CfTurnstileSitekey}}"></div>
 	</div>
+	<script src='https://challenges.cloudflare.com/turnstile/v0/api.js'></script>
 {{end}}{{end}}


### PR DESCRIPTION
It improves the maintainability for the templates.

Now `base/footer.tmpl` doesn't need to depend on "captcha" feature.