### PR TITLE
Enable poetry cache in `setup-python`

### DIFF
--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: poetry
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: poetry
       - run: pip install poetry
       - run: make deps-py
       - run: make lint-yaml

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -41,7 +42,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: pip install poetry
       - run: make deps-py
       - run: make deps-frontend
       - run: make lint-templates
@@ -52,11 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: poetry
-      - run: pip install poetry
       - run: make deps-py
       - run: make lint-yaml
 


### PR DESCRIPTION
Same as the go and npm caches, for poetry dependencies. Followed [this](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages).