### PR TITLE
Fix home topic edit form layout

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -24,7 +24,7 @@
 		</div>
 		{{end}}
 		{{if and .Permission.IsAdmin (not .Repository.IsArchived)}}
-		<div class="ui form tw-hidden tw-flex tw-flex-col tw-mt-4" id="topic_edit">
+		<div class="ui form tw-hidden tw-flex tw-gap-2 tw-mt-4" id="topic_edit">
 			<div class="field tw-flex-1 tw-mb-1">
 				<div class="ui fluid multiple search selection dropdown tw-flex-wrap" data-text-count-prompt="{{ctx.Locale.Tr "repo.topic.count_prompt"}}" data-text-format-prompt="{{ctx.Locale.Tr "repo.topic.format_prompt"}}">
 					<input type="hidden" name="topics" value="{{range $i, $v := .Topics}}{{.Name}}{{if Eval $i "+" 1 "<" (len $.Topics)}},{{end}}{{end}}">


### PR DESCRIPTION
The UI has been refactored by #30191 , so here are 2 choices:

1. Backport #30191
2. Apply this quick fix


Before:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/0db583cf-8ce8-4fdb-9e4d-8c93fe6766c7)

</details>

After:

<details>

![image](https://github.com/go-gitea/gitea/assets/2114189/0e732c4c-d28d-4c04-b328-72b9efd7daa9)

</details>
