### PR TITLE
Fix new issue/pr avatar

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -530,12 +530,8 @@ td .commit-summary {
   min-width: 100px;
 }
 
-.repository.new.issue .comment.form .comment .avatar {
+#new-issue .avatar {
   width: 3em;
-}
-
-.repository.new.issue .comment.form .content {
-  margin-left: 4em;
 }
 
 .repository.new.issue .comment.form .content::before,


### PR DESCRIPTION
The avatar on "New Issue" and "New Pull Request" pages was inconsistent. Removed the extra margin and the new CSS rules now use common parent `<form id="#new-issue">` because `.repository.new.issue` is not present on pull request page.

Before:

<img width="181" alt="Screenshot 2024-06-19 at 13 56 17" src="https://github.com/go-gitea/gitea/assets/115237/5270d352-db5b-45b3-9d06-4790c17ae9b4">
<img width="213" alt="Screenshot 2024-06-19 at 13 54 02" src="https://github.com/go-gitea/gitea/assets/115237/012f5607-aef0-4f48-90e3-8d4022480203">


After:

<img width="195" alt="Screenshot 2024-06-19 at 13 54 16" src="https://github.com/go-gitea/gitea/assets/115237/e7590c66-3b28-4790-9970-33bd567eeb31">
<img width="212" alt="Screenshot 2024-06-19 at 13 54 22" src="https://github.com/go-gitea/gitea/assets/115237/8e1cfede-614c-4cea-9af2-ada6da7a7361">
