### PR TITLE
Use flex wrap to layout the PR update button

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -935,18 +935,12 @@
 
 .repository.view.issue .comment-list .comment .merge-section .item-section {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   padding: 0;
   margin-top: -0.25rem;
   margin-bottom: -0.25rem;
-}
-
-@media (max-width: 991.98px) {
-  .repository.view.issue .comment-list .comment .merge-section .item-section {
-    align-items: flex-start;
-    flex-direction: column;
-  }
 }
 
 .repository.view.issue .comment-list .comment .merge-section .divider {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -939,8 +939,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0;
-  margin-top: -0.25rem;
-  margin-bottom: -0.25rem;
+  gap: 0.5em;
 }
 
 .repository.view.issue .comment-list .comment .merge-section .divider {


### PR DESCRIPTION
Follow #29418

After some tests, I think using "flex-wrap: wrap" here is better than hard-coding the screen width.

By using "flex-wrap: wrap", the UI layouts automatically for various widths (even if in some languages, the sentence might be pretty long)

![image](https://github.com/go-gitea/gitea/assets/2114189/8a938ca9-f673-41d9-8cce-e351af5b9fd7)

![image](https://github.com/go-gitea/gitea/assets/2114189/60aaba8a-e732-4b2f-9659-1d8ace07b257)
