### PR TITLE
Reduce `air` verbosity

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -21,3 +21,6 @@ exclude_dir = [
 ]
 exclude_regex = ["_test.go$", "_gen.go$"]
 stop_on_error = true
+
+[log]
+main_only = true


### PR DESCRIPTION
Make `air` log less. Uses the option added in https://github.com/air-verse/air/pull/367. `make watch` now looks like this:

```
$ make watch
npm install --no-save
GITEA_RUN_MODE=dev go run github.com/air-verse/air@v1 -c .air.toml

added 11 packages, removed 4 packages, and changed 73 packages in 2s
NODE_ENV=development npx webpack --watch --progress

  __    _   ___
 / /\  | | | |_)
/_/--\ |_| |_| \_ v1.52.2, built with Go go1.22.4

Running go generate...