### PR TITLE
Added support for custom Telegram proxy host

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2433,6 +2433,7 @@ settings.tags.protection.none = There are no protected tags.
 settings.tags.protection.pattern.description = You can use a single name or a glob pattern or regular expression to match multiple tags. Read more in the <a target="_blank" rel="noopener" href="https://docs.gitea.com/usage/protected-tags">protected tags guide</a>.
 settings.bot_token = Bot Token
 settings.chat_id = Chat ID
+settings.custom_host= Custom Host
 settings.thread_id = Thread ID
 settings.matrix.homeserver_url = Homeserver URL
 settings.matrix.room_id = Room ID

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -425,15 +425,19 @@ func TelegramHooksEditPost(ctx *context.Context) {
 func telegramHookParams(ctx *context.Context) webhookParams {
 	form := web.GetForm(ctx).(*forms.NewTelegramHookForm)
 
+	if form.CustomHost == "" {
+		form.CustomHost = "https://api.telegram.org"
+	}
 	return webhookParams{
 		Type:        webhook_module.TELEGRAM,
-		URL:         fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage?chat_id=%s&message_thread_id=%s", url.PathEscape(form.BotToken), url.QueryEscape(form.ChatID), url.QueryEscape(form.ThreadID)),
+		URL:         fmt.Sprintf("%s/bot%s/sendMessage?chat_id=%s&message_thread_id=%s", form.CustomHost, url.PathEscape(form.BotToken), url.QueryEscape(form.ChatID), url.QueryEscape(form.ThreadID)),
 		ContentType: webhook.ContentTypeJSON,
 		WebhookForm: form.WebhookForm,
 		Meta: &webhook_service.TelegramMeta{
-			BotToken: form.BotToken,
-			ChatID:   form.ChatID,
-			ThreadID: form.ThreadID,
+			BotToken:   form.BotToken,
+			ChatID:     form.ChatID,
+			CustomHost: form.CustomHost,
+			ThreadID:   form.ThreadID,
 		},
 	}
 }

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -350,9 +350,10 @@ func (f *NewDingtalkHookForm) Validate(req *http.Request, errs binding.Errors) b
 
 // NewTelegramHookForm form for creating telegram hook
 type NewTelegramHookForm struct {
-	BotToken string `binding:"Required"`
-	ChatID   string `binding:"Required"`
-	ThreadID string
+	BotToken   string `binding:"Required"`
+	ChatID     string `binding:"Required"`
+	CustomHost string
+	ThreadID   string
 	WebhookForm
 }
 

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -26,9 +26,10 @@ type (
 
 	// TelegramMeta contains the telegram metadata
 	TelegramMeta struct {
-		BotToken string `json:"bot_token"`
-		ChatID   string `json:"chat_id"`
-		ThreadID string `json:"thread_id"`
+		BotToken   string `json:"bot_token"`
+		ChatID     string `json:"chat_id"`
+		CustomHost string `json:"custom_host"`
+		ThreadID   string `json:"thread_id"`
 	}
 )
 

--- a/templates/repo/settings/webhook/telegram.tmpl
+++ b/templates/repo/settings/webhook/telegram.tmpl
@@ -10,6 +10,10 @@
 			<label for="chat_id">{{ctx.Locale.Tr "repo.settings.chat_id"}}</label>
 			<input id="chat_id" name="chat_id" type="text" value="{{.TelegramHook.ChatID}}" required>
 		</div>
+		<div class="field {{if .Err_CustomHost}}error{{end}}">
+			<label for="custom_host">{{ctx.Locale.Tr "repo.settings.custom_host"}}</label>
+			<input id="custom_host" name="custom_host" type="text" value="{{.TelegramHook.CustomHost}}" placeholder="https://api.telegram.org">
+		</div>
 		<div class="field {{if .Err_ThreadID}}error{{end}}">
 			<label for="thread_id">{{ctx.Locale.Tr "repo.settings.thread_id"}}</label>
 			<input id="thread_id" name="thread_id" type="text" value="{{.TelegramHook.ThreadID}}">


### PR DESCRIPTION
Added support for custom Telegram proxy domain names

In some specific environments, it supports defining the proxy or self-built domain name of the telegram bot API 

