### PR TITLE
Fix htmx rendering the login page in frame on session logout

### DIFF
--- a/modules/context/base.go
+++ b/modules/context/base.go
@@ -265,6 +265,14 @@ func (b *Base) Redirect(location string, status ...int) {
 		// So in this case, we should remove the session cookie from the response header
 		removeSessionCookieHeader(b.Resp)
 	}
+	// in case the request is made by htmx, have it redirect the browser instead of trying to follow the redirect inside htmx
+	if b.Req.Header.Get("HX-Request") == "true" {
+		b.Resp.Header().Set("HX-Redirect", location)
+		// we have to return a non-redirect status code so XMLHTTPRequest will not immediately follow the redirect
+		// so as to give htmx redirect logic a chance to run
+		b.Status(http.StatusNoContent)
+		return
+	}
 	http.Redirect(b.Resp, b.Req, location, code)
 }
 


### PR DESCRIPTION
- Fix #29391

With this change, htmx will not follow the redirect in the AJAX request but instead redirect the whole browser.

To reproduce the bug fixed by this change without waiting a long time for the token to expire, you can logout in another tab then look in the original tab. Just make sure to comment out both instances of `window.location.href = appSubUrl` in the codebase so you won't be redirected immediately on logout. This is what I did in the following gifs.

# Before
![before](https://github.com/go-gitea/gitea/assets/20454870/a9190c4e-9a88-4fee-bbac-5f524967db1b)

# After
![after](https://github.com/go-gitea/gitea/assets/20454870/6e438568-45ab-403d-99f4-48ccfe2a60bb)
