### PR TITLE
add `username` to OIDC introspection response

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -353,8 +353,9 @@ func IntrospectOAuth(ctx *context.Context) {
 	}
 
 	var response struct {
-		Active bool   `json:"active"`
-		Scope  string `json:"scope,omitempty"`
+		Active   bool   `json:"active"`
+		Scope    string `json:"scope,omitempty"`
+		Username string `json:"username,omitempty"`
 		jwt.RegisteredClaims
 	}
 
@@ -370,6 +371,9 @@ func IntrospectOAuth(ctx *context.Context) {
 				response.Issuer = setting.AppURL
 				response.Audience = []string{app.ClientID}
 				response.Subject = fmt.Sprint(grant.UserID)
+			}
+			if user, err := user_model.GetUserByID(ctx, grant.UserID); err == nil {
+				response.Username = user.Name
 			}
 		}
 	}

--- a/tests/integration/oauth_test.go
+++ b/tests/integration/oauth_test.go
@@ -450,12 +450,14 @@ func TestOAuthIntrospection(t *testing.T) {
 	req.Header.Add("Authorization", "Basic ZGE3ZGEzYmEtOWExMy00MTY3LTg1NmYtMzg5OWRlMGIwMTM4OjRNSzhOYTZSNTVzbWRDWTBXdUNDdW1aNmhqUlBuR1k1c2FXVlJISGpKaUE9")
 	resp = MakeRequest(t, req, http.StatusOK)
 	type introspectResponse struct {
-		Active bool   `json:"active"`
-		Scope  string `json:"scope,omitempty"`
+		Active   bool   `json:"active"`
+		Scope    string `json:"scope,omitempty"`
+		Username string `json:"username"`
 	}
 	introspectParsed := new(introspectResponse)
 	assert.NoError(t, json.Unmarshal(resp.Body.Bytes(), introspectParsed))
 	assert.True(t, introspectParsed.Active)
+	assert.Equal(t, "user1", introspectParsed.Username)
 
 	// successful request with a valid client_id/client_secret, but an invalid token
 	req = NewRequestWithValues(t, "POST", "/login/oauth/introspect", map[string]string{


### PR DESCRIPTION
This field is specified as optional here: https://datatracker.ietf.org/doc/html/rfc7662#section-2.2

It's used by some OIDC integrations, e.g. https://emersion.fr/blog/2022/irc-and-oauth2/