### PR TITLE
Add linter for package-lock.json `resolved`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,10 +360,10 @@ lint: lint-frontend lint-backend lint-spell
 lint-fix: lint-frontend-fix lint-backend-fix lint-spell-fix
 
 .PHONY: lint-frontend
-lint-frontend: lint-js lint-css
+lint-frontend: lint-js lint-css lint-js-misc
 
 .PHONY: lint-frontend-fix
-lint-frontend-fix: lint-js-fix lint-css-fix
+lint-frontend-fix: lint-js-fix lint-css-fix lint-js-misc
 
 .PHONY: lint-backend
 lint-backend: lint-go lint-go-vet lint-editorconfig
@@ -378,6 +378,10 @@ lint-js: node_modules
 .PHONY: lint-js-fix
 lint-js-fix: node_modules
 	npx eslint --color --max-warnings=0 --ext js,vue $(ESLINT_FILES) --fix
+
+.PHONY: lint-js-misc
+lint-js-misc: node_modules
+	node tools/lint-lockfiles.js
 
 .PHONY: lint-css
 lint-css: node_modules

--- a/tools/lint-lockfiles.js
+++ b/tools/lint-lockfiles.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import {readFileSync} from 'node:fs';
+import {exit} from 'node:process';
+import {relative} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const files = [
+  '../package-lock.json',
+  '../web_src/fomantic/package-lock.json',
+];
+
+const rootPath = fileURLToPath(new URL('..', import.meta.url));
+let hadErrors = false;
+
+for (const file of files.map((file) => fileURLToPath(new URL(file, import.meta.url)))) {
+  const data = JSON.parse(readFileSync(file));
+  for (const [pkg, {resolved}] of Object.entries(data.packages)) {
+    if (resolved && !resolved.startsWith('https://registry.npmjs.org/')) {
+      console.info(`${relative(rootPath, file)}: Expected "resolved" on package ${pkg} to start with "https://registry.npmjs.org/"`);
+      hadErrors = true;
+    }
+  }
+}
+
+exit(hadErrors ? 1 : 0);

--- a/tools/lint-lockfiles.js
+++ b/tools/lint-lockfiles.js
@@ -12,6 +12,9 @@ const files = [
 const rootPath = fileURLToPath(new URL('..', import.meta.url));
 let hadErrors = false;
 
+// This checks that all "resolved" URLs in package-lock.json point to the official npm registry.
+// If a user is using a npm proxy (private or public), they would write that proxy's URL into
+// the file which we do not want because it could cause issues during installation.
 for (const file of files.map((file) => fileURLToPath(new URL(file, import.meta.url)))) {
   const data = JSON.parse(readFileSync(file));
   for (const [pkg, {resolved}] of Object.entries(data.packages)) {

--- a/tools/lint-templates-svg.js
+++ b/tools/lint-templates-svg.js
@@ -17,7 +17,7 @@ for (const file of fastGlob.sync(fileURLToPath(new URL('../templates/**/*.tmpl',
   const content = readFileSync(file, 'utf8');
   for (const [_, name] of content.matchAll(/svg ["'`]([^"'`]+)["'`]/g)) {
     if (!knownSvgs.has(name)) {
-      console.info(`SVG "${name}" not found, used in ${relative(rootPath, file)}`);
+      console.info(`${relative(rootPath, file)}: SVG "${name}" not found`);
       hadErrors = true;
     }
   }


### PR DESCRIPTION
If the user is using a npm proxy, the will write its URL into `package-lock.json`, like it happened in https://github.com/go-gitea/gitea/pull/28571, which may cause issues in the future in case npm ever decides to use of these URLs (currently it doesn't seem to).

Add this linter to ensure all URLs in the files start with `https://registry.npmjs.org/`.

Example error:

```
package-lock.json: Expected "resolved" on package node_modules/@aashutoshrathi/word-wrap to start with "https://registry.npmjs.org/"
```