### PR TITLE
Include go files in tailwind processing

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,7 +31,7 @@ export default {
     isProduction && '!./web_src/js/standalone/devtest.js',
     '!./templates/swagger/v1_json.tmpl',
     '!./templates/user/auth/oidc_wellknown.tmpl',
-    '!./modules/{public,options/templates}/bindata.go',
+    '!./modules/{public,options,templates}/bindata.go',
     './{build,models,modules,routers,services}/**/*.go',
     './templates/**/*.tmpl',
     './web_src/js/**/*.{js,vue}',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,7 @@ export default {
     isProduction && '!./web_src/js/standalone/devtest.js',
     '!./templates/swagger/v1_json.tmpl',
     '!./templates/user/auth/oidc_wellknown.tmpl',
+    '!**/*_test.go',
     '!./modules/{public,options,templates}/bindata.go',
     './{build,models,modules,routers,services}/**/*.go',
     './templates/**/*.tmpl',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,8 @@ export default {
     isProduction && '!./web_src/js/standalone/devtest.js',
     '!./templates/swagger/v1_json.tmpl',
     '!./templates/user/auth/oidc_wellknown.tmpl',
+    '!./modules/{public,options/templates}/bindata.go',
+    './{build,models,modules,routers,services}/**/*.go',
     './templates/**/*.tmpl',
     './web_src/js/**/*.{js,vue}',
   ].filter(Boolean),


### PR DESCRIPTION
We need to scan `.go` files for tailwind classes. Does not seem to affect build time much luckily.

Fixes: https://github.com/go-gitea/gitea/pull/29678#discussion_r1518448600

Verified via `rg tw-object-contain public/assets/css/index.css`.