### PR TITLE
Load outdated comments when (un)resolving conversation on PR timeline (#29203)

### DIFF
--- a/routers/web/repo/pull_review.go
+++ b/routers/web/repo/pull_review.go
@@ -156,7 +156,8 @@ func UpdateResolveConversation(ctx *context.Context) {
 func renderConversation(ctx *context.Context, comment *issues_model.Comment, origin string) {
 	ctx.Data["PageIsPullFiles"] = origin == "diff"
 
-	comments, err := issues_model.FetchCodeCommentsByLine(ctx, comment.Issue, ctx.Doer, comment.TreePath, comment.Line, ctx.Data["ShowOutdatedComments"].(bool))
+	showOutdatedComments := origin == "timeline" || ctx.Data["ShowOutdatedComments"].(bool)
+	comments, err := issues_model.FetchCodeCommentsByLine(ctx, comment.Issue, ctx.Doer, comment.TreePath, comment.Line, showOutdatedComments)
 	if err != nil {
 		ctx.ServerError("FetchCodeCommentsByLine", err)
 		return

--- a/routers/web/repo/pull_review_test.go
+++ b/routers/web/repo/pull_review_test.go
@@ -68,9 +68,9 @@ func TestRenderConversation(t *testing.T) {
 		renderConversation(ctx, preparedComment, "timeline")
 		assert.Contains(t, resp.Body.String(), `<div id="code-comments-`)
 	})
-	run("timeline without outdated", func(t *testing.T, ctx *context.Context, resp *httptest.ResponseRecorder) {
+	run("timeline is not affected by ShowOutdatedComments=false", func(t *testing.T, ctx *context.Context, resp *httptest.ResponseRecorder) {
 		ctx.Data["ShowOutdatedComments"] = false
 		renderConversation(ctx, preparedComment, "timeline")
-		assert.Contains(t, resp.Body.String(), `conversation-not-existing`)
+		assert.Contains(t, resp.Body.String(), `<div id="code-comments-`)
 	})
 }


### PR DESCRIPTION
Backport #29203

Relates to #28654, #29039 and #29050.

The "show outdated comments" flag should only apply to the file diff view.
On the PR timeline, outdated comments are always shown. So they should also be loaded when (un)resolving a conversation on the timeline page.