### PR TITLE
Return an empty string when a repo has no avatar in the repo API (#31187)

### DIFF
--- a/models/repo/avatar.go
+++ b/models/repo/avatar.go
@@ -84,7 +84,13 @@ func (repo *Repository) relAvatarLink(ctx context.Context) string {
 	return setting.AppSubURL + "/repo-avatars/" + url.PathEscape(repo.Avatar)
 }
 
-// AvatarLink returns the full avatar url with http host. TODO: refactor it to a relative URL, but it is still used in API response at the moment
+// AvatarLink returns the full avatar url with http host or the empty string if the repo doesn't have an avatar.
+//
+// TODO: refactor it to a relative URL, but it is still used in API response at the moment
 func (repo *Repository) AvatarLink(ctx context.Context) string {
-	return httplib.MakeAbsoluteURL(ctx, repo.relAvatarLink(ctx))
+	relLink := repo.relAvatarLink(ctx)
+	if relLink != "" {
+		return httplib.MakeAbsoluteURL(ctx, relLink)
+	}
+	return ""
 }


### PR DESCRIPTION
Backport #31187

Resolves #31167.

https://github.com/go-gitea/gitea/pull/30885 changed the behavior of `repo.AvatarLink()` where it can now take the empty string and append it to the app data URL. This does not point to a valid avatar image URL, and, as the issue mentions, previous Gitea versions returned the empty string.