### PR TITLE
Wrap contained tags and branches again

### DIFF
--- a/templates/repo/commit_load_branches_and_tags.tmpl
+++ b/templates/repo/commit_load_branches_and_tags.tmpl
@@ -9,11 +9,11 @@
 		<div>{{ctx.Locale.Tr "repo.commit.contained_in"}}</div>
 		<div class="gt-df gt-mt-3">
 			<div class="gt-p-2">{{svg "octicon-git-branch"}}</div>
-			<div class="branch-area flex-text-block gt-f1"></div>
+			<div class="branch-area flex-text-block gt-fw gt-f1"></div>
 		</div>
 		<div class="gt-df gt-mt-3">
 			<div class="gt-p-2">{{svg "octicon-tag"}}</div>
-			<div class="tag-area flex-text-block gt-f1"></div>
+			<div class="tag-area flex-text-block gt-fw gt-f1"></div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Fixes #29016

## After

![grafik](https://github.com/go-gitea/gitea/assets/51889757/2c72ee8f-439e-4328-85df-77772e0f4aef)

