### PR TITLE
Fix duplicate status check contexts (#30660)

### DIFF
--- a/models/git/commit_status_test.go
+++ b/models/git/commit_status_test.go
@@ -5,11 +5,15 @@ package git_test
 
 import (
 	"testing"
+	"time"
 
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/gitrepo"
 	"code.gitea.io/gitea/modules/structs"
 
 	"github.com/stretchr/testify/assert"
@@ -173,5 +177,57 @@ func Test_CalcCommitStatus(t *testing.T) {
 
 	for _, kase := range kases {
 		assert.Equal(t, kase.expected, git_model.CalcCommitStatus(kase.statuses))
+	}
+}
+
+func TestFindRepoRecentCommitStatusContexts(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	repo2 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	gitRepo, err := gitrepo.OpenRepository(git.DefaultContext, repo2)
+	assert.NoError(t, err)
+	defer gitRepo.Close()
+
+	commit, err := gitRepo.GetBranchCommit(repo2.DefaultBranch)
+	assert.NoError(t, err)
+
+	defer func() {
+		_, err := db.DeleteByBean(db.DefaultContext, &git_model.CommitStatus{
+			RepoID:    repo2.ID,
+			CreatorID: user2.ID,
+			SHA:       commit.ID.String(),
+		})
+		assert.NoError(t, err)
+	}()
+
+	err = git_model.NewCommitStatus(db.DefaultContext, git_model.NewCommitStatusOptions{
+		Repo:    repo2,
+		Creator: user2,
+		SHA:     commit.ID,
+		CommitStatus: &git_model.CommitStatus{
+			State:     structs.CommitStatusFailure,
+			TargetURL: "https://example.com/tests/",
+			Context:   "compliance/lint-backend",
+		},
+	})
+	assert.NoError(t, err)
+
+	err = git_model.NewCommitStatus(db.DefaultContext, git_model.NewCommitStatusOptions{
+		Repo:    repo2,
+		Creator: user2,
+		SHA:     commit.ID,
+		CommitStatus: &git_model.CommitStatus{
+			State:     structs.CommitStatusSuccess,
+			TargetURL: "https://example.com/tests/",
+			Context:   "compliance/lint-backend",
+		},
+	})
+	assert.NoError(t, err)
+
+	contexts, err := git_model.FindRepoRecentCommitStatusContexts(db.DefaultContext, repo2.ID, time.Hour)
+	assert.NoError(t, err)
+	if assert.Len(t, contexts, 1) {
+		assert.Equal(t, "compliance/lint-backend", contexts[0])
 	}
 }


### PR DESCRIPTION
Backport #30660.

Caused by #30076. 

There may be some duplicate status check contexts when setting status checks for a branch protection rule. The duplicate contexts should be removed.

Before:
<img
src="https://github.com/go-gitea/gitea/assets/15528715/97f4de2d-4868-47a3-8a99-5a180f9ac0a3" width="600px" />

After:
<img
src="https://github.com/go-gitea/gitea/assets/15528715/ff7289c5-9793-4090-ba31-e8cb3c85f8a3" width="600px" />
