### PR TITLE
Remove jQuery from SSH key form parser

### DIFF
--- a/web_src/js/features/sshkey-helper.js
+++ b/web_src/js/features/sshkey-helper.js
@@ -3,7 +3,7 @@ export function initSshKeyFormParser() {
   document.getElementById('ssh-key-content')?.addEventListener('input', function () {
     const arrays = this.value.split(' ');
     const title = document.getElementById('ssh-key-title');
-    if (title.value === '' && arrays.length === 3 && arrays[2] !== '') {
+    if (!title.value && arrays.length === 3 && arrays[2] !== '') {
       title.value = arrays[2];
     }
   });

--- a/web_src/js/features/sshkey-helper.js
+++ b/web_src/js/features/sshkey-helper.js
@@ -1,12 +1,10 @@
-import $ from 'jquery';
-
 export function initSshKeyFormParser() {
-// Parse SSH Key
-  $('#ssh-key-content').on('change paste keyup', function () {
-    const arrays = $(this).val().split(' ');
-    const $title = $('#ssh-key-title');
-    if ($title.val() === '' && arrays.length === 3 && arrays[2] !== '') {
-      $title.val(arrays[2]);
+  // Parse SSH Key
+  document.getElementById('ssh-key-content')?.addEventListener('input', function () {
+    const arrays = this.value.split(' ');
+    const title = document.getElementById('ssh-key-title');
+    if (title.value === '' && arrays.length === 3 && arrays[2] !== '') {
+      title.value = arrays[2];
     }
   });
 }


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the SSH key title functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/4785c13d-8d30-448e-b74a-263935e2769f)

