### PR TITLE
Support annotated tags when using create release API

### DIFF
--- a/modules/structs/release.go
+++ b/modules/structs/release.go
@@ -33,6 +33,7 @@ type Release struct {
 type CreateReleaseOption struct {
 	// required: true
 	TagName      string `json:"tag_name" binding:"Required"`
+	TagMessage   string `json:"tag_message"`
 	Target       string `json:"target_commitish"`
 	Title        string `json:"name"`
 	Note         string `json:"body"`

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -247,7 +247,7 @@ func CreateRelease(ctx *context.APIContext) {
 			IsTag:        false,
 			Repo:         ctx.Repo.Repository,
 		}
-		if err := release_service.CreateRelease(ctx.Repo.GitRepo, rel, nil, ""); err != nil {
+		if err := release_service.CreateRelease(ctx.Repo.GitRepo, rel, nil, form.TagMessage); err != nil {
 			if repo_model.IsErrReleaseAlreadyExist(err) {
 				ctx.APIError(http.StatusConflict, err)
 			} else if release_service.IsErrProtectedTagName(err) {

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -247,6 +247,8 @@ func CreateRelease(ctx *context.APIContext) {
 			IsTag:        false,
 			Repo:         ctx.Repo.Repository,
 		}
+		// GitHub doesn't have "tag_message", GitLab has: https://docs.gitlab.com/api/releases/#create-a-release
+		// It doesn't need to be the same as the "release note"
 		if err := release_service.CreateRelease(ctx.Repo.GitRepo, rel, nil, form.TagMessage); err != nil {
 			if repo_model.IsErrReleaseAlreadyExist(err) {
 				ctx.APIError(http.StatusConflict, err)

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22295,6 +22295,10 @@
           "type": "boolean",
           "x-go-name": "IsPrerelease"
         },
+        "tag_message": {
+          "type": "string",
+          "x-go-name": "TagMessage"
+        },
         "tag_name": {
           "type": "string",
           "x-go-name": "TagName"


### PR DESCRIPTION
This adds a new field, "tag_message", that represents the message of the annotated tag.

Resolves #31835.