### PR TITLE
Remove jQuery from organization rename prompt toggle

### DIFF
--- a/web_src/js/features/common-organization.js
+++ b/web_src/js/features/common-organization.js
@@ -2,6 +2,10 @@ import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {toggleElem} from '../utils/dom.js';
 
 export function initCommonOrganization() {
+  if (document.querySelectorAll('.organization').length === 0) {
+    return;
+  }
+
   const orgNameInput = document.querySelector('.organization.settings.options #org_name');
   if (!orgNameInput) return;
   orgNameInput.addEventListener('input', function () {

--- a/web_src/js/features/common-organization.js
+++ b/web_src/js/features/common-organization.js
@@ -2,7 +2,7 @@ import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {toggleElem} from '../utils/dom.js';
 
 export function initCommonOrganization() {
-  if (!document.querySelectorAll('.organization')) {
+  if (document.querySelectorAll('.organization').length === 0) {
     return;
   }
 

--- a/web_src/js/features/common-organization.js
+++ b/web_src/js/features/common-organization.js
@@ -2,7 +2,7 @@ import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {toggleElem} from '../utils/dom.js';
 
 export function initCommonOrganization() {
-  if (document.querySelectorAll('.organization').length === 0) {
+  if (!document.querySelectorAll('.organization').length) {
     return;
   }
 

--- a/web_src/js/features/common-organization.js
+++ b/web_src/js/features/common-organization.js
@@ -1,14 +1,15 @@
-import $ from 'jquery';
 import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {toggleElem} from '../utils/dom.js';
 
 export function initCommonOrganization() {
-  if ($('.organization').length === 0) {
+  if (!document.querySelectorAll('.organization')) {
     return;
   }
 
-  $('.organization.settings.options #org_name').on('input', function () {
-    const nameChanged = $(this).val().toLowerCase() !== $(this).attr('data-org-name').toLowerCase();
+  const orgNameInput = document.querySelector('.organization.settings.options #org_name');
+  if (!orgNameInput) return;
+  orgNameInput.addEventListener('input', function () {
+    const nameChanged = this.value.toLowerCase() !== this.getAttribute('data-org-name').toLowerCase();
     toggleElem('#org-name-change-prompt', nameChanged);
   });
 

--- a/web_src/js/features/common-organization.js
+++ b/web_src/js/features/common-organization.js
@@ -2,10 +2,6 @@ import {initCompLabelEdit} from './comp/LabelEdit.js';
 import {toggleElem} from '../utils/dom.js';
 
 export function initCommonOrganization() {
-  if (document.querySelectorAll('.organization').length === 0) {
-    return;
-  }
-
   const orgNameInput = document.querySelector('.organization.settings.options #org_name');
   if (!orgNameInput) return;
   orgNameInput.addEventListener('input', function () {


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the organization rename prompt toggling functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/e6f641b0-aa46-4b85-9693-0d608cca855e)

