### PR TITLE
Make admin pages wider because of left sidebar added and some tables become too narrow

### DIFF
--- a/templates/admin/layout_head.tmpl
+++ b/templates/admin/layout_head.tmpl
@@ -3,7 +3,7 @@
 	<div class="ui container gt-mb-4">
 		{{template "base/alert" .ctxData}}
 	</div>
-	<div class="ui container flex-container">
+	<div class="ui container fluid padded flex-container">
 		{{template "admin/navbar" .ctxData}}
 		<div class="flex-container-main">
 			{{/* block: admin-setting-content */}}


### PR DESCRIPTION
Fix #25939

screenshots 

<img width="1895" alt="image" src="https://github.com/go-gitea/gitea/assets/81045/937eb28d-bb7d-4765-b580-bc991d61f467">
