### PR TITLE
De-duplicate contributor graph translations

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1985,10 +1985,7 @@ contributors.contribution_type.filter_label = Contribution type:
 contributors.contribution_type.commits = Commits
 contributors.contribution_type.additions = Additions
 contributors.contribution_type.deletions = Deletions
-contributors.loading_title = Loading contributions...
-contributors.loading_title_failed = Could not load contributions
-contributors.loading_info = This might take a bit…
-contributors.component_failed_to_load = An unexpected error happened.
+contributors.what = contributions
 
 search = Search
 search.search_repo = Search repository
@@ -2592,6 +2589,12 @@ find_file.no_matching = No matching file found
 error.csv.too_large = Can't render this file because it is too large.
 error.csv.unexpected = Can't render this file because it contains an unexpected character in line %d and column %d.
 error.csv.invalid_field_count = Can't render this file because it has a wrong number of fields in line %d.
+
+[graphs]
+component_loading = Loading %s...
+component_loading_failed = Could not load %s
+component_loading_info = This might take a bit…
+component_failed_to_load = An unexpected error happened.
 
 [org]
 org_name_holder = Organization Name

--- a/templates/repo/contributors.tmpl
+++ b/templates/repo/contributors.tmpl
@@ -4,10 +4,10 @@
 		data-locale-contribution-type-commits="{{ctx.Locale.Tr "repo.contributors.contribution_type.commits"}}"
 		data-locale-contribution-type-additions="{{ctx.Locale.Tr "repo.contributors.contribution_type.additions"}}"
 		data-locale-contribution-type-deletions="{{ctx.Locale.Tr "repo.contributors.contribution_type.deletions"}}"
-		data-locale-loading-title="{{ctx.Locale.Tr "repo.contributors.loading_title"}}"
-		data-locale-loading-title-failed="{{ctx.Locale.Tr "repo.contributors.loading_title_failed"}}"
-		data-locale-loading-info="{{ctx.Locale.Tr "repo.contributors.loading_info"}}"
-		data-locale-component-failed-to-load="{{ctx.Locale.Tr "repo.contributors.component_failed_to_load"}}"
+		data-locale-loading-title="{{ctx.Locale.Tr "graphs.component_loading" (ctx.Locale.Tr "repo.contributors.what")}}"
+		data-locale-loading-title-failed="{{ctx.Locale.Tr "graphs.component_loading_failed" (ctx.Locale.Tr "repo.contributors.what")}}"
+		data-locale-loading-info="{{ctx.Locale.Tr "graphs.component_loading_info"}}"
+		data-locale-component-failed-to-load="{{ctx.Locale.Tr "graphs.component_failed_to_load"}}"
 	>
 	</div>
 {{end}}


### PR DESCRIPTION
I was using duplicate translations and @denyskon suggested to use `%s`'s in translations [in their review](https://github.com/go-gitea/gitea/pull/29191#discussion_r1493399445). I will make use of these translations in other PRs of mine (#29210 and #29191). If we want to include the two PRs I mentioned in v1.22, we should merge this asap.