### PR TITLE
Fix border-radius of header+segment boxes

### DIFF
--- a/web_src/css/modules/segment.css
+++ b/web_src/css/modules/segment.css
@@ -151,6 +151,11 @@
   border-top: none;
 }
 
+.ui.attached.segment:has(+ .ui[class*="top attached"].header),
+.ui.attached.segment:last-child {
+  border-radius: 0 0 0.28571429rem 0.28571429rem;
+}
+
 .ui[class*="top attached"].segment {
   bottom: 0;
   margin-bottom: 0;


### PR DESCRIPTION
This is a very old bug with the bottom border-radiuses not being there and the `:has` selector now makes it possible to cleanly solve it. It affects all header+segment boxes, which there are many throughout the UI:

<img width="1017" alt="Screenshot 2024-04-23 at 20 47 21" src="https://github.com/go-gitea/gitea/assets/115237/870fe352-cc38-4bd6-bfe6-9fe8c3066f92">
