### PR TITLE
Add missing menu active item background back

### DIFF
--- a/web_src/css/modules/menu.css
+++ b/web_src/css/modules/menu.css
@@ -358,6 +358,7 @@
 }
 
 .ui.vertical.menu .active.item {
+  background: var(--color-active);
   border-radius: 0;
 }
 .ui.vertical.menu > .active.item:first-child {


### PR DESCRIPTION
Fix #30578

![image](https://github.com/go-gitea/gitea/assets/2114189/403fc1b4-3b79-40bf-9012-3c25d57dd7e4)
