### PR TITLE
Remove trust model selection from repository creation on web page because it can be changed in settings later

### DIFF
--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -288,7 +288,7 @@ func CreatePost(ctx *context.Context) {
 			DefaultBranch:    form.DefaultBranch,
 			AutoInit:         form.AutoInit,
 			IsTemplate:       form.Template,
-			TrustModel:       repo_model.ToTrustModel(form.TrustModel),
+			TrustModel:       repo_model.DefaultTrustModel,
 			ObjectFormatName: form.ObjectFormatName,
 		})
 		if err == nil {

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -21,13 +21,6 @@ import (
 	"gitea.com/go-chi/binding"
 )
 
-// _______________________________________    _________.______________________ _______________.___.
-// \______   \_   _____/\______   \_____  \  /   _____/|   \__    ___/\_____  \\______   \__  |   |
-//  |       _/|    __)_  |     ___//   |   \ \_____  \ |   | |    |    /   |   \|       _//   |   |
-//  |    |   \|        \ |    |   /    |    \/        \|   | |    |   /    |    \    |   \\____   |
-//  |____|_  /_______  / |____|   \_______  /_______  /|___| |____|   \_______  /____|_  // ______|
-//         \/        \/                   \/        \/                        \/       \/ \/
-
 // CreateRepoForm form for creating repository
 type CreateRepoForm struct {
 	UID           int64  `binding:"Required"`
@@ -50,7 +43,6 @@ type CreateRepoForm struct {
 	Avatar          bool
 	Labels          bool
 	ProtectedBranch bool
-	TrustModel      string
 
 	ForkSingleBranch string
 	ObjectFormatName string

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -186,29 +186,6 @@
 							<span class="help">{{ctx.Locale.Tr "repo.default_branch_helper"}}</span>
 						</div>
 						<div class="inline field">
-							<label>{{ctx.Locale.Tr "repo.settings.trust_model"}}</label>
-							<div class="ui selection owner dropdown">
-								<input type="hidden" id="trust_model" name="trust_model" value="default" required>
-								<div class="default text">{{ctx.Locale.Tr "repo.settings.trust_model"}}</div>
-								{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-								<div class="menu">
-									<div class="item" data-value="default">{{ctx.Locale.Tr "repo.settings.trust_model.default"}}</div>
-									<div class="item" data-value="collaborator">{{ctx.Locale.Tr "repo.settings.trust_model.collaborator"}}</div>
-									<div class="item" data-value="committer">{{ctx.Locale.Tr "repo.settings.trust_model.committer"}}</div>
-									<div class="item" data-value="collaboratorcommitter">{{ctx.Locale.Tr "repo.settings.trust_model.collaboratorcommitter"}}</div>
-								</div>
-							</div>
-							<div class="help">
-								{{ctx.Locale.Tr "repo.trust_model_helper"}}
-								<ul>
-									<li>{{ctx.Locale.Tr "repo.trust_model_helper_collaborator"}}</li>
-									<li>{{ctx.Locale.Tr "repo.trust_model_helper_committer"}}</li>
-									<li>{{ctx.Locale.Tr "repo.trust_model_helper_collaborator_committer"}}</li>
-									<li>{{ctx.Locale.Tr "repo.trust_model_helper_default"}}</li>
-								</ul>
-							</div>
-						</div>
-						<div class="inline field">
 							<label>{{ctx.Locale.Tr "repo.template"}}</label>
 							<div class="ui checkbox">
 								<input name="template" type="checkbox">
@@ -216,7 +193,6 @@
 							</div>
 						</div>
 					</div>
-
 					<br>
 					<div class="inline field">
 						<label></label>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -61,7 +61,7 @@
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
 						<label for="description">{{ctx.Locale.Tr "repo.repo_desc"}}</label>
-						<textarea id="description" name="description" placeholder="{{ctx.Locale.Tr "repo.repo_desc_helper"}}" maxlength="2048">{{.description}}</textarea>
+						<textarea id="description" rows="2" name="description" placeholder="{{ctx.Locale.Tr "repo.repo_desc_helper"}}" maxlength="2048">{{.description}}</textarea>
 					</div>
 					<div class="inline field">
 						<label>{{ctx.Locale.Tr "repo.template"}}</label>


### PR DESCRIPTION
As more and more options can be set for creating the repository, I don't think we should put all of them into the creation web page which will make things look complicated and confusing.

And I think we need some rules about how to decide which should/should not be put in creating a repository page. One rule I can imagine is if this option can be changed later and it's not a MUST on the creation, then it can be removed on the page. So I found trust model is the first one.

This PR removed the trust model selections on creating a repository web page and kept others as before.
This is also a preparation for #23894 which will add a choice about SHA1 or SHA256 that cannot be changed once the repository created.