### PR TITLE
Add e2e install testing

### DIFF
--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -82,19 +82,19 @@
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
 								<label>{{ctx.Locale.Tr "install.reinstall_confirm_check_1"}}</label>
-								<input name="reinstall_confirm_first" type="checkbox">
+								<input name="reinstall_confirm_first" data-testid="reinstall_confirm_first" type="checkbox">
 							</div>
 						</div>
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
 								<label>{{ctx.Locale.Tr "install.reinstall_confirm_check_2"}}</label>
-								<input name="reinstall_confirm_second" type="checkbox">
+								<input name="reinstall_confirm_second" data-testid="reinstall_confirm_second" type="checkbox">
 							</div>
 						</div>
 						<div class="reinstall-confirm">
 							<div class="ui checkbox">
 								<label>{{ctx.Locale.Tr "install.reinstall_confirm_check_3"}}</label>
-								<input name="reinstall_confirm_third" type="checkbox">
+								<input name="reinstall_confirm_third" data-testid="reinstall_confirm_third" type="checkbox">
 							</div>
 						</div>
 					</div>

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -106,6 +106,7 @@ func TestE2e(t *testing.T) {
 		// Load install routes for tests inside that folder
 		if strings.Contains(path, "install/") {
 			testE2eWebRoutes = install.Routes()
+			setting.InstallLock = false
 		} else {
 			testE2eWebRoutes = routers.NormalRoutes()
 		}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -101,7 +101,8 @@ func TestE2e(t *testing.T) {
 		_, filename := filepath.Split(path)
 		testname := filename[:len(filename)-len(filepath.Ext(path))]
 
-		runArgs := append(runCommand, path)
+		runArgs := runCommand
+		runArgs = append(runArgs, path)
 
 		// Load install routes for tests inside that folder
 		if strings.Contains(path, "install/") {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -85,7 +85,7 @@ func TestE2e(t *testing.T) {
 		t.Fatal(fmt.Errorf("No e2e tests found in %s", searchGlob))
 	}
 
-	// Also search subdirectories (go globbing does now support the "**" wildcard)
+	// Also search subdirectories (go globbing does not support the "**" wildcard)
 	searchGlobSubdir := filepath.Join(filepath.Dir(setting.AppPath), "tests", "e2e", "*", "*.test.e2e.js")
 	pathsSubdir, _ := filepath.Glob(searchGlobSubdir)
 

--- a/tests/e2e/install/README.md
+++ b/tests/e2e/install/README.md
@@ -1,0 +1,3 @@
+# End to End Install Tests
+
+Tests in this directory will be run against the Gitea web installer

--- a/tests/e2e/install/install.test.e2e.js
+++ b/tests/e2e/install/install.test.e2e.js
@@ -1,0 +1,11 @@
+// @ts-check
+import {test, expect} from '@playwright/test';
+
+test('Load Install Page', async ({page}) => {
+  const response = await page.goto('/');
+
+  await expect(response?.status()).toBe(200); // Status OK
+  await expect(page).toHaveTitle(
+    /^Installation - Gitea: Git with a cup of tea\s*$/,
+  );
+});

--- a/tests/e2e/install/install.test.e2e.js
+++ b/tests/e2e/install/install.test.e2e.js
@@ -9,3 +9,38 @@ test('Load Install Page', async ({page}) => {
     /^Installation - Gitea: Git with a cup of tea\s*$/,
   );
 });
+
+test('Perform Install', async ({page}) => {
+  const response = await page.goto('/');
+
+  await expect(response?.status()).toBe(200); // Status OK
+  await expect(page).toHaveTitle(
+    /^Installation - Gitea: Git with a cup of tea\s*$/,
+  );
+
+  await page.getByRole('combobox').click();
+
+  await page.getByRole('option', {name: 'SQLite3'}).click();
+
+  // Past this point, testing the install page functionality runs into a few issues:
+  //  - The existing fixtures/setup don't handle various db stuff that install
+  //      performs (clobbers subsequent tests)
+  //  - Existing .ini and db files trigger the "reinstall" dialogue rather than normal install
+  //  - Successfully reinstalling seems to work, but the backend will drop the "install" routes
+  //      and is not setup to start the "normal" routes (thats something the CLI handles)
+  // Those are probably all resolvable but might take a larger re-work of the fixtures/setup logic
+
+  // await page.getByRole('button', {name: "Install Gitea"}).click();
+
+  // await expect(page.getByTestId('reinstall_confirm_first'), 'performs database checks').toBeVisible();
+
+  // await page.waitForLoadState('domcontentloaded');
+
+  // await page.getByTestId('reinstall_confirm_first').check();
+  // await page.getByTestId('reinstall_confirm_second').check();
+  // await page.getByTestId('reinstall_confirm_third').check();
+
+  // await page.getByRole('button', {name: "Install Gitea"}).click();
+
+  // await page.getByRole('link', { name: 'Loading…' });
+});

--- a/tests/e2e/install/install.test.e2e.js
+++ b/tests/e2e/install/install.test.e2e.js
@@ -28,6 +28,7 @@ test('Perform Install', async ({page}) => {
   //  - Existing .ini and db files trigger the "reinstall" dialogue rather than normal install
   //  - Successfully reinstalling seems to work, but the backend will drop the "install" routes
   //      and is not setup to start the "normal" routes (thats something the CLI handles)
+  //  - Playwright will run all browsers simultaneously which leads to race conditions between the test runs
   // Those are probably all resolvable but might take a larger re-work of the fixtures/setup logic
 
   // await page.getByRole('button', {name: "Install Gitea"}).click();


### PR DESCRIPTION
This pull request expands e2e testing to include the install page. 

#21490 is the parent issue, and these changes should hopefully catch future regressions of that nature. From what I can tell the actual error occurred during page rendering.

The ability to actually perform an install during e2e testing is limited at the moment. I've added more details inside the relevant test, but this is my first contribution and so I felt it might be helpful to get some feedback on the right approach to expanding the coverage.
