### PR TITLE
Fix `DeleteCollaboration` transaction behaviour

### DIFF
--- a/services/repository/collaboration.go
+++ b/services/repository/collaboration.go
@@ -26,9 +26,12 @@ func DeleteCollaboration(ctx context.Context, repo *repo_model.Repository, uid i
 	}
 	defer committer.Close()
 
-	if has, err := db.GetEngine(ctx).Delete(collaboration); err != nil || has == 0 {
+	if has, err := db.GetEngine(ctx).Delete(collaboration); err != nil {
 		return err
-	} else if err = access_model.RecalculateAccesses(ctx, repo); err != nil {
+	} else if has == 0 {
+		return committer.Commit()
+	}
+	if err = access_model.RecalculateAccesses(ctx, repo); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The method can't be called with an outer transaction because if the user is not a collaborator the outer transaction will be rolled back even if the inner transaction uses the no-error path.

`has == 0` leads to `return nil` which cancels the transaction. A standalone call of this method does nothing but if used with an outer transaction, that will be canceled.