### PR TITLE
Update dorny/paths-filter action

### DIFF
--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -35,7 +35,7 @@ jobs:
       yaml: ${{ steps.changes.outputs.yaml }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |


### PR DESCRIPTION
Bump to [v3.0.0](https://github.com/dorny/paths-filter/releases/tag/v3.0.0). Requires Node 20 but other actions in use also already do as well.