### PR TITLE
Add `TAGS` to `TEST_TAGS` and fix bugs found with gogit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ TAGS ?=
 TAGS_SPLIT := $(subst $(COMMA), ,$(TAGS))
 TAGS_EVIDENCE := $(MAKE_EVIDENCE_DIR)/tags
 
-TEST_TAGS ?= sqlite sqlite_unlock_notify
+TEST_TAGS ?= $(TAGS_SPLIT) sqlite sqlite_unlock_notify
 
 TAR_EXCLUDES := .git data indexers queues log node_modules $(EXECUTABLE) $(FOMANTIC_WORK_DIR)/node_modules $(DIST) $(MAKE_EVIDENCE_DIR) $(AIR_TMP_DIR) $(GO_LICENSE_TMP_DIR)
 

--- a/modules/git/blame_sha256_test.go
+++ b/modules/git/blame_sha256_test.go
@@ -14,6 +14,11 @@ func TestReadingBlameOutputSha256(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if isGogit {
+		t.Skip("Skipping test since gogit does not support sha256")
+		return
+	}
+
 	t.Run("Without .git-blame-ignore-revs", func(t *testing.T) {
 		repo, err := OpenRepository(ctx, "./tests/repos/repo5_pulls_sha256")
 		assert.NoError(t, err)

--- a/modules/git/repo_tree_gogit.go
+++ b/modules/git/repo_tree_gogit.go
@@ -6,11 +6,20 @@
 
 package git
 
-import "github.com/go-git/go-git/v5/plumbing"
+import (
+	"errors"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
 
 func (repo *Repository) getTree(id ObjectID) (*Tree, error) {
 	gogitTree, err := repo.gogitRepo.TreeObject(plumbing.Hash(id.RawValue()))
 	if err != nil {
+		if errors.Is(err, plumbing.ErrObjectNotFound) {
+			return nil, ErrNotExist{
+				ID: id.String(),
+			}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Found at https://github.com/go-gitea/gitea/pull/31790#issuecomment-2272898915

`unit-tests-gogit` never work since the workflow set `TAGS` with `gogit`, but the Makefile use `TEST_TAGS`.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/fb68df49-952b-42b9-8438-44200cefff43">

![image](https://github.com/user-attachments/assets/78ff88c7-3b5f-4d50-9c58-e607bf7b1a71)

This PR adds the values of `TAGS` to `TEST_TAGS`, ensuring that setting `TAGS` is always acceptable and avoiding confusion about which one should be set.

After this PR:

<img width="714" alt="image" src="https://github.com/user-attachments/assets/54cc7f38-d95b-4dbc-a87c-daba63462b86">


