### PR TITLE
Use Markdown alert syntax for notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ More info: https://docs.gitea.com/installation/install-from-source
 
     ./gitea web
 
-NOTE: If you're interested in using our APIs, we have experimental
-support with [documentation](https://try.gitea.io/api/swagger).
+> [!NOTE]
+> If you're interested in using our APIs, we have experimental support with [documentation](https://try.gitea.io/api/swagger).
 
 ## Contributing
 
 Expected workflow is: Fork -> Patch -> Push -> Pull Request
 
-NOTES:
-
-1. **YOU MUST READ THE [CONTRIBUTORS GUIDE](CONTRIBUTING.md) BEFORE STARTING TO WORK ON A PULL REQUEST.**
-2. If you have found a vulnerability in the project, please write privately to **security@gitea.io**. Thanks!
+> [!NOTE]
+>
+> 1. **YOU MUST READ THE [CONTRIBUTORS GUIDE](CONTRIBUTING.md) BEFORE STARTING TO WORK ON A PULL REQUEST.**
+> 2. If you have found a vulnerability in the project, please write privately to **security@gitea.io**. Thanks!
 
 ## Translating
 


### PR DESCRIPTION
- It looks nicer
- This syntax is supported on both GitHub and Gitea

# Before

![image](https://github.com/go-gitea/gitea/assets/20454870/9a6953f6-7040-47ca-8305-2b94c86341ca)

# After

![image](https://github.com/go-gitea/gitea/assets/20454870/40d55787-fa1d-4a78-ba48-6f20db13c9bf)
