### PR TITLE
Fix alert blocks not following GitHub's behaviour with backslashes

### DIFF
--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -1019,4 +1019,9 @@ func TestAttention(t *testing.T) {
 	test(`> [!important]`, renderAttention("important", "octicon-report")+"\n</blockquote>")
 	test(`> [!warning]`, renderAttention("warning", "octicon-alert")+"\n</blockquote>")
 	test(`> [!caution]`, renderAttention("caution", "octicon-stop")+"\n</blockquote>")
+
+	test(`
+> \[!NOTE\]
+> text
+`, renderAttention("note", "octicon-info")+"\n<p>text</p>\n</blockquote>")
 }


### PR DESCRIPTION
Previously, these blocks would only get rendered if the markdown was `[!TYPE]`. Now they also render with `\[!TYPE\]`.

- Fixes https://github.com/go-gitea/gitea/issues/31214

# Before
![image](https://github.com/go-gitea/gitea/assets/20454870/0c07bcc5-723d-4c11-8b63-ebae9937ae87)

# After
![image](https://github.com/go-gitea/gitea/assets/20454870/9aeff173-7fb0-46b6-b891-9a3167a4312b)
