### PR TITLE
Fix hardcoded GitHub icon used as migrated release avatar

### DIFF
--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -55,7 +55,7 @@
 							<p class="text grey">
 								<span class="author">
 								{{if .OriginalAuthor}}
-									{{svg "octicon-mark-github" 20 "gt-mr-2"}}{{.OriginalAuthor}}
+									{{svg (MigrationIcon .Repo.GetOriginalURLHostname) 20 "gt-mr-2"}}{{.OriginalAuthor}}
 								{{else if .Publisher}}
 									{{ctx.AvatarUtils.Avatar .Publisher 20 "gt-mr-2"}}
 									<a href="{{.Publisher.HomeLink}}">{{.Publisher.GetDisplayName}}</a>


### PR DESCRIPTION
Unhardcodes the avatar of migrated release authors from `"octicon-mark-github"` to the host-specific one provided by `MigrationIcon`.

## Preview

With my repository imported from GitLab.

### Before

![Release with GitHub icon as avatar](https://github.com/go-gitea/gitea/assets/29505620/3fee895b-fef5-41a3-a84c-d0f36b6a102e)

### After

![Release with generic Git icon as avatar](https://github.com/go-gitea/gitea/assets/29505620/2c9f2e75-ede8-4707-991e-7e35ac0ab20b)

