### PR TITLE
Enable compression for Actions logs by default

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2692,7 +2692,7 @@ LEVEL = Info
 ;; It's always recommended to use compression when using local disk as log storage if CPU or memory is not a bottleneck.
 ;; And for object storage services like S3, which is billed for requests, it would cause extra 2 times of get requests for each log view.
 ;; But it will save storage space and network bandwidth, so it's still recommended to use compression.
-;LOG_COMPRESSION = none
+;LOG_COMPRESSION = zstd
 ;; Default artifact retention time in days. Artifacts could have their own retention periods by setting the `retention-days` option in `actions/upload-artifact` step.
 ;ARTIFACT_RETENTION_DAYS = 90
 ;; Timeout to stop the task which have running status, but haven't been updated for a long time

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -62,11 +62,11 @@ func (c logCompression) IsValid() bool {
 }
 
 func (c logCompression) IsNone() bool {
-	return c == "" || strings.ToLower(string(c)) == "none"
+	return strings.ToLower(string(c)) == "none"
 }
 
 func (c logCompression) IsZstd() bool {
-	return strings.ToLower(string(c)) == "zstd"
+	return c == "" || strings.ToLower(string(c)) == "zstd"
 }
 
 func loadActionsFrom(rootCfg ConfigProvider) error {


### PR DESCRIPTION
Close #31801. Follow #31761.

Since there are so many benefits of compression and there are no reports of related issues after weeks, it should be fine to enable compression by default.

