### PR TITLE
Do not show delete button when time tracker is disabled

### DIFF
--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -1,20 +1,18 @@
-{{if .ctxData.Repository.IsTimetrackerEnabled .ctxData.Context}}
-	{{if .comment.Time}} {{/* compatibility with time comments made before v1.14 */}}
-		{{if (not .comment.Time.Deleted)}}
-			{{if (or .ctxData.IsAdmin (and .ctxData.IsSigned (eq .ctxData.SignedUserID .comment.PosterID)))}}
-				<span class="gt-float-right">
-					<div class="ui mini modal issue-delete-time-modal" data-id="{{.comment.Time.ID}}">
-						<form method="post" class="delete-time-form" action="{{.ctxData.RepoLink}}/issues/{{.ctxData.Issue.Index}}/times/{{.comment.TimeID}}/delete">
-							{{.ctxData.CsrfTokenHtml}}
-						</form>
-						<div class="header">{{ctx.Locale.Tr "repo.issues.del_time"}}</div>
-						{{template "base/modal_actions_confirm"}}
-					</div>
-					<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.del_time"}}">
-						{{svg "octicon-trash"}}
-					</button>
-				</span>
-			{{end}}
+{{if and .comment.Time (.ctxData.Repository.IsTimetrackerEnabled ctx)}} {{/* compatibility with time comments made before v1.14 */}}
+	{{if (not .comment.Time.Deleted)}}
+		{{if (or .ctxData.IsAdmin (and .ctxData.IsSigned (eq .ctxData.SignedUserID .comment.PosterID)))}}
+			<span class="gt-float-right">
+				<div class="ui mini modal issue-delete-time-modal" data-id="{{.comment.Time.ID}}">
+					<form method="post" class="delete-time-form" action="{{.ctxData.RepoLink}}/issues/{{.ctxData.Issue.Index}}/times/{{.comment.TimeID}}/delete">
+						{{.ctxData.CsrfTokenHtml}}
+					</form>
+					<div class="header">{{ctx.Locale.Tr "repo.issues.del_time"}}</div>
+					{{template "base/modal_actions_confirm"}}
+				</div>
+				<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.del_time"}}">
+					{{svg "octicon-trash"}}
+				</button>
+			</span>
 		{{end}}
 	{{end}}
 {{end}}

--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -1,18 +1,20 @@
-{{if .comment.Time}} {{/* compatibility with time comments made before v1.14 */}}
-	{{if (not .comment.Time.Deleted)}}
-		{{if (or .ctxData.IsAdmin (and .ctxData.IsSigned (eq .ctxData.SignedUserID .comment.PosterID)))}}
-			<span class="gt-float-right">
-				<div class="ui mini modal issue-delete-time-modal" data-id="{{.comment.Time.ID}}">
-					<form method="post" class="delete-time-form" action="{{.ctxData.RepoLink}}/issues/{{.ctxData.Issue.Index}}/times/{{.comment.TimeID}}/delete">
-						{{.ctxData.CsrfTokenHtml}}
-					</form>
-					<div class="header">{{ctx.Locale.Tr "repo.issues.del_time"}}</div>
-					{{template "base/modal_actions_confirm"}}
-				</div>
-				<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.del_time"}}">
-					{{svg "octicon-trash"}}
-				</button>
-			</span>
+{{if .ctxData.Repository.IsTimetrackerEnabled .ctxData.Context}}
+	{{if .comment.Time}} {{/* compatibility with time comments made before v1.14 */}}
+		{{if (not .comment.Time.Deleted)}}
+			{{if (or .ctxData.IsAdmin (and .ctxData.IsSigned (eq .ctxData.SignedUserID .comment.PosterID)))}}
+				<span class="gt-float-right">
+					<div class="ui mini modal issue-delete-time-modal" data-id="{{.comment.Time.ID}}">
+						<form method="post" class="delete-time-form" action="{{.ctxData.RepoLink}}/issues/{{.ctxData.Issue.Index}}/times/{{.comment.TimeID}}/delete">
+							{{.ctxData.CsrfTokenHtml}}
+						</form>
+						<div class="header">{{ctx.Locale.Tr "repo.issues.del_time"}}</div>
+						{{template "base/modal_actions_confirm"}}
+					</div>
+					<button class="ui icon button compact mini issue-delete-time" data-id="{{.comment.Time.ID}}" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.del_time"}}">
+						{{svg "octicon-trash"}}
+					</button>
+				</span>
+			{{end}}
 		{{end}}
 	{{end}}
 {{end}}


### PR DESCRIPTION
Fix #29233

The delete button of time logs won't be shown when time tracker is disabled.

![image](https://github.com/go-gitea/gitea/assets/15528715/5cc4e0c9-d2f9-4b8f-a2f5-fe202b94c191)
