### PR TITLE
Fix archive creating LFS hooks and breaking pull requests

### DIFF
--- a/modules/git/repo_archive.go
+++ b/modules/git/repo_archive.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -62,11 +63,15 @@ func (repo *Repository) CreateArchive(ctx context.Context, format ArchiveType, t
 	cmd.AddOptionFormat("--format=%s", format.String())
 	cmd.AddDynamicArguments(commitID)
 
+	// Avoid LFS hooks getting installed because of /etc/gitconfig, which can break pull requests.
+	env := append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+
 	var stderr strings.Builder
 	err := cmd.Run(&RunOpts{
 		Dir:    repo.Path,
 		Stdout: target,
 		Stderr: &stderr,
+		Env:    env,
 	})
 	if err != nil {
 		return ConcatenateError(err, stderr.String())


### PR DESCRIPTION
When LFS hooks are present in gitea-repositories, operations like git push for creating a pull request fail. These repositories are not meant to include LFS files or git push them, that is handled separately. And so they should not have LFS hooks.

Installing git-lfs on some systems (like Debian Linux) will automatically set up /etc/gitconfig to create LFS hooks in repositories. For most git commands in Gitea this is not a problem, either because they run on a temporary clone or the git command does not create LFS hooks.

But one case where this happens is git archive for creating repository archives. To fix that, add a GIT_CONFIG_NOSYSTEM=1 to disable using the system configuration for that command.

According to a comment, GIT_CONFIG_NOSYSTEM is not used for all git commands because the system configuration can be intentionally set up for Gitea to use.

Resolves #19810, #21148