### PR TITLE
Use `Temporal.PlainDate` for absolute dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "sortablejs": "1.15.2",
         "swagger-ui-dist": "5.12.0",
         "tailwindcss": "3.4.1",
+        "temporal-polyfill": "0.2.3",
         "throttle-debounce": "5.0.0",
         "tinycolor2": "1.6.0",
         "tippy.js": "6.3.7",
@@ -11523,6 +11524,19 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.3.tgz",
+      "integrity": "sha512-7ZJRc7wq/1XjrOQYkkNpgo2qfE9XLrUU8D/DS+LAC/T0bYqZ46rW6dow0sOTXTPZS4bwer8bD/0OyuKQBfA3yw==",
+      "dependencies": {
+        "temporal-spec": "^0.2.0"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.0.tgz",
+      "integrity": "sha512-r1AT0XdEp8TMQ13FLvOt8mOtAxDQsRt2QU5rSWCA7YfshddU651Y1NHVrceLANvixKdf9fYO8B/S9fXHodB7HQ=="
     },
     "node_modules/terser": {
       "version": "5.29.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "sortablejs": "1.15.2",
     "swagger-ui-dist": "5.12.0",
     "tailwindcss": "3.4.1",
+    "temporal-polyfill": "0.2.3",
     "throttle-debounce": "5.0.0",
     "tinycolor2": "1.6.0",
     "tippy.js": "6.3.7",

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -1,5 +1,10 @@
 import {Temporal} from 'temporal-polyfill';
 
+export function toAbsoluteLocaleDate(str, lang, opts) {
+  const plainDate = Temporal.PlainDate.from(str);
+  return plainDate.toLocaleString(lang ?? [], opts);
+}
+
 window.customElements.define('absolute-date', class extends HTMLElement {
   static observedAttributes = ['date', 'year', 'month', 'weekday', 'day'];
 
@@ -13,9 +18,8 @@ window.customElements.define('absolute-date', class extends HTMLElement {
       '';
 
     // only use the first 10 characters, e.g. the `yyyy-mm-dd` part
-    const plainDate = Temporal.PlainDate.from(this.getAttribute('date').substring(0, 10));
     if (!this.shadowRoot) this.attachShadow({mode: 'open'});
-    this.shadowRoot.textContent = plainDate.toLocaleString(lang ?? [], {
+    this.shadowRoot.textContent = toAbsoluteLocaleDate(this.getAttribute('date').substring(0, 10), lang, {
       ...(year && {year}),
       ...(month && {month}),
       ...(weekday && {weekday}),

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -12,9 +12,8 @@ window.customElements.define('absolute-date', class extends HTMLElement {
       this.ownerDocument.documentElement.getAttribute('lang') ||
       '';
 
-    // only extract the first 10 characters, e.g. the `yyyy-mm-dd` part
-    const [isoYear, isoMonth, isoDate] = this.getAttribute('date').substring(0, 10).split('-');
-    const plainDate = new Temporal.PlainDate(isoYear, isoMonth, isoDate);
+    // only use the first 10 characters, e.g. the `yyyy-mm-dd` part
+    const plainDate = Temporal.PlainDate.from(this.getAttribute('date').substring(0, 10));
     if (!this.shadowRoot) this.attachShadow({mode: 'open'});
     this.shadowRoot.textContent = plainDate.toLocaleString(lang ?? [], {
       ...(year && {year}),

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -1,8 +1,7 @@
 import {Temporal} from 'temporal-polyfill';
 
 export function toAbsoluteLocaleDate(dateStr, lang, opts) {
-  const plainDate = Temporal.PlainDate.from(dateStr);
-  return plainDate.toLocaleString(lang ?? [], opts);
+  return Temporal.PlainDate.from(dateStr).toLocaleString(lang ?? [], opts);
 }
 
 window.customElements.define('absolute-date', class extends HTMLElement {

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -1,3 +1,5 @@
+import {Temporal} from 'temporal-polyfill';
+
 window.customElements.define('absolute-date', class extends HTMLElement {
   static observedAttributes = ['date', 'year', 'month', 'weekday', 'day'];
 
@@ -10,16 +12,11 @@ window.customElements.define('absolute-date', class extends HTMLElement {
       this.ownerDocument.documentElement.getAttribute('lang') ||
       '';
 
-    // only extract the `yyyy-mm-dd` part. When converting to Date, it will become midnight UTC and when rendered
-    // as localized date, will have a offset towards UTC, which we remove to shift the timestamp to midnight in the
-    // localized date. We should eventually use `Temporal.PlainDate` which will make the correction unnecessary.
-    // - https://stackoverflow.com/a/14569783/808699
-    // - https://tc39.es/proposal-temporal/docs/plaindate.html
-    const date = new Date(this.getAttribute('date').substring(0, 10));
-    const correctedDate = new Date(date.getTime() - date.getTimezoneOffset() * -60000);
-
+    // only extract the first 10 characters, e.g. the `yyyy-mm-dd` part
+    const [isoYear, isoMonth, isoDate] = this.getAttribute('date').substring(0, 10).split('-');
+    const date = new Temporal.PlainDate(isoYear, isoMonth, isoDate);
     if (!this.shadowRoot) this.attachShadow({mode: 'open'});
-    this.shadowRoot.textContent = correctedDate.toLocaleString(lang ?? [], {
+    this.shadowRoot.textContent = date.toLocaleString(lang ?? [], {
       ...(year && {year}),
       ...(month && {month}),
       ...(weekday && {weekday}),

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -14,9 +14,9 @@ window.customElements.define('absolute-date', class extends HTMLElement {
 
     // only extract the first 10 characters, e.g. the `yyyy-mm-dd` part
     const [isoYear, isoMonth, isoDate] = this.getAttribute('date').substring(0, 10).split('-');
-    const date = new Temporal.PlainDate(isoYear, isoMonth, isoDate);
+    const plainDate = new Temporal.PlainDate(isoYear, isoMonth, isoDate);
     if (!this.shadowRoot) this.attachShadow({mode: 'open'});
-    this.shadowRoot.textContent = date.toLocaleString(lang ?? [], {
+    this.shadowRoot.textContent = plainDate.toLocaleString(lang ?? [], {
       ...(year && {year}),
       ...(month && {month}),
       ...(weekday && {weekday}),

--- a/web_src/js/webcomponents/absolute-date.js
+++ b/web_src/js/webcomponents/absolute-date.js
@@ -1,7 +1,7 @@
 import {Temporal} from 'temporal-polyfill';
 
-export function toAbsoluteLocaleDate(str, lang, opts) {
-  const plainDate = Temporal.PlainDate.from(str);
+export function toAbsoluteLocaleDate(dateStr, lang, opts) {
+  const plainDate = Temporal.PlainDate.from(dateStr);
   return plainDate.toLocaleString(lang ?? [], opts);
 }
 
@@ -14,12 +14,13 @@ window.customElements.define('absolute-date', class extends HTMLElement {
     const weekday = this.getAttribute('weekday') ?? '';
     const day = this.getAttribute('day') ?? '';
     const lang = this.closest('[lang]')?.getAttribute('lang') ||
-      this.ownerDocument.documentElement.getAttribute('lang') ||
-      '';
+      this.ownerDocument.documentElement.getAttribute('lang') || '';
 
     // only use the first 10 characters, e.g. the `yyyy-mm-dd` part
+    const dateStr = this.getAttribute('date').substring(0, 10);
+
     if (!this.shadowRoot) this.attachShadow({mode: 'open'});
-    this.shadowRoot.textContent = toAbsoluteLocaleDate(this.getAttribute('date').substring(0, 10), lang, {
+    this.shadowRoot.textContent = toAbsoluteLocaleDate(dateStr, lang, {
       ...(year && {year}),
       ...(month && {month}),
       ...(weekday && {weekday}),

--- a/web_src/js/webcomponents/absolute-date.test.js
+++ b/web_src/js/webcomponents/absolute-date.test.js
@@ -1,0 +1,15 @@
+import {toAbsoluteLocaleDate} from './absolute-date.js';
+
+test('toAbsoluteLocaleDate', () => {
+  expect(toAbsoluteLocaleDate('2024-03-15', 'en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })).toEqual('March 15, 2024');
+
+  expect(toAbsoluteLocaleDate('2024-03-15', 'de-DE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })).toEqual('15. März 2024');
+});


### PR DESCRIPTION
Use the upcoming [Temporal.PlainDate](https://tc39.es/proposal-temporal/docs/plaindate.html) via polyfill. If there is any remaining bugs in `<absolute-date>` this will iron them out. I opted for the lightweight polyfill because both seem to achieve our goal of localizeable absolute dates.

- With [`@js-temporal/polyfill`](https://www.npmjs.com/package/@js-temporal/polyfill) chunk size goes from 81.4 KiB to 274 KiB
- With [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) chunk size goes from 81.4 KiB to 142 KiB

Also see [this table](https://github.com/fullcalendar/temporal-polyfill?tab=readme-ov-file#comparison-with-js-temporalpolyfill) for more comparisons of these polyfills. Soon there will be [treeshakable API](https://github.com/fullcalendar/temporal-polyfill?tab=readme-ov-file#tree-shakable-api) as well which will further reduce size.