### PR TITLE
Properly handle the name query param in create issue attachment API

### DIFF
--- a/models/repo/attachment.go
+++ b/models/repo/attachment.go
@@ -26,6 +26,7 @@ type Attachment struct {
 	UploaderID        int64  `xorm:"INDEX DEFAULT 0"` // Notice: will be zero before this column added
 	CommentID         int64  `xorm:"INDEX"`
 	Name              string
+	OriginalName      string             `xorm:"-"` // only used while its being created
 	DownloadCount     int64              `xorm:"DEFAULT 0"`
 	Size              int64              `xorm:"DEFAULT 0"`
 	CreatedUnix       timeutil.TimeStamp `xorm:"created"`

--- a/routers/api/v1/repo/issue_attachment.go
+++ b/routers/api/v1/repo/issue_attachment.go
@@ -178,11 +178,12 @@ func CreateIssueAttachment(ctx *context.APIContext) {
 		attachmentName = query
 	}
 
-	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
-		Name:       attachmentName,
-		UploaderID: ctx.Doer.ID,
-		RepoID:     ctx.Repo.Repository.ID,
-		IssueID:    issue.ID,
+	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, &repo_model.Attachment{
+		Name:         attachmentName,
+		OriginalName: header.Filename,
+		UploaderID:   ctx.Doer.ID,
+		RepoID:       ctx.Repo.Repository.ID,
+		IssueID:      issue.ID,
 	})
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "UploadAttachment", err)

--- a/routers/api/v1/repo/issue_attachment.go
+++ b/routers/api/v1/repo/issue_attachment.go
@@ -178,7 +178,7 @@ func CreateIssueAttachment(ctx *context.APIContext) {
 		attachmentName = query
 	}
 
-	attachment, err := attachment.UploadAttachmentWithCustomizableName(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
+	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
 		Name:       attachmentName,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,

--- a/routers/api/v1/repo/issue_attachment.go
+++ b/routers/api/v1/repo/issue_attachment.go
@@ -173,13 +173,13 @@ func CreateIssueAttachment(ctx *context.APIContext) {
 	}
 	defer file.Close()
 
-	filename := header.Filename
+	attachmentName := header.Filename
 	if query := ctx.FormString("name"); query != "" {
-		filename = query
+		attachmentName = query
 	}
 
-	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, &repo_model.Attachment{
-		Name:       filename,
+	attachment, err := attachment.UploadAttachmentWithCustomizableName(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
+		Name:       attachmentName,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		IssueID:    issue.ID,

--- a/routers/api/v1/repo/issue_comment_attachment.go
+++ b/routers/api/v1/repo/issue_comment_attachment.go
@@ -181,13 +181,13 @@ func CreateIssueCommentAttachment(ctx *context.APIContext) {
 	}
 	defer file.Close()
 
-	filename := header.Filename
+	attachmentName := header.Filename
 	if query := ctx.FormString("name"); query != "" {
-		filename = query
+		attachmentName = query
 	}
 
-	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, &repo_model.Attachment{
-		Name:       filename,
+	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
+		Name:       attachmentName,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		IssueID:    comment.IssueID,

--- a/routers/api/v1/repo/issue_comment_attachment.go
+++ b/routers/api/v1/repo/issue_comment_attachment.go
@@ -186,12 +186,13 @@ func CreateIssueCommentAttachment(ctx *context.APIContext) {
 		attachmentName = query
 	}
 
-	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, header.Filename, &repo_model.Attachment{
-		Name:       attachmentName,
-		UploaderID: ctx.Doer.ID,
-		RepoID:     ctx.Repo.Repository.ID,
-		IssueID:    comment.IssueID,
-		CommentID:  comment.ID,
+	attachment, err := attachment.UploadAttachment(ctx, file, setting.Attachment.AllowedTypes, header.Size, &repo_model.Attachment{
+		Name:         attachmentName,
+		OriginalName: header.Filename,
+		UploaderID:   ctx.Doer.ID,
+		RepoID:       ctx.Repo.Repository.ID,
+		IssueID:      comment.IssueID,
+		CommentID:    comment.ID,
 	})
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "UploadAttachment", err)

--- a/routers/api/v1/repo/release_attachment.go
+++ b/routers/api/v1/repo/release_attachment.go
@@ -206,7 +206,7 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 
 	// Get uploaded file from request
 	var content io.ReadCloser
-	var filename string
+	var attachmentName string
 	var size int64 = -1
 
 	if strings.HasPrefix(strings.ToLower(ctx.Req.Header.Get("Content-Type")), "multipart/form-data") {
@@ -219,23 +219,23 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 
 		content = file
 		size = header.Size
-		filename = header.Filename
+		attachmentName = header.Filename
 		if name := ctx.FormString("name"); name != "" {
-			filename = name
+			attachmentName = name
 		}
 	} else {
 		content = ctx.Req.Body
-		filename = ctx.FormString("name")
+		attachmentName = ctx.FormString("name")
 	}
 
-	if filename == "" {
+	if attachmentName == "" {
 		ctx.Error(http.StatusBadRequest, "CreateReleaseAttachment", "Could not determine name of attachment.")
 		return
 	}
 
 	// Create a new attachment and save the file
-	attach, err := attachment.UploadAttachment(ctx, content, setting.Repository.Release.AllowedTypes, size, &repo_model.Attachment{
-		Name:       filename,
+	attach, err := attachment.UploadAttachment(ctx, content, setting.Repository.Release.AllowedTypes, size, attachmentName, &repo_model.Attachment{
+		Name:       attachmentName,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		ReleaseID:  releaseID,

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -45,7 +45,7 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	}
 	defer file.Close()
 
-	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, &repo_model.Attachment{
+	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, header.Filename, &repo_model.Attachment{
 		Name:       header.Filename,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     repoID,

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -45,10 +45,11 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	}
 	defer file.Close()
 
-	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, header.Filename, &repo_model.Attachment{
-		Name:       header.Filename,
-		UploaderID: ctx.Doer.ID,
-		RepoID:     repoID,
+	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, &repo_model.Attachment{
+		Name:         header.Filename,
+		OriginalName: header.Filename,
+		UploaderID:   ctx.Doer.ID,
+		RepoID:       repoID,
 	})
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -50,3 +50,17 @@ func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, 
 
 	return NewAttachment(ctx, attach, io.MultiReader(bytes.NewReader(buf), file), fileSize)
 }
+
+// UploadAttachmentWithCustomizableName is like UploadAttachment, but you pass both the original file name and the attachment name
+// (which could be the same).
+func UploadAttachmentWithCustomizableName(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, originalFileName string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
+	buf := make([]byte, 1024)
+	n, _ := util.ReadAtMost(file, buf)
+	buf = buf[:n]
+
+	if err := upload.Verify(buf, originalFileName, allowedTypes); err != nil {
+		return nil, err
+	}
+
+	return NewAttachment(ctx, attach, io.MultiReader(bytes.NewReader(buf), file), fileSize)
+}

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -39,12 +39,12 @@ func NewAttachment(ctx context.Context, attach *repo_model.Attachment, file io.R
 }
 
 // UploadAttachment upload new attachment into storage and update database
-func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, originalFileName string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
+func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
 	buf := make([]byte, 1024)
 	n, _ := util.ReadAtMost(file, buf)
 	buf = buf[:n]
 
-	if err := upload.Verify(buf, originalFileName, allowedTypes); err != nil {
+	if err := upload.Verify(buf, attach.OriginalName, allowedTypes); err != nil {
 		return nil, err
 	}
 

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -39,21 +39,7 @@ func NewAttachment(ctx context.Context, attach *repo_model.Attachment, file io.R
 }
 
 // UploadAttachment upload new attachment into storage and update database
-func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
-	buf := make([]byte, 1024)
-	n, _ := util.ReadAtMost(file, buf)
-	buf = buf[:n]
-
-	if err := upload.Verify(buf, attach.Name, allowedTypes); err != nil {
-		return nil, err
-	}
-
-	return NewAttachment(ctx, attach, io.MultiReader(bytes.NewReader(buf), file), fileSize)
-}
-
-// UploadAttachmentWithCustomizableName is like UploadAttachment, but you pass both the original file name and the attachment name
-// (which could be the same).
-func UploadAttachmentWithCustomizableName(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, originalFileName string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
+func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, originalFileName string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
 	buf := make([]byte, 1024)
 	n, _ := util.ReadAtMost(file, buf)
 	buf = buf[:n]

--- a/services/mailer/incoming/incoming_handler.go
+++ b/services/mailer/incoming/incoming_handler.go
@@ -87,10 +87,11 @@ func (h *ReplyHandler) Handle(ctx context.Context, content *MailContent, doer *u
 		attachmentIDs := make([]string, 0, len(content.Attachments))
 		if setting.Attachment.Enabled {
 			for _, attachment := range content.Attachments {
-				a, err := attachment_service.UploadAttachment(ctx, bytes.NewReader(attachment.Content), setting.Attachment.AllowedTypes, int64(len(attachment.Content)), attachment.Name, &repo_model.Attachment{
-					Name:       attachment.Name,
-					UploaderID: doer.ID,
-					RepoID:     issue.Repo.ID,
+				a, err := attachment_service.UploadAttachment(ctx, bytes.NewReader(attachment.Content), setting.Attachment.AllowedTypes, int64(len(attachment.Content)), &repo_model.Attachment{
+					Name:         attachment.Name,
+					OriginalName: attachment.Name,
+					UploaderID:   doer.ID,
+					RepoID:       issue.Repo.ID,
 				})
 				if err != nil {
 					if upload.IsErrFileTypeForbidden(err) {

--- a/services/mailer/incoming/incoming_handler.go
+++ b/services/mailer/incoming/incoming_handler.go
@@ -87,7 +87,7 @@ func (h *ReplyHandler) Handle(ctx context.Context, content *MailContent, doer *u
 		attachmentIDs := make([]string, 0, len(content.Attachments))
 		if setting.Attachment.Enabled {
 			for _, attachment := range content.Attachments {
-				a, err := attachment_service.UploadAttachment(ctx, bytes.NewReader(attachment.Content), setting.Attachment.AllowedTypes, int64(len(attachment.Content)), &repo_model.Attachment{
+				a, err := attachment_service.UploadAttachment(ctx, bytes.NewReader(attachment.Content), setting.Attachment.AllowedTypes, int64(len(attachment.Content)), attachment.Name, &repo_model.Attachment{
 					Name:       attachment.Name,
 					UploaderID: doer.ID,
 					RepoID:     issue.Repo.ID,


### PR DESCRIPTION
Fixes #30766 by passing both the original file name and an attachment name to the lower API calls and performing verification on just the original file name. This behavior is pretty much in-line with how we handle attachment names in `EditIssueAttachment()`, where we don't perform any verification against the new name and just go straight to the DB to change it.
