### PR TITLE
Add aria-label to the navbar menu button

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -320,6 +320,7 @@ env_config_keys = Environment Configuration
 env_config_keys_prompt = The following environment variables will also be applied to your configuration file:
 
 [home]
+nav_menu = Navigation Menu
 uname_holder = Username or Email Address
 password_holder = Password
 switch_dashboard_context = Switch Dashboard Context
@@ -654,7 +655,7 @@ block.note.title = Optional note:
 block.note.info = The note is not visible to the blocked user.
 block.note.edit = Edit note
 block.list = Blocked users
-block.list.none = You have not blocked any users. 
+block.list.none = You have not blocked any users.
 
 [settings]
 profile = Profile

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -20,7 +20,7 @@
 				</div>
 			</a>
 			{{end}}
-			<button class="item tw-w-auto ui icon mini button gt-p-3 gt-m-0" id="navbar-expand-toggle">{{svg "octicon-three-bars"}}</button>
+			<button class="item tw-w-auto ui icon mini button gt-p-3 gt-m-0" id="navbar-expand-toggle" aria-label="{{ctx.Locale.Tr "home.nav_menu"}}">{{svg "octicon-three-bars"}}</button>
 		</div>
 
 		<!-- navbar links non-mobile -->


### PR DESCRIPTION
It doesn't have text content, so it needs an aria-label. The tippy tooltip doesn't work for this button, because the tooltip doesn't disappear on mobile.