### PR TITLE
Fix labels and projects menu overflow on issue page

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -79,6 +79,11 @@
   white-space: nowrap;
 }
 
+.repository .issue-content-right .filter.menu {
+  max-height: 500px;
+  overflow-x: auto;
+}
+
 .repository .filter.menu.labels .label-filter .menu .info {
   display: inline-block;
   padding: 0.5rem 0;
@@ -560,11 +565,6 @@ td .commit-summary {
 
 .repository.new.issue .comment.form .content .markup {
   font-size: 14px;
-}
-
-.repository.new.issue .comment.form .issue-content-right .filter.menu {
-  max-height: 500px;
-  overflow-x: auto;
 }
 
 .repository.view.issue .instruct-toggle {


### PR DESCRIPTION
It was correct only on the new issue page.

Resolves #31415
