### PR TITLE
Show 12 lines in markup code preview

### DIFF
--- a/web_src/css/markup/codepreview.css
+++ b/web_src/css/markup/codepreview.css
@@ -12,7 +12,7 @@
 
 .markup .code-preview-container table {
   width: 100%;
-  max-height: 240px;
+  max-height: 240px; /* 12 lines at 20px per line */
   overflow-y: auto;
   margin: 0; /* override ".markup table {margin}" */
 }

--- a/web_src/css/markup/codepreview.css
+++ b/web_src/css/markup/codepreview.css
@@ -12,7 +12,7 @@
 
 .markup .code-preview-container table {
   width: 100%;
-  max-height: 100px;
+  max-height: 240px;
   overflow-y: auto;
   margin: 0; /* override ".markup table {margin}" */
 }


### PR DESCRIPTION
Show up to 12 lines instead of previous 5.

<img width="929" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/de68f200-b9e2-4a25-bd6e-c46849849620">
