### PR TITLE
fix telegram webhook

### DIFF
--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -181,8 +181,9 @@ func (t telegramConvertor) Package(p *api.PackagePayload) (TelegramPayload, erro
 
 func createTelegramPayload(message string) TelegramPayload {
 	return TelegramPayload{
-		Message:   strings.TrimSpace(message),
-		ParseMode: "HTML",
+		Message:           strings.TrimSpace(message),
+		ParseMode:         "HTML",
+		DisableWebPreview: true,
 	}
 }
 

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -181,7 +181,8 @@ func (t telegramConvertor) Package(p *api.PackagePayload) (TelegramPayload, erro
 
 func createTelegramPayload(message string) TelegramPayload {
 	return TelegramPayload{
-		Message: strings.TrimSpace(message),
+		Message:   strings.TrimSpace(message),
+		ParseMode: "HTML",
 	}
 }
 

--- a/services/webhook/telegram_test.go
+++ b/services/webhook/telegram_test.go
@@ -18,6 +18,15 @@ import (
 
 func TestTelegramPayload(t *testing.T) {
 	tc := telegramConvertor{}
+
+	t.Run("Correct webhook params", func(t *testing.T) {
+		p := createTelegramPayload("testMsg ")
+
+		assert.Equal(t, "HTML", p.ParseMode)
+		assert.Equal(t, true, p.DisableWebPreview)
+		assert.Equal(t, "testMsg", p.Message)
+	})
+
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()
 


### PR DESCRIPTION
Fix #29837 which is a regression caused by https://github.com/go-gitea/gitea/pull/29145/files#diff-731445ee00f0f1bf2ff731f4f96ddcf51cdc53fd2faaf406eb3536fc292ea748L48. The line was probably removed by accident.
