### PR TITLE
Cancel previous runs of the same PR automatically

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -170,15 +170,17 @@ func updateRepoRunsNumbers(ctx context.Context, repo *repo_model.Repository) err
 	return err
 }
 
-// CancelRunningJobs cancels all running and waiting jobs associated with a specific workflow.
-func CancelRunningJobs(ctx context.Context, repoID int64, ref, workflowID string, event webhook_module.HookEventType) error {
-	// Find all runs in the specified repository, reference, and workflow with statuses 'Running' or 'Waiting'.
+// CancelPreviousJobs cancels all previous jobs of the same repository, reference, workflow, and event.
+// It's useful when a new run is triggered, and all previous runs needn't be continued anymore.
+func CancelPreviousJobs(ctx context.Context, repoID int64, ref, workflowID string, event webhook_module.HookEventType) error {
+	// Find all runs in the specified repository, reference, and workflow with non-final status
 	runs, total, err := db.FindAndCount[ActionRun](ctx, FindRunOptions{
 		RepoID:       repoID,
 		Ref:          ref,
 		WorkflowID:   workflowID,
 		TriggerEvent: event,
-		Status:       []Status{StatusRunning, StatusWaiting},
+		// Actually, the status of a run cannot be 'Blocked' now, but it's included for future compatibility.
+		Status: []Status{StatusRunning, StatusWaiting, StatusBlocked},
 	})
 	if err != nil {
 		return err

--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -179,8 +179,7 @@ func CancelPreviousJobs(ctx context.Context, repoID int64, ref, workflowID strin
 		Ref:          ref,
 		WorkflowID:   workflowID,
 		TriggerEvent: event,
-		// Actually, the status of a run cannot be 'Blocked' now, but it's included for future compatibility.
-		Status: []Status{StatusRunning, StatusWaiting, StatusBlocked},
+		Status:       []Status{StatusRunning, StatusWaiting, StatusBlocked},
 	})
 	if err != nil {
 		return err

--- a/models/actions/schedule.go
+++ b/models/actions/schedule.go
@@ -127,14 +127,14 @@ func CleanRepoScheduleTasks(ctx context.Context, repo *repo_model.Repository) er
 		return fmt.Errorf("DeleteCronTaskByRepo: %v", err)
 	}
 	// cancel running cron jobs of this repository and delete old schedules
-	if err := CancelRunningJobs(
+	if err := CancelPreviousJobs(
 		ctx,
 		repo.ID,
 		repo.DefaultBranch,
 		"",
 		webhook_module.HookEventSchedule,
 	); err != nil {
-		return fmt.Errorf("CancelRunningJobs: %v", err)
+		return fmt.Errorf("CancelPreviousJobs: %v", err)
 	}
 	return nil
 }

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -317,7 +317,7 @@ func handleWorkflows(
 			continue
 		}
 
-		// cancel running jobs if the event is push or
+		// cancel running jobs if the event is push or pull_request_sync
 		if run.Event == webhook_module.HookEventPush ||
 			run.Event == webhook_module.HookEventPullRequestSync {
 			if err := actions_model.CancelPreviousJobs(

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -317,17 +317,17 @@ func handleWorkflows(
 			continue
 		}
 
-		// cancel running jobs if the event is push
-		if run.Event == webhook_module.HookEventPush {
-			// cancel running jobs of the same workflow
-			if err := actions_model.CancelRunningJobs(
+		// cancel running jobs if the event is push or
+		if run.Event == webhook_module.HookEventPush ||
+			run.Event == webhook_module.HookEventPullRequestSync {
+			if err := actions_model.CancelPreviousJobs(
 				ctx,
 				run.RepoID,
 				run.Ref,
 				run.WorkflowID,
 				run.Event,
 			); err != nil {
-				log.Error("CancelRunningJobs: %v", err)
+				log.Error("CancelPreviousJobs: %v", err)
 			}
 		}
 

--- a/services/actions/schedule_tasks.go
+++ b/services/actions/schedule_tasks.go
@@ -55,14 +55,14 @@ func startTasks(ctx context.Context) error {
 			// cancel running jobs if the event is push
 			if row.Schedule.Event == webhook_module.HookEventPush {
 				// cancel running jobs of the same workflow
-				if err := actions_model.CancelRunningJobs(
+				if err := actions_model.CancelPreviousJobs(
 					ctx,
 					row.RepoID,
 					row.Schedule.Ref,
 					row.Schedule.WorkflowID,
 					webhook_module.HookEventSchedule,
 				); err != nil {
-					log.Error("CancelRunningJobs: %v", err)
+					log.Error("CancelPreviousJobs: %v", err)
 				}
 			}
 

--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -410,14 +410,14 @@ func RenameBranch(ctx context.Context, repo *repo_model.Repository, doer *user_m
 				log.Error("DeleteCronTaskByRepo: %v", err)
 			}
 			// cancel running cron jobs of this repository and delete old schedules
-			if err := actions_model.CancelRunningJobs(
+			if err := actions_model.CancelPreviousJobs(
 				ctx,
 				repo.ID,
 				from,
 				"",
 				webhook_module.HookEventSchedule,
 			); err != nil {
-				log.Error("CancelRunningJobs: %v", err)
+				log.Error("CancelPreviousJobs: %v", err)
 			}
 
 			err2 = gitrepo.SetDefaultBranch(ctx, repo, to)
@@ -575,14 +575,14 @@ func SetRepoDefaultBranch(ctx context.Context, repo *repo_model.Repository, gitR
 			log.Error("DeleteCronTaskByRepo: %v", err)
 		}
 		// cancel running cron jobs of this repository and delete old schedules
-		if err := actions_model.CancelRunningJobs(
+		if err := actions_model.CancelPreviousJobs(
 			ctx,
 			repo.ID,
 			oldDefaultBranchName,
 			"",
 			webhook_module.HookEventSchedule,
 		); err != nil {
-			log.Error("CancelRunningJobs: %v", err)
+			log.Error("CancelPreviousJobs: %v", err)
 		}
 
 		if err := gitrepo.SetDefaultBranch(ctx, repo, newBranchName); err != nil {


### PR DESCRIPTION
Follow #25716. Also cancel previous runs for `pull_request_sync`.

It's not a bug since it original PR said "if the event is push".

The main change is https://github.com/go-gitea/gitea/pull/29961/files#diff-08adda3f8ae0360937f46abb1f4418603bd3518522baa356be11c6c7ac4abcc3.

And also rename `CancelRunningJobs` to `CancelPreviousJobs` to make it more clear.