### PR TITLE
DOC: in ssh forwarding, user git must be allowed to run docker

### DIFF
--- a/docs/content/installation/with-docker-rootless.en-us.md
+++ b/docs/content/installation/with-docker-rootless.en-us.md
@@ -349,6 +349,7 @@ Match User git
   AuthorizedKeysCommandUser git
   AuthorizedKeysCommand /usr/bin/docker exec -i gitea /usr/local/bin/gitea keys -c /etc/gitea/app.ini -e git -u %u -t %t -k %k
 ```
+For this to work, the user `git` hast to be allowed to run `docker`.
 
 (From 1.16.0 you will not need to set the `-c /etc/gitea/app.ini` option.)
 

--- a/docs/content/installation/with-docker-rootless.en-us.md
+++ b/docs/content/installation/with-docker-rootless.en-us.md
@@ -349,7 +349,8 @@ Match User git
   AuthorizedKeysCommandUser git
   AuthorizedKeysCommand /usr/bin/docker exec -i gitea /usr/local/bin/gitea keys -c /etc/gitea/app.ini -e git -u %u -t %t -k %k
 ```
-For this to work, the user `git` hast to be allowed to run `docker`.
+
+For this to work, the user `git` has to be allowed to run `docker`.
 
 (From 1.16.0 you will not need to set the `-c /etc/gitea/app.ini` option.)
 

--- a/docs/content/installation/with-docker-rootless.en-us.md
+++ b/docs/content/installation/with-docker-rootless.en-us.md
@@ -350,7 +350,7 @@ Match User git
   AuthorizedKeysCommand /usr/bin/docker exec -i gitea /usr/local/bin/gitea keys -c /etc/gitea/app.ini -e git -u %u -t %t -k %k
 ```
 
-For this to work, the user `git` has to be allowed to run `docker`.
+For this to work, the user `git` has to be allowed to run the `docker` cli command. Please read through the [security considerations](https://docs.docker.com/engine/security/#docker-daemon-attack-surface) of providing non-root linux users access to the docker daemon.
 
 (From 1.16.0 you will not need to set the `-c /etc/gitea/app.ini` option.)
 


### PR DESCRIPTION
Added to doc for rootless Docker installation:  for SSH passthrough, the ssh user (git) has to be able to run docker.
