### PR TITLE
Require token for GET subscription endpoint

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1156,9 +1156,9 @@ func Routes() *web.Route {
 				m.Get("/subscribers", repo.ListSubscribers)
 				m.Group("/subscription", func() {
 					m.Get("", user.IsWatching)
-					m.Put("", reqToken(), user.Watch)
-					m.Delete("", reqToken(), user.Unwatch)
-				})
+					m.Put("", user.Watch)
+					m.Delete("", user.Unwatch)
+				}, reqToken())
 				m.Group("/releases", func() {
 					m.Combo("").Get(repo.ListReleases).
 						Post(reqToken(), reqRepoWriter(unit.TypeReleases), context.ReferencesGitRepo(), bind(api.CreateReleaseOption{}), repo.CreateRelease)


### PR DESCRIPTION
Fixes  #28756

## Changes
- Require and check API token for `GET /repos/{owner}/{repo}/subscription` in order to populate `ctx.Doer`.
