### PR TITLE
Respect DEFAULT_ORG_MEMBER_VISIBLE setting when adding creator to org

### DIFF
--- a/models/organization/org.go
+++ b/models/organization/org.go
@@ -319,8 +319,9 @@ func CreateOrganization(ctx context.Context, org *Organization, owner *user_mode
 
 	// Add initial creator to organization and owner team.
 	if err = db.Insert(ctx, &OrgUser{
-		UID:   owner.ID,
-		OrgID: org.ID,
+		UID:      owner.ID,
+		OrgID:    org.ID,
+		IsPublic: setting.Service.DefaultOrgMemberVisible,
 	}); err != nil {
 		return fmt.Errorf("insert org-user relation: %w", err)
 	}


### PR DESCRIPTION
This PR adds `setting.Service.DefaultOrgMemberVisible` value to dataset of user when the initial org creator is being added to the created org.

Fixes #30012.