### PR TITLE
Refactor to use UnsafeStringToBytes

### DIFF
--- a/modules/markup/markdown/prefixed_id.go
+++ b/modules/markup/markdown/prefixed_id.go
@@ -9,9 +9,9 @@ import (
 
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/markup/common"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/util"
 )
 
 type prefixedIDs struct {
@@ -36,7 +36,7 @@ func (p *prefixedIDs) GenerateWithDefault(value, dft []byte) []byte {
 	if !bytes.HasPrefix(result, []byte("user-content-")) {
 		result = append([]byte("user-content-"), result...)
 	}
-	if p.values.Add(util.BytesToReadOnlyString(result)) {
+	if p.values.Add(util.UnsafeBytesToString(result)) {
 		return result
 	}
 	for i := 1; ; i++ {
@@ -49,7 +49,7 @@ func (p *prefixedIDs) GenerateWithDefault(value, dft []byte) []byte {
 
 // Put puts a given element id to the used ids table.
 func (p *prefixedIDs) Put(value []byte) {
-	p.values.Add(util.BytesToReadOnlyString(value))
+	p.values.Add(util.UnsafeBytesToString(value))
 }
 
 func newPrefixedIDs() *prefixedIDs {

--- a/modules/markup/markdown/transform_heading.go
+++ b/modules/markup/markdown/transform_heading.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 
 	"code.gitea.io/gitea/modules/markup"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/text"
-	"github.com/yuin/goldmark/util"
 )
 
 func (g *ASTTransformer) transformHeading(_ *markup.RenderContext, v *ast.Heading, reader text.Reader, tocList *[]markup.Header) {
@@ -21,11 +21,11 @@ func (g *ASTTransformer) transformHeading(_ *markup.RenderContext, v *ast.Headin
 	}
 	txt := v.Text(reader.Source())
 	header := markup.Header{
-		Text:  util.BytesToReadOnlyString(txt),
+		Text:  util.UnsafeBytesToString(txt),
 		Level: v.Level,
 	}
 	if id, found := v.AttributeString("id"); found {
-		header.ID = util.BytesToReadOnlyString(id.([]byte))
+		header.ID = util.UnsafeBytesToString(id.([]byte))
 	}
 	*tocList = append(*tocList, header)
 	g.applyElementDir(v)

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -14,8 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup/mdstripper"
 	"code.gitea.io/gitea/modules/setting"
-
-	"github.com/yuin/goldmark/util"
+	"code.gitea.io/gitea/modules/util"
 )
 
 var (
@@ -341,7 +340,7 @@ func FindRenderizableReferenceNumeric(content string, prOnly, crossLinkOnly bool
 			return false, nil
 		}
 	}
-	r := getCrossReference(util.StringToReadOnlyBytes(content), match[2], match[3], false, prOnly)
+	r := getCrossReference(util.UnsafeStringToBytes(content), match[2], match[3], false, prOnly)
 	if r == nil {
 		return false, nil
 	}

--- a/modules/system/db.go
+++ b/modules/system/db.go
@@ -8,8 +8,7 @@ import (
 
 	"code.gitea.io/gitea/models/system"
 	"code.gitea.io/gitea/modules/json"
-
-	"github.com/yuin/goldmark/util"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // DBStore can be used to store app state items in local filesystem
@@ -24,7 +23,7 @@ func (f *DBStore) Get(ctx context.Context, item StateItem) error {
 	if content == "" {
 		return nil
 	}
-	return json.Unmarshal(util.StringToReadOnlyBytes(content), item)
+	return json.Unmarshal(util.UnsafeStringToBytes(content), item)
 }
 
 // Set saves the state item
@@ -33,5 +32,5 @@ func (f *DBStore) Set(ctx context.Context, item StateItem) error {
 	if err != nil {
 		return err
 	}
-	return system.SaveAppStateContent(ctx, item.Name(), util.BytesToReadOnlyString(b))
+	return system.SaveAppStateContent(ctx, item.Name(), util.UnsafeBytesToString(b))
 }

--- a/modules/util/sanitize.go
+++ b/modules/util/sanitize.go
@@ -6,8 +6,6 @@ package util
 import (
 	"bytes"
 	"unicode"
-
-	"github.com/yuin/goldmark/util"
 )
 
 type sanitizedError struct {
@@ -33,7 +31,7 @@ var schemeSep = []byte("://")
 
 // SanitizeCredentialURLs remove all credentials in URLs (starting with "scheme://") for the input string: "https://user:pass@domain.com" => "https://sanitized-credential@domain.com"
 func SanitizeCredentialURLs(s string) string {
-	bs := util.StringToReadOnlyBytes(s)
+	bs := UnsafeStringToBytes(s)
 	schemeSepPos := bytes.Index(bs, schemeSep)
 	if schemeSepPos == -1 || bytes.IndexByte(bs[schemeSepPos:], '@') == -1 {
 		return s // fast return if there is no URL scheme or no userinfo
@@ -70,5 +68,5 @@ func SanitizeCredentialURLs(s string) string {
 		schemeSepPos = bytes.Index(bs, schemeSep)
 	}
 	out = append(out, bs...)
-	return util.BytesToReadOnlyString(out)
+	return UnsafeBytesToString(out)
 }

--- a/modules/util/string.go
+++ b/modules/util/string.go
@@ -87,11 +87,11 @@ func ToSnakeCase(input string) string {
 }
 
 // UnsafeBytesToString uses Go's unsafe package to convert a byte slice to a string.
-// TODO: replace all "goldmark/util.BytesToReadOnlyString" with this official approach
 func UnsafeBytesToString(b []byte) string {
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
+// UnsafeStringToBytes uses Go's unsafe package to convert a string to a byte slice.
 func UnsafeStringToBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }


### PR DESCRIPTION
The PR replaces all `goldmark/util.BytesToReadOnlyString` with `util.UnsafeBytesToString`, `goldmark/util.StringToReadOnlyBytes` with `util.UnsafeStringToBytes`. This removes one `TODO`.