### PR TITLE
Change commit page signature indication to icon only

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -129,6 +129,9 @@ confirm_delete_artifact = Are you sure you want to delete the artifact '%s' ?
 
 archived = Archived
 
+sig_verified = Signed with user's verified signature
+sig_failed = Unable to verify this signature
+
 concept_system_global = Global
 concept_user_individual = Individual
 concept_code_repository = Repository

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -2,22 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content repository diff">
 	{{template "repo/header" .}}
 	<div class="ui container fluid padded">
-		{{$class := ""}}
-		{{if .Commit.Signature}}
-			{{$class = (print $class " isSigned")}}
-			{{if .Verification.Verified}}
-				{{if eq .Verification.TrustStatus "trusted"}}
-					{{$class = (print $class " isVerified")}}
-				{{else if eq .Verification.TrustStatus "untrusted"}}
-					{{$class = (print $class " isVerifiedUntrusted")}}
-				{{else}}
-					{{$class = (print $class " isVerifiedUnmatched")}}
-				{{end}}
-			{{else if .Verification.Warning}}
-				{{$class = (print $class " isWarning")}}
-			{{end}}
-		{{end}}
-		<div class="ui top attached header clearing segment tw-relative commit-header {{$class}}">
+		<div class="ui top attached header clearing segment tw-relative commit-header">
 			<div class="tw-flex tw-mb-4 tw-flex-wrap">
 				<h3 class="tw-mb-0 tw-flex-1"><span class="commit-summary" title="{{.Commit.Summary}}">{{RenderCommitMessage $.Context .Commit.Message ($.Repository.ComposeMetas ctx)}}</span>{{template "repo/commit_statuses" dict "Status" .CommitStatus "Statuses" .CommitStatuses}}</h3>
 				{{if not $.PageIsWiki}}
@@ -139,7 +124,7 @@
 			{{end}}
 			{{template "repo/commit_load_branches_and_tags" .}}
 		</div>
-		<div class="ui attached segment tw-flex tw-items-center tw-justify-between tw-py-1 commit-header-row tw-flex-wrap {{$class}}">
+		<div class="ui attached segment tw-flex tw-items-center tw-justify-between tw-py-1 commit-header-row tw-flex-wrap">
 				<div class="tw-flex tw-items-center author">
 					{{if .Author}}
 						{{ctx.AvatarUtils.Avatar .Author 28 "tw-mr-2"}}
@@ -163,6 +148,7 @@
 							<strong>{{.Commit.Committer.Name}}</strong>
 						{{end}}
 					{{end}}
+					{{template "shared/verifyicon" .}}
 				</div>
 				<div class="ui horizontal list tw-flex tw-items-center">
 					{{if .Parents}}
@@ -183,81 +169,6 @@
 					</div>
 				</div>
 		</div>
-		{{if .Commit.Signature}}
-			<div class="ui bottom attached message tw-text-left tw-flex tw-items-center tw-justify-between commit-header-row tw-flex-wrap tw-mb-0 {{$class}}">
-				<div class="tw-flex tw-items-center">
-					{{if .Verification.Verified}}
-						{{if ne .Verification.SigningUser.ID 0}}
-							{{svg "gitea-lock" 16 "tw-mr-2"}}
-							{{if eq .Verification.TrustStatus "trusted"}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
-							{{else if eq .Verification.TrustStatus "untrusted"}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
-							{{else}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
-							{{end}}
-							{{ctx.AvatarUtils.Avatar .Verification.SigningUser 28 "tw-mr-2"}}
-							<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Verification.SigningUser.GetDisplayName}}</strong></a>
-						{{else}}
-							<span title="{{ctx.Locale.Tr "gpg.default_key"}}">{{svg "gitea-lock-cog" 16 "tw-mr-2"}}</span>
-							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
-							{{ctx.AvatarUtils.AvatarByEmail .Verification.SigningEmail "" 28 "tw-mr-2"}}
-							<strong>{{.Verification.SigningUser.GetDisplayName}}</strong>
-						{{end}}
-					{{else}}
-						{{svg "gitea-unlock" 16 "tw-mr-2"}}
-						<span class="ui text">{{ctx.Locale.Tr .Verification.Reason}}</span>
-					{{end}}
-				</div>
-				<div class="tw-flex tw-items-center">
-					{{if .Verification.Verified}}
-						{{if ne .Verification.SigningUser.ID 0}}
-							{{svg "octicon-verified" 16 "tw-mr-2"}}
-							{{if .Verification.SigningSSHKey}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-								{{.Verification.SigningSSHKey.Fingerprint}}
-							{{else}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.PaddedKeyID}}
-							{{end}}
-						{{else}}
-							{{svg "octicon-unverified" 16 "tw-mr-2"}}
-							{{if .Verification.SigningSSHKey}}
-								<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-								{{.Verification.SigningSSHKey.Fingerprint}}
-							{{else}}
-								<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.PaddedKeyID}}
-							{{end}}
-						{{end}}
-					{{else if .Verification.Warning}}
-						{{svg "octicon-unverified" 16 "tw-mr-2"}}
-						{{if .Verification.SigningSSHKey}}
-							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-							{{.Verification.SigningSSHKey.Fingerprint}}
-						{{else}}
-							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-							{{.Verification.SigningKey.PaddedKeyID}}
-						{{end}}
-					{{else}}
-						{{if .Verification.SigningKey}}
-							{{if ne .Verification.SigningKey.KeyID ""}}
-								{{svg "octicon-verified" 16 "tw-mr-2"}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-								{{.Verification.SigningKey.PaddedKeyID}}
-							{{end}}
-						{{end}}
-						{{if .Verification.SigningSSHKey}}
-							{{if ne .Verification.SigningSSHKey.Fingerprint ""}}
-								{{svg "octicon-verified" 16 "tw-mr-2"}}
-								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-								{{.Verification.SigningSSHKey.Fingerprint}}
-							{{end}}
-						{{end}}
-					{{end}}
-				</div>
-			</div>
-		{{end}}
 		{{if .NoteRendered}}
 			<div class="ui top attached header segment git-notes">
 				{{svg "octicon-note" 16 "tw-mr-2"}}

--- a/templates/repo/pulls/status.tmpl
+++ b/templates/repo/pulls/status.tmpl
@@ -9,7 +9,7 @@ Template Attributes:
 
 {{if .CommitStatus}}
 <div class="commit-status-panel">
-	<div class="ui top attached header commit-status-header">
+	<div class="ui top attached header">
 		{{if or (eq .CommitStatus.State "pending") (.MissingRequiredChecks)}}
 			{{ctx.Locale.Tr "repo.pulls.status_checking"}}
 		{{else if eq .CommitStatus.State "success"}}

--- a/templates/shared/verifyicon.tmpl
+++ b/templates/shared/verifyicon.tmpl
@@ -4,12 +4,12 @@ Template Attributes:
 * Verification: Verification struct
 */}}
 {{if (and .Commit .Commit.Signature .Verification)}}
-	{{$icon := ""}}
+	{{$icon = "octicon-unverified"}}
 	{{$text := ""}}
 	{{$colorClass := ""}}
 	{{if .Verification.Verified}}
-		{{$icon = "octicon-verified"}}
 		{{if eq .Verification.TrustStatus "trusted"}}
+			{{$icon = "octicon-verified"}}
 			{{$colorClass = "tw-text-green"}}
 			{{$text = (ctx.Locale.Tr "sig_verified")}}
 		{{else if eq .Verification.TrustStatus "untrusted"}}
@@ -20,7 +20,6 @@ Template Attributes:
 			{{$text = (ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched")}}
 		{{end}}
 	{{else}}
-		{{$icon = "octicon-unverified"}}
 		{{if .Verification.Warning}}
 			{{$colorClass = "tw-text-red"}}
 		{{else}}

--- a/templates/shared/verifyicon.tmpl
+++ b/templates/shared/verifyicon.tmpl
@@ -1,0 +1,115 @@
+{{/*
+Template Attributes:
+* Commit: Commit object
+* Verification: Verification struct
+*/}}
+{{if (and .Commit .Commit.Signature .Verification)}}
+	{{$icon := ""}}
+	{{$text := ""}}
+	{{$colorClass := ""}}
+	{{if .Verification.Verified}}
+		{{$icon = "octicon-verified"}}
+		{{if eq .Verification.TrustStatus "trusted"}}
+			{{$colorClass = "tw-text-green"}}
+			{{$text = (ctx.Locale.Tr "sig_verified")}}
+		{{else if eq .Verification.TrustStatus "untrusted"}}
+			{{$colorClass = "tw-text-orange"}}
+			{{$text = (ctx.Locale.Tr "repo.commits.signed_by_untrusted_user")}}
+		{{else}}
+			{{$colorClass = "tw-text-orange"}}
+			{{$text = (ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched")}}
+		{{end}}
+	{{else}}
+		{{$icon = "octicon-unverified"}}
+		{{if .Verification.Warning}}
+			{{$colorClass = "tw-text-red"}}
+		{{else}}
+			{{$colorClass = "tw-text-inherit"}}
+		{{end}}
+		{{if .Verification.Reason}}
+			{{$text = (ctx.Locale.Tr .Verification.Reason)}}
+		{{else}}
+			{{$text = (ctx.Locale.Tr "sig_failed")}}
+		{{end}}
+	{{end}}
+	<button
+		class="btn interact-bg tippy-trigger tw-ml-1 tw-p-2"
+		data-tippy-theme="box-with-header"
+		data-tippy-role="dialog"
+		data-tippy-trigger="click"
+		data-tippy-interactive="true"
+		data-tippy-hideOnClick="true"
+	>
+		{{svg $icon 16 $colorClass}}
+	</button>
+	<div class="tippy-target">
+		<div class="verification-status-panel">
+		  <div class="ui top attached header">{{svg $icon 16 (printf "%s tw-mr-2" $colorClass)}}{{$text}}</div>
+		  <div class="tw-flex tw-flex-col">
+		  	{{if .Verification.Verified}}
+			  	<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
+		  			{{if ne .Verification.SigningUser.ID 0}}
+		  				{{if eq .Verification.TrustStatus "trusted"}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
+		  				{{else if eq .Verification.TrustStatus "untrusted"}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
+		  				{{else}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
+		  				{{end}}
+		  				{{ctx.AvatarUtils.Avatar .Verification.SigningUser 28 "tw-mr-2"}}
+		  				<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Verification.SigningUser.GetDisplayName}}</strong></a>
+		  			{{else}}
+		  				<span title="{{ctx.Locale.Tr "gpg.default_key"}}">
+		  				{{svg "gitea-lock-cog" 16 "tw-mr-2"}}</span>
+		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
+		  				{{ctx.AvatarUtils.AvatarByEmail .Verification.SigningEmail "" 28 "tw-mr-2"}}
+		  				<strong>{{.Verification.SigningUser.GetDisplayName}}</strong>
+		  			{{end}}
+		  		</div>
+		  	{{end}}
+		  	<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
+		  		{{if .Verification.Verified}}
+		  			{{if ne .Verification.SigningUser.ID 0}}
+		  				{{if .Verification.SigningSSHKey}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+		  				{{else}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+		  				{{end}}
+		  			{{else}}
+		  				{{if .Verification.SigningSSHKey}}
+		  					<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+		  				{{else}}
+		  					<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+		  				{{end}}
+		  			{{end}}
+		  		{{else if .Verification.Warning}}
+		  			{{if .Verification.SigningSSHKey}}
+		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+		  				<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+		  			{{else}}
+		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+		  				<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+		  			{{end}}
+		  		{{else}}
+		  			{{if .Verification.SigningKey}}
+		  				{{if ne .Verification.SigningKey.KeyID ""}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+		  				{{end}}
+		  			{{end}}
+		  			{{if .Verification.SigningSSHKey}}
+		  				{{if ne .Verification.SigningSSHKey.Fingerprint ""}}
+		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+		  				{{end}}
+		  			{{end}}
+		  		{{end}}
+		  	</div>
+		  </div>
+	  </div>
+	</div>
+{{end}}

--- a/templates/shared/verifyicon.tmpl
+++ b/templates/shared/verifyicon.tmpl
@@ -44,72 +44,72 @@ Template Attributes:
 	</button>
 	<div class="tippy-target">
 		<div class="verification-status-panel">
-		  <div class="ui top attached header">{{svg $icon 16 (printf "%s tw-mr-2" $colorClass)}}{{$text}}</div>
-		  <div class="tw-flex tw-flex-col">
-		  	{{if .Verification.Verified}}
-			  	<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
-		  			{{if ne .Verification.SigningUser.ID 0}}
-		  				{{if eq .Verification.TrustStatus "trusted"}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
-		  				{{else if eq .Verification.TrustStatus "untrusted"}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
-		  				{{else}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
-		  				{{end}}
-		  				{{ctx.AvatarUtils.Avatar .Verification.SigningUser 28 "tw-mr-2"}}
-		  				<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Verification.SigningUser.GetDisplayName}}</strong></a>
-		  			{{else}}
-		  				<span title="{{ctx.Locale.Tr "gpg.default_key"}}">
-		  				{{svg "gitea-lock-cog" 16 "tw-mr-2"}}</span>
-		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
-		  				{{ctx.AvatarUtils.AvatarByEmail .Verification.SigningEmail "" 28 "tw-mr-2"}}
-		  				<strong>{{.Verification.SigningUser.GetDisplayName}}</strong>
-		  			{{end}}
-		  		</div>
-		  	{{end}}
-		  	<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
-		  		{{if .Verification.Verified}}
-		  			{{if ne .Verification.SigningUser.ID 0}}
-		  				{{if .Verification.SigningSSHKey}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
-		  				{{else}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
-		  				{{end}}
-		  			{{else}}
-		  				{{if .Verification.SigningSSHKey}}
-		  					<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
-		  				{{else}}
-		  					<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
-		  				{{end}}
-		  			{{end}}
-		  		{{else if .Verification.Warning}}
-		  			{{if .Verification.SigningSSHKey}}
-		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-		  				<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
-		  			{{else}}
-		  				<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-		  				<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
-		  			{{end}}
-		  		{{else}}
-		  			{{if .Verification.SigningKey}}
-		  				{{if ne .Verification.SigningKey.KeyID ""}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
-		  				{{end}}
-		  			{{end}}
-		  			{{if .Verification.SigningSSHKey}}
-		  				{{if ne .Verification.SigningSSHKey.Fingerprint ""}}
-		  					<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
-		  					<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
-		  				{{end}}
-		  			{{end}}
-		  		{{end}}
-		  	</div>
-		  </div>
-	  </div>
+			<div class="ui top attached header">{{svg $icon 16 (printf "%s tw-mr-2" $colorClass)}}{{$text}}</div>
+			<div class="tw-flex tw-flex-col">
+				{{if .Verification.Verified}}
+					<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
+						{{if ne .Verification.SigningUser.ID 0}}
+							{{if eq .Verification.TrustStatus "trusted"}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
+							{{else if eq .Verification.TrustStatus "untrusted"}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user"}}:</span>
+							{{else}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by_untrusted_user_unmatched"}}:</span>
+							{{end}}
+							{{ctx.AvatarUtils.Avatar .Verification.SigningUser 28 "tw-mr-2"}}
+							<a href="{{.Verification.SigningUser.HomeLink}}"><strong>{{.Verification.SigningUser.GetDisplayName}}</strong></a>
+						{{else}}
+							<span title="{{ctx.Locale.Tr "gpg.default_key"}}">
+							{{svg "gitea-lock-cog" 16 "tw-mr-2"}}</span>
+							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.signed_by"}}:</span>
+							{{ctx.AvatarUtils.AvatarByEmail .Verification.SigningEmail "" 28 "tw-mr-2"}}
+							<strong>{{.Verification.SigningUser.GetDisplayName}}</strong>
+						{{end}}
+					</div>
+				{{end}}
+				<div class="tw-flex tw-items-center tw-px-3 tw-py-2">
+					{{if .Verification.Verified}}
+						{{if ne .Verification.SigningUser.ID 0}}
+							{{if .Verification.SigningSSHKey}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+							{{else}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+							{{end}}
+						{{else}}
+							{{if .Verification.SigningSSHKey}}
+								<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+							{{else}}
+								<span class="ui text tw-mr-2" data-tooltip-content="{{ctx.Locale.Tr "gpg.default_key"}}">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+							{{end}}
+						{{end}}
+					{{else if .Verification.Warning}}
+						{{if .Verification.SigningSSHKey}}
+							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+							<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+						{{else}}
+							<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+							<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+						{{end}}
+					{{else}}
+						{{if .Verification.SigningKey}}
+							{{if ne .Verification.SigningKey.KeyID ""}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.gpg_key_id"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningKey.PaddedKeyID}}</span>
+							{{end}}
+						{{end}}
+						{{if .Verification.SigningSSHKey}}
+							{{if ne .Verification.SigningSSHKey.Fingerprint ""}}
+								<span class="ui text tw-mr-2">{{ctx.Locale.Tr "repo.commits.ssh_key_fingerprint"}}:</span>
+								<span class="tw-font-mono">{{.Verification.SigningSSHKey.Fingerprint}}</span>
+							{{end}}
+						{{end}}
+					{{end}}
+				</div>
+			</div>
+		</div>
 	</div>
 {{end}}

--- a/templates/shared/verifyicon.tmpl
+++ b/templates/shared/verifyicon.tmpl
@@ -4,7 +4,7 @@ Template Attributes:
 * Verification: Verification struct
 */}}
 {{if (and .Commit .Commit.Signature .Verification)}}
-	{{$icon = "octicon-unverified"}}
+	{{$icon := "octicon-unverified"}}
 	{{$text := ""}}
 	{{$colorClass := ""}}
 	{{if .Verification.Verified}}

--- a/web_src/css/modules/tippy.css
+++ b/web_src/css/modules/tippy.css
@@ -83,6 +83,7 @@
 
 .tippy-box[data-theme="box-with-header"] {
   box-shadow: 0 6px 18px var(--color-shadow);
+  color: var(--color-text);
 }
 
 .tippy-box[data-theme="box-with-header"] .tippy-content {
@@ -97,6 +98,15 @@
 
 .tippy-box[data-theme="box-with-header"][data-placement^="bottom"] .tippy-svg-arrow-inner {
   fill: var(--color-box-header);
+}
+
+.tippy-box[data-theme="box-with-header"] .ui.top.attached.header {
+  /* reset the default ".ui.attached.header" styles, to use the outer border */
+  border: none !important;
+  /* add a bottom border to make sure the there is always a divider between the header and list when the list is scrolling */
+  border-bottom: 1px solid var(--color-secondary) !important;
+  /* use negative margin to avoid the newly added border conflict with the list's top border */
+  margin: 0 0 -1px !important;
 }
 
 .tippy-box[data-placement^="top"] > .tippy-svg-arrow {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1789,92 +1789,6 @@
   padding-top: 0;
 }
 
-.repository .ui.attached.isSigned.isWarning {
-  border-left: 1px solid var(--color-error-border);
-  border-right: 1px solid var(--color-error-border);
-}
-
-.repository .ui.attached.isSigned.isWarning.top,
-.repository .ui.attached.isSigned.isWarning.message {
-  border-top: 1px solid var(--color-error-border);
-}
-
-.repository .ui.attached.isSigned.isWarning.message {
-  box-shadow: none;
-  background-color: var(--color-error-bg);
-  color: var(--color-error-text);
-}
-
-.repository .ui.attached.isSigned.isWarning.message .ui.text {
-  color: var(--color-error-text);
-}
-
-.repository .ui.attached.isSigned.isWarning:last-child,
-.repository .ui.attached.isSigned.isWarning.bottom {
-  border-bottom: 1px solid var(--color-error-border);
-}
-
-.repository .ui.attached.isSigned.isVerified {
-  border-left: 1px solid var(--color-success-border);
-  border-right: 1px solid var(--color-success-border);
-}
-
-.repository .ui.attached.isSigned.isVerified.top,
-.repository .ui.attached.isSigned.isVerified.message {
-  border-top: 1px solid var(--color-success-border);
-}
-
-.repository .ui.attached.isSigned.isVerified.message {
-  box-shadow: none;
-  background-color: var(--color-success-bg);
-  color: var(--color-success-text);
-}
-
-.repository .ui.attached.isSigned.isVerified.message .pull-right {
-  color: var(--color-text);
-}
-
-.repository .ui.attached.isSigned.isVerified.message .ui.text {
-  color: var(--color-success-text);
-}
-
-.repository .ui.attached.isSigned.isVerified:last-child,
-.repository .ui.attached.isSigned.isVerified.bottom {
-  border-bottom: 1px solid var(--color-success-border);
-}
-
-.repository .ui.attached.isSigned.isVerifiedUntrusted,
-.repository .ui.attached.isSigned.isVerifiedUnmatched {
-  border-left: 1px solid var(--color-warning-border);
-  border-right: 1px solid var(--color-warning-border);
-}
-
-.repository .ui.attached.isSigned.isVerifiedUntrusted.top,
-.repository .ui.attached.isSigned.isVerifiedUnmatched.top,
-.repository .ui.attached.isSigned.isVerifiedUntrusted.message,
-.repository .ui.attached.isSigned.isVerifiedUnmatched.message {
-  border-top: 1px solid var(--color-warning-border);
-}
-
-.repository .ui.attached.isSigned.isVerifiedUntrusted.message,
-.repository .ui.attached.isSigned.isVerifiedUnmatched.message {
-  box-shadow: none;
-  background-color: var(--color-warning-bg);
-  color: var(--color-warning-text);
-}
-
-.repository .ui.attached.isSigned.isVerifiedUntrusted.message .ui.text,
-.repository .ui.attached.isSigned.isVerifiedUnmatched.message .ui.text {
-  color: var(--color-warning-text);
-}
-
-.repository .ui.attached.isSigned.isVerifiedUntrusted:last-child,
-.repository .ui.attached.isSigned.isVerifiedUnmatched:last-child,
-.repository .ui.attached.isSigned.isVerifiedUntrusted.bottom,
-.repository .ui.attached.isSigned.isVerifiedUnmatched.bottom {
-  border-bottom: 1px solid var(--color-warning-border);
-}
-
 .repository .segment.reactions.dropdown .menu,
 .repository .select-reaction.dropdown .menu {
   right: 0 !important;
@@ -2813,15 +2727,6 @@ tbody.commit-list {
   .branch-dropdown-button {
     max-width: 165px;
   }
-}
-
-.commit-status-header {
-  /* reset the default ".ui.attached.header" styles, to use the outer border */
-  border: none !important;
-  /* add a bottom border to make sure the there is always a divider between the header and list when the list is scrolling */
-  border-bottom: 1px solid var(--color-secondary) !important;
-  /* use negative margin to avoid the newly added border conflict with the list's top border */
-  margin: 0 0 -1px !important;
 }
 
 .commit-status-list {

--- a/web_src/js/modules/tippy.js
+++ b/web_src/js/modules/tippy.js
@@ -172,6 +172,26 @@ export function initGlobalTooltips() {
   observerConnect(observer);
 
   attachChildrenLazyTooltip(document.documentElement);
+  attachTippyTriggers();
+}
+
+// generic tippy creation via sibling elements:
+// <button class="tippy-trigger" data-tippy-theme="menu"></button>
+// <div class="tippy-target"></div>
+function attachTippyTriggers() {
+  for (const el of document.getElementsByClassName('tippy-trigger')) {
+    const nextSibling = el.nextElementSibling;
+    if (nextSibling?.matches('.tippy-target')) {
+      createTippy(el, {
+        trigger: el.getAttribute('data-tippy-trigger'),
+        role: el.getAttribute('data-tippy-role'),
+        theme: el.getAttribute('data-tippy-theme'),
+        interactive: el.getAttribute('data-tippy-interactive') === 'true',
+        hideOnClick: el.getAttribute('data-tippy-hideOnClick') === 'true',
+        content: nextSibling,
+      });
+    }
+  }
 }
 
 export function showTemporaryTooltip(target, content) {


### PR DESCRIPTION
Part of https://github.com/go-gitea/gitea/issues/29641.

Commit page header is now always uncolored and the signature status is shown by a new icon:
<img width="1299" alt="Screenshot 2024-04-01 at 02 10 15" src="https://github.com/go-gitea/gitea/assets/115237/e999f6b1-aa45-4bbd-9e58-abcd1f527109">

<img width="346" alt="Screenshot 2024-04-01 at 02 12 46" src="https://github.com/go-gitea/gitea/assets/115237/05dfa602-637e-40f0-b567-3b54bfc41b7e">

<img width="434" alt="Screenshot 2024-04-01 at 01 55 43" src="https://github.com/go-gitea/gitea/assets/115237/e7317899-ab84-459b-89c9-934c4c93a8d6">

