### PR TITLE
Adjust tailwind content globs

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,7 +32,6 @@ export default {
     '!./templates/swagger/v1_json.tmpl',
     '!./templates/user/auth/oidc_wellknown.tmpl',
     './templates/**/*.tmpl',
-    './templates/**/*.tmpl',
     './web_src/js/**/*.{js,vue}',
   ].filter(Boolean),
   blocklist: [

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,8 +29,11 @@ export default {
   content: [
     isProduction && '!./templates/devtest/**/*',
     isProduction && '!./web_src/js/standalone/devtest.js',
+    '!./templates/swagger/v1_json.tmpl',
+    '!./templates/user/auth/oidc_wellknown.tmpl',
     './templates/**/*.tmpl',
-    './web_src/**/*.{js,vue}',
+    './templates/**/*.tmpl',
+    './web_src/js/**/*.{js,vue}',
   ].filter(Boolean),
   blocklist: [
     // classes that don't work without CSS variables from "@tailwind base" which we don't use


### PR DESCRIPTION
Tailwind content is not going to appear in `web_src/css`, `web_src/fomantic` or `web_src/svg` or the JSON templates, so we don't need to have tailwind scan these directories which will speed up the build.