### PR TITLE
Fix the bug that user may logout if he switch pages too fast

### DIFF
--- a/services/auth/session.go
+++ b/services/auth/session.go
@@ -49,6 +49,7 @@ func (s *Session) Verify(req *http.Request, w http.ResponseWriter, store DataSto
 	if err != nil {
 		if !user_model.IsErrUserNotExist(err) {
 			log.Error("GetUserByID: %v", err)
+			// Return the err as-is to keep current signed-in session, in case the err is something like context.Canceled. Otherwise non-existing user (nil, nil) will make the caller clear the signed-in session.
 			return nil, err
 		}
 		return nil, nil


### PR DESCRIPTION
This PR fixed a bug when the user switching pages too fast, he will logout automatically.

The reason is that when the error is context cancelled, the previous code think user hasn't login then the session will be deleted. Now it will return the errors but not think it's not login.