### PR TITLE
Add bin to Composer Metadata

### DIFF
--- a/modules/packages/composer/metadata.go
+++ b/modules/packages/composer/metadata.go
@@ -48,6 +48,7 @@ type Metadata struct {
 	Homepage    string            `json:"homepage,omitempty"`
 	License     Licenses          `json:"license,omitempty"`
 	Authors     []Author          `json:"authors,omitempty"`
+	Bin         []string          `json:"bin,omitempty"`
 	Autoload    map[string]any    `json:"autoload,omitempty"`
 	AutoloadDev map[string]any    `json:"autoload-dev,omitempty"`
 	Extra       map[string]any    `json:"extra,omitempty"`

--- a/tests/integration/api_packages_composer_test.go
+++ b/tests/integration/api_packages_composer_test.go
@@ -36,6 +36,7 @@ func TestPackageComposer(t *testing.T) {
 	packageType := "composer-plugin"
 	packageAuthor := "Gitea Authors"
 	packageLicense := "MIT"
+	packageBin := "./bin/script"
 
 	var buf bytes.Buffer
 	archive := zip.NewWriter(&buf)
@@ -49,6 +50,9 @@ func TestPackageComposer(t *testing.T) {
 			{
 				"name": "` + packageAuthor + `"
 			}
+		],
+		"bin": [
+			"` + packageBin + `"
 		]
 	}`))
 	archive.Close()
@@ -210,6 +214,8 @@ func TestPackageComposer(t *testing.T) {
 		assert.Len(t, pkgs[0].Authors, 1)
 		assert.Equal(t, packageAuthor, pkgs[0].Authors[0].Name)
 		assert.Equal(t, "zip", pkgs[0].Dist.Type)
-		assert.Equal(t, "7b40bfd6da811b2b78deec1e944f156dbb2c747b", pkgs[0].Dist.Checksum)
+		assert.Equal(t, "4f5fa464c3cb808a1df191dbf6cb75363f8b7072", pkgs[0].Dist.Checksum)
+		assert.Len(t, pkgs[0].Bin, 1)
+		assert.Equal(t, packageBin, pkgs[0].Bin[0])
 	})
 }


### PR DESCRIPTION
This PR addresses the missing `bin` field in Composer metadata, which currently causes vendor-provided binaries to not be symlinked to `vendor/bin` during installation. 

In the current implementation, running `composer install` does not publish the binaries, leading to issues where expected binaries are not available. 

By properly declaring the `bin` field, this PR ensures that binaries are correctly symlinked upon installation, as described in the [Composer documentation](https://getcomposer.org/doc/articles/vendor-binaries.md).