### PR TITLE
Explained where create issue/PR template (#29035)

### DIFF
--- a/docs/content/usage/issue-pull-request-templates.en-us.md
+++ b/docs/content/usage/issue-pull-request-templates.en-us.md
@@ -22,7 +22,7 @@ when creating an issue or pull request. Gitea supports adding templates to the
 **default branch of the repository** so that they can autopopulate the form when users are
 creating issues and pull requests. This will cut down on the initial back and forth
 of getting some clarifying details.
-Is actually not possible to provide generic issue/pull-request templates for all instance.
+It is currently not possible to provide generic issue/pull-request templates globally.
 
 Additionally, the New Issue page URL can be suffixed with `?title=Issue+Title&body=Issue+Text` and the form will be populated with those strings. Those strings will be used instead of the template if there is one.
 

--- a/docs/content/usage/issue-pull-request-templates.en-us.md
+++ b/docs/content/usage/issue-pull-request-templates.en-us.md
@@ -19,9 +19,10 @@ menu:
 
 Some projects have a standard list of questions that users need to answer
 when creating an issue or pull request. Gitea supports adding templates to the
-main branch of the repository so that they can autopopulate the form when users are
+**default branch of the repository** so that they can autopopulate the form when users are
 creating issues and pull requests. This will cut down on the initial back and forth
 of getting some clarifying details.
+Is actually not possible to provide generic issue/pull-request templates for all instance.
 
 Additionally, the New Issue page URL can be suffixed with `?title=Issue+Title&body=Issue+Text` and the form will be populated with those strings. Those strings will be used instead of the template if there is one.
 


### PR DESCRIPTION
Frontport #29035

For some user (as me), documentation lack of precision about where to store issue/pr template.

I propose an enhancement about this point. With bold exergue and precision about server itself.

I've found some user with same interrogation as :
https://forum.gitea.com/t/issue-template-directory/3328
