### PR TITLE
fix(blame): Fix UI when code is in a single line, with no space

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1569,8 +1569,7 @@ a.ui.active.label:hover {
 }
 
 .blame .code-inner {
-  white-space: pre;
-  word-break: normal;
+  word-break: break-all;
   word-wrap: normal; /* not using overflow-wrap because safari does not treat is an an alias */
 }
 


### PR DESCRIPTION
This will fix UI when code is in a single line, with no space

<img width="1439" alt="Screenshot 2024-02-28 at 16 34 30" src="https://github.com/go-gitea/gitea/assets/66185935/14b9298a-5613-4443-89a5-42b52d6110a9">
