### PR TITLE
Don’t comment when locking

### DIFF
--- a/.github/workflows/cron-lock.yml
+++ b/.github/workflows/cron-lock.yml
@@ -20,8 +20,4 @@ jobs:
       - uses: dessant/lock-threads@v5
         with:
           issue-inactive-days: 10
-          issue-comment: |
-            Automatically locked because of our [CONTRIBUTING guidelines](https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md#issue-locking)
           pr-inactive-days: 7
-          pr-comment: |
-            Automatically locked because of our [CONTRIBUTING guidelines](https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md#issue-locking)


### PR DESCRIPTION
This reduces the number of emails/notifications on outdated issues.