### PR TITLE
fix 'convertor' typo

### DIFF
--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -24,8 +24,8 @@ type (
 	DingtalkPayload dingtalk.Payload
 )
 
-// Create implements PayloadConvertor Create method
-func (dc dingtalkConvertor) Create(p *api.CreatePayload) (DingtalkPayload, error) {
+// Create implements PayloadConverter Create method
+func (dc dingtalkConverter) Create(p *api.CreatePayload) (DingtalkPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s created", p.Repo.FullName, p.RefType, refName)
@@ -33,8 +33,8 @@ func (dc dingtalkConvertor) Create(p *api.CreatePayload) (DingtalkPayload, error
 	return createDingtalkPayload(title, title, fmt.Sprintf("view ref %s", refName), p.Repo.HTMLURL+"/src/"+util.PathEscapeSegments(refName)), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (dc dingtalkConvertor) Delete(p *api.DeletePayload) (DingtalkPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (dc dingtalkConverter) Delete(p *api.DeletePayload) (DingtalkPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s deleted", p.Repo.FullName, p.RefType, refName)
@@ -42,15 +42,15 @@ func (dc dingtalkConvertor) Delete(p *api.DeletePayload) (DingtalkPayload, error
 	return createDingtalkPayload(title, title, fmt.Sprintf("view ref %s", refName), p.Repo.HTMLURL+"/src/"+util.PathEscapeSegments(refName)), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (dc dingtalkConvertor) Fork(p *api.ForkPayload) (DingtalkPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (dc dingtalkConverter) Fork(p *api.ForkPayload) (DingtalkPayload, error) {
 	title := fmt.Sprintf("%s is forked to %s", p.Forkee.FullName, p.Repo.FullName)
 
 	return createDingtalkPayload(title, title, fmt.Sprintf("view forked repo %s", p.Repo.FullName), p.Repo.HTMLURL), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (dc dingtalkConvertor) Push(p *api.PushPayload) (DingtalkPayload, error) {
+// Push implements PayloadConverter Push method
+func (dc dingtalkConverter) Push(p *api.PushPayload) (DingtalkPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -90,37 +90,37 @@ func (dc dingtalkConvertor) Push(p *api.PushPayload) (DingtalkPayload, error) {
 	return createDingtalkPayload(title, text, linkText, titleLink), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (dc dingtalkConvertor) Issue(p *api.IssuePayload) (DingtalkPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (dc dingtalkConverter) Issue(p *api.IssuePayload) (DingtalkPayload, error) {
 	text, issueTitle, attachmentText, _ := getIssuesPayloadInfo(p, noneLinkFormatter, true)
 
 	return createDingtalkPayload(issueTitle, text+"\r\n\r\n"+attachmentText, "view issue", p.Issue.HTMLURL), nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (dc dingtalkConvertor) Wiki(p *api.WikiPayload) (DingtalkPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (dc dingtalkConverter) Wiki(p *api.WikiPayload) (DingtalkPayload, error) {
 	text, _, _ := getWikiPayloadInfo(p, noneLinkFormatter, true)
 	url := p.Repository.HTMLURL + "/wiki/" + url.PathEscape(p.Page)
 
 	return createDingtalkPayload(text, text, "view wiki", url), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (dc dingtalkConvertor) IssueComment(p *api.IssueCommentPayload) (DingtalkPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (dc dingtalkConverter) IssueComment(p *api.IssueCommentPayload) (DingtalkPayload, error) {
 	text, issueTitle, _ := getIssueCommentPayloadInfo(p, noneLinkFormatter, true)
 
 	return createDingtalkPayload(issueTitle, text+"\r\n\r\n"+p.Comment.Body, "view issue comment", p.Comment.HTMLURL), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (dc dingtalkConvertor) PullRequest(p *api.PullRequestPayload) (DingtalkPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (dc dingtalkConverter) PullRequest(p *api.PullRequestPayload) (DingtalkPayload, error) {
 	text, issueTitle, attachmentText, _ := getPullRequestPayloadInfo(p, noneLinkFormatter, true)
 
 	return createDingtalkPayload(issueTitle, text+"\r\n\r\n"+attachmentText, "view pull request", p.PullRequest.HTMLURL), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (dc dingtalkConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DingtalkPayload, error) {
+// Review implements PayloadConverter Review method
+func (dc dingtalkConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DingtalkPayload, error) {
 	var text, title string
 	switch p.Action {
 	case api.HookIssueReviewed:
@@ -136,8 +136,8 @@ func (dc dingtalkConvertor) Review(p *api.PullRequestPayload, event webhook_modu
 	return createDingtalkPayload(title, title+"\r\n\r\n"+text, "view pull request", p.PullRequest.HTMLURL), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (dc dingtalkConvertor) Repository(p *api.RepositoryPayload) (DingtalkPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (dc dingtalkConverter) Repository(p *api.RepositoryPayload) (DingtalkPayload, error) {
 	switch p.Action {
 	case api.HookRepoCreated:
 		title := fmt.Sprintf("[%s] Repository created", p.Repository.FullName)
@@ -157,14 +157,14 @@ func (dc dingtalkConvertor) Repository(p *api.RepositoryPayload) (DingtalkPayloa
 	return DingtalkPayload{}, nil
 }
 
-// Release implements PayloadConvertor Release method
-func (dc dingtalkConvertor) Release(p *api.ReleasePayload) (DingtalkPayload, error) {
+// Release implements PayloadConverter Release method
+func (dc dingtalkConverter) Release(p *api.ReleasePayload) (DingtalkPayload, error) {
 	text, _ := getReleasePayloadInfo(p, noneLinkFormatter, true)
 
 	return createDingtalkPayload(text, text, "view release", p.Release.HTMLURL), nil
 }
 
-func (dc dingtalkConvertor) Package(p *api.PackagePayload) (DingtalkPayload, error) {
+func (dc dingtalkConverter) Package(p *api.PackagePayload) (DingtalkPayload, error) {
 	text, _ := getPackagePayloadInfo(p, noneLinkFormatter, true)
 
 	return createDingtalkPayload(text, text, "view package", p.Package.HTMLURL), nil
@@ -186,10 +186,10 @@ func createDingtalkPayload(title, text, singleTitle, singleURL string) DingtalkP
 	}
 }
 
-type dingtalkConvertor struct{}
+type dingtalkConverter struct{}
 
-var _ payloadConvertor[DingtalkPayload] = dingtalkConvertor{}
+var _ payloadConverter[DingtalkPayload] = dingtalkConverter{}
 
 func newDingtalkRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
-	return newJSONRequest(dingtalkConvertor{}, w, t, true)
+	return newJSONRequest(dingtalkConverter{}, w, t, true)
 }

--- a/services/webhook/dingtalk_test.go
+++ b/services/webhook/dingtalk_test.go
@@ -27,7 +27,7 @@ func TestDingTalkPayload(t *testing.T) {
 		}
 		return ""
 	}
-	dc := dingtalkConvertor{}
+	dc := dingtalkConverter{}
 
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()

--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -100,8 +100,8 @@ var (
 	redColor         = color("ff3232")
 )
 
-// Create implements PayloadConvertor Create method
-func (d discordConvertor) Create(p *api.CreatePayload) (DiscordPayload, error) {
+// Create implements PayloadConverter Create method
+func (d discordConverter) Create(p *api.CreatePayload) (DiscordPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s created", p.Repo.FullName, p.RefType, refName)
@@ -109,8 +109,8 @@ func (d discordConvertor) Create(p *api.CreatePayload) (DiscordPayload, error) {
 	return d.createPayload(p.Sender, title, "", p.Repo.HTMLURL+"/src/"+util.PathEscapeSegments(refName), greenColor), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (d discordConvertor) Delete(p *api.DeletePayload) (DiscordPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (d discordConverter) Delete(p *api.DeletePayload) (DiscordPayload, error) {
 	// deleted tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s deleted", p.Repo.FullName, p.RefType, refName)
@@ -118,15 +118,15 @@ func (d discordConvertor) Delete(p *api.DeletePayload) (DiscordPayload, error) {
 	return d.createPayload(p.Sender, title, "", p.Repo.HTMLURL+"/src/"+util.PathEscapeSegments(refName), redColor), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (d discordConvertor) Fork(p *api.ForkPayload) (DiscordPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (d discordConverter) Fork(p *api.ForkPayload) (DiscordPayload, error) {
 	title := fmt.Sprintf("%s is forked to %s", p.Forkee.FullName, p.Repo.FullName)
 
 	return d.createPayload(p.Sender, title, "", p.Repo.HTMLURL, greenColor), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (d discordConvertor) Push(p *api.PushPayload) (DiscordPayload, error) {
+// Push implements PayloadConverter Push method
+func (d discordConverter) Push(p *api.PushPayload) (DiscordPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -160,29 +160,29 @@ func (d discordConvertor) Push(p *api.PushPayload) (DiscordPayload, error) {
 	return d.createPayload(p.Sender, title, text, titleLink, greenColor), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (d discordConvertor) Issue(p *api.IssuePayload) (DiscordPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (d discordConverter) Issue(p *api.IssuePayload) (DiscordPayload, error) {
 	title, _, text, color := getIssuesPayloadInfo(p, noneLinkFormatter, false)
 
 	return d.createPayload(p.Sender, title, text, p.Issue.HTMLURL, color), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (d discordConvertor) IssueComment(p *api.IssueCommentPayload) (DiscordPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (d discordConverter) IssueComment(p *api.IssueCommentPayload) (DiscordPayload, error) {
 	title, _, color := getIssueCommentPayloadInfo(p, noneLinkFormatter, false)
 
 	return d.createPayload(p.Sender, title, p.Comment.Body, p.Comment.HTMLURL, color), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (d discordConvertor) PullRequest(p *api.PullRequestPayload) (DiscordPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (d discordConverter) PullRequest(p *api.PullRequestPayload) (DiscordPayload, error) {
 	title, _, text, color := getPullRequestPayloadInfo(p, noneLinkFormatter, false)
 
 	return d.createPayload(p.Sender, title, text, p.PullRequest.HTMLURL, color), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (d discordConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DiscordPayload, error) {
+// Review implements PayloadConverter Review method
+func (d discordConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DiscordPayload, error) {
 	var text, title string
 	var color int
 	switch p.Action {
@@ -210,8 +210,8 @@ func (d discordConvertor) Review(p *api.PullRequestPayload, event webhook_module
 	return d.createPayload(p.Sender, title, text, p.PullRequest.HTMLURL, color), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (d discordConvertor) Repository(p *api.RepositoryPayload) (DiscordPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (d discordConverter) Repository(p *api.RepositoryPayload) (DiscordPayload, error) {
 	var title, url string
 	var color int
 	switch p.Action {
@@ -227,8 +227,8 @@ func (d discordConvertor) Repository(p *api.RepositoryPayload) (DiscordPayload, 
 	return d.createPayload(p.Sender, title, "", url, color), nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (d discordConvertor) Wiki(p *api.WikiPayload) (DiscordPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (d discordConverter) Wiki(p *api.WikiPayload) (DiscordPayload, error) {
 	text, color, _ := getWikiPayloadInfo(p, noneLinkFormatter, false)
 	htmlLink := p.Repository.HTMLURL + "/wiki/" + url.PathEscape(p.Page)
 
@@ -240,32 +240,32 @@ func (d discordConvertor) Wiki(p *api.WikiPayload) (DiscordPayload, error) {
 	return d.createPayload(p.Sender, text, description, htmlLink, color), nil
 }
 
-// Release implements PayloadConvertor Release method
-func (d discordConvertor) Release(p *api.ReleasePayload) (DiscordPayload, error) {
+// Release implements PayloadConverter Release method
+func (d discordConverter) Release(p *api.ReleasePayload) (DiscordPayload, error) {
 	text, color := getReleasePayloadInfo(p, noneLinkFormatter, false)
 
 	return d.createPayload(p.Sender, text, p.Release.Note, p.Release.HTMLURL, color), nil
 }
 
-func (d discordConvertor) Package(p *api.PackagePayload) (DiscordPayload, error) {
+func (d discordConverter) Package(p *api.PackagePayload) (DiscordPayload, error) {
 	text, color := getPackagePayloadInfo(p, noneLinkFormatter, false)
 
 	return d.createPayload(p.Sender, text, "", p.Package.HTMLURL, color), nil
 }
 
-type discordConvertor struct {
+type discordConverter struct {
 	Username  string
 	AvatarURL string
 }
 
-var _ payloadConvertor[DiscordPayload] = discordConvertor{}
+var _ payloadConverter[DiscordPayload] = discordConverter{}
 
 func newDiscordRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
 	meta := &DiscordMeta{}
 	if err := json.Unmarshal([]byte(w.Meta), meta); err != nil {
 		return nil, nil, fmt.Errorf("newDiscordRequest meta json: %w", err)
 	}
-	sc := discordConvertor{
+	sc := discordConverter{
 		Username:  meta.Username,
 		AvatarURL: meta.IconURL,
 	}
@@ -287,7 +287,7 @@ func parseHookPullRequestEventType(event webhook_module.HookEventType) (string, 
 	}
 }
 
-func (d discordConvertor) createPayload(s *api.User, title, text, url string, color int) DiscordPayload {
+func (d discordConverter) createPayload(s *api.User, title, text, url string, color int) DiscordPayload {
 	return DiscordPayload{
 		Username:  d.Username,
 		AvatarURL: d.AvatarURL,

--- a/services/webhook/discord_test.go
+++ b/services/webhook/discord_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDiscordPayload(t *testing.T) {
-	dc := discordConvertor{}
+	dc := discordConverter{}
 
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()

--- a/services/webhook/feishu.go
+++ b/services/webhook/feishu.go
@@ -36,8 +36,8 @@ func newFeishuTextPayload(text string) FeishuPayload {
 	}
 }
 
-// Create implements PayloadConvertor Create method
-func (fc feishuConvertor) Create(p *api.CreatePayload) (FeishuPayload, error) {
+// Create implements PayloadConverter Create method
+func (fc feishuConverter) Create(p *api.CreatePayload) (FeishuPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	text := fmt.Sprintf("[%s] %s %s created", p.Repo.FullName, p.RefType, refName)
@@ -45,8 +45,8 @@ func (fc feishuConvertor) Create(p *api.CreatePayload) (FeishuPayload, error) {
 	return newFeishuTextPayload(text), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (fc feishuConvertor) Delete(p *api.DeletePayload) (FeishuPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (fc feishuConverter) Delete(p *api.DeletePayload) (FeishuPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	text := fmt.Sprintf("[%s] %s %s deleted", p.Repo.FullName, p.RefType, refName)
@@ -54,15 +54,15 @@ func (fc feishuConvertor) Delete(p *api.DeletePayload) (FeishuPayload, error) {
 	return newFeishuTextPayload(text), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (fc feishuConvertor) Fork(p *api.ForkPayload) (FeishuPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (fc feishuConverter) Fork(p *api.ForkPayload) (FeishuPayload, error) {
 	text := fmt.Sprintf("%s is forked to %s", p.Forkee.FullName, p.Repo.FullName)
 
 	return newFeishuTextPayload(text), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (fc feishuConvertor) Push(p *api.PushPayload) (FeishuPayload, error) {
+// Push implements PayloadConverter Push method
+func (fc feishuConverter) Push(p *api.PushPayload) (FeishuPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -86,8 +86,8 @@ func (fc feishuConvertor) Push(p *api.PushPayload) (FeishuPayload, error) {
 	return newFeishuTextPayload(text), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (fc feishuConvertor) Issue(p *api.IssuePayload) (FeishuPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (fc feishuConverter) Issue(p *api.IssuePayload) (FeishuPayload, error) {
 	title, link, by, operator, result, assignees := getIssuesInfo(p)
 	if assignees != "" {
 		if p.Action == api.HookIssueAssigned || p.Action == api.HookIssueUnassigned || p.Action == api.HookIssueMilestoned {
@@ -98,14 +98,14 @@ func (fc feishuConvertor) Issue(p *api.IssuePayload) (FeishuPayload, error) {
 	return newFeishuTextPayload(fmt.Sprintf("%s\n%s\n%s\n%s\n\n%s", title, link, by, operator, p.Issue.Body)), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (fc feishuConvertor) IssueComment(p *api.IssueCommentPayload) (FeishuPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (fc feishuConverter) IssueComment(p *api.IssueCommentPayload) (FeishuPayload, error) {
 	title, link, by, operator := getIssuesCommentInfo(p)
 	return newFeishuTextPayload(fmt.Sprintf("%s\n%s\n%s\n%s\n\n%s", title, link, by, operator, p.Comment.Body)), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (fc feishuConvertor) PullRequest(p *api.PullRequestPayload) (FeishuPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (fc feishuConverter) PullRequest(p *api.PullRequestPayload) (FeishuPayload, error) {
 	title, link, by, operator, result, assignees := getPullRequestInfo(p)
 	if assignees != "" {
 		if p.Action == api.HookIssueAssigned || p.Action == api.HookIssueUnassigned || p.Action == api.HookIssueMilestoned {
@@ -116,8 +116,8 @@ func (fc feishuConvertor) PullRequest(p *api.PullRequestPayload) (FeishuPayload,
 	return newFeishuTextPayload(fmt.Sprintf("%s\n%s\n%s\n%s\n\n%s", title, link, by, operator, p.PullRequest.Body)), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (fc feishuConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (FeishuPayload, error) {
+// Review implements PayloadConverter Review method
+func (fc feishuConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (FeishuPayload, error) {
 	action, err := parseHookPullRequestEventType(event)
 	if err != nil {
 		return FeishuPayload{}, err
@@ -129,8 +129,8 @@ func (fc feishuConvertor) Review(p *api.PullRequestPayload, event webhook_module
 	return newFeishuTextPayload(title + "\r\n\r\n" + text), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (fc feishuConvertor) Repository(p *api.RepositoryPayload) (FeishuPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (fc feishuConverter) Repository(p *api.RepositoryPayload) (FeishuPayload, error) {
 	var text string
 	switch p.Action {
 	case api.HookRepoCreated:
@@ -144,30 +144,30 @@ func (fc feishuConvertor) Repository(p *api.RepositoryPayload) (FeishuPayload, e
 	return FeishuPayload{}, nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (fc feishuConvertor) Wiki(p *api.WikiPayload) (FeishuPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (fc feishuConverter) Wiki(p *api.WikiPayload) (FeishuPayload, error) {
 	text, _, _ := getWikiPayloadInfo(p, noneLinkFormatter, true)
 
 	return newFeishuTextPayload(text), nil
 }
 
-// Release implements PayloadConvertor Release method
-func (fc feishuConvertor) Release(p *api.ReleasePayload) (FeishuPayload, error) {
+// Release implements PayloadConverter Release method
+func (fc feishuConverter) Release(p *api.ReleasePayload) (FeishuPayload, error) {
 	text, _ := getReleasePayloadInfo(p, noneLinkFormatter, true)
 
 	return newFeishuTextPayload(text), nil
 }
 
-func (fc feishuConvertor) Package(p *api.PackagePayload) (FeishuPayload, error) {
+func (fc feishuConverter) Package(p *api.PackagePayload) (FeishuPayload, error) {
 	text, _ := getPackagePayloadInfo(p, noneLinkFormatter, true)
 
 	return newFeishuTextPayload(text), nil
 }
 
-type feishuConvertor struct{}
+type feishuConverter struct{}
 
-var _ payloadConvertor[FeishuPayload] = feishuConvertor{}
+var _ payloadConverter[FeishuPayload] = feishuConverter{}
 
 func newFeishuRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
-	return newJSONRequest(feishuConvertor{}, w, t, true)
+	return newJSONRequest(feishuConverter{}, w, t, true)
 }

--- a/services/webhook/feishu_test.go
+++ b/services/webhook/feishu_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFeishuPayload(t *testing.T) {
-	fc := feishuConvertor{}
+	fc := feishuConverter{}
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()
 

--- a/services/webhook/matrix_test.go
+++ b/services/webhook/matrix_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMatrixPayload(t *testing.T) {
-	mc := matrixConvertor{
+	mc := matrixConverter{
 		MsgType: "m.text",
 	}
 

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -58,8 +58,8 @@ type (
 	}
 )
 
-// Create implements PayloadConvertor Create method
-func (m msteamsConvertor) Create(p *api.CreatePayload) (MSTeamsPayload, error) {
+// Create implements PayloadConverter Create method
+func (m msteamsConverter) Create(p *api.CreatePayload) (MSTeamsPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s created", p.Repo.FullName, p.RefType, refName)
@@ -75,8 +75,8 @@ func (m msteamsConvertor) Create(p *api.CreatePayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (m msteamsConvertor) Delete(p *api.DeletePayload) (MSTeamsPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (m msteamsConverter) Delete(p *api.DeletePayload) (MSTeamsPayload, error) {
 	// deleted tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s deleted", p.Repo.FullName, p.RefType, refName)
@@ -92,8 +92,8 @@ func (m msteamsConvertor) Delete(p *api.DeletePayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (m msteamsConvertor) Fork(p *api.ForkPayload) (MSTeamsPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (m msteamsConverter) Fork(p *api.ForkPayload) (MSTeamsPayload, error) {
 	title := fmt.Sprintf("%s is forked to %s", p.Forkee.FullName, p.Repo.FullName)
 
 	return createMSTeamsPayload(
@@ -107,8 +107,8 @@ func (m msteamsConvertor) Fork(p *api.ForkPayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (m msteamsConvertor) Push(p *api.PushPayload) (MSTeamsPayload, error) {
+// Push implements PayloadConverter Push method
+func (m msteamsConverter) Push(p *api.PushPayload) (MSTeamsPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -150,8 +150,8 @@ func (m msteamsConvertor) Push(p *api.PushPayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (m msteamsConvertor) Issue(p *api.IssuePayload) (MSTeamsPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (m msteamsConverter) Issue(p *api.IssuePayload) (MSTeamsPayload, error) {
 	title, _, attachmentText, color := getIssuesPayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -165,8 +165,8 @@ func (m msteamsConvertor) Issue(p *api.IssuePayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (m msteamsConvertor) IssueComment(p *api.IssueCommentPayload) (MSTeamsPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (m msteamsConverter) IssueComment(p *api.IssueCommentPayload) (MSTeamsPayload, error) {
 	title, _, color := getIssueCommentPayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -180,8 +180,8 @@ func (m msteamsConvertor) IssueComment(p *api.IssueCommentPayload) (MSTeamsPaylo
 	), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (m msteamsConvertor) PullRequest(p *api.PullRequestPayload) (MSTeamsPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (m msteamsConverter) PullRequest(p *api.PullRequestPayload) (MSTeamsPayload, error) {
 	title, _, attachmentText, color := getPullRequestPayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -195,8 +195,8 @@ func (m msteamsConvertor) PullRequest(p *api.PullRequestPayload) (MSTeamsPayload
 	), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (m msteamsConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (MSTeamsPayload, error) {
+// Review implements PayloadConverter Review method
+func (m msteamsConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (MSTeamsPayload, error) {
 	var text, title string
 	var color int
 	switch p.Action {
@@ -232,8 +232,8 @@ func (m msteamsConvertor) Review(p *api.PullRequestPayload, event webhook_module
 	), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (m msteamsConvertor) Repository(p *api.RepositoryPayload) (MSTeamsPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (m msteamsConverter) Repository(p *api.RepositoryPayload) (MSTeamsPayload, error) {
 	var title, url string
 	var color int
 	switch p.Action {
@@ -257,8 +257,8 @@ func (m msteamsConvertor) Repository(p *api.RepositoryPayload) (MSTeamsPayload, 
 	), nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (m msteamsConvertor) Wiki(p *api.WikiPayload) (MSTeamsPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (m msteamsConverter) Wiki(p *api.WikiPayload) (MSTeamsPayload, error) {
 	title, color, _ := getWikiPayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -272,8 +272,8 @@ func (m msteamsConvertor) Wiki(p *api.WikiPayload) (MSTeamsPayload, error) {
 	), nil
 }
 
-// Release implements PayloadConvertor Release method
-func (m msteamsConvertor) Release(p *api.ReleasePayload) (MSTeamsPayload, error) {
+// Release implements PayloadConverter Release method
+func (m msteamsConverter) Release(p *api.ReleasePayload) (MSTeamsPayload, error) {
 	title, color := getReleasePayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -287,7 +287,7 @@ func (m msteamsConvertor) Release(p *api.ReleasePayload) (MSTeamsPayload, error)
 	), nil
 }
 
-func (m msteamsConvertor) Package(p *api.PackagePayload) (MSTeamsPayload, error) {
+func (m msteamsConverter) Package(p *api.PackagePayload) (MSTeamsPayload, error) {
 	title, color := getPackagePayloadInfo(p, noneLinkFormatter, false)
 
 	return createMSTeamsPayload(
@@ -343,10 +343,10 @@ func createMSTeamsPayload(r *api.Repository, s *api.User, title, text, actionTar
 	}
 }
 
-type msteamsConvertor struct{}
+type msteamsConverter struct{}
 
-var _ payloadConvertor[MSTeamsPayload] = msteamsConvertor{}
+var _ payloadConverter[MSTeamsPayload] = msteamsConverter{}
 
 func newMSTeamsRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
-	return newJSONRequest(msteamsConvertor{}, w, t, true)
+	return newJSONRequest(msteamsConverter{}, w, t, true)
 }

--- a/services/webhook/msteams_test.go
+++ b/services/webhook/msteams_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMSTeamsPayload(t *testing.T) {
-	mc := msteamsConvertor{}
+	mc := msteamsConverter{}
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()
 

--- a/services/webhook/packagist.go
+++ b/services/webhook/packagist.go
@@ -40,24 +40,24 @@ func GetPackagistHook(w *webhook_model.Webhook) *PackagistMeta {
 	return s
 }
 
-// Create implements PayloadConvertor Create method
-func (pc packagistConvertor) Create(_ *api.CreatePayload) (PackagistPayload, error) {
+// Create implements PayloadConverter Create method
+func (pc packagistConverter) Create(_ *api.CreatePayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (pc packagistConvertor) Delete(_ *api.DeletePayload) (PackagistPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (pc packagistConverter) Delete(_ *api.DeletePayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (pc packagistConvertor) Fork(_ *api.ForkPayload) (PackagistPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (pc packagistConverter) Fork(_ *api.ForkPayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Push implements PayloadConvertor Push method
+// Push implements PayloadConverter Push method
 // https://packagist.org/about
-func (pc packagistConvertor) Push(_ *api.PushPayload) (PackagistPayload, error) {
+func (pc packagistConverter) Push(_ *api.PushPayload) (PackagistPayload, error) {
 	return PackagistPayload{
 		PackagistRepository: struct {
 			URL string `json:"url"`
@@ -67,57 +67,57 @@ func (pc packagistConvertor) Push(_ *api.PushPayload) (PackagistPayload, error) 
 	}, nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (pc packagistConvertor) Issue(_ *api.IssuePayload) (PackagistPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (pc packagistConverter) Issue(_ *api.IssuePayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (pc packagistConvertor) IssueComment(_ *api.IssueCommentPayload) (PackagistPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (pc packagistConverter) IssueComment(_ *api.IssueCommentPayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (pc packagistConvertor) PullRequest(_ *api.PullRequestPayload) (PackagistPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (pc packagistConverter) PullRequest(_ *api.PullRequestPayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Review implements PayloadConvertor Review method
-func (pc packagistConvertor) Review(_ *api.PullRequestPayload, _ webhook_module.HookEventType) (PackagistPayload, error) {
+// Review implements PayloadConverter Review method
+func (pc packagistConverter) Review(_ *api.PullRequestPayload, _ webhook_module.HookEventType) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (pc packagistConvertor) Repository(_ *api.RepositoryPayload) (PackagistPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (pc packagistConverter) Repository(_ *api.RepositoryPayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (pc packagistConvertor) Wiki(_ *api.WikiPayload) (PackagistPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (pc packagistConverter) Wiki(_ *api.WikiPayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-// Release implements PayloadConvertor Release method
-func (pc packagistConvertor) Release(_ *api.ReleasePayload) (PackagistPayload, error) {
+// Release implements PayloadConverter Release method
+func (pc packagistConverter) Release(_ *api.ReleasePayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-func (pc packagistConvertor) Package(_ *api.PackagePayload) (PackagistPayload, error) {
+func (pc packagistConverter) Package(_ *api.PackagePayload) (PackagistPayload, error) {
 	return PackagistPayload{}, nil
 }
 
-type packagistConvertor struct {
+type packagistConverter struct {
 	PackageURL string
 }
 
-var _ payloadConvertor[PackagistPayload] = packagistConvertor{}
+var _ payloadConverter[PackagistPayload] = packagistConverter{}
 
 func newPackagistRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
 	meta := &PackagistMeta{}
 	if err := json.Unmarshal([]byte(w.Meta), meta); err != nil {
 		return nil, nil, fmt.Errorf("newpackagistRequest meta json: %w", err)
 	}
-	pc := packagistConvertor{
+	pc := packagistConverter{
 		PackageURL: meta.PackageURL,
 	}
 	return newJSONRequest(pc, w, t, true)

--- a/services/webhook/packagist_test.go
+++ b/services/webhook/packagist_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPackagistPayload(t *testing.T) {
-	pc := packagistConvertor{
+	pc := packagistConverter{
 		PackageURL: "https://packagist.org/packages/example",
 	}
 	t.Run("Create", func(t *testing.T) {

--- a/services/webhook/payloader.go
+++ b/services/webhook/payloader.go
@@ -14,8 +14,8 @@ import (
 	webhook_module "code.gitea.io/gitea/modules/webhook"
 )
 
-// payloadConvertor defines the interface to convert system payload to webhook payload
-type payloadConvertor[T any] interface {
+// payloadConverter defines the interface to convert system payload to webhook payload
+type payloadConverter[T any] interface {
 	Create(*api.CreatePayload) (T, error)
 	Delete(*api.DeletePayload) (T, error)
 	Fork(*api.ForkPayload) (T, error)
@@ -39,7 +39,7 @@ func convertUnmarshalledJSON[T, P any](convert func(P) (T, error), data []byte) 
 	return convert(p)
 }
 
-func newPayload[T any](rc payloadConvertor[T], data []byte, event webhook_module.HookEventType) (T, error) {
+func newPayload[T any](rc payloadConverter[T], data []byte, event webhook_module.HookEventType) (T, error) {
 	switch event {
 	case webhook_module.HookEventCreate:
 		return convertUnmarshalledJSON(rc.Create, data)
@@ -83,7 +83,7 @@ func newPayload[T any](rc payloadConvertor[T], data []byte, event webhook_module
 	return t, fmt.Errorf("newPayload unsupported event: %s", event)
 }
 
-func newJSONRequest[T any](pc payloadConvertor[T], w *webhook_model.Webhook, t *webhook_model.HookTask, withDefaultHeaders bool) (*http.Request, []byte, error) {
+func newJSONRequest[T any](pc payloadConverter[T], w *webhook_model.Webhook, t *webhook_model.HookTask, withDefaultHeaders bool) (*http.Request, []byte, error) {
 	payload, err := newPayload(pc, []byte(t.PayloadContent), t.EventType)
 	if err != nil {
 		return nil, nil, err

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -89,8 +89,8 @@ func SlackLinkToRef(repoURL, ref string) string {
 	return SlackLinkFormatter(url, refName)
 }
 
-// Create implements payloadConvertor Create method
-func (s slackConvertor) Create(p *api.CreatePayload) (SlackPayload, error) {
+// Create implements payloadConverter Create method
+func (s slackConverter) Create(p *api.CreatePayload) (SlackPayload, error) {
 	repoLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.FullName)
 	refLink := SlackLinkToRef(p.Repo.HTMLURL, p.Ref)
 	text := fmt.Sprintf("[%s:%s] %s created by %s", repoLink, refLink, p.RefType, p.Sender.UserName)
@@ -99,7 +99,7 @@ func (s slackConvertor) Create(p *api.CreatePayload) (SlackPayload, error) {
 }
 
 // Delete composes Slack payload for delete a branch or tag.
-func (s slackConvertor) Delete(p *api.DeletePayload) (SlackPayload, error) {
+func (s slackConverter) Delete(p *api.DeletePayload) (SlackPayload, error) {
 	refName := git.RefName(p.Ref).ShortName()
 	repoLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.FullName)
 	text := fmt.Sprintf("[%s:%s] %s deleted by %s", repoLink, refName, p.RefType, p.Sender.UserName)
@@ -108,7 +108,7 @@ func (s slackConvertor) Delete(p *api.DeletePayload) (SlackPayload, error) {
 }
 
 // Fork composes Slack payload for forked by a repository.
-func (s slackConvertor) Fork(p *api.ForkPayload) (SlackPayload, error) {
+func (s slackConverter) Fork(p *api.ForkPayload) (SlackPayload, error) {
 	baseLink := SlackLinkFormatter(p.Forkee.HTMLURL, p.Forkee.FullName)
 	forkLink := SlackLinkFormatter(p.Repo.HTMLURL, p.Repo.FullName)
 	text := fmt.Sprintf("%s is forked to %s", baseLink, forkLink)
@@ -116,8 +116,8 @@ func (s slackConvertor) Fork(p *api.ForkPayload) (SlackPayload, error) {
 	return s.createPayload(text, nil), nil
 }
 
-// Issue implements payloadConvertor Issue method
-func (s slackConvertor) Issue(p *api.IssuePayload) (SlackPayload, error) {
+// Issue implements payloadConverter Issue method
+func (s slackConverter) Issue(p *api.IssuePayload) (SlackPayload, error) {
 	text, issueTitle, attachmentText, color := getIssuesPayloadInfo(p, SlackLinkFormatter, true)
 
 	var attachments []SlackAttachment
@@ -135,8 +135,8 @@ func (s slackConvertor) Issue(p *api.IssuePayload) (SlackPayload, error) {
 	return s.createPayload(text, attachments), nil
 }
 
-// IssueComment implements payloadConvertor IssueComment method
-func (s slackConvertor) IssueComment(p *api.IssueCommentPayload) (SlackPayload, error) {
+// IssueComment implements payloadConverter IssueComment method
+func (s slackConverter) IssueComment(p *api.IssueCommentPayload) (SlackPayload, error) {
 	text, issueTitle, color := getIssueCommentPayloadInfo(p, SlackLinkFormatter, true)
 
 	return s.createPayload(text, []SlackAttachment{{
@@ -147,28 +147,28 @@ func (s slackConvertor) IssueComment(p *api.IssueCommentPayload) (SlackPayload, 
 	}}), nil
 }
 
-// Wiki implements payloadConvertor Wiki method
-func (s slackConvertor) Wiki(p *api.WikiPayload) (SlackPayload, error) {
+// Wiki implements payloadConverter Wiki method
+func (s slackConverter) Wiki(p *api.WikiPayload) (SlackPayload, error) {
 	text, _, _ := getWikiPayloadInfo(p, SlackLinkFormatter, true)
 
 	return s.createPayload(text, nil), nil
 }
 
-// Release implements payloadConvertor Release method
-func (s slackConvertor) Release(p *api.ReleasePayload) (SlackPayload, error) {
+// Release implements payloadConverter Release method
+func (s slackConverter) Release(p *api.ReleasePayload) (SlackPayload, error) {
 	text, _ := getReleasePayloadInfo(p, SlackLinkFormatter, true)
 
 	return s.createPayload(text, nil), nil
 }
 
-func (s slackConvertor) Package(p *api.PackagePayload) (SlackPayload, error) {
+func (s slackConverter) Package(p *api.PackagePayload) (SlackPayload, error) {
 	text, _ := getPackagePayloadInfo(p, SlackLinkFormatter, true)
 
 	return s.createPayload(text, nil), nil
 }
 
-// Push implements payloadConvertor Push method
-func (s slackConvertor) Push(p *api.PushPayload) (SlackPayload, error) {
+// Push implements payloadConverter Push method
+func (s slackConverter) Push(p *api.PushPayload) (SlackPayload, error) {
 	// n new commits
 	var (
 		commitDesc   string
@@ -208,8 +208,8 @@ func (s slackConvertor) Push(p *api.PushPayload) (SlackPayload, error) {
 	}}), nil
 }
 
-// PullRequest implements payloadConvertor PullRequest method
-func (s slackConvertor) PullRequest(p *api.PullRequestPayload) (SlackPayload, error) {
+// PullRequest implements payloadConverter PullRequest method
+func (s slackConverter) PullRequest(p *api.PullRequestPayload) (SlackPayload, error) {
 	text, issueTitle, attachmentText, color := getPullRequestPayloadInfo(p, SlackLinkFormatter, true)
 
 	var attachments []SlackAttachment
@@ -227,8 +227,8 @@ func (s slackConvertor) PullRequest(p *api.PullRequestPayload) (SlackPayload, er
 	return s.createPayload(text, attachments), nil
 }
 
-// Review implements payloadConvertor Review method
-func (s slackConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (SlackPayload, error) {
+// Review implements payloadConverter Review method
+func (s slackConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (SlackPayload, error) {
 	senderLink := SlackLinkFormatter(setting.AppURL+p.Sender.UserName, p.Sender.UserName)
 	title := fmt.Sprintf("#%d %s", p.Index, p.PullRequest.Title)
 	titleLink := fmt.Sprintf("%s/pulls/%d", p.Repository.HTMLURL, p.Index)
@@ -248,8 +248,8 @@ func (s slackConvertor) Review(p *api.PullRequestPayload, event webhook_module.H
 	return s.createPayload(text, nil), nil
 }
 
-// Repository implements payloadConvertor Repository method
-func (s slackConvertor) Repository(p *api.RepositoryPayload) (SlackPayload, error) {
+// Repository implements payloadConverter Repository method
+func (s slackConverter) Repository(p *api.RepositoryPayload) (SlackPayload, error) {
 	senderLink := SlackLinkFormatter(setting.AppURL+p.Sender.UserName, p.Sender.UserName)
 	repoLink := SlackLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 	var text string
@@ -264,7 +264,7 @@ func (s slackConvertor) Repository(p *api.RepositoryPayload) (SlackPayload, erro
 	return s.createPayload(text, nil), nil
 }
 
-func (s slackConvertor) createPayload(text string, attachments []SlackAttachment) SlackPayload {
+func (s slackConverter) createPayload(text string, attachments []SlackAttachment) SlackPayload {
 	return SlackPayload{
 		Channel:     s.Channel,
 		Text:        text,
@@ -274,21 +274,21 @@ func (s slackConvertor) createPayload(text string, attachments []SlackAttachment
 	}
 }
 
-type slackConvertor struct {
+type slackConverter struct {
 	Channel  string
 	Username string
 	IconURL  string
 	Color    string
 }
 
-var _ payloadConvertor[SlackPayload] = slackConvertor{}
+var _ payloadConverter[SlackPayload] = slackConverter{}
 
 func newSlackRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
 	meta := &SlackMeta{}
 	if err := json.Unmarshal([]byte(w.Meta), meta); err != nil {
 		return nil, nil, fmt.Errorf("newSlackRequest meta json: %w", err)
 	}
-	sc := slackConvertor{
+	sc := slackConverter{
 		Channel:  meta.Channel,
 		Username: meta.Username,
 		IconURL:  meta.IconURL,

--- a/services/webhook/slack_test.go
+++ b/services/webhook/slack_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSlackPayload(t *testing.T) {
-	sc := slackConvertor{}
+	sc := slackConverter{}
 
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -42,8 +42,8 @@ func GetTelegramHook(w *webhook_model.Webhook) *TelegramMeta {
 	return s
 }
 
-// Create implements PayloadConvertor Create method
-func (t telegramConvertor) Create(p *api.CreatePayload) (TelegramPayload, error) {
+// Create implements PayloadConverter Create method
+func (t telegramConverter) Create(p *api.CreatePayload) (TelegramPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf(`[<a href="%s">%s</a>] %s <a href="%s">%s</a> created`, p.Repo.HTMLURL, p.Repo.FullName, p.RefType,
@@ -52,8 +52,8 @@ func (t telegramConvertor) Create(p *api.CreatePayload) (TelegramPayload, error)
 	return createTelegramPayload(title), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (t telegramConvertor) Delete(p *api.DeletePayload) (TelegramPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (t telegramConverter) Delete(p *api.DeletePayload) (TelegramPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf(`[<a href="%s">%s</a>] %s <a href="%s">%s</a> deleted`, p.Repo.HTMLURL, p.Repo.FullName, p.RefType,
@@ -62,15 +62,15 @@ func (t telegramConvertor) Delete(p *api.DeletePayload) (TelegramPayload, error)
 	return createTelegramPayload(title), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (t telegramConvertor) Fork(p *api.ForkPayload) (TelegramPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (t telegramConverter) Fork(p *api.ForkPayload) (TelegramPayload, error) {
 	title := fmt.Sprintf(`%s is forked to <a href="%s">%s</a>`, p.Forkee.FullName, p.Repo.HTMLURL, p.Repo.FullName)
 
 	return createTelegramPayload(title), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (t telegramConvertor) Push(p *api.PushPayload) (TelegramPayload, error) {
+// Push implements PayloadConverter Push method
+func (t telegramConverter) Push(p *api.PushPayload) (TelegramPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -107,29 +107,29 @@ func (t telegramConvertor) Push(p *api.PushPayload) (TelegramPayload, error) {
 	return createTelegramPayload(title + "\n" + text), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (t telegramConvertor) Issue(p *api.IssuePayload) (TelegramPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (t telegramConverter) Issue(p *api.IssuePayload) (TelegramPayload, error) {
 	text, _, attachmentText, _ := getIssuesPayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text + "\n\n" + attachmentText), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (t telegramConvertor) IssueComment(p *api.IssueCommentPayload) (TelegramPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (t telegramConverter) IssueComment(p *api.IssueCommentPayload) (TelegramPayload, error) {
 	text, _, _ := getIssueCommentPayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text + "\n" + p.Comment.Body), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (t telegramConvertor) PullRequest(p *api.PullRequestPayload) (TelegramPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (t telegramConverter) PullRequest(p *api.PullRequestPayload) (TelegramPayload, error) {
 	text, _, attachmentText, _ := getPullRequestPayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text + "\n" + attachmentText), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (t telegramConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (TelegramPayload, error) {
+// Review implements PayloadConverter Review method
+func (t telegramConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (TelegramPayload, error) {
 	var text, attachmentText string
 	switch p.Action {
 	case api.HookIssueReviewed:
@@ -145,8 +145,8 @@ func (t telegramConvertor) Review(p *api.PullRequestPayload, event webhook_modul
 	return createTelegramPayload(text + "\n" + attachmentText), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (t telegramConvertor) Repository(p *api.RepositoryPayload) (TelegramPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (t telegramConverter) Repository(p *api.RepositoryPayload) (TelegramPayload, error) {
 	var title string
 	switch p.Action {
 	case api.HookRepoCreated:
@@ -159,21 +159,21 @@ func (t telegramConvertor) Repository(p *api.RepositoryPayload) (TelegramPayload
 	return TelegramPayload{}, nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (t telegramConvertor) Wiki(p *api.WikiPayload) (TelegramPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (t telegramConverter) Wiki(p *api.WikiPayload) (TelegramPayload, error) {
 	text, _, _ := getWikiPayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text), nil
 }
 
-// Release implements PayloadConvertor Release method
-func (t telegramConvertor) Release(p *api.ReleasePayload) (TelegramPayload, error) {
+// Release implements PayloadConverter Release method
+func (t telegramConverter) Release(p *api.ReleasePayload) (TelegramPayload, error) {
 	text, _ := getReleasePayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text), nil
 }
 
-func (t telegramConvertor) Package(p *api.PackagePayload) (TelegramPayload, error) {
+func (t telegramConverter) Package(p *api.PackagePayload) (TelegramPayload, error) {
 	text, _ := getPackagePayloadInfo(p, htmlLinkFormatter, true)
 
 	return createTelegramPayload(text), nil
@@ -185,10 +185,10 @@ func createTelegramPayload(message string) TelegramPayload {
 	}
 }
 
-type telegramConvertor struct{}
+type telegramConverter struct{}
 
-var _ payloadConvertor[TelegramPayload] = telegramConvertor{}
+var _ payloadConverter[TelegramPayload] = telegramConverter{}
 
 func newTelegramRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
-	return newJSONRequest(telegramConvertor{}, w, t, true)
+	return newJSONRequest(telegramConverter{}, w, t, true)
 }

--- a/services/webhook/telegram_test.go
+++ b/services/webhook/telegram_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestTelegramPayload(t *testing.T) {
-	tc := telegramConvertor{}
+	tc := telegramConverter{}
 	t.Run("Create", func(t *testing.T) {
 		p := createTestPayload()
 

--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -41,8 +41,8 @@ func newWechatworkMarkdownPayload(title string) WechatworkPayload {
 	}
 }
 
-// Create implements PayloadConvertor Create method
-func (wc wechatworkConvertor) Create(p *api.CreatePayload) (WechatworkPayload, error) {
+// Create implements PayloadConverter Create method
+func (wc wechatworkConverter) Create(p *api.CreatePayload) (WechatworkPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s created", p.Repo.FullName, p.RefType, refName)
@@ -50,8 +50,8 @@ func (wc wechatworkConvertor) Create(p *api.CreatePayload) (WechatworkPayload, e
 	return newWechatworkMarkdownPayload(title), nil
 }
 
-// Delete implements PayloadConvertor Delete method
-func (wc wechatworkConvertor) Delete(p *api.DeletePayload) (WechatworkPayload, error) {
+// Delete implements PayloadConverter Delete method
+func (wc wechatworkConverter) Delete(p *api.DeletePayload) (WechatworkPayload, error) {
 	// created tag/branch
 	refName := git.RefName(p.Ref).ShortName()
 	title := fmt.Sprintf("[%s] %s %s deleted", p.Repo.FullName, p.RefType, refName)
@@ -59,15 +59,15 @@ func (wc wechatworkConvertor) Delete(p *api.DeletePayload) (WechatworkPayload, e
 	return newWechatworkMarkdownPayload(title), nil
 }
 
-// Fork implements PayloadConvertor Fork method
-func (wc wechatworkConvertor) Fork(p *api.ForkPayload) (WechatworkPayload, error) {
+// Fork implements PayloadConverter Fork method
+func (wc wechatworkConverter) Fork(p *api.ForkPayload) (WechatworkPayload, error) {
 	title := fmt.Sprintf("%s is forked to %s", p.Forkee.FullName, p.Repo.FullName)
 
 	return newWechatworkMarkdownPayload(title), nil
 }
 
-// Push implements PayloadConvertor Push method
-func (wc wechatworkConvertor) Push(p *api.PushPayload) (WechatworkPayload, error) {
+// Push implements PayloadConverter Push method
+func (wc wechatworkConverter) Push(p *api.PushPayload) (WechatworkPayload, error) {
 	var (
 		branchName = git.RefName(p.Ref).ShortName()
 		commitDesc string
@@ -95,8 +95,8 @@ func (wc wechatworkConvertor) Push(p *api.PushPayload) (WechatworkPayload, error
 	return newWechatworkMarkdownPayload(title + "\r\n\r\n" + text), nil
 }
 
-// Issue implements PayloadConvertor Issue method
-func (wc wechatworkConvertor) Issue(p *api.IssuePayload) (WechatworkPayload, error) {
+// Issue implements PayloadConverter Issue method
+func (wc wechatworkConverter) Issue(p *api.IssuePayload) (WechatworkPayload, error) {
 	text, issueTitle, attachmentText, _ := getIssuesPayloadInfo(p, noneLinkFormatter, true)
 	var content string
 	content += fmt.Sprintf(" ><font color=\"info\">%s</font>\n >%s \n ><font color=\"warning\"> %s</font> \n [%s](%s)", text, attachmentText, issueTitle, p.Issue.HTMLURL, p.Issue.HTMLURL)
@@ -104,8 +104,8 @@ func (wc wechatworkConvertor) Issue(p *api.IssuePayload) (WechatworkPayload, err
 	return newWechatworkMarkdownPayload(content), nil
 }
 
-// IssueComment implements PayloadConvertor IssueComment method
-func (wc wechatworkConvertor) IssueComment(p *api.IssueCommentPayload) (WechatworkPayload, error) {
+// IssueComment implements PayloadConverter IssueComment method
+func (wc wechatworkConverter) IssueComment(p *api.IssueCommentPayload) (WechatworkPayload, error) {
 	text, issueTitle, _ := getIssueCommentPayloadInfo(p, noneLinkFormatter, true)
 	var content string
 	content += fmt.Sprintf(" ><font color=\"info\">%s</font>\n >%s \n ><font color=\"warning\">%s</font> \n [%s](%s)", text, p.Comment.Body, issueTitle, p.Comment.HTMLURL, p.Comment.HTMLURL)
@@ -113,8 +113,8 @@ func (wc wechatworkConvertor) IssueComment(p *api.IssueCommentPayload) (Wechatwo
 	return newWechatworkMarkdownPayload(content), nil
 }
 
-// PullRequest implements PayloadConvertor PullRequest method
-func (wc wechatworkConvertor) PullRequest(p *api.PullRequestPayload) (WechatworkPayload, error) {
+// PullRequest implements PayloadConverter PullRequest method
+func (wc wechatworkConverter) PullRequest(p *api.PullRequestPayload) (WechatworkPayload, error) {
 	text, issueTitle, attachmentText, _ := getPullRequestPayloadInfo(p, noneLinkFormatter, true)
 	pr := fmt.Sprintf("> <font color=\"info\"> %s </font> \r\n > <font color=\"comment\">%s </font> \r\n > <font color=\"comment\">%s </font> \r\n",
 		text, issueTitle, attachmentText)
@@ -122,8 +122,8 @@ func (wc wechatworkConvertor) PullRequest(p *api.PullRequestPayload) (Wechatwork
 	return newWechatworkMarkdownPayload(pr), nil
 }
 
-// Review implements PayloadConvertor Review method
-func (wc wechatworkConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (WechatworkPayload, error) {
+// Review implements PayloadConverter Review method
+func (wc wechatworkConverter) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (WechatworkPayload, error) {
 	var text, title string
 	switch p.Action {
 	case api.HookIssueReviewed:
@@ -138,8 +138,8 @@ func (wc wechatworkConvertor) Review(p *api.PullRequestPayload, event webhook_mo
 	return newWechatworkMarkdownPayload("# " + title + "\r\n\r\n >" + text), nil
 }
 
-// Repository implements PayloadConvertor Repository method
-func (wc wechatworkConvertor) Repository(p *api.RepositoryPayload) (WechatworkPayload, error) {
+// Repository implements PayloadConverter Repository method
+func (wc wechatworkConverter) Repository(p *api.RepositoryPayload) (WechatworkPayload, error) {
 	var title string
 	switch p.Action {
 	case api.HookRepoCreated:
@@ -153,30 +153,30 @@ func (wc wechatworkConvertor) Repository(p *api.RepositoryPayload) (WechatworkPa
 	return WechatworkPayload{}, nil
 }
 
-// Wiki implements PayloadConvertor Wiki method
-func (wc wechatworkConvertor) Wiki(p *api.WikiPayload) (WechatworkPayload, error) {
+// Wiki implements PayloadConverter Wiki method
+func (wc wechatworkConverter) Wiki(p *api.WikiPayload) (WechatworkPayload, error) {
 	text, _, _ := getWikiPayloadInfo(p, noneLinkFormatter, true)
 
 	return newWechatworkMarkdownPayload(text), nil
 }
 
-// Release implements PayloadConvertor Release method
-func (wc wechatworkConvertor) Release(p *api.ReleasePayload) (WechatworkPayload, error) {
+// Release implements PayloadConverter Release method
+func (wc wechatworkConverter) Release(p *api.ReleasePayload) (WechatworkPayload, error) {
 	text, _ := getReleasePayloadInfo(p, noneLinkFormatter, true)
 
 	return newWechatworkMarkdownPayload(text), nil
 }
 
-func (wc wechatworkConvertor) Package(p *api.PackagePayload) (WechatworkPayload, error) {
+func (wc wechatworkConverter) Package(p *api.PackagePayload) (WechatworkPayload, error) {
 	text, _ := getPackagePayloadInfo(p, noneLinkFormatter, true)
 
 	return newWechatworkMarkdownPayload(text), nil
 }
 
-type wechatworkConvertor struct{}
+type wechatworkConverter struct{}
 
-var _ payloadConvertor[WechatworkPayload] = wechatworkConvertor{}
+var _ payloadConverter[WechatworkPayload] = wechatworkConverter{}
 
 func newWechatworkRequest(ctx context.Context, w *webhook_model.Webhook, t *webhook_model.HookTask) (*http.Request, []byte, error) {
-	return newJSONRequest(wechatworkConvertor{}, w, t, true)
+	return newJSONRequest(wechatworkConverter{}, w, t, true)
 }


### PR DESCRIPTION
In #29145 `converter` was misspelled as `convertor`. Fixing before it spreads :)