### PR TITLE
Enable poetry non-package mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -878,7 +878,7 @@ node_modules: package-lock.json
 	@touch node_modules
 
 .venv: poetry.lock
-	poetry install --no-root
+	poetry install
 	@touch .venv
 
 .PHONY: update
@@ -895,7 +895,7 @@ update-js: node-check | node_modules
 update-py: node-check | node_modules
 	npx updates -u -f pyproject.toml
 	rm -rf .venv poetry.lock
-	poetry install --no-root
+	poetry install
 	@touch .venv
 
 .PHONY: fomantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.poetry]
-name = "gitea"
-version = "0.0.0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
[Poetry 1.8.0](https://github.com/python-poetry/poetry/releases/tag/1.8.0) added support for [non-package mode](https://python-poetry.org/docs/basic-usage/#operating-modes), e.g. projects that are not python packages themselves like we are. Make use of that and remove the previous workaround via `--no-root`.