### PR TITLE
Fix table header text-align

### DIFF
--- a/web_src/css/modules/table.css
+++ b/web_src/css/modules/table.css
@@ -23,11 +23,13 @@
 }
 .ui.table > thead,
 .ui.table > tbody {
+  text-align: inherit;
   vertical-align: inherit;
 }
 
 .ui.table > thead > tr > th {
   background: var(--color-box-header);
+  text-align: inherit;
   color: var(--color-text);
   padding: 6px 5px;
   vertical-align: inherit;
@@ -52,6 +54,7 @@
 .ui.table > tfoot > tr > td {
   border-top: 1px solid var(--color-secondary);
   background: var(--color-box-body);
+  text-align: inherit;
   color: var(--color-text);
   padding: 0.78571429em;
   vertical-align: inherit;
@@ -78,6 +81,7 @@
 .ui.table > tbody > tr > td {
   border-top: 1px solid var(--color-secondary-alpha-50);
   padding: 6px 5px;
+  text-align: inherit;
 }
 .ui.table > tr:first-child > td,
 .ui.table > tbody > tr:first-child > td {


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/pull/30047. Apparently tables have certain user-agent styles that center inside `<th>` etc. Restored the original fomantic rules for these.

Before:
<img width="1332" alt="Screenshot 2024-03-25 at 21 59 33" src="https://github.com/go-gitea/gitea/assets/115237/e06a5509-b505-4752-9b6e-91d5ed49f61d">

After:
<img width="1330" alt="Screenshot 2024-03-25 at 21 59 40" src="https://github.com/go-gitea/gitea/assets/115237/6444817f-dd61-4a1e-a8b3-959c2780148d">
