### PR TITLE
Fix `DEFAULT_SHOW_FULL_NAME=false` has no effect in commit list and commit graph page

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -16,7 +16,7 @@
 						<td class="author">
 							{{$userName := .Author.Name}}
 							{{if .User}}
-								{{if .User.FullName}}
+								{{if and .User.FullName DefaultShowFullName}}
 									{{$userName = .User.FullName}}
 								{{end}}
 								{{ctx.AvatarUtils.Avatar .User 28 "tw-mr-1"}}<a href="{{.User.HomeLink}}">{{$userName}}</a>

--- a/templates/repo/graph/commits.tmpl
+++ b/templates/repo/graph/commits.tmpl
@@ -61,7 +61,7 @@
 					<span class="author tw-flex tw-items-center tw-mr-2">
 						{{$userName := $commit.Commit.Author.Name}}
 						{{if $commit.User}}
-							{{if $commit.User.FullName}}
+							{{if and $commit.User.FullName DefaultShowFullName}}
 								{{$userName = $commit.User.FullName}}
 							{{end}}
 							<span class="tw-mr-1">{{ctx.AvatarUtils.Avatar $commit.User}}</span>

--- a/templates/repo/latest_commit.tmpl
+++ b/templates/repo/latest_commit.tmpl
@@ -3,7 +3,7 @@
 {{else}}
 	{{if .LatestCommitUser}}
 		{{ctx.AvatarUtils.Avatar .LatestCommitUser 24 "tw-mr-1"}}
-		{{if .LatestCommitUser.FullName}}
+		{{if and .LatestCommitUser.FullName DefaultShowFullName}}
 			<a class="muted author-wrapper" title="{{.LatestCommitUser.FullName}}" href="{{.LatestCommitUser.HomeLink}}"><strong>{{.LatestCommitUser.FullName}}</strong></a>
 		{{else}}
 			<a class="muted author-wrapper" title="{{if .LatestCommit.Author}}{{.LatestCommit.Author.Name}}{{else}}{{.LatestCommitUser.Name}}{{end}}" href="{{.LatestCommitUser.HomeLink}}"><strong>{{if .LatestCommit.Author}}{{.LatestCommit.Author.Name}}{{else}}{{.LatestCommitUser.Name}}{{end}}</strong></a>


### PR DESCRIPTION
Fix #20446

This PR will fix the username in:
repo home page
![image](https://github.com/go-gitea/gitea/assets/18380374/347c0f70-ea42-432d-aae3-bf87a7e07ae1)
repo commit list page
![image](https://github.com/go-gitea/gitea/assets/18380374/b3b1f5d5-c371-4222-ac2e-64b8994c7551)
repo commit graph page
![image](https://github.com/go-gitea/gitea/assets/18380374/01b7117c-3aea-4d7d-8bd1-35e5ea942821)
pr commit page
![image](https://github.com/go-gitea/gitea/assets/18380374/4d180c30-2150-4348-8eeb-0b4b2559ec19)

Will not fix:
wiki revisions page:
![image](https://github.com/go-gitea/gitea/assets/18380374/b49df6bf-d751-4374-b7ea-1ac85e2739e3)
ps: the author name is `FullName` by default