### PR TITLE
Replace http://golang.org with https://go.dev

### DIFF
--- a/options/locale/locale_cs-CZ.ini
+++ b/options/locale/locale_cs-CZ.ini
@@ -175,7 +175,7 @@ network_error=Chyba sítě
 app_desc=Snadno přístupný vlastní Git
 install=Jednoduchá na instalaci
 platform=Multiplatformní
-platform_desc=Gitea běží všude, kde <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> může kompilovat: Windows, macOS, Linux, ARM, atd. Vyberte si ten, který milujete!
+platform_desc=Gitea běží všude, kde <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> může kompilovat: Windows, macOS, Linux, ARM, atd. Vyberte si ten, který milujete!
 lightweight=Lehká
 lightweight_desc=Gitea má minimální požadavky a může běžet na Raspberry Pi. Šetřete energii vašeho stroje!
 license=Open Source

--- a/options/locale/locale_de-DE.ini
+++ b/options/locale/locale_de-DE.ini
@@ -184,7 +184,7 @@ app_desc=Ein einfacher, selbst gehosteter Git-Service
 install=Einfach zu installieren
 install_desc=Starte einfach <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">die Anwendung</a> für deine Plattform oder nutze <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>. Es existieren auch <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">paketierte Versionen</a>.
 platform=Plattformübergreifend
-platform_desc=Gitea läuft überall, wo <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> kompiliert: Windows, macOS, Linux, ARM, etc. Wähle das System, das dir am meisten gefällt!
+platform_desc=Gitea läuft überall, wo <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> kompiliert: Windows, macOS, Linux, ARM, etc. Wähle das System, das dir am meisten gefällt!
 lightweight=Leichtgewicht
 lightweight_desc=Gitea hat minimale Systemanforderungen und kann selbst auf einem günstigen und stromsparenden Raspberry Pi betrieben werden!
 license=Quelloffen

--- a/options/locale/locale_el-GR.ini
+++ b/options/locale/locale_el-GR.ini
@@ -175,7 +175,7 @@ network_error=Σφάλμα δικτύου
 app_desc=Μια ανώδυνη, αυτο-φιλοξενούμενη υπηρεσία Git
 install=Εύκολο στην εγκατάσταση
 platform=Πολυπλατφορμικό
-platform_desc=Ο Gitea τρέχει οπουδήποτε <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> μπορεί να γίνει compile για: Windows, macOS, Linux, ARM, κλπ. Επιλέξτε αυτό που αγαπάτε!
+platform_desc=Ο Gitea τρέχει οπουδήποτε <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> μπορεί να γίνει compile για: Windows, macOS, Linux, ARM, κλπ. Επιλέξτε αυτό που αγαπάτε!
 lightweight=Ελαφρύ
 lightweight_desc=Gitea έχει χαμηλές ελάχιστες απαιτήσεις και μπορεί να τρέξει σε ένα οικονομικό Raspberry Pi. Εξοικονομήστε ενέργεια!
 license=Ανοικτού κώδικα

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -186,7 +186,7 @@ app_desc = A painless, self-hosted Git service
 install = Easy to install
 install_desc = Simply <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">run the binary</a> for your platform, ship it with <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, or get it <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">packaged</a>.
 platform = Cross-platform
-platform_desc = Gitea runs anywhere <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> can compile for: Windows, macOS, Linux, ARM, etc. Choose the one you love!
+platform_desc = Gitea runs anywhere <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> can compile for: Windows, macOS, Linux, ARM, etc. Choose the one you love!
 lightweight = Lightweight
 lightweight_desc = Gitea has low minimal requirements and can run on an inexpensive Raspberry Pi. Save your machine energy!
 license = Open Source

--- a/options/locale/locale_es-ES.ini
+++ b/options/locale/locale_es-ES.ini
@@ -184,7 +184,7 @@ app_desc=Un servicio de Git autoalojado y sin complicaciones
 install=Fácil de instalar
 install_desc=Simplemente <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">ejecuta el binario</a> para tu plataforma, lánzalo con <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>o consíguelo <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">empaquetado</a>.
 platform=Multiplataforma
-platform_desc=Gitea funciona en cualquier platforma <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> puede compilarlo en: Windows, macOS, Linux, ARM, etc. ¡Elige tu favorita!
+platform_desc=Gitea funciona en cualquier platforma <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> puede compilarlo en: Windows, macOS, Linux, ARM, etc. ¡Elige tu favorita!
 lightweight=Ligero
 lightweight_desc=Gitea tiene pocos requisitos y puede funcionar en una Raspberry Pi barata. ¡Ahorra energía!
 license=Código abierto

--- a/options/locale/locale_fa-IR.ini
+++ b/options/locale/locale_fa-IR.ini
@@ -115,7 +115,7 @@ missing_csrf=درخواست بد: بلیط CSRF ندارد
 app_desc=یک سرویس گیت بی‌درد سر و راحت
 install=راه‌اندازی ساده
 platform=مستقل از سکو
-platform_desc=گیت همه جا اجرا می‌شود <a target="_blank" rel="noopener noreferrer" href="http://golang.org/"> بریم!</a> می‌توانید Windows, macOS, Linux, ARM و ... هر کدام را دوست داشتید انتخاب کنید!
+platform_desc=گیت همه جا اجرا می‌شود <a target="_blank" rel="noopener noreferrer" href="https://go.dev/"> بریم!</a> می‌توانید Windows, macOS, Linux, ARM و ... هر کدام را دوست داشتید انتخاب کنید!
 lightweight=ابزارک سبک
 lightweight_desc=گیتی با حداقل منابع میتوانید برای روی دستگاه Raspberry Pi اجرا شود و مصرف انرژی شما را کاهش دهد!
 license=متن باز

--- a/options/locale/locale_fi-FI.ini
+++ b/options/locale/locale_fi-FI.ini
@@ -133,7 +133,7 @@ network_error=Verkkovirhe
 app_desc=Kivuton, itsehostattu Git-palvelu
 install=Helppo asentaa
 platform=Alustariippumaton
-platform_desc=Gitea käy missä tahansa alustassa, johon <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> kykenee kääntämään. Windows, macOS, Linux, ARM, jne. Valitse omasi!
+platform_desc=Gitea käy missä tahansa alustassa, johon <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> kykenee kääntämään. Windows, macOS, Linux, ARM, jne. Valitse omasi!
 lightweight=Kevyt
 lightweight_desc=Gitealla on vähäiset vähimmäisvaatimukset, joten se toimii jopa halvassa Raspberry Pi:ssä. Säästä koneesi energiaa!
 license=Avoin lähdekoodi

--- a/options/locale/locale_fr-FR.ini
+++ b/options/locale/locale_fr-FR.ini
@@ -186,7 +186,7 @@ app_desc=Un service Git auto-hébergé sans prise de tête
 install=Facile à installer
 install_desc=Il suffit de <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">lancer l’exécutable</a> adapté à votre plateforme, le déployer avec <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a> ou de l’installer depuis un <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">gestionnaire de paquet</a>.
 platform=Multi-plateforme
-platform_desc=Gitea tourne partout où <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> peut être compilé : Windows, macOS, Linux, ARM, etc. Choisissez votre préféré !
+platform_desc=Gitea tourne partout où <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> peut être compilé : Windows, macOS, Linux, ARM, etc. Choisissez votre préféré !
 lightweight=Léger
 lightweight_desc=Gitea utilise peu de ressources. Il peut même tourner sur un Raspberry Pi très bon marché. Économisez l'énergie de vos serveurs !
 license=Open Source

--- a/options/locale/locale_hu-HU.ini
+++ b/options/locale/locale_hu-HU.ini
@@ -104,7 +104,7 @@ name=Név
 app_desc=Fájdalommentes, saját gépre telepíthető Git szolgáltatás
 install=Könnyen telepíthető
 platform=Keresztplatformos
-platform_desc=A Gitea minden platformon fut, ahol a <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> fordíthat: Windows, macOS, Linux, ARM, stb. Válassza azt, amelyet szereti!
+platform_desc=A Gitea minden platformon fut, ahol a <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> fordíthat: Windows, macOS, Linux, ARM, stb. Válassza azt, amelyet szereti!
 lightweight=Könnyűsúlyú
 license=Nyílt forráskódú
 

--- a/options/locale/locale_id-ID.ini
+++ b/options/locale/locale_id-ID.ini
@@ -97,7 +97,7 @@ name=Nama
 app_desc=Sebuah layanan hosting Git sendiri yang tanpa kesulitan
 install=Mudah dipasang
 platform=Lintas platform
-platform_desc=Gitea bisa digunakan di mana <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> bisa dijalankan: Windows, macOS, Linux, ARM, dll. Silahkan pilih yang Anda suka!
+platform_desc=Gitea bisa digunakan di mana <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> bisa dijalankan: Windows, macOS, Linux, ARM, dll. Silahkan pilih yang Anda suka!
 lightweight=Ringan
 lightweight_desc=Gitea hanya membutuhkan persyaratan minimal dan bisa berjalan pada Raspberry Pi yang murah. Bisa menghemat listrik!
 license=Sumber Terbuka

--- a/options/locale/locale_is-IS.ini
+++ b/options/locale/locale_is-IS.ini
@@ -130,7 +130,7 @@ network_error=Netkerfisvilla
 app_desc=Þrautalaus og sjálfhýst Git þjónusta
 install=Einföld uppsetning
 platform=Fjölvettvangur
-platform_desc=Gitea virkar hvar sem að <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> gerir: Linux, macOS, Windows, ARM o. s. frv. Veldu það sem þú vilt!
+platform_desc=Gitea virkar hvar sem að <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> gerir: Linux, macOS, Windows, ARM o. s. frv. Veldu það sem þú vilt!
 lightweight=Létt
 lightweight_desc=Gitea hefur lágar lágmarkskröfur og getur keyrt á ódýrum Raspberry Pi. Sparaðu orku!
 license=Frjáls Hugbúnaður

--- a/options/locale/locale_it-IT.ini
+++ b/options/locale/locale_it-IT.ini
@@ -135,7 +135,7 @@ network_error=Errore di rete
 app_desc=Un servizio auto-ospitato per Git pronto all'uso
 install=Facile da installare
 platform=Multipiattaforma
-platform_desc=Gitea funziona ovunque <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> possa essere compilato: Windows, macOS, Linux, ARM, etc. Scegli ciò che ami!
+platform_desc=Gitea funziona ovunque <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> possa essere compilato: Windows, macOS, Linux, ARM, etc. Scegli ciò che ami!
 lightweight=Leggero
 lightweight_desc=Gitea ha requisiti minimi bassi e può funzionare su un economico Raspberry Pi. Risparmia l'energia della tua macchina!
 license=Open Source

--- a/options/locale/locale_ja-JP.ini
+++ b/options/locale/locale_ja-JP.ini
@@ -186,7 +186,7 @@ app_desc=自分で立てる、超簡単 Git サービス
 install=簡単インストール
 install_desc=シンプルに、プラットフォームに応じて<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">バイナリを実行</a>したり、<a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>で動かしたり、<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">パッケージ</a>を使うだけ。
 platform=クロスプラットフォーム
-platform_desc=Giteaは<a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a>でコンパイルできる環境ならどこでも動きます: Windows、macOS、Linux、ARM等々、好きなものを選んでください!
+platform_desc=Giteaは<a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a>でコンパイルできる環境ならどこでも動きます: Windows、macOS、Linux、ARM等々、好きなものを選んでください!
 lightweight=軽量
 lightweight_desc=Gitea の最小動作要件は小さくて、安価な Raspberry Pi でも動きます。エネルギー消費を節約しましょう!
 license=オープンソース

--- a/options/locale/locale_lv-LV.ini
+++ b/options/locale/locale_lv-LV.ini
@@ -179,7 +179,7 @@ network_error=Tīkla kļūda
 app_desc=Viegli uzstādāms Git serviss
 install=Vienkārši instalējams
 platform=Pieejama dažādām platformām
-platform_desc=Gitea iespējams uzstādīt jebkur, kam <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> var nokompilēt: Windows, macOS, Linux, ARM utt. Izvēlies to, kas tev patīk!
+platform_desc=Gitea iespējams uzstādīt jebkur, kam <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> var nokompilēt: Windows, macOS, Linux, ARM utt. Izvēlies to, kas tev patīk!
 lightweight=Viegla
 lightweight_desc=Gitea ir miminālas prasības un to var darbināt uz nedārga Raspberry Pi datora. Ietaupi savai ierīcei resursus!
 license=Atvērtā pirmkoda

--- a/options/locale/locale_nl-NL.ini
+++ b/options/locale/locale_nl-NL.ini
@@ -134,7 +134,7 @@ network_error=Netwerk fout
 app_desc=Een eenvoudige, self-hosted Git service
 install=Makkelijk te installeren
 platform=Cross-platform
-platform_desc=Gitea werkt op alles waar <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> op kan compileren: Windows, macOS, Linux, ARM, etc. Kies het platform dat bij je past!
+platform_desc=Gitea werkt op alles waar <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> op kan compileren: Windows, macOS, Linux, ARM, etc. Kies het platform dat bij je past!
 lightweight=Lichtgewicht
 lightweight_desc=Gitea heeft hele lage systeemeisen, je kunt Gitea al draaien op een goedkope Raspberry Pi.
 license=Open Source

--- a/options/locale/locale_pl-PL.ini
+++ b/options/locale/locale_pl-PL.ini
@@ -132,7 +132,7 @@ network_error=Błąd sieci
 app_desc=Bezbolesna usługa Git na własnym serwerze
 install=Łatwa instalacja
 platform=Wieloplatformowość
-platform_desc=Gitea ruszy gdziekolwiek <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> jest możliwe do skompilowania: Windows, macOS, Linux, ARM, itd. Wybierz swój ulubiony system!
+platform_desc=Gitea ruszy gdziekolwiek <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> jest możliwe do skompilowania: Windows, macOS, Linux, ARM, itd. Wybierz swój ulubiony system!
 lightweight=Niskie wymagania
 lightweight_desc=Gitea ma niskie minimalne wymagania i może działać na niedrogim Raspberry Pi. Oszczędzaj energię swojego komputera!
 license=Otwarte źródło

--- a/options/locale/locale_pt-BR.ini
+++ b/options/locale/locale_pt-BR.ini
@@ -181,7 +181,7 @@ network_error=Erro de rede
 app_desc=Um serviço de hospedagem Git amigável
 install=Fácil de instalar
 platform=Multi-plataforma
-platform_desc=Gitea roda em qualquer sistema operacional em que <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> consegue compilar: Windows, macOS, Linux, ARM, etc. Escolha qual você gosta mais!
+platform_desc=Gitea roda em qualquer sistema operacional em que <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> consegue compilar: Windows, macOS, Linux, ARM, etc. Escolha qual você gosta mais!
 lightweight=Leve e rápido
 lightweight_desc=Gitea utiliza poucos recursos e consegue mesmo rodar no barato Raspberry Pi. Economize energia elétrica da sua máquina!
 license=Código aberto

--- a/options/locale/locale_pt-PT.ini
+++ b/options/locale/locale_pt-PT.ini
@@ -186,7 +186,7 @@ app_desc=Um serviço Git auto-hospedado e fácil de usar
 install=Fácil de instalar
 install_desc=Corra, simplesmente, <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">o ficheiro binário executável</a> para a sua plataforma, despache-o com o <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, ou obtenha-o sob a forma de <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">pacote</a>.
 platform=Multiplataforma
-platform_desc=Gitea corre em qualquer plataforma onde possa compilar em linguagem <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a>: Windows, macOS, Linux, ARM, etc. Escolha a sua preferida!
+platform_desc=Gitea corre em qualquer plataforma onde possa compilar em linguagem <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a>: Windows, macOS, Linux, ARM, etc. Escolha a sua preferida!
 lightweight=Leve
 lightweight_desc=Gitea requer poucos recursos e pode correr num simples Raspberry Pi. Economize a energia da sua máquina!
 license=Código aberto

--- a/options/locale/locale_ru-RU.ini
+++ b/options/locale/locale_ru-RU.ini
@@ -184,7 +184,7 @@ app_desc=Удобный сервис собственного хостинга �
 install=Простой в установке
 install_desc=Просто <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">запустите исполняемый файл</a> для вашей платформы, разверните через <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, или установите <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">с помощью менеджера пакетов</a>.
 platform=Кроссплатформенный
-platform_desc=Gitea работает на любой платформе, поддерживаемой <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a>: Windows, macOS, Linux, ARM и т. д. Выбирайте, что вам больше нравится!
+platform_desc=Gitea работает на любой платформе, поддерживаемой <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a>: Windows, macOS, Linux, ARM и т. д. Выбирайте, что вам больше нравится!
 lightweight=Легковесный
 lightweight_desc=Gitea имеет низкие системные требования и может работать на недорогом Raspberry Pi. Экономьте энергию вашей машины!
 license=Открытый исходный код

--- a/options/locale/locale_si-LK.ini
+++ b/options/locale/locale_si-LK.ini
@@ -115,7 +115,7 @@ missing_csrf=නරක ඉල්ලීම: CSRF ටෝකන් නොමැත
 app_desc=වේදනාකාරී, ස්වයං-සත්කාරක Git සේවාවක්
 install=ස්ථාපනයට පහසුය
 platform=හරස් වේදිකාව
-platform_desc=Gitea ඕනෑම තැනක ධාවනය <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> සඳහා සම්පාදනය කළ හැකිය: වින්ඩෝස්, මැකෝස්, ලිනක්ස්, ARM, ආදිය ඔබ ආදරය කරන එකක් තෝරන්න!
+platform_desc=Gitea ඕනෑම තැනක ධාවනය <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> සඳහා සම්පාදනය කළ හැකිය: වින්ඩෝස්, මැකෝස්, ලිනක්ස්, ARM, ආදිය ඔබ ආදරය කරන එකක් තෝරන්න!
 lightweight=සැහැල්ලු
 lightweight_desc=Gitea අඩු අවම අවශ්යතා ඇති අතර මිල අඩු Raspberry Pi මත ධාවනය කළ හැකිය. ඔබේ යන්ත්ර ශක්තිය සුරකින්න!
 license=විවෘත මූලාශ්‍ර

--- a/options/locale/locale_sk-SK.ini
+++ b/options/locale/locale_sk-SK.ini
@@ -185,7 +185,7 @@ app_desc=Jednoducho prístupný vlastný Git
 install=Jednoduchá inštalácia
 install_desc=Jednoducho <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">spustite binárku</a> pre vašu platformu, pošlite ju ako <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">Docker</a>, alebo ju získajte <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">ako balíček</a>.
 platform=Multiplatformový
-platform_desc=Gitea beží všade kde je možné preložiť <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a>: Windows, macOS, Linux, ARM, a podobne. Vyberte si!
+platform_desc=Gitea beží všade kde je možné preložiť <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a>: Windows, macOS, Linux, ARM, a podobne. Vyberte si!
 lightweight=Ľahká
 lightweight_desc=Gitea má minimálne požiadavky a môže bežať na Raspberry Pi. Šetrite energiou vášho stroja!
 license=Otvorený zdrojový kód

--- a/options/locale/locale_sv-SE.ini
+++ b/options/locale/locale_sv-SE.ini
@@ -105,7 +105,7 @@ name=Namn
 app_desc=En smidig, självhostad Git-tjänst
 install=Lätt att installera
 platform=Plattformsoberoende
-platform_desc=Gitea kan köra överallt där <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> kan kompileras: Windows, macOS, Linux, ARM, etc. Välj den du gillar!
+platform_desc=Gitea kan köra överallt där <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> kan kompileras: Windows, macOS, Linux, ARM, etc. Välj den du gillar!
 lightweight=Lättviktig
 lightweight_desc=Gitea har låga minimum-krav och kan köras på en billig Rasperry Pi. Spara på din maskins kraft!
 license=Öppen källkod

--- a/options/locale/locale_tr-TR.ini
+++ b/options/locale/locale_tr-TR.ini
@@ -181,7 +181,7 @@ network_error=Ağ hatası
 app_desc=Zahmetsiz, kendi sunucunuzda barındırabileceğiniz Git servisi
 install=Kurulumu kolay
 platform=Farklı platformlarda çalışablir
-platform_desc=Gitea <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a> ile derleme yapılabilecek her yerde çalışmaktadır: Windows, macOS, Linux, ARM, vb. Hangisini seviyorsanız onu seçin!
+platform_desc=Gitea <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a> ile derleme yapılabilecek her yerde çalışmaktadır: Windows, macOS, Linux, ARM, vb. Hangisini seviyorsanız onu seçin!
 lightweight=Hafif
 lightweight_desc=Gitea'nın minimal gereksinimleri çok düşüktür ve ucuz bir Raspberry Pi üzerinde çalışabilmektedir. Makine enerjinizden tasarruf edin!
 license=Açık Kaynak

--- a/options/locale/locale_uk-UA.ini
+++ b/options/locale/locale_uk-UA.ini
@@ -118,7 +118,7 @@ network_error=Помилка мережі
 app_desc=Зручний власний сервіс хостингу репозиторіїв Git
 install=Легко встановити
 platform=Платформонезалежність
-platform_desc=Gitea виконується на платформі, для якої можливо скомпілювати <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go</a>: Windows, macOS, Linux, ARM, та інших. Оберіть ту, яка вам до вподоби!
+platform_desc=Gitea виконується на платформі, для якої можливо скомпілювати <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go</a>: Windows, macOS, Linux, ARM, та інших. Оберіть ту, яка вам до вподоби!
 lightweight=Невибагливість
 lightweight_desc=Gitea має низькі вимоги до ресурсів та може працювати на недорогому Raspberry Pi. Збережіть свою машину енергію!
 license=Відкритий вихідний код

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -184,7 +184,7 @@ app_desc=一款极易搭建的自助 Git 服务
 install=易安装
 install_desc=通过 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-binary">二进制</a> 来运行；或者通过 <a target="_blank" rel="noopener noreferrer" href="https://github.com/go-gitea/gitea/tree/master/docker">docker</a> 来运行；或者通过 <a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/installation/install-from-package">安装包</a> 来运行
 platform=跨平台
-platform_desc=任何 <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go 语言</a> 支持的平台都可以运行 Gitea，包括 Windows、Mac、Linux 以及 ARM。挑一个您喜欢的就行！
+platform_desc=任何 <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go 语言</a> 支持的平台都可以运行 Gitea，包括 Windows、Mac、Linux 以及 ARM。挑一个您喜欢的就行！
 lightweight=轻量级
 lightweight_desc=一个廉价的树莓派的配置足以满足 Gitea 的最低系统硬件要求。最大程度上节省您的服务器资源！
 license=开源化

--- a/options/locale/locale_zh-TW.ini
+++ b/options/locale/locale_zh-TW.ini
@@ -167,7 +167,7 @@ network_error=網路錯誤
 app_desc=一套極易架設的 Git 服務
 install=安裝容易
 platform=跨平台
-platform_desc=Gitea 可以在所有能編譯 <a target="_blank" rel="noopener noreferrer" href="http://golang.org/">Go 語言</a>的平台上執行: Windows, macOS, Linux, ARM 等等。挑一個您喜歡的吧！
+platform_desc=Gitea 可以在所有能編譯 <a target="_blank" rel="noopener noreferrer" href="https://go.dev/">Go 語言</a>的平台上執行: Windows, macOS, Linux, ARM 等等。挑一個您喜歡的吧！
 lightweight=輕量級
 lightweight_desc=一片便宜的 Raspberry Pi 就可以滿足 Gitea 的最低需求。節省您的機器資源！
 license=開放原始碼


### PR DESCRIPTION
The link http://golang.org uses the insecure HTTP protocol and currently automatically redirects to https://go.dev - there is no reason to maintain that link.
