### PR TITLE
Use refname:strip-2 instead of refname:short when syncing tags

### DIFF
--- a/modules/git/foreachref/format_test.go
+++ b/modules/git/foreachref/format_test.go
@@ -49,9 +49,9 @@ func TestFormat_Flag(t *testing.T) {
 		{
 			name: "multiple fields",
 
-			givenFormat: foreachref.NewFormat("refname:lstrip-2", "objecttype", "objectname"),
+			givenFormat: foreachref.NewFormat("refname:lstrip=2", "objecttype", "objectname"),
 
-			wantFlag: "refname:lstrip-2 %(refname:lstrip-2)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
+			wantFlag: "refname:lstrip=2 %(refname:lstrip=2)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
 		},
 	}
 

--- a/modules/git/foreachref/format_test.go
+++ b/modules/git/foreachref/format_test.go
@@ -49,9 +49,9 @@ func TestFormat_Flag(t *testing.T) {
 		{
 			name: "multiple fields",
 
-			givenFormat: foreachref.NewFormat("refname:short", "objecttype", "objectname"),
+			givenFormat: foreachref.NewFormat("refname:lstrip-2", "objecttype", "objectname"),
 
-			wantFlag: "refname:short %(refname:short)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
+			wantFlag: "refname:lstrip-2 %(refname:short)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
 		},
 	}
 

--- a/modules/git/foreachref/format_test.go
+++ b/modules/git/foreachref/format_test.go
@@ -51,7 +51,7 @@ func TestFormat_Flag(t *testing.T) {
 
 			givenFormat: foreachref.NewFormat("refname:lstrip-2", "objecttype", "objectname"),
 
-			wantFlag: "refname:lstrip-2 %(refname:short)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
+			wantFlag: "refname:lstrip-2 %(refname:lstrip-2)%00objecttype %(objecttype)%00objectname %(objectname)%00%00",
 		},
 	}
 

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -112,7 +112,7 @@ func (repo *Repository) GetTagWithID(idStr, name string) (*Tag, error) {
 
 // GetTagInfos returns all tag infos of the repository.
 func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
-	forEachRefFmt := foreachref.NewFormat("objecttype", "refname:short", "object", "objectname", "creator", "contents", "contents:signature")
+	forEachRefFmt := foreachref.NewFormat("objecttype", "refname:strip=2", "object", "objectname", "creator", "contents", "contents:signature")
 
 	stdoutReader, stdoutWriter := io.Pipe()
 	defer stdoutReader.Close()

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -112,6 +112,8 @@ func (repo *Repository) GetTagWithID(idStr, name string) (*Tag, error) {
 
 // GetTagInfos returns all tag infos of the repository.
 func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
+	// Generally, refname:short should be equal to refname:lstrip=2 except core.warnAmbiguousRefs is used to select the strict abbreviation mode.
+	// https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-refname
 	forEachRefFmt := foreachref.NewFormat("objecttype", "refname:lstrip=2", "object", "objectname", "creator", "contents", "contents:signature")
 
 	stdoutReader, stdoutWriter := io.Pipe()

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -164,7 +164,7 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 func parseTagRef(objectFormat ObjectFormat, ref map[string]string) (tag *Tag, err error) {
 	tag = &Tag{
 		Type: ref["objecttype"],
-		Name: ref["refname:lstrip-2"],
+		Name: ref["refname:lstrip=2"],
 	}
 
 	tag.ID, err = NewIDFromString(ref["objectname"])

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -164,7 +164,7 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 func parseTagRef(objectFormat ObjectFormat, ref map[string]string) (tag *Tag, err error) {
 	tag = &Tag{
 		Type: ref["objecttype"],
-		Name: ref["refname:lstrip=2"],
+		Name: ref["refname:lstrip-2"],
 	}
 
 	tag.ID, err = NewIDFromString(ref["objectname"])

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -112,7 +112,7 @@ func (repo *Repository) GetTagWithID(idStr, name string) (*Tag, error) {
 
 // GetTagInfos returns all tag infos of the repository.
 func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
-	forEachRefFmt := foreachref.NewFormat("objecttype", "refname:strip=2", "object", "objectname", "creator", "contents", "contents:signature")
+	forEachRefFmt := foreachref.NewFormat("objecttype", "refname:lstrip=2", "object", "objectname", "creator", "contents", "contents:signature")
 
 	stdoutReader, stdoutWriter := io.Pipe()
 	defer stdoutReader.Close()
@@ -139,7 +139,7 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 			break
 		}
 
-		tag, err := parseTagRef(repo.objectFormat, ref)
+		tag, err := parseTagRef(repo.objectFormat, ref, "refname:lstrip=2")
 		if err != nil {
 			return nil, 0, fmt.Errorf("GetTagInfos: parse tag: %w", err)
 		}
@@ -159,10 +159,10 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 }
 
 // parseTagRef parses a tag from a 'git for-each-ref'-produced reference.
-func parseTagRef(objectFormat ObjectFormat, ref map[string]string) (tag *Tag, err error) {
+func parseTagRef(objectFormat ObjectFormat, ref map[string]string, tagNameKey string) (tag *Tag, err error) {
 	tag = &Tag{
 		Type: ref["objecttype"],
-		Name: ref["refname:short"],
+		Name: ref[tagNameKey],
 	}
 
 	tag.ID, err = NewIDFromString(ref["objectname"])

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -141,7 +141,7 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 			break
 		}
 
-		tag, err := parseTagRef(repo.objectFormat, ref, "refname:lstrip=2")
+		tag, err := parseTagRef(repo.objectFormat, ref)
 		if err != nil {
 			return nil, 0, fmt.Errorf("GetTagInfos: parse tag: %w", err)
 		}
@@ -161,10 +161,10 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 }
 
 // parseTagRef parses a tag from a 'git for-each-ref'-produced reference.
-func parseTagRef(objectFormat ObjectFormat, ref map[string]string, tagNameKey string) (tag *Tag, err error) {
+func parseTagRef(objectFormat ObjectFormat, ref map[string]string) (tag *Tag, err error) {
 	tag = &Tag{
 		Type: ref["objecttype"],
-		Name: ref[tagNameKey],
+		Name: ref["refname:lstrip=2"],
 	}
 
 	tag.ID, err = NewIDFromString(ref["objectname"])

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -351,7 +351,7 @@ Add changelog of v1.9.1 (#7859)
 	for _, test := range tests {
 		tc := test // don't close over loop variable
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseTagRef(sha1, tc.givenRef)
+			got, err := parseTagRef(sha1, tc.givenRef, "refname:short")
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -208,8 +208,8 @@ func TestRepository_parseTagRef(t *testing.T) {
 			name: "lightweight tag",
 
 			givenRef: map[string]string{
-				"objecttype":    "commit",
-				"refname:short": "v1.9.1",
+				"objecttype":       "commit",
+				"refname:lstrip-2": "v1.9.1",
 				// object will be empty for lightweight tags
 				"object":     "",
 				"objectname": "ab23e4b7f4cd0caafe0174c0e7ef6d651ba72889",
@@ -237,8 +237,8 @@ func TestRepository_parseTagRef(t *testing.T) {
 			name: "annotated tag",
 
 			givenRef: map[string]string{
-				"objecttype":    "tag",
-				"refname:short": "v0.0.1",
+				"objecttype":       "tag",
+				"refname:lstrip-2": "v0.0.1",
 				// object will refer to commit hash for annotated tag
 				"object":     "3325fd8a973321fd59455492976c042dde3fd1ca",
 				"objectname": "8c68a1f06fc59c655b7e3905b159d761e91c53c9",
@@ -266,11 +266,11 @@ func TestRepository_parseTagRef(t *testing.T) {
 			name: "annotated tag with signature",
 
 			givenRef: map[string]string{
-				"objecttype":    "tag",
-				"refname:short": "v0.0.1",
-				"object":        "3325fd8a973321fd59455492976c042dde3fd1ca",
-				"objectname":    "8c68a1f06fc59c655b7e3905b159d761e91c53c9",
-				"creator":       "Foo Bar <foo@bar.com> 1565789218 +0300",
+				"objecttype":       "tag",
+				"refname:lstrip-2": "v0.0.1",
+				"object":           "3325fd8a973321fd59455492976c042dde3fd1ca",
+				"objectname":       "8c68a1f06fc59c655b7e3905b159d761e91c53c9",
+				"creator":          "Foo Bar <foo@bar.com> 1565789218 +0300",
 				"contents": `Add changelog of v1.9.1 (#7859)
 
 * add changelog of v1.9.1
@@ -351,7 +351,7 @@ Add changelog of v1.9.1 (#7859)
 	for _, test := range tests {
 		tc := test // don't close over loop variable
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseTagRef(sha1, tc.givenRef, "refname:short")
+			got, err := parseTagRef(sha1, tc.givenRef)
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -209,7 +209,7 @@ func TestRepository_parseTagRef(t *testing.T) {
 
 			givenRef: map[string]string{
 				"objecttype":       "commit",
-				"refname:lstrip-2": "v1.9.1",
+				"refname:lstrip=2": "v1.9.1",
 				// object will be empty for lightweight tags
 				"object":     "",
 				"objectname": "ab23e4b7f4cd0caafe0174c0e7ef6d651ba72889",
@@ -238,7 +238,7 @@ func TestRepository_parseTagRef(t *testing.T) {
 
 			givenRef: map[string]string{
 				"objecttype":       "tag",
-				"refname:lstrip-2": "v0.0.1",
+				"refname:lstrip=2": "v0.0.1",
 				// object will refer to commit hash for annotated tag
 				"object":     "3325fd8a973321fd59455492976c042dde3fd1ca",
 				"objectname": "8c68a1f06fc59c655b7e3905b159d761e91c53c9",
@@ -267,7 +267,7 @@ func TestRepository_parseTagRef(t *testing.T) {
 
 			givenRef: map[string]string{
 				"objecttype":       "tag",
-				"refname:lstrip-2": "v0.0.1",
+				"refname:lstrip=2": "v0.0.1",
 				"object":           "3325fd8a973321fd59455492976c042dde3fd1ca",
 				"objectname":       "8c68a1f06fc59c655b7e3905b159d761e91c53c9",
 				"creator":          "Foo Bar <foo@bar.com> 1565789218 +0300",


### PR DESCRIPTION
Fix #28694 

Generally, `refname:short` should be equal to `refname:lstrip=2` except `core.warnAmbiguousRefs is used to select the strict abbreviation mode.`

ref: https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-refname