### PR TITLE
Add optional.ExtractValue() to be able to handle Option type within interface{} value

### DIFF
--- a/modules/optional/option.go
+++ b/modules/optional/option.go
@@ -3,6 +3,8 @@
 
 package optional
 
+import "reflect"
+
 type Option[T any] []T
 
 func None[T any]() Option[T] {
@@ -42,4 +44,30 @@ func (o Option[T]) ValueOrDefault(v T) T {
 		return o[0]
 	}
 	return v
+}
+
+// ExcractValue return value or nil and bool if object was an Optional
+// it should only be used if you already have to deal with interface{} values
+// and expect an Option type within it.
+func ExcractValue(obj any) (any, bool) {
+	rt := reflect.TypeOf(obj)
+	if rt.Kind() != reflect.Slice {
+		return nil, false
+	}
+
+	type hasHasFunc interface {
+		Has() bool
+	}
+	if hasObj, ok := obj.(hasHasFunc); !ok {
+		return nil, false
+	} else if !hasObj.Has() {
+		return nil, true
+	}
+
+	rv := reflect.ValueOf(obj)
+	if rv.Len() != 1 {
+		// it's still false as optional.Option[T] types would have reported with hasObj.Has() that it is empty
+		return nil, false
+	}
+	return rv.Index(0).Interface(), true
 }

--- a/modules/optional/option.go
+++ b/modules/optional/option.go
@@ -46,10 +46,10 @@ func (o Option[T]) ValueOrDefault(v T) T {
 	return v
 }
 
-// ExcractValue return value or nil and bool if object was an Optional
+// ExtractValue return value or nil and bool if object was an Optional
 // it should only be used if you already have to deal with interface{} values
 // and expect an Option type within it.
-func ExcractValue(obj any) (any, bool) {
+func ExtractValue(obj any) (any, bool) {
 	rt := reflect.TypeOf(obj)
 	if rt.Kind() != reflect.Slice {
 		return nil, false

--- a/modules/optional/option_test.go
+++ b/modules/optional/option_test.go
@@ -57,3 +57,46 @@ func TestOption(t *testing.T) {
 	assert.True(t, opt3.Has())
 	assert.Equal(t, int(1), opt3.Value())
 }
+
+func TestExcractValue(t *testing.T) {
+	val, ok := optional.ExcractValue("aaaa")
+	assert.False(t, ok)
+	assert.Nil(t, val)
+
+	val, ok = optional.ExcractValue(optional.Some("aaaa"))
+	assert.True(t, ok)
+	if assert.NotNil(t, val) {
+		val, ok := val.(string)
+		assert.True(t, ok)
+		assert.EqualValues(t, "aaaa", val)
+	}
+
+	val, ok = optional.ExcractValue(optional.None[float64]())
+	assert.True(t, ok)
+	assert.Nil(t, val)
+
+	val, ok = optional.ExcractValue(&fakeHas{})
+	assert.False(t, ok)
+	assert.Nil(t, val)
+
+	wrongType := make(fakeHas2, 0, 1)
+	val, ok = optional.ExcractValue(wrongType)
+	assert.False(t, ok)
+	assert.Nil(t, val)
+}
+
+func toPtr[T any](val T) *T {
+	return &val
+}
+
+type fakeHas struct{}
+
+func (fakeHas) Has() bool {
+	return true
+}
+
+type fakeHas2 []string
+
+func (fakeHas2) Has() bool {
+	return true
+}

--- a/modules/optional/option_test.go
+++ b/modules/optional/option_test.go
@@ -58,12 +58,12 @@ func TestOption(t *testing.T) {
 	assert.Equal(t, int(1), opt3.Value())
 }
 
-func TestExcractValue(t *testing.T) {
-	val, ok := optional.ExcractValue("aaaa")
+func TestExtractValue(t *testing.T) {
+	val, ok := optional.ExtractValue("aaaa")
 	assert.False(t, ok)
 	assert.Nil(t, val)
 
-	val, ok = optional.ExcractValue(optional.Some("aaaa"))
+	val, ok = optional.ExtractValue(optional.Some("aaaa"))
 	assert.True(t, ok)
 	if assert.NotNil(t, val) {
 		val, ok := val.(string)
@@ -71,22 +71,18 @@ func TestExcractValue(t *testing.T) {
 		assert.EqualValues(t, "aaaa", val)
 	}
 
-	val, ok = optional.ExcractValue(optional.None[float64]())
+	val, ok = optional.ExtractValue(optional.None[float64]())
 	assert.True(t, ok)
 	assert.Nil(t, val)
 
-	val, ok = optional.ExcractValue(&fakeHas{})
+	val, ok = optional.ExtractValue(&fakeHas{})
 	assert.False(t, ok)
 	assert.Nil(t, val)
 
 	wrongType := make(fakeHas2, 0, 1)
-	val, ok = optional.ExcractValue(wrongType)
+	val, ok = optional.ExtractValue(wrongType)
 	assert.False(t, ok)
 	assert.Nil(t, val)
-}
-
-func toPtr[T any](val T) *T {
-	return &val
 }
 
 type fakeHas struct{}


### PR DESCRIPTION
as title ... add an helper func for optional.Option type(s)

because simple type cast wont work if you not know the exact T type too ... (or want your func handle all Option Types ...)