### PR TITLE
Remove jQuery from the repo release form

### DIFF
--- a/web_src/js/features/repo-release.js
+++ b/web_src/js/features/repo-release.js
@@ -6,7 +6,7 @@ export function initRepoRelease() {
     if (e.target.matches('.remove-rel-attach')) {
       const uuid = e.target.getAttribute('data-uuid');
       const id = e.target.getAttribute('data-id');
-      document.querySelector(`input[name='attachment-del-${uuid}']`).value = true;
+      document.querySelector(`input[name='attachment-del-${uuid}']`).value = 'true';
       hideElem(`#attachment-${id}`);
     }
   });

--- a/web_src/js/features/repo-release.js
+++ b/web_src/js/features/repo-release.js
@@ -1,19 +1,19 @@
-import $ from 'jquery';
 import {hideElem, showElem} from '../utils/dom.js';
 import {initComboMarkdownEditor} from './comp/ComboMarkdownEditor.js';
 
 export function initRepoRelease() {
-  $(document).on('click', '.remove-rel-attach', function() {
-    const uuid = $(this).data('uuid');
-    const id = $(this).data('id');
-    $(`input[name='attachment-del-${uuid}']`).attr('value', true);
-    hideElem($(`#attachment-${id}`));
+  document.addEventListener('click', (e) => {
+    if (e.target.matches('.remove-rel-attach')) {
+      const uuid = e.target.getAttribute('data-uuid');
+      const id = e.target.getAttribute('data-id');
+      document.querySelector(`input[name='attachment-del-${uuid}']`).value = true;
+      hideElem(`#attachment-${id}`);
+    }
   });
 }
 
 export function initRepoReleaseNew() {
-  const $repoReleaseNew = $('.repository.new.release');
-  if (!$repoReleaseNew.length) return;
+  if (!document.querySelector('.repository.new.release')) return;
 
   initTagNameEditor();
   initRepoReleaseEditor();
@@ -45,9 +45,9 @@ function initTagNameEditor() {
 }
 
 function initRepoReleaseEditor() {
-  const $editor = $('.repository.new.release .combo-markdown-editor');
-  if ($editor.length === 0) {
+  const editor = document.querySelector('.repository.new.release .combo-markdown-editor');
+  if (!editor) {
     return;
   }
-  const _promise = initComboMarkdownEditor($editor);
+  initComboMarkdownEditor(editor);
 }


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the repo release form functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/ede2072a-823d-418f-9890-a5a7445a1cc6)

