### PR TITLE
Refactor issue label selection

### DIFF
--- a/models/issues/label.go
+++ b/models/issues/label.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/label"
 	"code.gitea.io/gitea/modules/optional"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -143,37 +144,32 @@ func (l *Label) CalOpenOrgIssues(ctx context.Context, repoID, labelID int64) {
 
 // LoadSelectedLabelsAfterClick calculates the set of selected labels when a label is clicked
 func (l *Label) LoadSelectedLabelsAfterClick(currentSelectedLabels []int64, currentSelectedExclusiveScopes []string) {
-	labelQuerySlice := []int64{}
+	labelQueryParams := container.Set[string]{}
 	labelSelected := false
-	labelScope := l.ExclusiveScope()
-	for i, s := range currentSelectedLabels {
-		if s == l.ID {
+	exclusiveScope := l.ExclusiveScope()
+	for i, curSel := range currentSelectedLabels {
+		if curSel == l.ID {
 			labelSelected = true
-		} else if -s == l.ID {
+		} else if -curSel == l.ID {
 			labelSelected = true
 			l.IsExcluded = true
-		} else if s != 0 {
+		} else if curSel != 0 {
 			// Exclude other labels in the same scope from selection
-			if s < 0 || labelScope == "" || labelScope != currentSelectedExclusiveScopes[i] {
-				labelQuerySlice = append(labelQuerySlice, s)
+			if curSel < 0 || exclusiveScope == "" || exclusiveScope != currentSelectedExclusiveScopes[i] {
+				labelQueryParams.Add(strconv.FormatInt(curSel, 10))
 			}
 		}
 	}
 
 	if !labelSelected {
-		labelQuerySlice = append(labelQuerySlice, l.ID)
+		labelQueryParams.Add(strconv.FormatInt(l.ID, 10))
 	}
 	l.IsSelected = labelSelected
 
 	// Sort and deduplicate the ids to avoid the crawlers asking for the
 	// same thing with simply a different order of parameters
-	slices.Sort(labelQuerySlice)
-	labelQuerySlice = slices.Compact(labelQuerySlice)
-	// Quick conversion (strings.Join() doesn't accept slices of Int64)
-	labelQuerySliceStrings := make([]string, len(labelQuerySlice))
-	for i, x := range labelQuerySlice {
-		labelQuerySliceStrings[i] = strconv.FormatInt(x, 10)
-	}
+	labelQuerySliceStrings := labelQueryParams.Values()
+	slices.Sort(labelQuerySliceStrings) // the sort is still needed because the underlying map of Set doesn't guarantee order
 	l.QueryString = strings.Join(labelQuerySliceStrings, ",")
 }
 
@@ -187,7 +183,7 @@ func (l *Label) BelongsToRepo() bool {
 	return l.RepoID > 0
 }
 
-// Return scope substring of label name, or empty string if none exists
+// ExclusiveScope returns scope substring of label name, or empty string if none exists
 func (l *Label) ExclusiveScope() string {
 	if !l.Exclusive {
 		return ""


### PR DESCRIPTION
Follow #26460, rename the variable names to follow Golang standard, and use `container.Set[string]` directly to simplify the code.