### PR TITLE
Strip trailing newline in markdown code copy

### DIFF
--- a/web_src/js/markup/codecopy.js
+++ b/web_src/js/markup/codecopy.js
@@ -12,6 +12,7 @@ export function renderCodeCopy() {
   if (!els.length) return;
 
   for (const el of els) {
+    if (!el.textContent) continue;
     const btn = makeCodeCopyButton();
     // remove final trailing newline introduced during HTML rendering
     btn.setAttribute('data-clipboard-text', el.textContent.replace(/\r?\n$/, ''));

--- a/web_src/js/markup/codecopy.js
+++ b/web_src/js/markup/codecopy.js
@@ -13,7 +13,8 @@ export function renderCodeCopy() {
 
   for (const el of els) {
     const btn = makeCodeCopyButton();
-    btn.setAttribute('data-clipboard-text', el.textContent);
+    // remove final trailing newline introduced during HTML rendering
+    btn.setAttribute('data-clipboard-text', el.textContent.replace(/\r?\n$/, ''));
     el.after(btn);
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/29012

Behaviour now matches GH. Safeguard added in the for loop because `textContent` may be null in which case it does not make sense to render the copy button.