### PR TITLE
Fix a branch divergence cache bug

### DIFF
--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -147,6 +147,21 @@ func DelDivergenceFromCache(repoID int64, branchName string) error {
 	return cache.GetCache().Delete(getDivergenceCacheKey(repoID, branchName))
 }
 
+// DelRepoDivergenceFromCache deletes all divergence caches of a repository
+func DelRepoDivergenceFromCache(ctx context.Context, repoID int64) error {
+	dbBranches, _, err := db.FindAndCount[git_model.Branch](ctx, git_model.FindBranchOptions{
+		RepoID:      repoID,
+		ListOptions: db.ListOptionsAll,
+	})
+	if err != nil {
+		return err
+	}
+	for i := range dbBranches {
+		DelDivergenceFromCache(repoID, dbBranches[i].Name)
+	}
+	return nil
+}
+
 func loadOneBranch(ctx context.Context, repo *repo_model.Repository, dbBranch *git_model.Branch, protectedBranches *git_model.ProtectedBranchRules,
 	repoIDToRepo map[int64]*repo_model.Repository,
 	repoIDToGitRepo map[int64]*git.Repository,

--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -149,7 +149,7 @@ func DelDivergenceFromCache(repoID int64, branchName string) error {
 
 // DelRepoDivergenceFromCache deletes all divergence caches of a repository
 func DelRepoDivergenceFromCache(ctx context.Context, repoID int64) error {
-	dbBranches, _, err := db.FindAndCount[git_model.Branch](ctx, git_model.FindBranchOptions{
+	dbBranches, err := db.Find[git_model.Branch](ctx, git_model.FindBranchOptions{
 		RepoID:      repoID,
 		ListOptions: db.ListOptionsAll,
 	})

--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -157,7 +157,9 @@ func DelRepoDivergenceFromCache(ctx context.Context, repoID int64) error {
 		return err
 	}
 	for i := range dbBranches {
-		DelDivergenceFromCache(repoID, dbBranches[i].Name)
+		if err := DelDivergenceFromCache(repoID, dbBranches[i].Name); err != nil {
+			log.Error("DelDivergenceFromCache: %v", err)
+		}
 	}
 	return nil
 }

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -221,8 +221,14 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 				}
 
 				// delete cache for divergence
-				if err := DelDivergenceFromCache(repo.ID, branch); err != nil {
-					log.Error("DelDivergenceFromCache: %v", err)
+				if branch == repo.DefaultBranch {
+					if err := DelRepoDivergenceFromCache(ctx, repo.ID); err != nil {
+						log.Error("DelRepoDivergenceFromCache: %v", err)
+					}
+				} else {
+					if err := DelDivergenceFromCache(repo.ID, branch); err != nil {
+						log.Error("DelDivergenceFromCache: %v", err)
+					}
 				}
 
 				commits := repo_module.GitToPushCommits(l)


### PR DESCRIPTION
Fix #31599
Fix #31472

A branch divergence is counted based on the default branch. If the default branch is updated, all divergence caches of the repo need to be deleted.