### PR TITLE
Fix view commit link

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -1,92 +1,91 @@
 <div class="ui attached table segment commit-table">
-		<table class="ui very basic striped table unstackable" id="commits-table">
-			<thead>
+	<table class="ui very basic striped table unstackable" id="commits-table">
+		<thead>
+			<tr>
+				<th class="three wide">{{ctx.Locale.Tr "repo.commits.author"}}</th>
+				<th class="two wide sha">{{StringUtils.ToUpper $.Repository.ObjectFormatName}}</th>
+				<th class="eight wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
+				<th class="two wide right aligned">{{ctx.Locale.Tr "repo.commits.date"}}</th>
+				<th class="one wide"></th>
+			</tr>
+		</thead>
+		<tbody class="commit-list">
+			{{$commitRepoLink := $.RepoLink}}{{if $.CommitRepoLink}}{{$commitRepoLink = $.CommitRepoLink}}{{end}}
+			{{range .Commits}}
 				<tr>
-					<th class="three wide">{{ctx.Locale.Tr "repo.commits.author"}}</th>
-					<th class="two wide sha">{{StringUtils.ToUpper $.Repository.ObjectFormatName}}</th>
-					<th class="eight wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
-					<th class="two wide right aligned">{{ctx.Locale.Tr "repo.commits.date"}}</th>
-					<th class="one wide"></th>
-				</tr>
-			</thead>
-			<tbody class="commit-list">
-				{{$commitRepoLink := $.RepoLink}}{{if $.CommitRepoLink}}{{$commitRepoLink = $.CommitRepoLink}}{{end}}
-				{{range .Commits}}
-					<tr>
-						<td class="author tw-flex">
-							{{$userName := .Author.Name}}
-							{{if .User}}
-								{{if and .User.FullName DefaultShowFullName}}
-									{{$userName = .User.FullName}}
-								{{end}}
-								{{ctx.AvatarUtils.Avatar .User 28 "tw-mr-2"}}<a class="muted author-wrapper" href="{{.User.HomeLink}}">{{$userName}}</a>
-							{{else}}
-								{{ctx.AvatarUtils.AvatarByEmail .Author.Email .Author.Name 28 "tw-mr-2"}}
-								<span class="author-wrapper">{{$userName}}</span>
+					<td class="author tw-flex">
+						{{$userName := .Author.Name}}
+						{{if .User}}
+							{{if and .User.FullName DefaultShowFullName}}
+								{{$userName = .User.FullName}}
 							{{end}}
-						</td>
-						<td class="sha">
-							{{$class := "ui sha label"}}
-							{{if .Signature}}
-								{{$class = (print $class " isSigned")}}
-								{{if .Verification.Verified}}
-									{{if eq .Verification.TrustStatus "trusted"}}
-										{{$class = (print $class " isVerified")}}
-									{{else if eq .Verification.TrustStatus "untrusted"}}
-										{{$class = (print $class " isVerifiedUntrusted")}}
-									{{else}}
-										{{$class = (print $class " isVerifiedUnmatched")}}
-									{{end}}
-								{{else if .Verification.Warning}}
-									{{$class = (print $class " isWarning")}}
-								{{end}}
-							{{end}}
-							{{$commitShaLink := ""}}
-							{{if $.PageIsWiki}}
-								{{$commitShaLink = (printf "%s/wiki/commit/%s" $commitRepoLink (PathEscape .ID.String))}}
-							{{else if $.PageIsPullCommits}}
-								{{$commitShaLink = (printf "%s/pulls/%d/commits/%s" $commitRepoLink $.Issue.Index (PathEscape .ID.String))}}
-							{{else if $.Reponame}}
-								{{$commitShaLink = (printf "%s/commit/%s" $commitRepoLink (PathEscape .ID.String))}}
-							{{end}}
-							<a {{if $commitShaLink}}href="{{$commitShaLink}}"{{end}} class="{{$class}}">
-								<span class="shortsha">{{ShortSha .ID.String}}</span>
-								{{if .Signature}}{{template "repo/shabox_badge" dict "root" $ "verification" .Verification}}{{end}}
-							</a>
-						</td>
-						<td class="message">
-							<span class="message-wrapper">
-							{{if $.PageIsWiki}}
-								<span class="commit-summary {{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary | RenderEmoji $.Context}}</span>
-							{{else}}
-								{{$commitLink:= printf "%s/commit/%s" $commitRepoLink (PathEscape .ID.String)}}
-								<span class="commit-summary {{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{RenderCommitMessageLinkSubject $.Context .Message $commitLink ($.Repository.ComposeMetas ctx)}}</span>
-							{{end}}
-							</span>
-							{{if IsMultilineCommitMessage .Message}}
-							<button class="ui button js-toggle-commit-body ellipsis-button" aria-expanded="false">...</button>
-							{{end}}
-							{{template "repo/commit_statuses" dict "Status" .Status "Statuses" .Statuses}}
-							{{if IsMultilineCommitMessage .Message}}
-							<pre class="commit-body tw-hidden">{{RenderCommitBody $.Context .Message ($.Repository.ComposeMetas ctx)}}</pre>
-							{{end}}
-						</td>
-						{{if .Committer}}
-							<td class="text right aligned">{{TimeSince .Committer.When ctx.Locale}}</td>
+							{{ctx.AvatarUtils.Avatar .User 28 "tw-mr-2"}}<a class="muted author-wrapper" href="{{.User.HomeLink}}">{{$userName}}</a>
 						{{else}}
-							<td class="text right aligned">{{TimeSince .Author.When ctx.Locale}}</td>
+							{{ctx.AvatarUtils.AvatarByEmail .Author.Email .Author.Name 28 "tw-mr-2"}}
+							<span class="author-wrapper">{{$userName}}</span>
 						{{end}}
-						<td class="text right aligned tw-py-0">
-							<button class="btn interact-bg tw-p-2" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
-							<a
-								class="btn interact-bg tw-p-2"
-								data-tooltip-content="{{ctx.Locale.Tr "repo.commits.view_path"}}"
-								href="{{if $.FileName}}{{printf "%s/src/commit/%s/%s" $commitRepoLink (PathEscape .ID.String) (PathEscapeSegments $.FileName)}}{{else}}{{printf "%s/src/commit/%s" $commitRepoLink (PathEscape .ID.String)}}{{end}}">
-								{{svg "octicon-file-code"}}
-							</a>
-						</td>
-					</tr>
-				{{end}}
-			</tbody>
-		</table>
-	</div>
+					</td>
+					<td class="sha">
+						{{$class := "ui sha label"}}
+						{{if .Signature}}
+							{{$class = (print $class " isSigned")}}
+							{{if .Verification.Verified}}
+								{{if eq .Verification.TrustStatus "trusted"}}
+									{{$class = (print $class " isVerified")}}
+								{{else if eq .Verification.TrustStatus "untrusted"}}
+									{{$class = (print $class " isVerifiedUntrusted")}}
+								{{else}}
+									{{$class = (print $class " isVerifiedUnmatched")}}
+								{{end}}
+							{{else if .Verification.Warning}}
+								{{$class = (print $class " isWarning")}}
+							{{end}}
+						{{end}}
+						{{$commitShaLink := ""}}
+						{{if $.PageIsWiki}}
+							{{$commitShaLink = (printf "%s/wiki/commit/%s" $commitRepoLink (PathEscape .ID.String))}}
+						{{else if $.PageIsPullCommits}}
+							{{$commitShaLink = (printf "%s/pulls/%d/commits/%s" $commitRepoLink $.Issue.Index (PathEscape .ID.String))}}
+						{{else if $.Reponame}}
+							{{$commitShaLink = (printf "%s/commit/%s" $commitRepoLink (PathEscape .ID.String))}}
+						{{end}}
+						<a {{if $commitShaLink}}href="{{$commitShaLink}}"{{end}} class="{{$class}}">
+							<span class="shortsha">{{ShortSha .ID.String}}</span>
+							{{if .Signature}}{{template "repo/shabox_badge" dict "root" $ "verification" .Verification}}{{end}}
+						</a>
+					</td>
+					<td class="message">
+						<span class="message-wrapper">
+						{{if $.PageIsWiki}}
+							<span class="commit-summary {{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{.Summary | RenderEmoji $.Context}}</span>
+						{{else}}
+							{{$commitLink:= printf "%s/commit/%s" $commitRepoLink (PathEscape .ID.String)}}
+							<span class="commit-summary {{if gt .ParentCount 1}} grey text{{end}}" title="{{.Summary}}">{{RenderCommitMessageLinkSubject $.Context .Message $commitLink ($.Repository.ComposeMetas ctx)}}</span>
+						{{end}}
+						</span>
+						{{if IsMultilineCommitMessage .Message}}
+						<button class="ui button js-toggle-commit-body ellipsis-button" aria-expanded="false">...</button>
+						{{end}}
+						{{template "repo/commit_statuses" dict "Status" .Status "Statuses" .Statuses}}
+						{{if IsMultilineCommitMessage .Message}}
+						<pre class="commit-body tw-hidden">{{RenderCommitBody $.Context .Message ($.Repository.ComposeMetas ctx)}}</pre>
+						{{end}}
+					</td>
+					{{if .Committer}}
+						<td class="text right aligned">{{TimeSince .Committer.When ctx.Locale}}</td>
+					{{else}}
+						<td class="text right aligned">{{TimeSince .Author.When ctx.Locale}}</td>
+					{{end}}
+					<td class="text right aligned tw-py-0">
+						<button class="btn interact-bg tw-p-2" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
+						{{if not $.PageIsWiki}}{{/* at the moment, wiki doesn't support "view at history point*/}}
+							{{$viewCommitLink := printf "%s/src/commit/%s" $commitRepoLink (PathEscape .ID.String)}}
+							{{if $.FileName}}{{$viewCommitLink = printf "%s/%s" $viewCommitLink (PathEscapeSegments $.FileName)}}{{end}}
+							<a class="btn interact-bg tw-p-2" data-tooltip-content="{{ctx.Locale.Tr "repo.commits.view_path"}}" href="{{$viewCommitLink}}">{{svg "octicon-file-code"}}</a>
+						{{end}}
+					</td>
+				</tr>
+			{{end}}
+		</tbody>
+	</table>
+</div>


### PR DESCRIPTION
Fix #30098 

Major changes:

1. Do not show the "view at history point" button for wiki pages (because the wiki doesn't support it)
2. Reformat the code, because the old code is strangely indented (please compare by ignoring spaces https://github.com/go-gitea/gitea/pull/30297/files?diff=split&w=1)