### PR TITLE
Bump `@github/relative-time-element` to 4.3.1 (#28819)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@citation-js/plugin-software-formats": "0.6.1",
         "@claviska/jquery-minicolors": "2.3.6",
         "@github/markdown-toolbar-element": "2.2.1",
-        "@github/relative-time-element": "4.3.0",
+        "@github/relative-time-element": "4.3.1",
         "@github/text-expander-element": "2.5.0",
         "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
         "@primer/octicons": "19.8.0",
@@ -1010,9 +1010,9 @@
       "integrity": "sha512-ap+ulyqzG3aVqwKsKjbDdYwM75TQXZpPtmIuPwm+54OTgcC96267oX3cEqd1wSqGsH7O5PonZ//fE9jH7Q4JkA=="
     },
     "node_modules/@github/relative-time-element": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.3.0.tgz",
-      "integrity": "sha512-+tFjX9//HRS1HnBa5cNgfEtE52arwiutYg1TOF+Trk40SPxst9Q8Rtc3BKD6aKsvfbtub68vfhipgchGjj9o7g=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.3.1.tgz",
+      "integrity": "sha512-zL79nlhZVCg7x2Pf/HT5MB0mowmErE71VXpF10/3Wy8dQwkninNO1M9aOizh2wKC5LkSpDXqNYjDZwbH0/bcSg=="
     },
     "node_modules/@github/text-expander-element": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@citation-js/plugin-software-formats": "0.6.1",
     "@claviska/jquery-minicolors": "2.3.6",
     "@github/markdown-toolbar-element": "2.2.1",
-    "@github/relative-time-element": "4.3.0",
+    "@github/relative-time-element": "4.3.1",
     "@github/text-expander-element": "2.5.0",
     "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
     "@primer/octicons": "19.8.0",


### PR DESCRIPTION
Backport #28819

- Fixes https://github.com/go-gitea/gitea/issues/28747

# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/65d8dc84-680f-4c16-9aa1-b5986102e4e7)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/7cb288e7-ebde-4e94-a10a-cac28d6bdcfd)