### PR TITLE
Fix missing images in editor preview due to wrong links

### DIFF
--- a/modules/markup/renderer.go
+++ b/modules/markup/renderer.go
@@ -86,8 +86,8 @@ type RenderContext struct {
 }
 
 type Links struct {
-	AbsolutePrefix bool
-	Base           string
+	AbsolutePrefix bool   // add absolute URL prefix to auto-resolved links like "#issue", but not for pre-provided links and medias
+	Base           string // base prefix for pre-provided links and medias (images, videos)
 	BranchPath     string
 	TreePath       string
 }

--- a/modules/markup/renderer.go
+++ b/modules/markup/renderer.go
@@ -88,8 +88,8 @@ type RenderContext struct {
 type Links struct {
 	AbsolutePrefix bool   // add absolute URL prefix to auto-resolved links like "#issue", but not for pre-provided links and medias
 	Base           string // base prefix for pre-provided links and medias (images, videos)
-	BranchPath     string
-	TreePath       string
+	BranchPath     string // actually it is the ref path, eg: "branch/features/feat-12", "tag/v1.0"
+	TreePath       string // the dir of the file, eg: "doc" if the file "doc/CHANGE.md" is being rendered
 }
 
 func (l *Links) Prefix() string {

--- a/modules/structs/miscellaneous.go
+++ b/modules/structs/miscellaneous.go
@@ -25,7 +25,8 @@ type MarkupOption struct {
 	//
 	// in: body
 	Mode string
-	// Context to render
+	// URL path for rendering issue, media and file links
+	// Expected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}
 	//
 	// in: body
 	Context string
@@ -53,7 +54,8 @@ type MarkdownOption struct {
 	//
 	// in: body
 	Mode string
-	// Context to render
+	// URL path for rendering issue, media and file links
+	// Expected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}
 	//
 	// in: body
 	Context string

--- a/modules/structs/miscellaneous.go
+++ b/modules/structs/miscellaneous.go
@@ -26,7 +26,7 @@ type MarkupOption struct {
 	// in: body
 	Mode string
 	// URL path for rendering issue, media and file links
-	// Expected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}
+	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}
 	//
 	// in: body
 	Context string
@@ -55,7 +55,7 @@ type MarkdownOption struct {
 	// in: body
 	Mode string
 	// URL path for rendering issue, media and file links
-	// Expected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}
+	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}
 	//
 	// in: body
 	Context string

--- a/modules/structs/miscellaneous.go
+++ b/modules/structs/miscellaneous.go
@@ -26,7 +26,7 @@ type MarkupOption struct {
 	// in: body
 	Mode string
 	// URL path for rendering issue, media and file links
-	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}
+	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file/dir}
 	//
 	// in: body
 	Context string
@@ -55,7 +55,7 @@ type MarkdownOption struct {
 	// in: body
 	Mode string
 	// URL path for rendering issue, media and file links
-	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}
+	// Expected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file/dir}
 	//
 	// in: body
 	Context string

--- a/routers/api/v1/misc/markup_test.go
+++ b/routers/api/v1/misc/markup_test.go
@@ -19,18 +19,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	AppURL  = "http://localhost:3000/"
-	Repo    = "gogits/gogs"
-	Branch  = "main"
-	FullURL = AppURL + Repo + "/"
-)
+const AppURL = "http://localhost:3000/"
 
-func testRenderMarkup(t *testing.T, mode string, wiki bool, filePath, text, responseBody string, responseCode int) {
+func testRenderMarkup(t *testing.T, mode string, wiki bool, filePath, text, expectedBody string, expectedCode int) {
+	t.Helper()
 	setting.AppURL = AppURL
-	context := Repo
+	context := "/gogits/gogs"
 	if !wiki {
-		context += "/src/branch/" + Branch
+		context += "/src/branch/main"
 	}
 	options := api.MarkupOption{
 		Mode:     mode,
@@ -42,16 +38,17 @@ func testRenderMarkup(t *testing.T, mode string, wiki bool, filePath, text, resp
 	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markup")
 	web.SetForm(ctx, &options)
 	Markup(ctx)
-	assert.Equal(t, responseBody, resp.Body.String())
-	assert.Equal(t, responseCode, resp.Code)
+	assert.Equal(t, expectedBody, resp.Body.String())
+	assert.Equal(t, expectedCode, resp.Code)
 	resp.Body.Reset()
 }
 
 func testRenderMarkdown(t *testing.T, mode string, wiki bool, text, responseBody string, responseCode int) {
+	t.Helper()
 	setting.AppURL = AppURL
-	context := Repo
+	context := "/gogits/gogs"
 	if !wiki {
-		context += "/src/branch/" + Branch
+		context += "/src/branch/main"
 	}
 	options := api.MarkdownOption{
 		Mode:    mode,
@@ -83,20 +80,20 @@ func TestAPI_RenderGFM(t *testing.T) {
 		// rendered
 		`<p>Wiki! Enjoy :)</p>
 <ul>
-<li><a href="` + FullURL + `wiki/Links" rel="nofollow">Links, Language bindings, Engine bindings</a></li>
-<li><a href="` + FullURL + `wiki/Tips" rel="nofollow">Tips</a></li>
-<li>Bezier widget (by <a href="` + AppURL + `r-lyeh" rel="nofollow">@r-lyeh</a>) <a href="https://github.com/ocornut/imgui/issues/786" rel="nofollow">https://github.com/ocornut/imgui/issues/786</a></li>
+<li><a href="http://localhost:3000/gogits/gogs/wiki/Links" rel="nofollow">Links, Language bindings, Engine bindings</a></li>
+<li><a href="http://localhost:3000/gogits/gogs/wiki/Tips" rel="nofollow">Tips</a></li>
+<li>Bezier widget (by <a href="http://localhost:3000/r-lyeh" rel="nofollow">@r-lyeh</a>) <a href="https://github.com/ocornut/imgui/issues/786" rel="nofollow">https://github.com/ocornut/imgui/issues/786</a></li>
 </ul>
 `,
 		// Guard wiki sidebar: special syntax
 		`[[Guardfile-DSL / Configuring-Guard|Guardfile-DSL---Configuring-Guard]]`,
 		// rendered
-		`<p><a href="` + FullURL + `wiki/Guardfile-DSL---Configuring-Guard" rel="nofollow">Guardfile-DSL / Configuring-Guard</a></p>
+		`<p><a href="http://localhost:3000/gogits/gogs/wiki/Guardfile-DSL---Configuring-Guard" rel="nofollow">Guardfile-DSL / Configuring-Guard</a></p>
 `,
 		// special syntax
 		`[[Name|Link]]`,
 		// rendered
-		`<p><a href="` + FullURL + `wiki/Link" rel="nofollow">Name</a></p>
+		`<p><a href="http://localhost:3000/gogits/gogs/wiki/Link" rel="nofollow">Name</a></p>
 `,
 		// empty
 		``,
@@ -120,8 +117,8 @@ Here are some links to the most important topics. You can find the full list of 
 <p><strong>Wine Staging</strong> on website <a href="http://wine-staging.com" rel="nofollow">wine-staging.com</a>.</p>
 <h2 id="user-content-quick-links">Quick Links</h2>
 <p>Here are some links to the most important topics. You can find the full list of pages at the sidebar.</p>
-<p><a href="` + FullURL + `wiki/Configuration" rel="nofollow">Configuration</a>
-<a href="` + FullURL + `wiki/raw/images/icon-bug.png" rel="nofollow"><img src="` + FullURL + `wiki/raw/images/icon-bug.png" title="icon-bug.png" alt="images/icon-bug.png"/></a></p>
+<p><a href="http://localhost:3000/gogits/gogs/wiki/Configuration" rel="nofollow">Configuration</a>
+<a href="http://localhost:3000/gogits/gogs/wiki/raw/images/icon-bug.png" rel="nofollow"><img src="http://localhost:3000/gogits/gogs/wiki/raw/images/icon-bug.png" title="icon-bug.png" alt="images/icon-bug.png"/></a></p>
 `,
 	}
 
@@ -132,8 +129,8 @@ Here are some links to the most important topics. You can find the full list of 
 ![Image](image.png)`,
 		// rendered
 		`<h1 id="user-content-title">Title</h1>
-<p><a href="` + FullURL + `src/branch/` + Branch + `/test.md" rel="nofollow">Link</a>
-<a href="` + FullURL + `media/branch/` + Branch + `/image.png" target="_blank" rel="nofollow noopener"><img src="` + FullURL + `media/branch/` + Branch + `/image.png" alt="Image"/></a></p>
+<p><a href="http://localhost:3000/gogits/gogs/src/branch/main/test.md" rel="nofollow">Link</a>
+<a href="http://localhost:3000/gogits/gogs/media/branch/main/image.png" target="_blank" rel="nofollow noopener"><img src="http://localhost:3000/gogits/gogs/media/branch/main/image.png" alt="Image"/></a></p>
 `,
 	}
 
@@ -189,7 +186,7 @@ func TestAPI_RenderSimple(t *testing.T) {
 	options := api.MarkdownOption{
 		Mode:    "markdown",
 		Text:    "",
-		Context: Repo,
+		Context: "/gogits/gogs",
 	}
 	ctx, resp := contexttest.MockAPIContext(t, "POST /api/v1/markdown")
 	for i := 0; i < len(simpleCases); i += 2 {

--- a/routers/api/v1/misc/markup_test.go
+++ b/routers/api/v1/misc/markup_test.go
@@ -22,7 +22,6 @@ import (
 const AppURL = "http://localhost:3000/"
 
 func testRenderMarkup(t *testing.T, mode string, wiki bool, filePath, text, expectedBody string, expectedCode int) {
-	t.Helper()
 	setting.AppURL = AppURL
 	context := "/gogits/gogs"
 	if !wiki {
@@ -44,7 +43,6 @@ func testRenderMarkup(t *testing.T, mode string, wiki bool, filePath, text, expe
 }
 
 func testRenderMarkdown(t *testing.T, mode string, wiki bool, text, responseBody string, responseCode int) {
-	t.Helper()
 	setting.AppURL = AppURL
 	context := "/gogits/gogs"
 	if !wiki {

--- a/routers/common/markup.go
+++ b/routers/common/markup.go
@@ -59,7 +59,7 @@ func RenderMarkup(ctx *context.Base, repo *context.Repository, mode, text, urlPa
 	}
 
 	fields := strings.SplitN(strings.TrimPrefix(urlPathContext, setting.AppSubURL+"/"), "/", 5)
-	if len(fields) == 5 && fields[2] == "src" && fields[3] == "branch" {
+	if len(fields) == 5 && fields[2] == "src" && (fields[3] == "branch" || fields[3] == "commit" || fields[3] == "tag") {
 		// absolute base prefix is something like "https://host/subpath/{user}/{repo}"
 		absoluteBasePrefix := fmt.Sprintf("%s%s/%s", httplib.GuessCurrentAppURL(ctx), fields[0], fields[1])
 

--- a/routers/common/markup.go
+++ b/routers/common/markup.go
@@ -20,7 +20,7 @@ import (
 
 // RenderMarkup renders markup text for the /markup and /markdown endpoints
 func RenderMarkup(ctx *context.Base, repo *context.Repository, mode, text, urlPathContext, filePath string, wiki bool) {
-	// urlPathContext format is "/subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file-base-path}"
+	// urlPathContext format is "/subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file/dir}"
 	// filePath is the path of the file to render if the end user is trying to preview a repo file (mode == "file")
 	// filePath will be used as RenderContext.RelativePath
 

--- a/routers/common/markup.go
+++ b/routers/common/markup.go
@@ -66,6 +66,22 @@ func RenderMarkup(ctx *context.Base, repo *context.Repository, mode, text, urlPr
 		}
 	}
 
+	links := markup.Links{
+		AbsolutePrefix: true,
+		Base:           urlPrefix,
+	}
+
+	// Parse branch path and tree path, for correct media links.
+	urlElements := strings.Split(strings.TrimPrefix(urlPrefix, setting.AppURL), "/")
+	if len(urlElements) >= 5 && urlElements[2] == "src" {
+		links = markup.Links{
+			AbsolutePrefix: true,
+			Base:           setting.AppURL + urlElements[0] + "/" + urlElements[1],
+			BranchPath:     urlElements[3] + "/" + urlElements[4],
+			TreePath:       strings.Join(urlElements[5:], "/"),
+		}
+	}
+
 	meta := map[string]string{}
 	var repoCtx *repo_model.Repository
 	if repo != nil && repo.Repository != nil {
@@ -81,12 +97,9 @@ func RenderMarkup(ctx *context.Base, repo *context.Repository, mode, text, urlPr
 	}
 
 	if err := markup.Render(&markup.RenderContext{
-		Ctx:  ctx,
-		Repo: repoCtx,
-		Links: markup.Links{
-			AbsolutePrefix: true,
-			Base:           urlPrefix,
-		},
+		Ctx:          ctx,
+		Repo:         repoCtx,
+		Links:        links,
 		Metas:        meta,
 		IsWiki:       wiki,
 		Type:         markupType,

--- a/routers/common/markup.go
+++ b/routers/common/markup.go
@@ -72,6 +72,7 @@ func RenderMarkup(ctx *context.Base, repo *context.Repository, mode, text, urlPr
 	}
 
 	// Parse branch path and tree path, for correct media links.
+	// The expected route is "{user}/{repo}/src/{branch, commit, tag]/{identifier}"
 	urlElements := strings.Split(strings.TrimPrefix(urlPrefix, setting.AppURL), "/")
 	if len(urlElements) >= 5 && urlElements[2] == "src" {
 		links = markup.Links{

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22404,7 +22404,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "URL path for rendering issue, media and file links\nExpected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}\n\nin: body",
           "type": "string"
         },
         "Mode": {
@@ -22427,7 +22427,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "URL path for rendering issue, media and file links\nExpected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}\n\nin: body",
           "type": "string"
         },
         "FilePath": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22404,7 +22404,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "Context to render\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}\n\nin: body",
           "type": "string"
         },
         "Mode": {
@@ -22427,7 +22427,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "Context to render\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: {user}/{repo}/src/{branch, commit, tag}/{identifier}/{filepath}\n\nin: body",
           "type": "string"
         },
         "FilePath": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22404,7 +22404,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file/dir}\n\nin: body",
           "type": "string"
         },
         "Mode": {
@@ -22427,7 +22427,7 @@
       "type": "object",
       "properties": {
         "Context": {
-          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}\n\nin: body",
+          "description": "URL path for rendering issue, media and file links\nExpected format: /subpath/{user}/{repo}/src/{branch, commit, tag}/{identifier/path}/{file/dir}\n\nin: body",
           "type": "string"
         },
         "FilePath": {


### PR DESCRIPTION
Parse base path and tree path so that media links can be correctly created with /media/.

Resolves #31294