### PR TITLE
Make blockquote border size less aggressive

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -270,7 +270,7 @@
   margin-left: 0;
   padding: 0 15px;
   color: var(--color-text-light-2);
-  border-left: 4px solid var(--color-secondary);
+  border-left: 0.25em solid var(--color-secondary);
 }
 
 .markup blockquote > :first-child {


### PR DESCRIPTION
It's too thick

I made it match GitHub's size

# Before

![image](https://github.com/go-gitea/gitea/assets/20454870/08c05004-acd9-485e-9219-110d93fe1226)

# After

![image](https://github.com/go-gitea/gitea/assets/20454870/e2e32b6c-4ba8-488e-9405-95d33f80adf7)

