### PR TITLE
Fix lint-swagger warning

### DIFF
--- a/modules/structs/user.go
+++ b/modules/structs/user.go
@@ -132,10 +132,3 @@ type UserBadgeOption struct {
 	// example: ["badge1","badge2"]
 	BadgeSlugs []string `json:"badge_slugs" binding:"Required"`
 }
-
-// BadgeList
-// swagger:response BadgeList
-type BadgeList struct {
-	// in:body
-	Body []Badge `json:"body"`
-}

--- a/routers/api/v1/swagger/options.go
+++ b/routers/api/v1/swagger/options.go
@@ -193,7 +193,4 @@ type swaggerParameterBodies struct {
 
 	// in:body
 	UserBadgeOption api.UserBadgeOption
-
-	// in:body
-	UserBadgeList api.BadgeList
 }

--- a/routers/api/v1/swagger/user.go
+++ b/routers/api/v1/swagger/user.go
@@ -48,3 +48,10 @@ type swaggerResponseUserSettings struct {
 	// in:body
 	Body []api.UserSettings `json:"body"`
 }
+
+// BadgeList
+// swagger:response BadgeList
+type swaggerResponseBadgeList struct {
+	// in:body
+	Body []api.Badge `json:"body"`
+}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -17413,21 +17413,6 @@
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
-    "BadgeList": {
-      "description": "BadgeList",
-      "type": "object",
-      "properties": {
-        "body": {
-          "description": "in:body",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Badge"
-          },
-          "x-go-name": "Body"
-        }
-      },
-      "x-go-package": "code.gitea.io/gitea/modules/structs"
-    },
     "Branch": {
       "description": "Branch represents a repository branch",
       "type": "object",
@@ -24722,7 +24707,7 @@
     "parameterBodies": {
       "description": "parameterBodies",
       "schema": {
-        "$ref": "#/definitions/BadgeList"
+        "$ref": "#/definitions/UserBadgeOption"
       }
     },
     "redirect": {


### PR DESCRIPTION
Caused by: #23106
Fix: https://github.com/go-gitea/gitea/actions/runs/8274650046/job/22640335697

1. Delete `UserBadgeList` in `options.go`, because it wasn't used. (The struct defined in `options.go` is the struct used to parse the request body)
2. Move `BadgeList` struct under `routers/api/v1/swagger` folder which response should be defined in.