### PR TITLE
Resolve `AcmeLiveDirectory` to `AppDataPath/AcmeLiveDirectory` when it is a relative path

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -260,6 +260,7 @@ RUN_USER = ; git
 ;;
 ;; ACME live directory (not to be confused with ACME directory URL: ACME_URL)
 ;; (Refer to caddy's ACME manager https://github.com/caddyserver/certmagic)
+;; Relative paths will be resolved to `${AppDataPath}/${AcmeLiveDirectory}`
 ;ACME_DIRECTORY = https
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/modules/setting/server.go
+++ b/modules/setting/server.go
@@ -205,6 +205,9 @@ func loadServerFrom(rootCfg ConfigProvider) {
 				deprecatedSetting(rootCfg, "server", "LETSENCRYPT_DIRECTORY", "server", "ACME_DIRECTORY", "v1.19.0")
 				AcmeLiveDirectory = sec.Key("LETSENCRYPT_DIRECTORY").MustString("https")
 			}
+			if !filepath.IsAbs(AcmeLiveDirectory) {
+				AcmeLiveDirectory = filepath.Join(AppDataPath, AcmeLiveDirectory)
+			}
 
 			if sec.HasKey("ACME_EMAIL") {
 				AcmeEmail = sec.Key("ACME_EMAIL").MustString("")


### PR DESCRIPTION
Fix #26590

This is a breaking change.