### PR TITLE
Enable `declaration-block-no-redundant-longhand-properties`

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -141,7 +141,7 @@ export default {
     'custom-property-pattern': null,
     'declaration-block-no-duplicate-custom-properties': true,
     'declaration-block-no-duplicate-properties': [true, {ignore: ['consecutive-duplicates-with-different-values']}],
-    'declaration-block-no-redundant-longhand-properties': null,
+    'declaration-block-no-redundant-longhand-properties': [true, {ignoreShorthands: ['flex-flow', 'overflow']}],
     'declaration-block-no-shorthand-property-overrides': null,
     'declaration-block-single-line-max-declarations': null,
     'declaration-empty-line-before': null,

--- a/web_src/css/modules/grid.css
+++ b/web_src/css/modules/grid.css
@@ -7,10 +7,7 @@
   flex-wrap: wrap;
   align-items: stretch;
   padding: 0;
-  margin-top: -1rem;
-  margin-bottom: -1rem;
-  margin-left: -1rem;
-  margin-right: -1rem;
+  margin: -1rem;
 }
 
 .ui.relaxed.grid {

--- a/web_src/css/modules/menu.css
+++ b/web_src/css/modules/menu.css
@@ -553,13 +553,11 @@
   border-bottom: 2px solid var(--color-secondary);
 }
 .ui.secondary.pointing.menu .item {
-  border-bottom-color: transparent;
-  border-bottom-style: solid;
+  border-bottom: 2px solid transparent;
   border-radius: 0;
   align-self: flex-end;
   margin: 0 0 -2px;
   padding: 0.85714286em 1.14285714em;
-  border-bottom-width: 2px;
 }
 .ui.secondary.pointing.menu .ui.dropdown .menu .item {
   border-bottom-width: 0;


### PR DESCRIPTION
Enable [`declaration-block-no-redundant-longhand-properties`](https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/) and autofix issues. The exclusions are because I find these two shorthands to be harder to read.