### PR TITLE
Remove jQuery `.attr` from the archive download and compare page branch selector

### DIFF
--- a/web_src/js/features/repo-common.js
+++ b/web_src/js/features/repo-common.js
@@ -34,7 +34,7 @@ async function getArchive($target, url, first) {
 export function initRepoArchiveLinks() {
   $('.archive-link').on('click', function (event) {
     event.preventDefault();
-    const url = $(this).attr('href');
+    const url = this.getAttribute('href');
     if (!url) return;
     getArchive($(event.target), url, true);
   });
@@ -80,10 +80,10 @@ export function initRepoCommonFilterSearchDropdown(selector) {
     fullTextSearch: 'exact',
     selectOnKeydown: false,
     onChange(_text, _value, $choice) {
-      if ($choice.attr('data-url')) {
-        window.location.href = $choice.attr('data-url');
+      if ($choice[0].getAttribute('data-url')) {
+        window.location.href = $choice[0].getAttribute('data-url');
       }
     },
-    message: {noResults: $dropdown.attr('data-no-results')},
+    message: {noResults: $dropdown[0].getAttribute('data-no-results')},
   });
 }


### PR DESCRIPTION
- Switched from jQuery `.attr` to plain javascript `.getAttribute`
- Tested the archive download and compare page branch selector functionality and it works as before