### PR TITLE
Remove duplicated checkinit on git module

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -166,10 +166,6 @@ func InitSimple(ctx context.Context) error {
 // InitFull initializes git module with version check and change global variables, sync gitconfig.
 // It should only be called once at the beginning of the program initialization (TestMain/GlobalInitInstalled) as this code makes unsynchronized changes to variables.
 func InitFull(ctx context.Context) (err error) {
-	if err = checkInit(); err != nil {
-		return err
-	}
-
 	if err = InitSimple(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
`checkInit` has been invoked in `InitSimple`. So it's unnecessary to invoke it twice in `InitFull`.