### PR TITLE
Adding back missing options to app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -956,6 +956,8 @@ LEVEL = Info
 ;GO_GET_CLONE_URL_PROTOCOL = https
 ;;
 ;; Close issues as long as a commit on any branch marks it as fixed
+;DEFAULT_CLOSE_ISSUES_VIA_COMMITS_IN_ANY_BRANCH = false
+;;
 ;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki, repo.projects, repo.packages, repo.actions.
 ;DISABLED_REPO_UNITS =
 ;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -957,9 +957,11 @@ LEVEL = Info
 ;;
 ;; Close issues as long as a commit on any branch marks it as fixed
 ;DEFAULT_CLOSE_ISSUES_VIA_COMMITS_IN_ANY_BRANCH = false
+;;
 ;; Allow users to push local repositories to Gitea and have them automatically created for a user or an org
 ;ENABLE_PUSH_CREATE_USER = false
 ;ENABLE_PUSH_CREATE_ORG = false
+;;
 ;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki, repo.projects, repo.packages, repo.actions.
 ;DISABLED_REPO_UNITS =
 ;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -957,7 +957,9 @@ LEVEL = Info
 ;;
 ;; Close issues as long as a commit on any branch marks it as fixed
 ;DEFAULT_CLOSE_ISSUES_VIA_COMMITS_IN_ANY_BRANCH = false
-;;
+;; Allow users to push local repositories to Gitea and have them automatically created for a user or an org
+;ENABLE_PUSH_CREATE_USER = false
+;ENABLE_PUSH_CREATE_ORG = false
 ;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki, repo.projects, repo.packages, repo.actions.
 ;DISABLED_REPO_UNITS =
 ;;


### PR DESCRIPTION
In the refactoring of the configuration file, that line was accidentally deleted:

DEFAULT_CLOSE_ISSUES_VIA_COMMITS_IN_ANY_BRANCH = false

See: https://github.com/go-gitea/gitea/commit/4a84022d2559ccfc99960c7c654ee8b9b38664f7?diff=split&w=1#diff-eda333ab2034231553808ef0f99e28cd1f209c7f583fd3d0aa0fb1b77e573cd4L56

Fix #29510 

