### PR TITLE
Strip `/` from relative links

### DIFF
--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -85,9 +85,11 @@ func (g *ASTTransformer) Transform(node *ast.Document, reader text.Reader, pc pa
 			// 2. If they're not wrapped with a link they need a link wrapper
 
 			// Check if the destination is a real link
-			link := v.Destination
-			if len(link) > 0 && !markup.IsLink(link) {
-				v.Destination = []byte(giteautil.URLJoin(ctx.Links.ResolveMediaLink(ctx.IsWiki), string(link)))
+			if len(v.Destination) > 0 && !markup.IsLink(v.Destination) {
+				v.Destination = []byte(giteautil.URLJoin(
+					ctx.Links.ResolveMediaLink(ctx.IsWiki),
+					strings.TrimLeft(string(v.Destination), "/"),
+				))
 			}
 
 			parent := n.Parent()
@@ -103,7 +105,7 @@ func (g *ASTTransformer) Transform(node *ast.Document, reader text.Reader, pc pa
 
 				// Duplicate the current image node
 				image := ast.NewImage(ast.NewLink())
-				image.Destination = link
+				image.Destination = v.Destination
 				image.Title = v.Title
 				for _, attr := range v.Attributes() {
 					image.SetAttribute(attr.Name, attr.Value)

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -580,6 +580,8 @@ https://example.com/file.bin
 [[local link|file.bin]]
 [[remote link|https://example.com]]
 ![local image](image.jpg)
+![local image](attachments/cc42dfde)
+![local image](/attachments/cc42dfde)
 ![remote image](https://example.com/image.jpg)
 [[local image|image.jpg]]
 [[remote link|https://example.com/image.jpg]]
@@ -609,6 +611,8 @@ mail@domain.com
 <a href="/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/image.jpg" target="_blank" rel="nofollow noopener"><img src="/image.jpg" alt="local image"/></a><br/>
+<a href="/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/image.jpg" rel="nofollow"><img src="/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -634,6 +638,8 @@ space</p>
 <a href="/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/wiki/raw/image.jpg" rel="nofollow"><img src="/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -661,6 +667,8 @@ space</p>
 <a href="https://gitea.io/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="https://gitea.io/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/image.jpg" alt="local image"/></a><br/>
+<a href="https://gitea.io/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="https://gitea.io/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="https://gitea.io/image.jpg" rel="nofollow"><img src="https://gitea.io/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -688,6 +696,8 @@ space</p>
 <a href="https://gitea.io/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="https://gitea.io/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="https://gitea.io/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="https://gitea.io/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="https://gitea.io/wiki/raw/image.jpg" rel="nofollow"><img src="https://gitea.io/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -715,6 +725,8 @@ space</p>
 <a href="/relative/path/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/image.jpg" alt="local image"/></a><br/>
+<a href="/relative/path/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/image.jpg" rel="nofollow"><img src="/relative/path/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -742,6 +754,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -770,6 +784,8 @@ space</p>
 <a href="/user/repo/src/branch/main/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/media/branch/main/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/image.jpg" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/media/branch/main/image.jpg" rel="nofollow"><img src="/user/repo/media/branch/main/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -798,6 +814,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -826,6 +844,8 @@ space</p>
 <a href="/user/repo/src/sub/folder/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/image.jpg" alt="local image"/></a><br/>
+<a href="/user/repo/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/image.jpg" rel="nofollow"><img src="/user/repo/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -854,6 +874,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -883,6 +905,8 @@ space</p>
 <a href="/user/repo/src/branch/main/sub/folder/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/media/branch/main/sub/folder/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/image.jpg" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/media/branch/main/sub/folder/image.jpg" rel="nofollow"><img src="/user/repo/media/branch/main/sub/folder/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -912,6 +936,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>

--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -580,8 +580,8 @@ https://example.com/file.bin
 [[local link|file.bin]]
 [[remote link|https://example.com]]
 ![local image](image.jpg)
-![local image](attachments/cc42dfde)
-![local image](/attachments/cc42dfde)
+![local image](path/file)
+![local image](/path/file)
 ![remote image](https://example.com/image.jpg)
 [[local image|image.jpg]]
 [[remote link|https://example.com/image.jpg]]
@@ -611,8 +611,8 @@ mail@domain.com
 <a href="/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/image.jpg" target="_blank" rel="nofollow noopener"><img src="/image.jpg" alt="local image"/></a><br/>
-<a href="/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/path/file" target="_blank" rel="nofollow noopener"><img src="/path/file" alt="local image"/></a><br/>
+<a href="/path/file" target="_blank" rel="nofollow noopener"><img src="/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/image.jpg" rel="nofollow"><img src="/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -638,8 +638,8 @@ space</p>
 <a href="/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/wiki/raw/image.jpg" rel="nofollow"><img src="/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -667,8 +667,8 @@ space</p>
 <a href="https://gitea.io/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="https://gitea.io/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/image.jpg" alt="local image"/></a><br/>
-<a href="https://gitea.io/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="https://gitea.io/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="https://gitea.io/path/file" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/path/file" alt="local image"/></a><br/>
+<a href="https://gitea.io/path/file" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="https://gitea.io/image.jpg" rel="nofollow"><img src="https://gitea.io/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -696,8 +696,8 @@ space</p>
 <a href="https://gitea.io/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="https://gitea.io/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="https://gitea.io/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="https://gitea.io/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="https://gitea.io/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="https://gitea.io/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="https://gitea.io/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="https://gitea.io/wiki/raw/image.jpg" rel="nofollow"><img src="https://gitea.io/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -725,8 +725,8 @@ space</p>
 <a href="/relative/path/src/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/image.jpg" alt="local image"/></a><br/>
-<a href="/relative/path/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/relative/path/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/path/file" alt="local image"/></a><br/>
+<a href="/relative/path/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/image.jpg" rel="nofollow"><img src="/relative/path/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -754,8 +754,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -784,8 +784,8 @@ space</p>
 <a href="/user/repo/src/branch/main/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/media/branch/main/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/image.jpg" alt="local image"/></a><br/>
-<a href="/user/repo/media/branch/main/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/user/repo/media/branch/main/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/path/file" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/media/branch/main/image.jpg" rel="nofollow"><img src="/user/repo/media/branch/main/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -814,8 +814,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -844,8 +844,8 @@ space</p>
 <a href="/user/repo/src/sub/folder/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/image.jpg" alt="local image"/></a><br/>
-<a href="/user/repo/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/user/repo/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/path/file" alt="local image"/></a><br/>
+<a href="/user/repo/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/image.jpg" rel="nofollow"><img src="/user/repo/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -874,8 +874,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -905,8 +905,8 @@ space</p>
 <a href="/user/repo/src/branch/main/sub/folder/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/user/repo/media/branch/main/sub/folder/image.jpg" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/image.jpg" alt="local image"/></a><br/>
-<a href="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/sub/folder/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/path/file" alt="local image"/></a><br/>
+<a href="/user/repo/media/branch/main/sub/folder/path/file" target="_blank" rel="nofollow noopener"><img src="/user/repo/media/branch/main/sub/folder/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/user/repo/media/branch/main/sub/folder/image.jpg" rel="nofollow"><img src="/user/repo/media/branch/main/sub/folder/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>
@@ -936,8 +936,8 @@ space</p>
 <a href="/relative/path/wiki/file.bin" rel="nofollow">local link</a><br/>
 <a href="https://example.com" rel="nofollow">remote link</a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/image.jpg" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
-<a href="/relative/path/wiki/raw/attachments/cc42dfde" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/attachments/cc42dfde" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
+<a href="/relative/path/wiki/raw/path/file" target="_blank" rel="nofollow noopener"><img src="/relative/path/wiki/raw/path/file" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" target="_blank" rel="nofollow noopener"><img src="https://example.com/image.jpg" alt="remote image"/></a><br/>
 <a href="/relative/path/wiki/raw/image.jpg" rel="nofollow"><img src="/relative/path/wiki/raw/image.jpg" title="local image" alt="local image"/></a><br/>
 <a href="https://example.com/image.jpg" rel="nofollow"><img src="https://example.com/image.jpg" title="remote link" alt="remote link"/></a><br/>


### PR DESCRIPTION
Fixes #28915

Restores the old behaviour:
https://github.com/go-gitea/gitea/pull/26745/files#diff-d78a9d361b1fddc12218e4dd42f42d39d6be1fda184041e06bb6fb30f0d94c59L96