### PR TITLE
Fix 500 when sorting the default project board

### DIFF
--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -574,16 +574,28 @@ func CheckProjectBoardChangePermissions(ctx *context.Context) (*project_model.Pr
 		return nil, nil
 	}
 
-	board, err := project_model.GetBoard(ctx, ctx.ParamsInt64(":boardID"))
-	if err != nil {
-		ctx.ServerError("GetProjectBoard", err)
-		return nil, nil
-	}
-	if board.ProjectID != ctx.ParamsInt64(":id") {
-		ctx.JSON(http.StatusUnprocessableEntity, map[string]string{
-			"message": fmt.Sprintf("ProjectBoard[%d] is not in Project[%d] as expected", board.ID, project.ID),
-		})
-		return nil, nil
+	var board *project_model.Board
+
+	if ctx.ParamsInt64(":boardID") == 0 {
+		board = &project_model.Board{
+			ID:        0,
+			ProjectID: project.ID,
+			Title:     ctx.Locale.TrString("repo.projects.type.uncategorized"),
+		}
+	} else {
+		board, err = project_model.GetBoard(ctx, ctx.ParamsInt64(":boardID"))
+		if err != nil {
+			if project_model.IsErrProjectBoardNotExist(err) {
+				ctx.NotFound("ProjectBoardNotExist", nil)
+			} else {
+				ctx.ServerError("GetProjectBoard", err)
+			}
+			return nil, nil
+		}
+		if board.ProjectID != project.ID {
+			ctx.NotFound("BoardNotInProject", nil)
+			return nil, nil
+		}
 	}
 
 	if project.OwnerID != ctx.ContextUser.ID {


### PR DESCRIPTION
fix #29853 
The problem is that `checkProjectBoardChangePermission` didn't check if the `project board id == 0`, which is the default project board.
BTW, I think the code about this `default project board` trick is a little redundant. It required every function to check whether the `project board id == 0`. I will clean it up afterward.
