### PR TITLE
Fix JS error and improve error message styles

### DIFF
--- a/web_src/js/bootstrap.js
+++ b/web_src/js/bootstrap.js
@@ -23,7 +23,7 @@ export function showGlobalErrorMessage(msg) {
   let msgDiv = pageContent.querySelector(`.js-global-error[data-global-error-msg-compact="${msgCompact}"]`);
   if (!msgDiv) {
     const el = document.createElement('div');
-    el.innerHTML = `<div class="ui container negative message center aligned js-global-error" style="white-space: pre-line;"></div>`;
+    el.innerHTML = `<div class="ui container negative message center aligned js-global-error tw-mt-[15px] tw-whitespace-pre-line"></div>`;
     msgDiv = el.childNodes[0];
   }
   // merge duplicated messages into "the message (count)" format

--- a/web_src/js/features/repo-common.js
+++ b/web_src/js/features/repo-common.js
@@ -76,6 +76,8 @@ export function initRepoCommonBranchOrTagDropdown(selector) {
 
 export function initRepoCommonFilterSearchDropdown(selector) {
   const $dropdown = $(selector);
+  if (!$dropdown.length) return;
+
   $dropdown.dropdown({
     fullTextSearch: 'exact',
     selectOnKeydown: false,


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/29956. This error exposed a existing bug in the code, it was just never noticed because the jQuery expression evaluated without error before while the new one doesn't.

Also improves error message styles:

Before:
<img width="1338" alt="Screenshot 2024-03-21 at 09 16 07" src="https://github.com/go-gitea/gitea/assets/115237/1cc1ef89-ad94-491e-bbca-75387f7547a0">

After:
<img width="1335" alt="Screenshot 2024-03-21 at 09 15 44" src="https://github.com/go-gitea/gitea/assets/115237/312efc79-5353-4e2a-a703-1bccd3c01736">
