### PR TITLE
Fix due dates not rendering with a one-off date

### DIFF
--- a/web_src/js/features/midnight.js
+++ b/web_src/js/features/midnight.js
@@ -1,0 +1,22 @@
+// Some timestamps are not meant to be localized in the user's timezone, only in their language.
+// This is true for due date timestamps. These include a specific year, month, and day combination. If a user in one timezone
+// sets the date YYYY-MM-DD, another user should see the same date, regardless of their timezone. So when a relative-time element
+// has their datetime attribute specified only as YYYY-MM-DD, we will update it to YYYY-MM-DD midnight in the user's timezone.
+// When the date is rendered, the only localization that will happen is the language.
+
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+// for all relative-time elements, if their datetime attribute is YYYY-MM-DD, we will update it to YYYY-MM-DD midnight in the user's timezone
+export function initMidnightRelativeTime() {
+  const relativeTimeElements = document.querySelectorAll('relative-time[datetime]');
+
+  for (const element of relativeTimeElements) {
+    const datetimeAttr = element.getAttribute('datetime');
+
+    if (dateRegex.test(datetimeAttr)) {
+      const [year, month, day] = datetimeAttr.split('-');
+      const userMidnight = new Date(year, month - 1, day);
+      element.setAttribute('datetime', userMidnight.toISOString());
+    }
+  }
+}

--- a/web_src/js/index.js
+++ b/web_src/js/index.js
@@ -85,12 +85,14 @@ import {initRepoRecentCommits} from './features/recent-commits.js';
 import {initRepoDiffCommitBranchesAndTags} from './features/repo-diff-commit.js';
 import {initDirAuto} from './modules/dirauto.js';
 import {initRepositorySearch} from './features/repo-search.js';
+import {initMidnightRelativeTime} from './features/midnight.js';
 
 // Init Gitea's Fomantic settings
 initGiteaFomantic();
 initDirAuto();
 
 onDomReady(() => {
+  initMidnightRelativeTime();
   initGlobalCommon();
 
   initGlobalTooltips();


### PR DESCRIPTION
- Fix https://github.com/go-gitea/gitea/issues/29034

Some timestamps are not meant to be localized in the user's timezone, only in their language. This is true for due date timestamps. These include a specific year, month, and day combination. If a user in one timezone sets the date YYYY-MM-DD, another user should see the same date, regardless of their timezone. So when a relative-time element has their datetime attribute specified only as YYYY-MM-DD, we will update it to YYYY-MM-DD midnight in the user's timezone. When the date is rendered, the only localization that will happen is the language.

For all relative-time elements, if their datetime attribute is YYYY-MM-DD, we will update it to YYYY-MM-DD midnight in the user's timezone.

# Demo GIFs

In these GIFs, I do the following:
1. Create an issue
2. Set its milestone to July 1, 2024
3. Show how it's rendered (it's rendered correctly in both cases)
4. Change my timezone to Arizona
5. Refresh the page
6. Show how it's rendered (incorrect in the "before" GIF, correct in the after GIF)

## Before
![before](https://github.com/go-gitea/gitea/assets/20454870/0be9c8e8-566b-4a7d-b3c9-8f3f418cd93a)

## After
![after](https://github.com/go-gitea/gitea/assets/20454870/06a65759-13e0-4dfb-b20b-81a4fb150ad9)
