### PR TITLE
Support GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT env

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -158,9 +158,14 @@ func loadCommonSettingsFrom(cfg ConfigProvider) error {
 func loadRunModeFrom(rootCfg ConfigProvider) {
 	rootSec := rootCfg.Section("")
 	RunUser = rootSec.Key("RUN_USER").MustString(user.CurrentUsername())
+
 	// The following is a purposefully undocumented option. Please do not run Gitea as root. It will only cause future headaches.
 	// Please don't use root as a bandaid to "fix" something that is broken, instead the broken thing should instead be fixed properly.
 	unsafeAllowRunAsRoot := ConfigSectionKeyBool(rootSec, "I_AM_BEING_UNSAFE_RUNNING_AS_ROOT")
+	if !unsafeAllowRunAsRoot && os.Getenv("GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT") == "true" {
+		unsafeAllowRunAsRoot = true
+	}
+
 	RunMode = os.Getenv("GITEA_RUN_MODE")
 	if RunMode == "" {
 		RunMode = rootSec.Key("RUN_MODE").MustString("prod")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -163,11 +163,7 @@ func loadRunModeFrom(rootCfg ConfigProvider) {
 	// The following is a purposefully undocumented option. Please do not run Gitea as root. It will only cause future headaches.
 	// Please don't use root as a bandaid to "fix" something that is broken, instead the broken thing should instead be fixed properly.
 	unsafeAllowRunAsRoot := ConfigSectionKeyBool(rootSec, "I_AM_BEING_UNSAFE_RUNNING_AS_ROOT")
-	unsafeAllowRunAsRoot = unsafeAllowRunAsRoot || func() bool {
-		v, _ := strconv.ParseBool(os.Getenv("GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT"))
-		return v
-	}()
-
+	unsafeAllowRunAsRoot = unsafeAllowRunAsRoot || util.OptionalBoolParse(os.Getenv("GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT")).Value()
 	RunMode = os.Getenv("GITEA_RUN_MODE")
 	if RunMode == "" {
 		RunMode = rootSec.Key("RUN_MODE").MustString("prod")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,9 +163,10 @@ func loadRunModeFrom(rootCfg ConfigProvider) {
 	// The following is a purposefully undocumented option. Please do not run Gitea as root. It will only cause future headaches.
 	// Please don't use root as a bandaid to "fix" something that is broken, instead the broken thing should instead be fixed properly.
 	unsafeAllowRunAsRoot := ConfigSectionKeyBool(rootSec, "I_AM_BEING_UNSAFE_RUNNING_AS_ROOT")
-	if !unsafeAllowRunAsRoot && os.Getenv("GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT") == "true" {
-		unsafeAllowRunAsRoot = true
-	}
+	unsafeAllowRunAsRoot = unsafeAllowRunAsRoot || func() bool {
+		v, _ := strconv.ParseBool(os.Getenv("GITEA_I_AM_BEING_UNSAFE_RUNNING_AS_ROOT"))
+		return v
+	}()
 
 	RunMode = os.Getenv("GITEA_RUN_MODE")
 	if RunMode == "" {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/user"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // settings


### PR DESCRIPTION
I was trying to run unit tests for Gitea on act runner, by using `make test`.

It failed with log:

```
2024/03/14 03:09:26 ...s/setting/setting.go:180:loadRunModeFrom() [F] Gitea is not supposed to be run as root. Sorry. If you need to use privileged TCP ports please instead use setcap and the `cap_net_bind_service` permission
```

So it will be convenient to skip by setting environment, since it's OK to use root user in job containers.

It's not a bug, but I want to backport it to v1.21 since it doesn't break anything.