### PR TITLE
proposal: add max height limit and overflow for organization profile

### DIFF
--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -108,6 +108,11 @@
   border: 1px solid var(--color-secondary);
 }
 
+.organization.profile #readme_profile {
+    max-height: 40vh;
+    overflow: auto;
+}
+
 #notification_table {
   background: var(--color-box-body);
   border: 1px solid var(--color-secondary);

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -109,8 +109,8 @@
 }
 
 .organization.profile #readme_profile {
-    max-height: 40vh;
-    overflow: auto;
+  max-height: 40vh;
+  overflow: auto;
 }
 
 #notification_table {


### PR DESCRIPTION
as title, maybe usefull for user to jump to repository quickly when the profile READEME is too long.
example view:

![屏幕截图 2024-06-13 091330](https://github.com/go-gitea/gitea/assets/25342410/5fc87c37-b60f-4625-9fe1-6a152a831419)
