### PR TITLE
Fix markdown math brackets render problem

### DIFF
--- a/modules/markup/markdown/markdown_test.go
+++ b/modules/markup/markdown/markdown_test.go
@@ -551,6 +551,10 @@ func TestMathBlock(t *testing.T) {
 			"$$a$$",
 			`<pre class="code-block is-loading"><code class="chroma language-math display">a</code></pre>` + nl,
 		},
+		{
+			"$a$ ($b$) [$c$] {$d$}",
+			`<p><code class="language-math is-loading">a</code> (<code class="language-math is-loading">b</code>) [$c$] {$d$}</p>` + nl,
+		},
 	}
 
 	for _, test := range testcases {

--- a/modules/markup/markdown/math/inline_parser.go
+++ b/modules/markup/markdown/math/inline_parser.go
@@ -45,6 +45,10 @@ func isPunctuation(b byte) bool {
 	return b == '.' || b == '!' || b == '?' || b == ',' || b == ';' || b == ':'
 }
 
+func isBracket(b byte) bool {
+	return b == ')'
+}
+
 func isAlphanumeric(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
@@ -84,7 +88,7 @@ func (parser *inlineParser) Parse(parent ast.Node, block text.Reader, pc parser.
 			break
 		}
 		suceedingCharacter := line[pos]
-		if !isPunctuation(suceedingCharacter) && !(suceedingCharacter == ' ') {
+		if !isPunctuation(suceedingCharacter) && !(suceedingCharacter == ' ') && !isBracket(suceedingCharacter) {
 			return nil
 		}
 		if line[ender-1] != '\\' {


### PR DESCRIPTION
close #31371

compare

original text:
```text
$i = \sqrt{-1}$ ($i = \sqrt{-1}$)

$i = \sqrt{-1}$ [$i = \sqrt{-1}$]

$i = \sqrt{-1}$ {$i = \sqrt{-1}$}

$abcd

(this is a test)

[$test]

$test$

$a$ ($b$) [$c$] {$d$}
```

before fix:
![image](https://github.com/go-gitea/gitea/assets/30816317/dbc4b790-5891-4f97-97f7-d5e5c26e7a55)

after fix:
![image](https://github.com/go-gitea/gitea/assets/30816317/b4c8a78d-7ea1-44ad-b9d4-6141338d83a2)

