### PR TITLE
Do not use lower tag names to find releases/tags (#29261)

### DIFF
--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -315,18 +315,18 @@ func pushUpdateAddTags(ctx context.Context, repo *repo_model.Repository, gitRepo
 		return nil
 	}
 
-	lowerTags := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		lowerTags = append(lowerTags, strings.ToLower(tag))
-	}
-
-	releases, err := repo_model.GetReleasesByRepoIDAndNames(ctx, repo.ID, lowerTags)
+	releases, err := repo_model.GetReleasesByRepoIDAndNames(ctx, repo.ID, tags)
 	if err != nil {
 		return fmt.Errorf("GetReleasesByRepoIDAndNames: %w", err)
 	}
 	relMap := make(map[string]*repo_model.Release)
 	for _, rel := range releases {
 		relMap[rel.LowerTagName] = rel
+	}
+
+	lowerTags := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		lowerTags = append(lowerTags, strings.ToLower(tag))
 	}
 
 	newReleases := make([]*repo_model.Release, 0, len(lowerTags)-len(relMap))


### PR DESCRIPTION
Backport #29261.

Fix #26090, see https://github.com/go-gitea/gitea/issues/26090#issuecomment-1952013206

Since `TagName` stores the original tag name and `LowerTagName` stores the lower tag name, it doesn't make sense to use lowercase tags as `TagNames` in `FindReleasesOptions`.

https://github.com/go-gitea/gitea/blob/5e72526da4e915791f03af056890e16821bde052/services/repository/push.go#L396-L397

While the only other usage looks correct:

https://github.com/go-gitea/gitea/blob/5e72526da4e915791f03af056890e16821bde052/routers/web/repo/repo.go#L416

