### PR TITLE
Enable eslint `space-before-function-paren`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -167,7 +167,7 @@ rules:
   "@stylistic/js/semi-spacing": [2, {before: false, after: true}]
   "@stylistic/js/semi-style": [2, last]
   "@stylistic/js/space-before-blocks": [2, always]
-  "@stylistic/js/space-before-function-paren": [0]
+  "@stylistic/js/space-before-function-paren": [2, {anonymous: ignore, named: never, asyncArrow: always}]
   "@stylistic/js/space-in-parens": [2, never]
   "@stylistic/js/space-infix-ops": [2]
   "@stylistic/js/space-unary-ops": [2]


### PR DESCRIPTION
Anonymous are set to ignore as I [couldn't decide](https://github.com/go-gitea/gitea/pull/30077#discussion_r1538117497). No current violations.

Rule docs: https://eslint.style/rules/js/space-before-function-paren