### PR TITLE
Link to executed workflow

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -74,6 +74,7 @@ func (run *ActionRun) Link() string {
 	return fmt.Sprintf("%s/actions/runs/%d", run.Repo.Link(), run.Index)
 }
 
+// WorkflowLink return the url to the actions list filtered for this runs workflow
 func (run *ActionRun) WorkflowLink() string {
 	if run.Repo == nil {
 		return ""

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -66,7 +66,6 @@ func ListWorkflows(commit *git.Commit) (git.Entries, error) {
 			ret = append(ret, entry)
 		}
 	}
-
 	return ret, nil
 }
 

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -66,6 +66,7 @@ func ListWorkflows(commit *git.Commit) (git.Entries, error) {
 			ret = append(ret, entry)
 		}
 	}
+
 	return ret, nil
 }
 

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -179,3 +179,24 @@ func (tes Entries) Sort() {
 func (tes Entries) CustomSort(cmp func(s1, s2 string) bool) {
 	sort.Sort(customSortableEntries{cmp, tes})
 }
+
+// GetPathInRepo returns the relative path in the tree to this entry
+func (te *TreeEntry) GetPathInRepo() string {
+	if te == nil {
+		return ""
+	}
+
+	path := te.name
+	current := te.ptree
+
+	for current != nil && current.ptree != nil {
+		for _, entry := range current.ptree.entries {
+			if entry.ID == current.ID {
+				path = entry.name + "/" + path
+			}
+		}
+		current = current.ptree
+	}
+
+	return path
+}

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -198,7 +198,7 @@ func (te *TreeEntry) GetPathInRepo() string {
 			return ""
 		}
 		for _, entry := range entries {
-			if entry.ID == current.ID {
+			if entry.ID.String() == current.ID.String() {
 				path = entry.Name() + "/" + path
 				break
 			}

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"code.gitea.io/gitea/modules/log"
 )
 
 // Type returns the type of the entry (commit, tree, blob)
@@ -190,7 +192,12 @@ func (te *TreeEntry) GetPathInRepo() string {
 	current := te.ptree
 
 	for current != nil && current.ptree != nil {
-		for _, entry := range current.ptree.entries {
+		entries, err := current.ptree.ListEntries()
+		if err != nil {
+			log.Error("Failed to climb git tree %v", err)
+			return ""
+		}
+		for _, entry := range entries {
 			if entry.ID == current.ID {
 				path = entry.Name() + "/" + path
 				break

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -193,6 +193,7 @@ func (te *TreeEntry) GetPathInRepo() string {
 		for _, entry := range current.ptree.entries {
 			if entry.ID == current.ID {
 				path = entry.name + "/" + path
+				break
 			}
 		}
 		current = current.ptree

--- a/modules/git/tree_entry.go
+++ b/modules/git/tree_entry.go
@@ -186,13 +186,13 @@ func (te *TreeEntry) GetPathInRepo() string {
 		return ""
 	}
 
-	path := te.name
+	path := te.Name()
 	current := te.ptree
 
 	for current != nil && current.ptree != nil {
 		for _, entry := range current.ptree.entries {
 			if entry.ID == current.ID {
-				path = entry.name + "/" + path
+				path = entry.Name() + "/" + path
 				break
 			}
 		}

--- a/modules/git/tree_entry_gogit_test.go
+++ b/modules/git/tree_entry_gogit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Gitea Authors. All rights reserved.
+// Copyright 2024 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 //go:build gogit

--- a/modules/git/tree_entry_gogit_test.go
+++ b/modules/git/tree_entry_gogit_test.go
@@ -1,0 +1,55 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build gogit
+
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestEntries() Entries {
+	return Entries{
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v1.0", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.0", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.1", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.12", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.2", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v12.0", Mode: filemode.Dir}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "abc", Mode: filemode.Regular}},
+		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "bcd", Mode: filemode.Regular}},
+	}
+}
+
+func TestEntriesSort(t *testing.T) {
+	entries := getTestEntries()
+	entries.Sort()
+	assert.Equal(t, "v1.0", entries[0].Name())
+	assert.Equal(t, "v12.0", entries[1].Name())
+	assert.Equal(t, "v2.0", entries[2].Name())
+	assert.Equal(t, "v2.1", entries[3].Name())
+	assert.Equal(t, "v2.12", entries[4].Name())
+	assert.Equal(t, "v2.2", entries[5].Name())
+	assert.Equal(t, "abc", entries[6].Name())
+	assert.Equal(t, "bcd", entries[7].Name())
+}
+
+func TestEntriesCustomSort(t *testing.T) {
+	entries := getTestEntries()
+	entries.CustomSort(func(s1, s2 string) bool {
+		return s1 > s2
+	})
+	assert.Equal(t, "v2.2", entries[0].Name())
+	assert.Equal(t, "v2.12", entries[1].Name())
+	assert.Equal(t, "v2.1", entries[2].Name())
+	assert.Equal(t, "v2.0", entries[3].Name())
+	assert.Equal(t, "v12.0", entries[4].Name())
+	assert.Equal(t, "v1.0", entries[5].Name())
+	assert.Equal(t, "bcd", entries[6].Name())
+	assert.Equal(t, "abc", entries[7].Name())
+}

--- a/modules/git/tree_entry_test.go
+++ b/modules/git/tree_entry_test.go
@@ -100,3 +100,30 @@ func TestFollowLink(t *testing.T) {
 	_, err = target.FollowLink()
 	assert.EqualError(t, err, "link_short: broken link")
 }
+
+func TestGetPathInRepo(t *testing.T) {
+	r, err := openRepositoryWithDefaultContext("tests/repos/repo1_bare")
+	assert.NoError(t, err)
+	defer r.Close()
+
+	commit, err := r.GetCommit("37991dec2c8e592043f47155ce4808d4580f9123")
+	assert.NoError(t, err)
+
+	// nested entry
+	entry, err := commit.Tree.GetTreeEntryByPath("foo/bar/link_to_hello")
+	assert.NoError(t, err)
+	path := entry.GetPathInRepo()
+	assert.Equal(t, "foo/bar/link_to_hello", path)
+
+	// folder
+	entry, err = commit.Tree.GetTreeEntryByPath("foo/bar")
+	assert.NoError(t, err)
+	path = entry.GetPathInRepo()
+	assert.Equal(t, "foo/bar", path)
+
+	// top level file
+	entry, err = commit.Tree.GetTreeEntryByPath("file2.txt")
+	assert.NoError(t, err)
+	path = entry.GetPathInRepo()
+	assert.Equal(t, "file2.txt", path)
+}

--- a/modules/git/tree_entry_test.go
+++ b/modules/git/tree_entry_test.go
@@ -1,58 +1,13 @@
 // Copyright 2017 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build gogit
-
 package git
 
 import (
 	"testing"
 
-	"github.com/go-git/go-git/v5/plumbing/filemode"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 )
-
-func getTestEntries() Entries {
-	return Entries{
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v1.0", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.0", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.1", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.12", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v2.2", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "v12.0", Mode: filemode.Dir}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "abc", Mode: filemode.Regular}},
-		&TreeEntry{gogitTreeEntry: &object.TreeEntry{Name: "bcd", Mode: filemode.Regular}},
-	}
-}
-
-func TestEntriesSort(t *testing.T) {
-	entries := getTestEntries()
-	entries.Sort()
-	assert.Equal(t, "v1.0", entries[0].Name())
-	assert.Equal(t, "v12.0", entries[1].Name())
-	assert.Equal(t, "v2.0", entries[2].Name())
-	assert.Equal(t, "v2.1", entries[3].Name())
-	assert.Equal(t, "v2.12", entries[4].Name())
-	assert.Equal(t, "v2.2", entries[5].Name())
-	assert.Equal(t, "abc", entries[6].Name())
-	assert.Equal(t, "bcd", entries[7].Name())
-}
-
-func TestEntriesCustomSort(t *testing.T) {
-	entries := getTestEntries()
-	entries.CustomSort(func(s1, s2 string) bool {
-		return s1 > s2
-	})
-	assert.Equal(t, "v2.2", entries[0].Name())
-	assert.Equal(t, "v2.12", entries[1].Name())
-	assert.Equal(t, "v2.1", entries[2].Name())
-	assert.Equal(t, "v2.0", entries[3].Name())
-	assert.Equal(t, "v12.0", entries[4].Name())
-	assert.Equal(t, "v1.0", entries[5].Name())
-	assert.Equal(t, "bcd", entries[6].Name())
-	assert.Equal(t, "abc", entries[7].Name())
-}
 
 func TestFollowLink(t *testing.T) {
 	r, err := openRepositoryWithDefaultContext("tests/repos/repo1_bare")

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -3697,6 +3697,7 @@ runs.no_workflows.documentation = For more information on Gitea Actions, see <a 
 runs.no_runs = The workflow has no runs yet.
 runs.empty_commit_message = (empty commit message)
 runs.expire_log_message = Logs have been purged because they were too old.
+runs.details = Run details
 
 workflow.disable = Disable Workflow
 workflow.disable_success = Workflow '%s' disabled successfully.
@@ -3708,6 +3709,7 @@ workflow.not_found = Workflow '%s' not found.
 workflow.run_success = Workflow '%s' run successfully.
 workflow.from_ref = Use workflow from
 workflow.has_workflow_dispatch = This workflow has a workflow_dispatch event trigger.
+workflow.file = Workflow file
 
 need_approval_desc = Need approval to run workflows for fork pull request.
 

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -171,7 +171,7 @@ func ViewPost(ctx *context_module.Context) {
 	resp.State.Run.CanRerun = run.Status.IsDone() && ctx.Repo.CanWrite(unit.TypeActions)
 	resp.State.Run.CanDeleteArtifact = run.Status.IsDone() && ctx.Repo.CanWrite(unit.TypeActions)
 	resp.State.Run.Done = run.Status.IsDone()
-	resp.State.Run.WorkflowFileLink = getWorkflowFileLink(ctx, run)
+	resp.State.Run.WorkflowFileLink = actions.GetRunsWorkflowFileLink(run, ctx.Repo.GitRepo)
 	resp.State.Run.WorkflowID = run.WorkflowID
 	resp.State.Run.WorkflowLink = run.WorkflowLink()
 	resp.State.Run.IsSchedule = run.IsSchedule()
@@ -304,42 +304,6 @@ func ViewPost(ctx *context_module.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, resp)
-}
-
-// getWorkflowFileLink return url for the source of the workflow file that was run
-func getWorkflowFileLink(ctx *context_module.Context, run *actions_model.ActionRun) string {
-	if run.Repo == nil || run.CommitSHA == "" {
-		return ""
-	}
-
-	commit, err := ctx.Repo.GitRepo.GetCommit(run.CommitSHA)
-	if err != nil {
-		return ""
-	}
-
-	entries, err := actions.ListWorkflows(commit)
-	if err != nil {
-		return ""
-	}
-
-	var workflowEntry *git.TreeEntry
-	for _, entry := range entries {
-		if entry.Name() == run.WorkflowID {
-			workflowEntry = entry
-			break
-		}
-	}
-
-	if workflowEntry == nil {
-		return ""
-	}
-
-	workflowFilePath := workflowEntry.GetPathInRepo()
-	if workflowFilePath == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("%s/src/commit/%s/%s", run.Repo.Link(), run.CommitSHA, workflowFilePath)
 }
 
 // Rerun will rerun jobs in the given run

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -316,20 +316,25 @@ func getWorkflowFileLink(ctx *context_module.Context, run *actions_model.ActionR
 	if err != nil {
 		return ""
 	}
+
 	entries, err := actions.ListWorkflows(commit)
 	if err != nil {
 		return ""
 	}
+
 	var workflowEntry *git.TreeEntry
 	for _, entry := range entries {
 		if entry.Name() == run.WorkflowID {
 			workflowEntry = entry
+			break
 		}
 	}
-	var workflowFilePath string
-	if workflowEntry != nil {
-		workflowFilePath = workflowEntry.GetPathInRepo()
+
+	if workflowEntry == nil {
+		return ""
 	}
+
+	workflowFilePath := workflowEntry.GetPathInRepo()
 	if workflowFilePath == "" {
 		return ""
 	}

--- a/templates/repo/actions/view.tmpl
+++ b/templates/repo/actions/view.tmpl
@@ -12,6 +12,7 @@
 		data-locale-rerun-all="{{ctx.Locale.Tr "rerun_all"}}"
 		data-locale-runs-scheduled="{{ctx.Locale.Tr "actions.runs.scheduled"}}"
 		data-locale-runs-commit="{{ctx.Locale.Tr "actions.runs.commit"}}"
+		data-locale-runs-details="{{ctx.Locale.Tr "actions.runs.details"}}"
 		data-locale-runs-pushed-by="{{ctx.Locale.Tr "actions.runs.pushed_by"}}"
 		data-locale-status-unknown="{{ctx.Locale.Tr "actions.status.unknown"}}"
 		data-locale-status-waiting="{{ctx.Locale.Tr "actions.status.waiting"}}"
@@ -27,6 +28,7 @@
 		data-locale-show-log-seconds="{{ctx.Locale.Tr "show_log_seconds"}}"
 		data-locale-show-full-screen="{{ctx.Locale.Tr "show_full_screen"}}"
 		data-locale-download-logs="{{ctx.Locale.Tr "download_logs"}}"
+		data-locale-workflow-file="{{ctx.Locale.Tr "actions.workflow.file"}}"
 	>
 	</div>
 </div>

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -351,10 +351,12 @@ export function initRepositoryActionView() {
       artifactsTitle: el.getAttribute('data-locale-artifacts-title'),
       areYouSure: el.getAttribute('data-locale-are-you-sure'),
       confirmDeleteArtifact: el.getAttribute('data-locale-confirm-delete-artifact'),
+      runDetails: el.getAttribute('data-locale-runs-details'),
       showTimeStamps: el.getAttribute('data-locale-show-timestamps'),
       showLogSeconds: el.getAttribute('data-locale-show-log-seconds'),
       showFullScreen: el.getAttribute('data-locale-show-full-screen'),
       downloadLogs: el.getAttribute('data-locale-download-logs'),
+      workflowFile: el.getAttribute('data-locale-workflow-file'),
       status: {
         unknown: el.getAttribute('data-locale-status-unknown'),
         waiting: el.getAttribute('data-locale-status-waiting'),
@@ -422,14 +424,14 @@ export function initRepositoryActionView() {
             </a>
           </div>
         </div>
-        <div class="left-side-section">
+        <div class="left-side-section" v-if="run.workflowFileLink">
           <div class="left-side-section-title">
-            Run details
+            {{ locale.runDetails }}
           </div>
           <ul class="left-side-section-list">
-            <li class="left-side-section-item" v-for="artifact in artifacts" :key="artifact.name">
+            <li class="left-side-section-item">
               <a class="left-side-section-link" target="_blank" :href="run.workflowFileLink">
-                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ run.workflowID }}
+                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ locale.workflowFile }}
               </a>
             </li>
           </ul>

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -46,6 +46,7 @@ const sfc = {
         done: false,
         workflowID: '',
         workflowLink: '',
+        workflowFileLink: '',
         isSchedule: false,
         jobs: [
           // {
@@ -421,17 +422,29 @@ export function initRepositoryActionView() {
             </a>
           </div>
         </div>
-        <div class="job-artifacts" v-if="artifacts.length > 0">
-          <div class="job-artifacts-title">
+        <div class="left-side-section">
+          <div class="left-side-section-title">
+            Run details
+          </div>
+          <ul class="left-side-section-list">
+            <li class="left-side-section-item" v-for="artifact in artifacts" :key="artifact.name">
+              <a class="left-side-section-link" target="_blank" :href="run.workflowFileLink">
+                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ run.workflowID }}
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="left-side-section" v-if="artifacts.length > 0">
+          <div class="left-side-section-title">
             {{ locale.artifactsTitle }}
           </div>
-          <ul class="job-artifacts-list">
-            <li class="job-artifacts-item" v-for="artifact in artifacts" :key="artifact.name">
-              <a class="job-artifacts-link" target="_blank" :href="run.link+'/artifacts/'+artifact.name">
-                <SvgIcon name="octicon-file" class="ui text black job-artifacts-icon"/>{{ artifact.name }}
+          <ul class="left-side-section-list">
+            <li class="left-side-section-item" v-for="artifact in artifacts" :key="artifact.name">
+              <a class="left-side-section-link" target="_blank" :href="run.link+'/artifacts/'+artifact.name">
+                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ artifact.name }}
               </a>
-              <a v-if="run.canDeleteArtifact" @click="deleteArtifact(artifact.name)" class="job-artifacts-delete">
-                <SvgIcon name="octicon-trash" class="ui text black job-artifacts-icon"/>
+              <a v-if="run.canDeleteArtifact" @click="deleteArtifact(artifact.name)" class="left-side-section-delete">
+                <SvgIcon name="octicon-trash" class="ui text black left-side-section-icon"/>
               </a>
             </li>
           </ul>
@@ -565,26 +578,26 @@ export function initRepositoryActionView() {
   }
 }
 
-.job-artifacts-title {
+.left-side-section-title {
   font-size: 18px;
   margin-top: 16px;
   padding: 16px 10px 0 20px;
   border-top: 1px solid var(--color-secondary);
 }
 
-.job-artifacts-item {
+.left-side-section-item {
   margin: 5px 0;
   padding: 6px;
   display: flex;
   justify-content: space-between;
 }
 
-.job-artifacts-list {
+.left-side-section-list {
   padding-left: 12px;
   list-style: none;
 }
 
-.job-artifacts-icon {
+.left-side-section-icon {
   padding-right: 3px;
 }
 

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -424,18 +424,6 @@ export function initRepositoryActionView() {
             </a>
           </div>
         </div>
-        <div class="left-side-section" v-if="run.workflowFileLink">
-          <div class="left-side-section-title">
-            {{ locale.runDetails }}
-          </div>
-          <ul class="left-side-section-list">
-            <li class="left-side-section-item">
-              <a class="left-side-section-link" target="_blank" :href="run.workflowFileLink">
-                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ locale.workflowFile }}
-              </a>
-            </li>
-          </ul>
-        </div>
         <div class="left-side-section" v-if="artifacts.length > 0">
           <div class="left-side-section-title">
             {{ locale.artifactsTitle }}
@@ -447,6 +435,18 @@ export function initRepositoryActionView() {
               </a>
               <a v-if="run.canDeleteArtifact" @click="deleteArtifact(artifact.name)" class="left-side-section-delete">
                 <SvgIcon name="octicon-trash" class="ui text black left-side-section-icon"/>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="left-side-section" v-if="run.workflowFileLink">
+          <div class="left-side-section-title">
+            {{ locale.runDetails }}
+          </div>
+          <ul class="left-side-section-list">
+            <li class="left-side-section-item">
+              <a class="left-side-section-link" target="_blank" :href="run.workflowFileLink">
+                <SvgIcon name="octicon-file" class="ui text black left-side-section-icon"/>{{ locale.workflowFile }}
               </a>
             </li>
           </ul>


### PR DESCRIPTION
This Pull Request adds a link in the action run details page that allows a user to quickly access the exact version of the workflow file that was run for the given action. This was requested by users who were actively iterating/debugging actions and needed to see which version of the workflow caused the results they are looking at.

This behavior matches similar behavior in github.

<img width="423" alt="Screenshot 2024-08-22 at 9 47 35 PM" src="https://github.com/user-attachments/assets/40aacd84-a74f-4d77-8f53-5d8f162aba4a">

<img width="1723" alt="Screenshot 2024-08-22 at 9 47 09 PM" src="https://github.com/user-attachments/assets/7fb9de09-7919-4b47-8c7e-367c9b99e313">

Two challenges implementing this feature were:
1. The workflow reference on an ActionRun ([WorkflowId](https://github.com/go-gitea/gitea/blob/main/models/actions/run.go#L34)) is just the name of the workflow file at the time it was run. This file can be renamed.
2. The [ListWorkflows](https://github.com/go-gitea/gitea/blob/main/modules/actions/workflows.go#L47-L50) function implements a "winner takes all" approach where the first matching workflow repo becomes the only visible workflow repo. This path can change over time, for instance if you migrate from .github/workflows to .gitea/workflows. 

To solve this, we take the commit from when the action was run, find the appropriate workflow entry, then traverse up the git tree to determine its relative path at the time the commit was made.