### PR TITLE
Document that all unmerged feature PRs will be moved to next milestone when the feature freeze time comes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,7 +464,7 @@ We assume in good faith that the information you provide is legally binding.
 We adopted a release schedule to streamline the process of working on, finishing, and issuing releases. \
 The overall goal is to make a major release every three or four months, which breaks down into two or three months of general development followed by one month of testing and polishing known as the release freeze. \
 All the feature pull requests should be
-merged before feature freeze. And, during the frozen period, a corresponding
+merged before feature freeze. All feature pull requests haven't been merged before this feature freeze will be moved to next milestone, please notice our feature freeze announcement on discord. And, during the frozen period, a corresponding
 release branch is open for fixes backported from main branch. Release candidates
 are made during this period for user testing to
 obtain a final version that is maintained in this branch.


### PR DESCRIPTION
Some contributors may be surprised when moving the feature PRs to the next release when the feature freeze time comes. So this PR documents the habits we have done for feature freeze so people expect the maintainers' behaviors. We are sorry for disturbing you with the milestones changes.

A feature freeze announcement should be published 2 or 3 weeks before the feature freeze by maintainers.