### PR TITLE
Remove jQuery `.attr` from the quick pull request button text

### DIFF
--- a/web_src/js/features/repo-editor.js
+++ b/web_src/js/features/repo-editor.js
@@ -72,7 +72,7 @@ export function initRepoEditor() {
       hideElem($('.quick-pull-branch-name'));
       document.querySelector('.quick-pull-branch-name input').required = false;
     }
-    $('#commit-button').text($(this).attr('button_text'));
+    $('#commit-button').text(this.getAttribute('button_text'));
   });
 
   const joinTreePath = ($fileNameEl) => {


### PR DESCRIPTION
- Switched from jQuery `.attr` to plain javascript `.getAttribute`
- Tested the quick pull request button text change functionality and it works as before
