### PR TITLE
When redirecting URLs in Oauth contain query parameters, there is an issue with correctly detecting whether the URL is legal or not. 

### DIFF
--- a/models/auth/oauth2.go
+++ b/models/auth/oauth2.go
@@ -138,6 +138,9 @@ func (app *OAuth2Application) TableName() string {
 // ContainsRedirectURI checks if redirectURI is allowed for app
 func (app *OAuth2Application) ContainsRedirectURI(redirectURI string) bool {
 	contains := func(s string) bool {
+		if idx := strings.Index(s, "?"); idx > 0 {
+			s = s[:idx]
+		}
 		s = strings.TrimSuffix(strings.ToLower(s), "/")
 		for _, u := range app.RedirectURIs {
 			if strings.TrimSuffix(strings.ToLower(u), "/") == s {


### PR DESCRIPTION
fix https://github.com/go-gitea/gitea/issues/26897


修复 Oauth 中重定向 url 中包含 query 参数时，不能正确地检测该 url 是否法的问题
When redirecting URLs in Oauth contain query parameters, there is an issue with correctly detecting whether the URL is legal or not. 
