### PR TITLE
Fixup app.example.ini for task section, which is now queue.task

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1433,44 +1433,6 @@ LEVEL = Info
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;[queue]
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; Specific queues can be individually configured with [queue.name]. [queue] provides defaults
-;; ([queue.issue_indexer] is special due to the old configuration described above)
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; General queue queue type, currently support: persistable-channel, channel, level, redis, dummy
-;; default to persistable-channel
-;TYPE = persistable-channel
-;;
-;; data-dir for storing persistable queues and level queues, individual queues will default to `queues/common` meaning the queue is shared.
-;DATADIR = queues/ ; Relative paths will be made absolute against `%(APP_DATA_PATH)s`.
-;;
-;; Default queue length before a channel queue will block
-;LENGTH = 100000
-;;
-;; Batch size to send for batched queues
-;BATCH_LENGTH = 20
-;;
-;; Connection string for redis queues this will store the redis or redis-cluster connection string.
-;; When `TYPE` is `persistable-channel`, this provides a directory for the underlying leveldb
-;; or additional options of the form `leveldb://path/to/db?option=value&....`, and will override `DATADIR`.
-;CONN_STR = "redis://127.0.0.1:6379/0"
-;;
-;; Provides the suffix of the default redis/disk queue name - specific queues can be overridden within in their [queue.name] sections.
-;QUEUE_NAME = "_queue"
-;;
-;; Provides the suffix of the default redis/disk unique queue set name - specific queues can be overridden within in their [queue.name] sections.
-;SET_NAME = "_unique"
-;;
-;; Maximum number of worker go-routines for the queue. Default value is "CpuNum/2" clipped to between 1 and 10.
-;MAX_WORKERS = ; (dynamic)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;[admin]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1433,6 +1433,44 @@ LEVEL = Info
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[queue]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Specific queues can be individually configured with [queue.name]. [queue] provides defaults
+;; ([queue.issue_indexer] is special due to the old configuration described above)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; General queue queue type, currently support: persistable-channel, channel, level, redis, dummy
+;; default to persistable-channel
+;TYPE = persistable-channel
+;;
+;; data-dir for storing persistable queues and level queues, individual queues will default to `queues/common` meaning the queue is shared.
+;DATADIR = queues/ ; Relative paths will be made absolute against `%(APP_DATA_PATH)s`.
+;;
+;; Default queue length before a channel queue will block
+;LENGTH = 100000
+;;
+;; Batch size to send for batched queues
+;BATCH_LENGTH = 20
+;;
+;; Connection string for redis queues this will store the redis or redis-cluster connection string.
+;; When `TYPE` is `persistable-channel`, this provides a directory for the underlying leveldb
+;; or additional options of the form `leveldb://path/to/db?option=value&....`, and will override `DATADIR`.
+;CONN_STR = "redis://127.0.0.1:6379/0"
+;;
+;; Provides the suffix of the default redis/disk queue name - specific queues can be overridden within in their [queue.name] sections.
+;QUEUE_NAME = "_queue"
+;;
+;; Provides the suffix of the default redis/disk unique queue set name - specific queues can be overridden within in their [queue.name] sections.
+;SET_NAME = "_unique"
+;;
+;; Maximum number of worker go-routines for the queue. Default value is "CpuNum/2" clipped to between 1 and 10.
+;MAX_WORKERS = ; (dynamic)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;[admin]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2338,22 +2376,6 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;[queue.task]
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; Task queue type, could be `channel` or `redis`.
-;TYPE = channel
-;;
-;; Task queue length, available only when `QUEUE_TYPE` is `channel`.
-;LENGTH = 1000
-;;
-;; Task queue connection string, available only when `QUEUE_TYPE` is `redis`.
-;; If there is a password of redis, use `redis://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s` or `redis+cluster://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s` for `redis-clsuter`.
-;CONN_STR = "redis://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2379,19 +2379,19 @@ LEVEL = Info
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;[task]
+;[queue.task]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Task queue type, could be `channel` or `redis`.
-;QUEUE_TYPE = channel
+;TYPE = channel
 ;;
 ;; Task queue length, available only when `QUEUE_TYPE` is `channel`.
-;QUEUE_LENGTH = 1000
+;LENGTH = 1000
 ;;
 ;; Task queue connection string, available only when `QUEUE_TYPE` is `redis`.
 ;; If there is a password of redis, use `redis://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s` or `redis+cluster://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s` for `redis-clsuter`.
-;QUEUE_CONN_STR = "redis://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s"
+;CONN_STR = "redis://127.0.0.1:6379/0?pool_size=100&idle_timeout=180s"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1198,14 +1198,6 @@ in this mapping or the filetype using heuristics.
 
 - `DEFAULT_UI_LOCATION`: Default location of time on the UI, so that we can display correct user's time on UI. i.e. Asia/Shanghai
 
-## Task (`task`)
-
-Task queue configuration has been moved to `queue.task`. However, the below configuration values are kept for backwards compatibility:
-
-- `QUEUE_TYPE`: **channel**: Task queue type, could be `channel` or `redis`.
-- `QUEUE_LENGTH`: **1000**: Task queue length, available only when `QUEUE_TYPE` is `channel`.
-- `QUEUE_CONN_STR`: **redis://127.0.0.1:6379/0**: Task queue connection string, available only when `QUEUE_TYPE` is `redis`. If redis needs a password, use `redis://123@127.0.0.1:6379/0` or `redis+cluster://123@127.0.0.1:6379/0`.
-
 ## Migrations (`migrations`)
 
 - `MAX_ATTEMPTS`: **3**: Max attempts per http/https request on migrations.

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -1128,15 +1128,6 @@ ALLOW_DATA_URI_IMAGES = true
 
 - `DEFAULT_UI_LOCATION`：在 UI 上的默认时间位置，以便我们可以在 UI 上显示正确的用户时间。例如：Asia/Shanghai
 
-## 任务 (`task`)
-
-任务队列配置已移动到 `queue.task`。然而，以下配置值仍保留以确保向后兼容：
-
-- `QUEUE_TYPE`：**channel**：任务队列类型，可以是 `channel` 或 `redis`。
-- `QUEUE_LENGTH`：**1000**：任务队列长度，仅在 `QUEUE_TYPE` 为 `channel` 时可用。
-- `QUEUE_CONN_STR`：**redis://127.0.0.1:6379/0**：任务队列连接字符串，仅在 `QUEUE_TYPE` 为 `redis` 时可用。
-  如果 redis 需要密码，使用 `redis://123@127.0.0.1:6379/0` 或 `redis+cluster://123@127.0.0.1:6379/0`。
-
 ## 迁移 (`migrations`)
 
 - `MAX_ATTEMPTS`：**3**：每次 http/https 请求的最大尝试次数（用于迁移）。


### PR DESCRIPTION
I am running gitea v1.21.11 and was using the `app.example.ini` from git on the previous tag. It seems `[task]` has been deprecated in favor of `[queue.task]`. See #30554 
