### PR TITLE
Fix incorrect link to swift doc and swift package-registry login command

### DIFF
--- a/docs/content/usage/packages/overview.en-us.md
+++ b/docs/content/usage/packages/overview.en-us.md
@@ -42,7 +42,7 @@ The following package managers are currently supported:
 | [PyPI](usage/packages/pypi.md) | Python | `pip`, `twine` |
 | [RPM](usage/packages/rpm.md) | - | `yum`, `dnf`, `zypper` |
 | [RubyGems](usage/packages/rubygems.md) | Ruby | `gem`, `Bundler` |
-| [Swift](usage/packages/rubygems.md) | Swift | `swift` |
+| [Swift](usage/packages/swift.md) | Swift | `swift` |
 | [Vagrant](usage/packages/vagrant.md) | - | `vagrant` |
 
 **The following paragraphs only apply if Packages are not globally disabled!**

--- a/docs/content/usage/packages/swift.en-us.md
+++ b/docs/content/usage/packages/swift.en-us.md
@@ -26,7 +26,8 @@ To work with the Swift package registry, you need to use [swift](https://www.swi
 To register the package registry and provide credentials, execute:
 
 ```shell
-swift package-registry set https://gitea.example.com/api/packages/{owner}/swift -login {username} -password {password}
+swift package-registry set https://gitea.example.com/api/packages/{owner}/swift
+swift package-registry login https://gitea.example.com/api/packages/{owner}/swift --username {username} --password {password}
 ```
 
 | Placeholder  | Description |


### PR DESCRIPTION
Fixes a few mistakes in the Swift package registry documentation.

Syntax for the `package-registry login` command can be found [here](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageRegistry/PackageRegistryUsage.md#registry-authentication). I was not sure the best way to compress all of that information, so I just focused on making sure the incorrect `package-registry set` command was fixed.
