### PR TITLE
Fix loading spinner on ContextPopup

### DIFF
--- a/web_src/js/components/ContextPopup.vue
+++ b/web_src/js/components/ContextPopup.vue
@@ -103,7 +103,7 @@ export default {
 </script>
 <template>
   <div ref="root">
-    <div v-if="loading" class="ui active centered inline loader"/>
+    <div v-if="loading" class="tw-h-12 tw-w-12 is-loading"/>
     <div v-if="!loading && issue !== null">
       <p><small>{{ issue.repository.full_name }} on {{ createdAt }}</small></p>
       <p><svg-icon :name="icon" :class="['text', color]"/> <strong>{{ issue.title }}</strong> #{{ issue.number }}</p>


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/pull/26670. Here with simulated delay:

![](https://github.com/go-gitea/gitea/assets/115237/9de5a136-c8a6-4d69-adc7-07e1184e3311)
