### PR TITLE
Apply Webpack processing for custom UI themes

### DIFF
--- a/docs/content/administration/customizing-gitea.en-us.md
+++ b/docs/content/administration/customizing-gitea.en-us.md
@@ -379,7 +379,7 @@ The list of themes a user can choose from can be configured with the `THEMES` va
 
 To make a custom theme available to all users:
 
-1. Add a CSS file to `$GITEA_CUSTOM/public/assets/css/theme-<theme-name>.css`.
+1. Add a CSS file to `$GITEA_CUSTOM/web_src/css/themes/theme-<theme-name>.css`.
   The value of `$GITEA_CUSTOM` of your instance can be queried by calling `gitea help` and looking up the value of "CustomPath".
 2. Add `<theme-name>` to the comma-separated list of setting `THEMES` in `app.ini`
 

--- a/docs/content/help/faq.en-us.md
+++ b/docs/content/help/faq.en-us.md
@@ -185,7 +185,7 @@ To add your own theme, currently the only way is to provide a complete theme (no
 
 As an example, let's say our theme is `arc-blue` (this is a real theme, and can be found [in this issue](https://github.com/go-gitea/gitea/issues/6011))
 
-Name the `.css` file `theme-arc-blue.css` and add it to your custom folder in `custom/public/assets/css`
+Name the `.css` file `theme-arc-blue.css` and add it to your custom folder in `custom/web_src/css/themes`
 
 Allow users to use it by adding `arc-blue` to the list of `THEMES` in your `app.ini`
 

--- a/docs/content/help/faq.zh-cn.md
+++ b/docs/content/help/faq.zh-cn.md
@@ -189,7 +189,7 @@ Gitea 目前支持三个官方主题，分别是 `gitea-light`、`gitea-dark` �
 
 假设我们的主题是 `arc-blue`（这是一个真实的主题，可以在[此问题](https://github.com/go-gitea/gitea/issues/6011)中找到）
 
-将`.css`文件命名为`theme-arc-blue.css`并将其添加到`custom/public/assets/css`文件夹中
+将`.css`文件命名为`theme-arc-blue.css`并将其添加到`custom/web_src/css/themes`文件夹中
 
 通过将`arc-blue`添加到`app.ini`中的`THEMES`列表中，允许用户使用该主题
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ const glob = (pattern) => fastGlob.sync(pattern, {
 });
 
 const themes = {};
-for (const path of glob('web_src/css/themes/*.css')) {
+for (const path of glob('{web_src,custom/web_src}/css/themes/*.css')) {
   themes[parse(path).name] = [path];
 }
 


### PR DESCRIPTION
There is currently no way to use the Webpack capabilities in custom UI theme files.

For example, if we take as a basis a standard theme (`theme-gitea-light.css`) that has imports:
```
@import "../chroma/light.css";
@import "../codemirror/light.css";
```

For this to work, you will need to duplicate the imported files in `custom/public/assets/css`. Moreover they will not be minified and glued together because `import` will work as a standard CSS directive, and not be processed by webpack.

To make working with custom themes similar to built-in ones, I suggest processing them with webpack. Placing it in similar path as main static files (`custom/web_src`) will help to further unify the work with CSS, JS and Vue files (this will be in the next PRs).