### PR TITLE
Disallow merging except canceling the auto merge status

### DIFF
--- a/web_src/js/components/PullRequestMergeForm.vue
+++ b/web_src/js/components/PullRequestMergeForm.vue
@@ -138,7 +138,7 @@ export default {
 
     <div v-if="!showActionForm" class="tw-flex">
       <!-- the merge button -->
-      <div class="ui buttons merge-button" :class="[mergeForm.emptyCommit ? '' : mergeForm.allOverridableChecksOk ? 'primary' : 'red']" @click="toggleActionForm(true)">
+      <div v-if="!mergeForm.hasPendingPullRequestMerge" class="ui buttons merge-button" :class="[mergeForm.emptyCommit ? '' : mergeForm.allOverridableChecksOk ? 'primary' : 'red']" @click="toggleActionForm(true)">
         <button class="ui button">
           <svg-icon name="octicon-git-merge"/>
           <span class="button-text">


### PR DESCRIPTION
Before:
Users can click merge button even if a pull request is on the automerge status

<img width="982" alt="image" src="https://github.com/go-gitea/gitea/assets/81045/dac7e482-ee17-464b-98d3-ced70415f9fd">

After:
Users have to `cancel` the automerge status before click merge button.

<img width="982" alt="image" src="https://github.com/go-gitea/gitea/assets/81045/9eb1a5ed-c359-42db-b1a5-68b9b05c614f">
