### PR TITLE
Fix button color on red and green buttons

### DIFF
--- a/web_src/css/modules/button.css
+++ b/web_src/css/modules/button.css
@@ -249,6 +249,7 @@
 
 .ui.red.button,
 .ui.red.buttons .button {
+  color: var(--color-white);
   background: var(--color-red);
 }
 
@@ -283,6 +284,7 @@
 
 .ui.green.button,
 .ui.green.buttons .button {
+  color: var(--color-white);
   background: var(--color-green);
 }
 


### PR DESCRIPTION
Previously these colors were provided by fomantic css. I missed them.

Fixes: https://github.com/go-gitea/gitea/issues/30499
Regressed by: https://github.com/go-gitea/gitea/pull/30475