### PR TITLE
Avoid unexpected panic in graceful manager

### DIFF
--- a/modules/graceful/manager_unix.go
+++ b/modules/graceful/manager_unix.go
@@ -59,7 +59,15 @@ func (g *Manager) start() {
 	go func() {
 		defer close(startupDone)
 		// Wait till we're done getting all the listeners and then close the unused ones
-		g.createServerWaitGroup.Wait()
+		func() {
+			// FIXME: there is a fundamental design problem of the "manager" and the "wait group".
+			// If nothing has started, the "Wait" just panics: sync: WaitGroup is reused before previous Wait has returned
+			// There is no clear solution besides a complete rewriting of the "manager"
+			defer func() {
+				_ = recover()
+			}()
+			g.createServerWaitGroup.Wait()
+		}()
 		// Ignore the error here there's not much we can do with it, they're logged in the CloseProvidedListeners function
 		_ = CloseProvidedListeners()
 		g.notify(readyMsg)


### PR DESCRIPTION
There is a fundamental design problem of the "manager" and the "wait group".
If nothing has started, the "Wait" just panics: sync: WaitGroup is reused before previous Wait has returned
There is no clear solution besides a complete rewriting of the "manager"

If there are some mistakes in the app.ini, end users would just see the "panic", but not the real error messages. A real case: #27643

This PR is just a quick fix for the annoying panic problem.