### PR TITLE
Fix missing link on outgoing new release notifications (#29079)

### DIFF
--- a/services/mailer/mail_release.go
+++ b/services/mailer/mail_release.go
@@ -74,6 +74,7 @@ func mailNewRelease(ctx context.Context, lang string, tos []string, rel *repo_mo
 		"Release":  rel,
 		"Subject":  subject,
 		"Language": locale.Language(),
+		"Link":     rel.HTMLURL(),
 	}
 
 	var mailBody bytes.Buffer


### PR DESCRIPTION
Backport #29079