### PR TITLE
Set owner id to zero when GetRegistrationToken for repo

### DIFF
--- a/routers/api/v1/repo/action.go
+++ b/routers/api/v1/repo/action.go
@@ -506,7 +506,7 @@ func (Action) GetRegistrationToken(ctx *context.APIContext) {
 	//   "200":
 	//     "$ref": "#/responses/RegistrationToken"
 
-	shared.GetRegistrationToken(ctx, ctx.Repo.Repository.OwnerID, ctx.Repo.Repository.ID)
+	shared.GetRegistrationToken(ctx, 0, ctx.Repo.Repository.ID)
 }
 
 var _ actions_service.API = new(Action)


### PR DESCRIPTION
Fix #31707.

It's split from #31724.

Although #31724 could also fix #31707, it has change a lot so it's not a good idea to backport it.