### PR TITLE
Fix display latest sync time for pull mirrors on the repo page

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -987,6 +987,7 @@ mirror_prune = Prune
 mirror_prune_desc = Remove obsolete remote-tracking references
 mirror_interval = Mirror Interval (valid time units are 'h', 'm', 's'). 0 to disable periodic sync. (Minimum interval: %s)
 mirror_interval_invalid = The mirror interval is not valid.
+mirror_sync = synced
 mirror_sync_on_commit = Sync when commits are pushed
 mirror_address = Clone From URL
 mirror_address_desc = Put any required credentials in the Authorization section.

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -28,13 +28,6 @@
 						<div class="repo-icon" data-tooltip-content="{{ctx.Locale.Tr "repo.desc.template"}}">{{svg "octicon-repo-template" 18}}</div>
 					{{end}}
 				</div>
-				{{if $.PullMirror}}
-					<div class="fork-flag">
-						{{ctx.Locale.Tr "repo.mirror_from"}}
-						<a target="_blank" rel="noopener noreferrer" href="{{$.PullMirror.RemoteAddress}}">{{$.PullMirror.RemoteAddress}}</a>
-						{{if $.PullMirror.UpdatedUnix}}{{ctx.Locale.Tr "repo.mirror_sync"}} {{TimeSinceUnix $.PullMirror.UpdatedUnix ctx.Locale}}{{end}}
-					</div>
-				{{end}}
 			</div>
 			{{if not (or .IsBeingCreated .IsBroken)}}
 				<div class="repo-buttons">
@@ -147,7 +140,13 @@
 				</div>
 			{{end}}
 		</div>
-		{{if $.PullMirror}}<div class="fork-flag">{{ctx.Locale.Tr "repo.mirror_from"}} <a target="_blank" rel="noopener noreferrer" href="{{$.PullMirror.RemoteAddress}}">{{$.PullMirror.RemoteAddress}}</a></div>{{end}}
+		{{if $.PullMirror}}
+			<div class="fork-flag">
+				{{ctx.Locale.Tr "repo.mirror_from"}}
+				<a target="_blank" rel="noopener noreferrer" href="{{$.PullMirror.RemoteAddress}}">{{$.PullMirror.RemoteAddress}}</a>
+				{{if $.PullMirror.UpdatedUnix}}{{ctx.Locale.Tr "repo.mirror_sync"}} {{TimeSinceUnix $.PullMirror.UpdatedUnix ctx.Locale}}{{end}}
+			</div>
+		{{end}}
 		{{if .IsFork}}<div class="fork-flag">{{ctx.Locale.Tr "repo.forked_from"}} <a href="{{.BaseRepo.Link}}">{{.BaseRepo.FullName}}</a></div>{{end}}
 		{{if .IsGenerated}}<div class="fork-flag">{{ctx.Locale.Tr "repo.generated_from"}} <a href="{{(.TemplateRepo ctx).Link}}">{{(.TemplateRepo ctx).FullName}}</a></div>{{end}}
 	</div>


### PR DESCRIPTION
Follow #28712

1. Missing Locale word `mirror_sync`
2. Maybe forgot checking the conflict from #27760

Before:
![image](https://github.com/go-gitea/gitea/assets/18380374/6100d35b-7fe3-4095-9c24-7875568f7380)

After:
![image](https://github.com/go-gitea/gitea/assets/18380374/69647169-b812-45bc-a267-ab28f2df6ef6)
