### PR TITLE
Make `ContextPopup` stateless, improve fetching logic

### DIFF
--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -2181,8 +2181,8 @@ func GetIssueInfo(ctx *context.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, map[string]any{
-		"convertedIssue": convert.ToIssue(ctx, ctx.Doer, issue),
-		"renderedLabels": templates.RenderLabels(ctx, ctx.Locale, issue.Labels, ctx.Repo.RepoLink, issue),
+		"issue": convert.ToIssue(ctx, ctx.Doer, issue),
+		"labelsHtml": templates.RenderLabels(ctx, ctx.Locale, issue.Labels, ctx.Repo.RepoLink, issue),
 	})
 }
 

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -2181,7 +2181,7 @@ func GetIssueInfo(ctx *context.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, map[string]any{
-		"issue": convert.ToIssue(ctx, ctx.Doer, issue),
+		"issue":      convert.ToIssue(ctx, ctx.Doer, issue),
 		"labelsHtml": templates.RenderLabels(ctx, ctx.Locale, issue.Labels, ctx.Repo.RepoLink, issue),
 	})
 }

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -36,7 +36,6 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 		i18n: {
 			copy_success: {{ctx.Locale.Tr "copy_success"}},
 			copy_error: {{ctx.Locale.Tr "copy_error"}},
-			error_occurred: {{ctx.Locale.Tr "error.occurred"}},
 			network_error: {{ctx.Locale.Tr "error.network_error"}},
 			remove_label_str: {{ctx.Locale.Tr "remove_label_str"}},
 			modal_confirm: {{ctx.Locale.Tr "modal.confirm"}},

--- a/tests/integration/issue_test.go
+++ b/tests/integration/issue_test.go
@@ -641,13 +641,13 @@ func TestGetIssueInfo(t *testing.T) {
 	req := NewRequest(t, "GET", urlStr)
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	var respStruct struct {
-		ConvertedIssue api.Issue
-		RenderedLabels template.HTML
+		Issue      api.Issue     `json:"issue"`
+		LabelsHTML template.HTML `json:"labelsHtml"`
 	}
 	DecodeJSON(t, resp, &respStruct)
 
-	assert.EqualValues(t, issue.ID, respStruct.ConvertedIssue.ID)
-	assert.Contains(t, string(respStruct.RenderedLabels), `"labels-list"`)
+	assert.EqualValues(t, issue.ID, respStruct.Issue.ID)
+	assert.Contains(t, string(respStruct.LabelsHTML), `"labels-list"`)
 }
 
 func TestUpdateIssueDeadline(t *testing.T) {

--- a/web_src/js/components/ContextPopup.vue
+++ b/web_src/js/components/ContextPopup.vue
@@ -1,18 +1,18 @@
 <script>
 import {SvgIcon} from '../svg.js';
-import {GET} from '../modules/fetch.js';
-
-const {appSubUrl, i18n} = window.config;
 
 export default {
   components: {SvgIcon},
-  data: () => ({
-    loading: false,
-    issue: null,
-    renderedLabels: '',
-    i18nErrorOccurred: i18n.error_occurred,
-    i18nErrorMessage: null,
-  }),
+  props: {
+    issue: {
+      type: Object,
+      default: null,
+    },
+    labelsHtml: {
+      type: String,
+      default: '',
+    },
+  },
   computed: {
     createdAt() {
       return new Date(this.issue.created_at).toLocaleDateString(undefined, {year: 'numeric', month: 'short', day: 'numeric'});
@@ -57,56 +57,20 @@ export default {
       return 'red'; // Closed Issue
     },
   },
-  mounted() {
-    this.$refs.root.addEventListener('ce-load-context-popup', (e) => {
-      const data = e.detail;
-      if (!this.loading && this.issue === null) {
-        this.load(data);
-      }
-    });
-  },
-  methods: {
-    async load(data) {
-      this.loading = true;
-      this.i18nErrorMessage = null;
-
-      try {
-        const response = await GET(`${appSubUrl}/${data.owner}/${data.repo}/issues/${data.index}/info`); // backend: GetIssueInfo
-        const respJson = await response.json();
-        if (!response.ok) {
-          this.i18nErrorMessage = respJson.message ?? i18n.network_error;
-          return;
-        }
-        this.issue = respJson.convertedIssue;
-        this.renderedLabels = respJson.renderedLabels;
-      } catch {
-        this.i18nErrorMessage = i18n.network_error;
-      } finally {
-        this.loading = false;
-      }
-    },
-  },
 };
 </script>
 <template>
-  <div ref="root">
-    <div v-if="loading" class="tw-h-12 tw-w-12 is-loading"/>
-    <div v-if="!loading && issue !== null" class="tw-flex tw-flex-col tw-gap-2">
-      <div class="tw-text-12">{{ issue.repository.full_name }} on {{ createdAt }}</div>
-      <div class="flex-text-block">
-        <svg-icon :name="icon" :class="['text', color]"/>
-        <span class="issue-title tw-font-semibold tw-break-anywhere">
-          {{ issue.title }}
-          <span class="index">#{{ issue.number }}</span>
-        </span>
-      </div>
-      <div v-if="body">{{ body }}</div>
-      <!-- eslint-disable-next-line vue/no-v-html -->
-      <div v-if="issue.labels.length" v-html="renderedLabels"/>
+  <div class="tw-p-3 tw-flex tw-flex-col tw-gap-2">
+    <div class="tw-text-12">{{ issue.repository.full_name }} on {{ createdAt }}</div>
+    <div class="flex-text-block tw-gap-2">
+      <svg-icon :name="icon" :class="['text', color]"/>
+      <span class="issue-title tw-font-semibold tw-break-anywhere">
+        {{ issue.title }}
+        <span class="index">#{{ issue.number }}</span>
+      </span>
     </div>
-    <div class="tw-flex tw-flex-col tw-gap-2" v-if="!loading && issue === null">
-      <div class="tw-text-12">{{ i18nErrorOccurred }}</div>
-      <div>{{ i18nErrorMessage }}</div>
-    </div>
+    <div v-if="body">{{ body }}</div>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-if="issue.labels.length" v-html="labelsHtml"/>
   </div>
 </template>

--- a/web_src/js/components/ContextPopup.vue
+++ b/web_src/js/components/ContextPopup.vue
@@ -12,6 +12,10 @@ export default {
       type: String,
       default: '',
     },
+    repoUrl: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     createdAt() {
@@ -61,7 +65,9 @@ export default {
 </script>
 <template>
   <div class="tw-p-3 tw-flex tw-flex-col tw-gap-2">
-    <div class="tw-text-12">{{ issue.repository.full_name }} on {{ createdAt }}</div>
+    <div class="tw-text-12">
+      <a class="muted" :href="repoUrl">{{ issue.repository.full_name }}</a> on {{ createdAt }}
+    </div>
     <div class="flex-text-block tw-gap-2">
       <svg-icon :name="icon" :class="['text', color]"/>
       <span class="issue-title tw-font-semibold tw-break-anywhere">

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -38,6 +38,7 @@ async function init(e) {
     interactiveBorder: 15,
   });
 
+  // set attribute on the link that indicates which url the tooltip currently renders
   link.setAttribute(urlAttribute, url);
 
   // show immediately because this runs during mouseenter and focus

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -9,6 +9,7 @@ const urlAttribute = 'data-issue-ref-url';
 
 async function init(e) {
   const link = e.currentTarget;
+  if (link.classList.contains('ref-external-issue')) return;
 
   const {owner, repo, index} = parseIssueHref(link.getAttribute('href'));
   if (!owner) return;
@@ -57,5 +58,5 @@ export function attachRefIssueContextPopup(els) {
 
 export function initContextPopups() {
   // TODO: Use MutationObserver to detect newly inserted .ref-issue
-  attachRefIssueContextPopup(document.querySelectorAll('.ref-issue:not(.ref-external-issue)'));
+  attachRefIssueContextPopup(document.querySelectorAll('.ref-issue'));
 }

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -5,12 +5,10 @@ import {createTippy} from '../modules/tippy.js';
 import {GET} from '../modules/fetch.js';
 
 const {appSubUrl} = window.config;
-const initAttr = 'data-contextpopup-init-done';
 
 async function init(e) {
   const link = e.currentTarget;
-  if (link.hasAttribute(initAttr)) return;
-  link.setAttribute(initAttr, 'true');
+  if (link._tippy) return; // link already has a tooltip
 
   const {owner, repo, index} = parseIssueHref(link.getAttribute('href'));
   if (!owner) return;
@@ -43,8 +41,8 @@ async function init(e) {
 
 export function attachRefIssueContextPopup(els) {
   for (const el of els) {
-    el.addEventListener('mouseenter', init, {once: true});
-    el.addEventListener('focus', init, {once: true});
+    el.addEventListener('mouseenter', init);
+    el.addEventListener('focus', init);
   }
 }
 

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -9,6 +9,8 @@ const urlAttribute = 'data-issue-ref-url';
 
 async function attach(e) {
   const link = e.currentTarget;
+
+  // ignore external issues
   if (link.classList.contains('ref-external-issue')) return;
 
   const {owner, repo, index} = parseIssueHref(link.getAttribute('href'));

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -5,9 +5,13 @@ import {createTippy} from '../modules/tippy.js';
 import {GET} from '../modules/fetch.js';
 
 const {appSubUrl} = window.config;
+const initAttr = 'data-contextpopup-init-done';
 
-async function show(e) {
+async function init(e) {
   const link = e.currentTarget;
+  if (link.hasAttribute(initAttr)) return;
+  link.setAttribute(initAttr, 'true');
+
   const {owner, repo, index} = parseIssueHref(link.getAttribute('href'));
   if (!owner) return;
 
@@ -29,7 +33,7 @@ async function show(e) {
     content,
     placement: 'top-start',
     interactive: true,
-    role: 'dialog',
+    role: 'tooltip',
     interactiveBorder: 15,
   });
 
@@ -38,9 +42,9 @@ async function show(e) {
 }
 
 export function attachRefIssueContextPopup(els) {
-  for (const link of els) {
-    link.addEventListener('mouseenter', show);
-    link.addEventListener('focus', show);
+  for (const el of els) {
+    el.addEventListener('mouseenter', init, {once: true});
+    el.addEventListener('focus', init, {once: true});
   }
 }
 

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -18,7 +18,7 @@ async function attach(e) {
   if (!owner) return;
 
   const url = `${appSubUrl}/${owner}/${repo}/issues/${index}/info`; // backend: GetIssueInfo
-  if (link.getAttribute('data-issue-ref-url') === url) return; // link already has a tooltip with this url
+  if (link.getAttribute('data-issue-ref-info-url') === url) return; // link already has a tooltip with this url
 
   try {
     link.setAttribute('data-issue-ref-loading', 'true');
@@ -48,7 +48,7 @@ async function attach(e) {
     });
 
     // set attribute on the link that indicates which url the tooltip currently renders
-    link.setAttribute('data-issue-ref-url', url);
+    link.setAttribute('data-issue-ref-info-url', url);
 
     // show immediately because this runs during mouseenter and focus
     tippy.show();

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -7,7 +7,7 @@ import {GET} from '../modules/fetch.js';
 const {appSubUrl} = window.config;
 const urlAttribute = 'data-issue-ref-url';
 
-async function init(e) {
+async function attach(e) {
   const link = e.currentTarget;
   if (link.classList.contains('ref-external-issue')) return;
 
@@ -51,8 +51,8 @@ async function init(e) {
 
 export function attachRefIssueContextPopup(els) {
   for (const el of els) {
-    el.addEventListener('mouseenter', init);
-    el.addEventListener('focus', init);
+    el.addEventListener('mouseenter', attach);
+    el.addEventListener('focus', attach);
   }
 }
 

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -5,15 +5,18 @@ import {createTippy} from '../modules/tippy.js';
 import {GET} from '../modules/fetch.js';
 
 const {appSubUrl} = window.config;
+const urlAttribute = 'data-issue-ref-url';
 
 async function init(e) {
   const link = e.currentTarget;
-  if (link._tippy) return; // link already has a tooltip
 
   const {owner, repo, index} = parseIssueHref(link.getAttribute('href'));
   if (!owner) return;
 
-  const res = await GET(`${appSubUrl}/${owner}/${repo}/issues/${index}/info`); // backend: GetIssueInfo
+  const url = `${appSubUrl}/${owner}/${repo}/issues/${index}/info`; // backend: GetIssueInfo
+  if (link.getAttribute(urlAttribute) === url) return; // link already has a tooltip with this url
+
+  const res = await GET(url);
   if (!res.ok) return;
 
   let issue, labelsHtml;
@@ -34,6 +37,8 @@ async function init(e) {
     role: 'tooltip',
     interactiveBorder: 15,
   });
+
+  link.setAttribute(urlAttribute, url);
 
   // show immediately because this runs during mouseenter and focus
   tippy.show();

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -34,7 +34,8 @@ async function attach(e) {
     } catch {}
     if (!issue) return;
 
-    const content = createVueRoot(ContextPopup, {issue, labelsHtml});
+    const repoUrl = `${appSubUrl}/${owner}/${repo}`;
+    const content = createVueRoot(ContextPopup, {issue, labelsHtml, repoUrl});
     if (!content) return;
 
     const tippy = createTippy(link, {

--- a/web_src/js/features/contextpopup.js
+++ b/web_src/js/features/contextpopup.js
@@ -16,7 +16,10 @@ async function init(e) {
   const url = `${appSubUrl}/${owner}/${repo}/issues/${index}/info`; // backend: GetIssueInfo
   if (link.getAttribute(urlAttribute) === url) return; // link already has a tooltip with this url
 
-  const res = await GET(url);
+  let res;
+  try {
+    res = await GET(url);
+  } catch {}
   if (!res.ok) return;
 
   let issue, labelsHtml;

--- a/web_src/js/utils/vue.js
+++ b/web_src/js/utils/vue.js
@@ -1,0 +1,14 @@
+import {createApp} from 'vue';
+
+// create a new vue root and container and mount a component into it
+export function createVueRoot(component, props) {
+  const container = document.createElement('div');
+  const view = createApp(component, props);
+  try {
+    view.mount(container);
+    return container;
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+}


### PR DESCRIPTION
1. `ContextPopup` is now a stateless component, accepting only props to render the popup
2. Loading state is gone, the requests are fast enough to not need a loading state
3. Error state is gone, we don't need to show any errors on this, imho
4. Popups now have the `tooltip` role which enables singleton behaviour, so multiple such popups won't show at the same time (happens when links are close together)
5. Increased the `interactiveBorder` to 15px
6. Tooltip init is now lazy
7. Repo link in tooltip is now clickable

Fixes: https://github.com/go-gitea/gitea/issues/31161
Helps with: https://github.com/go-gitea/gitea/issues/30275

Popup over existing issue:

<img width="614" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/cbf7f882-1d65-415c-862f-022bd259334d">

Nonexisting issue does not show anything:

<img width="78" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/2bb25c63-ccb7-44fb-a6c1-5d985d797bbe">

I think this is a nice bugfix for 1.22.
