### PR TITLE
WIP: Hide diff tail on files with trailing newline

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -397,7 +397,7 @@ func (diffFile *DiffFile) GetTailSection(gitRepo *git.Repository, leftCommitID, 
 	lastLine := lastSection.Lines[len(lastSection.Lines)-1]
 	leftLineCount := getCommitFileLineCount(leftCommit, diffFile.Name)
 	rightLineCount := getCommitFileLineCount(rightCommit, diffFile.Name)
-	if leftLineCount - lastLine.LeftIdx <= 1 || rightLineCount - lastLine.RightIdx <= 1 {
+	if leftLineCount-lastLine.LeftIdx <= 1 || rightLineCount-lastLine.RightIdx <= 1 {
 		return nil
 	}
 	tailDiffLine := &DiffLine{

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -397,7 +397,7 @@ func (diffFile *DiffFile) GetTailSection(gitRepo *git.Repository, leftCommitID, 
 	lastLine := lastSection.Lines[len(lastSection.Lines)-1]
 	leftLineCount := getCommitFileLineCount(leftCommit, diffFile.Name)
 	rightLineCount := getCommitFileLineCount(rightCommit, diffFile.Name)
-	if leftLineCount <= lastLine.LeftIdx || rightLineCount <= lastLine.RightIdx {
+	if leftLineCount - lastLine.LeftIdx <= 1 || rightLineCount - lastLine.RightIdx <= 1 {
 		return nil
 	}
 	tailDiffLine := &DiffLine{


### PR DESCRIPTION
When a file has a diff on its last line and the file has a trailing newline, the diff renderer will render a empty "diff tail" that is meant to hold the expander button.

WIP because I have not yet confirmed that it won't incorrectly hide a expander if it has exactly one line to expand below.

Before:
<img width="309" alt="Screenshot 2024-02-29 at 19 29 48" src="https://github.com/go-gitea/gitea/assets/115237/5f6f44fe-82b8-4ba8-a9cb-a1305a698362">

After:
<img width="330" alt="Screenshot 2024-02-29 at 19 29 53" src="https://github.com/go-gitea/gitea/assets/115237/e4be1581-aa44-4a1f-a14f-d44e6cb24e2f">
