### PR TITLE
Remove duplicate option in admin screen and now-unused translation keys (#28492)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3078,7 +3078,6 @@ config.enable_openid_signin = Enable OpenID Sign-In
 config.show_registration_button = Show Register Button
 config.require_sign_in_view = Require Sign-In to View Pages
 config.mail_notify = Enable Email Notifications
-config.disable_key_size_check = Disable Minimum Key Size Check
 config.enable_captcha = Enable CAPTCHA
 config.active_code_lives = Active Code Lives
 config.reset_password_code_lives = Recover Account Code Expiry Time

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -151,8 +151,6 @@
 				<dd>{{if .Service.RequireSignInView}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.mail_notify"}}</dt>
 				<dd>{{if .Service.EnableNotifyMail}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
-				<dt>{{ctx.Locale.Tr "admin.config.disable_key_size_check"}}</dt>
-				<dd>{{if .SSH.MinimumKeySizeCheck}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.enable_captcha"}}</dt>
 				<dd>{{if .Service.EnableCaptcha}}{{svg "octicon-check"}}{{else}}{{svg "octicon-x"}}{{end}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.default_keep_email_private"}}</dt>


### PR DESCRIPTION
Backport #28492
Fix #30019