### PR TITLE
Fix incorrect SVGs

### DIFF
--- a/templates/devtest/flex-list.tmpl
+++ b/templates/devtest/flex-list.tmpl
@@ -25,7 +25,7 @@
 				</div>
 				<div class="flex-item-trailing">
 					<button class="ui tiny red button">
-						{{svg "octicon-warning" 14}} CJK文本测试
+						{{svg "octicon-alert" 14}} CJK文本测试
 					</button>
 					<button class="ui tiny primary button">
 						{{svg "octicon-info" 14}} Button
@@ -54,7 +54,7 @@
 				</div>
 				<div class="flex-item-trailing">
 					<button class="ui tiny red button">
-						{{svg "octicon-warning" 12}} CJK文本测试 <!-- single CJK text test, it shouldn't be horizontal -->
+						{{svg "octicon-alert" 12}} CJK文本测试 <!-- single CJK text test, it shouldn't be horizontal -->
 					</button>
 				</div>
 			</div>

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -20,7 +20,7 @@
 		)}}
 
 		<div class="field footer gt-mx-3">
-			<span class="markup-info">{{svg "octicon-markup"}} {{ctx.Locale.Tr "repo.diff.comment.markdown_info"}}</span>
+			<span class="markup-info">{{svg "octicon-markdown"}} {{ctx.Locale.Tr "repo.diff.comment.markdown_info"}}</span>
 			<div class="gt-text-right">
 				{{if $.reply}}
 					<button class="ui submit primary tiny button btn-reply" type="submit">{{ctx.Locale.Tr "repo.diff.comment.reply"}}</button>


### PR DESCRIPTION
Just the SVG fixes from https://github.com/go-gitea/gitea/pull/30086 for v1.21 branch.