### PR TITLE
Move `registerActionsCleanup` to `initActionsTasks`

### DIFF
--- a/services/actions/cleanup.go
+++ b/services/actions/cleanup.go
@@ -5,7 +5,6 @@ package actions
 
 import (
 	"context"
-	"time"
 
 	"code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/modules/log"
@@ -13,7 +12,7 @@ import (
 )
 
 // Cleanup removes expired actions logs, data and artifacts
-func Cleanup(taskCtx context.Context, olderThan time.Duration) error {
+func Cleanup(taskCtx context.Context) error {
 	// TODO: clean up expired actions logs
 
 	// clean up expired artifacts

--- a/services/cron/tasks_actions.go
+++ b/services/cron/tasks_actions.go
@@ -5,6 +5,7 @@ package cron
 
 import (
 	"context"
+	"time"
 
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
@@ -19,6 +20,7 @@ func initActionsTasks() {
 	registerStopEndlessTasks()
 	registerCancelAbandonedJobs()
 	registerScheduleTasks()
+	registerActionsCleanup()
 }
 
 func registerStopZombieTasks() {
@@ -61,5 +63,19 @@ func registerScheduleTasks() {
 	}, func(ctx context.Context, _ *user_model.User, cfg Config) error {
 		// Call the function to start schedule tasks and pass the context.
 		return actions_service.StartScheduleTasks(ctx)
+	})
+}
+
+func registerActionsCleanup() {
+	RegisterTaskFatal("cleanup_actions", &OlderThanConfig{
+		BaseConfig: BaseConfig{
+			Enabled:    true,
+			RunAtStart: true,
+			Schedule:   "@midnight",
+		},
+		OlderThan: 24 * time.Hour,
+	}, func(ctx context.Context, _ *user_model.User, config Config) error {
+		realConfig := config.(*OlderThanConfig)
+		return actions_service.Cleanup(ctx, realConfig.OlderThan)
 	})
 }

--- a/services/cron/tasks_actions.go
+++ b/services/cron/tasks_actions.go
@@ -5,7 +5,6 @@ package cron
 
 import (
 	"context"
-	"time"
 
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
@@ -67,15 +66,11 @@ func registerScheduleTasks() {
 }
 
 func registerActionsCleanup() {
-	RegisterTaskFatal("cleanup_actions", &OlderThanConfig{
-		BaseConfig: BaseConfig{
-			Enabled:    true,
-			RunAtStart: true,
-			Schedule:   "@midnight",
-		},
-		OlderThan: 24 * time.Hour,
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
-		realConfig := config.(*OlderThanConfig)
-		return actions_service.Cleanup(ctx, realConfig.OlderThan)
+	RegisterTaskFatal("cleanup_actions", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: true,
+		Schedule:   "@midnight",
+	}, func(ctx context.Context, _ *user_model.User, _ Config) error {
+		return actions_service.Cleanup(ctx)
 	})
 }

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -13,7 +13,6 @@ import (
 	"code.gitea.io/gitea/models/webhook"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
-	"code.gitea.io/gitea/services/actions"
 	"code.gitea.io/gitea/services/auth"
 	"code.gitea.io/gitea/services/migrations"
 	mirror_service "code.gitea.io/gitea/services/mirror"
@@ -157,20 +156,6 @@ func registerCleanupPackages() {
 	})
 }
 
-func registerActionsCleanup() {
-	RegisterTaskFatal("cleanup_actions", &OlderThanConfig{
-		BaseConfig: BaseConfig{
-			Enabled:    true,
-			RunAtStart: true,
-			Schedule:   "@midnight",
-		},
-		OlderThan: 24 * time.Hour,
-	}, func(ctx context.Context, _ *user_model.User, config Config) error {
-		realConfig := config.(*OlderThanConfig)
-		return actions.Cleanup(ctx, realConfig.OlderThan)
-	})
-}
-
 func initBasicTasks() {
 	if setting.Mirror.Enabled {
 		registerUpdateMirrorTask()
@@ -186,8 +171,5 @@ func initBasicTasks() {
 	registerCleanupHookTaskTable()
 	if setting.Packages.Enabled {
 		registerCleanupPackages()
-	}
-	if setting.Actions.Enabled {
-		registerActionsCleanup()
 	}
 }


### PR DESCRIPTION
There's already `initActionsTasks`; it will avoid additional check for if Actions enabled to move `registerActionsCleanup` into it.

And we don't really need `OlderThanConfig`.