### PR TITLE
Fix account deletion for users without passwords

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -909,6 +909,7 @@ repos_none = You do not own any repositories.
 
 delete_account = Delete Your Account
 delete_prompt = This operation will permanently delete your user account. It <strong>CANNOT</strong> be undone.
+delete_no_password = You must set a password before you can delete your account.
 delete_with_all_comments = Your account is younger than %s. To avoid ghost comments, all issue/PR comments will be deleted with it.
 confirm_delete_account = Confirm Deletion
 delete_account_title = Delete User Account

--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -133,11 +133,16 @@
 		</h4>
 		<div class="ui attached error segment">
 			<div class="ui red message">
+				{{if .SignedUser.IsPasswordSet}}
 				<p class="text left">{{svg "octicon-alert"}} {{ctx.Locale.Tr "settings.delete_prompt" | Str2html}}</p>
 				{{if .UserDeleteWithComments}}
 				<p class="text left gt-font-semibold">{{ctx.Locale.Tr "settings.delete_with_all_comments" .UserDeleteWithCommentsMaxTime | Str2html}}</p>
 				{{end}}
+				{{else}}
+				<p class="text left">{{svg "octicon-alert"}} {{ctx.Locale.Tr "settings.delete_no_password"}}</p>
+				{{end}}
 			</div>
+			{{if .SignedUser.IsPasswordSet}}
 			<form class="ui form ignore-dirty" id="delete-form" action="{{AppSubUrl}}/user/settings/account/delete" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
@@ -151,6 +156,7 @@
 					</button>
 				</div>
 			</form>
+			{{end}}
 		</div>
 	</div>
 


### PR DESCRIPTION
Hides the password input of the account deletion form if the user does not have a password (i.e. they registered with OAuth or similar and never set a password) and puts a note saying that they must create a password before being able to delete their account.

Before:
![image](https://github.com/go-gitea/gitea/assets/29505620/df1090e5-c5cf-413f-a4fe-10917361bc36)
(with a 500 error after attempting to confirm deletion)

After:
![image](https://github.com/go-gitea/gitea/assets/29505620/96b117a2-3281-40da-919c-a7587f8678c7)

Closes #18329.