### PR TITLE
fix missed RenderLabel change in card template

### DIFF
--- a/templates/repo/issue/card.tmpl
+++ b/templates/repo/issue/card.tmpl
@@ -61,7 +61,7 @@
 	{{if or .Labels .Assignees}}
 	<div class="extra content labels-list gt-p-0 gt-pt-2">
 		{{range .Labels}}
-			<a target="_blank" href="{{$.Issue.Repo.Link}}/issues?labels={{.ID}}">{{RenderLabel ctx .}}</a>
+			<a target="_blank" href="{{$.Issue.Repo.Link}}/issues?labels={{.ID}}">{{RenderLabel ctx ctx.Locale .}}</a>
 		{{end}}
 		<div class="right floated">
 			{{range .Assignees}}


### PR DESCRIPTION
regression of #29680
close  #29770

PS: it would be nice to have a linter that is able to check template helpers ...