### PR TITLE
use correct l10n string

### DIFF
--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -42,7 +42,7 @@
 			<form class="ui form" id="repo-collab-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
 				<div id="search-user-box" class="ui search input tw-align-middle">
-					<input class="prompt" name="collaborator" placeholder="{{ctx.Locale.Tr "search.team_kind"}}" autocomplete="off" autofocus required>
+					<input class="prompt" name="collaborator" placeholder="{{ctx.Locale.Tr "search.user_kind"}}" autocomplete="off" autofocus required>
 				</div>
 				<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.add_collaborator"}}</button>
 			</form>


### PR DESCRIPTION
Uses the correct string for searching - this is what it looks like prior to the change:
![image](https://github.com/go-gitea/gitea/assets/24910512/38519825-c347-44d6-85d4-6fa3c71ddb7c)
(observe how the top box has "Search teams" even though collaborator would be user