### PR TITLE
Remove deprecated stuff for runners

### DIFF
--- a/routers/api/actions/runner/interceptor.go
+++ b/routers/api/actions/runner/interceptor.go
@@ -23,8 +23,6 @@ import (
 const (
 	uuidHeaderKey  = "x-runner-uuid"
 	tokenHeaderKey = "x-runner-token"
-	// Deprecated: will be removed after Gitea 1.20 released.
-	versionHeaderKey = "x-runner-version"
 )
 
 var withRunner = connect.WithInterceptors(connect.UnaryInterceptorFunc(func(unaryFunc connect.UnaryFunc) connect.UnaryFunc {
@@ -35,9 +33,6 @@ var withRunner = connect.WithInterceptors(connect.UnaryInterceptorFunc(func(unar
 		}
 		uuid := request.Header().Get(uuidHeaderKey)
 		token := request.Header().Get(tokenHeaderKey)
-		// TODO: version will be removed from request header after Gitea 1.20 released.
-		// And Gitea will not try to read version from request header
-		version := request.Header().Get(versionHeaderKey)
 
 		runner, err := actions_model.GetRunnerByUUID(ctx, uuid)
 		if err != nil {
@@ -51,14 +46,6 @@ var withRunner = connect.WithInterceptors(connect.UnaryInterceptorFunc(func(unar
 		}
 
 		cols := []string{"last_online"}
-
-		// TODO: version will be removed from request header after Gitea 1.20 released.
-		// And Gitea will not try to read version from request header
-		version, _ = util.SplitStringAtByteN(version, 64)
-		if !util.IsEmptyString(version) && runner.Version != version {
-			runner.Version = version
-			cols = append(cols, "version")
-		}
 		runner.LastOnline = timeutil.TimeStampNow()
 		if methodName == "UpdateTask" || methodName == "UpdateLog" {
 			runner.LastActive = timeutil.TimeStampNow()

--- a/routers/api/actions/runner/runner.go
+++ b/routers/api/actions/runner/runner.go
@@ -67,12 +67,6 @@ func (s *Service) Register(
 	}
 
 	labels := req.Msg.Labels
-	// TODO: agent_labels should be removed from pb after Gitea 1.20 released.
-	// Old version runner's agent_labels slice is not empty and labels slice is empty.
-	// And due to compatibility with older versions, it is temporarily marked as Deprecated in pb, so use `//nolint` here.
-	if len(req.Msg.AgentLabels) > 0 && len(req.Msg.Labels) == 0 { //nolint:staticcheck
-		labels = req.Msg.AgentLabels //nolint:staticcheck
-	}
 
 	// create new runner
 	name, _ := util.SplitStringAtByteN(req.Msg.Name, 255)


### PR DESCRIPTION
It's time (maybe somewhat late) to remove some deprecated stuff for the runner.

- `x-runner-version`: runners needn't to report version in every request, they will call `Declare`.
- `AgentLabels`: runners will report them as `Labels`.
