### PR TITLE
Remove jQuery AJAX from the comment edit box

### DIFF
--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -418,7 +418,7 @@ async function onEditContent(event) {
     try {
       const params = new URLSearchParams({
         content: comboMarkdownEditor.value(),
-        context: $editContentZone.attr('data-context')
+        context: $editContentZone.attr('data-context'),
       });
       for (const file of dz.files) params.append('files[]', file.uuid);
 

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -24,7 +24,7 @@ import {initRepoPullRequestCommitStatus} from './repo-issue-pr-status.js';
 import {hideElem, showElem} from '../utils/dom.js';
 import {getComboMarkdownEditor, initComboMarkdownEditor} from './comp/ComboMarkdownEditor.js';
 import {attachRefIssueContextPopup} from './contextpopup.js';
-import {POST} from '../modules/fetch.js';
+import {POST, GET} from '../modules/fetch.js';
 
 const {csrfToken} = window.config;
 
@@ -83,7 +83,7 @@ export function initRepoCommentForm() {
           await POST(form.attr('action'), {data: params});
           window.location.reload();
         } catch (error) {
-          console.error('Error:', error);
+          console.error(error);
         }
       } else if (editMode === '') {
         $selectBranch.find('.ui .branch-name').text(selectedValue);
@@ -355,14 +355,17 @@ async function onEditContent(event) {
           const input = $(`<input id="${data.uuid}" name="files" type="hidden">`).val(data.uuid);
           $dropzone.find('.files').append(input);
         });
-        this.on('removedfile', (file) => {
+        this.on('removedfile', async (file) => {
           if (disableRemovedfileEvent) return;
           $(`#${file.uuid}`).remove();
           if ($dropzone.attr('data-remove-url') && !fileUuidDict[file.uuid].submitted) {
-            $.post($dropzone.attr('data-remove-url'), {
-              file: file.uuid,
-              _csrf: csrfToken,
-            });
+            try {
+              const params = new URLSearchParams();
+              params.append('file', file.uuid);
+              await POST($dropzone.attr('data-remove-url'), {data: params});
+            } catch (error) {
+              console.error(error);
+            }
           }
         });
         this.on('submit', () => {
@@ -370,8 +373,10 @@ async function onEditContent(event) {
             fileUuidDict[fileUuid].submitted = true;
           });
         });
-        this.on('reload', () => {
-          $.getJSON($editContentZone.attr('data-attachment-url'), (data) => {
+        this.on('reload', async () => {
+          try {
+            const response = await GET($editContentZone.attr('data-attachment-url'));
+            const data = await response.json();
             // do not trigger the "removedfile" event, otherwise the attachments would be deleted from server
             disableRemovedfileEvent = true;
             dz.removeAllFiles(true);
@@ -390,7 +395,9 @@ async function onEditContent(event) {
               const input = $(`<input id="${attachment.uuid}" name="files" type="hidden">`).val(attachment.uuid);
               $dropzone.find('.files').append(input);
             }
-          });
+          } catch (error) {
+            console.error(error);
+          }
         });
       },
     });
@@ -406,22 +413,25 @@ async function onEditContent(event) {
     }
   };
 
-  const saveAndRefresh = (dz) => {
+  const saveAndRefresh = async (dz) => {
     showElem($renderContent);
     hideElem($editContentZone);
-    $.post($editContentZone.attr('data-update-url'), {
-      _csrf: csrfToken,
-      content: comboMarkdownEditor.value(),
-      context: $editContentZone.attr('data-context'),
-      files: dz.files.map((file) => file.uuid),
-    }, (data) => {
+
+    try {
+      const params = new URLSearchParams({
+        content: comboMarkdownEditor.value(),
+        context: $editContentZone.attr('data-context')
+      });
+      for (const file of dz.files) params.append('files[]', file.uuid);
+
+      const response = await POST($editContentZone.attr('data-update-url'), {data: params});
+      const data = await response.json();
       if (!data.content) {
         $renderContent.html($('#no-content').html());
         $rawContent.text('');
       } else {
         $renderContent.html(data.content);
         $rawContent.text(comboMarkdownEditor.value());
-
         const refIssues = $renderContent.find('p .ref-issue');
         attachRefIssueContextPopup(refIssues);
       }
@@ -442,7 +452,9 @@ async function onEditContent(event) {
       }
       initMarkupContent();
       initCommentContent();
-    });
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   if (!$editContentZone.html()) {

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -360,9 +360,7 @@ async function onEditContent(event) {
           $(`#${file.uuid}`).remove();
           if ($dropzone.attr('data-remove-url') && !fileUuidDict[file.uuid].submitted) {
             try {
-              const params = new URLSearchParams();
-              params.append('file', file.uuid);
-              await POST($dropzone.attr('data-remove-url'), {data: params});
+              await POST($dropzone.attr('data-remove-url'), {data: new URLSearchParams({file: file.uuid})});
             } catch (error) {
               console.error(error);
             }


### PR DESCRIPTION
- Removed all jQuery AJAX calls and replaced with our fetch wrapper
- Tested the file addition and removal functionality and it works as before

# Demo using `fetch` instead of jQuery AJAX
![demo](https://github.com/go-gitea/gitea/assets/20454870/846ed6d5-3798-43ca-920c-d619e9c3d745)
