### PR TITLE
refactor query key for fuzzy search

### DIFF
--- a/routers/web/explore/code.go
+++ b/routers/web/explore/code.go
@@ -34,12 +34,11 @@ func Code(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	queryType := ctx.FormTrim("t")
-	isFuzzy := queryType != "match"
+	isFuzzy := ctx.FormBool("fuzzy")
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language
-	ctx.Data["queryType"] = queryType
+	ctx.Data["IsFuzzy"] = isFuzzy
 	ctx.Data["PageIsViewCode"] = true
 
 	if keyword == "" {

--- a/routers/web/explore/code.go
+++ b/routers/web/explore/code.go
@@ -34,7 +34,7 @@ func Code(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	isFuzzy := ctx.FormBool("fuzzy")
+	isFuzzy := ctx.FormOptionalBool("fuzzy").ValueOrDefault(true)
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -24,12 +24,11 @@ func Search(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	queryType := ctx.FormTrim("t")
-	isFuzzy := queryType != "match"
+	isFuzzy := ctx.FormBool("fuzzy")
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language
-	ctx.Data["queryType"] = queryType
+	ctx.Data["IsFuzzy"] = isFuzzy
 	ctx.Data["PageIsViewCode"] = true
 
 	if keyword == "" {

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -24,7 +24,7 @@ func Search(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	isFuzzy := ctx.FormBool("fuzzy")
+	isFuzzy := ctx.FormOptionalBool("fuzzy").ValueOrDefault(true)
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language

--- a/routers/web/user/code.go
+++ b/routers/web/user/code.go
@@ -39,12 +39,11 @@ func CodeSearch(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	queryType := ctx.FormTrim("t")
-	isFuzzy := queryType != "match"
+	isFuzzy := ctx.FormBool("fuzzy")
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language
-	ctx.Data["queryType"] = queryType
+	ctx.Data["IsFuzzy"] = isFuzzy
 	ctx.Data["IsCodePage"] = true
 
 	if keyword == "" {

--- a/routers/web/user/code.go
+++ b/routers/web/user/code.go
@@ -39,7 +39,7 @@ func CodeSearch(ctx *context.Context) {
 	language := ctx.FormTrim("l")
 	keyword := ctx.FormTrim("q")
 
-	isFuzzy := ctx.FormBool("fuzzy")
+	isFuzzy := ctx.FormOptionalBool("fuzzy").ValueOrDefault(true)
 
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["Language"] = language

--- a/templates/code/searchform.tmpl
+++ b/templates/code/searchform.tmpl
@@ -1,7 +1,7 @@
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
 		{{template "shared/searchinput" dict "Value" .Keyword "Disabled" .CodeIndexerUnavailable}}
-		{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "QueryType" .queryType "Topic" "explore"}}
+		{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "IsFuzzy" .IsFuzzy "Topic" "explore"}}
 		<button class="ui primary button"{{if .CodeIndexerUnavailable}} disabled{{end}}>{{ctx.Locale.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/code/searchform.tmpl
+++ b/templates/code/searchform.tmpl
@@ -1,14 +1,7 @@
 <form class="ui form ignore-dirty">
 	<div class="ui fluid action input">
 		{{template "shared/searchinput" dict "Value" .Keyword "Disabled" .CodeIndexerUnavailable}}
-		<div class="ui dropdown selection {{if .CodeIndexerUnavailable}} disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr "explore.search.type.tooltip"}}">
-			<input name="t" type="hidden" value="{{.queryType}}"{{if .CodeIndexerUnavailable}} disabled{{end}}>{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-			<div class="text">{{ctx.Locale.Tr (printf "explore.search.%s" (or .queryType "fuzzy"))}}</div>
-			<div class="menu">
-				<div class="item" data-value="" data-tooltip-content="{{ctx.Locale.Tr "explore.search.fuzzy.tooltip"}}">{{ctx.Locale.Tr "explore.search.fuzzy"}}</div>
-				<div class="item" data-value="match" data-tooltip-content="{{ctx.Locale.Tr "explore.search.match.tooltip"}}">{{ctx.Locale.Tr "explore.search.match"}}</div>
-			</div>
-		</div>
+		{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "QueryType" .queryType "Topic" "explore"}}
 		<button class="ui primary button"{{if .CodeIndexerUnavailable}} disabled{{end}}>{{ctx.Locale.Tr "explore.search"}}</button>
 	</div>
 </form>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -6,14 +6,7 @@
 			<form class="ui form ignore-dirty" method="get">
 				<div class="ui fluid action input">
 					<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable}} disabled{{end}} placeholder="{{ctx.Locale.Tr "repo.search.search_repo"}}">
-					<div class="ui dropdown selection {{if .CodeIndexerUnavailable}} disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.search.type.tooltip"}}">
-						<input name="t" type="hidden"{{if .CodeIndexerUnavailable}} disabled{{end}} value="{{.queryType}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="text">{{ctx.Locale.Tr (printf "repo.search.%s" (or .queryType "fuzzy"))}}</div>
-						<div class="menu">
-							<div class="item" data-value="" data-tooltip-content="{{ctx.Locale.Tr "repo.search.fuzzy.tooltip"}}">{{ctx.Locale.Tr "repo.search.fuzzy"}}</div>
-							<div class="item" data-value="match" data-tooltip-content="{{ctx.Locale.Tr "repo.search.match.tooltip"}}">{{ctx.Locale.Tr "repo.search.match"}}</div>
-						</div>
-					</div>
+					{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "QueryType" .queryType "Topic" "repo"}}
 					<button class="ui icon button"{{if .CodeIndexerUnavailable}} disabled{{end}} type="submit">{{svg "octicon-search" 16}}</button>
 				</div>
 			</form>

--- a/templates/repo/search.tmpl
+++ b/templates/repo/search.tmpl
@@ -6,7 +6,7 @@
 			<form class="ui form ignore-dirty" method="get">
 				<div class="ui fluid action input">
 					<input name="q" value="{{.Keyword}}"{{if .CodeIndexerUnavailable}} disabled{{end}} placeholder="{{ctx.Locale.Tr "repo.search.search_repo"}}">
-					{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "QueryType" .queryType "Topic" "repo"}}
+					{{template "shared/searchfuzzy" dict "Disabled" .CodeIndexerUnavailable "IsFuzzy" .IsFuzzy "Topic" "repo"}}
 					<button class="ui icon button"{{if .CodeIndexerUnavailable}} disabled{{end}} type="submit">{{svg "octicon-search" 16}}</button>
 				</div>
 			</form>

--- a/templates/shared/searchfuzzy.tmpl
+++ b/templates/shared/searchfuzzy.tmpl
@@ -1,0 +1,8 @@
+<div class="ui dropdown selection {{if .Disabled}} disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.type.tooltip" .Topic)}}">
+	<input name="t" type="hidden"{{if .Disabled}} disabled{{end}} value="{{.QueryType}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+	<div class="text">{{ctx.Locale.Tr (printf "%s.search.%s" .Topic (or .QueryType "fuzzy"))}}</div>
+	<div class="menu">
+		<div class="item" data-value="fuzzy" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.fuzzy.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.fuzzy" .Topic)}}</div>
+		<div class="item" data-value="match" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.match.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.match" .Topic)}}</div>
+	</div>
+</div>

--- a/templates/shared/searchfuzzy.tmpl
+++ b/templates/shared/searchfuzzy.tmpl
@@ -1,3 +1,4 @@
+<!-- Topic can be "repo" or "explore" -->
 <div class="ui dropdown selection {{if .Disabled}} disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.type.tooltip" .Topic)}}">
 	<input name="t" type="hidden"{{if .Disabled}} disabled{{end}} value="{{.QueryType}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="text">{{ctx.Locale.Tr (printf "%s.search.%s" .Topic (or .QueryType "fuzzy"))}}</div>

--- a/templates/shared/searchfuzzy.tmpl
+++ b/templates/shared/searchfuzzy.tmpl
@@ -1,9 +1,13 @@
 <!-- Topic can be "repo" or "explore" -->
 <div class="ui dropdown selection {{if .Disabled}} disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.type.tooltip" .Topic)}}">
-	<input name="t" type="hidden"{{if .Disabled}} disabled{{end}} value="{{.QueryType}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-	<div class="text">{{ctx.Locale.Tr (printf "%s.search.%s" .Topic (or .QueryType "fuzzy"))}}</div>
+	<input name="fuzzy" type="hidden"{{if .Disabled}} disabled{{end}} value="{{.IsFuzzy}}">{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+	{{if .IsFuzzy}}
+		<div class="text">{{ctx.Locale.Tr (printf "%s.search.fuzzy" .Topic)}}</div>
+	{{else}}
+		<div class="text">{{ctx.Locale.Tr (printf "%s.search.match" .Topic)}}</div>
+	{{end}}
 	<div class="menu">
-		<div class="item" data-value="fuzzy" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.fuzzy.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.fuzzy" .Topic)}}</div>
-		<div class="item" data-value="match" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.match.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.match" .Topic)}}</div>
+		<div class="item" data-value="true" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.fuzzy.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.fuzzy" .Topic)}}</div>
+		<div class="item" data-value="false" data-tooltip-content="{{ctx.Locale.Tr (printf "%s.search.match.tooltip" .Topic)}}">{{ctx.Locale.Tr (printf "%s.search.match" .Topic)}}</div>
 	</div>
 </div>


### PR DESCRIPTION
Instead of a generic `t` param, we should use `fuzzy` as boolean key to enable or disable the fuzzy search.

Additionally, unify the templates.