### PR TITLE
Refactor and fix archive link bug

### DIFF
--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -69,6 +69,10 @@ export function queryElemChildren(parent, selector = '*', fn) {
   return applyElemsCallback(parent.querySelectorAll(`:scope > ${selector}`), fn);
 }
 
+export function queryElems(selector, fn) {
+  return applyElemsCallback(document.querySelectorAll(selector), fn);
+}
+
 export function onDomReady(cb) {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', cb);


### PR DESCRIPTION
Regression of #29920
Fixes: https://github.com/go-gitea/gitea/issues/30569

Also this is a rewriting to eliminate the remaining jQuery usages from code.