### PR TITLE
Fix label-list rendering in timeline, decrease gap

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -2274,9 +2274,9 @@
 }
 
 .labels-list {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: 0.25em;
+  gap: 2.5px;
 }
 
 .labels-list a {


### PR DESCRIPTION
Not sure exactly when this regressed, but has been a while I think.

Before:

<img width="895" alt="Screenshot 2024-04-08 at 22 46 50" src="https://github.com/go-gitea/gitea/assets/115237/9b1788f8-017e-4fe1-8ab9-938e0d76fb41">

After:

<img width="689" alt="Screenshot 2024-04-08 at 23 00 58" src="https://github.com/go-gitea/gitea/assets/115237/90193df9-5c24-4a1a-96fe-3d4e8392063c">