### PR TITLE
fix: set proper go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.gitea.io/gitea
 
-go 1.22
+go 1.22.2
 
 require (
 	code.gitea.io/actions-proto-go v0.4.0


### PR DESCRIPTION
This still means go v1.22 is the minimum[^1], but pin the patch allows go tooling to automatically download a required version.

[^1]: https://go.dev/doc/toolchain#config
