### PR TITLE
Fix incorrect tests in 1.21

### DIFF
--- a/tests/integration/xss_test.go
+++ b/tests/integration/xss_test.go
@@ -5,7 +5,7 @@ package integration
 
 import (
 	"context"
-	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,7 +27,7 @@ import (
 func TestXSSUserFullName(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-	const fullName = `name & <script class="evil">alert('Oh no!');</script>`
+	const fullName = `name & <script class="evil">alert('xss');</script>`
 
 	session := loginUser(t, user.Name)
 	req := NewRequestWithValues(t, "POST", "/user/settings", map[string]string{
@@ -43,58 +43,55 @@ func TestXSSUserFullName(t *testing.T) {
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	assert.EqualValues(t, 0, htmlDoc.doc.Find("script.evil").Length())
-	assert.EqualValues(t, fullName,
-		htmlDoc.doc.Find("div.content").Find(".header.text.center").Text(),
-	)
+	htmlCode, err := htmlDoc.doc.Find("div.content").Find(".header.text.center").Html()
+	assert.NoError(t, err)
+	assert.EqualValues(t, html.EscapeString(fullName), htmlCode)
 }
 
 func TestXSSWikiLastCommitInfo(t *testing.T) {
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
-		// Prepare the environment.
 		dstPath := t.TempDir()
-		r := fmt.Sprintf("%suser2/repo1.wiki.git", u.String())
-		u, err := url.Parse(r)
+		cloneWikiURL, err := url.Parse(u.String() + "user2/repo1.wiki.git")
 		assert.NoError(t, err)
-		u.User = url.UserPassword("user2", userPassword)
-		assert.NoError(t, git.CloneWithArgs(context.Background(), git.AllowLFSFiltersArgs(), u.String(), dstPath, git.CloneRepoOptions{}))
+		cloneWikiURL.User = url.UserPassword("user2", userPassword)
+		assert.NoError(t, git.CloneWithArgs(context.Background(), git.AllowLFSFiltersArgs(), cloneWikiURL.String(), dstPath, git.CloneRepoOptions{}))
 
 		// Use go-git here, because using git wouldn't work, it has code to remove
 		// `<`, `>` and `\n` in user names. Even though this is permitted and
 		// wouldn't result in a error by a Git server.
 		gitRepo, err := gogit.PlainOpen(dstPath)
-		if err != nil {
-			panic(err)
+		if !assert.NoError(t, err) {
+			return
 		}
-
 		w, err := gitRepo.Worktree()
-		if err != nil {
-			panic(err)
+		if !assert.NoError(t, err) {
+			return
 		}
 
 		filename := filepath.Join(dstPath, "Home.md")
-		err = os.WriteFile(filename, []byte("Oh, a XSS attack?"), 0o644)
+		err = os.WriteFile(filename, []byte("dummy content"), 0o644)
 		if !assert.NoError(t, err) {
-			t.FailNow()
+			return
 		}
 
 		_, err = w.Add("Home.md")
 		if !assert.NoError(t, err) {
-			t.FailNow()
+			return
 		}
 
-		_, err = w.Commit("Yay XSS", &gogit.CommitOptions{
+		_, err = w.Commit("dummy message", &gogit.CommitOptions{
 			Author: &object.Signature{
-				Name:  `Gusted <script class="evil">alert('Oh no!');</script>`,
+				Name:  `foo<script class="evil">alert('xss');</script>bar`,
 				Email: "valid@example.org",
-				When:  time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC),
+				When:  time.Date(2001, time.January, 31, 0, 0, 0, 0, time.UTC),
 			},
 		})
 		if !assert.NoError(t, err) {
-			t.FailNow()
+			return
 		}
 
 		// Push.
-		_, _, err = git.NewCommand(git.DefaultContext, "push").AddArguments(git.ToTrustedCmdArgs([]string{"origin", "master"})...).RunStdString(&git.RunOpts{Dir: dstPath})
+		_, _, err = git.NewCommand(git.DefaultContext, "push").AddArguments("origin", "master").RunStdString(&git.RunOpts{Dir: dstPath})
 		assert.NoError(t, err)
 
 		// Check on page view.
@@ -106,7 +103,9 @@ func TestXSSWikiLastCommitInfo(t *testing.T) {
 			htmlDoc := NewHTMLParser(t, resp.Body)
 
 			htmlDoc.AssertElement(t, "script.evil", false)
-			assert.EqualValues(t, `Gusted edited this page 0001-01-01 00:00:00 +00:00`, strings.TrimSpace(htmlDoc.Find(".ui.sub.header").Text()))
+			htmlCode, err := htmlDoc.Find(".ui.sub.header").Html()
+			assert.NoError(t, err)
+			assert.EqualValues(t, `foo&lt;script class=&#34;evil&#34;&gt;alert(&#39;xss&#39;);&lt;/script&gt;bar edited this page <relative-time class="time-since" prefix="" tense="past" datetime="2001-01-31T00:00:00Z" data-tooltip-content="" data-tooltip-interactive="true">2001-01-31 00:00:00 +00:00</relative-time>`, strings.TrimSpace(htmlCode))
 		})
 
 		// Check on revisions page.
@@ -118,7 +117,9 @@ func TestXSSWikiLastCommitInfo(t *testing.T) {
 			htmlDoc := NewHTMLParser(t, resp.Body)
 
 			htmlDoc.AssertElement(t, "script.evil", false)
-			assert.EqualValues(t, `Gusted edited this page 0001-01-01 00:00:00 +00:00`, strings.TrimSpace(htmlDoc.Find(".ui.sub.header").Text()))
+			htmlCode, err := htmlDoc.Find(".ui.sub.header").Html()
+			assert.NoError(t, err)
+			assert.EqualValues(t, `foo&lt;script class=&#34;evil&#34;&gt;alert(&#39;xss&#39;);&lt;/script&gt;bar edited this page <relative-time class="time-since" prefix="" tense="past" datetime="2001-01-31T00:00:00Z" data-tooltip-content="" data-tooltip-interactive="true">2001-01-31 00:00:00 +00:00</relative-time>`, strings.TrimSpace(htmlCode))
 		})
 	})
 }


### PR DESCRIPTION
The submitted tests in the patch for the XSS fix is not right.

To test, it should test "what should happen", but not "what doesn't exist" or "what is processed/decoded".