### PR TITLE
Use defaults browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,6 @@
     "vitest": "1.2.2"
   },
   "browserslist": [
-    "defaults",
-    "not ie > 0",
-    "not ie_mob > 0"
+    "defaults"
   ]
 }


### PR DESCRIPTION
IE usage has dropped enough to not be included in the defaults browserslist anymore as per https://browsersl.ist/#q=defaults, so we can use the defaults now.
