### PR TITLE
bump python version to 3.12 in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "ghcr.io/devcontainers/features/git-lfs:1.1.0": {},
     "ghcr.io/devcontainers-contrib/features/poetry:2": {},
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.10"
+      "version": "3.12"
     }
   },
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
     },
     "ghcr.io/devcontainers/features/git-lfs:1.1.0": {},
     "ghcr.io/devcontainers-contrib/features/poetry:2": {},
-    "ghcr.io/devcontainers/features/python:1": {}
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.10"
+    }
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
![image](https://github.com/go-gitea/gitea/assets/18380374/963dc021-ac9b-4713-8344-654f966c80a4)

The default version is 3.9.2, which is not supported by poetry.