### PR TITLE
Fix the wrong line number in the diff view page when expanded twice.

### DIFF
--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -53,17 +53,17 @@
 			<td colspan="2" class="lines-num">
 				<div class="code-expander-buttons" data-expand-direction="{{$expandDirection}}">
 					{{if or (eq $expandDirection 3) (eq $expandDirection 5)}}
-						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?data-query={{$line.GetBlobExcerptQuery}}&style=unified&direction=down&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
+						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?{{$line.GetBlobExcerptQuery}}&style=unified&direction=down&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
 							{{svg "octicon-fold-down"}}
 						</button>
 					{{end}}
 					{{if or (eq $expandDirection 3) (eq $expandDirection 4)}}
-						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?data-query={{$line.GetBlobExcerptQuery}}&style=unified&direction=up&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
+						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?{{$line.GetBlobExcerptQuery}}&style=unified&direction=up&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
 							{{svg "octicon-fold-up"}}
 						</button>
 					{{end}}
 					{{if eq $expandDirection 2}}
-						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?data-query={{$line.GetBlobExcerptQuery}}&style=unified&direction=&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
+						<button class="code-expander-button" hx-target="closest tr" hx-get="{{$.RepoLink}}/blob_excerpt/{{PathEscape $.AfterCommitID}}?{{$line.GetBlobExcerptQuery}}&style=unified&direction=&wiki={{$.PageIsWiki}}&anchor={{$.Anchor}}">
 							{{svg "octicon-fold"}}
 						</button>
 					{{end}}


### PR DESCRIPTION
close #31149

The problem is caused by the `data-query=` string affecting the parsing of the `last_left` parameter. When the page is first rendered, `data-query=` does not exist. However, after clicking expand, the returned HTML contains this string, causing the line numbers to start from 1 upon expanding a second time.

before fix
![圖片](https://github.com/go-gitea/gitea/assets/30816317/36842bde-cc30-43ba-91b0-c60a50a6dc0f)

after fix
![圖片](https://github.com/go-gitea/gitea/assets/30816317/b73d7e40-ec01-48ae-9992-09c19ee477ad)
