### PR TITLE
Add null check for responseData.invalidTopics

### DIFF
--- a/web_src/js/features/repo-home.ts
+++ b/web_src/js/features/repo-home.ts
@@ -60,7 +60,7 @@ export function initRepoTopicBar() {
       // how to test: input topic like " invalid topic " (with spaces), and select it from the list, then "Save"
       const responseData = await response.json();
       lastErrorToast = showErrorToast(responseData.message, {duration: 5000});
-      if (responseData.invalidTopics.length > 0) {
+      if (responseData.invalidTopics && responseData.invalidTopics.length > 0) {
         const {invalidTopics} = responseData;
         const topicLabels = queryElemChildren(topicDropdown, 'a.ui.label');
         for (const [index, value] of topics.split(',').entries()) {


### PR DESCRIPTION
<img width="553" alt="Screenshot 2024-10-08 at 10 49 10 AM" src="https://github.com/user-attachments/assets/faeef64d-684a-4aba-b7fc-c7c6a0301abe">

`responseData.invalidTopics` can be null but it wasn't handled.