### PR TITLE
Remove html tags from create tag and branch translation

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2642,7 +2642,7 @@ branch.delete_desc = Deleting a branch is permanent. Although the deleted branch
 branch.deletion_success = Branch "%s" has been deleted.
 branch.deletion_failed = Failed to delete branch "%s".
 branch.delete_branch_has_new_commits = Branch "%s" cannot be deleted because new commits have been added after merging.
-branch.create_branch = Create branch <strong>%s</strong>
+branch.create_branch = Create branch %s
 branch.create_from = from "%s"
 branch.create_success = Branch "%s" has been created.
 branch.branch_already_exists = Branch "%s" already exists in this repository.
@@ -2668,7 +2668,7 @@ branch.new_branch = Create new branch
 branch.new_branch_from = Create new branch from "%s"
 branch.renamed = Branch %s was renamed to %s.
 
-tag.create_tag = Create tag <strong>%s</strong>
+tag.create_tag = Create tag %s
 tag.create_tag_operation = Create tag
 tag.confirm_create_tag = Create tag
 tag.create_tag_from = Create new tag from "%s"


### PR DESCRIPTION
Follow #31950 and Fix the display bug of #31966 .

This will only fix the English version. I will update all these translation files in crowdin after this merged so that all the languages can be fixed.

And all these files should be backported together.

This PR remove the bold effect around the name when creating a new tag or branch.