### PR TITLE
use existing oauth grant for public client

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -571,7 +571,15 @@ func GrantApplicationOAuth(ctx *context.Context) {
 			}, form.RedirectURI)
 			return
 		}
+	} else if grant.Scope != form.Scope {
+		handleAuthorizeError(ctx, AuthorizeError{
+			State:            form.State,
+			ErrorDescription: "a grant exists with different scope",
+			ErrorCode:        ErrorCodeServerError,
+		}, form.RedirectURI)
+		return
 	}
+
 	if len(form.Nonce) > 0 {
 		err := grant.SetNonce(ctx, form.Nonce)
 		if err != nil {


### PR DESCRIPTION
Do not try to create a new authorization grant when one exists already, thus preventing a DB-related authorization issue.

Fix https://github.com/go-gitea/gitea/pull/30790#issuecomment-2118812426