### PR TITLE
Fix path escaping in 'Find files'

### DIFF
--- a/templates/repo/find/files.tmpl
+++ b/templates/repo/find/files.tmpl
@@ -6,7 +6,7 @@
 			<a href="{{$.RepoLink}}">{{.RepoName}}</a>
 			<span class="gt-mx-3">/</span>
 			<div class="ui input tw-flex-1">
-				<input id="repo-file-find-input" type="text" autofocus data-url-data-link="{{.DataLink}}" data-url-tree-link="{{.TreeLink}}">
+				<input id="repo-file-find-input" type="text" autofocus data-url-data-link="{{PathEscapeSegments .DataLink}}" data-url-tree-link="{{PathEscapeSegments .TreeLink}}">
 			</div>
 		</div>
 		<table id="repo-find-file-table" class="ui single line table">


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/30020

Before:
<img width="1325" alt="Screenshot 2024-03-23 at 13 10 07" src="https://github.com/go-gitea/gitea/assets/115237/e682e644-ebac-4dd2-b669-fa1a9efb9113">

After:
<img width="1327" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/120e7181-8a1e-4e08-b213-cd6fe217551b">
