### PR TITLE
Remove jQuery class from the commit button

### DIFF
--- a/web_src/js/features/repo-editor.js
+++ b/web_src/js/features/repo-editor.js
@@ -148,7 +148,7 @@ export function initRepoEditor() {
       dirtyClass: dirtyFileClass,
       fieldSelector: ':input:not(.commit-form-wrapper :input)',
       change() {
-        const dirty = $(this).hasClass(dirtyFileClass);
+        const dirty = this[0]?.classList.contains(dirtyFileClass);
         commitButton.disabled = !dirty;
       },
     });

--- a/web_src/js/features/repo-editor.js
+++ b/web_src/js/features/repo-editor.js
@@ -148,7 +148,7 @@ export function initRepoEditor() {
       dirtyClass: dirtyFileClass,
       fieldSelector: ':input:not(.commit-form-wrapper :input)',
       change($form) {
-        const dirty = this[0]?.classList.contains(dirtyFileClass);
+        const dirty = $form[0]?.classList.contains(dirtyFileClass);
         commitButton.disabled = !dirty;
       },
     });

--- a/web_src/js/features/repo-editor.js
+++ b/web_src/js/features/repo-editor.js
@@ -147,7 +147,7 @@ export function initRepoEditor() {
       silent: true,
       dirtyClass: dirtyFileClass,
       fieldSelector: ':input:not(.commit-form-wrapper :input)',
-      change() {
+      change($form) {
         const dirty = this[0]?.classList.contains(dirtyFileClass);
         commitButton.disabled = !dirty;
       },


### PR DESCRIPTION
- Switched from jQuery class functions to plain JavaScript `classList`
- Tested the commit button disabled toggling functionality and it works as before

