### PR TITLE
remove PATH and GOPATH modification in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ DOCKER_TAG ?= latest
 DOCKER_REF := $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 ifeq ($(HAS_GO), yes)
-	GOPATH ?= $(shell $(GO) env GOPATH)
-	export PATH := $(GOPATH)/bin:$(PATH)
-
 	CGO_EXTRA_CFLAGS := -DSQLITE_MAX_VARIABLE_NUMBER=32766
 	CGO_CFLAGS ?= $(shell $(GO) env CGO_CFLAGS) $(CGO_EXTRA_CFLAGS)
 endif


### PR DESCRIPTION
I think we don't need these modifications anymore since all tool dependencies run via `go run`.