### PR TITLE
Use more specific selector for `name` links

### DIFF
--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -39,8 +39,7 @@ export function initMarkupAnchors() {
     if (!href.startsWith('#user-content-')) continue;
     const originalId = href.replace(/^#user-content-/, '');
     a.setAttribute('href', `#${encodeURIComponent(originalId)}`);
-    const nameLinks = a.closest('.markup').querySelectorAll(`a[name="${originalId}"]`);
-    if (nameLinks.length !== 1) {
+    if (a.closest('.markup').querySelectorAll(`a[name="${originalId}"]`).length !== 1) {
       a.addEventListener('click', (e) => {
         scrollToAnchor(e.currentTarget.getAttribute('href'), false);
       });

--- a/web_src/js/markup/anchors.js
+++ b/web_src/js/markup/anchors.js
@@ -39,7 +39,8 @@ export function initMarkupAnchors() {
     if (!href.startsWith('#user-content-')) continue;
     const originalId = href.replace(/^#user-content-/, '');
     a.setAttribute('href', `#${encodeURIComponent(originalId)}`);
-    if (document.getElementsByName(originalId).length !== 1) {
+    const nameLinks = a.closest('.markup').querySelectorAll(`a[name="${originalId}"]`);
+    if (nameLinks.length !== 1) {
       a.addEventListener('click', (e) => {
         scrollToAnchor(e.currentTarget.getAttribute('href'), false);
       });


### PR DESCRIPTION
Followup https://github.com/go-gitea/gitea/pull/29305. As per discussion in https://github.com/go-gitea/gitea/pull/29666#discussion_r1517506422, make this selector only search in the current `.markup` document, as there can be multiples displayed at the same time.

@DanielMatiasCarvalho maybe you can review.