### PR TITLE
OIDC: case-insensitive comparison for auth scheme `Basic`

### DIFF
--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -327,7 +327,7 @@ func getOAuthGroupsForUser(ctx go_context.Context, user *user_model.User) ([]str
 
 func parseBasicAuth(ctx *context.Context) (username, password string, err error) {
 	authHeader := ctx.Req.Header.Get("Authorization")
-	if authType, authData, ok := strings.Cut(authHeader, " "); ok && authType == "Basic" {
+	if authType, authData, ok := strings.Cut(authHeader, " "); ok && strings.EqualFold(authType, "Basic") {
 		return base.BasicAuthDecode(authData)
 	}
 	return "", "", errors.New("invalid basic authentication")
@@ -661,7 +661,7 @@ func AccessTokenOAuth(ctx *context.Context) {
 	// if there is no ClientID or ClientSecret in the request body, fill these fields by the Authorization header and ensure the provided field matches the Authorization header
 	if form.ClientID == "" || form.ClientSecret == "" {
 		authHeader := ctx.Req.Header.Get("Authorization")
-		if authType, authData, ok := strings.Cut(authHeader, " "); ok && authType == "Basic" {
+		if authType, authData, ok := strings.Cut(authHeader, " "); ok && strings.EqualFold(authType, "Basic") {
 			clientID, clientSecret, err := base.BasicAuthDecode(authData)
 			if err != nil {
 				handleAccessTokenError(ctx, AccessTokenError{


### PR DESCRIPTION
@kylef pointed out on https://github.com/go-gitea/gitea/pull/31632 that [RFC7617](https://www.rfc-editor.org/rfc/rfc7617.html#section-2) mandates case-insensitive comparison of the scheme field `Basic`. #31632 copied a case-sensitive comparison from https://github.com/go-gitea/gitea/pull/6293. This PR fixes both comparisons.

The issue only affects OIDC, since the implementation for normal Gitea endpoints is already correct:

https://github.com/go-gitea/gitea/blob/930ca92d7ce80e8b0bdaf92e495026baf2a1d419/services/auth/basic.go#L55-L58