### PR TITLE
Fix JS error when edit project column twice and fix empty column title

### DIFF
--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -132,7 +132,7 @@ export function initRepoProject() {
             divider.style.removeProperty('color');
           }
         }
-        $('.ui.modal').modal('hide');
+        $(modal).modal('hide');
       }
     });
   }

--- a/web_src/js/features/repo-projects.js
+++ b/web_src/js/features/repo-projects.js
@@ -115,7 +115,9 @@ export function initRepoProject() {
       } catch (error) {
         console.error(error);
       } finally {
-        projectTitleLabel.textContent = projectTitleInput?.value;
+        if (projectTitleInput?.value !== '') {
+          projectTitleLabel.textContent = projectTitleInput?.value;
+        }
         projectTitleInput.closest('form')?.classList.remove('dirty');
         const dividers = boardColumn.querySelectorAll(':scope > .divider');
         if (projectColorInput.value) {


### PR DESCRIPTION
Reproduce:
- click edit project column
- click confirm
- click edit project column again

![image](https://github.com/go-gitea/gitea/assets/18380374/48e554ce-fa78-4c38-b13b-d082e38654f4)

And fix column title will be changed if the input is empty