### PR TITLE
Do not show delete button when time tracker is disabled (#29257)

### DIFF
--- a/templates/repo/issue/view_content/comments_delete_time.tmpl
+++ b/templates/repo/issue/view_content/comments_delete_time.tmpl
@@ -1,4 +1,4 @@
-{{if .comment.Time}} {{/* compatibility with time comments made before v1.14 */}}
+{{if and .comment.Time (.ctxData.Repository.IsTimetrackerEnabled ctx)}} {{/* compatibility with time comments made before v1.14 */}}
 	{{if (not .comment.Time.Deleted)}}
 		{{if (or .ctxData.IsAdmin (and .ctxData.IsSigned (eq .ctxData.SignedUserID .comment.PosterID)))}}
 			<span class="gt-float-right">


### PR DESCRIPTION
Backport #29257 
Fix #29233

The delete button of time logs won't be shown when the time tracker is disabled.
 
![image](https://github.com/go-gitea/gitea/assets/15528715/5cc4e0c9-d2f9-4b8f-a2f5-fe202b94c191)
