### PR TITLE
Render code block in activity tab

### DIFF
--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -126,7 +126,7 @@
 						<span class="ui green label">{{ctx.Locale.Tr "repo.activity.published_release_label"}}</span>
 						{{.TagName}}
 						{{if not .IsTag}}
-							<a class="title" href="{{$.RepoLink}}/src/{{.TagName | PathEscapeSegments}}">{{.Title | RenderEmoji $.Context}}</a>
+							<a class="title" href="{{$.RepoLink}}/src/{{.TagName | PathEscapeSegments}}">{{.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{end}}
 						{{TimeSinceUnix .CreatedUnix ctx.Locale}}
 					</p>
@@ -146,7 +146,7 @@
 				{{range .Activity.MergedPRs}}
 					<p class="desc">
 						<span class="ui purple label">{{ctx.Locale.Tr "repo.activity.merged_prs_label"}}</span>
-						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji $.Context}}</a>
+						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{TimeSinceUnix .MergedUnix ctx.Locale}}
 					</p>
 				{{end}}
@@ -165,7 +165,7 @@
 				{{range .Activity.OpenedPRs}}
 					<p class="desc">
 						<span class="ui green label">{{ctx.Locale.Tr "repo.activity.opened_prs_label"}}</span>
-						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji $.Context}}</a>
+						#{{.Index}} <a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Issue.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{TimeSinceUnix .Issue.CreatedUnix ctx.Locale}}
 					</p>
 				{{end}}
@@ -184,7 +184,7 @@
 				{{range .Activity.ClosedIssues}}
 					<p class="desc">
 						<span class="ui red label">{{ctx.Locale.Tr "repo.activity.closed_issue_label"}}</span>
-						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context}}</a>
+						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{TimeSinceUnix .ClosedUnix ctx.Locale}}
 					</p>
 				{{end}}
@@ -203,7 +203,7 @@
 				{{range .Activity.OpenedIssues}}
 					<p class="desc">
 						<span class="ui green label">{{ctx.Locale.Tr "repo.activity.new_issue_label"}}</span>
-						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context}}</a>
+						#{{.Index}} <a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{TimeSinceUnix .CreatedUnix ctx.Locale}}
 					</p>
 				{{end}}
@@ -221,9 +221,9 @@
 						<span class="ui green label">{{ctx.Locale.Tr "repo.activity.unresolved_conv_label"}}</span>
 						#{{.Index}}
 						{{if .IsPull}}
-						<a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Title | RenderEmoji $.Context}}</a>
+						<a class="title" href="{{$.RepoLink}}/pulls/{{.Index}}">{{.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{else}}
-						<a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context}}</a>
+						<a class="title" href="{{$.RepoLink}}/issues/{{.Index}}">{{.Title | RenderEmoji $.Context | RenderCodeBlock}}</a>
 						{{end}}
 						{{TimeSinceUnix .UpdatedUnix ctx.Locale}}
 					</p>


### PR DESCRIPTION
This is a little bugfix. Inline code is usually rendered in issue titles, but it is missing in the activity tab.

Before:
![Screenshot 2024-01-16 at 14-20-51 Test](https://github.com/go-gitea/gitea/assets/15185051/383370f3-0fb2-49de-81cc-014e5cf86727)
After:
![grafik](https://github.com/go-gitea/gitea/assets/15185051/83eaf973-ce9a-44ce-beea-2db49fc8bd73)
