### PR TITLE
Add tabindex in signin page

### DIFF
--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -14,20 +14,20 @@
 			{{.CsrfTokenHtml}}
 			<div class="required field {{if and (.Err_UserName) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}}">
 				<label for="user_name">{{ctx.Locale.Tr "home.uname_holder"}}</label>
-				<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required>
+				<input id="user_name" type="text" name="user_name" value="{{.user_name}}" autofocus required tabindex="1">
 			</div>
 			{{if or (not .DisablePassword) .LinkAccountMode}}
 			<div class="required field {{if and (.Err_Password) (or (not .LinkAccountMode) (and .LinkAccountMode .LinkAccountModeSignIn))}}error{{end}} form-field-content-aside-label">
 				<label for="password">{{ctx.Locale.Tr "password"}}</label>
-				<a href="{{AppSubUrl}}/user/forgot_password">{{ctx.Locale.Tr "auth.forgot_password"}}</a>
-				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="current-password" required>
+				<a href="{{AppSubUrl}}/user/forgot_password" tabindex="5">{{ctx.Locale.Tr "auth.forgot_password"}}</a>
+				<input id="password" name="password" type="password" value="{{.password}}" autocomplete="current-password" required tabindex="2">
 			</div>
 			{{end}}
 			{{if not .LinkAccountMode}}
 			<div class="inline field">
 				<div class="ui checkbox">
 					<label>{{ctx.Locale.Tr "auth.remember_me"}}</label>
-					<input name="remember" type="checkbox">
+					<input name="remember" type="checkbox" tabindex="3">
 				</div>
 			</div>
 			{{end}}
@@ -35,7 +35,7 @@
 			{{template "user/auth/captcha" .}}
 
 			<div class="field">
-				<button class="ui primary button tw-w-full">
+				<button class="ui primary button tw-w-full" tabindex="4">
 					{{if .LinkAccountMode}}
 						{{ctx.Locale.Tr "auth.oauth_signin_submit"}}
 					{{else}}


### PR DESCRIPTION
Recently, the order of the element when you press Tab is
![image](https://github.com/user-attachments/assets/824a7458-55b4-4307-a5ab-db50cfa2510d)
Normally, user would press Tab to turn to the password input box after they inputted the username.
![image](https://github.com/user-attachments/assets/7f97830a-3f56-4f31-bb3a-0cbf527d7148)
If there are any better solutions, you are welcome to replace this PR.