### PR TITLE
Warn that `DISABLE_QUERY_AUTH_TOKEN` is false only if it's explicitly defined

### DIFF
--- a/modules/setting/security.go
+++ b/modules/setting/security.go
@@ -159,10 +159,13 @@ func loadSecurityFrom(rootCfg ConfigProvider) {
 		}
 	}
 
+	sectionHasDisableQueryAuthToken := sec.HasKey("DISABLE_QUERY_AUTH_TOKEN")
+
 	// TODO: default value should be true in future releases
 	DisableQueryAuthToken = sec.Key("DISABLE_QUERY_AUTH_TOKEN").MustBool(false)
 
-	if !DisableQueryAuthToken {
+	// warn if the setting is set to false explicitly
+	if sectionHasDisableQueryAuthToken && !DisableQueryAuthToken {
 		log.Warn("Enabling Query API Auth tokens is not recommended. DISABLE_QUERY_AUTH_TOKEN will default to true in gitea 1.23 and will be removed in gitea 1.24.")
 	}
 }


### PR DESCRIPTION
So we don't warn on default behavior

- Fixes https://github.com/go-gitea/gitea/issues/28758
- Follows https://github.com/go-gitea/gitea/pull/28390