### PR TITLE
Prevent dropping onto project column 0

### DIFF
--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -66,7 +66,7 @@ async function initRepoProjectSortable() {
     onMove: (e) => {
       // prevent dropping onto column 0 because it currently can not be moved and doing
       // so would raise a 500 "project board does not exist" error on backend.
-      if (e.related.getAttribute('data-id') === '0') return false;
+      if (e.related?.getAttribute('data-id') === '0') return false;
     },
     onSort: async () => {
       boardColumns = mainBoard.getElementsByClassName('project-column');

--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -63,6 +63,11 @@ async function initRepoProjectSortable() {
     ghostClass: 'card-ghost',
     delayOnTouchOnly: true,
     delay: 500,
+    onMove: (e) => {
+      // prevent dropping onto column 0 because it currently can not be moved and doing
+      // so would raise a 500 "project board does not exist" error on backend.
+      if (e.related.getAttribute('data-id') === '0') return false;
+    },
     onSort: async () => {
       boardColumns = mainBoard.getElementsByClassName('project-column');
       for (let i = 0; i < boardColumns.length; i++) {


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/29853
Fixes: https://github.com/go-gitea/gitea/pull/29870

With this, it's no longer possible to drop something onto the first column, which prevents the 500 error from happening. In the future we should remove the restriction and allow dragging from and to column 0.

![](https://github.com/go-gitea/gitea/assets/115237/57dc7b83-6309-4204-aa21-2259cab3be02)
