### PR TITLE
Bug fix allow users with access to count as official reviewers

### DIFF
--- a/models/git/protected_branch.go
+++ b/models/git/protected_branch.go
@@ -206,12 +206,12 @@ func IsUserOfficialReviewer(ctx context.Context, protectBranch *ProtectedBranch,
 	}
 
 	if !protectBranch.EnableApprovalsWhitelist {
-		// Anyone with write access is considered official reviewer
-		writeAccess, err := access_model.HasAccessUnit(ctx, user, repo, unit.TypeCode, perm.AccessModeWrite)
+		// Anyone with code access is considered official reviewer
+		access, err := access_model.HasAccessUnit(ctx, user, repo, unit.TypeCode, perm.AccessModeRead)
 		if err != nil {
 			return false, err
 		}
-		return writeAccess, nil
+		return access, nil
 	}
 
 	if slices.Contains(protectBranch.ApprovalsWhitelistUserIDs, user.ID) {

--- a/models/git/protected_branch_test.go
+++ b/models/git/protected_branch_test.go
@@ -15,7 +15,6 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,12 +89,10 @@ func TestIsUserOfficialReviewer(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-	log.Info(fmt.Sprintf("repo.IsPrivate %v", repo.IsPrivate))
 	protectedBranch := &git_model.ProtectedBranch{
 		RepoID:                   repo.ID,
 		EnableApprovalsWhitelist: false,
 	}
-
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 3})
 
 	access := &access_model.Access{

--- a/models/git/protected_branch_test.go
+++ b/models/git/protected_branch_test.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"testing"
 
-	access_model "code.gitea.io/gitea/models/perm/access"
-
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
 	perm_model "code.gitea.io/gitea/models/perm"
+	access_model "code.gitea.io/gitea/models/perm/access"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -277,7 +277,6 @@ func IsOfficialReviewer(ctx context.Context, issue *Issue, reviewer *user_model.
 		}
 		return writeAccess, nil
 	}
-
 	official, err := git_model.IsUserOfficialReviewer(ctx, rule, reviewer)
 	if official || err != nil {
 		return official, err
@@ -300,7 +299,8 @@ func IsOfficialReviewerTeam(ctx context.Context, issue *Issue, team *organizatio
 	}
 
 	if !pb.EnableApprovalsWhitelist {
-		return team.UnitAccessMode(ctx, unit.TypeCode) >= perm.AccessModeWrite, nil
+		// Any team with code access is considered official reviewer
+		return team.UnitAccessMode(ctx, unit.TypeCode) >= perm.AccessModeRead, nil
 	}
 
 	return slices.Contains(pb.ApprovalsWhitelistTeamIDs, team.ID), nil

--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -277,6 +277,7 @@ func IsOfficialReviewer(ctx context.Context, issue *Issue, reviewer *user_model.
 		}
 		return writeAccess, nil
 	}
+
 	official, err := git_model.IsUserOfficialReviewer(ctx, rule, reviewer)
 	if official || err != nil {
 		return official, err


### PR DESCRIPTION
This Pull Request fixes an issue where you can assign a user with only READ access as a reviewer, but their review does not count towards the minimum required approval count.

You can see an example of this here: https://demo.gitea.com/Witea1/PermissionsTest/pulls/1

<img width="1358" alt="Screenshot 2024-08-20 at 11 29 03 AM" src="https://github.com/user-attachments/assets/1e799315-8296-4923-bcc1-1e7cf089e929">

Steps to reproduce:
1. Create a new organization
1a Keep default settings

2. Create a new repository

3. Create a branch protection
3a. Branch main
3b. 1 required approval

4. Create a “READ-ONLY” team with only access to read
4a. Set repository access to ‘All Repositories’

5. Add a non-admin user to the “READ-ONLY” team

6. In the repo you created for step 2, create a new pull request

7. Assign your user from the “READ-ONLY” team as a reviewer

8. Login as the user on the “READ-ONLY” team and approve the design review

9. Notice, you will still have “0 of 1” approvals granted and visible both from the “READ-ONLY” team member and from the admin user who created the design review.

