### PR TITLE
Run `detectWebAuthnSupport` only on sign-in page

### DIFF
--- a/web_src/js/features/user-auth-webauthn.ts
+++ b/web_src/js/features/user-auth-webauthn.ts
@@ -5,6 +5,10 @@ import {GET, POST} from '../modules/fetch.ts';
 const {appSubUrl} = window.config;
 
 export async function initUserAuthWebAuthn() {
+  if (!document.querySelector('.user.signin')) {
+    return;
+  }
+
   if (!detectWebAuthnSupport()) {
     return;
   }


### PR DESCRIPTION
Fix #31675, regression of #31504.
