### PR TITLE
Fix bug for generated repository object format

### DIFF
--- a/modules/repository/generate.go
+++ b/modules/repository/generate.go
@@ -224,8 +224,7 @@ func generateRepoCommit(ctx context.Context, repo, templateRepo, generateRepo *r
 		}
 	}
 
-	// FIXME: fix the hash
-	if err := git.InitRepository(ctx, tmpDir, false, git.Sha1ObjectFormat.Name()); err != nil {
+	if err := git.InitRepository(ctx, tmpDir, false, templateRepo.ObjectFormatName); err != nil {
 		return err
 	}
 
@@ -327,18 +326,19 @@ func (gro GenerateRepoOptions) IsValid() bool {
 // GenerateRepository generates a repository from a template
 func GenerateRepository(ctx context.Context, doer, owner *user_model.User, templateRepo *repo_model.Repository, opts GenerateRepoOptions) (_ *repo_model.Repository, err error) {
 	generateRepo := &repo_model.Repository{
-		OwnerID:       owner.ID,
-		Owner:         owner,
-		OwnerName:     owner.Name,
-		Name:          opts.Name,
-		LowerName:     strings.ToLower(opts.Name),
-		Description:   opts.Description,
-		DefaultBranch: opts.DefaultBranch,
-		IsPrivate:     opts.Private,
-		IsEmpty:       !opts.GitContent || templateRepo.IsEmpty,
-		IsFsckEnabled: templateRepo.IsFsckEnabled,
-		TemplateID:    templateRepo.ID,
-		TrustModel:    templateRepo.TrustModel,
+		OwnerID:          owner.ID,
+		Owner:            owner,
+		OwnerName:        owner.Name,
+		Name:             opts.Name,
+		LowerName:        strings.ToLower(opts.Name),
+		Description:      opts.Description,
+		DefaultBranch:    opts.DefaultBranch,
+		IsPrivate:        opts.Private,
+		IsEmpty:          !opts.GitContent || templateRepo.IsEmpty,
+		IsFsckEnabled:    templateRepo.IsFsckEnabled,
+		TemplateID:       templateRepo.ID,
+		TrustModel:       templateRepo.TrustModel,
+		ObjectFormatName: templateRepo.ObjectFormatName,
 	}
 
 	if err = CreateRepositoryByExample(ctx, doer, owner, generateRepo, false, false); err != nil {
@@ -358,8 +358,7 @@ func GenerateRepository(ctx context.Context, doer, owner *user_model.User, templ
 		}
 	}
 
-	// FIXME - fix the hash
-	if err = CheckInitRepository(ctx, owner.Name, generateRepo.Name, git.Sha1ObjectFormat.Name()); err != nil {
+	if err = CheckInitRepository(ctx, owner.Name, generateRepo.Name, generateRepo.ObjectFormatName); err != nil {
 		return generateRepo, err
 	}
 


### PR DESCRIPTION
A repository generated from a template repository should have the same git ObjectFormat.