### PR TITLE
Build backend before integrations test

### DIFF
--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 pgsql ldap minio" | sudo tee -a /etc/hosts'
       - run: make deps-backend
-      - run: make backend
-        env:
-          TAGS: bindata
       - name: run migration tests
         run: make test-pgsql-migration
       - name: run tests
@@ -72,9 +69,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - run: make deps-backend
-      - run: make backend
-        env:
-          TAGS: bindata gogit sqlite sqlite_unlock_notify
       - name: run migration tests
         run: make test-sqlite-migration
       - name: run tests
@@ -128,9 +122,6 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch meilisearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
-      - run: make backend
-        env:
-          TAGS: bindata
       - name: unit-tests
         run: make unit-test-coverage test-check
         env:
@@ -178,9 +169,6 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
-      - run: make backend
-        env:
-          TAGS: bindata
       - name: run migration tests
         run: make test-mysql-migration
       - name: run tests
@@ -213,9 +201,6 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mssql" | sudo tee -a /etc/hosts'
       - run: make deps-backend
-      - run: make backend
-        env:
-          TAGS: bindata
       - run: make test-mssql-migration
       - name: run tests
         run: make test-mssql

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 pgsql ldap minio" | sudo tee -a /etc/hosts'
       - run: make deps-backend
+      - run: make backend
+        env:
+          TAGS: bindata
       - name: run migration tests
         run: make test-pgsql-migration
       - name: run tests
@@ -69,6 +72,9 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - run: make deps-backend
+      - run: make backend
+        env:
+          TAGS: bindata gogit sqlite sqlite_unlock_notify
       - name: run migration tests
         run: make test-sqlite-migration
       - name: run tests
@@ -122,6 +128,9 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch meilisearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
+      - run: make backend
+        env:
+          TAGS: bindata
       - name: unit-tests
         run: make unit-test-coverage test-check
         env:
@@ -169,6 +178,9 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mysql elasticsearch smtpimap" | sudo tee -a /etc/hosts'
       - run: make deps-backend
+      - run: make backend
+        env:
+          TAGS: bindata
       - name: run migration tests
         run: make test-mysql-migration
       - name: run tests
@@ -201,6 +213,9 @@ jobs:
       - name: Add hosts to /etc/hosts
         run: '[ -e "/.dockerenv" ] || [ -e "/run/.containerenv" ] || echo "127.0.0.1 mssql" | sudo tee -a /etc/hosts'
       - run: make deps-backend
+      - run: make backend
+        env:
+          TAGS: bindata
       - run: make test-mssql-migration
       - name: run tests
         run: make test-mssql

--- a/Makefile
+++ b/Makefile
@@ -673,22 +673,22 @@ integration-test-coverage: integrations.cover.test generate-ini-mysql
 integration-test-coverage-sqlite: integrations.cover.sqlite.test generate-ini-sqlite
 	GITEA_ROOT="$(CURDIR)" GITEA_CONF=tests/sqlite.ini ./integrations.cover.sqlite.test -test.coverprofile=integration.coverage.out
 
-integrations.mysql.test: git-check $(GO_SOURCES)
+integrations.mysql.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -o integrations.mysql.test
 
-integrations.pgsql.test: git-check $(GO_SOURCES)
+integrations.pgsql.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -o integrations.pgsql.test
 
-integrations.mssql.test: git-check $(GO_SOURCES)
+integrations.mssql.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -o integrations.mssql.test
 
-integrations.sqlite.test: git-check $(GO_SOURCES)
+integrations.sqlite.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -o integrations.sqlite.test -tags '$(TEST_TAGS)'
 
-integrations.cover.test: git-check $(GO_SOURCES)
+integrations.cover.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -coverpkg $(shell echo $(GO_TEST_PACKAGES) | tr ' ' ',') -o integrations.cover.test
 
-integrations.cover.sqlite.test: git-check $(GO_SOURCES)
+integrations.cover.sqlite.test: git-check backend $(GO_SOURCES)
 	$(GO) test $(GOTESTFLAGS) -c code.gitea.io/gitea/tests/integration -coverpkg $(shell echo $(GO_TEST_PACKAGES) | tr ' ' ',') -o integrations.cover.sqlite.test -tags '$(TEST_TAGS)'
 
 .PHONY: migrations.mysql.test


### PR DESCRIPTION
It seems integration tests require the Gitea binary (maybe use it as git hooks?).

https://github.com/go-gitea/gitea/blob/3ee39db34efd532626d710de6717bf3c6255c10e/tests/integration/integration_test.go#L89

If I delete the old binary then `make test-sqlite`, it will fail. So let `integrations.*.test` depends on `backend`.

<img width="1260" alt="image" src="https://github.com/go-gitea/gitea/assets/9418365/8c87a6e3-5253-491c-a548-9cb94f9945ba">
