### PR TITLE
Fix non-alphabetic sorting of repo topics

### DIFF
--- a/models/repo/topic.go
+++ b/models/repo/topic.go
@@ -366,7 +366,7 @@ func syncTopicsInRepository(sess db.Engine, repoID int64) error {
 	topicNames := make([]string, 0, 25)
 	if err := sess.Table("topic").Cols("name").
 		Join("INNER", "repo_topic", "repo_topic.topic_id = topic.id").
-		Where("repo_topic.repo_id = ?", repoID).Desc("topic.repo_count").Find(&topicNames); err != nil {
+		Where("repo_topic.repo_id = ?", repoID).Asc("topic.name").Find(&topicNames); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`Desc("topic.repo_count")` -> `Asc("topic.name")`

### Description
This changes it so that when a repository's topics are synced, they are sorted in alphabetical order, fixing #28936 (see for more information).

Before:
![List of topics A, C, and B in that order](https://github.com/go-gitea/gitea/assets/29505620/3a5ceb8d-0031-4df5-9c57-1e6dd2feb2e3)

After (by editing the topics to trigger a sync):
![List of topics A, B, and C in that order](https://github.com/go-gitea/gitea/assets/29505620/4e13d0a6-77d7-4443-8fe3-58c2ab8f003c)

### Questions
1. Is this a good solution, or should the topics instead be sorted during the rendering of the template?
2. Should there be a new DB migration to force-sync all repo topics, or would that not be necessary?

### Issues
Closes #28936.
