### PR TITLE
Expire artifacts before deleting them physically

### DIFF
--- a/services/actions/cleanup.go
+++ b/services/actions/cleanup.go
@@ -35,12 +35,12 @@ func cleanExpiredArtifacts(taskCtx context.Context) error {
 	}
 	log.Info("Found %d expired artifacts", len(artifacts))
 	for _, artifact := range artifacts {
-		if err := storage.ActionsArtifacts.Delete(artifact.StoragePath); err != nil {
-			log.Error("Cannot delete artifact %d: %v", artifact.ID, err)
-			continue
-		}
 		if err := actions.SetArtifactExpired(taskCtx, artifact.ID); err != nil {
 			log.Error("Cannot set artifact %d expired: %v", artifact.ID, err)
+			continue
+		}
+		if err := storage.ActionsArtifacts.Delete(artifact.StoragePath); err != nil {
+			log.Error("Cannot delete artifact %d: %v", artifact.ID, err)
 			continue
 		}
 		log.Info("Artifact %d set expired", artifact.ID)
@@ -59,12 +59,12 @@ func cleanNeedDeleteArtifacts(taskCtx context.Context) error {
 		}
 		log.Info("Found %d artifacts pending deletion", len(artifacts))
 		for _, artifact := range artifacts {
-			if err := storage.ActionsArtifacts.Delete(artifact.StoragePath); err != nil {
-				log.Error("Cannot delete artifact %d: %v", artifact.ID, err)
-				continue
-			}
 			if err := actions.SetArtifactDeleted(taskCtx, artifact.ID); err != nil {
 				log.Error("Cannot set artifact %d deleted: %v", artifact.ID, err)
+				continue
+			}
+			if err := storage.ActionsArtifacts.Delete(artifact.StoragePath); err != nil {
+				log.Error("Cannot delete artifact %d: %v", artifact.ID, err)
 				continue
 			}
 			log.Info("Artifact %d set deleted", artifact.ID)


### PR DESCRIPTION
https://github.com/go-gitea/gitea/pull/27172#discussion_r1493735466

When cleanup artifacts, it removes storage first. If storage is not exist (maybe delete manually), it gets error and continue loop. It makes a dead loop if there are a lot pending but non-existing artifacts.

Now it updates db record at first to avoid keep a lot of pending status artifacts.