### PR TITLE
Fix loadRepository error when access user dashboard

### DIFF
--- a/models/git/commit_status.go
+++ b/models/git/commit_status.go
@@ -211,6 +211,10 @@ func (status *CommitStatus) LocaleString(lang translation.Locale) string {
 
 // HideActionsURL set `TargetURL` to an empty string if the status comes from Gitea Actions
 func (status *CommitStatus) HideActionsURL(ctx context.Context) {
+	if status.RepoID == 0 {
+		return
+	}
+
 	if status.Repo == nil {
 		if err := status.loadRepository(ctx); err != nil {
 			log.Error("loadRepository: %v", err)


### PR DESCRIPTION
Fix a bug from #30156
![image](https://github.com/user-attachments/assets/55cd7d63-7576-4ed2-a029-0964f17406bd)

Reproduce:
Ensure you have repos with actions, then access user dashboard, you will see this error.

ps: the commit statuses in user dashboard will be initialed no matter the repo has actions or not.
So commit statuses maybe empty, we need to skip them.