### PR TITLE
Have new announcement about docs contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,10 @@
-<!-- start tips --> 
+<!-- start tips -->
 Please check the following:
 1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for backports.
 2. Make sure you have read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md .
-3. Describe what your pull request does and which issue you're targeting (if any).
-4. It is recommended to enable "Allow edits by maintainers", so maintainers can help more easily.
-5. Your input here will be included in the commit message when this PR has been merged. If you don't want some content to be included, please separate them with a line like `---`.
-6. Delete all these tips before posting.
+3. For documentations contribution, please go to https://gitea.com/gitea/docs
+4. Describe what your pull request does and which issue you're targeting (if any).
+5. It is recommended to enable "Allow edits by maintainers", so maintainers can help more easily.
+6. Your input here will be included in the commit message when this PR has been merged. If you don't want some content to be included, please separate them with a line like `---`.
+7. Delete all these tips before posting.
 <!-- end tips -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,7 +358,8 @@ $REWRITTEN_PR_SUMMARY
 
 ## Documentation
 
-If you add a new feature or change an existing aspect of Gitea, the documentation for that feature must be created or updated in the same PR.
+If you add a new feature or change an existing aspect of Gitea, the documentation for that feature must be created or updated in another PR at [https://gitea.com/gitea/docs](https://gitea.com/gitea/docs).
+**The docs directory on main repository will be removed at some time. We will have a yaml file to store configuration file's meta data. After that completed, configuration documentation should be in the main respository.**
 
 ## API v1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ $REWRITTEN_PR_SUMMARY
 ## Documentation
 
 If you add a new feature or change an existing aspect of Gitea, the documentation for that feature must be created or updated in another PR at [https://gitea.com/gitea/docs](https://gitea.com/gitea/docs).
-**The docs directory on main repository will be removed at some time. We will have a yaml file to store configuration file's meta data. After that completed, configuration documentation should be in the main respository.**
+**The docs directory on main repository will be removed at some time. We will have a yaml file to store configuration file's meta data. After that completed, configuration documentation should be in the main repository.**
 
 ## API v1
 


### PR DESCRIPTION
According to the maintainers' discussion and voting. We decide to move docs to https://gitea.com/gitea/docs . Add some hints on this repository to not make contributors confusing.