### PR TITLE
tests: missing refs/ in bare repositories

### DIFF
--- a/tests/gitea-repositories-meta/user2/test_commit_revert.git/refs/heads/main
+++ b/tests/gitea-repositories-meta/user2/test_commit_revert.git/refs/heads/main
@@ -1,0 +1,1 @@
+deebcbc752e540bab4ce3ee713d3fc8fdc35b2f7


### PR DESCRIPTION
Git 2.43.0 will not detect a git repository as valid without refs/ subdirectory present. `git gc` cleans this up and puts it in packed-refs. We must keep refs/ non-empty.
