### PR TITLE
Fix download buttons on branches page

### DIFF
--- a/web_src/css/modules/animations.css
+++ b/web_src/css/modules/animations.css
@@ -13,6 +13,7 @@
   opacity: 0.3;
 }
 
+.btn.is-loading > *,
 .button.is-loading > * {
   opacity: 0;
 }

--- a/web_src/js/features/repo-common.js
+++ b/web_src/js/features/repo-common.js
@@ -3,7 +3,7 @@ import {hideElem, showElem} from '../utils/dom.js';
 import {POST} from '../modules/fetch.js';
 
 async function getArchive($target, url, first) {
-  const dropdownBtn = $target[0].closest('.ui.dropdown.button');
+  const dropdownBtn = $target[0].closest('.ui.dropdown.button') ?? $target[0].closest('.ui.dropdown.btn');
 
   try {
     dropdownBtn.classList.add('is-loading');


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/30143, regression from https://github.com/go-gitea/gitea/pull/29920.

We have `.button` on the repo page, but on the branch page it's a `.btn`. Eventually we should find a solution to have a single button class but until then this solution should be acceptable.