### PR TITLE
Deduplicate translations for contributors graph

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1980,12 +1980,10 @@ activity.git_stats_and_deletions = and
 activity.git_stats_deletion_1 = %d deletion
 activity.git_stats_deletion_n = %d deletions
 
-contributors = Contributors
 contributors.contribution_type.filter_label = Contribution type:
 contributors.contribution_type.commits = Commits
 contributors.contribution_type.additions = Additions
 contributors.contribution_type.deletions = Deletions
-contributors.what = contributions
 
 search = Search
 search.search_repo = Search repository
@@ -2595,6 +2593,7 @@ component_loading = Loading %s...
 component_loading_failed = Could not load %s
 component_loading_info = This might take a bit…
 component_failed_to_load = An unexpected error happened.
+contributors.what = contributions
 
 [org]
 org_name_holder = Organization Name

--- a/routers/web/repo/contributors.go
+++ b/routers/web/repo/contributors.go
@@ -18,7 +18,7 @@ const (
 
 // Contributors render the page to show repository contributors graph
 func Contributors(ctx *context.Context) {
-	ctx.Data["Title"] = ctx.Tr("repo.contributors")
+	ctx.Data["Title"] = ctx.Tr("repo.activity.navbar.contributors")
 
 	ctx.Data["PageIsActivity"] = true
 	ctx.Data["PageIsContributors"] = true

--- a/templates/repo/contributors.tmpl
+++ b/templates/repo/contributors.tmpl
@@ -4,8 +4,8 @@
 		data-locale-contribution-type-commits="{{ctx.Locale.Tr "repo.contributors.contribution_type.commits"}}"
 		data-locale-contribution-type-additions="{{ctx.Locale.Tr "repo.contributors.contribution_type.additions"}}"
 		data-locale-contribution-type-deletions="{{ctx.Locale.Tr "repo.contributors.contribution_type.deletions"}}"
-		data-locale-loading-title="{{ctx.Locale.Tr "graphs.component_loading" (ctx.Locale.Tr "repo.contributors.what")}}"
-		data-locale-loading-title-failed="{{ctx.Locale.Tr "graphs.component_loading_failed" (ctx.Locale.Tr "repo.contributors.what")}}"
+		data-locale-loading-title="{{ctx.Locale.Tr "graphs.component_loading" (ctx.Locale.Tr "graphs.contributors.what")}}"
+		data-locale-loading-title-failed="{{ctx.Locale.Tr "graphs.component_loading_failed" (ctx.Locale.Tr "graphs.contributors.what")}}"
 		data-locale-loading-info="{{ctx.Locale.Tr "graphs.component_loading_info"}}"
 		data-locale-component-failed-to-load="{{ctx.Locale.Tr "graphs.component_failed_to_load"}}"
 	>


### PR DESCRIPTION
 I have implemented three graph pages ([contributors](https://github.com/go-gitea/gitea/pull/27882), [code frequency](https://github.com/go-gitea/gitea/pull/29191) and [recent commits](https://github.com/go-gitea/gitea/pull/29210)) and they have all same page title as the tab name so I decided to use same translations for them. This PR is for contributors graph. Other PR's have their own respective commits.