### PR TITLE
Support legacy _links LFS batch responses

### DIFF
--- a/modules/lfs/http_client.go
+++ b/modules/lfs/http_client.go
@@ -181,6 +181,10 @@ func (c *HTTPClient) performOperation(ctx context.Context, objects []Pointer, dc
 		} else {
 			link, ok := object.Actions["download"]
 			if !ok {
+				// no actions block in response, try legacy response schema
+				link, ok = object.Links["download"]
+			}
+			if !ok {
 				log.Debug("%+v", object)
 				return errors.New("missing action 'download'")
 			}

--- a/modules/lfs/http_client_test.go
+++ b/modules/lfs/http_client_test.go
@@ -59,6 +59,17 @@ func lfsTestRoundtripHandler(req *http.Request) *http.Response {
 				},
 			},
 		}
+	} else if strings.Contains(url, "legacy-batch-request-download") {
+		batchResponse = &BatchResponse{
+			Transfer: "dummy",
+			Objects: []*ObjectResponse{
+				{
+					Links: map[string]*Link{
+						"download": {},
+					},
+				},
+			},
+		}
 	} else if strings.Contains(url, "valid-batch-request-upload") {
 		batchResponse = &BatchResponse{
 			Transfer: "dummy",
@@ -228,6 +239,11 @@ func TestHTTPClientDownload(t *testing.T) {
 		{
 			endpoint:      "https://unknown-actions-map.io",
 			expectederror: "missing action 'download'",
+		},
+		// case 11
+		{
+			endpoint:      "https://legacy-batch-request-download.io",
+			expectederror: "",
 		},
 	}
 

--- a/modules/lfs/shared.go
+++ b/modules/lfs/shared.go
@@ -47,6 +47,7 @@ type BatchResponse struct {
 type ObjectResponse struct {
 	Pointer
 	Actions map[string]*Link `json:"actions,omitempty"`
+	Links   map[string]*Link `json:"_links,omitempty"`
 	Error   *ObjectError     `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
Support legacy _links LFS batch response.

Fixes #31512.

This is backwards-compatible change to the LFS client so that, upon mirroring from an upstream which has a batch api, it can download objects whether the responses contain the `_links` field or its successor the `actions` field. When Gitea must fallback to the legacy `_links` field a logline is emitted at INFO level which looks like this:
```
...s/lfs/http_client.go:188:performOperation() [I] <LFSPointer ee95d0a27ccdfc7c12516d4f80dcf144a5eaf10d0461d282a7206390635cdbee:160> is using a deprecated batch schema response!
```

I've only run `test-backend` with this code, but added a new test to cover this case. Additionally I have a fork with this change deployed which I've confirmed syncs LFS from Gitea<-Artifactory (which has legacy `_links`) as well as from Gitea<-Gitea (which has the modern `actions`).
