### PR TITLE
Refactor globallock

### DIFF
--- a/modules/globallock/globallock.go
+++ b/modules/globallock/globallock.go
@@ -27,20 +27,20 @@ func DefaultLocker() Locker {
 
 // Lock tries to acquire a lock for the given key, it uses the default locker.
 // Read the documentation of Locker.Lock for more information about the behavior.
-func Lock(ctx context.Context, key string) (context.Context, ReleaseFunc, error) {
+func Lock(ctx context.Context, key string) (ReleaseFunc, error) {
 	return DefaultLocker().Lock(ctx, key)
 }
 
 // TryLock tries to acquire a lock for the given key, it uses the default locker.
 // Read the documentation of Locker.TryLock for more information about the behavior.
-func TryLock(ctx context.Context, key string) (bool, context.Context, ReleaseFunc, error) {
+func TryLock(ctx context.Context, key string) (bool, ReleaseFunc, error) {
 	return DefaultLocker().TryLock(ctx, key)
 }
 
 // LockAndDo tries to acquire a lock for the given key and then calls the given function.
 // It uses the default locker, and it will return an error if failed to acquire the lock.
 func LockAndDo(ctx context.Context, key string, f func(context.Context) error) error {
-	ctx, release, err := Lock(ctx, key)
+	release, err := Lock(ctx, key)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func LockAndDo(ctx context.Context, key string, f func(context.Context) error) e
 // TryLockAndDo tries to acquire a lock for the given key and then calls the given function.
 // It uses the default locker, and it will return false if failed to acquire the lock.
 func TryLockAndDo(ctx context.Context, key string, f func(context.Context) error) (bool, error) {
-	ok, ctx, release, err := TryLock(ctx, key)
+	ok, release, err := TryLock(ctx, key)
 	if err != nil {
 		return false, err
 	}

--- a/modules/globallock/locker.go
+++ b/modules/globallock/locker.go
@@ -5,16 +5,10 @@ package globallock
 
 import (
 	"context"
-	"fmt"
 )
 
 type Locker interface {
 	// Lock tries to acquire a lock for the given key, it blocks until the lock is acquired or the context is canceled.
-	//
-	// Lock returns a new context which should be used in the following code.
-	// The new context will be canceled when the lock is released or lost - yes, it's possible to lose a lock.
-	// For example, it lost the connection to the redis server while holding the lock.
-	// If it fails to acquire the lock, the returned context will be the same as the input context.
 	//
 	// Lock returns a ReleaseFunc to release the lock, it cannot be nil.
 	// It's always safe to call this function even if it fails to acquire the lock, and it will do nothing in that case.
@@ -22,39 +16,23 @@ type Locker interface {
 	// That's why it's called ReleaseFunc, not UnlockFunc.
 	// But be aware that it's not safe to not call it at all; it could lead to a memory leak.
 	// So a recommended pattern is to use defer to call it:
-	//   ctx, release, err := locker.Lock(ctx, "key")
+	//   release, err := locker.Lock(ctx, "key")
 	//   if err != nil {
 	//     return err
 	//   }
 	//   defer release()
-	// The ReleaseFunc will return the original context which was used to acquire the lock.
-	// It's useful when you want to continue to do something after releasing the lock.
-	// At that time, the ctx will be canceled, and you can use the returned context by the ReleaseFunc to continue:
-	//   ctx, release, err := locker.Lock(ctx, "key")
-	//   if err != nil {
-	//     return err
-	//   }
-	//   defer release()
-	//   doSomething(ctx)
-	//   ctx = release()
-	//   doSomethingElse(ctx)
-	// Please ignore it and use `defer release()` instead if you don't need this, to avoid forgetting to release the lock.
 	//
 	// Lock returns an error if failed to acquire the lock.
 	// Be aware that even the context is not canceled, it's still possible to fail to acquire the lock.
 	// For example, redis is down, or it reached the maximum number of tries.
-	Lock(ctx context.Context, key string) (context.Context, ReleaseFunc, error)
+	Lock(ctx context.Context, key string) (ReleaseFunc, error)
 
 	// TryLock tries to acquire a lock for the given key, it returns immediately.
 	// It follows the same pattern as Lock, but it doesn't block.
 	// And if it fails to acquire the lock because it's already locked, not other reasons like redis is down,
 	// it will return false without any error.
-	TryLock(ctx context.Context, key string) (bool, context.Context, ReleaseFunc, error)
+	TryLock(ctx context.Context, key string) (bool, ReleaseFunc, error)
 }
 
 // ReleaseFunc is a function that releases a lock.
-// It returns the original context which was used to acquire the lock.
-type ReleaseFunc func() context.Context
-
-// ErrLockReleased is used as context cause when a lock is released
-var ErrLockReleased = fmt.Errorf("lock released")
+type ReleaseFunc func()


### PR DESCRIPTION
Follow #31908. The main refactor is that it has removed the returned context of `Lock`.

The returned context of `Lock` in old code is to provide a way to let callers know that they have lost the lock. But in most cases, callers shouldn't cancel what they are doing even it has lost the lock. And the design would confuse developers and make them use it incorrectly.

See the discussion history: https://github.com/go-gitea/gitea/pull/31813#discussion_r1732041513 and https://github.com/go-gitea/gitea/pull/31813#discussion_r1734078998

It's a breaking change, but since the new module hasn't been used yet, I think it's OK to not add the `pr/breaking` label.

## Design principles

It's almost copied from #31908, but with some changes.

### Use spinlock even in memory implementation (unchanged)

In actual use cases, users may cancel requests. `sync.Mutex` will block the goroutine until the lock is acquired even if the request is canceled. And the spinlock is more suitable for this scenario since it's possible to give up the lock acquisition.

Although the spinlock consumes more CPU resources, I think it's acceptable in most cases.

### Do not expose the mutex to callers (unchanged)

If we expose the mutex to callers, it's possible for callers to reuse the mutex, which causes more complexity.

For example:
```go
lock := GetLocker(key)
lock.Lock()
// ...
// even if the lock is unlocked, we cannot GC the lock,
// since the caller may still use it again.
lock.Unlock()
lock.Lock()
// ...
lock.Unlock()

// callers have to GC the lock manually.
RemoveLocker(key)
```

That's why https://github.com/go-gitea/gitea/pull/31813#discussion_r1721200549

In this PR, we only expose `ReleaseFunc` to callers. So callers just need to call `ReleaseFunc` to release the lock, and do not need to care about the lock's lifecycle.
```go
release, err := locker.Lock(ctx, key)
if err != nil {
    return err
}
// ...
release()

// if callers want to lock again, they have to re-acquire the lock.
release, err := locker.Lock(ctx, key)
// ...
```

In this way, it's also much easier for redis implementation to extend the mutex automatically, so that callers do not need to care about the lock's lifecycle. See also https://github.com/go-gitea/gitea/pull/31813#discussion_r1722659743

### Use "release" instead of "unlock" (unchanged)

For "unlock", it has the meaning of "unlock an acquired lock". So it's not acceptable to call "unlock" when failed to acquire the lock, or call "unlock" multiple times. It causes more complexity for callers to decide whether to call "unlock" or not.

So we use "release" instead of "unlock" to make it clear. Whether the lock is acquired or not, callers can always call "release", and it's also safe to call "release" multiple times.

But the code DO NOT expect callers to not call "release" after acquiring the lock. If callers forget to call "release", it will cause resource leak. That's why it's always safe to call "release" without extra checks: to avoid callers to forget to call it.

### Acquired locks could be lost, but the callers shouldn't stop

Unlike `sync.Mutex` which will be locked forever once acquired until calling `Unlock`, for distributed lock, the acquired lock could be lost.

For example, the caller has acquired the lock, and it holds the lock for a long time since auto-extending is working for redis. However, it lost the connection to the redis server, and it's impossible to extend the lock anymore.

In #31908, it will cancel the context to make the operation stop, but it's not safe. Many operations are not revert-able. If they have been interrupted, then the instance goes corrupted. So `Lock` won't return `ctx` anymore in this PR.

### Multiple ways to use the lock

1. Regular way

```go
release, err := Lock(ctx, key)
if err != nil {
    return err
}
defer release()
// ...
```

2. Early release

```go
release, err := Lock(ctx, key)
if err != nil {
    return err
}
defer release()
// ...
// release the lock earlier
release()
// continue to do something else
// ...
```

3. Functional way

```go
if err := LockAndDo(ctx, key, func(ctx context.Context) error {
    // ...
    return nil
}); err != nil {
    return err
}
```
