### PR TITLE
Check for sha256 support to use --object-format flag

### DIFF
--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -101,7 +101,9 @@ func InitRepository(ctx context.Context, repoPath string, bare bool, objectForma
 	if !IsValidObjectFormat(objectFormatName) {
 		return fmt.Errorf("invalid object format: %s", objectFormatName)
 	}
-	cmd.AddOptionValues("--object-format", objectFormatName)
+	if SupportHashSha256 {
+		cmd.AddOptionValues("--object-format", objectFormatName)
+	}
 
 	if bare {
 		cmd.AddArguments("--bare")


### PR DESCRIPTION
This should fix https://github.com/go-gitea/gitea/issues/28927

Technically older versions of Git would support this flag as well, but per https://github.com/go-gitea/gitea/pull/28466 that's the version where using it (object-format=sha256) left "experimental" state.

`sha1` is (currently) the default, so older clients should be unaffected in either case.