### PR TITLE
Remove obsolete border-radius on comment content

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2289,10 +2289,6 @@
   padding: 1em;
 }
 
-.comment-body .markup {
-  border-radius: 0 0 var(--border-radius) var(--border-radius); /* don't render outside box */
-}
-
 .edit-label.modal .form .column,
 .new-label.modal .form .column {
   padding-right: 0;


### PR DESCRIPTION
This border-radius is obsolete since we changed the comment rendering a few months ago and it caused incorrect display on blockquotes.

Before:
<img width="160" alt="Screenshot 2024-02-10 at 18 42 48" src="https://github.com/go-gitea/gitea/assets/115237/ccbf4660-acf9-4268-aad9-1ad49d317a67">

After:
<img width="135" alt="Screenshot 2024-02-10 at 18 42 40" src="https://github.com/go-gitea/gitea/assets/115237/6f588e02-3b2a-49ee-b459-81d8068b2f4e">

