### PR TITLE
Swap word order in Comment and Close

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1555,9 +1555,9 @@ issues.no_content = No description provided.
 issues.close = Close Issue
 issues.comment_pull_merged_at = merged commit %[1]s into %[2]s %[3]s
 issues.comment_manually_pull_merged_at = manually merged commit %[1]s into %[2]s %[3]s
-issues.close_comment_issue = Comment and Close
+issues.close_comment_issue = Close with Comment
 issues.reopen_issue = Reopen
-issues.reopen_comment_issue = Comment and Reopen
+issues.reopen_comment_issue = Reopen with Comment
 issues.create_comment = Comment
 issues.comment.blocked_user = Cannot create or edit comment because you are blocked by the poster or repository owner.
 issues.closed_at = `closed this issue <a id="%[1]s" href="#%[1]s">%[2]s</a>`


### PR DESCRIPTION
Reduce accident closing of tickets only to re-open them right away. This aligns the text on these buttons with what GitHub has.

Commit is authored by @LazyDodo, and was committed to the Blender fork by @brechtvl 

Background details: https://projects.blender.org/infrastructure/gitea-custom/pulls/7
