### PR TITLE
Ignore `__debug_bin*` which is generated by vscode when debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ _test
 
 # MS VSCode
 .vscode
-__debug_bin
+__debug_bin*
 
 *.cgo1.go
 *.cgo2.c


### PR DESCRIPTION
When debugging in VSCode now, the executable file generated will come with a random string attached.