### PR TITLE
Remove jQuery from repo wiki creation page

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -2,7 +2,7 @@ import '@github/markdown-toolbar-element';
 import '@github/text-expander-element';
 import $ from 'jquery';
 import {attachTribute} from '../tribute.js';
-import {hideElem, showElem, autosize} from '../../utils/dom.js';
+import {hideElem, showElem, autosize, isVisible} from '../../utils/dom.js';
 import {initEasyMDEImagePaste, initTextareaImagePaste} from './ImagePaste.js';
 import {handleGlobalEnterQuickSubmit} from './QuickSubmit.js';
 import {renderPreviewPanelContent} from '../repo-editor.js';
@@ -14,19 +14,18 @@ let elementIdCounter = 0;
 
 /**
  * validate if the given textarea is non-empty.
- * @param {jQuery} $textarea
+ * @param {HTMLElement} textarea - The textarea element to be validated.
  * @returns {boolean} returns true if validation succeeded.
  */
-export function validateTextareaNonEmpty($textarea) {
+export function validateTextareaNonEmpty(textarea) {
   // When using EasyMDE, the original edit area HTML element is hidden, breaking HTML5 input validation.
   // The workaround (https://github.com/sparksuite/simplemde-markdown-editor/issues/324) doesn't work with contenteditable, so we just show an alert.
-  if (!$textarea.val()) {
-    if ($textarea.is(':visible')) {
-      $textarea.prop('required', true);
-      const $form = $textarea.parents('form');
-      $form[0]?.reportValidity();
+  if (!textarea.value) {
+    if (isVisible(textarea)) {
+      textarea.setAttribute('required', 'true');
+      const form = textarea.closest('form');
+      form?.reportValidity();
     } else {
-      // The alert won't hurt users too much, because we are dropping the EasyMDE and the check only occurs in a few places.
       showErrorToast('Require non-empty content');
     }
     return false;

--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -2,7 +2,7 @@ import '@github/markdown-toolbar-element';
 import '@github/text-expander-element';
 import $ from 'jquery';
 import {attachTribute} from '../tribute.js';
-import {hideElem, showElem, autosize, isVisible} from '../../utils/dom.js';
+import {hideElem, showElem, autosize, isElemVisible} from '../../utils/dom.js';
 import {initEasyMDEImagePaste, initTextareaImagePaste} from './ImagePaste.js';
 import {handleGlobalEnterQuickSubmit} from './QuickSubmit.js';
 import {renderPreviewPanelContent} from '../repo-editor.js';
@@ -21,11 +21,12 @@ export function validateTextareaNonEmpty(textarea) {
   // When using EasyMDE, the original edit area HTML element is hidden, breaking HTML5 input validation.
   // The workaround (https://github.com/sparksuite/simplemde-markdown-editor/issues/324) doesn't work with contenteditable, so we just show an alert.
   if (!textarea.value) {
-    if (isVisible(textarea)) {
-      textarea.setAttribute('required', 'true');
+    if (isElemVisible(textarea)) {
+      textarea.required = true;
       const form = textarea.closest('form');
       form?.reportValidity();
     } else {
+      // The alert won't hurt users too much, because we are dropping the EasyMDE and the check only occurs in a few places.
       showErrorToast('Require non-empty content');
     }
     return false;

--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -47,8 +47,8 @@ function initRepoDiffConversationForm() {
     e.preventDefault();
 
     const $form = $(e.target);
-    const $textArea = $form.find('textarea');
-    if (!validateTextareaNonEmpty($textArea)) {
+    const textArea = e.target.querySelector('textarea');
+    if (!validateTextareaNonEmpty(textArea)) {
       return;
     }
 

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -237,10 +237,5 @@ export function initSubmitEventPolyfill() {
 export function isVisible(element) {
   if (!element) return false;
 
-  const style = window.getComputedStyle(element);
-  return style.width !== '0' &&
-           style.height !== '0' &&
-           style.opacity !== '0' &&
-           style.display !== 'none' &&
-           style.visibility !== 'hidden';
+  return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
 }

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -234,7 +234,7 @@ export function initSubmitEventPolyfill() {
  * @param {HTMLElement} element The element to check.
  * @returns {boolean} True if the element is visible.
  */
-export function isVisible(element) {
+export function isElemVisible(element) {
   if (!element) return false;
 
   return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -229,7 +229,7 @@ export function initSubmitEventPolyfill() {
 }
 
 /**
- * Check if an element is visible.
+ * Check if an element is visible, equivalent to jQuery's `:visible` pseudo.
  * Note: This function doesn't account for all possible visibility scenarios.
  * @param {HTMLElement} element The element to check.
  * @returns {boolean} True if the element is visible.

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -227,3 +227,20 @@ export function initSubmitEventPolyfill() {
   document.body.addEventListener('click', submitEventPolyfillListener);
   document.body.addEventListener('focus', submitEventPolyfillListener);
 }
+
+/**
+ * Check if an element is visible.
+ * Note: This function doesn't account for all possible visibility scenarios.
+ * @param {HTMLElement} element The element to check.
+ * @returns {boolean} True if the element is visible.
+ */
+export function isVisible(element) {
+  if (!element) return false;
+
+  const style = window.getComputedStyle(element);
+  return style.width !== '0' &&
+           style.height !== '0' &&
+           style.opacity !== '0' &&
+           style.display !== 'none' &&
+           style.visibility !== 'hidden';
+}


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the wiki creation form functionality and it works as before

# Demo using JavaScript without jQuery
![action](https://github.com/go-gitea/gitea/assets/20454870/2dfc95fd-40cc-4ffb-9ae6-50f798fddd67)
