### PR TITLE
Exclude protected branches from recently pushed

### DIFF
--- a/models/git/branch.go
+++ b/models/git/branch.go
@@ -427,7 +427,8 @@ type RecentlyPushedNewBranch struct {
 
 // FindRecentlyPushedNewBranches return at most 2 new branches pushed by the user in 2 hours which has no opened PRs created
 // if opts.CommitAfterUnix is 0, we will find the branches that were committed to in the last 2 hours
-// if opts.ListOptions is not set, we will only display top 2 latest branch
+// if opts.ListOptions is not set, we will only display top 2 latest branches.
+// Protected branches will be skipped since they are unlikely to be used to create new PRs.
 func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, opts *FindRecentlyPushedNewBranchesOptions) ([]*RecentlyPushedNewBranch, error) {
 	if doer == nil {
 		return []*RecentlyPushedNewBranch{}, nil
@@ -486,6 +487,18 @@ func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, o
 		opts.MaxCount = 2
 	}
 	for _, branch := range branches {
+		// whether the branch is protected
+		protected, err := IsBranchProtected(ctx, branch.RepoID, branch.Name)
+		if err != nil {
+			return nil, fmt.Errorf("IsBranchProtected: %v", err)
+		}
+		if protected {
+			// Skip protected branches,
+			// since updates to protected branches often come from PR merges,
+			// and they are unlikely to be used to create new PRs.
+			continue
+		}
+
 		// whether branch have already created PR
 		count, err := db.GetEngine(ctx).Table("pull_request").
 			// we should not only use branch name here, because if there are branches with same name in other repos,


### PR DESCRIPTION
Resolve #31566.

Updates to protected branches often come from PR merges, and they are unlikely to be used to create new PRs.

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/9ed72bd6-0303-435d-856c-184784104c6a">
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/c1a1df4b-1c16-4116-aea3-d452242119e0">
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/706034ad-d3c3-4853-a6b8-cbaf87c70ba0">
