### PR TITLE
Skip the content when object is unexpected in `git.Repository.getTree`(no go-git)

### DIFF
--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -58,6 +58,10 @@ func (repo *Repository) getTree(id ObjectID) (*Tree, error) {
 		tree.entriesParsed = true
 		return tree, nil
 	default:
+		_, err := rd.Discard(int(size))
+		if err != nil {
+			return nil, err
+		}
 		return nil, ErrNotExist{
 			ID: id.String(),
 		}


### PR DESCRIPTION
Fix #29101

`cat-file --batch` output format:
``` text
<sha> SP <type> SP <size> LF\n<content>
```
When object type is expected, the content will be handled, but when it is not expected, the content will not be handled, and will be read in the next turn.