### PR TITLE
Add ac claim for old docker/build-push-action@v3 / current buildx gha cache

### DIFF
--- a/services/actions/auth.go
+++ b/services/actions/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 
@@ -24,8 +25,30 @@ type actionsClaims struct {
 	Ac     string `json:"ac"`
 }
 
+type actionsCacheScope struct {
+	Scope      string
+	Permission actionsCachePermission
+}
+
+type actionsCachePermission int
+
+const (
+	actionsCachePermissionRead = 1 << iota
+	actionsCachePermissionWrite
+)
+
 func CreateAuthorizationToken(taskID, runID, jobID int64) (string, error) {
 	now := time.Now()
+
+	ac, err := json.Marshal(&[]actionsCacheScope{
+		{
+			Scope:      "",
+			Permission: actionsCachePermissionWrite,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
 
 	claims := actionsClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -33,7 +56,7 @@ func CreateAuthorizationToken(taskID, runID, jobID int64) (string, error) {
 			NotBefore: jwt.NewNumericDate(now),
 		},
 		Scp:    fmt.Sprintf("Actions.Results:%d:%d", runID, jobID),
-		Ac:     "[]",
+		Ac:     string(ac),
 		TaskID: taskID,
 		RunID:  runID,
 		JobID:  jobID,

--- a/services/actions/auth.go
+++ b/services/actions/auth.go
@@ -21,6 +21,7 @@ type actionsClaims struct {
 	TaskID int64
 	RunID  int64
 	JobID  int64
+	Ac     string `json:"ac"`
 }
 
 func CreateAuthorizationToken(taskID, runID, jobID int64) (string, error) {
@@ -32,6 +33,7 @@ func CreateAuthorizationToken(taskID, runID, jobID int64) (string, error) {
 			NotBefore: jwt.NewNumericDate(now),
 		},
 		Scp:    fmt.Sprintf("Actions.Results:%d:%d", runID, jobID),
+		Ac:     "[]",
 		TaskID: taskID,
 		RunID:  runID,
 		JobID:  jobID,

--- a/services/actions/auth_test.go
+++ b/services/actions/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -29,6 +30,12 @@ func TestCreateAuthorizationToken(t *testing.T) {
 	taskIDClaim, ok := claims["TaskID"]
 	assert.True(t, ok, "Has TaskID claim in jwt token")
 	assert.Equal(t, float64(taskID), taskIDClaim, "Supplied taskid must match stored one")
+	acClaim, ok := claims["ac"]
+	assert.True(t, ok, "Has ac claim in jwt token")
+	ac, ok := acClaim.(string)
+	assert.True(t, ok, "ac claim is a string")
+	err = json.Unmarshal([]byte(ac), &[]struct{}{})
+	assert.NoError(t, err, "ac claim is a json list")
 }
 
 func TestParseAuthorizationToken(t *testing.T) {

--- a/services/actions/auth_test.go
+++ b/services/actions/auth_test.go
@@ -33,9 +33,11 @@ func TestCreateAuthorizationToken(t *testing.T) {
 	acClaim, ok := claims["ac"]
 	assert.True(t, ok, "Has ac claim in jwt token")
 	ac, ok := acClaim.(string)
-	assert.True(t, ok, "ac claim is a string")
-	err = json.Unmarshal([]byte(ac), &[]struct{}{})
-	assert.NoError(t, err, "ac claim is a json list")
+	assert.True(t, ok, "ac claim is a string for buildx gha cache")
+	scopes := []actionsCacheScope{}
+	err = json.Unmarshal([]byte(ac), &scopes)
+	assert.NoError(t, err, "ac claim is a json list for buildx gha cache")
+	assert.GreaterOrEqual(t, len(scopes), 1, "Expected at least one action cache scope for buildx gha cache")
 }
 
 func TestParseAuthorizationToken(t *testing.T) {


### PR DESCRIPTION
Also resolves a warning for current releases

```
| ##[group]GitHub Actions runtime token ACs
| ##[warning]Cannot parse GitHub Actions Runtime Token ACs: "undefined" is not valid JSON
| ##[endgroup]
====>
| ##[group]GitHub Actions runtime token ACs
| ##[endgroup]
```
\* this is an error in v3

References in the docker org:
- https://github.com/docker/build-push-action/blob/831ca179d3cf91cf0c90ca465a408fa61e2129a2/src/main.ts#L24
- https://github.com/docker/actions-toolkit/blob/7d8b4dc6694df35a06fae786427672ce27a8c18d/src/github.ts#L61

No known official action of GitHub makes use of this claim.

Current releases throw an error when configure to use actions cache
```
| ERROR: failed to solve: failed to configure gha cache exporter: invalid token without access controls
| ##[error]buildx failed with: ERROR: failed to solve: failed to configure gha cache exporter: invalid token without access controls
```