### PR TITLE
Pass es2020 to esbuild-loader as well

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,7 +135,7 @@ export default {
             loader: 'esbuild-loader',
             options: {
               loader: 'js',
-              target: 'es2015',
+              target: 'es2020',
             },
           },
         ],


### PR DESCRIPTION
Followup https://github.com/go-gitea/gitea/pull/28977. I forgot to pass the updated option to esbuild-loader, e.g. previously it was only passed to the minifier.