### PR TITLE
Reduce checkbox size to 15px

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -23,7 +23,7 @@
   --height-loading: 16rem;
   --min-height-textarea: 132px; /* padding + 6 lines + border = calc(1.57142em + 6lh + 2px), but lh is not fully supported */
   --tab-size: 4;
-  --checkbox-size: 16px; /* height and width of checkbox and radio inputs */
+  --checkbox-size: 15px; /* height and width of checkbox and radio inputs */
   --page-spacing: 16px; /* space between page elements */
 }
 

--- a/web_src/css/modules/checkbox.css
+++ b/web_src/css/modules/checkbox.css
@@ -20,7 +20,7 @@ input[type="radio"] {
 .ui.checkbox input[type="checkbox"],
 .ui.checkbox input[type="radio"] {
   position: absolute;
-  top: 0;
+  top: 1px;
   left: 0;
   width: var(--checkbox-size);
   height: var(--checkbox-size);


### PR DESCRIPTION
16 seems to big, 14 too small. Let's do 15. Alignment:

<img width="181" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/f2988611-dee2-492e-a18f-dc5ab3a1cd6c">

