### PR TITLE
Fix line number width in code preview

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1001,8 +1001,6 @@ overflow-menu .ui.label {
   padding: 0 8px;
   text-align: right !important;
   color: var(--color-text-light-2);
-  width: 1%;
-  font-family: var(--fonts-monospace);
 }
 
 .lines-num span.bottom-line::after {


### PR DESCRIPTION
Line numbers were using some hacky CSS `width: 1%` that did nothing to the code rendering as far as I can tell but broken the inline preview in markup when line numbers are greater than 2 digits. Also I removed one duplicate `font-family` rule (it is set below in the `.lines-num, .lines-code` selector.

Before:

<img width="973" alt="Screenshot 2024-06-10 at 13 57 15" src="https://github.com/go-gitea/gitea/assets/115237/80578614-e476-4dd1-b20a-bc786bee3574">

After:

<img width="975" alt="Screenshot 2024-06-10 at 13 59 19" src="https://github.com/go-gitea/gitea/assets/115237/a0697dbf-1792-4176-8088-f4dca9b262a0">
