### PR TITLE
Fix: Abnormal strings appear when comments are saved after editing

### DIFF
--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -436,7 +436,7 @@ async function onEditContent(event) {
       const $content = $segment;
       if (!$content.find('.dropzone-attachments').length) {
         if (data.attachments !== '') {
-          $content[0].append(data.attachments);
+          $content[0].insertAdjacentHTML('beforeend', data.attachments);
         }
       } else if (data.attachments === '') {
         $content.find('.dropzone-attachments').remove();


### PR DESCRIPTION
Partially resolved（The second problem）：   [#29986](https://github.com/go-gitea/gitea/issues/29986)

**Before**
HTML strings appear when comments are saved after editing

![image](https://github.com/go-gitea/gitea/assets/37935145/c356d99a-8473-4cc5-8e38-1b207ccd8b12)


**After**


https://github.com/go-gitea/gitea/assets/37935145/525601f9-3ee1-4266-9105-36d82b91b1c8

