### PR TITLE
Apply tailwindcss rules with `!important`

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ const isProduction = env.NODE_ENV !== 'development';
 
 export default {
   prefix: 'tw-',
+  important: true,
   content: [
     isProduction && '!./templates/devtest/**/*',
     isProduction && '!./web_src/js/standalone/devtest.js',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ const isProduction = env.NODE_ENV !== 'development';
 
 export default {
   prefix: 'tw-',
-  important: true,
+  important: true, // the frameworks are mixed together, so tailwind needs to override other framework's styles
   content: [
     isProduction && '!./templates/devtest/**/*',
     isProduction && '!./web_src/js/standalone/devtest.js',


### PR DESCRIPTION
As per discussion in https://github.com/go-gitea/gitea/pull/29423, I think this is the right way that does not burden developers having to think about CSS precedence which should be irrelevant with a atomic CSS framework.