### PR TITLE
Apply compact padding to small buttons with svg icons

### DIFF
--- a/templates/repo/release_tag_header.tmpl
+++ b/templates/repo/release_tag_header.tmpl
@@ -13,7 +13,7 @@
 		</div>
 		{{if .EnableFeed}}
 			<a class="ui small button" href="{{.RepoLink}}/{{if .PageIsTagList}}tags{{else}}releases{{end}}.rss">
-				{{svg "octicon-rss" 18}} {{ctx.Locale.Tr "rss_feed"}}
+				{{svg "octicon-rss" 16}} {{ctx.Locale.Tr "rss_feed"}}
 			</a>
 		{{end}}
 		{{if and (not .PageIsTagList) .CanCreateRelease}}

--- a/web_src/css/modules/button.css
+++ b/web_src/css/modules/button.css
@@ -85,6 +85,12 @@ It needs some tricks to tweak the left/right borders with active state */
   box-shadow: none;
 }
 
+/* apply the padding of .compact to non-compact buttons when they contain a svg as they would otherwise
+   appear too large. Seen on "RSS Feed" button on repo releases tab. */
+.ui.small.button:not(.compact):has(.svg) {
+  padding: 0.58928571em 1.125em 0.58928571em;
+}
+
 .ui.labeled.button.disabled > .button,
 .ui.basic.buttons .button,
 .ui.basic.button,

--- a/web_src/css/modules/button.css
+++ b/web_src/css/modules/button.css
@@ -85,10 +85,11 @@ It needs some tricks to tweak the left/right borders with active state */
   box-shadow: none;
 }
 
-/* apply the padding of .compact to non-compact buttons when they contain a svg as they would otherwise
-   appear too large. Seen on "RSS Feed" button on repo releases tab. */
+/* apply the vertical padding of .compact to non-compact buttons when they contain a svg as they
+   would otherwise appear too large. Seen on "RSS Feed" button on repo releases tab. */
 .ui.small.button:not(.compact):has(.svg) {
-  padding: 0.58928571em 1.125em 0.58928571em;
+  padding-top: 0.58928571em;
+  padding-bottom: 0.58928571em;
 }
 
 .ui.labeled.button.disabled > .button,


### PR DESCRIPTION
The buttons on the repo release tab were larger in height than on other tabs because one of them contained the RSS icon which stretched the button height by 3px. Workaround this problem by applying the "compact" padding to any such button. They are within 0.4px in height now to non-icon buttons.

Before:

<img width="406" alt="Screenshot 2024-02-28 at 15 30 23" src="https://github.com/go-gitea/gitea/assets/115237/805bb93a-6fe4-40a0-82d1-03001bee8ecf">

After:

<img width="407" alt="Screenshot 2024-02-28 at 15 38 43" src="https://github.com/go-gitea/gitea/assets/115237/27707588-890f-4852-ab08-105a57eda880">


For comparison, button on issue tab:

<img width="452" alt="Screenshot 2024-02-28 at 15 31 46" src="https://github.com/go-gitea/gitea/assets/115237/74ac13d5-d016-49ba-9dd9-40ed32a748e9">
