### PR TITLE
Avoid JS error on issue/pr list when logged out

### DIFF
--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -15,6 +15,7 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 		runModeIsProd: {{.RunModeIsProd}},
 		customEmojis: {{CustomEmojis}},
 		csrfToken: '{{.CsrfToken}}',
+		isSignedIn: {{.IsSigned}},
 		pageData: {{.PageData}},
 		notificationSettings: {{NotificationSettings}}, {{/*a map provided by NewFuncMap in helper.go*/}}
 		enableTimeTracking: {{EnableTimetracking}},

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -15,7 +15,6 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 		runModeIsProd: {{.RunModeIsProd}},
 		customEmojis: {{CustomEmojis}},
 		csrfToken: '{{.CsrfToken}}',
-		isSignedIn: {{.IsSigned}},
 		pageData: {{.PageData}},
 		notificationSettings: {{NotificationSettings}}, {{/*a map provided by NewFuncMap in helper.go*/}}
 		enableTimeTracking: {{EnableTimetracking}},

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -8,9 +8,9 @@ import {createSortable} from '../modules/sortable.js';
 import {DELETE, POST} from '../modules/fetch.js';
 
 function initRepoIssueListCheckboxes() {
-  if (!window.config.isSignedIn) return;
   const issueSelectAll = document.querySelector('.issue-checkbox-all');
   const issueCheckboxes = document.querySelectorAll('.issue-checkbox');
+  if(!issueSelectAll) return;
 
   const syncIssueSelectionState = () => {
     const checkedCheckboxes = Array.from(issueCheckboxes).filter((el) => el.checked);

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -8,6 +8,7 @@ import {createSortable} from '../modules/sortable.js';
 import {DELETE, POST} from '../modules/fetch.js';
 
 function initRepoIssueListCheckboxes() {
+  if (!window.config.isSignedIn) return;
   const issueSelectAll = document.querySelector('.issue-checkbox-all');
   const issueCheckboxes = document.querySelectorAll('.issue-checkbox');
 

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -40,7 +40,7 @@ function initRepoIssueListCheckboxes() {
     el.addEventListener('change', syncIssueSelectionState);
   }
 
-  issueSelectAll.addEventListener('change', () => {
+  issueSelectAll?.addEventListener('change', () => {
     for (const el of issueCheckboxes) {
       el.checked = issueSelectAll.checked;
     }

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -9,8 +9,8 @@ import {DELETE, POST} from '../modules/fetch.js';
 
 function initRepoIssueListCheckboxes() {
   const issueSelectAll = document.querySelector('.issue-checkbox-all');
+  if (!issueSelectAll) return; // logged out state
   const issueCheckboxes = document.querySelectorAll('.issue-checkbox');
-  if(!issueSelectAll) return;
 
   const syncIssueSelectionState = () => {
     const checkedCheckboxes = Array.from(issueCheckboxes).filter((el) => el.checked);
@@ -41,7 +41,7 @@ function initRepoIssueListCheckboxes() {
     el.addEventListener('change', syncIssueSelectionState);
   }
 
-  issueSelectAll?.addEventListener('change', () => {
+  issueSelectAll.addEventListener('change', () => {
     for (const el of issueCheckboxes) {
       el.checked = issueSelectAll.checked;
     }


### PR DESCRIPTION
When logged out, the checkboxes are not there on the issue/pr lists, which would cause an error here.

Fixes: https://github.com/go-gitea/gitea/issues/29862