### PR TITLE
Docker Tag Information in Docs (#29047)

### DIFF
--- a/docs/content/usage/packages/container.en-us.md
+++ b/docs/content/usage/packages/container.en-us.md
@@ -39,6 +39,16 @@ Images must follow this naming convention:
 
 `{registry}/{owner}/{image}`
 
+When building your docker image, using the naming convention above, this looks like:
+
+```shell
+# build an image with tag
+docker build -t {registry}/{owner}/{image}:{tag} .
+# name an existing image with tag
+docker tag {some-existing-image}:{tag} {registry}/{owner}/{image}:{tag}
+```
+
+where your registry is the domain of your gitea instance (e.g. gitea.example.com).
 For example, these are all valid image names for the owner `testuser`:
 
 `gitea.example.com/testuser/myimage`


### PR DESCRIPTION
Backport #29047 

Add more details for the docker tag when using container registry.

