### PR TITLE
Fix menu buttons in issues and release

### DIFF
--- a/templates/repo/issue/navbar.tmpl
+++ b/templates/repo/issue/navbar.tmpl
@@ -1,4 +1,4 @@
-<h2 class="ui compact small menu header small-menu-items issue-list-navbar">
+<h2 class="ui compact small menu small-menu-items issue-list-navbar">
 	<a class="{{if .PageIsLabels}}active {{end}}item" href="{{.RepoLink}}/labels">{{ctx.Locale.Tr "repo.labels"}}</a>
 	<a class="{{if .PageIsMilestones}}active {{end}}item" href="{{.RepoLink}}/milestones">{{ctx.Locale.Tr "repo.milestones"}}</a>
 </h2>

--- a/templates/repo/release_tag_header.tmpl
+++ b/templates/repo/release_tag_header.tmpl
@@ -4,7 +4,7 @@
 {{if $canReadReleases}}
 	<div class="tw-flex">
 		<div class="tw-flex-1 tw-flex tw-items-center">
-			<h2 class="ui compact small menu header small-menu-items">
+			<h2 class="ui compact small menu small-menu-items">
 				<a class="{{if and .PageIsReleaseList (not .PageIsSingleTag)}}active {{end}}item" href="{{.RepoLink}}/releases">{{ctx.Locale.PrettyNumber .NumReleases}} {{ctx.Locale.TrN .NumReleases "repo.release" "repo.releases"}}</a>
 				{{if $canReadCode}}
 					<a class="{{if or .PageIsTagList .PageIsSingleTag}}active {{end}}item" href="{{.RepoLink}}/tags">{{ctx.Locale.PrettyNumber .NumTags}} {{ctx.Locale.TrN .NumTags "repo.tag" "repo.tags"}}</a>


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/pull/30033

These buttons had lost their border because `.ui.header` sets `none` but `.ui.menu` has it, after the migration, the order of styles changed and header won. I see no reason why those have the `header` class in first place, besides for semantic meaning.

Before:
<img width="491" alt="Screenshot 2024-03-25 at 00 39 27" src="https://github.com/go-gitea/gitea/assets/115237/fa1b7505-75cf-4854-a97f-db3c46f31e93">

After:
<img width="496" alt="Screenshot 2024-03-25 at 00 39 14" src="https://github.com/go-gitea/gitea/assets/115237/8f6bdc07-9596-436b-8c82-9af283300004">
