### PR TITLE
Adjust VS Code debug filename match in .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,7 @@ _test
 
 # MS VSCode
 .vscode
-__debug_bin
+__debug_bin*
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ _test
 
 # MS VSCode
 .vscode
-__debug_bin
+__debug_bin*
 
 *.cgo1.go
 *.cgo2.c


### PR DESCRIPTION
Ignore VS Code debug files like `__debug_bin3317791802`.

Author-Change-Id: IB#1144587
