### PR TITLE
Enable npm cache on `setup-node` action (#30577)

### DIFF
--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend
       - run: make lint-swagger
 
@@ -130,6 +132,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend
       - run: make lint-frontend
       - run: make checks-frontend
@@ -177,6 +181,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend
       - run: make lint-md
       - run: make docs

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend frontend deps-backend
       - run: npx playwright install --with-deps
       - run: make test-e2e-sqlite

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: "~1.21"
           check-latest: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend deps-backend
       # xgo build
       - run: make release

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: "~1.21"
           check-latest: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend deps-backend
       # xgo build
       - run: make release

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: "~1.21"
           check-latest: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: make deps-frontend deps-backend
       # xgo build
       - run: make release

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: "~1.21"
           check-latest: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
Backport #30577 

Enable npm dependency cache in
[setup-node](https://github.com/actions/setup-node). This should work reliably and across branches as well.
