### PR TITLE
Fix incorrect default branch when adopt a repository (#30912)

### DIFF
--- a/services/repository/adopt.go
+++ b/services/repository/adopt.go
@@ -36,10 +36,6 @@ func AdoptRepository(ctx context.Context, doer, u *user_model.User, opts CreateR
 		}
 	}
 
-	if len(opts.DefaultBranch) == 0 {
-		opts.DefaultBranch = setting.Repository.DefaultBranch
-	}
-
 	repo := &repo_model.Repository{
 		OwnerID:                         u.ID,
 		Owner:                           u,
@@ -80,8 +76,8 @@ func AdoptRepository(ctx context.Context, doer, u *user_model.User, opts CreateR
 			return fmt.Errorf("getRepositoryByID: %w", err)
 		}
 
-		if err := adoptRepository(ctx, repoPath, doer, repo, opts.DefaultBranch); err != nil {
-			return fmt.Errorf("createDelegateHooks: %w", err)
+		if err := adoptRepository(ctx, repoPath, repo, opts.DefaultBranch); err != nil {
+			return fmt.Errorf("adoptRepository: %w", err)
 		}
 
 		if err := repo_module.CheckDaemonExportOK(ctx, repo); err != nil {
@@ -111,7 +107,7 @@ func AdoptRepository(ctx context.Context, doer, u *user_model.User, opts CreateR
 	return repo, nil
 }
 
-func adoptRepository(ctx context.Context, repoPath string, u *user_model.User, repo *repo_model.Repository, defaultBranch string) (err error) {
+func adoptRepository(ctx context.Context, repoPath string, repo *repo_model.Repository, defaultBranch string) (err error) {
 	isExist, err := util.IsExist(repoPath)
 	if err != nil {
 		log.Error("Unable to check if %s exists. Error: %v", repoPath, err)
@@ -141,6 +137,21 @@ func adoptRepository(ctx context.Context, repoPath string, u *user_model.User, r
 				return fmt.Errorf("setDefaultBranch: %w", err)
 			}
 		}
+	}
+
+	// Don't bother looking this repo in the context it won't be there
+	gitRepo, err := gitrepo.OpenRepository(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("openRepository: %w", err)
+	}
+	defer gitRepo.Close()
+
+	if _, err = repo_module.SyncRepoBranchesWithRepo(ctx, repo, gitRepo, 0); err != nil {
+		return fmt.Errorf("SyncRepoBranchesWithRepo: %w", err)
+	}
+
+	if err = repo_module.SyncReleasesWithTags(ctx, repo, gitRepo); err != nil {
+		return fmt.Errorf("SyncReleasesWithTags: %w", err)
 	}
 
 	branches, _ := git_model.FindBranchNames(ctx, git_model.FindBranchOptions{
@@ -183,24 +194,8 @@ func adoptRepository(ctx context.Context, repoPath string, u *user_model.User, r
 			return fmt.Errorf("setDefaultBranch: %w", err)
 		}
 	}
-
 	if err = repo_module.UpdateRepository(ctx, repo, false); err != nil {
 		return fmt.Errorf("updateRepository: %w", err)
-	}
-
-	// Don't bother looking this repo in the context it won't be there
-	gitRepo, err := gitrepo.OpenRepository(ctx, repo)
-	if err != nil {
-		return fmt.Errorf("openRepository: %w", err)
-	}
-	defer gitRepo.Close()
-
-	if _, err = repo_module.SyncRepoBranchesWithRepo(ctx, repo, gitRepo, 0); err != nil {
-		return fmt.Errorf("SyncRepoBranches: %w", err)
-	}
-
-	if err = repo_module.SyncReleasesWithTags(ctx, repo, gitRepo); err != nil {
-		return fmt.Errorf("SyncReleasesWithTags: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Backport #30912

ps: removed useless `u *user_model.User` for `adoptRepository`