### PR TITLE
gitea.service: Remove syslog.target

### DIFF
--- a/contrib/systemd/gitea.service
+++ b/contrib/systemd/gitea.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Gitea (Git with a cup of tea)
-After=syslog.target
 After=network.target
 ###
 # Don't forget to add the database service dependencies


### PR DESCRIPTION
Remove syslog.target from service file, this target hasn't existed for over a decade.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73