### PR TITLE
Fix content size does not match error when uploading lfs file

### DIFF
--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -408,7 +408,7 @@ func canReadFiles(r *context.Repository) bool {
 	return r.Permission.CanRead(unit.TypeCode)
 }
 
-func base64Reader(s string) (io.Reader, error) {
+func base64Reader(s string) (io.ReadSeeker, error) {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return nil, err

--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -40,7 +40,7 @@ type ChangeRepoFile struct {
 	Operation     string
 	TreePath      string
 	FromTreePath  string
-	ContentReader io.Reader
+	ContentReader io.ReadSeeker
 	SHA           string
 	Options       *RepoFileOptions
 }
@@ -448,6 +448,10 @@ func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file 
 			return err
 		}
 		if !exist {
+			_, err := file.ContentReader.Seek(0, io.SeekStart)
+			if err != nil {
+				return err
+			}
 			if err := contentStore.Put(lfsMetaObject.Pointer, file.ContentReader); err != nil {
 				if _, err2 := git_model.RemoveLFSMetaObjectByOid(ctx, repoID, lfsMetaObject.Oid); err2 != nil {
 					return fmt.Errorf("unable to remove failed inserted LFS object %s: %v (Prev Error: %w)", lfsMetaObject.Oid, err2, err)


### PR DESCRIPTION
![image](https://github.com/go-gitea/gitea/assets/38434877/cd726b4d-4771-4547-8aee-ae4e4b56b1d1)
When we update an lfs file by API `api/v1/repos/{owner}/{repo}/contents/{filepath}`, there will show an error 

```json
{
  "message": "Put \"http://localhost:9000/gitea/lfs/38/92/05904d6c7bb83fc676513911226f2be25bf1465616bb9b29587100ab1414\": readfrom tcp [::1]:57300->[::1]:9000: content size does not match",
  "url": "http://localhost:3000/api/swagger"
}
```

The reason of this error is  https://github.com/go-gitea/gitea/blob/main/services/repository/files/update.go, in this file, the `file.ContentReader` been used twice. So when use `file.ContentReader` in the second time, the `i` of this Reader has been updated to the length of the content. it will return 0 and an `io.EOF` error when we try to read cotent from this Reader.
