### PR TITLE
Fix URL In Gitea Actions Badge Docs

### DIFF
--- a/docs/content/usage/actions/badge.en-us.md
+++ b/docs/content/usage/actions/badge.en-us.md
@@ -25,7 +25,7 @@ It is designed to be compatible with [GitHub Actions workflow badge](https://doc
 You can use the following URL to get the badge:
 
 ```
-https://your-gitea-instance.com/{owner}/{repo}/actions/workflows/{workflow_file}?branch={branch}&event={event}
+https://your-gitea-instance.com/{owner}/{repo}/actions/workflows/{workflow_file}/badge.svg?branch={branch}&event={event}
 ```
 
 - `{owner}`: The owner of the repository.


### PR DESCRIPTION
The example URL given in the documentation leads to a 404.

For instance, `https://your-gitea-instance.com/{owner}/{repo}/actions/workflows/{workflow_file}?branch={branch}&event={event}` translates to `https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/actions/workflows/build.yml`, which is a 404.

I had to check the [linked GitHub docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) to learn that you have to add `/badge.svg` to the URL.

Example: https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/actions/workflows/build.yml/badge.svg