### PR TITLE
Add `/public/assets/img/webpack` to ignore files again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -95,7 +95,7 @@ cpu.out
 /.air
 /.go-licenses
 
-# Folders that previously existed
+# Files and folders that previously existed
 /public/assets/img/webpack
 
 # Snapcraft

--- a/.dockerignore
+++ b/.dockerignore
@@ -95,6 +95,9 @@ cpu.out
 /.air
 /.go-licenses
 
+# Folders that previously existed
+/public/assets/img/webpack
+
 # Snapcraft
 snap/.snapcraft/
 parts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -95,7 +95,7 @@ cpu.out
 /.air
 /.go-licenses
 
-# Files and folders that previously existed
+# Files and folders that were previously generated
 /public/assets/img/webpack
 
 # Snapcraft

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ cpu.out
 /.air
 /.go-licenses
 
+# Folders that previously existed
+/public/assets/img/webpack
+
 # Snapcraft
 /gitea_a*.txt
 snap/.snapcraft/

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ cpu.out
 /.air
 /.go-licenses
 
-# Files and folders that previously existed
+# Files and folders that were previously generated
 /public/assets/img/webpack
 
 # Snapcraft

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ cpu.out
 /.air
 /.go-licenses
 
-# Folders that previously existed
+# Files and folders that previously existed
 /public/assets/img/webpack
 
 # Snapcraft


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/30442

It's inconvenient to have new untracked files show up in git when switching to older branches that had generated them.

Introduce a list of such files and folders to gitignore and dockerignore.