### PR TITLE
Remove jQuery from the citation modal (except fomantic)

### DIFF
--- a/web_src/js/features/citation.js
+++ b/web_src/js/features/citation.js
@@ -36,7 +36,7 @@ export async function initCitationFileCopyContent() {
   const updateUi = () => {
     const isBibtex = (localStorage.getItem('citation-copy-format') || defaultCitationFormat) === 'bibtex';
     const copyContent = (isBibtex ? citationCopyBibtex : citationCopyApa).getAttribute('data-text');
-    inputContent.setAttribute('value', copyContent);
+    inputContent.value = copyContent;
     citationCopyBibtex.classList.toggle('primary', isBibtex);
     citationCopyApa.classList.toggle('primary', !isBibtex);
   };

--- a/web_src/js/features/citation.js
+++ b/web_src/js/features/citation.js
@@ -1,8 +1,9 @@
 import $ from 'jquery';
+import {getCurrentLocale} from '../utils.js';
 
 const {pageData} = window.config;
 
-async function initInputCitationValue($citationCopyApa, $citationCopyBibtex) {
+async function initInputCitationValue(citationCopyApa, citationCopyBibtex) {
   const [{Cite, plugins}] = await Promise.all([
     import(/* webpackChunkName: "citation-js-core" */'@citation-js/core'),
     import(/* webpackChunkName: "citation-js-formats" */'@citation-js/plugin-software-formats'),
@@ -14,11 +15,11 @@ async function initInputCitationValue($citationCopyApa, $citationCopyBibtex) {
   config.constants.fieldTypes.doi = ['field', 'literal'];
   config.constants.fieldTypes.version = ['field', 'literal'];
   const citationFormatter = new Cite(citationFileContent);
-  const lang = document.documentElement.lang || 'en-US';
+  const lang = getCurrentLocale() || 'en-US';
   const apaOutput = citationFormatter.format('bibliography', {template: 'apa', lang});
   const bibtexOutput = citationFormatter.format('bibtex', {lang});
-  $citationCopyBibtex.attr('data-text', bibtexOutput);
-  $citationCopyApa.attr('data-text', apaOutput);
+  citationCopyBibtex.setAttribute('data-text', bibtexOutput);
+  citationCopyApa.setAttribute('data-text', apaOutput);
 }
 
 export async function initCitationFileCopyContent() {
@@ -26,44 +27,45 @@ export async function initCitationFileCopyContent() {
 
   if (!pageData.citationFileContent) return;
 
-  const $citationCopyApa = $('#citation-copy-apa');
-  const $citationCopyBibtex = $('#citation-copy-bibtex');
-  const $inputContent = $('#citation-copy-content');
+  const citationCopyApa = document.getElementById('citation-copy-apa');
+  const citationCopyBibtex = document.getElementById('citation-copy-bibtex');
+  const inputContent = document.getElementById('citation-copy-content');
 
-  if ((!$citationCopyApa.length && !$citationCopyBibtex.length) || !$inputContent.length) return;
+  if ((!citationCopyApa && !citationCopyBibtex) || !inputContent) return;
+
   const updateUi = () => {
     const isBibtex = (localStorage.getItem('citation-copy-format') || defaultCitationFormat) === 'bibtex';
-    const copyContent = (isBibtex ? $citationCopyBibtex : $citationCopyApa).attr('data-text');
-
-    $inputContent.val(copyContent);
-    $citationCopyBibtex.toggleClass('primary', isBibtex);
-    $citationCopyApa.toggleClass('primary', !isBibtex);
+    const copyContent = (isBibtex ? citationCopyBibtex : citationCopyApa).getAttribute('data-text');
+    inputContent.setAttribute('value', copyContent);
+    citationCopyBibtex.classList.toggle('primary', isBibtex);
+    citationCopyApa.classList.toggle('primary', !isBibtex);
   };
 
-  $('#cite-repo-button').on('click', async (e) => {
+  document.getElementById('cite-repo-button')?.addEventListener('click', async (e) => {
     const dropdownBtn = e.target.closest('.ui.dropdown.button');
     dropdownBtn.classList.add('is-loading');
 
     try {
       try {
-        await initInputCitationValue($citationCopyApa, $citationCopyBibtex);
+        await initInputCitationValue(citationCopyApa, citationCopyBibtex);
       } catch (e) {
         console.error(`initCitationFileCopyContent error: ${e}`, e);
         return;
       }
       updateUi();
 
-      $citationCopyApa.on('click', () => {
+      citationCopyApa.addEventListener('click', () => {
         localStorage.setItem('citation-copy-format', 'apa');
         updateUi();
       });
-      $citationCopyBibtex.on('click', () => {
+
+      citationCopyBibtex.addEventListener('click', () => {
         localStorage.setItem('citation-copy-format', 'bibtex');
         updateUi();
       });
 
-      $inputContent.on('click', () => {
-        $inputContent.trigger('select');
+      inputContent.addEventListener('click', () => {
+        inputContent.select();
       });
     } finally {
       dropdownBtn.classList.remove('is-loading');


### PR DESCRIPTION
- Switched to plain JavaScript
- Tested the citation modal functionality and it works as before

# Demo using JavaScript without jQuery
![demo](https://github.com/go-gitea/gitea/assets/20454870/65bba1eb-dd4c-477f-8a2d-08e65f1e9f42)

