### PR TITLE
add label info in webhook: fix webhook receiving multiple request on label change, add  batched label update in /repo/issues/ID

### DIFF
--- a/models/issues/issue_label.go
+++ b/models/issues/issue_label.go
@@ -119,8 +119,8 @@ func NewIssueLabel(ctx context.Context, issue *Issue, label *Label, doer *user_m
 	return committer.Commit()
 }
 
-// newIssueLabels add labels to an issue. It will check if the labels are valid for the issue
-func newIssueLabels(ctx context.Context, issue *Issue, labels []*Label, doer *user_model.User) (err error) {
+// AddIssueLabels add labels to an issue. It will check if the labels are valid for the issue
+func AddIssueLabels(ctx context.Context, issue *Issue, labels []*Label, doer *user_model.User) (err error) {
 	if err = issue.LoadRepo(ctx); err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func NewIssueLabels(ctx context.Context, issue *Issue, labels []*Label, doer *us
 	}
 	defer committer.Close()
 
-	if err = newIssueLabels(ctx, issue, labels, doer); err != nil {
+	if err = AddIssueLabels(ctx, issue, labels, doer); err != nil {
 		return err
 	}
 
@@ -481,7 +481,7 @@ func ReplaceIssueLabels(ctx context.Context, issue *Issue, labels []*Label, doer
 	toRemove = append(toRemove, issue.Labels[removeIndex:]...)
 
 	if len(toAdd) > 0 {
-		if err = newIssueLabels(ctx, issue, toAdd, doer); err != nil {
+		if err = AddIssueLabels(ctx, issue, toAdd, doer); err != nil {
 			return fmt.Errorf("addLabels: %w", err)
 		}
 	}

--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -351,13 +351,15 @@ const (
 
 // IssuePayload represents the payload information that is sent along with an issue event.
 type IssuePayload struct {
-	Action     HookIssueAction `json:"action"`
-	Index      int64           `json:"number"`
-	Changes    *ChangesPayload `json:"changes,omitempty"`
-	Issue      *Issue          `json:"issue"`
-	Repository *Repository     `json:"repository"`
-	Sender     *User           `json:"sender"`
-	CommitID   string          `json:"commit_id"`
+	Action        HookIssueAction `json:"action"`
+	Index         int64           `json:"number"`
+	Changes       *ChangesPayload `json:"changes,omitempty"`
+	Issue         *Issue          `json:"issue"`
+	Repository    *Repository     `json:"repository"`
+	Sender        *User           `json:"sender"`
+	CommitID      string          `json:"commit_id"`
+	AddedLabels   []*Label        `json:"added_labels"`
+	RemovedLabels []*Label        `json:"removed_labels"`
 }
 
 // JSONPayload encodes the IssuePayload to JSON, with an indentation of two spaces.

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1181,7 +1181,7 @@ func registerRoutes(m *web.Route) {
 			})
 
 			m.Post("/labels", reqRepoIssuesOrPullsWriter, repo.UpdateIssueLabel)
-			m.Post("/labels2", reqRepoIssuesOrPullsWriter, repo.UpdateIssueLabelBatched)
+			m.Post("/batch_labels", reqRepoIssuesOrPullsWriter, repo.UpdateIssueLabelBatched)
 			m.Post("/milestone", reqRepoIssuesOrPullsWriter, repo.UpdateIssueMilestone)
 			m.Post("/projects", reqRepoIssuesOrPullsWriter, reqRepoProjectsReader, repo.UpdateIssueProject)
 			m.Post("/assignee", reqRepoIssuesOrPullsWriter, repo.UpdateIssueAssignee)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1181,6 +1181,7 @@ func registerRoutes(m *web.Route) {
 			})
 
 			m.Post("/labels", reqRepoIssuesOrPullsWriter, repo.UpdateIssueLabel)
+			m.Post("/labels2", reqRepoIssuesOrPullsWriter, repo.UpdateIssueLabelBatched)
 			m.Post("/milestone", reqRepoIssuesOrPullsWriter, repo.UpdateIssueMilestone)
 			m.Post("/projects", reqRepoIssuesOrPullsWriter, reqRepoProjectsReader, repo.UpdateIssueProject)
 			m.Post("/assignee", reqRepoIssuesOrPullsWriter, repo.UpdateIssueAssignee)

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -91,6 +91,17 @@ func getIssuesCommentInfo(p *api.IssueCommentPayload) (title, link, by, operator
 	return title, link, by, operator
 }
 
+func convertLabelToCSVString(labels []*api.Label) string {
+	labelString := ""
+	for index, label := range labels {
+		labelString += " " + label.Name
+		if index+1 != len(labels) {
+			labelString += ","
+		}
+	}
+	return labelString
+}
+
 func getIssuesPayloadInfo(p *api.IssuePayload, linkFormatter linkFormatter, withSender bool) (string, string, string, int) {
 	repoLink := linkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 	issueTitle := fmt.Sprintf("#%d %s", p.Index, p.Issue.Title)
@@ -119,7 +130,16 @@ func getIssuesPayloadInfo(p *api.IssuePayload, linkFormatter linkFormatter, with
 	case api.HookIssueUnassigned:
 		text = fmt.Sprintf("[%s] Issue unassigned: %s", repoLink, titleLink)
 	case api.HookIssueLabelUpdated:
-		text = fmt.Sprintf("[%s] Issue labels updated: %s", repoLink, titleLink)
+		labelText := ""
+		if len(p.AddedLabels) > 0 {
+			addedLabels := convertLabelToCSVString(p.AddedLabels)
+			labelText += "Labels Added:" + addedLabels + "\u000a"
+		}
+		if len(p.RemovedLabels) > 0 {
+			removedLabels := convertLabelToCSVString(p.RemovedLabels)
+			labelText += "Labels Removed:" + removedLabels + "\u000a"
+		}
+		text = fmt.Sprintf("[%s] Issue labels updated: %s, \u000a%s", repoLink, titleLink, labelText)
 	case api.HookIssueLabelCleared:
 		text = fmt.Sprintf("[%s] Issue labels cleared: %s", repoLink, titleLink)
 	case api.HookIssueSynchronized:

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -531,11 +531,13 @@ func (m *webhookNotifier) IssueChangeLabels(ctx context.Context, doer *user_mode
 		})
 	} else {
 		err = PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventIssueLabel, &api.IssuePayload{
-			Action:     api.HookIssueLabelUpdated,
-			Index:      issue.Index,
-			Issue:      convert.ToAPIIssue(ctx, issue),
-			Repository: convert.ToRepo(ctx, issue.Repo, permission),
-			Sender:     convert.ToUser(ctx, doer, nil),
+			Action:        api.HookIssueLabelUpdated,
+			Index:         issue.Index,
+			Issue:         convert.ToAPIIssue(ctx, issue),
+			Repository:    convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:        convert.ToUser(ctx, doer, nil),
+			AddedLabels:   convert.ToLabelList(addedLabels, issue.Repo, doer),
+			RemovedLabels: convert.ToLabelList(removedLabels, issue.Repo, doer),
 		})
 	}
 	if err != nil {

--- a/templates/repo/issue/labels/labels_selector_field.tmpl
+++ b/templates/repo/issue/labels/labels_selector_field.tmpl
@@ -5,7 +5,7 @@
 			{{svg "octicon-gear" 16 "gt-ml-2"}}
 		{{end}}
 	</span>
-	<div class="filter menu" {{if .Issue}}data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/labels"{{else}}data-id="#label_ids"{{end}}>
+	<div class="filter menu" {{if .Issue}}data-action="update" data-issue-id="{{$.Issue.ID}}" data-update-url="{{$.RepoLink}}/issues/batch_labels"{{else}}data-id="#label_ids"{{end}}>
 		{{if or .Labels .OrgLabels}}
 			<div class="ui icon search input">
 				<i class="icon">{{svg "octicon-search" 16}}</i>

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -344,7 +344,7 @@ export async function updateIssuesMeta(url, action, issueIds, elementId) {
 export async function updateIssuesLabelClear(url, issueId) {
   return $.ajax({
     type: 'POST',
-    url: `${url}2?issueID=${issueId}`,
+    url: `${url}?issueID=${issueId}`,
     data: {
       _csrf: csrfToken,
       isClear: true
@@ -360,7 +360,7 @@ export async function updateIssuesLabelBatched(url, issueId, labelsInfo) {
 
   return $.ajax({
     type: 'POST',
-    url: `${url}2?issueID=${issueId}`,
+    url: `${url}?issueID=${issueId}`,
     data: {
       _csrf: csrfToken,
       labelsInfo: JSON.stringify(labelsInfo),

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -341,6 +341,34 @@ export async function updateIssuesMeta(url, action, issueIds, elementId) {
   });
 }
 
+export async function updateIssuesLabelClear(url, issueId) {
+  return $.ajax({
+    type: 'POST',
+    url: `${url}2?issueID=${issueId}`,
+    data: {
+      _csrf: csrfToken,
+      isClear: true
+    },
+  });
+}
+
+export async function updateIssuesLabelBatched(url, issueId, labelsInfo) {
+  if (!Array.isArray(labelsInfo)) return;
+  if (labelsInfo.length === 0) return;
+  if (!issueId || typeof issueId !== 'number') return;
+  if (!url || typeof url !== 'string') return;
+
+  return $.ajax({
+    type: 'POST',
+    url: `${url}2?issueID=${issueId}`,
+    data: {
+      _csrf: csrfToken,
+      labelsInfo: JSON.stringify(labelsInfo),
+      isClear: false
+    },
+  });
+}
+
 export function initRepoIssueComments() {
   if ($('.repository.view.issue .timeline').length === 0) return;
 


### PR DESCRIPTION

why : the webhook on label change sends multiple requests to our webhook listener, and does not send which label was changed, only says label was updated,
lets say: i add three label to a issue and remove three label from the issue, it will send 6 webhook request, which we dont want, we want one request with all label change info with label details


---
*PR sponsored by [Obmondo.com](https://obmondo.com)*