### PR TITLE
Add gist to comparison

### DIFF
--- a/docs/content/installation/comparison.en-us.md
+++ b/docs/content/installation/comparison.en-us.md
@@ -52,6 +52,7 @@ _Symbols used in table:_
 | Markdown support                                 | ✓                                                   | ✓    | ✓         | ✓         | ✓         | ✓         | ✓            | ✓            |
 | CSV support                                      | ✓                                                   | ✘    | ✓         | ✘         | ✘         | ✓         | ✘            | ✘            |
 | 'GitHub / GitLab pages'                          | [⚙️][gitea-pages-server], [⚙️][gitea-caddy-plugin]    | ✘    | ✓         | ✓         | ✓         | ✘         | ✘            | ✘            |
+| Gists / Snippets                                 | [⚙️][opengist]                                      | ✘    | ✓         | ✓         | ✓         | ✓         | ✓            | ✓            |
 | Repo-specific wiki (as a repo itself)            | ✓                                                   | ✓    | ✓         | ✓         | ✓         | /         | ✘            | ✘            |
 | Deploy Tokens                                    | ✓                                                   | ✓    | ✓         | ✓         | ✓         | ✓         | ✓            | ✓            |
 | Repository Tokens with write rights              | ✓                                                   | ✘    | ✓         | ✓         | ✓         | ✓         | ✓            | ✓            |
@@ -147,3 +148,4 @@ _Symbols used in table:_
 
 [gitea-caddy-plugin]: https://github.com/42wim/caddy-gitea
 [gitea-pages-server]: https://codeberg.org/Codeberg/pages-server
+[opengist]: https://github.com/thomiceli/opengist


### PR DESCRIPTION
This PR adds a section to the documentation that links to the project [Opengist](https://github.com/thomiceli/opengist) on GitHub.

The feature was proposed in #16670 but didn't resonate well with the maintainers.