### PR TITLE
Fix  command --mirror lost pull/* files

### DIFF
--- a/models/issues/pull.go
+++ b/models/issues/pull.go
@@ -173,7 +173,7 @@ type PullRequest struct {
 	BaseRepoID          int64                  `xorm:"INDEX"`
 	BaseRepo            *repo_model.Repository `xorm:"-"`
 	HeadBranch          string
-	HeadCommitID        string `xorm:"-"`
+	HeadCommitID        string `xorm:"VARCHAR(64)"`
 	BaseBranch          string
 	MergeBase           string `xorm:"VARCHAR(64)"`
 	AllowMaintainerEdit bool   `xorm:"NOT NULL DEFAULT false"`

--- a/modules/structs/pull.go
+++ b/modules/structs/pull.go
@@ -43,9 +43,10 @@ type PullRequest struct {
 	MergedBy            *User      `json:"merged_by"`
 	AllowMaintainerEdit bool       `json:"allow_maintainer_edit"`
 
-	Base      *PRBranchInfo `json:"base"`
-	Head      *PRBranchInfo `json:"head"`
-	MergeBase string        `json:"merge_base"`
+	Base         *PRBranchInfo `json:"base"`
+	Head         *PRBranchInfo `json:"head"`
+	MergeBase    string        `json:"merge_base"`
+	HeadCommitID string        `xorm:"VARCHAR(64)" json:"head_commit_id"`
 
 	// swagger:strfmt date-time
 	Deadline *time.Time `json:"due_date"`

--- a/services/convert/pull.go
+++ b/services/convert/pull.go
@@ -81,6 +81,7 @@ func ToAPIPullRequest(ctx context.Context, pr *issues_model.PullRequest, doer *u
 		PatchURL:       pr.Issue.PatchURL(),
 		HasMerged:      pr.HasMerged,
 		MergeBase:      pr.MergeBase,
+		HeadCommitID:   pr.MergeBase,
 		Mergeable:      pr.Mergeable(ctx),
 		Deadline:       apiIssue.Deadline,
 		Created:        pr.Issue.CreatedUnix.AsTimePtr(),

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -344,6 +344,16 @@ func testPR(id int64) {
 		log.Error("Unable to GetPullRequestByID[%d] for testPR: %v", id, err)
 		return
 	}
+	err = pr.LoadBaseRepo(ctx)
+	if err == nil {
+		commitID, commitErr := git.GetFullCommitID(ctx, pr.BaseRepo.RepoPath(), pr.HeadBranch)
+		if commitErr == nil {
+			pr.HeadCommitID = commitID
+			if err := pr.UpdateCols(ctx, "head_commit_id"); err != nil {
+				log.Error("update pr [%-v] head_commit_id failed: %v", pr, err)
+			}
+		}
+	}
 
 	log.Trace("Testing %-v", pr)
 	defer func() {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -23452,6 +23452,10 @@
         "head": {
           "$ref": "#/definitions/PRBranchInfo"
         },
+        "head_commit_id": {
+          "type": "string",
+          "x-go-name": "HeadCommitID"
+        },
         "html_url": {
           "type": "string",
           "x-go-name": "HTMLURL"


### PR DESCRIPTION
fix `git push --mirror` gitea server lost pull/* files bug

Make 
```HeadCommitID string `xorm:"-"` ``` to `xorm:"VARCHAR(64)"`

if `pull/1/head` file is not exists , it will create a new file