### PR TITLE
Fix dropdown text ellipsis

### DIFF
--- a/templates/repo/issue/view_content/reference_issue_dialog.tmpl
+++ b/templates/repo/issue/view_content/reference_issue_dialog.tmpl
@@ -2,13 +2,13 @@
 	<div class="header">
 		{{ctx.Locale.Tr "repo.issues.context.reference_issue"}}
 	</div>
-	<div class="content tw-text-left">
-		<form class="ui form form-fetch-action" action="{{printf "%s/issues/new" .Repository.Link}}" method="post">
+	<div class="content">
+		<form class="ui form form-fetch-action" action="{{.Repository.Link}}/issues/new" method="post">
 			{{.CsrfTokenHtml}}
 			<div class="field">
 				<label><strong>{{ctx.Locale.Tr "repository"}}</strong></label>
 				<div class="ui search selection dropdown issue_reference_repository_search">
-					<div class="default text">{{.Repository.FullName}}</div>
+					<div class="default text gt-ellipsis">{{.Repository.FullName}}</div>
 					<div class="menu"></div>
 				</div>
 			</div>
@@ -18,7 +18,7 @@
 			</div>
 			<div class="field">
 				<label><strong>{{ctx.Locale.Tr "repo.issues.reference_issue.body"}}</strong></label>
-				<textarea name="content" class="form-control"></textarea>
+				<textarea name="content"></textarea>
 			</div>
 			<div class="text right">
 				<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.create"}}</button>

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -391,12 +391,6 @@ a.label,
   color: var(--color-text-light-2);
 }
 
-.ui.dropdown > .text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 /* extend fomantic style '.ui.dropdown > .text > img' to include svg.img */
 .ui.dropdown > .text > .img {
   margin-left: 0;


### PR DESCRIPTION
Follow https://github.com/go-gitea/gitea/pull/30547#discussion_r1573866519

Fix #30624

The Fomantic UI Dropdown wasn't designed to work that way, its "text" element might contain images. So the "overflow" shouldn't be added to any general dropdown text.

![image](https://github.com/go-gitea/gitea/assets/2114189/f6ceaabd-bc89-4bf2-baa2-a6f0324c1962)
