### PR TITLE
Remove `normal` CSS class

### DIFF
--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -65,7 +65,7 @@
 					</div>
 					<div class="inline field">
 						<label>{{ctx.Locale.Tr "repo.template"}}</label>
-						<div id="repo_template_search" class="ui search normal selection dropdown">
+						<div id="repo_template_search" class="ui search selection dropdown">
 							<input type="hidden" id="repo_template" name="repo_template" value="{{.repo_template}}">
 							<div class="default text">{{.repo_template_name}}</div>
 							<div class="menu">
@@ -119,7 +119,7 @@
 					<div id="non_template">
 						<div class="inline field">
 							<label>{{ctx.Locale.Tr "repo.issue_labels"}}</label>
-							<div class="ui search normal selection dropdown">
+							<div class="ui search selection dropdown">
 								<input type="hidden" name="issue_labels" value="{{.issueLabels}}">
 								<div class="default text">{{ctx.Locale.Tr "repo.issue_labels_helper"}}</div>
 								<div class="menu">
@@ -135,7 +135,7 @@
 
 						<div class="inline field">
 							<label>.gitignore</label>
-							<div class="ui multiple search normal selection dropdown">
+							<div class="ui multiple search selection dropdown">
 								<input type="hidden" name="gitignores" value="{{.gitignores}}">
 								<div class="default text">{{ctx.Locale.Tr "repo.repo_gitignore_helper"}}</div>
 								<div class="menu">

--- a/templates/repo/file_info.tmpl
+++ b/templates/repo/file_info.tmpl
@@ -1,4 +1,4 @@
-<div class="file-info text grey normal tw-font-mono">
+<div class="file-info tw-font-mono">
 	{{if .FileIsSymlink}}
 		<div class="file-info-entry">
 			{{ctx.Locale.Tr "repo.symbolic_link"}}

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -702,10 +702,6 @@ input:-webkit-autofill:active,
   text-align: right !important;
 }
 
-.ui .text.normal {
-  font-weight: var(--font-weight-normal);
-}
-
 .ui .text.italic {
   font-style: italic;
 }


### PR DESCRIPTION
This class had exactly one use and it wasn't even needed. I searched fomantic sources and it's not part of it.

<img width="243" alt="Screenshot 2024-04-18 at 21 38 51" src="https://github.com/go-gitea/gitea/assets/115237/330febf5-08c2-4044-ae11-6ecfde7b1215">
