### PR TITLE
Advertise WebAuthn support

### DIFF
--- a/routers/web/passkey.go
+++ b/routers/web/passkey.go
@@ -11,14 +11,15 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 )
 
-type passkeyEndpoints struct {
+type passkeyEndpointsType struct {
 	Enroll string `json:"enroll"`
 	Manage string `json:"manage"`
 }
 
-func PasskeyEndpoints(ctx *context.Context) {
-	ctx.JSON(http.StatusOK, passkeyEndpoints{
-		Enroll: path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security"),
-		Manage: path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security"),
+func passkeyEndpoints(ctx *context.Context) {
+	url := path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security")
+	ctx.JSON(http.StatusOK, passkeyEndpointsType{
+		Enroll: url,
+		Manage: url,
 	})
 }

--- a/routers/web/passkey.go
+++ b/routers/web/passkey.go
@@ -1,0 +1,24 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package web
+
+import (
+	"net/http"
+	"path"
+
+	"code.gitea.io/gitea/modules/context"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+type passkeyEndpoints struct {
+	Enroll string `json:"enroll"`
+	Manage string `json:"manage"`
+}
+
+func PasskeyEndpoints(ctx *context.Context) {
+	ctx.JSON(http.StatusOK, passkeyEndpoints{
+		Enroll: path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security"),
+		Manage: path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security"),
+	})
+}

--- a/routers/web/passkey.go
+++ b/routers/web/passkey.go
@@ -5,7 +5,6 @@ package web
 
 import (
 	"net/http"
-	"path"
 
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/setting"

--- a/routers/web/passkey.go
+++ b/routers/web/passkey.go
@@ -17,7 +17,7 @@ type passkeyEndpointsType struct {
 }
 
 func passkeyEndpoints(ctx *context.Context) {
-	url := path.Join(setting.AppURL, "user/settings/security")
+	url := setting.AppURL + "user/settings/security"
 	ctx.JSON(http.StatusOK, passkeyEndpointsType{
 		Enroll: url,
 		Manage: url,

--- a/routers/web/passkey.go
+++ b/routers/web/passkey.go
@@ -17,7 +17,7 @@ type passkeyEndpointsType struct {
 }
 
 func passkeyEndpoints(ctx *context.Context) {
-	url := path.Join(setting.AppURL, setting.AppSubURL, "user/settings/security")
+	url := path.Join(setting.AppURL, "user/settings/security")
 	ctx.JSON(http.StatusOK, passkeyEndpointsType{
 		Enroll: url,
 		Manage: url,

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -473,7 +473,7 @@ func registerRoutes(m *web.Route) {
 		m.Get("/change-password", func(ctx *context.Context) {
 			ctx.Redirect(setting.AppSubURL + "/user/settings/account")
 		})
-		m.Get("/passkey-endpoints", PasskeyEndpoints)
+		m.Get("/passkey-endpoints", passkeyEndpoints)
 		m.Methods("GET, HEAD", "/*", public.FileHandlerFunc())
 	}, optionsCorsHandler())
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -473,6 +473,7 @@ func registerRoutes(m *web.Route) {
 		m.Get("/change-password", func(ctx *context.Context) {
 			ctx.Redirect(setting.AppSubURL + "/user/settings/account")
 		})
+		m.Get("/passkey-endpoints", PasskeyEndpoints)
 		m.Methods("GET, HEAD", "/*", public.FileHandlerFunc())
 	}, optionsCorsHandler())
 


### PR DESCRIPTION
This well-known indicates for password manager, that passkeys are supported.

source: https://android-developers.googleblog.com/2023/10/make-passkey-endpoints-well-known-url-part-of-your-passkey-implementation.html

spec: https://github.com/ms-id-standards/MSIdentityStandardsExplainers/blob/main/PasskeyEndpointsWellKnownUrl/explainer.md