### PR TITLE
Add a id on body tag for every go template render page so that javascript function can init quicker

### DIFF
--- a/modules/context/context_response.go
+++ b/modules/context/context_response.go
@@ -71,6 +71,7 @@ func (ctx *Context) HTML(status int, name base.TplName) {
 	if !setting.IsProd {
 		ctx.Data["TemplateName"] = name
 	}
+	ctx.Data["PageID"] = strings.Replace(string(name), "/", "-", -1)
 	ctx.Data["TemplateLoadTimes"] = func() string {
 		return strconv.FormatInt(time.Since(tmplStartTime).Nanoseconds()/1e6, 10) + "ms"
 	}

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -29,7 +29,7 @@
 	{{template "base/head_style" .}}
 	{{template "custom/header" .}}
 </head>
-<body>
+<body{{if .PageID}} id="{{.PageID}}"{{end}}>
 	{{ctx.DataRaceCheck $.Context}}
 	{{template "custom/body_outer_pre" .}}
 

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -28,7 +28,6 @@ import {initIssueView} from './pages/issue/view.js';
 import {initIssueNew} from './pages/issue/new.js';
 import {
   initRepoIssueReferenceRepositorySearch,
-  initRepoIssueWipTitle,
   initRepoPullRequestMergeInstruction,
   initRepoPullRequestAllowMaintainerEdit,
   initRepoPullRequestReview, initArchivedLabelHandler,
@@ -155,7 +154,6 @@ onDomReady(() => {
   initRepoIssueList();
   initArchivedLabelHandler();
   initRepoIssueReferenceRepositorySearch();
-  initRepoIssueWipTitle();
   initRepoMigration();
   initRepoMigrationStatusChecker();
   initRepoProject();

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -24,14 +24,14 @@ import {initCommentContent, initMarkupContent} from './markup/content.js';
 import {initPdfViewer} from './render/pdf.js';
 
 import {initUserAuthLinkAccountView, initUserAuthOauth2} from './features/user-auth.js';
+import {initIssueView} from './pages/issue/view.js';
+import {initIssueNew} from './pages/issue/new.js';
 import {
-  initRepoIssueDue,
   initRepoIssueReferenceRepositorySearch,
-  initRepoIssueTimeTracking,
   initRepoIssueWipTitle,
   initRepoPullRequestMergeInstruction,
   initRepoPullRequestAllowMaintainerEdit,
-  initRepoPullRequestReview, initRepoIssueSidebarList, initArchivedLabelHandler,
+  initRepoPullRequestReview, initArchivedLabelHandler,
 } from './features/repo-issue.js';
 import {
   initRepoEllipsisButton,
@@ -148,13 +148,13 @@ onDomReady(() => {
   initRepoCommitLastCommitLoader();
   initRepoEditor();
   initRepoGraphGit();
+
+  initIssueView();
+  initIssueNew();
   initRepoIssueContentHistory();
-  initRepoIssueDue();
   initRepoIssueList();
-  initRepoIssueSidebarList();
   initArchivedLabelHandler();
   initRepoIssueReferenceRepositorySearch();
-  initRepoIssueTimeTracking();
   initRepoIssueWipTitle();
   initRepoMigration();
   initRepoMigrationStatusChecker();

--- a/web_src/js/pages/issue/new.js
+++ b/web_src/js/pages/issue/new.js
@@ -1,0 +1,11 @@
+import {
+  initRepoIssueWipTitle,
+} from '../../features/repo-issue.js';
+
+export function initIssueNew() {
+  if (!document.querySelector('#repo-issue-new')) {
+    return
+  }
+
+  initRepoIssueWipTitle();
+}

--- a/web_src/js/pages/issue/view.js
+++ b/web_src/js/pages/issue/view.js
@@ -1,0 +1,15 @@
+import {
+  initRepoIssueDue,
+  initRepoIssueTimeTracking,
+  initRepoIssueSidebarList,
+} from '../../features/repo-issue.js';
+
+export function initIssueView() {
+  if (!document.querySelector('#repo-issue-view')) {
+    return
+  }
+
+  initRepoIssueDue();
+  initRepoIssueTimeTracking();
+  initRepoIssueSidebarList();
+}


### PR DESCRIPTION
# Purpose

Since more and more javascript functions need to check whether current page have the special class or id, it will become copmlex to manage them and there is a potential necessary cpu usage.

# How do this PR work

This PR introduced a id attribute on body HTML tag for every go template render page. So it just need to check the id to conclude whether it's the right page and do or not the initlizing.