### PR TITLE
Do not use `ctx.Doer` when reset password

### DIFF
--- a/routers/web/auth/password.go
+++ b/routers/web/auth/password.go
@@ -204,7 +204,7 @@ func ResetPasswdPost(ctx *context.Context) {
 		Password:           optional.Some(ctx.FormString("password")),
 		MustChangePassword: optional.Some(false),
 	}
-	if err := user_service.UpdateAuth(ctx, ctx.Doer, opts); err != nil {
+	if err := user_service.UpdateAuth(ctx, u, opts); err != nil {
 		ctx.Data["IsResetForm"] = true
 		ctx.Data["Err_Password"] = true
 		switch {


### PR DESCRIPTION
Fix #29278.

Caused by a small typo in #28733, so it doesn't need to be backported.
