### PR TITLE
Fix the wrong locale key of searching users

### DIFF
--- a/templates/shared/user/blocked_users.tmpl
+++ b/templates/shared/user/blocked_users.tmpl
@@ -17,7 +17,7 @@
 		{{.CsrfTokenHtml}}
 		<input type="hidden" name="action" value="block" />
 		<div id="search-user-box" class="field ui fluid search input">
-			<input class="prompt gt-mr-3" name="blockee" placeholder="{{ctx.Locale.Tr "repo.settings.search_user_placeholder"}}" autocomplete="off" required>
+			<input class="prompt gt-mr-3" name="blockee" placeholder="{{ctx.Locale.Tr "search.user_kind"}}" autocomplete="off" required>
 			<button class="ui red button">{{ctx.Locale.Tr "user.block.block"}}</button>
 		</div>
 		<div class="field">


### PR DESCRIPTION
regression of #29530
I guess it's because the user-blocking feature is committed after that locale clean PR.
