### PR TITLE
Add background to dashboard navbar, fix missing padding

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -3,7 +3,7 @@
 		<div class="item">
 			<div class="ui floating dropdown jump">
 				<span class="text truncated-item-container">
-					{{ctx.AvatarUtils.Avatar .ContextUser}}
+					{{ctx.AvatarUtils.Avatar .ContextUser 24}}
 					<span class="truncated-item-name">{{.ContextUser.ShortName 40}}</span>
 					<span class="org-visibility">
 						{{if .ContextUser.Visibility.IsLimited}}<div class="ui basic tiny horizontal label">{{ctx.Locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}

--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -3,13 +3,13 @@
 		<div class="item">
 			<div class="ui floating dropdown jump">
 				<span class="text truncated-item-container">
-					{{ctx.AvatarUtils.Avatar .ContextUser 24}}
+					{{ctx.AvatarUtils.Avatar .ContextUser 24 "tw-mr-1"}}
 					<span class="truncated-item-name">{{.ContextUser.ShortName 40}}</span>
 					<span class="org-visibility">
 						{{if .ContextUser.Visibility.IsLimited}}<div class="ui basic tiny horizontal label">{{ctx.Locale.Tr "org.settings.visibility.limited_shortname"}}</div>{{end}}
 						{{if .ContextUser.Visibility.IsPrivate}}<div class="ui basic tiny horizontal label">{{ctx.Locale.Tr "org.settings.visibility.private_shortname"}}</div>{{end}}
 					</span>
-					{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+					{{svg "octicon-triangle-down" 14 "dropdown icon tw-ml-1"}}
 				</span>
 				<div class="context user overflow menu">
 					<div class="ui header">

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -669,7 +669,8 @@ img.ui.avatar,
 }
 
 .page-content.new:is(.repo,.migrate,.org),
-.page-content.profile:is(.user,.organization) {
+.page-content.profile:is(.user,.organization),
+.page-content.user:is(.settings,.notification) {
   padding-top: 15px;
 }
 

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1797,7 +1797,7 @@ table th[data-sortt-desc] .svg {
 
 .ui.tabular.menu .item,
 .ui.secondary.pointing.menu .item {
-  padding: 11px 12px !important;
+  padding: 11.55px 12px !important; /* match .dashboard-navbar in height */
   color: var(--color-text-light-2);
 }
 

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -78,7 +78,7 @@
 }
 
 .dashboard .dashboard-navbar {
-  padding: 1px 12px; /* match overflow-menu in height */
+  padding: 1px 12px; /* match .overflow-menu-items in height */
   background: var(--color-header-wrapper);
 }
 

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -78,7 +78,8 @@
 }
 
 .dashboard .dashboard-navbar {
-  padding: 4px 12px;
+  padding: 0 12px;
+  background: var(--color-header-wrapper);
 }
 
 .dashboard .dashboard-navbar .org-visibility .label {

--- a/web_src/css/dashboard.css
+++ b/web_src/css/dashboard.css
@@ -78,7 +78,7 @@
 }
 
 .dashboard .dashboard-navbar {
-  padding: 0 12px;
+  padding: 1px 12px; /* match overflow-menu in height */
   background: var(--color-header-wrapper);
 }
 


### PR DESCRIPTION
Two small CSS fixes:

1. Add background and reduced padding/avatar size to dashboard navbar. We use that background already in a number of "secondary navbars", so it fits.

<img width="1344" alt="Screenshot 2024-03-20 at 18 18 21" src="https://github.com/go-gitea/gitea/assets/115237/ce5ebedc-e607-42c7-b7b4-b7a4c0ee68f2">

2. Fix padding on top of user settings and subscriptions, regressed by https://github.com/go-gitea/gitea/pull/29922.