### PR TITLE
Remove obsolete monaco workaround

### DIFF
--- a/web_src/js/features/codeeditor.js
+++ b/web_src/js/features/codeeditor.js
@@ -102,10 +102,6 @@ export async function createMonaco(textarea, filename, editorOpts) {
     },
   });
 
-  // Quick fix: https://github.com/microsoft/monaco-editor/issues/2962
-  monaco.languages.register({id: 'vs.editor.nullLanguage'});
-  monaco.languages.setLanguageConfiguration('vs.editor.nullLanguage', {});
-
   const editor = monaco.editor.create(container, {
     value: textarea.value,
     theme: 'gitea',


### PR DESCRIPTION
This workaround is not neccessary any more since monaco 0.35.0.

Ref: https://github.com/microsoft/monaco-editor/issues/2962
Ref: https://github.com/microsoft/vscode/pull/173688