### PR TITLE
Use `<gitea-absolute-date>` on contributor graph

### DIFF
--- a/web_src/js/components/RepoContributors.vue
+++ b/web_src/js/components/RepoContributors.vue
@@ -22,6 +22,7 @@ import {chartJsColors} from '../utils/color.js';
 import {sleep} from '../utils.js';
 import 'chartjs-adapter-dayjs-4/dist/chartjs-adapter-dayjs-4.esm';
 import $ from 'jquery';
+import dayjs from 'dayjs';
 
 const {pageData} = window.config;
 
@@ -210,6 +211,10 @@ export default {
       };
     },
 
+    formatDate(date) {
+      return dayjs(date).format('YYYY-MM-DD');
+    },
+
     updateOtherCharts(event, reset) {
       const minVal = event.chart.options.scales.x.min;
       const maxVal = event.chart.options.scales.x.max;
@@ -305,29 +310,27 @@ export default {
   <div>
     <div class="ui header gt-df gt-ac gt-sb">
       <div>
-        <relative-time
+        <gitea-absolute-date
           v-if="xAxisMin > 0"
-          format="datetime"
           year="numeric"
-          month="short"
+          month="long"
           day="numeric"
           weekday=""
-          :datetime="new Date(xAxisMin)"
+          :date="formatDate(xAxisMin)"
         >
-          {{ new Date(xAxisMin) }}
-        </relative-time>
+          {{ formatDate(xAxisMin) }}
+        </gitea-absolute-date>
         {{ isLoading ? locale.loadingTitle : errorText ? locale.loadingTitleFailed: "-" }}
-        <relative-time
+        <gitea-absolute-date
           v-if="xAxisMax > 0"
-          format="datetime"
           year="numeric"
-          month="short"
+          month="long"
           day="numeric"
           weekday=""
-          :datetime="new Date(xAxisMax)"
+          :date="formatDate(xAxisMax)"
         >
-          {{ new Date(xAxisMax) }}
-        </relative-time>
+          {{ formatDate(xAxisMin) }}
+        </gitea-absolute-date>
       </div>
       <div>
         <!-- Contribution type -->


### PR DESCRIPTION
Before:

<img width="354" alt="Screenshot 2024-03-13 at 01 42 23" src="https://github.com/go-gitea/gitea/assets/115237/9078a62c-ff12-452a-a477-9e36ddc6a53f">

After (no tooltip):

<img width="337" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/57872cbe-7984-46fc-8d65-3a2d271814f9">

