### PR TITLE
Don't load entire page when switching tabs in repo

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -13,7 +13,9 @@
 
 	{{template "base/footer_content" .}}
 
+	{{if not (index $.Context.Base.Req.Header "Hx-Boosted")}}
 	<script src="{{AssetUrlPrefix}}/js/index.js?v={{AssetVersion}}" onerror="alert('Failed to load asset files from ' + this.src + '. Please make sure the asset files can be accessed.')"></script>
+	{{end}}
 
 	{{template "custom/footer" .}}
 	{{ctx.DataRaceCheck $.Context}}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -156,7 +156,7 @@
 {{end}}
 	<div class="ui container secondary pointing tabular top attached borderless menu new-menu navbar">
 		{{if not (or .Repository.IsBeingCreated .Repository.IsBroken)}}
-			<div class="new-menu-inner">
+			<div hx-boost="true" hx-push-url="true" class="new-menu-inner">
 				{{if .Permission.CanRead $.UnitTypeCode}}
 				<a class="{{if .PageIsViewCode}}active {{end}}item" href="{{.RepoLink}}{{if and (ne .BranchName .Repository.DefaultBranch) (not $.PageIsWiki)}}/src/{{.BranchNameSubURL}}{{end}}">
 					{{svg "octicon-code"}} {{ctx.Locale.Tr "repo.code"}}


### PR DESCRIPTION
This is (as of now a failed) attempt at using `hx-boost` to make the tab-switching experience more pleasant. `hx-boost` takes normal anchor tags and issues an AJAX request instead, grabs the body of the response HTML, and replaces the body in the DOM. It doesn't reprocess the `<head>` so we save time on loading styles and javascript.

The problem I am facing is our index.js initialization. It's at the bottom of our `<body>` so it gets executed twice. When it does, I get the following error:
![image](https://github.com/go-gitea/gitea/assets/20454870/1355db4d-8f12-4fee-bf56-922a1647ba0b)

If I disable the `index.js` on boosted requests with
```
{{if not (index $.Context.Base.Req.Header "Hx-Boosted")}}
<script src="{{AssetUrlPrefix}}/js/index.js?v={{AssetVersion}}"></script>
{{end}}
```
the page loses some functionality such as clicking the avatar and getting a dropdown.

Why is `index.js` imported in the body and not in the head?

BTW this is how it looks

#### Before, look at the avatars jumping
![before](https://github.com/go-gitea/gitea/assets/20454870/488be5c1-c07c-4547-b404-e1372898eecc)

#### After, reactive buttons, the avatars are not jumping
![after](https://github.com/go-gitea/gitea/assets/20454870/525d1e0f-efb1-433c-8c95-34fc2ae6d441)
