### PR TITLE
Skip email domain check when admins edit user emails

### DIFF
--- a/models/user/email_address.go
+++ b/models/user/email_address.go
@@ -162,7 +162,7 @@ func ValidateEmail(email string) error {
 	return validateEmailDomain(email)
 }
 
-// ValidateEmailForAdmin check if email is a valid address when admins manually add users
+// ValidateEmailForAdmin check if email is a valid address when admins manually add or edit users
 func ValidateEmailForAdmin(email string) error {
 	return validateEmailBasic(email)
 	// In this case we do not need to check the email domain

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -209,7 +209,7 @@ func EditUser(ctx *context.APIContext) {
 	}
 
 	if form.Email != nil {
-		if err := user_service.AddOrSetPrimaryEmailAddress(ctx, ctx.ContextUser, *form.Email); err != nil {
+		if err := user_service.AdminAddOrSetPrimaryEmailAddress(ctx, ctx.ContextUser, *form.Email); err != nil {
 			switch {
 			case user_model.IsErrEmailCharIsNotSupported(err), user_model.IsErrEmailInvalid(err):
 				ctx.Error(http.StatusBadRequest, "EmailInvalid", err)

--- a/routers/web/admin/users.go
+++ b/routers/web/admin/users.go
@@ -412,7 +412,7 @@ func EditUserPost(ctx *context.Context) {
 	}
 
 	if form.Email != "" {
-		if err := user_service.AddOrSetPrimaryEmailAddress(ctx, u, form.Email); err != nil {
+		if err := user_service.AdminAddOrSetPrimaryEmailAddress(ctx, u, form.Email); err != nil {
 			switch {
 			case user_model.IsErrEmailCharIsNotSupported(err), user_model.IsErrEmailInvalid(err):
 				ctx.Data["Err_Email"] = true

--- a/services/user/email.go
+++ b/services/user/email.go
@@ -14,12 +14,13 @@ import (
 	"code.gitea.io/gitea/modules/util"
 )
 
-func AddOrSetPrimaryEmailAddress(ctx context.Context, u *user_model.User, emailStr string) error {
+// AdminAddOrSetPrimaryEmailAddress is used by admins to add or set a user's primary email address
+func AdminAddOrSetPrimaryEmailAddress(ctx context.Context, u *user_model.User, emailStr string) error {
 	if strings.EqualFold(u.Email, emailStr) {
 		return nil
 	}
 
-	if err := user_model.ValidateEmail(emailStr); err != nil {
+	if err := user_model.ValidateEmailForAdmin(emailStr); err != nil {
 		return err
 	}
 

--- a/tests/integration/api_admin_test.go
+++ b/tests/integration/api_admin_test.go
@@ -359,3 +359,32 @@ func TestAPICreateUser_NotAllowedEmailDomain(t *testing.T) {
 	req = NewRequest(t, "DELETE", "/api/v1/admin/users/allowedUser1").AddTokenAuth(token)
 	MakeRequest(t, req, http.StatusNoContent)
 }
+
+func TestAPIEditUser_NotAllowedEmailDomain(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	setting.Service.EmailDomainAllowList = []glob.Glob{glob.MustCompile("example.org")}
+	defer func() {
+		setting.Service.EmailDomainAllowList = []glob.Glob{}
+	}()
+
+	adminUsername := "user1"
+	token := getUserToken(t, adminUsername, auth_model.AccessTokenScopeWriteAdmin)
+	urlStr := fmt.Sprintf("/api/v1/admin/users/%s", "user2")
+
+	newEmail := "user2@example1.com"
+	req := NewRequestWithJSON(t, "PATCH", urlStr, api.EditUserOption{
+		LoginName: "user2",
+		SourceID:  0,
+		Email:     &newEmail,
+	}).AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusOK)
+
+	originalEmail := "user2@example.com"
+	req = NewRequestWithJSON(t, "PATCH", urlStr, api.EditUserOption{
+		LoginName: "user2",
+		SourceID:  0,
+		Email:     &originalEmail,
+	}).AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusOK)
+}


### PR DESCRIPTION
Follow #29522

Administrators should be able to set a user's email address even if the email address is not in `EMAIL_DOMAIN_ALLOWLIST`