### PR TITLE
Add permission check to `LoadIssuesFromBoard`

### DIFF
--- a/models/fixtures/access.yml
+++ b/models/fixtures/access.yml
@@ -24,150 +24,168 @@
 
 -
   id: 5
+  user_id: 2
+  repo_id: 40
+  mode: 4
+
+-
+  id: 6
+  user_id: 2
+  repo_id: 41
+  mode: 4
+
+-
+  id: 7
   user_id: 4
   repo_id: 3
   mode: 2
 
 -
-  id: 6
+  id: 8
   user_id: 4
   repo_id: 4
   mode: 2
 
 -
-  id: 7
+  id: 9
   user_id: 4
   repo_id: 40
   mode: 2
 
 -
-  id: 8
-  user_id: 10
-  repo_id: 21
-  mode: 2
-
--
-  id: 9
-  user_id: 10
-  repo_id: 32
-  mode: 2
-
--
   id: 10
-  user_id: 15
-  repo_id: 21
+  user_id: 5
+  repo_id: 41
   mode: 2
 
 -
   id: 11
+  user_id: 10
+  repo_id: 21
+  mode: 2
+
+-
+  id: 12
+  user_id: 10
+  repo_id: 32
+  mode: 2
+
+-
+  id: 13
+  user_id: 15
+  repo_id: 21
+  mode: 2
+
+-
+  id: 14
   user_id: 15
   repo_id: 22
   mode: 2
 
 -
-  id: 12
+  id: 15
   user_id: 15
   repo_id: 23
   mode: 4
 
 -
-  id: 13
+  id: 16
   user_id: 15
   repo_id: 24
   mode: 4
 
 -
-  id: 14
+  id: 17
   user_id: 15
   repo_id: 32
   mode: 2
 
 -
-  id: 15
+  id: 18
   user_id: 18
   repo_id: 21
   mode: 2
 
 -
-  id: 16
+  id: 19
   user_id: 18
   repo_id: 22
   mode: 2
 
 -
-  id: 17
+  id: 20
   user_id: 18
   repo_id: 23
   mode: 4
 
 -
-  id: 18
+  id: 21
   user_id: 18
   repo_id: 24
   mode: 4
 
 -
-  id: 19
+  id: 22
   user_id: 20
   repo_id: 24
   mode: 1
 
 -
-  id: 20
+  id: 23
   user_id: 20
   repo_id: 27
   mode: 4
 
 -
-  id: 21
+  id: 24
   user_id: 20
   repo_id: 28
   mode: 4
 
 -
-  id: 22
+  id: 25
   user_id: 29
   repo_id: 4
   mode: 2
 
 -
-  id: 23
+  id: 26
   user_id: 29
   repo_id: 24
   mode: 1
 
 -
-  id: 24
+  id: 27
   user_id: 31
   repo_id: 27
   mode: 4
 
 -
-  id: 25
+  id: 28
   user_id: 31
   repo_id: 28
   mode: 4
 
 -
-  id: 26
+  id: 29
   user_id: 38
   repo_id: 60
   mode: 2
 
 -
-  id: 27
+  id: 30
   user_id: 38
   repo_id: 61
   mode: 1
 
 -
-  id: 28
+  id: 31
   user_id: 39
   repo_id: 61
   mode: 1
 
 -
-  id: 29
+  id: 32
   user_id: 40
   repo_id: 61
   mode: 4

--- a/models/fixtures/issue.yml
+++ b/models/fixtures/issue.yml
@@ -372,3 +372,71 @@
   created_unix: 1707270422
   updated_unix: 1707270422
   is_locked: false
+
+-
+  id: 23
+  repo_id: 1
+  index: 6
+  poster_id: 2
+  original_author_id: 0
+  name: repo1 issue6
+  content: content for repo1 issue6
+  milestone_id: 0
+  priority: 0
+  is_closed: false
+  is_pull: false
+  num_comments: 0
+  created_unix: 1707270422
+  updated_unix: 1707270422
+  is_locked: false
+
+-
+  id: 24
+  repo_id: 23
+  index: 2
+  poster_id: 2
+  original_author_id: 0
+  name: repo1 issue6
+  content: content for repo1 issue6
+  milestone_id: 0
+  priority: 0
+  is_closed: false
+  is_pull: false
+  num_comments: 0
+  created_unix: 1707270422
+  updated_unix: 1707270422
+  is_locked: false
+
+-
+  id: 25
+  repo_id: 41
+  index: 1
+  poster_id: 2
+  original_author_id: 0
+  name: repo41 issue1
+  content: content for repo41 issue1
+  milestone_id: 0
+  priority: 0
+  is_closed: false
+  is_pull: false
+  num_comments: 0
+  created_unix: 1707270422
+  updated_unix: 1707270422
+  is_locked: false
+
+-
+  id: 26
+  repo_id: 41
+  index: 2
+  poster_id: 2
+  original_author_id: 0
+  name: repo41 issue2
+  content: content for repo41 issue2
+  milestone_id: 0
+  priority: 0
+  is_closed: false
+  is_pull: false
+  num_comments: 0
+  created_unix: 1707270422
+  updated_unix: 1707270422
+  is_locked: false

--- a/models/fixtures/issue_index.yml
+++ b/models/fixtures/issue_index.yml
@@ -1,6 +1,6 @@
 -
   group_id: 1
-  max_index: 5
+  max_index: 6
 -
   group_id: 2
   max_index: 2
@@ -11,11 +11,17 @@
   group_id: 10
   max_index: 1
 -
+  group_id: 23
+  max_index: 2
+-
   group_id: 32
   max_index: 2
 -
   group_id: 48
   max_index: 1
+-
+  group_id: 41
+  max_index: 2
 -
   group_id: 42
   max_index: 1

--- a/models/fixtures/project.yml
+++ b/models/fixtures/project.yml
@@ -45,3 +45,51 @@
   type: 2
   created_unix: 1688973000
   updated_unix: 1688973000
+
+-
+  id: 5
+  title: project on repo23
+  owner_id: 0
+  repo_id: 23
+  is_closed: false
+  creator_id: 15
+  board_type: 1
+  type: 2
+  created_unix: 1688973000
+  updated_unix: 1688973000
+
+-
+  id: 6
+  title: project on org17
+  owner_id: 17
+  repo_id: 0
+  is_closed: false
+  creator_id: 15
+  board_type: 1
+  type: 2
+  created_unix: 1688973000
+  updated_unix: 1688973000
+
+-
+  id: 7
+  title: project on private_repo_on_private_org
+  owner_id: 0
+  repo_id: 41
+  is_closed: false
+  creator_id: 2
+  board_type: 1
+  type: 2
+  created_unix: 1688973000
+  updated_unix: 1688973000
+
+-
+  id: 8
+  title: project on privated_org
+  owner_id: 23
+  repo_id: 0
+  is_closed: false
+  creator_id: 2
+  board_type: 1
+  type: 2
+  created_unix: 1688973000
+  updated_unix: 1688973000

--- a/models/fixtures/project_board.yml
+++ b/models/fixtures/project_board.yml
@@ -29,3 +29,35 @@
   creator_id: 2
   created_unix: 1588117528
   updated_unix: 1588117528
+
+-
+  id: 5
+  project_id: 5
+  title: Done
+  creator_id: 15
+  created_unix: 1588117528
+  updated_unix: 1588117528
+
+-
+  id: 6
+  project_id: 6
+  title: Done
+  creator_id: 15
+  created_unix: 1588117528
+  updated_unix: 1588117528
+
+-
+  id: 7
+  project_id: 7
+  title: Done
+  creator_id: 2
+  created_unix: 1588117528
+  updated_unix: 1588117528
+
+-
+  id: 8
+  project_id: 8
+  title: Done
+  creator_id: 2
+  created_unix: 1588117528
+  updated_unix: 1588117528

--- a/models/fixtures/project_issue.yml
+++ b/models/fixtures/project_issue.yml
@@ -21,3 +21,33 @@
   issue_id: 5
   project_id: 1
   project_board_id: 3
+
+-
+  id: 5
+  issue_id: 23
+  project_id: 4
+  project_board_id: 4
+
+-
+  id: 6
+  issue_id: 20
+  project_id: 5
+  project_board_id: 5
+
+-
+  id: 7
+  issue_id: 24
+  project_id: 6
+  project_board_id: 6
+
+-
+  id: 8
+  issue_id: 25
+  project_id: 7
+  project_board_id: 7
+
+-
+  id: 9
+  issue_id: 26
+  project_id: 8
+  project_board_id: 8

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -9,7 +9,7 @@
   num_watches: 4
   num_stars: 0
   num_forks: 0
-  num_issues: 2
+  num_issues: 3
   num_closed_issues: 1
   num_pulls: 3
   num_closed_pulls: 0

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -677,13 +677,13 @@
   num_watches: 0
   num_stars: 0
   num_forks: 0
-  num_issues: 0
+  num_issues: 1
   num_closed_issues: 0
   num_pulls: 1
   num_closed_pulls: 0
   num_milestones: 0
   num_closed_milestones: 0
-  num_projects: 0
+  num_projects: 1
   num_closed_projects: 0
   is_private: false
   is_empty: true
@@ -1225,13 +1225,13 @@
   num_watches: 0
   num_stars: 0
   num_forks: 0
-  num_issues: 0
+  num_issues: 2
   num_closed_issues: 0
   num_pulls: 0
   num_closed_pulls: 0
   num_milestones: 0
   num_closed_milestones: 0
-  num_projects: 0
+  num_projects: 1
   num_closed_projects: 0
   is_private: true
   is_empty: false

--- a/models/fixtures/team.yml
+++ b/models/fixtures/team.yml
@@ -81,7 +81,7 @@
   lower_name: test_team
   name: test_team
   authorize: 2 # write
-  num_repos: 1
+  num_repos: 2
   num_members: 1
   includes_all_repositories: false
   can_create_org_repo: false
@@ -170,7 +170,7 @@
   name: Owners
   authorize: 4 # owner
   num_repos: 0
-  num_members: 0
+  num_members: 1
   includes_all_repositories: false
   can_create_org_repo: true
 
@@ -237,5 +237,16 @@
   authorize: 1 # read
   num_repos: 1
   num_members: 2
+  includes_all_repositories: false
+  can_create_org_repo: false
+
+-
+  id: 23
+  org_id: 23
+  lower_name: teamwithnoissueaccess
+  name: teamwithnoissueaccess
+  authorize: 0 # write
+  num_repos: 1
+  num_members: 1
   includes_all_repositories: false
   can_create_org_repo: false

--- a/models/fixtures/team.yml
+++ b/models/fixtures/team.yml
@@ -180,7 +180,7 @@
   lower_name: team14writeauth
   name: team14WriteAuth
   authorize: 2 # write
-  num_repos: 0
+  num_repos: 1
   num_members: 1
   includes_all_repositories: false
   can_create_org_repo: true

--- a/models/fixtures/team.yml
+++ b/models/fixtures/team.yml
@@ -169,7 +169,7 @@
   lower_name: owners
   name: Owners
   authorize: 4 # owner
-  num_repos: 0
+  num_repos: 1
   num_members: 1
   includes_all_repositories: false
   can_create_org_repo: true

--- a/models/fixtures/team_repo.yml
+++ b/models/fixtures/team_repo.yml
@@ -75,3 +75,15 @@
   org_id: 41
   team_id: 22
   repo_id: 61
+
+-
+  id: 14
+  org_id: 23
+  team_id: 16
+  repo_id: 41
+
+-
+  id: 15
+  org_id: 23
+  team_id: 23
+  repo_id: 41

--- a/models/fixtures/team_repo.yml
+++ b/models/fixtures/team_repo.yml
@@ -85,5 +85,11 @@
 -
   id: 15
   org_id: 23
+  team_id: 17
+  repo_id: 41
+
+-
+  id: 16
+  org_id: 23
   team_id: 23
   repo_id: 41

--- a/models/fixtures/team_unit.yml
+++ b/models/fixtures/team_unit.yml
@@ -322,3 +322,21 @@
   team_id: 22
   type: 3
   access_mode: 1
+
+-
+  id: 55
+  team_id: 16
+  type: 2 # issue
+  access_mode: 4
+
+-
+  id: 56
+  team_id: 17
+  type: 2 # issue
+  access_mode: 2
+
+-
+  id: 57
+  team_id: 23
+  type: 2 # issue
+  access_mode: 0

--- a/models/fixtures/team_user.yml
+++ b/models/fixtures/team_user.yml
@@ -147,3 +147,15 @@
   org_id: 41
   team_id: 22
   uid: 39
+
+-
+  id: 26
+  org_id: 23
+  team_id: 16
+  uid: 2
+
+-
+  id: 27
+  org_id: 23
+  team_id: 23
+  uid: 4

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -844,7 +844,7 @@
   num_following: 0
   num_stars: 0
   num_repos: 2
-  num_teams: 2
+  num_teams: 3
   num_members: 1
   visibility: 2
   repo_admin_change_team_access: false

--- a/models/issues/issue_project_test.go
+++ b/models/issues/issue_project_test.go
@@ -1,0 +1,222 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issues_test
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/models/issues"
+	"code.gitea.io/gitea/models/organization"
+	"code.gitea.io/gitea/models/project"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_LoadIssuesFromBoard(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	user3 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3})
+	user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4})
+	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
+	user15 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 15})
+
+	org3 := unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 3})
+	org17 := unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 17})
+
+	projectBoard1 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 1})
+	projectBoard4 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 4})
+	projectBoard5 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 5})
+	projectBoard6 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 6})
+	projectBoard7 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 7})
+	projectBoard8 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 8})
+
+	tests := []struct {
+		name   string
+		board  *project.Board
+		user   *user_model.User
+		org    *organization.Organization
+		expect int
+	}{
+		{
+			name:   "individual public repo, repo project, owner",
+			board:  projectBoard1,
+			user:   user2,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "individual public repo, repo project, login user",
+			board:  projectBoard1,
+			user:   user3,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "individual public repo, repo project, non-login",
+			board:  projectBoard1,
+			user:   nil,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "individual public repo, individual project, owner",
+			board:  projectBoard4,
+			user:   user2,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "individual public repo, individual project, login user",
+			board:  projectBoard4,
+			user:   user3,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "individual public repo, individual project, non-login",
+			board:  projectBoard4,
+			user:   nil,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, repo project, org admin",
+			board:  projectBoard5,
+			user:   user15,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, repo project, member",
+			board:  projectBoard5,
+			user:   user2,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, repo project, login user",
+			board:  projectBoard5,
+			user:   user3,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, repo project, non-login",
+			board:  projectBoard5,
+			user:   nil,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, org project, org admin",
+			board:  projectBoard6,
+			user:   user15,
+			org:    org17,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, org project, member",
+			board:  projectBoard6,
+			user:   user2,
+			org:    org17,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, org project, login user",
+			board:  projectBoard6,
+			user:   user3,
+			org:    org17,
+			expect: 1,
+		},
+		{
+			name:   "organization public repo, org project, non-login",
+			board:  projectBoard6,
+			user:   nil,
+			org:    org17,
+			expect: 1,
+		},
+		{
+			name:   "organization private repo, repo project, org admin",
+			board:  projectBoard7,
+			user:   user2,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization private repo, repo project, member with issue access",
+			board:  projectBoard7,
+			user:   user5,
+			org:    nil,
+			expect: 1,
+		},
+		{
+			name:   "organization private repo, repo project, member without issue access",
+			board:  projectBoard7,
+			user:   user4,
+			org:    nil,
+			expect: 0,
+		},
+		{
+			name:   "organization private repo, repo project, login user",
+			board:  projectBoard7,
+			user:   user3,
+			org:    nil,
+			expect: 0,
+		},
+		{
+			name:   "organization private repo, repo project, non-login",
+			board:  projectBoard7,
+			user:   nil,
+			org:    nil,
+			expect: 0,
+		},
+		{
+			name:   "organization private repo, org project, org admin",
+			board:  projectBoard8,
+			user:   user2,
+			org:    org3,
+			expect: 1,
+		},
+		{
+			name:   "organization private repo, org project, member with issue access",
+			board:  projectBoard8,
+			user:   user5,
+			org:    org3,
+			expect: 1,
+		},
+		{
+			name:   "organization private repo, org project, member without issue access",
+			board:  projectBoard8,
+			user:   user4,
+			org:    org3,
+			expect: 0,
+		},
+		{
+			name:   "organization private repo, org project, login user",
+			board:  projectBoard8,
+			user:   user3,
+			org:    org3,
+			expect: 0,
+		},
+		{
+			name:   "organization private repo, org project, non-login",
+			board:  projectBoard8,
+			user:   nil,
+			org:    org3,
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := issues.LoadIssuesFromBoard(db.DefaultContext, tt.board, tt.user, tt.org)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expect, len(results))
+		})
+
+	}
+}

--- a/models/issues/issue_project_test.go
+++ b/models/issues/issue_project_test.go
@@ -24,8 +24,8 @@ func Test_LoadIssuesFromBoard(t *testing.T) {
 	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
 	user15 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 15})
 
-	org3 := unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 3})
 	org17 := unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 17})
+	org23 := unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 23})
 
 	projectBoard1 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 1})
 	projectBoard4 := unittest.AssertExistsAndLoadBean(t, &project.Board{ID: 4})
@@ -87,28 +87,28 @@ func Test_LoadIssuesFromBoard(t *testing.T) {
 			name:   "organization public repo, repo project, org admin",
 			board:  projectBoard5,
 			user:   user15,
-			org:    nil,
+			org:    org17,
 			expect: 1,
 		},
 		{
 			name:   "organization public repo, repo project, member",
 			board:  projectBoard5,
 			user:   user2,
-			org:    nil,
+			org:    org17,
 			expect: 1,
 		},
 		{
 			name:   "organization public repo, repo project, login user",
 			board:  projectBoard5,
 			user:   user3,
-			org:    nil,
+			org:    org17,
 			expect: 1,
 		},
 		{
 			name:   "organization public repo, repo project, non-login",
 			board:  projectBoard5,
 			user:   nil,
-			org:    nil,
+			org:    org17,
 			expect: 1,
 		},
 		{
@@ -143,70 +143,70 @@ func Test_LoadIssuesFromBoard(t *testing.T) {
 			name:   "organization private repo, repo project, org admin",
 			board:  projectBoard7,
 			user:   user2,
-			org:    nil,
+			org:    org23,
 			expect: 1,
 		},
 		{
 			name:   "organization private repo, repo project, member with issue access",
 			board:  projectBoard7,
 			user:   user5,
-			org:    nil,
+			org:    org23,
 			expect: 1,
 		},
 		{
 			name:   "organization private repo, repo project, member without issue access",
 			board:  projectBoard7,
 			user:   user4,
-			org:    nil,
+			org:    org23,
 			expect: 0,
 		},
 		{
 			name:   "organization private repo, repo project, login user",
 			board:  projectBoard7,
 			user:   user3,
-			org:    nil,
+			org:    org23,
 			expect: 0,
 		},
 		{
 			name:   "organization private repo, repo project, non-login",
 			board:  projectBoard7,
 			user:   nil,
-			org:    nil,
+			org:    org23,
 			expect: 0,
 		},
 		{
 			name:   "organization private repo, org project, org admin",
 			board:  projectBoard8,
 			user:   user2,
-			org:    org3,
+			org:    org23,
 			expect: 1,
 		},
 		{
 			name:   "organization private repo, org project, member with issue access",
 			board:  projectBoard8,
 			user:   user5,
-			org:    org3,
+			org:    org23,
 			expect: 1,
 		},
 		{
 			name:   "organization private repo, org project, member without issue access",
 			board:  projectBoard8,
 			user:   user4,
-			org:    org3,
+			org:    org23,
 			expect: 0,
 		},
 		{
 			name:   "organization private repo, org project, login user",
 			board:  projectBoard8,
 			user:   user3,
-			org:    org3,
+			org:    org23,
 			expect: 0,
 		},
 		{
 			name:   "organization private repo, org project, non-login",
 			board:  projectBoard8,
 			user:   nil,
-			org:    org3,
+			org:    org23,
 			expect: 0,
 		},
 	}

--- a/models/issues/issue_project_test.go
+++ b/models/issues/issue_project_test.go
@@ -217,6 +217,5 @@ func Test_LoadIssuesFromBoard(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expect, len(results))
 		})
-
 	}
 }

--- a/models/issues/issue_search.go
+++ b/models/issues/issue_search.go
@@ -328,7 +328,12 @@ func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *organizati
 	}
 	if org != nil {
 		if team != nil {
-			cond = cond.And(teamUnitsRepoCond(repoIDstr, userID, org.ID, team.ID, unitType)) // special team member repos
+			cond = cond.And(
+				builder.Or(
+					repo_model.PublicRepoCond(repoIDstr),                            // all public repos
+					teamUnitsRepoCond(repoIDstr, userID, org.ID, team.ID, unitType), // special team member repos
+				),
+			)
 		} else {
 			cond = cond.And(
 				builder.Or(

--- a/models/issues/issue_search.go
+++ b/models/issues/issue_search.go
@@ -332,6 +332,7 @@ func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *organizati
 		} else {
 			cond = cond.And(
 				builder.Or(
+					repo_model.PublicRepoCond(repoIDstr),                                // all public repos
 					repo_model.UserOrgUnitRepoCond(repoIDstr, userID, org.ID, unitType), // team member repos
 					repo_model.UserOrgPublicUnitRepoCond(userID, org.ID),                // user org public non-member repos, TODO: check repo has issues
 				),

--- a/models/issues/issue_search.go
+++ b/models/issues/issue_search.go
@@ -202,7 +202,7 @@ func applyRepoConditions(sess *xorm.Session, opts *IssuesOptions) *xorm.Session 
 		if opts.RepoCond == nil {
 			opts.RepoCond = builder.NewCond()
 		}
-		opts.RepoCond = opts.RepoCond.Or(builder.In("issue.repo_id", builder.Select("id").From("repository").Where(builder.Eq{"is_private": false})))
+		opts.RepoCond = opts.RepoCond.Or(repo_model.PublicRepoCond("issue.repo_id"))
 	}
 	if opts.RepoCond != nil {
 		sess.And(opts.RepoCond)
@@ -340,6 +340,7 @@ func issuePullAccessibleRepoCond(repoIDstr string, userID int64, org *organizati
 	} else {
 		cond = cond.And(
 			builder.Or(
+				repo_model.PublicRepoCond(repoIDstr),                          // all public repos
 				repo_model.UserOwnedRepoCond(userID),                          // owned repos
 				repo_model.UserAccessRepoCond(repoIDstr, userID),              // user can access repo in a unit independent way
 				repo_model.UserAssignedRepoCond(repoIDstr, userID),            // user has been assigned accessible public repos

--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -229,6 +229,10 @@ const (
 	SearchOrderByForksReverse          SearchOrderBy = "num_forks DESC"
 )
 
+func PublicRepoCond(id string) builder.Cond {
+	return builder.In(id, builder.Select("id").From("repository").Where(builder.Eq{"is_private": false}))
+}
+
 // UserOwnedRepoCond returns user ownered repositories
 func UserOwnedRepoCond(userID int64) builder.Cond {
 	return builder.Eq{

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -357,7 +357,7 @@ func ViewProject(ctx *context.Context) {
 		boards[0].Title = ctx.Locale.TrString("repo.projects.type.uncategorized")
 	}
 
-	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards)
+	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, ctx.Org.Organization)
 	if err != nil {
 		ctx.ServerError("LoadIssuesOfBoards", err)
 		return

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -359,7 +359,7 @@ func ViewProject(ctx *context.Context) {
 
 	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, ctx.Org.Organization)
 	if err != nil {
-		ctx.ServerError("LoadIssuesOfBoards", err)
+		ctx.ServerError("LoadIssuesFromBoardList", err)
 		return
 	}
 

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -319,7 +319,7 @@ func ViewProject(ctx *context.Context) {
 		boards[0].Title = ctx.Locale.TrString("repo.projects.type.uncategorized")
 	}
 
-	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, ctx.Org.Organization)
+	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, nil)
 	if err != nil {
 		ctx.ServerError("LoadIssuesOfBoards", err)
 		return

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -12,6 +12,7 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	issues_model "code.gitea.io/gitea/models/issues"
+	"code.gitea.io/gitea/models/organization"
 	"code.gitea.io/gitea/models/perm"
 	project_model "code.gitea.io/gitea/models/project"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -319,7 +320,11 @@ func ViewProject(ctx *context.Context) {
 		boards[0].Title = ctx.Locale.TrString("repo.projects.type.uncategorized")
 	}
 
-	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, nil)
+	var org *organization.Organization
+	if ctx.ContextUser.IsOrganization() {
+		org = (*organization.Organization)(ctx.ContextUser)
+	}
+	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, org)
 	if err != nil {
 		ctx.ServerError("LoadIssuesOfBoards", err)
 		return

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -319,7 +319,7 @@ func ViewProject(ctx *context.Context) {
 		boards[0].Title = ctx.Locale.TrString("repo.projects.type.uncategorized")
 	}
 
-	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards)
+	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, ctx.Org.Organization)
 	if err != nil {
 		ctx.ServerError("LoadIssuesOfBoards", err)
 		return

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -326,7 +326,7 @@ func ViewProject(ctx *context.Context) {
 	}
 	issuesMap, err := issues_model.LoadIssuesFromBoardList(ctx, boards, ctx.Doer, org)
 	if err != nil {
-		ctx.ServerError("LoadIssuesOfBoards", err)
+		ctx.ServerError("LoadIssuesFromBoardList", err)
 		return
 	}
 

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -56,8 +56,9 @@ func TestAPIListIssues(t *testing.T) {
 	link.RawQuery = url.Values{"token": {token}, "state": {"all"}, "created_by": {"user2"}}.Encode()
 	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	if assert.Len(t, apiIssues, 1) {
+	if assert.Len(t, apiIssues, 2) {
 		assert.EqualValues(t, 5, apiIssues[0].ID)
+		assert.EqualValues(t, 23, apiIssues[1].ID)
 	}
 
 	link.RawQuery = url.Values{"token": {token}, "state": {"all"}, "assigned_by": {"user1"}}.Encode()

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -57,8 +57,8 @@ func TestAPIListIssues(t *testing.T) {
 	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
 	if assert.Len(t, apiIssues, 2) {
-		assert.EqualValues(t, 23, apiIssues[1].ID)
-		assert.EqualValues(t, 5, apiIssues[0].ID)
+		assert.EqualValues(t, 23, apiIssues[0].ID)
+		assert.EqualValues(t, 5, apiIssues[1].ID)
 	}
 
 	link.RawQuery = url.Values{"token": {token}, "state": {"all"}, "assigned_by": {"user1"}}.Encode()

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -264,7 +264,7 @@ func TestAPISearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String()).AddTokenAuth(token)
 	resp = MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.EqualValues(t, "22", resp.Header().Get("X-Total-Count"))
+	assert.EqualValues(t, "26", resp.Header().Get("X-Total-Count"))
 	assert.Len(t, apiIssues, 20)
 
 	query.Add("limit", "10")
@@ -272,7 +272,7 @@ func TestAPISearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String()).AddTokenAuth(token)
 	resp = MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.EqualValues(t, "22", resp.Header().Get("X-Total-Count"))
+	assert.EqualValues(t, "26", resp.Header().Get("X-Total-Count"))
 	assert.Len(t, apiIssues, 10)
 
 	query = url.Values{"assigned": {"true"}, "state": {"all"}}
@@ -301,7 +301,7 @@ func TestAPISearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String()).AddTokenAuth(token)
 	resp = MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.Len(t, apiIssues, 8)
+	assert.Len(t, apiIssues, 9)
 
 	query = url.Values{"owner": {"org3"}} // organization
 	link.RawQuery = query.Encode()

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -57,8 +57,8 @@ func TestAPIListIssues(t *testing.T) {
 	resp = MakeRequest(t, NewRequest(t, "GET", link.String()), http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
 	if assert.Len(t, apiIssues, 2) {
-		assert.EqualValues(t, 5, apiIssues[0].ID)
 		assert.EqualValues(t, 23, apiIssues[1].ID)
+		assert.EqualValues(t, 5, apiIssues[0].ID)
 	}
 
 	link.RawQuery = url.Values{"token": {token}, "state": {"all"}, "assigned_by": {"user1"}}.Encode()

--- a/tests/integration/api_nodeinfo_test.go
+++ b/tests/integration/api_nodeinfo_test.go
@@ -33,7 +33,7 @@ func TestNodeinfo(t *testing.T) {
 		assert.True(t, nodeinfo.OpenRegistrations)
 		assert.Equal(t, "gitea", nodeinfo.Software.Name)
 		assert.Equal(t, 29, nodeinfo.Usage.Users.Total)
-		assert.Equal(t, 22, nodeinfo.Usage.LocalPosts)
+		assert.Equal(t, 26, nodeinfo.Usage.LocalPosts)
 		assert.Equal(t, 3, nodeinfo.Usage.LocalComments)
 	})
 }

--- a/tests/integration/api_repo_test.go
+++ b/tests/integration/api_repo_test.go
@@ -267,7 +267,7 @@ func TestAPIViewRepo(t *testing.T) {
 	assert.EqualValues(t, 1, repo.ID)
 	assert.EqualValues(t, "repo1", repo.Name)
 	assert.EqualValues(t, 2, repo.Releases)
-	assert.EqualValues(t, 1, repo.OpenIssues)
+	assert.EqualValues(t, 2, repo.OpenIssues)
 	assert.EqualValues(t, 3, repo.OpenPulls)
 
 	req = NewRequest(t, "GET", "/api/v1/repos/user12/repo10")

--- a/tests/integration/issue_test.go
+++ b/tests/integration/issue_test.go
@@ -444,7 +444,7 @@ func TestSearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String())
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.EqualValues(t, "22", resp.Header().Get("X-Total-Count"))
+	assert.EqualValues(t, "26", resp.Header().Get("X-Total-Count"))
 	assert.Len(t, apiIssues, 20)
 
 	query.Add("limit", "5")
@@ -452,7 +452,7 @@ func TestSearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String())
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.EqualValues(t, "22", resp.Header().Get("X-Total-Count"))
+	assert.EqualValues(t, "26", resp.Header().Get("X-Total-Count"))
 	assert.Len(t, apiIssues, 5)
 
 	query = url.Values{"assigned": {"true"}, "state": {"all"}}
@@ -481,7 +481,7 @@ func TestSearchIssues(t *testing.T) {
 	req = NewRequest(t, "GET", link.String())
 	resp = session.MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
-	assert.Len(t, apiIssues, 8)
+	assert.Len(t, apiIssues, 9)
 
 	query = url.Values{"owner": {"org3"}} // organization
 	link.RawQuery = query.Encode()

--- a/tests/integration/org_test.go
+++ b/tests/integration/org_test.go
@@ -90,7 +90,7 @@ func TestPrivateOrg(t *testing.T) {
 	MakeRequest(t, req, http.StatusNotFound)
 
 	// login non-org member user
-	session := loginUser(t, "user2")
+	session := loginUser(t, "user8")
 	req = NewRequest(t, "GET", "/privated_org")
 	session.MakeRequest(t, req, http.StatusNotFound)
 	req = NewRequest(t, "GET", "/privated_org/public_repo_on_private_org")


### PR DESCRIPTION
A part of #22865

#### We already have `AllPublic` option, but why still need to add `PublicRepoCond` again in `issuePullAccessibleRepoCond` ?

Then condition will look like:
``` text
where [PublicRepoCond] and [issuePullAccessibleRepoCond] and [other conditions]
```
If `AllPublic` is true and  `opts.User` is not nil, because of  the relationship `and`, we will only find public repos of doer owned/ listed in `access` table/ assigned,mentioned or created issues in it, so other public repos will be ignored.
But it is not correct, as doer can also access these public repos.

#23630 maybe related.