### PR TITLE
Fix JS error with disabled attachment and easymde

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -264,7 +264,9 @@ class ComboMarkdownEditor {
     });
     this.applyEditorHeights(this.container.querySelector('.CodeMirror-scroll'), this.options.editorHeights);
     await attachTribute(this.easyMDE.codemirror.getInputField(), {mentions: true, emoji: true});
-    initEasyMDEPaste(this.easyMDE, this.dropzone);
+    if (this.dropzone) {
+      initEasyMDEPaste(this.easyMDE, this.dropzone);
+    }
     hideElem(this.textareaMarkdownToolbar);
   }
 


### PR DESCRIPTION
Not sure if this is a regression from https://github.com/go-gitea/gitea/pull/30513, but when attachments are disabled, `this.dropzone` is null and the code had failed in `initEasyMDEPaste` trying to access `dropzoneEl.dropzone`.