### PR TITLE
Remove DataRaceCheck

### DIFF
--- a/modules/context/context_template.go
+++ b/modules/context/context_template.go
@@ -5,10 +5,7 @@ package context
 
 import (
 	"context"
-	"errors"
 	"time"
-
-	"code.gitea.io/gitea/modules/log"
 )
 
 var _ context.Context = TemplateContext(nil)
@@ -35,15 +32,4 @@ func (c TemplateContext) Err() error {
 
 func (c TemplateContext) Value(key any) any {
 	return c.parentContext().Value(key)
-}
-
-// DataRaceCheck checks whether the template context function "ctx()" returns the consistent context
-// as the current template's rendering context (request context), to help to find data race issues as early as possible.
-// When the code is proven to be correct and stable, this function should be removed.
-func (c TemplateContext) DataRaceCheck(dataCtx context.Context) (string, error) {
-	if c.parentContext() != dataCtx {
-		log.Error("TemplateContext.DataRaceCheck: parent context mismatch\n%s", log.Stack(2))
-		return "", errors.New("parent context mismatch")
-	}
-	return "", nil
 }

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -16,6 +16,5 @@
 	<script src="{{AssetUrlPrefix}}/js/index.js?v={{AssetVersion}}" onerror="alert('Failed to load asset files from ' + this.src + '. Please make sure the asset files can be accessed.')"></script>
 
 	{{template "custom/footer" .}}
-	{{ctx.DataRaceCheck $.Context}}
 </body>
 </html>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -30,7 +30,6 @@
 	{{template "custom/header" .}}
 </head>
 <body hx-headers='{"x-csrf-token": "{{.CsrfToken}}"}' hx-swap="outerHTML" hx-ext="morph" hx-push-url="false">
-	{{ctx.DataRaceCheck $.Context}}
 	{{template "custom/body_outer_pre" .}}
 
 	<div class="full height">


### PR DESCRIPTION
Since #26254, it started using `{{ctx.Locale.Tr ...}}`

Now the `ctx` seems stable enough, so the check could be removed.