### PR TITLE
Fix overflow menu flickering on mobile

### DIFF
--- a/web_src/js/webcomponents/overflow-menu.js
+++ b/web_src/js/webcomponents/overflow-menu.js
@@ -61,6 +61,7 @@ window.customElements.define('overflow-menu', class extends HTMLElement {
     }
 
     const itemFlexSpace = this.menuItemsEl.querySelector('.item-flex-space');
+    const itemOverFlowMenuButton = this.querySelector('.overflow-menu-button');
 
     // move items in tippy back into the menu items for subsequent measurement
     for (const item of this.tippyItems || []) {
@@ -72,7 +73,9 @@ window.customElements.define('overflow-menu', class extends HTMLElement {
     }
 
     // measure which items are partially outside the element and move them into the button menu
+    // flex space and overflow menu are excluded from measurement
     itemFlexSpace?.style.setProperty('display', 'none', 'important');
+    itemOverFlowMenuButton?.style.setProperty('display', 'none', 'important');
     this.tippyItems = [];
     const menuRight = this.offsetLeft + this.offsetWidth;
     const menuItems = this.menuItemsEl.querySelectorAll('.item, .item-flex-space');
@@ -89,6 +92,7 @@ window.customElements.define('overflow-menu', class extends HTMLElement {
       }
     }
     itemFlexSpace?.style.removeProperty('display');
+    itemOverFlowMenuButton?.style.removeProperty('display');
 
     // if there are no overflown items, remove any previously created button
     if (!this.tippyItems?.length) {


### PR DESCRIPTION
The overflow menu button was incorrectly included in the measurement of the width of the items. As a result it could get stuck in a loop alternating between different measurements as the button appears and disappears.

---

Here's an example of this. I don't know the exact conditions to get it into this state. But just making the window width small on desktop and going back and forth should already show more flickering than there needs to be.

https://github.com/go-gitea/gitea/assets/450909/048bdeb3-89db-4532-97e4-a5319d5528b8