### PR TITLE
Introduce generic type values.NullableValue and reimplement OptionalBool

### DIFF
--- a/modules/indexer/issues/db/options.go
+++ b/modules/indexer/issues/db/options.go
@@ -11,6 +11,7 @@ import (
 	issue_model "code.gitea.io/gitea/models/issues"
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/indexer/issues/internal"
+	"code.gitea.io/gitea/modules/util"
 )
 
 func ToDBOptions(ctx context.Context, options *internal.SearchOptions) (*issue_model.IssuesOptions, error) {
@@ -75,7 +76,7 @@ func ToDBOptions(ctx context.Context, options *internal.SearchOptions) (*issue_m
 		UpdatedAfterUnix:   convertInt64(options.UpdatedAfterUnix),
 		UpdatedBeforeUnix:  convertInt64(options.UpdatedBeforeUnix),
 		PriorityRepoID:     0,
-		IsArchived:         0,
+		IsArchived:         util.OptionalBoolNone,
 		Org:                nil,
 		Team:               nil,
 		User:               nil,

--- a/modules/util/util.go
+++ b/modules/util/util.go
@@ -12,36 +12,37 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/optional"
+	"code.gitea.io/gitea/modules/values"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 // OptionalBool a boolean that can be "null"
-type OptionalBool byte
+type OptionalBool values.NullableValue[bool]
 
-const (
+var (
 	// OptionalBoolNone a "null" boolean value
-	OptionalBoolNone OptionalBool = iota
+	OptionalBoolNone = OptionalBool(values.None[bool]())
 	// OptionalBoolTrue a "true" boolean value
-	OptionalBoolTrue
+	OptionalBoolTrue = OptionalBool(values.Nullable(true))
 	// OptionalBoolFalse a "false" boolean value
-	OptionalBoolFalse
+	OptionalBoolFalse = OptionalBool(values.Nullable(false))
 )
 
 // IsTrue return true if equal to OptionalBoolTrue
 func (o OptionalBool) IsTrue() bool {
-	return o == OptionalBoolTrue
+	return values.NullableValue[bool](o).Equal(true)
 }
 
 // IsFalse return true if equal to OptionalBoolFalse
 func (o OptionalBool) IsFalse() bool {
-	return o == OptionalBoolFalse
+	return values.NullableValue[bool](o).Equal(false)
 }
 
 // IsNone return true if equal to OptionalBoolNone
 func (o OptionalBool) IsNone() bool {
-	return o == OptionalBoolNone
+	return values.NullableValue[bool](o).IsNone()
 }
 
 // ToGeneric converts OptionalBool to optional.Option[bool]
@@ -52,20 +53,9 @@ func (o OptionalBool) ToGeneric() optional.Option[bool] {
 	return optional.Some[bool](o.IsTrue())
 }
 
-// OptionalBoolFromGeneric converts optional.Option[bool] to OptionalBool
-func OptionalBoolFromGeneric(o optional.Option[bool]) OptionalBool {
-	if o.Has() {
-		return OptionalBoolOf(o.Value())
-	}
-	return OptionalBoolNone
-}
-
 // OptionalBoolOf get the corresponding OptionalBool of a bool
 func OptionalBoolOf(b bool) OptionalBool {
-	if b {
-		return OptionalBoolTrue
-	}
-	return OptionalBoolFalse
+	return OptionalBool(values.Nullable(b))
 }
 
 // OptionalBoolParse get the corresponding OptionalBool of a string using strconv.ParseBool

--- a/modules/values/nullable.go
+++ b/modules/values/nullable.go
@@ -3,7 +3,7 @@
 
 package values
 
-type NullableValue[T any] struct {
+type NullableValue[T comparable] struct {
 	value *T
 	isNil bool
 }
@@ -12,19 +12,19 @@ func (n NullableValue[T]) IsNone() bool {
 	return n.isNil
 }
 
-func (n NullableValue[T]) IsSome() bool {
-	return !n.isNil
-}
-
 func (n NullableValue[T]) Value() T {
-	// check if the value is nil first, otherwise panic
+	// check if the value IsNone first, otherwise panic
 	return *n.value
 }
 
-func None[T any]() NullableValue[T] {
+func (n NullableValue[T]) Equal(v T) bool {
+	return n.value != nil && *n.value == v
+}
+
+func None[T comparable]() NullableValue[T] {
 	return NullableValue[T]{nil, true}
 }
 
-func Nullable[T any](value T) NullableValue[T] {
+func Nullable[T comparable](value T) NullableValue[T] {
 	return NullableValue[T]{&value, false}
 }

--- a/modules/values/nullable.go
+++ b/modules/values/nullable.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package values
+
+type NullableValue[T any] struct {
+	value *T
+	isNil bool
+}
+
+func (n NullableValue[T]) IsNone() bool {
+	return n.isNil
+}
+
+func (n NullableValue[T]) IsSome() bool {
+	return !n.isNil
+}
+
+func (n NullableValue[T]) Value() T {
+	// check if the value is nil first, otherwise panic
+	return *n.value
+}
+
+func None[T any]() NullableValue[T] {
+	return NullableValue[T]{nil, true}
+}
+
+func Nullable[T any](value T) NullableValue[T] {
+	return NullableValue[T]{&value, false}
+}

--- a/modules/values/nullable_test.go
+++ b/modules/values/nullable_test.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package values
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNullable(t *testing.T) {
+	boolV := Nullable(true)
+	assert.True(t, boolV.Value())
+	assert.True(t, boolV.IsSome())
+	assert.False(t, boolV.IsNone())
+
+	nilBool := None[bool]()
+	assert.False(t, nilBool.IsSome())
+	assert.True(t, nilBool.IsNone())
+}


### PR DESCRIPTION
# Purpose

Since all Go basic types are not nullable, and nil has no type for default, but sometimes we need a nullable type. This PR introduces a new package `modules/values` and a generic type `NullableValue` which can resolve the defect of Golang types.

# What's changed

And this PR also reimplemented `util.OptionalBool` with the introduced `modules/values`, the new implementation will only affect the util.go file and less places. Most places reference util.OptionalBool can be kept and works as before.
P.S. A potential bug was found because at the previous implementation `util.OptionalBoolNone == 0`, so you can always use `0` as that value. But in the new implementation, they are different types.

# Next step

If this PR merged, many other places which needs a nullable type could reuse this infrastructure.