### PR TITLE
Slightly change repo scope format of action task versions to fix version handling of repo scope runnners

### DIFF
--- a/models/actions/tasks_version.go
+++ b/models/actions/tasks_version.go
@@ -95,7 +95,7 @@ func IncreaseTaskVersion(ctx context.Context, ownerID, repoID int64) error {
 
 	// 3. increase repo
 	if repoID > 0 {
-		if err := increaseTasksVersionByScope(ctx, 0, repoID); err != nil {
+		if err := increaseTasksVersionByScope(ctx, ownerID, repoID); err != nil {
 			log.Error("IncreaseTasksVersionByScope(Repo): %v", err)
 			return err
 		}


### PR DESCRIPTION
Fix for #31074 

This updates how versions for repo scope tasks are stored by IncreaseTaskVersion.
It used to be (0, repoID) i.e. the ownerID set to 0. But GetTasksVersionByScope querys with both IDs and would never find the old format.

This new format of IncreaseTaskVersion matches what GetTasksVersionByScope expects and global, org and repo scope formats will work.

However, two situations may still need attention:

- If a transfer own ownership occurs for a repository, the data in action_tasks_version should be updated

- The contents of actions_tasks_version in existing gitea installations should be updated.

Both are not critical since records in the new format will silently be created and the system will still work. It would just result in a few dead records in the database.
