### PR TITLE
Fix double border in system status table

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -76,9 +76,11 @@
 			{{ctx.Locale.Tr "admin.dashboard.system_status"}}
 		</h4>
 		{{/* TODO: make these stats work in multi-server deployments, likely needs per-server stats in DB */}}
-		<div hx-get="{{$.Link}}/system_status" hx-swap="morph:innerHTML" hx-trigger="every 5s" hx-indicator=".no-loading-indicator" class="ui attached table segment">
-			{{template "admin/system_status" .}}
+		<div class="ui attached table segment">
+			<div class="no-loading-indicator tw-hidden"></div>
+			<div hx-get="{{$.Link}}/system_status" hx-swap="morph:innerHTML" hx-trigger="every 5s" hx-indicator=".no-loading-indicator">
+				{{template "admin/system_status" .}}
+			</div>
 		</div>
-		<div class="no-loading-indicator tw-hidden"></div>
 	</div>
 {{template "admin/layout_footer" .}}

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -76,9 +76,9 @@
 			{{ctx.Locale.Tr "admin.dashboard.system_status"}}
 		</h4>
 		{{/* TODO: make these stats work in multi-server deployments, likely needs per-server stats in DB */}}
-		<div class="no-loading-indicator tw-hidden"></div>
 		<div hx-get="{{$.Link}}/system_status" hx-swap="morph:innerHTML" hx-trigger="every 5s" hx-indicator=".no-loading-indicator" class="ui attached table segment">
 			{{template "admin/system_status" .}}
 		</div>
+		<div class="no-loading-indicator tw-hidden"></div>
 	</div>
 {{template "admin/layout_footer" .}}


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/pull/30712 where the introduction of this `<div>` caused the `.ui.attached:not(.message) + .ui.attached.segment:not(.top)` CSS selector to no longer work and cause a double border.

Before:

<img width="200" alt="Screenshot 2024-06-13 at 19 06 12" src="https://github.com/go-gitea/gitea/assets/115237/a9fa0688-adf0-4b2d-a958-6a7679a62031">

After:
<img width="232" alt="Screenshot 2024-06-13 at 19 05 57" src="https://github.com/go-gitea/gitea/assets/115237/025b780f-f72f-4049-86de-a5d84851bd1d">
