### PR TITLE
Improve `flex-item` overflow

### DIFF
--- a/templates/shared/issuelist.tmpl
+++ b/templates/shared/issuelist.tmpl
@@ -13,17 +13,19 @@
 			<div class="flex-item-main">
 				<div class="flex-item-header">
 					<div class="flex-item-title">
-						<a class="tw-no-underline issue-title" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">{{RenderEmoji $.Context .Title | RenderCodeBlock}}</a>
-						{{if .IsPull}}
-							{{if (index $.CommitStatuses .PullRequest.ID)}}
-								{{template "repo/commit_statuses" dict "Status" (index $.CommitLastStatus .PullRequest.ID) "Statuses" (index $.CommitStatuses .PullRequest.ID)}}
+						<div class="flex-item-title-inline">
+							<a class="tw-no-underline issue-title" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">{{RenderEmoji $.Context .Title | RenderCodeBlock}}</a>
+							{{if .IsPull}}
+								{{if (index $.CommitStatuses .PullRequest.ID)}}
+									{{template "repo/commit_statuses" dict "Status" (index $.CommitLastStatus .PullRequest.ID) "Statuses" (index $.CommitStatuses .PullRequest.ID)}}
+								{{end}}
 							{{end}}
-						{{end}}
-						<span class="labels-list tw-ml-1">
-							{{range .Labels}}
-								<a href="?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{.ID}}{{if ne $.listType "milestone"}}&milestone={{$.MilestoneID}}{{end}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{RenderLabel $.Context ctx.Locale .}}</a>
-							{{end}}
-						</span>
+							<span class="labels-list">
+								{{range .Labels}}
+									<a href="?q={{$.Keyword}}&type={{$.ViewType}}&state={{$.State}}&labels={{.ID}}{{if ne $.listType "milestone"}}&milestone={{$.MilestoneID}}{{end}}&assignee={{$.AssigneeID}}&poster={{$.PosterID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{RenderLabel $.Context ctx.Locale .}}</a>
+								{{end}}
+							</span>
+						</div>
 					</div>
 					{{if or .TotalTrackedTime .Assignees .NumComments}}
 					<div class="flex-item-trailing">

--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -26,7 +26,12 @@
   display: flex;
   gap: .25rem;
   justify-content: space-between;
-  flex-wrap: wrap;
+}
+
+@media (max-width: 600px) {
+  .flex-item-header {
+    flex-direction: column;
+  }
 }
 
 .flex-item a:not(.label, .button):hover {
@@ -46,8 +51,15 @@
   gap: 0.5rem;
   align-items: center;
   flex-grow: 0;
+  flex-shrink: 0;
   flex-wrap: wrap;
   justify-content: end;
+}
+
+@media (max-width: 600px) {
+  .flex-item .flex-item-trailing {
+    justify-content: flex-start;
+  }
 }
 
 .flex-item .flex-item-title {
@@ -66,6 +78,15 @@
 .flex-item .flex-item-title a {
   color: var(--color-text);
   overflow-wrap: anywhere;
+}
+
+/* display:inline wrapper that makes labels overflow like text */
+.flex-item-title-inline {
+  display: inline;
+}
+.flex-item-title-inline > * {
+  display: inline !important;
+  vertical-align: bottom;
 }
 
 .flex-item .flex-item-body {

--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -53,7 +53,7 @@
   flex-grow: 0;
   flex-shrink: 0;
   flex-wrap: wrap;
-  justify-content: end;
+  justify-content: flex-end;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
Previously, labels could not break onto multiple lines when overflowing. Fix this by adding a wrapper element that sets `display: inline` which as far as I'm aware is the only `display` mode that achieves such overflow. Also introduced a breakpoint at 600px where the item goes into column layout.

Diff: https://github.com/go-gitea/gitea/pull/31404/files?diff=unified&w=1

Desktop before/after:

<img width="1137" alt="Screenshot 2024-06-17 at 23 24 56" src="https://github.com/go-gitea/gitea/assets/115237/611efe36-3481-4cca-aaaa-82e4dfb61459">
<img width="1139" alt="Screenshot 2024-06-17 at 23 24 43" src="https://github.com/go-gitea/gitea/assets/115237/685130ad-ee12-4ed0-99f4-fae3e152c4f3">

Mobile before/after:

<img width="499" alt="Screenshot 2024-06-17 at 23 25 49" src="https://github.com/go-gitea/gitea/assets/115237/17a287b9-a89c-4b5f-9098-29d48431d990">
<img width="494" alt="Screenshot 2024-06-17 at 23 25 36" src="https://github.com/go-gitea/gitea/assets/115237/af114e60-a103-400b-9340-90e7a991ef21">

