### PR TITLE
Fix missing link on outgoing new release notifications

### DIFF
--- a/services/mailer/mail_release.go
+++ b/services/mailer/mail_release.go
@@ -74,6 +74,7 @@ func mailNewRelease(ctx context.Context, lang string, tos []string, rel *repo_mo
 		"Release":  rel,
 		"Subject":  subject,
 		"Language": locale.Language(),
+		"Link":     rel.HTMLURL(),
 	}
 
 	var mailBody bytes.Buffer


### PR DESCRIPTION
Outgoing new release e-mail notifications were missing links to the actual release. An example from Codeberg.org e-mail:

    <a href=3D"">View it on Codeberg.org</a>.<br/>

This PR adds `"Link"` context property pointing to the release on the web interface.

The change was tested using `[mailer] PROTOCOL=dummy`.
