### PR TITLE
add/remove label on kanban column change

### DIFF
--- a/models/project/board.go
+++ b/models/project/board.go
@@ -55,6 +55,7 @@ type Board struct {
 	Default bool   `xorm:"NOT NULL DEFAULT false"` // issues not assigned to a specific board will be assigned to this board
 	Sorting int8   `xorm:"NOT NULL DEFAULT 0"`
 	Color   string `xorm:"VARCHAR(7)"`
+	LabelID int64  `xorm:"DEFAULT 0"`
 
 	ProjectID int64 `xorm:"INDEX NOT NULL"`
 	CreatorID int64 `xorm:"NOT NULL"`

--- a/models/project/issue.go
+++ b/models/project/issue.go
@@ -22,6 +22,9 @@ type ProjectIssue struct { //revive:disable-line:exported
 
 	// the sorting order on the board
 	Sorting int64 `xorm:"NOT NULL DEFAULT 0"`
+
+	// label that is added when a issue is moved to this column
+	LabelID int64 `xorm:"DEFAULT 0"`
 }
 
 func init() {

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -24,6 +24,7 @@ import (
 	"code.gitea.io/gitea/modules/web"
 	shared_user "code.gitea.io/gitea/routers/web/shared/user"
 	"code.gitea.io/gitea/services/forms"
+	issue_service "code.gitea.io/gitea/services/issue"
 )
 
 const (
@@ -545,6 +546,7 @@ func AddBoardToProjectPost(ctx *context.Context) {
 		ProjectID: project.ID,
 		Title:     form.Title,
 		Color:     form.Color,
+		LabelID:   form.LabelID,
 		CreatorID: ctx.Doer.ID,
 	}); err != nil {
 		ctx.ServerError("NewProjectBoard", err)
@@ -742,8 +744,25 @@ func MoveIssues(ctx *context.Context) {
 		}
 	}
 
+	fromColumnLabelID, err := strconv.ParseInt(ctx.FormString("fromColumnLabelID"), 10, 64)
+	if err != nil {
+		ctx.ServerError("fromColumnLableId is required", errors.New("fromColumnLableId is required"))
+		return
+	}
+
+	issueID, err := strconv.ParseInt(ctx.FormString("issueID"), 10, 64)
+	if err != nil {
+		ctx.ServerError("moved issueID is required", errors.New("moved issueID is required"))
+		return
+	}
+
 	if err = project_model.MoveIssuesOnProjectBoard(ctx, board, sortedIssueIDs); err != nil {
 		ctx.ServerError("MoveIssuesOnProjectBoard", err)
+		return
+	}
+
+	if err = issue_service.AddAndOrRemoveLabelFromIssue(ctx, issueID, fromColumnLabelID, board); err != nil {
+		ctx.ServerError("failed adding/removing label in addAndOrRemoveLabel", err)
 		return
 	}
 

--- a/routers/web/repo/issue_label.go
+++ b/routers/web/repo/issue_label.go
@@ -99,6 +99,17 @@ func RetrieveLabels(ctx *context.Context) {
 	ctx.Data["SortType"] = ctx.FormString("sort")
 }
 
+// RetrieveLabelsOrg clone of RetrieveLabels but without repo
+func RetrieveLabelsOrg(ctx *context.Context) {
+	orgLabels, err := issues_model.GetLabelsByOrgID(ctx, ctx.Org.Organization.ID, ctx.FormString("sort"), db.ListOptions{})
+	if err != nil {
+		ctx.ServerError("GetLabelsByOrgID", err)
+		return
+	}
+
+	ctx.Data["Labels"] = orgLabels
+}
+
 // NewLabel create new label for repository
 func NewLabel(ctx *context.Context) {
 	form := web.GetForm(ctx).(*forms.CreateLabelForm)

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"code.gitea.io/gitea/models/db"
@@ -25,6 +26,7 @@ import (
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/forms"
+	issue_service "code.gitea.io/gitea/services/issue"
 )
 
 const (
@@ -487,6 +489,7 @@ func AddBoardToProjectPost(ctx *context.Context) {
 		Title:     form.Title,
 		Color:     form.Color,
 		CreatorID: ctx.Doer.ID,
+		LabelID:   form.LabelID,
 	}); err != nil {
 		ctx.ServerError("NewProjectBoard", err)
 		return
@@ -691,8 +694,25 @@ func MoveIssues(ctx *context.Context) {
 		}
 	}
 
+	fromColumnLabelID, err := strconv.ParseInt(ctx.FormString("fromColumnLabelID"), 10, 64)
+	if err != nil {
+		ctx.ServerError("fromColumnLableId is required", errors.New("fromColumnLableId is required"))
+		return
+	}
+
+	issueID, err := strconv.ParseInt(ctx.FormString("issueID"), 10, 64)
+	if err != nil {
+		ctx.ServerError("moved issueID is required", errors.New("moved issueID is required"))
+		return
+	}
+
 	if err = project_model.MoveIssuesOnProjectBoard(ctx, board, sortedIssueIDs); err != nil {
 		ctx.ServerError("MoveIssuesOnProjectBoard", err)
+		return
+	}
+
+	if err = issue_service.AddAndOrRemoveLabelFromIssue(ctx, issueID, fromColumnLabelID, board); err != nil {
+		ctx.ServerError("failed adding/removing label in addAndOrRemoveLabel", err)
 		return
 	}
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -983,7 +983,7 @@ func registerRoutes(m *web.Route) {
 		m.Group("/projects", func() {
 			m.Group("", func() {
 				m.Get("", org.Projects)
-				m.Get("/{id}", org.ViewProject)
+				m.Get("/{id}", repo.RetrieveLabelsOrg, org.ViewProject)
 			}, reqUnitAccess(unit.TypeProjects, perm.AccessModeRead, true))
 			m.Group("", func() { //nolint:dupl
 				m.Get("/new", org.RenderNewProject)
@@ -1322,7 +1322,7 @@ func registerRoutes(m *web.Route) {
 
 		m.Group("/projects", func() {
 			m.Get("", repo.Projects)
-			m.Get("/{id}", repo.ViewProject)
+			m.Get("/{id}", repo.RetrieveLabels, repo.ViewProject)
 			m.Group("", func() { //nolint:dupl
 				m.Get("/new", repo.RenderNewProject)
 				m.Post("/new", web.Bind(forms.CreateProjectForm{}), repo.NewProjectPost)

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -531,6 +531,7 @@ type EditProjectBoardForm struct {
 	Title   string `binding:"Required;MaxSize(100)"`
 	Sorting int8
 	Color   string `binding:"MaxSize(7)"`
+	LabelID int64
 }
 
 //    _____  .__.__                   __

--- a/services/issue/project.go
+++ b/services/issue/project.go
@@ -12,8 +12,8 @@ import (
 )
 
 // AddAndOrRemoveLabelFromIssue updates issue label according to board LabelID
-func AddAndOrRemoveLabelFromIssue(ctx *context.Context, currentIssueId int64, fromColumnLabelID int64, board *project_model.Board) error {
-	issue, err := issues_model.GetIssueByID(ctx, currentIssueId)
+func AddAndOrRemoveLabelFromIssue(ctx *context.Context, currentIssueID, fromColumnLabelID int64, board *project_model.Board) error {
+	issue, err := issues_model.GetIssueByID(ctx, currentIssueID)
 	if err != nil {
 		return errors.New("failed getting issue")
 	}

--- a/services/issue/project.go
+++ b/services/issue/project.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"errors"
+
+	issues_model "code.gitea.io/gitea/models/issues"
+	project_model "code.gitea.io/gitea/models/project"
+	"code.gitea.io/gitea/modules/context"
+)
+
+// AddAndOrRemoveLabelFromIssue updates issue label according to board LabelID
+func AddAndOrRemoveLabelFromIssue(ctx *context.Context, currentIssueId int64, fromColumnLabelID int64, board *project_model.Board) error {
+	issue, err := issues_model.GetIssueByID(ctx, currentIssueId)
+	if err != nil {
+		return errors.New("failed getting issue")
+	}
+	var addedLabel *issues_model.Label
+	if board.LabelID != 0 {
+		addedLabel, err = issues_model.GetLabelByID(ctx, board.LabelID)
+		if err != nil {
+			return errors.New("failed getting add label")
+		}
+	}
+	var removedLabel *issues_model.Label
+	if fromColumnLabelID != 0 {
+
+		removedLabel, err = issues_model.GetLabelByID(ctx, fromColumnLabelID)
+		if err != nil {
+			return errors.New("failed getting remove label")
+		}
+	}
+
+	// Delete old label from current issue
+	if fromColumnLabelID != 0 {
+		if err := RemoveLabel(ctx, issue, ctx.Doer, removedLabel); err != nil {
+			return err
+		}
+	}
+
+	// Add New Label to current issue
+	if board.LabelID != 0 {
+		if err := AddLabel(ctx, issue, ctx.Doer, addedLabel); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -1,67 +1,91 @@
 {{$canWriteProject := and .CanWriteProjects (or (not .Repository) (not .Repository.IsArchived))}}
 
-<div class="ui container">
-	<div class="gt-df gt-sb gt-ac gt-mb-4">
-		<h2 class="gt-mb-0">{{.Project.Title}}</h2>
-		{{if $canWriteProject}}
-			<div class="ui compact mini menu">
-				<a class="item" href="{{.Link}}/edit?redirect=project">
-					{{svg "octicon-pencil"}}
-					{{ctx.Locale.Tr "repo.issues.label_edit"}}
-				</a>
-				{{if .Project.IsClosed}}
-					<button class="item btn link-action" data-url="{{.Link}}/open">
-						{{svg "octicon-check"}}
-						{{ctx.Locale.Tr "repo.projects.open"}}
-					</button>
-				{{else}}
-					<button class="item btn link-action" data-url="{{.Link}}/close">
-						{{svg "octicon-skip"}}
-						{{ctx.Locale.Tr "repo.projects.close"}}
-					</button>
-				{{end}}
-				<button class="item btn delete-button" data-url="{{.Link}}/delete" data-id="{{.Project.ID}}">
-					{{svg "octicon-trash"}}
-					{{ctx.Locale.Tr "repo.issues.label_delete"}}
+<div class="gt-df gt-sb gt-ac gt-mb-4">
+	<h2 class="gt-mb-0">{{.Project.Title}}</h2>
+	{{if $canWriteProject}}
+		<div class="ui compact mini menu">
+			<a class="item" href="{{.Link}}/edit?redirect=project">
+				{{svg "octicon-pencil"}}
+				{{ctx.Locale.Tr "repo.issues.label_edit"}}
+			</a>
+			{{if .Project.IsClosed}}
+				<button class="item btn link-action" data-url="{{.Link}}/open">
+					{{svg "octicon-check"}}
+					{{ctx.Locale.Tr "repo.projects.open"}}
 				</button>
-				<button class="item btn show-modal" data-modal="#new-project-column-item">
-					{{svg "octicon-plus"}}
-					{{ctx.Locale.Tr "new_project_column"}}
+			{{else}}
+				<button class="item btn link-action" data-url="{{.Link}}/close">
+					{{svg "octicon-skip"}}
+					{{ctx.Locale.Tr "repo.projects.close"}}
 				</button>
+			{{end}}
+			<button class="item btn delete-button" data-url="{{.Link}}/delete" data-id="{{.Project.ID}}">
+				{{svg "octicon-trash"}}
+				{{ctx.Locale.Tr "repo.issues.label_delete"}}
+			</button>
+			<button class="item btn show-modal" data-modal="#new-project-column-item">
+				{{svg "octicon-plus"}}
+				{{ctx.Locale.Tr "new_project_column"}}
+			</button>
+		</div>
+		<div class="ui small modal new-project-column-modal" id="new-project-column-item">
+			<div class="header">
+				{{ctx.Locale.Tr "repo.projects.column.new"}}
 			</div>
-			<div class="ui small modal new-project-column-modal" id="new-project-column-item">
-				<div class="header">
-					{{ctx.Locale.Tr "repo.projects.column.new"}}
-				</div>
-				<div class="content">
-					<form class="ui form">
-						<div class="required field">
-							<label for="new_project_column">{{ctx.Locale.Tr "repo.projects.column.new_title"}}</label>
-							<input class="new-project-column" id="new_project_column" name="title" required>
-						</div>
+			<div class="content">
+				<form class="ui form">
+					<div class="required field">
+						<label for="new_project_column">{{ctx.Locale.Tr "repo.projects.column.new_title"}}</label>
+						<input class="new-project-column" id="new_project_column" name="title" required>
+					</div>
 
-						<div class="field color-field">
-							<label for="new_project_column_color">{{ctx.Locale.Tr "repo.projects.column.color"}}</label>
-							<div class="color picker column">
-								<input class="color-picker" maxlength="7" placeholder="#c320f6" id="new_project_column_color_picker" name="color">
-								{{template "repo/issue/label_precolors"}}
+					<div class="field color-field">
+						<label for="new_project_column_color">{{ctx.Locale.Tr "repo.projects.column.color"}}</label>
+						<div class="color picker column">
+							<input class="color-picker" maxlength="7" placeholder="#c320f6" id="new_project_column_color_picker" name="color">
+							{{template "repo/issue/label_precolors"}}
+						</div>
+					</div>
+
+					{{if .Labels }}
+					<!-- Label -->
+						<div class="ui dropdown jump item label-filter" >
+							<span class="text">
+								Choose label
+								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+							</span>
+							<div class="menu" style="max-height:300px;overflow-y: scroll;">
+								<div class="ui icon search input">
+									<i class="icon gt-df gt-ac gt-jc">{{svg "octicon-search" 16}}</i>
+									<input type="text" id="new_project_column_label" name="label" placeholder="{{.locale.Tr "repo.issues.filter_label"}}">
+								</div>
+								{{$previousExclusiveScope := "_no_scope"}}
+								{{range .Labels}}
+									{{$exclusiveScope := .ExclusiveScope}}
+									{{if and (ne $previousExclusiveScope $exclusiveScope)}}
+										<div class="divider"></div>
+									{{end}}
+									{{$previousExclusiveScope = $exclusiveScope}}
+									<div class="item label-filter-item labels-for-project-creation" data-label-id="{{.ID}}" >{{RenderLabel $.Context .}}</div>
+								{{end}}
 							</div>
 						</div>
-
-						<div class="text right actions">
-							<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
-							<button data-url="{{$.Link}}" class="ui primary button" id="new_project_column_submit">{{ctx.Locale.Tr "repo.projects.column.new_submit"}}</button>
-						</div>
-					</form>
-				</div>
+							<input name="label" id="new_project_column_project_label" class="gt-mb-4">
+							<input name="labelId" id="new_project_column_project_label_id" type="number" style="display: none;">
+					{{end}}
+					<div class="text right actions">
+						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+						<button data-url="{{$.Link}}" class="ui primary button" id="new_project_column_submit">{{ctx.Locale.Tr "repo.projects.column.new_submit"}}</button>
+					</div>
+				</form>
 			</div>
-		{{end}}
-	</div>
-
-	<div class="content">{{$.Project.RenderedContent|Str2html}}</div>
-
-	<div class="divider"></div>
+		</div>
+	{{end}}
 </div>
+
+<div class="content">{{$.Project.RenderedContent|Str2html}}</div>
+
+<div class="divider"></div>
 
 <div id="project-board">
 	<div class="board {{if .CanWriteProjects}}sortable{{end}}">
@@ -165,9 +189,10 @@
 
 				<div class="divider"></div>
 
+				{{- $currentColumnLabelID := .LabelID }}
 				<div class="ui cards {{if and $canWriteProject (ne .ID 0)}}{{/* ID 0 is default column which cannot be moved */}}gt-cursor-grab{{end}}" data-url="{{$.Link}}/{{.ID}}" data-project="{{$.Project.ID}}" data-board="{{.ID}}" id="board_{{.ID}}">
 					{{range (index $.IssuesMap .ID)}}
-						<div class="issue-card gt-word-break {{if $canWriteProject}}gt-cursor-grab{{end}}" data-issue="{{.ID}}">
+						<div class="issue-card gt-word-break {{if $canWriteProject}}gt-cursor-grab{{end}}" data-issue="{{.ID}}" data-column-label-id="{{$currentColumnLabelID}}">
 							{{template "repo/issue/card" (dict "Issue" . "Page" $)}}
 						</div>
 					{{end}}

--- a/web_src/js/features/project-label.js
+++ b/web_src/js/features/project-label.js
@@ -1,0 +1,16 @@
+export function initNewProjectFormLabel() {
+  if (!document.querySelectorAll('#new-project-column-item form input#new_project_column_project_label').length) return;
+
+  const labels = document.querySelectorAll('.labels-for-project-creation');
+  const selectedLabel = document.querySelector('input#new_project_column_project_label');
+  const selectedLabelId = document.querySelector('input#new_project_column_project_label_id');
+
+  if (!labels || !selectedLabel || !selectedLabelId) return;
+
+  for (const l of labels) {
+    l.addEventListener('click', () => {
+      selectedLabel.value = l.textContent;
+      selectedLabelId.value = l.dataset.labelId;
+    });
+  }
+}

--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -11,10 +11,10 @@ function updateIssueCount(cards) {
   parent.getElementsByClassName('project-column-issue-count')[0].textContent = cnt;
 }
 
-function createNewColumn(url, columnTitle, projectColorInput) {
+function createNewColumn(url, columnTitle, projectColorInput, labelId) {
   $.ajax({
     url,
-    data: JSON.stringify({title: columnTitle.val(), color: projectColorInput.val()}),
+    data: JSON.stringify({title: columnTitle.val(), color: projectColorInput.val(), labelId: parseInt(labelId.val())}),
     headers: {
       'X-Csrf-Token': csrfToken,
     },
@@ -39,7 +39,7 @@ function moveIssue({item, from, to, oldIndex}) {
   };
 
   $.ajax({
-    url: `${to.getAttribute('data-url')}/move`,
+    url: `${to.getAttribute('data-url')}/move?fromColumnLabelID=${item.getAttribute('data-column-label-id')}&issueID=${item.getAttribute('data-issue')}`,
     data: JSON.stringify(columnSorting),
     headers: {
       'X-Csrf-Token': csrfToken,
@@ -187,11 +187,12 @@ export function initRepoProject() {
     e.preventDefault();
     const columnTitle = $('#new_project_column');
     const projectColorInput = $('#new_project_column_color_picker');
+    const labelId = $('#new_project_column_project_label_id');
     if (!columnTitle.val()) {
       return;
     }
     const url = $(this).data('url');
-    createNewColumn(url, columnTitle, projectColorInput);
+    createNewColumn(url, columnTitle, projectColorInput, labelId);
   });
 }
 

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -85,6 +85,7 @@ import {initRepoIssueList} from './features/repo-issue-list.js';
 import {initCommonIssueListQuickGoto} from './features/common-issue-list.js';
 import {initRepoDiffCommitBranchesAndTags} from './features/repo-diff-commit.js';
 import {initDirAuto} from './modules/dirauto.js';
+import {initNewProjectFormLabel} from './features/project-label.js';
 
 // Init Gitea's Fomantic settings
 initGiteaFomantic();
@@ -184,4 +185,6 @@ onDomReady(() => {
   initRepoDiffView();
   initPdfViewer();
   initScopedAccessTokenCategories();
+
+  initNewProjectFormLabel();
 });


### PR DESCRIPTION
add/remove label on kanban column change

the idea is each column in a kanban can have a labelId  attached to it
and everytime an issue is moved to a new column that label is added to the issue(and the other label attached is removed)
this does not  affect other labels that may be present in the issue

resolves https://github.com/go-gitea/gitea/issues/26704

[this is the idea](https://github.com/go-gitea/gitea/assets/20443971/f7a6f625-40a5-40de-b879-fed73d8a9cfe)



---
*PR sponsored by [Obmondo.com](https://obmondo.com)*



