### PR TITLE
Add an immutable tarball link to archive download headers for Nix

### DIFF
--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -319,6 +319,12 @@ func archiveDownload(ctx *context.APIContext) {
 func download(ctx *context.APIContext, archiveName string, archiver *repo_model.RepoArchiver) {
 	downloadName := ctx.Repo.Repository.Name + "-" + archiveName
 
+	// Add nix format link header so tarballs lock correctly:
+	// https://github.com/nixos/nix/blob/56763ff918eb308db23080e560ed2ea3e00c80a7/doc/manual/src/protocols/tarball-fetcher.md
+	ctx.Resp.Header().Add("Link", fmt.Sprintf(`<%s/archive/%s.tar.gz?rev=%s>; rel="immutable"`,
+		ctx.Repo.Repository.APIURL(),
+		archiver.CommitID, archiver.CommitID))
+
 	rPath := archiver.RelativePath()
 	if setting.RepoArchive.Storage.MinioConfig.ServeDirect {
 		// If we have a signed url (S3, object storage), redirect to this directly.

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -484,6 +484,12 @@ func Download(ctx *context.Context) {
 func download(ctx *context.Context, archiveName string, archiver *repo_model.RepoArchiver) {
 	downloadName := ctx.Repo.Repository.Name + "-" + archiveName
 
+	// Add nix format link header so tarballs lock correctly:
+	// https://github.com/nixos/nix/blob/56763ff918eb308db23080e560ed2ea3e00c80a7/doc/manual/src/protocols/tarball-fetcher.md
+	ctx.Resp.Header().Add("Link", fmt.Sprintf(`<%s/archive/%s.tar.gz?rev=%s>; rel="immutable"`,
+		ctx.Repo.Repository.APIURL(),
+		archiver.CommitID, archiver.CommitID))
+
 	rPath := archiver.RelativePath()
 	if setting.RepoArchive.Storage.MinioConfig.ServeDirect {
 		// If we have a signed url (S3, object storage), redirect to this directly.


### PR DESCRIPTION
This allows `nix flake metadata` and nix in general to lock a *branch* tarball link in a manner that causes it to fetch the correct commit even if the branch is updated with a newer version.

For further context, Nix flakes are a feature that, among other things, allows for "inputs" that are "github:someuser/somerepo", "https://some-tarball-service/some-tarball.tar.gz", "sourcehut:~meow/nya" or similar. This feature allows our users to fetch tarballs of git-based inputs to their builds rather than using git to fetch them, saving significant download time.

There is presently no gitea or forgejo specific fetcher in Nix, and we don't particularly wish to have one. Ideally (as a developer on a Nix implementation myself) we could just use the generic tarball fetcher and not add specific forgejo support, but to do so, we need additional metadata to know which commit a given *branch* tarball represents, which is the purpose of the Link header added here.

The result of this patch is that a Nix user can specify `inputs.something.url = "https://forgejo-host/some/project/archive/main.tar.gz"` in flake.nix and get a link to some concrete tarball for the actual commit in the lock file, then when they run `nix flake update` in the future, they will get the latest commit in that branch.

Example of it working locally:

 » nix flake metadata --refresh 'http://localhost:3000/api/v1/repos/jade/cats/archive/main.tar.gz?dir=configs/nix'
Resolved URL:  http://localhost:3000/api/v1/repos/jade/cats/archive/main.tar.gz?dir=configs/nix
Locked URL:    http://localhost:3000/api/v1/repos/jade/cats/archive/804ede182b6b66469b23ea4d21eece52766b7a06.tar.gz?dir=configs
/nix&narHash=sha256-yP7KkDVfuixZzs0fsqhSETXFC0y8m6nmPLw2GrAMxKQ%3D
Description:   Computers with the nixos
Path:          /nix/store/s856c6yqghyan4v0zy6jj19ksv0q22nx-source
Revision:      804ede182b6b66469b23ea4d21eece52766b7a06
Last modified: 2024-05-02 00:48:32

For details on the header value, see:
https://github.com/nixos/nix/blob/56763ff918eb308db23080e560ed2ea3e00c80a7/doc/manual/src/protocols/tarball-fetcher.md
