### PR TITLE
Fix JS error when opening to expanded code comment

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -449,10 +449,8 @@ export function initRepoPullRequestReview() {
           offset += $('.diff-detail-box').outerHeight() + $(diffHeader).outerHeight();
         }
 
-        document.getElementById(`show-outdated-${id}`)?.classList.add('tw-hidden');
-        document.getElementById(`code-comments-${id}`)?.classList.remove('tw-hidden');
-        document.getElementById(`code-preview-${id}`)?.classList.remove('tw-hidden');
-        document.getElementById(`hide-outdated-${id}`)?.classList.remove('tw-hidden');
+        hideElem(`#show-outdated-${id}`);
+        showElem(`#code-comments-${id}, #code-preview-${id}, #hide-outdated-${id}`);
         // if the comment box is folded, expand it
         if (ancestorDiffBox?.getAttribute('data-folded') === 'true') {
           setFileFolding(ancestorDiffBox, ancestorDiffBox.querySelector('.fold-file'), false);

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -449,12 +449,12 @@ export function initRepoPullRequestReview() {
           offset += $('.diff-detail-box').outerHeight() + $(diffHeader).outerHeight();
         }
 
-        document.getElementById(`show-outdated-${id}`).classList.add('tw-hidden');
-        document.getElementById(`code-comments-${id}`).classList.remove('tw-hidden');
-        document.getElementById(`code-preview-${id}`).classList.remove('tw-hidden');
-        document.getElementById(`hide-outdated-${id}`).classList.remove('tw-hidden');
+        document.getElementById(`show-outdated-${id}`)?.classList.add('tw-hidden');
+        document.getElementById(`code-comments-${id}`)?.classList.remove('tw-hidden');
+        document.getElementById(`code-preview-${id}`)?.classList.remove('tw-hidden');
+        document.getElementById(`hide-outdated-${id}`)?.classList.remove('tw-hidden');
         // if the comment box is folded, expand it
-        if (ancestorDiffBox.getAttribute('data-folded') === 'true') {
+        if (ancestorDiffBox?.getAttribute('data-folded') === 'true') {
           setFileFolding(ancestorDiffBox, ancestorDiffBox.querySelector('.fold-file'), false);
         }
 


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/commit/e0b018706fa7703ef1759d9a75a1399383715808 where opening to a code comment via hash link would give this error:

<img width="1247" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/f9aaeded-8492-4416-9a73-afa0c56220a7">
