### PR TITLE
Fix admin notice view-detail

### DIFF
--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -62,10 +62,7 @@
 
 <div class="ui modal admin" id="detail-modal">
 	<div class="header">{{ctx.Locale.Tr "admin.notices.view_detail_header"}}</div>
-	<div class="content">
-		<div class="sub header"></div>
-		<pre></pre>
-	</div>
+	<div class="content"><pre></pre></div>
 </div>
 
 {{template "admin/layout_footer" .}}

--- a/web_src/js/features/admin/common.js
+++ b/web_src/js/features/admin/common.js
@@ -207,13 +207,13 @@ export function initAdminCommon() {
 
   // Notice
   if (document.querySelector('.admin.notice')) {
-    const $detailModal = document.getElementById('detail-modal');
+    const detailModal = document.getElementById('detail-modal');
 
     // Attach view detail modals
     $('.view-detail').on('click', function () {
-      $detailModal.find('.content pre').text($(this).parents('tr').find('.notice-description').text());
-      $detailModal.find('.sub.header').text(this.closest('tr')?.querySelector('relative-time')?.getAttribute('title'));
-      $detailModal.modal('show');
+      const description = this.closest('tr').querySelector('.notice-description').textContent;
+      detailModal.querySelector('.content pre').textContent = description;
+      $(detailModal).modal('show');
       return false;
     });
 


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/issues/30434, regression from https://github.com/go-gitea/gitea/pull/30115.

I also removed the date insertion into the modal which was also broken since that date was switched to `absolute-date` because I see no real purpose to putting that date into the modal.

Result:

<img width="1038" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/aa2eb8b4-73dc-4d98-9b80-3f276f89d9e5">
