### PR TITLE
Support `ARTIFACT_ROOT_URL`

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2593,6 +2593,9 @@ LEVEL = Info
 ;DEFAULT_ACTIONS_URL = github
 ;; Default artifact retention time in days. Artifacts could have their own retention periods by setting the `retention-days` option in `actions/upload-artifact` step.
 ;ARTIFACT_RETENTION_DAYS = 90
+;; The root URL to generate links for uploading and downloading artifacts.
+;; If not set, ROOT_URL will be used.
+;ARTIFACT_ROOT_URL =
 ;; Timeout to stop the task which have running status, but haven't been updated for a long time
 ;ZOMBIE_TASK_TIMEOUT = 10m
 ;; Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time

--- a/docs/content/administration/config-cheat-sheet.en-us.md
+++ b/docs/content/administration/config-cheat-sheet.en-us.md
@@ -1399,6 +1399,7 @@ PROXY_HOSTS = *.github.com
 - `STORAGE_TYPE`: **local**: Storage type for actions logs, `local` for local disk or `minio` for s3 compatible object storage service, default is `local` or other name defined with `[storage.xxx]`
 - `MINIO_BASE_PATH`: **actions_log/**: Minio base path on the bucket only available when STORAGE_TYPE is `minio`
 - `ARTIFACT_RETENTION_DAYS`: **90**: Default number of days to keep artifacts. Artifacts could have their own retention periods by setting the `retention-days` option in `actions/upload-artifact` step.
+- `ARTIFACT_ROOT_URL`: **_empty_**: The root URL to generate links for uploading and downloading artifacts. If not set, `ROOT_URL` will be used.
 - `ZOMBIE_TASK_TIMEOUT`: **10m**: Timeout to stop the task which have running status, but haven't been updated for a long time
 - `ENDLESS_TASK_TIMEOUT`: **3h**: Timeout to stop the tasks which have running status and continuous updates, but don't end for a long time
 - `ABANDONED_JOB_TIMEOUT`: **24h**: Timeout to cancel the jobs which have waiting status, but haven't been picked by a runner for a long time

--- a/docs/content/administration/config-cheat-sheet.zh-cn.md
+++ b/docs/content/administration/config-cheat-sheet.zh-cn.md
@@ -1325,6 +1325,12 @@ PROXY_HOSTS = *.github.com
 - `DEFAULT_ACTIONS_URL`: **github**：获取操作插件的默认平台，`github`表示`https://github.com`，`self`表示当前的 Gitea 实例。
 - `STORAGE_TYPE`: **local**：用于操作日志的存储类型，`local`表示本地磁盘，`minio`表示与S3兼容的对象存储服务，默认为`local`，或者使用定义为`[storage.xxx]`的其他名称。
 - `MINIO_BASE_PATH`: **actions_log/**：Minio存储桶上的基本路径，仅在`STORAGE_TYPE`为`minio`时可用。
+- `ARTIFACT_RETENTION_DAYS`: **90**: 默认保留工件的天数。Artifacts 可以通过在`actions/upload-artifact`步骤中设置`retention-days`选项来设置自己的保留期。
+- `ARTIFACT_ROOT_URL`: **_empty_**: 生成上传和下载工件链接的根 URL。如果未设置，将使用`ROOT_URL`。
+- `ZOMBIE_TASK_TIMEOUT`: **10m**: 僵尸任务超时时间，用于停止处于运行状态但状态长时间未更新的任务。
+- `ENDLESS_TASK_TIMEOUT`: **3h**: 无尽任务超时时间，用于停止处于运行状态且持续更新，但长时间未结束的任务。
+- `ABANDONED_JOB_TIMEOUT`: **24h**: 未认领作业超时时间，用于取消处于等待状态但长时间未被运行器选择的作业。
+- `SKIP_WORKFLOW_STRINGS`: **[skip ci],[ci skip],[no ci],[skip actions],[actions skip]**: 提交者可以在提交消息或 PR 标题中放置的字符串，以跳过执行相应的操作工作流。
 
 `DEFAULT_ACTIONS_URL` 指示 Gitea 操作运行程序应该在哪里找到带有相对路径的操作。
 例如，`uses: actions/checkout@v4` 表示 `https://github.com/actions/checkout@v4`，因为 `DEFAULT_ACTIONS_URL` 的值为 `github`。

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -14,11 +14,12 @@ import (
 // Actions settings
 var (
 	Actions = struct {
-		LogStorage            *Storage // how the created logs should be stored
-		ArtifactStorage       *Storage // how the created artifacts should be stored
-		ArtifactRetentionDays int64    `ini:"ARTIFACT_RETENTION_DAYS"`
 		Enabled               bool
 		DefaultActionsURL     defaultActionsURL `ini:"DEFAULT_ACTIONS_URL"`
+		LogStorage            *Storage          // how the created logs should be stored
+		ArtifactStorage       *Storage          // how the created artifacts should be stored
+		ArtifactRetentionDays int64             `ini:"ARTIFACT_RETENTION_DAYS"`
+		ArtifactRootURL       string            `ini:"ARTIFACT_ROOT_URL"`
 		ZombieTaskTimeout     time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
 		EndlessTaskTimeout    time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
 		AbandonedJobTimeout   time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`

--- a/routers/api/actions/artifacts.go
+++ b/routers/api/actions/artifacts.go
@@ -185,11 +185,11 @@ type artifactRoutes struct {
 }
 
 func (ar artifactRoutes) buildArtifactURL(runID int64, artifactHash, suffix string) string {
-	rootUrl := setting.AppURL
+	rootURL := setting.AppURL
 	if setting.Actions.ArtifactRootURL != "" {
-		rootUrl = setting.Actions.ArtifactRootURL
+		rootURL = setting.Actions.ArtifactRootURL
 	}
-	uploadURL := strings.TrimSuffix(rootUrl, "/") + strings.TrimSuffix(ar.prefix, "/") +
+	uploadURL := strings.TrimSuffix(rootURL, "/") + strings.TrimSuffix(ar.prefix, "/") +
 		strings.ReplaceAll(artifactRouteBase, "{run_id}", strconv.FormatInt(runID, 10)) +
 		"/" + artifactHash + "/" + suffix
 	return uploadURL

--- a/routers/api/actions/artifacts.go
+++ b/routers/api/actions/artifacts.go
@@ -185,7 +185,11 @@ type artifactRoutes struct {
 }
 
 func (ar artifactRoutes) buildArtifactURL(runID int64, artifactHash, suffix string) string {
-	uploadURL := strings.TrimSuffix(setting.AppURL, "/") + strings.TrimSuffix(ar.prefix, "/") +
+	rootUrl := setting.AppURL
+	if setting.Actions.ArtifactRootURL != "" {
+		rootUrl = setting.Actions.ArtifactRootURL
+	}
+	uploadURL := strings.TrimSuffix(rootUrl, "/") + strings.TrimSuffix(ar.prefix, "/") +
 		strings.ReplaceAll(artifactRouteBase, "{run_id}", strconv.FormatInt(runID, 10)) +
 		"/" + artifactHash + "/" + suffix
 	return uploadURL

--- a/routers/api/actions/artifacts_test.go
+++ b/routers/api/actions/artifacts_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"crypto/md5"
+	"fmt"
+	"testing"
+
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_artifactRoutes_buildArtifactURL(t *testing.T) {
+	oldAppURL := setting.AppURL
+	oldArtifactRootURL := setting.Actions.ArtifactRootURL
+	defer func() {
+		setting.AppURL = oldAppURL
+		setting.Actions.ArtifactRootURL = oldArtifactRootURL
+	}()
+
+	routes := artifactRoutes{
+		prefix: "/api/actions_pipeline",
+	}
+
+	{
+		setting.AppURL = "https://gitea.com"
+		setting.Actions.ArtifactRootURL = ""
+		u := routes.buildArtifactURL(100, fmt.Sprintf("%x", md5.Sum([]byte("test"))), "download_url")
+		assert.Equal(t, "https://gitea.com/api/actions_pipeline/_apis/pipelines/workflows/100/artifacts/098f6bcd4621d373cade4e832627b4f6/download_url", u)
+	}
+
+	{
+		setting.AppURL = "https://gitea.com"
+		setting.Actions.ArtifactRootURL = "http://gitea:3000"
+		u := routes.buildArtifactURL(100, fmt.Sprintf("%x", md5.Sum([]byte("test"))), "download_url")
+		assert.Equal(t, "http://gitea:3000/api/actions_pipeline/_apis/pipelines/workflows/100/artifacts/098f6bcd4621d373cade4e832627b4f6/download_url", u)
+	}
+}


### PR DESCRIPTION
Fix https://gitea.com/gitea/act_runner/issues/541

Users may use a non-ROOT_URL address to register a runner, since the ROOT_URL may be a public address listened by a reverse proxy.

Most communication between runners and Gitea (like calling API and cloning repo) uses the URL provided during registration, except for uploading or downloading artifacts. These addresses are generated by Gitea and provided to the runners. Gitea always uses the ROOT_URL to generate these addresses, causing the runner to upload or download artifacts from the public network.

This PR adds an new configuration `ARTIFACT_ROOT_URL` to indicate the address for uploading or downloading artifacts. If not specified, the ROOT_URL is still used.