### PR TITLE
Fix incorrect diff expander for deletion of last lines in a file

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -154,7 +154,7 @@ func (d *DiffLine) GetBlobExcerptQuery() string {
 
 // GetExpandDirection gets DiffLineExpandDirection
 func (d *DiffLine) GetExpandDirection() DiffLineExpandDirection {
-	if d.Type != DiffLineSection || d.SectionInfo == nil || d.SectionInfo.RightIdx-d.SectionInfo.LastRightIdx <= 1 {
+	if d.Type != DiffLineSection || d.SectionInfo == nil || d.SectionInfo.RightIdx-d.SectionInfo.LastRightIdx <= 1 || d.SectionInfo.LeftIdx-d.SectionInfo.LastLeftIdx <= 1 {
 		return DiffLineExpandNone
 	}
 	if d.SectionInfo.LastLeftIdx <= 0 && d.SectionInfo.LastRightIdx <= 0 {

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -154,7 +154,7 @@ func (d *DiffLine) GetBlobExcerptQuery() string {
 
 // GetExpandDirection gets DiffLineExpandDirection
 func (d *DiffLine) GetExpandDirection() DiffLineExpandDirection {
-	if d.Type != DiffLineSection || d.SectionInfo == nil || d.SectionInfo.RightIdx-d.SectionInfo.LastRightIdx <= 1 || d.SectionInfo.LeftIdx-d.SectionInfo.LastLeftIdx <= 1 {
+	if d.Type != DiffLineSection || d.SectionInfo == nil || d.SectionInfo.LeftIdx-d.SectionInfo.LastLeftIdx <= 1 || d.SectionInfo.RightIdx-d.SectionInfo.LastRightIdx <= 1 {
 		return DiffLineExpandNone
 	}
 	if d.SectionInfo.LastLeftIdx <= 0 && d.SectionInfo.LastRightIdx <= 0 {


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/29498

I don't quite understand this code, but this change does seem to fix the issue and I tested a number of diffs with it and saw no issue. The function gets such value if last line is an addition:

```
  LastLeftIdx: (int) 0,
  LastRightIdx: (int) 47,
  LeftIdx: (int) 47,
  RightIdx: (int) 48,
```

If it's a deletion, it gets:

```
  LastLeftIdx: (int) 47,
  LastRightIdx: (int) 0,
  LeftIdx: (int) 48,
  RightIdx: (int) 47,
```

So I think it's correct to make this check respect both left and right side.