### PR TITLE
Load attachments for code comments

### DIFF
--- a/models/issues/comment_code.go
+++ b/models/issues/comment_code.go
@@ -74,6 +74,10 @@ func findCodeComments(ctx context.Context, opts FindCommentsOptions, issue *Issu
 		return nil, err
 	}
 
+	if err := comments.LoadAttachments(ctx); err != nil {
+		return nil, err
+	}
+
 	// Find all reviews by ReviewID
 	reviews := make(map[int64]*Review)
 	ids := make([]int64, 0, len(comments))


### PR DESCRIPTION
Fix #30103

ps: comments has `LoadAttributes`, but maybe considering performance problem, we don't call it.