### PR TITLE
Support OIDC RP-initiated logout

### DIFF
--- a/models/auth/auth_token.go
+++ b/models/auth/auth_token.go
@@ -34,6 +34,14 @@ func InsertAuthToken(ctx context.Context, t *AuthToken) error {
 	return err
 }
 
+func ExistAuthToken(ctx context.Context, id string) bool {
+	exist, err := db.Exist[AuthToken](ctx, builder.Eq{"`id`": id})
+	if err != nil {
+		return false
+	}
+	return exist
+}
+
 func GetAuthTokenByID(ctx context.Context, id string) (*AuthToken, error) {
 	at := &AuthToken{}
 

--- a/models/auth/auth_token.go
+++ b/models/auth/auth_token.go
@@ -16,10 +16,13 @@ import (
 var ErrAuthTokenNotExist = util.NewNotExistErrorf("auth token does not exist")
 
 type AuthToken struct { //nolint:revive
-	ID          string `xorm:"pk"`
-	TokenHash   string
-	UserID      int64              `xorm:"INDEX"`
-	ExpiresUnix timeutil.TimeStamp `xorm:"INDEX"`
+	ID            string `xorm:"pk"`
+	TokenHash     string
+	UserID        int64 `xorm:"INDEX"`
+	ExternalID    string
+	LoginSourceID int64
+	LoginType     Type
+	ExpiresUnix   timeutil.TimeStamp `xorm:"INDEX"`
 }
 
 func init() {

--- a/models/auth/external_auth_token.go
+++ b/models/auth/external_auth_token.go
@@ -1,0 +1,138 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/util"
+
+	"xorm.io/builder"
+)
+
+type ErrExternalAuthTokenNotExist struct {
+	SessionID   string
+	AuthTokenID string
+}
+
+func IsErrExternalAuthTokenNotExist(err error) bool {
+	_, ok := err.(ErrExternalAuthTokenNotExist)
+	return ok
+}
+
+func (err ErrExternalAuthTokenNotExist) Error() string {
+	return fmt.Sprintf("external auth token does not exist [sessionID: %s, authTokenID: %s]", err.SessionID, err.AuthTokenID)
+}
+
+func (err ErrExternalAuthTokenNotExist) Unwrap() error {
+	return util.ErrNotExist
+}
+
+type ExternalAuthToken struct {
+	SessionID         string         `xorm:"pk"`
+	AuthTokenID       string         `xorm:"INDEX"`
+	UserID            int64          `xorm:"INDEX NOT NULL"`
+	ExternalID        string         `xorm:"NOT NULL"`
+	LoginSourceID     int64          `xorm:"INDEX NOT NULL"`
+	RawData           map[string]any `xorm:"TEXT JSON"`
+	AccessToken       string         `xorm:"TEXT"`
+	AccessTokenSecret string         `xorm:"TEXT"`
+	RefreshToken      string         `xorm:"TEXT"`
+	ExpiresAt         time.Time
+	IDToken           string `xorm:"TEXT"`
+}
+
+func init() {
+	db.RegisterModel(new(ExternalAuthToken))
+}
+
+func InsertExternalAuthToken(ctx context.Context, t *ExternalAuthToken) error {
+	_, err := db.GetEngine(ctx).Insert(t)
+	return err
+}
+
+func GetExternalAuthTokenBySessionID(ctx context.Context, sessionID string) (*ExternalAuthToken, error) {
+	t := &ExternalAuthToken{}
+	has, err := db.GetEngine(ctx).ID(sessionID).Get(t)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, ErrExternalAuthTokenNotExist{SessionID: sessionID}
+	}
+	return t, nil
+}
+
+func GetExternalAuthTokenByAuthTokenID(ctx context.Context, authTokenID string) (*ExternalAuthToken, error) {
+	t := &ExternalAuthToken{}
+	has, err := db.GetEngine(ctx).Where(builder.Eq{"auth_token_id": authTokenID}).Get(t)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, ErrExternalAuthTokenNotExist{AuthTokenID: authTokenID}
+	}
+	return t, nil
+}
+
+func GetExternalAuthTokenSessionIDsAndAuthTokenIDs(ctx context.Context, userID, loginSourceID int64) ([]*ExternalAuthToken, error) {
+	tlist := []*ExternalAuthToken{}
+	cond := builder.NewCond().And(builder.Eq{"user_id": userID})
+	if loginSourceID > 0 {
+		cond = cond.And(builder.Eq{"login_source_id": loginSourceID})
+	}
+	if err := db.GetEngine(ctx).Cols("session_id", "auth_token_id").Where(cond).Find(&tlist); err != nil {
+		return nil, err
+	}
+	return tlist, nil
+}
+
+func UpdateExternalAuthTokenBySessionID(ctx context.Context, sessionID string, t *ExternalAuthToken) error {
+	_, err := db.GetEngine(ctx).ID(sessionID).AllCols().Update(t)
+	return err
+}
+
+func DeleteExternalAuthTokenBySessionID(ctx context.Context, sessionID string) error {
+	_, err := db.GetEngine(ctx).ID(sessionID).Delete(&ExternalAuthToken{})
+	return err
+}
+
+func DeleteExternalAuthTokensByUserLoginSourceID(ctx context.Context, userID, loginSourceID int64) error {
+	_, err := db.GetEngine(ctx).Where(builder.Eq{"user_id": userID, "login_source_id": loginSourceID}).Delete(&ExternalAuthToken{})
+	return err
+}
+
+func DeleteExternalAuthTokensByUserID(ctx context.Context, userID int64) error {
+	_, err := db.GetEngine(ctx).Where(builder.Eq{"user_id": userID}).Delete(&ExternalAuthToken{})
+	return err
+}
+
+type FindExternalAuthTokenOptions struct {
+	db.ListOptions
+	UserID        int64
+	ExternalID    string
+	LoginSourceID int64
+	OrderBy       string
+}
+
+func (opts FindExternalAuthTokenOptions) ToConds() builder.Cond {
+	cond := builder.NewCond()
+	if opts.UserID > 0 {
+		cond = cond.And(builder.Eq{"user_id": opts.UserID})
+	}
+	if len(opts.ExternalID) > 0 {
+		cond = cond.And(builder.Eq{"external_id": opts.ExternalID})
+	}
+	if opts.LoginSourceID > 0 {
+		cond = cond.And(builder.Eq{"login_source_id": opts.LoginSourceID})
+	}
+	return cond
+}
+
+func (opts FindExternalAuthTokenOptions) ToOrders() string {
+	return opts.OrderBy
+}

--- a/models/auth/source.go
+++ b/models/auth/source.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"context"
+	"encoding/gob"
 	"fmt"
 	"reflect"
 
@@ -129,6 +130,7 @@ func (Source) TableName() string {
 
 func init() {
 	db.RegisterModel(new(Source))
+	gob.Register(Type(0))
 }
 
 // BeforeSet is invoked from XORM before setting the value of a field of this object.

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -568,6 +568,8 @@ var migrations = []Migration{
 	NewMigration("Add PayloadVersion to HookTask", v1_22.AddPayloadVersionToHookTaskTable),
 	// v291 -> v292
 	NewMigration("Add Index to attachment.comment_id", v1_22.AddCommentIDIndexofAttachment),
+	// v292 -> v293
+	NewMigration("Drop raw_data, access_token, access_token_secret, refresh_token and expires_at columns from external_login_user table", v1_22.DropColumnsFromExternalLoginUserTable),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v1_22/v292.go
+++ b/models/migrations/v1_22/v292.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_22 //nolint
+
+import (
+	"time"
+
+	"code.gitea.io/gitea/models/migrations/base"
+
+	"xorm.io/xorm"
+)
+
+func DropColumnsFromExternalLoginUserTable(x *xorm.Engine) error {
+	type ExternalLoginUser struct {
+		RawData           map[string]any `xorm:"TEXT JSON"`
+		AccessToken       string         `xorm:"TEXT"`
+		AccessTokenSecret string         `xorm:"TEXT"`
+		RefreshToken      string         `xorm:"TEXT"`
+		ExpiresAt         time.Time
+	}
+	if err := x.Sync(new(ExternalLoginUser)); err != nil {
+		return err
+	}
+
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	if err := base.DropTableColumns(sess, "external_login_user", "raw_data", "access_token", "access_token_secret", "refresh_token", "expires_at"); err != nil {
+		return err
+	}
+
+	return sess.Commit()
+}

--- a/models/user/external_login_user.go
+++ b/models/user/external_login_user.go
@@ -6,7 +6,6 @@ package user
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/modules/util"
@@ -57,23 +56,18 @@ func (err ErrExternalLoginUserNotExist) Unwrap() error {
 
 // ExternalLoginUser makes the connecting between some existing user and additional external login sources
 type ExternalLoginUser struct {
-	ExternalID        string         `xorm:"pk NOT NULL"`
-	UserID            int64          `xorm:"INDEX NOT NULL"`
-	LoginSourceID     int64          `xorm:"pk NOT NULL"`
-	RawData           map[string]any `xorm:"TEXT JSON"`
-	Provider          string         `xorm:"index VARCHAR(25)"`
-	Email             string
-	Name              string
-	FirstName         string
-	LastName          string
-	NickName          string
-	Description       string
-	AvatarURL         string `xorm:"TEXT"`
-	Location          string
-	AccessToken       string `xorm:"TEXT"`
-	AccessTokenSecret string `xorm:"TEXT"`
-	RefreshToken      string `xorm:"TEXT"`
-	ExpiresAt         time.Time
+	ExternalID    string `xorm:"pk NOT NULL"`
+	UserID        int64  `xorm:"INDEX NOT NULL"`
+	LoginSourceID int64  `xorm:"pk NOT NULL"`
+	Provider      string `xorm:"index VARCHAR(25)"`
+	Email         string
+	Name          string
+	FirstName     string
+	LastName      string
+	NickName      string
+	Description   string
+	AvatarURL     string `xorm:"TEXT"`
+	Location      string
 }
 
 type ExternalUserMigrated interface {

--- a/modules/session/provider.go
+++ b/modules/session/provider.go
@@ -1,0 +1,16 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package session
+
+import (
+	"code.gitea.io/gitea/modules/setting"
+)
+
+func GetSessionProvider() (*VirtualSessionProvider, error) {
+	sessionProvider := &VirtualSessionProvider{}
+	if err := sessionProvider.Init(setting.SessionConfig.Gclifetime, setting.SessionConfig.ProviderConfig); err != nil {
+		return nil, err
+	}
+	return sessionProvider, nil
+}

--- a/modules/session/virtual.go
+++ b/modules/session/virtual.go
@@ -69,7 +69,9 @@ func (o *VirtualSessionProvider) Read(sid string) (session.RawStore, error) {
 
 // Exist returns true if session with given ID exists.
 func (o *VirtualSessionProvider) Exist(sid string) bool {
-	return true
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.provider.Exist(sid)
 }
 
 // Destroy deletes a session by session ID.

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -555,7 +555,7 @@ func SubmitInstall(ctx *context.Context) {
 			u, _ = user_model.GetUserByName(ctx, u.Name)
 		}
 
-		nt, token, err := auth_service.CreateAuthTokenForUserID(ctx, u.ID)
+		nt, token, err := auth_service.CreateAuthTokenForUserID(ctx, u.ID, 0, 0)
 		if err != nil {
 			ctx.ServerError("CreateAuthTokenForUserID", err)
 			return

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -431,12 +431,19 @@ func HandleSignOut(ctx *context.Context) {
 func SignOut(ctx *context.Context) {
 	loginType, _ := ctx.Session.Get("login_type").(auth.Type)
 
+	if loginType == auth.OAuth2 {
+		// Handle sign out in SignOutOAuth
+		redirectToSignOutOAuth(ctx)
+		return
+	}
+
 	if ctx.Doer != nil {
 		eventsource.GetManager().SendMessageBlocking(ctx.Doer.ID, &eventsource.Event{
 			Name: "logout",
 			Data: ctx.Session.ID(),
 		})
 	}
+
 	HandleSignOut(ctx)
 	ctx.JSONRedirect(setting.AppSubURL + "/")
 }

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -314,6 +314,8 @@ func handleSignIn(ctx *context.Context, u *user_model.User, remember bool) {
 }
 
 func handleSignInFull(ctx *context.Context, u *user_model.User, remember, obeyRedirect bool) string {
+	loginType, _ := ctx.Session.Get("login_type").(auth.Type)
+
 	if remember {
 		nt, token, err := auth_service.CreateAuthTokenForUserID(ctx, u.ID)
 		if err != nil {
@@ -404,6 +406,8 @@ func HandleSignOut(ctx *context.Context) {
 
 // SignOut sign out from login status
 func SignOut(ctx *context.Context) {
+	loginType, _ := ctx.Session.Get("login_type").(auth.Type)
+
 	if ctx.Doer != nil {
 		eventsource.GetManager().SendMessageBlocking(ctx.Doer.ID, &eventsource.Event{
 			Name: "logout",

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -88,8 +88,10 @@ func autoSignIn(ctx *context.Context) (bool, error) {
 
 	if err := updateSession(ctx, nil, map[string]any{
 		// Set session IDs
-		"uid":   u.ID,
-		"uname": u.Name,
+		"uid":             u.ID,
+		"uname":           u.Name,
+		"login_source_id": nt.LoginSourceID,
+		"login_type":      nt.LoginType,
 	}); err != nil {
 		return false, fmt.Errorf("unable to updateSession: %w", err)
 	}
@@ -317,7 +319,9 @@ func handleSignInFull(ctx *context.Context, u *user_model.User, remember, obeyRe
 	loginType, _ := ctx.Session.Get("login_type").(auth.Type)
 
 	if remember {
-		nt, token, err := auth_service.CreateAuthTokenForUserID(ctx, u.ID)
+		loginSourceID, _ := ctx.Session.Get("login_source_id").(int64)
+
+		nt, token, err := auth_service.CreateAuthTokenForUserID(ctx, u.ID, loginSourceID, loginType)
 		if err != nil {
 			ctx.ServerError("CreateAuthTokenForUserID", err)
 			return setting.AppSubURL + "/"

--- a/routers/web/auth/linkaccount.go
+++ b/routers/web/auth/linkaccount.go
@@ -187,6 +187,11 @@ func linkAccount(ctx *context.Context, u *user_model.User, gothUser goth.User, r
 			log.Error("UserLinkAccount: %v", err)
 		}
 
+		if err := auth_service.SetExternalAuthToken(ctx, ctx.Session.ID(), u, &gothUser); err != nil {
+			ctx.ServerError("SetExternalAuthToken", err)
+			return
+		}
+
 		handleSignIn(ctx, u, remember)
 		return
 	}

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1152,6 +1152,14 @@ func handleOAuth2SignIn(ctx *context.Context, source *auth.Source, u *user_model
 			}
 		}
 
+		if err := auth_service.CleanExternalAuthTokensByUser(ctx, u.ID); err != nil {
+			log.Error("CleanUserExternalAuthTokens failed: %v", err)
+		}
+
+		if err := auth_service.SetExternalAuthToken(ctx, ctx.Session.ID(), u, &gothUser); err != nil {
+			log.Error("SetExternalAuthToken failed: %v", err)
+		}
+
 		if err := resetLocale(ctx, u); err != nil {
 			ctx.ServerError("resetLocale", err)
 			return

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1117,8 +1117,10 @@ func handleOAuth2SignIn(ctx *context.Context, source *auth.Source, u *user_model
 	// we can't sign the user in just yet. Instead, redirect them to the 2FA authentication page.
 	if !needs2FA {
 		if err := updateSession(ctx, nil, map[string]any{
-			"uid":   u.ID,
-			"uname": u.Name,
+			"uid":             u.ID,
+			"uname":           u.Name,
+			"login_source_id": source.ID,
+			"login_type":      source.Type,
 		}); err != nil {
 			ctx.ServerError("updateSession", err)
 			return

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1024,6 +1024,13 @@ func SignInOAuthCallback(ctx *context.Context) {
 	handleOAuth2SignIn(ctx, authSource, u, gothUser)
 }
 
+// SignOutOAuthError shows any sign out errors occurring before SignOutOAuth
+func SignOutOAuthError(ctx *context.Context) {
+	HandleSignOut(ctx)
+	ctx.Flash.Error(ctx.Tr("Failed to handle OAuth2 or OpenID Connect sign out"), true)
+	ctx.ServerError("SignOutOAuthError", fmt.Errorf("error generating the internal OAuth2 logout URL"))
+}
+
 // SignOutOAuth handles OAuth2 and OIDC RP-initiated logout requests
 func SignOutOAuth(ctx *context.Context) {
 	provider := ctx.Params(":provider")

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -1024,6 +1024,25 @@ func SignInOAuthCallback(ctx *context.Context) {
 	handleOAuth2SignIn(ctx, authSource, u, gothUser)
 }
 
+func redirectToSignOutOAuth(ctx *context.Context) {
+	errURL := "/user/oauth2/-/logout/error"
+
+	loginSourceID, ok := ctx.Session.Get("login_source_id").(int64)
+	if !ok {
+		log.Error("redirectToSignOutOAuth: Failed to get login_source_id from session data")
+		ctx.JSONRedirect(errURL)
+		return
+	}
+	source, err := auth.GetSourceByID(ctx, loginSourceID)
+	if err != nil {
+		log.Error("redirectToSignOutOAuth: %w", err)
+		ctx.JSONRedirect(errURL)
+		return
+	}
+
+	ctx.JSONRedirect("/user/oauth2/" + source.Name + "/logout")
+}
+
 // SignOutOAuthError shows any sign out errors occurring before SignOutOAuth
 func SignOutOAuthError(ctx *context.Context) {
 	HandleSignOut(ctx)

--- a/routers/web/user/setting/security/security.go
+++ b/routers/web/user/setting/security/security.go
@@ -44,7 +44,9 @@ func DeleteAccountLink(ctx *context.Context) {
 	if id <= 0 {
 		ctx.Flash.Error("Account link id is not given")
 	} else {
-		if _, err := user_model.RemoveAccountLink(ctx, ctx.Doer, id); err != nil {
+		if err := auth_model.DeleteExternalAuthTokensByUserLoginSourceID(ctx, ctx.Doer.ID, id); err != nil {
+			ctx.Flash.Error("DeleteExternalAuthTokens: " + err.Error())
+		} else if _, err := user_model.RemoveAccountLink(ctx, ctx.Doer, id); err != nil {
 			ctx.Flash.Error("RemoveAccountLink: " + err.Error())
 		} else {
 			ctx.Flash.Success(ctx.Tr("settings.remove_account_link_success"))

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -670,6 +670,7 @@ func registerRoutes(m *web.Route) {
 		m.Group("/oauth2", func() {
 			m.Get("/{provider}", auth.SignInOAuth)
 			m.Get("/{provider}/callback", auth.SignInOAuthCallback)
+			m.Get("/{provider}/logout", auth.SignOutOAuth)
 		})
 	})
 	// ***** END: User *****

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -672,6 +672,7 @@ func registerRoutes(m *web.Route) {
 			m.Get("/{provider}/callback", auth.SignInOAuthCallback)
 			m.Get("/{provider}/logout", auth.SignOutOAuth)
 			m.Get("/{provider}/logout/callback", auth.SignOutOAuthCallback)
+			m.Get("/{provider}/logout/error", auth.SignOutOAuthError)
 		})
 	})
 	// ***** END: User *****

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -671,6 +671,7 @@ func registerRoutes(m *web.Route) {
 			m.Get("/{provider}", auth.SignInOAuth)
 			m.Get("/{provider}/callback", auth.SignInOAuthCallback)
 			m.Get("/{provider}/logout", auth.SignOutOAuth)
+			m.Get("/{provider}/logout/callback", auth.SignOutOAuthCallback)
 		})
 	})
 	// ***** END: User *****

--- a/services/auth/auth_token.go
+++ b/services/auth/auth_token.go
@@ -70,10 +70,12 @@ func RegenerateAuthToken(ctx context.Context, t *auth_model.AuthToken) (*auth_mo
 	}
 
 	newToken := &auth_model.AuthToken{
-		ID:          t.ID,
-		TokenHash:   hash,
-		UserID:      t.UserID,
-		ExpiresUnix: timeutil.TimeStampNow().AddDuration(time.Duration(setting.LogInRememberDays*24) * time.Hour),
+		ID:            t.ID,
+		TokenHash:     hash,
+		UserID:        t.UserID,
+		LoginSourceID: t.LoginSourceID,
+		LoginType:     t.LoginType,
+		ExpiresUnix:   timeutil.TimeStampNow().AddDuration(time.Duration(setting.LogInRememberDays*24) * time.Hour),
 	}
 
 	if err := auth_model.UpdateAuthTokenByID(ctx, newToken); err != nil {
@@ -83,10 +85,12 @@ func RegenerateAuthToken(ctx context.Context, t *auth_model.AuthToken) (*auth_mo
 	return newToken, token, nil
 }
 
-func CreateAuthTokenForUserID(ctx context.Context, userID int64) (*auth_model.AuthToken, string, error) {
+func CreateAuthTokenForUserID(ctx context.Context, userID, loginSourceID int64, loginType auth_model.Type) (*auth_model.AuthToken, string, error) {
 	t := &auth_model.AuthToken{
-		UserID:      userID,
-		ExpiresUnix: timeutil.TimeStampNow().AddDuration(time.Duration(setting.LogInRememberDays*24) * time.Hour),
+		UserID:        userID,
+		LoginSourceID: loginSourceID,
+		LoginType:     loginType,
+		ExpiresUnix:   timeutil.TimeStampNow().AddDuration(time.Duration(setting.LogInRememberDays*24) * time.Hour),
 	}
 
 	var err error

--- a/services/auth/auth_token_test.go
+++ b/services/auth/auth_token_test.go
@@ -39,7 +39,7 @@ func TestCheckAuthToken(t *testing.T) {
 	t.Run("Expired", func(t *testing.T) {
 		timeutil.MockSet(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 
-		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
+		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2, 0, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, at)
 		assert.NotEmpty(t, token)
@@ -54,7 +54,7 @@ func TestCheckAuthToken(t *testing.T) {
 	})
 
 	t.Run("InvalidHash", func(t *testing.T) {
-		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
+		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2, 0, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, at)
 		assert.NotEmpty(t, token)
@@ -67,7 +67,7 @@ func TestCheckAuthToken(t *testing.T) {
 	})
 
 	t.Run("Valid", func(t *testing.T) {
-		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
+		at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2, 0, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, at)
 		assert.NotEmpty(t, token)
@@ -86,7 +86,7 @@ func TestRegenerateAuthToken(t *testing.T) {
 	timeutil.MockSet(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 	defer timeutil.MockUnset()
 
-	at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2)
+	at, token, err := CreateAuthTokenForUserID(db.DefaultContext, 2, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, at)
 	assert.NotEmpty(t, token)

--- a/services/auth/external_auth_token.go
+++ b/services/auth/external_auth_token.go
@@ -1,0 +1,98 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+
+	auth "code.gitea.io/gitea/models/auth"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/session"
+
+	"github.com/markbates/goth"
+)
+
+func toExternalAuthToken(ctx context.Context, sessionID string, user *user_model.User, gothUser *goth.User) (*auth.ExternalAuthToken, error) {
+	authSource, err := auth.GetActiveOAuth2SourceByName(ctx, gothUser.Provider)
+	if err != nil {
+		return nil, err
+	}
+	return &auth.ExternalAuthToken{
+		SessionID:         sessionID,
+		UserID:            user.ID,
+		ExternalID:        gothUser.UserID,
+		LoginSourceID:     authSource.ID,
+		RawData:           gothUser.RawData,
+		AccessToken:       gothUser.AccessToken,
+		AccessTokenSecret: gothUser.AccessTokenSecret,
+		RefreshToken:      gothUser.RefreshToken,
+		ExpiresAt:         gothUser.ExpiresAt,
+		IDToken:           gothUser.IDToken,
+	}, nil
+}
+
+func SetExternalAuthToken(ctx context.Context, sessionID string, user *user_model.User, gothUser *goth.User) error {
+	t, err := toExternalAuthToken(ctx, sessionID, user, gothUser)
+	if err != nil {
+		return err
+	}
+
+	oldt, err := auth.GetExternalAuthTokenBySessionID(ctx, sessionID)
+	if auth.IsErrExternalAuthTokenNotExist(err) {
+		return auth.InsertExternalAuthToken(ctx, t)
+	} else if err != nil {
+		return err
+	}
+
+	t.AuthTokenID = oldt.AuthTokenID
+	return auth.UpdateExternalAuthTokenBySessionID(ctx, sessionID, t)
+}
+
+func UpdateExternalAuthTokenSessionID(ctx context.Context, oldSessionID, sessionID string) error {
+	t, err := auth.GetExternalAuthTokenBySessionID(ctx, oldSessionID)
+	if err != nil {
+		return err
+	}
+	t.SessionID = sessionID
+	return auth.UpdateExternalAuthTokenBySessionID(ctx, oldSessionID, t)
+}
+
+func UpdateExternalAuthTokenSessionIDByAuthTokenID(ctx context.Context, authTokenID, sessionID string) error {
+	t, err := auth.GetExternalAuthTokenByAuthTokenID(ctx, authTokenID)
+	if err != nil {
+		return err
+	}
+	oldSessionID := t.SessionID
+	t.SessionID = sessionID
+	return auth.UpdateExternalAuthTokenBySessionID(ctx, oldSessionID, t)
+}
+
+func UpdateExternalAuthTokenAuthTokenID(ctx context.Context, sessionID, authTokenID string) error {
+	t, err := auth.GetExternalAuthTokenBySessionID(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	t.AuthTokenID = authTokenID
+	return auth.UpdateExternalAuthTokenBySessionID(ctx, sessionID, t)
+}
+
+func CleanExternalAuthTokensByUser(ctx context.Context, userID int64) error {
+	tokens, err := auth.GetExternalAuthTokenSessionIDsAndAuthTokenIDs(ctx, userID, 0)
+	if err != nil {
+		return err
+	}
+	sessionProvider, err := session.GetSessionProvider()
+	if err != nil {
+		return err
+	}
+	for _, t := range tokens {
+		if !sessionProvider.Exist(t.SessionID) && (len(t.AuthTokenID) == 0 || !auth.ExistAuthToken(ctx, t.AuthTokenID)) {
+			if err := auth.DeleteExternalAuthTokenBySessionID(ctx, t.SessionID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/services/auth/source/oauth2/source_endsession.go
+++ b/services/auth/source/oauth2/source_endsession.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package oauth2
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
+	"code.gitea.io/gitea/services/context"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/openidConnect"
+)
+
+// EndSessionEndpoint returns end_session_endpoint URI for OIDC sources
+func (source *Source) EndSessionEndpoint(ctx *context.Context) (string, string, error) {
+	redirect := &url.URL{}
+	state := ""
+	providerName := source.authSource.Name
+
+	gothProvider, err := goth.GetProvider(providerName)
+	if err != nil {
+		return "", "", err
+	}
+
+	oidcProvider, ok := gothProvider.(*openidConnect.Provider)
+	if ok && oidcProvider.OpenIDConfig != nil && len(oidcProvider.OpenIDConfig.EndSessionEndpoint) > 0 {
+		if redirect, err = url.Parse(oidcProvider.OpenIDConfig.EndSessionEndpoint); err != nil {
+			return "", "", err
+		}
+
+		r, err := util.CryptoRandomBytes(8)
+		if err != nil {
+			return "", "", err
+		}
+		state = base64.RawURLEncoding.EncodeToString(r)
+
+		values := url.Values{}
+		values.Set("client_id", oidcProvider.ClientKey)
+		values.Set("post_logout_redirect_uri", fmt.Sprintf("%suser/oauth2/%s/logout/callback", setting.AppURL, providerName))
+		values.Set("state", state)
+
+		if ctx.Doer != nil {
+			t, err := auth_model.GetExternalAuthTokenBySessionID(ctx, ctx.Session.ID())
+			if auth_model.IsErrExternalAuthTokenNotExist(err) {
+				log.Error("EndSessionEndpoint: %v", err)
+			} else if err != nil {
+				return "", "", err
+			} else if t.UserID == ctx.Doer.ID && len(t.IDToken) > 0 {
+				values.Set("id_token_hint", t.IDToken)
+			} else {
+				log.Error("EndSessionEndpoint IDToken missing for UserID %d [SessionID: %s, Provider: %s]", ctx.Doer.ID, ctx.Session.ID(), providerName)
+			}
+		}
+
+		redirect.RawQuery = values.Encode()
+	}
+
+	return redirect.String(), state, nil
+}

--- a/services/externalaccount/user.go
+++ b/services/externalaccount/user.go
@@ -22,23 +22,18 @@ func toExternalLoginUser(ctx context.Context, user *user_model.User, gothUser go
 		return nil, err
 	}
 	return &user_model.ExternalLoginUser{
-		ExternalID:        gothUser.UserID,
-		UserID:            user.ID,
-		LoginSourceID:     authSource.ID,
-		RawData:           gothUser.RawData,
-		Provider:          gothUser.Provider,
-		Email:             gothUser.Email,
-		Name:              gothUser.Name,
-		FirstName:         gothUser.FirstName,
-		LastName:          gothUser.LastName,
-		NickName:          gothUser.NickName,
-		Description:       gothUser.Description,
-		AvatarURL:         gothUser.AvatarURL,
-		Location:          gothUser.Location,
-		AccessToken:       gothUser.AccessToken,
-		AccessTokenSecret: gothUser.AccessTokenSecret,
-		RefreshToken:      gothUser.RefreshToken,
-		ExpiresAt:         gothUser.ExpiresAt,
+		ExternalID:    gothUser.UserID,
+		UserID:        user.ID,
+		LoginSourceID: authSource.ID,
+		Provider:      gothUser.Provider,
+		Email:         gothUser.Email,
+		Name:          gothUser.Name,
+		FirstName:     gothUser.FirstName,
+		LastName:      gothUser.LastName,
+		NickName:      gothUser.NickName,
+		Description:   gothUser.Description,
+		AvatarURL:     gothUser.AvatarURL,
+		Location:      gothUser.Location,
 	}, nil
 }
 

--- a/services/user/delete.go
+++ b/services/user/delete.go
@@ -189,6 +189,12 @@ func deleteUser(ctx context.Context, u *user_model.User, purge bool) (err error)
 	}
 	// ***** END: ExternalLoginUser *****
 
+	// ***** START: ExternalAuthToken *****
+	if err = auth_model.DeleteExternalAuthTokensByUserID(ctx, u.ID); err != nil {
+		return fmt.Errorf("DeleteExternalAuthTokensByUserID: %w", err)
+	}
+	// ***** END: ExternalAuthToken *****
+
 	if err := auth_model.DeleteAuthTokensByUserID(ctx, u.ID); err != nil {
 		return fmt.Errorf("DeleteAuthTokensByUserID: %w", err)
 	}


### PR DESCRIPTION
Add support for OIDC RP-initiated logout as defined in https://openid.net/specs/openid-connect-rpinitiated-1_0.html:
- Track OIDC/OAuth2 login type, tokens and authentication data on session level
- Keep session level data synced when using a login cookie (remember option)
- Handle OIDC/OAuth2 logouts on an authentication source specific endpoint
- Redirect to the OIDC end_session_endpoint, if it exists in the provider configuration
- Fallback to local logout only
- Be verbose about external logout errors
- Use a callback endpoint for maintaining state between Gitea and an OIDC provider

Fixes #14270

---

### Additional notes:
- Tested with Keycloak (OIDC) and Github (OAuth2). **Thorough testing with other IdPs and server setups is needed**
- There are most likely some (small) merge conflicts with #29403 as these PRs modify partly the same code
- An additional PR is required for supporting OIDC back-channel (or front-channel) logout. I.e. your session in Gitea will still remain logged in, if you logout from your IdP elsewhere
- Tracking external logins on session level by using ExternalAuthTokens makes it easier to implement OIDC back-channel or front-channel logout support in the future