### PR TITLE
Fix cache bug

### DIFF
--- a/services/repository/commitstatus/commitstatus.go
+++ b/services/repository/commitstatus/commitstatus.go
@@ -32,6 +32,9 @@ type commitStatusCacheValue struct {
 
 func getCommitStatusCache(repoID int64, branchName string) *commitStatusCacheValue {
 	c := cache.GetCache()
+	if c == nil {
+		return nil
+	}
 	statusStr, ok := c.Get(getCacheKey(repoID, branchName)).(string)
 	if ok && statusStr != "" {
 		var cv commitStatusCacheValue
@@ -48,6 +51,9 @@ func getCommitStatusCache(repoID int64, branchName string) *commitStatusCacheVal
 
 func updateCommitStatusCache(repoID int64, branchName string, state api.CommitStatusState, targetURL string) error {
 	c := cache.GetCache()
+	if c == nil {
+		return nil
+	}
 	bs, err := json.Marshal(commitStatusCacheValue{
 		State:     state.String(),
 		TargetURL: targetURL,


### PR DESCRIPTION
Cache cannot be disabled from v1.22. So it still maybe `nil` in v1.21, we have to check whether cache is `nil`.