### PR TITLE
Use vue instead of plain template to render suscribe div of issue

### DIFF
--- a/routers/web/repo/issue_watch.go
+++ b/routers/web/repo/issue_watch.go
@@ -41,7 +41,7 @@ func IssueWatch(ctx *context.Context) {
 		return
 	}
 
-	watch, err := strconv.ParseBool(ctx.Req.PostForm.Get("watch"))
+	watch, err := strconv.ParseBool(ctx.FormString("watch"))
 	if err != nil {
 		ctx.ServerError("watch is not bool", err)
 		return
@@ -52,5 +52,5 @@ func IssueWatch(ctx *context.Context) {
 		return
 	}
 
-	ctx.Redirect(issue.Link())
+	ctx.JSONOK()
 }

--- a/templates/repo/issue/view_content/sidebar.tmpl
+++ b/templates/repo/issue/view_content/sidebar.tmpl
@@ -267,23 +267,13 @@
 	{{if and $.IssueWatch (not .Repository.IsArchived)}}
 		<div class="divider"></div>
 
-		<div class="ui watching">
-			<span class="text"><strong>{{ctx.Locale.Tr "notification.notifications"}}</strong></span>
-			<div class="gt-mt-3">
-				<form method="post" action="{{.Issue.Link}}/watch">
-					<input type="hidden" name="watch" value="{{if $.IssueWatch.IsWatching}}0{{else}}1{{end}}">
-					{{$.CsrfTokenHtml}}
-					<button class="fluid ui button">
-						{{if $.IssueWatch.IsWatching}}
-							{{svg "octicon-mute" 16 "gt-mr-3"}}
-							{{ctx.Locale.Tr "repo.issues.unsubscribe"}}
-						{{else}}
-							{{svg "octicon-unmute" 16 "gt-mr-3"}}
-							{{ctx.Locale.Tr "repo.issues.subscribe"}}
-						{{end}}
-					</button>
-				</form>
-			</div>
+		<div id="issue-subscribe"
+			data-locale-notifications="{{ctx.Locale.Tr "notification.notifications"}}"
+			data-locale-unsubscribe="{{ctx.Locale.Tr "repo.issues.unsubscribe"}}"
+			data-locale-subscribe="{{ctx.Locale.Tr "repo.issues.subscribe"}}"
+			data-is-watching="{{$.IssueWatch.IsWatching}}"
+			data-watch-link="{{.Issue.Link}}/watch"
+		>
 		</div>
 	{{end}}
 	{{if .Repository.IsTimetrackerEnabled $.Context}}

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -16,16 +16,11 @@ const sfc = {
     watchLink: {
       type: String,
       default: false,
-    },
-    locale: {
-      type: Object,
-      default: () => {},
     }
   },
   data() {
     return {
       isLoading: false,
-      isWatching: false,
     };
   },
   setup(props) {

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -1,0 +1,76 @@
+<script>
+import {initComponent} from '../../init.js';
+import {SvgIcon} from '../../svg.js';
+import {POST} from '../../modules/fetch.js';
+import {showErrorToast} from '../../modules/toast.js';
+import { ref } from 'vue';
+
+const sfc = {
+  name: 'IssueSubscribe',
+  components: {SvgIcon},
+  props: {
+    isWatchingReadOnly: {
+      type: Boolean,
+      default: false,
+    },
+    watchLink: {
+      type: String,
+      default: false,
+    },
+    locale: {
+      type: Object,
+      default: () => {},
+    }
+  },
+  data() {
+    return {
+      isLoading: false,
+      isWatching: false,
+    };
+  },
+  setup(props) {
+    const isWatching = ref(props.isWatchingReadOnly);
+    return {
+      isWatching,
+    };
+  },
+  methods: {
+    async toggleSubscribe() {
+      if (this.isLoading) return;
+
+      this.isLoading = true;
+      try {
+        const resp = await POST(`${this.watchLink}?watch=${!this.isWatching}`);
+        console.info(resp.status, resp.status === 200);
+        if (resp.status !== 200) {
+          showErrorToast(`Update watching status return: ${resp.status}`);
+          return;
+        }
+
+        this.isWatching = !this.isWatching;
+      } catch (e) {
+        showErrorToast(`Network error when fetching ${this.mode}, error: ${e}`);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  }
+};
+
+export default sfc;
+
+export function initIssueSubsribe() {
+  initComponent('issue-subscribe', sfc);
+}
+</script>
+<template>
+  <div class="ui watching">
+    <span class="text"><strong>{{ locale.notifications }}</strong></span>
+    <div class="gt-mt-3">
+      <button class="fluid ui button" @click="toggleSubscribe">
+        <SvgIcon :name="isWatching?'octicon-mute':'octicon-unmute'" class="text white" :size="16" class-name="gt-mr-3"/>
+        {{ isWatching?locale.unsubscribe:locale.subscribe }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -36,7 +36,6 @@ const sfc = {
       this.isLoading = true;
       try {
         const resp = await POST(`${this.watchLink}?watch=${!this.isWatching}`);
-        console.info(resp.status, resp.status === 200);
         if (resp.status !== 200) {
           showErrorToast(`Update watching status return: ${resp.status}`);
           return;

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -60,7 +60,7 @@ export function initIssueSubsribe() {
 <template>
   <div class="ui watching">
     <span class="text"><strong>{{ locale.notifications }}</strong></span>
-    <div class="gt-mt-3">
+    <div class="gt-mt-3" :class="isLoading?'is-loading':''">
       <button class="fluid ui button" @click="toggleSubscribe">
         <SvgIcon :name="isWatching?'octicon-mute':'octicon-unmute'" class="text white" :size="16" class-name="gt-mr-3"/>
         {{ isWatching?locale.unsubscribe:locale.subscribe }}

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -15,7 +15,7 @@ const sfc = {
     },
     watchLink: {
       type: String,
-      default: false,
+      required: true,
     }
   },
   data() {

--- a/web_src/js/components/issue/Subscribe.vue
+++ b/web_src/js/components/issue/Subscribe.vue
@@ -3,7 +3,7 @@ import {initComponent} from '../../init.js';
 import {SvgIcon} from '../../svg.js';
 import {POST} from '../../modules/fetch.js';
 import {showErrorToast} from '../../modules/toast.js';
-import { ref } from 'vue';
+import {ref} from 'vue';
 
 const sfc = {
   name: 'IssueSubscribe',

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -85,6 +85,7 @@ import {initRepoIssueList} from './features/repo-issue-list.js';
 import {initCommonIssueListQuickGoto} from './features/common-issue-list.js';
 import {initRepoDiffCommitBranchesAndTags} from './features/repo-diff-commit.js';
 import {initDirAuto} from './modules/dirauto.js';
+import {initIssueSubsribe} from './components/issue/Subscribe.vue';
 
 // Init Gitea's Fomantic settings
 initGiteaFomantic();
@@ -184,4 +185,6 @@ onDomReady(() => {
   initRepoDiffView();
   initPdfViewer();
   initScopedAccessTokenCategories();
+
+  initIssueSubsribe();
 });

--- a/web_src/js/init.js
+++ b/web_src/js/init.js
@@ -16,14 +16,14 @@ export function initComponent(id, sfc) {
 
   const data = {};
 
-  el.getAttributeNames().forEach((attr) => {
+  for (const attr of el.getAttributeNames()) {
     if (attr.startsWith('data-locale-')) {
       data.locale = data.locale || {};
       data.locale[convertName(attr.slice(12))] = el.getAttribute(attr);
     } else if (attr.startsWith('data-')) {
       data[convertName(attr.slice(5))] = el.getAttribute(attr);
     }
-  });
+  }
 
   const view = createApp(sfc, data);
   view.mount(el);

--- a/web_src/js/init.js
+++ b/web_src/js/init.js
@@ -25,6 +25,13 @@ export function initComponent(id, sfc) {
     }
   }
 
+  if (!sfc.props.locale) {
+    sfc.props.locale = {
+      type: Object,
+      default: () => {},
+    };
+  }
+
   const view = createApp(sfc, data);
   view.mount(el);
 }

--- a/web_src/js/init.js
+++ b/web_src/js/init.js
@@ -1,0 +1,26 @@
+import {createApp} from 'vue';
+
+function convertName(o) {
+  return o.replace(/-(\w)/g, (_, c) => {
+    return c ? c.toUpperCase() : '';
+  });
+}
+
+export function initComponent(id, sfc) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  const data = {};
+
+  el.getAttributeNames().forEach((attr) => {
+    if (attr.startsWith('data-locale-')) {
+      data.locale = data.locale || {};
+      data.locale[convertName(attr.slice(12))] = el.getAttribute(attr);
+    } else if (attr.startsWith('data-')) {
+      data[convertName(attr.slice(5))] = el.getAttribute(attr);
+    }
+  });
+
+  const view = createApp(sfc, data);
+  view.mount(el);
+}

--- a/web_src/js/init.js
+++ b/web_src/js/init.js
@@ -1,7 +1,7 @@
 import {createApp} from 'vue';
 
 // convertName convert the html tag a-b to aB
-function convertName(o) {
+export function convertName(o) {
   return o.replace(/-(\w)/g, (_, c) => {
     return c ? c.toUpperCase() : '';
   });

--- a/web_src/js/init.js
+++ b/web_src/js/init.js
@@ -1,11 +1,15 @@
 import {createApp} from 'vue';
 
+// convertName convert the html tag a-b to aB
 function convertName(o) {
   return o.replace(/-(\w)/g, (_, c) => {
     return c ? c.toUpperCase() : '';
   });
 }
 
+// initComponent will mount the component with tag id named id and vue sfc
+// it will also assign all attributes of the tag with the prefix data-locale- and data-
+// to the component as props
 export function initComponent(id, sfc) {
   const el = document.getElementById(id);
   if (!el) return;

--- a/web_src/js/init.test.js
+++ b/web_src/js/init.test.js
@@ -1,0 +1,7 @@
+import {convertName} from './init.js';
+
+test('init', () => {
+  expect(convertName('abc')).toEqual('abc');
+  expect(convertName('abc-repo')).toEqual('abcRepo');
+  expect(convertName('abc-repo-issue')).toEqual('abcRepoIssue');
+});

--- a/web_src/js/svg.js
+++ b/web_src/js/svg.js
@@ -69,6 +69,8 @@ import octiconTag from '../../public/assets/img/svg/octicon-tag.svg';
 import octiconTriangleDown from '../../public/assets/img/svg/octicon-triangle-down.svg';
 import octiconX from '../../public/assets/img/svg/octicon-x.svg';
 import octiconXCircleFill from '../../public/assets/img/svg/octicon-x-circle-fill.svg';
+import octiconMute from '../../public/assets/img/svg/octicon-mute.svg';
+import octiconUnmute from '../../public/assets/img/svg/octicon-unmute.svg';
 
 const svgs = {
   'gitea-double-chevron-left': giteaDoubleChevronLeft,
@@ -140,6 +142,8 @@ const svgs = {
   'octicon-triangle-down': octiconTriangleDown,
   'octicon-x': octiconX,
   'octicon-x-circle-fill': octiconXCircleFill,
+  'octicon-mute': octiconMute,
+  'octicon-unmute': octiconUnmute,
 };
 
 // TODO: use a more general approach to access SVG icons.


### PR DESCRIPTION
This PR did two things.

- Introducing `initComponent` which can make the component initlize simple than before
- Introducing `issue/Suscribe.vue` to instead of old template method

This can be compared with #28908 about a different framework to do the same thing.

![Screen Recording 2024-01-24 at 19 05 54 2024-01-24 19_08_26](https://github.com/go-gitea/gitea/assets/81045/e9f301bb-fd90-4f76-b5bb-7bfc7b4b87d0)

