### PR TITLE
Fix `for` attribute not pointing to the ID of the color picker

### DIFF
--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -41,7 +41,7 @@
 						</div>
 
 						<div class="field color-field">
-							<label for="new_project_column_color">{{ctx.Locale.Tr "repo.projects.column.color"}}</label>
+							<label for="new_project_column_color_picker">{{ctx.Locale.Tr "repo.projects.column.color"}}</label>
 							<div class="color picker column">
 								<input class="color-picker" maxlength="7" placeholder="#c320f6" id="new_project_column_color_picker" name="color">
 								{{template "repo/issue/label_precolors"}}


### PR DESCRIPTION
It didn't include the word picker.
