### PR TITLE
Fix Workflow names instead of workflow file name

### DIFF
--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -225,7 +225,7 @@ func List(ctx *context.Context) {
 		runs = append(runs, run)
 	}
 
-	ctx.Data["Runs"] = runs
+	ctx.Data["WorkflowActionRuns"] = runs
 
 	actors, err := actions_model.GetActors(ctx, ctx.Repo.Repository.ID)
 	if err != nil {

--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -218,9 +218,7 @@ func List(ctx *context.Context) {
 
 		// Connect the workflow to the run
 		for _, wf := range workflows {
-			fmt.Printf("Search workflow of %v", actionRun.WorkflowID)
 			if wf.WorkflowID == actionRun.WorkflowID {
-				fmt.Println("Found")
 				run.Workflow = wf
 			}
 		}

--- a/templates/repo/actions/list.tmpl
+++ b/templates/repo/actions/list.tmpl
@@ -10,7 +10,7 @@
 				<div class="ui fluid vertical menu">
 					<a class="item{{if not $.CurWorkflow}} active{{end}}" href="?actor={{$.CurActor}}&status={{$.CurStatus}}">{{ctx.Locale.Tr "actions.runs.all_workflows"}}</a>
 					{{range .workflows}}
-						<a class="item{{if eq .Entry.Name $.CurWorkflow}} active{{end}}" href="?workflow={{.Entry.Name}}&actor={{$.CurActor}}&status={{$.CurStatus}}">{{.Entry.Name}}
+						<a class="item{{if eq .Entry.Name $.CurWorkflow}} active{{end}}" href="?workflow={{.Entry.Name}}&actor={{$.CurActor}}&status={{$.CurStatus}}">{{.Name}}
 							{{if .ErrMsg}}
 								<span data-tooltip-content="{{.ErrMsg}}">
 									{{svg "octicon-alert" 16 "text red"}}

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -6,38 +6,42 @@
 	</div>
 	{{end}}
 	{{range .Runs}}
-		<div class="flex-item tw-items-center">
-			<div class="flex-item-leading">
-				{{template "repo/actions/status" (dict "status" .Status.String)}}
-			</div>
-			<div class="flex-item-main">
-				<a class="flex-item-title" title="{{.Title}}" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
-					{{if .Title}}{{.Title}}{{else}}{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}{{end}}
-				</a>
-				<div class="flex-item-body">
-					<span><b>{{if not $.CurWorkflow}}{{.WorkflowID}} {{end}}#{{.Index}}</b>:</span>
-					{{- if .ScheduleID -}}
-						{{ctx.Locale.Tr "actions.runs.scheduled"}}
-					{{- else -}}
-						{{ctx.Locale.Tr "actions.runs.commit"}}
-						<a href="{{$.RepoLink}}/commit/{{.CommitSHA}}">{{ShortSha .CommitSHA}}</a>
-						{{ctx.Locale.Tr "actions.runs.pushed_by"}}
-						<a href="{{.TriggerUser.HomeLink}}">{{.TriggerUser.GetDisplayName}}</a>
-					{{- end -}}
+		{{$CurWorkflow := $.CurWorkflow}}
+		{{$WorkflowName := .Workflow.Name}}
+		{{with .ActionRun}}
+			<div class="flex-item tw-items-center">
+				<div class="flex-item-leading">
+					{{template "repo/actions/status" (dict "status" .Status.String)}}
+				</div>
+				<div class="flex-item-main">
+					<a class="flex-item-title" title="{{.Title}}" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
+						{{if .Title}}{{.Title}}{{else}}{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}{{end}}
+					</a>
+					<div class="flex-item-body">
+						<span><b>{{if not $CurWorkflow}}{{$WorkflowName}} {{end}}#{{.Index}}</b>:</span>
+						{{- if .ScheduleID -}}
+							{{ctx.Locale.Tr "actions.runs.scheduled"}}
+						{{- else -}}
+							{{ctx.Locale.Tr "actions.runs.commit"}}
+							<a href="{{$.RepoLink}}/commit/{{.CommitSHA}}">{{ShortSha .CommitSHA}}</a>
+							{{ctx.Locale.Tr "actions.runs.pushed_by"}}
+							<a href="{{.TriggerUser.HomeLink}}">{{.TriggerUser.GetDisplayName}}</a>
+						{{- end -}}
+					</div>
+				</div>
+				<div class="flex-item-trailing">
+					{{if .RefLink}}
+						<a class="ui label run-list-ref gt-ellipsis" href="{{.RefLink}}">{{.PrettyRef}}</a>
+					{{else}}
+						<span class="ui label run-list-ref gt-ellipsis">{{.PrettyRef}}</span>
+					{{end}}
+					<div class="run-list-item-right">
+						<div class="run-list-meta">{{svg "octicon-calendar" 16}}{{TimeSinceUnix .Updated ctx.Locale}}</div>
+						<div class="run-list-meta">{{svg "octicon-stopwatch" 16}}{{.Duration}}</div>
+					</div>
 				</div>
 			</div>
-			<div class="flex-item-trailing">
-				{{if .RefLink}}
-					<a class="ui label run-list-ref gt-ellipsis" href="{{.RefLink}}">{{.PrettyRef}}</a>
-				{{else}}
-					<span class="ui label run-list-ref gt-ellipsis">{{.PrettyRef}}</span>
-				{{end}}
-				<div class="run-list-item-right">
-					<div class="run-list-meta">{{svg "octicon-calendar" 16}}{{TimeSinceUnix .Updated ctx.Locale}}</div>
-					<div class="run-list-meta">{{svg "octicon-stopwatch" 16}}{{.Duration}}</div>
-				</div>
-			</div>
-		</div>
+		{{end}}
 	{{end}}
 </div>
 {{template "base/paginate" .}}

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -1,47 +1,46 @@
 <div class="flex-list run-list">
-	{{if not .Runs}}
+	{{if not .WorkflowActionRuns}}
 	<div class="empty-placeholder">
 		{{svg "octicon-no-entry" 48}}
 		<h2>{{if $.IsFiltered}}{{ctx.Locale.Tr "actions.runs.no_results"}}{{else}}{{ctx.Locale.Tr "actions.runs.no_runs"}}{{end}}</h2>
 	</div>
 	{{end}}
-	{{range .Runs}}
-		{{$CurWorkflow := $.CurWorkflow}}
-		{{$WorkflowName := .Workflow.Name}}
-		{{with .ActionRun}}
-			<div class="flex-item tw-items-center">
-				<div class="flex-item-leading">
-					{{template "repo/actions/status" (dict "status" .Status.String)}}
-				</div>
-				<div class="flex-item-main">
-					<a class="flex-item-title" title="{{.Title}}" href="{{if .Link}}{{.Link}}{{else}}{{$.Link}}/{{.Index}}{{end}}">
-						{{if .Title}}{{.Title}}{{else}}{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}{{end}}
-					</a>
-					<div class="flex-item-body">
-						<span><b>{{if not $CurWorkflow}}{{$WorkflowName}} {{end}}#{{.Index}}</b>:</span>
-						{{- if .ScheduleID -}}
-							{{ctx.Locale.Tr "actions.runs.scheduled"}}
-						{{- else -}}
-							{{ctx.Locale.Tr "actions.runs.commit"}}
-							<a href="{{$.RepoLink}}/commit/{{.CommitSHA}}">{{ShortSha .CommitSHA}}</a>
-							{{ctx.Locale.Tr "actions.runs.pushed_by"}}
-							<a href="{{.TriggerUser.HomeLink}}">{{.TriggerUser.GetDisplayName}}</a>
-						{{- end -}}
-					</div>
-				</div>
-				<div class="flex-item-trailing">
-					{{if .RefLink}}
-						<a class="ui label run-list-ref gt-ellipsis" href="{{.RefLink}}">{{.PrettyRef}}</a>
-					{{else}}
-						<span class="ui label run-list-ref gt-ellipsis">{{.PrettyRef}}</span>
-					{{end}}
-					<div class="run-list-item-right">
-						<div class="run-list-meta">{{svg "octicon-calendar" 16}}{{TimeSinceUnix .Updated ctx.Locale}}</div>
-						<div class="run-list-meta">{{svg "octicon-stopwatch" 16}}{{.Duration}}</div>
-					</div>
+	{{range $run := .WorkflowActionRuns}}
+		{{$actionRun := $run.ActionRun}}
+		{{$workflow := $run.Workflow}}
+
+		<div class="flex-item tw-items-center">
+			<div class="flex-item-leading">
+				{{template "repo/actions/status" (dict "status" $actionRun.Status.String)}}
+			</div>
+			<div class="flex-item-main">
+				<a class="flex-item-title" title="{{$actionRun.Title}}" href="{{if $actionRun.Link}}{{$actionRun.Link}}{{else}}{{$.Link}}/{{$actionRun.Index}}{{end}}">
+					{{if $actionRun.Title}}{{$actionRun.Title}}{{else}}{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}{{end}}
+				</a>
+				<div class="flex-item-body">
+					<span><b>{{if not $.CurWorkflow}}{{$workflow.Name}} {{end}}#{{$actionRun.Index}}</b>:</span>
+					{{- if $actionRun.ScheduleID -}}
+						{{ctx.Locale.Tr "actions.runs.scheduled"}}
+					{{- else -}}
+						{{ctx.Locale.Tr "actions.runs.commit"}}
+						<a href="{{$.RepoLink}}/commit/{{$actionRun.CommitSHA}}">{{ShortSha $actionRun.CommitSHA}}</a>
+						{{ctx.Locale.Tr "actions.runs.pushed_by"}}
+						<a href="{{$actionRun.TriggerUser.HomeLink}}">{{$actionRun.TriggerUser.GetDisplayName}}</a>
+					{{- end -}}
 				</div>
 			</div>
-		{{end}}
+			<div class="flex-item-trailing">
+				{{if $actionRun.RefLink}}
+					<a class="ui label run-list-ref gt-ellipsis" href="{{$actionRun.RefLink}}">{{$actionRun.PrettyRef}}</a>
+				{{else}}
+					<span class="ui label run-list-ref gt-ellipsis">{{$actionRun.PrettyRef}}</span>
+				{{end}}
+				<div class="run-list-item-right">
+					<div class="run-list-meta">{{svg "octicon-calendar" 16}}{{TimeSinceUnix $actionRun.Updated ctx.Locale}}</div>
+					<div class="run-list-meta">{{svg "octicon-stopwatch" 16}}{{$actionRun.Duration}}</div>
+				</div>
+			</div>
+		</div>
 	{{end}}
 </div>
 {{template "base/paginate" .}}

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -8,7 +8,6 @@
 	{{range $run := .WorkflowActionRuns}}
 		{{$actionRun := $run.ActionRun}}
 		{{$workflow := $run.Workflow}}
-
 		<div class="flex-item tw-items-center">
 			<div class="flex-item-leading">
 				{{template "repo/actions/status" (dict "status" $actionRun.Status.String)}}


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/31458 and maybe https://github.com/go-gitea/gitea/issues/25912

I added the name from the YAML file to the workflow object. If there is no name in the file, the name remains the filename.
I created an object to connect the run and workflow together, which was necessary to show workflow name in action run list.

(Easier to review with disabled whitespace changes, unfortunately there is a lot of them in runs_list.tmpl :( )