### PR TITLE
Remove jQuery from the "quick submit" handler

### DIFF
--- a/web_src/js/features/comp/QuickSubmit.js
+++ b/web_src/js/features/comp/QuickSubmit.js
@@ -6,14 +6,9 @@ export function handleGlobalEnterQuickSubmit(target) {
       return;
     }
 
-    if (form.classList.contains('form-fetch-action')) {
-      form.dispatchEvent(new SubmitEvent('submit', {bubbles: true, cancelable: true}));
-      return;
-    }
-
     // here use the event to trigger the submit event (instead of calling `submit()` method directly)
     // otherwise the `areYouSure` handler won't be executed, then there will be an annoying "confirm to leave" dialog
-    form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+    form.dispatchEvent(new SubmitEvent('submit', {bubbles: true, cancelable: true}));
   } else {
     // if no form, then the editor is for an AJAX request, dispatch an event to the target, let the target's event handler to do the AJAX request.
     // the 'ce-' prefix means this is a CustomEvent

--- a/web_src/js/features/comp/QuickSubmit.js
+++ b/web_src/js/features/comp/QuickSubmit.js
@@ -8,7 +8,7 @@ export function handleGlobalEnterQuickSubmit(target) {
 
     // here use the event to trigger the submit event (instead of calling `submit()` method directly)
     // otherwise the `areYouSure` handler won't be executed, then there will be an annoying "confirm to leave" dialog
-    form.dispatchEvent(new SubmitEvent('submit', {bubbles: true, cancelable: true}));
+    form.dispatchEvent(new SubmitEvent('submit'));
   } else {
     // if no form, then the editor is for an AJAX request, dispatch an event to the target, let the target's event handler to do the AJAX request.
     // the 'ce-' prefix means this is a CustomEvent

--- a/web_src/js/features/comp/QuickSubmit.js
+++ b/web_src/js/features/comp/QuickSubmit.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 export function handleGlobalEnterQuickSubmit(target) {
   const form = target.closest('form');
   if (form) {
@@ -15,7 +13,7 @@ export function handleGlobalEnterQuickSubmit(target) {
 
     // here use the event to trigger the submit event (instead of calling `submit()` method directly)
     // otherwise the `areYouSure` handler won't be executed, then there will be an annoying "confirm to leave" dialog
-    $(form).trigger('submit');
+    form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
   } else {
     // if no form, then the editor is for an AJAX request, dispatch an event to the target, let the target's event handler to do the AJAX request.
     // the 'ce-' prefix means this is a CustomEvent

--- a/web_src/js/features/comp/QuickSubmit.js
+++ b/web_src/js/features/comp/QuickSubmit.js
@@ -8,7 +8,7 @@ export function handleGlobalEnterQuickSubmit(target) {
 
     // here use the event to trigger the submit event (instead of calling `submit()` method directly)
     // otherwise the `areYouSure` handler won't be executed, then there will be an annoying "confirm to leave" dialog
-    form.dispatchEvent(new SubmitEvent('submit'));
+    form.dispatchEvent(new SubmitEvent('submit', {bubbles: true, cancelable: true}));
   } else {
     // if no form, then the editor is for an AJAX request, dispatch an event to the target, let the target's event handler to do the AJAX request.
     // the 'ce-' prefix means this is a CustomEvent


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the quick submit functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/abbd6c49-ad0f-4f95-b4ba-e969b85a46e8)

