### PR TITLE
Fix and clean up `ConfirmModal`

### DIFF
--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -296,7 +296,7 @@ async function linkAction(e) {
   }
 
   const isRisky = el.classList.contains('red') || el.classList.contains('yellow') || el.classList.contains('orange') || el.classList.contains('negative');
-  if (await confirmModal({content: modalConfirmContent, buttonColor: isRisky ? 'orange' : 'primary'})) {
+  if (await confirmModal({content: modalConfirmContent, buttonColor: isRisky ? 'red' : 'primary'})) {
     await doRequest();
   }
 }

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -282,7 +282,6 @@ async function linkAction(e) {
   if (!el) return;
 
   e.preventDefault();
-
   const url = el.getAttribute('data-url');
   const doRequest = async () => {
     el.disabled = true;

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -295,7 +295,7 @@ async function linkAction(e) {
     return;
   }
 
-  const isRisky = el.classList.contains('red') || el.classList.contains('yellow') || el.classList.contains('orange') || el.classList.contains('negative');
+  const isRisky = el.classList.contains('red') || el.classList.contains('negative');
   if (await confirmModal({content: modalConfirmContent, buttonColor: isRisky ? 'red' : 'primary'})) {
     await doRequest();
   }

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -282,6 +282,7 @@ async function linkAction(e) {
   if (!el) return;
 
   e.preventDefault();
+
   const url = el.getAttribute('data-url');
   const doRequest = async () => {
     el.disabled = true;
@@ -296,7 +297,7 @@ async function linkAction(e) {
   }
 
   const isRisky = el.classList.contains('red') || el.classList.contains('negative');
-  if (await confirmModal({content: modalConfirmContent, buttonColor: isRisky ? 'red' : 'primary'})) {
+  if (await confirmModal(modalConfirmContent, {confirmButtonColor: isRisky ? 'red' : 'primary'})) {
     await doRequest();
   }
 }

--- a/web_src/js/features/comp/ConfirmModal.js
+++ b/web_src/js/features/comp/ConfirmModal.js
@@ -1,22 +1,23 @@
 import $ from 'jquery';
 import {svg} from '../../svg.js';
 import {htmlEscape} from 'escape-goat';
+import {createElementFromHTML} from '../../utils/dom.js';
 
 const {i18n} = window.config;
 
-export async function confirmModal(opts = {content: '', buttonColor: 'primary'}) {
+export function confirmModal({content = '', buttonColor = 'red'} = {}) {
   return new Promise((resolve) => {
-    const $modal = $(`
-<div class="ui g-modal-confirm modal">
-  <div class="content">${htmlEscape(opts.content)}</div>
-  <div class="actions">
-    <button class="ui cancel button">${svg('octicon-x')} ${i18n.modal_cancel}</button>
-    <button class="ui ${opts.buttonColor || 'primary'} ok button">${svg('octicon-check')} ${i18n.modal_confirm}</button>
-  </div>
-</div>
-`);
-
-    $modal.appendTo(document.body);
+    const modal = createElementFromHTML(`
+      <div class="ui g-modal-confirm modal">
+        <div class="content">${htmlEscape(content)}</div>
+        <div class="actions">
+          <button class="ui cancel button">${svg('octicon-x')} ${htmlEscape(i18n.modal_cancel)}</button>
+          <button class="ui ${buttonColor} ok button">${svg('octicon-check')} ${htmlEscape(i18n.modal_confirm)}</button>
+        </div>
+      </div>
+    `);
+    document.body.append(modal);
+    const $modal = $(modal);
     $modal.modal({
       onApprove() {
         resolve(true);

--- a/web_src/js/features/comp/ConfirmModal.js
+++ b/web_src/js/features/comp/ConfirmModal.js
@@ -5,14 +5,14 @@ import {createElementFromHTML} from '../../utils/dom.js';
 
 const {i18n} = window.config;
 
-export function confirmModal({content = '', buttonColor = 'red'}) {
+export function confirmModal(content, {confirmButtonColor = 'primary'} = {}) {
   return new Promise((resolve) => {
     const modal = createElementFromHTML(`
       <div class="ui g-modal-confirm modal">
         <div class="content">${htmlEscape(content)}</div>
         <div class="actions">
           <button class="ui cancel button">${svg('octicon-x')} ${htmlEscape(i18n.modal_cancel)}</button>
-          <button class="ui ${buttonColor} ok button">${svg('octicon-check')} ${htmlEscape(i18n.modal_confirm)}</button>
+          <button class="ui ${confirmButtonColor} ok button">${svg('octicon-check')} ${htmlEscape(i18n.modal_confirm)}</button>
         </div>
       </div>
     `);

--- a/web_src/js/features/comp/ConfirmModal.js
+++ b/web_src/js/features/comp/ConfirmModal.js
@@ -5,7 +5,7 @@ import {createElementFromHTML} from '../../utils/dom.js';
 
 const {i18n} = window.config;
 
-export function confirmModal({content = '', buttonColor = 'red'} = {}) {
+export function confirmModal({content = '', buttonColor = 'red'}) {
   return new Promise((resolve) => {
     const modal = createElementFromHTML(`
       <div class="ui g-modal-confirm modal">

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -76,7 +76,7 @@ function initRepoIssueListCheckboxes() {
     // for delete
     if (action === 'delete') {
       const confirmText = e.target.getAttribute('data-action-delete-confirm');
-      if (!await confirmModal({content: confirmText})) {
+      if (!await confirmModal(confirmText, {confirmButtonColor: 'red'})) {
         return;
       }
     }

--- a/web_src/js/features/repo-issue-list.js
+++ b/web_src/js/features/repo-issue-list.js
@@ -76,7 +76,7 @@ function initRepoIssueListCheckboxes() {
     // for delete
     if (action === 'delete') {
       const confirmText = e.target.getAttribute('data-action-delete-confirm');
-      if (!await confirmModal({content: confirmText, buttonColor: 'orange'})) {
+      if (!await confirmModal({content: confirmText})) {
         return;
       }
     }

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -297,3 +297,9 @@ export function replaceTextareaSelection(textarea, text) {
     textarea.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: true}));
   }
 }
+
+export function createElementFromHTML(htmlString) {
+  const div = document.createElement('div');
+  div.innerHTML = htmlString.trim();
+  return div.firstChild;
+}

--- a/web_src/js/utils/dom.js
+++ b/web_src/js/utils/dom.js
@@ -298,6 +298,7 @@ export function replaceTextareaSelection(textarea, text) {
   }
 }
 
+// Warning: Do not enter any unsanitized variables here
 export function createElementFromHTML(htmlString) {
   const div = document.createElement('div');
   div.innerHTML = htmlString.trim();

--- a/web_src/js/utils/dom.test.js
+++ b/web_src/js/utils/dom.test.js
@@ -2,4 +2,5 @@ import {createElementFromHTML} from './dom.js';
 
 test('createElementFromHTML', () => {
   expect(createElementFromHTML('<a>foo<span>bar</span></a>').textContent).toEqual('foobar');
+  expect(createElementFromHTML('<a>foo<span>bar</span></a>').outerHTML).toEqual('<a>foo<span>bar</span></a>');
 });

--- a/web_src/js/utils/dom.test.js
+++ b/web_src/js/utils/dom.test.js
@@ -1,0 +1,5 @@
+import {createElementFromHTML} from './dom.js';
+
+test('createElementFromHTML', () => {
+  expect(createElementFromHTML('<a>foo<span>bar</span></a>').textContent).toEqual('foobar');
+});

--- a/web_src/js/utils/dom.test.js
+++ b/web_src/js/utils/dom.test.js
@@ -1,6 +1,5 @@
 import {createElementFromHTML} from './dom.js';
 
 test('createElementFromHTML', () => {
-  expect(createElementFromHTML('<a>foo<span>bar</span></a>').textContent).toEqual('foobar');
   expect(createElementFromHTML('<a>foo<span>bar</span></a>').outerHTML).toEqual('<a>foo<span>bar</span></a>');
 });


### PR DESCRIPTION
Bug: orange button color was removed in https://github.com/go-gitea/gitea/pull/30475, replaced with red
Bug: translation text was not html-escaped
Refactor: Replaced as much jQuery as possible, added useful `createElementFromHTML`
Refactor: Remove colors checks that don't exist on `.link-action`

<img width="381" alt="image" src="https://github.com/go-gitea/gitea/assets/115237/5900bf6a-8a86-4a86-b368-0559cbfea66e">
