### PR TITLE
Fix overflowing content in action run log

### DIFF
--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -863,6 +863,7 @@ export function initRepositoryActionView() {
   word-break: break-all;
   white-space: break-spaces;
   margin-left: 10px;
+  overflow-wrap: anywhere;
 }
 
 /* selectors here are intentionally exact to only match fullscreen */


### PR DESCRIPTION
When a long line with characters such as dots is returned by a step in an action (e.g. by the output of the Ruby on Rails test runner), it overflows the log container, causing the page to scroll sideways (see first screenshot):

![before](https://github.com/user-attachments/assets/d71a8446-2c81-42d7-ad20-92514884365a)

This PR adds the CSS `overflow-wrap: anywhere;` to the `.job-step-section .job-step-logs .job-log-line .log-msg` selector, which causes such lines to wrap as well (see second screenshot in which the line wraps nicely):

![after](https://github.com/user-attachments/assets/ba9abaec-dc0b-4fab-8129-b9341d4bf784)

