### PR TITLE
Fix manual merge form and 404 page templates

### DIFF
--- a/templates/repo/issue/view_content/pull.tmpl
+++ b/templates/repo/issue/view_content/pull.tmpl
@@ -360,7 +360,7 @@
 			{{if and $.StillCanManualMerge (not $showGeneralMergeForm)}}
 				<div class="divider"></div>
 				<div class="ui form">
-					<form action="{{.Link}}/merge" method="post">
+					<form class="form-fetch-action" action="{{.Link}}/merge" method="post">
 						{{.CsrfTokenHtml}}
 						<div class="field">
 							<input type="text" name="merge_commit_id" placeholder="{{ctx.Locale.Tr "repo.pulls.merge_commit_id"}}">

--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -1,14 +1,10 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content ui container center gt-w-screen {{if .IsRepo}}repository{{end}}">
+<div role="main" aria-label="{{.Title}}" class="page-content {{if .IsRepo}}repository{{end}}">
 	{{if .IsRepo}}{{template "repo/header" .}}{{end}}
 	<div class="ui container center">
-		<p style="margin-top: 100px"><img src="{{AssetUrlPrefix}}/img/404.png" alt="404"></p>
+		<img style="margin: 50px 0; max-width: 80vw" src="{{AssetUrlPrefix}}/img/404.png" alt="404">
 		<p>{{if .NotFoundPrompt}}{{.NotFoundPrompt}}{{else}}{{ctx.Locale.Tr "error404" | Safe}}{{end}}</p>
 		{{if .NotFoundGoBackURL}}<a class="ui button green" href="{{.NotFoundGoBackURL}}">{{ctx.Locale.Tr "go_back"}}</a>{{end}}
-
-		<div class="divider"></div>
-		<br>
-		{{if .ShowFooterVersion}}<p>{{ctx.Locale.Tr "admin.config.app_ver"}}: {{AppVer}}</p>{{end}}
 	</div>
 </div>
 {{template "base/footer" .}}


### PR DESCRIPTION
Partially backport #29985, fix some template errors.

The manual-merge form:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/8fcee9c6-cd5c-4cc9-999c-3499510934a8)

</details>

The 404 page:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/7a32afad-df07-48c0-bb3d-35d6b74aa3bd)

</details>