### PR TITLE
Remove jQuery from issue reference context popup attach

### DIFF
--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -1,11 +1,10 @@
-import $ from 'jquery';
 import {createApp} from 'vue';
 import ContextPopup from '../components/ContextPopup.vue';
 import {parseIssueHref} from '../utils.js';
 import {createTippy} from '../modules/tippy.js';
 
 export function initContextPopups() {
-  const refIssues = $('.ref-issue');
+  const refIssues = document.querySelectorAll('.ref-issue');
   attachRefIssueContextPopup(refIssues);
 }
 


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the context popup functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/1d2f173e-e626-4f7d-82c8-d1539d38d247)
