### PR TITLE
Fix tippy styling on heatmap

### DIFF
--- a/web_src/css/modules/tippy.css
+++ b/web_src/css/modules/tippy.css
@@ -29,8 +29,11 @@
 }
 
 /* for vue3-calendar-heatmap's tippy instances */
-.tippy-content:not([data-theme]) {
-  padding: 8px 14px;
+.tippy-box:not([data-theme]) {
+  padding: 0.5rem 1rem;
+  background-color: var(--color-tooltip-bg);
+  color: var(--color-tooltip-text);
+  border: none;
 }
 
 /* bare theme, no styling at all, except box-shadow */

--- a/web_src/css/modules/tippy.css
+++ b/web_src/css/modules/tippy.css
@@ -28,6 +28,11 @@
   z-index: 1;
 }
 
+/* for vue3-calendar-heatmap's tippy instances */
+.tippy-content:not([data-theme]) {
+  padding: 8px 14px;
+}
+
 /* bare theme, no styling at all, except box-shadow */
 .tippy-box[data-theme="bare"] {
   border: none;


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/30808

I will follup up with an [upstream](https://github.com/razorness/vue3-calendar-heatmap) PR to enable us to pass options to these tippy instances.

<img width="338" alt="Screenshot 2024-05-02 at 13 39 47" src="https://github.com/go-gitea/gitea/assets/115237/2910114e-3dbe-443e-a66e-a0ed1213c24a">

