### PR TITLE
Fix adopt repository has empty object name in database

### DIFF
--- a/modules/repository/branch.go
+++ b/modules/repository/branch.go
@@ -45,6 +45,7 @@ func SyncRepoBranchesWithRepo(ctx context.Context, repo *repo_model.Repository, 
 	if err != nil {
 		return 0, fmt.Errorf("UpdateRepository: %w", err)
 	}
+	repo.ObjectFormatName = objFmt.Name() // keep consistent with db
 
 	allBranches := container.Set[string]{}
 	{


### PR DESCRIPTION
Fix #31330
Fix #31311

A workaround to fix the old database is to update object_format_name to `sha1` if it's empty or null.