### PR TITLE
Fix checkbox field markup

### DIFF
--- a/templates/user/settings/applications_oauth2_edit_form.tmpl
+++ b/templates/user/settings/applications_oauth2_edit_form.tmpl
@@ -41,9 +41,11 @@
 			<label for="redirect-uris">{{ctx.Locale.Tr "settings.oauth2_redirect_uris"}}</label>
 			<textarea name="redirect_uris" id="redirect-uris" required>{{StringUtils.Join .App.RedirectURIs "\n"}}</textarea>
 		</div>
-		<div class="field ui checkbox {{if .Err_ConfidentialClient}}error{{end}}">
-			<label>{{ctx.Locale.Tr "settings.oauth2_confidential_client"}}</label>
-			<input type="checkbox" name="confidential_client" {{if .App.ConfidentialClient}}checked{{end}}>
+		<div class="field {{if .Err_ConfidentialClient}}error{{end}}">
+			<div class="ui checkbox">
+				<label>{{ctx.Locale.Tr "settings.oauth2_confidential_client"}}</label>
+				<input type="checkbox" name="confidential_client" {{if .App.ConfidentialClient}}checked{{end}}>
+			</div>
 		</div>
 		<button class="ui primary button">
 			{{ctx.Locale.Tr "settings.save_application"}}

--- a/templates/user/settings/applications_oauth2_list.tmpl
+++ b/templates/user/settings/applications_oauth2_list.tmpl
@@ -61,9 +61,11 @@
 			<label for="redirect-uris">{{ctx.Locale.Tr "settings.oauth2_redirect_uris"}}</label>
 			<textarea name="redirect_uris" id="redirect-uris"></textarea>
 		</div>
-		<div class="field ui checkbox {{if .Err_ConfidentialClient}}error{{end}}">
-			<label>{{ctx.Locale.Tr "settings.oauth2_confidential_client"}}</label>
-			<input type="checkbox" name="confidential_client" checked>
+		<div class="field {{if .Err_ConfidentialClient}}error{{end}}">
+			<div class="ui checkbox">
+				<label>{{ctx.Locale.Tr "settings.oauth2_confidential_client"}}</label>
+				<input type="checkbox" name="confidential_client" checked>
+			</div>
 		</div>
 		<button class="ui primary button">
 			{{ctx.Locale.Tr "settings.create_oauth2_application_button"}}


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/30664.

Previous use was not a supported way by fomantic and the misuse only became visible after the checkbox migration.