### PR TITLE
Skip gzip for some well-known compressed file types

### DIFF
--- a/modules/httplib/serve.go
+++ b/modules/httplib/serve.go
@@ -41,7 +41,7 @@ type ServeHeaderOptions struct {
 func ServeSetHeaders(w http.ResponseWriter, opts *ServeHeaderOptions) {
 	header := w.Header()
 
-	skipCompressionExts := container.SetOf(".gz", ".bz2", ".zip", ".xz", ".zst", ".deb", ".apk", ".jar", ".png", ".jpg")
+	skipCompressionExts := container.SetOf(".gz", ".bz2", ".zip", ".xz", ".zst", ".deb", ".apk", ".jar", ".png", ".jpg", ".webp")
 	if skipCompressionExts.Contains(path.Ext(opts.Filename)) {
 		w.Header().Add(gzhttp.HeaderNoCompression, "1")
 	}

--- a/modules/httplib/serve.go
+++ b/modules/httplib/serve.go
@@ -17,11 +17,14 @@ import (
 	"time"
 
 	charsetModule "code.gitea.io/gitea/modules/charset"
+	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/httpcache"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/typesniffer"
 	"code.gitea.io/gitea/modules/util"
+
+	"github.com/klauspost/compress/gzhttp"
 )
 
 type ServeHeaderOptions struct {
@@ -37,6 +40,11 @@ type ServeHeaderOptions struct {
 // ServeSetHeaders sets necessary content serve headers
 func ServeSetHeaders(w http.ResponseWriter, opts *ServeHeaderOptions) {
 	header := w.Header()
+
+	skipCompressionExts := container.SetOf(".gz", ".bz2", ".zip", ".xz", ".zst", ".deb", ".apk", ".jar", ".png", ".jpg")
+	if skipCompressionExts.Contains(path.Ext(opts.Filename)) {
+		w.Header().Add(gzhttp.HeaderNoCompression, "1")
+	}
 
 	contentType := typesniffer.ApplicationOctetStream
 	if opts.ContentType != "" {

--- a/modules/httplib/serve.go
+++ b/modules/httplib/serve.go
@@ -42,7 +42,7 @@ func ServeSetHeaders(w http.ResponseWriter, opts *ServeHeaderOptions) {
 	header := w.Header()
 
 	skipCompressionExts := container.SetOf(".gz", ".bz2", ".zip", ".xz", ".zst", ".deb", ".apk", ".jar", ".png", ".jpg", ".webp")
-	if skipCompressionExts.Contains(path.Ext(opts.Filename)) {
+	if skipCompressionExts.Contains(strings.ToLower(path.Ext(opts.Filename))) {
 		w.Header().Add(gzhttp.HeaderNoCompression, "1")
 	}
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -54,7 +54,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const GzipMinSize = 1400 // min size to compress for the body size of response
+var GzipMinSize = 1400 // min size to compress for the body size of response
 
 // optionsCorsHandler return a http handler which sets CORS options if enabled by config, it blocks non-CORS OPTIONS requests.
 func optionsCorsHandler() func(next http.Handler) http.Handler {

--- a/tests/integration/repo_archive_test.go
+++ b/tests/integration/repo_archive_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/routers"
+	"code.gitea.io/gitea/routers/web"
+	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoDownloadArchive(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	defer test.MockVariableValue(&setting.EnableGzip, true)()
+	defer test.MockVariableValue(&web.GzipMinSize, 10)()
+	defer test.MockVariableValue(&testWebRoutes, routers.NormalRoutes())()
+
+	req := NewRequest(t, "GET", "/user2/repo1/archive/master.zip")
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp := MakeRequest(t, req, http.StatusOK)
+	bs, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Empty(t, resp.Header().Get("Content-Encoding"))
+	assert.Equal(t, 320, len(bs))
+}


### PR DESCRIPTION
Not a perfect solution, it just works well.

Nice to have, even without this change, all HTTP agents (clients) should also work correctly.