### PR TITLE
Make loading animation less aggressive

### DIFF
--- a/web_src/css/modules/animations.css
+++ b/web_src/css/modules/animations.css
@@ -22,7 +22,7 @@
   height: min(4em, 66.6%);
   aspect-ratio: 1;
   transform: translate(-50%, -50%);
-  animation: isloadingspin 500ms infinite linear;
+  animation: isloadingspin 1000ms infinite linear;
   border-width: 4px;
   border-style: solid;
   border-color: var(--color-secondary) var(--color-secondary) var(--color-secondary-dark-8) var(--color-secondary-dark-8);


### PR DESCRIPTION
The current animation loops in a very fast manner, causing a slight feeling of uncomfortableness. This change slows it a bit for a smoother experience.

# Before

![before](https://github.com/go-gitea/gitea/assets/20454870/215a722d-feb4-4643-819d-c37a620c5e48)

# After

![after](https://github.com/go-gitea/gitea/assets/20454870/7acb1fab-9157-4f4d-8cc7-45fea0234b47)
