### PR TITLE
Fix avatar radius problem on the new issue page

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -535,7 +535,7 @@ td .commit-summary {
   min-width: 100px;
 }
 
-#new-issue .avatar {
+#new-issue .comment .avatar {
   width: 3em;
 }
 


### PR DESCRIPTION
Close #31502

Related to #31419.

In this PR, the avatar width is set to 3em, but the height is not set, so the image is not squared.

When object-fit is set to contain, it can't maintain the radius of the image.

Result:
![圖片](https://github.com/go-gitea/gitea/assets/30816317/bceb98aa-b0f7-4753-bc8b-3b9c41dfd55a)
