### PR TITLE
Fix incorrect button CSS usages

### DIFF
--- a/templates/repo/settings/lfs_file.tmpl
+++ b/templates/repo/settings/lfs_file.tmpl
@@ -33,7 +33,7 @@
 							{{else if .IsPDFFile}}
 								<div class="pdf-content is-loading" data-src="{{$.RawFileLink}}" data-fallback-button-text="{{ctx.Locale.Tr "diff.view_file"}}"></div>
 							{{else}}
-								<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{ctx.Locale.Tr "repo.file_view_raw"}}</a>
+								<a href="{{$.RawFileLink}}" rel="nofollow">{{ctx.Locale.Tr "repo.file_view_raw"}}</a>
 							{{end}}
 						</div>
 					{{else if .FileSize}}

--- a/templates/repo/unicode_escape_prompt.tmpl
+++ b/templates/repo/unicode_escape_prompt.tmpl
@@ -1,7 +1,7 @@
 {{if .EscapeStatus}}
 	{{if .EscapeStatus.HasInvisible}}
 		<div class="ui warning message unicode-escape-prompt gt-text-left">
-			<button class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
+			<button class="btn close icon hide-panel" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
 			<div class="header">
 				{{ctx.Locale.Tr "repo.invisible_runes_header"}}
 			</div>
@@ -12,7 +12,7 @@
 		</div>
 	{{else if .EscapeStatus.HasAmbiguous}}
 		<div class="ui warning message unicode-escape-prompt gt-text-left">
-			<button class="close icon hide-panel button" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
+			<button class="btn close icon hide-panel" data-panel-closest=".message">{{svg "octicon-x" 16 "close inside"}}</button>
 			<div class="header">
 				{{ctx.Locale.Tr "repo.ambiguous_runes_header"}}
 			</div>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -108,7 +108,7 @@
 					{{else if .IsPDFFile}}
 						<div class="pdf-content is-loading" data-src="{{$.RawFileLink}}" data-fallback-button-text="{{ctx.Locale.Tr "repo.diff.view_file"}}"></div>
 					{{else}}
-						<a href="{{$.RawFileLink}}" rel="nofollow" class="btn btn-gray btn-radius">{{ctx.Locale.Tr "repo.file_view_raw"}}</a>
+						<a href="{{$.RawFileLink}}" rel="nofollow">{{ctx.Locale.Tr "repo.file_view_raw"}}</a>
 					{{end}}
 				</div>
 			{{else if .FileSize}}


### PR DESCRIPTION
Fix 2 problems:

1. Remove the legacy (non-existing) CSS: `class="btn btn-gray btn-radius"`
2. Remove the button styles inside the `ui message`, according to: https://fomantic-ui.com/collections/message.html , the button shouldn't have any border/padding.

### Before

![image](https://github.com/go-gitea/gitea/assets/2114189/4c7e98e2-4e8a-493f-9b7e-446a365066a1)


![image](https://github.com/go-gitea/gitea/assets/2114189/05221251-7a79-4c96-8973-fb4588275672)

### After


![image](https://github.com/go-gitea/gitea/assets/2114189/8bc3edbc-42a6-40bd-85fd-de40e94841d4)

![image](https://github.com/go-gitea/gitea/assets/2114189/93f69143-d835-437c-b5eb-0f6dddde97a1)