### PR TITLE
Improve contrast on blame timestamp, fix double border

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1576,7 +1576,7 @@ a.ui.active.label:hover {
 
 .lines-commit {
   vertical-align: top;
-  color: var(--color-grey);
+  color: var(--color-text-light-2);
   padding: 0 !important;
   background: var(--color-code-sidebar-bg);
   width: 1%;

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1619,6 +1619,10 @@ a.ui.active.label:hover {
   border-top: 1px solid var(--color-secondary);
 }
 
+.code-view tr.top-line-blame:first-of-type {
+  border-top: none;
+}
+
 .lines-code .bottom-line,
 .lines-commit .bottom-line {
   border-bottom: 1px solid var(--color-secondary);


### PR DESCRIPTION
Before, double border on top, bad contrast on dark:
<img width="155" alt="Screenshot 2024-02-29 at 02 06 17" src="https://github.com/go-gitea/gitea/assets/115237/fc0f1e08-a5ce-47ed-9eb6-135eed5a1abb">
<img width="126" alt="Screenshot 2024-02-29 at 02 07 28" src="https://github.com/go-gitea/gitea/assets/115237/38ae8483-8d9b-484c-8909-d4466131ea16">

After, no double border on top, good contrast:
<img width="154" alt="Screenshot 2024-02-29 at 02 20 20" src="https://github.com/go-gitea/gitea/assets/115237/ad91282b-e9f5-4f41-8f5e-6ba28db3beac">
<img width="147" alt="Screenshot 2024-02-29 at 02 20 38" src="https://github.com/go-gitea/gitea/assets/115237/7ee2ec92-e72a-4981-aec3-98fc8e579bae">