### PR TITLE
Add label `docs-update-needed` for PRs that modify `app.example.ini`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -76,7 +76,7 @@ modifies/js:
           - "**/*.js"
           - "**/*.vue"
 
-modifies/docs-update-needed:
+docs-update-needed:
   - changed-files:
       - any-glob-to-any-file:
           - "custom/conf/app.example.ini"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,3 +75,8 @@ modifies/js:
       - any-glob-to-any-file:
           - "**/*.js"
           - "**/*.vue"
+
+modifies/docs-update-needed:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom/conf/app.example.ini"


### PR DESCRIPTION
To help #31536.

Or it's easy to forget to update https://gitea.com/gitea/docs when modifying `app.example.ini`.