### PR TITLE
Only update poster in issue/comment list if it has been loaded

### DIFF
--- a/models/issues/comment_list.go
+++ b/models/issues/comment_list.go
@@ -32,7 +32,9 @@ func (comments CommentList) LoadPosters(ctx context.Context) error {
 	}
 
 	for _, comment := range comments {
-		comment.Poster = getPoster(comment.PosterID, posterMaps)
+		if comment.Poster == nil {
+			comment.Poster = getPoster(comment.PosterID, posterMaps)
+		}
 	}
 	return nil
 }

--- a/models/issues/issue_list.go
+++ b/models/issues/issue_list.go
@@ -87,7 +87,9 @@ func (issues IssueList) LoadPosters(ctx context.Context) error {
 	}
 
 	for _, issue := range issues {
-		issue.Poster = getPoster(issue.PosterID, posterMaps)
+		if issue.Poster == nil {
+			issue.Poster = getPoster(issue.PosterID, posterMaps)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, all posters were updated, even if they were not part of posterMaps. In that case, a ghost user was erroneously inserted.

Fixes #31213.