### PR TITLE
Fix WebHookEditor regression from jQuery removal

### DIFF
--- a/web_src/js/features/comp/WebHookEditor.js
+++ b/web_src/js/features/comp/WebHookEditor.js
@@ -22,14 +22,14 @@ export function initCompWebHookEditor() {
     });
   }
 
+  // some webhooks (like Gitea) allow to set the request method (GET/POST), and it would toggle the "Content Type" field
   const httpMethodInput = document.getElementById('http_method');
   if (httpMethodInput) {
     const updateContentType = function () {
       const visible = httpMethodInput.value === 'POST';
-      toggleElem(document.getElementById('content_type')?.parentNode.parentNode, visible);
+      toggleElem(document.getElementById('content_type').closest('.field'), visible);
     };
     updateContentType();
-
     httpMethodInput.addEventListener('change', updateContentType);
   }
 

--- a/web_src/js/features/comp/WebHookEditor.js
+++ b/web_src/js/features/comp/WebHookEditor.js
@@ -22,13 +22,16 @@ export function initCompWebHookEditor() {
     });
   }
 
-  const updateContentType = function () {
-    const visible = document.getElementById('http_method')?.value === 'POST';
-    toggleElem(document.getElementById('content_type')?.parentNode.parentNode, visible);
-  };
-  updateContentType();
+  const httpMethodInput = document.getElementById('http_method');
+  if (httpMethodInput) {
+    const updateContentType = function () {
+      const visible = httpMethodInput.value === 'POST';
+      toggleElem(document.getElementById('content_type')?.parentNode.parentNode, visible);
+    };
+    updateContentType();
 
-  document.getElementById('http_method')?.addEventListener('change', updateContentType);
+    httpMethodInput.addEventListener('change', updateContentType);
+  }
 
   // Test delivery
   document.getElementById('test-delivery')?.addEventListener('click', async function () {

--- a/web_src/js/features/comp/WebHookEditor.js
+++ b/web_src/js/features/comp/WebHookEditor.js
@@ -23,12 +23,12 @@ export function initCompWebHookEditor() {
   }
 
   const updateContentType = function () {
-    const visible = document.getElementById('http_method').value === 'POST';
-    toggleElem(document.getElementById('content_type').parentNode.parentNode, visible);
+    const visible = document.getElementById('http_method')?.value === 'POST';
+    toggleElem(document.getElementById('content_type')?.parentNode.parentNode, visible);
   };
   updateContentType();
 
-  document.getElementById('http_method').addEventListener('change', updateContentType);
+  document.getElementById('http_method')?.addEventListener('change', updateContentType);
 
   // Test delivery
   document.getElementById('test-delivery')?.addEventListener('click', async function () {


### PR DESCRIPTION
Make these calls optional

- Fix https://github.com/go-gitea/gitea/pull/29211#discussion_r1518558584