### PR TITLE
Fix line height on inline code preview

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1242,6 +1242,7 @@ overflow-menu .ui.label {
   white-space: pre-wrap;
   word-break: break-all;
   overflow-wrap: anywhere;
+  line-height: inherit; /* needed for inline code preview in markup */
 }
 
 .blame .code-inner {


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/30353.

I don't know what causes `code-inner` to not inherit `line-height` from its direct parent `.lines-code` but instead from grandparent `.markup` even thought MDN tells me it's [inherited](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#formal_definition). This causes no negative impact on other code views, so I think it's the best solution.