### PR TITLE
Use correct `has error` check for internal responses

### DIFF
--- a/modules/private/actions.go
+++ b/modules/private/actions.go
@@ -22,7 +22,7 @@ func GenerateActionsRunnerToken(ctx context.Context, scope string) (string, Resp
 	})
 
 	resp, extra := requestJSONResp(req, &responseText{})
-	if resp == nil {
+	if extra.HasError() {
 		return "", extra
 	}
 	return resp.Text, extra

--- a/modules/private/key.go
+++ b/modules/private/key.go
@@ -27,7 +27,7 @@ func AuthorizedPublicKeyByContent(ctx context.Context, content string) (string, 
 	req := newInternalRequest(ctx, reqURL, "POST")
 	req.Param("content", content)
 	resp, extra := requestJSONResp(req, &responseText{})
-	if resp == nil {
+	if extra.HasError() {
 		return "", extra
 	}
 	return resp.Text, extra

--- a/modules/private/mail.go
+++ b/modules/private/mail.go
@@ -30,7 +30,7 @@ func SendEmail(ctx context.Context, subject, message string, to []string) (strin
 	})
 
 	resp, extra := requestJSONResp(req, &responseText{})
-	if resp == nil {
+	if extra.HasError() {
 		return "", extra
 	}
 	return resp.Text, extra

--- a/modules/private/request.go
+++ b/modules/private/request.go
@@ -47,6 +47,7 @@ func (re responseError) Error() string {
 // requestJSONResp sends a request to the gitea server and then parses the response.
 // If the status code is not 2xx, or any error occurs, the ResponseExtra.Error field is guaranteed to be non-nil,
 // and the ResponseExtra.UserMsg field will be set to a message for the end user.
+// Caller should check the ResponseExtra.HasError() first to see whether the request fails.
 //
 // * If the "res" is a struct pointer, the response will be parsed as JSON
 // * If the "res" is responseText pointer, the response will be stored as text in it


### PR DESCRIPTION
`resp != nil`  doesn't mean the request really succeeded. Add a comment for requestJSONResp to clarify the behavior.