### PR TITLE
Fix project description rendering for org (#30587)

### DIFF
--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -19,6 +19,7 @@ import (
 	"code.gitea.io/gitea/modules/context"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/templates"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	shared_user "code.gitea.io/gitea/routers/web/shared/user"
@@ -100,7 +101,7 @@ func Projects(ctx *context.Context) {
 	}
 
 	for _, project := range projects {
-		project.RenderedContent = project.Description
+		project.RenderedContent = string(templates.RenderMarkdownToHtml(ctx, project.Description))
 	}
 
 	err = shared_user.LoadHeaderCount(ctx)
@@ -391,7 +392,7 @@ func ViewProject(ctx *context.Context) {
 		}
 	}
 
-	project.RenderedContent = project.Description
+	project.RenderedContent = string(templates.RenderMarkdownToHtml(ctx, project.Description))
 	ctx.Data["LinkedPRs"] = linkedPrsMap
 	ctx.Data["PageIsViewProjects"] = true
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)


### PR DESCRIPTION
Backport #30587

Manually tested with 1.21:


![image](https://github.com/go-gitea/gitea/assets/2114189/fbe9a2c9-0563-4d69-bcdb-8e5e41f288a1)
