### PR TITLE
Fix push multiple branches error with tests

### DIFF
--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -332,7 +332,7 @@ func SyncBranchesToDB(ctx context.Context, repoID, pusherID int64, branchNames, 
 				if _, err := git_model.UpdateBranch(ctx, repoID, pusherID, branchName, commit); err != nil {
 					return fmt.Errorf("git_model.UpdateBranch %d:%s failed: %v", repoID, branchName, err)
 				}
-				return nil
+				continue
 			}
 
 			// if database have branches but not this branch, it means this is a new branch

--- a/tests/integration/git_helper_for_declarative_test.go
+++ b/tests/integration/git_helper_for_declarative_test.go
@@ -160,6 +160,24 @@ func doGitPushTestRepositoryFail(dstPath string, args ...string) func(*testing.T
 	}
 }
 
+func doGitAddSomeCommits(dstPath, branch string) func(*testing.T) {
+	return func(t *testing.T) {
+		doGitCheckoutBranch(dstPath, branch)(t)
+
+		assert.NoError(t, os.WriteFile(filepath.Join(dstPath, fmt.Sprintf("file-%s.txt", branch)), []byte(fmt.Sprintf("file %s", branch)), 0o644))
+		assert.NoError(t, git.AddChanges(dstPath, true))
+		signature := git.Signature{
+			Email: "test@test.test",
+			Name:  "test",
+		}
+		assert.NoError(t, git.CommitChanges(dstPath, git.CommitChangesOptions{
+			Committer: &signature,
+			Author:    &signature,
+			Message:   fmt.Sprintf("update %s", branch),
+		}))
+	}
+}
+
 func doGitCreateBranch(dstPath, branch string) func(*testing.T) {
 	return func(t *testing.T) {
 		_, _, err := git.NewCommand(git.DefaultContext, "checkout", "-b").AddDynamicArguments(branch).RunStdString(&git.RunOpts{Dir: dstPath})

--- a/tests/integration/git_push_test.go
+++ b/tests/integration/git_push_test.go
@@ -37,6 +37,41 @@ func testGitPush(t *testing.T, u *url.URL) {
 		})
 	})
 
+	t.Run("Push branches exists", func(t *testing.T) {
+		runTestGitPush(t, u, func(t *testing.T, gitPath string) (pushed, deleted []string) {
+			for i := 0; i < 10; i++ {
+				branchName := fmt.Sprintf("branch-%d", i)
+				if i < 5 {
+					pushed = append(pushed, branchName)
+				}
+				doGitCreateBranch(gitPath, branchName)(t)
+			}
+			// only push master and the first 5 branches
+			pushed = append(pushed, "master")
+			args := append([]string{"origin"}, pushed...)
+			doGitPushTestRepository(gitPath, args...)(t)
+
+			pushed = pushed[:0]
+			// do some changes for the first 5 branches created above
+			for i := 0; i < 5; i++ {
+				branchName := fmt.Sprintf("branch-%d", i)
+				pushed = append(pushed, branchName)
+
+				doGitAddSomeCommits(gitPath, branchName)(t)
+			}
+
+			for i := 5; i < 10; i++ {
+				pushed = append(pushed, fmt.Sprintf("branch-%d", i))
+			}
+			pushed = append(pushed, "master")
+
+			// push all, so that master are not chagned
+			doGitPushTestRepository(gitPath, "origin", "--all")(t)
+
+			return pushed, deleted
+		})
+	})
+
 	t.Run("Push branches one by one", func(t *testing.T) {
 		runTestGitPush(t, u, func(t *testing.T, gitPath string) (pushed, deleted []string) {
 			for i := 0; i < 100; i++ {


### PR DESCRIPTION
Fix #31140 

The previous logic is wrong when pushing multiple branches. After first branch updated, it will ignore left other branches sync operations.

As a workaround for the repositories, just push a new commit after the patch applied will fix the repositories status.