### PR TITLE
Remove duplicate `ProxyPreserveHost` in Apache httpd doc

### DIFF
--- a/docs/content/administration/reverse-proxies.en-us.md
+++ b/docs/content/administration/reverse-proxies.en-us.md
@@ -169,7 +169,6 @@ If you want Apache HTTPD to serve your Gitea instance, you can add the following
     ProxyRequests off
     AllowEncodedSlashes NoDecode
     ProxyPass / http://localhost:3000/ nocanon
-    ProxyPreserveHost On
     RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
 </VirtualHost>
 ```


### PR DESCRIPTION
---

(fix up for #31003)